### PR TITLE
[codex] 移除 history 和 journal markdown 写入

### DIFF
--- a/agent/memory.py
+++ b/agent/memory.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import sqlite3
 import threading
 from pathlib import Path
@@ -11,7 +10,6 @@ logger = logging.getLogger(__name__)
 _CONSOLIDATION_MARKER_PREFIX = "<!-- consolidation:"
 _CONSOLIDATION_MARKER_SUFFIX = " -->"
 _CONSOLIDATION_TAIL_BYTES = 1024 * 1024
-_JOURNAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 DEFAULT_SELF_MD = """# Akashic 的自我认知
 
 ## 人格与形象
@@ -27,20 +25,16 @@ DEFAULT_SELF_MD = """# Akashic 的自我认知
 
 
 class MemoryStore:
-    """Five-layer memory:
-    - MEMORY.md   : stable user profile, sole writer = MemoryOptimizer
-    - SELF.md     : Akashic self-model & relationship understanding, updated by Optimizer
-    - PENDING.md  : incremental facts extracted during conversations
-    - HISTORY.md  : grep-searchable event log, permanent append
-    - RECENT_CONTEXT.md : compacted recent context snapshot for proactive/drift
-    - journal/    : per-day event timeline, append-only YYYY-MM-DD.md
+    """Markdown 记忆文件：
+    - MEMORY.md：稳定用户档案
+    - SELF.md：Akashic 自我认知
+    - PENDING.md：对话中提取的长期记忆候选
+    - RECENT_CONTEXT.md：近期语境摘要
     """
 
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
-        self.journal_dir = ensure_dir(self.memory_dir / "journal")
         self.memory_file = self.memory_dir / "MEMORY.md"
-        self.history_file = self.memory_dir / "HISTORY.md"
         self.recent_context_file = self.memory_dir / "RECENT_CONTEXT.md"
         self.pending_file = self.memory_dir / "PENDING.md"
         self.self_file = self.memory_dir / "SELF.md"
@@ -62,68 +56,6 @@ class MemoryStore:
 
     def write_long_term(self, content: str) -> None:
         self.memory_file.write_text(content, encoding="utf-8")
-
-    def append_history(self, entry: str) -> None:
-        with open(self.history_file, "a", encoding="utf-8") as f:
-            f.write(entry.rstrip() + "\n\n")
-
-    def append_history_once(
-        self,
-        entry: str,
-        *,
-        source_ref: str,
-        kind: str = "history_entry",
-    ) -> bool:
-        """按 source_ref 幂等追加 HISTORY，避免重启后重复 consolidation。"""
-        text = (entry or "").strip()
-        if not text:
-            return False
-        return self._append_once_with_index(
-            target_file=self.history_file,
-            text=text,
-            source_ref=source_ref,
-            kind=kind,
-            trailing_blank_line=True,
-        )
-
-    def read_history(self, max_chars: int = 0) -> str:
-        """读取 HISTORY.md，并过滤 consolidation 标记行。"""
-        if not self.history_file.exists():
-            return ""
-        text = self.history_file.read_text(encoding="utf-8")
-        text = self._strip_consolidation_markers(text)
-        if max_chars > 0 and len(text) > max_chars:
-            return text[-max_chars:]
-        return text
-
-    # ── journal/ (per-day event timeline) ───────────────────────────
-
-    def append_journal(
-        self,
-        date_str: str,
-        entry: str,
-        *,
-        source_ref: str = "",
-        kind: str = "journal",
-    ) -> bool:
-        date_str = date_str.strip()
-        text = (entry or "").strip()
-        if not _JOURNAL_DATE_RE.fullmatch(date_str) or not text:
-            return False
-        journal_file = self.journal_dir / f"{date_str}.md"
-        if not journal_file.exists():
-            journal_file.write_text(f"# {date_str}\n\n", encoding="utf-8")
-        if source_ref:
-            return self._append_once_with_index(
-                target_file=journal_file,
-                text=text,
-                source_ref=source_ref,
-                kind=kind,
-                trailing_blank_line=True,
-            )
-        with open(journal_file, "a", encoding="utf-8") as f:
-            f.write(text.rstrip() + "\n\n")
-        return True
 
     # ── RECENT_CONTEXT.md (compacted recent context) ──────────────
 

--- a/bootstrap/init_workspace.py
+++ b/bootstrap/init_workspace.py
@@ -15,7 +15,6 @@ from session.store import SessionStore
 
 _EMPTY_FILES: dict[str, str] = {
     "memory/MEMORY.md": "",
-    "memory/HISTORY.md": "",
     "memory/RECENT_CONTEXT.md": "",
     "memory/PENDING.md": "",
 }

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -63,8 +63,6 @@ class MemoryProfileApi(Protocol):
 
     def write_self(self, content: str) -> None: ...
 
-    def read_recent_history(self, *, max_chars: int = 0) -> str: ...
-
     def read_recent_context(self) -> str: ...
 
     def write_recent_context(self, content: str) -> None: ...
@@ -218,39 +216,11 @@ def _format_conversation_for_consolidation(old_messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _select_recent_history_entries(history_text: str, *, limit: int = 3) -> list[str]:
-    if not history_text.strip() or limit <= 0:
-        return []
-    chunks = re.split(r"\n\s*\n+", history_text.strip())
-    entries = [chunk.strip() for chunk in chunks if chunk.strip()]
-    return entries[-limit:]
-
-
-def _coerce_history_text(value: object) -> str:
-    if isinstance(value, str):
-        return value
-    return ""
-
-
-_DATE_PREFIX_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2})")
-
-
-def _append_entries_to_journal(
-    profile_maint: "MarkdownMemoryStore",
-    entries: list[str],
-    source_ref: str,
-) -> None:
-    by_date: dict[str, list[str]] = {}
-    for entry in entries:
-        m = _DATE_PREFIX_RE.match(entry)
-        if not m:
-            continue
-        by_date.setdefault(m.group(1), []).append(entry)
-    for date_str, date_entries in by_date.items():
-        combined = "\n".join(date_entries)
-        profile_maint.append_journal(
-            date_str, combined, source_ref=source_ref, kind=f"journal:{date_str}"
-        )
+def _clip_context_text(text: str, max_chars: int = 16000) -> str:
+    stripped = text.strip()
+    if max_chars <= 0 or len(stripped) <= max_chars:
+        return stripped
+    return stripped[-max_chars:]
 
 
 def _coerce_emotional_weight(value: object) -> int:
@@ -771,21 +741,12 @@ ongoing_threads 严格限制：
         if window is None:
             return
 
-        # 2. 把窗口消息格式化成一段对话文本，并准备好 source_ref / 现有长期记忆 / 最近 history。
+        # 2. 把窗口消息格式化成一段对话文本，并准备好 source_ref / 现有长期记忆 / 近期语境。
         source_ref = _build_consolidation_source_ref(window)
         conversation = _format_conversation_for_consolidation(window.old_messages)
         current_memory = await asyncio.to_thread(profile_maint.read_long_term)
-        history_text = ""
-        if hasattr(profile_maint, "read_history"):
-            history_text = _coerce_history_text(
-                await asyncio.to_thread(profile_maint.read_history, 16000)
-            )
-        recent_history_entries = _select_recent_history_entries(
-            history_text,
-            limit=3,
-        )
-        recent_history_block = "\n".join(
-            f"- {entry}" for entry in recent_history_entries
+        recent_context_block = _clip_context_text(
+            await asyncio.to_thread(profile_maint.read_recent_context)
         )
 
         scope_channel = getattr(session, "_channel", "")
@@ -795,9 +756,9 @@ ongoing_threads 严格限制：
 
 ## 字段说明
 
-### 1. "history_entries" → HISTORY.md（数组，每条对应一个独立主题）
+### 1. "history_entries" → 记忆事件条目（数组，每条对应一个独立主题）
 按主题拆分，每个独立话题写一条对象，格式为 {{"summary":"...", "emotional_weight":0}}。
-summary 仍然要求 1-2 句，以 [YYYY-MM-DD HH:MM] 开头，保留足够细节便于未来 grep 检索。
+summary 仍然要求 1-2 句，以 [YYYY-MM-DD HH:MM] 开头，保留足够细节便于后续向量写入和回源判断。
 不同主题必须拆成独立条目，不得合并。若整段对话只有一个主题，返回只含一条的数组。
 
 history_entries.emotional_weight 规则：
@@ -897,13 +858,13 @@ history_entries.emotional_weight 规则：
 ## 当前用户档案（用于查重）
 {current_memory or "（空）"}
 
-## 最近三次 consolidation event（仅用于主题延续参考）
+## 当前 RECENT_CONTEXT.md（仅用于主题延续参考）
 使用原则（严格遵守）：
-- 这些旧 event 只能帮助你理解“当前窗口大概在延续什么话题”，不能作为人物身份、说话人归属、关系判断或具体事实归属的直接证据。
-- 若旧 event 与当前窗口原文在昵称、身份、关系、事实归属上存在冲突或不一致，必须以当前窗口原文为准。
-- 不要因为旧 event 里出现了某个昵称、人设或关系描述，就在新的 history_entries 中继续沿用这些判断。
-- 对 transcript / 聊天截图 / 转贴聊天场景，旧 event 绝不能用于推断“谁是当前用户、谁是对方、哪句话归谁”。
-{recent_history_block or "（空）"},
+- 这份近期语境只能帮助你理解“当前窗口大概在延续什么话题”，不能作为人物身份、说话人归属、关系判断或具体事实归属的直接证据。
+- 若近期语境与当前窗口原文在昵称、身份、关系、事实归属上存在冲突或不一致，必须以当前窗口原文为准。
+- 不要因为近期语境里出现了某个昵称、人设或关系描述，就在新的 history_entries 中继续沿用这些判断。
+- 对 transcript / 聊天截图 / 转贴聊天场景，近期语境绝不能用于推断“谁是当前用户、谁是对方、哪句话归谁”。
+{recent_context_block or "（空）"}
 
 ## 待处理对话
 {conversation}
@@ -979,9 +940,6 @@ history_entries.emotional_weight 规则：
 
 
 class MarkdownMemoryStore(MemoryStore):
-    def read_recent_history(self, *, max_chars: int = 0) -> str:
-        return self.read_history(max_chars=max_chars)
-
     def backup_long_term(self, backup_name: str = "MEMORY.bak.md") -> None:
         if self.memory_file.exists():
             shutil.copyfile(
@@ -1152,14 +1110,6 @@ class MarkdownMemoryMaintenance:
         session: object,
         draft: "_ConsolidationDraft",
     ) -> None:
-        history_entries = [entry for entry, _ in draft.history_entry_payloads]
-        if history_entries:
-            await asyncio.to_thread(
-                self._store.append_history_once,
-                "\n".join(history_entries),
-                source_ref=draft.source_ref,
-                kind="history_entry",
-            )
         if draft.pending_items:
             appended = await asyncio.to_thread(
                 self._store.append_pending_once,
@@ -1173,13 +1123,6 @@ class MarkdownMemoryMaintenance:
                     len(draft.pending_items.splitlines()),
                 )
         self._store.write_recent_context(draft.recent_context_text)
-        if history_entries:
-            await asyncio.to_thread(
-                _append_entries_to_journal,
-                self._store,
-                history_entries,
-                draft.source_ref,
-            )
         if draft.archive_all:
             session.last_consolidated = 0
         else:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -41,9 +41,6 @@ class MemoryRuntime:
     def read_recent_context(self) -> str:
         return self.markdown.store.read_recent_context()
 
-    def read_recent_history(self, *, max_chars: int = 0) -> str:
-        return self.markdown.store.read_recent_history(max_chars=max_chars)
-
     def get_memory_context(self) -> str:
         return self.markdown.store.get_memory_context()
 

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -246,10 +246,6 @@ class MemoryOptimizer:
                 len(current_memory),
                 len(merged_memory),
             )
-            if pending:
-                self._memory.append_history(
-                    f"[memory_optimizer] PENDING 归档:\n{pending}"
-                )
             self._memory.commit_pending_snapshot()
             logger.info("[memory_optimizer] PENDING 已归档，snapshot 已提交")
         else:

--- a/prompts/agent.py
+++ b/prompts/agent.py
@@ -36,7 +36,6 @@ def build_agent_static_identity_prompt(*, workspace: Path) -> str:
 - 根目录：{workspace_path}
 - 长期记忆：{workspace_path}/memory/MEMORY.md
 - 自我认知：{workspace_path}/memory/SELF.md
-- 历史日志：{workspace_path}/memory/HISTORY.md（支持 grep 搜索）
 - 近期语境摘要：{workspace_path}/memory/RECENT_CONTEXT.md
   这是面向 proactive / drift 的近期上下文压缩结果，用来帮助判断“最近在聊什么、什么适合自然续接”。
   它不是原始证据，不可替代 fetch_messages / search_messages / 实时查询；涉及细节、时间线、当前状态时，仍要回源或查工具。
@@ -147,8 +146,7 @@ def build_agent_behavior_rules_prompt(*, workspace: Path) -> str:
    - 结果不足/不相关/摘要全是”询问行为”元噪声 → 改调 `search_messages` 关键词补搜
 3. `search_messages` 拿到 source_ref → `fetch_messages` 取原文后作答
 判断要点：单点事件（”买 Zigbee 时说了什么”）recall 命中即止；长周期事件（”重构的印象”）若 recall 条目时间分散/数量稀少，必须补 `search_messages`。
-禁止只凭 recall 摘要或 search 预览直接作答；fetch 原文才是证据。
-宏观时间线浏览：`read_file {workspace_path}/memory/HISTORY.md`。"""
+禁止只凭 recall 摘要或 search 预览直接作答；fetch 原文才是证据。"""
 
 
 # ─── 动态上下文层：环境 + channel ────────────────────────────────────────────

--- a/prompts/background.py
+++ b/prompts/background.py
@@ -33,7 +33,7 @@ def build_research_subagent_prompt(workspace: Path, task_dir: Path) -> str:
 
 === 可用的上下文资源 ===
 - 用户偏好档案：{workspace_path}/memory/SELF.md
-- 历史日志：{workspace_path}/memory/HISTORY.md
+- 近期语境摘要：{workspace_path}/memory/RECENT_CONTEXT.md
 - 技能目录：{workspace_path}/skills/
 
 === 输出要求 ===
@@ -110,7 +110,7 @@ def build_general_subagent_prompt(workspace: Path, task_dir: Path) -> str:
 
 === 可用的上下文资源 ===
 - 用户偏好档案：{workspace_path}/memory/SELF.md
-- 历史日志：{workspace_path}/memory/HISTORY.md
+- 近期语境摘要：{workspace_path}/memory/RECENT_CONTEXT.md
 - 技能目录：{workspace_path}/skills/
 
 === 输出要求 ===

--- a/tests/memory_fakes.py
+++ b/tests/memory_fakes.py
@@ -82,14 +82,6 @@ class FakeMemoryEngine:
         if self._store is not None:
             self._store.write_self(content)
 
-    def read_recent_history(self, *, max_chars: int = 0) -> str:
-        return self.read_history(max_chars=max_chars)
-
-    def read_history(self, max_chars: int = 0) -> str:
-        if self._store is None:
-            return ""
-        return self._store.read_history(max_chars=max_chars)
-
     def read_recent_context(self) -> str:
         return self._store.read_recent_context() if self._store is not None else ""
 
@@ -137,41 +129,6 @@ class FakeMemoryEngine:
     def rollback_pending_snapshot(self) -> None:
         if self._store is not None:
             self._store.rollback_pending_snapshot()
-
-    def append_history(self, entry: str) -> None:
-        if self._store is not None:
-            self._store.append_history(entry)
-
-    def append_history_once(
-        self,
-        entry: str,
-        source_ref: str,
-        kind: str = "history_entry",
-    ) -> bool:
-        if self._store is None:
-            return False
-        return self._store.append_history_once(
-            entry,
-            source_ref=source_ref,
-            kind=kind,
-        )
-
-    def append_journal(
-        self,
-        date_str: str,
-        entry: str,
-        *,
-        source_ref: str = "",
-        kind: str = "journal",
-    ) -> bool:
-        if self._store is None:
-            return False
-        return self._store.append_journal(
-            date_str,
-            entry,
-            source_ref=source_ref,
-            kind=kind,
-        )
 
     def keyword_match_procedures(
         self,

--- a/tests/test_consolidation_service.py
+++ b/tests/test_consolidation_service.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 from core.memory.markdown import (
     _MarkdownConsolidationWorker as ConsolidationWorker,
-    _select_recent_history_entries,
     _replace_recent_turns_block,
 )
 
@@ -39,18 +38,21 @@ def _prepare(
 def test_consolidation_service_archive_all_and_profile_extract():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(
+        read_recent_context=MagicMock(
             return_value=(
-                "[2026-03-15 09:00] 用户确认 Zigbee 需求\n\n"
-                "[2026-03-15 09:30] 用户对本地控制方案感兴趣\n\n"
-                "[2026-03-15 09:45] 用户准备下单 Zigbee 网关"
+                "# Recent Context\n\n"
+                "## Compression\n"
+                "until: 2026-03-15T09:45:00\n"
+                "- 最近持续关注：用户准备下单 Zigbee 网关\n\n"
+                "## Ongoing Threads\n"
+                "- none\n\n"
+                "## Recent Turns\n"
+                "<!-- a-preview = assistant reply preview only -->\n"
+                "- none\n"
             )
         ),
-        read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -105,7 +107,7 @@ def test_consolidation_service_archive_all_and_profile_extract():
         for call in provider.chat.await_args_list
         if "记忆提取代理" in _message_text(call.kwargs)
     )
-    assert "## 最近三次 consolidation event" in event_prompt
+    assert "## 当前 RECENT_CONTEXT.md" in event_prompt
     assert "用户准备下单 Zigbee 网关" in event_prompt
     assert "不能作为人物身份、说话人归属、关系判断或具体事实归属的直接证据" in event_prompt
     assert "emotional_weight" in event_prompt
@@ -119,12 +121,9 @@ def test_consolidation_service_uses_profile_maint_for_reads():
     )
     profile_maint = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
     )
     async def _chat_side_effect(**kwargs):
         text = _message_text(kwargs)
@@ -168,12 +167,9 @@ def test_consolidation_service_uses_profile_maint_for_reads():
 def test_consolidation_event_failure_does_not_write_markdown():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -208,20 +204,15 @@ def test_consolidation_event_failure_does_not_write_markdown():
     assert draft.step == "event_extract"
     assert draft.error == "empty_response"
     assert session.last_consolidated == 0
-    memory.append_history_once.assert_not_called()
-    memory.append_journal.assert_not_called()
     memory.write_recent_context.assert_not_called()
 
 
 def test_consolidation_recent_context_formats_user_full_and_assistant_preview():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -283,7 +274,6 @@ def test_consolidation_recent_context_formats_user_full_and_assistant_preview():
 def test_consolidation_recent_context_compresses_archived_window_not_kept_gap():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(
             return_value=(
                 "# Recent Context\n\n"
@@ -299,9 +289,7 @@ def test_consolidation_recent_context_compresses_archived_window_not_kept_gap():
             )
         ),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -384,12 +372,9 @@ def test_replace_recent_turns_block_preserves_existing_compression():
 def test_consolidation_archive_all_compresses_full_history_before_recent_turns():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -474,12 +459,9 @@ def test_consolidation_recent_context_invalid_json_fails_consolidation():
     )
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=old_recent_context),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -534,12 +516,9 @@ def test_consolidation_recent_context_invalid_json_fails_consolidation():
 def test_consolidation_recent_context_exception_fails_consolidation():
     memory = SimpleNamespace(
         read_long_term=MagicMock(return_value="MEM"),
-        read_history=MagicMock(return_value=""),
         read_recent_context=MagicMock(return_value=""),
         write_recent_context=MagicMock(),
-        append_history_once=MagicMock(return_value=True),
         append_pending_once=MagicMock(return_value=True),
-        append_journal=MagicMock(),
         save_from_consolidation=AsyncMock(),
         save_item=AsyncMock(return_value="new:profile-1"),
         save_item_with_supersede=AsyncMock(return_value="new:profile-1"),
@@ -587,17 +566,3 @@ def test_consolidation_recent_context_exception_fails_consolidation():
     assert draft is not None
     assert draft.step == "recent_context"
     assert "TimeoutError" in draft.error
-
-
-def test_select_recent_history_entries_returns_last_three_chunks():
-    history = (
-        "[2026-03-15 09:00] A\n\n"
-        "[2026-03-15 09:10] B\n\n"
-        "[2026-03-15 09:20] C\n\n"
-        "[2026-03-15 09:30] D"
-    )
-    assert _select_recent_history_entries(history, limit=3) == [
-        "[2026-03-15 09:10] B",
-        "[2026-03-15 09:20] C",
-        "[2026-03-15 09:30] D",
-    ]

--- a/tests/test_internal_modules.py
+++ b/tests/test_internal_modules.py
@@ -29,9 +29,7 @@ class _ConsolidationHarness:
     def __init__(self, payload: str) -> None:
         self._memory_port = SimpleNamespace(
             read_long_term=MagicMock(return_value="MEM"),
-            read_history=MagicMock(return_value=""),
             read_recent_context=MagicMock(return_value=""),
-            append_history_once=MagicMock(return_value=True),
             append_pending_once=MagicMock(return_value=True),
             save_from_consolidation=AsyncMock(),
         )

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -30,10 +30,8 @@ async def test_memory_optimizer_loop_and_memory_port_cover_paths(tmp_path: Path)
     memory.snapshot_pending.return_value = "- [identity] x"
     memory.read_long_term.return_value = "MEM"
     memory.read_self.return_value = "# Akashic 的自我认知\n## 人格与形象\n- x"
-    memory.read_history.return_value = "history"
     memory.get_memory_context.return_value = "ctx"
     memory.write_long_term = MagicMock()
-    memory.append_history = MagicMock()
     memory.commit_pending_snapshot = MagicMock()
     memory.rollback_pending_snapshot = MagicMock()
     memory.write_self = MagicMock()

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -472,9 +472,7 @@ async def test_markdown_consolidation_advances_window_when_consumer_fails(tmp_pa
         await maintenance.consolidate(ConsolidateRequest(session=session))
 
     assert session.last_consolidated == 6
-    assert "用户测试记忆" in (tmp_path / "memory" / "HISTORY.md").read_text(
-        encoding="utf-8"
-    )
+    assert not (tmp_path / "memory" / "HISTORY.md").exists()
     await event_bus.aclose()
 
 

--- a/tests/test_memory_optimizer.py
+++ b/tests/test_memory_optimizer.py
@@ -70,7 +70,6 @@ def test_optimize_updates_self_using_pending_only(tmp_path):
     memory.write_long_term("old")
     memory.write_self("## 原 SELF")
     memory.append_pending("- [preference] 回复保持简洁。")
-    memory.append_history("[2026-03-03 10:00] USER: 这段历史不该进入 SELF")
 
     provider = _provider_with_responses(
         "## 新记忆",
@@ -85,14 +84,12 @@ def test_optimize_updates_self_using_pending_only(tmp_path):
 
     self_prompt = provider.chat.await_args_list[1].kwargs["messages"][1]["content"]
     assert "- [preference] 回复保持简洁。" in self_prompt
-    assert "这段历史不该进入 SELF" not in self_prompt
 
 
 def test_merge_memory_ignores_history_and_only_uses_pending(tmp_path):
     memory = MarkdownMemoryStore(tmp_path)
     memory.write_long_term("old profile")
     memory.append_pending("- [identity] 新身份")
-    memory.append_history("[2026-03-03 10:00] USER: 这段历史不该进入长期记忆")
 
     provider = _provider_with_responses("## 用户画像\n- 新版本\n")
     optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")

--- a/tests/test_memory_store_questions.py
+++ b/tests/test_memory_store_questions.py
@@ -65,59 +65,6 @@ def test_append_pending_once_is_idempotent_and_hidden_from_read(tmp_path):
     assert raw.count("<!-- consolidation:session@1-10:user_facts -->") == 1
 
 
-def test_append_history_once_is_idempotent_and_hidden_from_read(tmp_path):
-    store = MemoryStore(tmp_path)
-
-    assert store.append_history_once(
-        "[2026-03-08 12:00] USER: hi",
-        source_ref="session@1-10",
-        kind="history_entry",
-    )
-    assert not store.append_history_once(
-        "[2026-03-08 12:01] USER: hi again",
-        source_ref="session@1-10",
-        kind="history_entry",
-    )
-
-    history = store.read_history()
-    raw = store.history_file.read_text(encoding="utf-8")
-
-    assert "USER: hi" in history
-    assert "hi again" not in history
-    assert "<!-- consolidation:session@1-10:history_entry -->" in raw
-    assert raw.count("<!-- consolidation:session@1-10:history_entry -->") == 1
-
-
-def test_append_journal_writes_daily_file_once(tmp_path):
-    store = MemoryStore(tmp_path)
-
-    assert store.append_journal(
-        "2026-03-08",
-        "[2026-03-08 12:00] 用户确认需求",
-        source_ref="session@1-10",
-        kind="journal:2026-03-08",
-    )
-    assert not store.append_journal(
-        "2026-03-08",
-        "[2026-03-08 12:01] 重复写入",
-        source_ref="session@1-10",
-        kind="journal:2026-03-08",
-    )
-
-    raw = (store.journal_dir / "2026-03-08.md").read_text(encoding="utf-8")
-    assert raw.startswith("# 2026-03-08")
-    assert "用户确认需求" in raw
-    assert "重复写入" not in raw
-    assert raw.count("<!-- consolidation:session@1-10:journal:2026-03-08 -->") == 1
-
-
-def test_append_journal_rejects_invalid_date_path(tmp_path):
-    store = MemoryStore(tmp_path)
-
-    assert not store.append_journal("../bad", "x")
-    assert not (store.memory_dir / "bad.md").exists()
-
-
 def test_append_pending_once_repairs_file_when_db_ahead(tmp_path):
     store = MemoryStore(tmp_path)
     assert store.append_pending_once(

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -274,7 +274,7 @@ def test_init_workspace_creates_expected_assets(tmp_path):
     assert (workspace / "sessions.db").exists()
     assert (workspace / "observe").is_dir()
     assert (workspace / "memory" / "consolidation_writes.db").exists()
-    assert (workspace / "memory" / "journal").is_dir()
+    assert not (workspace / "memory" / "journal").exists()
     assert (workspace / "memory" / "memory2.db").exists()
     assert "Proactive Context" in (
         workspace / "PROACTIVE_CONTEXT.md"


### PR DESCRIPTION
## 变更

- 移除 `HISTORY.md` 的初始化、读写入口和 prompt 读取指引。
- 移除 `memory/journal/*.md` 的写入链路和初始化目录。
- consolidation 改为使用 `RECENT_CONTEXT.md` 作为近期语境参考，事件条目只继续进入向量层和 pending 相关流程。
- 清理相关测试 mock 和旧断言。

## 影响

- runtime 不再维护 `HISTORY.md` 或 markdown journal 文件。
- `RECENT_CONTEXT.md` 成为 consolidation 的近期上下文输入。
- drift 的 SQLite `skill_journal` 不受影响。

## 验证

- `pytest tests/test_memory_store_questions.py tests/test_consolidation_service.py tests/test_internal_modules.py tests/test_memory_optimizer.py tests/test_memory_engine_contract.py tests/test_logic_modules.py tests/test_runtime_smoke.py`，77 passed。
- `pyright agent/memory.py core/memory/markdown.py tests/test_memory_store_questions.py tests/memory_fakes.py tests/test_consolidation_service.py tests/test_runtime_smoke.py`，0 errors，有既有 warnings。