### PR TITLE
[codex] 同步 Akasha reinforce 激活簇机制

### DIFF
--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -367,21 +367,23 @@ def activation_edge_updates(
     candidates: list[AkashaCandidate],
     ts: float,
     query_residual: float = 1.0,
-    reinforced: bool = False,
+    reinforce_boost: float = 1.0,
 ) -> list[EdgeUpdate]:
     # Residual Hebb：右脑只对预测误差产生可塑性。
-    # gain = max(ν_turn, REINFORCE_NU_FLOOR if reinforced else 0)
+    # gain = max(ν_turn, REINFORCE_NU_FLOOR if reinforce_boost > 1 else 0)
     # 完全重复输入 ν=0：本轮所有边写入权重为 0，反馈环数学上断开。
     # reinforce 重新解释：用户标记 = 给 ν 设下界，相当于一次弱新 episode 的 surprise，
     # 比普通复读厚但不超过自然 episode。
-    floor = REINFORCE_NU_FLOOR if reinforced else 0.0
+    floor = REINFORCE_NU_FLOOR if reinforce_boost > 1.0 else 0.0
     gain = max(0.0, min(1.0, max(query_residual, floor)))
-    if gain <= 0.0:
-        return []
     updates: list[EdgeUpdate] = []
+
+    if gain <= 0.0:
+        return updates
+
     key_to_score = {item.key: item.score for item in candidates}
     for item in candidates:
-        edge_strength = key_to_score.get(item.key, 1.0)
+        edge_strength = key_to_score.get(item.key, 1.0) * reinforce_boost
         updates.append(
             EdgeUpdate(item.key, current_key, edge_strength * STDP_CAUSAL_EDGE_GAIN * gain, ts)
         )
@@ -395,6 +397,23 @@ def activation_edge_updates(
             updates.append(EdgeUpdate(left.key, right.key, edge_strength, ts))
             updates.append(EdgeUpdate(right.key, left.key, edge_strength, ts))
     return updates
+
+
+def reinforced_activation_items(
+    current_items: list[AkashaCandidate],
+    previous_items: list[AkashaCandidate],
+    reinforce_boost: float,
+) -> list[AkashaCandidate]:
+    if reinforce_boost <= 1.0 or not previous_items:
+        return current_items
+    combined = list(current_items)
+    seen_keys = {item.key for item in combined}
+    for item in previous_items:
+        if item.key in seen_keys:
+            continue
+        combined.append(item)
+        seen_keys.add(item.key)
+    return combined
 
 
 def local_residual(query_vec: np.ndarray, prior_vecs: np.ndarray) -> float:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -46,6 +46,7 @@ from plugins.akasha.core import (
     parse_turn_key as _parse_turn_key,
     bounded_add as _bounded_add,
     reinforce_boost_from_payload as _reinforce_boost_from_payload,
+    reinforced_activation_items as _reinforced_activation_items,
 )
 from agent.config_models import Config  # noqa: F401
 from bus.events_lifecycle import TurnCommitted
@@ -146,6 +147,7 @@ class AkashaMemoryEngine:
         )
         self._event_bus = event_publisher
         self._pending_by_session: dict[str, PendingActivation] = {}
+        self._prev_activation_by_session: dict[str, list[AkashaCandidate]] = {}
         self._graph_lock = threading.RLock()
         self._nodes: dict[str, AkashaNode] = {}
         self._edges: dict[tuple[str, str], float] = {}
@@ -651,31 +653,46 @@ class AkashaMemoryEngine:
         # 3. 用真实 current_key 建边，并记录激活诊断。
         #    reinforce 标记 = 本轮调用了 reinforce_memory 工具(记在 tool_chain)或 extra 回填；
         #    与离线重建(build._load_reinforce_boosts)读同一来源，live 与重放一致。
-        reinforced = _reinforce_boost_for_turn(
+        reinforce_boost = _reinforce_boost_for_turn(
             event.extra,
             event.tool_chain_raw,
-        ) > 1.0
+        )
         pending = self._pending_by_session.pop(event.session_key, None)
         if current_key and pending is not None:
-            self._commit_pending_activation(current_key, pending, reinforced=reinforced)
+            self._commit_pending_activation(
+                current_key,
+                pending,
+                session_key=event.session_key,
+                reinforce_boost=reinforce_boost,
+            )
 
     # 把 pending activation 转成边和事件。
     def _commit_pending_activation(
         self,
         current_key: str,
         pending: PendingActivation,
-        reinforced: bool = False,
+        session_key: str = "",
+        reinforce_boost: float = 1.0,
     ) -> None:
         query_residual = self._compute_query_residual(pending.query_vec, current_key)
+        prev_by_session = getattr(self, "_prev_activation_by_session", {})
+        edge_items = _reinforced_activation_items(
+            pending.items,
+            prev_by_session.get(session_key, []),
+            reinforce_boost,
+        )
         edge_updates = _activation_edge_updates(
             current_key,
-            pending.items,
+            edge_items,
             pending.ts,
             query_residual=query_residual,
-            reinforced=reinforced,
+            reinforce_boost=reinforce_boost,
         )
         self._store.upsert_edges(edge_updates)
         self._apply_edge_updates(edge_updates)
+        if session_key:
+            prev_by_session[session_key] = list(pending.items)
+            self._prev_activation_by_session = prev_by_session
 
         # 2. 记录本轮激活明细，便于之后诊断。
         self._store.insert_activation_events([

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -32,6 +32,7 @@ from plugins.akasha.core import (
     graph_seed_keys_from_snapshot,
     parse_turn_key,
     parse_ts_unix,
+    reinforced_activation_items,
     turn_key,
 )
 from plugins.akasha.engine import (
@@ -127,6 +128,7 @@ class AkashaReplayRuntime:
         self._message_turn_keys = dict(message_turn_keys)
         # turn_key -> gain_boost：来自 messages.extra["akasha_reinforce"]，重放时定向加厚该轮边。
         self._reinforce_boosts = dict(reinforce_boosts or {})
+        self._prev_activation_by_session: dict[str, list[AkashaCandidate]] = {}
 
     # 按线上状态机回放一轮：先激活旧图，再提交当前 turn。
     def replay_turn(
@@ -245,22 +247,30 @@ class AkashaReplayRuntime:
         if current_key and activation_items:
             trigger = next((item.message for item in items if item.message.role == "user"), items[0].message)
             ts = parse_ts_unix(trigger.ts)
-            reinforced = self._reinforce_boosts.get(current_key, 1.0) > 1.0
+            reinforce_boost = self._reinforce_boosts.get(current_key, 1.0)
             trigger_emb = next(
                 (item.embedding for item in items if item.message.role == "user"),
                 items[0].embedding,
             )
             query_residual = self._query_residual(trigger_emb, current_key)
+            edge_items = reinforced_activation_items(
+                activation_items,
+                self._prev_activation_by_session.get(trigger.session_key, []),
+                reinforce_boost,
+            )
             self._store.upsert_edges(
                 activation_edge_updates(
                     current_key,
-                    activation_items,
+                    edge_items,
                     ts,
                     query_residual=query_residual,
-                    reinforced=reinforced,
+                    reinforce_boost=reinforce_boost,
                 )
             )
             self._store.insert_activation_events(_activation_events(trigger, activation_items))
+        session_key = next((item.message.session_key for item in items if item.message.session_key), "")
+        if session_key and activation_items:
+            self._prev_activation_by_session[session_key] = list(activation_items)
         return current_key
 
     # ν_turn = 1 − max_{j<i} cos(query, prior_j)²；当前 turn 自身排除。

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -386,6 +386,89 @@ def test_replay_and_runtime_use_same_directional_stdp_edges(tmp_path: Path) -> N
         runtime_store.close()
 
 
+def test_replay_and_runtime_reinforce_previous_activation_cluster(tmp_path: Path) -> None:
+    prev = _candidate("s:0", 0.8)
+    current = _candidate("s:2", 0.7)
+    ts = QUERY_TS.timestamp()
+    replay_store = AkashaStore(tmp_path / "replay.db")
+    runtime_store = AkashaStore(tmp_path / "runtime.db")
+    try:
+        with closing(sqlite3.connect(":memory:")) as source_db:
+            replay = AkashaReplayRuntime(
+                store=replay_store,
+                config=AkashaConfig(),
+                source_db_path=tmp_path / "sessions.db",
+                source_cursor=source_db.cursor(),
+                message_embeddings={},
+                message_turn_keys={},
+                reinforce_boosts={"s:4": 3.0},
+            )
+            replay.commit_turn(
+                [ReplayMessage(SourceMessage("m2", "s", 2, "user", "beta", QUERY_TS.isoformat()), [1.0, 0.0])],
+                [prev],
+            )
+            replay.commit_turn(
+                [ReplayMessage(SourceMessage("m4", "s", 4, "user", "gamma", QUERY_TS.isoformat()), [1.0, 0.0])],
+                [current],
+            )
+
+        engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+        engine._store = runtime_store
+        engine._graph_lock = threading.RLock()
+        engine._edges = {}
+        engine._edges_meta = {}
+        engine._edges_by_src = {}
+        engine._fan = {}
+        engine._nodes = {}
+        engine._prev_activation_by_session = {}
+        first_key = runtime_store.upsert_message_node(
+            SourceMessage("m2", "s", 2, "user", "beta", QUERY_TS.isoformat()),
+            [1.0, 0.0],
+        )
+        first_node = runtime_store.get_node(first_key)
+        assert first_node is not None
+        engine._nodes[first_key] = first_node
+        engine._commit_pending_activation(
+            "s:2",
+            PendingActivation(
+                query_id="s:2",
+                seq=2,
+                ts=ts,
+                items=[prev],
+                query_vec=np.array([1.0, 0.0], dtype=np.float32),
+            ),
+            "s",
+        )
+        second_key = runtime_store.upsert_message_node(
+            SourceMessage("m4", "s", 4, "user", "gamma", QUERY_TS.isoformat()),
+            [1.0, 0.0],
+        )
+        second_node = runtime_store.get_node(second_key)
+        assert second_node is not None
+        engine._nodes[second_key] = second_node
+        engine._commit_pending_activation(
+            "s:4",
+            PendingActivation(
+                query_id="s:4",
+                seq=4,
+                ts=ts,
+                items=[current],
+                query_vec=np.array([1.0, 0.0], dtype=np.float32),
+            ),
+            "s",
+            3.0,
+        )
+
+        replay_edges = replay_store.load_edges()
+        runtime_edges = runtime_store.load_edges()
+        assert replay_edges == pytest.approx(runtime_edges)
+        assert ("s:0", "s:4") in replay_edges
+        assert ("s:4", "s:0") in replay_edges
+    finally:
+        replay_store.close()
+        runtime_store.close()
+
+
 def test_replay_writes_query_log_with_activation_items(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 改动

- 同步 Akasha 插件的 reinforce 激活簇机制。
- 更新对应插件测试。

## 验证

- `pyright plugins/akasha/core.py plugins/akasha/engine.py plugins/akasha/replay.py tests/test_akasha_plugin.py`：0 errors, 2 warnings
- `pytest tests/test_akasha_plugin.py`：25 passed

## 配置影响

- 无配置变更。