### PR TITLE
fix(shell): task_output block 钳到 30s 上限，改为轮询语义

### DIFF
--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -40,6 +40,8 @@ _BLOCKING_TIMEOUT = 21_600  # 秒（auto_promote=False 时默认 6 小时）
 _MAX_OUTPUT = 30_000  # 字符（与 OpenCode MaxOutputLength 一致）
 _STREAM_CHUNK_SIZE = 4096
 _STREAM_DRAIN_GRACE_S = 0.2
+_BLOCK_DEFAULT_MS = 30_000  # task_output block 默认单次等待
+_BLOCK_MAX_MS = 30_000  # task_output block 单次硬上限：超过按上限，迫使长任务走轮询而非一次死等
 _BG_TTL_S = 4 * 3600  # 后台任务最长存活时间：4 小时
 _BG_EVICT_DELAY_S = 300  # 任务完成后延迟 5 分钟清理注册表和日志
 _IS_WINDOWS = os.name == "nt"
@@ -284,7 +286,7 @@ class ShellTool(Tool):
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false；未显式传 timeout 时会默认阻塞 21600 秒\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
             "- 收到 background_task_id 后，由你负责用 task_output 主动查看进展和结果；不会有系统自动回传\n"
-            "- 等待后台任务结果时，使用 task_output 的 block=true 并设置合理 timeout_ms，避免高频轮询\n"
+            "- task_output 是轮询接口：block=true 单次最多等 30s 就返回快照（不会等到任务结束），长任务靠多次轮询推进\n"
             "- 如果决定放弃后台任务并准备最终回复，必须先调用 task_stop 终止它\n"
             "禁止用途：不得用 shell 替代专用工具（read_file 读文件、web_fetch 抓网页、list_dir 列目录）。"
         )
@@ -669,7 +671,9 @@ class ShellTaskOutputTool(Tool):
             "  - 任务挂起：有过输出但 since_last_output_ms 异常大，不符合该命令的预期节奏\n"
             "  - 任务卡死：从未有过输出（since_last_output_ms=null）且 elapsed_ms 超过合理预期\n"
             "不需要 stop 的情况：编译、下载、训练等明确会结束的长时间任务，或用户主动要求的服务进程。\n"
-            "- block=true 是等待后台任务结果的推荐方式；设置合理 timeout_ms 后轮询一次，再判断继续等待、汇报结果或 task_stop。\n"
+            "- 这是轮询接口：block=true 最多等待 timeout_ms（上限 30s）就返回一次快照，不会一直阻塞到任务结束。\n"
+            "- 长任务用轮询循环：每次 block 一段→返回后判断 done/继续轮询/task_stop，不要期望一次调用就等到结束（传超大 timeout_ms 也会被钳到 30s）。\n"
+            "- 分次轮询才能在等待期间响应用户新消息或 /stop；一次死等会让你长时间无响应。\n"
             "- 如果你决定放弃某个后台任务、准备输出最终回复，必须先调用 task_stop 将其终止，再生成回复。不要让后台任务在你回复后继续孤立运行。\n"
             "- 如果返回 status=done，本轮必须负责处理结果，不会有任何系统自动回传。"
         )
@@ -689,8 +693,9 @@ class ShellTaskOutputTool(Tool):
                 },
                 "timeout_ms": {
                     "type": "integer",
-                    "description": "block=true 时的最长等待时间（毫秒），默认 30000",
+                    "description": "block=true 时本次最多等待毫秒数，默认 30000，上限 30000（超过按上限处理，单次轮询不会等到任务结束）",
                     "minimum": 0,
+                    "maximum": _BLOCK_MAX_MS,
                 },
             },
             "required": ["task_id"],
@@ -699,7 +704,8 @@ class ShellTaskOutputTool(Tool):
     async def execute(self, **kwargs: Any) -> str:
         task_id: str = kwargs.get("task_id", "")
         block: bool = bool(kwargs.get("block", False))
-        timeout_ms: int = int(kwargs.get("timeout_ms", 30000))
+        # 钳到硬上限：block 本质是轮询一次，单次最多等 _BLOCK_MAX_MS，避免一次调用长时间静默
+        timeout_ms: int = min(max(int(kwargs.get("timeout_ms", _BLOCK_DEFAULT_MS)), 0), _BLOCK_MAX_MS)
 
         task = _BG_REGISTRY.get(task_id)
         if task is None:

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -992,6 +992,51 @@ async def test_task_output_timeout_expired(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_task_output_clamps_block_timeout(monkeypatch, tmp_path):
+    """超大 timeout_ms 被钳到 _BLOCK_MAX_MS，单次 block 不会长时间死等。"""
+    import agent.tools.shell as shell_mod
+
+    log_path = tmp_path / "running.log"
+    log_path.write_text("running output", encoding="utf-8")
+
+    fake_proc = _FakeProc(stdout="", stderr="", returncode=None)  # 运行中
+    fake_proc.pid = 4567
+
+    task_id = "shell_clamp"
+    shell_mod._BG_REGISTRY[task_id] = shell_mod._BackgroundTask(
+        proc=fake_proc,
+        log_path=str(log_path),
+        pump_task=asyncio.ensure_future(asyncio.sleep(100)),  # 测试期间不会完成
+        started_at=shell_mod.time.monotonic(),
+        wall_started_at_ms=0,
+        timeout_s=3600,
+    )
+
+    captured: dict[str, float] = {}
+
+    async def fake_wait_for(aw, timeout):
+        captured["timeout"] = timeout
+        if hasattr(aw, "cancel"):
+            aw.cancel()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(shell_mod.asyncio, "wait_for", fake_wait_for)
+
+    tool = ShellTaskOutputTool()
+    result = json.loads(
+        await tool.execute(task_id=task_id, block=True, timeout_ms=99_999_999)
+    )
+
+    # 实际传给 wait_for 的超时被钳到 30s，而非 99999999ms
+    assert captured["timeout"] == shell_mod._BLOCK_MAX_MS / 1000
+    assert result["status"] == "running"
+
+    bg = shell_mod._BG_REGISTRY.pop(task_id, None)
+    if bg is not None and bg.pump_task is not None:
+        bg.pump_task.cancel()
+
+
+@pytest.mark.asyncio
 async def test_bg_pump_done_evicts_registry_and_log(monkeypatch, tmp_path):
     """pump_task 完成后的 done callback 应清理注册表并删除日志文件。
 


### PR DESCRIPTION
## 问题

`task_output(block=true)` 的 `timeout_ms` 没有上限，LLM 传超大值会让**单次调用**静默 `await` 整个长任务的时长——曾出现一次 `block` 卡住 ~20 分钟，期间无中间返回、无法被 `/stop` 中断、用户零反馈。block 本应是"轮询一次"，却被当成"等到结束"。

## 改动（只动 `agent/tools/shell.py`）

- **execute**：`timeout_ms` 钳到 `[0, _BLOCK_MAX_MS=30s]`。无论传多大，单次 `block` 最多等 30s 必返回 → 长任务由"一次死等"变为"每 ≤30s 一次轮询"，每次返回都是可被 `/stop` 中断、可反馈的活点。
- **schema**：`timeout_ms` 加 `maximum=30000` 并改描述。
- **description**：明确为轮询接口——block 单次最多等 30s 返回快照、不会等到任务结束、长任务用轮询循环；同步 `ShellTool` 提示措辞。

## 为什么不修"子进程 fd"那条

`_bg_pump` 已经处理：先 `await proc.wait()`（只等主进程退出，不等子孙关 fd）→ 排水 `_STREAM_DRAIN_GRACE_S=0.2s` → 超时强制 `cancel`。所以 `pump_task` 在主进程退出后 0.2s 内必结束，不会因 fd 滞留永久阻塞。该逻辑 2026-04-12 提交，早于事故。再加 `proc.returncode` 判定属冗余，且会抢在排水前返回、丢掉最后几帧输出。

## 测试

- 新增 `test_task_output_clamps_block_timeout`：传 `timeout_ms=99_999_999` 时断言实际传给 `wait_for` 的超时被钳到 30.0s。
- `tests/test_shell_tool.py` 33 用例全过；`pyright agent/tools/shell.py` 0 error。