### PR TITLE
[codex] 修复 observe 错误排障台黑屏

### DIFF
--- a/plugins/observe/dashboard.py
+++ b/plugins/observe/dashboard.py
@@ -433,6 +433,7 @@ def _aggregate_fingerprint(rows: list[sqlite3.Row]) -> dict[str, Any]:
         "channel": _channel_of(sessions),
         "is_new": _is_new(first_ts),
         "is_spiking": _is_spiking(spark),
+        "spark": spark,
         "_buckets": buckets,
     }
 

--- a/plugins/observe/dashboard_panel.tsx
+++ b/plugins/observe/dashboard_panel.tsx
@@ -414,6 +414,7 @@ function ErrorDrill({
 
 function ErrorRow({ g, active, onClick }: { g: GErrGroup; active: boolean; onClick: () => void }): ReactElement {
   const tone = _severity(g.count, g.is_spiking);
+  const spark = g.spark ?? [];
   return (
     <button
       type="button"
@@ -437,7 +438,7 @@ function ErrorRow({ g, active, onClick }: { g: GErrGroup; active: boolean; onCli
         </div>
       </div>
       <div className="flex flex-col items-end gap-1.5">
-        <div className="h-[22px] w-[62px]">{g.spark.length > 1 && <Sparkline data={g.spark} tone={tone} height={22} />}</div>
+        <div className="h-[22px] w-[62px]">{spark.length > 1 && <Sparkline data={spark} tone={tone} height={22} />}</div>
         <span className="font-mono text-[10px] text-subtle">{_shortTs(g.last_ts)}</span>
       </div>
     </button>

--- a/tests/test_observe_global_dashboard.py
+++ b/tests/test_observe_global_dashboard.py
@@ -66,6 +66,7 @@ def test_global_list_type_facet(tmp_path):
     assert items[0]["error_type"] == "TimeoutError"
     assert items[0]["count"] == 13
     assert items[0]["sessions"] == 2
+    assert items[0]["spark"] == [5, 8]
     assert "_buckets" not in items[0]
 
 


### PR DESCRIPTION
## 问题

点击 Observe 的“错误”卡片后，前端在错误列表行里读取 `g.spark.length`。后端的 global error list 响应没有返回 `spark` 字段，导致 React 渲染抛出 TypeError，页面只剩遮罩，看起来像黑屏。

## 改动

- 在 `global_errors` 指纹聚合结果中返回每个错误的 `spark` 时间桶序列。
- 前端读取 `spark` 时增加空数组兜底，避免边界数据再次让排障台整体崩溃。
- 补充 dashboard 聚合测试，覆盖列表响应里的 `spark` 字段。

## 验证

- `.venv/bin/pytest -q tests/test_observe_global_dashboard.py`
- `.venv/bin/pyright plugins/observe/dashboard.py tests/test_observe_global_dashboard.py`
- `npm run typecheck`
- `npm run build:plugins`