### PR TITLE
feat(akasha): 接入 Akasha 记忆引擎

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -240,14 +240,21 @@ def _load_channels_config(data: dict) -> ChannelsConfig:
                 groups=groups,
             )
 
-    socket_value = channels_data.get("socket") or channels_data.get("cli", {}).get(
+    cli_data = _as_dict(channels_data.get("cli"))
+    socket_value = channels_data.get("socket") or cli_data.get(
         "socket", DEFAULT_SOCKET
     )
+    cli_session_key = str(cli_data.get("session_key") or "").strip()
+    cli_channel = str(cli_data.get("channel") or "").strip()
+    cli_chat_id = str(cli_data.get("chat_id") or "").strip()
+    if not cli_session_key and cli_channel and cli_chat_id:
+        cli_session_key = f"{cli_channel}:{cli_chat_id}"
     channels = ChannelsConfig(
         telegram=telegram,
         qq=qq,
         qqbot=qqbot,
         socket=_normalize_cli_socket_endpoint(socket_value),
+        cli_session_key=cli_session_key,
     )
     channels.socket = _normalize_cli_socket_endpoint(channels.socket)
     return channels

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -50,6 +50,7 @@ class ChannelsConfig:
     qq: QQChannelConfig | None = None
     qqbot: QQBotChannelConfig | None = None
     socket: str = "/tmp/akashic.sock"
+    cli_session_key: str = ""
 
 
 @dataclass

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -514,8 +514,8 @@ class DefaultContextStore(ContextStore):
             RetrievalRequest(
                 message=msg.content,
                 session_key=session_key,
-                channel=msg.channel,
-                chat_id=msg.chat_id,
+                channel=msg.context_channel,
+                chat_id=msg.context_chat_id,
                 history=history_messages,
                 session_metadata=(
                     session.metadata if isinstance(session.metadata, dict) else {}

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -16,7 +16,7 @@ from agent.core.types import (
 )
 from agent.prompting import DEFAULT_CONTEXT_TRIM_PLANS, is_context_frame
 from agent.provider import ContentSafetyError, ContextLengthError
-from agent.retrieval.protocol import RetrievalRequest
+from agent.retrieval.protocol import RetrievalRequest, RetrievalResult
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutor
 from agent.tool_runtime import (
     append_assistant_tool_calls,
@@ -509,20 +509,23 @@ class DefaultContextStore(ContextStore):
         raw_history = list(session.get_history())
         history_messages = support.to_history_messages(raw_history)
 
-        # 2. 再执行 retrieval，保持当前 pipeline 行为不变。
-        retrieval_result = await self._retrieval.retrieve(
-            RetrievalRequest(
-                message=msg.content,
-                session_key=session_key,
-                channel=msg.context_channel,
-                chat_id=msg.context_chat_id,
-                history=history_messages,
-                session_metadata=(
-                    session.metadata if isinstance(session.metadata, dict) else {}
-                ),
-                timestamp=msg.timestamp,
+        # 2. 系统轮次可显式跳过预检索，避免污染检索诊断和激活状态。
+        if bool((msg.metadata or {}).get("skip_memory_retrieval")):
+            retrieval_result = RetrievalResult(block="", trace=None)
+        else:
+            retrieval_result = await self._retrieval.retrieve(
+                RetrievalRequest(
+                    message=msg.content,
+                    session_key=session_key,
+                    channel=msg.context_channel,
+                    chat_id=msg.context_chat_id,
+                    history=history_messages,
+                    session_metadata=(
+                        session.metadata if isinstance(session.metadata, dict) else {}
+                    ),
+                    timestamp=msg.timestamp,
+                )
             )
-        )
 
         # 3. 最后补齐 ContextBundle，把主链正式字段直接收进显式合同。
         skill_mentions = support.collect_skill_mentions(

--- a/agent/lifecycle/phases/before_reasoning.py
+++ b/agent/lifecycle/phases/before_reasoning.py
@@ -54,6 +54,7 @@ class _SyncToolContextModule:
         self._tools.set_context(
             channel=before_turn.channel,
             chat_id=before_turn.chat_id,
+            current_timestamp=before_turn.timestamp.isoformat(),
             current_user_source_ref=predict_current_user_source_ref(
                 session_manager=self._session_manager,
                 session=state.session,

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -85,8 +85,8 @@ class _BuildBeforeTurnCtxModule:
         bundle = cast(ContextBundle, frame.slots[_CONTEXT_BUNDLE_SLOT])
         frame.slots[_CTX_SLOT] = BeforeTurnCtx(
             session_key=state.session_key,
-            channel=state.msg.channel,
-            chat_id=state.msg.chat_id,
+            channel=state.msg.context_channel,
+            chat_id=state.msg.context_chat_id,
             content=state.msg.content,
             timestamp=state.msg.timestamp,
             skill_names=list(bundle.skill_mentions),

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -607,6 +607,7 @@ class AgentLoop:
         chat_id: str = "direct",
         omit_user_turn: bool = False,
         skip_post_memory: bool = False,
+        skip_memory_retrieval: bool = False,
         stream_events: bool = False,
         disabled_tools: list[str] | None = None,
     ) -> str:
@@ -615,6 +616,8 @@ class AgentLoop:
             metadata["omit_user_turn"] = True
         if skip_post_memory:
             metadata["skip_post_memory"] = True
+        if skip_memory_retrieval:
+            metadata["skip_memory_retrieval"] = True
         if not stream_events:
             metadata["suppress_stream_events"] = True
         if disabled_tools:

--- a/agent/looping/handlers.py
+++ b/agent/looping/handlers.py
@@ -71,7 +71,11 @@ async def process_spawn_completion_event(
     )
 
     # 2. 再调用主模型生成用户可见回复。
-    tools.set_context(channel=item.channel, chat_id=item.chat_id)
+    tools.set_context(
+        channel=item.channel,
+        chat_id=item.chat_id,
+        current_timestamp=item.timestamp.isoformat(),
+    )
     prompt_render = await prompt_render_fn(
         PromptRenderInput(
             session_key=key,

--- a/agent/retrieval/default_pipeline.py
+++ b/agent/retrieval/default_pipeline.py
@@ -43,6 +43,7 @@ class DefaultMemoryRetrievalPipeline(MemoryRetrievalPipeline):
                     "session_metadata": request.session_metadata,
                 },
                 filters=MemoryQueryFilters(hints=dict(request.extra or {})),
+                timestamp=request.timestamp,
             )
         )
 

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -490,7 +490,13 @@ class SchedulerService:
                 session_key=f"scheduler:{job.id}",
                 omit_user_turn=True,
                 skip_post_memory=True,
-                disabled_tools=["message_push"],
+                skip_memory_retrieval=True,
+                disabled_tools=[
+                    "message_push",
+                    "recall_memory",
+                    "memorize",
+                    "forget_memory",
+                ],
             )
             elapsed = time.monotonic() - t0
             self.tracker.record(elapsed)

--- a/agent/tools/recall_memory.py
+++ b/agent/tools/recall_memory.py
@@ -78,6 +78,7 @@ class RecallMemoryTool(Tool):
                 ),
                 limit=max(1, min(int(limit), 200)),
                 context=dict(extra),
+                timestamp=_parse_current_timestamp(extra.get("current_timestamp")),
             )
         )
         return _render_records(result.records, trace=result.trace)
@@ -162,6 +163,12 @@ def _normalize_intent(
 def _memory_kinds(memory_kind: str) -> tuple[str, ...]:
     value = memory_kind.strip()
     return (value,) if value else ()
+
+
+def _parse_current_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return datetime.fromisoformat(value)
 
 
 def _now_local() -> datetime:

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -24,7 +24,11 @@ async def start_channels(
 ) -> tuple[Any, Any, Any, Any]:
     from infra.channels.ipc_server import IPCServerChannel
 
-    ipc = IPCServerChannel(bus, config.channels.socket)
+    ipc = IPCServerChannel(
+        bus,
+        config.channels.socket,
+        default_session_key=config.channels.cli_session_key,
+    )
     await ipc.start()
     print(f"Agent 已启动  |  CLI 连接地址: {config.channels.socket}")
 

--- a/bus/events.py
+++ b/bus/events.py
@@ -32,7 +32,18 @@ class InboundMessage:
     @property
     def session_key(self) -> str:
         """唯一会话标识，用于维护对话历史"""
+        override = str(self.metadata.get("session_key_override") or "").strip()
+        if override:
+            return override
         return f"{self.channel}:{self.chat_id}"
+
+    @property
+    def context_channel(self) -> str:
+        return str(self.metadata.get("context_channel") or self.channel).strip()
+
+    @property
+    def context_chat_id(self) -> str:
+        return str(self.metadata.get("context_chat_id") or self.chat_id).strip()
 
 
 @dataclass

--- a/core/memory/engine.py
+++ b/core/memory/engine.py
@@ -109,6 +109,7 @@ class MemoryQuery:
     filters: MemoryQueryFilters = field(default_factory=MemoryQueryFilters)
     context: dict[str, object] = field(default_factory=dict[str, object])
     limit: int = 8
+    timestamp: datetime | None = None
 
 
 @dataclass

--- a/infra/channels/ipc_server.py
+++ b/infra/channels/ipc_server.py
@@ -48,10 +48,12 @@ class IPCServerChannel:
         bus: MessageBus,
         socket_path: str,
         proactive_loop: "ProactiveLoop | None" = None,
+        default_session_key: str = "",
     ) -> None:
         self._bus = bus
         self._socket_path = _normalize_endpoint(socket_path)
         self._proactive_loop = proactive_loop
+        self._default_session_key = default_session_key.strip()
         self._writers: dict[str, asyncio.StreamWriter] = {}
         self._server: asyncio.AbstractServer | None = None
         bus.subscribe_outbound(CHANNEL, self._on_response)
@@ -118,13 +120,24 @@ class IPCServerChannel:
                 if not content:
                     continue
                 preview = content[:60] + "..." if len(content) > 60 else content
-                logger.info("[cli] received session=%s content=%r", chat_id, preview)
+                metadata = _session_override_metadata(
+                    data,
+                    default_session_key=self._default_session_key,
+                )
+                session_key = metadata.get("session_key_override", f"{CHANNEL}:{chat_id}")
+                logger.info(
+                    "[cli] received route=%s session=%s content=%r",
+                    chat_id,
+                    session_key,
+                    preview,
+                )
                 await self._bus.publish_inbound(
                     InboundMessage(
                         channel=CHANNEL,
                         sender="cli-user",
                         chat_id=chat_id,
                         content=content,
+                        metadata=metadata,
                     )
                 )
         finally:
@@ -180,3 +193,35 @@ class IPCServerChannel:
             )
             writer.write(payload.encode("utf-8"))
             await writer.drain()
+
+
+def _session_override_metadata(
+    data: dict,
+    *,
+    default_session_key: str,
+) -> dict[str, object]:
+    session_key = str(
+        data.get("as_session_key")
+        or data.get("session_key")
+        or default_session_key
+        or ""
+    ).strip()
+    if not session_key:
+        channel = str(data.get("as_channel") or "").strip()
+        chat_id = str(data.get("as_chat_id") or "").strip()
+        session_key = f"{channel}:{chat_id}" if channel and chat_id else ""
+    if not session_key:
+        return {}
+    channel, chat_id = _split_session_key(session_key)
+    return {
+        "session_key_override": session_key,
+        "context_channel": channel,
+        "context_chat_id": chat_id,
+    }
+
+
+def _split_session_key(session_key: str) -> tuple[str, str]:
+    channel, sep, chat_id = session_key.partition(":")
+    if not sep:
+        return "", session_key
+    return channel, chat_id

--- a/plugins/akasha/config.py
+++ b/plugins/akasha/config.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+
+@dataclass(frozen=True)
+class AkashaConfig:
+    db_path: str = ""
+    dense_top_k: int = 10
+    ripple_top_k: int = 10
+    activate_limit: int = 8
+    inject_max_chars: int = 6000
+    assistant_preview_chars: int = 15
+    dense_seed_threshold: float = 0.675
+    nearby_time_seconds: int = 1800
+    nearby_dense_threshold: float = 0.28
+    activation_threshold: float = 0.22
+    soft_recall_threshold: float = 0.165
+    soft_recall_direct_floor: float = 0.45
+    cross_boost: float = 36.0
+
+
+# 读取 Akasha 插件配置文件。
+def load_akasha_config(
+    *,
+    plugin_dir: Path | None = None,
+) -> AkashaConfig:
+    # 1. 读取插件目录下的本地配置。
+    root = plugin_dir or Path(__file__).resolve().parent
+    payload = _read_toml(root / "config.local.toml")
+
+    # 2. 把 TOML 字段收敛成强类型配置。
+    return AkashaConfig(
+        db_path=str(payload.get("db_path") or ""),
+        dense_top_k=_int_value(payload.get("dense_top_k"), 10),
+        ripple_top_k=_int_value(payload.get("ripple_top_k"), 10),
+        activate_limit=_int_value(payload.get("activate_limit"), 8),
+        inject_max_chars=_int_value(payload.get("inject_max_chars"), 6000),
+        assistant_preview_chars=_int_value(payload.get("assistant_preview_chars"), 15),
+        dense_seed_threshold=_float_value(payload.get("dense_seed_threshold"), 0.675),
+        nearby_time_seconds=_int_value(payload.get("nearby_time_seconds"), 1800),
+        nearby_dense_threshold=_float_value(payload.get("nearby_dense_threshold"), 0.28),
+        activation_threshold=_float_value(payload.get("activation_threshold"), 0.22),
+        soft_recall_threshold=_float_value(payload.get("soft_recall_threshold"), 0.165),
+        soft_recall_direct_floor=_float_value(payload.get("soft_recall_direct_floor"), 0.45),
+        cross_boost=_float_value(payload.get("cross_boost"), 36.0),
+    )
+
+
+# 渲染默认 Akasha 配置。
+def render_akasha_config(config: AkashaConfig | None = None) -> str:
+    # 1. 使用传入配置或默认配置生成本地配置文本。
+    cfg = config or AkashaConfig()
+    return "\n".join([
+        f'db_path = "{cfg.db_path}"',
+        f"dense_top_k = {cfg.dense_top_k}",
+        f"ripple_top_k = {cfg.ripple_top_k}",
+        f"activate_limit = {cfg.activate_limit}",
+        f"inject_max_chars = {cfg.inject_max_chars}",
+        f"assistant_preview_chars = {cfg.assistant_preview_chars}",
+        f"dense_seed_threshold = {cfg.dense_seed_threshold}",
+        f"nearby_time_seconds = {cfg.nearby_time_seconds}",
+        f"nearby_dense_threshold = {cfg.nearby_dense_threshold}",
+        f"activation_threshold = {cfg.activation_threshold}",
+        f"soft_recall_threshold = {cfg.soft_recall_threshold}",
+        f"soft_recall_direct_floor = {cfg.soft_recall_direct_floor}",
+        f"cross_boost = {cfg.cross_boost}",
+        "",
+    ])
+
+
+# 确保 Akasha 本地配置文件存在。
+def ensure_akasha_config_file(*, plugin_dir: Path | None = None) -> Path:
+    # 1. 缺省时只写入默认配置，不覆盖用户已有配置。
+    root = plugin_dir or Path(__file__).resolve().parent
+    path = root / "config.local.toml"
+    if not path.exists():
+        _ = path.write_text(render_akasha_config(), encoding="utf-8")
+    return path
+
+
+# 解析 Akasha sidecar 数据库路径。
+def resolve_akasha_db_path(
+    *,
+    workspace: Path,
+    akasha_config: AkashaConfig,
+) -> Path:
+    # 1. 默认落在 workspace/memory/akasha.db。
+    if not akasha_config.db_path:
+        return workspace / "memory" / "akasha.db"
+
+    # 2. 相对路径以 workspace 为根，绝对路径原样使用。
+    path = Path(akasha_config.db_path)
+    return path if path.is_absolute() else workspace / path
+
+
+# 读取 TOML 文件为普通 dict。
+def _read_toml(path: Path) -> dict[str, object]:
+    # 1. 配置不存在时回到默认值。
+    if not path.exists():
+        return {}
+    return cast(dict[str, object], tomllib.loads(path.read_text(encoding="utf-8")))
+
+
+# 把配置值转换成 int。
+def _int_value(value: object, default: int) -> int:
+    # 1. 支持 TOML 数字和字符串数字。
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str | float):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+    return default
+
+
+# 把配置值转换成 float。
+def _float_value(value: object, default: float) -> float:
+    # 1. 支持 TOML 数字和字符串数字。
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -238,6 +238,11 @@ class AkashaCandidate:
     path_value: float = 0.0
 
 
+@dataclass(frozen=True)
+class DenseMessageIndex:
+    by_dim: dict[int, tuple[tuple[str, ...], np.ndarray]]
+
+
 @dataclass
 class _GraphPathAggregate:
     signal: float = 0.0
@@ -264,6 +269,7 @@ class AkashaActivationSnapshot:
     edges_by_src: dict[str, dict[str, float]]
     message_embeddings: dict[str, np.ndarray]
     message_turn_keys: dict[str, str]
+    message_index: DenseMessageIndex | None = None
 
 
 @dataclass(frozen=True)
@@ -592,6 +598,28 @@ def dense_candidates(
     ]
 
 
+def build_dense_message_index(
+    message_embeddings: dict[str, np.ndarray],
+) -> DenseMessageIndex:
+    grouped: dict[int, list[tuple[str, np.ndarray]]] = {}
+    for message_id, embedding in message_embeddings.items():
+        grouped.setdefault(int(embedding.size), []).append((message_id, embedding))
+
+    by_dim: dict[int, tuple[tuple[str, ...], np.ndarray]] = {}
+    for dim, items in grouped.items():
+        message_ids = tuple(message_id for message_id, _ in items)
+        matrix = np.vstack([embedding for _, embedding in items]).astype(np.float32, copy=False)
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        normalized = np.divide(
+            matrix,
+            norms,
+            out=np.zeros_like(matrix),
+            where=norms > 0,
+        )
+        by_dim[dim] = (message_ids, normalized)
+    return DenseMessageIndex(by_dim=by_dim)
+
+
 def dense_message_candidates(
     query_vec: np.ndarray,
     nodes: dict[str, AkashaNode],
@@ -599,18 +627,29 @@ def dense_message_candidates(
     message_turn_keys: dict[str, str],
     *,
     limit: int,
+    message_index: DenseMessageIndex | None = None,
 ) -> list[AkashaCandidate]:
     """从 message-level embedding 命中映射回 turn 的 Dense 候选。"""
     if not message_embeddings:
         return dense_candidates(query_vec, nodes, limit=limit)
 
     query_norm = normalize(query_vec)
-    scored: list[tuple[str, float]] = []
-    for message_id, embedding in message_embeddings.items():
-        if embedding.size != query_norm.size:
-            continue
-        score = float(np.dot(normalize(embedding), query_norm))
-        scored.append((message_id, score))
+    if message_index is not None:
+        indexed = message_index.by_dim.get(int(query_norm.size))
+        if indexed is None:
+            return []
+        message_ids, matrix = indexed
+        scored = [
+            (message_id, float(score))
+            for message_id, score in zip(message_ids, np.dot(matrix, query_norm))
+        ]
+    else:
+        scored = []
+        for message_id, embedding in message_embeddings.items():
+            if embedding.size != query_norm.size:
+                continue
+            score = float(np.dot(normalize(embedding), query_norm))
+            scored.append((message_id, score))
 
     candidates: list[AkashaCandidate] = []
     seen: set[str] = set()
@@ -644,6 +683,7 @@ def graph_seed_keys_from_snapshot(
             snapshot.message_embeddings,
             snapshot.message_turn_keys,
             limit=limit,
+            message_index=snapshot.message_index,
         )
     ]
 

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -40,7 +40,6 @@ def initial_strength(salience: float) -> float:
     return STRENGTH_CAP * (INITIAL_STRENGTH_BASE + INITIAL_STRENGTH_SALIENCE_BONUS * s)
 ASSISTANT_ONLY_PENALTY = 0.12
 FAN_PENALTY_POWER = 0.10
-EXPANDED_DIRECT_FLOOR = 0.62
 ACTIVATION_THRESHOLD = 0.22
 GRAPH_EXPAND_LIMIT = 8
 GRAPH_DIRECT_BIAS = 0.25
@@ -994,8 +993,8 @@ def score_candidates(
         edge_value = float(np.max(cross_mat[index])) if len(keys) else 0.0
         ptype, seed_key, bridge_key, path_value = path_info_dict.get(key, ("direct", "", "", 0.0))
         hop_penalty = {"direct": 1.0, "1hop": 0.86, "2hop": 0.62}.get(ptype, 0.62)
-        source = seed_sources.get(key, "Expanded")
-        direct_weight = 0.50 if source != "Expanded" else 0.18
+        source = seed_sources.get(key, "")
+        direct_weight = 0.50 if source else 0.18
         fan_penalty = math.pow(1.0 + fan_value, FAN_PENALTY_POWER)
         user_penalty = 1.0 if has_user_turn(source_cursor, key) else ASSISTANT_ONLY_PENALTY
         # ── 乘算 gain modulation (Salinas & Sejnowski 2001) ───────
@@ -1021,8 +1020,6 @@ def score_candidates(
             * gain_long
             * gain_edge
         ) * resource * hop_penalty * user_penalty / fan_penalty
-        if source == "Expanded" and ptype == "1hop" and direct_value >= EXPANDED_DIRECT_FLOOR:
-            score = max(score, config.activation_threshold + 0.01)
         all_candidates[key] = AkashaCandidate(
             key=key, source=source, ripple=float(current[index]),
             direct=direct_value, state=state_value, edge=edge_value,
@@ -1056,11 +1053,13 @@ def score_candidates(
     candidates: list[AkashaCandidate] = []
     suppressed: list[AkashaCandidate] = []
     for candidate in all_candidates.values():
+        if not candidate.source:
+            continue
         soft_hit = (
             soft_recall
             and candidate.score >= config.soft_recall_threshold
             and candidate.direct >= config.soft_recall_direct_floor
-            and candidate.source in {"Bridge", "Expanded"}
+            and candidate.source == "Bridge"
             and candidate.path_type in {"bridge", "1hop", "2hop"}
         )
         if candidate.score >= config.activation_threshold or soft_hit:

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -229,6 +229,17 @@ class AkashaCandidate:
     path_value: float = 0.0
 
 
+@dataclass
+class _GraphPathAggregate:
+    signal: float = 0.0
+    best_signal: float = 0.0
+    best_edge: float = 0.0
+    best_weight: float = 0.0
+    direct: float = 0.0
+    paths: float = 0.0
+    seed_key: str = ""
+
+
 @dataclass(frozen=True)
 class ActivationTrace:
     seed_count: int
@@ -970,7 +981,7 @@ def graph_expand_candidates(
         for dst_key, edge_weight in src_neighbors.items():
             in_strength[dst_key] = in_strength.get(dst_key, 0.0) + edge_weight
 
-    candidates: list[AkashaCandidate] = []
+    aggregate: dict[str, _GraphPathAggregate] = {}
     for seed_key in graph_seed_keys:
         if seed_key not in nodes:
             continue
@@ -979,42 +990,46 @@ def graph_expand_candidates(
         if out_strength <= 0:
             continue
 
-        scored_neighbors = []
+        scored_neighbors: list[tuple[float, float, float, str, float]] = []
         for key, edge_weight in raw_neighbors.items():
             if key not in nodes or key in seed_set or not has_user_turn(source_cursor, key):
                 continue
             dst_strength = in_strength.get(key, edge_weight)
             edge_signal = edge_weight / math.sqrt(max(out_strength * dst_strength, 1e-9))
             direct = max(0.0, direct_scores.get(key, 0.0))
-            degree_penalty = math.pow(1.0 + max(0, fan.get(key, 0)), GRAPH_FAN_PENALTY_POWER)
-            candidate_signal = edge_signal * (GRAPH_DIRECT_BIAS + direct) / degree_penalty
+            seed_direct = max(GRAPH_DIRECT_BIAS, max(0.0, direct_scores.get(seed_key, 0.0)))
+            candidate_signal = edge_signal * seed_direct
             scored_neighbors.append((candidate_signal, edge_signal, direct, key, edge_weight))
         scored_neighbors.sort(reverse=True, key=lambda item: item[0])
-        max_edge_signal = max((item[1] for item in scored_neighbors), default=0.0)
+        for candidate_signal, edge_signal, direct, key, edge_weight in scored_neighbors[:GRAPH_EXPAND_LIMIT]:
+            item = aggregate.setdefault(key, _GraphPathAggregate(direct=direct, seed_key=seed_key))
+            item.signal += candidate_signal
+            item.paths += 1.0
+            item.direct = max(item.direct, direct)
+            if candidate_signal > item.best_signal:
+                item.best_signal = candidate_signal
+                item.best_edge = edge_signal
+                item.best_weight = edge_weight
+                item.seed_key = seed_key
 
-        for _, edge_signal, direct, key, edge_weight in scored_neighbors[:GRAPH_EXPAND_LIMIT]:
-            if max_edge_signal <= 0:
-                continue
-            node = nodes[key]
-            degree = max(0, fan.get(key, 0))
-            resource = recover_resource(node, now_ts)
-            long_score = min(1.0, node.strength / STRENGTH_CAP)
-            normalized_edge = edge_signal / max_edge_signal
-            score = (
-                3.0
-                * normalized_edge
-                * (GRAPH_DIRECT_BIAS + direct)
-                * (1.0 + 0.15 * long_score)
-                / math.pow(1.0 + degree, GRAPH_FAN_PENALTY_POWER)
-            )
-            candidates.append(AkashaCandidate(
-                key=key, source="Graph", ripple=float(edge_weight),
-                direct=direct, state=0.0, edge=float(edge_signal),
-                long=long_score, resource=resource, fan=degree,
-                score=float(score), path_type="1hop",
-                seed_key=seed_key, path_value=float(edge_signal),
-            ))
-    return candidates
+    candidates: list[AkashaCandidate] = []
+    for key, item in aggregate.items():
+        node = nodes[key]
+        resource = recover_resource(node, now_ts)
+        long_score = min(1.0, node.strength / STRENGTH_CAP)
+        direct = item.direct
+        paths = max(1.0, item.paths)
+        signal = item.signal * (1.0 + math.log(paths))
+        score = 6.0 * signal * (GRAPH_DIRECT_BIAS + direct) * (1.0 + 0.15 * long_score)
+        candidates.append(AkashaCandidate(
+            key=key, source="Graph", ripple=item.best_weight,
+            direct=direct, state=0.0, edge=signal,
+            long=long_score, resource=resource, fan=max(0, fan.get(key, 0)),
+            score=float(score * resource), path_type="1hop",
+            seed_key=item.seed_key, path_value=item.best_edge,
+        ))
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    return candidates[:GRAPH_EXPAND_LIMIT]
 
 
 def merge_active_candidates(

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -18,11 +18,23 @@ import numpy as np
 
 # ── 常量 ──────────────────────────────────────────────────────────────
 
-LONG_DECAY_TAU = 2200.0
-RESOURCE_RECOVER_TAU = 14.0
+# 时间衰减常数（秒）—— 基于 sessions.db 真实对话间隔统计
+LONG_DECAY_TAU = 604800.0       # 7 天：strength 衰减到 1/e
+RESOURCE_RECOVER_TAU = 1800.0   # 30 分钟：短期抑制恢复
+EDGE_DECAY_TAU = 1209600.0      # 14 天：Hebbian 边衰减
 RESOURCE_USE_RATE = 0.35
 STRENGTH_LR = 0.18
 STRENGTH_CAP = 3.0
+# 新事件初始 strength：编码即峰值（Ebbinghaus / ACT-R / early-LTP）
+# initial_strength = STRENGTH_CAP × (BASE + SALIENCE_BONUS · σ)
+INITIAL_STRENGTH_BASE = 0.70
+INITIAL_STRENGTH_SALIENCE_BONUS = 0.30
+
+
+def initial_strength(salience: float) -> float:
+    """新节点 encoding 时的 strength。高显著度事件起步更接近 cap。"""
+    s = max(0.0, min(1.0, salience))
+    return STRENGTH_CAP * (INITIAL_STRENGTH_BASE + INITIAL_STRENGTH_SALIENCE_BONUS * s)
 ASSISTANT_ONLY_PENALTY = 0.12
 FAN_PENALTY_POWER = 0.10
 EXPANDED_DIRECT_FLOOR = 0.62
@@ -171,9 +183,9 @@ class AkashaNode:
     strength: float
     resource: float
     recall_count: int
-    last_activated_seq: int
-    last_strength_seq: int
-    last_resource_seq: int
+    last_activated_ts: float
+    last_strength_ts: float
+    last_resource_ts: float
     embedding: np.ndarray
     emb_count: int
 
@@ -184,7 +196,7 @@ class ActivationUpdate:
     strength: float
     resource: float
     recall_count: int
-    seq: int
+    ts: float
 
 
 @dataclass(frozen=True)
@@ -228,7 +240,7 @@ class EdgeUpdate:
     src_key: str
     dst_key: str
     strength: float
-    seq: int
+    ts: float
 
 
 @dataclass(frozen=True)
@@ -380,8 +392,8 @@ def load_state(path: str) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], 
     cursor.execute(
         """
         SELECT key, anchor_id, session_key, turn_seq, first_ts_unix, salience,
-               strength, resource, recall_count, last_activated_seq,
-               last_strength_seq, last_resource_seq, embedding, emb_count
+               strength, resource, recall_count, last_activated_ts,
+               last_strength_ts, last_resource_ts, embedding, emb_count
         FROM akasha_nodes
         """
     )
@@ -390,7 +402,7 @@ def load_state(path: str) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], 
         (
             key, anchor_id, session_key, turn_seq, first_ts_unix,
             salience, strength, resource, recall_count,
-            last_activated_seq, last_strength_seq, last_resource_seq,
+            last_activated_ts, last_strength_ts, last_resource_ts,
             embedding_blob, emb_count,
         ) = row
         embedding = deserialize_f32(embedding_blob)
@@ -406,9 +418,9 @@ def load_state(path: str) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], 
             strength=strength,
             resource=resource,
             recall_count=recall_count,
-            last_activated_seq=last_activated_seq,
-            last_strength_seq=last_strength_seq,
-            last_resource_seq=last_resource_seq,
+            last_activated_ts=last_activated_ts,
+            last_strength_ts=last_strength_ts,
+            last_resource_ts=last_resource_ts,
             embedding=embedding,
             emb_count=emb_count,
         )
@@ -431,16 +443,24 @@ def load_state(path: str) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], 
 # ── 状态计算辅助函数 ──────────────────────────────────────────────────
 
 
-def recover_resource(node: AkashaNode, seq: int) -> float:
-    """计算短期资源恢复后的值。"""
-    gap = max(0, seq - node.last_resource_seq)
+def recover_resource(node: AkashaNode, now_ts: float) -> float:
+    """计算短期资源恢复后的值（按真实时间）。"""
+    gap = max(0.0, now_ts - node.last_resource_ts)
     return 1.0 - (1.0 - node.resource) * math.exp(-gap / RESOURCE_RECOVER_TAU)
 
 
-def decayed_strength(node: AkashaNode, seq: int) -> float:
-    """计算长期强度衰减后的值。"""
-    gap = max(0, seq - node.last_strength_seq)
+def decayed_strength(node: AkashaNode, now_ts: float) -> float:
+    """计算长期强度衰减后的值（按真实时间）。"""
+    gap = max(0.0, now_ts - node.last_strength_ts)
     return node.strength * math.exp(-gap / LONG_DECAY_TAU)
+
+
+def effective_edge_weight(weight: float, last_used_ts: float, now_ts: float) -> float:
+    """边的 lazy time-decay。"""
+    if last_used_ts <= 0:
+        return weight
+    gap = max(0.0, now_ts - last_used_ts)
+    return weight * math.exp(-gap / EDGE_DECAY_TAU)
 
 
 def bounded_add(value: float, delta: float, cap: float) -> float:
@@ -681,14 +701,14 @@ def state_array(
     keys: list[str],
     nodes: dict[str, AkashaNode],
     fan: dict[str, int],
-    seq: int,
+    now_ts: float,
 ) -> np.ndarray:
     """计算节点状态权重（salience + 长期强度 + 短期资源 + fan 惩罚）。"""
     values = np.zeros(len(keys), dtype=np.float32)
     for index, key in enumerate(keys):
         node = nodes[key]
-        long_score = min(1.0, decayed_strength(node, seq) / STRENGTH_CAP)
-        resource = recover_resource(node, seq)
+        long_score = min(1.0, decayed_strength(node, now_ts) / STRENGTH_CAP)
+        resource = recover_resource(node, now_ts)
         values[index] = (
             math.exp(1.4 * node.salience + 1.0 * long_score)
             * resource
@@ -702,22 +722,39 @@ def cross_matrix(
     edges: dict[tuple[str, str], float],
     index_by_key: dict[str, int],
     edges_by_src: dict[str, dict[str, float]] | None = None,
+    edges_meta: dict[tuple[str, str], float] | None = None,
+    now_ts: float = 0.0,
 ) -> np.ndarray:
-    """构建微型图内部的共激活边矩阵。"""
+    """构建微型图内部的共激活边矩阵。
+
+    若提供 edges_meta + now_ts，对每条边按 last_used_ts 做 lazy 时间衰减。
+    """
     matrix = np.zeros((len(keys), len(keys)), dtype=np.float32)
+    apply_decay = edges_meta is not None and now_ts > 0
+
+    def _eff(src_key: str, dst_key: str, weight: float) -> float:
+        if not apply_decay:
+            return weight
+        last_used_ts = edges_meta.get((src_key, dst_key), 0.0)  # type: ignore[union-attr]
+        return effective_edge_weight(weight, last_used_ts, now_ts)
+
     if edges_by_src is not None:
         for src_key in keys:
             src_index = index_by_key[src_key]
             for dst_key, weight in edges_by_src.get(src_key, {}).items():
                 dst_index = index_by_key.get(dst_key)
-                if dst_index is not None:
-                    matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+                if dst_index is None:
+                    continue
+                eff_w = _eff(src_key, dst_key, weight)
+                matrix[dst_index, src_index] = max(matrix[dst_index, src_index], eff_w)
         return matrix
     for (src_key, dst_key), weight in edges.items():
         src_index = index_by_key.get(src_key)
         dst_index = index_by_key.get(dst_key)
-        if src_index is not None and dst_index is not None:
-            matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+        if src_index is None or dst_index is None:
+            continue
+        eff_w = _eff(src_key, dst_key, weight)
+        matrix[dst_index, src_index] = max(matrix[dst_index, src_index], eff_w)
     return matrix
 
 
@@ -796,7 +833,7 @@ def score_candidates(
     state_arr: np.ndarray,
     cross_mat: np.ndarray,
     fan: dict[str, int],
-    seq: int,
+    now_ts: float,
     path_info_dict: dict[str, tuple[str, str, str, float]],
     config: CoreConfig,
     source_cursor: sqlite3.Cursor | None,
@@ -809,8 +846,8 @@ def score_candidates(
     max_state = max(float(np.max(state_arr)), 1e-10)
     for index, key in enumerate(keys):
         node = nodes[key]
-        long_score = min(1.0, decayed_strength(node, seq) / STRENGTH_CAP)
-        resource = recover_resource(node, seq)
+        long_score = min(1.0, decayed_strength(node, now_ts) / STRENGTH_CAP)
+        resource = recover_resource(node, now_ts)
         fan_value = fan.get(key, 0)
         direct_value = max(0.0, direct_scores.get(key, 0.0))
         state_value = min(1.0, float(state_arr[index]) / max_state)
@@ -821,12 +858,23 @@ def score_candidates(
         direct_weight = 0.50 if source != "Expanded" else 0.18
         fan_penalty = math.pow(1.0 + fan_value, FAN_PENALTY_POWER)
         user_penalty = 1.0 if has_user_turn(source_cursor, key) else ASSISTANT_ONLY_PENALTY
+        # ── 乘算 gain modulation (Salinas & Sejnowski 2001) ───────
+        # 内容基底：spreading 能量 + 直接相似度（取较大方，避免双重计数）
+        ripple_term = float(current[index]) * 3.0 * state_value
+        direct_term = direct_weight * direct_value
+        content_base = max(ripple_term, direct_term) + 0.3 * min(ripple_term, direct_term)
+
+        # 每个状态信号都是乘法 gain factor，signal=0 时 gain=1（不影响）
+        # signal 高时 gain > 1（multiplicative 放大）
+        gain_salience = 1.0 + 0.8 * node.salience           # σ ∈ [0,1] → gain ∈ [1, 1.8]
+        gain_long     = 1.0 + 0.6 * long_score              # long ∈ [0,1] → gain ∈ [1, 1.6]
+        gain_edge     = 1.0 + 0.5 * min(1.0, edge_value)    # edge → gain ∈ [1, 1.5]
+
         score = (
-            float(current[index]) * 3.0 * state_value
-            + direct_weight * direct_value
-            + 0.18 * long_score
-            + 0.12 * node.salience
-            + 0.20 * min(1.0, edge_value)
+            content_base
+            * gain_salience
+            * gain_long
+            * gain_edge
         ) * resource * hop_penalty * user_penalty / fan_penalty
         if source == "Expanded" and ptype == "1hop" and direct_value >= EXPANDED_DIRECT_FLOOR:
             score = max(score, config.activation_threshold + 0.01)
@@ -907,7 +955,7 @@ def graph_expand_candidates(
     nodes: dict[str, AkashaNode],
     direct_scores: dict[str, float],
     fan: dict[str, int],
-    seq: int,
+    now_ts: float,
     source_cursor: sqlite3.Cursor | None,
     edges_by_src: dict[str, dict[str, float]] | None,
     graph_seed_keys: list[str],
@@ -949,7 +997,7 @@ def graph_expand_candidates(
                 continue
             node = nodes[key]
             degree = max(0, fan.get(key, 0))
-            resource = recover_resource(node, seq)
+            resource = recover_resource(node, now_ts)
             long_score = min(1.0, node.strength / STRENGTH_CAP)
             normalized_edge = edge_signal / max_edge_signal
             score = (
@@ -991,12 +1039,13 @@ def compute_candidates(
     query_vec: np.ndarray,
     nodes: dict[str, AkashaNode],
     edges: dict[tuple[str, str], float],
-    seq: int,
+    now_ts: float,
     *,
     config: CoreConfig,
     fan: dict[str, int],
     source_cursor: sqlite3.Cursor | None = None,
     edges_by_src: dict[str, dict[str, float]] | None = None,
+    edges_meta: dict[tuple[str, str], float] | None = None,
     soft_recall: bool = False,
     return_limit: int | None = None,
     graph_seed_keys: list[str] | None = None,
@@ -1048,8 +1097,11 @@ def compute_candidates(
     sim_matrix = np.maximum(np.dot(embeddings, embeddings.T), 0.0)
     np.fill_diagonal(sim_matrix, 0.0)
 
-    state_arr = state_array(valid_keys, nodes, fan, seq)
-    cross_mat = cross_matrix(valid_keys, edges, index_by_key, edges_by_src)
+    state_arr = state_array(valid_keys, nodes, fan, now_ts)
+    cross_mat = cross_matrix(
+        valid_keys, edges, index_by_key, edges_by_src,
+        edges_meta=edges_meta, now_ts=now_ts,
+    )
 
     transition = sim_matrix * state_arr[:, np.newaxis]
     transition *= 1.0 + config.cross_boost * cross_mat
@@ -1065,13 +1117,13 @@ def compute_candidates(
     path_info_dict = path_info(valid_keys, transition, e0, te0)
     candidates, suppressed = score_candidates(
         valid_keys, nodes, direct_scores_map, seed_sources,
-        current, state_arr, cross_mat, fan, seq,
+        current, state_arr, cross_mat, fan, now_ts,
         path_info_dict, config, source_cursor,
         soft_recall=soft_recall, return_limit=return_limit,
     )
     if graph_seed_keys:
         graph_candidates = graph_expand_candidates(
-            query_vec, nodes, direct_scores_map, fan, seq,
+            query_vec, nodes, direct_scores_map, fan, now_ts,
             source_cursor, edges_by_src, graph_seed_keys,
         )
         limit = return_limit or config.activate_limit
@@ -1089,7 +1141,7 @@ def compute_candidates(
 def activation_updates(
     items: list[AkashaCandidate],
     nodes: dict[str, AkashaNode],
-    seq: int,
+    now_ts: float,
 ) -> list[ActivationUpdate]:
     """生成被激活节点的状态更新。"""
     updates: list[ActivationUpdate] = []
@@ -1097,12 +1149,12 @@ def activation_updates(
         node = nodes.get(item.key)
         if node is None:
             continue
-        strength = decayed_strength(node, seq)
+        strength = decayed_strength(node, now_ts)
         strength = bounded_add(strength, STRENGTH_LR * item.score, STRENGTH_CAP)
-        resource = recover_resource(node, seq)
+        resource = recover_resource(node, now_ts)
         resource *= max(0.05, 1.0 - RESOURCE_USE_RATE * min(1.0, item.score))
         updates.append(ActivationUpdate(
             key=item.key, strength=strength, resource=resource,
-            recall_count=node.recall_count + 1, seq=seq,
+            recall_count=node.recall_count + 1, ts=now_ts,
         ))
     return updates

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -57,6 +57,92 @@ def load_idf_from_db(conn: sqlite3.Connection) -> dict[str, float]:
         return {}
     return {t: float(v) for t, v in rows}
 
+
+def build_idf_table(
+    sessions_db_path: str,
+    target_conn: sqlite3.Connection,
+) -> dict[str, float]:
+    """扫描 sessions.db 所有 message 算 IDF，写入 target_conn 的 fts_token_idf 表。
+
+    用法：当 fts_token_idf 不存在或为空时调用，一次性建表。
+    增量更新场景下也可重新调用——会全表重写。
+    """
+    import jieba
+    from collections import defaultdict
+
+    sconn = sqlite3.connect(sessions_db_path)
+    df: dict[str, int] = defaultdict(int)
+    n_docs = 0
+    for (content,) in sconn.execute("SELECT content FROM messages"):
+        n_docs += 1
+        seen: set[str] = set()
+        for w in jieba.cut_for_search(content or ""):
+            cleaned = "".join(
+                ch for ch in w.strip()
+                if ch.isalnum() or "一" <= ch <= "鿿"
+            ).lower()
+            if len(cleaned) > 1 and cleaned not in seen:
+                seen.add(cleaned)
+                df[cleaned] += 1
+    sconn.close()
+
+    idf: dict[str, float] = {}
+    for tok, freq in df.items():
+        idf[tok] = math.log((n_docs + 1) / (freq + 1)) + 1
+
+    target_conn.execute("""
+        CREATE TABLE IF NOT EXISTS fts_token_idf (
+            token TEXT PRIMARY KEY,
+            df INTEGER NOT NULL,
+            idf REAL NOT NULL
+        )
+    """)
+    target_conn.execute("""
+        CREATE TABLE IF NOT EXISTS fts_token_idf_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+    target_conn.execute("DELETE FROM fts_token_idf")
+    target_conn.executemany(
+        "INSERT INTO fts_token_idf VALUES (?, ?, ?)",
+        [(t, df[t], idf[t]) for t in df],
+    )
+    target_conn.execute(
+        "INSERT OR REPLACE INTO fts_token_idf_meta VALUES ('n_docs', ?)",
+        (str(n_docs),),
+    )
+    target_conn.commit()
+    return idf
+
+
+def idf_table_is_stale(
+    sessions_db_path: str,
+    target_conn: sqlite3.Connection,
+    drift_ratio: float = 0.20,
+) -> bool:
+    """判断 IDF 表是否需要重建。"""
+    try:
+        cnt = target_conn.execute("SELECT COUNT(*) FROM fts_token_idf").fetchone()[0]
+    except sqlite3.OperationalError:
+        return True
+    if cnt == 0:
+        return True
+    try:
+        row = target_conn.execute(
+            "SELECT value FROM fts_token_idf_meta WHERE key='n_docs'"
+        ).fetchone()
+        last_n = int(row[0]) if row else None
+    except sqlite3.OperationalError:
+        last_n = None
+    if last_n is None or last_n == 0:
+        return False  # 已有数据但无 meta，先不强制重建
+    sconn = sqlite3.connect(sessions_db_path)
+    cur_n = sconn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    sconn.close()
+    return abs(cur_n - last_n) / last_n > drift_ratio
+
+
 # ── 数据类型 ──────────────────────────────────────────────────────────
 
 

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import math
 import struct
 import sqlite3
-import time
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -25,10 +24,14 @@ EDGE_DECAY_TAU = 1209600.0      # 14 天：Hebbian 边衰减
 RESOURCE_USE_RATE = 0.35
 STRENGTH_LR = 0.18
 STRENGTH_CAP = 3.0
+STDP_CAUSAL_EDGE_GAIN = 1.0
+STDP_ACAUSAL_EDGE_GAIN = 0.35
+STDP_COACTIVE_EDGE_GAIN = 1.0
 # 新事件初始 strength：编码即峰值（Ebbinghaus / ACT-R / early-LTP）
 # initial_strength = STRENGTH_CAP × (BASE + SALIENCE_BONUS · σ)
 INITIAL_STRENGTH_BASE = 0.70
 INITIAL_STRENGTH_SALIENCE_BONUS = 0.30
+SALIENCE_CENTROID_SCALE = 2.0
 
 
 def initial_strength(salience: float) -> float:
@@ -42,6 +45,12 @@ ACTIVATION_THRESHOLD = 0.22
 GRAPH_EXPAND_LIMIT = 8
 GRAPH_DIRECT_BIAS = 0.25
 GRAPH_FAN_PENALTY_POWER = 0.15
+
+# RWR 重启概率 α：扩散迭代和 path_info 各 hop 权重都由它推出，
+# 不再是 0.2 / 0.16 / 0.64 三个独立字面量。
+#   iteration : r = (1−α)·P·r + α·e0
+#   path_info : direct = α, 1hop = α(1−α), 2hop = (1−α)²
+RWR_RESTART_ALPHA = 0.2
 
 # FTS 改进参数
 FTS_MIN_IDF = 3.5          # 过滤低 IDF 常见 token
@@ -247,11 +256,46 @@ class ActivationTrace:
 
 
 @dataclass(frozen=True)
+class AkashaActivationSnapshot:
+    nodes: dict[str, AkashaNode]
+    edges: dict[tuple[str, str], float]
+    edges_meta: dict[tuple[str, str], float]
+    fan: dict[str, int]
+    edges_by_src: dict[str, dict[str, float]]
+    message_embeddings: dict[str, np.ndarray]
+    message_turn_keys: dict[str, str]
+
+
+@dataclass(frozen=True)
 class EdgeUpdate:
     src_key: str
     dst_key: str
     strength: float
     ts: float
+
+
+def activation_edge_updates(
+    current_key: str,
+    candidates: list[AkashaCandidate],
+    ts: float,
+) -> list[EdgeUpdate]:
+    updates: list[EdgeUpdate] = []
+    key_to_score = {item.key: item.score for item in candidates}
+    for item in candidates:
+        edge_strength = key_to_score.get(item.key, 1.0)
+        updates.append(
+            EdgeUpdate(item.key, current_key, edge_strength * STDP_CAUSAL_EDGE_GAIN, ts)
+        )
+        updates.append(
+            EdgeUpdate(current_key, item.key, edge_strength * STDP_ACAUSAL_EDGE_GAIN, ts)
+        )
+    for left_index, left in enumerate(candidates):
+        for right in candidates[left_index + 1:]:
+            edge_strength = math.sqrt(key_to_score[left.key] * key_to_score[right.key])
+            edge_strength *= STDP_COACTIVE_EDGE_GAIN
+            updates.append(EdgeUpdate(left.key, right.key, edge_strength, ts))
+            updates.append(EdgeUpdate(right.key, left.key, edge_strength, ts))
+    return updates
 
 
 @dataclass(frozen=True)
@@ -276,6 +320,30 @@ def normalize(vector: np.ndarray) -> np.ndarray:
     """归一化向量到单位长度。"""
     norm = float(np.linalg.norm(vector))
     return vector / norm if norm > 0 else vector
+
+
+def causal_salience(
+    embedding: list[float] | np.ndarray,
+    prior_sum: np.ndarray | None,
+    prior_count: int,
+) -> float:
+    """只用当前消息之前的全局重心计算 salience。"""
+    if prior_sum is None or prior_count <= 0:
+        return 0.0
+    vector = normalize(np.array(embedding, dtype=np.float32))
+    centroid = normalize(prior_sum / float(prior_count))
+    value = (1.0 - float(np.dot(vector, centroid))) * SALIENCE_CENTROID_SCALE
+    return min(1.0, max(0.0, value))
+
+
+def advance_salience_state(
+    prior_sum: np.ndarray | None,
+    prior_count: int,
+    embedding: list[float] | np.ndarray,
+) -> tuple[np.ndarray, int]:
+    vector = normalize(np.array(embedding, dtype=np.float32))
+    total = vector.copy() if prior_sum is None else prior_sum + vector
+    return total, prior_count + 1
 
 
 def _best_device() -> str:
@@ -324,8 +392,8 @@ def parse_ts_unix(value: str) -> float:
     """把时间字符串转换成 Unix 秒。"""
     try:
         return datetime.fromisoformat(value).timestamp()
-    except Exception:
-        return time.time()
+    except ValueError as exc:
+        raise ValueError(f"无效时间戳: {value}") from exc
 
 
 def message_id_to_key_from_db(cursor: sqlite3.Cursor, message_id: str) -> str:
@@ -558,6 +626,26 @@ def dense_message_candidates(
         if len(candidates) >= limit:
             break
     return candidates
+
+
+def graph_seed_keys_from_snapshot(
+    query_vec: np.ndarray,
+    snapshot: AkashaActivationSnapshot,
+    *,
+    limit: int,
+) -> list[str]:
+    if not snapshot.message_embeddings:
+        return []
+    return [
+        item.key
+        for item in dense_message_candidates(
+            query_vec,
+            snapshot.nodes,
+            snapshot.message_embeddings,
+            snapshot.message_turn_keys,
+            limit=limit,
+        )
+    ]
 
 
 # ── Seed 选择 ─────────────────────────────────────────────────────────
@@ -811,13 +899,14 @@ def path_info(
 ) -> dict[str, tuple[str, str, str, float]]:
     """回溯每个候选的能量路径（direct / 1hop / 2hop）。"""
     result: dict[str, tuple[str, str, str, float]] = {}
+    alpha = RWR_RESTART_ALPHA
     seed_indices = np.where(e0 > 0)[0]
     for index, key in enumerate(keys):
-        c0 = float(0.2 * e0[index])
-        c1_vec = 0.16 * transition[index, :] * e0
+        c0 = float(alpha * e0[index])
+        c1_vec = alpha * (1.0 - alpha) * transition[index, :] * e0
         s1 = int(np.argmax(c1_vec))
         c1 = float(c1_vec[s1])
-        c2_vec = 0.64 * transition[index, :] * te0
+        c2_vec = (1.0 - alpha) ** 2 * transition[index, :] * te0
         c2_vec[index] = 0.0
         c2_vec[seed_indices] = 0.0
         bridge = int(np.argmax(c2_vec))
@@ -870,10 +959,15 @@ def score_candidates(
         fan_penalty = math.pow(1.0 + fan_value, FAN_PENALTY_POWER)
         user_penalty = 1.0 if has_user_turn(source_cursor, key) else ASSISTANT_ONLY_PENALTY
         # ── 乘算 gain modulation (Salinas & Sejnowski 2001) ───────
-        # 内容基底：spreading 能量 + 直接相似度（取较大方，避免双重计数）
+        # 内容基底：spreading 能量 + 直接相似度两路证据按 noisy-OR 融合。
+        # P(relevant) = a + b − a·b = strong + weak·(1 − strong)，
+        # 取代原 max + 0.3·min：0.3 本就是 (1 − strong) 的硬编码近似。
+        # strong ≥ 1（证据已饱和）时 (1−strong) 截到 0，次要证据不再加成。
         ripple_term = float(current[index]) * 3.0 * state_value
         direct_term = direct_weight * direct_value
-        content_base = max(ripple_term, direct_term) + 0.3 * min(ripple_term, direct_term)
+        strong = max(ripple_term, direct_term)
+        weak = min(ripple_term, direct_term)
+        content_base = strong + weak * max(0.0, 1.0 - strong)
 
         # 每个状态信号都是乘法 gain factor，signal=0 时 gain=1（不影响）
         # signal 高时 gain > 1（multiplicative 放大）
@@ -969,24 +1063,37 @@ def graph_expand_candidates(
     now_ts: float,
     source_cursor: sqlite3.Cursor | None,
     edges_by_src: dict[str, dict[str, float]] | None,
+    edges_meta: dict[tuple[str, str], float] | None,
     graph_seed_keys: list[str],
 ) -> list[AkashaCandidate]:
     """沿 Dense 种子的强共激活边补一跳候选。"""
     if edges_by_src is None or not graph_seed_keys:
         return []
 
+    def _eff(src_key: str, dst_key: str, weight: float) -> float:
+        if edges_meta is None or now_ts <= 0:
+            return weight
+        return effective_edge_weight(
+            weight,
+            edges_meta.get((src_key, dst_key), 0.0),
+            now_ts,
+        )
+
     seed_set = {key for key in graph_seed_keys if key in nodes}
     in_strength: dict[str, float] = {}
-    for src_neighbors in edges_by_src.values():
+    for src_key, src_neighbors in edges_by_src.items():
         for dst_key, edge_weight in src_neighbors.items():
-            in_strength[dst_key] = in_strength.get(dst_key, 0.0) + edge_weight
+            in_strength[dst_key] = in_strength.get(dst_key, 0.0) + _eff(src_key, dst_key, edge_weight)
 
     aggregate: dict[str, _GraphPathAggregate] = {}
     for seed_key in graph_seed_keys:
         if seed_key not in nodes:
             continue
         raw_neighbors = edges_by_src.get(seed_key, {})
-        out_strength = sum(raw_neighbors.values())
+        out_strength = sum(
+            _eff(seed_key, dst_key, edge_weight)
+            for dst_key, edge_weight in raw_neighbors.items()
+        )
         if out_strength <= 0:
             continue
 
@@ -994,12 +1101,13 @@ def graph_expand_candidates(
         for key, edge_weight in raw_neighbors.items():
             if key not in nodes or key in seed_set or not has_user_turn(source_cursor, key):
                 continue
-            dst_strength = in_strength.get(key, edge_weight)
-            edge_signal = edge_weight / math.sqrt(max(out_strength * dst_strength, 1e-9))
+            effective_weight = _eff(seed_key, key, edge_weight)
+            dst_strength = in_strength.get(key, effective_weight)
+            edge_signal = effective_weight / math.sqrt(max(out_strength * dst_strength, 1e-9))
             direct = max(0.0, direct_scores.get(key, 0.0))
             seed_direct = max(GRAPH_DIRECT_BIAS, max(0.0, direct_scores.get(seed_key, 0.0)))
             candidate_signal = edge_signal * seed_direct
-            scored_neighbors.append((candidate_signal, edge_signal, direct, key, edge_weight))
+            scored_neighbors.append((candidate_signal, edge_signal, direct, key, effective_weight))
         scored_neighbors.sort(reverse=True, key=lambda item: item[0])
         for candidate_signal, edge_signal, direct, key, edge_weight in scored_neighbors[:GRAPH_EXPAND_LIMIT]:
             item = aggregate.setdefault(key, _GraphPathAggregate(direct=direct, seed_key=seed_key))
@@ -1127,7 +1235,7 @@ def compute_candidates(
     te0 = np.dot(transition, e0)
     current = e0.copy()
     for _ in range(2):
-        current = 0.8 * np.dot(transition, current) + 0.2 * e0
+        current = (1.0 - RWR_RESTART_ALPHA) * np.dot(transition, current) + RWR_RESTART_ALPHA * e0
 
     path_info_dict = path_info(valid_keys, transition, e0, te0)
     candidates, suppressed = score_candidates(
@@ -1139,7 +1247,7 @@ def compute_candidates(
     if graph_seed_keys:
         graph_candidates = graph_expand_candidates(
             query_vec, nodes, direct_scores_map, fan, now_ts,
-            source_cursor, edges_by_src, graph_seed_keys,
+            source_cursor, edges_by_src, edges_meta, graph_seed_keys,
         )
         limit = return_limit or config.activate_limit
         candidates = merge_active_candidates(candidates, graph_candidates, limit)
@@ -1147,6 +1255,35 @@ def compute_candidates(
         suppressed = [item for item in suppressed if item.key not in active_keys]
     return candidates, suppressed, ActivationTrace(
         seed_count=len(seed_sources), pool_count=len(valid_keys),
+    )
+
+
+def compute_candidates_from_snapshot(
+    query: str,
+    query_vec: np.ndarray,
+    snapshot: AkashaActivationSnapshot,
+    now_ts: float,
+    *,
+    config: CoreConfig,
+    source_cursor: sqlite3.Cursor | None = None,
+    soft_recall: bool = False,
+    return_limit: int | None = None,
+    graph_seed_keys: list[str] | None = None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate], ActivationTrace]:
+    return compute_candidates(
+        query,
+        query_vec,
+        snapshot.nodes,
+        snapshot.edges,
+        now_ts,
+        config=config,
+        fan=snapshot.fan,
+        source_cursor=source_cursor,
+        edges_by_src=snapshot.edges_by_src,
+        edges_meta=snapshot.edges_meta,
+        soft_recall=soft_recall,
+        return_limit=return_limit,
+        graph_seed_keys=graph_seed_keys,
     )
 
 

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -1,0 +1,926 @@
+"""
+akasha/core.py — 纯算法核心
+
+Akasha RAR（Ripple Activation & Recall）引擎的纯算法层。
+只依赖 numpy + jieba + stdlib，不依赖任何框架代码。
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+import numpy as np
+
+# ── 常量 ──────────────────────────────────────────────────────────────
+
+LONG_DECAY_TAU = 2200.0
+RESOURCE_RECOVER_TAU = 14.0
+RESOURCE_USE_RATE = 0.35
+STRENGTH_LR = 0.18
+STRENGTH_CAP = 3.0
+ASSISTANT_ONLY_PENALTY = 0.12
+FAN_PENALTY_POWER = 0.10
+EXPANDED_DIRECT_FLOOR = 0.62
+ACTIVATION_THRESHOLD = 0.22
+GRAPH_EXPAND_LIMIT = 8
+GRAPH_DIRECT_BIAS = 0.25
+GRAPH_FAN_PENALTY_POWER = 0.15
+
+# ── 数据类型 ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CoreConfig:
+    """算法配置。字段与 AkashaConfig 保持一致的命名和默认值。"""
+    dense_top_k: int = 10
+    dense_seed_threshold: float = 0.675
+    activation_threshold: float = 0.22
+    cross_boost: float = 36.0
+    nearby_time_seconds: int = 1800
+    nearby_dense_threshold: float = 0.28
+    soft_recall_threshold: float = 0.165
+    soft_recall_direct_floor: float = 0.45
+    activate_limit: int = 8
+
+
+@dataclass(frozen=True)
+class AkashaNode:
+    key: str
+    anchor_id: str
+    session_key: str
+    turn_seq: int
+    first_ts_unix: float
+    salience: float
+    strength: float
+    resource: float
+    recall_count: int
+    last_activated_seq: int
+    last_strength_seq: int
+    last_resource_seq: int
+    embedding: np.ndarray
+    emb_count: int
+
+
+@dataclass(frozen=True)
+class ActivationUpdate:
+    key: str
+    strength: float
+    resource: float
+    recall_count: int
+    seq: int
+
+
+@dataclass(frozen=True)
+class SourceMessage:
+    id: str
+    session_key: str
+    seq: int
+    role: str
+    content: str
+    ts: str
+    salience: float | None = None
+
+
+@dataclass(frozen=True)
+class AkashaCandidate:
+    key: str
+    source: str
+    ripple: float
+    direct: float
+    state: float
+    edge: float
+    long: float
+    resource: float
+    fan: int
+    score: float
+    suppressed: str = ""
+    path_type: str = "direct"
+    seed_key: str = ""
+    bridge_key: str = ""
+    path_value: float = 0.0
+
+
+@dataclass(frozen=True)
+class ActivationTrace:
+    seed_count: int
+    pool_count: int
+
+
+@dataclass(frozen=True)
+class EdgeUpdate:
+    src_key: str
+    dst_key: str
+    strength: float
+    seq: int
+
+
+@dataclass(frozen=True)
+class ActivationEventRow:
+    seq: int
+    query_id: str
+    activated_key: str
+    source: str
+    score: float
+    direct_score: float
+    state_score: float
+    edge_score: float
+    long_score: float
+    resource: float
+    fan: int
+
+
+# ── 工具函数 ──────────────────────────────────────────────────────────
+
+
+def normalize(vector: np.ndarray) -> np.ndarray:
+    """归一化向量到单位长度。"""
+    norm = float(np.linalg.norm(vector))
+    return vector / norm if norm > 0 else vector
+
+
+def _best_device() -> str:
+    """选择最佳推理设备。"""
+    try:
+        import torch
+        if torch.cuda.is_available():
+            return "cuda"
+        if torch.backends.mps.is_available():
+            return "mps"
+    except Exception:
+        pass
+    return "cpu"
+
+
+def parse_turn_key(key: str) -> tuple[str, int] | None:
+    """从 turn key 解析 session_key 和 seq。"""
+    left, sep, right = key.rpartition(":")
+    if not sep:
+        return None
+    try:
+        return left, int(right)
+    except ValueError:
+        return None
+
+
+def turn_key(session_key: str, seq: int, role: str) -> tuple[str, int, str]:
+    """把 message 映射成 turn key。assistant 归到前一个 user turn。"""
+    turn_seq = seq if role == "user" else max(0, seq - 1)
+    return session_key, turn_seq, f"{session_key}:{turn_seq}"
+
+
+def serialize_f32(vector: np.ndarray) -> bytes:
+    """把 float32 向量打包成 BLOB。"""
+    return struct.pack(f"{len(vector)}f", *vector.astype(np.float32).tolist())
+
+
+def deserialize_f32(blob: bytes) -> np.ndarray:
+    """从 BLOB 还原 float32 向量。"""
+    if not blob:
+        return np.array([], dtype=np.float32)
+    return np.array(struct.unpack(f"{len(blob) // 4}f", blob), dtype=np.float32)
+
+
+def parse_ts_unix(value: str) -> float:
+    """把时间字符串转换成 Unix 秒。"""
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except Exception:
+        return time.time()
+
+
+def message_id_to_key_from_db(cursor: sqlite3.Cursor, message_id: str) -> str:
+    """从 messages 表反查 message id 对应的 turn key。"""
+    cursor.execute(
+        "SELECT session_key, seq, role FROM messages WHERE id = ?",
+        (message_id,),
+    )
+    row = cursor.fetchone()
+    if row:
+        _, _, key = turn_key(str(row[0]), int(row[1]), str(row[2] or ""))
+        return key
+    return message_id  # fallback
+
+
+# ── DB 工具函数 ───────────────────────────────────────────────────────
+
+
+def open_source_db(path: str) -> sqlite3.Connection:
+    """打开带 sqlite-vec 的源数据库。"""
+    import sqlite_vec
+    db = sqlite3.connect(path)
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    return db
+
+
+def has_user_turn(cursor: sqlite3.Cursor | None, key: str) -> bool:
+    """判断 turn key 对应的轮次是否有 user 消息。"""
+    if cursor is None:
+        return True
+    parsed = parse_turn_key(key)
+    if parsed is None:
+        return False
+    session_key, seq = parsed
+    cursor.execute(
+        "SELECT 1 FROM messages WHERE session_key = ? AND seq = ? AND role = 'user' LIMIT 1",
+        (session_key, seq),
+    )
+    return cursor.fetchone() is not None
+
+
+def get_turn_context(cursor: sqlite3.Cursor, key: str) -> tuple[str, str]:
+    """从 messages 表读取 user/assistant 消息内容（用于展示）。"""
+    parsed = parse_turn_key(key)
+    if parsed is None:
+        return "", ""
+    session_key, seq = parsed
+    cursor.execute(
+        "SELECT content FROM messages WHERE session_key = ? AND seq = ? AND role = 'user'",
+        (session_key, seq),
+    )
+    user_row = cursor.fetchone()
+    cursor.execute(
+        "SELECT content FROM messages WHERE session_key = ? AND seq = ? AND role = 'assistant'",
+        (session_key, seq + 1),
+    )
+    assistant_row = cursor.fetchone()
+    user_text = (user_row[0] if user_row else "") or ""
+    assistant_text = (assistant_row[0] if assistant_row else "") or ""
+    user_text = user_text.replace("\n", " ").strip()
+    assistant_text = assistant_text.replace("\n", " ").strip()
+    if len(user_text) > 58:
+        user_text = user_text[:55] + "..."
+    if len(assistant_text) > 58:
+        assistant_text = assistant_text[:55] + "..."
+    return user_text, assistant_text
+
+
+def load_state(path: str) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], float], dict[str, tuple]]:
+    """从 sidecar DB 加载全部节点、边和激活统计。"""
+    db = sqlite3.connect(path)
+    cursor = db.cursor()
+    cursor.execute(
+        """
+        SELECT key, anchor_id, session_key, turn_seq, first_ts_unix, salience,
+               strength, resource, recall_count, last_activated_seq,
+               last_strength_seq, last_resource_seq, embedding, emb_count
+        FROM akasha_nodes
+        """
+    )
+    nodes: dict[str, AkashaNode] = {}
+    for row in cursor.fetchall():
+        (
+            key, anchor_id, session_key, turn_seq, first_ts_unix,
+            salience, strength, resource, recall_count,
+            last_activated_seq, last_strength_seq, last_resource_seq,
+            embedding_blob, emb_count,
+        ) = row
+        embedding = deserialize_f32(embedding_blob)
+        if embedding.size == 0:
+            continue
+        nodes[key] = AkashaNode(
+            key=key,
+            anchor_id=anchor_id,
+            session_key=session_key,
+            turn_seq=turn_seq,
+            first_ts_unix=first_ts_unix,
+            salience=salience,
+            strength=strength,
+            resource=resource,
+            recall_count=recall_count,
+            last_activated_seq=last_activated_seq,
+            last_strength_seq=last_strength_seq,
+            last_resource_seq=last_resource_seq,
+            embedding=embedding,
+            emb_count=emb_count,
+        )
+
+    cursor.execute("SELECT src_key, dst_key, weight FROM akasha_edges")
+    edges = {(str(src_key), str(dst_key)): float(weight) for src_key, dst_key, weight in cursor.fetchall()}
+
+    cursor.execute(
+        """
+        SELECT activated_key, COUNT(*) AS c, MAX(seq) AS last_seq
+        FROM akasha_activation_events
+        GROUP BY activated_key
+        """
+    )
+    activation_stats = {str(key): (int(count), int(last_seq)) for key, count, last_seq in cursor.fetchall()}
+    db.close()
+    return nodes, edges, activation_stats
+
+
+# ── 状态计算辅助函数 ──────────────────────────────────────────────────
+
+
+def recover_resource(node: AkashaNode, seq: int) -> float:
+    """计算短期资源恢复后的值。"""
+    gap = max(0, seq - node.last_resource_seq)
+    return 1.0 - (1.0 - node.resource) * math.exp(-gap / RESOURCE_RECOVER_TAU)
+
+
+def decayed_strength(node: AkashaNode, seq: int) -> float:
+    """计算长期强度衰减后的值。"""
+    gap = max(0, seq - node.last_strength_seq)
+    return node.strength * math.exp(-gap / LONG_DECAY_TAU)
+
+
+def bounded_add(value: float, delta: float, cap: float) -> float:
+    """有界增加：越接近 cap 增速越慢。"""
+    return value + delta * max(0.0, 1.0 - value / cap)
+
+
+def fan_counts(edges: dict[tuple[str, str], float]) -> dict[str, int]:
+    """统计每个节点的扇入/扇出总数。"""
+    fan: dict[str, int] = {}
+    for src, dst in edges:
+        fan[src] = fan.get(src, 0) + 1
+        fan[dst] = fan.get(dst, 0) + 1
+    return fan
+
+
+def edges_by_src(edges: dict[tuple[str, str], float]) -> dict[str, dict[str, float]]:
+    """把边表按源节点分组索引。"""
+    grouped: dict[str, dict[str, float]] = {}
+    for (src, dst), weight in edges.items():
+        grouped.setdefault(src, {})[dst] = weight
+    return grouped
+
+
+# ── Dense 计算 ────────────────────────────────────────────────────────
+
+
+def dense_scores(query_vec: np.ndarray, nodes: dict[str, AkashaNode]) -> dict[str, float]:
+    """计算 query 对所有节点的余弦相似度。"""
+    if not nodes:
+        return {}
+    keys = list(nodes.keys())
+    matrix = np.vstack([nodes[key].embedding for key in keys])
+    scores = np.dot(matrix, normalize(query_vec))
+    return {key: float(score) for key, score in zip(keys, scores)}
+
+
+def dense_candidates(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    *,
+    limit: int,
+) -> list[AkashaCandidate]:
+    """纯 Dense top-K 候选。"""
+    scores = dense_scores(query_vec, nodes)
+    return [
+        AkashaCandidate(key=key, source="Dense", ripple=0.0, direct=score,
+                        state=0.0, edge=0.0, long=0.0, resource=1.0, fan=0, score=score)
+        for key, score in sorted(scores.items(), key=lambda item: item[1], reverse=True)[:limit]
+    ]
+
+
+def dense_message_candidates(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    message_embeddings: dict[str, np.ndarray],
+    message_turn_keys: dict[str, str],
+    *,
+    limit: int,
+) -> list[AkashaCandidate]:
+    """从 message-level embedding 命中映射回 turn 的 Dense 候选。"""
+    if not message_embeddings:
+        return dense_candidates(query_vec, nodes, limit=limit)
+
+    query_norm = normalize(query_vec)
+    scored: list[tuple[str, float]] = []
+    for message_id, embedding in message_embeddings.items():
+        if embedding.size != query_norm.size:
+            continue
+        score = float(np.dot(normalize(embedding), query_norm))
+        scored.append((message_id, score))
+
+    candidates: list[AkashaCandidate] = []
+    seen: set[str] = set()
+    for message_id, score in sorted(scored, key=lambda item: item[1], reverse=True):
+        key = message_turn_keys.get(message_id)
+        if key is None or key not in nodes or key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            AkashaCandidate(key=key, source="Dense", ripple=0.0, direct=score,
+                            state=0.0, edge=0.0, long=0.0, resource=1.0, fan=0, score=score)
+        )
+        if len(candidates) >= limit:
+            break
+    return candidates
+
+
+# ── Seed 选择 ─────────────────────────────────────────────────────────
+
+
+def get_jieba_keywords(text: str) -> str:
+    """把文本切成 SQLite FTS 可用的 OR 查询。"""
+    import jieba
+    words: list[str] = []
+    for word in jieba.cut_for_search(text):
+        cleaned = "".join(
+            char for char in word.strip()
+            if char.isalnum() or "\u4e00" <= char <= "\u9fff"
+        )
+        if len(cleaned) > 1:
+            words.append(f'"{cleaned}"')
+    return " OR ".join(words[:20])
+
+
+def seed_pool(
+    query: str,
+    direct_scores: dict[str, float],
+    nodes: dict[str, AkashaNode],
+    config: CoreConfig,
+    source_cursor: sqlite3.Cursor | None,
+) -> tuple[dict[str, str], dict[str, float]]:
+    """Dense / FTS / BlackHole 三路种子选择。"""
+    ranked = sorted(direct_scores.items(), key=lambda item: item[1], reverse=True)
+    seed_sources: dict[str, str] = {}
+    seed_energy: dict[str, float] = {}
+    for key, score in ranked[:min(100, len(ranked))]:
+        if score > config.dense_seed_threshold:
+            seed_sources[key] = "Dense"
+            seed_energy[key] = 1.0
+    if not seed_sources:
+        for key, _ in ranked[:config.dense_top_k]:
+            seed_sources[key] = "Dense(FB)"
+            seed_energy[key] = 1.0
+
+    if source_cursor is not None:
+        fts_query = get_jieba_keywords(query)
+        if fts_query:
+            source_cursor.execute(
+                "SELECT rowid FROM messages_fts WHERE content MATCH ? LIMIT 10",
+                (fts_query,),
+            )
+            rowids = [int(row[0]) for row in source_cursor.fetchall()]
+            if rowids:
+                placeholders = ",".join("?" for _ in rowids)
+                source_cursor.execute(
+                    f"SELECT session_key, seq, role FROM messages WHERE rowid IN ({placeholders})",
+                    rowids,
+                )
+                for session_key, seq, role in source_cursor.fetchall():
+                    _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
+                    if key not in nodes:
+                        continue
+                    if key not in seed_sources:
+                        seed_sources[key] = "FTS"
+                    elif "FTS" not in seed_sources[key].split("+"):
+                        seed_sources[key] += "+FTS"
+                    seed_energy[key] = 1.0
+
+    blackhole_hits: list[tuple[str, float]] = []
+    for key, node in nodes.items():
+        if node.salience <= 0.8 or key in seed_sources:
+            continue
+        score = direct_scores.get(key, 0.0)
+        if score > 0.60:
+            blackhole_hits.append((key, score))
+    for key, _ in sorted(blackhole_hits, key=lambda item: item[1], reverse=True)[:5]:
+        seed_sources[key] = "BlackHole"
+        seed_energy[key] = 1.0
+
+    return seed_sources, seed_energy
+
+
+# ── 扩散矩阵 ──────────────────────────────────────────────────────────
+
+
+def state_array(
+    keys: list[str],
+    nodes: dict[str, AkashaNode],
+    fan: dict[str, int],
+    seq: int,
+) -> np.ndarray:
+    """计算节点状态权重（salience + 长期强度 + 短期资源 + fan 惩罚）。"""
+    values = np.zeros(len(keys), dtype=np.float32)
+    for index, key in enumerate(keys):
+        node = nodes[key]
+        long_score = min(1.0, decayed_strength(node, seq) / STRENGTH_CAP)
+        resource = recover_resource(node, seq)
+        values[index] = (
+            math.exp(1.4 * node.salience + 1.0 * long_score)
+            * resource
+            / math.sqrt(1.0 + fan.get(key, 0))
+        )
+    return values
+
+
+def cross_matrix(
+    keys: list[str],
+    edges: dict[tuple[str, str], float],
+    index_by_key: dict[str, int],
+    edges_by_src: dict[str, dict[str, float]] | None = None,
+) -> np.ndarray:
+    """构建微型图内部的共激活边矩阵。"""
+    matrix = np.zeros((len(keys), len(keys)), dtype=np.float32)
+    if edges_by_src is not None:
+        for src_key in keys:
+            src_index = index_by_key[src_key]
+            for dst_key, weight in edges_by_src.get(src_key, {}).items():
+                dst_index = index_by_key.get(dst_key)
+                if dst_index is not None:
+                    matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+        return matrix
+    for (src_key, dst_key), weight in edges.items():
+        src_index = index_by_key.get(src_key)
+        dst_index = index_by_key.get(dst_key)
+        if src_index is not None and dst_index is not None:
+            matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+    return matrix
+
+
+def keep_top_edges_per_column(matrix: np.ndarray, *, top_k: int) -> np.ndarray:
+    """每列只保留最强的 top_k 条边。"""
+    if len(matrix) <= top_k:
+        return matrix
+    kth = np.partition(matrix, -top_k, axis=0)[-top_k]
+    return np.where(matrix >= kth[np.newaxis, :], matrix, 0.0)
+
+
+def normalize_columns(matrix: np.ndarray) -> np.ndarray:
+    """对转移矩阵按列归一化。"""
+    sums = matrix.sum(axis=0)
+    sums[sums == 0] = 1e-10
+    return matrix / sums
+
+
+def initial_energy(
+    keys: list[str],
+    seed_energy: dict[str, float],
+    fan: dict[str, int],
+    index_by_key: dict[str, int],
+) -> np.ndarray:
+    """构造 RWR 初始能量向量。"""
+    energy = np.zeros(len(keys), dtype=np.float32)
+    for key, value in seed_energy.items():
+        index = index_by_key.get(key)
+        if index is not None:
+            energy[index] = value / math.sqrt(1.0 + fan.get(key, 0))
+    total = float(energy.sum())
+    return energy / total if total > 0 else energy
+
+
+# ── 路径回溯 ──────────────────────────────────────────────────────────
+
+
+def path_info(
+    keys: list[str],
+    transition: np.ndarray,
+    e0: np.ndarray,
+    te0: np.ndarray,
+) -> dict[str, tuple[str, str, str, float]]:
+    """回溯每个候选的能量路径（direct / 1hop / 2hop）。"""
+    result: dict[str, tuple[str, str, str, float]] = {}
+    seed_indices = np.where(e0 > 0)[0]
+    for index, key in enumerate(keys):
+        c0 = float(0.2 * e0[index])
+        c1_vec = 0.16 * transition[index, :] * e0
+        s1 = int(np.argmax(c1_vec))
+        c1 = float(c1_vec[s1])
+        c2_vec = 0.64 * transition[index, :] * te0
+        c2_vec[index] = 0.0
+        c2_vec[seed_indices] = 0.0
+        bridge = int(np.argmax(c2_vec))
+        c2 = float(c2_vec[bridge])
+        s2 = int(np.argmax(transition[bridge, :] * e0))
+        if c0 >= c1 and c0 >= c2:
+            result[key] = ("direct", "", "", c0)
+        elif c1 >= c2:
+            result[key] = ("1hop", keys[s1], "", c1)
+        else:
+            result[key] = ("2hop", keys[s2], keys[bridge], c2)
+    return result
+
+
+# ── 候选评分 ──────────────────────────────────────────────────────────
+
+
+def score_candidates(
+    keys: list[str],
+    nodes: dict[str, AkashaNode],
+    direct_scores: dict[str, float],
+    seed_sources: dict[str, str],
+    current: np.ndarray,
+    state_arr: np.ndarray,
+    cross_mat: np.ndarray,
+    fan: dict[str, int],
+    seq: int,
+    path_info_dict: dict[str, tuple[str, str, str, float]],
+    config: CoreConfig,
+    source_cursor: sqlite3.Cursor | None,
+    *,
+    soft_recall: bool,
+    return_limit: int | None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate]]:
+    """计算最终 Ripple 分数，返回 (candidates, suppressed)。"""
+    all_candidates: dict[str, AkashaCandidate] = {}
+    max_state = max(float(np.max(state_arr)), 1e-10)
+    for index, key in enumerate(keys):
+        node = nodes[key]
+        long_score = min(1.0, decayed_strength(node, seq) / STRENGTH_CAP)
+        resource = recover_resource(node, seq)
+        fan_value = fan.get(key, 0)
+        direct_value = max(0.0, direct_scores.get(key, 0.0))
+        state_value = min(1.0, float(state_arr[index]) / max_state)
+        edge_value = float(np.max(cross_mat[index])) if len(keys) else 0.0
+        ptype, seed_key, bridge_key, path_value = path_info_dict.get(key, ("direct", "", "", 0.0))
+        hop_penalty = {"direct": 1.0, "1hop": 0.86, "2hop": 0.62}.get(ptype, 0.62)
+        source = seed_sources.get(key, "Expanded")
+        direct_weight = 0.50 if source != "Expanded" else 0.18
+        fan_penalty = math.pow(1.0 + fan_value, FAN_PENALTY_POWER)
+        user_penalty = 1.0 if has_user_turn(source_cursor, key) else ASSISTANT_ONLY_PENALTY
+        score = (
+            float(current[index]) * 3.0 * state_value
+            + direct_weight * direct_value
+            + 0.18 * long_score
+            + 0.12 * node.salience
+            + 0.20 * min(1.0, edge_value)
+        ) * resource * hop_penalty * user_penalty / fan_penalty
+        if source == "Expanded" and ptype == "1hop" and direct_value >= EXPANDED_DIRECT_FLOOR:
+            score = max(score, config.activation_threshold + 0.01)
+        all_candidates[key] = AkashaCandidate(
+            key=key, source=source, ripple=float(current[index]),
+            direct=direct_value, state=state_value, edge=edge_value,
+            long=long_score, resource=resource, fan=fan_value,
+            score=score, path_type=ptype, seed_key=seed_key,
+            bridge_key=bridge_key, path_value=path_value,
+        )
+
+    # Bridge 提升
+    for child in list(all_candidates.values()):
+        if child.path_type != "2hop" or not child.bridge_key:
+            continue
+        bridge = all_candidates.get(child.bridge_key)
+        if bridge is None or not has_user_turn(source_cursor, bridge.key):
+            continue
+        bridge_score = max(
+            bridge.score,
+            child.score * 0.62,
+            bridge.direct * 0.24 + bridge.state * 0.08,
+        )
+        all_candidates[bridge.key] = AkashaCandidate(
+            key=bridge.key, source="Bridge",
+            ripple=bridge.ripple, direct=bridge.direct,
+            state=bridge.state, edge=bridge.edge,
+            long=bridge.long, resource=bridge.resource,
+            fan=bridge.fan, score=bridge_score, path_type="bridge",
+            seed_key=child.seed_key, bridge_key="",
+            path_value=max(bridge.path_value, child.path_value),
+        )
+
+    candidates: list[AkashaCandidate] = []
+    suppressed: list[AkashaCandidate] = []
+    for candidate in all_candidates.values():
+        soft_hit = (
+            soft_recall
+            and candidate.score >= config.soft_recall_threshold
+            and candidate.direct >= config.soft_recall_direct_floor
+            and candidate.source in {"Bridge", "Expanded"}
+            and candidate.path_type in {"bridge", "1hop", "2hop"}
+        )
+        if candidate.score >= config.activation_threshold or soft_hit:
+            if soft_hit and candidate.score < config.activation_threshold:
+                candidate = AkashaCandidate(
+                    key=candidate.key, source=candidate.source,
+                    ripple=candidate.ripple, direct=candidate.direct,
+                    state=candidate.state, edge=candidate.edge,
+                    long=candidate.long, resource=candidate.resource,
+                    fan=candidate.fan, score=candidate.score,
+                    suppressed="soft-recall", path_type=candidate.path_type,
+                    seed_key=candidate.seed_key, bridge_key=candidate.bridge_key,
+                    path_value=candidate.path_value,
+                )
+            candidates.append(candidate)
+        else:
+            suppressed.append(
+                AkashaCandidate(
+                    key=candidate.key, source=candidate.source,
+                    ripple=candidate.ripple, direct=candidate.direct,
+                    state=candidate.state, edge=candidate.edge,
+                    long=candidate.long, resource=candidate.resource,
+                    fan=candidate.fan, score=candidate.score,
+                    suppressed="below-threshold", path_type=candidate.path_type,
+                    seed_key=candidate.seed_key, bridge_key=candidate.bridge_key,
+                    path_value=candidate.path_value,
+                )
+            )
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    suppressed.sort(key=lambda item: item.score, reverse=True)
+    limit = return_limit or config.activate_limit
+    return candidates[:limit], suppressed[:limit]
+
+
+def graph_expand_candidates(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    direct_scores: dict[str, float],
+    fan: dict[str, int],
+    seq: int,
+    source_cursor: sqlite3.Cursor | None,
+    edges_by_src: dict[str, dict[str, float]] | None,
+    graph_seed_keys: list[str],
+) -> list[AkashaCandidate]:
+    """沿 Dense 种子的强共激活边补一跳候选。"""
+    if edges_by_src is None or not graph_seed_keys:
+        return []
+
+    seed_set = {key for key in graph_seed_keys if key in nodes}
+    in_strength: dict[str, float] = {}
+    for src_neighbors in edges_by_src.values():
+        for dst_key, edge_weight in src_neighbors.items():
+            in_strength[dst_key] = in_strength.get(dst_key, 0.0) + edge_weight
+
+    candidates: list[AkashaCandidate] = []
+    for seed_key in graph_seed_keys:
+        if seed_key not in nodes:
+            continue
+        raw_neighbors = edges_by_src.get(seed_key, {})
+        out_strength = sum(raw_neighbors.values())
+        if out_strength <= 0:
+            continue
+
+        scored_neighbors = []
+        for key, edge_weight in raw_neighbors.items():
+            if key not in nodes or key in seed_set or not has_user_turn(source_cursor, key):
+                continue
+            dst_strength = in_strength.get(key, edge_weight)
+            edge_signal = edge_weight / math.sqrt(max(out_strength * dst_strength, 1e-9))
+            direct = max(0.0, direct_scores.get(key, 0.0))
+            degree_penalty = math.pow(1.0 + max(0, fan.get(key, 0)), GRAPH_FAN_PENALTY_POWER)
+            candidate_signal = edge_signal * (GRAPH_DIRECT_BIAS + direct) / degree_penalty
+            scored_neighbors.append((candidate_signal, edge_signal, direct, key, edge_weight))
+        scored_neighbors.sort(reverse=True, key=lambda item: item[0])
+        max_edge_signal = max((item[1] for item in scored_neighbors), default=0.0)
+
+        for _, edge_signal, direct, key, edge_weight in scored_neighbors[:GRAPH_EXPAND_LIMIT]:
+            if max_edge_signal <= 0:
+                continue
+            node = nodes[key]
+            degree = max(0, fan.get(key, 0))
+            resource = recover_resource(node, seq)
+            long_score = min(1.0, node.strength / STRENGTH_CAP)
+            normalized_edge = edge_signal / max_edge_signal
+            score = (
+                3.0
+                * normalized_edge
+                * (GRAPH_DIRECT_BIAS + direct)
+                * (1.0 + 0.15 * long_score)
+                / math.pow(1.0 + degree, GRAPH_FAN_PENALTY_POWER)
+            )
+            candidates.append(AkashaCandidate(
+                key=key, source="Graph", ripple=float(edge_weight),
+                direct=direct, state=0.0, edge=float(edge_signal),
+                long=long_score, resource=resource, fan=degree,
+                score=float(score), path_type="1hop",
+                seed_key=seed_key, path_value=float(edge_signal),
+            ))
+    return candidates
+
+
+def merge_active_candidates(
+    candidates: list[AkashaCandidate],
+    graph_candidates: list[AkashaCandidate],
+    limit: int,
+) -> list[AkashaCandidate]:
+    best_by_key: dict[str, AkashaCandidate] = {}
+    for item in candidates + graph_candidates:
+        current = best_by_key.get(item.key)
+        if current is None or item.score > current.score:
+            best_by_key[item.key] = item
+    merged = sorted(best_by_key.values(), key=lambda item: item.score, reverse=True)
+    return merged[:limit]
+
+
+# ── 主入口 ────────────────────────────────────────────────────────────
+
+
+def compute_candidates(
+    query: str,
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    edges: dict[tuple[str, str], float],
+    seq: int,
+    *,
+    config: CoreConfig,
+    fan: dict[str, int],
+    source_cursor: sqlite3.Cursor | None = None,
+    edges_by_src: dict[str, dict[str, float]] | None = None,
+    soft_recall: bool = False,
+    return_limit: int | None = None,
+    graph_seed_keys: list[str] | None = None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate], ActivationTrace]:
+    """
+    状态化 RAR 扩散主入口。
+
+    参数：
+        query: 查询文本
+        query_vec: 查询向量（已归一化）
+        nodes: 所有状态节点 {key: AkashaNode}
+        edges: 共激活边 {(src, dst): weight}
+        seq: 当前消息序号
+        config: 算法参数
+        fan: 节点扇出统计
+        source_cursor: 源数据库 cursor（FTS 和 user_turn 查询）
+        edges_by_src: 边按源节点索引（可选加速）
+        soft_recall: 是否开启软召回（展示用）
+        return_limit: 返回数量上限
+
+    返回：
+        (candidates, suppressed, trace)
+    """
+    if not nodes:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+
+    direct_scores_map = dense_scores(query_vec, nodes)
+    seed_sources, seed_energy = seed_pool(
+        query, direct_scores_map, nodes, config, source_cursor,
+    )
+    if not seed_sources:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+
+    micro_keys = set(seed_sources)
+    for seed_key in seed_sources:
+        seed_ts = nodes[seed_key].first_ts_unix
+        for key, node in nodes.items():
+            if key in micro_keys:
+                continue
+            is_near = abs(node.first_ts_unix - seed_ts) <= config.nearby_time_seconds
+            if is_near and direct_scores_map.get(key, 0.0) > config.nearby_dense_threshold:
+                micro_keys.add(key)
+    valid_keys = list(micro_keys)
+    if not valid_keys:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+
+    index_by_key = {key: idx for idx, key in enumerate(valid_keys)}
+    embeddings = np.vstack([nodes[key].embedding for key in valid_keys])
+    sim_matrix = np.maximum(np.dot(embeddings, embeddings.T), 0.0)
+    np.fill_diagonal(sim_matrix, 0.0)
+
+    state_arr = state_array(valid_keys, nodes, fan, seq)
+    cross_mat = cross_matrix(valid_keys, edges, index_by_key, edges_by_src)
+
+    transition = sim_matrix * state_arr[:, np.newaxis]
+    transition *= 1.0 + config.cross_boost * cross_mat
+    transition = keep_top_edges_per_column(transition, top_k=12)
+    transition = normalize_columns(transition)
+
+    e0 = initial_energy(valid_keys, seed_energy, fan, index_by_key)
+    te0 = np.dot(transition, e0)
+    current = e0.copy()
+    for _ in range(2):
+        current = 0.8 * np.dot(transition, current) + 0.2 * e0
+
+    path_info_dict = path_info(valid_keys, transition, e0, te0)
+    candidates, suppressed = score_candidates(
+        valid_keys, nodes, direct_scores_map, seed_sources,
+        current, state_arr, cross_mat, fan, seq,
+        path_info_dict, config, source_cursor,
+        soft_recall=soft_recall, return_limit=return_limit,
+    )
+    if graph_seed_keys:
+        graph_candidates = graph_expand_candidates(
+            query_vec, nodes, direct_scores_map, fan, seq,
+            source_cursor, edges_by_src, graph_seed_keys,
+        )
+        limit = return_limit or config.activate_limit
+        candidates = merge_active_candidates(candidates, graph_candidates, limit)
+        active_keys = {item.key for item in candidates}
+        suppressed = [item for item in suppressed if item.key not in active_keys]
+    return candidates, suppressed, ActivationTrace(
+        seed_count=len(seed_sources), pool_count=len(valid_keys),
+    )
+
+
+# ── 状态更新 ──────────────────────────────────────────────────────────
+
+
+def activation_updates(
+    items: list[AkashaCandidate],
+    nodes: dict[str, AkashaNode],
+    seq: int,
+) -> list[ActivationUpdate]:
+    """生成被激活节点的状态更新。"""
+    updates: list[ActivationUpdate] = []
+    for item in items:
+        node = nodes.get(item.key)
+        if node is None:
+            continue
+        strength = decayed_strength(node, seq)
+        strength = bounded_add(strength, STRENGTH_LR * item.score, STRENGTH_CAP)
+        resource = recover_resource(node, seq)
+        resource *= max(0.05, 1.0 - RESOURCE_USE_RATE * min(1.0, item.score))
+        updates.append(ActivationUpdate(
+            key=item.key, strength=strength, resource=resource,
+            recall_count=node.recall_count + 1, seq=seq,
+        ))
+    return updates

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -31,6 +31,32 @@ GRAPH_EXPAND_LIMIT = 8
 GRAPH_DIRECT_BIAS = 0.25
 GRAPH_FAN_PENALTY_POWER = 0.15
 
+# FTS 改进参数
+FTS_MIN_IDF = 3.5          # 过滤低 IDF 常见 token
+FTS_MIN_TOKEN_LEN = 3      # trigram 分词器要求至少 3 字符
+FTS_MAX_TOKENS = 10        # FTS query 最多 OR 多少 token
+FTS_TOP_K = 10             # BM25 取 top K
+FTS_ONLY_MAX_HITS = 5      # 单跑 FTS 没 Dense 配对时最多保留几个
+FTS_OVERLAP_BOOST = 1.3    # Dense ∩ FTS 时 seed_energy 倍数
+
+# 模块级 IDF 表（由 engine 调用 set_idf_table 注入）
+_IDF_TABLE: dict[str, float] = {}
+
+
+def set_idf_table(table: dict[str, float] | None) -> None:
+    """注入 IDF 表。空表 / None 时退化到无过滤行为。"""
+    global _IDF_TABLE
+    _IDF_TABLE = table or {}
+
+
+def load_idf_from_db(conn: sqlite3.Connection) -> dict[str, float]:
+    """从 akasha.db 的 fts_token_idf 表加载 IDF 字典。"""
+    try:
+        rows = conn.execute("SELECT token, idf FROM fts_token_idf").fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {t: float(v) for t, v in rows}
+
 # ── 数据类型 ──────────────────────────────────────────────────────────
 
 
@@ -423,15 +449,55 @@ def dense_message_candidates(
 def get_jieba_keywords(text: str) -> str:
     """把文本切成 SQLite FTS 可用的 OR 查询。"""
     import jieba
-    words: list[str] = []
-    for word in jieba.cut_for_search(text):
-        cleaned = "".join(
-            char for char in word.strip()
-            if char.isalnum() or "\u4e00" <= char <= "\u9fff"
-        )
-        if len(cleaned) > 1:
-            words.append(f'"{cleaned}"')
-    return " OR ".join(words[:20])
+    import re
+
+    pairs: list[tuple[str, float]] = []
+    seen: set[str] = set()
+
+    def _consider(token: str, default_idf: float) -> None:
+        if len(token) < FTS_MIN_TOKEN_LEN or token in seen:
+            return
+        seen.add(token)
+        if _IDF_TABLE:
+            idf = _IDF_TABLE.get(token, 6.0)  # \u672a\u89c1\u8fc7\u89c6\u4e3a\u7a00\u6709
+            if idf < FTS_MIN_IDF:
+                return
+            pairs.append((token, idf))
+        else:
+            pairs.append((token, default_idf))
+
+    # 1. Latin / \u6570\u5b57 \u8bcd\u7ec4\uff08trigram \u76f4\u63a5\u80fd\u5904\u7406\uff09
+    for m in re.finditer(r"[a-z0-9_]{3,}", text.lower()):
+        _consider(m.group(), 5.0)
+
+    # 2. jieba \u5207\u8bcd
+    tokens = list(jieba.lcut(text))
+    cleaned_tokens: list[str] = []
+    for w in tokens:
+        c = "".join(ch for ch in w if "\u4e00" <= ch <= "\u9fff")
+        cleaned_tokens.append(c.lower())
+
+    # 3a. 3+ \u5b57\u4e2d\u6587 token \u76f4\u63a5\u52a0\uff08IDF \u8fc7\u6ee4\uff09
+    for c in cleaned_tokens:
+        if len(c) >= 3:
+            _consider(c, 5.0)
+
+    # 3b. 2 \u5b57\u4e2d\u6587 token \u4e0e\u76f8\u90bb\u5b57\u7b26\u62fc\u6210 3 \u5b57 phrase\uff08trigram \u624d\u80fd\u547d\u4e2d\uff09
+    for i, c in enumerate(cleaned_tokens):
+        if len(c) != 2:
+            continue
+        # \u62fc\u63a5\u4e0b\u4e00\u4e2a token \u7684\u9996\u5b57
+        if i + 1 < len(cleaned_tokens) and cleaned_tokens[i + 1]:
+            combined = c + cleaned_tokens[i + 1][0]
+            _consider(combined, 5.0)
+        # \u4e5f\u62fc\u63a5\u4e0a\u4e00\u4e2a token \u7684\u672b\u5b57
+        if i - 1 >= 0 and cleaned_tokens[i - 1]:
+            combined = cleaned_tokens[i - 1][-1] + c
+            _consider(combined, 5.0)
+
+    pairs.sort(key=lambda x: -x[1])
+    pairs = pairs[:FTS_MAX_TOKENS]
+    return " OR ".join(f'"{w}"' for w, _ in pairs)
 
 
 def seed_pool(
@@ -457,26 +523,56 @@ def seed_pool(
     if source_cursor is not None:
         fts_query = get_jieba_keywords(query)
         if fts_query:
-            source_cursor.execute(
-                "SELECT rowid FROM messages_fts WHERE content MATCH ? LIMIT 10",
-                (fts_query,),
-            )
-            rowids = [int(row[0]) for row in source_cursor.fetchall()]
-            if rowids:
-                placeholders = ",".join("?" for _ in rowids)
+            # 用 BM25 排序拿 top K（bm25() 返回负值，越小越匹配）
+            try:
                 source_cursor.execute(
-                    f"SELECT session_key, seq, role FROM messages WHERE rowid IN ({placeholders})",
-                    rowids,
+                    """
+                    SELECT rowid, bm25(messages_fts) AS rank
+                    FROM messages_fts
+                    WHERE content MATCH ?
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (fts_query, FTS_TOP_K),
                 )
-                for session_key, seq, role in source_cursor.fetchall():
+                rows = source_cursor.fetchall()
+            except sqlite3.OperationalError:
+                # FTS5 不支持 bm25 时退回旧行为
+                source_cursor.execute(
+                    "SELECT rowid, 0 FROM messages_fts WHERE content MATCH ? LIMIT ?",
+                    (fts_query, FTS_TOP_K),
+                )
+                rows = source_cursor.fetchall()
+            if rows:
+                rowid_to_rank = {int(r[0]): float(r[1] or 0.0) for r in rows}
+                placeholders = ",".join("?" for _ in rowid_to_rank)
+                source_cursor.execute(
+                    f"SELECT session_key, seq, role, rowid FROM messages WHERE rowid IN ({placeholders})",
+                    list(rowid_to_rank.keys()),
+                )
+                fts_candidates: list[tuple[str, float]] = []
+                for session_key, seq, role, rowid in source_cursor.fetchall():
                     _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
                     if key not in nodes:
                         continue
-                    if key not in seed_sources:
+                    fts_candidates.append((key, rowid_to_rank.get(int(rowid), 0.0)))
+                # 按 BM25 |rank| 降序（更匹配的排前）
+                fts_candidates.sort(key=lambda x: x[1])  # rank 是负值，小的更匹配
+
+                fts_only_count = 0
+                for key, _ in fts_candidates:
+                    if key in seed_sources:
+                        # Dense ∩ FTS: 加 boost（multiplicative fusion）
+                        if "FTS" not in seed_sources[key].split("+"):
+                            seed_sources[key] += "+FTS"
+                        seed_energy[key] = min(1.5, seed_energy[key] * FTS_OVERLAP_BOOST)
+                    else:
+                        # FTS-only: 限制数量，只让最匹配的几个进
+                        if fts_only_count >= FTS_ONLY_MAX_HITS:
+                            continue
                         seed_sources[key] = "FTS"
-                    elif "FTS" not in seed_sources[key].split("+"):
-                        seed_sources[key] += "+FTS"
-                    seed_energy[key] = 1.0
+                        seed_energy[key] = 1.0
+                        fts_only_count += 1
 
     blackhole_hits: list[tuple[str, float]] = []
     for key, node in nodes.items():

--- a/plugins/akasha/dashboard.py
+++ b/plugins/akasha/dashboard.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, cast
+
+from fastapi import FastAPI, HTTPException
+
+from plugins.akasha.config import AkashaConfig, load_akasha_config, resolve_akasha_db_path
+from plugins.akasha.store import AkashaStore
+
+
+def plugin_enabled(app: FastAPI) -> bool:
+    return _active_memory_engine(app) == "akasha"
+
+
+class AkashaInspectorReader:
+    def __init__(self, store: AkashaStore) -> None:
+        self._store = store
+        self._lock = threading.RLock()
+
+    def get_overview(self) -> dict[str, Any]:
+        items, total = self._store.list_query_logs(page=1, page_size=1)
+        latest = items[0]["ts"] if items else None
+        return {"available": True, "total": total, "latest_at": latest}
+
+    def list_turns(
+        self,
+        *,
+        session_key: str = "",
+        q: str = "",
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[dict[str, Any]], int]:
+        return self._store.list_query_logs(
+            session_key=session_key,
+            q=q,
+            page=page,
+            page_size=page_size,
+        )
+
+    def get_turn(self, query_id: str) -> dict[str, Any] | None:
+        raw = self._store.get_query_log(query_id)
+        if raw is None:
+            return None
+        result = dict(raw)
+        # 反序列化 JSON 列
+        for json_key, out_key in [
+            ("activation_items_json", "activation_items"),
+            ("dense_items_json", "dense_items"),
+            ("ripple_items_json", "ripple_items"),
+        ]:
+            raw_json = result.pop(json_key, "[]")
+            try:
+                parsed = json.loads(str(raw_json))
+            except Exception:
+                parsed = []
+            result[out_key] = parsed if isinstance(parsed, list) else []
+        return cast(dict[str, Any], result)
+
+
+def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> list[object]:
+    _ = plugin_dir
+
+    # 找到 akasha sidecar DB 路径（复用 engine 的 config 解析）。
+    akasha_config = _load_akasha_config(workspace)
+    if akasha_config is None:
+        return []
+
+    store = AkashaStore(resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config))
+    reader = AkashaInspectorReader(store)
+
+    @app.get("/api/dashboard/akasha-inspector/overview")
+    def get_akasha_inspector_overview() -> dict[str, Any]:
+        return reader.get_overview()
+
+    @app.get("/api/dashboard/akasha-inspector/turns")
+    def list_akasha_inspector_turns(
+        session_key: str = "",
+        q: str = "",
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict[str, Any]:
+        items, total = reader.list_turns(
+            session_key=session_key,
+            q=q,
+            page=page,
+            page_size=page_size,
+        )
+        return {
+            "items": items,
+            "total": total,
+            "page": max(1, page),
+            "page_size": max(1, min(page_size, 200)),
+        }
+
+    @app.get("/api/dashboard/akasha-inspector/turns/{query_id:path}")
+    def get_akasha_inspector_turn(query_id: str) -> dict[str, Any]:
+        item = reader.get_turn(query_id)
+        if item is None:
+            raise HTTPException(status_code=404, detail="Akasha 检索记录不存在")
+        return item
+
+    return [store]
+
+
+def _active_memory_engine(app: FastAPI) -> str:
+    memory_admin = getattr(app.state, "memory_admin", None)
+    describe = getattr(memory_admin, "describe", None)
+    if not callable(describe):
+        return ""
+    return str(describe().name)
+
+
+def _load_akasha_config(workspace: Path) -> AkashaConfig | None:
+    # 从插件目录的 config.local.toml 加载；读取失败返回默认配置。
+    _ = workspace
+    try:
+        plugin_dir = Path(__file__).resolve().parent
+        return load_akasha_config(plugin_dir=plugin_dir)
+    except Exception:
+        return AkashaConfig()

--- a/plugins/akasha/dashboard_panel_inspector.css
+++ b/plugins/akasha/dashboard_panel_inspector.css
@@ -1,0 +1,250 @@
+/* ── Akasha Inspector Panel ── */
+
+.ai-inspector {}
+
+/* Query text */
+.ai-query-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text);
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
+}
+
+.ai-meta-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.ai-meta-kv {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.ai-meta-k {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-soft);
+}
+
+.ai-meta-v {
+  font-size: 12px;
+  color: var(--text);
+}
+
+/* Stats row */
+.ai-stats-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.ai-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.ai-stat-val {
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1;
+}
+
+.ai-stat-val.ai-threshold {
+  color: var(--text-soft);
+  font-size: 14px;
+}
+
+.ai-stat-k {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-soft);
+}
+
+.ai-stat-sep {
+  font-size: 14px;
+  color: var(--text-soft);
+  padding-bottom: 12px;
+}
+
+/* Count badge next to label */
+.ai-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--line);
+  color: var(--text-soft);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  border-radius: 99px;
+  padding: 1px 7px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* Tags */
+.ai-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--text-soft);
+}
+
+/* source tags */
+.ai-src-dense    { background: var(--blue-soft);   color: var(--tool);   border-color: rgba(39,100,137,.25); }
+.ai-src-densefb  { background: var(--blue-soft);   color: var(--tool);   border-color: rgba(39,100,137,.15); opacity: .75; }
+.ai-src-fts      { background: var(--accent-soft); color: var(--accent); border-color: rgba(204,120,92,.3); }
+.ai-src-blackhole{ background: #1a1a2e; color: #b8b8ff; border-color: rgba(160,160,255,.3); }
+.ai-src-expanded { background: var(--green-soft);  color: var(--green);  border-color: rgba(93,184,114,.35); }
+.ai-src-bridge   { background: var(--yellow-soft); color: var(--system); border-color: rgba(139,107,9,.3); }
+.ai-src-other    {}
+
+/* path tags */
+.ai-path-direct { background: var(--green-soft);  color: var(--green);  border-color: rgba(93,184,114,.35); }
+.ai-path-1hop   { background: var(--blue-soft);   color: var(--tool);   border-color: rgba(39,100,137,.25); }
+.ai-path-2hop   { background: var(--accent-soft); color: var(--accent); border-color: rgba(204,120,92,.3); }
+.ai-path-bridge { background: var(--yellow-soft); color: var(--system); border-color: rgba(139,107,9,.3); }
+
+/* suppressed */
+.ai-suppressed { background: var(--paper); color: var(--text-soft); opacity: .6; margin-left: 4px; }
+
+/* score coloring */
+.ai-score     { font-family: var(--mono); font-size: 11px; }
+.ai-score-hi  { color: var(--green); }
+.ai-score-mid { color: var(--accent); }
+.ai-score-lo  { color: var(--text-soft); }
+
+/* Table wrapper */
+.ai-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.ai-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.ai-table th {
+  padding: 6px 10px;
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-soft);
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  background: var(--paper);
+}
+
+.ai-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: middle;
+}
+
+.ai-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ai-row-suppressed td {
+  opacity: .55;
+}
+
+.ai-cell-key {
+  font-size: 10.5px;
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-soft);
+}
+
+.ai-cell-num {
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* Cards table */
+.ai-table-cards .ai-th-msg     { min-width: 160px; max-width: 260px; }
+.ai-table-cards .ai-th-preview { min-width: 120px; max-width: 220px; }
+
+.ai-cell-msg {
+  max-width: 260px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+}
+
+.ai-cell-preview {
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-soft);
+  font-size: 11.5px;
+}
+
+/* Source ref link */
+.ai-source-ref {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--tool);
+  cursor: default;
+  white-space: nowrap;
+}
+
+/* Text block preview */
+.ai-preview-block {
+  margin-top: 8px;
+}
+
+.ai-preview-block summary {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-soft);
+  cursor: pointer;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.ai-preview-pre {
+  margin: 8px 0 0;
+  padding: 12px 14px;
+  background: var(--code-bg, #1e1e2e);
+  color: var(--code-text, #cdd6f4);
+  border-radius: var(--radius);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--line);
+}
+
+/* Empty state */
+.ai-empty {
+  padding: 14px;
+  font-size: 12.5px;
+  color: var(--text-soft);
+}

--- a/plugins/akasha/dashboard_panel_inspector.ts
+++ b/plugins/akasha/dashboard_panel_inspector.ts
@@ -78,7 +78,6 @@ function ai_sourceTag(source: string): string {
     "Dense(FB)": "ai-src-densefb",
     FTS: "ai-src-fts",
     BlackHole: "ai-src-blackhole",
-    Expanded: "ai-src-expanded",
     Bridge: "ai-src-bridge",
   }[source] ?? "ai-src-other";
   return `<span class="ai-tag ${cls}">${escapeHtml(source)}</span>`;

--- a/plugins/akasha/dashboard_panel_inspector.ts
+++ b/plugins/akasha/dashboard_panel_inspector.ts
@@ -1,0 +1,348 @@
+/// <reference path="../../types/akashic-dashboard.d.ts" />
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface AkashaCandidate {
+  key: string;
+  user_message: string;
+  assistant_preview: string;
+  score: number;
+  source: string;
+  path_type: string;
+  fan: number;
+  direct: number;
+  state: number;
+  edge: number;
+  long: number;
+  resource: number;
+  ripple: number;
+  seed_key: string;
+  bridge_key: string;
+  suppressed: string;
+}
+
+interface AkashaCard extends AkashaCandidate {
+  user_message: string;
+  assistant_preview: string;
+  source_ref: string;
+}
+
+interface AkashaQueryRow {
+  query_id: string;
+  session_key: string;
+  seq: number;
+  query_text: string;
+  intent: string;
+  ts: string;
+  seed_count: number;
+  pool_count: number;
+  activated_count: number;
+  activation_threshold: number;
+  dense_count: number;
+  ripple_count: number;
+  inject_chars: number;
+  source_ref_count: number;
+}
+
+interface AkashaQueryDetail extends AkashaQueryRow {
+  activation_items: AkashaCandidate[];
+  dense_items: AkashaCard[];
+  ripple_items: AkashaCard[];
+  text_block_preview: string;
+}
+
+interface AkashaOverview {
+  available: boolean;
+  total: number;
+  latest_at: string | null;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Prefix all helpers with ai_ to avoid collisions with other panels.
+function ai_fmt2(v: number | null | undefined): string {
+  if (v == null) return "-";
+  return v.toFixed(2);
+}
+
+function ai_fmtScore(v: number | null | undefined): string {
+  if (v == null) return "-";
+  const n = Number(v);
+  const cls = n >= 0.5 ? "ai-score-hi" : n >= 0.25 ? "ai-score-mid" : "ai-score-lo";
+  return `<span class="ai-score ${cls}">${n.toFixed(3)}</span>`;
+}
+
+function ai_sourceTag(source: string): string {
+  const cls = {
+    Dense: "ai-src-dense",
+    "Dense(FB)": "ai-src-densefb",
+    FTS: "ai-src-fts",
+    BlackHole: "ai-src-blackhole",
+    Expanded: "ai-src-expanded",
+    Bridge: "ai-src-bridge",
+  }[source] ?? "ai-src-other";
+  return `<span class="ai-tag ${cls}">${escapeHtml(source)}</span>`;
+}
+
+function ai_pathTag(pt: string): string {
+  const cls = {
+    direct: "ai-path-direct",
+    "1hop": "ai-path-1hop",
+    "2hop": "ai-path-2hop",
+    bridge: "ai-path-bridge",
+  }[pt] ?? "";
+  return `<span class="ai-tag ${cls}">${escapeHtml(pt)}</span>`;
+}
+
+function ai_suppressedTag(s: string): string {
+  if (!s) return "";
+  return `<span class="ai-tag ai-suppressed">${escapeHtml(s)}</span>`;
+}
+
+function ai_shortKey(key: string): string {
+  // session_key:seq → last 2 segments for readability
+  const parts = key.split(":");
+  if (parts.length >= 2) {
+    const seq = parts[parts.length - 1];
+    const sk = parts.slice(0, -1).join(":");
+    const short = sk.length > 20 ? "…" + sk.slice(-18) : sk;
+    return `${short}:${seq}`;
+  }
+  return key;
+}
+
+function ai_shortTs(value: unknown): string {
+  if (!value) return "-";
+  const d = new Date(String(value));
+  if (isNaN(d.getTime())) return String(value);
+  return `${d.getMonth() + 1}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+// ── Activation table ───────────────────────────────────────────────────────
+
+function ai_renderActivationTable(items: AkashaCandidate[]): string {
+  if (!items.length) {
+    return '<div class="ai-empty">无激活节点</div>';
+  }
+  const rows = items.map((item) => `
+    <tr class="${item.suppressed ? "ai-row-suppressed" : ""}">
+      <td class="ai-cell-msg" title="${escapeHtml(item.user_message)}">${escapeHtml(item.user_message || "-")}</td>
+      <td class="ai-cell-preview" title="${escapeHtml(item.assistant_preview)}">${escapeHtml(item.assistant_preview || "-")}</td>
+      <td class="ai-cell-num">${ai_fmtScore(item.score)}</td>
+      <td>${ai_sourceTag(item.source)}</td>
+      <td>${ai_pathTag(item.path_type)}${ai_suppressedTag(item.suppressed)}</td>
+      <td class="ai-cell-num mono">${item.fan}</td>
+      <td class="ai-cell-num mono">${ai_fmt2(item.direct)}</td>
+      <td class="ai-cell-num mono">${ai_fmt2(item.state)}</td>
+      <td class="ai-cell-num mono">${ai_fmt2(item.edge)}</td>
+      <td class="ai-cell-num mono">${ai_fmt2(item.long)}</td>
+      <td class="ai-cell-num mono">${ai_fmt2(item.resource)}</td>
+    </tr>
+  `).join("");
+  return `
+    <div class="ai-table-wrap">
+      <table class="ai-table ai-table-cards">
+        <thead>
+          <tr>
+            <th class="ai-th-msg">user</th>
+            <th class="ai-th-preview">assistant</th>
+            <th>score</th><th>source</th><th>path</th>
+            <th>fan</th><th>direct</th><th>state</th><th>edge</th><th>long</th><th>resource</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+// ── Dense / Ripple card table ─────────────────────────────────────────────
+
+function ai_renderCardTable(items: AkashaCard[], showPath: boolean): string {
+  if (!items.length) {
+    return '<div class="ai-empty">无记录</div>';
+  }
+  const extraHeaders = showPath
+    ? "<th>path</th><th>seed</th><th>bridge</th>"
+    : "";
+  const rows = items.map((item) => {
+    const srcRefIds: string[] = (() => {
+      try { return JSON.parse(item.source_ref) as string[]; }
+      catch { return []; }
+    })();
+    const srcRefLink = srcRefIds.length
+      ? `<span class="ai-source-ref" title="${escapeHtml(item.source_ref)}">${srcRefIds.length} msg</span>`
+      : "-";
+    const extraCells = showPath
+      ? `<td>${ai_pathTag(item.path_type)}${ai_suppressedTag(item.suppressed)}</td>
+         <td class="mono ai-cell-key" title="${escapeHtml(item.seed_key)}">${escapeHtml(ai_shortKey(item.seed_key))}</td>
+         <td class="mono ai-cell-key" title="${escapeHtml(item.bridge_key)}">${escapeHtml(ai_shortKey(item.bridge_key))}</td>`
+      : "";
+    return `
+      <tr>
+        <td class="ai-cell-msg">${escapeHtml(item.user_message)}</td>
+        <td class="ai-cell-preview">${escapeHtml(item.assistant_preview)}</td>
+        <td class="ai-cell-num">${ai_fmtScore(item.score)}</td>
+        <td>${ai_sourceTag(item.source)}</td>
+        ${extraCells}
+        <td>${srcRefLink}</td>
+      </tr>
+    `;
+  }).join("");
+  return `
+    <div class="ai-table-wrap">
+      <table class="ai-table ai-table-cards">
+        <thead>
+          <tr>
+            <th class="ai-th-msg">user</th>
+            <th class="ai-th-preview">assistant</th>
+            <th>score</th>
+            <th>source</th>
+            ${extraHeaders}
+            <th>ref</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+// ── Detail renderer ───────────────────────────────────────────────────────
+
+function ai_renderEmpty(): string {
+  return `
+    <div class="detail-empty">
+      <div class="detail-empty-title">Akasha Inspector</div>
+      <div class="detail-empty-text">点开一轮检索记录，这里会显示激活图、Dense 精确命中、Ripple 联想命中和注入预览。</div>
+    </div>
+  `;
+}
+
+function ai_renderDetail(item: AkashaQueryDetail): string {
+  const threshold = (item.activation_threshold ?? 0).toFixed(3);
+  return `
+    <div class="detail-wrap ai-inspector">
+      <div class="detail-toolbar">
+        <div>
+          <div class="detail-title">Akasha 检索记录</div>
+          <div class="detail-subtext mono">${escapeHtml(item.session_key)} · seq ${item.seq}</div>
+        </div>
+      </div>
+
+      <!-- 1. User Query -->
+      <div class="detail-block">
+        <div class="detail-label">User Query</div>
+        <div class="ai-query-text">${escapeHtml(item.query_text)}</div>
+        <div class="ai-meta-row">
+          <span class="ai-meta-kv"><span class="ai-meta-k">intent</span><span class="ai-meta-v">${escapeHtml(item.intent)}</span></span>
+          <span class="ai-meta-kv"><span class="ai-meta-k">ts</span><span class="ai-meta-v mono">${escapeHtml(ai_shortTs(item.ts))}</span></span>
+        </div>
+      </div>
+
+      <!-- 2. Activation 激活 -->
+      <div class="detail-block">
+        <div class="detail-label">Activation 激活</div>
+        <div class="ai-stats-row">
+          <div class="ai-stat"><span class="ai-stat-val">${item.seed_count}</span><span class="ai-stat-k">seeds</span></div>
+          <div class="ai-stat-sep">→</div>
+          <div class="ai-stat"><span class="ai-stat-val">${item.pool_count}</span><span class="ai-stat-k">pool</span></div>
+          <div class="ai-stat-sep">→</div>
+          <div class="ai-stat"><span class="ai-stat-val">${item.activated_count}</span><span class="ai-stat-k">activated</span></div>
+          <div class="ai-stat-sep"> / </div>
+          <div class="ai-stat"><span class="ai-stat-val ai-threshold">${threshold}</span><span class="ai-stat-k">threshold</span></div>
+        </div>
+        ${ai_renderActivationTable(item.activation_items || [])}
+      </div>
+
+      <!-- 3. Dense 左脑记忆 -->
+      <div class="detail-block">
+        <div class="detail-label">左脑记忆：精确回忆 <span class="ai-count-badge">${item.dense_count}</span></div>
+        ${ai_renderCardTable(item.dense_items || [], false)}
+      </div>
+
+      <!-- 4. Ripple 右脑联想 -->
+      <div class="detail-block">
+        <div class="detail-label">右脑联想：潜意识第一反应 <span class="ai-count-badge">${item.ripple_count}</span></div>
+        ${ai_renderCardTable(item.ripple_items || [], true)}
+      </div>
+
+      <!-- 5. Prompt 注入 -->
+      <div class="detail-block">
+        <div class="detail-label">Prompt 注入</div>
+        <div class="ai-stats-row">
+          <div class="ai-stat"><span class="ai-stat-val">${item.dense_count}</span><span class="ai-stat-k">dense</span></div>
+          <div class="ai-stat-sep">+</div>
+          <div class="ai-stat"><span class="ai-stat-val">${item.ripple_count}</span><span class="ai-stat-k">ripple</span></div>
+          <div class="ai-stat-sep">·</div>
+          <div class="ai-stat"><span class="ai-stat-val">${item.inject_chars}</span><span class="ai-stat-k">chars</span></div>
+          <div class="ai-stat-sep">·</div>
+          <div class="ai-stat"><span class="ai-stat-val">${item.source_ref_count}</span><span class="ai-stat-k">refs</span></div>
+        </div>
+        ${item.text_block_preview
+          ? `<details class="ai-preview-block"><summary>注入文本预览</summary><pre class="ai-preview-pre">${escapeHtml(item.text_block_preview)}</pre></details>`
+          : '<div class="ai-empty">本轮无注入（非 context intent）</div>'}
+      </div>
+    </div>
+  `;
+}
+
+// ── Plugin registration ───────────────────────────────────────────────────
+
+window.AkashicDashboard.registerPlugin({
+  id: "akasha_inspector",
+  label: "Akasha Inspector",
+  viewLabel: "akasha inspector",
+  pageSize: 25,
+  rowKey: "query_id",
+
+  countTitle(total: number): string {
+    return `${total} 轮检索`;
+  },
+
+  columns: [
+    { key: "session_key", label: "Session", width: 108, fmt: "mono-session", cellClass: "mono cell-session", rawTitle: true },
+    { key: "ts", label: "Time", width: 96, fmt: "mono-time", cellClass: "mono cell-time", rawTitle: true,
+      renderCell(value) { return escapeHtml(ai_shortTs(value)); } },
+    { key: "query_text", label: "Query", flex: true, fmt: "text-preview", cellClass: "content-preview" },
+    { key: "seed_count", label: "Seeds", width: 60, fmt: "metric", cellClass: "mono cell-metric", align: "right" },
+    { key: "activated_count", label: "Active", width: 60, fmt: "metric", cellClass: "mono cell-metric", align: "right" },
+    { key: "dense_count", label: "Dense", width: 60, fmt: "metric", cellClass: "mono cell-metric", align: "right" },
+    { key: "ripple_count", label: "Ripple", width: 60, fmt: "metric", cellClass: "mono cell-metric", align: "right" },
+    { key: "inject_chars", label: "Chars", width: 70, fmt: "metric", cellClass: "mono cell-metric", align: "right" },
+  ],
+
+  async getCount(): Promise<number | null> {
+    try {
+      const r = await api<AkashaOverview>("/api/dashboard/akasha-inspector/overview");
+      return r.available ? (r.total ?? 0) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetchPage({ page, pageSize, filters }: FetchPageOpts): Promise<FetchPageResult> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("page_size", String(pageSize));
+    if (filters?.["session_key"]) params.set("session_key", filters["session_key"]);
+    if (filters?.["q"]) params.set("q", filters["q"]);
+    const data = await api<{ items: Record<string, unknown>[]; total: number }>(
+      `/api/dashboard/akasha-inspector/turns?${params.toString()}`
+    );
+    return { items: data.items || [], total: data.total || 0 };
+  },
+
+  async fetchDetail(item: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const queryId = String(item["query_id"] ?? "");
+    return api(`/api/dashboard/akasha-inspector/turns/${encodePath(queryId)}`);
+  },
+
+  renderDetail(item: Record<string, unknown> | null, container: HTMLElement): void {
+    if (!item) {
+      container.innerHTML = ai_renderEmpty();
+      return;
+    }
+    container.innerHTML = ai_renderDetail(item as unknown as AkashaQueryDetail);
+  },
+});

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -30,6 +30,7 @@ from plugins.akasha.core import (
     CoreConfig,
     EdgeUpdate,
     SourceMessage,
+    build_dense_message_index,
     turn_key,
     # Algorithm functions (aliased with _ prefix for internal convention)
     activation_edge_updates as _activation_edge_updates,
@@ -148,6 +149,7 @@ class AkashaMemoryEngine:
         self._fan: dict[str, int] = {}
         self._message_embeddings: dict[str, np.ndarray] = {}
         self._message_turn_keys: dict[str, str] = {}
+        self._message_index = build_dense_message_index({})
         self._load_graph_cache()
         self._ensure_idf_table()
         self.closeables: list[object] = [self._store, self._embedder]
@@ -517,6 +519,7 @@ class AkashaMemoryEngine:
                 snapshot.message_embeddings,
                 snapshot.message_turn_keys,
                 limit=max(self._akasha_config.dense_top_k, request.limit),
+                message_index=snapshot.message_index,
             )
             graph_seed_keys = _graph_seed_keys_from_snapshot(
                 query_vec,
@@ -647,6 +650,7 @@ class AkashaMemoryEngine:
             self._store.list_cached_embeddings(model=self._config.memory.embedding.model)
         )
         message_turn_keys = _load_message_turn_keys(self._session_db_path)
+        message_index = build_dense_message_index(message_embeddings)
         with self._graph_lock:
             self._nodes = nodes
             self._edges = edges
@@ -655,6 +659,7 @@ class AkashaMemoryEngine:
             self._fan = _fan_counts(edges)
             self._message_embeddings = message_embeddings
             self._message_turn_keys = message_turn_keys
+            self._message_index = message_index
 
     # 取查询使用的内存图快照。
     def _graph_snapshot(self) -> AkashaActivationSnapshot:
@@ -667,8 +672,11 @@ class AkashaMemoryEngine:
             self._fan = {}
             self._message_embeddings = {}
             self._message_turn_keys = {}
+            self._message_index = build_dense_message_index({})
             self._load_graph_cache()
         with self._graph_lock:
+            if not hasattr(self, "_message_index"):
+                self._message_index = build_dense_message_index(self._message_embeddings)
             return AkashaActivationSnapshot(
                 nodes=dict(self._nodes),
                 edges=dict(self._edges),
@@ -680,6 +688,7 @@ class AkashaMemoryEngine:
                 },
                 message_embeddings=dict(self._message_embeddings),
                 message_turn_keys=dict(self._message_turn_keys),
+                message_index=self._message_index,
             )
 
     # 把查询产生的状态更新同步进内存图。
@@ -719,6 +728,7 @@ class AkashaMemoryEngine:
         with self._graph_lock:
             self._message_embeddings[message.id] = np.array(embedding, dtype=np.float32)
             self._message_turn_keys[message.id] = turn_key_value
+            self._message_index = build_dense_message_index(self._message_embeddings)
 
     # 把新增或增强的边同步进内存图。
     def _apply_edge_updates(self, updates: list[EdgeUpdate]) -> None:
@@ -774,6 +784,7 @@ class AkashaMemoryEngine:
             for message_id in remove_ids:
                 _ = self._message_embeddings.pop(message_id, None)
                 _ = self._message_turn_keys.pop(message_id, None)
+            self._message_index = build_dense_message_index(self._message_embeddings)
 
     # 根据 message id 找到本轮 Akasha turn 节点。
     def _affected_turn_keys(self, message_ids: list[str]) -> set[str]:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -4,9 +4,10 @@ import json
 import hashlib
 import math
 import sqlite3
+import threading
 from collections.abc import Callable, Iterable
 from contextlib import closing
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -151,6 +152,14 @@ class AkashaMemoryEngine:
         )
         self._event_bus = event_publisher
         self._pending_by_session: dict[str, PendingActivation] = {}
+        self._graph_lock = threading.RLock()
+        self._nodes: dict[str, AkashaNode] = {}
+        self._edges: dict[tuple[str, str], float] = {}
+        self._edges_by_src: dict[str, dict[str, float]] = {}
+        self._fan: dict[str, int] = {}
+        self._message_embeddings: dict[str, np.ndarray] = {}
+        self._message_turn_keys: dict[str, str] = {}
+        self._load_graph_cache()
         self.closeables: list[object] = [self._store, self._embedder]
         self._wire_events()
 
@@ -405,12 +414,18 @@ class AkashaMemoryEngine:
     # 删除 Akasha sidecar 节点。
     def delete_item(self, item_id: str) -> bool:
         # 1. 只删除 sidecar 索引，不删除原始 messages。
-        return self._store.delete_item(item_id)
+        deleted = self._store.delete_item(item_id)
+        if deleted:
+            self._remove_cached_nodes([item_id])
+        return deleted
 
     # 批量删除 Akasha sidecar 节点。
     def delete_items_batch(self, ids: list[str]) -> int:
         # 1. 只删除 sidecar 索引，不删除原始 messages。
-        return self._store.delete_items_batch(ids)
+        deleted = self._store.delete_items_batch(ids)
+        if deleted:
+            self._remove_cached_nodes(ids)
+        return deleted
 
     # 查找相似 Akasha 节点。
     def find_similar_items_for_dashboard(
@@ -434,10 +449,8 @@ class AkashaMemoryEngine:
         request: MemoryQuery,
     ) -> "_AkashaRetrieval":
         # 1. 准备内存图和当前查询所在的预测 seq。
-        nodes = {node.key: node for node in self._store.list_nodes()}
-        edges = self._store.load_edges()
+        nodes, fan, edges_by_src, message_embeddings, message_turn_keys = self._graph_snapshot()
         seq = _current_query_seq(self._session_db_path, request.scope)
-        fan = _fan_counts(edges)
         source_db = (
             sqlite3.connect(str(self._session_db_path))
             if self._session_db_path.exists()
@@ -450,20 +463,20 @@ class AkashaMemoryEngine:
             dense_items = _dense_message_candidates(
                 query_vec,
                 nodes,
-                self._store,
-                self._config.memory.embedding.model,
-                source_cursor,
+                message_embeddings,
+                message_turn_keys,
                 limit=max(self._akasha_config.dense_top_k, request.limit),
             )
             activation_items, _, _ = _compute_candidates(
                 query,
                 query_vec,
                 nodes,
-                edges,
+                {},
                 seq,
                 config=self._akasha_config,
                 fan=fan,
                 source_cursor=source_cursor,
+                edges_by_src=edges_by_src,
                 soft_recall=False,
                 return_limit=self._akasha_config.activate_limit,
             )
@@ -475,11 +488,12 @@ class AkashaMemoryEngine:
                 query,
                 query_vec,
                 nodes,
-                edges,
+                {},
                 seq,
                 config=self._akasha_config,
                 fan=fan,
                 source_cursor=source_cursor,
+                edges_by_src=edges_by_src,
                 soft_recall=True,
                 return_limit=display_limit,
             )
@@ -490,6 +504,7 @@ class AkashaMemoryEngine:
         # 3. 查询阶段只更新旧节点状态，当前 turn 的边等 after-turn 再补。
         updates = _activation_updates(activation_items, nodes, seq)
         self._store.update_activation_batch(updates)
+        self._apply_activation_updates(updates)
         return _AkashaRetrieval(
             dense_items=dense_items,
             ripple_items=ripple_items,
@@ -533,6 +548,8 @@ class AkashaMemoryEngine:
                 embedding=embedding,
             )
             current_key = self._store.upsert_message_node(message, embedding)
+            self._refresh_cached_node(current_key)
+            self._refresh_cached_message(message, embedding, current_key)
 
         # 3. 用真实 current_key 建边，并记录激活诊断。
         pending = self._pending_by_session.pop(event.session_key, None)
@@ -562,6 +579,7 @@ class AkashaMemoryEngine:
                 edge_updates.append(EdgeUpdate(left.key, right.key, edge_strength, pending.seq))
                 edge_updates.append(EdgeUpdate(right.key, left.key, edge_strength, pending.seq))
         self._store.upsert_edges(edge_updates)
+        self._apply_edge_updates(edge_updates)
 
         # 3. 记录本轮激活明细，便于之后诊断。
         self._store.insert_activation_events([
@@ -580,6 +598,123 @@ class AkashaMemoryEngine:
             )
             for item in pending.items
         ])
+
+    # 启动时加载一次内存图。
+    def _load_graph_cache(self) -> None:
+        nodes = {node.key: node for node in self._store.list_nodes()}
+        edges = self._store.load_edges()
+        message_embeddings = dict(
+            self._store.list_cached_embeddings(model=self._config.memory.embedding.model)
+        )
+        message_turn_keys = _load_message_turn_keys(self._session_db_path)
+        with self._graph_lock:
+            self._nodes = nodes
+            self._edges = edges
+            self._edges_by_src = _edges_by_src(edges)
+            self._fan = _fan_counts(edges)
+            self._message_embeddings = message_embeddings
+            self._message_turn_keys = message_turn_keys
+
+    # 取查询使用的内存图快照。
+    def _graph_snapshot(
+        self,
+    ) -> tuple[
+        dict[str, AkashaNode],
+        dict[str, int],
+        dict[str, dict[str, float]],
+        dict[str, np.ndarray],
+        dict[str, str],
+    ]:
+        if not hasattr(self, "_graph_lock"):
+            self._graph_lock = threading.RLock()
+            self._nodes = {}
+            self._edges = {}
+            self._edges_by_src = {}
+            self._fan = {}
+            self._message_embeddings = {}
+            self._message_turn_keys = {}
+            self._load_graph_cache()
+        with self._graph_lock:
+            return (
+                dict(self._nodes),
+                dict(self._fan),
+                self._edges_by_src,
+                dict(self._message_embeddings),
+                dict(self._message_turn_keys),
+            )
+
+    # 把查询产生的状态更新同步进内存图。
+    def _apply_activation_updates(self, updates: list[ActivationUpdate]) -> None:
+        if not updates:
+            return
+        with self._graph_lock:
+            for item in updates:
+                node = self._nodes.get(item.key)
+                if node is None:
+                    continue
+                self._nodes[item.key] = replace(
+                    node,
+                    strength=item.strength,
+                    resource=item.resource,
+                    recall_count=item.recall_count,
+                    last_activated_seq=item.seq,
+                    last_strength_seq=item.seq,
+                    last_resource_seq=item.seq,
+                )
+
+    # 把新写入或合并的节点同步进内存图。
+    def _refresh_cached_node(self, key: str) -> None:
+        node = self._store.get_node(key)
+        if node is None:
+            return
+        with self._graph_lock:
+            self._nodes[key] = node
+
+    # 把 message-level dense 缓存同步进内存图。
+    def _refresh_cached_message(
+        self,
+        message: SourceMessage,
+        embedding: list[float],
+        turn_key_value: str,
+    ) -> None:
+        with self._graph_lock:
+            self._message_embeddings[message.id] = np.array(embedding, dtype=np.float32)
+            self._message_turn_keys[message.id] = turn_key_value
+
+    # 把新增或增强的边同步进内存图。
+    def _apply_edge_updates(self, updates: list[EdgeUpdate]) -> None:
+        if not updates:
+            return
+        with self._graph_lock:
+            for item in updates:
+                if item.src_key == item.dst_key:
+                    continue
+                edge_key = (item.src_key, item.dst_key)
+                old = self._edges.get(edge_key)
+                if old is None:
+                    weight = 0.12 * item.strength
+                else:
+                    decayed = old * 0.9995
+                    weight = decayed + 0.12 * item.strength * max(0.0, 1.0 - decayed / 2.0)
+                self._edges[edge_key] = weight
+                self._edges_by_src.setdefault(item.src_key, {})[item.dst_key] = weight
+            self._fan = _fan_counts(self._edges)
+
+    # 删除 dashboard 移除的节点和相关边。
+    def _remove_cached_nodes(self, ids: list[str]) -> None:
+        remove_ids = set(ids)
+        if not remove_ids:
+            return
+        with self._graph_lock:
+            for item_id in remove_ids:
+                _ = self._nodes.pop(item_id, None)
+            self._edges = {
+                key: weight
+                for key, weight in self._edges.items()
+                if key[0] not in remove_ids and key[1] not in remove_ids
+            }
+            self._edges_by_src = _edges_by_src(self._edges)
+            self._fan = _fan_counts(self._edges)
 
     # 把 turn key 列表转成可注入 card。
     def _cards_from_keys(
@@ -763,6 +898,13 @@ def _fan_counts(edges: dict[tuple[str, str], float]) -> dict[str, int]:
     return fan
 
 
+def _edges_by_src(edges: dict[tuple[str, str], float]) -> dict[str, dict[str, float]]:
+    grouped: dict[str, dict[str, float]] = {}
+    for (src, dst), weight in edges.items():
+        grouped.setdefault(src, {})[dst] = weight
+    return grouped
+
+
 # 计算 query 对所有节点的 dense 分数。
 def _dense_scores(
     query_vec: np.ndarray,
@@ -807,21 +949,19 @@ def _dense_candidates(
 def _dense_message_candidates(
     query_vec: np.ndarray,
     nodes: dict[str, AkashaNode],
-    store: AkashaStore,
-    model: str,
-    source_cursor: sqlite3.Cursor | None,
+    message_embeddings: dict[str, np.ndarray],
+    message_turn_keys: dict[str, str],
     *,
     limit: int,
 ) -> list[AkashaCandidate]:
     # 1. Dense 展示贴合原始 CLI：先命中 message，再折回 turn key。
-    rows = store.list_cached_embeddings(model=model)
-    if not rows or source_cursor is None:
+    if not message_embeddings:
         return _dense_candidates(query_vec, nodes, limit=limit)
 
     # 2. 对缓存向量做余弦排序，过滤掉尚未 replay 成节点的消息。
     query_norm = _normalize(query_vec)
     scored: list[tuple[str, float]] = []
-    for message_id, embedding in rows:
+    for message_id, embedding in message_embeddings.items():
         if embedding.size != query_norm.size:
             continue
         score = float(np.dot(_normalize(embedding), query_norm))
@@ -831,7 +971,7 @@ def _dense_message_candidates(
     candidates: list[AkashaCandidate] = []
     seen: set[str] = set()
     for message_id, score in sorted(scored, key=lambda item: item[1], reverse=True):
-        key = _message_id_to_turn_key(source_cursor, message_id)
+        key = message_turn_keys.get(message_id)
         if key is None or key not in nodes or key in seen:
             continue
         seen.add(key)
@@ -1314,21 +1454,17 @@ def _bounded_add(value: float, delta: float, cap: float) -> float:
     return value + delta * max(0.0, 1.0 - value / cap)
 
 
-# 从 message id 映射到原始 turn key。
-def _message_id_to_turn_key(
-    cursor: sqlite3.Cursor,
-    message_id: str,
-) -> str | None:
-    # 1. Dense 命中的是 message，展示和去重都回到 user turn。
-    _ = cursor.execute(
-        "SELECT session_key, seq, role FROM messages WHERE id = ? LIMIT 1",
-        (message_id,),
-    )
-    row = cursor.fetchone()
-    if row is None:
-        return None
-    _, _, key = turn_key(str(row[0]), int(row[1]), str(row[2] or ""))
-    return key
+# 读取 message 到 turn key 的映射。
+def _load_message_turn_keys(session_db_path: Path) -> dict[str, str]:
+    if not session_db_path.exists():
+        return {}
+    with closing(sqlite3.connect(str(session_db_path))) as db:
+        rows = db.execute("SELECT id, session_key, seq, role FROM messages").fetchall()
+    result: dict[str, str] = {}
+    for message_id, session_key, seq, role in rows:
+        _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
+        result[str(message_id)] = key
+    return result
 
 
 # 把 query 切成 SQLite FTS 可用的搜索词。
@@ -1688,4 +1824,3 @@ def _candidate_signals(item: AkashaCandidate) -> dict[str, object]:
         "path_value": item.path_value,
         "suppressed": item.suppressed,
     }
-

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 
 import json
 import hashlib
-import math
 import sqlite3
 import threading
-import time
 from contextlib import closing
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -25,6 +23,7 @@ from plugins.akasha.core import (
     # Types shared with core
     ActivationEventRow,
     ActivationTrace,
+    AkashaActivationSnapshot,
     ActivationUpdate,
     AkashaCandidate,
     AkashaNode,
@@ -33,11 +32,15 @@ from plugins.akasha.core import (
     SourceMessage,
     turn_key,
     # Algorithm functions (aliased with _ prefix for internal convention)
+    activation_edge_updates as _activation_edge_updates,
     activation_updates as _activation_updates,
     compute_candidates as _core_compute_candidates,
+    compute_candidates_from_snapshot as _core_compute_candidates_from_snapshot,
     dense_message_candidates as _dense_message_candidates,
     edges_by_src as _edges_by_src,
+    effective_edge_weight as _effective_edge_weight,
     fan_counts as _fan_counts,
+    graph_seed_keys_from_snapshot as _graph_seed_keys_from_snapshot,
     parse_turn_key as _parse_turn_key,
     bounded_add as _bounded_add,
 )
@@ -239,10 +242,19 @@ class AkashaMemoryEngine:
             return MemoryQueryResult(trace={"engine": self.DESCRIPTOR.name, "hit_count": 0})
 
         # 3. 检索旧 turn 图，并在 context 入口记录本轮激活。
+        now_ts = _query_timestamp_unix(request)
+        if now_ts is None:
+            return MemoryQueryResult(
+                trace={
+                    "engine": self.DESCRIPTOR.name,
+                    "intent": request.intent,
+                    "error": "missing_query_timestamp",
+                }
+            )
         query_vec = np.array(await self._embedder.embed(query_text), dtype=np.float32)
-        result = self._retrieve(query_text, query_vec, request)
+        result = self._retrieve(query_text, query_vec, request, now_ts=now_ts)
         if request.intent in {"context", "answer"}:
-            self._remember_pending_activation(request, result.activation_items)
+            self._remember_pending_activation(request, result.activation_items, now_ts=now_ts)
 
         # 4. context 注入按 Akasha 配置展示 topK；工具查询继续尊重调用方 limit。
         dense_limit = self._akasha_config.dense_top_k
@@ -266,7 +278,7 @@ class AkashaMemoryEngine:
             skip_pairs=dense_pairs,
         )
         text_block = (
-            self._format_context_block(dense_cards, ripple_cards)
+            self._format_context_block(dense_cards, ripple_cards, now_ts=now_ts)
             if request.intent == "context"
             else ""
         )
@@ -484,11 +496,12 @@ class AkashaMemoryEngine:
         query: str,
         query_vec: np.ndarray,
         request: MemoryQuery,
+        *,
+        now_ts: float,
     ) -> "_AkashaRetrieval":
         # 1. 准备内存图和当前查询所在的预测 seq。
-        nodes, fan, edges_by_src, message_embeddings, message_turn_keys = self._graph_snapshot()
+        snapshot = self._graph_snapshot()
         seq = _current_query_seq(self._session_db_path, request.scope)
-        now_ts = time.time()
         source_db = (
             sqlite3.connect(str(self._session_db_path))
             if self._session_db_path.exists()
@@ -500,39 +513,38 @@ class AkashaMemoryEngine:
             source_cursor = source_db.cursor() if source_db is not None else None
             dense_items = _dense_message_candidates(
                 query_vec,
-                nodes,
-                message_embeddings,
-                message_turn_keys,
+                snapshot.nodes,
+                snapshot.message_embeddings,
+                snapshot.message_turn_keys,
                 limit=max(self._akasha_config.dense_top_k, request.limit),
             )
-            graph_seed_keys = [item.key for item in dense_items[:self._akasha_config.dense_top_k]]
-            activation_items, _, _ = _compute_candidates(
+            graph_seed_keys = _graph_seed_keys_from_snapshot(
+                query_vec,
+                snapshot,
+                limit=self._akasha_config.dense_top_k,
+            )
+            activation_items, _, _ = _compute_candidates_from_snapshot(
                 query,
                 query_vec,
-                nodes,
-                {},
                 now_ts,
+                snapshot=snapshot,
                 config=self._akasha_config,
-                fan=fan,
                 source_cursor=source_cursor,
-                edges_by_src=edges_by_src,
                 soft_recall=False,
                 return_limit=self._akasha_config.activate_limit,
+                graph_seed_keys=graph_seed_keys,
             )
             display_limit = max(
                 24,
                 max(self._akasha_config.ripple_top_k, request.limit) * 3,
             )
-            ripple_items, _, trace = _compute_candidates(
+            ripple_items, _, trace = _compute_candidates_from_snapshot(
                 query,
                 query_vec,
-                nodes,
-                {},
                 now_ts,
+                snapshot=snapshot,
                 config=self._akasha_config,
-                fan=fan,
                 source_cursor=source_cursor,
-                edges_by_src=edges_by_src,
                 soft_recall=True,
                 return_limit=display_limit,
                 graph_seed_keys=graph_seed_keys,
@@ -542,7 +554,7 @@ class AkashaMemoryEngine:
                 source_db.close()
 
         # 3. 查询阶段只更新旧节点状态，当前 turn 的边等 after-turn 再补。
-        updates = _activation_updates(activation_items, nodes, now_ts)
+        updates = _activation_updates(activation_items, snapshot.nodes, now_ts)
         self._store.update_activation_batch(updates)
         self._apply_activation_updates(updates)
         return _AkashaRetrieval(
@@ -558,6 +570,8 @@ class AkashaMemoryEngine:
         self,
         request: MemoryQuery,
         items: list[AkashaCandidate],
+        *,
+        now_ts: float,
     ) -> None:
         # 1. 没有 session_key 时仍可检索，但不建当前 turn 的共激活边。
         if not request.scope.session_key or not items:
@@ -566,7 +580,7 @@ class AkashaMemoryEngine:
         self._pending_by_session[request.scope.session_key] = PendingActivation(
             query_id=f"{request.scope.session_key}:{seq}",
             seq=seq,
-            ts=time.time(),
+            ts=now_ts,
             items=list(items),
         )
 
@@ -603,26 +617,11 @@ class AkashaMemoryEngine:
         current_key: str,
         pending: PendingActivation,
     ) -> None:
-        # 1. 当前输入和被激活旧节点互连，形成后续桥接能力。
-        key_to_score = {item.key: item.score for item in pending.items}
-        edge_updates: list[EdgeUpdate] = []
-        for item in pending.items:
-            edge_strength = key_to_score.get(item.key, 1.0)
-            edge_updates.append(EdgeUpdate(current_key, item.key, edge_strength, pending.ts))
-            edge_updates.append(EdgeUpdate(item.key, current_key, edge_strength, pending.ts))
-
-        # 2. 同轮共同激活的旧节点互连，保持 cross CLI 的共激活语义。
-        for left_index, left in enumerate(pending.items):
-            for right in pending.items[left_index + 1:]:
-                edge_strength = math.sqrt(
-                    key_to_score.get(left.key, 1.0) * key_to_score.get(right.key, 1.0)
-                )
-                edge_updates.append(EdgeUpdate(left.key, right.key, edge_strength, pending.ts))
-                edge_updates.append(EdgeUpdate(right.key, left.key, edge_strength, pending.ts))
+        edge_updates = _activation_edge_updates(current_key, pending.items, pending.ts)
         self._store.upsert_edges(edge_updates)
         self._apply_edge_updates(edge_updates)
 
-        # 3. 记录本轮激活明细，便于之后诊断。
+        # 2. 记录本轮激活明细，便于之后诊断。
         self._store.insert_activation_events([
             ActivationEventRow(
                 seq=pending.seq,
@@ -643,7 +642,7 @@ class AkashaMemoryEngine:
     # 启动时加载一次内存图。
     def _load_graph_cache(self) -> None:
         nodes = {node.key: node for node in self._store.list_nodes()}
-        edges = self._store.load_edges()
+        edges, edges_meta = self._store.load_edges_with_meta()
         message_embeddings = dict(
             self._store.list_cached_embeddings(model=self._config.memory.embedding.model)
         )
@@ -651,37 +650,36 @@ class AkashaMemoryEngine:
         with self._graph_lock:
             self._nodes = nodes
             self._edges = edges
+            self._edges_meta = edges_meta
             self._edges_by_src = _edges_by_src(edges)
             self._fan = _fan_counts(edges)
             self._message_embeddings = message_embeddings
             self._message_turn_keys = message_turn_keys
 
     # 取查询使用的内存图快照。
-    def _graph_snapshot(
-        self,
-    ) -> tuple[
-        dict[str, AkashaNode],
-        dict[str, int],
-        dict[str, dict[str, float]],
-        dict[str, np.ndarray],
-        dict[str, str],
-    ]:
+    def _graph_snapshot(self) -> AkashaActivationSnapshot:
         if not hasattr(self, "_graph_lock"):
             self._graph_lock = threading.RLock()
             self._nodes = {}
             self._edges = {}
+            self._edges_meta = {}
             self._edges_by_src = {}
             self._fan = {}
             self._message_embeddings = {}
             self._message_turn_keys = {}
             self._load_graph_cache()
         with self._graph_lock:
-            return (
-                dict(self._nodes),
-                dict(self._fan),
-                self._edges_by_src,
-                dict(self._message_embeddings),
-                dict(self._message_turn_keys),
+            return AkashaActivationSnapshot(
+                nodes=dict(self._nodes),
+                edges=dict(self._edges),
+                edges_meta=dict(self._edges_meta),
+                fan=dict(self._fan),
+                edges_by_src={
+                    key: dict(value)
+                    for key, value in self._edges_by_src.items()
+                },
+                message_embeddings=dict(self._message_embeddings),
+                message_turn_keys=dict(self._message_turn_keys),
             )
 
     # 把查询产生的状态更新同步进内存图。
@@ -735,9 +733,14 @@ class AkashaMemoryEngine:
                 if old is None:
                     weight = 0.12 * item.strength
                 else:
-                    decayed = old * 0.9995
+                    decayed = _effective_edge_weight(
+                        old,
+                        self._edges_meta.get(edge_key, 0.0),
+                        item.ts,
+                    )
                     weight = _bounded_add(decayed, 0.12 * item.strength, 2.0)
                 self._edges[edge_key] = weight
+                self._edges_meta[edge_key] = item.ts
                 self._edges_by_src.setdefault(item.src_key, {})[item.dst_key] = weight
             self._fan = _fan_counts(self._edges)
 
@@ -752,6 +755,11 @@ class AkashaMemoryEngine:
             self._edges = {
                 key: weight
                 for key, weight in self._edges.items()
+                if key[0] not in remove_ids and key[1] not in remove_ids
+            }
+            self._edges_meta = {
+                key: value
+                for key, value in self._edges_meta.items()
                 if key[0] not in remove_ids and key[1] not in remove_ids
             }
             self._edges_by_src = _edges_by_src(self._edges)
@@ -908,14 +916,13 @@ class AkashaMemoryEngine:
         store = getattr(self, "_store", None)
         if store is None:
             return
-        from datetime import datetime, timezone
         store.insert_query_log(
             query_id=_query_log_id(request.scope.session_key or "", seq, request.intent, request.text),
             session_key=request.scope.session_key or "",
             seq=seq,
             query_text=request.text.strip(),
             intent=request.intent,
-            ts=datetime.now(timezone.utc).isoformat(),
+            ts=datetime.fromtimestamp(_query_timestamp_unix(request) or 0.0, timezone.utc).isoformat(),
             seed_count=result.trace.seed_count,
             pool_count=result.trace.pool_count,
             activated_count=len(result.activation_items),
@@ -935,11 +942,14 @@ class AkashaMemoryEngine:
         self,
         dense_cards: list[AkashaCard],
         ripple_cards: list[AkashaCard],
+        *,
+        now_ts: float,
     ) -> str:
         # 1. Dense 块优先展示重叠项，Ripple 块只展示 ripple-only。
         parts: list[str] = []
         if dense_cards or ripple_cards:
-            parts.append(f"# Akasha memory now={datetime.now().astimezone().strftime('%Y-%m-%d')}")
+            date_label = datetime.fromtimestamp(now_ts, timezone.utc).astimezone().strftime("%Y-%m-%d")
+            parts.append(f"# Akasha memory now={date_label}")
         if dense_cards:
             parts.append(_format_cards("## 左脑记忆：精确回忆", _sort_cards_by_time(dense_cards)))
         if ripple_cards:
@@ -987,6 +997,7 @@ def _compute_candidates(
     fan: dict[str, int],
     source_cursor: sqlite3.Cursor | None = None,
     edges_by_src: dict[str, dict[str, float]] | None = None,
+    edges_meta: dict[tuple[str, str], float] | None = None,
     soft_recall: bool = False,
     return_limit: int | None = None,
     graph_seed_keys: list[str] | None = None,
@@ -1001,6 +1012,32 @@ def _compute_candidates(
         fan=fan,
         source_cursor=source_cursor,
         edges_by_src=edges_by_src,
+        edges_meta=edges_meta,
+        soft_recall=soft_recall,
+        return_limit=return_limit,
+        graph_seed_keys=graph_seed_keys,
+    )
+
+
+def _compute_candidates_from_snapshot(
+    query: str,
+    query_vec: np.ndarray,
+    now_ts: float,
+    *,
+    snapshot: AkashaActivationSnapshot,
+    config: AkashaConfig,
+    source_cursor: sqlite3.Cursor | None = None,
+    soft_recall: bool = False,
+    return_limit: int | None = None,
+    graph_seed_keys: list[str] | None = None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate], ActivationTrace]:
+    return _core_compute_candidates_from_snapshot(
+        query,
+        query_vec,
+        snapshot,
+        now_ts,
+        config=_core_config(config),
+        source_cursor=source_cursor,
         soft_recall=soft_recall,
         return_limit=return_limit,
         graph_seed_keys=graph_seed_keys,
@@ -1008,6 +1045,12 @@ def _compute_candidates(
 
 
 # ── sessions.db 特有辅助函数 ──────────────────────────────────────────
+
+
+def _query_timestamp_unix(request: MemoryQuery) -> float | None:
+    if request.timestamp is None:
+        return None
+    return float(request.timestamp.timestamp())
 
 
 # 读取 message 到 turn key 的映射。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -74,6 +74,7 @@ class AkashaCard:
     source_ref: str
     user_message: str
     assistant_preview: str
+    happened_at: str
     score: float
     lane: str
     signals: dict[str, object]
@@ -937,10 +938,12 @@ class AkashaMemoryEngine:
     ) -> str:
         # 1. Dense 块优先展示重叠项，Ripple 块只展示 ripple-only。
         parts: list[str] = []
+        if dense_cards or ripple_cards:
+            parts.append(f"# Akasha memory now={datetime.now().astimezone().strftime('%Y-%m-%d')}")
         if dense_cards:
-            parts.append(_format_cards("## 左脑记忆：精确回忆", dense_cards))
+            parts.append(_format_cards("## 左脑记忆：精确回忆", _sort_cards_by_time(dense_cards)))
         if ripple_cards:
-            parts.append(_format_cards("## 右脑联想：潜意识第一反应", ripple_cards))
+            parts.append(_format_cards("## 右脑联想：潜意识第一反应", _sort_cards_by_time(ripple_cards)))
 
         # 2. 应用字符预算，避免历史消息过长撑爆上下文。
         text = "\n\n".join(part for part in parts if part.strip())
@@ -978,7 +981,7 @@ def _compute_candidates(
     query_vec: np.ndarray,
     nodes: dict[str, AkashaNode],
     edges: dict[tuple[str, str], float],
-    seq: int,
+    now_ts: float,
     *,
     config: AkashaConfig,
     fan: dict[str, int],
@@ -993,7 +996,7 @@ def _compute_candidates(
         query_vec,
         nodes,
         edges,
-        seq,
+        now_ts,
         config=_core_config(config),
         fan=fan,
         source_cursor=source_cursor,
@@ -1114,7 +1117,7 @@ def _load_turn_card(
         db.row_factory = sqlite3.Row
         user_row = db.execute(
             """
-            SELECT id, content
+            SELECT id, content, ts
             FROM messages
             WHERE session_key = ? AND seq = ? AND role = 'user'
             """,
@@ -1122,7 +1125,7 @@ def _load_turn_card(
         ).fetchone()
         assistant_row = db.execute(
             """
-            SELECT id, content
+            SELECT id, content, ts
             FROM messages
             WHERE session_key = ? AND seq = ? AND role = 'assistant'
             """,
@@ -1137,11 +1140,17 @@ def _load_turn_card(
     ]
     assistant_text = str(assistant_row["content"] or "") if assistant_row is not None else ""
     user_text = str(user_row["content"] or "") if user_row is not None else ""
+    happened_at = (
+        str(user_row["ts"] or "")
+        if user_row is not None
+        else str(assistant_row["ts"] or "")
+    )
     return AkashaCard(
         key=key,
         source_ref=json.dumps(source_ids, ensure_ascii=False),
         user_message=user_text,
         assistant_preview=_clip_assistant(assistant_text, assistant_preview_chars),
+        happened_at=happened_at,
         score=score,
         lane=lane,
         signals=signals,
@@ -1192,6 +1201,17 @@ def _card_dedupe_key(card: AkashaCard) -> tuple[str, str]:
     return _normalize_card_text(card.user_message), _normalize_card_text(card.assistant_preview)
 
 
+def _card_ts(card: AkashaCard) -> float:
+    try:
+        return datetime.fromisoformat(card.happened_at.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _sort_cards_by_time(cards: list[AkashaCard]) -> list[AkashaCard]:
+    return sorted(cards, key=_card_ts, reverse=True)
+
+
 # 生成检索日志 ID，避免同一轮 context 和 recall_memory 互相覆盖。
 def _query_log_id(session_key: str, seq: int, intent: str, query_text: str) -> str:
     # 1. 同一轮可能有预检索和显式 recall_memory，多条日志都要保留。
@@ -1209,11 +1229,20 @@ def _format_cards(title: str, cards: list[AkashaCard]) -> str:
             _normalize_card_text(card.assistant_preview),
             ensure_ascii=False,
         )
+        happened_at = _format_card_time(card.happened_at)
+        time_part = f" t={happened_at}" if happened_at else ""
         lines.append(
-            f"- user={user_text} assistant={assistant_text} "
-            f"score={card.score:.4f} source_ref={card.source_ref}"
+            f"- user={user_text} assistant={assistant_text}"
+            f"{time_part} source_ref={card.source_ref}"
         )
     return "\n".join(lines)
+
+
+def _format_card_time(value: str) -> str:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).strftime("%m-%d")
+    except ValueError:
+        return ""
 
 
 # 把 card 转成 MemoryRecord。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -143,11 +143,31 @@ class AkashaMemoryEngine:
         self._message_embeddings: dict[str, np.ndarray] = {}
         self._message_turn_keys: dict[str, str] = {}
         self._load_graph_cache()
-        # 加载 IDF 表给 FTS 过滤用（表不存在时退化到无过滤）
-        from plugins.akasha.core import load_idf_from_db, set_idf_table
-        set_idf_table(load_idf_from_db(self._store._db))
+        self._ensure_idf_table()
         self.closeables: list[object] = [self._store, self._embedder]
         self._wire_events()
+
+    # 启动时自动检查 / 建 FTS IDF 表。缺失或漂移过大时重建。
+    def _ensure_idf_table(self) -> None:
+        from plugins.akasha.core import (
+            build_idf_table, idf_table_is_stale, load_idf_from_db, set_idf_table,
+        )
+        sessions_db = str(self._session_db_path)
+        conn = self._store._db
+        try:
+            stale = idf_table_is_stale(sessions_db, conn)
+        except Exception:
+            stale = True
+        if stale and self._session_db_path.exists():
+            try:
+                idf = build_idf_table(sessions_db, conn)
+                print(f"[akasha] built FTS IDF table: {len(idf)} tokens")
+            except Exception as exc:  # noqa: BLE001
+                print(f"[akasha] IDF build failed, falling back to no-filter: {exc}")
+                set_idf_table({})
+                return
+        idf = load_idf_from_db(conn)
+        set_idf_table(idf)
 
     # 创建 Akasha sidecar 数据库。
     @classmethod

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -143,6 +143,9 @@ class AkashaMemoryEngine:
         self._message_embeddings: dict[str, np.ndarray] = {}
         self._message_turn_keys: dict[str, str] = {}
         self._load_graph_cache()
+        # 加载 IDF 表给 FTS 过滤用（表不存在时退化到无过滤）
+        from plugins.akasha.core import load_idf_from_db, set_idf_table
+        set_idf_table(load_idf_from_db(self._store._db))
         self.closeables: list[object] = [self._store, self._embedder]
         self._wire_events()
 

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -335,6 +335,34 @@ class AkashaMemoryEngine:
         # 1. 引用强化暂不改变 Akasha 图，图状态由真实 query 激活驱动。
         return None
 
+    # 撤销由指定消息生成的 Akasha 状态。
+    def undo_by_message_sources(
+        self,
+        message_ids: list[str],
+        *,
+        dry_run: bool = False,
+    ) -> dict[str, object]:
+        clean_ids = [str(item).strip() for item in message_ids if str(item).strip()]
+        if not clean_ids:
+            return {"affected_ids": [], "restored_ids": [], "rollback_source_ids": []}
+        affected_keys = self._affected_turn_keys(clean_ids)
+        rollback_source_ids = list(clean_ids) if affected_keys else []
+        if not dry_run and affected_keys:
+            keys = sorted(affected_keys)
+            turns = [
+                parsed for key in keys if (parsed := _parse_turn_key(key)) is not None
+            ]
+            _ = self._store.delete_items_batch(keys)
+            self._store.delete_query_state_for_turns(turns)
+            _ = self._store.delete_cached_embeddings(clean_ids)
+            self._remove_cached_nodes(keys)
+            self._remove_cached_messages(clean_ids)
+        return {
+            "affected_ids": sorted(affected_keys),
+            "restored_ids": [],
+            "rollback_source_ids": sorted(rollback_source_ids),
+        }
+
     # 返回引擎描述。
     def describe(self) -> MemoryEngineDescriptor:
         # 1. runtime 和 dashboard 都通过 descriptor 识别当前 engine。
@@ -715,6 +743,37 @@ class AkashaMemoryEngine:
             }
             self._edges_by_src = _edges_by_src(self._edges)
             self._fan = _fan_counts(self._edges)
+
+    # 删除 undo 移除的 message-level dense 缓存。
+    def _remove_cached_messages(self, message_ids: list[str]) -> None:
+        remove_ids = {str(item).strip() for item in message_ids if str(item).strip()}
+        if not remove_ids:
+            return
+        with self._graph_lock:
+            for message_id in remove_ids:
+                _ = self._message_embeddings.pop(message_id, None)
+                _ = self._message_turn_keys.pop(message_id, None)
+
+    # 根据 message id 找到本轮 Akasha turn 节点。
+    def _affected_turn_keys(self, message_ids: list[str]) -> set[str]:
+        affected: set[str] = set()
+        message_id_set = set(message_ids)
+        with self._graph_lock:
+            cached_turn_keys = dict(self._message_turn_keys)
+            existing_keys = set(self._nodes)
+        for message_id in message_ids:
+            cached = cached_turn_keys.get(message_id)
+            if cached and cached in existing_keys:
+                affected.add(cached)
+                continue
+            parsed = _parse_message_id(message_id)
+            if parsed is None:
+                continue
+            session_key, seq = parsed
+            for candidate in _possible_turn_keys(session_key, seq, message_id_set):
+                if candidate in existing_keys:
+                    affected.add(candidate)
+        return affected
 
     # 把 turn key 列表转成可注入 card。
     def _cards_from_keys(
@@ -1650,6 +1709,28 @@ def _parse_turn_key(key: str) -> tuple[str, int] | None:
         return left, int(right)
     except ValueError:
         return None
+
+
+def _parse_message_id(message_id: str) -> tuple[str, int] | None:
+    return _parse_turn_key(message_id)
+
+
+def _possible_turn_keys(
+    session_key: str,
+    seq: int,
+    deleted_message_ids: set[str],
+) -> tuple[str, ...]:
+    current_id = f"{session_key}:{seq}"
+    previous_id = f"{session_key}:{seq - 1}" if seq > 0 else ""
+    next_id = f"{session_key}:{seq + 1}"
+    if next_id in deleted_message_ids:
+        return (current_id,)
+    if previous_id in deleted_message_ids:
+        return (previous_id,)
+    keys = [current_id]
+    if seq > 0:
+        keys.append(previous_id)
+    return tuple(key for key in keys if key)
 
 
 # 截断 assistant 预览。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1,3 +1,10 @@
+"""
+akasha 记忆引擎 — 生产运行时层
+
+依赖 agent-framework 的基础设施（Config、Embedder、EventBus 等）。
+纯算法逻辑委托到 akasha.core。
+"""
+
 from __future__ import annotations
 
 import json
@@ -5,7 +12,6 @@ import hashlib
 import math
 import sqlite3
 import threading
-from collections.abc import Callable, Iterable
 from contextlib import closing
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -14,6 +20,26 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
+from plugins.akasha.core import (
+    # Types shared with core
+    ActivationEventRow,
+    ActivationTrace,
+    ActivationUpdate,
+    AkashaCandidate,
+    AkashaNode,
+    CoreConfig,
+    EdgeUpdate,
+    SourceMessage,
+    turn_key,
+    # Algorithm functions (aliased with _ prefix for internal convention)
+    activation_updates as _activation_updates,
+    compute_candidates as _core_compute_candidates,
+    dense_message_candidates as _dense_message_candidates,
+    edges_by_src as _edges_by_src,
+    fan_counts as _fan_counts,
+    parse_turn_key as _parse_turn_key,
+    bounded_add as _bounded_add,
+)
 from agent.config_models import Config
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import (
@@ -34,54 +60,11 @@ from core.memory.engine import (
 )
 from memory2.embedder import Embedder
 from plugins.akasha.config import AkashaConfig, resolve_akasha_db_path
-from plugins.akasha.store import (
-    ActivationEventRow,
-    ActivationUpdate,
-    AkashaNode,
-    AkashaStore,
-    EdgeUpdate,
-    SourceMessage,
-    turn_key,
-)
+from plugins.akasha.store import AkashaStore
 
 if TYPE_CHECKING:
     from bus.event_bus import EventBus
     from core.net.http import SharedHttpResources
-
-
-_LONG_DECAY_TAU = 2200.0
-_RESOURCE_RECOVER_TAU = 14.0
-_RESOURCE_USE_RATE = 0.35
-_STRENGTH_LR = 0.18
-_STRENGTH_CAP = 3.0
-_ASSISTANT_ONLY_PENALTY = 0.12
-_FAN_PENALTY_POWER = 0.10
-_EXPANDED_DIRECT_FLOOR = 0.62
-
-
-@dataclass(frozen=True)
-class AkashaCandidate:
-    key: str
-    source: str
-    ripple: float
-    direct: float
-    state: float
-    edge: float
-    long: float
-    resource: float
-    fan: int
-    score: float
-    suppressed: str = ""
-    path_type: str = "direct"
-    seed_key: str = ""
-    bridge_key: str = ""
-    path_value: float = 0.0
-
-
-@dataclass(frozen=True)
-class ActivationTrace:
-    seed_count: int
-    pool_count: int
 
 
 @dataclass(frozen=True)
@@ -495,6 +478,7 @@ class AkashaMemoryEngine:
                 message_turn_keys,
                 limit=max(self._akasha_config.dense_top_k, request.limit),
             )
+            graph_seed_keys = [item.key for item in dense_items[:self._akasha_config.dense_top_k]]
             activation_items, _, _ = _compute_candidates(
                 query,
                 query_vec,
@@ -524,6 +508,7 @@ class AkashaMemoryEngine:
                 edges_by_src=edges_by_src,
                 soft_recall=True,
                 return_limit=display_limit,
+                graph_seed_keys=graph_seed_keys,
             )
         finally:
             if source_db is not None:
@@ -723,7 +708,7 @@ class AkashaMemoryEngine:
                     weight = 0.12 * item.strength
                 else:
                     decayed = old * 0.9995
-                    weight = decayed + 0.12 * item.strength * max(0.0, 1.0 - decayed / 2.0)
+                    weight = _bounded_add(decayed, 0.12 * item.strength, 2.0)
                 self._edges[edge_key] = weight
                 self._edges_by_src.setdefault(item.src_key, {})[item.dst_key] = weight
             self._fan = _fan_counts(self._edges)
@@ -947,113 +932,20 @@ class _AkashaRetrieval:
     seq: int
 
 
-# 计算节点扇出。
-def _fan_counts(edges: dict[tuple[str, str], float]) -> dict[str, int]:
-    # 1. 边两端都计入 fan，和 cross CLI 保持一致。
-    fan: dict[str, int] = {}
-    for src, dst in edges:
-        fan[src] = fan.get(src, 0) + 1
-        fan[dst] = fan.get(dst, 0) + 1
-    return fan
+def _core_config(config: AkashaConfig) -> CoreConfig:
+    return CoreConfig(
+        dense_top_k=config.dense_top_k,
+        dense_seed_threshold=config.dense_seed_threshold,
+        activation_threshold=config.activation_threshold,
+        cross_boost=config.cross_boost,
+        nearby_time_seconds=config.nearby_time_seconds,
+        nearby_dense_threshold=config.nearby_dense_threshold,
+        soft_recall_threshold=config.soft_recall_threshold,
+        soft_recall_direct_floor=config.soft_recall_direct_floor,
+        activate_limit=config.activate_limit,
+    )
 
 
-def _edges_by_src(edges: dict[tuple[str, str], float]) -> dict[str, dict[str, float]]:
-    grouped: dict[str, dict[str, float]] = {}
-    for (src, dst), weight in edges.items():
-        grouped.setdefault(src, {})[dst] = weight
-    return grouped
-
-
-# 计算 query 对所有节点的 dense 分数。
-def _dense_scores(
-    query_vec: np.ndarray,
-    nodes: dict[str, AkashaNode],
-) -> dict[str, float]:
-    # 1. sidecar 节点 embedding 已归一化，点积即余弦相似度。
-    if not nodes:
-        return {}
-    keys = list(nodes.keys())
-    matrix = np.vstack([nodes[key].embedding for key in keys])
-    scores = np.dot(matrix, _normalize(query_vec))
-    return {key: float(score) for key, score in zip(keys, scores, strict=False)}
-
-
-# 取 dense top 候选。
-def _dense_candidates(
-    query_vec: np.ndarray,
-    nodes: dict[str, AkashaNode],
-    *,
-    limit: int,
-) -> list[AkashaCandidate]:
-    # 1. dense 只按直接语义分数排序，不掺入状态。
-    scores = _dense_scores(query_vec, nodes)
-    return [
-        AkashaCandidate(
-            key=key,
-            source="Dense",
-            ripple=0.0,
-            direct=score,
-            state=0.0,
-            edge=0.0,
-            long=0.0,
-            resource=1.0,
-            fan=0,
-            score=score,
-        )
-        for key, score in sorted(scores.items(), key=lambda item: item[1], reverse=True)[:limit]
-    ]
-
-
-# 取原始 message-level dense 命中并映射回 turn。
-def _dense_message_candidates(
-    query_vec: np.ndarray,
-    nodes: dict[str, AkashaNode],
-    message_embeddings: dict[str, np.ndarray],
-    message_turn_keys: dict[str, str],
-    *,
-    limit: int,
-) -> list[AkashaCandidate]:
-    # 1. Dense 展示贴合原始 CLI：先命中 message，再折回 turn key。
-    if not message_embeddings:
-        return _dense_candidates(query_vec, nodes, limit=limit)
-
-    # 2. 对缓存向量做余弦排序，过滤掉尚未 replay 成节点的消息。
-    query_norm = _normalize(query_vec)
-    scored: list[tuple[str, float]] = []
-    for message_id, embedding in message_embeddings.items():
-        if embedding.size != query_norm.size:
-            continue
-        score = float(np.dot(_normalize(embedding), query_norm))
-        scored.append((message_id, score))
-
-    # 3. 同一个 turn 只保留最高分，避免 user/assistant 重复占位。
-    candidates: list[AkashaCandidate] = []
-    seen: set[str] = set()
-    for message_id, score in sorted(scored, key=lambda item: item[1], reverse=True):
-        key = message_turn_keys.get(message_id)
-        if key is None or key not in nodes or key in seen:
-            continue
-        seen.add(key)
-        candidates.append(
-            AkashaCandidate(
-                key=key,
-                source="Dense",
-                ripple=0.0,
-                direct=score,
-                state=0.0,
-                edge=0.0,
-                long=0.0,
-                resource=1.0,
-                fan=0,
-                score=score,
-            )
-        )
-        if len(candidates) >= limit:
-            break
-    return candidates
-
-
-# 计算 Ripple 联想候选。
 def _compute_candidates(
     query: str,
     query_vec: np.ndarray,
@@ -1067,454 +959,30 @@ def _compute_candidates(
     edges_by_src: dict[str, dict[str, float]] | None = None,
     soft_recall: bool = False,
     return_limit: int | None = None,
+    graph_seed_keys: list[str] | None = None,
 ) -> tuple[list[AkashaCandidate], list[AkashaCandidate], ActivationTrace]:
-    # 1. 先用 Dense/FTS/BlackHole 三路选 seed。
-    if not nodes:
-        return [], [], ActivationTrace(seed_count=0, pool_count=0)
-    direct_scores = _dense_scores(query_vec, nodes)
-    seed_sources, seed_energy = _seed_pool(
+    return _core_compute_candidates(
         query,
-        direct_scores,
+        query_vec,
         nodes,
-        config,
-        source_cursor,
-    )
-    if not seed_sources:
-        return [], [], ActivationTrace(seed_count=0, pool_count=0)
-
-    # 2. 只在 seed 附近构建微型图，避免全图扩散噪音。
-    micro_keys = set(seed_sources)
-    for seed_key in seed_sources:
-        seed_ts = nodes[seed_key].first_ts_unix
-        for key, node in nodes.items():
-            if key in micro_keys:
-                continue
-            is_near = abs(node.first_ts_unix - seed_ts) <= config.nearby_time_seconds
-            if is_near and direct_scores.get(key, 0.0) > config.nearby_dense_threshold:
-                micro_keys.add(key)
-    valid_keys = list(micro_keys)
-    if not valid_keys:
-        return [], [], ActivationTrace(seed_count=0, pool_count=0)
-
-    # 3. 构建状态调制转移矩阵，并执行两轮 RWR 扩散。
-    index_by_key = {key: index for index, key in enumerate(valid_keys)}
-    embeddings = np.vstack([nodes[key].embedding for key in valid_keys])
-    sim_matrix = np.maximum(np.dot(embeddings, embeddings.T), 0.0)
-    np.fill_diagonal(sim_matrix, 0.0)
-    state_arr = _state_array(valid_keys, nodes, fan, seq)
-    cross_matrix = _cross_matrix(valid_keys, edges, index_by_key, edges_by_src)
-    transition = sim_matrix * state_arr[:, np.newaxis]
-    transition *= 1.0 + config.cross_boost * cross_matrix
-    transition = _keep_top_edges_per_column(transition, top_k=12)
-    transition = _normalize_columns(transition)
-    e0 = _initial_energy(valid_keys, seed_energy, fan, index_by_key)
-    te0 = np.dot(transition, e0)
-    current = e0.copy()
-    for _ in range(2):
-        current = 0.8 * np.dot(transition, current) + 0.2 * e0
-
-    # 4. 回溯路径并计算最终分数。
-    path_info = _path_info(valid_keys, transition, e0, te0)
-    candidates, suppressed = _score_candidates(
-        valid_keys,
-        nodes,
-        direct_scores,
-        seed_sources,
-        current,
-        state_arr,
-        cross_matrix,
-        fan,
+        edges,
         seq,
-        path_info,
-        config,
-        source_cursor,
+        config=_core_config(config),
+        fan=fan,
+        source_cursor=source_cursor,
+        edges_by_src=edges_by_src,
         soft_recall=soft_recall,
         return_limit=return_limit,
-    )
-    return candidates, suppressed, ActivationTrace(
-        seed_count=len(seed_sources),
-        pool_count=len(valid_keys),
+        graph_seed_keys=graph_seed_keys,
     )
 
 
-# 选择 Ripple 的语义 seed。
-def _seed_pool(
-    query: str,
-    direct_scores: dict[str, float],
-    nodes: dict[str, AkashaNode],
-    config: AkashaConfig,
-    source_cursor: sqlite3.Cursor | None,
-) -> tuple[dict[str, str], dict[str, float]]:
-    # 1. 优先选择高置信 dense seed，缺失时回退 dense top-k。
-    ranked = sorted(direct_scores.items(), key=lambda item: item[1], reverse=True)
-    seed_sources: dict[str, str] = {}
-    seed_energy: dict[str, float] = {}
-    for key, score in ranked[: min(100, len(ranked))]:
-        if score > config.dense_seed_threshold:
-            seed_sources[key] = "Dense"
-            seed_energy[key] = 1.0
-    if not seed_sources:
-        for key, _ in ranked[: config.dense_top_k]:
-            seed_sources[key] = "Dense(FB)"
-            seed_energy[key] = 1.0
-
-    # 2. FTS seed 从原始 messages_fts 映射回 turn key。
-    if source_cursor is not None:
-        fts_query = _get_jieba_keywords(query)
-        if fts_query:
-            _ = source_cursor.execute(
-                """
-                SELECT rowid
-                FROM messages_fts
-                WHERE content MATCH ?
-                LIMIT 10
-                """,
-                (fts_query,),
-            )
-            rowids = [int(row[0]) for row in source_cursor.fetchall()]
-            if rowids:
-                placeholders = ",".join("?" for _ in rowids)
-                _ = source_cursor.execute(
-                    f"""
-                    SELECT session_key, seq, role
-                    FROM messages
-                    WHERE rowid IN ({placeholders})
-                    """,
-                    rowids,
-                )
-                for session_key, seq, role in source_cursor.fetchall():
-                    _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
-                    if key not in nodes:
-                        continue
-                    if key not in seed_sources:
-                        seed_sources[key] = "FTS"
-                    elif "FTS" not in seed_sources[key].split("+"):
-                        seed_sources[key] += "+FTS"
-                    seed_energy[key] = 1.0
-
-    # 3. BlackHole 保留高 salience 且语义相近的少量节点。
-    blackhole_hits: list[tuple[str, float]] = []
-    for key, node in nodes.items():
-        if node.salience <= 0.8 or key in seed_sources:
-            continue
-        score = direct_scores.get(key, 0.0)
-        if score > 0.60:
-            blackhole_hits.append((key, score))
-    for key, _ in sorted(blackhole_hits, key=lambda item: item[1], reverse=True)[:5]:
-        seed_sources[key] = "BlackHole"
-        seed_energy[key] = 1.0
-    return seed_sources, seed_energy
-
-
-# 计算节点状态权重。
-def _state_array(
-    keys: list[str],
-    nodes: dict[str, AkashaNode],
-    fan: dict[str, int],
-    seq: int,
-) -> np.ndarray:
-    # 1. 状态权重包含显著度、长期强度、短期资源和 fan 惩罚。
-    values = np.zeros(len(keys), dtype=np.float32)
-    for index, key in enumerate(keys):
-        node = nodes[key]
-        long_score = min(1.0, _decayed_strength(node, seq) / _STRENGTH_CAP)
-        resource = _recover_resource(node, seq)
-        values[index] = (
-            math.exp(1.4 * node.salience + 1.0 * long_score)
-            * resource
-            / math.sqrt(1.0 + fan.get(key, 0))
-        )
-    return values
-
-
-# 构建共激活边矩阵。
-def _cross_matrix(
-    keys: list[str],
-    edges: dict[tuple[str, str], float],
-    index_by_key: dict[str, int],
-    edges_by_src: dict[str, dict[str, float]] | None = None,
-) -> np.ndarray:
-    # 1. 只把微型图内部的边投影进矩阵。
-    matrix = np.zeros((len(keys), len(keys)), dtype=np.float32)
-    if edges_by_src is not None:
-        for src_key in keys:
-            src_index = index_by_key[src_key]
-            for dst_key, weight in edges_by_src.get(src_key, {}).items():
-                dst_index = index_by_key.get(dst_key)
-                if dst_index is not None:
-                    matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
-        return matrix
-
-    # 2. 没有 src 索引时扫描边表。
-    for (src_key, dst_key), weight in edges.items():
-        src_index = index_by_key.get(src_key)
-        dst_index = index_by_key.get(dst_key)
-        if src_index is not None and dst_index is not None:
-            matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
-    return matrix
-
-
-# 每列只保留最强的若干条边。
-def _keep_top_edges_per_column(matrix: np.ndarray, *, top_k: int) -> np.ndarray:
-    # 1. 这个稀疏化来自 cross CLI，避免微型图变成全连接噪音。
-    if len(matrix) <= top_k:
-        return matrix
-    kth = np.partition(matrix, -top_k, axis=0)[-top_k]
-    return np.where(matrix >= kth[np.newaxis, :], matrix, 0.0)
-
-
-# 对转移矩阵按列归一化。
-def _normalize_columns(matrix: np.ndarray) -> np.ndarray:
-    # 1. 空列用极小值防止除零。
-    sums = matrix.sum(axis=0)
-    sums[sums == 0] = 1e-10
-    return matrix / sums
-
-
-# 构造 RWR 初始能量。
-def _initial_energy(
-    keys: list[str],
-    seed_energy: dict[str, float],
-    fan: dict[str, int],
-    index_by_key: dict[str, int],
-) -> np.ndarray:
-    # 1. seed 能量按 fan 惩罚后再归一化。
-    energy = np.zeros(len(keys), dtype=np.float32)
-    for key, value in seed_energy.items():
-        index = index_by_key.get(key)
-        if index is not None:
-            energy[index] = value / math.sqrt(1.0 + fan.get(key, 0))
-    total = float(energy.sum())
-    return energy / total if total > 0 else energy
-
-
-# 回溯每个候选主要能量路径。
-def _path_info(
-    keys: list[str],
-    transition: np.ndarray,
-    e0: np.ndarray,
-    te0: np.ndarray,
-) -> dict[str, tuple[str, str, str, float]]:
-    # 1. 区分 direct / 1hop / 2hop，用于后续跳数惩罚和提示诊断。
-    result: dict[str, tuple[str, str, str, float]] = {}
-    seed_indices = np.where(e0 > 0)[0]
-    for index, key in enumerate(keys):
-        c0 = float(0.2 * e0[index])
-        c1_vec = 0.16 * transition[index, :] * e0
-        s1 = int(np.argmax(c1_vec))
-        c1 = float(c1_vec[s1])
-        c2_vec = 0.64 * transition[index, :] * te0
-        c2_vec[index] = 0.0
-        c2_vec[seed_indices] = 0.0
-        bridge = int(np.argmax(c2_vec))
-        c2 = float(c2_vec[bridge])
-        s2 = int(np.argmax(transition[bridge, :] * e0))
-        if c0 >= c1 and c0 >= c2:
-            result[key] = ("direct", "", "", c0)
-        elif c1 >= c2:
-            result[key] = ("1hop", keys[s1], "", c1)
-        else:
-            result[key] = ("2hop", keys[s2], keys[bridge], c2)
-    return result
-
-
-# 计算最终 Ripple 分数。
-def _score_candidates(
-    keys: list[str],
-    nodes: dict[str, AkashaNode],
-    direct_scores: dict[str, float],
-    seed_sources: dict[str, str],
-    current: np.ndarray,
-    state_arr: np.ndarray,
-    cross_matrix: np.ndarray,
-    fan: dict[str, int],
-    seq: int,
-    path_info: dict[str, tuple[str, str, str, float]],
-    config: AkashaConfig,
-    source_cursor: sqlite3.Cursor | None,
-    *,
-    soft_recall: bool,
-    return_limit: int | None,
-) -> tuple[list[AkashaCandidate], list[AkashaCandidate]]:
-    # 1. 先为微型图内每个节点计算完整分数。
-    all_candidates: dict[str, AkashaCandidate] = {}
-    max_state = max(float(np.max(state_arr)), 1e-10)
-    for index, key in enumerate(keys):
-        node = nodes[key]
-        long_score = min(1.0, _decayed_strength(node, seq) / _STRENGTH_CAP)
-        resource = _recover_resource(node, seq)
-        fan_value = fan.get(key, 0)
-        direct_value = max(0.0, direct_scores.get(key, 0.0))
-        state_value = min(1.0, float(state_arr[index]) / max_state)
-        edge_value = float(np.max(cross_matrix[index])) if len(keys) else 0.0
-        path_type, seed_key, bridge_key, path_value = path_info.get(key, ("direct", "", "", 0.0))
-        hop_penalty = {"direct": 1.0, "1hop": 0.86, "2hop": 0.62}.get(path_type, 0.62)
-        source = seed_sources.get(key, "Expanded")
-        direct_weight = 0.50 if source != "Expanded" else 0.18
-        fan_penalty = math.pow(1.0 + fan_value, _FAN_PENALTY_POWER)
-        user_penalty = 1.0 if _has_user_turn(source_cursor, key) else _ASSISTANT_ONLY_PENALTY
-        score = (
-            float(current[index]) * 3.0 * state_value
-            + direct_weight * direct_value
-            + 0.18 * long_score
-            + 0.12 * node.salience
-            + 0.20 * min(1.0, edge_value)
-        ) * resource * hop_penalty * user_penalty / fan_penalty
-        if source == "Expanded" and path_type == "1hop" and direct_value >= _EXPANDED_DIRECT_FLOOR:
-            score = max(score, config.activation_threshold + 0.01)
-        all_candidates[key] = AkashaCandidate(
-            key=key,
-            source=source,
-            ripple=float(current[index]),
-            direct=direct_value,
-            state=state_value,
-            edge=edge_value,
-            long=long_score,
-            resource=resource,
-            fan=fan_value,
-            score=score,
-            path_type=path_type,
-            seed_key=seed_key,
-            bridge_key=bridge_key,
-            path_value=path_value,
-        )
-
-    # 2. 原始算法会把 2-hop child 的中间节点提升成 Bridge 候选。
-    for child in list(all_candidates.values()):
-        if child.path_type != "2hop" or not child.bridge_key:
-            continue
-        bridge = all_candidates.get(child.bridge_key)
-        if bridge is None or not _has_user_turn(source_cursor, bridge.key):
-            continue
-        bridge_score = max(
-            bridge.score,
-            child.score * 0.62,
-            bridge.direct * 0.24 + bridge.state * 0.08,
-        )
-        all_candidates[bridge.key] = AkashaCandidate(
-            key=bridge.key,
-            source="Bridge",
-            ripple=bridge.ripple,
-            direct=bridge.direct,
-            state=bridge.state,
-            edge=bridge.edge,
-            long=bridge.long,
-            resource=bridge.resource,
-            fan=bridge.fan,
-            score=bridge_score,
-            path_type="bridge",
-            seed_key=child.seed_key,
-            bridge_key="",
-            path_value=max(bridge.path_value, child.path_value),
-        )
-
-    # 3. 写状态默认只接受硬阈值；展示查询可以追加 soft recall。
-    candidates: list[AkashaCandidate] = []
-    suppressed: list[AkashaCandidate] = []
-    for candidate in all_candidates.values():
-        soft_hit = (
-            soft_recall
-            and candidate.score >= config.soft_recall_threshold
-            and candidate.direct >= config.soft_recall_direct_floor
-            and candidate.source in {"Bridge", "Expanded"}
-            and candidate.path_type in {"bridge", "1hop", "2hop"}
-        )
-        if candidate.score >= config.activation_threshold or soft_hit:
-            if soft_hit and candidate.score < config.activation_threshold:
-                candidate = AkashaCandidate(
-                    key=candidate.key,
-                    source=candidate.source,
-                    ripple=candidate.ripple,
-                    direct=candidate.direct,
-                    state=candidate.state,
-                    edge=candidate.edge,
-                    long=candidate.long,
-                    resource=candidate.resource,
-                    fan=candidate.fan,
-                    score=candidate.score,
-                    suppressed="soft-recall",
-                    path_type=candidate.path_type,
-                    seed_key=candidate.seed_key,
-                    bridge_key=candidate.bridge_key,
-                    path_value=candidate.path_value,
-                )
-            candidates.append(candidate)
-        else:
-            suppressed.append(
-                AkashaCandidate(
-                    key=candidate.key,
-                    source=candidate.source,
-                    ripple=candidate.ripple,
-                    direct=candidate.direct,
-                    state=candidate.state,
-                    edge=candidate.edge,
-                    long=candidate.long,
-                    resource=candidate.resource,
-                    fan=candidate.fan,
-                    score=candidate.score,
-                    suppressed="below-threshold",
-                    path_type=candidate.path_type,
-                    seed_key=candidate.seed_key,
-                    bridge_key=candidate.bridge_key,
-                    path_value=candidate.path_value,
-                )
-            )
-    candidates.sort(key=lambda item: item.score, reverse=True)
-    suppressed.sort(key=lambda item: item.score, reverse=True)
-    limit = return_limit or config.activate_limit
-    return candidates[:limit], suppressed[:limit]
-
-
-# 生成旧节点状态更新。
-def _activation_updates(
-    items: list[AkashaCandidate],
-    nodes: dict[str, AkashaNode],
-    seq: int,
-) -> list[ActivationUpdate]:
-    # 1. 被激活节点执行长期强度巩固和短期资源消耗。
-    updates: list[ActivationUpdate] = []
-    for item in items:
-        node = nodes.get(item.key)
-        if node is None:
-            continue
-        strength = _decayed_strength(node, seq)
-        strength = _bounded_add(strength, _STRENGTH_LR * item.score, _STRENGTH_CAP)
-        resource = _recover_resource(node, seq)
-        resource *= max(0.05, 1.0 - _RESOURCE_USE_RATE * min(1.0, item.score))
-        updates.append(
-            ActivationUpdate(
-                key=item.key,
-                strength=strength,
-                resource=resource,
-                recall_count=node.recall_count + 1,
-                seq=seq,
-            )
-        )
-    return updates
-
-
-# 计算短期资源恢复。
-def _recover_resource(node: AkashaNode, seq: int) -> float:
-    # 1. 距离上次激活越久，resource 越接近 1。
-    gap = max(0, seq - node.last_resource_seq)
-    return 1.0 - (1.0 - node.resource) * math.exp(-gap / _RESOURCE_RECOVER_TAU)
-
-
-# 计算长期强度衰减。
-def _decayed_strength(node: AkashaNode, seq: int) -> float:
-    # 1. strength 是历史激活强度，随消息序号差缓慢衰减。
-    gap = max(0, seq - node.last_strength_seq)
-    return node.strength * math.exp(-gap / _LONG_DECAY_TAU)
-
-
-# 有界增加状态值。
-def _bounded_add(value: float, delta: float, cap: float) -> float:
-    # 1. 越接近 cap，新增越慢。
-    return value + delta * max(0.0, 1.0 - value / cap)
+# ── sessions.db 特有辅助函数 ──────────────────────────────────────────
 
 
 # 读取 message 到 turn key 的映射。
 def _load_message_turn_keys(session_db_path: Path) -> dict[str, str]:
+    # 1. sessions.db messages 表映射。
     if not session_db_path.exists():
         return {}
     with closing(sqlite3.connect(str(session_db_path))) as db:
@@ -1524,52 +992,6 @@ def _load_message_turn_keys(session_db_path: Path) -> dict[str, str]:
         _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
         result[str(message_id)] = key
     return result
-
-
-# 把 query 切成 SQLite FTS 可用的搜索词。
-def _get_jieba_keywords(text: str) -> str:
-    # 1. 和原始 cross CLI 一样使用 jieba 的 search mode。
-    import jieba
-
-    cut_for_search = cast(Callable[[str], Iterable[str]], getattr(jieba, "cut_for_search"))
-    words: list[str] = []
-    for word in cut_for_search(text):
-        cleaned = "".join(
-            char
-            for char in word.strip()
-            if char.isalnum() or "\u4e00" <= char <= "\u9fff"
-        )
-        if len(cleaned) > 1:
-            words.append(f'"{cleaned}"')
-    return " OR ".join(words[:20])
-
-
-# 判断 turn key 是否有 user anchor。
-def _has_user_turn(cursor: sqlite3.Cursor | None, key: str) -> bool:
-    # 1. 有 source cursor 时贴合原始 DB 检查；没有时保留节点级语义。
-    if cursor is None:
-        return True
-    parsed = _parse_turn_key(key)
-    if parsed is None:
-        return False
-    session_key, seq = parsed
-    _ = cursor.execute(
-        """
-        SELECT 1
-        FROM messages
-        WHERE session_key = ? AND seq = ? AND role = 'user'
-        LIMIT 1
-        """,
-        (session_key, seq),
-    )
-    return cursor.fetchone() is not None
-
-
-# 归一化向量。
-def _normalize(vector: np.ndarray) -> np.ndarray:
-    # 1. 所有相似度都基于单位向量。
-    norm = float(np.linalg.norm(vector))
-    return vector / norm if norm > 0 else vector
 
 
 # 获取当前 query 对应的预测 seq。
@@ -1697,18 +1119,6 @@ def _load_turn_card(
         lane=lane,
         signals=signals,
     )
-
-
-# 解析 turn key。
-def _parse_turn_key(key: str) -> tuple[str, int] | None:
-    # 1. session_key 自身可能含冒号，因此只从右侧切 seq。
-    left, sep, right = key.rpartition(":")
-    if not sep:
-        return None
-    try:
-        return left, int(right)
-    except ValueError:
-        return None
 
 
 def _parse_message_id(message_id: str) -> tuple[str, int] | None:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1,0 +1,1487 @@
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+from collections.abc import Callable, Iterable
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from agent.config_models import Config
+from bus.events_lifecycle import TurnCommitted
+from core.memory.engine import (
+    EngineProfile,
+    EvidenceRef,
+    MemoryCapability,
+    MemoryEngineDescriptor,
+    MemoryIngestRequest,
+    MemoryIngestResult,
+    MemoryMutation,
+    MemoryMutationResult,
+    MemoryQuery,
+    MemoryQueryResult,
+    MemoryRecord,
+    MemoryScope,
+    MemoryToolProfile,
+    MemoryToolSpec,
+)
+from memory2.embedder import Embedder
+from plugins.akasha.config import AkashaConfig, resolve_akasha_db_path
+from plugins.akasha.store import (
+    ActivationEventRow,
+    ActivationUpdate,
+    AkashaNode,
+    AkashaStore,
+    EdgeUpdate,
+    SourceMessage,
+    turn_key,
+)
+
+if TYPE_CHECKING:
+    from bus.event_bus import EventBus
+    from core.net.http import SharedHttpResources
+
+
+_LONG_DECAY_TAU = 2200.0
+_RESOURCE_RECOVER_TAU = 14.0
+_RESOURCE_USE_RATE = 0.35
+_STRENGTH_LR = 0.18
+_STRENGTH_CAP = 3.0
+_ASSISTANT_ONLY_PENALTY = 0.12
+_FAN_PENALTY_POWER = 0.10
+_EXPANDED_DIRECT_FLOOR = 0.62
+
+
+@dataclass(frozen=True)
+class AkashaCandidate:
+    key: str
+    source: str
+    ripple: float
+    direct: float
+    state: float
+    edge: float
+    long: float
+    resource: float
+    fan: int
+    score: float
+    suppressed: str = ""
+    path_type: str = "direct"
+    seed_key: str = ""
+    bridge_key: str = ""
+    path_value: float = 0.0
+
+
+@dataclass(frozen=True)
+class ActivationTrace:
+    seed_count: int
+    pool_count: int
+
+
+@dataclass(frozen=True)
+class AkashaCard:
+    key: str
+    source_ref: str
+    user_message: str
+    assistant_preview: str
+    score: float
+    lane: str
+    signals: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PendingActivation:
+    query_id: str
+    seq: int
+    items: list[AkashaCandidate]
+
+
+class AkashaMemoryEngine:
+    DESCRIPTOR = MemoryEngineDescriptor(
+        name="akasha",
+        profile=EngineProfile.RICH_MEMORY_ENGINE,
+        capabilities=frozenset(
+            {
+                MemoryCapability.INGEST_MESSAGES,
+                MemoryCapability.RETRIEVE_SEMANTIC,
+                MemoryCapability.RETRIEVE_CONTEXT_BLOCK,
+                MemoryCapability.RETRIEVE_STRUCTURED_HITS,
+                MemoryCapability.SEMANTICS_RICH_MEMORY,
+            }
+        ),
+        notes={"owner": "plugins.akasha.engine", "truth": "sessions.db/messages"},
+    )
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        akasha_config: AkashaConfig,
+        workspace: Path,
+        http_resources: "SharedHttpResources",
+        event_publisher: "EventBus | None" = None,
+    ) -> None:
+        # 1. 初始化 sidecar store、原始消息库路径和 embedding 客户端。
+        self._config = config
+        self._akasha_config = akasha_config
+        self._workspace = workspace
+        self._session_db_path = workspace / "sessions.db"
+        self._store = AkashaStore(
+            resolve_akasha_db_path(
+                workspace=workspace,
+                akasha_config=akasha_config,
+            )
+        )
+        embedding = config.memory.embedding
+        self._embedder = Embedder(
+            base_url=embedding.base_url
+            or config.light_base_url
+            or config.base_url
+            or "",
+            api_key=embedding.api_key
+            or config.light_api_key
+            or config.api_key,
+            model=embedding.model,
+            requester=http_resources.external_default,
+        )
+        self._event_bus = event_publisher
+        self._pending_by_session: dict[str, PendingActivation] = {}
+        self.closeables: list[object] = [self._store, self._embedder]
+        self._wire_events()
+
+    # 创建 Akasha sidecar 数据库。
+    @classmethod
+    def ensure_workspace_storage(
+        cls,
+        *,
+        akasha_config: AkashaConfig,
+        workspace: Path,
+    ) -> None:
+        # 1. 启动前只确保数据库和 schema 存在。
+        store = AkashaStore(
+            resolve_akasha_db_path(
+                workspace=workspace,
+                akasha_config=akasha_config,
+            )
+        )
+        store.close()
+
+    # 注册 after-turn 增量写入。
+    def _wire_events(self) -> None:
+        # 1. Akasha 不接 consolidation，只关心每轮真实消息提交。
+        if self._event_bus is not None:
+            self._event_bus.on(TurnCommitted, self._on_turn_committed)
+
+    # 返回 Akasha 工具描述。
+    def tool_profile(self) -> MemoryToolProfile:
+        # 1. Akasha 只开放 recall_memory；事实写入来自 sessions.db 生命周期。
+        return MemoryToolProfile(
+            recall=MemoryToolSpec(
+                description=(
+                    "从 Akasha message-as-truth 记忆引擎召回原始对话。"
+                    "返回 Dense 精确命中和 Ripple 联想命中；回答具体事实前继续用 fetch_messages(source_ref) 取原文。"
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "要召回的历史对话主题"},
+                        "limit": {
+                            "type": "integer",
+                            "description": "最多返回条数",
+                            "minimum": 1,
+                            "maximum": 20,
+                            "default": 10,
+                        },
+                    },
+                    "required": ["query"],
+                },
+                search_hint="历史对话 原始消息 Akasha 右脑联想",
+            )
+        )
+
+    # 根据 MemoryQuery 执行 Akasha 检索。
+    async def query(
+        self,
+        request: MemoryQuery,
+    ) -> MemoryQueryResult:
+        # 1. timeline 不是 Akasha MVP 范围，时间线事实仍应走 fetch/search messages。
+        if request.intent == "timeline":
+            return MemoryQueryResult(
+                trace={"engine": self.DESCRIPTOR.name, "intent": "timeline_unsupported"}
+            )
+
+        # 2. 空 query 不触发状态更新。
+        query_text = request.text.strip()
+        if not query_text:
+            return MemoryQueryResult(trace={"engine": self.DESCRIPTOR.name, "hit_count": 0})
+
+        # 3. 检索旧 turn 图，并在 context 入口记录本轮激活。
+        query_vec = np.array(await self._embedder.embed(query_text), dtype=np.float32)
+        result = self._retrieve(query_text, query_vec, request)
+        if request.intent in {"context", "answer"}:
+            self._remember_pending_activation(request, result.activation_items)
+
+        # 4. context 注入按 Akasha 配置展示 topK；工具查询继续尊重调用方 limit。
+        dense_limit = self._akasha_config.dense_top_k
+        ripple_limit = self._akasha_config.ripple_top_k
+        if request.intent != "context":
+            dense_limit = min(request.limit, dense_limit)
+            ripple_limit = min(request.limit, ripple_limit)
+        dense_cards = self._cards_from_keys(
+            [(item.key, item.score, "dense", _candidate_signals(item)) for item in result.dense_items],
+            limit=dense_limit,
+        )
+        dense_keys = {card.key for card in dense_cards}
+        ripple_cards = self._cards_from_keys(
+            [
+                (item.key, item.score, "ripple", _candidate_signals(item))
+                for item in result.ripple_items
+                if item.key not in dense_keys
+            ],
+            limit=ripple_limit,
+        )
+        text_block = (
+            self._format_context_block(dense_cards, ripple_cards)
+            if request.intent == "context"
+            else ""
+        )
+        cards = [*dense_cards, *ripple_cards]
+        return MemoryQueryResult(
+            text_block=text_block,
+            records=[_card_to_record(card, injected=bool(text_block)) for card in cards],
+            trace={
+                "engine": self.DESCRIPTOR.name,
+                "profile": self.DESCRIPTOR.profile.value,
+                "intent": request.intent,
+                "dense_count": len(dense_cards),
+                "ripple_count": len(ripple_cards),
+                "seed_count": result.trace.seed_count,
+                "pool_count": result.trace.pool_count,
+            },
+            raw={"items": [_card_to_raw(card) for card in cards]},
+        )
+
+    # 接收外部批量 ingest 请求。
+    async def ingest(self, request: MemoryIngestRequest) -> MemoryIngestResult:
+        # 1. Akasha 的主写入来自 TurnCommitted；ingest 只支持显式 conversation_turn。
+        if request.source_kind not in {"conversation_turn", "conversation_batch"}:
+            return MemoryIngestResult(
+                accepted=False,
+                summary="unsupported source_kind",
+                raw={"reason": "unsupported_source_kind"},
+            )
+        content: dict[str, object] = {}
+        payload: object = request.content
+        if isinstance(payload, dict):
+            raw_content = cast(dict[object, object], payload)
+            content = {str(key): value for key, value in raw_content.items()}
+        user_text = str(content.get("user_message") or "")
+        assistant_text = str(content.get("assistant_response") or "")
+        if not user_text and not assistant_text:
+            return MemoryIngestResult(
+                accepted=False,
+                summary="empty conversation",
+                raw={"reason": "empty_conversation"},
+            )
+
+        # 2. 没有稳定 message id 时不伪造事实来源。
+        return MemoryIngestResult(
+            accepted=False,
+            summary="akasha ingest requires persisted sessions.db messages",
+            raw={"reason": "requires_persisted_messages"},
+        )
+
+    # Akasha 不通过 memorize/forget 改写事实。
+    async def mutate(self, request: MemoryMutation) -> MemoryMutationResult:
+        # 1. sidecar 不是事实库，显式写删不在 MVP 中提供。
+        if request.kind == "forget":
+            return MemoryMutationResult(
+                accepted=False,
+                status="unsupported",
+                missing_ids=list(request.ids),
+            )
+        return MemoryMutationResult(accepted=False, status="unsupported")
+
+    # 强化已引用项。
+    def reinforce_items_batch(self, ids: list[str]) -> None:
+        # 1. 引用强化暂不改变 Akasha 图，图状态由真实 query 激活驱动。
+        return None
+
+    # 返回引擎描述。
+    def describe(self) -> MemoryEngineDescriptor:
+        # 1. runtime 和 dashboard 都通过 descriptor 识别当前 engine。
+        return self.DESCRIPTOR
+
+    # Akasha 不提供 procedure 关键词规则。
+    def keyword_match_procedures(
+        self,
+        action_tokens: list[str],
+    ) -> list[dict[str, object]]:
+        # 1. procedure 语义属于 default memory，不混进 message-as-truth 引擎。
+        return []
+
+    # Akasha 不提供 event timeline 查询。
+    def list_events_by_time_range(
+        self,
+        time_start: datetime,
+        time_end: datetime,
+        *,
+        limit: int = 200,
+    ) -> list[dict[str, object]]:
+        # 1. 时间线问题使用 search_messages/fetch_messages 更贴近原始事实。
+        return []
+
+    # dashboard 列出 Akasha turn 节点。
+    def list_items_for_dashboard(
+        self,
+        *,
+        q: str = "",
+        memory_type: str = "",
+        status: str = "",
+        source_ref: str = "",
+        scope_channel: str = "",
+        scope_chat_id: str = "",
+        has_embedding: bool | None = None,
+        page: int = 1,
+        page_size: int = 50,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> tuple[list[dict[str, object]], int]:
+        # 1. 过滤项先保持 MVP，只支持 q 和分页排序。
+        _ = (memory_type, status, source_ref, scope_channel, scope_chat_id, has_embedding)
+        return self._store.list_items_for_dashboard(
+            q=q,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+
+    # dashboard 读取 Akasha 节点详情。
+    def get_item_for_dashboard(
+        self,
+        item_id: str,
+        *,
+        include_embedding: bool = False,
+    ) -> dict[str, object] | None:
+        # 1. include_embedding 由 store MVP 忽略，避免把大向量塞进 dashboard。
+        _ = include_embedding
+        return self._store.get_item_for_dashboard(item_id)
+
+    # dashboard 更新 Akasha 节点。
+    def update_item_for_dashboard(
+        self,
+        item_id: str,
+        *,
+        status: str | None = None,
+        extra_json: dict[str, object] | None = None,
+        source_ref: str | None = None,
+        happened_at: str | None = None,
+        emotional_weight: int | None = None,
+    ) -> dict[str, object] | None:
+        # 1. Akasha sidecar 不支持手改事实或状态，直接返回当前详情。
+        _ = (status, extra_json, source_ref, happened_at, emotional_weight)
+        return self._store.get_item_for_dashboard(item_id)
+
+    # 删除 Akasha sidecar 节点。
+    def delete_item(self, item_id: str) -> bool:
+        # 1. 只删除 sidecar 索引，不删除原始 messages。
+        return self._store.delete_item(item_id)
+
+    # 批量删除 Akasha sidecar 节点。
+    def delete_items_batch(self, ids: list[str]) -> int:
+        # 1. 只删除 sidecar 索引，不删除原始 messages。
+        return self._store.delete_items_batch(ids)
+
+    # 查找相似 Akasha 节点。
+    def find_similar_items_for_dashboard(
+        self,
+        item_id: str,
+        *,
+        top_k: int = 8,
+        memory_type: str = "",
+        score_threshold: float = 0.0,
+        include_superseded: bool = False,
+    ) -> list[dict[str, object]]:
+        # 1. MVP dashboard 不做相似节点展开。
+        _ = (item_id, top_k, memory_type, score_threshold, include_superseded)
+        return []
+
+    # 检索 Akasha 图并更新旧节点激活。
+    def _retrieve(
+        self,
+        query: str,
+        query_vec: np.ndarray,
+        request: MemoryQuery,
+    ) -> "_AkashaRetrieval":
+        # 1. 准备内存图和当前查询所在的预测 seq。
+        nodes = {node.key: node for node in self._store.list_nodes()}
+        edges = self._store.load_edges()
+        seq = _current_query_seq(self._session_db_path, request.scope)
+        fan = _fan_counts(edges)
+        source_db = (
+            sqlite3.connect(str(self._session_db_path))
+            if self._session_db_path.exists()
+            else None
+        )
+
+        # 2. 状态激活只取原始 replay 限额，展示候选单独放宽。
+        try:
+            source_cursor = source_db.cursor() if source_db is not None else None
+            dense_items = _dense_message_candidates(
+                query_vec,
+                nodes,
+                self._store,
+                self._config.memory.embedding.model,
+                source_cursor,
+                limit=max(self._akasha_config.dense_top_k, request.limit),
+            )
+            activation_items, _, _ = _compute_candidates(
+                query,
+                query_vec,
+                nodes,
+                edges,
+                seq,
+                config=self._akasha_config,
+                fan=fan,
+                source_cursor=source_cursor,
+                soft_recall=False,
+                return_limit=self._akasha_config.activate_limit,
+            )
+            display_limit = max(
+                24,
+                max(self._akasha_config.ripple_top_k, request.limit) * 3,
+            )
+            ripple_items, _, trace = _compute_candidates(
+                query,
+                query_vec,
+                nodes,
+                edges,
+                seq,
+                config=self._akasha_config,
+                fan=fan,
+                source_cursor=source_cursor,
+                soft_recall=True,
+                return_limit=display_limit,
+            )
+        finally:
+            if source_db is not None:
+                source_db.close()
+
+        # 3. 查询阶段只更新旧节点状态，当前 turn 的边等 after-turn 再补。
+        updates = _activation_updates(activation_items, nodes, seq)
+        self._store.update_activation_batch(updates)
+        return _AkashaRetrieval(
+            dense_items=dense_items,
+            ripple_items=ripple_items,
+            activation_items=activation_items,
+            trace=trace,
+            seq=seq,
+        )
+
+    # 暂存本轮激活，等待 after-turn 拿到真实 message id 后建边。
+    def _remember_pending_activation(
+        self,
+        request: MemoryQuery,
+        items: list[AkashaCandidate],
+    ) -> None:
+        # 1. 没有 session_key 时仍可检索，但不建当前 turn 的共激活边。
+        if not request.scope.session_key or not items:
+            return
+        seq = _current_query_seq(self._session_db_path, request.scope)
+        self._pending_by_session[request.scope.session_key] = PendingActivation(
+            query_id=f"{request.scope.session_key}:{seq}",
+            seq=seq,
+            items=list(items),
+        )
+
+    # TurnCommitted 后把真实 user/assistant 写入 sidecar，并补本轮共激活边。
+    async def _on_turn_committed(self, event: TurnCommitted) -> None:
+        # 1. 跳过不应进入记忆的系统轮次。
+        if bool((event.extra or {}).get("skip_post_memory")):
+            return
+        messages = _load_committed_turn_messages(self._session_db_path, event)
+        if not messages:
+            return
+
+        # 2. 分别 embed user 和 assistant，再按 cross CLI 规则合并到 turn 节点。
+        embeddings = await self._embedder.embed_batch([message.content for message in messages])
+        current_key = ""
+        for message, embedding in zip(messages, embeddings, strict=False):
+            self._store.upsert_cached_embedding(
+                message=message,
+                model=self._config.memory.embedding.model,
+                embedding=embedding,
+            )
+            current_key = self._store.upsert_message_node(message, embedding)
+
+        # 3. 用真实 current_key 建边，并记录激活诊断。
+        pending = self._pending_by_session.pop(event.session_key, None)
+        if current_key and pending is not None:
+            self._commit_pending_activation(current_key, pending)
+
+    # 把 pending activation 转成边和事件。
+    def _commit_pending_activation(
+        self,
+        current_key: str,
+        pending: PendingActivation,
+    ) -> None:
+        # 1. 当前输入和被激活旧节点互连，形成后续桥接能力。
+        key_to_score = {item.key: item.score for item in pending.items}
+        edge_updates: list[EdgeUpdate] = []
+        for item in pending.items:
+            edge_strength = key_to_score.get(item.key, 1.0)
+            edge_updates.append(EdgeUpdate(current_key, item.key, edge_strength, pending.seq))
+            edge_updates.append(EdgeUpdate(item.key, current_key, edge_strength, pending.seq))
+
+        # 2. 同轮共同激活的旧节点互连，保持 cross CLI 的共激活语义。
+        for left_index, left in enumerate(pending.items):
+            for right in pending.items[left_index + 1:]:
+                edge_strength = math.sqrt(
+                    key_to_score.get(left.key, 1.0) * key_to_score.get(right.key, 1.0)
+                )
+                edge_updates.append(EdgeUpdate(left.key, right.key, edge_strength, pending.seq))
+                edge_updates.append(EdgeUpdate(right.key, left.key, edge_strength, pending.seq))
+        self._store.upsert_edges(edge_updates)
+
+        # 3. 记录本轮激活明细，便于之后诊断。
+        self._store.insert_activation_events([
+            ActivationEventRow(
+                seq=pending.seq,
+                query_id=pending.query_id,
+                activated_key=item.key,
+                source=item.source,
+                score=item.score,
+                direct_score=item.direct,
+                state_score=item.state,
+                edge_score=item.edge,
+                long_score=item.long,
+                resource=item.resource,
+                fan=item.fan,
+            )
+            for item in pending.items
+        ])
+
+    # 把 turn key 列表转成可注入 card。
+    def _cards_from_keys(
+        self,
+        items: list[tuple[str, float, str, dict[str, object]]],
+        *,
+        limit: int,
+    ) -> list[AkashaCard]:
+        # 1. 每个 card 的正文都回 sessions.db 取，sidecar 不充当事实来源。
+        cards: list[AkashaCard] = []
+        seen: set[str] = set()
+        for key, score, lane, signals in items:
+            if key in seen:
+                continue
+            seen.add(key)
+            card = _load_turn_card(
+                self._session_db_path,
+                key,
+                assistant_preview_chars=self._akasha_config.assistant_preview_chars,
+                score=score,
+                lane=lane,
+                signals=signals,
+            )
+            if card is None:
+                continue
+            cards.append(card)
+            if len(cards) >= limit:
+                break
+        return cards
+
+    # 格式化 agent 看到的 Dense/Ripple 双块。
+    def _format_context_block(
+        self,
+        dense_cards: list[AkashaCard],
+        ripple_cards: list[AkashaCard],
+    ) -> str:
+        # 1. Dense 块优先展示重叠项，Ripple 块只展示 ripple-only。
+        parts: list[str] = []
+        if dense_cards:
+            parts.append(_format_cards("## 左脑记忆：精确回忆", dense_cards))
+        if ripple_cards:
+            parts.append(_format_cards("## 右脑联想：潜意识第一反应", ripple_cards))
+
+        # 2. 应用字符预算，避免历史消息过长撑爆上下文。
+        text = "\n\n".join(part for part in parts if part.strip())
+        max_chars = max(1, self._akasha_config.inject_max_chars)
+        if len(text) <= max_chars:
+            return text
+        return text[:max_chars].rstrip() + f"\n...[Akasha 已截断 {len(text) - max_chars} 字]"
+
+
+@dataclass(frozen=True)
+class _AkashaRetrieval:
+    dense_items: list[AkashaCandidate]
+    ripple_items: list[AkashaCandidate]
+    activation_items: list[AkashaCandidate]
+    trace: ActivationTrace
+    seq: int
+
+
+# 计算节点扇出。
+def _fan_counts(edges: dict[tuple[str, str], float]) -> dict[str, int]:
+    # 1. 边两端都计入 fan，和 cross CLI 保持一致。
+    fan: dict[str, int] = {}
+    for src, dst in edges:
+        fan[src] = fan.get(src, 0) + 1
+        fan[dst] = fan.get(dst, 0) + 1
+    return fan
+
+
+# 计算 query 对所有节点的 dense 分数。
+def _dense_scores(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+) -> dict[str, float]:
+    # 1. sidecar 节点 embedding 已归一化，点积即余弦相似度。
+    if not nodes:
+        return {}
+    keys = list(nodes.keys())
+    matrix = np.vstack([nodes[key].embedding for key in keys])
+    scores = np.dot(matrix, _normalize(query_vec))
+    return {key: float(score) for key, score in zip(keys, scores, strict=False)}
+
+
+# 取 dense top 候选。
+def _dense_candidates(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    *,
+    limit: int,
+) -> list[AkashaCandidate]:
+    # 1. dense 只按直接语义分数排序，不掺入状态。
+    scores = _dense_scores(query_vec, nodes)
+    return [
+        AkashaCandidate(
+            key=key,
+            source="Dense",
+            ripple=0.0,
+            direct=score,
+            state=0.0,
+            edge=0.0,
+            long=0.0,
+            resource=1.0,
+            fan=0,
+            score=score,
+        )
+        for key, score in sorted(scores.items(), key=lambda item: item[1], reverse=True)[:limit]
+    ]
+
+
+# 取原始 message-level dense 命中并映射回 turn。
+def _dense_message_candidates(
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    store: AkashaStore,
+    model: str,
+    source_cursor: sqlite3.Cursor | None,
+    *,
+    limit: int,
+) -> list[AkashaCandidate]:
+    # 1. Dense 展示贴合原始 CLI：先命中 message，再折回 turn key。
+    rows = store.list_cached_embeddings(model=model)
+    if not rows or source_cursor is None:
+        return _dense_candidates(query_vec, nodes, limit=limit)
+
+    # 2. 对缓存向量做余弦排序，过滤掉尚未 replay 成节点的消息。
+    query_norm = _normalize(query_vec)
+    scored: list[tuple[str, float]] = []
+    for message_id, embedding in rows:
+        if embedding.size != query_norm.size:
+            continue
+        score = float(np.dot(_normalize(embedding), query_norm))
+        scored.append((message_id, score))
+
+    # 3. 同一个 turn 只保留最高分，避免 user/assistant 重复占位。
+    candidates: list[AkashaCandidate] = []
+    seen: set[str] = set()
+    for message_id, score in sorted(scored, key=lambda item: item[1], reverse=True):
+        key = _message_id_to_turn_key(source_cursor, message_id)
+        if key is None or key not in nodes or key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            AkashaCandidate(
+                key=key,
+                source="Dense",
+                ripple=0.0,
+                direct=score,
+                state=0.0,
+                edge=0.0,
+                long=0.0,
+                resource=1.0,
+                fan=0,
+                score=score,
+            )
+        )
+        if len(candidates) >= limit:
+            break
+    return candidates
+
+
+# 计算 Ripple 联想候选。
+def _compute_candidates(
+    query: str,
+    query_vec: np.ndarray,
+    nodes: dict[str, AkashaNode],
+    edges: dict[tuple[str, str], float],
+    seq: int,
+    *,
+    config: AkashaConfig,
+    fan: dict[str, int],
+    source_cursor: sqlite3.Cursor | None = None,
+    edges_by_src: dict[str, dict[str, float]] | None = None,
+    soft_recall: bool = False,
+    return_limit: int | None = None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate], ActivationTrace]:
+    # 1. 先用 Dense/FTS/BlackHole 三路选 seed。
+    if not nodes:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+    direct_scores = _dense_scores(query_vec, nodes)
+    seed_sources, seed_energy = _seed_pool(
+        query,
+        direct_scores,
+        nodes,
+        config,
+        source_cursor,
+    )
+    if not seed_sources:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+
+    # 2. 只在 seed 附近构建微型图，避免全图扩散噪音。
+    micro_keys = set(seed_sources)
+    for seed_key in seed_sources:
+        seed_ts = nodes[seed_key].first_ts_unix
+        for key, node in nodes.items():
+            if key in micro_keys:
+                continue
+            is_near = abs(node.first_ts_unix - seed_ts) <= config.nearby_time_seconds
+            if is_near and direct_scores.get(key, 0.0) > config.nearby_dense_threshold:
+                micro_keys.add(key)
+    valid_keys = list(micro_keys)
+    if not valid_keys:
+        return [], [], ActivationTrace(seed_count=0, pool_count=0)
+
+    # 3. 构建状态调制转移矩阵，并执行两轮 RWR 扩散。
+    index_by_key = {key: index for index, key in enumerate(valid_keys)}
+    embeddings = np.vstack([nodes[key].embedding for key in valid_keys])
+    sim_matrix = np.maximum(np.dot(embeddings, embeddings.T), 0.0)
+    np.fill_diagonal(sim_matrix, 0.0)
+    state_arr = _state_array(valid_keys, nodes, fan, seq)
+    cross_matrix = _cross_matrix(valid_keys, edges, index_by_key, edges_by_src)
+    transition = sim_matrix * state_arr[:, np.newaxis]
+    transition *= 1.0 + config.cross_boost * cross_matrix
+    transition = _keep_top_edges_per_column(transition, top_k=12)
+    transition = _normalize_columns(transition)
+    e0 = _initial_energy(valid_keys, seed_energy, fan, index_by_key)
+    te0 = np.dot(transition, e0)
+    current = e0.copy()
+    for _ in range(2):
+        current = 0.8 * np.dot(transition, current) + 0.2 * e0
+
+    # 4. 回溯路径并计算最终分数。
+    path_info = _path_info(valid_keys, transition, e0, te0)
+    candidates, suppressed = _score_candidates(
+        valid_keys,
+        nodes,
+        direct_scores,
+        seed_sources,
+        current,
+        state_arr,
+        cross_matrix,
+        fan,
+        seq,
+        path_info,
+        config,
+        source_cursor,
+        soft_recall=soft_recall,
+        return_limit=return_limit,
+    )
+    return candidates, suppressed, ActivationTrace(
+        seed_count=len(seed_sources),
+        pool_count=len(valid_keys),
+    )
+
+
+# 选择 Ripple 的语义 seed。
+def _seed_pool(
+    query: str,
+    direct_scores: dict[str, float],
+    nodes: dict[str, AkashaNode],
+    config: AkashaConfig,
+    source_cursor: sqlite3.Cursor | None,
+) -> tuple[dict[str, str], dict[str, float]]:
+    # 1. 优先选择高置信 dense seed，缺失时回退 dense top-k。
+    ranked = sorted(direct_scores.items(), key=lambda item: item[1], reverse=True)
+    seed_sources: dict[str, str] = {}
+    seed_energy: dict[str, float] = {}
+    for key, score in ranked[: min(100, len(ranked))]:
+        if score > config.dense_seed_threshold:
+            seed_sources[key] = "Dense"
+            seed_energy[key] = 1.0
+    if not seed_sources:
+        for key, _ in ranked[: config.dense_top_k]:
+            seed_sources[key] = "Dense(FB)"
+            seed_energy[key] = 1.0
+
+    # 2. FTS seed 从原始 messages_fts 映射回 turn key。
+    if source_cursor is not None:
+        fts_query = _get_jieba_keywords(query)
+        if fts_query:
+            _ = source_cursor.execute(
+                """
+                SELECT rowid
+                FROM messages_fts
+                WHERE content MATCH ?
+                LIMIT 10
+                """,
+                (fts_query,),
+            )
+            rowids = [int(row[0]) for row in source_cursor.fetchall()]
+            if rowids:
+                placeholders = ",".join("?" for _ in rowids)
+                _ = source_cursor.execute(
+                    f"""
+                    SELECT session_key, seq, role
+                    FROM messages
+                    WHERE rowid IN ({placeholders})
+                    """,
+                    rowids,
+                )
+                for session_key, seq, role in source_cursor.fetchall():
+                    _, _, key = turn_key(str(session_key), int(seq), str(role or ""))
+                    if key not in nodes:
+                        continue
+                    if key not in seed_sources:
+                        seed_sources[key] = "FTS"
+                    elif "FTS" not in seed_sources[key].split("+"):
+                        seed_sources[key] += "+FTS"
+                    seed_energy[key] = 1.0
+
+    # 3. BlackHole 保留高 salience 且语义相近的少量节点。
+    blackhole_hits: list[tuple[str, float]] = []
+    for key, node in nodes.items():
+        if node.salience <= 0.8 or key in seed_sources:
+            continue
+        score = direct_scores.get(key, 0.0)
+        if score > 0.60:
+            blackhole_hits.append((key, score))
+    for key, _ in sorted(blackhole_hits, key=lambda item: item[1], reverse=True)[:5]:
+        seed_sources[key] = "BlackHole"
+        seed_energy[key] = 1.0
+    return seed_sources, seed_energy
+
+
+# 计算节点状态权重。
+def _state_array(
+    keys: list[str],
+    nodes: dict[str, AkashaNode],
+    fan: dict[str, int],
+    seq: int,
+) -> np.ndarray:
+    # 1. 状态权重包含显著度、长期强度、短期资源和 fan 惩罚。
+    values = np.zeros(len(keys), dtype=np.float32)
+    for index, key in enumerate(keys):
+        node = nodes[key]
+        long_score = min(1.0, _decayed_strength(node, seq) / _STRENGTH_CAP)
+        resource = _recover_resource(node, seq)
+        values[index] = (
+            math.exp(1.4 * node.salience + 1.0 * long_score)
+            * resource
+            / math.sqrt(1.0 + fan.get(key, 0))
+        )
+    return values
+
+
+# 构建共激活边矩阵。
+def _cross_matrix(
+    keys: list[str],
+    edges: dict[tuple[str, str], float],
+    index_by_key: dict[str, int],
+    edges_by_src: dict[str, dict[str, float]] | None = None,
+) -> np.ndarray:
+    # 1. 只把微型图内部的边投影进矩阵。
+    matrix = np.zeros((len(keys), len(keys)), dtype=np.float32)
+    if edges_by_src is not None:
+        for src_key in keys:
+            src_index = index_by_key[src_key]
+            for dst_key, weight in edges_by_src.get(src_key, {}).items():
+                dst_index = index_by_key.get(dst_key)
+                if dst_index is not None:
+                    matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+        return matrix
+
+    # 2. 没有 src 索引时扫描边表。
+    for (src_key, dst_key), weight in edges.items():
+        src_index = index_by_key.get(src_key)
+        dst_index = index_by_key.get(dst_key)
+        if src_index is not None and dst_index is not None:
+            matrix[dst_index, src_index] = max(matrix[dst_index, src_index], weight)
+    return matrix
+
+
+# 每列只保留最强的若干条边。
+def _keep_top_edges_per_column(matrix: np.ndarray, *, top_k: int) -> np.ndarray:
+    # 1. 这个稀疏化来自 cross CLI，避免微型图变成全连接噪音。
+    if len(matrix) <= top_k:
+        return matrix
+    kth = np.partition(matrix, -top_k, axis=0)[-top_k]
+    return np.where(matrix >= kth[np.newaxis, :], matrix, 0.0)
+
+
+# 对转移矩阵按列归一化。
+def _normalize_columns(matrix: np.ndarray) -> np.ndarray:
+    # 1. 空列用极小值防止除零。
+    sums = matrix.sum(axis=0)
+    sums[sums == 0] = 1e-10
+    return matrix / sums
+
+
+# 构造 RWR 初始能量。
+def _initial_energy(
+    keys: list[str],
+    seed_energy: dict[str, float],
+    fan: dict[str, int],
+    index_by_key: dict[str, int],
+) -> np.ndarray:
+    # 1. seed 能量按 fan 惩罚后再归一化。
+    energy = np.zeros(len(keys), dtype=np.float32)
+    for key, value in seed_energy.items():
+        index = index_by_key.get(key)
+        if index is not None:
+            energy[index] = value / math.sqrt(1.0 + fan.get(key, 0))
+    total = float(energy.sum())
+    return energy / total if total > 0 else energy
+
+
+# 回溯每个候选主要能量路径。
+def _path_info(
+    keys: list[str],
+    transition: np.ndarray,
+    e0: np.ndarray,
+    te0: np.ndarray,
+) -> dict[str, tuple[str, str, str, float]]:
+    # 1. 区分 direct / 1hop / 2hop，用于后续跳数惩罚和提示诊断。
+    result: dict[str, tuple[str, str, str, float]] = {}
+    seed_indices = np.where(e0 > 0)[0]
+    for index, key in enumerate(keys):
+        c0 = float(0.2 * e0[index])
+        c1_vec = 0.16 * transition[index, :] * e0
+        s1 = int(np.argmax(c1_vec))
+        c1 = float(c1_vec[s1])
+        c2_vec = 0.64 * transition[index, :] * te0
+        c2_vec[index] = 0.0
+        c2_vec[seed_indices] = 0.0
+        bridge = int(np.argmax(c2_vec))
+        c2 = float(c2_vec[bridge])
+        s2 = int(np.argmax(transition[bridge, :] * e0))
+        if c0 >= c1 and c0 >= c2:
+            result[key] = ("direct", "", "", c0)
+        elif c1 >= c2:
+            result[key] = ("1hop", keys[s1], "", c1)
+        else:
+            result[key] = ("2hop", keys[s2], keys[bridge], c2)
+    return result
+
+
+# 计算最终 Ripple 分数。
+def _score_candidates(
+    keys: list[str],
+    nodes: dict[str, AkashaNode],
+    direct_scores: dict[str, float],
+    seed_sources: dict[str, str],
+    current: np.ndarray,
+    state_arr: np.ndarray,
+    cross_matrix: np.ndarray,
+    fan: dict[str, int],
+    seq: int,
+    path_info: dict[str, tuple[str, str, str, float]],
+    config: AkashaConfig,
+    source_cursor: sqlite3.Cursor | None,
+    *,
+    soft_recall: bool,
+    return_limit: int | None,
+) -> tuple[list[AkashaCandidate], list[AkashaCandidate]]:
+    # 1. 先为微型图内每个节点计算完整分数。
+    all_candidates: dict[str, AkashaCandidate] = {}
+    max_state = max(float(np.max(state_arr)), 1e-10)
+    for index, key in enumerate(keys):
+        node = nodes[key]
+        long_score = min(1.0, _decayed_strength(node, seq) / _STRENGTH_CAP)
+        resource = _recover_resource(node, seq)
+        fan_value = fan.get(key, 0)
+        direct_value = max(0.0, direct_scores.get(key, 0.0))
+        state_value = min(1.0, float(state_arr[index]) / max_state)
+        edge_value = float(np.max(cross_matrix[index])) if len(keys) else 0.0
+        path_type, seed_key, bridge_key, path_value = path_info.get(key, ("direct", "", "", 0.0))
+        hop_penalty = {"direct": 1.0, "1hop": 0.86, "2hop": 0.62}.get(path_type, 0.62)
+        source = seed_sources.get(key, "Expanded")
+        direct_weight = 0.50 if source != "Expanded" else 0.18
+        fan_penalty = math.pow(1.0 + fan_value, _FAN_PENALTY_POWER)
+        user_penalty = 1.0 if _has_user_turn(source_cursor, key) else _ASSISTANT_ONLY_PENALTY
+        score = (
+            float(current[index]) * 3.0 * state_value
+            + direct_weight * direct_value
+            + 0.18 * long_score
+            + 0.12 * node.salience
+            + 0.20 * min(1.0, edge_value)
+        ) * resource * hop_penalty * user_penalty / fan_penalty
+        if source == "Expanded" and path_type == "1hop" and direct_value >= _EXPANDED_DIRECT_FLOOR:
+            score = max(score, config.activation_threshold + 0.01)
+        all_candidates[key] = AkashaCandidate(
+            key=key,
+            source=source,
+            ripple=float(current[index]),
+            direct=direct_value,
+            state=state_value,
+            edge=edge_value,
+            long=long_score,
+            resource=resource,
+            fan=fan_value,
+            score=score,
+            path_type=path_type,
+            seed_key=seed_key,
+            bridge_key=bridge_key,
+            path_value=path_value,
+        )
+
+    # 2. 原始算法会把 2-hop child 的中间节点提升成 Bridge 候选。
+    for child in list(all_candidates.values()):
+        if child.path_type != "2hop" or not child.bridge_key:
+            continue
+        bridge = all_candidates.get(child.bridge_key)
+        if bridge is None or not _has_user_turn(source_cursor, bridge.key):
+            continue
+        bridge_score = max(
+            bridge.score,
+            child.score * 0.62,
+            bridge.direct * 0.24 + bridge.state * 0.08,
+        )
+        all_candidates[bridge.key] = AkashaCandidate(
+            key=bridge.key,
+            source="Bridge",
+            ripple=bridge.ripple,
+            direct=bridge.direct,
+            state=bridge.state,
+            edge=bridge.edge,
+            long=bridge.long,
+            resource=bridge.resource,
+            fan=bridge.fan,
+            score=bridge_score,
+            path_type="bridge",
+            seed_key=child.seed_key,
+            bridge_key="",
+            path_value=max(bridge.path_value, child.path_value),
+        )
+
+    # 3. 写状态默认只接受硬阈值；展示查询可以追加 soft recall。
+    candidates: list[AkashaCandidate] = []
+    suppressed: list[AkashaCandidate] = []
+    for candidate in all_candidates.values():
+        soft_hit = (
+            soft_recall
+            and candidate.score >= config.soft_recall_threshold
+            and candidate.direct >= config.soft_recall_direct_floor
+            and candidate.source in {"Bridge", "Expanded"}
+            and candidate.path_type in {"bridge", "1hop", "2hop"}
+        )
+        if candidate.score >= config.activation_threshold or soft_hit:
+            if soft_hit and candidate.score < config.activation_threshold:
+                candidate = AkashaCandidate(
+                    key=candidate.key,
+                    source=candidate.source,
+                    ripple=candidate.ripple,
+                    direct=candidate.direct,
+                    state=candidate.state,
+                    edge=candidate.edge,
+                    long=candidate.long,
+                    resource=candidate.resource,
+                    fan=candidate.fan,
+                    score=candidate.score,
+                    suppressed="soft-recall",
+                    path_type=candidate.path_type,
+                    seed_key=candidate.seed_key,
+                    bridge_key=candidate.bridge_key,
+                    path_value=candidate.path_value,
+                )
+            candidates.append(candidate)
+        else:
+            suppressed.append(
+                AkashaCandidate(
+                    key=candidate.key,
+                    source=candidate.source,
+                    ripple=candidate.ripple,
+                    direct=candidate.direct,
+                    state=candidate.state,
+                    edge=candidate.edge,
+                    long=candidate.long,
+                    resource=candidate.resource,
+                    fan=candidate.fan,
+                    score=candidate.score,
+                    suppressed="below-threshold",
+                    path_type=candidate.path_type,
+                    seed_key=candidate.seed_key,
+                    bridge_key=candidate.bridge_key,
+                    path_value=candidate.path_value,
+                )
+            )
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    suppressed.sort(key=lambda item: item.score, reverse=True)
+    limit = return_limit or config.activate_limit
+    return candidates[:limit], suppressed[:limit]
+
+
+# 生成旧节点状态更新。
+def _activation_updates(
+    items: list[AkashaCandidate],
+    nodes: dict[str, AkashaNode],
+    seq: int,
+) -> list[ActivationUpdate]:
+    # 1. 被激活节点执行长期强度巩固和短期资源消耗。
+    updates: list[ActivationUpdate] = []
+    for item in items:
+        node = nodes.get(item.key)
+        if node is None:
+            continue
+        strength = _decayed_strength(node, seq)
+        strength = _bounded_add(strength, _STRENGTH_LR * item.score, _STRENGTH_CAP)
+        resource = _recover_resource(node, seq)
+        resource *= max(0.05, 1.0 - _RESOURCE_USE_RATE * min(1.0, item.score))
+        updates.append(
+            ActivationUpdate(
+                key=item.key,
+                strength=strength,
+                resource=resource,
+                recall_count=node.recall_count + 1,
+                seq=seq,
+            )
+        )
+    return updates
+
+
+# 计算短期资源恢复。
+def _recover_resource(node: AkashaNode, seq: int) -> float:
+    # 1. 距离上次激活越久，resource 越接近 1。
+    gap = max(0, seq - node.last_resource_seq)
+    return 1.0 - (1.0 - node.resource) * math.exp(-gap / _RESOURCE_RECOVER_TAU)
+
+
+# 计算长期强度衰减。
+def _decayed_strength(node: AkashaNode, seq: int) -> float:
+    # 1. strength 是历史激活强度，随消息序号差缓慢衰减。
+    gap = max(0, seq - node.last_strength_seq)
+    return node.strength * math.exp(-gap / _LONG_DECAY_TAU)
+
+
+# 有界增加状态值。
+def _bounded_add(value: float, delta: float, cap: float) -> float:
+    # 1. 越接近 cap，新增越慢。
+    return value + delta * max(0.0, 1.0 - value / cap)
+
+
+# 从 message id 映射到原始 turn key。
+def _message_id_to_turn_key(
+    cursor: sqlite3.Cursor,
+    message_id: str,
+) -> str | None:
+    # 1. Dense 命中的是 message，展示和去重都回到 user turn。
+    _ = cursor.execute(
+        "SELECT session_key, seq, role FROM messages WHERE id = ? LIMIT 1",
+        (message_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    _, _, key = turn_key(str(row[0]), int(row[1]), str(row[2] or ""))
+    return key
+
+
+# 把 query 切成 SQLite FTS 可用的搜索词。
+def _get_jieba_keywords(text: str) -> str:
+    # 1. 和原始 cross CLI 一样使用 jieba 的 search mode。
+    import jieba
+
+    cut_for_search = cast(Callable[[str], Iterable[str]], getattr(jieba, "cut_for_search"))
+    words: list[str] = []
+    for word in cut_for_search(text):
+        cleaned = "".join(
+            char
+            for char in word.strip()
+            if char.isalnum() or "\u4e00" <= char <= "\u9fff"
+        )
+        if len(cleaned) > 1:
+            words.append(f'"{cleaned}"')
+    return " OR ".join(words[:20])
+
+
+# 判断 turn key 是否有 user anchor。
+def _has_user_turn(cursor: sqlite3.Cursor | None, key: str) -> bool:
+    # 1. 有 source cursor 时贴合原始 DB 检查；没有时保留节点级语义。
+    if cursor is None:
+        return True
+    parsed = _parse_turn_key(key)
+    if parsed is None:
+        return False
+    session_key, seq = parsed
+    _ = cursor.execute(
+        """
+        SELECT 1
+        FROM messages
+        WHERE session_key = ? AND seq = ? AND role = 'user'
+        LIMIT 1
+        """,
+        (session_key, seq),
+    )
+    return cursor.fetchone() is not None
+
+
+# 归一化向量。
+def _normalize(vector: np.ndarray) -> np.ndarray:
+    # 1. 所有相似度都基于单位向量。
+    norm = float(np.linalg.norm(vector))
+    return vector / norm if norm > 0 else vector
+
+
+# 获取当前 query 对应的预测 seq。
+def _current_query_seq(
+    session_db_path: Path,
+    scope: MemoryScope,
+) -> int:
+    # 1. before-turn 检索时 user 尚未持久化，因此使用 sessions.db 当前 next seq。
+    if not scope.session_key or not session_db_path.exists():
+        return 0
+    with closing(sqlite3.connect(str(session_db_path))) as db:
+        row = db.execute(
+            "SELECT COALESCE(MAX(seq) + 1, 0) FROM messages WHERE session_key = ?",
+            (scope.session_key,),
+        ).fetchone()
+    return int(row[0] if row else 0)
+
+
+# 从 sessions.db 反查 after-turn 已经持久化的本轮消息。
+def _load_committed_turn_messages(
+    session_db_path: Path,
+    event: TurnCommitted,
+) -> list[SourceMessage]:
+    # 1. after-turn 发生在 append_messages 后，这里用内容和相邻 seq 反查稳定 id。
+    if not session_db_path.exists() or not (event.persisted_user_message or event.input_message):
+        return []
+    user_text = event.persisted_user_message or event.input_message
+    with closing(sqlite3.connect(str(session_db_path))) as db:
+        db.row_factory = sqlite3.Row
+        row = db.execute(
+            """
+            SELECT
+                u.id AS user_id, u.session_key AS session_key, u.seq AS user_seq,
+                u.content AS user_content, u.ts AS user_ts,
+                a.id AS assistant_id, a.seq AS assistant_seq,
+                a.content AS assistant_content, a.ts AS assistant_ts
+            FROM messages u
+            LEFT JOIN messages a
+                ON a.session_key = u.session_key
+               AND a.seq = u.seq + 1
+               AND a.role = 'assistant'
+               AND a.content = ?
+            WHERE u.session_key = ?
+              AND u.role = 'user'
+              AND u.content = ?
+            ORDER BY u.seq DESC
+            LIMIT 1
+            """,
+            (event.assistant_response, event.session_key, user_text),
+        ).fetchone()
+    if row is None:
+        return []
+    messages = [
+        SourceMessage(
+            id=str(row["user_id"]),
+            session_key=str(row["session_key"]),
+            seq=int(row["user_seq"]),
+            role="user",
+            content=str(row["user_content"] or ""),
+            ts=str(row["user_ts"] or ""),
+        )
+    ]
+    if row["assistant_id"] is not None:
+        messages.append(
+            SourceMessage(
+                id=str(row["assistant_id"]),
+                session_key=str(row["session_key"]),
+                seq=int(row["assistant_seq"]),
+                role="assistant",
+                content=str(row["assistant_content"] or ""),
+                ts=str(row["assistant_ts"] or ""),
+            )
+        )
+    return messages
+
+
+# 从 sessions.db 读取 turn card。
+def _load_turn_card(
+    session_db_path: Path,
+    key: str,
+    *,
+    assistant_preview_chars: int,
+    score: float,
+    lane: str,
+    signals: dict[str, object],
+) -> AkashaCard | None:
+    # 1. 用 turn key 回源到 messages 表，user 全量、assistant 截断。
+    parsed = _parse_turn_key(key)
+    if parsed is None or not session_db_path.exists():
+        return None
+    session_key, seq = parsed
+    with closing(sqlite3.connect(str(session_db_path))) as db:
+        db.row_factory = sqlite3.Row
+        user_row = db.execute(
+            """
+            SELECT id, content
+            FROM messages
+            WHERE session_key = ? AND seq = ? AND role = 'user'
+            """,
+            (session_key, seq),
+        ).fetchone()
+        assistant_row = db.execute(
+            """
+            SELECT id, content
+            FROM messages
+            WHERE session_key = ? AND seq = ? AND role = 'assistant'
+            """,
+            (session_key, seq + 1),
+        ).fetchone()
+    if user_row is None and assistant_row is None:
+        return None
+    source_ids = [
+        str(row["id"])
+        for row in (user_row, assistant_row)
+        if row is not None and str(row["id"]).strip()
+    ]
+    assistant_text = str(assistant_row["content"] or "") if assistant_row is not None else ""
+    user_text = str(user_row["content"] or "") if user_row is not None else ""
+    return AkashaCard(
+        key=key,
+        source_ref=json.dumps(source_ids, ensure_ascii=False),
+        user_message=user_text,
+        assistant_preview=_clip_assistant(assistant_text, assistant_preview_chars),
+        score=score,
+        lane=lane,
+        signals=signals,
+    )
+
+
+# 解析 turn key。
+def _parse_turn_key(key: str) -> tuple[str, int] | None:
+    # 1. session_key 自身可能含冒号，因此只从右侧切 seq。
+    left, sep, right = key.rpartition(":")
+    if not sep:
+        return None
+    try:
+        return left, int(right)
+    except ValueError:
+        return None
+
+
+# 截断 assistant 预览。
+def _clip_assistant(text: str, limit: int) -> str:
+    # 1. assistant 只作为 disambiguation，不能替代 fetch 原文。
+    clean = " ".join(text.split())
+    limit = max(0, int(limit))
+    if limit <= 0 or len(clean) <= limit:
+        return clean
+    return clean[:limit].rstrip() + "..."
+
+
+# 格式化一个记忆块。
+def _format_cards(title: str, cards: list[AkashaCard]) -> str:
+    # 1. 每条 card 都带 source_ref，agent 需要事实时可继续 fetch_messages。
+    lines = [title]
+    for card in cards:
+        user_text = json.dumps(" ".join(card.user_message.split()), ensure_ascii=False)
+        assistant_text = json.dumps(
+            " ".join(card.assistant_preview.split()),
+            ensure_ascii=False,
+        )
+        lines.append(
+            f"- user={user_text} assistant={assistant_text} "
+            f"score={card.score:.4f} source_ref={card.source_ref}"
+        )
+    return "\n".join(lines)
+
+
+# 把 card 转成 MemoryRecord。
+def _card_to_record(card: AkashaCard, *, injected: bool) -> MemoryRecord:
+    # 1. summary 是展示 card，不是事实摘要；证据仍然指向 source_ref。
+    summary = f"user_message: {card.user_message}"
+    if card.assistant_preview:
+        summary += f"\nassistant_message: {card.assistant_preview}"
+    return MemoryRecord(
+        id=card.key,
+        kind="turn",
+        summary=summary,
+        score=card.score,
+        engine_kind="akasha",
+        evidence=[
+            EvidenceRef(
+                kind="message_range",
+                refs=_source_ref_ids(card.source_ref),
+                resolver="session",
+                source_ref=card.source_ref,
+            )
+        ],
+        signals=card.signals,
+        injected=injected,
+    )
+
+
+# 把 card 转成 raw item。
+def _card_to_raw(card: AkashaCard) -> dict[str, object]:
+    # 1. raw item 兼容 recall_memory 和 dashboard 里的通用命名。
+    return {
+        "id": card.key,
+        "memory_type": "turn",
+        "summary": f"user_message: {card.user_message}",
+        "score": card.score,
+        "source_ref": card.source_ref,
+        "extra_json": card.signals,
+    }
+
+
+# 从 source_ref JSON 数组中取消息 id。
+def _source_ref_ids(source_ref: str) -> list[str]:
+    # 1. source_ref 始终由 Akasha 生成，解析失败时回退空列表。
+    try:
+        value = cast(object, json.loads(source_ref))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(value, list):
+        return []
+    items = cast(list[object], value)
+    return [str(item) for item in items if str(item).strip()]
+
+
+# 把 candidate 信号放进 record。
+def _candidate_signals(item: AkashaCandidate) -> dict[str, object]:
+    # 1. signals 只用于诊断，不参与事实判断。
+    return {
+        "lane": "akasha",
+        "source": item.source,
+        "ripple": item.ripple,
+        "direct": item.direct,
+        "state": item.state,
+        "edge": item.edge,
+        "long": item.long,
+        "resource": item.resource,
+        "fan": item.fan,
+        "path_type": item.path_type,
+        "seed_key": item.seed_key,
+        "bridge_key": item.bridge_key,
+        "path_value": item.path_value,
+        "suppressed": item.suppressed,
+    }

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -12,6 +12,7 @@ import hashlib
 import math
 import sqlite3
 import threading
+import time
 from contextlib import closing
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -81,7 +82,8 @@ class AkashaCard:
 @dataclass(frozen=True)
 class PendingActivation:
     query_id: str
-    seq: int
+    seq: int          # 仅作 query_log 标识用
+    ts: float         # 用于 EdgeUpdate / last_used_ts
     items: list[AkashaCandidate]
 
 
@@ -485,6 +487,7 @@ class AkashaMemoryEngine:
         # 1. 准备内存图和当前查询所在的预测 seq。
         nodes, fan, edges_by_src, message_embeddings, message_turn_keys = self._graph_snapshot()
         seq = _current_query_seq(self._session_db_path, request.scope)
+        now_ts = time.time()
         source_db = (
             sqlite3.connect(str(self._session_db_path))
             if self._session_db_path.exists()
@@ -507,7 +510,7 @@ class AkashaMemoryEngine:
                 query_vec,
                 nodes,
                 {},
-                seq,
+                now_ts,
                 config=self._akasha_config,
                 fan=fan,
                 source_cursor=source_cursor,
@@ -524,7 +527,7 @@ class AkashaMemoryEngine:
                 query_vec,
                 nodes,
                 {},
-                seq,
+                now_ts,
                 config=self._akasha_config,
                 fan=fan,
                 source_cursor=source_cursor,
@@ -538,7 +541,7 @@ class AkashaMemoryEngine:
                 source_db.close()
 
         # 3. 查询阶段只更新旧节点状态，当前 turn 的边等 after-turn 再补。
-        updates = _activation_updates(activation_items, nodes, seq)
+        updates = _activation_updates(activation_items, nodes, now_ts)
         self._store.update_activation_batch(updates)
         self._apply_activation_updates(updates)
         return _AkashaRetrieval(
@@ -562,6 +565,7 @@ class AkashaMemoryEngine:
         self._pending_by_session[request.scope.session_key] = PendingActivation(
             query_id=f"{request.scope.session_key}:{seq}",
             seq=seq,
+            ts=time.time(),
             items=list(items),
         )
 
@@ -603,8 +607,8 @@ class AkashaMemoryEngine:
         edge_updates: list[EdgeUpdate] = []
         for item in pending.items:
             edge_strength = key_to_score.get(item.key, 1.0)
-            edge_updates.append(EdgeUpdate(current_key, item.key, edge_strength, pending.seq))
-            edge_updates.append(EdgeUpdate(item.key, current_key, edge_strength, pending.seq))
+            edge_updates.append(EdgeUpdate(current_key, item.key, edge_strength, pending.ts))
+            edge_updates.append(EdgeUpdate(item.key, current_key, edge_strength, pending.ts))
 
         # 2. 同轮共同激活的旧节点互连，保持 cross CLI 的共激活语义。
         for left_index, left in enumerate(pending.items):
@@ -612,8 +616,8 @@ class AkashaMemoryEngine:
                 edge_strength = math.sqrt(
                     key_to_score.get(left.key, 1.0) * key_to_score.get(right.key, 1.0)
                 )
-                edge_updates.append(EdgeUpdate(left.key, right.key, edge_strength, pending.seq))
-                edge_updates.append(EdgeUpdate(right.key, left.key, edge_strength, pending.seq))
+                edge_updates.append(EdgeUpdate(left.key, right.key, edge_strength, pending.ts))
+                edge_updates.append(EdgeUpdate(right.key, left.key, edge_strength, pending.ts))
         self._store.upsert_edges(edge_updates)
         self._apply_edge_updates(edge_updates)
 
@@ -693,9 +697,9 @@ class AkashaMemoryEngine:
                     strength=item.strength,
                     resource=item.resource,
                     recall_count=item.recall_count,
-                    last_activated_seq=item.seq,
-                    last_strength_seq=item.seq,
-                    last_resource_seq=item.seq,
+                    last_activated_ts=item.ts,
+                    last_strength_ts=item.ts,
+                    last_resource_ts=item.ts,
                 )
 
     # 把新写入或合并的节点同步进内存图。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import math
 import sqlite3
 from collections.abc import Callable, Iterable
@@ -236,6 +237,7 @@ class AkashaMemoryEngine:
             limit=dense_limit,
         )
         dense_keys = {card.key for card in dense_cards}
+        dense_pairs = {_card_dedupe_key(card) for card in dense_cards}
         ripple_cards = self._cards_from_keys(
             [
                 (item.key, item.score, "ripple", _candidate_signals(item))
@@ -243,6 +245,7 @@ class AkashaMemoryEngine:
                 if item.key not in dense_keys
             ],
             limit=ripple_limit,
+            skip_pairs=dense_pairs,
         )
         text_block = (
             self._format_context_block(dense_cards, ripple_cards)
@@ -250,6 +253,18 @@ class AkashaMemoryEngine:
             else ""
         )
         cards = [*dense_cards, *ripple_cards]
+
+        # 5. 记录检索诊断日志（context/answer intent 才有意义）。
+        if request.intent in {"context", "answer"} and request.scope.session_key:
+            self._write_query_log(
+                request=request,
+                result=result,
+                seq=result.seq,
+                dense_cards=dense_cards,
+                ripple_cards=ripple_cards,
+                text_block=text_block,
+            )
+
         return MemoryQueryResult(
             text_block=text_block,
             records=[_card_to_record(card, injected=bool(text_block)) for card in cards],
@@ -572,14 +587,16 @@ class AkashaMemoryEngine:
         items: list[tuple[str, float, str, dict[str, object]]],
         *,
         limit: int,
+        skip_pairs: set[tuple[str, str]] | None = None,
     ) -> list[AkashaCard]:
         # 1. 每个 card 的正文都回 sessions.db 取，sidecar 不充当事实来源。
         cards: list[AkashaCard] = []
-        seen: set[str] = set()
+        seen_keys: set[str] = set()
+        seen_pairs = set(skip_pairs or set())
         for key, score, lane, signals in items:
-            if key in seen:
+            if key in seen_keys:
                 continue
-            seen.add(key)
+            seen_keys.add(key)
             card = _load_turn_card(
                 self._session_db_path,
                 key,
@@ -590,10 +607,121 @@ class AkashaMemoryEngine:
             )
             if card is None:
                 continue
+            pair_key = _card_dedupe_key(card)
+            if pair_key in seen_pairs:
+                continue
+            seen_pairs.add(pair_key)
             cards.append(card)
             if len(cards) >= limit:
                 break
         return cards
+
+    # 序列化并写入本次检索诊断日志。
+    def _write_query_log(
+        self,
+        *,
+        request: "MemoryQuery",
+        result: "_AkashaRetrieval",
+        seq: int,
+        dense_cards: list[AkashaCard],
+        ripple_cards: list[AkashaCard],
+        text_block: str,
+    ) -> None:
+        # 1. 收集 source_ref 去重统计。
+        all_source_refs: set[str] = set()
+        for card in dense_cards:
+            try:
+                for ref in json.loads(card.source_ref):
+                    all_source_refs.add(str(ref))
+            except Exception:
+                pass
+        for card in ripple_cards:
+            try:
+                for ref in json.loads(card.source_ref):
+                    all_source_refs.add(str(ref))
+            except Exception:
+                pass
+
+        # 2. 批量读取 activation_items 的消息内容，填充 user_message / assistant_preview。
+        session_db_path = getattr(self, "_session_db_path", None) or Path("")
+        activation_content = _load_messages_batch(
+            session_db_path,
+            [item.key for item in result.activation_items],
+            assistant_preview_chars=self._akasha_config.assistant_preview_chars,
+        )
+
+        def _candidate_to_dict(item: AkashaCandidate) -> dict[str, object]:
+            user_msg, asst_preview = activation_content.get(item.key, ("", ""))
+            return {
+                "key": item.key,
+                "user_message": user_msg,
+                "assistant_preview": asst_preview,
+                "score": item.score,
+                "source": item.source,
+                "path_type": item.path_type,
+                "fan": item.fan,
+                "direct": item.direct,
+                "state": item.state,
+                "edge": item.edge,
+                "long": item.long,
+                "resource": item.resource,
+                "ripple": item.ripple,
+                "seed_key": item.seed_key,
+                "bridge_key": item.bridge_key,
+                "suppressed": item.suppressed,
+            }
+
+        def _card_to_dict(card: AkashaCard) -> dict[str, object]:
+            d: dict[str, object] = {
+                "key": card.key,
+                "user_message": card.user_message,
+                "assistant_preview": card.assistant_preview,
+                "score": card.score,
+                "source_ref": card.source_ref,
+            }
+            d.update(card.signals)
+            return d
+
+        activation_items_json = json.dumps(
+            [_candidate_to_dict(item) for item in result.activation_items],
+            ensure_ascii=False,
+        )
+        dense_items_json = json.dumps(
+            [_card_to_dict(card) for card in dense_cards],
+            ensure_ascii=False,
+        )
+        ripple_items_json = json.dumps(
+            [_card_to_dict(card) for card in ripple_cards],
+            ensure_ascii=False,
+        )
+
+        # 3. text_block 截断到 500 chars 作为预览。
+        preview = text_block[:500].rstrip() + ("..." if len(text_block) > 500 else "")
+
+        store = getattr(self, "_store", None)
+        if store is None:
+            return
+        from datetime import datetime, timezone
+        store.insert_query_log(
+            query_id=_query_log_id(request.scope.session_key or "", seq, request.intent, request.text),
+            session_key=request.scope.session_key or "",
+            seq=seq,
+            query_text=request.text.strip(),
+            intent=request.intent,
+            ts=datetime.now(timezone.utc).isoformat(),
+            seed_count=result.trace.seed_count,
+            pool_count=result.trace.pool_count,
+            activated_count=len(result.activation_items),
+            activation_threshold=self._akasha_config.activation_threshold,
+            dense_count=len(dense_cards),
+            ripple_count=len(ripple_cards),
+            inject_chars=len(text_block),
+            source_ref_count=len(all_source_refs),
+            activation_items_json=activation_items_json,
+            dense_items_json=dense_items_json,
+            ripple_items_json=ripple_items_json,
+            text_block_preview=preview,
+        )
 
     # 格式化 agent 看到的 Dense/Ripple 双块。
     def _format_context_block(
@@ -1398,14 +1526,33 @@ def _clip_assistant(text: str, limit: int) -> str:
     return clean[:limit].rstrip() + "..."
 
 
+# 归一化文本，避免多空格造成同文候选无法去重。
+def _normalize_card_text(text: str) -> str:
+    # 1. prompt 单行展示和去重都使用相同的空白规则。
+    return " ".join(text.split()).strip()
+
+
+# 生成注入去重键，只压掉 user 和助手预览都相同的候选。
+def _card_dedupe_key(card: AkashaCard) -> tuple[str, str]:
+    # 1. 同一句历史消息可能在不同 turn 重复出现，展示时只保留最高分。
+    return _normalize_card_text(card.user_message), _normalize_card_text(card.assistant_preview)
+
+
+# 生成检索日志 ID，避免同一轮 context 和 recall_memory 互相覆盖。
+def _query_log_id(session_key: str, seq: int, intent: str, query_text: str) -> str:
+    # 1. 同一轮可能有预检索和显式 recall_memory，多条日志都要保留。
+    digest = hashlib.sha1(f"{intent}\n{query_text}".encode("utf-8")).hexdigest()[:10]
+    return f"{session_key}:{seq}:{intent}:{digest}"
+
+
 # 格式化一个记忆块。
 def _format_cards(title: str, cards: list[AkashaCard]) -> str:
     # 1. 每条 card 都带 source_ref，agent 需要事实时可继续 fetch_messages。
     lines = [title]
     for card in cards:
-        user_text = json.dumps(" ".join(card.user_message.split()), ensure_ascii=False)
+        user_text = json.dumps(_normalize_card_text(card.user_message), ensure_ascii=False)
         assistant_text = json.dumps(
-            " ".join(card.assistant_preview.split()),
+            _normalize_card_text(card.assistant_preview),
             ensure_ascii=False,
         )
         lines.append(
@@ -1453,6 +1600,62 @@ def _card_to_raw(card: AkashaCard) -> dict[str, object]:
     }
 
 
+# 批量从 sessions.db 读取多个 turn key 的消息内容，一次连接完成。
+def _load_messages_batch(
+    session_db_path: Path,
+    keys: list[str],
+    *,
+    assistant_preview_chars: int,
+) -> dict[str, tuple[str, str]]:
+    # 1. 解析所有 key，跳过无法解析的。
+    if not keys or not session_db_path.exists():
+        return {}
+    parsed: list[tuple[str, str, int]] = []
+    for key in keys:
+        result = _parse_turn_key(key)
+        if result is not None:
+            session_key, seq = result
+            parsed.append((key, session_key, seq))
+    if not parsed:
+        return {}
+
+    # 2. 一次性拉取 user seq 和 user_seq+1（assistant），避免每个 key 单独开连接。
+    seq_pairs: list[tuple[str, int]] = []
+    for _, sk, user_seq in parsed:
+        seq_pairs.append((sk, user_seq))
+        seq_pairs.append((sk, user_seq + 1))
+    placeholders = ",".join("(?,?)" for _ in seq_pairs)
+    flat_params: list[object] = [v for pair in seq_pairs for v in pair]
+    with closing(sqlite3.connect(str(session_db_path))) as db:
+        db.row_factory = sqlite3.Row
+        rows = db.execute(
+            f"""
+            SELECT session_key, seq, role, content
+            FROM messages
+            WHERE (session_key, seq) IN ({placeholders})
+              AND role IN ('user', 'assistant')
+            """,
+            flat_params,
+        ).fetchall()
+
+    # 3. 按 (session_key, seq) 分组成 {(sk, seq): {role: content}}。
+    by_turn: dict[tuple[str, int], dict[str, str]] = {}
+    for row in rows:
+        sk = str(row["session_key"])
+        seq_val = int(row["seq"])
+        role = str(row["role"])
+        content = str(row["content"] or "")
+        by_turn.setdefault((sk, seq_val), {})[role] = content
+
+    # 4. 为每个 key 映射 user_message / assistant_preview。
+    result_map: dict[str, tuple[str, str]] = {}
+    for key, sk, user_seq in parsed:
+        user_msg = by_turn.get((sk, user_seq), {}).get("user", "")
+        asst_raw = by_turn.get((sk, user_seq + 1), {}).get("assistant", "")
+        result_map[key] = (user_msg, _clip_assistant(asst_raw, assistant_preview_chars))
+    return result_map
+
+
 # 从 source_ref JSON 数组中取消息 id。
 def _source_ref_ids(source_ref: str) -> list[str]:
     # 1. source_ref 始终由 Akasha 生成，解析失败时回退空列表。
@@ -1485,3 +1688,4 @@ def _candidate_signals(item: AkashaCandidate) -> dict[str, object]:
         "path_value": item.path_value,
         "suppressed": item.suppressed,
     }
+

--- a/plugins/akasha/memory_plugin.py
+++ b/plugins/akasha/memory_plugin.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.config_models import Config
+from core.memory.plugin import MemoryPluginBuildDeps, MemoryPluginRuntime
+from plugins.akasha.config import (
+    ensure_akasha_config_file,
+    load_akasha_config,
+    resolve_akasha_db_path,
+)
+from plugins.akasha.engine import AkashaMemoryEngine
+
+
+class MemoryPlugin:
+    plugin_id = "akasha"
+
+    # 准备 Akasha sidecar 存储。
+    def ensure_workspace_storage(
+        self,
+        *,
+        config: Config,
+        workspace: Path,
+    ) -> list[tuple[Path, bool]]:
+        # 1. 确保插件配置存在，并按配置解析数据库路径。
+        _ = config
+        _ = ensure_akasha_config_file()
+        akasha_config = load_akasha_config()
+        db_path = resolve_akasha_db_path(
+            workspace=workspace,
+            akasha_config=akasha_config,
+        )
+        existed = db_path.exists()
+
+        # 2. 创建 schema 后返回给启动日志展示。
+        AkashaMemoryEngine.ensure_workspace_storage(
+            akasha_config=akasha_config,
+            workspace=workspace,
+        )
+        return [(db_path, existed)]
+
+    # 构造 Akasha memory runtime。
+    def build(
+        self,
+        deps: MemoryPluginBuildDeps,
+    ) -> MemoryPluginRuntime:
+        # 1. Akasha 是独立 memory engine，不继承 default_memory 的 store/retriever。
+        akasha_config = load_akasha_config()
+        engine = AkashaMemoryEngine(
+            config=deps.config,
+            akasha_config=akasha_config,
+            workspace=deps.workspace,
+            http_resources=deps.http_resources,
+            event_publisher=deps.event_publisher,
+        )
+        return MemoryPluginRuntime(
+            engine=engine,
+            closeables=list(engine.closeables),
+            admin=engine,
+        )

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+from agent.lifecycle.types import BeforeTurnCtx, TurnState
+from agent.plugins import Plugin
+from plugins.akasha.config import load_akasha_config, resolve_akasha_db_path
+from plugins.akasha.store import AkashaStore
+
+_CTX_SLOT = "session:ctx"
+_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+
+
+class AkashaLastCommandModule:
+    slot = "akasha.last_query"
+    requires = ("before_turn.acquire_session", "session:session")
+    produces = (_CTX_SLOT,)
+
+    def __init__(self, plugin: "AkashaPlugin") -> None:
+        self._plugin = plugin
+
+    async def run(self, frame: Any) -> Any:
+        if _CTX_SLOT in frame.slots:
+            return frame
+        state = cast(Any, frame.input)
+        command = _normalize_command(state.msg.content)
+        if command not in {"/akashalast", "/akasha_last"}:
+            return frame
+        if not self._plugin.is_active():
+            return frame
+        frame.slots[_CTX_SLOT] = _abort_ctx(
+            state,
+            self._plugin.render_last_query(state.session_key),
+        )
+        return frame
+
+
+class AkashaPlugin(Plugin):
+    name = "akasha"
+
+    def telegram_bot_commands(self) -> list[tuple[str, str]]:
+        if not self.is_active():
+            return []
+        return [("akashalast", "查看上一轮 Akasha 检索诊断")]
+
+    def before_turn_modules(self) -> list[object]:
+        if not self.is_active():
+            return []
+        return [AkashaLastCommandModule(self)]
+
+    def is_active(self) -> bool:
+        return _is_memory_engine(getattr(self.context, "memory_engine", None), "akasha")
+
+    def render_last_query(self, session_key: str) -> str:
+        workspace = self.context.workspace
+        if workspace is None:
+            return "Akasha 诊断不可用：workspace 不存在。"
+        store = AkashaStore(
+            resolve_akasha_db_path(
+                workspace=workspace,
+                akasha_config=load_akasha_config(plugin_dir=Path(__file__).resolve().parent),
+            )
+        )
+        try:
+            rows, _ = store.list_query_logs(
+                session_key=session_key,
+                page=1,
+                page_size=1,
+            )
+            if not rows:
+                return "暂无 Akasha 检索诊断记录。"
+            query_id = str(rows[0]["query_id"])
+            raw = store.get_query_log(query_id)
+        finally:
+            store.close()
+        if raw is None:
+            return "暂无 Akasha 检索诊断记录。"
+        return _render_query_detail(raw)
+
+
+def _render_query_detail(raw: dict[str, object]) -> str:
+    activation_items = _json_items(raw.get("activation_items_json"))
+    dense_items = _json_items(raw.get("dense_items_json"))
+    ripple_items = _json_items(raw.get("ripple_items_json"))
+    threshold = _float(raw.get("activation_threshold"))
+    lines = [
+        "🧠 Akasha 记忆检索诊断",
+        f"📍 会话: `{raw.get('session_key')}` | seq `{raw.get('seq')}`",
+        f"❓ 提问: {_clip(str(raw.get('query_text') or ''), 60)}",
+        f"🏷️ 意图: `{raw.get('intent')}` | 🕒 `{_format_ts(str(raw.get('ts') or ''))}`",
+        "",
+        "⚡ 图扩散状态 (Activation):",
+        f"• 种子节点 (Seeds): `{raw.get('seed_count')}` 个",
+        f"• 扩散范围 (Pool): `{raw.get('pool_count')}` 个",
+        (
+            f"• 实际激活 (Activated): `{raw.get('activated_count')}` 个"
+            f" | 门槛: `{threshold:.3f}`"
+        ),
+    ]
+    lines.extend(_render_activated_nodes(
+        activation_items,
+        threshold=threshold,
+        limit=8,
+    ))
+    lines.extend(_render_memory_items(
+        "🎯 左脑精确回忆 (Dense):",
+        "(最终注入大模型的左脑候选)",
+        dense_items,
+        show_signals=False,
+        show_path=False,
+        score_label="得",
+        limit=8,
+    ))
+    lines.extend(_render_memory_items(
+        "🌊 右脑联想记忆 (Ripple):",
+        "(最终注入大模型的右脑候选)",
+        ripple_items,
+        show_signals=True,
+        show_path=True,
+        score_label="得",
+        limit=8,
+    ))
+    return "\n".join(lines).strip()
+
+
+def _render_activated_nodes(
+    items: list[dict[str, object]],
+    *,
+    threshold: float,
+    limit: int,
+) -> list[str]:
+    lines = [
+        "",
+        "──────",
+        "🔥 本轮图激活节点 (Activated Nodes):",
+        f"(得分配分超过 `{threshold:.3f}`，执行状态更新并与本轮新节点建边的节点)",
+    ]
+    if not items:
+        lines.append("无")
+        return lines
+    for index, item in enumerate(items[:limit], start=1):
+        lines.extend(_render_item(
+            index,
+            item,
+            inline=False,
+            score_label="分",
+            show_path=True,
+            show_signals=False,
+        ))
+    if len(items) > limit:
+        lines.append(f"(后略，还有 `{len(items) - limit}` 条)")
+    return lines
+
+
+def _render_memory_items(
+    title: str,
+    subtitle: str,
+    items: list[dict[str, object]],
+    *,
+    show_signals: bool,
+    show_path: bool,
+    score_label: str,
+    limit: int,
+) -> list[str]:
+    lines = ["", "──────", title, subtitle]
+    if not items:
+        lines.append("无")
+        return lines
+    for index, item in enumerate(items[:limit], start=1):
+        lines.extend(_render_item(
+            index,
+            item,
+            inline=True,
+            score_label=score_label,
+            show_path=show_path,
+            show_signals=show_signals,
+        ))
+    if len(items) > limit:
+        lines.append(f"(后略，还有 `{len(items) - limit}` 条)")
+    return lines
+
+
+def _render_item(
+    index: int,
+    item: dict[str, object],
+    *,
+    inline: bool,
+    score_label: str,
+    show_path: bool,
+    show_signals: bool,
+) -> list[str]:
+    user_text = _clip(str(item.get("user_message") or item.get("summary") or ""), 32)
+    assistant = _clip(str(item.get("assistant_preview") or ""), 24)
+    score = _float(item.get("score"))
+    source = str(item.get("source") or item.get("lane") or "")
+    path = str(item.get("path_type") or "")
+    lines: list[str] = []
+    meta: list[str] = [f"{score_label}: `{score:.3f}`"]
+    if source:
+        meta.append(f"源: `{source}`")
+    if show_path and path:
+        meta.append(f"径: `{path}`")
+    if inline:
+        text = f"{_rank_label(index)} U: {user_text}"
+        if assistant:
+            text += f" ➔ A: {assistant}"
+        text += " | " + " | ".join(meta)
+        lines.append(text)
+    else:
+        lines.append(f"{_rank_label(index)} U: {user_text}")
+        if assistant:
+            lines.append(f"   A: {assistant}")
+        lines.append(" | ".join(meta))
+    if show_signals:
+        lines.append(
+            "因: "
+            f"`dir:{_float(item.get('direct')):.2f} "
+            f"st:{_float(item.get('state')):.2f} "
+            f"edg:{_float(item.get('edge')):.2f} "
+            f"res:{_float(item.get('resource')):.2f} "
+            f"fan:{int(_float(item.get('fan')))}"
+            "`"
+        )
+    return lines
+
+
+def _rank_label(index: int) -> str:
+    labels = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
+    if 1 <= index <= len(labels):
+        return labels[index - 1]
+    return f"{index}."
+
+
+def _json_items(value: object) -> list[dict[str, object]]:
+    try:
+        loaded = json.loads(str(value or "[]"))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [
+        cast(dict[str, object], item)
+        for item in cast(list[object], loaded)
+        if isinstance(item, dict)
+    ]
+
+
+def _normalize_command(content: str) -> str:
+    parts = (content or "").strip().split(maxsplit=1)
+    if not parts:
+        return ""
+    head = parts[0].lower()
+    if "@" in head:
+        head = head.split("@", 1)[0]
+    return head
+
+
+def _abort_ctx(state: TurnState, reply: str) -> BeforeTurnCtx:
+    return BeforeTurnCtx(
+        session_key=state.session_key,
+        channel=state.msg.channel,
+        chat_id=state.msg.chat_id,
+        content=state.msg.content,
+        timestamp=state.msg.timestamp,
+        skill_names=[],
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
+        history_messages=(),
+        abort=True,
+        abort_reply=reply,
+    )
+
+
+def _is_memory_engine(engine: object, name: str) -> bool:
+    describe = getattr(engine, "describe", None)
+    if not callable(describe):
+        return False
+    description = cast(Any, describe())
+    return str(getattr(description, "name", "")) == name
+
+
+def _format_ts(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(_BEIJING_TZ)
+        return f"{parsed.month}-{parsed.day} {parsed.hour:02d}:{parsed.minute:02d}"
+    except ValueError:
+        return value
+
+
+def _clip(text: str, limit: int) -> str:
+    clean = " ".join(text.split()).strip()
+    if len(clean) <= limit:
+        return clean
+    return clean[:limit].rstrip() + "..."
+
+
+def _float(value: object) -> float:
+    try:
+        return float(cast(Any, value) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import math
+import sqlite3
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from plugins.akasha.config import AkashaConfig
+from plugins.akasha.core import (
+    ActivationEventRow,
+    AkashaCandidate,
+    CoreConfig,
+    EdgeUpdate,
+    SourceMessage,
+    activation_updates,
+    compute_candidates,
+    edges_by_src,
+    fan_counts,
+    parse_ts_unix,
+)
+from plugins.akasha.store import AkashaStore
+
+
+@dataclass(frozen=True)
+class ReplayMessage:
+    message: SourceMessage
+    embedding: list[float]
+
+
+@dataclass(frozen=True)
+class ReplayTurnResult:
+    current_key: str
+    activation_items: list[AkashaCandidate]
+
+
+class AkashaReplayRuntime:
+    def __init__(
+        self,
+        *,
+        store: AkashaStore,
+        config: AkashaConfig,
+        source_cursor: sqlite3.Cursor,
+    ) -> None:
+        self._store = store
+        self._config = config
+        self._core_config = _core_config(config)
+        self._source_cursor = source_cursor
+
+    # 按线上状态机回放一轮：先激活旧图，再提交当前 turn。
+    def replay_turn(
+        self,
+        items: Sequence[ReplayMessage],
+    ) -> ReplayTurnResult:
+        if not items:
+            return ReplayTurnResult(current_key="", activation_items=[])
+        trigger = next((item for item in items if item.message.role == "user"), None)
+        activation_items = (
+            self.activate_before_turn(trigger.message, trigger.embedding)
+            if trigger is not None
+            else []
+        )
+        current_key = self.commit_turn(items, activation_items)
+        return ReplayTurnResult(
+            current_key=current_key,
+            activation_items=activation_items,
+        )
+
+    # 使用当前 user embedding 检索历史节点，并更新旧节点状态。
+    def activate_before_turn(
+        self,
+        message: SourceMessage,
+        embedding: list[float],
+    ) -> list[AkashaCandidate]:
+        if message.role != "user":
+            return []
+        nodes = {node.key: node for node in self._store.list_nodes()}
+        if not nodes:
+            return []
+
+        edges = self._store.load_edges()
+        now_ts = parse_ts_unix(message.ts)
+        candidates, _, _ = compute_candidates(
+            message.content,
+            np.array(embedding, dtype=np.float32),
+            nodes,
+            edges,
+            now_ts,
+            config=self._core_config,
+            fan=fan_counts(edges),
+            source_cursor=self._source_cursor,
+            edges_by_src=edges_by_src(edges),
+            soft_recall=False,
+            return_limit=self._config.activate_limit,
+        )
+        self._store.update_activation_batch(activation_updates(candidates, nodes, now_ts))
+        return candidates
+
+    # 提交当前 turn，并把本轮激活转成共激活边和诊断事件。
+    def commit_turn(
+        self,
+        items: Sequence[ReplayMessage],
+        activation_items: list[AkashaCandidate],
+    ) -> str:
+        current_key = ""
+        for item in items:
+            current_key = self._store.upsert_message_node(item.message, item.embedding)
+        if current_key and activation_items:
+            trigger = next((item.message for item in items if item.message.role == "user"), items[0].message)
+            ts = parse_ts_unix(trigger.ts)
+            self._store.upsert_edges(_edge_updates(current_key, activation_items, ts))
+            self._store.insert_activation_events(_activation_events(trigger, activation_items))
+        return current_key
+
+
+def _core_config(config: AkashaConfig) -> CoreConfig:
+    return CoreConfig(
+        dense_top_k=config.dense_top_k,
+        dense_seed_threshold=config.dense_seed_threshold,
+        activation_threshold=config.activation_threshold,
+        cross_boost=config.cross_boost,
+        nearby_time_seconds=config.nearby_time_seconds,
+        nearby_dense_threshold=config.nearby_dense_threshold,
+        soft_recall_threshold=config.soft_recall_threshold,
+        soft_recall_direct_floor=config.soft_recall_direct_floor,
+        activate_limit=config.activate_limit,
+    )
+
+
+def _edge_updates(
+    current_key: str,
+    candidates: list[AkashaCandidate],
+    ts: float,
+) -> list[EdgeUpdate]:
+    updates: list[EdgeUpdate] = []
+    key_to_score = {item.key: item.score for item in candidates}
+    for item in candidates:
+        edge_strength = key_to_score.get(item.key, 1.0)
+        updates.append(EdgeUpdate(current_key, item.key, edge_strength, ts))
+        updates.append(EdgeUpdate(item.key, current_key, edge_strength, ts))
+    for left_index, left in enumerate(candidates):
+        for right in candidates[left_index + 1:]:
+            edge_strength = math.sqrt(key_to_score[left.key] * key_to_score[right.key])
+            updates.append(EdgeUpdate(left.key, right.key, edge_strength, ts))
+            updates.append(EdgeUpdate(right.key, left.key, edge_strength, ts))
+    return updates
+
+
+def _activation_events(
+    message: SourceMessage,
+    candidates: list[AkashaCandidate],
+) -> list[ActivationEventRow]:
+    return [
+        ActivationEventRow(
+            seq=message.seq,
+            query_id=message.id,
+            activated_key=item.key,
+            source=item.source,
+            score=item.score,
+            direct_score=item.direct,
+            state_score=item.state,
+            edge_score=item.edge,
+            long_score=item.long,
+            resource=item.resource,
+            fan=item.fan,
+        )
+        for item in candidates
+    ]

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import math
+import json
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Sequence
 
 import numpy as np
@@ -10,17 +12,35 @@ import numpy as np
 from plugins.akasha.config import AkashaConfig
 from plugins.akasha.core import (
     ActivationEventRow,
+    ActivationTrace,
+    AkashaActivationSnapshot,
     AkashaCandidate,
     CoreConfig,
-    EdgeUpdate,
     SourceMessage,
+    activation_edge_updates,
     activation_updates,
-    compute_candidates,
+    compute_candidates_from_snapshot,
+    dense_message_candidates,
     edges_by_src,
     fan_counts,
+    graph_seed_keys_from_snapshot,
+    parse_turn_key,
     parse_ts_unix,
+    turn_key,
+)
+from plugins.akasha.engine import (
+    AkashaCard,
+    _candidate_signals,
+    _card_dedupe_key,
+    _format_cards,
+    _load_messages_batch,
+    _load_turn_card,
+    _query_log_id,
+    _sort_cards_by_time,
 )
 from plugins.akasha.store import AkashaStore
+
+CONTEXT_QUERY_LIMIT = 8
 
 
 @dataclass(frozen=True)
@@ -35,18 +55,32 @@ class ReplayTurnResult:
     activation_items: list[AkashaCandidate]
 
 
+@dataclass(frozen=True)
+class ReplayActivation:
+    activation_items: list[AkashaCandidate]
+    dense_items: list[AkashaCandidate]
+    ripple_items: list[AkashaCandidate]
+    trace: ActivationTrace
+
+
 class AkashaReplayRuntime:
     def __init__(
         self,
         *,
         store: AkashaStore,
         config: AkashaConfig,
+        source_db_path: Path,
         source_cursor: sqlite3.Cursor,
+        message_embeddings: dict[str, np.ndarray],
+        message_turn_keys: dict[str, str],
     ) -> None:
         self._store = store
         self._config = config
         self._core_config = _core_config(config)
+        self._source_db_path = source_db_path
         self._source_cursor = source_cursor
+        self._message_embeddings = dict(message_embeddings)
+        self._message_turn_keys = dict(message_turn_keys)
 
     # 按线上状态机回放一轮：先激活旧图，再提交当前 turn。
     def replay_turn(
@@ -56,15 +90,18 @@ class AkashaReplayRuntime:
         if not items:
             return ReplayTurnResult(current_key="", activation_items=[])
         trigger = next((item for item in items if item.message.role == "user"), None)
-        activation_items = (
-            self.activate_before_turn(trigger.message, trigger.embedding)
-            if trigger is not None
-            else []
+        has_query = trigger is not None and bool(trigger.message.content.strip())
+        activation = (
+            self._activate_before_turn(trigger.message, trigger.embedding)
+            if has_query and trigger is not None
+            else _empty_activation()
         )
-        current_key = self.commit_turn(items, activation_items)
+        current_key = self.commit_turn(items, activation.activation_items)
+        if has_query and trigger is not None and trigger.message.session_key:
+            self._write_query_log(trigger.message, activation)
         return ReplayTurnResult(
             current_key=current_key,
-            activation_items=activation_items,
+            activation_items=activation.activation_items,
         )
 
     # 使用当前 user embedding 检索历史节点，并更新旧节点状态。
@@ -73,29 +110,76 @@ class AkashaReplayRuntime:
         message: SourceMessage,
         embedding: list[float],
     ) -> list[AkashaCandidate]:
+        return self._activate_before_turn(message, embedding).activation_items
+
+    def _activate_before_turn(
+        self,
+        message: SourceMessage,
+        embedding: list[float],
+    ) -> ReplayActivation:
         if message.role != "user":
-            return []
+            return _empty_activation()
+        query_text = message.content.strip()
+        if not query_text:
+            return _empty_activation()
+        if query_text != message.content:
+            raise ValueError(f"Akasha replay 缺少 strip 后 query embedding: {message.id}")
         nodes = {node.key: node for node in self._store.list_nodes()}
         if not nodes:
-            return []
+            return _empty_activation()
 
-        edges = self._store.load_edges()
+        edges, edges_meta = self._store.load_edges_with_meta()
+        query_vec = np.array(embedding, dtype=np.float32)
+        snapshot = AkashaActivationSnapshot(
+            nodes=nodes,
+            edges=edges,
+            edges_meta=edges_meta,
+            fan=fan_counts(edges),
+            edges_by_src=edges_by_src(edges),
+            message_embeddings=self._message_embeddings,
+            message_turn_keys=self._message_turn_keys,
+        )
+        graph_seed_keys = graph_seed_keys_from_snapshot(
+            query_vec,
+            snapshot,
+            limit=self._config.dense_top_k,
+        )
         now_ts = parse_ts_unix(message.ts)
-        candidates, _, _ = compute_candidates(
-            message.content,
-            np.array(embedding, dtype=np.float32),
-            nodes,
-            edges,
+        dense_items = dense_message_candidates(
+            query_vec,
+            snapshot.nodes,
+            snapshot.message_embeddings,
+            snapshot.message_turn_keys,
+            limit=max(self._config.dense_top_k, CONTEXT_QUERY_LIMIT),
+        )
+        candidates, _, trace = compute_candidates_from_snapshot(
+            query_text,
+            query_vec,
+            snapshot,
             now_ts,
             config=self._core_config,
-            fan=fan_counts(edges),
             source_cursor=self._source_cursor,
-            edges_by_src=edges_by_src(edges),
             soft_recall=False,
             return_limit=self._config.activate_limit,
+            graph_seed_keys=graph_seed_keys,
+        )
+        display_limit = max(
+            24,
+            max(self._config.ripple_top_k, CONTEXT_QUERY_LIMIT) * 3,
+        )
+        ripple_items, _, trace = compute_candidates_from_snapshot(
+            query_text,
+            query_vec,
+            snapshot,
+            now_ts,
+            config=self._core_config,
+            source_cursor=self._source_cursor,
+            soft_recall=True,
+            return_limit=display_limit,
+            graph_seed_keys=graph_seed_keys,
         )
         self._store.update_activation_batch(activation_updates(candidates, nodes, now_ts))
-        return candidates
+        return ReplayActivation(candidates, dense_items, ripple_items, trace)
 
     # 提交当前 turn，并把本轮激活转成共激活边和诊断事件。
     def commit_turn(
@@ -106,12 +190,89 @@ class AkashaReplayRuntime:
         current_key = ""
         for item in items:
             current_key = self._store.upsert_message_node(item.message, item.embedding)
+            self._message_embeddings[item.message.id] = np.array(item.embedding, dtype=np.float32)
+            self._message_turn_keys[item.message.id] = turn_key(
+                item.message.session_key,
+                item.message.seq,
+                item.message.role,
+            )[2]
         if current_key and activation_items:
             trigger = next((item.message for item in items if item.message.role == "user"), items[0].message)
             ts = parse_ts_unix(trigger.ts)
-            self._store.upsert_edges(_edge_updates(current_key, activation_items, ts))
+            self._store.upsert_edges(activation_edge_updates(current_key, activation_items, ts))
             self._store.insert_activation_events(_activation_events(trigger, activation_items))
         return current_key
+
+    def _write_query_log(
+        self,
+        message: SourceMessage,
+        activation: ReplayActivation,
+    ) -> None:
+        dense_cards = _cards_from_candidates(
+            self._source_db_path,
+            self._config,
+            activation.dense_items,
+            lane="dense",
+            limit=self._config.dense_top_k,
+        )
+        dense_keys = {card.key for card in dense_cards}
+        dense_pairs = {_card_dedupe_key(card) for card in dense_cards}
+        ripple_cards = _cards_from_candidates(
+            self._source_db_path,
+            self._config,
+            [item for item in activation.ripple_items if item.key not in dense_keys],
+            lane="ripple",
+            limit=self._config.ripple_top_k,
+            skip_pairs=dense_pairs,
+        )
+        text_block = _format_context_block(
+            self._config,
+            dense_cards,
+            ripple_cards,
+            now_ts=parse_ts_unix(message.ts),
+        )
+        all_source_refs = _source_refs(dense_cards, ripple_cards)
+        activation_content = _load_messages_batch(
+            self._source_db_path,
+            [item.key for item in activation.activation_items],
+            assistant_preview_chars=self._config.assistant_preview_chars,
+        )
+        activation_items_json = json.dumps(
+            [
+                _candidate_to_log_item(
+                    activation_content,
+                    item,
+                )
+                for item in activation.activation_items
+            ],
+            ensure_ascii=False,
+        )
+        self._store.insert_query_log(
+            query_id=_query_log_id(message.session_key, message.seq, "context", message.content),
+            session_key=message.session_key,
+            seq=message.seq,
+            query_text=message.content.strip(),
+            intent="context",
+            ts=datetime.fromtimestamp(parse_ts_unix(message.ts), timezone.utc).isoformat(),
+            seed_count=activation.trace.seed_count,
+            pool_count=activation.trace.pool_count,
+            activated_count=len(activation.activation_items),
+            activation_threshold=self._config.activation_threshold,
+            dense_count=len(dense_cards),
+            ripple_count=len(ripple_cards),
+            inject_chars=len(text_block),
+            source_ref_count=len(all_source_refs),
+            activation_items_json=activation_items_json,
+            dense_items_json=json.dumps(
+                [_card_to_log_item(card) for card in dense_cards],
+                ensure_ascii=False,
+            ),
+            ripple_items_json=json.dumps(
+                [_card_to_log_item(card) for card in ripple_cards],
+                ensure_ascii=False,
+            ),
+            text_block_preview=_preview_text_block(text_block),
+        )
 
 
 def _core_config(config: AkashaConfig) -> CoreConfig:
@@ -128,33 +289,18 @@ def _core_config(config: AkashaConfig) -> CoreConfig:
     )
 
 
-def _edge_updates(
-    current_key: str,
-    candidates: list[AkashaCandidate],
-    ts: float,
-) -> list[EdgeUpdate]:
-    updates: list[EdgeUpdate] = []
-    key_to_score = {item.key: item.score for item in candidates}
-    for item in candidates:
-        edge_strength = key_to_score.get(item.key, 1.0)
-        updates.append(EdgeUpdate(current_key, item.key, edge_strength, ts))
-        updates.append(EdgeUpdate(item.key, current_key, edge_strength, ts))
-    for left_index, left in enumerate(candidates):
-        for right in candidates[left_index + 1:]:
-            edge_strength = math.sqrt(key_to_score[left.key] * key_to_score[right.key])
-            updates.append(EdgeUpdate(left.key, right.key, edge_strength, ts))
-            updates.append(EdgeUpdate(right.key, left.key, edge_strength, ts))
-    return updates
-
+def _empty_activation() -> ReplayActivation:
+    return ReplayActivation([], [], [], ActivationTrace(seed_count=0, pool_count=0))
 
 def _activation_events(
     message: SourceMessage,
     candidates: list[AkashaCandidate],
 ) -> list[ActivationEventRow]:
+    query_id = f"{message.session_key}:{message.seq}"
     return [
         ActivationEventRow(
             seq=message.seq,
-            query_id=message.id,
+            query_id=query_id,
             activated_key=item.key,
             source=item.source,
             score=item.score,
@@ -167,3 +313,156 @@ def _activation_events(
         )
         for item in candidates
     ]
+
+
+def _candidate_to_log_item(
+    activation_content: dict[str, tuple[str, str]],
+    item: AkashaCandidate,
+) -> dict[str, object]:
+    user_message, assistant_preview = activation_content.get(item.key, ("", ""))
+    return {
+        "key": item.key,
+        "user_message": user_message,
+        "assistant_preview": assistant_preview,
+        "score": item.score,
+        "source": item.source,
+        "path_type": item.path_type,
+        "fan": item.fan,
+        "direct": item.direct,
+        "state": item.state,
+        "edge": item.edge,
+        "long": item.long,
+        "resource": item.resource,
+        "ripple": item.ripple,
+        "seed_key": item.seed_key,
+        "bridge_key": item.bridge_key,
+        "suppressed": item.suppressed,
+    }
+
+
+def _cards_from_candidates(
+    source_db_path: Path,
+    config: AkashaConfig,
+    items: list[AkashaCandidate],
+    *,
+    lane: str,
+    limit: int,
+    skip_pairs: set[tuple[str, str]] | None = None,
+) -> list[AkashaCard]:
+    cards: list[AkashaCard] = []
+    seen_keys: set[str] = set()
+    seen_pairs = set(skip_pairs or set())
+    for item in items:
+        if item.key in seen_keys:
+            continue
+        seen_keys.add(item.key)
+        card = _load_turn_card(
+            source_db_path,
+            item.key,
+            assistant_preview_chars=config.assistant_preview_chars,
+            score=item.score,
+            lane=lane,
+            signals=_candidate_signals(item),
+        )
+        if card is None:
+            continue
+        pair_key = _card_dedupe_key(card)
+        if pair_key in seen_pairs:
+            continue
+        seen_pairs.add(pair_key)
+        cards.append(card)
+        if len(cards) >= limit:
+            break
+    return cards
+
+
+def _format_context_block(
+    config: AkashaConfig,
+    dense_cards: list[AkashaCard],
+    ripple_cards: list[AkashaCard],
+    *,
+    now_ts: float,
+) -> str:
+    parts: list[str] = []
+    if dense_cards or ripple_cards:
+        date_label = datetime.fromtimestamp(now_ts, timezone.utc).astimezone().strftime("%Y-%m-%d")
+        parts.append(f"# Akasha memory now={date_label}")
+    if dense_cards:
+        parts.append(_format_cards("## 左脑记忆：精确回忆", _sort_cards_by_time(dense_cards)))
+    if ripple_cards:
+        parts.append(_format_cards("## 右脑联想：潜意识第一反应", _sort_cards_by_time(ripple_cards)))
+
+    text = "\n\n".join(part for part in parts if part.strip())
+    max_chars = max(1, config.inject_max_chars)
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + f"\n...[Akasha 已截断 {len(text) - max_chars} 字]"
+
+
+def _source_refs(
+    dense_cards: list[AkashaCard],
+    ripple_cards: list[AkashaCard],
+) -> set[str]:
+    refs: set[str] = set()
+    for card in [*dense_cards, *ripple_cards]:
+        for item in json.loads(card.source_ref):
+            refs.add(str(item))
+    return refs
+
+
+def _card_to_log_item(card: AkashaCard) -> dict[str, object]:
+    item: dict[str, object] = {
+        "key": card.key,
+        "user_message": card.user_message,
+        "assistant_preview": card.assistant_preview,
+        "score": card.score,
+        "source_ref": card.source_ref,
+    }
+    item.update(card.signals)
+    return item
+
+
+def _preview_text_block(text_block: str) -> str:
+    return text_block[:500].rstrip() + ("..." if len(text_block) > 500 else "")
+
+
+def _turn_messages(
+    cursor: sqlite3.Cursor,
+    key: str,
+    *,
+    assistant_preview_chars: int,
+) -> tuple[str, str]:
+    parsed = parse_turn_key(key)
+    if parsed is None:
+        raise ValueError(f"Akasha turn key 无法解析: {key}")
+    session_key, turn_seq = parsed
+    rows = cursor.execute(
+        """
+        SELECT seq, role, content
+        FROM messages
+        WHERE session_key = ? AND seq IN (?, ?)
+        ORDER BY seq
+        """,
+        (session_key, turn_seq, turn_seq + 1),
+    ).fetchall()
+    user_message = ""
+    assistant_preview = ""
+    has_user = False
+    for row in rows:
+        seq = int(row[0])
+        role = str(row[1] or "")
+        content = str(row[2] or "")
+        if seq == turn_seq and role == "user":
+            has_user = True
+            user_message = content
+        elif seq == turn_seq + 1 and role == "assistant":
+            assistant_preview = _clip_text(content, assistant_preview_chars)
+    if not has_user:
+        raise LookupError(f"Akasha replay 找不到 turn 内容: {key}")
+    return user_message, assistant_preview
+
+
+def _clip_text(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -12,6 +12,7 @@ import numpy as np
 from plugins.akasha.core import (
     AkashaNode, ActivationUpdate, EdgeUpdate, ActivationEventRow,
     SourceMessage, turn_key, serialize_f32, deserialize_f32, parse_ts_unix,
+    initial_strength,
     normalize as _normalize,
 )
 
@@ -51,9 +52,9 @@ CREATE TABLE IF NOT EXISTS akasha_nodes (
     strength           REAL NOT NULL,
     resource           REAL NOT NULL,
     recall_count       INTEGER NOT NULL,
-    last_activated_seq INTEGER NOT NULL,
-    last_strength_seq  INTEGER NOT NULL,
-    last_resource_seq  INTEGER NOT NULL,
+    last_activated_ts  REAL NOT NULL,
+    last_strength_ts   REAL NOT NULL,
+    last_resource_ts   REAL NOT NULL,
     embedding          BLOB NOT NULL,
     emb_count          INTEGER NOT NULL,
     created_at         TEXT NOT NULL,
@@ -66,7 +67,7 @@ CREATE TABLE IF NOT EXISTS akasha_edges (
     dst_key       TEXT NOT NULL,
     weight        REAL NOT NULL,
     co_count      INTEGER NOT NULL,
-    last_used_seq INTEGER NOT NULL,
+    last_used_ts  REAL NOT NULL,
     PRIMARY KEY (src_key, dst_key)
 );
 CREATE INDEX IF NOT EXISTS ix_akasha_edges_src
@@ -396,14 +397,18 @@ class AkashaStore:
                 (key,),
             ).fetchone()
             if row is None:
+                # 编码即峰值：strength 按 salience 初始化为接近 cap 的值
+                # 对应 Ebbinghaus 遗忘曲线起点 + ACT-R 初次激活高 base-level
+                init_str = initial_strength(salience)
+                # 新节点的 last_*_ts 设为 first_ts_unix（编码即"被激活"那一刻）
                 _ = self._db.execute(
                     """
                     INSERT INTO akasha_nodes
                         (key, anchor_id, session_key, turn_seq, first_ts_unix,
                          salience, strength, resource, recall_count,
-                         last_activated_seq, last_strength_seq, last_resource_seq,
+                         last_activated_ts, last_strength_ts, last_resource_ts,
                          embedding, emb_count, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, 0.0, 1.0, 0, 0, ?, ?, ?, 1, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 1.0, 0, ?, ?, ?, ?, 1, ?, ?)
                     """,
                     (
                         key,
@@ -412,8 +417,10 @@ class AkashaStore:
                         turn_seq,
                         ts_unix,
                         salience,
-                        message.seq,
-                        message.seq,
+                        init_str,
+                        ts_unix,
+                        ts_unix,
+                        ts_unix,
                         serialize_f32(vector),
                         now,
                         now,
@@ -489,9 +496,9 @@ class AkashaStore:
                 SET strength = ?,
                     resource = ?,
                     recall_count = ?,
-                    last_activated_seq = ?,
-                    last_strength_seq = ?,
-                    last_resource_seq = ?,
+                    last_activated_ts = ?,
+                    last_strength_ts = ?,
+                    last_resource_ts = ?,
                     updated_at = ?
                 WHERE key = ?
                 """,
@@ -500,9 +507,9 @@ class AkashaStore:
                         item.strength,
                         item.resource,
                         item.recall_count,
-                        item.seq,
-                        item.seq,
-                        item.seq,
+                        item.ts,
+                        item.ts,
+                        item.ts,
                         now,
                         item.key,
                     )
@@ -532,7 +539,7 @@ class AkashaStore:
                     weight = 0.12 * item.strength
                     _ = self._db.execute(
                         "INSERT INTO akasha_edges VALUES (?, ?, ?, 1, ?)",
-                        (item.src_key, item.dst_key, weight, item.seq),
+                        (item.src_key, item.dst_key, weight, item.ts),
                     )
                     continue
                 old = float(row["weight"] or 0.0) * 0.9995
@@ -542,13 +549,13 @@ class AkashaStore:
                     UPDATE akasha_edges
                     SET weight = ?,
                         co_count = ?,
-                        last_used_seq = ?
+                        last_used_ts = ?
                     WHERE src_key = ? AND dst_key = ?
                     """,
                     (
                         new_weight,
                         int(row["co_count"] or 0) + 1,
-                        item.seq,
+                        item.ts,
                         item.src_key,
                         item.dst_key,
                     ),
@@ -826,9 +833,9 @@ def _row_to_node(row: sqlite3.Row) -> AkashaNode | None:
         strength=float(row["strength"] or 0.0),
         resource=float(row["resource"] or 1.0),
         recall_count=int(row["recall_count"] or 0),
-        last_activated_seq=int(row["last_activated_seq"] or 0),
-        last_strength_seq=int(row["last_strength_seq"] or 0),
-        last_resource_seq=int(row["last_resource_seq"] or 0),
+        last_activated_ts=float(row["last_activated_ts"] or 0.0),
+        last_strength_ts=float(row["last_strength_ts"] or 0.0),
+        last_resource_ts=float(row["last_resource_ts"] or 0.0),
         embedding=embedding,
         emb_count=int(row["emb_count"] or 1),
     )

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sqlite3
-import struct
 import threading
 import uuid
 from dataclasses import dataclass
@@ -9,6 +8,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
+
+from plugins.akasha.core import (
+    AkashaNode, ActivationUpdate, EdgeUpdate, ActivationEventRow,
+    SourceMessage, turn_key, serialize_f32, deserialize_f32, parse_ts_unix,
+    normalize as _normalize,
+)
 
 
 SCHEMA = """
@@ -126,103 +131,11 @@ DROP TABLE IF EXISTS akasha_nodes;
 
 
 @dataclass(frozen=True)
-class SourceMessage:
-    id: str
-    session_key: str
-    seq: int
-    role: str
-    content: str
-    ts: str
-    salience: float | None = None
-
-
-@dataclass(frozen=True)
-class AkashaNode:
-    key: str
-    anchor_id: str
-    session_key: str
-    turn_seq: int
-    first_ts_unix: float
-    salience: float
-    strength: float
-    resource: float
-    recall_count: int
-    last_activated_seq: int
-    last_strength_seq: int
-    last_resource_seq: int
-    embedding: np.ndarray
-    emb_count: int
-
-
-@dataclass(frozen=True)
-class ActivationUpdate:
-    key: str
-    strength: float
-    resource: float
-    recall_count: int
-    seq: int
-
-
-@dataclass(frozen=True)
-class EdgeUpdate:
-    src_key: str
-    dst_key: str
-    strength: float
-    seq: int
-
-
-@dataclass(frozen=True)
-class ActivationEventRow:
-    seq: int
-    query_id: str
-    activated_key: str
-    source: str
-    score: float
-    direct_score: float
-    state_score: float
-    edge_score: float
-    long_score: float
-    resource: float
-    fan: int
-
-
-@dataclass(frozen=True)
 class SourceSessionSnapshot:
     session_key: str
     last_consolidated: int
     next_seq: int
     max_seq: int
-
-
-# 把 message 映射成原始 cross CLI 使用的 turn key。
-def turn_key(session_key: str, seq: int, role: str) -> tuple[str, int, str]:
-    # 1. assistant 归到前一个 user turn，user 归到自身 seq。
-    turn_seq = seq if role == "user" else max(0, seq - 1)
-    return session_key, turn_seq, f"{session_key}:{turn_seq}"
-
-
-# 把向量打包成 float32 BLOB。
-def serialize_f32(vector: np.ndarray) -> bytes:
-    # 1. 数据库只保存紧凑 float32，避免 JSON 大字段膨胀。
-    values = vector.astype(np.float32).tolist()
-    return struct.pack(f"{len(values)}f", *values)
-
-
-# 从 float32 BLOB 还原向量。
-def deserialize_f32(blob: bytes) -> np.ndarray:
-    # 1. 空向量不应该写入，这里按空数组兜底。
-    if not blob:
-        return np.array([], dtype=np.float32)
-    return np.array(struct.unpack(f"{len(blob) // 4}f", blob), dtype=np.float32)
-
-
-# 把时间字符串转换成 Unix 秒。
-def parse_ts_unix(value: str) -> float:
-    # 1. 优先使用 sessions.db 里的 ISO 时间。
-    try:
-        return datetime.fromisoformat(value).timestamp()
-    except Exception:
-        return datetime.now(timezone.utc).timestamp()
 
 
 # 计算 message 内容指纹。
@@ -237,15 +150,6 @@ def content_hash(content: str) -> str:
 def _now_iso() -> str:
     # 1. sidecar 内部时间统一用 UTC。
     return datetime.now(timezone.utc).isoformat()
-
-
-# 把向量归一化到单位长度。
-def _normalize(vector: np.ndarray) -> np.ndarray:
-    # 1. cross CLI 默认使用归一化 embedding；这里保持同一语义。
-    norm = float(np.linalg.norm(vector))
-    if norm <= 0:
-        return vector.astype(np.float32)
-    return (vector / norm).astype(np.float32)
 
 
 class AkashaStore:

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -12,6 +12,30 @@ import numpy as np
 
 
 SCHEMA = """
+CREATE TABLE IF NOT EXISTS akasha_query_log (
+    query_id              TEXT PRIMARY KEY,
+    session_key           TEXT NOT NULL,
+    seq                   INTEGER NOT NULL,
+    query_text            TEXT NOT NULL,
+    intent                TEXT NOT NULL,
+    ts                    TEXT NOT NULL,
+    seed_count            INTEGER NOT NULL DEFAULT 0,
+    pool_count            INTEGER NOT NULL DEFAULT 0,
+    activated_count       INTEGER NOT NULL DEFAULT 0,
+    activation_threshold  REAL NOT NULL DEFAULT 0,
+    dense_count           INTEGER NOT NULL DEFAULT 0,
+    ripple_count          INTEGER NOT NULL DEFAULT 0,
+    inject_chars          INTEGER NOT NULL DEFAULT 0,
+    source_ref_count      INTEGER NOT NULL DEFAULT 0,
+    activation_items      TEXT,
+    dense_items           TEXT,
+    ripple_items          TEXT,
+    text_block_preview    TEXT
+);
+CREATE INDEX IF NOT EXISTS ix_akasha_query_log_session
+    ON akasha_query_log (session_key, seq DESC);
+CREATE INDEX IF NOT EXISTS ix_akasha_query_log_ts
+    ON akasha_query_log (ts DESC);
 CREATE TABLE IF NOT EXISTS akasha_nodes (
     key                TEXT PRIMARY KEY,
     anchor_id          TEXT NOT NULL,
@@ -703,6 +727,144 @@ class AkashaStore:
             if self.delete_item(item_id):
                 count += 1
         return count
+
+    # 写入一条检索诊断日志。
+    def insert_query_log(
+        self,
+        *,
+        query_id: str,
+        session_key: str,
+        seq: int,
+        query_text: str,
+        intent: str,
+        ts: str,
+        seed_count: int,
+        pool_count: int,
+        activated_count: int,
+        activation_threshold: float,
+        dense_count: int,
+        ripple_count: int,
+        inject_chars: int,
+        source_ref_count: int,
+        activation_items_json: str,
+        dense_items_json: str,
+        ripple_items_json: str,
+        text_block_preview: str,
+    ) -> None:
+        # 1. 写失败不中断主链路，只记录到 warning。
+        import logging
+        try:
+            with self._lock:
+                _ = self._db.execute(
+                    """
+                    INSERT OR REPLACE INTO akasha_query_log (
+                        query_id, session_key, seq, query_text, intent, ts,
+                        seed_count, pool_count, activated_count, activation_threshold,
+                        dense_count, ripple_count, inject_chars, source_ref_count,
+                        activation_items, dense_items, ripple_items, text_block_preview
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        query_id, session_key, seq, query_text, intent, ts,
+                        seed_count, pool_count, activated_count, activation_threshold,
+                        dense_count, ripple_count, inject_chars, source_ref_count,
+                        activation_items_json, dense_items_json, ripple_items_json,
+                        text_block_preview,
+                    ),
+                )
+                self._db.commit()
+        except Exception:
+            logging.getLogger("akasha.store").warning("insert_query_log failed", exc_info=True)
+
+    # 读取检索诊断日志列表（仅轻量字段）。
+    def list_query_logs(
+        self,
+        *,
+        session_key: str = "",
+        q: str = "",
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[dict[str, object]], int]:
+        # 1. 过滤 session_key 和 query_text 关键字。
+        clauses: list[str] = []
+        params: list[object] = []
+        if session_key.strip():
+            clauses.append("session_key = ?")
+            params.append(session_key.strip())
+        if q.strip():
+            clauses.append("query_text LIKE ?")
+            params.append(f"%{q.strip()}%")
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        page = max(1, page)
+        page_size = max(1, min(page_size, 200))
+        offset = (page - 1) * page_size
+        with self._lock:
+            count_row = self._db.execute(
+                f"SELECT COUNT(1) FROM akasha_query_log {where}", params
+            ).fetchone()
+            rows = self._db.execute(
+                f"""
+                SELECT query_id, session_key, seq, query_text, intent, ts,
+                       seed_count, pool_count, activated_count, activation_threshold,
+                       dense_count, ripple_count, inject_chars, source_ref_count
+                FROM akasha_query_log {where}
+                ORDER BY ts DESC, seq DESC
+                LIMIT ? OFFSET ?
+                """,
+                [*params, page_size, offset],
+            ).fetchall()
+        total = int((count_row[0] if count_row else 0) or 0)
+        items = [
+            {
+                "query_id": str(row["query_id"]),
+                "session_key": str(row["session_key"]),
+                "seq": int(row["seq"]),
+                "query_text": str(row["query_text"]),
+                "intent": str(row["intent"]),
+                "ts": str(row["ts"]),
+                "seed_count": int(row["seed_count"] or 0),
+                "pool_count": int(row["pool_count"] or 0),
+                "activated_count": int(row["activated_count"] or 0),
+                "activation_threshold": float(row["activation_threshold"] or 0.0),
+                "dense_count": int(row["dense_count"] or 0),
+                "ripple_count": int(row["ripple_count"] or 0),
+                "inject_chars": int(row["inject_chars"] or 0),
+                "source_ref_count": int(row["source_ref_count"] or 0),
+            }
+            for row in rows
+        ]
+        return items, total
+
+    # 按 query_id 读取完整检索诊断记录。
+    def get_query_log(self, query_id: str) -> dict[str, object] | None:
+        # 1. 完整记录包含 JSON 列，由调用方反序列化。
+        with self._lock:
+            row = self._db.execute(
+                "SELECT * FROM akasha_query_log WHERE query_id = ?",
+                (query_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "query_id": str(row["query_id"]),
+            "session_key": str(row["session_key"]),
+            "seq": int(row["seq"]),
+            "query_text": str(row["query_text"]),
+            "intent": str(row["intent"]),
+            "ts": str(row["ts"]),
+            "seed_count": int(row["seed_count"] or 0),
+            "pool_count": int(row["pool_count"] or 0),
+            "activated_count": int(row["activated_count"] or 0),
+            "activation_threshold": float(row["activation_threshold"] or 0.0),
+            "dense_count": int(row["dense_count"] or 0),
+            "ripple_count": int(row["ripple_count"] or 0),
+            "inject_chars": int(row["inject_chars"] or 0),
+            "source_ref_count": int(row["source_ref_count"] or 0),
+            "activation_items_json": str(row["activation_items"] or "[]"),
+            "dense_items_json": str(row["dense_items"] or "[]"),
+            "ripple_items_json": str(row["ripple_items"] or "[]"),
+            "text_block_preview": str(row["text_block_preview"] or ""),
+        }
 
 
 # 把 SQLite row 转成 AkashaNode。

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -356,6 +356,20 @@ class AkashaStore:
             for row in rows
         ]
 
+    # 删除指定消息的 embedding cache。
+    def delete_cached_embeddings(self, message_ids: list[str]) -> int:
+        clean_ids = [str(item).strip() for item in message_ids if str(item).strip()]
+        if not clean_ids:
+            return 0
+        placeholders = ",".join("?" for _ in clean_ids)
+        with self._lock:
+            cur = self._db.execute(
+                f"DELETE FROM akasha_embedding_cache WHERE message_id IN ({placeholders})",
+                clean_ids,
+            )
+            self._db.commit()
+        return int(cur.rowcount or 0)
+
     # 开始记录一次 Akasha 迁移。
     def start_migration_run(
         self,
@@ -736,6 +750,22 @@ class AkashaStore:
             if self.delete_item(item_id):
                 count += 1
         return count
+
+    # 删除指定 turn 的检索诊断状态。
+    def delete_query_state_for_turns(self, turns: list[tuple[str, int]]) -> None:
+        if not turns:
+            return
+        with self._lock:
+            for session_key, seq in turns:
+                _ = self._db.execute(
+                    "DELETE FROM akasha_query_log WHERE session_key = ? AND seq = ?",
+                    (session_key, seq),
+                )
+                _ = self._db.execute(
+                    "DELETE FROM akasha_activation_events WHERE query_id = ?",
+                    (f"{session_key}:{seq}",),
+                )
+            self._db.commit()
 
     # 写入一条检索诊断日志。
     def insert_query_log(

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -537,6 +537,15 @@ class AkashaStore:
             rows = self._db.execute("SELECT * FROM akasha_nodes").fetchall()
         return [node for row in rows if (node := _row_to_node(row)) is not None]
 
+    # 读取单个 turn 节点。
+    def get_node(self, key: str) -> AkashaNode | None:
+        with self._lock:
+            row = self._db.execute(
+                "SELECT * FROM akasha_nodes WHERE key = ?",
+                (key,),
+            ).fetchone()
+        return _row_to_node(row) if row is not None else None
+
     # 读取全部共激活边。
     def load_edges(self) -> dict[tuple[str, str], float]:
         # 1. 查询阶段把边转成 dict，便于构造扩散矩阵。
@@ -814,7 +823,7 @@ class AkashaStore:
                 [*params, page_size, offset],
             ).fetchall()
         total = int((count_row[0] if count_row else 0) or 0)
-        items = [
+        items: list[dict[str, object]] = [
             {
                 "query_id": str(row["query_id"]),
                 "session_key": str(row["session_key"]),

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -125,6 +125,7 @@ CREATE TABLE IF NOT EXISTS akasha_source_session_snapshot (
 """
 
 RESET_SQL = """
+DROP TABLE IF EXISTS akasha_query_log;
 DROP TABLE IF EXISTS akasha_activation_events;
 DROP TABLE IF EXISTS akasha_edges;
 DROP TABLE IF EXISTS akasha_nodes;
@@ -153,6 +154,11 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _table_columns(db: sqlite3.Connection, table: str) -> set[str]:
+    rows = db.execute(f"PRAGMA table_info({table})").fetchall()
+    return {str(row[1]) for row in rows}
+
+
 class AkashaStore:
     def __init__(self, db_path: str | Path) -> None:
         # 1. 初始化 sidecar 数据库和 schema。
@@ -176,6 +182,10 @@ class AkashaStore:
     def ensure_schema(self) -> None:
         # 1. schema 可重复执行，用于启动和迁移前检查。
         with self._lock:
+            if "run_id" not in _table_columns(self._db, "akasha_source_session_snapshot"):
+                _ = self._db.execute("DROP TABLE IF EXISTS akasha_source_session_snapshot")
+            if "message_count" not in _table_columns(self._db, "akasha_migration_runs"):
+                _ = self._db.execute("DROP TABLE IF EXISTS akasha_migration_runs")
             _ = self._db.executescript(SCHEMA)
             self._db.commit()
 

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -12,6 +12,10 @@ import numpy as np
 from plugins.akasha.core import (
     AkashaNode, ActivationUpdate, EdgeUpdate, ActivationEventRow,
     SourceMessage, turn_key, serialize_f32, deserialize_f32, parse_ts_unix,
+    advance_salience_state,
+    bounded_add,
+    causal_salience,
+    effective_edge_weight,
     initial_strength,
     normalize as _normalize,
 )
@@ -101,6 +105,12 @@ CREATE TABLE IF NOT EXISTS akasha_embedding_cache (
 );
 CREATE INDEX IF NOT EXISTS ix_akasha_embedding_cache_hash
     ON akasha_embedding_cache (content_hash, model);
+CREATE TABLE IF NOT EXISTS akasha_salience_state (
+    key         TEXT PRIMARY KEY,
+    vector_sum BLOB NOT NULL,
+    count       INTEGER NOT NULL,
+    updated_at  TEXT NOT NULL
+);
 CREATE TABLE IF NOT EXISTS akasha_migration_runs (
     id               TEXT PRIMARY KEY,
     source_db_path   TEXT NOT NULL,
@@ -129,6 +139,7 @@ DROP TABLE IF EXISTS akasha_query_log;
 DROP TABLE IF EXISTS akasha_activation_events;
 DROP TABLE IF EXISTS akasha_edges;
 DROP TABLE IF EXISTS akasha_nodes;
+DROP TABLE IF EXISTS akasha_salience_state;
 """
 
 
@@ -393,15 +404,17 @@ class AkashaStore:
         )
         vector = _normalize(np.array(embedding, dtype=np.float32))
         ts_unix = parse_ts_unix(message.ts)
-        salience = (
-            0.0
-            if message.salience is None
-            else min(1.0, max(0.0, float(message.salience)))
-        )
         now = _now_iso()
 
         # 2. 新 turn 直接写入；已有 turn 用均值更新 embedding，并保留 user 作为 anchor。
         with self._lock:
+            prior_sum, prior_count = self._load_salience_state_locked()
+            salience = (
+                causal_salience(vector, prior_sum, prior_count)
+                if message.salience is None
+                else min(1.0, max(0.0, float(message.salience)))
+            )
+            next_sum, next_count = advance_salience_state(prior_sum, prior_count, vector)
             row = self._db.execute(
                 "SELECT * FROM akasha_nodes WHERE key = ?",
                 (key,),
@@ -436,6 +449,7 @@ class AkashaStore:
                         now,
                     ),
                 )
+                self._write_salience_state_locked(next_sum, next_count, now)
                 self._db.commit()
                 return key
 
@@ -462,8 +476,37 @@ class AkashaStore:
                     key,
                 ),
             )
+            self._write_salience_state_locked(next_sum, next_count, now)
             self._db.commit()
         return key
+
+    def _load_salience_state_locked(self) -> tuple[np.ndarray | None, int]:
+        row = self._db.execute(
+            "SELECT vector_sum, count FROM akasha_salience_state WHERE key = 'global'"
+        ).fetchone()
+        if row is None:
+            return None, 0
+        vector_sum = deserialize_f32(row["vector_sum"])
+        count = int(row["count"] or 0)
+        return (vector_sum if vector_sum.size else None), count
+
+    def _write_salience_state_locked(
+        self,
+        vector_sum: np.ndarray,
+        count: int,
+        now: str,
+    ) -> None:
+        _ = self._db.execute(
+            """
+            INSERT INTO akasha_salience_state (key, vector_sum, count, updated_at)
+            VALUES ('global', ?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                vector_sum = excluded.vector_sum,
+                count = excluded.count,
+                updated_at = excluded.updated_at
+            """,
+            (serialize_f32(vector_sum), count, now),
+        )
 
     # 读取全部 turn 节点。
     def list_nodes(self) -> list[AkashaNode]:
@@ -483,15 +526,26 @@ class AkashaStore:
 
     # 读取全部共激活边。
     def load_edges(self) -> dict[tuple[str, str], float]:
-        # 1. 查询阶段把边转成 dict，便于构造扩散矩阵。
+        edges, _ = self.load_edges_with_meta()
+        return edges
+
+    # 读取全部共激活边和更新时间。
+    def load_edges_with_meta(
+        self,
+    ) -> tuple[dict[tuple[str, str], float], dict[tuple[str, str], float]]:
         with self._lock:
             rows = self._db.execute(
-                "SELECT src_key, dst_key, weight FROM akasha_edges"
+                "SELECT src_key, dst_key, weight, last_used_ts FROM akasha_edges"
             ).fetchall()
-        return {
+        edges = {
             (str(row["src_key"]), str(row["dst_key"])): float(row["weight"] or 0.0)
             for row in rows
         }
+        meta = {
+            (str(row["src_key"]), str(row["dst_key"])): float(row["last_used_ts"] or 0.0)
+            for row in rows
+        }
+        return edges, meta
 
     # 批量更新被激活节点的长期状态。
     def update_activation_batch(self, updates: list[ActivationUpdate]) -> None:
@@ -539,7 +593,7 @@ class AkashaStore:
                     continue
                 row = self._db.execute(
                     """
-                    SELECT weight, co_count
+                    SELECT weight, co_count, last_used_ts
                     FROM akasha_edges
                     WHERE src_key = ? AND dst_key = ?
                     """,
@@ -552,8 +606,12 @@ class AkashaStore:
                         (item.src_key, item.dst_key, weight, item.ts),
                     )
                     continue
-                old = float(row["weight"] or 0.0) * 0.9995
-                new_weight = old + 0.12 * item.strength * max(0.0, 1.0 - old / 2.0)
+                old = effective_edge_weight(
+                    float(row["weight"] or 0.0),
+                    float(row["last_used_ts"] or 0.0),
+                    item.ts,
+                )
+                new_weight = bounded_add(old, 0.12 * item.strength, 2.0)
                 _ = self._db.execute(
                     """
                     UPDATE akasha_edges
@@ -711,30 +769,26 @@ class AkashaStore:
         ripple_items_json: str,
         text_block_preview: str,
     ) -> None:
-        # 1. 写失败不中断主链路，只记录到 warning。
-        import logging
-        try:
-            with self._lock:
-                _ = self._db.execute(
-                    """
-                    INSERT OR REPLACE INTO akasha_query_log (
-                        query_id, session_key, seq, query_text, intent, ts,
-                        seed_count, pool_count, activated_count, activation_threshold,
-                        dense_count, ripple_count, inject_chars, source_ref_count,
-                        activation_items, dense_items, ripple_items, text_block_preview
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        query_id, session_key, seq, query_text, intent, ts,
-                        seed_count, pool_count, activated_count, activation_threshold,
-                        dense_count, ripple_count, inject_chars, source_ref_count,
-                        activation_items_json, dense_items_json, ripple_items_json,
-                        text_block_preview,
-                    ),
-                )
-                self._db.commit()
-        except Exception:
-            logging.getLogger("akasha.store").warning("insert_query_log failed", exc_info=True)
+        # 1. 诊断日志是可验收状态，写失败要直接暴露。
+        with self._lock:
+            _ = self._db.execute(
+                """
+                INSERT OR REPLACE INTO akasha_query_log (
+                    query_id, session_key, seq, query_text, intent, ts,
+                    seed_count, pool_count, activated_count, activation_threshold,
+                    dense_count, ripple_count, inject_chars, source_ref_count,
+                    activation_items, dense_items, ripple_items, text_block_preview
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    query_id, session_key, seq, query_text, intent, ts,
+                    seed_count, pool_count, activated_count, activation_threshold,
+                    dense_count, ripple_count, inject_chars, source_ref_count,
+                    activation_items_json, dense_items_json, ripple_items_json,
+                    text_block_preview,
+                ),
+            )
+            self._db.commit()
 
     # 读取检索诊断日志列表（仅轻量字段）。
     def list_query_logs(

--- a/plugins/akasha/store.py
+++ b/plugins/akasha/store.py
@@ -1,0 +1,754 @@
+from __future__ import annotations
+
+import sqlite3
+import struct
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS akasha_nodes (
+    key                TEXT PRIMARY KEY,
+    anchor_id          TEXT NOT NULL,
+    session_key        TEXT NOT NULL,
+    turn_seq           INTEGER NOT NULL,
+    first_ts_unix      REAL NOT NULL,
+    salience           REAL NOT NULL,
+    strength           REAL NOT NULL,
+    resource           REAL NOT NULL,
+    recall_count       INTEGER NOT NULL,
+    last_activated_seq INTEGER NOT NULL,
+    last_strength_seq  INTEGER NOT NULL,
+    last_resource_seq  INTEGER NOT NULL,
+    embedding          BLOB NOT NULL,
+    emb_count          INTEGER NOT NULL,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_akasha_nodes_session_seq
+    ON akasha_nodes (session_key, turn_seq);
+CREATE TABLE IF NOT EXISTS akasha_edges (
+    src_key       TEXT NOT NULL,
+    dst_key       TEXT NOT NULL,
+    weight        REAL NOT NULL,
+    co_count      INTEGER NOT NULL,
+    last_used_seq INTEGER NOT NULL,
+    PRIMARY KEY (src_key, dst_key)
+);
+CREATE INDEX IF NOT EXISTS ix_akasha_edges_src
+    ON akasha_edges (src_key);
+CREATE INDEX IF NOT EXISTS ix_akasha_edges_dst
+    ON akasha_edges (dst_key);
+CREATE TABLE IF NOT EXISTS akasha_activation_events (
+    seq           INTEGER NOT NULL,
+    query_id      TEXT NOT NULL,
+    activated_key TEXT NOT NULL,
+    source        TEXT NOT NULL,
+    score         REAL NOT NULL,
+    direct_score  REAL NOT NULL,
+    state_score   REAL NOT NULL,
+    edge_score    REAL NOT NULL,
+    long_score    REAL NOT NULL,
+    resource      REAL NOT NULL,
+    fan           INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_akasha_events_seq
+    ON akasha_activation_events (seq);
+CREATE TABLE IF NOT EXISTS akasha_embedding_cache (
+    message_id   TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    model        TEXT NOT NULL,
+    embedding    BLOB NOT NULL,
+    dim          INTEGER NOT NULL,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    PRIMARY KEY (message_id, model)
+);
+CREATE INDEX IF NOT EXISTS ix_akasha_embedding_cache_hash
+    ON akasha_embedding_cache (content_hash, model);
+CREATE TABLE IF NOT EXISTS akasha_migration_runs (
+    id               TEXT PRIMARY KEY,
+    source_db_path   TEXT NOT NULL,
+    target_db_path   TEXT NOT NULL,
+    embedding_model  TEXT NOT NULL,
+    started_at       TEXT NOT NULL,
+    finished_at      TEXT,
+    status           TEXT NOT NULL,
+    message_count    INTEGER NOT NULL DEFAULT 0,
+    activation_count INTEGER NOT NULL DEFAULT 0,
+    cache_hit_count  INTEGER NOT NULL DEFAULT 0,
+    cache_miss_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS akasha_source_session_snapshot (
+    run_id            TEXT NOT NULL,
+    session_key       TEXT NOT NULL,
+    last_consolidated INTEGER NOT NULL,
+    next_seq          INTEGER NOT NULL,
+    max_seq           INTEGER NOT NULL,
+    PRIMARY KEY (run_id, session_key)
+);
+"""
+
+RESET_SQL = """
+DROP TABLE IF EXISTS akasha_activation_events;
+DROP TABLE IF EXISTS akasha_edges;
+DROP TABLE IF EXISTS akasha_nodes;
+"""
+
+
+@dataclass(frozen=True)
+class SourceMessage:
+    id: str
+    session_key: str
+    seq: int
+    role: str
+    content: str
+    ts: str
+    salience: float | None = None
+
+
+@dataclass(frozen=True)
+class AkashaNode:
+    key: str
+    anchor_id: str
+    session_key: str
+    turn_seq: int
+    first_ts_unix: float
+    salience: float
+    strength: float
+    resource: float
+    recall_count: int
+    last_activated_seq: int
+    last_strength_seq: int
+    last_resource_seq: int
+    embedding: np.ndarray
+    emb_count: int
+
+
+@dataclass(frozen=True)
+class ActivationUpdate:
+    key: str
+    strength: float
+    resource: float
+    recall_count: int
+    seq: int
+
+
+@dataclass(frozen=True)
+class EdgeUpdate:
+    src_key: str
+    dst_key: str
+    strength: float
+    seq: int
+
+
+@dataclass(frozen=True)
+class ActivationEventRow:
+    seq: int
+    query_id: str
+    activated_key: str
+    source: str
+    score: float
+    direct_score: float
+    state_score: float
+    edge_score: float
+    long_score: float
+    resource: float
+    fan: int
+
+
+@dataclass(frozen=True)
+class SourceSessionSnapshot:
+    session_key: str
+    last_consolidated: int
+    next_seq: int
+    max_seq: int
+
+
+# 把 message 映射成原始 cross CLI 使用的 turn key。
+def turn_key(session_key: str, seq: int, role: str) -> tuple[str, int, str]:
+    # 1. assistant 归到前一个 user turn，user 归到自身 seq。
+    turn_seq = seq if role == "user" else max(0, seq - 1)
+    return session_key, turn_seq, f"{session_key}:{turn_seq}"
+
+
+# 把向量打包成 float32 BLOB。
+def serialize_f32(vector: np.ndarray) -> bytes:
+    # 1. 数据库只保存紧凑 float32，避免 JSON 大字段膨胀。
+    values = vector.astype(np.float32).tolist()
+    return struct.pack(f"{len(values)}f", *values)
+
+
+# 从 float32 BLOB 还原向量。
+def deserialize_f32(blob: bytes) -> np.ndarray:
+    # 1. 空向量不应该写入，这里按空数组兜底。
+    if not blob:
+        return np.array([], dtype=np.float32)
+    return np.array(struct.unpack(f"{len(blob) // 4}f", blob), dtype=np.float32)
+
+
+# 把时间字符串转换成 Unix 秒。
+def parse_ts_unix(value: str) -> float:
+    # 1. 优先使用 sessions.db 里的 ISO 时间。
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except Exception:
+        return datetime.now(timezone.utc).timestamp()
+
+
+# 计算 message 内容指纹。
+def content_hash(content: str) -> str:
+    # 1. cache 命中必须同时匹配 message_id、model 和原文内容。
+    import hashlib
+
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+# 生成 UTC ISO 时间。
+def _now_iso() -> str:
+    # 1. sidecar 内部时间统一用 UTC。
+    return datetime.now(timezone.utc).isoformat()
+
+
+# 把向量归一化到单位长度。
+def _normalize(vector: np.ndarray) -> np.ndarray:
+    # 1. cross CLI 默认使用归一化 embedding；这里保持同一语义。
+    norm = float(np.linalg.norm(vector))
+    if norm <= 0:
+        return vector.astype(np.float32)
+    return (vector / norm).astype(np.float32)
+
+
+class AkashaStore:
+    def __init__(self, db_path: str | Path) -> None:
+        # 1. 初始化 sidecar 数据库和 schema。
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._closed = False
+        self.ensure_schema()
+
+    # 关闭 SQLite 连接。
+    def close(self) -> None:
+        # 1. close 需要幂等，方便 runtime 多路径收尾。
+        if self._closed:
+            return
+        self._db.close()
+        self._closed = True
+
+    # 确保 Akasha schema 存在。
+    def ensure_schema(self) -> None:
+        # 1. schema 可重复执行，用于启动和迁移前检查。
+        with self._lock:
+            _ = self._db.executescript(SCHEMA)
+            self._db.commit()
+
+    # 清空并重建 Akasha 状态表。
+    def reset_schema(self) -> None:
+        # 1. 只清 replay 产物，保留 embedding cache 和迁移记录。
+        with self._lock:
+            _ = self._db.executescript(RESET_SQL)
+            _ = self._db.executescript(SCHEMA)
+            self._db.commit()
+
+    # 读取可复用的 message embedding。
+    def get_cached_embedding(
+        self,
+        *,
+        message: SourceMessage,
+        model: str,
+    ) -> list[float] | None:
+        # 1. 同一 message id 只有在内容和模型都一致时复用。
+        digest = content_hash(message.content)
+        with self._lock:
+            row = self._db.execute(
+                """
+                SELECT embedding
+                FROM akasha_embedding_cache
+                WHERE message_id = ? AND model = ? AND content_hash = ?
+                """,
+                (message.id, model, digest),
+            ).fetchone()
+        if row is None:
+            return None
+        return deserialize_f32(row["embedding"]).astype(float).tolist()
+
+    # 写入或刷新 message embedding cache。
+    def upsert_cached_embedding(
+        self,
+        *,
+        message: SourceMessage,
+        model: str,
+        embedding: list[float],
+    ) -> None:
+        # 1. message 内容变更时覆盖同 model 的旧 embedding。
+        vector = np.array(embedding, dtype=np.float32)
+        now = _now_iso()
+        with self._lock:
+            _ = self._db.execute(
+                """
+                INSERT INTO akasha_embedding_cache
+                    (message_id, content_hash, model, embedding, dim, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(message_id, model) DO UPDATE SET
+                    content_hash = excluded.content_hash,
+                    embedding = excluded.embedding,
+                    dim = excluded.dim,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    message.id,
+                    content_hash(message.content),
+                    model,
+                    serialize_f32(vector),
+                    int(vector.size),
+                    now,
+                    now,
+                ),
+            )
+            self._db.commit()
+
+    # 读取指定模型的全部 message embedding cache。
+    def list_cached_embeddings(self, *, model: str) -> list[tuple[str, np.ndarray]]:
+        # 1. Dense 展示使用 message-level embedding，再映射回 turn。
+        with self._lock:
+            rows = self._db.execute(
+                """
+                SELECT message_id, embedding
+                FROM akasha_embedding_cache
+                WHERE model = ?
+                """,
+                (model,),
+            ).fetchall()
+        return [
+            (str(row["message_id"]), deserialize_f32(row["embedding"]))
+            for row in rows
+        ]
+
+    # 开始记录一次 Akasha 迁移。
+    def start_migration_run(
+        self,
+        *,
+        source_db_path: Path,
+        embedding_model: str,
+    ) -> str:
+        # 1. run 记录只保存路径和模型，不保存密钥。
+        run_id = uuid.uuid4().hex
+        now = _now_iso()
+        with self._lock:
+            _ = self._db.execute(
+                """
+                INSERT INTO akasha_migration_runs
+                    (id, source_db_path, target_db_path, embedding_model, started_at, status)
+                VALUES (?, ?, ?, ?, ?, 'running')
+                """,
+                (
+                    run_id,
+                    str(source_db_path),
+                    str(self.db_path),
+                    embedding_model,
+                    now,
+                ),
+            )
+            self._db.commit()
+        return run_id
+
+    # 完成一次 Akasha 迁移记录。
+    def finish_migration_run(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        message_count: int,
+        activation_count: int,
+        cache_hit_count: int,
+        cache_miss_count: int,
+    ) -> None:
+        # 1. 脚本失败时也写入 status，便于知道当前 sidecar 是否可信。
+        with self._lock:
+            _ = self._db.execute(
+                """
+                UPDATE akasha_migration_runs
+                SET finished_at = ?,
+                    status = ?,
+                    message_count = ?,
+                    activation_count = ?,
+                    cache_hit_count = ?,
+                    cache_miss_count = ?
+                WHERE id = ?
+                """,
+                (
+                    _now_iso(),
+                    status,
+                    message_count,
+                    activation_count,
+                    cache_hit_count,
+                    cache_miss_count,
+                    run_id,
+                ),
+            )
+            self._db.commit()
+
+    # 保存迁移开始时的 session 游标快照。
+    def insert_session_snapshots(
+        self,
+        *,
+        run_id: str,
+        snapshots: list[SourceSessionSnapshot],
+    ) -> None:
+        # 1. 只记录旧系统游标，不修改 sessions.db。
+        if not snapshots:
+            return
+        with self._lock:
+            _ = self._db.executemany(
+                """
+                INSERT OR REPLACE INTO akasha_source_session_snapshot
+                    (run_id, session_key, last_consolidated, next_seq, max_seq)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        run_id,
+                        item.session_key,
+                        item.last_consolidated,
+                        item.next_seq,
+                        item.max_seq,
+                    )
+                    for item in snapshots
+                ],
+            )
+            self._db.commit()
+
+    # 插入或更新一条 message 对应的 turn 节点。
+    def upsert_message_node(
+        self,
+        message: SourceMessage,
+        embedding: list[float],
+    ) -> str:
+        # 1. 按 cross CLI 规则把 user/assistant 映射到同一个 turn key。
+        session_key, turn_seq, key = turn_key(
+            message.session_key,
+            message.seq,
+            message.role,
+        )
+        vector = _normalize(np.array(embedding, dtype=np.float32))
+        ts_unix = parse_ts_unix(message.ts)
+        salience = (
+            0.0
+            if message.salience is None
+            else min(1.0, max(0.0, float(message.salience)))
+        )
+        now = _now_iso()
+
+        # 2. 新 turn 直接写入；已有 turn 用均值更新 embedding，并保留 user 作为 anchor。
+        with self._lock:
+            row = self._db.execute(
+                "SELECT * FROM akasha_nodes WHERE key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                _ = self._db.execute(
+                    """
+                    INSERT INTO akasha_nodes
+                        (key, anchor_id, session_key, turn_seq, first_ts_unix,
+                         salience, strength, resource, recall_count,
+                         last_activated_seq, last_strength_seq, last_resource_seq,
+                         embedding, emb_count, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, 0.0, 1.0, 0, 0, ?, ?, ?, 1, ?, ?)
+                    """,
+                    (
+                        key,
+                        message.id,
+                        session_key,
+                        turn_seq,
+                        ts_unix,
+                        salience,
+                        message.seq,
+                        message.seq,
+                        serialize_f32(vector),
+                        now,
+                        now,
+                    ),
+                )
+                self._db.commit()
+                return key
+
+            old_embedding = deserialize_f32(row["embedding"])
+            old_count = max(1, int(row["emb_count"] or 1))
+            merged = _normalize(old_embedding * old_count + vector)
+            anchor_id = message.id if message.role == "user" else str(row["anchor_id"])
+            _ = self._db.execute(
+                """
+                UPDATE akasha_nodes
+                SET anchor_id = ?,
+                    salience = ?,
+                    embedding = ?,
+                    emb_count = ?,
+                    updated_at = ?
+                WHERE key = ?
+                """,
+                (
+                    anchor_id,
+                    max(float(row["salience"] or 0.0), salience),
+                    serialize_f32(merged),
+                    old_count + 1,
+                    now,
+                    key,
+                ),
+            )
+            self._db.commit()
+        return key
+
+    # 读取全部 turn 节点。
+    def list_nodes(self) -> list[AkashaNode]:
+        # 1. 查询阶段一次性读入节点，和 cross CLI 的内存图保持一致。
+        with self._lock:
+            rows = self._db.execute("SELECT * FROM akasha_nodes").fetchall()
+        return [node for row in rows if (node := _row_to_node(row)) is not None]
+
+    # 读取全部共激活边。
+    def load_edges(self) -> dict[tuple[str, str], float]:
+        # 1. 查询阶段把边转成 dict，便于构造扩散矩阵。
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT src_key, dst_key, weight FROM akasha_edges"
+            ).fetchall()
+        return {
+            (str(row["src_key"]), str(row["dst_key"])): float(row["weight"] or 0.0)
+            for row in rows
+        }
+
+    # 批量更新被激活节点的长期状态。
+    def update_activation_batch(self, updates: list[ActivationUpdate]) -> None:
+        # 1. 查询阶段只更新旧节点状态，不创建当前 turn 的边。
+        if not updates:
+            return
+        now = _now_iso()
+        with self._lock:
+            _ = self._db.executemany(
+                """
+                UPDATE akasha_nodes
+                SET strength = ?,
+                    resource = ?,
+                    recall_count = ?,
+                    last_activated_seq = ?,
+                    last_strength_seq = ?,
+                    last_resource_seq = ?,
+                    updated_at = ?
+                WHERE key = ?
+                """,
+                [
+                    (
+                        item.strength,
+                        item.resource,
+                        item.recall_count,
+                        item.seq,
+                        item.seq,
+                        item.seq,
+                        now,
+                        item.key,
+                    )
+                    for item in updates
+                ],
+            )
+            self._db.commit()
+
+    # 批量写入或增强共激活边。
+    def upsert_edges(self, updates: list[EdgeUpdate]) -> None:
+        # 1. after-turn 拿到真实 user message id 后，再建立当前 turn 和旧节点的边。
+        if not updates:
+            return
+        with self._lock:
+            for item in updates:
+                if item.src_key == item.dst_key:
+                    continue
+                row = self._db.execute(
+                    """
+                    SELECT weight, co_count
+                    FROM akasha_edges
+                    WHERE src_key = ? AND dst_key = ?
+                    """,
+                    (item.src_key, item.dst_key),
+                ).fetchone()
+                if row is None:
+                    weight = 0.12 * item.strength
+                    _ = self._db.execute(
+                        "INSERT INTO akasha_edges VALUES (?, ?, ?, 1, ?)",
+                        (item.src_key, item.dst_key, weight, item.seq),
+                    )
+                    continue
+                old = float(row["weight"] or 0.0) * 0.9995
+                new_weight = old + 0.12 * item.strength * max(0.0, 1.0 - old / 2.0)
+                _ = self._db.execute(
+                    """
+                    UPDATE akasha_edges
+                    SET weight = ?,
+                        co_count = ?,
+                        last_used_seq = ?
+                    WHERE src_key = ? AND dst_key = ?
+                    """,
+                    (
+                        new_weight,
+                        int(row["co_count"] or 0) + 1,
+                        item.seq,
+                        item.src_key,
+                        item.dst_key,
+                    ),
+                )
+            self._db.commit()
+
+    # 批量记录本轮激活诊断事件。
+    def insert_activation_events(self, rows: list[ActivationEventRow]) -> None:
+        # 1. 诊断事件只用于观察，不参与原始事实来源。
+        if not rows:
+            return
+        with self._lock:
+            _ = self._db.executemany(
+                """
+                INSERT INTO akasha_activation_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        row.seq,
+                        row.query_id,
+                        row.activated_key,
+                        row.source,
+                        row.score,
+                        row.direct_score,
+                        row.state_score,
+                        row.edge_score,
+                        row.long_score,
+                        row.resource,
+                        row.fan,
+                    )
+                    for row in rows
+                ],
+            )
+            self._db.commit()
+
+    # 读取 dashboard 需要的节点列表。
+    def list_items_for_dashboard(
+        self,
+        *,
+        q: str = "",
+        page: int = 1,
+        page_size: int = 50,
+        sort_by: str = "updated_at",
+        sort_order: str = "desc",
+    ) -> tuple[list[dict[str, object]], int]:
+        # 1. Akasha dashboard MVP 只展示节点状态，不展示原文。
+        where = ""
+        params: list[object] = []
+        if q.strip():
+            where = "WHERE key LIKE ? OR anchor_id LIKE ?"
+            like = f"%{q.strip()}%"
+            params.extend([like, like])
+        safe_sort = sort_by if sort_by in {"updated_at", "first_ts_unix", "strength", "resource"} else "updated_at"
+        safe_order = "ASC" if sort_order.lower() == "asc" else "DESC"
+        page = max(1, int(page))
+        page_size = max(1, min(int(page_size), 200))
+        offset = (page - 1) * page_size
+        with self._lock:
+            count_row = self._db.execute(
+                f"SELECT COUNT(1) AS c FROM akasha_nodes {where}",
+                params,
+            ).fetchone()
+            rows = self._db.execute(
+                f"""
+                SELECT *
+                FROM akasha_nodes
+                {where}
+                ORDER BY {safe_sort} {safe_order}
+                LIMIT ? OFFSET ?
+                """,
+                [*params, page_size, offset],
+            ).fetchall()
+        total = int((count_row["c"] if count_row else 0) or 0)
+        return [_node_row_to_dashboard(row) for row in rows], total
+
+    # 按 id 读取 dashboard 节点详情。
+    def get_item_for_dashboard(self, item_id: str) -> dict[str, object] | None:
+        # 1. item_id 对应 turn key。
+        with self._lock:
+            row = self._db.execute(
+                "SELECT * FROM akasha_nodes WHERE key = ?",
+                (item_id,),
+            ).fetchone()
+        return _node_row_to_dashboard(row) if row is not None else None
+
+    # 物理删除一个 Akasha 节点和相关边。
+    def delete_item(self, item_id: str) -> bool:
+        # 1. 删除只影响 sidecar，不影响 sessions.db 原始消息。
+        with self._lock:
+            cur = self._db.execute("DELETE FROM akasha_nodes WHERE key = ?", (item_id,))
+            _ = self._db.execute(
+                "DELETE FROM akasha_edges WHERE src_key = ? OR dst_key = ?",
+                (item_id, item_id),
+            )
+            self._db.commit()
+        return cur.rowcount > 0
+
+    # 批量物理删除 Akasha 节点。
+    def delete_items_batch(self, ids: list[str]) -> int:
+        # 1. 复用单删逻辑，保持边清理一致。
+        count = 0
+        for item_id in ids:
+            if self.delete_item(item_id):
+                count += 1
+        return count
+
+
+# 把 SQLite row 转成 AkashaNode。
+def _row_to_node(row: sqlite3.Row) -> AkashaNode | None:
+    # 1. embedding 损坏时跳过该节点，避免一次坏数据打断整轮检索。
+    embedding = deserialize_f32(row["embedding"])
+    if embedding.size == 0:
+        return None
+    return AkashaNode(
+        key=str(row["key"]),
+        anchor_id=str(row["anchor_id"]),
+        session_key=str(row["session_key"]),
+        turn_seq=int(row["turn_seq"]),
+        first_ts_unix=float(row["first_ts_unix"] or 0.0),
+        salience=float(row["salience"] or 0.0),
+        strength=float(row["strength"] or 0.0),
+        resource=float(row["resource"] or 1.0),
+        recall_count=int(row["recall_count"] or 0),
+        last_activated_seq=int(row["last_activated_seq"] or 0),
+        last_strength_seq=int(row["last_strength_seq"] or 0),
+        last_resource_seq=int(row["last_resource_seq"] or 0),
+        embedding=embedding,
+        emb_count=int(row["emb_count"] or 1),
+    )
+
+
+# 把节点 row 转成 dashboard 通用 item。
+def _node_row_to_dashboard(row: sqlite3.Row) -> dict[str, object]:
+    # 1. dashboard 使用 MemoryAdminApi 的通用字段名。
+    return {
+        "id": str(row["key"]),
+        "memory_type": "turn",
+        "summary": str(row["key"]),
+        "source_ref": str(row["anchor_id"]),
+        "status": "active",
+        "created_at": str(row["created_at"] or ""),
+        "updated_at": str(row["updated_at"] or ""),
+        "happened_at": str(row["first_ts_unix"] or ""),
+        "extra_json": {
+            "session_key": str(row["session_key"]),
+            "turn_seq": int(row["turn_seq"]),
+            "strength": float(row["strength"] or 0.0),
+            "resource": float(row["resource"] or 1.0),
+            "recall_count": int(row["recall_count"] or 0),
+            "emb_count": int(row["emb_count"] or 1),
+        },
+        "has_embedding": True,
+        "embedding_dim": len(deserialize_f32(row["embedding"])),
+    }

--- a/plugins/citation/plugin.py
+++ b/plugins/citation/plugin.py
@@ -13,7 +13,7 @@ _REASONING_CTX_SLOT = "reasoning:ctx"
 _PERSIST_CITED_SLOT = "persist:assistant:cited_memory_ids"
 _TRAILING_PROTOCOL_TAG = r"<[a-zA-Z][a-zA-Z0-9_-]*:[^<>\s]+>"
 _CITED_RE = re.compile(
-    rf"(?:\n|\r\n)?§cited:\[([A-Za-z0-9_,\-\s]*)\]§(?P<trailing>(?:\s*{_TRAILING_PROTOCOL_TAG}\s*)*)$",
+    rf"(?:\n|\r\n)?§cited:\[([A-Za-z0-9_:,\-\s]*)\]§(?P<trailing>(?:\s*{_TRAILING_PROTOCOL_TAG}\s*)*)$",
     re.IGNORECASE,
 )
 _TRAILING_PROTOCOL_TAGS_RE = re.compile(

--- a/plugins/meme/plugin.py
+++ b/plugins/meme/plugin.py
@@ -11,6 +11,7 @@ from .runtime import MemeCatalog, MemeDecorator
 
 _CTX_SLOT = "prompt:ctx"
 _MEME_RE = re.compile(r"<meme:([a-zA-Z0-9_-]+)>", re.IGNORECASE)
+_MEME_PROTOCOL_RE = re.compile(r"<meme:[^>]*>", re.IGNORECASE)
 
 
 class MemePromptModule:
@@ -75,7 +76,7 @@ class MemePlugin(Plugin):
 
 def _extract_meme_tag(response: str) -> tuple[str, str | None]:
     first = _MEME_RE.search(response)
-    cleaned = _MEME_RE.sub("", response).strip()
+    cleaned = _MEME_PROTOCOL_RE.sub("", response).strip()
     if first is None:
         return cleaned, None
     return cleaned, first.group(1).lower()

--- a/proactive_v2/tools.py
+++ b/proactive_v2/tools.py
@@ -205,14 +205,14 @@ TERMINAL_TOOL_SCHEMAS: list[dict] = [
 
 async def _recall_memory(ctx: AgentTickContext, args: dict, *, memory) -> str:
     query = args["query"]
-    hits = await _retrieve_interest_hits(memory=memory, query=query)
+    hits = await _retrieve_interest_hits(memory=memory, query=query, timestamp=ctx.now_utc)
     if not hits:
         return json.dumps({"result": "", "hits": 0}, ensure_ascii=False)
     texts = [h.get("text", "") for h in hits if h.get("text")]
     return json.dumps({"result": "\n---\n".join(texts), "hits": len(hits)}, ensure_ascii=False)
 
 
-async def _retrieve_interest_hits(*, memory, query: str) -> list[dict]:
+async def _retrieve_interest_hits(*, memory, query: str, timestamp) -> list[dict]:
     if memory is None:
         return []
 
@@ -222,6 +222,7 @@ async def _retrieve_interest_hits(*, memory, query: str) -> list[dict]:
             text=query,
             intent="interest",
             limit=2,
+            timestamp=timestamp,
         )
     )
     return [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pyright>=1.1.403
 pytest>=9.0.0
 pytest-asyncio>=1.3.0
 pytest-cov>=6.0.0
+httpx2>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ ftfy>=6.3.1
 html2text>=2025.4.0
 httpx[socks]>=0.28.0
 json_repair>=0.58.0
+jieba>=0.42.1
 lxml>=6.0.0
 markdown-it-py>=4.0.0
 mdit-py-plugins>=0.5.0

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
+import json
 import shutil
 import sqlite3
 import sys
@@ -11,7 +11,7 @@ from contextlib import closing
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, cast
 
 import numpy as np
 
@@ -20,26 +20,16 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from agent.config_models import Config
-from core.net.http import SharedHttpResources
-from memory2.embedder import Embedder
 from plugins.akasha.config import (
     AkashaConfig,
     load_akasha_config,
     resolve_akasha_db_path,
 )
-from plugins.akasha.engine import (
-    AkashaCandidate,
-    _activation_updates,
-    _compute_candidates,
-    _fan_counts,
-)
+from plugins.akasha.core import SourceMessage
+from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage
 from plugins.akasha.store import (
-    ActivationEventRow,
     AkashaStore,
-    EdgeUpdate,
-    SourceMessage,
     SourceSessionSnapshot,
-    turn_key,
 )
 
 
@@ -68,7 +58,6 @@ def _parse_args() -> argparse.Namespace:
     )
     _ = parser.add_argument("--sessions-db", default="", help="原始 sessions.db 路径")
     _ = parser.add_argument("--db-path", default="", help="输出 akasha.db 路径")
-    _ = parser.add_argument("--batch-size", type=int, default=10, help="embedding 批大小")
     _ = parser.add_argument("--progress-every", type=int, default=500, help="进度打印间隔")
     return parser.parse_args()
 
@@ -85,36 +74,20 @@ def _load_script_config(
     return config
 
 
-# 构造 embedding 客户端。
-def _build_embedder(
-    *,
-    config: Config,
-    http_resources: SharedHttpResources,
-) -> Embedder:
-    # 1. 复用运行时的 embedding 配置和 HTTP requester。
-    embedding = config.memory.embedding
-    return Embedder(
-        base_url=embedding.base_url or config.light_base_url or config.base_url or "",
-        api_key=embedding.api_key or config.light_api_key or config.api_key,
-        model=embedding.model,
-        requester=http_resources.external_default,
-    )
-
-
 # 读取 sessions.db 中的原始消息。
 def _iter_source_batches(
     *,
     sessions_db: Path,
     batch_size: int,
 ) -> Iterator[list[SourceMessage]]:
-    # 1. 按 cross CLI 的 session_key, seq 顺序 replay。
+    # 1. 按真实时间顺序 replay，避免后来的 turn 提前进入历史图。
     with closing(sqlite3.connect(str(sessions_db))) as db:
         cursor = db.execute(
             """
             SELECT id, session_key, seq, role, content, ts
             FROM messages
             WHERE role IN ('user', 'assistant')
-            ORDER BY session_key, seq
+            ORDER BY COALESCE(datetime(ts), ts), session_key, seq
             """
         )
         while rows := cursor.fetchmany(max(1, batch_size)):
@@ -168,6 +141,26 @@ def _load_session_snapshots(sessions_db: Path) -> list[SourceSessionSnapshot]:
     ]
 
 
+# 读取不应进入 Akasha 的消息。
+def _load_skip_message_ids(sessions_db: Path) -> set[str]:
+    result: set[str] = set()
+    with closing(sqlite3.connect(str(sessions_db))) as db:
+        rows = db.execute("SELECT id, extra FROM messages").fetchall()
+    for message_id, raw_extra in rows:
+        try:
+            parsed: object = json.loads(str(raw_extra or "{}"))
+        except json.JSONDecodeError:
+            parsed = {}
+        extra = cast(dict[str, object], parsed) if isinstance(parsed, dict) else {}
+        if bool(extra.get("proactive")) or bool(extra.get("skip_post_memory")):
+            result.add(str(message_id))
+    return result
+
+
+def _skip_message(message: SourceMessage, skip_message_ids: set[str]) -> bool:
+    return message.id in skip_message_ids or message.content.startswith("[后台任务完成]")
+
+
 # 备份已有 Akasha sidecar。
 def _backup_existing_db(db_path: Path) -> Path | None:
     # 1. 重建前保留旧库，避免迁移脚本误覆盖唯一状态。
@@ -179,74 +172,22 @@ def _backup_existing_db(db_path: Path) -> Path | None:
     return backup_path
 
 
-# 从 cache 读取 embedding，缺失时批量调用 embedding API。
-async def _embed_batch_with_cache(
+# 从 cache 读取回放需要的 embedding，缺失时跳过对应消息。
+def _load_embeddings_from_cache(
     *,
     store: AkashaStore,
-    embedder: Embedder,
-    model: str,
-    batch: list[SourceMessage],
-) -> tuple[list[list[float]], int, int]:
-    # 1. 先按 message_id + content_hash + model 查 cache。
-    embeddings: list[list[float] | None] = []
-    missing: list[tuple[int, SourceMessage]] = []
-    cache_hits = 0
-    for index, message in enumerate(batch):
-        cached = store.get_cached_embedding(message=message, model=model)
-        embeddings.append(cached)
-        if cached is None:
-            missing.append((index, message))
-        else:
-            cache_hits += 1
-
-    # 2. 只对缺口调用远端 embedding，并立刻写回 cache。
-    cache_misses = len(missing)
-    if missing:
-        fresh = await embedder.embed_batch([
-            message.content if message.content.strip() else " "
-            for _, message in missing
-        ])
-        for (index, message), embedding in zip(missing, fresh, strict=False):
-            store.upsert_cached_embedding(
-                message=message,
-                model=model,
-                embedding=embedding,
-            )
-            embeddings[index] = embedding
-
-    # 3. 返回顺序必须和 batch 一致，后面的 replay 依赖消息顺序。
-    ordered: list[list[float]] = []
-    for embedding in embeddings:
-        if embedding is None:
-            raise RuntimeError("embedding cache 写入后仍有缺口")
-        ordered.append(embedding)
-    return ordered, cache_hits, cache_misses
-
-
-# 确保全量 message embedding 都在 cache 里。
-async def _ensure_embeddings_with_cache(
-    *,
-    store: AkashaStore,
-    embedder: Embedder,
     model: str,
     messages: list[SourceMessage],
-    batch_size: int,
 ) -> tuple[dict[str, list[float]], int, int]:
-    # 1. 按批次补齐缺失 embedding，但 replay 之前先拿到完整向量表。
     embedding_map: dict[str, list[float]] = {}
     cache_hits = 0
     cache_misses = 0
-    for index in range(0, len(messages), max(1, batch_size)):
-        batch = messages[index : index + max(1, batch_size)]
-        embeddings, batch_hits, batch_misses = await _embed_batch_with_cache(
-            store=store,
-            embedder=embedder,
-            model=model,
-            batch=batch,
-        )
-        cache_hits += batch_hits
-        cache_misses += batch_misses
-        for message, embedding in zip(batch, embeddings, strict=False):
+    for message in messages:
+        embedding = store.get_cached_embedding(message=message, model=model)
+        if embedding is None:
+            cache_misses += 1
+        else:
+            cache_hits += 1
             embedding_map[message.id] = embedding
     return embedding_map, cache_hits, cache_misses
 
@@ -274,6 +215,8 @@ def _compute_salience_map(
     for index, (message, _) in enumerate(available):
         session_sorted.setdefault(message.session_key, []).append(index)
         seq_index[(message.session_key, message.seq)] = index
+    for indices in session_sorted.values():
+        indices.sort(key=lambda item: available[item][0].seq)
 
     # 2. 先计算每个 session 的质心。
     centroids: dict[str, np.ndarray] = {}
@@ -342,99 +285,33 @@ def _normalize_vector(vector: np.ndarray) -> np.ndarray:
     return vector / norm if norm > 0 else vector
 
 
-# 在写入当前 user turn 前，按 cross CLI 规则激活历史节点。
-def _activate_before_upsert(
-    *,
-    store: AkashaStore,
-    message: SourceMessage,
-    embedding: list[float],
-    config: AkashaConfig,
-    source_cursor: sqlite3.Cursor,
-) -> int:
-    # 1. 只有 user 输入会触发状态激活。
-    if message.role != "user":
-        return 0
-    nodes = {node.key: node for node in store.list_nodes()}
-    if not nodes:
-        return 0
-
-    # 2. 使用当前 user embedding 检索历史节点，并更新旧节点状态。
-    edges = store.load_edges()
-    candidates, _, _ = _compute_candidates(
-        message.content,
-        np.array(embedding, dtype=np.float32),
-        nodes,
-        edges,
-        message.seq,
-        config=config,
-        fan=_fan_counts(edges),
-        source_cursor=source_cursor,
-        soft_recall=False,
-        return_limit=config.activate_limit,
-    )
-    store.update_activation_batch(_activation_updates(candidates, nodes, message.seq))
-
-    # 3. 当前 turn key 先参与建边，随后再被 upsert_message_node 写成节点。
-    current_key = turn_key(message.session_key, message.seq, message.role)[2]
-    store.upsert_edges(_edge_updates(current_key, candidates, message.seq))
-    store.insert_activation_events(_activation_events(message, candidates))
-    return len(candidates)
-
-
-# 把一轮激活候选转成共激活边。
-def _edge_updates(
-    current_key: str,
-    candidates: list[AkashaCandidate],
-    seq: int,
-) -> list[EdgeUpdate]:
-    # 1. 当前输入和被激活旧节点互连。
-    updates: list[EdgeUpdate] = []
-    key_to_score = {item.key: item.score for item in candidates}
-    for item in candidates:
-        edge_strength = key_to_score.get(item.key, 1.0)
-        updates.append(EdgeUpdate(current_key, item.key, edge_strength, seq))
-        updates.append(EdgeUpdate(item.key, current_key, edge_strength, seq))
-
-    # 2. 同轮共同激活的旧节点互连。
-    for left_index, left in enumerate(candidates):
-        for right in candidates[left_index + 1:]:
-            edge_strength = float(
-                np.sqrt(
-                    key_to_score.get(left.key, 1.0)
-                    * key_to_score.get(right.key, 1.0)
-                )
-            )
-            updates.append(EdgeUpdate(left.key, right.key, edge_strength, seq))
-            updates.append(EdgeUpdate(right.key, left.key, edge_strength, seq))
-    return updates
-
-
-# 把一轮激活候选转成诊断事件。
-def _activation_events(
-    message: SourceMessage,
-    candidates: list[AkashaCandidate],
-) -> list[ActivationEventRow]:
-    # 1. query_id 使用当前 user message id，便于回源诊断。
-    return [
-        ActivationEventRow(
-            seq=message.seq,
-            query_id=message.id,
-            activated_key=item.key,
-            source=item.source,
-            score=item.score,
-            direct_score=item.direct,
-            state_score=item.state,
-            edge_score=item.edge,
-            long_score=item.long,
-            resource=item.resource,
-            fan=item.fan,
-        )
-        for item in candidates
-    ]
+# 按 user turn 聚合回放输入，assistant 归入前一个 user turn。
+def _iter_replay_turns(
+    messages: list[SourceMessage],
+    skip_message_ids: set[str],
+) -> Iterator[list[SourceMessage]]:
+    by_turn = {
+        (message.session_key, message.seq, message.role): message
+        for message in messages
+        if not _skip_message(message, skip_message_ids)
+    }
+    used: set[str] = set()
+    for message in messages:
+        if message.id in used or _skip_message(message, skip_message_ids):
+            continue
+        if message.role != "user":
+            continue
+        turn = [message]
+        used.add(message.id)
+        assistant = by_turn.get((message.session_key, message.seq + 1, "assistant"))
+        if assistant is not None and assistant.id not in used:
+            turn.append(assistant)
+            used.add(assistant.id)
+        yield turn
 
 
 # 执行 Akasha sidecar 重建。
-async def _run() -> MigrationStats:
+def _run() -> MigrationStats:
     # 1. 解析路径、配置和目标 sidecar。
     args = _parse_args()
     workspace = Path(str(args.workspace)).expanduser()
@@ -457,9 +334,7 @@ async def _run() -> MigrationStats:
     store.insert_session_snapshots(run_id=run_id, snapshots=snapshots)
     store.reset_schema()
 
-    # 3. 先复用 embedding cache 和 salience，再按消息顺序 replay 激活状态。
-    http_resources = SharedHttpResources()
-    embedder = _build_embedder(config=config, http_resources=http_resources)
+    # 3. 只复用 embedding cache，再按消息顺序 replay 激活状态。
     messages = 0
     activations = 0
     cache_hits = 0
@@ -467,33 +342,39 @@ async def _run() -> MigrationStats:
     status = "failed"
     try:
         source_messages = _load_source_messages(sessions_db)
-        embedding_map, cache_hits, cache_misses = await _ensure_embeddings_with_cache(
+        skip_message_ids = _load_skip_message_ids(sessions_db)
+        replay_turns = list(_iter_replay_turns(source_messages, skip_message_ids))
+        replay_messages = [message for turn in replay_turns for message in turn]
+        embedding_map, cache_hits, cache_misses = _load_embeddings_from_cache(
             store=store,
-            embedder=embedder,
             model=embedding_model,
-            messages=source_messages,
-            batch_size=int(args.batch_size),
+            messages=replay_messages,
         )
-        salience_map = _compute_salience_map(source_messages, embedding_map)
+        salience_map = _compute_salience_map(replay_messages, embedding_map)
         with closing(sqlite3.connect(str(sessions_db))) as source_db:
-            source_cursor = source_db.cursor()
-            for raw_message in source_messages:
-                embedding = embedding_map.get(raw_message.id)
-                if embedding is None:
+            runtime = AkashaReplayRuntime(
+                store=store,
+                config=akasha_config,
+                source_cursor=source_db.cursor(),
+            )
+            for raw_turn in replay_turns:
+                replay_items: list[ReplayMessage] = []
+                for raw_message in raw_turn:
+                    embedding = embedding_map.get(raw_message.id)
+                    if embedding is None:
+                        continue
+                    replay_items.append(ReplayMessage(
+                        message=replace(
+                            raw_message,
+                            salience=salience_map.get(raw_message.id, 0.0),
+                        ),
+                        embedding=embedding,
+                    ))
+                if not any(item.message.role == "user" for item in replay_items):
                     continue
-                message = replace(
-                    raw_message,
-                    salience=salience_map.get(raw_message.id, 0.0),
-                )
-                activations += _activate_before_upsert(
-                    store=store,
-                    message=message,
-                    embedding=embedding,
-                    config=akasha_config,
-                    source_cursor=source_cursor,
-                )
-                _ = store.upsert_message_node(message, embedding)
-                messages += 1
+                result = runtime.replay_turn(replay_items)
+                activations += len(result.activation_items)
+                messages += len(replay_items)
                 if args.progress_every > 0 and messages % int(args.progress_every) == 0:
                     print(f"已处理 messages={messages} activations={activations}")
         status = "completed"
@@ -507,8 +388,6 @@ async def _run() -> MigrationStats:
             cache_miss_count=cache_misses,
         )
         store.close()
-        await embedder.aclose()
-        await http_resources.aclose()
 
     return MigrationStats(
         messages=messages,
@@ -523,8 +402,7 @@ async def _run() -> MigrationStats:
 
 # 脚本入口。
 def main() -> None:
-    # 1. asyncio 只包住 embedding HTTP 调用。
-    stats = asyncio.run(_run())
+    stats = _run()
     print(
         "Akasha 迁移完成: "
         f"run_id={stats.run_id} "

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -25,7 +25,7 @@ from plugins.akasha.config import (
     load_akasha_config,
     resolve_akasha_db_path,
 )
-from plugins.akasha.core import SourceMessage
+from plugins.akasha.core import SourceMessage, parse_ts_unix, turn_key
 from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage
 from plugins.akasha.store import (
     AkashaStore,
@@ -80,14 +80,13 @@ def _iter_source_batches(
     sessions_db: Path,
     batch_size: int,
 ) -> Iterator[list[SourceMessage]]:
-    # 1. 按真实时间顺序 replay，避免后来的 turn 提前进入历史图。
+    # 1. 先批量读取，最终统一用核心时间解析器排序。
     with closing(sqlite3.connect(str(sessions_db))) as db:
         cursor = db.execute(
             """
             SELECT id, session_key, seq, role, content, ts
             FROM messages
             WHERE role IN ('user', 'assistant')
-            ORDER BY COALESCE(datetime(ts), ts), session_key, seq
             """
         )
         while rows := cursor.fetchmany(max(1, batch_size)):
@@ -106,10 +105,10 @@ def _iter_source_batches(
 
 # 读取 sessions.db 中全部原始消息。
 def _load_source_messages(sessions_db: Path) -> list[SourceMessage]:
-    # 1. salience 需要全量 embedding 分布，不能边读边 replay。
     messages: list[SourceMessage] = []
     for batch in _iter_source_batches(sessions_db=sessions_db, batch_size=1000):
         messages.extend(batch)
+    messages.sort(key=lambda item: (parse_ts_unix(item.ts), item.session_key, item.seq))
     return messages
 
 
@@ -192,99 +191,6 @@ def _load_embeddings_from_cache(
     return embedding_map, cache_hits, cache_misses
 
 
-# 计算原始 cross activation 使用的 message salience。
-def _compute_salience_map(
-    messages: list[SourceMessage],
-    embedding_map: dict[str, list[float]],
-) -> dict[str, float]:
-    # 1. 用 temporal isolation、assistant arousal、session outlier 三个分量复刻原始建库逻辑。
-    available = [
-        (message, embedding_map[message.id])
-        for message in messages
-        if message.id in embedding_map
-    ]
-    if not available:
-        return {}
-    matrix = np.vstack([
-        _normalize_vector(np.array(embedding, dtype=np.float32))
-        for _, embedding in available
-    ])
-    index_by_id = {message.id: index for index, (message, _) in enumerate(available)}
-    session_sorted: dict[str, list[int]] = {}
-    seq_index: dict[tuple[str, int], int] = {}
-    for index, (message, _) in enumerate(available):
-        session_sorted.setdefault(message.session_key, []).append(index)
-        seq_index[(message.session_key, message.seq)] = index
-    for indices in session_sorted.values():
-        indices.sort(key=lambda item: available[item][0].seq)
-
-    # 2. 先计算每个 session 的质心。
-    centroids: dict[str, np.ndarray] = {}
-    for session_key, indices in session_sorted.items():
-        group = matrix[indices]
-        centroid = group.mean(axis=0)
-        centroids[session_key] = _normalize_vector(centroid)
-
-    # 3. 三个原始分量分别做 p5-p95 归一化后加权。
-    temporal_raw = np.zeros(len(available), dtype=np.float32)
-    arousal_raw = np.zeros(len(available), dtype=np.float32)
-    session_out_raw = np.zeros(len(available), dtype=np.float32)
-    position_by_index = {
-        source_index: position
-        for indices in session_sorted.values()
-        for position, source_index in enumerate(indices)
-    }
-    for index, (message, _) in enumerate(available):
-        session_indices = session_sorted[message.session_key]
-        position = position_by_index[index]
-        neighbors = [
-            float(np.dot(matrix[index], matrix[neighbor_index]))
-            for neighbor_index in session_indices[max(0, position - 5) : position]
-        ]
-        temporal_raw[index] = 1.0 - max(neighbors) if neighbors else 1.0
-        if message.role == "user":
-            assistant_index = seq_index.get((message.session_key, message.seq + 1))
-            if (
-                assistant_index is None
-                or available[assistant_index][0].role != "assistant"
-            ):
-                assistant_len = 0
-            else:
-                assistant_len = len(available[assistant_index][0].content)
-            arousal_raw[index] = min(1.0, assistant_len / 300.0)
-        else:
-            arousal_raw[index] = min(1.0, len(message.content) / 300.0)
-        centroid = centroids[message.session_key]
-        session_out_raw[index] = max(0.0, (1.0 - float(np.dot(matrix[index], centroid))) / 2.0)
-
-    salience = (
-        0.4 * _percentile_normalize(temporal_raw)
-        + 0.3 * _percentile_normalize(arousal_raw)
-        + 0.3 * _percentile_normalize(session_out_raw)
-    )
-    return {
-        message_id: float(value)
-        for message_id, value in zip(index_by_id, np.clip(salience, 0.0, 1.0), strict=False)
-    }
-
-
-# p5-p95 拉伸到 0..1。
-def _percentile_normalize(values: np.ndarray) -> np.ndarray:
-    # 1. 常量分布保留中性值，避免除零。
-    p5 = float(np.percentile(values, 5))
-    p95 = float(np.percentile(values, 95))
-    if p95 - p5 < 1e-8:
-        return np.full_like(values, 0.5)
-    return np.clip((values - p5) / (p95 - p5), 0.0, 1.0)
-
-
-# 归一化向量。
-def _normalize_vector(vector: np.ndarray) -> np.ndarray:
-    # 1. 原始 salience 和 dense 分数都基于单位向量。
-    norm = float(np.linalg.norm(vector))
-    return vector / norm if norm > 0 else vector
-
-
 # 按 user turn 聚合回放输入，assistant 归入前一个 user turn。
 def _iter_replay_turns(
     messages: list[SourceMessage],
@@ -339,6 +245,7 @@ def _run() -> MigrationStats:
     activations = 0
     cache_hits = 0
     cache_misses = 0
+    next_progress = int(args.progress_every)
     status = "failed"
     try:
         source_messages = _load_source_messages(sessions_db)
@@ -350,12 +257,23 @@ def _run() -> MigrationStats:
             model=embedding_model,
             messages=replay_messages,
         )
-        salience_map = _compute_salience_map(replay_messages, embedding_map)
+        message_embeddings = {
+            message_id: np.array(embedding, dtype=np.float32)
+            for message_id, embedding in embedding_map.items()
+        }
+        message_turn_keys = {
+            message.id: turn_key(message.session_key, message.seq, message.role)[2]
+            for message in replay_messages
+            if message.id in embedding_map
+        }
         with closing(sqlite3.connect(str(sessions_db))) as source_db:
             runtime = AkashaReplayRuntime(
                 store=store,
                 config=akasha_config,
+                source_db_path=sessions_db,
                 source_cursor=source_db.cursor(),
+                message_embeddings=message_embeddings,
+                message_turn_keys=message_turn_keys,
             )
             for raw_turn in replay_turns:
                 replay_items: list[ReplayMessage] = []
@@ -364,10 +282,7 @@ def _run() -> MigrationStats:
                     if embedding is None:
                         continue
                     replay_items.append(ReplayMessage(
-                        message=replace(
-                            raw_message,
-                            salience=salience_map.get(raw_message.id, 0.0),
-                        ),
+                        message=raw_message,
                         embedding=embedding,
                     ))
                 if not any(item.message.role == "user" for item in replay_items):
@@ -375,8 +290,10 @@ def _run() -> MigrationStats:
                 result = runtime.replay_turn(replay_items)
                 activations += len(result.activation_items)
                 messages += len(replay_items)
-                if args.progress_every > 0 and messages % int(args.progress_every) == 0:
-                    print(f"已处理 messages={messages} activations={activations}")
+                if next_progress > 0 and messages >= next_progress:
+                    print(f"已处理 messages={messages} activations={activations}", flush=True)
+                    while messages >= next_progress:
+                        next_progress += int(args.progress_every)
         status = "completed"
     finally:
         store.finish_migration_run(

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -1,0 +1,542 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sqlite3
+import sys
+from contextlib import closing
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from agent.config_models import Config
+from core.net.http import SharedHttpResources
+from memory2.embedder import Embedder
+from plugins.akasha.config import (
+    AkashaConfig,
+    load_akasha_config,
+    resolve_akasha_db_path,
+)
+from plugins.akasha.engine import (
+    AkashaCandidate,
+    _activation_updates,
+    _compute_candidates,
+    _fan_counts,
+)
+from plugins.akasha.store import (
+    ActivationEventRow,
+    AkashaStore,
+    EdgeUpdate,
+    SourceMessage,
+    SourceSessionSnapshot,
+    turn_key,
+)
+
+
+@dataclass(frozen=True)
+class MigrationStats:
+    messages: int = 0
+    activations: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    snapshots: int = 0
+    run_id: str = ""
+    backup_path: Path | None = None
+
+
+# 解析迁移脚本参数。
+def _parse_args() -> argparse.Namespace:
+    # 1. 只保留迁移必须参数，避免脚本变成另一套配置系统。
+    parser = argparse.ArgumentParser(
+        description="从 workspace/sessions.db 重建 Akasha sidecar 数据库。"
+    )
+    _ = parser.add_argument("--config", default="config.toml", help="主配置文件路径")
+    _ = parser.add_argument(
+        "--workspace",
+        default=str(Path.home() / ".akashic" / "workspace"),
+        help="Akashic workspace 路径",
+    )
+    _ = parser.add_argument("--sessions-db", default="", help="原始 sessions.db 路径")
+    _ = parser.add_argument("--db-path", default="", help="输出 akasha.db 路径")
+    _ = parser.add_argument("--batch-size", type=int, default=10, help="embedding 批大小")
+    _ = parser.add_argument("--progress-every", type=int, default=500, help="进度打印间隔")
+    return parser.parse_args()
+
+
+# 构造 Akasha 配置，并允许命令行覆盖 db_path。
+def _load_script_config(
+    *,
+    db_path: str,
+) -> AkashaConfig:
+    # 1. 插件配置仍从 plugins/akasha/config.local.toml 读取。
+    config = load_akasha_config()
+    if db_path.strip():
+        return replace(config, db_path=db_path)
+    return config
+
+
+# 构造 embedding 客户端。
+def _build_embedder(
+    *,
+    config: Config,
+    http_resources: SharedHttpResources,
+) -> Embedder:
+    # 1. 复用运行时的 embedding 配置和 HTTP requester。
+    embedding = config.memory.embedding
+    return Embedder(
+        base_url=embedding.base_url or config.light_base_url or config.base_url or "",
+        api_key=embedding.api_key or config.light_api_key or config.api_key,
+        model=embedding.model,
+        requester=http_resources.external_default,
+    )
+
+
+# 读取 sessions.db 中的原始消息。
+def _iter_source_batches(
+    *,
+    sessions_db: Path,
+    batch_size: int,
+) -> Iterator[list[SourceMessage]]:
+    # 1. 按 cross CLI 的 session_key, seq 顺序 replay。
+    with closing(sqlite3.connect(str(sessions_db))) as db:
+        cursor = db.execute(
+            """
+            SELECT id, session_key, seq, role, content, ts
+            FROM messages
+            WHERE role IN ('user', 'assistant')
+            ORDER BY session_key, seq
+            """
+        )
+        while rows := cursor.fetchmany(max(1, batch_size)):
+            yield [
+                SourceMessage(
+                    id=str(row[0]),
+                    session_key=str(row[1]),
+                    seq=int(row[2]),
+                    role=str(row[3] or ""),
+                    content=str(row[4] or ""),
+                    ts=str(row[5] or ""),
+                )
+                for row in rows
+            ]
+
+
+# 读取 sessions.db 中全部原始消息。
+def _load_source_messages(sessions_db: Path) -> list[SourceMessage]:
+    # 1. salience 需要全量 embedding 分布，不能边读边 replay。
+    messages: list[SourceMessage] = []
+    for batch in _iter_source_batches(sessions_db=sessions_db, batch_size=1000):
+        messages.extend(batch)
+    return messages
+
+
+# 读取迁移开始时的 session 游标快照。
+def _load_session_snapshots(sessions_db: Path) -> list[SourceSessionSnapshot]:
+    # 1. 只读取旧系统游标，用于回滚和迁移诊断。
+    with closing(sqlite3.connect(str(sessions_db))) as db:
+        rows = db.execute(
+            """
+            SELECT
+                s.key,
+                COALESCE(s.last_consolidated, 0),
+                COALESCE(s.next_seq, 0),
+                COALESCE(MAX(m.seq), -1)
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_key = s.key
+            GROUP BY s.key
+            ORDER BY s.key
+            """
+        ).fetchall()
+    return [
+        SourceSessionSnapshot(
+            session_key=str(row[0]),
+            last_consolidated=int(row[1] or 0),
+            next_seq=int(row[2] or 0),
+            max_seq=int(row[3] or -1),
+        )
+        for row in rows
+    ]
+
+
+# 备份已有 Akasha sidecar。
+def _backup_existing_db(db_path: Path) -> Path | None:
+    # 1. 重建前保留旧库，避免迁移脚本误覆盖唯一状态。
+    if not db_path.exists():
+        return None
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_path = db_path.with_name(f"{db_path.name}.bak-{stamp}")
+    _ = shutil.copy2(db_path, backup_path)
+    return backup_path
+
+
+# 从 cache 读取 embedding，缺失时批量调用 embedding API。
+async def _embed_batch_with_cache(
+    *,
+    store: AkashaStore,
+    embedder: Embedder,
+    model: str,
+    batch: list[SourceMessage],
+) -> tuple[list[list[float]], int, int]:
+    # 1. 先按 message_id + content_hash + model 查 cache。
+    embeddings: list[list[float] | None] = []
+    missing: list[tuple[int, SourceMessage]] = []
+    cache_hits = 0
+    for index, message in enumerate(batch):
+        cached = store.get_cached_embedding(message=message, model=model)
+        embeddings.append(cached)
+        if cached is None:
+            missing.append((index, message))
+        else:
+            cache_hits += 1
+
+    # 2. 只对缺口调用远端 embedding，并立刻写回 cache。
+    cache_misses = len(missing)
+    if missing:
+        fresh = await embedder.embed_batch([
+            message.content if message.content.strip() else " "
+            for _, message in missing
+        ])
+        for (index, message), embedding in zip(missing, fresh, strict=False):
+            store.upsert_cached_embedding(
+                message=message,
+                model=model,
+                embedding=embedding,
+            )
+            embeddings[index] = embedding
+
+    # 3. 返回顺序必须和 batch 一致，后面的 replay 依赖消息顺序。
+    ordered: list[list[float]] = []
+    for embedding in embeddings:
+        if embedding is None:
+            raise RuntimeError("embedding cache 写入后仍有缺口")
+        ordered.append(embedding)
+    return ordered, cache_hits, cache_misses
+
+
+# 确保全量 message embedding 都在 cache 里。
+async def _ensure_embeddings_with_cache(
+    *,
+    store: AkashaStore,
+    embedder: Embedder,
+    model: str,
+    messages: list[SourceMessage],
+    batch_size: int,
+) -> tuple[dict[str, list[float]], int, int]:
+    # 1. 按批次补齐缺失 embedding，但 replay 之前先拿到完整向量表。
+    embedding_map: dict[str, list[float]] = {}
+    cache_hits = 0
+    cache_misses = 0
+    for index in range(0, len(messages), max(1, batch_size)):
+        batch = messages[index : index + max(1, batch_size)]
+        embeddings, batch_hits, batch_misses = await _embed_batch_with_cache(
+            store=store,
+            embedder=embedder,
+            model=model,
+            batch=batch,
+        )
+        cache_hits += batch_hits
+        cache_misses += batch_misses
+        for message, embedding in zip(batch, embeddings, strict=False):
+            embedding_map[message.id] = embedding
+    return embedding_map, cache_hits, cache_misses
+
+
+# 计算原始 cross activation 使用的 message salience。
+def _compute_salience_map(
+    messages: list[SourceMessage],
+    embedding_map: dict[str, list[float]],
+) -> dict[str, float]:
+    # 1. 用 temporal isolation、assistant arousal、session outlier 三个分量复刻原始建库逻辑。
+    available = [
+        (message, embedding_map[message.id])
+        for message in messages
+        if message.id in embedding_map
+    ]
+    if not available:
+        return {}
+    matrix = np.vstack([
+        _normalize_vector(np.array(embedding, dtype=np.float32))
+        for _, embedding in available
+    ])
+    index_by_id = {message.id: index for index, (message, _) in enumerate(available)}
+    session_sorted: dict[str, list[int]] = {}
+    seq_index: dict[tuple[str, int], int] = {}
+    for index, (message, _) in enumerate(available):
+        session_sorted.setdefault(message.session_key, []).append(index)
+        seq_index[(message.session_key, message.seq)] = index
+
+    # 2. 先计算每个 session 的质心。
+    centroids: dict[str, np.ndarray] = {}
+    for session_key, indices in session_sorted.items():
+        group = matrix[indices]
+        centroid = group.mean(axis=0)
+        centroids[session_key] = _normalize_vector(centroid)
+
+    # 3. 三个原始分量分别做 p5-p95 归一化后加权。
+    temporal_raw = np.zeros(len(available), dtype=np.float32)
+    arousal_raw = np.zeros(len(available), dtype=np.float32)
+    session_out_raw = np.zeros(len(available), dtype=np.float32)
+    position_by_index = {
+        source_index: position
+        for indices in session_sorted.values()
+        for position, source_index in enumerate(indices)
+    }
+    for index, (message, _) in enumerate(available):
+        session_indices = session_sorted[message.session_key]
+        position = position_by_index[index]
+        neighbors = [
+            float(np.dot(matrix[index], matrix[neighbor_index]))
+            for neighbor_index in session_indices[max(0, position - 5) : position]
+        ]
+        temporal_raw[index] = 1.0 - max(neighbors) if neighbors else 1.0
+        if message.role == "user":
+            assistant_index = seq_index.get((message.session_key, message.seq + 1))
+            if (
+                assistant_index is None
+                or available[assistant_index][0].role != "assistant"
+            ):
+                assistant_len = 0
+            else:
+                assistant_len = len(available[assistant_index][0].content)
+            arousal_raw[index] = min(1.0, assistant_len / 300.0)
+        else:
+            arousal_raw[index] = min(1.0, len(message.content) / 300.0)
+        centroid = centroids[message.session_key]
+        session_out_raw[index] = max(0.0, (1.0 - float(np.dot(matrix[index], centroid))) / 2.0)
+
+    salience = (
+        0.4 * _percentile_normalize(temporal_raw)
+        + 0.3 * _percentile_normalize(arousal_raw)
+        + 0.3 * _percentile_normalize(session_out_raw)
+    )
+    return {
+        message_id: float(value)
+        for message_id, value in zip(index_by_id, np.clip(salience, 0.0, 1.0), strict=False)
+    }
+
+
+# p5-p95 拉伸到 0..1。
+def _percentile_normalize(values: np.ndarray) -> np.ndarray:
+    # 1. 常量分布保留中性值，避免除零。
+    p5 = float(np.percentile(values, 5))
+    p95 = float(np.percentile(values, 95))
+    if p95 - p5 < 1e-8:
+        return np.full_like(values, 0.5)
+    return np.clip((values - p5) / (p95 - p5), 0.0, 1.0)
+
+
+# 归一化向量。
+def _normalize_vector(vector: np.ndarray) -> np.ndarray:
+    # 1. 原始 salience 和 dense 分数都基于单位向量。
+    norm = float(np.linalg.norm(vector))
+    return vector / norm if norm > 0 else vector
+
+
+# 在写入当前 user turn 前，按 cross CLI 规则激活历史节点。
+def _activate_before_upsert(
+    *,
+    store: AkashaStore,
+    message: SourceMessage,
+    embedding: list[float],
+    config: AkashaConfig,
+    source_cursor: sqlite3.Cursor,
+) -> int:
+    # 1. 只有 user 输入会触发状态激活。
+    if message.role != "user":
+        return 0
+    nodes = {node.key: node for node in store.list_nodes()}
+    if not nodes:
+        return 0
+
+    # 2. 使用当前 user embedding 检索历史节点，并更新旧节点状态。
+    edges = store.load_edges()
+    candidates, _, _ = _compute_candidates(
+        message.content,
+        np.array(embedding, dtype=np.float32),
+        nodes,
+        edges,
+        message.seq,
+        config=config,
+        fan=_fan_counts(edges),
+        source_cursor=source_cursor,
+        soft_recall=False,
+        return_limit=config.activate_limit,
+    )
+    store.update_activation_batch(_activation_updates(candidates, nodes, message.seq))
+
+    # 3. 当前 turn key 先参与建边，随后再被 upsert_message_node 写成节点。
+    current_key = turn_key(message.session_key, message.seq, message.role)[2]
+    store.upsert_edges(_edge_updates(current_key, candidates, message.seq))
+    store.insert_activation_events(_activation_events(message, candidates))
+    return len(candidates)
+
+
+# 把一轮激活候选转成共激活边。
+def _edge_updates(
+    current_key: str,
+    candidates: list[AkashaCandidate],
+    seq: int,
+) -> list[EdgeUpdate]:
+    # 1. 当前输入和被激活旧节点互连。
+    updates: list[EdgeUpdate] = []
+    key_to_score = {item.key: item.score for item in candidates}
+    for item in candidates:
+        edge_strength = key_to_score.get(item.key, 1.0)
+        updates.append(EdgeUpdate(current_key, item.key, edge_strength, seq))
+        updates.append(EdgeUpdate(item.key, current_key, edge_strength, seq))
+
+    # 2. 同轮共同激活的旧节点互连。
+    for left_index, left in enumerate(candidates):
+        for right in candidates[left_index + 1:]:
+            edge_strength = float(
+                np.sqrt(
+                    key_to_score.get(left.key, 1.0)
+                    * key_to_score.get(right.key, 1.0)
+                )
+            )
+            updates.append(EdgeUpdate(left.key, right.key, edge_strength, seq))
+            updates.append(EdgeUpdate(right.key, left.key, edge_strength, seq))
+    return updates
+
+
+# 把一轮激活候选转成诊断事件。
+def _activation_events(
+    message: SourceMessage,
+    candidates: list[AkashaCandidate],
+) -> list[ActivationEventRow]:
+    # 1. query_id 使用当前 user message id，便于回源诊断。
+    return [
+        ActivationEventRow(
+            seq=message.seq,
+            query_id=message.id,
+            activated_key=item.key,
+            source=item.source,
+            score=item.score,
+            direct_score=item.direct,
+            state_score=item.state,
+            edge_score=item.edge,
+            long_score=item.long,
+            resource=item.resource,
+            fan=item.fan,
+        )
+        for item in candidates
+    ]
+
+
+# 执行 Akasha sidecar 重建。
+async def _run() -> MigrationStats:
+    # 1. 解析路径、配置和目标 sidecar。
+    args = _parse_args()
+    workspace = Path(str(args.workspace)).expanduser()
+    sessions_db = Path(str(args.sessions_db)).expanduser() if args.sessions_db else workspace / "sessions.db"
+    akasha_config = _load_script_config(db_path=str(args.db_path or ""))
+    db_path = resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config)
+    if not sessions_db.exists():
+        raise FileNotFoundError(f"sessions.db 不存在: {sessions_db}")
+
+    # 2. 备份旧 sidecar，并初始化本次迁移记录。
+    backup_path = _backup_existing_db(db_path)
+    store = AkashaStore(db_path)
+    config = Config.load(str(args.config))
+    embedding_model = config.memory.embedding.model
+    run_id = store.start_migration_run(
+        source_db_path=sessions_db,
+        embedding_model=embedding_model,
+    )
+    snapshots = _load_session_snapshots(sessions_db)
+    store.insert_session_snapshots(run_id=run_id, snapshots=snapshots)
+    store.reset_schema()
+
+    # 3. 先复用 embedding cache 和 salience，再按消息顺序 replay 激活状态。
+    http_resources = SharedHttpResources()
+    embedder = _build_embedder(config=config, http_resources=http_resources)
+    messages = 0
+    activations = 0
+    cache_hits = 0
+    cache_misses = 0
+    status = "failed"
+    try:
+        source_messages = _load_source_messages(sessions_db)
+        embedding_map, cache_hits, cache_misses = await _ensure_embeddings_with_cache(
+            store=store,
+            embedder=embedder,
+            model=embedding_model,
+            messages=source_messages,
+            batch_size=int(args.batch_size),
+        )
+        salience_map = _compute_salience_map(source_messages, embedding_map)
+        with closing(sqlite3.connect(str(sessions_db))) as source_db:
+            source_cursor = source_db.cursor()
+            for raw_message in source_messages:
+                embedding = embedding_map.get(raw_message.id)
+                if embedding is None:
+                    continue
+                message = replace(
+                    raw_message,
+                    salience=salience_map.get(raw_message.id, 0.0),
+                )
+                activations += _activate_before_upsert(
+                    store=store,
+                    message=message,
+                    embedding=embedding,
+                    config=akasha_config,
+                    source_cursor=source_cursor,
+                )
+                _ = store.upsert_message_node(message, embedding)
+                messages += 1
+                if args.progress_every > 0 and messages % int(args.progress_every) == 0:
+                    print(f"已处理 messages={messages} activations={activations}")
+        status = "completed"
+    finally:
+        store.finish_migration_run(
+            run_id=run_id,
+            status=status,
+            message_count=messages,
+            activation_count=activations,
+            cache_hit_count=cache_hits,
+            cache_miss_count=cache_misses,
+        )
+        store.close()
+        await embedder.aclose()
+        await http_resources.aclose()
+
+    return MigrationStats(
+        messages=messages,
+        activations=activations,
+        cache_hits=cache_hits,
+        cache_misses=cache_misses,
+        snapshots=len(snapshots),
+        run_id=run_id,
+        backup_path=backup_path,
+    )
+
+
+# 脚本入口。
+def main() -> None:
+    # 1. asyncio 只包住 embedding HTTP 调用。
+    stats = asyncio.run(_run())
+    print(
+        "Akasha 迁移完成: "
+        f"run_id={stats.run_id} "
+        f"messages={stats.messages} "
+        f"activations={stats.activations} "
+        f"cache_hits={stats.cache_hits} "
+        f"cache_misses={stats.cache_misses} "
+        f"snapshots={stats.snapshots}"
+    )
+    if stats.backup_path is not None:
+        print(f"旧库备份: {stats.backup_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_fts_idf.py
+++ b/scripts/build_fts_idf.py
@@ -1,0 +1,99 @@
+"""
+扫描 sessions.db 所有 message，用 jieba 切词算 IDF，写入 akasha.db 的 fts_token_idf 表。
+"""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import jieba
+
+AKASHA_DB = Path.home() / ".akashic" / "workspace" / "memory" / "akasha.db"
+SESSIONS_DB = Path.home() / ".akashic" / "workspace" / "sessions.db"
+
+
+def tokenize(text: str) -> set[str]:
+    out: set[str] = set()
+    for w in jieba.cut_for_search(text or ""):
+        cleaned = "".join(
+            c for c in w.strip()
+            if c.isalnum() or "一" <= c <= "鿿"
+        )
+        if len(cleaned) > 1:
+            out.add(cleaned.lower())
+    return out
+
+
+def main() -> None:
+    if not AKASHA_DB.exists():
+        print(f"❌ {AKASHA_DB} 不存在"); sys.exit(1)
+    if not SESSIONS_DB.exists():
+        print(f"❌ {SESSIONS_DB} 不存在"); sys.exit(1)
+
+    sconn = sqlite3.connect(SESSIONS_DB)
+    cur = sconn.cursor()
+    print("[scan] messages ...")
+    df: dict[str, int] = defaultdict(int)
+    n_docs = 0
+    for (content,) in cur.execute("SELECT content FROM messages"):
+        n_docs += 1
+        for tok in tokenize(content):
+            df[tok] += 1
+        if n_docs % 1000 == 0:
+            print(f"  {n_docs} messages, {len(df)} unique tokens")
+    sconn.close()
+    print(f"  done: {n_docs} messages, {len(df)} unique tokens")
+
+    idf: dict[str, float] = {}
+    for tok, freq in df.items():
+        idf[tok] = math.log((n_docs + 1) / (freq + 1)) + 1
+
+    # 写入 akasha.db
+    aconn = sqlite3.connect(AKASHA_DB)
+    aconn.execute("""
+        CREATE TABLE IF NOT EXISTS fts_token_idf (
+            token TEXT PRIMARY KEY,
+            df INTEGER NOT NULL,
+            idf REAL NOT NULL
+        )
+    """)
+    aconn.execute("DELETE FROM fts_token_idf")
+    aconn.executemany(
+        "INSERT INTO fts_token_idf VALUES (?, ?, ?)",
+        [(t, df[t], idf[t]) for t in df],
+    )
+    aconn.commit()
+    print(f"  wrote {len(df)} tokens to akasha.db:fts_token_idf")
+
+    # 分布报告
+    sorted_by_idf = sorted(idf.items(), key=lambda x: x[1])
+    print(f"\n=== IDF 分布 ===")
+    bins = [
+        (-1, 1, "极常见"),
+        (1, 2, "常见"),
+        (2, 3, "中等"),
+        (3, 5, "稀有"),
+        (5, 99, "极稀有"),
+    ]
+    for lo, hi, label in bins:
+        cnt = sum(1 for _, v in idf.items() if lo <= v < hi)
+        print(f"  IDF [{lo:.1f},{hi:.1f}) {label:<8} {cnt} tokens")
+
+    print(f"\n=== 最常见 token (低 IDF，应过滤) ===")
+    for tok, v in sorted_by_idf[:20]:
+        print(f"  IDF={v:.2f}  df={df[tok]:>5}  {tok}")
+
+    print(f"\n=== 最稀有 token sample (高 IDF，有信息量) ===")
+    rare = [t for t in sorted_by_idf if 4.5 < t[1] < 8.5]
+    for tok, v in rare[::max(1, len(rare)//20)][:20]:
+        print(f"  IDF={v:.2f}  df={df[tok]:>5}  {tok}")
+
+    aconn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/proactive_v2/test_tools.py
+++ b/tests/proactive_v2/test_tools.py
@@ -15,6 +15,7 @@ TDD — Phase 3: proactive_v2/tools.py
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -306,11 +307,17 @@ async def test_recall_memory_skips_empty_text():
 async def test_recall_memory_passes_query_to_facade_interest_request():
     fake_memory = MagicMock()
     fake_memory.query = AsyncMock(return_value=SimpleNamespace(records=[]))
-    await _recall_memory(ctx=AgentTickContext(), args={"query": "q"}, memory=fake_memory)
+    now = datetime(2026, 4, 4, 14, 0, 0, tzinfo=timezone.utc)
+    await _recall_memory(
+        ctx=AgentTickContext(now_utc=now),
+        args={"query": "q"},
+        memory=fake_memory,
+    )
     request = fake_memory.query.await_args.args[0]
     assert request.text == "q"
     assert request.intent == "interest"
     assert request.limit == 2
+    assert request.timestamp == now
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_core_p3_context_store.py
+++ b/tests/test_agent_core_p3_context_store.py
@@ -120,6 +120,41 @@ async def test_default_context_store_prepare_uses_explicit_session_key_for_retri
     assert request.session_key != msg.session_key
 
 
+@pytest.mark.asyncio
+async def test_default_context_store_uses_cli_context_override_for_retrieval():
+    retrieval = SimpleNamespace(
+        retrieve=AsyncMock(
+            return_value=RetrievalResult(
+                block="remembered",
+                trace=RetrievalTrace(raw={"route": "RETRIEVE"}),
+            )
+        )
+    )
+    context = SimpleNamespace(
+        skills=SimpleNamespace(list_skills=MagicMock(return_value=[]))
+    )
+    store = DefaultContextStore(retrieval=cast(Any, retrieval), context=cast(Any, context))
+    session = _DummySession()
+    msg = InboundMessage(
+        channel="cli",
+        sender="hua",
+        chat_id="local",
+        content="测试",
+        metadata={
+            "session_key_override": "telegram:7674283004",
+            "context_channel": "telegram",
+            "context_chat_id": "7674283004",
+        },
+    )
+
+    await store.prepare(msg=msg, session_key=msg.session_key, session=cast(Any, session))
+
+    request = retrieval.retrieve.await_args.args[0]
+    assert request.session_key == "telegram:7674283004"
+    assert request.channel == "telegram"
+    assert request.chat_id == "7674283004"
+
+
 def test_estimate_history_budget_returns_serialized_history_size():
     stats = estimate_history_budget(
         [

--- a/tests/test_agent_core_p3_context_store.py
+++ b/tests/test_agent_core_p3_context_store.py
@@ -66,7 +66,10 @@ async def test_default_context_store_prepare_returns_bundle_with_legacy_metadata
             )
         )
     )
-    store = DefaultContextStore(retrieval=cast(Any, retrieval), context=cast(Any, context))
+    store = DefaultContextStore(
+        retrieval=cast(Any, retrieval),
+        context=cast(Any, context),
+    )
     session = _DummySession()
     msg = InboundMessage(
         channel="cli",
@@ -118,6 +121,41 @@ async def test_default_context_store_prepare_uses_explicit_session_key_for_retri
     request = retrieval.retrieve.await_args.args[0]
     assert request.session_key == "scheduler:job-123"
     assert request.session_key != msg.session_key
+
+
+@pytest.mark.asyncio
+async def test_default_context_store_prepare_skips_retrieval_when_requested():
+    retrieval = SimpleNamespace(
+        retrieve=AsyncMock(
+            return_value=RetrievalResult(
+                block="should-not-load",
+                trace=RetrievalTrace(raw={"route": "RETRIEVE"}),
+            )
+        )
+    )
+    context = SimpleNamespace(
+        skills=SimpleNamespace(list_skills=MagicMock(return_value=[]))
+    )
+    store = DefaultContextStore(retrieval=cast(Any, retrieval), context=cast(Any, context))
+    session = _DummySession()
+    msg = InboundMessage(
+        channel="telegram",
+        sender="scheduler",
+        chat_id="7674283004",
+        content="查询北京天气",
+        metadata={"skip_memory_retrieval": True},
+    )
+
+    bundle = await store.prepare(
+        msg=msg,
+        session_key="scheduler:job-123",
+        session=cast(Any, session),
+    )
+
+    retrieval.retrieve.assert_not_awaited()
+    assert bundle.memory_blocks == []
+    assert bundle.retrieved_memory_block == ""
+    assert bundle.retrieval_trace_raw is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_core_p5_agent_core.py
+++ b/tests/test_agent_core_p5_agent_core.py
@@ -128,6 +128,7 @@ async def test_agent_core_process_runs_prepare_prompt_run_commit_in_order():
         channel="telegram",
         chat_id="123",
         current_user_source_ref="telegram:123:0",
+        current_timestamp="2026-04-04T22:00:00",
     )
     assert reasoner.run_turn.await_args.kwargs["skill_names"] == ["refactor"]
     assert reasoner.run_turn.await_args.kwargs["retrieved_memory_block"] == "remembered"

--- a/tests/test_agent_core_p6_runner.py
+++ b/tests/test_agent_core_p6_runner.py
@@ -109,7 +109,11 @@ async def test_core_runner_handles_spawn_completion_via_direct_helper_deps():
 
     assert out.content == "spawn done"
     session_svc.session_manager.get_or_create.assert_called_once_with("scheduler:job-1")
-    tools.set_context.assert_called_once_with(channel="telegram", chat_id="123")
+    tools.set_context.assert_called_once_with(
+        channel="telegram",
+        chat_id="123",
+        current_timestamp=item.timestamp.isoformat(),
+    )
     prompt_render_fn.assert_awaited_once()
     render_input = prompt_render_fn.await_args.args[0]
     assert render_input.session_key == "scheduler:job-1"

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -235,6 +235,53 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
     assert 'source_ref=["s:2", "s:3"]' in ripple_block
 
 
+def test_cards_from_keys_deduplicates_same_user_assistant_pair(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    with closing(sqlite3.connect(str(db_path))) as db:
+        db.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        db.executemany(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("s:0", "s", 0, "user", "我现在健康状态怎么样呢", "2026-01-01T00:00:00+00:00"),
+                ("s:1", "s", 1, "assistant", "健康状态的话……我这边真的没有更多信息", "2026-01-01T00:00:01+00:00"),
+                ("s:2", "s", 2, "user", "我现在健康状态怎么样呢", "2026-01-01T00:00:02+00:00"),
+                ("s:3", "s", 3, "assistant", "健康状态的话……我这边真的没有更多信息", "2026-01-01T00:00:03+00:00"),
+                ("s:4", "s", 4, "user", "另一个问题", "2026-01-01T00:00:04+00:00"),
+                ("s:5", "s", 5, "assistant", "第三次回复", "2026-01-01T00:00:05+00:00"),
+            ],
+        )
+        db.commit()
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig(assistant_preview_chars=15)
+    engine._session_db_path = db_path
+
+    cards = engine._cards_from_keys(
+        [
+            ("s:0", 0.9, "ripple", {}),
+            ("s:2", 0.8, "ripple", {}),
+            ("s:4", 0.7, "ripple", {}),
+        ],
+        limit=10,
+    )
+
+    assert [card.source_ref for card in cards] == [
+        '["s:0", "s:1"]',
+        '["s:4", "s:5"]',
+    ]
+
+
 @pytest.mark.asyncio
 async def test_context_query_uses_akasha_top_k_over_default_query_limit(
     tmp_path: Path,
@@ -337,3 +384,38 @@ def test_compute_candidates_uses_activation_limit_for_stateful_replay(tmp_path: 
     assert len(candidates) == 8
     assert trace.seed_count == 30
     assert suppressed == []
+
+
+def test_query_log_keeps_context_and_answer_for_same_seq(tmp_path: Path) -> None:
+    store = AkashaStore(tmp_path / "akasha.db")
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._store = store
+    engine._akasha_config = AkashaConfig()
+    result = _AkashaRetrieval(
+        dense_items=[],
+        ripple_items=[],
+        activation_items=[],
+        trace=ActivationTrace(seed_count=1, pool_count=2),
+        seq=10,
+    )
+    try:
+        for intent, text_block in [("context", "注入文本"), ("answer", "")]:
+            engine._write_query_log(
+                request=MemoryQuery(
+                    text="同一轮问题",
+                    intent=intent,
+                    scope=MemoryScope(session_key="s"),
+                ),
+                result=result,
+                seq=10,
+                dense_cards=[],
+                ripple_cards=[],
+                text_block=text_block,
+            )
+
+        items, total = store.list_query_logs(session_key="s", page=1, page_size=10)
+    finally:
+        store.close()
+
+    assert total == 2
+    assert {item["intent"] for item in items} == {"context", "answer"}

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -168,6 +168,7 @@ def test_load_turn_card_uses_full_user_and_short_assistant(tmp_path: Path) -> No
     assert card.user_message == "第一条用户消息需要完整展示"
     assert card.assistant_preview == "第一条助手回复会被截断展示并保..."
     assert card.source_ref == '["s:0", "s:1"]'
+    assert card.happened_at == "2026-01-01T00:00:00+00:00"
 
 
 @pytest.mark.asyncio
@@ -238,11 +239,59 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
 
     assert "## 左脑记忆：精确回忆" in result.text_block
     assert "## 右脑联想：潜意识第一反应" in result.text_block
+    assert "# Akasha memory now=" in result.text_block
     assert '- user="第一条用户消息需要完整展示" assistant=' in result.text_block
+    assert " t=01-01 source_ref=" in result.text_block
+    assert " score=" not in result.text_block
     dense_block, ripple_block = result.text_block.split("## 右脑联想：潜意识第一反应", 1)
     assert 'source_ref=["s:0", "s:1"]' in dense_block
     assert 'source_ref=["s:0", "s:1"]' not in ripple_block
     assert 'source_ref=["s:2", "s:3"]' in ripple_block
+
+
+@pytest.mark.asyncio
+async def test_context_block_sorts_injected_cards_by_time_desc(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+
+    def candidate(key: str, score: float) -> AkashaCandidate:
+        return AkashaCandidate(
+            key=key,
+            source="Dense",
+            ripple=0.0,
+            direct=score,
+            state=0.0,
+            edge=0.0,
+            long=0.0,
+            resource=1.0,
+            fan=0,
+            score=score,
+        )
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig(dense_top_k=10, ripple_top_k=10)
+    engine._session_db_path = db_path
+    engine._embedder = FakeEmbedder()
+    engine._remember_pending_activation = lambda request, items: None
+    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+        dense_items=[candidate("s:0", 0.9), candidate("s:2", 0.8)],
+        ripple_items=[],
+        activation_items=[],
+        trace=ActivationTrace(seed_count=1, pool_count=2),
+        seq=4,
+    )
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户消息",
+            intent="context",
+            scope=MemoryScope(session_key="s"),
+        )
+    )
+
+    assert result.text_block.index('source_ref=["s:2", "s:3"]') < result.text_block.index(
+        'source_ref=["s:0", "s:1"]'
+    )
 
 
 def test_cards_from_keys_deduplicates_same_user_assistant_pair(tmp_path: Path) -> None:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import numpy as np
+
+from core.memory.engine import MemoryQuery, MemoryScope
+from plugins.akasha.config import AkashaConfig
+from plugins.akasha.engine import (
+    ActivationTrace,
+    AkashaCandidate,
+    AkashaMemoryEngine,
+    _AkashaRetrieval,
+    _compute_candidates,
+    _load_turn_card,
+)
+from plugins.akasha.store import AkashaStore, SourceMessage
+from scripts.build_akasha_db import _embed_batch_with_cache
+
+
+def _init_sessions_db(path: Path) -> None:
+    with closing(sqlite3.connect(str(path))) as db:
+        db.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        db.executemany(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("s:0", "s", 0, "user", "第一条用户消息需要完整展示", "2026-01-01T00:00:00+00:00"),
+                ("s:1", "s", 1, "assistant", "第一条助手回复会被截断展示并保留引用", "2026-01-01T00:00:01+00:00"),
+                ("s:2", "s", 2, "user", "第二条用户消息只在联想块", "2026-01-01T00:00:02+00:00"),
+                ("s:3", "s", 3, "assistant", "第二条助手回复也会被截断", "2026-01-01T00:00:03+00:00"),
+            ],
+        )
+        db.commit()
+
+
+class FakeEmbedder:
+    async def embed(self, text: str) -> list[float]:
+        _ = text
+        return [1.0, 0.0]
+
+
+class FakeBatchEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[10.0 + index, 0.0] for index, _ in enumerate(texts)]
+
+
+def test_store_merges_user_and_assistant_into_turn_node(tmp_path: Path) -> None:
+    store = AkashaStore(tmp_path / "akasha.db")
+    try:
+        store.upsert_message_node(
+            SourceMessage("s:0", "s", 0, "user", "用户消息", "2026-01-01T00:00:00+00:00"),
+            [1.0, 0.0],
+        )
+        store.upsert_message_node(
+            SourceMessage("s:1", "s", 1, "assistant", "助手消息", "2026-01-01T00:00:01+00:00"),
+            [0.0, 1.0],
+        )
+
+        nodes = store.list_nodes()
+    finally:
+        store.close()
+
+    assert len(nodes) == 1
+    assert nodes[0].key == "s:0"
+    assert nodes[0].anchor_id == "s:0"
+    assert nodes[0].emb_count == 2
+
+
+def test_reset_schema_keeps_embedding_cache(tmp_path: Path) -> None:
+    store = AkashaStore(tmp_path / "akasha.db")
+    message = SourceMessage(
+        "s:0",
+        "s",
+        0,
+        "user",
+        "用户消息",
+        "2026-01-01T00:00:00+00:00",
+    )
+    try:
+        store.upsert_cached_embedding(message=message, model="m", embedding=[1.0, 2.0])
+        _ = store.upsert_message_node(message, [1.0, 0.0])
+        store.reset_schema()
+
+        cached = store.get_cached_embedding(message=message, model="m")
+        nodes = store.list_nodes()
+    finally:
+        store.close()
+
+    assert cached == [1.0, 2.0]
+    assert nodes == []
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_with_cache_only_embeds_missing_messages(
+    tmp_path: Path,
+) -> None:
+    store = AkashaStore(tmp_path / "akasha.db")
+    messages = [
+        SourceMessage("s:0", "s", 0, "user", "已缓存", "2026-01-01T00:00:00+00:00"),
+        SourceMessage("s:1", "s", 1, "assistant", "新消息", "2026-01-01T00:00:01+00:00"),
+    ]
+    fake = FakeBatchEmbedder()
+    try:
+        store.upsert_cached_embedding(
+            message=messages[0],
+            model="m",
+            embedding=[1.0, 0.0],
+        )
+
+        embeddings, hits, misses = await _embed_batch_with_cache(
+            store=store,
+            embedder=cast(Any, fake),
+            model="m",
+            batch=messages,
+        )
+    finally:
+        store.close()
+
+    assert hits == 1
+    assert misses == 1
+    assert fake.calls == [["新消息"]]
+    assert embeddings == [[1.0, 0.0], [10.0, 0.0]]
+
+
+def test_load_turn_card_uses_full_user_and_short_assistant(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+
+    card = _load_turn_card(
+        db_path,
+        "s:0",
+        assistant_preview_chars=15,
+        score=0.8,
+        lane="dense",
+        signals={},
+    )
+
+    assert card is not None
+    assert card.user_message == "第一条用户消息需要完整展示"
+    assert card.assistant_preview == "第一条助手回复会被截断展示并保..."
+    assert card.source_ref == '["s:0", "s:1"]'
+
+
+@pytest.mark.asyncio
+async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig(assistant_preview_chars=15)
+    engine._session_db_path = db_path
+    engine._embedder = FakeEmbedder()
+    engine._remember_pending_activation = lambda request, items: None
+    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+        dense_items=[
+            AkashaCandidate(
+                key="s:0",
+                source="Dense",
+                ripple=0.0,
+                direct=0.9,
+                state=0.0,
+                edge=0.0,
+                long=0.0,
+                resource=1.0,
+                fan=0,
+                score=0.9,
+            )
+        ],
+        ripple_items=[
+            AkashaCandidate(
+                key="s:0",
+                source="Dense",
+                ripple=0.6,
+                direct=0.9,
+                state=1.0,
+                edge=0.0,
+                long=0.0,
+                resource=1.0,
+                fan=0,
+                score=0.8,
+            ),
+            AkashaCandidate(
+                key="s:2",
+                source="Expanded",
+                ripple=0.5,
+                direct=0.4,
+                state=0.8,
+                edge=0.2,
+                long=0.0,
+                resource=1.0,
+                fan=1,
+                score=0.7,
+            ),
+        ],
+        activation_items=[],
+        trace=ActivationTrace(seed_count=1, pool_count=2),
+        seq=4,
+    )
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户消息",
+            intent="context",
+            scope=MemoryScope(session_key="s"),
+        )
+    )
+
+    assert "## 左脑记忆：精确回忆" in result.text_block
+    assert "## 右脑联想：潜意识第一反应" in result.text_block
+    assert '- user="第一条用户消息需要完整展示" assistant=' in result.text_block
+    dense_block, ripple_block = result.text_block.split("## 右脑联想：潜意识第一反应", 1)
+    assert 'source_ref=["s:0", "s:1"]' in dense_block
+    assert 'source_ref=["s:0", "s:1"]' not in ripple_block
+    assert 'source_ref=["s:2", "s:3"]' in ripple_block
+
+
+@pytest.mark.asyncio
+async def test_context_query_uses_akasha_top_k_over_default_query_limit(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    with closing(sqlite3.connect(str(db_path))) as db:
+        db.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        rows = []
+        for turn in range(24):
+            user_seq = turn * 2
+            rows.append((f"s:{user_seq}", "s", user_seq, "user", f"用户消息{turn}", "2026-01-01T00:00:00+00:00"))
+            rows.append((f"s:{user_seq + 1}", "s", user_seq + 1, "assistant", f"助手回复{turn}", "2026-01-01T00:00:01+00:00"))
+        db.executemany("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)", rows)
+        db.commit()
+
+    def candidate(key: str, score: float) -> AkashaCandidate:
+        return AkashaCandidate(
+            key=key,
+            source="Dense",
+            ripple=0.0,
+            direct=score,
+            state=0.0,
+            edge=0.0,
+            long=0.0,
+            resource=1.0,
+            fan=0,
+            score=score,
+        )
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig(dense_top_k=10, ripple_top_k=10, inject_max_chars=20000)
+    engine._session_db_path = db_path
+    engine._embedder = FakeEmbedder()
+    engine._remember_pending_activation = lambda request, items: None
+    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+        dense_items=[candidate(f"s:{turn * 2}", 1.0 - turn * 0.01) for turn in range(12)],
+        ripple_items=[candidate(f"s:{24 + turn * 2}", 0.8 - turn * 0.01) for turn in range(12)],
+        activation_items=[],
+        trace=ActivationTrace(seed_count=1, pool_count=24),
+        seq=48,
+    )
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户消息",
+            intent="context",
+            scope=MemoryScope(session_key="s"),
+            limit=8,
+        )
+    )
+
+    assert result.trace["dense_count"] == 10
+    assert result.trace["ripple_count"] == 10
+    assert result.text_block.count("source_ref=") == 20
+
+
+def test_compute_candidates_uses_activation_limit_for_stateful_replay(tmp_path: Path) -> None:
+    store = AkashaStore(tmp_path / "akasha.db")
+    try:
+        for seq in range(30):
+            _ = store.upsert_message_node(
+                SourceMessage(
+                    f"s:{seq}",
+                    "s",
+                    seq,
+                    "user",
+                    f"消息 {seq}",
+                    "2026-01-01T00:00:00+00:00",
+                    salience=1.0,
+                ),
+                [1.0, 0.0],
+            )
+        nodes = {node.key: node for node in store.list_nodes()}
+    finally:
+        store.close()
+
+    candidates, suppressed, trace = _compute_candidates(
+        "消息",
+        np.array([1.0, 0.0], dtype=np.float32),
+        nodes,
+        {},
+        100,
+        config=AkashaConfig(dense_top_k=30, activate_limit=8),
+        fan={},
+        soft_recall=False,
+        return_limit=8,
+    )
+
+    assert len(candidates) == 8
+    assert trace.seed_count == 30
+    assert suppressed == []

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from contextlib import closing
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -18,7 +20,12 @@ from plugins.akasha.engine import (
     _compute_candidates,
     _load_turn_card,
 )
-from plugins.akasha.store import AkashaStore, SourceMessage
+from plugins.akasha.store import (
+    ActivationEventRow,
+    AkashaStore,
+    EdgeUpdate,
+    SourceMessage,
+)
 from scripts.build_akasha_db import _embed_batch_with_cache
 
 
@@ -419,3 +426,99 @@ def test_query_log_keeps_context_and_answer_for_same_seq(tmp_path: Path) -> None
 
     assert total == 2
     assert {item["intent"] for item in items} == {"context", "answer"}
+
+
+def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+    store = AkashaStore(tmp_path / "akasha.db")
+    try:
+        messages = [
+            SourceMessage("s:0", "s", 0, "user", "第一条用户消息需要完整展示", "2026-01-01T00:00:00+00:00"),
+            SourceMessage("s:1", "s", 1, "assistant", "第一条助手回复会被截断展示并保留引用", "2026-01-01T00:00:01+00:00"),
+            SourceMessage("s:2", "s", 2, "user", "第二条用户消息只在联想块", "2026-01-01T00:00:02+00:00"),
+        ]
+        for index, message in enumerate(messages):
+            embedding = [1.0, 0.0] if index < 2 else [0.0, 1.0]
+            store.upsert_cached_embedding(message=message, model="m", embedding=embedding)
+            _ = store.upsert_message_node(message, embedding)
+        store.upsert_edges([
+            EdgeUpdate("s:0", "s:2", 1.0, 0),
+            EdgeUpdate("s:2", "s:0", 1.0, 0),
+        ])
+        store.insert_activation_events([
+            ActivationEventRow(
+                seq=0,
+                query_id="s:0",
+                activated_key="s:2",
+                source="Dense",
+                score=0.8,
+                direct_score=0.8,
+                state_score=0.0,
+                edge_score=0.0,
+                long_score=0.0,
+                resource=1.0,
+                fan=0,
+            )
+        ])
+        store.insert_query_log(
+            query_id="s:0:context:abc",
+            session_key="s",
+            seq=0,
+            query_text="第一条用户消息",
+            intent="context",
+            ts="2026-01-01T00:00:00+00:00",
+            seed_count=1,
+            pool_count=2,
+            activated_count=1,
+            activation_threshold=0.2,
+            dense_count=1,
+            ripple_count=1,
+            inject_chars=10,
+            source_ref_count=2,
+            activation_items_json="[]",
+            dense_items_json="[]",
+            ripple_items_json="[]",
+            text_block_preview="preview",
+        )
+
+        engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+        engine._store = store
+        engine._session_db_path = db_path
+        engine._config = SimpleNamespace(
+            memory=SimpleNamespace(embedding=SimpleNamespace(model="m"))
+        )
+        engine._graph_lock = threading.RLock()
+        engine._nodes = {}
+        engine._edges = {}
+        engine._edges_by_src = {}
+        engine._fan = {}
+        engine._message_embeddings = {}
+        engine._message_turn_keys = {}
+        engine._load_graph_cache()
+
+        dry_run = engine.undo_by_message_sources(["s:0", "s:1"], dry_run=True)
+        with closing(sqlite3.connect(str(db_path))) as db:
+            _ = db.execute("DELETE FROM messages WHERE id IN ('s:0', 's:1')")
+            db.commit()
+        result = engine.undo_by_message_sources(["s:0", "s:1"])
+
+        assert dry_run["affected_ids"] == ["s:0"]
+        assert result["affected_ids"] == ["s:0"]
+        assert result["restored_ids"] == []
+        assert result["rollback_source_ids"] == ["s:0", "s:1"]
+        assert store.get_node("s:0") is None
+        assert store.get_node("s:2") is not None
+        assert store.load_edges() == {}
+        assert store.list_query_logs(page=1, page_size=10)[1] == 0
+        with closing(sqlite3.connect(str(store.db_path))) as db:
+            event_count = db.execute("SELECT COUNT(1) FROM akasha_activation_events").fetchone()[0]
+            cache_count = db.execute("SELECT COUNT(1) FROM akasha_embedding_cache").fetchone()[0]
+        assert event_count == 0
+        assert cache_count == 1
+        assert "s:0" not in engine._nodes
+        assert ("s:0", "s:2") not in engine._edges
+        assert "s:0" not in engine._message_embeddings
+        assert "s:1" not in engine._message_turn_keys
+    finally:
+        store.close()

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -24,7 +24,12 @@ from plugins.akasha.engine import (
     _compute_candidates,
     _load_turn_card,
 )
-from plugins.akasha.core import activation_edge_updates
+from plugins.akasha.core import (
+    AkashaNode,
+    activation_edge_updates,
+    build_dense_message_index,
+    dense_message_candidates,
+)
 from plugins.akasha.plugin import AkashaPlugin
 from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage, _turn_messages
 from plugins.akasha.store import (
@@ -85,6 +90,99 @@ def _candidate(key: str, score: float) -> AkashaCandidate:
         resource=1.0,
         fan=0,
         score=score,
+    )
+
+
+def test_dense_message_candidates_vectorized_preserves_turn_ranking() -> None:
+    nodes = {
+        "s:0": AkashaNode(
+            key="s:0",
+            anchor_id="m0",
+            session_key="s",
+            turn_seq=0,
+            first_ts_unix=QUERY_TS.timestamp(),
+            salience=0.0,
+            strength=0.0,
+            resource=1.0,
+            recall_count=0,
+            last_activated_ts=0.0,
+            last_strength_ts=QUERY_TS.timestamp(),
+            last_resource_ts=QUERY_TS.timestamp(),
+            embedding=np.array([1.0, 0.0], dtype=np.float32),
+            emb_count=1,
+        ),
+        "s:2": AkashaNode(
+            key="s:2",
+            anchor_id="m2",
+            session_key="s",
+            turn_seq=2,
+            first_ts_unix=QUERY_TS.timestamp(),
+            salience=0.0,
+            strength=0.0,
+            resource=1.0,
+            recall_count=0,
+            last_activated_ts=0.0,
+            last_strength_ts=QUERY_TS.timestamp(),
+            last_resource_ts=QUERY_TS.timestamp(),
+            embedding=np.array([0.0, 1.0], dtype=np.float32),
+            emb_count=1,
+        ),
+        "s:4": AkashaNode(
+            key="s:4",
+            anchor_id="m4",
+            session_key="s",
+            turn_seq=4,
+            first_ts_unix=QUERY_TS.timestamp(),
+            salience=0.0,
+            strength=0.0,
+            resource=1.0,
+            recall_count=0,
+            last_activated_ts=0.0,
+            last_strength_ts=QUERY_TS.timestamp(),
+            last_resource_ts=QUERY_TS.timestamp(),
+            embedding=np.array([0.0, 0.0], dtype=np.float32),
+            emb_count=1,
+        ),
+    }
+    message_embeddings = {
+        "m0": np.array([1.0, 0.0], dtype=np.float32),
+        "m2": np.array([0.8, 0.6], dtype=np.float32),
+        "m3": np.array([0.9, 0.1], dtype=np.float32),
+        "bad-dim": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "m4": np.array([0.0, 0.0], dtype=np.float32),
+    }
+    message_turn_keys = {
+        "m0": "s:0",
+        "m2": "s:2",
+        "m3": "s:2",
+        "bad-dim": "s:0",
+        "m4": "s:4",
+    }
+    loop_result = dense_message_candidates(
+        np.array([1.0, 0.0], dtype=np.float32),
+        nodes,
+        message_embeddings,
+        message_turn_keys,
+        limit=3,
+    )
+    indexed_result = dense_message_candidates(
+        np.array([1.0, 0.0], dtype=np.float32),
+        nodes,
+        message_embeddings,
+        message_turn_keys,
+        limit=3,
+        message_index=build_dense_message_index(message_embeddings),
+    )
+
+    assert [item.key for item in loop_result] == ["s:0", "s:2", "s:4"]
+    assert [item.key for item in indexed_result] == [item.key for item in loop_result]
+    assert [item.score for item in loop_result] == pytest.approx([
+        1.0,
+        0.9 / ((0.9 ** 2 + 0.1 ** 2) ** 0.5),
+        0.0,
+    ])
+    assert [item.score for item in indexed_result] == pytest.approx(
+        [item.score for item in loop_result]
     )
 
 

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 import numpy as np
 
-from core.memory.engine import MemoryQuery, MemoryScope
+from core.memory.engine import MemoryQuery, MemoryQueryIntent, MemoryScope
 from agent.plugins.context import PluginContext, PluginKVStore
 from plugins.akasha.config import AkashaConfig
 from plugins.akasha.engine import (
@@ -753,7 +753,8 @@ def test_query_log_keeps_context_and_answer_for_same_seq(tmp_path: Path) -> None
         seq=10,
     )
     try:
-        for intent, text_block in [("context", "注入文本"), ("answer", "")]:
+        cases: list[tuple[MemoryQueryIntent, str]] = [("context", "注入文本"), ("answer", "")]
+        for intent, text_block in cases:
             engine._write_query_log(
                 request=MemoryQuery(
                     text="同一轮问题",

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import threading
 from contextlib import closing
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -18,18 +19,24 @@ from plugins.akasha.engine import (
     ActivationTrace,
     AkashaCandidate,
     AkashaMemoryEngine,
+    PendingActivation,
     _AkashaRetrieval,
     _compute_candidates,
     _load_turn_card,
 )
+from plugins.akasha.core import activation_edge_updates
 from plugins.akasha.plugin import AkashaPlugin
+from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage, _turn_messages
 from plugins.akasha.store import (
     ActivationEventRow,
     AkashaStore,
     EdgeUpdate,
     SourceMessage,
 )
-from scripts.build_akasha_db import _embed_batch_with_cache
+from scripts.build_akasha_db import _load_embeddings_from_cache
+
+
+QUERY_TS = datetime.fromtimestamp(1_700_000_000.0, timezone.utc)
 
 
 def _init_sessions_db(path: Path) -> None:
@@ -55,6 +62,8 @@ def _init_sessions_db(path: Path) -> None:
                 ("s:3", "s", 3, "assistant", "第二条助手回复也会被截断", "2026-01-01T00:00:03+00:00"),
             ],
         )
+        db.execute("CREATE VIRTUAL TABLE messages_fts USING fts5(content)")
+        db.execute("INSERT INTO messages_fts(rowid, content) SELECT rowid, content FROM messages")
         db.commit()
 
 
@@ -64,13 +73,19 @@ class FakeEmbedder:
         return [1.0, 0.0]
 
 
-class FakeBatchEmbedder:
-    def __init__(self) -> None:
-        self.calls: list[list[str]] = []
-
-    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        self.calls.append(list(texts))
-        return [[10.0 + index, 0.0] for index, _ in enumerate(texts)]
+def _candidate(key: str, score: float) -> AkashaCandidate:
+    return AkashaCandidate(
+        key=key,
+        source="Dense",
+        ripple=0.0,
+        direct=score,
+        state=0.0,
+        edge=0.0,
+        long=0.0,
+        resource=1.0,
+        fan=0,
+        score=score,
+    )
 
 
 def test_store_merges_user_and_assistant_into_turn_node(tmp_path: Path) -> None:
@@ -119,8 +134,7 @@ def test_reset_schema_keeps_embedding_cache(tmp_path: Path) -> None:
     assert nodes == []
 
 
-@pytest.mark.asyncio
-async def test_embed_batch_with_cache_only_embeds_missing_messages(
+def test_load_embeddings_from_cache_counts_hits_and_misses(
     tmp_path: Path,
 ) -> None:
     store = AkashaStore(tmp_path / "akasha.db")
@@ -128,7 +142,6 @@ async def test_embed_batch_with_cache_only_embeds_missing_messages(
         SourceMessage("s:0", "s", 0, "user", "已缓存", "2026-01-01T00:00:00+00:00"),
         SourceMessage("s:1", "s", 1, "assistant", "新消息", "2026-01-01T00:00:01+00:00"),
     ]
-    fake = FakeBatchEmbedder()
     try:
         store.upsert_cached_embedding(
             message=messages[0],
@@ -136,19 +149,200 @@ async def test_embed_batch_with_cache_only_embeds_missing_messages(
             embedding=[1.0, 0.0],
         )
 
-        embeddings, hits, misses = await _embed_batch_with_cache(
+        embeddings, hits, misses = _load_embeddings_from_cache(
             store=store,
-            embedder=cast(Any, fake),
             model="m",
-            batch=messages,
+            messages=messages,
         )
     finally:
         store.close()
 
     assert hits == 1
     assert misses == 1
-    assert fake.calls == [["新消息"]]
-    assert embeddings == [[1.0, 0.0], [10.0, 0.0]]
+    assert embeddings == {"s:0": [1.0, 0.0]}
+
+
+def test_replay_and_runtime_use_same_directional_stdp_edges(tmp_path: Path) -> None:
+    candidate = _candidate("s:0", 0.8)
+    ts = QUERY_TS.timestamp()
+    expected = {
+        (item.src_key, item.dst_key): 0.12 * item.strength
+        for item in activation_edge_updates("s:2", [candidate], ts)
+    }
+    replay_store = AkashaStore(tmp_path / "replay.db")
+    runtime_store = AkashaStore(tmp_path / "runtime.db")
+    try:
+        with closing(sqlite3.connect(":memory:")) as source_db:
+            replay = AkashaReplayRuntime(
+                store=replay_store,
+                config=AkashaConfig(),
+                source_db_path=tmp_path / "sessions.db",
+                source_cursor=source_db.cursor(),
+                message_embeddings={},
+                message_turn_keys={},
+            )
+            replay.commit_turn(
+                [
+                    ReplayMessage(
+                        SourceMessage(
+                            "m2",
+                            "s",
+                            2,
+                            "user",
+                            "当前消息",
+                            QUERY_TS.isoformat(),
+                        ),
+                        [1.0, 0.0],
+                    )
+                ],
+                [candidate],
+            )
+
+        engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+        engine._store = runtime_store
+        engine._graph_lock = threading.RLock()
+        engine._edges = {}
+        engine._edges_meta = {}
+        engine._edges_by_src = {}
+        engine._fan = {}
+        engine._commit_pending_activation(
+            "s:2",
+            PendingActivation(query_id="q", seq=2, ts=ts, items=[candidate]),
+        )
+
+        assert replay_store.load_edges() == pytest.approx(expected)
+        assert runtime_store.load_edges() == pytest.approx(expected)
+        assert expected[("s:0", "s:2")] > expected[("s:2", "s:0")]
+    finally:
+        replay_store.close()
+        runtime_store.close()
+
+
+def test_replay_writes_query_log_with_activation_items(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+    monkeypatch.setattr("plugins.akasha.core.get_jieba_keywords", lambda _: "")
+    replay_store = AkashaStore(tmp_path / "replay.db")
+    old_messages = [
+        SourceMessage("s:0", "s", 0, "user", "第一条用户消息需要完整展示", "2026-01-01T00:00:00+00:00"),
+        SourceMessage("s:2", "s", 2, "user", "第二条用户消息只在联想块", "2026-01-01T00:00:02+00:00"),
+    ]
+    try:
+        replay_store.upsert_message_node(old_messages[0], [1.0, 0.0])
+        replay_store.upsert_message_node(old_messages[1], [0.98, 0.02])
+        with closing(sqlite3.connect(str(db_path))) as source_db:
+            replay = AkashaReplayRuntime(
+                store=replay_store,
+                config=AkashaConfig(dense_seed_threshold=0.1, nearby_dense_threshold=0.0),
+                source_db_path=db_path,
+                source_cursor=source_db.cursor(),
+                message_embeddings={
+                    "s:0": np.array([1.0, 0.0], dtype=np.float32),
+                    "s:2": np.array([0.98, 0.02], dtype=np.float32),
+                },
+                message_turn_keys={"s:0": "s:0", "s:2": "s:2"},
+            )
+            result = replay.replay_turn([
+                ReplayMessage(
+                    SourceMessage("s:4", "s", 4, "user", "第一条", QUERY_TS.isoformat()),
+                    [1.0, 0.0],
+                )
+            ])
+
+        rows, total = replay_store.list_query_logs(session_key="s", page=1, page_size=10)
+        assert total == 1
+        raw = replay_store.get_query_log(str(rows[0]["query_id"]))
+        assert raw is not None
+        activation_items = json.loads(str(raw["activation_items_json"]))
+        dense_items = json.loads(str(raw["dense_items_json"]))
+        ripple_items = json.loads(str(raw["ripple_items_json"]))
+        assert str(rows[0]["query_id"]).startswith("s:4:context:")
+        assert rows[0]["intent"] == "context"
+        assert rows[0]["activated_count"] == len(result.activation_items)
+        assert rows[0]["dense_count"] == len(dense_items)
+        assert rows[0]["ripple_count"] == len(ripple_items)
+        assert raw["text_block_preview"]
+        assert activation_items
+        assert dense_items
+        assert isinstance(ripple_items, list)
+        assert activation_items[0]["user_message"] in {
+            "第一条用户消息需要完整展示",
+            "第二条用户消息只在联想块",
+        }
+    finally:
+        replay_store.close()
+
+
+def test_replay_empty_query_commits_without_activation_or_query_log(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+    replay_store = AkashaStore(tmp_path / "replay.db")
+    replay_store.upsert_message_node(
+        SourceMessage("s:0", "s", 0, "user", "第一条用户消息需要完整展示", "2026-01-01T00:00:00+00:00"),
+        [1.0, 0.0],
+    )
+    try:
+        with closing(sqlite3.connect(str(db_path))) as source_db:
+            replay = AkashaReplayRuntime(
+                store=replay_store,
+                config=AkashaConfig(dense_seed_threshold=0.1, nearby_dense_threshold=0.0),
+                source_db_path=db_path,
+                source_cursor=source_db.cursor(),
+                message_embeddings={"s:0": np.array([1.0, 0.0], dtype=np.float32)},
+                message_turn_keys={"s:0": "s:0"},
+            )
+            result = replay.replay_turn([
+                ReplayMessage(
+                    SourceMessage("s:4", "s", 4, "user", "", QUERY_TS.isoformat()),
+                    [0.0, 0.0],
+                )
+            ])
+
+        rows, total = replay_store.list_query_logs(session_key="s", page=1, page_size=10)
+        assert result.current_key == "s:4"
+        assert result.activation_items == []
+        assert total == 0
+        assert rows == []
+        with closing(sqlite3.connect(str(tmp_path / "replay.db"))) as db:
+            assert db.execute("SELECT COUNT(*) FROM akasha_activation_events").fetchone()[0] == 0
+    finally:
+        replay_store.close()
+
+
+def test_query_log_content_loader_allows_empty_user_message(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    with closing(sqlite3.connect(str(db_path))) as db:
+        db.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        db.executemany(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("m0", "s", 0, "user", "", QUERY_TS.isoformat()),
+                ("m1", "s", 1, "assistant", "assistant preview", QUERY_TS.isoformat()),
+            ],
+        )
+        db.commit()
+        user_message, assistant_preview = _turn_messages(
+            db.cursor(),
+            "s:0",
+            assistant_preview_chars=9,
+        )
+
+    assert user_message == ""
+    assert assistant_preview == "assistant..."
 
 
 def test_load_turn_card_uses_full_user_and_short_assistant(tmp_path: Path) -> None:
@@ -182,8 +376,8 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
     engine._akasha_config = AkashaConfig(assistant_preview_chars=15)
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
-    engine._remember_pending_activation = lambda request, items: None
-    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+    engine._remember_pending_activation = lambda request, items, **_: None
+    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
         dense_items=[
             AkashaCandidate(
                 key="s:0",
@@ -234,6 +428,7 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
             text="用户消息",
             intent="context",
             scope=MemoryScope(session_key="s"),
+            timestamp=QUERY_TS,
         )
     )
 
@@ -272,8 +467,8 @@ async def test_context_block_sorts_injected_cards_by_time_desc(tmp_path: Path) -
     engine._akasha_config = AkashaConfig(dense_top_k=10, ripple_top_k=10)
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
-    engine._remember_pending_activation = lambda request, items: None
-    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+    engine._remember_pending_activation = lambda request, items, **_: None
+    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
         dense_items=[candidate("s:0", 0.9), candidate("s:2", 0.8)],
         ripple_items=[],
         activation_items=[],
@@ -286,6 +481,7 @@ async def test_context_block_sorts_injected_cards_by_time_desc(tmp_path: Path) -
             text="用户消息",
             intent="context",
             scope=MemoryScope(session_key="s"),
+            timestamp=QUERY_TS,
         )
     )
 
@@ -385,8 +581,8 @@ async def test_context_query_uses_akasha_top_k_over_default_query_limit(
     engine._akasha_config = AkashaConfig(dense_top_k=10, ripple_top_k=10, inject_max_chars=20000)
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
-    engine._remember_pending_activation = lambda request, items: None
-    engine._retrieve = lambda query, query_vec, request: _AkashaRetrieval(
+    engine._remember_pending_activation = lambda request, items, **_: None
+    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
         dense_items=[candidate(f"s:{turn * 2}", 1.0 - turn * 0.01) for turn in range(12)],
         ripple_items=[candidate(f"s:{24 + turn * 2}", 0.8 - turn * 0.01) for turn in range(12)],
         activation_items=[],
@@ -400,6 +596,7 @@ async def test_context_query_uses_akasha_top_k_over_default_query_limit(
             intent="context",
             scope=MemoryScope(session_key="s"),
             limit=8,
+            timestamp=QUERY_TS,
         )
     )
 
@@ -464,6 +661,7 @@ def test_query_log_keeps_context_and_answer_for_same_seq(tmp_path: Path) -> None
                     text="同一轮问题",
                     intent=intent,
                     scope=MemoryScope(session_key="s"),
+                    timestamp=QUERY_TS,
                 ),
                 result=result,
                 seq=10,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -505,7 +505,7 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
             ),
             AkashaCandidate(
                 key="s:2",
-                source="Expanded",
+                source="Graph",
                 ripple=0.5,
                 direct=0.4,
                 state=0.8,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from contextlib import closing
@@ -11,6 +12,7 @@ import pytest
 import numpy as np
 
 from core.memory.engine import MemoryQuery, MemoryScope
+from agent.plugins.context import PluginContext, PluginKVStore
 from plugins.akasha.config import AkashaConfig
 from plugins.akasha.engine import (
     ActivationTrace,
@@ -20,6 +22,7 @@ from plugins.akasha.engine import (
     _compute_candidates,
     _load_turn_card,
 )
+from plugins.akasha.plugin import AkashaPlugin
 from plugins.akasha.store import (
     ActivationEventRow,
     AkashaStore,
@@ -522,3 +525,112 @@ def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> 
         assert "s:1" not in engine._message_turn_keys
     finally:
         store.close()
+
+
+def test_akashalast_command_only_registers_for_akasha_engine(tmp_path: Path) -> None:
+    akasha = AkashaPlugin()
+    akasha.context = PluginContext(
+        event_bus=None,
+        tool_registry=None,
+        plugin_id="akasha",
+        plugin_dir=tmp_path,
+        kv_store=PluginKVStore(tmp_path / ".akasha-kv.json"),
+        workspace=tmp_path,
+        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="akasha")),
+    )
+    default = AkashaPlugin()
+    default.context = PluginContext(
+        event_bus=None,
+        tool_registry=None,
+        plugin_id="akasha",
+        plugin_dir=tmp_path,
+        kv_store=PluginKVStore(tmp_path / ".default-kv.json"),
+        workspace=tmp_path,
+        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="default")),
+    )
+
+    assert akasha.telegram_bot_commands() == [("akashalast", "查看上一轮 Akasha 检索诊断")]
+    assert len(akasha.before_turn_modules()) == 1
+    assert default.telegram_bot_commands() == []
+    assert default.before_turn_modules() == []
+
+
+def test_akashalast_renders_latest_query_log(tmp_path: Path) -> None:
+    store = AkashaStore(tmp_path / "memory" / "akasha.db")
+    try:
+        activation_items = json.dumps([
+            {
+                "user_message": "这个是他转的别人的帖子而已",
+                "assistant_preview": "啊你说得对，那个是转推",
+                "score": 0.501,
+                "source": "Dense",
+                "path_type": "direct",
+            }
+        ], ensure_ascii=False)
+        dense_items = json.dumps([
+            {
+                "user_message": "这个是他转的别人的帖子而已",
+                "assistant_preview": "啊你说得对，那个是转推",
+                "score": 0.703,
+                "source": "Dense",
+            }
+        ], ensure_ascii=False)
+        ripple_items = json.dumps([
+            {
+                "user_message": "我纠正过你几次有关汪远哲这个名字",
+                "assistant_preview": "花月哥哥，这个错误我真是犯过",
+                "score": 0.247,
+                "source": "FTS",
+                "path_type": "direct",
+                "direct": 0.41,
+                "state": 0.18,
+                "edge": 0.08,
+                "resource": 1.0,
+                "fan": 32,
+            }
+        ], ensure_ascii=False)
+        store.insert_query_log(
+            query_id="s:2:context:abc",
+            session_key="s",
+            seq=2,
+            query_text="这个其实不是她的 是她转发的别人的帖子",
+            intent="context",
+            ts="2026-05-24T22:15:00+08:00",
+            seed_count=11,
+            pool_count=81,
+            activated_count=4,
+            activation_threshold=0.22,
+            dense_count=1,
+            ripple_count=1,
+            inject_chars=100,
+            source_ref_count=2,
+            activation_items_json=activation_items,
+            dense_items_json=dense_items,
+            ripple_items_json=ripple_items,
+            text_block_preview="preview",
+        )
+    finally:
+        store.close()
+
+    plugin = AkashaPlugin()
+    plugin.context = PluginContext(
+        event_bus=None,
+        tool_registry=None,
+        plugin_id="akasha",
+        plugin_dir=tmp_path,
+        kv_store=PluginKVStore(tmp_path / ".kv.json"),
+        workspace=tmp_path,
+        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="akasha")),
+    )
+
+    reply = plugin.render_last_query("s")
+
+    assert "🧠 Akasha 记忆检索诊断" in reply
+    assert "📍 会话: `s` | seq `2`" in reply
+    assert "• 种子节点 (Seeds): `11` 个" in reply
+    assert "🔥 本轮图激活节点 (Activated Nodes):" in reply
+    assert "🎯 左脑精确回忆 (Dense):" in reply
+    assert "🌊 右脑联想记忆 (Ripple):" in reply
+    assert "分: `0.501` | 源: `Dense` | 径: `direct`" in reply
+    assert "得: `0.703` | 源: `Dense`" in reply
+    assert "因: `dir:0.41 st:0.18 edg:0.08 res:1.00 fan:32`" in reply

--- a/tests/test_citation_plugin.py
+++ b/tests/test_citation_plugin.py
@@ -49,6 +49,15 @@ def test_citation_extracts_marker_with_spaces_after_commas() -> None:
     assert ids == ["mem_1", "mem-2"]
 
 
+def test_citation_extracts_colon_message_ids() -> None:
+    clean, ids = extract_cited_ids(
+        "答复正文\n§cited:[telegram:7674283004:4395,telegram:7674283004:4396]§"
+    )
+
+    assert clean == "答复正文"
+    assert ids == ["telegram:7674283004:4395", "telegram:7674283004:4396"]
+
+
 def test_citation_strips_empty_marker() -> None:
     clean, ids = extract_cited_ids("答复正文\n§cited:[]§")
 

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -413,6 +413,42 @@ async def test_ipc_server_channel_covers_connection_command_and_response(
 
 
 @pytest.mark.asyncio
+async def test_ipc_server_can_route_cli_to_existing_session():
+    bus = MessageBus()
+    channel = IPCServerChannel(
+        bus,
+        "/tmp/agent.sock",
+        default_session_key="telegram:7674283004",
+    )
+    reader = SimpleNamespace(
+        readline=AsyncMock(
+            side_effect=[
+                b'{"content":"hello"}\n',
+                b'{"content":"hi","as_session_key":"telegram:42"}\n',
+                b"",
+            ]
+        )
+    )
+    writer = SimpleNamespace(
+        get_extra_info=lambda name: "peer",
+        close=MagicMock(),
+        wait_closed=AsyncMock(),
+    )
+
+    await channel._handle_connection(
+        cast(asyncio.StreamReader, reader), cast(asyncio.StreamWriter, writer)
+    )
+
+    first = await bus.consume_inbound()
+    second = await bus.consume_inbound()
+    assert first.channel == "cli"
+    assert first.session_key == "telegram:7674283004"
+    assert first.context_channel == "telegram"
+    assert first.context_chat_id == "7674283004"
+    assert second.session_key == "telegram:42"
+
+
+@pytest.mark.asyncio
 async def test_ipc_server_uses_tcp_for_explicit_host_port_on_all_platforms(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -294,10 +294,48 @@ async def test_before_turn_setup_fills_turn_state():
 
     assert state.session is session
     assert ctx.skill_names == ["search"]
+    assert ctx.channel == "telegram"
+    assert ctx.chat_id == "123"
     assert ctx.retrieved_memory_block == "block_text"
     assert ctx.retrieval_trace_raw == {"trace": 1}
     assert ctx.history_messages == ({"role": "user", "content": "prev"},)
     assert ctx.abort is False
+
+
+@pytest.mark.asyncio
+async def test_before_turn_uses_cli_session_override_context():
+    bus = EventBus()
+    session = _DummySession("telegram:7674283004")
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock(return_value=ContextBundle()))
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = InboundMessage(
+        channel="cli",
+        sender="user",
+        chat_id="cli-1",
+        content="hello",
+        timestamp=_now,
+        metadata={
+            "session_key_override": "telegram:7674283004",
+            "context_channel": "telegram",
+            "context_chat_id": "7674283004",
+        },
+    )
+    state = TurnState(msg=msg, session_key=msg.session_key, dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert state.session is session
+    assert ctx.session_key == "telegram:7674283004"
+    assert ctx.channel == "telegram"
+    assert ctx.chat_id == "7674283004"
 
 
 @pytest.mark.asyncio

--- a/tests/test_meme_plugin.py
+++ b/tests/test_meme_plugin.py
@@ -148,3 +148,27 @@ async def test_meme_plugin_decorates_after_reasoning(tmp_path: Path) -> None:
     assert out.reply == "好的"
     assert out.media == [str(image)]
     assert out.meme_tag == "shy"
+
+
+@pytest.mark.asyncio
+async def test_meme_plugin_strips_empty_protocol_tag(tmp_path: Path) -> None:
+    _write_meme_workspace(tmp_path)
+    plugin = await _make_plugin(tmp_path)
+    ctx = AfterReasoningCtx(
+        session_key="telegram:1",
+        channel="telegram",
+        chat_id="1",
+        tools_used=(),
+        thinking=None,
+        response_metadata=ResponseMetadata(raw_text="好的 <meme:>"),
+        streamed=False,
+        tool_chain=(),
+        context_retry={},
+        reply="好的 <meme:>",
+    )
+
+    out = await plugin.decorate_meme(ctx)
+
+    assert out.reply == "好的"
+    assert out.media == []
+    assert out.meme_tag is None

--- a/tests/test_recall_memory_tool.py
+++ b/tests/test_recall_memory_tool.py
@@ -14,7 +14,7 @@ import agent.tools.recall_memory as recall_memory_module
 import memory2.retriever as retriever_module
 from agent.provider import LLMProvider, LLMResponse
 from agent.tools.recall_memory import RecallMemoryTool
-from core.memory.engine import EvidenceRef, MemoryQueryResult, MemoryRecord
+from core.memory.engine import EvidenceRef, MemoryQueryResult, MemoryRecord, MemoryToolSpec
 from plugins.default_memory.engine import DefaultMemoryEngine
 from memory2.embedder import Embedder
 from memory2.retriever import Retriever
@@ -61,6 +61,20 @@ class _CaptureMemory:
     async def query(self, request):
         self.request = request
         return MemoryQueryResult()
+
+
+@pytest.mark.asyncio
+async def test_recall_memory_passes_current_timestamp_to_engine() -> None:
+    memory = _CaptureMemory()
+    tool = RecallMemoryTool(
+        cast(Any, memory),
+        MemoryToolSpec(description="", parameters={"type": "object", "properties": {}}),
+    )
+    ts = datetime(2026, 4, 4, 22, 0, 0)
+
+    _ = await tool.execute(query="Akasha", current_timestamp=ts.isoformat())
+
+    assert memory.request.timestamp == ts
 
 
 class _FakeProvider:

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -304,9 +304,10 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     fake_qqbot_channel = types.ModuleType("infra.channels.qqbot_channel")
 
     class _IPCServerChannel:
-        def __init__(self, bus, socket):
+        def __init__(self, bus, socket, default_session_key: str = ""):
             self.bus = bus
             self.socket = socket
+            self.default_session_key = default_session_key
 
         async def start(self) -> None:
             starts.append("ipc")
@@ -447,9 +448,10 @@ async def test_start_channels_skips_unfilled_optional_channels(monkeypatch, tmp_
     fake_qq_channel = types.ModuleType("infra.channels.qq_channel")
 
     class _IPCServerChannel:
-        def __init__(self, bus, socket):
+        def __init__(self, bus, socket, default_session_key: str = ""):
             self.bus = bus
             self.socket = socket
+            self.default_session_key = default_session_key
 
         async def start(self) -> None:
             starts.append("ipc")

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -85,7 +85,13 @@ async def test_soft_calls_process_direct_not_push_directly(
     assert call_kwargs.kwargs["channel"] == "telegram"
     assert call_kwargs.kwargs["chat_id"] == "123"
     assert call_kwargs.kwargs["skip_post_memory"] is True
-    assert call_kwargs.kwargs["disabled_tools"] == ["message_push"]
+    assert call_kwargs.kwargs["skip_memory_retrieval"] is True
+    assert call_kwargs.kwargs["disabled_tools"] == [
+        "message_push",
+        "recall_memory",
+        "memorize",
+        "forget_memory",
+    ]
 
 
 async def test_soft_sends_ai_response_via_push(

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -134,6 +134,7 @@ async def test_process_direct_suppresses_stream_and_memory_when_requested():
         chat_id="123",
         omit_user_turn=True,
         skip_post_memory=True,
+        skip_memory_retrieval=True,
         disabled_tools=["message_push"],
     )
 
@@ -142,6 +143,7 @@ async def test_process_direct_suppresses_stream_and_memory_when_requested():
     assert msg.metadata == {
         "omit_user_turn": True,
         "skip_post_memory": True,
+        "skip_memory_retrieval": True,
         "suppress_stream_events": True,
         "disabled_tools": ["message_push"],
     }


### PR DESCRIPTION
## 问题

现有记忆链路只有默认 memory engine，缺少 Akasha 这套基于 turn 节点、dense 检索和图扩散联想的独立引擎入口。调试时也缺少能直接查看上一轮 Akasha 检索细节的诊断面板和命令。

## 改动

- 新增 `akasha` memory plugin，支持 sidecar SQLite 存储、turn 节点建模、dense 候选和 ripple 联想召回。
- 接入 Akasha dashboard inspector 和 Telegram `/akashalast` 诊断命令，展示上一轮激活节点、dense 候选和 ripple 候选。
- 新增 Akasha replay 与建库脚本，用于从 session 消息重建 Akasha 数据库并对齐线上检索路径。
- 优化 dense 向量检索索引，移除 `Expanded` 召回来源，保留最终注入候选的来源边界。
- 调整 scheduler soft job，跳过记忆检索并禁用记忆工具，避免后台任务污染普通记忆链路。

## 链路

```text
┌───────────────┐
│ Memory Plugin │
└───────┬───────┘
        │
        ├── default_memory
        │
        └── akasha
            ├── sidecar SQLite
            ├── dense recall
            ├── ripple activation
            ├── dashboard inspector
            └── /akashalast
```

## 验证

- `git diff --check main...HEAD`
- `pyright <changed python files>`：0 errors，保留既有 warnings
- `pytest tests/test_akasha_plugin.py tests/test_recall_memory_tool.py tests/test_scheduler_service.py tests/test_lifecycle_phases.py tests/test_io_modules.py tests/test_meme_plugin.py tests/test_citation_plugin.py tests/proactive_v2/test_tools.py -q`：182 passed
- `npm run typecheck && npm run lint && npm run build:dashboard`

## 配置影响

新增 Akasha 插件本地配置 `plugins/akasha/config.local.toml`，首次启用时自动生成默认值；默认数据库路径为 `workspace/memory/akasha.db`。现有 default memory 配置不变。