### PR TITLE
fix(memory): 调整记忆窗口和优化间隔默认值

### DIFF
--- a/_handbook/memory-markdown.md
+++ b/_handbook/memory-markdown.md
@@ -108,7 +108,7 @@ PENDING.md 只是缓冲——consolidation 把新事实写进 PENDING，但 PEND
 
 **为什么要隔一层？为了缓存。**
 
-MEMORY.md 是全文注入 system prompt 的。如果每次 consolidation 都直接改 MEMORY.md，那每轮对话的 system prompt 都不一样 → DeepSeek 的 prompt cache 永远命中不了 → 每轮都多花几秒和一份 cache_write token。Optimizer 把 MEMORY.md 的更新频率降到 3 小时一次，中间攒在 PENDING.md 里不动它，让 prompt cache 能稳定命中几十上百轮。
+MEMORY.md 是全文注入 system prompt 的。如果每次 consolidation 都直接改 MEMORY.md，那每轮对话的 system prompt 都不一样 → DeepSeek 的 prompt cache 永远命中不了 → 每轮都多花几秒和一份 cache_write token。Optimizer 把 MEMORY.md 的更新频率降到 18 小时一次，中间攒在 PENDING.md 里不动它，让 prompt cache 能稳定命中几十上百轮。
 
 ```
 consolidation (每 N 条消息触发一次)
@@ -129,7 +129,7 @@ Optimizer (定时触发)
 ```
 PENDING.md（增量事实缓冲区）
     ↓
-  Optimizer 定时触发（默认 memory_optimizer_interval_seconds = 50400）
+  Optimizer 定时触发（默认 memory_optimizer_interval_seconds = 64800）
     ↓
   读 MEMORY.md + PENDING.md → LLM 做归档决策：
     • 新事实 → 写入 MEMORY.md 对应分类

--- a/agent/config.py
+++ b/agent/config.py
@@ -103,7 +103,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
             agent_cfg.get("max_iterations", data.get("max_iterations", 10))
         ),
         memory_window=int(
-            agent_context.get("memory_window", data.get("memory_window", 24))
+            agent_context.get("memory_window", data.get("memory_window", 40))
         ),
         base_url=str(llm_main.get("base_url") or data.get("base_url") or _PRESETS.get(provider) or ""),
         extra_body=_load_extra_body(data),
@@ -118,7 +118,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         memory_optimizer_interval_seconds=int(
             agent_maintenance.get(
                 "memory_optimizer_interval_seconds",
-                data.get("memory_optimizer_interval_seconds", 50400),
+                data.get("memory_optimizer_interval_seconds", 64800),
             )
         ),
         light_model=str(llm_fast.get("model") or data.get("light_model", "")),

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -104,13 +104,13 @@ class Config:
     system_prompt: str
     max_tokens: int = 8192
     max_iterations: int = 10
-    memory_window: int = 24
+    memory_window: int = 40
     base_url: str | None = None
     extra_body: dict = field(default_factory=dict)
     channels: ChannelsConfig = field(default_factory=ChannelsConfig)
     proactive: ProactiveConfig = field(default_factory=ProactiveConfig)
     memory_optimizer_enabled: bool = True
-    memory_optimizer_interval_seconds: int = 50400
+    memory_optimizer_interval_seconds: int = 64800
     light_model: str = ""
     light_api_key: str = ""
     light_base_url: str = ""

--- a/config.example.toml
+++ b/config.example.toml
@@ -48,7 +48,7 @@ search_enabled = true
 # 可选：长期记忆整理任务（默认已启用，通常无需修改）
 # [agent.maintenance]
 # memory_optimizer_enabled = true
-# memory_optimizer_interval_seconds = 50400
+# memory_optimizer_interval_seconds = 64800
 
 # 可选：控制加载哪些工具集（默认值适合大多数场景）
 # [agent.wiring]

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -322,7 +322,7 @@ class MemoryOptimizer:
 
 # ── MemoryOptimizerLoop ───────────────────────────────────────────
 
-_DEFAULT_INTERVAL_SECONDS = 10800  # 默认每 3 小时整点
+_DEFAULT_INTERVAL_SECONDS = 64800  # 默认每 18 小时整点
 
 
 class MemoryOptimizerLoop:

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -117,7 +117,7 @@ system_prompt = "test"
     assert cfg.max_iterations == 10
 
 
-def test_load_config_defaults_memory_optimizer_to_14h(tmp_path: Path):
+def test_load_config_defaults_memory_window_and_optimizer_interval(tmp_path: Path):
     config_path = tmp_path / "config.toml"
     config_path.write_text(
         """
@@ -137,7 +137,8 @@ system_prompt = "test"
 
     cfg = load_config(config_path)
 
-    assert cfg.memory_optimizer_interval_seconds == 50400
+    assert cfg.memory_window == 40
+    assert cfg.memory_optimizer_interval_seconds == 64800
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

近期 KV cache 与 memory_window 排查里发现两个默认值需要一起收口：

- `memory_window` 本地被调到 80 后，真实 observe 成本并不适合作为默认值；按当前使用模式，默认保留 40 更符合 token 成本和短期连续性的平衡。
- `memory_window=40` 会更频繁地产生 PENDING，但 PENDING 不进入普通 prompt；真正伤缓存的是 optimizer 更新 MEMORY.md / SELF.md，因此 optimizer 默认间隔需要从 14h 调整到更贴近体验与缓存成本的 18h。

## 改动

- 将配置加载默认 `memory_window` 从 24 调整为 40，并同步 `Config` dataclass 默认值。
- 将 memory optimizer 默认间隔从 14h 调整为 18h（64800 秒），并同步 loop fallback 常量。
- 更新 `config.example.toml` 与 memory handbook 中的默认值说明。
- 补充 runtime smoke 测试，覆盖 `memory_window` 和 optimizer 默认间隔。

## 验证

- `pytest tests/test_runtime_smoke.py tests/test_memory_window_alignment.py -q`：10 passed
- `git diff --check`
- `pyright agent/config.py agent/config_models.py proactive_v2/memory_optimizer.py tests/test_runtime_smoke.py`：0 errors，保留既有 warnings

## 配置影响

无新增配置；默认 `memory_window` 调整为 40，默认 `memory_optimizer_interval_seconds` 调整为 64800。已有显式配置仍按用户配置生效。
