### PR TITLE
扩展生命周期 slot 导出能力

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt
+          .venv/bin/python -m pip install -r requirements-dev.txt
 
       - name: Run pyright
         run: |
-          pyright --level error
+          .venv/bin/pyright --level error
       - name: Run pyright for tests
         run: |
-          pyright --project pyrightconfig.tests.json --level error
+          .venv/bin/pyright --project pyrightconfig.tests.json --level error
 
       - name: Run pytest
         timeout-minutes: 10
         run: |
-          pytest tests/
+          .venv/bin/pytest tests/

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -8,14 +8,15 @@
 4. [注册工具 (`@tool`)](#注册工具-tool)
 5. [拦截工具调用 (`@on_tool_pre`)](#拦截工具调用-on_tool_pre)
 6. [生命周期事件钩子 (`@on_*`)](#生命周期事件钩子-on_)
-7. [Before-Turn 管道模块 (`PhaseModule`)](#before-turn-管道模块-phasemodule)
-8. [插件配置 (`_conf_schema.json`)](#插件配置-_conf_schemajson)
-9. [持久化存储 (`PluginKVStore`)](#持久化存储-pluginkvstore)
-10. [元数据 (`manifest.yaml`)](#元数据-manifestyaml)
-11. [初始化与清理](#初始化与清理)
-12. [多插件协作](#多插件协作)
-13. [完整示例：留言板插件](#完整示例留言板插件)
-14. [参考](#参考)
+7. [生命周期管道模块 (`PhaseModule`)](#生命周期管道模块-phasemodule)
+8. [Slot Export 机制](#slot-export-机制)
+9. [插件配置 (`_conf_schema.json`)](#插件配置-_conf_schemajson)
+10. [持久化存储 (`PluginKVStore`)](#持久化存储-pluginkvstore)
+11. [元数据 (`manifest.yaml`)](#元数据-manifestyaml)
+12. [初始化与清理](#初始化与清理)
+13. [多插件协作](#多插件协作)
+14. [完整示例：留言板插件](#完整示例留言板插件)
+15. [参考](#参考)
 
 ---
 
@@ -30,7 +31,8 @@
 | 注册新工具 | `@tool(name="...")` | LLM 调用工具时 |
 | 拦截工具调用 | `@on_tool_pre(tool_name="...")` | 工具执行前 |
 | 钩入生命周期事件 | `@on_before_turn` 等 | 对应生命周期阶段 |
-| 插入 before-turn 管道模块 | `before_turn_modules_early()` / `late()` | 每轮 turn 开始 |
+| 插入生命周期管道模块 | `before/reasoning/step/after_*_modules_*()` 共 12 个注入点 | 对应阶段 |
+| 通过 slot 导出数据 | `frame.slots["<phase>:<category>:<key>"] = value` | PhaseModule 内 |
 | 读取配置 | `self.context.config` | 任意时机 |
 | 持久化键值存储 | `self.context.kv_store` | 任意时机 |
 | 初始化 / 清理 | `initialize()` / `terminate()` | 加载 / 停机 |
@@ -226,15 +228,15 @@ class PreToolCtx:
 每个事件对应一个上下文类型：
 
 | 事件 | 上下文类型 | 关键字段 |
-|---|---|---|
-| `before_turn` | `BeforeTurnCtx` | `content`, `skill_names`, `retrieved_memory_block`, `history_messages`, `abort`, `abort_reply` |
-| `before_reasoning` | `BeforeReasoningCtx` | `messages`, `system_prompt`, `tool_schemas` |
-| `before_step` | `BeforeStepCtx` | `messages`, `step_index` |
-| `after_step` | `AfterStepCtx` | `tool_calls`, `assistant_content` |
-| `after_reasoning` | `AfterReasoningCtx` | `tool_calls`, `final_text` |
-| `after_turn` | `AfterTurnCtx` | `outbound_content`, `session_key` |
-| `before_tool_call` | `BeforeToolCallCtx` | `tool_name`, `tool_args`, `tool_call_id` |
-| `after_tool_result` | `AfterToolResultCtx` | `tool_name`, `result_text`, `error` |
+|---|---|---|---|
+| `before_turn` | `BeforeTurnCtx` | `content`, `skill_names`, `retrieved_memory_block`, `history_messages`, `extra_hints`, `extra_metadata`, `abort`, `abort_reply` |
+| `before_reasoning` | `BeforeReasoningCtx` | `content`, `skill_names`, `retrieved_memory_block`, `extra_hints`, `abort`, `abort_reply` |
+| `before_step` | `BeforeStepCtx` | `iteration`, `input_tokens_estimate`, `visible_tool_names`, `extra_hints`, `early_stop`, `early_stop_reply` |
+| `after_step` | `AfterStepCtx` | `iteration`, `tools_called`, `partial_reply`, `extra_metadata` |
+| `after_reasoning` | `AfterReasoningCtx` | `reply`, `thinking`, `tools_used`, `tool_chain`, `media`, `meme_tag`, `outbound_metadata` |
+| `after_turn` | `AfterTurnCtx` | `reply`, `tools_used`, `thinking`, `will_dispatch`, `extra_metadata` |
+| `before_tool_call` | `BeforeToolCallCtx` | `tool_name`, `arguments` |
+| `after_tool_result` | `AfterToolResultCtx` | `tool_name`, `arguments`, `result`, `status` |
 
 完整定义见 `agent/lifecycle/types.py`。
 
@@ -257,7 +259,7 @@ class Audit(Plugin):
     @on_after_turn()
     async def log_finish(self, event: AfterTurnCtx) -> None:
         """每轮 turn 结束后记录。"""
-        print(f"[audit] turn 结束: outbound={event.outbound_content[:50]}")
+        print(f"[audit] turn 结束: reply={event.reply[:50]}")
 
     @on_before_turn(priority=100)   # 高优先级先执行
     async def content_filter(self, event: BeforeTurnCtx) -> BeforeTurnCtx | None:
@@ -270,7 +272,9 @@ class Audit(Plugin):
 
 ### GATE 阻断机制
 
-在 `BeforeTurnCtx` 中设置 `abort=True` + `abort_reply` 可以阻断整个 turn：
+GATE 阶段支持两种阻断方式：
+
+**方式 1：直接修改 ctx（适用 before_emit 插件）**
 
 ```python
 @on_before_turn()
@@ -281,7 +285,20 @@ async def gate(self, event: BeforeTurnCtx) -> BeforeTurnCtx:
     return event
 ```
 
-`BeforeTurnCtx.abort` 被设置后，`PassiveTurnPipeline.run()` 会直接返回 `abort_reply`，跳过推理和执行。
+**方式 2：Slot export（适用 after_emit 插件）**
+
+在 after_emit 位置不能直接改 ctx（GATE emit 已经发生），应通过 slot 触发 abort：
+
+```python
+class MyAfterEmitModule:
+    async def run(self, frame):
+        frame.slots["session:abort_reply"] = "由插件阻断"
+        return frame
+```
+
+各阶段的 abort slot：`session:abort_reply`、`reasoning:abort_reply`、`step:abort_reply`。
+
+`BeforeTurnCtx.abort` / `BeforeReasoningCtx.abort` 被设置后，`PassiveTurnPipeline.run()` 会直接返回 `abort_reply`，跳过推理和执行。`step:abort_reply` 映射为 `BeforeStepCtx.early_stop_reply`，只终止当前 tool loop。
 
 ### priority 参数
 
@@ -297,98 +314,341 @@ async def last(self, event): ...
 
 ---
 
-## Before-Turn 管道模块 (`PhaseModule`)
+## 生命周期管道模块 (`PhaseModule`)
 
-Before-turn 管道是 `default_before_turn_modules()` 返回的模块链，按顺序执行。
+每个生命周期阶段都是一条 `PhaseModule` 链，按顺序执行。插件通过定义特定方法返回模块列表来注入到各阶段的特定位置。
 
-### 管道顺序
+### 全阶段注入点一览
+
+| 阶段 | 注入方法 | 插入位置 | 典型用途 |
+|---|---|---|---|
+| `before_turn` | `before_turn_modules_early()` | 记忆检索 + EventBus 之前 | 命令拦截、早期 abort |
+| `before_turn` | `before_turn_modules_late()` | EventBus 之后、返回之前 | 补充 hints / metadata |
+| `before_reasoning` | `before_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx 字段（GATE 链） |
+| `before_reasoning` | `before_reasoning_modules_after_emit()` | EventBus emit 之后、prompt warmup 之前 | 设置 slot export（hints、abort） |
+| `prompt_render` | `prompt_render_modules_top()` | system sections top 拼装前 | 插入 system prompt 顶部 section |
+| `prompt_render` | `prompt_render_modules_bottom()` | system sections bottom 拼装后 | 插入 system prompt 底部 section 或 extra_hints |
+| `before_step` | `before_step_modules_before_emit()` | EventBus emit 之前 | 修改 BeforeStepCtx（GATE 链） |
+| `before_step` | `before_step_modules_after_emit()` | EventBus emit 之后 | 设置 slot export（hints、early_stop） |
+| `after_step` | `after_step_modules_before_fanout()` | fanout 之前 | 设置 telemetry slot（进入 fanout handler） |
+| `after_step` | `after_step_modules_after_fanout()` | fanout 之后 | 补充 telemetry（不覆盖 fanout handler 已看到的） |
+| `after_reasoning` | `after_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx 字段（reply、media、outbound_metadata） |
+| `after_reasoning` | `after_reasoning_modules_before_persist()` | persist 之前、emit 之后 | 设置 persist / outbound slot export |
+| `after_turn` | `after_turn_modules_before_commit()` | TurnCommitted 构建之前 | 设置 `turn:extra:*` slot |
+| `after_turn` | `after_turn_modules_before_fanout()` | AfterTurnCtx fanout 之前 | 设置 `turn:telemetry:*` slot |
+
+### 阶段详解
+
+#### before_turn 管道
 
 ```
-1. _AcquireSessionModule         ← 加载 session，产出 SESSION_SLOT
-2. ★ plugin_modules_early        ← 你的早于检索的模块
-3. _PrepareContextModule         ← 记忆检索，产出 CONTEXT_BUNDLE_SLOT
-4. _BuildBeforeTurnCtxModule     ← 构建 BeforeTurnCtx，产出 CTX_SLOT
-5. _EmitBeforeTurnCtxModule      ← EventBus 触发 on_before_turn GATE
-6. ★ plugin_modules_late         ← 你的晚于 EventBus 的模块
-7. _ReturnBeforeTurnCtxModule    ← 产出最终 output
+1. _AcquireSessionModule              ← 加载 session
+2. ★ plugin_modules_early             ← 适合做命令拦截（abort 跳过后续）
+3. _PrepareContextModule              ← 记忆检索
+4. _BuildBeforeTurnCtxModule          ← 构建 BeforeTurnCtx
+5. _EmitBeforeTurnCtxModule           ← EventBus GATE 链（@on_before_turn）
+6. ★ plugin_modules_late              ← 在 GATE 之后补充处理
+7. _CollectBeforeTurnExportSlotsModule ← 收集 session:extra_hint:* / session:abort_reply
+8. _ReturnBeforeTurnCtxModule         ← 产出最终 output
 ```
 
-### 早于 vs 晚于
+#### before_reasoning 管道
 
-- **`early`**：在记忆检索和 EventBus 之前运行。适合做**命令拦截**（如 `/memory_status`），因为可以 abort 并跳过后面的检索/推理。
-- **`late`**：在 EventBus 之后运行。适合在 GATE handler 处理完后做**补充处理**。
+```
+1. _SyncToolContextModule             ← 设置 tool context
+2. _BuildBeforeReasoningCtxModule     ← 构建 ctx（继承 before_turn 字段）
+3. ★ plugin_modules_before_emit        ← GATE 链：直接修改 ctx
+4. _EmitBeforeReasoningCtxModule      ← EventBus GATE 链（@on_before_reasoning）
+5. ★ plugin_modules_after_emit         ← 设置 reasoning:extra_hint:* / reasoning:abort_reply
+6. _CollectBeforeReasoningExportSlotsModule ← 收集 slot 到 ctx
+7. _PromptWarmupModule                ← 预热 prompt（ctx.abort 时跳过）
+8. _ReturnBeforeReasoningCtxModule    ← 产出 ctx
+```
+
+#### prompt_render 管道
+
+```
+1. _BuildPromptRenderCtxModule        ← 构建 ctx
+2. _EmitPromptRenderCtxModule         ← EventBus emit
+3. ★ plugin_modules_top               ← 通过 system_sections_top / prompt:section_top:* 插入
+4. ★ plugin_modules_bottom            ← 通过 system_sections_bottom / prompt:section_bottom:* 或 extra_hints
+5. _CollectPromptExportSlotsModule    ← 收集 prompt:section_*:*/ prompt:extra_hint:*
+6. _RenderPromptModule                ← ContextBuilder.render()
+7. _ReturnPromptRenderResultModule    ← 产出 PromptRenderResult
+```
+
+#### before_step 管道（每轮 tool loop iteration）
+
+```
+1. _BuildBeforeStepCtxModule          ← 构建 ctx
+2. ★ plugin_modules_before_emit        ← GATE 链：直接修改 ctx
+3. _EmitBeforeStepCtxModule           ← EventBus GATE 链（@on_before_step）
+4. ★ plugin_modules_after_emit         ← 设置 step:extra_hint:* / step:abort_reply
+5. _CollectBeforeStepExportSlotsModule ← 收集 slot 到 ctx（early_stop、extra_hints）
+6. _InjectHintsModule                 ← 将 extra_hints 注入 messages
+7. _ReturnBeforeStepCtxModule         ← 产出 ctx
+```
+
+#### after_step 管道（每轮 tool loop iteration 后）
+
+```
+1. _CopyInputToCtxModule              ← 输入快照复制为 ctx
+2. ★ plugin_modules_before_fanout      ← 设置 step:telemetry:*
+3. _CollectAfterStepExportSlotsModule  ← 第 1 次收集：记入 extra_metadata + tracked keys
+4. _FanoutAfterStepCtxModule          ← TAP fanout（handler 看到 collected telemetry）
+5. ★ plugin_modules_after_fanout       ← 补充新的 telemetry key
+6. _CollectAfterStepExportSlotsModule  ← 第 2 次收集：只补充未被 collected 的 key
+7. _ReturnAfterStepCtxModule          ← 产出 ctx
+```
+
+> **注意**：after_step 的 telemetry 收集分两次。fanout 前的 telemetry 会被 handler 看到并锁定；fanout 后的补充只能新增 key，不能覆盖已看过的同名 key。
+
+#### after_reasoning 管道
+
+```
+1. _BuildAfterReasoningCtxModule      ← 构建 ctx（含 outbound_metadata 初始值）
+2. ★ plugin_modules_before_emit        ← GATE 链：修改 ctx 字段
+3. _EmitAfterReasoningCtxModule       ← EventBus GATE 链（@on_after_reasoning）
+4. ★ plugin_modules_before_persist     ← 设置 persist:user:*/ persist:assistant:*/ outbound:metadata:*/ outbound:media:*
+5. _PersistUserMessageModule          ← 持久化 user 消息（读取 persist:user:*）
+6. _PersistAssistantMessageModule     ← 持久化 assistant 消息（读取 persist:assistant:*）
+7. _UpdateSessionMetadataModule       ← 更新 session 运行时 metadata
+8. _AppendMessagesModule              ← 追加到 session 存储
+9. _BuildOutboundMessageModule        ← 构建出站消息（读取 outbound:metadata:* / outbound:media:*）
+10. _ReturnAfterReasoningResultModule ← 产出 AfterReasoningResult
+```
+
+#### after_turn 管道
+
+```
+1. _BuildTurnWorkModule               ← 构建 budget、react_stats、extra 等
+2. ★ plugin_modules_before_commit      ← 设置 turn:extra:*
+3. _CollectAfterTurnExtraSlotsModule   ← 收集 turn:extra:* → extra dict
+4. _BuildTurnCommittedModule           ← 构建 TurnCommitted 事件（依赖 extra_collected）
+5. _FanoutTurnCommittedModule          ← fanout TurnCommitted
+6. _LogBudgetModule                    ← 日志记录 budget
+7. _BuildAfterTurnCtxModule            ← 构建 AfterTurnCtx
+8. ★ plugin_modules_before_fanout      ← 设置 turn:telemetry:*
+9. _CollectAfterTurnTelemetrySlotsModule ← 收集 turn:telemetry:* → extra_metadata
+10. _FanoutAfterTurnCtxModule          ← TAP fanout（@on_after_turn）
+11. _DispatchOutboundModule            ← 派发出站消息
+12. _ReturnOutboundMessageModule       ← 返回 OutboundMessage
+```
+
+> **注意**：after_turn 的 `_BuildTurnCommittedModule` 依赖 `_EXTRA_COLLECTED_SLOT`，保证 `_CollectAfterTurnExtraSlotsModule` 一定先于它执行。这通过模块的 `requires` / `produces` 契约实现。
 
 ### 编写 PhaseModule
 
-一个 `PhaseModule` 必须符合协议：
+`PhaseModule` 协议：
 
 ```python
 class MyModule:
-    requires = ("session:session",)     # 依赖哪些 slot
-    produces = ("session:ctx",)         # 产出哪些 slot
+    requires = ("phase:slot_name",)   # 可选：依赖哪些 slot（用于顺序校验）
+    produces = ("phase:slot_name",)   # 可选：产出哪些 slot
 
-    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
-        state = frame.input                    # TurnState (含 msg, session_key 等)
-        session = frame.slots["session:session"]
-        # ... 处理逻辑 ...
-        if should_abort:
-            frame.slots["session:ctx"] = BeforeTurnCtx(
-                session_key=state.session_key,
-                channel=state.msg.channel,
-                chat_id=state.msg.chat_id,
-                content=state.msg.content,
-                timestamp=state.msg.timestamp,
-                skill_names=[],
-                retrieved_memory_block="",
-                retrieval_trace_raw=None,
-                history_messages=(),
-                abort=True,
-                abort_reply="回复文本",
-            )
+    async def run(self, frame: PhaseFrame) -> PhaseFrame:
+        # 通过 frame.slots 读写中间状态
+        # 通过 frame.input / frame.output 读写输入输出
         return frame
 ```
 
-### 关键 Slot 名
-
-| Slot | 内容 | 由谁产出 |
-|---|---|---|
-| `session:session` | `Session` 对象 | `_AcquireSessionModule` |
-| `session:context_bundle` | `ContextBundle`（记忆、skill 等） | `_PrepareContextModule` |
-| `session:ctx` | `BeforeTurnCtx`（最终输出） | `_BuildBeforeTurnCtxModule` |
-
-### 模块间通信：slot 依赖与跳过
-
-如果前面的模块已经设置了 `session:ctx`（abort），后面的模块应该检查并跳过：
+完整的 GATE 链 ctx 修改示例（before_reasoning）：
 
 ```python
-class MyLateModule:
-    requires = ("session:ctx",)
-    produces = ("session:ctx",)
+class MyBeforeReasoningModule:
+    requires = ("reasoning:ctx",)
+    produces = ("reasoning:ctx",)
 
     async def run(self, frame):
-        ctx = frame.slots.get("session:ctx")
-        if ctx and ctx.abort:
-            return frame  # 已 abort，跳过
-        # 正常处理...
+        from typing import cast
+        from agent.lifecycle.types import BeforeReasoningCtx
+        ctx = cast(BeforeReasoningCtx, frame.slots["reasoning:ctx"])
+        # 直接修改 ctx 字段（GATE 链允许）
+        ctx.extra_hints.append("hint from my plugin")
+        ctx.abort = True
+        ctx.abort_reply = "由我的插件阻断"
+        frame.slots["reasoning:ctx"] = ctx
         return frame
 ```
+
+### 关键 Slot 名速查
+
+| 阶段 | Slot | 内容 |
+|---|---|---|
+| before_turn | `session:session` | `Session` 对象 |
+| before_turn | `session:context_bundle` | `ContextBundle` |
+| before_turn | `session:ctx` | `BeforeTurnCtx` |
+| before_reasoning | `reasoning:ctx` | `BeforeReasoningCtx` |
+| prompt_render | `prompt:ctx` | `PromptRenderCtx` |
+| prompt_render | `prompt:result` | `PromptRenderResult` |
+| before_step | `step:ctx` | `BeforeStepCtx` |
+| after_step | `step:ctx` | `AfterStepCtx` |
+| after_step | `step:telemetry_collected` | `set[str]` — 已收集过的 telemetry key |
+| after_reasoning | `reasoning:ctx` | `AfterReasoningCtx` |
+| after_reasoning | `reasoning:outbound` | `OutboundMessage` |
+| after_turn | `turn:budget` | `dict` — post-reply context budget |
+| after_turn | `turn:extra` | `dict` — TurnCommitted extra |
+| after_turn | `turn:extra_collected` | `True` — 标记 extra 已收集 |
+| after_turn | `turn:committed` | `TurnCommitted` 事件 |
+| after_turn | `turn:ctx` | `AfterTurnCtx` |
 
 ### 从插件暴露 PhaseModule
 
-在 Plugin 子类上定义 `before_turn_modules_early()` 和/或 `before_turn_modules_late()`：
+在 Plugin 子类上定义对应的方法，返回模块列表。全部可用方法：
 
 ```python
-class StatusCommands(Plugin):
-    name = "status_commands"
+class MyPlugin(Plugin):
+    name = "my_plugin"
 
     def before_turn_modules_early(self) -> list[object]:
-        return [
-            MemoryStatusCommandModule(),
-            KVCacheCommandModule(self.context.observe_db_path),
-        ]
+        return [MyCommandModule()]
+
+    def before_turn_modules_late(self) -> list[object]:
+        return [MyHintModule()]
+
+    def before_reasoning_modules_before_emit(self) -> list[object]:
+        return [MyReasoningGateModule()]
+
+    def before_reasoning_modules_after_emit(self) -> list[object]:
+        return [MyReasoningSlotModule()]
+
+    def prompt_render_modules_top(self) -> list[object]:
+        return [MyTopSectionModule()]
+
+    def prompt_render_modules_bottom(self) -> list[object]:
+        return [MyBottomSectionModule()]
+
+    def before_step_modules_before_emit(self) -> list[object]:
+        return [MyStepGateModule()]
+
+    def before_step_modules_after_emit(self) -> list[object]:
+        return [MyStepSlotModule()]
+
+    def after_step_modules_before_fanout(self) -> list[object]:
+        return [MyStepTelemetryModule()]
+
+    def after_step_modules_after_fanout(self) -> list[object]:
+        return [MyStepLateTelemetryModule()]
+
+    def after_reasoning_modules_before_emit(self) -> list[object]:
+        return [MyAfterReasoningGateModule()]
+
+    def after_reasoning_modules_before_persist(self) -> list[object]:
+        return [MyPersistModule()]
+
+    def after_turn_modules_before_commit(self) -> list[object]:
+        return [MyTurnExtraModule()]
+
+    def after_turn_modules_before_fanout(self) -> list[object]:
+        return [MyTurnTelemetryModule()]
 ```
 
-这些方法在 `PluginManager._load_one()` 中被调用，返回的模块列表被合并到管理器的 `_before_turn_modules_early` / `_late` 列表中。
+仅定义你需要的方法即可，管理器只收集已定义的方法返回的模块。
+
+---
+
+---
+
+## Slot Export 机制
+
+Slot export 是 PhaseModule 间传递数据的标准方式。插件通过向 `frame.slots` 写入带前缀的 key，由 collection 模块自动合并到下游 ctx 或持久化数据中。
+
+### 核心 Helper
+
+```python
+from agent.lifecycle.phase import collect_prefixed_slots, append_string_exports
+```
+
+- `collect_prefixed_slots(slots, prefix, *, reserved=())` — 收集所有以 `prefix` 开头的 slot，返回 `dict[str, object]`。`reserved` 集合中的 key 会被排除（用于保护内置字段不被覆盖）。
+- `append_string_exports(target, exports)` — 将 exports 中的字符串（或字符串列表）追加到 `target` 列表中。
+
+### 可用 Slot 前缀
+
+| 前缀 | 阶段 | 语义 | 目标 |
+|---|---|---|---|
+| `session:extra_hint:*` | before_turn (late) | 注入额外提示 | `BeforeTurnCtx.extra_hints` → reasoning |
+| `session:abort_reply` | before_turn (late) | 阻断 turn 并返回此文本 | `BeforeTurnCtx.abort_reply` |
+| `reasoning:extra_hint:*` | before_reasoning | 注入额外提示 | `BeforeReasoningCtx.extra_hints` → prompt |
+| `reasoning:abort_reply` | before_reasoning | 阻断 reasoning 并返回此文本 | `BeforeReasoningCtx.abort_reply` |
+| `prompt:section_top:*` | prompt_render | 插入 system prompt 顶部 | `system_sections_top` → rendered |
+| `prompt:section_bottom:*` | prompt_render | 插入 system prompt 底部 | `system_sections_bottom` → rendered |
+| `prompt:extra_hint:*` | prompt_render | 注入 context hint | `PromptRenderCtx.extra_hints` |
+| `step:extra_hint:*` | before_step | 注入额外提示到 messages | `BeforeStepCtx.extra_hints` → `_InjectHintsModule` |
+| `step:abort_reply` | before_step | 提前终止当前 tool loop | `BeforeStepCtx.early_stop_reply` |
+| `step:telemetry:*` | after_step | 注入 telemetry 到 extra_metadata | `AfterStepCtx.extra_metadata` |
+| `persist:user:*` | after_reasoning | 持久化到 user 消息的额外字段 | user message kwargs |
+| `persist:assistant:*` | after_reasoning | 持久化到 assistant 消息的额外字段 | assistant message kwargs |
+| `outbound:metadata:*` | after_reasoning | 注入出站消息 metadata | `OutboundMessage.metadata` |
+| `outbound:media:*` | after_reasoning | 追加出站媒体 URL | `OutboundMessage.media` |
+| `turn:extra:*` | after_turn | 注入 TurnCommitted extra 字段 | `TurnCommitted.extra` |
+| `turn:telemetry:*` | after_turn | 注入 AfterTurnCtx telemetry | `AfterTurnCtx.extra_metadata` |
+
+### 示例：在 before_reasoning 中注入 extra_hints
+
+```python
+from agent.lifecycle.phase import collect_prefixed_slots, append_string_exports
+from agent.lifecycle.types import BeforeReasoningCtx
+
+class MyHintModule:
+    requires = ("reasoning:ctx",)
+    produces = ("reasoning:ctx",)
+
+    async def run(self, frame):
+        # 方式 1：直接写入 slot，collection 模块会自动处理
+        frame.slots["reasoning:extra_hint:weather"] = "今天北京有暴雨，建议提醒用户带伞"
+        return frame
+```
+
+### 示例：在 prompt_render 中插入 system section
+
+```python
+from agent.prompting import PromptSectionRender
+
+class MySectionModule:
+    async def run(self, frame):
+        # 可以用字符串
+        frame.slots["prompt:section_bottom:custom"] = "## 自定义规则\n请用中文回答。"
+        # 也可以用 PromptSectionRender（控制 is_static 等属性）
+        frame.slots["prompt:section_bottom:rules"] = PromptSectionRender(
+            name="rules",
+            content="你是一个严肃、准确的助手，不可编造事实。",
+            is_static=False,
+        )
+        return frame
+```
+
+### 示例：在 after_reasoning 中注入 persist / outbound
+
+```python
+class MyPersistModule:
+    async def run(self, frame):
+        # 给 user 消息添加自定义字段
+        frame.slots["persist:user:plugin_tag"] = "my_plugin_v1"
+        # 给 assistant 消息添加自定义字段
+        frame.slots["persist:assistant:confidence"] = 0.95
+        # 给出站消息添加 metadata
+        frame.slots["outbound:metadata:source_plugin"] = "my_plugin"
+        # 给出站消息追加媒体文件
+        frame.slots["outbound:media:chart"] = "/tmp/output.png"
+        return frame
+```
+
+### Slot Export 的执行顺序
+
+每个阶段的 collection 模块在 pipeline 中的位置是固定的（见上一节各阶段管道图）。一般模式：
+
+- **after_emit 插件** 写入 slot → **collection 模块** 读取并合并
+- **after_step** 特殊：分两次 collect（fanout 前锁定 + fanout 后补充）
+- **after_turn** 特殊：`turn:extra:*` 在 `_CollectAfterTurnExtraSlotsModule` 收集，`turn:telemetry:*` 在 `_CollectAfterTurnTelemetrySlotsModule` 收集
+
+### Slot vs 直接修改 ctx
+
+| 方式 | 适用场景 | 示例 |
+|---|---|---|
+| 直接修改 ctx（GATE 链） | before_emit 位置，需要 EventBus handler 也能看到变化 | `ctx.reply = "new reply"` |
+| Slot export | after_emit / before_fanout / before_persist 位置，多个插件各自产出独立数据 | `frame.slots["persist:user:tag"] = "v1"` |
+
+选择原则：如果需要 EventBus handler（`@on_*`）能看到变化 → 直接改 ctx。如果只是向下游模块传递数据 → slot export。
 
 ---
 
@@ -640,7 +900,7 @@ class MessageBoard(Plugin):
     @on_after_turn()
     async def log_outbound(self, event: AfterTurnCtx) -> None:
         """记录每次发送的内容长度。"""
-        content_len = len(event.outbound_content or "")
+        content_len = len(event.reply or "")
         self.context.kv_store.set("last_content_length", content_len)
         self.context.kv_store.increment("total_turns")
 ```
@@ -659,15 +919,15 @@ class MessageBoard(Plugin):
 class PluginA(Plugin):
     @on_before_reasoning(priority=100)
     async def a_early(self, event: BeforeReasoningCtx) -> BeforeReasoningCtx:
-        """先执行：高优先级修改 system prompt"""
-        event.system_prompt += "\n附加规则 A"
+        """先执行：高优先级追加 extra_hints"""
+        event.extra_hints.append("\n附加规则 A")
         return event
 
 class PluginB(Plugin):
     @on_before_reasoning(priority=-10)
     async def b_late(self, event: BeforeReasoningCtx) -> BeforeReasoningCtx:
-        """后执行：看到的是 A 改过的 prompt"""
-        print(f"当前 prompt: {event.system_prompt}")
+        """后执行：看到的是 A 追加过的 hints"""
+        print(f"当前 hints: {event.extra_hints}")
         return event
 ```
 

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -37,11 +37,13 @@ from agent.lifecycle.phases.after_reasoning import (
     AfterReasoningFrame,
     default_after_reasoning_modules,
 )
+from agent.lifecycle.phases.after_step import AfterStepFrame, default_after_step_modules
 from agent.lifecycle.phases.after_turn import AfterTurnFrame, default_after_turn_modules
 from agent.lifecycle.phases.before_reasoning import (
     BeforeReasoningFrame,
     default_before_reasoning_modules,
 )
+from agent.lifecycle.phases.before_step import BeforeStepFrame, default_before_step_modules
 from agent.lifecycle.phases.before_turn import BeforeTurnFrame, default_before_turn_modules
 from agent.lifecycle.phases.prompt_render import (
     PromptRenderFrame,
@@ -135,8 +137,16 @@ class AgentCoreDeps:
     history_window: int = 500
     before_turn_plugin_modules_early: list[object] | None = None
     before_turn_plugin_modules_late: list[object] | None = None
+    before_reasoning_plugin_modules_before_emit: list[object] | None = None
+    before_reasoning_plugin_modules_after_emit: list[object] | None = None
+    before_step_plugin_modules_before_emit: list[object] | None = None
+    before_step_plugin_modules_after_emit: list[object] | None = None
+    after_step_plugin_modules_before_fanout: list[object] | None = None
+    after_step_plugin_modules_after_fanout: list[object] | None = None
     after_reasoning_plugin_modules_before_emit: list[object] | None = None
     after_reasoning_plugin_modules_before_persist: list[object] | None = None
+    after_turn_plugin_modules_before_commit: list[object] | None = None
+    after_turn_plugin_modules_before_fanout: list[object] | None = None
 
 
 class AgentCore:
@@ -163,6 +173,16 @@ class AgentCore:
     ) -> None:
         self._passive_pipeline.add_before_turn_plugin_modules(early, late)
 
+    def add_before_reasoning_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        self._passive_pipeline.add_before_reasoning_plugin_modules(
+            before_emit,
+            after_emit,
+        )
+
     def add_after_reasoning_plugin_modules(
         self,
         before_emit: list[object],
@@ -171,6 +191,16 @@ class AgentCore:
         self._passive_pipeline.add_after_reasoning_plugin_modules(
             before_emit,
             before_persist,
+        )
+
+    def add_after_turn_plugin_modules(
+        self,
+        before_commit: list[object],
+        before_fanout: list[object],
+    ) -> None:
+        self._passive_pipeline.add_after_turn_plugin_modules(
+            before_commit,
+            before_fanout,
         )
 
     async def process(
@@ -207,43 +237,47 @@ class PassiveTurnPipeline:
         self._context = deps.context
         self._tools = deps.tools
         self._reasoner = deps.reasoner
-        self._outbound_port = deps.outbound_port
+        add_before_step = getattr(self._reasoner, "add_before_step_plugin_modules", None)
+        if add_before_step is not None:
+            add_before_step(
+                list(deps.before_step_plugin_modules_before_emit or []),
+                list(deps.before_step_plugin_modules_after_emit or []),
+            )
+        add_after_step = getattr(self._reasoner, "add_after_step_plugin_modules", None)
+        if add_after_step is not None:
+            add_after_step(
+                list(deps.after_step_plugin_modules_before_fanout or []),
+                list(deps.after_step_plugin_modules_after_fanout or []),
+            )
+        self._outbound_port = deps.outbound_port or _NoopOutboundPort()
+        self._history_window = deps.history_window
         self._before_turn_plugin_modules_early = list(deps.before_turn_plugin_modules_early or [])
         self._before_turn_plugin_modules_late = list(deps.before_turn_plugin_modules_late or [])
+        self._before_reasoning_plugin_modules_before_emit = list(
+            deps.before_reasoning_plugin_modules_before_emit or []
+        )
+        self._before_reasoning_plugin_modules_after_emit = list(
+            deps.before_reasoning_plugin_modules_after_emit or []
+        )
         self._after_reasoning_plugin_modules_before_emit = list(
             deps.after_reasoning_plugin_modules_before_emit or []
         )
         self._after_reasoning_plugin_modules_before_persist = list(
             deps.after_reasoning_plugin_modules_before_persist or []
         )
+        self._after_turn_plugin_modules_before_commit = list(
+            deps.after_turn_plugin_modules_before_commit or []
+        )
+        self._after_turn_plugin_modules_before_fanout = list(
+            deps.after_turn_plugin_modules_before_fanout or []
+        )
         bus = deps.event_bus or EventBus()
         self._bus = bus
 
         self._before_turn = self._build_before_turn_phase()
-        self._before_reasoning: Phase[
-            BeforeReasoningInput,
-            BeforeReasoningCtx,
-            BeforeReasoningFrame,
-        ] = Phase(
-            default_before_reasoning_modules(
-                bus,
-                deps.tools,
-                self._session.session_manager,
-                deps.context,
-            ),
-            frame_factory=BeforeReasoningFrame,
-        )
+        self._before_reasoning = self._build_before_reasoning_phase()
         self._after_reasoning = self._build_after_reasoning_phase()
-        outbound_port = deps.outbound_port or _NoopOutboundPort()
-        self._after_turn: Phase[TurnSnapshot, OutboundMessage, AfterTurnFrame] = Phase(
-            default_after_turn_modules(
-                bus,
-                outbound_port,
-                deps.context,
-                deps.history_window,
-            ),
-            frame_factory=AfterTurnFrame,
-        )
+        self._after_turn = self._build_after_turn_phase()
 
     def add_before_turn_plugin_modules(
         self,
@@ -254,6 +288,15 @@ class PassiveTurnPipeline:
         self._before_turn_plugin_modules_late.extend(late)
         self._before_turn = self._build_before_turn_phase()
 
+    def add_before_reasoning_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        self._before_reasoning_plugin_modules_before_emit.extend(before_emit)
+        self._before_reasoning_plugin_modules_after_emit.extend(after_emit)
+        self._before_reasoning = self._build_before_reasoning_phase()
+
     def add_after_reasoning_plugin_modules(
         self,
         before_emit: list[object],
@@ -262,6 +305,15 @@ class PassiveTurnPipeline:
         self._after_reasoning_plugin_modules_before_emit.extend(before_emit)
         self._after_reasoning_plugin_modules_before_persist.extend(before_persist)
         self._after_reasoning = self._build_after_reasoning_phase()
+
+    def add_after_turn_plugin_modules(
+        self,
+        before_commit: list[object],
+        before_fanout: list[object],
+    ) -> None:
+        self._after_turn_plugin_modules_before_commit.extend(before_commit)
+        self._after_turn_plugin_modules_before_fanout.extend(before_fanout)
+        self._after_turn = self._build_after_turn_phase()
 
     def _build_before_turn_phase(self) -> Phase[TurnState, BeforeTurnCtx, BeforeTurnFrame]:
         return Phase(
@@ -273,6 +325,27 @@ class PassiveTurnPipeline:
                 plugin_modules_late=cast("list[Any]", self._before_turn_plugin_modules_late),
             ),
             frame_factory=BeforeTurnFrame,
+        )
+
+    def _build_before_reasoning_phase(
+        self,
+    ) -> Phase[BeforeReasoningInput, BeforeReasoningCtx, BeforeReasoningFrame]:
+        return Phase(
+            default_before_reasoning_modules(
+                self._bus,
+                self._tools,
+                self._session.session_manager,
+                self._context,
+                plugin_modules_before_emit=cast(
+                    "list[Any]",
+                    self._before_reasoning_plugin_modules_before_emit,
+                ),
+                plugin_modules_after_emit=cast(
+                    "list[Any]",
+                    self._before_reasoning_plugin_modules_after_emit,
+                ),
+            ),
+            frame_factory=BeforeReasoningFrame,
         )
 
     def _build_after_reasoning_phase(
@@ -294,6 +367,27 @@ class PassiveTurnPipeline:
             frame_factory=AfterReasoningFrame,
         )
 
+    def _build_after_turn_phase(
+        self,
+    ) -> Phase[TurnSnapshot, OutboundMessage, AfterTurnFrame]:
+        return Phase(
+            default_after_turn_modules(
+                self._bus,
+                self._outbound_port,
+                self._context,
+                self._history_window,
+                plugin_modules_before_commit=cast(
+                    "list[Any]",
+                    self._after_turn_plugin_modules_before_commit,
+                ),
+                plugin_modules_before_fanout=cast(
+                    "list[Any]",
+                    self._after_turn_plugin_modules_before_fanout,
+                ),
+            ),
+            frame_factory=AfterTurnFrame,
+        )
+
     # 核心方法：处理一条普通被动消息，并提交最终出站结果。
     async def run(
         self,
@@ -311,6 +405,8 @@ class PassiveTurnPipeline:
         try:
             # Phase 1: BeforeTurn 模块链（会话、上下文、BeforeTurn 事件）。
             before_turn = await self._before_turn.run(state)
+            # TurnState 存内部默认 metadata；BeforeTurnCtx 存插件导出，同名 key 以后者覆盖。
+            state.extra_metadata.update(before_turn.extra_metadata)
             if before_turn.abort:
                 return await self._control_outbound(
                     state,
@@ -406,7 +502,7 @@ class PassiveTurnPipeline:
         state: TurnState,
         outbound: OutboundMessage,
     ) -> OutboundMessage:
-        if state.dispatch_outbound and self._outbound_port is not None:
+        if state.dispatch_outbound:
             _ = await self._outbound_port.dispatch(
                 OutboundDispatch(
                     channel=outbound.channel,
@@ -540,6 +636,20 @@ class Reasoner(ABC):
     ) -> None:
         """子类可重写以注入 prompt render modules。默认 no-op。"""
 
+    def add_before_step_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        """子类可重写以注入 before-step modules。默认 no-op。"""
+
+    def add_after_step_plugin_modules(
+        self,
+        before_fanout: list[object],
+        after_fanout: list[object],
+    ) -> None:
+        """子类可重写以注入 after-step modules。默认 no-op。"""
+
     async def render_prompt(
         self,
         input: PromptRenderInput,
@@ -572,6 +682,10 @@ class DefaultReasoner(Reasoner):
         self._event_bus = event_bus
         self._prompt_render_plugin_modules_top: list[object] = []
         self._prompt_render_plugin_modules_bottom: list[object] = []
+        self._before_step_plugin_modules_before_emit: list[object] = []
+        self._before_step_plugin_modules_after_emit: list[object] = []
+        self._after_step_plugin_modules_before_fanout: list[object] = []
+        self._after_step_plugin_modules_after_fanout: list[object] = []
         # Direct reference to ToolSearchTool so we can pass excluded_names
         # explicitly instead of routing through the ContextVar side-channel.
         _ts = tools.get_tool("tool_search")
@@ -584,23 +698,8 @@ class DefaultReasoner(Reasoner):
         ] | None = None
         bus = event_bus or EventBus()
         self._bus = bus
-        from agent.lifecycle.phases.before_step import (
-            BeforeStepFrame,
-            default_before_step_modules,
-        )
-        from agent.lifecycle.phases.after_step import (
-            AfterStepFrame,
-            default_after_step_modules,
-        )
-
-        self._before_step: Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame] = Phase(
-            default_before_step_modules(bus),
-            frame_factory=BeforeStepFrame,
-        )
-        self._after_step: Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame] = Phase(
-            default_after_step_modules(bus),
-            frame_factory=AfterStepFrame,
-        )
+        self._before_step = self._build_before_step_phase()
+        self._after_step = self._build_after_step_phase()
         self._prompt_render: Phase[
             PromptRenderInput,
             PromptRenderResult,
@@ -623,6 +722,58 @@ class DefaultReasoner(Reasoner):
         self._prompt_render_plugin_modules_bottom.extend(bottom)
         if self._context is not None:
             self._prompt_render = self._build_prompt_render_phase(self._context)
+
+    def add_before_step_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        self._before_step_plugin_modules_before_emit.extend(before_emit)
+        self._before_step_plugin_modules_after_emit.extend(after_emit)
+        self._before_step = self._build_before_step_phase()
+
+    def add_after_step_plugin_modules(
+        self,
+        before_fanout: list[object],
+        after_fanout: list[object],
+    ) -> None:
+        self._after_step_plugin_modules_before_fanout.extend(before_fanout)
+        self._after_step_plugin_modules_after_fanout.extend(after_fanout)
+        self._after_step = self._build_after_step_phase()
+
+    def _build_before_step_phase(
+        self,
+    ) -> Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame]:
+        return Phase(
+            default_before_step_modules(
+                self._bus,
+                plugin_modules_before_emit=cast(
+                    "list[Any]",
+                    self._before_step_plugin_modules_before_emit,
+                ),
+                plugin_modules_after_emit=cast(
+                    "list[Any]",
+                    self._before_step_plugin_modules_after_emit,
+                ),
+            ),
+            frame_factory=BeforeStepFrame,
+        )
+
+    def _build_after_step_phase(self) -> Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame]:
+        return Phase(
+            default_after_step_modules(
+                self._bus,
+                plugin_modules_before_fanout=cast(
+                    "list[Any]",
+                    self._after_step_plugin_modules_before_fanout,
+                ),
+                plugin_modules_after_fanout=cast(
+                    "list[Any]",
+                    self._after_step_plugin_modules_after_fanout,
+                ),
+            ),
+            frame_factory=AfterStepFrame,
+        )
 
     def _build_prompt_render_phase(
         self,

--- a/agent/lifecycle/phase.py
+++ b/agent/lifecycle/phase.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 from typing import Generic, Protocol, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -15,6 +15,47 @@ F = TypeVar("F", bound="PhaseFrame[Any, Any]")
 
 def _empty_slots() -> dict[str, Any]:
     return {}
+
+
+def collect_prefixed_slots(
+    slots: Mapping[str, object],
+    prefix: str,
+    *,
+    reserved: Collection[str] = (),
+) -> dict[str, object]:
+    values: dict[str, object] = {}
+    reserved_fields = set(reserved)
+    for key, value in slots.items():
+        if not key.startswith(prefix):
+            continue
+        field_name = key.removeprefix(prefix)
+        if not field_name or field_name in reserved_fields:
+            continue
+        values[field_name] = value
+    return values
+
+
+def append_string_exports(target: list[str], exports: Mapping[str, object]) -> None:
+    for key, value in exports.items():
+        if isinstance(value, str) and value.strip():
+            target.append(value)
+        elif isinstance(value, list):
+            items = cast(list[object], value)
+            for item in items:
+                if isinstance(item, str) and item.strip():
+                    target.append(item)
+                elif item is not None:
+                    logger.warning(
+                        "忽略非字符串 slot export: key=%s type=%s",
+                        key,
+                        type(item).__name__,
+                    )
+        elif value is not None:
+            logger.warning(
+                "忽略非字符串 slot export: key=%s type=%s",
+                key,
+                type(value).__name__,
+            )
 
 
 @dataclass

--- a/agent/lifecycle/phases/after_reasoning.py
+++ b/agent/lifecycle/phases/after_reasoning.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from agent.core.passive_support import update_session_runtime_metadata
 from agent.core.response_parser import parse_response
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import (
+    PhaseFrame,
+    PhaseModule,
+    append_string_exports,
+    collect_prefixed_slots,
+)
 from agent.lifecycle.types import (
     AfterReasoningCtx,
     AfterReasoningInput,
@@ -32,8 +37,12 @@ AfterReasoningModules: TypeAlias = list[PhaseModule[AfterReasoningFrame]]
 
 _CTX_SLOT = "reasoning:ctx"
 _OUTBOUND_SLOT = "reasoning:outbound"
+_PERSIST_USER_PREFIX = "persist:user:"
 _PERSIST_ASSISTANT_PREFIX = "persist:assistant:"
+_OUTBOUND_METADATA_PREFIX = "outbound:metadata:"
+_OUTBOUND_MEDIA_PREFIX = "outbound:media:"
 _ASSISTANT_FIXED_FIELDS = {"tools_used", "tool_chain", "reasoning_content"}
+_USER_FIXED_FIELDS = {"media"}
 
 
 class _BuildAfterReasoningCtxModule:
@@ -61,6 +70,7 @@ class _BuildAfterReasoningCtxModule:
             context_retry=dict(turn_result.context_retry),
             outbound_metadata={
                 **(msg.metadata or {}),
+                **input.state.extra_metadata,
                 "tools_used": list(turn_result.tools_used),
                 "tool_chain": list(tool_chain),
                 "context_retry": dict(turn_result.context_retry),
@@ -109,6 +119,7 @@ class _PersistUserMessageModule:
         llm_context_frame = ctx.context_retry.get("llm_context_frame")
         if isinstance(llm_context_frame, str) and llm_context_frame.strip():
             user_kwargs["llm_context_frame"] = llm_context_frame
+        user_kwargs.update(_collect_persist_user_slots(frame.slots))
         session.add_message(
             "user",
             msg.content,
@@ -179,13 +190,17 @@ class _BuildOutboundMessageModule:
 
     async def run(self, frame: AfterReasoningFrame) -> AfterReasoningFrame:
         ctx = cast(AfterReasoningCtx, frame.slots[_CTX_SLOT])
+        metadata = dict(ctx.outbound_metadata)
+        metadata.update(collect_prefixed_slots(frame.slots, _OUTBOUND_METADATA_PREFIX))
+        media = list(ctx.media)
+        _append_media(media, collect_prefixed_slots(frame.slots, _OUTBOUND_MEDIA_PREFIX))
         frame.slots[_OUTBOUND_SLOT] = OutboundMessage(
             channel=ctx.channel,
             chat_id=ctx.chat_id,
             content=ctx.reply,
             thinking=ctx.thinking,
-            media=list(ctx.media),
-            metadata=dict(ctx.outbound_metadata),
+            media=media,
+            metadata=metadata,
         )
         return frame
 
@@ -224,12 +239,20 @@ def default_after_reasoning_modules(
 
 
 def _collect_persist_assistant_slots(slots: dict[str, object]) -> dict[str, object]:
-    values: dict[str, object] = {}
-    for key, value in slots.items():
-        if not key.startswith(_PERSIST_ASSISTANT_PREFIX):
-            continue
-        field = key.removeprefix(_PERSIST_ASSISTANT_PREFIX)
-        if not field or field in _ASSISTANT_FIXED_FIELDS:
-            continue
-        values[field] = value
-    return values
+    return collect_prefixed_slots(
+        slots,
+        _PERSIST_ASSISTANT_PREFIX,
+        reserved=_ASSISTANT_FIXED_FIELDS,
+    )
+
+
+def _collect_persist_user_slots(slots: dict[str, object]) -> dict[str, object]:
+    return collect_prefixed_slots(
+        slots,
+        _PERSIST_USER_PREFIX,
+        reserved=_USER_FIXED_FIELDS,
+    )
+
+
+def _append_media(target: list[str], exports: dict[str, object]) -> None:
+    append_string_exports(target, exports)

--- a/agent/lifecycle/phases/after_step.py
+++ b/agent/lifecycle/phases/after_step.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TypeAlias, cast
 
 from bus.event_bus import EventBus
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import PhaseFrame, PhaseModule, collect_prefixed_slots
 from agent.lifecycle.types import AfterStepCtx
 
 
@@ -17,6 +17,8 @@ AfterStepModules: TypeAlias = list[PhaseModule[AfterStepFrame]]
 
 
 _CTX_SLOT = "step:ctx"
+_TELEMETRY_PREFIX = "step:telemetry:"
+_COLLECTED_TELEMETRY_SLOT = "step:telemetry_collected"
 
 
 class _CopyInputToCtxModule:
@@ -39,6 +41,27 @@ class _FanoutAfterStepCtxModule:
         return frame
 
 
+class _CollectAfterStepExportSlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: AfterStepFrame) -> AfterStepFrame:
+        ctx = cast(AfterStepCtx, frame.slots[_CTX_SLOT])
+        collected = set(cast(set[str], frame.slots.get(_COLLECTED_TELEMETRY_SLOT, set())))
+        exports = collect_prefixed_slots(frame.slots, _TELEMETRY_PREFIX)
+        # after_fanout 可补充 telemetry，但不能覆盖 fanout handler 已看到的同名值。
+        new_exports = {
+            key: value
+            for key, value in exports.items()
+            if key not in collected
+        }
+        extra_metadata = dict(ctx.extra_metadata)
+        extra_metadata.update(new_exports)
+        frame.slots[_CTX_SLOT] = replace(ctx, extra_metadata=extra_metadata)
+        frame.slots[_COLLECTED_TELEMETRY_SLOT] = collected | set(new_exports)
+        return frame
+
+
 class _ReturnAfterStepCtxModule:
     requires = (_CTX_SLOT,)
 
@@ -47,9 +70,20 @@ class _ReturnAfterStepCtxModule:
         return frame
 
 
-def default_after_step_modules(bus: EventBus) -> AfterStepModules:
+def default_after_step_modules(
+    bus: EventBus,
+    plugin_modules_before_fanout: AfterStepModules | None = None,
+    plugin_modules_after_fanout: AfterStepModules | None = None,
+) -> AfterStepModules:
+    before_fanout = plugin_modules_before_fanout or []
+    after_fanout = plugin_modules_after_fanout or []
     return [
         _CopyInputToCtxModule(),
+        *before_fanout,
+        # collect 两次：fanout 前给 handler 读，fanout 后把 after_fanout 的补充带回返回 ctx。
+        _CollectAfterStepExportSlotsModule(),
         _FanoutAfterStepCtxModule(bus),
+        *after_fanout,
+        _CollectAfterStepExportSlotsModule(),
         _ReturnAfterStepCtxModule(),
     ]

--- a/agent/lifecycle/phases/after_turn.py
+++ b/agent/lifecycle/phases/after_turn.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
@@ -12,7 +12,7 @@ from agent.core.passive_support import (
     log_react_context_budget,
 )
 from agent.core.types import to_tool_call_groups
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import PhaseFrame, PhaseModule, collect_prefixed_slots
 from agent.lifecycle.types import AfterTurnCtx, TurnSnapshot
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from bus.event_bus import EventBus
@@ -39,8 +39,11 @@ _REACT_STATS_SLOT = "turn:react_stats"
 _TOOL_CHAIN_SLOT = "turn:tool_chain"
 _OMIT_USER_TURN_SLOT = "turn:omit_user_turn"
 _EXTRA_SLOT = "turn:extra"
+_EXTRA_COLLECTED_SLOT = "turn:extra_collected"
 _TURN_COMMITTED_SLOT = "turn:committed"
 _CTX_SLOT = "turn:ctx"
+_EXTRA_PREFIX = "turn:extra:"
+_TELEMETRY_PREFIX = "turn:telemetry:"
 
 
 class _BuildTurnWorkModule:
@@ -94,6 +97,7 @@ class _BuildTurnCommittedModule:
         _TOOL_CHAIN_SLOT,
         _OMIT_USER_TURN_SLOT,
         _EXTRA_SLOT,
+        _EXTRA_COLLECTED_SLOT,
     )
     produces = (_TURN_COMMITTED_SLOT,)
 
@@ -123,6 +127,18 @@ class _BuildTurnCommittedModule:
             react_stats=dict(cast(dict[str, int], frame.slots[_REACT_STATS_SLOT])),
             extra=dict(cast(dict[str, object], frame.slots[_EXTRA_SLOT])),
         )
+        return frame
+
+
+class _CollectAfterTurnExtraSlotsModule:
+    requires = (_EXTRA_SLOT,)
+    produces = (_EXTRA_SLOT, _EXTRA_COLLECTED_SLOT)
+
+    async def run(self, frame: AfterTurnFrame) -> AfterTurnFrame:
+        extra = dict(cast(dict[str, object], frame.slots[_EXTRA_SLOT]))
+        extra.update(collect_prefixed_slots(frame.slots, _EXTRA_PREFIX))
+        frame.slots[_EXTRA_SLOT] = extra
+        frame.slots[_EXTRA_COLLECTED_SLOT] = True
         return frame
 
 
@@ -182,6 +198,18 @@ class _FanoutAfterTurnCtxModule:
         return frame
 
 
+class _CollectAfterTurnTelemetrySlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: AfterTurnFrame) -> AfterTurnFrame:
+        ctx = cast(AfterTurnCtx, frame.slots[_CTX_SLOT])
+        extra_metadata = dict(ctx.extra_metadata)
+        extra_metadata.update(collect_prefixed_slots(frame.slots, _TELEMETRY_PREFIX))
+        frame.slots[_CTX_SLOT] = replace(ctx, extra_metadata=extra_metadata)
+        return frame
+
+
 class _DispatchOutboundModule:
     requires = (_CTX_SLOT,)
 
@@ -216,13 +244,21 @@ def default_after_turn_modules(
     outbound: OutboundPort,
     context: ContextBuilder,
     history_window: int = 500,
+    plugin_modules_before_commit: AfterTurnModules | None = None,
+    plugin_modules_before_fanout: AfterTurnModules | None = None,
 ) -> AfterTurnModules:
+    before_commit = plugin_modules_before_commit or []
+    before_fanout = plugin_modules_before_fanout or []
     return [
         _BuildTurnWorkModule(context, history_window),
+        *before_commit,
+        _CollectAfterTurnExtraSlotsModule(),
         _BuildTurnCommittedModule(),
         _FanoutTurnCommittedModule(bus),
         _LogBudgetModule(),
         _BuildAfterTurnCtxModule(),
+        *before_fanout,
+        _CollectAfterTurnTelemetrySlotsModule(),
         _FanoutAfterTurnCtxModule(bus),
         _DispatchOutboundModule(outbound),
         _ReturnOutboundMessageModule(),

--- a/agent/lifecycle/phases/before_reasoning.py
+++ b/agent/lifecycle/phases/before_reasoning.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 
 from agent.core.passive_support import predict_current_user_source_ref
 from agent.core.types import ContextRequest
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import (
+    PhaseFrame,
+    PhaseModule,
+    append_string_exports,
+    collect_prefixed_slots,
+)
 from agent.lifecycle.types import BeforeReasoningCtx, BeforeReasoningInput
 from bus.event_bus import EventBus
 
@@ -24,6 +29,8 @@ BeforeReasoningModules: TypeAlias = list[PhaseModule[BeforeReasoningFrame]]
 
 
 _CTX_SLOT = "reasoning:ctx"
+_EXTRA_HINT_PREFIX = "reasoning:extra_hint:"
+_ABORT_REPLY_SLOT = "reasoning:abort_reply"
 
 
 class _SyncToolContextModule:
@@ -64,6 +71,7 @@ class _BuildBeforeReasoningCtxModule:
             timestamp=before_turn.timestamp,
             skill_names=list(before_turn.skill_names),
             retrieved_memory_block=before_turn.retrieved_memory_block,
+            extra_hints=list(before_turn.extra_hints),
         )
         return frame
 
@@ -89,6 +97,8 @@ class _PromptWarmupModule:
 
     async def run(self, frame: BeforeReasoningFrame) -> BeforeReasoningFrame:
         ctx = cast(BeforeReasoningCtx, frame.slots[_CTX_SLOT])
+        if ctx.abort:
+            return frame
         _ = self._context.render(
             ContextRequest(
                 history=[],
@@ -100,6 +110,24 @@ class _PromptWarmupModule:
                 retrieved_memory_block=ctx.retrieved_memory_block,
             )
         )
+        return frame
+
+
+class _CollectBeforeReasoningExportSlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: BeforeReasoningFrame) -> BeforeReasoningFrame:
+        ctx = cast(BeforeReasoningCtx, frame.slots[_CTX_SLOT])
+        append_string_exports(
+            ctx.extra_hints,
+            collect_prefixed_slots(frame.slots, _EXTRA_HINT_PREFIX),
+        )
+        # 插件也可以在 before_emit 阶段直接改 ctx.abort；after_emit 阶段用 slot export。
+        abort_reply = frame.slots.get(_ABORT_REPLY_SLOT)
+        if isinstance(abort_reply, str) and abort_reply:
+            ctx.abort = True
+            ctx.abort_reply = abort_reply
         return frame
 
 
@@ -116,11 +144,18 @@ def default_before_reasoning_modules(
     tools: ToolRegistry,
     session_manager: SessionManager,
     context: ContextBuilder,
+    plugin_modules_before_emit: BeforeReasoningModules | None = None,
+    plugin_modules_after_emit: BeforeReasoningModules | None = None,
 ) -> BeforeReasoningModules:
+    before_emit = plugin_modules_before_emit or []
+    after_emit = plugin_modules_after_emit or []
     return [
         _SyncToolContextModule(tools, session_manager),
         _BuildBeforeReasoningCtxModule(),
+        *before_emit,
         _EmitBeforeReasoningCtxModule(bus),
+        *after_emit,
+        _CollectBeforeReasoningExportSlotsModule(),
         _PromptWarmupModule(context),
         _ReturnBeforeReasoningCtxModule(),
     ]

--- a/agent/lifecycle/phases/before_step.py
+++ b/agent/lifecycle/phases/before_step.py
@@ -7,7 +7,12 @@ from agent.core.passive_support import (
     build_context_hint_message,
     estimate_messages_tokens,
 )
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import (
+    PhaseFrame,
+    PhaseModule,
+    append_string_exports,
+    collect_prefixed_slots,
+)
 from agent.lifecycle.types import BeforeStepCtx, BeforeStepInput
 from bus.event_bus import EventBus
 
@@ -21,6 +26,9 @@ BeforeStepModules: TypeAlias = list[PhaseModule[BeforeStepFrame]]
 
 
 _CTX_SLOT = "step:ctx"
+_EXTRA_HINT_PREFIX = "step:extra_hint:"
+# slot suffix 统一用 abort_reply；step 内部映射为 early_stop，只终止当前 tool loop。
+_ABORT_REPLY_SLOT = "step:abort_reply"
 
 
 class _BuildBeforeStepCtxModule:
@@ -71,6 +79,23 @@ class _InjectHintsModule:
         return frame
 
 
+class _CollectBeforeStepExportSlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: BeforeStepFrame) -> BeforeStepFrame:
+        ctx = cast(BeforeStepCtx, frame.slots[_CTX_SLOT])
+        append_string_exports(
+            ctx.extra_hints,
+            collect_prefixed_slots(frame.slots, _EXTRA_HINT_PREFIX),
+        )
+        early_stop_reply = frame.slots.get(_ABORT_REPLY_SLOT)
+        if isinstance(early_stop_reply, str) and early_stop_reply:
+            ctx.early_stop = True
+            ctx.early_stop_reply = early_stop_reply
+        return frame
+
+
 class _ReturnBeforeStepCtxModule:
     requires = (_CTX_SLOT,)
 
@@ -79,10 +104,19 @@ class _ReturnBeforeStepCtxModule:
         return frame
 
 
-def default_before_step_modules(bus: EventBus) -> BeforeStepModules:
+def default_before_step_modules(
+    bus: EventBus,
+    plugin_modules_before_emit: BeforeStepModules | None = None,
+    plugin_modules_after_emit: BeforeStepModules | None = None,
+) -> BeforeStepModules:
+    before_emit = plugin_modules_before_emit or []
+    after_emit = plugin_modules_after_emit or []
     return [
         _BuildBeforeStepCtxModule(),
+        *before_emit,
         _EmitBeforeStepCtxModule(bus),
+        *after_emit,
+        _CollectBeforeStepExportSlotsModule(),
         _InjectHintsModule(),
         _ReturnBeforeStepCtxModule(),
     ]

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 from bus.event_bus import EventBus
 from agent.core.runtime_support import SessionLike
 from agent.core.types import ContextBundle
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import (
+    PhaseFrame,
+    PhaseModule,
+    append_string_exports,
+    collect_prefixed_slots,
+)
 from agent.lifecycle.types import BeforeTurnCtx, TurnState
 
 if TYPE_CHECKING:
@@ -25,6 +30,8 @@ BeforeTurnModules: TypeAlias = list[PhaseModule[BeforeTurnFrame]]
 _SESSION_SLOT = "session:session"
 _CONTEXT_BUNDLE_SLOT = "session:context_bundle"
 _CTX_SLOT = "session:ctx"
+_EXTRA_HINT_PREFIX = "session:extra_hint:"
+_ABORT_REPLY_SLOT = "session:abort_reply"
 
 
 class _AcquireSessionModule:
@@ -108,6 +115,23 @@ class _ReturnBeforeTurnCtxModule:
         return frame
 
 
+class _CollectBeforeTurnExportSlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        ctx = cast(BeforeTurnCtx, frame.slots[_CTX_SLOT])
+        append_string_exports(
+            ctx.extra_hints,
+            collect_prefixed_slots(frame.slots, _EXTRA_HINT_PREFIX),
+        )
+        abort_reply = frame.slots.get(_ABORT_REPLY_SLOT)
+        if isinstance(abort_reply, str) and abort_reply:
+            ctx.abort = True
+            ctx.abort_reply = abort_reply
+        return frame
+
+
 def default_before_turn_modules(
     bus: EventBus,
     session_manager: SessionManager,
@@ -124,5 +148,6 @@ def default_before_turn_modules(
         _BuildBeforeTurnCtxModule(),
         _EmitBeforeTurnCtxModule(bus),
         *late_modules,
+        _CollectBeforeTurnExportSlotsModule(),
         _ReturnBeforeTurnCtxModule(),
     ]

--- a/agent/lifecycle/phases/prompt_render.py
+++ b/agent/lifecycle/phases/prompt_render.py
@@ -5,8 +5,14 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 
 from agent.core.passive_support import build_context_hint_message
 from agent.core.types import ContextRequest
-from agent.lifecycle.phase import PhaseFrame, PhaseModule
+from agent.lifecycle.phase import (
+    PhaseFrame,
+    PhaseModule,
+    append_string_exports,
+    collect_prefixed_slots,
+)
 from agent.lifecycle.types import PromptRenderCtx, PromptRenderInput, PromptRenderResult
+from agent.prompting import PromptSectionRender
 from bus.event_bus import EventBus
 
 if TYPE_CHECKING:
@@ -23,6 +29,9 @@ PromptRenderModules: TypeAlias = list[PhaseModule[PromptRenderFrame]]
 
 _CTX_SLOT = "prompt:ctx"
 _RESULT_SLOT = "prompt:result"
+_SECTION_TOP_PREFIX = "prompt:section_top:"
+_SECTION_BOTTOM_PREFIX = "prompt:section_bottom:"
+_EXTRA_HINT_PREFIX = "prompt:extra_hint:"
 
 
 class _BuildPromptRenderCtxModule:
@@ -97,6 +106,27 @@ class _RenderPromptModule:
         return frame
 
 
+class _CollectPromptExportSlotsModule:
+    requires = (_CTX_SLOT,)
+    produces = (_CTX_SLOT,)
+
+    async def run(self, frame: PromptRenderFrame) -> PromptRenderFrame:
+        ctx = cast(PromptRenderCtx, frame.slots[_CTX_SLOT])
+        _append_sections(
+            ctx.system_sections_top,
+            collect_prefixed_slots(frame.slots, _SECTION_TOP_PREFIX),
+        )
+        _append_sections(
+            ctx.system_sections_bottom,
+            collect_prefixed_slots(frame.slots, _SECTION_BOTTOM_PREFIX),
+        )
+        append_string_exports(
+            ctx.extra_hints,
+            collect_prefixed_slots(frame.slots, _EXTRA_HINT_PREFIX),
+        )
+        return frame
+
+
 class _ReturnPromptRenderResultModule:
     requires = (_RESULT_SLOT,)
 
@@ -118,6 +148,24 @@ def default_prompt_render_modules(
         _EmitPromptRenderCtxModule(bus),
         *top_modules,
         *bottom_modules,
+        _CollectPromptExportSlotsModule(),
         _RenderPromptModule(context),
         _ReturnPromptRenderResultModule(),
     ]
+
+
+def _append_sections(
+    target: list[PromptSectionRender],
+    exports: dict[str, object],
+) -> None:
+    for name, value in exports.items():
+        if isinstance(value, PromptSectionRender):
+            target.append(value)
+        elif isinstance(value, str) and value.strip():
+            target.append(
+                PromptSectionRender(
+                    name=name,
+                    content=value,
+                    is_static=False,
+                )
+            )

--- a/agent/lifecycle/types.py
+++ b/agent/lifecycle/types.py
@@ -32,10 +32,12 @@ class TurnState:
     dispatch_outbound: bool
     session: SessionLike | None = None
     retrieval_raw: object | None = None
+    extra_metadata: dict[str, Any] = field(default_factory=_empty_metadata)
 
 
 @dataclass
 class BeforeTurnCtx:
+    # before-* ctx 走 GATE 链，插件可直接改写字段影响后续阶段。
     # read-only by convention
     session_key: str
     channel: str
@@ -49,6 +51,7 @@ class BeforeTurnCtx:
     skill_names: list[str] = field(default_factory=_empty_str_list)
     abort: bool = False
     abort_reply: str = ""
+    extra_hints: list[str] = field(default_factory=_empty_str_list)
     extra_metadata: dict[str, Any] = field(default_factory=_empty_metadata)
 
 
@@ -60,6 +63,7 @@ class BeforeReasoningInput:
 
 @dataclass
 class BeforeReasoningCtx:
+    # before-* ctx 走 GATE 链，插件可直接改写字段影响后续阶段。
     # read-only by convention
     session_key: str
     channel: str
@@ -92,6 +96,7 @@ class PromptRenderInput:
 
 @dataclass
 class PromptRenderCtx:
+    # render/before-step ctx 走 GATE 链，插件可直接改写字段影响后续阶段。
     # read-only by convention
     session_key: str
     channel: str
@@ -131,6 +136,7 @@ class BeforeStepInput:
 
 @dataclass
 class BeforeStepCtx:
+    # before-* ctx 走 GATE 链，插件可直接改写字段影响后续阶段。
     # read-only by convention
     session_key: str
     channel: str
@@ -146,6 +152,7 @@ class BeforeStepCtx:
 
 @dataclass(frozen=True)
 class AfterStepCtx:
+    # after-* fanout ctx 是观察快照；需要补充 metadata 时由 PhaseModule replace 新实例。
     session_key: str
     channel: str
     chat_id: str
@@ -156,6 +163,7 @@ class AfterStepCtx:
     tool_chain_partial: tuple[dict[str, Any], ...]
     partial_thinking: str | None
     has_more: bool
+    extra_metadata: dict[str, Any] = field(default_factory=_empty_metadata)
 
 
 @dataclass(frozen=True)
@@ -166,6 +174,7 @@ class AfterReasoningInput:
 
 @dataclass
 class AfterReasoningCtx:
+    # after_reasoning 仍是 GATE 链，插件可改写 reply/media/outbound_metadata。
     # read-only by convention
     session_key: str
     channel: str
@@ -198,6 +207,7 @@ class TurnSnapshot:
 
 @dataclass(frozen=True)
 class AfterTurnCtx:
+    # after-* fanout ctx 是观察快照；需要补充 metadata 时由 PhaseModule replace 新实例。
     session_key: str
     channel: str
     chat_id: str
@@ -206,6 +216,7 @@ class AfterTurnCtx:
     thinking: str | None
     # pre-dispatch intent flag: dispatch has NOT happened yet when Tap handlers run
     will_dispatch: bool
+    extra_metadata: dict[str, Any] = field(default_factory=_empty_metadata)
 
 
 @dataclass(frozen=True)

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -512,6 +512,13 @@ class AgentLoop:
     ) -> None:
         self._agent_core.add_before_turn_plugin_modules(early, late)
 
+    def add_before_reasoning_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        self._agent_core.add_before_reasoning_plugin_modules(before_emit, after_emit)
+
     def add_after_reasoning_plugin_modules(
         self,
         before_emit: list[object],
@@ -522,12 +529,33 @@ class AgentLoop:
             before_persist,
         )
 
+    def add_after_turn_plugin_modules(
+        self,
+        before_commit: list[object],
+        before_fanout: list[object],
+    ) -> None:
+        self._agent_core.add_after_turn_plugin_modules(before_commit, before_fanout)
+
     def add_prompt_render_plugin_modules(
         self,
         top: list[object],
         bottom: list[object],
     ) -> None:
         self._reasoner.add_prompt_render_plugin_modules(top, bottom)
+
+    def add_before_step_plugin_modules(
+        self,
+        before_emit: list[object],
+        after_emit: list[object],
+    ) -> None:
+        self._reasoner.add_before_step_plugin_modules(before_emit, after_emit)
+
+    def add_after_step_plugin_modules(
+        self,
+        before_fanout: list[object],
+        after_fanout: list[object],
+    ) -> None:
+        self._reasoner.add_after_step_plugin_modules(before_fanout, after_fanout)
 
     # ── 中断控制面 ────────────────────────────────────────────────
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -61,10 +61,18 @@ class PluginManager:
         self._tool_hooks: list[ToolHook] = []
         self._before_turn_modules_early: list[object] = []
         self._before_turn_modules_late: list[object] = []
+        self._before_reasoning_modules_before_emit: list[object] = []
+        self._before_reasoning_modules_after_emit: list[object] = []
         self._prompt_render_modules_top: list[object] = []
         self._prompt_render_modules_bottom: list[object] = []
+        self._before_step_modules_before_emit: list[object] = []
+        self._before_step_modules_after_emit: list[object] = []
+        self._after_step_modules_before_fanout: list[object] = []
+        self._after_step_modules_after_fanout: list[object] = []
         self._after_reasoning_modules_before_emit: list[object] = []
         self._after_reasoning_modules_before_persist: list[object] = []
+        self._after_turn_modules_before_commit: list[object] = []
+        self._after_turn_modules_before_fanout: list[object] = []
 
     @property
     def loaded_count(self) -> int:
@@ -83,6 +91,14 @@ class PluginManager:
         return list(self._before_turn_modules_late)
 
     @property
+    def before_reasoning_modules_before_emit(self) -> list[object]:
+        return list(self._before_reasoning_modules_before_emit)
+
+    @property
+    def before_reasoning_modules_after_emit(self) -> list[object]:
+        return list(self._before_reasoning_modules_after_emit)
+
+    @property
     def prompt_render_modules_top(self) -> list[object]:
         return list(self._prompt_render_modules_top)
 
@@ -91,12 +107,36 @@ class PluginManager:
         return list(self._prompt_render_modules_bottom)
 
     @property
+    def before_step_modules_before_emit(self) -> list[object]:
+        return list(self._before_step_modules_before_emit)
+
+    @property
+    def before_step_modules_after_emit(self) -> list[object]:
+        return list(self._before_step_modules_after_emit)
+
+    @property
+    def after_step_modules_before_fanout(self) -> list[object]:
+        return list(self._after_step_modules_before_fanout)
+
+    @property
+    def after_step_modules_after_fanout(self) -> list[object]:
+        return list(self._after_step_modules_after_fanout)
+
+    @property
     def after_reasoning_modules_before_emit(self) -> list[object]:
         return list(self._after_reasoning_modules_before_emit)
 
     @property
     def after_reasoning_modules_before_persist(self) -> list[object]:
         return list(self._after_reasoning_modules_before_persist)
+
+    @property
+    def after_turn_modules_before_commit(self) -> list[object]:
+        return list(self._after_turn_modules_before_commit)
+
+    @property
+    def after_turn_modules_before_fanout(self) -> list[object]:
+        return list(self._after_turn_modules_before_fanout)
 
     @property
     def telegram_bot_commands(self) -> list[tuple[str, str]]:
@@ -186,16 +226,38 @@ class PluginManager:
         early_count_before = len(self._before_turn_modules_early)
         late_count_before = len(self._before_turn_modules_late)
         self._collect_before_turn_modules(instance)
+        before_reasoning_before_emit_count_before = len(
+            self._before_reasoning_modules_before_emit
+        )
+        before_reasoning_after_emit_count_before = len(
+            self._before_reasoning_modules_after_emit
+        )
+        self._collect_before_reasoning_modules(instance)
         prompt_top_count_before = len(self._prompt_render_modules_top)
         prompt_bottom_count_before = len(self._prompt_render_modules_bottom)
         self._collect_prompt_render_modules(instance)
-        reasoning_before_emit_count_before = len(
+        step_before_emit_count_before = len(self._before_step_modules_before_emit)
+        step_after_emit_count_before = len(self._before_step_modules_after_emit)
+        self._collect_before_step_modules(instance)
+        after_step_before_fanout_count_before = len(
+            self._after_step_modules_before_fanout
+        )
+        after_step_after_fanout_count_before = len(
+            self._after_step_modules_after_fanout
+        )
+        self._collect_after_step_modules(instance)
+        after_reasoning_before_emit_count_before = len(
             self._after_reasoning_modules_before_emit
         )
-        reasoning_before_persist_count_before = len(
+        after_reasoning_before_persist_count_before = len(
             self._after_reasoning_modules_before_persist
         )
         self._collect_after_reasoning_modules(instance)
+        turn_before_commit_count_before = len(self._after_turn_modules_before_commit)
+        turn_before_fanout_count_before = len(
+            self._after_turn_modules_before_fanout
+        )
+        self._collect_after_turn_modules(instance)
         # 5. 给插件机会做异步初始化；失败时回滚所有注册
         try:
             if hasattr(instance, "initialize"):
@@ -209,13 +271,33 @@ class PluginManager:
             del self._tool_hooks[hook_count_before:]
             del self._before_turn_modules_early[early_count_before:]
             del self._before_turn_modules_late[late_count_before:]
+            del self._before_reasoning_modules_before_emit[
+                before_reasoning_before_emit_count_before:
+            ]
+            del self._before_reasoning_modules_after_emit[
+                before_reasoning_after_emit_count_before:
+            ]
             del self._prompt_render_modules_top[prompt_top_count_before:]
             del self._prompt_render_modules_bottom[prompt_bottom_count_before:]
+            del self._before_step_modules_before_emit[step_before_emit_count_before:]
+            del self._before_step_modules_after_emit[step_after_emit_count_before:]
+            del self._after_step_modules_before_fanout[
+                after_step_before_fanout_count_before:
+            ]
+            del self._after_step_modules_after_fanout[
+                after_step_after_fanout_count_before:
+            ]
             del self._after_reasoning_modules_before_emit[
-                reasoning_before_emit_count_before:
+                after_reasoning_before_emit_count_before:
             ]
             del self._after_reasoning_modules_before_persist[
-                reasoning_before_persist_count_before:
+                after_reasoning_before_persist_count_before:
+            ]
+            del self._after_turn_modules_before_commit[
+                turn_before_commit_count_before:
+            ]
+            del self._after_turn_modules_before_fanout[
+                turn_before_fanout_count_before:
             ]
             return
         self._loaded.add(mp)
@@ -307,6 +389,14 @@ class PluginManager:
             _load_module_list(instance, "before_turn_modules_late")
         )
 
+    def _collect_before_reasoning_modules(self, instance: Any) -> None:
+        self._before_reasoning_modules_before_emit.extend(
+            _load_module_list(instance, "before_reasoning_modules_before_emit")
+        )
+        self._before_reasoning_modules_after_emit.extend(
+            _load_module_list(instance, "before_reasoning_modules_after_emit")
+        )
+
     def _collect_prompt_render_modules(self, instance: Any) -> None:
         self._prompt_render_modules_top.extend(
             _load_module_list(instance, "prompt_render_modules_top")
@@ -315,12 +405,36 @@ class PluginManager:
             _load_module_list(instance, "prompt_render_modules_bottom")
         )
 
+    def _collect_before_step_modules(self, instance: Any) -> None:
+        self._before_step_modules_before_emit.extend(
+            _load_module_list(instance, "before_step_modules_before_emit")
+        )
+        self._before_step_modules_after_emit.extend(
+            _load_module_list(instance, "before_step_modules_after_emit")
+        )
+
+    def _collect_after_step_modules(self, instance: Any) -> None:
+        self._after_step_modules_before_fanout.extend(
+            _load_module_list(instance, "after_step_modules_before_fanout")
+        )
+        self._after_step_modules_after_fanout.extend(
+            _load_module_list(instance, "after_step_modules_after_fanout")
+        )
+
     def _collect_after_reasoning_modules(self, instance: Any) -> None:
         self._after_reasoning_modules_before_emit.extend(
             _load_module_list(instance, "after_reasoning_modules_before_emit")
         )
         self._after_reasoning_modules_before_persist.extend(
             _load_module_list(instance, "after_reasoning_modules_before_persist")
+        )
+
+    def _collect_after_turn_modules(self, instance: Any) -> None:
+        self._after_turn_modules_before_commit.extend(
+            _load_module_list(instance, "after_turn_modules_before_commit")
+        )
+        self._after_turn_modules_before_fanout.extend(
+            _load_module_list(instance, "after_turn_modules_before_fanout")
         )
 
     async def terminate_all(self) -> None:
@@ -340,10 +454,18 @@ class PluginManager:
         self._tool_hooks.clear()
         self._before_turn_modules_early.clear()
         self._before_turn_modules_late.clear()
+        self._before_reasoning_modules_before_emit.clear()
+        self._before_reasoning_modules_after_emit.clear()
         self._prompt_render_modules_top.clear()
         self._prompt_render_modules_bottom.clear()
+        self._before_step_modules_before_emit.clear()
+        self._before_step_modules_after_emit.clear()
+        self._after_step_modules_before_fanout.clear()
+        self._after_step_modules_after_fanout.clear()
         self._after_reasoning_modules_before_emit.clear()
         self._after_reasoning_modules_before_persist.clear()
+        self._after_turn_modules_before_commit.clear()
+        self._after_turn_modules_before_fanout.clear()
 
 
 def _load_plugin_config(plugin_dir: Path) -> "Any":

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -117,13 +117,29 @@ class CoreRuntime:
                 self.plugin_manager.before_turn_modules_early,
                 self.plugin_manager.before_turn_modules_late,
             )
+            self.loop.add_before_reasoning_plugin_modules(
+                self.plugin_manager.before_reasoning_modules_before_emit,
+                self.plugin_manager.before_reasoning_modules_after_emit,
+            )
             self.loop.add_prompt_render_plugin_modules(
                 self.plugin_manager.prompt_render_modules_top,
                 self.plugin_manager.prompt_render_modules_bottom,
             )
+            self.loop.add_before_step_plugin_modules(
+                self.plugin_manager.before_step_modules_before_emit,
+                self.plugin_manager.before_step_modules_after_emit,
+            )
+            self.loop.add_after_step_plugin_modules(
+                self.plugin_manager.after_step_modules_before_fanout,
+                self.plugin_manager.after_step_modules_after_fanout,
+            )
             self.loop.add_after_reasoning_plugin_modules(
                 self.plugin_manager.after_reasoning_modules_before_emit,
                 self.plugin_manager.after_reasoning_modules_before_persist,
+            )
+            self.loop.add_after_turn_plugin_modules(
+                self.plugin_manager.after_turn_modules_before_commit,
+                self.plugin_manager.after_turn_modules_before_fanout,
             )
             if self.plugin_manager.tool_hooks:
                 self.loop.add_tool_hooks(self.plugin_manager.tool_hooks)

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -15,9 +15,13 @@ from agent.lifecycle.phase import Phase
 from agent.tools.registry import ToolRegistry
 from core.observe.db import open_db as open_observe_db
 from bus.event_bus import EventBus
-from bus.events import InboundMessage
+from bus.events import InboundMessage, OutboundMessage
+from bus.events_lifecycle import TurnCommitted
 from agent.lifecycle.types import (
+    AfterReasoningCtx,
+    AfterReasoningInput,
     AfterStepCtx,
+    AfterTurnCtx,
     BeforeReasoningCtx,
     BeforeReasoningInput,
     BeforeStepCtx,
@@ -25,11 +29,20 @@ from agent.lifecycle.types import (
     BeforeTurnCtx,
     PromptRenderCtx,
     PromptRenderInput,
+    TurnSnapshot,
     TurnState,
+)
+from agent.lifecycle.phases.after_reasoning import (
+    AfterReasoningFrame,
+    default_after_reasoning_modules,
 )
 from agent.lifecycle.phases.after_step import (
     AfterStepFrame,
     default_after_step_modules,
+)
+from agent.lifecycle.phases.after_turn import (
+    AfterTurnFrame,
+    default_after_turn_modules,
 )
 from agent.lifecycle.phases.before_reasoning import (
     BeforeReasoningFrame,
@@ -433,6 +446,7 @@ async def test_before_turn_accepts_plugin_modules_early_and_late():
             ctx = cast(BeforeTurnCtx, frame.slots["session:ctx"])
             ctx.extra_metadata["late_seen"] = ctx.retrieved_memory_block
             frame.slots["session:ctx"] = ctx
+            frame.slots["session:extra_hint:late"] = "hint from before turn"
             return frame
 
     phase = Phase(
@@ -454,6 +468,7 @@ async def test_before_turn_accepts_plugin_modules_early_and_late():
     assert seen == ["early", "late"]
     assert state.msg.metadata["early_seen"] is True
     assert ctx.extra_metadata["late_seen"] == "retrieved block"
+    assert ctx.extra_hints == ["hint from before turn"]
     ctx_store.prepare.assert_called_once()
 
 
@@ -724,13 +739,58 @@ async def test_before_reasoning_chain_can_add_extra_hints():
         content=msg.content, timestamp=msg.timestamp,
         retrieved_memory_block="", retrieval_trace_raw=None,
         history_messages=(),
+        extra_hints=["hint from before turn"],
     )
 
     state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
     state.session = session
 
     ctx = await phase.run(BeforeReasoningInput(state=state, before_turn=before_turn))
-    assert ctx.extra_hints == ["hint from plugin"]
+    assert ctx.extra_hints == ["hint from before turn", "hint from plugin"]
+
+
+@pytest.mark.asyncio
+async def test_before_reasoning_collects_export_slots():
+    bus = EventBus()
+    tools = Mock()
+    tools.set_context = Mock()
+    session = _DummySession("telegram:123")
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    context_builder = Mock()
+    context_builder.render = Mock(return_value=None)
+
+    class SlotModule:
+        async def run(self, frame: BeforeReasoningFrame) -> BeforeReasoningFrame:
+            frame.slots["reasoning:extra_hint:test"] = "slot hint"
+            frame.slots["reasoning:abort_reply"] = "slot abort"
+            return frame
+
+    phase = Phase(
+        default_before_reasoning_modules(
+            bus,
+            cast(ToolRegistry, tools),
+            cast(SessionManager, session_mgr),
+            cast(ContextBuilder, context_builder),
+            plugin_modules_after_emit=[SlotModule()],
+        ),
+        frame_factory=BeforeReasoningFrame,
+    )
+    msg = _inbound()
+    before_turn = BeforeTurnCtx(
+        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
+        content=msg.content, timestamp=msg.timestamp,
+        retrieved_memory_block="", retrieval_trace_raw=None,
+        history_messages=(),
+    )
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+    state.session = session
+
+    ctx = await phase.run(BeforeReasoningInput(state=state, before_turn=before_turn))
+
+    assert ctx.extra_hints == ["slot hint"]
+    assert ctx.abort is True
+    assert ctx.abort_reply == "slot abort"
+    context_builder.render.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -896,6 +956,56 @@ async def test_prompt_render_chain_respects_disabled_sections(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_prompt_render_collects_export_slots(tmp_path):
+    class SlotModule:
+        async def run(self, frame: PromptRenderFrame) -> PromptRenderFrame:
+            frame.slots["prompt:section_top:top_slot"] = "top content"
+            frame.slots["prompt:section_bottom:bottom_slot"] = PromptSectionRender(
+                name="bottom_slot",
+                content="bottom content",
+                is_static=False,
+            )
+            frame.slots["prompt:extra_hint:test"] = "hint content"
+            return frame
+
+    memory = SimpleNamespace(
+        read_self=lambda: "",
+        read_profile=lambda: "",
+        read_recent_context=lambda: "",
+    )
+    context = ContextBuilder(tmp_path, memory=cast(Any, memory))
+    phase = Phase(
+        default_prompt_render_modules(
+            EventBus(),
+            context,
+            plugin_modules_bottom=[SlotModule()],
+        ),
+        frame_factory=PromptRenderFrame,
+    )
+
+    result = await phase.run(
+        PromptRenderInput(
+            session_key="k",
+            channel="cli",
+            chat_id="ch",
+            content="hello",
+            media=None,
+            timestamp=_now,
+            history=[],
+            skill_names=None,
+            retrieved_memory_block="",
+            disabled_sections=set(),
+            turn_injection_prompt="",
+        )
+    )
+    rendered = str(result.messages)
+
+    assert "top content" in rendered
+    assert "bottom content" in rendered
+    assert "hint content" in rendered
+
+
+@pytest.mark.asyncio
 async def test_before_step_finalize_injects_extra_hints():
     bus = EventBus()
 
@@ -920,6 +1030,39 @@ async def test_before_step_finalize_injects_extra_hints():
 
     expected = build_context_hint_message("plugin_hints", "hints from plugin")
     assert messages == [{"role": "user", "content": "hello"}, expected]
+
+
+@pytest.mark.asyncio
+async def test_before_step_collects_export_slots():
+    class SlotModule:
+        async def run(self, frame: BeforeStepFrame) -> BeforeStepFrame:
+            frame.slots["step:extra_hint:test"] = "slot step hint"
+            frame.slots["step:abort_reply"] = "slot stop"
+            return frame
+
+    phase = Phase(
+        default_before_step_modules(
+            EventBus(),
+            plugin_modules_after_emit=[SlotModule()],
+        ),
+        frame_factory=BeforeStepFrame,
+    )
+    messages = [{"role": "user", "content": "hello"}]
+
+    ctx = await phase.run(
+        BeforeStepInput(
+            session_key="k",
+            channel="c",
+            chat_id="ch",
+            iteration=1,
+            messages=messages,
+            visible_names=None,
+        )
+    )
+
+    assert ctx.extra_hints == ["slot step hint"]
+    assert ctx.early_stop is True
+    assert ctx.early_stop_reply == "slot stop"
 
 
 @pytest.mark.asyncio
@@ -976,3 +1119,161 @@ async def test_after_step_phase_runs_observers():
     )
 
     assert side_effect == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_after_step_collects_telemetry_slots_before_fanout():
+    bus = EventBus()
+    seen: list[dict[str, Any]] = []
+
+    class SlotModule:
+        async def run(self, frame: AfterStepFrame) -> AfterStepFrame:
+            frame.slots["step:telemetry:test"] = {"ok": True}
+            return frame
+
+    class AfterFanoutSlotModule:
+        async def run(self, frame: AfterStepFrame) -> AfterStepFrame:
+            frame.slots["step:telemetry:after"] = "done"
+            frame.slots["step:telemetry:test"] = "overwritten"
+            return frame
+
+    async def handler(ctx: AfterStepCtx) -> None:
+        seen.append(dict(ctx.extra_metadata))
+
+    bus.on(AfterStepCtx, handler)
+    phase = Phase(
+        default_after_step_modules(
+            bus,
+            plugin_modules_before_fanout=[SlotModule()],
+            plugin_modules_after_fanout=[AfterFanoutSlotModule()],
+        ),
+        frame_factory=AfterStepFrame,
+    )
+    ctx = await phase.run(
+        AfterStepCtx(
+            session_key="k",
+            channel="c",
+            chat_id="ch",
+            iteration=0,
+            tools_called=(),
+            partial_reply="ok",
+            tools_used_so_far=(),
+            tool_chain_partial=(),
+            partial_thinking=None,
+            has_more=True,
+        )
+    )
+
+    assert seen == [{"test": {"ok": True}}]
+    assert ctx.extra_metadata == {"test": {"ok": True}, "after": "done"}
+
+
+@pytest.mark.asyncio
+async def test_after_reasoning_collects_persist_and_outbound_slots():
+    class SlotModule:
+        async def run(self, frame: AfterReasoningFrame) -> AfterReasoningFrame:
+            frame.slots["persist:user:user_flag"] = "u"
+            frame.slots["persist:assistant:assistant_flag"] = "a"
+            frame.slots["outbound:metadata:plugin_flag"] = "m"
+            frame.slots["outbound:media:image"] = ["/tmp/a.png", None, 1]
+            return frame
+
+    session = _DummySession("telegram:123")
+    msg = _inbound()
+    state = TurnState(msg=msg, session_key=session.key, dispatch_outbound=True)
+    state.session = session
+    state.extra_metadata["before_turn_flag"] = "bt"
+    services = SimpleNamespace(
+        presence=Mock(),
+        session_manager=SimpleNamespace(append_messages=AsyncMock()),
+    )
+    turn_result = SimpleNamespace(
+        reply="reply",
+        tool_chain=[],
+        tools_used=[],
+        thinking=None,
+        streamed=False,
+        context_retry={},
+    )
+    phase = Phase(
+        default_after_reasoning_modules(
+            EventBus(),
+            cast(Any, services),
+            plugin_modules_before_persist=[SlotModule()],
+        ),
+        frame_factory=AfterReasoningFrame,
+    )
+
+    result = await phase.run(AfterReasoningInput(state=state, turn_result=turn_result))
+
+    assert session.messages[0]["user_flag"] == "u"
+    assert session.messages[1]["assistant_flag"] == "a"
+    assert result.outbound.metadata["before_turn_flag"] == "bt"
+    assert result.outbound.metadata["plugin_flag"] == "m"
+    assert result.outbound.media == ["/tmp/a.png"]
+
+
+@pytest.mark.asyncio
+async def test_after_turn_collects_extra_and_telemetry_slots():
+    committed_extra: list[dict[str, object]] = []
+    after_turn_metadata: list[dict[str, object]] = []
+    bus = EventBus()
+
+    class ExtraModule:
+        async def run(self, frame: AfterTurnFrame) -> AfterTurnFrame:
+            frame.slots["turn:extra:plugin_flag"] = "extra"
+            return frame
+
+    class TelemetryModule:
+        async def run(self, frame: AfterTurnFrame) -> AfterTurnFrame:
+            frame.slots["turn:telemetry:plugin_flag"] = "telemetry"
+            return frame
+
+    async def committed_handler(event: TurnCommitted) -> None:
+        committed_extra.append(dict(event.extra))
+
+    async def after_turn_handler(ctx: AfterTurnCtx) -> None:
+        after_turn_metadata.append(dict(ctx.extra_metadata))
+
+    bus.on(AfterTurnCtx, after_turn_handler)
+    bus.on(TurnCommitted, committed_handler)
+    session = _DummySession("telegram:123")
+    msg = _inbound()
+    state = TurnState(msg=msg, session_key=session.key, dispatch_outbound=False)
+    state.session = session
+    ctx = AfterReasoningCtx(
+        session_key=session.key,
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        tools_used=(),
+        thinking=None,
+        response_metadata=SimpleNamespace(raw_text="reply"),
+        streamed=False,
+        tool_chain=(),
+        context_retry={},
+        reply="reply",
+    )
+    context = Mock()
+    context.render = Mock(return_value=SimpleNamespace(messages=[]))
+    context.last_debug_breakdown = []
+    phase = Phase(
+        default_after_turn_modules(
+            bus,
+            SimpleNamespace(dispatch=AsyncMock()),
+            cast(ContextBuilder, context),
+            plugin_modules_before_commit=[ExtraModule()],
+            plugin_modules_before_fanout=[TelemetryModule()],
+        ),
+        frame_factory=AfterTurnFrame,
+    )
+
+    await phase.run(
+        TurnSnapshot(
+            state=state,
+            outbound=OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content="reply"),
+            ctx=ctx,
+        )
+    )
+
+    assert committed_extra[0]["plugin_flag"] == "extra"
+    assert after_turn_metadata == [{"plugin_flag": "telemetry"}]

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -10,6 +10,8 @@ import pytest
 from agent.context import ContextBuilder
 from agent.core.passive_support import build_context_hint_message
 from agent.core.passive_turn import ContextStore
+from agent.core.response_parser import ResponseMetadata
+from agent.core.runtime_support import TurnRunResult
 from agent.core.types import ContextBundle
 from agent.lifecycle.phase import Phase
 from agent.tools.registry import ToolRegistry
@@ -61,6 +63,7 @@ from agent.lifecycle.phases.prompt_render import (
     default_prompt_render_modules,
 )
 from agent.prompting import PromptSectionRender
+from agent.turns.outbound import OutboundDispatch
 from session.manager import SessionManager
 
 _now = datetime.now()
@@ -96,6 +99,11 @@ class _MemoryStatusPluginModule:
             abort_reply=_format_memory_status_reply(messages, last),
         )
         return frame
+
+
+class _DummyOutbound:
+    async def dispatch(self, outbound: OutboundDispatch) -> bool:
+        return True
 
 
 class _KVCachePluginModule:
@@ -1187,7 +1195,7 @@ async def test_after_reasoning_collects_persist_and_outbound_slots():
         presence=Mock(),
         session_manager=SimpleNamespace(append_messages=AsyncMock()),
     )
-    turn_result = SimpleNamespace(
+    turn_result = TurnRunResult(
         reply="reply",
         tool_chain=[],
         tools_used=[],
@@ -1247,7 +1255,7 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
         chat_id=msg.chat_id,
         tools_used=(),
         thinking=None,
-        response_metadata=SimpleNamespace(raw_text="reply"),
+        response_metadata=ResponseMetadata(raw_text="reply"),
         streamed=False,
         tool_chain=(),
         context_retry={},
@@ -1259,7 +1267,7 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
     phase = Phase(
         default_after_turn_modules(
             bus,
-            SimpleNamespace(dispatch=AsyncMock()),
+            _DummyOutbound(),
             cast(ContextBuilder, context),
             plugin_modules_before_commit=[ExtraModule()],
             plugin_modules_before_fanout=[TelemetryModule()],

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -292,11 +292,43 @@ class PromptBottomModule:
     async def run(self, frame):
         return frame
 
+class BeforeReasoningBeforeEmitModule:
+    async def run(self, frame):
+        return frame
+
+class BeforeReasoningAfterEmitModule:
+    async def run(self, frame):
+        return frame
+
+class BeforeStepBeforeEmitModule:
+    async def run(self, frame):
+        return frame
+
+class BeforeStepAfterEmitModule:
+    async def run(self, frame):
+        return frame
+
+class AfterStepBeforeFanoutModule:
+    async def run(self, frame):
+        return frame
+
+class AfterStepAfterFanoutModule:
+    async def run(self, frame):
+        return frame
+
 class AfterReasoningBeforeEmitModule:
     async def run(self, frame):
         return frame
 
 class AfterReasoningBeforePersistModule:
+    async def run(self, frame):
+        return frame
+
+class AfterTurnBeforeCommitModule:
+    async def run(self, frame):
+        return frame
+
+class AfterTurnBeforeFanoutModule:
     async def run(self, frame):
         return frame
 
@@ -310,17 +342,41 @@ class PhasePlugin(Plugin):
     def before_turn_modules_late(self):
         return [LateModule()]
 
+    def before_reasoning_modules_before_emit(self):
+        return [BeforeReasoningBeforeEmitModule()]
+
+    def before_reasoning_modules_after_emit(self):
+        return [BeforeReasoningAfterEmitModule()]
+
     def prompt_render_modules_top(self):
         return [PromptTopModule()]
 
     def prompt_render_modules_bottom(self):
         return [PromptBottomModule()]
 
+    def before_step_modules_before_emit(self):
+        return [BeforeStepBeforeEmitModule()]
+
+    def before_step_modules_after_emit(self):
+        return [BeforeStepAfterEmitModule()]
+
+    def after_step_modules_before_fanout(self):
+        return [AfterStepBeforeFanoutModule()]
+
+    def after_step_modules_after_fanout(self):
+        return [AfterStepAfterFanoutModule()]
+
     def after_reasoning_modules_before_emit(self):
         return [AfterReasoningBeforeEmitModule()]
 
     def after_reasoning_modules_before_persist(self):
         return [AfterReasoningBeforePersistModule()]
+
+    def after_turn_modules_before_commit(self):
+        return [AfterTurnBeforeCommitModule()]
+
+    def after_turn_modules_before_fanout(self):
+        return [AfterTurnBeforeFanoutModule()]
 """.strip(),
             encoding="utf-8",
         )
@@ -329,16 +385,32 @@ class PhasePlugin(Plugin):
 
         assert len(mgr.before_turn_modules_early) == 1
         assert len(mgr.before_turn_modules_late) == 1
+        assert len(mgr.before_reasoning_modules_before_emit) == 1
+        assert len(mgr.before_reasoning_modules_after_emit) == 1
         assert len(mgr.prompt_render_modules_top) == 1
         assert len(mgr.prompt_render_modules_bottom) == 1
+        assert len(mgr.before_step_modules_before_emit) == 1
+        assert len(mgr.before_step_modules_after_emit) == 1
+        assert len(mgr.after_step_modules_before_fanout) == 1
+        assert len(mgr.after_step_modules_after_fanout) == 1
         assert len(mgr.after_reasoning_modules_before_emit) == 1
         assert len(mgr.after_reasoning_modules_before_persist) == 1
+        assert len(mgr.after_turn_modules_before_commit) == 1
+        assert len(mgr.after_turn_modules_before_fanout) == 1
         assert mgr.before_turn_modules_early[0].__class__.__name__ == "EarlyModule"
         assert mgr.before_turn_modules_late[0].__class__.__name__ == "LateModule"
+        assert mgr.before_reasoning_modules_before_emit[0].__class__.__name__ == "BeforeReasoningBeforeEmitModule"
+        assert mgr.before_reasoning_modules_after_emit[0].__class__.__name__ == "BeforeReasoningAfterEmitModule"
         assert mgr.prompt_render_modules_top[0].__class__.__name__ == "PromptTopModule"
         assert mgr.prompt_render_modules_bottom[0].__class__.__name__ == "PromptBottomModule"
+        assert mgr.before_step_modules_before_emit[0].__class__.__name__ == "BeforeStepBeforeEmitModule"
+        assert mgr.before_step_modules_after_emit[0].__class__.__name__ == "BeforeStepAfterEmitModule"
+        assert mgr.after_step_modules_before_fanout[0].__class__.__name__ == "AfterStepBeforeFanoutModule"
+        assert mgr.after_step_modules_after_fanout[0].__class__.__name__ == "AfterStepAfterFanoutModule"
         assert mgr.after_reasoning_modules_before_emit[0].__class__.__name__ == "AfterReasoningBeforeEmitModule"
         assert mgr.after_reasoning_modules_before_persist[0].__class__.__name__ == "AfterReasoningBeforePersistModule"
+        assert mgr.after_turn_modules_before_commit[0].__class__.__name__ == "AfterTurnBeforeCommitModule"
+        assert mgr.after_turn_modules_before_fanout[0].__class__.__name__ == "AfterTurnBeforeFanoutModule"
 
 
 # ── _conf_schema.json 测试 ────────────────────────────────────────────────────
@@ -805,10 +877,18 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.tool_hooks = [object()]
             self.before_turn_modules_early = [object()]
             self.before_turn_modules_late = [object()]
+            self.before_reasoning_modules_before_emit = [object()]
+            self.before_reasoning_modules_after_emit = [object()]
             self.prompt_render_modules_top = [object()]
             self.prompt_render_modules_bottom = [object()]
+            self.before_step_modules_before_emit = [object()]
+            self.before_step_modules_after_emit = [object()]
+            self.after_step_modules_before_fanout = [object()]
+            self.after_step_modules_after_fanout = [object()]
             self.after_reasoning_modules_before_emit = [object()]
             self.after_reasoning_modules_before_persist = [object()]
+            self.after_turn_modules_before_commit = [object()]
+            self.after_turn_modules_before_fanout = [object()]
             self.loaded_count = 0
 
         async def load_all(self) -> None:
@@ -819,10 +899,18 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.received_hooks: list[ToolHook] | None = None
             self.received_before_turn_early: list[object] | None = None
             self.received_before_turn_late: list[object] | None = None
+            self.received_before_reasoning_before_emit: list[object] | None = None
+            self.received_before_reasoning_after_emit: list[object] | None = None
             self.received_prompt_render_top: list[object] | None = None
             self.received_prompt_render_bottom: list[object] | None = None
+            self.received_before_step_before_emit: list[object] | None = None
+            self.received_before_step_after_emit: list[object] | None = None
+            self.received_after_step_before_fanout: list[object] | None = None
+            self.received_after_step_after_fanout: list[object] | None = None
             self.received_after_reasoning_before_emit: list[object] | None = None
             self.received_after_reasoning_before_persist: list[object] | None = None
+            self.received_after_turn_before_commit: list[object] | None = None
+            self.received_after_turn_before_fanout: list[object] | None = None
 
         def add_tool_hooks(self, hooks: list[ToolHook]) -> None:
             self.received_hooks = list(hooks)
@@ -835,6 +923,14 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.received_before_turn_early = list(early)
             self.received_before_turn_late = list(late)
 
+        def add_before_reasoning_plugin_modules(
+            self,
+            before_emit: list[object],
+            after_emit: list[object],
+        ) -> None:
+            self.received_before_reasoning_before_emit = list(before_emit)
+            self.received_before_reasoning_after_emit = list(after_emit)
+
         def add_prompt_render_plugin_modules(
             self,
             top: list[object],
@@ -843,6 +939,22 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.received_prompt_render_top = list(top)
             self.received_prompt_render_bottom = list(bottom)
 
+        def add_before_step_plugin_modules(
+            self,
+            before_emit: list[object],
+            after_emit: list[object],
+        ) -> None:
+            self.received_before_step_before_emit = list(before_emit)
+            self.received_before_step_after_emit = list(after_emit)
+
+        def add_after_step_plugin_modules(
+            self,
+            before_fanout: list[object],
+            after_fanout: list[object],
+        ) -> None:
+            self.received_after_step_before_fanout = list(before_fanout)
+            self.received_after_step_after_fanout = list(after_fanout)
+
         def add_after_reasoning_plugin_modules(
             self,
             before_emit: list[object],
@@ -850,6 +962,14 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
         ) -> None:
             self.received_after_reasoning_before_emit = list(before_emit)
             self.received_after_reasoning_before_persist = list(before_persist)
+
+        def add_after_turn_plugin_modules(
+            self,
+            before_commit: list[object],
+            before_fanout: list[object],
+        ) -> None:
+            self.received_after_turn_before_commit = list(before_commit)
+            self.received_after_turn_before_fanout = list(before_fanout)
 
     class FakeSpawnTool:
         def __init__(self) -> None:
@@ -894,9 +1014,17 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
     assert plugin_manager.loaded_count == 1
     assert loop.received_before_turn_early == plugin_manager.before_turn_modules_early
     assert loop.received_before_turn_late == plugin_manager.before_turn_modules_late
+    assert loop.received_before_reasoning_before_emit == plugin_manager.before_reasoning_modules_before_emit
+    assert loop.received_before_reasoning_after_emit == plugin_manager.before_reasoning_modules_after_emit
     assert loop.received_prompt_render_top == plugin_manager.prompt_render_modules_top
     assert loop.received_prompt_render_bottom == plugin_manager.prompt_render_modules_bottom
+    assert loop.received_before_step_before_emit == plugin_manager.before_step_modules_before_emit
+    assert loop.received_before_step_after_emit == plugin_manager.before_step_modules_after_emit
+    assert loop.received_after_step_before_fanout == plugin_manager.after_step_modules_before_fanout
+    assert loop.received_after_step_after_fanout == plugin_manager.after_step_modules_after_fanout
     assert loop.received_after_reasoning_before_emit == plugin_manager.after_reasoning_modules_before_emit
     assert loop.received_after_reasoning_before_persist == plugin_manager.after_reasoning_modules_before_persist
+    assert loop.received_after_turn_before_commit == plugin_manager.after_turn_modules_before_commit
+    assert loop.received_after_turn_before_fanout == plugin_manager.after_turn_modules_before_fanout
     assert loop.received_hooks == plugin_manager.tool_hooks
     assert spawn_tool.received_hooks == plugin_manager.tool_hooks


### PR DESCRIPTION
## 背景

这次 PR 把已有 persist slot 的导出模式推广到生命周期各阶段，让插件可以用固定命名空间向后续链路传递 hint、metadata、telemetry、persist 字段和 outbound 信息。

## 改动

- 新增通用 slot 收集与字符串导出 helper，覆盖 before_turn、prompt_render、before_reasoning、before_step、after_step、after_reasoning、after_turn。
- PluginManager、AgentCore、AgentLoop 和 bootstrap 接入各阶段插件 module 注入点，step 阶段也可通过 AgentCoreDeps 声明。
- before_turn extra_metadata 现在会进入 TurnState 并合并进 outbound metadata，session:extra_hint:* 会传递到 reasoning。
- after_step 支持 fanout 前后两次 telemetry 收集，并避免 after_fanout 覆盖 fanout handler 已看到的同名 key。
- after_turn 支持 turn:extra:* 和 turn:telemetry:*，并用 requires 保护 collect 与 commit 顺序。
- 统一提前终止 slot 命名为 session:abort_reply、reasoning:abort_reply、step:abort_reply。
- 补充生命周期和插件管理器回归测试，覆盖 slot 导出、注入装配、非法媒体值过滤和 telemetry 覆盖规则。

## 验证

- `pytest tests/test_lifecycle_phases.py tests/test_plugin_manager.py tests/test_citation_plugin.py tests/test_agent_core_p5_agent_core.py tests/test_agent_core_p7_commit.py`：79 passed
- `pyright agent/lifecycle/phase.py agent/lifecycle/phases/before_turn.py agent/lifecycle/phases/prompt_render.py agent/lifecycle/phases/before_reasoning.py agent/lifecycle/phases/before_step.py agent/lifecycle/phases/after_step.py agent/lifecycle/phases/after_reasoning.py agent/lifecycle/phases/after_turn.py agent/lifecycle/types.py agent/plugins/manager.py agent/core/passive_turn.py agent/looping/core.py bootstrap/tools.py tests/test_lifecycle_phases.py tests/test_plugin_manager.py`：0 errors, 280 warnings
- `pytest tests/`：1223 passed
