### PR TITLE
fix(telegram): 限制出站消息速率

### DIFF
--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -36,6 +36,7 @@ from bus.queue import MessageBus
 from agent.looping.interrupt import InterruptController
 from infra.channels.base import AttachmentStore, MessageDeduper, SessionIdentityIndex
 from infra.channels.telegram_utils import (
+    TelegramOutboundLimiter,
     TelegramLiveEditQueue,
     TelegramLiveTextMessage,
     TelegramStreamMessage,
@@ -109,8 +110,9 @@ class TelegramChannel:
             event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
         self.user_map = self._identity_index.mapping
         self._polling_conflict_task: asyncio.Task[None] | None = None
+        self._telegram_outbound_limiter = TelegramOutboundLimiter()
         self._active_streams: dict[str, TelegramStreamMessage] = {}
-        self._live_edit_queue = TelegramLiveEditQueue()
+        self._live_edit_queue = TelegramLiveEditQueue(limiter=self._telegram_outbound_limiter)
         self._live_messages: dict[str, TelegramLiveTextMessage] = {}
         self._reply_buffers: dict[str, str] = {}
         self._thinking_buffers: dict[str, str] = {}
@@ -300,7 +302,12 @@ class TelegramChannel:
             )
             return
         if self._interrupt_controller is None:
-            await send_markdown(self._app.bot, str(chat.id), "当前未启用中断功能。")
+            await send_markdown(
+                self._app.bot,
+                str(chat.id),
+                "当前未启用中断功能。",
+                self._telegram_outbound_limiter,
+            )
             return
 
         session_key = f"{_CHANNEL}:{chat.id}"
@@ -309,7 +316,12 @@ class TelegramChannel:
             sender=str(user.id),
             command="/stop",
         )
-        await send_markdown(self._app.bot, str(chat.id), result.message)
+        await send_markdown(
+            self._app.bot,
+            str(chat.id),
+            result.message,
+            self._telegram_outbound_limiter,
+        )
 
     async def _on_photo(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -449,7 +461,12 @@ class TelegramChannel:
 
     async def send(self, chat_id: str, message: str) -> None:
         """发送文本消息（供 MessagePushTool 调用）"""
-        await send_markdown(self._app.bot, self._resolve_chat_id(chat_id), message)
+        await send_markdown(
+            self._app.bot,
+            self._resolve_chat_id(chat_id),
+            message,
+            self._telegram_outbound_limiter,
+        )
 
     async def send_stream(self, chat_id: str, message: str) -> None:
         """发送流式文本消息（私聊优先 draft，其他场景降级普通发送）"""
@@ -457,6 +474,7 @@ class TelegramChannel:
             self._app.bot,
             self._resolve_chat_id(chat_id),
             message,
+            self._telegram_outbound_limiter,
         )
 
     def create_stream_sender(self, chat_id: str):
@@ -464,7 +482,7 @@ class TelegramChannel:
         if cid <= 0:
             return None
         key = str(cid)
-        stream = TelegramStreamMessage(self._app.bot, cid)
+        stream = TelegramStreamMessage(self._app.bot, cid, self._telegram_outbound_limiter)
         self._active_streams[key] = stream
 
         async def _push(delta: dict[str, str] | str) -> None:
@@ -616,11 +634,12 @@ class TelegramChannel:
     ) -> None:
         if not thinking:
             return
-        await self._live_edit_queue.reserve(
-            chat_id,
-            label="send_message(final_thinking)",
+        await send_thinking_block(
+            self._app.bot,
+            original_chat_id,
+            thinking,
+            self._telegram_outbound_limiter,
         )
-        await send_thinking_block(self._app.bot, original_chat_id, thinking)
 
     async def _send_final_tool_snapshot(
         self,
@@ -632,7 +651,12 @@ class TelegramChannel:
             return
         tool_text = _tail_text(_format_tool_live(lines), _TOOL_LIVE_TAIL)
         if tool_text:
-            await send_markdown(self._app.bot, chat_id, f"```\n{tool_text}\n```")
+            await send_markdown(
+                self._app.bot,
+                chat_id,
+                f"```\n{tool_text}\n```",
+                self._telegram_outbound_limiter,
+            )
 
     async def send_file(
         self,
@@ -643,19 +667,46 @@ class TelegramChannel:
     ) -> None:
         """发送文件，可附带说明文字"""
         cid = int(self._resolve_chat_id(chat_id))
-        with open(file_path, "rb") as f:
-            await self._app.bot.send_document(
-                chat_id=cid, document=f, filename=name, caption=caption
-            )
+        await self._telegram_outbound_limiter.run(
+            cid,
+            kind="send",
+            label="send_document",
+            action=lambda: self._send_document_file(cid, file_path, name, caption),
+        )
 
     async def send_image(self, chat_id: str, image: str) -> None:
         """发送图片（本地路径或 URL）"""
         cid = int(self._resolve_chat_id(chat_id))
         if image.startswith(("http://", "https://")):
-            await self._app.bot.send_photo(chat_id=cid, photo=image)
+            await self._telegram_outbound_limiter.run(
+                cid,
+                kind="send",
+                label="send_photo",
+                action=lambda: self._app.bot.send_photo(chat_id=cid, photo=image),
+            )
         else:
-            with open(image, "rb") as f:
-                await self._app.bot.send_photo(chat_id=cid, photo=f)
+            await self._telegram_outbound_limiter.run(
+                cid,
+                kind="send",
+                label="send_photo",
+                action=lambda: self._send_photo_file(cid, image),
+            )
+
+    async def _send_document_file(
+        self,
+        chat_id: int,
+        file_path: str,
+        name: str | None,
+        caption: str | None,
+    ) -> object:
+        with open(file_path, "rb") as f:
+            return await self._app.bot.send_document(
+                chat_id=chat_id, document=f, filename=name, caption=caption
+            )
+
+    async def _send_photo_file(self, chat_id: int, image: str) -> object:
+        with open(image, "rb") as f:
+            return await self._app.bot.send_photo(chat_id=chat_id, photo=f)
 
     async def _on_response(self, msg: OutboundMessage) -> None:
         preview = msg.content[:60] + "..." if len(msg.content) > 60 else msg.content
@@ -669,7 +720,12 @@ class TelegramChannel:
         final_thinking = self._final_thinking_text(session_key, msg.thinking)
         if had_live:
             if final_thinking:
-                await send_thinking_block(self._app.bot, msg.chat_id, final_thinking)
+                await send_thinking_block(
+                    self._app.bot,
+                    msg.chat_id,
+                    final_thinking,
+                    self._telegram_outbound_limiter,
+                )
             await self._send_final_tool_snapshot(session_key, msg.chat_id)
         streamed_reply = bool((msg.metadata or {}).get("streamed_reply"))
         if msg.content.strip():
@@ -678,9 +734,19 @@ class TelegramChannel:
                 if stream is not None:
                     await stream.finalize(msg.content)
                 else:
-                    await send_markdown(self._app.bot, msg.chat_id, msg.content)
+                    await send_markdown(
+                        self._app.bot,
+                        msg.chat_id,
+                        msg.content,
+                        self._telegram_outbound_limiter,
+                    )
             else:
-                await send_markdown(self._app.bot, msg.chat_id, msg.content)
+                await send_markdown(
+                    self._app.bot,
+                    msg.chat_id,
+                    msg.content,
+                    self._telegram_outbound_limiter,
+                )
         if final_thinking and not had_live:
             await self._send_final_thinking(cid, msg.chat_id, final_thinking)
         self._reply_buffers.pop(session_key, None)
@@ -695,40 +761,21 @@ class TelegramChannel:
         self, context: ContextTypes.DEFAULT_TYPE, chat_id: int
     ) -> None:
         """发送 typing 状态；失败时指数退避重试，不影响消息主流程。"""
-        base_delay = 0.4
-        max_attempts = 3
-        for attempt in range(1, max_attempts + 1):
-            try:
-                await context.bot.send_chat_action(
+        try:
+            await self._telegram_outbound_limiter.run(
+                chat_id,
+                kind="typing",
+                label="send_chat_action",
+                action=lambda: context.bot.send_chat_action(
                     chat_id=chat_id, action=ChatAction.TYPING
-                )
-                return
-            except (TimedOut, NetworkError) as e:
-                if attempt >= max_attempts:
-                    logger.warning(
-                        "[telegram] send_chat_action 重试耗尽，跳过 typing chat_id=%s attempts=%d err=%s",
-                        chat_id,
-                        attempt,
-                        e,
-                    )
-                    return
-                delay = base_delay * (2 ** (attempt - 1))
-                logger.warning(
-                    "[telegram] send_chat_action 失败，准备重试 chat_id=%s attempt=%d/%d backoff=%.1fs err=%s",
-                    chat_id,
-                    attempt,
-                    max_attempts,
-                    delay,
-                    e,
-                )
-                await asyncio.sleep(delay)
-            except Exception as e:
-                logger.warning(
-                    "[telegram] send_chat_action 失败，已跳过 typing chat_id=%s err=%s",
-                    chat_id,
-                    e,
-                )
-                return
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                "[telegram] send_chat_action 失败，已跳过 typing chat_id=%s err=%s",
+                chat_id,
+                e,
+            )
 
     def _on_polling_error(self, exc: TelegramError) -> None:
         """处理 Telegram polling 异常，避免 Conflict 场景下持续刷屏。"""

--- a/infra/channels/telegram_utils.py
+++ b/infra/channels/telegram_utils.py
@@ -47,6 +47,175 @@ _ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)|(?<!_)_(?!_)(.+?)(
 _T = TypeVar("_T")
 
 
+class TelegramOutboundLimiter:
+    def __init__(
+        self,
+        *,
+        send_interval_s: float = 2.0,
+        edit_interval_s: float = 5.0,
+        typing_interval_s: float = 8.0,
+        global_interval_s: float = 0.25,
+        retry_padding_s: float = 1.0,
+        max_attempts: int = 5,
+    ) -> None:
+        self._send_interval_s = send_interval_s
+        self._edit_interval_s = edit_interval_s
+        self._typing_interval_s = typing_interval_s
+        self._global_interval_s = global_interval_s
+        self._retry_padding_s = retry_padding_s
+        self._max_attempts = max_attempts
+        self._chat_locks: dict[int, asyncio.Lock] = {}
+        self._typing_locks: dict[int, asyncio.Lock] = {}
+        self._global_lock = asyncio.Lock()
+        self._next_chat_at: dict[int, float] = {}
+        self._next_typing_at: dict[int, float] = {}
+        self._next_global_at = 0.0
+
+    async def run(
+        self,
+        chat_id: int | str,
+        *,
+        kind: str,
+        label: str,
+        action: Callable[[], Awaitable[_T]],
+        max_attempts: int | None = None,
+    ) -> _T:
+        cid = int(chat_id)
+        if kind == "typing":
+            return await self._run_typing(cid, label=label, action=action)
+        attempts = max_attempts or self._max_attempts
+        lock = self._chat_locks.setdefault(cid, asyncio.Lock())
+        async with lock:
+            last_err: Exception | None = None
+            for attempt in range(1, attempts + 1):
+                await self._wait_for_chat_slot(cid)
+                try:
+                    result = await self._run_with_global_slot(action)
+                    self._mark_used(cid, kind)
+                    return result
+                except RetryAfter as e:
+                    last_err = e
+                    delay = max(
+                        float(getattr(e, "retry_after", 1.0) or 1.0) + self._retry_padding_s,
+                        self._interval(kind),
+                    )
+                    self._cooldown(cid, delay)
+                    logger.warning(
+                        "[telegram] %s 命中限流，按 retry_after 冷却 chat_id=%s attempt=%d/%d delay=%.1fs",
+                        label,
+                        cid,
+                        attempt,
+                        attempts,
+                        delay,
+                    )
+                except (TimedOut, NetworkError) as e:
+                    last_err = e
+                    delay = min(0.8 * (2 ** (attempt - 1)), 8.0)
+                    self._cooldown(cid, delay)
+                    logger.warning(
+                        "[telegram] %s 网络失败，准备重试 chat_id=%s attempt=%d/%d delay=%.1fs err=%s",
+                        label,
+                        cid,
+                        attempt,
+                        attempts,
+                        delay,
+                        e,
+                    )
+                if attempt >= attempts:
+                    break
+                await self._sleep_until_ready(cid)
+            if last_err is not None:
+                raise last_err
+            raise RuntimeError(f"{label} failed without exception")
+
+    async def _run_typing(
+        self,
+        chat_id: int,
+        *,
+        label: str,
+        action: Callable[[], Awaitable[_T]],
+    ) -> _T:
+        lock = self._typing_locks.setdefault(chat_id, asyncio.Lock())
+        async with lock:
+            now = asyncio.get_running_loop().time()
+            wait_s = self._next_typing_at.get(chat_id, 0.0) - now
+            if wait_s > 0:
+                await asyncio.sleep(wait_s)
+            try:
+                result = await action()
+                self._next_typing_at[chat_id] = (
+                    asyncio.get_running_loop().time() + self._typing_interval_s
+                )
+                return result
+            except RetryAfter as e:
+                delay = (
+                    float(getattr(e, "retry_after", 1.0) or 1.0)
+                    + self._retry_padding_s
+                )
+                self._next_typing_at[chat_id] = asyncio.get_running_loop().time() + delay
+                raise
+
+    async def _wait_for_chat_slot(self, chat_id: int) -> None:
+        now = asyncio.get_running_loop().time()
+        wait_s = self._next_chat_at.get(chat_id, 0.0) - now
+        if wait_s > 0:
+            await asyncio.sleep(wait_s)
+
+    async def _run_with_global_slot(
+        self,
+        action: Callable[[], Awaitable[_T]],
+    ) -> _T:
+        async with self._global_lock:
+            now = asyncio.get_running_loop().time()
+            wait_s = self._next_global_at - now
+            if wait_s > 0:
+                await asyncio.sleep(wait_s)
+            try:
+                return await action()
+            finally:
+                self._next_global_at = (
+                    asyncio.get_running_loop().time() + self._global_interval_s
+                )
+
+    async def _sleep_until_ready(self, chat_id: int) -> None:
+        now = asyncio.get_running_loop().time()
+        wait_s = self._next_chat_at.get(chat_id, 0.0) - now
+        if wait_s > 0:
+            await asyncio.sleep(wait_s)
+
+    def _mark_used(self, chat_id: int, kind: str) -> None:
+        now = asyncio.get_running_loop().time()
+        self._next_chat_at[chat_id] = now + self._interval(kind)
+
+    def _cooldown(self, chat_id: int, delay: float) -> None:
+        now = asyncio.get_running_loop().time()
+        self._next_chat_at[chat_id] = max(
+            self._next_chat_at.get(chat_id, 0.0),
+            now + delay,
+        )
+        self._next_global_at = max(self._next_global_at, now + self._global_interval_s)
+
+    def _interval(self, kind: str) -> float:
+        if kind == "edit":
+            return self._edit_interval_s
+        if kind == "typing":
+            return self._typing_interval_s
+        return self._send_interval_s
+
+
+async def _run_outbound(
+    limiter: TelegramOutboundLimiter | None,
+    chat_id: int,
+    *,
+    kind: str,
+    label: str,
+    action: Callable[[], Awaitable[_T]],
+) -> _T:
+    if limiter is not None:
+        return await limiter.run(chat_id, kind=kind, label=label, action=action)
+    return await _send_with_retry_result(action, label=label)
+
+
 async def _send_with_retry(
     send_coro_factory,
     *,
@@ -134,30 +303,42 @@ def _strip_chunk(
     return stripped, adjusted
 
 
-async def send_markdown(bot: Bot, chat_id: int | str, text: str) -> None:
+async def send_markdown(
+    bot: Bot,
+    chat_id: int | str,
+    text: str,
+    limiter: TelegramOutboundLimiter | None = None,
+) -> None:
     cid = int(chat_id)
     try:
         rendered_text, entities, _segments = convert_with_segments(text)
         chunks = split_entities(rendered_text, entities, 4090)
-        for chunk_text, chunk_entities in chunks:
-            chunk_text, chunk_entities = _strip_chunk(chunk_text, chunk_entities)
-            if not chunk_text:
-                continue
-            await _send_with_retry(
-                lambda: bot.send_message(
-                    chat_id=cid,
-                    text=chunk_text,
-                    entities=cast(Any, _serialize_entities(chunk_entities)),
-                ),
-                label="send_message(markdown)",
-            )
     except Exception as e:
         logger.warning(f"[telegram] Markdown 转换失败，降级纯文本: {e}")
         for chunk in _split_text(text, 4090):
-            await _send_with_retry(
-                lambda: bot.send_message(chat_id=cid, text=chunk),
+            await _run_outbound(
+                limiter,
+                cid,
+                kind="send",
+                action=lambda: bot.send_message(chat_id=cid, text=chunk),
                 label="send_message(plain)",
             )
+        return
+    for chunk_text, chunk_entities in chunks:
+        chunk_text, chunk_entities = _strip_chunk(chunk_text, chunk_entities)
+        if not chunk_text:
+            continue
+        await _run_outbound(
+            limiter,
+            cid,
+            kind="send",
+            action=lambda: bot.send_message(
+                chat_id=cid,
+                text=chunk_text,
+                entities=cast(Any, _serialize_entities(chunk_entities)),
+            ),
+            label="send_message(markdown)",
+        )
 
 
 def _split_text(text: str, limit: int) -> list[str]:
@@ -179,7 +360,12 @@ def _split_text(text: str, limit: int) -> list[str]:
     return chunks
 
 
-async def send_thinking_block(bot: Bot, chat_id: int | str, thinking: str) -> None:
+async def send_thinking_block(
+    bot: Bot,
+    chat_id: int | str,
+    thinking: str,
+    limiter: TelegramOutboundLimiter | None = None,
+) -> None:
     """Send thinking content as expandable blockquote message(s).
 
     Telegram 单条消息限制 4096 UTF-16 code units。超长 thinking 按行分段，
@@ -197,8 +383,11 @@ async def send_thinking_block(bot: Bot, chat_id: int | str, thinking: str) -> No
         utf16_len = len(text.encode("utf-16-le")) // 2
         entity = TgEntity(type="expandable_blockquote", offset=0, length=utf16_len)
         try:
-            await _send_with_retry(
-                lambda text=text, entity=entity: bot.send_message(
+            await _run_outbound(
+                limiter,
+                cid,
+                kind="send",
+                action=lambda text=text, entity=entity: bot.send_message(
                     chat_id=cid,
                     text=text,
                     entities=[entity],
@@ -247,7 +436,12 @@ def _utf16_cut(text: str, max_utf16: int) -> int:
     return len(text)
 
 
-async def send_stream_markdown(bot: Bot, chat_id: int | str, text: str) -> None:
+async def send_stream_markdown(
+    bot: Bot,
+    chat_id: int | str,
+    text: str,
+    limiter: TelegramOutboundLimiter | None = None,
+) -> None:
     """主动推送场景的简化流式展示。"""
     cid = int(chat_id)
     stripped = text.strip()
@@ -256,15 +450,16 @@ async def send_stream_markdown(bot: Bot, chat_id: int | str, text: str) -> None:
 
     if cid > 0:
         try:
-            stream = TelegramStreamMessage(bot, cid)
+            stream = TelegramStreamMessage(bot, cid, limiter)
             for chunk in _iter_stream_chunks(stripped):
                 await stream.push_delta(chunk, force=True)
             await stream.finalize(text)
         except Exception as e:
             logger.warning("[telegram] stream edit 失败，降级普通发送: %s", e)
+            await send_markdown(bot, cid, text, limiter)
 
     else:
-        await send_markdown(bot, cid, text)
+        await send_markdown(bot, cid, text, limiter)
 
 
 def _ring_tail(text: str, cap: int) -> str:
@@ -277,8 +472,13 @@ def _ring_tail(text: str, cap: int) -> str:
 
 
 class TelegramLiveEditQueue:
-    def __init__(self, min_interval_s: float = _LIVE_EDIT_MIN_INTERVAL_S) -> None:
+    def __init__(
+        self,
+        min_interval_s: float = _LIVE_EDIT_MIN_INTERVAL_S,
+        limiter: TelegramOutboundLimiter | None = None,
+    ) -> None:
         self._min_interval_s = min_interval_s
+        self._limiter = limiter
         self._locks: dict[int, asyncio.Lock] = {}
         self._next_allowed_at: dict[int, float] = {}
         self._flood_strikes: dict[int, int] = {}
@@ -299,6 +499,39 @@ class TelegramLiveEditQueue:
         force: bool = False,
         action: Callable[[], Awaitable[_T]],
     ) -> _T | None:
+        if self._limiter is not None:
+            strikes = self._flood_strikes.get(chat_id, 0)
+            if strikes >= _LIVE_MAX_FLOOD_STRIKES and not force:
+                logger.warning(
+                    "[telegram] %s live 更新因连续限流跳过 chat_id=%s strikes=%d",
+                    label,
+                    chat_id,
+                    strikes,
+                )
+                return None
+            try:
+                result = await self._limiter.run(
+                    chat_id,
+                    kind="edit" if label.startswith("edit_") else "send",
+                    label=label,
+                    action=action,
+                    max_attempts=1,
+                )
+                self._flood_strikes[chat_id] = 0
+                return result
+            except RetryAfter as e:
+                strikes = self._record_flood(chat_id)
+                logger.warning(
+                    "[telegram] %s live 更新命中限流，跳过本帧 chat_id=%s strikes=%d err=%s",
+                    label,
+                    chat_id,
+                    strikes,
+                    e,
+                )
+                return None
+            except (TimedOut, NetworkError) as e:
+                logger.warning("[telegram] %s live 更新失败，已跳过: %s", label, e)
+                return None
         lock = self._locks.setdefault(chat_id, asyncio.Lock())
         async with lock:
             strikes = self._flood_strikes.get(chat_id, 0)
@@ -433,13 +666,20 @@ class TelegramLiveTextMessage:
     async def delete(self) -> None:
         if self._message_id is None:
             return
+        message_id = self._message_id
         try:
-            await self._bot.delete_message(
-                chat_id=self._chat_id,
-                message_id=self._message_id,
+            ok = await self._queue.run(
+                self._chat_id,
+                label="delete_message(live)",
+                force=True,
+                action=lambda: self._bot.delete_message(
+                    chat_id=self._chat_id,
+                    message_id=message_id,
+                ),
             )
-            self._message_id = None
-            self._last_plain = ""
+            if ok is not None:
+                self._message_id = None
+                self._last_plain = ""
         except RetryAfter as e:
             logger.warning("[telegram] live 预览删除命中限流，已跳过: %s", e)
         except (TimedOut, NetworkError) as e:
@@ -512,9 +752,15 @@ async def _edit_live_message(
 
 
 class TelegramStreamMessage:
-    def __init__(self, bot: Bot, chat_id: int) -> None:
+    def __init__(
+        self,
+        bot: Bot,
+        chat_id: int,
+        limiter: TelegramOutboundLimiter | None = None,
+    ) -> None:
         self._bot = bot
         self._chat_id = int(chat_id)
+        self._limiter = limiter
         self._message_id: int | None = None
         self._reply_buffer = ""
         self._thinking_buffer = ""
@@ -624,11 +870,14 @@ class TelegramStreamMessage:
         if plain_text == self._last_sent_plain and self._message_id is not None:
             return
         if self._message_id is None:
-            sent = await _send_with_retry_result(
-                lambda: _send_preview_message(
+            sent = await _run_outbound(
+                self._limiter,
+                self._chat_id,
+                kind="send",
+                label="send_message(stream_start)",
+                action=lambda: _send_preview_message(
                     self._bot, self._chat_id, html_text, plain_text
                 ),
-                label="send_message(stream_start)",
             )
             self._message_id = int(getattr(sent, "message_id", 0) or 0) or None
             self._last_sent_plain = plain_text
@@ -642,13 +891,28 @@ class TelegramStreamMessage:
         plain_text: str,
     ) -> bool:
         try:
-            await _edit_preview_message(
-                self._bot,
-                self._chat_id,
-                self._message_id,
-                html_text,
-                plain_text,
-            )
+            if self._limiter is None:
+                await _edit_preview_message(
+                    self._bot,
+                    self._chat_id,
+                    self._message_id,
+                    html_text,
+                    plain_text,
+                )
+            else:
+                await _run_outbound(
+                    self._limiter,
+                    self._chat_id,
+                    kind="edit",
+                    label="edit_message_text(stream)",
+                    action=lambda: _edit_preview_message(
+                        self._bot,
+                        self._chat_id,
+                        self._message_id,
+                        html_text,
+                        plain_text,
+                    ),
+                )
             return True
         except RetryAfter as e:
             delay = max(float(getattr(e, "retry_after", 1.0) or 1.0), 1.0)

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -498,7 +498,17 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
         event_bus=event_bus,
         interrupt_controller=interrupt_controller,
     )
-    channel._live_edit_queue._min_interval_s = 0.0
+    channel._telegram_outbound_limiter = mod.TelegramOutboundLimiter(
+        send_interval_s=0.0,
+        edit_interval_s=0.0,
+        typing_interval_s=0.0,
+        global_interval_s=0.0,
+        retry_padding_s=0.0,
+    )
+    channel._live_edit_queue = mod.TelegramLiveEditQueue(
+        min_interval_s=0.0,
+        limiter=channel._telegram_outbound_limiter,
+    )
     monkeypatch.setattr(mod, "send_markdown", AsyncMock())
     monkeypatch.setattr(mod, "send_stream_markdown", AsyncMock())
     monkeypatch.setattr(mod, "send_thinking_block", AsyncMock())

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, cast
 from types import SimpleNamespace
 
@@ -7,9 +8,11 @@ from unittest.mock import AsyncMock
 from infra.channels.telegram_utils import (
     TelegramLiveEditQueue,
     TelegramLiveTextMessage,
+    TelegramOutboundLimiter,
     TelegramStreamMessage,
     render_telegram_preview_html,
     send_markdown,
+    send_stream_markdown,
     send_thinking_block,
 )
 
@@ -50,6 +53,120 @@ async def test_send_markdown_splits_long_code_block_into_multiple_messages():
     assert all(call["text"].strip() for call in bot.messages)
     assert any(entity["type"] == "pre" for entity in bot.messages[0]["entities"])
     assert all(len(call["text"]) <= 4090 for call in bot.messages)
+
+
+@pytest.mark.asyncio
+async def test_outbound_limiter_retries_after_cooling_down(monkeypatch):
+    from infra.channels import telegram_utils as mod
+
+    limiter = TelegramOutboundLimiter(
+        send_interval_s=2.0,
+        global_interval_s=0.0,
+        retry_padding_s=1.0,
+        max_attempts=2,
+    )
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("infra.channels.telegram_utils.asyncio.sleep", sleep_mock)
+    calls = 0
+
+    async def action():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise mod.RetryAfter(cast(Any, 3.0))
+        return "ok"
+
+    result = await limiter.run(123, kind="send", label="send_message(test)", action=action)
+
+    assert result == "ok"
+    assert calls == 2
+    assert sleep_mock.await_args_list[0].args[0] >= 3.9
+
+
+@pytest.mark.asyncio
+async def test_outbound_limiter_typing_does_not_delay_send(monkeypatch):
+    limiter = TelegramOutboundLimiter(
+        send_interval_s=2.0,
+        typing_interval_s=8.0,
+        global_interval_s=0.0,
+    )
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("infra.channels.telegram_utils.asyncio.sleep", sleep_mock)
+
+    await limiter.run(123, kind="typing", label="typing", action=AsyncMock(return_value=True))
+    await limiter.run(123, kind="send", label="send", action=AsyncMock(return_value=True))
+
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_outbound_limiter_global_slot_covers_action():
+    limiter = TelegramOutboundLimiter(
+        send_interval_s=0.0,
+        global_interval_s=0.0,
+    )
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def first_action():
+        first_started.set()
+        await release_first.wait()
+        return "first"
+
+    async def second_action():
+        second_started.set()
+        return "second"
+
+    first_task = asyncio.create_task(
+        limiter.run(123, kind="send", label="first", action=first_action)
+    )
+    await first_started.wait()
+    second_task = asyncio.create_task(
+        limiter.run(456, kind="send", label="second", action=second_action)
+    )
+    await asyncio.sleep(0)
+
+    assert not second_started.is_set()
+    release_first.set()
+    assert await first_task == "first"
+    assert await second_task == "second"
+
+
+@pytest.mark.asyncio
+async def test_outbound_limiter_typing_retry_after_sets_cooldown(monkeypatch):
+    from infra.channels import telegram_utils as mod
+
+    limiter = TelegramOutboundLimiter(
+        typing_interval_s=8.0,
+        retry_padding_s=1.0,
+    )
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("infra.channels.telegram_utils.asyncio.sleep", sleep_mock)
+
+    with pytest.raises(mod.RetryAfter):
+        await limiter.run(
+            123,
+            kind="typing",
+            label="typing",
+            action=AsyncMock(side_effect=mod.RetryAfter(cast(Any, 3.0))),
+        )
+    await limiter.run(123, kind="typing", label="typing", action=AsyncMock(return_value=True))
+
+    assert sleep_mock.await_args_list[0].args[0] >= 3.9
+
+
+@pytest.mark.asyncio
+async def test_send_markdown_does_not_fallback_when_send_fails(monkeypatch):
+    from infra.channels import telegram_utils as mod
+
+    bot = BotStub()
+    bot.send_message = AsyncMock(side_effect=mod.TimedOut("x"))
+
+    with pytest.raises(mod.TimedOut):
+        await send_markdown(cast(Any, bot), 123, "hello")
+
+    assert bot.send_message.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -110,6 +227,19 @@ async def test_stream_message_falls_back_to_plain_text_on_html_parse_error():
 
     assert bot.messages[0]["parse_mode"] == "HTML"
     assert bot.edits[-1]["text"] == "**hello**\n\n- a\n- b"
+
+
+@pytest.mark.asyncio
+async def test_send_stream_markdown_falls_back_to_markdown_on_stream_failure():
+    bot = BotStub()
+    bot.edit_message_text = AsyncMock(side_effect=RuntimeError("boom"))
+
+    text = "hello world " * 30
+    await send_stream_markdown(cast(Any, bot), 123, text)
+
+    assert len(bot.messages) == 2
+    assert bot.messages[-1]["text"] == text
+    assert bot.edit_message_text.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -228,6 +358,32 @@ async def test_live_edit_queue_backoff_and_force_retry(monkeypatch):
     await live.update("hello world final", force=True)
     assert bot.edit_message_text.await_count == 1
     assert queue._flood_strikes[123] == 0
+
+
+@pytest.mark.asyncio
+async def test_live_edit_queue_with_limiter_skips_retry_after_frame(monkeypatch):
+    from infra.channels import telegram_utils as mod
+
+    bot = BotStub()
+    bot.edit_message_text = AsyncMock(side_effect=mod.RetryAfter(cast(Any, 8.0)))
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("infra.channels.telegram_utils.asyncio.sleep", sleep_mock)
+    limiter = TelegramOutboundLimiter(
+        send_interval_s=0.0,
+        edit_interval_s=0.0,
+        global_interval_s=0.0,
+        retry_padding_s=0.0,
+    )
+    queue = TelegramLiveEditQueue(min_interval_s=0.0, limiter=limiter)
+    live = TelegramLiveTextMessage(cast(Any, bot), queue, 123)
+    live._message_id = 1
+    live._last_plain = "old"
+
+    await live.update("new")
+
+    assert bot.edit_message_text.await_count == 1
+    sleep_mock.assert_not_awaited()
+    assert queue._flood_strikes[123] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更内容
- 为 Telegram 文本、流式编辑、thinking、文件和图片发送接入统一出站限流。
- 将 typing 状态与正文发送分开节流，避免 typing 阻塞真实回复。
- 对 RetryAfter、网络超时和 live edit 限流补充冷却、跳帧和回退发送。

## 影响
减少连续 send/edit/typing 触发 Telegram 限流的概率，并避免流式发送失败时整条消息丢失。

## 验证
- pytest tests/test_telegram_utils.py tests/test_channel_clients.py
- pyright infra/channels/telegram_utils.py infra/channels/telegram_channel.py tests/test_telegram_utils.py tests/test_channel_clients.py（0 errors，65 warnings）