### PR TITLE
[codex] fix memory context guard consolidation

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -44,7 +44,11 @@ from agent.lifecycle.phases.before_reasoning import (
     default_before_reasoning_modules,
 )
 from agent.lifecycle.phases.before_step import BeforeStepFrame, default_before_step_modules
-from agent.lifecycle.phases.before_turn import BeforeTurnFrame, default_before_turn_modules
+from agent.lifecycle.phases.before_turn import (
+    BeforeTurnFrame,
+    MemoryConsolidator,
+    default_before_turn_modules,
+)
 from agent.lifecycle.phases.prompt_render import (
     PromptRenderFrame,
     default_prompt_render_modules,
@@ -151,6 +155,7 @@ class AgentCoreDeps:
     event_bus: "EventBus | None" = None
     outbound_port: "OutboundPort | None" = None
     history_window: int = 500
+    memory_consolidator: MemoryConsolidator | None = None
     before_turn_plugin_modules: list[object] | None = None
     before_reasoning_plugin_modules: list[object] | None = None
     before_step_plugin_modules: list[object] | None = None
@@ -242,6 +247,7 @@ class PassiveTurnPipeline:
             add_after_step(list(deps.after_step_plugin_modules or []))
         self._outbound_port = deps.outbound_port or _NoopOutboundPort()
         self._history_window = deps.history_window
+        self._memory_consolidator = deps.memory_consolidator
         self._before_turn_plugin_modules = list(deps.before_turn_plugin_modules or [])
         self._before_reasoning_plugin_modules = list(
             deps.before_reasoning_plugin_modules or []
@@ -293,6 +299,7 @@ class PassiveTurnPipeline:
                 self._session.session_manager,
                 self._context_store,
                 keep_count=self._history_window,
+                consolidator=self._memory_consolidator,
                 plugin_modules=cast("list[Any]", self._before_turn_plugin_modules),
             ),
             frame_factory=BeforeTurnFrame,

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, Protocol, TypeAlias, cast
 
 from bus.event_bus import EventBus
 from agent.core.runtime_support import SessionLike
@@ -29,6 +29,16 @@ class BeforeTurnFrame(PhaseFrame[TurnState, BeforeTurnCtx]):
 
 
 BeforeTurnModules: TypeAlias = list[PhaseModule[BeforeTurnFrame]]
+
+
+class MemoryConsolidator(Protocol):
+    async def trigger_memory_consolidation(
+        self,
+        session_key: str,
+        *,
+        archive_all: bool = False,
+        force: bool = False,
+    ) -> bool: ...
 
 
 _SESSION_SLOT = "session:session"
@@ -81,10 +91,15 @@ class _MemoryContextGuardModule:
     requires = ("before_turn.acquire_session", _SESSION_SLOT)
     produces = (_CTX_SLOT,)
 
-    def __init__(self, keep_count: int) -> None:
+    def __init__(
+        self,
+        keep_count: int,
+        consolidator: MemoryConsolidator | None = None,
+    ) -> None:
         self._keep_count = max(1, int(keep_count))
         self._min_new = max(5, self._keep_count // 2)
         self._threshold = self._keep_count + self._min_new
+        self._consolidator = consolidator
 
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
         if _CTX_SLOT in frame.slots:
@@ -101,6 +116,22 @@ class _MemoryContextGuardModule:
         pending = len(messages) - last
         if pending < self._threshold:
             return frame
+
+        if self._consolidator is not None:
+            try:
+                triggered = await self._consolidator.trigger_memory_consolidation(
+                    state.session_key,
+                )
+            except Exception:
+                logger.exception(
+                    "memory context guard failed to consolidate: session=%s pending=%d threshold=%d",
+                    state.session_key,
+                    pending,
+                    self._threshold,
+                )
+            else:
+                if triggered:
+                    return frame
 
         logger.error(
             "memory context guard blocked turn: session=%s pending=%d threshold=%d last_consolidated=%d total=%d",
@@ -211,11 +242,12 @@ def default_before_turn_modules(
     context_store: ContextStore,
     *,
     keep_count: int = 20,
+    consolidator: MemoryConsolidator | None = None,
     plugin_modules: BeforeTurnModules | None = None,
 ) -> BeforeTurnModules:
     builtins: BeforeTurnModules = [
         _AcquireSessionModule(session_manager),
-        _MemoryContextGuardModule(keep_count),
+        _MemoryContextGuardModule(keep_count, consolidator),
         _PrepareContextModule(context_store),
         _BuildBeforeTurnCtxModule(),
         _EmitBeforeTurnCtxModule(bus),

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -314,6 +314,7 @@ class AgentLoop:
                 event_bus=self._event_bus,
                 outbound_port=BusOutboundPort(self.bus),
                 history_window=config.memory.keep_count,
+                memory_consolidator=self,
             )
         )
         self._agent_core = agent_core

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -459,6 +459,96 @@ async def test_before_turn_memory_context_guard_blocks_unconsolidated_tail():
 
 
 @pytest.mark.asyncio
+async def test_before_turn_memory_context_guard_consolidates_before_blocking():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session.messages = [
+        {"role": "user", "content": f"u{i}"}
+        for i in range(30)
+    ]
+    session.last_consolidated = 0
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(
+        prepare=AsyncMock(return_value=ContextBundle(history_messages=[]))
+    )
+
+    class _Consolidator:
+        async def trigger_memory_consolidation(
+            self,
+            session_key: str,
+            *,
+            archive_all: bool = False,
+            force: bool = False,
+        ) -> bool:
+            assert session_key == "telegram:123"
+            assert archive_all is False
+            assert force is False
+            session.last_consolidated = len(session.messages) - 20
+            return True
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            keep_count=20,
+            consolidator=_Consolidator(),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = _inbound()
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is False
+    assert session.last_consolidated == 10
+    ctx_store.prepare.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_before_turn_memory_context_guard_blocks_after_consolidation_failure():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session.messages = [
+        {"role": "user", "content": f"u{i}"}
+        for i in range(30)
+    ]
+    session.last_consolidated = 0
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(prepare=AsyncMock())
+
+    class _Consolidator:
+        async def trigger_memory_consolidation(
+            self,
+            session_key: str,
+            *,
+            archive_all: bool = False,
+            force: bool = False,
+        ) -> bool:
+            return False
+
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            keep_count=20,
+            consolidator=_Consolidator(),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = _inbound()
+    state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
+
+    ctx = await phase.run(state)
+
+    assert ctx.abort is True
+    assert "记忆归档现在处于异常积压状态" in ctx.abort_reply
+    ctx_store.prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_before_turn_accepts_custom_command_module():
     bus = EventBus()
     session = _DummySession("telegram:123")

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -694,11 +694,13 @@ class TestBaseline:
     """
 
     @pytest.fixture(scope="class")
-    def reg(self):
+    @classmethod
+    def reg(cls):
         return _make_registry()
 
     @pytest.fixture(scope="class")
-    def cases(self):
+    @classmethod
+    def cases(cls):
         return json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
 
     def test_baseline_cases(self, reg, cases):


### PR DESCRIPTION
问题

- 记忆上下文保护在未归档尾巴达到阈值时直接中止普通回复。
- 主动推送也会进入会话上下文，直接 fail-stop 会让尾巴更容易卡住。

改动

- BeforeTurn 守卫超阈值时先触发一次普通 memory consolidation。
- consolidation 成功后继续正常上下文准备，失败后才返回保护消息。
- AgentLoop 将现有 trigger_memory_consolidation 接入 AgentCore。
- 补充成功压缩和压缩失败两个回归测试。

链路

- 守卫调用普通 consolidation，不传 force，因此推进边界与后台一致：保留 keep_count 热尾巴。

验证

- pytest tests/test_lifecycle_phases.py tests/test_agent_self_check.py tests/test_agent_core_p5_agent_core.py -q
- pyright agent/lifecycle/phases/before_turn.py agent/core/passive_turn.py agent/looping/core.py tests/test_lifecycle_phases.py
- git diff --check

配置影响

- 无配置变更。