### PR TITLE
[codex] 修复 shell 后台任务超时取消 turn

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
@@ -76,8 +78,9 @@ if TYPE_CHECKING:
     from agent.looping.ports import LLMConfig, LLMServices, SessionServices
     from agent.retrieval.protocol import MemoryRetrievalPipeline
     from agent.tool_hooks.base import ToolHook
-    from session.manager import SessionManager
     from agent.tools.registry import ToolRegistry
+    from session.manager import SessionManager
+from core.common.diagnostic_log import diagnostic_context, diagnostic_line
 
 # 1. 统一通过模块 logger 记录关键分支，供排障和回归测试抓取。
 logger = logging.getLogger(__name__)
@@ -117,6 +120,11 @@ _INCOMPLETE_SUMMARY_PROMPT = """当前任务需要先暂停继续调用工具，
 4) 如果继续，下一步会怎么做。
 可以提到工具名称和关键结果，但不要暴露 tool_call_id、schema、内部 prompt 或原始参数 JSON。
 禁止输出"已达到最大迭代次数"这类模板句；不要输出 JSON。"""
+
+
+def _turn_log_id(key: str, msg: InboundMessage) -> str:
+    raw = f"{key}|{msg.timestamp.isoformat()}|{msg.content[:80]}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8]
 
 
 def _is_tool_loop_guard_denial(exec_result: object) -> bool:
@@ -353,77 +361,234 @@ class PassiveTurnPipeline:
         *,
         dispatch_outbound: bool = True,
     ) -> OutboundMessage:
+        started = time.perf_counter()
+        turn_id = _turn_log_id(key, msg)
         state = TurnState(
             msg=msg,
             session_key=key,
             dispatch_outbound=dispatch_outbound,
         )
-        # try/except 只包前置模块链和 reasoning：在派发前兜底并返回错误提示。
-        try:
-            # Phase 1: BeforeTurn 模块链（会话、上下文、BeforeTurn 事件）。
-            before_turn = await self._before_turn.run(state)
-            # TurnState 存内部默认 metadata；BeforeTurnCtx 存插件导出，同名 key 以后者覆盖。
-            state.extra_metadata.update(before_turn.extra_metadata)
-            if before_turn.abort:
+        with diagnostic_context(session=key, flow="passive", turn=turn_id):
+            logger.info(
+                diagnostic_line(
+                    "PassiveTurnPipeline.run",
+                    event="start",
+                    flow="passive",
+                    phase="before_turn",
+                    session=key,
+                    turn=turn_id,
+                    action="run",
+                )
+            )
+            # try/except 只包前置模块链和 reasoning：在派发前兜底并返回错误提示。
+            try:
+                # Phase 1: BeforeTurn 模块链（会话、上下文、BeforeTurn 事件）。
+                with diagnostic_context(phase="before_turn"):
+                    before_turn = await self._before_turn.run(state)
+                # TurnState 存内部默认 metadata；BeforeTurnCtx 存插件导出，同名 key 以后者覆盖。
+                state.extra_metadata.update(before_turn.extra_metadata)
+                if before_turn.abort:
+                    logger.info(
+                        diagnostic_line(
+                            "PassiveTurnPipeline.run",
+                            event="gate_exit",
+                            flow="passive",
+                            phase="before_turn",
+                            session=key,
+                            turn=turn_id,
+                            action="abort",
+                            reason="before_turn_abort",
+                            duration_ms=int((time.perf_counter() - started) * 1000),
+                        )
+                    )
+                    return await self._control_outbound(
+                        state,
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content=before_turn.abort_reply,
+                        ),
+                    )
+                logger.info(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="end",
+                        flow="passive",
+                        phase="before_turn",
+                        session=key,
+                        turn=turn_id,
+                        action="continue",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                    )
+                )
+
+                # Phase 2: BeforeReasoning 模块链（工具上下文、BeforeReasoning 事件、prompt warmup）。
+                with diagnostic_context(phase="before_reasoning"):
+                    before_reasoning = await self._before_reasoning.run(
+                        BeforeReasoningInput(state=state, before_turn=before_turn)
+                    )
+                if before_reasoning.abort:
+                    logger.info(
+                        diagnostic_line(
+                            "PassiveTurnPipeline.run",
+                            event="gate_exit",
+                            flow="passive",
+                            phase="before_reasoning",
+                            session=key,
+                            turn=turn_id,
+                            action="abort",
+                            reason="before_reasoning_abort",
+                            duration_ms=int((time.perf_counter() - started) * 1000),
+                        )
+                    )
+                    return await self._control_outbound(
+                        state,
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content=before_reasoning.abort_reply,
+                        ),
+                    )
+                logger.info(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="end",
+                        flow="passive",
+                        phase="before_reasoning",
+                        session=key,
+                        turn=turn_id,
+                        action="continue",
+                        counts=f"skills:{len(before_reasoning.skill_names)},hints:{len(before_reasoning.extra_hints)}",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                    )
+                )
+
+                # Phase 3-4: Reasoning（BeforeStep/AfterStep 模块链在 Reasoner 内部执行）。
+                session = state.session
+                if session is None:
+                    raise RuntimeError("Passive turn requires TurnState.session")
+                with diagnostic_context(phase="reasoner"):
+                    turn_result = await self._reasoner.run_turn(
+                        msg=msg,
+                        skill_names=list(before_reasoning.skill_names) or None,
+                        session=session,
+                        base_history=None,
+                        retrieved_memory_block=before_reasoning.retrieved_memory_block,
+                        extra_hints=list(before_reasoning.extra_hints) or None,
+                    )
+                logger.info(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="end",
+                        flow="passive",
+                        phase="reasoner",
+                        session=key,
+                        turn=turn_id,
+                        action="continue",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                    )
+                )
+            except Exception as exc:
+                logger.exception(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="phase_error",
+                        flow="passive",
+                        phase="reasoner",
+                        session=key,
+                        turn=turn_id,
+                        action="fail",
+                        reason="provider_error",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                        error_type=type(exc).__name__,
+                        note=str(exc)[:160],
+                    )
+                )
                 return await self._control_outbound(
                     state,
                     OutboundMessage(
                         channel=msg.channel,
                         chat_id=msg.chat_id,
-                        content=before_turn.abort_reply,
+                        content="处理消息时出错，请稍后再试。",
                     ),
                 )
 
-            # Phase 2: BeforeReasoning 模块链（工具上下文、BeforeReasoning 事件、prompt warmup）。
-            before_reasoning = await self._before_reasoning.run(
-                BeforeReasoningInput(state=state, before_turn=before_turn)
-            )
-            if before_reasoning.abort:
-                return await self._control_outbound(
-                    state,
-                    OutboundMessage(
-                        channel=msg.channel,
-                        chat_id=msg.chat_id,
-                        content=before_reasoning.abort_reply,
-                    ),
+            try:
+                # Phase 5: AfterReasoning 模块链（parse、AfterReasoning 事件、持久化、出站消息）。
+                with diagnostic_context(phase="after_reasoning"):
+                    after_reasoning = await self._after_reasoning.run(
+                        AfterReasoningInput(state=state, turn_result=turn_result)
+                    )
+            except Exception as exc:
+                logger.exception(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="phase_error",
+                        flow="passive",
+                        phase="after_reasoning",
+                        session=key,
+                        turn=turn_id,
+                        action="fail",
+                        reason="invalid_output",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                        error_type=type(exc).__name__,
+                        note=str(exc)[:160],
+                    )
                 )
-
-            # Phase 3-4: Reasoning（BeforeStep/AfterStep 模块链在 Reasoner 内部执行）。
-            session = state.session
-            if session is None:
-                raise RuntimeError("Passive turn requires TurnState.session")
-            turn_result = await self._reasoner.run_turn(
-                msg=msg,
-                skill_names=list(before_reasoning.skill_names) or None,
-                session=session,
-                base_history=None,
-                retrieved_memory_block=before_reasoning.retrieved_memory_block,
-                extra_hints=list(before_reasoning.extra_hints) or None,
-            )
-        except Exception:
-            logger.exception("PassiveTurnPipeline.run failed before dispatch session=%s", key)
-            return await self._control_outbound(
-                state,
-                OutboundMessage(
-                    channel=msg.channel,
-                    chat_id=msg.chat_id,
-                    content="处理消息时出错，请稍后再试。",
-                ),
+                raise
+            logger.info(
+                diagnostic_line(
+                    "PassiveTurnPipeline.run",
+                    event="end",
+                    flow="passive",
+                    phase="after_reasoning",
+                    session=key,
+                    turn=turn_id,
+                    action="continue",
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                )
             )
 
-        # Phase 5: AfterReasoning 模块链（parse、AfterReasoning 事件、持久化、出站消息）。
-        after_reasoning = await self._after_reasoning.run(
-            AfterReasoningInput(state=state, turn_result=turn_result)
-        )
-
-        # Phase 6: AfterTurn 模块链（TurnCommitted fanout、AfterTurn fanout、dispatch）。
-        return await self._after_turn.run(
-            TurnSnapshot(
-                state=state,
-                outbound=after_reasoning.outbound,
-                ctx=after_reasoning.ctx,
+            try:
+                # Phase 6: AfterTurn 模块链（TurnCommitted fanout、AfterTurn fanout、dispatch）。
+                with diagnostic_context(phase="after_turn"):
+                    outbound = await self._after_turn.run(
+                        TurnSnapshot(
+                            state=state,
+                            outbound=after_reasoning.outbound,
+                            ctx=after_reasoning.ctx,
+                        )
+                    )
+            except Exception as exc:
+                logger.exception(
+                    diagnostic_line(
+                        "PassiveTurnPipeline.run",
+                        event="phase_error",
+                        flow="passive",
+                        phase="after_turn",
+                        session=key,
+                        turn=turn_id,
+                        action="fail",
+                        reason="write_error",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                        error_type=type(exc).__name__,
+                        note=str(exc)[:160],
+                    )
+                )
+                raise
+            logger.info(
+                diagnostic_line(
+                    "PassiveTurnPipeline.run",
+                    event="end",
+                    flow="passive",
+                    phase="after_turn",
+                    session=key,
+                    turn=turn_id,
+                    action="done",
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                )
             )
-        )
+            return outbound
 
     # 供外部调用方（如 spawn completion）复用 AfterReasoning + dispatch 流程。
     async def post_reasoning(

--- a/agent/core/proactive_turn.py
+++ b/agent/core/proactive_turn.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import random as _random_module
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from hashlib import sha1
@@ -35,6 +36,7 @@ from agent.prompting import (
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutor, ToolHook
 from agent.turns.orchestrator import TurnOrchestrator
 from agent.turns.result import TurnOutbound, TurnResult, TurnTrace
+from core.common.diagnostic_log import diagnostic_context, diagnostic_line
 from core.memory.markdown import MemoryProfileApi
 from proactive_v2.config import ProactiveConfig
 from proactive_v2.context import AgentTickContext
@@ -338,39 +340,115 @@ class ProactiveTurnPipeline:
 
     # 核心方法：处理一次主动 tick，串起 Gate → Fetch → Judge → Resolve → Deliver 五段链路。
     async def run(self) -> float | None:
+        started = time.perf_counter()
         # 1. Gate — 该不该动？
         ctx = AgentTickContext(
             session_key=self._session_key,
             now_utc=datetime.now(timezone.utc),
         )
+        with diagnostic_context(session=self._session_key, flow="proactive", tick=ctx.tick_id):
+            logger.info(
+                diagnostic_line(
+                    "ProactiveTurnPipeline.run",
+                    event="start",
+                    flow="proactive",
+                    phase="pregate",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action="run",
+                )
+            )
+            try:
+                return await self._run_with_context(ctx, started)
+            except Exception as exc:
+                logger.exception(
+                    diagnostic_line(
+                        "ProactiveTurnPipeline.run",
+                        event="phase_error",
+                        flow="proactive",
+                        phase="tick",
+                        session=self._session_key,
+                        tick=ctx.tick_id,
+                        action="fail",
+                        reason="proactive_tick_error",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                        error_type=type(exc).__name__,
+                        note=str(exc)[:160],
+                    )
+                )
+                raise
+
+    async def _run_with_context(self, ctx: AgentTickContext, started: float) -> float | None:
         gate = self._gate_check(ctx)
         if gate.blocked:
+            logger.info(
+                diagnostic_line(
+                    "ProactiveTurnPipeline.run",
+                    event="gate_exit",
+                    flow="proactive",
+                    phase="pregate",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action="skip",
+                    reason=gate.reason,
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                )
+            )
             self._record_tick_log_finish(ctx, gate_exit=gate.reason)
             return gate.base_score
 
         ctx.context_as_fallback_open = gate.context_as_fallback_open
         self.last_ctx = ctx
         self._record_tick_log_start(ctx)
+        logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline.run",
+                event="end",
+                flow="proactive",
+                phase="pregate",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action="continue",
+                duration_ms=int((time.perf_counter() - started) * 1000),
+            )
+        )
 
         # 2. Fetch — 外面有什么新鲜事？
-        feed = await self._fetch_pull(ctx)
+        with diagnostic_context(phase="gateway"):
+            feed = await self._fetch_pull(ctx)
         if feed.drift_entered:
             self._finalize_after_drift(ctx)
             return feed.base_score
 
         # 3. Judge — LLM 评估哪些值得说
         if feed.messages and ctx.terminal_action is None:
-            await self._judge_evaluate(ctx, feed.messages)
+            with diagnostic_context(phase="agent_loop"):
+                await self._judge_evaluate(ctx, feed.messages)
 
         # 3.5 LLM 判定 reply 时记录 anyaction（drift 路径在 _finalize_after_drift 中处理）。
         if ctx.terminal_action == "reply" and self._any_action_gate is not None:
             self._any_action_gate.record_action(now_utc=ctx.now_utc)
 
         # 4. Resolve — 发还是不发？
-        decision = await self._resolve_decide(ctx)
+        with diagnostic_context(phase="resolve"):
+            decision = await self._resolve_decide(ctx)
 
         # 5. Deliver — 执行发送
         score = await self._deliver_execute(ctx, decision)
+        logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline.run",
+                event="end",
+                flow="proactive",
+                phase="resolve",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action=decision.action,
+                reason=ctx.skip_reason or "-",
+                duration_ms=int((time.perf_counter() - started) * 1000),
+                counts=f"steps:{ctx.steps_taken},interesting:{len(ctx.interesting_item_ids)},discarded:{len(ctx.discarded_item_ids)}",
+            )
+        )
         ctx.content_store.clear()
         return score
 
@@ -456,6 +534,18 @@ class ProactiveTurnPipeline:
         gw_result = await gw.run()
         self._last_gateway_result = gw_result
         _log_content_candidates(gw_result)
+        logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline._fetch_pull",
+                event="end",
+                flow="proactive",
+                phase="gateway",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action="fetched",
+                counts=f"alerts:{len(gw_result.alerts)},content:{len(gw_result.content_meta)},context:{len(gw_result.context)}",
+            )
+        )
 
         # 2.2 把拉取结果灌入 ctx。
         ctx.mark_alerts_prefetched(gw_result.alerts)
@@ -485,6 +575,19 @@ class ProactiveTurnPipeline:
                     and (ctx.now_utc - last_drift_at).total_seconds() < min_interval_hours * 3600
                 ):
                     logger.info(
+                        diagnostic_line(
+                            "ProactiveTurnPipeline._fetch_pull",
+                            event="skip",
+                            flow="proactive",
+                            phase="gateway",
+                            session=self._session_key,
+                            tick=ctx.tick_id,
+                            action="skip",
+                            reason="cooldown",
+                            counts="alerts:0,content:0,context:0",
+                        )
+                    )
+                    logger.info(
                         "[proactive_v2] fetch: drift blocked by interval last_drift_at=%s min_interval_hours=%d",
                         last_drift_at.isoformat(),
                         min_interval_hours,
@@ -502,6 +605,19 @@ class ProactiveTurnPipeline:
                     return FeedResult(drift_entered=True, base_score=0.0)
                 logger.info("[proactive_v2] fetch: drift not entered")
             logger.info("[proactive_v2] fetch: no data and fallback off → skip")
+            logger.info(
+                diagnostic_line(
+                    "ProactiveTurnPipeline._fetch_pull",
+                    event="skip",
+                    flow="proactive",
+                    phase="gateway",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action="skip",
+                    reason="no_content",
+                    counts="alerts:0,content:0,context:0",
+                )
+            )
             ctx.terminal_action = "skip"
             ctx.skip_reason = "no_content"
             self.last_ctx = ctx
@@ -606,6 +722,20 @@ class ProactiveTurnPipeline:
         # 4.1 LLM 判定为 skip → 直接构建 skip 结果。
         if ctx.terminal_action != "reply":
             logger.info(
+                diagnostic_line(
+                    "ProactiveTurnPipeline._resolve_decide",
+                    event="resolve",
+                    flow="proactive",
+                    phase="resolve",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action="skip",
+                    reason=ctx.skip_reason or "no_content",
+                    counts=f"steps:{ctx.steps_taken},interesting:{len(ctx.interesting_item_ids)},discarded:{len(ctx.discarded_item_ids)}",
+                    note=ctx.skip_note or "-",
+                )
+            )
+            logger.info(
                 "[proactive_v2] resolve: action=%s steps=%d discarded=%d interesting=%d skip_reason=%s note=%s",
                 ctx.terminal_action or "none",
                 ctx.steps_taken,
@@ -639,6 +769,20 @@ class ProactiveTurnPipeline:
         if self._state_store.is_delivery_duplicate(
             self._session_key, delivery_key, self._cfg.delivery_dedupe_hours
         ):
+            logger.info(
+                diagnostic_line(
+                    "ProactiveTurnPipeline._resolve_decide",
+                    event="resolve",
+                    flow="proactive",
+                    phase="resolve",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action="skip",
+                    reason="already_sent_similar",
+                    counts=f"steps:{ctx.steps_taken},interesting:{len(ctx.interesting_item_ids)},discarded:{len(ctx.discarded_item_ids)}",
+                    note="delivery_dedupe",
+                )
+            )
             logger.info("[proactive_v2] resolve: delivery_dedupe hit")
             return ResolveResult(
                 action="skip",
@@ -678,6 +822,20 @@ class ProactiveTurnPipeline:
                 new_state_summary_tag="none",
             )
             if is_dup:
+                logger.info(
+                    diagnostic_line(
+                        "ProactiveTurnPipeline._resolve_decide",
+                        event="resolve",
+                        flow="proactive",
+                        phase="resolve",
+                        session=self._session_key,
+                        tick=ctx.tick_id,
+                        action="skip",
+                        reason="already_sent_similar",
+                        counts=f"steps:{ctx.steps_taken},interesting:{len(ctx.interesting_item_ids)},discarded:{len(ctx.discarded_item_ids)}",
+                        note=str(reason or "message_dedupe")[:160],
+                    )
+                )
                 logger.info("[proactive_v2] resolve: message_dedupe hit: %s", reason)
                 return ResolveResult(
                     action="skip",
@@ -706,6 +864,19 @@ class ProactiveTurnPipeline:
                 )
 
         # 4.4 两层 guard 都通过 → 构建 send 结果。
+        logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline._resolve_decide",
+                event="resolve",
+                flow="proactive",
+                phase="resolve",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action="send",
+                reason="-",
+                counts=f"steps:{ctx.steps_taken},interesting:{len(ctx.interesting_item_ids)},discarded:{len(ctx.discarded_item_ids)},cited:{len(ctx.cited_item_ids)}",
+            )
+        )
         send_result = TurnResult(
             decision="reply",
             outbound=TurnOutbound(session_key=self._session_key, content=ctx.final_message),
@@ -813,6 +984,18 @@ class ProactiveTurnPipeline:
         tool_args = tool_call.get("input", {})
         arg_summary = json.dumps(tool_args, ensure_ascii=False)[:200]
         logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline._run_tool_step",
+                event="tool_call",
+                flow="proactive",
+                phase="agent_loop",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action=str(tool_name or "-"),
+                counts=f"step:{ctx.steps_taken}",
+            )
+        )
+        logger.info(
             "[proactive_v2] %s step %d: %s  args=%s",
             loop_tag,
             ctx.steps_taken,
@@ -831,6 +1014,20 @@ class ProactiveTurnPipeline:
             lambda name, args: dispatch(name, args, ctx, self._tool_deps),
         )
         if exec_result.status == "error":
+            logger.warning(
+                diagnostic_line(
+                    "ProactiveTurnPipeline._run_tool_step",
+                    event="tool_result",
+                    flow="proactive",
+                    phase="agent_loop",
+                    session=self._session_key,
+                    tick=ctx.tick_id,
+                    action=str(tool_name or "-"),
+                    reason="tool_error",
+                    counts=f"step:{ctx.steps_taken}",
+                    note=str(exec_result.output)[:160],
+                )
+            )
             logger.warning("[proactive_v2] %s: tool error: %s", loop_tag, exec_result.output)
             result = str(exec_result.output)
             call_id = tool_call.get("id") or f"call_{ctx.steps_taken}"
@@ -851,6 +1048,19 @@ class ProactiveTurnPipeline:
             )
             return False
         result = str(exec_result.output)
+        logger.info(
+            diagnostic_line(
+                "ProactiveTurnPipeline._run_tool_step",
+                event="tool_result",
+                flow="proactive",
+                phase="agent_loop",
+                session=self._session_key,
+                tick=ctx.tick_id,
+                action=str(tool_name or "-"),
+                reason="-",
+                counts=f"step:{ctx.steps_taken}",
+            )
+        )
         call_id = tool_call.get("id") or f"call_{ctx.steps_taken}"
         self._record_tick_step(
             ctx,

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -282,7 +282,7 @@ class ShellTool(Tool):
             "- 以下命令被禁止：nc、telnet、浏览器等高风险工具\n"
             "- 输出超过 30000 字符时自动截断\n"
             "- 前台阻塞总超时默认 60 秒，普通命令最大 600 秒\n"
-            "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；只有显式设置 timeout，后台才会继续沿用这个硬截止时间\n"
+            "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；后台会沿用当前 timeout 作为硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false；未显式传 timeout 时会默认阻塞 21600 秒\n"
             "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
             "- 收到 background_task_id 后，由你负责用 task_output 主动查看进展和结果；不会有系统自动回传\n"
@@ -484,7 +484,7 @@ class ShellTool(Tool):
 
         wall_start_ms = int(time.time() * 1000)
         start_mono = time.monotonic()
-        hard_timeout_s = timeout if timeout_specified else None
+        hard_timeout_s = timeout
 
         proc = await asyncio.create_subprocess_shell(
             command,
@@ -719,12 +719,26 @@ class ShellTaskOutputTool(Tool):
             return _err(f"任务 {task_id!r} 已超时（{task.timeout_s}s），已自动终止")
 
         if block and not pump_task.done():
+            if task.timeout_s is not None:
+                remaining_ms = int(
+                    max(task.timeout_s - (time.monotonic() - task.started_at), 0)
+                    * 1000
+                )
+                timeout_ms = min(timeout_ms, remaining_ms)
             try:
                 await asyncio.wait_for(
                     asyncio.shield(pump_task), timeout=timeout_ms / 1000
                 )
             except asyncio.TimeoutError:
                 pass
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+
+        if task.finish_reason == "timeout" or _is_background_timeout(task):
+            _bg_timeout(task_id)
+            return _err(f"任务 {task_id!r} 已超时（{task.timeout_s}s），已自动终止")
 
         done = pump_task.done()
         if done and time.monotonic() - task.started_at > _BG_TTL_S:

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -564,7 +564,7 @@ def _esbuild_command(project_root: Path) -> list[str] | None:
 
 def _build_plugin_panels_js(project_root: Path, plugin_dir: Path) -> None:
     esbuild_cmd: list[str] | None = None
-    for ts_path in sorted(plugin_dir.glob("dashboard_panel*.ts")):
+    for ts_path in _iter_plugin_panel_sources(plugin_dir):
         js_path = ts_path.with_suffix(".js")
         if js_path.exists() and js_path.stat().st_mtime >= ts_path.stat().st_mtime:
             continue
@@ -577,6 +577,14 @@ def _build_plugin_panels_js(project_root: Path, plugin_dir: Path) -> None:
         _run_esbuild(esbuild_cmd, ts_path, js_path, f"{plugin_dir.name}/{ts_path.stem}")
 
 
+def _iter_plugin_panel_sources(plugin_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in plugin_dir.glob("dashboard_panel*")
+        if path.suffix in {".ts", ".tsx"}
+    )
+
+
 def _run_esbuild(cmd: list[str], ts_path: Path, js_path: Path, name: str) -> None:
     try:
         result = subprocess.run(
@@ -584,10 +592,16 @@ def _run_esbuild(cmd: list[str], ts_path: Path, js_path: Path, name: str) -> Non
                 *cmd,
                 str(ts_path),
                 f"--outfile={js_path}",
-                "--bundle=false",
+                "--bundle",
                 "--platform=browser",
                 "--target=es2020",
-                "--format=iife",
+                "--format=esm",
+                "--jsx=automatic",
+                "--external:react",
+                "--external:react-dom",
+                "--external:react-dom/client",
+                "--external:react/jsx-runtime",
+                "--external:@akashic/dashboard-ui",
             ],
             capture_output=True,
             text=True,
@@ -645,7 +659,7 @@ async def _compile_pending_plugins_async() -> None:
     version = stdout.decode("utf-8", errors="replace").strip()
     logger.info("npx esbuild 就绪 (%s)，开始编译插件面板...", version)
     for root, pdir in pending:
-        for ts_path in sorted(pdir.glob("dashboard_panel*.ts")):
+        for ts_path in _iter_plugin_panel_sources(pdir):
             js_path = ts_path.with_suffix(".js")
             if not (js_path.exists() and js_path.stat().st_mtime >= ts_path.stat().st_mtime):
                 _run_esbuild(esbuild_cmd, ts_path, js_path, f"{pdir.name}/{ts_path.stem}")

--- a/core/common/diagnostic_log.py
+++ b/core/common/diagnostic_log.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+_DIAG_FIELDS = (
+    "event",
+    "flow",
+    "phase",
+    "session",
+    "turn",
+    "tick",
+    "action",
+    "reason",
+    "duration_ms",
+    "counts",
+    "error_type",
+    "error_fp",
+    "note",
+)
+
+diagnostic_session: ContextVar[str | None] = ContextVar("diagnostic_session", default=None)
+diagnostic_flow: ContextVar[str | None] = ContextVar("diagnostic_flow", default=None)
+diagnostic_phase: ContextVar[str | None] = ContextVar("diagnostic_phase", default=None)
+diagnostic_turn: ContextVar[str | None] = ContextVar("diagnostic_turn", default=None)
+diagnostic_tick: ContextVar[str | None] = ContextVar("diagnostic_tick", default=None)
+
+
+def diagnostic_line(method: str, **fields: object) -> str:
+    parts = [f"[{method}]"]
+    for key in _DIAG_FIELDS:
+        value = _clean(fields.get(key, "-"))
+        if key == "note":
+            value = f'"{value}"'
+        parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+@contextmanager
+def diagnostic_context(
+    *,
+    session: str | None = None,
+    flow: str | None = None,
+    phase: str | None = None,
+    turn: str | None = None,
+    tick: str | None = None,
+) -> Iterator[None]:
+    tokens = []
+    if session is not None:
+        tokens.append((diagnostic_session, diagnostic_session.set(session)))
+    if flow is not None:
+        tokens.append((diagnostic_flow, diagnostic_flow.set(flow)))
+    if phase is not None:
+        tokens.append((diagnostic_phase, diagnostic_phase.set(phase)))
+    if turn is not None:
+        tokens.append((diagnostic_turn, diagnostic_turn.set(turn)))
+    if tick is not None:
+        tokens.append((diagnostic_tick, diagnostic_tick.set(tick)))
+    try:
+        yield
+    finally:
+        for var, token in reversed(tokens):
+            var.reset(token)
+
+
+def current_diagnostic_context() -> dict[str, str]:
+    return {
+        "session": diagnostic_session.get() or "",
+        "flow": diagnostic_flow.get() or "",
+        "phase": diagnostic_phase.get() or "",
+        "turn": diagnostic_turn.get() or "",
+        "tick": diagnostic_tick.get() or "",
+    }
+
+
+def _clean(value: object) -> str:
+    text = str(value if value is not None else "-").replace("\n", " ").strip()
+    if not text:
+        return "-"
+    return text.replace('"', "'")

--- a/plugins/observe/collector.py
+++ b/plugins/observe/collector.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import sys
+import threading
+import traceback
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Any, Callable
+
+from core.common.diagnostic_log import current_diagnostic_context
+
+from .events import GlobalErrorTrace
+
+_SKIP_LOGGER_PREFIXES = ("plugin.observe", "observe.", "plugins.observe")
+_HEX_RE = re.compile(r"\b[0-9a-f]{8,}\b", re.IGNORECASE)
+_NUM_RE = re.compile(r"\b\d+\b")
+_MESSAGE_LIMIT = 500
+_TRACEBACK_LIMIT = 4000
+
+
+class GlobalErrorCollector:
+    def __init__(self, writer: Any) -> None:
+        self._writer = writer
+        self._handler = _GlobalErrorLogHandler(self)
+        self._old_sys_excepthook: Callable[..., object] | None = None
+        self._old_threading_excepthook: Callable[..., object] | None = None
+        self._old_asyncio_handler: Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._installed = False
+
+    def install(self) -> None:
+        if self._installed:
+            return
+        self._installed = True
+        logging.getLogger().addHandler(self._handler)
+        self._old_sys_excepthook = sys.excepthook
+        sys.excepthook = self._handle_sys_exception
+        self._old_threading_excepthook = threading.excepthook
+        threading.excepthook = self._handle_thread_exception
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
+        if self._loop is not None:
+            self._old_asyncio_handler = self._loop.get_exception_handler()
+            self._loop.set_exception_handler(self._handle_asyncio_exception)
+
+    def close(self) -> None:
+        if not self._installed:
+            return
+        self._installed = False
+        logging.getLogger().removeHandler(self._handler)
+        if self._old_sys_excepthook is not None:
+            sys.excepthook = self._old_sys_excepthook
+        if self._old_threading_excepthook is not None:
+            threading.excepthook = self._old_threading_excepthook
+        if self._loop is not None:
+            self._loop.set_exception_handler(self._old_asyncio_handler)
+
+    def emit_log_record(self, record: logging.LogRecord) -> None:
+        if record.levelno < logging.ERROR or _skip_logger(record.name):
+            return
+        exc_type: type[BaseException] | None = None
+        exc_value: BaseException | None = None
+        exc_tb: TracebackType | None = None
+        if record.exc_info:
+            exc_type, exc_value, exc_tb = record.exc_info
+        message = record.getMessage()
+        self._emit(
+            source="log",
+            logger_name=record.name,
+            level=record.levelname,
+            message=message,
+            exc_type=exc_type,
+            exc_value=exc_value,
+            exc_tb=exc_tb,
+        )
+
+    def _handle_sys_exception(
+        self,
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._emit(
+            source="uncaught",
+            logger_name="sys.excepthook",
+            level="CRITICAL",
+            message=str(exc_value),
+            exc_type=exc_type,
+            exc_value=exc_value,
+            exc_tb=exc_tb,
+        )
+        if self._old_sys_excepthook is not None:
+            self._old_sys_excepthook(exc_type, exc_value, exc_tb)
+
+    def _handle_thread_exception(self, args: threading.ExceptHookArgs) -> None:
+        self._emit(
+            source="thread",
+            logger_name=str(getattr(args.thread, "name", "") or "threading.excepthook"),
+            level="CRITICAL",
+            message=str(args.exc_value),
+            exc_type=args.exc_type,
+            exc_value=args.exc_value,
+            exc_tb=args.exc_traceback,
+        )
+        if self._old_threading_excepthook is not None:
+            self._old_threading_excepthook(args)
+
+    def _handle_asyncio_exception(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        context: dict[str, Any],
+    ) -> None:
+        exc = context.get("exception")
+        message = str(context.get("message") or exc or "asyncio exception")
+        self._emit(
+            source="asyncio",
+            logger_name="asyncio",
+            level="ERROR",
+            message=message,
+            exc_type=type(exc) if isinstance(exc, BaseException) else None,
+            exc_value=exc if isinstance(exc, BaseException) else None,
+            exc_tb=exc.__traceback__ if isinstance(exc, BaseException) else None,
+        )
+        if self._old_asyncio_handler is not None:
+            self._old_asyncio_handler(loop, context)
+        else:
+            loop.default_exception_handler(context)
+
+    def _emit(
+        self,
+        *,
+        source: str,
+        logger_name: str,
+        level: str,
+        message: str,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        error_type = exc_type.__name__ if exc_type is not None else "LogError"
+        traceback_text = _format_traceback(exc_type, exc_value, exc_tb)
+        fingerprint = _fingerprint(error_type, message, traceback_text)
+        diag = current_diagnostic_context()
+        session = diag["session"]
+        self._writer.emit(
+            GlobalErrorTrace(
+                fingerprint=fingerprint,
+                bucket=now[:13],
+                source=source,
+                logger_name=logger_name,
+                error_type=error_type,
+                message=message[:_MESSAGE_LIMIT],
+                traceback_text=traceback_text[:_TRACEBACK_LIMIT],
+                level=level,
+                first_ts=now,
+                last_ts=now,
+                count=1,
+                session_keys=[session] if session else [],
+                flow=diag["flow"],
+                phase=diag["phase"],
+                turn=diag["turn"],
+                tick=diag["tick"],
+            )
+        )
+
+
+class _GlobalErrorLogHandler(logging.Handler):
+    def __init__(self, collector: GlobalErrorCollector) -> None:
+        super().__init__(level=logging.ERROR)
+        self._collector = collector
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._collector.emit_log_record(record)
+
+
+def _skip_logger(name: str) -> bool:
+    return any(name.startswith(prefix) for prefix in _SKIP_LOGGER_PREFIXES)
+
+
+def _format_traceback(
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
+    exc_tb: TracebackType | None,
+) -> str:
+    if exc_type is None:
+        return ""
+    return "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+
+
+def _fingerprint(error_type: str, message: str, traceback_text: str) -> str:
+    normalized = _NUM_RE.sub("<n>", _HEX_RE.sub("<hex>", message))
+    frame = _top_app_frame(traceback_text)
+    raw = f"{error_type}|{normalized}|{frame}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _top_app_frame(traceback_text: str) -> str:
+    for line in traceback_text.splitlines():
+        if "/akasic-agent/" in line and "/plugins/observe/" not in line:
+            return line.strip()
+    return ""

--- a/plugins/observe/dashboard.py
+++ b/plugins/observe/dashboard.py
@@ -4,10 +4,13 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
+import json
 import sqlite3
 import threading
 
 from fastapi import FastAPI
+
+from plugins.observe.db import open_db
 
 # Observe monitoring dashboard: aggregates the agent-loop telemetry written to
 # observe.db (turns table) into Grafana-style metrics — token & KV cache usage,
@@ -140,6 +143,131 @@ class ObserveDashboardReader:
         }
 
 
+    # ── 全局错误（global_errors 表）─────────────────────────────────
+
+    # KPI + 排障台头部：总数、错误种类、新类型、爆发类型、最近时间、整体 spark。
+    def get_global_overview(self, range_token: str) -> dict[str, Any]:
+        cutoff, _ = _resolve_range(range_token)
+        groups = self._global_groups(cutoff)
+        total = sum(g["count"] for g in groups)
+        last_ts = max((g["last_ts"] for g in groups), default=None)
+        spark = _merge_buckets(groups)
+        return {
+            "range": range_token,
+            "total": total,
+            "types": len(groups),
+            "new_types": sum(1 for g in groups if g["is_new"]),
+            "spiking_types": sum(1 for g in groups if g["is_spiking"]),
+            "last_ts": last_ts,
+            "spark": [p["value"] for p in spark],
+        }
+
+    # 排障台左栏：按指纹聚合的群组，可按 facet 分组、按 q 过滤。
+    def get_global_list(self, range_token: str, *, facet: str, q: str) -> dict[str, Any]:
+        cutoff, _ = _resolve_range(range_token)
+        groups = self._global_groups(cutoff, include_ignored=False)
+        if q:
+            needle = q.lower()
+            groups = [
+                g for g in groups
+                if needle in g["error_type"].lower()
+                or needle in g["message"].lower()
+                or needle in g["logger_name"].lower()
+            ]
+        groups.sort(key=lambda g: g["count"], reverse=True)
+        sections = _facet_sections(groups, facet)
+        for g in groups:
+            g.pop("_buckets", None)
+        return {
+            "range": range_token,
+            "facet": facet,
+            "total": sum(g["count"] for g in groups),
+            "sections": sections,
+        }
+
+    # 排障台右栏详情：完整 message、趋势、变体（同类型其他指纹）、现场 occurrences。
+    def get_global_detail(self, fingerprint: str, range_token: str) -> dict[str, Any]:
+        if not self.db_path.exists():
+            return {}
+        with self._lock, _connect(self.db_path) as db:
+            rows = db.execute(
+                "SELECT * FROM global_errors WHERE fingerprint = ? ORDER BY bucket ASC",
+                (fingerprint,),
+            ).fetchall()
+            if not rows:
+                return {}
+            agg = _aggregate_fingerprint(rows)
+            siblings = db.execute(
+                """
+                SELECT fingerprint, traceback_text, SUM(count) AS count, MAX(last_ts) AS last_ts
+                FROM global_errors WHERE error_type = ? GROUP BY fingerprint ORDER BY count DESC
+                """,
+                (agg["error_type"],),
+            ).fetchall()
+            occurrences = self._global_occurrences(db, agg["session_keys"])
+        agg["trend"] = [{"bucket": b, "count": c} for b, c in sorted(agg["_buckets"].items())]
+        agg["variants"] = [
+            {
+                "fingerprint": s["fingerprint"],
+                "count": int(s["count"] or 0),
+                "traceback_text": s["traceback_text"] or "",
+            }
+            for s in siblings
+        ]
+        agg["occurrences"] = occurrences
+        agg.pop("_buckets", None)
+        return agg
+
+    def set_global_status(self, fingerprint: str, status: str) -> dict[str, Any]:
+        if status not in ("active", "acknowledged", "ignored") or not self.db_path.exists():
+            return {"ok": False}
+        with self._lock, _connect(self.db_path) as db:
+            with db:
+                db.execute(
+                    "UPDATE global_errors SET status = ? WHERE fingerprint = ?",
+                    (status, fingerprint),
+                )
+        return {"ok": True, "fingerprint": fingerprint, "status": status}
+
+    # 取窗口内 global_errors 全部行，按指纹在 Python 侧聚合成群组列表。
+    def _global_groups(
+        self, cutoff: str | None, *, include_ignored: bool = True
+    ) -> list[dict[str, Any]]:
+        if not self.db_path.exists():
+            return []
+        where = "1=1" if cutoff is None else "last_ts >= ?"
+        params: tuple[Any, ...] = () if cutoff is None else (cutoff,)
+        with self._lock, _connect(self.db_path) as db:
+            rows = db.execute(
+                f"SELECT * FROM global_errors WHERE {where} ORDER BY fingerprint, bucket ASC",
+                params,
+            ).fetchall()
+        by_fp: dict[str, list[sqlite3.Row]] = {}
+        for row in rows:
+            by_fp.setdefault(row["fingerprint"], []).append(row)
+        groups = [_aggregate_fingerprint(rows) for rows in by_fp.values()]
+        if not include_ignored:
+            groups = [g for g in groups if g["status"] != "ignored"]
+        return groups
+
+    # 现场：对每个 session_key 反查 turns 最近一条，取 user_msg 作触发上下文。
+    def _global_occurrences(
+        self, db: sqlite3.Connection, session_keys: list[str]
+    ) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for key in session_keys[:8]:
+            row = db.execute(
+                "SELECT ts, user_msg FROM turns WHERE session_key = ? ORDER BY ts DESC LIMIT 1",
+                (key,),
+            ).fetchone()
+            out.append({
+                "session_key": key,
+                "ts": row["ts"] if row else None,
+                "user_preview": _preview(row["user_msg"], 80) if row else "",
+            })
+        return out
+
+
 def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> None:
     reader = ObserveDashboardReader(workspace)
 
@@ -154,6 +282,22 @@ def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> None:
     @app.get("/api/dashboard/observe/errors")
     def observe_errors(range: str = "24h", page: int = 1, page_size: int = 25) -> dict[str, Any]:
         return reader.get_errors(range, page=page, page_size=page_size)
+
+    @app.get("/api/dashboard/observe/global_errors/overview")
+    def global_errors_overview(range: str = "24h") -> dict[str, Any]:
+        return reader.get_global_overview(range)
+
+    @app.get("/api/dashboard/observe/global_errors")
+    def global_errors_list(range: str = "24h", facet: str = "type", q: str = "") -> dict[str, Any]:
+        return reader.get_global_list(range, facet=facet, q=q)
+
+    @app.get("/api/dashboard/observe/global_errors/{fingerprint}")
+    def global_errors_detail(fingerprint: str, range: str = "7d") -> dict[str, Any]:
+        return reader.get_global_detail(fingerprint, range)
+
+    @app.post("/api/dashboard/observe/global_errors/{fingerprint}/status")
+    def global_errors_status(fingerprint: str, value: str = "acknowledged") -> dict[str, Any]:
+        return reader.set_global_status(fingerprint, value)
 
 
 # Build the shared WHERE clause: agent turns, optionally bounded by cutoff.
@@ -247,9 +391,120 @@ def _preview(value: Any, limit: int) -> str:
     return text[:limit].rstrip() + "..."
 
 
+# ── 全局错误聚合辅助 ──────────────────────────────────────────────────────────
+
+
+def _channel_of(session_keys: list[str]) -> str:
+    for key in session_keys:
+        head = key.split(":", 1)[0] if ":" in key else ""
+        if head:
+            return head
+    return "—"
+
+
+# 把同一指纹的多个小时桶行聚合成一个群组 dict（含派生的 spark / is_new / is_spiking）。
+def _aggregate_fingerprint(rows: list[sqlite3.Row]) -> dict[str, Any]:
+    rep = max(rows, key=lambda r: str(r["last_ts"] or ""))
+    buckets: dict[str, int] = {}
+    sessions: list[str] = []
+    for row in rows:
+        buckets[row["bucket"]] = buckets.get(row["bucket"], 0) + int(row["count"] or 0)
+        for key in _parse_keys(row["session_keys"]):
+            if key not in sessions and len(sessions) < 20:
+                sessions.append(key)
+    count = sum(buckets.values())
+    first_ts = min(str(r["first_ts"] or "") for r in rows)
+    last_ts = max(str(r["last_ts"] or "") for r in rows)
+    spark = [buckets[b] for b in sorted(buckets)]
+    return {
+        "fingerprint": rep["fingerprint"],
+        "error_type": rep["error_type"] or "Error",
+        "logger_name": rep["logger_name"] or "",
+        "source": rep["source"] or "log",
+        "level": rep["level"] or "ERROR",
+        "status": rep["status"] or "active",
+        "message": _preview(rep["message"], 200),
+        "traceback_text": rep["traceback_text"] or "",
+        "count": count,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "session_keys": sessions,
+        "sessions": len(sessions),
+        "channel": _channel_of(sessions),
+        "is_new": _is_new(first_ts),
+        "is_spiking": _is_spiking(spark),
+        "_buckets": buckets,
+    }
+
+
+def _parse_keys(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    try:
+        data = json.loads(str(raw))
+    except (ValueError, TypeError):
+        return []
+    return [str(x) for x in data] if isinstance(data, list) else []
+
+
+# NEW = 指纹首次出现在最近 24h 内。
+def _is_new(first_ts: str) -> bool:
+    if not first_ts:
+        return False
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    return first_ts >= cutoff
+
+
+# 爆发 = 最近一个桶的计数显著高于此前桶的均值。
+def _is_spiking(spark: list[int]) -> bool:
+    if len(spark) < 3:
+        return False
+    last = spark[-1]
+    prev = spark[:-1]
+    avg = sum(prev) / len(prev) if prev else 0
+    return last >= 3 and last >= 2 * max(avg, 1)
+
+
+# 按 facet 把群组切成带小标题的 section；type 走单段平铺。
+def _facet_sections(groups: list[dict[str, Any]], facet: str) -> list[dict[str, Any]]:
+    if facet not in ("source", "channel"):
+        return [{"key": "all", "label": "", "count": sum(g["count"] for g in groups), "items": groups}]
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for g in groups:
+        buckets.setdefault(str(g[facet]), []).append(g)
+    sections = [
+        {
+            "key": key,
+            "label": _SOURCE_LABEL.get(key, key) if facet == "source" else key,
+            "count": sum(g["count"] for g in items),
+            "items": items,
+        }
+        for key, items in buckets.items()
+    ]
+    sections.sort(key=lambda s: s["count"], reverse=True)
+    return sections
+
+
+# 合并多个群组的小时桶 → 整体 spark 点序列。
+def _merge_buckets(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[str, int] = {}
+    for g in groups:
+        for bucket, count in g.get("_buckets", {}).items():
+            merged[bucket] = merged.get(bucket, 0) + count
+    return [{"bucket": b, "value": merged[b]} for b in sorted(merged)]
+
+
+_SOURCE_LABEL: dict[str, str] = {
+    "log": "主动日志",
+    "uncaught": "未捕获异常",
+    "asyncio": "asyncio 任务",
+    "thread": "子线程",
+}
+
+
 @contextmanager
 def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn = open_db(db_path)
     conn.row_factory = sqlite3.Row
     try:
         yield conn

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -1,6 +1,13 @@
 /// <reference path="../../types/akashic-dashboard.d.ts" />
-import { useEffect, useState, type ReactElement, type ReactNode } from "react";
-import { MetricTile, TrendChart, Chip, api } from "@akashic/dashboard-ui";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { MetricTile, TrendChart, Sparkline, Chip, api, type ChartTone } from "@akashic/dashboard-ui";
 
 interface Overview {
   range: string;
@@ -25,18 +32,79 @@ interface SeriesPoint {
   avg_iteration: number | null;
 }
 
-interface ErrorRow {
-  id: number;
-  ts: string;
-  session_key: string;
-  user_preview: string;
-  error: string;
+// ── 全局错误（global_errors）类型 ──────────────────────────────────────────────
+
+interface GErrGroup {
+  fingerprint: string;
+  error_type: string;
+  logger_name: string;
+  source: string;
+  level: string;
+  status: string;
+  message: string;
+  count: number;
+  sessions: number;
+  channel: string;
+  is_new: boolean;
+  is_spiking: boolean;
+  spark: number[];
+  first_ts: string;
+  last_ts: string;
 }
 
-interface ErrorGroup {
-  signature: string;
+interface GErrSection {
+  key: string;
+  label: string;
   count: number;
+  items: GErrGroup[];
+}
+
+interface GErrListResp {
+  range: string;
+  facet: string;
+  total: number;
+  sections: GErrSection[];
+}
+
+interface GErrOverview {
+  range: string;
+  total: number;
+  types: number;
+  new_types: number;
+  spiking_types: number;
+  last_ts: string | null;
+  spark: number[];
+}
+
+interface GErrVariant {
+  fingerprint: string;
+  count: number;
+  traceback_text: string;
+}
+
+interface GErrOccurrence {
+  session_key: string;
+  ts: string | null;
+  user_preview: string;
+}
+
+interface GErrDetail {
+  fingerprint: string;
+  error_type: string;
+  logger_name: string;
+  source: string;
+  level: string;
+  status: string;
+  message: string;
+  traceback_text: string;
+  count: number;
+  sessions: number;
+  channel: string;
+  first_ts: string;
   last_ts: string;
+  trend: { bucket: string; count: number }[];
+  variants: GErrVariant[];
+  occurrences: GErrOccurrence[];
 }
 
 const RANGES: { key: string; label: string }[] = [
@@ -45,6 +113,27 @@ const RANGES: { key: string; label: string }[] = [
   { key: "30d", label: "30 天" },
   { key: "all", label: "全部" },
 ];
+
+const SOURCE_LABEL: Record<string, string> = {
+  log: "主动日志",
+  uncaught: "未捕获异常",
+  asyncio: "asyncio 任务",
+  thread: "子线程",
+};
+
+const STATUS_META: Record<string, { label: string; tone: ChartTone }> = {
+  active: { label: "● 活跃", tone: "warning" },
+  acknowledged: { label: "◌ 已确认", tone: "muted" },
+  ignored: { label: "✓ 已忽略", tone: "success" },
+};
+
+const TONE_BG: Record<ChartTone, string> = {
+  danger: "bg-danger",
+  warning: "bg-warning",
+  success: "bg-success",
+  accent: "bg-accent",
+  muted: "bg-subtle",
+};
 
 function _compact(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
@@ -63,7 +152,8 @@ function _bucketLabel(bucket: string): string {
   return m && d ? `${Number(m)}-${d}` : bucket;
 }
 
-function _shortTs(value: string): string {
+function _shortTs(value: string | null): string {
+  if (!value) return "—";
   const dt = new Date(value);
   if (Number.isNaN(dt.getTime())) return value || "—";
   return `${dt.getMonth() + 1}-${String(dt.getDate()).padStart(2, "0")} ${String(dt.getHours()).padStart(2, "0")}:${String(dt.getMinutes()).padStart(2, "0")}`;
@@ -78,11 +168,32 @@ function _delta(values: number[]): number | null {
   return ((last - prev) / prev) * 100;
 }
 
+// 相对时间标签："刚刚" / "Xs 前" / "Xm 前"。
+function _ago(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "刚刚";
+  const s = Math.floor(ms / 1000);
+  if (s < 3) return "刚刚";
+  if (s < 60) return `${s}s 前`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m 前`;
+  return `${Math.floor(m / 60)}h 前`;
+}
+
+// 严重度配色：爆发或高频 -> danger，中频 -> warning，低频 -> muted。
+function _severity(count: number, spiking: boolean): ChartTone {
+  if (spiking || count >= 20) return "danger";
+  if (count >= 5) return "warning";
+  return "muted";
+}
+
 // A monitoring widget card with a hairline header — mirrors the superlog widget
 // chrome (uppercase mono title, bottom-bordered header, padded body).
-function Card({ title, children, bodyClass }: { title: string; children: ReactNode; bodyClass?: string }): ReactElement {
+function Card({ title, children, bodyClass, style }: { title: string; children: ReactNode; bodyClass?: string; style?: React.CSSProperties }): ReactElement {
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm">
+    <div
+      className="flex animate-fade-up flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lift-sm transition-[box-shadow,border-color] duration-200 hover:border-border-strong hover:shadow-lift-md"
+      style={style}
+    >
       <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{title}</h3>
       </div>
@@ -91,35 +202,479 @@ function Card({ title, children, bodyClass }: { title: string; children: ReactNo
   );
 }
 
+// ── 错误排障台：从「错误」KPI 卡 FLIP 放大的独立卡片，stats-over-detail 构图 ──────────
+
+function ErrorDrill({
+  portalRef,
+  range,
+  onClose,
+}: {
+  portalRef: React.RefObject<HTMLDivElement | null>;
+  range: string;
+  onClose: () => void;
+}): ReactElement {
+  const drillRef = useRef<HTMLDivElement>(null);
+  const [overview, setOverview] = useState<GErrOverview | null>(null);
+  const [facet, setFacet] = useState<string>("type");
+  const [q, setQ] = useState<string>("");
+  const [sections, setSections] = useState<GErrSection[]>([]);
+  const [selFp, setSelFp] = useState<string | null>(null);
+  const [detail, setDetail] = useState<GErrDetail | null>(null);
+  const [tab, setTab] = useState<"trend" | "trace" | "occ">("trace");
+  const [variant, setVariant] = useState<number>(0);
+
+  const loadList = useCallback(async () => {
+    const [ov, list] = await Promise.all([
+      api<GErrOverview>(`/api/dashboard/observe/global_errors/overview?range=${range}`),
+      api<GErrListResp>(`/api/dashboard/observe/global_errors?range=${range}&facet=${facet}&q=${encodeURIComponent(q)}`),
+    ]);
+    setOverview(ov);
+    setSections(list.sections ?? []);
+    const flat = (list.sections ?? []).flatMap((s) => s.items);
+    setSelFp((cur) => (cur && flat.some((i) => i.fingerprint === cur) ? cur : flat[0]?.fingerprint ?? null));
+  }, [range, facet, q]);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList]);
+
+  useEffect(() => {
+    if (!selFp) {
+      setDetail(null);
+      return;
+    }
+    let alive = true;
+    void (async () => {
+      const d = await api<GErrDetail>(`/api/dashboard/observe/global_errors/${selFp}?range=${range}`);
+      if (alive) {
+        setDetail(d);
+        setVariant(0);
+        setTab("trace");
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [selFp, range]);
+
+  // FLIP：从传送门卡的位置/尺寸长大到中央。
+  useEffect(() => {
+    const drill = drillRef.current;
+    const portal = portalRef.current;
+    if (!drill || !portal) return;
+    const tr = portal.getBoundingClientRect();
+    const cr = drill.getBoundingClientRect();
+    drill.style.transition = "none";
+    drill.style.transformOrigin = "top left";
+    drill.style.transform = `translate(${tr.left - cr.left}px, ${tr.top - cr.top}px) scale(${tr.width / cr.width}, ${tr.height / cr.height})`;
+    drill.style.opacity = "0";
+    void drill.getBoundingClientRect();
+    requestAnimationFrame(() => {
+      drill.style.transition = "transform .44s cubic-bezier(.2,.85,.25,1), opacity .26s ease";
+      drill.style.transform = "";
+      drill.style.opacity = "";
+    });
+  }, [portalRef]);
+
+  const close = useCallback(() => {
+    const drill = drillRef.current;
+    const portal = portalRef.current;
+    if (drill && portal) {
+      const tr = portal.getBoundingClientRect();
+      const cr = drill.getBoundingClientRect();
+      drill.style.transition = "transform .4s cubic-bezier(.4,0,.6,1), opacity .3s ease";
+      drill.style.transformOrigin = "top left";
+      drill.style.transform = `translate(${tr.left - cr.left}px, ${tr.top - cr.top}px) scale(${tr.width / cr.width}, ${tr.height / cr.height})`;
+      drill.style.opacity = "0";
+      window.setTimeout(onClose, 360);
+    } else {
+      onClose();
+    }
+  }, [onClose, portalRef]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [close]);
+
+  const setStatus = async (status: string): Promise<void> => {
+    if (!detail) return;
+    await api(`/api/dashboard/observe/global_errors/${detail.fingerprint}/status?value=${status}`, { method: "POST" });
+    await loadList();
+    setDetail((d) => (d ? { ...d, status } : d));
+  };
+
+  const gotoSession = (key: string): void => {
+    window.dispatchEvent(new CustomEvent("akashic:goto-session", { detail: key }));
+    close();
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-30 bg-black/55 backdrop-blur-[2px]" onClick={close} />
+      <div
+        ref={drillRef}
+        className="fixed z-40 flex flex-col overflow-hidden rounded-2xl border border-border-strong bg-surface shadow-lift-md"
+        style={{
+          width: "min(1180px, 94vw)",
+          height: "min(84vh, 760px)",
+          left: "50%",
+          top: "50%",
+          marginLeft: "calc(min(1180px, 94vw) / -2)",
+          marginTop: "calc(min(84vh, 760px) / -2)",
+        }}
+      >
+        {/* 头部：402 大数字 + 摘要徽标 + range */}
+        <div className="flex flex-shrink-0 items-center gap-4 border-b border-border px-5 py-4">
+          <button
+            type="button"
+            onClick={close}
+            className="grid h-8 w-8 place-items-center rounded-md border border-border-strong bg-surface-2 text-[18px] text-muted transition-colors hover:text-fg"
+            title="返回 (Esc)"
+          >
+            ‹
+          </button>
+          <span className="font-mono text-[26px] font-semibold tabular-nums text-danger">{overview?.total ?? "—"}</span>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold">错误 · {RANGES.find((r) => r.key === range)?.label ?? range}</div>
+            <div className="mt-0.5 flex items-center gap-3 font-mono text-[11px] text-muted">
+              <span>{overview?.types ?? 0} 个类型</span>
+              {(overview?.new_types ?? 0) > 0 && <span className="rounded border border-accent-deep bg-accent-soft px-1.5 py-0.5 text-accent">🆕 {overview?.new_types} 新类型</span>}
+              {(overview?.spiking_types ?? 0) > 0 && <span className="rounded border border-danger/30 bg-danger/10 px-1.5 py-0.5 text-danger">⚡ {overview?.spiking_types} 爆发</span>}
+            </div>
+          </div>
+        </div>
+
+        {/* 切维 + 搜索 */}
+        <div className="flex flex-shrink-0 items-center gap-3 border-b border-border px-4 py-2.5">
+          <div className="flex gap-1 rounded-md border border-border bg-bg p-0.5">
+            {[
+              { k: "type", l: "按类型" },
+              { k: "source", l: "按来源" },
+              { k: "channel", l: "按通道" },
+            ].map((f) => (
+              <button
+                key={f.k}
+                type="button"
+                onClick={() => setFacet(f.k)}
+                className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-colors ${facet === f.k ? "bg-surface-3 text-fg shadow-[inset_0_0_0_1px_var(--color-border-strong)]" : "text-muted hover:text-fg"}`}
+              >
+                {f.l}
+              </button>
+            ))}
+          </div>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="按消息 / 模块过滤…"
+            className="w-[280px] rounded-md border border-border bg-bg px-3 py-1.5 font-mono text-[11.5px] text-fg outline-none focus:border-accent-deep"
+          />
+        </div>
+
+        {/* 左群组 / 右详情 */}
+        <div className="grid min-h-0 flex-1 grid-cols-[340px_1fr]">
+          <div className="overflow-auto border-r border-border p-1.5">
+            {sections.map((section) => (
+              <div key={section.key}>
+                {section.label && (
+                  <div className="flex items-center justify-between px-2.5 pb-1 pt-3 font-mono text-[9.5px] uppercase tracking-[0.14em] text-subtle">
+                    <span>{section.label}</span>
+                    <span>{section.count} 次</span>
+                  </div>
+                )}
+                {section.items.map((g) => (
+                  <ErrorRow key={g.fingerprint} g={g} active={g.fingerprint === selFp} onClick={() => setSelFp(g.fingerprint)} />
+                ))}
+              </div>
+            ))}
+            {sections.length === 0 && <div className="p-6 text-[12.5px] text-muted">区间内无错误 🎉</div>}
+          </div>
+
+          {detail ? (
+            <ErrorDetail
+              detail={detail}
+              tab={tab}
+              setTab={setTab}
+              variant={variant}
+              setVariant={setVariant}
+              onStatus={setStatus}
+              onGoto={gotoSession}
+            />
+          ) : (
+            <div className="grid place-items-center text-[13px] text-muted">选择左侧一个错误查看现场</div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ErrorRow({ g, active, onClick }: { g: GErrGroup; active: boolean; onClick: () => void }): ReactElement {
+  const tone = _severity(g.count, g.is_spiking);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`grid w-full grid-cols-[9px_1fr_auto] items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-all duration-150 ${active ? "border-border-strong bg-accent-soft" : "border-transparent hover:border-border hover:bg-surface-2"}`}
+    >
+      <span className="relative flex h-2 w-2">
+        {g.is_spiking && <span className={`absolute inline-flex h-full w-full rounded-full ${TONE_BG[tone]} opacity-60 animate-ping`} />}
+        <span className={`relative inline-flex h-2 w-2 rounded-full ${TONE_BG[tone]} ${g.is_spiking ? "animate-pulse-dot" : ""}`} />
+      </span>
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5 font-mono text-[12.5px]">
+          <span className="truncate">{g.error_type}</span>
+          {g.is_new && <span className="rounded-sm bg-accent-soft px-1 py-px text-[8.5px] text-accent">NEW</span>}
+          {g.is_spiking && <span className="rounded-sm bg-danger/15 px-1 py-px text-[8.5px] text-danger">⚡</span>}
+        </div>
+        <div className="mt-0.5 truncate font-mono text-[10px] text-subtle">{g.logger_name}</div>
+        <div className="mt-1 flex gap-2.5 font-mono text-[10px] text-muted">
+          <span><b className="font-semibold text-fg">{g.count}</b> 次</span>
+          <span><b className="font-semibold text-fg">{g.sessions}</b> session</span>
+        </div>
+      </div>
+      <div className="flex flex-col items-end gap-1.5">
+        <div className="h-[22px] w-[62px]">{g.spark.length > 1 && <Sparkline data={g.spark} tone={tone} height={22} />}</div>
+        <span className="font-mono text-[10px] text-subtle">{_shortTs(g.last_ts)}</span>
+      </div>
+    </button>
+  );
+}
+
+function ErrorDetail({
+  detail,
+  tab,
+  setTab,
+  variant,
+  setVariant,
+  onStatus,
+  onGoto,
+}: {
+  detail: GErrDetail;
+  tab: "trend" | "trace" | "occ";
+  setTab: (t: "trend" | "trace" | "occ") => void;
+  variant: number;
+  setVariant: (n: number) => void;
+  onStatus: (s: string) => void;
+  onGoto: (key: string) => void;
+}): ReactElement {
+  const status = STATUS_META[detail.status] ?? STATUS_META.active;
+  const tone = _severity(detail.count, false);
+  const activeVariant = detail.variants[variant] ?? detail.variants[0];
+  return (
+    <div className="flex min-h-0 flex-col">
+      {/* hero */}
+      <div className="border-b border-border px-5 py-4">
+        <div className="font-mono text-[19px] font-semibold">{detail.error_type}</div>
+        <div className="mt-1.5 font-mono text-[12px] leading-relaxed text-danger">{detail.message}</div>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          <Chip>{detail.logger_name}</Chip>
+          <Chip>来源 · {SOURCE_LABEL[detail.source] ?? detail.source}</Chip>
+          <Chip>{detail.channel}</Chip>
+          <Chip tone="danger">{detail.level}</Chip>
+          <Chip tone={status.tone}>{status.label}</Chip>
+        </div>
+      </div>
+
+      {/* 爆炸半径 */}
+      <div className="grid grid-cols-4 gap-px border-b border-border bg-border">
+        <Blast label="累计次数" value={String(detail.count)} />
+        <Blast label="独立 session" value={String(detail.sessions)} />
+        <Blast label="首次" value={_shortTs(detail.first_ts)} small />
+        <Blast label="最近" value={_shortTs(detail.last_ts)} small />
+      </div>
+
+      {/* 分段 */}
+      <div className="flex gap-1 border-b border-border px-5 pt-3">
+        <TabBtn active={tab === "trend"} onClick={() => setTab("trend")}>趋势</TabBtn>
+        <TabBtn active={tab === "trace"} onClick={() => setTab("trace")}>
+          Traceback{detail.variants.length > 1 ? ` · ${detail.variants.length} 变体` : ""}
+        </TabBtn>
+        <TabBtn active={tab === "occ"} onClick={() => setTab("occ")}>现场 · {detail.occurrences.length}</TabBtn>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+        {tab === "trend" && (
+          <TrendChart
+            data={detail.trend.map((p) => ({ label: _bucketLabel(p.bucket), value: p.count }))}
+            kind="bar"
+            tone={tone}
+            valueFmt={(n) => String(n)}
+            empty="区间内无发作"
+          />
+        )}
+        {tab === "trace" && (
+          <div>
+            {detail.variants.length > 1 && (
+              <div className="mb-3 flex gap-2">
+                {detail.variants.map((v, i) => (
+                  <button
+                    key={v.fingerprint}
+                    type="button"
+                    onClick={() => setVariant(i)}
+                    className={`rounded-md border px-2.5 py-1.5 text-left font-mono text-[10.5px] ${i === variant ? "border-accent-deep bg-accent-soft text-fg" : "border-border bg-bg text-muted"}`}
+                  >
+                    <b className="text-fg">{v.count}</b> 次 · 变体 {i + 1}
+                  </button>
+                ))}
+              </div>
+            )}
+            <pre className="m-0 max-h-[280px] overflow-auto rounded-lg border border-border bg-bg p-4 font-mono text-[11px] leading-relaxed text-[#c4c4cc]">
+              {activeVariant?.traceback_text || detail.traceback_text}
+            </pre>
+          </div>
+        )}
+        {tab === "occ" && (
+          <div className="flex flex-col gap-2">
+            {detail.occurrences.length === 0 && <div className="text-[12px] text-muted">无可关联的 session 现场。</div>}
+            {detail.occurrences.map((o) => (
+              <div key={o.session_key} className="grid grid-cols-[auto_1fr_auto] items-center gap-3.5 rounded-lg border border-border bg-bg px-3.5 py-2.5">
+                <span className="font-mono text-[11px] text-accent">{_shortTs(o.ts)}</span>
+                <div className="min-w-0">
+                  <div className="truncate text-[12px]">{o.user_preview || "（无用户消息）"}</div>
+                  <div className="mt-0.5 font-mono text-[10px] text-subtle">session {o.session_key}</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onGoto(o.session_key)}
+                  className="whitespace-nowrap rounded-md border border-accent-deep bg-accent-soft px-2.5 py-1.5 font-mono text-[10.5px] text-[#dfe3ff]"
+                >
+                  查看对话 ↗
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 操作 */}
+      <div className="flex flex-shrink-0 gap-2 border-t border-border px-5 py-3">
+        <button
+          type="button"
+          onClick={() => detail.occurrences[0] && onGoto(detail.occurrences[0].session_key)}
+          disabled={detail.occurrences.length === 0}
+          className="rounded-md border border-accent-deep bg-accent-soft px-3 py-2 font-mono text-[11px] text-[#dfe3ff] transition-all duration-150 hover:brightness-110 active:brightness-95 disabled:opacity-40"
+        >
+          查看最近对话 ↗
+        </button>
+        <button
+          type="button"
+          onClick={() => void navigator.clipboard?.writeText(detail.traceback_text)}
+          className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[11px] text-muted transition-colors hover:text-fg"
+        >
+          复制 Traceback
+        </button>
+        <div className="flex-1" />
+        <button type="button" onClick={() => onStatus("acknowledged")} className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[11px] text-muted transition-colors hover:text-fg">
+          标记已确认
+        </button>
+        <button type="button" onClick={() => onStatus("ignored")} className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[11px] text-muted transition-colors hover:border-danger/40 hover:text-danger">
+          忽略此类型
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Blast({ label, value, small }: { label: string; value: string; small?: boolean }): ReactElement {
+  return (
+    <div className="bg-surface px-4 py-3">
+      <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-subtle">{label}</div>
+      <div className={`mt-1.5 font-mono font-semibold tabular-nums ${small ? "text-[12.5px]" : "text-[18px]"}`}>{value}</div>
+    </div>
+  );
+}
+
+function TabBtn({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 font-mono text-[11.5px] transition-colors ${active ? "border-accent text-fg" : "border-transparent text-muted hover:text-fg"}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// 首屏骨架：发丝边框块 + scan 光流扫过，取代白屏 → 数据啪地弹出。
+function SkelBlock({ className }: { className: string }): ReactElement {
+  return (
+    <div className={`relative overflow-hidden rounded-2xl border border-border bg-surface ${className}`}>
+      <div className="absolute inset-0 -translate-x-full animate-scan bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" />
+    </div>
+  );
+}
+
+function ObserveSkeleton(): ReactElement {
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex items-end justify-between">
+        <div className="flex flex-col gap-2">
+          <SkelBlock className="h-7 w-48 rounded-lg" />
+          <SkelBlock className="h-3 w-64 rounded" />
+        </div>
+        <SkelBlock className="h-9 w-56 rounded-md" />
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[132px]" />)}
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {[0, 1, 2, 3].map((i) => <SkelBlock key={i} className="h-[218px] rounded-lg" />)}
+      </div>
+    </div>
+  );
+}
+
+// ── 监测主面板 ────────────────────────────────────────────────────────────────
+
 // Grafana-style monitoring overview over observe.db agent-loop telemetry.
 function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   const [range, setRange] = useState<string>("24h");
   const [overview, setOverview] = useState<Overview | null>(null);
   const [points, setPoints] = useState<SeriesPoint[]>([]);
-  const [errorRows, setErrorRows] = useState<ErrorRow[]>([]);
-  const [groups, setGroups] = useState<ErrorGroup[]>([]);
+  const [gErr, setGErr] = useState<GErrOverview | null>(null);
+  const [drillOpen, setDrillOpen] = useState<boolean>(false);
+  const [updatedAt, setUpdatedAt] = useState<number>(0);
+  const [nowTs, setNowTs] = useState<number>(() => Date.now());
+  const [refreshing, setRefreshing] = useState<boolean>(false);
+  const portalRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    let alive = true;
-    void (async () => {
-      const [ov, series, errs] = await Promise.all([
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const [ov, series, ge] = await Promise.all([
         api<Overview>(`/api/dashboard/observe/overview?range=${range}`),
         api<{ points: SeriesPoint[] }>(`/api/dashboard/observe/timeseries?range=${range}`),
-        api<{ items: ErrorRow[]; groups: ErrorGroup[] }>(`/api/dashboard/observe/errors?range=${range}&page=1&page_size=30`),
+        api<GErrOverview>(`/api/dashboard/observe/global_errors/overview?range=${range}`),
       ]);
-      if (!alive) return;
       setOverview(ov);
       setPoints(series.points ?? []);
-      setErrorRows(errs.items ?? []);
-      setGroups(errs.groups ?? []);
-    })();
-    return () => {
-      alive = false;
-    };
+      setGErr(ge);
+      setUpdatedAt(Date.now());
+    } finally {
+      setRefreshing(false);
+    }
   }, [range]);
 
+  // 首次 + range 变化加载；并以 15s 心跳自动刷新，制造"活的"实时感。
+  useEffect(() => {
+    void load();
+    const id = window.setInterval(() => void load(), 15000);
+    return () => window.clearInterval(id);
+  }, [load]);
+
+  // 1s tick 驱动"更新于 Xs 前"的相对时间标签。
+  useEffect(() => {
+    const id = window.setInterval(() => setNowTs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
   if (!overview) {
-    return <div className="p-6 text-[13px] text-muted">加载中…</div>;
+    return <ObserveSkeleton />;
   }
 
   const turnSeries = points.map((p) => p.turns);
@@ -127,119 +682,103 @@ function ObserveMain(_props: { dispatch: PluginDispatch }): ReactElement {
   const tokenSeries = points.map((p) => p.input_tokens);
   const hitSeries = points.map((p) => (p.cache_hit_rate ?? 0) * 100);
   const iterSeries = points.map((p) => p.avg_iteration ?? 0);
-
   const labelled = (vals: number[]) => points.map((p, i) => ({ label: _bucketLabel(p.bucket), value: vals[i] }));
 
+  // 全局错误总数（采集到的、跨子系统）优先用于「错误」卡，与排障台数字一致。
+  const gErrTotal = gErr?.total ?? overview.errors;
+  const gErrSpark = gErr && gErr.spark.length > 1 ? gErr.spark : errorSeries;
+
   return (
-    <div className="flex flex-col gap-4 p-6">
-      {/* header + range switcher */}
-      <div className="flex items-end justify-between">
-        <div>
-          <div className="detail-title">Observe · 监测</div>
-          <div className="detail-subtext">Agent 主循环遥测 · Token / 迭代 / 错误</div>
-        </div>
-        <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
-          {RANGES.map((r) => (
+    <>
+      <div
+        className="flex flex-col gap-4 p-6 transition-[filter,transform,opacity] duration-[420ms]"
+        style={drillOpen ? { filter: "blur(7px)", transform: "scale(0.97)", opacity: 0.5, pointerEvents: "none" } : undefined}
+      >
+        {/* header + range switcher */}
+        <div className="flex items-end justify-between">
+          <div>
+            <div className="flex items-center gap-2.5">
+              <span className="detail-title">Observe · 监测</span>
+              <span className="flex items-center gap-1.5 rounded-full border border-success/25 bg-success/10 px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-success">
+                <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse-dot" />
+                Live
+              </span>
+            </div>
+            <div className="detail-subtext">
+              Agent 主循环遥测 · Token / 迭代 / 错误
+              <span className="ml-2 font-mono text-[11px] text-subtle">更新于 {_ago(nowTs - updatedAt)}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
             <button
-              key={r.key}
-              onClick={() => setRange(r.key)}
-              className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-colors ${
-                range === r.key ? "bg-accent text-accent-ink" : "text-muted hover:text-fg"
-              }`}
+              onClick={() => void load()}
+              className={`grid h-7 w-7 place-items-center rounded-md border border-border bg-surface-2 text-muted transition-colors hover:border-border-strong hover:text-fg ${refreshing ? "animate-spin" : ""}`}
+              title="刷新"
             >
-              {r.label}
+              ↻
             </button>
-          ))}
-        </div>
-      </div>
-
-      {/* KPI tiles */}
-      <div className="grid grid-cols-4 gap-4">
-        <MetricTile
-          label="对话轮数"
-          value={_compact(overview.turns)}
-          delta={_delta(turnSeries)}
-          sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"}
-          tone="accent"
-          spark={turnSeries}
-        />
-        <MetricTile
-          label="错误"
-          value={_compact(overview.errors)}
-          sub={overview.error_rate != null ? `错误率 ${_pct(overview.error_rate)}` : "error 非空轮次"}
-          tone="danger"
-          spark={errorSeries}
-        />
-        <MetricTile
-          label="KV 缓存命中率"
-          value={_pct(overview.cache_hit_rate)}
-          sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`}
-          tone="success"
-          spark={hitSeries}
-        />
-        <MetricTile
-          label="平均迭代"
-          value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"}
-          unit={`峰 ${overview.max_iteration}`}
-          sub="每轮 LLM 调用次数"
-          tone="warning"
-          spark={iterSeries}
-        />
-      </div>
-
-      {/* trend charts */}
-      <div className="grid grid-cols-2 gap-4">
-        <Card title="输入 Token 趋势">
-          <TrendChart data={labelled(tokenSeries)} kind="area" tone="accent" valueFmt={_compact} />
-        </Card>
-        <Card title="平均迭代趋势">
-          <TrendChart data={labelled(iterSeries)} kind="area" tone="warning" valueFmt={(n) => n.toFixed(1)} />
-        </Card>
-        <Card title="KV 缓存命中率趋势">
-          <TrendChart data={labelled(hitSeries)} kind="area" tone="success" valueFmt={(n) => `${n.toFixed(0)}%`} />
-        </Card>
-        <Card title="错误趋势">
-          <TrendChart data={labelled(errorSeries)} kind="bar" tone="danger" valueFmt={(n) => String(n)} empty="区间内无错误 🎉" />
-        </Card>
-      </div>
-
-      {/* error aggregation + recent errors */}
-      <div className="grid grid-cols-[300px_1fr] gap-4">
-        <Card title="错误聚合 · Top">
-          {groups.length === 0 ? (
-            <div className="text-[12.5px] text-muted">无错误 🎉</div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {groups.map((g, i) => (
-                <div key={i} className="flex items-center justify-between gap-2">
-                  <span className="truncate text-[12px] text-fg" title={g.signature}>{g.signature}</span>
-                  <Chip tone="danger">{g.count}</Chip>
-                </div>
+            <div className="flex gap-1 rounded-md border border-border bg-surface-2 p-1">
+              {RANGES.map((r) => (
+                <button
+                  key={r.key}
+                  onClick={() => setRange(r.key)}
+                  className={`rounded-[4px] px-2.5 py-1 font-mono text-[11px] transition-all duration-150 active:brightness-95 ${range === r.key ? "bg-accent text-accent-ink hover:brightness-110" : "text-muted hover:bg-surface-3 hover:text-fg"}`}
+                >
+                  {r.label}
+                </button>
               ))}
             </div>
-          )}
-        </Card>
+          </div>
+        </div>
 
-        <Card title="最近错误" bodyClass="max-h-[34vh] overflow-auto">
-          {errorRows.length === 0 ? (
-            <div className="px-4 py-4 text-[12.5px] text-muted">区间内无错误记录。</div>
-          ) : (
-            errorRows.map((row) => (
-              <div key={row.id} className="border-b border-border px-4 py-2 last:border-b-0 hover:bg-surface-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-mono text-[11px] tabular-nums text-muted">{row.session_key}</span>
-                  <span className="font-mono text-[10px] tabular-nums text-subtle">{_shortTs(row.ts)}</span>
-                </div>
-                <div className="mt-1 truncate text-[12.5px] text-danger" title={row.error}>{row.error}</div>
-                {row.user_preview && (
-                  <div className="mt-0.5 truncate text-[11.5px] text-subtle" title={row.user_preview}>{row.user_preview}</div>
-                )}
-              </div>
-            ))
-          )}
-        </Card>
+        {/* KPI tiles */}
+        <div className="grid grid-cols-4 gap-4">
+          <div className="animate-fade-up" style={{ animationDelay: "0ms" }}>
+            <MetricTile label="对话轮数" value={_compact(overview.turns)} delta={_delta(turnSeries)} sub={overview.last_ts ? `最近 ${_shortTs(overview.last_ts)}` : "无记录"} tone="accent" spark={turnSeries} />
+          </div>
+          {/* 错误卡 = 传送门：点击 FLIP 放大成排障台 */}
+          <div
+            ref={portalRef}
+            onClick={() => setDrillOpen(true)}
+            className="group relative animate-fade-up cursor-pointer rounded-2xl transition-transform duration-200 hover:-translate-y-0.5"
+            style={{ animationDelay: "60ms" }}
+          >
+            {gErrTotal > 0 && (
+              <span className="absolute left-[68px] top-[18px] z-10 flex h-2 w-2">
+                {(gErr?.spiking_types ?? 0) > 0 && <span className="absolute inline-flex h-full w-full rounded-full bg-danger opacity-60 animate-ping" />}
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-danger animate-pulse-dot" />
+              </span>
+            )}
+            <span className="pointer-events-none absolute right-4 top-4 z-10 font-mono text-[10px] text-danger opacity-0 transition-opacity group-hover:opacity-100">展开分析 →</span>
+            <MetricTile label="错误" value={_compact(gErrTotal)} sub={`${gErr?.types ?? 0} 类型 · 点击展开`} tone="danger" spark={gErrSpark} />
+          </div>
+          <div className="animate-fade-up" style={{ animationDelay: "120ms" }}>
+            <MetricTile label="KV 缓存命中率" value={_pct(overview.cache_hit_rate)} sub={`${_compact(overview.cache_hit_tokens)} / ${_compact(overview.cache_prompt_tokens)} tok`} tone="success" spark={hitSeries} />
+          </div>
+          <div className="animate-fade-up" style={{ animationDelay: "180ms" }}>
+            <MetricTile label="平均迭代" value={overview.avg_iteration != null ? overview.avg_iteration.toFixed(1) : "—"} unit={`峰 ${overview.max_iteration}`} sub="每轮 LLM 调用次数" tone="warning" spark={iterSeries} />
+          </div>
+        </div>
+
+        {/* trend charts */}
+        <div className="grid grid-cols-2 gap-4">
+          <Card title="输入 Token 趋势" style={{ animationDelay: "220ms" }}>
+            <TrendChart data={labelled(tokenSeries)} kind="area" tone="accent" valueFmt={_compact} />
+          </Card>
+          <Card title="平均迭代趋势" style={{ animationDelay: "280ms" }}>
+            <TrendChart data={labelled(iterSeries)} kind="area" tone="warning" valueFmt={(n) => n.toFixed(1)} />
+          </Card>
+          <Card title="KV 缓存命中率趋势" style={{ animationDelay: "340ms" }}>
+            <TrendChart data={labelled(hitSeries)} kind="area" tone="success" valueFmt={(n) => `${n.toFixed(0)}%`} />
+          </Card>
+          <Card title="错误趋势" style={{ animationDelay: "400ms" }}>
+            <TrendChart data={labelled(errorSeries)} kind="bar" tone="danger" valueFmt={(n) => String(n)} empty="区间内无错误 🎉" />
+          </Card>
+        </div>
       </div>
-    </div>
+
+      {drillOpen && <ErrorDrill portalRef={portalRef} range={range} onClose={() => setDrillOpen(false)} />}
+    </>
   );
 }
 

--- a/plugins/observe/db.py
+++ b/plugins/observe/db.py
@@ -73,6 +73,30 @@ CREATE TABLE IF NOT EXISTS memory_writes (
 CREATE INDEX IF NOT EXISTS ix_mw_sk_ts ON memory_writes (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_mw_action ON memory_writes (action, ts);
 
+CREATE TABLE IF NOT EXISTS global_errors (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    fingerprint    TEXT NOT NULL,
+    bucket         TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    logger_name    TEXT,
+    error_type     TEXT,
+    message        TEXT,
+    traceback_text TEXT,
+    level          TEXT,
+    first_ts       TEXT NOT NULL,
+    last_ts        TEXT NOT NULL,
+    count          INTEGER NOT NULL DEFAULT 1,
+    session_keys   TEXT,
+    flow           TEXT,
+    phase          TEXT,
+    turn           TEXT,
+    tick           TEXT,
+    status         TEXT NOT NULL DEFAULT 'active'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gerr_fp_bucket ON global_errors (fingerprint, bucket);
+CREATE INDEX IF NOT EXISTS ix_gerr_last_ts ON global_errors (last_ts);
+CREATE INDEX IF NOT EXISTS ix_gerr_type ON global_errors (error_type, last_ts);
+
 """
 
 
@@ -95,6 +119,14 @@ _TURNS_COLUMNS: dict[str, str] = {
     "react_cache_hit_tokens": "INTEGER",
 }
 
+_GLOBAL_ERRORS_COLUMNS: dict[str, str] = {
+    "flow": "TEXT",
+    "phase": "TEXT",
+    "turn": "TEXT",
+    "tick": "TEXT",
+    "status": "TEXT NOT NULL DEFAULT 'active'",
+}
+
 
 def _ensure_turns_columns(conn: sqlite3.Connection) -> None:
     cols = {
@@ -104,6 +136,18 @@ def _ensure_turns_columns(conn: sqlite3.Connection) -> None:
         if col in cols:
             continue
         _ = conn.execute(f"ALTER TABLE turns ADD COLUMN {col} {ddl}")
+
+
+def _ensure_global_errors_columns(conn: sqlite3.Connection) -> None:
+    cols = {
+        row[1] for row in conn.execute("PRAGMA table_info(global_errors)").fetchall()
+    }
+    if not cols:
+        return
+    for col, ddl in _GLOBAL_ERRORS_COLUMNS.items():
+        if col in cols:
+            continue
+        _ = conn.execute(f"ALTER TABLE global_errors ADD COLUMN {col} {ddl}")
 
 
 def _migrate_removed_proactive_observe(conn: sqlite3.Connection) -> None:
@@ -117,6 +161,7 @@ def open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     _ = conn.executescript(_SCHEMA_SQL)
     _ensure_turns_columns(conn)
+    _ensure_global_errors_columns(conn)
     _migrate_removed_proactive_observe(conn)
     conn.commit()
     return conn

--- a/plugins/observe/events.py
+++ b/plugins/observe/events.py
@@ -73,3 +73,25 @@ class MemoryWriteTrace:
     summary: str | None = None       # write: 写入的 summary
     superseded_ids: list[str] = field(default_factory=list)  # supersede: 被退休的 id 列表
     error: str | None = None
+
+
+@dataclass
+class GlobalErrorTrace:
+    """全局错误采集记录，按 fingerprint + bucket 聚合。"""
+
+    fingerprint: str
+    bucket: str
+    source: str
+    logger_name: str
+    error_type: str
+    message: str
+    traceback_text: str
+    level: str
+    first_ts: str
+    last_ts: str
+    count: int = 1
+    session_keys: list[str] = field(default_factory=list)
+    flow: str = ""
+    phase: str = ""
+    turn: str = ""
+    tick: str = ""

--- a/plugins/observe/observe.sql
+++ b/plugins/observe/observe.sql
@@ -76,6 +76,33 @@ CREATE TABLE IF NOT EXISTS memory_writes (
 CREATE INDEX IF NOT EXISTS ix_mw_sk_ts ON memory_writes (session_key, ts);
 CREATE INDEX IF NOT EXISTS ix_mw_action ON memory_writes (action, ts);
 
+-- ─────────────────────────────────────────────
+-- 4. global_errors  全局异常聚合
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS global_errors (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    fingerprint    TEXT NOT NULL,
+    bucket         TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    logger_name    TEXT,
+    error_type     TEXT,
+    message        TEXT,
+    traceback_text TEXT,
+    level          TEXT,
+    first_ts       TEXT NOT NULL,
+    last_ts        TEXT NOT NULL,
+    count          INTEGER NOT NULL DEFAULT 1,
+    session_keys   TEXT,
+    flow           TEXT,
+    phase          TEXT,
+    turn           TEXT,
+    tick           TEXT,
+    status         TEXT NOT NULL DEFAULT 'active'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gerr_fp_bucket ON global_errors (fingerprint, bucket);
+CREATE INDEX IF NOT EXISTS ix_gerr_last_ts ON global_errors (last_ts);
+CREATE INDEX IF NOT EXISTS ix_gerr_type ON global_errors (error_type, last_ts);
+
 -- 淘汰策略（由 retention.py 执行，不在 schema 里 enforce）
 -- turns:               180 天
 -- rag_queries:          90 天

--- a/plugins/observe/plugin.py
+++ b/plugins/observe/plugin.py
@@ -11,6 +11,7 @@ from agent.plugins import Plugin
 from bus.events_lifecycle import TurnCommitted
 from core.memory.events import MemoryWritten, RetrievalCompleted
 
+from .collector import GlobalErrorCollector
 from .retention import run_retention_if_needed
 from .writer import TraceWriter
 
@@ -36,6 +37,8 @@ class ObservePlugin(Plugin):
             self._writer.run(),
             name="observe_writer",
         )
+        self._collector = GlobalErrorCollector(self._writer)
+        self._collector.install()
         self._retention_task = asyncio.create_task(
             run_retention_if_needed(workspace / "observe" / "observe.db"),
             name="observe_retention",
@@ -45,6 +48,9 @@ class ObservePlugin(Plugin):
         self.context.event_bus.on(MemoryWritten, self._observe_memory_written)
 
     async def terminate(self) -> None:
+        collector = getattr(self, "_collector", None)
+        if collector is not None:
+            collector.close()
         for task in (
             getattr(self, "_retention_task", None),
             getattr(self, "_writer_task", None),

--- a/plugins/observe/retention.py
+++ b/plugins/observe/retention.py
@@ -20,6 +20,7 @@ logger = logging.getLogger("observe.retention")
 _RETENTION_DAYS = {
     "turns": 180,
     "rag_queries": 90,
+    "global_errors": 90,
 }
 _STAMP_FILE = ".last_cleanup"
 
@@ -45,8 +46,9 @@ def _run_cleanup(db_path: Path) -> None:
         with conn:
             for table, days in _RETENTION_DAYS.items():
                 cutoff = f"datetime('now', '-{days} days')"
+                status_clause = " AND status != 'ignored'" if table == "global_errors" else ""
                 cur = conn.execute(
-                    f"DELETE FROM {table} WHERE ts < {cutoff} AND error IS NULL"
+                    f"DELETE FROM {table} WHERE {_retention_ts_col(table)} < {cutoff}{status_clause} AND {_retention_error_clause(table)}"
                 )
                 deleted[table] = cur.rowcount
 
@@ -66,3 +68,11 @@ async def run_retention_if_needed(db_path: Path) -> None:
         return
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, _run_cleanup, db_path)
+
+
+def _retention_ts_col(table: str) -> str:
+    return "last_ts" if table == "global_errors" else "ts"
+
+
+def _retention_error_clause(table: str) -> str:
+    return "1 = 1" if table == "global_errors" else "error IS NULL"

--- a/plugins/observe/writer.py
+++ b/plugins/observe/writer.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .db import open_db
-from .events import MemoryWriteTrace, RagQueryLog, TurnTrace
+from .events import GlobalErrorTrace, MemoryWriteTrace, RagQueryLog, TurnTrace
 
 logger = logging.getLogger("observe.writer")
 
@@ -44,7 +44,7 @@ class TraceWriter:
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._queue: asyncio.Queue[
-            TurnTrace | RagQueryLog | MemoryWriteTrace
+            TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace
         ] = asyncio.Queue(
             maxsize=_QUEUE_MAX
         )
@@ -52,7 +52,7 @@ class TraceWriter:
 
     # ── 公共接口 ─────────────────────────────────
 
-    def emit(self, event: TurnTrace | RagQueryLog | MemoryWriteTrace) -> None:
+    def emit(self, event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace) -> None:
         """非阻塞 emit。Queue 满时 drop 并记录计数。"""
         try:
             self._queue.put_nowait(event)
@@ -97,7 +97,7 @@ class TraceWriter:
     # ── 内部写入 ─────────────────────────────────
 
     def _write_one(
-        self, conn, event: TurnTrace | RagQueryLog | MemoryWriteTrace
+        self, conn, event: TurnTrace | RagQueryLog | MemoryWriteTrace | GlobalErrorTrace
     ) -> None:
         ts = _now_iso()
         if isinstance(event, TurnTrace):
@@ -106,6 +106,8 @@ class TraceWriter:
             _write_rag(conn, event, ts)
         elif isinstance(event, MemoryWriteTrace):
             _write_memory_write(conn, event, ts)
+        elif isinstance(event, GlobalErrorTrace):
+            _write_global_error(conn, event)
 
 
 # ── DB 写入函数 ───────────────────────────────────────────────────────────────
@@ -217,3 +219,67 @@ def _write_memory_write(conn, e: MemoryWriteTrace, ts: str) -> None:
                 e.error,
             ),
         )
+
+
+def _write_global_error(conn, e: GlobalErrorTrace) -> None:
+    session_keys = _merge_session_keys([], e.session_keys)
+    with conn:
+        row = conn.execute(
+            "SELECT session_keys FROM global_errors WHERE fingerprint = ? AND bucket = ?",
+            (e.fingerprint, e.bucket),
+        ).fetchone()
+        if row is not None:
+            session_keys = _merge_session_keys(_json_loads_list(row[0]), e.session_keys)
+        conn.execute(
+            """
+            INSERT INTO global_errors (
+                fingerprint, bucket, source, logger_name, error_type, message,
+                traceback_text, level, first_ts, last_ts, count, session_keys,
+                flow, phase, turn, tick
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(fingerprint, bucket) DO UPDATE SET
+                count = global_errors.count + excluded.count,
+                last_ts = excluded.last_ts,
+                session_keys = excluded.session_keys,
+                status = global_errors.status
+            """,
+            (
+                e.fingerprint,
+                e.bucket,
+                e.source,
+                e.logger_name,
+                e.error_type,
+                e.message,
+                e.traceback_text,
+                e.level,
+                e.first_ts,
+                e.last_ts,
+                max(1, int(e.count)),
+                json.dumps(session_keys, ensure_ascii=False) if session_keys else None,
+                e.flow,
+                e.phase,
+                e.turn,
+                e.tick,
+            ),
+        )
+
+
+def _json_loads_list(raw: object) -> list[str]:
+    try:
+        value = json.loads(str(raw or "[]"))
+    except Exception:
+        return []
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _merge_session_keys(old: list[str], new: list[str]) -> list[str]:
+    seen: list[str] = []
+    for key in [*old, *new]:
+        text = str(key or "").strip()
+        if text and text not in seen:
+            seen.append(text)
+        if len(seen) >= 20:
+            break
+    return seen

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import random as _random_module
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, cast
@@ -30,6 +31,7 @@ from agent.tools.registry import ToolRegistry
 from agent.turns.outbound import PushToolOutboundPort
 from agent.turns.orchestrator import TurnOrchestrator, TurnOrchestratorDeps
 from core.common.strategy_trace import build_strategy_trace_envelope
+from core.common.diagnostic_log import diagnostic_context, diagnostic_line
 from proactive_v2.anyaction import AnyActionGate, QuotaStore
 from proactive_v2.energy import (
     compute_energy,
@@ -391,7 +393,10 @@ class ProactiveLoop:
         return interval
 
     def _target_session_key(self) -> str:
-        return self._sense.target_session_key()
+        sense = getattr(self, "_sense", None)
+        if sense is None:
+            return "-"
+        return sense.target_session_key()
 
     def stop(self) -> None:
         self._running = False
@@ -437,7 +442,49 @@ class ProactiveLoop:
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
         # 主动回复全链路入口：Gate → Fetch → Judge → Resolve → Deliver。
-        return await self._proactive_pipeline.run()
+        started = time.perf_counter()
+        session_key = self._target_session_key()
+        with diagnostic_context(session=session_key, flow="proactive", phase="tick"):
+            logger.info(
+                diagnostic_line(
+                    "ProactiveLoop._tick",
+                    event="start",
+                    flow="proactive",
+                    phase="tick",
+                    session=session_key,
+                    action="run",
+                )
+            )
+            try:
+                score = await self._proactive_pipeline.run()
+            except Exception as exc:
+                logger.exception(
+                    diagnostic_line(
+                        "ProactiveLoop._tick",
+                        event="phase_error",
+                        flow="proactive",
+                        phase="tick",
+                        session=session_key,
+                        action="fail",
+                        reason="proactive_tick_error",
+                        duration_ms=int((time.perf_counter() - started) * 1000),
+                        error_type=type(exc).__name__,
+                        note=str(exc)[:160],
+                    )
+                )
+                raise
+            logger.info(
+                diagnostic_line(
+                    "ProactiveLoop._tick",
+                    event="end",
+                    flow="proactive",
+                    phase="tick",
+                    session=session_key,
+                    action="done",
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                )
+            )
+            return score
 
 
 def build_proactive_loop(**kwargs: Any) -> ProactiveLoop:

--- a/tests/test_observe_dashboard.py
+++ b/tests/test_observe_dashboard.py
@@ -65,6 +65,31 @@ def _seed(workspace: Path) -> None:
         session_key="telegram:1",
         react_input_sum_tokens=123,
     )
+    conn.execute(
+        """
+        INSERT INTO global_errors (
+            fingerprint, bucket, source, logger_name, error_type, message,
+            traceback_text, level, first_ts, last_ts, count, session_keys,
+            flow, phase
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "fp1",
+            _iso(now - timedelta(hours=1))[:13],
+            "log",
+            "agent.test",
+            "RuntimeError",
+            "provider failed",
+            "trace",
+            "ERROR",
+            _iso(now - timedelta(hours=1)),
+            _iso(now - timedelta(hours=1)),
+            3,
+            '["telegram:1"]',
+            "passive",
+            "reasoner",
+        ),
+    )
     conn.commit()
     conn.close()
 
@@ -115,6 +140,24 @@ def test_errors_list_and_groups(tmp_path) -> None:
     assert res["items"][0]["session_key"] == "cli:local"
     assert len(res["groups"]) == 1
     assert res["groups"][0]["count"] == 1
+
+
+def test_global_errors_overview_and_list(tmp_path) -> None:
+    _seed(tmp_path)
+    reader = ObserveDashboardReader(tmp_path)
+    ov = reader.get_global_overview("24h")
+    assert ov["total"] == 3
+    assert ov["types"] == 1
+    assert ov["spark"] == [3]
+    res = reader.get_global_list("24h", facet="type", q="")
+    assert len(res["sections"]) == 1
+    item = res["sections"][0]["items"][0]
+    assert item["fingerprint"] == "fp1"
+    assert item["count"] == 3
+    assert item["error_type"] == "RuntimeError"
+    detail = reader.get_global_detail("fp1", "24h")
+    assert detail["message"] == "provider failed"
+    assert detail["occurrences"][0]["session_key"] == "telegram:1"
 
 
 def test_missing_db_returns_empty(tmp_path) -> None:

--- a/tests/test_observe_writer.py
+++ b/tests/test_observe_writer.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import suppress
 import importlib
 import json
+import logging
 import sqlite3
 from collections.abc import Callable
 from pathlib import Path
@@ -14,15 +15,38 @@ _observe_events = importlib.import_module("plugins.observe.events")
 _observe_migration = importlib.import_module("plugins.observe.migrate_legacy_rag")
 _observe_retention = importlib.import_module("plugins.observe.retention")
 _observe_writer = importlib.import_module("plugins.observe.writer")
+_observe_collector = importlib.import_module("plugins.observe.collector")
+_diagnostic_log = importlib.import_module("core.common.diagnostic_log")
 
 open_db = cast(Callable[[Path], sqlite3.Connection], getattr(_observe_db, "open_db"))
 RagHitLog = getattr(_observe_events, "RagHitLog")
 RagQueryLog = getattr(_observe_events, "RagQueryLog")
 TurnTrace = getattr(_observe_events, "TurnTrace")
+GlobalErrorTrace = getattr(_observe_events, "GlobalErrorTrace")
+GlobalErrorCollector = getattr(_observe_collector, "GlobalErrorCollector")
+diagnostic_context = getattr(_diagnostic_log, "diagnostic_context")
+diagnostic_line = getattr(_diagnostic_log, "diagnostic_line")
 migrate_legacy_rag_tables = getattr(_observe_migration, "migrate_legacy_rag_tables")
 _run_cleanup = cast(Callable[[Path], None], getattr(_observe_retention, "_run_cleanup"))
 _write_turn = getattr(_observe_writer, "_write_turn")
 TraceWriter = getattr(_observe_writer, "TraceWriter")
+
+
+def test_diagnostic_line_uses_fixed_field_order():
+    line = diagnostic_line(
+        "PassiveTurnPipeline.run",
+        event="start",
+        flow="passive",
+        phase="before_turn",
+        session="telegram:1",
+        turn="abc123",
+        action="run",
+    )
+    assert line == (
+        "[PassiveTurnPipeline.run] event=start flow=passive phase=before_turn "
+        "session=telegram:1 turn=abc123 tick=- action=run reason=- "
+        "duration_ms=- counts=- error_type=- error_fp=- note=\"-\""
+    )
 
 
 def test_write_turn_persists_raw_output_and_meme_fields(tmp_path):
@@ -157,6 +181,81 @@ def test_open_db_creates_react_budget_columns(tmp_path):
     assert "react_cache_hit_tokens" in cols
 
 
+def test_open_db_migrates_global_error_context_columns(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE global_errors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                fingerprint TEXT NOT NULL,
+                bucket TEXT NOT NULL,
+                source TEXT NOT NULL,
+                logger_name TEXT,
+                error_type TEXT,
+                message TEXT,
+                traceback_text TEXT,
+                level TEXT,
+                first_ts TEXT NOT NULL,
+                last_ts TEXT NOT NULL,
+                count INTEGER NOT NULL DEFAULT 1,
+                session_keys TEXT
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    conn = open_db(db_path)
+    try:
+        cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(global_errors)").fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert {"flow", "phase", "turn", "tick", "status"} <= cols
+
+
+def test_write_global_error_upserts_count_and_sessions(tmp_path):
+    db_path = tmp_path / "observe.db"
+    conn = open_db(db_path)
+    try:
+        event = GlobalErrorTrace(
+            fingerprint="fp1",
+            bucket="2026-06-20T11",
+            source="log",
+            logger_name="agent.test",
+            error_type="RuntimeError",
+            message="boom",
+            traceback_text="trace",
+            level="ERROR",
+            first_ts="2026-06-20T11:00:00+00:00",
+            last_ts="2026-06-20T11:00:00+00:00",
+            session_keys=["telegram:1"],
+            flow="passive",
+            phase="reasoner",
+            turn="turn-a",
+        )
+        _observe_writer._write_global_error(conn, event)
+        event.last_ts = "2026-06-20T11:01:00+00:00"
+        event.session_keys = ["telegram:2"]
+        _observe_writer._write_global_error(conn, event)
+        row = conn.execute(
+            "SELECT count, session_keys, flow, phase FROM global_errors WHERE fingerprint = ?",
+            ("fp1",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row[0] == 2
+    assert json.loads(row[1]) == ["telegram:1", "telegram:2"]
+    assert row[2] == "passive"
+    assert row[3] == "reasoner"
+
+
 @pytest.mark.asyncio
 async def test_trace_writer_drain_waits_for_rag_query(tmp_path):
     db_path = tmp_path / "observe.db"
@@ -209,6 +308,48 @@ async def test_trace_writer_drain_waits_for_rag_query(tmp_path):
     assert row[4] == 1
     assert row[5] == "RETRIEVE"
     assert '"id": "m1"' in row[6]
+
+
+@pytest.mark.asyncio
+async def test_global_error_collector_captures_error_log_with_context(tmp_path):
+    db_path = tmp_path / "observe.db"
+    writer = TraceWriter(db_path)
+    task = asyncio.create_task(writer.run())
+    collector = GlobalErrorCollector(writer)
+    test_logger = logging.getLogger("tests.observe.collector")
+    row = None
+    try:
+        collector.install()
+        with diagnostic_context(session="telegram:1", flow="passive", phase="reasoner", turn="turn-a"):
+            try:
+                raise RuntimeError("provider failed 123")
+            except RuntimeError:
+                test_logger.exception("provider failed 123")
+        await writer.drain()
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                """
+                SELECT source, error_type, message, session_keys, flow, phase, turn
+                FROM global_errors
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+    finally:
+        collector.close()
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    assert row is not None
+    assert row[0] == "log"
+    assert row[1] == "RuntimeError"
+    assert row[2] == "provider failed 123"
+    assert json.loads(row[3]) == ["telegram:1"]
+    assert row[4] == "passive"
+    assert row[5] == "reasoner"
+    assert row[6] == "turn-a"
 
 
 def test_open_db_does_not_create_legacy_rag_tables(tmp_path):

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -783,12 +783,14 @@ async def test_shell_auto_promotes_to_background_after_fg_threshold(monkeypatch)
     assert task_id is not None, "应返回 background_task_id"
     assert result["status"] == "running"
     assert result.get("auto_promoted") is True
-    assert result["timeout_s"] is None
+    assert result["timeout_s"] == shell_mod._DEFAULT_TIMEOUT
     assert task_id in shell_mod._BG_REGISTRY
-    assert shell_mod._BG_REGISTRY[task_id].timeout_s is None
-    assert shell_mod._BG_REGISTRY[task_id].timeout_handle is None
+    assert shell_mod._BG_REGISTRY[task_id].timeout_s == shell_mod._DEFAULT_TIMEOUT
+    assert shell_mod._BG_REGISTRY[task_id].timeout_handle is not None
 
-    # 清理
+    handle = shell_mod._BG_REGISTRY[task_id].timeout_handle
+    if handle is not None:
+        handle.cancel()
     shell_mod._BG_REGISTRY.pop(task_id, None)
 
 
@@ -1034,6 +1036,45 @@ async def test_task_output_clamps_block_timeout(monkeypatch, tmp_path):
     bg = shell_mod._BG_REGISTRY.pop(task_id, None)
     if bg is not None and bg.pump_task is not None:
         bg.pump_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_task_output_handles_internal_timeout_cancellation(monkeypatch, tmp_path):
+    import agent.tools.shell as shell_mod
+
+    monkeypatch.setattr("agent.tools.shell._kill_process_tree", lambda *_: None)
+
+    log_path = tmp_path / "internal_timeout.log"
+    log_path.write_text("", encoding="utf-8")
+
+    fake_proc = _FakeProc(stdout="", stderr="", returncode=None)
+    fake_proc.pid = 5678
+    pump_task = asyncio.ensure_future(asyncio.sleep(100))
+
+    task_id = "shell_internal_timeout"
+    shell_mod._BG_REGISTRY[task_id] = shell_mod._BackgroundTask(
+        proc=fake_proc,
+        log_path=str(log_path),
+        pump_task=pump_task,
+        started_at=shell_mod.time.monotonic(),
+        wall_started_at_ms=0,
+        timeout_s=60,
+    )
+
+    async def fake_wait_for(aw, timeout):
+        shell_mod._bg_timeout(task_id)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(shell_mod.asyncio, "wait_for", fake_wait_for)
+
+    tool = ShellTaskOutputTool()
+    result = json.loads(
+        await tool.execute(task_id=task_id, block=True, timeout_ms=30000)
+    )
+
+    assert "error" in result
+    assert "超时" in result["error"]
+    assert task_id not in shell_mod._BG_REGISTRY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

Fixes #88。

前台 `shell` 自动转后台后，后台任务达到硬超时时会取消内部 `pump_task`。如果此时 `task_output(block=true)` 正在等待该任务，内部 `CancelledError` 会冒泡到外层，导致整轮被记录为 `Turn cancelled`。

## 改动

- 自动转后台任务继承当前 shell timeout，避免默认后台任务没有硬截止时间。
- `task_output` 的 block 等待会按后台任务剩余硬超时时间截断。
- 内部后台超时取消会转换为正常工具超时结果；外层主动取消仍继续抛出。
- 补充回归测试覆盖内部 timeout cancellation 场景。

## 验证

- `pytest tests/test_shell_tool.py`：34 passed
- `pyright agent/tools/shell.py tests/test_shell_tool.py`：0 errors，保留既有 warnings