### PR TITLE
docs(handbook): 重写核心文档体系

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,411 +2,116 @@
 
 # akashic Agent
 
+一个**会主动找你**的 AI 伙伴——不只是被动回答问题，还能根据你订阅的信息源主动判断"现在该不该发消息、发什么"，在空闲时自主执行后台任务。
+
+**[Proactive 主动推送](./_handbook/proactive-guide.md)** — **[Drift 空闲任务](./_handbook/drift-guide.md)**
+
 ---
 
 ## Quickstart
 
-**1. 安装依赖**
-
-需要 Python 3.12。推荐用 `uv` 管理虚拟环境：
+需要 Python 3.12。
 
 ```bash
 git clone <this-repo>
 cd akashic-agent
-uv venv                              # 创建 .venv
-uv pip install -r requirements.txt  # 安装依赖
+uv venv && uv pip install -r requirements.txt
 ```
 
-没有 uv？先装：`python -m pip install uv`
+没有 uv？先 `pip install uv`。
 
-**2. 初始化（推荐用交互向导）**
+### 1. 初始化
 
 ```bash
-uv run python main.py setup
+uv run python main.py setup    # 交互向导（推荐）
+# 或
+uv run python main.py init     # 非交互，CI/自动化用
 ```
 
-向导会逐步引导你配置主模型、频道、记忆，自动生成 `config.toml` 并初始化工作区。Telegram 配置完成后会实时获取你的 `chat_id`，proactive 一步到位。
+### 2. 填写 config.toml 最少配置
 
-如果是自动化/CI 场景，用非交互模式：
-
-```bash
-uv run python main.py init   # 复制 config.example.toml，手动编辑后启动
-```
-
-`init` 创建的工作区结构：
-
-```
-~/.akashic/workspace/
-  memory/
-    MEMORY.md          # 长期记忆（空）
-    SELF.md            # 自我认知（空）
-    HISTORY.md         # 事件日志（空）
-    RECENT_CONTEXT.md  # 近期上下文摘要（空）
-    PENDING.md         # 待提取事实（空）
-    NOW.md             # 近期进行中 / 待确认事项（模板）
-    memory2.db         # 语义记忆数据库（memory.enabled=true 时）
-    consolidation_writes.db  # 归档写入记录
-  PROACTIVE_CONTEXT.md # 主动推送规则文件（模板）
-  mcp_servers.json     # MCP server 注册表
-  schedules.json       # 定时任务列表
-  proactive_sources.json  # 信息源列表
-  memes/manifest.json  # 表情包清单
-  skills/              # 用户自定义 skill 目录
-  drift/skills/        # 用户自定义 Drift skill 目录
-  sessions.db          # 会话存储
-  observe/observe.db   # trace 数据库
-  proactive.db         # proactive 状态数据库
-  proactive_quota.json # proactive 配额
-```
-
-**3. 填写配置**
-
-编辑 `config.toml`，至少填写主模型 API key 和一个频道（Telegram 或 QQ 选一个）。推荐配置（DeepSeek 主模型 + Qwen 轻量/视觉）：
 ```toml
-[llm]
-provider = "deepseek"
-
 [llm.main]
-model = "deepseek-v4-flash"     # 主模型：推理能力强、速度快、价格低
-api_key = "sk-..."              # DeepSeek API key
-base_url = "https://api.deepseek.com/v1"
-enable_thinking = true          # 开启 reasoning（R1 模式）
-multimodal = false              # DeepSeek 不支持图片，用 VL 工具补
-
-[llm.fast]
-model = "qwen-flash"            # 轻量模型：memory gate / query rewrite / HyDE
-api_key = "sk-..."              # Qwen API key（DashScope）
-base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-
-[llm.vl]
-model = "qwen-vl-plus"          # 视觉模型：主模型 multimodal=false 时自动启用
-api_key = "sk-..."              # 同 Qwen key
-base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-
-[agent.context]
-memory_window = 40              # 上下文窗口，运行时自动对齐到 6 的倍数
-
-[memory]
-enabled = true                  # 开启语义记忆（memory2 引擎）
-engine = ""                     # 记忆引擎，留空 = default_memory 插件
-
-[memory.embedding]
-model = "text-embedding-v3"     # 向量模型
+model = "deepseek-v4-flash"
 api_key = "sk-..."
-base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 
 [channels.telegram]
-token = "123456:ABC..."         # BotFather 给的 bot token
-allow_from = ["your_username"]  # 你的 Telegram 用户名（不带 @）
-
-[channels.qqbot]
-# 可选：官方 QQBot 私聊通道。留空自动跳过。
-user_openid = ""
-app_id = ""
-bot_token = ""
+token = "123456:ABC..."
+allow_from = ["your_username"]
 ```
 
-也可以用 Qwen 全家桶（主模型换 `qwen3.5-plus`，`multimodal = true`，`llm.vl` 留空），或者用 OpenAI 兼容的任意 provider。
+见 `config.example.toml` 完整模板。
 
-**图像能力**
-
-| 路线 | 配置 | 效果 |
-|------|------|------|
-| A: 主模型多模态 | `multimodal = true`，`llm.vl.model = ""` | 图片直接 `image_url` 进主模型 |
-| B: 主模型 + VL 工具 | `multimodal = false`，`llm.vl.model = "qwen-vl-plus"` | 图片转路径提示，模型按需调用 `read_image_vision` |
-| C: 纯文本 | `multimodal = false`，`llm.vl.model = ""` | 图片不可理解，只保留路径 |
-
-路线 B 是推荐方案：主模型用 DeepSeek 这类纯文本强模型，图片理解交给专门的 VL 模型，性价比最高。
-
-**4. 启动**
+### 3. 启动
 
 ```bash
 uv run python main.py
 ```
 
-打开 Telegram，找到你的 bot，发一条消息，就可以开始对话。
-
-**5. 配置 Proactive（可选）**
-
-`config.example.toml` 默认 `proactive.enabled = true`。填上你的 Telegram chat_id（可以向 bot 发一条消息后从日志里拿到），agent 就会在订阅的信息源有内容时主动推送消息。如果不需要主动推送，设为 `enabled = false`。
-
-```toml
-[proactive.target]
-channel = "telegram"
-chat_id = "123456789"   # 你的 Telegram user id
-```
-
-**6. 打开 Drift**
-
-```toml
-[proactive.drift]
-enabled = true
-min_interval_hours = 3  # 每次 drift 最小间隔
-```
-
-Drift 打开后，没有可推送内容时，agent 会利用空闲时间自主执行 `drift/skills/` 下定义的任务。本轮不打扰用户时用 `finish_drift(message_result="silent")` 静默收尾；如果已经主动发消息，则必须用 `finish_drift(message_result="sent")` 收尾。
-
-**7. 打开 Dashboard（可选）**
-
-Dashboard 用来查看会话、消息、记忆、proactive 记录和插件面板：
-
-```bash
-uv run python main.py dashboard
-```
-
-默认监听 `0.0.0.0:2236`。如需改地址：
-
-```bash
-uv run python main.py dashboard --host 127.0.0.1 --port 2236
-```
-
-**8. 配置 MCP servers（可选）**
-
-MCP server 注册表在工作区的 `mcp_servers.json`。也可以在对话里让 agent 调用 `mcp_add` 添加，手动配置格式如下：
-
-```json
-{
-  "servers": {
-    "calendar": {
-      "command": ["python", "/path/to/run_server.py"],
-      "env": {
-        "GOOGLE_CLIENT_ID": "..."
-      },
-      "cwd": "/path/to"
-    }
-  }
-}
-```
-
-启动时会读取这个文件并把 MCP 工具注册进工具列表。
-
-**9. Docker 调试沙盒（可选）**
-
-调试多模态、Telegram 图片等真实入口时，可以用 Docker 沙盒。它不会挂载宿主机 `HOME`，也不会挂载正式 `~/.akashic/workspace`；所有调试配置、记忆、会话、图片和数据库都只写入 `docker/debug/profiles/<name>/`。
-
-```
-host
-  |
-  +-- akashic-agent
-      |
-      +-- docker/debug/profiles/default
-          |
-          +-- config.toml
-          +-- workspace
-          +-- home
-          +-- akashic.sock
-
-container
-  |
-  +-- /app                 -> 当前代码
-  +-- /sandbox/config.toml -> 调试 bot 配置
-  +-- /sandbox/workspace   -> 调试 workspace
-  +-- /sandbox/home        -> 容器 HOME
-```
-
-第一次进入沙盒配置专用 Telegram bot：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml run --rm akashic-debug setup
-```
-
-需要保留多套调试配置时，用不同 profile：
-
-```bash
-AKASHIC_DEBUG_PROFILE=multimodal docker compose -f docker/debug/docker-compose.yml run --rm akashic-debug setup
-AKASHIC_DEBUG_PROFILE=multimodal docker compose -f docker/debug/docker-compose.yml up akashic-debug
-```
-
-启动调试 agent：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml up akashic-debug
-```
-
-另开一个终端连接沙盒 CLI：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml run --rm akashic-debug cli
-```
-
-打开沙盒 Dashboard：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml run --rm --service-ports akashic-debug dashboard
-```
-
-停止调试环境：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml down
-```
-
-只清空调试 workspace、保留调试 `config.toml`：
-
-```bash
-docker compose -f docker/debug/docker-compose.yml run --rm akashic-debug reset-workspace
-```
-
-**Troubleshooting**
-
-- `chat_id` 不知道怎么拿：优先跑 `uv run python main.py setup`，向导会在 Telegram 配好后自动获取；手动配置时，先给 bot 发一条消息，再从日志里的 Telegram update 里取 user id。
-- `uv` 装不上：先升级 pip，执行 `python -m pip install --upgrade pip`，再执行 `python -m pip install uv`。
-- Dashboard 打不开：确认主程序没有占用同一端口，或用 `--port` 换一个端口。
-- MCP server 没工具：先确认 `mcp_servers.json` 里的 `command` 能在终端单独启动，且需要的环境变量都在 `env` 里。
+给 bot 发一条消息即可开始对话。
 
 ---
 
-## 链路说明
+## 核心功能
 
----
+### 被动回复链路
 
-## 一、被动回复链
+收到消息 → 记忆检索 → 工具调用 → 流式回复。每轮经过 6 个生命周期 Phase（BeforeTurn → BeforeReasoning → Reasoner → AfterReasoning → AfterTurn），插件可在各 Phase 通过 EventBus 或模块插入点介入。
 
-每条被动 turn 经 6 个生命周期 Phase 按序执行，产出一条回复。
+### Proactive 主动推送
 
-```
-InboundMessage
-  → AgentLoop → CoreRunner → AgentCore (PassiveTurnPipeline)
-      ├─ BeforeTurn        session → context → emit[插件介入] → output
-      ├─ BeforeReasoning   tool sync → build ctx → emit → prompt 预热
-      ├─ Reasoner.run_turn()   (retry / trim / tool loop)
-      │    ├─ BeforeStep    token 估算 → emit → inject hints (每轮)
-      │    └─ AfterStep     fanout 通知进度 (每轮)
-      ├─ AfterReasoning    parse → emit → persist user/assistant → build outbound
-      └─ AfterTurn         TurnCommitted fanout → emit → dispatch
-  → OutboundMessage
-```
-
-### 生命周期模块链
-
-每个 Phase 内部是一条模块链。核心抽象三件套：
-
-| 抽象 | 说明 |
-|------|------|
-| `PhaseFrame[I, O]` | 数据盘。`input`（只读）、`slots`（模块间 dict 通道）、`output`（最终产出）。一次 run 一份 |
-| `PhaseModule[F]` | 单个步骤。接口：`async (frame) → frame`。可选声明 `requires`/`produces` 供启动校验 |
-| `Phase[I, O, F]` | 生产线。`Phase(modules, frame_factory=Frame)`，按序执行 module 列表 |
-
-链式示例（BeforeTurn）：
+agent 定期检查你订阅的信息源，自主决定是否推送。
 
 ```
-Phase([_AcquireSession, *early_modules, _PrepareContext, _BuildCtx,
-       _Emit(EventBus), *late_modules, _Return], frame_factory=BeforeTurnFrame)
-
-Step1: session 从 manager 取出，写 slots["session:session"]
-Step1.5: ★ 插件 early module（如命令拦截 /memory_status，可 abort 跳过后续）
-Step2: 上下文记忆检索，写 slots["session:context_bundle"]
-Step3: 拼 BeforeTurnCtx，写 slots["session:ctx"]
-Step4: EventBus.emit() 依序执行注册的插件 handler（可修改 ctx）
-Step4.5: ★ 插件 late module（EventBus emit 后的补充处理）
-Step5: ctx → output，Phase 返回
+proactive loop
+  ├── 自适应轮询（你的活跃度决定频率）
+  ├── 三路数据预取（alert / content / context）
+  ├── LLM 逐条评分分类（interesting / not_interesting）
+  └── 推送决策（去重 + 打扰检查 → 发送或跳过）
 ```
 
-内置模块和外部插件在链上是平等节点——都满足 `PhaseModule` 协议，都通过 slots 读写数据。插件可以通过两种方式介入：
-- **EventBus 装饰器**（`@on_before_turn`、`@on_after_reasoning` 等）：注入到每个 Phase 的 emit 步骤，GATE 可改写事件，TAP 只读观察
-- **PhaseModule 插入点**（`before_turn_modules_early()` / `late()`）：仅在 before-turn 阶段可用，分别位于记忆检索之前和 EventBus emit 之后
+三类数据通道：
+- **alert**：高优先级告警（心率异常、日历提醒），直接透传不评分
+- **content**：内容流（RSS 新闻、社交更新），逐条评分分类
+- **context**：背景上下文（睡眠状态、游戏在线），概率注入
 
-每个 Phase 提供 `default_xxx_modules()` 工厂函数供 `PassiveTurnPipeline` 组装内置模块链。
+详见 [proactive-guide.md](./_handbook/proactive-guide.md)。
 
-`PassiveTurnPipeline` 将 6 个 Phase 串联为完整链路。Reasoner 内部的 `BeforeStep` / `AfterStep` 也是相同抽象，每次迭代执行一次。
+### Drift 空闲任务
 
----
+没有可推送内容时，agent 不空转——它会执行你定义的 drift skill：
 
-## 二、Proactive 信息源处理
+- **audit-dirty-memories** — 随机抽检长期记忆，回溯原文验证准确性
+- **explore-curiosity** — 补足用户画像空白，随口一问
+- **review-drift-gaps** — Drift 自我反思，跟踪停滞方向
 
-主动推送链路在每个 tick 里，先于 agent loop 并行预取所有数据源。
-
-```
-AgentTick.tick()
-  └─ Pre-gate（冷却 / 用户在线 / busy 检查）
-       └─ DataGateway.run()          # 三路并行预取
-            ├─ _fetch_alerts()       # 实时告警（完整内容，直接传给 agent）
-            ├─ _fetch_context()      # 上下文条目（直接传给 agent）
-            └─ _fetch_content()      # feed 内容（并行 web_fetch，存入 content_store）
-                                     # agent 通过 get_content 工具按需取正文
-       └─ _run_loop(ctx)             # agent loop，max 20 步
-            工具：recall_memory / get_content / web_fetch
-                  mark_interesting / mark_not_interesting / send_message
-```
-
-Gateway 的设计原则是：agent 启动前所有数据已经就位，形成一份本 tick 的静态输入快照。单源失败不影响其他源。
-
-**ACK / 去重**：
-
-| 场景 | TTL |
-|------|-----|
-| 已引用内容/告警 | 168h |
-| interesting 未引用 | 24h |
-| delivery/message 去重命中 | 24h |
-| mark_not_interesting | 720h |
-
-去重 key 优先按稳定 URL，其次 source+title，最后退化为 event_id；没有内容引用时用消息文本 hash。
-
----
-
-## 三、Drift 链路
-
-Proactive gateway 没有 alert、feed 内容和可用 fallback context 时，进入 Drift 模式——agent 用一段空闲时间自主做一件有意义的事。
-
-```
-AgentTick.tick()
-  └─ DataGateway.run()
-       └─ no alert / no content / no fallback context
-            └─ DriftRunner.run(ctx, llm_fn)
-                 ├─ scan_skills()
-                 │    └─ 读取 drift/skills/ 和内建 skill 的 SKILL.md
-                 ├─ filter_skills()
-                 │    └─ 跳过 requires_mcp 未满足的 skill
-                 ├─ build_context()
-                 │    └─ 注入记忆、近期上下文、skill 列表、recent_runs[message_result]
-                 └─ tool_loop(max_steps)
-                      ├─ read_file / write_file / edit_file
-                      ├─ recall_memory / web_fetch / web_search
-                      ├─ fetch_messages / search_messages / shell
-                      ├─ message_push     # 最多一次
-                      ├─ finish_drift     # 必须声明 message_result
-                      └─ mount_server     # 可挂载 MCP server
-```
-
-Drift 的核心约束：
-
-- 每次进入都重新比较所有 skill，不默认继续上次的
-- `message_push` 成功后只允许 `write_file` / `edit_file` / `finish_drift` 收尾
-- 发出的消息要像自然聊天，不像在汇报内部执行流程
-- 执行结束前必须调用 `finish_drift` 保存状态，并填写 `message_result`
-- `message_result="sent"` 要求本轮已经成功 `message_push`
-- `message_result="silent"` 要求本轮没有成功 `message_push`
-- `drift.json` 的 `recent_runs` 会记录每轮是 `sent` 还是 `silent`
-- 到达 `max_steps` 时不再强制写文件或强制 `finish_drift`；如果模型没有主动收尾，本轮保持未完成
+详见 [drift-guide.md](./_handbook/drift-guide.md)。
 
 ---
 
 ## 其他命令
 
 ```bash
-uv run python main.py           # 启动主进程
-uv run python main.py cli       # 连接运行中的 agent（TUI / 纯文本 CLI）
-uv run python main.py dashboard # 打开 Dashboard
-uv run python main.py setup     # 交互式初始化向导
-uv run python main.py init      # 非交互初始化（CI/自动化）
+uv run python main.py cli       # 连接运行中的 agent（TUI）
+uv run python main.py dashboard # 打开 Dashboard（默认 :2236）
 uv run python main.py --help    # 查看全部子命令
 
-pytest tests/           # 单元测试
-akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/  # 场景测试（真实 LLM）
+pytest tests/                   # 单元测试
+akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/  # 场景测试
 ```
 
-## Roadmap
+---
 
-### Done
-- [x] **Lifecycle Module Chain**: 6 个生命周期 Phase 统一为模块链架构。`Phase(modules, frame_factory=Frame)` 按序执行 `PhaseModule` 列表，模块通过 `slots` 传递数据，声明 `requires`/`produces` 做启动校验。内置模块和插件模块在链上平等。替代旧的 `GatePhase`/`TapPhase` 两段式 `_setup → emit → _finalize` 模式。
-- [x] **Typed EventBus**: 进程内类型化 EventBus，支持 `emit`（顺序拦截） / `fanout`（并发广播） / `enqueue`（后台消费）。TurnCommitted 事件统一提交后处理，替代 `agent/postturn/` 模块。
-- [x] **Event-Driven Streaming**: 流式输出通过 EventBus 发射 `StreamDeltaReady`，频道自订阅消费，不再需要 `set_stream_sink_factory()`。
-- [x] **Turn Lifecycle Observability**: 每条 turn 发射 `BeforeTurn` → `BeforeReasoning` → `ToolCallStarted/Completed`(per step) → `AfterReasoning` → `AfterTurn` 全链路事件。空回复自动 retry。
-- [x] **Managed Subagent (spawn)**: 长时间任务通过 `spawn` 创建受管 subagent，完成/取消后统一回灌为后台任务完成消息，安全合并进当前会话。
-- [x] **Memory**: 支持 recall 时间范围过滤、语义+关键词融合检索。post-response 失效检测标记 supersede 旧记忆。Consolidation 批量阶段抽取新记忆。
-- [x] **Response Parser Pipeline**: 统一文本解析管道，从 LLM 原始输出抽离 `§cited:xxx§` / `<meme:xxx>` 标签，清洗后传入下游。
-- [x] **Lifecycle Plugin System**: 基于插件目录的声明式 API——`@tool` 注册工具、`@on_tool_pre` 拦截工具调用、`@on_*` 钩入生命周期事件、`before_turn_modules_early/late()` 插入管道模块。插件放在 `plugins/` 下自动发现。见 [`_handbook/plugins-tutorial.md`](_handbook/plugins-tutorial.md)。
-- [x] **Memory Pluginification**: 提取 `DefaultMemory` 行为为 SPI 接口，通过 `[memory].engine` 切换记忆引擎实现，默认引擎迁入 `plugins/default_memory/`。
+## 配置图像能力
 
-### Active
-- [ ] **Tool Pluginification**: 重构工具注册为动态 Plugin 系统。
+| 路线 | 配置 | 说明 |
+|------|------|------|
+| A: 主模型多模态 | `multimodal = true`，`vl.model = ""` | 图片直接进主模型 |
+| B: 主模型 + VL 工具 | `multimodal = false`，`vl.model = "qwen-vl-plus"` | 推荐方案（DeepSeek + Qwen VL） |
+| C: 纯文本 | `multimodal = false`，`vl.model = ""` | 图片不可理解 |
+
+---
+
+## 工作区
+
+所有运行时数据在 `~/.akashic/workspace/`。

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 一个**会主动找你**的 AI 伙伴——不只是被动回答问题，还能根据你订阅的信息源主动判断"现在该不该发消息、发什么"，在空闲时自主执行后台任务。
 
-**[Proactive 主动推送](./_handbook/proactive-guide.md)** — **[Drift 空闲任务](./_handbook/drift-guide.md)**
-
 ---
 
 ## Quickstart
@@ -20,29 +18,57 @@ uv venv && uv pip install -r requirements.txt
 
 没有 uv？先 `pip install uv`。
 
-### 1. 初始化
+**1. 初始化**
 
 ```bash
 uv run python main.py setup    # 交互向导（推荐）
-# 或
 uv run python main.py init     # 非交互，CI/自动化用
 ```
 
-### 2. 填写 config.toml 最少配置
+**2. 填写 config.toml**
+
+推荐配置：DeepSeek 主模型 + Qwen 轻量/视觉/向量：
 
 ```toml
+[llm]
+provider = "deepseek"
+
 [llm.main]
-model = "deepseek-v4-flash"
+model = "deepseek-v4-flash"     # 主模型：推理强、速度快、价格低
 api_key = "sk-..."
+base_url = "https://api.deepseek.com/v1"
+enable_thinking = true          # 开启 reasoning
+multimodal = false              # DeepSeek 不支持图片，用 VL 工具补
+
+[llm.fast]
+model = "qwen-flash"            # 轻量模型：memory gate / query rewrite / HyDE
+api_key = "sk-..."
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+[llm.vl]
+model = "qwen-vl-plus"          # 视觉：主模型 multimodal=false 时自动启用
+api_key = "sk-..."
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+[memory]
+enabled = true
+engine = ""                     # 记忆引擎，留空 = default_memory 插件
+
+[memory.embedding]
+model = "text-embedding-v3"     # 向量模型
+api_key = "sk-..."
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 
 [channels.telegram]
 token = "123456:ABC..."
 allow_from = ["your_username"]
 ```
 
-见 `config.example.toml` 完整模板。
+**个人推荐**：
+这个项目和 deepseekv4flash 以及 qwen 相性比较好，其他模型不保证效果。特别是一些连 xml 输出都做不好的国产模型。
+通信渠道推荐 telegram，提供了丰富好看的流式输出。
 
-### 3. 启动
+**3. 启动**
 
 ```bash
 uv run python main.py
@@ -52,40 +78,56 @@ uv run python main.py
 
 ---
 
-## 核心功能
-
-### 被动回复链路
-
-收到消息 → 记忆检索 → 工具调用 → 流式回复。每轮经过 6 个生命周期 Phase（BeforeTurn → BeforeReasoning → Reasoner → AfterReasoning → AfterTurn），插件可在各 Phase 通过 EventBus 或模块插入点介入。
-
-### Proactive 主动推送
-
-agent 定期检查你订阅的信息源，自主决定是否推送。
+## 系统全景
 
 ```
-proactive loop
-  ├── 自适应轮询（你的活跃度决定频率）
-  ├── 三路数据预取（alert / content / context）
-  ├── LLM 逐条评分分类（interesting / not_interesting）
-  └── 推送决策（去重 + 打扰检查 → 发送或跳过）
+你的消息 → [被动回复] ──→ agent loop ──→ 回复
+                │
+                ├── 记忆系统 ─── 每轮注入长期记忆 + 对话后 consolidation
+                │
+                └── 插件系统 ─── 拦截命令、注入协议、阻断工具、挂载新工具...
+
+[主动推送] ──→ 定期轮询 ──→ 三路数据 (alert/content/context) ──→ LLM 决策 ──→ 推送或跳过
+                │
+                └── [Drift] ──→ 没东西推时执行后台任务 (SKILL.md)
 ```
 
-三类数据通道：
-- **alert**：高优先级告警（心率异常、日历提醒），直接透传不评分
-- **content**：内容流（RSS 新闻、社交更新），逐条评分分类
-- **context**：背景上下文（睡眠状态、游戏在线），概率注入
+| 想看什么 | 文档 |
+|---------|------|
+| 怎么让 agent 主动推送消息、怎么配数据源 | [_handbook/proactive-guide.md](./_handbook/proactive-guide.md) |
+| 怎么写后台任务让 agent 空闲时自动干活 | [_handbook/drift-guide.md](./_handbook/drift-guide.md) |
+| MEMORY.md / SELF.md / consolidation / 记忆怎么流转 | [_handbook/memory-markdown.md](./_handbook/memory-markdown.md) |
+| 怎么写插件介入生命周期、注册工具 | [_handbook/plugins-tutorial.md](./_handbook/plugins-tutorial.md) |
 
-详见 [proactive-guide.md](./_handbook/proactive-guide.md)。
+---
 
-### Drift 空闲任务
+## 被动回复
 
-没有可推送内容时，agent 不空转——它会执行你定义的 drift skill：
+收到消息 → 记忆检索 → 工具调用 → 流式回复。每轮经过 6 个 Phase（BeforeTurn → BeforeReasoning → PromptRender → Reasoner → AfterReasoning → AfterTurn）。
 
-- **audit-dirty-memories** — 随机抽检长期记忆，回溯原文验证准确性
-- **explore-curiosity** — 补足用户画像空白，随口一问
-- **review-drift-gaps** — Drift 自我反思，跟踪停滞方向
+插件有 **4 种介入方式**：PhaseModule 链（14 个注入位置）、EventBus 装饰器（9 种事件）、`@on_tool_pre`（工具拦截）、`@tool`（注册工具）。见 [插件系统](./_handbook/plugins-tutorial.md)。
 
-详见 [drift-guide.md](./_handbook/drift-guide.md)。
+## 主动推送（Proactive）
+
+Agent 根据电量模型自适应调整轮询频率——你刚聊完时不烦你（8 分钟一次），半天没动静就加速到 1 分钟一次。每轮拉取三路 MCP 数据：
+
+- **alert** — 高优先级告警，直接透传
+- **content** — 内容流，逐条 LLM 评分分类
+- **context** — 背景上下文，概率注入做 fallback
+
+见 [Proactive 配置指南](./_handbook/proactive-guide.md)。
+
+## 记忆系统
+
+对话通过 **consolidation** 自动提取为结构化事实：HISTORY.md（时间线事件） + PENDING.md（待归档缓冲） + RECENT_CONTEXT.md（近期上下文摘要）。**Optimizer** 定时将 PENDING 归档到 MEMORY.md——中间隔一层是为了保护 prompt cache（MEMORY.md 全文注入 system prompt，高频修改会破坏缓存）。同时 `memory2.db`（向量层）提供语义检索。
+
+见 [记忆系统](./_handbook/memory-markdown.md)。
+
+## Drift 空闲任务
+
+没内容可推时 agent 不空转——执行你写的 `SKILL.md`（分步操作指南），比如审计长期记忆是否准确、补用户画像、自我诊断。
+
+见 [Drift 指南](./_handbook/drift-guide.md)。
 
 ---
 
@@ -96,21 +138,9 @@ uv run python main.py cli       # 连接运行中的 agent（TUI）
 uv run python main.py dashboard # 打开 Dashboard（默认 :2236）
 uv run python main.py --help    # 查看全部子命令
 
-pytest tests/                   # 单元测试
-akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/  # 场景测试
+pytest tests/
+akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/
 ```
-
----
-
-## 配置图像能力
-
-| 路线 | 配置 | 说明 |
-|------|------|------|
-| A: 主模型多模态 | `multimodal = true`，`vl.model = ""` | 图片直接进主模型 |
-| B: 主模型 + VL 工具 | `multimodal = false`，`vl.model = "qwen-vl-plus"` | 推荐方案（DeepSeek + Qwen VL） |
-| C: 纯文本 | `multimodal = false`，`vl.model = ""` | 图片不可理解 |
-
----
 
 ## 工作区
 

--- a/_handbook/drift-guide.md
+++ b/_handbook/drift-guide.md
@@ -1,0 +1,210 @@
+# Drift 系统指南
+
+## 先理解它是什么
+
+Drift 是一个**你写模型可以做什么、模型照着执行**的后台任务系统。
+
+- **什么时候跑**：proactive 拉了一圈啥也没有（无 alert、无 content、无 context fallback）
+- **做什么**：你写在 `drift/skills/<skill-name>/SKILL.md` 里的事
+- **怎么做**：SKILL.md 是一份分步操作指南——先读哪个文件、跑什么脚本、怎么判断、什么时候发消息——模型一步步按着走
+- **跟 proactive 的本质区别**：proactive 的行为是代码里写死的 system prompt，drift 的行为是你写的 SKILL.md
+
+**一个 drift skill 就是一个 agent run**：它拿到一套工具（read_file / write_file / shell / fetch_messages / message_push...），拿着你写的 SKILL.md 当 system prompt，一步一步执行，最后调 `finish_drift` 收尾。
+
+## 什么是 Drift（展开）
+
+当 proactive gateway 拉完数据发现三路都空时，agent 不空转，而是进入 Drift 模式利用空闲时间做后台工作。简单说：**没新闻可推的时候就干点后台活儿**。
+
+```
+tick
+  └── DataGateway.run() → 无 alert / 无 content / 无 context
+       └── DriftRunner.run()
+            ├── scan_skills()      读取 drift/skills/*/SKILL.md
+            ├── filter_skills()   跳过 requires_mcp 未满足的 skill
+            ├── build_context()   注入记忆、近期上下文、skill 列表
+            └── tool_loop(max_steps)
+                 ├── read_file / write_file / edit_file
+                 ├── recall_memory / web_fetch / web_search
+                 ├── fetch_messages / search_messages / shell
+                 ├── message_push      最多一次
+                 ├── mount_server      可挂载 MCP server
+                 └── finish_drift      必须声明 message_result
+```
+
+## Drift 的核心约束
+
+1. **每次重新选择**：不默认继续上次的 skill，每轮重新比较所有 skill
+2. **message_push 限制**：最多推送一次用户消息；推送后只允许 write_file / edit_file / finish_drift 收尾
+3. **必须 finish_drift**：执行结束前必须调用，填写 `message_result`
+4. **message_result 与实际一致**：
+   - `"sent"` — 本轮成功调用了 `message_push`
+   - `"silent"` — 本轮没有推送消息
+5. **到达 max_steps 不强收**：如果模型没主动调 finish_drift，本轮保持未完成
+6. **最小间隔**：`drift.min_interval_hours` 控制连续两次 drift 的最小间隔
+
+---
+
+## Drift Skill 格式
+
+每个 skill 是一个目录，放在 `~/.akashic/workspace/drift/skills/<skill-name>/` 下，核心文件是 `SKILL.md`。
+
+### 哪些文件你写、哪些 agent 写
+
+| 文件 | 维护方式 | 说明 |
+|------|---------|------|
+| `drift/skills/<name>/SKILL.md` | **你写** | drift 任务定义，agent 每轮当 system prompt 读。也可以让主 agent 用内置 skill `create-drift-skill` 帮你生成 |
+| `drift/skills/<name>/state.json` | **agent 写** | skill 执行时自动更新状态，不用管 |
+| `drift/skills/<name>/*.md` | **agent 写** | 工作文件（audited.md、queue.md、backlog.md 等），skill 执行时自动读写 |
+| `drift/skills/<name>/scripts/*.py` | **你写** | 固定脚本，skill 通过 `shell` 工具调用 |
+| `drift/drift.json` | **agent 写** | DriftRunner 自动写运行记录（recent_runs），不用管 |
+| `drift/drift_note.md` | **agent 写** | 跨轮次的自由笔记，agent 可读可写 |
+
+内置了一个 skill 放仓库里（`agent/skills/`），用来创建新的 drift skill。
+
+### SKILL.md 结构
+
+```yaml
+---
+name: <skill-name>
+description: <一句话描述>
+---
+
+## 目标
+
+## 工作文件
+（列出这个 skill 会读写的工作文件路径）
+
+## 工作流程
+1. ...
+2. ...
+
+## 要求
+- 约束和规则
+```
+
+---
+
+## 真实案例
+
+### 案例一：audit-dirty-memories（记忆审计）
+
+**目标**：随机抽检一条带 `source_ref` 的长期记忆，回溯原始消息，判断记忆摘要是否准确。
+
+**工作流程**：
+1. 脚本抽样（`sample_memory_for_audit.py`）→ 随机选一条未审计的记忆
+2. `fetch_messages` 读取原始消息上下文
+3. 对比摘要与原文做"高置信可疑判断"
+4. 干净 → 静默记录（`message_result="silent"`）
+5. 可疑 → 发消息告诉用户哪条记忆为什么可疑（`message_result="sent"`）
+
+**实际运行记录**（`drift.json`）：
+```json
+{
+  "skill": "audit-dirty-memories",
+  "run_at": "2026-05-08T14:10:48Z",
+  "one_line": "审计记忆 7cf7657414cb：摘要声称 Falcons 阵容查询，source_ref 却是测试消息，内容完全不匹配，判定可疑已报告",
+  "message_result": "sent"
+}
+```
+
+**工作文件**：
+- `audited.md`：已审计的 memory_id 列表（防止重复）
+- `state.json`：运行状态
+- `scripts/sample_memory_for_audit.py`：固定抽样脚本
+
+### 案例二：explore-curiosity（好奇心探索）
+
+**目标**：补足用户画像中的生活化信息空白，一次只问一个轻量、自然的问题。
+
+**工作流程**：
+1. 读 `queue.md`，取第一行问题
+2. `message_push` 发送
+3. 删除该行，写回剩余问题
+
+如果 queue 为空，基于长期记忆生成 5 个问题放入 queue。
+
+**实际运行记录**：
+```json
+{
+  "skill": "explore-curiosity",
+  "run_at": "2026-05-08T20:02:54Z",
+  "one_line": "推送睡前小说话题，更新队列",
+  "message_result": "sent"
+}
+```
+
+**queue.md 示例**：
+```
+有没有什么你最近特别想买的东西，或者一直在忍住没买的？
+```
+
+**规则**：
+- 问题必须轻量、自然、像朋友随口一问
+- 优先问：音乐偏好、开源项目、运动习惯、食物口味、日常消遣
+- 禁止问太大、太虚、太像采访的问题
+- 避开长期记忆里已经明确有答案的信息
+
+### 案例三：review-drift-gaps（Drift 自我反思）
+
+**目标**：定期回顾 Drift 全局行动历史，找出一直没推进的方向，维护有界 backlog（最多 10 项）。
+
+**工作流程**：
+1. 读 `drift.json` 获取最近运行历史
+2. 扫描各 skill 的 `state.json` 获取当前状态
+3. 对比上轮快照，判断停滞方向（长期无进展 / 阶段停滞 / 待办未推进）
+4. 更新双计数器（停滞轮数 / 恢复轮数）
+5. 按优先级排序后写回 `backlog.md`
+
+**核心逻辑**：
+- 显式跳过自身（review-drift-gaps）
+- 停滞轮数越多的方向排越前
+- 连续恢复 3 轮的方向自动从 backlog 移除
+- 不调用 message_push，纯后台记录
+
+---
+
+## 写自己的 Drift Skill
+
+### 最小示例
+
+```markdown
+---
+name: my-skill
+description: 每天备份一次 conversation 精华到 notion
+---
+
+## 目标
+定期把用户最近对话中的值得回顾的内容同步到 notion 数据库。
+
+## 工作流程
+1. `fetch_messages` 获取最近 24 小时的对话
+2. 提取值得回顾的内容（用户明确提到的计划、决策、偏好变化）
+3. 如果有可同步的内容 → write_file 写入 notion API 格式 → shell 调用 notion API
+4. 没有新内容 → 静默结束
+
+## 工作文件
+- `skills/my-skill/last_sync.md`：上次同步时间
+
+## 要求
+- 不调用 message_push（此 skill 纯后台）
+- finish_drift(message_result="silent")
+```
+
+### 关键工具
+
+| 工具 | 用途 |
+|------|------|
+| `read_file` / `write_file` / `edit_file` | 读写 drift 工作文件 |
+| `recall_memory` | 检索长期记忆 |
+| `fetch_messages` | 读取被动对话历史 |
+| `web_fetch` / `web_search` | 获取外部信息 |
+| `shell` | 运行脚本 |
+| `message_push` | 推一条消息给用户（最多一次） |
+| `finish_drift` | 保存状态并结束本轮 |
+
+### 注意事项
+- `finish_drift` 的 `message_result` 必须和本轮实际动作一致
+- `finish_drift.next` 写这个 skill 下次该做什么，不写全局调度愿景
+- 把状态写在 `state.json` 里，把数据写在专门的工作文件里
+- 只读工具（read_file / fetch_messages 等）放在前面，写操作放在后面
+- 如果 skill 需要 MCP server，可以用 `mount_server` 挂载

--- a/_handbook/memory-markdown.md
+++ b/_handbook/memory-markdown.md
@@ -1,0 +1,268 @@
+# 记忆系统——Markdown 文件层
+
+akashic 的记忆分为两层：**Markdown 文件层**（人类可读，LLM 直接写入）和**向量数据库层**（`memory2.db`，语义检索）。本文档只讲 Markdown 层——哪几个文件、各自干什么、consolidation 怎么把对话变成记忆。
+
+---
+
+## 五个 Markdown 文件
+
+都在 `~/.akashic/workspace/memory/` 下：
+
+| 文件 | 写者 | 读方 | 用途 |
+|------|------|------|------|
+| **MEMORY.md** | Optimizer（主 agent 自动维护） | 被动/主动 agent 的 system prompt | 长期记忆——用户的稳定事实、偏好、身份 |
+| **SELF.md** | Optimizer（主 agent 自动维护） | 被动/主动 agent 的 system prompt | Akashic 的自我认知——形象、对用户的理解、关系定义 |
+| **HISTORY.md** | Consolidation worker 自动追加 | 被动 agent（检索时 grep）、consolidation 自身（取最近 3 条做上下文） | 按时间线的事件日志，只追加不修改 |
+| **RECENT_CONTEXT.md** | Consolidation worker 自动维护 | 被动/主动 agent 的 system prompt | 近期上下文摘要——最近在聊什么、关注什么 |
+| **PENDING.md** | Consolidation worker 追加 → Optimizer 消费后清空 | Optimizer | 缓冲队列——从对话中提取的待归档事实 |
+
+还有一个 `NOW.md` 在工作区根目录下（不是 `memory/` 里），是纯用户维护的备忘录，agent 不自动读写。
+
+---
+
+## Consolidation：对话怎么变成记忆
+
+每次 agent 回复完后会触发一次 consolidation 检查。不是每条消息都触发——有一个最小新消息数的门槛。
+
+### 什么时候触发
+
+```
+TurnCommitted 事件
+  → MarkdownMemoryMaintenance._should_consolidate_session()
+    → 检查：(新消息数 - 保留数 - 上次 consolidate 的位置) >= min
+       min = max(5, keep_count // 2)
+  → 够了就调 consolidation，不够就只刷新 RECENT_CONTEXT.md 的 Recent Turns 块
+```
+
+### Consolidation 干了什么
+
+一次 consolidation 会调用 LLM 做两件事，然后写三个文件：
+
+```
+最近 N 条对话消息（文本格式）
+    ↓
+  LLM 提取（一段 prompt，一次调用）
+    ↓
+  产出两样东西：
+    1. history_entries[]  — 时间线事件，每条 {summary: "1-2句摘要", emotional_weight: 0-10}
+    2. pending_items[]    — 可归档的长期事实，每条 {tag: "identity|preference|...", content: "..."}
+    ↓
+  写入三个 markdown 文件：
+    • HISTORY.md    — 追加 history_entries（幂等，按 source_ref 去重）
+    • PENDING.md    — 追加 pending_items（幂等，按 source_ref 去重）
+    • RECENT_CONTEXT.md — 用第二次 LLM 调用生成 Compression 摘要
+    • journal/YYYY-MM-DD.md — 同 history_entries，按天分文件
+```
+
+**HISTORY.md 格式**：每条一行，前面有不可见的 consolidation 标记（`<!-- consolidation:["msg_id1","msg_id2"]:history_entry -->`），正常渲染看不到。
+
+```
+[2026-05-09 14:30] 用户开始学习 Rust 语言，购买了《Rust程序设计》第二版。
+[2026-05-09 15:00] 用户表示不喜欢悬疑压抑风格的游戏。
+```
+
+**PENDING.md 格式**：每条 `- [tag] 内容`，支持 6 种 tag：
+
+| Tag | 含义 | 例子 |
+|-----|------|------|
+| `identity` | 稳定身份事实 | `- [identity] 用户是互联网公司产品经理` |
+| `preference` | 稳定偏好/禁忌 | `- [preference] 用户不喜欢悬疑压抑风格的游戏` |
+| `key_info` | 密钥/账号/ID | `- [key_info] 用户的 GitHub 用户名是 example` |
+| `health_long_term` | 长期健康事实 | `- [health_long_term] 用户有慢性偏头痛` |
+| `requested_memory` | 用户明确要求记住 | `- [requested_memory] 项目 deadline 是 6 月 15 日` |
+| `correction` | 更正已有记忆 | `- [correction] 更正：用户不是学生，已毕业` |
+
+**RECENT_CONTEXT.md 格式**：
+
+```markdown
+# Recent Context
+
+## Compression
+until: 2026-05-09T15:00:00
+- 最近持续关注：用户最近在讨论记忆检索架构重构
+- 最近明确偏好：偏好低压力、能长期坚持的创作方式
+- 最近待延续话题：上次未完成的代码讨论
+- 最近避免事项：不要在不适当的时机讨论技术架构
+
+## Ongoing Threads
+- 用户最近持续受睡眠问题影响，情绪低落
+
+## Recent Turns
+[user] 我头有点疼，可能昨晚没睡好
+[a-preview] 先休息一下，不要勉强
+```
+
+Compression 部分由第二次 LLM 调用生成，有严格规则：**只从 USER 消息里提取，不把 assistant 的建议当事实**。Recent Turns 部分是轻量的——每次 turn 后单独刷新，不触发完整 LLM 调用。
+
+### 幂等性保证
+
+`consolidation_writes.db`（SQLite）用 `source_ref`（一条 JSON 数组，比如 `["msg_001","msg_002"]`）做主键，同一批消息不会写两次。HISTORY.md 和 PENDING.md 内部的隐藏标记也做第二层保护。
+
+PENDING.md 还有两阶段提交：`snapshot_pending()` → Optimizer 处理 → `commit_pending_snapshot()` 或 `rollback_pending_snapshot()`。启动时如果发现残留 snapshot 会自动回滚合并，防止崩溃丢数据。
+
+---
+
+## PENDING → MEMORY：Optimizer 怎么归档
+
+PENDING.md 只是缓冲——consolidation 把新事实写进 PENDING，但 PENDING 不注入 system prompt。真正的长期记忆 MEMORY.md 交给一个定时任务（Optimizer）来更新。
+
+**为什么要隔一层？为了缓存。**
+
+MEMORY.md 是全文注入 system prompt 的。如果每次 consolidation 都直接改 MEMORY.md，那每轮对话的 system prompt 都不一样 → DeepSeek 的 prompt cache 永远命中不了 → 每轮都多花几秒和一份 cache_write token。Optimizer 把 MEMORY.md 的更新频率降到 3 小时一次，中间攒在 PENDING.md 里不动它，让 prompt cache 能稳定命中几十上百轮。
+
+```
+consolidation (每 N 条消息触发一次)
+    ↓
+  写入 PENDING.md（高频追加，不改 MEMORY.md）
+    ↓
+  MEMORY.md 保持不变 → prompt cache 持续命中
+    ↓
+Optimizer (定时触发)
+    ↓
+  读 MEMORY.md + PENDING.md → LLM 归档 → 一次性地更新 MEMORY.md → 清空 PENDING.md
+    ↓
+  MEMORY.md 变化一次 → prompt cache miss 一次 → 下一轮重新建立缓存
+```
+
+### Optimizer 怎么工作的
+
+```
+PENDING.md（增量事实缓冲区）
+    ↓
+  Optimizer 定时触发（默认 memory_optimizer_interval_seconds = 10800）
+    ↓
+  读 MEMORY.md + PENDING.md → LLM 做归档决策：
+    • 新事实 → 写入 MEMORY.md 对应分类
+    • 与已有条目冲突 → 更新或替换
+    • 重复 → 忽略
+    • 更正 → 用 correction tag 的内容覆盖旧条目
+    ↓
+  写入新的 MEMORY.md
+  clear_pending() → 清空 PENDING.md
+```
+
+Optimizer 在主 agent 启动时注册为后台任务（`memory_optimizer_enabled = true`）。
+
+---
+
+## 这些文件怎么进入 System Prompt
+
+每次回复前构建 system prompt 时，按 priority 顺序依次渲染：
+
+| Priority | 块名 | 来源文件 | 注入形式 |
+|----------|------|---------|---------|
+| 30 | SelfModel | `SELF.md` | `## Akashic 自我认知\n\n{全文}` |
+| 35 | LongTermMemory | `MEMORY.md` | `## Long-term Memory\n\n{全文}` |
+| 45 | RecentContext | `RECENT_CONTEXT.md` | Compression + Ongoing Threads（不含 Recent Turns，那个有独立的滑动窗口） |
+| 55 | MemoryBlock | 向量检索结果 | `recall_memory` 的语义召回块（带 [id] 前缀和时间戳） |
+
+**注意**：MEMORY.md 和 SELF.md 是**全文注入**的，不做截断或检索——这也是为什么 Optimizer 需要保持它们紧凑。HISTORY.md 不直接注入 prompt，只用于 grep 检索和 consolidation 自身的上下文。
+
+---
+
+## 文件流转总览
+
+```
+用户发消息
+    ↓
+system prompt 注入：SELF.md + MEMORY.md + RECENT_CONTEXT.md + 向量检索块
+    ↓
+LLM 回复（记忆在上下文里）
+    ↓
+TurnCommitted
+    ↓
+┌─ 新消息不够 → 只刷新 RECENT_CONTEXT.md 的 Recent Turns 块
+└─ 新消息够了 →
+    ├─ LLM 提取 history_entries + pending_items
+    ├─ 写入 HISTORY.md（追加，幂等）
+    ├─ 写入 PENDING.md（追加，幂等）
+    ├─ 写入 RECENT_CONTEXT.md（LLM 生成 Compression + 刷新 Recent Turns）
+    └─ 写入 journal/YYYY-MM-DD.md（追加）
+    ↓
+Optimizer 定时任务
+    ├─ 读 PENDING.md + MEMORY.md → LLM 归档 → 更新 MEMORY.md
+    └─ clear_pending()
+```
+
+两层记忆的分工：**Markdown 层**管"人类能看懂的全景"——你是谁、你喜欢什么、最近发生了什么。**向量层**管"机器能搜到的细节"——语义检索、时间过滤、去重计数。两个层各自独立更新，通过 `ConsolidationCommitted` 事件桥接——markdown 层写完 HISTORY 后发事件，向量层收到后把同批数据 embed 写入 `memory2.db`。
+
+---
+
+## 向量记忆 API——谁在调它
+
+`core/memory/engine.py` 定义了一套抽象协议（`MemoryEngine`），由四个子协议组成。引擎本身是一个 **plugin**——`[memory].engine` 配置项指定用哪个实现，留空 = `default_memory` 插件。协议与实现解耦。
+
+### API 协议一览
+
+**MemoryIngestApi** — 程序化内容摄入
+
+| 方法 | 用途 |
+|------|------|
+| `ingest(request)` | 摄入一条内容（目前无生产级调用方，仅 default_memory 内部使用） |
+
+**MemoryRetrievalApi** — 语义检索
+
+| 方法 | 调用方 |
+|------|--------|
+| `retrieve(request)` | 被动回复每轮自动检索（注入 system prompt） |
+| `retrieve_explicit(request)` | `recall_memory` 工具（LLM 主动调用） |
+| `retrieve_interest_block(request)` | proactive tick 中评估内容候选时 |
+
+**MemoryWriteApi** — 写入/删除
+
+| 方法 | 调用方 |
+|------|--------|
+| `remember(request)` | `memorize` 工具（用户要求"记住..."） |
+| `forget(request)` | `forget_memory` 工具（用户纠正错误记忆） |
+| `reinforce_items_batch(ids)` | 仅 default_memory 内部调用，无外部调用点 |
+
+**MemoryAdminApi** — 管理面板
+
+| 方法 | 调用方 |
+|------|--------|
+| `list_items_for_dashboard(...)` | Dashboard `GET /api/dashboard/memories` |
+| `get_item_for_dashboard(id)` | Dashboard `GET /api/dashboard/memories/{id}` |
+| `update_item_for_dashboard(id, ...)` | Dashboard `PATCH /api/dashboard/memories/{id}` |
+| `delete_item(id)` | Dashboard `DELETE /api/dashboard/memories/{id}` |
+| `delete_items_batch(ids)` | Dashboard `POST /api/dashboard/memories/batch-delete` |
+| `find_similar_items_for_dashboard(id)` | Dashboard `GET /api/dashboard/memories/{id}/similar` |
+| `describe()` | 引擎描述（仅 default_memory 内部） |
+| `keyword_match_procedures(tokens)` | 关键词匹配过程（仅 default_memory 内部） |
+| `list_events_by_time_range(start, end)` | 时间范围事件列表（仅 default_memory 内部） |
+
+### 调用点汇总
+
+所有不在 `plugins/default_memory/` 下的真实调用点：
+
+| 位置 | 行 | 方法 | 说明 |
+|------|-----|------|------|
+| `agent/retrieval/default_pipeline.py` | 31 | `retrieve()` | 被动 turn 每轮的语义检索入口。`DefaultContextStore.prepare()` → `retrieval_pipeline.retrieve()` → `engine.retrieve(MemoryEngineRetrieveRequest)` |
+| `agent/tools/recall_memory.py` | 138 | `retrieve_explicit()` | `recall_memory` 工具。LLM 传入 query/memory_type/time_filter/limit，工具调 `facade.retrieve_explicit(ExplicitRetrievalRequest)` |
+| `proactive_v2/tools.py` | 220 | `retrieve_interest_block()` | proactive tick 中评估内容候选时调用，查询用户对某条内容是否可能感兴趣 |
+| `agent/tools/memorize.py` | 71 | `remember()` | `memorize` 工具。用户要求"记住..."时调 `engine.remember(RememberRequest)` |
+| `agent/tools/forget_memory.py` | 55 | `forget()` | `forget_memory` 工具。用户纠正错误记忆时调 `memory.forget(ForgetRequest)` |
+| `bootstrap/dashboard_api.py` | 1032 | `list_items_for_dashboard()` | Dashboard 记忆列表页 |
+| `bootstrap/dashboard_api.py` | 1063 | `find_similar_items_for_dashboard()` | Dashboard 相似记忆查询 |
+| `bootstrap/dashboard_api.py` | 1085 | `get_item_for_dashboard()` | Dashboard 单条记忆详情 |
+| `bootstrap/dashboard_api.py` | 1099 | `update_item_for_dashboard()` | Dashboard 编辑记忆 |
+| `bootstrap/dashboard_api.py` | 1115 | `delete_item()` | Dashboard 删除单条 |
+| `bootstrap/dashboard_api.py` | 1122 | `delete_items_batch()` | Dashboard 批量删除 |
+| `core/memory/runtime.py` | 51/57/63 | `retrieve()` / `retrieve_explicit()` / `retrieve_interest_block()` | `MemoryRuntime` 薄封装层，统一入口 |
+| `core/memory/plugin.py` | 80-126 | 全部方法 | `DisabledMemoryEngine` — 记忆关闭时的空实现，所有方法都返回空/报错 |
+
+### 引擎如何注入
+
+```
+bootstrap/memory.py:116 → engine = plugin_runtime.engine
+    ↓
+  bootstrap/tools.py:231 → memory_engine 注入 ToolsetDeps
+    ↓
+    ├── 被动 reply: DefaultMemoryRetrievalPipeline(memory=...) → engine.retrieve()
+    ├── 工具注册: memorize/forget/recall_memory 拿到 engine 引用
+    └── PluginManager(memory_engine=...) → 所有插件都能通过 self.context.memory_engine 访问
+    ↓
+  bootstrap/app.py:145 → memory_admin=engine → Dashboard API
+  proactive_v2/tools.py:38 → ToolDeps.memory → engine.retrieve_interest_block()
+```
+
+调用方拿到的都是协议类型（`MemoryRetrievalApi` / `MemoryWriteApi` / `MemoryAdminApi`），不是 `DefaultMemoryEngine`。换引擎实现只需要改 `config.toml` 的 `[memory].engine`。

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -1,1018 +1,392 @@
-# 插件开发教程
+# 插件系统
 
-## 目录
+agent 每次收到一条用户消息，经过 6 个生命周期阶段产出一条回复。插件可以在这些阶段的任意位置插入自己的逻辑。
 
-1. [概述](#概述)
-2. [插件目录结构](#插件目录结构)
-3. [第一个插件](#第一个插件)
-4. [注册工具 (`@tool`)](#注册工具-tool)
-5. [拦截工具调用 (`@on_tool_pre`)](#拦截工具调用-on_tool_pre)
-6. [生命周期事件钩子 (`@on_*`)](#生命周期事件钩子-on_)
-7. [生命周期管道模块 (`PhaseModule`)](#生命周期管道模块-phasemodule)
-8. [Slot Export 机制](#slot-export-机制)
-9. [插件配置 (`_conf_schema.json`)](#插件配置-_conf_schemajson)
-10. [持久化存储 (`PluginKVStore`)](#持久化存储-pluginkvstore)
-11. [元数据 (`manifest.yaml`)](#元数据-manifestyaml)
-12. [初始化与清理](#初始化与清理)
-13. [多插件协作](#多插件协作)
-14. [完整示例：留言板插件](#完整示例留言板插件)
-15. [参考](#参考)
+## 先理解它怎么运转的
+
+插件放到 `plugins/` 目录下，启动时自动发现、加载、注册。过程：
+
+```
+PluginManager.discover()
+  → 扫描 plugins/ 下每个有 plugin.py 的子目录
+  → 按目录名排序（01_citation 在 02_meme 之前）
+  → 动态 import plugin.py，Plugin.__init_subclass__() 自动注册
+  → 调用 initialize()，失败则回滚该插件的所有注册
+```
+
+插件有 **4 种方式** 介入 agent 的行为。不是四种独立的系统，是同一份代码可以同时使用全部四种。
+
+| 机制 | 适合做什么 | 在哪用 |
+|------|-----------|--------|
+| **PhaseModule** | 在某个 Phase 的精确位置注入逻辑 | 写一个方法返回模块列表，模块链会自动编排 |
+| **EventBus 装饰器** | 在生命周期关键节点做观察或改写 | `@on_before_turn` 等 9 种 |
+| **@on_tool_pre** | 工具执行前拦截、改参数、拒绝 | LLM 调用工具时 |
+| **@tool** | 给 LLM 注册新工具 | 任何时候 LLM 决定调工具 |
 
 ---
 
-## 概述
+## PhaseModule：插件系统最核心的机制
 
-插件系统允许以独立目录形式扩展 agent 的行为，无需修改核心代码。
-
-每个插件是一个包含 `plugin.py` 的目录，**放在 `plugins/` 下自动发现**。插件可以：
-
-| 能力 | 使用方式 | 运行时机 |
-|---|---|---|
-| 注册新工具 | `@tool(name="...")` | LLM 调用工具时 |
-| 拦截工具调用 | `@on_tool_pre(tool_name="...")` | 工具执行前 |
-| 钩入生命周期事件 | `@on_before_turn` 等 | 对应生命周期阶段 |
-| 插入生命周期管道模块 | `before/reasoning/step/after_*_modules_*()` 共 12 个注入点 | 对应阶段 |
-| 通过 slot 导出数据 | `frame.slots["<phase>:<category>:<key>"] = value` | PhaseModule 内 |
-| 读取配置 | `self.context.config` | 任意时机 |
-| 持久化键值存储 | `self.context.kv_store` | 任意时机 |
-| 初始化 / 清理 | `initialize()` / `terminate()` | 加载 / 停机 |
-
----
-
-## 插件目录结构
+每个生命周期 Phase 是一条模块链。比如 BeforeTurn 是 8 个模块排好队依次执行，数据通过一个叫 **slots** 的字典在模块间传递。
 
 ```
-plugins/
-└── my_plugin/                  # 插件目录名 = 插件名
-    ├── plugin.py               # 必需：入口文件，定义 Plugin 子类
-    ├── manifest.yaml           # 可选：覆盖元数据
-    ├── _conf_schema.json       # 可选：声明默认配置项
-    └── plugin_config.json      # 可选：用户级配置覆盖
+BeforeTurn 管道:
+  _AcquireSession → ★early → _PrepareContext → _BuildCtx → _Emit → ★late → _CollectSlot → _Return
 ```
 
-`plugin.py` 是最小要求。管理器扫描 `plugins/` 下所有子目录，发现 `plugin.py` 即视为插件。
+标 `★` 的位置就是插件注入点。插件写的 PhaseModule 和内置模块在链上是平等的——都实现同一个接口，都通过 `frame.slots` 收发数据。
 
----
-
-## 第一个插件
-
-```python
-# plugins/hello/plugin.py
-from agent.plugins import Plugin
-
-class Hello(Plugin):
-    name = "hello"
-    desc = "一个示例插件"
-
-    async def initialize(self) -> None:
-        print(f"[hello] 插件已加载，plugin_id={self.context.plugin_id}")
-
-    async def terminate(self) -> None:
-        print("[hello] 插件已卸载")
-```
-
-继承 `Plugin`，设置 `name`、`desc` 即可。`initialize()` 在所有注册完成后被调用，`terminate()` 在停机时调用。
-
-`self.context` 在实例化后由管理器注入，类型为 `PluginContext`：
-
-```python
-@dataclass
-class PluginContext:
-    event_bus: Any              # EventBus 实例
-    tool_registry: Any          # ToolRegistry 实例
-    plugin_id: str              # 插件名
-    plugin_dir: Path            # 插件目录
-    kv_store: PluginKVStore     # 基于文件的键值存储
-    config: PluginConfig | None # 解析后的配置
-    workspace: Path | None      # 工作区路径
-```
-
----
-
-## 注册工具 (`@tool`)
-
-使用 `@tool` 装饰器声明工具。管理器自动创建 `Tool` 实例并注册到 `ToolRegistry`。
-
-```python
-# plugins/weather/plugin.py
-from agent.plugins import Plugin, tool
-
-class Weather(Plugin):
-    name = "weather"
-
-    @tool(
-        name="get_weather",
-        risk="read-only",
-        search_hint="查询天气",
-    )
-    async def get_weather(
-        self,
-        event,                              # 第二个参数固定为 event（插件工具无实际值，传 None）
-        city: str,                          # 参数类型决定 JSON Schema
-        date: str = "today",
-    ) -> str:
-        """查询指定城市的天气信息。
-
-        Args:
-            city: 城市名称，如 "北京"
-            date: 日期，默认 "today"
-        """
-        return f"{city} 在 {date} 的天气：晴，23°C"
-```
-
-### 装饰器参数
-
-| 参数 | 类型 | 说明 |
-|---|---|---|
-| `name` | `str` | 必需。工具名，LLM 看到的就是这个名字 |
-| `risk` | `str` | 默认 `"read-write"`。标记风险等级 |
-| `always_on` | `bool` | 默认 `False`。是否始终在 tools 列表中 |
-| `search_hint` | `str` | 搜索提示，`/help` 等场景使用 |
-
-### 参数 Schema 自动生成
-
-`_derive_params_schema()` 通过函数签名 + docstring（Google/NumPy 风格）自动构建 JSON Schema：
-
-- 前两个参数 `self` 和 `event` 被跳过
-- Python 类型映射：`str → string`、`int → number`、`float → number`、`bool → boolean`、`dict → object`、`list → array`
-- 无默认值的参数进入 `required` 列表
-- docstring 中的 `Args:` 段被解析为参数描述
-
-### 函数签名约束
-
-**前两个参数必须是 `self` 和 `event`**，否则装饰器抛 `TypeError`。这是为了对齐事件处理规范 — 第二个参数 `event` 在插件工具中传 `None`。
-
----
-
-## 拦截工具调用 (`@on_tool_pre`)
-
-在工具真正执行前修改参数或拒绝调用。
-
-```python
-# plugins/shell_restore/plugin.py
-from agent.plugins import Plugin, on_tool_pre
-from agent.lifecycle.types import PreToolCtx
-
-class ShellRestore(Plugin):
-    name = "shell_restore"
-
-    @on_tool_pre(tool_name="shell")
-    async def rewrite_rm_to_mv(self, event: PreToolCtx) -> dict | None:
-        """拦截 shell 工具的 rm 命令，改写为 mv（防止误删）。"""
-        command = str(event.arguments.get("command", "")).strip()
-
-        # 解析 rm 命令，提取目标文件
-        if " rm " not in f" {command} ":
-            return None  # 不是 rm 命令，不做处理
-
-        targets = self._extract_targets(command)
-        if not targets:
-            return None
-
-        # 改写为 mv
-        mv_cmd = f"mv -- {' '.join(targets)} /home/user/restore/"
-        return dict(event.arguments, command=mv_cmd)
-```
-
-### `PreToolCtx` 结构
-
-```python
-@dataclass
-class PreToolCtx:
-    session_key: str         # 会话标识
-    channel: str             # 通道名（telegram / cli）
-    chat_id: str             # 聊天 ID
-    tool_name: str           # 被调用的工具名
-    arguments: dict          # 原始参数字典
-```
-
-### 返回值
-
-| 返回值 | 效果 |
-|---|---|
-| `None` | 不做修改，原参数继续执行 |
-| `dict` | 用返回的字典**替换** arguments |
-
-### 装饰器参数
-
-| 参数 | 说明 |
-|---|---|
-| `tool_name` | 限定目标工具名。`None`（默认）匹配所有工具 |
-
----
-
-## 生命周期事件钩子 (`@on_*`)
-
-在 agent turn 生命周期的关键阶段插入 handler。handler 通过 EventBus 以 **顺序链** 方式运行。
-
-### 可用事件
-
-| 装饰器 | 事件阶段 | 模式 |
-|---|---|---|
-| `@on_before_turn` | Turn 开始 | GATE |
-| `@on_before_reasoning` | 推理前 | GATE |
-| `@on_before_step` | 每步推理前 | GATE |
-| `@on_after_step` | 每步推理后 | TAP |
-| `@on_after_reasoning` | 推理完成后 | GATE |
-| `@on_after_turn` | Turn 结束后 | TAP |
-| `@on_tool_call` | 工具调用前 | TAP |
-| `@on_tool_result` | 工具返回后 | TAP |
-
-### GATE vs TAP
-
-- **GATE**：可以修改或**阻断**事件。返回修改后的事件（或 `None` 跳过）。运行于 `EventBus.emit()` 顺序链中。
-- **TAP**：只能做观察/记录，不可修改事件。运行于 `EventBus.observe()` 或 `enqueue()` 中，失败不打断主流程。
-
-### 上下文类型
-
-每个事件对应一个上下文类型：
-
-| 事件 | 上下文类型 | 关键字段 |
-|---|---|---|---|
-| `before_turn` | `BeforeTurnCtx` | `content`, `skill_names`, `retrieved_memory_block`, `history_messages`, `extra_hints`, `extra_metadata`, `abort`, `abort_reply` |
-| `before_reasoning` | `BeforeReasoningCtx` | `content`, `skill_names`, `retrieved_memory_block`, `extra_hints`, `abort`, `abort_reply` |
-| `before_step` | `BeforeStepCtx` | `iteration`, `input_tokens_estimate`, `visible_tool_names`, `extra_hints`, `early_stop`, `early_stop_reply` |
-| `after_step` | `AfterStepCtx` | `iteration`, `tools_called`, `partial_reply`, `extra_metadata` |
-| `after_reasoning` | `AfterReasoningCtx` | `reply`, `thinking`, `tools_used`, `tool_chain`, `media`, `meme_tag`, `outbound_metadata` |
-| `after_turn` | `AfterTurnCtx` | `reply`, `tools_used`, `thinking`, `will_dispatch`, `extra_metadata` |
-| `before_tool_call` | `BeforeToolCallCtx` | `tool_name`, `arguments` |
-| `after_tool_result` | `AfterToolResultCtx` | `tool_name`, `arguments`, `result`, `status` |
-
-完整定义见 `agent/lifecycle/types.py`。
-
-### 示例
-
-```python
-# plugins/audit/plugin.py
-from agent.plugins import Plugin, on_before_turn, on_after_turn
-from agent.lifecycle.types import BeforeTurnCtx, AfterTurnCtx
-
-class Audit(Plugin):
-    name = "audit"
-
-    @on_before_turn()
-    async def log_start(self, event: BeforeTurnCtx) -> BeforeTurnCtx:
-        """每轮 turn 开始前记录。"""
-        print(f"[audit] turn 开始: session={event.session_key}, content={event.content[:50]}")
-        return event    # GATE handler 必须返回事件
-
-    @on_after_turn()
-    async def log_finish(self, event: AfterTurnCtx) -> None:
-        """每轮 turn 结束后记录。"""
-        print(f"[audit] turn 结束: reply={event.reply[:50]}")
-
-    @on_before_turn(priority=100)   # 高优先级先执行
-    async def content_filter(self, event: BeforeTurnCtx) -> BeforeTurnCtx | None:
-        """屏蔽特定关键词。"""
-        if "禁止词" in (event.content or ""):
-            event.abort = True
-            event.abort_reply = "此消息已被过滤器拦截。"
-        return event
-```
-
-### GATE 阻断机制
-
-GATE 阶段支持两种阻断方式：
-
-**方式 1：直接修改 ctx（适用 before_emit 插件）**
-
-```python
-@on_before_turn()
-async def gate(self, event: BeforeTurnCtx) -> BeforeTurnCtx:
-    if self._should_block(event.content):
-        event.abort = True
-        event.abort_reply = "您的请求已被拦截。"
-    return event
-```
-
-**方式 2：Slot export（适用 after_emit 插件）**
-
-在 after_emit 位置不能直接改 ctx（GATE emit 已经发生），应通过 slot 触发 abort：
-
-```python
-class MyAfterEmitModule:
-    async def run(self, frame):
-        frame.slots["session:abort_reply"] = "由插件阻断"
-        return frame
-```
-
-各阶段的 abort slot：`session:abort_reply`、`reasoning:abort_reply`、`step:abort_reply`。
-
-`BeforeTurnCtx.abort` / `BeforeReasoningCtx.abort` 被设置后，`PassiveTurnPipeline.run()` 会直接返回 `abort_reply`，跳过推理和执行。`step:abort_reply` 映射为 `BeforeStepCtx.early_stop_reply`，只终止当前 tool loop。
-
-### priority 参数
-
-所有 `@on_*` 装饰器接受 `priority: int` 参数（默认 0）。值越大越先执行：
-
-```python
-@on_before_turn(priority=100)  # 第一个执行
-async def first(self, event): ...
-
-@on_before_turn(priority=-10)  # 最后执行
-async def last(self, event): ...
-```
-
----
-
-## 生命周期管道模块 (`PhaseModule`)
-
-每个生命周期阶段都是一条 `PhaseModule` 链，按顺序执行。插件通过定义特定方法返回模块列表来注入到各阶段的特定位置。
-
-### 全阶段注入点一览
-
-| 阶段 | 注入方法 | 插入位置 | 典型用途 |
-|---|---|---|---|
-| `before_turn` | `before_turn_modules_early()` | 记忆检索 + EventBus 之前 | 命令拦截、早期 abort |
-| `before_turn` | `before_turn_modules_late()` | EventBus 之后、返回之前 | 补充 hints / metadata |
-| `before_reasoning` | `before_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx 字段（GATE 链） |
-| `before_reasoning` | `before_reasoning_modules_after_emit()` | EventBus emit 之后、prompt warmup 之前 | 设置 slot export（hints、abort） |
-| `prompt_render` | `prompt_render_modules_top()` | system sections top 拼装前 | 插入 system prompt 顶部 section |
-| `prompt_render` | `prompt_render_modules_bottom()` | system sections bottom 拼装后 | 插入 system prompt 底部 section 或 extra_hints |
-| `before_step` | `before_step_modules_before_emit()` | EventBus emit 之前 | 修改 BeforeStepCtx（GATE 链） |
-| `before_step` | `before_step_modules_after_emit()` | EventBus emit 之后 | 设置 slot export（hints、early_stop） |
-| `after_step` | `after_step_modules_before_fanout()` | fanout 之前 | 设置 telemetry slot（进入 fanout handler） |
-| `after_step` | `after_step_modules_after_fanout()` | fanout 之后 | 补充 telemetry（不覆盖 fanout handler 已看到的） |
-| `after_reasoning` | `after_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx 字段（reply、media、outbound_metadata） |
-| `after_reasoning` | `after_reasoning_modules_before_persist()` | persist 之前、emit 之后 | 设置 persist / outbound slot export |
-| `after_turn` | `after_turn_modules_before_commit()` | TurnCommitted 构建之前 | 设置 `turn:extra:*` slot |
-| `after_turn` | `after_turn_modules_before_fanout()` | AfterTurnCtx fanout 之前 | 设置 `turn:telemetry:*` slot |
-
-### 阶段详解
-
-#### before_turn 管道
-
-```
-1. _AcquireSessionModule              ← 加载 session
-2. ★ plugin_modules_early             ← 适合做命令拦截（abort 跳过后续）
-3. _PrepareContextModule              ← 记忆检索
-4. _BuildBeforeTurnCtxModule          ← 构建 BeforeTurnCtx
-5. _EmitBeforeTurnCtxModule           ← EventBus GATE 链（@on_before_turn）
-6. ★ plugin_modules_late              ← 在 GATE 之后补充处理
-7. _CollectBeforeTurnExportSlotsModule ← 收集 session:extra_hint:* / session:abort_reply
-8. _ReturnBeforeTurnCtxModule         ← 产出最终 output
-```
-
-#### before_reasoning 管道
-
-```
-1. _SyncToolContextModule             ← 设置 tool context
-2. _BuildBeforeReasoningCtxModule     ← 构建 ctx（继承 before_turn 字段）
-3. ★ plugin_modules_before_emit        ← GATE 链：直接修改 ctx
-4. _EmitBeforeReasoningCtxModule      ← EventBus GATE 链（@on_before_reasoning）
-5. ★ plugin_modules_after_emit         ← 设置 reasoning:extra_hint:* / reasoning:abort_reply
-6. _CollectBeforeReasoningExportSlotsModule ← 收集 slot 到 ctx
-7. _PromptWarmupModule                ← 预热 prompt（ctx.abort 时跳过）
-8. _ReturnBeforeReasoningCtxModule    ← 产出 ctx
-```
-
-#### prompt_render 管道
-
-```
-1. _BuildPromptRenderCtxModule        ← 构建 ctx
-2. _EmitPromptRenderCtxModule         ← EventBus emit
-3. ★ plugin_modules_top               ← 通过 system_sections_top / prompt:section_top:* 插入
-4. ★ plugin_modules_bottom            ← 通过 system_sections_bottom / prompt:section_bottom:* 或 extra_hints
-5. _CollectPromptExportSlotsModule    ← 收集 prompt:section_*:*/ prompt:extra_hint:*
-6. _RenderPromptModule                ← ContextBuilder.render()
-7. _ReturnPromptRenderResultModule    ← 产出 PromptRenderResult
-```
-
-#### before_step 管道（每轮 tool loop iteration）
-
-```
-1. _BuildBeforeStepCtxModule          ← 构建 ctx
-2. ★ plugin_modules_before_emit        ← GATE 链：直接修改 ctx
-3. _EmitBeforeStepCtxModule           ← EventBus GATE 链（@on_before_step）
-4. ★ plugin_modules_after_emit         ← 设置 step:extra_hint:* / step:abort_reply
-5. _CollectBeforeStepExportSlotsModule ← 收集 slot 到 ctx（early_stop、extra_hints）
-6. _InjectHintsModule                 ← 将 extra_hints 注入 messages
-7. _ReturnBeforeStepCtxModule         ← 产出 ctx
-```
-
-#### after_step 管道（每轮 tool loop iteration 后）
-
-```
-1. _CopyInputToCtxModule              ← 输入快照复制为 ctx
-2. ★ plugin_modules_before_fanout      ← 设置 step:telemetry:*
-3. _CollectAfterStepExportSlotsModule  ← 第 1 次收集：记入 extra_metadata + tracked keys
-4. _FanoutAfterStepCtxModule          ← TAP fanout（handler 看到 collected telemetry）
-5. ★ plugin_modules_after_fanout       ← 补充新的 telemetry key
-6. _CollectAfterStepExportSlotsModule  ← 第 2 次收集：只补充未被 collected 的 key
-7. _ReturnAfterStepCtxModule          ← 产出 ctx
-```
-
-> **注意**：after_step 的 telemetry 收集分两次。fanout 前的 telemetry 会被 handler 看到并锁定；fanout 后的补充只能新增 key，不能覆盖已看过的同名 key。
-
-#### after_reasoning 管道
-
-```
-1. _BuildAfterReasoningCtxModule      ← 构建 ctx（含 outbound_metadata 初始值）
-2. ★ plugin_modules_before_emit        ← GATE 链：修改 ctx 字段
-3. _EmitAfterReasoningCtxModule       ← EventBus GATE 链（@on_after_reasoning）
-4. ★ plugin_modules_before_persist     ← 设置 persist:user:*/ persist:assistant:*/ outbound:metadata:*/ outbound:media:*
-5. _PersistUserMessageModule          ← 持久化 user 消息（读取 persist:user:*）
-6. _PersistAssistantMessageModule     ← 持久化 assistant 消息（读取 persist:assistant:*）
-7. _UpdateSessionMetadataModule       ← 更新 session 运行时 metadata
-8. _AppendMessagesModule              ← 追加到 session 存储
-9. _BuildOutboundMessageModule        ← 构建出站消息（读取 outbound:metadata:* / outbound:media:*）
-10. _ReturnAfterReasoningResultModule ← 产出 AfterReasoningResult
-```
-
-#### after_turn 管道
-
-```
-1. _BuildTurnWorkModule               ← 构建 budget、react_stats、extra 等
-2. ★ plugin_modules_before_commit      ← 设置 turn:extra:*
-3. _CollectAfterTurnExtraSlotsModule   ← 收集 turn:extra:* → extra dict
-4. _BuildTurnCommittedModule           ← 构建 TurnCommitted 事件（依赖 extra_collected）
-5. _FanoutTurnCommittedModule          ← fanout TurnCommitted
-6. _LogBudgetModule                    ← 日志记录 budget
-7. _BuildAfterTurnCtxModule            ← 构建 AfterTurnCtx
-8. ★ plugin_modules_before_fanout      ← 设置 turn:telemetry:*
-9. _CollectAfterTurnTelemetrySlotsModule ← 收集 turn:telemetry:* → extra_metadata
-10. _FanoutAfterTurnCtxModule          ← TAP fanout（@on_after_turn）
-11. _DispatchOutboundModule            ← 派发出站消息
-12. _ReturnOutboundMessageModule       ← 返回 OutboundMessage
-```
-
-> **注意**：after_turn 的 `_BuildTurnCommittedModule` 依赖 `_EXTRA_COLLECTED_SLOT`，保证 `_CollectAfterTurnExtraSlotsModule` 一定先于它执行。这通过模块的 `requires` / `produces` 契约实现。
-
-### 编写 PhaseModule
-
-`PhaseModule` 协议：
-
-```python
-class MyModule:
-    requires = ("phase:slot_name",)   # 可选：依赖哪些 slot（用于顺序校验）
-    produces = ("phase:slot_name",)   # 可选：产出哪些 slot
-
-    async def run(self, frame: PhaseFrame) -> PhaseFrame:
-        # 通过 frame.slots 读写中间状态
-        # 通过 frame.input / frame.output 读写输入输出
-        return frame
-```
-
-完整的 GATE 链 ctx 修改示例（before_reasoning）：
-
-```python
-class MyBeforeReasoningModule:
-    requires = ("reasoning:ctx",)
-    produces = ("reasoning:ctx",)
-
-    async def run(self, frame):
-        from typing import cast
-        from agent.lifecycle.types import BeforeReasoningCtx
-        ctx = cast(BeforeReasoningCtx, frame.slots["reasoning:ctx"])
-        # 直接修改 ctx 字段（GATE 链允许）
-        ctx.extra_hints.append("hint from my plugin")
-        ctx.abort = True
-        ctx.abort_reply = "由我的插件阻断"
-        frame.slots["reasoning:ctx"] = ctx
-        return frame
-```
-
-### 关键 Slot 名速查
-
-| 阶段 | Slot | 内容 |
-|---|---|---|
-| before_turn | `session:session` | `Session` 对象 |
-| before_turn | `session:context_bundle` | `ContextBundle` |
-| before_turn | `session:ctx` | `BeforeTurnCtx` |
-| before_reasoning | `reasoning:ctx` | `BeforeReasoningCtx` |
-| prompt_render | `prompt:ctx` | `PromptRenderCtx` |
-| prompt_render | `prompt:result` | `PromptRenderResult` |
-| before_step | `step:ctx` | `BeforeStepCtx` |
-| after_step | `step:ctx` | `AfterStepCtx` |
-| after_step | `step:telemetry_collected` | `set[str]` — 已收集过的 telemetry key |
-| after_reasoning | `reasoning:ctx` | `AfterReasoningCtx` |
-| after_reasoning | `reasoning:outbound` | `OutboundMessage` |
-| after_turn | `turn:budget` | `dict` — post-reply context budget |
-| after_turn | `turn:extra` | `dict` — TurnCommitted extra |
-| after_turn | `turn:extra_collected` | `True` — 标记 extra 已收集 |
-| after_turn | `turn:committed` | `TurnCommitted` 事件 |
-| after_turn | `turn:ctx` | `AfterTurnCtx` |
-
-### 从插件暴露 PhaseModule
-
-在 Plugin 子类上定义对应的方法，返回模块列表。全部可用方法：
-
-```python
-class MyPlugin(Plugin):
-    name = "my_plugin"
-
-    def before_turn_modules_early(self) -> list[object]:
-        return [MyCommandModule()]
-
-    def before_turn_modules_late(self) -> list[object]:
-        return [MyHintModule()]
-
-    def before_reasoning_modules_before_emit(self) -> list[object]:
-        return [MyReasoningGateModule()]
-
-    def before_reasoning_modules_after_emit(self) -> list[object]:
-        return [MyReasoningSlotModule()]
-
-    def prompt_render_modules_top(self) -> list[object]:
-        return [MyTopSectionModule()]
-
-    def prompt_render_modules_bottom(self) -> list[object]:
-        return [MyBottomSectionModule()]
-
-    def before_step_modules_before_emit(self) -> list[object]:
-        return [MyStepGateModule()]
-
-    def before_step_modules_after_emit(self) -> list[object]:
-        return [MyStepSlotModule()]
-
-    def after_step_modules_before_fanout(self) -> list[object]:
-        return [MyStepTelemetryModule()]
-
-    def after_step_modules_after_fanout(self) -> list[object]:
-        return [MyStepLateTelemetryModule()]
-
-    def after_reasoning_modules_before_emit(self) -> list[object]:
-        return [MyAfterReasoningGateModule()]
-
-    def after_reasoning_modules_before_persist(self) -> list[object]:
-        return [MyPersistModule()]
-
-    def after_turn_modules_before_commit(self) -> list[object]:
-        return [MyTurnExtraModule()]
-
-    def after_turn_modules_before_fanout(self) -> list[object]:
-        return [MyTurnTelemetryModule()]
-```
-
-仅定义你需要的方法即可，管理器只收集已定义的方法返回的模块。
-
----
-
----
-
-## Slot Export 机制
-
-Slot export 是 PhaseModule 间传递数据的标准方式。插件通过向 `frame.slots` 写入带前缀的 key，由 collection 模块自动合并到下游 ctx 或持久化数据中。
-
-### 核心 Helper
-
-```python
-from agent.lifecycle.phase import collect_prefixed_slots, append_string_exports
-```
-
-- `collect_prefixed_slots(slots, prefix, *, reserved=())` — 收集所有以 `prefix` 开头的 slot，返回 `dict[str, object]`。`reserved` 集合中的 key 会被排除（用于保护内置字段不被覆盖）。
-- `append_string_exports(target, exports)` — 将 exports 中的字符串（或字符串列表）追加到 `target` 列表中。
-
-### 可用 Slot 前缀
-
-| 前缀 | 阶段 | 语义 | 目标 |
-|---|---|---|---|
-| `session:extra_hint:*` | before_turn (late) | 注入额外提示 | `BeforeTurnCtx.extra_hints` → reasoning |
-| `session:abort_reply` | before_turn (late) | 阻断 turn 并返回此文本 | `BeforeTurnCtx.abort_reply` |
-| `reasoning:extra_hint:*` | before_reasoning | 注入额外提示 | `BeforeReasoningCtx.extra_hints` → prompt |
-| `reasoning:abort_reply` | before_reasoning | 阻断 reasoning 并返回此文本 | `BeforeReasoningCtx.abort_reply` |
-| `prompt:section_top:*` | prompt_render | 插入 system prompt 顶部 | `system_sections_top` → rendered |
-| `prompt:section_bottom:*` | prompt_render | 插入 system prompt 底部 | `system_sections_bottom` → rendered |
-| `prompt:extra_hint:*` | prompt_render | 注入 context hint | `PromptRenderCtx.extra_hints` |
-| `step:extra_hint:*` | before_step | 注入额外提示到 messages | `BeforeStepCtx.extra_hints` → `_InjectHintsModule` |
-| `step:abort_reply` | before_step | 提前终止当前 tool loop | `BeforeStepCtx.early_stop_reply` |
-| `step:telemetry:*` | after_step | 注入 telemetry 到 extra_metadata | `AfterStepCtx.extra_metadata` |
-| `persist:user:*` | after_reasoning | 持久化到 user 消息的额外字段 | user message kwargs |
-| `persist:assistant:*` | after_reasoning | 持久化到 assistant 消息的额外字段 | assistant message kwargs |
-| `outbound:metadata:*` | after_reasoning | 注入出站消息 metadata | `OutboundMessage.metadata` |
-| `outbound:media:*` | after_reasoning | 追加出站媒体 URL | `OutboundMessage.media` |
-| `turn:extra:*` | after_turn | 注入 TurnCommitted extra 字段 | `TurnCommitted.extra` |
-| `turn:telemetry:*` | after_turn | 注入 AfterTurnCtx telemetry | `AfterTurnCtx.extra_metadata` |
-
-### 示例：在 before_reasoning 中注入 extra_hints
-
-```python
-from agent.lifecycle.phase import collect_prefixed_slots, append_string_exports
-from agent.lifecycle.types import BeforeReasoningCtx
-
-class MyHintModule:
-    requires = ("reasoning:ctx",)
-    produces = ("reasoning:ctx",)
-
-    async def run(self, frame):
-        # 方式 1：直接写入 slot，collection 模块会自动处理
-        frame.slots["reasoning:extra_hint:weather"] = "今天北京有暴雨，建议提醒用户带伞"
-        return frame
-```
-
-### 示例：在 prompt_render 中插入 system section
+### 写一个 PhaseModule
 
 ```python
 from agent.prompting import PromptSectionRender
 
-class MySectionModule:
+class MyPromptModule:
+    requires = ("prompt:ctx",)          # 告诉框架：我需要 prompt:ctx 这个 slot
+    produces = ("prompt:ctx",)          # 告诉框架：我可能改写它
+
     async def run(self, frame):
-        # 可以用字符串
-        frame.slots["prompt:section_bottom:custom"] = "## 自定义规则\n请用中文回答。"
-        # 也可以用 PromptSectionRender（控制 is_static 等属性）
-        frame.slots["prompt:section_bottom:rules"] = PromptSectionRender(
-            name="rules",
-            content="你是一个严肃、准确的助手，不可编造事实。",
-            is_static=False,
+        ctx = frame.slots["prompt:ctx"]   # PromptRenderCtx 实例
+        ctx.system_sections_bottom.append(
+            PromptSectionRender(
+                name="my_rules",
+                content="## 自定义规则\n请用中文回答。",
+                is_static=True,
+            )
         )
         return frame
 ```
 
-### 示例：在 after_reasoning 中注入 persist / outbound
-
-```python
-class MyPersistModule:
-    async def run(self, frame):
-        # 给 user 消息添加自定义字段
-        frame.slots["persist:user:plugin_tag"] = "my_plugin_v1"
-        # 给 assistant 消息添加自定义字段
-        frame.slots["persist:assistant:confidence"] = 0.95
-        # 给出站消息添加 metadata
-        frame.slots["outbound:metadata:source_plugin"] = "my_plugin"
-        # 给出站消息追加媒体文件
-        frame.slots["outbound:media:chart"] = "/tmp/output.png"
-        return frame
-```
-
-### Slot Export 的执行顺序
-
-每个阶段的 collection 模块在 pipeline 中的位置是固定的（见上一节各阶段管道图）。一般模式：
-
-- **after_emit 插件** 写入 slot → **collection 模块** 读取并合并
-- **after_step** 特殊：分两次 collect（fanout 前锁定 + fanout 后补充）
-- **after_turn** 特殊：`turn:extra:*` 在 `_CollectAfterTurnExtraSlotsModule` 收集，`turn:telemetry:*` 在 `_CollectAfterTurnTelemetrySlotsModule` 收集
-
-### Slot vs 直接修改 ctx
-
-| 方式 | 适用场景 | 示例 |
-|---|---|---|
-| 直接修改 ctx（GATE 链） | before_emit 位置，需要 EventBus handler 也能看到变化 | `ctx.reply = "new reply"` |
-| Slot export | after_emit / before_fanout / before_persist 位置，多个插件各自产出独立数据 | `frame.slots["persist:user:tag"] = "v1"` |
-
-选择原则：如果需要 EventBus handler（`@on_*`）能看到变化 → 直接改 ctx。如果只是向下游模块传递数据 → slot export。
-
----
-
-## 插件配置 (`_conf_schema.json`)
-
-在插件目录放置 `_conf_schema.json` 声明可配置项默认值：
-
-```json
-{
-    "max_results": {
-        "default": 5,
-        "description": "最大返回结果数"
-    },
-    "api_endpoint": {
-        "default": "https://api.example.com",
-        "description": "API 端点地址"
-    }
-}
-```
-
-用户可以用 `plugin_config.json` 覆盖：
-
-```json
-{
-    "max_results": 10
-}
-```
-
-在代码中读取：
-
-```python
-max_results = self.context.config.get("max_results")  # 10
-endpoint = self.context.config.api_endpoint            # "https://api.example.com"
-```
-
-`PluginConfig` 同时支持 `get(key)` 和 `config.key` 两种访问方式。
-
----
-
-## 持久化存储 (`PluginKVStore`)
-
-`self.context.kv_store` 是一个基于 JSON 文件的键值存储，文件位于 `{plugin_dir}/.kv.json`。
-
-```python
-# 读写
-self.context.kv_store.set("last_run", str(datetime.now()))
-last = self.context.kv_store.get("last_run", default="从未运行")
-
-# 原子递增
-count = self.context.kv_store.increment("request_count")  # +1 并返回新值
-count = self.context.kv_store.increment("request_count", 10)  # +10
-```
-
-每次 `set()` / `increment()` 都会写回文件。适合存储少量元数据（计数器、状态标记等），不适合高频写入或大量数据。
-
----
-
-## 元数据 (`manifest.yaml`)
-
-`manifest.yaml` 覆盖 Plugin 基类的元数据字段：
-
-```yaml
-name: my_plugin
-version: "1.0.0"
-desc: 我的插件描述
-author: your-name
-```
-
-这些字段也可以在类上直接设置：
+然后在 Plugin 子类上暴露它：
 
 ```python
 class MyPlugin(Plugin):
     name = "my_plugin"
-    version = "1.0.0"
-    desc = "我的插件描述"
-    author = "your-name"
+
+    def prompt_render_modules_bottom(self):
+        return [MyPromptModule()]
 ```
 
-`manifest.yaml` 的优先级更高（会覆盖类属性）。管理器加载时调用 `_apply_manifest()` 读取并设置。
+`requires` / `produces` 在**启动时**就会被校验——如果链上某个模块要求 `reasoning:ctx` 但前面没有人产出它，启动就会报错。这是编译期安全。
+
+### 14 个注入点
+
+一个 turn 经过 6 个 Phase，每个 Phase 有 2~3 个插件注入位置：
+
+| Phase | 方法 | 在管道中的位置 | 适合 |
+|-------|------|--------------|------|
+| BeforeTurn | `before_turn_modules_early()` | session 加载后、记忆检索前 | 命令拦截、直接 abort |
+| BeforeTurn | `before_turn_modules_late()` | EventBus emit 之后 | 补充 extra_hints |
+| BeforeReasoning | `before_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx（改完 EventBus handler 能看见） |
+| BeforeReasoning | `before_reasoning_modules_after_emit()` | EventBus emit 之后 | 通过 slot 传数据给下游 |
+| PromptRender | `prompt_render_modules_top()` | system prompt 顶部拼装前 | 插入顶部 section |
+| PromptRender | `prompt_render_modules_bottom()` | system prompt 底部拼装后 | 插入底部 section（最常见） |
+| BeforeStep | `before_step_modules_before_emit()` | EventBus emit 之前 | 修改每步的 ctx |
+| BeforeStep | `before_step_modules_after_emit()` | EventBus emit 之后 | slot export |
+| AfterStep | `after_step_modules_before_fanout()` | fanout 之前 | 写入 telemetry（fanout 的 handler 可读） |
+| AfterStep | `after_step_modules_after_fanout()` | fanout 之后 | 补充 telemetry（不覆盖已广播的） |
+| AfterReasoning | `after_reasoning_modules_before_emit()` | EventBus emit 之前 | 修改 ctx.reply/media |
+| AfterReasoning | `after_reasoning_modules_before_persist()` | 持久化之前 | 写 persist/outbound slot |
+| AfterTurn | `after_turn_modules_before_commit()` | TurnCommitted 构建前 | 写 turn:extra:* |
+| AfterTurn | `after_turn_modules_before_fanout()` | AfterTurnCtx fanout 前 | 写 turn:telemetry:* |
 
 ---
 
-## 初始化与清理
+## Slot：模块间的类型化数据总线
+
+这是插件系统最巧妙的设计。每个 Phase 内部，模块不直接调下一个模块——它们只读写 `frame.slots`，管道的 collection 模块负责把 slots 翻译成下游能用的东西。
+
+### Slot 的工作原理
+
+```
+Module A: frame.slots["persist:assistant:cited_memory_ids"] = ["m1", "m2"]
+         ↓
+Module B: （不需要关心 A 做了什么）
+         ↓
+_Collect 模块在管道末尾扫描所有 slots，按前缀规则合并到输出
+         ↓
+_PersistAssistantMessage 模块从合并好的数据里拿到了 cited_memory_ids
+```
+
+你不需要知道下游模块的签名，不需要 import 任何东西——**写对 slot key 就行**。
+
+### 完整的 Slot 前缀表
+
+| 前缀 | 阶段 | 最终去向 |
+|------|------|---------|
+| `session:extra_hint:*` | BeforeTurn late | 合并进 `BeforeTurnCtx.extra_hints`，最终注入 system prompt |
+| `session:abort_reply` | BeforeTurn late | 设置 abort → 整个 turn 跳过推理，直接返回这段文本 |
+| `reasoning:extra_hint:*` | BeforeReasoning | 合并进 `BeforeReasoningCtx.extra_hints` → prompt |
+| `reasoning:abort_reply` | BeforeReasoning | 跳过 LLM 推理 |
+| `prompt:section_top:*` | PromptRender | 插入 system prompt 顶部 |
+| `prompt:section_bottom:*` | PromptRender | 插入 system prompt 底部 |
+| `prompt:extra_hint:*` | PromptRender | context frame 额外提示 |
+| `step:extra_hint:*` | BeforeStep | 注入到本轮 messages 中 |
+| `step:early_stop_reason` | BeforeStep | 停止 tool loop |
+| `step:telemetry:*` | AfterStep | 合并进 `AfterStepCtx.extra_metadata`（TAP handler 可见） |
+| `persist:user:*` | AfterReasoning | 持久化到 user 消息的额外字段 |
+| `persist:assistant:*` | AfterReasoning | 持久化到 assistant 消息的额外字段 |
+| `persist:assistant:cited_memory_ids` | AfterReasoning | citation 插件专用：被引用的记忆 ID 列表 |
+| `outbound:metadata:*` | AfterReasoning | 出站消息的 metadata 字典 |
+| `outbound:media:*` | AfterReasoning | 追加出站媒体 URL |
+| `turn:extra:*` | AfterTurn | TurnCommitted 事件的 extra 字段 |
+| `turn:telemetry:*` | AfterTurn | 合并进 `AfterTurnCtx.extra_metadata` |
+
+### 实际例子
+
+**例 1：注入一个提示到 system prompt（最简单）**
 
 ```python
+class HintModule:
+    async def run(self, frame):
+        frame.slots["prompt:section_bottom:weather"] = "# 天气规则\n今天北京暴雨，建议提醒用户带伞"
+        return frame
+```
+
+`prompt:section_bottom:*` 前缀 + 自定义 key `weather`。管道的 `_CollectPromptExportSlotsModule` 会自动扫描所有以 `prompt:section_bottom:` 开头的 slot，合并进 system prompt。
+
+**例 2：在 after_step 写入 telemetry 让 TAP handler 能看到**
+
+```python
+class PressureModule:
+    async def run(self, frame):
+        ctx = frame.slots["step:ctx"]
+        if ctx.context_tokens_estimate > 800_000:
+            frame.slots["step:early_stop_reason"] = "context_pressure"
+            frame.slots["step:telemetry:pressure_tokens"] = ctx.context_tokens_estimate
+        return frame
+```
+
+`after_step_before_fanout` 位置写入的 `step:telemetry:*` 会在 fanout 之前被收集进 `extra_metadata`，所有 `@on_after_step` TAP handler 都能读到（但 `after_step_after_fanout` 写入的 telemetry 只有第二轮收集才能拿到，fanout 的 handler 已经看不到了）。
+
+**例 3：在 after_reasoning 中给 assistant 消息加自定义字段**
+
+```python
+class CitationModule:
+    async def run(self, frame):
+        # 正则扫 reply 里有没有 §cited:[id1,id2]§
+        reply = frame.slots["reasoning:ctx"].reply
+        cleaned, ids = extract_cited_ids(reply)
+        if ids:
+            # 写 slot → 持久化模块自动拿这个 key 写数据库
+            frame.slots["persist:assistant:cited_memory_ids"] = ids
+        # 把标签从 reply 文本里剥掉
+        frame.slots["reasoning:ctx"].reply = cleaned
+        return frame
+```
+
+这就是 citation 插件的实际写法。`persist:assistant:cited_memory_ids` 是一个约定好的 slot key——`_PersistAssistantMessageModule` 在持久化时专门会读这个 key，把它存到消息记录的 `extra` 字段里。**你只需要知道这个 key 名，不需要知道是谁读的、怎么存的。**
+
+---
+
+## EventBus 装饰器
+
+PhaseModule 适合"在某一个精确位置做一件事"。但如果你的逻辑很简单——比如"每轮结束后记录一下回复长度"——直接挂一个装饰器就够。
+
+```python
+from agent.plugins import Plugin, on_after_turn
+from agent.lifecycle.types import AfterTurnCtx
+
 class MyPlugin(Plugin):
-    async def initialize(self) -> None:
-        """所有 handler、tool、hook 注册完成后调用。"""
-        # 启动后台任务
-        # 连接外部服务
-        # 初始化状态
-
-    async def terminate(self) -> None:
-        """停机时调用。在 CoreRuntime.stop() 中触发。"""
-        # 断开连接
-        # 清理资源
-        # 保存状态
-```
-
-### 重要：initialize 失败会回滚
-
-如果 `initialize()` 抛出异常，管理器会**回滚**该插件的所有注册：
-
-- 从 `PluginRegistry` 移除（handler、class、instance）
-- 从 `ToolRegistry` **注销**已注册的工具
-- 移除已添加的 tool hooks
-- 移除已添加的 before-turn 模块
-
-所以 `initialize()` 是验证外部依赖的好位置 — 如果所需服务不可用，抛异常即可安全回滚。
-
----
-
-## 完整示例：留言板插件
-
-一个带完整功能的示例插件：注册留言工具 + 拦截 shell 危险命令 + after-turn 日志。
-
-```
-plugins/message_board/
-├── plugin.py
-├── _conf_schema.json
-└── manifest.yaml
-```
-
-### `_conf_schema.json`
-
-```json
-{
-    "max_messages": {
-        "default": 50,
-        "description": "最多保留留言条数"
-    }
-}
-```
-
-### `manifest.yaml`
-
-```yaml
-name: message_board
-version: "1.0.0"
-desc: 留言板插件，支持发布留言和查看历史
-author: plugin-author
-```
-
-### `plugin.py`
-
-```python
-"""plugin.py — 留言板插件"""
-from datetime import datetime
-from pathlib import Path
-
-from agent.lifecycle.types import (
-    AfterTurnCtx,
-    PreToolCtx,
-)
-from agent.plugins import Plugin, tool, on_tool_pre, on_after_turn
-
-
-class MessageBoard(Plugin):
-    name = "message_board"
-    desc = "留言板插件"
-
-    # ── 配置 ─────────────────────────────────────────
-
-    @property
-    def _max_messages(self) -> int:
-        return self.context.config.get("max_messages", 50)
-
-    # ── 生命周期 ─────────────────────────────────────
-
-    async def initialize(self) -> None:
-        # 确保存储文件存在
-        _ = self.context.kv_store.get("messages", default=[])
-
-    # ── 工具注册 ─────────────────────────────────────
-
-    @tool(
-        name="leave_message",
-        risk="read-write",
-        search_hint="发布留言",
-    )
-    async def leave_message(
-        self,
-        event,
-        content: str,
-        author: str = "anonymous",
-    ) -> str:
-        """在留言板上发布一条留言。
-
-        Args:
-            content: 留言内容
-            author: 留言者，默认 anonymous
-        """
-        messages = self.context.kv_store.get("messages", [])
-        messages.append({
-            "author": author,
-            "content": content,
-            "time": datetime.now().isoformat(),
-        })
-        # 裁剪到最大条数
-        messages = messages[-self._max_messages:]
-        self.context.kv_store.set("messages", messages)
-        return f"留言已发布。当前共 {len(messages)} 条。"
-
-    @tool(
-        name="read_messages",
-        risk="read-only",
-        search_hint="查看留言板",
-    )
-    async def read_messages(
-        self,
-        event,
-        limit: int = 10,
-    ) -> str:
-        """读取最近的留言。
-
-        Args:
-            limit: 返回条数，默认 10
-        """
-        messages = self.context.kv_store.get("messages", [])
-        recent = messages[-min(limit, len(messages)):]
-        if not recent:
-            return "留言板暂无内容。"
-        lines = []
-        for m in recent:
-            lines.append(f"[{m['time'][:19]}] {m['author']}: {m['content']}")
-        return "\n".join(lines)
-
-    # ── 工具拦截 ─────────────────────────────────────
-
-    @on_tool_pre(tool_name="shell")
-    async def block_dangerous_commands(
-        self,
-        event: PreToolCtx,
-    ) -> dict | None:
-        """拦截 shell 中的危险命令。"""
-        command = str(event.arguments.get("command", ""))
-        dangerous = ["rm -rf /", "mkfs.", "dd if=", ":(){ :|:& };:"]
-        for pattern in dangerous:
-            if pattern in command:
-                # 返回新命令：替换为无害的 echo
-                return dict(
-                    event.arguments,
-                    command=f"echo '[message_board] 危险命令已拦截: {pattern}'",
-                )
-        return None
-
-    # ── 生命周期钩子 ─────────────────────────────────
+    name = "my_plugin"
 
     @on_after_turn()
-    async def log_outbound(self, event: AfterTurnCtx) -> None:
-        """记录每次发送的内容长度。"""
-        content_len = len(event.reply or "")
-        self.context.kv_store.set("last_content_length", content_len)
-        self.context.kv_store.increment("total_turns")
+    async def log_reply(self, ctx: AfterTurnCtx) -> None:
+        print(f"回复长度: {len(ctx.reply)}")
 ```
+
+### GATE（可修改事件）
+
+这 5 个装饰器的 handler 可以修改 ctx，甚至可以用 `ctx.abort = True` 阻断整个 turn：
+
+| 装饰器 | ctx 类型 | 关键可写字段 |
+|--------|---------|-------------|
+| `@on_before_turn()` | `BeforeTurnCtx` | `abort`, `abort_reply`, `extra_hints` |
+| `@on_before_reasoning()` | `BeforeReasoningCtx` | `abort`, `abort_reply`, `extra_hints` |
+| `@on_prompt_render()` | `PromptRenderCtx` | `system_sections_bottom`, `extra_hints` |
+| `@on_before_step()` | `BeforeStepCtx` | `extra_hints`, `early_stop`, `early_stop_reply` |
+| `@on_after_reasoning()` | `AfterReasoningCtx` | `reply`, `media`, `meme_tag`, `outbound_metadata` |
+
+```python
+@on_before_turn()
+async def block_spam(self, ctx: BeforeTurnCtx) -> BeforeTurnCtx:
+    if "禁止词" in ctx.content:
+        ctx.abort = True
+        ctx.abort_reply = "此消息已被拦截"
+    return ctx  # GATE 必须返回 ctx
+```
+
+`priority` 参数控制执行顺序（越大越先执行，默认 0）：
+
+```python
+@on_before_turn(priority=100)
+async def first(self, ctx): ...
+```
+
+### TAP（只观察）
+
+这 4 个装饰器的 handler 不能修改事件，只能观察/记录：
+
+| 装饰器 | ctx 类型 |
+|--------|---------|
+| `@on_after_step()` | `AfterStepCtx` |
+| `@on_after_turn()` | `AfterTurnCtx` |
+| `@on_tool_call()` | `BeforeToolCallCtx` |
+| `@on_tool_result()` | `AfterToolResultCtx` |
 
 ---
 
-## 多插件协作
+## @on_tool_pre — LLM 调工具前拦截
 
-当多个插件同时加载时，执行顺序由以下机制控制：
-
-### EventBus 装饰器：优先级控制
-
-`@on_before_turn`、`@on_before_reasoning` 等所有 `@on_*` 装饰器接受 `priority` 参数（默认 0）。值越大执行越早：
+PhaseModule 和 EventBus 管的是生命周期，`@on_tool_pre` 管的是**工具调用**。
 
 ```python
-class PluginA(Plugin):
-    @on_before_reasoning(priority=100)
-    async def a_early(self, event: BeforeReasoningCtx) -> BeforeReasoningCtx:
-        """先执行：高优先级追加 extra_hints"""
-        event.extra_hints.append("\n附加规则 A")
-        return event
+from agent.plugins import Plugin, on_tool_pre
+from agent.lifecycle.types import PreToolCtx
+from agent.tool_hooks import HookOutcome
 
-class PluginB(Plugin):
-    @on_before_reasoning(priority=-10)
-    async def b_late(self, event: BeforeReasoningCtx) -> BeforeReasoningCtx:
-        """后执行：看到的是 A 追加过的 hints"""
-        print(f"当前 hints: {event.extra_hints}")
-        return event
+class ShellSafety(Plugin):
+    name = "shell_safety"
+
+    @on_tool_pre(tool_name="shell")
+    async def block_interactive(self, ctx: PreToolCtx) -> HookOutcome | dict | None:
+        cmd = str(ctx.arguments.get("command", ""))
+        if "vi " in cmd or "vim " in cmd:
+            return HookOutcome(decision="deny", reason="禁止交互式命令")
+        return None
 ```
 
-同优先级时按插件加载顺序执行。`PluginHandlerRegistry.append()` 内部按 `-priority` 排序。
+`PreToolCtx` 关键字段：`tool_name`, `arguments`（dict）, `session_key`, `call_id`, `source`, `tool_batch`（批量调用时的完整列表）, `tool_batch_index`（自己在批量中的位置）。
 
-### PhaseModule：加载顺序即执行顺序
+返回值三种：
+- `None` — 不管，继续执行
+- `dict` — 替换 arguments
+- `HookOutcome(decision="deny")` — 拒绝调用
 
-`before_turn_modules_early()` 和 `late()` 返回的模块按插件发现顺序合并到统一列表中。`discover()` 按目录名排序：
-
-```
-plugins/
-├── 01_auth/        # 先被发现 → 模块先执行
-├── 02_filter/      # 中间
-└── 03_business/    # 最后
-```
-
-PhaseModule 本身没有 priority 机制。如果需要控制跨插件的 PhaseModule 顺序，在插件目录名上编码是最直接的做法。
-
-### ToolHook 拦截链
-
-`@on_tool_pre` 钩子按加载顺序逐个执行。每个钩子看到的是前一个钩子修改过的参数：
-
-```python
-# PluginA 先加载
-@on_tool_pre(tool_name="shell")
-async def hook_a(self, event) -> dict | None:
-    args = dict(event.arguments)
-    args["command"] = f"echo prefix; {args['command']}"
-    return args
-
-# PluginB 后加载：看到的是加了 prefix 的命令
-@on_tool_pre(tool_name="shell")
-async def hook_b(self, event) -> dict | None:
-    print(f"即将执行: {event.arguments['command']}")
-    return None  # 不改参，只观察
-```
-
-如果某个钩子返回 `decision="deny"`，后续钩子不再执行，调用被阻断。
-
-### 工具注册：同名后覆盖前
-
-多个插件可以注册同名工具，但后加载的会覆盖先加载的：
-
-```python
-# ToolRegistry.register() 做 self._tools[tool.name] = tool
-# 后加载的插件同名工具会覆盖先加载的
-```
-
-如果插件之间需要共享或扩展工具，建议在 `@tool` 上使用**不同的工具名**，需要时在 `@on_tool_pre` 中编排调用链。
-
-### 使用建议
-
-| 场景 | 推荐做法 |
-|---|---|
-| 跨插件 EventBus handler 排序 | 显式设 `priority` |
-| 跨插件 PhaseModule 排序 | 目录名前缀编码 |
-| 工具互斥（同名冲突） | 避免同名，或用不同 namespace 前缀 |
-| 工具编排（A 需要先处理再交给 B） | B 的 `@on_tool_pre` 在 A 之后加载即可 |
+**不填 `tool_name` 匹配所有工具**（tool_loop_guard 就这么做）。
 
 ---
 
-## 参考
+## @tool — 注册 LLM 可调用的工具
 
-### 核心类型
+```python
+from agent.plugins import Plugin, tool
 
-| 类型 | 位置 |
-|---|---|
-| `Plugin` | `agent/plugins/base.py` |
-| `PluginContext` | `agent/plugins/context.py` |
-| `PluginConfig` | `agent/plugins/config.py` |
-| `PluginKVStore` | `agent/plugins/context.py` |
-| `PreToolCtx` | `agent/lifecycle/types.py` |
-| `BeforeTurnCtx` | `agent/lifecycle/types.py` |
-| `BeforeTurnFrame` | `agent/lifecycle/phases/before_turn.py` |
-| `BeforeTurnCtx`（含 abort/abort_reply） | `agent/lifecycle/types.py` |
-| `ToolHook` | `agent/tool_hooks/base.py` |
-| `HookContext` / `HookOutcome` | `agent/tool_hooks/types.py` |
+class MyPlugin(Plugin):
+    name = "my_plugin"
 
-### 所有生命周期上下文类型
+    @tool(name="get_weather", risk="read-only", search_hint="查天气")
+    async def get_weather(self, event, city: str, date: str = "today") -> str:
+        """查询指定城市的天气。
 
-见 `agent/lifecycle/types.py`：`BeforeTurnCtx`, `BeforeReasoningCtx`, `BeforeStepCtx`, `AfterStepCtx`, `AfterReasoningCtx`, `AfterTurnCtx`, `BeforeToolCallCtx`, `AfterToolResultCtx`, `PreToolCtx`。
+        Args:
+            city: 城市名称
+            date: 日期，默认 today
+        """
+        return f"{city} {date}：晴，23°C"
+```
 
-### 已有插件
+JSON Schema 从函数签名和 docstring 的 `Args:` 段自动生成。前两个参数 `self` 和 `event` 固定（`event` 传 `None`）。
 
-| 插件 | 目录 | 演示的能力 |
-|---|---|---|
-| shell_restore | `plugins/shell_restore/` | `@on_tool_pre` 拦截 shell 工具 |
-| status_commands | `plugins/status_commands/` | `before_turn_modules_early()` + `PhaseModule` 命令拦截 |
+---
+
+## 配置文件
+
+```json
+// 插件目录下 _conf_schema.json（声明默认值）
+{"max_results": {"default": 5, "description": "最大返回数"}}
+
+// 插件目录下 plugin_config.json（用户覆盖）
+{"max_results": 10}
+```
+
+代码里读：`self.context.config.get("max_results")` 或 `self.context.config.max_results`。
+
+---
+
+## 其他
+
+| 能力 | API |
+|------|-----|
+| KV 存储 | `self.context.kv_store.get/set/increment()` → `{plugin_dir}/.kv.json` |
+| 直接订阅 EventBus | `self.context.event_bus.on(TurnCommitted, handler)` — 不需要装饰器 |
+| 初始化 / 清理 | `async def initialize(self)`, `async def terminate(self)` |
+
+---
+
+## 例子
+
+### citation — 纯 PhaseModule 的典型用法
+
+```python
+class CitationPlugin(Plugin):
+    name = "citation"
+
+    # 注入协议文本到 system prompt
+    def prompt_render_modules_bottom(self):
+        return [CitationPromptModule()]
+
+    # 扫 §cited:[]§ 标签，提取 ID 写入 persist slot
+    def after_reasoning_modules_before_emit(self):
+        return [CitationAfterReasoningModule()]
+
+    # 清理残留的 <tag:value>
+    def after_reasoning_modules_before_persist(self):
+        return [ProtocolTagCleanupModule()]
+```
+
+三个模块在不同的 Phase，通过 `frame.slots` 的 `persist:assistant:cited_memory_ids` key 把数据从 AfterReasoning 传到 persist 层。没有 @on_*，没有 @tool。
+
+### tool_loop_guard — 纯 @on_tool_pre 的典型用法
+
+```python
+class ToolLoopGuard(Plugin):
+    name = "tool_loop_guard"
+
+    @on_tool_pre()  # 通配所有工具
+    async def guard(self, ctx: PreToolCtx) -> HookOutcome | None:
+        sig = f"{ctx.tool_name}:{json.dumps(ctx.arguments, sort_keys=True)}"
+        state = self._states.setdefault(ctx.session_key, _LoopState())
+        if sig == state.signature:
+            state.count += 1
+        else:
+            state.signature = sig
+            state.count = 1
+        if state.count >= 3:
+            return HookOutcome(decision="deny", reason="连续重复 3 次")
+        return None
+```
+
+### 命令拦截 — 用 slot 做 abort
+
+```python
+class UndoCommandModule:
+    requires = ("session:ctx",)
+
+    async def run(self, frame):
+        ctx = frame.slots["session:ctx"]
+        if ctx.content.strip() == "/undo":
+            ctx.abort = True
+            ctx.abort_reply = "已回滚上一轮。"
+        return frame
+```
+
+放在 `before_turn_modules_early()` ——整个 turn 不走记忆检索、不走 LLM 推理，直接返回。
+
+---
+
+## 所有真实插件
+
+| 插件 | 用了什么 | 一句话 |
+|------|---------|--------|
+| citation | PhaseModule ×3 | 扫 `§cited:[]§` 标签提取被引用的记忆 ID |
+| meme | PhaseModule + @on_after_reasoning GATE | 扫 `<meme:tag>` 替换成表情图片 |
+| observe | 裸 EventBus 订阅 | 全链路 trace 写入 observe.db |
+| tool_loop_guard | @on_tool_pre(通配) | 连续重复调同一工具 3 次就 deny |
+| shell_safety | @on_tool_pre(shell) | 拒绝 vi/vim/sudo 等交互命令 |
+| shell_restore | @on_tool_pre(shell) | rm 改写成 mv |
+| context_pressure | PhaseModule | token 超 80% 窗口时提前停止 tool loop |
+| plugin_undo | PhaseModule(early) | /undo 回滚 |
+| status_commands | PhaseModule(early) | /memorystatus, /kvcache |
+| setup_helper | PhaseModule(early) | /chatid, /myid |
+| recall_inspector | PhaseModule(late) + @on_tool_result TAP | recall_memory 调用追踪 |

--- a/_handbook/proactive-guide.md
+++ b/_handbook/proactive-guide.md
@@ -1,0 +1,464 @@
+# Proactive 主动推送
+
+akashic 不只是被动回复——它每 N 秒/分钟跑一轮 tick，检查你订阅的信息源，自主决定"现在该不该给你发消息、发什么"。没有内容可推时就进入 **Drift 空闲任务**。
+
+## 先理解它是什么
+
+> 把 proactive 和 drift 想成两个**独立的小 agent**，各带一套固定工具，各自醒来干活。
+
+### Proactive：一个定时醒来的"要不要发消息"决策器
+
+Proactive 本质上是：
+
+1. **一套固定工具**：`recall_memory`、`get_content`、`web_fetch`、`mark_interesting`、`mark_not_interesting`、`get_recent_chat`、`message_push`、`finish_turn`
+2. **一段固定 system prompt**（硬编码在 `proactive_v2/agent_tick.py:_build_system_prompt()`）
+3. **一个 MCP 数据源池**：从你配置的 server 拉 alert / content / context
+
+每次 tick 做的事非常机械：**把 MCP server 返回的数据灌进 prompt → LLM 按 prompt 指令逐条判断 → 调用工具写分类结果 → 如果有内容值得推就 message_push 完事**。
+
+```
+[外部 MCP server 数据] + [你的 PROACTIVE_CONTEXT.md 规则] + [长期记忆]
+        ↓
+   灌进 system prompt
+        ↓
+   LLM 调工具做 mark_interesting / mark_not_interesting
+        ↓
+   有 interesting → 写一条消息 → message_push → 发给你
+   没有 → finish_turn(skip)
+```
+
+**决策逻辑在哪里？都在 prompt 里。** 你没有写代码，你写的是 `PROACTIVE_CONTEXT.md` 里的白名单/黑名单/过滤规则，以及 `proactive_sources.json` 里告诉它去哪拉数据。剩下的"这条内容发不发"的判断，全是 LLM 自己根据 prompt 做的。
+
+### Drift：一个没东西可推时才醒来的"后台干活"执行器
+
+当 proactive 拉了一圈发现——没有 alert、没有 content、context fallback 也没开——它会进入 Drift。
+
+Drift 跟 proactive 的**根本区别在于控制方式**：
+
+| | Proactive | Drift |
+|---|---|---|
+| **行为由谁定义** | 固定 system prompt（代码里写死的） | `SKILL.md` 文件（你写的，放在 `drift/skills/` 下） |
+| **做什么** | 分类、筛选、决定推不推 | 你定义什么就做什么（审记忆、问问题、自我诊断...） |
+| **工具** | 推送决策专用工具（mark_*, message_push, finish_turn） | 通用工具（read_file, write_file, fetch_messages, shell...）+ 可 message_push 一次 |
+| **收尾** | finish_turn(decision=reply/skip) | finish_drift(message_result=sent/silent) |
+
+写一个 drift skill 就是写一份 `SKILL.md`，告诉模型：
+- 你这次的任务是什么
+- 有哪些工作文件（读什么、写什么）
+- 每一步怎么做（像 SOP 一样）
+- 什么时候发消息、什么时候静默
+
+**proactive 是"筛选推送引擎"，drift 是"用户可编程后台任务"。**
+
+### 两者的关系
+
+```
+proactive tick
+  └── DataGateway 拉数据
+       ├── 有 alert/content → 跑 proactive agent loop（prompt 驱动）
+       └── 啥都没有 → 跑 drift（SKILL.md 驱动）
+```
+
+就这么简单。下面展开讲怎么配、怎么跑。
+
+---
+
+## 配置步骤
+
+### 哪些你写、哪些 agent 写
+
+配 proactive 涉及的 workspace 文件分两类：
+
+| 文件 | 维护方式 | 说明 |
+|------|---------|------|
+| `config.toml` | **你写** | 全局开关、profile、target、agent/drift 参数 |
+| `mcp_servers.json` | **你写** | MCP server 启动命令和环境变量。也可以通过对话让 agent 调 `mcp_add` 工具写 |
+| `proactive_sources.json` | **你写** | 声明哪个 MCP server 提供哪类数据（alert/content/context） |
+| `PROACTIVE_CONTEXT.md` | **agent 维护** | 主 agent（被动回复时）通过对话帮你写和改。proactive agent 只读不写 |
+| `schedules.json` | **都行** | 你可以手动写，也可以让主 agent 调内置的 `schedule` 工具增删改 |
+| `drift/skills/*/SKILL.md` | **你写** | Drift 的任务定义。也可以用内置 skill `create-drift-skill` 让 agent 帮你生成 |
+| `memory/*.md` | **agent 维护** | 长期记忆、自我认知、近期上下文——全部由主 agent 通过被动对话自动读写 |
+| `drift/drift.json` | **agent 维护** | Drift runner 自动写运行记录，不用管 |
+| `proactive_quota.json` | **agent 维护** | AnyAction gate 自动写配额计数，不用管 |
+
+### 1. 开启 proactive（config.toml）
+
+```toml
+[proactive]
+enabled = true
+profile = "daily"           # daily / quiet / dev_verify
+
+[proactive.target]
+channel = "telegram"
+chat_id = "7674283004"
+
+[proactive.agent]
+max_steps = 20
+content_limit = 5
+web_fetch_max_chars = 8000
+context_prob = 0.03
+delivery_cooldown_hours = 0
+
+[proactive.drift]
+enabled = true
+max_steps = 30
+min_interval_hours = 1
+```
+
+### 2. 注册 MCP server（`~/.akashic/workspace/mcp_servers.json`）
+
+```json
+{
+  "servers": {
+    "fitbit": {
+      "command": ["/path/to/fitbit-mcp/.venv/bin/python", "/path/to/fitbit-mcp/run_mcp.py"],
+      "env": {},
+      "cwd": "/path/to/fitbit-mcp"
+    },
+    "feed": {
+      "command": ["/path/to/feed-mcp/.venv/bin/python", "/path/to/feed-mcp/run_mcp.py"],
+      "env": {},
+      "cwd": "/path/to/feed-mcp"
+    }
+  }
+}
+```
+
+MCP server 通过 stdio 与 agent 通信，启动时 `McpClientPool.connect_all()` 建立常驻连接。也可以用内置工具 `mcp_add` 让 agent 帮你加。
+
+### 3. 声明信息源（`~/.akashic/workspace/proactive_sources.json`）
+
+把 MCP server 的工具映射到 proactive 通道：
+
+```json
+{
+  "sources": [
+    {
+      "server": "fitbit",
+      "channel": "alert",
+      "get_tool": "get_proactive_events",
+      "ack_tool": "acknowledge_events",
+      "enabled": true
+    },
+    {
+      "server": "fitbit",
+      "channel": "context",
+      "get_tool": "get_sleep_context",
+      "enabled": true
+    },
+    {
+      "server": "feed",
+      "channel": "content",
+      "get_tool": "get_proactive_events",
+      "ack_tool": "acknowledge_events",
+      "poll_tool": "poll_feeds",
+      "enabled": true
+    },
+    {
+      "server": "steam",
+      "channel": "context",
+      "get_tool": "get_steam_context",
+      "enabled": true
+    }
+  ]
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `server` | 对应 `mcp_servers.json` 里的 key |
+| `channel` | `"alert"` / `"content"` / `"context"` |
+| `get_tool` | MCP tool 名。content/alert 默认 `get_proactive_events`，context 默认 `get_context` |
+| `ack_tool` | 确认工具。alert/content 需要，context 不需要（不走 ACK） |
+| `poll_tool` | content 专用：周期拉新的 tool（如 `poll_feeds`） |
+
+### 4. 写推送规则（`~/.akashic/workspace/PROACTIVE_CONTEXT.md`）
+
+这是主被动 loop 共享的规则面板。你通过**被动对话**让主 agent 帮你写和维护。proactive agent 每轮只读。
+
+```
+# Proactive Context
+
+## CS2 新闻推送过滤规则
+
+**白名单队伍**：HLTV Top 15（每周一更新）+ TyLoo + BC.Game + 100 Thieves
+**过滤逻辑**：仅推送白名单队伍及选手相关新闻，其他一律过滤
+```
+
+规则要点：写结论不写过程、主 agent 负责维护、proactive agent 每轮读取。**怎么改：直接跟 agent 聊天说"帮我在 proactive context 里加一条规则..."**。
+
+### 5. 定时任务（`schedules.json`）
+
+手动写或通过主 agent 对话让它调 `schedule` 工具增删：
+
+```json
+[
+  {
+    "trigger": "every",
+    "tier": "soft",
+    "cron_expr": "0 7 * * *",
+    "timezone": "Asia/Shanghai",
+    "channel": "telegram",
+    "chat_id": "7674283004",
+    "prompt": "查询北京今天全天天气预报...",
+    "name": "通勤天气决策",
+    "enabled": true
+  }
+]
+```
+
+### 6. tick 间隔——不是固定的
+
+tick 不是一个 cron，它是一个**根据你上次说话时间动态变化**的间隔。
+
+```
+你上次发消息的时间
+    ↓
+compute_energy(last_user_at) → 当前"电量" [0, 1]
+    三条衰减曲线叠加（30分钟/4小时/48小时）
+    刚聊完 → 电量 ≈ 1.0（满）
+    半天没聊 → 电量 ≈ 0.0（空）
+    ↓
+d_energy = 1 - energy → "饥渴度"
+    电量满 → 不饿 → d_energy 低
+    电量空 → 饿了 → d_energy 高
+    ↓
+base_score = w_e × d_energy + w_c × 新内容量 + w_r × 最近对话丰富度
+    ↓
+next_tick_from_score(base_score)
+    base_score > 0.70 → s3（最快）
+    base_score > 0.40 → s2
+    base_score > 0.20 → s1
+    base_score ≤ 0.20 → s0（最慢）
+```
+
+**直觉**：你刚说完话，agent 不想烦你，慢悠悠地查（8 分钟一次）。你半天没动静，agent 觉得"该找点东西了"，加速查到 1 分钟一次。
+
+三种预设只是调整这张"饥渴→间隔"的映射表：
+
+| 预设 | s0（不饿） | s1 | s2 | s3（很饿） | 适用场景 |
+|------|-----------|-----|-----|-----|----------|
+| `daily` | 8 min | 4 min | 2 min | 1 min | 日常 |
+| `dev_verify` | 1 min | 30 s | 15 s | 10 s | 开发调试 |
+| `quiet` | 30 min | 15 min | 8 min | 4 min | 低打扰 |
+
+每次 tick 后重新算，间隔持续变化——不是定时器，是自适应循环。
+
+### 7. 微调参数（overrides）
+
+```toml
+[proactive.overrides.gate]
+judge_send_threshold = 0.65    # 提高发送门槛
+
+[proactive.overrides.trigger]
+tick_interval_s0 = 600         # 不饿时 10 分钟
+tick_interval_s3 = 120         # 很饿时至少 2 分钟
+```
+
+---
+
+## 系统怎么跑的（技术展开）
+
+```
+ProactiveLoop.run()
+  ├── McpClientPool.connect_all()         # 启动时连接所有 MCP server（常驻连接）
+  ├── feed poll loop（后台）               # 周期性调用 poll_feeds 拉新内容
+  └── tick loop（自适应频率）
+       ├── _next_interval(score)           # 电量模型 → 下次 tick 间隔
+       ├── DataGateway.run()               # 三路并行预取（alert / content / context）
+       │    ├── _fetch_alerts()            # 调 MCP tool: get_proactive_events(kind=alert)
+       │    ├── _fetch_content()           # 调 MCP tool: get_proactive_events(kind=content) → 并行 web_fetch 正文
+       │    └── _fetch_context()           # 调 MCP tool: get_context / get_sleep_context / get_steam_context
+       ├── AgentTick.tick()
+       │    ├── Pre-gate（冷却 / busy / AnyAction 概率门 / context gate）
+       │    ├── agent loop（LLM 逐条评分分类 → mark_interesting/mark_not_interesting → message_push → finish_turn）
+       │    ├── Classification completeness check（未分类条目强制补完）
+       │    └── Reflection pass（有 interesting 但没收尾时注入提示）
+       ├── Post-loop（delivery 去重 / 消息语义去重 → 发送或跳过）
+       └── ACK（已消费事件标记为已处理，设置 TTL 防止重复拉取）
+```
+
+关键设计点：
+- **常驻 MCP 连接**：启动时 `connect_all()`，整个生命周期不复连，避免每次 tick 重启子进程
+- **数据先到齐再决策**：三路预取在 agent loop 之前完成，单源失败不影响其他源
+- **去重分层**：delivery 级（同一批内容不重复发）+ message 级（语义去重，新消息和最近主动消息如果实质重复也跳过）
+- **ACK 机制**：每个被消费的事件都要 ACK，带不同 TTL（cited 168h / interesting uncited 24h / discarded 720h）
+
+---
+
+## 数据从哪来——MCP 接口契约
+
+三种事件通道各有自己的 MCP tool 约定和返回 schema。这是**写 MCP server 的人需要遵守的合同**——只要满足这个合同，你的数据源就能被 proactive 消费。
+
+### 1. Alert 通道
+
+**设计语义**：高优先级、时效性强的告警，bypass 内容评分，直接透传 agent。
+
+**MCP tool 约定**：`get_proactive_events()` 返回 `list[dict]`，每个 dict 的 `kind` 为 `"alert"`。
+
+**标准 schema**（以 fitbit 为例）：
+
+```json
+{
+  "event_id": "fb_20260508_001",
+  "kind": "alert",
+  "source_type": "health_event",
+  "source_name": "fitbit",
+  "title": "hr_elevated_rest",
+  "content": "静息心率异常升高：当前 92 bpm（基线 68 bpm），持续 15 分钟",
+  "severity": "high",
+  "published_at": "2026-05-08T14:30:00",
+  "suggested_tone": "关切但不过度紧张",
+  "metrics": {"current_bpm": 92, "baseline_bpm": 68, "duration_min": 15}
+}
+```
+
+| 字段 | 类型 | 必须 | 说明 |
+|------|------|------|------|
+| `event_id` | string | 是 | ACK 的唯一标识 |
+| `kind` | string | 是 | 固定 `"alert"` |
+| `source_name` | string | 是 | 可读来源名 |
+| `title` | string | 是 | 事件类型 |
+| `content` | string | 是 | 人类可读告警正文 |
+| `severity` | string | 否 | `"high"` / `"medium"`。`"high"` 时 bypass 评分直接推 |
+| `published_at` | string | 否 | ISO 时间戳 |
+| `suggested_tone` | string | 否 | LLM 语气提示 |
+| `metrics` | dict | 否 | 结构化指标，最多 8 key，value 最长 60 字符 |
+
+**ACK tool**：`acknowledge_events(event_ids: list[str])` — alert 走独立 ACK 通道，无 TTL（一次性消费）。
+
+**真实实现**：`~/.akashic/workspace/mcp/fitbit-mcp/src/mcp_bridge.py`：
+
+```python
+@mcp.tool()
+def get_proactive_events() -> str:
+    data = _fetch_agent_payload(timeout=5)
+    raw_events = data.get("health_events") or []
+    events = [_to_standard_event(e) for e in raw_events]
+    return json.dumps(events, ensure_ascii=False)
+```
+
+### 2. Content 通道
+
+**设计语义**：内容流（RSS 新闻、社交更新），参与评分分类，走去重和 ACK。
+
+**MCP tool 约定**：`get_proactive_events()` 返回 `list[dict]`，每个 dict 的 `kind` 为 `"content"`。
+
+**标准 schema**（以 feed-mcp 为例）：
+
+```json
+{
+  "event_id": "rss_abc123",
+  "kind": "content",
+  "source_type": "rss",
+  "source_name": "HLTV.org",
+  "title": "Vitality win BLAST Open Spring 2026",
+  "content": "Vitality defeated NAVI 2-0...",
+  "url": "https://www.hltv.org/news/40001/vitality-win-blast",
+  "published_at": "2026-05-08T12:00:00",
+  "display_text": "Vitality 2-0 NAVI · BLAST · 2026-05-08"
+}
+```
+
+| 字段 | 类型 | 必须 | 说明 |
+|------|------|------|------|
+| `event_id` | string | 是 | ACK 的唯一标识 |
+| `kind` | string | 是 | 固定 `"content"` |
+| `source_name` | string | 是 | 可读来源名 |
+| `title` | string | 是 | 标题，agent 先看这个做初筛 |
+| `url` | string | 是 | 原文链接，gateway 会据此预取正文 |
+| `content` | string | 否 | 短摘要。详细正文由 gateway 通过 web_fetch 从 url 抓取 |
+| `published_at` | string | 否 | ISO 时间戳 |
+| `display_text` | string | 否 | 紧凑展示文本 |
+
+**处理流程**：
+1. gateway 调 `get_proactive_events` → 拿到 meta 列表
+2. 并行 web_fetch 每个 `url` → 正文截断后存 content_store hashmap
+3. agent 在 loop 中通过 `get_content` 工具按需取正文
+4. 分类后 ACK 带 TTL
+
+**Poll tool**（content 专用）：`poll_feeds()` — 后台周期性调用，让 MCP server 去真正抓取 RSS/API。
+
+**真实实现**：`~/.akashic/workspace/mcp/feed-mcp/src/feed_backend.py:1284`：
+
+```python
+def get_proactive_events() -> list[dict[str, Any]]:
+    rows = conn.execute("""
+        SELECT i.event_id, i.source_type, i.source_name, i.title,
+               i.content, i.url, i.published_at
+        FROM items i LEFT JOIN acked_items a ON a.event_id = i.event_id
+        WHERE a.event_id IS NULL
+          AND coalesce(i.published_at, i.first_seen_at) >= ?
+        ORDER BY coalesce(i.published_at, i.first_seen_at) DESC LIMIT ?
+    """, (published_after, cfg.max_content_events)).fetchall()
+    return [{
+        "event_id": row["event_id"], "kind": "content",
+        "source_type": row["source_type"], "source_name": row["source_name"],
+        "title": row["title"], "content": row["content"],
+        "url": row["url"], "published_at": row["published_at"],
+        "display_text": _build_display_text(row),
+    } for row in rows]
+```
+
+### 3. Context 通道
+
+**设计语义**：背景上下文——不是事件流，不参与评分，不做 ACK。alert 和 content 都空时，以低概率注入作为"没东西推时能不能找点话说"的 fallback。
+
+**与 alert/content 的根本不同**：
+- 没有 event_id，不走去重，不做 ACK
+- 不触发推送决策，只在 alert 和 content 都为空时才被 agent 看到
+- 注入有概率阀（`context_prob`，默认 3%）和日配额（`context_only_daily_max`，默认 1 次/天）
+
+**MCP tool 约定**：每个 context 源定义独立 tool（命名习惯 `get_<name>_context`），返回单个 dict 或 list[dict]。没有强 schema 要求，只有语义约定：
+
+```json
+// fitbit sleep context
+{
+  "available": true,
+  "summary": "用户当前可能已经睡着（概率 0.87），数据延迟约 5 分钟。",
+  "sleep": {"state": "sleeping", "prob": 0.87, "prob_source": "hrv"}
+}
+
+// steam game context
+{
+  "available": true,
+  "games": [{"name": "CS2", "recent_2w_hours": 12.5, "all_time_hours": 2340.0}],
+  "realtime": {"online_status": "in-game", "currently_playing": "Counter-Strike 2"}
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `available` | 数据是否可用。false 时 agent 不应据此做推断 |
+| `_source` | framework 自动注入，标记来自哪个 MCP server |
+| `summary` / `hint` | 人类可读说明和判断指引 |
+
+**真实实现**：
+- fitbit sleep：`~/.akashic/workspace/mcp/fitbit-mcp/src/mcp_bridge.py:136`
+- steam game：`~/.akashic/workspace/mcp/steam-mcp/steam_proactive.py`
+
+---
+
+## 一个完整的实际例子
+
+以 fitbit 告警从数据源到用户收到消息的完整链路：
+
+```
+1. fitbit-mcp 后台运行，周期性拉 Fitbit API
+   └── 检测到静息心率异常 → 写入内部事件队列
+
+2. proactive loop tick
+   └── DataGateway._fetch_alerts()
+       └── pool.call("fitbit", "get_proactive_events", {})
+       └── 返回 [{"event_id":"fb_001","kind":"alert","title":"hr_elevated_rest",...}]
+
+3. agent loop（LLM 决策）
+   └── system prompt："本轮如有 Alert → 整合所有 Alert → message_push → finish_turn"
+   └── LLM 调 message_push: "你的静息心率在过去15分钟异常升高（92 bpm，基线68）。建议留意。"
+   └── evidence: ["fitbit:fb_001"]
+   └── finish_turn(decision=reply)
+
+4. Post-loop → delivery 去重通过 → 消息语义去重通过 → Telegram 发送
+
+5. ACK: acknowledge_events(event_ids=["fb_001"]) → fitbit-mcp 标记已处理
+```


### PR DESCRIPTION
## 变更

重写了 handbook 文档体系，把原来混乱的 README 和过时的教程替换为结构清晰的四份文档。

### 新增/重写

- **README.md** — 浓缩到 120 行。顶部加入系统全景图 + 文档索引表，Quickstart 展示推荐模型配置（DeepSeek v4 flash + Qwen flash），核心功能段各自指到对应 handbook
- **`_handbook/proactive-guide.md`** — Proactive 完整配置指南。从"先理解它是什么"开始（proactive 就是一段固定 prompt + 固定工具集的 agent），展开讲三种事件通道的 MCP 接口契约（schema、真实实现代码）、电量驱动的自适应 tick 间隔、完整端到端例子
- **`_handbook/drift-guide.md`** — Drift 空闲任务系统。核心概念（proactive 是 prompt 驱动，drift 是 SKILL.md 驱动），三个真实病例的完整工作流程，怎么写自己的 drift skill
- **`_handbook/memory-markdown.md`** — 记忆系统的 Markdown 文件层。五个文件的格式和流转，consolidation 全流程（触发时机 → LLM 提取 → 写入 → 幂等性），Optimizer 为什么隔一层（保护 prompt cache），向量记忆 API 的 12 个调用点全景
- **`_handbook/plugins-tutorial.md`** — 完全重写。从"看系统怎么运转"出发，PhaseModule/Slot/EventBus/@on_tool_pre/@tool 四种介入机制各自独立成节，slot 系统有完整前缀表和三个实操例子，真实插件压缩为速查表

### 设计原则

- 每份文档开头先讲"本质是什么"（proactive = 一段 prompt + 工具集，drift = 你写 SOP 模型照办，plugin = 四个介入机制）
- 先讲怎么配置/怎么写，再展开技术细节
- 所有 schema/字段表基于真实 `~/.akashic/workspace` 里的实际数据