### PR TITLE
拆分 proactive 动态上下文回放

### DIFF
--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -111,7 +111,13 @@ class McpClient:
         )
         return self._tool_infos
 
-    async def call(self, tool_name: str, arguments: dict[str, Any]) -> str:
+    async def call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> str:
         """调用远端工具，返回结果字符串。"""
         call_id = self._new_id()
         await self._send(
@@ -125,6 +131,7 @@ class McpClient:
         resp = await self._recv(
             expected_id=call_id,
             stage=f"tools/call:{tool_name}",
+            timeout=timeout,
         )
 
         if "error" in resp:
@@ -175,15 +182,19 @@ class McpClient:
         self,
         expected_id: int | None = None,
         stage: str = "recv",
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         assert self._process and self._process.stdout
+        recv_timeout = _RECV_TIMEOUT if timeout is None else timeout
         while True:
             try:
                 line = await asyncio.wait_for(
-                    self._process.stdout.readline(), timeout=_RECV_TIMEOUT
+                    self._process.stdout.readline(), timeout=recv_timeout
                 )
             except asyncio.TimeoutError as e:
-                raise TimeoutError(self._build_timeout_message(stage, expected_id)) from e
+                raise TimeoutError(
+                    self._build_timeout_message(stage, expected_id, recv_timeout)
+                ) from e
             if not line:
                 raise ConnectionError(f"MCP server {self.name!r} 意外关闭了 stdout")
             text = line.decode().strip()
@@ -225,9 +236,14 @@ class McpClient:
         except Exception:
             pass
 
-    def _build_timeout_message(self, stage: str, expected_id: int | None) -> str:
+    def _build_timeout_message(
+        self,
+        stage: str,
+        expected_id: int | None,
+        timeout: float,
+    ) -> str:
         details = [
-            f"MCP server {self.name!r} 在阶段 {stage!r} 等待响应超时（{_RECV_TIMEOUT:.0f}s）",
+            f"MCP server {self.name!r} 在阶段 {stage!r} 等待响应超时（{timeout:.0f}s）",
         ]
         if expected_id is not None:
             details.append(f"expected_id={expected_id}")

--- a/proactive_v2/agent_tick.py
+++ b/proactive_v2/agent_tick.py
@@ -18,6 +18,11 @@ from hashlib import sha1
 from typing import Any, Awaitable, Callable
 from urllib.parse import urlsplit, urlunsplit
 
+from agent.prompting import (
+    PromptSectionRender,
+    build_context_frame_content,
+    build_context_frame_message,
+)
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutor, ToolHook
 from agent.turns.orchestrator import TurnOrchestrator
 from agent.turns.result import TurnOutbound, TurnResult, TurnTrace
@@ -409,65 +414,15 @@ class AgentTick:
             final_message_after=ctx.final_message,
         )
 
-    def _build_system_prompt(self, ctx: AgentTickContext, gw: GatewayResult) -> str:
-        fallback_status = "允许" if ctx.context_as_fallback_open else "不允许"
-
-        memory_block = ""
-        self_block = ""
-        recent_context_block = ""
-        if self._tool_deps.memory is not None:
-            try:
-                raw = _read_long_term_text(self._tool_deps.memory).strip()
-                if raw:
-                    memory_block = "\n【用户长期记忆】\n" + raw + "\n"
-            except Exception:
-                pass
-            try:
-                self_content = _read_self_text(self._tool_deps.memory).strip()
-                if self_content:
-                    self_block = f"## Akashic 自我认知\n\n{self_content}\n\n"
-            except Exception:
-                pass
-            try:
-                rc = str(self._tool_deps.memory.read_recent_context() or "").strip()
-                if rc:
-                    recent_context_block = "【近期交互上下文】\n" + rc + "\n\n"
-            except Exception:
-                pass
-
-        alert_block = self._render_alert_block(gw.alerts)
-        context_block = self._render_context_block(gw.context)
-
-        workspace_context_block = ""
-        if self._workspace_context_fn is not None:
-            try:
-                raw = (self._workspace_context_fn() or "").strip()
-                if raw:
-                    workspace_context_block = (
-                        "【Workspace 主动上下文（主/被动 loop 共享规则面板，不是内容源）】\n"
-                        + raw[:3000]
-                        + "\n\n"
-                    )
-            except Exception:
-                pass
-
-        content_block = self._render_content_block(gw.content_meta, gw.content_store)
-
+    def _build_system_prompt(self) -> str:
         from agent.persona import AKASHIC_IDENTITY, PERSONALITY_RULES
 
         return (
             f"{AKASHIC_IDENTITY}\n\n"
             f"{PERSONALITY_RULES}\n\n"
-            f"{self_block}"
             "你现在处于主动推送决策模式：判断现在是否该给用户发一条消息，以及发什么。\n"
-            "数据已预取完毕，基于下方数据直接决策。\n\n"
-            f"{alert_block}"
-            f"{content_block}"
-            f"{context_block}"
-            f"{workspace_context_block}"
-            f"{memory_block}\n"
-            f"{recent_context_block}"
-            f"【优先级】Alert > Content > Context-fallback（本轮：{fallback_status}）\n\n"
+            "数据已预取完毕，会在后续 system context frame 里提供；基于那些数据直接决策。\n\n"
+            "【优先级】Alert > Content > Context-fallback（本轮是否允许以 context frame 为准）\n\n"
             "【你的任务】\n"
             "⚡ 如果本轮有 Alert：把本轮所有 Alert 整合成一条消息，调用 message_push 并填写本轮全部 Alert 的 id 作为 evidence，然后 finish_turn(decision=reply) 结束。Alert 是系统触发的高优先级通知，不走内容筛选流程。\n"
             "1. 对本轮 Content 逐条判断：这条内容是否可能让用户不感兴趣，是否可能不符合规则，是否值得进入 interesting。\n"
@@ -551,6 +506,81 @@ class AgentTick:
             "- 当本轮 content 和 alerts 均为空时，evidence 必须为 []；任何 'feed:xxx' 格式的 id 只能来自本轮真实提供的候选列表，不能自行捏造\n"
             "- 没有实质内容时 finish_turn(decision=skip, reason=no_content) 是正确选择\n\n"
             "【finish_turn.reason】no_content | user_busy | already_sent_similar | other"
+        )
+
+    def _build_runtime_context_message(
+        self,
+        ctx: AgentTickContext,
+        gw: GatewayResult,
+    ) -> dict[str, str]:
+        # 动态上下文统一放进 context frame，避免后续被当作用户原话或普通回复回放。
+        sections: list[PromptSectionRender] = [
+            PromptSectionRender(
+                name="proactive_tick_state",
+                content=(
+                    f"context_fallback={'允许' if ctx.context_as_fallback_open else '不允许'}\n"
+                    f"alert_count={len(gw.alerts)}\n"
+                    f"content_count={len(gw.content_meta)}\n"
+                    f"context_count={len(gw.context)}"
+                ),
+                is_static=False,
+            )
+        ]
+
+        self_content = ""
+        memory_block = ""
+        recent_context_block = ""
+        if self._tool_deps.memory is not None:
+            try:
+                self_content = _read_self_text(self._tool_deps.memory).strip()
+            except Exception:
+                self_content = ""
+            try:
+                memory_block = _read_long_term_text(self._tool_deps.memory).strip()
+            except Exception:
+                memory_block = ""
+            try:
+                recent_context_block = str(
+                    self._tool_deps.memory.read_recent_context() or ""
+                ).strip()
+            except Exception:
+                recent_context_block = ""
+
+        for name, content in (
+            ("self_model", self_content),
+            ("long_term_memory", memory_block),
+            ("recent_context", recent_context_block),
+            ("proactive_alerts", self._render_alert_block(gw.alerts).strip()),
+            (
+                "proactive_content",
+                self._render_content_block(gw.content_meta, gw.content_store).strip(),
+            ),
+            ("proactive_context", self._render_context_block(gw.context).strip()),
+            ("workspace_proactive_context", self._read_workspace_context_for_prompt()),
+        ):
+            if content:
+                sections.append(
+                    PromptSectionRender(
+                        name=name,
+                        content=content,
+                        is_static=False,
+                    )
+                )
+
+        return build_context_frame_message(build_context_frame_content(sections))
+
+    def _read_workspace_context_for_prompt(self) -> str:
+        if self._workspace_context_fn is None:
+            return ""
+        try:
+            raw = (self._workspace_context_fn() or "").strip()
+        except Exception:
+            return ""
+        if not raw:
+            return ""
+        return (
+            "【Workspace 主动上下文（主/被动 loop 共享规则面板，不是内容源）】\n"
+            + raw[:3000]
         )
 
     def _render_alert_block(self, alerts: list[dict]) -> str:
@@ -670,8 +700,9 @@ class AgentTick:
             self.last_ctx = ctx
             return False
 
-        # 3. 构造本轮 proactive 专用 system prompt，把预取数据一次性注入给模型。
-        system_msg = {"role": "system", "content": self._build_system_prompt(ctx, gw_result)}
+        # 3. 构造本轮 proactive 输入：稳定规则放 system，本轮数据放 context frame。
+        system_msg = {"role": "system", "content": self._build_system_prompt()}
+        runtime_context_msg = self._build_runtime_context_message(ctx, gw_result)
         kickoff_msg = {
             "role": "user",
             "content": (
@@ -680,7 +711,7 @@ class AgentTick:
                 "最后通过 message_push + finish_turn(decision=reply)，或 finish_turn(decision=skip, reason=...) 收尾。"
             ),
         }
-        messages: list[dict] = [system_msg, kickoff_msg]
+        messages: list[dict] = [system_msg, runtime_context_msg, kickoff_msg]
 
         # 4. 主 loop：每轮允许模型自行决定是否调用工具。
         #    直到 finish_turn 写入 terminal_action，或达到步数上限。

--- a/proactive_v2/agent_tick_factory.py
+++ b/proactive_v2/agent_tick_factory.py
@@ -287,29 +287,7 @@ class AgentTickFactory:
                 max_web_fetch_chars=tool_deps.max_chars,
             ),
             max_steps=getattr(self._deps.cfg, "drift_max_steps", 20),
-            step_recorder=self._record_drift_step,
             tool_hooks=self._deps.tool_hooks,
-        )
-
-    def _record_drift_step(
-        self,
-        ctx,
-        phase: str,
-        tool_name: str,
-        tool_call_id: str,
-        tool_args: dict[str, Any],
-        tool_result_text: str,
-    ) -> None:
-        tick = getattr(self, "_tick", None)
-        if tick is None:
-            return
-        tick._record_tick_step(
-            ctx,
-            phase=phase,
-            tool_name=tool_name,
-            tool_call_id=tool_call_id,
-            tool_args=tool_args,
-            tool_result_text=tool_result_text,
         )
 
     def _build_drift_send_message_fn(self) -> Callable[[str], Awaitable[bool]] | None:

--- a/proactive_v2/drift_runner.py
+++ b/proactive_v2/drift_runner.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, cast
 
+from agent.prompting import (
+    PromptSectionRender,
+    build_context_frame_content,
+    build_context_frame_message,
+)
 from agent.persona import AKASHIC_IDENTITY, PERSONALITY_RULES
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutor
 from agent.tool_hooks.base import ToolHook
@@ -74,7 +79,8 @@ class DriftRunner:
         base_schemas = tools.get_schemas()
 
         messages: list[dict] = [
-            {"role": "system", "content": self._build_system_prompt(skills, connected_servers)}
+            {"role": "system", "content": self._build_system_prompt()},
+            self._build_runtime_context_message(skills, connected_servers),
         ]
         steps = 0
         warned = False
@@ -208,9 +214,11 @@ class DriftRunner:
         )
         return True
 
-    def _build_system_prompt(
-        self, skills: list[SkillMeta], connected_servers: set[str] | None = None,
-    ) -> str:
+    def _build_runtime_context_message(
+        self,
+        skills: list[SkillMeta],
+        connected_servers: set[str] | None = None,
+    ) -> dict[str, str]:
         memory_text = ""
         recent_context_text = ""
         if self.tool_deps.memory is not None:
@@ -266,20 +274,57 @@ class DriftRunner:
             mcp_block = (
                 "【可挂载的外部能力】\n"
                 + "\n".join(mcp_lines) + "\n"
-                "使用 mount_server(server=\"名称\") 挂载后即可调用其中的工具。\n\n"
+                "使用 mount_server(server=\"名称\") 挂载后即可调用其中的工具。"
             )
 
+        sections = [
+            PromptSectionRender(
+                name="drift_runtime_state",
+                content=f"【Drift 工作区绝对路径】\n{self.store.drift_dir}",
+                is_static=False,
+            ),
+            PromptSectionRender(
+                name="long_term_memory",
+                content=memory_text or "（空）",
+                is_static=False,
+            ),
+            PromptSectionRender(
+                name="recent_context",
+                content=recent_context_text or "（空）",
+                is_static=False,
+            ),
+            PromptSectionRender(
+                name="drift_skills",
+                content=skill_block,
+                is_static=False,
+            ),
+            PromptSectionRender(
+                name="recent_drift_runs",
+                content=recent_block,
+                is_static=False,
+            ),
+            PromptSectionRender(
+                name="drift_note",
+                content=drift_note or "（空）",
+                is_static=False,
+            ),
+        ]
+        if mcp_block:
+            sections.append(
+                PromptSectionRender(
+                    name="drift_mcp_directory",
+                    content=mcp_block,
+                    is_static=False,
+                )
+            )
+        return build_context_frame_message(build_context_frame_content(sections))
+
+    def _build_system_prompt(self) -> str:
         return (
             f"{AKASHIC_IDENTITY}\n\n"
             f"{PERSONALITY_RULES}\n\n"
             "你现在有一段空闲时间（Drift 模式）。没有外部内容需要推送，\n"
-            "你可以自主决定做一件有意义的事。\n\n"
-            f"【Drift 工作区绝对路径】\n{self.store.drift_dir}\n\n"
-            f"【用户长期记忆】\n{memory_text}\n\n"
-            f"【近期交互上下文】\n{recent_context_text or '（空）'}\n\n"
-            f"【可用 Drift Skills】\n{skill_block}\n\n"
-            f"【最近的 Drift 记录】\n{recent_block}\n\n"
-            f"【全局备注】\n{drift_note}\n\n"
+            "你可以自主决定做一件有意义的事。本轮记忆、skill 和工作区信息会在后续 system context frame 里提供。\n\n"
             "【执行规则】\n"
             "1. 每次进入 Drift 都先重新比较所有可用 skill，不要因为某个 skill 最近刚运行过，"
             "或它的 next 很明确，就默认继续它。\n"
@@ -306,11 +351,10 @@ class DriftRunner:
             "9. message_push 成功后不要再调用 recall_memory / web_fetch / web_search / fetch_messages / search_messages / shell，"
             "后续只允许 write_file、edit_file 和 finish_drift 收尾。\n"
             "10. 执行结束前必须调用 finish_drift 保存状态。\n\n"
-            f"{mcp_block}"
             "【可用工具】\n"
             "read_file, write_file, edit_file, recall_memory, web_fetch, web_search, "
-            "fetch_messages, search_messages, shell, message_push, finish_drift"
-            + (", mount_server" if mcp_block else "")
+            "fetch_messages, search_messages, shell, message_push, finish_drift；"
+            "若 context frame 里列出了可挂载外部能力，可用 mount_server 挂载。"
         )
 
     @staticmethod

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_WORKSPACE = Path.home() / ".akashic" / "workspace"
+_POLL_TOOL_TIMEOUT = 180.0
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +135,14 @@ class McpClientPool:
             logger.warning("[mcp_pool] connect failed %s: %s", server, e, exc_info=True)
             return False
 
-    async def call(self, server: str, tool_name: str, args: dict) -> Any:
+    async def call(
+        self,
+        server: str,
+        tool_name: str,
+        args: dict[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> Any:
         """调用 tool，连接断开时自动重连一次。
 
         MCP stdio 传输不支持并发调用，per-server lock 保证串行。
@@ -149,8 +157,15 @@ class McpClientPool:
                     raise RuntimeError(f"[mcp_pool] could not connect: {server}")
             client = self._clients[server]
             try:
-                raw = await client.call(tool_name, args)
+                raw = await client.call(tool_name, args, timeout=timeout)
                 return json.loads(raw) if raw and raw.strip().startswith(("[", "{")) else raw
+            except TimeoutError:
+                self._clients.pop(server, None)
+                try:
+                    await client.disconnect()
+                except Exception:
+                    pass
+                raise
             except Exception as e:
                 logger.warning(
                     "[mcp_pool] call failed %s.%s, reconnecting: %s", server, tool_name, e
@@ -161,8 +176,17 @@ class McpClientPool:
                 except Exception:
                     pass
                 if await self._connect(server):
-                    raw = await self._clients[server].call(tool_name, args)
-                    return json.loads(raw) if raw and raw.strip().startswith(("[", "{")) else raw
+                    retry_client = self._clients[server]
+                    try:
+                        raw = await retry_client.call(tool_name, args, timeout=timeout)
+                        return json.loads(raw) if raw and raw.strip().startswith(("[", "{")) else raw
+                    except Exception:
+                        self._clients.pop(server, None)
+                        try:
+                            await retry_client.disconnect()
+                        except Exception:
+                            pass
+                        raise
                 raise
 
     async def disconnect_all(self) -> None:
@@ -306,7 +330,7 @@ async def poll_content_feeds_async(pool: McpClientPool) -> None:
             continue
         server = src.get("server", "")
         try:
-            result = await pool.call(server, poll_tool, {})
+            result = await pool.call(server, poll_tool, {}, timeout=_POLL_TOOL_TIMEOUT)
             if isinstance(result, str) and result.startswith("error:"):
                 raise RuntimeError(f"poll_feeds 系统级失败: {result}")
             logger.info("[mcp_sources] poll_content_feeds: %s.%s 完成", server, poll_tool)

--- a/session/manager.py
+++ b/session/manager.py
@@ -9,11 +9,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from agent.prompting import (
+    PromptSectionRender,
+    build_context_frame_content,
+    build_context_frame_message,
+)
 from session.store import SessionStore
 
 logger = logging.getLogger(__name__)
 
 _TOOL_RESULT_CHAR_BUDGET = 100
+_PROACTIVE_HISTORY_CHAR_BUDGET = 360
+_PROACTIVE_META_HISTORY_CHAR_BUDGET = 1200
 
 
 def _truncate_tool_result(content: object) -> str:
@@ -59,6 +66,43 @@ def _append_proactive_meta(content: str, msg: dict[str, Any]) -> str:
     return f"{content}\n\n[proactive_meta]\n" + "\n".join(meta_lines)
 
 
+def _build_proactive_history_messages(
+    content: str,
+    msg: dict[str, Any],
+) -> list[dict[str, str]]:
+    preview = _truncate_text(content, _PROACTIVE_HISTORY_CHAR_BUDGET)
+    messages = [
+        {
+            "role": "assistant",
+            "content": f"[主动推送] {preview}" if preview else "[主动推送]",
+        }
+    ]
+    meta = _append_proactive_meta("", msg).strip()
+    if not meta:
+        return messages
+    frame = build_context_frame_message(
+        build_context_frame_content([
+            PromptSectionRender(
+                name="recent_proactive_message_meta",
+                content=(
+                    "上一条 assistant 消息是系统主动推送。"
+                    "以下 metadata 仅用于理解用户后续指代，不是用户陈述。\n"
+                    + _truncate_text(meta, _PROACTIVE_META_HISTORY_CHAR_BUDGET)
+                ),
+                is_static=False,
+            )
+        ])
+    )
+    messages.append(frame)
+    return messages
+
+
+def _truncate_text(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + f"…（截断 {len(text) - limit} 字）"
+
+
 def _rebuild_user_content(text: str, media_paths: list[str]) -> "str | list[dict]":
     """重建带附件的用户消息。图片内联 base64；非图片文件保留路径引用供 agent 调用 read_file。"""
     images = []
@@ -93,7 +137,9 @@ def _rebuild_user_content(text: str, media_paths: list[str]) -> "str | list[dict
 
 def _align_to_user_boundary(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for i, m in enumerate(messages):
-        if m.get("role") == "user":
+        if m.get("role") == "user" or (
+            m.get("role") == "assistant" and m.get("proactive")
+        ):
             return messages[i:]
     return []
 
@@ -145,11 +191,24 @@ class Session:
             if start >= len(self.messages):
                 return []
             # 向前回退到最近的 user 边界（保留完整 turn）
-            while start > 0 and self.messages[start].get("role") != "user":
+            while (
+                start > 0
+                and self.messages[start].get("role") != "user"
+                and not (
+                    self.messages[start].get("role") == "assistant"
+                    and self.messages[start].get("proactive")
+                )
+            ):
                 start -= 1
-            # start=0 但仍非 user 时，向后找第一个 user
+            # start=0 但仍非合法边界时，向后找第一个 user 或 proactive assistant。
             messages = self.messages[start:]
-            if messages and messages[0].get("role") != "user":
+            if messages and not (
+                messages[0].get("role") == "user"
+                or (
+                    messages[0].get("role") == "assistant"
+                    and messages[0].get("proactive")
+                )
+            ):
                 messages = _align_to_user_boundary(messages)
             if not messages:
                 return []
@@ -191,6 +250,11 @@ class Session:
             if role != "assistant":
                 continue
 
+            content = m.get("content", "") or ""
+            if m.get("proactive"):
+                out.extend(_build_proactive_history_messages(str(content), m))
+                continue
+
             tool_chain: list[dict] = m.get("tool_chain") or []
             for group in tool_chain:
                 calls: list[dict] = group.get("calls") or []
@@ -226,7 +290,6 @@ class Session:
                         }
                     )
 
-            content = m.get("content", "") or ""
             if content:
                 content = _append_proactive_meta(content, m)
             assistant_msg = {"role": "assistant", "content": content}

--- a/tests/proactive_v2/test_agent_loop.py
+++ b/tests/proactive_v2/test_agent_loop.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from agent.prompting import is_context_frame
 from proactive_v2.gateway import GatewayDeps
 from proactive_v2.tools import ToolDeps
 from tests.proactive_v2.conftest import FakeLLM, cfg_with, make_agent_tick
@@ -63,6 +64,38 @@ async def test_loop_stops_when_llm_returns_none():
     await tick.tick()
     assert tick.last_ctx.steps_taken == 0
     assert tick.last_ctx.terminal_action is None
+
+
+@pytest.mark.asyncio
+async def test_loop_puts_runtime_context_frame_before_kickoff():
+    llm = FakeLLM([("finish_turn", {"decision": "skip", "reason": "no_content"})])
+    tick = make_agent_tick(
+        llm_fn=llm,
+        gateway_deps=GatewayDeps(
+            alert_fn=AsyncMock(return_value=[]),
+            feed_fn=AsyncMock(
+                return_value=[
+                    {
+                        "event_id": "c1",
+                        "ack_server": "feed",
+                        "title": "测试内容",
+                        "source_name": "feed",
+                        "url": "https://example.com/a",
+                    }
+                ]
+            ),
+            context_fn=AsyncMock(return_value=[]),
+        ),
+    )
+
+    await tick.tick()
+
+    messages = llm.calls[0]
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "user"
+    assert is_context_frame(str(messages[1]["content"]))
+    assert "proactive_tick_state" in str(messages[1]["content"])
+    assert str(messages[2]["content"]).startswith("开始本轮 proactive 处理。")
 
 
 @pytest.mark.asyncio

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.prompting import is_context_frame
 from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
 from agent.looping.ports import ObservabilityServices, SessionServices
@@ -155,7 +156,8 @@ def test_drift_system_prompt_discourages_stuck_skill_and_lists_new_tools(tmp_pat
             shared_tools=_build_shared_tools(),
         ),
     )
-    prompt = runner._build_system_prompt(store.scan_skills())
+    prompt = runner._build_system_prompt()
+    runtime = str(runner._build_runtime_context_message(store.scan_skills())["content"])
     assert "不要因为某个 skill 最近刚运行过" in prompt
     assert "如果这个 skill 当前明显处于“等待用户回复/等待外部条件”的状态，就不要选它" in prompt
     assert "对用户的表达要像此刻自然想到的一句聊天" in prompt
@@ -163,6 +165,8 @@ def test_drift_system_prompt_discourages_stuck_skill_and_lists_new_tools(tmp_pat
     assert "fetch_messages" in prompt
     assert "search_messages" in prompt
     assert "shell" in prompt
+    assert is_context_frame(runtime)
+    assert "drift_skills" in runtime
 
 
 @pytest.mark.asyncio
@@ -282,6 +286,7 @@ async def test_drift_runner_runs_and_finishes(tmp_path: Path):
     entered = await runner.run(ctx, cast(Any, llm))
     assert entered is True
     assert ctx.drift_finished is True
+    assert is_context_frame(str(llm.calls[0][1]["content"]))
     drift = store.load_drift()
     assert drift["recent_runs"][-1]["skill"] == "explore-curiosity"
     assert llm.tool_choices[:2] == ["required", "required"]
@@ -788,14 +793,18 @@ def test_system_prompt_includes_mcp_directory(tmp_path: Path):
         store=store,
         tool_deps=DriftToolDeps(drift_dir=tmp_path, store=store, shared_tools=shared),
     )
-    prompt = runner._build_system_prompt(store.scan_skills(), shared.get_mcp_server_names())
-    assert "可挂载的外部能力" in prompt
-    assert "calendar" in prompt
-    assert "mount_server" in prompt
+    content = str(
+        runner._build_runtime_context_message(
+            store.scan_skills(), shared.get_mcp_server_names()
+        )["content"]
+    )
+    assert "可挂载的外部能力" in content
+    assert "calendar" in content
+    assert "mount_server" in content
     # 不应展开具体工具名，只列 server 名和工具数
-    assert "mcp_calendar__tool_a" not in prompt
-    assert "mcp_calendar__tool_b" not in prompt
-    assert "2 个工具" in prompt
+    assert "mcp_calendar__tool_a" not in content
+    assert "mcp_calendar__tool_b" not in content
+    assert "2 个工具" in content
 
 
 def test_system_prompt_no_mcp_block_without_servers(tmp_path: Path):
@@ -805,9 +814,9 @@ def test_system_prompt_no_mcp_block_without_servers(tmp_path: Path):
         store=store,
         tool_deps=DriftToolDeps(drift_dir=tmp_path, store=store, shared_tools=_build_shared_tools()),
     )
-    prompt = runner._build_system_prompt(store.scan_skills(), set())
-    assert "可挂载的外部能力" not in prompt
-    assert "mount_server" not in prompt
+    content = str(runner._build_runtime_context_message(store.scan_skills(), set())["content"])
+    assert "可挂载的外部能力" not in content
+    assert "mount_server" not in content
 
 
 def test_system_prompt_skill_requires_mcp_annotation(tmp_path: Path):
@@ -818,8 +827,12 @@ def test_system_prompt_skill_requires_mcp_annotation(tmp_path: Path):
         store=store,
         tool_deps=DriftToolDeps(drift_dir=tmp_path, store=store, shared_tools=shared),
     )
-    prompt = runner._build_system_prompt(store.scan_skills(), shared.get_mcp_server_names())
-    assert "[需要: calendar]" in prompt
+    content = str(
+        runner._build_runtime_context_message(
+            store.scan_skills(), shared.get_mcp_server_names()
+        )["content"]
+    )
+    assert "[需要: calendar]" in content
 
 
 class _FakeProvider:

--- a/tests/proactive_v2/test_hltv_whitelist_verification.py
+++ b/tests/proactive_v2/test_hltv_whitelist_verification.py
@@ -329,19 +329,10 @@ async def test_system_prompt_contains_training_data_warning():
     验证系统提示里包含"训练数据记忆"不能替代 web_fetch 的规则。
     这是一个确定性测试，不依赖真实 LLM。
     """
-    from proactive_v2.agent_tick import AgentTick, AgentTickContext
-    from proactive_v2.gateway import GatewayResult
-    from proactive_v2.config import ProactiveConfig
-    from datetime import datetime, timezone
-    from unittest.mock import MagicMock
-
     # 构建一个最小化的 AgentTick 来获取系统提示
     tick = make_agent_tick(llm_fn=None)
 
-    ctx = AgentTickContext(session_key="test", now_utc=datetime.now(timezone.utc))
-    gw = GatewayResult()
-
-    prompt = tick._build_system_prompt(ctx, gw)
+    prompt = tick._build_system_prompt()
 
     assert "训练数据" in prompt, (
         "系统提示应包含'训练数据'相关的规则，防止 LLM 用训练记忆跳过 web_fetch 验证"
@@ -356,14 +347,8 @@ async def test_system_prompt_rule8_covers_ranking_verification():
     """
     验证规则第8条明确说明排名/赛况等时效性数据必须 web_fetch，不能用训练记忆。
     """
-    from proactive_v2.context import AgentTickContext
-    from proactive_v2.gateway import GatewayResult
-    from datetime import datetime, timezone
-
     tick = make_agent_tick(llm_fn=None)
-    ctx = AgentTickContext(session_key="test", now_utc=datetime.now(timezone.utc))
-    gw = GatewayResult()
-    prompt = tick._build_system_prompt(ctx, gw)
+    prompt = tick._build_system_prompt()
 
     # 规则8的核心断言
     assert "训练数据记忆" in prompt, "规则8应明确提到训练数据记忆不等于常识"

--- a/tests/proactive_v2/test_message_quality.py
+++ b/tests/proactive_v2/test_message_quality.py
@@ -8,7 +8,6 @@ tests/proactive_v2/test_message_quality.py
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -135,7 +134,7 @@ async def test_get_recent_chat_mixed_passive_and_proactive():
 
 def _make_system_prompt() -> str:
     from proactive_v2.agent_tick import AgentTick
-    from proactive_v2.gateway import GatewayDeps, GatewayResult
+    from proactive_v2.gateway import GatewayDeps
     from proactive_v2.config import ProactiveConfig
     from unittest.mock import MagicMock
 
@@ -160,9 +159,7 @@ def _make_system_prompt() -> str:
         ),
         llm_fn=None,
     )
-    ctx = AgentTickContext(session_key="test", now_utc=datetime.now(timezone.utc))
-    gw = GatewayResult()
-    return tick._build_system_prompt(ctx, gw)
+    return tick._build_system_prompt()
 
 
 def test_system_prompt_contains_no_hallucination_rule():

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -447,13 +447,15 @@ async def test_mcp_recv_timeout_includes_stage_and_recent_output(
     client._recent_stdout.append('{"jsonrpc":"2.0","method":"note"}')
     client._recent_stderr.append("GitHub MCP Server running on stdio")
 
-    async def raise_timeout(*args, **kwargs):
+    async def raise_timeout(awaitable, *args, **kwargs):
+        awaitable.close()
         raise asyncio.TimeoutError
 
     monkeypatch.setattr(mcp_client_module.asyncio, "wait_for", raise_timeout)
     with pytest.raises(TimeoutError) as exc:
-        await client._recv(expected_id=1, stage="initialize")
+        await client._recv(expected_id=1, stage="initialize", timeout=12.0)
     text = str(exc.value)
     assert "initialize" in text
+    assert "12s" in text
     assert "expected_id=1" in text
     assert "recent_stderr=GitHub MCP Server running on stdio" in text

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.prompting import is_context_frame
 from agent.provider import LLMResponse
 from core.memory.port import DefaultMemoryPort
 from proactive_v2.loop import ProactiveLoop
@@ -149,8 +150,11 @@ async def test_session_manager_and_proactive_loop_cover_paths(tmp_path: Path):
         {"calls": [{"call_id": "1", "name": "tool", "arguments": {}, "result": "ok"}]}
     ]
     history = session.get_history()
+    assert len(history) == 3
     assert history[0]["role"] == "user"
-    assert history[-1]["role"] == "assistant"
+    assert history[1] == {"role": "assistant", "content": "[主动推送] reply"}
+    assert history[2]["role"] == "user"
+    assert is_context_frame(str(history[2]["content"]))
     assert _safe_filename("telegram:1") == "telegram_1"
 
     manager = SessionManager(tmp_path)
@@ -231,6 +235,48 @@ def test_session_get_history_replays_cached_llm_turn_from_consolidated_index():
         },
         {"role": "user", "content": user_content},
         {"role": "assistant", "content": "world"},
+    ]
+
+
+def test_session_get_history_replays_proactive_as_short_assistant_with_meta_frame():
+    session = Session("cli:1")
+    session.add_message(
+        "assistant",
+        "这是一条主动消息",
+        proactive=True,
+        source_refs=[
+            {
+                "source_name": "feed",
+                "title": "标题",
+                "url": "https://example.com/a",
+            }
+        ],
+    )
+
+    history = session.get_history()
+
+    assert len(history) == 2
+    assert history[0] == {"role": "assistant", "content": "[主动推送] 这是一条主动消息"}
+    assert history[1]["role"] == "user"
+    content = str(history[1]["content"])
+    assert is_context_frame(content)
+    assert "recent_proactive_message_meta" in content
+    assert "proactive_meta" in content
+
+
+def test_session_get_history_allows_proactive_assistant_boundary():
+    session = Session("cli:1")
+    session.add_message("user", "old")
+    session.add_message("assistant", "old reply")
+    session.add_message("assistant", "主动消息", proactive=True)
+    session.add_message("user", "刚才那个")
+    session.last_consolidated = 2
+
+    history = session.get_history(start_index=session.last_consolidated)
+
+    assert history == [
+        {"role": "assistant", "content": "[主动推送] 主动消息"},
+        {"role": "user", "content": "刚才那个"},
     ]
 
 

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -18,9 +18,18 @@ class _FakePool:
         self._responses = responses
         self._failures = failures or set()
         self.calls: list[tuple[str, str, dict]] = []
+        self.timeouts: list[float | None] = []
 
-    async def call(self, server: str, tool_name: str, args: dict):
+    async def call(
+        self,
+        server: str,
+        tool_name: str,
+        args: dict[str, Any],
+        *,
+        timeout: float | None = None,
+    ):
         self.calls.append((server, tool_name, dict(args)))
+        self.timeouts.append(timeout)
         if (server, tool_name) in self._failures:
             raise RuntimeError(f"failed: {server}.{tool_name}")
         return self._responses[(server, tool_name)]
@@ -126,6 +135,40 @@ async def test_poll_content_feeds_async_raises_when_any_source_failed(monkeypatc
 
     assert "s2" in str(exc.value)
     assert ("a1", "poll", {}) not in pool.calls
+    assert pool.timeouts == [mcp_sources._POLL_TOOL_TIMEOUT, mcp_sources._POLL_TOOL_TIMEOUT]
+
+
+@pytest.mark.asyncio
+async def test_mcp_pool_disconnects_timeout_client_without_retry():
+    class _TimeoutClient:
+        def __init__(self) -> None:
+            self.disconnected = False
+            self.calls = 0
+
+        async def call(
+            self,
+            tool_name: str,
+            args: dict[str, Any],
+            *,
+            timeout: float | None = None,
+        ) -> str:
+            self.calls += 1
+            raise TimeoutError("slow")
+
+        async def disconnect(self) -> None:
+            self.disconnected = True
+
+    pool = mcp_sources.McpClientPool(Path("unused-workspace"))
+    client = _TimeoutClient()
+    pool._configs["feed"] = (["cmd"], {})
+    pool._clients["feed"] = client
+
+    with pytest.raises(TimeoutError):
+        await pool.call("feed", "poll_feeds", {}, timeout=1.0)
+
+    assert client.calls == 1
+    assert client.disconnected is True
+    assert "feed" not in pool._clients
 
 
 @pytest.mark.asyncio

--- a/tests/test_proactive_agent_tick_factory.py
+++ b/tests/test_proactive_agent_tick_factory.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 from typing import Any, cast
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from proactive_v2.agent_tick_factory import AgentTickDeps, AgentTickFactory
 from proactive_v2.config import ProactiveConfig
+from proactive_v2.context import AgentTickContext
 from proactive_v2.mcp_sources import McpClientPool
 from bootstrap.proactive import build_proactive_runtime
 
@@ -75,6 +77,41 @@ def test_agent_tick_factory_builds_drift_runner_when_enabled(tmp_path):
     tick = AgentTickFactory(deps).build()
     assert tick._drift_runner is not None
     assert tick._drift_runner.store.drift_dir == tmp_path / "drift"
+
+
+def test_agent_tick_factory_binds_drift_step_recorder_to_tick_store(tmp_path):
+    deps = _build_deps(with_pool=True)
+    deps.cfg = ProactiveConfig(
+        default_chat_id="cid",
+        drift_enabled=True,
+    )
+    state_store = SimpleNamespace(
+        workspace_dir=tmp_path,
+        record_tick_step_log=MagicMock(),
+    )
+    deps.state_store = state_store
+
+    tick = AgentTickFactory(deps).build()
+    assert tick._drift_runner is not None
+    assert tick._drift_runner.step_recorder is not None
+
+    ctx = AgentTickContext(tick_id="tick1", session_key="telegram:1")
+    ctx.steps_taken = 3
+    tick._drift_runner.step_recorder(
+        ctx,
+        "drift",
+        "read_file",
+        "call1",
+        {"path": "x"},
+        "ok",
+    )
+
+    state_store.record_tick_step_log.assert_called_once()
+    kwargs = state_store.record_tick_step_log.call_args.kwargs
+    assert kwargs["tick_id"] == "tick1"
+    assert kwargs["step_index"] == 3
+    assert kwargs["phase"] == "drift"
+    assert kwargs["tool_name"] == "read_file"
 
 
 def test_build_proactive_runtime_accepts_light_agent_loop_stub(tmp_path):

--- a/tests/test_proactive_facade_phase4.py
+++ b/tests/test_proactive_facade_phase4.py
@@ -102,10 +102,11 @@ def test_agent_tick_prompt_keeps_self_block_with_facade():
         llm_fn=None,
     )
 
-    prompt = tick._build_system_prompt(
+    runtime_context = tick._build_runtime_context_message(
         AgentTickContext(session_key="test"),
         GatewayResult(),
     )
+    content = str(runtime_context["content"])
 
-    assert "Akashic 自我认知" in prompt
-    assert "SELF" in prompt
+    assert "self_model" in content
+    assert "SELF" in content


### PR DESCRIPTION
## 变更
- proactive / drift 的动态数据改走 context frame，保留稳定 system prompt。
- 主动消息回放改成短 assistant message，并用 context frame 承载元信息，避免 tool_chain 进入普通对话上下文。
- 修复 drift tool chain 观测写入：drift step recorder 现在绑定到当前 AgentTick 的 state store，后续 tick_step_log 能记录 drift 工具链。
- MCP feed 轮询支持单次 180 秒超时；超时后断开旧连接，避免晚到响应污染后续调用。

## 验证
- `pytest tests/proactive_v2/test_agent_loop.py tests/proactive_v2/test_drift.py tests/proactive_v2/test_hltv_whitelist_verification.py tests/proactive_v2/test_message_quality.py tests/test_io_modules.py tests/test_logic_modules.py tests/test_mcp_sources_async.py tests/test_proactive_facade_phase4.py tests/test_proactive_agent_tick_factory.py`：119 passed, 2 skipped
- `pyright agent/mcp/client.py proactive_v2/agent_tick.py proactive_v2/agent_tick_factory.py proactive_v2/drift_runner.py proactive_v2/mcp_sources.py session/manager.py tests/proactive_v2/test_agent_loop.py tests/proactive_v2/test_drift.py tests/proactive_v2/test_hltv_whitelist_verification.py tests/proactive_v2/test_message_quality.py tests/test_io_modules.py tests/test_logic_modules.py tests/test_mcp_sources_async.py tests/test_proactive_facade_phase4.py tests/test_proactive_agent_tick_factory.py`：0 errors, 425 warnings（项目既有 typing/unused warnings）