### PR TITLE
feat(qqbot): 新增官方 QQBot 私聊通道

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -19,6 +19,8 @@ from agent.config_models import (
     FitbitIntegrationConfig,
     MemoryV2Config,
     PeerAgentConfig,
+    QQBotChannelConfig,
+    QQBotGroupConfig,
     QQChannelConfig,
     QQGroupConfig,
     TelegramChannelConfig,
@@ -198,9 +200,45 @@ def _load_channels_config(data: dict) -> ChannelsConfig:
                 groups=groups,
             )
 
+    qqbot = None
+    if qqbot_data := channels_data.get("qqbot"):
+        app_id = _normalize_optional_config_text(
+            _resolve(str(qqbot_data.get("app_id", qqbot_data.get("appId", ""))))
+        )
+        client_secret = _normalize_optional_config_text(
+            _resolve(str(qqbot_data.get("client_secret", qqbot_data.get("clientSecret", ""))))
+        )
+        if bool(qqbot_data.get("enabled", True)) and app_id and client_secret:
+            groups = [
+                QQBotGroupConfig(
+                    group_openid=str(
+                        g["group_openid"] if "group_openid" in g else g["groupOpenid"]
+                    ),
+                    allow_from=[
+                        str(u)
+                        for u in g.get("allow_from", g.get("allowFrom", []))
+                    ],
+                    require_at=g.get("require_at", g.get("requireAt", True)),
+                    allow_proactive=bool(
+                        g.get("allow_proactive", g.get("allowProactive", False))
+                    ),
+                )
+                for g in qqbot_data.get("groups", [])
+            ]
+            qqbot = QQBotChannelConfig(
+                app_id=app_id,
+                client_secret=client_secret,
+                allow_from=[
+                    str(u)
+                    for u in qqbot_data.get("allow_from", qqbot_data.get("allowFrom", []))
+                ],
+                groups=groups,
+            )
+
     channels = ChannelsConfig(
         telegram=telegram,
         qq=qq,
+        qqbot=qqbot,
         socket=channels_data.get("socket")
         or channels_data.get("cli", {}).get("socket", DEFAULT_SOCKET),
     )

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -27,9 +27,26 @@ class QQChannelConfig:
 
 
 @dataclass
+class QQBotGroupConfig:
+    group_openid: str
+    allow_from: list[str] = field(default_factory=list)
+    require_at: bool = True
+    allow_proactive: bool = False
+
+
+@dataclass
+class QQBotChannelConfig:
+    app_id: str
+    client_secret: str
+    allow_from: list[str] = field(default_factory=list)
+    groups: list[QQBotGroupConfig] = field(default_factory=list)
+
+
+@dataclass
 class ChannelsConfig:
     telegram: TelegramChannelConfig | None = None
     qq: QQChannelConfig | None = None
+    qqbot: QQBotChannelConfig | None = None
     socket: str = "/tmp/akashic.sock"
 
 
@@ -141,6 +158,8 @@ __all__ = [
     "MemoryV2Config",
     "PeerAgentConfig",
     "QQChannelConfig",
+    "QQBotChannelConfig",
+    "QQBotGroupConfig",
     "QQGroupConfig",
     "TelegramChannelConfig",
     "WiringConfig",

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -60,6 +60,7 @@ class AppRuntime:
         self.ipc = None
         self.tg_channel = None
         self.qq_channel = None
+        self.qqbot_channel = None
         self.core: CoreRuntime | None = None
         self.agent_loop = None
         self.bus = None
@@ -111,7 +112,7 @@ class AppRuntime:
             await self.core.start()
 
             plugin_manager = getattr(self.core, "plugin_manager", None)
-            self.ipc, self.tg_channel, self.qq_channel = await start_channels(
+            self.ipc, self.tg_channel, self.qq_channel, self.qqbot_channel = await start_channels(
                 self.config,
                 bus=self.bus,
                 session_manager=self.session_manager,
@@ -196,6 +197,10 @@ class AppRuntime:
                     self.tg_channel.stop if self.tg_channel else _noop_async,
                 ),
                 ("qq.stop", self.qq_channel.stop if self.qq_channel else _noop_async),
+                (
+                    "qqbot.stop",
+                    self.qqbot_channel.stop if self.qqbot_channel else _noop_async,
+                ),
                 (
                     "memory_runtime.aclose",
                     self.memory_runtime.aclose if self.memory_runtime else _noop_async,

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -21,7 +21,7 @@ async def start_channels(
     event_bus: EventBus,
     bot_commands: list[tuple[str, str]] | None = None,
     interrupt_controller: InterruptController | None = None,
-) -> tuple[Any, Any, Any]:
+) -> tuple[Any, Any, Any, Any]:
     from infra.channels.ipc_server import IPCServerChannel
 
     ipc = IPCServerChannel(bus, config.channels.socket)
@@ -75,4 +75,27 @@ async def start_channels(
         )
         print(f"QQ Bot 已启动  |  QQ 号: {qq.bot_uin}")
 
-    return ipc, tg_channel, qq_channel
+    qqbot_channel = None
+    if config.channels.qqbot and config.channels.qqbot.app_id:
+        from infra.channels.qqbot_channel import QQBotChannel
+
+        qqbot = config.channels.qqbot
+        qqbot_channel = QQBotChannel(
+            app_id=qqbot.app_id,
+            client_secret=qqbot.client_secret,
+            bus=bus,
+            session_manager=session_manager,
+            allow_from=qqbot.allow_from,
+            groups=qqbot.groups,
+            event_bus=event_bus,
+            interrupt_controller=interrupt_controller,
+        )
+        await qqbot_channel.start()
+        push_tool.register_channel(
+            "qqbot",
+            text=qqbot_channel.send_proactive,
+            stream_text=qqbot_channel.send_stream,
+        )
+        print(f"官方 QQBot 已启动  |  AppID: {qqbot.app_id}")
+
+    return ipc, tg_channel, qq_channel, qqbot_channel

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -5,14 +5,22 @@ python main.py setup
 """
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
 import select
 import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 import click
+
+
+def _empty_str_list() -> list[str]:
+    return []
+
 
 # ---------------------------------------------------------------------------
 # 数据结构
@@ -33,9 +41,13 @@ class WizardAnswers:
     fast_api_key: str = ""
     fast_base_url: str = ""
     tg_token: str = ""
-    tg_allow_from: list[str] = field(default_factory=list)
+    tg_allow_from: list[str] = field(default_factory=_empty_str_list)
     proactive_enabled: bool = False
     proactive_chat_id: str = ""
+    proactive_channel: str = ""
+    qqbot_app_id: str = ""
+    qqbot_client_secret: str = ""
+    qqbot_user_openid: str = ""
     embed_model: str = ""
     embed_api_key: str = ""
     embed_base_url: str = ""
@@ -198,13 +210,13 @@ def run_setup_wizard(config_path: Path, workspace: Path) -> None:
     click.echo("\n正在生成配置并初始化工作区...")
 
     toml_str = _render_config(answers)
-    config_path.write_text(toml_str, encoding="utf-8")
+    _ = config_path.write_text(toml_str, encoding="utf-8")
     _ok(f"{config_path} 已生成")
 
     _validate_config(config_path)
 
     from bootstrap.init_workspace import init_workspace
-    init_workspace(config_path=config_path, workspace=workspace)
+    _ = init_workspace(config_path=config_path, workspace=workspace)
     _ok(f"{workspace} 已初始化")
 
     _print_completion(answers)
@@ -218,7 +230,8 @@ def _collect_answers() -> WizardAnswers:
     a = WizardAnswers()
     _phase_main_llm(a)
     _phase_fast_model(a)
-    _phase_channels(a)
+    _phase_telegram(a)
+    _phase_qqbot(a)
     _phase_memory(a)
     return a
 
@@ -268,8 +281,8 @@ def _phase_fast_model(a: WizardAnswers) -> None:
     ) or a.api_key
 
 
-def _phase_channels(a: WizardAnswers) -> None:
-    _section_header("3/4", "Telegram 频道 + Proactive")
+def _phase_telegram(a: WizardAnswers) -> None:
+    _section_header("3/5", "Telegram 频道 + Proactive")
 
     if not click.confirm("配置 Telegram 频道？", default=True):
         _hint("跳过后仅支持 CLI 模式（uv run python main.py cli），proactive 已关闭")
@@ -304,6 +317,7 @@ def _phase_channels(a: WizardAnswers) -> None:
         return
 
     a.proactive_enabled = True
+    a.proactive_channel = "telegram"
 
     # 获取 chat_id
     click.echo()
@@ -322,8 +336,53 @@ def _phase_channels(a: WizardAnswers) -> None:
         _hint("启动后向 bot 发 /chatid 可以随时补填")
 
 
+def _phase_qqbot(a: WizardAnswers) -> None:
+    _section_header("4/5", "官方 QQBot 频道（可跳过）")
+    _hint("使用腾讯开放平台 WebSocket 长连接，无需 NapCat，与 Telegram 并存")
+
+    if not click.confirm("配置官方 QQBot？", default=False):
+        return
+
+    click.echo()
+    click.echo(click.style("  还没有 QQ 开放平台应用？按以下步骤创建：", dim=True))
+    _hint("1. 打开 https://q.qq.com，登录腾讯开放平台")
+    _hint("2. 创建机器人应用，记录 AppID 和 AppSecret")
+    _hint("3. 在「开发设置」中开启「私聊」C2C 消息权限")
+    click.echo()
+
+    a.qqbot_app_id = click.prompt("AppID")
+    a.qqbot_client_secret = _secret_prompt("AppSecret (client_secret)")
+
+    err = _validate_qqbot_credentials(a.qqbot_app_id, a.qqbot_client_secret)
+    if err:
+        _warn(f"凭据验证失败：{err}")
+        _hint("继续配置，启动后检查凭据是否正确")
+
+    click.echo()
+    click.echo(click.style("  需要获取你的 user_openid：", bold=True))
+    _hint("在 QQ 中搜索你的 bot，向它发任意一条消息（比如「你好」）")
+    _hint("发完回来按回车，向导会自动读取")
+    click.echo()
+    click.pause(info="发完消息后按回车继续...")
+
+    openid = _fetch_qqbot_openid_with_spinner(
+        a.qqbot_app_id, a.qqbot_client_secret, timeout_s=90
+    )
+    if openid:
+        _ok(f"user_openid 已获取：{openid}")
+        a.qqbot_user_openid = openid
+        # 仅在没有 Telegram proactive 时才用 qqbot 作为 proactive 目标
+        if not a.proactive_enabled and click.confirm("开启 proactive 主动推送（via QQBot）？", default=True):
+            a.proactive_enabled = True
+            a.proactive_channel = "qqbot"
+            a.proactive_chat_id = f"c2c:{openid}"
+    else:
+        _warn("未收到消息，allow_from 留空")
+        _hint("启动后可在 config.toml 的 [channels.qqbot] 中手动填入 allow_from")
+
+
 def _phase_memory(a: WizardAnswers) -> None:
-    _section_header("4/4", "语义记忆（Embedding）")
+    _section_header("5/5", "语义记忆（Embedding）")
     _hint("agent 用 embedding 模型将记忆转为向量，实现语义检索")
     click.echo()
 
@@ -415,6 +474,117 @@ def _fetch_chat_id(token: str, username: str, timeout_s: int, stop: threading.Ev
     return None
 
 
+def _validate_qqbot_credentials(app_id: str, client_secret: str) -> str | None:
+    try:
+        import httpx
+        resp = httpx.post(
+            "https://bots.qq.com/app/getAppAccessToken",
+            json={"appId": app_id, "clientSecret": client_secret},
+            timeout=10,
+        )
+        data = resp.json()
+        if data.get("access_token"):
+            _ok("AppID / AppSecret 验证成功")
+            return None
+        return f"token 获取失败（{data}）"
+    except Exception as e:
+        return f"网络错误：{e}"
+
+
+def _fetch_qqbot_openid_with_spinner(app_id: str, client_secret: str, timeout_s: int = 90) -> str | None:
+    result: list[str | None] = [None]
+    done = threading.Event()
+
+    def _run() -> None:
+        try:
+            result[0] = asyncio.run(
+                _async_fetch_qqbot_openid(app_id, client_secret, timeout_s, done)
+            )
+        except Exception as e:
+            _err(f"获取 user_openid 失败：{e}")
+        done.set()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    i = 0
+    while not done.wait(timeout=0.1):
+        frame = click.style(frames[i % len(frames)], fg="cyan")
+        click.echo(f"\r  {frame} 等待消息中...", nl=False)
+        i += 1
+    click.echo("\r" + " " * 30 + "\r", nl=False)
+
+    thread.join()
+    return result[0]
+
+
+async def _async_fetch_qqbot_openid(
+    app_id: str,
+    client_secret: str,
+    timeout_s: int,
+    stop: threading.Event,
+) -> str | None:
+    import httpx
+    import websockets
+
+    # 1. 获取 access token
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            "https://bots.qq.com/app/getAppAccessToken",
+            json={"appId": app_id, "clientSecret": client_secret},
+        )
+        token_data = resp.json()
+        token = str(token_data.get("access_token") or "")
+        if not token:
+            return None
+
+    # 2. 获取 gateway URL
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            "https://api.sgroup.qq.com/gateway",
+            headers={"Authorization": f"QQBot {token}"},
+        )
+        gateway_url = str(resp.json().get("url") or "")
+        if not gateway_url:
+            return None
+
+    # 3. 连接 WS，监听第一条 C2C 私聊消息
+    try:
+        async with asyncio.timeout(timeout_s):
+            async with websockets.connect(gateway_url) as ws:
+                async for raw in ws:
+                    if stop.is_set():
+                        return None
+                    payload = json.loads(raw)
+                    op = payload.get("op")
+                    if op == 10:
+                        # Hello：发送鉴权 Identify
+                        await ws.send(json.dumps({
+                            "op": 2,
+                            "d": {
+                                "token": f"QQBot {token}",
+                                "intents": 1 << 25,
+                                "shard": [0, 1],
+                            },
+                        }))
+                    elif op == 0 and payload.get("t") == "C2C_MESSAGE_CREATE":
+                        raw_d = payload.get("d")
+                        d = cast(dict[str, object], raw_d) if isinstance(raw_d, dict) else {}
+                        raw_author = d.get("author")
+                        author = (
+                            cast(dict[str, object], raw_author)
+                            if isinstance(raw_author, dict)
+                            else {}
+                        )
+                        openid = str(author.get("user_openid") or d.get("user_openid") or "")
+                        if openid:
+                            return openid
+    except TimeoutError:
+        return None
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Config 验证
 # ---------------------------------------------------------------------------
@@ -422,7 +592,7 @@ def _fetch_chat_id(token: str, username: str, timeout_s: int, stop: threading.Ev
 def _validate_config(config_path: Path) -> None:
     try:
         from agent.config import Config
-        Config.load(config_path)
+        _ = Config.load(config_path)
         _ok("配置验证通过")
     except KeyError as e:
         _err(f"配置缺少必填字段：{e}")
@@ -533,7 +703,7 @@ def _render_channels(a: WizardAnswers) -> str:
         ]
 
     lines += [
-        "# QQ 频道（如需启用，填写后取消注释）",
+        "# QQ 频道（NapCat，如需启用，填写后取消注释）",
         "# [channels.qq]",
         '# bot_uin = ""',
         '# allow_from = ["your_qq_number"]',
@@ -544,6 +714,26 @@ def _render_channels(a: WizardAnswers) -> str:
         "# require_at = true",
         "",
     ]
+
+    if a.qqbot_app_id:
+        allow = ", ".join(f'"{u}"' for u in ([a.qqbot_user_openid] if a.qqbot_user_openid else []))
+        lines += [
+            "[channels.qqbot]",
+            f'app_id = "{a.qqbot_app_id}"',
+            f'client_secret = "{a.qqbot_client_secret}"',
+            f"allow_from = [{allow}]",
+            "",
+        ]
+    else:
+        lines += [
+            "# 官方 QQBot（如需启用，填写后取消注释）",
+            "# [channels.qqbot]",
+            '# app_id = ""',
+            '# client_secret = ""',
+            '# allow_from = []  # 用户的 user_openid，发一条消息后可从日志获取',
+            "",
+        ]
+
     return "\n".join(lines)
 
 
@@ -587,7 +777,7 @@ def _render_memory(a: WizardAnswers) -> str:
 
 def _render_proactive(a: WizardAnswers) -> str:
     enabled = "true" if a.proactive_enabled else "false"
-    channel = "telegram" if a.tg_token else ""
+    channel = a.proactive_channel or ("telegram" if a.tg_token else "")
     return "\n".join([
         "[proactive]",
         f"enabled = {enabled}",
@@ -641,10 +831,26 @@ def _print_completion(a: WizardAnswers) -> None:
     if a.proactive_enabled and not a.proactive_chat_id:
         click.echo()
         _warn("proactive 已开启，但 chat_id 未获取到")
-        _hint("启动后向 bot 发 /chatid，把返回的 id 填入 config.toml：")
-        _hint("[proactive.target]")
-        _hint('chat_id = "<你的 id>"')
+        if a.proactive_channel == "qqbot" or (not a.tg_token and a.qqbot_app_id):
+            _hint("启动后向 bot 发任意消息，日志中会出现 user_openid")
+            _hint("将其填入 config.toml：")
+            _hint("[channels.qqbot]")
+            _hint('allow_from = ["<user_openid>"]')
+            _hint("[proactive.target]")
+            _hint('channel = "qqbot"')
+            _hint('chat_id = "c2c:<user_openid>"')
+        else:
+            _hint("启动后向 bot 发 /chatid，把返回的 id 填入 config.toml：")
+            _hint("[proactive.target]")
+            _hint('chat_id = "<你的 id>"')
         _hint("修改后重启生效")
     elif a.proactive_enabled and a.proactive_chat_id:
         click.echo()
         _ok("proactive 已配置，启动后会主动向你推送消息")
+
+    if a.qqbot_app_id and not a.qqbot_user_openid:
+        click.echo()
+        _warn("QQBot allow_from 为空，启动后所有私聊请求会被拒绝")
+        _hint("向 bot 发一条消息，日志里找到 user_openid，填入 config.toml：")
+        _hint("[channels.qqbot]")
+        _hint('allow_from = ["<user_openid>"]')

--- a/config.example.toml
+++ b/config.example.toml
@@ -75,6 +75,20 @@ allow_from = ["your_qq_number"]
 # allow_from = ["your_qq_number"]
 # require_at = true
 
+[channels.qqbot]
+# 官方 QQBot，和 NapCat QQ 通道并存。留空跳过。
+app_id = ""
+client_secret = ""
+# 私聊白名单使用官方 user_openid。
+allow_from = []
+
+# 当前实现仅启用私聊；群配置先保留为后续扩展占位。
+# [[channels.qqbot.groups]]
+# group_openid = "GROUP_OPENID"
+# allow_from = ["MEMBER_OPENID"]
+# require_at = true
+# allow_proactive = false
+
 # =============================================================================
 # 语义记忆
 # embedding api_key 通常和 llm.fast 用同一个 key。
@@ -126,6 +140,7 @@ profile = "daily"
 [proactive.target]
 channel = "telegram"
 # 你的 Telegram user id（向 bot 发一条消息后从日志里可以拿到）。
+# 官方 QQBot 私聊可填：channel = "qqbot"，chat_id = "c2c:USER_OPENID"
 chat_id = ""
 
 [proactive.agent]

--- a/infra/channels/qqbot_channel.py
+++ b/infra/channels/qqbot_channel.py
@@ -1,0 +1,570 @@
+"""
+官方 QQBot 通道。
+
+MVP 只支持文本：
+- WebSocket 接收私聊事件
+- REST API 发送私聊 markdown 文本
+- 私聊流式消息可用时走官方 stream_messages
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from collections.abc import Callable, Coroutine
+from typing import Any, cast
+
+import httpx
+import websockets
+
+from agent.config_models import QQBotGroupConfig
+from agent.looping.interrupt import InterruptController
+from bus.event_bus import EventBus
+from bus.events import InboundMessage, OutboundMessage
+from bus.events_lifecycle import StreamDeltaReady, TurnStarted
+from bus.queue import MessageBus
+from session.manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+_CHANNEL = "qqbot"
+_API_BASE = "https://api.sgroup.qq.com"
+_TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
+_LIVE_STREAM_MIN_CHARS = 120
+_LIVE_STREAM_MIN_INTERVAL_S = 1.5
+_LIVE_MAX_FAILURES = 3
+_REPLY_LIVE_TAIL = 900
+
+
+@dataclass
+class _TokenCache:
+    token: str
+    expires_at: float
+
+
+@dataclass
+class _LiveStreamState:
+    openid: str
+    msg_id: str
+    msg_seq: int
+    stream_msg_id: str = ""
+    index: int = 0
+    completed: bool = False
+
+
+class QQBotChannel:
+    def __init__(
+        self,
+        app_id: str,
+        client_secret: str,
+        bus: MessageBus,
+        session_manager: SessionManager,
+        allow_from: list[str] | None = None,
+        groups: list[QQBotGroupConfig] | None = None,
+        event_bus: EventBus | None = None,
+        interrupt_controller: InterruptController | None = None,
+    ) -> None:
+        self._app_id = app_id
+        self._client_secret = client_secret
+        self._bus = bus
+        self._session_manager = session_manager
+        self._allow_from = set(allow_from or [])
+        self._groups = {g.group_openid: g for g in (groups or [])}
+        self._interrupt_controller = interrupt_controller
+        self._client = httpx.AsyncClient(timeout=30.0)
+        self._token: _TokenCache | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._stopped = asyncio.Event()
+        self._last_c2c_msg_id: dict[str, str] = {}
+        self._live_states: dict[str, _LiveStreamState] = {}
+        self._reply_buffers: dict[str, str] = {}
+        self._live_next_at: dict[str, float] = {}
+        self._live_last_lengths: dict[str, int] = {}
+        self._live_failures: dict[str, int] = {}
+        self._live_disabled: set[str] = set()
+        self._live_locks: dict[str, asyncio.Lock] = {}
+        self._live_tasks: set[asyncio.Task[None]] = set()
+        self._live_tasks_by_session: dict[str, set[asyncio.Task[None]]] = {}
+        if event_bus is not None:
+            event_bus.on(TurnStarted, self._on_turn_started)
+            event_bus.on(StreamDeltaReady, self._on_stream_delta)
+
+    async def start(self) -> None:
+        _ = self._stopped.clear()
+        self._task = asyncio.create_task(self._gateway_loop())
+        self._bus.subscribe_outbound(_CHANNEL, self._on_response)
+        logger.info("[qqbot] 官方 QQBot 通道已启动")
+
+    async def stop(self) -> None:
+        self._stopped.set()
+        if self._task:
+            _ = self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        await self._drain_live_tasks()
+        await self._client.aclose()
+        logger.info("[qqbot] 官方 QQBot 通道已停止")
+
+    async def _gateway_loop(self) -> None:
+        while not self._stopped.is_set():
+            try:
+                token = await self._get_access_token()
+                gateway = await self._api_request("GET", "/gateway", token=token)
+                url = str(gateway["url"])
+                await self._run_gateway(url, token)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("[qqbot] gateway 连接失败: %s", e)
+                await asyncio.sleep(5)
+
+    async def _run_gateway(self, url: str, token: str) -> None:
+        last_seq: int | None = None
+        heartbeat_task: asyncio.Task[None] | None = None
+        async with websockets.connect(url) as ws:
+            async for raw in ws:
+                payload = json.loads(raw)
+                op = payload.get("op")
+                raw_data = payload.get("d")
+                data = cast(dict[str, Any], raw_data) if isinstance(raw_data, dict) else {}
+                event_type = payload.get("t")
+                if isinstance(payload.get("s"), int):
+                    last_seq = int(payload["s"])
+
+                if op == 10:
+                    heartbeat_ms = int(data["heartbeat_interval"])
+                    await ws.send(json.dumps({
+                        "op": 2,
+                        "d": {
+                            "token": f"QQBot {token}",
+                            "intents": self._intents(),
+                            "shard": [0, 1],
+                        },
+                    }))
+                    heartbeat_task = asyncio.create_task(
+                        self._heartbeat(ws, heartbeat_ms, lambda: last_seq)
+                    )
+                elif op == 0:
+                    await self._handle_dispatch(str(event_type), data)
+                elif op == 7:
+                    break
+
+        if heartbeat_task:
+            _ = heartbeat_task.cancel()
+
+    async def _heartbeat(
+        self,
+        ws: Any,
+        heartbeat_ms: int,
+        seq_fn: Callable[[], int | None],
+    ) -> None:
+        while True:
+            await asyncio.sleep(max(1, heartbeat_ms / 1000))
+            await ws.send(json.dumps({"op": 1, "d": seq_fn()}))
+
+    def _intents(self) -> int:
+        return 1 << 25
+
+    async def _handle_dispatch(self, event_type: str, data: dict[str, Any]) -> None:
+        if event_type == "C2C_MESSAGE_CREATE":
+            await self._handle_c2c(data)
+        elif event_type.startswith("GROUP_"):
+            logger.debug("[qqbot] 当前仅启用私聊模式，忽略群事件 event=%s", event_type)
+
+    async def _handle_c2c(self, data: dict[str, Any]) -> None:
+        author = _as_dict(data.get("author"))
+        user_openid = str(author.get("user_openid") or data.get("user_openid") or "")
+        if not user_openid:
+            return
+        if self._allow_from and user_openid not in self._allow_from:
+            logger.warning("[qqbot] 拒绝未授权私聊用户 user_openid=%s", user_openid)
+            return
+        content = str(data.get("content") or "").strip()
+        message_id = str(data.get("id") or "")
+        if message_id:
+            self._last_c2c_msg_id[user_openid] = message_id
+            await self._send_input_notify(user_openid, message_id)
+        logger.info("[qqbot] 收到私聊消息 user_openid=%s msg_id=%s", user_openid, message_id)
+        if content == "/stop":
+            await self._handle_stop(f"c2c:{user_openid}", user_openid)
+            return
+        await self._bus.publish_inbound(
+            InboundMessage(
+                channel=_CHANNEL,
+                sender=user_openid,
+                chat_id=f"c2c:{user_openid}",
+                content=content,
+                metadata={
+                    "chat_type": "private",
+                    "user_openid": user_openid,
+                    "message_id": message_id,
+                },
+            )
+        )
+
+    async def _handle_stop(self, chat_id: str, sender: str) -> None:
+        if self._interrupt_controller is None:
+            await self.send(chat_id, "当前未启用中断功能。")
+            return
+        result = self._interrupt_controller.request_interrupt(
+            session_key=f"{_CHANNEL}:{chat_id}",
+            sender=sender,
+            command="/stop",
+        )
+        await self.send(chat_id, result.message)
+
+    async def _on_response(self, msg: OutboundMessage) -> None:
+        session_key = f"{_CHANNEL}:{msg.chat_id}"
+        content = msg.content.strip()
+        sent_as_stream = False
+        if session_key in self._live_states:
+            await self._cancel_live_tasks(session_key)
+            if content:
+                sent_as_stream = await self._send_live_stream(
+                    session_key,
+                    msg.chat_id,
+                    content,
+                    terminal=True,
+                )
+            else:
+                await self._delete_live_preview(session_key)
+            self._clear_live_session(session_key)
+        if content and not sent_as_stream:
+            await self.send(msg.chat_id, msg.content)
+
+    async def send_proactive(self, chat_id: str, message: str) -> None:
+        kind, _target = self._parse_chat_id(chat_id)
+        if kind != "c2c":
+            raise ValueError("当前 QQBotChannel 仅支持私聊 c2c")
+        await self.send(chat_id, message)
+
+    async def send(self, chat_id: str, message: str) -> None:
+        kind, target = self._parse_chat_id(chat_id)
+        if kind != "c2c":
+            raise ValueError("当前 QQBotChannel 仅支持私聊 c2c")
+        token = await self._get_access_token()
+        body = self._build_message_body(message)
+        _ = await self._api_request("POST", f"/v2/users/{target}/messages", body, token)
+
+    async def send_stream(self, chat_id: str, message: str) -> None:
+        kind, target = self._parse_chat_id(chat_id)
+        if kind != "c2c":
+            raise ValueError("当前 QQBotChannel 仅支持私聊 c2c")
+        msg_id = self._last_c2c_msg_id.get(target)
+        if not msg_id:
+            await self.send(chat_id, message)
+            return
+        try:
+            await self._send_stream_c2c(target, msg_id, message)
+        except Exception as e:
+            logger.warning("[qqbot] 私聊流式发送失败，回退普通发送: %s", e)
+            await self.send(chat_id, message)
+
+    async def _send_stream_c2c(self, openid: str, msg_id: str, message: str) -> None:
+        token = await self._get_access_token()
+        msg_seq = self._next_msg_seq()
+        stream_msg_id = ""
+        chunks = list(_iter_stream_chunks(message))
+        if not chunks:
+            chunks = [""]
+        for index, content in enumerate(chunks):
+            is_last = index == len(chunks) - 1
+            body: dict[str, Any] = {
+                "input_mode": "replace",
+                "input_state": 10 if is_last else 1,
+                "content_type": "markdown",
+                "content_raw": content,
+                "event_id": msg_id,
+                "msg_id": msg_id,
+                "msg_seq": msg_seq,
+                "index": index,
+            }
+            if stream_msg_id:
+                body["stream_msg_id"] = stream_msg_id
+            result = await self._api_request(
+                "POST",
+                f"/v2/users/{openid}/stream_messages",
+                body,
+                token,
+            )
+            stream_msg_id = str(result.get("id") or stream_msg_id)
+
+    async def _on_turn_started(self, event: TurnStarted) -> None:
+        if event.channel != _CHANNEL:
+            return
+        await self._cancel_live_tasks(event.session_key)
+        self._clear_live_session(event.session_key)
+
+    async def _on_stream_delta(self, event: StreamDeltaReady) -> None:
+        if event.channel != _CHANNEL:
+            return
+        if not event.content_delta:
+            return
+        reply = self._reply_buffers.get(event.session_key, "")
+        self._reply_buffers[event.session_key] = reply + event.content_delta
+        live_len = len(self._reply_buffers.get(event.session_key, ""))
+        last_len = self._live_last_lengths.get(event.session_key, 0)
+        now = asyncio.get_running_loop().time()
+        next_at = self._live_next_at.get(event.session_key, 0.0)
+        if now < next_at and live_len - last_len < _LIVE_STREAM_MIN_CHARS:
+            return
+        self._live_next_at[event.session_key] = now + _LIVE_STREAM_MIN_INTERVAL_S
+        self._live_last_lengths[event.session_key] = live_len
+        self._start_live_task(
+            event.session_key,
+            self._sync_live_message(event.session_key, event.chat_id),
+        )
+
+    async def _sync_live_message(
+        self,
+        session_key: str,
+        chat_id: str,
+    ) -> None:
+        text = _format_turn_live(self._reply_buffers.get(session_key, ""))
+        if text:
+            _ = await self._send_live_stream(session_key, chat_id, text, terminal=False)
+
+    async def _delete_live_preview(
+        self,
+        session_key: str,
+    ) -> None:
+        state = self._live_states.get(session_key)
+        if state is None or not state.stream_msg_id:
+            return
+        try:
+            await self._delete_message(
+                state.openid,
+                state.stream_msg_id,
+            )
+        except Exception as e:
+            logger.debug("[qqbot] 临时流式消息撤回失败，忽略: %s", e)
+
+    async def _send_live_stream(
+        self,
+        session_key: str,
+        chat_id: str,
+        text: str,
+        *,
+        terminal: bool,
+    ) -> bool:
+        if session_key in self._live_disabled:
+            return False
+        kind, openid = self._parse_chat_id(chat_id)
+        if kind != "c2c":
+            return False
+        msg_id = self._last_c2c_msg_id.get(openid)
+        if not msg_id:
+            return False
+        lock = self._live_locks.setdefault(session_key, asyncio.Lock())
+        async with lock:
+            if session_key in self._live_disabled:
+                return False
+            state = self._live_states.get(session_key)
+            if state is None:
+                state = _LiveStreamState(
+                    openid=openid,
+                    msg_id=msg_id,
+                    msg_seq=self._next_msg_seq(),
+                )
+                self._live_states[session_key] = state
+            if state.completed:
+                return False
+            try:
+                token = await self._get_access_token()
+                body: dict[str, Any] = {
+                    "input_mode": "replace",
+                    "input_state": 10 if terminal else 1,
+                    "content_type": "markdown",
+                    "content_raw": text,
+                    "event_id": state.msg_id,
+                    "msg_id": state.msg_id,
+                    "msg_seq": state.msg_seq,
+                    "index": state.index,
+                }
+                if state.stream_msg_id:
+                    body["stream_msg_id"] = state.stream_msg_id
+                result = await self._api_request(
+                    "POST",
+                    f"/v2/users/{state.openid}/stream_messages",
+                    body,
+                    token,
+                )
+            except Exception as e:
+                failures = self._live_failures.get(session_key, 0) + 1
+                self._live_failures[session_key] = failures
+                status_code = _http_status_code(e)
+                if (status_code is not None and status_code != 429) or failures >= _LIVE_MAX_FAILURES:
+                    self._live_disabled.add(session_key)
+                logger.warning(
+                    "[qqbot] 临时流式刷新失败，跳过本帧 session=%s failures=%d disabled=%s err=%s",
+                    session_key,
+                    failures,
+                    session_key in self._live_disabled,
+                    e,
+                )
+                return False
+            self._live_failures[session_key] = 0
+            state.stream_msg_id = str(result.get("id") or state.stream_msg_id)
+            state.index += 1
+            state.completed = terminal
+            return True
+
+    def _start_live_task(
+        self,
+        session_key: str,
+        coro: Coroutine[Any, Any, None],
+    ) -> None:
+        task = asyncio.create_task(coro)
+        self._live_tasks.add(task)
+        self._live_tasks_by_session.setdefault(session_key, set()).add(task)
+        task.add_done_callback(lambda done: self._on_live_task_done(session_key, done))
+
+    def _on_live_task_done(self, session_key: str, task: asyncio.Task[None]) -> None:
+        self._live_tasks.discard(task)
+        tasks = self._live_tasks_by_session.get(session_key)
+        if tasks is not None:
+            tasks.discard(task)
+            if not tasks:
+                _ = self._live_tasks_by_session.pop(session_key, None)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.debug("[qqbot] 临时流式状态刷新失败: %s", exc)
+
+    async def _cancel_live_tasks(self, session_key: str) -> None:
+        tasks = list(self._live_tasks_by_session.get(session_key, set()))
+        for task in tasks:
+            _ = task.cancel()
+        if tasks:
+            _ = await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _drain_live_tasks(self) -> None:
+        tasks = [task for task in self._live_tasks if not task.done()]
+        if tasks:
+            _ = await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _clear_live_session(self, session_key: str) -> None:
+        _ = self._live_states.pop(session_key, None)
+        _ = self._reply_buffers.pop(session_key, None)
+        _ = self._live_next_at.pop(session_key, None)
+        _ = self._live_last_lengths.pop(session_key, None)
+        _ = self._live_failures.pop(session_key, None)
+        self._live_disabled.discard(session_key)
+        _ = self._live_locks.pop(session_key, None)
+
+    async def _send_input_notify(self, openid: str, msg_id: str) -> None:
+        try:
+            token = await self._get_access_token()
+            _ = await self._api_request(
+                "POST",
+                f"/v2/users/{openid}/messages",
+                {
+                    "msg_type": 6,
+                    "input_notify": {"input_type": 1, "input_second": 60},
+                    "msg_seq": self._next_msg_seq(),
+                    "msg_id": msg_id,
+                },
+                token,
+            )
+        except Exception as e:
+            logger.debug("[qqbot] 发送输入中提示失败: %s", e)
+
+    async def _delete_message(self, openid: str, message_id: str) -> None:
+        token = await self._get_access_token()
+        _ = await self._api_request(
+            "DELETE",
+            f"/v2/users/{openid}/messages/{message_id}",
+            token=token,
+        )
+
+    def _build_message_body(self, message: str) -> dict[str, Any]:
+        return {
+            "markdown": {"content": message},
+            "msg_type": 2,
+            "msg_seq": self._next_msg_seq(),
+        }
+
+    def _next_msg_seq(self) -> int:
+        return int(time.time() * 1000) % 65536
+
+    def _parse_chat_id(self, chat_id: str) -> tuple[str, str]:
+        value = chat_id.strip()
+        if value.startswith("qqbot:"):
+            value = value[len("qqbot:"):]
+        if ":" not in value:
+            return "c2c", value
+        kind, target = value.split(":", 1)
+        if kind not in {"c2c", "group"} or not target:
+            raise ValueError(f"无效的 QQBot chat_id: {chat_id!r}")
+        return kind, target
+
+    async def _get_access_token(self) -> str:
+        now = time.time()
+        if self._token and now < self._token.expires_at - 300:
+            return self._token.token
+        resp = await self._client.post(
+            _TOKEN_URL,
+            json={"appId": self._app_id, "clientSecret": self._client_secret},
+        )
+        _ = resp.raise_for_status()
+        data = resp.json()
+        token = str(data["access_token"])
+        expires_in = int(data.get("expires_in") or 7200)
+        self._token = _TokenCache(token=token, expires_at=now + expires_in)
+        return token
+
+    async def _api_request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        access_token = token or await self._get_access_token()
+        kwargs: dict[str, Any] = {
+            "headers": {
+                "Authorization": f"QQBot {access_token}",
+                "Content-Type": "application/json",
+            }
+        }
+        if body is not None:
+            kwargs["json"] = body
+        resp = await self._client.request(method, f"{_API_BASE}{path}", **kwargs)
+        _ = resp.raise_for_status()
+        if not resp.content:
+            return {}
+        data = resp.json()
+        return cast(dict[str, Any], data) if isinstance(data, dict) else {}
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return cast(dict[str, Any], value) if isinstance(value, dict) else {}
+
+
+def _http_status_code(err: Exception) -> int | None:
+    if isinstance(err, httpx.HTTPStatusError):
+        return err.response.status_code
+    return None
+
+
+def _iter_stream_chunks(text: str, limit: int = 160) -> list[str]:
+    chunks: list[str] = []
+    for end in range(limit, len(text) + limit, limit):
+        chunks.append(text[:end])
+    return chunks
+
+
+def _format_turn_live(reply: str) -> str:
+    return _tail_text(reply.strip(), _REPLY_LIVE_TAIL)
+
+
+def _tail_text(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return "..." + text[-(limit - 3):]

--- a/plugins/setup_helper/plugin.py
+++ b/plugins/setup_helper/plugin.py
@@ -17,7 +17,7 @@ class ChatIdCommandModule:
         if _normalize_command(state.msg.content) not in {"/chatid", "/myid"}:
             return frame
         chat_id = state.msg.chat_id or "（未知）"
-        reply = _format_reply(chat_id)
+        reply = _format_reply(chat_id, channel=state.msg.channel)
         frame.slots["session:ctx"] = _abort_ctx(state, reply)  # type: ignore[attr-defined]
         return frame
 
@@ -43,8 +43,8 @@ def _normalize_command(content: str) -> str:
     return head
 
 
-def _format_reply(chat_id: str) -> str:
-    return "\n".join([
+def _format_reply(chat_id: str, channel: str = "telegram") -> str:
+    lines = [
         f"你的 chat_id 是：`{chat_id}`",
         "",
         "将它填入 config.toml 即可开启主动推送：",
@@ -54,10 +54,23 @@ def _format_reply(chat_id: str) -> str:
         "enabled = true",
         "",
         "[proactive.target]",
-        "channel = \"telegram\"",
-        f"chat_id = \"{chat_id}\"",
+        f'channel = "{channel}"',
+        f'chat_id = "{chat_id}"',
         "```",
-    ])
+    ]
+    if channel == "qqbot":
+        # user_openid 也需要加入 allow_from 白名单
+        raw_openid = chat_id.removeprefix("c2c:")
+        lines += [
+            "",
+            "同时确认 allow_from 已包含你的 user_openid：",
+            "",
+            "```toml",
+            "[channels.qqbot]",
+            f'allow_from = ["{raw_openid}"]',
+            "```",
+        ]
+    return "\n".join(lines)
 
 
 def _abort_ctx(state: TurnState, reply: str) -> BeforeTurnCtx:

--- a/tests/test_bootstrap_wiring_p2.py
+++ b/tests/test_bootstrap_wiring_p2.py
@@ -176,7 +176,7 @@ def test_config_load_accepts_dev_model_alias(tmp_path: Path):
     assert cfg.dev_mode is True
 
 
-def test_config_load_skips_unfilled_channels(tmp_path: Path):
+def test_config_load_skips_unfilled_channels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     cfg_path = tmp_path / "config.toml"
     _write_toml(
         cfg_path,
@@ -200,14 +200,36 @@ def test_config_load_skips_unfilled_channels(tmp_path: Path):
                     "bot_uin": "",
                     "allow_from": ["42"],
                 },
+                "qqbot": {
+                    "app_id": "app",
+                    "client_secret": "${QQBOT_SECRET}",
+                    "allow_from": ["user-openid"],
+                    "groups": [
+                        {
+                            "group_openid": "group-openid",
+                            "allow_from": ["member-openid"],
+                            "require_at": True,
+                            "allow_proactive": True,
+                        }
+                    ],
+                },
             },
         },
     )
 
+    monkeypatch.setenv("QQBOT_SECRET", "secret")
     cfg = Config.load(cfg_path)
 
     assert cfg.channels.telegram is None
     assert cfg.channels.qq is None
+    assert cfg.channels.qqbot is not None
+    assert cfg.channels.qqbot.app_id == "app"
+    assert cfg.channels.qqbot.client_secret == "secret"
+    assert cfg.channels.qqbot.allow_from == ["user-openid"]
+    assert cfg.channels.qqbot.groups[0].group_openid == "group-openid"
+    assert cfg.channels.qqbot.groups[0].allow_from == ["member-openid"]
+    assert cfg.channels.qqbot.groups[0].require_at is True
+    assert cfg.channels.qqbot.groups[0].allow_proactive is True
     assert cfg.channels.socket == "/tmp/akashic.sock"
 
 

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from bus.event_bus import EventBus
@@ -949,4 +950,127 @@ async def test_qq_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     with pytest.raises(RuntimeError):
         await mod.QQChannel._run_on_bot_loop(channel, pending)
     pending.close()
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_qqbot_channel_text_paths(monkeypatch: pytest.MonkeyPatch):
+    sys.modules.pop("infra.channels.qqbot_channel", None)
+    mod = importlib.import_module("infra.channels.qqbot_channel")
+    bus = _Bus()
+    session_manager = _SessionManager()
+    channel = mod.QQBotChannel(
+        app_id="app",
+        client_secret="secret",
+        bus=bus,
+        session_manager=session_manager,
+        allow_from=["user-1"],
+        interrupt_controller=SimpleNamespace(
+            request_interrupt=MagicMock(return_value=SimpleNamespace(message="已中断"))
+        ),
+    )
+    channel._get_access_token = AsyncMock(return_value="token")
+    channel._api_request = AsyncMock(return_value={"id": "m1", "timestamp": "now"})
+
+    assert channel._parse_chat_id("user-1") == ("c2c", "user-1")
+    assert channel._parse_chat_id("qqbot:group:group-1") == ("group", "group-1")
+
+    await channel._handle_c2c({
+        "id": "msg-1",
+        "author": {"user_openid": "user-1"},
+        "content": "你好",
+    })
+    await channel._handle_c2c({
+        "id": "msg-2",
+        "author": {"user_openid": "other"},
+        "content": "不该进来",
+    })
+    await channel._handle_dispatch("GROUP_AT_MESSAGE_CREATE", {
+        "group_openid": "group-1",
+        "author": {"member_openid": "member-1"},
+        "content": "群消息",
+    })
+
+    assert len(bus.inbound) == 1
+    assert bus.inbound[0].chat_id == "c2c:user-1"
+    assert bus.inbound[0].metadata["message_id"] == "msg-1"
+    assert session_manager.saved == []
+
+    await channel.send("c2c:user-1", "pong")
+    send_call = channel._api_request.await_args_list[-1]
+    assert send_call.args[1] == "/v2/users/user-1/messages"
+    assert send_call.args[2]["msg_type"] == 2
+    assert send_call.args[2]["markdown"]["content"] == "pong"
+
+    await channel.send_stream("c2c:user-1", "stream " * 40)
+    stream_calls = [
+        call for call in channel._api_request.await_args_list
+        if call.args[1] == "/v2/users/user-1/stream_messages"
+    ]
+    assert stream_calls
+    assert stream_calls[-1].args[2]["input_state"] == 10
+    assert stream_calls[-1].args[2]["msg_id"] == "msg-1"
+
+    session_key = "qqbot:c2c:user-1"
+    await channel._on_stream_delta(StreamDeltaReady(
+        session_key=session_key,
+        channel="qqbot",
+        chat_id="c2c:user-1",
+        content_delta="临时回复",
+        thinking_delta="正在想",
+    ))
+    await channel._drain_live_tasks()
+    live_calls = [
+        call for call in channel._api_request.await_args_list
+        if call.args[1] == "/v2/users/user-1/stream_messages"
+        and call.args[2]["content_raw"] == "临时回复"
+    ]
+    assert live_calls
+    assert "工具调用" not in live_calls[-1].args[2]["content_raw"]
+    assert "正在想" not in live_calls[-1].args[2]["content_raw"]
+
+    await channel._on_response(OutboundMessage(
+        channel="qqbot",
+        chat_id="c2c:user-1",
+        content="最终回复",
+    ))
+    final_call = channel._api_request.await_args_list[-1]
+    assert final_call.args[1] == "/v2/users/user-1/stream_messages"
+    assert final_call.args[2]["input_state"] == 10
+    assert final_call.args[2]["content_raw"] == "最终回复"
+
+    session_key = "qqbot:c2c:user-1"
+    channel._live_states[session_key] = mod._LiveStreamState(
+        openid="user-1",
+        msg_id="msg-1",
+        msg_seq=1,
+        stream_msg_id="old-stream",
+    )
+    stream_error = httpx.HTTPStatusError(
+        "server error",
+        request=httpx.Request("POST", "https://api.sgroup.qq.com"),
+        response=httpx.Response(500, request=httpx.Request("POST", "https://api.sgroup.qq.com")),
+    )
+    channel._api_request = AsyncMock(side_effect=[
+        stream_error,
+        {"id": "normal-1"},
+    ])
+    await channel._on_response(OutboundMessage(
+        channel="qqbot",
+        chat_id="c2c:user-1",
+        content="流式失败后普通发送",
+    ))
+    assert channel._api_request.await_args_list[-1].args[1] == "/v2/users/user-1/messages"
+    assert session_key not in channel._live_states
+
+    channel._last_c2c_msg_id["user-1"] = "msg-1"
+    channel._api_request = AsyncMock(side_effect=stream_error)
+    assert await channel._send_live_stream(session_key, "c2c:user-1", "预览", terminal=False) is False
+    assert session_key in channel._live_disabled
+    assert await channel._send_live_stream(session_key, "c2c:user-1", "预览2", terminal=False) is False
+    assert channel._api_request.await_count == 1
+    with pytest.raises(ValueError):
+        await channel.send("group:group-1", "group pong")
+    with pytest.raises(ValueError):
+        await channel.send_proactive("group:not-configured", "blocked")
     await channel.stop()

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -684,7 +684,7 @@ async def test_app_runtime_start_passes_profile_maint_to_memory_optimizer(
     )
     monkeypatch.setattr(
         "bootstrap.app.start_channels",
-        AsyncMock(return_value=(MagicMock(), None, None)),
+        AsyncMock(return_value=(MagicMock(), None, None, None)),
     )
     build_proactive_runtime = MagicMock(return_value=([], None))
     monkeypatch.setattr(

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -14,6 +14,8 @@ from bootstrap.channels import start_channels
 from agent.config import (
     ChannelsConfig,
     Config,
+    QQBotChannelConfig,
+    QQBotGroupConfig,
     QQChannelConfig,
     QQGroupConfig,
     TelegramChannelConfig,
@@ -241,11 +243,12 @@ def test_init_workspace_respects_force_for_text_assets(tmp_path):
 @pytest.mark.asyncio
 async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     starts: list[str] = []
-    registrations: list[str] = []
+    registrations: list[tuple[str, list[str]]] = []
 
     fake_ipc_server = types.ModuleType("infra.channels.ipc_server")
     fake_telegram_channel = types.ModuleType("infra.channels.telegram_channel")
     fake_qq_channel = types.ModuleType("infra.channels.qq_channel")
+    fake_qqbot_channel = types.ModuleType("infra.channels.qqbot_channel")
 
     class _IPCServerChannel:
         def __init__(self, bus, socket):
@@ -299,16 +302,34 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
         async def send_image(self, *args, **kwargs):
             return None
 
+    class _QQBotChannel:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def start(self) -> None:
+            starts.append("qqbot")
+
+        async def stop(self) -> None:
+            starts.append("qqbot.stop")
+
+        async def send_proactive(self, *args, **kwargs):
+            return None
+
+        async def send_stream(self, *args, **kwargs):
+            return None
+
     fake_ipc_server.IPCServerChannel = _IPCServerChannel  # type: ignore[attr-defined]
     fake_telegram_channel.TelegramChannel = _TelegramChannel  # type: ignore[attr-defined]
     fake_qq_channel.QQChannel = _QQChannel  # type: ignore[attr-defined]
+    fake_qqbot_channel.QQBotChannel = _QQBotChannel  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "infra.channels.ipc_server", fake_ipc_server)
     monkeypatch.setitem(sys.modules, "infra.channels.telegram_channel", fake_telegram_channel)
     monkeypatch.setitem(sys.modules, "infra.channels.qq_channel", fake_qq_channel)
+    monkeypatch.setitem(sys.modules, "infra.channels.qqbot_channel", fake_qqbot_channel)
 
     class _PushTool:
         def register_channel(self, name: str, **kwargs) -> None:
-            registrations.append(name)
+            registrations.append((name, sorted(kwargs)))
 
     config = Config(
         provider="openai",
@@ -322,6 +343,12 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
                 allow_from=["2"],
                 groups=[QQGroupConfig(group_id="3")],
             ),
+            qqbot=QQBotChannelConfig(
+                app_id="app",
+                client_secret="secret",
+                allow_from=["user-openid"],
+                groups=[QQBotGroupConfig(group_openid="group-openid")],
+            ),
             socket=str(tmp_path / "sock"),
         ),
     )
@@ -329,7 +356,7 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     event_bus = EventBus()
     try:
         controller = object()
-        ipc, tg, qq = await start_channels(
+        ipc, tg, qq, qqbot = await start_channels(
             config,
             bus=cast(Any, object()),
             session_manager=cast(Any, object()),
@@ -344,11 +371,18 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     assert ipc is not None
     assert tg is not None
     assert qq is not None
-    assert starts == ["ipc", "telegram", "qq"]
-    assert registrations == ["telegram", "qq"]
+    assert qqbot is not None
+    assert starts == ["ipc", "telegram", "qq", "qqbot"]
+    assert registrations == [
+        ("telegram", ["file", "image", "stream_text", "text"]),
+        ("qq", ["file", "image", "text"]),
+        ("qqbot", ["stream_text", "text"]),
+    ]
     assert tg.kwargs["event_bus"] is event_bus
     assert tg.kwargs["interrupt_controller"] is controller
     assert qq.kwargs["interrupt_controller"] is controller
+    assert qqbot.kwargs["event_bus"] is event_bus
+    assert qqbot.kwargs["interrupt_controller"] is controller
 
 
 @pytest.mark.asyncio
@@ -402,7 +436,7 @@ async def test_start_channels_skips_unfilled_optional_channels(monkeypatch, tmp_
     )
     resources = SharedHttpResources()
     try:
-        ipc, tg, qq = await start_channels(
+        ipc, tg, qq, qqbot = await start_channels(
             config,
             bus=cast(Any, object()),
             session_manager=cast(Any, object()),
@@ -416,4 +450,5 @@ async def test_start_channels_skips_unfilled_optional_channels(monkeypatch, tmp_
     assert ipc is not None
     assert tg is None
     assert qq is None
+    assert qqbot is None
     assert starts == ["ipc"]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 import types
 
 import pytest
@@ -57,6 +58,6 @@ async def test_qqbot_openid_fetch_times_out_without_ws_frames(
     monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
     monkeypatch.setitem(sys.modules, "websockets", fake_websockets)
 
-    result = await _async_fetch_qqbot_openid("app", "secret", 1, asyncio.Event())
+    result = await _async_fetch_qqbot_openid("app", "secret", 1, threading.Event())
 
     assert result is None

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from bootstrap.setup_wizard import _async_fetch_qqbot_openid
+
+
+@pytest.mark.asyncio
+async def test_qqbot_openid_fetch_times_out_without_ws_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Resp:
+        def __init__(self, payload: dict[str, str]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, str]:
+            return self._payload
+
+    class _Client:
+        def __init__(self, timeout: int) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, *args, **kwargs) -> _Resp:
+            return _Resp({"access_token": "token"})
+
+        async def get(self, *args, **kwargs) -> _Resp:
+            return _Resp({"url": "wss://example.invalid"})
+
+    class _NeverFrames:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.sleep(3600)
+            raise StopAsyncIteration
+
+    fake_httpx = types.ModuleType("httpx")
+    fake_httpx.AsyncClient = _Client
+    fake_websockets = types.ModuleType("websockets")
+    fake_websockets.connect = lambda *_args, **_kwargs: _NeverFrames()
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+    monkeypatch.setitem(sys.modules, "websockets", fake_websockets)
+
+    result = await _async_fetch_qqbot_openid("app", "secret", 1, asyncio.Event())
+
+    assert result is None


### PR DESCRIPTION
## 背景

目前 QQ 通道主要依赖 NapCat / NcatBot。官方 QQBot 私聊 API 已经能接收 C2C 消息，也能向平台允许的私聊对象主动发送消息，因此需要一个独立 channel 用来验证并承接官方 QQBot 的私聊、流式回复和 proactive 推送链路。

## 改动

- 新增官方 QQBot 私聊 channel，支持 WebSocket 接收 C2C 消息、普通 markdown 回复、私聊主动推送和 `/stop` 中断。
- 接入配置加载、启动/停止生命周期、`message_push` 注册和 proactive target，空 `qqbot` 配置会像其他可选频道一样自动跳过，不影响存量 `config.toml`。
- QQBot 临时流式预览采用保守策略：只预览模型正文，不展示工具调用和思考过程；最终回复优先用同一条 stream 消息收尾，失败后回退普通消息。
- setup 向导新增 QQBot 配置和 user_openid 获取；WebSocket 等待过程加 `asyncio.timeout`，避免用户未发消息时卡死。
- 更新 `/chatid` helper 和 `config.example.toml`，QQBot proactive 示例只使用当前支持的私聊 `c2c:USER_OPENID`。

## 验证

- `pytest tests/test_setup_wizard.py tests/test_bootstrap_wiring_p2.py::test_config_load_skips_unfilled_channels tests/test_channel_clients.py::test_qqbot_channel_text_paths tests/test_runtime_smoke.py::test_start_channels_wires_telegram_and_qq tests/test_runtime_smoke.py::test_start_channels_skips_unfilled_optional_channels tests/test_more_support_modules.py::test_app_runtime_start_passes_profile_maint_to_memory_optimizer`：6 passed
- `.venv/bin/pyright --project pyrightconfig.tests.json --level error tests/test_setup_wizard.py`：0 errors
- `pyright agent/config.py agent/config_models.py bootstrap/app.py bootstrap/channels.py bootstrap/setup_wizard.py infra/channels/qqbot_channel.py plugins/setup_helper/plugin.py tests/test_bootstrap_wiring_p2.py tests/test_channel_clients.py tests/test_more_support_modules.py tests/test_runtime_smoke.py tests/test_setup_wizard.py`：0 errors，旧的 config/bootstrap typing warning 仍存在

## 配置影响

- 新增可选 `[channels.qqbot]`，未配置或留空时不会启动官方 QQBot channel。
- 当前实现只支持 QQBot 私聊，proactive target 应填 `channel = "qqbot"` 和 `chat_id = "c2c:USER_OPENID"`。
- `allow_from = []` 仍保持现有白名单语义：空列表表示不限制；要限制为本人需填入自己的 `user_openid`。
