### PR TITLE
fix(session): 保留整理尾部历史以稳定缓存

### DIFF
--- a/session/manager.py
+++ b/session/manager.py
@@ -183,7 +183,6 @@ class Session:
         start_index: int | None = None,
     ) -> list[dict[str, Any]]:
         """将 session 消息展开为 LLM 可直接使用的 OpenAI 格式消息列表。"""
-        cache_tail_mode = False
         if start_index is not None:
             if max_messages <= 0:
                 return []
@@ -212,17 +211,6 @@ class Session:
                 messages = _align_to_user_boundary(messages)
             if not messages:
                 return []
-            if len(messages) > max_messages * 2:
-                self.consolidation_requested = True
-                logger.warning(
-                    "get_history: consolidated tail (%d) exceeds 2x window (%d), "
-                    "falling back to sliding window",
-                    len(messages), max_messages,
-                )
-                messages = self.messages[-max_messages:]
-                messages = _align_to_user_boundary(messages)
-            else:
-                cache_tail_mode = True
         elif max_messages <= 0:
             messages = []
         else:

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -291,15 +291,18 @@ def test_session_get_history_rewinds_consolidated_index_to_user_boundary():
     assert history[0] == {"role": "user", "content": "hello"}
 
 
-def test_session_get_history_requests_consolidation_when_tail_overflows():
+def test_session_get_history_keeps_full_consolidated_tail():
     session = Session("cli:1")
     for i in range(5):
         session.add_message("user", f"u{i}")
 
     history = session.get_history(max_messages=2, start_index=0)
 
-    assert session.consolidation_requested is True
+    assert session.consolidation_requested is False
     assert history == [
+        {"role": "user", "content": "u0"},
+        {"role": "user", "content": "u1"},
+        {"role": "user", "content": "u2"},
         {"role": "user", "content": "u3"},
         {"role": "user", "content": "u4"},
     ]


### PR DESCRIPTION
## 改动

- start_index 模式下保留 last_consolidated 之后的完整历史尾部，不再因 tail 超过窗口而回退到滑动窗口。
- 更新 session 历史测试，覆盖完整保留 consolidated tail 的行为。

## 原因

DeepSeek v4flash 的缓存未命中输入价格远高于命中价格。原逻辑在记忆整理前后可能切换历史窗口策略，导致 prompt 前缀变化，KVCache 命中率大幅下降。

## 验证

- pytest tests/test_logic_modules.py -q
- pyright session/manager.py，无错误；仍有该文件既有 unknown 类型警告。
