### PR TITLE
收紧 Drift 消息收尾契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ enabled = true
 min_interval_hours = 3  # 每次 drift 最小间隔
 ```
 
-Drift 打开后，没有可推送内容时，agent 会利用空闲时间自主执行 `drift/skills/` 下定义的任务，偶尔也会主动发一条消息。
+Drift 打开后，没有可推送内容时，agent 会利用空闲时间自主执行 `drift/skills/` 下定义的任务。本轮不打扰用户时用 `finish_drift(message_result="silent")` 静默收尾；如果已经主动发消息，则必须用 `finish_drift(message_result="sent")` 收尾。
 
 ---
 
@@ -200,33 +200,38 @@ Gateway 的设计原则是：agent 启动前所有数据已经就位，形成一
 
 ## 三、Drift 链路
 
-Proactive gateway 没有可推送内容时，进入 Drift 模式——agent 用一段空闲时间自主做一件有意义的事。
+Proactive gateway 没有 alert、feed 内容和可用 fallback context 时，进入 Drift 模式——agent 用一段空闲时间自主做一件有意义的事。
 
 ```
 AgentTick.tick()
-  └─ (gateway 没有可发内容，或 agent loop 决定不发)
-       └─ DriftRunner.run(ctx, llm_fn)
-            1. scan_skills()              # 扫描 workspace/skills/ 下的 SKILL.md 目录
-            2. 过滤 requires_mcp 未满足的 skill
-            3. 构建 system prompt         # 注入长期记忆 + RECENT_CONTEXT + skill 列表 + 最近运行记录
-            4. tool loop（max 20 步）
-                 工具：read_file / write_file / edit_file
-                       recall_memory / web_fetch / web_search
-                       fetch_messages / search_messages / shell
-                       send_message（最多一次） / finish_drift
-                       mount_server（可挂载 MCP server）
-            5. 强制落地机制：
-                 step N-3  注入警告提示
-                 step N-2  限制 schema 为 write_file/edit_file，强制写文件
-                 step N-1  强制调用 finish_drift
+  └─ DataGateway.run()
+       └─ no alert / no content / no fallback context
+            └─ DriftRunner.run(ctx, llm_fn)
+                 ├─ scan_skills()
+                 │    └─ 读取 drift/skills/ 和内建 skill 的 SKILL.md
+                 ├─ filter_skills()
+                 │    └─ 跳过 requires_mcp 未满足的 skill
+                 ├─ build_context()
+                 │    └─ 注入记忆、近期上下文、skill 列表、recent_runs[message_result]
+                 └─ tool_loop(max_steps)
+                      ├─ read_file / write_file / edit_file
+                      ├─ recall_memory / web_fetch / web_search
+                      ├─ fetch_messages / search_messages / shell
+                      ├─ message_push     # 最多一次
+                      ├─ finish_drift     # 必须声明 message_result
+                      └─ mount_server     # 可挂载 MCP server
 ```
 
 Drift 的核心约束：
 
 - 每次进入都重新比较所有 skill，不默认继续上次的
-- `send_message` 成功后只允许 `write_file` / `edit_file` / `finish_drift` 收尾
+- `message_push` 成功后只允许 `write_file` / `edit_file` / `finish_drift` 收尾
 - 发出的消息要像自然聊天，不像在汇报内部执行流程
-- 执行结束前必须调用 `finish_drift` 保存状态
+- 执行结束前必须调用 `finish_drift` 保存状态，并填写 `message_result`
+- `message_result="sent"` 要求本轮已经成功 `message_push`
+- `message_result="silent"` 要求本轮没有成功 `message_push`
+- `drift.json` 的 `recent_runs` 会记录每轮是 `sent` 还是 `silent`
+- 到达 `max_steps` 时不再强制写文件或强制 `finish_drift`；如果模型没有主动收尾，本轮保持未完成
 
 ---
 

--- a/proactive_v2/drift_runner.py
+++ b/proactive_v2/drift_runner.py
@@ -18,8 +18,6 @@ from agent.tool_hooks.base import ToolHook
 from proactive_v2.context import AgentTickContext
 from proactive_v2.drift_state import DriftStateStore, SkillMeta
 from proactive_v2.drift_tools import (
-    FORCED_FINISH_PROMPT,
-    FORCED_WRITE_PROMPT,
     DriftToolDeps,
     build_drift_tool_registry,
 )
@@ -83,7 +81,6 @@ class DriftRunner:
             self._build_runtime_context_message(skills, connected_servers),
         ]
         steps = 0
-        warned = False
 
         while steps < self.max_steps and not ctx.drift_finished:
             tool_choice: str | dict = "required"
@@ -91,34 +88,6 @@ class DriftRunner:
             # 拼接已挂载 MCP 工具的 schema
             if mounted_tool_names and shared:
                 schemas += shared.get_schemas(names=mounted_tool_names)
-
-            if steps == self.max_steps - 3 and not warned:
-                warned = True
-                logger.info("[drift] forced-landing warning at step=%d", steps)
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            "你还剩 3 步。请整理本次执行结果，"
-                            "下一步必须写入 working files，最后一步调用 finish_drift。"
-                        ),
-                    }
-                )
-            elif steps == self.max_steps - 2:
-                logger.info("[drift] forced write at step=%d", steps)
-                messages[0] = {"role": "system", "content": FORCED_WRITE_PROMPT}
-                schemas = [
-                    s for s in schemas
-                    if s["function"]["name"] in {"write_file", "edit_file"}
-                ]
-                tool_choice = "required"
-            elif steps == self.max_steps - 1:
-                logger.info("[drift] forced finish at step=%d", steps)
-                messages[0] = {"role": "system", "content": FORCED_FINISH_PROMPT}
-                tool_choice = {
-                    "type": "function",
-                    "function": {"name": "finish_drift"},
-                }
 
             if ctx.drift_message_sent:
                 allowed_after_send = {"write_file", "edit_file", "finish_drift"}
@@ -257,7 +226,9 @@ class DriftRunner:
             except Exception:
                 time_text = run_at[:16]
             recent_rows.append(
-                f"- {time_text}  {row.get('skill', '')}   {str(row.get('one_line', ''))[:150]}"
+                f"- {time_text}  {row.get('skill', '')}   "
+                f"[{row.get('message_result', 'silent')}] "
+                f"{str(row.get('one_line', ''))[:150]}"
             )
         recent_block = "\n".join(recent_rows) if recent_rows else "- (none)"
 
@@ -350,7 +321,8 @@ class DriftRunner:
             "8. 单次 run 最多只能 message_push 一次。\n"
             "9. message_push 成功后不要再调用 recall_memory / web_fetch / web_search / fetch_messages / search_messages / shell，"
             "后续只允许 write_file、edit_file 和 finish_drift 收尾。\n"
-            "10. 执行结束前必须调用 finish_drift 保存状态。\n\n"
+            "10. 执行结束前必须调用 finish_drift 保存状态，并用 message_result 标注本轮是 sent 还是 silent。\n"
+            "    如果本轮已经成功 message_push，message_result 必须是 sent；否则必须是 silent。\n\n"
             "【可用工具】\n"
             "read_file, write_file, edit_file, recall_memory, web_fetch, web_search, "
             "fetch_messages, search_messages, shell, message_push, finish_drift；"

--- a/proactive_v2/drift_state.py
+++ b/proactive_v2/drift_state.py
@@ -135,9 +135,17 @@ class DriftStateStore:
             skill = _clip(row.get("skill", ""), 80)
             run_at = _clip(row.get("run_at", ""), 80)
             one_line = _clip(row.get("one_line", ""), 150)
+            message_result = _clip(row.get("message_result", "silent"), 20)
+            if message_result not in {"sent", "silent"}:
+                message_result = "silent"
             if not skill or not run_at or not one_line:
                 continue
-            rows.append({"skill": skill, "run_at": run_at, "one_line": one_line})
+            rows.append({
+                "skill": skill,
+                "run_at": run_at,
+                "one_line": one_line,
+                "message_result": message_result,
+            })
         return {
             "version": 1,
             "recent_runs": rows[-10:],
@@ -163,6 +171,7 @@ class DriftStateStore:
         skill_used: str,
         one_line: str,
         next_action: str,
+        message_result: str,
         note: str | None,
         now_utc: datetime,
     ) -> None:
@@ -195,6 +204,7 @@ class DriftStateStore:
                 "skill": skill_name,
                 "run_at": now_utc.isoformat(),
                 "one_line": _clip(one_line, 150),
+                "message_result": message_result,
             }
         )
         payload = {

--- a/proactive_v2/drift_tools.py
+++ b/proactive_v2/drift_tools.py
@@ -15,22 +15,6 @@ from proactive_v2.outbound_text import normalize_outbound_text
 
 logger = logging.getLogger(__name__)
 
-FORCED_WRITE_PROMPT = (
-    "步数即将用尽。你必须现在调用 write_file 或 edit_file，\n"
-    "将当前 working files 更新到最新状态。\n"
-    "下一步将强制结束，请确保进度已完整写入。"
-)
-
-FORCED_FINISH_PROMPT = (
-    "你正在执行 Drift 任务，步数已用尽。\n"
-    "根据上方对话历史，立即调用 finish_drift，填写：\n"
-    "- skill_used：你执行的技能名\n"
-    "- one_line：一句话总结本次做了什么\n"
-    "- next：下次从哪里继续（一句话）\n"
-    "- note：全局备注（可选）"
-)
-
-
 @dataclass
 class DriftToolDeps:
     drift_dir: Path
@@ -124,9 +108,17 @@ class FinishDriftTool(Tool):
                 "skill_used": {"type": "string"},
                 "one_line": {"type": "string"},
                 "next": {"type": "string"},
+                "message_result": {
+                    "type": "string",
+                    "enum": ["sent", "silent"],
+                    "description": (
+                        "sent 表示本轮已经成功调用 message_push；"
+                        "silent 表示本轮确认不该打扰用户，静默结束。"
+                    ),
+                },
                 "note": {"type": "string"},
             },
-            "required": ["skill_used", "one_line", "next"],
+            "required": ["skill_used", "one_line", "next", "message_result"],
         }
 
     async def execute(
@@ -134,6 +126,7 @@ class FinishDriftTool(Tool):
         skill_used: str,
         one_line: str,
         next: str,
+        message_result: str = "",
         note: str | None = None,
         **_: Any,
     ) -> str:
@@ -150,11 +143,28 @@ class FinishDriftTool(Tool):
             return json.dumps({"error": "one_line is required"}, ensure_ascii=False)
         if not next_action:
             return json.dumps({"error": "next is required"}, ensure_ascii=False)
+        message_result_value = str(message_result or "").strip()
+        if message_result_value not in {"sent", "silent"}:
+            return json.dumps(
+                {"error": "message_result must be one of: sent, silent"},
+                ensure_ascii=False,
+            )
+        if message_result_value == "sent" and not self._ctx.drift_message_sent:
+            return json.dumps(
+                {"error": "message_result=sent requires successful message_push first"},
+                ensure_ascii=False,
+            )
+        if message_result_value == "silent" and self._ctx.drift_message_sent:
+            return json.dumps(
+                {"error": "message_result=silent conflicts with successful message_push"},
+                ensure_ascii=False,
+            )
         note_text = str(note).strip() if note is not None else None
         self._store.save_finish(
             skill_used=skill_name,
             one_line=summary,
             next_action=next_action,
+            message_result=message_result_value,
             note=note_text,
             now_utc=self._ctx.now_utc,
         )

--- a/skills/create-drift-skill/SKILL.md
+++ b/skills/create-drift-skill/SKILL.md
@@ -34,3 +34,4 @@ description: <一句话描述>
 - skill 文件必须写到工作区 `drift/skills/` 下，不要写到仓库内建目录
 - 不要为了一个一次性动作创建 skill
 - 如果只是当前 skill 的进展变化，优先更新它的 working files 或 state，而不是新建 skill
+- 结束流程必须写清 `finish_drift.message_result`：已成功推送写 `sent`，静默结束写 `silent`

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -162,6 +162,7 @@ def test_drift_system_prompt_discourages_stuck_skill_and_lists_new_tools(tmp_pat
     assert "如果这个 skill 当前明显处于“等待用户回复/等待外部条件”的状态，就不要选它" in prompt
     assert "对用户的表达要像此刻自然想到的一句聊天" in prompt
     assert "先把内部依据转写成自然联想，再说出口" in prompt
+    assert "message_result" in prompt
     assert "fetch_messages" in prompt
     assert "search_messages" in prompt
     assert "shell" in prompt
@@ -229,10 +230,93 @@ async def test_finish_drift_rejects_unknown_skill(tmp_path: Path):
         tmp_path,
         ctx,
         "finish_drift",
-        {"skill_used": "missing", "one_line": "x", "next": "y"},
+        {"skill_used": "missing", "one_line": "x", "next": "y", "message_result": "silent"},
         store=store,
     )
     assert json.loads(cast(Any, raw))["error"] == "unknown skill: missing"
+
+
+@pytest.mark.asyncio
+async def test_finish_drift_requires_message_result_to_match_actual_send(tmp_path: Path):
+    _write_skill(tmp_path)
+    store = DriftStateStore(tmp_path)
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    raw = await _exec_drift_tool(
+        tmp_path,
+        ctx,
+        "finish_drift",
+        {
+            "skill_used": "explore-curiosity",
+            "one_line": "x",
+            "next": "y",
+            "message_result": "sent",
+        },
+        store=store,
+    )
+    payload = json.loads(cast(Any, raw))
+    assert payload["error"] == "message_result=sent requires successful message_push first"
+    assert ctx.drift_finished is False
+
+
+@pytest.mark.asyncio
+async def test_finish_drift_rejects_missing_message_result(tmp_path: Path):
+    _write_skill(tmp_path)
+    store = DriftStateStore(tmp_path)
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    raw = await _exec_drift_tool(
+        tmp_path,
+        ctx,
+        "finish_drift",
+        {"skill_used": "explore-curiosity", "one_line": "x", "next": "y"},
+        store=store,
+    )
+    payload = json.loads(cast(Any, raw))
+    assert payload["error"] == "message_result must be one of: sent, silent"
+    assert ctx.drift_finished is False
+
+
+@pytest.mark.asyncio
+async def test_finish_drift_rejects_silent_after_message_sent(tmp_path: Path):
+    _write_skill(tmp_path)
+    store = DriftStateStore(tmp_path)
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    ctx.drift_message_sent = True
+    raw = await _exec_drift_tool(
+        tmp_path,
+        ctx,
+        "finish_drift",
+        {
+            "skill_used": "explore-curiosity",
+            "one_line": "x",
+            "next": "y",
+            "message_result": "silent",
+        },
+        store=store,
+    )
+    payload = json.loads(cast(Any, raw))
+    assert payload["error"] == "message_result=silent conflicts with successful message_push"
+    assert ctx.drift_finished is False
+
+
+@pytest.mark.asyncio
+async def test_finish_drift_saves_silent_message_result(tmp_path: Path):
+    _write_skill(tmp_path)
+    store = DriftStateStore(tmp_path)
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    raw = await _exec_drift_tool(
+        tmp_path,
+        ctx,
+        "finish_drift",
+        {
+            "skill_used": "explore-curiosity",
+            "one_line": "x",
+            "next": "y",
+            "message_result": "silent",
+        },
+        store=store,
+    )
+    assert json.loads(cast(Any, raw))["ok"] is True
+    assert store.load_drift()["recent_runs"][-1]["message_result"] == "silent"
 
 
 @pytest.mark.asyncio
@@ -269,6 +353,7 @@ async def test_drift_runner_runs_and_finishes(tmp_path: Path):
                     "skill_used": "explore-curiosity",
                     "one_line": "问了一个问题",
                     "next": "继续问下一个问题",
+                    "message_result": "silent",
                 },
             ),
         ]
@@ -300,7 +385,15 @@ async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
     llm = FakeLLM(
         [
             ("message_push", {"message": "hello\\n\\nfrom drift"}),
-            ("finish_drift", {"skill_used": "explore-curiosity", "one_line": "sent", "next": "next"}),
+            (
+                "finish_drift",
+                {
+                    "skill_used": "explore-curiosity",
+                    "one_line": "sent",
+                    "next": "next",
+                    "message_result": "sent",
+                },
+            ),
         ]
     )
     runner = DriftRunner(
@@ -320,11 +413,12 @@ async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
     # 第二次 llm 调用的 schemas 只能由 DriftRunner 约束为 write_file/edit_file/finish_drift；
     # FakeLLM 不记录 schemas，这里用行为结果兜底：send 后仍正常 finish。
     assert ctx.drift_finished is True
+    assert store.load_drift()["recent_runs"][-1]["message_result"] == "sent"
     send_message.assert_awaited_once_with("hello\n\nfrom drift")
 
 
 @pytest.mark.asyncio
-async def test_drift_runner_forced_write_allows_write_file_or_edit_file(tmp_path: Path):
+async def test_drift_runner_does_not_force_finish_at_step_limit(tmp_path: Path):
     _write_skill(tmp_path)
     store = DriftStateStore(tmp_path)
     captured: list[tuple[list[str], str | dict]] = []
@@ -335,15 +429,14 @@ async def test_drift_runner_forced_write_allows_write_file_or_edit_file(tmp_path
         if step == 1:
             return {"name": "read_file", "input": {"path": "skills/explore-curiosity/SKILL.md"}}
         if step == 2:
-            return {"name": "edit_file", "input": {"path": "skills/explore-curiosity/SKILL.md", "old_text": "test skill\n", "new_text": "updated\n"}}
+            return {
+                "name": "write_file",
+                "input": {"path": "skills/explore-curiosity/state.json", "content": "{}"},
+            }
         if step == 3:
             return {
-                "name": "finish_drift",
-                "input": {
-                    "skill_used": "explore-curiosity",
-                    "one_line": "updated",
-                    "next": "continue",
-                },
+                "name": "read_file",
+                "input": {"path": "skills/explore-curiosity/state.json"},
             }
         return None
 
@@ -358,8 +451,10 @@ async def test_drift_runner_forced_write_allows_write_file_or_edit_file(tmp_path
     )
     ctx = AgentTickContext(now_utc=datetime.now(timezone.utc), session_key="s")
     await runner.run(ctx, cast(Any, llm))
-    assert captured[1][1] == "required"
-    assert set(captured[1][0]) == {"write_file", "edit_file"}
+    assert "finish_drift" in captured[2][0]
+    assert "read_file" in captured[2][0]
+    assert captured[2][1] == "required"
+    assert ctx.drift_finished is False
 
 
 @pytest.mark.asyncio
@@ -376,6 +471,7 @@ async def test_agent_tick_enters_drift_and_records_action(tmp_path: Path):
                     "skill_used": "explore-curiosity",
                     "one_line": "整理了漂移状态",
                     "next": "下次继续",
+                    "message_result": "silent",
                 },
             ),
         ]
@@ -477,6 +573,7 @@ async def test_agent_tick_drift_send_message_skips_normal_post_loop(tmp_path: Pa
                     "skill_used": "explore-curiosity",
                     "one_line": "发出一条消息",
                     "next": "下次继续",
+                    "message_result": "sent",
                 },
             ),
         ]
@@ -669,7 +766,15 @@ async def test_drift_runner_keeps_skills_when_mcp_available(tmp_path: Path):
     shared = _build_shared_tools_with_mcp("calendar")
     llm = FakeLLM([
         ("read_file", {"path": "skills/needs-cal/SKILL.md"}),
-        ("finish_drift", {"skill_used": "needs-cal", "one_line": "done", "next": "next"}),
+        (
+            "finish_drift",
+            {
+                "skill_used": "needs-cal",
+                "one_line": "done",
+                "next": "next",
+                "message_result": "silent",
+            },
+        ),
     ])
     runner = DriftRunner(
         store=store,
@@ -768,7 +873,12 @@ async def test_drift_runner_executes_mounted_mcp_tool(tmp_path: Path):
         if step == 3:
             return {
                 "name": "finish_drift",
-                "input": {"skill_used": "explore-curiosity", "one_line": "used cal", "next": "next"},
+                "input": {
+                    "skill_used": "explore-curiosity",
+                    "one_line": "used cal",
+                    "next": "next",
+                    "message_result": "silent",
+                },
             }
         return None
 

--- a/tests/proactive_v2/test_pregate.py
+++ b/tests/proactive_v2/test_pregate.py
@@ -288,7 +288,15 @@ async def test_drift_interval_allows_after_window():
     state = FakeStateStore()
     state.set_last_drift_at(datetime.now(timezone.utc) - timedelta(hours=4))
     llm = FakeLLM([
-        ("finish_drift", {"skill_used": "explore-curiosity", "one_line": "x", "next": "y"}),
+        (
+            "finish_drift",
+            {
+                "skill_used": "explore-curiosity",
+                "one_line": "x",
+                "next": "y",
+                "message_result": "silent",
+            },
+        ),
     ])
     import tempfile
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 背景

这次 PR 把 Drift 的“是否发送”和“收尾行为”从 prompt 约束收紧成代码契约，避免模型在 clean / suspicious 等场景里写出与真实发送状态不一致的 finish_drift 结果。同时删除 max_steps 末尾的强制写入和强制 finish 提示，让未主动收尾的 run 保持未完成。

## 改动

- finish_drift 新增必填 message_result，只允许 sent / silent，并校验它必须和本轮真实 message_push 状态一致。
- drift.json 的 recent_runs 记录 message_result，Drift runtime context 也展示每轮 sent / silent。
- 删除 max_steps 最后三轮的 forced landing 逻辑，不再强制 write_file / edit_file 或 finish_drift。
- 更新 create-drift-skill 文档和 README 里的 Proactive Drift 说明，补齐当前收尾契约和 max_steps 行为。
- 补充回归测试，覆盖漏填、sent 未发送、silent 已发送、recent_runs 记录和到步数上限不强制 finish。

## 验证

- `pytest tests/proactive_v2/test_drift.py tests/proactive_v2/test_pregate.py`：57 passed
- `pyright proactive_v2/drift_runner.py proactive_v2/drift_tools.py`：0 errors，28 warnings（项目既有 Unknown 类型警告）
- `git diff --check`
