### PR TITLE
chore(proactive): 清理无效主动参数

### DIFF
--- a/_handbook/proactive-guide.md
+++ b/_handbook/proactive-guide.md
@@ -223,24 +223,22 @@ d_energy = 1 - energy → "饥渴度"
     电量满 → 不饿 → d_energy 低
     电量空 → 饿了 → d_energy 高
     ↓
-base_score = w_e × d_energy + w_c × 新内容量 + w_r × 最近对话丰富度
+base_score = w_e × d_energy
     ↓
 next_tick_from_score(base_score)
-    base_score > 0.70 → s3（最快）
-    base_score > 0.40 → s2
     base_score > 0.20 → s1
     base_score ≤ 0.20 → s0（最慢）
 ```
 
-**直觉**：你刚说完话，agent 不想烦你，慢悠悠地查（8 分钟一次）。你半天没动静，agent 觉得"该找点东西了"，加速查到 1 分钟一次。
+**直觉**：你刚说完话，agent 不想烦你，慢悠悠地查（8 分钟一次）。你半天没动静，agent 觉得"该找点东西了"，加速查到 4 分钟一次。
 
 三种预设只是调整这张"饥渴→间隔"的映射表：
 
-| 预设 | s0（不饿） | s1 | s2 | s3（很饿） | 适用场景 |
-|------|-----------|-----|-----|-----|----------|
-| `daily` | 8 min | 4 min | 2 min | 1 min | 日常 |
-| `dev_verify` | 1 min | 30 s | 15 s | 10 s | 开发调试 |
-| `quiet` | 30 min | 15 min | 8 min | 4 min | 低打扰 |
+| 预设 | s0（不饿） | s1（很饿） | 适用场景 |
+|------|-----------|------------|----------|
+| `daily` | 8 min | 4 min | 日常 |
+| `dev_verify` | 1 min | 30 s | 开发调试 |
+| `quiet` | 30 min | 15 min | 低打扰 |
 
 每次 tick 后重新算，间隔持续变化——不是定时器，是自适应循环。
 
@@ -252,7 +250,7 @@ judge_send_threshold = 0.65    # 提高发送门槛
 
 [proactive.overrides.trigger]
 tick_interval_s0 = 600         # 不饿时 10 分钟
-tick_interval_s3 = 120         # 很饿时至少 2 分钟
+tick_interval_s1 = 180         # 很饿时至少 3 分钟
 ```
 
 ---

--- a/proactive_v2/anyaction.py
+++ b/proactive_v2/anyaction.py
@@ -155,8 +155,6 @@ class AnyActionGate:
         idle_factor = 1.0 - math.exp(
             -idle_min / max(self._cfg.anyaction_idle_scale_minutes, 1.0)
         )
-        local_hour = now_utc.astimezone(_safe_zone(self._cfg.anyaction_timezone)).hour
-        time_factor = self._time_factor(local_hour)
         p = (
             self._cfg.anyaction_probability_min
             + (
@@ -164,7 +162,6 @@ class AnyActionGate:
                 - self._cfg.anyaction_probability_min
             )
             * idle_factor
-            * time_factor
         )
         p = max(0.0, min(1.0, p))
         draw = (self._rng or _random_module).random()
@@ -173,7 +170,6 @@ class AnyActionGate:
             "used_today": snap.used,
             "remaining_today": remaining,
             "idle_minutes": idle_min,
-            "time_factor": time_factor,
             "p_act": p,
             "draw": draw,
         }
@@ -184,7 +180,3 @@ class AnyActionGate:
             reset_hour=self._cfg.anyaction_reset_hour_local,
             timezone_name=self._cfg.anyaction_timezone,
         )
-
-    @staticmethod
-    def _time_factor(local_hour: int) -> float:
-        return 1.0

--- a/proactive_v2/config.py
+++ b/proactive_v2/config.py
@@ -23,8 +23,6 @@ class ProactiveConfig:
     # Trigger 配置
     tick_interval_s0: int = 4800
     tick_interval_s1: int = 2400
-    tick_interval_s2: int = 1080
-    tick_interval_s3: int = 420
     tick_jitter: float = 0.3
 
     # Gate 配置
@@ -88,7 +86,6 @@ class ProactiveConfig:
     message_dedupe_enabled: bool = True
 
     # 其他
-    threshold: float = 0.70
     recent_chat_messages: int = 20
     interval_seconds: int = 1800
     sleep_modifier_sleeping: float = 0.15

--- a/proactive_v2/config_loader.py
+++ b/proactive_v2/config_loader.py
@@ -76,12 +76,10 @@ def _validate_ranges(config: dict[str, Any]) -> None:
                 f"anyaction_probability_max ({pmax})"
             )
 
-    # tick_interval_s0 >= s1 >= s2 >= s3 >= 1
+    # tick_interval_s0 >= s1 >= 1
     intervals = [
         config.get("tick_interval_s0"),
         config.get("tick_interval_s1"),
-        config.get("tick_interval_s2"),
-        config.get("tick_interval_s3"),
     ]
     if all(x is not None for x in intervals):
         interval_values = [int(cast(int, x)) for x in intervals]
@@ -92,7 +90,7 @@ def _validate_ranges(config: dict[str, Any]) -> None:
                 )
         if interval_values[-1] < 1:
             raise ProactiveConfigError(
-                f"tick_interval_s3 必须 >= 1，当前值: {interval_values[-1]}"
+                f"tick_interval_s1 必须 >= 1，当前值: {interval_values[-1]}"
             )
 
     # context_only_judge_threshold_with_evidence <= context_only_judge_threshold

--- a/proactive_v2/energy.py
+++ b/proactive_v2/energy.py
@@ -1,5 +1,5 @@
 """
-proactive/energy.py — 动态电量衰减与多维主动冲动计算。
+proactive/energy.py — 动态电量衰减与主动冲动计算。
 
 核心思路（多时间尺度指数衰减）：
   E(t) = α·exp(-t/τ₁) + β·exp(-t/τ₂) + γ·exp(-t/τ₃)
@@ -8,15 +8,11 @@ proactive/energy.py — 动态电量衰减与多维主动冲动计算。
   τ₂=240min 中时：同一天语境
   τ₃=2880min 长时：关系连续性（48h）
 
-多维打分模型（新）：
-  base_score = w_e·D_energy + w_c·D_content + w_r·D_recent
-
+贡献函数：
   D_energy  = 1 - energy            互动饥渴度（越久没说话越高）
-  D_content = 1 - exp(-n/halfsat)   信息流新鲜度（新条目越多越高）
   D_recent  = log(1+k)/log(1+scale) 对话语境丰富度（近期消息越多越高）
 
-  draw_score = base_score × random_weight()
-  draw_score > llm_threshold → 调 LLM 反思
+base_score 越高 → next_tick_from_score 给出的间隔越短 → 越快触发。
 """
 
 from __future__ import annotations
@@ -51,7 +47,7 @@ def compute_energy(
     )
 
 
-# ── 三维贡献函数 ───────────────────────────────────────────────────
+# ── 贡献函数 ───────────────────────────────────────────────────────
 
 
 def d_energy(energy: float) -> float:
@@ -61,17 +57,6 @@ def d_energy(energy: float) -> float:
     高电量（刚聊完）→ 贡献小但非零，不再作为硬闸。
     """
     return 1.0 - max(0.0, min(1.0, energy))
-
-
-def d_content(new_items: int, halfsat: float = 3.0) -> float:
-    """信息流新鲜度：新条目越多 → D_content 越高。
-
-    指数饱和曲线：D_content = 1 - exp(-new_items / halfsat)
-    halfsat=3 时：0条→0.00  1条→0.28  3条→0.63  5条→0.81  10条→0.96
-    """
-    if new_items <= 0:
-        return 0.0
-    return 1.0 - math.exp(-max(0, new_items) / max(halfsat, 0.1))
 
 
 def d_recent(msg_count: int, scale: float = 10.0) -> float:
@@ -85,27 +70,12 @@ def d_recent(msg_count: int, scale: float = 10.0) -> float:
     return min(1.0, math.log1p(max(0, msg_count)) / math.log1p(max(scale, 1.0)))
 
 
-def composite_score(
-    de: float,
-    dc: float,
-    dr: float,
-    w_e: float = 0.40,
-    w_c: float = 0.40,
-    w_r: float = 0.20,
-) -> float:
-    """三维加权合成，结果裁剪至 [0, 1]。"""
-    raw = w_e * de + w_c * dc + w_r * dr
-    return max(0.0, min(1.0, raw))
-
-
-# ── tick 间隔（由 base_score 驱动，替代旧的 energy 驱动）───────────
+# ── tick 间隔（由 base_score 驱动）──────────────────────────────────
 
 
 def next_tick_from_score(
     base_score: float,
     *,
-    tick_s3: int = 420,  # base_score > 0.70 → ~7 min
-    tick_s2: int = 1080,  # base_score > 0.40 → ~18 min
     tick_s1: int = 2400,  # base_score > 0.20 → ~40 min
     tick_s0: int = 4800,  # base_score ≤ 0.20 → ~80 min
     tick_jitter: float = 0.3,
@@ -115,27 +85,8 @@ def next_tick_from_score(
 
     base_score 越高 → 间隔越短 → 单位时间内抽签次数越多 → 越快触发。
     """
-    if base_score > 0.70:
-        base = tick_s3
-    elif base_score > 0.40:
-        base = tick_s2
-    elif base_score > 0.20:
-        base = tick_s1
-    else:
-        base = tick_s0
-
+    base = tick_s1 if base_score > 0.20 else tick_s0
     if tick_jitter <= 0:
         return base
     r = (rng or _random).uniform(1.0 - tick_jitter, 1.0 + tick_jitter)
     return max(1, int(base * r))
-
-
-def random_weight(rng: _random.Random | None = None) -> float:
-    """随机扰动系数，防止行为过于规律可预测。
-
-    从 Beta(2, 2) 采样（偏中间，极端少），线性映射到 [0.5, 1.5]。
-    均值 ≈ 1.0，标准差适中。
-    """
-    r = rng or _random
-    sample = r.betavariate(2, 2)  # [0, 1]，均值 0.5
-    return 0.5 + sample  # [0.5, 1.5]

--- a/proactive_v2/event.py
+++ b/proactive_v2/event.py
@@ -169,7 +169,7 @@ class GenericAlertEvent(AlertEvent):
 class ContentEvent(ProactiveEvent, ABC):
     """内容流类事件的抽象基类。
 
-    共同特征：参与 d_content 评分、进 pending queue、进 compose 候选池。
+    共同特征：进 pending queue、进 compose 候选池。
     event_id 由 compute_item_id 确定性生成，始终可作为 ack_id。
     新内容类型（网页搜索、novel-kb 等）继承此类，只需实现 kind / from_xxx()。
     """

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -246,12 +246,9 @@ class ProactiveLoop:
     def _trace_proactive_config_snapshot(self) -> None:
         payload = {
             "enabled": self._cfg.enabled,
-            "threshold": self._cfg.threshold,
             "score_llm_threshold": self._cfg.score_llm_threshold,
             "tick_interval_s0": self._cfg.tick_interval_s0,
             "tick_interval_s1": self._cfg.tick_interval_s1,
-            "tick_interval_s2": self._cfg.tick_interval_s2,
-            "tick_interval_s3": self._cfg.tick_interval_s3,
             "tick_jitter": self._cfg.tick_jitter,
             "anyaction_enabled": self._cfg.anyaction_enabled,
             "anyaction_min_interval_seconds": self._cfg.anyaction_min_interval_seconds,
@@ -275,12 +272,9 @@ class ProactiveLoop:
                 "mode": mode,
                 "base_score": round(base_score, 4) if base_score is not None else None,
                 "interval_seconds": int(interval),
-                "threshold": self._cfg.threshold,
                 "score_llm_threshold": self._cfg.score_llm_threshold,
                 "tick_interval_s0": self._cfg.tick_interval_s0,
                 "tick_interval_s1": self._cfg.tick_interval_s1,
-                "tick_interval_s2": self._cfg.tick_interval_s2,
-                "tick_interval_s3": self._cfg.tick_interval_s3,
                 "tick_jitter": self._cfg.tick_jitter,
             },
         )
@@ -336,7 +330,7 @@ class ProactiveLoop:
     async def run(self) -> None:
         self._running = True
         logger.info(
-            f"ProactiveLoop 已启动  阈值={self._cfg.threshold}  "
+            f"ProactiveLoop 已启动  "
             f"目标={self._cfg.default_channel}:{self._cfg.default_chat_id}"
         )
         if not hasattr(self, "_mcp_pool"):
@@ -384,8 +378,6 @@ class ProactiveLoop:
             base_score = d_energy(energy) * self._cfg.score_weight_energy
         interval = next_tick_from_score(
             base_score,
-            tick_s3=self._cfg.tick_interval_s3,
-            tick_s2=self._cfg.tick_interval_s2,
             tick_s1=self._cfg.tick_interval_s1,
             tick_s0=self._cfg.tick_interval_s0,
             tick_jitter=self._cfg.tick_jitter,

--- a/proactive_v2/presets.py
+++ b/proactive_v2/presets.py
@@ -8,8 +8,6 @@ from typing import TypedDict
 class TriggerPreset(TypedDict):
     tick_interval_s0: int
     tick_interval_s1: int
-    tick_interval_s2: int
-    tick_interval_s3: int
     tick_jitter: float
 
 
@@ -57,8 +55,6 @@ PRESETS: dict[str, PresetConfig] = {
         "trigger": {
             "tick_interval_s0": 480,  # 8分钟
             "tick_interval_s1": 240,  # 4分钟
-            "tick_interval_s2": 120,  # 2分钟
-            "tick_interval_s3": 60,   # 1分钟
             "tick_jitter": 0.2,
         },
         "gate": {
@@ -92,8 +88,6 @@ PRESETS: dict[str, PresetConfig] = {
         "trigger": {
             "tick_interval_s0": 60,   # 1分钟
             "tick_interval_s1": 30,   # 30秒
-            "tick_interval_s2": 15,   # 15秒
-            "tick_interval_s3": 10,   # 10秒
             "tick_jitter": 0.0,       # 无抖动，精确触发
         },
         "gate": {
@@ -127,8 +121,6 @@ PRESETS: dict[str, PresetConfig] = {
         "trigger": {
             "tick_interval_s0": 1800,  # 30分钟
             "tick_interval_s1": 900,   # 15分钟
-            "tick_interval_s2": 480,   # 8分钟
-            "tick_interval_s3": 240,   # 4分钟
             "tick_jitter": 0.3,
         },
         "gate": {
@@ -192,7 +184,6 @@ STRATEGY_PARAMS = {
     # 去重细节
     "message_dedupe_enabled": True,
     # 其他
-    "threshold": 0.70,
     "recent_chat_messages": 20,
     "interval_seconds": 1800,
     "sleep_modifier_sleeping": 0.15,
@@ -204,8 +195,6 @@ ALLOWED_OVERRIDE_KEYS = {
     "trigger": {
         "tick_interval_s0",
         "tick_interval_s1",
-        "tick_interval_s2",
-        "tick_interval_s3",
         "tick_jitter",
     },
     "gate": {

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -3,7 +3,6 @@ TDD for proactive/energy.py
 
 测试覆盖：
   - compute_energy: 多时间尺度衰减
-  - random_weight: 随机扰动
 """
 
 from datetime import datetime, timezone, timedelta
@@ -67,35 +66,3 @@ def test_energy_accepts_custom_decay_params():
     last = now - timedelta(minutes=30)
     e = compute_energy(last, now, tau1_min=1.0, tau2_min=2.0, tau3_min=5.0)
     assert e < 0.01
-
-
-# ── random_weight ─────────────────────────────────────────────────
-
-from proactive_v2.energy import random_weight
-import random as _random_module
-
-
-def test_random_weight_is_in_valid_range():
-    for _ in range(200):
-        w = random_weight()
-        assert 0.5 <= w <= 1.5, f"random_weight out of range: {w}"
-
-
-def test_random_weight_is_deterministic_with_seed():
-    rng = _random_module.Random(42)
-    w1 = random_weight(rng=rng)
-    rng2 = _random_module.Random(42)
-    w2 = random_weight(rng=rng2)
-    assert w1 == w2
-
-
-def test_random_weight_varies_across_calls():
-    weights = [random_weight() for _ in range(50)]
-    assert len(set(weights)) > 1, "random_weight should not be constant"
-
-
-def test_random_weight_roughly_centered():
-    """均值应在 0.9 ~ 1.1 之间（Beta(2,2) 中心为 0.5，映射后中心为 1.0）。"""
-    weights = [random_weight() for _ in range(2000)]
-    mean = sum(weights) / len(weights)
-    assert 0.9 <= mean <= 1.1, f"mean={mean:.3f} unexpectedly off-center"

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -90,8 +90,6 @@ async def test_session_manager_and_proactive_loop_cover_paths(tmp_path: Path):
     loop._cfg = SimpleNamespace(
         interval_seconds=10,
         score_weight_energy=0.5,
-        tick_interval_s3=1,
-        tick_interval_s2=2,
         tick_interval_s1=3,
         tick_interval_s0=4,
         tick_jitter=0.0,
@@ -348,12 +346,9 @@ async def test_proactive_loop_wrapper_methods_cover_paths(tmp_path: Path):
     loop._cfg = SimpleNamespace(
         interval_seconds=10,
         score_weight_energy=0.5,
-        tick_interval_s3=1,
-        tick_interval_s2=2,
         tick_interval_s1=3,
         tick_interval_s0=4,
         tick_jitter=0.0,
-        threshold=0.5,
         default_channel="telegram",
         default_chat_id="42",
     )

--- a/tests/test_strategy_trace.py
+++ b/tests/test_strategy_trace.py
@@ -27,12 +27,9 @@ class _ProactiveTraceLoop(ProactiveLoop):
         self._sessions = SimpleNamespace(workspace=workspace)
         self._cfg = SimpleNamespace(
             enabled=True,
-            threshold=0.7,
             score_llm_threshold=0.6,
             tick_interval_s0=30,
             tick_interval_s1=60,
-            tick_interval_s2=120,
-            tick_interval_s3=240,
             tick_jitter=0.1,
             anyaction_enabled=True,
             anyaction_min_interval_seconds=60,


### PR DESCRIPTION
## 问题

当前 `config.toml` 的 proactive daily 链路只使用 s0/s1 tick 间隔；原先保留的 s2/s3、内容分和随机权重配置在这条主动链路里没有实际生效，继续留着会误导后续调参。

## 改动

- 清理 proactive v2 中无效的 `tick_interval_s2/s3`、content score 和 random weight 配置。
- 将下一轮 tick 间隔收敛为 s0/s1，保留 energy 基础节奏。
- 更新 handbook 为当前 `config.toml` 对应的二档节奏说明。
- 删除相关无效测试期望。

## 验证

- `pytest tests/proactive_v2 tests/test_energy.py tests/test_logic_modules.py tests/test_strategy_trace.py -q`
- `pyright proactive_v2/anyaction.py proactive_v2/config.py proactive_v2/config_loader.py proactive_v2/energy.py proactive_v2/event.py proactive_v2/loop.py proactive_v2/presets.py`
- `git diff --check HEAD~1..HEAD`

## 配置影响

以现有 `config.toml` 为基准，无需新增配置；这次移除的是此前未生效的主动链路配置项。