### PR TITLE
fix(memory): 稳定工具解锁缓存并延长优化间隔

### DIFF
--- a/_handbook/memory-markdown.md
+++ b/_handbook/memory-markdown.md
@@ -129,7 +129,7 @@ Optimizer (定时触发)
 ```
 PENDING.md（增量事实缓冲区）
     ↓
-  Optimizer 定时触发（默认 memory_optimizer_interval_seconds = 10800）
+  Optimizer 定时触发（默认 memory_optimizer_interval_seconds = 50400）
     ↓
   读 MEMORY.md + PENDING.md → LLM 做归档决策：
     • 新事实 → 写入 MEMORY.md 对应分类

--- a/agent/config.py
+++ b/agent/config.py
@@ -118,7 +118,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         memory_optimizer_interval_seconds=int(
             agent_maintenance.get(
                 "memory_optimizer_interval_seconds",
-                data.get("memory_optimizer_interval_seconds", 10800),
+                data.get("memory_optimizer_interval_seconds", 50400),
             )
         ),
         light_model=str(llm_fast.get("model") or data.get("light_model", "")),

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -110,7 +110,7 @@ class Config:
     channels: ChannelsConfig = field(default_factory=ChannelsConfig)
     proactive: ProactiveConfig = field(default_factory=ProactiveConfig)
     memory_optimizer_enabled: bool = True
-    memory_optimizer_interval_seconds: int = 10800
+    memory_optimizer_interval_seconds: int = 50400
     light_model: str = ""
     light_api_key: str = ""
     light_base_url: str = ""

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -552,6 +552,7 @@ class Reasoner(ABC):
         *,
         request_time: datetime | None = None,
         preloaded_tools: set[str] | None = None,
+        preloaded_tool_order: list[str] | None = None,
         preflight_injected: bool = True,
         on_content_delta: Callable[[dict[str, str]], Awaitable[None]] | None = None,
         tool_event_session_key: str = "",
@@ -760,11 +761,13 @@ class DefaultReasoner(Reasoner):
         )
         total_history = len(source_history)
         preloaded: set[str] | None = None
+        preloaded_order: list[str] = []
         if self._tool_search_enabled:
-            preloaded = self._discovery.get_preloaded(session.key)
+            preloaded_order = self._discovery.get_preloaded_ordered(session.key)
+            preloaded = set(preloaded_order)
             logger.info(
                 "[tool_search] LRU preloaded=%s",
-                sorted(preloaded) if preloaded else "[]",
+                preloaded_order if preloaded_order else "[]",
             )
         stream_sink = (
             self._stream_sink_factory(msg) if self._stream_sink_factory is not None else None
@@ -819,6 +822,7 @@ class DefaultReasoner(Reasoner):
                     initial_messages,
                     request_time=msg.timestamp,
                     preloaded_tools=preloaded,
+                    preloaded_tool_order=preloaded_order,
                     preflight_injected=True,
                     on_content_delta=stream_sink,
                     tool_event_session_key=session.key,
@@ -827,6 +831,7 @@ class DefaultReasoner(Reasoner):
                     disabled_tools=disabled_tools,
                 )
                 tools_used = list(result.metadata.get("tools_used") or [])
+                tools_unlocked = list(result.metadata.get("tools_unlocked") or [])
                 tool_chain = list(result.metadata.get("tool_chain") or [])
                 if attempt > 0:
                     window = plan["history_window"]
@@ -845,10 +850,10 @@ class DefaultReasoner(Reasoner):
                     session.last_consolidated = 0
                     await self._session_manager.save_async(cast(Any, session))
 
-                if self._tool_search_enabled and tools_used:
+                if self._tool_search_enabled and (tools_used or tools_unlocked):
                     self._discovery.update(
                         session.key,
-                        tools_used,
+                        [*tools_unlocked, *tools_used],
                         self._tools.get_always_on_names(),
                     )
                 if attempt == 0:
@@ -913,6 +918,7 @@ class DefaultReasoner(Reasoner):
         *,
         request_time: datetime | None = None,
         preloaded_tools: set[str] | None = None,
+        preloaded_tool_order: list[str] | None = None,
         preflight_injected: bool = True,
         on_content_delta: Callable[[dict[str, str]], Awaitable[None]] | None = None,
         tool_event_session_key: str = "",
@@ -923,9 +929,11 @@ class DefaultReasoner(Reasoner):
         # 1. 初始化消息上下文、本轮工具轨迹。
         messages = initial_messages
         tools_used: list[str] = []
+        tools_unlocked: list[str] = []
         tool_chain: list[dict[str, Any]] = []
         # 2. 初始化本轮可见工具集合。
         visible_names: set[str] | None = None
+        visible_order: list[str] | None = None
         streamed = False
         react_input_samples: list[int] = []
         react_cache_prompt_tokens = 0
@@ -935,6 +943,12 @@ class DefaultReasoner(Reasoner):
         if self._tool_search_enabled:
             always_on = self._tools.get_always_on_names()
             visible_names = (always_on | (preloaded_tools or set())) - disabled
+            visible_order = self._tools.get_registered_order(always_on - disabled)
+            seen_visible = set(visible_order)
+            for name in preloaded_tool_order or sorted(preloaded_tools or set()):
+                if name in visible_names and name not in seen_visible:
+                    visible_order.append(name)
+                    seen_visible.add(name)
             logger.info(
                 "[tool_search] visible=%d 个工具 always_on=%d preloaded=%d need_search=%s",
                 len(visible_names),
@@ -978,6 +992,7 @@ class DefaultReasoner(Reasoner):
                     cache_prompt_tokens=react_cache_prompt_tokens,
                     cache_hit_tokens=react_cache_hit_tokens,
                     cache_seen=react_cache_seen,
+                    tools_unlocked=tools_unlocked,
                 )
             # 4. 调用 LLM，带上当前可见工具 schema。
             react_input_samples.append(step_ctx.input_tokens_estimate)
@@ -987,11 +1002,13 @@ class DefaultReasoner(Reasoner):
                 f"{len(visible_names)}个" if visible_names is not None else "全部（tool_search未开启）",
                 step_ctx.input_tokens_estimate,
             )
-            schema_names = set(visible_names) if visible_names is not None else None
+            schema_names: list[str] | set[str] | None = (
+                list(visible_order) if visible_order is not None else None
+            )
             if schema_names is None and disabled:
                 schema_names = self._tools.get_registered_names() - disabled
             elif schema_names is not None:
-                schema_names -= disabled
+                schema_names = [name for name in schema_names if name not in disabled]
             response = await self._llm.provider.chat(
                 messages=messages,
                 tools=self._tools.get_schemas(names=schema_names),
@@ -1157,6 +1174,7 @@ class DefaultReasoner(Reasoner):
                                 cache_prompt_tokens=react_cache_prompt_tokens,
                                 cache_hit_tokens=react_cache_hit_tokens,
                                 cache_seen=react_cache_seen,
+                                tools_unlocked=tools_unlocked,
                             )
                         logger.warning(
                             "[工具未解锁] LLM 尝试调用 '%s'，但该工具 schema 不可见，引导模型先 tool_search",
@@ -1287,11 +1305,20 @@ class DefaultReasoner(Reasoner):
                         and tool_call.name == "tool_search"
                         and visible_names is not None
                     ):
-                        _newly_unlocked = self._discovery.unlock_from_result(normalized.text)
-                        _newly_unlocked -= visible_names  # keep only genuinely new ones
-                        _newly_unlocked -= disabled
+                        _newly_unlocked = [
+                            name
+                            for name in self._discovery.unlock_names_from_result(normalized.text)
+                            if name not in visible_names and name not in disabled
+                        ]
                         if _newly_unlocked:
                             visible_names.update(_newly_unlocked)
+                            tools_unlocked.extend(_newly_unlocked)
+                            if visible_order is not None:
+                                seen_visible = set(visible_order)
+                                for name in _newly_unlocked:
+                                    if name not in seen_visible:
+                                        visible_order.append(name)
+                                        seen_visible.add(name)
                             logger.info("[工具解锁] tool_search 新解锁: %s", sorted(_newly_unlocked))
                         else:
                             logger.info("[工具解锁] tool_search 未解锁新工具")
@@ -1360,26 +1387,14 @@ class DefaultReasoner(Reasoner):
                             cache_prompt_tokens=react_cache_prompt_tokens,
                             cache_hit_tokens=react_cache_hit_tokens,
                             cache_seen=react_cache_seen,
+                            tools_unlocked=tools_unlocked,
                         )
 
-                # 7. 本轮工具执行完后，记录 tool_chain 并追加下一轮 loop_state 提示。
+                # 7. 本轮工具执行完后，记录 tool_chain。
                 tool_chain_group = {"text": response.content, "calls": iter_calls}
                 if response.thinking is not None:
                     tool_chain_group["reasoning_content"] = response.thinking
                 tool_chain.append(tool_chain_group)
-                messages.append(
-                    support.build_context_hint_message(
-                        "loop_state",
-                        build_loop_state_hint(
-                            visible_names=visible_names,
-                            always_on_names=(
-                                self._tools.get_always_on_names()
-                                if self._tool_search_enabled
-                                else None
-                            ),
-                        ),
-                    )
-                )
                 pressure_tokens = support.estimate_messages_tokens(messages)
                 # 7a. AfterStep 模块链（工具分支）：通知观察者本轮工具执行完毕。
                 after_step = await self._after_step.run(AfterStepCtx(
@@ -1419,6 +1434,7 @@ class DefaultReasoner(Reasoner):
                         cache_prompt_tokens=react_cache_prompt_tokens,
                         cache_hit_tokens=react_cache_hit_tokens,
                         cache_seen=react_cache_seen,
+                        tools_unlocked=tools_unlocked,
                     )
                 continue
 
@@ -1485,6 +1501,7 @@ class DefaultReasoner(Reasoner):
                 cache_prompt_tokens=react_cache_prompt_tokens,
                 cache_hit_tokens=react_cache_hit_tokens,
                 cache_seen=react_cache_seen,
+                tools_unlocked=tools_unlocked,
             )
 
         # 9. 达到最大迭代次数后，生成不完整进展总结。
@@ -1510,6 +1527,7 @@ class DefaultReasoner(Reasoner):
             cache_prompt_tokens=react_cache_prompt_tokens,
             cache_hit_tokens=react_cache_hit_tokens,
             cache_seen=react_cache_seen,
+            tools_unlocked=tools_unlocked,
         )
 
     async def _observe_tool_call_started(
@@ -1625,6 +1643,7 @@ class DefaultReasoner(Reasoner):
         cache_prompt_tokens: int,
         cache_hit_tokens: int,
         cache_seen: bool,
+        tools_unlocked: list[str] | None = None,
     ) -> ReasonerResult:
         # 1. 先把 tool_chain 扁平化成 invocations。
         invocations: list[LLMToolCall] = []
@@ -1662,6 +1681,7 @@ class DefaultReasoner(Reasoner):
             )
         metadata = {
             "tools_used": list(tools_used),
+            "tools_unlocked": list(tools_unlocked or []),
             "tool_chain": list(tool_chain),
             "visible_names": set(visible_names) if visible_names is not None else None,
             "react_stats": react_stats,
@@ -1814,19 +1834,3 @@ def build_deferred_tools_hint(
         "- 描述功能   → tool_search(query=\"关键词\") 搜索匹配"
     )
     return "\n".join(lines) + "\n\n"
-
-
-def build_loop_state_hint(
-    visible_names: set[str] | None = None,
-    always_on_names: set[str] | None = None,
-) -> str:
-    if visible_names is None or always_on_names is None:
-        return "【当前工具状态】tool_search 未开启，本轮按现有工具继续。"
-
-    unlocked_extra = visible_names - always_on_names - {"tool_search"}
-    visible_text = ", ".join(sorted(unlocked_extra)) if unlocked_extra else "仅 always-on"
-    return (
-        f"【当前工具状态】已解锁: {visible_text}\n"
-        "未知工具: tool_search(query=\"关键词\") 搜索\n"
-        "已知工具名但未加载: tool_search(query=\"select:工具名\")"
-    )

--- a/agent/core/runtime_support.py
+++ b/agent/core/runtime_support.py
@@ -38,6 +38,32 @@ class ToolDiscoveryState:
     def get_preloaded(self, session_key: str) -> set[str]:
         return set(self._unlocked.get(session_key, {}).keys())
 
+    def get_preloaded_ordered(self, session_key: str) -> list[str]:
+        return list(self._unlocked.get(session_key, {}).keys())
+
+    def unlock_names_from_result(self, result_json: str) -> list[str]:
+        try:
+            data = json.loads(result_json)
+            raw_unlocked = data.get("unlocked")
+            raw_names: list[object]
+            if isinstance(raw_unlocked, list):
+                raw_names = raw_unlocked
+            else:
+                raw_names = [
+                    item.get("name")
+                    for item in data.get("matched", [])
+                    if isinstance(item, dict)
+                ]
+            names: list[str] = []
+            seen: set[str] = set()
+            for item in raw_names:
+                if isinstance(item, str) and item and item not in seen:
+                    names.append(item)
+                    seen.add(item)
+            return names
+        except Exception:
+            return []
+
     def unlock_from_result(self, result_json: str) -> set[str]:
         """Parse a tool_search JSON result and return the tool names in 'matched'.
 
@@ -45,15 +71,7 @@ class ToolDiscoveryState:
         lived in agent/core/reasoner.py. Pure parsing — no mutation of external
         state; caller decides what to do with the returned names.
         """
-        try:
-            data = json.loads(result_json)
-            return {
-                item["name"]
-                for item in data.get("matched", [])
-                if isinstance(item.get("name"), str) and item["name"]
-            }
-        except Exception:
-            return set()
+        return set(self.unlock_names_from_result(result_json))
 
     def update(self, session_key: str, tools_used: list[str], always_on: set[str]) -> None:
         skip = always_on | {"tool_search"}

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -520,11 +520,17 @@ def _save_llm_payload_snapshot(
 def _extract_cache_usage(usage: Any) -> tuple[int | None, int | None]:
     hit_tokens = _coerce_int(_get_field(usage, "prompt_cache_hit_tokens"))
     miss_tokens = _coerce_int(_get_field(usage, "prompt_cache_miss_tokens"))
-    if hit_tokens is None and miss_tokens is None:
+    if hit_tokens is not None or miss_tokens is not None:
+        hit = hit_tokens or 0
+        miss = miss_tokens or 0
+        return hit + miss, hit
+
+    prompt_tokens = _coerce_int(_get_field(usage, "prompt_tokens"))
+    prompt_details = _get_field(usage, "prompt_tokens_details")
+    cached_tokens = _coerce_int(_get_field(prompt_details, "cached_tokens"))
+    if prompt_tokens is None or cached_tokens is None:
         return None, None
-    hit = hit_tokens or 0
-    miss = miss_tokens or 0
-    return hit + miss, hit
+    return prompt_tokens, cached_tokens
 
 
 def _iter_tool_call_deltas(delta: Any) -> list[dict[str, str | int]]:

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Set as AbstractSet
+from collections.abc import Iterable, Set as AbstractSet
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, cast
@@ -170,21 +170,35 @@ class ToolRegistry:
         """返回当前已注册工具名集合。"""
         return set(self._tools.keys())
 
-    def get_schemas(self, names: set[str] | None = None) -> list[dict[str, Any]]:
+    def get_schemas(
+        self,
+        names: AbstractSet[str] | Iterable[str] | None = None,
+    ) -> list[dict[str, Any]]:
         """返回 OpenAI function calling 格式的工具定义列表。
 
-        names 为 None 时返回全量；否则只返回指定名称的工具。
+        names 为 None 时返回全量；传 set 时按注册顺序过滤；传 list/tuple 时按调用方顺序返回。
         """
         if names is None:
             return [
                 _with_progress_description(t.to_schema(), t)
                 for t in self._tools.values()
             ]
+        if not isinstance(names, AbstractSet):
+            return [
+                _with_progress_description(tool.to_schema(), tool)
+                for name in names
+                if (tool := self._tools.get(name)) is not None
+            ]
         return [
             _with_progress_description(t.to_schema(), t)
             for name, t in self._tools.items()
             if name in names
         ]
+
+    def get_registered_order(self, names: AbstractSet[str] | None = None) -> list[str]:
+        if names is None:
+            return list(self._tools.keys())
+        return [name for name in self._tools.keys() if name in names]
 
     def get_always_on_names(self) -> set[str]:
         """返回标记为 always_on 的工具名称集合。"""

--- a/agent/tools/tool_search.py
+++ b/agent/tools/tool_search.py
@@ -91,7 +91,12 @@ class ToolSearchTool(Tool):
         query = (query or "").strip()
         if not query:
             return json.dumps(
-                {"matched": [], "tip": "query 不能为空，请描述你需要的功能"},
+                {
+                    "matched": [],
+                    "unlocked": [],
+                    "already_loaded": [],
+                    "tip": "query 不能为空，请描述你需要的功能",
+                },
                 ensure_ascii=False,
             )
 
@@ -113,10 +118,32 @@ class ToolSearchTool(Tool):
         )
         if not results:
             return json.dumps(
-                {"matched": [], "tip": "没有找到匹配工具，请换个关键词重试"},
+                {
+                    "matched": [],
+                    "unlocked": [],
+                    "already_loaded": [],
+                    "tip": "没有找到匹配工具，请换个关键词重试",
+                },
                 ensure_ascii=False,
             )
-        return json.dumps({"matched": results}, ensure_ascii=False, indent=2)
+        unlocked = [
+            item["name"]
+            for item in results
+            if isinstance(item.get("name"), str) and item["name"]
+        ]
+        return json.dumps(
+            {
+                "matched": results,
+                "unlocked": unlocked,
+                "already_loaded": [],
+                "next_action": (
+                    "unlocked 中的工具 schema 已加载。下一步直接调用需要的工具，"
+                    "不要再次 tool_search。"
+                ),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
 
     def _handle_select(
         self,
@@ -134,7 +161,12 @@ class ToolSearchTool(Tool):
         requested = [n.strip() for n in names_str.split(",") if n.strip()]
         if not requested:
             return json.dumps(
-                {"matched": [], "tip": "select: 后面需要提供工具名"},
+                {
+                    "matched": [],
+                    "unlocked": [],
+                    "already_loaded": [],
+                    "tip": "select: 后面需要提供工具名",
+                },
                 ensure_ascii=False,
             )
 
@@ -159,7 +191,16 @@ class ToolSearchTool(Tool):
                     found.append(name)
 
         matched = self._registry.get_schemas_as_doc_results(found)
-        result: dict[str, Any] = {"matched": matched}
+        result: dict[str, Any] = {
+            "matched": matched,
+            "unlocked": found,
+            "already_loaded": already_loaded,
+        }
+        if found:
+            result["next_action"] = (
+                "unlocked 中的工具 schema 已加载。下一步直接调用需要的工具，"
+                "不要再次 tool_search。"
+            )
 
         tip_parts: list[str] = []
         if already_loaded:

--- a/config.example.toml
+++ b/config.example.toml
@@ -48,7 +48,7 @@ search_enabled = true
 # 可选：长期记忆整理任务（默认已启用，通常无需修改）
 # [agent.maintenance]
 # memory_optimizer_enabled = true
-# memory_optimizer_interval_seconds = 10800
+# memory_optimizer_interval_seconds = 50400
 
 # 可选：控制加载哪些工具集（默认值适合大多数场景）
 # [agent.wiring]

--- a/docker/debug/tool_search_unlock_probe.py
+++ b/docker/debug/tool_search_unlock_probe.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent.config_models import Config
+from bootstrap.tools import build_core_runtime
+from core.net.http import (
+    SharedHttpResources,
+    clear_default_shared_http_resources,
+    configure_default_shared_http_resources,
+)
+
+
+def _as_mapping(value: object) -> Mapping[str, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return cast(Mapping[str, object], value)
+
+
+def _profile_dir(profile: str) -> Path:
+    return Path(__file__).resolve().parent / "profiles" / profile
+
+
+def _tool_names(tools: object) -> list[str]:
+    if not isinstance(tools, list):
+        return []
+    names: list[str] = []
+    for raw_tool in cast(list[object], tools):
+        tool = _as_mapping(raw_tool)
+        if tool is None:
+            continue
+        function = tool.get("function")
+        function_map = _as_mapping(function)
+        if function_map is None:
+            continue
+        name = function_map.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def _tool_chain_names(messages: list[dict[str, object]]) -> list[str]:
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        chain = message.get("tool_chain")
+        if not isinstance(chain, list):
+            continue
+        names: list[str] = []
+        for raw_group in cast(list[object], chain):
+            group = _as_mapping(raw_group)
+            if group is None:
+                continue
+            calls = group.get("calls")
+            if not isinstance(calls, list):
+                continue
+            for raw_call in cast(list[object], calls):
+                call = _as_mapping(raw_call)
+                if call is None:
+                    continue
+                name = call.get("name")
+                if isinstance(name, str):
+                    names.append(name)
+        return names
+    return []
+
+
+async def _run(args: argparse.Namespace) -> None:
+    profile_dir = _profile_dir(args.profile)
+    config_path = args.config or profile_dir / "config.toml"
+    workspace = args.workspace or profile_dir / "workspace"
+    config = Config.load(config_path)
+    if config.model != "mimo-v2.5":
+        raise SystemExit(f"主模型必须是 mimo-v2.5，当前是 {config.model!r}")
+    if config.light_model != "qwen-flash":
+        raise SystemExit(f"轻量模型必须是 qwen-flash，当前是 {config.light_model!r}")
+
+    _ = workspace.mkdir(parents=True, exist_ok=True)
+    resources = SharedHttpResources()
+    configure_default_shared_http_resources(resources)
+    schema_calls: list[list[str]] = []
+    llm_calls: list[dict[str, Any]] = []
+    try:
+        core = build_core_runtime(config, workspace, resources)
+        provider = cast(Any, core.loop)._llm_services.provider
+        original_chat = provider.chat
+
+        async def capture_chat(*chat_args: Any, **chat_kwargs: Any):
+            names = _tool_names(chat_kwargs.get("tools"))
+            schema_calls.append(names)
+            response = await original_chat(*chat_args, **chat_kwargs)
+            prompt_tokens = response.cache_prompt_tokens
+            hit_tokens = response.cache_hit_tokens
+            llm_calls.append(
+                {
+                    "tools": names,
+                    "cache_prompt_tokens": prompt_tokens,
+                    "cache_hit_tokens": hit_tokens,
+                    "cache_hit_rate": (
+                        round(hit_tokens / prompt_tokens, 4)
+                        if prompt_tokens and hit_tokens is not None
+                        else None
+                    ),
+                }
+            )
+            return response
+
+        provider.chat = capture_chat
+        reply = await core.loop.process_direct(
+            args.prompt,
+            session_key=args.session_key,
+            channel="cli",
+            chat_id="tool-search-probe",
+            skip_post_memory=True,
+        )
+        session = core.session_manager.get_or_create(args.session_key)
+        tool_calls = _tool_chain_names(cast(list[dict[str, object]], session.messages))
+
+        if tool_calls[:2] != ["tool_search", "list_schedules"]:
+            raise SystemExit(f"工具调用顺序异常: {tool_calls}")
+        first_schema = schema_calls[0] if schema_calls else []
+        unlocked_schema = next(
+            (names for names in schema_calls[1:] if "list_schedules" in names),
+            list[str](),
+        )
+        if not first_schema or not unlocked_schema:
+            raise SystemExit(f"未捕获到解锁前后 schema: {schema_calls}")
+        if unlocked_schema[: len(first_schema)] != first_schema:
+            raise SystemExit(
+                "解锁后 schema 没有保留原前缀: "
+                + json.dumps(schema_calls, ensure_ascii=False)
+            )
+        if unlocked_schema[len(first_schema)] != "list_schedules":
+            raise SystemExit(
+                "list_schedules 没有追加在原 schema 前缀之后: "
+                + json.dumps(schema_calls, ensure_ascii=False)
+            )
+
+        print(json.dumps(
+            {
+                "ok": True,
+                "model": config.model,
+                "light_model": config.light_model,
+                "tool_calls": tool_calls,
+                "llm_calls": llm_calls,
+                "reply": reply,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ))
+    finally:
+        clear_default_shared_http_resources(resources)
+        await resources.aclose()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="真实配置验证 tool_search 解锁顺序。")
+    _ = parser.add_argument("--profile", default="scheduler-soft-real")
+    _ = parser.add_argument("--config", type=Path)
+    _ = parser.add_argument("--workspace", type=Path)
+    _ = parser.add_argument("--session-key", default="probe:tool_search_unlock")
+    _ = parser.add_argument(
+        "--prompt",
+        default=(
+            "请严格按顺序执行：先调用 tool_search(query=\"select:list_schedules\") "
+            "加载工具，再调用 list_schedules 查看当前定时任务，最后用一句中文概括结果。"
+            "不要跳过工具。"
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    asyncio.run(_run(_parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_core_foundation.py
+++ b/tests/test_agent_core_foundation.py
@@ -43,11 +43,13 @@ def test_agent_core_runtime_support_tool_discovery_lru():
     state = ToolDiscoveryState(capacity=2)
     state.update("cli:1", ["tool_a", "tool_b"], {"always"})
     assert state.get_preloaded("cli:1") == {"tool_a", "tool_b"}
+    assert state.get_preloaded_ordered("cli:1") == ["tool_a", "tool_b"]
 
     state.update("cli:1", ["tool_a"], {"always"})
     state.update("cli:1", ["tool_c"], {"always"})
 
     assert state.get_preloaded("cli:1") == {"tool_a", "tool_c"}
+    assert state.get_preloaded_ordered("cli:1") == ["tool_a", "tool_c"]
     assert "tool_b" not in state.get_preloaded("cli:1")
 
 

--- a/tests/test_loop_tool_visibility.py
+++ b/tests/test_loop_tool_visibility.py
@@ -236,6 +236,50 @@ class TestVisibilityGuard:
         assert "tool_search" in first_call_tools
         assert "hidden_tool" not in first_call_tools
 
+    def test_unlocked_schema_appends_after_always_on(self, tmp_path):
+        reg = ToolRegistry()
+        hidden = _DummyTool("early_hidden")
+        reg.register(hidden)
+        reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
+
+        schemas_seen: list[list[str]] = []
+        messages_seen: list[list[dict[str, Any]]] = []
+
+        class _CapturingProvider(_FakeProvider):
+            async def chat(self, **kwargs: Any) -> LLMResponse:
+                schemas_seen.append(
+                    [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+                )
+                messages_seen.append(list(kwargs.get("messages") or []))
+                return await super().chat(**kwargs)
+
+        provider = _CapturingProvider(
+            [
+                LLMResponse(
+                    content="",
+                    tool_calls=[
+                        ToolCall("s1", "tool_search", {"query": "select:early_hidden"})
+                    ],
+                ),
+                LLMResponse(content="", tool_calls=[ToolCall("h1", "early_hidden", {})]),
+                LLMResponse(content="done", tool_calls=[]),
+            ]
+        )
+        loop = _make_loop(tmp_path, provider, reg)
+
+        final, tools_used, _, _, _ = asyncio.run(
+            loop._run_agent_loop([{"role": "user", "content": "use hidden"}])
+        )
+
+        assert final == "done"
+        assert "early_hidden" in tools_used
+        assert schemas_seen[0] == ["tool_search"]
+        assert schemas_seen[1] == ["tool_search", "early_hidden"]
+        second_call_text = "\n".join(
+            str(message.get("content") or "") for message in messages_seen[1]
+        )
+        assert "当前工具状态" not in second_call_text
+
 
 # ── LRU 测试 ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -144,6 +144,22 @@ async def test_provider_chat_and_retry_paths(monkeypatch: pytest.MonkeyPatch):
 
     fake = _FakeClient(
         [
+            _Response(
+                content="mimo-cache-ok",
+                usage=SimpleNamespace(
+                    prompt_tokens=100,
+                    prompt_tokens_details=SimpleNamespace(cached_tokens=76),
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    result = await LLMProvider(api_key="k").chat([], [], "mimo-v2.5", 1)
+    assert result.cache_prompt_tokens == 100
+    assert result.cache_hit_tokens == 76
+
+    fake = _FakeClient(
+        [
             RuntimeError("Error code: 429"),
             _Response(content="retry-ok"),
         ]
@@ -319,6 +335,43 @@ async def test_provider_chat_stream_parses_content_reasoning_and_tool_calls(
     assert fake.calls[0]["stream"] is True
     assert result.cache_prompt_tokens == 64
     assert result.cache_hit_tokens == 16
+
+
+@pytest.mark.asyncio
+async def test_provider_chat_stream_extracts_openai_cached_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="好", tool_calls=[]))
+                ]
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(
+                    prompt_tokens=100,
+                    prompt_tokens_details={"cached_tokens": 80},
+                ),
+            ),
+        ]
+    )
+    fake = _FakeClient([stream])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    provider = LLMProvider(api_key="k")
+
+    result = await provider.chat(
+        messages=[],
+        tools=[],
+        model="mimo-v2.5",
+        max_tokens=10,
+        on_content_delta=lambda chunk: _collect_delta([], chunk),
+    )
+
+    assert result.content == "好"
+    assert result.cache_prompt_tokens == 100
+    assert result.cache_hit_tokens == 80
 
 
 @pytest.mark.asyncio

--- a/tests/test_procedure_hint_semantic.py
+++ b/tests/test_procedure_hint_semantic.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-from agent.prompting import is_context_frame
+from agent.prompting import (
+    PromptSectionRender,
+    build_context_frame_content,
+    build_context_frame_message,
+    is_context_frame,
+)
 
 from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig, MemoryServices
@@ -82,7 +87,18 @@ def test_reflect_prompt_no_longer_contains_procedure_hint(tmp_path: Path):
     )
     loop = _make_loop(tmp_path, provider, tool)
 
-    asyncio.run(loop._run_agent_loop([{"role": "user", "content": "test"}]))
+    context_frame = build_context_frame_message(
+        build_context_frame_content(
+            [
+                PromptSectionRender(
+                    name="retrieved_memory",
+                    content="已知上下文",
+                    is_static=False,
+                )
+            ]
+        )
+    )
+    asyncio.run(loop._run_agent_loop([context_frame, {"role": "user", "content": "test"}]))
 
     reflect_msgs = provider.calls[1]["messages"]
     all_content = " ".join(str(m.get("content", "")) for m in reflect_msgs)

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -117,6 +117,29 @@ system_prompt = "test"
     assert cfg.max_iterations == 10
 
 
+def test_load_config_defaults_memory_optimizer_to_14h(tmp_path: Path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[llm]
+provider = "openai"
+
+[llm.main]
+model = "test-model"
+api_key = "test-key"
+
+[agent]
+system_prompt = "test"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.memory_optimizer_interval_seconds == 50400
+
+
 @pytest.mark.asyncio
 async def test_serve_smoke_loads_config_and_runs_shutdown(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -163,6 +163,19 @@ def test_registry_adds_model_description_for_progress() -> None:
     assert "description" not in _PathOnlyTool.parameters["properties"]
 
 
+def test_registry_get_schemas_preserves_explicit_name_order() -> None:
+    reg = ToolRegistry()
+    reg.register(_StubTool("hidden_first", "先注册的隐藏工具"))
+    reg.register(_StubTool("always_later", "后注册的常驻工具"), always_on=True)
+
+    schemas = reg.get_schemas(names=["always_later", "hidden_first"])
+
+    assert [schema["function"]["name"] for schema in schemas] == [
+        "always_later",
+        "hidden_first",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_registry_strips_progress_description_before_execute() -> None:
     reg = ToolRegistry()
@@ -606,6 +619,37 @@ class TestToolSearchTool:
         assert all(r["name"] != "schedule" for r in data.get("matched", []))
         assert "tip" in data
         assert "schedule" in data["tip"]
+        assert data["already_loaded"] == ["schedule"]
+
+    def test_select_result_reports_unlocked_next_action(self):
+        reg = _make_registry()
+        tool = ToolSearchTool(reg)
+
+        data = json.loads(asyncio.run(tool.execute(query="select:schedule")))
+
+        assert data["unlocked"] == ["schedule"]
+        assert data["already_loaded"] == []
+        assert "直接调用" in data["next_action"]
+
+    def test_select_empty_result_keeps_unlock_shape(self):
+        reg = _make_registry()
+        tool = ToolSearchTool(reg)
+
+        data = json.loads(asyncio.run(tool.execute(query="select:")))
+
+        assert data["matched"] == []
+        assert data["unlocked"] == []
+        assert data["already_loaded"] == []
+
+    def test_keyword_result_reports_unlocked_next_action(self):
+        reg = _make_registry()
+        tool = ToolSearchTool(reg)
+
+        data = json.loads(asyncio.run(tool.execute(query="定时任务", top_k=3)))
+
+        assert any(name == "schedule" for name in data["unlocked"])
+        assert data["already_loaded"] == []
+        assert "再次 tool_search" in data["next_action"]
 
     def test_select_meta_tools_are_excluded(self):
         """select:tool_search 与 search() 语义一致 → matched 为空。"""


### PR DESCRIPTION
## 问题

近期 KV cache 排查里有两个会影响 prompt 稳定性的点：`tool_search` 轮内解锁会改变 tools schema，旧实现还会额外插入动态 `loop_state` 提示；同时 memory optimizer 默认 3h 整理偏频繁，容易让历史内容形态更快变化。

## 改动

- 将 memory optimizer 默认间隔从 3h 调整为 14h，并同步示例配置、文档和测试。
- reasoner 改为维护有序可见工具列表，新解锁工具追加到当前 schema 末尾。
- 移除 ReAct 轮内 `loop_state` 提示，减少动态 prompt 片段。
- 优化 `tool_search` 返回结构，补充 `unlocked` / `already_loaded` / `next_action`。
- provider 支持 DeepSeek 原生 cache 字段，以及 MiMo/OpenAI 兼容的 `prompt_tokens_details.cached_tokens`。
- 增加 Docker debug 探针，验证真实配置下工具解锁顺序和 cache 字段。
- 修正 context frame 语义测试：显式提供已有 context frame，验证反射轮继续以 user 角色携带它，而不是依赖已移除的 `loop_state`。

## 验证

- `git diff --check`
- `pytest tests/ -q`：1222 passed
- `pyright tests/test_procedure_hint_semantic.py`：0 errors
- `pyright agent/provider.py agent/core/passive_turn.py agent/core/runtime_support.py agent/tools/registry.py agent/tools/tool_search.py docker/debug/tool_search_unlock_probe.py tests/test_more_support_modules.py tests/test_agent_core_foundation.py tests/test_tool_search.py tests/test_loop_tool_visibility.py tests/test_runtime_smoke.py`：0 errors，保留既有 warnings
- Docker debug / full runtime probe：工具解锁后新工具追加到 schema 末尾，移除 `loop_state` 后 post-unlock 缓存恢复到高命中；v4 full runtime 中解锁后一轮约 97.75% cache hit。

## 配置影响

无新增配置；`memory_optimizer_interval_hours` 默认值从 3 调整为 14。
