### PR TITLE
fix(shell): 移除后台完成自动回调

### DIFF
--- a/agent/core/runner.py
+++ b/agent/core/runner.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from agent.looping.handlers import (
-    process_shell_completion_event,
-    process_spawn_completion_event,
-)
+from agent.looping.handlers import process_spawn_completion_event
 from bus.events import (
     InboundItem,
     InboundMessage,
     OutboundMessage,
-    ShellCompletionItem,
     SpawnCompletionItem,
 )
 
@@ -83,13 +79,6 @@ class CoreRunner:
                         dispatch_outbound=dispatch_outbound,
                     )
                 raise RuntimeError("spawn completion 缺少处理依赖")
-            case ShellCompletionItem():
-                return await process_shell_completion_event(
-                    item=msg,
-                    key=key,
-                    pipeline=self._agent_core.pipeline,
-                    dispatch_outbound=dispatch_outbound,
-                )
             case InboundMessage():
                 # 2. 默认普通被动消息统一走 AgentCore。
                 return await self._agent_core.process(

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -38,7 +38,6 @@ from bus.events import (
     InboundItem,
     InboundMessage,
     OutboundMessage,
-    ShellCompletionItem,
     SpawnCompletionItem,
 )
 from bus.events_lifecycle import (
@@ -95,10 +94,6 @@ def _suppresses_stream_events(msg: object) -> bool:
 def _item_content(item: InboundItem) -> str:
     if isinstance(item, InboundMessage):
         return item.content
-    if isinstance(item, ShellCompletionItem):
-        event = item.event
-        label = event.description or event.command or event.task_id
-        return f"[后台 shell 完成] {label}"
     return f"[后台任务完成] {item.event.label or item.event.status or item.event.job_id}"
 
 
@@ -515,12 +510,6 @@ class AgentLoop:
                     original_metadata=dict(item.metadata or {}),
                 )
             case SpawnCompletionItem():
-                return TurnInterruptState(
-                    session_key=key,
-                    original_user_message=_item_content(item),
-                    original_metadata={},
-                )
-            case ShellCompletionItem():
                 return TurnInterruptState(
                     session_key=key,
                     original_user_message=_item_content(item),

--- a/agent/looping/handlers.py
+++ b/agent/looping/handlers.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, cast
 from agent.core.runtime_support import AgentLoopRunner, PromptRenderRunner, TurnRunResult
 from agent.lifecycle.types import PromptRenderInput
 from agent.looping.ports import SessionServices
-from agent.tools.shell import is_shell_completion_consumed
-from bus.events import InboundMessage, OutboundMessage, ShellCompletionItem, SpawnCompletionItem
+from bus.events import InboundMessage, OutboundMessage, SpawnCompletionItem
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import PassiveTurnPipeline
@@ -125,62 +124,6 @@ async def process_spawn_completion_event(
             reply=final_content,
             tools_used=tools_used,
             tool_chain=parsed_tool_chain,
-        ),
-        dispatch_outbound=dispatch_outbound,
-    )
-
-
-async def process_shell_completion_event(
-    *,
-    item: ShellCompletionItem,
-    key: str,
-    pipeline: "PassiveTurnPipeline",
-    dispatch_outbound: bool = True,
-) -> OutboundMessage:
-    event = item.event
-    label = event.description.strip() or event.command.strip() or event.task_id
-    if is_shell_completion_consumed(event.task_id):
-        return OutboundMessage(
-            channel=item.channel,
-            chat_id=item.chat_id,
-            content="",
-            metadata={"shell_completion_consumed": True},
-        )
-    status_label = {
-        "completed": "完成",
-        "failed": "失败",
-        "timeout": "超时",
-    }.get(event.status, event.status or "完成")
-    exit_code = "null" if event.exit_code is None else str(event.exit_code)
-    output = event.output.strip() or "（无输出）"
-    truncation = "\n输出已截断，完整日志见 output_path。" if event.output_truncated else ""
-    reply = (
-        f"后台命令已{status_label}：{label}\n"
-        f"退出码：{exit_code}\n"
-        f"耗时：{event.duration_ms}ms\n"
-        f"日志：{event.output_path}\n\n"
-        f"输出：\n{output}{truncation}"
-    )
-    pseudo_msg = InboundMessage(
-        channel=item.channel,
-        sender="shell",
-        chat_id=item.chat_id,
-        content=f"[后台 shell 完成] {label}",
-        timestamp=item.timestamp,
-        media=[],
-        metadata={
-            "omit_user_turn": True,
-            "skip_post_memory": True,
-            "shell_completion": True,
-        },
-    )
-    return await pipeline.post_reasoning(
-        msg=pseudo_msg,
-        session_key=key,
-        turn_result=TurnRunResult(
-            reply=reply,
-            tools_used=[],
-            tool_chain=[],
         ),
         dispatch_outbound=dispatch_outbound,
     )

--- a/agent/tools/meta/register.py
+++ b/agent/tools/meta/register.py
@@ -12,7 +12,6 @@ from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
 from agent.tools.shell import ShellTool, ShellTaskOutputTool, ShellTaskStopTool
 from agent.tools.tool_search import ToolSearchTool
-from bus.queue import MessageBus
 
 _MEMORY_TOOL_NAMES = {"recall_memory", "memorize", "forget_memory"}
 
@@ -22,11 +21,10 @@ def register_common_meta_tools(
     readonly_tools: dict[str, Tool],
     session_store: Any,
     push_tool: MessagePushTool | None = None,
-    bus: MessageBus | None = None,
 ) -> MessagePushTool:
     tools.register(ToolSearchTool(tools), always_on=True, risk="read-only")
     tools.register(
-        ShellTool(completion_bus=bus),
+        ShellTool(),
         always_on=True,
         risk="external-side-effect",
         search_hint="终端 脚本 bash 命令",

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -30,9 +30,6 @@ import time
 from typing import Any, Callable, cast
 
 from agent.tools.base import Tool
-from bus.events import ShellCompletionItem
-from bus.internal_events import ShellCompletionEvent
-from bus.queue import MessageBus
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +37,6 @@ _DEFAULT_TIMEOUT = 60  # 秒（OpenCode 默认 1 分钟）
 _FG_THRESHOLD = 15    # 前台最长等待秒数；超时自动转后台
 _MAX_TIMEOUT = 600  # 秒（OpenCode 最大 10 分钟）
 _MAX_OUTPUT = 30_000  # 字符（与 OpenCode MaxOutputLength 一致）
-_COMPLETION_OUTPUT_MAX = 6000
 _STREAM_CHUNK_SIZE = 4096
 _STREAM_DRAIN_GRACE_S = 0.2
 _BG_TTL_S = 4 * 3600  # 后台任务最长存活时间：4 小时
@@ -118,21 +114,14 @@ class _BackgroundTask:
     wall_started_at_ms: int          # epoch ms，返回给 LLM
     command: str = ""
     description: str = ""
-    channel: str = ""
-    chat_id: str = ""
-    completion_bus: MessageBus | None = None
     last_output_at_ms: int | None = None  # epoch ms，每次写文件时更新
     timeout_s: int | None = None
     timeout_handle: asyncio.TimerHandle | None = None
     finish_reason: str = "natural"
-    suppress_completion: bool = False
-    completion_dispatched: bool = False
-    completion_consumed: bool = False
 
 
 # 模块级单例：跨 ShellTool 实例共享
 _BG_REGISTRY: dict[str, _BackgroundTask] = {}
-_CONSUMED_COMPLETIONS: set[str] = set()
 
 
 async def _bg_pump(
@@ -199,84 +188,7 @@ def _schedule_eviction(task_id: str, log_path: str) -> None:
     loop.call_later(_BG_EVICT_DELAY_S, _evict)
 
 
-def _completion_output(log_path: str) -> tuple[str, bool]:
-    try:
-        content = Path(log_path).read_bytes().decode(errors="replace")
-    except OSError:
-        content = ""
-    if len(content) <= _COMPLETION_OUTPUT_MAX:
-        return content, False
-    return content[-_COMPLETION_OUTPUT_MAX:], True
-
-
-def _shell_completion_status(task: _BackgroundTask) -> str:
-    if task.finish_reason == "timeout":
-        return "timeout"
-    exit_code = task.proc.returncode
-    return "completed" if exit_code == 0 else "failed"
-
-
-def _mark_shell_completion_consumed(
-    task_id: str,
-    task: _BackgroundTask | None = None,
-) -> None:
-    _CONSUMED_COMPLETIONS.add(task_id)
-    target = task or _BG_REGISTRY.get(task_id)
-    if target is None:
-        return
-    target.completion_consumed = True
-    target.suppress_completion = True
-
-
-def is_shell_completion_consumed(task_id: str) -> bool:
-    if task_id in _CONSUMED_COMPLETIONS:
-        return True
-    task = _BG_REGISTRY.get(task_id)
-    return bool(task is not None and task.completion_consumed)
-
-
-def _publish_shell_completion(task_id: str, task: _BackgroundTask) -> None:
-    if is_shell_completion_consumed(task_id):
-        return
-    if task.suppress_completion or task.completion_dispatched:
-        return
-    if task.completion_bus is None or not task.channel or not task.chat_id:
-        return
-    output, truncated = _completion_output(task.log_path)
-    task.completion_dispatched = True
-    duration_ms = int((time.monotonic() - task.started_at) * 1000)
-    item = ShellCompletionItem(
-        channel=task.channel,
-        chat_id=task.chat_id,
-        event=ShellCompletionEvent(
-            task_id=task_id,
-            description=task.description,
-            command=task.command,
-            status=_shell_completion_status(task),
-            exit_code=task.proc.returncode,
-            duration_ms=duration_ms,
-            output=output,
-            output_path=task.log_path,
-            output_truncated=truncated,
-        ),
-    )
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return
-    publish_task = loop.create_task(task.completion_bus.publish_inbound(item))
-
-    def _log_publish_error(done: asyncio.Task) -> None:
-        try:
-            done.result()
-        except Exception:
-            logger.exception("shell completion publish failed task_id=%s", task_id)
-
-    publish_task.add_done_callback(_log_publish_error)
-
-
 def _on_background_task_done(task_id: str, task: _BackgroundTask) -> None:
-    _publish_shell_completion(task_id, task)
     _schedule_eviction(task_id, task.log_path)
 
 
@@ -313,10 +225,7 @@ def _bg_kill(task_id: str, *, finish_reason: str = "stopped") -> None:
     task = _BG_REGISTRY.pop(task_id, None)
     if task is None:
         return
-    _CONSUMED_COMPLETIONS.add(task_id)
     task.finish_reason = finish_reason
-    task.suppress_completion = True
-    task.completion_consumed = True
     if task.timeout_handle is not None:
         task.timeout_handle.cancel()
     try:
@@ -335,17 +244,7 @@ def _bg_timeout(task_id: str) -> None:
     task = _BG_REGISTRY.get(task_id)
     if task is None:
         return
-    if task.completion_bus is None or not task.channel or not task.chat_id:
-        _bg_kill(task_id, finish_reason="timeout")
-        return
-    task.finish_reason = "timeout"
-    if task.timeout_handle is not None:
-        task.timeout_handle.cancel()
-        task.timeout_handle = None
-    try:
-        _kill_process_tree(task.proc)
-    except (ProcessLookupError, PermissionError):
-        pass
+    _bg_kill(task_id, finish_reason="timeout")
 
 
 # ── ShellTool ────────────────────────────────────────────────────────
@@ -363,13 +262,11 @@ class ShellTool(Tool):
         working_dir: Path | None = None,
         restricted_dir: Path | None = None,
         spawn_hook: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-        completion_bus: MessageBus | None = None,
     ) -> None:
         self._allow_network = allow_network
         self._working_dir = working_dir
         self._restricted_dir = restricted_dir.resolve() if restricted_dir else None
         self._spawn_hook = spawn_hook
-        self._completion_bus = completion_bus
 
     @property
     def description(self) -> str:
@@ -385,8 +282,9 @@ class ShellTool(Tool):
             "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；只有显式设置 timeout，后台才会继续沿用这个硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false，并显式配置 timeout\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
-            "- 收到 background_task_id 后，不要为了等待完成而反复调用 task_output；后台结束会自动回传。"
-            "只在需要查看实时输出或判断卡死时调用 task_output，若判断卡死则 task_stop 终止\n"
+            "- 收到 background_task_id 后，由你负责用 task_output 主动查看进展和结果；不会有系统自动回传\n"
+            "- 等待后台任务结果时，使用 task_output 的 block=true 并设置合理 timeout_ms，避免高频轮询\n"
+            "- 如果决定放弃后台任务并准备最终回复，必须先调用 task_stop 终止它\n"
             "禁止用途：不得用 shell 替代专用工具（read_file 读文件、web_fetch 抓网页、list_dir 列目录）。"
         )
 
@@ -441,8 +339,6 @@ class ShellTool(Tool):
         timeout_specified = "timeout" in kwargs and kwargs.get("timeout") is not None
         run_in_background: bool = bool(kwargs.get("run_in_background", False))
         auto_promote: bool = bool(kwargs.get("auto_promote", True))
-        channel = str(kwargs.get("channel", "") or "")
-        chat_id = str(kwargs.get("chat_id", "") or "")
         on_data = kwargs.get("_on_data")
 
         if not command:
@@ -485,7 +381,7 @@ class ShellTool(Tool):
         if run_in_background:
             bg_timeout = timeout if timeout_specified else None
             return await self._execute_background(
-                command, description, cwd, env, bg_timeout, channel, chat_id
+                command, description, cwd, env, bg_timeout
             )
 
         # ── 前台路径（默认 15s 未完成自动转后台）──────────────────────
@@ -501,8 +397,6 @@ class ShellTool(Tool):
             timeout_specified,
             data_callback,
             auto_promote,
-            channel,
-            chat_id,
         )
 
     async def _execute_background(
@@ -512,8 +406,6 @@ class ShellTool(Tool):
         cwd: Path | None,
         env: dict[str, str],
         timeout_s: int | None,
-        channel: str,
-        chat_id: str,
     ) -> str:
         task_id = f"shell_{uuid4().hex[:12]}"
         log_fd, log_path = tempfile.mkstemp(
@@ -535,9 +427,6 @@ class ShellTool(Tool):
             wall_started_at_ms=wall_start_ms,
             command=command,
             description=description,
-            channel=channel,
-            chat_id=chat_id,
-            completion_bus=self._completion_bus,
             timeout_s=timeout_s,
         )
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg))
@@ -571,8 +460,6 @@ class ShellTool(Tool):
         timeout_specified: bool,
         on_data: Callable[[str], None] | None,
         auto_promote: bool,
-        channel: str,
-        chat_id: str,
     ) -> str:
         """前台执行；允许按需关闭自动转后台，直接等待完整结果。"""
         task_id = f"shell_{uuid4().hex[:12]}"
@@ -597,9 +484,6 @@ class ShellTool(Tool):
             wall_started_at_ms=wall_start_ms,
             command=command,
             description=description,
-            channel=channel,
-            chat_id=chat_id,
-            completion_bus=self._completion_bus,
             timeout_s=hard_timeout_s,
         )
         pump = asyncio.create_task(_bg_pump(proc, log_path, bg, on_data))
@@ -773,8 +657,9 @@ class ShellTaskOutputTool(Tool):
             "  - 任务挂起：有过输出但 since_last_output_ms 异常大，不符合该命令的预期节奏\n"
             "  - 任务卡死：从未有过输出（since_last_output_ms=null）且 elapsed_ms 超过合理预期\n"
             "不需要 stop 的情况：编译、下载、训练等明确会结束的长时间任务，或用户主动要求的服务进程。\n"
-            "- block=true 时会等待任务完成或 timeout_ms 超时后再返回；不要用它反复等待后台任务完成。\n"
-            "- 如果返回 status=done，本轮必须负责向用户汇报结果，系统不会再额外发送自动完成回灌"
+            "- block=true 是等待后台任务结果的推荐方式；设置合理 timeout_ms 后轮询一次，再判断继续等待、汇报结果或 task_stop。\n"
+            "- 如果你决定放弃某个后台任务、准备输出最终回复，必须先调用 task_stop 将其终止，再生成回复。不要让后台任务在你回复后继续孤立运行。\n"
+            "- 如果返回 status=done，本轮必须负责处理结果，不会有任何系统自动回传。"
         )
 
     @property
@@ -824,8 +709,6 @@ class ShellTaskOutputTool(Tool):
                 pass
 
         done = pump_task.done()
-        if done:
-            _mark_shell_completion_consumed(task_id, task)
         if done and time.monotonic() - task.started_at > _BG_TTL_S:
             if task_id in _BG_REGISTRY:
                 del _BG_REGISTRY[task_id]

--- a/bootstrap/toolsets/meta.py
+++ b/bootstrap/toolsets/meta.py
@@ -32,7 +32,6 @@ class CommonMetaToolsetProvider(ToolsetProvider):
             self._readonly_tools,
             deps.session_store,
             push_tool=deps.push_tool,
-            bus=deps.bus,
         )
 
         # 主模型不支持多模态时，注册视觉工具供模型调用

--- a/bus/events.py
+++ b/bus/events.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from agent.policies.delegation import SpawnDecision
-    from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
+    from bus.internal_events import SpawnCompletionEvent
 
 
 def _empty_media() -> list[str]:
@@ -63,18 +63,4 @@ class SpawnCompletionItem:
         return f"{self.channel}:{self.chat_id}"
 
 
-@dataclass
-class ShellCompletionItem:
-    """后台 shell 完成后的内部回灌项。"""
-
-    channel: str
-    chat_id: str
-    event: "ShellCompletionEvent"
-    timestamp: datetime = field(default_factory=datetime.now)
-
-    @property
-    def session_key(self) -> str:
-        return f"{self.channel}:{self.chat_id}"
-
-
-InboundItem = InboundMessage | SpawnCompletionItem | ShellCompletionItem
+InboundItem = InboundMessage | SpawnCompletionItem

--- a/bus/internal_events.py
+++ b/bus/internal_events.py
@@ -15,16 +15,3 @@ class SpawnCompletionEvent:
     result: str
     retry_count: int = 0
     profile: str = ""
-
-
-@dataclass(frozen=True)
-class ShellCompletionEvent:
-    task_id: str
-    description: str
-    command: str
-    status: str
-    exit_code: int | None
-    duration_ms: int
-    output: str
-    output_path: str
-    output_truncated: bool = False

--- a/docker/debug/shell_background_probe.py
+++ b/docker/debug/shell_background_probe.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+"""
+shell_background_probe.py
+
+验证新版 shell 后台设计：agent 能自主发现卡死任务并调用 task_stop，
+整个生命周期在单次 turn 内完成，不依赖系统自动回调。
+
+被测行为：
+  1. agent 对外观无害的命令启动 shell
+  2. 命令 15s 后 auto-promote 转后台，agent 拿到 task_id
+  3. agent 用 task_output 轮询，发现从无输出（since_last_output_ms=null）
+  4. agent 判定卡死，调用 task_stop
+  5. agent 给用户一条最终回复，整个 turn 内完成，无孤悬后台进程
+"""
 from __future__ import annotations
 
 import argparse
@@ -14,6 +27,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+
+# ── 路径 ─────────────────────────────────────────────────────────────
 
 @dataclass
 class ProbePaths:
@@ -45,14 +60,12 @@ class ProbePaths:
     def observe_db(self) -> Path:
         return self.workspace / "observe" / "observe.db"
 
-    @property
-    def memory_db(self) -> Path:
-        return self.workspace / "memory" / "memory2.db"
-
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
+
+# ── Docker / 配置 ─────────────────────────────────────────────────────
 
 def _run_compose(paths: ProbePaths, args: list[str]) -> None:
     _ = subprocess.run(
@@ -75,12 +88,7 @@ def _bootstrap_profile(paths: ProbePaths, from_profile: str | None) -> None:
     shutil.copy2(src, paths.config)
 
 
-def _replace_section_value(
-    text: str,
-    section_name: str,
-    key: str,
-    value: str,
-) -> str:
+def _replace_section_value(text: str, section_name: str, key: str, value: str) -> str:
     marker = f"[{section_name}]\n"
     if marker not in text:
         return text
@@ -106,6 +114,8 @@ def _isolate_cli_config(config_path: Path) -> str:
     return original
 
 
+# ── DB ────────────────────────────────────────────────────────────────
+
 def _connect_db(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(path, timeout=10)
     conn.row_factory = sqlite3.Row
@@ -117,13 +127,7 @@ def _latest_cli_session_key(db_path: Path) -> str:
     conn = _connect_db(db_path)
     try:
         row = conn.execute(
-            """
-            select key
-            from sessions
-            where key like 'cli:%'
-            order by updated_at desc
-            limit 1
-            """
+            "select key from sessions where key like 'cli:%' order by updated_at desc limit 1"
         ).fetchone()
         return str(row["key"]) if row else ""
     finally:
@@ -143,147 +147,121 @@ def _session_messages(db_path: Path, session_key: str) -> list[dict[str, Any]]:
     conn = _connect_db(db_path)
     try:
         rows = conn.execute(
-            """
-            select seq, role, content, tool_chain, extra, ts
-            from messages
-            where session_key = ?
-            order by seq
-            """,
+            "select seq, role, content, tool_chain, extra, ts from messages "
+            "where session_key = ? order by seq",
             (session_key,),
         ).fetchall()
     finally:
         conn.close()
     result: list[dict[str, Any]] = []
     for row in rows:
-        extra = _json_loads(row["extra"]) or {}
-        result.append(
-            {
-                "seq": int(row["seq"]),
-                "role": str(row["role"]),
-                "content": str(row["content"] or ""),
-                "tool_chain": _json_loads(row["tool_chain"]),
-                "extra": extra,
-                "ts": str(row["ts"]),
-            }
-        )
+        result.append({
+            "seq": int(row["seq"]),
+            "role": str(row["role"]),
+            "content": str(row["content"] or ""),
+            "tool_chain": _json_loads(row["tool_chain"]),
+            "extra": _json_loads(row["extra"]) or {},
+            "ts": str(row["ts"]),
+        })
     return result
 
 
-def _observe_turns(db_path: Path, session_key: str) -> list[dict[str, Any]]:
-    if not db_path.exists():
+# ── 工具调用提取 ──────────────────────────────────────────────────────
+
+def _flatten_calls(tool_chain: Any) -> list[dict[str, Any]]:
+    """从 tool_chain 里按顺序提取所有工具调用。"""
+    if not isinstance(tool_chain, list):
         return []
-    conn = _connect_db(db_path)
-    try:
-        rows = conn.execute(
-            """
-            select id, user_msg, tool_calls, error
-            from turns
-            where session_key = ?
-            order by id
-            """,
-            (session_key,),
-        ).fetchall()
-    except sqlite3.Error:
-        return []
-    finally:
-        conn.close()
-    return [
-        {
-            "id": int(row["id"]),
-            "user": str(row["user_msg"] or ""),
-            "tool_calls": _json_loads(row["tool_calls"]) or [],
-            "error": str(row["error"] or ""),
-        }
-        for row in rows
-    ]
+    calls: list[dict[str, Any]] = []
+    for group in tool_chain:
+        if not isinstance(group, dict):
+            continue
+        for call in group.get("calls") or []:
+            if isinstance(call, dict):
+                calls.append(call)
+    return calls
 
 
-def _memory_baseline(memory_db: Path) -> dict[str, str]:
-    if not memory_db.exists():
-        return {}
-    conn = _connect_db(memory_db)
-    try:
-        rows = conn.execute("select id, updated_at from memory_items").fetchall()
-    except sqlite3.Error:
-        return {}
-    finally:
-        conn.close()
-    return {str(row["id"]): str(row["updated_at"] or "") for row in rows}
+def _calls_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg["role"] == "assistant":
+            calls.extend(_flatten_calls(msg.get("tool_chain")))
+    return calls
 
 
-def _changed_memory_items(
-    memory_db: Path,
-    baseline: dict[str, str],
-) -> list[dict[str, str]]:
-    if not memory_db.exists():
-        return []
-    conn = _connect_db(memory_db)
-    try:
-        rows = conn.execute(
-            """
-            select id, memory_type, summary, source_ref, updated_at
-            from memory_items
-            order by updated_at
-            """
-        ).fetchall()
-    except sqlite3.Error:
-        return []
-    finally:
-        conn.close()
-    return [
-        {
-            "id": str(row["id"]),
-            "memory_type": str(row["memory_type"] or ""),
-            "summary": str(row["summary"] or ""),
-            "source_ref": str(row["source_ref"] or ""),
-        }
-        for row in rows
-        if baseline.get(str(row["id"])) != str(row["updated_at"] or "")
-    ]
+# ── Checks ────────────────────────────────────────────────────────────
 
-
-def _memory_writes(
-    observe_db: Path,
-    session_key: str,
-    started_at: str,
-) -> list[dict[str, str]]:
-    if not observe_db.exists():
-        return []
-    conn = _connect_db(observe_db)
-    try:
-        rows = conn.execute(
-            """
-            select action, item_id, memory_type, summary, source_ref, ts
-            from memory_writes
-            where session_key = ? and ts >= ?
-            order by id
-            """,
-            (session_key, started_at),
-        ).fetchall()
-    except sqlite3.Error:
-        return []
-    finally:
-        conn.close()
-    return [
-        {
-            "action": str(row["action"] or ""),
-            "item_id": str(row["item_id"] or ""),
-            "memory_type": str(row["memory_type"] or ""),
-            "summary": str(row["summary"] or ""),
-            "source_ref": str(row["source_ref"] or ""),
-            "ts": str(row["ts"] or ""),
-        }
-        for row in rows
-    ]
-
-
-async def _read_assistant(
-    reader: asyncio.StreamReader,
-    timeout: float,
+def _build_checks(
+    *,
+    responses: list[dict[str, Any]],
+    messages: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    all_calls = _calls_from_messages(messages)
+    call_names = [c.get("name", "") for c in all_calls]
+
+    shell_idx = next((i for i, n in enumerate(call_names) if n == "shell"), -1)
+    task_output_idx = next((i for i, n in enumerate(call_names) if n == "task_output"), -1)
+    task_stop_idx = next((i for i, n in enumerate(call_names) if n == "task_stop"), -1)
+
+    assistant_messages = [m for m in messages if m["role"] == "assistant"]
+    # 旧格式消息："后台命令已..." 由已删除的 process_shell_completion_event 生成
+    old_format_messages = [
+        m for m in assistant_messages if "后台命令已" in m["content"]
+    ]
+
+    # task_output 调用里有没有拿到 status=done（不应该，死循环不会自然结束）
+    task_output_done = any(
+        _json_loads(c.get("output", "")) is not None
+        and isinstance(_json_loads(c.get("output", "")), dict)
+        and _json_loads(c.get("output", "")).get("status") == "done"
+        for c in all_calls
+        if c.get("name") == "task_output"
+    )
+
+    checks: dict[str, Any] = {
+        # 核心行为验证
+        "shell_called": shell_idx >= 0,
+        "task_output_called": task_output_idx >= 0,
+        "task_stop_called": task_stop_idx >= 0,
+        # 顺序：shell → task_output → task_stop
+        "correct_call_order": (
+            shell_idx >= 0
+            and task_output_idx > shell_idx
+            and task_stop_idx > task_output_idx
+        ),
+        # 单 turn 内完成，无孤悬回调产生的额外消息
+        "single_assistant_turn": len(assistant_messages) == 1,
+        # 旧格式的自动回调消息不再出现
+        "no_old_completion_format": len(old_format_messages) == 0,
+        # 死循环不应该自然结束，agent 不应该看到 status=done
+        "task_not_done_naturally": not task_output_done,
+        # 调用序列摘要（供报告查看）
+        "call_sequence": call_names,
+    }
+    checks["passed"] = all(
+        bool(checks[k])
+        for k in (
+            "shell_called",
+            "task_output_called",
+            "task_stop_called",
+            "correct_call_order",
+            "single_assistant_turn",
+            "no_old_completion_format",
+        )
+    )
+    return checks
+
+
+# ── CLI 通信 ──────────────────────────────────────────────────────────
+
+async def _read_assistant(reader: asyncio.StreamReader, timeout: float) -> dict[str, Any]:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        line = await asyncio.wait_for(reader.readline(), timeout=deadline - time.monotonic())
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        line = await asyncio.wait_for(reader.readline(), timeout=remaining)
         if not line:
             raise RuntimeError("CLI 连接已断开")
         data = json.loads(line)
@@ -295,106 +273,14 @@ async def _read_assistant(
     raise TimeoutError("等待 assistant 回复超时")
 
 
-async def _send(
-    writer: asyncio.StreamWriter,
-    text: str,
-) -> None:
+async def _send(writer: asyncio.StreamWriter, text: str) -> None:
     writer.write((json.dumps({"content": text}, ensure_ascii=False) + "\n").encode())
     await writer.drain()
 
 
-def _extract_marker(text: str) -> str:
-    match = re.search(r"AKASHIC_BG_DONE_[0-9a-f]{32}", text)
-    return match.group(0) if match else ""
+# ── 报告 ──────────────────────────────────────────────────────────────
 
-
-def _has_shell_tool(msg: dict[str, Any]) -> bool:
-    extra = msg.get("extra") if isinstance(msg.get("extra"), dict) else {}
-    tools_used = extra.get("tools_used") if isinstance(extra, dict) else None
-    if isinstance(tools_used, list) and "shell" in tools_used:
-        return True
-    chain = msg.get("tool_chain")
-    if not isinstance(chain, list):
-        return False
-    for group in chain:
-        if not isinstance(group, dict):
-            continue
-        calls = group.get("calls")
-        if not isinstance(calls, list):
-            continue
-        for call in calls:
-            if isinstance(call, dict) and call.get("name") == "shell":
-                return True
-    return False
-
-
-def _build_checks(
-    *,
-    responses: list[dict[str, Any]],
-    messages: list[dict[str, Any]],
-    memory_writes: list[dict[str, str]],
-    memory_items: list[dict[str, str]],
-) -> dict[str, Any]:
-    completion_messages = [
-        msg
-        for msg in messages
-        if msg["role"] == "assistant" and "后台命令已" in msg["content"]
-    ]
-    first_shell_messages = [
-        msg
-        for msg in messages
-        if msg["role"] == "assistant" and _has_shell_tool(msg)
-    ]
-    marker = ""
-    for row in responses:
-        marker = _extract_marker(row["content"])
-        if marker:
-            break
-    memory_blob = "\n".join(
-        [
-            *(row["summary"] + "\n" + row["source_ref"] for row in memory_writes),
-            *(row["summary"] + "\n" + row["source_ref"] for row in memory_items),
-        ]
-    )
-    fake_user_rows = [
-        msg
-        for msg in messages
-        if msg["role"] == "user" and "[后台 shell 完成]" in msg["content"]
-    ]
-    completion_uses_shell = [
-        msg
-        for msg in completion_messages
-        if _has_shell_tool(msg)
-    ]
-    checks = {
-        "first_turn_used_shell": bool(first_shell_messages),
-        "has_auto_completion_message": bool(completion_messages),
-        "no_fake_user_shell_completion": not fake_user_rows,
-        "completion_tools_used_is_empty": not completion_uses_shell,
-        "completion_marker_observed": bool(marker),
-        "completion_marker_not_in_memory": bool(marker) and marker not in memory_blob,
-        "assistant_completion_count": len(completion_messages),
-        "exact_marker": marker,
-    }
-    checks["passed"] = all(
-        bool(checks[name])
-        for name in (
-            "first_turn_used_shell",
-            "has_auto_completion_message",
-            "no_fake_user_shell_completion",
-            "completion_tools_used_is_empty",
-            "completion_marker_observed",
-            "completion_marker_not_in_memory",
-        )
-    )
-    return checks
-
-
-def _write_report(
-    *,
-    report_base: Path,
-    payload: dict[str, Any],
-) -> None:
+def _write_report(*, report_base: Path, payload: dict[str, Any]) -> None:
     report_base.parent.mkdir(parents=True, exist_ok=True)
     report_json = report_base.with_suffix(".json")
     report_md = report_base.with_suffix(".md")
@@ -402,58 +288,59 @@ def _write_report(
         json.dumps(payload, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    checks = payload["checks"]
     lines = [
         "# shell background probe",
         "",
-        "```text",
-        "docker/debug profile",
-        "  |",
-        "  +-- cli user prompt",
-        "  |     |",
-        "  |     +-- shell auto-promote after 15s",
-        "  |",
-        "  +-- shell completion inbound",
-        "        |",
-        "        +-- assistant-only persistence",
+        "验证 agent 能自主发现卡死的后台 shell 任务并调用 task_stop，",
+        "整个生命周期在单次 turn 内完成，不依赖系统自动回调。",
+        "",
+        "```",
+        "shell(死循环命令)",
+        "  └─ auto-promote 15s → task_id",
+        "       └─ task_output(block=true) → since_last_output_ms=null",
+        "            └─ task_stop → 最终回复（单 turn 完成）",
         "```",
         "",
         f"- profile: {payload['profile']}",
         f"- session_key: {payload['session_key']}",
-        f"- passed: {payload['checks']['passed']}",
-        f"- exact_marker: {payload['checks']['exact_marker']}",
+        f"- passed: **{checks['passed']}**",
         "",
         "## Checks",
         "",
     ]
-    for key, value in payload["checks"].items():
-        lines.append(f"- {key}: {value}")
-    lines.extend(["", "## Responses", ""])
-    for index, row in enumerate(payload["responses"], 1):
-        lines.extend([f"### Response {index}", "", row["content"], ""])
+    for key, value in checks.items():
+        if key == "call_sequence":
+            lines.append(f"- call_sequence: {' → '.join(value) if value else '(empty)'}")
+        else:
+            icon = "✓" if value else "✗"
+            lines.append(f"- {icon} {key}: {value}")
+    lines.extend(["", "## Agent Response", ""])
+    for i, r in enumerate(payload["responses"], 1):
+        lines.extend([f"### Response {i}", "", r["content"], ""])
     lines.extend(["## Session Messages", ""])
     for row in payload["session_messages"]:
         content = row["content"].replace("\n", "\\n")
-        if len(content) > 180:
-            content = content[:180] + "..."
-        tools_used = row["extra"].get("tools_used") if isinstance(row["extra"], dict) else None
-        lines.append(
-            f"- seq={row['seq']} role={row['role']} tools_used={tools_used} content={content}"
-        )
-    lines.extend(["", "## Memory Writes", ""])
-    if payload["memory_writes"]:
-        for row in payload["memory_writes"]:
-            lines.append(f"- {row['action']} [{row['memory_type']}] {row['summary']}")
-    else:
-        lines.append("- none")
-    lines.extend(["", "## Changed Memory Items", ""])
-    if payload["changed_memory_items"]:
-        for row in payload["changed_memory_items"]:
-            lines.append(f"- [{row['memory_type']}] {row['summary']}")
-    else:
-        lines.append("- none")
+        if len(content) > 200:
+            content = content[:200] + "..."
+        tools = row["extra"].get("tools_used") if isinstance(row["extra"], dict) else None
+        lines.append(f"- seq={row['seq']} role={row['role']} tools={tools} | {content}")
     report_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
     print(f"markdown: {report_md}")
-    print(f"json: {report_json}")
+    print(f"json:     {report_json}")
+
+
+# ── 主流程 ────────────────────────────────────────────────────────────
+
+# 死循环命令：外表像"运行中"，实际永远无输出
+# iter(int, 1) 是永远不停的迭代器；time.sleep(1) 让进程安静占着 CPU
+_HIDDEN_LOOP_COMMAND = "python3 -c \"import time; [time.sleep(1) for _ in iter(int, 1)]\""
+
+# 发给 agent 的 prompt：不暴露循环意图，agent 只能通过 task_output 观察到什么都没输出
+_PROBE_PROMPT = (
+    "帮我运行下面这个命令，告诉我它的输出是什么。\n\n"
+    f"命令：{_HIDDEN_LOOP_COMMAND}"
+)
 
 
 async def _run_probe(args: argparse.Namespace) -> None:
@@ -468,17 +355,12 @@ async def _run_probe(args: argparse.Namespace) -> None:
     try:
         if args.reset_workspace:
             _run_compose(paths, ["run", "--rm", "akashic-debug", "reset-workspace"])
+
         if args.start_agent:
             paths.socket.unlink(missing_ok=True)
             proc = subprocess.Popen(
-                [
-                    "docker",
-                    "compose",
-                    "-f",
-                    str(paths.debug_dir / "docker-compose.yml"),
-                    "up",
-                    "akashic-debug",
-                ],
+                ["docker", "compose", "-f", str(paths.debug_dir / "docker-compose.yml"),
+                 "up", "akashic-debug"],
                 cwd=paths.repo,
                 env={**dict(os.environ), "AKASHIC_DEBUG_PROFILE": paths.profile},
                 stdout=subprocess.DEVNULL if args.quiet_agent else None,
@@ -492,70 +374,54 @@ async def _run_probe(args: argparse.Namespace) -> None:
             if not paths.socket.exists():
                 raise SystemExit(f"等待 socket 超时: {paths.socket}")
 
-        started_at = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
-        memory_baseline = _memory_baseline(paths.memory_db)
         reader, writer = await asyncio.open_unix_connection(str(paths.socket))
-        command = (
-            "python -c 'import time, uuid; "
-            'print("AKASHIC_BG_START", flush=True); '
-            "time.sleep(18); "
-            'print("AKASHIC_BG_DONE_"+uuid.uuid4().hex, flush=True)' "'"
-        )
-        prompt = (
-            "请真实调用 shell 工具执行下面这个命令，不要用文字模拟。"
-            "不要设置 timeout，不要设置 run_in_background=true，让它按默认 15 秒自动转后台。"
-            "拿到 background_task_id 后只告诉我任务已转后台，不要调用 task_output。\n\n"
-            f"命令：{command}"
-        )
         responses: list[dict[str, Any]] = []
         try:
-            await _send(writer, prompt)
-            first = await _read_assistant(reader, args.turn_timeout)
-            responses.append(first)
-            print(f"first response: {first['content'][:120]}")
-            deadline = time.monotonic() + args.completion_timeout
-            while time.monotonic() < deadline:
-                item = await _read_assistant(
-                    reader,
-                    max(1.0, deadline - time.monotonic()),
-                )
-                responses.append(item)
-                print(f"completion candidate: {item['content'][:120]}")
-                if _extract_marker(item["content"]) or "后台命令已" in item["content"]:
-                    break
-            session_key = _latest_cli_session_key(paths.sessions_db)
-            if not session_key:
-                raise SystemExit("未找到 CLI session")
+            print(f"发送 prompt（死循环命令，agent 不知情）：\n  {_HIDDEN_LOOP_COMMAND}\n")
+            await _send(writer, _PROBE_PROMPT)
+            # agent 需要：15s auto-promote + 至少一次 task_output + task_stop + 回复
+            # 给充裕的 turn_timeout（默认 120s）
+            response = await _read_assistant(reader, args.turn_timeout)
+            responses.append(response)
+            print(f"agent 回复：{response['content'][:200]}")
         finally:
             writer.close()
             await writer.wait_closed()
 
-        await asyncio.sleep(args.after_completion_wait)
+        await asyncio.sleep(2.0)  # 等 DB 写入
+
+        session_key = _latest_cli_session_key(paths.sessions_db)
+        if not session_key:
+            raise SystemExit("未找到 CLI session")
+
         messages = _session_messages(paths.sessions_db, session_key)
-        observe_turns = _observe_turns(paths.observe_db, session_key)
-        writes = _memory_writes(paths.observe_db, session_key, started_at)
-        changed_items = _changed_memory_items(paths.memory_db, memory_baseline)
-        checks = _build_checks(
-            responses=responses,
-            messages=messages,
-            memory_writes=writes,
-            memory_items=changed_items,
-        )
+        checks = _build_checks(responses=responses, messages=messages)
+
+        print("\n── checks ──")
+        for k, v in checks.items():
+            if k == "call_sequence":
+                print(f"  call_sequence: {' → '.join(v) if v else '(empty)'}")
+            else:
+                icon = "✓" if v else "✗"
+                print(f"  {icon} {k}: {v}")
+        print(f"\npassed: {checks['passed']}\n")
+
         payload = {
             "profile": paths.profile,
             "session_key": session_key,
-            "prompt": prompt,
+            "prompt": _PROBE_PROMPT,
+            "command": _HIDDEN_LOOP_COMMAND,
             "responses": responses,
             "session_messages": messages,
-            "observe_turns": observe_turns,
-            "memory_writes": writes,
-            "changed_memory_items": changed_items,
             "checks": checks,
         }
         report_base = args.output or paths.workspace / f"shell-background-probe-{paths.profile}"
         _write_report(report_base=report_base, payload=payload)
+
         if not checks["passed"]:
-            raise SystemExit("shell background probe failed")
+            raise SystemExit("shell background probe FAILED")
+        print("shell background probe PASSED")
+
     finally:
         if proc is not None and args.stop_agent:
             _run_compose(paths, ["down"])
@@ -563,15 +429,18 @@ async def _run_probe(args: argparse.Namespace) -> None:
             paths.config.write_text(original_config, encoding="utf-8")
 
 
+# ── CLI ───────────────────────────────────────────────────────────────
+
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="运行后台 shell 完成回灌真实探针。")
+    parser = argparse.ArgumentParser(
+        description="测试 agent 能否自主发现卡死后台 shell 任务并调用 task_stop。"
+    )
     parser.add_argument("--profile", default="shell-bg-probe")
     parser.add_argument("--bootstrap-from", default="")
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--turn-timeout", type=float, default=180)
-    parser.add_argument("--completion-timeout", type=float, default=90)
+    parser.add_argument("--turn-timeout", type=float, default=120,
+                        help="等待 agent 完成整个 turn 的超时秒数（含 auto-promote 15s + 轮询 + 回复）")
     parser.add_argument("--start-timeout", type=float, default=90)
-    parser.add_argument("--after-completion-wait", type=float, default=2)
     parser.add_argument("--reset-workspace", action="store_true")
     parser.add_argument("--start-agent", action="store_true")
     parser.add_argument("--stop-agent", action="store_true")

--- a/tests/test_agent_core_p6_runner.py
+++ b/tests/test_agent_core_p6_runner.py
@@ -11,8 +11,8 @@ from agent.lifecycle.types import PromptRenderResult
 from agent.looping.ports import SessionServices
 from agent.tools.registry import ToolRegistry
 from agent.core.runner import CoreRunner, CoreRunnerDeps
-from bus.events import InboundMessage, OutboundMessage, ShellCompletionItem, SpawnCompletionItem
-from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
+from bus.events import InboundMessage, OutboundMessage, SpawnCompletionItem
+from bus.internal_events import SpawnCompletionEvent
 
 
 @pytest.mark.asyncio
@@ -119,97 +119,3 @@ async def test_core_runner_handles_spawn_completion_via_direct_helper_deps():
     pr_kwargs = pipeline_mock.post_reasoning.await_args.kwargs
     assert pr_kwargs["dispatch_outbound"] is False
     runner._agent_core.process.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_core_runner_handles_shell_completion_without_llm():
-    pipeline_mock = SimpleNamespace(
-        post_reasoning=AsyncMock(
-            return_value=OutboundMessage(
-                channel="telegram",
-                chat_id="123",
-                content="shell done",
-            )
-        )
-    )
-    runner = CoreRunner(
-        CoreRunnerDeps(
-            agent_core=cast(
-                Any,
-                SimpleNamespace(
-                    process=AsyncMock(),
-                    pipeline=pipeline_mock,
-                ),
-            ),
-        )
-    )
-    item = ShellCompletionItem(
-        channel="telegram",
-        chat_id="123",
-        event=ShellCompletionEvent(
-            task_id="shell_1",
-            description="跑测试",
-            command="pytest",
-            status="completed",
-            exit_code=0,
-            duration_ms=123,
-            output="31 passed",
-            output_path="/tmp/shell.log",
-        ),
-    )
-
-    out = await runner.process(item, "telegram:123", dispatch_outbound=False)
-
-    assert out.content == "shell done"
-    pipeline_mock.post_reasoning.assert_awaited_once()
-    kwargs = pipeline_mock.post_reasoning.await_args.kwargs
-    assert kwargs["dispatch_outbound"] is False
-    assert kwargs["turn_result"].reply.startswith("后台命令已完成：跑测试")
-    assert kwargs["turn_result"].tools_used == []
-    assert kwargs["msg"].metadata["omit_user_turn"] is True
-    assert kwargs["msg"].metadata["skip_post_memory"] is True
-    runner._agent_core.process.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_core_runner_skips_consumed_shell_completion():
-    import agent.tools.shell as shell_mod
-
-    pipeline_mock = SimpleNamespace(post_reasoning=AsyncMock())
-    runner = CoreRunner(
-        CoreRunnerDeps(
-            agent_core=cast(
-                Any,
-                SimpleNamespace(
-                    process=AsyncMock(),
-                    pipeline=pipeline_mock,
-                ),
-            ),
-        )
-    )
-    task_id = "shell_consumed"
-    shell_mod._mark_shell_completion_consumed(task_id)
-    item = ShellCompletionItem(
-        channel="telegram",
-        chat_id="123",
-        event=ShellCompletionEvent(
-            task_id=task_id,
-            description="跑测试",
-            command="pytest",
-            status="completed",
-            exit_code=0,
-            duration_ms=123,
-            output="31 passed",
-            output_path="/tmp/shell.log",
-        ),
-    )
-
-    try:
-        out = await runner.process(item, "telegram:123", dispatch_outbound=True)
-
-        assert out.content == ""
-        assert out.metadata["shell_completion_consumed"] is True
-        pipeline_mock.post_reasoning.assert_not_awaited()
-        runner._agent_core.process.assert_not_awaited()
-    finally:
-        shell_mod._CONSUMED_COMPLETIONS.discard(task_id)

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -17,8 +17,6 @@ from agent.tools.shell import (
     _validate_command,
     _run,
 )
-from bus.events import ShellCompletionItem
-from bus.queue import MessageBus
 
 _KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
@@ -431,123 +429,6 @@ async def test_shell_run_in_background_returns_task_id(monkeypatch, tmp_path):
 
     # 清理注册表，避免污染其他测试
     _BG_REGISTRY.pop(task_id, None)
-
-
-@pytest.mark.asyncio
-async def test_shell_background_completion_publishes_item(monkeypatch):
-    async def _fake_create_subprocess_shell(command, **kwargs):
-        return _FakeProc(stdout="done from bg", stderr="", returncode=0)
-
-    monkeypatch.setattr(
-        "agent.tools.shell.asyncio.create_subprocess_shell",
-        _fake_create_subprocess_shell,
-    )
-
-    bus = MessageBus()
-    tool = ShellTool(completion_bus=bus)
-    result = json.loads(
-        await tool.execute(
-            command="echo done",
-            description="后台完成",
-            run_in_background=True,
-            channel="telegram",
-            chat_id="123",
-        )
-    )
-    task_id = result["background_task_id"]
-
-    item = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
-
-    assert isinstance(item, ShellCompletionItem)
-    assert item.channel == "telegram"
-    assert item.chat_id == "123"
-    assert item.event.task_id == task_id
-    assert item.event.description == "后台完成"
-    assert item.event.command == "echo done"
-    assert item.event.status == "completed"
-    assert item.event.exit_code == 0
-    assert "done from bg" in item.event.output
-
-    _BG_REGISTRY.pop(task_id, None)
-
-
-@pytest.mark.asyncio
-async def test_task_stop_suppresses_shell_completion(monkeypatch):
-    import agent.tools.shell as shell_mod
-
-    async def _fake_create_subprocess_shell(command, **kwargs):
-        proc = _FakeProc(stdout="", stderr="", returncode=None)
-
-        async def _wait_forever():
-            await asyncio.Future()
-
-        proc.wait = _wait_forever
-        return proc
-
-    monkeypatch.setattr(
-        "agent.tools.shell.asyncio.create_subprocess_shell",
-        _fake_create_subprocess_shell,
-    )
-    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
-
-    bus = MessageBus()
-    tool = ShellTool(completion_bus=bus)
-    result = json.loads(
-        await tool.execute(
-            command="sleep infinity",
-            description="手动停止",
-            run_in_background=True,
-            channel="telegram",
-            chat_id="123",
-        )
-    )
-    task_id = result["background_task_id"]
-
-    stop_tool = ShellTaskStopTool()
-    stop_result = json.loads(await stop_tool.execute(task_id=task_id))
-
-    assert stop_result["status"] == "stopped"
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(bus.consume_inbound(), timeout=0.05)
-    shell_mod._BG_REGISTRY.pop(task_id, None)
-
-
-@pytest.mark.asyncio
-async def test_task_output_done_consumes_shell_completion(monkeypatch, tmp_path):
-    import agent.tools.shell as shell_mod
-
-    bus = MessageBus()
-    log_path = tmp_path / "done.log"
-    log_path.write_text("final output", encoding="utf-8")
-    pump = asyncio.ensure_future(asyncio.sleep(0))
-    await pump
-
-    task_id = "shell_done_consumed"
-    task = shell_mod._BackgroundTask(
-        proc=_FakeProc(stdout="", stderr="", returncode=0),
-        log_path=str(log_path),
-        pump_task=pump,
-        started_at=shell_mod.time.monotonic(),
-        wall_started_at_ms=int(shell_mod.time.time() * 1000),
-        command="pytest",
-        description="检查测试",
-        channel="telegram",
-        chat_id="123",
-        completion_bus=bus,
-    )
-    shell_mod._BG_REGISTRY[task_id] = task
-
-    try:
-        result = json.loads(await ShellTaskOutputTool().execute(task_id=task_id))
-        shell_mod._on_background_task_done(task_id, task)
-
-        assert result["status"] == "done"
-        assert "final output" in result["output"]
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(bus.consume_inbound(), timeout=0.05)
-    finally:
-        shell_mod._BG_REGISTRY.pop(task_id, None)
-        shell_mod._CONSUMED_COMPLETIONS.discard(task_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_spawn_completion_flow.py
+++ b/tests/test_spawn_completion_flow.py
@@ -7,8 +7,8 @@ from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig, MemoryServices
 from agent.provider import LLMResponse
 from agent.tools.registry import ToolRegistry
-from bus.events import ShellCompletionItem, SpawnCompletionItem
-from bus.internal_events import ShellCompletionEvent, SpawnCompletionEvent
+from bus.events import SpawnCompletionItem
+from bus.internal_events import SpawnCompletionEvent
 from tests.memory_fakes import FakeMemoryEngine
 from session.manager import SessionManager
 
@@ -117,57 +117,3 @@ async def test_spawn_completion_retry_count_one_disables_retry_guidance(tmp_path
     )
     assert "已重试一次，不再重试" in joined_messages
     assert "调用 spawn 重试" not in joined_messages
-
-
-@pytest.mark.asyncio
-async def test_shell_completion_persists_assistant_only_without_llm(tmp_path):
-    provider = _Provider()
-    session_manager = SessionManager(tmp_path)
-    tools = ToolRegistry()
-    loop = AgentLoop(
-        AgentLoopDeps(
-            bus=MagicMock(),
-            provider=cast(Any, provider),
-            tools=tools,
-            session_manager=session_manager,
-            workspace=tmp_path,
-            memory_services=MemoryServices(engine=FakeMemoryEngine(tmp_path)),
-        ),
-        AgentLoopConfig(llm=LLMConfig(max_iterations=3)),
-    )
-
-    session = session_manager.get_or_create("telegram:123")
-    session.add_message("user", "跑一下测试")
-    session.add_message("assistant", "我开始跑，结束后告诉你。")
-    session_manager.save(session)
-
-    item = ShellCompletionItem(
-        channel="telegram",
-        chat_id="123",
-        event=ShellCompletionEvent(
-            task_id="shell_abc",
-            description="测试",
-            command="pytest tests/test_shell_tool.py -q",
-            status="completed",
-            exit_code=0,
-            duration_ms=1680,
-            output="31 passed",
-            output_path="/tmp/shell.log",
-        ),
-    )
-
-    response = await loop._process(item)
-    updated = session_manager.get_or_create("telegram:123")
-
-    assert response.channel == "telegram"
-    assert response.chat_id == "123"
-    assert "后台命令已完成：测试" in response.content
-    assert "31 passed" in response.content
-    assert provider.calls == []
-    assert len(updated.messages) == 3
-    assert updated.messages[-1]["role"] == "assistant"
-    assert "后台命令已完成：测试" in updated.messages[-1]["content"]
-    assert all(
-        message["content"] != "[后台 shell 完成] 测试"
-        for message in updated.messages
-    )


### PR DESCRIPTION
## 问题

shell 后台任务完成后存在一条自动 completion 回调链路，会绕过 LLM 直接向用户发送技术格式消息。这和当前 agent 由 LLM 主动掌控 shell 生命周期的定位冲突，也会让被放弃的后台任务在用户已收到最终回复后继续孤立运行并自动回传。

## 改动

- 删除 `ShellCompletionItem` / `ShellCompletionEvent` 以及 runner、handler、loop 里的 shell completion 分支。
- 移除 shell 后台任务的 completion bus、消费标记和自动发布逻辑。
- 保留 spawn completion 回调链路不变。
- 更新 `shell` / `task_output` 工具描述，明确由 LLM 使用 `task_output block=true + timeout_ms` 主动等待、判断和 `task_stop`。
- 更新 Docker debug shell 探针，验证卡死后台任务由 agent 主动 `task_stop`，不依赖自动回调。

## 验证

- `pytest tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py`：35 passed
- `python -m py_compile agent/tools/shell.py bus/events.py bus/internal_events.py agent/core/runner.py agent/looping/handlers.py agent/looping/core.py agent/tools/meta/register.py bootstrap/toolsets/meta.py tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py docker/debug/shell_background_probe.py`
- `git diff --check -- agent/core/runner.py agent/looping/core.py agent/looping/handlers.py agent/tools/meta/register.py agent/tools/shell.py bootstrap/toolsets/meta.py bus/events.py bus/internal_events.py docker/debug/shell_background_probe.py tests/test_agent_core_p6_runner.py tests/test_shell_tool.py tests/test_spawn_completion_flow.py`
- `pyright agent/tools/shell.py bus/events.py bus/internal_events.py agent/core/runner.py agent/looping/handlers.py agent/looping/core.py agent/tools/meta/register.py bootstrap/toolsets/meta.py docker/debug/shell_background_probe.py tests/test_shell_tool.py tests/test_agent_core_p6_runner.py tests/test_spawn_completion_flow.py`：0 errors，保留既有 warnings
- Telegram debug bot 手动验证：长时间无输出脚本自动转后台后，agent 主动 `task_output`、`task_stop` 并回复结果。

## 配置影响

无新增配置。