### PR TITLE
feat(dashboard): observe.db 通用监测页(grafana 风)

### DIFF
--- a/frontend/dashboard/public/sdk/ui.js
+++ b/frontend/dashboard/public/sdk/ui.js
@@ -3,6 +3,7 @@
 const U = window.__akashicRuntime.UI;
 export const {
   ShortcutKey, Label, FieldLabel, Tile, Btn, Chip, Input, SearchInput, Select,
-  BrandMark, useTheme, ThemeToggle, cn, Pie, api, asPageResult, pageCount,
+  BrandMark, useTheme, ThemeToggle, cn, Pie, MetricTile, Sparkline, BarChart,
+  api, asPageResult, pageCount,
 } = U;
 export default U;

--- a/frontend/dashboard/src/design/charts.tsx
+++ b/frontend/dashboard/src/design/charts.tsx
@@ -1,5 +1,17 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import { cn } from "./cn";
+
+// Shared accent palette for the monitoring atoms below — resolved to the
+// industrial RGB-triplet tokens so opacity blending stays theme-aware.
+export type ChartTone = "accent" | "success" | "warning" | "danger" | "muted";
+
+const TONE_RGB: Record<ChartTone, string> = {
+  accent: "var(--color-accent-rgb)",
+  success: "var(--color-success-rgb)",
+  warning: "var(--color-warning-rgb)",
+  danger: "var(--color-danger-rgb)",
+  muted: "var(--color-muted-rgb)",
+};
 
 // Hand-rolled SVG pie — a 2-slice hit/miss filled pie with a glossy, dimensional
 // finish (radial sheen + drop shadow + rim) and a sweep-in animation on mount.
@@ -106,6 +118,145 @@ export function Pie({
           <span className="h-2 w-2 rounded-full bg-surface-3" />
           {missLabel} {fmt(miss)} · {Math.round((100 - pct) * 10) / 10}%
         </span>
+      </div>
+    </div>
+  );
+}
+
+// MetricTile — a KPI card: a big tabular-nums value with an optional unit, a
+// secondary line (delta / context), and an inline sparkline. The workhorse of
+// the monitoring overview.
+export function MetricTile({
+  label,
+  value,
+  unit,
+  sub,
+  tone = "accent",
+  spark,
+  className,
+}: {
+  label: string;
+  value: ReactNode;
+  unit?: string;
+  sub?: ReactNode;
+  tone?: ChartTone;
+  spark?: number[];
+  className?: string;
+}) {
+  return (
+    <div className={cn("relative overflow-hidden rounded-lg border border-border bg-surface p-4 shadow-lift-sm", className)}>
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">{label}</span>
+      <div className="mt-2 flex items-baseline gap-1.5">
+        <span className="font-mono text-[26px] font-semibold leading-none tracking-tight tabular-nums text-fg">{value}</span>
+        {unit && <span className="font-mono text-[12px] text-muted">{unit}</span>}
+      </div>
+      {sub && <div className="mt-1.5 font-mono text-[11px] tabular-nums text-muted">{sub}</div>}
+      {spark && spark.length > 1 && (
+        <Sparkline data={spark} tone={tone} className="mt-3 w-full" height={28} />
+      )}
+    </div>
+  );
+}
+
+// Sparkline — a normalized SVG area+line trend, no axes. Fills its container
+// width via a preserveAspectRatio="none" viewBox.
+export function Sparkline({
+  data,
+  tone = "accent",
+  height = 32,
+  className,
+}: {
+  data: number[];
+  tone?: ChartTone;
+  height?: number;
+  className?: string;
+}) {
+  const uid = useId().replace(/:/g, "");
+  const w = 100;
+  const h = 32;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const span = max - min || 1;
+  const step = data.length > 1 ? w / (data.length - 1) : w;
+  const pts = data.map((v, i) => {
+    const x = i * step;
+    const y = h - ((v - min) / span) * h;
+    return [x, Math.max(1, Math.min(h - 1, y))] as const;
+  });
+  const line = pts.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`).join(" ");
+  const area = `${line} L ${w} ${h} L 0 ${h} Z`;
+  const rgb = TONE_RGB[tone];
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      style={{ height }}
+      className={cn("block", className)}
+    >
+      <defs>
+        <linearGradient id={`spark-${uid}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={`rgb(${rgb})`} stopOpacity="0.32" />
+          <stop offset="100%" stopColor={`rgb(${rgb})`} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={area} fill={`url(#spark-${uid})`} />
+      <path d={line} fill="none" stroke={`rgb(${rgb})`} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+// BarChart — a bucketed bar series with a baseline grid line and per-bar hover
+// titles. Used for token / error / iteration trends over time.
+export function BarChart({
+  points,
+  height = 140,
+  tone = "accent",
+  valueFmt = (n: number) => String(n),
+  className,
+}: {
+  points: { label: string; value: number }[];
+  height?: number;
+  tone?: ChartTone;
+  valueFmt?: (n: number) => string;
+  className?: string;
+}) {
+  const rgb = TONE_RGB[tone];
+  const max = Math.max(...points.map((p) => p.value), 1);
+  if (points.length === 0) {
+    return (
+      <div className={cn("flex items-center justify-center text-[12px] text-subtle", className)} style={{ height }}>
+        暂无数据
+      </div>
+    );
+  }
+  return (
+    <div className={cn("relative", className)} style={{ height }}>
+      <div className="absolute inset-x-0 bottom-5 top-2 border-b border-border" />
+      <div className="absolute inset-x-0 bottom-5 top-2 flex items-end gap-[2px]">
+        {points.map((p, i) => {
+          const frac = p.value / max;
+          return (
+            <div
+              key={`${p.label}-${i}`}
+              className="group relative flex-1 cursor-default"
+              style={{ height: "100%" }}
+              title={`${p.label} · ${valueFmt(p.value)}`}
+            >
+              <div
+                className="absolute bottom-0 w-full rounded-t-[2px] transition-[height] duration-300"
+                style={{
+                  height: `${Math.max(frac * 100, p.value > 0 ? 2 : 0)}%`,
+                  background: `linear-gradient(to top, rgb(${rgb} / 0.55), rgb(${rgb} / 0.95))`,
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="absolute inset-x-0 bottom-0 flex justify-between font-mono text-[9px] tabular-nums text-subtle">
+        <span>{points[0]?.label}</span>
+        {points.length > 2 && <span>{points[Math.floor(points.length / 2)]?.label}</span>}
+        <span>{points[points.length - 1]?.label}</span>
       </div>
     </div>
   );

--- a/frontend/dashboard/src/design/sdk.ts
+++ b/frontend/dashboard/src/design/sdk.ts
@@ -4,5 +4,6 @@
 // component implementations and its single React instance.
 export * from "./ui";
 export { cn } from "./cn";
-export { Pie } from "./charts";
+export { Pie, MetricTile, Sparkline, BarChart } from "./charts";
+export type { ChartTone } from "./charts";
 export { api, asPageResult, pageCount } from "../api";

--- a/plugins/observe/dashboard.py
+++ b/plugins/observe/dashboard.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+import sqlite3
+import threading
+
+from fastapi import FastAPI
+
+# Observe monitoring dashboard: aggregates the agent-loop telemetry written to
+# observe.db (turns table) into Grafana-style metrics — token & KV cache usage,
+# ReAct iteration health, and error aggregation. Read-only.
+
+# Range presets -> lookback hours (None = all history).
+_RANGES: dict[str, int | None] = {
+    "24h": 24,
+    "7d": 24 * 7,
+    "30d": 24 * 30,
+    "all": None,
+}
+
+
+# Resolve a range token to (cutoff_iso, bucket_len). bucket_len is the substring
+# length of the ISO ts used to group time buckets: 13 = hour (YYYY-MM-DDTHH),
+# 10 = day (YYYY-MM-DD).
+def _resolve_range(range_token: str) -> tuple[str | None, int]:
+    hours = _RANGES.get(range_token, 24)
+    bucket_len = 13 if (hours is not None and hours <= 24) else 10
+    if hours is None:
+        return None, bucket_len
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return cutoff.isoformat(), bucket_len
+
+
+class ObserveDashboardReader:
+    def __init__(self, workspace: Path) -> None:
+        self.db_path = workspace / "observe" / "observe.db"
+        self._lock = threading.RLock()
+
+    # Aggregate the metric-card figures over the selected window.
+    def get_overview(self, range_token: str) -> dict[str, Any]:
+        cutoff, _ = _resolve_range(range_token)
+        if not self.db_path.exists():
+            return _empty_overview(range_token)
+        where, params = _agent_window(cutoff)
+        with self._lock, _connect(self.db_path) as db:
+            row = db.execute(
+                f"""
+                SELECT
+                    COUNT(*) AS turns,
+                    SUM(CASE WHEN error IS NOT NULL THEN 1 ELSE 0 END) AS errors,
+                    COALESCE(SUM(COALESCE(react_input_sum_tokens, prompt_tokens, 0)), 0) AS input_tokens,
+                    COALESCE(SUM(react_cache_prompt_tokens), 0) AS cache_prompt_tokens,
+                    COALESCE(SUM(react_cache_hit_tokens), 0) AS cache_hit_tokens,
+                    AVG(react_iteration_count) AS avg_iteration,
+                    MAX(react_iteration_count) AS max_iteration,
+                    MAX(ts) AS last_ts
+                FROM turns
+                WHERE {where}
+                """,
+                params,
+            ).fetchone()
+        return _overview_from_row(row, range_token)
+
+    # Bucketed time series for the trend charts.
+    def get_timeseries(self, range_token: str) -> dict[str, Any]:
+        cutoff, bucket_len = _resolve_range(range_token)
+        if not self.db_path.exists():
+            return {"range": range_token, "bucket": _bucket_name(bucket_len), "points": []}
+        where, params = _agent_window(cutoff)
+        with self._lock, _connect(self.db_path) as db:
+            rows = db.execute(
+                f"""
+                SELECT
+                    substr(ts, 1, ?) AS bucket,
+                    COUNT(*) AS turns,
+                    SUM(CASE WHEN error IS NOT NULL THEN 1 ELSE 0 END) AS errors,
+                    COALESCE(SUM(COALESCE(react_input_sum_tokens, prompt_tokens, 0)), 0) AS input_tokens,
+                    COALESCE(SUM(react_cache_prompt_tokens), 0) AS cache_prompt_tokens,
+                    COALESCE(SUM(react_cache_hit_tokens), 0) AS cache_hit_tokens,
+                    AVG(react_iteration_count) AS avg_iteration
+                FROM turns
+                WHERE {where}
+                GROUP BY bucket
+                ORDER BY bucket ASC
+                """,
+                (bucket_len, *params),
+            ).fetchall()
+        return {
+            "range": range_token,
+            "bucket": _bucket_name(bucket_len),
+            "points": [_point_from_row(r) for r in rows],
+        }
+
+    # Error rows plus a top-N aggregation by normalized error signature.
+    def get_errors(self, range_token: str, *, page: int, page_size: int) -> dict[str, Any]:
+        cutoff, _ = _resolve_range(range_token)
+        if not self.db_path.exists():
+            return {"range": range_token, "items": [], "total": 0, "page": 1, "page_size": page_size, "groups": []}
+        safe_page = max(1, page)
+        safe_size = max(1, min(page_size, 100))
+        offset = (safe_page - 1) * safe_size
+        where, params = _agent_window(cutoff)
+        err_where = f"{where} AND error IS NOT NULL"
+        with self._lock, _connect(self.db_path) as db:
+            total = int(
+                (db.execute(f"SELECT COUNT(*) AS c FROM turns WHERE {err_where}", params).fetchone() or {"c": 0})["c"]
+                or 0
+            )
+            rows = db.execute(
+                f"""
+                SELECT id, ts, session_key, user_msg, error
+                FROM turns
+                WHERE {err_where}
+                ORDER BY ts DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                (*params, safe_size, offset),
+            ).fetchall()
+            group_rows = db.execute(
+                f"""
+                SELECT error, COUNT(*) AS count, MAX(ts) AS last_ts
+                FROM turns
+                WHERE {err_where}
+                GROUP BY substr(error, 1, 80)
+                ORDER BY count DESC, last_ts DESC
+                LIMIT 8
+                """,
+                params,
+            ).fetchall()
+        return {
+            "range": range_token,
+            "items": [_error_row(r) for r in rows],
+            "total": total,
+            "page": safe_page,
+            "page_size": safe_size,
+            "groups": [_error_group(r) for r in group_rows],
+        }
+
+
+def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> None:
+    reader = ObserveDashboardReader(workspace)
+
+    @app.get("/api/dashboard/observe/overview")
+    def observe_overview(range: str = "24h") -> dict[str, Any]:
+        return reader.get_overview(range)
+
+    @app.get("/api/dashboard/observe/timeseries")
+    def observe_timeseries(range: str = "24h") -> dict[str, Any]:
+        return reader.get_timeseries(range)
+
+    @app.get("/api/dashboard/observe/errors")
+    def observe_errors(range: str = "24h", page: int = 1, page_size: int = 25) -> dict[str, Any]:
+        return reader.get_errors(range, page=page, page_size=page_size)
+
+
+# Build the shared WHERE clause: agent turns, optionally bounded by cutoff.
+def _agent_window(cutoff: str | None) -> tuple[str, tuple[Any, ...]]:
+    if cutoff is None:
+        return "source = 'agent'", ()
+    return "source = 'agent' AND ts >= ?", (cutoff,)
+
+
+def _bucket_name(bucket_len: int) -> str:
+    return "hour" if bucket_len == 13 else "day"
+
+
+def _rate(hit: int, total: int) -> float | None:
+    return (hit / total) if total > 0 else None
+
+
+def _overview_from_row(row: sqlite3.Row | None, range_token: str) -> dict[str, Any]:
+    if row is None:
+        return _empty_overview(range_token)
+    turns = int(row["turns"] or 0)
+    errors = int(row["errors"] or 0)
+    cache_prompt = int(row["cache_prompt_tokens"] or 0)
+    cache_hit = int(row["cache_hit_tokens"] or 0)
+    return {
+        "range": range_token,
+        "turns": turns,
+        "errors": errors,
+        "error_rate": _rate(errors, turns),
+        "input_tokens": int(row["input_tokens"] or 0),
+        "cache_prompt_tokens": cache_prompt,
+        "cache_hit_tokens": cache_hit,
+        "cache_hit_rate": _rate(cache_hit, cache_prompt),
+        "avg_iteration": float(row["avg_iteration"]) if row["avg_iteration"] is not None else None,
+        "max_iteration": int(row["max_iteration"] or 0),
+        "last_ts": row["last_ts"],
+    }
+
+
+def _empty_overview(range_token: str) -> dict[str, Any]:
+    return {
+        "range": range_token,
+        "turns": 0,
+        "errors": 0,
+        "error_rate": None,
+        "input_tokens": 0,
+        "cache_prompt_tokens": 0,
+        "cache_hit_tokens": 0,
+        "cache_hit_rate": None,
+        "avg_iteration": None,
+        "max_iteration": 0,
+        "last_ts": None,
+    }
+
+
+def _point_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    cache_prompt = int(row["cache_prompt_tokens"] or 0)
+    cache_hit = int(row["cache_hit_tokens"] or 0)
+    return {
+        "bucket": row["bucket"],
+        "turns": int(row["turns"] or 0),
+        "errors": int(row["errors"] or 0),
+        "input_tokens": int(row["input_tokens"] or 0),
+        "cache_hit_rate": _rate(cache_hit, cache_prompt),
+        "avg_iteration": float(row["avg_iteration"]) if row["avg_iteration"] is not None else None,
+    }
+
+
+def _error_row(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": int(row["id"]),
+        "ts": row["ts"],
+        "session_key": row["session_key"],
+        "user_preview": _preview(row["user_msg"], 80),
+        "error": _preview(row["error"], 200),
+    }
+
+
+def _error_group(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "signature": _preview(row["error"], 80),
+        "count": int(row["count"] or 0),
+        "last_ts": row["last_ts"],
+    }
+
+
+def _preview(value: Any, limit: int) -> str:
+    text = str(value or "").replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+@contextmanager
+def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -1,0 +1,270 @@
+/// <reference path="../../types/akashic-dashboard.d.ts" />
+import { useEffect, useState, type ReactElement } from "react";
+import { MetricTile, BarChart, Chip, api } from "@akashic/dashboard-ui";
+
+interface Overview {
+  range: string;
+  turns: number;
+  errors: number;
+  error_rate: number | null;
+  input_tokens: number;
+  cache_prompt_tokens: number;
+  cache_hit_tokens: number;
+  cache_hit_rate: number | null;
+  avg_iteration: number | null;
+  max_iteration: number;
+  last_ts: string | null;
+}
+
+interface SeriesPoint {
+  bucket: string;
+  turns: number;
+  errors: number;
+  input_tokens: number;
+  cache_hit_rate: number | null;
+  avg_iteration: number | null;
+}
+
+interface ErrorRow {
+  id: number;
+  ts: string;
+  session_key: string;
+  user_preview: string;
+  error: string;
+}
+
+interface ErrorGroup {
+  signature: string;
+  count: number;
+  last_ts: string;
+}
+
+const RANGES: { key: string; label: string }[] = [
+  { key: "24h", label: "24 小时" },
+  { key: "7d", label: "7 天" },
+  { key: "30d", label: "30 天" },
+  { key: "all", label: "全部" },
+];
+
+function _compact(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+function _pct(value: number | null): string {
+  return typeof value === "number" ? `${(value * 100).toFixed(1)}%` : "—";
+}
+
+// Shorten an ISO-bucket label: "2026-06-17T11" -> "11:00", "2026-06-17" -> "6-17".
+function _bucketLabel(bucket: string): string {
+  if (bucket.includes("T")) {
+    const hour = bucket.slice(11, 13);
+    return `${hour}:00`;
+  }
+  const [, m, d] = bucket.split("-");
+  return m && d ? `${Number(m)}-${d}` : bucket;
+}
+
+function _shortTs(value: string): string {
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value || "—";
+  return `${dt.getMonth() + 1}-${String(dt.getDate()).padStart(2, "0")} ${String(dt.getHours()).padStart(2, "0")}:${String(dt.getMinutes()).padStart(2, "0")}`;
+}
+
+// Grafana-style monitoring overview over the agent-loop telemetry in observe.db:
+// KPI tiles (turns / errors / KV hit rate / iterations) + trend charts + errors.
+function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
+  const [range, setRange] = useState<string>("24h");
+  const [overview, setOverview] = useState<Overview | null>(null);
+  const [points, setPoints] = useState<SeriesPoint[]>([]);
+  const [errorRows, setErrorRows] = useState<ErrorRow[]>([]);
+  const [groups, setGroups] = useState<ErrorGroup[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const [ov, series, errs] = await Promise.all([
+        api<Overview>(`/api/dashboard/observe/overview?range=${range}`),
+        api<{ points: SeriesPoint[] }>(`/api/dashboard/observe/timeseries?range=${range}`),
+        api<{ items: ErrorRow[]; groups: ErrorGroup[] }>(`/api/dashboard/observe/errors?range=${range}&page=1&page_size=30`),
+      ]);
+      if (!alive) return;
+      setOverview(ov);
+      setPoints(series.points ?? []);
+      setErrorRows(errs.items ?? []);
+      setGroups(errs.groups ?? []);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [range]);
+
+  if (!overview) {
+    return <div className="p-5 text-[13px] text-muted">加载中…</div>;
+  }
+
+  const turnSpark = points.map((p) => p.turns);
+  const errorSpark = points.map((p) => p.errors);
+  const hitSpark = points.map((p) => (p.cache_hit_rate ?? 0) * 100);
+  const iterSpark = points.map((p) => p.avg_iteration ?? 0);
+
+  return (
+    <div className="p-5">
+      {/* header + range switcher */}
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="detail-title">Observe · 监测</div>
+          <div className="detail-subtext">Agent 主循环遥测 · Token / 迭代 / 错误</div>
+        </div>
+        <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
+          {RANGES.map((r) => (
+            <button
+              key={r.key}
+              onClick={() => setRange(r.key)}
+              className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-colors ${
+                range === r.key ? "bg-accent text-accent-ink" : "text-muted hover:text-fg"
+              }`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* KPI tiles */}
+      <div className="mt-5 grid grid-cols-4 gap-3">
+        <MetricTile
+          label="对话轮数"
+          value={_compact(overview.turns)}
+          sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"}
+          tone="accent"
+          spark={turnSpark}
+        />
+        <MetricTile
+          label="错误"
+          value={_compact(overview.errors)}
+          unit={overview.error_rate != null ? `· ${_pct(overview.error_rate)}` : undefined}
+          sub="error 非空轮次"
+          tone="danger"
+          spark={errorSpark}
+        />
+        <MetricTile
+          label="KV 缓存命中率"
+          value={_pct(overview.cache_hit_rate)}
+          sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`}
+          tone="success"
+          spark={hitSpark}
+        />
+        <MetricTile
+          label="平均迭代"
+          value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"}
+          unit={`· 峰 ${overview.max_iteration}`}
+          sub="每轮 LLM 调用次数"
+          tone="warning"
+          spark={iterSpark}
+        />
+      </div>
+
+      {/* trend charts */}
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">输入 Token 趋势</div>
+          <BarChart
+            points={points.map((p) => ({ label: _bucketLabel(p.bucket), value: p.input_tokens }))}
+            tone="accent"
+            valueFmt={_compact}
+          />
+        </div>
+        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">错误趋势</div>
+          <BarChart
+            points={points.map((p) => ({ label: _bucketLabel(p.bucket), value: p.errors }))}
+            tone="danger"
+            valueFmt={(n) => String(n)}
+          />
+        </div>
+      </div>
+
+      {/* error aggregation + recent errors */}
+      <div className="mt-4 grid grid-cols-[280px_1fr] gap-3">
+        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
+          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">错误聚合 · Top</div>
+          {groups.length === 0 ? (
+            <div className="text-[12.5px] text-muted">无错误 🎉</div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {groups.map((g, i) => (
+                <div key={i} className="flex items-center justify-between gap-2">
+                  <span className="truncate text-[12px] text-fg" title={g.signature}>{g.signature}</span>
+                  <Chip tone="danger">{g.count}</Chip>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
+          <div className="border-b border-border-strong bg-surface-2 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">
+            最近错误
+          </div>
+          <div className="max-h-[36vh] overflow-auto">
+            {errorRows.length === 0 ? (
+              <div className="px-3 py-4 text-[12.5px] text-muted">区间内无错误记录。</div>
+            ) : (
+              errorRows.map((row) => (
+                <div key={row.id} className="border-b border-border px-3 py-2 last:border-b-0 hover:bg-surface-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-mono text-[11px] tabular-nums text-muted">{row.session_key}</span>
+                    <span className="font-mono text-[10px] tabular-nums text-subtle">{_shortTs(row.ts)}</span>
+                  </div>
+                  <div className="mt-1 truncate text-[12.5px] text-danger" title={row.error}>{row.error}</div>
+                  {row.user_preview && (
+                    <div className="mt-0.5 truncate text-[11.5px] text-subtle" title={row.user_preview}>{row.user_preview}</div>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.AkashicDashboard.registerPlugin({
+  id: "observe",
+  label: "Observe 监测",
+  viewLabel: "observe",
+  layout: "workbench",
+  pageSize: 30,
+  rowKey: "id",
+
+  countTitle(total: number): string {
+    return `${total} 轮遥测`;
+  },
+
+  columns: [
+    { key: "session_key", label: "Session", width: 120, cellClass: "mono cell-session", rawTitle: true },
+    { key: "ts", label: "Time", width: 96, fmt: "mono-time", cellClass: "mono cell-time", rawTitle: true },
+    { key: "error", label: "Error", flex: true, cellClass: "content-preview" },
+  ],
+
+  async getCount(): Promise<number | null> {
+    try {
+      const ov = await api<Overview>("/api/dashboard/observe/overview?range=all");
+      return ov.turns || 0;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetchPage({ page, pageSize }: { page: number; pageSize: number }) {
+    const data = await api<{ items: Record<string, unknown>[]; total: number }>(
+      `/api/dashboard/observe/errors?range=all&page=${page}&page_size=${pageSize}`,
+    );
+    return { items: data.items || [], total: data.total || 0 };
+  },
+
+  Main: ObserveMain,
+});

--- a/tests/test_observe_dashboard.py
+++ b/tests/test_observe_dashboard.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from plugins.observe.db import open_db
+from plugins.observe.dashboard import ObserveDashboardReader
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _insert_turn(conn: Any, **fields: Any) -> None:
+    cols = ", ".join(fields.keys())
+    placeholders = ", ".join("?" for _ in fields)
+    conn.execute(
+        f"INSERT INTO turns ({cols}) VALUES ({placeholders})",
+        tuple(fields.values()),
+    )
+
+
+def _seed(workspace: Path) -> None:
+    db_path = workspace / "observe" / "observe.db"
+    conn = open_db(db_path)
+    now = datetime.now(timezone.utc)
+    # Two recent agent turns: one healthy with cache, one errored.
+    _insert_turn(
+        conn,
+        ts=_iso(now - timedelta(hours=1)),
+        source="agent",
+        session_key="telegram:1",
+        user_msg="hello",
+        react_input_sum_tokens=1000,
+        react_cache_prompt_tokens=800,
+        react_cache_hit_tokens=600,
+        react_iteration_count=2,
+    )
+    _insert_turn(
+        conn,
+        ts=_iso(now - timedelta(hours=2)),
+        source="agent",
+        session_key="cli:local",
+        user_msg="boom",
+        react_input_sum_tokens=500,
+        react_iteration_count=5,
+        error="ValueError: bad provider response",
+    )
+    # An old turn outside the 24h window — must be excluded from 24h aggregates.
+    _insert_turn(
+        conn,
+        ts=_iso(now - timedelta(days=5)),
+        source="agent",
+        session_key="telegram:1",
+        user_msg="ancient",
+        react_input_sum_tokens=9999,
+        react_iteration_count=1,
+    )
+    # A non-agent row — must never be counted.
+    _insert_turn(
+        conn,
+        ts=_iso(now - timedelta(hours=1)),
+        source="proactive",
+        session_key="telegram:1",
+        react_input_sum_tokens=123,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_overview_aggregates_within_window(tmp_path) -> None:
+    _seed(tmp_path)
+    reader = ObserveDashboardReader(tmp_path)
+    ov = reader.get_overview("24h")
+    # Only the two recent agent turns count.
+    assert ov["turns"] == 2
+    assert ov["errors"] == 1
+    assert ov["error_rate"] == 0.5
+    assert ov["input_tokens"] == 1500
+    assert ov["cache_prompt_tokens"] == 800
+    assert ov["cache_hit_tokens"] == 600
+    assert ov["cache_hit_rate"] == 0.75
+    assert ov["avg_iteration"] == 3.5
+    assert ov["max_iteration"] == 5
+
+
+def test_overview_all_range_includes_old(tmp_path) -> None:
+    _seed(tmp_path)
+    reader = ObserveDashboardReader(tmp_path)
+    ov = reader.get_overview("all")
+    # All three agent turns (recent two + ancient one); proactive still excluded.
+    assert ov["turns"] == 3
+    assert ov["input_tokens"] == 1500 + 9999
+
+
+def test_timeseries_buckets_by_hour(tmp_path) -> None:
+    _seed(tmp_path)
+    reader = ObserveDashboardReader(tmp_path)
+    ts = reader.get_timeseries("24h")
+    assert ts["bucket"] == "hour"
+    # Two recent turns fall in two distinct hour buckets.
+    assert len(ts["points"]) == 2
+    assert sum(p["turns"] for p in ts["points"]) == 2
+    assert sum(p["errors"] for p in ts["points"]) == 1
+
+
+def test_errors_list_and_groups(tmp_path) -> None:
+    _seed(tmp_path)
+    reader = ObserveDashboardReader(tmp_path)
+    res = reader.get_errors("24h", page=1, page_size=25)
+    assert res["total"] == 1
+    assert len(res["items"]) == 1
+    assert res["items"][0]["error"].startswith("ValueError")
+    assert res["items"][0]["session_key"] == "cli:local"
+    assert len(res["groups"]) == 1
+    assert res["groups"][0]["count"] == 1
+
+
+def test_missing_db_returns_empty(tmp_path) -> None:
+    reader = ObserveDashboardReader(tmp_path)
+    ov = reader.get_overview("24h")
+    assert ov["turns"] == 0
+    assert ov["cache_hit_rate"] is None
+    assert reader.get_timeseries("24h")["points"] == []
+    assert reader.get_errors("24h", page=1, page_size=25)["total"] == 0


### PR DESCRIPTION
## 概述

接续 #83 的设计系统,新增一个 **Grafana 风格的通用监测面板**,数据源是 agent 主循环遥测库 `observe.db` 的 `turns` 表 —— 这些指标此前**仅落库、未暴露任何接口**。

调查发现 akashic 已有非常完整的可观测性数据(observe / proactive / memory2 等 7 个数据源),其中 `observe.db` 是含金量最高、却唯一没读接口的一个,故优先落地。

## 后端 `plugins/observe/dashboard.py`

`ObserveDashboardReader`,按时间窗(`24h`/`7d`/`30d`/`all`)聚合,三个只读接口:

- `GET /api/dashboard/observe/overview` — KPI:对话轮数、错误数/率、KV 命中率、平均/峰值迭代、输入 token
- `GET /api/dashboard/observe/timeseries` — 按小时/天分桶的趋势(用 `substr` 切 ISO `ts`,字典序即时间序,不依赖 sqlite 日期解析)
- `GET /api/dashboard/observe/errors` — 错误明细 + 按签名 Top-N 聚合

## 前端监测原子(`charts.tsx`,经 SDK 共享给插件)

- `MetricTile` — 大号 tabular-nums KPI 卡 + 内联 sparkline
- `Sparkline` — 归一化 SVG 面积折线
- `BarChart` — 分桶柱状趋势

均为轻量自研 SVG,沿用工业风 tokens,无新增图表依赖。

## 监测页 `plugins/observe/dashboard_panel.tsx`(workbench)

RangePicker + 4 个 KPI 卡 + Token/错误趋势图 + 错误聚合/最近错误。覆盖本次选定的维度:**Token & KV cache / ReAct 迭代健康度 / 错误聚合**。

## 验证

- `tests/test_observe_dashboard.py` 5 例(窗口过滤、all 范围、分桶、错误聚合、缺库降级)全绿
- `tsc --noEmit` + `npm run build` 通过
- **CDP 实测**(headless chromium 连真实 2236 实例):监测页正确渲染真实数据(2630 轮 / KV 73.5% / 平均迭代 1.6),**零 console 错误**,左栏 section 计数正确

## 备注

- 构建产物(`plugins/observe/dashboard_panel.js`、`static/dashboard/`)已 gitignore,全新 clone 需 `npm run build`
- 沿用 #83 的 React 单实例插件架构,observe 作为自包含插件被自动发现挂载