### PR TITLE
[codex] fail-stop markdown memory consolidation

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -292,6 +292,7 @@ class PassiveTurnPipeline:
                 self._bus,
                 self._session.session_manager,
                 self._context_store,
+                keep_count=self._history_window,
                 plugin_modules=cast("list[Any]", self._before_turn_plugin_modules),
             ),
             frame_factory=BeforeTurnFrame,

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from bus.event_bus import EventBus
@@ -18,6 +19,8 @@ from agent.lifecycle.types import BeforeTurnCtx, TurnState
 if TYPE_CHECKING:
     from agent.core.passive_turn import ContextStore
     from session.manager import SessionManager
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -70,6 +73,70 @@ class _PrepareContextModule:
             session=session,
         )
         frame.slots[_CONTEXT_BUNDLE_SLOT] = bundle
+        return frame
+
+
+class _MemoryContextGuardModule:
+    slot = "before_turn.memory_context_guard"
+    requires = ("before_turn.acquire_session", _SESSION_SLOT)
+    produces = (_CTX_SLOT,)
+
+    def __init__(self, keep_count: int) -> None:
+        self._keep_count = max(1, int(keep_count))
+        self._min_new = max(5, self._keep_count // 2)
+        self._threshold = self._keep_count + self._min_new
+
+    async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
+        if _CTX_SLOT in frame.slots:
+            return frame
+        state = frame.input
+        if bool((state.msg.metadata or {}).get("skip_memory_context_guard")):
+            return frame
+        session = cast(SessionLike, frame.slots[_SESSION_SLOT])
+        messages = list(getattr(session, "messages", []))
+        last = _clamp_last_consolidated(
+            getattr(session, "last_consolidated", 0),
+            len(messages),
+        )
+        pending = len(messages) - last
+        if pending < self._threshold:
+            return frame
+
+        logger.error(
+            "memory context guard blocked turn: session=%s pending=%d threshold=%d last_consolidated=%d total=%d",
+            state.session_key,
+            pending,
+            self._threshold,
+            last,
+            len(messages),
+        )
+        frame.slots[_CTX_SLOT] = BeforeTurnCtx(
+            session_key=state.session_key,
+            channel=state.msg.context_channel,
+            chat_id=state.msg.context_chat_id,
+            content=state.msg.content,
+            timestamp=state.msg.timestamp,
+            retrieved_memory_block="",
+            retrieval_trace_raw=None,
+            history_messages=(),
+            abort=True,
+            abort_reply=_memory_context_guard_reply(
+                pending=pending,
+                threshold=self._threshold,
+                keep_count=self._keep_count,
+                last_consolidated=last,
+                total_messages=len(messages),
+            ),
+            extra_metadata={
+                "memory_context_guard": {
+                    "pending": pending,
+                    "threshold": self._threshold,
+                    "keep_count": self._keep_count,
+                    "last_consolidated": last,
+                    "total_messages": len(messages),
+                }
+            },
+        )
         return frame
 
 
@@ -142,10 +209,13 @@ def default_before_turn_modules(
     bus: EventBus,
     session_manager: SessionManager,
     context_store: ContextStore,
+    *,
+    keep_count: int = 20,
     plugin_modules: BeforeTurnModules | None = None,
 ) -> BeforeTurnModules:
     builtins: BeforeTurnModules = [
         _AcquireSessionModule(session_manager),
+        _MemoryContextGuardModule(keep_count),
         _PrepareContextModule(context_store),
         _BuildBeforeTurnCtxModule(),
         _EmitBeforeTurnCtxModule(bus),
@@ -155,4 +225,33 @@ def default_before_turn_modules(
     return cast(
         BeforeTurnModules,
         topo_sort_modules(builtins + list(plugin_modules or [])),
+    )
+
+
+def _clamp_last_consolidated(value: object, total_messages: int) -> int:
+    if isinstance(value, int):
+        last = value
+    elif isinstance(value, str):
+        try:
+            last = int(value)
+        except ValueError:
+            last = 0
+    else:
+        last = 0
+    return min(max(0, last), max(0, int(total_messages)))
+
+
+def _memory_context_guard_reply(
+    *,
+    pending: int,
+    threshold: int,
+    keep_count: int,
+    last_consolidated: int,
+    total_messages: int,
+) -> str:
+    return (
+        "记忆归档现在处于异常积压状态，我先暂停本轮普通回复，避免把未归档历史继续塞进模型上下文。\n"
+        f"当前未归档消息数 {pending}，安全阈值 {threshold}，热上下文保留 {keep_count}，"
+        f"last_consolidated={last_consolidated}，total_messages={total_messages}。\n"
+        "请先修复 memory consolidation 后再重试。"
     )

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -714,7 +714,7 @@ class AgentLoop:
             )
         except TimeoutError as exc:
             raise TimeoutError("memory consolidation busy") from exc
-        if result.trace.get("mode") != "skipped":
+        if result.trace.get("mode") == "markdown":
             await self.session_manager.save_async(session)
             return True
         return False

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("memory.markdown")
 
+_EVENT_EXTRACTION_TIMEOUT_S = 300.0
+_RECENT_CONTEXT_TIMEOUT_S = 180.0
+
 
 @dataclass(frozen=True)
 class ConsolidateRequest:
@@ -110,6 +113,13 @@ def _parse_consolidation_payload(text: str) -> dict | None:
     return load_json_object_loose(text)
 
 
+def _format_consolidation_error(exc: BaseException) -> str:
+    message = str(exc).strip()
+    if message:
+        return f"{type(exc).__name__}: {message}"
+    return type(exc).__name__
+
+
 @dataclass(frozen=True)
 class _ConsolidationWindow:
     old_messages: list[dict]
@@ -128,6 +138,13 @@ class _ConsolidationDraft:
     scope_channel: str
     scope_chat_id: str
     archive_all: bool = False
+
+
+@dataclass(frozen=True)
+class _ConsolidationFailure:
+    step: str
+    error: str
+    elapsed_ms: int = 0
 
 
 def _select_consolidation_window(
@@ -551,6 +568,41 @@ ongoing_threads 严格限制：
             parsed["ongoing_threads"] = ongoing_items[:3]
         return parsed
 
+    async def _call_llm_step(
+        self,
+        *,
+        step: str,
+        provider: "LLMProvider",
+        model: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        timeout_s: float,
+    ) -> tuple[str, int] | _ConsolidationFailure:
+        started_at = time.perf_counter()
+        try:
+            response = await asyncio.wait_for(
+                provider.chat(
+                    messages=messages,
+                    tools=[],
+                    model=model,
+                    max_tokens=max_tokens,
+                    disable_thinking=True,
+                ),
+                timeout=timeout_s,
+            )
+        except Exception as e:
+            elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+            error = _format_consolidation_error(e)
+            logger.error(
+                "Memory consolidation llm step failed: step=%s elapsed_ms=%d error=%s",
+                step,
+                elapsed_ms,
+                error,
+            )
+            return _ConsolidationFailure(step=step, error=error, elapsed_ms=elapsed_ms)
+        elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+        return (response.content or "").strip(), elapsed_ms
+
     async def _build_recent_context_snapshot(
         self,
         *,
@@ -558,7 +610,7 @@ ongoing_threads 严格限制：
         profile_maint,
         window: _ConsolidationWindow | None,
         archive_all: bool,
-    ) -> str:
+    ) -> str | _ConsolidationFailure:
         tail = list(session.messages[-self._keep_count :]) if self._keep_count > 0 else []
         recent_count = min(len(tail), _recent_turn_count(self._keep_count))
         session_messages = list(session.messages)
@@ -585,7 +637,10 @@ ongoing_threads 严格限制：
                 conversation=conversation,
                 recent_turns=recent_turns_for_prompt,
             )
-            response = await self._recent_context_provider.chat(
+            call_result = await self._call_llm_step(
+                step="recent_context",
+                provider=self._recent_context_provider,
+                model=self._recent_context_model,
                 messages=[
                     {
                         "role": "system",
@@ -593,13 +648,25 @@ ongoing_threads 严格限制：
                     },
                     {"role": "user", "content": prompt},
                 ],
-                tools=[],
-                model=self._recent_context_model,
                 max_tokens=512,
-                disable_thinking=True,
+                timeout_s=_RECENT_CONTEXT_TIMEOUT_S,
             )
-            text = (response.content or "").strip()
-            parsed = _parse_consolidation_payload(text) if text else None
+            if isinstance(call_result, _ConsolidationFailure):
+                return call_result
+            text, elapsed_ms = call_result
+            logger.info(
+                "Memory consolidation recent_context raw: elapsed_ms=%d chars=%d preview=%r",
+                elapsed_ms,
+                len(text),
+                text[:300],
+            )
+            if not text:
+                return _ConsolidationFailure(
+                    step="recent_context",
+                    error="empty_response",
+                    elapsed_ms=elapsed_ms,
+                )
+            parsed = _parse_consolidation_payload(text)
             if isinstance(parsed, dict):
                 compression = {
                     key: [
@@ -616,7 +683,11 @@ ongoing_threads 严格限制：
                     )
                 }
             else:
-                compression = self._extract_recent_context_compression(old_recent_context)
+                return _ConsolidationFailure(
+                    step="recent_context",
+                    error="invalid_json",
+                    elapsed_ms=elapsed_ms,
+                )
         elif old_recent_context.strip():
             compression = self._extract_recent_context_compression(old_recent_context)
         return _render_recent_context(
@@ -652,7 +723,7 @@ ongoing_threads 严格限制：
         session,
         archive_all: bool = False,
         force: bool = False,
-    ) -> _ConsolidationDraft | None:
+    ) -> _ConsolidationDraft | _ConsolidationFailure | None:
         profile_maint = self._profile_maint
         # 1. 先决定这次要归档哪一段消息窗口；没有新窗口就直接返回。
         window = _select_consolidation_window(
@@ -839,65 +910,70 @@ history_entries.emotional_weight 规则：
 
 只返回合法 JSON，不要 markdown 代码块。"""
 
-        try:
-            # 3. 调主模型把这段旧对话提炼成结构化结果。
-            event_started_at = time.perf_counter()
-            response = await self._provider.chat(
-                messages=[{"role": "user", "content": prompt}],
-                tools=[],
-                model=self._model,
-                max_tokens=1024,
-                disable_thinking=True,
+        # 3. 调主模型把这段旧对话提炼成结构化结果。
+        call_result = await self._call_llm_step(
+            step="event_extract",
+            provider=self._provider,
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            timeout_s=_EVENT_EXTRACTION_TIMEOUT_S,
+        )
+        if isinstance(call_result, _ConsolidationFailure):
+            return call_result
+        text, event_elapsed_ms = call_result
+        logger.info(
+            "Memory consolidation event llm raw: elapsed_ms=%d chars=%d preview=%r",
+            event_elapsed_ms,
+            len(text),
+            text[:300],
+        )
+
+        if not text:
+            logger.warning("Memory consolidation: LLM returned empty response")
+            return _ConsolidationFailure(
+                step="event_extract",
+                error="empty_response",
+                elapsed_ms=event_elapsed_ms,
             )
-            text = (response.content or "").strip()
-            event_elapsed_ms = int((time.perf_counter() - event_started_at) * 1000)
-            logger.info(
-                "Memory consolidation event llm raw: elapsed_ms=%d chars=%d preview=%r",
-                event_elapsed_ms,
-                len(text),
-                text[:300],
+        result = _parse_consolidation_payload(text)
+        if result is None:
+            logger.warning(
+                "Memory consolidation: unexpected response type. Response: %r",
+                text[:200],
+            )
+            return _ConsolidationFailure(
+                step="event_extract",
+                error="invalid_json",
+                elapsed_ms=event_elapsed_ms,
             )
 
-            if not text:
-                logger.warning(
-                    "Memory consolidation: LLM returned empty response, skipping"
-                )
-                return
-            result = _parse_consolidation_payload(text)
-            if result is None:
-                logger.warning(
-                    "Memory consolidation: unexpected response type, skipping. Response: %r",
-                    text[:200],
-                )
-                return
-
-            # 4. 归一化文本产物，并把后续写入所需信息交给 engine。
-            history_entry_payloads = _normalize_history_entries(
-                result.get("history_entries"),
-                result.get("history_entry"),
-            )
-            pending_items = _format_pending_items(result.get("pending_items", []))
-            # 4. 归一化 markdown 产物，向量写入由 engine 订阅提交事件完成。
-            recent_context_text = await self._build_recent_context_snapshot(
-                session=session,
-                profile_maint=profile_maint,
-                window=window,
-                archive_all=archive_all,
-            )
-            return _ConsolidationDraft(
-                window=window,
-                source_ref=source_ref,
-                history_entry_payloads=history_entry_payloads,
-                pending_items=pending_items,
-                conversation=conversation,
-                recent_context_text=recent_context_text,
-                scope_channel=scope_channel,
-                scope_chat_id=scope_chat_id,
-                archive_all=archive_all,
-            )
-        except Exception as e:
-            logger.error("Memory consolidation failed: %s", e)
-            return None
+        # 4. 归一化文本产物，并把后续写入所需信息交给 engine。
+        history_entry_payloads = _normalize_history_entries(
+            result.get("history_entries"),
+            result.get("history_entry"),
+        )
+        pending_items = _format_pending_items(result.get("pending_items", []))
+        # 4. 归一化 markdown 产物，向量写入由 engine 订阅提交事件完成。
+        recent_context_text = await self._build_recent_context_snapshot(
+            session=session,
+            profile_maint=profile_maint,
+            window=window,
+            archive_all=archive_all,
+        )
+        if isinstance(recent_context_text, _ConsolidationFailure):
+            return recent_context_text
+        return _ConsolidationDraft(
+            window=window,
+            source_ref=source_ref,
+            history_entry_payloads=history_entry_payloads,
+            pending_items=pending_items,
+            conversation=conversation,
+            recent_context_text=recent_context_text,
+            scope_channel=scope_channel,
+            scope_chat_id=scope_chat_id,
+            archive_all=archive_all,
+        )
 
 
 
@@ -993,7 +1069,7 @@ class MarkdownMemoryMaintenance:
                     result = await self._consolidate_unlocked(
                         ConsolidateRequest(session=session)
                     )
-                    if result.trace.get("mode") != "skipped" and self._save_session:
+                    if result.trace.get("mode") == "markdown" and self._save_session:
                         await self._save_session(session)
                 else:
                     await self.refresh_recent_turns(
@@ -1056,6 +1132,15 @@ class MarkdownMemoryMaintenance:
         )
         if draft is None:
             return ConsolidateResult(trace={"mode": "skipped"})
+        if isinstance(draft, _ConsolidationFailure):
+            return ConsolidateResult(
+                trace={
+                    "mode": "failed",
+                    "step": draft.step,
+                    "error": draft.error,
+                    "elapsed_ms": draft.elapsed_ms,
+                }
+            )
         await self._commit_markdown_draft(request.session, draft)
         return ConsolidateResult(
             consolidated_count=len(draft.window.old_messages),

--- a/tests/memory_fakes.py
+++ b/tests/memory_fakes.py
@@ -63,7 +63,7 @@ class FakeMemoryEngine:
 
     async def consolidate(self, request: ConsolidateRequest) -> ConsolidateResult:
         self.consolidate_calls.append(request)
-        return ConsolidateResult()
+        return ConsolidateResult(trace={"mode": "markdown"})
 
     async def refresh_recent_turns(self, request) -> None:
         return None

--- a/tests/test_consolidation_service.py
+++ b/tests/test_consolidation_service.py
@@ -204,7 +204,9 @@ def test_consolidation_event_failure_does_not_write_markdown():
     draft = _prepare(service, session, archive_all=True)
 
     # event 失败 → last_consolidated 不推进，隐式结果不写库
-    assert draft is None
+    assert draft is not None
+    assert draft.step == "event_extract"
+    assert draft.error == "empty_response"
     assert session.last_consolidated == 0
     memory.append_history_once.assert_not_called()
     memory.append_journal.assert_not_called()
@@ -458,7 +460,7 @@ def test_consolidation_archive_all_compresses_full_history_before_recent_turns()
     assert "[user] 第十三条" in written
 
 
-def test_consolidation_recent_context_invalid_json_keeps_old_compression():
+def test_consolidation_recent_context_invalid_json_fails_consolidation():
     old_recent_context = (
         "# Recent Context\n\n"
         "## Compression\n"
@@ -525,11 +527,66 @@ def test_consolidation_recent_context_invalid_json_keeps_old_compression():
     draft = _prepare(service, session)
 
     assert draft is not None
-    written = draft.recent_context_text
-    assert "until: 2026-03-15T10:08:00" in written
-    assert "旧话题" in written
-    assert "重要线程" in written
-    assert "[user] 第十三条" in written
+    assert draft.step == "recent_context"
+    assert draft.error == "invalid_json"
+
+
+def test_consolidation_recent_context_exception_fails_consolidation():
+    memory = SimpleNamespace(
+        read_long_term=MagicMock(return_value="MEM"),
+        read_history=MagicMock(return_value=""),
+        read_recent_context=MagicMock(return_value=""),
+        write_recent_context=MagicMock(),
+        append_history_once=MagicMock(return_value=True),
+        append_pending_once=MagicMock(return_value=True),
+        append_journal=MagicMock(),
+        save_from_consolidation=AsyncMock(),
+        save_item=AsyncMock(return_value="new:profile-1"),
+        save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
+    )
+
+    async def _chat_side_effect(**kwargs):
+        text = _message_text(kwargs)
+        if "近期语境压缩代理" in text:
+            raise TimeoutError("light timeout")
+        return _Resp(
+            '{"history_entries":["[2026-03-15 10:07] 用户继续对话"],"pending_items":[]}'
+        )
+
+    provider = SimpleNamespace(chat=AsyncMock(side_effect=_chat_side_effect))
+    service = ConsolidationWorker(
+        profile_maint=cast(Any, memory),
+        provider=cast(Any, provider),
+        model="m",
+        keep_count=4,
+    )
+    session = SimpleNamespace(
+        key="cli:1",
+        messages=[
+            {"role": "user", "content": "第一条", "timestamp": "2026-03-15T10:00:00"},
+            {"role": "assistant", "content": "第二条", "timestamp": "2026-03-15T10:01:00"},
+            {"role": "user", "content": "第三条", "timestamp": "2026-03-15T10:02:00"},
+            {"role": "assistant", "content": "第四条", "timestamp": "2026-03-15T10:03:00"},
+            {"role": "user", "content": "第五条", "timestamp": "2026-03-15T10:04:00"},
+            {"role": "assistant", "content": "第六条", "timestamp": "2026-03-15T10:05:00"},
+            {"role": "user", "content": "第七条", "timestamp": "2026-03-15T10:06:00"},
+            {"role": "assistant", "content": "第八条", "timestamp": "2026-03-15T10:07:00"},
+            {"role": "user", "content": "第九条", "timestamp": "2026-03-15T10:08:00"},
+            {"role": "assistant", "content": "第十条", "timestamp": "2026-03-15T10:09:00"},
+            {"role": "user", "content": "第十一条", "timestamp": "2026-03-15T10:10:00"},
+            {"role": "assistant", "content": "第十二条", "timestamp": "2026-03-15T10:11:00"},
+            {"role": "user", "content": "第十三条", "timestamp": "2026-03-15T10:12:00"},
+        ],
+        last_consolidated=4,
+        _channel="cli",
+        _chat_id="1",
+    )
+
+    draft = _prepare(service, session)
+
+    assert draft is not None
+    assert draft.step == "recent_context"
+    assert "TimeoutError" in draft.error
 
 
 def test_select_recent_history_entries_returns_last_three_chunks():

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -416,6 +416,49 @@ async def test_before_turn_memory_status_command_aborts_without_context_prepare(
 
 
 @pytest.mark.asyncio
+async def test_before_turn_memory_context_guard_blocks_unconsolidated_tail():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session.messages = [
+        {"role": "user", "content": f"u{i}"}
+        for i in range(30)
+    ]
+    session.last_consolidated = 0
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock())
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            keep_count=20,
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = _inbound()
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is True
+    assert "记忆归档现在处于异常积压状态" in ctx.abort_reply
+    assert "当前未归档消息数 30" in ctx.abort_reply
+    assert "安全阈值 30" in ctx.abort_reply
+    assert "热上下文保留 20" in ctx.abort_reply
+    assert "last_consolidated=0" in ctx.abort_reply
+    assert "total_messages=30" in ctx.abort_reply
+    assert ctx.extra_metadata["memory_context_guard"] == {
+        "pending": 30,
+        "threshold": 30,
+        "keep_count": 20,
+        "last_consolidated": 0,
+        "total_messages": 30,
+    }
+    ctx_store.prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_before_turn_accepts_custom_command_module():
     bus = EventBus()
     session = _DummySession("telegram:123")

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -27,6 +27,7 @@ from core.memory.markdown import (
     ConsolidateRequest,
     ConsolidateResult,
     _ConsolidationDraft,
+    _ConsolidationFailure,
     _ConsolidationWindow,
     MarkdownMemoryMaintenance,
     MarkdownMemoryStore,
@@ -475,6 +476,38 @@ async def test_markdown_consolidation_advances_window_when_consumer_fails(tmp_pa
         encoding="utf-8"
     )
     await event_bus.aclose()
+
+
+async def test_markdown_consolidation_failure_trace_does_not_advance_cursor(tmp_path: Path):
+    session = SimpleNamespace(
+        key="cli:1",
+        messages=[{"role": "user", "content": f"u{i}"} for i in range(8)],
+        last_consolidated=0,
+    )
+    maintenance = MarkdownMemoryMaintenance(
+        store=MarkdownMemoryStore(tmp_path),
+        provider=cast(Any, SimpleNamespace()),
+        model="lm",
+        keep_count=4,
+    )
+    maintenance._worker.prepare_consolidation = AsyncMock(
+        return_value=_ConsolidationFailure(
+            step="recent_context",
+            error="TimeoutError",
+            elapsed_ms=180000,
+        )
+    )
+
+    result = await maintenance.consolidate(ConsolidateRequest(session=session))
+
+    assert result.consolidated_count == 0
+    assert result.trace == {
+        "mode": "failed",
+        "step": "recent_context",
+        "error": "TimeoutError",
+        "elapsed_ms": 180000,
+    }
+    assert session.last_consolidated == 0
 
 
 async def test_default_memory_engine_serializes_lifecycle_maintenance():


### PR DESCRIPTION
## 问题

markdown memory consolidation 依赖 LLM/light model 生成归档内容。失败时如果静默跳过，`last_consolidated` 不推进，普通回复会继续从旧游标携带整段未归档历史，导致上下文和 token 成本持续膨胀。

Closes #74

## 改动

- 给 event extraction 和 recent context compression 加显式超时与失败 trace。
- consolidation 任一步失败时返回 `mode=failed`，不写 markdown，不推进 `last_consolidated`。
- before_turn 增加 memory context guard：未归档消息达到安全阈值时，直接拦截本轮普通回复，并向原 chat 返回详细诊断提醒。
- 手动 consolidation 入口只把 `mode=markdown` 视为成功，避免失败路径保存 session。
- 补充 event / recent_context 失败、guard 拦截、游标不推进的回归测试。

## 链路

```text
incoming message
  |
  v
before_turn memory guard
  |
  +-- pending < threshold -> normal LLM turn
  |
  +-- pending >= threshold
        |
        v
      abort normal turn
        |
        +-- reply diagnostic warning to original chat
        +-- log pending / threshold / last_consolidated / total

consolidation
  |
  +-- event_extract failed -> mode=failed, no write, no cursor advance
  +-- recent_context failed -> mode=failed, no write, no cursor advance
  +-- success -> write markdown, advance last_consolidated
```

## 验证

- `pytest tests/ -q` -> 1271 passed
- `pyright core/memory/markdown.py agent/lifecycle/phases/before_turn.py agent/core/passive_turn.py agent/looping/core.py tests/test_consolidation_service.py tests/test_memory_engine_contract.py tests/test_lifecycle_phases.py tests/memory_fakes.py` -> 0 errors, 374 warnings
- `git diff --check` -> passed
- Docker debug sandbox smoke: `consolidation-guard-smoke` profile seeded `cli:guard-smoke` with 30 unconsolidated messages and `last_consolidated=0`; CLI socket returned the guard diagnostic without entering LLM, logs emitted `memory context guard blocked turn`, DB stayed at 30 messages and cursor 0.

## 配置影响

- 无新增配置项。
- 默认阈值复用现有窗口语义：`threshold = keep_count + max(5, keep_count // 2)`。