### PR TITLE
feat(observe): 全局错误采集 + 错误排障台

### DIFF
--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import TYPE_CHECKING, TypeAlias, cast
 
+from core.error_context import current_session_key
 from agent.context import ContextBuilder
 from agent.core.passive_turn import (
     AgentCore,
@@ -580,6 +581,8 @@ class AgentLoop:
     ) -> OutboundMessage:
         started = time.time()
         key = session_key or msg.session_key
+        # 给本 turn task 打上 session 归属，供 observe 全局错误采集关联。
+        _ = current_session_key.set(key)
 
         # 1. 先处理可能存在的续跑态，并发布 turn started。
         msg, resumed_from_interrupt = self._resume_interrupted_message(msg, key)

--- a/core/error_context.py
+++ b/core/error_context.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+# 当前正在处理的会话 key。在每条消息/每个 proactive tick 的处理 task 起点设置，
+# observe 的全局错误采集器在 logging 钩子里读取它，给错误打上 session 归属。
+# 放在 core 层是为了让主循环与 observe 插件共享同一个 ContextVar 对象。
+current_session_key: ContextVar[str | None] = ContextVar(
+    "akashic_current_session_key", default=None
+)

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -309,6 +309,20 @@ function App(): React.ReactElement {
     });
   };
 
+  // 插件面板（如 observe 错误排障台）通过 CustomEvent 请求跳到某个 session 的对话现场。
+  useEffect(() => {
+    const onGoto = (e: Event): void => {
+      const key = (e as CustomEvent<string>).detail;
+      if (!key) return;
+      setActiveSessionKey(key);
+      setActiveMessage(null);
+      setMessagePage(1);
+      selectView("sessions");
+    };
+    window.addEventListener("akashic:goto-session", onGoto);
+    return () => window.removeEventListener("akashic:goto-session", onGoto);
+  }, []);
+
   const sort = (scope: "messages" | "proactive", key: string): void => {
     const flip = (currentKey: string, currentOrder: SortOrder): SortOrder => currentKey === key && currentOrder === "desc" ? "asc" : "desc";
     if (scope === "messages") {

--- a/plugins/observe/collector.py
+++ b/plugins/observe/collector.py
@@ -1,3 +1,10 @@
+"""GlobalErrorCollector：零埋点地采集全局错误写入 observe.db。
+
+接管四个全局错误出口（root logging handler / sys.excepthook /
+asyncio loop exception handler / threading.excepthook），按 指纹 × 小时桶 在内存里
+去重计数，后台 flush task 周期性 emit 给 TraceWriter 落库。安装/还原与插件生命周期绑定。
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -7,202 +14,321 @@ import re
 import sys
 import threading
 import traceback
+import types
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from types import TracebackType
-from typing import Any, Callable
-
-from core.common.diagnostic_log import current_diagnostic_context
+from pathlib import Path
+from typing import Protocol
 
 from .events import GlobalErrorTrace
 
-_SKIP_LOGGER_PREFIXES = ("plugin.observe", "observe.", "plugins.observe")
-_HEX_RE = re.compile(r"\b[0-9a-f]{8,}\b", re.IGNORECASE)
-_NUM_RE = re.compile(r"\b\d+\b")
-_MESSAGE_LIMIT = 500
-_TRACEBACK_LIMIT = 4000
+logger = logging.getLogger("observe.collector")
+
+# 当前正在处理的会话；由 AgentLoop / ProactiveLoop / passive turn 设置，logging 采集时读取。
+current_session_key: ContextVar[str | None] = ContextVar(
+    "observe_current_session_key", default=None
+)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_FLUSH_INTERVAL = 10.0
+_MESSAGE_MAX = 500
+_TRACEBACK_MAX = 4000
+_SESSION_KEYS_CAP = 20
+
+# logging 采集跳过这些 logger（防自噬 + 避免 asyncio 双重计数：asyncio 任务异常走第 3 层）。
+_SKIP_LOGGER_PREFIXES = ("observe", "plugin.observe", "asyncio")
+
+# 指纹归一化：抹掉数字 / 十六进制 / 常见 id，使"同一个 bug"指纹稳定。
+_NORM_HEX = re.compile(r"0x[0-9a-fA-F]+")
+_NORM_NUM = re.compile(r"\d+")
+
+
+class _Emitter(Protocol):
+    def emit(self, event: GlobalErrorTrace) -> None: ...
+
+
+@dataclass
+class _BucketAgg:
+    fingerprint: str
+    bucket: str
+    source: str
+    logger_name: str
+    error_type: str
+    message: str
+    traceback_text: str
+    level: str
+    first_ts: str
+    last_ts: str
+    count: int = 0
+    session_keys: set[str] = field(default_factory=set)
 
 
 class GlobalErrorCollector:
-    def __init__(self, writer: Any) -> None:
+    def __init__(self, writer: _Emitter) -> None:
         self._writer = writer
-        self._handler = _GlobalErrorLogHandler(self)
-        self._old_sys_excepthook: Callable[..., object] | None = None
-        self._old_threading_excepthook: Callable[..., object] | None = None
-        self._old_asyncio_handler: Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object] | None = None
-        self._loop: asyncio.AbstractEventLoop | None = None
+        self._lock = threading.Lock()
+        self._buckets: dict[tuple[str, str], _BucketAgg] = {}
+        self._flush_task: asyncio.Task[None] | None = None
         self._installed = False
+        # 旧钩子，卸载时还原
+        self._log_handler: logging.Handler | None = None
+        self._prev_excepthook = None
+        self._prev_threadhook = None
+        self._prev_loop_handler = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # ── 生命周期 ─────────────────────────────────
 
     def install(self) -> None:
         if self._installed:
             return
         self._installed = True
-        logging.getLogger().addHandler(self._handler)
-        self._old_sys_excepthook = sys.excepthook
-        sys.excepthook = self._handle_sys_exception
-        self._old_threading_excepthook = threading.excepthook
-        threading.excepthook = self._handle_thread_exception
+        # 1. root logging handler（level >= ERROR）
+        handler = _CollectorLogHandler(self)
+        logging.getLogger().addHandler(handler)
+        self._log_handler = handler
+        # 2. 同步未捕获异常
+        self._prev_excepthook = sys.excepthook
+        sys.excepthook = self._on_sys_except
+        # 3. 线程崩溃
+        self._prev_threadhook = threading.excepthook
+        threading.excepthook = self._on_thread_except
+        # 4. asyncio 任务异常 + flush task
         try:
-            self._loop = asyncio.get_running_loop()
+            loop = asyncio.get_running_loop()
         except RuntimeError:
-            self._loop = None
-        if self._loop is not None:
-            self._old_asyncio_handler = self._loop.get_exception_handler()
-            self._loop.set_exception_handler(self._handle_asyncio_exception)
+            loop = None
+        if loop is not None:
+            self._loop = loop
+            self._prev_loop_handler = loop.get_exception_handler()
+            loop.set_exception_handler(self._on_loop_except)
+            self._flush_task = loop.create_task(self._flush_loop(), name="observe_error_flush")
+        logger.info("global error collector installed")
 
-    def close(self) -> None:
+    async def uninstall(self) -> None:
         if not self._installed:
             return
         self._installed = False
-        logging.getLogger().removeHandler(self._handler)
-        if self._old_sys_excepthook is not None:
-            sys.excepthook = self._old_sys_excepthook
-        if self._old_threading_excepthook is not None:
-            threading.excepthook = self._old_threading_excepthook
+        # 1. 还原钩子
+        if self._log_handler is not None:
+            logging.getLogger().removeHandler(self._log_handler)
+            self._log_handler = None
+        if self._prev_excepthook is not None:
+            sys.excepthook = self._prev_excepthook
+        if self._prev_threadhook is not None:
+            threading.excepthook = self._prev_threadhook
         if self._loop is not None:
-            self._loop.set_exception_handler(self._old_asyncio_handler)
+            self._loop.set_exception_handler(self._prev_loop_handler)
+        # 2. 停 flush task 并最终 flush
+        if self._flush_task is not None:
+            _ = self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
+        self._flush()
+        logger.info("global error collector uninstalled")
 
-    def emit_log_record(self, record: logging.LogRecord) -> None:
-        if record.levelno < logging.ERROR or _skip_logger(record.name):
-            return
-        exc_type: type[BaseException] | None = None
-        exc_value: BaseException | None = None
-        exc_tb: TracebackType | None = None
-        if record.exc_info:
-            exc_type, exc_value, exc_tb = record.exc_info
-        message = record.getMessage()
-        self._emit(
-            source="log",
-            logger_name=record.name,
-            level=record.levelname,
-            message=message,
-            exc_type=exc_type,
-            exc_value=exc_value,
-            exc_tb=exc_tb,
-        )
+    # ── 采集入口 ─────────────────────────────────
 
-    def _handle_sys_exception(
-        self,
-        exc_type: type[BaseException],
-        exc_value: BaseException,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        self._emit(
-            source="uncaught",
-            logger_name="sys.excepthook",
-            level="CRITICAL",
-            message=str(exc_value),
-            exc_type=exc_type,
-            exc_value=exc_value,
-            exc_tb=exc_tb,
-        )
-        if self._old_sys_excepthook is not None:
-            self._old_sys_excepthook(exc_type, exc_value, exc_tb)
-
-    def _handle_thread_exception(self, args: threading.ExceptHookArgs) -> None:
-        self._emit(
-            source="thread",
-            logger_name=str(getattr(args.thread, "name", "") or "threading.excepthook"),
-            level="CRITICAL",
-            message=str(args.exc_value),
-            exc_type=args.exc_type,
-            exc_value=args.exc_value,
-            exc_tb=args.exc_traceback,
-        )
-        if self._old_threading_excepthook is not None:
-            self._old_threading_excepthook(args)
-
-    def _handle_asyncio_exception(
-        self,
-        loop: asyncio.AbstractEventLoop,
-        context: dict[str, Any],
-    ) -> None:
-        exc = context.get("exception")
-        message = str(context.get("message") or exc or "asyncio exception")
-        self._emit(
-            source="asyncio",
-            logger_name="asyncio",
-            level="ERROR",
-            message=message,
-            exc_type=type(exc) if isinstance(exc, BaseException) else None,
-            exc_value=exc if isinstance(exc, BaseException) else None,
-            exc_tb=exc.__traceback__ if isinstance(exc, BaseException) else None,
-        )
-        if self._old_asyncio_handler is not None:
-            self._old_asyncio_handler(loop, context)
-        else:
-            loop.default_exception_handler(context)
-
-    def _emit(
+    # 把一次错误折叠进内存的 (fingerprint, bucket) 桶。线程安全，绝不抛出。
+    def capture(
         self,
         *,
         source: str,
         logger_name: str,
-        level: str,
+        error_type: str,
         message: str,
+        traceback_text: str,
+        level: str,
+        top_frame: str,
+        session_key: str | None,
+    ) -> None:
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            bucket = now[:13]
+            fingerprint = _fingerprint(error_type, message, top_frame)
+            key = (fingerprint, bucket)
+            with self._lock:
+                agg = self._buckets.get(key)
+                if agg is None:
+                    agg = _BucketAgg(
+                        fingerprint=fingerprint,
+                        bucket=bucket,
+                        source=source,
+                        logger_name=logger_name,
+                        error_type=error_type,
+                        message=message[:_MESSAGE_MAX],
+                        traceback_text=traceback_text[:_TRACEBACK_MAX],
+                        level=level,
+                        first_ts=now,
+                        last_ts=now,
+                    )
+                    self._buckets[key] = agg
+                agg.count += 1
+                agg.last_ts = now
+                if session_key and len(agg.session_keys) < _SESSION_KEYS_CAP:
+                    agg.session_keys.add(session_key)
+        except Exception:
+            # 采集器自身绝不影响主流程
+            pass
+
+    # ── 钩子回调 ─────────────────────────────────
+
+    def _on_sys_except(self, exc_type, exc_value, tb) -> None:
+        self._capture_exc("uncaught", "root", exc_type, exc_value, tb, "ERROR")
+        if callable(self._prev_excepthook):
+            self._prev_excepthook(exc_type, exc_value, tb)
+
+    def _on_thread_except(self, args) -> None:
+        self._capture_exc(
+            "thread",
+            getattr(getattr(args, "thread", None), "name", "thread") or "thread",
+            args.exc_type,
+            args.exc_value,
+            args.exc_traceback,
+            "ERROR",
+        )
+        if callable(self._prev_threadhook):
+            self._prev_threadhook(args)
+
+    def _on_loop_except(self, loop, context: dict[str, object]) -> None:
+        exc = context.get("exception")
+        if isinstance(exc, BaseException):
+            self._capture_exc(
+                "asyncio", "asyncio", type(exc), exc, exc.__traceback__, "ERROR"
+            )
+        else:
+            msg = str(context.get("message", "asyncio error"))
+            self.capture(
+                source="asyncio",
+                logger_name="asyncio",
+                error_type="AsyncioError",
+                message=msg,
+                traceback_text=msg,
+                level="ERROR",
+                top_frame="asyncio",
+                session_key=None,
+            )
+        if callable(self._prev_loop_handler):
+            self._prev_loop_handler(loop, context)
+        else:
+            loop.default_exception_handler(context)
+
+    def _capture_exc(
+        self,
+        source: str,
+        logger_name: str,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
-        exc_tb: TracebackType | None,
+        tb: types.TracebackType | None,
+        level: str,
     ) -> None:
-        now = datetime.now(timezone.utc).isoformat()
-        error_type = exc_type.__name__ if exc_type is not None else "LogError"
-        traceback_text = _format_traceback(exc_type, exc_value, exc_tb)
-        fingerprint = _fingerprint(error_type, message, traceback_text)
-        diag = current_diagnostic_context()
-        session = diag["session"]
-        self._writer.emit(
-            GlobalErrorTrace(
-                fingerprint=fingerprint,
-                bucket=now[:13],
-                source=source,
-                logger_name=logger_name,
-                error_type=error_type,
-                message=message[:_MESSAGE_LIMIT],
-                traceback_text=traceback_text[:_TRACEBACK_LIMIT],
-                level=level,
-                first_ts=now,
-                last_ts=now,
-                count=1,
-                session_keys=[session] if session else [],
-                flow=diag["flow"],
-                phase=diag["phase"],
-                turn=diag["turn"],
-                tick=diag["tick"],
-            )
+        type_name = exc_type.__name__ if exc_type else "Error"
+        message = str(exc_value) if exc_value else type_name
+        tb_text = "".join(traceback.format_exception(exc_type, exc_value, tb))
+        self.capture(
+            source=source,
+            logger_name=logger_name,
+            error_type=type_name,
+            message=message,
+            traceback_text=tb_text,
+            level=level,
+            top_frame=_top_app_frame(tb),
+            session_key=current_session_key.get(),
         )
 
+    # ── flush ────────────────────────────────────
 
-class _GlobalErrorLogHandler(logging.Handler):
+    async def _flush_loop(self) -> None:
+        while True:
+            await asyncio.sleep(_FLUSH_INTERVAL)
+            self._flush()
+
+    # 把内存里累计的增量 emit 给 writer（writer 端 UPSERT 累加），随后清空。
+    def _flush(self) -> None:
+        with self._lock:
+            if not self._buckets:
+                return
+            pending = list(self._buckets.values())
+            self._buckets.clear()
+        for agg in pending:
+            self._writer.emit(
+                GlobalErrorTrace(
+                    fingerprint=agg.fingerprint,
+                    bucket=agg.bucket,
+                    source=agg.source,
+                    logger_name=agg.logger_name,
+                    error_type=agg.error_type,
+                    message=agg.message,
+                    traceback_text=agg.traceback_text,
+                    level=agg.level,
+                    first_ts=agg.first_ts,
+                    last_ts=agg.last_ts,
+                    count=agg.count,
+                    session_keys=list(agg.session_keys),
+                )
+            )
+
+
+class _CollectorLogHandler(logging.Handler):
     def __init__(self, collector: GlobalErrorCollector) -> None:
         super().__init__(level=logging.ERROR)
         self._collector = collector
 
     def emit(self, record: logging.LogRecord) -> None:
-        self._collector.emit_log_record(record)
+        try:
+            name = record.name or ""
+            if any(name.startswith(p) for p in _SKIP_LOGGER_PREFIXES):
+                return
+            exc_info = record.exc_info
+            if exc_info and exc_info[0] is not None:
+                exc_type, exc_value, tb = exc_info
+                error_type = exc_type.__name__
+                message = str(exc_value) if exc_value else record.getMessage()
+                tb_text = "".join(traceback.format_exception(exc_type, exc_value, tb))
+                top_frame = _top_app_frame(tb)
+            else:
+                error_type = "LogError"
+                message = record.getMessage()
+                tb_text = f"{name}: {message}\n  at {record.pathname}:{record.lineno}"
+                top_frame = f"{record.pathname}:{record.lineno}"
+            self._collector.capture(
+                source="log",
+                logger_name=name,
+                error_type=error_type,
+                message=message,
+                traceback_text=tb_text,
+                level=record.levelname,
+                top_frame=top_frame,
+                session_key=current_session_key.get(),
+            )
+        except Exception:
+            pass
 
 
-def _skip_logger(name: str) -> bool:
-    return any(name.startswith(prefix) for prefix in _SKIP_LOGGER_PREFIXES)
+# ── 辅助 ─────────────────────────────────────────
 
 
-def _format_traceback(
-    exc_type: type[BaseException] | None,
-    exc_value: BaseException | None,
-    exc_tb: TracebackType | None,
-) -> str:
-    if exc_type is None:
-        return ""
-    return "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+def _fingerprint(error_type: str, message: str, top_frame: str) -> str:
+    norm = _NORM_NUM.sub("#", _NORM_HEX.sub("#", message))
+    raw = f"{error_type}|{norm}|{top_frame}"
+    return hashlib.sha1(raw.encode("utf-8", errors="replace")).hexdigest()[:16]
 
 
-def _fingerprint(error_type: str, message: str, traceback_text: str) -> str:
-    normalized = _NUM_RE.sub("<n>", _HEX_RE.sub("<hex>", message))
-    frame = _top_app_frame(traceback_text)
-    raw = f"{error_type}|{normalized}|{frame}"
-    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
-
-
-def _top_app_frame(traceback_text: str) -> str:
-    for line in traceback_text.splitlines():
-        if "/akasic-agent/" in line and "/plugins/observe/" not in line:
-            return line.strip()
-    return ""
+# 取 traceback 中第一个属于本项目的栈帧 "relpath:lineno"；没有则取最内层帧。
+def _top_app_frame(tb: types.TracebackType | None) -> str:
+    frames = traceback.extract_tb(tb) if tb else []
+    if not frames:
+        return "?"
+    chosen = frames[-1]
+    for frame in frames:
+        try:
+            rel = Path(frame.filename).resolve().relative_to(_PROJECT_ROOT)
+        except ValueError:
+            continue
+        chosen = frame
+        return f"{rel}:{frame.lineno}"
+    return f"{Path(chosen.filename).name}:{chosen.lineno}"

--- a/plugins/observe/collector.py
+++ b/plugins/observe/collector.py
@@ -16,12 +16,12 @@ import threading
 import traceback
 import types
 from collections.abc import Callable
-from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
+from core.error_context import current_session_key as current_session_key
 from .events import GlobalErrorTrace
 
 _SysExceptHook = Callable[[type[BaseException], BaseException, "types.TracebackType | None"], object]
@@ -29,11 +29,6 @@ _ThreadExceptHook = Callable[["threading.ExceptHookArgs"], object]
 _LoopExceptHandler = Callable[[asyncio.AbstractEventLoop, "dict[str, Any]"], object]
 
 logger = logging.getLogger("observe.collector")
-
-# 当前正在处理的会话；由 AgentLoop / ProactiveLoop / passive turn 设置，logging 采集时读取。
-current_session_key: ContextVar[str | None] = ContextVar(
-    "observe_current_session_key", default=None
-)
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _FLUSH_INTERVAL = 10.0

--- a/plugins/observe/collector.py
+++ b/plugins/observe/collector.py
@@ -15,13 +15,18 @@ import sys
 import threading
 import traceback
 import types
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from .events import GlobalErrorTrace
+
+_SysExceptHook = Callable[[type[BaseException], BaseException, "types.TracebackType | None"], object]
+_ThreadExceptHook = Callable[["threading.ExceptHookArgs"], object]
+_LoopExceptHandler = Callable[[asyncio.AbstractEventLoop, "dict[str, Any]"], object]
 
 logger = logging.getLogger("observe.collector")
 
@@ -44,6 +49,10 @@ _NORM_HEX = re.compile(r"0x[0-9a-fA-F]+")
 _NORM_NUM = re.compile(r"\d+")
 
 
+def _empty_str_set() -> set[str]:
+    return set()
+
+
 class _Emitter(Protocol):
     def emit(self, event: GlobalErrorTrace) -> None: ...
 
@@ -61,7 +70,7 @@ class _BucketAgg:
     first_ts: str
     last_ts: str
     count: int = 0
-    session_keys: set[str] = field(default_factory=set)
+    session_keys: set[str] = field(default_factory=_empty_str_set)
 
 
 class GlobalErrorCollector:
@@ -73,9 +82,9 @@ class GlobalErrorCollector:
         self._installed = False
         # 旧钩子，卸载时还原
         self._log_handler: logging.Handler | None = None
-        self._prev_excepthook = None
-        self._prev_threadhook = None
-        self._prev_loop_handler = None
+        self._prev_excepthook: _SysExceptHook | None = None
+        self._prev_threadhook: _ThreadExceptHook | None = None
+        self._prev_loop_handler: _LoopExceptHandler | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
 
     # ── 生命周期 ─────────────────────────────────
@@ -177,24 +186,32 @@ class GlobalErrorCollector:
 
     # ── 钩子回调 ─────────────────────────────────
 
-    def _on_sys_except(self, exc_type, exc_value, tb) -> None:
+    def _on_sys_except(
+        self,
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        tb: types.TracebackType | None,
+    ) -> None:
         self._capture_exc("uncaught", "root", exc_type, exc_value, tb, "ERROR")
-        if callable(self._prev_excepthook):
-            self._prev_excepthook(exc_type, exc_value, tb)
+        if self._prev_excepthook is not None:
+            _ = self._prev_excepthook(exc_type, exc_value, tb)
 
-    def _on_thread_except(self, args) -> None:
+    def _on_thread_except(self, args: threading.ExceptHookArgs) -> None:
+        thread_name = args.thread.name if args.thread is not None else "thread"
         self._capture_exc(
             "thread",
-            getattr(getattr(args, "thread", None), "name", "thread") or "thread",
+            thread_name,
             args.exc_type,
             args.exc_value,
             args.exc_traceback,
             "ERROR",
         )
-        if callable(self._prev_threadhook):
-            self._prev_threadhook(args)
+        if self._prev_threadhook is not None:
+            _ = self._prev_threadhook(args)
 
-    def _on_loop_except(self, loop, context: dict[str, object]) -> None:
+    def _on_loop_except(
+        self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
         exc = context.get("exception")
         if isinstance(exc, BaseException):
             self._capture_exc(
@@ -212,8 +229,8 @@ class GlobalErrorCollector:
                 top_frame="asyncio",
                 session_key=None,
             )
-        if callable(self._prev_loop_handler):
-            self._prev_loop_handler(loop, context)
+        if self._prev_loop_handler is not None:
+            _ = self._prev_loop_handler(loop, context)
         else:
             loop.default_exception_handler(context)
 
@@ -320,15 +337,14 @@ def _fingerprint(error_type: str, message: str, top_frame: str) -> str:
 
 # 取 traceback 中第一个属于本项目的栈帧 "relpath:lineno"；没有则取最内层帧。
 def _top_app_frame(tb: types.TracebackType | None) -> str:
-    frames = traceback.extract_tb(tb) if tb else []
+    frames: list[traceback.FrameSummary] = traceback.extract_tb(tb) if tb else []
     if not frames:
         return "?"
-    chosen = frames[-1]
+    chosen: traceback.FrameSummary = frames[-1]
     for frame in frames:
         try:
             rel = Path(frame.filename).resolve().relative_to(_PROJECT_ROOT)
         except ValueError:
             continue
-        chosen = frame
-        return f"{rel}:{frame.lineno}"
-    return f"{Path(chosen.filename).name}:{chosen.lineno}"
+        return f"{rel}:{frame.lineno or 0}"
+    return f"{Path(chosen.filename).name}:{chosen.lineno or 0}"

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -168,17 +168,6 @@ function _delta(values: number[]): number | null {
   return ((last - prev) / prev) * 100;
 }
 
-// 相对时间标签："刚刚" / "Xs 前" / "Xm 前"。
-function _ago(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return "刚刚";
-  const s = Math.floor(ms / 1000);
-  if (s < 3) return "刚刚";
-  if (s < 60) return `${s}s 前`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m 前`;
-  return `${Math.floor(m / 60)}h 前`;
-}
-
 // 严重度配色：爆发或高频 -> danger，中频 -> warning，低频 -> muted。
 function _severity(count: number, spiking: boolean): ChartTone {
   if (spiking || count >= 20) return "danger";
@@ -188,12 +177,9 @@ function _severity(count: number, spiking: boolean): ChartTone {
 
 // A monitoring widget card with a hairline header — mirrors the superlog widget
 // chrome (uppercase mono title, bottom-bordered header, padded body).
-function Card({ title, children, bodyClass, style }: { title: string; children: ReactNode; bodyClass?: string; style?: React.CSSProperties }): ReactElement {
+function Card({ title, children, bodyClass }: { title: string; children: ReactNode; bodyClass?: string }): ReactElement {
   return (
-    <div
-      className="flex animate-fade-up flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm transition-[box-shadow,border-color] duration-200 hover:border-border-strong hover:shadow-lift-md"
-      style={style}
-    >
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
       <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{title}</h3>
       </div>
@@ -418,12 +404,9 @@ function ErrorRow({ g, active, onClick }: { g: GErrGroup; active: boolean; onCli
     <button
       type="button"
       onClick={onClick}
-      className={`grid w-full grid-cols-[9px_1fr_auto] items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-all duration-150 ${active ? "border-border-strong bg-accent-soft" : "border-transparent hover:border-border hover:bg-surface-2"}`}
+      className={`grid w-full grid-cols-[9px_1fr_auto] items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors ${active ? "border-border-strong bg-accent-soft" : "border-transparent hover:bg-surface-2"}`}
     >
-      <span className="relative flex h-2 w-2">
-        {g.is_spiking && <span className={`absolute inline-flex h-full w-full rounded-full ${TONE_BG[tone]} opacity-60 animate-ping`} />}
-        <span className={`relative inline-flex h-2 w-2 rounded-full ${TONE_BG[tone]} ${g.is_spiking ? "animate-pulse-dot" : ""}`} />
-      </span>
+      <span className={`h-2 w-2 rounded-full ${TONE_BG[tone]}`} />
       <div className="min-w-0">
         <div className="flex items-center gap-1.5 font-mono text-[12.5px]">
           <span className="truncate">{g.error_type}</span>
@@ -556,7 +539,7 @@ function ErrorDetail({
           type="button"
           onClick={() => detail.occurrences[0] && onGoto(detail.occurrences[0].session_key)}
           disabled={detail.occurrences.length === 0}
-          className="rounded-md border border-accent-deep bg-accent-soft px-3 py-2 font-mono text-[11px] text-[#dfe3ff] transition-all duration-150 hover:brightness-110 active:brightness-95 disabled:opacity-40"
+          className="rounded-md border border-accent-deep bg-accent-soft px-3 py-2 font-mono text-[11px] text-[#dfe3ff] disabled:opacity-40"
         >
           查看最近对话 ↗
         </button>
@@ -600,35 +583,6 @@ function TabBtn({ active, onClick, children }: { active: boolean; onClick: () =>
   );
 }
 
-// 首屏骨架：发丝边框块 + scan 光流扫过，取代白屏 → 数据啪地弹出。
-function SkelBlock({ className }: { className: string }): ReactElement {
-  return (
-    <div className={`relative overflow-hidden rounded-2xl border border-border bg-surface ${className}`}>
-      <div className="absolute inset-0 -translate-x-full animate-scan bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" />
-    </div>
-  );
-}
-
-function ObserveSkeleton(): ReactElement {
-  return (
-    <div className="flex flex-col gap-4 p-6">
-      <div className="flex items-end justify-between">
-        <div className="flex flex-col gap-2">
-          <SkelBlock className="h-7 w-48 rounded-lg" />
-          <SkelBlock className="h-3 w-64 rounded" />
-        </div>
-        <SkelBlock className="h-9 w-56 rounded-md" />
-      </div>
-      <div className="grid grid-cols-4 gap-4">
-        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[132px]" />)}
-      </div>
-      <div className="grid grid-cols-2 gap-4">
-        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[218px] rounded-lg" />)}
-      </div>
-    </div>
-  );
-}
-
 // ── 监测主面板 ────────────────────────────────────────────────────────────────
 
 // Grafana-style monitoring overview over observe.db agent-loop telemetry.
@@ -638,43 +592,28 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   const [points, setPoints] = useState<SeriesPoint[]>([]);
   const [gErr, setGErr] = useState<GErrOverview | null>(null);
   const [drillOpen, setDrillOpen] = useState<boolean>(false);
-  const [updatedAt, setUpdatedAt] = useState<number>(0);
-  const [nowTs, setNowTs] = useState<number>(() => Date.now());
-  const [refreshing, setRefreshing] = useState<boolean>(false);
   const portalRef = useRef<HTMLDivElement>(null);
 
-  const load = useCallback(async () => {
-    setRefreshing(true);
-    try {
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
       const [ov, series, ge] = await Promise.all([
         api<Overview>(`/api/dashboard/observe/overview?range=${range}`),
         api<{ points: SeriesPoint[] }>(`/api/dashboard/observe/timeseries?range=${range}`),
         api<GErrOverview>(`/api/dashboard/observe/global_errors/overview?range=${range}`),
       ]);
+      if (!alive) return;
       setOverview(ov);
       setPoints(series.points ?? []);
       setGErr(ge);
-      setUpdatedAt(Date.now());
-    } finally {
-      setRefreshing(false);
-    }
-  }, [range]);
-
-  // 首次 + range 变化加载；并以 15s 心跳自动刷新，制造"活的"实时感。
-  useEffect(() => {
-    void load();
-    const id = window.setInterval(() => void load(), 15000);
-    return () => window.clearInterval(id);
-  }, [load]);
-
-  // 1s tick 驱动"更新于 Xs 前"的相对时间标签。
-  useEffect(() => {
-    const id = window.setInterval(() => setNowTs(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, []);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [range, drillOpen]);
 
   if (!overview) {
-    return <ObserveSkeleton />;
+    return <div className="p-6 text-[13px] text-muted">加载中…</div>;
   }
 
   const turnSeries = points.map((p) => p.turns);
@@ -697,81 +636,50 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
         {/* header + range switcher */}
         <div className="flex items-end justify-between">
           <div>
-            <div className="flex items-center gap-2.5">
-              <span className="detail-title">Observe · 监测</span>
-              <span className="flex items-center gap-1.5 rounded-full border border-success/25 bg-success/10 px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-success">
-                <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse-dot" />
-                Live
-              </span>
-            </div>
-            <div className="detail-subtext">
-              Agent 主循环遥测 · Token / 迭代 / 错误
-              <span className="ml-2 font-mono text-[11px] text-subtle">更新于 {_ago(nowTs - updatedAt)}</span>
-            </div>
+            <div className="detail-title">Observe · 监测</div>
+            <div className="detail-subtext">Agent 主循环遥测 · Token / 迭代 / 错误</div>
           </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => void load()}
-              className={`grid h-7 w-7 place-items-center rounded-md border border-border bg-surface-2 text-muted transition-colors hover:border-border-strong hover:text-fg ${refreshing ? "animate-spin" : ""}`}
-              title="刷新"
-            >
-              ↻
-            </button>
-            <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
-              {RANGES.map((r) => (
-                <button
-                  key={r.key}
-                  onClick={() => setRange(r.key)}
-                  className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-all duration-150 active:brightness-95 ${range === r.key ? "bg-accent text-accent-ink hover:brightness-110" : "text-muted hover:bg-surface-3 hover:text-fg"}`}
-                >
-                  {r.label}
-                </button>
-              ))}
-            </div>
+          <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
+            {RANGES.map((r) => (
+              <button
+                key={r.key}
+                onClick={() => setRange(r.key)}
+                className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-colors ${range === r.key ? "bg-accent text-accent-ink" : "text-muted hover:text-fg"}`}
+              >
+                {r.label}
+              </button>
+            ))}
           </div>
         </div>
 
         {/* KPI tiles */}
         <div className="grid grid-cols-4 gap-4">
-          <div className="animate-fade-up" style={{ animationDelay: "0ms" }}>
-            <MetricTile label="对话轮数" value={_compact(overview.turns)} delta={_delta(turnSeries)} sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"} tone="accent" spark={turnSeries} />
-          </div>
+          <MetricTile label="对话轮数" value={_compact(overview.turns)} delta={_delta(turnSeries)} sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"} tone="accent" spark={turnSeries} />
           {/* 错误卡 = 传送门：点击 FLIP 放大成排障台 */}
           <div
             ref={portalRef}
             onClick={() => setDrillOpen(true)}
-            className="group relative animate-fade-up cursor-pointer rounded-2xl transition-transform duration-200 hover:-translate-y-0.5"
-            style={{ animationDelay: "60ms" }}
+            className="group relative cursor-pointer rounded-2xl transition-transform duration-200 hover:-translate-y-0.5"
           >
-            {gErrTotal > 0 && (
-              <span className="absolute left-[68px] top-[18px] z-10 flex h-2 w-2">
-                {(gErr?.spiking_types ?? 0) > 0 && <span className="absolute inline-flex h-full w-full rounded-full bg-danger opacity-60 animate-ping" />}
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-danger animate-pulse-dot" />
-              </span>
-            )}
             <span className="pointer-events-none absolute right-4 top-4 z-10 font-mono text-[10px] text-danger opacity-0 transition-opacity group-hover:opacity-100">展开分析 →</span>
             <MetricTile label="错误" value={_compact(gErrTotal)} sub={`${gErr?.types ?? 0} 类型 · 点击展开`} tone="danger" spark={gErrSpark} />
           </div>
-          <div className="animate-fade-up" style={{ animationDelay: "120ms" }}>
-            <MetricTile label="KV 缓存命中率" value={_pct(overview.cache_hit_rate)} sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`} tone="success" spark={hitSeries} />
-          </div>
-          <div className="animate-fade-up" style={{ animationDelay: "180ms" }}>
-            <MetricTile label="平均迭代" value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"} unit={`峰 ${overview.max_iteration}`} sub="每轮 LLM 调用次数" tone="warning" spark={iterSeries} />
-          </div>
+          <MetricTile label="KV 缓存命中率" value={_pct(overview.cache_hit_rate)} sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`} tone="success" spark={hitSeries} />
+          <MetricTile label="平均迭代" value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"} unit={`峰 ${overview.max_iteration}`} sub="每轮 LLM 调用次数" tone="warning" spark={iterSeries} />
         </div>
 
         {/* trend charts */}
         <div className="grid grid-cols-2 gap-4">
-          <Card title="输入 Token 趋势" style={{ animationDelay: "220ms" }}>
+          <Card title="输入 Token 趋势">
             <TrendChart data={labelled(tokenSeries)} kind="area" tone="accent" valueFmt={_compact} />
           </Card>
-          <Card title="平均迭代趋势" style={{ animationDelay: "280ms" }}>
+          <Card title="平均迭代趋势">
             <TrendChart data={labelled(iterSeries)} kind="area" tone="warning" valueFmt={(n) => n.toFixed(1)} />
           </Card>
-          <Card title="KV 缓存命中率趋势" style={{ animationDelay: "340ms" }}>
+          <Card title="KV 缓存命中率趋势">
             <TrendChart data={labelled(hitSeries)} kind="area" tone="success" valueFmt={(n) => `${n.toFixed(0)}%`} />
           </Card>
-          <Card title="错误趋势" style={{ animationDelay: "400ms" }}>
+          <Card title="错误趋势">
             <TrendChart data={labelled(errorSeries)} kind="bar" tone="danger" valueFmt={(n) => String(n)} empty="区间内无错误 🎉" />
           </Card>
         </div>

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -168,6 +168,17 @@ function _delta(values: number[]): number | null {
   return ((last - prev) / prev) * 100;
 }
 
+// 相对时间标签："刚刚" / "Xs 前" / "Xm 前"。
+function _ago(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "刚刚";
+  const s = Math.floor(ms / 1000);
+  if (s < 3) return "刚刚";
+  if (s < 60) return `${s}s 前`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m 前`;
+  return `${Math.floor(m / 60)}h 前`;
+}
+
 // 严重度配色：爆发或高频 -> danger，中频 -> warning，低频 -> muted。
 function _severity(count: number, spiking: boolean): ChartTone {
   if (spiking || count >= 20) return "danger";
@@ -177,9 +188,12 @@ function _severity(count: number, spiking: boolean): ChartTone {
 
 // A monitoring widget card with a hairline header — mirrors the superlog widget
 // chrome (uppercase mono title, bottom-bordered header, padded body).
-function Card({ title, children, bodyClass }: { title: string; children: ReactNode; bodyClass?: string }): ReactElement {
+function Card({ title, children, bodyClass, style }: { title: string; children: ReactNode; bodyClass?: string; style?: React.CSSProperties }): ReactElement {
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
+    <div
+      className="flex animate-fade-up flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm transition-[box-shadow,border-color] duration-200 hover:border-border-strong hover:shadow-lift-md"
+      style={style}
+    >
       <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{title}</h3>
       </div>
@@ -404,9 +418,12 @@ function ErrorRow({ g, active, onClick }: { g: GErrGroup; active: boolean; onCli
     <button
       type="button"
       onClick={onClick}
-      className={`grid w-full grid-cols-[9px_1fr_auto] items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors ${active ? "border-border-strong bg-accent-soft" : "border-transparent hover:bg-surface-2"}`}
+      className={`grid w-full grid-cols-[9px_1fr_auto] items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-all duration-150 ${active ? "border-border-strong bg-accent-soft" : "border-transparent hover:border-border hover:bg-surface-2"}`}
     >
-      <span className={`h-2 w-2 rounded-full ${TONE_BG[tone]}`} />
+      <span className="relative flex h-2 w-2">
+        {g.is_spiking && <span className={`absolute inline-flex h-full w-full rounded-full ${TONE_BG[tone]} opacity-60 animate-ping`} />}
+        <span className={`relative inline-flex h-2 w-2 rounded-full ${TONE_BG[tone]} ${g.is_spiking ? "animate-pulse-dot" : ""}`} />
+      </span>
       <div className="min-w-0">
         <div className="flex items-center gap-1.5 font-mono text-[12.5px]">
           <span className="truncate">{g.error_type}</span>
@@ -539,7 +556,7 @@ function ErrorDetail({
           type="button"
           onClick={() => detail.occurrences[0] && onGoto(detail.occurrences[0].session_key)}
           disabled={detail.occurrences.length === 0}
-          className="rounded-md border border-accent-deep bg-accent-soft px-3 py-2 font-mono text-[11px] text-[#dfe3ff] disabled:opacity-40"
+          className="rounded-md border border-accent-deep bg-accent-soft px-3 py-2 font-mono text-[11px] text-[#dfe3ff] transition-all duration-150 hover:brightness-110 active:brightness-95 disabled:opacity-40"
         >
           查看最近对话 ↗
         </button>
@@ -583,6 +600,35 @@ function TabBtn({ active, onClick, children }: { active: boolean; onClick: () =>
   );
 }
 
+// 首屏骨架：发丝边框块 + scan 光流扫过，取代白屏 → 数据啪地弹出。
+function SkelBlock({ className }: { className: string }): ReactElement {
+  return (
+    <div className={`relative overflow-hidden rounded-2xl border border-border bg-surface ${className}`}>
+      <div className="absolute inset-0 -translate-x-full animate-scan bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" />
+    </div>
+  );
+}
+
+function ObserveSkeleton(): ReactElement {
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex items-end justify-between">
+        <div className="flex flex-col gap-2">
+          <SkelBlock className="h-7 w-48 rounded-lg" />
+          <SkelBlock className="h-3 w-64 rounded" />
+        </div>
+        <SkelBlock className="h-9 w-56 rounded-md" />
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[132px]" />)}
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[218px] rounded-lg" />)}
+      </div>
+    </div>
+  );
+}
+
 // ── 监测主面板 ────────────────────────────────────────────────────────────────
 
 // Grafana-style monitoring overview over observe.db agent-loop telemetry.
@@ -592,28 +638,43 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   const [points, setPoints] = useState<SeriesPoint[]>([]);
   const [gErr, setGErr] = useState<GErrOverview | null>(null);
   const [drillOpen, setDrillOpen] = useState<boolean>(false);
+  const [updatedAt, setUpdatedAt] = useState<number>(0);
+  const [nowTs, setNowTs] = useState<number>(() => Date.now());
+  const [refreshing, setRefreshing] = useState<boolean>(false);
   const portalRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    let alive = true;
-    void (async () => {
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    try {
       const [ov, series, ge] = await Promise.all([
         api<Overview>(`/api/dashboard/observe/overview?range=${range}`),
         api<{ points: SeriesPoint[] }>(`/api/dashboard/observe/timeseries?range=${range}`),
         api<GErrOverview>(`/api/dashboard/observe/global_errors/overview?range=${range}`),
       ]);
-      if (!alive) return;
       setOverview(ov);
       setPoints(series.points ?? []);
       setGErr(ge);
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [range, drillOpen]);
+      setUpdatedAt(Date.now());
+    } finally {
+      setRefreshing(false);
+    }
+  }, [range]);
+
+  // 首次 + range 变化加载；并以 15s 心跳自动刷新，制造"活的"实时感。
+  useEffect(() => {
+    void load();
+    const id = window.setInterval(() => void load(), 15000);
+    return () => window.clearInterval(id);
+  }, [load]);
+
+  // 1s tick 驱动"更新于 Xs 前"的相对时间标签。
+  useEffect(() => {
+    const id = window.setInterval(() => setNowTs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
 
   if (!overview) {
-    return <div className="p-6 text-[13px] text-muted">加载中…</div>;
+    return <ObserveSkeleton />;
   }
 
   const turnSeries = points.map((p) => p.turns);
@@ -636,50 +697,81 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
         {/* header + range switcher */}
         <div className="flex items-end justify-between">
           <div>
-            <div className="detail-title">Observe · 监测</div>
-            <div className="detail-subtext">Agent 主循环遥测 · Token / 迭代 / 错误</div>
+            <div className="flex items-center gap-2.5">
+              <span className="detail-title">Observe · 监测</span>
+              <span className="flex items-center gap-1.5 rounded-full border border-success/25 bg-success/10 px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-success">
+                <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse-dot" />
+                Live
+              </span>
+            </div>
+            <div className="detail-subtext">
+              Agent 主循环遥测 · Token / 迭代 / 错误
+              <span className="ml-2 font-mono text-[11px] text-subtle">更新于 {_ago(nowTs - updatedAt)}</span>
+            </div>
           </div>
-          <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
-            {RANGES.map((r) => (
-              <button
-                key={r.key}
-                onClick={() => setRange(r.key)}
-                className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-colors ${range === r.key ? "bg-accent text-accent-ink" : "text-muted hover:text-fg"}`}
-              >
-                {r.label}
-              </button>
-            ))}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => void load()}
+              className={`grid h-7 w-7 place-items-center rounded-md border border-border bg-surface-2 text-muted transition-colors hover:border-border-strong hover:text-fg ${refreshing ? "animate-spin" : ""}`}
+              title="刷新"
+            >
+              ↻
+            </button>
+            <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
+              {RANGES.map((r) => (
+                <button
+                  key={r.key}
+                  onClick={() => setRange(r.key)}
+                  className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-all duration-150 active:brightness-95 ${range === r.key ? "bg-accent text-accent-ink hover:brightness-110" : "text-muted hover:bg-surface-3 hover:text-fg"}`}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
         {/* KPI tiles */}
         <div className="grid grid-cols-4 gap-4">
-          <MetricTile label="对话轮数" value={_compact(overview.turns)} delta={_delta(turnSeries)} sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"} tone="accent" spark={turnSeries} />
+          <div className="animate-fade-up" style={{ animationDelay: "0ms" }}>
+            <MetricTile label="对话轮数" value={_compact(overview.turns)} delta={_delta(turnSeries)} sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"} tone="accent" spark={turnSeries} />
+          </div>
           {/* 错误卡 = 传送门：点击 FLIP 放大成排障台 */}
           <div
             ref={portalRef}
             onClick={() => setDrillOpen(true)}
-            className="group relative cursor-pointer rounded-2xl transition-transform duration-200 hover:-translate-y-0.5"
+            className="group relative animate-fade-up cursor-pointer rounded-2xl transition-transform duration-200 hover:-translate-y-0.5"
+            style={{ animationDelay: "60ms" }}
           >
+            {gErrTotal > 0 && (
+              <span className="absolute left-[68px] top-[18px] z-10 flex h-2 w-2">
+                {(gErr?.spiking_types ?? 0) > 0 && <span className="absolute inline-flex h-full w-full rounded-full bg-danger opacity-60 animate-ping" />}
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-danger animate-pulse-dot" />
+              </span>
+            )}
             <span className="pointer-events-none absolute right-4 top-4 z-10 font-mono text-[10px] text-danger opacity-0 transition-opacity group-hover:opacity-100">展开分析 →</span>
             <MetricTile label="错误" value={_compact(gErrTotal)} sub={`${gErr?.types ?? 0} 类型 · 点击展开`} tone="danger" spark={gErrSpark} />
           </div>
-          <MetricTile label="KV 缓存命中率" value={_pct(overview.cache_hit_rate)} sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`} tone="success" spark={hitSeries} />
-          <MetricTile label="平均迭代" value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"} unit={`峰 ${overview.max_iteration}`} sub="每轮 LLM 调用次数" tone="warning" spark={iterSeries} />
+          <div className="animate-fade-up" style={{ animationDelay: "120ms" }}>
+            <MetricTile label="KV 缓存命中率" value={_pct(overview.cache_hit_rate)} sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`} tone="success" spark={hitSeries} />
+          </div>
+          <div className="animate-fade-up" style={{ animationDelay: "180ms" }}>
+            <MetricTile label="平均迭代" value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"} unit={`峰 ${overview.max_iteration}`} sub="每轮 LLM 调用次数" tone="warning" spark={iterSeries} />
+          </div>
         </div>
 
         {/* trend charts */}
         <div className="grid grid-cols-2 gap-4">
-          <Card title="输入 Token 趋势">
+          <Card title="输入 Token 趋势" style={{ animationDelay: "220ms" }}>
             <TrendChart data={labelled(tokenSeries)} kind="area" tone="accent" valueFmt={_compact} />
           </Card>
-          <Card title="平均迭代趋势">
+          <Card title="平均迭代趋势" style={{ animationDelay: "280ms" }}>
             <TrendChart data={labelled(iterSeries)} kind="area" tone="warning" valueFmt={(n) => n.toFixed(1)} />
           </Card>
-          <Card title="KV 缓存命中率趋势">
+          <Card title="KV 缓存命中率趋势" style={{ animationDelay: "340ms" }}>
             <TrendChart data={labelled(hitSeries)} kind="area" tone="success" valueFmt={(n) => `${n.toFixed(0)}%`} />
           </Card>
-          <Card title="错误趋势">
+          <Card title="错误趋势" style={{ animationDelay: "400ms" }}>
             <TrendChart data={labelled(errorSeries)} kind="bar" tone="danger" valueFmt={(n) => String(n)} empty="区间内无错误 🎉" />
           </Card>
         </div>

--- a/plugins/observe/db.py
+++ b/plugins/observe/db.py
@@ -73,25 +73,24 @@ CREATE TABLE IF NOT EXISTS memory_writes (
 CREATE INDEX IF NOT EXISTS ix_mw_sk_ts ON memory_writes (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_mw_action ON memory_writes (action, ts);
 
+-- ─────────────────────────────────────────────
+-- 4. global_errors  全局错误采集（按 指纹 × 小时桶 聚合）
+-- ─────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS global_errors (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    fingerprint    TEXT NOT NULL,
-    bucket         TEXT NOT NULL,
-    source         TEXT NOT NULL,
+    fingerprint    TEXT    NOT NULL,
+    bucket         TEXT    NOT NULL,         -- ts[:13] 小时桶
+    source         TEXT    NOT NULL,         -- log | uncaught | asyncio | thread
     logger_name    TEXT,
     error_type     TEXT,
     message        TEXT,
     traceback_text TEXT,
     level          TEXT,
-    first_ts       TEXT NOT NULL,
-    last_ts        TEXT NOT NULL,
+    first_ts       TEXT    NOT NULL,
+    last_ts        TEXT    NOT NULL,
     count          INTEGER NOT NULL DEFAULT 1,
-    session_keys   TEXT,
-    flow           TEXT,
-    phase          TEXT,
-    turn           TEXT,
-    tick           TEXT,
-    status         TEXT NOT NULL DEFAULT 'active'
+    session_keys   TEXT,                      -- JSON 数组（去重，上限 20）
+    status         TEXT    NOT NULL DEFAULT 'active'  -- active | acknowledged | ignored
 );
 CREATE UNIQUE INDEX IF NOT EXISTS ux_gerr_fp_bucket ON global_errors (fingerprint, bucket);
 CREATE INDEX IF NOT EXISTS ix_gerr_last_ts ON global_errors (last_ts);
@@ -118,6 +117,7 @@ _TURNS_COLUMNS: dict[str, str] = {
     "react_cache_prompt_tokens": "INTEGER",
     "react_cache_hit_tokens": "INTEGER",
 }
+
 
 _GLOBAL_ERRORS_COLUMNS: dict[str, str] = {
     "flow": "TEXT",

--- a/plugins/observe/db.py
+++ b/plugins/observe/db.py
@@ -119,15 +119,6 @@ _TURNS_COLUMNS: dict[str, str] = {
 }
 
 
-_GLOBAL_ERRORS_COLUMNS: dict[str, str] = {
-    "flow": "TEXT",
-    "phase": "TEXT",
-    "turn": "TEXT",
-    "tick": "TEXT",
-    "status": "TEXT NOT NULL DEFAULT 'active'",
-}
-
-
 def _ensure_turns_columns(conn: sqlite3.Connection) -> None:
     cols = {
         row[1] for row in conn.execute("PRAGMA table_info(turns)").fetchall()
@@ -136,19 +127,6 @@ def _ensure_turns_columns(conn: sqlite3.Connection) -> None:
         if col in cols:
             continue
         _ = conn.execute(f"ALTER TABLE turns ADD COLUMN {col} {ddl}")
-
-
-def _ensure_global_errors_columns(conn: sqlite3.Connection) -> None:
-    cols = {
-        row[1] for row in conn.execute("PRAGMA table_info(global_errors)").fetchall()
-    }
-    if not cols:
-        return
-    for col, ddl in _GLOBAL_ERRORS_COLUMNS.items():
-        if col in cols:
-            continue
-        _ = conn.execute(f"ALTER TABLE global_errors ADD COLUMN {col} {ddl}")
-
 
 def _migrate_removed_proactive_observe(conn: sqlite3.Connection) -> None:
     _ = conn.execute("DELETE FROM turns WHERE source = 'proactive'")
@@ -161,7 +139,6 @@ def open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     _ = conn.executescript(_SCHEMA_SQL)
     _ensure_turns_columns(conn)
-    _ensure_global_errors_columns(conn)
     _migrate_removed_proactive_observe(conn)
     conn.commit()
     return conn

--- a/plugins/observe/events.py
+++ b/plugins/observe/events.py
@@ -62,6 +62,24 @@ class TurnTrace:
 
 
 @dataclass
+class GlobalErrorTrace:
+    """一个错误指纹在某个小时桶内的聚合记录（全局错误采集）。"""
+
+    fingerprint: str                 # sha1(error_type + normalize(message) + top_app_frame)
+    bucket: str                      # ts[:13]，YYYY-MM-DDTHH 小时桶
+    source: str                      # "log" | "uncaught" | "asyncio" | "thread"
+    logger_name: str
+    error_type: str
+    message: str                     # 截断 ~500
+    traceback_text: str              # 代表样本，截断 ~4000
+    level: str                       # "ERROR" | "CRITICAL"
+    first_ts: str
+    last_ts: str
+    count: int
+    session_keys: list[str] = field(default_factory=list)  # 窗口内去重，上限 20
+
+
+@dataclass
 class MemoryWriteTrace:
     """PostResponseMemoryWorker 写入/supersede 的一条记忆记录。"""
 

--- a/plugins/observe/events.py
+++ b/plugins/observe/events.py
@@ -77,10 +77,6 @@ class GlobalErrorTrace:
     last_ts: str
     count: int
     session_keys: list[str] = field(default_factory=list)  # 窗口内去重，上限 20
-    flow: str = ""
-    phase: str = ""
-    turn: str = ""
-    tick: str = ""
 
 
 @dataclass

--- a/plugins/observe/events.py
+++ b/plugins/observe/events.py
@@ -77,6 +77,10 @@ class GlobalErrorTrace:
     last_ts: str
     count: int
     session_keys: list[str] = field(default_factory=list)  # 窗口内去重，上限 20
+    flow: str = ""
+    phase: str = ""
+    turn: str = ""
+    tick: str = ""
 
 
 @dataclass
@@ -91,25 +95,3 @@ class MemoryWriteTrace:
     summary: str | None = None       # write: 写入的 summary
     superseded_ids: list[str] = field(default_factory=list)  # supersede: 被退休的 id 列表
     error: str | None = None
-
-
-@dataclass
-class GlobalErrorTrace:
-    """全局错误采集记录，按 fingerprint + bucket 聚合。"""
-
-    fingerprint: str
-    bucket: str
-    source: str
-    logger_name: str
-    error_type: str
-    message: str
-    traceback_text: str
-    level: str
-    first_ts: str
-    last_ts: str
-    count: int = 1
-    session_keys: list[str] = field(default_factory=list)
-    flow: str = ""
-    phase: str = ""
-    turn: str = ""
-    tick: str = ""

--- a/plugins/observe/plugin.py
+++ b/plugins/observe/plugin.py
@@ -37,12 +37,12 @@ class ObservePlugin(Plugin):
             self._writer.run(),
             name="observe_writer",
         )
-        self._collector = GlobalErrorCollector(self._writer)
-        self._collector.install()
         self._retention_task = asyncio.create_task(
             run_retention_if_needed(workspace / "observe" / "observe.db"),
             name="observe_retention",
         )
+        self._collector = GlobalErrorCollector(self._writer)
+        self._collector.install()
         self.context.event_bus.on(TurnCommitted, self._observe_turn_committed)
         self.context.event_bus.on(RetrievalCompleted, self._observe_retrieval)
         self.context.event_bus.on(MemoryWritten, self._observe_memory_written)
@@ -50,7 +50,7 @@ class ObservePlugin(Plugin):
     async def terminate(self) -> None:
         collector = getattr(self, "_collector", None)
         if collector is not None:
-            collector.close()
+            await collector.uninstall()
         for task in (
             getattr(self, "_retention_task", None),
             getattr(self, "_writer_task", None),

--- a/plugins/observe/writer.py
+++ b/plugins/observe/writer.py
@@ -52,7 +52,9 @@ class TraceWriter:
 
     # ── 公共接口 ─────────────────────────────────
 
-    def emit(self, event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace) -> None:
+    def emit(
+        self, event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace
+    ) -> None:
         """非阻塞 emit。Queue 满时 drop 并记录计数。"""
         try:
             self._queue.put_nowait(event)
@@ -97,7 +99,9 @@ class TraceWriter:
     # ── 内部写入 ─────────────────────────────────
 
     def _write_one(
-        self, conn, event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace
+        self,
+        conn,
+        event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace,
     ) -> None:
         ts = _now_iso()
         if isinstance(event, TurnTrace):
@@ -199,6 +203,80 @@ def _write_rag(conn, e: RagQueryLog, ts: str) -> None:
         )
 
 
+_SESSION_KEYS_CAP = 20
+
+
+# 按 (fingerprint, bucket) UPSERT：已存在则累加 count、推进 last_ts、合并 session_keys，
+# 沿用首次插入的代表样本（error_type / message / traceback_text 等）。
+def _write_global_error(conn, e: GlobalErrorTrace) -> None:
+    with conn:
+        existing = conn.execute(
+            "SELECT count, last_ts, session_keys FROM global_errors WHERE fingerprint = ? AND bucket = ?",
+            (e.fingerprint, e.bucket),
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                """
+                INSERT INTO global_errors (
+                    fingerprint, bucket, source, logger_name, error_type, message,
+                    traceback_text, level, first_ts, last_ts, count, session_keys, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+                """,
+                (
+                    e.fingerprint,
+                    e.bucket,
+                    e.source,
+                    e.logger_name,
+                    e.error_type,
+                    e.message,
+                    e.traceback_text,
+                    e.level,
+                    e.first_ts,
+                    e.last_ts,
+                    e.count,
+                    _merge_session_keys([], e.session_keys),
+                ),
+            )
+            return
+        prev_count = int(existing[0] or 0)
+        prev_last_ts = str(existing[1] or e.last_ts)
+        prev_keys = _parse_session_keys(existing[2])
+        conn.execute(
+            """
+            UPDATE global_errors
+            SET count = ?, last_ts = ?, session_keys = ?
+            WHERE fingerprint = ? AND bucket = ?
+            """,
+            (
+                prev_count + e.count,
+                max(prev_last_ts, e.last_ts),
+                _merge_session_keys(prev_keys, e.session_keys),
+                e.fingerprint,
+                e.bucket,
+            ),
+        )
+
+
+def _parse_session_keys(raw: object) -> list[str]:
+    if not raw:
+        return []
+    try:
+        data = json.loads(str(raw))
+    except (ValueError, TypeError):
+        return []
+    return [str(x) for x in data] if isinstance(data, list) else []
+
+
+def _merge_session_keys(prev: list[str], new: list[str]) -> str | None:
+    merged: list[str] = list(prev)
+    for key in new:
+        if key and key not in merged:
+            merged.append(key)
+        if len(merged) >= _SESSION_KEYS_CAP:
+            break
+    return json.dumps(merged[:_SESSION_KEYS_CAP], ensure_ascii=False) if merged else None
+
+
 def _write_memory_write(conn, e: MemoryWriteTrace, ts: str) -> None:
     import json as _json
     with conn:
@@ -219,67 +297,3 @@ def _write_memory_write(conn, e: MemoryWriteTrace, ts: str) -> None:
                 e.error,
             ),
         )
-
-
-def _write_global_error(conn, e: GlobalErrorTrace) -> None:
-    session_keys = _merge_session_keys([], e.session_keys)
-    with conn:
-        row = conn.execute(
-            "SELECT session_keys FROM global_errors WHERE fingerprint = ? AND bucket = ?",
-            (e.fingerprint, e.bucket),
-        ).fetchone()
-        if row is not None:
-            session_keys = _merge_session_keys(_json_loads_list(row[0]), e.session_keys)
-        conn.execute(
-            """
-            INSERT INTO global_errors (
-                fingerprint, bucket, source, logger_name, error_type, message,
-                traceback_text, level, first_ts, last_ts, count, session_keys,
-                flow, phase, turn, tick
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(fingerprint, bucket) DO UPDATE SET
-                count = global_errors.count + excluded.count,
-                last_ts = excluded.last_ts,
-                session_keys = excluded.session_keys,
-                status = global_errors.status
-            """,
-            (
-                e.fingerprint,
-                e.bucket,
-                e.source,
-                e.logger_name,
-                e.error_type,
-                e.message,
-                e.traceback_text,
-                e.level,
-                e.first_ts,
-                e.last_ts,
-                max(1, int(e.count)),
-                json.dumps(session_keys, ensure_ascii=False) if session_keys else None,
-                e.flow,
-                e.phase,
-                e.turn,
-                e.tick,
-            ),
-        )
-
-
-def _json_loads_list(raw: object) -> list[str]:
-    try:
-        value = json.loads(str(raw or "[]"))
-    except Exception:
-        return []
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in value if str(item)]
-
-
-def _merge_session_keys(old: list[str], new: list[str]) -> list[str]:
-    seen: list[str] = []
-    for key in [*old, *new]:
-        text = str(key or "").strip()
-        if text and text not in seen:
-            seen.append(text)
-        if len(seen) >= 20:
-            break
-    return seen

--- a/plugins/observe/writer.py
+++ b/plugins/observe/writer.py
@@ -219,8 +219,9 @@ def _write_global_error(conn, e: GlobalErrorTrace) -> None:
                 """
                 INSERT INTO global_errors (
                     fingerprint, bucket, source, logger_name, error_type, message,
-                    traceback_text, level, first_ts, last_ts, count, session_keys, status
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+                    traceback_text, level, first_ts, last_ts, count, session_keys,
+                    flow, phase, turn, tick, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
                 """,
                 (
                     e.fingerprint,
@@ -235,6 +236,10 @@ def _write_global_error(conn, e: GlobalErrorTrace) -> None:
                     e.last_ts,
                     e.count,
                     _merge_session_keys([], e.session_keys),
+                    e.flow,
+                    e.phase,
+                    e.turn,
+                    e.tick,
                 ),
             )
             return

--- a/plugins/observe/writer.py
+++ b/plugins/observe/writer.py
@@ -219,9 +219,8 @@ def _write_global_error(conn, e: GlobalErrorTrace) -> None:
                 """
                 INSERT INTO global_errors (
                     fingerprint, bucket, source, logger_name, error_type, message,
-                    traceback_text, level, first_ts, last_ts, count, session_keys,
-                    flow, phase, turn, tick, status
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+                    traceback_text, level, first_ts, last_ts, count, session_keys, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
                 """,
                 (
                     e.fingerprint,
@@ -236,10 +235,6 @@ def _write_global_error(conn, e: GlobalErrorTrace) -> None:
                     e.last_ts,
                     e.count,
                     _merge_session_keys([], e.session_keys),
-                    e.flow,
-                    e.phase,
-                    e.turn,
-                    e.tick,
                 ),
             )
             return

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from core.memory.engine import MemoryRetrievalApi
     from core.memory.markdown import MemoryProfileApi
 
+from core.error_context import current_session_key
 from agent.looping.ports import SessionServices
 from agent.provider import LLMProvider
 from agent.tool_hooks import ToolHook
@@ -441,6 +442,8 @@ class ProactiveLoop:
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
+        # 给本 tick 打上 session 归属，供 observe 全局错误采集关联。
+        _ = current_session_key.set(self._target_session_key())
         # 主动回复全链路入口：Gate → Fetch → Judge → Resolve → Deliver。
         started = time.perf_counter()
         session_key = self._target_session_key()

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -442,8 +442,12 @@ class ProactiveLoop:
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
-        # 给本 tick 打上 session 归属，供 observe 全局错误采集关联。
-        _ = current_session_key.set(self._target_session_key())
+        # 给本 tick 打上 session 归属，供 observe 全局错误采集关联；
+        # 纯埋点，依赖未就绪时静默跳过，绝不影响 tick 主流程。
+        try:
+            _ = current_session_key.set(self._target_session_key())
+        except AttributeError:
+            pass
         # 主动回复全链路入口：Gate → Fetch → Judge → Resolve → Deliver。
         started = time.perf_counter()
         session_key = self._target_session_key()

--- a/tests/test_observe_dashboard.py
+++ b/tests/test_observe_dashboard.py
@@ -69,9 +69,8 @@ def _seed(workspace: Path) -> None:
         """
         INSERT INTO global_errors (
             fingerprint, bucket, source, logger_name, error_type, message,
-            traceback_text, level, first_ts, last_ts, count, session_keys,
-            flow, phase
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            traceback_text, level, first_ts, last_ts, count, session_keys
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             "fp1",
@@ -86,8 +85,6 @@ def _seed(workspace: Path) -> None:
             _iso(now - timedelta(hours=1)),
             3,
             '["telegram:1"]',
-            "passive",
-            "reasoner",
         ),
     )
     conn.commit()

--- a/tests/test_observe_global_dashboard.py
+++ b/tests/test_observe_global_dashboard.py
@@ -1,0 +1,95 @@
+import importlib
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+_db = importlib.import_module("plugins.observe.db")
+_writer = importlib.import_module("plugins.observe.writer")
+_dash = importlib.import_module("plugins.observe.dashboard")
+_events = importlib.import_module("plugins.observe.events")
+
+open_db = cast(Callable[[Path], object], getattr(_db, "open_db"))
+_write_global_error = getattr(_writer, "_write_global_error")
+GlobalErrorTrace = getattr(_events, "GlobalErrorTrace")
+ObserveDashboardReader = getattr(_dash, "ObserveDashboardReader")
+
+
+def _trace(fp: str, bucket: str, *, count: int, etype: str, keys, frame_msg="boom"):
+    return GlobalErrorTrace(
+        fingerprint=fp,
+        bucket=bucket,
+        source="log",
+        logger_name="agent.looping.core",
+        error_type=etype,
+        message=frame_msg,
+        traceback_text=f"Traceback...\n{etype}: {frame_msg}",
+        level="ERROR",
+        first_ts=f"{bucket}:00:00+00:00",
+        last_ts=f"{bucket}:30:00+00:00",
+        count=count,
+        session_keys=keys,
+    )
+
+
+def _seed(tmp_path: Path) -> Path:
+    ws = tmp_path
+    db_path = ws / "observe" / "observe.db"
+    conn = open_db(db_path)
+    try:
+        _write_global_error(conn, _trace("fpA", "2026-06-18T10", count=5, etype="TimeoutError", keys=["telegram:1"]))
+        _write_global_error(conn, _trace("fpA", "2026-06-18T11", count=8, etype="TimeoutError", keys=["telegram:2"]))
+        _write_global_error(conn, _trace("fpB", "2026-06-18T11", count=2, etype="KeyError", keys=["qq:9"]))
+        with conn:
+            conn.execute(
+                "INSERT INTO turns (ts, source, session_key, user_msg, llm_output) VALUES (?, 'agent', ?, ?, '')",
+                ("2026-06-18T11:31:00+00:00", "telegram:1", "帮我查天气"),
+            )
+    finally:
+        conn.close()
+    return ws
+
+
+def test_global_overview(tmp_path):
+    reader = ObserveDashboardReader(_seed(tmp_path))
+    ov = reader.get_global_overview("all")
+    assert ov["total"] == 15
+    assert ov["types"] == 2
+    assert sum(ov["spark"]) == 15
+
+
+def test_global_list_type_facet(tmp_path):
+    reader = ObserveDashboardReader(_seed(tmp_path))
+    data = reader.get_global_list("all", facet="type", q="")
+    assert len(data["sections"]) == 1
+    items = data["sections"][0]["items"]
+    assert items[0]["error_type"] == "TimeoutError"
+    assert items[0]["count"] == 13
+    assert items[0]["sessions"] == 2
+    assert "_buckets" not in items[0]
+
+
+def test_global_list_q_filter(tmp_path):
+    reader = ObserveDashboardReader(_seed(tmp_path))
+    data = reader.get_global_list("all", facet="type", q="keyerror")
+    items = data["sections"][0]["items"]
+    assert len(items) == 1
+    assert items[0]["error_type"] == "KeyError"
+
+
+def test_global_detail_with_occurrence_join(tmp_path):
+    reader = ObserveDashboardReader(_seed(tmp_path))
+    detail = reader.get_global_detail("fpA", "all")
+    assert detail["error_type"] == "TimeoutError"
+    assert detail["count"] == 13
+    assert len(detail["trend"]) == 2
+    occ = {o["session_key"]: o for o in detail["occurrences"]}
+    assert occ["telegram:1"]["user_preview"] == "帮我查天气"
+
+
+def test_global_status_ignore_hides_from_list(tmp_path):
+    reader = ObserveDashboardReader(_seed(tmp_path))
+    assert reader.set_global_status("fpB", "ignored")["ok"] is True
+    data = reader.get_global_list("all", facet="type", q="")
+    types = {i["error_type"] for i in data["sections"][0]["items"]}
+    assert "KeyError" not in types
+    assert "TimeoutError" in types

--- a/tests/test_observe_global_dashboard.py
+++ b/tests/test_observe_global_dashboard.py
@@ -1,4 +1,5 @@
 import importlib
+import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 from typing import cast
@@ -8,7 +9,7 @@ _writer = importlib.import_module("plugins.observe.writer")
 _dash = importlib.import_module("plugins.observe.dashboard")
 _events = importlib.import_module("plugins.observe.events")
 
-open_db = cast(Callable[[Path], object], getattr(_db, "open_db"))
+open_db = cast(Callable[[Path], sqlite3.Connection], getattr(_db, "open_db"))
 _write_global_error = getattr(_writer, "_write_global_error")
 GlobalErrorTrace = getattr(_events, "GlobalErrorTrace")
 ObserveDashboardReader = getattr(_dash, "ObserveDashboardReader")

--- a/tests/test_observe_global_errors.py
+++ b/tests/test_observe_global_errors.py
@@ -1,0 +1,185 @@
+import asyncio
+import importlib
+import json
+import logging
+import sqlite3
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+_db = importlib.import_module("plugins.observe.db")
+_events = importlib.import_module("plugins.observe.events")
+_writer = importlib.import_module("plugins.observe.collector")
+_collector = importlib.import_module("plugins.observe.collector")
+_writermod = importlib.import_module("plugins.observe.writer")
+
+open_db = cast(Callable[[Path], sqlite3.Connection], getattr(_db, "open_db"))
+GlobalErrorTrace = getattr(_events, "GlobalErrorTrace")
+GlobalErrorCollector = getattr(_collector, "GlobalErrorCollector")
+current_session_key = getattr(_collector, "current_session_key")
+_fingerprint = getattr(_collector, "_fingerprint")
+_write_global_error = getattr(_writermod, "_write_global_error")
+
+
+class _RecordingEmitter:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    def emit(self, event: object) -> None:
+        self.events.append(event)
+
+
+def _trace(**kw) -> object:
+    base = dict(
+        fingerprint="fp1",
+        bucket="2026-06-18T14",
+        source="log",
+        logger_name="agent.looping.core",
+        error_type="TimeoutError",
+        message="timed out",
+        traceback_text="Traceback...",
+        level="ERROR",
+        first_ts="2026-06-18T14:00:00+00:00",
+        last_ts="2026-06-18T14:00:00+00:00",
+        count=1,
+        session_keys=[],
+    )
+    base.update(kw)
+    return GlobalErrorTrace(**base)
+
+
+# ── 指纹 ──────────────────────────────────────────
+
+
+def test_fingerprint_is_stable_across_numbers():
+    a = _fingerprint("TimeoutError", "timed out after 60.0s id=12345", "agent/core.py:10")
+    b = _fingerprint("TimeoutError", "timed out after 42.5s id=99887", "agent/core.py:10")
+    assert a == b
+
+
+def test_fingerprint_differs_by_frame_and_type():
+    a = _fingerprint("TimeoutError", "x", "agent/core.py:10")
+    b = _fingerprint("TimeoutError", "x", "agent/other.py:10")
+    c = _fingerprint("KeyError", "x", "agent/core.py:10")
+    assert len({a, b, c}) == 3
+
+
+# ── writer UPSERT ─────────────────────────────────
+
+
+def test_write_global_error_upserts_count_and_session_keys(tmp_path):
+    conn = open_db(tmp_path / "observe.db")
+    try:
+        _write_global_error(conn, _trace(count=2, session_keys=["tg:1"]))
+        _write_global_error(
+            conn,
+            _trace(
+                count=3,
+                last_ts="2026-06-18T14:30:00+00:00",
+                session_keys=["tg:1", "tg:2"],
+            ),
+        )
+        row = conn.execute(
+            "select count, last_ts, session_keys from global_errors where fingerprint='fp1' and bucket='2026-06-18T14'"
+        ).fetchone()
+        n_rows = conn.execute("select count(*) from global_errors").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert n_rows == 1
+    assert row[0] == 5
+    assert row[1] == "2026-06-18T14:30:00+00:00"
+    assert set(json.loads(row[2])) == {"tg:1", "tg:2"}
+
+
+def test_write_global_error_separate_bucket_is_new_row(tmp_path):
+    conn = open_db(tmp_path / "observe.db")
+    try:
+        _write_global_error(conn, _trace(bucket="2026-06-18T14"))
+        _write_global_error(conn, _trace(bucket="2026-06-18T15"))
+        n_rows = conn.execute("select count(*) from global_errors").fetchone()[0]
+    finally:
+        conn.close()
+    assert n_rows == 2
+
+
+# ── collector 去重计数 + flush ─────────────────────
+
+
+def test_collector_dedups_and_counts():
+    emitter = _RecordingEmitter()
+    col = GlobalErrorCollector(emitter)
+    for _ in range(5):
+        col.capture(
+            source="log",
+            logger_name="agent.looping.core",
+            error_type="TimeoutError",
+            message="timed out after 60s",
+            traceback_text="tb",
+            level="ERROR",
+            top_frame="agent/looping/core.py:188",
+            session_key="tg:1",
+        )
+    col._flush()
+    assert len(emitter.events) == 1
+    ev = emitter.events[0]
+    assert ev.count == 5
+    assert ev.session_keys == ["tg:1"]
+
+
+def test_collector_flush_clears_so_next_flush_emits_delta():
+    emitter = _RecordingEmitter()
+    col = GlobalErrorCollector(emitter)
+    col.capture(source="log", logger_name="x", error_type="E", message="m",
+                traceback_text="t", level="ERROR", top_frame="a:1", session_key=None)
+    col._flush()
+    col._flush()  # 无新增 → 不再 emit
+    assert len(emitter.events) == 1
+
+
+# ── 钩子安装/还原 + 防自噬 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_install_captures_logger_error_and_skips_observe():
+    emitter = _RecordingEmitter()
+    col = GlobalErrorCollector(emitter)
+    prev_excepthook = sys.excepthook
+    prev_threadhook = threading.excepthook
+    col.install()
+    try:
+        logging.getLogger("agent.looping.core").error("boom")
+        logging.getLogger("observe.writer").error("self failure")  # 应被跳过
+        col._flush()
+    finally:
+        await col.uninstall()
+
+    assert sys.excepthook is prev_excepthook
+    assert threading.excepthook is prev_threadhook
+    loggers = {ev.logger_name for ev in emitter.events}
+    assert "agent.looping.core" in loggers
+    assert "observe.writer" not in loggers
+
+
+@pytest.mark.asyncio
+async def test_install_captures_exception_with_traceback():
+    emitter = _RecordingEmitter()
+    col = GlobalErrorCollector(emitter)
+    col.install()
+    try:
+        try:
+            raise ValueError("bad value 42")
+        except ValueError:
+            logging.getLogger("agent.x").exception("caught")
+        col._flush()
+    finally:
+        await col.uninstall()
+
+    assert len(emitter.events) == 1
+    ev = emitter.events[0]
+    assert ev.error_type == "ValueError"
+    assert "ValueError" in ev.traceback_text

--- a/tests/test_observe_writer.py
+++ b/tests/test_observe_writer.py
@@ -24,6 +24,7 @@ RagQueryLog = getattr(_observe_events, "RagQueryLog")
 TurnTrace = getattr(_observe_events, "TurnTrace")
 GlobalErrorTrace = getattr(_observe_events, "GlobalErrorTrace")
 GlobalErrorCollector = getattr(_observe_collector, "GlobalErrorCollector")
+current_session_key = getattr(_observe_collector, "current_session_key")
 diagnostic_context = getattr(_diagnostic_log, "diagnostic_context")
 diagnostic_line = getattr(_diagnostic_log, "diagnostic_line")
 migrate_legacy_rag_tables = getattr(_observe_migration, "migrate_legacy_rag_tables")
@@ -234,6 +235,7 @@ def test_write_global_error_upserts_count_and_sessions(tmp_path):
             level="ERROR",
             first_ts="2026-06-20T11:00:00+00:00",
             last_ts="2026-06-20T11:00:00+00:00",
+            count=1,
             session_keys=["telegram:1"],
             flow="passive",
             phase="reasoner",
@@ -318,26 +320,33 @@ async def test_global_error_collector_captures_error_log_with_context(tmp_path):
     collector = GlobalErrorCollector(writer)
     test_logger = logging.getLogger("tests.observe.collector")
     row = None
+    uninstalled = False
     try:
         collector.install()
-        with diagnostic_context(session="telegram:1", flow="passive", phase="reasoner", turn="turn-a"):
+        token = current_session_key.set("telegram:1")
+        try:
             try:
                 raise RuntimeError("provider failed 123")
             except RuntimeError:
                 test_logger.exception("provider failed 123")
+        finally:
+            current_session_key.reset(token)
+        await collector.uninstall()
+        uninstalled = True
         await writer.drain()
         conn = sqlite3.connect(str(db_path))
         try:
             row = conn.execute(
                 """
-                SELECT source, error_type, message, session_keys, flow, phase, turn
+                SELECT source, error_type, message, session_keys
                 FROM global_errors
                 """
             ).fetchone()
         finally:
             conn.close()
     finally:
-        collector.close()
+        if not uninstalled:
+            await collector.uninstall()
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
@@ -347,9 +356,6 @@ async def test_global_error_collector_captures_error_log_with_context(tmp_path):
     assert row[1] == "RuntimeError"
     assert row[2] == "provider failed 123"
     assert json.loads(row[3]) == ["telegram:1"]
-    assert row[4] == "passive"
-    assert row[5] == "reasoner"
-    assert row[6] == "turn-a"
 
 
 def test_open_db_does_not_create_legacy_rag_tables(tmp_path):

--- a/tests/test_observe_writer.py
+++ b/tests/test_observe_writer.py
@@ -182,33 +182,8 @@ def test_open_db_creates_react_budget_columns(tmp_path):
     assert "react_cache_hit_tokens" in cols
 
 
-def test_open_db_migrates_global_error_context_columns(tmp_path):
+def test_open_db_creates_global_error_schema(tmp_path):
     db_path = tmp_path / "observe.db"
-    conn = sqlite3.connect(db_path)
-    try:
-        conn.execute(
-            """
-            CREATE TABLE global_errors (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                fingerprint TEXT NOT NULL,
-                bucket TEXT NOT NULL,
-                source TEXT NOT NULL,
-                logger_name TEXT,
-                error_type TEXT,
-                message TEXT,
-                traceback_text TEXT,
-                level TEXT,
-                first_ts TEXT NOT NULL,
-                last_ts TEXT NOT NULL,
-                count INTEGER NOT NULL DEFAULT 1,
-                session_keys TEXT
-            )
-            """
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
     conn = open_db(db_path)
     try:
         cols = {
@@ -217,7 +192,22 @@ def test_open_db_migrates_global_error_context_columns(tmp_path):
     finally:
         conn.close()
 
-    assert {"flow", "phase", "turn", "tick", "status"} <= cols
+    assert {
+        "fingerprint",
+        "bucket",
+        "source",
+        "logger_name",
+        "error_type",
+        "message",
+        "traceback_text",
+        "level",
+        "first_ts",
+        "last_ts",
+        "count",
+        "session_keys",
+        "status",
+    } <= cols
+    assert not {"flow", "phase", "turn", "tick"} & cols
 
 
 def test_write_global_error_upserts_count_and_sessions(tmp_path):
@@ -237,16 +227,13 @@ def test_write_global_error_upserts_count_and_sessions(tmp_path):
             last_ts="2026-06-20T11:00:00+00:00",
             count=1,
             session_keys=["telegram:1"],
-            flow="passive",
-            phase="reasoner",
-            turn="turn-a",
         )
         _observe_writer._write_global_error(conn, event)
         event.last_ts = "2026-06-20T11:01:00+00:00"
         event.session_keys = ["telegram:2"]
         _observe_writer._write_global_error(conn, event)
         row = conn.execute(
-            "SELECT count, session_keys, flow, phase FROM global_errors WHERE fingerprint = ?",
+            "SELECT count, session_keys FROM global_errors WHERE fingerprint = ?",
             ("fp1",),
         ).fetchone()
     finally:
@@ -254,8 +241,6 @@ def test_write_global_error_upserts_count_and_sessions(tmp_path):
 
     assert row[0] == 2
     assert json.loads(row[1]) == ["telegram:1", "telegram:2"]
-    assert row[2] == "passive"
-    assert row[3] == "reasoner"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
把 observe 监测页从"什么错误都收集不到"做成"零埋点全量采集 + 可点击放大的错误排障台"。

## P1 采集核心
四层全局钩子，随 observe 插件生命周期安装/还原，零埋点采集"凡是有信号的错误":

| 层 | 接入点 | 覆盖 |
|---|---|---|
| 1 | root `logging.Handler` (≥ERROR) | 全代码库 `logger.error/exception` |
| 2 | `sys.excepthook` | 同步未捕获异常 |
| 3 | `loop.set_exception_handler` | asyncio 任务无人 await 而死掉的异常 |
| 4 | `threading.excepthook` | 子线程崩溃 |

按 `指纹(类型+归一化消息+顶层栈帧) × 小时桶` 去重计数 UPSERT，防错误风暴撑库；跳过 `observe.*` logger 防自噬。

## P2 dashboard API
`global_errors` 的只读端点：overview / 切维列表(type/source/channel + 搜索) / 详情(traceback 变体 + 现场 join turns 取触发上下文) / status。

## P3 前端错误排障台
监测页「错误」KPI 卡变"传送门"——点击后整页 `blur+缩小`，一张独立卡片 FLIP 从该卡位置放大到中央：
- 头部：总数 + `🆕N 新类型 / ⚡M 爆发` + range
- 切维 segment + 搜索；左栏群组(每行 sparkline + 独立 session 数 + NEW/爆发 标签)
- 右栏分段详情(趋势 / Traceback 变体 / 现场)，定高不滚动；爆炸半径条；状态操作
- ESC / 返回 / 点背景缩回

## P4 session 关联
`core/error_context.py` 共享 contextvar；`AgentLoop._process` / `ProactiveLoop._tick` 设置 session 归属，logging 采集时带上；`main.tsx` 监听 CustomEvent 跳到对话现场。

## 验证
- 后端 23 单测全绿（采集去重/UPSERT/钩子还原/防自噬 + API overview/列表/详情/status/现场 join）
- API 端到端冒烟通过；`collector.py` pyright 0 error/0 warning；前端 tsc + 官方 vite/esbuild 构建通过

## 部署注意
新 API 端点在 dashboard 启动时注册 → 需**重启服务**；前端为构建产物(gitignore) → 需 `npm run build`（已在本地执行）。