### PR TITLE
fix(akasha): 默认使用快速重建

### DIFF
--- a/plugins/akasha/REBUILD.md
+++ b/plugins/akasha/REBUILD.md
@@ -1,0 +1,119 @@
+# Akasha 记忆库重建指南
+
+> 场景：以前聊过一些内容（都在 `sessions.db` 里），想从这些对话**重新建出 akasha 的图**
+> （比如改了图算法/参数、清了脏图、或换了机器）。
+
+## 心智模型
+
+- **`sessions.db`** = 唯一真相源（原始 user/assistant 消息，不动）。
+- **`akasha.db`** = 在真相之上的**索引 + 图**，由重放 `sessions.db` 算出来：
+  - `akasha_nodes` / `akasha_edges` / `akasha_salience_state` —— 图本体（重建会清掉重算）
+  - `akasha_query_log` / `akasha_activation_events` —— 诊断（重建重算）
+  - `akasha_embedding_cache` —— **每条消息的 embedding 缓存**（重建**默认保留**）
+  - `fts_token_idf` —— FTS 稀有词的 IDF 表（FTS 种子用，单独一步建）
+
+重建 = 拿 `sessions.db` 的消息，按时间顺序重放过 akasha 的激活/建边逻辑，把图算出来落回 `akasha.db`。
+**embedding 不参与重算**——重放复用缓存里的向量。所以有没有缓存，决定走哪条路。
+
+> 重建是**确定性**的（已修 `core.py` 的 `PYTHONHASHSEED` 漂移）：同一份 `sessions.db` + 同一份缓存，
+> 每次重建出的图逐位一致、可复现。
+
+---
+
+## 路径 A — 有缓存（常态，~3 分钟）
+
+平时聊天时线上 engine 已经把每条消息 embed 并写进 `akasha_embedding_cache`（见 `engine.py` `_on_turn_committed`）。
+所以**只要你是在用过的库上重建**，缓存就是热的，直接跑：
+
+```bash
+python scripts/build_akasha_db.py \
+  --config config.toml \
+  --sessions-db ~/.akashic/workspace/sessions.db \
+  --db-path    ~/.akashic/workspace/memory/akasha.db
+```
+
+（不带参数时用默认路径：`~/.akashic/workspace/{sessions.db, memory/akasha.db}`、`config.toml`。）
+
+做了什么：
+1. 自动备份旧 `akasha.db`（`*.bak-时间戳`）。
+2. `reset_schema()` 清掉图表与诊断，**保留 `embedding_cache`**。
+3. 用内存 `MemoryStore` 全库快速重放（graph_fast + fast_dense），末尾一次性批量落库。
+4. 写迁移记录，打印 `nodes/edges/query_logs/activation_events` 计数。
+
+输出里看 `cache_hits / cache_misses`：**miss=0 说明缓存全命中**，图完整。
+
+> 这是"以前聊了内容、想重建图"的标准做法——embedding 没变，只是把图算法重新跑一遍。
+
+---
+
+## 路径 B — 没缓存（冷启动 / 删过缓存 / 换了 embedding 模型）
+
+`build_akasha_db.py` **只读缓存、不生成 embedding**。缓存里查不到的消息会被**直接跳过**
+（`_load_embeddings_from_cache` 里 `cache_misses += 1`），结果就是**图残缺甚至为空**。
+
+会落到这条路的情况：
+- 全新 / 空的 `akasha.db`（从没在上面聊过）；
+- 手动删过 `akasha_embedding_cache`；
+- **换了 embedding 模型**——缓存命中键是 `(message_id, model, content_hash)`，model 一变全部失配。
+
+解决：**先预热缓存，再走路径 A。** 目前没有现成脚本，预热的最小范式（与线上同一个 `Embedder`、
+**同一个 config 里的 model**）：
+
+```python
+import asyncio, sqlite3
+from agent.config_models import Config
+from memory2.embedder import Embedder
+from plugins.akasha.core import SourceMessage
+from plugins.akasha.store import AkashaStore
+
+cfg = Config.load("config.toml")
+emb_cfg = cfg.memory.embedding          # base_url / api_key / model
+embedder = Embedder(emb_cfg.base_url, emb_cfg.api_key, model=emb_cfg.model)
+store = AkashaStore("~/.akashic/workspace/memory/akasha.db")
+
+src = sqlite3.connect("~/.akashic/workspace/sessions.db"); src.row_factory = sqlite3.Row
+rows = src.execute(
+    "SELECT id, session_key, seq, role, content, ts FROM messages "
+    "WHERE role IN ('user','assistant')"
+).fetchall()
+
+async def warm():
+    msgs = [SourceMessage(r["id"], r["session_key"], r["seq"], r["role"], r["content"], r["ts"]) for r in rows]
+    vecs = await embedder.embed_batch([m.content for m in msgs])
+    for m, v in zip(msgs, vecs):
+        store.upsert_cached_embedding(message=m, model=emb_cfg.model, embedding=v)
+
+asyncio.run(warm())
+store.close()
+```
+
+> ⚠️ model 必须和 `config.toml` 的 `memory.embedding.model` 一致，否则重建时仍然失配跳过。
+> embed 会调用外部 API（DashScope 风格），耗时和条数成正比；预热一次后缓存就持久了。
+
+预热完，再跑**路径 A** 的 `build_akasha_db.py` 即可。
+
+---
+
+## 从零重建还要补：FTS / IDF 索引
+
+`build_akasha_db.py` **不建** `fts_token_idf`（FTS 稀有词种子用的 IDF 表）。全新库或想刷新 IDF：
+
+```bash
+python scripts/build_fts_idf.py
+```
+
+它扫 `sessions.db` 全部消息、jieba 切词算 IDF、写回 `akasha.db:fts_token_idf`。
+
+---
+
+## 速查
+
+| 情况 | 步骤 |
+|---|---|
+| 用过的库，改了图逻辑/参数想重建 | 直接 `build_akasha_db.py`（路径 A） |
+| 全新空库 / 删过缓存 | 先预热缓存（路径 B）→ `build_akasha_db.py` → `build_fts_idf.py` |
+| 换了 embedding 模型 | 同"全新库"：必须重新预热（旧缓存全失配） |
+| 想确认图完整 | 看输出 `cache_misses` 是否为 0 |
+
+> 实现细节：快速重放后端在 `plugins/akasha/fast/`（内存 `MemoryStore` + graph_fast/fast_dense + `dump.dump_to_db`），
+> 对拍/确定性回归见 `tests/test_fast_rebuild_parity.py`。

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -1241,7 +1241,9 @@ def compute_candidates(
     if not seed_sources:
         return [], [], ActivationTrace(seed_count=0, pool_count=0)
 
-    micro_keys = set(seed_sources)
+    # dict.fromkeys 作有序集合：成员判断 O(1)，迭代序由确定的 seed→邻居遍历决定，
+    # 不受 PYTHONHASHSEED 影响（set 的迭代序随 hash 种子变，会让下游 RWR 矩阵行列序漂移）。
+    micro_keys = dict.fromkeys(seed_sources)
     for seed_key in seed_sources:
         seed_ts = nodes[seed_key].first_ts_unix
         for key, node in nodes.items():
@@ -1249,7 +1251,7 @@ def compute_candidates(
                 continue
             is_near = abs(node.first_ts_unix - seed_ts) <= config.nearby_time_seconds
             if is_near and direct_scores_map.get(key, 0.0) > config.nearby_dense_threshold:
-                micro_keys.add(key)
+                micro_keys[key] = None
     valid_keys = list(micro_keys)
     if not valid_keys:
         return [], [], ActivationTrace(seed_count=0, pool_count=0)

--- a/plugins/akasha/fast/__init__.py
+++ b/plugins/akasha/fast/__init__.py
@@ -1,0 +1,8 @@
+"""akasha.fast —— 离线重建加速后端（纯加性，靠 install() 注入，不改 core/replay/store/engine）。
+
+  * mem_store.MemoryStore / CapturingMemoryStore —— 纯内存图 + 增量 in_strength/edges_by_src/fan 视图
+  * graph_fast.install(store)  —— monkeypatch graph_expand(O(E)→增量) + edges_by_src/fan 视图 + has_user_turn 缓存
+  * fast_dense.install()       —— 向量化 dense_message_candidates
+  * dump.dump_to_db(path, store) —— 末尾一次性批量落库（复用 embedding_cache）
+"""
+from plugins.akasha.fast import mem_store, graph_fast, fast_dense, dump  # noqa: F401

--- a/plugins/akasha/fast/dump.py
+++ b/plugins/akasha/fast/dump.py
@@ -1,0 +1,105 @@
+"""dump_to_db —— 把内存 MemoryStore 一次性批量落进已开的 AkashaStore（sqlite），复用 embedding_cache。
+
+列与序列化严格对齐 store.py 的慢路写法：
+  * embedding / salience vector_sum 用 core.serialize_f32
+  * created_at/updated_at 用 _now_iso（与慢路 store._now_iso 同语义）
+  * 各表 VALUES 顺序对齐 store.py 的 INSERT
+reset_schema 只清 5 张图表(nodes/edges/salience_state/query_log/activation_events)，
+保留 embedding_cache / migration_runs / source_session_snapshot。复用调用方已开的连接（单连接）。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+
+from plugins.akasha.core import serialize_f32
+from plugins.akasha.store import AkashaStore
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def dump_to_db(store: AkashaStore, mem) -> dict[str, int]:
+    """把 mem(MemoryStore/CapturingMemoryStore)的全图 + 诊断批量写入 store。"""
+    now = _now_iso()
+    ql = list(getattr(mem, "query_logs", []))
+    ev = list(getattr(mem, "activation_events", []))
+    with store._lock:  # pyright: ignore[reportPrivateUsage]
+        store.reset_schema()
+        db = store._db  # pyright: ignore[reportPrivateUsage]
+
+        node_rows = [
+            (
+                n.key, n.anchor_id, n.session_key, n.turn_seq, n.first_ts_unix,
+                n.salience, n.strength, n.resource, n.recall_count,
+                n.last_activated_ts, n.last_strength_ts, n.last_resource_ts,
+                serialize_f32(np.asarray(n.embedding, dtype=np.float32)), n.emb_count, now, now,
+            )
+            for n in mem._nodes.values()  # pyright: ignore[reportPrivateUsage]
+        ]
+        db.executemany(
+            """INSERT INTO akasha_nodes
+               (key, anchor_id, session_key, turn_seq, first_ts_unix,
+                salience, strength, resource, recall_count,
+                last_activated_ts, last_strength_ts, last_resource_ts,
+                embedding, emb_count, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            node_rows,
+        )
+
+        edges = mem._edges  # pyright: ignore[reportPrivateUsage]
+        meta = mem._meta  # pyright: ignore[reportPrivateUsage]
+        cocount = mem._cocount  # pyright: ignore[reportPrivateUsage]
+        edge_rows = [
+            (s, d, w, int(cocount.get((s, d), 1)), float(meta.get((s, d), 0.0)))
+            for (s, d), w in edges.items()
+        ]
+        db.executemany("INSERT INTO akasha_edges VALUES (?, ?, ?, ?, ?)", edge_rows)
+
+        csum = mem._csum  # pyright: ignore[reportPrivateUsage]
+        if csum is not None:
+            db.execute(
+                "INSERT INTO akasha_salience_state (key, vector_sum, count, updated_at) "
+                "VALUES ('global', ?, ?, ?)",
+                (serialize_f32(np.asarray(csum, dtype=np.float32)),
+                 int(mem._ccount), now),  # pyright: ignore[reportPrivateUsage]
+            )
+
+        if ql:
+            db.executemany(
+                """INSERT OR REPLACE INTO akasha_query_log (
+                       query_id, session_key, seq, query_text, intent, ts,
+                       seed_count, pool_count, activated_count, activation_threshold,
+                       dense_count, ripple_count, inject_chars, source_ref_count,
+                       activation_items, dense_items, ripple_items, text_block_preview
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    (q["query_id"], q["session_key"], q["seq"], q["query_text"], q["intent"], q["ts"],
+                     q["seed_count"], q["pool_count"], q["activated_count"], q["activation_threshold"],
+                     q["dense_count"], q["ripple_count"], q["inject_chars"], q["source_ref_count"],
+                     q["activation_items_json"], q["dense_items_json"], q["ripple_items_json"],
+                     q["text_block_preview"])
+                    for q in ql
+                ],
+            )
+
+        if ev:
+            db.executemany(
+                "INSERT INTO akasha_activation_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (r.seq, r.query_id, r.activated_key, r.source, r.score, r.direct_score,
+                     r.state_score, r.edge_score, r.long_score, r.resource, r.fan)
+                    for r in ev
+                ],
+            )
+
+        db.commit()
+
+    return {
+        "nodes": len(mem._nodes),  # pyright: ignore[reportPrivateUsage]
+        "edges": len(edges),
+        "query_logs": len(ql),
+        "activation_events": len(ev),
+    }

--- a/plugins/akasha/fast/fast_dense.py
+++ b/plugins/akasha/fast/fast_dense.py
@@ -1,0 +1,84 @@
+"""
+fast_dense —— 把 dense_message_candidates 的 message_index=None 慢路径（对全部消息做
+Python 点积循环）换成"构建一次归一矩阵 + 缓存复用 + 向量化 matmul"。
+
+数字与 core 原函数完全一致（就是 core 自己 message_index 快路径的逻辑），只是：
+  * 不再每轮重建/重算（缓存键 = (id(message_embeddings), len)，replay 全程同一 dict 对象、长度不变 → 只建一次）
+  * 选择逻辑（normalize·query → 降序 → 跳过未提交节点/已见 → 取 limit）逐行照搬，保证 top-K 与排名一致。
+
+通过 install() 同时替换 core 和 replay 两个命名空间里的引用（replay 用 from-import 持有自己的绑定）。
+不修改任何源文件。
+"""
+from __future__ import annotations
+
+import numpy as np
+
+import plugins.akasha.core as _core
+import plugins.akasha.replay as _replay
+from plugins.akasha.core import (
+    AkashaCandidate, normalize, build_dense_message_index, dense_candidates,
+)
+
+_CACHE: dict[tuple[int, int], object] = {}
+
+
+def fast_dense_message_candidates(query_vec, nodes, message_embeddings, message_turn_keys,
+                                  *, limit, message_index=None):
+    if not message_embeddings:
+        return dense_candidates(query_vec, nodes, limit=limit)
+    query_norm = normalize(query_vec)
+    idx = message_index
+    if idx is None:
+        ck = (id(message_embeddings), len(message_embeddings))
+        idx = _CACHE.get(ck)
+        if idx is None:
+            idx = build_dense_message_index(message_embeddings)
+            _CACHE[ck] = idx
+    indexed = idx.by_dim.get(int(query_norm.size))
+    if indexed is None:
+        return []
+    message_ids, matrix = indexed
+    scores = np.dot(matrix, query_norm)
+    order = np.argsort(-scores, kind="stable")  # 降序，平局保持原插入序（对齐 sorted reverse=True）
+    candidates: list = []
+    seen: set = set()
+    for j in order:
+        key = message_turn_keys.get(message_ids[j])
+        if key is None or key not in nodes or key in seen:
+            continue
+        seen.add(key)
+        s = float(scores[j])
+        candidates.append(AkashaCandidate(
+            key=key, source="Dense", ripple=0.0, direct=s, state=0.0, edge=0.0,
+            long=0.0, resource=1.0, fan=0, score=s))
+        if len(candidates) >= limit:
+            break
+    return candidates
+
+
+_ORIG: dict = {}  # uninstall 还原用
+
+
+def install():
+    _CACHE.clear()
+    if not _ORIG:
+        _ORIG.update(
+            core=_core.dense_message_candidates,
+            replay=_replay.dense_message_candidates,
+        )
+    _core.dense_message_candidates = fast_dense_message_candidates
+    _replay.dense_message_candidates = fast_dense_message_candidates
+    print("[fast_dense] installed (向量化 dense + 缓存归一矩阵)", flush=True)
+
+
+def uninstall():
+    """还原 dense_message_candidates 并清缓存（同进程测试/复用时调用）。"""
+    if _ORIG:
+        _core.dense_message_candidates = _ORIG["core"]
+        _replay.dense_message_candidates = _ORIG["replay"]
+        _ORIG.clear()
+    _CACHE.clear()
+
+
+def clear_cache():
+    _CACHE.clear()

--- a/plugins/akasha/fast/graph_fast.py
+++ b/plugins/akasha/fast/graph_fast.py
@@ -1,0 +1,131 @@
+"""
+graph_fast —— 消灭 graph_expand 的 O(E)/轮（in_strength 全边遍历）+ replay 每轮重建
+edges_by_src/fan_counts。
+
+做法（不改源文件，monkeypatch）：
+  * core.graph_expand_candidates：函数体一字不改，只把 in_strength 的 O(E) 循环换成读
+    ACTIVE.in_strength(dst, now_ts)（= e^{-(now-t0)/τ}·A_dec[dst]+A_const[dst]，增量维护）。
+  * replay.edges_by_src / replay.fan_counts：返回 ACTIVE 的增量视图，免每轮 O(E) 重建。
+
+等价：in_strength 因式分解后与原 Σ effective_edge_weight 数学恒等（仅浮点求和顺序差异，
+不影响 rank/指标）。靠差分 parity test 对拍验证。
+"""
+from __future__ import annotations
+
+import math
+
+import plugins.akasha.core as _core
+import plugins.akasha.replay as _replay
+from plugins.akasha.core import (
+    AkashaCandidate, _GraphPathAggregate, GRAPH_DIRECT_BIAS, GRAPH_EXPAND_LIMIT,
+    STRENGTH_CAP, effective_edge_weight, has_user_turn as _orig_has_user_turn, recover_resource,
+)
+
+ACTIVE = None  # 当前 MemoryStore
+_HUT_CACHE: dict[str, bool] = {}  # has_user_turn 记忆化（源库固定、纯可缓存）
+
+
+def cached_has_user_turn(cursor, key):
+    v = _HUT_CACHE.get(key)
+    if v is None:
+        v = _orig_has_user_turn(cursor, key)
+        _HUT_CACHE[key] = v
+    return v
+
+
+def _fast_graph_expand_candidates(query_vec, nodes, direct_scores, fan, now_ts,
+                                  source_cursor, edges_by_src, edges_meta, graph_seed_keys):
+    if edges_by_src is None or not graph_seed_keys:
+        return []
+
+    def _eff(src_key, dst_key, weight):
+        if edges_meta is None or now_ts <= 0:
+            return weight
+        return effective_edge_weight(weight, edges_meta.get((src_key, dst_key), 0.0), now_ts)
+
+    seed_set = {key for key in graph_seed_keys if key in nodes}
+    store = ACTIVE  # in_strength 增量来源（替代 O(E) 全边遍历）
+
+    aggregate: dict[str, _GraphPathAggregate] = {}
+    for seed_key in graph_seed_keys:
+        if seed_key not in nodes:
+            continue
+        raw_neighbors = edges_by_src.get(seed_key, {})
+        out_strength = sum(_eff(seed_key, dst_key, w) for dst_key, w in raw_neighbors.items())
+        if out_strength <= 0:
+            continue
+        scored_neighbors = []
+        for key, edge_weight in raw_neighbors.items():
+            if key not in nodes or key in seed_set or not cached_has_user_turn(source_cursor, key):
+                continue
+            effective_weight = _eff(seed_key, key, edge_weight)
+            s = store.in_strength(key, now_ts)
+            dst_strength = effective_weight if s is None else s
+            edge_signal = effective_weight / math.sqrt(max(out_strength * dst_strength, 1e-9))
+            direct = max(0.0, direct_scores.get(key, 0.0))
+            seed_direct = max(GRAPH_DIRECT_BIAS, max(0.0, direct_scores.get(seed_key, 0.0)))
+            candidate_signal = edge_signal * seed_direct
+            scored_neighbors.append((candidate_signal, edge_signal, direct, key, effective_weight))
+        scored_neighbors.sort(reverse=True, key=lambda item: item[0])
+        for candidate_signal, edge_signal, direct, key, edge_weight in scored_neighbors[:GRAPH_EXPAND_LIMIT]:
+            item = aggregate.setdefault(key, _GraphPathAggregate(direct=direct, seed_key=seed_key))
+            item.signal += candidate_signal
+            item.paths += 1.0
+            item.direct = max(item.direct, direct)
+            if candidate_signal > item.best_signal:
+                item.best_signal = candidate_signal
+                item.best_edge = edge_signal
+                item.best_weight = edge_weight
+                item.seed_key = seed_key
+
+    candidates = []
+    for key, item in aggregate.items():
+        node = nodes[key]
+        resource = recover_resource(node, now_ts)
+        long_score = min(1.0, node.strength / STRENGTH_CAP)
+        direct = item.direct
+        paths = max(1.0, item.paths)
+        signal = item.signal * (1.0 + math.log(paths))
+        score = 6.0 * signal * (GRAPH_DIRECT_BIAS + direct) * (1.0 + 0.15 * long_score)
+        candidates.append(AkashaCandidate(
+            key=key, source="Graph", ripple=item.best_weight, direct=direct, state=0.0,
+            edge=signal, long=long_score, resource=resource, fan=max(0, fan.get(key, 0)),
+            score=float(score * resource), path_type="1hop",
+            seed_key=item.seed_key, path_value=item.best_edge))
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    return candidates[:GRAPH_EXPAND_LIMIT]
+
+
+_ORIG: dict = {}  # uninstall 还原用：首次 install 时存下被替换的原函数
+
+
+def install(store):
+    global ACTIVE
+    ACTIVE = store
+    _HUT_CACHE.clear()
+    if not _ORIG:
+        _ORIG.update(
+            graph_expand_candidates=_core.graph_expand_candidates,
+            has_user_turn=_core.has_user_turn,
+            edges_by_src=_replay.edges_by_src,
+            fan_counts=_replay.fan_counts,
+        )
+    _core.graph_expand_candidates = _fast_graph_expand_candidates
+    _core.has_user_turn = cached_has_user_turn  # score_candidates 也走缓存
+    _replay.edges_by_src = lambda edges: store.edges_by_src_view()
+    _replay.fan_counts = lambda edges: store.fan_view()
+    print("[graph_fast] installed (in_strength 增量 + has_user_turn 缓存 + edges_by_src/fan 视图)", flush=True)
+
+
+def uninstall():
+    """还原被 install 替换的全局函数（同进程测试/复用时必须调用，避免污染后续 replay）。"""
+    global ACTIVE
+    ACTIVE = None
+    _HUT_CACHE.clear()
+    if not _ORIG:
+        return
+    _core.graph_expand_candidates = _ORIG["graph_expand_candidates"]
+    _core.has_user_turn = _ORIG["has_user_turn"]
+    _replay.edges_by_src = _ORIG["edges_by_src"]
+    _replay.fan_counts = _ORIG["fan_counts"]
+    _ORIG.clear()

--- a/plugins/akasha/fast/mem_store.py
+++ b/plugins/akasha/fast/mem_store.py
@@ -1,0 +1,168 @@
+"""
+MemoryStore —— 纯内存版 AkashaStore，duck-type 出 AkashaReplayRuntime 用到的方法。
+
+替代 replay 每轮从 sqlite 重读全库 + 反序列化（O(N²)）。线上 engine.py 本来就是内存增量。
+
+性能增量维护（消灭每轮 O(E)）：
+  * edges_by_src / fan：增量更新（engine.py 已有先例）
+  * in_strength：用 exp 衰减因式分解 —— in_strength[d](t)=e^{-(t-t0)/τ}·A_dec[d]+A_const[d]，
+    A 与 t 无关、只在边变化时增量；t0 在数学上完全约掉，仅用于防 exp 溢出。
+    → graph_expand 的 O(E) 全边遍历降为 O(候选)。
+mutating 公式逐行照搬 store.py，保证与落库版等价（差分 parity 验证）。
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import numpy as np
+
+from plugins.akasha.core import (
+    AkashaNode, EDGE_DECAY_TAU, advance_salience_state, causal_salience,
+    effective_edge_weight, bounded_add, initial_strength, normalize, parse_ts_unix, turn_key,
+)
+
+
+class MemoryStore:
+    def __init__(self):
+        self._nodes: dict[str, AkashaNode] = {}
+        self._edges: dict[tuple[str, str], float] = {}
+        self._meta: dict[tuple[str, str], float] = {}
+        self._cocount: dict[tuple[str, str], int] = {}
+        self._csum: np.ndarray | None = None
+        self._ccount: int = 0
+        self._frozen = False
+        # 增量结构
+        self._ebs: dict[str, dict[str, float]] = {}      # edges_by_src
+        self._fan: dict[str, int] = {}                   # fan 计数
+        self._A_dec: dict[str, float] = {}               # Σ w·e^{(lu-t0)/τ}  (lu>0)
+        self._A_const: dict[str, float] = {}             # Σ w               (lu<=0)
+        self._t0: float | None = None                    # 参考纪元（数学上约掉，仅防溢出）
+
+    # ── 读路径 ───────────────────────────────────────────────────────
+    def list_nodes(self):
+        return list(self._nodes.values())
+
+    def load_edges_with_meta(self):
+        return self._edges, self._meta  # 不复制：replay 只读不改
+
+    def get_node(self, key):
+        return self._nodes.get(key)
+
+    def edges_by_src_view(self):
+        return self._ebs
+
+    def fan_view(self):
+        return self._fan
+
+    def in_strength(self, dst: str, now_ts: float):
+        """= Σ_src effective_edge_weight(w,lu,now)。无入边返回 None（对齐原 dict.get 缺省语义）。"""
+        in_dec = dst in self._A_dec
+        if not in_dec and dst not in self._A_const:
+            return None
+        val = self._A_const.get(dst, 0.0)
+        if in_dec and self._t0 is not None:
+            val += math.exp(-(now_ts - self._t0) / EDGE_DECAY_TAU) * self._A_dec[dst]
+        return val
+
+    # ── A 的增量加减 ─────────────────────────────────────────────────
+    def _contrib_add(self, dst, w, lu, sign):
+        if lu > 0:
+            if self._t0 is None:
+                self._t0 = lu
+            term = w * math.exp((lu - self._t0) / EDGE_DECAY_TAU)
+            self._A_dec[dst] = self._A_dec.get(dst, 0.0) + sign * term
+        else:
+            self._A_const[dst] = self._A_const.get(dst, 0.0) + sign * w
+
+    # ── 写路径：逐行照搬 store.py ────────────────────────────────────
+    def upsert_message_node(self, message, embedding) -> str:
+        session_key, turn_seq, key = turn_key(message.session_key, message.seq, message.role)
+        vector = normalize(np.array(embedding, dtype=np.float32))
+        ts_unix = parse_ts_unix(message.ts)
+        prior_sum, prior_count = self._csum, self._ccount
+        salience = (
+            causal_salience(vector, prior_sum, prior_count)
+            if getattr(message, "salience", None) is None
+            else min(1.0, max(0.0, float(message.salience)))
+        )
+        self._csum, self._ccount = advance_salience_state(prior_sum, prior_count, vector)
+        node = self._nodes.get(key)
+        if node is None:
+            self._nodes[key] = AkashaNode(
+                key=key, anchor_id=message.id, session_key=session_key, turn_seq=turn_seq,
+                first_ts_unix=ts_unix, salience=salience, strength=initial_strength(salience),
+                resource=1.0, recall_count=0, last_activated_ts=ts_unix,
+                last_strength_ts=ts_unix, last_resource_ts=ts_unix, embedding=vector, emb_count=1)
+        else:
+            old_count = max(1, node.emb_count)
+            merged = normalize(node.embedding * old_count + vector)
+            anchor = message.id if message.role == "user" else node.anchor_id
+            self._nodes[key] = replace(node, anchor_id=anchor,
+                                       salience=max(node.salience, salience),
+                                       embedding=merged, emb_count=old_count + 1)
+        return key
+
+    def update_activation_batch(self, updates) -> None:
+        if self._frozen:
+            return
+        for u in updates:
+            n = self._nodes.get(u.key)
+            if n is None:
+                continue
+            self._nodes[u.key] = replace(
+                n, strength=u.strength, resource=u.resource, recall_count=u.recall_count,
+                last_activated_ts=u.ts, last_strength_ts=u.ts, last_resource_ts=u.ts)
+
+    def upsert_edges(self, updates) -> None:
+        if self._frozen:
+            return
+        for u in updates:
+            if u.src_key == u.dst_key:
+                continue
+            ek = (u.src_key, u.dst_key)
+            if ek not in self._edges:
+                neww = 0.12 * u.strength
+                self._edges[ek] = neww
+                self._meta[ek] = u.ts
+                self._cocount[ek] = 1
+                self._ebs.setdefault(u.src_key, {})[u.dst_key] = neww
+                self._fan[u.src_key] = self._fan.get(u.src_key, 0) + 1
+                self._fan[u.dst_key] = self._fan.get(u.dst_key, 0) + 1
+                self._contrib_add(u.dst_key, neww, u.ts, +1)
+            else:
+                oldw, oldlu = self._edges[ek], self._meta[ek]
+                neww = bounded_add(effective_edge_weight(oldw, oldlu, u.ts), 0.12 * u.strength, 2.0)
+                self._contrib_add(u.dst_key, oldw, oldlu, -1)   # 撤旧
+                self._contrib_add(u.dst_key, neww, u.ts, +1)    # 加新
+                self._edges[ek] = neww
+                self._meta[ek] = u.ts
+                self._cocount[ek] = self._cocount.get(ek, 0) + 1
+                self._ebs[u.src_key][u.dst_key] = neww
+
+    def insert_activation_events(self, rows) -> None:
+        return None
+
+    def insert_query_log(self, **kwargs) -> None:
+        return None
+
+    def fan(self) -> dict[str, int]:
+        return dict(self._fan)
+
+
+class CapturingMemoryStore(MemoryStore):
+    """重放时把 query_log / activation_events 攒在内存，末尾由 dump.dump_to_db 一起落库。
+
+    与 MemoryStore 唯一区别：override 两个诊断写入(原本是 no-op)为内存累积。
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.query_logs: list[dict] = []
+        self.activation_events: list = []
+
+    def insert_query_log(self, **kwargs) -> None:
+        self.query_logs.append(kwargs)
+
+    def insert_activation_events(self, rows) -> None:
+        self.activation_events.extend(rows)

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -5,7 +5,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Protocol, Sequence
 
 import numpy as np
 
@@ -13,8 +13,11 @@ from plugins.akasha.config import AkashaConfig
 from plugins.akasha.core import (
     ActivationEventRow,
     ActivationTrace,
+    ActivationUpdate,
     AkashaActivationSnapshot,
     AkashaCandidate,
+    AkashaNode,
+    EdgeUpdate,
     CoreConfig,
     SourceMessage,
     activation_edge_updates,
@@ -38,9 +41,46 @@ from plugins.akasha.engine import (
     _query_log_id,
     _sort_cards_by_time,
 )
-from plugins.akasha.store import AkashaStore
-
 CONTEXT_QUERY_LIMIT = 8
+
+
+class ReplayStore(Protocol):
+    """AkashaReplayRuntime 依赖的 store 接口。
+
+    落库版 store.AkashaStore 与内存版 fast.MemoryStore/CapturingMemoryStore 都结构性满足，
+    runtime 不关心底层是 sqlite 还是内存。
+    """
+
+    def list_nodes(self) -> list[AkashaNode]: ...
+    def load_edges_with_meta(
+        self,
+    ) -> tuple[dict[tuple[str, str], float], dict[tuple[str, str], float]]: ...
+    def update_activation_batch(self, updates: list[ActivationUpdate]) -> None: ...
+    def upsert_message_node(self, message: SourceMessage, embedding: list[float]) -> str: ...
+    def upsert_edges(self, updates: list[EdgeUpdate]) -> None: ...
+    def insert_activation_events(self, rows: list[ActivationEventRow]) -> None: ...
+    def insert_query_log(
+        self,
+        *,
+        query_id: str,
+        session_key: str,
+        seq: int,
+        query_text: str,
+        intent: str,
+        ts: str,
+        seed_count: int,
+        pool_count: int,
+        activated_count: int,
+        activation_threshold: float,
+        dense_count: int,
+        ripple_count: int,
+        inject_chars: int,
+        source_ref_count: int,
+        activation_items_json: str,
+        dense_items_json: str,
+        ripple_items_json: str,
+        text_block_preview: str,
+    ) -> None: ...
 
 
 @dataclass(frozen=True)
@@ -67,7 +107,7 @@ class AkashaReplayRuntime:
     def __init__(
         self,
         *,
-        store: AkashaStore,
+        store: ReplayStore,
         config: AkashaConfig,
         source_db_path: Path,
         source_cursor: sqlite3.Cursor,

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -26,6 +26,9 @@ from plugins.akasha.config import (
     resolve_akasha_db_path,
 )
 from plugins.akasha.core import SourceMessage, parse_ts_unix, turn_key
+from plugins.akasha.fast import fast_dense, graph_fast
+from plugins.akasha.fast.dump import dump_to_db
+from plugins.akasha.fast.mem_store import CapturingMemoryStore
 from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage
 from plugins.akasha.store import (
     AkashaStore,
@@ -240,6 +243,11 @@ def _run() -> MigrationStats:
     store.insert_session_snapshots(run_id=run_id, snapshots=snapshots)
     store.reset_schema()
 
+    # 2b. 用内存图重放，末尾一次性落库；AkashaStore 只负责 cache、迁移记录和 dump 连接。
+    mem = CapturingMemoryStore()
+    graph_fast.install(mem)
+    fast_dense.install()
+
     # 3. 只复用 embedding cache，再按消息顺序 replay 激活状态。
     messages = 0
     activations = 0
@@ -268,7 +276,7 @@ def _run() -> MigrationStats:
         }
         with closing(sqlite3.connect(str(sessions_db))) as source_db:
             runtime = AkashaReplayRuntime(
-                store=store,
+                store=mem,
                 config=akasha_config,
                 source_db_path=sessions_db,
                 source_cursor=source_db.cursor(),
@@ -294,8 +302,13 @@ def _run() -> MigrationStats:
                     print(f"已处理 messages={messages} activations={activations}", flush=True)
                     while messages >= next_progress:
                         next_progress += int(args.progress_every)
+        # 3b. 内存重放完成后一次性批量落库。
+        dumped = dump_to_db(store, mem)
+        print(f"dump 完成 {dumped}", flush=True)
         status = "completed"
     finally:
+        graph_fast.uninstall()
+        fast_dense.uninstall()
         store.finish_migration_run(
             run_id=run_id,
             status=status,

--- a/tests/test_fast_rebuild_parity.py
+++ b/tests/test_fast_rebuild_parity.py
@@ -1,0 +1,291 @@
+"""Akasha 快速重建默认路径回归。"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import plugins.akasha.core as core
+    import plugins.akasha.replay as replay
+    from plugins.akasha.config import AkashaConfig
+    from plugins.akasha.fast import fast_dense, graph_fast
+    from plugins.akasha.fast.dump import dump_to_db
+    from plugins.akasha.fast.mem_store import CapturingMemoryStore
+    from plugins.akasha.replay import AkashaReplayRuntime, ReplayMessage
+    from plugins.akasha.store import AkashaStore
+except Exception:  # pragma: no cover - host 依赖缺失时跳过
+    pytest.skip("akasha host 依赖缺失", allow_module_level=True)
+
+
+T0 = 1_700_000_000.0
+
+_TURN_PAIRS = [
+    ("u0", 0, "alpha 引流条", [1.0, 0.0, 0.0, 0.0], "a0", "收到 alpha", [0.96, 0.04, 0.0, 0.0]),
+    ("u1", 2, "beta 鱼石脂", [0.9, 0.1, 0.0, 0.0], "a1", "收到 beta", [0.88, 0.12, 0.0, 0.0]),
+    ("u2", 4, "gamma 换药", [0.8, 0.2, 0.1, 0.0], "a2", "收到 gamma", [0.79, 0.21, 0.09, 0.0]),
+    ("u3", 6, "alpha 又问引流条", [0.95, 0.05, 0.0, 0.0], "a3", "继续 alpha", [0.94, 0.06, 0.0, 0.0]),
+    ("u4", 8, "beta 又问鱼石脂", [0.85, 0.15, 0.0, 0.02], "a4", "继续 beta", [0.84, 0.16, 0.0, 0.02]),
+    ("u5", 10, "delta 旁支", [0.0, 0.0, 1.0, 0.0], "a5", "收到 delta", [0.0, 0.0, 0.95, 0.05]),
+]
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat()
+
+
+def _source_message(
+    message_id: str,
+    seq: int,
+    role: str,
+    content: str,
+) -> core.SourceMessage:
+    return core.SourceMessage(message_id, "s", seq, role, content, _iso(T0 + seq))
+
+
+def _turn_messages() -> list[list[tuple[core.SourceMessage, list[float]]]]:
+    turns: list[list[tuple[core.SourceMessage, list[float]]]] = []
+    for user_id, seq, user_text, user_vec, assistant_id, assistant_text, assistant_vec in _TURN_PAIRS:
+        turns.append([
+            (_source_message(user_id, seq, "user", user_text), user_vec),
+            (_source_message(assistant_id, seq + 1, "assistant", assistant_text), assistant_vec),
+        ])
+    return turns
+
+
+def _init_sessions(path: Path) -> None:
+    with closing(sqlite3.connect(str(path))) as db:
+        db.execute(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, session_key TEXT, seq INTEGER, "
+            "role TEXT, content TEXT, ts TEXT)"
+        )
+        db.execute("CREATE VIRTUAL TABLE messages_fts USING fts5(content)")
+        rowid = 1
+        for turn in _turn_messages():
+            for message, _ in turn:
+                db.execute(
+                    "INSERT INTO messages(rowid, id, session_key, seq, role, content, ts) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (rowid, message.id, message.session_key, message.seq, message.role, message.content, message.ts),
+                )
+                db.execute("INSERT INTO messages_fts(rowid, content) VALUES (?, ?)", (rowid, message.content))
+                rowid += 1
+        db.commit()
+
+
+def _core_config(config: AkashaConfig) -> core.CoreConfig:
+    return core.CoreConfig(
+        dense_top_k=config.dense_top_k,
+        dense_seed_threshold=config.dense_seed_threshold,
+        activation_threshold=config.activation_threshold,
+        cross_boost=config.cross_boost,
+        nearby_time_seconds=config.nearby_time_seconds,
+        nearby_dense_threshold=config.nearby_dense_threshold,
+        soft_recall_threshold=config.soft_recall_threshold,
+        soft_recall_direct_floor=config.soft_recall_direct_floor,
+        activate_limit=config.activate_limit,
+    )
+
+
+def _message_embeddings() -> tuple[dict[str, np.ndarray], dict[str, str]]:
+    embeddings: dict[str, np.ndarray] = {}
+    turn_keys: dict[str, str] = {}
+    for turn in _turn_messages():
+        for message, vector in turn:
+            embeddings[message.id] = np.array(vector, dtype=np.float32)
+            turn_keys[message.id] = core.turn_key(message.session_key, message.seq, message.role)[2]
+    return embeddings, turn_keys
+
+
+def _replay(store, sessions_db: Path, embeddings, turn_keys) -> None:
+    with closing(sqlite3.connect(str(sessions_db))) as source_db:
+        runtime = AkashaReplayRuntime(
+            store=store,
+            config=AkashaConfig(),
+            source_db_path=sessions_db,
+            source_cursor=source_db.cursor(),
+            message_embeddings=embeddings,
+            message_turn_keys=turn_keys,
+        )
+        for turn in _turn_messages():
+            runtime.replay_turn([
+                ReplayMessage(message=message, embedding=list(map(float, vector)))
+                for message, vector in turn
+            ])
+
+
+def _snapshot(db_path: Path):
+    db = sqlite3.connect(str(db_path))
+    nodes = {
+        row[0]: (round(row[1], 6), round(row[2], 6), int(row[3]))
+        for row in db.execute("SELECT key, strength, resource, recall_count FROM akasha_nodes")
+    }
+    edges = {
+        (row[0], row[1]): (round(row[2], 6), int(row[3]), round(row[4], 6))
+        for row in db.execute("SELECT src_key, dst_key, weight, co_count, last_used_ts FROM akasha_edges")
+    }
+    db.close()
+    return nodes, edges
+
+
+def _build_fast(tmp_path: Path, tag: str) -> Path:
+    sessions = tmp_path / f"sessions_{tag}.db"
+    _init_sessions(sessions)
+    db_path = tmp_path / f"fast_{tag}.db"
+    store = AkashaStore(db_path)
+    mem = CapturingMemoryStore()
+    graph_fast.install(mem)
+    fast_dense.install()
+    embeddings, turn_keys = _message_embeddings()
+    try:
+        _replay(mem, sessions, embeddings, turn_keys)
+        dump_to_db(store, mem)
+    finally:
+        graph_fast.uninstall()
+        fast_dense.uninstall()
+        store.close()
+    return db_path
+
+
+def _build_online_path(tmp_path: Path) -> Path:
+    sessions = tmp_path / "online_sessions.db"
+    _init_sessions(sessions)
+    db_path = tmp_path / "online.db"
+    store = AkashaStore(db_path)
+    config = AkashaConfig()
+    core_config = _core_config(config)
+    nodes: dict[str, core.AkashaNode] = {}
+    edges: dict[tuple[str, str], float] = {}
+    edges_meta: dict[tuple[str, str], float] = {}
+    edges_by_src: dict[str, dict[str, float]] = {}
+    fan: dict[str, int] = {}
+    message_embeddings: dict[str, np.ndarray] = {}
+    message_turn_keys: dict[str, str] = {}
+    message_index = core.build_dense_message_index({})
+    with closing(sqlite3.connect(str(sessions))) as source_db:
+        source_cursor = source_db.cursor()
+        try:
+            for turn in _turn_messages():
+                user_message, user_vector = turn[0]
+                query_vec = np.array(user_vector, dtype=np.float32)
+                now_ts = core.parse_ts_unix(user_message.ts)
+                snapshot = core.AkashaActivationSnapshot(
+                    nodes=dict(nodes),
+                    edges=dict(edges),
+                    edges_meta=dict(edges_meta),
+                    fan=dict(fan),
+                    edges_by_src={key: dict(value) for key, value in edges_by_src.items()},
+                    message_embeddings=dict(message_embeddings),
+                    message_turn_keys=dict(message_turn_keys),
+                    message_index=message_index,
+                )
+                activation_items: list[core.AkashaCandidate] = []
+                if snapshot.nodes:
+                    graph_seed_keys = core.graph_seed_keys_from_snapshot(
+                        query_vec,
+                        snapshot,
+                        limit=config.dense_top_k,
+                    )
+                    activation_items, _, _ = core.compute_candidates_from_snapshot(
+                        user_message.content,
+                        query_vec,
+                        snapshot,
+                        now_ts,
+                        config=core_config,
+                        source_cursor=source_cursor,
+                        soft_recall=False,
+                        return_limit=config.activate_limit,
+                        graph_seed_keys=graph_seed_keys,
+                    )
+                updates = core.activation_updates(activation_items, snapshot.nodes, now_ts)
+                store.update_activation_batch(updates)
+                for item in updates:
+                    node = nodes.get(item.key)
+                    if node is None:
+                        continue
+                    nodes[item.key] = replace(
+                        node,
+                        strength=item.strength,
+                        resource=item.resource,
+                        recall_count=item.recall_count,
+                        last_activated_ts=item.ts,
+                        last_strength_ts=item.ts,
+                        last_resource_ts=item.ts,
+                    )
+                current_key = ""
+                for message, vector in turn:
+                    current_key = store.upsert_message_node(message, vector)
+                    node = store.get_node(current_key)
+                    assert node is not None
+                    nodes[current_key] = node
+                    message_embeddings[message.id] = np.array(vector, dtype=np.float32)
+                    message_turn_keys[message.id] = core.turn_key(
+                        message.session_key,
+                        message.seq,
+                        message.role,
+                    )[2]
+                    message_index = core.build_dense_message_index(message_embeddings)
+                if current_key and activation_items:
+                    edge_updates = core.activation_edge_updates(current_key, activation_items, now_ts)
+                    store.upsert_edges(edge_updates)
+                    for item in edge_updates:
+                        if item.src_key == item.dst_key:
+                            continue
+                        edge_key = (item.src_key, item.dst_key)
+                        old = edges.get(edge_key)
+                        if old is None:
+                            weight = 0.12 * item.strength
+                        else:
+                            decayed = core.effective_edge_weight(
+                                old,
+                                edges_meta.get(edge_key, 0.0),
+                                item.ts,
+                            )
+                            weight = core.bounded_add(decayed, 0.12 * item.strength, 2.0)
+                        edges[edge_key] = weight
+                        edges_meta[edge_key] = item.ts
+                        edges_by_src.setdefault(item.src_key, {})[item.dst_key] = weight
+                    fan = core.fan_counts(edges)
+        finally:
+            store.close()
+    return db_path
+
+
+def test_fast_matches_online_turn_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("plugins.akasha.core.get_jieba_keywords", lambda _: "")
+    online = _snapshot(_build_online_path(tmp_path))
+    fast = _snapshot(_build_fast(tmp_path, "online"))
+    assert fast == online
+
+
+def test_fast_rebuild_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("plugins.akasha.core.get_jieba_keywords", lambda _: "")
+    a = _snapshot(_build_fast(tmp_path, "a"))
+    b = _snapshot(_build_fast(tmp_path, "b"))
+    assert a == b
+
+
+def test_fast_rebuild_restores_global_patches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("plugins.akasha.core.get_jieba_keywords", lambda _: "")
+    originals = (
+        core.graph_expand_candidates,
+        core.has_user_turn,
+        core.dense_message_candidates,
+        replay.edges_by_src,
+        replay.fan_counts,
+        replay.dense_message_candidates,
+    )
+    _build_fast(tmp_path, "restore")
+    assert (
+        core.graph_expand_candidates,
+        core.has_user_turn,
+        core.dense_message_candidates,
+        replay.edges_by_src,
+        replay.fan_counts,
+        replay.dense_message_candidates,
+    ) == originals


### PR DESCRIPTION
## 问题

离线重建已经有快速内存重放后端，但脚本仍保留慢速路径和 `--fast` 分叉，容易让离线建库路径和线上一轮检索、写回、激活路径继续分裂。快速路径里的全局注入和类型边界也需要回归覆盖，避免同进程测试被污染。

## 改动

- 删除 `build_akasha_db.py` 的慢速 replay 分支，默认使用 `CapturingMemoryStore`、`graph_fast` 和 `fast_dense` 重放，结束后一次性 dump 到 `AkashaStore`。
- 新增 `plugins/akasha/fast/` 内存存储、图更新、dense 快速索引和批量落库实现。
- 将 replay store 收窄为 `ReplayStore` 协议，避免脚本依赖慢速 `AkashaStore` 的完整实现。
- 重写快速重建回归，直接对齐线上单轮检索、写回、激活路径，并覆盖确定性和全局 patch 还原。
- 新增 `plugins/akasha/REBUILD.md`，说明缓存、快速重建和 FTS IDF 重建边界。

## 链路

```text
+-------------+      +--------------------+
| sessions.db | ---> | build_akasha_db.py |
+-------------+      +---------+----------+
                              |
                              v
                    +----------------------+
                    | CapturingMemoryStore |
                    +----+------------+----+
                         |            |
                         v            v
                   +------------+  +------------+
                   | graph_fast |  | fast_dense |
                   +-----+------+  +-----+------+
                         |               |
                         +-------+-------+
                                 |
                                 v
                           +------------+
                           | dump_to_db |
                           +-----+------+
                                 |
                                 v
                           +-----------+
                           | akasha.db |
                           +-----------+
```

## 验证

- `git diff --check origin/main...HEAD`
- `.venv/bin/pyright --level error plugins/akasha/replay.py plugins/akasha/fast/fast_dense.py plugins/akasha/fast/graph_fast.py plugins/akasha/fast/mem_store.py plugins/akasha/fast/dump.py scripts/build_akasha_db.py tests/test_fast_rebuild_parity.py`：0 errors
- `.venv/bin/pytest tests/test_fast_rebuild_parity.py tests/test_akasha_plugin.py -q`：21 passed
- `.venv/bin/python scripts/build_akasha_db.py --help`：确认已无 `--fast`

## 配置影响

无新增配置。`build_akasha_db.py` 的 `--fast` 参数已删除，离线 replay 默认直接走快速路径。