### PR TITLE
统一记忆检索与 observe trace

### DIFF
--- a/agent/looping/memory_gate.py
+++ b/agent/looping/memory_gate.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from agent.looping.constants import _RETRIEVE_TRACE_SUMMARY_MAX
 from agent.policies.history_route import HistoryRoutePolicy, RouteDecision
 from agent.prompting import is_context_frame
 from core.common.strategy_trace import build_strategy_trace_envelope
@@ -18,78 +17,6 @@ logger = logging.getLogger("agent.loop")
 
 
 # ── Module-level functions (moved from AgentLoopMemoryGateMixin in Phase 2) ──
-
-
-def _trace_memory_retrieve(
-    workspace: Path,
-    *,
-    session_key: str,
-    channel: str,
-    chat_id: str,
-    user_msg: str,
-    items: list[dict],
-    injected_block: str,
-    gate_type: str = "history_route",
-    route_decision: str = "RETRIEVE",
-    rewritten_query: str = "",
-    fallback_reason: str = "",
-    procedure_guard_applied: bool = False,
-    procedure_hits: int = 0,
-    history_hits: int = 0,
-    injected_item_ids: list[str] | None = None,
-    gate_latency_ms: dict | None = None,
-    sufficiency_check: dict | None = None,
-    error: str = "",
-) -> None:
-    try:
-        memory_dir = workspace / "memory"
-        memory_dir.mkdir(parents=True, exist_ok=True)
-        trace_file = memory_dir / "memory2_retrieve_trace.jsonl"
-        payload = {
-            "session_key": session_key,
-            "channel": channel,
-            "chat_id": chat_id,
-            "user_msg": user_msg,
-            "hit_count": len(items),
-            "procedure_hits": procedure_hits,
-            "history_hits": history_hits,
-            "injected_chars": len(injected_block or ""),
-            "gate_type": gate_type,
-            "route_decision": route_decision,
-            "rewritten_query": rewritten_query,
-            "fallback_reason": fallback_reason,
-            "procedure_guard_applied": procedure_guard_applied,
-            "injected_item_ids": injected_item_ids or [],
-            "gate_latency_ms": gate_latency_ms or {},
-            "sufficiency_check": sufficiency_check or {},
-            "error": error,
-            "top_items": [
-                {
-                    "id": item.get("id", ""),
-                    "memory_type": item.get("memory_type", ""),
-                    "score": round(float(item.get("score", 0.0)), 4),
-                    "summary": (item.get("summary", "") or "")[
-                        :_RETRIEVE_TRACE_SUMMARY_MAX
-                    ],
-                }
-                for item in items
-            ],
-        }
-        line = {
-            **build_strategy_trace_envelope(
-                trace_type="route",
-                source="agent.memory_route",
-                subject_kind="session",
-                subject_id=session_key,
-                payload=payload,
-                timestamp=datetime.now().astimezone().isoformat(),
-            ),
-            **payload,
-        }
-        with trace_file.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(line, ensure_ascii=False) + "\n")
-    except Exception as e:
-        logger.warning("memory2 retrieve trace write failed: %s", e)
 
 
 def _is_flow_execution_state(user_msg: str, metadata: dict) -> bool:

--- a/agent/retrieval/default_pipeline.py
+++ b/agent/retrieval/default_pipeline.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import Protocol, runtime_checkable
 
 from agent.core.types import RetrievalTrace
 from agent.looping.ports import LLMServices, MemoryConfig, MemoryServices
@@ -18,14 +17,8 @@ from core.memory.default_runtime_facade import (
     _retrieve_episodic_items,
 )
 from core.memory.runtime_facade import ContextRetrievalRequest, ContextRetrievalResult
-from core.observe.events import RagTrace
 
 logger = logging.getLogger("agent.retrieval")
-
-
-@runtime_checkable
-class _InjectedItem(Protocol):
-    injected: bool
 
 
 class DefaultMemoryRetrievalPipeline(MemoryRetrievalPipeline):
@@ -105,19 +98,6 @@ async def _retrieve_context_with_facade(
 def _build_retrieval_trace(
     context_result: ContextRetrievalResult,
 ) -> RetrievalTrace | None:
-    rag_trace = context_result.raw.get("rag_trace")
-    if isinstance(rag_trace, RagTrace):
-        return RetrievalTrace(
-            gate_type=rag_trace.gate_type,
-            route_decision=rag_trace.route_decision,
-            rewritten_query=rag_trace.query,
-            injected_count=sum(
-                1
-                for item in (rag_trace.items or [])
-                if isinstance(item, _InjectedItem) and item.injected
-            ),
-            raw=rag_trace,
-        )
     if not context_result.trace and not context_result.injected_item_ids and not context_result.text_block:
         return None
     return RetrievalTrace(
@@ -125,5 +105,5 @@ def _build_retrieval_trace(
         route_decision=str(context_result.trace.get("route_decision") or "") or None,
         rewritten_query=str(context_result.raw.get("rewritten_query") or "") or None,
         injected_count=len(context_result.injected_item_ids),
-        raw=context_result.trace or None,
+        raw=context_result.raw.get("rag_trace"),
     )

--- a/agent/tools/recall_memory.py
+++ b/agent/tools/recall_memory.py
@@ -1,43 +1,29 @@
 """
 recall_memory 工具：主动检索记忆数据库。
 
-工作流：
-  1. 并行生成 2 条 HyDE 假想记忆条目（"用户在X月重构了akashic…"）
-  2. 向量路：embed(query) + embed(hypothesis×2) → 三路 vector_search → union
-  3. 关键字路：提取 query 关键词 → keyword_search_summary（OR-LIKE，按命中词数排序）
-  4. RRF 融合两路排名，取 top-N
-  5. 每条结果携带 source_ref，可直接传给 fetch_messages 回溯原始对话
+工具层只负责参数校验和引用协议输出；检索策略走 memory facade，
+真正查库融合在 memory2.Retriever。
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
-import logging
-import re
-from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
 from agent.tools.base import Tool
+from core.memory.runtime_facade import ExplicitRetrievalRequest
 
 if TYPE_CHECKING:
-    from agent.provider import LLMProvider, LLMResponse
+    from agent.provider import LLMProvider
+    from agent.memory import MemoryStore
+    from core.memory.runtime_facade import MemoryRuntimeFacade
     from memory2.embedder import Embedder
     from memory2.store import MemoryStore2
 
-logger = logging.getLogger(__name__)
-
-_RRF_K = 60
-_HYPOTHESIS_MAX_TOKENS = 80
-_HYPOTHESIS_TIMEOUT_S = 3.0
-_EMBED_TIMEOUT_S = 8.0
-_VECTOR_SCORE_THRESHOLD = 0.35   # 比自动注入低一档，宁可多召回
-_VECTOR_TOP_K = 15
 _LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 _MemoryHit = dict[str, object]
-_ChatCall = Callable[..., Awaitable["LLMResponse"]]
 _RECENT_PRESETS = {
     "recent_3d": 3,
     "recent_7d": 7,
@@ -121,15 +107,35 @@ class RecallMemoryTool(Tool):
 
     def __init__(
         self,
-        store: "MemoryStore2",
-        embedder: "Embedder",
-        provider: "LLMProvider",
-        model: str,
+        facade: "MemoryRuntimeFacade | None" = None,
+        store: "MemoryStore2 | None" = None,
+        embedder: "Embedder | None" = None,
+        provider: "LLMProvider | None" = None,
+        model: str = "",
     ) -> None:
-        self._store = store
-        self._embedder = embedder
-        self._provider = provider
-        self._model = model
+        if facade is not None:
+            self._facade = facade
+            return
+        if store is None or embedder is None or provider is None or not model:
+            raise ValueError("RecallMemoryTool requires facade or legacy memory dependencies")
+
+        # TODO: 兼容壳；旧 bootstrap/tests 仍可传 store/embedder/provider，后续移除。
+        from core.memory.default_runtime_facade import DefaultMemoryRuntimeFacade
+        from core.memory.explicit_retriever import DefaultExplicitRetriever
+        from core.memory.port import DefaultMemoryPort
+        from memory2.retriever import Retriever
+
+        retriever = Retriever(store, embedder)
+        port = DefaultMemoryPort(cast("MemoryStore", store), retriever=retriever)
+        explicit_retriever = DefaultExplicitRetriever(
+            port=port,
+            provider=provider,
+            model=model,
+        )
+        self._facade = DefaultMemoryRuntimeFacade(
+            port=port,
+            explicit_retriever=explicit_retriever,
+        )
 
     async def execute(
         self,
@@ -156,173 +162,21 @@ class RecallMemoryTool(Tool):
         if mode == "grep":
             assert time_window is not None
             start, end = time_window
-            items = self._store.list_events_by_time_range(start, end, limit=limit)
-            return _build_response(items)
-
-        types = [memory_type] if memory_type else None
-        time_start = None
-        time_end = None
-        if time_window is not None:
-            time_start, time_end = time_window
-
-        # 并行：embed(query) + 生成 2 条 HyDE 假想条目
-        embed_task = asyncio.create_task(self._embed(query, label="query"))
-        hyp1_task = asyncio.create_task(self._gen_hypothesis(query, style="event"))
-        hyp2_task = asyncio.create_task(self._gen_hypothesis(query, style="general"))
-
-        query_vec, hyp1, hyp2 = await asyncio.gather(embed_task, hyp1_task, hyp2_task)
-
-        vector_results: list[_MemoryHit] = []
-        if query_vec is not None:
-            hypotheses = [h for h in (hyp1, hyp2) if h]
-            vector_results = await self._vector_union(
-                query_vec, hypotheses, types, time_start, time_end
-            )
-
-        # 关键字路：从 query 中提取词（中文按字符切分 + 英文按空格）
-        terms = _extract_terms(query)
-        kw_results = self._store.keyword_search_summary(
-            terms,
-            memory_types=types,
-            limit=30,
-            time_start=time_start,
-            time_end=time_end,
-        )
-
-        # RRF 融合
-        merged = _rrf_merge(vector_results, kw_results, top_n=limit)
-
-        logger.info(
-            "recall_memory: mode=%s time_filter=%r query=%r vector=%d kw=%d merged=%d hyp=[%r, %r]",
-            mode,
-            time_filter,
-            query[:60],
-            len(vector_results),
-            len(kw_results),
-            len(merged),
-            hyp1[:50] if hyp1 else None,
-            hyp2[:50] if hyp2 else None,
-        )
-        return _build_response(merged)
-
-    async def _vector_union(
-        self,
-        query_vec: list[float],
-        hypotheses: list[str],
-        types: list[str] | None,
-        time_start: datetime | None,
-        time_end: datetime | None,
-    ) -> list[_MemoryHit]:
-        """embed query + hypotheses，各自 vector_search，union dedup。"""
-        hyp_vecs: list[list[float]] = []
-        if hypotheses:
-            hyp_vecs = [
-                v
-                for v in await asyncio.gather(
-                    *[self._embed(h, label="hypothesis") for h in hypotheses]
-                )
-                if v is not None
-            ]
-
-        all_vecs = [query_vec] + list(hyp_vecs)
-        seen: dict[str, _MemoryHit] = {}
-        hit_groups: list[list[_MemoryHit]] = []
-        if time_start is not None or time_end is not None:
-            try:
-                hit_groups = self._store.vector_search_batch(
-                    all_vecs,
-                    top_k=_VECTOR_TOP_K,
-                    memory_types=types,
-                    score_threshold=_VECTOR_SCORE_THRESHOLD,
-                    time_start=time_start,
-                    time_end=time_end,
-                )
-            except Exception as e:
-                logger.debug("recall_memory: vector_search_batch failed: %s", e)
-
-        if hit_groups:
-            for hits in hit_groups:
-                for hit in hits:
-                    _remember_vector_hit(seen, hit)
-            return list(seen.values())
-
-        for vec in all_vecs:
-            try:
-                hits = self._store.vector_search(
-                    vec,
-                    top_k=_VECTOR_TOP_K,
-                    memory_types=types,
-                    score_threshold=_VECTOR_SCORE_THRESHOLD,
-                    time_start=time_start,
-                    time_end=time_end,
-                )
-            except Exception as e:
-                logger.debug("recall_memory: vector_search failed: %s", e)
-                continue
-            for hit in hits:
-                _remember_vector_hit(seen, hit)
-        return list(seen.values())
-
-    async def _embed(self, text: str, *, label: str) -> list[float] | None:
-        try:
-            return await asyncio.wait_for(
-                self._embedder.embed(text),
-                timeout=_EMBED_TIMEOUT_S,
-            )
-        except Exception as e:
-            logger.warning(
-                "recall_memory: %s embed failed, fallback to keyword only: %s",
-                label,
-                e,
-            )
-            return None
-
-    async def _gen_hypothesis(self, query: str, style: str) -> str | None:
-        """生成一条假想记忆条目，style=event 生成带时间戳的事件，style=general 生成通用陈述。"""
-        if style == "event":
-            prompt = (
-                "你是个人助手的记忆系统。根据用户提问，生成一条**带具体时间**的假想记忆条目，"
-                "格式如 '[2026-03-08] 用户...'\n"
-                "规则：第三人称、简洁事实陈述、只输出那一条文本\n\n"
-                f"用户提问：{query}\n假想记忆条目："
-            )
         else:
-            prompt = (
-                "你是个人助手的记忆系统。根据用户提问，生成一条假想记忆条目。\n"
-                "规则：始终生成肯定式、第三人称（'用户…'）、简洁事实陈述、只输出那一条文本\n\n"
-                f"用户提问：{query}\n假想记忆条目："
+            start = time_window[0] if time_window is not None else None
+            end = time_window[1] if time_window is not None else None
+
+        result = await self._facade.retrieve_explicit(
+            ExplicitRetrievalRequest(
+                query=query,
+                memory_type=memory_type,
+                search_mode=mode,
+                limit=limit,
+                time_start=start,
+                time_end=end,
             )
-        try:
-            chat = cast(_ChatCall, getattr(self._provider, "chat"))
-            resp = await asyncio.wait_for(
-                chat(
-                    messages=[{"role": "user", "content": prompt}],
-                    tools=[],
-                    model=self._model,
-                    max_tokens=_HYPOTHESIS_MAX_TOKENS,
-                ),
-                timeout=_HYPOTHESIS_TIMEOUT_S,
-            )
-            text = (resp.content or "").strip()
-            return text if text else None
-        except Exception as e:
-            logger.debug("recall_memory: hypothesis generation failed (style=%s): %s", style, e)
-            return None
-
-
-def _remember_vector_hit(
-    seen: dict[str, _MemoryHit],
-    hit: _MemoryHit,
-) -> None:
-    hit_id = _hit_id(hit)
-    hit_score = _hit_score(hit)
-    seen_score = _hit_score(seen.get(hit_id, {}))
-    if hit_id not in seen or hit_score > seen_score:
-        seen[hit_id] = hit
-
-
-def _hit_id(item: _MemoryHit) -> str:
-    return str(item.get("id", "") or "")
+        )
+        return _build_response(result.hits)
 
 
 def _hit_score(item: _MemoryHit, fallback_key: str = "score") -> float:
@@ -400,97 +254,3 @@ def _build_response(raw_items: list[_MemoryHit]) -> str:
         },
         ensure_ascii=False,
     )
-
-
-_CJK_STOPWORDS = {
-    "用户", "助手", "我们", "他们", "这个", "那个", "什么", "如何", "是否",
-    "有没", "没有", "有过", "做过", "进行", "完成", "包括", "通过", "实现",
-    "行为", "内容", "相关", "情况", "问题", "方式", "时候", "时间", "目前",
-    "当前", "最近", "之前", "以前", "后来", "然后", "因为", "所以", "但是",
-    "用户在", "用户对", "的行为吗", "进行了",
-}
-
-
-def _extract_terms(query: str) -> list[str]:
-    """从 query 中提取关键词。
-
-    策略：
-    - ASCII/数字 token（>= 2 chars）直接保留（Phase、akashic、1-4 等）
-    - CJK 块 <= 4 chars：整体保留（重构、架构、运行时、工具链 这类复合词）
-    - CJK 块 > 4 chars：拆成 2-gram（避免过长短语无法匹配）
-    - 去掉高频虚词
-    """
-    terms: list[str] = []
-    ascii_tokens = re.findall(r"[a-zA-Z0-9_\-\.]{2,}", query)
-    terms.extend(ascii_tokens)
-
-    cjk_chunks = re.findall(r"[\u4e00-\u9fff\u3040-\u30ff]{2,}", query)
-    for chunk in cjk_chunks:
-        if len(chunk) <= 4:
-            if chunk not in _CJK_STOPWORDS:
-                terms.append(chunk)
-        else:
-            # 长块拆 2-gram，保留有意义的片段
-            for i in range(len(chunk) - 1):
-                bigram = chunk[i:i + 2]
-                if bigram not in _CJK_STOPWORDS:
-                    terms.append(bigram)
-
-    seen: set[str] = set()
-    result: list[str] = []
-    for t in terms:
-        if t not in seen:
-            seen.add(t)
-            result.append(t)
-    return result[:20]
-
-
-def _rrf_merge(
-    vector_items: list[_MemoryHit],
-    kw_items: list[_MemoryHit],
-    *,
-    top_n: int,
-    k: int = _RRF_K,
-) -> list[_MemoryHit]:
-    """Reciprocal Rank Fusion：合并向量排名和关键字排名。"""
-    # 构建各路排名 {id: rank}（rank 从 1 开始）
-    vec_rank: dict[str, int] = {}
-    for i, item in enumerate(sorted(vector_items, key=_hit_score, reverse=True)):
-        item_id = _hit_id(item)
-        if item_id:
-            vec_rank[item_id] = i + 1
-    kw_rank: dict[str, int] = {}
-    for i, item in enumerate(kw_items):
-        item_id = _hit_id(item)
-        if item_id:
-            kw_rank[item_id] = i + 1
-
-    # 合并所有 id
-    all_ids: set[str] = set(vec_rank) | set(kw_rank)
-    # 建 id → item 映射（向量结果优先，因为包含完整字段）
-    id_to_item: dict[str, _MemoryHit] = {}
-    for item in kw_items:
-        item_id = _hit_id(item)
-        if item_id:
-            id_to_item[item_id] = item
-    for item in vector_items:
-        item_id = _hit_id(item)
-        if item_id:
-            id_to_item[item_id] = item  # 覆盖 kw，vector 结果字段更全
-
-    scored: list[tuple[str, float]] = []
-    for item_id in all_ids:
-        rrf = 0.0
-        if item_id in vec_rank:
-            rrf += 1.0 / (k + vec_rank[item_id])
-        if item_id in kw_rank:
-            rrf += 1.0 / (k + kw_rank[item_id])
-        scored.append((item_id, rrf))
-
-    scored.sort(key=lambda x: x[1], reverse=True)
-    result: list[_MemoryHit] = []
-    for item_id, rrf_score in scored[:top_n]:
-        item = dict(id_to_item[item_id])
-        item["rrf_score"] = rrf_score
-        result.append(item)
-    return result

--- a/agent/tools/recall_memory.py
+++ b/agent/tools/recall_memory.py
@@ -16,11 +16,7 @@ from agent.tools.base import Tool
 from core.memory.runtime_facade import ExplicitRetrievalRequest
 
 if TYPE_CHECKING:
-    from agent.provider import LLMProvider
-    from agent.memory import MemoryStore
     from core.memory.runtime_facade import MemoryRuntimeFacade
-    from memory2.embedder import Embedder
-    from memory2.store import MemoryStore2
 
 _LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 _MemoryHit = dict[str, object]
@@ -107,35 +103,9 @@ class RecallMemoryTool(Tool):
 
     def __init__(
         self,
-        facade: "MemoryRuntimeFacade | None" = None,
-        store: "MemoryStore2 | None" = None,
-        embedder: "Embedder | None" = None,
-        provider: "LLMProvider | None" = None,
-        model: str = "",
+        facade: "MemoryRuntimeFacade",
     ) -> None:
-        if facade is not None:
-            self._facade = facade
-            return
-        if store is None or embedder is None or provider is None or not model:
-            raise ValueError("RecallMemoryTool requires facade or legacy memory dependencies")
-
-        # TODO: 兼容壳；旧 bootstrap/tests 仍可传 store/embedder/provider，后续移除。
-        from core.memory.default_runtime_facade import DefaultMemoryRuntimeFacade
-        from core.memory.explicit_retriever import DefaultExplicitRetriever
-        from core.memory.port import DefaultMemoryPort
-        from memory2.retriever import Retriever
-
-        retriever = Retriever(store, embedder)
-        port = DefaultMemoryPort(cast("MemoryStore", store), retriever=retriever)
-        explicit_retriever = DefaultExplicitRetriever(
-            port=port,
-            provider=provider,
-            model=model,
-        )
-        self._facade = DefaultMemoryRuntimeFacade(
-            port=port,
-            explicit_retriever=explicit_retriever,
-        )
+        self._facade = facade
 
     async def execute(
         self,
@@ -176,7 +146,7 @@ class RecallMemoryTool(Tool):
                 time_end=end,
             )
         )
-        return _build_response(result.hits)
+        return _build_response(cast(list[_MemoryHit], result.hits))
 
 
 def _hit_score(item: _MemoryHit, fallback_key: str = "score") -> float:

--- a/bootstrap/memory.py
+++ b/bootstrap/memory.py
@@ -135,15 +135,22 @@ def build_memory_runtime(
     )
     memory_engine = cast(MemoryEngine, engine)
     from agent.tools.recall_memory import RecallMemoryTool
+    from core.memory.explicit_retriever import DefaultExplicitRetriever
 
     memorize_tool = MemorizeTool(memory_engine)
     forget_tool = ForgetMemoryTool(mem2_store)
-    recall_tool = RecallMemoryTool(
-        store=mem2_store,
-        embedder=embedder,
+    explicit_retriever = DefaultExplicitRetriever(
+        port=port,
         provider=light_provider or provider,
         model=config.light_model or config.model,
     )
+    facade = DefaultMemoryRuntimeFacade(
+        port=port,
+        engine=memory_engine,
+        profile_maint=port,
+        explicit_retriever=explicit_retriever,
+    )
+    recall_tool = RecallMemoryTool(facade=facade)
     register_memory_meta_tools(
         tools,
         memorize_tool=memorize_tool,
@@ -151,11 +158,6 @@ def build_memory_runtime(
         recall_tool=recall_tool,
         write_file_tool=WriteFileTool(),
         edit_file_tool=EditFileTool(),
-    )
-    facade = DefaultMemoryRuntimeFacade(
-        port=port,
-        engine=memory_engine,
-        profile_maint=port,
     )
 
     return MemoryRuntime(

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -243,6 +243,7 @@ class DefaultRetrievalSemantics:
         workspace: Path,
         light_model: str,
     ) -> None:
+        self._config = config
         self._gate_resolver = _GateResolver(
             memory=memory,
             config=config,

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, TypedDict,
 from agent.looping.memory_gate import (
     _decide_history_route,
     _format_gate_history,
-    _trace_memory_retrieve,
     _trace_route_reason,
 )
 from core.memory.engine import (
@@ -38,7 +37,7 @@ from core.memory.runtime_facade import (
 if TYPE_CHECKING:
     from agent.core.types import HistoryMessage
     from agent.looping.ports import LLMServices, MemoryConfig, MemoryServices
-    from core.observe.events import RagTrace
+    from core.observe.events import RagQueryLog
     from core.memory.engine import MemoryEngine
     from core.memory.port import MemoryPort
     from core.memory.profile import ProfileMaintenanceStore
@@ -290,7 +289,6 @@ class DefaultRetrievalSemantics:
         self._finalizer = _MemoryRetrievalFinalizer(
             memory=memory,
             config=config,
-            workspace=workspace,
         )
 
     async def retrieve_context(
@@ -298,7 +296,7 @@ class DefaultRetrievalSemantics:
         request: ContextRetrievalRequest,
     ) -> ContextRetrievalResult:
         retrieved_block = ""
-        rag_trace: RagTrace | None = None
+        rag_trace: RagQueryLog | None = None
         gate_type = "history_route"
         sufficiency_trace: dict[str, object] = _empty_sufficiency_state()
         p_items: list[dict] = []
@@ -354,22 +352,13 @@ class DefaultRetrievalSemantics:
             rag_trace = self._finalizer.finalize(
                 session_key=request.session_key,
                 message=request.message,
-                channel=request.channel,
-                chat_id=request.chat_id,
-                gate_type=gate_type,
-                route_decision=route_decision,
-                rewritten_query=rewritten_query,
-                route_ms=route_ms,
-                fallback_reason=fallback_reason,
-                gate_latency_ms=gate_latency_ms,
                 p_items=p_items,
                 h_items=h_items,
-                h_scope_mode=h_scope_mode,
                 hyde_hypothesis=hyde_hypothesis,
-                selected_items=selected_items,
-                retrieved_block=retrieved_block,
                 injected_item_ids=injected_item_ids,
-                sufficiency_trace=sufficiency_trace,
+                rewritten_query=rewritten_query,
+                route_decision=route_decision,
+                config=self._config,
             )
         except Exception as e:
             logger.warning("memory2 retrieve 失败，跳过: %s", e)
@@ -518,55 +507,33 @@ class _MemoryRetrievalFinalizer:
         *,
         memory: "MemoryServices",
         config: "MemoryConfig",
-        workspace: Path,
     ) -> None:
         self._memory = memory
         self._config = config
-        self._workspace = workspace
 
     def finalize(
         self,
         *,
         session_key: str,
         message: str,
-        channel: str,
-        chat_id: str,
-        gate_type: str,
-        route_decision: str,
-        rewritten_query: str,
-        route_ms: int,
-        fallback_reason: str,
-        gate_latency_ms: dict[str, int],
         p_items: list[dict],
         h_items: list[dict],
-        h_scope_mode: str,
         hyde_hypothesis: str | None,
-        selected_items: list[dict],
-        retrieved_block: str,
         injected_item_ids: list[str],
-        sufficiency_trace: dict[str, object],
-    ) -> RagTrace:
+        rewritten_query: str,
+        route_decision: str,
+        config: "MemoryConfig",
+    ) -> "RagQueryLog":
         return _finalize_memory_retrieval(
             session_key=session_key,
             message=message,
-            channel=channel,
-            chat_id=chat_id,
-            gate_type=gate_type,
-            route_decision=route_decision,
-            rewritten_query=rewritten_query,
-            route_ms=route_ms,
-            fallback_reason=fallback_reason,
-            gate_latency_ms=gate_latency_ms,
             p_items=p_items,
             h_items=h_items,
-            h_scope_mode=h_scope_mode,
             hyde_hypothesis=hyde_hypothesis,
-            selected_items=selected_items,
-            retrieved_block=retrieved_block,
             injected_item_ids=injected_item_ids,
-            sufficiency_trace=sufficiency_trace,
-            workspace=self._workspace,
-            config=self._config,
+            rewritten_query=rewritten_query,
+            route_decision=route_decision,
+            config=config,
         )
 
     def trace_exception(
@@ -579,35 +546,15 @@ class _MemoryRetrievalFinalizer:
         gate_type: str,
         sufficiency_trace: dict[str, object],
         error: Exception,
-    ) -> RagTrace:
-        _trace_memory_retrieve(
-            self._workspace,
-            session_key=session_key,
-            channel=channel,
-            chat_id=chat_id,
-            user_msg=message,
-            items=[],
-            injected_block="",
-            gate_type=gate_type,
-            fallback_reason="retrieve_exception",
-            sufficiency_check=sufficiency_trace,
-            error=str(error),
-        )
-        return _build_agent_rag_trace(
+    ) -> "RagQueryLog":
+        return _build_rag_query_log(
             session_key=session_key,
             user_msg=message,
             rewritten_query=message,
-            gate_type=gate_type,
-            route_decision=None,
-            route_latency_ms=None,
-            h_scope_mode=None,
             p_items=[],
             h_items=[],
             hyde_hypothesis=None,
             injected_id_set=set(),
-            injected_block="",
-            sufficiency_check=sufficiency_trace,
-            fallback_reason="retrieve_exception",
             error=str(error),
         )
 
@@ -1154,76 +1101,24 @@ def _finalize_memory_retrieval(
     *,
     session_key: str,
     message: str,
-    channel: str,
-    chat_id: str,
-    gate_type: str,
-    route_decision: str,
-    rewritten_query: str,
-    route_ms: int,
-    fallback_reason: str,
-    gate_latency_ms: dict[str, int],
     p_items: list[dict],
     h_items: list[dict],
-    h_scope_mode: str,
     hyde_hypothesis: str | None,
-    selected_items: list[dict],
-    retrieved_block: str,
     injected_item_ids: list[str],
-    sufficiency_trace: dict[str, object],
-    workspace: Path,
+    rewritten_query: str,
+    route_decision: str,
     config: "MemoryConfig",
-) -> "RagTrace":
-    logger.info(
-        "memory2 retrieve: route=%s scope=%s query=%r p=%d h=%d 命中，选出 %d 条，注入 %d 条%s",
-        route_decision,
-        h_scope_mode,
-        rewritten_query[:50],
-        len(p_items),
-        len(h_items),
-        len(selected_items),
-        len(injected_item_ids),
-        "" if retrieved_block else "（无内容注入）",
-    )
-    _log_memory_injection(selected_items)
-    procedure_guard_applied = _has_procedure_guard_hit(
-        procedure_items=p_items,
-        injected_item_ids=injected_item_ids,
-        config=config,
-    )
-    _trace_memory_retrieve(
-        workspace,
-        session_key=session_key,
-        channel=channel,
-        chat_id=chat_id,
-        user_msg=message,
-        items=selected_items,
-        injected_block=retrieved_block,
-        gate_type=gate_type,
-        route_decision=route_decision,
-        rewritten_query=rewritten_query,
-        fallback_reason=fallback_reason,
-        procedure_guard_applied=procedure_guard_applied,
-        procedure_hits=len(p_items),
-        history_hits=len(h_items),
-        injected_item_ids=injected_item_ids,
-        gate_latency_ms=gate_latency_ms,
-        sufficiency_check=sufficiency_trace,
-    )
-    return _build_agent_rag_trace(
+) -> "RagQueryLog":
+    _log_memory_injection([i for i in p_items + h_items if str(i.get("id", "")) in set(injected_item_ids)])
+    return _build_rag_query_log(
         session_key=session_key,
         user_msg=message,
         rewritten_query=rewritten_query,
-        gate_type=gate_type,
-        route_decision=route_decision,
-        route_latency_ms=route_ms,
-        h_scope_mode=h_scope_mode,
         p_items=p_items,
         h_items=h_items,
         hyde_hypothesis=hyde_hypothesis,
         injected_id_set=set(injected_item_ids),
-        injected_block=retrieved_block,
-        sufficiency_check=sufficiency_trace,
-        fallback_reason=fallback_reason,
+        route_decision=route_decision,
     )
 
 
@@ -1265,62 +1160,40 @@ def _has_procedure_guard_hit(
     )
 
 
-def _build_agent_rag_trace(
+def _build_rag_query_log(
     *,
     session_key: str,
     user_msg: str,
     rewritten_query: str,
-    gate_type: str | None,
-    route_decision: str | None,
-    route_latency_ms: int | None,
-    h_scope_mode: str | None,
     p_items: list[dict],
     h_items: list[dict],
     hyde_hypothesis: str | None,
     injected_id_set: set[str],
-    injected_block: str,
-    sufficiency_check: dict[str, object],
-    fallback_reason: str = "",
+    route_decision: str | None = None,
     error: str | None = None,
-) -> "RagTrace":
-    from core.observe.events import RagItemTrace, RagTrace
+) -> "RagQueryLog":
+    from core.observe.events import RagHitLog, RagQueryLog
 
-    def _item_to_trace(item: dict, path: str) -> RagItemTrace:
-        raw_extra = item.get("extra_json")
-        extra_str = json.dumps(raw_extra, ensure_ascii=False) if raw_extra else None
-        return RagItemTrace(
-            item_id=str(item.get("id", "")),
-            memory_type=str(item.get("memory_type", "")),
-            score=float(item.get("score", 0.0)),
-            summary=str(item.get("summary", "")),
-            happened_at=item.get("happened_at"),
-            extra_json=extra_str,
-            retrieval_path=path,
-            injected=str(item.get("id", "")) in injected_id_set,
-        )
+    hits: list[RagHitLog] = []
+    for item in p_items + h_items:
+        item_id = str(item.get("id", "") or "")
+        hits.append(RagHitLog(
+            item_id=item_id,
+            memory_type=str(item.get("memory_type", "") or ""),
+            score=float(item.get("score", 0.0) or 0.0),
+            summary=str(item.get("summary", "") or "")[:120],
+            injected=bool(item_id and item_id in injected_id_set),
+        ))
 
-    trace_items: list[RagItemTrace] = []
-    for item in p_items:
-        trace_items.append(_item_to_trace(item, "procedure"))
-    for item in h_items:
-        path = str(item.get("_retrieval_path", "history_raw") or "history_raw")
-        trace_items.append(_item_to_trace(item, path))
-
-    return RagTrace(
-        source="agent",
+    return RagQueryLog(
+        caller="passive",
         session_key=session_key,
-        original_query=user_msg,
         query=rewritten_query,
-        gate_type=gate_type,
+        orig_query=user_msg if user_msg != rewritten_query else None,
+        aux_queries=[hyde_hypothesis] if hyde_hypothesis else [],
+        hits=hits,
+        injected_count=sum(1 for h in hits if h.injected),
         route_decision=route_decision,
-        route_latency_ms=route_latency_ms,
-        hyde_hypothesis=hyde_hypothesis,
-        history_scope_mode=h_scope_mode,
-        history_gate_reason=None,
-        items=trace_items,
-        injected_block=injected_block,
-        sufficiency_check_json=json.dumps(sufficiency_check, ensure_ascii=False),
-        fallback_reason=fallback_reason,
         error=error,
     )
 

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import inspect
 import logging
 import asyncio
-import json
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, TypedDict, cast
@@ -21,7 +20,6 @@ from core.memory.engine import (
     RememberRequest,
     RememberResult,
 )
-from memory2.query_rewriter import GateDecision
 from core.memory.runtime_facade import (
     ConsolidationRunner,
     ContextRetrievalRequest,
@@ -207,43 +205,9 @@ class DefaultMemoryRuntimeFacade:
         self,
         request: ExplicitRetrievalRequest,
     ) -> ExplicitRetrievalResult:
-        if self._explicit_retriever is not None:
-            return await self._explicit_retriever(request)
-        types = [request.memory_type] if request.memory_type else None
-        if request.search_mode == "grep":
-            if request.time_start is None or request.time_end is None:
-                return ExplicitRetrievalResult(
-                    trace={"source": "default_runtime_facade", "mode": "grep_missing_time"}
-                )
-            hits = self._port.list_events_by_time_range(
-                request.time_start,
-                request.time_end,
-                limit=request.limit,
-            )
-            return ExplicitRetrievalResult(
-                hits=list(hits),
-                trace={"source": "default_runtime_facade", "mode": "grep_port_fallback"},
-                raw={"hits": list(hits)},
-            )
-
-        # TODO: 兼容壳；DefaultExplicitRetriever 接管前保留可用的显式检索 fallback。
-        hits = await self._port.retrieve_related(
-            request.query,
-            memory_types=types,
-            top_k=request.limit,
-            scope_channel=request.scope.channel or None,
-            scope_chat_id=request.scope.chat_id or None,
-            require_scope_match=bool(request.scope.channel and request.scope.chat_id),
-            time_start=request.time_start,
-            time_end=request.time_end,
-            score_threshold=0.35,
-            keyword_enabled=True,
-        )
-        return ExplicitRetrievalResult(
-            hits=list(hits),
-            trace={"source": "default_runtime_facade", "mode": "explicit_port_fallback"},
-            raw={"hits": list(hits)},
-        )
+        if self._explicit_retriever is None:
+            raise RuntimeError("explicit_retriever unavailable")
+        return await self._explicit_retriever(request)
 
     async def remember_explicit(self, request: RememberRequest) -> RememberResult:
         # 1. 显式记忆仍然以 engine 为 owner，facade 只做统一入口。

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -28,6 +28,9 @@ from core.memory.runtime_facade import (
     ContextRetrievalRequest,
     ContextRetrievalResult,
     ContextRetriever,
+    ExplicitRetrievalRequest,
+    ExplicitRetrievalResult,
+    ExplicitRetriever,
     InterestRetrievalRequest,
     InterestRetrievalResult,
 )
@@ -41,8 +44,8 @@ if TYPE_CHECKING:
     from core.memory.profile import ProfileMaintenanceStore
 
 
-InterestRetriever = Callable[[InterestRetrievalRequest], Awaitable[InterestRetrievalResult]]
 logger = logging.getLogger("memory.runtime_facade")
+InterestRetriever = Callable[[InterestRetrievalRequest], Awaitable[InterestRetrievalResult]]
 
 
 class _GateResult(TypedDict):
@@ -76,6 +79,7 @@ class DefaultMemoryRuntimeFacade:
         retrieval_semantics: ContextRetriever | None = None,
         consolidation_runner: ConsolidationRunner | None = None,
         interest_retriever: InterestRetriever | None = None,
+        explicit_retriever: ExplicitRetriever | None = None,
     ) -> None:
         self._port = port
         self._engine = engine
@@ -84,6 +88,7 @@ class DefaultMemoryRuntimeFacade:
         self._retrieval_semantics = retrieval_semantics
         self._consolidation_runner = consolidation_runner
         self._interest_retriever = interest_retriever
+        self._explicit_retriever = explicit_retriever
 
     def bind_context_retriever(self, retriever: ContextRetriever) -> None:
         self._context_retriever = retriever
@@ -177,7 +182,7 @@ class DefaultMemoryRuntimeFacade:
     async def retrieve_interest_block(
         self, request: InterestRetrievalRequest
     ) -> InterestRetrievalResult:
-        # 1. proactive 未来会切到 facade，这里先保留旧的 preference/profile recall 语义。
+        # TODO: 兼容壳；proactive 还保留旧的 preference/profile block 形状。
         if self._interest_retriever is not None:
             return await self._interest_retriever(request)
 
@@ -196,6 +201,48 @@ class DefaultMemoryRuntimeFacade:
             text_block="\n---\n".join(texts),
             hits=list(hits),
             trace={"source": "default_runtime_facade", "mode": "port_fallback"},
+            raw={"hits": list(hits)},
+        )
+
+    async def retrieve_explicit(
+        self,
+        request: ExplicitRetrievalRequest,
+    ) -> ExplicitRetrievalResult:
+        if self._explicit_retriever is not None:
+            return await self._explicit_retriever(request)
+        types = [request.memory_type] if request.memory_type else None
+        if request.search_mode == "grep":
+            if request.time_start is None or request.time_end is None:
+                return ExplicitRetrievalResult(
+                    trace={"source": "default_runtime_facade", "mode": "grep_missing_time"}
+                )
+            hits = self._port.list_events_by_time_range(
+                request.time_start,
+                request.time_end,
+                limit=request.limit,
+            )
+            return ExplicitRetrievalResult(
+                hits=list(hits),
+                trace={"source": "default_runtime_facade", "mode": "grep_port_fallback"},
+                raw={"hits": list(hits)},
+            )
+
+        # TODO: 兼容壳；DefaultExplicitRetriever 接管前保留可用的显式检索 fallback。
+        hits = await self._port.retrieve_related(
+            request.query,
+            memory_types=types,
+            top_k=request.limit,
+            scope_channel=request.scope.channel or None,
+            scope_chat_id=request.scope.chat_id or None,
+            require_scope_match=bool(request.scope.channel and request.scope.chat_id),
+            time_start=request.time_start,
+            time_end=request.time_end,
+            score_threshold=0.35,
+            keyword_enabled=True,
+        )
+        return ExplicitRetrievalResult(
+            hits=list(hits),
+            trace={"source": "default_runtime_facade", "mode": "explicit_port_fallback"},
             raw={"hits": list(hits)},
         )
 

--- a/core/memory/explicit_retriever.py
+++ b/core/memory/explicit_retriever.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, cast
+
+from core.memory.runtime_facade import ExplicitRetrievalRequest, ExplicitRetrievalResult
+
+if TYPE_CHECKING:
+    from agent.provider import LLMProvider, LLMResponse
+    from core.memory.port import MemoryPort
+
+logger = logging.getLogger("memory.explicit_retriever")
+
+_HYPOTHESIS_MAX_TOKENS = 80
+_HYPOTHESIS_TIMEOUT_S = 3.0
+_VECTOR_SCORE_THRESHOLD = 0.35
+_VECTOR_TOP_K = 15
+_ChatCall = Callable[..., Awaitable["LLMResponse"]]
+
+
+class DefaultExplicitRetriever:
+    def __init__(
+        self,
+        *,
+        port: "MemoryPort",
+        provider: "LLMProvider",
+        model: str,
+    ) -> None:
+        self._port = port
+        self._provider = provider
+        self._model = model
+
+    async def __call__(
+        self,
+        request: ExplicitRetrievalRequest,
+    ) -> ExplicitRetrievalResult:
+        return await self.retrieve(request)
+
+    async def retrieve(
+        self,
+        request: ExplicitRetrievalRequest,
+    ) -> ExplicitRetrievalResult:
+        if request.search_mode == "grep":
+            return self._retrieve_grep(request)
+        return await self._retrieve_semantic(request)
+
+    def _retrieve_grep(
+        self,
+        request: ExplicitRetrievalRequest,
+    ) -> ExplicitRetrievalResult:
+        if request.time_start is None or request.time_end is None:
+            return ExplicitRetrievalResult(
+                trace={"source": "default_explicit_retriever", "mode": "grep_missing_time"}
+            )
+        hits = self._port.list_events_by_time_range(
+            request.time_start,
+            request.time_end,
+            limit=request.limit,
+        )
+        return ExplicitRetrievalResult(
+            hits=list(hits),
+            trace={
+                "source": "default_explicit_retriever",
+                "mode": "grep",
+                "hit_count": len(hits),
+            },
+            raw={"hits": list(hits)},
+        )
+
+    async def _retrieve_semantic(
+        self,
+        request: ExplicitRetrievalRequest,
+    ) -> ExplicitRetrievalResult:
+        hyp1_task = asyncio.create_task(self._gen_hypothesis(request.query, style="event"))
+        hyp2_task = asyncio.create_task(self._gen_hypothesis(request.query, style="general"))
+        hyp1, hyp2 = await asyncio.gather(hyp1_task, hyp2_task)
+        aux_queries = [text for text in (hyp1, hyp2) if text]
+        types = [request.memory_type] if request.memory_type else None
+        fetch_limit = max(request.limit, _VECTOR_TOP_K)
+        hits = await self._port.retrieve_related(
+            request.query,
+            memory_types=types,
+            top_k=fetch_limit,
+            scope_channel=request.scope.channel or None,
+            scope_chat_id=request.scope.chat_id or None,
+            require_scope_match=bool(request.scope.channel and request.scope.chat_id),
+            aux_queries=aux_queries,
+            score_threshold=_VECTOR_SCORE_THRESHOLD,
+            time_start=request.time_start,
+            time_end=request.time_end,
+            keyword_enabled=True,
+        )
+        sliced = list(hits)[: request.limit]
+        logger.info(
+            "explicit_retriever: mode=semantic query=%r hits=%d hyp=[%r, %r]",
+            request.query[:60],
+            len(sliced),
+            hyp1[:50] if hyp1 else None,
+            hyp2[:50] if hyp2 else None,
+        )
+        return ExplicitRetrievalResult(
+            hits=sliced,
+            trace={
+                "source": "default_explicit_retriever",
+                "mode": "semantic",
+                "hit_count": len(sliced),
+                "hyde_hypotheses": aux_queries,
+            },
+            raw={"hits": sliced},
+        )
+
+    async def _gen_hypothesis(self, query: str, style: str) -> str | None:
+        if style == "event":
+            prompt = (
+                "你是个人助手的记忆系统。根据用户提问，生成一条**带具体时间**的假想记忆条目，"
+                "格式如 '[2026-03-08] 用户...'\n"
+                "规则：第三人称、简洁事实陈述、只输出那一条文本\n\n"
+                f"用户提问：{query}\n假想记忆条目："
+            )
+        else:
+            prompt = (
+                "你是个人助手的记忆系统。根据用户提问，生成一条假想记忆条目。\n"
+                "规则：始终生成肯定式、第三人称（'用户…'）、简洁事实陈述、只输出那一条文本\n\n"
+                f"用户提问：{query}\n假想记忆条目："
+            )
+        try:
+            chat = cast(_ChatCall, getattr(self._provider, "chat"))
+            resp = await asyncio.wait_for(
+                chat(
+                    messages=[{"role": "user", "content": prompt}],
+                    tools=[],
+                    model=self._model,
+                    max_tokens=_HYPOTHESIS_MAX_TOKENS,
+                ),
+                timeout=_HYPOTHESIS_TIMEOUT_S,
+            )
+            text = (resp.content or "").strip()
+            return text if text else None
+        except Exception as e:
+            logger.debug("explicit_retriever: hypothesis generation failed: %s", e)
+            return None

--- a/core/memory/port.py
+++ b/core/memory/port.py
@@ -5,6 +5,7 @@ core/memory/port.py — 文件层 memory port + 存量向量适配器
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -95,6 +96,11 @@ class MemoryPort(Protocol):
         scope_channel: str | None = None,
         scope_chat_id: str | None = None,
         require_scope_match: bool = False,
+        aux_queries: list[str] | None = None,
+        score_threshold: float | None = None,
+        time_start: datetime | None = None,
+        time_end: datetime | None = None,
+        keyword_enabled: bool = True,
     ) -> list[dict]: ...
 
     async def embed_query(self, query: str) -> list[float]: ...
@@ -110,6 +116,14 @@ class MemoryPort(Protocol):
     ) -> list[dict]: ...
 
     def build_injection_block(self, items: list[dict]) -> tuple[str, list[str]]: ...
+
+    def list_events_by_time_range(
+        self,
+        time_start: datetime,
+        time_end: datetime,
+        *,
+        limit: int = 200,
+    ) -> list[dict]: ...
 
     # ── v2: write ─────────────────────────────────────────────────
     async def save_item(
@@ -295,6 +309,11 @@ class DefaultMemoryPort:
         scope_channel: str | None = None,
         scope_chat_id: str | None = None,
         require_scope_match: bool = False,
+        aux_queries: list[str] | None = None,
+        score_threshold: float | None = None,
+        time_start: datetime | None = None,
+        time_end: datetime | None = None,
+        keyword_enabled: bool = True,
     ) -> list[dict]:
         """Embed query and return top-k memory items; empty list if no retriever."""
         if not self._retriever:
@@ -307,6 +326,11 @@ class DefaultMemoryPort:
                 scope_channel=scope_channel,
                 scope_chat_id=scope_chat_id,
                 require_scope_match=require_scope_match,
+                aux_queries=aux_queries,
+                score_threshold=score_threshold,
+                time_start=time_start,
+                time_end=time_end,
+                keyword_enabled=keyword_enabled,
             )
         except Exception as e:
             logger.warning("[memory_port] retrieve_related failed: %s", e)
@@ -355,6 +379,22 @@ class DefaultMemoryPort:
         except Exception as e:
             logger.warning("[memory_port] build_injection_block failed: %s", e)
             return "", []
+
+    def list_events_by_time_range(
+        self,
+        time_start: datetime,
+        time_end: datetime,
+        *,
+        limit: int = 200,
+    ) -> list[dict]:
+        store = getattr(self._retriever, "_store", None) if self._retriever else None
+        if store is None:
+            return []
+        try:
+            return store.list_events_by_time_range(time_start, time_end, limit=limit)
+        except Exception as e:
+            logger.warning("[memory_port] list_events_by_time_range failed: %s", e)
+            return []
 
     # ── v2: write ──────────────────────────────────────────────────
 

--- a/core/memory/runtime_facade.py
+++ b/core/memory/runtime_facade.py
@@ -54,8 +54,27 @@ class InterestRetrievalResult:
     raw: dict[str, object] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ExplicitRetrievalRequest:
+    query: str
+    memory_type: str = ""
+    search_mode: str = "semantic"
+    limit: int = 8
+    time_start: datetime | None = None
+    time_end: datetime | None = None
+    scope: MemoryScope = field(default_factory=MemoryScope)
+
+
+@dataclass
+class ExplicitRetrievalResult:
+    hits: list[dict] = field(default_factory=list)
+    trace: dict[str, object] = field(default_factory=dict)
+    raw: dict[str, object] = field(default_factory=dict)
+
+
 ContextRetriever = Callable[[ContextRetrievalRequest], Awaitable[ContextRetrievalResult]]
 ConsolidationRunner = Callable[[object, bool], Awaitable[None]]
+ExplicitRetriever = Callable[[ExplicitRetrievalRequest], Awaitable[ExplicitRetrievalResult]]
 
 
 @runtime_checkable
@@ -80,6 +99,10 @@ class MemoryRuntimeFacade(Protocol):
     async def retrieve_interest_block(
         self, request: InterestRetrievalRequest
     ) -> InterestRetrievalResult: ...
+
+    async def retrieve_explicit(
+        self, request: ExplicitRetrievalRequest
+    ) -> ExplicitRetrievalResult: ...
 
     async def remember_explicit(self, request: RememberRequest) -> RememberResult: ...
 

--- a/core/observe/__init__.py
+++ b/core/observe/__init__.py
@@ -1,10 +1,10 @@
-from core.observe.events import ProactiveDecisionTrace, RagItemTrace, RagTrace, TurnTrace
+from core.observe.events import ProactiveDecisionTrace, RagHitLog, RagQueryLog, TurnTrace
 from core.observe.writer import TraceWriter
 
 __all__ = [
     "TraceWriter",
     "TurnTrace",
-    "RagTrace",
-    "RagItemTrace",
+    "RagQueryLog",
+    "RagHitLog",
     "ProactiveDecisionTrace",
 ]

--- a/core/observe/db.py
+++ b/core/observe/db.py
@@ -63,6 +63,22 @@ CREATE TABLE IF NOT EXISTS rag_events (
 CREATE INDEX IF NOT EXISTS ix_re_sk_ts   ON rag_events (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_re_source  ON rag_events (source, ts);
 
+CREATE TABLE IF NOT EXISTS rag_queries (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT    NOT NULL,
+    caller         TEXT    NOT NULL,    -- passive | proactive | explicit
+    session_key    TEXT    NOT NULL,
+    query          TEXT    NOT NULL,    -- rewrite 后的检索 query
+    orig_query     TEXT,               -- 改写前原文，NULL = 未改写
+    aux_queries    TEXT,               -- JSON: ["hypothesis1", ...]  HyDE 假想条目
+    hits_json      TEXT,               -- JSON: [{id, type, score, summary, injected}]
+    injected_count INTEGER NOT NULL DEFAULT 0,
+    route_decision TEXT,               -- "RETRIEVE" | "NO_RETRIEVE" | NULL
+    error          TEXT
+);
+CREATE INDEX IF NOT EXISTS ix_rq_sk_ts  ON rag_queries (session_key, ts);
+CREATE INDEX IF NOT EXISTS ix_rq_caller ON rag_queries (caller, ts);
+
 CREATE TABLE IF NOT EXISTS rag_items (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     rag_event_id    INTEGER NOT NULL REFERENCES rag_events (id),
@@ -79,7 +95,7 @@ CREATE INDEX IF NOT EXISTS ix_ri_event ON rag_items (rag_event_id);
 CREATE INDEX IF NOT EXISTS ix_ri_item  ON rag_items (item_id);
 
 -- ─────────────────────────────────────────────
--- 4. memory_writes  post-response 记忆写入记录
+-- 5. memory_writes  post-response 记忆写入记录
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_writes (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/core/observe/db.py
+++ b/core/observe/db.py
@@ -39,30 +39,6 @@ CREATE TABLE IF NOT EXISTS turns (
 CREATE INDEX IF NOT EXISTS ix_turns_sk_ts  ON turns (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_turns_source ON turns (source, ts);
 
-CREATE TABLE IF NOT EXISTS rag_events (
-    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts                  TEXT    NOT NULL,
-    source              TEXT    NOT NULL,
-    session_key         TEXT    NOT NULL,
-    tick_id             TEXT,           -- proactive: 关联 proactive_decisions.tick_id
-    original_query      TEXT    NOT NULL,
-    query               TEXT    NOT NULL,
-    gate_type           TEXT,
-    route_decision      TEXT,
-    route_latency_ms    INTEGER,
-    hyde_hypothesis     TEXT,
-    history_scope_mode  TEXT,
-    history_gate_reason TEXT,
-    injected_block      TEXT,
-    preference_block    TEXT,
-    preference_query    TEXT,
-    sufficiency_check_json TEXT,
-    fallback_reason     TEXT,
-    error               TEXT
-);
-CREATE INDEX IF NOT EXISTS ix_re_sk_ts   ON rag_events (session_key, ts);
-CREATE INDEX IF NOT EXISTS ix_re_source  ON rag_events (source, ts);
-
 CREATE TABLE IF NOT EXISTS rag_queries (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     ts             TEXT    NOT NULL,
@@ -79,23 +55,8 @@ CREATE TABLE IF NOT EXISTS rag_queries (
 CREATE INDEX IF NOT EXISTS ix_rq_sk_ts  ON rag_queries (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_rq_caller ON rag_queries (caller, ts);
 
-CREATE TABLE IF NOT EXISTS rag_items (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    rag_event_id    INTEGER NOT NULL REFERENCES rag_events (id),
-    item_id         TEXT    NOT NULL,
-    memory_type     TEXT    NOT NULL,
-    score           REAL    NOT NULL,
-    summary         TEXT    NOT NULL,
-    happened_at     TEXT,
-    extra_json      TEXT,
-    retrieval_path  TEXT    NOT NULL,
-    injected        INTEGER NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS ix_ri_event ON rag_items (rag_event_id);
-CREATE INDEX IF NOT EXISTS ix_ri_item  ON rag_items (item_id);
-
 -- ─────────────────────────────────────────────
--- 5. memory_writes  post-response 记忆写入记录
+-- 3. memory_writes  post-response 记忆写入记录
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_writes (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -194,12 +155,6 @@ _PROACTIVE_DECISION_COLUMNS: dict[str, str] = {
     "fact_claims_count": "INTEGER",
 }
 
-_RAG_EVENT_COLUMNS: dict[str, str] = {
-    "tick_id": "TEXT",
-    "gate_type": "TEXT",
-    "sufficiency_check_json": "TEXT",
-}
-
 _TURNS_COLUMNS: dict[str, str] = {
     "tool_chain_json": "TEXT",
     "raw_llm_output": "TEXT",
@@ -227,7 +182,7 @@ def _ensure_turns_columns(conn: sqlite3.Connection) -> None:
     for col, ddl in _TURNS_COLUMNS.items():
         if col in cols:
             continue
-        conn.execute(f"ALTER TABLE turns ADD COLUMN {col} {ddl}")
+        _ = conn.execute(f"ALTER TABLE turns ADD COLUMN {col} {ddl}")
 
 
 def _ensure_proactive_decision_columns(conn: sqlite3.Connection) -> None:
@@ -237,25 +192,12 @@ def _ensure_proactive_decision_columns(conn: sqlite3.Connection) -> None:
     for col, ddl in _PROACTIVE_DECISION_COLUMNS.items():
         if col in cols:
             continue
-        conn.execute(f"ALTER TABLE proactive_decisions ADD COLUMN {col} {ddl}")
-    conn.execute(
+        _ = conn.execute(f"ALTER TABLE proactive_decisions ADD COLUMN {col} {ddl}")
+    _ = conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS ux_pd_tick_id ON proactive_decisions (tick_id)"
     )
-    conn.execute(
+    _ = conn.execute(
         "UPDATE proactive_decisions SET updated_ts = ts WHERE updated_ts IS NULL OR updated_ts = ''"
-    )
-
-
-def _ensure_rag_event_columns(conn: sqlite3.Connection) -> None:
-    cols = {
-        row[1] for row in conn.execute("PRAGMA table_info(rag_events)").fetchall()
-    }
-    for col, ddl in _RAG_EVENT_COLUMNS.items():
-        if col in cols:
-            continue
-        conn.execute(f"ALTER TABLE rag_events ADD COLUMN {col} {ddl}")
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS ix_re_tick_id ON rag_events (tick_id)"
     )
 
 
@@ -263,9 +205,8 @@ def open_db(db_path: Path) -> sqlite3.Connection:
     """打开（或新建）observe.db，初始化 schema，返回连接。"""
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
-    conn.executescript(_SCHEMA_SQL)
+    _ = conn.executescript(_SCHEMA_SQL)
     _ensure_proactive_decision_columns(conn)
-    _ensure_rag_event_columns(conn)
     _ensure_turns_columns(conn)
     conn.commit()
     return conn

--- a/core/observe/events.py
+++ b/core/observe/events.py
@@ -5,41 +5,29 @@ from typing import Literal
 
 
 @dataclass
-class RagItemTrace:
-    """一个从向量库检索到的 item，保留原始字段。"""
+class RagHitLog:
+    """一次检索中命中的单条记忆条目。"""
 
     item_id: str
     memory_type: str
     score: float
-    summary: str
-    happened_at: str | None
-    extra_json: str | None          # 原始 extra_json 序列化为 JSON string
-    retrieval_path: str             # procedure | history_raw | history_hyde | preference
-    injected: bool                  # 是否最终注入到 context
+    summary: str        # 截断 120 字符
+    injected: bool      # 是否最终注入到 context
 
 
 @dataclass
-class RagTrace:
-    """一次完整的 memory 检索事件。agent 和 proactive 共用同一结构。"""
+class RagQueryLog:
+    """一次 memory 检索事件：query → hits → injected。"""
 
-    source: Literal["agent", "proactive"]
+    caller: str                         # "passive" | "proactive" | "explicit"
     session_key: str
-    original_query: str             # 改写前的原始 query（agent: user_msg）
-    query: str                      # 实际用于检索的 query（route decision 改写后）
-    gate_type: str | None           # 'query_rewriter' | 'history_route' | None
-    route_decision: str | None      # 'RETRIEVE' | 'NO_RETRIEVE'（仅 agent）
-    route_latency_ms: int | None
-    hyde_hypothesis: str | None     # HyDE 生成的假设文本，None = 未使用
-    history_scope_mode: str | None
-    history_gate_reason: str | None
-    items: list[RagItemTrace] = field(default_factory=list)
-    injected_block: str = ""
-    preference_block: str = ""
-    preference_query: str | None = None
-    sufficiency_check_json: str | None = None
-    fallback_reason: str = ""
+    query: str                          # 实际检索用的 query（rewrite 之后）
+    orig_query: str | None              # 改写前原文，None = 未改写
+    aux_queries: list[str]              # HyDE 生成的假想条目列表
+    hits: list[RagHitLog]
+    injected_count: int
+    route_decision: str | None = None   # "RETRIEVE" | "NO_RETRIEVE"；None = 无 gate
     error: str | None = None
-    tick_id: str | None = None      # proactive: 关联 proactive_decisions.tick_id
 
 
 @dataclass

--- a/core/observe/migrate_legacy_rag.py
+++ b/core/observe/migrate_legacy_rag.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.observe.db import open_db
+
+
+@dataclass(frozen=True)
+class LegacyRagMigrationResult:
+    migrated_events: int
+    migrated_hits: int
+    dropped_tables: tuple[str, ...]
+
+
+def migrate_legacy_rag_tables(db_path: Path) -> LegacyRagMigrationResult:
+    conn = open_db(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        if not _table_exists(conn, "rag_events"):
+            return LegacyRagMigrationResult(0, 0, ())
+
+        has_items = _table_exists(conn, "rag_items")
+        events = conn.execute("SELECT * FROM rag_events ORDER BY id").fetchall()
+        migrated_hits = 0
+
+        with conn:
+            for event in events:
+                items = _load_items(conn, event["id"]) if has_items else []
+                hits, injected_count = _build_hits(items)
+                migrated_hits += len(hits)
+                _ = conn.execute(
+                    """
+                    INSERT INTO rag_queries (
+                        ts, caller, session_key, query, orig_query,
+                        aux_queries, hits_json, injected_count, route_decision, error
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        _get(event, "ts") or "",
+                        _caller_from_source(_get(event, "source")),
+                        _get(event, "session_key") or "",
+                        _get(event, "query") or _get(event, "original_query") or "",
+                        _orig_query(event),
+                        _aux_queries(event),
+                        json.dumps(hits, ensure_ascii=False) if hits else None,
+                        injected_count,
+                        _get(event, "route_decision"),
+                        _get(event, "error"),
+                    ),
+                )
+
+            if has_items:
+                _ = conn.execute("DROP TABLE rag_items")
+            _ = conn.execute("DROP TABLE rag_events")
+
+        dropped = ("rag_items", "rag_events") if has_items else ("rag_events",)
+        return LegacyRagMigrationResult(len(events), migrated_hits, dropped)
+    finally:
+        conn.close()
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _load_items(conn: sqlite3.Connection, event_id: int) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT * FROM rag_items WHERE rag_event_id = ? ORDER BY id",
+        (event_id,),
+    ).fetchall()
+
+
+def _get(row: sqlite3.Row, key: str) -> Any:
+    if key not in row.keys():
+        return None
+    return row[key]
+
+
+def _caller_from_source(source: Any) -> str:
+    if source == "proactive":
+        return "proactive"
+    if source == "explicit":
+        return "explicit"
+    return "passive"
+
+
+def _orig_query(event: sqlite3.Row) -> str | None:
+    original_query = _get(event, "original_query")
+    query = _get(event, "query")
+    if not original_query or original_query == query:
+        return None
+    return str(original_query)
+
+
+def _aux_queries(event: sqlite3.Row) -> str | None:
+    hypothesis = _get(event, "hyde_hypothesis")
+    if not hypothesis:
+        return None
+    return json.dumps([hypothesis], ensure_ascii=False)
+
+
+def _build_hits(items: list[sqlite3.Row]) -> tuple[list[dict[str, Any]], int]:
+    hits: list[dict[str, Any]] = []
+    injected_count = 0
+    for item in items:
+        injected = bool(_get(item, "injected") or 0)
+        if injected:
+            injected_count += 1
+        hits.append(
+            {
+                "id": _get(item, "item_id") or "",
+                "type": _get(item, "memory_type") or "",
+                "score": float(_get(item, "score") or 0),
+                "summary": _get(item, "summary") or "",
+                "injected": injected,
+            }
+        )
+    return hits, injected_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("db_path", type=Path)
+    args = parser.parse_args()
+
+    result = migrate_legacy_rag_tables(args.db_path)
+    print(
+        "migrated_events=%d migrated_hits=%d dropped_tables=%s"
+        % (result.migrated_events, result.migrated_hits, ",".join(result.dropped_tables))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/core/observe/retention.py
+++ b/core/observe/retention.py
@@ -1,9 +1,10 @@
 """淘汰策略：定期清理过期的 observe 数据。
 
 规则：
-  turns:       保留 180 天（error IS NOT NULL 永久保留）
-  rag_events:  保留  90 天（error IS NOT NULL 永久保留）
-  rag_items:   随 rag_events 联动删除（孤立行）
+  turns:        保留 180 天（error IS NOT NULL 永久保留）
+  rag_queries:  保留  90 天（error IS NOT NULL 永久保留）
+  rag_events:   保留  90 天（旧表，error IS NOT NULL 永久保留）
+  rag_items:    随 rag_events 联动删除（孤立行）
 
 触发：启动时后台跑一次，距上次清理超过 24h 才执行。
 """
@@ -14,10 +15,13 @@ import asyncio
 import logging
 from pathlib import Path
 
+from core.observe.db import open_db
+
 logger = logging.getLogger("observe.retention")
 
 _RETENTION_DAYS = {
     "turns": 180,
+    "rag_queries": 90,
     "rag_events": 90,
     "proactive_decisions": 90,
 }
@@ -39,9 +43,7 @@ def _should_run(db_path: Path) -> bool:
 
 
 def _run_cleanup(db_path: Path) -> None:
-    import sqlite3
-
-    conn = sqlite3.connect(str(db_path))
+    conn = open_db(db_path)
     try:
         deleted: dict[str, int] = {}
         with conn:
@@ -52,14 +54,13 @@ def _run_cleanup(db_path: Path) -> None:
                 )
                 deleted[table] = cur.rowcount
 
-            # 清理孤立 rag_items（rag_events 已被删除的）
             cur = conn.execute(
                 "DELETE FROM rag_items WHERE rag_event_id NOT IN (SELECT id FROM rag_events)"
             )
             deleted["rag_items_orphan"] = cur.rowcount
 
         logger.info("observe retention done: %s", deleted)
-        _stamp_path(db_path).write_text("ok")
+        _ = _stamp_path(db_path).write_text("ok")
     except Exception:
         logger.exception("observe retention failed")
     finally:

--- a/core/observe/retention.py
+++ b/core/observe/retention.py
@@ -3,8 +3,7 @@
 规则：
   turns:        保留 180 天（error IS NOT NULL 永久保留）
   rag_queries:  保留  90 天（error IS NOT NULL 永久保留）
-  rag_events:   保留  90 天（旧表，error IS NOT NULL 永久保留）
-  rag_items:    随 rag_events 联动删除（孤立行）
+  proactive_decisions: 保留 90 天（error IS NOT NULL 永久保留）
 
 触发：启动时后台跑一次，距上次清理超过 24h 才执行。
 """
@@ -22,7 +21,6 @@ logger = logging.getLogger("observe.retention")
 _RETENTION_DAYS = {
     "turns": 180,
     "rag_queries": 90,
-    "rag_events": 90,
     "proactive_decisions": 90,
 }
 _STAMP_FILE = ".last_cleanup"
@@ -53,11 +51,6 @@ def _run_cleanup(db_path: Path) -> None:
                     f"DELETE FROM {table} WHERE ts < {cutoff} AND error IS NULL"
                 )
                 deleted[table] = cur.rowcount
-
-            cur = conn.execute(
-                "DELETE FROM rag_items WHERE rag_event_id NOT IN (SELECT id FROM rag_events)"
-            )
-            deleted["rag_items_orphan"] = cur.rowcount
 
         logger.info("observe retention done: %s", deleted)
         _ = _stamp_path(db_path).write_text("ok")

--- a/core/observe/writer.py
+++ b/core/observe/writer.py
@@ -1,4 +1,4 @@
-"""异步 TraceWriter：把 TurnTrace / RagTrace 写入 SQLite。
+"""异步 TraceWriter：把 TurnTrace / RagQueryLog 写入 SQLite。
 
 非阻塞：调用方用 emit() put_nowait，后台 task 消费队列写 DB。
 Queue 满时 drop + 计数，不崩溃主循环。
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from core.observe.db import open_db
-from core.observe.events import MemoryWriteTrace, ProactiveDecisionTrace, RagItemTrace, RagTrace, TurnTrace
+from core.observe.events import MemoryWriteTrace, ProactiveDecisionTrace, RagQueryLog, TurnTrace
 
 logger = logging.getLogger("observe.writer")
 
@@ -44,7 +44,7 @@ class TraceWriter:
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._queue: asyncio.Queue[
-            TurnTrace | RagTrace | ProactiveDecisionTrace | MemoryWriteTrace
+            TurnTrace | RagQueryLog | ProactiveDecisionTrace | MemoryWriteTrace
         ] = asyncio.Queue(
             maxsize=_QUEUE_MAX
         )
@@ -52,7 +52,7 @@ class TraceWriter:
 
     # ── 公共接口 ─────────────────────────────────
 
-    def emit(self, event: TurnTrace | RagTrace | ProactiveDecisionTrace | MemoryWriteTrace) -> None:
+    def emit(self, event: TurnTrace | RagQueryLog | ProactiveDecisionTrace | MemoryWriteTrace) -> None:
         """非阻塞 emit。Queue 满时 drop 并记录计数。"""
         try:
             self._queue.put_nowait(event)
@@ -60,6 +60,10 @@ class TraceWriter:
             self._dropped += 1
             if self._dropped % 100 == 1:
                 logger.warning("observe queue full, total_dropped=%d", self._dropped)
+
+    async def drain(self) -> None:
+        """等待已入队事件写入完成。"""
+        await self._queue.join()
 
     async def run(self) -> None:
         """后台循环，持续消费队列写 DB。作为 asyncio task 运行。"""
@@ -72,26 +76,33 @@ class TraceWriter:
                     self._write_one(conn, event)
                 except Exception:
                     logger.exception("observe write failed for %s", type(event).__name__)
+                finally:
+                    self._queue.task_done()
         finally:
             # flush remaining on shutdown
             while not self._queue.empty():
                 try:
                     e = self._queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                try:
                     self._write_one(conn, e)
                 except Exception:
                     pass
+                finally:
+                    self._queue.task_done()
             conn.close()
             logger.info("observe writer stopped")
 
     # ── 内部写入 ─────────────────────────────────
 
     def _write_one(
-        self, conn, event: TurnTrace | RagTrace | ProactiveDecisionTrace | MemoryWriteTrace
+        self, conn, event: TurnTrace | RagQueryLog | ProactiveDecisionTrace | MemoryWriteTrace
     ) -> None:
         ts = _now_iso()
         if isinstance(event, TurnTrace):
             _write_turn(conn, event, ts)
-        elif isinstance(event, RagTrace):
+        elif isinstance(event, RagQueryLog):
             _write_rag(conn, event, ts)
         elif isinstance(event, ProactiveDecisionTrace):
             _write_proactive_decision(conn, event, ts)
@@ -147,65 +158,45 @@ def _write_turn(conn, e: TurnTrace, ts: str) -> None:
         )
 
 
-def _write_rag(conn, e: RagTrace, ts: str) -> None:
+def _write_rag(conn, e: RagQueryLog, ts: str) -> None:
+    hits_json = (
+        json.dumps(
+            [
+                {
+                    "id": h.item_id,
+                    "type": h.memory_type,
+                    "score": round(h.score, 4),
+                    "summary": h.summary,
+                    "injected": h.injected,
+                }
+                for h in e.hits
+            ],
+            ensure_ascii=False,
+        )
+        if e.hits
+        else None
+    )
     with conn:
-        cur = conn.execute(
+        conn.execute(
             """
-            INSERT INTO rag_events (
-                ts, source, session_key, tick_id,
-                original_query, query, gate_type,
-                route_decision, route_latency_ms,
-                hyde_hypothesis,
-                history_scope_mode, history_gate_reason,
-                injected_block, preference_block, preference_query,
-                sufficiency_check_json, fallback_reason, error
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO rag_queries (
+                ts, caller, session_key, query, orig_query,
+                aux_queries, hits_json, injected_count, route_decision, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 ts,
-                e.source,
+                e.caller,
                 e.session_key,
-                e.tick_id or None,
-                e.original_query,
                 e.query,
-                e.gate_type,
+                e.orig_query,
+                json.dumps(e.aux_queries, ensure_ascii=False) if e.aux_queries else None,
+                hits_json,
+                e.injected_count,
                 e.route_decision,
-                e.route_latency_ms,
-                e.hyde_hypothesis,
-                e.history_scope_mode,
-                e.history_gate_reason,
-                e.injected_block or None,
-                e.preference_block or None,
-                e.preference_query or None,
-                e.sufficiency_check_json,
-                e.fallback_reason or None,
                 e.error,
             ),
         )
-        rag_event_id = cur.lastrowid
-        if e.items:
-            conn.executemany(
-                """
-                INSERT INTO rag_items (
-                    rag_event_id, item_id, memory_type, score, summary,
-                    happened_at, extra_json, retrieval_path, injected
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        rag_event_id,
-                        item.item_id,
-                        item.memory_type,
-                        item.score,
-                        item.summary,
-                        item.happened_at,
-                        item.extra_json,
-                        item.retrieval_path,
-                        1 if item.injected else 0,
-                    )
-                    for item in e.items
-                ],
-            )
 
 
 def _write_proactive_decision(conn, e: ProactiveDecisionTrace, ts: str) -> None:

--- a/memory2/retriever.py
+++ b/memory2/retriever.py
@@ -4,15 +4,23 @@ Memory v2 检索器：查询 → top-k items + 格式化注入块
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 import json
 import logging
+import re
+from typing import cast
 
 from memory2.store import MemoryStore2
 from memory2.embedder import Embedder
 
 logger = logging.getLogger(__name__)
 
+_RRF_K = 60
+_KEYWORD_RRF_WEIGHT = 0.5
+_KEYWORD_LIMIT_FLOOR = 30
+_KEYWORD_LIMIT_MULTIPLIER = 2
+_EMBED_TIMEOUT_S = 8.0
 _LOW_CONFIDENCE_PHRASES = (
     "未在对话中明确记录",
     "无法凭记忆确认",
@@ -79,23 +87,160 @@ class Retriever:
         scope_channel: str | None = None,
         scope_chat_id: str | None = None,
         require_scope_match: bool = False,
+        aux_queries: list[str] | None = None,
+        score_threshold: float | None = None,
+        time_start: datetime | None = None,
+        time_end: datetime | None = None,
+        keyword_enabled: bool = True,
     ) -> list[dict]:
-        """embed query → cosine search → 返回命中条目列表"""
-        query_vec = await self._embedder.embed(query)
+        """embed query → vector/keyword search → RRF 融合返回命中条目列表"""
         actual_top_k = self._top_k if top_k is None else max(1, int(top_k))
-        items = self._store.vector_search(
-            query_vec=query_vec,
-            top_k=actual_top_k,
+        actual_threshold = (
+            self._score_threshold if score_threshold is None else float(score_threshold)
+        )
+        query_texts = _dedupe_texts([query, *(aux_queries or [])])
+        vector_items = await self._retrieve_vector_lanes(
+            query_texts,
+            actual_top_k=actual_top_k,
             memory_types=memory_types,
-            score_threshold=self._score_threshold,
+            score_threshold=actual_threshold,
             scope_channel=scope_channel,
             scope_chat_id=scope_chat_id,
             require_scope_match=require_scope_match,
-            hotness_alpha=self._hotness_alpha,
-            hotness_half_life_days=self._hotness_half_life_days,
+            time_start=time_start,
+            time_end=time_end,
         )
-        logger.debug(f"memory2 retrieve: query={query[:60]!r} hits={len(items)}")
+        keyword_items: list[dict] = []
+        if keyword_enabled:
+            keyword_items = self._retrieve_keyword_lane(
+                query,
+                actual_top_k=actual_top_k,
+                memory_types=memory_types,
+                scope_channel=scope_channel,
+                scope_chat_id=scope_chat_id,
+                require_scope_match=require_scope_match,
+                time_start=time_start,
+                time_end=time_end,
+            )
+        items = _rrf_merge(vector_items, keyword_items, top_n=actual_top_k)
+        logger.debug(
+            "memory2 retrieve: query=%r vector=%d keyword=%d fused=%d",
+            query[:60],
+            len(vector_items),
+            len(keyword_items),
+            len(items),
+        )
         return items
+
+    async def _retrieve_vector_lanes(
+        self,
+        query_texts: list[str],
+        *,
+        actual_top_k: int,
+        memory_types: list[str] | None,
+        score_threshold: float,
+        scope_channel: str | None,
+        scope_chat_id: str | None,
+        require_scope_match: bool,
+        time_start: datetime | None,
+        time_end: datetime | None,
+    ) -> list[dict]:
+        if not query_texts:
+            return []
+        vectors = await self._embed_lanes(query_texts)
+        if not vectors:
+            return []
+        hit_groups: list[list[dict]] = []
+        try:
+            hit_groups = self._store.vector_search_batch(
+                vectors,
+                top_k=actual_top_k,
+                memory_types=memory_types,
+                score_threshold=score_threshold,
+                scope_channel=scope_channel,
+                scope_chat_id=scope_chat_id,
+                require_scope_match=require_scope_match,
+                hotness_alpha=self._hotness_alpha,
+                hotness_half_life_days=self._hotness_half_life_days,
+                time_start=time_start,
+                time_end=time_end,
+            )
+        except Exception as e:
+            logger.debug("memory2 retrieve: vector_search_batch failed: %s", e)
+
+        seen: dict[str, dict] = {}
+        if hit_groups:
+            for hits in hit_groups:
+                for hit in hits:
+                    _remember_vector_hit(seen, hit)
+            return list(seen.values())
+
+        for vector in vectors:
+            try:
+                hits = self._store.vector_search(
+                    query_vec=vector,
+                    top_k=actual_top_k,
+                    memory_types=memory_types,
+                    score_threshold=score_threshold,
+                    scope_channel=scope_channel,
+                    scope_chat_id=scope_chat_id,
+                    require_scope_match=require_scope_match,
+                    hotness_alpha=self._hotness_alpha,
+                    hotness_half_life_days=self._hotness_half_life_days,
+                    time_start=time_start,
+                    time_end=time_end,
+                )
+            except Exception as e:
+                logger.debug("memory2 retrieve: vector_search failed: %s", e)
+                continue
+            for hit in hits:
+                _remember_vector_hit(seen, hit)
+        return list(seen.values())
+
+    async def _embed_lanes(self, query_texts: list[str]) -> list[list[float]]:
+        results = await asyncio.gather(
+            *(
+                asyncio.wait_for(
+                    self._embedder.embed(text),
+                    timeout=_EMBED_TIMEOUT_S,
+                )
+                for text in query_texts
+            ),
+            return_exceptions=True,
+        )
+        vectors: list[list[float]] = []
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning("memory2 retrieve: embed failed, fallback lane skipped: %s", result)
+                continue
+            vectors.append(cast(list[float], result))
+        return vectors
+
+    def _retrieve_keyword_lane(
+        self,
+        query: str,
+        *,
+        actual_top_k: int,
+        memory_types: list[str] | None,
+        scope_channel: str | None,
+        scope_chat_id: str | None,
+        require_scope_match: bool,
+        time_start: datetime | None,
+        time_end: datetime | None,
+    ) -> list[dict]:
+        terms = _extract_terms(query)
+        if not terms:
+            return []
+        return self._store.keyword_search_summary(
+            terms,
+            memory_types=memory_types,
+            limit=max(_KEYWORD_LIMIT_FLOOR, actual_top_k * _KEYWORD_LIMIT_MULTIPLIER),
+            time_start=time_start,
+            time_end=time_end,
+            scope_channel=scope_channel,
+            scope_chat_id=scope_chat_id,
+            require_scope_match=require_scope_match,
+        )
 
     async def embed(self, query: str) -> list[float]:
         """仅做 embedding，不触发 vector_search。"""
@@ -294,6 +439,125 @@ class Retriever:
                     seen_ids.add(item_id)
                     injected_ids.append(item_id)
         return "\n\n".join(final_parts), injected_ids
+
+
+def _dedupe_texts(texts: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for text in texts:
+        normalized = (text or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _remember_vector_hit(
+    seen: dict[str, dict],
+    hit: dict,
+) -> None:
+    hit_id = _hit_id(hit)
+    hit_score = _hit_score(hit)
+    seen_score = _hit_score(seen.get(hit_id, {}))
+    if hit_id and (hit_id not in seen or hit_score > seen_score):
+        seen[hit_id] = hit
+
+
+def _hit_id(item: dict) -> str:
+    return str(item.get("id", "") or "")
+
+
+def _hit_score(item: dict, fallback_key: str = "score") -> float:
+    raw = item.get(fallback_key)
+    if raw is None and fallback_key != "score":
+        raw = item.get("score")
+    return float(raw) if isinstance(raw, int | float) else 0.0
+
+
+_CJK_STOPWORDS = {
+    "用户", "助手", "我们", "他们", "这个", "那个", "什么", "如何", "是否",
+    "有没", "没有", "有过", "做过", "进行", "完成", "包括", "通过", "实现",
+    "行为", "内容", "相关", "情况", "问题", "方式", "时候", "时间", "目前",
+    "当前", "最近", "之前", "以前", "后来", "然后", "因为", "所以", "但是",
+    "用户在", "用户对", "的行为吗", "进行了",
+}
+
+
+def _extract_terms(query: str) -> list[str]:
+    terms: list[str] = []
+    ascii_tokens = re.findall(r"[a-zA-Z0-9_\-\.]{2,}", query)
+    terms.extend(ascii_tokens)
+
+    cjk_chunks = re.findall(r"[\u4e00-\u9fff\u3040-\u30ff]{2,}", query)
+    for chunk in cjk_chunks:
+        if len(chunk) <= 4:
+            if chunk not in _CJK_STOPWORDS:
+                terms.append(chunk)
+            continue
+        for i in range(len(chunk) - 1):
+            bigram = chunk[i:i + 2]
+            if bigram not in _CJK_STOPWORDS:
+                terms.append(bigram)
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for term in terms:
+        if term in seen:
+            continue
+        seen.add(term)
+        result.append(term)
+    return result[:20]
+
+
+def _rrf_merge(
+    vector_items: list[dict],
+    keyword_items: list[dict],
+    *,
+    top_n: int,
+    k: int = _RRF_K,
+) -> list[dict]:
+    vec_rank: dict[str, int] = {}
+    for index, item in enumerate(sorted(vector_items, key=_hit_score, reverse=True)):
+        item_id = _hit_id(item)
+        if item_id and item_id not in vec_rank:
+            vec_rank[item_id] = index + 1
+
+    keyword_rank: dict[str, int] = {}
+    for index, item in enumerate(keyword_items):
+        item_id = _hit_id(item)
+        if item_id and item_id not in keyword_rank:
+            keyword_rank[item_id] = index + 1
+
+    id_to_item: dict[str, dict] = {}
+    for item in keyword_items:
+        item_id = _hit_id(item)
+        if item_id:
+            merged_item = dict(item)
+            if "score" not in merged_item:
+                merged_item["score"] = _hit_score(merged_item, fallback_key="keyword_score")
+            id_to_item[item_id] = merged_item
+    for item in vector_items:
+        item_id = _hit_id(item)
+        if item_id:
+            id_to_item[item_id] = item
+
+    scored: list[tuple[str, float, float]] = []
+    for item_id in set(vec_rank) | set(keyword_rank):
+        rrf_score = 0.0
+        if item_id in vec_rank:
+            rrf_score += 1.0 / (k + vec_rank[item_id])
+        if item_id in keyword_rank:
+            rrf_score += _KEYWORD_RRF_WEIGHT / (k + keyword_rank[item_id])
+        scored.append((item_id, rrf_score, _hit_score(id_to_item.get(item_id, {}))))
+
+    scored.sort(key=lambda item: (item[1], item[2]), reverse=True)
+    result: list[dict] = []
+    for item_id, rrf_score, _score in scored[:top_n]:
+        item = dict(id_to_item[item_id])
+        item["rrf_score"] = rrf_score
+        result.append(item)
+    return result
 
 
 def _format_source_tag(source_ref: str | None) -> str:

--- a/memory2/store.py
+++ b/memory2/store.py
@@ -1724,6 +1724,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
         limit: int = 20,
         time_start: datetime | None = None,
         time_end: datetime | None = None,
+        scope_channel: str | None = None,
+        scope_chat_id: str | None = None,
+        require_scope_match: bool = False,
     ) -> list[dict[str, object]]:
         """对 summary 字段做 OR-LIKE 关键字检索，按命中词数降序排列。
 
@@ -1739,6 +1742,15 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
             placeholders = ",".join("?" for _ in memory_types)
             type_filter = f" AND memory_type IN ({placeholders})"
             type_params = list(memory_types)
+
+        scope_filter = ""
+        scope_params: list[str] = []
+        if require_scope_match:
+            scope_filter = (
+                " AND COALESCE(TRIM(json_extract(extra_json, '$.scope_channel')), '') = ?"
+                " AND COALESCE(TRIM(json_extract(extra_json, '$.scope_chat_id')), '') = ?"
+            )
+            scope_params = [(scope_channel or "").strip(), (scope_chat_id or "").strip()]
 
         or_conditions = " OR ".join("summary LIKE ?" for _ in terms)
         score_expr = " + ".join(
@@ -1763,7 +1775,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
             f"SELECT id, memory_type, summary, source_ref, happened_at, created_at, "
             f"reinforcement, ({score_expr}) AS kw_score "
             f"FROM memory_items "
-            f"WHERE status='active' AND ({or_conditions}){type_filter}{time_filter} "
+            f"WHERE status='active' AND ({or_conditions}){type_filter}{scope_filter}{time_filter} "
             f"ORDER BY kw_score DESC, reinforcement DESC, id ASC "
             f"LIMIT ? OFFSET ?"
         )
@@ -1774,6 +1786,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
                 like_vals
                 + like_vals
                 + type_params
+                + scope_params
                 + time_params
                 + [batch_size, offset]
             )

--- a/schema/observe.sql
+++ b/schema/observe.sql
@@ -1,6 +1,6 @@
 -- Observe DB schema
 -- Agent Loop + Proactive Loop 可观测性数据库
--- 版本：3 (2026-03-14)
+-- 版本：4 (2026-05-01)
 
 PRAGMA journal_mode = WAL;
 PRAGMA synchronous  = NORMAL;
@@ -39,62 +39,7 @@ CREATE INDEX IF NOT EXISTS ix_turns_sk_ts ON turns (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_turns_source ON turns (source, ts);
 
 -- ─────────────────────────────────────────────
--- 2. rag_events  旧版 memory 检索事件表，仅兼容历史库
--- ─────────────────────────────────────────────
-CREATE TABLE IF NOT EXISTS rag_events (
-    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts                  TEXT    NOT NULL,
-    source              TEXT    NOT NULL,   -- 'agent' | 'proactive'
-    session_key         TEXT    NOT NULL,
-    tick_id             TEXT,               -- proactive: 关联 proactive_decisions.tick_id
-    -- query 链路
-    original_query      TEXT    NOT NULL,   -- agent: user_msg; proactive: build_proactive_memory_query 输出前的原始 query
-    query               TEXT    NOT NULL,   -- 实际用于检索的 query（route decision 改写后）
-    gate_type           TEXT,
-    route_decision      TEXT,               -- 'RETRIEVE' | 'NO_RETRIEVE'（仅 agent）
-    route_latency_ms    INTEGER,
-    -- HyDE
-    hyde_hypothesis     TEXT,               -- HyDE 生成的假设文本（NULL = 未使用 HyDE）
-    -- history 检索元信息
-    history_scope_mode  TEXT,               -- scoped / global / global-fallback / disabled
-    history_gate_reason TEXT,               -- 仅 proactive
-    -- 最终注入内容（完整，不截断）
-    injected_block      TEXT,
-    preference_block    TEXT,
-    preference_query    TEXT,
-    sufficiency_check_json TEXT,
-    fallback_reason     TEXT,
-    error               TEXT
-);
-
-CREATE INDEX IF NOT EXISTS ix_re_sk_ts   ON rag_events (session_key, ts);
-CREATE INDEX IF NOT EXISTS ix_re_source  ON rag_events (source, ts);
-CREATE INDEX IF NOT EXISTS ix_re_tick_id ON rag_events (tick_id);
-
--- ─────────────────────────────────────────────
--- 3. rag_items  旧版检索 item 展开表，仅兼容历史库
--- ─────────────────────────────────────────────
-CREATE TABLE IF NOT EXISTS rag_items (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    rag_event_id    INTEGER NOT NULL REFERENCES rag_events (id),
-    -- vector_search 原始返回字段，不加工
-    item_id         TEXT    NOT NULL,
-    memory_type     TEXT    NOT NULL,       -- event | profile | procedure | preference
-    score           REAL    NOT NULL,
-    summary         TEXT    NOT NULL,       -- 完整 summary
-    happened_at     TEXT,
-    extra_json      TEXT,                   -- 原始 extra_json 序列化为 JSON string
-    -- 检索路径（区分来源）
-    retrieval_path  TEXT    NOT NULL,
-    -- procedure | history_raw | history_hyde | preference
-    injected        INTEGER NOT NULL DEFAULT 0  -- 1 = 最终注入到 context
-);
-
-CREATE INDEX IF NOT EXISTS ix_ri_event ON rag_items (rag_event_id);
-CREATE INDEX IF NOT EXISTS ix_ri_item  ON rag_items (item_id);
-
--- ─────────────────────────────────────────────
--- 4. rag_queries  当前 memory 检索记录
+-- 2. rag_queries  当前 memory 检索记录
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS rag_queries (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -114,7 +59,7 @@ CREATE INDEX IF NOT EXISTS ix_rq_sk_ts  ON rag_queries (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_rq_caller ON rag_queries (caller, ts);
 
 -- ─────────────────────────────────────────────
--- 5. memory_writes  post-response 记忆写入记录
+-- 3. memory_writes  post-response 记忆写入记录
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_writes (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -132,7 +77,7 @@ CREATE INDEX IF NOT EXISTS ix_mw_sk_ts ON memory_writes (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_mw_action ON memory_writes (action, ts);
 
 -- ─────────────────────────────────────────────
--- 6. proactive_decisions  主动链路关键决策
+-- 4. proactive_decisions  主动链路关键决策
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS proactive_decisions (
     id                               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -188,7 +133,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_pd_tick_id ON proactive_decisions (tick_id)
 -- turns:               180 天
 -- rag_queries:          90 天
 -- proactive_decisions:  90 天
--- rag_events:           90 天（旧表兼容，不再由当前 writer 写入）
--- rag_items:            随 rag_events 清理孤立行
 -- 例外：error IS NOT NULL 的行永久保留
 -- ─────────────────────────────────────────────

--- a/schema/observe.sql
+++ b/schema/observe.sql
@@ -39,7 +39,7 @@ CREATE INDEX IF NOT EXISTS ix_turns_sk_ts ON turns (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_turns_source ON turns (source, ts);
 
 -- ─────────────────────────────────────────────
--- 2. rag_events  每次 memory 检索事件
+-- 2. rag_events  旧版 memory 检索事件表，仅兼容历史库
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS rag_events (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -72,7 +72,7 @@ CREATE INDEX IF NOT EXISTS ix_re_source  ON rag_events (source, ts);
 CREATE INDEX IF NOT EXISTS ix_re_tick_id ON rag_events (tick_id);
 
 -- ─────────────────────────────────────────────
--- 3. rag_items  每个检索到的 item 展开一行（raw data）
+-- 3. rag_items  旧版检索 item 展开表，仅兼容历史库
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS rag_items (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -94,7 +94,27 @@ CREATE INDEX IF NOT EXISTS ix_ri_event ON rag_items (rag_event_id);
 CREATE INDEX IF NOT EXISTS ix_ri_item  ON rag_items (item_id);
 
 -- ─────────────────────────────────────────────
--- 4. memory_writes  post-response 记忆写入记录
+-- 4. rag_queries  当前 memory 检索记录
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS rag_queries (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT    NOT NULL,
+    caller         TEXT    NOT NULL,    -- passive | proactive | explicit
+    session_key    TEXT    NOT NULL,
+    query          TEXT    NOT NULL,    -- rewrite 后的检索 query
+    orig_query     TEXT,               -- 改写前原文，NULL = 未改写
+    aux_queries    TEXT,               -- JSON: ["hypothesis1", ...]  HyDE 假想条目
+    hits_json      TEXT,               -- JSON: [{id, type, score, summary, injected}]
+    injected_count INTEGER NOT NULL DEFAULT 0,
+    route_decision TEXT,               -- "RETRIEVE" | "NO_RETRIEVE" | NULL
+    error          TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_rq_sk_ts  ON rag_queries (session_key, ts);
+CREATE INDEX IF NOT EXISTS ix_rq_caller ON rag_queries (caller, ts);
+
+-- ─────────────────────────────────────────────
+-- 5. memory_writes  post-response 记忆写入记录
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_writes (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -112,7 +132,7 @@ CREATE INDEX IF NOT EXISTS ix_mw_sk_ts ON memory_writes (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_mw_action ON memory_writes (action, ts);
 
 -- ─────────────────────────────────────────────
--- 5. proactive_decisions  主动链路关键决策
+-- 6. proactive_decisions  主动链路关键决策
 -- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS proactive_decisions (
     id                               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -165,8 +185,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_pd_tick_id ON proactive_decisions (tick_id)
 
 -- ─────────────────────────────────────────────
 -- 淘汰策略（由 retention.py 执行，不在 schema 里 enforce）
--- turns:      180 天
--- rag_events:  90 天
--- rag_items:   90 天（随 rag_events 级联）
+-- turns:               180 天
+-- rag_queries:          90 天
+-- proactive_decisions:  90 天
+-- rag_events:           90 天（旧表兼容，不再由当前 writer 写入）
+-- rag_items:            随 rag_events 清理孤立行
 -- 例外：error IS NOT NULL 的行永久保留
 -- ─────────────────────────────────────────────

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -114,6 +114,7 @@ async def test_default_memory_engine_retrieve_falls_back_to_session_scope():
     assert kwargs["scope_channel"] == "telegram"
     assert kwargs["scope_chat_id"] == "test_user"
     assert kwargs["require_scope_match"] is True
+    assert "keyword_only_enabled" not in kwargs
 
 
 async def test_default_engine_keeps_history_injected_ids():

--- a/tests/test_memory_retrieval_facade_phase2.py
+++ b/tests/test_memory_retrieval_facade_phase2.py
@@ -138,6 +138,7 @@ async def test_default_retrieval_semantics_returns_rich_context_result(tmp_path:
     assert result.trace["route_decision"] == "RETRIEVE"
     assert result.trace["gate_type"] == "history_route"
     assert result.raw["rewritten_query"] == "改写问题"
+    assert finalizer.finalize.call_args.kwargs["config"] is semantics._config
 
 
 @pytest.mark.asyncio

--- a/tests/test_observe_writer.py
+++ b/tests/test_observe_writer.py
@@ -1,11 +1,13 @@
 import asyncio
 from contextlib import suppress
+import json
 import sqlite3
 
 import pytest
 
 from core.observe.db import open_db
 from core.observe.events import ProactiveDecisionTrace, RagHitLog, RagQueryLog, TurnTrace
+from core.observe.migrate_legacy_rag import migrate_legacy_rag_tables
 from core.observe.retention import _run_cleanup
 from core.observe.writer import _write_proactive_decision, _write_turn
 from core.observe.writer import TraceWriter
@@ -285,81 +287,31 @@ async def test_trace_writer_drain_waits_for_rag_query(tmp_path):
     assert '"id": "m1"' in row[6]
 
 
-def test_retention_cleans_legacy_rag_events_and_orphan_items(tmp_path):
+def test_open_db_does_not_create_legacy_rag_tables(tmp_path):
     db_path = tmp_path / "observe.db"
     conn = open_db(db_path)
     try:
-        with conn:
-            old_event = conn.execute(
-                """
-                insert into rag_events (
-                    ts, source, session_key, original_query, query
-                ) values (
-                    datetime('now', '-91 days'), 'agent', 'cli:1', '旧问题', '旧问题'
-                )
-                """
-            ).lastrowid
-            kept_event = conn.execute(
-                """
-                insert into rag_events (
-                    ts, source, session_key, original_query, query, error
-                ) values (
-                    datetime('now', '-91 days'), 'agent', 'cli:1', '错误问题', '错误问题', 'failed'
-                )
-                """
-            ).lastrowid
-            conn.execute(
-                """
-                insert into rag_items (
-                    rag_event_id, item_id, memory_type, score, summary, retrieval_path
-                ) values (?, 'old-item', 'event', 0.8, '旧记忆', 'history_raw')
-                """,
-                (old_event,),
-            )
-            conn.execute(
-                """
-                insert into rag_items (
-                    rag_event_id, item_id, memory_type, score, summary, retrieval_path
-                ) values (?, 'kept-item', 'event', 0.8, '保留记忆', 'history_raw')
-                """,
-                (kept_event,),
-            )
-    finally:
-        conn.close()
-
-    _run_cleanup(db_path)
-
-    conn = sqlite3.connect(str(db_path))
-    try:
-        event_count = conn.execute("select count(*) from rag_events").fetchone()[0]
-        item_ids = [
+        tables = {
             row[0]
             for row in conn.execute(
-                "select item_id from rag_items order by item_id"
+                "select name from sqlite_master where type = 'table'"
             ).fetchall()
-        ]
+        }
     finally:
         conn.close()
 
-    assert event_count == 1
-    assert item_ids == ["kept-item"]
+    assert "rag_queries" in tables
+    assert "rag_events" not in tables
+    assert "rag_items" not in tables
 
 
-def test_retention_initializes_missing_rag_queries_for_old_db(tmp_path):
+def test_migrate_legacy_rag_tables_moves_events_into_rag_queries(tmp_path):
     db_path = tmp_path / "observe.db"
     conn = sqlite3.connect(str(db_path))
     try:
         with conn:
             conn.executescript(
                 """
-                create table turns (
-                    id integer primary key autoincrement,
-                    ts text not null,
-                    source text not null,
-                    session_key text not null,
-                    llm_output text not null default '',
-                    error text
-                );
                 create table rag_events (
                     id integer primary key autoincrement,
                     ts text not null,
@@ -367,6 +319,8 @@ def test_retention_initializes_missing_rag_queries_for_old_db(tmp_path):
                     session_key text not null,
                     original_query text not null,
                     query text not null,
+                    route_decision text,
+                    hyde_hypothesis text,
                     error text
                 );
                 create table rag_items (
@@ -379,18 +333,107 @@ def test_retention_initializes_missing_rag_queries_for_old_db(tmp_path):
                     retrieval_path text not null,
                     injected integer not null default 0
                 );
-                create table proactive_decisions (
-                    id integer primary key autoincrement,
-                    ts text not null,
-                    session_key text not null,
-                    stage text not null,
-                    error text
-                );
+                """
+            )
+            event_id = conn.execute(
+                """
                 insert into rag_events (
-                    ts, source, session_key, original_query, query
+                    ts, source, session_key, original_query, query,
+                    route_decision, hyde_hypothesis
                 ) values (
-                    datetime('now', '-91 days'), 'agent', 'cli:1', '旧问题', '旧问题'
-                );
+                    '2026-04-01T00:00:00+00:00', 'agent', 'cli:1',
+                    '原问题', '改写问题', 'RETRIEVE', '假想答案'
+                )
+                """
+            ).lastrowid
+            conn.execute(
+                """
+                insert into rag_items (
+                    rag_event_id, item_id, memory_type, score, summary,
+                    retrieval_path, injected
+                ) values (?, 'm1', 'event', 0.8, '旧记忆', 'history_raw', 1)
+                """,
+                (event_id,),
+            )
+    finally:
+        conn.close()
+
+    result = migrate_legacy_rag_tables(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            """
+            select ts, caller, session_key, query, orig_query,
+                   aux_queries, hits_json, injected_count, route_decision
+            from rag_queries
+            """
+        ).fetchone()
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "select name from sqlite_master where type = 'table'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert result.migrated_events == 1
+    assert result.migrated_hits == 1
+    assert row[0] == "2026-04-01T00:00:00+00:00"
+    assert row[1] == "passive"
+    assert row[2] == "cli:1"
+    assert row[3] == "改写问题"
+    assert row[4] == "原问题"
+    assert json.loads(row[5]) == ["假想答案"]
+    assert json.loads(row[6]) == [
+        {
+            "id": "m1",
+            "type": "event",
+            "score": 0.8,
+            "summary": "旧记忆",
+            "injected": True,
+        }
+    ]
+    assert row[7] == 1
+    assert row[8] == "RETRIEVE"
+    assert "rag_events" not in tables
+    assert "rag_items" not in tables
+
+
+def test_migrate_legacy_rag_tables_is_noop_without_legacy_tables(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = open_db(db_path)
+    conn.close()
+
+    result = migrate_legacy_rag_tables(db_path)
+
+    assert result.migrated_events == 0
+    assert result.migrated_hits == 0
+    assert result.dropped_tables == ()
+
+
+def test_retention_cleans_rag_queries(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = open_db(db_path)
+    try:
+        with conn:
+            conn.execute(
+                """
+                insert into rag_queries (
+                    ts, caller, session_key, query
+                ) values (
+                    datetime('now', '-91 days'), 'passive', 'cli:1', '旧问题'
+                )
+                """
+            )
+            conn.execute(
+                """
+                insert into rag_queries (
+                    ts, caller, session_key, query, error
+                ) values (
+                    datetime('now', '-91 days'), 'passive', 'cli:1', '错误问题', 'failed'
+                )
                 """
             )
     finally:
@@ -400,13 +443,10 @@ def test_retention_initializes_missing_rag_queries_for_old_db(tmp_path):
 
     conn = sqlite3.connect(str(db_path))
     try:
-        rag_query_cols = {
-            row[1]
-            for row in conn.execute("pragma table_info(rag_queries)").fetchall()
-        }
-        legacy_count = conn.execute("select count(*) from rag_events").fetchone()[0]
+        rows = conn.execute(
+            "select query from rag_queries order by query"
+        ).fetchall()
     finally:
         conn.close()
 
-    assert "hits_json" in rag_query_cols
-    assert legacy_count == 0
+    assert rows == [("错误问题",)]

--- a/tests/test_observe_writer.py
+++ b/tests/test_observe_writer.py
@@ -1,8 +1,14 @@
+import asyncio
+from contextlib import suppress
 import sqlite3
 
+import pytest
+
 from core.observe.db import open_db
-from core.observe.events import ProactiveDecisionTrace, TurnTrace
+from core.observe.events import ProactiveDecisionTrace, RagHitLog, RagQueryLog, TurnTrace
+from core.observe.retention import _run_cleanup
 from core.observe.writer import _write_proactive_decision, _write_turn
+from core.observe.writer import TraceWriter
 
 
 def test_write_proactive_decision_backfills_legacy_columns_for_gate_and_sense(tmp_path):
@@ -223,3 +229,184 @@ def test_open_db_creates_react_budget_columns(tmp_path):
     assert "react_final_input_tokens" in cols
     assert "react_cache_prompt_tokens" in cols
     assert "react_cache_hit_tokens" in cols
+
+
+@pytest.mark.asyncio
+async def test_trace_writer_drain_waits_for_rag_query(tmp_path):
+    db_path = tmp_path / "observe.db"
+    writer = TraceWriter(db_path)
+    task = asyncio.create_task(writer.run())
+    row = None
+    try:
+        writer.emit(
+            RagQueryLog(
+                caller="passive",
+                session_key="telegram:1",
+                query="改写问题",
+                orig_query="原问题",
+                aux_queries=[],
+                hits=[
+                    RagHitLog(
+                        item_id="m1",
+                        memory_type="event",
+                        score=0.9,
+                        summary="记忆",
+                        injected=True,
+                    )
+                ],
+                injected_count=1,
+                route_decision="RETRIEVE",
+            )
+        )
+        await writer.drain()
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                """
+                select caller, session_key, query, orig_query, injected_count,
+                       route_decision, hits_json
+                from rag_queries
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    assert row is not None
+    assert row[0] == "passive"
+    assert row[1] == "telegram:1"
+    assert row[2] == "改写问题"
+    assert row[3] == "原问题"
+    assert row[4] == 1
+    assert row[5] == "RETRIEVE"
+    assert '"id": "m1"' in row[6]
+
+
+def test_retention_cleans_legacy_rag_events_and_orphan_items(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = open_db(db_path)
+    try:
+        with conn:
+            old_event = conn.execute(
+                """
+                insert into rag_events (
+                    ts, source, session_key, original_query, query
+                ) values (
+                    datetime('now', '-91 days'), 'agent', 'cli:1', '旧问题', '旧问题'
+                )
+                """
+            ).lastrowid
+            kept_event = conn.execute(
+                """
+                insert into rag_events (
+                    ts, source, session_key, original_query, query, error
+                ) values (
+                    datetime('now', '-91 days'), 'agent', 'cli:1', '错误问题', '错误问题', 'failed'
+                )
+                """
+            ).lastrowid
+            conn.execute(
+                """
+                insert into rag_items (
+                    rag_event_id, item_id, memory_type, score, summary, retrieval_path
+                ) values (?, 'old-item', 'event', 0.8, '旧记忆', 'history_raw')
+                """,
+                (old_event,),
+            )
+            conn.execute(
+                """
+                insert into rag_items (
+                    rag_event_id, item_id, memory_type, score, summary, retrieval_path
+                ) values (?, 'kept-item', 'event', 0.8, '保留记忆', 'history_raw')
+                """,
+                (kept_event,),
+            )
+    finally:
+        conn.close()
+
+    _run_cleanup(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        event_count = conn.execute("select count(*) from rag_events").fetchone()[0]
+        item_ids = [
+            row[0]
+            for row in conn.execute(
+                "select item_id from rag_items order by item_id"
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+    assert event_count == 1
+    assert item_ids == ["kept-item"]
+
+
+def test_retention_initializes_missing_rag_queries_for_old_db(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        with conn:
+            conn.executescript(
+                """
+                create table turns (
+                    id integer primary key autoincrement,
+                    ts text not null,
+                    source text not null,
+                    session_key text not null,
+                    llm_output text not null default '',
+                    error text
+                );
+                create table rag_events (
+                    id integer primary key autoincrement,
+                    ts text not null,
+                    source text not null,
+                    session_key text not null,
+                    original_query text not null,
+                    query text not null,
+                    error text
+                );
+                create table rag_items (
+                    id integer primary key autoincrement,
+                    rag_event_id integer not null references rag_events (id),
+                    item_id text not null,
+                    memory_type text not null,
+                    score real not null,
+                    summary text not null,
+                    retrieval_path text not null,
+                    injected integer not null default 0
+                );
+                create table proactive_decisions (
+                    id integer primary key autoincrement,
+                    ts text not null,
+                    session_key text not null,
+                    stage text not null,
+                    error text
+                );
+                insert into rag_events (
+                    ts, source, session_key, original_query, query
+                ) values (
+                    datetime('now', '-91 days'), 'agent', 'cli:1', '旧问题', '旧问题'
+                );
+                """
+            )
+    finally:
+        conn.close()
+
+    _run_cleanup(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rag_query_cols = {
+            row[1]
+            for row in conn.execute("pragma table_info(rag_queries)").fetchall()
+        }
+        legacy_count = conn.execute("select count(*) from rag_events").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert "hits_json" in rag_query_cols
+    assert legacy_count == 0

--- a/tests/test_recall_memory_tool.py
+++ b/tests/test_recall_memory_tool.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import Any, TypeAlias, cast
 from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
@@ -14,6 +14,9 @@ import agent.tools.recall_memory as recall_memory_module
 import memory2.retriever as retriever_module
 from agent.provider import LLMProvider, LLMResponse
 from agent.tools.recall_memory import RecallMemoryTool
+from core.memory.default_runtime_facade import DefaultMemoryRuntimeFacade
+from core.memory.explicit_retriever import DefaultExplicitRetriever
+from core.memory.port import DefaultMemoryPort
 from memory2.embedder import Embedder
 from memory2.retriever import Retriever
 from memory2.store import MemoryStore2
@@ -31,11 +34,19 @@ _EmbeddingRow: TypeAlias = tuple[
 
 
 def _recall_tool(store: object, embedder: object, provider: object) -> RecallMemoryTool:
-    return RecallMemoryTool(
-        store=cast(MemoryStore2, store),
-        embedder=cast(Embedder, embedder),
+    retriever = Retriever(cast(MemoryStore2, store), cast(Embedder, embedder))
+    port = DefaultMemoryPort(cast(Any, store), retriever=retriever)
+    explicit_retriever = DefaultExplicitRetriever(
+        port=port,
         provider=cast(LLMProvider, provider),
         model="test-model",
+    )
+    facade = DefaultMemoryRuntimeFacade(
+        port=port,
+        explicit_retriever=explicit_retriever,
+    )
+    return RecallMemoryTool(
+        facade=facade,
     )
 
 

--- a/tests/test_recall_memory_tool.py
+++ b/tests/test_recall_memory_tool.py
@@ -11,9 +11,11 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import agent.tools.recall_memory as recall_memory_module
+import memory2.retriever as retriever_module
 from agent.provider import LLMProvider, LLMResponse
 from agent.tools.recall_memory import RecallMemoryTool
 from memory2.embedder import Embedder
+from memory2.retriever import Retriever
 from memory2.store import MemoryStore2
 
 _MemoryHit: TypeAlias = dict[str, object]
@@ -176,6 +178,34 @@ class _TimedSemanticStore:
         raise AssertionError("semantic 模式不应直接走 grep 列表")
 
 
+class _FusionStore:
+    def __init__(
+        self,
+        vector_groups: list[list[_MemoryHit]],
+        keyword_hits: list[_MemoryHit],
+    ) -> None:
+        self.vector_groups = vector_groups
+        self.keyword_hits = keyword_hits
+        self.vector_kwargs: list[dict[str, object]] = []
+        self.keyword_kwargs: list[dict[str, object]] = []
+
+    def vector_search_batch(
+        self,
+        _query_vecs: list[list[float]],
+        **kwargs: object,
+    ) -> list[list[_MemoryHit]]:
+        self.vector_kwargs.append(kwargs)
+        return self.vector_groups
+
+    def keyword_search_summary(
+        self,
+        _terms: list[str],
+        **kwargs: object,
+    ) -> list[_MemoryHit]:
+        self.keyword_kwargs.append(kwargs)
+        return self.keyword_hits
+
+
 def test_parse_time_filter_supports_presets_and_ranges(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -307,6 +337,86 @@ def test_store_semantic_searches_respect_time_range(tmp_path: Path) -> None:
     assert [item["summary"] for item in keyword_hits] == [
         "[2026-04-25 01:30] DeepSeek 今日事件"
     ]
+
+
+def test_store_keyword_search_respects_required_scope(tmp_path: Path) -> None:
+    store = MemoryStore2(tmp_path / "memory2.db")
+    store.upsert_item(
+        "event",
+        "用户在当前会话讨论支付问题",
+        None,
+        extra={"scope_channel": "telegram", "scope_chat_id": "chat-a"},
+    )
+    store.upsert_item(
+        "event",
+        "用户在其他会话讨论支付问题",
+        None,
+        extra={"scope_channel": "telegram", "scope_chat_id": "chat-b"},
+    )
+
+    hits = store.keyword_search_summary(
+        ["支付"],
+        limit=10,
+        scope_channel="telegram",
+        scope_chat_id="chat-a",
+        require_scope_match=True,
+    )
+
+    assert [item["summary"] for item in hits] == ["用户在当前会话讨论支付问题"]
+
+
+@pytest.mark.asyncio
+async def test_retriever_returns_keyword_hits_when_vector_empty() -> None:
+    store = _FusionStore(
+        vector_groups=[[]],
+        keyword_hits=[
+            {
+                "id": "kw1",
+                "memory_type": "event",
+                "summary": "用户处理过支付问题",
+                "keyword_score": 1.0,
+            }
+        ],
+    )
+    retriever = Retriever(cast(MemoryStore2, store), cast(Embedder, _StaticEmbedder()))
+
+    hits = await retriever.retrieve("支付", top_k=5)
+
+    assert [item["id"] for item in hits] == ["kw1"]
+    assert hits[0]["score"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_retriever_keeps_strong_vector_order_when_keyword_hits_are_low_rank() -> None:
+    vector_hits: list[_MemoryHit] = [
+        {
+            "id": "vec1",
+            "memory_type": "event",
+            "summary": "高质量向量命中 1",
+            "score": 0.95,
+        },
+        {
+            "id": "vec2",
+            "memory_type": "event",
+            "summary": "高质量向量命中 2",
+            "score": 0.9,
+        },
+    ]
+    keyword_hits: list[_MemoryHit] = [
+        {
+            "id": f"kw{i}",
+            "memory_type": "event",
+            "summary": f"低排名关键词命中 {i}",
+            "keyword_score": 1.0,
+        }
+        for i in range(12)
+    ]
+    store = _FusionStore(vector_groups=[vector_hits], keyword_hits=keyword_hits)
+    retriever = Retriever(cast(MemoryStore2, store), cast(Embedder, _StaticEmbedder()))
+
+    hits = await retriever.retrieve("支付", top_k=2)
+
+    assert [item["id"] for item in hits] == ["vec1", "vec2"]
 
 
 def test_store_vector_batch_reuses_time_filtered_embedding_rows(
@@ -449,7 +559,7 @@ async def test_recall_memory_semantic_mode_passes_time_range_to_searches() -> No
     assert payload["items"][0]["id"] == "deepseek"
     assert store.vector_kwargs == []
     assert store.vector_batch_kwargs
-    assert store.vector_batch_vec_count == 3
+    assert store.vector_batch_vec_count == 2
     assert store.keyword_kwargs
     assert store.vector_batch_kwargs[0]["memory_types"] is None
     assert store.vector_batch_kwargs[0]["time_start"] is not None
@@ -481,7 +591,7 @@ async def test_recall_memory_falls_back_to_keyword_when_query_embed_fails() -> N
 async def test_recall_memory_falls_back_to_keyword_when_query_embed_hangs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(recall_memory_module, "_EMBED_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(retriever_module, "_EMBED_TIMEOUT_S", 0.01)
     store = _KeywordOnlyStore()
     provider = _FakeProvider("用户处理过支付相关问题")
     tool = _recall_tool(store, _HangingEmbedder(), provider)

--- a/tests/test_strategy_trace.py
+++ b/tests/test_strategy_trace.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
-from agent.looping.memory_gate import _trace_memory_retrieve
 from core.common.strategy_trace import build_strategy_trace_envelope
 from proactive_v2.loop import ProactiveLoop
 
@@ -21,25 +20,6 @@ def test_build_strategy_trace_envelope_uses_subject_scope():
     assert payload["source"] == "agent.spawn"
     assert payload["subject"] == {"kind": "job", "id": "abcd1234"}
     assert payload["payload"] == {"status": "completed"}
-
-
-def test_route_trace_writes_strategy_envelope(tmp_path: Path):
-    _trace_memory_retrieve(
-        tmp_path,
-        session_key="telegram:1",
-        channel="telegram",
-        chat_id="1",
-        user_msg="你好",
-        items=[],
-        injected_block="",
-    )
-
-    trace_path = tmp_path / "memory" / "memory2_retrieve_trace.jsonl"
-    line = json.loads(trace_path.read_text(encoding="utf-8").strip())
-    assert line["trace_type"] == "route"
-    assert line["subject"] == {"kind": "session", "id": "telegram:1"}
-    assert line["payload"]["session_key"] == "telegram:1"
-    assert line["session_key"] == "telegram:1"
 
 
 class _ProactiveTraceLoop(ProactiveLoop):


### PR DESCRIPTION
## 背景

这次 PR 收敛 memory 检索路径，目标是让显式 recall、每轮开局注入和 observe trace 的边界更清楚，减少旧兼容路径对当前行为的干扰。

## 改动

- 将 `recall_memory` 工具改成只通过 `MemoryRuntimeFacade.retrieve_explicit()` 调用，不再支持旧的 `store/embedder/provider` 构造兼容壳。
- 将显式检索逻辑下沉到 `DefaultExplicitRetriever`，底层查库统一走 `memory2.Retriever.retrieve()` 的 vector + keyword + RRF 融合路径。
- observe RAG trace 统一写入 `rag_queries`。
- 新增一次性迁移脚本，可把旧 `rag_events/rag_items` 数据迁入 `rag_queries`，迁移完成后删除旧表。
- 运行时 schema 与 retention 不再创建和清理旧 `rag_events/rag_items` 表。
- 补充测试，锁定 `DefaultMemoryEngine` 不传 `keyword_only_enabled` 这类尚未进入契约的参数。

## 迁移

提供迁移入口：

```bash
./.venv/bin/python -m core.observe.migrate_legacy_rag /path/to/observe.db
```

脚本会在同一事务内完成旧表到 `rag_queries` 的迁移，并删除 `rag_events/rag_items`。

## 验证

- `./.venv/bin/python -m pytest tests/test_memory_engine_contract.py -q` -> `14 passed`
- 相关 memory / observe 回归此前已通过
- `pyright` 曾验证改动文件为 `0 errors`，仍有既有 warnings
