### PR TITLE
refactor(prompt): 重排 block 顺序并补充来源注释

### DIFF
--- a/agent/context.py
+++ b/agent/context.py
@@ -136,7 +136,9 @@ class MessageEnvelopeBuilder:
     ) -> str:
         stripped = text.lstrip()
         if not stripped:
-            return text
+            return build_current_message_time_envelope(
+                message_timestamp=message_timestamp
+            )
         if stripped.startswith("[当前消息时间:"):
             return text
         stamp = build_current_message_time_envelope(message_timestamp=message_timestamp)
@@ -224,7 +226,6 @@ class ContextBuilder:
         skill_names: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
-        message_timestamp: "datetime | None" = None,
         retrieved_memory_block: str = "",
         disabled_sections: set[str] | None = None,
     ) -> SystemPromptBuildResult:
@@ -235,7 +236,6 @@ class ContextBuilder:
             skill_names=skill_names or [],
             channel=channel,
             chat_id=chat_id,
-            message_timestamp=message_timestamp,
             retrieved_memory_block=retrieved_memory_block,
         )
         built = self._system_prompt_builder.build(

--- a/agent/core/prompt_block.py
+++ b/agent/core/prompt_block.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
@@ -30,7 +29,6 @@ class TurnContext:
     skill_names: list[str]
     channel: str | None
     chat_id: str | None
-    message_timestamp: datetime | None
     retrieved_memory_block: str
 
 
@@ -45,15 +43,36 @@ class PromptBlock(Protocol):
 
 
 # ─── Prompt Block 渲染顺序（priority 升序 = system prompt 拼接顺序）────────────
-#  10 IdentityPromptBlock      → 工作区路径 + 文件索引         (static, cacheable)
-#  15 BehaviorRulesPromptBlock → 行为规范 + 历史检索协议        (static, cacheable)
-#  20 MemoryBlockPromptBlock   → 本轮语义检索注入              (dynamic)
-#  30 LongTermMemoryPromptBlock→ 长期 profile                 (dynamic)
-#  40 SelfModelPromptBlock     → SELF.md                     (dynamic)
-#  50 SessionContextPromptBlock→ 当前时间 + 环境 + channel     (dynamic)
-#  60 ActiveSkillsPromptBlock  → active skill 内容            (dynamic)
-#  65 MemesPromptBlock         → meme catalog                 (dynamic)
-#  70 SkillsCatalogPromptBlock → 技能目录                     (static, cacheable)
+#  10 IdentityPromptBlock      → build_agent_static_identity_prompt(workspace)
+#                              来源：工作区路径、memory/* 文件索引
+#                              时机：仅 workspace 变化时才变，最稳定
+#  15 BehaviorRulesPromptBlock → build_agent_behavior_rules_prompt(workspace)
+#                              来源：prompts/agent.py 里的固定行为规范
+#                              时机：仅代码或 workspace 变化时才变，最稳定
+#  20 SkillsCatalogPromptBlock → skills.build_skills_summary()
+#                              来源：skills/ 目录扫描结果、技能描述、依赖可用性
+#                              时机：技能文件或环境依赖变化时才变，低频
+#  25 MemesPromptBlock         → memes/manifest.json
+#                              来源：MemeCatalog.build_prompt_block()
+#                              时机：表情 manifest 更新时才变，低频
+#  30 SelfModelPromptBlock     → memory/SELF.md
+#                              来源：memory.read_self()
+#                              时机：自我认知被写回时才变，低频
+#  35 LongTermMemoryPromptBlock→ memory/MEMORY.md
+#                              来源：memory.read_profile() / get_memory_context()
+#                              时机：长期记忆 consolidate 或人工更新时才变，低频
+#  40 SessionContextPromptBlock→ 环境 + 当前 session
+#                              来源：platform.machine() + channel + chat_id
+#                              时机：切换机器架构、channel、chat_id 时才变；同 session 基本稳定
+#  45 RecentContextPromptBlock → memory/RECENT_CONTEXT.md（裁掉 Recent Turns）
+#                              来源：memory.read_recent_context()
+#                              时机：近期语境压缩摘要更新时变化；每轮 Recent Turns 刷新不会直接进入这里
+#  50 ActiveSkillsPromptBlock  → active skill 内容
+#                              来源：always skills + 本轮命中的 skill_names
+#                              时机：本轮技能命中集合变化时就会变，中频
+#  55 MemoryBlockPromptBlock   → 本轮语义检索注入
+#                              来源：retrieved_memory_block
+#                              时机：每轮 retrieval 结果都可能不同，最高频
 # ─────────────────────────────────────────────────────────────────────────────
 class IdentityPromptBlock:
     priority = 10
@@ -85,21 +104,60 @@ class BehaviorRulesPromptBlock:
         return str(ctx.workspace.expanduser().resolve())
 
 
-class MemoryBlockPromptBlock:
+class SkillsCatalogPromptBlock:
     priority = 20
-    label = "retrieved_memory"
+    label = "skills_catalog"
+    is_static = True
+
+    def __init__(self, render_fn=build_skills_catalog_prompt) -> None:
+        self._render_fn = render_fn
+
+    def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
+        summary = cached_signature or ""
+        if not summary:
+            return None
+        return self._render_fn(summary)
+
+    def cache_signature(self, ctx: TurnContext) -> str | None:
+        summary = ctx.skills.build_skills_summary()
+        return summary or None
+
+
+class MemesPromptBlock:
+    priority = 25
+    label = "memes"
+    is_static = False
+
+    def __init__(self, catalog: MemeCatalog) -> None:
+        self._catalog = catalog
+
+    def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
+        block = self._catalog.build_prompt_block()
+        if not block:
+            return None
+        return f"# Memes\n\n{block}"
+
+    def cache_signature(self, ctx: TurnContext) -> str | None:
+        return None
+
+
+class SelfModelPromptBlock:
+    priority = 30
+    label = "self_model"
     is_static = False
 
     def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
-        block = (ctx.retrieved_memory_block or "").strip()
-        return block or None
+        self_content = ctx.memory.read_self()
+        if not self_content:
+            return None
+        return f"## Akashic 自我认知\n\n{self_content}"
 
     def cache_signature(self, ctx: TurnContext) -> str | None:
         return None
 
 
 class LongTermMemoryPromptBlock:
-    priority = 30
+    priority = 35
     label = "long_term_memory"
     is_static = False
 
@@ -111,16 +169,19 @@ class LongTermMemoryPromptBlock:
         return None
 
 
-class SelfModelPromptBlock:
+class SessionContextPromptBlock:
     priority = 40
-    label = "self_model"
+    label = "session_context"
     is_static = False
 
+    def __init__(self, render_fn=build_agent_session_context_prompt) -> None:
+        self._render_fn = render_fn
+
     def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
-        self_content = ctx.memory.read_self()
-        if not self_content:
-            return None
-        return f"## Akashic 自我认知\n\n{self_content}"
+        return self._render_fn(
+            channel=ctx.channel,
+            chat_id=ctx.chat_id,
+        )
 
     def cache_signature(self, ctx: TurnContext) -> str | None:
         return None
@@ -145,27 +206,8 @@ class RecentContextPromptBlock:
         return None
 
 
-class SessionContextPromptBlock:
-    priority = 50
-    label = "session_context"
-    is_static = False
-
-    def __init__(self, render_fn=build_agent_session_context_prompt) -> None:
-        self._render_fn = render_fn
-
-    def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
-        return self._render_fn(
-            message_timestamp=ctx.message_timestamp,
-            channel=ctx.channel,
-            chat_id=ctx.chat_id,
-        )
-
-    def cache_signature(self, ctx: TurnContext) -> str | None:
-        return None
-
-
 class ActiveSkillsPromptBlock:
-    priority = 60
+    priority = 50
     label = "active_skills"
     is_static = False
 
@@ -189,41 +231,17 @@ class ActiveSkillsPromptBlock:
         return None
 
 
-class MemesPromptBlock:
-    priority = 65
-    label = "memes"
+class MemoryBlockPromptBlock:
+    priority = 55
+    label = "retrieved_memory"
     is_static = False
 
-    def __init__(self, catalog: MemeCatalog) -> None:
-        self._catalog = catalog
-
     def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
-        block = self._catalog.build_prompt_block()
-        if not block:
-            return None
-        return f"# Memes\n\n{block}"
+        block = (ctx.retrieved_memory_block or "").strip()
+        return block or None
 
     def cache_signature(self, ctx: TurnContext) -> str | None:
         return None
-
-
-class SkillsCatalogPromptBlock:
-    priority = 70
-    label = "skills_catalog"
-    is_static = True
-
-    def __init__(self, render_fn=build_skills_catalog_prompt) -> None:
-        self._render_fn = render_fn
-
-    def render(self, ctx: TurnContext, cached_signature: str | None = None) -> str | None:
-        summary = cached_signature or ""
-        if not summary:
-            return None
-        return self._render_fn(summary)
-
-    def cache_signature(self, ctx: TurnContext) -> str | None:
-        summary = ctx.skills.build_skills_summary()
-        return summary or None
 
 
 @dataclass

--- a/agent/prompting/assembler.py
+++ b/agent/prompting/assembler.py
@@ -74,7 +74,6 @@ class PromptAssembler:
             skill_names=skill_names,
             channel=channel,
             chat_id=chat_id,
-            message_timestamp=message_timestamp,
             retrieved_memory_block=retrieved_memory_block,
             disabled_sections=disabled_sections,
         )

--- a/prompts/agent.py
+++ b/prompts/agent.py
@@ -33,7 +33,7 @@ def _weekday_cn(ts: datetime) -> str:
     return ["周一", "周二", "周三", "周四", "周五", "周六", "周日"][ts.weekday()]
 
 
-# ─── Layer 1: 静态身份（priority=10，workspace 路径 + 文件索引）────────────────
+# ─── 静态身份层：工作区路径 + 文件索引 ──────────────────────────────────────────
 def build_agent_static_identity_prompt(*, workspace: Path) -> str:
     workspace_path = str(workspace.expanduser().resolve())
 
@@ -67,7 +67,7 @@ def build_agent_static_identity_prompt(*, workspace: Path) -> str:
 """
 
 
-# ─── Layer 2: 行为规范（priority=15，工具路由 + 历史检索协议 + 输出格式）────────
+# ─── 行为规范层：工具路由 + 历史检索协议 + 输出格式 ────────────────────────────
 def build_agent_behavior_rules_prompt(*, workspace: Path) -> str:
     workspace_path = str(workspace.expanduser().resolve())
 
@@ -174,56 +174,34 @@ def build_agent_behavior_rules_prompt(*, workspace: Path) -> str:
 宏观时间线浏览：`read_file {workspace_path}/memory/HISTORY.md`。""" + _MEMORY_CITATION_PROTOCOL
 
 
-# ─── Layer 3: 动态上下文（priority=50，每轮变化：时间 + 环境 + channel）─────────
+# ─── 动态上下文层：环境 + channel ────────────────────────────────────────────
 def build_agent_session_context_prompt(
     *,
-    message_timestamp: datetime | None = None,
     channel: str | None = None,
     chat_id: str | None = None,
 ) -> str:
-    parts = [
-        build_agent_request_time_prompt(message_timestamp=message_timestamp),
-        build_agent_environment_prompt(),
-    ]
+    parts = [build_agent_environment_prompt()]
     if channel and chat_id:
         parts.append(build_current_session_prompt(channel=channel, chat_id=chat_id).strip())
     return "\n\n".join(part for part in parts if part.strip())
-
-
-def build_agent_request_time_prompt(*, message_timestamp: datetime | None = None) -> str:
-    ts = _normalize_timestamp(message_timestamp)
-    now = ts.strftime("%Y-%m-%d %H:%M:%S %Z")
-    now_iso = ts.isoformat()
-    local_date = ts.strftime("%Y-%m-%d")
-    weekday = ts.strftime("%A")
-    timezone_name = ts.tzname() or "UNKNOWN"
-    yesterday = ts - timedelta(days=1)
-    tomorrow = ts + timedelta(days=1)
-    day_after_tomorrow = ts + timedelta(days=2)
-    return f"""## 当前时间
-{now}
-request_time={now_iso}
-local_date={local_date}
-weekday={weekday}
-timezone_name={timezone_name}
-相对日期换算：
-- 昨天={yesterday.strftime("%Y-%m-%d")}（{_weekday_cn(yesterday)}）
-- 今天={local_date}（{_weekday_cn(ts)}）
-- 明天={tomorrow.strftime("%Y-%m-%d")}（{_weekday_cn(tomorrow)}）
-- 后天={day_after_tomorrow.strftime("%Y-%m-%d")}（{_weekday_cn(day_after_tomorrow)}）
-- 当前用户消息里的“今天/明天/昨天/后天/周几”等相对时间，默认都以这里为准再换算成绝对日期
-（调用 schedule 工具时，将该 request_time 原样传入 request_time 字段）"""
 
 
 def build_current_message_time_envelope(*, message_timestamp: datetime | None = None) -> str:
     ts = _normalize_timestamp(message_timestamp)
     if ts.tzinfo is None:
         ts = ts.astimezone()
+    yesterday = ts - timedelta(days=1)
     tomorrow = ts + timedelta(days=1)
+    day_after_tomorrow = ts + timedelta(days=2)
     return (
-        f"[当前消息时间: {ts.strftime('%Y-%m-%d %H:%M %Z')} | "
-        f"今天={ts.strftime('%Y-%m-%d')} | "
-        f"明天={tomorrow.strftime('%Y-%m-%d')}]"
+        f"[当前消息时间: {ts.strftime('%Y-%m-%d %H:%M:%S %Z')} | "
+        f"request_time={ts.isoformat()} | "
+        f"今天={ts.strftime('%Y-%m-%d')}（{_weekday_cn(ts)}） | "
+        f"昨天={yesterday.strftime('%Y-%m-%d')}（{_weekday_cn(yesterday)}） | "
+        f"明天={tomorrow.strftime('%Y-%m-%d')}（{_weekday_cn(tomorrow)}） | "
+        f"后天={day_after_tomorrow.strftime('%Y-%m-%d')}（{_weekday_cn(day_after_tomorrow)}） | "
+        f"weekday={ts.strftime('%A')} | "
+        f"相对时间以此为准]"
     )
 
 

--- a/tests/test_agent_core_p4_prompt_block.py
+++ b/tests/test_agent_core_p4_prompt_block.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 from agent.core.prompt_block import (
+    ActiveSkillsPromptBlock,
+    BehaviorRulesPromptBlock,
     IdentityPromptBlock,
+    LongTermMemoryPromptBlock,
+    MemesPromptBlock,
     MemoryBlockPromptBlock,
+    RecentContextPromptBlock,
+    SelfModelPromptBlock,
+    SessionContextPromptBlock,
+    SkillsCatalogPromptBlock,
     SystemPromptBuilder,
     TurnContext,
 )
@@ -46,7 +53,6 @@ def test_system_prompt_builder_uses_prompt_blocks_and_static_cache(tmp_path: Pat
         skill_names=[],
         channel=None,
         chat_id=None,
-        message_timestamp=datetime(2026, 4, 4, 21, 0, 0),
         retrieved_memory_block="retrieved",
     )
 
@@ -72,7 +78,6 @@ def test_system_prompt_builder_respects_disabled_sections(tmp_path: Path):
         skill_names=[],
         channel=None,
         chat_id=None,
-        message_timestamp=None,
         retrieved_memory_block="retrieved",
     )
 
@@ -87,3 +92,31 @@ def test_static_identity_prompt_is_not_hardcoded_to_specific_user(tmp_path: Path
 
     assert "花月的长期 AI 伙伴" not in prompt
     assert "用户的长期 AI 伙伴" in prompt
+
+
+def test_prompt_block_priorities_leave_spacing_for_future_inserts():
+    priorities = [
+        (IdentityPromptBlock.label, IdentityPromptBlock.priority),
+        (BehaviorRulesPromptBlock.label, BehaviorRulesPromptBlock.priority),
+        (SkillsCatalogPromptBlock.label, SkillsCatalogPromptBlock.priority),
+        (MemesPromptBlock.label, MemesPromptBlock.priority),
+        (SelfModelPromptBlock.label, SelfModelPromptBlock.priority),
+        (LongTermMemoryPromptBlock.label, LongTermMemoryPromptBlock.priority),
+        (SessionContextPromptBlock.label, SessionContextPromptBlock.priority),
+        (RecentContextPromptBlock.label, RecentContextPromptBlock.priority),
+        (ActiveSkillsPromptBlock.label, ActiveSkillsPromptBlock.priority),
+        (MemoryBlockPromptBlock.label, MemoryBlockPromptBlock.priority),
+    ]
+
+    assert priorities == [
+        ("identity", 10),
+        ("behavior_rules", 15),
+        ("skills_catalog", 20),
+        ("memes", 25),
+        ("self_model", 30),
+        ("long_term_memory", 35),
+        ("session_context", 40),
+        ("recent_context", 45),
+        ("active_skills", 50),
+        ("retrieved_memory", 55),
+    ]

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -475,9 +475,6 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
     assert "retrieved" in prompt
     assert "memory block" in prompt
     assert "Akashic 自我认知" in prompt
-    assert "request_time=" in prompt
-    assert "今天=" in prompt
-    assert "明天=" in prompt
     assert "## 环境" in prompt
     assert "# Memes" in prompt
     assert "<meme:shy>" in prompt
@@ -510,14 +507,18 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
         )
     ).messages
     assert messages[0]["role"] == "system"
-    assert "request_time=" in messages[0]["content"]
-    assert "今天=" in messages[0]["content"]
-    assert "明天=" in messages[0]["content"]
     assert "## 环境" in messages[0]["content"]
     assert "## Current Session" in messages[0]["content"]
     assert messages[-1]["role"] == "user"
     assert len(messages[-1]["content"]) == 3
-    assert messages[-1]["content"][-1]["text"].startswith("[当前消息时间:")
+    stamped_message = messages[-1]["content"][-1]["text"]
+    assert stamped_message.startswith("[当前消息时间:")
+    assert "request_time=" in stamped_message
+    assert "今天=" in stamped_message
+    assert "昨天=" in stamped_message
+    assert "明天=" in stamped_message
+    assert "后天=" in stamped_message
+    assert "weekday=" in stamped_message
     assert builder.last_assembled_contexts["turn_injection_context"] == {}
 
     turn_injection = builder.build_turn_injection_context(turn_injection_prompt="pref")
@@ -536,6 +537,20 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
     assert render_result.system_prompt
     assert render_result.turn_injection_context == turn_injection
     assert render_result.messages
+
+    media_only_messages = builder.render(
+        ContextRequest(
+            history=[],
+            current_message="",
+            media=["https://img"],
+            skill_names=["extra"],
+            message_timestamp=now,
+        )
+    ).messages
+    media_only_text = media_only_messages[-1]["content"][-1]["text"]
+    assert media_only_text.startswith("[当前消息时间:")
+    assert "request_time=" in media_only_text
+    assert "今天=" in media_only_text
 
 
 def test_context_builder_reproduces_temporal_conflict_baseline(
@@ -608,16 +623,21 @@ def test_context_builder_reproduces_temporal_conflict_baseline(
     system_prompt = result.messages[0]["content"]
     user_message = result.messages[-1]["content"]
 
-    assert "request_time=2026-04-08T17:57:00+08:00" in system_prompt
-    assert "local_date=2026-04-08" in system_prompt
-    assert "今天=2026-04-08" in system_prompt
-    assert "明天=2026-04-09" in system_prompt
+    assert "request_time=2026-04-08T17:57:00+08:00" not in system_prompt
+    assert "local_date=2026-04-08" not in system_prompt
+    assert "今天=2026-04-08" not in system_prompt
+    assert "明天=2026-04-09" not in system_prompt
     assert "用户表示明天下午三点有面试" in system_prompt
     assert "准备次日下午三点的字节跳动面试" in system_prompt
     assert "4 月 9 日（周四）下午 3 点" in system_prompt
-    assert user_message.startswith("[当前消息时间: 2026-04-08 17:57")
+    assert user_message.startswith("[当前消息时间: 2026-04-08 17:57:00")
+    assert "request_time=2026-04-08T17:57:00+08:00" in user_message
     assert "今天=2026-04-08" in user_message
+    assert "昨天=2026-04-07" in user_message
     assert "明天=2026-04-09" in user_message
+    assert "后天=2026-04-10" in user_message
+    assert "weekday=Wednesday" in user_message
+    assert "相对时间以此为准" in user_message
     assert user_message.endswith("你还记得明天什么时候面试吗")
 
 


### PR DESCRIPTION
调整 prompt block 顺序，让更稳定的 SessionContext 前置，提升同 session 连续对话的前缀缓存命中率。

同时移除 system prompt 里的 request_time，改为放入用户消息时间戳；清理死代码和死参数链路；补充每个 block 的来源与更新时机注释，方便 review 和后续维护。