### PR TITLE
fix(ci): tighten test strictness and resource cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
 
       - name: Run pytest
         timeout-minutes: 10
+        env:
+          PYTHONWARNINGS: "ignore:.*AbstractEventLoopPolicy.*:DeprecationWarning"
         run: |
-          .venv/bin/pytest tests/
+          .venv/bin/pytest -q -W error tests/

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -161,52 +161,54 @@ class ProactiveDashboardReader:
             "tick_steps": self._count("tick_step_log"),
         }
         with self._lock:
-            recent_tick = self._db.execute(
-                """
+            recent_tick = self._db.execute("""
                 SELECT tick_id, session_key, started_at, finished_at, gate_exit,
                        terminal_action, skip_reason, steps_taken, drift_entered
                 FROM tick_log
                 ORDER BY started_at DESC
                 LIMIT 1
-                """
-            ).fetchone()
-            last_send_at = self._db.execute(
-                """
+                """).fetchone()
+            last_send_at = self._db.execute("""
                 SELECT sent_at
                 FROM deliveries
                 ORDER BY sent_at DESC
                 LIMIT 1
-                """
-            ).fetchone()
-            result_counts_rows = self._db.execute(
-                """
+                """).fetchone()
+            result_counts_rows = self._db.execute("""
                 SELECT COALESCE(terminal_action, gate_exit, 'unknown') AS bucket, COUNT(*) AS total
                 FROM tick_log
                 GROUP BY COALESCE(terminal_action, gate_exit, 'unknown')
-                """
-            ).fetchall()
-            flow_counts_rows = self._db.execute(
-                """
+                """).fetchall()
+            flow_counts_rows = self._db.execute("""
                 SELECT CASE WHEN drift_entered = 1 THEN 'drift' ELSE 'proactive' END AS bucket,
                        COUNT(*) AS total
                 FROM tick_log
                 GROUP BY CASE WHEN drift_entered = 1 THEN 'drift' ELSE 'proactive' END
-                """
-            ).fetchall()
-        result_counts = {str(row["bucket"]): int(row["total"]) for row in result_counts_rows}
-        flow_counts = {str(row["bucket"]): int(row["total"]) for row in flow_counts_rows}
+                """).fetchall()
+        result_counts = {
+            str(row["bucket"]): int(row["total"]) for row in result_counts_rows
+        }
+        flow_counts = {
+            str(row["bucket"]): int(row["total"]) for row in flow_counts_rows
+        }
         return {
             "counts": counts,
             "result_counts": result_counts,
             "flow_counts": flow_counts,
-            "last_tick_at": recent_tick["started_at"] if recent_tick is not None else None,
-            "last_send_at": last_send_at["sent_at"] if last_send_at is not None else None,
+            "last_tick_at": (
+                recent_tick["started_at"] if recent_tick is not None else None
+            ),
+            "last_send_at": (
+                last_send_at["sent_at"] if last_send_at is not None else None
+            ),
             "last_skip_reason": (
                 recent_tick["skip_reason"]
                 if recent_tick is not None and recent_tick["terminal_action"] != "reply"
                 else None
             ),
-            "recent_tick": self._row_to_tick_log(recent_tick) if recent_tick is not None else None,
+            "recent_tick": (
+                self._row_to_tick_log(recent_tick) if recent_tick is not None else None
+            ),
         }
 
     def list_deliveries(
@@ -307,18 +309,23 @@ class ProactiveDashboardReader:
             drift_only = "1"
         elif flow == "proactive":
             drift_only = "0"
-        safe_sort_by = sort_by if sort_by in {
-            "session_key",
-            "started_at",
-            "finished_at",
-            "terminal_action",
-            "gate_exit",
-            "steps_taken",
-            "alert_count",
-            "content_count",
-            "context_count",
-            "drift_entered",
-        } else "started_at"
+        safe_sort_by = (
+            sort_by
+            if sort_by
+            in {
+                "session_key",
+                "started_at",
+                "finished_at",
+                "terminal_action",
+                "gate_exit",
+                "steps_taken",
+                "alert_count",
+                "content_count",
+                "context_count",
+                "drift_entered",
+            }
+            else "started_at"
+        )
         safe_sort_order = "ASC" if str(sort_order).lower() == "asc" else "DESC"
         where, params = self._build_filters(
             ("session_key = ?", session_key),
@@ -493,7 +500,9 @@ class ProactiveDashboardReader:
 
     def _row_to_tick_log(self, row: sqlite3.Row) -> dict[str, Any]:
         payload = self._row_to_dict(row)
-        payload["interesting_ids"] = self._decode_json_list(payload.get("interesting_ids"))
+        payload["interesting_ids"] = self._decode_json_list(
+            payload.get("interesting_ids")
+        )
         payload["discarded_ids"] = self._decode_json_list(payload.get("discarded_ids"))
         payload["cited_ids"] = self._decode_json_list(payload.get("cited_ids"))
         payload["drift_entered"] = bool(payload.get("drift_entered"))
@@ -501,10 +510,18 @@ class ProactiveDashboardReader:
 
     def _row_to_tick_step(self, row: sqlite3.Row) -> dict[str, Any]:
         payload = self._row_to_dict(row)
-        payload["tool_args"] = self._decode_json_object(payload.pop("tool_args_json", ""))
-        payload["interesting_ids_after"] = self._decode_json_list(payload.get("interesting_ids_after"))
-        payload["discarded_ids_after"] = self._decode_json_list(payload.get("discarded_ids_after"))
-        payload["cited_ids_after"] = self._decode_json_list(payload.get("cited_ids_after"))
+        payload["tool_args"] = self._decode_json_object(
+            payload.pop("tool_args_json", "")
+        )
+        payload["interesting_ids_after"] = self._decode_json_list(
+            payload.get("interesting_ids_after")
+        )
+        payload["discarded_ids_after"] = self._decode_json_list(
+            payload.get("discarded_ids_after")
+        )
+        payload["cited_ids_after"] = self._decode_json_list(
+            payload.get("cited_ids_after")
+        )
         return payload
 
     @staticmethod
@@ -611,7 +628,8 @@ async def _compile_pending_plugins_async() -> None:
         logger.warning("esbuild unavailable: neither local install nor npx was found")
         return
     proc = await asyncio.create_subprocess_exec(
-        *esbuild_cmd, "--version",
+        *esbuild_cmd,
+        "--version",
         cwd=str(first_root),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -627,7 +645,12 @@ async def _compile_pending_plugins_async() -> None:
     version = stdout.decode("utf-8", errors="replace").strip()
     logger.info("npx esbuild 就绪 (%s)，开始编译插件面板...", version)
     for root, pdir in pending:
-        _run_esbuild(esbuild_cmd, pdir / "dashboard_panel.ts", pdir / "dashboard_panel.js", pdir.name)
+        _run_esbuild(
+            esbuild_cmd,
+            pdir / "dashboard_panel.ts",
+            pdir / "dashboard_panel.js",
+            pdir.name,
+        )
 
 
 def _load_plugin_dashboard(app: FastAPI, plugin_dir: Path, workspace: Path) -> None:
@@ -691,6 +714,8 @@ def create_dashboard_app(
             except asyncio.CancelledError:
                 pass
             store.close()
+            if hasattr(memory_admin, "close"):
+                memory_admin.close()
             if proactive_reader is not None:
                 get_proactive_reader().close()
 
@@ -726,10 +751,12 @@ def create_dashboard_app(
                 asset_mtime = js_path.stat().st_mtime_ns
                 if css_path.exists():
                     asset_mtime = max(asset_mtime, css_path.stat().st_mtime_ns)
-                result.append({
-                    "id": plugin_dir.name,
-                    "asset_version": str(asset_mtime),
-                })
+                result.append(
+                    {
+                        "id": plugin_dir.name,
+                        "asset_version": str(asset_mtime),
+                    }
+                )
         return result
 
     @app.get("/plugins/{plugin_id}/panel.js")
@@ -891,8 +918,7 @@ def create_dashboard_app(
         if manual_memory_optimizer is None:
             raise HTTPException(status_code=503, detail="memory optimizer 未启用")
         if (
-            optimizer_task is not None
-            and not optimizer_task.done()
+            optimizer_task is not None and not optimizer_task.done()
         ) or manual_memory_optimizer.is_running:
             raise HTTPException(status_code=409, detail="memory optimizer 正在运行")
         logger.info("Manual memory optimizer triggered via dashboard")

--- a/plugins/status_commands/dashboard.py
+++ b/plugins/status_commands/dashboard.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import sqlite3
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from fastapi import FastAPI
 
@@ -18,8 +19,7 @@ class KVCacheDashboardReader:
             return _summary_from_row(None)
         with self._lock:
             with _connect(self.db_path) as db:
-                row = db.execute(
-                    """
+                row = db.execute("""
                     SELECT
                         COUNT(*) AS turn_count,
                         SUM(CASE WHEN react_cache_prompt_tokens IS NOT NULL THEN 1 ELSE 0 END) AS tracked_turn_count,
@@ -27,8 +27,7 @@ class KVCacheDashboardReader:
                         COALESCE(SUM(react_cache_hit_tokens), 0) AS hit_tokens,
                         MAX(CASE WHEN react_cache_prompt_tokens IS NOT NULL THEN ts ELSE NULL END) AS last_tracked_at
                     FROM turns
-                    """
-                ).fetchone()
+                    """).fetchone()
         return _summary_from_row(row)
 
     def list_turns(
@@ -44,13 +43,11 @@ class KVCacheDashboardReader:
         offset = (safe_page - 1) * safe_size
         with self._lock:
             with _connect(self.db_path) as db:
-                total_row = db.execute(
-                    """
+                total_row = db.execute("""
                     SELECT COUNT(*) AS total
                     FROM turns
                     WHERE react_cache_prompt_tokens IS NOT NULL
-                    """
-                ).fetchone()
+                    """).fetchone()
                 rows = db.execute(
                     """
                     SELECT
@@ -139,10 +136,14 @@ def _summary_from_row(row: sqlite3.Row | None) -> dict[str, Any]:
     }
 
 
-def _connect(db_path: Path) -> sqlite3.Connection:
+@contextmanager
+def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
-    return conn
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 def _row_to_cache_turn(row: sqlite3.Row) -> dict[str, Any]:

--- a/proactive_v2/state.py
+++ b/proactive_v2/state.py
@@ -31,6 +31,7 @@ class ProactiveStateStore:
         self._lock = threading.RLock()
         self._db = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self._db.row_factory = sqlite3.Row
+        self._closed = False
         with self._lock:
             self._db.execute("PRAGMA journal_mode=WAL")
             self._db.execute("PRAGMA synchronous=NORMAL")
@@ -44,8 +45,18 @@ class ProactiveStateStore:
             self._count_rows("rejection_cooldown"),
         )
 
+    def __del__(self) -> None:
+        if not self._closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
     def close(self) -> None:
         with self._lock:
+            if self._closed:
+                return
+            self._closed = True
             self._db.close()
 
     def record_tick_log_start(
@@ -224,7 +235,10 @@ class ProactiveStateStore:
             return
         now = now or _utcnow()
         ts = now.isoformat()
-        params = [(_dedupe_source_key(source_key), item_id, ts) for source_key, item_id in entries]
+        params = [
+            (_dedupe_source_key(source_key), item_id, ts)
+            for source_key, item_id in entries
+        ]
         with self._lock:
             self._db.executemany(
                 """
@@ -424,7 +438,10 @@ class ProactiveStateStore:
             return
         now = now or _utcnow()
         ts = now.isoformat()
-        params = [(_dedupe_source_key(source_key), item_id, ts) for source_key, item_id in entries]
+        params = [
+            (_dedupe_source_key(source_key), item_id, ts)
+            for source_key, item_id in entries
+        ]
         with self._lock:
             self._db.executemany(
                 """
@@ -450,8 +467,12 @@ class ProactiveStateStore:
     ) -> None:
         now = _utcnow()
         seen_cutoff = (now - timedelta(hours=max(seen_ttl_hours, 1))).isoformat()
-        delivery_cutoff = (now - timedelta(hours=max(delivery_ttl_hours, 1))).isoformat()
-        semantic_cutoff = (now - timedelta(hours=max(semantic_ttl_hours, 1))).isoformat()
+        delivery_cutoff = (
+            now - timedelta(hours=max(delivery_ttl_hours, 1))
+        ).isoformat()
+        semantic_cutoff = (
+            now - timedelta(hours=max(semantic_ttl_hours, 1))
+        ).isoformat()
         context_only_cutoff = (now - timedelta(hours=24)).isoformat()
         with self._lock:
             removed_seen = self._db.execute(
@@ -557,8 +578,7 @@ class ProactiveStateStore:
         return int(row[0]) if row is not None else 0
 
     def _init_schema(self) -> None:
-        self._db.executescript(
-            """
+        self._db.executescript("""
             CREATE TABLE IF NOT EXISTS seen_items (
                 source_key TEXT NOT NULL,
                 item_id TEXT NOT NULL,
@@ -652,8 +672,7 @@ class ProactiveStateStore:
             );
             CREATE INDEX IF NOT EXISTS idx_tick_step_log_tick_step
             ON tick_step_log(tick_id, step_index);
-            """
-        )
+            """)
         self._db.commit()
 
     def _get_kv_datetime(self, key: str) -> datetime | None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = session
 addopts = -W error
 testpaths = tests
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+addopts = -W error
 testpaths = tests
 markers =
     scenario_mvp: agent loop 基础场景测试

--- a/session/store.py
+++ b/session/store.py
@@ -16,13 +16,20 @@ class SessionStore:
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._lock = threading.Lock()
+        self._closed = False
         self._has_fts = False
         self._init_schema()
 
+    def __del__(self) -> None:
+        if not self._closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
     def _init_schema(self) -> None:
         with self._lock:
-            self._conn.execute(
-                """
+            self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS sessions (
                     key               TEXT PRIMARY KEY,
                     created_at        TEXT NOT NULL,
@@ -30,11 +37,9 @@ class SessionStore:
                     last_consolidated INTEGER NOT NULL DEFAULT 0,
                     metadata          TEXT
                 )
-                """
-            )
+                """)
             self._ensure_session_columns()
-            self._conn.execute(
-                """
+            self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS messages (
                     id          TEXT PRIMARY KEY,
                     session_key TEXT NOT NULL,
@@ -46,8 +51,7 @@ class SessionStore:
                     ts          TEXT NOT NULL,
                     UNIQUE (session_key, seq)
                 )
-                """
-            )
+                """)
             self._ensure_next_seq_values()
             self._ensure_fts()
             self._conn.commit()
@@ -56,22 +60,16 @@ class SessionStore:
         rows = self._conn.execute("PRAGMA table_info(sessions)").fetchall()
         existing = {str(row["name"]) for row in rows}
         if "last_user_at" not in existing:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN last_user_at TEXT"
-            )
+            self._conn.execute("ALTER TABLE sessions ADD COLUMN last_user_at TEXT")
         if "last_proactive_at" not in existing:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN last_proactive_at TEXT"
-            )
+            self._conn.execute("ALTER TABLE sessions ADD COLUMN last_proactive_at TEXT")
         if "next_seq" not in existing:
             self._conn.execute(
                 "ALTER TABLE sessions ADD COLUMN next_seq INTEGER NOT NULL DEFAULT 0"
             )
 
     def _ensure_next_seq_values(self) -> None:
-        rows = self._conn.execute(
-            "SELECT key, next_seq FROM sessions"
-        ).fetchall()
+        rows = self._conn.execute("SELECT key, next_seq FROM sessions").fetchall()
         for row in rows:
             session_key = str(row["key"])
             current = int(row["next_seq"] or 0)
@@ -96,7 +94,9 @@ class SessionStore:
             if existing:
                 try:
                     cfg = dict(
-                        self._conn.execute("SELECT * FROM messages_fts_config").fetchall()
+                        self._conn.execute(
+                            "SELECT * FROM messages_fts_config"
+                        ).fetchall()
                     )
                     is_trigram = "trigram" in cfg.get("tokenize", "")
                 except sqlite3.OperationalError:
@@ -106,42 +106,36 @@ class SessionStore:
                     for trig in ("messages_ai", "messages_ad", "messages_au"):
                         self._conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
 
-            self._conn.execute(
-                """
+            self._conn.execute("""
                 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
                     content,
                     content='messages',
                     content_rowid='rowid',
                     tokenize='trigram'
                 )
-                """
-            )
-            self._conn.execute(
-                """
+                """)
+            self._conn.execute("""
                 CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
                     INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
                 END
-                """
-            )
-            self._conn.execute(
-                """
+                """)
+            self._conn.execute("""
                 CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
                     INSERT INTO messages_fts(messages_fts, rowid, content)
                     VALUES('delete', old.rowid, old.content);
                 END
-                """
-            )
-            self._conn.execute(
-                """
+                """)
+            self._conn.execute("""
                 CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
                     INSERT INTO messages_fts(messages_fts, rowid, content)
                     VALUES('delete', old.rowid, old.content);
                     INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
                 END
-                """
-            )
+                """)
             # Rebuild index so existing messages are covered by trigram.
-            self._conn.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+            self._conn.execute(
+                "INSERT INTO messages_fts(messages_fts) VALUES('rebuild')"
+            )
             self._conn.commit()
             self._has_fts = True
         except sqlite3.OperationalError:
@@ -149,6 +143,9 @@ class SessionStore:
 
     def close(self) -> None:
         with self._lock:
+            if self._closed:
+                return
+            self._closed = True
             self._conn.close()
 
     def session_exists(self, key: str) -> bool:
@@ -215,13 +212,11 @@ class SessionStore:
 
     def list_sessions(self) -> list[dict[str, Any]]:
         with self._lock:
-            rows = self._conn.execute(
-                """
+            rows = self._conn.execute("""
                 SELECT key, created_at, updated_at, last_user_at, last_proactive_at
                 FROM sessions
                 ORDER BY updated_at DESC
-                """
-            ).fetchall()
+                """).fetchall()
         return [
             {
                 "key": str(row["key"]),
@@ -249,12 +244,17 @@ class SessionStore:
         safe_page = max(1, int(page))
         safe_page_size = max(1, min(int(page_size), 200))
         offset = (safe_page - 1) * safe_page_size
-        safe_sort_by = sort_by if sort_by in {
-            "updated_at",
-            "created_at",
-            "last_user_at",
-            "last_proactive_at",
-        } else "updated_at"
+        safe_sort_by = (
+            sort_by
+            if sort_by
+            in {
+                "updated_at",
+                "created_at",
+                "last_user_at",
+                "last_proactive_at",
+            }
+            else "updated_at"
+        )
         safe_sort_order = "ASC" if str(sort_order).lower() == "asc" else "DESC"
 
         params: list[Any] = []
@@ -439,7 +439,9 @@ class SessionStore:
                 ).fetchone()
                 count = int((row["c"] if row else 0) or 0)
                 if count > 0:
-                    raise ValueError("选中的 session 中仍有 messages，需使用 cascade 删除")
+                    raise ValueError(
+                        "选中的 session 中仍有 messages，需使用 cascade 删除"
+                    )
             else:
                 self._conn.execute(
                     f"DELETE FROM messages WHERE session_key IN ({placeholders})",
@@ -501,13 +503,11 @@ class SessionStore:
 
     def list_presence(self) -> dict[str, dict[str, str | None]]:
         with self._lock:
-            rows = self._conn.execute(
-                """
+            rows = self._conn.execute("""
                 SELECT key, last_user_at, last_proactive_at
                 FROM sessions
                 WHERE last_user_at IS NOT NULL OR last_proactive_at IS NOT NULL
-                """
-            ).fetchall()
+                """).fetchall()
         return {
             str(row["key"]): {
                 "last_user_at": row["last_user_at"],
@@ -518,13 +518,11 @@ class SessionStore:
 
     def most_recent_user_at(self) -> str | None:
         with self._lock:
-            row = self._conn.execute(
-                """
+            row = self._conn.execute("""
                 SELECT MAX(last_user_at) AS last_user_at
                 FROM sessions
                 WHERE last_user_at IS NOT NULL
-                """
-            ).fetchone()
+                """).fetchone()
         if row is None:
             return None
         return row["last_user_at"]
@@ -551,7 +549,8 @@ class SessionStore:
     def count_messages(self, session_key: str) -> int:
         with self._lock:
             row = self._conn.execute(
-                "SELECT COUNT(1) AS c FROM messages WHERE session_key = ?", (session_key,)
+                "SELECT COUNT(1) AS c FROM messages WHERE session_key = ?",
+                (session_key,),
             ).fetchone()
         return int((row["c"] if row else 0) or 0)
 
@@ -583,7 +582,9 @@ class SessionStore:
     ) -> dict[str, Any]:
         message_id = f"{session_key}:{seq}"
         tool_chain_payload = (
-            json.dumps(tool_chain, ensure_ascii=False) if tool_chain is not None else None
+            json.dumps(tool_chain, ensure_ascii=False)
+            if tool_chain is not None
+            else None
         )
         extra_payload = json.dumps(extra or {}, ensure_ascii=False)
         with self._lock:
@@ -592,7 +593,16 @@ class SessionStore:
                 INSERT INTO messages (id, session_key, seq, role, content, tool_chain, extra, ts)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (message_id, session_key, seq, role, content, tool_chain_payload, extra_payload, ts),
+                (
+                    message_id,
+                    session_key,
+                    seq,
+                    role,
+                    content,
+                    tool_chain_payload,
+                    extra_payload,
+                    ts,
+                ),
             )
             self._conn.execute(
                 """
@@ -645,7 +655,9 @@ class SessionStore:
         safe_page_size = max(1, min(int(page_size), 200))
         offset = (safe_page - 1) * safe_page_size
         safe_sort = "ASC" if str(sort_order).lower() == "asc" else "DESC"
-        safe_sort_by = sort_by if sort_by in {"ts", "seq", "role", "session_key"} else "ts"
+        safe_sort_by = (
+            sort_by if sort_by in {"ts", "seq", "role", "session_key"} else "ts"
+        )
 
         params: list[Any] = []
         where_parts: list[str] = []
@@ -765,7 +777,9 @@ class SessionStore:
         return cur.rowcount > 0
 
     def delete_messages_batch(self, ids: list[str]) -> int:
-        clean_ids = [str(message_id).strip() for message_id in ids if str(message_id).strip()]
+        clean_ids = [
+            str(message_id).strip() for message_id in ids if str(message_id).strip()
+        ]
         if not clean_ids:
             return 0
         placeholders = ",".join("?" for _ in clean_ids)
@@ -794,7 +808,9 @@ class SessionStore:
         ids: list[str],
         last_consolidated: int,
     ) -> int:
-        clean_ids = [str(message_id).strip() for message_id in ids if str(message_id).strip()]
+        clean_ids = [
+            str(message_id).strip() for message_id in ids if str(message_id).strip()
+        ]
         if not clean_ids:
             return 0
         placeholders = ",".join("?" for _ in clean_ids)
@@ -811,9 +827,7 @@ class SessionStore:
                     tuple([session_key, *clean_ids]),
                 ).fetchall()
                 next_seq = (
-                    max(int(row["seq"]) for row in seq_rows) + 1
-                    if seq_rows
-                    else 0
+                    max(int(row["seq"]) for row in seq_rows) + 1 if seq_rows else 0
                 )
                 cur = self._conn.execute(
                     f"""
@@ -838,7 +852,9 @@ class SessionStore:
                 raise
         return int(cur.rowcount or 0)
 
-    def fetch_by_ids_with_context(self, ids: list[str], context: int) -> list[dict[str, Any]]:
+    def fetch_by_ids_with_context(
+        self, ids: list[str], context: int
+    ) -> list[dict[str, Any]]:
         """Fetch messages by ID, expanding each hit by ±context rows in its session.
 
         Returns messages ordered by (session_key, seq).
@@ -970,7 +986,9 @@ class SessionStore:
                 fts_params.extend([limit, offset])
                 try:
                     with self._lock:
-                        count_row = self._conn.execute(count_sql, tuple(count_params)).fetchone()
+                        count_row = self._conn.execute(
+                            count_sql, tuple(count_params)
+                        ).fetchone()
                         rows = self._conn.execute(fts_sql, tuple(fts_params)).fetchall()
                     total = int((count_row["c"] if count_row else 0) or 0)
                     return [self._row_to_message(row) for row in rows], total

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -6,13 +6,35 @@ import sqlite3
 import threading
 from datetime import datetime
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient as _RawTestClient
 
 from bootstrap.dashboard_api import create_dashboard_app as _create_dashboard_app
 from plugins.default_memory.engine import DefaultMemoryEngine
 from memory2.store import MemoryStore2
 from proactive_v2.state import ProactiveStateStore
 from session.store import SessionStore
+
+
+class _TrackedTestClient(_RawTestClient):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._is_closed = False
+
+    def close(self) -> None:
+        if self._is_closed:
+            return
+        self._is_closed = True
+        super().close()
+
+    def __del__(self) -> None:
+        if not self._is_closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+
+TestClient = _TrackedTestClient
 
 
 class _DashboardMemoryAdmin:
@@ -32,7 +54,9 @@ class _DashboardMemoryAdmin:
         return self._store.list_items_for_dashboard(**kwargs)
 
     def get_item_for_dashboard(self, item_id: str, *, include_embedding: bool = False):
-        return self._store.get_item_for_dashboard(item_id, include_embedding=include_embedding)
+        return self._store.get_item_for_dashboard(
+            item_id, include_embedding=include_embedding
+        )
 
     def update_item_for_dashboard(self, item_id: str, **kwargs):
         return self._store.update_item_for_dashboard(item_id, **kwargs)
@@ -45,6 +69,9 @@ class _DashboardMemoryAdmin:
 
     def find_similar_items_for_dashboard(self, item_id: str, **kwargs):
         return self._store.find_similar_items_for_dashboard(item_id, **kwargs)
+
+    def close(self) -> None:
+        self._store.close()
 
 
 def create_dashboard_app(tmp_path, **kwargs):
@@ -338,101 +365,95 @@ def _seed_workspace(tmp_path) -> None:
 
 def test_list_sessions_with_filters(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        resp = client.get(
+            "/api/dashboard/sessions",
+            params={"q": "alpha", "channel": "telegram"},
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["total"] == 1
+        assert payload["items"][0]["key"] == "telegram:100"
+        assert payload["items"][0]["message_count"] == 2
 
-    resp = client.get(
-        "/api/dashboard/sessions",
-        params={"q": "alpha", "channel": "telegram"},
-    )
-    assert resp.status_code == 200
-    payload = resp.json()
-    assert payload["total"] == 1
-    assert payload["items"][0]["key"] == "telegram:100"
-    assert payload["items"][0]["message_count"] == 2
-
-    messages_resp = client.get(
-        "/api/dashboard/messages",
-        params={"sort_by": "seq", "sort_order": "asc"},
-    )
-    assert messages_resp.status_code == 200
-    assert messages_resp.json()["items"][0]["seq"] == 0
+        messages_resp = client.get(
+            "/api/dashboard/messages",
+            params={"sort_by": "seq", "sort_order": "asc"},
+        )
+        assert messages_resp.status_code == 200
+        assert messages_resp.json()["items"][0]["seq"] == 0
 
 
 def test_update_and_delete_session(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        patch_resp = client.patch(
+            "/api/dashboard/sessions/telegram:100",
+            json={"metadata": {"title": "patched"}, "last_consolidated": 9},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["metadata"]["title"] == "patched"
+        assert patch_resp.json()["last_consolidated"] == 9
 
-    patch_resp = client.patch(
-        "/api/dashboard/sessions/telegram:100",
-        json={"metadata": {"title": "patched"}, "last_consolidated": 9},
-    )
-    assert patch_resp.status_code == 200
-    assert patch_resp.json()["metadata"]["title"] == "patched"
-    assert patch_resp.json()["last_consolidated"] == 9
+        delete_resp = client.delete("/api/dashboard/sessions/telegram:100")
+        assert delete_resp.status_code == 200
 
-    delete_resp = client.delete("/api/dashboard/sessions/telegram:100")
-    assert delete_resp.status_code == 200
-
-    get_resp = client.get("/api/dashboard/sessions/telegram:100")
-    assert get_resp.status_code == 404
+        get_resp = client.get("/api/dashboard/sessions/telegram:100")
+        assert get_resp.status_code == 404
 
 
 def test_manual_consolidate_session_uses_runtime_entrypoint(tmp_path) -> None:
     _seed_workspace(tmp_path)
     consolidator = _ManualConsolidator(result=True)
-    client = TestClient(
+    with TestClient(
         create_dashboard_app(tmp_path, manual_consolidator=consolidator)
-    )
+    ) as client:
+        resp = client.post(
+            "/api/dashboard/sessions/telegram:100/consolidate",
+            json={"archive_all": True},
+        )
 
-    resp = client.post(
-        "/api/dashboard/sessions/telegram:100/consolidate",
-        json={"archive_all": True},
-    )
-
-    assert resp.status_code == 200
-    payload = resp.json()
-    assert payload["triggered"] is True
-    assert payload["archive_all"] is True
-    assert payload["force"] is True
-    assert payload["session"]["key"] == "telegram:100"
-    assert consolidator.calls == [("telegram:100", True, True)]
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["triggered"] is True
+        assert payload["archive_all"] is True
+        assert payload["force"] is True
+        assert payload["session"]["key"] == "telegram:100"
+        assert consolidator.calls == [("telegram:100", True, True)]
 
 
 def test_manual_consolidate_session_requires_existing_session(tmp_path) -> None:
     _seed_workspace(tmp_path)
     consolidator = _ManualConsolidator(result=True)
-    client = TestClient(
+    with TestClient(
         create_dashboard_app(tmp_path, manual_consolidator=consolidator)
-    )
+    ) as client:
+        resp = client.post("/api/dashboard/sessions/missing/consolidate", json={})
 
-    resp = client.post("/api/dashboard/sessions/missing/consolidate", json={})
-
-    assert resp.status_code == 404
-    assert consolidator.calls == []
+        assert resp.status_code == 404
+        assert consolidator.calls == []
 
 
 def test_manual_consolidate_session_reports_unavailable_runtime(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        resp = client.post("/api/dashboard/sessions/telegram:100/consolidate", json={})
 
-    resp = client.post("/api/dashboard/sessions/telegram:100/consolidate", json={})
-
-    assert resp.status_code == 503
+        assert resp.status_code == 503
 
 
 def test_manual_consolidate_session_reports_concurrency_timeout(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(
+    with TestClient(
         create_dashboard_app(
             tmp_path,
             manual_consolidator=_ManualConsolidator(error=TimeoutError("busy")),
         )
-    )
+    ) as client:
+        resp = client.post("/api/dashboard/sessions/telegram:100/consolidate", json={})
 
-    resp = client.post("/api/dashboard/sessions/telegram:100/consolidate", json={})
-
-    assert resp.status_code == 409
-    assert resp.json()["detail"] == "busy"
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "busy"
 
 
 def test_manual_memory_optimizer_uses_runtime_entrypoint(tmp_path) -> None:
@@ -449,14 +470,13 @@ def test_manual_memory_optimizer_uses_runtime_entrypoint(tmp_path) -> None:
 
 
 def test_manual_memory_optimizer_reports_unavailable_runtime(tmp_path) -> None:
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        status_resp = client.get("/api/dashboard/memory/optimizer")
+        resp = client.post("/api/dashboard/memory/optimize")
 
-    status_resp = client.get("/api/dashboard/memory/optimizer")
-    resp = client.post("/api/dashboard/memory/optimize")
-
-    assert status_resp.status_code == 200
-    assert status_resp.json()["enabled"] is False
-    assert resp.status_code == 503
+        assert status_resp.status_code == 200
+        assert status_resp.json()["enabled"] is False
+        assert resp.status_code == 503
 
 
 def test_manual_memory_optimizer_reports_busy_runtime(tmp_path) -> None:
@@ -497,68 +517,68 @@ def test_manual_memory_optimizer_skips_when_backend_reports_busy(tmp_path) -> No
 
 def test_list_update_and_batch_delete_messages(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        list_resp = client.get(
+            "/api/dashboard/sessions/telegram:100/messages",
+            params={"q": "睡", "role": "assistant"},
+        )
+        assert list_resp.status_code == 200
+        payload = list_resp.json()
+        assert payload["total"] == 1
+        message_id = payload["items"][0]["id"]
 
-    list_resp = client.get(
-        "/api/dashboard/sessions/telegram:100/messages",
-        params={"q": "睡", "role": "assistant"},
-    )
-    assert list_resp.status_code == 200
-    payload = list_resp.json()
-    assert payload["total"] == 1
-    message_id = payload["items"][0]["id"]
+        patch_resp = client.patch(
+            f"/api/dashboard/messages/{message_id}",
+            json={"content": "已经睡了", "extra": {"edited": True}},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["content"] == "已经睡了"
+        assert patch_resp.json()["edited"] is True
 
-    patch_resp = client.patch(
-        f"/api/dashboard/messages/{message_id}",
-        json={"content": "已经睡了", "extra": {"edited": True}},
-    )
-    assert patch_resp.status_code == 200
-    assert patch_resp.json()["content"] == "已经睡了"
-    assert patch_resp.json()["edited"] is True
+        batch_resp = client.post(
+            "/api/dashboard/messages/batch-delete",
+            json={"ids": [message_id, "cli:local:0"]},
+        )
+        assert batch_resp.status_code == 200
+        assert batch_resp.json()["deleted_count"] == 2
 
-    batch_resp = client.post(
-        "/api/dashboard/messages/batch-delete",
-        json={"ids": [message_id, "cli:local:0"]},
-    )
-    assert batch_resp.status_code == 200
-    assert batch_resp.json()["deleted_count"] == 2
-
-    remain_resp = client.get("/api/dashboard/messages", params={"session_key": "telegram:100"})
-    assert remain_resp.status_code == 200
-    assert remain_resp.json()["total"] == 1
+        remain_resp = client.get(
+            "/api/dashboard/messages", params={"session_key": "telegram:100"}
+        )
+        assert remain_resp.status_code == 200
+        assert remain_resp.json()["total"] == 1
 
 
 def test_list_memory_items_with_filters(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        resp = client.get(
+            "/api/dashboard/memories",
+            params={
+                "q": "奶茶",
+                "memory_type": "preference",
+                "scope_channel": "telegram",
+                "has_embedding": "true",
+            },
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["total"] == 1
+        assert payload["items"][0]["memory_type"] == "preference"
+        assert payload["items"][0]["scope_chat_id"] == "100"
+        assert payload["items"][0]["has_embedding"] is True
 
-    resp = client.get(
-        "/api/dashboard/memories",
-        params={
-            "q": "奶茶",
-            "memory_type": "preference",
-            "scope_channel": "telegram",
-            "has_embedding": "true",
-        },
-    )
-    assert resp.status_code == 200
-    payload = resp.json()
-    assert payload["total"] == 1
-    assert payload["items"][0]["memory_type"] == "preference"
-    assert payload["items"][0]["scope_chat_id"] == "100"
-    assert payload["items"][0]["has_embedding"] is True
-
-    status_resp = client.get(
-        "/api/dashboard/memories",
-        params={
-            "memory_type": "profile",
-            "status": "active",
-            "page_size": 1,
-        },
-    )
-    assert status_resp.status_code == 200
-    assert status_resp.json()["total"] == 1
-    assert status_resp.json()["items"][0]["memory_type"] == "profile"
+        status_resp = client.get(
+            "/api/dashboard/memories",
+            params={
+                "memory_type": "profile",
+                "status": "active",
+                "page_size": 1,
+            },
+        )
+        assert status_resp.status_code == 200
+        assert status_resp.json()["total"] == 1
+        assert status_resp.json()["items"][0]["memory_type"] == "profile"
 
 
 def test_list_memory_items_sorts_by_created_at_desc(tmp_path) -> None:
@@ -580,19 +600,18 @@ def test_list_memory_items_sorts_by_created_at_desc(tmp_path) -> None:
         conn.commit()
     finally:
         conn.close()
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        resp = client.get(
+            "/api/dashboard/memories",
+            params={"sort_by": "created_at", "sort_order": "desc"},
+        )
 
-    resp = client.get(
-        "/api/dashboard/memories",
-        params={"sort_by": "created_at", "sort_order": "desc"},
-    )
-
-    assert resp.status_code == 200
-    assert [item["source_ref"] for item in resp.json()["items"]] == [
-        "cli:local:profile",
-        "telegram:100:event",
-        "telegram:100:pref",
-    ]
+        assert resp.status_code == 200
+        assert [item["source_ref"] for item in resp.json()["items"]] == [
+            "cli:local:profile",
+            "telegram:100:event",
+            "telegram:100:pref",
+        ]
 
 
 def test_list_memory_items_default_sort_is_created_at_desc(tmp_path) -> None:
@@ -626,170 +645,170 @@ def test_list_memory_items_default_sort_is_created_at_desc(tmp_path) -> None:
         conn.commit()
     finally:
         conn.close()
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        resp = client.get("/api/dashboard/memories")
 
-    resp = client.get("/api/dashboard/memories")
-
-    assert resp.status_code == 200
-    assert resp.json()["items"][0]["source_ref"] == "cli:local:profile"
+        assert resp.status_code == 200
+        assert resp.json()["items"][0]["source_ref"] == "cli:local:profile"
 
 
 def test_get_update_and_delete_memory(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        list_resp = client.get("/api/dashboard/memories", params={"q": "奶茶"})
+        memory_id = list_resp.json()["items"][0]["id"]
 
-    list_resp = client.get("/api/dashboard/memories", params={"q": "奶茶"})
-    memory_id = list_resp.json()["items"][0]["id"]
+        get_resp = client.get(
+            f"/api/dashboard/memories/{memory_id}",
+            params={"include_embedding": "true"},
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["embedding_dim"] == 2
 
-    get_resp = client.get(
-        f"/api/dashboard/memories/{memory_id}",
-        params={"include_embedding": "true"},
-    )
-    assert get_resp.status_code == 200
-    assert get_resp.json()["embedding_dim"] == 2
+        patch_resp = client.patch(
+            f"/api/dashboard/memories/{memory_id}",
+            json={
+                "status": "superseded",
+                "source_ref": "telegram:100:pref:patched",
+                "emotional_weight": 9,
+                "extra_json": {"scope_channel": "telegram", "scope_chat_id": "100"},
+            },
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["status"] == "superseded"
+        assert patch_resp.json()["emotional_weight"] == 9
+        assert patch_resp.json()["source_ref"] == "telegram:100:pref:patched"
 
-    patch_resp = client.patch(
-        f"/api/dashboard/memories/{memory_id}",
-        json={
-            "status": "superseded",
-            "source_ref": "telegram:100:pref:patched",
-            "emotional_weight": 9,
-            "extra_json": {"scope_channel": "telegram", "scope_chat_id": "100"},
-        },
-    )
-    assert patch_resp.status_code == 200
-    assert patch_resp.json()["status"] == "superseded"
-    assert patch_resp.json()["emotional_weight"] == 9
-    assert patch_resp.json()["source_ref"] == "telegram:100:pref:patched"
+        delete_resp = client.delete(f"/api/dashboard/memories/{memory_id}")
+        assert delete_resp.status_code == 200
 
-    delete_resp = client.delete(f"/api/dashboard/memories/{memory_id}")
-    assert delete_resp.status_code == 200
-
-    missing_resp = client.get(f"/api/dashboard/memories/{memory_id}")
-    assert missing_resp.status_code == 404
+        missing_resp = client.get(f"/api/dashboard/memories/{memory_id}")
+        assert missing_resp.status_code == 404
 
 
 def test_memory_similar_and_batch_delete(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        list_resp = client.get(
+            "/api/dashboard/memories", params={"scope_channel": "telegram"}
+        )
+        items = list_resp.json()["items"]
+        pref = next(item for item in items if item["memory_type"] == "preference")
+        event = next(item for item in items if item["memory_type"] == "event")
 
-    list_resp = client.get("/api/dashboard/memories", params={"scope_channel": "telegram"})
-    items = list_resp.json()["items"]
-    pref = next(item for item in items if item["memory_type"] == "preference")
-    event = next(item for item in items if item["memory_type"] == "event")
+        similar_resp = client.get(f"/api/dashboard/memories/{pref['id']}/similar")
+        assert similar_resp.status_code == 200
+        assert similar_resp.json()["total"] >= 1
+        assert similar_resp.json()["items"][0]["id"] == event["id"]
 
-    similar_resp = client.get(f"/api/dashboard/memories/{pref['id']}/similar")
-    assert similar_resp.status_code == 200
-    assert similar_resp.json()["total"] >= 1
-    assert similar_resp.json()["items"][0]["id"] == event["id"]
-
-    batch_resp = client.post(
-        "/api/dashboard/memories/batch-delete",
-        json={"ids": [pref["id"], event["id"]]},
-    )
-    assert batch_resp.status_code == 200
-    assert batch_resp.json()["deleted_count"] == 2
+        batch_resp = client.post(
+            "/api/dashboard/memories/batch-delete",
+            json={"ids": [pref["id"], event["id"]]},
+        )
+        assert batch_resp.status_code == 200
+        assert batch_resp.json()["deleted_count"] == 2
 
 
 def test_memory_dashboard_filters_survive_parallel_requests(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
 
-    def _fetch(memory_type: str) -> tuple[int, dict]:
-        resp = client.get(
-            "/api/dashboard/memories",
-            params={
-                "status": "active",
-                "memory_type": memory_type,
-                "page_size": 1,
-                "sort_by": "updated_at",
-                "sort_order": "desc",
-            },
-        )
-        return resp.status_code, resp.json()
+        def _fetch(memory_type: str) -> tuple[int, dict]:
+            resp = client.get(
+                "/api/dashboard/memories",
+                params={
+                    "status": "active",
+                    "memory_type": memory_type,
+                    "page_size": 1,
+                    "sort_by": "updated_at",
+                    "sort_order": "desc",
+                },
+            )
+            return resp.status_code, resp.json()
 
-    with ThreadPoolExecutor(max_workers=4) as executor:
-        results = list(
-            executor.map(_fetch, ["procedure", "preference", "profile", "event"])
-        )
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(
+                executor.map(_fetch, ["procedure", "preference", "profile", "event"])
+            )
 
-    for status_code, payload in results:
-        assert status_code == 200
-        assert "total" in payload
+        for status_code, payload in results:
+            assert status_code == 200
+            assert "total" in payload
 
 
 def test_proactive_dashboard_endpoints(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        overview_resp = client.get("/api/dashboard/proactive/overview")
+        assert overview_resp.status_code == 200
+        overview = overview_resp.json()
+        assert overview["counts"]["seen_items"] == 3
+        assert overview["counts"]["deliveries"] == 2
+        assert overview["counts"]["tick_logs"] == 2
+        assert overview["flow_counts"]["drift"] == 1
+        assert overview["flow_counts"]["proactive"] == 1
+        assert overview["last_tick_at"] == "2026-04-19T03:00:00+00:00"
+        assert overview["last_send_at"] == "2026-04-19T02:06:00+00:00"
+        assert overview["last_skip_reason"] == "busy"
 
-    overview_resp = client.get("/api/dashboard/proactive/overview")
-    assert overview_resp.status_code == 200
-    overview = overview_resp.json()
-    assert overview["counts"]["seen_items"] == 3
-    assert overview["counts"]["deliveries"] == 2
-    assert overview["counts"]["tick_logs"] == 2
-    assert overview["flow_counts"]["drift"] == 1
-    assert overview["flow_counts"]["proactive"] == 1
-    assert overview["last_tick_at"] == "2026-04-19T03:00:00+00:00"
-    assert overview["last_send_at"] == "2026-04-19T02:06:00+00:00"
-    assert overview["last_skip_reason"] == "busy"
+        deliveries_resp = client.get(
+            "/api/dashboard/proactive/deliveries",
+            params={"session_key": "telegram:100"},
+        )
+        assert deliveries_resp.status_code == 200
+        assert deliveries_resp.json()["total"] == 1
+        assert deliveries_resp.json()["items"][0]["delivery_key"] == "delivery-a"
 
-    deliveries_resp = client.get(
-        "/api/dashboard/proactive/deliveries",
-        params={"session_key": "telegram:100"},
-    )
-    assert deliveries_resp.status_code == 200
-    assert deliveries_resp.json()["total"] == 1
-    assert deliveries_resp.json()["items"][0]["delivery_key"] == "delivery-a"
+        seen_resp = client.get(
+            "/api/dashboard/proactive/seen_items",
+            params={"source_key": "mcp:feed"},
+        )
+        assert seen_resp.status_code == 200
+        assert seen_resp.json()["total"] == 2
 
-    seen_resp = client.get(
-        "/api/dashboard/proactive/seen_items",
-        params={"source_key": "mcp:feed"},
-    )
-    assert seen_resp.status_code == 200
-    assert seen_resp.json()["total"] == 2
+        semantic_resp = client.get(
+            "/api/dashboard/proactive/semantic_items",
+            params={"window_hours": 100000},
+        )
+        assert semantic_resp.status_code == 200
+        assert semantic_resp.json()["total"] == 2
 
-    semantic_resp = client.get(
-        "/api/dashboard/proactive/semantic_items",
-        params={"window_hours": 100000},
-    )
-    assert semantic_resp.status_code == 200
-    assert semantic_resp.json()["total"] == 2
+        tick_logs_resp = client.get(
+            "/api/dashboard/proactive/tick_logs",
+            params={"terminal_action": "skip"},
+        )
+        assert tick_logs_resp.status_code == 200
+        assert tick_logs_resp.json()["total"] == 1
+        assert tick_logs_resp.json()["items"][0]["tick_id"] == "tick-2"
 
-    tick_logs_resp = client.get(
-        "/api/dashboard/proactive/tick_logs",
-        params={"terminal_action": "skip"},
-    )
-    assert tick_logs_resp.status_code == 200
-    assert tick_logs_resp.json()["total"] == 1
-    assert tick_logs_resp.json()["items"][0]["tick_id"] == "tick-2"
+        drift_logs_resp = client.get(
+            "/api/dashboard/proactive/tick_logs",
+            params={"flow": "drift"},
+        )
+        assert drift_logs_resp.status_code == 200
+        assert drift_logs_resp.json()["total"] == 1
+        assert drift_logs_resp.json()["items"][0]["tick_id"] == "tick-2"
 
-    drift_logs_resp = client.get(
-        "/api/dashboard/proactive/tick_logs",
-        params={"flow": "drift"},
-    )
-    assert drift_logs_resp.status_code == 200
-    assert drift_logs_resp.json()["total"] == 1
-    assert drift_logs_resp.json()["items"][0]["tick_id"] == "tick-2"
+        proactive_sorted_resp = client.get(
+            "/api/dashboard/proactive/tick_logs",
+            params={"sort_by": "started_at", "sort_order": "asc"},
+        )
+        assert proactive_sorted_resp.status_code == 200
+        assert proactive_sorted_resp.json()["items"][0]["tick_id"] == "tick-1"
 
-    proactive_sorted_resp = client.get(
-        "/api/dashboard/proactive/tick_logs",
-        params={"sort_by": "started_at", "sort_order": "asc"},
-    )
-    assert proactive_sorted_resp.status_code == 200
-    assert proactive_sorted_resp.json()["items"][0]["tick_id"] == "tick-1"
+        tick_detail_resp = client.get("/api/dashboard/proactive/tick_logs/tick-1")
+        assert tick_detail_resp.status_code == 200
+        assert tick_detail_resp.json()["interesting_ids"] == ["mcp:feed:feed-1"]
+        assert tick_detail_resp.json()["final_message"] == "记得早点休息"
 
-    tick_detail_resp = client.get("/api/dashboard/proactive/tick_logs/tick-1")
-    assert tick_detail_resp.status_code == 200
-    assert tick_detail_resp.json()["interesting_ids"] == ["mcp:feed:feed-1"]
-    assert tick_detail_resp.json()["final_message"] == "记得早点休息"
-
-    tick_steps_resp = client.get("/api/dashboard/proactive/tick_logs/tick-1/steps")
-    assert tick_steps_resp.status_code == 200
-    assert tick_steps_resp.json()["total"] == 2
-    assert tick_steps_resp.json()["items"][0]["tool_name"] == "message_push"
-    assert tick_steps_resp.json()["items"][0]["tool_args"]["message"] == "记得早点休息"
-    assert tick_steps_resp.json()["items"][1]["terminal_action_after"] == "reply"
+        tick_steps_resp = client.get("/api/dashboard/proactive/tick_logs/tick-1/steps")
+        assert tick_steps_resp.status_code == 200
+        assert tick_steps_resp.json()["total"] == 2
+        assert tick_steps_resp.json()["items"][0]["tool_name"] == "message_push"
+        assert (
+            tick_steps_resp.json()["items"][0]["tool_args"]["message"] == "记得早点休息"
+        )
+        assert tick_steps_resp.json()["items"][1]["terminal_action_after"] == "reply"
 
 
 def test_status_commands_kvcache_dashboard_uses_workspace_observe(tmp_path) -> None:
@@ -798,8 +817,7 @@ def test_status_commands_kvcache_dashboard_uses_workspace_observe(tmp_path) -> N
     observe_dir.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(observe_dir / "observe.db")
     try:
-        conn.execute(
-            """
+        conn.execute("""
             CREATE TABLE turns(
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 ts TEXT NOT NULL,
@@ -810,8 +828,7 @@ def test_status_commands_kvcache_dashboard_uses_workspace_observe(tmp_path) -> N
                 react_cache_prompt_tokens INTEGER,
                 react_cache_hit_tokens INTEGER
             )
-            """
-        )
+            """)
         conn.execute(
             """
             INSERT INTO turns(
@@ -832,85 +849,83 @@ def test_status_commands_kvcache_dashboard_uses_workspace_observe(tmp_path) -> N
         conn.commit()
     finally:
         conn.close()
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        overview = client.get("/api/dashboard/status-commands/kvcache/overview")
+        turns = client.get("/api/dashboard/status-commands/kvcache/turns")
 
-    overview = client.get("/api/dashboard/status-commands/kvcache/overview")
-    turns = client.get("/api/dashboard/status-commands/kvcache/turns")
-
-    assert overview.status_code == 200
-    assert overview.json()["tracked_turn_count"] == 1
-    assert overview.json()["hit_rate"] == 260 / 300
-    assert turns.status_code == 200
-    payload = turns.json()
-    assert payload["total"] == 1
-    assert payload["items"][0]["session_key"] == "telegram:100"
-    assert payload["items"][0]["user_preview"] == "again"
+        assert overview.status_code == 200
+        assert overview.json()["tracked_turn_count"] == 1
+        assert overview.json()["hit_rate"] == 260 / 300
+        assert turns.status_code == 200
+        payload = turns.json()
+        assert payload["total"] == 1
+        assert payload["items"][0]["session_key"] == "telegram:100"
+        assert payload["items"][0]["user_preview"] == "again"
 
 
 def test_proactive_dashboard_batch_delete(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        seen_delete_resp = client.request(
+            "DELETE",
+            "/api/dashboard/proactive/seen_items/batch",
+            json={"source_key": "mcp:feed", "item_ids": ["feed-1"]},
+        )
+        assert seen_delete_resp.status_code == 200
+        assert seen_delete_resp.json()["deleted_count"] == 1
 
-    seen_delete_resp = client.request(
-        "DELETE",
-        "/api/dashboard/proactive/seen_items/batch",
-        json={"source_key": "mcp:feed", "item_ids": ["feed-1"]},
-    )
-    assert seen_delete_resp.status_code == 200
-    assert seen_delete_resp.json()["deleted_count"] == 1
+        seen_resp = client.get(
+            "/api/dashboard/proactive/seen_items",
+            params={"source_key": "mcp:feed"},
+        )
+        assert seen_resp.json()["total"] == 1
 
-    seen_resp = client.get(
-        "/api/dashboard/proactive/seen_items",
-        params={"source_key": "mcp:feed"},
-    )
-    assert seen_resp.json()["total"] == 1
+        cooldown_delete_resp = client.request(
+            "DELETE",
+            "/api/dashboard/proactive/rejection_cooldown/batch",
+            json={"source_key": "mcp:feed", "item_ids": ["feed-3"]},
+        )
+        assert cooldown_delete_resp.status_code == 200
+        assert cooldown_delete_resp.json()["deleted_count"] == 1
 
-    cooldown_delete_resp = client.request(
-        "DELETE",
-        "/api/dashboard/proactive/rejection_cooldown/batch",
-        json={"source_key": "mcp:feed", "item_ids": ["feed-3"]},
-    )
-    assert cooldown_delete_resp.status_code == 200
-    assert cooldown_delete_resp.json()["deleted_count"] == 1
-
-    cooldown_resp = client.get(
-        "/api/dashboard/proactive/rejection_cooldown",
-        params={"source_key": "mcp:feed"},
-    )
-    assert cooldown_resp.status_code == 200
-    assert cooldown_resp.json()["total"] == 0
+        cooldown_resp = client.get(
+            "/api/dashboard/proactive/rejection_cooldown",
+            params={"source_key": "mcp:feed"},
+        )
+        assert cooldown_resp.status_code == 200
+        assert cooldown_resp.json()["total"] == 0
 
 
 def test_proactive_dashboard_batch_delete_rejects_empty_payload(tmp_path) -> None:
     _seed_workspace(tmp_path)
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        seen_delete_resp = client.request(
+            "DELETE",
+            "/api/dashboard/proactive/seen_items/batch",
+            json={},
+        )
+        assert seen_delete_resp.status_code == 400
+        assert seen_delete_resp.json()["detail"] == "至少提供 source_key 或 item_ids"
 
-    seen_delete_resp = client.request(
-        "DELETE",
-        "/api/dashboard/proactive/seen_items/batch",
-        json={},
-    )
-    assert seen_delete_resp.status_code == 400
-    assert seen_delete_resp.json()["detail"] == "至少提供 source_key 或 item_ids"
-
-    cooldown_delete_resp = client.request(
-        "DELETE",
-        "/api/dashboard/proactive/rejection_cooldown/batch",
-        json={},
-    )
-    assert cooldown_delete_resp.status_code == 400
-    assert cooldown_delete_resp.json()["detail"] == "至少提供 source_key 或 item_ids"
+        cooldown_delete_resp = client.request(
+            "DELETE",
+            "/api/dashboard/proactive/rejection_cooldown/batch",
+            json={},
+        )
+        assert cooldown_delete_resp.status_code == 400
+        assert (
+            cooldown_delete_resp.json()["detail"] == "至少提供 source_key 或 item_ids"
+        )
 
 
 def test_plugin_asset_paths_reject_cross_platform_traversal(tmp_path) -> None:
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        for path in (
+            "/plugins/..%5Csecret/panel.js",
+            "/plugins/C:%5Csecret/panel.js",
+            "/plugins/%5C%5Cserver%5Cshare/panel.css",
+        ):
+            response = client.get(path)
+            assert response.status_code == 400
 
-    for path in (
-        "/plugins/..%5Csecret/panel.js",
-        "/plugins/C:%5Csecret/panel.js",
-        "/plugins/%5C%5Cserver%5Cshare/panel.css",
-    ):
-        response = client.get(path)
-        assert response.status_code == 400
-
-    assert client.get("/plugins/missing/panel.js").status_code == 404
+        assert client.get("/plugins/missing/panel.js").status_code == 404

--- a/tests/test_memory_rollup_plugin.py
+++ b/tests/test_memory_rollup_plugin.py
@@ -3,12 +3,34 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient as _RawTestClient
 
 from agent.memory import MemoryStore
 from bootstrap.dashboard_api import create_dashboard_app as _create_dashboard_app
 from plugins.default_memory.engine import DefaultMemoryEngine
 from memory2.store import MemoryStore2
+
+
+class _TrackedTestClient(_RawTestClient):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._is_closed = False
+
+    def close(self) -> None:
+        if self._is_closed:
+            return
+        self._is_closed = True
+        super().close()
+
+    def __del__(self) -> None:
+        if not self._is_closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+
+TestClient = _TrackedTestClient
 
 
 class _DashboardMemoryAdmin:
@@ -29,7 +51,9 @@ class _DashboardMemoryAdmin:
         return self._store.list_items_for_dashboard(**kwargs)
 
     def get_item_for_dashboard(self, item_id: str, *, include_embedding: bool = False):
-        return self._store.get_item_for_dashboard(item_id, include_embedding=include_embedding)
+        return self._store.get_item_for_dashboard(
+            item_id, include_embedding=include_embedding
+        )
 
     def update_item_for_dashboard(self, item_id: str, **kwargs):
         return self._store.update_item_for_dashboard(item_id, **kwargs)
@@ -42,6 +66,9 @@ class _DashboardMemoryAdmin:
 
     def find_similar_items_for_dashboard(self, item_id: str, **kwargs):
         return self._store.find_similar_items_for_dashboard(item_id, **kwargs)
+
+    def close(self) -> None:
+        self._store.close()
 
     def read_long_term(self) -> str:
         return self._memory.read_long_term()
@@ -90,44 +117,41 @@ def test_memory_rollup_generates_and_commits_pending(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
+        assert generated["total"] >= 1
+        candidate = generated["items"][0]
 
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
-    assert generated["total"] >= 1
-    candidate = generated["items"][0]
+        committed = client.post(
+            "/api/dashboard/memory-rollup/commit",
+            json={"items": [{"id": candidate["id"]}]},
+        ).json()
 
-    committed = client.post(
-        "/api/dashboard/memory-rollup/commit",
-        json={"items": [{"id": candidate["id"]}]},
-    ).json()
+        assert committed["appended_count"] == 1
+        after_commit = client.get("/api/dashboard/memory-rollup/candidates").json()
+        assert candidate["id"] not in {item["id"] for item in after_commit["items"]}
+        pending = MemoryStore(tmp_path).read_pending()
+        assert "- [preference]" in pending
+        assert "用户希望回复温暖直接，先给结论，不喜欢成功学式鼓励" in pending
 
-    assert committed["appended_count"] == 1
-    after_commit = client.get("/api/dashboard/memory-rollup/candidates").json()
-    assert candidate["id"] not in {
-        item["id"] for item in after_commit["items"]
-    }
-    pending = MemoryStore(tmp_path).read_pending()
-    assert "- [preference]" in pending
-    assert "用户希望回复温暖直接，先给结论，不喜欢成功学式鼓励" in pending
+        marked_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
+        try:
+            for source_id in candidate["source_ids"]:
+                item = marked_store.get_item_for_dashboard(source_id)
+                assert item is not None
+                extra = cast(dict[str, object], item["extra_json"])
+                rollup = cast(dict[str, object], extra["_rollup"])
+                assert rollup["candidate_id"] == candidate["id"]
+        finally:
+            marked_store.close()
 
-    marked_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
-    try:
-        for source_id in candidate["source_ids"]:
-            item = marked_store.get_item_for_dashboard(source_id)
-            assert item is not None
-            extra = cast(dict[str, object], item["extra_json"])
-            rollup = cast(dict[str, object], extra["_rollup"])
-            assert rollup["candidate_id"] == candidate["id"]
-    finally:
-        marked_store.close()
-
-    regenerated = client.post("/api/dashboard/memory-rollup/generate").json()
-    regenerated_source_ids = {
-        source_id
-        for item in regenerated["items"]
-        for source_id in item["source_ids"]
-    }
-    assert not set(candidate["source_ids"]) & regenerated_source_ids
+        regenerated = client.post("/api/dashboard/memory-rollup/generate").json()
+        regenerated_source_ids = {
+            source_id
+            for item in regenerated["items"]
+            for source_id in item["source_ids"]
+        }
+        assert not set(candidate["source_ids"]) & regenerated_source_ids
 
 
 def test_memory_rollup_profile_candidate_uses_profile_tag(tmp_path: Path):
@@ -140,11 +164,11 @@ def test_memory_rollup_profile_candidate_uses_profile_tag(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
 
-    assert generated["items"][0]["title"] == "身份信息"
-    assert generated["items"][0]["tag"] == "identity"
+        assert generated["items"][0]["title"] == "身份信息"
+        assert generated["items"][0]["tag"] == "identity"
 
 
 def test_memory_rollup_uses_real_memory_content(tmp_path: Path):
@@ -157,10 +181,10 @@ def test_memory_rollup_uses_real_memory_content(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
 
-    assert generated["items"][0]["content"] == "用户希望回复简洁、冷淡"
+        assert generated["items"][0]["content"] == "用户希望回复简洁、冷淡"
 
 
 def test_memory_rollup_does_not_group_by_keywords(tmp_path: Path):
@@ -177,11 +201,11 @@ def test_memory_rollup_does_not_group_by_keywords(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
 
-    contents = {item["content"] for item in generated["items"]}
-    assert contents == {"用户希望回复简洁", "用户希望语气自然"}
+        contents = {item["content"] for item in generated["items"]}
+        assert contents == {"用户希望回复简洁", "用户希望语气自然"}
 
 
 def test_memory_rollup_scores_with_memory_table_metrics(tmp_path: Path):
@@ -204,13 +228,13 @@ def test_memory_rollup_scores_with_memory_table_metrics(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
 
-    assert generated["items"][0]["content"] == "用户偏好高频出现的记忆"
-    assert generated["items"][0]["reinforcement"] == 2
-    assert generated["items"][0]["emotional_weight"] == 8
-    assert generated["items"][0]["score"] > generated["items"][1]["score"]
+        assert generated["items"][0]["content"] == "用户偏好高频出现的记忆"
+        assert generated["items"][0]["reinforcement"] == 2
+        assert generated["items"][0]["emotional_weight"] == 8
+        assert generated["items"][0]["score"] > generated["items"][1]["score"]
 
 
 def test_memory_rollup_shows_sensitive_profile_content(tmp_path: Path):
@@ -222,11 +246,11 @@ def test_memory_rollup_shows_sensitive_profile_content(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
 
-    contents = {item["content"] for item in generated["items"]}
-    assert "用户的邮箱是 hanayue@example.com" in contents
+        contents = {item["content"] for item in generated["items"]}
+        assert "用户的邮箱是 hanayue@example.com" in contents
 
 
 def test_memory_rollup_ignore_marks_sources_without_pending(tmp_path: Path):
@@ -238,37 +262,37 @@ def test_memory_rollup_ignore_marks_sources_without_pending(tmp_path: Path):
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
-    candidate = generated["items"][0]
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
+        candidate = generated["items"][0]
 
-    ignored = client.post(
-        "/api/dashboard/memory-rollup/ignore",
-        json={"id": candidate["id"]},
-    ).json()
+        ignored = client.post(
+            "/api/dashboard/memory-rollup/ignore",
+            json={"id": candidate["id"]},
+        ).json()
 
-    assert ignored["ignored"] is True
-    assert MemoryStore(tmp_path).read_pending() == ""
-    after_ignore = client.get("/api/dashboard/memory-rollup/candidates").json()
-    assert candidate["id"] not in {item["id"] for item in after_ignore["items"]}
+        assert ignored["ignored"] is True
+        assert MemoryStore(tmp_path).read_pending() == ""
+        after_ignore = client.get("/api/dashboard/memory-rollup/candidates").json()
+        assert candidate["id"] not in {item["id"] for item in after_ignore["items"]}
 
-    marked_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
-    try:
-        item = marked_store.get_item_for_dashboard(candidate["source_ids"][0])
-        assert item is not None
-        extra = cast(dict[str, object], item["extra_json"])
-        rollup = cast(dict[str, object], extra["_rollup"])
-        assert rollup["action"] == "ignored"
-    finally:
-        marked_store.close()
+        marked_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
+        try:
+            item = marked_store.get_item_for_dashboard(candidate["source_ids"][0])
+            assert item is not None
+            extra = cast(dict[str, object], item["extra_json"])
+            rollup = cast(dict[str, object], extra["_rollup"])
+            assert rollup["action"] == "ignored"
+        finally:
+            marked_store.close()
 
-    regenerated = client.post("/api/dashboard/memory-rollup/generate").json()
-    regenerated_source_ids = {
-        source_id
-        for item in regenerated["items"]
-        for source_id in item["source_ids"]
-    }
-    assert candidate["source_ids"][0] not in regenerated_source_ids
+        regenerated = client.post("/api/dashboard/memory-rollup/generate").json()
+        regenerated_source_ids = {
+            source_id
+            for item in regenerated["items"]
+            for source_id in item["source_ids"]
+        }
+        assert candidate["source_ids"][0] not in regenerated_source_ids
 
 
 def test_memory_rollup_delete_sources_removes_memory_without_pending(tmp_path: Path):
@@ -280,23 +304,23 @@ def test_memory_rollup_delete_sources_removes_memory_without_pending(tmp_path: P
     )
     memory2.close()
 
-    client = TestClient(create_dashboard_app(tmp_path))
-    generated = client.post("/api/dashboard/memory-rollup/generate").json()
-    candidate = generated["items"][0]
-    source_id = candidate["source_ids"][0]
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        generated = client.post("/api/dashboard/memory-rollup/generate").json()
+        candidate = generated["items"][0]
+        source_id = candidate["source_ids"][0]
 
-    deleted = client.post(
-        "/api/dashboard/memory-rollup/delete-sources",
-        json={"id": candidate["id"]},
-    ).json()
+        deleted = client.post(
+            "/api/dashboard/memory-rollup/delete-sources",
+            json={"id": candidate["id"]},
+        ).json()
 
-    assert deleted["deleted_count"] == 1
-    assert MemoryStore(tmp_path).read_pending() == ""
-    after_delete = client.get("/api/dashboard/memory-rollup/candidates").json()
-    assert candidate["id"] not in {item["id"] for item in after_delete["items"]}
+        assert deleted["deleted_count"] == 1
+        assert MemoryStore(tmp_path).read_pending() == ""
+        after_delete = client.get("/api/dashboard/memory-rollup/candidates").json()
+        assert candidate["id"] not in {item["id"] for item in after_delete["items"]}
 
-    check_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
-    try:
-        assert check_store.get_item_for_dashboard(source_id) is None
-    finally:
-        check_store.close()
+        check_store = MemoryStore2(tmp_path / "memory" / "memory2.db")
+        try:
+            assert check_store.get_item_for_dashboard(source_id) is None
+        finally:
+            check_store.close()


### PR DESCRIPTION
## 问题

测试环境最近逐步出现以下噪音：
- pytest 警告与资源管理行为在 CI 与本地输出不一致
- 部分测试路径在长跑时出现资源清理相关警告

## 改动

- 调整 pytest 默认行为：将 `addopts` 改为 `-W error`，把警告当作回归信号
- CI 中新增 `PYTHONWARNINGS` 过滤已知的第三方 `pytest-asyncio` 兼容性告警
- 对若干资源持有点补齐关闭路径与上下文管理，减少数据库连接泄漏风险
- 使用 `black --check` 后同步风格：`bootstrap/dashboard_api.py`、`plugins/status_commands/dashboard.py`、`proactive_v2/state.py`、`session/store.py`、`tests/test_dashboard_api.py`、`tests/test_memory_rollup_plugin.py`

## 验证

- `PYTHONWARNINGS='ignore:.*AbstractEventLoopPolicy.*:DeprecationWarning' python -m pytest -q -W error`
- `1224 passed`
- `pyright` 与 `pyright --project pyrightconfig.tests.json`：0 errors

## 影响范围

CI 质量门槛更严格，现有测试前置环境需保持相同警告过滤配置，以避免第三方已知告警影响通过。
