### PR TITLE
feat(scheduler): 后台任务禁用 message_push 并跳过 post_memory

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -123,6 +123,19 @@ def _is_tool_loop_guard_denial(exec_result: object) -> bool:
         for item in traces
     )
 
+
+def _disabled_tools_from_msg(msg: object) -> set[str]:
+    metadata: object = getattr(msg, "metadata", None)
+    if not isinstance(metadata, dict):
+        return set()
+    raw = metadata.get("disabled_tools")
+    if isinstance(raw, str):
+        return {raw} if raw else set()
+    if isinstance(raw, (list, tuple, set)):
+        return {str(item) for item in raw if str(item)}
+    return set()
+
+
 class _NoopOutboundPort:
     async def dispatch(self, outbound: OutboundDispatch) -> bool:
         return False
@@ -544,6 +557,7 @@ class Reasoner(ABC):
         tool_event_session_key: str = "",
         tool_event_channel: str = "",
         tool_event_chat_id: str = "",
+        disabled_tools: set[str] | None = None,
     ) -> ReasonerResult:
         """执行多轮 tool loop，并返回本轮结果。"""
 
@@ -755,6 +769,7 @@ class DefaultReasoner(Reasoner):
         stream_sink = (
             self._stream_sink_factory(msg) if self._stream_sink_factory is not None else None
         )
+        disabled_tools = _disabled_tools_from_msg(msg)
 
         # 2. 再按 trim plan + history window 顺序逐轮尝试。
         attempts = self._build_attempt_plans(total_history)
@@ -773,7 +788,11 @@ class DefaultReasoner(Reasoner):
             turn_injection_prompt = build_turn_injection_prompt(
                 tools=self._tools,
                 tool_search_enabled=self._tool_search_enabled,
-                visible_names=preloaded if self._tool_search_enabled else None,
+                visible_names=(
+                    (preloaded or set()) | disabled_tools
+                    if self._tool_search_enabled
+                    else None
+                ),
             )
             prompt_render = await self.render_prompt(
                 PromptRenderInput(
@@ -805,6 +824,7 @@ class DefaultReasoner(Reasoner):
                     tool_event_session_key=session.key,
                     tool_event_channel=msg.channel,
                     tool_event_chat_id=msg.chat_id,
+                    disabled_tools=disabled_tools,
                 )
                 tools_used = list(result.metadata.get("tools_used") or [])
                 tool_chain = list(result.metadata.get("tool_chain") or [])
@@ -898,6 +918,7 @@ class DefaultReasoner(Reasoner):
         tool_event_session_key: str = "",
         tool_event_channel: str = "",
         tool_event_chat_id: str = "",
+        disabled_tools: set[str] | None = None,
     ) -> ReasonerResult:
         # 1. 初始化消息上下文、本轮工具轨迹。
         messages = initial_messages
@@ -910,9 +931,10 @@ class DefaultReasoner(Reasoner):
         react_cache_prompt_tokens = 0
         react_cache_hit_tokens = 0
         react_cache_seen = False
+        disabled = set(disabled_tools or set())
         if self._tool_search_enabled:
             always_on = self._tools.get_always_on_names()
-            visible_names = always_on | (preloaded_tools or set())
+            visible_names = (always_on | (preloaded_tools or set())) - disabled
             logger.info(
                 "[tool_search] visible=%d 个工具 always_on=%d preloaded=%d need_search=%s",
                 len(visible_names),
@@ -965,9 +987,14 @@ class DefaultReasoner(Reasoner):
                 f"{len(visible_names)}个" if visible_names is not None else "全部（tool_search未开启）",
                 step_ctx.input_tokens_estimate,
             )
+            schema_names = set(visible_names) if visible_names is not None else None
+            if schema_names is None and disabled:
+                schema_names = self._tools.get_registered_names() - disabled
+            elif schema_names is not None:
+                schema_names -= disabled
             response = await self._llm.provider.chat(
                 messages=messages,
-                tools=self._tools.get_schemas(names=visible_names),
+                tools=self._tools.get_schemas(names=schema_names),
                 model=self._llm_config.model,
                 max_tokens=self._llm_config.max_tokens,
                 tool_choice="auto",
@@ -998,6 +1025,48 @@ class DefaultReasoner(Reasoner):
                 # 6. 逐个执行本轮工具调用。
                 iter_calls: list[dict[str, Any]] = []
                 for tool_batch_index, tool_call in enumerate(response.tool_calls):
+                    if tool_call.name in disabled:
+                        await self._observe_tool_call_started(
+                            session_key=tool_event_session_key,
+                            channel=tool_event_channel,
+                            chat_id=tool_event_chat_id,
+                            iteration=iteration + 1,
+                            call_id=tool_call.id,
+                            tool_name=tool_call.name,
+                            arguments=tool_call.arguments,
+                        )
+                        result = (
+                            f"工具 '{tool_call.name}' 在当前后台任务中不可用。"
+                            "请直接返回要发送的最终内容，不要主动推送。"
+                        )
+                        append_tool_result(
+                            messages,
+                            tool_call_id=tool_call.id,
+                            content=result,
+                            tool_name=tool_call.name,
+                        )
+                        await self._observe_tool_call_completed(
+                            session_key=tool_event_session_key,
+                            channel=tool_event_channel,
+                            chat_id=tool_event_chat_id,
+                            iteration=iteration + 1,
+                            call_id=tool_call.id,
+                            tool_name=tool_call.name,
+                            arguments=tool_call.arguments,
+                            final_arguments=tool_call.arguments,
+                            status="blocked",
+                            result_preview=support.log_preview(result),
+                        )
+                        iter_calls.append(
+                            {
+                                "call_id": tool_call.id,
+                                "name": tool_call.name,
+                                "status": "blocked",
+                                "arguments": tool_call.arguments,
+                                "result": result,
+                            }
+                        )
+                        continue
                     # 6.1 deferred 工具未解锁时，先回填 select: 引导错误。
                     if visible_names is not None and tool_call.name not in visible_names:
                         exec_result = await self._tool_executor.preflight(
@@ -1133,7 +1202,9 @@ class DefaultReasoner(Reasoner):
                         and visible_names is not None
                         and self._tool_search_tool is not None
                     ):
-                        self._tool_search_tool.set_excluded_names(visible_names)
+                        self._tool_search_tool.set_excluded_names(
+                            visible_names | disabled
+                        )
                     _args_preview = support.log_preview(tool_call.arguments, 120)
                     logger.info("[工具执行→] %s  args=%s", tool_call.name, _args_preview)
                     await self._observe_tool_call_started(
@@ -1218,6 +1289,7 @@ class DefaultReasoner(Reasoner):
                     ):
                         _newly_unlocked = self._discovery.unlock_from_result(normalized.text)
                         _newly_unlocked -= visible_names  # keep only genuinely new ones
+                        _newly_unlocked -= disabled
                         if _newly_unlocked:
                             visible_names.update(_newly_unlocked)
                             logger.info("[工具解锁] tool_search 新解锁: %s", sorted(_newly_unlocked))

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -84,6 +84,14 @@ def _supports_stream_events(channel: str, chat_id: str) -> bool:
     return bool(policy is not None and policy(chat_id))
 
 
+def _suppresses_stream_events(msg: object) -> bool:
+    metadata: object = getattr(msg, "metadata", None)
+    if not isinstance(metadata, dict):
+        return False
+    typed = cast(dict[str, object], metadata)
+    return bool(typed.get("suppress_stream_events"))
+
+
 def _item_content(item: InboundItem) -> str:
     if isinstance(item, InboundMessage):
         return item.content
@@ -171,6 +179,8 @@ class AgentLoop:
             return None
 
         def _build(msg: object) -> StreamSink | None:
+            if _suppresses_stream_events(msg):
+                return None
             downstream = factory(msg)
             channel = str(getattr(msg, "channel", ""))
             chat_id = str(getattr(msg, "chat_id", ""))
@@ -198,6 +208,8 @@ class AgentLoop:
     def _build_stream_event_sink(self, msg: object) -> StreamSink | None:
         channel = str(getattr(msg, "channel", ""))
         chat_id = str(getattr(msg, "chat_id", ""))
+        if _suppresses_stream_events(msg):
+            return None
         if not _supports_stream_events(channel, chat_id):
             return None
         session_key = str(getattr(msg, "session_key", f"{channel}:{chat_id}"))
@@ -605,13 +617,25 @@ class AgentLoop:
         channel: str = "cli",
         chat_id: str = "direct",
         omit_user_turn: bool = False,
+        skip_post_memory: bool = False,
+        stream_events: bool = False,
+        disabled_tools: list[str] | None = None,
     ) -> str:
+        metadata: dict[str, object] = {}
+        if omit_user_turn:
+            metadata["omit_user_turn"] = True
+        if skip_post_memory:
+            metadata["skip_post_memory"] = True
+        if not stream_events:
+            metadata["suppress_stream_events"] = True
+        if disabled_tools:
+            metadata["disabled_tools"] = list(disabled_tools)
         msg = InboundMessage(
             channel=channel,
             sender="user",
             chat_id=chat_id,
             content=content,
-            metadata={"omit_user_turn": True} if omit_user_turn else {},
+            metadata=metadata,
         )
         response = await self._process(
             msg,

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -489,6 +489,8 @@ class SchedulerService:
                 chat_id=job.chat_id,
                 session_key=f"scheduler:{job.id}",
                 omit_user_turn=True,
+                skip_post_memory=True,
+                disabled_tools=["message_push"],
             )
             elapsed = time.monotonic() - t0
             self.tracker.record(elapsed)

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -944,6 +944,8 @@ class MarkdownMemoryMaintenance:
         self._save_session = request.save_session
 
     def on_turn_committed(self, event: TurnCommitted) -> None:
+        if bool((event.extra or {}).get("skip_post_memory")):
+            return
         self._enqueue_maintenance(event.session_key)
 
     def _enqueue_maintenance(self, session_key: str) -> None:

--- a/tests/test_agent_core_p2_reasoner.py
+++ b/tests/test_agent_core_p2_reasoner.py
@@ -113,6 +113,92 @@ def test_default_reasoner_runs_tool_loop_and_returns_reasoner_result():
     assert not any("未加载工具目录" in str(m.get("content", "")) for m in first_messages)
 
 
+def test_default_reasoner_blocks_disabled_tool_even_if_model_calls_it():
+    provider = _Provider(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[ToolCall("c1", "message_push", {"message": "天气"})],
+            ),
+            LLMResponse(content="最终天气", tool_calls=[]),
+        ]
+    )
+    push = _DummyTool("message_push")
+    tools = ToolRegistry()
+    tools.register(push, always_on=True, risk="external-side-effect")
+    reasoner = DefaultReasoner(
+        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=tools,
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=False,
+        memory_window=40,
+    )
+
+    result = asyncio.run(
+        reasoner.run(
+            [{"role": "user", "content": "发天气"}],
+            disabled_tools={"message_push"},
+        )
+    )
+
+    first_tool_names = [
+        schema["function"]["name"] for schema in provider.calls[0]["tools"]
+    ]
+    assert "message_push" not in first_tool_names
+    assert push.calls == []
+    assert result.reply == "最终天气"
+    assert result.metadata["tools_used"] == []
+    calls = result.metadata["tool_chain"][0]["calls"]
+    assert calls[0]["name"] == "message_push"
+    assert calls[0]["status"] == "blocked"
+
+
+def test_default_reasoner_tool_search_cannot_reunlock_disabled_tool():
+    provider = _Provider(
+        [
+            LLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall("s1", "tool_search", {"query": "select:message_push"})
+                ],
+            ),
+            LLMResponse(content="最终天气", tool_calls=[]),
+        ]
+    )
+    push = _DummyTool("message_push")
+    tools = ToolRegistry()
+    tools.register(ToolSearchTool(tools), always_on=True, risk="read-only")
+    tools.register(push, always_on=True, risk="external-side-effect")
+    reasoner = DefaultReasoner(
+        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=tools,
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=True,
+        memory_window=40,
+    )
+
+    result = asyncio.run(
+        reasoner.run(
+            [{"role": "user", "content": "发天气"}],
+            disabled_tools={"message_push"},
+        )
+    )
+
+    first_tool_names = [
+        schema["function"]["name"] for schema in provider.calls[0]["tools"]
+    ]
+    second_tool_names = [
+        schema["function"]["name"] for schema in provider.calls[1]["tools"]
+    ]
+    assert "message_push" not in first_tool_names
+    assert "message_push" not in second_tool_names
+    assert push.calls == []
+    assert result.reply == "最终天气"
+    assert "message_push" not in result.metadata["visible_names"]
+
+
 def test_default_reasoner_zero_max_iterations_is_unlimited():
     provider = _Provider(
         [

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -283,6 +283,26 @@ async def test_default_memory_engine_respects_skip_post_memory_event_flag():
     await event_bus.aclose()
 
 
+def test_markdown_maintenance_respects_skip_post_memory_event_flag():
+    maintenance = MarkdownMemoryMaintenance.__new__(MarkdownMemoryMaintenance)
+    maintenance._enqueue_maintenance = MagicMock()
+
+    maintenance.on_turn_committed(
+        TurnCommitted(
+            session_key="scheduler:job",
+            channel="telegram",
+            chat_id="1",
+            input_message="天气",
+            persisted_user_message=None,
+            assistant_response="不带伞",
+            tools_used=[],
+            extra={"skip_post_memory": True},
+        )
+    )
+
+    maintenance._enqueue_maintenance.assert_not_called()
+
+
 async def test_default_memory_engine_refreshes_recent_context_from_lifecycle():
     event_bus = EventBus()
     session = SimpleNamespace(

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -84,6 +84,8 @@ async def test_soft_calls_process_direct_not_push_directly(
     assert call_kwargs.kwargs["content"] == "查询北京天气"
     assert call_kwargs.kwargs["channel"] == "telegram"
     assert call_kwargs.kwargs["chat_id"] == "123"
+    assert call_kwargs.kwargs["skip_post_memory"] is True
+    assert call_kwargs.kwargs["disabled_tools"] == ["message_push"]
 
 
 async def test_soft_sends_ai_response_via_push(

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -21,7 +21,7 @@ from agent.retrieval.protocol import (
 from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
-from bus.events import InboundMessage
+from bus.events import InboundMessage, OutboundMessage
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryEngineRetrieveResult
 from bootstrap.wiring import wire_turn_lifecycle
@@ -99,6 +99,53 @@ def test_stream_events_only_support_telegram_private_chat():
     assert not _supports_stream_events("telegram", "@alice")
     assert not _supports_stream_events("qq", "123")
     assert not _supports_stream_events("cli", "direct")
+
+
+def test_stream_event_sink_respects_suppression_flag():
+    loop = object.__new__(AgentLoop)
+    loop._event_bus = EventBus()
+    msg = InboundMessage(
+        channel="telegram",
+        sender="u",
+        chat_id="123",
+        content="hello",
+        metadata={"suppress_stream_events": True},
+    )
+
+    assert AgentLoop._build_stream_event_sink(loop, msg) is None
+
+
+@pytest.mark.asyncio
+async def test_process_direct_suppresses_stream_and_memory_when_requested():
+    loop = object.__new__(AgentLoop)
+    loop._process = AsyncMock(
+        return_value=OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="ok",
+        )
+    )
+
+    result = await AgentLoop.process_direct(
+        loop,
+        content="天气",
+        session_key="scheduler:job",
+        channel="telegram",
+        chat_id="123",
+        omit_user_turn=True,
+        skip_post_memory=True,
+        disabled_tools=["message_push"],
+    )
+
+    msg = loop._process.await_args.args[0]
+    assert result == "ok"
+    assert msg.metadata == {
+        "omit_user_turn": True,
+        "skip_post_memory": True,
+        "suppress_stream_events": True,
+        "disabled_tools": ["message_push"],
+    }
+    assert loop._process.await_args.kwargs["dispatch_outbound"] is False
 
 
 def _make_loop(


### PR DESCRIPTION
## Summary

后台定时任务（scheduler）执行时不应该调用 `message_push` 向外推送消息，也不应该触发 post-memory 维护。新增通用的 `disabled_tools` / `skip_post_memory` / `suppress_stream_events` 机制，供 reasoner loop 各阶段拦截。

## 改动

- **agent/core/passive_turn.py** — Reasoner 新增 `disabled_tools` 参数：从 schemas 中移除禁用工具、模型误调用时直接回填 "不可用" 结果（`blocked` 状态）、tool_search 不会重新解锁禁用工具
- **agent/looping/core.py** — `process_direct()` 新增 `skip_post_memory` / `stream_events` / `disabled_tools`，通过 metadata 传递；stream event sink 支持 `suppress_stream_events` 标记关闭
- **agent/scheduler.py** — scheduler 调用后台任务时传入 `skip_post_memory=True`、`disabled_tools=["message_push"]`
- **core/memory/markdown.py** — `MarkdownMemoryMaintenance.on_turn_committed()` 检测 `skip_post_memory` 标记并跳过入队

## 影响

- 后台定时任务不会再通过 `message_push` 向用户推送消息
- 后台任务完成后不再触发 memory maintenance（减轻不必要的 IO），不影响用户主动发起的 turn
- stream events 在后台任务中被抑制，不产生无关的前端流式事件

## 验证

```
pytest tests/test_agent_core_p2_reasoner.py tests/test_scheduler_service.py tests/test_memory_engine_contract.py tests/test_turn_pipelines.py -q
```