### PR TITLE
添加 memory status 命令

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
 
 import agent.core.passive_support as support
@@ -110,6 +112,7 @@ class AgentCoreDeps:
     event_bus: "EventBus | None" = None
     outbound_port: "OutboundPort | None" = None
     history_window: int = 500
+    observe_db_path: Path | None = None
 
 
 class AgentCore:
@@ -172,6 +175,7 @@ class PassiveTurnPipeline:
                 bus,
                 self._session.session_manager,
                 deps.context_store,
+                observe_db_path=deps.observe_db_path,
             ),
             frame_factory=BeforeTurnFrame,
         )

--- a/agent/lifecycle/__init__.py
+++ b/agent/lifecycle/__init__.py
@@ -12,6 +12,11 @@ from agent.lifecycle.phases.before_reasoning import (
 )
 from agent.lifecycle.phases.before_step import BeforeStepFrame, default_before_step_modules
 from agent.lifecycle.phases.before_turn import BeforeTurnFrame, default_before_turn_modules
+from agent.lifecycle.phases.before_turn_commands import (
+    default_before_turn_command_modules,
+    MemoryStatusCommandModule,
+    KVCacheCommandModule,
+)
 from agent.lifecycle.types import (
     AfterReasoningCtx,
     AfterReasoningInput,
@@ -56,4 +61,7 @@ __all__ = [
     "default_before_reasoning_modules",
     "default_before_step_modules",
     "default_before_turn_modules",
+    "default_before_turn_command_modules",
+    "MemoryStatusCommandModule",
+    "KVCacheCommandModule",
 ]

--- a/agent/lifecycle/phases/__init__.py
+++ b/agent/lifecycle/phases/__init__.py
@@ -10,6 +10,11 @@ from agent.lifecycle.phases.before_reasoning import (
 )
 from agent.lifecycle.phases.before_step import BeforeStepFrame, default_before_step_modules
 from agent.lifecycle.phases.before_turn import BeforeTurnFrame, default_before_turn_modules
+from agent.lifecycle.phases.before_turn_commands import (
+    default_before_turn_command_modules,
+    MemoryStatusCommandModule,
+    KVCacheCommandModule,
+)
 
 __all__ = [
     "AfterReasoningFrame",
@@ -24,4 +29,7 @@ __all__ = [
     "default_before_reasoning_modules",
     "default_before_step_modules",
     "default_before_turn_modules",
+    "default_before_turn_command_modules",
+    "MemoryStatusCommandModule",
+    "KVCacheCommandModule",
 ]

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from bus.event_bus import EventBus
-from agent.core.types import ContextBundle
 from agent.core.runtime_support import SessionLike
+from agent.core.types import ContextBundle
 from agent.lifecycle.phase import PhaseFrame, PhaseModule
 from agent.lifecycle.types import BeforeTurnCtx, TurnState
-from agent.prompting import is_context_frame
+
+from agent.lifecycle.phases.before_turn_commands import (
+    default_before_turn_command_modules,
+)
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import ContextStore
@@ -37,42 +41,9 @@ class _AcquireSessionModule:
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
         state = frame.input
         session = self._session_manager.get_or_create(state.session_key)
-        # TurnState 是跨 phase 通信载体，后续 BeforeReasoning / AfterReasoning 会读取。
         state.session = session
         state.retrieval_raw = None
         frame.slots[_SESSION_SLOT] = session
-        return frame
-
-
-class _MemoryStatusCommandModule:
-    requires = (_SESSION_SLOT,)
-    produces = (_CTX_SLOT,)
-
-    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
-        state = frame.input
-        command = _normalize_command(state.msg.content)
-        if command != "/memory_status":
-            return frame
-
-        session = cast(SessionLike, frame.slots[_SESSION_SLOT])
-        messages = list(getattr(session, "messages", []))
-        total = len(messages)
-        last = max(0, int(getattr(session, "last_consolidated", 0)))
-        last = min(last, total)
-        reply = _format_memory_status_reply(messages, last)
-        frame.slots[_CTX_SLOT] = BeforeTurnCtx(
-            session_key=state.session_key,
-            channel=state.msg.channel,
-            chat_id=state.msg.chat_id,
-            content=state.msg.content,
-            timestamp=state.msg.timestamp,
-            skill_names=[],
-            retrieved_memory_block="",
-            retrieval_trace_raw=None,
-            history_messages=(),
-            abort=True,
-            abort_reply=reply,
-        )
         return frame
 
 
@@ -93,7 +64,6 @@ class _PrepareContextModule:
             session_key=state.session_key,
             session=session,
         )
-        # TurnState 是跨 phase 通信载体，AfterTurn 会把 retrieval trace 发给后处理。
         state.retrieval_raw = bundle.retrieval_trace_raw
         frame.slots[_CONTEXT_BUNDLE_SLOT] = bundle
         return frame
@@ -147,81 +117,17 @@ def default_before_turn_modules(
     bus: EventBus,
     session_manager: SessionManager,
     context_store: ContextStore,
+    observe_db_path: Path | None = None,
+    command_modules: BeforeTurnModules | None = None,
 ) -> BeforeTurnModules:
+    commands = command_modules
+    if commands is None:
+        commands = default_before_turn_command_modules(observe_db_path)
     return [
         _AcquireSessionModule(session_manager),
-        _MemoryStatusCommandModule(),
+        *commands,
         _PrepareContextModule(context_store),
         _BuildBeforeTurnCtxModule(),
         _EmitBeforeTurnCtxModule(bus),
         _ReturnBeforeTurnCtxModule(),
     ]
-
-
-def _normalize_command(content: str) -> str:
-    head = (content or "").strip().split(maxsplit=1)[0].lower()
-    if "@" in head:
-        head = head.split("@", 1)[0]
-    return head
-
-
-def _format_memory_status_reply(messages: list[dict], last_consolidated: int) -> str:
-    consolidated_user = _count_real_user_messages(messages[:last_consolidated])
-    total_user = _count_real_user_messages(messages)
-    pending_user = max(0, total_user - consolidated_user)
-    last_user_message = _latest_real_user_content(messages[:last_consolidated])
-
-    lines = ["记忆整理状态："]
-    if last_consolidated <= 0 or not last_user_message:
-        lines.append("当前会话还没有完成过记忆整理。")
-    elif pending_user == 0:
-        lines.append("当前会话已经整理到最新的用户消息。")
-    else:
-        lines.append(f"上次整理到 {pending_user} 条用户消息之前。")
-    if last_user_message:
-        lines.extend(["", "最后已整理的用户消息：", f"“{_preview_text(last_user_message)}”"])
-    lines.extend(
-        [
-            "",
-            f"尚未整理的用户消息数：{pending_user}",
-            f"当前会话消息数：{len(messages)}",
-        ]
-    )
-    return "\n".join(lines)
-
-
-def _count_real_user_messages(messages: list[dict]) -> int:
-    return sum(1 for item in messages if _is_real_user_message(item))
-
-
-def _latest_real_user_content(messages: list[dict]) -> str:
-    for item in reversed(messages):
-        if _is_real_user_message(item):
-            return _content_to_text(item.get("content", ""))
-    return ""
-
-
-def _is_real_user_message(item: dict) -> bool:
-    if item.get("role") != "user":
-        return False
-    content = _content_to_text(item.get("content", ""))
-    return bool(content) and not is_context_frame(content)
-
-
-def _content_to_text(content: object) -> str:
-    if isinstance(content, str):
-        return content.strip()
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, dict) and item.get("type") == "text":
-                parts.append(str(item.get("text", "")).strip())
-        return "\n".join(part for part in parts if part).strip()
-    return str(content).strip()
-
-
-def _preview_text(text: str, limit: int = 80) -> str:
-    normalized = " ".join(text.split())
-    if len(normalized) <= limit:
-        return normalized
-    return normalized[: limit - 1] + "…"

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -8,6 +8,7 @@ from agent.core.types import ContextBundle
 from agent.core.runtime_support import SessionLike
 from agent.lifecycle.phase import PhaseFrame, PhaseModule
 from agent.lifecycle.types import BeforeTurnCtx, TurnState
+from agent.prompting import is_context_frame
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import ContextStore
@@ -43,6 +44,38 @@ class _AcquireSessionModule:
         return frame
 
 
+class _MemoryStatusCommandModule:
+    requires = (_SESSION_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        state = frame.input
+        command = _normalize_command(state.msg.content)
+        if command != "/memory_status":
+            return frame
+
+        session = cast(SessionLike, frame.slots[_SESSION_SLOT])
+        messages = list(getattr(session, "messages", []))
+        total = len(messages)
+        last = max(0, int(getattr(session, "last_consolidated", 0)))
+        last = min(last, total)
+        reply = _format_memory_status_reply(messages, last)
+        frame.slots[_CTX_SLOT] = BeforeTurnCtx(
+            session_key=state.session_key,
+            channel=state.msg.channel,
+            chat_id=state.msg.chat_id,
+            content=state.msg.content,
+            timestamp=state.msg.timestamp,
+            skill_names=[],
+            retrieved_memory_block="",
+            retrieval_trace_raw=None,
+            history_messages=(),
+            abort=True,
+            abort_reply=reply,
+        )
+        return frame
+
+
 class _PrepareContextModule:
     requires = (_SESSION_SLOT,)
     produces = (_CONTEXT_BUNDLE_SLOT,)
@@ -51,6 +84,8 @@ class _PrepareContextModule:
         self._context_store = context_store
 
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        if _CTX_SLOT in frame.slots:
+            return frame
         state = frame.input
         session = cast(SessionLike, frame.slots[_SESSION_SLOT])
         bundle = await self._context_store.prepare(
@@ -69,6 +104,8 @@ class _BuildBeforeTurnCtxModule:
     produces = (_CTX_SLOT,)
 
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        if _CTX_SLOT in frame.slots:
+            return frame
         state = frame.input
         bundle = cast(ContextBundle, frame.slots[_CONTEXT_BUNDLE_SLOT])
         frame.slots[_CTX_SLOT] = BeforeTurnCtx(
@@ -113,8 +150,78 @@ def default_before_turn_modules(
 ) -> BeforeTurnModules:
     return [
         _AcquireSessionModule(session_manager),
+        _MemoryStatusCommandModule(),
         _PrepareContextModule(context_store),
         _BuildBeforeTurnCtxModule(),
         _EmitBeforeTurnCtxModule(bus),
         _ReturnBeforeTurnCtxModule(),
     ]
+
+
+def _normalize_command(content: str) -> str:
+    head = (content or "").strip().split(maxsplit=1)[0].lower()
+    if "@" in head:
+        head = head.split("@", 1)[0]
+    return head
+
+
+def _format_memory_status_reply(messages: list[dict], last_consolidated: int) -> str:
+    consolidated_user = _count_real_user_messages(messages[:last_consolidated])
+    total_user = _count_real_user_messages(messages)
+    pending_user = max(0, total_user - consolidated_user)
+    last_user_message = _latest_real_user_content(messages[:last_consolidated])
+
+    lines = ["记忆整理状态："]
+    if last_consolidated <= 0 or not last_user_message:
+        lines.append("当前会话还没有完成过记忆整理。")
+    elif pending_user == 0:
+        lines.append("当前会话已经整理到最新的用户消息。")
+    else:
+        lines.append(f"上次整理到 {pending_user} 条用户消息之前。")
+    if last_user_message:
+        lines.extend(["", "最后已整理的用户消息：", f"“{_preview_text(last_user_message)}”"])
+    lines.extend(
+        [
+            "",
+            f"尚未整理的用户消息数：{pending_user}",
+            f"当前会话消息数：{len(messages)}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _count_real_user_messages(messages: list[dict]) -> int:
+    return sum(1 for item in messages if _is_real_user_message(item))
+
+
+def _latest_real_user_content(messages: list[dict]) -> str:
+    for item in reversed(messages):
+        if _is_real_user_message(item):
+            return _content_to_text(item.get("content", ""))
+    return ""
+
+
+def _is_real_user_message(item: dict) -> bool:
+    if item.get("role") != "user":
+        return False
+    content = _content_to_text(item.get("content", ""))
+    return bool(content) and not is_context_frame(content)
+
+
+def _content_to_text(content: object) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")).strip())
+        return "\n".join(part for part in parts if part).strip()
+    return str(content).strip()
+
+
+def _preview_text(text: str, limit: int = 80) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1] + "…"

--- a/agent/lifecycle/phases/before_turn_commands.py
+++ b/agent/lifecycle/phases/before_turn_commands.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent.lifecycle.phase import PhaseModule
+from agent.lifecycle.types import BeforeTurnCtx, TurnState
+from agent.prompting import is_context_frame
+
+if TYPE_CHECKING:
+    from agent.lifecycle.phases.before_turn import BeforeTurnFrame
+
+logger = logging.getLogger(__name__)
+
+_SESSION_SLOT = "session:session"
+_CTX_SLOT = "session:ctx"
+
+_TS_PATTERN = re.compile(r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})")
+
+
+# ── 命令 module ────────────────────────────────────────────────────
+
+
+class MemoryStatusCommandModule:
+    requires = (_SESSION_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        if _CTX_SLOT in frame.slots:
+            return frame
+        state = frame.input
+        if _normalize_command(state.msg.content) not in {
+            "/memory_status",
+            "/compact_status",
+        }:
+            return frame
+        session = state.session
+        if session is None:
+            return frame
+        messages = list(getattr(session, "messages", []))
+        last = max(0, int(getattr(session, "last_consolidated", 0)))
+        last = min(last, len(messages))
+        frame.slots[_CTX_SLOT] = _abort_ctx(
+            state, _format_memory_status_reply(messages, last)
+        )
+        return frame
+
+
+class KVCacheCommandModule:
+    requires = (_SESSION_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    def __init__(self, observe_db_path: Path | None = None) -> None:
+        self._observe_db_path = observe_db_path
+
+    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        if _CTX_SLOT in frame.slots:
+            return frame
+        state = frame.input
+        if _normalize_command(state.msg.content) not in {"/kvcache", "/cache_status"}:
+            return frame
+        reply = self._build_reply(state)
+        frame.slots[_CTX_SLOT] = _abort_ctx(state, reply)
+        return frame
+
+    def _build_reply(self, state: TurnState) -> str:
+        db_path = self._observe_db_path
+        if not db_path or not db_path.exists():
+            return "暂无 KVCache 数据（observe 数据库不存在）。"
+
+        args = (state.msg.content or "").strip().split()
+        limit = 5
+        if len(args) > 1:
+            try:
+                limit = max(1, min(30, int(args[1])))
+            except ValueError:
+                pass
+
+        try:
+            conn = sqlite3.connect(str(db_path))
+            try:
+                cursor = conn.execute(
+                    """SELECT llm_output, ts, react_cache_prompt_tokens, react_cache_hit_tokens
+                       FROM turns WHERE session_key=? AND source='agent'
+                       ORDER BY id DESC LIMIT ?""",
+                    [state.session_key, limit],
+                )
+                rows = cursor.fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception("KVCache 查询失败")
+            return "KVCache 查询失败。"
+
+        if not rows:
+            return "暂无 KVCache 数据。"
+
+        overall_prompt = sum(r[2] or 0 for r in rows)
+        overall_hit = sum(r[3] or 0 for r in rows)
+        overall_pct = (overall_hit / overall_prompt * 100) if overall_prompt > 0 else 0.0
+
+        lines = [f"最近 {len(rows)} 轮 KVCache 状态（总命中率 {overall_pct:.2f}%）", ""]
+        for row in rows:
+            llm_output, ts, prompt_tokens, hit_tokens = row
+            content = _content_to_text(llm_output or "")
+            if is_context_frame(content):
+                content = ""
+            preview = _preview_text(content, limit=80)
+            hit = hit_tokens or 0
+            prompt = prompt_tokens or 0
+            pct = (hit / prompt * 100) if prompt > 0 else 0.0
+            lines.append(preview or "（无内容）")
+            lines.append(_format_ts(ts))
+            lines.append(f"{hit:,} / {prompt:,}")
+            lines.append(f"{pct:.2f}%")
+            lines.append("")
+        return "\n".join(lines).rstrip("\n")
+
+
+def default_before_turn_command_modules(
+    observe_db_path: Path | None = None,
+) -> list[PhaseModule[BeforeTurnFrame]]:
+    return [
+        MemoryStatusCommandModule(),
+        KVCacheCommandModule(observe_db_path),
+    ]
+
+
+# ── 内部辅助 ───────────────────────────────────────────────────────
+
+
+def _normalize_command(content: str) -> str:
+    head = (content or "").strip().split(maxsplit=1)[0].lower()
+    if "@" in head:
+        head = head.split("@", 1)[0]
+    return head
+
+
+def _abort_ctx(state: TurnState, reply: str) -> BeforeTurnCtx:
+    return BeforeTurnCtx(
+        session_key=state.session_key,
+        channel=state.msg.channel,
+        chat_id=state.msg.chat_id,
+        content=state.msg.content,
+        timestamp=state.msg.timestamp,
+        skill_names=[],
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
+        history_messages=(),
+        abort=True,
+        abort_reply=reply,
+    )
+
+
+def _format_ts(ts: str) -> str:
+    m = _TS_PATTERN.search(ts)
+    if m:
+        return f"{int(m.group(2))}-{int(m.group(3))} {m.group(4)}:{m.group(5)}"
+    return ts
+
+
+# ── 格式化辅助（memory_status） ──────────────────────────────────
+
+
+def _format_memory_status_reply(messages: list[dict], last_consolidated: int) -> str:
+    consolidated_user = _count_real_user_messages(messages[:last_consolidated])
+    total_user = _count_real_user_messages(messages)
+    pending_user = max(0, total_user - consolidated_user)
+    last_user_message = _latest_real_user_content(messages[:last_consolidated])
+
+    lines = ["记忆整理状态："]
+    if last_consolidated <= 0 or not last_user_message:
+        lines.append("当前会话还没有完成过记忆整理。")
+    elif pending_user == 0:
+        lines.append("当前会话已经整理到最新的用户消息。")
+    else:
+        lines.append(f"上次整理到 {pending_user} 条用户消息之前。")
+    if last_user_message:
+        lines.extend(["", "最后已整理的用户消息：", f"“{_preview_text(last_user_message)}”"])
+    lines.extend(
+        [
+            "",
+            f"尚未整理的用户消息数：{pending_user}",
+            f"当前会话消息数：{len(messages)}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _count_real_user_messages(messages: list[dict]) -> int:
+    return sum(1 for item in messages if _is_real_user_message(item))
+
+
+def _latest_real_user_content(messages: list[dict]) -> str:
+    for item in reversed(messages):
+        if _is_real_user_message(item):
+            return _content_to_text(item.get("content", ""))
+    return ""
+
+
+def _is_real_user_message(item: dict) -> bool:
+    if item.get("role") != "user":
+        return False
+    content = _content_to_text(item.get("content", ""))
+    return bool(content) and not is_context_frame(content)
+
+
+def _content_to_text(content: object) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")).strip())
+        return "\n".join(part for part in parts if part).strip()
+    return str(content).strip()
+
+
+def _preview_text(text: str, limit: int = 80) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1] + "…"

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -410,6 +410,7 @@ class AgentLoop:
                 event_bus=self._event_bus,
                 outbound_port=BusOutboundPort(self.bus),
                 history_window=config.memory.keep_count,
+                observe_db_path=deps.workspace / "observe" / "observe.db",
             )
         )
         self._core_runner = deps.core_runner or CoreRunner(

--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -69,7 +69,7 @@ class McpClient:
             cwd=self.cwd,
             limit=_STREAM_LIMIT,
         )
-        asyncio.create_task(self._drain_stderr())
+        _ = asyncio.create_task(self._drain_stderr())
 
         # initialize 握手
         init_id = self._new_id()
@@ -85,7 +85,7 @@ class McpClient:
                 },
             }
         )
-        await self._recv(expected_id=init_id, stage="initialize")
+        _ = await self._recv(expected_id=init_id, stage="initialize")
 
         # initialized 通知（无 id，不等响应）
         await self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
@@ -145,7 +145,10 @@ class McpClient:
             return
         try:
             self._process.terminate()
-            await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            _ = await asyncio.wait_for(self._process.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            self._process.kill()
+            _ = await self._process.wait()
         except Exception as e:
             logger.warning("[mcp] 断开 %r 时出错: %s", self.name, e)
         finally:

--- a/bootstrap/proactive.py
+++ b/bootstrap/proactive.py
@@ -18,12 +18,6 @@ if TYPE_CHECKING:
     from core.memory.runtime_facade import MemoryRuntimeFacade
 
 
-_FITBIT_DEFAULT_URL = "http://127.0.0.1:18765"
-_FITBIT_DEFAULT_PATH = (
-    Path(__file__).resolve().parent.parent / "scripts" / "fitbit-monitor"
-)
-
-
 def _build_proactive_provider(config: Config, provider: LLMProvider) -> LLMProvider:
     api_key = str(getattr(config, "api_key", "") or "").strip()
     system_prompt = str(getattr(config, "system_prompt", "") or "")
@@ -86,19 +80,10 @@ def build_proactive_runtime(
         ),
         observe_writer=observe_writer,
         shared_tools=getattr(agent_loop, "tools", None),
-        fitbit_enabled=config.fitbit.enabled,
-        fitbit_url=_FITBIT_DEFAULT_URL,
     )
 
     # 4. 主动链路本体以后台任务方式常驻运行。
     tasks.append(proactive_loop.run())
-
-    if config.fitbit.enabled:
-        from proactive_v2.fitbit_sleep import run_fitbit_monitor
-
-        # 5. 可选挂载 fitbit 监控子任务，给主动链路提供睡眠上下文。
-        tasks.append(run_fitbit_monitor(_FITBIT_DEFAULT_PATH, _FITBIT_DEFAULT_URL))
-        print(f"fitbit-monitor 已启动  |  路径={_FITBIT_DEFAULT_PATH}")
 
     return tasks, proactive_loop
 

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -94,6 +94,12 @@ class TelegramChannel:
         self._app = Application.builder().token(token).build()
         self._app.add_handler(CommandHandler("stop", self._on_stop_command))
         self._app.add_handler(
+            CommandHandler("memory_status", self._on_memory_status_command)
+        )
+        self._app.add_handler(
+            CommandHandler("compact_status", self._on_memory_status_command)
+        )
+        self._app.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_message)
         )
         self._app.add_handler(
@@ -321,6 +327,31 @@ class TelegramChannel:
             str(chat.id),
             result.message,
             self._telegram_outbound_limiter,
+        )
+
+    async def _on_memory_status_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        msg = update.effective_message
+        chat = update.effective_chat
+        user = update.effective_user
+
+        if not msg or not chat or not user:
+            return
+        if not self._is_allowed(user):
+            logger.warning(
+                f"[telegram] 拒绝未授权 /memory_status  id={user.id}  username=@{user.username}"
+            )
+            return
+
+        await self._bus.publish_inbound(
+            InboundMessage(
+                channel=_CHANNEL,
+                sender=str(user.id),
+                chat_id=str(chat.id),
+                content="/memory_status",
+                metadata={"username": user.username or ""},
+            )
         )
 
     async def _on_photo(

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -100,6 +100,9 @@ class TelegramChannel:
             CommandHandler("compact_status", self._on_memory_status_command)
         )
         self._app.add_handler(
+            CommandHandler("kvcache", self._on_kvcache_command)
+        )
+        self._app.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_message)
         )
         self._app.add_handler(
@@ -349,7 +352,32 @@ class TelegramChannel:
                 channel=_CHANNEL,
                 sender=str(user.id),
                 chat_id=str(chat.id),
-                content="/memory_status",
+                content=str(getattr(msg, "text", "") or "/memory_status"),
+                metadata={"username": user.username or ""},
+            )
+        )
+
+    async def _on_kvcache_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        msg = update.effective_message
+        chat = update.effective_chat
+        user = update.effective_user
+
+        if not msg or not chat or not user:
+            return
+        if not self._is_allowed(user):
+            logger.warning(
+                f"[telegram] 拒绝未授权 /kvcache  id={user.id}  username=@{user.username}"
+            )
+            return
+
+        await self._bus.publish_inbound(
+            InboundMessage(
+                channel=_CHANNEL,
+                sender=str(user.id),
+                chat_id=str(chat.id),
+                content=str(getattr(msg, "text", "") or "/kvcache"),
                 metadata={"username": user.username or ""},
             )
         )

--- a/main.py
+++ b/main.py
@@ -9,7 +9,9 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 from agent.config import Config
@@ -72,7 +74,32 @@ async def serve(
         config,
         workspace=workspace or _default_workspace(),
     )
-    await runtime.run()
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+    watched_signals = (signal.SIGINT, signal.SIGTERM)
+    for sig in watched_signals:
+        loop.add_signal_handler(sig, stop_event.set)
+
+    runtime_task = asyncio.create_task(runtime.run(), name="app_runtime")
+    stop_task = asyncio.create_task(stop_event.wait(), name="shutdown_signal")
+    try:
+        done, _ = await asyncio.wait(
+            {runtime_task, stop_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if runtime_task in done:
+            _ = stop_task.cancel()
+            await runtime_task
+            return
+        _ = runtime_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await runtime_task
+    finally:
+        for sig in watched_signals:
+            _ = loop.remove_signal_handler(sig)
+        _ = stop_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await stop_task
 
 
 if __name__ == "__main__":

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -513,7 +513,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     monkeypatch.setattr(mod, "send_stream_markdown", AsyncMock())
     monkeypatch.setattr(mod, "send_thinking_block", AsyncMock())
     await channel.start()
-    assert len(channel._app.handlers) == 6
+    assert len(channel._app.handlers) == 7
     assert bus.outbound[0][0] == "telegram"
 
     class _File:
@@ -577,6 +577,16 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     assert bus.inbound[1].content == "/memory_status"
     assert bus.inbound[1].metadata["username"] == "Alice"
 
+    kvcache_update = SimpleNamespace(
+        effective_message=SimpleNamespace(text="/kvcache 5", message_id=101),
+        effective_chat=SimpleNamespace(id=123),
+        effective_user=SimpleNamespace(id=1, username="Alice"),
+    )
+    await channel._on_kvcache_command(kvcache_update, context)
+    assert len(bus.inbound) == 3
+    assert bus.inbound[2].content == "/kvcache 5"
+    assert bus.inbound[2].metadata["username"] == "Alice"
+
     photo_update = SimpleNamespace(
         effective_message=SimpleNamespace(
             photo=[SimpleNamespace(file_id="main"), SimpleNamespace(file_id="main2")],
@@ -605,7 +615,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
         effective_user=SimpleNamespace(id=1, username="Alice"),
     )
     await channel._on_document(doc_update, context)
-    assert len(bus.inbound) == 4
+    assert len(bus.inbound) == 5
     assert bus.inbound[-1].metadata["document_filename"] == "a.md"
 
     assert channel._resolve_chat_id("123") == "123"

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -513,7 +513,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     monkeypatch.setattr(mod, "send_stream_markdown", AsyncMock())
     monkeypatch.setattr(mod, "send_thinking_block", AsyncMock())
     await channel.start()
-    assert len(channel._app.handlers) == 4
+    assert len(channel._app.handlers) == 6
     assert bus.outbound[0][0] == "telegram"
 
     class _File:
@@ -567,6 +567,16 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     )
     assert len(bus.inbound) == 1
 
+    status_update = SimpleNamespace(
+        effective_message=SimpleNamespace(text="/memory_status", message_id=100),
+        effective_chat=SimpleNamespace(id=123),
+        effective_user=SimpleNamespace(id=1, username="Alice"),
+    )
+    await channel._on_memory_status_command(status_update, context)
+    assert len(bus.inbound) == 2
+    assert bus.inbound[1].content == "/memory_status"
+    assert bus.inbound[1].metadata["username"] == "Alice"
+
     photo_update = SimpleNamespace(
         effective_message=SimpleNamespace(
             photo=[SimpleNamespace(file_id="main"), SimpleNamespace(file_id="main2")],
@@ -595,7 +605,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
         effective_user=SimpleNamespace(id=1, username="Alice"),
     )
     await channel._on_document(doc_update, context)
-    assert len(bus.inbound) == 3
+    assert len(bus.inbound) == 4
     assert bus.inbound[-1].metadata["document_filename"] == "a.md"
 
     assert channel._resolve_chat_id("123") == "123"

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -13,6 +13,7 @@ from agent.core.passive_turn import ContextStore
 from agent.core.types import ContextBundle
 from agent.lifecycle.phase import Phase
 from agent.tools.registry import ToolRegistry
+from core.observe.db import open_db as open_observe_db
 from bus.event_bus import EventBus
 from bus.events import InboundMessage
 from agent.lifecycle.types import (
@@ -24,6 +25,7 @@ from agent.lifecycle.types import (
     BeforeTurnCtx,
     TurnState,
 )
+from agent.lifecycle.phases.before_turn_commands import MemoryStatusCommandModule
 from agent.lifecycle.phases.after_step import (
     AfterStepFrame,
     default_after_step_modules,
@@ -179,15 +181,142 @@ async def test_before_turn_memory_status_command_aborts_without_context_prepare(
         timestamp=_now,
     )
     state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
-
     ctx = await phase.run(state)
-
     assert ctx.abort is True
     assert "上次整理到 1 条用户消息之前。" in ctx.abort_reply
     assert "帮我看看 Telegram 流式消息为什么重复发送" in ctx.abort_reply
     assert "尚未整理的用户消息数：1" in ctx.abort_reply
     assert "当前会话消息数：4" in ctx.abort_reply
     assert "内部" not in ctx.abort_reply
+    ctx_store.prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_turn_accepts_custom_command_module():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock())
+
+    class CustomCommandModule:
+        requires = ("session:session",)
+        produces = ("session:ctx",)
+
+        async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+            state = frame.input
+            if state.msg.content != "/debug":
+                return frame
+            frame.slots["session:ctx"] = BeforeTurnCtx(
+                session_key=state.session_key,
+                channel=state.msg.channel,
+                chat_id=state.msg.chat_id,
+                content=state.msg.content,
+                timestamp=state.msg.timestamp,
+                skill_names=[],
+                retrieved_memory_block="",
+                retrieval_trace_raw=None,
+                history_messages=(),
+                abort=True,
+                abort_reply="debug ok",
+            )
+            return frame
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            command_modules=[MemoryStatusCommandModule(), CustomCommandModule()],
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = InboundMessage(
+        channel="telegram",
+        sender="user",
+        chat_id="123",
+        content="/debug",
+        timestamp=_now,
+    )
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is True
+    assert ctx.abort_reply == "debug ok"
+    ctx_store.prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_before_turn_kvcache_command(tmp_path):
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock())
+
+    db_path = tmp_path / "observe" / "observe.db"
+    conn = open_observe_db(db_path)
+    conn.execute(
+        """INSERT INTO turns (source, session_key, user_msg, llm_output, ts,
+           react_cache_prompt_tokens, react_cache_hit_tokens)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            "agent",
+            "telegram:123",
+            "之前的问题",
+            "这是之前的回答",
+            "2026-04-29T16:14:00.123456+00:00",
+            52564,
+            50560,
+        ],
+    )
+    conn.execute(
+        """INSERT INTO turns (source, session_key, user_msg, llm_output, ts,
+           react_cache_prompt_tokens, react_cache_hit_tokens)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            "agent",
+            "telegram:123",
+            "新的问题",
+            "这是新的回答\n有多行",
+            "2026-04-29T16:15:00+00:00",
+            50000,
+            40000,
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            observe_db_path=db_path,
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = InboundMessage(
+        channel="telegram",
+        sender="user",
+        chat_id="123",
+        content="/kvcache",
+        timestamp=_now,
+    )
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is True
+    assert "最近 2 轮 KVCache 状态" in ctx.abort_reply
+    assert "总命中率" in ctx.abort_reply
+    assert "这是之前的回答" in ctx.abort_reply
+    assert "这是新的回答" in ctx.abort_reply
+    assert "4-29 16:14" in ctx.abort_reply
+    assert "4-29 16:15" in ctx.abort_reply
+    assert "50,560 / 52,564" in ctx.abort_reply
+    assert "96.19%" in ctx.abort_reply
+    assert "80.00%" in ctx.abort_reply
+    assert ctx.abort_reply.count("\n\n") <= 2
     ctx_store.prepare.assert_not_called()
 
 

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -147,6 +147,51 @@ async def test_before_turn_chain_can_abort():
 
 
 @pytest.mark.asyncio
+async def test_before_turn_memory_status_command_aborts_without_context_prepare():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session.messages = [
+        {
+            "role": "user",
+            "content": '<system-reminder data-system-context-frame="true">内部</system-reminder>',
+        },
+        {"role": "user", "content": "帮我看看 Telegram 流式消息为什么重复发送"},
+        {"role": "assistant", "content": "已修复"},
+        {"role": "user", "content": "再看一下超时问题"},
+    ]
+    session.last_consolidated = 3
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock())
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = InboundMessage(
+        channel="telegram",
+        sender="user",
+        chat_id="123",
+        content="/memory_status",
+        timestamp=_now,
+    )
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is True
+    assert "上次整理到 1 条用户消息之前。" in ctx.abort_reply
+    assert "帮我看看 Telegram 流式消息为什么重复发送" in ctx.abort_reply
+    assert "尚未整理的用户消息数：1" in ctx.abort_reply
+    assert "当前会话消息数：4" in ctx.abort_reply
+    assert "内部" not in ctx.abort_reply
+    ctx_store.prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_before_turn_chain_can_modify_skill_names():
     bus = EventBus()
     session = _DummySession("telegram:123")

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -769,11 +769,6 @@ def test_bootstrap_proactive_builders_cover_enabled_and_disabled_paths(
             run=lambda: ("mem-task", interval_seconds)
         ),
     )
-    monkeypatch.setattr(
-        "proactive_v2.fitbit_sleep.run_fitbit_monitor",
-        lambda path, url: ("fitbit-task", path, url),
-    )
-
     cfg = SimpleNamespace(
         proactive=SimpleNamespace(
             enabled=True,
@@ -798,14 +793,7 @@ def test_bootstrap_proactive_builders_cover_enabled_and_disabled_paths(
             processing_state=SimpleNamespace(is_busy=lambda: False)
         )),
     )
-    assert tasks == [
-        "loop-task",
-        (
-            "fitbit-task",
-            Path(__file__).resolve().parents[1] / "scripts" / "fitbit-monitor",
-            "http://127.0.0.1:18765",
-        ),
-    ]
+    assert tasks == ["loop-task"]
     assert loop is proactive_loop
     mem_tasks = build_memory_optimizer_task(
         cast(Any, cfg),


### PR DESCRIPTION
## 变更
- 在 BeforeTurn 增加 /memory_status 短路命令，读取 session 记忆整理状态，不进入 context prepare / LLM。
- Telegram 注册 /memory_status 和 /compact_status，统一转成标准 /memory_status inbound。
- 输出按真实用户消息展示，跳过 system-reminder 内部上下文帧。

## 验证
- .venv-312/bin/python -m pytest tests/test_lifecycle_phases.py tests/test_channel_clients.py tests/test_agent_core_p5_agent_core.py