### PR TITLE
feat(dashboard): 记忆表格行悬停时浮现单条删除按钮

### DIFF
--- a/plugins/default_memory/dashboard_panel.css
+++ b/plugins/default_memory/dashboard_panel.css
@@ -1,0 +1,20 @@
+.row-delete-cell {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.table-row:hover .row-delete-cell {
+  opacity: 1;
+}
+
+.row-delete-btn {
+  color: var(--danger) !important;
+}
+
+.row-delete-btn:hover {
+  background: var(--red-soft);
+}

--- a/plugins/default_memory/dashboard_panel.ts
+++ b/plugins/default_memory/dashboard_panel.ts
@@ -427,6 +427,11 @@ async function dmemFetchPage(opts: FetchPageOpts): Promise<FetchPageResult> {
   return { items: payload.items || [], total: payload.total || 0 };
 }
 
+function dmemRenderDeleteBtn(_value: unknown, item: Record<string, unknown>): string {
+  const id = escapeHtml(String(item.id ?? ""));
+  return `<button class="icon-btn row-delete-btn" type="button" onclick="event.stopPropagation();void(async()=>{try{await api('/api/dashboard/memories/batch-delete',{method:'POST',body:JSON.stringify({ids:['${id}']})});window.dispatchEvent(new CustomEvent('akashic-dashboard-refresh'))}catch(e){alert(e.message||String(e))}})()" title="删除此条">✕</button>`;
+}
+
 async function dmemGetCount(): Promise<number | null> {
   try {
     const payload = await api<{ items: unknown[]; total: number }>("/api/dashboard/memories?page=1&page_size=1&sort_by=created_at&sort_order=desc");
@@ -458,6 +463,7 @@ window.AkashicDashboard.registerPlugin({
     { key: "created_at", label: "Created", width: 96, fmt: "mono-time", cellClass: "mono cell-time", sortable: true },
     { key: "updated_at", label: "Updated", width: 96, fmt: "mono-time", cellClass: "mono cell-time", sortable: true },
     { key: "status", label: "Status", width: 88, cellClass: "cell-status", renderCell: (v) => dmemStatusPill(String(v ?? "")) },
+    { key: "_actions", label: "", width: 40, cellClass: "row-delete-cell", renderCell: dmemRenderDeleteBtn },
   ],
 
   batchActions: [


### PR DESCRIPTION
## Summary

- default_memory 表格末尾新增 `_actions` 列（width: 40px），行悬停时浮现红色 ✕ 删除按钮
- 点击直接调用 `batch-delete` API 删除该条记忆，完成后自动刷新列表
- CSS `opacity: 0` → `:hover` 显示，与现有 session-actions 交互模式一致
- 新增 `plugins/default_memory/dashboard_panel.css`

## Demo

行悬停在 status 列右侧时出现删除按钮，点击即删。

## Config Impact

无