### PR TITLE
插件化工具循环检测

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -18,7 +18,11 @@ from agent.prompting import DEFAULT_CONTEXT_TRIM_PLANS, is_context_frame
 from agent.provider import ContentSafetyError, ContextLengthError
 from agent.retrieval.protocol import RetrievalRequest
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutor
-from agent.tool_runtime import append_assistant_tool_calls, append_tool_result, tool_call_signature
+from agent.tool_runtime import (
+    append_assistant_tool_calls,
+    append_tool_result,
+    tool_call_batch_snapshot,
+)
 from agent.tools.base import normalize_tool_result
 from agent.tools.tool_search import ToolSearchTool
 from agent.turns.outbound import OutboundDispatch, OutboundPort
@@ -97,7 +101,6 @@ logger = logging.getLogger(__name__)
 
 # ── 被动 turn 内联常量 ──────────────────────────────────────────
 _SAFETY_RETRY_RATIOS = (1.0, 0.5, 0.0)
-_TOOL_LOOP_REPEAT_LIMIT = 3
 _SUMMARY_MAX_TOKENS = 512
 _INCOMPLETE_SUMMARY_PROMPT = """当前任务未在预算内完成，请直接输出给用户的中文收尾说明（不要提及系统/工具内部细节）。
 必须包含三点：
@@ -105,6 +108,15 @@ _INCOMPLETE_SUMMARY_PROMPT = """当前任务未在预算内完成，请直接输
 2) 目前还缺什么信息或步骤；
 3) 下一步你会怎么继续。
 禁止输出"已达到最大迭代次数"这类模板句；不要输出 JSON。"""
+
+
+def _is_tool_loop_guard_denial(exec_result: object) -> bool:
+    traces = getattr(exec_result, "pre_hook_trace", ()) or ()
+    return any(
+        getattr(item, "decision", "") == "deny"
+        and str(getattr(item, "reason", "")).startswith("tool_loop_guard:")
+        for item in traces
+    )
 
 class _NoopOutboundPort:
     async def dispatch(self, outbound: OutboundDispatch) -> bool:
@@ -835,12 +847,10 @@ class DefaultReasoner(Reasoner):
         tool_event_channel: str = "",
         tool_event_chat_id: str = "",
     ) -> ReasonerResult:
-        # 1. 初始化消息上下文、本轮工具轨迹、循环检测状态。
+        # 1. 初始化消息上下文、本轮工具轨迹。
         messages = initial_messages
         tools_used: list[str] = []
         tool_chain: list[dict] = []
-        last_tool_signature = ""
-        repeat_count = 0
         # 2. 初始化本轮可见工具集合。
         visible_names: set[str] | None = None
         streamed = False
@@ -918,51 +928,32 @@ class DefaultReasoner(Reasoner):
                     iteration + 1,
                     [tc.name for tc in response.tool_calls],
                 )
-                signature = tool_call_signature(response.tool_calls)
-                if signature and signature == last_tool_signature:
-                    repeat_count += 1
-                else:
-                    repeat_count = 1
-                    last_tool_signature = signature
-
-                if repeat_count >= _TOOL_LOOP_REPEAT_LIMIT:
-                    logger.warning(
-                        "[循环检测] 工具调用连续重复%d次，强制收尾 (iteration=%d, signature=%s)",
-                        repeat_count,
-                        iteration + 1,
-                        signature[:80] if signature else "",
-                    )
-                    summary = await self._summarize_incomplete_progress(
-                        messages,
-                        reason="tool_call_loop",
-                        iteration=iteration + 1,
-                        tools_used=tools_used,
-                    )
-                    return self._build_result(
-                        reply=summary,
-                        tools_used=tools_used,
-                        tool_chain=tool_chain,
-                        visible_names=visible_names,
-                        thinking=None,
-                        streamed=False,
-                        react_input_samples=react_input_samples,
-                        cache_prompt_tokens=react_cache_prompt_tokens,
-                        cache_hit_tokens=react_cache_hit_tokens,
-                        cache_seen=react_cache_seen,
-                    )
-
                 append_assistant_tool_calls(
                     messages,
                     content=response.content,
                     tool_calls=response.tool_calls,
                     provider_fields=response.provider_fields,
                 )
+                tool_batch = tool_call_batch_snapshot(response.tool_calls)
 
                 # 6. 逐个执行本轮工具调用。
                 iter_calls: list[dict] = []
-                for tool_call in response.tool_calls:
+                for tool_batch_index, tool_call in enumerate(response.tool_calls):
                     # 6.1 deferred 工具未解锁时，先回填 select: 引导错误。
                     if visible_names is not None and tool_call.name not in visible_names:
+                        exec_result = await self._tool_executor.preflight(
+                            ToolExecutionRequest(
+                                call_id=tool_call.id,
+                                tool_name=tool_call.name,
+                                arguments=tool_call.arguments,
+                                source="passive",
+                                session_key=tool_event_session_key,
+                                channel=tool_event_channel,
+                                chat_id=tool_event_chat_id,
+                                tool_batch=tool_batch,
+                                tool_batch_index=tool_batch_index,
+                            )
+                        )
                         await self._observe_tool_call_started(
                             session_key=tool_event_session_key,
                             channel=tool_event_channel,
@@ -972,6 +963,73 @@ class DefaultReasoner(Reasoner):
                             tool_name=tool_call.name,
                             arguments=tool_call.arguments,
                         )
+                        if _is_tool_loop_guard_denial(exec_result):
+                            result = str(exec_result.output)
+                            append_tool_result(
+                                messages,
+                                tool_call_id=tool_call.id,
+                                content=result,
+                                tool_name=tool_call.name,
+                            )
+                            await self._observe_tool_call_completed(
+                                session_key=tool_event_session_key,
+                                channel=tool_event_channel,
+                                chat_id=tool_event_chat_id,
+                                iteration=iteration + 1,
+                                call_id=tool_call.id,
+                                tool_name=tool_call.name,
+                                arguments=tool_call.arguments,
+                                final_arguments=exec_result.final_arguments,
+                                status=exec_result.status,
+                                result_preview=support.log_preview(result),
+                            )
+                            iter_calls.append(
+                                {
+                                    "call_id": tool_call.id,
+                                    "name": tool_call.name,
+                                    "status": exec_result.status,
+                                    "arguments": tool_call.arguments,
+                                    "final_arguments": exec_result.final_arguments,
+                                    "pre_hook_trace": [
+                                        {
+                                            "hook_name": item.hook_name,
+                                            "event": item.event,
+                                            "matched": item.matched,
+                                            "decision": item.decision,
+                                            "reason": item.reason,
+                                            "extra_message": item.extra_message,
+                                        }
+                                        for item in exec_result.pre_hook_trace
+                                    ],
+                                    "result": result,
+                                }
+                            )
+                            for skipped in response.tool_calls[tool_batch_index + 1:]:
+                                append_tool_result(
+                                    messages,
+                                    tool_call_id=skipped.id,
+                                    content="工具调用已因重复循环检测跳过。",
+                                    tool_name=skipped.name,
+                                )
+                            tool_chain.append({"text": response.content, "calls": iter_calls})
+                            summary = await self._summarize_incomplete_progress(
+                                messages,
+                                reason="tool_call_loop",
+                                iteration=iteration + 1,
+                                tools_used=tools_used,
+                            )
+                            return self._build_result(
+                                reply=summary,
+                                tools_used=tools_used,
+                                tool_chain=tool_chain,
+                                visible_names=visible_names,
+                                thinking=None,
+                                streamed=False,
+                                react_input_samples=react_input_samples,
+                                cache_prompt_tokens=react_cache_prompt_tokens,
+                                cache_hit_tokens=react_cache_hit_tokens,
+                                cache_seen=react_cache_seen,
+                            )
                         logger.warning(
                             "[工具未解锁] LLM 尝试调用 '%s'，但该工具 schema 不可见，引导模型先 tool_search",
                             tool_call.name,
@@ -1046,6 +1104,8 @@ class DefaultReasoner(Reasoner):
                             session_key=tool_event_session_key,
                             channel=tool_event_channel,
                             chat_id=tool_event_chat_id,
+                            tool_batch=tool_batch,
+                            tool_batch_index=tool_batch_index,
                         ),
                         # 真实工具执行入口仍是 ToolRegistry.execute；
                         # hook 只负责拦截与记录，不替代 registry。
@@ -1138,6 +1198,38 @@ class DefaultReasoner(Reasoner):
                             "result": normalized.preview(),
                         }
                     )
+                    if _is_tool_loop_guard_denial(exec_result):
+                        logger.warning(
+                            "[循环检测] 插件截断重复工具调用，进入收尾 (iteration=%d, tool=%s)",
+                            iteration + 1,
+                            tool_call.name,
+                        )
+                        for skipped in response.tool_calls[tool_batch_index + 1:]:
+                            append_tool_result(
+                                messages,
+                                tool_call_id=skipped.id,
+                                content="工具调用已因重复循环检测跳过。",
+                                tool_name=skipped.name,
+                            )
+                        tool_chain.append({"text": response.content, "calls": iter_calls})
+                        summary = await self._summarize_incomplete_progress(
+                            messages,
+                            reason="tool_call_loop",
+                            iteration=iteration + 1,
+                            tools_used=tools_used,
+                        )
+                        return self._build_result(
+                            reply=summary,
+                            tools_used=tools_used,
+                            tool_chain=tool_chain,
+                            visible_names=visible_names,
+                            thinking=None,
+                            streamed=False,
+                            react_input_samples=react_input_samples,
+                            cache_prompt_tokens=react_cache_prompt_tokens,
+                            cache_hit_tokens=react_cache_hit_tokens,
+                            cache_seen=react_cache_seen,
+                        )
 
                 # 7. 本轮工具执行完后，记录 tool_chain 并追加下一轮 loop_state 提示。
                 tool_chain_group = {"text": response.content, "calls": iter_calls}

--- a/agent/lifecycle/types.py
+++ b/agent/lifecycle/types.py
@@ -236,3 +236,8 @@ class PreToolCtx:
     chat_id: str
     tool_name: str
     arguments: dict[str, Any]
+    call_id: str = ""
+    source: str = ""
+    request_text: str = ""
+    tool_batch: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    tool_batch_index: int = 0

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -477,6 +477,11 @@ class _PluginToolHook(ToolHook):
             chat_id=ctx.request.chat_id,
             tool_name=ctx.request.tool_name,
             arguments=dict(ctx.current_arguments),
+            call_id=ctx.request.call_id,
+            source=ctx.request.source,
+            request_text=ctx.request.request_text,
+            tool_batch=ctx.request.tool_batch,
+            tool_batch_index=ctx.request.tool_batch_index,
         )
         # 2. 调插件 handler，返回值决定行为
         result = self._handler(event)

--- a/agent/subagent.py
+++ b/agent/subagent.py
@@ -26,7 +26,7 @@ from agent.tool_runtime import (
     append_assistant_tool_calls,
     append_tool_result,
     prepare_toolset,
-    tool_call_signature,
+    tool_call_batch_snapshot,
 )
 from agent.tool_hooks.types import ToolExecutionResult
 from agent.tools.base import Tool, normalize_tool_result
@@ -56,7 +56,6 @@ _WARN_THRESHOLD = 5  # 剩余步数 <= 此值时开始提示
 _MAX_TOOL_RESULT_CHARS = 100_000  # 单条工具结果字符上限（约 ~25K tokens）
 _RECENT_TOOL_ROUNDS = 3  # 保留完整 tool result 的最近轮次数
 _CLEARED = "[已清除]"  # 旧 tool result 的占位符
-_TOOL_LOOP_REPEAT_LIMIT = 3  # 连续同签名工具调用达到该次数时判定循环
 _SUMMARY_MAX_TOKENS = 512
 _INCOMPLETE_SUMMARY_PROMPT = (
     "当前任务未在步骤预算内完成，请直接输出中文进度总结，不要 JSON。\n"
@@ -73,6 +72,15 @@ _FORCED_FINAL_SUMMARY_FALLBACK = (
     "这次后台任务已先停在当前进度。我已经完成了一部分关键步骤，"
     "但还有剩余工作未收束；下一次可从当前检查点继续推进。"
 )
+
+
+def _is_tool_loop_guard_denial(exec_result: object) -> bool:
+    traces = getattr(exec_result, "pre_hook_trace", ()) or ()
+    return any(
+        getattr(item, "decision", "") == "deny"
+        and str(getattr(item, "reason", "")).startswith("tool_loop_guard:")
+        for item in traces
+    )
 
 
 def _trim_tool_results(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -132,6 +140,7 @@ class SubAgent:
         self.last_exit_reason: str = "idle"
         self.iterations_used: int = 0  # 实际使用的迭代次数
         self.tools_called: list[str] = []  # 实际调用的工具名称列表
+        self._run_seq = 0
         prepared = prepare_toolset(tools)
         self._tool_map: dict[str, Tool] = prepared.tool_map
         self._tool_schemas: list[dict[str, Any]] = prepared.schemas
@@ -151,11 +160,11 @@ class SubAgent:
         self.last_exit_reason = "running"
         self.iterations_used = 0
         self.tools_called = []
+        self._run_seq += 1
+        tool_session_key = f"subagent:{id(self)}:{self._run_seq}"
         if self._system_prompt:
             messages.append({"role": "system", "content": self._system_prompt})
         messages.append({"role": "user", "content": task})
-        last_tool_signature = ""
-        repeat_count = 0
         for iteration in range(self._max_iterations):
             self.iterations_used = iteration + 1
             try:
@@ -176,28 +185,6 @@ class SubAgent:
                 self.last_exit_reason = "completed"
                 return (response.content or "").strip()
 
-            signature = tool_call_signature(response.tool_calls)
-            if signature and signature == last_tool_signature:
-                repeat_count += 1
-            else:
-                repeat_count = 1
-                last_tool_signature = signature
-
-            if repeat_count >= _TOOL_LOOP_REPEAT_LIMIT:
-                logger.warning(
-                    "[subagent] 检测到工具调用循环 signature=%s repeat=%d，提前收尾",
-                    signature[:160],
-                    repeat_count,
-                )
-                self.last_exit_reason = "tool_loop"
-                if self._mandatory_exit_tools:
-                    await self._run_mandatory_exit(messages)
-                return await self._summarize_incomplete_progress(
-                    messages,
-                    reason="tool_call_loop",
-                    iteration=iteration + 1,
-                )
-
             # 追加 assistant 消息（含 tool_calls）
             append_assistant_tool_calls(
                 messages,
@@ -205,9 +192,10 @@ class SubAgent:
                 tool_calls=response.tool_calls,
                 provider_fields=response.provider_fields,
             )
+            tool_batch = tool_call_batch_snapshot(response.tool_calls)
 
             # 执行工具
-            for tc in response.tool_calls:
+            for tool_batch_index, tc in enumerate(response.tool_calls):
                 logger.info(
                     "[subagent] 调用工具 %s args=%s",
                     tc.name,
@@ -217,6 +205,9 @@ class SubAgent:
                     tc.id,
                     tc.name,
                     tc.arguments,
+                    session_key=tool_session_key,
+                    tool_batch=tool_batch,
+                    tool_batch_index=tool_batch_index,
                 )
                 if (
                     exec_result.status == "success"
@@ -247,6 +238,26 @@ class SubAgent:
                     content=normalized,
                     tool_name=tc.name,
                 )
+                if _is_tool_loop_guard_denial(exec_result):
+                    logger.warning(
+                        "[subagent] 插件截断重复工具调用 tool=%s，提前收尾",
+                        tc.name,
+                    )
+                    self.last_exit_reason = "tool_loop"
+                    for skipped in response.tool_calls[tool_batch_index + 1:]:
+                        append_tool_result(
+                            messages,
+                            tool_call_id=skipped.id,
+                            content="工具调用已因重复循环检测跳过。",
+                            tool_name=skipped.name,
+                        )
+                    if self._mandatory_exit_tools:
+                        await self._run_mandatory_exit(messages, tool_session_key)
+                    return await self._summarize_incomplete_progress(
+                        messages,
+                        reason="tool_call_loop",
+                        iteration=iteration + 1,
+                    )
 
             remaining = self._max_iterations - iteration - 1
             if remaining == 0:
@@ -259,7 +270,7 @@ class SubAgent:
 
         logger.warning("[subagent] 已达到最大迭代次数 %d", self._max_iterations)
         if self._mandatory_exit_tools:
-            await self._run_mandatory_exit(messages)
+            await self._run_mandatory_exit(messages, tool_session_key)
         return await self._force_final_summary(
             messages,
             reason="max_iterations",
@@ -318,7 +329,11 @@ class SubAgent:
         self.last_exit_reason = "forced_summary_fallback"
         return _FORCED_FINAL_SUMMARY_FALLBACK
 
-    async def _run_mandatory_exit(self, messages: list[dict[str, Any]]) -> None:
+    async def _run_mandatory_exit(
+        self,
+        messages: list[dict[str, Any]],
+        session_key: str,
+    ) -> None:
         """强制收尾：逐个调用 mandatory_exit_tools 中的工具。"""
         for tool_name in self._mandatory_exit_tools:
             if tool_name not in self._tool_map:
@@ -351,6 +366,7 @@ class SubAgent:
                 tc.id,
                 tc.name,
                 tc.arguments,
+                session_key=session_key,
             )
             normalized = normalize_tool_result(exec_result.output)
             logger.info(
@@ -370,6 +386,10 @@ class SubAgent:
         call_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        session_key: str = "",
+        tool_batch: tuple[dict[str, Any], ...] = (),
+        tool_batch_index: int = 0,
     ):
         tool = self._tool_map.get(tool_name)
         if tool is None:
@@ -388,6 +408,9 @@ class SubAgent:
                 tool_name=tool_name,
                 arguments=arguments,
                 source="subagent",
+                session_key=session_key,
+                tool_batch=tool_batch,
+                tool_batch_index=tool_batch_index,
             ),
             _invoke,
         )

--- a/agent/tool_hooks/executor.py
+++ b/agent/tool_hooks/executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Awaitable, Callable
 
+from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import (
     HookContext,
     HookTraceItem,
@@ -22,10 +23,10 @@ class HookExecutionError(RuntimeError):
 
 
 class ToolExecutor:
-    def __init__(self, hooks: Sequence[object] | None = None) -> None:
+    def __init__(self, hooks: Sequence[ToolHook] | None = None) -> None:
         self._hooks = list(hooks or [])
 
-    def add_hooks(self, hooks: Sequence[object]) -> None:
+    def add_hooks(self, hooks: Sequence[ToolHook]) -> None:
         self._hooks.extend(hooks)
 
     async def execute(
@@ -140,6 +141,44 @@ class ToolExecutor:
             extra_messages=extra_messages,
             pre_hook_trace=pre_trace,
             post_hook_trace=post_trace,
+        )
+
+    async def preflight(
+        self,
+        request: ToolExecutionRequest,
+    ) -> ToolExecutionResult:
+        current_arguments = dict(request.arguments)
+        extra_messages: list[str] = []
+        pre_trace: list[HookTraceItem] = []
+        try:
+            denied_reason, current_arguments = await self._run_pre_hooks(
+                request=request,
+                current_arguments=current_arguments,
+                extra_messages=extra_messages,
+                traces=pre_trace,
+            )
+        except HookExecutionError as exc:
+            return ToolExecutionResult(
+                status="error",
+                output=f"工具执行出错: {exc}",
+                final_arguments=dict(current_arguments),
+                extra_messages=extra_messages,
+                pre_hook_trace=pre_trace,
+            )
+        if denied_reason:
+            return ToolExecutionResult(
+                status="denied",
+                output=denied_reason,
+                final_arguments=dict(current_arguments),
+                extra_messages=extra_messages,
+                pre_hook_trace=pre_trace,
+            )
+        return ToolExecutionResult(
+            status="success",
+            output="",
+            final_arguments=dict(current_arguments),
+            extra_messages=extra_messages,
+            pre_hook_trace=pre_trace,
         )
 
     async def _run_pre_hooks(

--- a/agent/tool_hooks/types.py
+++ b/agent/tool_hooks/types.py
@@ -19,6 +19,8 @@ class ToolExecutionRequest:
     channel: str = ""
     chat_id: str = ""
     request_text: str = ""
+    tool_batch: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    tool_batch_index: int = 0
 
 
 @dataclass
@@ -48,11 +50,23 @@ class HookTraceItem:
     extra_message: str = ""
 
 
+def _empty_str_list() -> list[str]:
+    return []
+
+
+def _empty_pre_trace() -> list[HookTraceItem]:
+    return []
+
+
+def _empty_post_trace() -> list[HookTraceItem]:
+    return []
+
+
 @dataclass
 class ToolExecutionResult:
     status: ToolExecStatus
     output: Any
     final_arguments: dict[str, Any]
-    extra_messages: list[str] = field(default_factory=list)
-    pre_hook_trace: list[HookTraceItem] = field(default_factory=list)
-    post_hook_trace: list[HookTraceItem] = field(default_factory=list)
+    extra_messages: list[str] = field(default_factory=_empty_str_list)
+    pre_hook_trace: list[HookTraceItem] = field(default_factory=_empty_pre_trace)
+    post_hook_trace: list[HookTraceItem] = field(default_factory=_empty_post_trace)

--- a/agent/tool_runtime.py
+++ b/agent/tool_runtime.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, cast
 
 from agent.tools.base import Tool, ToolResult, normalize_tool_result
 
@@ -50,6 +51,23 @@ def tool_call_signature(tool_calls: list[Any]) -> str:
         args = json.dumps(tool_call.arguments, ensure_ascii=False, sort_keys=True)
         parts.append(f"{tool_call.name}:{args}")
     return "|".join(parts)
+
+
+def tool_call_batch_snapshot(tool_calls: Sequence[Any]) -> tuple[dict[str, Any], ...]:
+    batch: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        raw_arguments: object = getattr(tool_call, "arguments", {})
+        snapshot_args: dict[str, Any] = {}
+        if isinstance(raw_arguments, dict):
+            for key, value in cast("dict[Any, Any]", raw_arguments).items():
+                snapshot_args[str(key)] = value
+        batch.append(
+            {
+                "name": str(getattr(tool_call, "name", "")),
+                "arguments": snapshot_args,
+            }
+        )
+    return tuple(batch)
 
 
 def format_tool_calls(tool_calls: list[Any]) -> list[dict[str, Any]]:

--- a/plugins/tool_loop_guard/plugin.py
+++ b/plugins/tool_loop_guard/plugin.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+from agent.lifecycle.types import PreToolCtx
+from agent.plugins import Plugin, on_tool_pre
+from agent.tool_hooks import HookOutcome
+
+_DEFAULT_REPEAT_LIMIT = 3
+_DENY_PREFIX = "tool_loop_guard:"
+_EXCLUDED_TOOLS = frozenset({"task_output", "task_stop"})
+
+
+@dataclass
+class _LoopState:
+    signature: str = ""
+    repeat_count: int = 0
+
+
+class ToolLoopGuard(Plugin):
+    name = "tool_loop_guard"
+    version = "0.1.0"
+    desc = "检测连续重复的工具调用并提前截断"
+
+    def __init__(self) -> None:
+        self._states: dict[str, _LoopState] = {}
+        self._repeat_limit = _DEFAULT_REPEAT_LIMIT
+
+    async def initialize(self) -> None:
+        config = getattr(self, "context", None)
+        plugin_config = getattr(config, "config", None)
+        raw_limit = (
+            plugin_config.get("repeat_limit", _DEFAULT_REPEAT_LIMIT)
+            if plugin_config
+            else _DEFAULT_REPEAT_LIMIT
+        )
+        try:
+            self._repeat_limit = max(2, int(raw_limit))
+        except (TypeError, ValueError):
+            self._repeat_limit = _DEFAULT_REPEAT_LIMIT
+
+    @on_tool_pre()
+    async def detect_repeated_tool_call(self, event: PreToolCtx) -> HookOutcome | None:
+        signature, active_index = self._event_signature(event)
+        if not signature or event.tool_batch_index != active_index:
+            return None
+        state_key = self._state_key(event)
+        state = self._states.setdefault(state_key, _LoopState())
+        if signature == state.signature:
+            state.repeat_count += 1
+        else:
+            state.signature = signature
+            state.repeat_count = 1
+        if state.repeat_count < self._repeat_limit:
+            return None
+        return HookOutcome(
+            decision="deny",
+            reason=(
+                f"{_DENY_PREFIX}连续重复调用工具 "
+                f"{state.repeat_count} 次，已截断并进入收尾。"
+            ),
+        )
+
+    def _state_key(self, event: PreToolCtx) -> str:
+        if event.session_key:
+            return f"{event.source}:{event.session_key}"
+        return f"{event.source}:{event.channel}:{event.chat_id}"
+
+    def _signature(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        args = json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+        return f"{tool_name}:{args}"
+
+    def _event_signature(self, event: PreToolCtx) -> tuple[str, int]:
+        if not event.tool_batch:
+            if event.tool_name in _EXCLUDED_TOOLS:
+                return "", 0
+            return self._signature(event.tool_name, event.arguments), 0
+
+        parts: list[str] = []
+        active_index = -1
+        for index, tool_call in enumerate(event.tool_batch):
+            tool_name = str(tool_call.get("name", ""))
+            if tool_name in _EXCLUDED_TOOLS:
+                continue
+            arguments = tool_call.get("arguments")
+            if not isinstance(arguments, dict):
+                arguments = {}
+            if active_index < 0:
+                active_index = index
+            parts.append(self._signature(tool_name, cast("dict[str, Any]", arguments)))
+        if active_index < 0:
+            return "", 0
+        return "|".join(parts), active_index

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -1,4 +1,6 @@
 import asyncio
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -8,16 +10,21 @@ import pytest
 from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig
 from agent.memory import MemoryStore
+from agent.plugins.manager import PluginManager
 from agent.provider import LLMResponse, ToolCall
 from agent.subagent import SubAgent
+from agent.tool_hooks.base import ToolHook
 from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
 from core.net.http import (
     SharedHttpResources,
     clear_default_shared_http_resources,
     configure_default_shared_http_resources,
 )
 from core.memory.port import DefaultMemoryPort
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _DummyTool(Tool):
@@ -122,10 +129,17 @@ class _ExitTool(Tool):
         return "noted"
 
 
-def _make_agent_loop(tmp_path: Path, provider: _FakeProvider, tool: Tool) -> AgentLoop:
+def _make_agent_loop_with_tools(
+    tmp_path: Path,
+    provider: _FakeProvider,
+    tools_to_register: list[Tool],
+    *,
+    tool_search_enabled: bool = False,
+) -> AgentLoop:
     tools = ToolRegistry()
-    tools.register(tool)
-    return AgentLoop(
+    for tool in tools_to_register:
+        tools.register(tool)
+    loop = AgentLoop(
         AgentLoopDeps(
             bus=MagicMock(),
             provider=cast(Any, provider),
@@ -134,8 +148,33 @@ def _make_agent_loop(tmp_path: Path, provider: _FakeProvider, tool: Tool) -> Age
             workspace=tmp_path,
             memory_port=DefaultMemoryPort(MemoryStore(tmp_path)),
         ),
-        AgentLoopConfig(llm=LLMConfig(max_iterations=10)),
+        AgentLoopConfig(
+            llm=LLMConfig(
+                max_iterations=10,
+                tool_search_enabled=tool_search_enabled,
+            )
+        ),
     )
+    loop.add_tool_hooks(_tool_loop_guard_hooks())
+    return loop
+
+
+def _make_agent_loop(tmp_path: Path, provider: _FakeProvider, tool: Tool) -> AgentLoop:
+    return _make_agent_loop_with_tools(tmp_path, provider, [tool])
+
+
+def _tool_loop_guard_hooks() -> list[ToolHook]:
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "tool_loop_guard"
+        shutil.copytree(_PROJECT_ROOT / "plugins" / "tool_loop_guard", plugin_dir)
+        mgr = PluginManager(plugin_dirs=[Path(tmp)], event_bus=EventBus())
+        asyncio.run(mgr.load_all())
+        return mgr.tool_hooks
+
+
+def _install_tool_loop_guard(subagent: SubAgent) -> SubAgent:
+    subagent.add_tool_hooks(_tool_loop_guard_hooks())
+    return subagent
 
 
 def test_agent_loop_breaks_on_repeated_same_signature_and_returns_summary(tmp_path):
@@ -161,6 +200,73 @@ def test_agent_loop_breaks_on_repeated_same_signature_and_returns_summary(tmp_pa
     # 第三次重复签名会被提前拦截，不应执行第三次工具
     assert len(tool.calls) == 2
     assert tools_used == ["dummy", "dummy"]
+
+
+def test_agent_loop_breaks_on_repeated_multi_tool_batch_and_keeps_chain_closed(tmp_path):
+    tool_a = _DummyTool("a")
+    tool_b = _DummyTool("b")
+    provider = _StrictProvider(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a1", "a", {"x": 1}),
+                    ToolCall("b1", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a2", "a", {"x": 1}),
+                    ToolCall("b2", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a3", "a", {"x": 1}),
+                    ToolCall("b3", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(content="已总结当前进度", tool_calls=[]),
+        ]
+    )
+    loop = _make_agent_loop_with_tools(tmp_path, provider, [tool_a, tool_b])
+
+    final, tools_used, _, _vn, _ = asyncio.run(
+        loop._run_agent_loop([{"role": "user", "content": "test"}])
+    )
+
+    assert "已总结" in final
+    assert tools_used == ["a", "b", "a", "b"]
+    assert len(tool_a.calls) == 2
+    assert len(tool_b.calls) == 2
+
+
+def test_agent_loop_breaks_on_repeated_unlocked_tool_request(tmp_path):
+    tool = _DummyTool("hidden_tool")
+    provider = _StrictProvider(
+        [
+            LLMResponse(content="", tool_calls=[ToolCall("h1", "hidden_tool", {"x": 1})]),
+            LLMResponse(content="", tool_calls=[ToolCall("h2", "hidden_tool", {"x": 1})]),
+            LLMResponse(content="", tool_calls=[ToolCall("h3", "hidden_tool", {"x": 1})]),
+            LLMResponse(content="已总结当前进度", tool_calls=[]),
+        ]
+    )
+    loop = _make_agent_loop_with_tools(
+        tmp_path,
+        provider,
+        [tool],
+        tool_search_enabled=True,
+    )
+
+    final, tools_used, _, _vn, _ = asyncio.run(
+        loop._run_agent_loop([{"role": "user", "content": "test"}])
+    )
+
+    assert "已总结" in final
+    assert tools_used == []
+    assert len(tool.calls) == 0
 
 
 def test_agent_loop_does_not_false_positive_when_args_change(tmp_path):
@@ -216,12 +322,58 @@ def test_subagent_marks_tool_loop_and_summarizes():
     subagent = SubAgent(
         provider=cast(Any, provider), model="m", tools=[tool], max_iterations=10
     )
+    _install_tool_loop_guard(subagent)
 
     result = asyncio.run(subagent.run("do work"))
 
     assert subagent.last_exit_reason == "tool_loop"
     assert "最大迭代" not in result
     assert len(tool.calls) == 2
+
+
+def test_subagent_breaks_on_repeated_multi_tool_batch_with_closed_chain():
+    tool_a = _DummyTool("a")
+    tool_b = _DummyTool("b")
+    provider = _StrictProvider(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a1", "a", {"x": 1}),
+                    ToolCall("b1", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a2", "a", {"x": 1}),
+                    ToolCall("b2", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("a3", "a", {"x": 1}),
+                    ToolCall("b3", "b", {"x": 2}),
+                ],
+            ),
+            LLMResponse(content="已总结当前进度", tool_calls=[]),
+        ]
+    )
+    subagent = SubAgent(
+        provider=cast(Any, provider),
+        model="m",
+        tools=[tool_a, tool_b],
+        max_iterations=10,
+    )
+    _install_tool_loop_guard(subagent)
+
+    result = asyncio.run(subagent.run("do work"))
+
+    assert subagent.last_exit_reason == "tool_loop"
+    assert "已总结" in result
+    assert len(tool_a.calls) == 2
+    assert len(tool_b.calls) == 2
 
 
 def test_subagent_no_false_positive_when_same_tool_but_different_args():
@@ -236,6 +388,7 @@ def test_subagent_no_false_positive_when_same_tool_but_different_args():
     subagent = SubAgent(
         provider=cast(Any, provider), model="m", tools=[tool], max_iterations=10
     )
+    _install_tool_loop_guard(subagent)
 
     result = asyncio.run(subagent.run("do work"))
 
@@ -257,6 +410,7 @@ def test_subagent_ignores_repeated_task_output_in_loop_guard():
     subagent = SubAgent(
         provider=cast(Any, provider), model="m", tools=[tool], max_iterations=10
     )
+    _install_tool_loop_guard(subagent)
 
     result = asyncio.run(subagent.run("看后台任务状态"))
 
@@ -278,6 +432,7 @@ def test_subagent_ignores_repeated_task_stop_in_loop_guard():
     subagent = SubAgent(
         provider=cast(Any, provider), model="m", tools=[tool], max_iterations=10
     )
+    _install_tool_loop_guard(subagent)
 
     result = asyncio.run(subagent.run("停止后台任务"))
 
@@ -571,6 +726,7 @@ def test_subagent_loop_path_runs_mandatory_exit_with_closed_chain():
         max_iterations=10,
         mandatory_exit_tools=["checkpoint"],
     )
+    _install_tool_loop_guard(subagent)
 
     result = asyncio.run(subagent.run("do work"))
 


### PR DESCRIPTION
## 变更\n- 将工具调用循环检测迁移为 tool_loop_guard 插件\n- 支持整批 tool_calls 签名检测，并覆盖未解锁工具重复调用\n- 提前收尾时补齐剩余 tool result，避免消息链未闭合\n\n## 验证\n- pytest tests/test_plugin_manager.py tests/test_shell_safety_plugin.py tests/test_shell_rm_hook.py tests/test_tool_loop_guard.py\n- pyright agent/core/passive_turn.py agent/subagent.py agent/lifecycle/types.py agent/plugins/manager.py agent/tool_hooks/types.py agent/tool_hooks/executor.py agent/tool_runtime.py plugins/tool_loop_guard/plugin.py tests/test_tool_loop_guard.py