### PR TITLE
feat(proactive_v2): drift 消息推送支持图片/媒体附件

### DIFF
--- a/agent/turns/orchestrator.py
+++ b/agent/turns/orchestrator.py
@@ -43,11 +43,13 @@ class TurnOrchestrator:
             raise ValueError("proactive reply result requires outbound")
 
         content = result.outbound.content
+        media = list(result.outbound.media or [])
         session = self._session.session_manager.get_or_create(session_key)
         # 2. reply 路径只写 proactive session；后处理只归 passive commit 管。
         self._persist_proactive_session(
             session=session,
             content=content,
+            media=media,
             result=result,
         )
         await self._session.session_manager.append_messages(session, session.messages[-1:])
@@ -62,6 +64,7 @@ class TurnOrchestrator:
                     chat_id=chat_id,
                     content=content,
                     metadata={},
+                    media=media,
                 )
             )
         except Exception as e:
@@ -94,6 +97,7 @@ class TurnOrchestrator:
         *,
         session: SessionLike,
         content: str,
+        media: list[str],
         result: TurnResult,
     ) -> None:
         source_refs = []
@@ -106,6 +110,7 @@ class TurnOrchestrator:
         session.add_message(
             "assistant",
             content,
+            media=media if media else None,
             proactive=True,
             tools_used=["message_push"],
             evidence_item_ids=[str(item_id) for item_id in result.evidence],

--- a/agent/turns/outbound.py
+++ b/agent/turns/outbound.py
@@ -49,14 +49,24 @@ class PushToolOutboundPort:
         message = str(outbound.content or "").strip()
         channel = str(outbound.channel or "").strip()
         chat_id = str(outbound.chat_id or "").strip()
-        if not message or not channel or not chat_id:
+        media = [str(item).strip() for item in outbound.media if str(item).strip()]
+        if (not message and not media) or not channel or not chat_id:
             return False
         try:
-            result = await self._push.execute(
-                channel=channel,
-                chat_id=chat_id,
-                message=message,
-            )
+            result = ""
+            if message or media:
+                result = await self._push.execute(
+                    channel=channel,
+                    chat_id=chat_id,
+                    message=message,
+                    image=media[0] if media else None,
+                )
+            for image in media[1:]:
+                result = await self._push.execute(
+                    channel=channel,
+                    chat_id=chat_id,
+                    image=image,
+                )
         except Exception:
             return False
         return "已发送" in str(result)

--- a/agent/turns/result.py
+++ b/agent/turns/result.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 class TurnOutbound:
     session_key: str
     content: str
+    media: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/proactive_v2/agent_tick_factory.py
+++ b/proactive_v2/agent_tick_factory.py
@@ -289,7 +289,7 @@ class AgentTickFactory:
             tool_hooks=self._deps.tool_hooks,
         )
 
-    def _build_drift_send_message_fn(self) -> Callable[[str], Awaitable[bool]] | None:
+    def _build_drift_send_message_fn(self) -> Callable[..., Awaitable[bool]] | None:
         orchestrator = self._deps.turn_orchestrator
         session_key = self._get_session_key()
         state_store = self._deps.state_store
@@ -303,11 +303,12 @@ class AgentTickFactory:
             async def run(self) -> None:
                 self.callback()
 
-        async def send_message(content: str) -> bool:
-            delivery_key = sha1(content[:500].encode()).hexdigest()[:16]
+        async def send_message(content: str, media: list[str] | None = None) -> bool:
+            media_paths = list(media or [])
+            delivery_key = sha1((content[:500] + "|".join(media_paths[:5])).encode()).hexdigest()[:16]
             result = TurnResult(
                 decision="reply",
-                outbound=TurnOutbound(session_key=session_key, content=content),
+                outbound=TurnOutbound(session_key=session_key, content=content, media=media_paths),
                 trace=TurnTrace(source="proactive", extra={"source_mode": "drift"}),
                 success_side_effects=[
                     _SideEffect(

--- a/proactive_v2/drift_tools.py
+++ b/proactive_v2/drift_tools.py
@@ -38,7 +38,7 @@ class SendMessageTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "向用户发送一条消息。单次 Drift run 最多只能调用一次。\n"
+            "向用户发送一条消息，可附带图片。单次 Drift run 最多只能调用一次。\n"
             "channel 和 chat_id 在 Drift 上下文中已由配置预设，可省略不填。"
         )
 
@@ -48,6 +48,12 @@ class SendMessageTool(Tool):
             "type": "object",
             "properties": {
                 "message": {"type": "string", "description": "要发送的消息内容"},
+                "image": {"type": "string", "description": "要发送的一张图片本地路径或 URL"},
+                "media": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "要随消息发送的图片路径或 URL 列表",
+                },
                 "channel": {
                     "type": "string",
                     "description": "目标渠道（Drift 上下文可省略，已由配置预设）",
@@ -57,11 +63,19 @@ class SendMessageTool(Tool):
                     "description": "目标会话 ID（Drift 上下文可省略，已由配置预设）",
                 },
             },
-            "required": ["message"],
+            "required": [],
         }
 
-    async def execute(self, message: str = "", content: str = "", **_: Any) -> str:
+    async def execute(
+        self,
+        message: str = "",
+        content: str = "",
+        image: str = "",
+        media: list[str] | str | None = None,
+        **_: Any,
+    ) -> str:
         text = normalize_outbound_text(message or content or "").strip()
+        media_paths = self._normalize_media(image=image, media=media)
         if self._send_message_fn is None:
             logger.info("[drift_tools] message_push unavailable")
             return json.dumps({"error": "message_push not configured"}, ensure_ascii=False)
@@ -71,16 +85,27 @@ class SendMessageTool(Tool):
                 {"error": "message_push already used in this drift run"},
                 ensure_ascii=False,
             )
-        if not text:
-            logger.info("[drift_tools] message_push rejected: empty message")
-            return json.dumps({"error": "message is required"}, ensure_ascii=False)
-        ok = await self._send_message_fn(text)
+        if not text and not media_paths:
+            logger.info("[drift_tools] message_push rejected: empty message and media")
+            return json.dumps({"error": "message or media is required"}, ensure_ascii=False)
+        ok = await self._send_message_fn(text, media_paths)
         if not ok:
             logger.warning("[drift_tools] message_push failed")
             return json.dumps({"error": "message_push failed"}, ensure_ascii=False)
         self._ctx.drift_message_sent = True
         logger.info("[drift_tools] message_push ok")
         return json.dumps({"ok": True}, ensure_ascii=False)
+
+    @staticmethod
+    def _normalize_media(*, image: str = "", media: list[str] | str | None = None) -> list[str]:
+        paths: list[str] = []
+        if image:
+            paths.append(str(image).strip())
+        if isinstance(media, str):
+            paths.append(media.strip())
+        elif media:
+            paths.extend(str(item).strip() for item in media)
+        return [path for path in paths if path]
 
 
 class FinishDriftTool(Tool):

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -145,6 +145,44 @@ def test_drift_tool_schemas_include_reused_tools():
     assert "get_recent_chat" not in names
 
 
+def test_drift_message_push_schema_supports_media(tmp_path: Path):
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    schemas = build_drift_tool_registry(
+        ctx=ctx,
+        deps=DriftToolDeps(
+            drift_dir=tmp_path,
+            store=DriftStateStore(tmp_path),
+            shared_tools=_build_shared_tools(),
+        ),
+    ).get_schemas()
+    message_push = next(
+        schema["function"] for schema in schemas if schema["function"]["name"] == "message_push"
+    )
+    props = message_push["parameters"]["properties"]
+    assert "image" in props
+    assert "media" in props
+    assert "message" not in message_push["parameters"].get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_drift_message_push_sends_media(tmp_path: Path):
+    ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
+    send_message = AsyncMock(return_value=True)
+    raw = await _exec_drift_tool(
+        tmp_path,
+        ctx,
+        "message_push",
+        {
+            "message": "新表情来啦",
+            "image": "/tmp/one.png",
+            "media": ["/tmp/two.png"],
+        },
+        send_message_fn=send_message,
+    )
+    assert json.loads(cast(Any, raw))["ok"] is True
+    send_message.assert_awaited_once_with("新表情来啦", ["/tmp/one.png", "/tmp/two.png"])
+
+
 def test_drift_system_prompt_discourages_stuck_skill_and_lists_new_tools(tmp_path: Path):
     _write_skill(tmp_path)
     store = DriftStateStore(tmp_path)
@@ -414,7 +452,7 @@ async def test_drift_runner_restricts_tools_after_send_message(tmp_path: Path):
     # FakeLLM 不记录 schemas，这里用行为结果兜底：send 后仍正常 finish。
     assert ctx.drift_finished is True
     assert store.load_drift()["recent_runs"][-1]["message_result"] == "sent"
-    send_message.assert_awaited_once_with("hello\n\nfrom drift")
+    send_message.assert_awaited_once_with("hello\n\nfrom drift", [])
 
 
 @pytest.mark.asyncio
@@ -544,11 +582,11 @@ async def test_agent_tick_drift_send_message_skips_normal_post_loop(tmp_path: Pa
         )
     )
 
-    async def send_message(content: str) -> bool:
+    async def send_message(content: str, media: list[str] | None = None) -> bool:
         return await orchestrator.handle_proactive_turn(
             result=TurnResult(
                 decision="reply",
-                outbound=TurnOutbound(session_key="test_session", content=content),
+                outbound=TurnOutbound(session_key="test_session", content=content, media=list(media or [])),
                 trace=TurnTrace(source="proactive", extra={"source_mode": "drift"}),
             ),
             session_key="test_session",

--- a/tests/turns/test_orchestrator.py
+++ b/tests/turns/test_orchestrator.py
@@ -125,3 +125,43 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
     assert session.messages[0]["proactive"] is True
     assert session.messages[0]["content"] == "hello"
     assert order == ["persist", "side_effect", "dispatch", "presence", "success_effect"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_proactive_reply_dispatches_media():
+    session = _DummySession("telegram:123")
+    dispatched: list[OutboundDispatch] = []
+
+    class _Outbound:
+        async def dispatch(self, outbound: OutboundDispatch) -> bool:
+            dispatched.append(outbound)
+            return True
+
+    session_manager = SimpleNamespace(
+        get_or_create=lambda _key: session,
+        append_messages=AsyncMock(return_value=None),
+    )
+    orchestrator = TurnOrchestrator(
+        TurnOrchestratorDeps(
+            session=SessionServices(session_manager=cast(Any, session_manager), presence=None),
+            outbound=_Outbound(),
+        )
+    )
+
+    sent = await orchestrator.handle_proactive_turn(
+        result=TurnResult(
+            decision="reply",
+            outbound=TurnOutbound(
+                session_key="telegram:123",
+                content="新表情来啦",
+                media=["/tmp/meme.png"],
+            ),
+        ),
+        session_key="telegram:123",
+        channel="telegram",
+        chat_id="123",
+    )
+
+    assert sent is True
+    assert dispatched[0].media == ["/tmp/meme.png"]
+    assert session.messages[0]["media"] == ["/tmp/meme.png"]


### PR DESCRIPTION
## 变更

Drift 消息推送链路增加图片/媒体支持。

### 改动范围

- **`agent/turns/result.py`** — `TurnOutbound` 新增 `media: list[str]` 字段
- **`agent/turns/orchestrator.py`** — proactive turn 路径传递 media 到 session 持久化和 outbound dispatch
- **`agent/turns/outbound.py`** — `PushToolOutboundPort` 支持多图发送，允许 message 为空但有 media
- **`proactive_v2/drift_tools.py`** — `SendMessageTool` 新增 `image` / `media` 参数，`message` 不再必填
- **`proactive_v2/agent_tick_factory.py`** — `send_message` 签名增加 `media` 参数，delivery key 纳入 media 路径

### 测试

- `pytest tests/proactive_v2/test_drift.py::test_drift_message_push_schema_supports_media`
- `pytest tests/proactive_v2/test_drift.py::test_drift_message_push_sends_media`
- `pytest tests/turns/test_orchestrator.py::test_orchestrator_proactive_reply_dispatches_media`