### PR TITLE
回传 feed 兴趣反馈并移除 ack TTL

### DIFF
--- a/docker/debug/proactive_feed_feedback_probe.py
+++ b/docker/debug/proactive_feed_feedback_probe.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from proactive_v2.mcp_sources import McpClientPool
+from proactive_v2.modules_source import McpGatewaySource
+
+
+EVENT_ID = "probe_interest_feedback"
+
+
+def _write_sources(workspace: Path) -> None:
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "proactive_sources.json").write_text(
+        json.dumps(
+            {
+                "sources": [
+                    {
+                        "server": "feed",
+                        "channel": "content",
+                        "get_tool": "get_proactive_events",
+                        "ack_tool": "acknowledge_events",
+                        "enabled": True,
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _seed_feed_db(feed_db: Path) -> None:
+    feed_db.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    conn = sqlite3.connect(feed_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS items (
+                event_id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                source_name TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                title TEXT,
+                content TEXT NOT NULL,
+                url TEXT,
+                author TEXT,
+                published_at TEXT,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                emitted_at TEXT,
+                content_hash TEXT NOT NULL,
+                interest_ok INTEGER,
+                interest_scored_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS acked_items (
+                event_id TEXT PRIMARY KEY,
+                acked_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute("DELETE FROM acked_items WHERE event_id = ?", (EVENT_ID,))
+        conn.execute("DELETE FROM items WHERE event_id = ?", (EVENT_ID,))
+        conn.execute(
+            """
+            INSERT INTO items (
+                event_id, source_id, source_name, source_type, title, content,
+                url, author, published_at, first_seen_at, last_seen_at, emitted_at,
+                content_hash, interest_ok, interest_scored_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL)
+            """,
+            (
+                EVENT_ID,
+                "probe-source",
+                "Probe Feed",
+                "rss",
+                "Probe item",
+                "This item exists only for proactive feedback verification.",
+                "https://example.com/probe-interest-feedback",
+                "probe",
+                now,
+                now,
+                now,
+                "probe-hash",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_interest(feed_db: Path) -> tuple[int | None, str | None]:
+    conn = sqlite3.connect(feed_db)
+    try:
+        row = conn.execute(
+            "SELECT interest_ok, interest_scored_at FROM items WHERE event_id = ?",
+            (EVENT_ID,),
+        ).fetchone()
+        if row is None:
+            raise AssertionError("probe item disappeared")
+        return row[0], row[1]
+    finally:
+        conn.close()
+
+
+async def _run(args: argparse.Namespace) -> None:
+    workspace = args.workspace
+    feed_root = args.feed_root
+    data_dir = args.data_dir
+    feed_db = data_dir / "feed_mcp.sqlite3"
+    python = feed_root / "mcp" / ".venv" / "bin" / "python"
+    if not python.exists():
+        raise SystemExit(f"feed MCP venv missing: {python}")
+    _write_sources(workspace)
+    _seed_feed_db(feed_db)
+
+    pool = McpClientPool(
+        workspace,
+        extra_server_configs={
+            "feed": {
+                "command": [
+                    "bash",
+                    "-lc",
+                    f"cd {feed_root} && exec {python} mcp/run_mcp.py",
+                ],
+                "env": {"AKA_PLUGIN_DATA_DIR": str(data_dir)},
+            }
+        },
+    )
+    await pool.connect_all()
+    try:
+        source = McpGatewaySource(pool, content_limit=5)
+        events = await source.feed_fn(limit=5)
+        if not any(item.get("event_id") == EVENT_ID for item in events):
+            raise AssertionError(f"probe item not fetched: {events}")
+
+        await source.ack_fn(f"feed:{EVENT_ID}", 24, "interesting")
+        interest_ok, scored_at = _read_interest(feed_db)
+        if interest_ok != 1 or not scored_at:
+            raise AssertionError(f"interesting ack not persisted: {(interest_ok, scored_at)}")
+
+        await source.ack_fn(f"feed:{EVENT_ID}", 720, "not_interesting")
+        interest_ok, scored_at = _read_interest(feed_db)
+        if interest_ok != 0 or not scored_at:
+            raise AssertionError(f"not_interesting ack not persisted: {(interest_ok, scored_at)}")
+
+        print(json.dumps({"ok": True, "event_id": EVENT_ID, "interest_ok": interest_ok}, ensure_ascii=False))
+    finally:
+        await pool.disconnect_all()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, default=Path(os.environ.get("AKASHIC_DEBUG_WORKSPACE", "/sandbox/workspace")))
+    parser.add_argument("--feed-root", type=Path, default=Path.home() / ".akashic-plugin" / "cache" / "lab" / "feed" / "0.1.0")
+    parser.add_argument("--data-dir", type=Path, default=Path.home() / ".akashic-plugin" / "data" / "feed-lab")
+    asyncio.run(_run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -341,10 +341,14 @@ async def acknowledge_events_async(
 async def acknowledge_content_entries_async(
     pool: McpClientPool,
     entries: list[tuple[str, str]],
+    *,
     ttl_hours: int | None = None,
+    feedback: str,
 ) -> None:
     if not entries:
         return
+    if feedback not in {"interesting", "not_interesting"}:
+        raise ValueError(f"invalid feedback: {feedback}")
     ack_map = _build_ack_map(_load_sources(pool._workspace))
     for source_key, item_id in entries:
         if not source_key.startswith("mcp:"):
@@ -360,6 +364,7 @@ async def acknowledge_content_entries_async(
         args: dict = {"event_ids": ids}
         if ttl_hours is not None and ttl_hours > 0:
             args["ttl_hours"] = ttl_hours
+        args["feedback"] = feedback
         try:
             await pool.call(server, ack_tool, args)
         except Exception as e:

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -342,7 +342,6 @@ async def acknowledge_content_entries_async(
     pool: McpClientPool,
     entries: list[tuple[str, str]],
     *,
-    ttl_hours: int | None = None,
     feedback: str,
 ) -> None:
     if not entries:
@@ -362,8 +361,6 @@ async def acknowledge_content_entries_async(
         if not ids:
             continue
         args: dict = {"event_ids": ids}
-        if ttl_hours is not None and ttl_hours > 0:
-            args["ttl_hours"] = ttl_hours
         args["feedback"] = feedback
         try:
             await pool.call(server, ack_tool, args)

--- a/proactive_v2/modules_resolve.py
+++ b/proactive_v2/modules_resolve.py
@@ -87,7 +87,7 @@ async def ack_discarded(ctx: AgentTickContext, ack_fn: Any) -> None:
     if ack_fn is None:
         return
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL)
+        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
 
 
 async def ack_post_guard_fail(
@@ -108,18 +108,18 @@ async def ack_post_guard_fail(
         if alert_ack_fn is not None:
             await alert_ack_fn(key)
         else:
-            await ack_fn(key, _POST_GUARD_ACK_TTL)
+            await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
 
     for key in cited_set - fetched_alert_keys:
-        await ack_fn(key, _POST_GUARD_ACK_TTL)
+        await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
     for key in cited_set & fetched_alert_keys:
         await _ack_alert(key)
     for key in fetched_alert_keys - cited_set:
         await _ack_alert(key)
     for key in (ctx.interesting_item_ids - cited_set) - fetched_alert_keys:
-        await ack_fn(key, _POST_GUARD_ACK_TTL)
+        await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL)
+        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
 
 
 async def ack_on_success(
@@ -140,16 +140,16 @@ async def ack_on_success(
     }
     cited_set = set(ctx.cited_item_ids)
     for key in cited_set & fetched_content_keys:
-        await ack_fn(key, _CITED_ACK_TTL)
+        await ack_fn(key, _CITED_ACK_TTL, "interesting")
     for key in cited_set & fetched_alert_keys:
         if alert_ack_fn is not None:
             await alert_ack_fn(key)
         else:
-            await ack_fn(key, _CITED_ACK_TTL)
+            await ack_fn(key, _CITED_ACK_TTL, "interesting")
     for key in (ctx.interesting_item_ids - cited_set) - fetched_alert_keys:
-        await ack_fn(key, _UNCITED_ACK_TTL)
+        await ack_fn(key, _UNCITED_ACK_TTL, "interesting")
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL)
+        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
 
 
 async def _mark_delivery(

--- a/proactive_v2/modules_resolve.py
+++ b/proactive_v2/modules_resolve.py
@@ -13,12 +13,6 @@ from proactive_v2.context import AgentTickContext
 
 logger = logging.getLogger(__name__)
 
-_CITED_ACK_TTL = 168
-_UNCITED_ACK_TTL = 24
-_POST_GUARD_ACK_TTL = 24
-_DISCARDED_ACK_TTL = 720
-
-
 @dataclass
 class ResolveResult:
     action: str
@@ -87,7 +81,7 @@ async def ack_discarded(ctx: AgentTickContext, ack_fn: Any) -> None:
     if ack_fn is None:
         return
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
+        await ack_fn(key, "not_interesting")
 
 
 async def ack_post_guard_fail(
@@ -108,18 +102,18 @@ async def ack_post_guard_fail(
         if alert_ack_fn is not None:
             await alert_ack_fn(key)
         else:
-            await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
+            await ack_fn(key, "interesting")
 
     for key in cited_set - fetched_alert_keys:
-        await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
+        await ack_fn(key, "interesting")
     for key in cited_set & fetched_alert_keys:
         await _ack_alert(key)
     for key in fetched_alert_keys - cited_set:
         await _ack_alert(key)
     for key in (ctx.interesting_item_ids - cited_set) - fetched_alert_keys:
-        await ack_fn(key, _POST_GUARD_ACK_TTL, "interesting")
+        await ack_fn(key, "interesting")
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
+        await ack_fn(key, "not_interesting")
 
 
 async def ack_on_success(
@@ -140,16 +134,16 @@ async def ack_on_success(
     }
     cited_set = set(ctx.cited_item_ids)
     for key in cited_set & fetched_content_keys:
-        await ack_fn(key, _CITED_ACK_TTL, "interesting")
+        await ack_fn(key, "interesting")
     for key in cited_set & fetched_alert_keys:
         if alert_ack_fn is not None:
             await alert_ack_fn(key)
         else:
-            await ack_fn(key, _CITED_ACK_TTL, "interesting")
+            await ack_fn(key, "interesting")
     for key in (ctx.interesting_item_ids - cited_set) - fetched_alert_keys:
-        await ack_fn(key, _UNCITED_ACK_TTL, "interesting")
+        await ack_fn(key, "interesting")
     for key in ctx.discarded_item_ids:
-        await ack_fn(key, _DISCARDED_ACK_TTL, "not_interesting")
+        await ack_fn(key, "not_interesting")
 
 
 async def _mark_delivery(

--- a/proactive_v2/modules_source.py
+++ b/proactive_v2/modules_source.py
@@ -122,7 +122,7 @@ class McpGatewaySource:
             return []
         return cast(list[dict[str, object]], rows)
 
-    async def ack_fn(self, compound_key: str, ttl_hours: int, feedback: str) -> None:
+    async def ack_fn(self, compound_key: str, feedback: str) -> None:
         parts = compound_key.split(":", 1)
         if len(parts) != 2:
             return
@@ -131,7 +131,6 @@ class McpGatewaySource:
         await mcp_sources.acknowledge_content_entries_async(
             self._pool,
             [(source_key, item_id)],
-            ttl_hours=ttl_hours,
             feedback=feedback,
         )
 

--- a/proactive_v2/modules_source.py
+++ b/proactive_v2/modules_source.py
@@ -122,7 +122,7 @@ class McpGatewaySource:
             return []
         return cast(list[dict[str, object]], rows)
 
-    async def ack_fn(self, compound_key: str, ttl_hours: int) -> None:
+    async def ack_fn(self, compound_key: str, ttl_hours: int, feedback: str) -> None:
         parts = compound_key.split(":", 1)
         if len(parts) != 2:
             return
@@ -132,6 +132,7 @@ class McpGatewaySource:
             self._pool,
             [(source_key, item_id)],
             ttl_hours=ttl_hours,
+            feedback=feedback,
         )
 
     async def alert_ack_fn(self, compound_key: str) -> None:

--- a/proactive_v2/tools.py
+++ b/proactive_v2/tools.py
@@ -37,7 +37,7 @@ class ToolDeps:
     web_search_tool: Any = None         # WebSearchTool（可选）
     memory: "MemoryProfileApi | MemoryRetrievalApi | None" = None
     recent_chat_fn: Any = None          # async (n) -> list[dict]
-    ack_fn: Any = None                  # async (compound_key: str, ttl_hours: int) -> None
+    ack_fn: Any = None                  # async (compound_key: str, feedback: str) -> None
     alert_ack_fn: Any = None            # async (compound_key: str) -> None
     max_chars: int = 8_000
 
@@ -133,7 +133,7 @@ TOOL_SCHEMAS: list[dict] = [
             (
                 "将指定 item 明确标记为「感兴趣」。只用于你已单独评估且明确相关的条目，"
                 "不能因为其中一条相关就把整批不同主题内容一起标记。"
-                "被标记但未被 message_push.evidence 引用的条目将得到 24h ACK。"
+                "被标记但未被 message_push.evidence 引用的条目也会 ACK。"
                 "可选传 reason，简短说明为什么 interesting。"
             ),
             {"type": "object", "properties": {
@@ -150,7 +150,7 @@ TOOL_SCHEMAS: list[dict] = [
 
     _schema("mark_not_interesting",
             (
-                "将指定 item 标记为「本质上不感兴趣」（720h ACK，30天内不再出现）。\n"
+                "将指定 item 标记为「本质上不感兴趣」。\n"
                 "仅用于内容本身无价值；时机问题、抓取失败不得调用。"
                 "可选传 reason，简短说明为什么 not_interesting。"
             ),

--- a/tests/proactive_v2/conftest.py
+++ b/tests/proactive_v2/conftest.py
@@ -107,22 +107,19 @@ class FakeAckSink:
     """记录所有 ACK 调用。"""
 
     def __init__(self):
-        self.calls: list[tuple[str, int, str]] = []
+        self.calls: list[tuple[str, str]] = []
 
-    async def __call__(self, compound_key: str, ttl_hours: int, feedback: str) -> None:
-        self.calls.append((compound_key, ttl_hours, feedback))
+    async def __call__(self, compound_key: str, feedback: str) -> None:
+        self.calls.append((compound_key, feedback))
 
-    def acked(self, key: str, ttl: int) -> bool:
-        return any(k == key and t == ttl for k, t, _ in self.calls)
-
-    def ttls_for(self, key: str) -> list[int]:
-        return [ttl for k, ttl, _ in self.calls if k == key]
+    def acked(self, key: str) -> bool:
+        return any(k == key for k, _ in self.calls)
 
     def not_acked(self, key: str) -> bool:
-        return all(k != key for k, _, _ in self.calls)
+        return all(k != key for k, _ in self.calls)
 
     def all_keys(self) -> set[str]:
-        return {k for k, _, _ in self.calls}
+        return {k for k, _ in self.calls}
 
 
 # ── FakeAlertAckSink ─────────────────────────────────────────────────────

--- a/tests/proactive_v2/conftest.py
+++ b/tests/proactive_v2/conftest.py
@@ -104,25 +104,25 @@ class FakeRng:
 # ── FakeAckSink ──────────────────────────────────────────────────────────
 
 class FakeAckSink:
-    """记录所有 ACK 调用的 (compound_key, ttl_hours) 对。"""
+    """记录所有 ACK 调用。"""
 
     def __init__(self):
-        self.calls: list[tuple[str, int]] = []
+        self.calls: list[tuple[str, int, str]] = []
 
-    async def __call__(self, compound_key: str, ttl_hours: int) -> None:
-        self.calls.append((compound_key, ttl_hours))
+    async def __call__(self, compound_key: str, ttl_hours: int, feedback: str) -> None:
+        self.calls.append((compound_key, ttl_hours, feedback))
 
     def acked(self, key: str, ttl: int) -> bool:
-        return (key, ttl) in self.calls
+        return any(k == key and t == ttl for k, t, _ in self.calls)
 
     def ttls_for(self, key: str) -> list[int]:
-        return [ttl for k, ttl in self.calls if k == key]
+        return [ttl for k, ttl, _ in self.calls if k == key]
 
     def not_acked(self, key: str) -> bool:
-        return all(k != key for k, _ in self.calls)
+        return all(k != key for k, _, _ in self.calls)
 
     def all_keys(self) -> set[str]:
-        return {k for k, _ in self.calls}
+        return {k for k, _, _ in self.calls}
 
 
 # ── FakeAlertAckSink ─────────────────────────────────────────────────────

--- a/tests/proactive_v2/test_post_guard_ack.py
+++ b/tests/proactive_v2/test_post_guard_ack.py
@@ -110,13 +110,13 @@ def test_delivery_key_falls_back_to_source_and_title_when_url_missing():
 # ── ack_discarded ─────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_ack_discarded_720h():
+async def test_ack_discarded():
     ctx = AgentTickContext()
     ctx.discarded_item_ids = {"feed-mcp:1", "feed-mcp:2"}
     sink = FakeAckSink()
     await ack_discarded(ctx, sink)
-    assert sink.acked("feed-mcp:1", 720)
-    assert sink.acked("feed-mcp:2", 720)
+    assert sink.acked("feed-mcp:1")
+    assert sink.acked("feed-mcp:2")
 
 
 @pytest.mark.asyncio
@@ -147,33 +147,33 @@ async def test_ack_discarded_none_ack_fn_no_error():
 # ── ack_post_guard_fail ───────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_ack_post_guard_fail_cited_24h():
+async def test_ack_post_guard_fail_cited():
     ctx = AgentTickContext()
     ctx.cited_item_ids = ["feed-mcp:1"]
     ctx.interesting_item_ids = {"feed-mcp:1"}
     sink = FakeAckSink()
     await ack_post_guard_fail(ctx, sink)
-    assert sink.acked("feed-mcp:1", 24)
+    assert sink.acked("feed-mcp:1")
 
 
 @pytest.mark.asyncio
-async def test_ack_post_guard_fail_uncited_interesting_24h():
+async def test_ack_post_guard_fail_uncited_interesting():
     ctx = AgentTickContext()
     ctx.cited_item_ids = ["feed-mcp:1"]
     ctx.interesting_item_ids = {"feed-mcp:1", "feed-mcp:2"}  # feed-mcp:2 uncited
     sink = FakeAckSink()
     await ack_post_guard_fail(ctx, sink)
-    assert sink.acked("feed-mcp:2", 24)
+    assert sink.acked("feed-mcp:2")
 
 
 @pytest.mark.asyncio
-async def test_ack_post_guard_fail_discarded_720h():
+async def test_ack_post_guard_fail_discarded():
     ctx = AgentTickContext()
     ctx.cited_item_ids = []
     ctx.discarded_item_ids = {"feed-mcp:3"}
     sink = FakeAckSink()
     await ack_post_guard_fail(ctx, sink)
-    assert sink.acked("feed-mcp:3", 720)
+    assert sink.acked("feed-mcp:3")
 
 
 @pytest.mark.asyncio
@@ -184,15 +184,15 @@ async def test_ack_post_guard_fail_all_three_buckets():
     ctx.discarded_item_ids = {"feed-mcp:3"}
     sink = FakeAckSink()
     await ack_post_guard_fail(ctx, sink)
-    assert sink.acked("feed-mcp:1", 24)   # cited
-    assert sink.acked("feed-mcp:2", 24)   # uncited interesting
-    assert sink.acked("feed-mcp:3", 720)  # discarded
+    assert sink.acked("feed-mcp:1")
+    assert sink.acked("feed-mcp:2")
+    assert sink.acked("feed-mcp:3")
 
 
 # ── ack_on_success ────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_ack_on_success_content_cited_168h():
+async def test_ack_on_success_content_cited():
     ctx = AgentTickContext()
     ctx.fetched_contents = [{"id": "c1", "ack_server": "feed-mcp"}]
     ctx.fetched_alerts = []
@@ -200,11 +200,11 @@ async def test_ack_on_success_content_cited_168h():
     ctx.interesting_item_ids = {"feed-mcp:c1"}
     sink = FakeAckSink()
     await ack_on_success(ctx, sink)
-    assert sink.acked("feed-mcp:c1", 168)
+    assert sink.acked("feed-mcp:c1")
 
 
 @pytest.mark.asyncio
-async def test_ack_on_success_alert_cited_168h():
+async def test_ack_on_success_alert_cited():
     ctx = AgentTickContext()
     ctx.fetched_alerts = [{"id": "a1", "ack_server": "alert-mcp"}]
     ctx.fetched_contents = []
@@ -212,11 +212,11 @@ async def test_ack_on_success_alert_cited_168h():
     ctx.interesting_item_ids = {"alert-mcp:a1"}
     sink = FakeAckSink()
     await ack_on_success(ctx, sink)
-    assert sink.acked("alert-mcp:a1", 168)
+    assert sink.acked("alert-mcp:a1")
 
 
 @pytest.mark.asyncio
-async def test_ack_on_success_uncited_interesting_24h():
+async def test_ack_on_success_uncited_interesting():
     ctx = AgentTickContext()
     ctx.fetched_contents = [
         {"id": "c1", "ack_server": "feed-mcp"},
@@ -227,12 +227,12 @@ async def test_ack_on_success_uncited_interesting_24h():
     ctx.interesting_item_ids = {"feed-mcp:c1", "feed-mcp:c2"}  # c2 uncited
     sink = FakeAckSink()
     await ack_on_success(ctx, sink)
-    assert sink.acked("feed-mcp:c1", 168)   # cited → 168h
-    assert sink.acked("feed-mcp:c2", 24)    # uncited interesting → 24h
+    assert sink.acked("feed-mcp:c1")
+    assert sink.acked("feed-mcp:c2")
 
 
 @pytest.mark.asyncio
-async def test_ack_on_success_discarded_720h():
+async def test_ack_on_success_discarded():
     ctx = AgentTickContext()
     ctx.fetched_contents = [{"id": "c1", "ack_server": "feed-mcp"}]
     ctx.fetched_alerts = []
@@ -241,7 +241,7 @@ async def test_ack_on_success_discarded_720h():
     ctx.discarded_item_ids = {"feed-mcp:c99"}
     sink = FakeAckSink()
     await ack_on_success(ctx, sink)
-    assert sink.acked("feed-mcp:c99", 720)
+    assert sink.acked("feed-mcp:c99")
 
 
 @pytest.mark.asyncio
@@ -254,8 +254,8 @@ async def test_ack_on_success_split_alert_content_by_compound_key():
     ctx.interesting_item_ids = {"alert-mcp:42", "feed-mcp:42"}
     sink = FakeAckSink()
     await ack_on_success(ctx, sink)
-    assert sink.acked("alert-mcp:42", 168)
-    assert sink.acked("feed-mcp:42", 168)
+    assert sink.acked("alert-mcp:42")
+    assert sink.acked("feed-mcp:42")
 
 
 @pytest.mark.asyncio
@@ -332,7 +332,7 @@ async def test_delivery_dedupe_hit_prevents_send():
 
 
 @pytest.mark.asyncio
-async def test_delivery_dedupe_hit_acks_cited_24h():
+async def test_delivery_dedupe_hit_acks_cited():
     state = FakeStateStore()
     state.set_is_duplicate(True)
     event = {"id": "1", "ack_server": "feed-mcp"}
@@ -346,7 +346,7 @@ async def test_delivery_dedupe_hit_acks_cited_24h():
     )
     await run_proactive_pipeline(tick)
 
-    assert sink.acked("feed-mcp:1", 24)
+    assert sink.acked("feed-mcp:1")
 
 
 @pytest.mark.asyncio
@@ -384,7 +384,7 @@ async def test_message_dedupe_hit_prevents_send():
 
 
 @pytest.mark.asyncio
-async def test_message_dedupe_hit_acks_cited_24h():
+async def test_message_dedupe_hit_acks_cited():
     deduper = AsyncMock()
     deduper.is_duplicate = AsyncMock(return_value=(True, "dup"))
     event = {"id": "1", "ack_server": "feed-mcp"}
@@ -400,7 +400,7 @@ async def test_message_dedupe_hit_acks_cited_24h():
     )
     await run_proactive_pipeline(tick)
 
-    assert sink.acked("feed-mcp:1", 24)
+    assert sink.acked("feed-mcp:1")
 
 
 @pytest.mark.asyncio
@@ -469,7 +469,7 @@ async def test_send_success_marks_delivery():
 
 
 @pytest.mark.asyncio
-async def test_send_success_acks_content_168h():
+async def test_send_success_acks_content():
     event = {"id": "c1", "ack_server": "feed-mcp"}
     llm = FakeLLM([
         ("get_content_events", {}),
@@ -480,11 +480,11 @@ async def test_send_success_acks_content_168h():
         llm, tool_deps_extra={"feed_fn": AsyncMock(return_value=[event])}
     )
     await run_proactive_pipeline(tick)
-    assert sink.acked("feed-mcp:c1", 168)
+    assert sink.acked("feed-mcp:c1")
 
 
 @pytest.mark.asyncio
-async def test_send_success_acks_discarded_720h():
+async def test_send_success_acks_discarded():
     llm = FakeLLM([
         ("mark_not_interesting", {"item_ids": ["feed-mcp:bad"]}),
         ("message_push", {"message": "hi", "evidence": []}),
@@ -492,7 +492,7 @@ async def test_send_success_acks_discarded_720h():
     ])
     tick, sink = _make_pipeline_with_sink(llm)
     await run_proactive_pipeline(tick)
-    assert sink.acked("feed-mcp:bad", 720)
+    assert sink.acked("feed-mcp:bad")
 
 
 # ── send failure ──────────────────────────────────────────────────────────
@@ -529,7 +529,7 @@ async def test_send_failure_no_ack_cited():
 
 
 @pytest.mark.asyncio
-async def test_send_failure_acks_discarded_720h():
+async def test_send_failure_acks_discarded():
     sender = AsyncMock()
     sender.send.return_value = False
 
@@ -541,13 +541,13 @@ async def test_send_failure_acks_discarded_720h():
     tick, sink = _make_pipeline_with_sink(llm, sender=sender)
     await run_proactive_pipeline(tick)
 
-    assert sink.acked("feed-mcp:bad", 720)
+    assert sink.acked("feed-mcp:bad")
 
 
 # ── skip → only discarded ACK ─────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_skip_acks_discarded_720h():
+async def test_skip_acks_discarded():
     llm = FakeLLM([
         ("mark_not_interesting", {"item_ids": ["feed-mcp:x"]}),
         ("finish_turn", {"decision": "skip", "reason": "no_content"}),
@@ -555,7 +555,7 @@ async def test_skip_acks_discarded_720h():
     tick, sink = _make_pipeline_with_sink(llm)
     await run_proactive_pipeline(tick)
 
-    assert sink.acked("feed-mcp:x", 720)
+    assert sink.acked("feed-mcp:x")
 
 
 @pytest.mark.asyncio
@@ -664,12 +664,12 @@ async def test_context_only_not_marked_when_cited_ids_present():
 # ── cited vs discarded conflict ───────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_cited_wins_over_discarded_gets_168h_not_720h():
-    """先 mark_not_interesting 再 send_message → cited 优先，168h 而非 720h"""
+async def test_cited_wins_over_discarded_acks_once():
+    """先 mark_not_interesting 再 send_message，cited 优先。"""
     event = {"id": "c1", "ack_server": "feed-mcp"}
     llm = FakeLLM([
         ("get_content_events", {}),
-        ("mark_not_interesting", {"item_ids": ["feed-mcp:c1"]}),  # discarded
+        ("mark_not_interesting", {"item_ids": ["feed-mcp:c1"]}),
         ("message_push", {"message": "actually good", "evidence": ["feed-mcp:c1"]}),  # cited wins
         ("finish_turn", {"decision": "reply"}),
     ])
@@ -678,9 +678,7 @@ async def test_cited_wins_over_discarded_gets_168h_not_720h():
     )
     await run_proactive_pipeline(tick)
 
-    # cited 优先 → 168h；不应有 720h
-    assert sink.acked("feed-mcp:c1", 168)
-    assert 720 not in sink.ttls_for("feed-mcp:c1")
+    assert sink.acked("feed-mcp:c1")
 
 
 # ── alert ACK 语义（§20：post-guard 失败时 alert 不 ACK）────────────────────
@@ -701,19 +699,19 @@ async def test_ack_post_guard_fail_alert_cited_uses_alert_ack_fn():
 
 @pytest.mark.asyncio
 async def test_ack_post_guard_fail_alert_cited_fallback_to_ack_fn_when_no_alert_ack_fn():
-    """post-guard 失败，无 alert_ack_fn 时，alert cited → ack_fn 24h（回退）。"""
+    """post-guard 失败，无 alert_ack_fn 时，alert cited → ack_fn（回退）。"""
     ctx = AgentTickContext()
     ctx.fetched_alerts = [{"id": "a1", "ack_server": "alert-mcp"}]
     ctx.cited_item_ids = ["alert-mcp:a1"]
     ctx.interesting_item_ids = {"alert-mcp:a1"}
     sink = FakeAckSink()
     await ack_post_guard_fail(ctx, sink)  # alert_ack_fn=None
-    assert sink.acked("alert-mcp:a1", 24)
+    assert sink.acked("alert-mcp:a1")
 
 
 @pytest.mark.asyncio
 async def test_ack_post_guard_fail_content_cited_and_alert_cited_separate_channels():
-    """post-guard 失败：content cited → ack_fn 24h；alert cited → alert_ack_fn。"""
+    """post-guard 失败：content cited → ack_fn；alert cited → alert_ack_fn。"""
     ctx = AgentTickContext()
     ctx.fetched_alerts = [{"id": "a1", "ack_server": "alert-mcp"}]
     ctx.fetched_contents = [{"id": "c1", "ack_server": "feed-mcp"}]
@@ -722,7 +720,7 @@ async def test_ack_post_guard_fail_content_cited_and_alert_cited_separate_channe
     sink = FakeAckSink()
     alert_sink = FakeAlertAckSink()
     await ack_post_guard_fail(ctx, sink, alert_ack_fn=alert_sink)
-    assert sink.acked("feed-mcp:c1", 24)           # content → 24h
+    assert sink.acked("feed-mcp:c1")
     assert alert_sink.called_with("alert-mcp:a1")  # alert → 独立通道
     assert sink.not_acked("alert-mcp:a1")           # alert 不重复走 ack_fn
 
@@ -807,7 +805,7 @@ async def test_message_dedupe_empty_list_when_no_fn():
 
 @pytest.mark.asyncio
 async def test_discarded_content_not_in_interesting():
-    """mark_not_interesting 后未 cite → discarded 720h，不应出现 24h"""
+    """mark_not_interesting 后未 cite → discarded ACK"""
     event = {"id": "c1", "ack_server": "feed-mcp"}
     llm = FakeLLM([
         ("get_content_events", {}),
@@ -819,8 +817,7 @@ async def test_discarded_content_not_in_interesting():
         llm, tool_deps_extra={"feed_fn": AsyncMock(return_value=[event])}
     )
     await run_proactive_pipeline(tick)
-    assert sink.acked("feed-mcp:c1", 720)
-    assert 24 not in sink.ttls_for("feed-mcp:c1")
+    assert sink.acked("feed-mcp:c1")
 
 
 # ── Fix 4: alert_ack_fn 独立通道（§20：成功时 alert cited 走独立 ack_fn）──
@@ -846,7 +843,7 @@ async def test_ack_on_success_alert_cited_calls_alert_ack_fn():
 
 @pytest.mark.asyncio
 async def test_ack_on_success_alert_ack_fn_none_falls_back_to_regular():
-    """alert_ack_fn=None 时，cited alert 回退到普通 ack_fn（168h）"""
+    """alert_ack_fn=None 时，cited alert 回退到普通 ack_fn"""
     from agent.core.proactive_turn import ack_on_success
     ctx = AgentTickContext()
     ctx.fetched_alerts = [{"id": "a1", "ack_server": "alert-mcp"}]
@@ -858,12 +855,12 @@ async def test_ack_on_success_alert_ack_fn_none_falls_back_to_regular():
     regular_sink = FakeAckSink()
     await ack_on_success(ctx, regular_sink, alert_ack_fn=None)
 
-    assert regular_sink.acked("alert-mcp:a1", 168)  # 回退到 168h
+    assert regular_sink.acked("alert-mcp:a1")
 
 
 @pytest.mark.asyncio
 async def test_ack_on_success_content_unaffected_by_alert_ack_fn():
-    """alert_ack_fn 独立时，content cited 仍走普通 ack_fn（168h）"""
+    """alert_ack_fn 独立时，content cited 仍走普通 ack_fn"""
     from agent.core.proactive_turn import ack_on_success
     ctx = AgentTickContext()
     ctx.fetched_alerts = []
@@ -876,7 +873,7 @@ async def test_ack_on_success_content_unaffected_by_alert_ack_fn():
     alert_sink = FakeAlertAckSink()
     await ack_on_success(ctx, regular_sink, alert_ack_fn=alert_sink)
 
-    assert regular_sink.acked("feed-mcp:c1", 168)
+    assert regular_sink.acked("feed-mcp:c1")
     assert alert_sink.keys == []  # alert_ack_fn 未被调用
 
 
@@ -945,8 +942,8 @@ def test_mark_interesting_tool_in_schema():
 
 
 @pytest.mark.asyncio
-async def test_mark_interesting_uncited_acks_24h_on_success():
-    """mark_interesting 后未引用 → 发送成功后 24h ACK（uncited interesting）"""
+async def test_mark_interesting_uncited_acks_on_success():
+    """mark_interesting 后未引用 → 发送成功后 ACK"""
     event = {"id": "c1", "ack_server": "feed-mcp"}
     llm = FakeLLM([
         ("get_content_events", {}),
@@ -958,7 +955,7 @@ async def test_mark_interesting_uncited_acks_24h_on_success():
         llm, tool_deps_extra={"feed_fn": AsyncMock(return_value=[event])}
     )
     await run_proactive_pipeline(tick)
-    assert sink.acked("feed-mcp:c1", 24)
+    assert sink.acked("feed-mcp:c1")
 
 
 @pytest.mark.asyncio

--- a/tests/proactive_v2/test_source_modules.py
+++ b/tests/proactive_v2/test_source_modules.py
@@ -77,12 +77,13 @@ async def test_mcp_gateway_source_ack_routes(monkeypatch):
     pool = object()
     source = McpGatewaySource(pool, content_limit=5)  # type: ignore[arg-type]
 
-    await source.ack_fn("feed-mcp:item-1", 720)
+    await source.ack_fn("feed-mcp:item-1", 720, "not_interesting")
     await source.alert_ack_fn("calendar:alert-1")
 
     content_ack.assert_awaited_once_with(
         pool,
         [("mcp:feed-mcp", "item-1")],
         ttl_hours=720,
+        feedback="not_interesting",
     )
     assert alert_ack.await_args.args[1] == [("calendar", "alert-1")]

--- a/tests/proactive_v2/test_source_modules.py
+++ b/tests/proactive_v2/test_source_modules.py
@@ -77,13 +77,12 @@ async def test_mcp_gateway_source_ack_routes(monkeypatch):
     pool = object()
     source = McpGatewaySource(pool, content_limit=5)  # type: ignore[arg-type]
 
-    await source.ack_fn("feed-mcp:item-1", 720, "not_interesting")
+    await source.ack_fn("feed-mcp:item-1", "not_interesting")
     await source.alert_ack_fn("calendar:alert-1")
 
     content_ack.assert_awaited_once_with(
         pool,
         [("mcp:feed-mcp", "item-1")],
-        ttl_hours=720,
         feedback="not_interesting",
     )
     assert alert_ack.await_args.args[1] == [("calendar", "alert-1")]

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -246,7 +246,7 @@ async def test_acknowledge_events_async_groups_by_ack_server(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_acknowledge_content_entries_async_passes_ttl_hours(monkeypatch):
+async def test_acknowledge_content_entries_async_passes_feedback(monkeypatch):
     monkeypatch.setattr(
         mcp_sources,
         "_load_sources",
@@ -259,10 +259,10 @@ async def test_acknowledge_content_entries_async_passes_ttl_hours(monkeypatch):
         ("mcp:feed", "evt-2"),
         ("rss:other", "skip"),
     ]
-    await mcp_sources.acknowledge_content_entries_async(cast(Any, pool), entries, ttl_hours=24)
+    await mcp_sources.acknowledge_content_entries_async(cast(Any, pool), entries, feedback="interesting")
 
     assert (
         "feed",
         "ack_content",
-        {"event_ids": ["evt-1", "evt-2"], "ttl_hours": 24},
+        {"event_ids": ["evt-1", "evt-2"], "feedback": "interesting"},
     ) in pool.calls


### PR DESCRIPTION
## 改动
- 回传 feed 内容的 interesting / not_interesting 标注
- 增加 feed 反馈沙盒验证
- 移除 proactive 内容反馈 ack TTL，由 feedmcp 统一管理 ack 过期

## 验证
- pytest -q tests/proactive_v2/test_agent_loop.py tests/proactive_v2/test_post_guard_ack.py tests/proactive_v2/test_source_modules.py tests/test_mcp_sources_async.py
- 105 passed