### PR TITLE
[codex] fix(akasha): 隔离主动召回和定时任务记忆

### DIFF
--- a/core/memory/engine.py
+++ b/core/memory/engine.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 from typing import Literal, Protocol, runtime_checkable
 
 MemoryQueryIntent = Literal["context", "answer", "timeline", "interest", "procedure"]
+MemoryQueryEffect = Literal["stateful", "read_only"]
 
 
 class EngineProfile(str, Enum):
@@ -105,6 +106,7 @@ class MemoryQuery:
     text: str
     # answer/timeline 由模型工具公开；context/interest/procedure 是 runtime 内部入口。
     intent: MemoryQueryIntent = "answer"
+    effect: MemoryQueryEffect = "stateful"
     scope: MemoryScope = field(default_factory=MemoryScope)
     filters: MemoryQueryFilters = field(default_factory=MemoryQueryFilters)
     context: dict[str, object] = field(default_factory=dict[str, object])

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -254,8 +254,15 @@ class AkashaMemoryEngine:
                 }
             )
         query_vec = np.array(await self._embedder.embed(query_text), dtype=np.float32)
-        result = self._retrieve(query_text, query_vec, request, now_ts=now_ts)
-        if request.intent in {"context", "answer"}:
+        stateful = request.effect != "read_only"
+        result = self._retrieve(
+            query_text,
+            query_vec,
+            request,
+            now_ts=now_ts,
+            update_state=stateful,
+        )
+        if stateful and request.intent in {"context", "answer"}:
             self._remember_pending_activation(request, result.activation_items, now_ts=now_ts)
 
         # 4. context 注入按 Akasha 配置展示 topK；工具查询继续尊重调用方 limit。
@@ -287,7 +294,7 @@ class AkashaMemoryEngine:
         cards = [*dense_cards, *ripple_cards]
 
         # 5. 记录检索诊断日志（context/answer intent 才有意义）。
-        if request.intent in {"context", "answer"} and request.scope.session_key:
+        if stateful and request.intent in {"context", "answer"} and request.scope.session_key:
             self._write_query_log(
                 request=request,
                 result=result,
@@ -304,6 +311,7 @@ class AkashaMemoryEngine:
                 "engine": self.DESCRIPTOR.name,
                 "profile": self.DESCRIPTOR.profile.value,
                 "intent": request.intent,
+                "effect": request.effect,
                 "dense_count": len(dense_cards),
                 "ripple_count": len(ripple_cards),
                 "seed_count": result.trace.seed_count,
@@ -500,6 +508,7 @@ class AkashaMemoryEngine:
         request: MemoryQuery,
         *,
         now_ts: float,
+        update_state: bool,
     ) -> "_AkashaRetrieval":
         # 1. 准备内存图和当前查询所在的预测 seq。
         snapshot = self._graph_snapshot()
@@ -556,10 +565,11 @@ class AkashaMemoryEngine:
             if source_db is not None:
                 source_db.close()
 
-        # 3. 查询阶段只更新旧节点状态，当前 turn 的边等 after-turn 再补。
-        updates = _activation_updates(activation_items, snapshot.nodes, now_ts)
-        self._store.update_activation_batch(updates)
-        self._apply_activation_updates(updates)
+        # 3. 只读查询没有记忆动力学副作用。
+        if update_state:
+            updates = _activation_updates(activation_items, snapshot.nodes, now_ts)
+            self._store.update_activation_batch(updates)
+            self._apply_activation_updates(updates)
         return _AkashaRetrieval(
             dense_items=dense_items,
             ripple_items=ripple_items,
@@ -590,7 +600,7 @@ class AkashaMemoryEngine:
     # TurnCommitted 后把真实 user/assistant 写入 sidecar，并补本轮共激活边。
     async def _on_turn_committed(self, event: TurnCommitted) -> None:
         # 1. 跳过不应进入记忆的系统轮次。
-        if bool((event.extra or {}).get("skip_post_memory")):
+        if event.session_key.startswith("scheduler:") or bool((event.extra or {}).get("skip_post_memory")):
             return
         messages = _load_committed_turn_messages(self._session_db_path, event)
         if not messages:

--- a/plugins/default_memory/engine.py
+++ b/plugins/default_memory/engine.py
@@ -778,6 +778,7 @@ class DefaultMemoryEngine:
                 "engine": self.DESCRIPTOR.name,
                 "profile": self.DESCRIPTOR.profile.value,
                 "intent": request.intent,
+                "effect": request.effect,
             },
             raw={"items": items},
         )
@@ -1157,6 +1158,7 @@ class DefaultMemoryEngine:
             trace={
                 "source": self.DESCRIPTOR.name,
                 "intent": request.intent,
+                "effect": request.effect,
                 "hit_count": len(sliced),
                 "hyde_hypotheses": aux_queries,
             },
@@ -1169,7 +1171,11 @@ class DefaultMemoryEngine:
     ) -> MemoryQueryResult:
         if request.filters.time_start is None or request.filters.time_end is None:
             return MemoryQueryResult(
-                trace={"source": self.DESCRIPTOR.name, "intent": "timeline_missing_time"}
+                trace={
+                    "source": self.DESCRIPTOR.name,
+                    "intent": "timeline_missing_time",
+                    "effect": request.effect,
+                }
             )
         hits = self.list_events_by_time_range(
             request.filters.time_start,
@@ -1178,7 +1184,12 @@ class DefaultMemoryEngine:
         )
         return MemoryQueryResult(
             records=[self._build_record(item) for item in hits if isinstance(item, dict)],
-            trace={"source": self.DESCRIPTOR.name, "intent": "timeline", "hit_count": len(hits)},
+            trace={
+                "source": self.DESCRIPTOR.name,
+                "intent": "timeline",
+                "effect": request.effect,
+                "hit_count": len(hits),
+            },
             raw={"items": list(hits)},
         )
 
@@ -1200,7 +1211,11 @@ class DefaultMemoryEngine:
         return MemoryQueryResult(
             text_block="\n---\n".join(texts),
             records=records,
-            trace={"source": self.DESCRIPTOR.name, "intent": "interest"},
+            trace={
+                "source": self.DESCRIPTOR.name,
+                "intent": "interest",
+                "effect": request.effect,
+            },
             raw={"items": list(hits)},
         )
 

--- a/proactive_v2/tools.py
+++ b/proactive_v2/tools.py
@@ -221,6 +221,7 @@ async def _retrieve_interest_hits(*, memory, query: str, timestamp) -> list[dict
         MemoryQuery(
             text=query,
             intent="interest",
+            effect="read_only",
             limit=2,
             timestamp=timestamp,
         )

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -147,20 +147,28 @@ def _load_session_snapshots(sessions_db: Path) -> list[SourceSessionSnapshot]:
 def _load_skip_message_ids(sessions_db: Path) -> set[str]:
     result: set[str] = set()
     with closing(sqlite3.connect(str(sessions_db))) as db:
-        rows = db.execute("SELECT id, extra FROM messages").fetchall()
-    for message_id, raw_extra in rows:
+        rows = db.execute("SELECT id, session_key, extra FROM messages").fetchall()
+    for message_id, session_key, raw_extra in rows:
         try:
             parsed: object = json.loads(str(raw_extra or "{}"))
         except json.JSONDecodeError:
             parsed = {}
         extra = cast(dict[str, object], parsed) if isinstance(parsed, dict) else {}
-        if bool(extra.get("proactive")) or bool(extra.get("skip_post_memory")):
+        if _skip_session_key(str(session_key)) or bool(extra.get("proactive")) or bool(extra.get("skip_post_memory")):
             result.add(str(message_id))
     return result
 
 
+def _skip_session_key(session_key: str) -> bool:
+    return session_key.startswith("scheduler:")
+
+
 def _skip_message(message: SourceMessage, skip_message_ids: set[str]) -> bool:
-    return message.id in skip_message_ids or message.content.startswith("[后台任务完成]")
+    return (
+        message.id in skip_message_ids
+        or _skip_session_key(message.session_key)
+        or message.content.startswith("[后台任务完成]")
+    )
 
 
 # 备份已有 Akasha sidecar。
@@ -258,6 +266,11 @@ def _run() -> MigrationStats:
     try:
         source_messages = _load_source_messages(sessions_db)
         skip_message_ids = _load_skip_message_ids(sessions_db)
+        skipped_source_messages = [
+            message for message in source_messages if _skip_message(message, skip_message_ids)
+        ]
+        if skipped_source_messages:
+            _ = store.delete_cached_embeddings([message.id for message in skipped_source_messages])
         replay_turns = list(_iter_replay_turns(source_messages, skip_message_ids))
         replay_messages = [message for turn in replay_turns for message in turn]
         embedding_map, cache_hits, cache_misses = _load_embeddings_from_cache(

--- a/tests/proactive_v2/test_tools.py
+++ b/tests/proactive_v2/test_tools.py
@@ -316,6 +316,7 @@ async def test_recall_memory_passes_query_to_facade_interest_request():
     request = fake_memory.query.await_args.args[0]
     assert request.text == "q"
     assert request.intent == "interest"
+    assert request.effect == "read_only"
     assert request.limit == 2
     assert request.timestamp == now
 

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -8,10 +8,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 import numpy as np
 
+from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryQueryIntent, MemoryScope
 from agent.plugins.context import PluginContext, PluginKVStore
 from plugins.akasha.config import AkashaConfig
@@ -38,7 +40,7 @@ from plugins.akasha.store import (
     EdgeUpdate,
     SourceMessage,
 )
-from scripts.build_akasha_db import _load_embeddings_from_cache
+from scripts.build_akasha_db import _iter_replay_turns, _load_embeddings_from_cache, _skip_message
 
 
 QUERY_TS = datetime.fromtimestamp(1_700_000_000.0, timezone.utc)
@@ -443,6 +445,52 @@ def test_query_log_content_loader_allows_empty_user_message(tmp_path: Path) -> N
     assert assistant_preview == "assistant..."
 
 
+def test_akasha_rebuild_skips_scheduler_messages() -> None:
+    scheduler_user = SourceMessage(
+        "scheduler:job:0",
+        "scheduler:job",
+        0,
+        "user",
+        "查询北京天气",
+        "2026-01-01T00:00:00+00:00",
+    )
+    normal_user = SourceMessage(
+        "telegram:1:0",
+        "telegram:1",
+        0,
+        "user",
+        "今天聊 Akasha",
+        "2026-01-01T00:00:01+00:00",
+    )
+
+    assert _skip_message(scheduler_user, set()) is True
+    assert _skip_message(normal_user, set()) is False
+    assert list(_iter_replay_turns([scheduler_user, normal_user], set())) == [[normal_user]]
+
+
+@pytest.mark.asyncio
+async def test_runtime_skips_scheduler_turn_even_without_extra_flag(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._session_db_path = db_path
+    engine._embedder = SimpleNamespace(embed_batch=AsyncMock(side_effect=AssertionError("should skip")))
+
+    await engine._on_turn_committed(
+        TurnCommitted(
+            session_key="scheduler:job",
+            channel="telegram",
+            chat_id="1",
+            input_message="查询天气",
+            persisted_user_message="查询天气",
+            assistant_response="天气回复",
+            tools_used=[],
+        )
+    )
+
+    engine._embedder.embed_batch.assert_not_awaited()
+
+
 def test_load_turn_card_uses_full_user_and_short_assistant(tmp_path: Path) -> None:
     db_path = tmp_path / "sessions.db"
     _init_sessions_db(db_path)
@@ -475,7 +523,7 @@ async def test_query_places_overlap_in_dense_and_ripple_only_in_ripple(
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
     engine._remember_pending_activation = lambda request, items, **_: None
-    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
+    engine._retrieve = lambda query, query_vec, request, *, now_ts, update_state: _AkashaRetrieval(
         dense_items=[
             AkashaCandidate(
                 key="s:0",
@@ -566,7 +614,7 @@ async def test_context_block_sorts_injected_cards_by_time_desc(tmp_path: Path) -
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
     engine._remember_pending_activation = lambda request, items, **_: None
-    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
+    engine._retrieve = lambda query, query_vec, request, *, now_ts, update_state: _AkashaRetrieval(
         dense_items=[candidate("s:0", 0.9), candidate("s:2", 0.8)],
         ripple_items=[],
         activation_items=[],
@@ -680,7 +728,7 @@ async def test_context_query_uses_akasha_top_k_over_default_query_limit(
     engine._session_db_path = db_path
     engine._embedder = FakeEmbedder()
     engine._remember_pending_activation = lambda request, items, **_: None
-    engine._retrieve = lambda query, query_vec, request, *, now_ts: _AkashaRetrieval(
+    engine._retrieve = lambda query, query_vec, request, *, now_ts, update_state: _AkashaRetrieval(
         dense_items=[candidate(f"s:{turn * 2}", 1.0 - turn * 0.01) for turn in range(12)],
         ripple_items=[candidate(f"s:{24 + turn * 2}", 0.8 - turn * 0.01) for turn in range(12)],
         activation_items=[],
@@ -775,6 +823,56 @@ def test_query_log_keeps_context_and_answer_for_same_seq(tmp_path: Path) -> None
 
     assert total == 2
     assert {item["intent"] for item in items} == {"context", "answer"}
+
+
+@pytest.mark.asyncio
+async def test_read_only_query_skips_akasha_state_effects(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig()
+    engine._session_db_path = db_path
+    engine._embedder = FakeEmbedder()
+    side_effects: list[str] = []
+    update_state_values: list[bool] = []
+
+    def fake_retrieve(
+        query: str,
+        query_vec: np.ndarray,
+        request: MemoryQuery,
+        *,
+        now_ts: float,
+        update_state: bool,
+    ) -> _AkashaRetrieval:
+        _ = (query, query_vec, request, now_ts)
+        update_state_values.append(update_state)
+        return _AkashaRetrieval(
+            dense_items=[_candidate("s:0", 0.9)],
+            ripple_items=[],
+            activation_items=[_candidate("s:2", 0.8)],
+            trace=ActivationTrace(seed_count=1, pool_count=1),
+            seq=4,
+        )
+
+    engine._retrieve = fake_retrieve
+    engine._remember_pending_activation = lambda *_, **__: side_effects.append("pending")
+    engine._write_query_log = lambda *_, **__: side_effects.append("query_log")
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户消息",
+            intent="answer",
+            effect="read_only",
+            scope=MemoryScope(session_key="s"),
+            timestamp=QUERY_TS,
+        )
+    )
+
+    assert update_state_values == [False]
+    assert side_effects == []
+    assert result.trace["effect"] == "read_only"
+    assert result.records
 
 
 def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> None:

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -152,6 +152,40 @@ async def test_default_memory_engine_retrieve_keeps_raw_items_and_mode_trace():
     assert result.records[0].injected is True
 
 
+async def test_default_memory_engine_interest_preserves_read_only_effect():
+    retriever = SimpleNamespace(
+        retrieve=AsyncMock(
+            return_value=[
+                {
+                    "id": "p1",
+                    "summary": "用户偏好中文回复",
+                    "score": 0.8,
+                    "source_ref": "telegram:1@seed",
+                    "memory_type": "preference",
+                    "extra_json": {},
+                }
+            ]
+        ),
+        build_injection_block=lambda items: ("", []),
+    )
+    engine = _make_default_engine(retriever=cast(Any, retriever))
+
+    result = await engine.query(
+        MemoryQuery(
+            text="中文回复",
+            intent="interest",
+            effect="read_only",
+            scope=MemoryScope(session_key="telegram:1"),
+            limit=2,
+        )
+    )
+
+    assert result.trace["intent"] == "interest"
+    assert result.trace["effect"] == "read_only"
+    assert result.records[0].id == "p1"
+    retriever.retrieve.assert_awaited_once()
+
+
 async def test_default_memory_engine_retrieve_falls_back_to_session_scope():
     retriever = SimpleNamespace(
         retrieve=AsyncMock(return_value=[]),


### PR DESCRIPTION
## 问题

scheduler 定时任务和 proactive 主动链路不应该给 Akasha 写入激活状态或查询日志。之前 `skip_post_memory` 只能挡住 turn 后写入，挡不住 retrieval 阶段的 Akasha activation/query log；rebuild 脚本也会把历史 scheduler session 重放进 Akasha 库。

## 改动

- 在 `MemoryQuery` 增加 `effect`，让 proactive interest recall 走 `read_only`。
- Akasha 查询在 `read_only` 时不更新 activation、不记录 pending activation、不写 query log。
- runtime `TurnCommitted` 直接跳过 `scheduler:` session。
- Akasha rebuild 过滤 `scheduler:` 消息，并删除被过滤消息的 cached embeddings。
- default memory engine 保留 `effect` trace，方便链路诊断。

## 链路

```text
proactive recall
  -> MemoryQuery(effect=read_only)
  -> Akasha query
  -> no activation update / no query log

scheduler turn
  -> skip_memory_retrieval / skip_post_memory
  -> TurnCommitted scheduler guard
  -> rebuild scheduler filter
```

## 验证

- `pytest tests/test_akasha_plugin.py tests/test_scheduler_service.py tests/test_agent_core_p3_context_store.py tests/proactive_v2/test_tools.py tests/test_memory_engine_contract.py -q` -> 139 passed
- `pyright core/memory/engine.py plugins/akasha/engine.py plugins/default_memory/engine.py proactive_v2/tools.py scripts/build_akasha_db.py tests/proactive_v2/test_tools.py tests/test_akasha_plugin.py tests/test_memory_engine_contract.py` -> 0 errors, 195 existing warnings
- 本地线上库重建后确认 `scheduler` nodes/cache/query logs 均为 0

## 配置影响

无。