### PR TITLE
归一化主动出站文本

### DIFF
--- a/proactive_v2/drift_tools.py
+++ b/proactive_v2/drift_tools.py
@@ -11,6 +11,7 @@ from agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
 from agent.tools.registry import ToolRegistry
 from proactive_v2.context import AgentTickContext
 from proactive_v2.drift_state import DriftStateStore
+from proactive_v2.outbound_text import normalize_outbound_text
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ class SendMessageTool(Tool):
         }
 
     async def execute(self, message: str = "", content: str = "", **_: Any) -> str:
-        text = (message or content or "").strip()
+        text = normalize_outbound_text(message or content or "").strip()
         if self._send_message_fn is None:
             logger.info("[drift_tools] message_push unavailable")
             return json.dumps({"error": "message_push not configured"}, ensure_ascii=False)

--- a/proactive_v2/outbound_text.py
+++ b/proactive_v2/outbound_text.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+
+from ftfy.fixes import decode_escapes, fix_line_breaks
+
+
+_ESCAPED_LINE_BREAK_RE = re.compile(r"(?<!\\)\\[nr]")
+
+
+def normalize_outbound_text(text: str) -> str:
+    normalized = fix_line_breaks(text)
+    if _should_decode_escaped_line_breaks(normalized):
+        normalized = fix_line_breaks(decode_escapes(normalized))
+    return normalized
+
+
+def _should_decode_escaped_line_breaks(text: str) -> bool:
+    escaped_count = len(_ESCAPED_LINE_BREAK_RE.findall(text))
+    if escaped_count == 0:
+        return False
+    if "\\n\\n" in text or "\\r\\n" in text:
+        return True
+    return escaped_count >= 2 and escaped_count > text.count("\n")

--- a/proactive_v2/tools.py
+++ b/proactive_v2/tools.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from agent.prompting import is_context_frame
 from proactive_v2.context import AgentTickContext
+from proactive_v2.outbound_text import normalize_outbound_text
 
 logger = logging.getLogger(__name__)
 
@@ -377,7 +378,7 @@ def _parse_evidence(ctx: AgentTickContext, evidence_raw: object) -> list[str]:
 
 
 def _finish_reply(ctx: AgentTickContext, args: dict) -> str:
-    content = str(args.get("content", "") or "")
+    content = normalize_outbound_text(str(args.get("content", "") or ""))
     if not content.strip():
         raise ValueError("finish_reply requires non-empty content")
     evidence = _parse_evidence(ctx, args.get("evidence", []))
@@ -446,7 +447,7 @@ def _finish_turn(ctx: AgentTickContext, args: dict) -> str:
 def _message_push(ctx: AgentTickContext, args: dict) -> str:
     if ctx.draft_message.strip():
         raise ValueError("message_push already called this turn; cannot overwrite draft")
-    message = str(args.get("message", "") or "")
+    message = normalize_outbound_text(str(args.get("message", "") or ""))
     if not message.strip():
         raise ValueError("message_push requires non-empty message")
     evidence = _parse_evidence(ctx, args.get("evidence", []))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ docstring_parser
 duckduckgo_search>=8.0.0
 fake-useragent>=2.0.0
 fastapi>=0.134.0
+ftfy>=6.3.1
 html2text>=2025.4.0
 httpx>=0.28.0
 json_repair>=0.58.0

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -296,9 +296,10 @@ async def test_drift_runner_runs_and_finishes(tmp_path: Path):
 async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
     _write_skill(tmp_path)
     store = DriftStateStore(tmp_path)
+    send_message = AsyncMock(return_value=True)
     llm = FakeLLM(
         [
-            ("message_push", {"message": "hello"}),
+            ("message_push", {"message": "hello\\n\\nfrom drift"}),
             ("finish_drift", {"skill_used": "explore-curiosity", "one_line": "sent", "next": "next"}),
         ]
     )
@@ -308,7 +309,7 @@ async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
             drift_dir=tmp_path,
             store=store,
             shared_tools=_build_shared_tools(),
-            send_message_fn=AsyncMock(return_value=True),
+            send_message_fn=send_message,
         ),
         max_steps=5,
     )
@@ -319,6 +320,7 @@ async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
     # 第二次 llm 调用的 schemas 只能由 DriftRunner 约束为 write_file/edit_file/finish_drift；
     # FakeLLM 不记录 schemas，这里用行为结果兜底：send 后仍正常 finish。
     assert ctx.drift_finished is True
+    send_message.assert_awaited_once_with("hello\n\nfrom drift")
 
 
 @pytest.mark.asyncio

--- a/tests/proactive_v2/test_tools.py
+++ b/tests/proactive_v2/test_tools.py
@@ -365,6 +365,19 @@ def test_message_push_writes_draft_not_final():
     assert ctx.terminal_action is None
 
 
+def test_message_push_decodes_escaped_newlines_for_outbound_text():
+    ctx = AgentTickContext()
+    result = json.loads(_message_push(ctx, {"message": "第一段\\n\\n第二段\\n第三段"}))
+    assert result["ok"] is True
+    assert ctx.draft_message == "第一段\n\n第二段\n第三段"
+
+
+def test_message_push_keeps_single_literal_escape_text():
+    ctx = AgentTickContext()
+    _message_push(ctx, {"message": "Python 里换行符写作 \\n"})
+    assert ctx.draft_message == "Python 里换行符写作 \\n"
+
+
 def test_message_push_second_call_raises():
     ctx = AgentTickContext()
     _message_push(ctx, {"message": "first"})


### PR DESCRIPTION
## 变更
- 新增 proactive 出站文本归一化，使用 ftfy 处理疑似转义换行泄漏。
- proactive message_push / finish_reply 和 drift message_push 发送前归一化。
- 保留单个字面量 `\n` 场景，避免误改用户可见技术说明。
- 新增 ftfy 运行依赖。

## 验证
- `.venv/bin/python -m pytest tests/proactive_v2/test_tools.py tests/proactive_v2/test_drift.py tests/proactive_v2/test_agent_loop.py`：134 passed
- `pyright proactive_v2/outbound_text.py proactive_v2/tools.py proactive_v2/drift_tools.py tests/proactive_v2/test_tools.py tests/proactive_v2/test_drift.py`：0 errors, 153 warnings（项目既有 unknown typing warnings）