### PR TITLE
feat(spawn): add subagent management

### DIFF
--- a/agent/background/subagent_manager.py
+++ b/agent/background/subagent_manager.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 import logging
 import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from agent.background.runtime import (
@@ -35,6 +37,20 @@ _SPAWN_MAX_ITERATIONS = 50
 _SYNC_MAX_ITERATIONS = 10
 
 
+@dataclass(frozen=True)
+class RunningSubagentJob:
+    job_id: str
+    label: str
+    task: str
+    profile: str
+    origin_channel: str
+    origin_chat_id: str
+    task_dir: str
+    retry_count: int
+    started_at: str
+    status: str = "running"
+
+
 class SubagentManager:
     """Manage background subagent jobs and announce completion to the main loop."""
 
@@ -59,6 +75,8 @@ class SubagentManager:
         self._fetch_requester = fetch_requester
         self._multimodal = multimodal
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._running_jobs: dict[str, RunningSubagentJob] = {}
+        self._cancel_announced: set[str] = set()
 
     def _spawn_jobs_dir(self) -> Path:
         root = self._workspace / "subagent-runs"
@@ -167,7 +185,18 @@ class SubagentManager:
         )
         # 3. 最后登记运行中任务，并返回给主 agent 一段立即可回复用户的确认文本。
         self._running_tasks[job_id] = bg_task
-        bg_task.add_done_callback(lambda _: self._running_tasks.pop(job_id, None))
+        self._running_jobs[job_id] = RunningSubagentJob(
+            job_id=job_id,
+            label=display_label,
+            task=task,
+            profile=profile,
+            origin_channel=origin_channel,
+            origin_chat_id=origin_chat_id,
+            task_dir=str(task_dir),
+            retry_count=retry_count,
+            started_at=datetime.now(timezone.utc).isoformat(),
+        )
+        bg_task.add_done_callback(lambda _: self._forget_running_job(job_id))
         logger.info(
             "[spawn] started job_id=%s label=%r profile=%s retry_count=%d origin=%s:%s reason=%s confidence=%s",
             job_id,
@@ -187,6 +216,27 @@ class SubagentManager:
     def get_running_count(self) -> int:
         return len(self._running_tasks)
 
+    def list_running_jobs(self) -> list[dict[str, object]]:
+        return [asdict(job) for job in self._running_jobs.values()]
+
+    async def cancel(self, job_id: str) -> bool:
+        task = self._running_tasks.get(job_id)
+        if task is None or task.done():
+            return False
+        job = self._running_jobs.get(job_id)
+        if job is not None:
+            self._cancel_announced.add(job_id)
+            await self._announce_cancelled_job(job)
+        task.cancel()
+        await asyncio.sleep(0)
+        logger.info("[spawn] cancel requested job_id=%s", job_id)
+        return True
+
+    def _forget_running_job(self, job_id: str) -> None:
+        self._running_tasks.pop(job_id, None)
+        self._running_jobs.pop(job_id, None)
+        self._cancel_announced.discard(job_id)
+
     async def _run_subagent(
         self,
         *,
@@ -204,22 +254,51 @@ class SubagentManager:
         job_runner = AgentBackgroundJobRunner(
             lambda: self._build_subagent(task_dir=task_dir, profile=profile)
         )
-        # 1. 先按统一 background job spec 执行 subagent，本层不直接碰 loop 细节。
-        result = await job_runner.run(
-            AgentBackgroundJobSpec(
+        try:
+            # 1. 先按统一 background job spec 执行 subagent，本层不直接碰 loop 细节。
+            result = await job_runner.run(
+                AgentBackgroundJobSpec(
+                    job_id=job_id,
+                    job_kind="conversation_spawn",
+                    label=label,
+                    task=task,
+                    max_iterations=_SPAWN_MAX_ITERATIONS,
+                    completion_mode="message_bus",
+                    persistence_mode="ephemeral",
+                ),
+                on_exception=lambda e: logger.exception(
+                    "[spawn] subagent failed job_id=%s err=%s", job_id, e
+                ),
+                error_result_summary=None,
+            )
+        except asyncio.CancelledError:
+            if job_id not in self._cancel_announced:
+                await self._announce_result(
+                    job_id=job_id,
+                    label=label,
+                    task=task,
+                    origin_channel=origin_channel,
+                    origin_chat_id=origin_chat_id,
+                    status="cancelled",
+                    exit_reason="cancelled",
+                    result="后台任务已按请求取消。",
+                    decision=decision,
+                    profile=profile,
+                    retry_count=retry_count,
+                )
+            self._append_spawn_trace(
                 job_id=job_id,
-                job_kind="conversation_spawn",
-                label=label,
-                task=task,
-                max_iterations=_SPAWN_MAX_ITERATIONS,
-                completion_mode="message_bus",
-                persistence_mode="ephemeral",
-            ),
-            on_exception=lambda e: logger.exception(
-                "[spawn] subagent failed job_id=%s err=%s", job_id, e
-            ),
-            error_result_summary=None,
-        )
+                payload={
+                    "phase": "cancelled",
+                    "task_dir": str(task_dir),
+                    "status": "cancelled",
+                    "exit_reason": "cancelled",
+                    "profile": profile,
+                    "retry_count": retry_count,
+                    "decision": _decision_payload(decision),
+                },
+            )
+            raise
         # 2. 再把统一结果协议转成 bus completion event，回到原会话。
         await self._announce_result(
             job_id=job_id,
@@ -251,6 +330,21 @@ class SubagentManager:
                 "retry_count": retry_count,
                 "decision": _decision_payload(decision),
             },
+        )
+
+    async def _announce_cancelled_job(self, job: RunningSubagentJob) -> None:
+        await self._announce_result(
+            job_id=job.job_id,
+            label=job.label,
+            task=job.task,
+            origin_channel=job.origin_channel,
+            origin_chat_id=job.origin_chat_id,
+            status="cancelled",
+            exit_reason="cancelled",
+            result="后台任务已按请求取消。",
+            decision=None,
+            profile=job.profile,
+            retry_count=job.retry_count,
         )
 
     def _build_subagent(

--- a/agent/background/subagent_profiles.py
+++ b/agent/background/subagent_profiles.py
@@ -89,7 +89,6 @@ def build_scripting_spec(
         ShellTool(
             allow_network=False,
             working_dir=task_dir,
-            restricted_dir=task_dir,
         ),
     ]
     return SubagentSpec(
@@ -120,7 +119,6 @@ def build_general_spec(
         ShellTool(
             allow_network=True,
             working_dir=task_dir,
-            restricted_dir=task_dir,
         ),
     ]
     return SubagentSpec(

--- a/agent/core/context_store.py
+++ b/agent/core/context_store.py
@@ -542,11 +542,7 @@ async def _run_effects(effects: list[object]) -> None:
 
 
 # ── Session metadata helpers (moved from agent/looping/memory_gate.py) ────────
-# agent/looping/memory_gate.py re-exports these for backward compat.
-
-
-def _extract_task_tools(tools_used: list[str]) -> list[str]:
-    return []
+# agent/looping/memory_gate.py re-exports this for backward compat.
 
 
 def _update_session_runtime_metadata(
@@ -564,26 +560,6 @@ def _update_session_runtime_metadata(
         if isinstance(group, dict)
     )
 
-    turn_task_tools = _extract_task_tools(tools_used)
-    turns = md.get("_task_tools_turns")
-    if not isinstance(turns, list):
-        turns = []
-    turns.append(turn_task_tools)
-    turns = turns[-2:]
-
-    flat_recent: list[str] = []
-    seen: set[str] = set()
-    for turn in turns:
-        if not isinstance(turn, list):
-            continue
-        for name in turn:
-            if isinstance(name, str) and name not in seen:
-                seen.add(name)
-                flat_recent.append(name)
-
     md["last_turn_tool_calls_count"] = call_count
-    md["recent_task_tools"] = flat_recent
-    md["last_turn_had_task_tool"] = bool(turn_task_tools)
     md["last_turn_ts"] = datetime.now().astimezone().isoformat()
-    md["_task_tools_turns"] = turns
     session.metadata = md  # type: ignore[union-attr]

--- a/agent/looping/handlers.py
+++ b/agent/looping/handlers.py
@@ -40,6 +40,7 @@ async def process_spawn_completion_event(
         "tool_loop": "工具调用循环截断（任务可能不完整）",
         "error": "执行出错",
         "forced_summary": "强制汇总（任务可能不完整）",
+        "cancelled": "已取消",
     }
     exit_label = _EXIT_LABELS.get(exit_reason, exit_reason or "未知")
 
@@ -92,6 +93,8 @@ async def process_spawn_completion_event(
             final_content = "后台任务已完成。"
         elif status == "incomplete":
             final_content = "后台任务未全部完成，部分工作尚未收尾。"
+        elif status == "cancelled":
+            final_content = "后台任务已取消。"
         else:
             final_content = "后台任务执行出错。"
 

--- a/agent/looping/memory_gate.py
+++ b/agent/looping/memory_gate.py
@@ -96,11 +96,6 @@ def _trace_memory_retrieve(
 # creating a circular import at module load time.
 
 
-def _extract_task_tools(tools_used: list[str]) -> list[str]:
-    from agent.core.context_store import _extract_task_tools as _impl
-    return _impl(tools_used)
-
-
 def _update_session_runtime_metadata(
     session: object,
     *,

--- a/agent/policies/history_route.py
+++ b/agent/policies/history_route.py
@@ -61,13 +61,6 @@ class HistoryRoutePolicy:
             return True
         if _FLOW_SEQUENCE_PATTERN.search(text):
             return True
-        if bool(metadata.get("last_turn_had_task_tool", False)):
-            return True
-        recent_task_tools = metadata.get("recent_task_tools")
-        if isinstance(recent_task_tools, list) and any(
-            isinstance(tool, str) and tool for tool in recent_task_tools
-        ):
-            return True
         return False
 
     async def decide(

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -21,7 +21,7 @@ import signal
 import shlex
 import ipaddress
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -234,7 +234,8 @@ class ShellTool(Tool):
             "- 以下命令被禁止：nc、telnet、浏览器等高风险工具\n"
             "- 输出超过 30000 字符时自动截断\n"
             "- 前台总超时默认 60 秒，最大 600 秒\n"
-            "- 命令超过 15 秒未完成时自动转为后台任务，返回 background_task_id；若本次设置了 timeout，后台会继续沿用这个截止时间\n"
+            "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；若本次设置了 timeout，后台会继续沿用这个截止时间\n"
+            "- 只有用户明确说“阻塞”时，才设置 auto_promote=false，并显式配置 timeout\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
             "- 收到 background_task_id 后，调用 task_output 查看输出和耗时，"
             "根据命令的性质自行判断是否卡死；若判断卡死则 task_stop 终止\n"
@@ -271,6 +272,13 @@ class ShellTool(Tool):
                         "适用于服务进程、长时间编译等不需要等待结果的场景。"
                     ),
                 },
+                "auto_promote": {
+                    "type": "boolean",
+                    "description": (
+                        "前台命令超过 15 秒未完成时是否自动转后台，默认 true。"
+                        "只有用户明确说“阻塞”时才设为 false；同时应显式设置 timeout。"
+                    ),
+                },
             },
             "required": ["command", "description"],
         }
@@ -281,13 +289,14 @@ class ShellTool(Tool):
         timeout: int = min(int(kwargs.get("timeout", _DEFAULT_TIMEOUT)), _MAX_TIMEOUT)
         timeout_specified = "timeout" in kwargs and kwargs.get("timeout") is not None
         run_in_background: bool = bool(kwargs.get("run_in_background", False))
+        auto_promote: bool = bool(kwargs.get("auto_promote", True))
         on_data = kwargs.get("_on_data")
 
         if not command:
             return _err("命令不能为空")
 
         cwd = self._working_dir
-        env = os.environ.copy()
+        env = _shell_env()
         if self._spawn_hook is not None:
             hooked = self._spawn_hook(
                 {
@@ -324,12 +333,12 @@ class ShellTool(Tool):
             bg_timeout = timeout if timeout_specified else None
             return await self._execute_background(command, cwd, env, bg_timeout)
 
-        # ── 前台路径（15s 未完成自动转后台）────────────────────────────
+        # ── 前台路径（默认 15s 未完成自动转后台）──────────────────────
         data_callback = (
             cast(Callable[[str], None], on_data) if callable(on_data) else None
         )
         return await self._execute_with_auto_promote(
-            command, cwd, env, timeout, data_callback
+            command, cwd, env, timeout, data_callback, auto_promote
         )
 
     async def _execute_background(
@@ -391,8 +400,9 @@ class ShellTool(Tool):
         env: dict[str, str],
         timeout: int,
         on_data: Callable[[str], None] | None,
+        auto_promote: bool,
     ) -> str:
-        """前台执行；若 _FG_THRESHOLD 秒内未完成则不 kill，自动转后台并返回 task_id。"""
+        """前台执行；允许按需关闭自动转后台，直接等待完整结果。"""
         task_id = f"shell_{uuid4().hex[:12]}"
         log_fd, log_path = tempfile.mkstemp(
             prefix=f"akashic-fg-{task_id}-", suffix=".log"
@@ -421,13 +431,15 @@ class ShellTool(Tool):
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg, on_data))
         bg.pump_task = pump
 
-        fg_wait_timeout = min(timeout, _FG_THRESHOLD)
+        fg_wait_timeout = min(timeout, _FG_THRESHOLD) if auto_promote else timeout
         try:
             await asyncio.wait_for(asyncio.shield(pump), timeout=fg_wait_timeout)
         except asyncio.TimeoutError:
             elapsed_s = time.monotonic() - start_mono
-            if elapsed_s >= timeout:
-                return await self._finalize_timed_out_process(command, proc, pump, log_path, start_mono)
+            if not auto_promote or elapsed_s >= timeout:
+                return await self._finalize_timed_out_process(
+                    command, proc, pump, log_path, start_mono
+                )
             # ── 自动转后台 ──────────────────────────────────────────────
             pump.add_done_callback(lambda _: _schedule_eviction(task_id, log_path))
             _BG_REGISTRY[task_id] = bg
@@ -741,6 +753,66 @@ def _is_background_timeout(task: _BackgroundTask) -> bool:
     if task.timeout_s is None:
         return False
     return time.monotonic() - task.started_at >= task.timeout_s
+
+
+def _shell_env() -> dict[str, str]:
+    env = os.environ.copy()
+    _prepend_existing_path_entries(env, _discover_user_path_entries(env))
+    return env
+
+
+def _discover_user_path_entries(env: dict[str, str]) -> list[Path]:
+    home_text = env.get("HOME")
+    if not home_text:
+        return []
+    home = Path(home_text).expanduser()
+    nvm_dir = Path(env.get("NVM_DIR") or home / ".nvm").expanduser()
+    entries = [home / ".local" / "bin"]
+    nvm_bin = env.get("NVM_BIN")
+    if nvm_bin:
+        entries.append(Path(nvm_bin).expanduser())
+    entries.extend(_discover_nvm_node_bins(nvm_dir))
+    return entries
+
+
+def _discover_nvm_node_bins(nvm_dir: Path) -> list[Path]:
+    node_root = nvm_dir / "versions" / "node"
+    try:
+        version_dirs = [p for p in node_root.iterdir() if p.is_dir()]
+    except OSError:
+        return []
+    return [
+        version_dir / "bin"
+        for version_dir in sorted(
+            version_dirs,
+            key=lambda p: _node_version_key(p.name),
+            reverse=True,
+        )
+        if (version_dir / "bin").is_dir()
+    ]
+
+
+def _node_version_key(version: str) -> tuple[int, int, int]:
+    parts = version.removeprefix("v").split(".")
+    nums: list[int] = []
+    for part in parts[:3]:
+        nums.append(int(part) if part.isdigit() else 0)
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2])
+
+
+def _prepend_existing_path_entries(env: dict[str, str], entries: list[Path]) -> None:
+    current = [p for p in env.get("PATH", "").split(os.pathsep) if p]
+    seen = set(current)
+    prepend: list[str] = []
+    for entry in entries:
+        text = str(entry)
+        if text in seen or not entry.is_dir():
+            continue
+        prepend.append(text)
+        seen.add(text)
+    env["PATH"] = os.pathsep.join([*prepend, *current])
 
 
 async def _run(

--- a/agent/tools/spawn.py
+++ b/agent/tools/spawn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from agent.background.subagent_manager import SubagentManager
@@ -159,3 +160,72 @@ subagent 没有看过当前会话。像给刚进房间的同事写交接文档�
             label=label,
             profile=profile,
         )
+
+
+class SpawnManageTool(Tool):
+    """List or cancel background subagent jobs."""
+
+    def __init__(self, manager: SubagentManager) -> None:
+        self._manager = manager
+
+    @property
+    def name(self) -> str:
+        return "spawn_manage"
+
+    @property
+    def description(self) -> str:
+        return """\
+管理当前运行中的后台 subagent。
+
+可用 action：
+- list：列出正在运行的后台任务，包含 job_id、label、profile、task_dir、任务摘要和启动时间
+- cancel：按 job_id 取消后台任务；取消后系统会把“已取消”作为后台任务完成事件回灌当前会话
+
+只在用户询问后台任务状态、要求查看 job_id、或明确要求停止某个后台任务时使用。\
+"""
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "cancel"],
+                    "description": "list 查看运行中任务；cancel 取消指定 job_id",
+                },
+                "job_id": {
+                    "type": "string",
+                    "description": "action=cancel 时要取消的后台任务 job_id",
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(
+        self,
+        action: str,
+        job_id: str | None = None,
+        **_: Any,
+    ) -> str:
+        if action == "list":
+            return json.dumps(
+                {
+                    "running_count": self._manager.get_running_count(),
+                    "jobs": self._manager.list_running_jobs(),
+                },
+                ensure_ascii=False,
+            )
+        if action == "cancel":
+            target = (job_id or "").strip()
+            if not target:
+                return json.dumps({"error": "缺少 job_id"}, ensure_ascii=False)
+            cancelled = await self._manager.cancel(target)
+            return json.dumps(
+                {
+                    "job_id": target,
+                    "status": "cancel_requested" if cancelled else "not_found",
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps({"error": f"未知 action: {action}"}, ensure_ascii=False)

--- a/bootstrap/toolsets/meta.py
+++ b/bootstrap/toolsets/meta.py
@@ -10,7 +10,7 @@ from agent.tools.base import Tool
 from agent.tools.meta import register_common_meta_tools
 from agent.tools.message_push import MessagePushTool
 from agent.tools.registry import ToolRegistry
-from agent.tools.spawn import SpawnTool
+from agent.tools.spawn import SpawnManageTool, SpawnTool
 from bus.queue import MessageBus
 from bootstrap.toolsets.protocol import (
     ToolsetDeps,
@@ -79,6 +79,12 @@ class SpawnToolsetProvider(ToolsetProvider):
                 always_on=True,
                 risk="write",
                 search_hint="后台执行 子任务 多步调研 独立任务",
+            )
+            registry.register(
+                SpawnManageTool(subagent_manager),
+                always_on=True,
+                risk="external-side-effect",
+                search_hint="查看 取消 后台任务 subagent job_id spawn_manage",
             )
         return build_registration_result(
             registry=registry,

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -131,13 +131,11 @@ class MemoryOptimizer:
         provider: LLMProvider,
         model: str,
         max_tokens: int = 16384,
-        history_max_chars: int = 6000,
     ) -> None:
         self._memory = memory
         self._provider = provider
         self._model = model
         self._max_tokens = max_tokens
-        self._history_max_chars = history_max_chars
 
     # 各步骤之间的间隔（秒），避免短时间内连续请求触发 limit_burst_rate
     _STEP_DELAY_SECONDS: int = 15
@@ -223,12 +221,6 @@ class MemoryOptimizer:
                 logger.info("[memory_optimizer] SELF.md 已更新")
         except Exception as e:
             logger.error("[memory_optimizer] SELF.md 更新失败: %s", e)
-
-    def _read_recent_history(self) -> str:
-        try:
-            return self._memory.read_history(max_chars=self._history_max_chars)
-        except Exception:
-            return ""
 
     async def _request_text_response(
         self,

--- a/prompts/background.py
+++ b/prompts/background.py
@@ -65,6 +65,8 @@ def build_scripting_subagent_prompt(workspace: Path, task_dir: Path) -> str:
 === 工作指引 ===
 - 所有产出文件只能写入当前任务目录：{task_dir_path}
 - 执行命令前先确认工作目录和路径正确
+- shell 可以检查用户指定的目标路径和使用管道；不要用 shell 在任务目录外写文件
+- 只有用户明确要求阻塞时，调用 shell 才设置 auto_promote=false，并显式给出 timeout；其他长命令保持默认自动转后台
 - 优先读取任务描述中已提供的上下文，不要重复抓取已有信息
 - 命令执行出错时，换个方式处理，不要把报错写进最终回复
 
@@ -101,6 +103,8 @@ def build_general_subagent_prompt(workspace: Path, task_dir: Path) -> str:
 === 工作指引 ===
 - 先明确任务边界，避免过度延伸
 - 调研和执行按需切换，不要同时打开过多方向
+- shell 可以检查用户指定的目标路径和使用管道；不要用 shell 在任务目录外写文件
+- 只有用户明确要求阻塞时，调用 shell 才设置 auto_promote=false，并显式给出 timeout；其他长命令保持默认自动转后台
 - 命令执行出错时换个方式，不要把报错直接塞进结果
 - 任务描述中若已有用户上下文，优先使用；需要更多背景时可读取以下资源
 

--- a/tests/test_core_decoupling_baseline.py
+++ b/tests/test_core_decoupling_baseline.py
@@ -188,57 +188,6 @@ def test_session_metadata_update_counts_tool_calls():
     assert session.metadata["last_turn_tool_calls_count"] == 3
 
 
-def test_session_metadata_update_has_no_task_tools_after_update_now_removal():
-    """_update_session_runtime_metadata no longer tracks removed task tools."""
-    from agent.looping.memory_gate import _update_session_runtime_metadata
-
-    session = _make_session()
-    _update_session_runtime_metadata(
-        session,
-        tools_used=["shell"],
-        tool_chain=[{"calls": [{"name": "shell"}]}],
-    )
-    assert session.metadata["last_turn_had_task_tool"] is False
-    assert session.metadata["recent_task_tools"] == []
-
-
-def test_session_metadata_update_no_task_tools():
-    """Turn without task tools: last_turn_had_task_tool is False."""
-    from agent.looping.memory_gate import _update_session_runtime_metadata
-
-    session = _make_session()
-    _update_session_runtime_metadata(
-        session,
-        tools_used=["shell"],
-        tool_chain=[{"calls": [{"name": "shell"}]}],
-    )
-    assert session.metadata["last_turn_had_task_tool"] is False
-    assert session.metadata["recent_task_tools"] == []
-
-
-def test_session_metadata_update_task_tools_turns_rolling_window():
-    """_task_tools_turns keeps only the last 2 turns."""
-    from agent.looping.memory_gate import _update_session_runtime_metadata
-
-    session = _make_session()
-    _update_session_runtime_metadata(session, tools_used=["shell"], tool_chain=[])
-    _update_session_runtime_metadata(session, tools_used=["web_search"], tool_chain=[])
-    _update_session_runtime_metadata(session, tools_used=["shell"], tool_chain=[])
-    turns = session.metadata["_task_tools_turns"]
-    assert len(turns) == 2, "_task_tools_turns must be capped at 2 turns"
-
-
-def test_session_metadata_update_recent_task_tools_dedup():
-    """recent_task_tools flattens and deduplicates across the rolling window."""
-    from agent.looping.memory_gate import _update_session_runtime_metadata
-
-    session = _make_session()
-    _update_session_runtime_metadata(session, tools_used=["shell"], tool_chain=[])
-    _update_session_runtime_metadata(session, tools_used=["shell"], tool_chain=[])
-    recent = session.metadata["recent_task_tools"]
-    assert recent == []
-
-
 def test_session_metadata_update_sets_last_turn_ts():
     """last_turn_ts is set to a non-empty ISO timestamp."""
     from agent.looping.memory_gate import _update_session_runtime_metadata

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -40,7 +40,7 @@ async def test_memory_optimizer_loop_and_memory_port_cover_paths(tmp_path: Path)
             LLMResponse(content="updated self"),
         ]
     )
-    opt = MemoryOptimizer(memory, provider, "m", max_tokens=100, history_max_chars=20)
+    opt = MemoryOptimizer(memory, provider, "m", max_tokens=100)
     opt._STEP_DELAY_SECONDS = 0
     await opt.optimize()
     memory.write_long_term.assert_called_once_with("merged")

--- a/tests/test_memory_retrieval_gates.py
+++ b/tests/test_memory_retrieval_gates.py
@@ -266,21 +266,14 @@ def test_flow_execution_state_not_triggered_by_single_char_xian_zai():
     assert _is_flow_execution_state("先查再说", {}) is True
 
 
-def test_flow_execution_state_uses_task_tool_flag_not_any_tool_count():
+def test_flow_execution_state_ignores_tool_count_metadata():
     loop = _make_loop(_Provider(), memory_route_intention_enabled=True)
     assert (
         _is_flow_execution_state(
             "普通问题",
-            {"last_turn_tool_calls_count": 3, "last_turn_had_task_tool": False},
+            {"last_turn_tool_calls_count": 3},
         )
         is False
-    )
-    assert (
-        _is_flow_execution_state(
-            "普通问题",
-            {"last_turn_tool_calls_count": 0, "last_turn_had_task_tool": True},
-        )
-        is True
     )
 
 

--- a/tests/test_memory_retrieval_phase0.py
+++ b/tests/test_memory_retrieval_phase0.py
@@ -244,8 +244,6 @@ def test_loop_updates_session_runtime_metadata(tmp_path: Path):
     )
 
     assert session.metadata["last_turn_tool_calls_count"] == 2
-    assert session.metadata["last_turn_had_task_tool"] is False
-    assert session.metadata["recent_task_tools"] == []
     assert isinstance(session.metadata.get("last_turn_ts"), str)
 
     _update_session_runtime_metadata(
@@ -255,8 +253,6 @@ def test_loop_updates_session_runtime_metadata(tmp_path: Path):
     )
 
     assert session.metadata["last_turn_tool_calls_count"] == 1
-    assert isinstance(session.metadata.get("_task_tools_turns"), list)
-    assert len(session.metadata["_task_tools_turns"]) <= 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -101,6 +101,37 @@ async def test_shell_tool_uses_configured_working_dir(monkeypatch, tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_shell_tool_adds_nvm_bin_to_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    observed: dict[str, object] = {}
+    nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v22.17.1" / "bin"
+    nvm_bin.mkdir(parents=True)
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        observed["kwargs"] = kwargs
+        return _FakeProc(stdout="ok")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.delenv("NVM_BIN", raising=False)
+    monkeypatch.delenv("NVM_DIR", raising=False)
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    await tool.execute(command="which codex", description="找 codex")
+
+    observed_kwargs = cast(dict[str, object], observed["kwargs"])
+    env = cast(dict[str, str], observed_kwargs["env"])
+    path_entries = env["PATH"].split(os.pathsep)
+    assert str(nvm_bin) in path_entries
+    assert path_entries.index(str(nvm_bin)) < path_entries.index("/usr/bin")
+
+
+@pytest.mark.asyncio
 async def test_shell_tool_supports_spawn_hook_and_streaming(monkeypatch, tmp_path: Path):
     observed: dict[str, object] = {}
     streamed: list[str] = []
@@ -680,6 +711,43 @@ async def test_shell_auto_promotes_to_background_after_fg_threshold(monkeypatch)
 
     # 清理
     shell_mod._BG_REGISTRY.pop(task_id, None)
+
+
+@pytest.mark.asyncio
+async def test_shell_auto_promote_false_waits_for_foreground_completion(monkeypatch):
+    """auto_promote=False 时，即使超过前台阈值也应同步等待完整结果。"""
+    import agent.tools.shell as shell_mod
+
+    monkeypatch.setattr(shell_mod, "_FG_THRESHOLD", 0)
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        proc = _FakeProc(stdout="done", stderr="", returncode=0)
+
+        async def _wait_after_threshold():
+            await asyncio.sleep(0.01)
+            return 0
+
+        proc.wait = _wait_after_threshold
+        return proc
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(
+            command="codex exec test",
+            description="同步 codex",
+            timeout=1,
+            auto_promote=False,
+        )
+    )
+
+    assert "background_task_id" not in result
+    assert result["exit_code"] == 0
+    assert result["output"] == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/test_spawn_tool.py
+++ b/tests/test_spawn_tool.py
@@ -4,7 +4,7 @@ import pytest
 
 from agent.policies.delegation import SpawnDecision, SpawnDecisionMeta
 from agent.tools.registry import ToolRegistry
-from agent.tools.spawn import SpawnTool
+from agent.tools.spawn import SpawnManageTool, SpawnTool
 
 
 def _make_manager(spawn_return="started", spawn_sync_return="sync-result"):
@@ -12,6 +12,8 @@ def _make_manager(spawn_return="started", spawn_sync_return="sync-result"):
     manager.spawn = AsyncMock(return_value=spawn_return)
     manager.spawn_sync = AsyncMock(return_value=spawn_sync_return)
     manager.get_running_count = Mock(return_value=0)
+    manager.list_running_jobs = Mock(return_value=[])
+    manager.cancel = AsyncMock(return_value=False)
     return manager
 
 
@@ -134,7 +136,7 @@ async def test_spawn_tool_forwards_retry_count_in_background_mode():
     registry.set_context(channel="telegram", chat_id="123")
 
     await tool.execute(
-        task="retry task",
+        task="retry task auto_promote=false",
         label="job",
         run_in_background=True,
         retry_count=1,
@@ -142,3 +144,31 @@ async def test_spawn_tool_forwards_retry_count_in_background_mode():
 
     kwargs = manager.spawn.await_args.kwargs
     assert kwargs["retry_count"] == 1
+    assert kwargs["task"] == "retry task auto_promote=false"
+
+
+@pytest.mark.asyncio
+async def test_spawn_manage_lists_running_jobs():
+    manager = _make_manager()
+    manager.get_running_count = Mock(return_value=1)
+    manager.list_running_jobs = Mock(
+        return_value=[{"job_id": "abc123", "label": "job", "status": "running"}]
+    )
+    tool = SpawnManageTool(manager)
+
+    result = await tool.execute(action="list")
+
+    assert '"running_count": 1' in result
+    assert "abc123" in result
+
+
+@pytest.mark.asyncio
+async def test_spawn_manage_cancels_by_job_id():
+    manager = _make_manager()
+    manager.cancel = AsyncMock(return_value=True)
+    tool = SpawnManageTool(manager)
+
+    result = await tool.execute(action="cancel", job_id="abc123")
+
+    assert "cancel_requested" in result
+    manager.cancel.assert_awaited_once_with("abc123")

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -125,6 +125,49 @@ async def test_subagent_manager_announces_completion_to_origin_session(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_subagent_manager_lists_and_cancels_running_job(tmp_path):
+    bus = MessageBus()
+    manager = SubagentManager(
+        provider=cast(Any, _Provider()),
+        workspace=tmp_path,
+        bus=bus,
+        model="m",
+        max_tokens=256,
+        fetch_requester=object(),  # type: ignore[arg-type]
+    )
+
+    class _WaitingSubAgent:
+        last_exit_reason = "running"
+
+        async def run(self, task: str) -> str:
+            await asyncio.Future()
+            return "never"
+
+    manager._build_subagent = (
+        lambda *, task_dir, profile="research": _WaitingSubAgent()
+    )  # type: ignore[assignment]
+
+    await manager.spawn(
+        task="long task",
+        label="long",
+        origin_channel="telegram",
+        origin_chat_id="42",
+    )
+
+    jobs = manager.list_running_jobs()
+    assert len(jobs) == 1
+    job_id = str(jobs[0]["job_id"])
+    assert jobs[0]["label"] == "long"
+    assert await manager.cancel(job_id) is True
+
+    msg = await asyncio.wait_for(bus.consume_inbound(), timeout=0.2)
+    assert msg.metadata["spawn"]["status"] == "cancelled"
+    assert msg.metadata["spawn"]["exit_reason"] == "cancelled"
+    await asyncio.sleep(0)
+    assert manager.get_running_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_spawn_sync_uses_shorter_iteration_budget(tmp_path):
     bus = MessageBus()
     manager = SubagentManager(

--- a/tests/test_subagent_spawn_task_dir.py
+++ b/tests/test_subagent_spawn_task_dir.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest.mock import MagicMock
+import json
 
 import pytest
 
@@ -82,6 +83,35 @@ def test_scripting_profile_has_no_web_tools(tmp_path: Path):
     assert "web_search" not in tool_names
     assert "shell" in tool_names
     assert "write_file" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_scripting_shell_allows_pipes_and_target_paths(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    task_dir = workspace / "subagent-runs" / "job-1"
+    target_dir = tmp_path / "target"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    target_dir.mkdir()
+
+    spec = build_spawn_spec(
+        workspace=workspace,
+        task_dir=task_dir,
+        fetch_requester=MagicMock(),
+        system_prompt="test",
+        profile="scripting",
+    )
+    shell_tool = next(t for t in spec.tools if t.name == "shell")
+
+    output = await shell_tool.execute(
+        command=f"ls -la {target_dir} 2>&1 | head -1",
+        description="检查目标目录",
+        timeout=10,
+    )
+    assert isinstance(output, str)
+    result = json.loads(output)
+
+    assert "error" not in result
+    assert result["exit_code"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
 ## 变更内容

  - 为 `spawn` 工具组新增 `spawn_manage`，支持查看和终止运行中的 subagent。
  - 调整 subagent / shell 行为：允许用户明确要求时进行阻塞式 shell 调用，并让 subagent 能更自然地调用 `codex` 等 CLI。
  - 放宽 subagent shell 的过度限制，保留写文件工具的任务目录限制。
  - 清理已失效的 task-tool metadata 链路和 `MemoryOptimizer` 死代码。