### PR TITLE
调整 LLM 流式超时

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -673,6 +674,12 @@ class DefaultReasoner(Reasoner):
                         reply="上下文过长无法处理，请尝试新建对话。",
                         context_retry=retry_trace,
                     )
+            except asyncio.TimeoutError:
+                logger.warning("LLM 流响应超时 (attempt=%d)，远端连接中断", attempt + 1)
+                return TurnRunResult(
+                    reply="模型流响应中断，请刷新对话重试。",
+                    context_retry=retry_trace,
+                )
         return TurnRunResult(reply="（安全重试异常）", context_retry=retry_trace)
 
     async def run(

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -104,7 +104,6 @@ class AgentLoop:
     对话历史按 session_key 独立维护，格式为 OpenAI messages。
     """
 
-    _MESSAGE_TIMEOUT_S: float = 600.0
     _CONSOLIDATION_WAIT_S: float = 30.0
 
     def __init__(
@@ -640,27 +639,14 @@ class AgentLoop:
         if self._processing_state:
             self._processing_state.enter(key)
         try:
-            outbound = await asyncio.wait_for(
-                self._core_runner.process(
-                    msg,
-                    key,
-                    dispatch_outbound=dispatch_outbound,
-                ),
-                timeout=self._MESSAGE_TIMEOUT_S,
+            outbound = await self._core_runner.process(
+                msg,
+                key,
+                dispatch_outbound=dispatch_outbound,
             )
             if resumed_from_interrupt:
                 self._interrupt_states.pop(key, None)
             return outbound
-        except asyncio.TimeoutError:
-            logger.error(
-                f"消息处理超时 ({self._MESSAGE_TIMEOUT_S}s)  "
-                f"channel={msg.channel} chat_id={msg.chat_id}"
-            )
-            return OutboundMessage(
-                channel=msg.channel,
-                chat_id=msg.chat_id,
-                content="（处理超时，请重试）",
-            )
         finally:
             # 3. 最后无论成功失败都直接释放 busy 状态。
             if self._processing_state:

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -202,6 +202,7 @@ class LLMProvider:
         system_prompt: str = "",
         extra_body: dict | None = None,
         request_timeout_s: float = 90.0,
+        stream_idle_timeout_s: float | None = None,
         max_retries: int = 1,
         provider_name: str = "",
         force_disable_thinking: bool = False,
@@ -214,6 +215,14 @@ class LLMProvider:
         self._system = system_prompt
         self._extra_body = extra_body or {}
         self._request_timeout_s = max(1.0, float(request_timeout_s))
+        self._stream_idle_timeout_s = max(
+            0.001,
+            float(
+                request_timeout_s
+                if stream_idle_timeout_s is None
+                else stream_idle_timeout_s
+            ),
+        )
         self._max_retries = max(0, int(max_retries))
         self._force_disable_thinking = force_disable_thinking
         self._payload_snapshot_enabled = (
@@ -312,7 +321,15 @@ class LLMProvider:
         cache_prompt_tokens: int | None = None
         cache_hit_tokens: int | None = None
 
-        async for chunk in stream:
+        stream_iter = aiter(stream)
+        while True:
+            try:
+                chunk = await asyncio.wait_for(
+                    anext(stream_iter),
+                    timeout=self._stream_idle_timeout_s,
+                )
+            except StopAsyncIteration:
+                break
             prompt_tokens, hit_tokens = _extract_cache_usage(
                 getattr(chunk, "usage", None)
             )

--- a/bootstrap/providers.py
+++ b/bootstrap/providers.py
@@ -5,6 +5,8 @@ from infra.providers.llm_provider import LLMProvider
 
 _MAIN_PROVIDER_TIMEOUT_S = 300.0
 _LIGHT_PROVIDER_TIMEOUT_S = 180.0
+_MAIN_STREAM_IDLE_TIMEOUT_S = 120.0
+_LIGHT_STREAM_IDLE_TIMEOUT_S = 60.0
 
 
 def build_providers(
@@ -21,6 +23,7 @@ def build_providers(
         system_prompt=config.system_prompt,
         extra_body=main_extra,
         request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
+        stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
         provider_name=config.provider,
         payload_snapshot_enabled=payload_snapshot_enabled,
     )
@@ -43,6 +46,7 @@ def build_providers(
             system_prompt=config.system_prompt,
             extra_body=light_extra,
             request_timeout_s=_LIGHT_PROVIDER_TIMEOUT_S,
+            stream_idle_timeout_s=_LIGHT_STREAM_IDLE_TIMEOUT_S,
             force_disable_thinking=True,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
@@ -57,6 +61,7 @@ def build_providers(
             system_prompt=config.system_prompt,
             extra_body=agent_extra,
             request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
+            stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
 
@@ -75,6 +80,7 @@ def build_vl_provider(config: Config) -> LLMProvider | None:
             system_prompt="",
             extra_body=vl_extra,
             request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
+            stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
     return None

--- a/tests/test_agent_core_p2_reasoner.py
+++ b/tests/test_agent_core_p2_reasoner.py
@@ -48,6 +48,15 @@ class _Provider:
         return self._responses.pop(0)
 
 
+class _TimeoutProvider:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        self.calls.append(kwargs)
+        raise asyncio.TimeoutError
+
+
 def test_default_reasoner_runs_tool_loop_and_returns_reasoner_result():
     provider = _Provider(
         [
@@ -397,6 +406,44 @@ def test_default_reasoner_run_turn_uses_context_render():
     result = asyncio.run(reasoner.run_turn(msg=msg, session=cast(Any, session)))
 
     assert result.reply == "done"
+
+
+def test_default_reasoner_run_turn_reports_llm_timeout():
+    provider = _TimeoutProvider()
+    tools = ToolRegistry()
+    tools.register(_DummyTool(), always_on=True)
+    reasoner = DefaultReasoner(
+        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=tools,
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=False,
+        memory_window=40,
+        context=cast(Any, SimpleNamespace(
+            render=lambda request: SimpleNamespace(
+                messages=[{"role": "user", "content": request.current_message}],
+            ),
+        )),
+        session_manager=cast(Any, SimpleNamespace(save_async=lambda *_args, **_kwargs: None)),
+    )
+    session = SimpleNamespace(
+        key="cli:1",
+        messages=[],
+        get_history=lambda max_messages=40: [],
+        last_consolidated=0,
+    )
+    msg = SimpleNamespace(
+        content="hi",
+        media=[],
+        channel="cli",
+        chat_id="1",
+        timestamp=datetime(2026, 4, 5, 12, 0, 0),
+    )
+
+    result = asyncio.run(reasoner.run_turn(msg=msg, session=cast(Any, session)))
+
+    assert result.reply == "模型流响应中断，请刷新对话重试。"
+    assert len(provider.calls) == 1
 
 
 def test_empty_content_with_thinking_triggers_retry_and_succeeds():

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -27,6 +27,7 @@ from memory2.models import MemoryItem
 from proactive_v2.anyaction import AnyActionGate, QuotaStore
 from proactive_v2.memory_sampler import sample_memory_chunks, split_memory_chunks
 from bootstrap.app import AppRuntime
+from bootstrap.providers import build_providers, build_vl_provider
 from bus.event_bus import EventBus
 
 
@@ -70,8 +71,9 @@ class _FakeClient:
 
 
 class _FakeStream:
-    def __init__(self, chunks: list[object]) -> None:
+    def __init__(self, chunks: list[object], delay_s: float = 0.0) -> None:
         self._chunks = list(chunks)
+        self._delay_s = delay_s
 
     def __aiter__(self):
         return self
@@ -79,6 +81,8 @@ class _FakeStream:
     async def __anext__(self):
         if not self._chunks:
             raise StopAsyncIteration
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
         return self._chunks.pop(0)
 
 
@@ -315,6 +319,78 @@ async def test_provider_chat_stream_parses_content_reasoning_and_tool_calls(
     assert fake.calls[0]["stream"] is True
     assert result.cache_prompt_tokens == 64
     assert result.cache_hit_tokens == 16
+
+
+@pytest.mark.asyncio
+async def test_provider_chat_stream_times_out_when_idle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="慢", tool_calls=[]))
+                ]
+            )
+        ],
+        delay_s=0.05,
+    )
+    fake = _FakeClient([stream])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+
+    provider = LLMProvider(
+        api_key="k",
+        stream_idle_timeout_s=0.01,
+        max_retries=0,
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            model="m",
+            max_tokens=10,
+            on_content_delta=lambda chunk: _collect_delta([], chunk),
+        )
+
+
+def test_bootstrap_providers_set_stream_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created: list[dict] = []
+
+    class _ProviderConfig:
+        def __init__(self, **kwargs) -> None:
+            created.append(kwargs)
+
+    monkeypatch.setattr("bootstrap.providers.LLMProvider", _ProviderConfig)
+    cfg = SimpleNamespace(
+        api_key="main-key",
+        base_url="https://example.com/v1",
+        system_prompt="system",
+        extra_body={},
+        provider="openai",
+        dev_mode=False,
+        light_model="light",
+        light_api_key="light-key",
+        light_base_url="https://light.example.com/v1",
+        agent_model="agent",
+        agent_api_key="agent-key",
+        agent_base_url="https://agent.example.com/v1",
+        multimodal=False,
+        vl_model="vl",
+        vl_api_key="vl-key",
+        vl_base_url="https://vl.example.com/v1",
+    )
+
+    build_providers(cast(Any, cfg))
+    build_vl_provider(cast(Any, cfg))
+
+    assert [item["stream_idle_timeout_s"] for item in created] == [
+        120.0,
+        60.0,
+        120.0,
+        120.0,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -542,7 +542,7 @@ def test_request_interrupt_uses_active_turn_state_snapshot(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_resumed_interrupt_state_survives_timeout(tmp_path: Path):
+async def test_resumed_interrupt_state_completes_normally(tmp_path: Path):
     loop = _make_loop(tmp_path)
     session_key = "telegram:123"
     loop._interrupt_states[session_key] = TurnInterruptState(  # type: ignore[attr-defined]
@@ -550,8 +550,6 @@ async def test_resumed_interrupt_state_survives_timeout(tmp_path: Path):
         original_user_message="原始消息 A",
         partial_reply="半截回答",
     )
-    loop._MESSAGE_TIMEOUT_S = 0.01  # type: ignore[attr-defined]
-
     async def _slow_process(*args, **kwargs):
         await asyncio.sleep(0.05)
         return MagicMock(content="ok")
@@ -566,9 +564,8 @@ async def test_resumed_interrupt_state_survives_timeout(tmp_path: Path):
     )
     outbound = await loop._process(msg)
 
-    assert "超时" in outbound.content
-    assert session_key in loop._interrupt_states  # type: ignore[attr-defined]
-    assert loop._interrupt_states[session_key].original_user_message == "原始消息 A"  # type: ignore[attr-defined]
+    assert outbound.content == "ok"
+    assert session_key not in loop._interrupt_states  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更
- 移除被动 turn 的 600s 整轮硬超时，避免长任务被 wall-clock 误杀。
- 为流式 LLM 响应增加 chunk 级 idle timeout，使用 anext() 精准检测远端流卡死。
- bootstrap provider 显式设置 stream idle timeout，避免主模型继承 300s request timeout。
- LLM 流超时时返回明确用户提示，并补充相关测试。

## 验证
- .venv-312/bin/python -m pytest tests/test_more_support_modules.py tests/test_turn_pipelines.py tests/test_agent_core_p2_reasoner.py