### PR TITLE
feat(memory): 用 LLM 并行改写 procedure 检索 query

### DIFF
--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -1200,13 +1200,16 @@ def _build_retrieval_completed(
     )
 
 
+# 合并 procedure_queries 与 hyde hypothesis，去重保序后返回。
 def _merge_aux_queries(
     procedure_queries: list[str],
     hyde_hypothesis: str | None,
 ) -> list[str]:
+    # 1. 收集非空 query：procedure_queries 在前，hyde hypothesis 在后。
     queries = [str(item).strip() for item in procedure_queries if str(item).strip()]
     if hyde_hypothesis:
         queries.append(hyde_hypothesis.strip())
+    # 2. 去重保序。
     seen: set[str] = set()
     merged: list[str] = []
     for item in queries:

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -295,7 +295,7 @@ class DefaultRetrievalSemantics:
             resolved_gate = cast(_GateResult, gate_result)
             gate_type = str(resolved_gate["gate_type"])
             rewritten_query = str(resolved_gate["episodic_query"])
-            procedure_queries = list(resolved_gate["procedure_queries"])
+            procedure_queries = list(resolved_gate.get("procedure_queries") or [])
             route_decision = str(resolved_gate["route_decision"])
             route_ms = resolved_gate["route_latency_ms"]
             fallback_reason = str(resolved_gate["fallback_reason"])

--- a/core/memory/default_runtime_facade.py
+++ b/core/memory/default_runtime_facade.py
@@ -32,6 +32,7 @@ from core.memory.runtime_facade import (
     InterestRetrievalRequest,
     InterestRetrievalResult,
 )
+from memory2.query_builder import build_procedure_queries
 
 if TYPE_CHECKING:
     from agent.core.types import HistoryMessage
@@ -49,6 +50,7 @@ InterestRetriever = Callable[[InterestRetrievalRequest], Awaitable[InterestRetri
 class _GateResult(TypedDict):
     gate_type: str | None
     episodic_query: str
+    procedure_queries: list[str]
     route_decision: str
     route_latency_ms: int
     fallback_reason: str
@@ -272,6 +274,7 @@ class DefaultRetrievalSemantics:
         h_scope_mode = "disabled"
         hyde_hypothesis: str | None = None
         injected_item_ids: list[str] = []
+        procedure_queries: list[str] = []
         route_decision = "NO_RETRIEVE"
         rewritten_query = request.message
         try:
@@ -292,6 +295,7 @@ class DefaultRetrievalSemantics:
             resolved_gate = cast(_GateResult, gate_result)
             gate_type = str(resolved_gate["gate_type"])
             rewritten_query = str(resolved_gate["episodic_query"])
+            procedure_queries = list(resolved_gate["procedure_queries"])
             route_decision = str(resolved_gate["route_decision"])
             route_ms = resolved_gate["route_latency_ms"]
             fallback_reason = str(resolved_gate["fallback_reason"])
@@ -326,6 +330,7 @@ class DefaultRetrievalSemantics:
                 h_items=h_items,
                 hyde_hypothesis=hyde_hypothesis,
                 injected_item_ids=injected_item_ids,
+                procedure_queries=procedure_queries,
                 rewritten_query=rewritten_query,
                 route_decision=route_decision,
                 config=self._config,
@@ -497,6 +502,7 @@ class _MemoryRetrievalFinalizer:
         h_items: list[dict],
         hyde_hypothesis: str | None,
         injected_item_ids: list[str],
+        procedure_queries: list[str],
         rewritten_query: str,
         route_decision: str,
         config: "MemoryConfig",
@@ -510,6 +516,7 @@ class _MemoryRetrievalFinalizer:
             h_items=h_items,
             hyde_hypothesis=hyde_hypothesis,
             injected_item_ids=injected_item_ids,
+            procedure_queries=procedure_queries,
             rewritten_query=rewritten_query,
             route_decision=route_decision,
             config=config,
@@ -536,6 +543,7 @@ class _MemoryRetrievalFinalizer:
             h_items=[],
             hyde_hypothesis=None,
             injected_id_set=set(),
+            procedure_queries=[],
             error=str(error),
         )
 
@@ -600,26 +608,24 @@ async def _resolve_memory_gate(
     light_model: str,
 ) -> tuple[_GateResult, list[dict], MemoryEngineRetrieveResult | None]:
     if memory.query_rewriter is not None:
-        decision_task = asyncio.create_task(
-            memory.query_rewriter.decide(
-                user_msg=message,
-                recent_history=recent_turns,
-            )
+        decision = await memory.query_rewriter.decide(
+            user_msg=message,
+            recent_history=recent_turns,
         )
-        procedure_task = asyncio.create_task(
-            _retrieve_engine_items(
-                memory=memory,
-                query=message,
-                scope=MemoryScope(),
-                mode="procedure",
-                memory_types=["procedure", "preference"],
-                top_k=config.top_k_procedure,
-            )
+        procedure_queries = build_procedure_queries(message, decision.procedure_query)
+        p_result = await _retrieve_engine_items(
+            memory=memory,
+            query=message,
+            scope=MemoryScope(),
+            mode="procedure",
+            memory_types=["procedure", "preference"],
+            queries=procedure_queries,
+            top_k=config.top_k_procedure,
         )
-        decision, p_result = await asyncio.gather(decision_task, procedure_task)
         return {
             "gate_type": "query_rewriter",
             "episodic_query": decision.episodic_query,
+            "procedure_queries": procedure_queries,
             "route_decision": "RETRIEVE" if decision.needs_episodic else "NO_RETRIEVE",
             "route_latency_ms": decision.latency_ms,
             "fallback_reason": "",
@@ -646,6 +652,7 @@ async def _resolve_fallback_memory_gate(
     llm: "LLMServices",
     light_model: str,
 ) -> tuple[_GateResult, list[dict], MemoryEngineRetrieveResult | None]:
+    procedure_queries = build_procedure_queries(message)
     p_task = asyncio.create_task(
         _retrieve_engine_items(
             memory=memory,
@@ -653,6 +660,7 @@ async def _resolve_fallback_memory_gate(
             scope=MemoryScope(),
             mode="procedure",
             memory_types=["procedure", "preference"],
+            queries=procedure_queries,
             top_k=config.top_k_procedure,
         )
     )
@@ -673,6 +681,7 @@ async def _resolve_fallback_memory_gate(
     return {
         "gate_type": "history_route",
         "episodic_query": route_decision_obj.rewritten_query,
+        "procedure_queries": procedure_queries,
         "route_decision": "RETRIEVE" if route_decision_obj.needs_history else "NO_RETRIEVE",
         "route_latency_ms": route_decision_obj.latency_ms,
         "fallback_reason": "" if route_reason == "ok" else route_reason,
@@ -872,6 +881,7 @@ async def _retrieve_engine_items(
     mode: str,
     memory_types: list[str],
     top_k: int,
+    queries: list[str] | None = None,
     recent_turns: str = "",
     require_scope_match: bool = False,
 ) -> MemoryEngineRetrieveResult:
@@ -886,6 +896,7 @@ async def _retrieve_engine_items(
             hints={
                 "memory_types": memory_types,
                 "require_scope_match": require_scope_match,
+                "queries": queries or [],
             },
             top_k=top_k,
         )
@@ -1088,6 +1099,7 @@ def _finalize_memory_retrieval(
     h_items: list[dict],
     hyde_hypothesis: str | None,
     injected_item_ids: list[str],
+    procedure_queries: list[str],
     rewritten_query: str,
     route_decision: str,
     config: "MemoryConfig",
@@ -1102,6 +1114,7 @@ def _finalize_memory_retrieval(
         p_items=p_items,
         h_items=h_items,
         hyde_hypothesis=hyde_hypothesis,
+        procedure_queries=procedure_queries,
         injected_id_set=set(injected_item_ids),
         route_decision=route_decision,
     )
@@ -1156,6 +1169,7 @@ def _build_retrieval_completed(
     h_items: list[dict],
     hyde_hypothesis: str | None,
     injected_id_set: set[str],
+    procedure_queries: list[str] | None = None,
     route_decision: str | None = None,
     error: str | None = None,
 ) -> RetrievalCompleted:
@@ -1178,12 +1192,29 @@ def _build_retrieval_completed(
         chat_id=chat_id,
         query=rewritten_query,
         orig_query=user_msg if user_msg != rewritten_query else None,
-        aux_queries=[hyde_hypothesis] if hyde_hypothesis else [],
+        aux_queries=_merge_aux_queries(procedure_queries or [], hyde_hypothesis),
         hits=hits,
         injected_count=sum(1 for h in hits if h.injected),
         route_decision=route_decision,
         error=error,
     )
+
+
+def _merge_aux_queries(
+    procedure_queries: list[str],
+    hyde_hypothesis: str | None,
+) -> list[str]:
+    queries = [str(item).strip() for item in procedure_queries if str(item).strip()]
+    if hyde_hypothesis:
+        queries.append(hyde_hypothesis.strip())
+    seen: set[str] = set()
+    merged: list[str] = []
+    for item in queries:
+        if item in seen:
+            continue
+        seen.add(item)
+        merged.append(item)
+    return merged
 
 
 def _memory_hit_to_item(hit) -> dict[str, Any]:

--- a/memory2/query_builder.py
+++ b/memory2/query_builder.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 
-def build_procedure_queries(user_msg: str, context_hint: str = "") -> list[str]:
-    """为 procedure 检索生成 query 列表。
-
-    Refactor 后只保留保守策略：直接使用原始消息，不再做领域关键词扩展。
-    """
+def build_procedure_queries(user_msg: str, rewritten_query: str = "") -> list[str]:
+    """为 procedure/preference 检索生成原始 query 和改写 query。"""
     msg = _normalize_text(user_msg)
-    hint = _normalize_text(context_hint)
-    if not msg:
-        return [hint] if hint else []
-    return [msg]
+    rewritten = _normalize_text(rewritten_query)
+    queries = [item for item in (msg, rewritten) if item]
+    if not queries:
+        return []
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for item in queries:
+        if item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
+    return deduped
 
 
 def _normalize_text(text: str) -> str:

--- a/memory2/query_rewriter.py
+++ b/memory2/query_rewriter.py
@@ -12,6 +12,7 @@ class GateDecision:
     needs_episodic: bool
     episodic_query: str
     latency_ms: int
+    procedure_query: str = ""
 
 
 class QueryRewriter:
@@ -37,21 +38,49 @@ class QueryRewriter:
             needs_episodic=True,
             episodic_query=user_msg,
         )
-        prompt = self._build_prompt(user_msg=user_msg, recent_history=recent_history)
 
-        # 2. 再调用 LLM；异常或超时都直接 fail-open。
-        try:
-            raw_output = await asyncio.wait_for(
-                self._call_llm(prompt),
-                timeout=self._timeout_s,
+        # 2. 分开改写 history 和 procedure，避免任一路失败吞掉另一路结果。
+        raw_output = ""
+        procedure_query = ""
+        main_task = asyncio.create_task(
+            self._call_llm(
+                self._build_prompt(
+                    user_msg=user_msg,
+                    recent_history=recent_history,
+                )
             )
-        except Exception:
+        )
+        procedure_task = asyncio.create_task(self._rewrite_procedure_query(user_msg))
+        done, pending = await asyncio.wait(
+            {main_task, procedure_task},
+            timeout=self._timeout_s,
+        )
+        for task in pending:
+            _ = task.cancel()
+        if not done:
             return fallback
+        if main_task in done:
+            try:
+                raw_output = main_task.result()
+            except Exception:
+                raw_output = ""
+        if procedure_task in done:
+            try:
+                procedure_query = procedure_task.result()
+            except Exception:
+                procedure_query = ""
 
-        # 3. 最后解析 XML；结构无效则继续回退原始消息。
+        # 3. 最后解析；history 结构无效则回退原始消息，但保留 procedure 改写。
         decision = self._parse_output(raw_output)
         if decision is None:
-            return fallback
+            return self._build_decision(
+                started=started,
+                user_msg=user_msg,
+                needs_episodic=True,
+                episodic_query=user_msg,
+                procedure_query=procedure_query,
+            )
+        decision["procedure_query"] = procedure_query
         return self._build_decision(started=started, user_msg=user_msg, **decision)
 
     async def _call_llm(self, prompt: str) -> str:
@@ -60,9 +89,18 @@ class QueryRewriter:
             tools=[],
             model=self._model,
             max_tokens=self._max_tokens,
+            disable_thinking=True,
         )
         content = getattr(response, "content", response)
         return str(content or "")
+
+    async def _rewrite_procedure_query(self, user_msg: str) -> str:
+        prompt = self._build_procedure_prompt(user_msg)
+        try:
+            raw_output = await self._call_llm(prompt)
+        except Exception:
+            return ""
+        return self._clean_procedure_query(raw_output)
 
     def _parse_output(self, raw_output: str) -> dict[str, Any] | None:
         decision_text = self._extract_tag(raw_output, "decision").upper()
@@ -80,6 +118,7 @@ class QueryRewriter:
         user_msg: str,
         needs_episodic: bool,
         episodic_query: str,
+        procedure_query: str = "",
     ) -> GateDecision:
         fallback_query = user_msg.strip()
         latency_ms = max(0, int((time.perf_counter() - started) * 1000))
@@ -87,6 +126,7 @@ class QueryRewriter:
             needs_episodic=needs_episodic,
             episodic_query=episodic_query.strip() or fallback_query,
             latency_ms=latency_ms,
+            procedure_query=procedure_query.strip(),
         )
 
     @staticmethod
@@ -101,7 +141,7 @@ class QueryRewriter:
     @staticmethod
     def _build_prompt(*, user_msg: str, recent_history: str) -> str:
         history_block = recent_history.strip() or "（无）"
-        return f"""你是记忆检索决策器。根据近期对话和当前用户消息，判断是否需要检索 episodic memory，并输出一个查询。
+        return f"""你是记忆检索决策器。根据近期对话和当前用户消息，判断是否需要检索用户个人事实或历史事件，并输出查询。
 
 近期对话：
 {history_block}
@@ -110,41 +150,111 @@ class QueryRewriter:
 {user_msg}
 
 规则：
-- NO_RETRIEVE：打招呼、闲聊、确认当前轮内容、通用知识问答、简单回应”好/嗯/继续”
-- RETRIEVE：询问过去发生的事、用户偏好、个人信息，或要求执行某类操作时需要查 memory
+- NO_RETRIEVE：打招呼、闲聊、确认当前轮内容、通用知识问答、简单回应“好/嗯/继续”、用户提出新的服务偏好或执行规则
+- RETRIEVE：询问过去发生的事、用户个人信息、用户是否告诉过某事
+- 用户提出新的偏好或规则时，decision 仍是 NO_RETRIEVE；这类内容只交给 procedure/preference 检索 query 处理
+- 出现“都有哪些/列举/所有/一共/总共/历史上”这类聚合问题 → RETRIEVE，并改写成覆盖主题的宽泛 query
+- 出现“他/她/它/这个/那个/这东西/这玩意”这类指示词时，优先用近期对话消解为实际实体
+- “你还记得吗/你知道我的/你记不记得/我跟你说过”等元问题是在查事实本身，history_query 要贴近记忆 summary
+- 提到快递、物流、包裹、到货时，若语境指向用户最近购买行为，应查购买历史；纯工具查询可以不查
+- 提到身体症状、药、复查时，若语境指向用户健康状态，应查健康档案或历史记录
 
-聚合类问题处理（包含”都有哪些/列举/所有/一共/总共/历史上”等词）：
-- 判断为 RETRIEVE
-- history_query 改写为宽泛的语义 query，覆盖该主题下所有可能的记录
-  例：用户问”我买过哪些键盘” → history_query: “购买 键盘 外设”
-  例：用户问”我们讨论过哪些游戏” → history_query: “游戏 推荐 讨论”
+<example id="new_service_rule_not_history">
+用户消息：以后讲复杂问题先给我一个能贯穿始终的例子
+输出：
+<decision>NO_RETRIEVE</decision>
+<history_query></history_query>
+</example>
 
-代词消解（优先执行，再做其他推断）：
-- 消息中出现”他 / 她 / 它 / 这个 / 那个 / 这玩意 / 这东西 / 这 / 那”等指示词时，必须根据近期对话将其替换为实际指代的实体名称
-- 例：近期讨论了 “recursive language model”，用户说”他会经常返回奇怪的 repl 字符” → history_query: “recursive language model repl 字符 输出异常”
-- 例：近期讨论了 MCP 协议，用户说”这玩意为啥突然又火了” → history_query: “MCP 协议 突然流行 原因”
-- 若实在无法确定指代，保留原词并追加近期对话中最相关的实体词
+<example id="external_resource_not_history">
+用户消息：【视频标题-示例站点】 https://short.example/item
+输出：
+<decision>NO_RETRIEVE</decision>
+<history_query></history_query>
+</example>
 
-隐式意图推断（先想再决策）：
-- 在输出 XML 之前，先用 <thinking>...</thinking> 推断用户消息的隐含背景
-- 提到快递 / 物流 / 单号 / 包裹 / 到货：隐含意图通常是查用户最近的购买行为
-- 提到身体症状 / 药 / 复查：隐含意图通常是查用户健康档案
-- 提到那个任务 / 项目 / 上次说的”：隐含意图通常是查用户正在进行的事项
-- 如果隐含意图指向历史记录，则应 RETRIEVE，history_query 应面向隐含意图，而不是表面词
-- <thinking> 只用于内部推理，不要把它混入最终 XML 字段
+<example id="memory_question_history">
+用户消息：你还记得我用的是哪个 Fitbit 吗
+输出：
+<decision>RETRIEVE</decision>
+<history_query>用户使用的 Fitbit 设备型号</history_query>
+</example>
 
-元问题处理（用户在问 agent 是否记得某件事）：
-- 识别标志：”你忘了吗””你还记得吗””你知道我的...””你记不记得””我跟你说过”等
-- 隐含意图是查询该事实本身，history_query 应提取目标事实的语义，而非保留问句形式
-- 记忆库中 profile 条目是纯事实陈述（如”用户佩戴 Fitbit Inspire 3”），event 条目带时间戳；query 需贴近这种陈述语义才能命中
-- 例：”你忘记我用的是哪个 Fitbit 了吗” → history_query: “用户佩戴的 Fitbit 设备型号”
-- 例：”你还记得我喜欢哪个游戏吗” → history_query: “用户喜欢的游戏 偏好”
-- 例：”我跟你说过我的 Steam ID 吧” → history_query: “用户 Steam ID”
-
-输出要求：
-- history_query：面向 event/profile 的完整语义 query，可以包含上下文
-
-只输出 XML：
+只输出 XML，不要解释：
 <decision>RETRIEVE|NO_RETRIEVE</decision>
 <history_query>...</history_query>
 """
+
+
+    @staticmethod
+    def _build_procedure_prompt(user_msg: str) -> str:
+        return f"""只输出一行检索 query，不要解释。
+
+把用户消息改写成 preference/procedure 库能命中的 summary 风格查询：
+- 用户希望 agent 怎样服务、讲解、推荐
+- agent 在某类请求下必须怎么做、用什么工具
+- 用户发来某类外部资源、文件、图片、链接时 agent 应如何处理
+不要抽一次性标题词，要写可复用场景。
+丢弃一次性标题、情绪词、短链路径；保留可复用类别词，如平台、资源类型、输入形态、用户动作、agent 应执行的对象。
+如果用户消息里出现了具体平台名或资源类型，要保留这些可复用类别词；不要输出“某平台”“某资源”这类占位词。
+
+<example id="procedure_explicit_command">
+用户消息：把这个资源下载下来
+输出：用户要求 agent 下载外部资源
+</example>
+
+<example id="procedure_direct_action">
+用户消息：帮我把这个内容整理成表格
+输出：用户要求 agent 整理内容
+</example>
+
+<example id="procedure_resource_share">
+用户消息：【视频标题-哔哩哔哩】 https://short.example/item
+输出：用户发送哔哩哔哩视频链接时 agent 应如何处理
+</example>
+
+<example id="procedure_document_link">
+用户消息：这个文档链接你看一下 https://docs.example.com/item
+输出：用户发送文档链接时 agent 应如何处理
+</example>
+
+<example id="procedure_attachment">
+用户消息：这是文件，帮我处理一下
+输出：用户发送文件并要求 agent 处理
+</example>
+
+<example id="procedure_media">
+用户消息：帮我看看这张图
+输出：用户发送图片并要求 agent 分析
+</example>
+
+<example id="preference_service_style">
+用户消息：以后讲复杂问题先给我一个能贯穿始终的例子
+输出：用户希望 agent 讲解复杂问题时先给贯穿始终的例子
+</example>
+
+<example id="preference_future_rule">
+用户消息：以后遇到这种问题先给结论再解释
+输出：用户希望 agent 回答时先给结论再解释
+</example>
+
+<example id="memory_answer_rule">
+用户消息：你还记得我之前告诉你的设备型号吗
+输出：用户询问记忆内容时 agent 应如何查找依据
+</example>
+
+<example id="answer_style_rule">
+用户消息：解释一下这两个协议有什么区别
+输出：用户询问知识问题时 agent 应如何组织回答
+</example>
+
+用户消息：{user_msg}
+输出：
+"""
+
+    @staticmethod
+    def _clean_procedure_query(raw_output: str) -> str:
+        text = re.sub(r"\s+", " ", str(raw_output or "")).strip("。 .")
+        if text.lower() in {"", "空", "无", "none", "null", "n/a", "not applicable", "(empty)"}:
+            return ""
+        return text

--- a/memory2/query_rewriter.py
+++ b/memory2/query_rewriter.py
@@ -94,12 +94,16 @@ class QueryRewriter:
         content = getattr(response, "content", response)
         return str(content or "")
 
+    # 用独立 LLM 调用把用户消息改写为 procedure/preference 库可命中的 summary 句式。
     async def _rewrite_procedure_query(self, user_msg: str) -> str:
+        # 1. 构造 procedure 改写专用 prompt。
         prompt = self._build_procedure_prompt(user_msg)
+        # 2. 调用 LLM；异常时返回空，不阻断 history 决策路径。
         try:
             raw_output = await self._call_llm(prompt)
         except Exception:
             return ""
+        # 3. 清洗输出：压缩空白、剔除哨兵占位符。
         return self._clean_procedure_query(raw_output)
 
     def _parse_output(self, raw_output: str) -> dict[str, Any] | None:
@@ -252,9 +256,12 @@ class QueryRewriter:
 输出：
 """
 
+    # 清洗 LLM 产出的 procedure query：压缩空白，剔除常见哨兵占位符。
     @staticmethod
     def _clean_procedure_query(raw_output: str) -> str:
+        # 1. 先压缩所有连续空白为单空格，再剔除首尾句号和空格。
         text = re.sub(r"\s+", " ", str(raw_output or "")).strip("。 .")
+        # 2. 若清洗后命中已知哨兵词，返回空，避免把占位符当 query 送入向量检索。
         if text.lower() in {"", "空", "无", "none", "null", "n/a", "not applicable", "(empty)"}:
             return ""
         return text

--- a/tests/test_memory_retrieval_gates.py
+++ b/tests/test_memory_retrieval_gates.py
@@ -357,7 +357,7 @@ def test_retrieve_memory_block_prefers_query_rewriter_primary_path():
     retrieval._memory.query_rewriter.decide.assert_awaited_once()
 
 
-def test_retrieve_memory_block_query_rewriter_path_uses_raw_msg_for_procedure_lane():
+def test_retrieve_memory_block_query_rewriter_path_uses_dual_query_for_procedure_lane():
     loop = _make_loop(_Provider())
     session = _DummySession("cli:1")
     retrieval = _make_retrieval(loop)
@@ -367,6 +367,7 @@ def test_retrieve_memory_block_query_rewriter_path_uses_raw_msg_for_procedure_la
             needs_episodic=True,
             episodic_query="用户的B站下载偏好历史",
             latency_ms=8,
+            procedure_query="B站视频下载 SOP",
         )
     )
     memory_port = MagicMock()
@@ -396,6 +397,10 @@ def test_retrieve_memory_block_query_rewriter_path_uses_raw_msg_for_procedure_la
     procedure_calls = [call for call in engine_calls if call["mode"] == "procedure"]
     assert len(procedure_calls) == 1
     assert procedure_calls[0]["query"] == "把这个B站视频下载下来"
+    assert procedure_calls[0]["queries"] == [
+        "把这个B站视频下载下来",
+        "B站视频下载 SOP",
+    ]
 
 
 def test_process_inner_schedules_consolidation_only_after_append_messages():

--- a/tests/test_procedure_query_builder.py
+++ b/tests/test_procedure_query_builder.py
@@ -20,9 +20,9 @@ def test_no_hardcoded_caozuoguifan_suffix():
 
 
 def test_returns_at_least_two_queries():
-    """Refactor 后保守退化为单 query。"""
-    queries = build_procedure_queries("把这个B站视频下载下来")
-    assert queries == ["把这个B站视频下载下来"]
+    """保留原始 query，并追加 LLM 产出的改写 query。"""
+    queries = build_procedure_queries("把这个B站视频下载下来", "B站视频 下载 SOP")
+    assert queries == ["把这个B站视频下载下来", "B站视频 下载 SOP"]
 
 
 def test_all_queries_are_non_empty_strings():
@@ -44,16 +44,13 @@ def test_short_message_still_works():
 
 
 def test_generic_message_with_no_keywords_returns_original_only():
-    """对于没有命中领域关键词的普通消息，只返回原始消息本身。
-
-    Refactor 后所有消息都统一走这个保守行为。
-    """
+    """对于没有命中领域语境的普通消息，只返回原始消息本身。"""
     queries = build_procedure_queries("帮我创建一个新技能")
     assert queries == ["帮我创建一个新技能"]
 
 
-def test_context_hint_no_longer_expands_query():
-    """context_hint 保留签名兼容，但不再触发额外 query 扩展。"""
+def test_no_rewritten_query_returns_original_only():
+    """没有 LLM 改写时，不额外扩展 query。"""
     msg = "把这个视频发给我"
-    queries = build_procedure_queries(msg, context_hint="bilibili.com")
+    queries = build_procedure_queries(msg)
     assert queries == [msg]

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -17,10 +17,12 @@ def test_gate_decision_is_dataclass_with_required_fields():
         needs_episodic=True,
         episodic_query="用户关于B站下载的历史偏好",
         latency_ms=42,
+        procedure_query="B站视频下载 SOP",
     )
     assert d.needs_episodic is True
     assert d.episodic_query == "用户关于B站下载的历史偏好"
     assert d.latency_ms == 42
+    assert d.procedure_query == "B站视频下载 SOP"
 
 
 @pytest.mark.asyncio
@@ -66,6 +68,54 @@ async def test_decide_fails_open_on_llm_exception():
     result = await rewriter.decide(user_msg="帮我搜代码", recent_history="")
     assert result.needs_episodic is True
     assert result.episodic_query == "帮我搜代码"
+    assert result.procedure_query == ""
+
+
+@pytest.mark.asyncio
+async def test_decide_preserves_procedure_query_when_history_call_fails():
+    client = MagicMock()
+    calls = 0
+
+    async def _chat(*, messages, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("history failed")
+        return "用户发送哔哩哔哩视频链接时 agent 应如何处理"
+
+    client.chat = AsyncMock(side_effect=_chat)
+    rewriter = QueryRewriter(llm_client=client)
+
+    result = await rewriter.decide(
+        user_msg="【视频-哔哩哔哩】 https://example.test/item",
+        recent_history="",
+    )
+
+    assert result.needs_episodic is True
+    assert result.episodic_query.startswith("【视频")
+    assert result.procedure_query == "用户发送哔哩哔哩视频链接时 agent 应如何处理"
+
+
+@pytest.mark.asyncio
+async def test_decide_cleans_empty_procedure_query_sentinels():
+    client = MagicMock()
+
+    async def _chat(*, messages, **kwargs):
+        prompt = messages[0]["content"]
+        if "只输出一行检索 query" in prompt:
+            return "None."
+        return """
+<decision>NO_RETRIEVE</decision>
+<history_query></history_query>
+"""
+
+    client.chat = AsyncMock(side_effect=_chat)
+    rewriter = QueryRewriter(llm_client=client)
+
+    result = await rewriter.decide(user_msg="你好", recent_history="")
+
+    assert result.needs_episodic is False
+    assert result.procedure_query == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

目前 procedure 检索直接使用原始用户消息做 query，但原始消息包含一次性标题、短链路径、情绪词等噪声，在 `preference/procedure` 语义库中命中率低。需要让 LLM 将用户消息改写成与 memory summary 风格接近的可复用 query。

同时 QueryRewriter 原来只做 history 决策，procedure 检索和 LLM 调用是串行的，可以将 procedure 改写与 history 改写并行化。

## 改动

- `QueryRewriter.decide()`：用 `asyncio.wait` 并行调用 history 决策和 procedure 改写，任一路失败不吞掉另一路结果
- `GateDecision` 新增 `procedure_query` 字段
- 新增 `_build_procedure_prompt()`：将用户消息改写为 preference/procedure 检索友好的 query（保留平台/资源类别，丢弃一次性词和短链）
- 新增 `_clean_procedure_query()`：处理 LLM 空白/哨兵响应
- `build_procedure_queries`：签名从 `(msg, context_hint)` 改为 `(msg, rewritten_query)`，合并去重
- `procedure_queries` 贯穿 `_GateResult` → `DefaultRetrievalSemantics` → `_MemoryRetrievalFinalizer` → `_build_retrieval_completed` 全链路
- `_retrieve_engine_items` 新增 `queries` 参数，传给 engine hints
- `_build_prompt` 增加 procedure vs history 边界示例（偏好/规则类输入 → NO_RETRIEVE）
- `_call_llm` 增加 `disable_thinking=True`（gate 不需要 thinking）

## 验证

- `pytest tests/test_query_rewriter.py tests/test_procedure_query_builder.py tests/test_memory_retrieval_gates.py`：36 passed
- `pyright memory2/query_rewriter.py memory2/query_builder.py core/memory/default_runtime_facade.py`：0 errors
- 真实 LLM 泛化测试：YouTube / Twitter / arXiv / GitHub / Notion / 飞书 / 小红书 / CSV / JSON / SQL dump / PDF / Excel / 偏好 / 规则 / 边界输入全部正确改写

## 配置影响

- 无，不涉及 config