### PR TITLE
feat(observe): 优化监测页趋势图

### DIFF
--- a/frontend/dashboard/public/sdk/ui.js
+++ b/frontend/dashboard/public/sdk/ui.js
@@ -3,7 +3,7 @@
 const U = window.__akashicRuntime.UI;
 export const {
   ShortcutKey, Label, FieldLabel, Tile, Btn, Chip, Input, SearchInput, Select,
-  BrandMark, useTheme, ThemeToggle, cn, Pie, MetricTile, Sparkline, BarChart,
+  BrandMark, useTheme, ThemeToggle, cn, Pie, MetricTile, Sparkline, TrendChart,
   api, asPageResult, pageCount,
 } = U;
 export default U;

--- a/frontend/dashboard/src/design/charts.tsx
+++ b/frontend/dashboard/src/design/charts.tsx
@@ -1,4 +1,15 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart as RBarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { cn } from "./cn";
 
 // Shared accent palette for the monitoring atoms below — resolved to the
@@ -13,10 +24,13 @@ const TONE_RGB: Record<ChartTone, string> = {
   muted: "var(--color-muted-rgb)",
 };
 
+const toneColor = (tone: ChartTone): string => `rgb(${TONE_RGB[tone]})`;
+
+const AXIS_TICK = { fontSize: 10, fill: "rgba(138,138,143,0.6)", fontFamily: "JetBrains Mono, monospace" };
+const GRID_STROKE = "rgba(255,255,255,0.07)";
+
 // Hand-rolled SVG pie — a 2-slice hit/miss filled pie with a glossy, dimensional
 // finish (radial sheen + drop shadow + rim) and a sweep-in animation on mount.
-// Lightweight (no charting lib), themed with the industrial tokens, and exposed
-// via the dashboard SDK so plugins render it as a shared React component.
 export function Pie({
   rate,
   hit,
@@ -123,13 +137,14 @@ export function Pie({
   );
 }
 
-// MetricTile — a KPI card: a big tabular-nums value with an optional unit, a
-// secondary line (delta / context), and an inline sparkline. The workhorse of
-// the monitoring overview.
+// MetricTile — a KPI card: a big tabular-nums value, an optional delta badge and
+// unit, a secondary line, and an inline sparkline. The workhorse of the
+// monitoring overview. Matches the superlog density (36px value, 14px radius).
 export function MetricTile({
   label,
   value,
   unit,
+  delta,
   sub,
   tone = "accent",
   spark,
@@ -138,21 +153,30 @@ export function MetricTile({
   label: string;
   value: ReactNode;
   unit?: string;
+  delta?: number | null;
   sub?: ReactNode;
   tone?: ChartTone;
   spark?: number[];
   className?: string;
 }) {
   return (
-    <div className={cn("relative overflow-hidden rounded-lg border border-border bg-surface p-4 shadow-lift-sm", className)}>
-      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">{label}</span>
-      <div className="mt-2 flex items-baseline gap-1.5">
-        <span className="font-mono text-[26px] font-semibold leading-none tracking-tight tabular-nums text-fg">{value}</span>
-        {unit && <span className="font-mono text-[12px] text-muted">{unit}</span>}
+    <div className={cn("relative overflow-hidden rounded-2xl border border-border bg-surface p-5 shadow-lift-sm", className)}>
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{label}</span>
+        {typeof delta === "number" && (
+          <span className={cn("font-mono text-[11px] tabular-nums", delta >= 0 ? "text-success" : "text-danger")}>
+            {delta >= 0 ? "+" : ""}
+            {delta.toFixed(1)}%
+          </span>
+        )}
       </div>
-      {sub && <div className="mt-1.5 font-mono text-[11px] tabular-nums text-muted">{sub}</div>}
+      <div className="mt-3 flex items-baseline gap-1.5">
+        <span className="font-sans text-4xl font-semibold leading-none tracking-tight tabular-nums text-fg">{value}</span>
+        {unit && <span className="font-mono text-[11px] text-subtle">{unit}</span>}
+      </div>
+      {sub && <div className="mt-2 font-mono text-[11px] tabular-nums text-muted">{sub}</div>}
       {spark && spark.length > 1 && (
-        <Sparkline data={spark} tone={tone} className="mt-3 w-full" height={28} />
+        <Sparkline data={spark} tone={tone} className="mt-4 w-full" height={40} />
       )}
     </div>
   );
@@ -163,7 +187,7 @@ export function MetricTile({
 export function Sparkline({
   data,
   tone = "accent",
-  height = 32,
+  height = 40,
   className,
 }: {
   data: number[];
@@ -173,19 +197,19 @@ export function Sparkline({
 }) {
   const uid = useId().replace(/:/g, "");
   const w = 100;
-  const h = 32;
+  const h = 40;
   const max = Math.max(...data, 1);
   const min = Math.min(...data, 0);
   const span = max - min || 1;
   const step = data.length > 1 ? w / (data.length - 1) : w;
   const pts = data.map((v, i) => {
     const x = i * step;
-    const y = h - ((v - min) / span) * h;
+    const y = h - ((v - min) / span) * (h - 2) - 1;
     return [x, Math.max(1, Math.min(h - 1, y))] as const;
   });
   const line = pts.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`).join(" ");
   const area = `${line} L ${w} ${h} L 0 ${h} Z`;
-  const rgb = TONE_RGB[tone];
+  const color = toneColor(tone);
   return (
     <svg
       viewBox={`0 0 ${w} ${h}`}
@@ -195,69 +219,107 @@ export function Sparkline({
     >
       <defs>
         <linearGradient id={`spark-${uid}`} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={`rgb(${rgb})`} stopOpacity="0.32" />
-          <stop offset="100%" stopColor={`rgb(${rgb})`} stopOpacity="0" />
+          <stop offset="0%" stopColor={color} stopOpacity="0.3" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
         </linearGradient>
       </defs>
       <path d={area} fill={`url(#spark-${uid})`} />
-      <path d={line} fill="none" stroke={`rgb(${rgb})`} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+      <path d={line} fill="none" stroke={color} strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
     </svg>
   );
 }
 
-// BarChart — a bucketed bar series with a baseline grid line and per-bar hover
-// titles. Used for token / error / iteration trends over time.
-export function BarChart({
-  points,
-  height = 140,
+// Tooltip styled to the industrial tokens, shared by all recharts surfaces.
+const TOOLTIP_CONTENT_STYLE = {
+  background: "rgb(var(--color-surface-2-rgb))",
+  border: "1px solid var(--color-border-strong)",
+  borderRadius: 8,
+  fontSize: 11,
+  fontFamily: "JetBrains Mono, monospace",
+  padding: "6px 10px",
+  boxShadow: "0 8px 24px -6px rgba(0,0,0,0.6)",
+};
+
+// TrendChart — a recharts area/bar time series with a dashed horizontal grid,
+// muted axis ticks (Y + sparse X), and a themed floating tooltip. This is what
+// gives the monitoring page its precision-instrument feel.
+export function TrendChart({
+  data,
+  kind = "area",
   tone = "accent",
+  height = 170,
   valueFmt = (n: number) => String(n),
   className,
+  empty,
 }: {
-  points: { label: string; value: number }[];
-  height?: number;
+  data: { label: string; value: number }[];
+  kind?: "area" | "bar";
   tone?: ChartTone;
+  height?: number;
   valueFmt?: (n: number) => string;
   className?: string;
+  empty?: ReactNode;
 }) {
-  const rgb = TONE_RGB[tone];
-  const max = Math.max(...points.map((p) => p.value), 1);
-  if (points.length === 0) {
+  const uid = useId().replace(/:/g, "");
+  const color = toneColor(tone);
+  const allZero = data.every((d) => d.value === 0);
+  if (data.length === 0 || (allZero && empty)) {
     return (
       <div className={cn("flex items-center justify-center text-[12px] text-subtle", className)} style={{ height }}>
-        暂无数据
+        {empty ?? "暂无数据"}
       </div>
     );
   }
+  const axisProps = {
+    tick: AXIS_TICK,
+    axisLine: false as const,
+    tickLine: false as const,
+  };
   return (
-    <div className={cn("relative", className)} style={{ height }}>
-      <div className="absolute inset-x-0 bottom-5 top-2 border-b border-border" />
-      <div className="absolute inset-x-0 bottom-5 top-2 flex items-end gap-[2px]">
-        {points.map((p, i) => {
-          const frac = p.value / max;
-          return (
-            <div
-              key={`${p.label}-${i}`}
-              className="group relative flex-1 cursor-default"
-              style={{ height: "100%" }}
-              title={`${p.label} · ${valueFmt(p.value)}`}
-            >
-              <div
-                className="absolute bottom-0 w-full rounded-t-[2px] transition-[height] duration-300"
-                style={{
-                  height: `${Math.max(frac * 100, p.value > 0 ? 2 : 0)}%`,
-                  background: `linear-gradient(to top, rgb(${rgb} / 0.55), rgb(${rgb} / 0.95))`,
-                }}
-              />
-            </div>
-          );
-        })}
-      </div>
-      <div className="absolute inset-x-0 bottom-0 flex justify-between font-mono text-[9px] tabular-nums text-subtle">
-        <span>{points[0]?.label}</span>
-        {points.length > 2 && <span>{points[Math.floor(points.length / 2)]?.label}</span>}
-        <span>{points[points.length - 1]?.label}</span>
-      </div>
+    <div className={className} style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        {kind === "area" ? (
+          <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id={`trend-${uid}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity="0.28" />
+                <stop offset="100%" stopColor={color} stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={GRID_STROKE} />
+            <XAxis dataKey="label" {...axisProps} minTickGap={28} />
+            <YAxis {...axisProps} width={42} tickFormatter={valueFmt} />
+            <Tooltip
+              cursor={{ stroke: GRID_STROKE }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              labelStyle={{ color: "rgb(var(--color-subtle-rgb))", marginBottom: 2 }}
+              itemStyle={{ color: "rgb(var(--color-fg-rgb))" }}
+              formatter={(v) => [valueFmt(Number(v)), ""] as [string, string]}
+            />
+            <Area type="monotone" dataKey="value" stroke={color} strokeWidth={1.5} fill={`url(#trend-${uid})`} dot={false} activeDot={{ r: 3, fill: color }} />
+          </AreaChart>
+        ) : (
+          <RBarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id={`bar-${uid}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity="0.95" />
+                <stop offset="100%" stopColor={color} stopOpacity="0.5" />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={GRID_STROKE} />
+            <XAxis dataKey="label" {...axisProps} minTickGap={28} />
+            <YAxis {...axisProps} width={42} tickFormatter={valueFmt} />
+            <Tooltip
+              cursor={{ fill: "rgba(255,255,255,0.04)" }}
+              contentStyle={TOOLTIP_CONTENT_STYLE}
+              labelStyle={{ color: "rgb(var(--color-subtle-rgb))", marginBottom: 2 }}
+              itemStyle={{ color: "rgb(var(--color-fg-rgb))" }}
+              formatter={(v) => [valueFmt(Number(v)), ""] as [string, string]}
+            />
+            <Bar dataKey="value" fill={`url(#bar-${uid})`} radius={[2, 2, 0, 0]} maxBarSize={28} />
+          </RBarChart>
+        )}
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/frontend/dashboard/src/design/sdk.ts
+++ b/frontend/dashboard/src/design/sdk.ts
@@ -4,6 +4,6 @@
 // component implementations and its single React instance.
 export * from "./ui";
 export { cn } from "./cn";
-export { Pie, MetricTile, Sparkline, BarChart } from "./charts";
+export { Pie, MetricTile, Sparkline, TrendChart } from "./charts";
 export type { ChartTone } from "./charts";
 export { api, asPageResult, pageCount } from "../api";

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -713,15 +713,17 @@ function TopbarFilters(props: {
 }): React.ReactElement {
   return (
     <div className="topbar-filters">
-      {props.viewMode.startsWith("plugin:") && props.currentPlugin?.renderFilters && props.currentPluginState && props.onSetPluginState
-        ? <PluginFilters
-            plugin={props.currentPlugin}
-            pluginId={props.currentPlugin.id}
-            state={props.currentPluginState}
-            onSetState={props.onSetPluginState}
-            onActivate={() => {}}
-          />
-        : props.viewMode === "proactive" ? (
+      {props.viewMode.startsWith("plugin:") ? (
+          props.currentPlugin?.renderFilters && props.currentPluginState && props.onSetPluginState
+            ? <PluginFilters
+                plugin={props.currentPlugin}
+                pluginId={props.currentPlugin.id}
+                state={props.currentPluginState}
+                onSetState={props.onSetPluginState}
+                onActivate={() => {}}
+              />
+            : null
+        ) : props.viewMode === "proactive" ? (
           <div className="filter-row">
             <div className="active-session-chip"><span>result</span><code>{proactiveSectionLabel(props.proactiveSection)}</code></div>
             {props.proactiveSessionFilter && <Chip label="session" value={props.proactiveSessionFilter} onClear={props.clearProactiveSession} />}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^2.6.0"
   }
 }

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -1,6 +1,6 @@
 /// <reference path="../../types/akashic-dashboard.d.ts" />
-import { useEffect, useState, type ReactElement } from "react";
-import { MetricTile, BarChart, Chip, api } from "@akashic/dashboard-ui";
+import { useEffect, useState, type ReactElement, type ReactNode } from "react";
+import { MetricTile, TrendChart, Chip, api } from "@akashic/dashboard-ui";
 
 interface Overview {
   range: string;
@@ -49,7 +49,7 @@ const RANGES: { key: string; label: string }[] = [
 function _compact(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
-  return String(value);
+  return String(Math.round(value));
 }
 
 function _pct(value: number | null): string {
@@ -58,10 +58,7 @@ function _pct(value: number | null): string {
 
 // Shorten an ISO-bucket label: "2026-06-17T11" -> "11:00", "2026-06-17" -> "6-17".
 function _bucketLabel(bucket: string): string {
-  if (bucket.includes("T")) {
-    const hour = bucket.slice(11, 13);
-    return `${hour}:00`;
-  }
+  if (bucket.includes("T")) return `${bucket.slice(11, 13)}:00`;
   const [, m, d] = bucket.split("-");
   return m && d ? `${Number(m)}-${d}` : bucket;
 }
@@ -72,8 +69,29 @@ function _shortTs(value: string): string {
   return `${dt.getMonth() + 1}-${String(dt.getDate()).padStart(2, "0")} ${String(dt.getHours()).padStart(2, "0")}:${String(dt.getMinutes()).padStart(2, "0")}`;
 }
 
-// Grafana-style monitoring overview over the agent-loop telemetry in observe.db:
-// KPI tiles (turns / errors / KV hit rate / iterations) + trend charts + errors.
+// Percentage change of the last bucket vs the previous one, for the tile delta.
+function _delta(values: number[]): number | null {
+  if (values.length < 2) return null;
+  const last = values[values.length - 1];
+  const prev = values[values.length - 2];
+  if (!prev) return null;
+  return ((last - prev) / prev) * 100;
+}
+
+// A monitoring widget card with a hairline header — mirrors the superlog widget
+// chrome (uppercase mono title, bottom-bordered header, padded body).
+function Card({ title, children, bodyClass }: { title: string; children: ReactNode; bodyClass?: string }): ReactElement {
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{title}</h3>
+      </div>
+      <div className={bodyClass ?? "p-4"}>{children}</div>
+    </div>
+  );
+}
+
+// Grafana-style monitoring overview over observe.db agent-loop telemetry.
 function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   const [range, setRange] = useState<string>("24h");
   const [overview, setOverview] = useState<Overview | null>(null);
@@ -101,16 +119,19 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   }, [range]);
 
   if (!overview) {
-    return <div className="p-5 text-[13px] text-muted">加载中…</div>;
+    return <div className="p-6 text-[13px] text-muted">加载中…</div>;
   }
 
-  const turnSpark = points.map((p) => p.turns);
-  const errorSpark = points.map((p) => p.errors);
-  const hitSpark = points.map((p) => (p.cache_hit_rate ?? 0) * 100);
-  const iterSpark = points.map((p) => p.avg_iteration ?? 0);
+  const turnSeries = points.map((p) => p.turns);
+  const errorSeries = points.map((p) => p.errors);
+  const tokenSeries = points.map((p) => p.input_tokens);
+  const hitSeries = points.map((p) => (p.cache_hit_rate ?? 0) * 100);
+  const iterSeries = points.map((p) => p.avg_iteration ?? 0);
+
+  const labelled = (vals: number[]) => points.map((p, i) => ({ label: _bucketLabel(p.bucket), value: vals[i] }));
 
   return (
-    <div className="p-5">
+    <div className="flex flex-col gap-4 p-6">
       {/* header + range switcher */}
       <div className="flex items-end justify-between">
         <div>
@@ -133,63 +154,58 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
       </div>
 
       {/* KPI tiles */}
-      <div className="mt-5 grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-4 gap-4">
         <MetricTile
           label="对话轮数"
           value={_compact(overview.turns)}
+          delta={_delta(turnSeries)}
           sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"}
           tone="accent"
-          spark={turnSpark}
+          spark={turnSeries}
         />
         <MetricTile
           label="错误"
           value={_compact(overview.errors)}
-          unit={overview.error_rate != null ? `· ${_pct(overview.error_rate)}` : undefined}
-          sub="error 非空轮次"
+          sub={overview.error_rate != null ? `错误率 ${_pct(overview.error_rate)}` : "error 非空轮次"}
           tone="danger"
-          spark={errorSpark}
+          spark={errorSeries}
         />
         <MetricTile
           label="KV 缓存命中率"
           value={_pct(overview.cache_hit_rate)}
           sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`}
           tone="success"
-          spark={hitSpark}
+          spark={hitSeries}
         />
         <MetricTile
           label="平均迭代"
           value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"}
-          unit={`· 峰 ${overview.max_iteration}`}
+          unit={`峰 ${overview.max_iteration}`}
           sub="每轮 LLM 调用次数"
           tone="warning"
-          spark={iterSpark}
+          spark={iterSeries}
         />
       </div>
 
       {/* trend charts */}
-      <div className="mt-4 grid grid-cols-2 gap-3">
-        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">输入 Token 趋势</div>
-          <BarChart
-            points={points.map((p) => ({ label: _bucketLabel(p.bucket), value: p.input_tokens }))}
-            tone="accent"
-            valueFmt={_compact}
-          />
-        </div>
-        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">错误趋势</div>
-          <BarChart
-            points={points.map((p) => ({ label: _bucketLabel(p.bucket), value: p.errors }))}
-            tone="danger"
-            valueFmt={(n) => String(n)}
-          />
-        </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Card title="输入 Token 趋势">
+          <TrendChart data={labelled(tokenSeries)} kind="area" tone="accent" valueFmt={_compact} />
+        </Card>
+        <Card title="平均迭代趋势">
+          <TrendChart data={labelled(iterSeries)} kind="area" tone="warning" valueFmt={(n) => n.toFixed(1)} />
+        </Card>
+        <Card title="KV 缓存命中率趋势">
+          <TrendChart data={labelled(hitSeries)} kind="area" tone="success" valueFmt={(n) => `${n.toFixed(0)}%`} />
+        </Card>
+        <Card title="错误趋势">
+          <TrendChart data={labelled(errorSeries)} kind="bar" tone="danger" valueFmt={(n) => String(n)} empty="区间内无错误 🎉" />
+        </Card>
       </div>
 
       {/* error aggregation + recent errors */}
-      <div className="mt-4 grid grid-cols-[280px_1fr] gap-3">
-        <div className="rounded-lg border border-border bg-surface p-4 shadow-lift-sm">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">错误聚合 · Top</div>
+      <div className="grid grid-cols-[300px_1fr] gap-4">
+        <Card title="错误聚合 · Top">
           {groups.length === 0 ? (
             <div className="text-[12.5px] text-muted">无错误 🎉</div>
           ) : (
@@ -202,31 +218,26 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
               ))}
             </div>
           )}
-        </div>
+        </Card>
 
-        <div className="overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
-          <div className="border-b border-border-strong bg-surface-2 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">
-            最近错误
-          </div>
-          <div className="max-h-[36vh] overflow-auto">
-            {errorRows.length === 0 ? (
-              <div className="px-3 py-4 text-[12.5px] text-muted">区间内无错误记录。</div>
-            ) : (
-              errorRows.map((row) => (
-                <div key={row.id} className="border-b border-border px-3 py-2 last:border-b-0 hover:bg-surface-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-mono text-[11px] tabular-nums text-muted">{row.session_key}</span>
-                    <span className="font-mono text-[10px] tabular-nums text-subtle">{_shortTs(row.ts)}</span>
-                  </div>
-                  <div className="mt-1 truncate text-[12.5px] text-danger" title={row.error}>{row.error}</div>
-                  {row.user_preview && (
-                    <div className="mt-0.5 truncate text-[11.5px] text-subtle" title={row.user_preview}>{row.user_preview}</div>
-                  )}
+        <Card title="最近错误" bodyClass="max-h-[34vh] overflow-auto">
+          {errorRows.length === 0 ? (
+            <div className="px-4 py-4 text-[12.5px] text-muted">区间内无错误记录。</div>
+          ) : (
+            errorRows.map((row) => (
+              <div key={row.id} className="border-b border-border px-4 py-2 last:border-b-0 hover:bg-surface-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-[11px] tabular-nums text-muted">{row.session_key}</span>
+                  <span className="font-mono text-[10px] tabular-nums text-subtle">{_shortTs(row.ts)}</span>
                 </div>
-              ))
-            )}
-          </div>
-        </div>
+                <div className="mt-1 truncate text-[12.5px] text-danger" title={row.error}>{row.error}</div>
+                {row.user_preview && (
+                  <div className="mt-0.5 truncate text-[11.5px] text-subtle" title={row.user_preview}>{row.user_preview}</div>
+                )}
+              </div>
+            ))
+          )}
+        </Card>
       </div>
     </div>
   );


### PR DESCRIPTION
## 问题
PR #84 已经合并，但后续本地的 observe 监测页 UI 优化还没有进入 main。

## 改动
- 将 observe 监测页趋势图切到 Recharts 的 area/bar 图。
- 更新 dashboard SDK 导出，从 BarChart 改为 TrendChart。
- 调整指标卡片、错误趋势和插件过滤渲染细节。

## 验证
- npm run typecheck
- npm run lint
- npm run build

## 配置影响
新增前端依赖 recharts，package-lock.json 已无额外 diff。
