### PR TITLE
feat(shell): 后台任务完成自动回灌

### DIFF
--- a/agent/core/runner.py
+++ b/agent/core/runner.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from agent.looping.handlers import process_spawn_completion_event
-from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
+from agent.looping.handlers import (
+    process_shell_completion_event,
+    process_spawn_completion_event,
+)
+from bus.events import (
+    InboundItem,
+    InboundMessage,
+    OutboundMessage,
+    ShellCompletionItem,
+    SpawnCompletionItem,
+)
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import AgentCore
@@ -74,6 +83,13 @@ class CoreRunner:
                         dispatch_outbound=dispatch_outbound,
                     )
                 raise RuntimeError("spawn completion 缺少处理依赖")
+            case ShellCompletionItem():
+                return await process_shell_completion_event(
+                    item=msg,
+                    key=key,
+                    pipeline=self._agent_core.pipeline,
+                    dispatch_outbound=dispatch_outbound,
+                )
             case InboundMessage():
                 # 2. 默认普通被动消息统一走 AgentCore。
                 return await self._agent_core.process(

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -34,7 +34,13 @@ __all__ = [
     "AgentLoop",
 ]
 from bus.event_bus import EventBus
-from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
+from bus.events import (
+    InboundItem,
+    InboundMessage,
+    OutboundMessage,
+    ShellCompletionItem,
+    SpawnCompletionItem,
+)
 from bus.events_lifecycle import (
     StreamDeltaReady,
     TurnStarted,
@@ -81,6 +87,10 @@ def _supports_stream_events(channel: str, chat_id: str) -> bool:
 def _item_content(item: InboundItem) -> str:
     if isinstance(item, InboundMessage):
         return item.content
+    if isinstance(item, ShellCompletionItem):
+        event = item.event
+        label = event.description or event.command or event.task_id
+        return f"[后台 shell 完成] {label}"
     return f"[后台任务完成] {item.event.label or item.event.status or item.event.job_id}"
 
 
@@ -503,6 +513,12 @@ class AgentLoop:
                     original_metadata=dict(item.metadata or {}),
                 )
             case SpawnCompletionItem():
+                return TurnInterruptState(
+                    session_key=key,
+                    original_user_message=_item_content(item),
+                    original_metadata={},
+                )
+            case ShellCompletionItem():
                 return TurnInterruptState(
                     session_key=key,
                     original_user_message=_item_content(item),

--- a/agent/looping/handlers.py
+++ b/agent/looping/handlers.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, cast
 from agent.core.runtime_support import AgentLoopRunner, PromptRenderRunner, TurnRunResult
 from agent.lifecycle.types import PromptRenderInput
 from agent.looping.ports import SessionServices
-from bus.events import InboundMessage, OutboundMessage, SpawnCompletionItem
+from agent.tools.shell import is_shell_completion_consumed
+from bus.events import InboundMessage, OutboundMessage, ShellCompletionItem, SpawnCompletionItem
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import PassiveTurnPipeline
@@ -124,6 +125,62 @@ async def process_spawn_completion_event(
             reply=final_content,
             tools_used=tools_used,
             tool_chain=parsed_tool_chain,
+        ),
+        dispatch_outbound=dispatch_outbound,
+    )
+
+
+async def process_shell_completion_event(
+    *,
+    item: ShellCompletionItem,
+    key: str,
+    pipeline: "PassiveTurnPipeline",
+    dispatch_outbound: bool = True,
+) -> OutboundMessage:
+    event = item.event
+    label = event.description.strip() or event.command.strip() or event.task_id
+    if is_shell_completion_consumed(event.task_id):
+        return OutboundMessage(
+            channel=item.channel,
+            chat_id=item.chat_id,
+            content="",
+            metadata={"shell_completion_consumed": True},
+        )
+    status_label = {
+        "completed": "完成",
+        "failed": "失败",
+        "timeout": "超时",
+    }.get(event.status, event.status or "完成")
+    exit_code = "null" if event.exit_code is None else str(event.exit_code)
+    output = event.output.strip() or "（无输出）"
+    truncation = "\n输出已截断，完整日志见 output_path。" if event.output_truncated else ""
+    reply = (
+        f"后台命令已{status_label}：{label}\n"
+        f"退出码：{exit_code}\n"
+        f"耗时：{event.duration_ms}ms\n"
+        f"日志：{event.output_path}\n\n"
+        f"输出：\n{output}{truncation}"
+    )
+    pseudo_msg = InboundMessage(
+        channel=item.channel,
+        sender="shell",
+        chat_id=item.chat_id,
+        content=f"[后台 shell 完成] {label}",
+        timestamp=item.timestamp,
+        media=[],
+        metadata={
+            "omit_user_turn": True,
+            "skip_post_memory": True,
+            "shell_completion": True,
+        },
+    )
+    return await pipeline.post_reasoning(
+        msg=pseudo_msg,
+        session_key=key,
+        turn_result=TurnRunResult(
+            reply=reply,
+            tools_used=[],
+            tool_chain=[],
         ),
         dispatch_outbound=dispatch_outbound,
     )

--- a/agent/tools/meta/register.py
+++ b/agent/tools/meta/register.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 from agent.tools.filesystem import EditFileTool, WriteFileTool
 from agent.tools.forget_memory import ForgetMemoryTool
@@ -12,6 +12,7 @@ from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
 from agent.tools.shell import ShellTool, ShellTaskOutputTool, ShellTaskStopTool
 from agent.tools.tool_search import ToolSearchTool
+from bus.queue import MessageBus
 
 _MEMORY_TOOL_NAMES = {"recall_memory", "memorize", "forget_memory"}
 
@@ -19,12 +20,13 @@ _MEMORY_TOOL_NAMES = {"recall_memory", "memorize", "forget_memory"}
 def register_common_meta_tools(
     tools: ToolRegistry,
     readonly_tools: dict[str, Tool],
-    session_store,
+    session_store: Any,
     push_tool: MessagePushTool | None = None,
+    bus: MessageBus | None = None,
 ) -> MessagePushTool:
     tools.register(ToolSearchTool(tools), always_on=True, risk="read-only")
     tools.register(
-        ShellTool(),
+        ShellTool(completion_bus=bus),
         always_on=True,
         risk="external-side-effect",
         search_hint="终端 脚本 bash 命令",

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -263,8 +263,8 @@ class ShellTool(Tool):
             "- 网络命令（curl/wget/httpie/xh）仅允许访问公网 HTTP(S)，且禁止上传/写文件\n"
             "- 以下命令被禁止：nc、telnet、浏览器等高风险工具\n"
             "- 输出超过 30000 字符时自动截断\n"
-            "- 前台总超时默认 60 秒，最大 600 秒\n"
-            "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；若本次设置了 timeout，后台会继续沿用这个截止时间\n"
+            "- 前台阻塞总超时默认 60 秒，最大 600 秒\n"
+            "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；只有显式设置 timeout，后台才会继续沿用这个硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false，并显式配置 timeout\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
             "- 收到 background_task_id 后，调用 task_output 查看输出和耗时，"
@@ -290,7 +290,10 @@ class ShellTool(Tool):
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": f"超时秒数，默认 {_DEFAULT_TIMEOUT}，最大 {_MAX_TIMEOUT}",
+                    "description": (
+                        f"前台阻塞或显式硬超时秒数，默认 {_DEFAULT_TIMEOUT}，最大 {_MAX_TIMEOUT}；"
+                        "自动转后台后只有显式传入才生效"
+                    ),
                     "minimum": 1,
                     "maximum": _MAX_TIMEOUT,
                 },
@@ -368,7 +371,7 @@ class ShellTool(Tool):
             cast(Callable[[str], None], on_data) if callable(on_data) else None
         )
         return await self._execute_with_auto_promote(
-            command, cwd, env, timeout, data_callback, auto_promote
+            command, cwd, env, timeout, timeout_specified, data_callback, auto_promote
         )
 
     async def _execute_background(
@@ -425,6 +428,7 @@ class ShellTool(Tool):
         cwd: Path | None,
         env: dict[str, str],
         timeout: int,
+        timeout_specified: bool,
         on_data: Callable[[str], None] | None,
         auto_promote: bool,
     ) -> str:
@@ -437,6 +441,7 @@ class ShellTool(Tool):
 
         wall_start_ms = int(time.time() * 1000)
         start_mono = time.monotonic()
+        hard_timeout_s = timeout if timeout_specified else None
 
         proc = await asyncio.create_subprocess_shell(
             command,
@@ -448,7 +453,7 @@ class ShellTool(Tool):
             pump_task=None,
             started_at=start_mono,
             wall_started_at_ms=wall_start_ms,
-            timeout_s=timeout,
+            timeout_s=hard_timeout_s,
         )
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg, on_data))
         bg.pump_task = pump
@@ -458,7 +463,7 @@ class ShellTool(Tool):
             await asyncio.wait_for(asyncio.shield(pump), timeout=fg_wait_timeout)
         except asyncio.TimeoutError:
             elapsed_s = time.monotonic() - start_mono
-            if not auto_promote or elapsed_s >= timeout:
+            if not auto_promote or (timeout_specified and elapsed_s >= timeout):
                 return await self._finalize_timed_out_process(
                     command, proc, pump, log_path, start_mono
                 )
@@ -476,7 +481,7 @@ class ShellTool(Tool):
                     "status": "running",
                     "output_path": log_path,
                     "started_at_ms": wall_start_ms,
-                    "timeout_s": timeout,
+                    "timeout_s": hard_timeout_s,
                     "exit_code": None,
                     "interrupted": False,
                     "auto_promoted": True,
@@ -655,16 +660,13 @@ class ShellTaskOutputTool(Tool):
         if task is None:
             return _err(f"任务 {task_id!r} 不存在或已清理")
 
-        if _is_background_timeout(task):
-            _bg_kill(task_id)
-            return _err(f"任务 {task_id!r} 已超时（{task.timeout_s}s），已自动终止")
-        if time.monotonic() - task.started_at > _BG_TTL_S:
-            _bg_kill(task_id)
-            return _err(f"任务 {task_id!r} 已超出 TTL（{_BG_TTL_S}s），已自动终止")
-
         pump_task = task.pump_task
         if pump_task is None:
             return _err(f"任务 {task_id!r} 状态异常：缺少输出泵")
+        if _is_background_timeout(task):
+            _bg_kill(task_id)
+            return _err(f"任务 {task_id!r} 已超时（{task.timeout_s}s），已自动终止")
+
         if block and not pump_task.done():
             try:
                 await asyncio.wait_for(
@@ -674,6 +676,17 @@ class ShellTaskOutputTool(Tool):
                 pass
 
         done = pump_task.done()
+        if done and time.monotonic() - task.started_at > _BG_TTL_S:
+            if task_id in _BG_REGISTRY:
+                del _BG_REGISTRY[task_id]
+            if task.timeout_handle is not None:
+                task.timeout_handle.cancel()
+            try:
+                os.unlink(task.log_path)
+            except OSError:
+                pass
+            return _err(f"任务 {task_id!r} 已超出 TTL（{_BG_TTL_S}s），已清理")
+
         exit_code = task.proc.returncode if done else None
         status = "done" if done else "running"
 

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -30,6 +30,9 @@ import time
 from typing import Any, Callable, cast
 
 from agent.tools.base import Tool
+from bus.events import ShellCompletionItem
+from bus.internal_events import ShellCompletionEvent
+from bus.queue import MessageBus
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,7 @@ _DEFAULT_TIMEOUT = 60  # 秒（OpenCode 默认 1 分钟）
 _FG_THRESHOLD = 15    # 前台最长等待秒数；超时自动转后台
 _MAX_TIMEOUT = 600  # 秒（OpenCode 最大 10 分钟）
 _MAX_OUTPUT = 30_000  # 字符（与 OpenCode MaxOutputLength 一致）
+_COMPLETION_OUTPUT_MAX = 6000
 _STREAM_CHUNK_SIZE = 4096
 _STREAM_DRAIN_GRACE_S = 0.2
 _BG_TTL_S = 4 * 3600  # 后台任务最长存活时间：4 小时
@@ -112,13 +116,23 @@ class _BackgroundTask:
     pump_task: asyncio.Task | None   # None 仅在创建瞬间，pump 注册后立即填入
     started_at: float                # monotonic，用于 TTL 检查
     wall_started_at_ms: int          # epoch ms，返回给 LLM
+    command: str = ""
+    description: str = ""
+    channel: str = ""
+    chat_id: str = ""
+    completion_bus: MessageBus | None = None
     last_output_at_ms: int | None = None  # epoch ms，每次写文件时更新
     timeout_s: int | None = None
     timeout_handle: asyncio.TimerHandle | None = None
+    finish_reason: str = "natural"
+    suppress_completion: bool = False
+    completion_dispatched: bool = False
+    completion_consumed: bool = False
 
 
 # 模块级单例：跨 ShellTool 实例共享
 _BG_REGISTRY: dict[str, _BackgroundTask] = {}
+_CONSUMED_COMPLETIONS: set[str] = set()
 
 
 async def _bg_pump(
@@ -185,6 +199,87 @@ def _schedule_eviction(task_id: str, log_path: str) -> None:
     loop.call_later(_BG_EVICT_DELAY_S, _evict)
 
 
+def _completion_output(log_path: str) -> tuple[str, bool]:
+    try:
+        content = Path(log_path).read_bytes().decode(errors="replace")
+    except OSError:
+        content = ""
+    if len(content) <= _COMPLETION_OUTPUT_MAX:
+        return content, False
+    return content[-_COMPLETION_OUTPUT_MAX:], True
+
+
+def _shell_completion_status(task: _BackgroundTask) -> str:
+    if task.finish_reason == "timeout":
+        return "timeout"
+    exit_code = task.proc.returncode
+    return "completed" if exit_code == 0 else "failed"
+
+
+def _mark_shell_completion_consumed(
+    task_id: str,
+    task: _BackgroundTask | None = None,
+) -> None:
+    _CONSUMED_COMPLETIONS.add(task_id)
+    target = task or _BG_REGISTRY.get(task_id)
+    if target is None:
+        return
+    target.completion_consumed = True
+    target.suppress_completion = True
+
+
+def is_shell_completion_consumed(task_id: str) -> bool:
+    if task_id in _CONSUMED_COMPLETIONS:
+        return True
+    task = _BG_REGISTRY.get(task_id)
+    return bool(task is not None and task.completion_consumed)
+
+
+def _publish_shell_completion(task_id: str, task: _BackgroundTask) -> None:
+    if is_shell_completion_consumed(task_id):
+        return
+    if task.suppress_completion or task.completion_dispatched:
+        return
+    if task.completion_bus is None or not task.channel or not task.chat_id:
+        return
+    output, truncated = _completion_output(task.log_path)
+    task.completion_dispatched = True
+    duration_ms = int((time.monotonic() - task.started_at) * 1000)
+    item = ShellCompletionItem(
+        channel=task.channel,
+        chat_id=task.chat_id,
+        event=ShellCompletionEvent(
+            task_id=task_id,
+            description=task.description,
+            command=task.command,
+            status=_shell_completion_status(task),
+            exit_code=task.proc.returncode,
+            duration_ms=duration_ms,
+            output=output,
+            output_path=task.log_path,
+            output_truncated=truncated,
+        ),
+    )
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    publish_task = loop.create_task(task.completion_bus.publish_inbound(item))
+
+    def _log_publish_error(done: asyncio.Task) -> None:
+        try:
+            done.result()
+        except Exception:
+            logger.exception("shell completion publish failed task_id=%s", task_id)
+
+    publish_task.add_done_callback(_log_publish_error)
+
+
+def _on_background_task_done(task_id: str, task: _BackgroundTask) -> None:
+    _publish_shell_completion(task_id, task)
+    _schedule_eviction(task_id, task.log_path)
+
+
 def _subprocess_options(cwd: Path | None, env: dict[str, str] | None) -> dict[str, Any]:
     options: dict[str, Any] = {
         "cwd": str(cwd) if cwd is not None else None,
@@ -213,11 +308,15 @@ def _kill_process_tree(proc: Any) -> None:
     os.killpg(proc.pid, signal.SIGKILL)
 
 
-def _bg_kill(task_id: str) -> None:
+def _bg_kill(task_id: str, *, finish_reason: str = "stopped") -> None:
     """杀掉后台任务、从注册表移除并立即删除日志文件。"""
     task = _BG_REGISTRY.pop(task_id, None)
     if task is None:
         return
+    _CONSUMED_COMPLETIONS.add(task_id)
+    task.finish_reason = finish_reason
+    task.suppress_completion = True
+    task.completion_consumed = True
     if task.timeout_handle is not None:
         task.timeout_handle.cancel()
     try:
@@ -229,6 +328,23 @@ def _bg_kill(task_id: str) -> None:
     try:
         os.unlink(task.log_path)
     except OSError:
+        pass
+
+
+def _bg_timeout(task_id: str) -> None:
+    task = _BG_REGISTRY.get(task_id)
+    if task is None:
+        return
+    if task.completion_bus is None or not task.channel or not task.chat_id:
+        _bg_kill(task_id, finish_reason="timeout")
+        return
+    task.finish_reason = "timeout"
+    if task.timeout_handle is not None:
+        task.timeout_handle.cancel()
+        task.timeout_handle = None
+    try:
+        _kill_process_tree(task.proc)
+    except (ProcessLookupError, PermissionError):
         pass
 
 
@@ -247,11 +363,13 @@ class ShellTool(Tool):
         working_dir: Path | None = None,
         restricted_dir: Path | None = None,
         spawn_hook: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        completion_bus: MessageBus | None = None,
     ) -> None:
         self._allow_network = allow_network
         self._working_dir = working_dir
         self._restricted_dir = restricted_dir.resolve() if restricted_dir else None
         self._spawn_hook = spawn_hook
+        self._completion_bus = completion_bus
 
     @property
     def description(self) -> str:
@@ -267,8 +385,8 @@ class ShellTool(Tool):
             "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；只有显式设置 timeout，后台才会继续沿用这个硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false，并显式配置 timeout\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
-            "- 收到 background_task_id 后，调用 task_output 查看输出和耗时，"
-            "根据命令的性质自行判断是否卡死；若判断卡死则 task_stop 终止\n"
+            "- 收到 background_task_id 后，不要为了等待完成而反复调用 task_output；后台结束会自动回传。"
+            "只在需要查看实时输出或判断卡死时调用 task_output，若判断卡死则 task_stop 终止\n"
             "禁止用途：不得用 shell 替代专用工具（read_file 读文件、web_fetch 抓网页、list_dir 列目录）。"
         )
 
@@ -323,6 +441,8 @@ class ShellTool(Tool):
         timeout_specified = "timeout" in kwargs and kwargs.get("timeout") is not None
         run_in_background: bool = bool(kwargs.get("run_in_background", False))
         auto_promote: bool = bool(kwargs.get("auto_promote", True))
+        channel = str(kwargs.get("channel", "") or "")
+        chat_id = str(kwargs.get("chat_id", "") or "")
         on_data = kwargs.get("_on_data")
 
         if not command:
@@ -364,22 +484,36 @@ class ShellTool(Tool):
 
         if run_in_background:
             bg_timeout = timeout if timeout_specified else None
-            return await self._execute_background(command, cwd, env, bg_timeout)
+            return await self._execute_background(
+                command, description, cwd, env, bg_timeout, channel, chat_id
+            )
 
         # ── 前台路径（默认 15s 未完成自动转后台）──────────────────────
         data_callback = (
             cast(Callable[[str], None], on_data) if callable(on_data) else None
         )
         return await self._execute_with_auto_promote(
-            command, cwd, env, timeout, timeout_specified, data_callback, auto_promote
+            command,
+            description,
+            cwd,
+            env,
+            timeout,
+            timeout_specified,
+            data_callback,
+            auto_promote,
+            channel,
+            chat_id,
         )
 
     async def _execute_background(
         self,
         command: str,
+        description: str,
         cwd: Path | None,
         env: dict[str, str],
         timeout_s: int | None,
+        channel: str,
+        chat_id: str,
     ) -> str:
         task_id = f"shell_{uuid4().hex[:12]}"
         log_fd, log_path = tempfile.mkstemp(
@@ -399,10 +533,15 @@ class ShellTool(Tool):
             pump_task=None,
             started_at=time.monotonic(),
             wall_started_at_ms=wall_start_ms,
+            command=command,
+            description=description,
+            channel=channel,
+            chat_id=chat_id,
+            completion_bus=self._completion_bus,
             timeout_s=timeout_s,
         )
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg))
-        pump.add_done_callback(lambda _: _schedule_eviction(task_id, log_path))
+        pump.add_done_callback(lambda _: _on_background_task_done(task_id, bg))
         bg.pump_task = pump
         _BG_REGISTRY[task_id] = bg
         _arm_background_timeout(task_id, bg)
@@ -425,12 +564,15 @@ class ShellTool(Tool):
     async def _execute_with_auto_promote(
         self,
         command: str,
+        description: str,
         cwd: Path | None,
         env: dict[str, str],
         timeout: int,
         timeout_specified: bool,
         on_data: Callable[[str], None] | None,
         auto_promote: bool,
+        channel: str,
+        chat_id: str,
     ) -> str:
         """前台执行；允许按需关闭自动转后台，直接等待完整结果。"""
         task_id = f"shell_{uuid4().hex[:12]}"
@@ -453,6 +595,11 @@ class ShellTool(Tool):
             pump_task=None,
             started_at=start_mono,
             wall_started_at_ms=wall_start_ms,
+            command=command,
+            description=description,
+            channel=channel,
+            chat_id=chat_id,
+            completion_bus=self._completion_bus,
             timeout_s=hard_timeout_s,
         )
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg, on_data))
@@ -468,7 +615,7 @@ class ShellTool(Tool):
                     command, proc, pump, log_path, start_mono
                 )
             # ── 自动转后台 ──────────────────────────────────────────────
-            pump.add_done_callback(lambda _: _schedule_eviction(task_id, log_path))
+            pump.add_done_callback(lambda _: _on_background_task_done(task_id, bg))
             _BG_REGISTRY[task_id] = bg
             _arm_background_timeout(task_id, bg)
             logger.info(
@@ -626,7 +773,8 @@ class ShellTaskOutputTool(Tool):
             "  - 任务挂起：有过输出但 since_last_output_ms 异常大，不符合该命令的预期节奏\n"
             "  - 任务卡死：从未有过输出（since_last_output_ms=null）且 elapsed_ms 超过合理预期\n"
             "不需要 stop 的情况：编译、下载、训练等明确会结束的长时间任务，或用户主动要求的服务进程。\n"
-            "- block=true 时会等待任务完成或 timeout_ms 超时后再返回"
+            "- block=true 时会等待任务完成或 timeout_ms 超时后再返回；不要用它反复等待后台任务完成。\n"
+            "- 如果返回 status=done，本轮必须负责向用户汇报结果，系统不会再额外发送自动完成回灌"
         )
 
     @property
@@ -664,7 +812,7 @@ class ShellTaskOutputTool(Tool):
         if pump_task is None:
             return _err(f"任务 {task_id!r} 状态异常：缺少输出泵")
         if _is_background_timeout(task):
-            _bg_kill(task_id)
+            _bg_timeout(task_id)
             return _err(f"任务 {task_id!r} 已超时（{task.timeout_s}s），已自动终止")
 
         if block and not pump_task.done():
@@ -676,6 +824,8 @@ class ShellTaskOutputTool(Tool):
                 pass
 
         done = pump_task.done()
+        if done:
+            _mark_shell_completion_consumed(task_id, task)
         if done and time.monotonic() - task.started_at > _BG_TTL_S:
             if task_id in _BG_REGISTRY:
                 del _BG_REGISTRY[task_id]
@@ -775,13 +925,13 @@ def _arm_background_timeout(task_id: str, task: _BackgroundTask) -> None:
         return
     remain_s = task.timeout_s - (time.monotonic() - task.started_at)
     if remain_s <= 0:
-        _bg_kill(task_id)
+        _bg_timeout(task_id)
         return
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         return
-    task.timeout_handle = loop.call_later(remain_s, lambda: _bg_kill(task_id))
+    task.timeout_handle = loop.call_later(remain_s, lambda: _bg_timeout(task_id))
 
 
 def _is_background_timeout(task: _BackgroundTask) -> bool:

--- a/bootstrap/toolsets/meta.py
+++ b/bootstrap/toolsets/meta.py
@@ -32,6 +32,7 @@ class CommonMetaToolsetProvider(ToolsetProvider):
             self._readonly_tools,
             deps.session_store,
             push_tool=deps.push_tool,
+            bus=deps.bus,
         )
 
         # 主模型不支持多模态时，注册视觉工具供模型调用

--- a/bus/events.py
+++ b/bus/events.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from agent.policies.delegation import SpawnDecision
-    from bus.internal_events import SpawnCompletionEvent
+    from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
 
 
 def _empty_media() -> list[str]:
@@ -63,4 +63,18 @@ class SpawnCompletionItem:
         return f"{self.channel}:{self.chat_id}"
 
 
-InboundItem = InboundMessage | SpawnCompletionItem
+@dataclass
+class ShellCompletionItem:
+    """后台 shell 完成后的内部回灌项。"""
+
+    channel: str
+    chat_id: str
+    event: "ShellCompletionEvent"
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    @property
+    def session_key(self) -> str:
+        return f"{self.channel}:{self.chat_id}"
+
+
+InboundItem = InboundMessage | SpawnCompletionItem | ShellCompletionItem

--- a/bus/internal_events.py
+++ b/bus/internal_events.py
@@ -15,3 +15,16 @@ class SpawnCompletionEvent:
     result: str
     retry_count: int = 0
     profile: str = ""
+
+
+@dataclass(frozen=True)
+class ShellCompletionEvent:
+    task_id: str
+    description: str
+    command: str
+    status: str
+    exit_code: int | None
+    duration_ms: int
+    output: str
+    output_path: str
+    output_truncated: bool = False

--- a/docker/debug/shell_background_probe.py
+++ b/docker/debug/shell_background_probe.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ProbePaths:
+    repo: Path
+    debug_dir: Path
+    profile: str
+
+    @property
+    def profile_dir(self) -> Path:
+        return self.debug_dir / "profiles" / self.profile
+
+    @property
+    def config(self) -> Path:
+        return self.profile_dir / "config.toml"
+
+    @property
+    def workspace(self) -> Path:
+        return self.profile_dir / "workspace"
+
+    @property
+    def socket(self) -> Path:
+        return self.profile_dir / "akashic.sock"
+
+    @property
+    def sessions_db(self) -> Path:
+        return self.workspace / "sessions.db"
+
+    @property
+    def observe_db(self) -> Path:
+        return self.workspace / "observe" / "observe.db"
+
+    @property
+    def memory_db(self) -> Path:
+        return self.workspace / "memory" / "memory2.db"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _run_compose(paths: ProbePaths, args: list[str]) -> None:
+    _ = subprocess.run(
+        ["docker", "compose", "-f", str(paths.debug_dir / "docker-compose.yml"), *args],
+        cwd=paths.repo,
+        env={**dict(os.environ), "AKASHIC_DEBUG_PROFILE": paths.profile},
+        check=True,
+    )
+
+
+def _bootstrap_profile(paths: ProbePaths, from_profile: str | None) -> None:
+    if paths.config.exists():
+        return
+    if not from_profile:
+        raise SystemExit(f"缺少 profile config: {paths.config}")
+    src = paths.debug_dir / "profiles" / from_profile / "config.toml"
+    if not src.exists():
+        raise SystemExit(f"缺少 bootstrap config: {src}")
+    paths.profile_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, paths.config)
+
+
+def _replace_section_value(
+    text: str,
+    section_name: str,
+    key: str,
+    value: str,
+) -> str:
+    marker = f"[{section_name}]\n"
+    if marker not in text:
+        return text
+    head, tail = text.split(marker, 1)
+    section, sep, rest = tail.partition("\n[")
+    pattern = rf"(?m)^{re.escape(key)}\s*=.*$"
+    replacement = f"{key} = {value}"
+    if re.search(pattern, section):
+        section = re.sub(pattern, replacement, section, count=1)
+    else:
+        section = replacement + "\n" + section
+    return head + marker + section + (sep + rest if sep else "")
+
+
+def _isolate_cli_config(config_path: Path) -> str:
+    original = config_path.read_text(encoding="utf-8")
+    text = original
+    text = _replace_section_value(text, "channels.telegram", "token", '""')
+    text = _replace_section_value(text, "channels.qq", "bot_uin", '""')
+    text = _replace_section_value(text, "channels.qqbot", "app_id", '""')
+    text = _replace_section_value(text, "proactive", "enabled", "false")
+    config_path.write_text(text, encoding="utf-8")
+    return original
+
+
+def _connect_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=10000")
+    return conn
+
+
+def _latest_cli_session_key(db_path: Path) -> str:
+    conn = _connect_db(db_path)
+    try:
+        row = conn.execute(
+            """
+            select key
+            from sessions
+            where key like 'cli:%'
+            order by updated_at desc
+            limit 1
+            """
+        ).fetchone()
+        return str(row["key"]) if row else ""
+    finally:
+        conn.close()
+
+
+def _json_loads(value: object) -> Any:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _session_messages(db_path: Path, session_key: str) -> list[dict[str, Any]]:
+    conn = _connect_db(db_path)
+    try:
+        rows = conn.execute(
+            """
+            select seq, role, content, tool_chain, extra, ts
+            from messages
+            where session_key = ?
+            order by seq
+            """,
+            (session_key,),
+        ).fetchall()
+    finally:
+        conn.close()
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        extra = _json_loads(row["extra"]) or {}
+        result.append(
+            {
+                "seq": int(row["seq"]),
+                "role": str(row["role"]),
+                "content": str(row["content"] or ""),
+                "tool_chain": _json_loads(row["tool_chain"]),
+                "extra": extra,
+                "ts": str(row["ts"]),
+            }
+        )
+    return result
+
+
+def _observe_turns(db_path: Path, session_key: str) -> list[dict[str, Any]]:
+    if not db_path.exists():
+        return []
+    conn = _connect_db(db_path)
+    try:
+        rows = conn.execute(
+            """
+            select id, user_msg, tool_calls, error
+            from turns
+            where session_key = ?
+            order by id
+            """,
+            (session_key,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    return [
+        {
+            "id": int(row["id"]),
+            "user": str(row["user_msg"] or ""),
+            "tool_calls": _json_loads(row["tool_calls"]) or [],
+            "error": str(row["error"] or ""),
+        }
+        for row in rows
+    ]
+
+
+def _memory_baseline(memory_db: Path) -> dict[str, str]:
+    if not memory_db.exists():
+        return {}
+    conn = _connect_db(memory_db)
+    try:
+        rows = conn.execute("select id, updated_at from memory_items").fetchall()
+    except sqlite3.Error:
+        return {}
+    finally:
+        conn.close()
+    return {str(row["id"]): str(row["updated_at"] or "") for row in rows}
+
+
+def _changed_memory_items(
+    memory_db: Path,
+    baseline: dict[str, str],
+) -> list[dict[str, str]]:
+    if not memory_db.exists():
+        return []
+    conn = _connect_db(memory_db)
+    try:
+        rows = conn.execute(
+            """
+            select id, memory_type, summary, source_ref, updated_at
+            from memory_items
+            order by updated_at
+            """
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    return [
+        {
+            "id": str(row["id"]),
+            "memory_type": str(row["memory_type"] or ""),
+            "summary": str(row["summary"] or ""),
+            "source_ref": str(row["source_ref"] or ""),
+        }
+        for row in rows
+        if baseline.get(str(row["id"])) != str(row["updated_at"] or "")
+    ]
+
+
+def _memory_writes(
+    observe_db: Path,
+    session_key: str,
+    started_at: str,
+) -> list[dict[str, str]]:
+    if not observe_db.exists():
+        return []
+    conn = _connect_db(observe_db)
+    try:
+        rows = conn.execute(
+            """
+            select action, item_id, memory_type, summary, source_ref, ts
+            from memory_writes
+            where session_key = ? and ts >= ?
+            order by id
+            """,
+            (session_key, started_at),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    return [
+        {
+            "action": str(row["action"] or ""),
+            "item_id": str(row["item_id"] or ""),
+            "memory_type": str(row["memory_type"] or ""),
+            "summary": str(row["summary"] or ""),
+            "source_ref": str(row["source_ref"] or ""),
+            "ts": str(row["ts"] or ""),
+        }
+        for row in rows
+    ]
+
+
+async def _read_assistant(
+    reader: asyncio.StreamReader,
+    timeout: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = await asyncio.wait_for(reader.readline(), timeout=deadline - time.monotonic())
+        if not line:
+            raise RuntimeError("CLI 连接已断开")
+        data = json.loads(line)
+        if data.get("type") == "assistant":
+            return {
+                "content": str(data.get("content") or ""),
+                "metadata": data.get("metadata") or {},
+            }
+    raise TimeoutError("等待 assistant 回复超时")
+
+
+async def _send(
+    writer: asyncio.StreamWriter,
+    text: str,
+) -> None:
+    writer.write((json.dumps({"content": text}, ensure_ascii=False) + "\n").encode())
+    await writer.drain()
+
+
+def _extract_marker(text: str) -> str:
+    match = re.search(r"AKASHIC_BG_DONE_[0-9a-f]{32}", text)
+    return match.group(0) if match else ""
+
+
+def _has_shell_tool(msg: dict[str, Any]) -> bool:
+    extra = msg.get("extra") if isinstance(msg.get("extra"), dict) else {}
+    tools_used = extra.get("tools_used") if isinstance(extra, dict) else None
+    if isinstance(tools_used, list) and "shell" in tools_used:
+        return True
+    chain = msg.get("tool_chain")
+    if not isinstance(chain, list):
+        return False
+    for group in chain:
+        if not isinstance(group, dict):
+            continue
+        calls = group.get("calls")
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if isinstance(call, dict) and call.get("name") == "shell":
+                return True
+    return False
+
+
+def _build_checks(
+    *,
+    responses: list[dict[str, Any]],
+    messages: list[dict[str, Any]],
+    memory_writes: list[dict[str, str]],
+    memory_items: list[dict[str, str]],
+) -> dict[str, Any]:
+    completion_messages = [
+        msg
+        for msg in messages
+        if msg["role"] == "assistant" and "后台命令已" in msg["content"]
+    ]
+    first_shell_messages = [
+        msg
+        for msg in messages
+        if msg["role"] == "assistant" and _has_shell_tool(msg)
+    ]
+    marker = ""
+    for row in responses:
+        marker = _extract_marker(row["content"])
+        if marker:
+            break
+    memory_blob = "\n".join(
+        [
+            *(row["summary"] + "\n" + row["source_ref"] for row in memory_writes),
+            *(row["summary"] + "\n" + row["source_ref"] for row in memory_items),
+        ]
+    )
+    fake_user_rows = [
+        msg
+        for msg in messages
+        if msg["role"] == "user" and "[后台 shell 完成]" in msg["content"]
+    ]
+    completion_uses_shell = [
+        msg
+        for msg in completion_messages
+        if _has_shell_tool(msg)
+    ]
+    checks = {
+        "first_turn_used_shell": bool(first_shell_messages),
+        "has_auto_completion_message": bool(completion_messages),
+        "no_fake_user_shell_completion": not fake_user_rows,
+        "completion_tools_used_is_empty": not completion_uses_shell,
+        "completion_marker_observed": bool(marker),
+        "completion_marker_not_in_memory": bool(marker) and marker not in memory_blob,
+        "assistant_completion_count": len(completion_messages),
+        "exact_marker": marker,
+    }
+    checks["passed"] = all(
+        bool(checks[name])
+        for name in (
+            "first_turn_used_shell",
+            "has_auto_completion_message",
+            "no_fake_user_shell_completion",
+            "completion_tools_used_is_empty",
+            "completion_marker_observed",
+            "completion_marker_not_in_memory",
+        )
+    )
+    return checks
+
+
+def _write_report(
+    *,
+    report_base: Path,
+    payload: dict[str, Any],
+) -> None:
+    report_base.parent.mkdir(parents=True, exist_ok=True)
+    report_json = report_base.with_suffix(".json")
+    report_md = report_base.with_suffix(".md")
+    report_json.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    lines = [
+        "# shell background probe",
+        "",
+        "```text",
+        "docker/debug profile",
+        "  |",
+        "  +-- cli user prompt",
+        "  |     |",
+        "  |     +-- shell auto-promote after 15s",
+        "  |",
+        "  +-- shell completion inbound",
+        "        |",
+        "        +-- assistant-only persistence",
+        "```",
+        "",
+        f"- profile: {payload['profile']}",
+        f"- session_key: {payload['session_key']}",
+        f"- passed: {payload['checks']['passed']}",
+        f"- exact_marker: {payload['checks']['exact_marker']}",
+        "",
+        "## Checks",
+        "",
+    ]
+    for key, value in payload["checks"].items():
+        lines.append(f"- {key}: {value}")
+    lines.extend(["", "## Responses", ""])
+    for index, row in enumerate(payload["responses"], 1):
+        lines.extend([f"### Response {index}", "", row["content"], ""])
+    lines.extend(["## Session Messages", ""])
+    for row in payload["session_messages"]:
+        content = row["content"].replace("\n", "\\n")
+        if len(content) > 180:
+            content = content[:180] + "..."
+        tools_used = row["extra"].get("tools_used") if isinstance(row["extra"], dict) else None
+        lines.append(
+            f"- seq={row['seq']} role={row['role']} tools_used={tools_used} content={content}"
+        )
+    lines.extend(["", "## Memory Writes", ""])
+    if payload["memory_writes"]:
+        for row in payload["memory_writes"]:
+            lines.append(f"- {row['action']} [{row['memory_type']}] {row['summary']}")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Changed Memory Items", ""])
+    if payload["changed_memory_items"]:
+        for row in payload["changed_memory_items"]:
+            lines.append(f"- [{row['memory_type']}] {row['summary']}")
+    else:
+        lines.append("- none")
+    report_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"markdown: {report_md}")
+    print(f"json: {report_json}")
+
+
+async def _run_probe(args: argparse.Namespace) -> None:
+    paths = ProbePaths(
+        repo=_repo_root(),
+        debug_dir=Path(__file__).resolve().parent,
+        profile=args.profile,
+    )
+    _bootstrap_profile(paths, args.bootstrap_from)
+    original_config = _isolate_cli_config(paths.config) if args.isolate_channels else None
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        if args.reset_workspace:
+            _run_compose(paths, ["run", "--rm", "akashic-debug", "reset-workspace"])
+        if args.start_agent:
+            paths.socket.unlink(missing_ok=True)
+            proc = subprocess.Popen(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(paths.debug_dir / "docker-compose.yml"),
+                    "up",
+                    "akashic-debug",
+                ],
+                cwd=paths.repo,
+                env={**dict(os.environ), "AKASHIC_DEBUG_PROFILE": paths.profile},
+                stdout=subprocess.DEVNULL if args.quiet_agent else None,
+                stderr=subprocess.STDOUT if args.quiet_agent else None,
+            )
+            deadline = time.monotonic() + args.start_timeout
+            while time.monotonic() < deadline and not paths.socket.exists():
+                if proc.poll() is not None:
+                    raise SystemExit("agent 启动失败，docker compose 已退出")
+                await asyncio.sleep(0.5)
+            if not paths.socket.exists():
+                raise SystemExit(f"等待 socket 超时: {paths.socket}")
+
+        started_at = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+        memory_baseline = _memory_baseline(paths.memory_db)
+        reader, writer = await asyncio.open_unix_connection(str(paths.socket))
+        command = (
+            "python -c 'import time, uuid; "
+            'print("AKASHIC_BG_START", flush=True); '
+            "time.sleep(18); "
+            'print("AKASHIC_BG_DONE_"+uuid.uuid4().hex, flush=True)' "'"
+        )
+        prompt = (
+            "请真实调用 shell 工具执行下面这个命令，不要用文字模拟。"
+            "不要设置 timeout，不要设置 run_in_background=true，让它按默认 15 秒自动转后台。"
+            "拿到 background_task_id 后只告诉我任务已转后台，不要调用 task_output。\n\n"
+            f"命令：{command}"
+        )
+        responses: list[dict[str, Any]] = []
+        try:
+            await _send(writer, prompt)
+            first = await _read_assistant(reader, args.turn_timeout)
+            responses.append(first)
+            print(f"first response: {first['content'][:120]}")
+            deadline = time.monotonic() + args.completion_timeout
+            while time.monotonic() < deadline:
+                item = await _read_assistant(
+                    reader,
+                    max(1.0, deadline - time.monotonic()),
+                )
+                responses.append(item)
+                print(f"completion candidate: {item['content'][:120]}")
+                if _extract_marker(item["content"]) or "后台命令已" in item["content"]:
+                    break
+            session_key = _latest_cli_session_key(paths.sessions_db)
+            if not session_key:
+                raise SystemExit("未找到 CLI session")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        await asyncio.sleep(args.after_completion_wait)
+        messages = _session_messages(paths.sessions_db, session_key)
+        observe_turns = _observe_turns(paths.observe_db, session_key)
+        writes = _memory_writes(paths.observe_db, session_key, started_at)
+        changed_items = _changed_memory_items(paths.memory_db, memory_baseline)
+        checks = _build_checks(
+            responses=responses,
+            messages=messages,
+            memory_writes=writes,
+            memory_items=changed_items,
+        )
+        payload = {
+            "profile": paths.profile,
+            "session_key": session_key,
+            "prompt": prompt,
+            "responses": responses,
+            "session_messages": messages,
+            "observe_turns": observe_turns,
+            "memory_writes": writes,
+            "changed_memory_items": changed_items,
+            "checks": checks,
+        }
+        report_base = args.output or paths.workspace / f"shell-background-probe-{paths.profile}"
+        _write_report(report_base=report_base, payload=payload)
+        if not checks["passed"]:
+            raise SystemExit("shell background probe failed")
+    finally:
+        if proc is not None and args.stop_agent:
+            _run_compose(paths, ["down"])
+        if original_config is not None:
+            paths.config.write_text(original_config, encoding="utf-8")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="运行后台 shell 完成回灌真实探针。")
+    parser.add_argument("--profile", default="shell-bg-probe")
+    parser.add_argument("--bootstrap-from", default="")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--turn-timeout", type=float, default=180)
+    parser.add_argument("--completion-timeout", type=float, default=90)
+    parser.add_argument("--start-timeout", type=float, default=90)
+    parser.add_argument("--after-completion-wait", type=float, default=2)
+    parser.add_argument("--reset-workspace", action="store_true")
+    parser.add_argument("--start-agent", action="store_true")
+    parser.add_argument("--stop-agent", action="store_true")
+    parser.add_argument("--quiet-agent", action="store_true")
+    parser.add_argument("--isolate-channels", action="store_true", default=True)
+    parser.add_argument("--no-isolate-channels", dest="isolate_channels", action="store_false")
+    return parser.parse_args()
+
+
+def main() -> None:
+    asyncio.run(_run_probe(_parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_core_p6_runner.py
+++ b/tests/test_agent_core_p6_runner.py
@@ -11,8 +11,8 @@ from agent.lifecycle.types import PromptRenderResult
 from agent.looping.ports import SessionServices
 from agent.tools.registry import ToolRegistry
 from agent.core.runner import CoreRunner, CoreRunnerDeps
-from bus.events import InboundMessage, OutboundMessage, SpawnCompletionItem
-from bus.internal_events import SpawnCompletionEvent
+from bus.events import InboundMessage, OutboundMessage, ShellCompletionItem, SpawnCompletionItem
+from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
 
 
 @pytest.mark.asyncio
@@ -119,3 +119,97 @@ async def test_core_runner_handles_spawn_completion_via_direct_helper_deps():
     pr_kwargs = pipeline_mock.post_reasoning.await_args.kwargs
     assert pr_kwargs["dispatch_outbound"] is False
     runner._agent_core.process.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_core_runner_handles_shell_completion_without_llm():
+    pipeline_mock = SimpleNamespace(
+        post_reasoning=AsyncMock(
+            return_value=OutboundMessage(
+                channel="telegram",
+                chat_id="123",
+                content="shell done",
+            )
+        )
+    )
+    runner = CoreRunner(
+        CoreRunnerDeps(
+            agent_core=cast(
+                Any,
+                SimpleNamespace(
+                    process=AsyncMock(),
+                    pipeline=pipeline_mock,
+                ),
+            ),
+        )
+    )
+    item = ShellCompletionItem(
+        channel="telegram",
+        chat_id="123",
+        event=ShellCompletionEvent(
+            task_id="shell_1",
+            description="跑测试",
+            command="pytest",
+            status="completed",
+            exit_code=0,
+            duration_ms=123,
+            output="31 passed",
+            output_path="/tmp/shell.log",
+        ),
+    )
+
+    out = await runner.process(item, "telegram:123", dispatch_outbound=False)
+
+    assert out.content == "shell done"
+    pipeline_mock.post_reasoning.assert_awaited_once()
+    kwargs = pipeline_mock.post_reasoning.await_args.kwargs
+    assert kwargs["dispatch_outbound"] is False
+    assert kwargs["turn_result"].reply.startswith("后台命令已完成：跑测试")
+    assert kwargs["turn_result"].tools_used == []
+    assert kwargs["msg"].metadata["omit_user_turn"] is True
+    assert kwargs["msg"].metadata["skip_post_memory"] is True
+    runner._agent_core.process.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_core_runner_skips_consumed_shell_completion():
+    import agent.tools.shell as shell_mod
+
+    pipeline_mock = SimpleNamespace(post_reasoning=AsyncMock())
+    runner = CoreRunner(
+        CoreRunnerDeps(
+            agent_core=cast(
+                Any,
+                SimpleNamespace(
+                    process=AsyncMock(),
+                    pipeline=pipeline_mock,
+                ),
+            ),
+        )
+    )
+    task_id = "shell_consumed"
+    shell_mod._mark_shell_completion_consumed(task_id)
+    item = ShellCompletionItem(
+        channel="telegram",
+        chat_id="123",
+        event=ShellCompletionEvent(
+            task_id=task_id,
+            description="跑测试",
+            command="pytest",
+            status="completed",
+            exit_code=0,
+            duration_ms=123,
+            output="31 passed",
+            output_path="/tmp/shell.log",
+        ),
+    )
+
+    try:
+        out = await runner.process(item, "telegram:123", dispatch_outbound=True)
+
+        assert out.content == ""
+        assert out.metadata["shell_completion_consumed"] is True
+        pipeline_mock.post_reasoning.assert_not_awaited()
+        runner._agent_core.process.assert_not_awaited()
+    finally:
+        shell_mod._CONSUMED_COMPLETIONS.discard(task_id)

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -17,6 +17,8 @@ from agent.tools.shell import (
     _validate_command,
     _run,
 )
+from bus.events import ShellCompletionItem
+from bus.queue import MessageBus
 
 _KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
@@ -429,6 +431,123 @@ async def test_shell_run_in_background_returns_task_id(monkeypatch, tmp_path):
 
     # 清理注册表，避免污染其他测试
     _BG_REGISTRY.pop(task_id, None)
+
+
+@pytest.mark.asyncio
+async def test_shell_background_completion_publishes_item(monkeypatch):
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        return _FakeProc(stdout="done from bg", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    bus = MessageBus()
+    tool = ShellTool(completion_bus=bus)
+    result = json.loads(
+        await tool.execute(
+            command="echo done",
+            description="后台完成",
+            run_in_background=True,
+            channel="telegram",
+            chat_id="123",
+        )
+    )
+    task_id = result["background_task_id"]
+
+    item = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+
+    assert isinstance(item, ShellCompletionItem)
+    assert item.channel == "telegram"
+    assert item.chat_id == "123"
+    assert item.event.task_id == task_id
+    assert item.event.description == "后台完成"
+    assert item.event.command == "echo done"
+    assert item.event.status == "completed"
+    assert item.event.exit_code == 0
+    assert "done from bg" in item.event.output
+
+    _BG_REGISTRY.pop(task_id, None)
+
+
+@pytest.mark.asyncio
+async def test_task_stop_suppresses_shell_completion(monkeypatch):
+    import agent.tools.shell as shell_mod
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        proc = _FakeProc(stdout="", stderr="", returncode=None)
+
+        async def _wait_forever():
+            await asyncio.Future()
+
+        proc.wait = _wait_forever
+        return proc
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
+
+    bus = MessageBus()
+    tool = ShellTool(completion_bus=bus)
+    result = json.loads(
+        await tool.execute(
+            command="sleep infinity",
+            description="手动停止",
+            run_in_background=True,
+            channel="telegram",
+            chat_id="123",
+        )
+    )
+    task_id = result["background_task_id"]
+
+    stop_tool = ShellTaskStopTool()
+    stop_result = json.loads(await stop_tool.execute(task_id=task_id))
+
+    assert stop_result["status"] == "stopped"
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(bus.consume_inbound(), timeout=0.05)
+    shell_mod._BG_REGISTRY.pop(task_id, None)
+
+
+@pytest.mark.asyncio
+async def test_task_output_done_consumes_shell_completion(monkeypatch, tmp_path):
+    import agent.tools.shell as shell_mod
+
+    bus = MessageBus()
+    log_path = tmp_path / "done.log"
+    log_path.write_text("final output", encoding="utf-8")
+    pump = asyncio.ensure_future(asyncio.sleep(0))
+    await pump
+
+    task_id = "shell_done_consumed"
+    task = shell_mod._BackgroundTask(
+        proc=_FakeProc(stdout="", stderr="", returncode=0),
+        log_path=str(log_path),
+        pump_task=pump,
+        started_at=shell_mod.time.monotonic(),
+        wall_started_at_ms=int(shell_mod.time.time() * 1000),
+        command="pytest",
+        description="检查测试",
+        channel="telegram",
+        chat_id="123",
+        completion_bus=bus,
+    )
+    shell_mod._BG_REGISTRY[task_id] = task
+
+    try:
+        result = json.loads(await ShellTaskOutputTool().execute(task_id=task_id))
+        shell_mod._on_background_task_done(task_id, task)
+
+        assert result["status"] == "done"
+        assert "final output" in result["output"]
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(bus.consume_inbound(), timeout=0.05)
+    finally:
+        shell_mod._BG_REGISTRY.pop(task_id, None)
+        shell_mod._CONSUMED_COMPLETIONS.discard(task_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -602,22 +602,28 @@ async def test_task_stop_deletes_log_file(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_task_output_ttl_deletes_log_file(monkeypatch, tmp_path):
-    """TTL 到期时 _bg_kill 应同时删除日志文件。"""
+    """TTL 到期只清理已完成任务的注册表和日志。"""
     import agent.tools.shell as shell_mod
 
-    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
+    killed = []
+    monkeypatch.setattr(
+        "agent.tools.shell._kill_process_tree",
+        lambda proc: killed.append(proc.pid),
+    )
 
     log_path = tmp_path / "ttl.log"
     log_path.write_text("old output", encoding="utf-8")
 
     fake_proc = _FakeProc(stdout="", stderr="", returncode=0)
     fake_proc.pid = 2222
+    pump = asyncio.ensure_future(asyncio.sleep(0))
+    await pump
 
     task_id = "shell_ttllog"
     shell_mod._BG_REGISTRY[task_id] = shell_mod._BackgroundTask(
         proc=fake_proc,
         log_path=str(log_path),
-        pump_task=asyncio.ensure_future(asyncio.sleep(100)),
+        pump_task=pump,
         started_at=shell_mod.time.monotonic() - shell_mod._BG_TTL_S - 1,
         wall_started_at_ms=0,
     )
@@ -626,7 +632,10 @@ async def test_task_output_ttl_deletes_log_file(monkeypatch, tmp_path):
     result = json.loads(await tool.execute(task_id=task_id))
 
     assert "error" in result
-    assert not log_path.exists(), "TTL 到期后日志文件应已被删除"
+    assert "TTL" in result["error"]
+    assert not log_path.exists(), "已完成任务 TTL 到期后日志文件应已被删除"
+    assert task_id not in shell_mod._BG_REGISTRY
+    assert killed == []
 
 
 @pytest.mark.asyncio
@@ -638,30 +647,49 @@ async def test_task_stop_not_found():
 
 
 @pytest.mark.asyncio
-async def test_task_output_ttl_expired(monkeypatch):
-    """TTL 到期的任务在 task_output 时被自动终止并返回 error。"""
+async def test_task_output_ttl_does_not_kill_running_task_without_timeout(
+    monkeypatch, tmp_path
+):
+    """未显式 timeout 的 running 任务超过 TTL 后仍只返回状态，不杀进程。"""
     import agent.tools.shell as shell_mod
 
-    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
+    killed = []
+    monkeypatch.setattr(
+        "agent.tools.shell._kill_process_tree",
+        lambda proc: killed.append(proc.pid),
+    )
 
-    fake_proc = _FakeProc(stdout="", stderr="", returncode=0)
+    log_path = tmp_path / "running_ttl.log"
+    log_path.write_text("still running", encoding="utf-8")
+
+    fake_proc = _FakeProc(stdout="", stderr="", returncode=None)
     fake_proc.pid = 1234
+    pump = asyncio.ensure_future(asyncio.sleep(100))
 
     task_id = "shell_expired"
     shell_mod._BG_REGISTRY[task_id] = shell_mod._BackgroundTask(
         proc=fake_proc,
-        log_path="/tmp/fake_expired.log",
-        pump_task=asyncio.ensure_future(asyncio.sleep(100)),
+        log_path=str(log_path),
+        pump_task=pump,
         started_at=shell_mod.time.monotonic() - shell_mod._BG_TTL_S - 1,
         wall_started_at_ms=0,
+        timeout_s=None,
     )
 
     tool = ShellTaskOutputTool()
-    result = json.loads(await tool.execute(task_id=task_id))
+    try:
+        result = json.loads(await tool.execute(task_id=task_id))
 
-    assert "error" in result
-    assert "TTL" in result["error"]
-    assert task_id not in shell_mod._BG_REGISTRY
+        assert result["status"] == "running"
+        assert result["exit_code"] is None
+        assert "still running" in result["output"]
+        assert task_id in shell_mod._BG_REGISTRY
+        assert log_path.exists()
+        assert killed == []
+    finally:
+        shell_mod._BG_REGISTRY.pop(task_id, None)
+        pump.cancel()
+        await asyncio.gather(pump, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -755,9 +783,49 @@ async def test_shell_auto_promotes_to_background_after_fg_threshold(monkeypatch)
     assert task_id is not None, "应返回 background_task_id"
     assert result["status"] == "running"
     assert result.get("auto_promoted") is True
+    assert result["timeout_s"] is None
     assert task_id in shell_mod._BG_REGISTRY
+    assert shell_mod._BG_REGISTRY[task_id].timeout_s is None
+    assert shell_mod._BG_REGISTRY[task_id].timeout_handle is None
 
     # 清理
+    shell_mod._BG_REGISTRY.pop(task_id, None)
+
+
+@pytest.mark.asyncio
+async def test_shell_auto_promote_preserves_explicit_timeout(monkeypatch):
+    import agent.tools.shell as shell_mod
+
+    monkeypatch.setattr(shell_mod, "_FG_THRESHOLD", 0)
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        proc = _FakeProc(stdout="", stderr="", returncode=None)
+
+        async def _wait_forever():
+            await asyncio.Future()
+
+        proc.wait = _wait_forever
+        return proc
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(command="sleep infinity", description="显式超时", timeout=30)
+    )
+
+    task_id = result["background_task_id"]
+    assert result["timeout_s"] == 30
+    assert shell_mod._BG_REGISTRY[task_id].timeout_s == 30
+    assert shell_mod._BG_REGISTRY[task_id].timeout_handle is not None
+
+    handle = shell_mod._BG_REGISTRY[task_id].timeout_handle
+    if handle is not None:
+        handle.cancel()
     shell_mod._BG_REGISTRY.pop(task_id, None)
 
 

--- a/tests/test_spawn_completion_flow.py
+++ b/tests/test_spawn_completion_flow.py
@@ -7,8 +7,8 @@ from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig, MemoryServices
 from agent.provider import LLMResponse
 from agent.tools.registry import ToolRegistry
-from bus.events import SpawnCompletionItem
-from bus.internal_events import SpawnCompletionEvent
+from bus.events import ShellCompletionItem, SpawnCompletionItem
+from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
 from tests.memory_fakes import FakeMemoryEngine
 from session.manager import SessionManager
 
@@ -117,3 +117,57 @@ async def test_spawn_completion_retry_count_one_disables_retry_guidance(tmp_path
     )
     assert "已重试一次，不再重试" in joined_messages
     assert "调用 spawn 重试" not in joined_messages
+
+
+@pytest.mark.asyncio
+async def test_shell_completion_persists_assistant_only_without_llm(tmp_path):
+    provider = _Provider()
+    session_manager = SessionManager(tmp_path)
+    tools = ToolRegistry()
+    loop = AgentLoop(
+        AgentLoopDeps(
+            bus=MagicMock(),
+            provider=cast(Any, provider),
+            tools=tools,
+            session_manager=session_manager,
+            workspace=tmp_path,
+            memory_services=MemoryServices(engine=FakeMemoryEngine(tmp_path)),
+        ),
+        AgentLoopConfig(llm=LLMConfig(max_iterations=3)),
+    )
+
+    session = session_manager.get_or_create("telegram:123")
+    session.add_message("user", "跑一下测试")
+    session.add_message("assistant", "我开始跑，结束后告诉你。")
+    session_manager.save(session)
+
+    item = ShellCompletionItem(
+        channel="telegram",
+        chat_id="123",
+        event=ShellCompletionEvent(
+            task_id="shell_abc",
+            description="测试",
+            command="pytest tests/test_shell_tool.py -q",
+            status="completed",
+            exit_code=0,
+            duration_ms=1680,
+            output="31 passed",
+            output_path="/tmp/shell.log",
+        ),
+    )
+
+    response = await loop._process(item)
+    updated = session_manager.get_or_create("telegram:123")
+
+    assert response.channel == "telegram"
+    assert response.chat_id == "123"
+    assert "后台命令已完成：测试" in response.content
+    assert "31 passed" in response.content
+    assert provider.calls == []
+    assert len(updated.messages) == 3
+    assert updated.messages[-1]["role"] == "assistant"
+    assert "后台命令已完成：测试" in updated.messages[-1]["content"]
+    assert all(
+        message["content"] != "[后台 shell 完成] 测试"
+        for message in updated.messages
+    )


### PR DESCRIPTION
## 背景

后台 shell 任务之前只能靠 agent 主动轮询 `task_output` 才能看到最终结果。长命令自动转后台后，如果被最大步数或后续 turn 打断，用户很容易只看到 `background_task_id`，但看不到最终完成状态。

## 改动

- 新增 `ShellCompletionItem` / `ShellCompletionEvent`，后台 shell pump 完成后通过 inbound 队列回灌结果。
- shell completion 走 assistant-only 持久化，不调用 LLM，不写假 user 消息，并跳过 post memory。
- `task_output` 读取到 done 时会消费对应 completion，避免用户查看输出与自动完成同时发生时重复发送。
- `task_stop` 和手动 kill 会抑制自动完成，避免停止任务后误发完成通知。
- 修正后台任务 timeout 语义：未显式设置 timeout 的后台任务不再被默认 60 秒杀掉；running TTL 不杀进程，只清理已结束旧任务。
- 新增 Docker debug 真实探针 `docker/debug/shell_background_probe.py`，验证 CLI + LLM + shell 自动转后台 + assistant-only 落库 + memory 不污染。

## 影响

后台 shell 完成后会自动给同一 channel/chat_id 发送一条格式化完成结果，并作为 assistant 消息进入 session history。该完成消息的 `tools_used` 为空，不会污染 after-turn 工具统计或钩子；内部 marker 不会作为 user message 入库。

## 验证

- `pytest tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py -q`：41 passed
- `docker compose -f docker/debug/docker-compose.yml run --rm akashic-debug pytest tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py -q`：41 passed
- `pyright docker/debug/shell_background_probe.py agent/tools/shell.py agent/looping/handlers.py tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py`：0 errors，仍有既有 warning
- `python docker/debug/shell_background_probe.py --profile shell-bg-probe --bootstrap-from default --reset-workspace --start-agent --stop-agent --quiet-agent`：passed

## 配置影响

无新增配置。
