### PR TITLE
feat: add merged trace forwarding for QQ private chats

### DIFF
--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -65,6 +65,7 @@ async def start_channels(
             groups=qq.groups,
             websocket_open_timeout_seconds=qq.websocket_open_timeout_seconds,
             http_requester=http_resources.external_default,
+            event_bus=event_bus,
             interrupt_controller=interrupt_controller,
         )
         await qq_channel.start()

--- a/infra/channels/qq_channel.py
+++ b/infra/channels/qq_channel.py
@@ -16,6 +16,7 @@ chat_id 约定：
 
 import asyncio
 import base64
+from dataclasses import dataclass, field
 import html
 import importlib
 import logging
@@ -26,7 +27,13 @@ from typing import Any, cast
 
 from agent.config_models import QQGroupConfig
 from agent.looping.interrupt import InterruptController
+from bus.event_bus import EventBus
 from bus.events import InboundMessage, OutboundMessage
+from bus.events_lifecycle import (
+    ToolCallCompleted,
+    ToolCallStarted,
+    TurnStarted,
+)
 from bus.queue import MessageBus
 from infra.channels.base import AttachmentStore, SessionIdentityIndex
 from infra.channels.group_filter import (
@@ -44,6 +51,162 @@ logger = logging.getLogger(__name__)
 
 _CHANNEL = "qq"
 _GROUP_PREFIX = "gqq:"
+_TRACE_THINKING_LIMIT = 500
+_TRACE_TOOL_RESULT_LIMIT = 120
+_TRACE_DEFAULT_ACTOR = "Akashic"
+
+
+@dataclass
+class _QQTraceLine:
+    tool_name: str
+    status: str = "started"
+    intent: str = ""
+    target: str = ""
+    result_preview: str = ""
+
+
+@dataclass
+class _QQTraceState:
+    user_message: str = ""
+    tool_lines: list[_QQTraceLine] = field(default_factory=list)
+
+
+def _session_key_for_chat(chat_id: str) -> str:
+    return f"{_CHANNEL}:{chat_id}"
+
+
+def _truncate_trace_text(text: str, limit: int) -> str:
+    raw = str(text or "").strip()
+    if len(raw) <= limit:
+        return raw
+    omitted = len(raw) - limit
+    head = max(0, limit // 2)
+    tail = max(0, limit - head)
+    return f"{raw[:head]} ...[{omitted} chars omitted]... {raw[-tail:]}"
+
+
+def _format_tool_intent(arguments: dict[str, Any]) -> str:
+    if not isinstance(arguments, dict):
+        return ""
+    for key in ("description", "query", "summary", "task", "action"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            return _truncate_trace_text(value, 80)
+    return ""
+
+
+def _format_tool_target(arguments: dict[str, Any]) -> str:
+    if not isinstance(arguments, dict):
+        return ""
+    if isinstance(arguments.get("path"), str) and arguments.get("path", "").strip():
+        return _truncate_trace_text(str(arguments["path"]).strip(), 60)
+    if isinstance(arguments.get("file_path"), str) and arguments.get("file_path", "").strip():
+        return _truncate_trace_text(str(arguments["file_path"]).strip(), 60)
+    for key in (
+        "cmd",
+        "command",
+        "query",
+        "url",
+        "file",
+        "text",
+        "content",
+        "prompt",
+        "name",
+    ):
+        value = arguments.get(key)
+        if isinstance(value, str | int | float) and str(value).strip():
+            return _truncate_trace_text(str(value).strip(), 80)
+    return ""
+
+
+def _format_tool_trace_lines(lines: list[_QQTraceLine]) -> str:
+    if not lines:
+        return "No tool calls."
+    rendered: list[str] = []
+    for index, line in enumerate(lines, start=1):
+        rendered.append(f"{index}. {_compress_tool_line(line)}")
+    return "\n".join(rendered)
+
+
+def _summarize_tool_result_preview(tool_name: str, preview: str) -> str:
+    text = str(preview or "").strip()
+    if not text:
+        return ""
+    name = tool_name.lower()
+    if name == "fetch_messages":
+        if '"matched_count"' in text or '"count"' in text:
+            matched = re.search(r'"matched_count"\s*:\s*(\d+)', text)
+            count = re.search(r'"count"\s*:\s*(\d+)', text)
+            hit_text = matched.group(1) if matched else "?"
+            total_text = count.group(1) if count else "?"
+            return f"结果：命中 {hit_text} 条，返回上下文 {total_text} 条"
+        return "结果：已返回消息上下文"
+    if name == "list_dir":
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        if lines:
+            return f"结果：列出 {len(lines)} 项"
+        return "结果：已列出目录内容"
+    if name == "read_file":
+        line_no = re.search(r"(\d+)→", text)
+        if line_no:
+            return f"结果：已读取第 {line_no.group(1)} 行附近内容"
+        if "字节" in text:
+            return "结果：已读取文件片段"
+        return "结果：已读取文件"
+    if name == "shell":
+        exit_code = re.search(r'"exit_code"\s*:\s*(-?\d+)', text)
+        if exit_code:
+            code = exit_code.group(1)
+            if code == "0":
+                return "结果：命令执行成功"
+            return f"结果：命令退出码 {code}"
+        command = re.search(r'"command"\s*:\s*"([^"]+)"', text)
+        if command:
+            snippet = _truncate_trace_text(command.group(1), 50)
+            return f"结果：已执行命令 {snippet}"
+        if "（无输出）" in text or "(无输出)" in text:
+            return "结果：命令已执行（无输出）"
+        return "结果：命令已执行"
+    if name == "list_schedules":
+        matched = re.search(r"(\d+)\s*个", text)
+        if matched:
+            return f"结果：当前有 {matched.group(1)} 个提醒"
+        return "结果：已列出提醒"
+    if name == "cancel_schedule":
+        matched = re.search(r"(\d+)\s*个", text)
+        if matched:
+            return f"结果：已取消 {matched.group(1)} 个提醒"
+        return "结果：已执行取消"
+    if name == "schedule":
+        return "结果：已创建提醒"
+    return f"结果：{_truncate_trace_text(text, _TRACE_TOOL_RESULT_LIMIT)}"
+
+
+def _tool_emoji(tool_name: str) -> str:
+    name = tool_name.lower()
+    if name.startswith("mcp"):
+        return "📡"
+    if "search" in name or "fetch" in name:
+        return "🔍"
+    if "schedule" in name or "cancel" in name:
+        return "⏰"
+    if "shell" in name:
+        return "⚙"
+    if "file" in name or "read" in name or "write" in name:
+        return "📄"
+    return "🔧"
+
+
+def _compress_tool_line(line: _QQTraceLine) -> str:
+    status = "已完成" if line.status == "done" else "失败" if line.status == "error" else "进行中"
+    parts = [f"{_tool_emoji(line.tool_name)} {line.tool_name}", status]
+    if line.intent:
+        parts.append(f"意图：{line.intent}")
+    elif line.target:
+        parts.append(f"目标：{line.target}")
+    if line.result_preview:
+        parts.append(line.result_preview)
+    return " | ".join(parts)
 
 # 匹配 CQ:image 码中的 url 字段
 _CQ_IMAGE_RE = re.compile(r"\[CQ:image[^\]]*?(?:,|\b)url=([^,\]]+)[^\]]*\]")
@@ -140,6 +303,7 @@ class QQChannel:
         websocket_open_timeout_seconds: float = 5.0,
         group_filter: GroupMessageFilter | None = None,
         http_requester: HttpRequester | None = None,
+        event_bus: EventBus | None = None,
         interrupt_controller: InterruptController | None = None,
     ) -> None:
         from ncatbot.core import BotClient
@@ -153,7 +317,9 @@ class QQChannel:
         self._websocket_open_timeout_seconds = float(websocket_open_timeout_seconds)
         self._interrupt_controller = interrupt_controller
         ws = getattr(session_manager, "workspace", None)
+        self._workspace = Path(ws) if ws else None
         self._attachments = AttachmentStore(Path(ws) / "uploads" if ws else None)
+        self._trace_actor_name_cache: str | None = None
         self._identity_index = SessionIdentityIndex(
             session_manager,
             channel=_CHANNEL,
@@ -170,6 +336,8 @@ class QQChannel:
         self._http_requester = http_requester or get_default_http_requester(
             "external_default"
         )
+        self._event_bus = event_bus
+        self._trace_states: dict[str, _QQTraceState] = {}
 
         self._bot = BotClient()
         self._api = None
@@ -202,6 +370,10 @@ class QQChannel:
     async def start(self) -> None:
         self._main_loop = asyncio.get_running_loop()
         self._identity_index.rebuild()
+        if self._event_bus is not None:
+            self._event_bus.on(TurnStarted, self._on_turn_started)
+            self._event_bus.on(ToolCallStarted, self._on_tool_call_started)
+            self._event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
 
         @cast(Any, self._bot.on_private_message())
         async def _(event) -> None:
@@ -279,6 +451,52 @@ class QQChannel:
             if callable(bot_exit):
                 await loop.run_in_executor(None, bot_exit)
             logger.info("[qq] QQChannel 已停止")
+
+    async def _on_turn_started(self, event: TurnStarted) -> None:
+        if event.channel != _CHANNEL:
+            return
+        self._trace_states[event.session_key] = _QQTraceState(
+            user_message=event.content,
+        )
+
+    async def _on_tool_call_started(self, event: ToolCallStarted) -> None:
+        if event.channel != _CHANNEL:
+            return
+        state = self._trace_states.setdefault(event.session_key, _QQTraceState())
+        state.tool_lines.append(
+            _QQTraceLine(
+                tool_name=event.tool_name,
+                intent=_format_tool_intent(event.arguments),
+                target=_format_tool_target(event.arguments),
+            )
+        )
+
+    async def _on_tool_call_completed(self, event: ToolCallCompleted) -> None:
+        if event.channel != _CHANNEL:
+            return
+        state = self._trace_states.setdefault(event.session_key, _QQTraceState())
+        line = next(
+            (
+                item
+                for item in reversed(state.tool_lines)
+                if item.tool_name == event.tool_name and item.status == "started"
+            ),
+            None,
+        )
+        if line is None:
+            line = _QQTraceLine(
+                tool_name=event.tool_name,
+                intent=_format_tool_intent(event.final_arguments or event.arguments),
+                target=_format_tool_target(event.final_arguments or event.arguments),
+            )
+            state.tool_lines.append(line)
+        line.status = "error" if event.status == "error" else "done"
+        preview = str(event.result_preview or "").strip()
+        if preview:
+            line.result_preview = _summarize_tool_result_preview(
+                event.tool_name,
+                preview,
+            )
 
     # ── 入站处理 ──────────────────────────────────────────────────────
 
@@ -366,6 +584,12 @@ class QQChannel:
         api = self._api
         if api is None:
             raise RuntimeError("QQChannel 尚未启动")
+        session_key = _session_key_for_chat(msg.chat_id)
+        if not msg.chat_id.startswith(_GROUP_PREFIX):
+            try:
+                await self._send_private_trace(msg.chat_id, session_key, msg)
+            except Exception as e:
+                logger.warning(f"[qq] 私聊 tracing 合并转发失败  chat_id={msg.chat_id}  错误: {e}")
         if msg.content.strip():
             try:
                 if msg.chat_id.startswith(_GROUP_PREFIX):
@@ -386,6 +610,82 @@ class QQChannel:
                 await self.send_image(msg.chat_id, image)
             except Exception as e:
                 logger.error(f"[qq] meme 图片发送失败  chat_id={msg.chat_id}  path={image}  err={e}")
+        self._trace_states.pop(session_key, None)
+
+    async def _send_private_trace(
+        self,
+        chat_id: str,
+        session_key: str,
+        msg: OutboundMessage,
+    ) -> None:
+        api = self._api
+        if api is None:
+            raise RuntimeError("QQChannel 尚未启动")
+        trace = self._trace_states.get(session_key)
+        if trace is None:
+            return
+        thinking_source = str(msg.thinking or "")
+        thinking = _truncate_trace_text(thinking_source, _TRACE_THINKING_LIMIT)
+        tool_text = _format_tool_trace_lines(trace.tool_lines)
+        if not thinking and not trace.tool_lines:
+            return
+        from ncatbot.core import ForwardConstructor
+
+        info = await self._run_on_bot_loop(api.get_login_info())
+        actor_name = self._trace_actor_name()
+        constructor = ForwardConstructor(str(info.user_id), actor_name)
+        constructor.attach_text(
+            f"【模型思路】\n{thinking or '（无 thinking）'}",
+            nickname=actor_name,
+        )
+        constructor.attach_text(
+            f"【工具链】\n{tool_text}",
+            nickname=actor_name,
+        )
+        forward = constructor.to_forward()
+        payload = forward.to_forward_dict()
+        payload["source"] = f"{actor_name} 的过程记录"
+        payload["summary"] = "查看本轮过程记录"
+        payload["prompt"] = f"{actor_name} 过程记录"
+        payload["news"] = [
+            {"text": f"{actor_name}：【模型思路】"},
+            {"text": f"{actor_name}：【工具链】"},
+        ]
+        await self._run_on_bot_loop(
+            api.send_private_forward_msg(int(chat_id), **payload)
+        )
+
+    def _trace_actor_name(self) -> str:
+        cached = self._trace_actor_name_cache
+        if cached:
+            return cached
+        workspace = self._workspace
+        if workspace is None:
+            self._trace_actor_name_cache = _TRACE_DEFAULT_ACTOR
+            return _TRACE_DEFAULT_ACTOR
+        self_path = workspace / "memory" / "SELF.md"
+        try:
+            text = self_path.read_text(encoding="utf-8")
+        except Exception:
+            self._trace_actor_name_cache = _TRACE_DEFAULT_ACTOR
+            return _TRACE_DEFAULT_ACTOR
+        body_match = re.search(
+            r"(?m)^-\s*我是\s+([A-Za-z][A-Za-z0-9_-]{1,40})\b",
+            text,
+        )
+        if body_match:
+            name = body_match.group(1).strip()
+            if name:
+                self._trace_actor_name_cache = name
+                return name
+        match = re.search(r"(?m)^#\s*(.+?)\s+的自我认知\s*$", text)
+        if match:
+            name = match.group(1).strip()
+            if name:
+                self._trace_actor_name_cache = name
+                return name
+        self._trace_actor_name_cache = _TRACE_DEFAULT_ACTOR
+        return _TRACE_DEFAULT_ACTOR
 
     # ── 主动推送（供 MessagePushTool 使用）────────────────────────────
 
@@ -436,11 +736,11 @@ class QQChannel:
 
     async def _run_on_bot_loop(
         self, coro: Coroutine[object, object, object]
-    ) -> None:
+    ) -> object:
         if self._bot_loop is None:
             raise RuntimeError("QQ bot loop 未就绪")
         future = asyncio.run_coroutine_threadsafe(coro, self._bot_loop)
-        await asyncio.wrap_future(future)
+        return await asyncio.wrap_future(future)
 
 
 def _is_local(path: str) -> bool:

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -6,6 +6,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -13,7 +14,12 @@ import pytest
 
 from bus.event_bus import EventBus
 from bus.events import OutboundMessage
-from bus.events_lifecycle import StreamDeltaReady, ToolCallCompleted, ToolCallStarted
+from bus.events_lifecycle import (
+    StreamDeltaReady,
+    ToolCallCompleted,
+    ToolCallStarted,
+    TurnStarted,
+)
 
 
 class _Bus:
@@ -363,11 +369,44 @@ def _import_qq_channel(monkeypatch: pytest.MonkeyPatch):
         def exit(self):
             return None
 
+    class ForwardConstructor:
+        def __init__(self, user_id, nickname):
+            self.user_id = user_id
+            self.nickname = nickname
+            self.nodes = []
+
+        def attach_text(self, text, nickname=None):
+            self.nodes.append(
+                {
+                    "type": "text",
+                    "data": {"text": text},
+                    "nickname": nickname or self.nickname,
+                    "user_id": self.user_id,
+                }
+            )
+
+        def to_forward(self):
+            class _Forward:
+                def __init__(self, nodes):
+                    self._nodes = nodes
+
+                def to_forward_dict(self):
+                    return {
+                        "messages": list(self._nodes),
+                        "news": [],
+                        "prompt": "",
+                        "summary": "",
+                        "source": "",
+                    }
+
+            return _Forward(self.nodes)
+
     def _fake_connect(*args, **kwargs):
         captured_connect_calls.append(kwargs.copy())
         return ("connect", args, kwargs)
 
     ncatbot_core.BotClient = BotClient
+    ncatbot_core.ForwardConstructor = ForwardConstructor
     ncatbot_core_adapter_adapter.websockets = SimpleNamespace(connect=_fake_connect)
     ncatbot_core_adapter_adapter._captured_connect_calls = captured_connect_calls
     ncatbot_utils.ncatbot_config = SimpleNamespace(
@@ -972,7 +1011,12 @@ async def test_qq_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     assert mod._is_local("https://example.com/x.jpg") is False
     assert mod._local_to_base64(str(sample)).startswith("base64://")
 
-    paths = await mod._download_to_temp(["http://x/a.png", "http://x/b.png"], requester)
+    test_attachments = mod.AttachmentStore(tmp_path / "uploads")
+    paths = await mod._download_to_temp(
+        ["http://x/a.png", "http://x/b.png"],
+        requester,
+        test_attachments,
+    )
     assert len(paths) == 1
 
     channel._bot_loop = None
@@ -981,6 +1025,164 @@ async def test_qq_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
         await mod.QQChannel._run_on_bot_loop(channel, pending)
     pending.close()
     await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_qq_private_trace_sends_forward_then_final_and_clears_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    mod = _import_qq_channel(monkeypatch)
+    bus = _Bus()
+    session_manager = _SessionManager()
+    event_bus = EventBus()
+    channel = mod.QQChannel(
+        "42",
+        bus,
+        session_manager,
+        allow_from=["1"],
+        event_bus=event_bus,
+        http_requester=SimpleNamespace(get=AsyncMock()),
+    )
+    await channel.start()
+
+    calls: list[tuple[str, object, object]] = []
+
+    async def _drain(coro):
+        return await coro
+
+    async def _fake_send_private_forward_msg(user_id, **payload):
+        calls.append(("forward", user_id, payload))
+
+    async def _fake_send_private_text(user_id, content):
+        calls.append(("text", user_id, content))
+
+    async def _fake_get_login_info():
+        return SimpleNamespace(user_id="42", nickname="Bot")
+
+    channel._run_on_bot_loop = AsyncMock(side_effect=_drain)
+    channel._api.send_private_forward_msg = _fake_send_private_forward_msg
+    channel._api.send_private_text = _fake_send_private_text
+    channel._api.get_login_info = _fake_get_login_info
+    channel._workspace = tmp_path
+    (tmp_path / "memory").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "memory" / "SELF.md").write_text(
+        "# Akashic 的自我认知\n- 我是 Steria，负责陪伴和协作。\n",
+        encoding="utf-8",
+    )
+
+    await event_bus.observe(
+        TurnStarted(
+            session_key="qq:1",
+            channel="qq",
+            chat_id="1",
+            content="帮我看看最近的提交",
+            timestamp=__import__("datetime").datetime.now(),
+        )
+    )
+    await event_bus.observe(
+        ToolCallStarted(
+            session_key="qq:1",
+            channel="qq",
+            chat_id="1",
+            iteration=1,
+            call_id="call-1",
+            tool_name="fetch_messages",
+            arguments={"description": "查最近消息", "query": "最近提交"},
+        )
+    )
+    await event_bus.observe(
+        ToolCallCompleted(
+            session_key="qq:1",
+            channel="qq",
+            chat_id="1",
+            iteration=1,
+            call_id="call-1",
+            tool_name="fetch_messages",
+            arguments={"description": "查最近消息", "query": "最近提交"},
+            final_arguments={"description": "查最近消息", "query": "最近提交"},
+            status="ok",
+            result_preview='{"count": 21, "matched_count": 1}',
+        )
+    )
+
+    await channel._on_response(
+        OutboundMessage(
+            channel="qq",
+            chat_id="1",
+            content="我看到了，最近主要是 QQ tracing 的改动。",
+            thinking="先确认这轮是否有工具调用，再组织结论。",
+        )
+    )
+
+    assert [item[0] for item in calls] == ["forward", "text"]
+    forward_payload = cast(dict[str, Any], calls[0][2])
+    assert forward_payload["news"] == [
+        {"text": "Steria：【模型思路】"},
+        {"text": "Steria：【工具链】"},
+    ]
+    assert "fetch_messages" in str(forward_payload)
+    assert "命中 1 条，返回上下文 21 条" in str(forward_payload)
+    assert calls[1] == ("text", 1, "我看到了，最近主要是 QQ tracing 的改动。")
+    assert "qq:1" not in channel._trace_states
+
+
+@pytest.mark.asyncio
+async def test_qq_private_trace_skips_empty_trace(monkeypatch: pytest.MonkeyPatch):
+    mod = _import_qq_channel(monkeypatch)
+    bus = _Bus()
+    session_manager = _SessionManager()
+    event_bus = EventBus()
+    channel = mod.QQChannel(
+        "42",
+        bus,
+        session_manager,
+        allow_from=["1"],
+        event_bus=event_bus,
+        http_requester=SimpleNamespace(get=AsyncMock()),
+    )
+    await channel.start()
+
+    calls: list[tuple[str, object, object]] = []
+
+    async def _drain(coro):
+        return await coro
+
+    async def _fake_send_private_forward_msg(user_id, **payload):
+        calls.append(("forward", user_id, payload))
+
+    async def _fake_send_private_text(user_id, content):
+        calls.append(("text", user_id, content))
+
+    async def _fake_get_login_info():
+        return SimpleNamespace(user_id="42", nickname="Bot")
+
+    channel._run_on_bot_loop = AsyncMock(side_effect=_drain)
+    channel._api.send_private_forward_msg = _fake_send_private_forward_msg
+    channel._api.send_private_text = _fake_send_private_text
+    channel._api.get_login_info = _fake_get_login_info
+
+    await event_bus.observe(
+        TurnStarted(
+            session_key="qq:1",
+            channel="qq",
+            chat_id="1",
+            content="好",
+            timestamp=__import__("datetime").datetime.now(),
+        )
+    )
+
+    await channel._on_response(
+        OutboundMessage(
+            channel="qq",
+            chat_id="1",
+            content="嗯，收到。",
+            thinking=None,
+        )
+    )
+
+    assert [item[0] for item in calls] == ["text"]
+    assert calls[0] == ("text", 1, "嗯，收到。")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更说明

本次 PR 为 QQ/NapCat 私聊通道增加了过程 tracing 能力，并以合并转发的形式发送到私聊窗口，再在下方发送最终答案。

主要改动包括：

- 为 `QQChannel` 接入生命周期事件订阅
  - `TurnStarted`
  - `StreamDeltaReady`
  - `ToolCallStarted`
  - `ToolCallCompleted`
- 在 QQ 私聊中新增 tracing 合并转发
  - 先发送 tracing
  - 再发送最终答案
- tracing 内容聚焦过程信息
  - 保留「模型思路」
  - 保留「工具链」
  - 不再重复展示用户问题和最终答案
- 优化工具链展示格式
  - 对常见工具结果做摘要化处理
  - 避免直接输出大段原始 JSON / 文件内容 / shell 原始结果
- tracing 展示名称改为从 `SELF.md` 动态提取
  - 优先解析正文中的“我是 XXX”
  - 回退到标题中的名称
  - 最终回退到默认名称

## 测试情况

已在 NapCat 私聊场景下验证：

- 可以正常发送 tracing 合并转发
- tracing 发送后会继续发送最终答案
- 私聊窗口中最终答案位于最下方
- tracing 外层预览名称可根据 `SELF.md` 动态变化
- 工具链展示相比原始输出更紧凑、可读

## 影响范围

本次改动主要涉及：

- `bootstrap/channels.py`
- `infra/channels/qq_channel.py`

未改动其他通道的现有行为。
