### PR TITLE
[codex] migrate qqbot to plugin channel

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -11,6 +11,7 @@ import sys
 import tomllib
 import zlib
 from pathlib import Path
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 from agent.config_models import (
@@ -20,8 +21,6 @@ from agent.config_models import (
     MemoryConfig,
     MemoryEmbeddingConfig,
     PeerAgentConfig,
-    QQBotChannelConfig,
-    QQBotGroupConfig,
     QQChannelConfig,
     QQGroupConfig,
     TelegramChannelConfig,
@@ -89,6 +88,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
     peer_agents = _load_peer_agents_config(data)
     fitbit = _load_fitbit_config(data)
     wiring = _load_wiring_config(data)
+    plugins = _load_plugins_config(data)
 
     return Config(
         provider=provider,
@@ -158,6 +158,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         vl_base_url=str(llm_vl.get("base_url") or data.get("vl_base_url", "")),
         peer_agents=peer_agents,
         wiring=wiring,
+        plugins=plugins,
     )
 
 
@@ -205,41 +206,6 @@ def _load_channels_config(data: dict) -> ChannelsConfig:
                 ),
             )
 
-    qqbot = None
-    if qqbot_data := channels_data.get("qqbot"):
-        app_id = _normalize_optional_config_text(
-            _resolve(str(qqbot_data.get("app_id", qqbot_data.get("appId", ""))))
-        )
-        client_secret = _normalize_optional_config_text(
-            _resolve(str(qqbot_data.get("client_secret", qqbot_data.get("clientSecret", ""))))
-        )
-        if bool(qqbot_data.get("enabled", True)) and app_id and client_secret:
-            groups = [
-                QQBotGroupConfig(
-                    group_openid=str(
-                        g["group_openid"] if "group_openid" in g else g["groupOpenid"]
-                    ),
-                    allow_from=[
-                        str(u)
-                        for u in g.get("allow_from", g.get("allowFrom", []))
-                    ],
-                    require_at=g.get("require_at", g.get("requireAt", True)),
-                    allow_proactive=bool(
-                        g.get("allow_proactive", g.get("allowProactive", False))
-                    ),
-                )
-                for g in qqbot_data.get("groups", [])
-            ]
-            qqbot = QQBotChannelConfig(
-                app_id=app_id,
-                client_secret=client_secret,
-                allow_from=[
-                    str(u)
-                    for u in qqbot_data.get("allow_from", qqbot_data.get("allowFrom", []))
-                ],
-                groups=groups,
-            )
-
     cli_data = _as_dict(channels_data.get("cli"))
     socket_value = channels_data.get("socket") or cli_data.get(
         "socket", DEFAULT_SOCKET
@@ -252,7 +218,6 @@ def _load_channels_config(data: dict) -> ChannelsConfig:
     channels = ChannelsConfig(
         telegram=telegram,
         qq=qq,
-        qqbot=qqbot,
         socket=_normalize_cli_socket_endpoint(socket_value),
         cli_session_key=cli_session_key,
     )
@@ -336,6 +301,24 @@ def _load_wiring_config(data: dict) -> WiringConfig:
     )
 
 
+def _load_plugins_config(data: dict) -> dict[str, dict[str, Any]]:
+    plugins_data = _as_dict(data.get("plugins"))
+    plugins: dict[str, dict[str, Any]] = {}
+    for name, value in plugins_data.items():
+        if isinstance(name, str) and isinstance(value, dict):
+            plugins[name] = cast(dict[str, Any], _resolve_config_value(value))
+
+    legacy_qqbot = _as_dict(_as_dict(data.get("channels")).get("qqbot"))
+    if "qqbot" not in plugins and legacy_qqbot:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "[channels.qqbot] 已迁移到 [plugins.qqbot]，当前仍兼容旧配置"
+        )
+        plugins["qqbot"] = cast(dict[str, Any], _resolve_config_value(legacy_qqbot))
+    return plugins
+
+
 def _load_extra_body(data: dict) -> dict:
     llm = _as_dict(data.get("llm"))
     llm_main = _as_dict(llm.get("main"))
@@ -354,6 +337,16 @@ def _load_extra_body(data: dict) -> dict:
 
 def _as_dict(value: object) -> dict:
     return value if isinstance(value, dict) else {}
+
+
+def _resolve_config_value(value: object) -> object:
+    if isinstance(value, str):
+        return _resolve(value)
+    if isinstance(value, list):
+        return [_resolve_config_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _resolve_config_value(item) for key, item in value.items()}
+    return value
 
 
 def _resolve(value: str) -> str:

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from proactive_v2.config import ProactiveConfig
 
@@ -37,18 +38,9 @@ class QQBotGroupConfig:
 
 
 @dataclass
-class QQBotChannelConfig:
-    app_id: str
-    client_secret: str
-    allow_from: list[str] = field(default_factory=list)
-    groups: list[QQBotGroupConfig] = field(default_factory=list)
-
-
-@dataclass
 class ChannelsConfig:
     telegram: TelegramChannelConfig | None = None
     qq: QQChannelConfig | None = None
-    qqbot: QQBotChannelConfig | None = None
     socket: str = "/tmp/akashic.sock"
     cli_session_key: str = ""
 
@@ -131,6 +123,7 @@ class Config:
     dev_mode: bool = False
     peer_agents: list[PeerAgentConfig] = field(default_factory=list)
     wiring: WiringConfig = field(default_factory=WiringConfig)
+    plugins: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     @classmethod
     def load(cls, path: str | Path = "config.toml") -> Config:
@@ -147,7 +140,6 @@ __all__ = [
     "MemoryEmbeddingConfig",
     "PeerAgentConfig",
     "QQChannelConfig",
-    "QQBotChannelConfig",
     "QQBotGroupConfig",
     "QQGroupConfig",
     "TelegramChannelConfig",

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -4,6 +4,8 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from infra.channels.contract import Channel
     from agent.plugins.context import PluginContext
 
 
@@ -12,6 +14,7 @@ class Plugin(ABC):
     version: str | None = None
     desc: str | None = None
     author: str | None = None
+    ConfigModel: "type[BaseModel] | None" = None
     context: "PluginContext"
 
     def __init_subclass__(cls, **kwargs: object) -> None:
@@ -41,4 +44,7 @@ class Plugin(ABC):
         return []
 
     def after_turn_modules(self) -> list[object]:
+        return []
+
+    def channels(self) -> list["Channel"]:
         return []

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
     from agent.plugins.config import PluginConfig
 
 
@@ -16,7 +17,7 @@ class PluginContext:
     plugin_id: str
     plugin_dir: Path
     kv_store: "PluginKVStore"
-    config: "PluginConfig | None" = None
+    config: "BaseModel | PluginConfig | None" = None
     workspace: Path | None = None
     session_manager: Any = None
     memory_engine: Any = None

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from collections.abc import Callable
 from typing import Any, cast
 
+from pydantic import BaseModel, ValidationError
+
 from agent.lifecycle.types import (
     AfterReasoningCtx,
     AfterStepCtx,
@@ -26,6 +28,7 @@ from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registr
 from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import HookContext, HookOutcome
 from bus.event_bus import EventBus
+from infra.channels.contract import Channel
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +55,7 @@ class PluginManager:
         workspace: Path | None = None,
         session_manager: Any = None,
         memory_engine: Any = None,
+        plugin_configs: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
@@ -59,7 +63,9 @@ class PluginManager:
         self._workspace = workspace
         self._session_manager = session_manager
         self._memory_engine = memory_engine
+        self._plugin_configs = plugin_configs or {}
         self._loaded: set[str] = set()
+        self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
         self._before_turn_modules: list[object] = []
         self._before_reasoning_modules: list[object] = []
@@ -76,6 +82,10 @@ class PluginManager:
     @property
     def tool_hooks(self) -> list[ToolHook]:
         return list(self._tool_hooks)
+
+    @property
+    def channels(self) -> list[Channel]:
+        return list(self._channels)
 
     @property
     def before_turn_modules(self) -> list[object]:
@@ -177,7 +187,15 @@ class PluginManager:
         plugin_dir = Path(mod["module_path"]).parent
         _apply_manifest(instance, plugin_dir)
         plugin_id = str(instance.name) if instance.name else mod["name"]
-        plugin_config = _load_plugin_config(plugin_dir)
+        try:
+            plugin_config = _load_plugin_config(
+                plugin_dir,
+                getattr(cls, "ConfigModel", None),
+                self._plugin_configs.get(plugin_id),
+            )
+        except _PluginConfigError as e:
+            logger.warning("插件 %s 配置无效，跳过: %s", mod["name"], e)
+            return
         from agent.plugins.context import PluginContext, PluginKVStore
         instance.context = PluginContext(  # type: ignore[attr-defined]
             event_bus=self._event_bus,
@@ -229,6 +247,7 @@ class PluginManager:
             del self._after_turn_modules[after_turn_count_before:]
             return
         self._loaded.add(mp)
+        self._collect_channels(instance)
         logger.info("插件已加载: %s", mod["name"])
 
     def _import_plugin(self, module_name: str, path: Path) -> None:
@@ -358,6 +377,10 @@ class PluginManager:
             self._after_turn_modules,
         )
 
+    def _collect_channels(self, instance: Any) -> None:
+        for channel in _load_module_list(instance, "channels"):
+            self._channels.append(cast(Channel, channel))
+
     def _collect_phase_modules(
         self,
         instance: Any,
@@ -388,9 +411,23 @@ class PluginManager:
         self._after_step_modules.clear()
         self._after_reasoning_modules.clear()
         self._after_turn_modules.clear()
+        self._channels.clear()
 
 
-def _load_plugin_config(plugin_dir: Path) -> "Any":
+class _PluginConfigError(Exception):
+    pass
+
+
+def _load_plugin_config(
+    plugin_dir: Path,
+    config_model: type[BaseModel] | None = None,
+    raw_config: dict[str, Any] | None = None,
+) -> Any:
+    if config_model is not None:
+        try:
+            return config_model.model_validate(raw_config or {})
+        except ValidationError as e:
+            raise _PluginConfigError(_format_validation_error(e)) from e
     # 1. 读取 _conf_schema.json，提取每个字段的 default 值
     from agent.plugins.config import PluginConfig
     schema_path = plugin_dir / "_conf_schema.json"
@@ -430,6 +467,14 @@ def _load_plugin_config(plugin_dir: Path) -> "Any":
             else:
                 logger.warning("plugin_config.json 格式错误，期望 dict (%s)", plugin_dir)
     return PluginConfig(values)
+
+
+def _format_validation_error(error: ValidationError) -> str:
+    parts: list[str] = []
+    for item in error.errors():
+        path = ".".join(str(part) for part in item.get("loc", ())) or "<root>"
+        parts.append(f"{path}: {item.get('msg', 'invalid')}")
+    return "; ".join(parts)
 
 
 def _load_module_list(instance: Any, method_name: str) -> list[object]:

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from agent.config_models import Config
+from bootstrap.channel_host import ChannelHost
 from bootstrap.channels import start_channels
 from bootstrap.dashboard_api import build_dashboard_server
 from bootstrap.memory import build_memory_runtime
@@ -58,9 +59,7 @@ class AppRuntime:
         self.workspace = workspace
         self.http_resources = SharedHttpResources()
         self.ipc = None
-        self.tg_channel = None
-        self.qq_channel = None
-        self.qqbot_channel = None
+        self.channel_host: ChannelHost | None = None
         self.core: CoreRuntime | None = None
         self.agent_loop = None
         self.bus = None
@@ -112,7 +111,7 @@ class AppRuntime:
             await self.core.start()
 
             plugin_manager = getattr(self.core, "plugin_manager", None)
-            self.ipc, self.tg_channel, self.qq_channel, self.qqbot_channel = await start_channels(
+            self.ipc, self.channel_host = await start_channels(
                 self.config,
                 bus=self.bus,
                 session_manager=self.session_manager,
@@ -125,7 +124,9 @@ class AppRuntime:
                     else None
                 ),
                 interrupt_controller=self.agent_loop,
+                plugin_channels=plugin_manager.channels if plugin_manager else None,
             )
+            await self.channel_host.start_all()
 
             self.tasks = [
                 self.agent_loop.run(),
@@ -193,13 +194,8 @@ class AppRuntime:
                 ("core.stop", self.core.stop if self.core else _noop_async),
                 ("ipc.stop", self.ipc.stop if self.ipc else _noop_async),
                 (
-                    "telegram.stop",
-                    self.tg_channel.stop if self.tg_channel else _noop_async,
-                ),
-                ("qq.stop", self.qq_channel.stop if self.qq_channel else _noop_async),
-                (
-                    "qqbot.stop",
-                    self.qqbot_channel.stop if self.qqbot_channel else _noop_async,
+                    "channels.stop",
+                    self.channel_host.stop_all if self.channel_host else _noop_async,
                 ),
                 (
                     "memory_runtime.aclose",

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from infra.channels.contract import Channel, ChannelContext
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelHost:
+    def __init__(
+        self,
+        ctx_factory: Callable[[Channel], ChannelContext],
+    ) -> None:
+        self._ctx_factory = ctx_factory
+        self._channels: list[Channel] = []
+
+    def add(self, channel: Channel) -> None:
+        self._channels.append(channel)
+
+    async def start_all(self) -> None:
+        for channel in self._channels:
+            try:
+                await channel.start(self._ctx_factory(channel))
+                print(f"渠道已启动: {channel.name}")
+            except Exception as e:
+                logger.error("渠道启动失败 %s: %s", channel.name, e)
+
+    async def stop_all(self) -> None:
+        for channel in reversed(self._channels):
+            try:
+                await channel.stop()
+            except Exception as e:
+                logger.warning("渠道停止失败 %s: %s", channel.name, e)
+
+    @property
+    def channels(self) -> list[Channel]:
+        return list(self._channels)

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+import logging
 
 from agent.config_models import Config
 from agent.looping.interrupt import InterruptController
 from agent.tools.message_push import MessagePushTool
+from bootstrap.channel_host import ChannelHost
 from bus.event_bus import EventBus
 from bus.queue import MessageBus
 from core.net.http import SharedHttpResources
+from infra.channels.base import AttachmentStore
+from infra.channels.contract import Channel, ChannelContext
 from session.manager import SessionManager
 
 
@@ -21,7 +24,8 @@ async def start_channels(
     event_bus: EventBus,
     bot_commands: list[tuple[str, str]] | None = None,
     interrupt_controller: InterruptController | None = None,
-) -> tuple[Any, Any, Any, Any]:
+    plugin_channels: list[Channel] | None = None,
+) -> tuple[object, ChannelHost]:
     from infra.channels.ipc_server import IPCServerChannel
 
     ipc = IPCServerChannel(
@@ -32,12 +36,28 @@ async def start_channels(
     await ipc.start()
     print(f"Agent 已启动  |  CLI 连接地址: {config.channels.socket}")
 
-    tg_channel = None
+    attachment_store = AttachmentStore()
+
+    def _ctx_factory(channel: Channel) -> ChannelContext:
+        return ChannelContext(
+            bus=bus,
+            session_manager=session_manager,
+            event_bus=event_bus,
+            push_tool=push_tool,
+            attachment_store=attachment_store,
+            http_resources=http_resources,
+            interrupt_controller=interrupt_controller,
+            bot_commands=bot_commands or [],
+            log=logging.getLogger(f"channels.{channel.name}"),
+        )
+
+    host = ChannelHost(_ctx_factory)
+
     if config.channels.telegram and config.channels.telegram.token:
         from infra.channels.telegram_channel import TelegramChannel
 
         tg = config.channels.telegram
-        tg_channel = TelegramChannel(
+        host.add(TelegramChannel(
             token=tg.token,
             bus=bus,
             session_manager=session_manager,
@@ -46,23 +66,13 @@ async def start_channels(
             event_bus=event_bus,
             interrupt_controller=interrupt_controller,
             channel_name=tg.channel_name,
-        )
-        await tg_channel.start()
-        push_tool.register_channel(
-            tg.channel_name,
-            text=tg_channel.send,
-            stream_text=tg_channel.send_stream,
-            file=tg_channel.send_file,
-            image=tg_channel.send_image,
-        )
-        print("Telegram Bot 已启动")
+        ))
 
-    qq_channel = None
     if config.channels.qq and config.channels.qq.bot_uin:
         from infra.channels.qq_channel import QQChannel
 
         qq = config.channels.qq
-        qq_channel = QQChannel(
+        host.add(QQChannel(
             bot_uin=qq.bot_uin,
             bus=bus,
             session_manager=session_manager,
@@ -72,37 +82,9 @@ async def start_channels(
             http_requester=http_resources.external_default,
             event_bus=event_bus,
             interrupt_controller=interrupt_controller,
-        )
-        await qq_channel.start()
-        push_tool.register_channel(
-            "qq",
-            text=qq_channel.send,
-            file=qq_channel.send_file,
-            image=qq_channel.send_image,
-        )
-        print(f"QQ Bot 已启动  |  QQ 号: {qq.bot_uin}")
+        ))
 
-    qqbot_channel = None
-    if config.channels.qqbot and config.channels.qqbot.app_id:
-        from infra.channels.qqbot_channel import QQBotChannel
+    for channel in plugin_channels or []:
+        host.add(channel)
 
-        qqbot = config.channels.qqbot
-        qqbot_channel = QQBotChannel(
-            app_id=qqbot.app_id,
-            client_secret=qqbot.client_secret,
-            bus=bus,
-            session_manager=session_manager,
-            allow_from=qqbot.allow_from,
-            groups=qqbot.groups,
-            event_bus=event_bus,
-            interrupt_controller=interrupt_controller,
-        )
-        await qqbot_channel.start()
-        push_tool.register_channel(
-            "qqbot",
-            text=qqbot_channel.send_proactive,
-            stream_text=qqbot_channel.send_stream,
-        )
-        print(f"官方 QQBot 已启动  |  AppID: {qqbot.app_id}")
-
-    return ipc, tg_channel, qq_channel, qqbot_channel
+    return ipc, host

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -386,7 +386,7 @@ def _phase_qqbot(a: WizardAnswers) -> None:
             a.proactive_chat_id = f"c2c:{openid}"
     else:
         _warn("未收到消息，allow_from 留空")
-        _hint("启动后可在 config.toml 的 [channels.qqbot] 中手动填入 allow_from")
+        _hint("启动后可在 config.toml 的 [plugins.qqbot] 中手动填入 allow_from")
 
 
 def _phase_memory(a: WizardAnswers) -> None:
@@ -727,7 +727,7 @@ def _render_channels(a: WizardAnswers) -> str:
     if a.qqbot_app_id:
         allow = ", ".join(f'"{u}"' for u in ([a.qqbot_user_openid] if a.qqbot_user_openid else []))
         lines += [
-            "[channels.qqbot]",
+            "[plugins.qqbot]",
             f'app_id = "{a.qqbot_app_id}"',
             f'client_secret = "{a.qqbot_client_secret}"',
             f"allow_from = [{allow}]",
@@ -736,7 +736,7 @@ def _render_channels(a: WizardAnswers) -> str:
     else:
         lines += [
             "# 官方 QQBot（如需启用，填写后取消注释）",
-            "# [channels.qqbot]",
+            "# [plugins.qqbot]",
             '# app_id = ""',
             '# client_secret = ""',
             '# allow_from = []  # 用户的 user_openid，发一条消息后可从日志获取',
@@ -827,7 +827,7 @@ def _print_completion(a: WizardAnswers) -> None:
         if a.proactive_channel == "qqbot" or (not a.tg_token and a.qqbot_app_id):
             _hint("启动后向 bot 发任意消息，日志中会出现 user_openid")
             _hint("将其填入 config.toml：")
-            _hint("[channels.qqbot]")
+            _hint("[plugins.qqbot]")
             _hint('allow_from = ["<user_openid>"]')
             _hint("[proactive.target]")
             _hint('channel = "qqbot"')
@@ -845,5 +845,5 @@ def _print_completion(a: WizardAnswers) -> None:
         click.echo()
         _warn("QQBot allow_from 为空，启动后所有私聊请求会被拒绝")
         _hint("向 bot 发一条消息，日志里找到 user_openid，填入 config.toml：")
-        _hint("[channels.qqbot]")
+        _hint("[plugins.qqbot]")
         _hint('allow_from = ["<user_openid>"]')

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -502,6 +502,7 @@ def build_core_runtime(
         workspace=workspace,
         session_manager=session_manager,
         memory_engine=memory_runtime.engine,
+        plugin_configs=config.plugins,
     )
 
     return CoreRuntime(

--- a/config.example.toml
+++ b/config.example.toml
@@ -80,7 +80,7 @@ websocket_open_timeout_seconds = 5.0
 # allow_from = ["your_qq_number"]
 # require_at = true
 
-[channels.qqbot]
+[plugins.qqbot]
 # 官方 QQBot，和 NapCat QQ 通道并存。留空跳过。
 app_id = ""
 client_secret = ""
@@ -88,7 +88,7 @@ client_secret = ""
 allow_from = []
 
 # 当前实现仅启用私聊；群配置先保留为后续扩展占位。
-# [[channels.qqbot.groups]]
+# [[plugins.qqbot.groups]]
 # group_openid = "GROUP_OPENID"
 # allow_from = ["MEMBER_OPENID"]
 # require_at = true

--- a/docker/debug/shell_background_probe.py
+++ b/docker/debug/shell_background_probe.py
@@ -108,7 +108,7 @@ def _isolate_cli_config(config_path: Path) -> str:
     text = original
     text = _replace_section_value(text, "channels.telegram", "token", '""')
     text = _replace_section_value(text, "channels.qq", "bot_uin", '""')
-    text = _replace_section_value(text, "channels.qqbot", "app_id", '""')
+    text = _replace_section_value(text, "plugins.qqbot", "app_id", '""')
     text = _replace_section_value(text, "proactive", "enabled", "false")
     config_path.write_text(text, encoding="utf-8")
     return original

--- a/infra/channels/contract.py
+++ b/infra/channels/contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Protocol
+
+from agent.looping.interrupt import InterruptController
+from agent.tools.message_push import MessagePushTool
+from bus.event_bus import EventBus
+from bus.queue import MessageBus
+from core.net.http import SharedHttpResources
+from infra.channels.base import AttachmentStore
+from session.manager import SessionManager
+
+
+class Channel(Protocol):
+    name: str
+
+    async def start(self, ctx: ChannelContext) -> None: ...
+    async def stop(self) -> None: ...
+
+
+@dataclass
+class ChannelContext:
+    bus: MessageBus
+    session_manager: SessionManager
+    event_bus: EventBus
+    push_tool: MessagePushTool
+    attachment_store: AttachmentStore
+    http_resources: SharedHttpResources
+    interrupt_controller: InterruptController | None
+    bot_commands: list[tuple[str, str]]
+    log: logging.Logger

--- a/infra/channels/qq_channel.py
+++ b/infra/channels/qq_channel.py
@@ -36,6 +36,7 @@ from bus.events_lifecycle import (
 )
 from bus.queue import MessageBus
 from infra.channels.base import AttachmentStore, SessionIdentityIndex
+from infra.channels.contract import ChannelContext
 from infra.channels.group_filter import (
     DefaultGroupFilter,
     GroupMessageFilter,
@@ -292,6 +293,7 @@ async def _download_to_temp(
 
 
 class QQChannel:
+    name = _CHANNEL
 
     def __init__(
         self,
@@ -337,6 +339,8 @@ class QQChannel:
             "external_default"
         )
         self._event_bus = event_bus
+        self._outbound_bound = False
+        self._events_bound = False
         self._trace_states: dict[str, _QQTraceState] = {}
 
         self._bot = BotClient()
@@ -367,13 +371,20 @@ class QQChannel:
             return True
         return user_id in self._allow_from
 
-    async def start(self) -> None:
+    async def start(self, ctx: ChannelContext | None = None) -> None:
+        if ctx is not None:
+            self._bus = ctx.bus
+            self._event_bus = ctx.event_bus
+            self._interrupt_controller = ctx.interrupt_controller
+            ctx.push_tool.register_channel(
+                self.name,
+                text=self.send,
+                file=self.send_file,
+                image=self.send_image,
+            )
         self._main_loop = asyncio.get_running_loop()
         self._identity_index.rebuild()
-        if self._event_bus is not None:
-            self._event_bus.on(TurnStarted, self._on_turn_started)
-            self._event_bus.on(ToolCallStarted, self._on_tool_call_started)
-            self._event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
+        self._bind_events()
 
         @cast(Any, self._bot.on_private_message())
         async def _(event) -> None:
@@ -442,7 +453,17 @@ class QQChannel:
         self._api = await self._main_loop.run_in_executor(None, self._bot.run_backend)
         logger.info("[qq] NcatBot 已启动")
 
-        self._bus.subscribe_outbound(_CHANNEL, self._on_response)
+        if not self._outbound_bound:
+            self._bus.subscribe_outbound(_CHANNEL, self._on_response)
+            self._outbound_bound = True
+
+    def _bind_events(self) -> None:
+        if self._event_bus is None or self._events_bound:
+            return
+        self._event_bus.on(TurnStarted, self._on_turn_started)
+        self._event_bus.on(ToolCallStarted, self._on_tool_call_started)
+        self._event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
+        self._events_bound = True
 
     async def stop(self) -> None:
         if self._api:

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -35,6 +35,7 @@ from bus.events_lifecycle import (
 from bus.queue import MessageBus
 from agent.looping.interrupt import InterruptController
 from infra.channels.base import AttachmentStore, MessageDeduper, SessionIdentityIndex
+from infra.channels.contract import ChannelContext
 from infra.channels.telegram_utils import (
     TelegramOutboundLimiter,
     TelegramLiveEditQueue,
@@ -84,6 +85,7 @@ class TelegramChannel:
         self._session_manager = session_manager
         self._interrupt_controller = interrupt_controller
         self._channel = channel_name
+        self.name = channel_name
         self._allow_from: set[str] = set(allow_from) if allow_from else set()
         self._message_deduper = MessageDeduper(_SEEN_MSG_MAXSIZE)
         ws = getattr(session_manager, "workspace", None)
@@ -109,12 +111,9 @@ class TelegramChannel:
         self._app.add_handler(
             MessageHandler(filters.Document.ALL & ~filters.COMMAND, self._on_document)
         )
-        bus.subscribe_outbound(self._channel, self._on_response)
-        if event_bus is not None:
-            event_bus.on(TurnStarted, self._on_turn_started)
-            event_bus.on(StreamDeltaReady, self._on_stream_delta)
-            event_bus.on(ToolCallStarted, self._on_tool_call_started)
-            event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
+        self._event_bus = event_bus
+        self._outbound_bound = False
+        self._events_bound = False
         self.user_map = self._identity_index.mapping
         self._polling_conflict_task: asyncio.Task[None] | None = None
         self._telegram_outbound_limiter = TelegramOutboundLimiter()
@@ -163,7 +162,19 @@ class TelegramChannel:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def start(self) -> None:
+    async def start(self, ctx: ChannelContext | None = None) -> None:
+        if ctx is not None:
+            self._bus = ctx.bus
+            self._event_bus = ctx.event_bus
+            self._interrupt_controller = ctx.interrupt_controller
+            ctx.push_tool.register_channel(
+                self.name,
+                text=self.send,
+                stream_text=self.send_stream,
+                file=self.send_file,
+                image=self.send_image,
+            )
+        self._bind_runtime()
         self._rebuild_user_map()
         await self._app.initialize()
         await self._app.start()
@@ -176,6 +187,17 @@ class TelegramChannel:
             error_callback=self._on_polling_error,
         )
         logger.info(f"TelegramChannel 已启动  已知用户: {len(self.user_map)}")
+
+    def _bind_runtime(self) -> None:
+        if not self._outbound_bound:
+            self._bus.subscribe_outbound(self._channel, self._on_response)
+            self._outbound_bound = True
+        if self._event_bus is not None and not self._events_bound:
+            self._event_bus.on(TurnStarted, self._on_turn_started)
+            self._event_bus.on(StreamDeltaReady, self._on_stream_delta)
+            self._event_bus.on(ToolCallStarted, self._on_tool_call_started)
+            self._event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
+            self._events_bound = True
 
     async def stop(self) -> None:
         if self._polling_conflict_task and not self._polling_conflict_task.done():

--- a/plugins/qqbot/channel.py
+++ b/plugins/qqbot/channel.py
@@ -15,18 +15,19 @@ import logging
 import time
 from dataclasses import dataclass
 from collections.abc import Callable, Coroutine
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import websockets
 
-from agent.config_models import QQBotGroupConfig
 from agent.looping.interrupt import InterruptController
-from bus.event_bus import EventBus
 from bus.events import InboundMessage, OutboundMessage
 from bus.events_lifecycle import StreamDeltaReady, TurnStarted
 from bus.queue import MessageBus
-from session.manager import SessionManager
+from infra.channels.contract import ChannelContext
+
+if TYPE_CHECKING:
+    from plugins.qqbot.plugin import QQBotGroupConfigModel
 
 logger = logging.getLogger(__name__)
 
@@ -56,27 +57,28 @@ class _LiveStreamState:
 
 
 class QQBotChannel:
+    name = _CHANNEL
+
     def __init__(
         self,
         app_id: str,
         client_secret: str,
-        bus: MessageBus,
-        session_manager: SessionManager,
         allow_from: list[str] | None = None,
-        groups: list[QQBotGroupConfig] | None = None,
-        event_bus: EventBus | None = None,
-        interrupt_controller: InterruptController | None = None,
+        groups: list["QQBotGroupConfigModel"] | None = None,
     ) -> None:
         self._app_id = app_id
         self._client_secret = client_secret
-        self._bus = bus
-        self._session_manager = session_manager
+        self._bus: MessageBus | None = None
         self._allow_from = set(allow_from or [])
-        self._groups = {g.group_openid: g for g in (groups or [])}
-        self._interrupt_controller = interrupt_controller
+        self._groups: dict[str, QQBotGroupConfigModel] = {
+            g.group_openid: g for g in (groups or [])
+        }
+        self._interrupt_controller: InterruptController | None = None
         self._client = httpx.AsyncClient(timeout=30.0)
         self._token: _TokenCache | None = None
         self._task: asyncio.Task[None] | None = None
+        self._outbound_bound = False
+        self._events_bound = False
         self._stopped = asyncio.Event()
         self._last_c2c_msg_id: dict[str, str] = {}
         self._live_states: dict[str, _LiveStreamState] = {}
@@ -88,14 +90,24 @@ class QQBotChannel:
         self._live_locks: dict[str, asyncio.Lock] = {}
         self._live_tasks: set[asyncio.Task[None]] = set()
         self._live_tasks_by_session: dict[str, set[asyncio.Task[None]]] = {}
-        if event_bus is not None:
-            event_bus.on(TurnStarted, self._on_turn_started)
-            event_bus.on(StreamDeltaReady, self._on_stream_delta)
 
-    async def start(self) -> None:
-        _ = self._stopped.clear()
+    async def start(self, ctx: ChannelContext) -> None:
+        self._bus = ctx.bus
+        self._interrupt_controller = ctx.interrupt_controller
+        if not self._events_bound:
+            ctx.event_bus.on(TurnStarted, self._on_turn_started)
+            ctx.event_bus.on(StreamDeltaReady, self._on_stream_delta)
+            self._events_bound = True
+        ctx.push_tool.register_channel(
+            self.name,
+            text=self.send_proactive,
+            stream_text=self.send_stream,
+        )
+        self._stopped.clear()
         self._task = asyncio.create_task(self._gateway_loop())
-        self._bus.subscribe_outbound(_CHANNEL, self._on_response)
+        if not self._outbound_bound:
+            ctx.bus.subscribe_outbound(_CHANNEL, self._on_response)
+            self._outbound_bound = True
         logger.info("[qqbot] 官方 QQBot 通道已启动")
 
     async def stop(self) -> None:
@@ -109,6 +121,11 @@ class QQBotChannel:
         await self._drain_live_tasks()
         await self._client.aclose()
         logger.info("[qqbot] 官方 QQBot 通道已停止")
+
+    def _require_bus(self) -> MessageBus:
+        if self._bus is None:
+            raise RuntimeError("QQBotChannel 尚未启动")
+        return self._bus
 
     async def _gateway_loop(self) -> None:
         while not self._stopped.is_set():
@@ -193,7 +210,7 @@ class QQBotChannel:
         if content == "/stop":
             await self._handle_stop(f"c2c:{user_openid}", user_openid)
             return
-        await self._bus.publish_inbound(
+        await self._require_bus().publish_inbound(
             InboundMessage(
                 channel=_CHANNEL,
                 sender=user_openid,

--- a/plugins/qqbot/manifest.yaml
+++ b/plugins/qqbot/manifest.yaml
@@ -1,0 +1,3 @@
+name: qqbot
+version: 0.1.0
+desc: 官方 QQBot 渠道

--- a/plugins/qqbot/plugin.py
+++ b/plugins/qqbot/plugin.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, cast
+
+from pydantic import AliasChoices, BaseModel, Field, field_validator
+
+from agent.plugins import Plugin
+from .channel import QQBotChannel
+
+if TYPE_CHECKING:
+    from infra.channels.contract import Channel
+
+_UNRESOLVED_ENV_RE = re.compile(r"^\$\{\w+\}$")
+
+
+class QQBotGroupConfigModel(BaseModel):
+    group_openid: str = Field(
+        default="",
+        validation_alias=AliasChoices("group_openid", "groupOpenid"),
+    )
+    allow_from: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("allow_from", "allowFrom"),
+    )
+    require_at: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("require_at", "requireAt"),
+    )
+    allow_proactive: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("allow_proactive", "allowProactive"),
+    )
+
+
+class QQBotConfigModel(BaseModel):
+    app_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("app_id", "appId"),
+    )
+    client_secret: str = Field(
+        default="",
+        validation_alias=AliasChoices("client_secret", "clientSecret"),
+    )
+    allow_from: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("allow_from", "allowFrom"),
+    )
+    groups: list[QQBotGroupConfigModel] = Field(default_factory=list)
+
+    @field_validator("app_id", "client_secret", mode="before")
+    @classmethod
+    def _normalize_optional_text(cls, value: object) -> str:
+        text = str(value or "").strip()
+        if _UNRESOLVED_ENV_RE.fullmatch(text):
+            return ""
+        return text
+
+
+class QQBotPlugin(Plugin):
+    name = "qqbot"
+    desc = "官方 QQBot 渠道"
+    ConfigModel = QQBotConfigModel
+
+    def channels(self) -> list["Channel"]:
+        config = cast(QQBotConfigModel | None, self.context.config)
+        if config is None or not config.app_id or not config.client_secret:
+            return []
+        return [
+            QQBotChannel(
+                app_id=config.app_id,
+                client_secret=config.client_secret,
+                allow_from=config.allow_from,
+                groups=config.groups,
+            )
+        ]

--- a/plugins/setup_helper/plugin.py
+++ b/plugins/setup_helper/plugin.py
@@ -67,7 +67,7 @@ def _format_reply(chat_id: str, channel: str = "telegram") -> str:
             "同时确认 allow_from 已包含你的 user_openid：",
             "",
             "```toml",
-            "[channels.qqbot]",
+            "[plugins.qqbot]",
             f'allow_from = ["{raw_openid}"]',
             "```",
         ]

--- a/tests/test_bootstrap_wiring_p2.py
+++ b/tests/test_bootstrap_wiring_p2.py
@@ -344,14 +344,13 @@ def test_config_load_skips_unfilled_channels(tmp_path: Path, monkeypatch: pytest
 
     assert cfg.channels.telegram is None
     assert cfg.channels.qq is None
-    assert cfg.channels.qqbot is not None
-    assert cfg.channels.qqbot.app_id == "app"
-    assert cfg.channels.qqbot.client_secret == "secret"
-    assert cfg.channels.qqbot.allow_from == ["user-openid"]
-    assert cfg.channels.qqbot.groups[0].group_openid == "group-openid"
-    assert cfg.channels.qqbot.groups[0].allow_from == ["member-openid"]
-    assert cfg.channels.qqbot.groups[0].require_at is True
-    assert cfg.channels.qqbot.groups[0].allow_proactive is True
+    assert cfg.plugins["qqbot"]["app_id"] == "app"
+    assert cfg.plugins["qqbot"]["client_secret"] == "secret"
+    assert cfg.plugins["qqbot"]["allow_from"] == ["user-openid"]
+    assert cfg.plugins["qqbot"]["groups"][0]["group_openid"] == "group-openid"
+    assert cfg.plugins["qqbot"]["groups"][0]["allow_from"] == ["member-openid"]
+    assert cfg.plugins["qqbot"]["groups"][0]["require_at"] is True
+    assert cfg.plugins["qqbot"]["groups"][0]["allow_proactive"] is True
     assert cfg.channels.socket == DEFAULT_SOCKET
 
 

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 import sys
 import types
 from pathlib import Path
@@ -20,6 +21,8 @@ from bus.events_lifecycle import (
     ToolCallStarted,
     TurnStarted,
 )
+from infra.channels.base import AttachmentStore
+from infra.channels.contract import ChannelContext
 
 
 class _Bus:
@@ -1197,22 +1200,52 @@ async def test_qq_private_trace_skips_empty_trace(monkeypatch: pytest.MonkeyPatc
 
 @pytest.mark.asyncio
 async def test_qqbot_channel_text_paths(monkeypatch: pytest.MonkeyPatch):
-    sys.modules.pop("infra.channels.qqbot_channel", None)
-    mod = importlib.import_module("infra.channels.qqbot_channel")
+    sys.modules.pop("plugins.qqbot.channel", None)
+    mod = importlib.import_module("plugins.qqbot.channel")
     bus = _Bus()
     session_manager = _SessionManager()
     channel = mod.QQBotChannel(
         app_id="app",
         client_secret="secret",
-        bus=bus,
-        session_manager=session_manager,
         allow_from=["user-1"],
-        interrupt_controller=SimpleNamespace(
-            request_interrupt=MagicMock(return_value=SimpleNamespace(message="已中断"))
-        ),
     )
     channel._get_access_token = AsyncMock(return_value="token")
     channel._api_request = AsyncMock(return_value={"id": "m1", "timestamp": "now"})
+
+    class _PushTool:
+        def __init__(self) -> None:
+            self.registrations = []
+
+        def register_channel(self, name: str, **kwargs) -> None:
+            self.registrations.append((name, sorted(kwargs)))
+
+    async def _no_gateway_loop() -> None:
+        return None
+
+    channel._gateway_loop = _no_gateway_loop
+    push_tool = _PushTool()
+    await channel.start(
+        ChannelContext(
+            bus=cast(Any, bus),
+            session_manager=cast(Any, session_manager),
+            event_bus=EventBus(),
+            push_tool=cast(Any, push_tool),
+            attachment_store=AttachmentStore(),
+            http_resources=cast(Any, SimpleNamespace()),
+            interrupt_controller=cast(
+                Any,
+                SimpleNamespace(
+                    request_interrupt=MagicMock(
+                        return_value=SimpleNamespace(message="已中断")
+                    )
+                ),
+            ),
+            bot_commands=[],
+            log=logging.getLogger("test.qqbot"),
+        )
+    )
+    assert push_tool.registrations == [("qqbot", ["stream_text", "text"])]
+    assert bus.outbound[0][0] == "qqbot"
 
     assert channel._parse_chat_id("user-1") == ("c2c", "user-1")
     assert channel._parse_chat_id("qqbot:group:group-1") == ("group", "group-1")

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from bootstrap.channel_host import ChannelHost
+
+
+class _Channel:
+    def __init__(
+        self,
+        name: str,
+        events: list[str],
+        *,
+        fail_start: bool = False,
+        fail_stop: bool = False,
+    ) -> None:
+        self.name = name
+        self._events = events
+        self._fail_start = fail_start
+        self._fail_stop = fail_stop
+
+    async def start(self, ctx: object) -> None:
+        self._events.append(f"start:{self.name}:{ctx}")
+        if self._fail_start:
+            raise RuntimeError("start failed")
+
+    async def stop(self) -> None:
+        self._events.append(f"stop:{self.name}")
+        if self._fail_stop:
+            raise RuntimeError("stop failed")
+
+
+@pytest.mark.asyncio
+async def test_channel_host_start_failure_does_not_block_others():
+    events: list[str] = []
+    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host.add(_Channel("a", events))  # type: ignore[arg-type]
+    host.add(_Channel("b", events, fail_start=True))  # type: ignore[arg-type]
+    host.add(_Channel("c", events))  # type: ignore[arg-type]
+
+    await host.start_all()
+
+    assert events == [
+        "start:a:ctx:a",
+        "start:b:ctx:b",
+        "start:c:ctx:c",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_stops_in_reverse_order():
+    events: list[str] = []
+    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host.add(_Channel("a", events))  # type: ignore[arg-type]
+    host.add(_Channel("b", events, fail_stop=True))  # type: ignore[arg-type]
+    host.add(_Channel("c", events))  # type: ignore[arg-type]
+
+    await host.stop_all()
+
+    assert events == ["stop:c", "stop:b", "stop:a"]

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -736,7 +736,12 @@ async def test_app_runtime_start_passes_markdown_store_to_memory_optimizer(
     )
     monkeypatch.setattr(
         "bootstrap.app.start_channels",
-        AsyncMock(return_value=(MagicMock(), None, None, None)),
+        AsyncMock(
+            return_value=(
+                MagicMock(),
+                SimpleNamespace(start_all=AsyncMock(), stop_all=AsyncMock()),
+            )
+        ),
     )
     build_proactive_runtime = MagicMock(return_value=([], None))
     monkeypatch.setattr(

--- a/tests/test_plugin_config_schema.py
+++ b/tests/test_plugin_config_schema.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.config import Config
+from agent.plugins.manager import PluginManager
+from agent.plugins.registry import plugin_registry
+from bus.event_bus import EventBus
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+    yield
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+
+
+def _write_typed_plugin(root: Path) -> None:
+    plugin_dir = root / "typed"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        """
+from pydantic import BaseModel
+from agent.plugins import Plugin
+
+
+class TypedConfig(BaseModel):
+    api_key: str
+    max_results: int = 5
+
+
+class TypedPlugin(Plugin):
+    name = "typed"
+    ConfigModel = TypedConfig
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _get_instance(name: str):
+    for instance in plugin_registry._instances.values():
+        if getattr(instance, "name", None) == name:
+            return instance
+    raise KeyError(name)
+
+
+@pytest.mark.asyncio
+async def test_plugin_config_model_validates_and_injects_config(tmp_path: Path):
+    _write_typed_plugin(tmp_path)
+    manager = PluginManager(
+        plugin_dirs=[tmp_path],
+        event_bus=EventBus(),
+        plugin_configs={"typed": {"api_key": "secret", "max_results": 9}},
+    )
+
+    await manager.load_all()
+
+    config = _get_instance("typed").context.config
+    assert config.api_key == "secret"
+    assert config.max_results == 9
+
+
+@pytest.mark.asyncio
+async def test_plugin_config_model_failure_skips_plugin(tmp_path: Path):
+    _write_typed_plugin(tmp_path)
+    manager = PluginManager(
+        plugin_dirs=[tmp_path],
+        event_bus=EventBus(),
+        plugin_configs={"typed": {"max_results": "bad"}},
+    )
+
+    await manager.load_all()
+
+    assert manager.loaded_count == 0
+
+
+def test_config_load_resolves_plugin_env_and_legacy_qqbot(tmp_path: Path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[llm]
+provider = "openai"
+
+[llm.main]
+model = "m"
+api_key = "k"
+
+[agent]
+system_prompt = "s"
+
+[plugins.typed]
+api_key = "${PLUGIN_TOKEN}"
+
+[channels.qqbot]
+app_id = "app"
+client_secret = "${QQBOT_SECRET}"
+allow_from = ["user-openid"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PLUGIN_TOKEN", "plugin-secret")
+    monkeypatch.setenv("QQBOT_SECRET", "qq-secret")
+
+    config = Config.load(config_path)
+
+    assert config.plugins["typed"]["api_key"] == "plugin-secret"
+    assert config.plugins["qqbot"]["client_secret"] == "qq-secret"
+    assert config.plugins["qqbot"]["allow_from"] == ["user-openid"]

--- a/tests/test_qqbot_plugin.py
+++ b/tests/test_qqbot_plugin.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from bus.event_bus import EventBus
+from infra.channels.base import AttachmentStore
+from infra.channels.contract import ChannelContext
+from plugins.qqbot.plugin import QQBotConfigModel, QQBotPlugin
+
+
+class _Bus:
+    def __init__(self) -> None:
+        self.outbound = []
+
+    def subscribe_outbound(self, channel: str, callback: object) -> None:
+        self.outbound.append((channel, callback))
+
+
+class _PushTool:
+    def __init__(self) -> None:
+        self.registrations = []
+
+    def register_channel(self, name: str, **kwargs: object) -> None:
+        self.registrations.append((name, sorted(kwargs)))
+
+
+def test_qqbot_plugin_returns_no_channel_without_credentials():
+    plugin = QQBotPlugin()
+    plugin.context = cast(Any, SimpleNamespace(config=QQBotConfigModel()))
+
+    assert plugin.channels() == []
+
+
+@pytest.mark.asyncio
+async def test_qqbot_plugin_channel_registers_runtime_hooks():
+    plugin = QQBotPlugin()
+    plugin.context = cast(Any, SimpleNamespace(config=QQBotConfigModel(
+        app_id="app",
+        client_secret="secret",
+        allow_from=["user-1"],
+    )))
+    channel = plugin.channels()[0]
+
+    async def _no_gateway_loop() -> None:
+        return None
+
+    channel._gateway_loop = _no_gateway_loop
+    bus = _Bus()
+    push_tool = _PushTool()
+    await channel.start(
+        ChannelContext(
+            bus=cast(Any, bus),
+            session_manager=cast(Any, SimpleNamespace()),
+            event_bus=EventBus(),
+            push_tool=cast(Any, push_tool),
+            attachment_store=AttachmentStore(),
+            http_resources=cast(Any, SimpleNamespace()),
+            interrupt_controller=None,
+            bot_commands=[],
+            log=logging.getLogger("test.qqbot"),
+        )
+    )
+    await channel.stop()
+
+    assert bus.outbound[0][0] == "qqbot"
+    assert push_tool.registrations == [("qqbot", ["stream_text", "text"])]

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -15,8 +15,6 @@ from agent.config import (
     ChannelsConfig,
     Config,
     DEFAULT_SOCKET,
-    QQBotChannelConfig,
-    QQBotGroupConfig,
     QQChannelConfig,
     QQGroupConfig,
     TelegramChannelConfig,
@@ -301,7 +299,6 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     fake_ipc_server = types.ModuleType("infra.channels.ipc_server")
     fake_telegram_channel = types.ModuleType("infra.channels.telegram_channel")
     fake_qq_channel = types.ModuleType("infra.channels.qq_channel")
-    fake_qqbot_channel = types.ModuleType("infra.channels.qqbot_channel")
 
     class _IPCServerChannel:
         def __init__(self, bus, socket, default_session_key: str = ""):
@@ -318,9 +315,17 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     class _TelegramChannel:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
+            self.name = kwargs.get("channel_name", "telegram")
 
-        async def start(self) -> None:
+        async def start(self, ctx) -> None:
             starts.append("telegram")
+            ctx.push_tool.register_channel(
+                self.name,
+                text=self.send,
+                stream_text=self.send_stream,
+                file=self.send_file,
+                image=self.send_image,
+            )
 
         async def stop(self) -> None:
             starts.append("telegram.stop")
@@ -338,11 +343,19 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
             return None
 
     class _QQChannel:
+        name = "qq"
+
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
-        async def start(self) -> None:
+        async def start(self, ctx) -> None:
             starts.append("qq")
+            ctx.push_tool.register_channel(
+                self.name,
+                text=self.send,
+                file=self.send_file,
+                image=self.send_image,
+            )
 
         async def stop(self) -> None:
             starts.append("qq.stop")
@@ -357,11 +370,18 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
             return None
 
     class _QQBotChannel:
+        name = "qqbot"
+
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
-        async def start(self) -> None:
+        async def start(self, ctx) -> None:
             starts.append("qqbot")
+            ctx.push_tool.register_channel(
+                self.name,
+                text=self.send_proactive,
+                stream_text=self.send_stream,
+            )
 
         async def stop(self) -> None:
             starts.append("qqbot.stop")
@@ -375,11 +395,9 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     fake_ipc_server.IPCServerChannel = _IPCServerChannel  # type: ignore[attr-defined]
     fake_telegram_channel.TelegramChannel = _TelegramChannel  # type: ignore[attr-defined]
     fake_qq_channel.QQChannel = _QQChannel  # type: ignore[attr-defined]
-    fake_qqbot_channel.QQBotChannel = _QQBotChannel  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "infra.channels.ipc_server", fake_ipc_server)
     monkeypatch.setitem(sys.modules, "infra.channels.telegram_channel", fake_telegram_channel)
     monkeypatch.setitem(sys.modules, "infra.channels.qq_channel", fake_qq_channel)
-    monkeypatch.setitem(sys.modules, "infra.channels.qqbot_channel", fake_qqbot_channel)
 
     class _PushTool:
         def register_channel(self, name: str, **kwargs) -> None:
@@ -397,12 +415,6 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
                 allow_from=["2"],
                 groups=[QQGroupConfig(group_id="3")],
             ),
-            qqbot=QQBotChannelConfig(
-                app_id="app",
-                client_secret="secret",
-                allow_from=["user-openid"],
-                groups=[QQBotGroupConfig(group_openid="group-openid")],
-            ),
             socket=str(tmp_path / "sock"),
         ),
     )
@@ -410,7 +422,8 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     event_bus = EventBus()
     try:
         controller = object()
-        ipc, tg, qq, qqbot = await start_channels(
+        plugin_channel = _QQBotChannel(event_bus=event_bus)
+        ipc, host = await start_channels(
             config,
             bus=cast(Any, object()),
             session_manager=cast(Any, object()),
@@ -418,14 +431,14 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
             http_resources=resources,
             event_bus=event_bus,
             interrupt_controller=cast(Any, controller),
+            plugin_channels=[cast(Any, plugin_channel)],
         )
+        await host.start_all()
     finally:
         await resources.aclose()
 
     assert ipc is not None
-    assert tg is not None
-    assert qq is not None
-    assert qqbot is not None
+    tg, qq, qqbot = host.channels
     assert starts == ["ipc", "telegram", "qq", "qqbot"]
     assert registrations == [
         ("telegram", ["file", "image", "stream_text", "text"]),
@@ -436,7 +449,6 @@ async def test_start_channels_wires_telegram_and_qq(monkeypatch, tmp_path):
     assert tg.kwargs["interrupt_controller"] is controller
     assert qq.kwargs["interrupt_controller"] is controller
     assert qqbot.kwargs["event_bus"] is event_bus
-    assert qqbot.kwargs["interrupt_controller"] is controller
 
 
 @pytest.mark.asyncio
@@ -491,7 +503,7 @@ async def test_start_channels_skips_unfilled_optional_channels(monkeypatch, tmp_
     )
     resources = SharedHttpResources()
     try:
-        ipc, tg, qq, qqbot = await start_channels(
+        ipc, host = await start_channels(
             config,
             bus=cast(Any, object()),
             session_manager=cast(Any, object()),
@@ -503,7 +515,5 @@ async def test_start_channels_skips_unfilled_optional_channels(monkeypatch, tmp_
         await resources.aclose()
 
     assert ipc is not None
-    assert tg is None
-    assert qq is None
-    assert qqbot is None
+    assert host.channels == []
     assert starts == ["ipc"]


### PR DESCRIPTION
## What changed

- Added a shared Channel protocol and ChannelHost lifecycle supervisor.
- Moved the official QQBot channel from core infra into `plugins/qqbot/`.
- Added plugin `ConfigModel` validation and `[plugins.qqbot]` config loading, with legacy `[channels.qqbot]` fallback.
- Updated setup hints, config examples, and tests for the plugin-based channel path.

## Why

This removes QQBot from the hardcoded channel startup path and gives future channels a plugin registration path without migrating Telegram or NapCat QQ yet.

## Validation

- `.venv/bin/pytest tests/` -> 1275 passed
- `.venv/bin/pyright --level error <changed files>` -> 0 errors