### PR TITLE
feat(cache): retain context_frame in history for prefix cache stability

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -376,11 +376,7 @@ class DefaultContextStore(ContextStore):
         session: "SessionLike",
     ) -> ContextBundle:
         # 1. 先读取 session history，并转换成 retrieval pipeline 需要的结构。
-        raw_history = [
-            item
-            for item in session.get_history()
-            if not support.is_llm_context_frame(item)
-        ]
+        raw_history = list(session.get_history())
         history_messages = support.to_history_messages(raw_history)
 
         # 2. 再执行 retrieval，保持当前 pipeline 行为不变。

--- a/agent/looping/memory_gate.py
+++ b/agent/looping/memory_gate.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from agent.looping.constants import _RETRIEVE_TRACE_SUMMARY_MAX
 from agent.policies.history_route import HistoryRoutePolicy, RouteDecision
+from agent.prompting import is_context_frame
 from core.common.strategy_trace import build_strategy_trace_envelope
 
 if TYPE_CHECKING:
@@ -111,6 +112,8 @@ def _format_gate_history(
                 c.get("text", "") for c in content if isinstance(c, dict)
             )
         content = str(content).strip()
+        if is_context_frame(content):
+            continue
         if max_content_len is not None:
             content = content[:max_content_len]
         if content:

--- a/agent/prompting/assembler.py
+++ b/agent/prompting/assembler.py
@@ -58,7 +58,7 @@ LEGACY_CONTEXT_FRAME_MARKER = "[SYSTEM_CONTEXT_FRAME]"
 
 def is_context_frame(content: str) -> bool:
     text = content.lstrip()
-    return text.startswith(SYSTEM_CONTEXT_FRAME_MARKER) or text.startswith(
+    return text.startswith("<system-reminder") or text.startswith(
         LEGACY_CONTEXT_FRAME_MARKER
     )
 

--- a/proactive_v2/sensor.py
+++ b/proactive_v2/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from agent.prompting import is_context_frame
 from proactive_v2.energy import compute_energy, d_recent
 from proactive_v2.presence import PresenceStore
 from proactive_v2.state import ProactiveStateStore
@@ -109,10 +110,13 @@ class Sensor:
                 continue
             if not message.get("content"):
                 continue
+            content = str(message.get("content", ""))
+            if is_context_frame(content):
+                continue
             results.append(
                 {
                     "role": message["role"],
-                    "content": str(message.get("content", ""))[:200],
+                    "content": content[:200],
                     "timestamp": str(message.get("timestamp", "")),
                 }
             )

--- a/proactive_v2/tools.py
+++ b/proactive_v2/tools.py
@@ -15,6 +15,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent.prompting import is_context_frame
 from proactive_v2.context import AgentTickContext
 
 logger = logging.getLogger(__name__)
@@ -294,10 +295,15 @@ async def _get_recent_chat(ctx: AgentTickContext, args: dict, *, recent_chat_fn)
     #   role=assistant, proactive 为假 → 保留（被动回复，代表用户主动发起的对话上下文）
     #   role=assistant, proactive=True → 过滤（主动推送，不能当成事实被循环引用；
     #                                           去重逻辑由 recent_proactive_fn 独立负责）
-    filtered = [
-        m for m in (messages or [])
-        if m.get("role") == "user" or (m.get("role") == "assistant" and not m.get("proactive"))
-    ]
+    filtered = []
+    for m in messages or []:
+        content = str(m.get("content") or "")
+        if is_context_frame(content):
+            continue
+        if m.get("role") == "user" or (
+            m.get("role") == "assistant" and not m.get("proactive")
+        ):
+            filtered.append(m)
     return json.dumps(filtered, ensure_ascii=False)
 
 

--- a/session/manager.py
+++ b/session/manager.py
@@ -173,6 +173,9 @@ class Session:
             role = m.get("role")
 
             if role == "user":
+                context_frame = m.get("llm_context_frame")
+                if isinstance(context_frame, str) and context_frame.strip():
+                    out.append({"role": "user", "content": context_frame})
                 user_content = m.get("llm_user_content")
                 if user_content is None:
                     text = m.get("content", "")

--- a/tests/proactive_v2/test_message_quality.py
+++ b/tests/proactive_v2/test_message_quality.py
@@ -63,6 +63,21 @@ async def test_get_recent_chat_keeps_passive_assistant_replies():
 
 
 @pytest.mark.asyncio
+async def test_get_recent_chat_filters_context_frames():
+    mixed = [
+        {"role": "user", "content": '<system-reminder data-system-context-frame="true">内部</system-reminder>'},
+        {"role": "user", "content": "真实用户消息"},
+    ]
+    fake_chat_fn = AsyncMock(return_value=mixed)
+    ctx = AgentTickContext()
+
+    raw = await _get_recent_chat(ctx, {}, recent_chat_fn=fake_chat_fn)
+    result = json.loads(raw)
+
+    assert [m["content"] for m in result] == ["真实用户消息"]
+
+
+@pytest.mark.asyncio
 async def test_get_recent_chat_empty_after_filtering_all_proactive():
     """全部是主动推送时，返回空列表。"""
     all_proactive = [

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -225,6 +225,10 @@ def test_session_get_history_replays_cached_llm_turn_from_consolidated_index():
     history = session.get_history(start_index=session.last_consolidated)
 
     assert history == [
+        {
+            "role": "user",
+            "content": '<system-reminder data-system-context-frame="true">\n\n## retrieved_memory\n旧记忆',
+        },
         {"role": "user", "content": user_content},
         {"role": "assistant", "content": "world"},
     ]
@@ -263,7 +267,7 @@ def test_session_get_history_assistant_only_returns_empty():
     assert session.get_history(start_index=0) == []
 
 
-def test_session_get_history_drops_persisted_context_frame():
+def test_session_get_history_keeps_persisted_context_frame():
     session = Session("cli:1")
     session.add_message(
         "user",
@@ -274,7 +278,10 @@ def test_session_get_history_drops_persisted_context_frame():
 
     history = session.get_history(start_index=0)
 
-    assert history == [{"role": "user", "content": "hello"}]
+    assert history == [
+        {"role": "user", "content": "[SYSTEM_CONTEXT_FRAME]\n\n## recent_context\n旧内容"},
+        {"role": "user", "content": "hello"},
+    ]
 
 
 def test_session_get_history_does_not_inject_inference_tag():

--- a/tests/test_memory_retrieval_gates.py
+++ b/tests/test_memory_retrieval_gates.py
@@ -12,6 +12,7 @@ from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig, MemoryConfig
 from agent.looping.memory_gate import (
     _decide_history_route,
+    _format_gate_history,
     _is_flow_execution_state,
     _trace_route_reason,
 )
@@ -130,6 +131,20 @@ def _req(msg: InboundMessage, session: _DummySession) -> RetrievalRequest:
         session_metadata=session.metadata,
         timestamp=msg.timestamp,
     )
+
+
+def test_format_gate_history_skips_context_frames():
+    history = [
+        {"role": "user", "content": '<system-reminder data-system-context-frame="true">内部</system-reminder>'},
+        {"role": "user", "content": "真实用户消息"},
+        {"role": "assistant", "content": "真实回复"},
+    ]
+
+    text = _format_gate_history(history)
+
+    assert "内部" not in text
+    assert "真实用户消息" in text
+    assert "真实回复" in text
 
 
 def test_route_gate_no_retrieve_when_high_confidence_no_retrieve():


### PR DESCRIPTION
## Summary

Keep context_frame (`<system-reminder>`) as a separate message in
`get_history()` output instead of filtering it out. This prevents message
position shifts between requests, allowing DeepSeek's byte-level prefix
cache to hit on unchanged conversation history.

## Changes

- **session/manager.py** — `get_history()` now outputs `llm_context_frame`
  as a separate `{"role": "user"}` message before each user content.
  Previously it was silently dropped.
- **passive_turn.py** — Removed `is_llm_context_frame` filter from
  `ContextStore.prepare()`. Frame messages now flow through to the API
  request assembly, preserving their position in the message order.
- **assembler.py** — `is_context_frame()` broadened to match any
  `<system-reminder` prefix (was exact match on the full marker). This
  catches compacted frames and legacy `[SYSTEM_CONTEXT_FRAME]` markers.
- **memory_gate.py** / **proactive_v2/tools.py** / **proactive_v2/sensor.py**
  — Added `is_context_frame()` filter to memory extraction and proactive
  context paths, preventing stale frame content from polluting retrieval
  prompts and proactive summaries.

## Test evidence

- `tests/test_logic_modules.py` — `test_session_get_history_keeps_persisted_context_frame`
  verifies context_frame is now included in history output
- `tests/test_memory_retrieval_gates.py` — verifies `_format_gate_history`
  correctly skips context_frame messages
- `tests/proactive_v2/test_message_quality.py` — verifies
  `_get_recent_chat` filters context_frame from proactive context

```text
pytest tests/test_logic_modules.py tests/test_loop_consolidation_json.py \
  tests/test_memory_retrieval_gates.py tests/proactive_v2/test_message_quality.py
=> 114 passed in 0.56s

pyright session/manager.py agent/core/passive_turn.py agent/looping/memory_gate.py \
  proactive_v2/tools.py proactive_v2/sensor.py agent/looping/consolidation.py agent/prompting/assembler.py
=> 0 errors
```