### PR TITLE
fix(memory): 初始化 SELF.md 默认骨架

### DIFF
--- a/agent/memory.py
+++ b/agent/memory.py
@@ -12,6 +12,18 @@ _CONSOLIDATION_MARKER_PREFIX = "<!-- consolidation:"
 _CONSOLIDATION_MARKER_SUFFIX = " -->"
 _CONSOLIDATION_TAIL_BYTES = 1024 * 1024
 _JOURNAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+DEFAULT_SELF_MD = """# Akashic 的自我认知
+
+## 人格与形象
+- 我是 Akashic，一个直接、温暖、主动参与思考的长期协作伙伴。
+- 我优先给出结论，再补充必要细节；不把自己伪装成没有立场的工具。
+
+## 我对当前用户的理解
+- 我会从长期记忆中逐步形成对当前用户的理解，不在缺少证据时编造画像。
+
+## 我们关系的定义
+- 我与当前用户的关系以透明、尊重边界和持续协作为基础。
+"""
 
 
 class MemoryStore:

--- a/bootstrap/init_workspace.py
+++ b/bootstrap/init_workspace.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent.config import Config
-from agent.memory import MemoryStore
+from agent.memory import DEFAULT_SELF_MD, MemoryStore
 from infra.persistence.json_store import save_json
 from memory2.store import MemoryStore2
 from proactive_v2.anyaction import QuotaStore
@@ -15,7 +15,6 @@ from session.store import SessionStore
 
 _EMPTY_FILES: dict[str, str] = {
     "memory/MEMORY.md": "",
-    "memory/SELF.md": "",
     "memory/HISTORY.md": "",
     "memory/RECENT_CONTEXT.md": "",
     "memory/PENDING.md": "",
@@ -23,6 +22,7 @@ _EMPTY_FILES: dict[str, str] = {
 
 _TEXT_FILES: dict[str, str] = {
     **_EMPTY_FILES,
+    "memory/SELF.md": DEFAULT_SELF_MD,
     "PROACTIVE_CONTEXT.md": ProactiveLoop._PROACTIVE_CONTEXT_TEMPLATE,
 }
 

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from core.memory.profile import MemoryOptimizerStore
 
+from agent.memory import DEFAULT_SELF_MD
 from agent.provider import LLMProvider
 
 logger = logging.getLogger(__name__)
@@ -279,7 +280,7 @@ class MemoryOptimizer:
 
     async def _update_self(self, pending: str) -> None:
         """只更新 SELF.md 现有保留的三段，不新增 section。"""
-        self_content = self._memory.read_self().strip()
+        self_content = self._memory.read_self().strip() or DEFAULT_SELF_MD.strip()
         if not self_content:
             logger.info("[memory_optimizer] SELF.md 不存在或为空，跳过更新")
             return

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -18,6 +18,7 @@ from agent.config import (
     QQGroupConfig,
     TelegramChannelConfig,
 )
+from agent.memory import DEFAULT_SELF_MD
 from bus.event_bus import EventBus
 from core.net.http import SharedHttpResources
 
@@ -233,7 +234,7 @@ def test_init_workspace_respects_force_for_text_assets(tmp_path):
         workspace=workspace,
         force=True,
     )
-    assert self_path.read_text(encoding="utf-8") == ""
+    assert self_path.read_text(encoding="utf-8") == DEFAULT_SELF_MD
     assert any(path == self_path for path in summary_force.overwritten)
 
 


### PR DESCRIPTION
## 背景

`SELF.md` 负责 Akashic 的自我认知与关系理解，但初始化流程之前会创建空文件。MemoryOptimizer 更新 SELF 时又要求基于既有三段结构改写，遇到空文件会直接跳过，导致新 workspace 和存量空 SELF 用户都无法启用这部分记忆更新。

## 改动

- 新增 `DEFAULT_SELF_MD` 默认三段骨架，包含「人格与形象」「我对当前用户的理解」「我们关系的定义」。
- workspace 初始化时写入默认 `memory/SELF.md`，新用户 setup/init 后即可拥有可更新结构。
- MemoryOptimizer 读取到空 `SELF.md` 时使用默认骨架继续更新，存量空文件用户在下一次优化时可自愈。

## 验证

- `pyright agent/memory.py bootstrap/init_workspace.py proactive_v2/memory_optimizer.py`：0 errors，40 warnings（既有 unused / Unknown 类 warning）
- `pytest tests/test_dashboard_api.py tests/test_consolidation_service.py -q`：30 passed
- Docker sandbox `setup-v4flash-self`：通过 `setup` 新建 profile 后 `SELF.md` 立即存在；`memory_window = 2` 的 CLI 测试自动写入 PENDING，手动触发 memory optimizer 后成功合并 MEMORY 并更新 SELF。
