### PR TITLE
fix(proactive): normalize drift skill mounting

### DIFF
--- a/agent/core/drift_turn.py
+++ b/agent/core/drift_turn.py
@@ -168,7 +168,7 @@ class DriftTurnPipeline:
         # 2.4 构建初始 messages。
         messages: list[dict] = [
             {"role": "system", "content": self._build_system_prompt()},
-            await self._build_runtime_context_message(skills, connected_servers),
+            await self._build_runtime_context_message(skills, connected_servers, ctx=ctx),
         ]
 
         return tools, messages
@@ -499,6 +499,7 @@ class DriftTurnPipeline:
         self,
         skills: list[SkillMeta],
         connected_servers: set[str] | None = None,
+        ctx: AgentTickContext | None = None,
     ) -> dict[str, str]:
         """构建 runtime context frame，包含记忆、skill 列表、近期 run 记录。"""
 
@@ -600,7 +601,22 @@ class DriftTurnPipeline:
                     is_static=False,
                 )
             )
+        sections.append(
+            PromptSectionRender(
+                name="runtime_clock",
+                content=self._build_runtime_clock(ctx),
+                is_static=False,
+            )
+        )
         return build_context_frame_message(build_context_frame_content(sections))
+
+    def _build_runtime_clock(self, ctx: AgentTickContext | None) -> str:
+        now_utc = ctx.now_utc if ctx is not None else datetime.now(timezone.utc)
+        local_now = now_utc.astimezone()
+        return (
+            f"current_time_utc={now_utc.isoformat()}\n"
+            f"current_time_local={local_now.isoformat()}"
+        )
 
     def _build_selection_context(self, skills: list[SkillMeta]) -> str:
         if not skills:

--- a/agent/core/drift_turn.py
+++ b/agent/core/drift_turn.py
@@ -624,9 +624,10 @@ class DriftTurnPipeline:
 
         lines = [
             "下面按 skill 名称排列，顺序不代表优先级，也不是强制首选。",
-            "选择依据：status、上次 finish 时间、上次摘要、scratchpad、cursor、recent_raw_chat 和最近 runs。",
+            "选择依据：runtime_clock、status、上次 finish 时间、上次摘要、scratchpad、cursor、recent_raw_chat 和最近 runs。",
             "completed 表示上次小闭环已完成；paused 表示可接续；waiting 表示等待外部条件。",
             "local_context 只在 select_skill 后作为执行上下文参考，其中 scratchpad 是自然语言前情，cursor 是结构化游标。",
+            "判断“刚刚、今天、昨天、两天前”等相对时间时，必须以 runtime_clock 的完整日期和时间为准；只有时分没有日期时，不要断言它发生在今天。",
         ]
         for skill in skills:
             continuum = self._store.load_skill_continuum(skill.name)
@@ -680,7 +681,9 @@ class DriftTurnPipeline:
             f"{AKASHIC_IDENTITY}\n\n"
             f"{PERSONALITY_RULES}\n\n"
             "你现在有一段空闲时间（Drift 模式）。没有外部内容需要推送，\n"
-            "你可以自主决定做一件有意义的事。本轮记忆、skill 和工作区信息会在后续 system context frame 里提供。\n\n"
+            "这段时间更像一个人没有被叫住时的自处：可以整理想法、延续自己的小兴趣、准备以后可能用得上的素材，或只是安静待着。"
+            "Drift 不是定时巡检，也不是补跑所有历史任务；不要为了显得忙而硬找事做。"
+            "本轮记忆、skill 和工作区信息会在后续 system context frame 里提供。\n\n"
             "【执行规则】\n"
             "1. 先根据 context frame 比较所有可用 skill 和最近聊天气氛。"
             "如果没有值得做的事、刚刚打扰过用户或当前气氛不适合主动行动，调用 idle_drift(reason) 静默结束；"

--- a/agent/plugins/skill_links.py
+++ b/agent/plugins/skill_links.py
@@ -135,7 +135,7 @@ class PluginSkillLinker:
                 if plugin.declares_aka_plugin and manifest_key == "skills":
                     link_name = skill_dir.name
                 elif plugin.declares_aka_plugin and manifest_key == "drift_skills":
-                    link_name = f"{plugin.plugin_id.split('@', 1)[0]}:{skill_dir.name}"
+                    link_name = skill_dir.name
                 else:
                     link_name = f"{plugin.plugin_id}:{skill_dir.name}"
                 target = skill_dir.resolve(strict=False)

--- a/proactive_v2/modules_prompt.py
+++ b/proactive_v2/modules_prompt.py
@@ -191,7 +191,22 @@ class ProactivePromptBuilder:
                     )
                 )
 
+        sections.append(
+            PromptSectionRender(
+                name="runtime_clock",
+                content=self.render_runtime_clock(ctx),
+                is_static=False,
+            )
+        )
+
         return build_context_frame_message(build_context_frame_content(sections))
+
+    def render_runtime_clock(self, ctx: AgentTickContext) -> str:
+        local_now = ctx.now_utc.astimezone()
+        return (
+            f"current_time_utc={ctx.now_utc.isoformat()}\n"
+            f"current_time_local={local_now.isoformat()}"
+        )
 
     def read_workspace_context_for_prompt(self) -> str:
         if self._workspace_context_fn is None:

--- a/tests/proactive_v2/test_agent_loop.py
+++ b/tests/proactive_v2/test_agent_loop.py
@@ -95,8 +95,13 @@ async def test_loop_puts_runtime_context_frame_before_kickoff():
     messages = llm.calls[0]
     assert messages[0]["role"] == "system"
     assert messages[1]["role"] == "user"
-    assert is_context_frame(str(messages[1]["content"]))
-    assert "proactive_tick_state" in str(messages[1]["content"])
+    runtime = str(messages[1]["content"])
+    assert is_context_frame(runtime)
+    assert "proactive_tick_state" in runtime
+    assert "runtime_clock" in runtime
+    assert "current_time_utc=" in runtime
+    assert "current_time_local=" in runtime
+    assert runtime.index("proactive_content") < runtime.index("runtime_clock")
     assert str(messages[2]["content"]).startswith("开始本轮 proactive 处理。")
 
 

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -245,6 +245,9 @@ async def test_drift_system_prompt_discourages_stuck_skill_and_lists_new_tools(t
     prompt = pipeline._build_system_prompt()
     runtime = str((await pipeline._build_runtime_context_message(store.scan_skills()))["content"])
     assert "select_skill 会记录本轮 selected_skill" in prompt
+    assert "没有被叫住时的自处" in prompt
+    assert "不要为了显得忙而硬找事做" in prompt
+    assert "Drift 不是定时巡检" in prompt
     assert "路径由 drift mount resolver 解析" in prompt
     assert "message_result" in prompt
     assert "select_skill" in prompt
@@ -297,7 +300,8 @@ async def test_drift_runtime_context_provides_skill_selection_state(tmp_path: Pa
     assert "current_time_utc=2026-01-03T12:34:00+00:00" in runtime
     assert "current_time_local=" in runtime
     assert "按 skill 名称排列，顺序不代表优先级" in runtime
-    assert "选择依据：status、上次 finish 时间" in runtime
+    assert "选择依据：runtime_clock、status、上次 finish 时间" in runtime
+    assert "必须以 runtime_clock 的完整日期和时间为准" in runtime
     assert "recent_raw_chat" in runtime
     assert "local_context 只在 select_skill 后作为执行上下文参考" in runtime
     assert "explore-curiosity: status=completed" in runtime
@@ -311,7 +315,7 @@ async def test_drift_runtime_context_provides_skill_selection_state(tmp_path: Pa
     assert "本轮首选" not in runtime
     assert "首个工具调用" not in runtime
     assert runtime.index("drift_selection_context") < runtime.index("long_term_memory")
-    assert runtime.index("recent_drift_runs") < runtime.index("runtime_clock")
+    assert runtime.index("## recent_drift_runs") < runtime.index("## runtime_clock")
 
 
 @pytest.mark.asyncio

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -288,8 +288,14 @@ async def test_drift_runtime_context_provides_skill_selection_state(tmp_path: Pa
             shared_tools=_build_shared_tools(),
         ),
     )
-    runtime = str((await pipeline._build_runtime_context_message(store.scan_skills()))["content"])
+    ctx = AgentTickContext(now_utc=datetime(2026, 1, 3, 12, 34, tzinfo=timezone.utc))
+    runtime = str(
+        (await pipeline._build_runtime_context_message(store.scan_skills(), ctx=ctx))["content"]
+    )
     assert "drift_selection_context" in runtime
+    assert "runtime_clock" in runtime
+    assert "current_time_utc=2026-01-03T12:34:00+00:00" in runtime
+    assert "current_time_local=" in runtime
     assert "按 skill 名称排列，顺序不代表优先级" in runtime
     assert "选择依据：status、上次 finish 时间" in runtime
     assert "recent_raw_chat" in runtime
@@ -305,6 +311,7 @@ async def test_drift_runtime_context_provides_skill_selection_state(tmp_path: Pa
     assert "本轮首选" not in runtime
     assert "首个工具调用" not in runtime
     assert runtime.index("drift_selection_context") < runtime.index("long_term_memory")
+    assert runtime.index("recent_drift_runs") < runtime.index("runtime_clock")
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_skill_links.py
+++ b/tests/test_plugin_skill_links.py
@@ -262,7 +262,7 @@ def test_aka_plugin_drift_skill_uses_bare_plugin_name(tmp_path: Path) -> None:
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\n"
-        "name: emotion:feedback-preference-context\n"
+        "name: feedback-preference-context\n"
         "description: drift skill\n"
         "---\n"
         "body\n",
@@ -284,7 +284,8 @@ def test_aka_plugin_drift_skill_uses_bare_plugin_name(tmp_path: Path) -> None:
     ).sync([plugin])
 
     assert result.expected == 1
-    assert (workspace / "drift" / "skills" / "emotion:feedback-preference-context").is_symlink()
+    assert (workspace / "drift" / "skills" / "feedback-preference-context").is_symlink()
+    assert not (workspace / "drift" / "skills" / "emotion:feedback-preference-context").exists()
     assert not (workspace / "drift" / "skills" / "emotion@github:feedback-preference-context").exists()
 
 
@@ -424,7 +425,7 @@ def test_emotion_feedback_drift_skill_is_exposed(tmp_path: Path) -> None:
     scripts_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\n"
-        "name: emotion:feedback-preference-context\n"
+        "name: feedback-preference-context\n"
         "description: 情绪反馈 drift skill\n"
         "---\n"
         "body\n",
@@ -450,12 +451,12 @@ def test_emotion_feedback_drift_skill_is_exposed(tmp_path: Path) -> None:
     ).sync([plugin])
     skills = DriftStateStore(workspace / "drift").scan_skills()
     linked_skill_dir = DriftStateStore(workspace / "drift").skill_dir_for(
-        "emotion:feedback-preference-context"
+        "feedback-preference-context"
     )
 
     assert result.expected >= 1
-    assert (workspace / "drift" / "skills" / "emotion:feedback-preference-context").is_symlink()
-    assert "emotion:feedback-preference-context" in {skill.name for skill in skills}
+    assert (workspace / "drift" / "skills" / "feedback-preference-context").is_symlink()
+    assert "feedback-preference-context" in {skill.name for skill in skills}
     assert linked_skill_dir is not None
     assert (
         linked_skill_dir / "scripts" / "sample_feedback_context.py"


### PR DESCRIPTION
## 问题

Drift 插件 skill 历史上出现过 `emotion:feedback-preference-context` 和 `feedback-preference-context` 两套名字，导致插件挂载、drift 运行记录、自动合并触发条件不完全统一。Drift 本身也缺少明确的当前时间上下文和自发 idle 定位。

## 改动

- `.aka-plugin` drift skill 挂载时使用插件内目录名，不再加 `plugin_id:` 前缀。
- Drift runtime 上下文加入 `runtime_clock`，让模型能明确当前时间和相对日期。
- 调整 Drift prompt，让空档行为更接近自发探索，而不是只等任务或轻量提醒入口。
- 更新相关测试，覆盖插件 skill 链接和 Drift prompt 行为。

## 验证

- `pytest tests/test_plugin_skill_links.py tests/proactive_v2/test_drift.py`：68 passed
- `pyright agent/plugins/skill_links.py agent/core/drift_turn.py tests/test_plugin_skill_links.py tests/proactive_v2/test_drift.py`：0 errors, 52 warnings

## 配置影响

无配置项变更。已手动备份并迁移本机 workspace 的历史 drift skill 名称；运行中的 agent 进程需要重启后加载新的插件代码。
