### PR TITLE
[codex] fix memory embedding output dimension

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -274,6 +274,14 @@ def _load_proactive_config(data: dict) -> ProactiveConfig:
 def _load_memory_config(data: dict) -> MemoryConfig:
     memory = _as_dict(data.get("memory"))
     embedding = _as_dict(memory.get("embedding"))
+    raw_output_dimensionality = embedding.get("output_dimensionality")
+    output_dimensionality = (
+        int(raw_output_dimensionality)
+        if raw_output_dimensionality not in (None, "")
+        else None
+    )
+    if output_dimensionality is not None and output_dimensionality <= 0:
+        raise ValueError("memory.embedding.output_dimensionality 必须大于 0")
     return MemoryConfig(
         enabled=bool(memory.get("enabled", False)),
         engine=str(memory.get("engine", "") or ""),
@@ -281,6 +289,7 @@ def _load_memory_config(data: dict) -> MemoryConfig:
             model=str(embedding.get("model", "text-embedding-v3")),
             api_key=_resolve(str(embedding.get("api_key", ""))),
             base_url=str(embedding.get("base_url", "")),
+            output_dimensionality=output_dimensionality,
         ),
     )
 

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -58,6 +58,7 @@ class MemoryEmbeddingConfig:
     model: str = "text-embedding-v3"
     api_key: str = ""
     base_url: str = ""
+    output_dimensionality: int | None = None
 
 
 @dataclass

--- a/memory2/embedder.py
+++ b/memory2/embedder.py
@@ -21,11 +21,13 @@ class Embedder:
         base_url: str,
         api_key: str,
         model: str = "text-embedding-v3",
+        output_dimensionality: int | None = None,
         requester: HttpRequester | None = None,
     ) -> None:
         self._url = base_url.rstrip("/") + "/embeddings"
         self._key = api_key
         self._model = model
+        self._output_dimensionality = output_dimensionality
         self._requester = requester or get_default_http_requester("external_default")
 
     async def embed(self, text: str) -> list[float]:
@@ -40,13 +42,16 @@ class Embedder:
 
         for i in range(0, len(truncated), self.MAX_BATCH):
             batch = truncated[i : i + self.MAX_BATCH]
+            payload: dict[str, object] = {"model": self._model, "input": batch}
+            if self._output_dimensionality is not None:
+                payload["dimensions"] = self._output_dimensionality
             resp = await self._requester.post(
                 self._url,
                 headers={
                     "Authorization": f"Bearer {self._key}",
                     "Content-Type": "application/json",
                 },
-                json={"model": self._model, "input": batch},
+                json=payload,
                 timeout_s=30.0,
                 budget=RequestBudget(total_timeout_s=40.0),
             )

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -141,6 +141,7 @@ class AkashaMemoryEngine:
             or config.light_api_key
             or config.api_key,
             model=embedding.model,
+            output_dimensionality=embedding.output_dimensionality,
             requester=http_resources.external_default,
         )
         self._event_bus = event_publisher

--- a/plugins/default_memory/engine.py
+++ b/plugins/default_memory/engine.py
@@ -44,7 +44,7 @@ from memory2.procedure_tagger import ProcedureTagger
 from memory2.query_builder import build_procedure_queries
 from memory2.retriever import Retriever
 from memory2.rule_schema import build_procedure_rule_schema
-from memory2.store import MemoryStore2
+from memory2.store import VEC_DIM, MemoryStore2
 from plugins.default_memory.config import DefaultMemoryConfig, resolve_memory_db_path
 
 if TYPE_CHECKING:
@@ -572,7 +572,10 @@ class DefaultMemoryEngine:
         )
         embedding = config.memory.embedding
         retrieval = default_config.retrieval
-        self._v2_store = MemoryStore2(db_path)
+        self._v2_store = MemoryStore2(
+            db_path,
+            vec_dim=embedding.output_dimensionality or VEC_DIM,
+        )
         self._embedder = Embedder(
             base_url=embedding.base_url
             or config.light_base_url
@@ -582,6 +585,7 @@ class DefaultMemoryEngine:
             or config.light_api_key
             or config.api_key,
             model=embedding.model,
+            output_dimensionality=embedding.output_dimensionality,
             requester=http_resources.external_default,
         )
         self._memorizer = Memorizer(self._v2_store, self._embedder)

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -16,6 +16,7 @@ import numpy as np
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryQueryIntent, MemoryScope
 from agent.plugins.context import PluginContext, PluginKVStore
+from agent.config_models import Config, MemoryConfig, MemoryEmbeddingConfig
 from plugins.akasha.config import AkashaConfig
 from plugins.akasha.engine import (
     ActivationTrace,
@@ -114,6 +115,45 @@ def test_reinforce_memory_tool_description_states_current_turn_contract() -> Non
     assert "fitbit_health_snapshot" in reinforce.description
     assert "sleep_report" in reinforce.description
     assert "fetch_messages(source_ref)" in reinforce.description
+
+
+def test_akasha_engine_passes_embedding_dimension_to_embedder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Embedder:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr("plugins.akasha.engine.Embedder", _Embedder)
+
+    engine = AkashaMemoryEngine(
+        config=Config(
+            provider="openai",
+            model="chat-model",
+            api_key="chat-key",
+            system_prompt="system",
+            memory=MemoryConfig(
+                embedding=MemoryEmbeddingConfig(
+                    model="embedding-model",
+                    output_dimensionality=768,
+                )
+            ),
+        ),
+        akasha_config=AkashaConfig(),
+        workspace=tmp_path,
+        http_resources=cast(Any, SimpleNamespace(external_default=object())),
+    )
+    try:
+        assert captured["model"] == "embedding-model"
+        assert captured["output_dimensionality"] == 768
+    finally:
+        engine._store.close()
 
 
 def test_dense_message_candidates_vectorized_preserves_turn_ranking() -> None:

--- a/tests/test_bootstrap_wiring_p2.py
+++ b/tests/test_bootstrap_wiring_p2.py
@@ -201,6 +201,7 @@ def test_config_load_reads_embedding_and_ignores_private_memory_sections(tmp_pat
                 "embedding": {
                     "model": "legacy-embedding",
                     "api_key": "legacy-key",
+                    "output_dimensionality": 1536,
                 },
                 "retrieval": {
                     "score_threshold": 0.99,
@@ -217,6 +218,7 @@ def test_config_load_reads_embedding_and_ignores_private_memory_sections(tmp_pat
     assert cfg.memory.engine == ""
     assert cfg.memory.embedding.model == "legacy-embedding"
     assert cfg.memory.embedding.api_key == "legacy-key"
+    assert cfg.memory.embedding.output_dimensionality == 1536
 
 
 def test_config_load_reads_memory_window_and_socket(tmp_path: Path):

--- a/tests/test_default_memory_plugin_config.py
+++ b/tests/test_default_memory_plugin_config.py
@@ -57,4 +57,5 @@ def test_root_config_example_does_not_expose_default_memory_private_config() -> 
     assert "[memory.retrieval]" not in text
     assert "[memory.gate]" not in text
     assert "[memory.hyde]" not in text
+    assert "output_dimensionality" not in text
     assert "[memory_v2]" not in text

--- a/tests/test_http_migrations.py
+++ b/tests/test_http_migrations.py
@@ -95,6 +95,7 @@ async def test_embedder_uses_injected_requester():
     def _handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode("utf-8"))
         assert payload["input"] == ["first", "second"]
+        assert "dimensions" not in payload
         return httpx.Response(
             200,
             request=request,
@@ -115,5 +116,30 @@ async def test_embedder_uses_injected_requester():
         )
         vectors = await embedder.embed_batch(["first", "second"])
         assert vectors == [[0.0, 0.1], [0.2, 0.3]]
+    finally:
+        await requester.client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_embedder_sends_configured_output_dimension():
+    def _handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["dimensions"] == 768
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": [{"index": 0, "embedding": [0.1, 0.2]}]},
+        )
+
+    requester = _build_requester(_handler)
+    try:
+        embedder = Embedder(
+            base_url="https://embeddings.example.com/v1",
+            api_key="test-key",
+            output_dimensionality=768,
+            requester=requester,
+        )
+        vectors = await embedder.embed_batch(["first"])
+        assert vectors == [[0.1, 0.2]]
     finally:
         await requester.client.aclose()


### PR DESCRIPTION
## 问题

`memory2` 的 sqlite-vec 默认维度固定为 1024，但 `[memory.embedding]` 没有把可选输出维度贯穿到 embedding 请求和记忆引擎初始化里。使用非 1024 维 embedding 时，向量索引会失配或退化。

Fixes #70

## 改动

- 在全局 `memory.embedding` 配置里支持可选 `output_dimensionality`，未配置时保持默认行为。
- 让 `memory2.embedder.Embedder` 仅在显式配置时向 embedding API 发送 `dimensions`。
- default memory 使用配置维度初始化 `MemoryStore2` 的 sqlite-vec 表，默认仍为 `VEC_DIM = 1024`。
- Akasha 运行时也把同一维度配置传给 embedding 客户端。

## 链路

`[memory.embedding].output_dimensionality` -> `MemoryEmbeddingConfig` -> `Embedder(..., output_dimensionality=...)` -> provider `dimensions`；default memory 额外把该值用于 `MemoryStore2(vec_dim=...)`。

## 验证

- `.venv/bin/pytest tests/test_bootstrap_wiring_p2.py::test_config_load_reads_embedding_and_ignores_private_memory_sections tests/test_default_memory_plugin_config.py::test_root_config_example_does_not_expose_default_memory_private_config tests/test_http_migrations.py::test_embedder_uses_injected_requester tests/test_http_migrations.py::test_embedder_sends_configured_output_dimension tests/test_akasha_plugin.py::test_akasha_engine_passes_embedding_dimension_to_embedder`
- `.venv/bin/pyright agent/config_models.py agent/config.py memory2/embedder.py plugins/default_memory/engine.py plugins/akasha/engine.py tests/test_bootstrap_wiring_p2.py tests/test_default_memory_plugin_config.py tests/test_http_migrations.py tests/test_akasha_plugin.py` -> 0 errors, existing warnings only
- `git diff --check`

## 配置影响

`config.example.toml` 不新增默认项。需要非默认 embedding 维度时，只在本地配置中显式设置 `[memory.embedding].output_dimensionality`。