### PR TITLE
[codex] 优化 Akasha 记忆图快照体验

### DIFF
--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -367,21 +367,23 @@ def activation_edge_updates(
     candidates: list[AkashaCandidate],
     ts: float,
     query_residual: float = 1.0,
-    reinforced: bool = False,
+    reinforce_boost: float = 1.0,
 ) -> list[EdgeUpdate]:
     # Residual Hebb：右脑只对预测误差产生可塑性。
-    # gain = max(ν_turn, REINFORCE_NU_FLOOR if reinforced else 0)
+    # gain = max(ν_turn, REINFORCE_NU_FLOOR if reinforce_boost > 1 else 0)
     # 完全重复输入 ν=0：本轮所有边写入权重为 0，反馈环数学上断开。
     # reinforce 重新解释：用户标记 = 给 ν 设下界，相当于一次弱新 episode 的 surprise，
     # 比普通复读厚但不超过自然 episode。
-    floor = REINFORCE_NU_FLOOR if reinforced else 0.0
+    floor = REINFORCE_NU_FLOOR if reinforce_boost > 1.0 else 0.0
     gain = max(0.0, min(1.0, max(query_residual, floor)))
-    if gain <= 0.0:
-        return []
     updates: list[EdgeUpdate] = []
+
+    if gain <= 0.0:
+        return updates
+
     key_to_score = {item.key: item.score for item in candidates}
     for item in candidates:
-        edge_strength = key_to_score.get(item.key, 1.0)
+        edge_strength = key_to_score.get(item.key, 1.0) * reinforce_boost
         updates.append(
             EdgeUpdate(item.key, current_key, edge_strength * STDP_CAUSAL_EDGE_GAIN * gain, ts)
         )
@@ -395,6 +397,23 @@ def activation_edge_updates(
             updates.append(EdgeUpdate(left.key, right.key, edge_strength, ts))
             updates.append(EdgeUpdate(right.key, left.key, edge_strength, ts))
     return updates
+
+
+def reinforced_activation_items(
+    current_items: list[AkashaCandidate],
+    previous_items: list[AkashaCandidate],
+    reinforce_boost: float,
+) -> list[AkashaCandidate]:
+    if reinforce_boost <= 1.0 or not previous_items:
+        return current_items
+    combined = list(current_items)
+    seen_keys = {item.key for item in combined}
+    for item in previous_items:
+        if item.key in seen_keys:
+            continue
+        combined.append(item)
+        seen_keys.add(item.key)
+    return combined
 
 
 def local_residual(query_vec: np.ndarray, prior_vecs: np.ndarray) -> float:

--- a/plugins/akasha/dashboard.py
+++ b/plugins/akasha/dashboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 from pathlib import Path
 from typing import Any, cast
@@ -8,6 +9,26 @@ from typing import Any, cast
 from fastapi import FastAPI, HTTPException
 
 from plugins.akasha.config import AkashaConfig, load_akasha_config, resolve_akasha_db_path
+from plugins.akasha.graph_snapshot import (
+    EdgeRow,
+    GraphSnapshotConfig,
+    as_float,
+    as_int,
+    build_snapshot_to_file,
+    chunks,
+    clean_text,
+    clip,
+    community_legend,
+    default_snapshot_path,
+    dense_sim,
+    graph_from_edges,
+    layout_graph,
+    load_snapshot,
+    node_radius,
+    normalize_positions,
+    normalized_embedding,
+    read_graph_signature,
+)
 from plugins.akasha.store import AkashaStore
 
 
@@ -18,7 +39,6 @@ def plugin_enabled(app: FastAPI) -> bool:
 class AkashaInspectorReader:
     def __init__(self, store: AkashaStore) -> None:
         self._store = store
-        self._lock = threading.RLock()
 
     def get_overview(self) -> dict[str, Any]:
         items, total = self._store.list_query_logs(page=1, page_size=1)
@@ -45,7 +65,6 @@ class AkashaInspectorReader:
         if raw is None:
             return None
         result = dict(raw)
-        # 反序列化 JSON 列
         for json_key, out_key in [
             ("activation_items_json", "activation_items"),
             ("dense_items_json", "dense_items"),
@@ -60,16 +79,285 @@ class AkashaInspectorReader:
         return cast(dict[str, Any], result)
 
 
+class AkashaGraphReader:
+    def __init__(
+        self,
+        store: AkashaStore,
+        *,
+        akasha_db_path: Path,
+        sessions_db_path: Path,
+        snapshot_path: Path,
+    ) -> None:
+        self._store = store
+        self._akasha_db_path = akasha_db_path
+        self._sessions_db_path = sessions_db_path
+        self._snapshot_path = snapshot_path
+        self._lock = threading.RLock()
+        self._rebuild_lock = threading.RLock()
+        self._rebuild_running = False
+        self._rebuild_thread: threading.Thread | None = None
+
+    def get_global_graph(self) -> dict[str, Any]:
+        snapshot = load_snapshot(self._snapshot_path)
+        if snapshot is not None:
+            status = self._snapshot_status(snapshot)
+            if bool(status["stale"]):
+                self.ensure_rebuild_started()
+            snapshot.setdefault("meta", {}).update(status)
+            return snapshot
+        self.ensure_rebuild_started()
+        return {
+            "nodes": [],
+            "edges": [],
+            "legend": [],
+            "meta": {
+                "missing": True,
+                "rebuilding": self._rebuild_running,
+                "snapshot_path": str(self._snapshot_path),
+            },
+        }
+
+    def rebuild_global_graph(self) -> dict[str, Any]:
+        thread_to_wait: threading.Thread | None = None
+        with self._rebuild_lock:
+            if self._rebuild_running and self._rebuild_thread is not threading.current_thread():
+                thread_to_wait = self._rebuild_thread
+        if thread_to_wait is not None:
+            thread_to_wait.join()
+            snapshot = load_snapshot(self._snapshot_path)
+            if snapshot is not None:
+                return snapshot
+        with self._lock:
+            return build_snapshot_to_file(
+                akasha_db_path=self._akasha_db_path,
+                sessions_db_path=self._sessions_db_path,
+                snapshot_path=self._snapshot_path,
+                config=GraphSnapshotConfig(),
+            )
+
+    def ensure_rebuild_started(self) -> None:
+        with self._rebuild_lock:
+            if self._rebuild_running:
+                return
+            thread = threading.Thread(target=self._rebuild_in_background, daemon=True)
+            self._rebuild_running = True
+            self._rebuild_thread = thread
+        thread.start()
+
+    def _rebuild_in_background(self) -> None:
+        try:
+            _ = self.rebuild_global_graph()
+        finally:
+            with self._rebuild_lock:
+                self._rebuild_running = False
+                self._rebuild_thread = None
+
+    def _snapshot_status(self, snapshot: dict[str, Any]) -> dict[str, object]:
+        current = read_graph_signature(self._akasha_db_path)
+        raw_meta = snapshot.get("meta", {})
+        meta = cast(dict[str, object], raw_meta) if isinstance(raw_meta, dict) else {}
+        old_signature = meta.get("signature")
+        stale = bool(old_signature != current.as_dict())
+        return {
+            "missing": False,
+            "stale": stale,
+            "rebuilding": self._rebuild_running,
+            "current_signature": current.as_dict(),
+        }
+
+    def get_query_graph(self, query_id: str) -> dict[str, Any]:
+        raw = self._store.get_query_log(query_id)
+        if raw is None:
+            raise KeyError(query_id)
+        activation_items = _json_items(raw.get("activation_items_json"))
+        dense_items = _json_items(raw.get("dense_items_json"))
+        ripple_items = _json_items(raw.get("ripple_items_json"))
+        node_meta = _query_node_meta(activation_items, dense_items, ripple_items)
+        focus_keys = set(node_meta)
+        for item in [*activation_items, *dense_items, *ripple_items]:
+            for key_name in ("seed_key", "bridge_key"):
+                value = str(item.get(key_name) or "")
+                if value:
+                    focus_keys.add(value)
+                    _ = node_meta.setdefault(value, {"kind": "neighbor"})
+        edge_rows = self._load_edges_touching(focus_keys, limit=1200)
+        all_keys = set(focus_keys)
+        for row in edge_rows:
+            all_keys.add(row.src)
+            all_keys.add(row.dst)
+        payload = self._build_query_payload(all_keys, edge_rows, node_meta=node_meta)
+        payload["query"] = {
+            "query_id": raw.get("query_id"),
+            "session_key": raw.get("session_key"),
+            "seq": raw.get("seq"),
+            "query_text": raw.get("query_text"),
+            "intent": raw.get("intent"),
+            "ts": raw.get("ts"),
+            "seed_count": raw.get("seed_count"),
+            "pool_count": raw.get("pool_count"),
+            "activated_count": raw.get("activated_count"),
+            "activation_threshold": raw.get("activation_threshold"),
+            "dense_count": raw.get("dense_count"),
+            "ripple_count": raw.get("ripple_count"),
+        }
+        return payload
+
+    def _build_query_payload(
+        self,
+        keys: set[str],
+        edge_rows: list[EdgeRow],
+        *,
+        node_meta: dict[str, dict[str, object]],
+    ) -> dict[str, Any]:
+        if not keys:
+            return {"nodes": [], "edges": [], "legend": []}
+        nodes_by_key = self._load_nodes(keys)
+        if not nodes_by_key:
+            return {"nodes": [], "edges": [], "legend": []}
+        graph = graph_from_edges([
+            row
+            for row in edge_rows
+            if row.src in nodes_by_key and row.dst in nodes_by_key
+        ])
+        for key in keys:
+            if key in nodes_by_key:
+                cast(Any, graph).add_node(key)
+        pos, node_to_comm, comms = layout_graph(graph)
+        texts = self._load_texts(nodes_by_key)
+        colors, legend = community_legend(graph, comms, node_to_comm, nodes_by_key, texts)
+        node_list = [str(node) for node in graph.nodes()]
+        node_id = {key: index for index, key in enumerate(node_list)}
+        saliences = [as_float(nodes_by_key[key]["salience"]) for key in node_list]
+        min_sal = min(saliences) if saliences else 0.0
+        max_sal = max(saliences) if saliences else 0.0
+        coords = normalize_positions(pos)
+        payload_nodes: list[dict[str, object]] = []
+        for key in node_list:
+            row = nodes_by_key[key]
+            meta = node_meta.get(key, {})
+            comm = node_to_comm.get(key, 0)
+            salience = as_float(row["salience"])
+            x, y = coords.get(key, (500.0, 500.0))
+            payload_nodes.append({
+                "id": key,
+                "anchor_id": row["anchor_id"],
+                "session_key": row["session_key"],
+                "turn_seq": row["turn_seq"],
+                "x": x,
+                "y": y,
+                "r": node_radius(salience, min_sal, max_sal),
+                "c": colors.get(comm, "#7a7f8a"),
+                "g": comm,
+                "t": clip(texts.get(key, ""), 120),
+                "salience": salience,
+                "strength": as_float(row["strength"]),
+                "resource": as_float(row["resource"]),
+                "recall_count": as_int(row["recall_count"]),
+                "kind": str(meta.get("kind") or "global"),
+                "score": meta.get("score"),
+                "source": meta.get("source"),
+                "path_type": meta.get("path_type"),
+                "direct": meta.get("direct"),
+                "state": meta.get("state"),
+                "edge": meta.get("edge"),
+                "ripple": meta.get("ripple"),
+            })
+        payload_edges: list[dict[str, object]] = []
+        for src, dst, data in cast(Any, graph).edges(data=True):
+            payload_edges.append({
+                "s": node_id[str(src)],
+                "t": node_id[str(dst)],
+                "w": round(float(data.get("weight", 0.0)), 4),
+                "cc": int(data.get("cc", 0)),
+                "sim": dense_sim(nodes_by_key[str(src)].get("embedding"), nodes_by_key[str(dst)].get("embedding")),
+            })
+        return {"nodes": payload_nodes, "edges": payload_edges, "legend": legend}
+
+    def _load_nodes(self, keys: set[str]) -> dict[str, dict[str, object]]:
+        result: dict[str, dict[str, object]] = {}
+        key_list = sorted(keys)
+        with self._lock:
+            for part in chunks(key_list, 800):
+                placeholders = ",".join("?" for _ in part)
+                rows = self._store.db.execute(
+                    f"""
+                    SELECT key, anchor_id, session_key, turn_seq, salience, strength,
+                           resource, recall_count, embedding
+                    FROM akasha_nodes
+                    WHERE key IN ({placeholders})
+                    """,
+                    part,
+                ).fetchall()
+                for row in rows:
+                    result[str(row["key"])] = {
+                        "id": str(row["key"]),
+                        "anchor_id": str(row["anchor_id"]),
+                        "session_key": str(row["session_key"]),
+                        "turn_seq": int(row["turn_seq"] or 0),
+                        "salience": float(row["salience"] or 0.0),
+                        "strength": float(row["strength"] or 0.0),
+                        "resource": float(row["resource"] or 0.0),
+                        "recall_count": int(row["recall_count"] or 0),
+                        "embedding": normalized_embedding(row["embedding"]),
+                    }
+        return result
+
+    def _load_edges_touching(self, keys: set[str], *, limit: int) -> list[EdgeRow]:
+        if not keys:
+            return []
+        rows: list[sqlite3.Row] = []
+        key_list = sorted(keys)
+        with self._lock:
+            for part in chunks(key_list, 400):
+                placeholders = ",".join("?" for _ in part)
+                rows.extend(self._store.db.execute(
+                    f"""
+                    SELECT src_key, dst_key, weight, co_count
+                    FROM akasha_edges
+                    WHERE src_key IN ({placeholders}) OR dst_key IN ({placeholders})
+                    ORDER BY co_count DESC, weight DESC
+                    LIMIT ?
+                    """,
+                    [*part, *part, limit],
+                ).fetchall())
+        return _merge_undirected_edges(rows)[:limit]
+
+    def _load_texts(self, nodes_by_key: dict[str, dict[str, object]]) -> dict[str, str]:
+        anchor_to_key = {
+            str(row["anchor_id"]): key
+            for key, row in nodes_by_key.items()
+            if str(row.get("anchor_id") or "")
+        }
+        result = {key: "" for key in nodes_by_key}
+        if not anchor_to_key or not self._sessions_db_path.exists():
+            return result
+        with sqlite3.connect(str(self._sessions_db_path)) as db:
+            for part in chunks(sorted(anchor_to_key), 800):
+                placeholders = ",".join("?" for _ in part)
+                rows = db.execute(
+                    f"SELECT id, content FROM messages WHERE id IN ({placeholders})",
+                    part,
+                ).fetchall()
+                for msg_id, content in rows:
+                    result[anchor_to_key[str(msg_id)]] = clean_text(str(content or ""))
+        return result
+
+
 def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> list[object]:
     _ = plugin_dir
-
-    # 找到 akasha sidecar DB 路径（复用 engine 的 config 解析）。
     akasha_config = _load_akasha_config(workspace)
     if akasha_config is None:
         return []
 
-    store = AkashaStore(resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config))
+    akasha_db_path = resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config)
+    store = AkashaStore(akasha_db_path)
     reader = AkashaInspectorReader(store)
+    graph_reader = AkashaGraphReader(
+        store,
+        akasha_db_path=akasha_db_path,
+        sessions_db_path=workspace / "sessions.db",
+        snapshot_path=default_snapshot_path(workspace),
+    )
 
     @app.get("/api/dashboard/akasha-inspector/overview")
     def get_akasha_inspector_overview() -> dict[str, Any]:
@@ -102,6 +390,21 @@ def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> list[object]:
             raise HTTPException(status_code=404, detail="Akasha 检索记录不存在")
         return item
 
+    @app.get("/api/dashboard/akasha-graph/global")
+    def get_akasha_graph_global() -> dict[str, Any]:
+        return graph_reader.get_global_graph()
+
+    @app.post("/api/dashboard/akasha-graph/rebuild")
+    def rebuild_akasha_graph_global() -> dict[str, Any]:
+        return graph_reader.rebuild_global_graph()
+
+    @app.get("/api/dashboard/akasha-graph/query/{query_id:path}")
+    def get_akasha_graph_query(query_id: str) -> dict[str, Any]:
+        try:
+            return graph_reader.get_query_graph(query_id)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Akasha 检索记录不存在") from None
+
     return [store]
 
 
@@ -110,14 +413,80 @@ def _active_memory_engine(app: FastAPI) -> str:
     describe = getattr(memory_admin, "describe", None)
     if not callable(describe):
         return ""
-    return str(describe().name)
+    return str(getattr(describe(), "name", ""))
 
 
 def _load_akasha_config(workspace: Path) -> AkashaConfig | None:
-    # 从插件目录的 config.local.toml 加载；读取失败返回默认配置。
     _ = workspace
     try:
         plugin_dir = Path(__file__).resolve().parent
         return load_akasha_config(plugin_dir=plugin_dir)
     except Exception:
         return AkashaConfig()
+
+
+def _json_items(value: object) -> list[dict[str, object]]:
+    try:
+        loaded = json.loads(str(value or "[]"))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [
+        cast(dict[str, object], item)
+        for item in cast(list[object], loaded)
+        if isinstance(item, dict)
+    ]
+
+
+def _query_node_meta(
+    activation_items: list[dict[str, object]],
+    dense_items: list[dict[str, object]],
+    ripple_items: list[dict[str, object]],
+) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    for kind, items in [("activated", activation_items), ("dense", dense_items), ("ripple", ripple_items)]:
+        for item in items:
+            key = str(item.get("key") or "")
+            if not key:
+                continue
+            current = result.get(key, {})
+            if _kind_rank(kind) >= _kind_rank(str(current.get("kind") or "")):
+                result[key] = {
+                    "kind": kind,
+                    "score": item.get("score"),
+                    "source": item.get("source") or item.get("lane"),
+                    "path_type": item.get("path_type"),
+                    "direct": item.get("direct"),
+                    "state": item.get("state"),
+                    "edge": item.get("edge"),
+                    "ripple": item.get("ripple"),
+                }
+    return result
+
+
+def _kind_rank(kind: str) -> int:
+    return {"neighbor": 0, "ripple": 1, "dense": 2, "activated": 3}.get(kind, 0)
+
+
+def _merge_undirected_edges(rows: list[sqlite3.Row]) -> list[EdgeRow]:
+    merged: dict[tuple[str, str], EdgeRow] = {}
+    for row in rows:
+        src = str(row["src_key"])
+        dst = str(row["dst_key"])
+        if src == dst:
+            continue
+        key = (src, dst) if src < dst else (dst, src)
+        weight = as_float(row["weight"])
+        co_count = as_int(row["co_count"])
+        old = merged.get(key)
+        if old is None:
+            merged[key] = EdgeRow(key[0], key[1], weight, co_count)
+        else:
+            merged[key] = EdgeRow(
+                key[0],
+                key[1],
+                max(old.weight, weight),
+                max(old.co_count, co_count),
+            )
+    return sorted(merged.values(), key=lambda item: (item.co_count, item.weight), reverse=True)

--- a/plugins/akasha/dashboard_panel_graph.css
+++ b/plugins/akasha/dashboard_panel_graph.css
@@ -243,6 +243,95 @@
   color: #737a88;
 }
 
+.ag-html .ag-loading-card {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 8;
+  display: none;
+  width: min(420px, calc(100vw - 48px));
+  transform: translate(-50%, -50%);
+  border: 1px solid rgba(150, 200, 255, 0.18);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(18, 22, 31, 0.88), rgba(10, 12, 18, 0.78));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.52), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  padding: 18px 20px;
+  overflow: hidden;
+}
+
+.ag-html .ag-loading-card.visible {
+  display: block;
+  animation: ag-loading-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ag-html .ag-loading-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(150, 200, 255, 0.08), transparent);
+  animation: ag-loading-scan 2.4s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.ag-html .ag-loading-kicker {
+  color: #96c8ff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.ag-html .ag-loading-title {
+  margin-top: 8px;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.ag-html .ag-loading-copy {
+  margin-top: 6px;
+  color: #9aa3b5;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.ag-html .ag-loading-track {
+  height: 5px;
+  margin-top: 16px;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ag-html .ag-loading-track #loading_bar {
+  width: 18%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #5d91d5, #96c8ff);
+  box-shadow: 0 0 18px rgba(150, 200, 255, 0.65);
+  transition: width 0.45s ease;
+}
+
+.ag-html .ag-loading-note {
+  margin-top: 10px;
+  color: #737a88;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+@keyframes ag-loading-in {
+  from { opacity: 0; transform: translate(-50%, -46%); }
+  to { opacity: 1; transform: translate(-50%, -50%); }
+}
+
+@keyframes ag-loading-scan {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(100%); }
+}
+
 .ag-html #tip {
   position: absolute;
   z-index: 6;
@@ -335,4 +424,3 @@
   border-color: rgba(255, 90, 120, 0.2);
   color: #ff5a78;
 }
-

--- a/plugins/akasha/dashboard_panel_graph.css
+++ b/plugins/akasha/dashboard_panel_graph.css
@@ -4,7 +4,7 @@
   min-height: 620px;
   margin: 0;
   overflow: hidden;
-  background: #11131a;
+  background: radial-gradient(circle at center, #191c26 0%, #0c0e14 100%);
   color: #cdd3df;
   font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
 }
@@ -24,9 +24,12 @@
   left: 12px;
   z-index: 5;
   max-width: 300px;
-  border: 1px solid #2a2f3d;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 8px;
-  background: rgba(20, 23, 32, .82);
+  background: rgba(15, 18, 25, 0.65);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   padding: 10px 12px;
   font-size: 12px;
   line-height: 1.5;
@@ -41,12 +44,20 @@
   width: 100%;
   box-sizing: border-box;
   margin-top: 8px;
-  border: 1px solid #333a4a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 6px;
-  background: #0c0e14;
+  background: rgba(0, 0, 0, 0.2);
   color: #cdd3df;
-  padding: 6px 8px;
+  padding: 8px 12px;
   font-size: 12px;
+  outline: none;
+  transition: all 0.2s ease;
+}
+
+.ag-html #search:focus {
+  border-color: rgba(150, 200, 255, 0.5);
+  box-shadow: 0 0 0 3px rgba(150, 200, 255, 0.15);
+  background: rgba(0, 0, 0, 0.4);
 }
 
 .ag-html #search_results {
@@ -58,19 +69,36 @@
   width: 100%;
   max-height: 250px;
   overflow-y: auto;
-  border: 1px solid #333a4a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 6px;
-  background: #0c0e14;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, .8);
+  background: rgba(15, 18, 25, 0.75);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.8);
+  animation: ag-fade-in-down 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.ag-html #search_results::-webkit-scrollbar {
-  width: 4px;
+@keyframes ag-fade-in-down {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-.ag-html #search_results::-webkit-scrollbar-thumb {
-  border-radius: 2px;
-  background: rgba(255, 255, 255, .2);
+.ag-html ::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+.ag-html ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.ag-html ::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.ag-html ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .ag-html #search_results .res-item {
@@ -95,6 +123,34 @@
 .ag-html #cc_slider {
   flex: 1;
   cursor: pointer;
+  -webkit-appearance: none;
+  background: transparent;
+}
+
+.ag-html #cc_slider:focus {
+  outline: none;
+}
+
+.ag-html #cc_slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+}
+
+.ag-html #cc_slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  background: #96c8ff;
+  margin-top: -5px;
+  box-shadow: 0 0 10px rgba(150, 200, 255, 0.8);
+  transition: transform 0.1s;
+}
+
+.ag-html #cc_slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
 }
 
 .ag-html #leg {
@@ -105,22 +161,24 @@
   width: 360px;
   max-height: 88vh;
   overflow: auto;
-  border: 1px solid #2a2f3d;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-right: 0;
   border-radius: 8px 0 0 8px;
-  background: rgba(20, 23, 32, .82);
+  background: rgba(15, 18, 25, 0.65);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   padding: 10px 12px 10px 40px;
   font-size: 11px;
   line-height: 1.45;
   transform: translateX(326px);
-  transition: transform .18s ease, background .18s ease, box-shadow .18s ease;
+  transition: transform .25s cubic-bezier(0.16, 1, 0.3, 1), background .25s ease, box-shadow .25s ease;
   scrollbar-width: thin;
 }
 
 .ag-html #leg:hover {
   transform: translateX(0);
-  background: rgba(20, 23, 32, .94);
-  box-shadow: -10px 0 32px rgba(0, 0, 0, .35);
+  background: rgba(15, 18, 25, 0.85);
+  box-shadow: -10px 0 32px rgba(0, 0, 0, 0.5);
 }
 
 .ag-html #leg .grab {
@@ -147,14 +205,30 @@
 .ag-html #leg .row {
   display: flex;
   align-items: flex-start;
-  gap: 6px;
-  margin: 3px 0;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.02);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   opacity: .9;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .ag-html #leg .row:hover {
   opacity: 1;
+  transform: translateY(-1px) translateX(2px);
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.ag-html #leg .row.selected {
+  opacity: 1;
+  background: rgba(150, 200, 255, 0.1);
+  border-color: rgba(150, 200, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .ag-html #leg .dot {
@@ -174,13 +248,16 @@
   z-index: 6;
   display: none;
   max-width: 340px;
-  border: 1px solid #3a4255;
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 6px;
-  background: rgba(8, 9, 13, .95);
+  background: rgba(8, 9, 13, 0.8);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   padding: 6px 9px;
   color: #e8ecf4;
   font-size: 12px;
   pointer-events: none;
+  transition: left 0.12s ease-out, top 0.12s ease-out;
 }
 
 .ag-html .hint {
@@ -197,21 +274,65 @@
   width: 380px;
   max-height: 65vh;
   overflow-y: auto;
-  border: 1px solid #3a4255;
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
-  background: rgba(15, 18, 25, .96);
-  box-shadow: 0 10px 40px rgba(0, 0, 0, .6);
+  background: rgba(15, 18, 25, 0.7);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
   padding: 18px;
   color: #cdd3df;
   font-size: 12px;
   line-height: 1.5;
+  animation: ag-slide-up 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.ag-html #node_detail::-webkit-scrollbar {
-  width: 4px;
+.ag-html .detail-item {
+  border-radius: 0 8px 8px 0;
+  transition: background 0.2s;
+}
+.ag-html .detail-item:hover {
+  filter: brightness(1.2);
 }
 
-.ag-html #node_detail::-webkit-scrollbar-thumb {
-  border-radius: 2px;
-  background: rgba(255, 255, 255, .2);
+@keyframes ag-slide-up {
+  from { opacity: 0; transform: translateY(15px); }
+  to { opacity: 1; transform: translateY(0); }
 }
+
+.ag-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 99px;
+  font-family: monospace;
+  font-size: 10px;
+  font-weight: 500;
+  margin-right: 6px;
+  margin-top: 6px;
+  border: 1px solid transparent;
+}
+
+.ag-badge-outline {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: #9aa3b5;
+}
+
+.ag-badge-success {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.2);
+  color: #4ade80;
+}
+
+.ag-badge-warning {
+  background: rgba(251, 191, 36, 0.1);
+  border-color: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+}
+
+.ag-badge-danger {
+  background: rgba(255, 90, 120, 0.1);
+  border-color: rgba(255, 90, 120, 0.2);
+  color: #ff5a78;
+}
+

--- a/plugins/akasha/dashboard_panel_graph.css
+++ b/plugins/akasha/dashboard_panel_graph.css
@@ -1,0 +1,217 @@
+.ag-html {
+  position: relative;
+  height: calc(100vh - 76px);
+  min-height: 620px;
+  margin: 0;
+  overflow: hidden;
+  background: #11131a;
+  color: #cdd3df;
+  font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.ag-html #c {
+  display: block;
+  cursor: grab;
+}
+
+.ag-html #c.drag {
+  cursor: grabbing;
+}
+
+.ag-html #hud {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  max-width: 300px;
+  border: 1px solid #2a2f3d;
+  border-radius: 8px;
+  background: rgba(20, 23, 32, .82);
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ag-html #hud b {
+  color: #fff;
+  font-size: 13px;
+}
+
+.ag-html #search {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  border: 1px solid #333a4a;
+  border-radius: 6px;
+  background: #0c0e14;
+  color: #cdd3df;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.ag-html #search_results {
+  position: absolute;
+  top: 38px;
+  left: 0;
+  z-index: 20;
+  display: none;
+  width: 100%;
+  max-height: 250px;
+  overflow-y: auto;
+  border: 1px solid #333a4a;
+  border-radius: 6px;
+  background: #0c0e14;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, .8);
+}
+
+.ag-html #search_results::-webkit-scrollbar {
+  width: 4px;
+}
+
+.ag-html #search_results::-webkit-scrollbar-thumb {
+  border-radius: 2px;
+  background: rgba(255, 255, 255, .2);
+}
+
+.ag-html #search_results .res-item {
+  border-bottom: 1px solid #1a1e29;
+  padding: 8px 10px;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.ag-html #search_results .res-item:hover {
+  background: #1a1e29;
+  color: #fff;
+}
+
+.ag-html #slider-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.ag-html #cc_slider {
+  flex: 1;
+  cursor: pointer;
+}
+
+.ag-html #leg {
+  position: absolute;
+  top: 12px;
+  right: 0;
+  z-index: 5;
+  width: 360px;
+  max-height: 88vh;
+  overflow: auto;
+  border: 1px solid #2a2f3d;
+  border-right: 0;
+  border-radius: 8px 0 0 8px;
+  background: rgba(20, 23, 32, .82);
+  padding: 10px 12px 10px 40px;
+  font-size: 11px;
+  line-height: 1.45;
+  transform: translateX(326px);
+  transition: transform .18s ease, background .18s ease, box-shadow .18s ease;
+  scrollbar-width: thin;
+}
+
+.ag-html #leg:hover {
+  transform: translateX(0);
+  background: rgba(20, 23, 32, .94);
+  box-shadow: -10px 0 32px rgba(0, 0, 0, .35);
+}
+
+.ag-html #leg .grab {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  width: 30px;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid #2a2f3d;
+  color: #9aa3b5;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  writing-mode: vertical-rl;
+}
+
+.ag-html #leg .content {
+  min-width: 0;
+}
+
+.ag-html #leg .row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 3px 0;
+  cursor: pointer;
+  opacity: .9;
+}
+
+.ag-html #leg .row:hover {
+  opacity: 1;
+}
+
+.ag-html #leg .dot {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 10px;
+  margin-top: 2px;
+  border-radius: 50%;
+}
+
+.ag-html #leg .sz {
+  color: #737a88;
+}
+
+.ag-html #tip {
+  position: absolute;
+  z-index: 6;
+  display: none;
+  max-width: 340px;
+  border: 1px solid #3a4255;
+  border-radius: 6px;
+  background: rgba(8, 9, 13, .95);
+  padding: 6px 9px;
+  color: #e8ecf4;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.ag-html .hint {
+  margin-top: 8px;
+  color: #737a88;
+}
+
+.ag-html #node_detail {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  z-index: 10;
+  display: none;
+  width: 380px;
+  max-height: 65vh;
+  overflow-y: auto;
+  border: 1px solid #3a4255;
+  border-radius: 12px;
+  background: rgba(15, 18, 25, .96);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, .6);
+  padding: 18px;
+  color: #cdd3df;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ag-html #node_detail::-webkit-scrollbar {
+  width: 4px;
+}
+
+.ag-html #node_detail::-webkit-scrollbar-thumb {
+  border-radius: 2px;
+  background: rgba(255, 255, 255, .2);
+}

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -98,6 +98,13 @@ function renderAkashaGraph(container: HTMLElement): void {
         <div class="hint">远景看大岛 · 中景看子岛 · 近景看联想根系</div>
       </div>
       <div id="leg"></div>
+      <div id="loading_card" class="ag-loading-card">
+        <div class="ag-loading-kicker">Akasha Graph</div>
+        <div class="ag-loading-title">正在生成全量记忆图</div>
+        <div class="ag-loading-copy">第一次进入需要构建 snapshot，之后会直接读取缓存。</div>
+        <div class="ag-loading-track"><div id="loading_bar"></div></div>
+        <div id="loading_note" class="ag-loading-note">启动后台布局任务...</div>
+      </div>
       <div id="tip"></div>
       <div id="node_detail"></div>
     </div>
@@ -119,6 +126,9 @@ function renderAkashaGraph(container: HTMLElement): void {
   const tip = root.querySelector<HTMLElement>("#tip")!;
   const stat = root.querySelector<HTMLElement>("#stat")!;
   const legEl = root.querySelector<HTMLElement>("#leg")!;
+  const loadingCard = root.querySelector<HTMLElement>("#loading_card")!;
+  const loadingBar = root.querySelector<HTMLElement>("#loading_bar")!;
+  const loadingNote = root.querySelector<HTMLElement>("#loading_note")!;
   const detailPanel = root.querySelector<HTMLElement>("#node_detail")!;
   const searchEl = root.querySelector<HTMLInputElement>("#search")!;
   const resEl = root.querySelector<HTMLElement>("#search_results")!;
@@ -159,6 +169,8 @@ function renderAkashaGraph(container: HTMLElement): void {
   let hlInternalPath = new Path2D();
   let hlCrossPath = new Path2D();
   const globalEdgeScaleLimit = 1.2;
+  const loadingStartedAt = Date.now();
+  let loadingTick = 0;
 
   function updateHlPaths() {
     hlInternalPath = new Path2D();
@@ -1125,9 +1137,21 @@ function renderAkashaGraph(container: HTMLElement): void {
     });
   }
 
+  function setLoadingCard(visible: boolean, payload?: GraphPayload): void {
+    loadingCard.classList.toggle("visible", visible);
+    if (!visible) return;
+    loadingTick += 1;
+    const elapsed = Math.max(0, Math.round((Date.now() - loadingStartedAt) / 1000));
+    const progress = Math.min(92, 18 + loadingTick * 7 + elapsed * 2);
+    loadingBar.style.width = `${progress}%`;
+    const state = payload?.meta?.rebuilding ? "后台布局计算中" : "等待布局任务启动";
+    loadingNote.textContent = `${state} · ${elapsed}s`;
+  }
+
   function applyPayload(payload: GraphPayload, refit: boolean): void {
     if (payload.meta?.missing) {
       stat.textContent = payload.meta.rebuilding ? "快照后台生成中..." : "等待快照生成...";
+      setLoadingCard(NODES.length === 0, payload);
       return;
     }
     const nextVersion = payload.meta?.version || "";
@@ -1139,6 +1163,7 @@ function renderAkashaGraph(container: HTMLElement): void {
     NODES = payload.nodes || [];
     EDGES = ghEdges(payload.edges || []);
     LEG = payload.legend || [];
+    setLoadingCard(false);
     rebalanceFractalSpacing();
     recomputeCommunities();
     ccThreshold = 2;
@@ -1152,7 +1177,10 @@ function renderAkashaGraph(container: HTMLElement): void {
   }
 
   async function load(refit: boolean): Promise<void> {
-    if (refit) stat.textContent = "加载全景快照...";
+    if (refit) {
+      stat.textContent = "加载全景快照...";
+      setLoadingCard(NODES.length === 0);
+    }
     const payload = await api<GraphPayload>("/api/dashboard/akasha-graph/global");
     if (disposed) return;
     applyPayload(payload, refit);

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -120,8 +120,10 @@ function renderAkashaGraph(container: HTMLElement): void {
   let pollTimer: number | undefined;
   let tweenFrame: number | undefined;
   let lockedColor: string | null = null;
+  let bgEdgePaths: Path2D[] = [new Path2D(), new Path2D(), new Path2D(), new Path2D()];
   let hlInternalPath = new Path2D();
   let hlCrossPath = new Path2D();
+  const globalEdgeScaleLimit = 1.2;
 
   function updateHlPaths() {
     hlInternalPath = new Path2D();
@@ -217,18 +219,42 @@ function renderAkashaGraph(container: HTMLElement): void {
   function invY(py: number): number { return (py - ty) / scale; }
   function activeId(): number { return pinned; }
 
+  function edgeBin(w: number): number {
+    if (w > 0.15) return 3;
+    if (w > 0.1) return 2;
+    if (w > 0.05) return 1;
+    return 0;
+  }
+
   function recomputeAdj(): void {
     adj = NODES.map(() => []);
     adjEdges = NODES.map(() => []);
+    bgEdgePaths = [new Path2D(), new Path2D(), new Path2D(), new Path2D()];
     for (const edge of EDGES) {
-      const [a, b, , cc] = edge;
+      const [a, b, w, cc] = edge;
       if (cc >= ccThreshold) {
         adj[a].push(b);
         adj[b].push(a);
         adjEdges[a].push(edge);
         adjEdges[b].push(edge);
+        const bin = edgeBin(w);
+        bgEdgePaths[bin].moveTo(NODES[a].x, NODES[a].y);
+        bgEdgePaths[bin].lineTo(NODES[b].x, NODES[b].y);
       }
     }
+  }
+
+  function drawGlobalEdges(): void {
+    ctx.save();
+    ctx.translate(tx, ty);
+    ctx.scale(scale, scale);
+    const alphas = [0.08, 0.12, 0.18, 0.25];
+    ctx.lineWidth = Math.max(0.3 / scale, 0.5);
+    for (let i = 0; i < 4; i++) {
+      ctx.strokeStyle = `rgba(120,130,150,${alphas[i]})`;
+      ctx.stroke(bgEdgePaths[i]);
+    }
+    ctx.restore();
   }
 
   function drawBase(): void {
@@ -253,7 +279,9 @@ function renderAkashaGraph(container: HTMLElement): void {
       ? new Set(NODES.map((n, i) => n.t.toLowerCase().includes(fil) ? i : -1).filter((i) => i >= 0))
       : null;
 
-    if (act >= 0) {
+    if (act < 0 && !match && scale <= globalEdgeScaleLimit) {
+      drawGlobalEdges();
+    } else if (act >= 0) {
       for (const [a, b] of adjEdges[act] || []) {
         const nA = NODES[a], nB = NODES[b];
         const cross = nA.g !== nB.g;

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -1,0 +1,533 @@
+/// <reference path="../../types/akashic-dashboard.d.ts" />
+
+interface GraphNode {
+  id?: string;
+  x: number;
+  y: number;
+  r: number;
+  c: string;
+  t: string;
+  g: number;
+}
+
+interface GraphEdgeObject {
+  s: number;
+  t: number;
+  w: number;
+  cc: number;
+  sim: number;
+}
+
+type GraphEdge = [number, number, number, number, number];
+
+interface GraphLegend {
+  c: string;
+  size: number;
+  label: string;
+}
+
+interface GraphPayload {
+  nodes: GraphNode[];
+  edges: GraphEdgeObject[];
+  legend: GraphLegend[];
+  meta?: {
+    missing?: boolean;
+    stale?: boolean;
+    rebuilding?: boolean;
+    version?: string;
+    elapsed_ms?: number;
+  };
+}
+
+function ghEscape(value: string): string {
+  return escapeHtml(String(value || ""));
+}
+
+function ghEdges(edges: GraphEdgeObject[]): GraphEdge[] {
+  return edges.map((edge) => [edge.s, edge.t, edge.w, edge.cc, edge.sim]);
+}
+
+function renderAkashaGraph(container: HTMLElement): void {
+  const previous = (container as HTMLElement & { __agDispose?: () => void }).__agDispose;
+  if (previous) previous();
+
+  container.innerHTML = `
+    <div class="ag-html">
+      <canvas id="c"></canvas>
+      <div id="hud">
+        <b>Akasha 真实记忆图</b><br>telegram 子图 · 数据透明版<br>
+        <span id="stat">布局计算中...</span>
+        <div style="position:relative;">
+          <input id="search" placeholder="搜索记忆正文…">
+          <div id="search_results"></div>
+        </div>
+        <div id="slider-container">
+          <input type="range" id="cc_slider" min="1" max="10" value="2">
+          <span style="font-size:11px">共现频次 &ge; <span id="cc_val" style="color:#fff;font-weight:bold;font-size:13px">2</span></span>
+        </div>
+        <div class="hint">拖拽平移 · 滚轮缩放 · 悬停看邻居 · 调滑块看引力</div>
+      </div>
+      <div id="leg"></div>
+      <div id="tip"></div>
+      <div id="node_detail"></div>
+    </div>
+  `;
+
+  let disposed = false;
+  (container as HTMLElement & { __agDispose?: () => void }).__agDispose = () => {
+    disposed = true;
+    if (pollTimer !== undefined) window.clearInterval(pollTimer);
+    window.removeEventListener("resize", resize);
+    window.removeEventListener("mouseup", onMouseUp);
+    document.removeEventListener("click", onDocumentClick);
+  };
+
+  const root = container.querySelector<HTMLElement>(".ag-html")!;
+  const cv = root.querySelector<HTMLCanvasElement>("#c")!;
+  const ctx = cv.getContext("2d")!;
+  const tip = root.querySelector<HTMLElement>("#tip")!;
+  const stat = root.querySelector<HTMLElement>("#stat")!;
+  const legEl = root.querySelector<HTMLElement>("#leg")!;
+  const detailPanel = root.querySelector<HTMLElement>("#node_detail")!;
+  const searchEl = root.querySelector<HTMLInputElement>("#search")!;
+  const resEl = root.querySelector<HTMLElement>("#search_results")!;
+  const slider = root.querySelector<HTMLInputElement>("#cc_slider")!;
+  const ccVal = root.querySelector<HTMLElement>("#cc_val")!;
+
+  let NODES: GraphNode[] = [];
+  let EDGES: GraphEdge[] = [];
+  let LEG: GraphLegend[] = [];
+  let W = 1;
+  let H = 1;
+  let DPR = 1;
+  let scale = 0.6;
+  let tx = 0;
+  let ty = 0;
+  let ccThreshold = 2;
+  let adj: number[][] = [];
+  let hover = -1;
+  let pinned = -1;
+  let filter = "";
+  let drag = false;
+  let lx = 0;
+  let ly = 0;
+  let moved = false;
+  let hlColor: string | null = null;
+  let currentVersion = "";
+  let pollTimer: number | undefined;
+
+  function resize(): void {
+    if (disposed) return;
+    const rect = root.getBoundingClientRect();
+    W = Math.max(320, rect.width);
+    H = Math.max(320, rect.height);
+    DPR = window.devicePixelRatio || 1;
+    cv.width = W * DPR;
+    cv.height = H * DPR;
+    cv.style.width = `${W}px`;
+    cv.style.height = `${H}px`;
+    ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    draw();
+  }
+
+  function fit(): void {
+    const m = 60;
+    const s = Math.min(W - 2 * m, H - 2 * m) / 1000;
+    scale = Math.max(0.2, s);
+    tx = (W - 1000 * scale) / 2;
+    ty = (H - 1000 * scale) / 2;
+  }
+
+  function X(x: number): number { return x * scale + tx; }
+  function Y(y: number): number { return y * scale + ty; }
+  function invX(px: number): number { return (px - tx) / scale; }
+  function invY(py: number): number { return (py - ty) / scale; }
+  function activeId(): number { return hover >= 0 ? hover : pinned; }
+
+  function recomputeAdj(): void {
+    adj = NODES.map(() => []);
+    for (const [a, b, , cc] of EDGES) {
+      if (cc >= ccThreshold) {
+        adj[a].push(b);
+        adj[b].push(a);
+      }
+    }
+  }
+
+  function drawBase(): void {
+    ctx.clearRect(0, 0, W, H);
+    const act = activeId();
+    const hl = new Set<number>();
+    if (act >= 0) {
+      hl.add(act);
+      for (const n of adj[act] || []) hl.add(n);
+    }
+    const fil = filter.trim().toLowerCase();
+    const match = fil
+      ? new Set(NODES.map((n, i) => n.t.toLowerCase().includes(fil) ? i : -1).filter((i) => i >= 0))
+      : null;
+
+    ctx.lineWidth = Math.max(0.3, 0.5 * scale);
+    for (const [a, b, w, cc] of EDGES) {
+      if (cc < ccThreshold) continue;
+      const on = act >= 0 && (a === act || b === act);
+      if (act >= 0 && !on) continue;
+      if (on) {
+        const cross = NODES[a].g !== NODES[b].g;
+        ctx.strokeStyle = cross ? "rgba(255,90,120,0.85)" : "rgba(150,200,255,.6)";
+        ctx.lineWidth = cross ? Math.max(1.5, 2 * scale) : Math.max(0.6, scale);
+      } else {
+        ctx.strokeStyle = `rgba(120,130,150,${Math.min(.22, .05 + w)})`;
+        ctx.lineWidth = Math.max(0.3, 0.5 * scale);
+      }
+      ctx.beginPath();
+      ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
+      ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
+      ctx.stroke();
+    }
+
+    if (act < 0) {
+      ctx.strokeStyle = "rgba(110,120,140,.10)";
+      ctx.lineWidth = Math.max(0.25, 0.35 * scale);
+      ctx.beginPath();
+      for (const [a, b, , cc] of EDGES) {
+        if (cc < ccThreshold) continue;
+        ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
+        ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
+      }
+      ctx.stroke();
+    }
+
+    for (let i = 0; i < NODES.length; i += 1) {
+      const n = NODES[i];
+      let alpha = 1;
+      let r = n.r * Math.max(0.6, Math.sqrt(scale));
+      if ((adj[i]?.length || 0) === 0 && ccThreshold > 1 && !match) alpha = 0.08;
+      if (act >= 0 && !hl.has(i)) alpha = 0.12;
+      if (match && !match.has(i)) alpha = 0.06;
+      if (match && match.has(i)) r *= 1.5;
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = n.c;
+      ctx.beginPath();
+      ctx.arc(X(n.x), Y(n.y), r, 0, Math.PI * 2);
+      ctx.fill();
+      if ((act >= 0 && hl.has(i)) || (match && match.has(i))) {
+        ctx.globalAlpha = 1;
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = (act >= 0 && i !== act && NODES[i].g !== NODES[act].g) ? "#ff5a78" : "#fff";
+        ctx.stroke();
+      }
+    }
+    ctx.globalAlpha = 1;
+
+    if (act >= 0) {
+      const n = NODES[act];
+      ctx.fillStyle = "#fff";
+      ctx.font = "bold 14px sans-serif";
+      const text = n.t.length > 25 ? `${n.t.slice(0, 25)}...` : n.t;
+      ctx.fillText(text, X(n.x) + 12, Y(n.y) - 12);
+    }
+  }
+
+  function draw(): void {
+    if (hlColor) {
+      ctx.clearRect(0, 0, W, H);
+      ctx.strokeStyle = "rgba(110,120,140,.08)";
+      ctx.lineWidth = 0.35 * scale;
+      ctx.beginPath();
+      for (const [a, b, , cc] of EDGES) {
+        if (cc < ccThreshold) continue;
+        ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
+        ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
+      }
+      ctx.stroke();
+      for (let i = 0; i < NODES.length; i += 1) {
+        const n = NODES[i];
+        const on = n.c === hlColor;
+        ctx.globalAlpha = on ? 1 : ((adj[i]?.length || 0) === 0 ? 0.03 : 0.08);
+        ctx.fillStyle = n.c;
+        ctx.beginPath();
+        ctx.arc(X(n.x), Y(n.y), n.r * Math.max(0.6, Math.sqrt(scale)) * (on ? 1.3 : 1), 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+      return;
+    }
+    drawBase();
+  }
+
+  function badgeHTML(t: GraphNode & { w: number; cc: number; sim: number }): string {
+    const simColor = t.sim > 0.65 ? "#4ade80" : (t.sim > 0.45 ? "#fbbf24" : "#ff5a78");
+    const simText = t.sim > 0.65 ? "同义" : (t.sim > 0.45 ? "相关" : "潜意识跳跃");
+    const simPct = `${(t.sim * 100).toFixed(0)}%`;
+    return `<div style="display:flex;gap:6px;font-size:10px;color:#9aa3b5;font-family:monospace;margin-top:5px;flex-wrap:wrap;">
+      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;">同框:${t.cc}次</span>
+      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;">引力:${t.w.toFixed(2)}</span>
+      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;color:${simColor}">语义:${simPct} (${simText})</span>
+    </div>`;
+  }
+
+  function updateDetailPanel(): void {
+    if (pinned < 0) {
+      detailPanel.style.display = "none";
+      return;
+    }
+    const n = NODES[pinned];
+    const neighbors: Array<{ id: number; w: number; cc: number; sim: number }> = [];
+    for (const [a, b, w, cc, sim] of EDGES) {
+      if (cc < ccThreshold) continue;
+      if (a === pinned) neighbors.push({ id: b, w, cc, sim });
+      if (b === pinned) neighbors.push({ id: a, w, cc, sim });
+    }
+    neighbors.sort((x, y) => y.w - x.w);
+    const internal: Array<GraphNode & { w: number; cc: number; sim: number }> = [];
+    const external: Array<GraphNode & { w: number; cc: number; sim: number }> = [];
+    for (const nb of neighbors) {
+      const target = { ...NODES[nb.id], w: nb.w, cc: nb.cc, sim: nb.sim };
+      if (target.g === n.g) internal.push(target);
+      else external.push(target);
+    }
+
+    let html = '<div style="font-size:13px;color:#8b9eb5;margin-bottom:6px;">选中记忆切片</div>';
+    html += `<div style="font-size:14px;padding:12px;background:rgba(255,255,255,0.06);border-radius:8px;margin-bottom:16px;">${ghEscape(n.t)}</div>`;
+    if (external.length > 0) {
+      html += `<div style="color:#ff5a78;font-weight:bold;margin-bottom:4px;border-bottom:1px solid rgba(255,90,120,0.3);padding-bottom:6px;">思想跳跃 / 跨界走神 (${external.length})</div>`;
+      html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：分属不同的话题岛屿，但在特定时间点被你跨界关联。</div>';
+      for (const t of external) {
+        html += `<div style="margin-bottom:14px;display:flex;gap:8px;align-items:flex-start;">
+          <span style="width:8px;height:8px;border-radius:50%;background:${t.c};flex-shrink:0;margin-top:5px;box-shadow:0 0 5px ${t.c};"></span>
+          <div style="display:flex;flex-direction:column;flex:1;"><span style="opacity:0.95">${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
+        </div>`;
+      }
+    }
+    if (internal.length > 0) {
+      html += `<div style="color:#96c8ff;font-weight:bold;margin-bottom:4px;margin-top:20px;border-bottom:1px solid rgba(150,200,255,0.3);padding-bottom:6px;">核心圈层 (${internal.length})</div>`;
+      html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：基于模块度算法，这些话题形成了高频同框的内聚孤岛。</div>';
+      for (const t of internal) {
+        html += `<div style="margin-bottom:14px;padding-left:10px;opacity:0.85;border-left:2px solid ${t.c};">
+          <div style="display:flex;flex-direction:column;flex:1;"><span>${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
+        </div>`;
+      }
+    }
+    detailPanel.innerHTML = html;
+    detailPanel.style.display = "block";
+  }
+
+  function pick(px: number, py: number): number {
+    let best = -1;
+    let bd = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < NODES.length; i += 1) {
+      if ((adj[i]?.length || 0) === 0 && !filter) continue;
+      const dx = X(NODES[i].x) - px;
+      const dy = Y(NODES[i].y) - py;
+      const d = dx * dx + dy * dy;
+      const rr = Math.max(6, NODES[i].r * Math.sqrt(scale) + 4);
+      if (d < rr * rr && d < bd) {
+        bd = d;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  function onMouseUp(): void {
+    drag = false;
+    cv.classList.remove("drag");
+  }
+
+  function onDocumentClick(event: MouseEvent): void {
+    const target = event.target as Node;
+    if (!searchEl.contains(target) && !resEl.contains(target)) {
+      resEl.style.display = "none";
+    }
+  }
+
+  cv.addEventListener("mousedown", (event) => {
+    drag = true;
+    moved = false;
+    lx = event.clientX;
+    ly = event.clientY;
+    cv.classList.add("drag");
+  });
+  window.addEventListener("mouseup", onMouseUp);
+  cv.addEventListener("mousemove", (event) => {
+    const rect = cv.getBoundingClientRect();
+    const mx = event.clientX - rect.left;
+    const my = event.clientY - rect.top;
+    if (drag) {
+      tx += event.clientX - lx;
+      ty += event.clientY - ly;
+      lx = event.clientX;
+      ly = event.clientY;
+      moved = true;
+      draw();
+      tip.style.display = "none";
+      return;
+    }
+    const h = pick(mx, my);
+    if (h !== hover) {
+      hover = h;
+      draw();
+    }
+    if (h >= 0) {
+      tip.style.display = "block";
+      tip.style.left = `${mx + 14}px`;
+      tip.style.top = `${my + 14}px`;
+      tip.textContent = NODES[h].t.length > 40 ? `${NODES[h].t.slice(0, 40)}...` : NODES[h].t;
+    } else {
+      tip.style.display = "none";
+    }
+  });
+  cv.addEventListener("click", (event) => {
+    if (moved) return;
+    const rect = cv.getBoundingClientRect();
+    const h = pick(event.clientX - rect.left, event.clientY - rect.top);
+    pinned = h === pinned ? -1 : h;
+    draw();
+    updateDetailPanel();
+  });
+  cv.addEventListener("wheel", (event) => {
+    event.preventDefault();
+    const rect = cv.getBoundingClientRect();
+    const mx = event.clientX - rect.left;
+    const my = event.clientY - rect.top;
+    const f = event.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const wx = invX(mx);
+    const wy = invY(my);
+    scale *= f;
+    tx = mx - wx * scale;
+    ty = my - wy * scale;
+    draw();
+  }, { passive: false });
+
+  slider.addEventListener("input", () => {
+    ccThreshold = Number(slider.value);
+    ccVal.textContent = String(ccThreshold);
+    recomputeAdj();
+    draw();
+    updateDetailPanel();
+  });
+
+  searchEl.addEventListener("input", () => {
+    filter = searchEl.value.trim().toLowerCase();
+    if (!filter) {
+      resEl.style.display = "none";
+      draw();
+      return;
+    }
+    const matches: number[] = [];
+    for (let i = 0; i < NODES.length; i += 1) {
+      if (NODES[i].t.toLowerCase().includes(filter)) matches.push(i);
+    }
+    if (matches.length > 0) {
+      resEl.innerHTML = matches.slice(0, 30).map((i) => {
+        const txt = NODES[i].t.length > 30 ? `${NODES[i].t.slice(0, 30)}...` : NODES[i].t;
+        return `<div class="res-item" data-node="${i}">${ghEscape(txt)}</div>`;
+      }).join("");
+      resEl.querySelectorAll<HTMLElement>(".res-item").forEach((item) => {
+        item.onclick = () => selectNode(Number(item.dataset.node));
+      });
+      resEl.style.display = "block";
+    } else {
+      resEl.innerHTML = '<div style="padding:8px 10px;color:#737a88;">无匹配项</div>';
+      resEl.style.display = "block";
+    }
+    draw();
+  });
+  document.addEventListener("click", onDocumentClick);
+
+  function selectNode(i: number): void {
+    pinned = i;
+    hover = -1;
+    const n = NODES[i];
+    scale = Math.max(scale, 1.2);
+    tx = W / 2 - n.x * scale;
+    ty = H / 2 - n.y * scale;
+    searchEl.value = "";
+    filter = "";
+    resEl.style.display = "none";
+    draw();
+    updateDetailPanel();
+  }
+
+  function renderLegend(): void {
+    legEl.innerHTML = '<div class="grab">社区</div><div class="content"><b style="color:#fff">社区主题</b>（按规模，悬停高亮）<br>'
+      + LEG.map((l) => `<div class="row" data-c="${ghEscape(l.c)}"><span class="dot" style="background:${ghEscape(l.c)}"></span><span><span style="color:#9aa3b5">[${l.size}]</span> ${ghEscape(l.label)}</span></div>`).join("")
+      + "</div>";
+    legEl.querySelectorAll<HTMLElement>(".row").forEach((row) => {
+      row.addEventListener("mouseenter", () => {
+        filter = "";
+        hlColor = row.dataset.c || null;
+        draw();
+      });
+      row.addEventListener("mouseleave", () => {
+        hlColor = null;
+        draw();
+      });
+    });
+  }
+
+  function applyPayload(payload: GraphPayload, refit: boolean): void {
+    if (payload.meta?.missing) {
+      stat.textContent = payload.meta.rebuilding ? "快照后台生成中..." : "等待快照生成...";
+      return;
+    }
+    const nextVersion = payload.meta?.version || "";
+    if (!refit && nextVersion && nextVersion === currentVersion) {
+      stat.textContent = `${NODES.length} 节点 · 共 ${EDGES.length} 候选边${payload.meta?.stale ? " · 后台刷新中" : ""}`;
+      return;
+    }
+    currentVersion = nextVersion;
+    NODES = payload.nodes || [];
+    EDGES = ghEdges(payload.edges || []);
+    LEG = payload.legend || [];
+    ccThreshold = 2;
+    slider.value = "2";
+    ccVal.textContent = "2";
+    recomputeAdj();
+    renderLegend();
+    stat.textContent = `${NODES.length} 节点 · 共 ${EDGES.length} 候选边${payload.meta?.stale ? " · 后台刷新中" : ""}`;
+    if (refit) fit();
+    resize();
+  }
+
+  async function load(refit: boolean): Promise<void> {
+    if (refit) stat.textContent = "加载全景快照...";
+    const payload = await api<GraphPayload>("/api/dashboard/akasha-graph/global");
+    if (disposed) return;
+    applyPayload(payload, refit);
+  }
+
+  window.addEventListener("resize", resize);
+  resize();
+  void load(true).catch((error) => {
+    stat.textContent = error instanceof Error ? error.message : String(error);
+  });
+  pollTimer = window.setInterval(() => {
+    void load(false).catch(() => undefined);
+  }, 5000);
+}
+
+window.AkashicDashboard.registerPlugin({
+  id: "akasha_graph",
+  label: "Akasha Graph",
+  viewLabel: "akasha graph",
+  layout: "workbench",
+  pageSize: 1,
+  rowKey: "id",
+  columns: [{ key: "id", label: "Graph", flex: true }],
+  async getCount(): Promise<number | null> {
+    try {
+      const data = await api<GraphPayload>("/api/dashboard/akasha-graph/global");
+      return data.nodes.length;
+    } catch {
+      return null;
+    }
+  },
+  async fetchPage(): Promise<FetchPageResult> {
+    return { items: [], total: 0 };
+  },
+  renderMain(container: HTMLElement): void {
+    renderAkashaGraph(container);
+  },
+});

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -114,7 +114,60 @@ function renderAkashaGraph(container: HTMLElement): void {
   let moved = false;
   let hlColor: string | null = null;
   let currentVersion = "";
+  // eslint-disable-next-line prefer-const
   let pollTimer: number | undefined;
+  let tweenFrame: number | undefined;
+  let lockedColor: string | null = null;
+
+  function flyTo(targetScale: number, targetTx: number, targetTy: number) {
+    if (tweenFrame) cancelAnimationFrame(tweenFrame);
+    const startScale = scale, startTx = tx, startTy = ty;
+    let progress = 0;
+    function step() {
+      progress += 0.08;
+      if (progress >= 1) {
+        scale = targetScale; tx = targetTx; ty = targetTy;
+        draw();
+        return;
+      }
+      const ease = 1 - Math.pow(1 - progress, 3);
+      scale = startScale + (targetScale - startScale) * ease;
+      tx = startTx + (targetTx - startTx) * ease;
+      ty = startTy + (targetTy - startTy) * ease;
+      draw();
+      tweenFrame = requestAnimationFrame(step);
+    }
+    step();
+  }
+
+  function flyToCommunity(c: string): void {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of NODES) {
+      if (n.c === c) {
+        if (n.x < minX) minX = n.x;
+        if (n.x > maxX) maxX = n.x;
+        if (n.y < minY) minY = n.y;
+        if (n.y > maxY) maxY = n.y;
+      }
+    }
+    if (minX === Infinity) return;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    const w = maxX - minX;
+    const h = maxY - minY;
+    
+    let targetScale = scale;
+    if (w > 0 && h > 0) {
+      const s = Math.min((W - 120) / w, (H - 120) / h);
+      targetScale = Math.max(0.2, Math.min(s, 2.5));
+    } else {
+      targetScale = Math.max(scale, 1.2);
+    }
+    
+    const targetTx = W / 2 - cx * targetScale;
+    const targetTy = H / 2 - cy * targetScale;
+    flyTo(targetScale, targetTx, targetTy);
+  }
 
   function resize(): void {
     if (disposed) return;
@@ -176,14 +229,20 @@ function renderAkashaGraph(container: HTMLElement): void {
         const cross = NODES[a].g !== NODES[b].g;
         ctx.strokeStyle = cross ? "rgba(255,90,120,0.85)" : "rgba(150,200,255,.6)";
         ctx.lineWidth = cross ? Math.max(1.5, 2 * scale) : Math.max(0.6, scale);
+        if (cross) {
+          ctx.shadowBlur = 6 * scale;
+          ctx.shadowColor = "rgba(255,90,120,0.9)";
+        }
       } else {
         ctx.strokeStyle = `rgba(120,130,150,${Math.min(.22, .05 + w)})`;
         ctx.lineWidth = Math.max(0.3, 0.5 * scale);
+        ctx.shadowBlur = 0;
       }
       ctx.beginPath();
       ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
       ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
       ctx.stroke();
+      ctx.shadowBlur = 0;
     }
 
     if (act < 0) {
@@ -208,9 +267,16 @@ function renderAkashaGraph(container: HTMLElement): void {
       if (match && match.has(i)) r *= 1.5;
       ctx.globalAlpha = alpha;
       ctx.fillStyle = n.c;
+      if ((act >= 0 && hl.has(i)) || (match && match.has(i))) {
+        ctx.shadowBlur = Math.max(6, r * 1.5);
+        ctx.shadowColor = n.c;
+      } else {
+        ctx.shadowBlur = 0;
+      }
       ctx.beginPath();
       ctx.arc(X(n.x), Y(n.y), r, 0, Math.PI * 2);
       ctx.fill();
+      ctx.shadowBlur = 0;
       if ((act >= 0 && hl.has(i)) || (match && match.has(i))) {
         ctx.globalAlpha = 1;
         ctx.lineWidth = 1;
@@ -232,23 +298,44 @@ function renderAkashaGraph(container: HTMLElement): void {
   function draw(): void {
     if (hlColor) {
       ctx.clearRect(0, 0, W, H);
-      ctx.strokeStyle = "rgba(110,120,140,.08)";
-      ctx.lineWidth = 0.35 * scale;
-      ctx.beginPath();
-      for (const [a, b, , cc] of EDGES) {
+      ctx.lineWidth = Math.max(0.6, scale);
+      for (const [a, b, w, cc] of EDGES) {
         if (cc < ccThreshold) continue;
+        const aOn = NODES[a].c === hlColor;
+        const bOn = NODES[b].c === hlColor;
+        if (!aOn && !bOn) continue;
+        
+        const cross = aOn !== bOn;
+        if (cross) {
+            ctx.strokeStyle = "rgba(255,90,120,0.6)";
+            ctx.shadowBlur = 4 * scale;
+            ctx.shadowColor = "rgba(255,90,120,0.8)";
+        } else {
+            ctx.strokeStyle = "rgba(150,200,255,0.4)";
+            ctx.shadowBlur = 2 * scale;
+            ctx.shadowColor = "rgba(150,200,255,0.6)";
+        }
+        ctx.beginPath();
         ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
         ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
+        ctx.stroke();
+        ctx.shadowBlur = 0;
       }
-      ctx.stroke();
       for (let i = 0; i < NODES.length; i += 1) {
         const n = NODES[i];
         const on = n.c === hlColor;
         ctx.globalAlpha = on ? 1 : ((adj[i]?.length || 0) === 0 ? 0.03 : 0.08);
         ctx.fillStyle = n.c;
+        if (on) {
+          ctx.shadowBlur = n.r * 2 * Math.sqrt(scale);
+          ctx.shadowColor = n.c;
+        } else {
+          ctx.shadowBlur = 0;
+        }
         ctx.beginPath();
         ctx.arc(X(n.x), Y(n.y), n.r * Math.max(0.6, Math.sqrt(scale)) * (on ? 1.3 : 1), 0, Math.PI * 2);
         ctx.fill();
+        ctx.shadowBlur = 0;
       }
       ctx.globalAlpha = 1;
       return;
@@ -257,13 +344,13 @@ function renderAkashaGraph(container: HTMLElement): void {
   }
 
   function badgeHTML(t: GraphNode & { w: number; cc: number; sim: number }): string {
-    const simColor = t.sim > 0.65 ? "#4ade80" : (t.sim > 0.45 ? "#fbbf24" : "#ff5a78");
+    const simClass = t.sim > 0.65 ? "ag-badge-success" : (t.sim > 0.45 ? "ag-badge-warning" : "ag-badge-danger");
     const simText = t.sim > 0.65 ? "同义" : (t.sim > 0.45 ? "相关" : "潜意识跳跃");
     const simPct = `${(t.sim * 100).toFixed(0)}%`;
-    return `<div style="display:flex;gap:6px;font-size:10px;color:#9aa3b5;font-family:monospace;margin-top:5px;flex-wrap:wrap;">
-      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;">同框:${t.cc}次</span>
-      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;">引力:${t.w.toFixed(2)}</span>
-      <span style="background:rgba(255,255,255,0.08);padding:2px 5px;border-radius:4px;color:${simColor}">语义:${simPct} (${simText})</span>
+    return `<div style="display:flex;flex-wrap:wrap;margin-top:2px;">
+      <span class="ag-badge ag-badge-outline">同框:${t.cc}次</span>
+      <span class="ag-badge ag-badge-outline">引力:${t.w.toFixed(2)}</span>
+      <span class="ag-badge ${simClass}">语义:${simPct} (${simText})</span>
     </div>`;
   }
 
@@ -289,13 +376,12 @@ function renderAkashaGraph(container: HTMLElement): void {
     }
 
     let html = '<div style="font-size:13px;color:#8b9eb5;margin-bottom:6px;">选中记忆切片</div>';
-    html += `<div style="font-size:14px;padding:12px;background:rgba(255,255,255,0.06);border-radius:8px;margin-bottom:16px;">${ghEscape(n.t)}</div>`;
+    html += `<div style="font-size:14px;padding:12px;background:linear-gradient(135deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.02) 100%); border: 1px solid rgba(255,255,255,0.05); border-radius:8px; margin-bottom:16px;">${ghEscape(n.t)}</div>`;
     if (external.length > 0) {
       html += `<div style="color:#ff5a78;font-weight:bold;margin-bottom:4px;border-bottom:1px solid rgba(255,90,120,0.3);padding-bottom:6px;">思想跳跃 / 跨界走神 (${external.length})</div>`;
       html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：分属不同的话题岛屿，但在特定时间点被你跨界关联。</div>';
       for (const t of external) {
-        html += `<div style="margin-bottom:14px;display:flex;gap:8px;align-items:flex-start;">
-          <span style="width:8px;height:8px;border-radius:50%;background:${t.c};flex-shrink:0;margin-top:5px;box-shadow:0 0 5px ${t.c};"></span>
+        html += `<div class="detail-item" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px;">
           <div style="display:flex;flex-direction:column;flex:1;"><span style="opacity:0.95">${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
         </div>`;
       }
@@ -304,7 +390,7 @@ function renderAkashaGraph(container: HTMLElement): void {
       html += `<div style="color:#96c8ff;font-weight:bold;margin-bottom:4px;margin-top:20px;border-bottom:1px solid rgba(150,200,255,0.3);padding-bottom:6px;">核心圈层 (${internal.length})</div>`;
       html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：基于模块度算法，这些话题形成了高频同框的内聚孤岛。</div>';
       for (const t of internal) {
-        html += `<div style="margin-bottom:14px;padding-left:10px;opacity:0.85;border-left:2px solid ${t.c};">
+        html += `<div class="detail-item" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px;">
           <div style="display:flex;flex-direction:column;flex:1;"><span>${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
         </div>`;
       }
@@ -343,6 +429,7 @@ function renderAkashaGraph(container: HTMLElement): void {
   }
 
   cv.addEventListener("mousedown", (event) => {
+    if (tweenFrame) cancelAnimationFrame(tweenFrame);
     drag = true;
     moved = false;
     lx = event.clientX;
@@ -380,13 +467,27 @@ function renderAkashaGraph(container: HTMLElement): void {
   });
   cv.addEventListener("click", (event) => {
     if (moved) return;
+    if (lockedColor) {
+      lockedColor = null;
+      hlColor = null;
+      legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
+    }
     const rect = cv.getBoundingClientRect();
     const h = pick(event.clientX - rect.left, event.clientY - rect.top);
     pinned = h === pinned ? -1 : h;
-    draw();
+    if (pinned >= 0) {
+      const n = NODES[pinned];
+      const targetScale = Math.max(scale, 1.2);
+      const targetTx = W / 2 - n.x * targetScale;
+      const targetTy = H / 2 - n.y * targetScale;
+      flyTo(targetScale, targetTx, targetTy);
+    } else {
+      draw();
+    }
     updateDetailPanel();
   });
   cv.addEventListener("wheel", (event) => {
+    if (tweenFrame) cancelAnimationFrame(tweenFrame);
     event.preventDefault();
     const rect = cv.getBoundingClientRect();
     const mx = event.clientX - rect.left;
@@ -437,31 +538,57 @@ function renderAkashaGraph(container: HTMLElement): void {
   document.addEventListener("click", onDocumentClick);
 
   function selectNode(i: number): void {
+    if (lockedColor) {
+      lockedColor = null;
+      hlColor = null;
+      legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
+    }
     pinned = i;
     hover = -1;
     const n = NODES[i];
-    scale = Math.max(scale, 1.2);
-    tx = W / 2 - n.x * scale;
-    ty = H / 2 - n.y * scale;
+    const targetScale = Math.max(scale, 1.2);
+    const targetTx = W / 2 - n.x * targetScale;
+    const targetTy = H / 2 - n.y * targetScale;
+    flyTo(targetScale, targetTx, targetTy);
     searchEl.value = "";
     filter = "";
     resEl.style.display = "none";
-    draw();
     updateDetailPanel();
   }
 
   function renderLegend(): void {
-    legEl.innerHTML = '<div class="grab">社区</div><div class="content"><b style="color:#fff">社区主题</b>（按规模，悬停高亮）<br>'
+    legEl.innerHTML = '<div class="grab">社区</div><div class="content" style="padding-top:4px;"><div style="margin-bottom:12px;"><b style="color:#fff;font-size:13px;">社区主题</b> <span style="color:#737a88;">(悬停或点击锁定)</span></div>'
       + LEG.map((l) => `<div class="row" data-c="${ghEscape(l.c)}"><span class="dot" style="background:${ghEscape(l.c)}"></span><span><span style="color:#9aa3b5">[${l.size}]</span> ${ghEscape(l.label)}</span></div>`).join("")
       + "</div>";
     legEl.querySelectorAll<HTMLElement>(".row").forEach((row) => {
       row.addEventListener("mouseenter", () => {
-        filter = "";
-        hlColor = row.dataset.c || null;
-        draw();
+        if (!lockedColor) {
+          filter = "";
+          hlColor = row.dataset.c || null;
+          draw();
+        }
       });
       row.addEventListener("mouseleave", () => {
-        hlColor = null;
+        if (!lockedColor) {
+          hlColor = null;
+          draw();
+        }
+      });
+      row.addEventListener("click", () => {
+        const c = row.dataset.c || null;
+        if (lockedColor === c) {
+          lockedColor = null;
+          hlColor = c;
+        } else {
+          lockedColor = c;
+          hlColor = c;
+          filter = "";
+          pinned = -1;
+          updateDetailPanel();
+          if (c) flyToCommunity(c);
+        }
+        legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
+        if (lockedColor) row.classList.add("selected");
         draw();
       });
     });

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -26,6 +26,36 @@ interface GraphLegend {
   label: string;
 }
 
+interface CommunityView {
+  g: number;
+  c: string;
+  size: number;
+  label: string;
+  x: number;
+  y: number;
+  r: number;
+}
+
+interface SubIslandView {
+  id: number;
+  parent: number;
+  c: string;
+  size: number;
+  x: number;
+  y: number;
+  r: number;
+}
+
+interface IslandLink {
+  ax: number;
+  ay: number;
+  bx: number;
+  by: number;
+  color: string;
+  strength: number;
+  cross: boolean;
+}
+
 interface GraphPayload {
   nodes: GraphNode[];
   edges: GraphEdgeObject[];
@@ -65,7 +95,7 @@ function renderAkashaGraph(container: HTMLElement): void {
           <input type="range" id="cc_slider" min="1" max="10" value="2">
           <span style="font-size:11px">共现频次 &ge; <span id="cc_val" style="color:#fff;font-weight:bold;font-size:13px">2</span></span>
         </div>
-        <div class="hint">拖拽平移 · 滚轮缩放 · 点击节点看连线 · 调滑块看引力</div>
+        <div class="hint">远景看大岛 · 中景看子岛 · 近景看联想根系</div>
       </div>
       <div id="leg"></div>
       <div id="tip"></div>
@@ -98,6 +128,12 @@ function renderAkashaGraph(container: HTMLElement): void {
   let NODES: GraphNode[] = [];
   let EDGES: GraphEdge[] = [];
   let LEG: GraphLegend[] = [];
+  let COMMUNITIES: CommunityView[] = [];
+  let SUB_ISLANDS: SubIslandView[] = [];
+  let childByNode: number[] = [];
+  let nodeIsRepresentative: boolean[] = [];
+  let parentLinks: IslandLink[] = [];
+  let childLinks: IslandLink[] = [];
   let W = 1;
   let H = 1;
   let DPR = 1;
@@ -120,7 +156,6 @@ function renderAkashaGraph(container: HTMLElement): void {
   let pollTimer: number | undefined;
   let tweenFrame: number | undefined;
   let lockedColor: string | null = null;
-  let bgEdgePaths: Path2D[] = [new Path2D(), new Path2D(), new Path2D(), new Path2D()];
   let hlInternalPath = new Path2D();
   let hlCrossPath = new Path2D();
   const globalEdgeScaleLimit = 1.2;
@@ -219,41 +254,465 @@ function renderAkashaGraph(container: HTMLElement): void {
   function invY(py: number): number { return (py - ty) / scale; }
   function activeId(): number { return pinned; }
 
-  function edgeBin(w: number): number {
-    if (w > 0.15) return 3;
-    if (w > 0.1) return 2;
-    if (w > 0.05) return 1;
-    return 0;
+  function colorAlpha(color: string, alpha: number): string {
+    const safeAlpha = Math.max(0, Math.min(1, alpha));
+    if (color.startsWith("hsl(")) return color.replace("hsl(", "hsla(").replace(")", `,${safeAlpha})`);
+    const hex = color.startsWith("#") ? color.slice(1) : "";
+    if (hex.length === 6) {
+      const r = parseInt(hex.slice(0, 2), 16);
+      const g = parseInt(hex.slice(2, 4), 16);
+      const b = parseInt(hex.slice(4, 6), 16);
+      return `rgba(${r},${g},${b},${safeAlpha})`;
+    }
+    return color;
+  }
+
+  function rebalanceFractalSpacing(): void {
+    const groups = new Map<number, { count: number; sx: number; sy: number }>();
+    for (const n of NODES) {
+      const old = groups.get(n.g);
+      if (old) {
+        old.count += 1;
+        old.sx += n.x;
+        old.sy += n.y;
+      } else {
+        groups.set(n.g, { count: 1, sx: n.x, sy: n.y });
+      }
+    }
+    const centers = new Map<number, { x: number; y: number; spread: number }>();
+    for (const [g, item] of groups.entries()) {
+      centers.set(g, {
+        x: item.sx / item.count,
+        y: item.sy / item.count,
+        spread: item.count >= 180 ? 1.55 : (item.count >= 70 ? 1.42 : 1.26),
+      });
+    }
+    const world = { x: 500, y: 500 };
+    NODES = NODES.map((node) => {
+      const center = centers.get(node.g);
+      if (!center) return node;
+      const cx = world.x + (center.x - world.x) * 0.74;
+      const cy = world.y + (center.y - world.y) * 0.74;
+      return {
+        ...node,
+        x: cx + (node.x - center.x) * center.spread,
+        y: cy + (node.y - center.y) * center.spread,
+      };
+    });
   }
 
   function recomputeAdj(): void {
     adj = NODES.map(() => []);
     adjEdges = NODES.map(() => []);
-    bgEdgePaths = [new Path2D(), new Path2D(), new Path2D(), new Path2D()];
     for (const edge of EDGES) {
-      const [a, b, w, cc] = edge;
+      const [a, b, , cc] = edge;
       if (cc >= ccThreshold) {
         adj[a].push(b);
         adj[b].push(a);
         adjEdges[a].push(edge);
         adjEdges[b].push(edge);
-        const bin = edgeBin(w);
-        bgEdgePaths[bin].moveTo(NODES[a].x, NODES[a].y);
-        bgEdgePaths[bin].lineTo(NODES[b].x, NODES[b].y);
+      }
+    }
+    recomputeLinks();
+  }
+
+  function recomputeCommunities(): void {
+    const groups = new Map<number, {
+      c: string;
+      label: string;
+      count: number;
+      sx: number;
+      sy: number;
+      minX: number;
+      minY: number;
+      maxX: number;
+      maxY: number;
+    }>();
+    const nodesByGroup = new Map<number, number[]>();
+    for (let i = 0; i < NODES.length; i += 1) {
+      const n = NODES[i];
+      const bucket = nodesByGroup.get(n.g);
+      if (bucket) bucket.push(i);
+      else nodesByGroup.set(n.g, [i]);
+      const old = groups.get(n.g);
+      const label = LEG[n.g]?.label || `社区 ${n.g}`;
+      if (!old) {
+        groups.set(n.g, {
+          c: n.c,
+          label,
+          count: 1,
+          sx: n.x,
+          sy: n.y,
+          minX: n.x,
+          minY: n.y,
+          maxX: n.x,
+          maxY: n.y,
+        });
+        continue;
+      }
+      old.count += 1;
+      old.sx += n.x;
+      old.sy += n.y;
+      old.minX = Math.min(old.minX, n.x);
+      old.minY = Math.min(old.minY, n.y);
+      old.maxX = Math.max(old.maxX, n.x);
+      old.maxY = Math.max(old.maxY, n.y);
+    }
+    COMMUNITIES = [...groups.entries()].map(([g, item]) => {
+      const x = item.sx / item.count;
+      const y = item.sy / item.count;
+      const dx = Math.max(x - item.minX, item.maxX - x);
+      const dy = Math.max(y - item.minY, item.maxY - y);
+      return {
+        g,
+        c: item.c,
+        size: item.count,
+        label: item.label,
+        x,
+        y,
+        r: Math.max(18, Math.hypot(dx, dy) + 10 + Math.sqrt(item.count) * 1.8),
+      };
+    }).sort((a, b) => b.size - a.size);
+    recomputeSubIslands(nodesByGroup);
+  }
+
+  function recomputeSubIslands(nodesByGroup: Map<number, number[]>): void {
+    SUB_ISLANDS = [];
+    childByNode = NODES.map(() => -1);
+    nodeIsRepresentative = NODES.map(() => false);
+    for (const comm of COMMUNITIES) {
+      const indexes = nodesByGroup.get(comm.g) || [];
+      const parts = splitSubIslands(indexes, comm);
+      for (const part of parts) {
+        const id = SUB_ISLANDS.length;
+        let sx = 0, sy = 0;
+        for (const nodeIndex of part) {
+          sx += NODES[nodeIndex].x;
+          sy += NODES[nodeIndex].y;
+        }
+        const x = sx / part.length;
+        const y = sy / part.length;
+        let far = 0;
+        for (const nodeIndex of part) {
+          const n = NODES[nodeIndex];
+          far = Math.max(far, Math.hypot(n.x - x, n.y - y));
+          childByNode[nodeIndex] = id;
+        }
+        const sub = {
+          id,
+          parent: comm.g,
+          c: comm.c,
+          size: part.length,
+          x,
+          y,
+          r: Math.max(7, far + 4 + Math.sqrt(part.length) * 0.9),
+        };
+        SUB_ISLANDS.push(sub);
+        markRepresentatives(part, sub);
       }
     }
   }
 
-  function drawGlobalEdges(): void {
+  function splitSubIslands(indexes: number[], comm: CommunityView): number[][] {
+    if (indexes.length < 32) return [indexes];
+    const k = Math.max(2, Math.min(8, Math.round(Math.sqrt(indexes.length) / 2.7)));
+    const centers: Array<{ x: number; y: number }> = [];
+    let first = indexes[0];
+    let far = -1;
+    for (const nodeIndex of indexes) {
+      const n = NODES[nodeIndex];
+      const d = Math.hypot(n.x - comm.x, n.y - comm.y);
+      if (d > far) {
+        far = d;
+        first = nodeIndex;
+      }
+    }
+    centers.push({ x: NODES[first].x, y: NODES[first].y });
+    while (centers.length < k) {
+      let next = indexes[0];
+      let best = -1;
+      for (const nodeIndex of indexes) {
+        const n = NODES[nodeIndex];
+        let nearest = Infinity;
+        for (const c of centers) nearest = Math.min(nearest, Math.hypot(n.x - c.x, n.y - c.y));
+        if (nearest > best) {
+          best = nearest;
+          next = nodeIndex;
+        }
+      }
+      centers.push({ x: NODES[next].x, y: NODES[next].y });
+    }
+    let buckets: number[][] = [];
+    for (let iter = 0; iter < 5; iter += 1) {
+      buckets = Array.from({ length: centers.length }, () => []);
+      for (const nodeIndex of indexes) {
+        const n = NODES[nodeIndex];
+        let pick = 0;
+        let best = Infinity;
+        for (let i = 0; i < centers.length; i += 1) {
+          const c = centers[i];
+          const d = Math.hypot(n.x - c.x, n.y - c.y);
+          if (d < best) {
+            best = d;
+            pick = i;
+          }
+        }
+        buckets[pick].push(nodeIndex);
+      }
+      for (let i = 0; i < buckets.length; i += 1) {
+        if (!buckets[i].length) continue;
+        let sx = 0, sy = 0;
+        for (const nodeIndex of buckets[i]) {
+          sx += NODES[nodeIndex].x;
+          sy += NODES[nodeIndex].y;
+        }
+        centers[i] = { x: sx / buckets[i].length, y: sy / buckets[i].length };
+      }
+    }
+    return buckets.filter((bucket) => bucket.length > 0);
+  }
+
+  function markRepresentatives(indexes: number[], sub: SubIslandView): void {
+    const limit = Math.min(5, Math.max(1, Math.round(Math.sqrt(indexes.length) / 3)));
+    const ranked = [...indexes].sort((a, b) => {
+      const na = NODES[a], nb = NODES[b];
+      return Math.hypot(na.x - sub.x, na.y - sub.y) - Math.hypot(nb.x - sub.x, nb.y - sub.y);
+    });
+    for (const nodeIndex of ranked.slice(0, limit)) nodeIsRepresentative[nodeIndex] = true;
+  }
+
+  function recomputeLinks(): void {
+    const commByGroup = new Map(COMMUNITIES.map((comm) => [comm.g, comm]));
+    const parentAgg = new Map<string, { a: number; b: number; cc: number; w: number }>();
+    const childAgg = new Map<string, { a: number; b: number; cc: number; w: number }>();
+    for (const [a, b, w, cc] of EDGES) {
+      if (cc < ccThreshold) continue;
+      const na = NODES[a], nb = NODES[b];
+      if (na.g !== nb.g && cc >= 5) {
+        addAgg(parentAgg, na.g, nb.g, cc, w);
+      }
+      const ca = childByNode[a], cb = childByNode[b];
+      if (ca >= 0 && cb >= 0 && ca !== cb && cc >= 3) {
+        const sameParent = SUB_ISLANDS[ca]?.parent === SUB_ISLANDS[cb]?.parent;
+        if (sameParent || cc >= 8) addAgg(childAgg, ca, cb, cc, w);
+      }
+    }
+    parentLinks = [...parentAgg.values()]
+      .map((item) => {
+        const a = commByGroup.get(item.a);
+        const b = commByGroup.get(item.b);
+        if (!a || !b) return null;
+        return linkFrom(a, b, item.cc, item.w, true);
+      })
+      .filter((item): item is IslandLink => item !== null)
+      .sort((a, b) => b.strength - a.strength)
+      .slice(0, 240);
+    childLinks = [...childAgg.values()]
+      .map((item) => {
+        const a = SUB_ISLANDS[item.a];
+        const b = SUB_ISLANDS[item.b];
+        if (!a || !b) return null;
+        return linkFrom(a, b, item.cc, item.w, a.parent !== b.parent);
+      })
+      .filter((item): item is IslandLink => item !== null)
+      .sort((a, b) => b.strength - a.strength)
+      .slice(0, 1100);
+  }
+
+  function addAgg(
+    map: Map<string, { a: number; b: number; cc: number; w: number }>,
+    a: number,
+    b: number,
+    cc: number,
+    w: number,
+  ): void {
+    const x = Math.min(a, b);
+    const y = Math.max(a, b);
+    const key = `${x}:${y}`;
+    const old = map.get(key);
+    if (old) {
+      old.cc += cc;
+      old.w = Math.max(old.w, w);
+    } else {
+      map.set(key, { a: x, b: y, cc, w });
+    }
+  }
+
+  function linkFrom(
+    a: CommunityView | SubIslandView,
+    b: CommunityView | SubIslandView,
+    cc: number,
+    w: number,
+    cross: boolean,
+  ): IslandLink {
+    return {
+      ax: a.x,
+      ay: a.y,
+      bx: b.x,
+      by: b.y,
+      color: cross ? "#d7e4ff" : a.c,
+      strength: Math.sqrt(cc) * Math.max(0.04, w),
+      cross,
+    };
+  }
+
+  function drawIslands(act: number): void {
     ctx.save();
     ctx.translate(tx, ty);
     ctx.scale(scale, scale);
-    const alphas = [0.08, 0.12, 0.18, 0.25];
-    ctx.lineWidth = Math.max(0.3 / scale, 0.5);
-    for (let i = 0; i < 4; i++) {
-      ctx.strokeStyle = `rgba(120,130,150,${alphas[i]})`;
-      ctx.stroke(bgEdgePaths[i]);
+    for (let i = COMMUNITIES.length - 1; i >= 0; i -= 1) {
+      const comm = COMMUNITIES[i];
+      const active = act >= 0 && NODES[act]?.g === comm.g;
+      const alpha = active ? 0.22 : (scale < 0.9 ? 0.12 : 0.06);
+      const radius = comm.r + (scale < 0.9 ? 10 : 4);
+      const gradient = ctx.createRadialGradient(
+        comm.x,
+        comm.y,
+        Math.max(4, radius * 0.12),
+        comm.x,
+        comm.y,
+        radius,
+      );
+      gradient.addColorStop(0, colorAlpha(comm.c, alpha));
+      gradient.addColorStop(0.72, colorAlpha(comm.c, alpha * 0.32));
+      gradient.addColorStop(1, colorAlpha(comm.c, 0));
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(comm.x, comm.y, radius, 0, Math.PI * 2);
+      ctx.fill();
     }
+    if (scale > 0.68) {
+      for (const sub of SUB_ISLANDS) {
+        const active = act >= 0 && childByNode[act] === sub.id;
+        const alpha = active ? 0.28 : (scale < 1.18 ? 0.15 : 0.08);
+        const radius = sub.r + (scale < 1.1 ? 3 : 1.5);
+        const gradient = ctx.createRadialGradient(sub.x, sub.y, 1, sub.x, sub.y, radius);
+        gradient.addColorStop(0, colorAlpha(sub.c, alpha));
+        gradient.addColorStop(0.68, colorAlpha(sub.c, alpha * 0.28));
+        gradient.addColorStop(1, colorAlpha(sub.c, 0));
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(sub.x, sub.y, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+    if (scale < 0.95) {
+      ctx.textBaseline = "middle";
+      ctx.font = `${Math.max(9 / scale, 7)}px sans-serif`;
+      for (const comm of COMMUNITIES) {
+        if (comm.size < 60) continue;
+        const label = comm.label.split(" · ")[0] || `社区 ${comm.g}`;
+        ctx.fillStyle = "rgba(232,236,244,0.72)";
+        ctx.fillText(`[${comm.size}] ${label.slice(0, 16)}`, comm.x - comm.r * 0.32, comm.y - comm.r - 8 / scale);
+      }
+    }
+    ctx.restore();
+  }
+
+  function drawGlobalEdges(): void {
+    drawIslandLinks(parentLinks, scale < 0.75 ? 0.42 : 0.24, 1.35);
+    if (scale > 0.72) drawIslandLinks(childLinks, scale < 1.08 ? 0.22 : 0.13, 0.78);
+  }
+
+  function drawIslandLinks(links: IslandLink[], alphaBase: number, widthBase: number): void {
+    ctx.save();
+    ctx.translate(tx, ty);
+    ctx.scale(scale, scale);
+    for (const link of links) {
+      const dx = link.bx - link.ax;
+      const dy = link.by - link.ay;
+      const len = Math.max(1, Math.hypot(dx, dy));
+      const bend = Math.min(60, len * 0.12) * (link.cross ? 1 : -0.5);
+      const cx = (link.ax + link.bx) / 2 - dy / len * bend;
+      const cy = (link.ay + link.by) / 2 + dx / len * bend;
+      const alpha = Math.min(0.62, alphaBase * (0.65 + Math.log1p(link.strength) * 0.42));
+      ctx.strokeStyle = link.cross ? `rgba(210,224,255,${alpha})` : colorAlpha(link.color, alpha);
+      ctx.lineWidth = Math.max(0.45 / scale, widthBase * (0.55 + Math.log1p(link.strength) * 0.34) / scale);
+      ctx.beginPath();
+      ctx.moveTo(link.ax, link.ay);
+      ctx.quadraticCurveTo(cx, cy, link.bx, link.by);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  function drawActiveEdges(act: number): void {
+    const n0 = NODES[act];
+    const items = [...(adjEdges[act] || [])]
+      .sort((a, b) => (b[3] - a[3]) || (b[2] - a[2]))
+      .slice(0, 180);
+    for (let i = 0; i < items.length; i += 1) {
+      const [a, b, w, cc] = items[i];
+      const target = a === act ? b : a;
+      const n1 = NODES[target];
+      const dx = n1.x - n0.x;
+      const dy = n1.y - n0.y;
+      const len = Math.max(1, Math.hypot(dx, dy));
+      const sign = ((a * 31 + b * 17 + i) % 2) === 0 ? 1 : -1;
+      const bend = Math.min(38, Math.max(8, len * 0.1)) * sign;
+      const cx = (n0.x + n1.x) / 2 - dy / len * bend;
+      const cy = (n0.y + n1.y) / 2 + dx / len * bend;
+      const cross = n0.g !== n1.g;
+      const alpha = Math.min(0.9, 0.26 + cc / 32 + w * 0.24);
+      ctx.strokeStyle = cross ? `rgba(255,99,130,${alpha})` : `rgba(142,205,255,${alpha * 0.82})`;
+      ctx.lineWidth = cross ? Math.max(1.3, 1.8 * scale) : Math.max(0.65, 0.95 * scale);
+      ctx.beginPath();
+      ctx.moveTo(X(n0.x), Y(n0.y));
+      ctx.quadraticCurveTo(X(cx), Y(cy), X(n1.x), Y(n1.y));
+      ctx.stroke();
+    }
+  }
+
+  function shouldDrawNode(index: number, act: number, match: Set<number> | null): boolean {
+    if (match) return match.has(index) || scale >= 1.35;
+    if (act >= 0) return index === act || (adj[act] || []).includes(index);
+    if (scale < 0.9) return false;
+    if (scale < 1.35) return nodeIsRepresentative[index] || (adj[index]?.length || 0) >= 40;
+    return true;
+  }
+
+  function representativeForColor(color: string): number {
+    const comm = COMMUNITIES.find((item) => item.c === color);
+    let best = -1;
+    let bestScore = -Infinity;
+    for (let i = 0; i < NODES.length; i += 1) {
+      const n = NODES[i];
+      if (n.c !== color) continue;
+      const degree = adj[i]?.length || 0;
+      if (degree <= 0) continue;
+      const distScore = comm
+        ? 1 - Math.min(1, Math.hypot(n.x - comm.x, n.y - comm.y) / Math.max(comm.r, 1))
+        : 0;
+      const degreeScore = Math.min(degree, 24) / 24;
+      const score = distScore * 2 + degreeScore + (nodeIsRepresentative[i] ? 1 : 0);
+      if (score > bestScore) {
+        bestScore = score;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  function drawActiveNode(index: number): void {
+    const n = NODES[index];
+    const r = n.r * Math.max(0.6, Math.sqrt(scale)) * 1.65;
+    ctx.save();
+    ctx.globalAlpha = 1;
+    ctx.shadowBlur = Math.min(64, Math.max(24, r * 3.1));
+    ctx.shadowColor = "rgba(255,220,128,0.95)";
+    ctx.fillStyle = "rgba(255,194,92,0.96)";
+    ctx.beginPath();
+    ctx.arc(X(n.x), Y(n.y), r, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.shadowBlur = Math.min(26, Math.max(10, r * 1.3));
+    ctx.shadowColor = "rgba(255,255,255,0.9)";
+    ctx.lineWidth = Math.max(2.5, 1.4 * scale);
+    ctx.strokeStyle = "rgba(255,255,255,0.96)";
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+    ctx.lineWidth = Math.max(1.2, 0.8 * scale);
+    ctx.strokeStyle = "rgba(255,126,80,0.95)";
+    ctx.stroke();
     ctx.restore();
   }
 
@@ -279,32 +738,19 @@ function renderAkashaGraph(container: HTMLElement): void {
       ? new Set(NODES.map((n, i) => n.t.toLowerCase().includes(fil) ? i : -1).filter((i) => i >= 0))
       : null;
 
+    drawIslands(act);
     if (act < 0 && !match && scale <= globalEdgeScaleLimit) {
       drawGlobalEdges();
     } else if (act >= 0) {
-      for (const [a, b] of adjEdges[act] || []) {
-        const nA = NODES[a], nB = NODES[b];
-        const cross = nA.g !== nB.g;
-        ctx.strokeStyle = cross ? "rgba(255,90,120,0.85)" : "rgba(150,200,255,.6)";
-        ctx.lineWidth = cross ? Math.max(1.5, 2 * scale) : Math.max(0.6, scale);
-        if (cross) {
-          ctx.shadowBlur = Math.min(20, 6 * scale);
-          ctx.shadowColor = "rgba(255,90,120,0.9)";
-        } else {
-          ctx.shadowBlur = 0;
-        }
-        ctx.beginPath();
-        ctx.moveTo(X(nA.x), Y(nA.y));
-        ctx.lineTo(X(nB.x), Y(nB.y));
-        ctx.stroke();
-        ctx.shadowBlur = 0;
-      }
+      drawActiveEdges(act);
     }
 
     for (let i = 0; i < NODES.length; i += 1) {
       const n = NODES[i];
       let r = n.r * Math.max(0.6, Math.sqrt(scale));
+      if (!shouldDrawNode(i, act, match)) continue;
       if (!inView(n.x, n.y, r * 1.5)) continue;
+      if (act === i) continue;
 
       let alpha = 1;
       if ((adj[i]?.length || 0) === 0 && ccThreshold > 1 && !match) alpha = 0.08;
@@ -314,14 +760,17 @@ function renderAkashaGraph(container: HTMLElement): void {
       const isNeighbor = act >= 0 && hl.has(i) && !isActive;
       const isMatch = match && match.has(i);
 
+      if (act < 0 && !match && scale < 1.35) {
+        alpha *= 0.82;
+        r *= 0.82;
+      }
       if (isMatch) r *= 1.5;
-      if (isActive) r *= 1.4;
-      else if (isNeighbor) r *= 1.1;
+      if (isNeighbor) r *= 1.1;
 
       ctx.globalAlpha = alpha;
       ctx.fillStyle = n.c;
 
-      if (isActive || isMatch) {
+      if (isMatch) {
         ctx.shadowBlur = Math.min(40, Math.max(12, r * 2.5));
         ctx.shadowColor = n.c;
       } else if (isNeighbor) {
@@ -336,9 +785,9 @@ function renderAkashaGraph(container: HTMLElement): void {
       ctx.fill();
       ctx.shadowBlur = 0;
 
-      if (isActive || isMatch || isNeighbor) {
+      if (isMatch || isNeighbor) {
         ctx.globalAlpha = 1;
-        if (isActive || isMatch) {
+        if (isMatch) {
           ctx.lineWidth = 2;
           ctx.strokeStyle = "#fff";
         } else {
@@ -352,6 +801,7 @@ function renderAkashaGraph(container: HTMLElement): void {
 
     if (act >= 0) {
       const n = NODES[act];
+      drawActiveNode(act);
       ctx.fillStyle = "#fff";
       ctx.font = "bold 14px sans-serif";
       ctx.shadowBlur = 4;
@@ -374,27 +824,13 @@ function renderAkashaGraph(container: HTMLElement): void {
       function inView(x: number, y: number, r: number) {
         return x + r >= viewLeft && x - r <= viewRight && y + r >= viewTop && y - r <= viewBottom;
       }
-      ctx.save();
-      ctx.translate(tx, ty);
-      ctx.scale(scale, scale);
-      ctx.lineWidth = Math.max(0.6 / scale, 1);
-
-      ctx.strokeStyle = "rgba(150,200,255,0.4)";
-      ctx.shadowBlur = 15 / scale;
-      ctx.shadowColor = "rgba(150,200,255,0.6)";
-      ctx.stroke(hlInternalPath);
-
-      ctx.strokeStyle = "rgba(255,90,120,0.6)";
-      ctx.shadowBlur = 20 / scale;
-      ctx.shadowColor = "rgba(255,90,120,0.8)";
-      ctx.stroke(hlCrossPath);
-
-      ctx.restore();
-      ctx.shadowBlur = 0;
+      drawIslands(-1);
       for (let i = 0; i < NODES.length; i += 1) {
         const n = NODES[i];
         let r = n.r * Math.max(0.6, Math.sqrt(scale));
         const on = n.c === hlColor;
+        if (!on && scale < 1.2) continue;
+        if (on && scale < 1.05 && !nodeIsRepresentative[i] && (adj[i]?.length || 0) < 40) continue;
         if (on) r *= 1.3;
         if (!inView(n.x, n.y, r * 1.5)) continue;
 
@@ -441,10 +877,10 @@ function renderAkashaGraph(container: HTMLElement): void {
       if (b === pinned) neighbors.push({ id: a, w, cc, sim });
     }
     neighbors.sort((x, y) => y.w - x.w);
-    const internal: Array<GraphNode & { w: number; cc: number; sim: number }> = [];
-    const external: Array<GraphNode & { w: number; cc: number; sim: number }> = [];
+    const internal: Array<GraphNode & { nodeIndex: number; w: number; cc: number; sim: number }> = [];
+    const external: Array<GraphNode & { nodeIndex: number; w: number; cc: number; sim: number }> = [];
     for (const nb of neighbors) {
-      const target = { ...NODES[nb.id], w: nb.w, cc: nb.cc, sim: nb.sim };
+      const target = { ...NODES[nb.id], nodeIndex: nb.id, w: nb.w, cc: nb.cc, sim: nb.sim };
       if (target.g === n.g) internal.push(target);
       else external.push(target);
     }
@@ -455,7 +891,7 @@ function renderAkashaGraph(container: HTMLElement): void {
       html += `<div style="color:#ff5a78;font-weight:bold;margin-bottom:4px;border-bottom:1px solid rgba(255,90,120,0.3);padding-bottom:6px;">思想跳跃 / 跨界走神 (${external.length})</div>`;
       html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：分属不同的话题岛屿，但在特定时间点被你跨界关联。</div>';
       for (const t of external) {
-        html += `<div class="detail-item" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px;">
+        html += `<div class="detail-item" data-node="${t.nodeIndex}" title="锁定这个记忆切片" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px; cursor:pointer;">
           <div style="display:flex;flex-direction:column;flex:1;"><span style="opacity:0.95">${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
         </div>`;
       }
@@ -464,7 +900,7 @@ function renderAkashaGraph(container: HTMLElement): void {
       html += `<div style="color:#96c8ff;font-weight:bold;margin-bottom:4px;margin-top:20px;border-bottom:1px solid rgba(150,200,255,0.3);padding-bottom:6px;">核心圈层 (${internal.length})</div>`;
       html += '<div style="font-size:11px;color:#737a88;margin-bottom:12px;line-height:1.4;">溯源：基于模块度算法，这些话题形成了高频同框的内聚孤岛。</div>';
       for (const t of internal) {
-        html += `<div class="detail-item" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px;">
+        html += `<div class="detail-item" data-node="${t.nodeIndex}" title="锁定这个记忆切片" style="display:flex;gap:8px;align-items:flex-start;background:linear-gradient(90deg, rgba(255,255,255,0.05) 0%, transparent 100%); border-left: 2px solid ${t.c}; padding: 8px; margin-bottom: 8px; cursor:pointer;">
           <div style="display:flex;flex-direction:column;flex:1;"><span>${ghEscape(t.t)}</span>${badgeHTML(t)}</div>
         </div>`;
       }
@@ -476,8 +912,12 @@ function renderAkashaGraph(container: HTMLElement): void {
   function pick(px: number, py: number): number {
     let best = -1;
     let bd = Number.POSITIVE_INFINITY;
+    const match = filter
+      ? new Set(NODES.map((n, i) => n.t.toLowerCase().includes(filter) ? i : -1).filter((i) => i >= 0))
+      : null;
     for (let i = 0; i < NODES.length; i += 1) {
       if ((adj[i]?.length || 0) === 0 && !filter) continue;
+      if (!shouldDrawNode(i, pinned, match)) continue;
       const dx = X(NODES[i].x) - px;
       const dy = Y(NODES[i].y) - py;
       const d = dx * dx + dy * dy;
@@ -501,6 +941,14 @@ function renderAkashaGraph(container: HTMLElement): void {
       resEl.style.display = "none";
     }
   }
+
+  detailPanel.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLElement>(".detail-item[data-node]");
+    if (!target) return;
+    event.stopPropagation();
+    const next = Number(target.dataset.node);
+    if (Number.isInteger(next) && next >= 0 && next < NODES.length) selectNode(next);
+  });
 
   cv.addEventListener("mousedown", (event) => {
     if (tweenFrame) cancelAnimationFrame(tweenFrame);
@@ -634,7 +1082,7 @@ function renderAkashaGraph(container: HTMLElement): void {
   }
 
   function renderLegend(): void {
-    legEl.innerHTML = '<div class="grab">社区</div><div class="content" style="padding-top:4px;"><div style="margin-bottom:12px;"><b style="color:#fff;font-size:13px;">社区主题</b> <span style="color:#737a88;">(悬停或点击锁定)</span></div>'
+    legEl.innerHTML = '<div class="grab">岛屿</div><div class="content" style="padding-top:4px;"><div style="margin-bottom:12px;"><b style="color:#fff;font-size:13px;">记忆岛屿</b> <span style="color:#737a88;">(悬停预览 · 点击选代表记忆)</span></div>'
       + LEG.map((l) => `<div class="row" data-c="${ghEscape(l.c)}"><span class="dot" style="background:${ghEscape(l.c)}"></span><span><span style="color:#9aa3b5">[${l.size}]</span> ${ghEscape(l.label)}</span></div>`).join("")
       + "</div>";
     legEl.querySelectorAll<HTMLElement>(".row").forEach((row) => {
@@ -655,21 +1103,23 @@ function renderAkashaGraph(container: HTMLElement): void {
       });
       row.addEventListener("click", () => {
         const c = row.dataset.c || null;
-        if (lockedColor === c) {
-          lockedColor = null;
-          hlColor = c;
-          updateHlPaths();
+        if (!c) return;
+        lockedColor = null;
+        hlColor = null;
+        filter = "";
+        searchEl.value = "";
+        resEl.style.display = "none";
+        updateHlPaths();
+        const target = representativeForColor(c);
+        if (target >= 0) {
+          selectNode(target);
         } else {
-          lockedColor = c;
-          hlColor = c;
-          filter = "";
           pinned = -1;
-          updateHlPaths();
           updateDetailPanel();
-          if (c) flyToCommunity(c);
+          flyToCommunity(c);
         }
         legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
-        if (lockedColor) row.classList.add("selected");
+        row.classList.add("selected");
         draw();
       });
     });
@@ -689,6 +1139,8 @@ function renderAkashaGraph(container: HTMLElement): void {
     NODES = payload.nodes || [];
     EDGES = ghEdges(payload.edges || []);
     LEG = payload.legend || [];
+    rebalanceFractalSpacing();
+    recomputeCommunities();
     ccThreshold = 2;
     slider.value = "2";
     ccVal.textContent = "2";

--- a/plugins/akasha/dashboard_panel_graph.ts
+++ b/plugins/akasha/dashboard_panel_graph.ts
@@ -65,7 +65,7 @@ function renderAkashaGraph(container: HTMLElement): void {
           <input type="range" id="cc_slider" min="1" max="10" value="2">
           <span style="font-size:11px">共现频次 &ge; <span id="cc_val" style="color:#fff;font-weight:bold;font-size:13px">2</span></span>
         </div>
-        <div class="hint">拖拽平移 · 滚轮缩放 · 悬停看邻居 · 调滑块看引力</div>
+        <div class="hint">拖拽平移 · 滚轮缩放 · 点击节点看连线 · 调滑块看引力</div>
       </div>
       <div id="leg"></div>
       <div id="tip"></div>
@@ -77,6 +77,7 @@ function renderAkashaGraph(container: HTMLElement): void {
   (container as HTMLElement & { __agDispose?: () => void }).__agDispose = () => {
     disposed = true;
     if (pollTimer !== undefined) window.clearInterval(pollTimer);
+    if (tweenFrame !== undefined) cancelAnimationFrame(tweenFrame);
     window.removeEventListener("resize", resize);
     window.removeEventListener("mouseup", onMouseUp);
     document.removeEventListener("click", onDocumentClick);
@@ -105,6 +106,7 @@ function renderAkashaGraph(container: HTMLElement): void {
   let ty = 0;
   let ccThreshold = 2;
   let adj: number[][] = [];
+  let adjEdges: GraphEdge[][] = [];
   let hover = -1;
   let pinned = -1;
   let filter = "";
@@ -118,6 +120,28 @@ function renderAkashaGraph(container: HTMLElement): void {
   let pollTimer: number | undefined;
   let tweenFrame: number | undefined;
   let lockedColor: string | null = null;
+  let hlInternalPath = new Path2D();
+  let hlCrossPath = new Path2D();
+
+  function updateHlPaths() {
+    hlInternalPath = new Path2D();
+    hlCrossPath = new Path2D();
+    if (!hlColor) return;
+    for (const [a, b, , cc] of EDGES) {
+      if (cc < ccThreshold) continue;
+      const nA = NODES[a], nB = NODES[b];
+      const aOn = nA.c === hlColor;
+      const bOn = nB.c === hlColor;
+      if (!aOn && !bOn) continue;
+      if (aOn !== bOn) {
+        hlCrossPath.moveTo(nA.x, nA.y);
+        hlCrossPath.lineTo(nB.x, nB.y);
+      } else {
+        hlInternalPath.moveTo(nA.x, nA.y);
+        hlInternalPath.lineTo(nB.x, nB.y);
+      }
+    }
+  }
 
   function flyTo(targetScale: number, targetTx: number, targetTy: number) {
     if (tweenFrame) cancelAnimationFrame(tweenFrame);
@@ -155,15 +179,11 @@ function renderAkashaGraph(container: HTMLElement): void {
     const cy = (minY + maxY) / 2;
     const w = maxX - minX;
     const h = maxY - minY;
-    
-    let targetScale = scale;
-    if (w > 0 && h > 0) {
-      const s = Math.min((W - 120) / w, (H - 120) / h);
-      targetScale = Math.max(0.2, Math.min(s, 2.5));
-    } else {
-      targetScale = Math.max(scale, 1.2);
-    }
-    
+
+    const targetScale = w > 0 && h > 0
+      ? Math.max(0.2, Math.min(Math.min((W - 120) / w, (H - 120) / h), 2.5))
+      : Math.max(scale, 1.2);
+
     const targetTx = W / 2 - cx * targetScale;
     const targetTy = H / 2 - cy * targetScale;
     flyTo(targetScale, targetTx, targetTy);
@@ -195,20 +215,33 @@ function renderAkashaGraph(container: HTMLElement): void {
   function Y(y: number): number { return y * scale + ty; }
   function invX(px: number): number { return (px - tx) / scale; }
   function invY(py: number): number { return (py - ty) / scale; }
-  function activeId(): number { return hover >= 0 ? hover : pinned; }
+  function activeId(): number { return pinned; }
 
   function recomputeAdj(): void {
     adj = NODES.map(() => []);
-    for (const [a, b, , cc] of EDGES) {
+    adjEdges = NODES.map(() => []);
+    for (const edge of EDGES) {
+      const [a, b, , cc] = edge;
       if (cc >= ccThreshold) {
         adj[a].push(b);
         adj[b].push(a);
+        adjEdges[a].push(edge);
+        adjEdges[b].push(edge);
       }
     }
   }
 
   function drawBase(): void {
     ctx.clearRect(0, 0, W, H);
+    const viewLeft = -tx / scale;
+    const viewRight = (W - tx) / scale;
+    const viewTop = -ty / scale;
+    const viewBottom = (H - ty) / scale;
+
+    function inView(x: number, y: number, r: number) {
+      return x + r >= viewLeft && x - r <= viewRight && y + r >= viewTop && y - r <= viewBottom;
+    }
+
     const act = activeId();
     const hl = new Set<number>();
     if (act >= 0) {
@@ -220,67 +253,70 @@ function renderAkashaGraph(container: HTMLElement): void {
       ? new Set(NODES.map((n, i) => n.t.toLowerCase().includes(fil) ? i : -1).filter((i) => i >= 0))
       : null;
 
-    ctx.lineWidth = Math.max(0.3, 0.5 * scale);
-    for (const [a, b, w, cc] of EDGES) {
-      if (cc < ccThreshold) continue;
-      const on = act >= 0 && (a === act || b === act);
-      if (act >= 0 && !on) continue;
-      if (on) {
-        const cross = NODES[a].g !== NODES[b].g;
+    if (act >= 0) {
+      for (const [a, b] of adjEdges[act] || []) {
+        const nA = NODES[a], nB = NODES[b];
+        const cross = nA.g !== nB.g;
         ctx.strokeStyle = cross ? "rgba(255,90,120,0.85)" : "rgba(150,200,255,.6)";
         ctx.lineWidth = cross ? Math.max(1.5, 2 * scale) : Math.max(0.6, scale);
         if (cross) {
-          ctx.shadowBlur = 6 * scale;
+          ctx.shadowBlur = Math.min(20, 6 * scale);
           ctx.shadowColor = "rgba(255,90,120,0.9)";
+        } else {
+          ctx.shadowBlur = 0;
         }
-      } else {
-        ctx.strokeStyle = `rgba(120,130,150,${Math.min(.22, .05 + w)})`;
-        ctx.lineWidth = Math.max(0.3, 0.5 * scale);
+        ctx.beginPath();
+        ctx.moveTo(X(nA.x), Y(nA.y));
+        ctx.lineTo(X(nB.x), Y(nB.y));
+        ctx.stroke();
         ctx.shadowBlur = 0;
       }
-      ctx.beginPath();
-      ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
-      ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
-      ctx.stroke();
-      ctx.shadowBlur = 0;
-    }
-
-    if (act < 0) {
-      ctx.strokeStyle = "rgba(110,120,140,.10)";
-      ctx.lineWidth = Math.max(0.25, 0.35 * scale);
-      ctx.beginPath();
-      for (const [a, b, , cc] of EDGES) {
-        if (cc < ccThreshold) continue;
-        ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
-        ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
-      }
-      ctx.stroke();
     }
 
     for (let i = 0; i < NODES.length; i += 1) {
       const n = NODES[i];
-      let alpha = 1;
       let r = n.r * Math.max(0.6, Math.sqrt(scale));
+      if (!inView(n.x, n.y, r * 1.5)) continue;
+
+      let alpha = 1;
       if ((adj[i]?.length || 0) === 0 && ccThreshold > 1 && !match) alpha = 0.08;
-      if (act >= 0 && !hl.has(i)) alpha = 0.12;
+      if (act >= 0 && !hl.has(i)) alpha = 0.05;
       if (match && !match.has(i)) alpha = 0.06;
-      if (match && match.has(i)) r *= 1.5;
+      const isActive = act === i;
+      const isNeighbor = act >= 0 && hl.has(i) && !isActive;
+      const isMatch = match && match.has(i);
+
+      if (isMatch) r *= 1.5;
+      if (isActive) r *= 1.4;
+      else if (isNeighbor) r *= 1.1;
+
       ctx.globalAlpha = alpha;
       ctx.fillStyle = n.c;
-      if ((act >= 0 && hl.has(i)) || (match && match.has(i))) {
-        ctx.shadowBlur = Math.max(6, r * 1.5);
+
+      if (isActive || isMatch) {
+        ctx.shadowBlur = Math.min(40, Math.max(12, r * 2.5));
+        ctx.shadowColor = n.c;
+      } else if (isNeighbor) {
+        ctx.shadowBlur = Math.min(20, Math.max(4, r * 1));
         ctx.shadowColor = n.c;
       } else {
         ctx.shadowBlur = 0;
       }
+
       ctx.beginPath();
       ctx.arc(X(n.x), Y(n.y), r, 0, Math.PI * 2);
       ctx.fill();
       ctx.shadowBlur = 0;
-      if ((act >= 0 && hl.has(i)) || (match && match.has(i))) {
+
+      if (isActive || isMatch || isNeighbor) {
         ctx.globalAlpha = 1;
-        ctx.lineWidth = 1;
-        ctx.strokeStyle = (act >= 0 && i !== act && NODES[i].g !== NODES[act].g) ? "#ff5a78" : "#fff";
+        if (isActive || isMatch) {
+          ctx.lineWidth = 2;
+          ctx.strokeStyle = "#fff";
+        } else {
+          ctx.lineWidth = 1;
+          ctx.strokeStyle = (NODES[i].g !== NODES[act].g) ? "#ff5a78" : "rgba(255, 255, 255, 0.6)";
+        }
         ctx.stroke();
       }
     }
@@ -290,50 +326,60 @@ function renderAkashaGraph(container: HTMLElement): void {
       const n = NODES[act];
       ctx.fillStyle = "#fff";
       ctx.font = "bold 14px sans-serif";
+      ctx.shadowBlur = 4;
+      ctx.shadowColor = "rgba(0,0,0,0.8)";
       const text = n.t.length > 25 ? `${n.t.slice(0, 25)}...` : n.t;
       ctx.fillText(text, X(n.x) + 12, Y(n.y) - 12);
+      ctx.shadowBlur = 0;
     }
   }
 
   function draw(): void {
     if (hlColor) {
       ctx.clearRect(0, 0, W, H);
-      ctx.lineWidth = Math.max(0.6, scale);
-      for (const [a, b, w, cc] of EDGES) {
-        if (cc < ccThreshold) continue;
-        const aOn = NODES[a].c === hlColor;
-        const bOn = NODES[b].c === hlColor;
-        if (!aOn && !bOn) continue;
-        
-        const cross = aOn !== bOn;
-        if (cross) {
-            ctx.strokeStyle = "rgba(255,90,120,0.6)";
-            ctx.shadowBlur = 4 * scale;
-            ctx.shadowColor = "rgba(255,90,120,0.8)";
-        } else {
-            ctx.strokeStyle = "rgba(150,200,255,0.4)";
-            ctx.shadowBlur = 2 * scale;
-            ctx.shadowColor = "rgba(150,200,255,0.6)";
-        }
-        ctx.beginPath();
-        ctx.moveTo(X(NODES[a].x), Y(NODES[a].y));
-        ctx.lineTo(X(NODES[b].x), Y(NODES[b].y));
-        ctx.stroke();
-        ctx.shadowBlur = 0;
+
+      const viewLeft = -tx / scale;
+      const viewRight = (W - tx) / scale;
+      const viewTop = -ty / scale;
+      const viewBottom = (H - ty) / scale;
+
+      function inView(x: number, y: number, r: number) {
+        return x + r >= viewLeft && x - r <= viewRight && y + r >= viewTop && y - r <= viewBottom;
       }
+      ctx.save();
+      ctx.translate(tx, ty);
+      ctx.scale(scale, scale);
+      ctx.lineWidth = Math.max(0.6 / scale, 1);
+
+      ctx.strokeStyle = "rgba(150,200,255,0.4)";
+      ctx.shadowBlur = 15 / scale;
+      ctx.shadowColor = "rgba(150,200,255,0.6)";
+      ctx.stroke(hlInternalPath);
+
+      ctx.strokeStyle = "rgba(255,90,120,0.6)";
+      ctx.shadowBlur = 20 / scale;
+      ctx.shadowColor = "rgba(255,90,120,0.8)";
+      ctx.stroke(hlCrossPath);
+
+      ctx.restore();
+      ctx.shadowBlur = 0;
       for (let i = 0; i < NODES.length; i += 1) {
         const n = NODES[i];
+        let r = n.r * Math.max(0.6, Math.sqrt(scale));
         const on = n.c === hlColor;
-        ctx.globalAlpha = on ? 1 : ((adj[i]?.length || 0) === 0 ? 0.03 : 0.08);
+        if (on) r *= 1.3;
+        if (!inView(n.x, n.y, r * 1.5)) continue;
+
+        ctx.globalAlpha = on ? 1 : ((adj[i]?.length || 0) === 0 ? 0.03 : 0.05);
         ctx.fillStyle = n.c;
         if (on) {
-          ctx.shadowBlur = n.r * 2 * Math.sqrt(scale);
+          ctx.shadowBlur = Math.min(30, r * 2);
           ctx.shadowColor = n.c;
         } else {
           ctx.shadowBlur = 0;
         }
         ctx.beginPath();
-        ctx.arc(X(n.x), Y(n.y), n.r * Math.max(0.6, Math.sqrt(scale)) * (on ? 1.3 : 1), 0, Math.PI * 2);
+        ctx.arc(X(n.x), Y(n.y), r, 0, Math.PI * 2);
         ctx.fill();
         ctx.shadowBlur = 0;
       }
@@ -432,6 +478,7 @@ function renderAkashaGraph(container: HTMLElement): void {
     if (tweenFrame) cancelAnimationFrame(tweenFrame);
     drag = true;
     moved = false;
+    hover = -1;
     lx = event.clientX;
     ly = event.clientY;
     cv.classList.add("drag");
@@ -454,7 +501,6 @@ function renderAkashaGraph(container: HTMLElement): void {
     const h = pick(mx, my);
     if (h !== hover) {
       hover = h;
-      draw();
     }
     if (h >= 0) {
       tip.style.display = "block";
@@ -470,6 +516,7 @@ function renderAkashaGraph(container: HTMLElement): void {
     if (lockedColor) {
       lockedColor = null;
       hlColor = null;
+      updateHlPaths();
       legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
     }
     const rect = cv.getBoundingClientRect();
@@ -505,6 +552,7 @@ function renderAkashaGraph(container: HTMLElement): void {
     ccThreshold = Number(slider.value);
     ccVal.textContent = String(ccThreshold);
     recomputeAdj();
+    updateHlPaths();
     draw();
     updateDetailPanel();
   });
@@ -541,6 +589,7 @@ function renderAkashaGraph(container: HTMLElement): void {
     if (lockedColor) {
       lockedColor = null;
       hlColor = null;
+      updateHlPaths();
       legEl.querySelectorAll<HTMLElement>(".row").forEach(r => r.classList.remove("selected"));
     }
     pinned = i;
@@ -565,12 +614,14 @@ function renderAkashaGraph(container: HTMLElement): void {
         if (!lockedColor) {
           filter = "";
           hlColor = row.dataset.c || null;
+          updateHlPaths();
           draw();
         }
       });
       row.addEventListener("mouseleave", () => {
         if (!lockedColor) {
           hlColor = null;
+          updateHlPaths();
           draw();
         }
       });
@@ -579,11 +630,13 @@ function renderAkashaGraph(container: HTMLElement): void {
         if (lockedColor === c) {
           lockedColor = null;
           hlColor = c;
+          updateHlPaths();
         } else {
           lockedColor = c;
           hlColor = c;
           filter = "";
           pinned = -1;
+          updateHlPaths();
           updateDetailPanel();
           if (c) flyToCommunity(c);
         }

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -46,6 +46,7 @@ from plugins.akasha.core import (
     parse_turn_key as _parse_turn_key,
     bounded_add as _bounded_add,
     reinforce_boost_from_payload as _reinforce_boost_from_payload,
+    reinforced_activation_items as _reinforced_activation_items,
 )
 from agent.config_models import Config  # noqa: F401
 from bus.events_lifecycle import TurnCommitted
@@ -146,6 +147,7 @@ class AkashaMemoryEngine:
         )
         self._event_bus = event_publisher
         self._pending_by_session: dict[str, PendingActivation] = {}
+        self._prev_activation_by_session: dict[str, list[AkashaCandidate]] = {}
         self._graph_lock = threading.RLock()
         self._nodes: dict[str, AkashaNode] = {}
         self._edges: dict[tuple[str, str], float] = {}
@@ -651,31 +653,46 @@ class AkashaMemoryEngine:
         # 3. 用真实 current_key 建边，并记录激活诊断。
         #    reinforce 标记 = 本轮调用了 reinforce_memory 工具(记在 tool_chain)或 extra 回填；
         #    与离线重建(build._load_reinforce_boosts)读同一来源，live 与重放一致。
-        reinforced = _reinforce_boost_for_turn(
+        reinforce_boost = _reinforce_boost_for_turn(
             event.extra,
             event.tool_chain_raw,
-        ) > 1.0
+        )
         pending = self._pending_by_session.pop(event.session_key, None)
         if current_key and pending is not None:
-            self._commit_pending_activation(current_key, pending, reinforced=reinforced)
+            self._commit_pending_activation(
+                current_key,
+                pending,
+                session_key=event.session_key,
+                reinforce_boost=reinforce_boost,
+            )
 
     # 把 pending activation 转成边和事件。
     def _commit_pending_activation(
         self,
         current_key: str,
         pending: PendingActivation,
-        reinforced: bool = False,
+        session_key: str = "",
+        reinforce_boost: float = 1.0,
     ) -> None:
         query_residual = self._compute_query_residual(pending.query_vec, current_key)
+        prev_by_session = getattr(self, "_prev_activation_by_session", {})
+        edge_items = _reinforced_activation_items(
+            pending.items,
+            prev_by_session.get(session_key, []),
+            reinforce_boost,
+        )
         edge_updates = _activation_edge_updates(
             current_key,
-            pending.items,
+            edge_items,
             pending.ts,
             query_residual=query_residual,
-            reinforced=reinforced,
+            reinforce_boost=reinforce_boost,
         )
         self._store.upsert_edges(edge_updates)
         self._apply_edge_updates(edge_updates)
+        if session_key:
+            prev_by_session[session_key] = list(pending.items)
+            self._prev_activation_by_session = prev_by_session
 
         # 2. 记录本轮激活明细，便于之后诊断。
         self._store.insert_activation_events([

--- a/plugins/akasha/graph_snapshot.py
+++ b/plugins/akasha/graph_snapshot.py
@@ -1,0 +1,594 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import networkx as nx
+import numpy as np
+from numpy.typing import NDArray
+
+BIG_COMMUNITY_SIZE = 8
+LAYOUT_EDGE_LIMIT = 5000
+
+
+@dataclass(frozen=True)
+class GraphSnapshotConfig:
+    min_co_count: int = 1
+    layout_min_co_count: int = 2
+    layout_edge_limit: int = LAYOUT_EDGE_LIMIT
+
+
+@dataclass(frozen=True)
+class GraphSnapshotSignature:
+    node_count: int
+    edge_count: int
+    max_node_updated_at: str
+    max_edge_last_used_ts: float
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "node_count": self.node_count,
+            "edge_count": self.edge_count,
+            "max_node_updated_at": self.max_node_updated_at,
+            "max_edge_last_used_ts": self.max_edge_last_used_ts,
+        }
+
+
+def default_snapshot_path(workspace: Path) -> Path:
+    return workspace / "memory" / "akasha_graph_snapshot.json"
+
+
+def load_snapshot(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except Exception:
+        return None
+
+
+def read_graph_signature(akasha_db_path: Path) -> GraphSnapshotSignature:
+    with sqlite3.connect(str(akasha_db_path)) as db:
+        node_row = db.execute(
+            "SELECT COUNT(*) AS count, COALESCE(MAX(updated_at), '') AS max_updated_at FROM akasha_nodes"
+        ).fetchone()
+        edge_row = db.execute(
+            "SELECT COUNT(*) AS count, COALESCE(MAX(last_used_ts), 0) AS max_last_used_ts FROM akasha_edges"
+        ).fetchone()
+    return GraphSnapshotSignature(
+        node_count=int(node_row[0] or 0),
+        edge_count=int(edge_row[0] or 0),
+        max_node_updated_at=str(node_row[1] or ""),
+        max_edge_last_used_ts=float(edge_row[1] or 0.0),
+    )
+    try:
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except Exception:
+        return None
+
+
+def build_snapshot_to_file(
+    *,
+    akasha_db_path: Path,
+    sessions_db_path: Path,
+    snapshot_path: Path,
+    config: GraphSnapshotConfig | None = None,
+) -> dict[str, Any]:
+    payload = build_snapshot(
+        akasha_db_path=akasha_db_path,
+        sessions_db_path=sessions_db_path,
+        config=config or GraphSnapshotConfig(),
+    )
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = snapshot_path.with_suffix(snapshot_path.suffix + ".tmp")
+    _ = tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    _ = tmp_path.replace(snapshot_path)
+    return payload
+
+
+def build_snapshot(
+    *,
+    akasha_db_path: Path,
+    sessions_db_path: Path,
+    config: GraphSnapshotConfig,
+) -> dict[str, Any]:
+    start = time.perf_counter()
+    signature = read_graph_signature(akasha_db_path)
+    with sqlite3.connect(str(akasha_db_path)) as akasha_db:
+        akasha_db.row_factory = sqlite3.Row
+        all_edges = _load_merged_edges(akasha_db, min_co_count=config.min_co_count)
+        keys = {edge.src for edge in all_edges}
+        keys.update(edge.dst for edge in all_edges)
+        nodes_by_key = _load_nodes(akasha_db, keys)
+
+    all_edges = [
+        edge
+        for edge in all_edges
+        if edge.src in nodes_by_key and edge.dst in nodes_by_key
+    ]
+    keys = {edge.src for edge in all_edges}
+    keys.update(edge.dst for edge in all_edges)
+    nodes_by_key = {key: nodes_by_key[key] for key in keys if key in nodes_by_key}
+    texts = _load_texts(sessions_db_path, nodes_by_key)
+
+    layout_edges = _layout_edges(
+        all_edges,
+        layout_min_co_count=config.layout_min_co_count,
+        layout_edge_limit=config.layout_edge_limit,
+    )
+    layout_graph = _graph_from_edges(layout_edges)
+    pos, node_to_comm, comms = _layout_graph(layout_graph)
+    _place_missing_nodes(pos, node_to_comm, comms, nodes_by_key, all_edges)
+
+    full_graph = _graph_from_edges(all_edges)
+    colors, legend = _community_legend(
+        full_graph,
+        comms,
+        node_to_comm,
+        nodes_by_key,
+        texts,
+    )
+    coords = _normalize_positions(pos)
+    payload_nodes = _payload_nodes(nodes_by_key, texts, coords, node_to_comm, colors)
+    node_id = {str(node["id"]): index for index, node in enumerate(payload_nodes)}
+    payload_edges = _payload_edges(all_edges, node_id, nodes_by_key)
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+    return {
+        "nodes": payload_nodes,
+        "edges": payload_edges,
+        "legend": legend,
+        "meta": {
+            "version": f"{signature.node_count}:{signature.edge_count}:{signature.max_node_updated_at}:{signature.max_edge_last_used_ts}",
+            "signature": signature.as_dict(),
+            "generated_at_unix": time.time(),
+            "elapsed_ms": elapsed_ms,
+            "node_count": len(payload_nodes),
+            "edge_count": len(payload_edges),
+            "layout_edge_count": len(layout_edges),
+            "min_co_count": config.min_co_count,
+            "layout_min_co_count": config.layout_min_co_count,
+            "layout_edge_limit": config.layout_edge_limit,
+        },
+    }
+
+
+@dataclass(frozen=True)
+class EdgeRow:
+    src: str
+    dst: str
+    weight: float
+    co_count: int
+
+
+def _load_merged_edges(db: sqlite3.Connection, *, min_co_count: int) -> list[EdgeRow]:
+    rows = db.execute(
+        """
+        SELECT src_key, dst_key, weight, co_count
+        FROM akasha_edges
+        WHERE co_count >= ?
+        """,
+        (min_co_count,),
+    ).fetchall()
+    merged: dict[tuple[str, str], EdgeRow] = {}
+    for row in rows:
+        src = str(row["src_key"])
+        dst = str(row["dst_key"])
+        if src == dst:
+            continue
+        key = (src, dst) if src < dst else (dst, src)
+        weight = float(row["weight"] or 0.0)
+        co_count = int(row["co_count"] or 0)
+        old = merged.get(key)
+        if old is None:
+            merged[key] = EdgeRow(key[0], key[1], weight, co_count)
+        else:
+            merged[key] = EdgeRow(
+                key[0],
+                key[1],
+                max(old.weight, weight),
+                max(old.co_count, co_count),
+            )
+    return sorted(merged.values(), key=lambda item: (item.co_count, item.weight), reverse=True)
+
+
+def _load_nodes(
+    db: sqlite3.Connection,
+    keys: set[str],
+) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    key_list = sorted(keys)
+    for part in _chunks(key_list, 800):
+        placeholders = ",".join("?" for _ in part)
+        rows = db.execute(
+            f"""
+            SELECT key, anchor_id, session_key, turn_seq, salience, strength,
+                   resource, recall_count, embedding
+            FROM akasha_nodes
+            WHERE key IN ({placeholders})
+            """,
+            part,
+        ).fetchall()
+        for row in rows:
+            result[str(row["key"])] = {
+                "id": str(row["key"]),
+                "anchor_id": str(row["anchor_id"]),
+                "session_key": str(row["session_key"]),
+                "turn_seq": int(row["turn_seq"] or 0),
+                "salience": float(row["salience"] or 0.0),
+                "strength": float(row["strength"] or 0.0),
+                "resource": float(row["resource"] or 0.0),
+                "recall_count": int(row["recall_count"] or 0),
+                "embedding": _normalized_embedding(row["embedding"]),
+            }
+    return result
+
+
+def _layout_edges(
+    edges: list[EdgeRow],
+    *,
+    layout_min_co_count: int,
+    layout_edge_limit: int,
+) -> list[EdgeRow]:
+    strong = [edge for edge in edges if edge.co_count >= layout_min_co_count]
+    if not strong:
+        strong = edges
+    return strong[:max(1, layout_edge_limit)]
+
+
+def _graph_from_edges(edges: list[EdgeRow]) -> Any:
+    graph = cast(Any, nx.Graph())
+    for edge in edges:
+        graph.add_edge(edge.src, edge.dst, weight=edge.weight, cc=edge.co_count)
+    return graph
+
+
+def _layout_graph(
+    graph: Any,
+) -> tuple[dict[str, tuple[float, float]], dict[str, int], list[set[str]]]:
+    if graph.number_of_nodes() == 0:
+        return {}, {}, []
+    if graph.number_of_edges() == 0:
+        nodes = [str(node) for node in graph.nodes()]
+        return _spiral_positions(nodes), {key: index for index, key in enumerate(nodes)}, [
+            {key} for key in nodes
+        ]
+    comms = [
+        set(str(item) for item in comm)
+        for comm in nx.algorithms.community.greedy_modularity_communities(graph, weight="weight")
+    ]
+    comms.sort(key=len, reverse=True)
+    node_to_comm = {node: index for index, comm in enumerate(comms) for node in comm}
+    pos: dict[str, tuple[float, float]] = {}
+    island_centers = _island_centers([len(comm) for comm in comms])
+    island_radii = [0.6 + 1.4 * math.sqrt(len(comm)) for comm in comms]
+    for index, comm in enumerate(comms):
+        sub = graph.subgraph(comm)
+        if len(comm) == 1:
+            local: dict[str, tuple[float, float]] = {next(iter(comm)): (0.0, 0.0)}
+        else:
+            local = {
+                str(node): (float(xy[0]), float(xy[1]))
+                for node, xy in nx.spring_layout(
+                    cast(Any, sub),
+                    k=1.1 / math.sqrt(len(comm)),
+                    iterations=60,
+                    weight="weight",
+                    seed=0,
+                ).items()
+            }
+        cx, cy = island_centers[index]
+        radius = island_radii[index]
+        for node in comm:
+            lx, ly = local[node]
+            pos[node] = (cx + lx * radius, cy + ly * radius)
+    return pos, node_to_comm, comms
+
+
+def _place_missing_nodes(
+    pos: dict[str, tuple[float, float]],
+    node_to_comm: dict[str, int],
+    comms: list[set[str]],
+    nodes_by_key: dict[str, dict[str, object]],
+    edges: list[EdgeRow],
+) -> None:
+    missing = [key for key in nodes_by_key if key not in pos]
+    if not missing:
+        return
+    neighbors: dict[str, list[tuple[str, EdgeRow]]] = {}
+    for edge in edges:
+        neighbors.setdefault(edge.src, []).append((edge.dst, edge))
+        neighbors.setdefault(edge.dst, []).append((edge.src, edge))
+    next_comm = len(comms)
+    for index, key in enumerate(missing):
+        parent = _best_positioned_neighbor(neighbors.get(key, []), pos)
+        if parent is None:
+            x, y = _loose_spiral_point(index)
+            comm_id = next_comm
+            next_comm += 1
+            comms.append({key})
+        else:
+            parent_key, rank = parent
+            base_x, base_y = pos[parent_key]
+            angle = (rank * 2.399963229728653) + index * 0.17
+            radius = 0.55 + 0.08 * math.sqrt(index % 17)
+            x = base_x + math.cos(angle) * radius
+            y = base_y + math.sin(angle) * radius
+            comm_id = node_to_comm.get(parent_key, next_comm)
+            if comm_id == next_comm:
+                next_comm += 1
+                comms.append(set())
+            comms[comm_id].add(key)
+        pos[key] = (x, y)
+        node_to_comm[key] = comm_id
+
+
+def _best_positioned_neighbor(
+    candidates: list[tuple[str, EdgeRow]],
+    pos: dict[str, tuple[float, float]],
+) -> tuple[str, int] | None:
+    ranked = sorted(candidates, key=lambda item: (item[1].co_count, item[1].weight), reverse=True)
+    for rank, (key, _) in enumerate(ranked):
+        if key in pos:
+            return key, rank
+    return None
+
+
+def _payload_nodes(
+    nodes_by_key: dict[str, dict[str, object]],
+    texts: dict[str, str],
+    coords: dict[str, tuple[float, float]],
+    node_to_comm: dict[str, int],
+    colors: dict[int, str],
+) -> list[dict[str, object]]:
+    node_list = sorted(nodes_by_key, key=lambda key: (node_to_comm.get(key, 0), key))
+    saliences = [_as_float(nodes_by_key[key]["salience"]) for key in node_list]
+    min_sal = min(saliences) if saliences else 0.0
+    max_sal = max(saliences) if saliences else 0.0
+    result: list[dict[str, object]] = []
+    for key in node_list:
+        row = nodes_by_key[key]
+        comm = node_to_comm.get(key, 0)
+        salience = _as_float(row["salience"])
+        x, y = coords.get(key, (500.0, 500.0))
+        result.append({
+            "id": key,
+            "anchor_id": row["anchor_id"],
+            "session_key": row["session_key"],
+            "turn_seq": row["turn_seq"],
+            "x": x,
+            "y": y,
+            "r": _node_radius(salience, min_sal, max_sal),
+            "c": colors.get(comm, "#7a7f8a"),
+            "g": comm,
+            "t": _clip(texts.get(key, ""), 120),
+            "salience": salience,
+            "strength": _as_float(row["strength"]),
+            "resource": _as_float(row["resource"]),
+            "recall_count": _as_int(row["recall_count"]),
+        })
+    return result
+
+
+def _payload_edges(
+    edges: list[EdgeRow],
+    node_id: dict[str, int],
+    nodes_by_key: dict[str, dict[str, object]],
+) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for edge in edges:
+        if edge.src not in node_id or edge.dst not in node_id:
+            continue
+        result.append({
+            "s": node_id[edge.src],
+            "t": node_id[edge.dst],
+            "w": round(edge.weight, 4),
+            "cc": edge.co_count,
+            "sim": _dense_sim(
+                nodes_by_key[edge.src].get("embedding"),
+                nodes_by_key[edge.dst].get("embedding"),
+            ),
+        })
+    return result
+
+
+def _load_texts(
+    sessions_db_path: Path,
+    nodes_by_key: dict[str, dict[str, object]],
+) -> dict[str, str]:
+    anchor_to_key = {
+        str(row["anchor_id"]): key
+        for key, row in nodes_by_key.items()
+        if str(row.get("anchor_id") or "")
+    }
+    result = {key: "" for key in nodes_by_key}
+    if not anchor_to_key or not sessions_db_path.exists():
+        return result
+    with sqlite3.connect(str(sessions_db_path)) as db:
+        for part in _chunks(sorted(anchor_to_key), 800):
+            placeholders = ",".join("?" for _ in part)
+            rows = db.execute(
+                f"SELECT id, content FROM messages WHERE id IN ({placeholders})",
+                part,
+            ).fetchall()
+            for msg_id, content in rows:
+                result[anchor_to_key[str(msg_id)]] = _clean_text(str(content or ""))
+    return result
+
+
+def _community_legend(
+    graph: Any,
+    comms: list[set[str]],
+    node_to_comm: dict[str, int],
+    nodes_by_key: dict[str, dict[str, object]],
+    texts: dict[str, str],
+) -> tuple[dict[int, str], list[dict[str, object]]]:
+    big_ids = [index for index, comm in enumerate(comms) if len(comm) >= BIG_COMMUNITY_SIZE]
+    colors = {comm_id: _hsl(rank, len(big_ids)) for rank, comm_id in enumerate(big_ids)}
+    legend: list[dict[str, object]] = []
+    for comm_id in big_ids[:30]:
+        comm = comms[comm_id]
+        scored: list[tuple[float, str]] = []
+        for node in comm:
+            text = texts.get(node, "")
+            if len(text) < 5 or len(text) > 140 or "http" in text:
+                continue
+            internal = sum(
+                float(data.get("weight", 1.0))
+                for neighbor, data in graph[node].items()
+                if str(neighbor) in comm
+            )
+            total = float(graph.degree(node, weight="weight") or 0.0)
+            purity = internal / (total + 1e-9)
+            salience = max(_as_float(nodes_by_key[node]["salience"]), 0.1)
+            scored.append((internal * purity * salience, _clip(text, 24)))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        legend.append({
+            "c": colors[comm_id],
+            "size": len(comm),
+            "label": " · ".join(text for _, text in scored[:3]) or f"社区{comm_id}",
+        })
+    all_colors = {
+        node_to_comm.get(str(node), 0): colors.get(node_to_comm.get(str(node), 0), "#7a7f8a")
+        for node in graph.nodes()
+    }
+    return all_colors, legend
+
+
+def _spiral_positions(nodes: list[str]) -> dict[str, tuple[float, float]]:
+    result: dict[str, tuple[float, float]] = {}
+    for index, node in enumerate(nodes):
+        x, y = _loose_spiral_point(index)
+        result[node] = (x, y)
+    return result
+
+
+def _loose_spiral_point(index: int) -> tuple[float, float]:
+    golden = math.pi * (3 - math.sqrt(5))
+    radius = math.sqrt(index + 1)
+    angle = index * golden
+    return radius * math.cos(angle), radius * math.sin(angle)
+
+
+def _island_centers(sizes: list[int]) -> dict[int, tuple[float, float]]:
+    golden = math.pi * (3 - math.sqrt(5))
+    centers: dict[int, tuple[float, float]] = {}
+    area_cum = 0.0
+    for index, size in enumerate(sizes):
+        island_radius = 0.6 + 1.4 * math.sqrt(size)
+        area = (island_radius * 1.5) ** 2
+        area_cum += area / 2
+        radius = math.sqrt(area_cum) * 1.9
+        angle = index * golden
+        centers[index] = (radius * math.cos(angle), radius * math.sin(angle))
+        area_cum += area / 2
+    return centers
+
+
+def _normalize_positions(pos: dict[str, tuple[float, float]]) -> dict[str, tuple[float, float]]:
+    if not pos:
+        return {}
+    xs = [xy[0] for xy in pos.values()]
+    ys = [xy[1] for xy in pos.values()]
+    x0, x1 = min(xs), max(xs)
+    y0, y1 = min(ys), max(ys)
+    return {
+        key: (
+            round((xy[0] - x0) / (x1 - x0 + 1e-9) * 1000, 1),
+            round((xy[1] - y0) / (y1 - y0 + 1e-9) * 1000, 1),
+        )
+        for key, xy in pos.items()
+    }
+
+
+def _hsl(index: int, total: int) -> str:
+    hue = int(360 * index / max(1, total))
+    return f"hsl({hue},65%,58%)"
+
+
+def _node_radius(salience: float, min_sal: float, max_sal: float) -> float:
+    return round(2.5 + 6.5 * ((salience - min_sal) / (max_sal - min_sal + 1e-9)), 1)
+
+
+def _as_float(value: object) -> float:
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _normalized_embedding(value: object) -> NDArray[np.float32] | None:
+    if not isinstance(value, bytes | bytearray | memoryview):
+        return None
+    try:
+        emb = np.frombuffer(cast(Any, value), dtype=np.float32).copy()
+    except Exception:
+        return None
+    norm = float(np.linalg.norm(emb))
+    if norm <= 0:
+        return None
+    return emb / norm
+
+
+def _dense_sim(left: object, right: object) -> float:
+    if not isinstance(left, np.ndarray) or not isinstance(right, np.ndarray):
+        return 0.0
+    left_arr = cast(Any, left)
+    right_arr = cast(Any, right)
+    if left_arr.shape != right_arr.shape:
+        return 0.0
+    return round(float(np.dot(left_arr, right_arr)), 3)
+
+
+def _chunks(items: list[str], size: int) -> list[list[str]]:
+    return [items[index:index + size] for index in range(0, len(items), size)]
+
+
+def _clean_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def _clip(value: str, limit: int) -> str:
+    text = _clean_text(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+as_float = _as_float
+as_int = _as_int
+chunks = _chunks
+clean_text = _clean_text
+clip = _clip
+community_legend = _community_legend
+dense_sim = _dense_sim
+graph_from_edges = _graph_from_edges
+layout_graph = _layout_graph
+node_radius = _node_radius
+normalize_positions = _normalize_positions
+normalized_embedding = _normalized_embedding

--- a/plugins/akasha/graph_snapshot.py
+++ b/plugins/akasha/graph_snapshot.py
@@ -67,10 +67,6 @@ def read_graph_signature(akasha_db_path: Path) -> GraphSnapshotSignature:
         max_node_updated_at=str(node_row[1] or ""),
         max_edge_last_used_ts=float(edge_row[1] or 0.0),
     )
-    try:
-        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
-    except Exception:
-        return None
 
 
 def build_snapshot_to_file(
@@ -80,13 +76,16 @@ def build_snapshot_to_file(
     snapshot_path: Path,
     config: GraphSnapshotConfig | None = None,
 ) -> dict[str, Any]:
+    import uuid
+    prev_snapshot = load_snapshot(snapshot_path)
     payload = build_snapshot(
         akasha_db_path=akasha_db_path,
         sessions_db_path=sessions_db_path,
         config=config or GraphSnapshotConfig(),
+        prev_snapshot=prev_snapshot,
     )
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = snapshot_path.with_suffix(snapshot_path.suffix + ".tmp")
+    tmp_path = snapshot_path.with_name(snapshot_path.name + f".{uuid.uuid4().hex}.tmp")
     _ = tmp_path.write_text(
         json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
         encoding="utf-8",
@@ -100,6 +99,7 @@ def build_snapshot(
     akasha_db_path: Path,
     sessions_db_path: Path,
     config: GraphSnapshotConfig,
+    prev_snapshot: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     start = time.perf_counter()
     signature = read_graph_signature(akasha_db_path)
@@ -126,8 +126,16 @@ def build_snapshot(
         layout_edge_limit=config.layout_edge_limit,
     )
     layout_graph = _graph_from_edges(layout_edges)
-    pos, node_to_comm, comms = _layout_graph(layout_graph)
-    _place_missing_nodes(pos, node_to_comm, comms, nodes_by_key, all_edges)
+
+    incremental = _incremental_layout_from_snapshot(prev_snapshot, nodes_by_key, all_edges)
+    if incremental is None:
+        pos, node_to_comm, comms = _layout_graph(layout_graph)
+        _place_missing_nodes(pos, node_to_comm, comms, nodes_by_key, all_edges)
+        coords = _normalize_positions(pos)
+        layout_mode = "full"
+    else:
+        coords, node_to_comm, comms = incremental
+        layout_mode = "incremental"
 
     full_graph = _graph_from_edges(all_edges)
     colors, legend = _community_legend(
@@ -137,7 +145,6 @@ def build_snapshot(
         nodes_by_key,
         texts,
     )
-    coords = _normalize_positions(pos)
     payload_nodes = _payload_nodes(nodes_by_key, texts, coords, node_to_comm, colors)
     node_id = {str(node["id"]): index for index, node in enumerate(payload_nodes)}
     payload_edges = _payload_edges(all_edges, node_id, nodes_by_key)
@@ -157,6 +164,7 @@ def build_snapshot(
             "min_co_count": config.min_co_count,
             "layout_min_co_count": config.layout_min_co_count,
             "layout_edge_limit": config.layout_edge_limit,
+            "layout_mode": layout_mode,
         },
     }
 
@@ -258,9 +266,8 @@ def _layout_graph(
         return {}, {}, []
     if graph.number_of_edges() == 0:
         nodes = [str(node) for node in graph.nodes()]
-        return _spiral_positions(nodes), {key: index for index, key in enumerate(nodes)}, [
-            {key} for key in nodes
-        ]
+        return _spiral_positions(nodes), {key: index for index, key in enumerate(nodes)}, [{key} for key in nodes]
+
     comms = [
         set(str(item) for item in comm)
         for comm in nx.algorithms.community.greedy_modularity_communities(graph, weight="weight")
@@ -291,6 +298,94 @@ def _layout_graph(
             lx, ly = local[node]
             pos[node] = (cx + lx * radius, cy + ly * radius)
     return pos, node_to_comm, comms
+
+
+def _incremental_layout_from_snapshot(
+    snapshot: dict[str, Any] | None,
+    nodes_by_key: dict[str, dict[str, object]],
+    edges: list[EdgeRow],
+) -> tuple[dict[str, tuple[float, float]], dict[str, int], list[set[str]]] | None:
+    if not snapshot:
+        return None
+    raw_nodes = snapshot.get("nodes")
+    if not isinstance(raw_nodes, list):
+        return None
+
+    coords: dict[str, tuple[float, float]] = {}
+    node_to_comm: dict[str, int] = {}
+    for raw_node_item in cast(list[object], raw_nodes):
+        if not isinstance(raw_node_item, dict):
+            continue
+        raw_node = cast(dict[str, object], raw_node_item)
+        key = str(raw_node.get("id") or "")
+        if key not in nodes_by_key:
+            continue
+        x = _as_float(raw_node.get("x"))
+        y = _as_float(raw_node.get("y"))
+        coords[key] = (x, y)
+        node_to_comm[key] = _as_int(raw_node.get("g"))
+    if not coords:
+        return None
+
+    comms = _communities_from_map(node_to_comm, nodes_by_key)
+    _place_incremental_nodes(coords, node_to_comm, comms, nodes_by_key, edges)
+    return coords, node_to_comm, comms
+
+
+def _communities_from_map(
+    node_to_comm: dict[str, int],
+    nodes_by_key: dict[str, dict[str, object]],
+) -> list[set[str]]:
+    max_comm = max(node_to_comm.values(), default=-1)
+    comms: list[set[str]] = [set() for _ in range(max_comm + 1)]
+    for key in nodes_by_key:
+        comm = node_to_comm.get(key)
+        if comm is None:
+            continue
+        if comm >= len(comms):
+            for _ in range(comm - len(comms) + 1):
+                comms.append(set())
+        comms[comm].add(key)
+    return comms
+
+
+def _place_incremental_nodes(
+    coords: dict[str, tuple[float, float]],
+    node_to_comm: dict[str, int],
+    comms: list[set[str]],
+    nodes_by_key: dict[str, dict[str, object]],
+    edges: list[EdgeRow],
+) -> None:
+    missing = [key for key in nodes_by_key if key not in coords]
+    if not missing:
+        return
+    neighbors: dict[str, list[tuple[str, EdgeRow]]] = {}
+    for edge in edges:
+        neighbors.setdefault(edge.src, []).append((edge.dst, edge))
+        neighbors.setdefault(edge.dst, []).append((edge.src, edge))
+
+    next_comm = len(comms)
+    for index, key in enumerate(missing):
+        parent = _best_positioned_neighbor(neighbors.get(key, []), coords)
+        if parent is None:
+            x, y = _normalized_spiral_point(index, len(missing))
+            comm_id = next_comm
+            next_comm += 1
+            comms.append({key})
+        else:
+            parent_key, rank = parent
+            base_x, base_y = coords[parent_key]
+            angle = (rank * 2.399963229728653) + index * 0.17
+            radius = 9.0 + 2.2 * math.sqrt(index % 23)
+            x = min(1000.0, max(0.0, base_x + math.cos(angle) * radius))
+            y = min(1000.0, max(0.0, base_y + math.sin(angle) * radius))
+            comm_id = node_to_comm.get(parent_key, next_comm)
+            if comm_id == next_comm:
+                next_comm += 1
+                comms.append(set())
+            comms[comm_id].add(key)
+        coords[key] = (round(x, 1), round(y, 1))
+        node_to_comm[key] = comm_id
 
 
 def _place_missing_nodes(
@@ -432,7 +527,7 @@ def _community_legend(
     texts: dict[str, str],
 ) -> tuple[dict[int, str], list[dict[str, object]]]:
     big_ids = [index for index, comm in enumerate(comms) if len(comm) >= BIG_COMMUNITY_SIZE]
-    colors = {comm_id: _hsl(rank, len(big_ids)) for rank, comm_id in enumerate(big_ids)}
+    colors = {comm_id: _community_color(rank) for rank, comm_id in enumerate(big_ids)}
     legend: list[dict[str, object]] = []
     for comm_id in big_ids[:30]:
         comm = comms[comm_id]
@@ -478,6 +573,13 @@ def _loose_spiral_point(index: int) -> tuple[float, float]:
     return radius * math.cos(angle), radius * math.sin(angle)
 
 
+def _normalized_spiral_point(index: int, total: int) -> tuple[float, float]:
+    golden = math.pi * (3 - math.sqrt(5))
+    radius = min(460.0, 30.0 + 430.0 * math.sqrt((index + 1) / max(1, total)))
+    angle = index * golden
+    return 500.0 + radius * math.cos(angle), 500.0 + radius * math.sin(angle)
+
+
 def _island_centers(sizes: list[int]) -> dict[int, tuple[float, float]]:
     golden = math.pi * (3 - math.sqrt(5))
     centers: dict[int, tuple[float, float]] = {}
@@ -509,9 +611,11 @@ def _normalize_positions(pos: dict[str, tuple[float, float]]) -> dict[str, tuple
     }
 
 
-def _hsl(index: int, total: int) -> str:
-    hue = int(360 * index / max(1, total))
-    return f"hsl({hue},65%,58%)"
+def _community_color(index: int) -> str:
+    hue = int((index * 137.508 + (index // 12) * 17) % 360)
+    saturation = [72, 62, 82, 68][index % 4]
+    lightness = [58, 66, 52, 72, 60, 48][(index // 4) % 6]
+    return f"hsl({hue},{saturation}%,{lightness}%)"
 
 
 def _node_radius(salience: float, min_sal: float, max_sal: float) -> float:

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -32,6 +32,7 @@ from plugins.akasha.core import (
     graph_seed_keys_from_snapshot,
     parse_turn_key,
     parse_ts_unix,
+    reinforced_activation_items,
     turn_key,
 )
 from plugins.akasha.engine import (
@@ -127,6 +128,7 @@ class AkashaReplayRuntime:
         self._message_turn_keys = dict(message_turn_keys)
         # turn_key -> gain_boost：来自 messages.extra["akasha_reinforce"]，重放时定向加厚该轮边。
         self._reinforce_boosts = dict(reinforce_boosts or {})
+        self._prev_activation_by_session: dict[str, list[AkashaCandidate]] = {}
 
     # 按线上状态机回放一轮：先激活旧图，再提交当前 turn。
     def replay_turn(
@@ -245,22 +247,30 @@ class AkashaReplayRuntime:
         if current_key and activation_items:
             trigger = next((item.message for item in items if item.message.role == "user"), items[0].message)
             ts = parse_ts_unix(trigger.ts)
-            reinforced = self._reinforce_boosts.get(current_key, 1.0) > 1.0
+            reinforce_boost = self._reinforce_boosts.get(current_key, 1.0)
             trigger_emb = next(
                 (item.embedding for item in items if item.message.role == "user"),
                 items[0].embedding,
             )
             query_residual = self._query_residual(trigger_emb, current_key)
+            edge_items = reinforced_activation_items(
+                activation_items,
+                self._prev_activation_by_session.get(trigger.session_key, []),
+                reinforce_boost,
+            )
             self._store.upsert_edges(
                 activation_edge_updates(
                     current_key,
-                    activation_items,
+                    edge_items,
                     ts,
                     query_residual=query_residual,
-                    reinforced=reinforced,
+                    reinforce_boost=reinforce_boost,
                 )
             )
             self._store.insert_activation_events(_activation_events(trigger, activation_items))
+        session_key = next((item.message.session_key for item in items if item.message.session_key), "")
+        if session_key and activation_items:
+            self._prev_activation_by_session[session_key] = list(activation_items)
         return current_key
 
     # ν_turn = 1 − max_{j<i} cos(query, prior_j)²；当前 turn 自身排除。

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -386,6 +386,89 @@ def test_replay_and_runtime_use_same_directional_stdp_edges(tmp_path: Path) -> N
         runtime_store.close()
 
 
+def test_replay_and_runtime_reinforce_previous_activation_cluster(tmp_path: Path) -> None:
+    prev = _candidate("s:0", 0.8)
+    current = _candidate("s:2", 0.7)
+    ts = QUERY_TS.timestamp()
+    replay_store = AkashaStore(tmp_path / "replay.db")
+    runtime_store = AkashaStore(tmp_path / "runtime.db")
+    try:
+        with closing(sqlite3.connect(":memory:")) as source_db:
+            replay = AkashaReplayRuntime(
+                store=replay_store,
+                config=AkashaConfig(),
+                source_db_path=tmp_path / "sessions.db",
+                source_cursor=source_db.cursor(),
+                message_embeddings={},
+                message_turn_keys={},
+                reinforce_boosts={"s:4": 3.0},
+            )
+            replay.commit_turn(
+                [ReplayMessage(SourceMessage("m2", "s", 2, "user", "beta", QUERY_TS.isoformat()), [1.0, 0.0])],
+                [prev],
+            )
+            replay.commit_turn(
+                [ReplayMessage(SourceMessage("m4", "s", 4, "user", "gamma", QUERY_TS.isoformat()), [1.0, 0.0])],
+                [current],
+            )
+
+        engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+        engine._store = runtime_store
+        engine._graph_lock = threading.RLock()
+        engine._edges = {}
+        engine._edges_meta = {}
+        engine._edges_by_src = {}
+        engine._fan = {}
+        engine._nodes = {}
+        engine._prev_activation_by_session = {}
+        first_key = runtime_store.upsert_message_node(
+            SourceMessage("m2", "s", 2, "user", "beta", QUERY_TS.isoformat()),
+            [1.0, 0.0],
+        )
+        first_node = runtime_store.get_node(first_key)
+        assert first_node is not None
+        engine._nodes[first_key] = first_node
+        engine._commit_pending_activation(
+            "s:2",
+            PendingActivation(
+                query_id="s:2",
+                seq=2,
+                ts=ts,
+                items=[prev],
+                query_vec=np.array([1.0, 0.0], dtype=np.float32),
+            ),
+            "s",
+        )
+        second_key = runtime_store.upsert_message_node(
+            SourceMessage("m4", "s", 4, "user", "gamma", QUERY_TS.isoformat()),
+            [1.0, 0.0],
+        )
+        second_node = runtime_store.get_node(second_key)
+        assert second_node is not None
+        engine._nodes[second_key] = second_node
+        engine._commit_pending_activation(
+            "s:4",
+            PendingActivation(
+                query_id="s:4",
+                seq=4,
+                ts=ts,
+                items=[current],
+                query_vec=np.array([1.0, 0.0], dtype=np.float32),
+            ),
+            "s",
+            3.0,
+        )
+
+        replay_edges = replay_store.load_edges()
+        runtime_edges = runtime_store.load_edges()
+        assert replay_edges == pytest.approx(runtime_edges)
+        assert ("s:0", "s:4") in replay_edges
+        assert ("s:4", "s:0") in replay_edges
+    finally:
+        replay_store.close()
+        runtime_store.close()
+
+
 def test_replay_writes_query_log_with_activation_items(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 问题

Akasha Graph 首次打开时需要生成全量 snapshot，用户会看到长时间空白或旧状态文案；同时全量图重建后，社区颜色按连续 HSL 分配，视觉上容易重复。旧的全量布局如果每次重跑，也会让已有节点位置跳动。

## 改动

- 新增 Akasha Graph 全局 snapshot 的增量布局路径：无旧 snapshot 时保留原全量布局算法，有旧 snapshot 时复用旧节点坐标和社区，只摆放新增节点。
- 优化社区颜色分配：使用黄金角分散色相，并交替饱和度和明度，减少相邻社区颜色重复感。
- 在图谱面板首次等待 snapshot 时显示居中加载卡片、进度条和等待状态，snapshot 就绪后自动隐藏。
- 保留现有图谱交互、搜索、图例和缩放行为。

## 影响

首次进入仍会触发全量 snapshot 生成，但用户能看到明确加载状态。之后读取已有 snapshot 时直接展示图谱；增量重建时旧节点位置保持稳定。

## 验证

- `npm run typecheck`
- `npm run build:dashboard`
- `pyright plugins/akasha/graph_snapshot.py plugins/akasha/dashboard.py`
- `python -m py_compile plugins/akasha/graph_snapshot.py plugins/akasha/dashboard.py`
- 真实 Akasha DB 临时构建验证：首次 `layout_mode=full`，二次 `layout_mode=incremental`，旧节点坐标变化为 `0`。
- 真实 Akasha DB 调色验证：图例前 30 个颜色唯一数为 `30`。