### PR TITLE
fix(dashboard): scan installed plugin panels for styles

### DIFF
--- a/frontend/dashboard/tailwind.config.ts
+++ b/frontend/dashboard/tailwind.config.ts
@@ -15,6 +15,7 @@ export default {
     resolve(here, "index.html"),
     resolve(here, "src/**/*.{ts,tsx}"),
     resolve(repoRoot, "plugins/**/*.{ts,tsx}"),
+    resolve(repoRoot, "akashic-plugin/**/*.{ts,tsx}"),
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Problem
After built-in plugins moved out to the installed plugin directory, Tailwind still only scanned the in-repo `plugins/**/*` sources. Utility classes used only by installed plugin panels were purged, which broke observe, KVCache, and meme dashboard layouts.

## Change
- Include `akashic-plugin/**/*.{ts,tsx}` in the dashboard Tailwind content scan.

## Verification
- `npm run build:dashboard` -> passed
- Confirmed key plugin layout classes are present in built CSS: `grid-cols-4`, `p-6`, `max-h-[42vh]`, `items-end`.