### PR TITLE
feat(plugins): 全能力热重载与插件迁移

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ https://github.com/akashic-plugins/steam-mcp
 Akashic 理想上的动作应该是：
 
 ```text
-安装插件
-├─ 识别这是一个 GitHub 插件仓库
-├─ 执行 plugin-install
-├─ 检查 manifest.toml 与 plugin.py 声明的能力
-└─ 提醒你重启后生效
+┌─ 安装插件
+│  ├─ 识别 GitHub 插件仓库
+│  ├─ 执行 plugin-install
+│  ├─ 检查 manifest.toml 与 plugin.py
+│  └─ Runtime 自动发现并原子发布新快照
+└─ 不重启，下一次执行使用新代际
 ```
 
-当前这套插件系统默认按“重启后生效”理解，尤其是 lifecycle、skill、MCP 声明变更后。
+安装、升级、启停、源码和 `config.local.toml` 修改都会自动热重载。正在执行的请求保持旧代际，新请求统一使用新代际；候选验证失败时继续保留旧版本。
 
 想看完整机制，直接看 [插件系统 Handbook](./_handbook/plugins-tutorial.md)。
 

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -209,3 +209,18 @@ Runtime 每秒检查插件清单、源码和本地配置的元数据。发现变
 ```
 
 插件需要独占后台服务时，通过 `managed_services()` 声明；短期异步任务使用 `self.context.create_task()`。MCP bridge 只连接服务，不应再维护第二套进程所有权。
+
+## 仍需重启的边界
+
+热重载只替换插件代际，不替换宿主进程本身。
+
+```text
+┌─ 可热重载
+│  ├─ Python 插件源码与资源
+│  ├─ config.local.toml
+│  └─ MCP、Skill、Job、Channel、Dashboard 与 managed service 声明
+└─ 必须重启 Runtime
+   ├─ CPython 或核心 Runtime ABI 变化
+   ├─ 已载入的原生动态库升级
+   └─ Runtime 自身依赖与启动参数变化
+```

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -168,6 +168,16 @@ python main.py plugin-install \
 python main.py plugin-doctor --plugin demo@github
 ```
 
+运行中的 Runtime 会自动应用启停和卸载变化：
+
+```bash
+python main.py plugin-disable demo@github
+python main.py plugin-enable demo@github
+python main.py plugin-uninstall demo@github
+```
+
+`plugin-disable` 与 `plugin-enable` 只修改全局 `manifest.toml`。`plugin-uninstall` 删除插件的 manifest 条目和全部 cache 版本，但始终保留 `data/demo-github/`，重新安装后会继续复用原配置与持久数据。
+
 安装后检查：
 
 ```text

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -175,7 +175,28 @@ python main.py plugin-doctor --plugin demo@github
 ├─ cache/github/demo/<version>/plugin.py 存在
 ├─ data/demo-github/config.local.toml 可通过 schema 验证
 ├─ 声明的 skills 与 MCP 入口存在
-└─ 重启后 doctor 与运行日志无加载错误
+└─ watcher 发布 committed snapshot，运行日志无加载错误
+```
+
+## 热重载
+
+Runtime 每秒检查插件清单、源码和本地配置的元数据。发现变化后先构建完整候选代际，通过声明、资源 readiness 与插件语义检查后再一次性发布。
+
+```text
+┌─ 变化入口
+│  ├─ 安装或删除插件目录
+│  ├─ manifest.toml enabled 改变
+│  ├─ plugin.py 或插件资源改变
+│  └─ config.local.toml 改变
+├─ Candidate Gate
+│  ├─ 编译 lifecycle、tool、skill、MCP、job、proactive
+│  ├─ 预热 Dashboard、Channel 与 managed service
+│  └─ 失败时丢弃候选，旧代继续服务
+├─ RuntimeSnapshot 原子发布
+│  ├─ 已开始的执行继续持有旧快照
+│  └─ 新执行只租用新快照
+└─ Drain
+   └─ 最后一个旧 lease 释放后关闭旧资源
 ```
 
 ## 升级边界
@@ -187,4 +208,4 @@ python main.py plugin-doctor --plugin demo@github
    └─ 必须保留：配置、数据库、Token、模型、日志
 ```
 
-插件需要后台服务时，由插件的 `initialize()` 启动，由 `terminate()` 停止。MCP bridge 只连接服务，不应再维护第二套进程所有权。
+插件需要独占后台服务时，通过 `managed_services()` 声明；短期异步任务使用 `self.context.create_task()`。MCP bridge 只连接服务，不应再维护第二套进程所有权。

--- a/agent/background/subagent_manager.py
+++ b/agent/background/subagent_manager.py
@@ -82,6 +82,7 @@ class SubagentManager:
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._running_jobs: dict[str, RunningSubagentJob] = {}
         self._cancel_announced: set[str] = set()
+        self._snapshot_release_tasks: set[asyncio.Task[None]] = set()
 
     def add_tool_hooks(self, hooks: list[ToolHook]) -> None:
         object.__setattr__(self._runtime, "tool_hooks", list(hooks))
@@ -374,9 +375,25 @@ class SubagentManager:
     ) -> None:
         self._forget_running_job(job_id)
         if snapshot_lease is not None and snapshot_lease.active:
-            _ = asyncio.create_task(
+            task = asyncio.create_task(
                 snapshot_lease.release(),
                 name=f"spawn_snapshot_release:{job_id}",
+            )
+            self._snapshot_release_tasks.add(task)
+            task.add_done_callback(self._snapshot_release_tasks.discard)
+
+    async def shutdown(self) -> None:
+        tasks = list(self._running_tasks.values())
+        for task in tasks:
+            _ = task.cancel()
+        if tasks:
+            _ = await asyncio.gather(*tasks, return_exceptions=True)
+        while self._snapshot_release_tasks:
+            release_tasks = tuple(self._snapshot_release_tasks)
+            self._snapshot_release_tasks.difference_update(release_tasks)
+            _ = await asyncio.gather(
+                *release_tasks,
+                return_exceptions=True,
             )
 
     async def _announce_cancelled_job(self, job: RunningSubagentJob) -> None:

--- a/agent/background/subagent_manager.py
+++ b/agent/background/subagent_manager.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent.background.runtime import (
     AgentBackgroundJobRunner,
@@ -31,6 +32,9 @@ from core.net.http import HttpRequester
 from prompts.background import build_spawn_subagent_prompt
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshotLease
 
 _RESULT_MAX_CHARS = 12_000
 _SYNC_RESULT_MAX_CHARS = 100_000
@@ -173,6 +177,9 @@ class SubagentManager:
             },
         )
         # 2. 再把真正执行逻辑放到后台 task 中，避免阻塞当前会话。
+        from agent.plugins.snapshot import lease_current_runtime_snapshot
+
+        snapshot_lease = lease_current_runtime_snapshot()
         bg_task = asyncio.create_task(
             self._run_subagent(
                 job_id=job_id,
@@ -184,6 +191,7 @@ class SubagentManager:
                 decision=decision,
                 profile=profile,
                 retry_count=retry_count,
+                snapshot_lease=snapshot_lease,
             ),
             name=f"spawn:{job_id}",
         )
@@ -200,7 +208,9 @@ class SubagentManager:
             retry_count=retry_count,
             started_at=datetime.now(timezone.utc).isoformat(),
         )
-        bg_task.add_done_callback(lambda _: self._forget_running_job(job_id))
+        bg_task.add_done_callback(
+            lambda _: self._finish_background_job(job_id, snapshot_lease)
+        )
         logger.info(
             "[spawn] started job_id=%s label=%r profile=%s retry_count=%d origin=%s:%s reason=%s confidence=%s",
             job_id,
@@ -253,7 +263,28 @@ class SubagentManager:
         decision: SpawnDecision | None,
         profile: str = PROFILE_RESEARCH,
         retry_count: int = 0,
+        snapshot_lease: RuntimeSnapshotLease | None = None,
     ) -> None:
+        if snapshot_lease is not None:
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with snapshot_lease:
+                token = bind_runtime_snapshot(snapshot_lease)
+                try:
+                    await self._run_subagent(
+                        job_id=job_id,
+                        task=task,
+                        label=label,
+                        task_dir=task_dir,
+                        origin_channel=origin_channel,
+                        origin_chat_id=origin_chat_id,
+                        decision=decision,
+                        profile=profile,
+                        retry_count=retry_count,
+                    )
+                finally:
+                    reset_runtime_snapshot(token)
+            return
         """运行后台 subagent，并把统一结果协议回灌给主 agent。"""
         job_runner = AgentBackgroundJobRunner(
             lambda: self._build_subagent(task_dir=task_dir, profile=profile)
@@ -335,6 +366,18 @@ class SubagentManager:
                 "decision": _decision_payload(decision),
             },
         )
+
+    def _finish_background_job(
+        self,
+        job_id: str,
+        snapshot_lease: RuntimeSnapshotLease | None,
+    ) -> None:
+        self._forget_running_job(job_id)
+        if snapshot_lease is not None and snapshot_lease.active:
+            _ = asyncio.create_task(
+                snapshot_lease.release(),
+                name=f"spawn_snapshot_release:{job_id}",
+            )
 
     async def _announce_cancelled_job(self, job: RunningSubagentJob) -> None:
         await self._announce_result(

--- a/agent/context.py
+++ b/agent/context.py
@@ -232,7 +232,7 @@ class ContextBuilder:
         vl_available: bool = False,
     ):
         self.workspace = workspace
-        self.skills = SkillsLoader(workspace)
+        self.skills = SkillsLoader(workspace, runtime_catalog="normal")
         self.memory = memory
         self._system_prompt_builder = SystemPromptBuilder(
             [

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -71,7 +71,7 @@ from agent.lifecycle.types import (
     TurnState,
     TurnPersistencePolicy,
 )
-from agent.plugins.snapshot import current_runtime_snapshot
+from agent.plugins.snapshot import get_current_runtime_snapshot
 
 if TYPE_CHECKING:
     from agent.context import ContextBuilder
@@ -389,7 +389,7 @@ class PassiveTurnPipeline:
         )
 
     def _runtime_phase(self, name: str):
-        snapshot = current_runtime_snapshot.get()
+        snapshot = get_current_runtime_snapshot()
         if snapshot is None:
             return getattr(self, f"_{name}")
         modules = list(getattr(snapshot, f"{name}_modules"))
@@ -961,7 +961,7 @@ class DefaultReasoner(Reasoner):
     ) -> PromptRenderResult:
         if self._context is None:
             raise RuntimeError("DefaultReasoner.render_prompt requires context")
-        snapshot = current_runtime_snapshot.get()
+        snapshot = get_current_runtime_snapshot()
         if snapshot is not None:
             phase = self._build_prompt_render_phase(
                 self._context,
@@ -975,7 +975,7 @@ class DefaultReasoner(Reasoner):
     def _runtime_before_step_phase(
         self,
     ) -> Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame]:
-        snapshot = current_runtime_snapshot.get()
+        snapshot = get_current_runtime_snapshot()
         if snapshot is None:
             return self._before_step
         return self._build_before_step_phase(list(snapshot.before_step_modules))
@@ -983,7 +983,7 @@ class DefaultReasoner(Reasoner):
     def _runtime_after_step_phase(
         self,
     ) -> Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame]:
-        snapshot = current_runtime_snapshot.get()
+        snapshot = get_current_runtime_snapshot()
         if snapshot is None:
             return self._after_step
         return self._build_after_step_phase(list(snapshot.after_step_modules))

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -71,6 +71,7 @@ from agent.lifecycle.types import (
     TurnState,
     TurnPersistencePolicy,
 )
+from agent.plugins.snapshot import current_runtime_snapshot
 
 if TYPE_CHECKING:
     from agent.context import ContextBuilder
@@ -308,7 +309,10 @@ class PassiveTurnPipeline:
         self._after_turn_plugin_modules.extend(modules)
         self._after_turn = self._build_after_turn_phase()
 
-    def _build_before_turn_phase(self) -> Phase[TurnState, BeforeTurnCtx, BeforeTurnFrame]:
+    def _build_before_turn_phase(
+        self,
+        plugin_modules: list[object] | None = None,
+    ) -> Phase[TurnState, BeforeTurnCtx, BeforeTurnFrame]:
         return Phase(
             default_before_turn_modules(
                 self._bus,
@@ -316,13 +320,19 @@ class PassiveTurnPipeline:
                 self._context_store,
                 keep_count=self._history_window,
                 consolidator=self._memory_consolidator,
-                plugin_modules=cast("list[Any]", self._before_turn_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._before_turn_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=BeforeTurnFrame,
         )
 
     def _build_before_reasoning_phase(
         self,
+        plugin_modules: list[object] | None = None,
     ) -> Phase[BeforeReasoningInput, BeforeReasoningCtx, BeforeReasoningFrame]:
         return Phase(
             default_before_reasoning_modules(
@@ -330,25 +340,37 @@ class PassiveTurnPipeline:
                 self._tools,
                 self._session.session_manager,
                 self._context,
-                plugin_modules=cast("list[Any]", self._before_reasoning_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._before_reasoning_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=BeforeReasoningFrame,
         )
 
     def _build_after_reasoning_phase(
         self,
+        plugin_modules: list[object] | None = None,
     ) -> Phase[AfterReasoningInput, AfterReasoningResult, AfterReasoningFrame]:
         return Phase(
             default_after_reasoning_modules(
                 self._bus,
                 self._session,
-                plugin_modules=cast("list[Any]", self._after_reasoning_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._after_reasoning_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=AfterReasoningFrame,
         )
 
     def _build_after_turn_phase(
         self,
+        plugin_modules: list[object] | None = None,
     ) -> Phase[TurnSnapshot, OutboundMessage, AfterTurnFrame]:
         return Phase(
             default_after_turn_modules(
@@ -356,10 +378,22 @@ class PassiveTurnPipeline:
                 self._outbound_port,
                 self._context,
                 self._history_window,
-                plugin_modules=cast("list[Any]", self._after_turn_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._after_turn_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=AfterTurnFrame,
         )
+
+    def _runtime_phase(self, name: str):
+        snapshot = current_runtime_snapshot.get()
+        if snapshot is None:
+            return getattr(self, f"_{name}")
+        modules = list(getattr(snapshot, f"{name}_modules"))
+        return getattr(self, f"_build_{name}_phase")(modules)
 
     # 核心方法：处理一条普通被动消息，并提交最终出站结果。
     async def run(
@@ -393,7 +427,7 @@ class PassiveTurnPipeline:
             try:
                 # Phase 1: BeforeTurn 模块链（会话、上下文、BeforeTurn 事件）。
                 with diagnostic_context(phase="before_turn"):
-                    before_turn = await self._before_turn.run(state)
+                    before_turn = await self._runtime_phase("before_turn").run(state)
                 # TurnState 存内部默认 metadata；BeforeTurnCtx 存插件导出，同名 key 以后者覆盖。
                 state.extra_metadata.update(before_turn.extra_metadata)
                 if before_turn.abort:
@@ -433,7 +467,7 @@ class PassiveTurnPipeline:
 
                 # Phase 2: BeforeReasoning 模块链（工具上下文、BeforeReasoning 事件、prompt warmup）。
                 with diagnostic_context(phase="before_reasoning"):
-                    before_reasoning = await self._before_reasoning.run(
+                    before_reasoning = await self._runtime_phase("before_reasoning").run(
                         BeforeReasoningInput(state=state, before_turn=before_turn)
                     )
                 if before_reasoning.abort:
@@ -528,7 +562,7 @@ class PassiveTurnPipeline:
             try:
                 # Phase 5: AfterReasoning 模块链（parse、AfterReasoning 事件、持久化、出站消息）。
                 with diagnostic_context(phase="after_reasoning"):
-                    after_reasoning = await self._after_reasoning.run(
+                    after_reasoning = await self._runtime_phase("after_reasoning").run(
                         AfterReasoningInput(state=state, turn_result=turn_result)
                     )
             except Exception as exc:
@@ -564,7 +598,7 @@ class PassiveTurnPipeline:
             try:
                 # Phase 6: AfterTurn 模块链（TurnCommitted fanout、AfterTurn fanout、dispatch）。
                 with diagnostic_context(phase="after_turn"):
-                    outbound = await self._after_turn.run(
+                    outbound = await self._runtime_phase("after_turn").run(
                         TurnSnapshot(
                             state=state,
                             outbound=after_reasoning.outbound,
@@ -619,10 +653,10 @@ class PassiveTurnPipeline:
             session=self._session.session_manager.get_or_create(session_key),
             persistence=persistence or _persistence_from_metadata(msg.metadata),
         )
-        after_reasoning = await self._after_reasoning.run(
+        after_reasoning = await self._runtime_phase("after_reasoning").run(
             AfterReasoningInput(state=state, turn_result=turn_result)
         )
-        return await self._after_turn.run(
+        return await self._runtime_phase("after_turn").run(
             TurnSnapshot(
                 state=state,
                 outbound=after_reasoning.outbound,
@@ -870,20 +904,34 @@ class DefaultReasoner(Reasoner):
 
     def _build_before_step_phase(
         self,
+        plugin_modules: list[object] | None = None,
     ) -> Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame]:
         return Phase(
             default_before_step_modules(
                 self._bus,
-                plugin_modules=cast("list[Any]", self._before_step_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._before_step_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=BeforeStepFrame,
         )
 
-    def _build_after_step_phase(self) -> Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame]:
+    def _build_after_step_phase(
+        self,
+        plugin_modules: list[object] | None = None,
+    ) -> Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame]:
         return Phase(
             default_after_step_modules(
                 self._bus,
-                plugin_modules=cast("list[Any]", self._after_step_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._after_step_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=AfterStepFrame,
         )
@@ -891,12 +939,18 @@ class DefaultReasoner(Reasoner):
     def _build_prompt_render_phase(
         self,
         context: "ContextBuilder",
+        plugin_modules: list[object] | None = None,
     ) -> Phase[PromptRenderInput, PromptRenderResult, PromptRenderFrame]:
         return Phase(
             default_prompt_render_modules(
                 self._bus,
                 context,
-                plugin_modules=cast("list[Any]", self._prompt_render_plugin_modules),
+                plugin_modules=cast(
+                    "list[Any]",
+                    self._prompt_render_plugin_modules
+                    if plugin_modules is None
+                    else plugin_modules,
+                ),
             ),
             frame_factory=PromptRenderFrame,
         )
@@ -907,9 +961,32 @@ class DefaultReasoner(Reasoner):
     ) -> PromptRenderResult:
         if self._context is None:
             raise RuntimeError("DefaultReasoner.render_prompt requires context")
+        snapshot = current_runtime_snapshot.get()
+        if snapshot is not None:
+            phase = self._build_prompt_render_phase(
+                self._context,
+                list(snapshot.prompt_render_modules),
+            )
+            return await phase.run(input)
         if self._prompt_render is None:
             self._prompt_render = self._build_prompt_render_phase(self._context)
         return await self._prompt_render.run(input)
+
+    def _runtime_before_step_phase(
+        self,
+    ) -> Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame]:
+        snapshot = current_runtime_snapshot.get()
+        if snapshot is None:
+            return self._before_step
+        return self._build_before_step_phase(list(snapshot.before_step_modules))
+
+    def _runtime_after_step_phase(
+        self,
+    ) -> Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame]:
+        snapshot = current_runtime_snapshot.get()
+        if snapshot is None:
+            return self._after_step
+        return self._build_after_step_phase(list(snapshot.after_step_modules))
 
     def set_stream_sink_factory(
         self,
@@ -1159,7 +1236,7 @@ class DefaultReasoner(Reasoner):
             ):
                 break
             # 3. BeforeStep 模块链：token 估算、BeforeStep 事件、提示注入。
-            step_ctx = await self._before_step.run(BeforeStepInput(
+            step_ctx = await self._runtime_before_step_phase().run(BeforeStepInput(
                 session_key=tool_event_session_key,
                 channel=tool_event_channel,
                 chat_id=tool_event_chat_id,
@@ -1602,7 +1679,7 @@ class DefaultReasoner(Reasoner):
                 tool_chain.append(tool_chain_group)
                 pressure_tokens = support.estimate_messages_tokens(messages)
                 # 7a. AfterStep 模块链（工具分支）：通知观察者本轮工具执行完毕。
-                after_step = await self._after_step.run(AfterStepCtx(
+                after_step = await self._runtime_after_step_phase().run(AfterStepCtx(
                     session_key=tool_event_session_key,
                     channel=tool_event_channel,
                     chat_id=tool_event_chat_id,
@@ -1683,7 +1760,7 @@ class DefaultReasoner(Reasoner):
             )
             messages.append({"role": "assistant", "content": response.content})
             # 8b. AfterStep 模块链（最终回复分支）：通知观察者本轮推理结束。
-            _ = await self._after_step.run(AfterStepCtx(
+            _ = await self._runtime_after_step_phase().run(AfterStepCtx(
                 session_key=tool_event_session_key,
                 channel=tool_event_channel,
                 chat_id=tool_event_chat_id,

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from core.memory.markdown import MemoryProfileApi
     from core.memory.runtime import MemoryRuntime
     from agent.tool_hooks.base import ToolHook
+    from agent.plugins.snapshot import RuntimeSnapshotStore
 
 logger = logging.getLogger("agent.loop")
 _MANUAL_CONSOLIDATION_TIMEOUT_SECONDS = 30.0
@@ -126,6 +127,7 @@ class AgentLoop:
         self._processing_state = deps.processing_state
         self._event_bus = deps.event_bus or EventBus()
         self._passive_runtime_lock = asyncio.Lock()
+        self._runtime_snapshot_store: RuntimeSnapshotStore | None = None
 
         # ── 中断控制面（纯内存态） ──
         self._active_tasks: dict[str, asyncio.Task] = {}
@@ -169,6 +171,9 @@ class AgentLoop:
         setter = getattr(self._reasoner, "set_stream_sink_factory", None)
         if callable(setter):
             _ = setter(self._wrap_stream_sink_factory(factory))
+
+    def bind_runtime_snapshot_store(self, store: RuntimeSnapshotStore) -> None:
+        self._runtime_snapshot_store = store
 
     def _configure_stream_events(self) -> None:
         setter = getattr(self._reasoner, "set_stream_sink_factory", None)
@@ -652,12 +657,28 @@ class AgentLoop:
         if self._passive_runtime_lock.locked():
             logger.info("[runtime_admission] 等待 passive runtime session=%s", key)
         async with self._passive_runtime_lock:
-            return await self._process(
-                msg,
-                session_key=session_key,
-                busy_session_key=busy_session_key,
-                dispatch_outbound=dispatch_outbound,
-            )
+            store = self._runtime_snapshot_store
+            if store is None or store.current is None:
+                return await self._process(
+                    msg,
+                    session_key=session_key,
+                    busy_session_key=busy_session_key,
+                    dispatch_outbound=dispatch_outbound,
+                )
+            from agent.plugins.snapshot import current_runtime_snapshot
+
+            lease = store.lease()
+            async with lease as snapshot:
+                token = current_runtime_snapshot.set(snapshot)
+                try:
+                    return await self._process(
+                        msg,
+                        session_key=session_key,
+                        busy_session_key=busy_session_key,
+                        dispatch_outbound=dispatch_outbound,
+                    )
+                finally:
+                    current_runtime_snapshot.reset(token)
 
     async def process_direct(
         self,

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -670,7 +670,7 @@ class AgentLoop:
                 reset_runtime_snapshot,
             )
 
-            lease = store.lease()
+            lease = await store.acquire()
             async with lease as snapshot:
                 token = bind_runtime_snapshot(lease)
                 try:

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -665,11 +665,14 @@ class AgentLoop:
                     busy_session_key=busy_session_key,
                     dispatch_outbound=dispatch_outbound,
                 )
-            from agent.plugins.snapshot import current_runtime_snapshot
+            from agent.plugins.snapshot import (
+                bind_runtime_snapshot,
+                reset_runtime_snapshot,
+            )
 
             lease = store.lease()
             async with lease as snapshot:
-                token = current_runtime_snapshot.set(snapshot)
+                token = bind_runtime_snapshot(lease)
                 try:
                     return await self._process(
                         msg,
@@ -678,7 +681,7 @@ class AgentLoop:
                         dispatch_outbound=dispatch_outbound,
                     )
                 finally:
-                    current_runtime_snapshot.reset(token)
+                    reset_runtime_snapshot(token)
 
     async def process_direct(
         self,

--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -54,6 +54,7 @@ class McpClient:
         self._tool_infos: list[McpToolInfo] = []
         self._recent_stdout: deque[str] = deque(maxlen=8)
         self._recent_stderr: deque[str] = deque(maxlen=8)
+        self._stderr_task: asyncio.Task[None] | None = None
 
     @property
     def tool_infos(self) -> list[McpToolInfo]:
@@ -65,7 +66,7 @@ class McpClient:
                 self._connect_impl(),
                 timeout=_CONNECT_TIMEOUT,
             )
-        except Exception:
+        except BaseException:
             await self.disconnect()
             raise
 
@@ -82,7 +83,10 @@ class McpClient:
             cwd=self.cwd,
             limit=_STREAM_LIMIT,
         )
-        _ = asyncio.create_task(self._drain_stderr())
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr(),
+            name=f"mcp_stderr:{self.name}",
+        )
 
         # initialize 握手
         init_id = self._new_id()
@@ -165,27 +169,43 @@ class McpClient:
         if self._process is None:
             return
         process = self._process
+        stopped = False
         try:
             if process.stdin is not None:
                 process.stdin.close()
-            _ = await asyncio.wait_for(
-                process.wait(),
-                timeout=_DISCONNECT_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            process.terminate()
             try:
                 _ = await asyncio.wait_for(
                     process.wait(),
                     timeout=_DISCONNECT_TIMEOUT,
                 )
+                stopped = True
             except asyncio.TimeoutError:
-                process.kill()
-                _ = await process.wait()
-        except Exception as e:
-            logger.warning("[mcp] 断开 %r 时出错: %s", self.name, e)
+                process.terminate()
+                try:
+                    _ = await asyncio.wait_for(
+                        process.wait(),
+                        timeout=_DISCONNECT_TIMEOUT,
+                    )
+                    stopped = True
+                except asyncio.TimeoutError:
+                    process.kill()
+                    _ = await process.wait()
+                    stopped = True
         finally:
-            self._process = None
+            try:
+                if not stopped:
+                    process.kill()
+                    _ = await process.wait()
+                    stopped = True
+            finally:
+                if stopped:
+                    self._process = None
+                stderr_task = self._stderr_task
+                self._stderr_task = None
+                if stderr_task is not None:
+                    if not stderr_task.done():
+                        _ = stderr_task.cancel()
+                    _ = await asyncio.gather(stderr_task, return_exceptions=True)
 
     def _new_id(self) -> int:
         i = self._next_id
@@ -251,16 +271,13 @@ class McpClient:
     async def _drain_stderr(self) -> None:
         """后台读取 stderr，防止缓冲区阻塞。"""
         assert self._process and self._process.stderr
-        try:
-            while True:
-                line = await self._process.stderr.readline()
-                if not line:
-                    break
-                text = line.decode().rstrip()
-                self._recent_stderr.append(text[:500])
-                logger.debug("[mcp:%s] stderr: %s", self.name, text)
-        except Exception:
-            pass
+        while True:
+            line = await self._process.stderr.readline()
+            if not line:
+                break
+            text = line.decode().rstrip()
+            self._recent_stderr.append(text[:500])
+            logger.debug("[mcp:%s] stderr: %s", self.name, text)
 
     def _build_timeout_message(
         self,

--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -7,7 +7,7 @@ import os
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,10 @@ class McpClient:
     def tool_infos(self) -> list[McpToolInfo]:
         return self._tool_infos
 
+    @property
+    def connected(self) -> bool:
+        return self._process is not None
+
     async def connect(self) -> list[McpToolInfo]:
         try:
             return await asyncio.wait_for(
@@ -102,7 +106,8 @@ class McpClient:
                 },
             }
         )
-        _ = await self._recv(expected_id=init_id, stage="initialize")
+        init_response = await self._recv(expected_id=init_id, stage="initialize")
+        _ = self._response_result(init_response, "initialize")
 
         # initialized 通知（无 id，不等响应）
         await self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
@@ -112,17 +117,31 @@ class McpClient:
         await self._send(
             {"jsonrpc": "2.0", "id": list_id, "method": "tools/list", "params": {}}
         )
-        resp = await self._recv(expected_id=list_id, stage="tools/list")
-
-        raw_tools = resp.get("result", {}).get("tools", [])
-        self._tool_infos = [
-            McpToolInfo(
-                name=t["name"],
-                description=t.get("description", ""),
-                input_schema=t.get("inputSchema", {"type": "object", "properties": {}}),
+        response = await self._recv(expected_id=list_id, stage="tools/list")
+        result = self._response_result(response, "tools/list")
+        raw_tools: object = result.get("tools", [])
+        if not isinstance(raw_tools, list):
+            raise RuntimeError(f"MCP server {self.name!r} tools/list.tools 不是 list")
+        tool_infos: list[McpToolInfo] = []
+        for raw_tool in cast(list[object], raw_tools):
+            if not isinstance(raw_tool, dict):
+                raise RuntimeError(f"MCP server {self.name!r} 返回了无效 tool")
+            tool = cast(dict[str, Any], raw_tool)
+            name = tool.get("name")
+            schema = tool.get(
+                "inputSchema",
+                {"type": "object", "properties": {}},
             )
-            for t in raw_tools
-        ]
+            if not isinstance(name, str) or not name or not isinstance(schema, dict):
+                raise RuntimeError(f"MCP server {self.name!r} 返回了无效 tool")
+            tool_infos.append(
+                McpToolInfo(
+                    name=name,
+                    description=str(tool.get("description") or ""),
+                    input_schema=cast(dict[str, Any], schema),
+                )
+            )
+        self._tool_infos = tool_infos
         logger.debug(
             "[mcp] %r 已连接，工具：%s", self.name, [t.name for t in self._tool_infos]
         )
@@ -248,10 +267,13 @@ class McpClient:
                 continue
             self._recent_stdout.append(text[:500])
             try:
-                msg = json.loads(text)
+                raw_message: object = json.loads(text)
             except json.JSONDecodeError:
                 logger.debug("[mcp:%s] 非 JSON 输出: %s", self.name, text[:200])
                 continue
+            if not isinstance(raw_message, dict):
+                raise RuntimeError(f"MCP server {self.name!r} 返回了非对象响应")
+            msg = cast(dict[str, Any], raw_message)
             # 跳过通知（有 method 但无 id）
             if "method" in msg and "id" not in msg:
                 logger.debug("[mcp:%s] <- notification: %s", self.name, text[:400])
@@ -267,6 +289,22 @@ class McpClient:
                 continue
             logger.debug("[mcp:%s] <- %s", self.name, text[:400])
             return msg
+
+    def _response_result(
+        self,
+        response: dict[str, Any],
+        stage: str,
+    ) -> dict[str, Any]:
+        if "error" in response:
+            raise RuntimeError(
+                f"MCP server {self.name!r} {stage} 失败: {response['error']}"
+            )
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"MCP server {self.name!r} {stage} 返回了无效 result"
+            )
+        return cast(dict[str, Any], result)
 
     async def _drain_stderr(self) -> None:
         """后台读取 stderr，防止缓冲区阻塞。"""

--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -62,7 +62,7 @@ class McpClient:
 
     @property
     def connected(self) -> bool:
-        return self._process is not None
+        return self._process is not None and self._process.returncode is None
 
     async def connect(self) -> list[McpToolInfo]:
         try:

--- a/agent/mcp/registry.py
+++ b/agent/mcp/registry.py
@@ -146,6 +146,9 @@ class McpServerRegistry:
             lines.append(f"- {name}（{len(tools)} 个工具）：{', '.join(tools) or '无'}")
         return "\n".join(lines)
 
+    def connected_server_names(self) -> set[str]:
+        return set(self._clients)
+
     async def _connect(
         self,
         name: str,

--- a/agent/mcp/tool.py
+++ b/agent/mcp/tool.py
@@ -13,17 +13,24 @@ class McpToolWrapper(Tool):
     避免与内置工具冲突，也方便按 server 识别。
     """
 
-    def __init__(self, client: McpClient, info: McpToolInfo) -> None:
+    def __init__(
+        self,
+        client: McpClient,
+        info: McpToolInfo,
+        *,
+        server_name: str | None = None,
+    ) -> None:
         self._client = client
         self._info = info
+        self._server_name = server_name or client.name
 
     @property
     def name(self) -> str:
-        return f"mcp_{self._client.name}__{self._info.name}"
+        return f"mcp_{self._server_name}__{self._info.name}"
 
     @property
     def description(self) -> str:
-        return f"[MCP:{self._client.name}] {self._info.description}"
+        return f"[MCP:{self._server_name}] {self._info.description}"
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/agent/plugins/__init__.py
+++ b/agent/plugins/__init__.py
@@ -1,6 +1,7 @@
 from agent.plugins.base import Plugin
 from agent.plugins.config import PluginConfig
 from agent.plugins.context import PluginContext, PluginKVStore
+from agent.plugins.scope import CleanupFailure, PluginScope
 from agent.plugins.decorators import (
     on_before_turn,
     on_before_reasoning,
@@ -31,6 +32,8 @@ __all__ = [
     "PluginConfig",
     "PluginContext",
     "PluginKVStore",
+    "CleanupFailure",
+    "PluginScope",
     "EventTrigger",
     "IntervalTrigger",
     "PluginJobContext",

--- a/agent/plugins/__init__.py
+++ b/agent/plugins/__init__.py
@@ -29,6 +29,7 @@ from agent.plugins.jobs import (
     PluginJobSpec,
 )
 from agent.plugins.specs import (
+    ManagedServiceSpec,
     McpServerSpec,
     ProactiveSourceSpec,
     RegisteredProactiveSource,
@@ -51,6 +52,7 @@ __all__ = [
     "PluginJobContext",
     "PluginJobSpec",
     "McpServerSpec",
+    "ManagedServiceSpec",
     "ProactiveSourceSpec",
     "RegisteredProactiveSource",
     "on_before_turn",

--- a/agent/plugins/__init__.py
+++ b/agent/plugins/__init__.py
@@ -2,6 +2,12 @@ from agent.plugins.base import Plugin
 from agent.plugins.config import PluginConfig
 from agent.plugins.context import PluginContext, PluginKVStore
 from agent.plugins.scope import CleanupFailure, PluginScope
+from agent.plugins.generation import (
+    GateCheckResult,
+    GateResult,
+    PluginGeneration,
+    PluginSemanticCheck,
+)
 from agent.plugins.decorators import (
     on_before_turn,
     on_before_reasoning,
@@ -34,6 +40,10 @@ __all__ = [
     "PluginKVStore",
     "CleanupFailure",
     "PluginScope",
+    "GateCheckResult",
+    "GateResult",
+    "PluginGeneration",
+    "PluginSemanticCheck",
     "EventTrigger",
     "IntervalTrigger",
     "PluginJobContext",

--- a/agent/plugins/__init__.py
+++ b/agent/plugins/__init__.py
@@ -6,6 +6,7 @@ from agent.plugins.generation import (
     GateCheckResult,
     GateResult,
     PluginGeneration,
+    PluginReadinessContext,
     PluginSemanticCheck,
 )
 from agent.plugins.decorators import (
@@ -43,6 +44,7 @@ __all__ = [
     "GateCheckResult",
     "GateResult",
     "PluginGeneration",
+    "PluginReadinessContext",
     "PluginSemanticCheck",
     "EventTrigger",
     "IntervalTrigger",

--- a/agent/plugins/activity_host.py
+++ b/agent/plugins/activity_host.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import MappingProxyType
 
 from agent.plugins.jobs import (
@@ -40,7 +40,10 @@ class PluginJobHost:
             if key in compiled:
                 raise RuntimeError(f"插件 Job 稳定键重复: {key}")
             self._validate(job)
-            compiled[key] = job
+            compiled[key] = replace(
+                job,
+                spec=replace(job.spec, triggers=tuple(job.spec.triggers)),
+            )
         catalog = PreparedJobCatalog(
             generation_id=generation_id,
             jobs=MappingProxyType(compiled),

--- a/agent/plugins/activity_host.py
+++ b/agent/plugins/activity_host.py
@@ -98,7 +98,10 @@ class PluginProactiveHost:
             key = proactive_source_key(source)
             if key in compiled:
                 raise RuntimeError(f"proactive source 稳定键重复: {key}")
-            compiled[key] = source
+            compiled[key] = replace(
+                source,
+                spec=replace(source.spec, channels=tuple(source.spec.channels)),
+            )
         catalog = PreparedProactiveCatalog(
             generation_id=generation_id,
             sources=MappingProxyType(compiled),

--- a/agent/plugins/activity_host.py
+++ b/agent/plugins/activity_host.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from agent.plugins.jobs import (
+    EventTrigger,
+    IntervalTrigger,
+    RegisteredPluginJob,
+    plugin_job_key,
+)
+from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
+
+
+@dataclass(frozen=True)
+class PreparedJobCatalog:
+    generation_id: str
+    jobs: Mapping[str, RegisteredPluginJob]
+
+
+@dataclass(frozen=True)
+class PreparedProactiveCatalog:
+    generation_id: str
+    sources: Mapping[str, RegisteredProactiveSource]
+
+
+class PluginJobHost:
+    def __init__(self) -> None:
+        self._catalogs: dict[str, PreparedJobCatalog] = {}
+
+    def prepare(
+        self,
+        generation_id: str,
+        jobs: tuple[RegisteredPluginJob, ...],
+    ) -> PreparedJobCatalog:
+        compiled: dict[str, RegisteredPluginJob] = {}
+        for job in jobs:
+            key = plugin_job_key(job)
+            if key in compiled:
+                raise RuntimeError(f"插件 Job 稳定键重复: {key}")
+            self._validate(job)
+            compiled[key] = job
+        catalog = PreparedJobCatalog(
+            generation_id=generation_id,
+            jobs=MappingProxyType(compiled),
+        )
+        self._catalogs[generation_id] = catalog
+        return catalog
+
+    def close(self, generation_id: str) -> None:
+        _ = self._catalogs.pop(generation_id, None)
+
+    def get(self, generation_id: str) -> PreparedJobCatalog | None:
+        return self._catalogs.get(generation_id)
+
+    @staticmethod
+    def _validate(job: RegisteredPluginJob) -> None:
+        spec = job.spec
+        if not callable(spec.handler):
+            raise RuntimeError(f"插件 Job handler 不可调用: {plugin_job_key(job)}")
+        if (
+            isinstance(spec.debounce_seconds, bool)
+            or not isinstance(spec.debounce_seconds, int)
+            or spec.debounce_seconds < 0
+            or not isinstance(spec.coalesce, bool)
+        ):
+            raise RuntimeError(f"插件 Job 策略无效: {plugin_job_key(job)}")
+        for trigger in spec.triggers:
+            if isinstance(trigger, IntervalTrigger):
+                if (
+                    isinstance(trigger.seconds, bool)
+                    or not isinstance(trigger.seconds, int)
+                    or trigger.seconds <= 0
+                ):
+                    raise RuntimeError(f"插件 Job interval 无效: {plugin_job_key(job)}")
+            elif isinstance(trigger, EventTrigger):
+                if not isinstance(trigger.event_type, type):
+                    raise RuntimeError(f"插件 Job event type 无效: {plugin_job_key(job)}")
+            else:
+                raise RuntimeError(f"插件 Job trigger 无效: {plugin_job_key(job)}")
+
+
+class PluginProactiveHost:
+    def __init__(self) -> None:
+        self._catalogs: dict[str, PreparedProactiveCatalog] = {}
+
+    def prepare(
+        self,
+        generation_id: str,
+        sources: tuple[RegisteredProactiveSource, ...],
+    ) -> PreparedProactiveCatalog:
+        compiled: dict[str, RegisteredProactiveSource] = {}
+        for source in sources:
+            key = proactive_source_key(source)
+            if key in compiled:
+                raise RuntimeError(f"proactive source 稳定键重复: {key}")
+            compiled[key] = source
+        catalog = PreparedProactiveCatalog(
+            generation_id=generation_id,
+            sources=MappingProxyType(compiled),
+        )
+        self._catalogs[generation_id] = catalog
+        return catalog
+
+    def close(self, generation_id: str) -> None:
+        _ = self._catalogs.pop(generation_id, None)
+
+    def get(self, generation_id: str) -> PreparedProactiveCatalog | None:
+        return self._catalogs.get(generation_id)

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -32,6 +32,9 @@ class Plugin(ABC):
     def static_semantic_checks(self) -> list["PluginSemanticCheck"]:
         return []
 
+    def readiness_semantic_checks(self) -> list["PluginSemanticCheck"]:
+        return []
+
     @classmethod
     def skill_roots(cls) -> tuple[str, ...]:
         return ()

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -9,9 +9,11 @@ if TYPE_CHECKING:
     from agent.plugins.context import PluginContext
     from agent.plugins.jobs import PluginJobSpec
     from agent.plugins.specs import McpServerSpec, ProactiveSourceSpec
+    from agent.plugins.generation import PluginSemanticCheck
 
 
 class Plugin(ABC):
+    api_version: int = 1
     name: str | None = None
     version: str | None = None
     desc: str | None = None
@@ -26,6 +28,9 @@ class Plugin(ABC):
 
     async def initialize(self) -> None: ...
     async def terminate(self) -> None: ...
+
+    def static_semantic_checks(self) -> list["PluginSemanticCheck"]:
+        return []
 
     @classmethod
     def skill_roots(cls) -> tuple[str, ...]:

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -92,3 +92,7 @@ class Plugin(ABC):
 
     def channels(self) -> list["Channel"]:
         return []
+
+    @classmethod
+    def dashboard_module(cls) -> str | None:
+        return None

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from agent.plugins.jobs import PluginJobSpec
     from agent.plugins.specs import McpServerSpec, ProactiveSourceSpec
     from agent.plugins.generation import PluginSemanticCheck
+    from agent.plugins.generation import PluginReadinessContext
 
 
 class Plugin(ABC):
@@ -32,7 +33,10 @@ class Plugin(ABC):
     def static_semantic_checks(self) -> list["PluginSemanticCheck"]:
         return []
 
-    def readiness_semantic_checks(self) -> list["PluginSemanticCheck"]:
+    async def readiness_semantic_checks(
+        self,
+        context: "PluginReadinessContext",
+    ) -> list["PluginSemanticCheck"]:
         return []
 
     @classmethod

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from infra.channels.contract import Channel
     from agent.plugins.context import PluginContext
     from agent.plugins.jobs import PluginJobSpec
-    from agent.plugins.specs import McpServerSpec, ProactiveSourceSpec
+    from agent.plugins.specs import ManagedServiceSpec, McpServerSpec, ProactiveSourceSpec
     from agent.plugins.generation import PluginSemanticCheck
     from agent.plugins.generation import PluginReadinessContext
 
@@ -49,6 +49,10 @@ class Plugin(ABC):
 
     @classmethod
     def mcp_servers(cls) -> list["McpServerSpec"]:
+        return []
+
+    @classmethod
+    def managed_services(cls) -> list["ManagedServiceSpec"]:
         return []
 
     def proactive_sources(self) -> list["ProactiveSourceSpec"]:

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -60,20 +60,21 @@ class PluginContext:
 
 
 class PluginKVStore:
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, writable: bool = True) -> None:
         self._path = path
+        self._writable = writable
 
     def get(self, key: str, default: Any = None) -> Any:
         return self._read().get(key, default)
 
     def set(self, key: str, value: Any) -> None:
-        # 1. 读取现有数据，写入新值，落盘
+        self._require_writable()
         data = self._read()
         data[key] = value
         self._write(data)
 
     def increment(self, key: str, delta: int = 1) -> int:
-        # 1. 读取 → 加 delta → 写回，返回新值
+        self._require_writable()
         data = self._read()
         new_val = int(data.get(key, 0)) + delta
         data[key] = new_val
@@ -90,3 +91,7 @@ class PluginKVStore:
         _ = self._path.write_text(
             json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
         )
+
+    def _require_writable(self) -> None:
+        if not self._writable:
+            raise RuntimeError("候选声明阶段禁止写入插件 KV")

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -30,6 +30,7 @@ class PluginContext:
     memory_engine: Any = None
     llm: "PluginLlmService | None" = None
     scope: "PluginScope | None" = None
+    generation_id: str = ""
 
     def create_task(
         self,

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
+
+T = TypeVar("T")
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
     from agent.plugins.config import PluginConfig
     from agent.plugins.jobs import PluginLlmService
+    from agent.plugins.scope import PluginScope, ScopedEventBus
 
 
 @dataclass
 class PluginContext:
-    event_bus: Any
+    event_bus: "ScopedEventBus"
     tool_registry: Any
     plugin_id: str
     plugin_dir: Path
@@ -24,6 +29,33 @@ class PluginContext:
     session_manager: Any = None
     memory_engine: Any = None
     llm: "PluginLlmService | None" = None
+    scope: "PluginScope | None" = None
+
+    def create_task(
+        self,
+        coroutine: Coroutine[Any, Any, T],
+        *,
+        name: str | None = None,
+    ) -> Any:
+        if self.scope is None:
+            raise RuntimeError(f"插件缺少资源作用域: {self.plugin_id}")
+        return self.scope.create_task(coroutine, name=name)
+
+    def defer(self, resource: str, cleanup: Any) -> None:
+        if self.scope is None:
+            raise RuntimeError(f"插件缺少资源作用域: {self.plugin_id}")
+        self.scope.defer(resource, cleanup)
+
+    def track_process(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        name: str,
+        timeout: float = 5,
+    ) -> None:
+        if self.scope is None:
+            raise RuntimeError(f"插件缺少资源作用域: {self.plugin_id}")
+        self.scope.track_process(process, name=name, timeout=timeout)
 
 
 class PluginKVStore:

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from fastapi import FastAPI
+from starlette.routing import Match
+
+from agent.plugins.generation import PluginGeneration
+from agent.plugins.snapshot import (
+    RuntimeSnapshot,
+    RuntimeSnapshotStore,
+    bind_runtime_snapshot,
+    reset_runtime_snapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DashboardBinding:
+    app: FastAPI
+    routes: tuple[object, ...]
+
+    def matches(self, scope: dict[str, Any]) -> bool:
+        return any(route.matches(scope)[0] is Match.FULL for route in self.routes)
+
+
+class PluginDashboardHost:
+    def __init__(
+        self,
+        *,
+        workspace: Path,
+        memory_admin: object,
+        memory_store: object,
+    ) -> None:
+        self._workspace = workspace
+        self._memory_admin = memory_admin
+        self._memory_store = memory_store
+        self._bindings: dict[str, DashboardBinding] = {}
+        self._unavailable: set[str] = set()
+
+    def prepare_snapshot(self, snapshot: RuntimeSnapshot) -> None:
+        self._prepare_snapshot(snapshot, tolerate_failures=False)
+
+    def prepare_initial_snapshot(self, snapshot: RuntimeSnapshot) -> None:
+        self._prepare_snapshot(snapshot, tolerate_failures=True)
+
+    def _prepare_snapshot(
+        self,
+        snapshot: RuntimeSnapshot,
+        *,
+        tolerate_failures: bool,
+    ) -> None:
+        bindings: list[DashboardBinding] = []
+        for generation in snapshot.generations.values():
+            module_path = generation.contributions.dashboard_module
+            generation_id = generation.generation_id
+            if module_path is None or generation_id in self._unavailable:
+                continue
+            binding = self._bindings.get(generation_id)
+            if binding is None:
+                try:
+                    binding = self._build_binding(generation, module_path)
+                except Exception as error:
+                    if not tolerate_failures:
+                        raise
+                    self._unavailable.add(generation_id)
+
+                    def remove_unavailable(
+                        generation_id: str = generation_id,
+                    ) -> None:
+                        self._unavailable.discard(generation_id)
+
+                    generation.scope.defer(
+                        "dashboard_unavailable",
+                        remove_unavailable,
+                    )
+                    logger.warning(
+                        "初始插件 dashboard 挂载失败 (%s): %s",
+                        generation.plugin_id,
+                        error,
+                    )
+                    continue
+                self._bindings[generation_id] = binding
+
+                def remove_binding(
+                    generation_id: str = generation_id,
+                ) -> None:
+                    _ = self._bindings.pop(generation_id, None)
+
+                generation.scope.defer(
+                    "dashboard",
+                    remove_binding,
+                )
+            bindings.append(binding)
+        snapshot.dashboard_bindings = tuple(bindings)
+
+    def _build_binding(
+        self,
+        generation: PluginGeneration,
+        module_path: Path,
+    ) -> DashboardBinding:
+        app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+        app.state.memory_admin = self._memory_admin
+        app.state.memory_store = self._memory_store
+        name = f"{generation.module_path}.dashboard"
+        module = ModuleType(name)
+        module.__file__ = str(module_path)
+        module.__package__ = generation.module_path
+        sys.modules[name] = module
+        try:
+            source = module_path.read_text(encoding="utf-8")
+            exec(compile(source, str(module_path), "exec"), module.__dict__)
+            register = getattr(module, "register", None)
+            if not callable(register):
+                raise RuntimeError(f"dashboard module 缺少 register: {module_path}")
+            enabled = getattr(module, "plugin_enabled", None)
+            closeables = (
+                []
+                if callable(enabled) and not enabled(app)
+                else _closeables(register(app, module_path.parent, self._workspace))
+            )
+        except BaseException:
+            _ = sys.modules.pop(name, None)
+            raise
+
+        def remove_module() -> None:
+            _ = sys.modules.pop(name, None)
+
+        generation.scope.defer("dashboard_module", remove_module)
+        for index, closeable in enumerate(closeables):
+            generation.scope.defer(
+                f"dashboard_closeable:{index}",
+                getattr(closeable, "close"),
+            )
+        return DashboardBinding(app=app, routes=tuple(app.routes))
+
+
+class SnapshotDashboardMiddleware:
+    def __init__(self, app: object, snapshot_store: RuntimeSnapshotStore) -> None:
+        self._app = app
+        self._snapshot_store = snapshot_store
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") == "http" and self._snapshot_store.current is not None:
+            lease = self._snapshot_store.lease()
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    for raw_binding in lease.snapshot.dashboard_bindings:
+                        binding = raw_binding
+                        if isinstance(binding, DashboardBinding) and binding.matches(scope):
+                            await binding.app(scope, receive, send)
+                            return
+                finally:
+                    reset_runtime_snapshot(token)
+        await self._app(scope, receive, send)  # type: ignore[operator]
+
+
+def _closeables(value: object) -> list[object]:
+    values = value if isinstance(value, list) else [value]
+    return [item for item in values if callable(getattr(item, "close", None))]

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import inspect
+import re
 import sys
 from dataclasses import dataclass
 from collections.abc import Sequence
@@ -45,7 +47,7 @@ class PluginDashboardHost:
         self._workspace = workspace
         self._memory_admin = memory_admin
         self._memory_store = memory_store
-        self._core_route_keys = _core_route_keys(core_routes)
+        self._core_routes = _core_routes(core_routes)
         self._bindings: dict[str, DashboardBinding] = {}
         self._unavailable: set[str] = set()
 
@@ -62,7 +64,7 @@ class PluginDashboardHost:
         tolerate_failures: bool,
     ) -> None:
         bindings: list[DashboardBinding] = []
-        occupied = set(self._core_route_keys)
+        occupied = list(self._core_routes)
         for generation in snapshot.generations.values():
             module_path = generation.contributions.dashboard_module
             generation_id = generation.generation_id
@@ -108,9 +110,9 @@ class PluginDashboardHost:
                     remove_binding,
                 )
             else:
-                _require_route_keys_available(binding, occupied)
+                _require_routes_available(binding, occupied)
             bindings.append(binding)
-            occupied.update(_binding_route_keys(binding))
+            occupied.extend(binding.routes)
         snapshot.dashboard_bindings = tuple(bindings)
 
     def _build_binding(
@@ -118,7 +120,7 @@ class PluginDashboardHost:
         generation: PluginGeneration,
         module_path: Path,
         *,
-        occupied: set[tuple[str, str]],
+        occupied: list[APIRoute],
     ) -> DashboardBinding:
         app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
         app.state.memory_admin = self._memory_admin
@@ -141,6 +143,7 @@ class PluginDashboardHost:
                 if callable(enabled) and not enabled(app)
                 else _closeables(register(app, module_path.parent, self._workspace))
             )
+            _validate_closeables(closeables)
             if app.router.on_startup or app.router.on_shutdown:
                 raise RuntimeError("dashboard module 不支持 startup/shutdown hook")
             routes = _plugin_routes(app.routes)
@@ -149,10 +152,16 @@ class PluginDashboardHost:
                 app=app,
                 routes=routes,
             )
-            _require_route_keys_available(binding, occupied)
+            _require_routes_available(binding, occupied)
         except BaseException:
             for closeable in reversed(closeables):
-                _ = closeable.close()  # type: ignore[attr-defined]
+                try:
+                    _ = closeable.close()  # type: ignore[attr-defined]
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "dashboard closeable 清理失败: %s",
+                        cleanup_error,
+                    )
             _ = sys.modules.pop(name, None)
             raise
 
@@ -202,28 +211,50 @@ def _plugin_routes(routes: Sequence[object]) -> tuple[APIRoute, ...]:
     return tuple(route for route in routes if isinstance(route, APIRoute))
 
 
-def _core_route_keys(routes: tuple[object, ...]) -> set[tuple[str, str]]:
-    return {
-        (route.path, method)
-        for route in routes
-        if isinstance(route, APIRoute)
-        for method in route.methods
-    }
+def _core_routes(routes: tuple[object, ...]) -> tuple[APIRoute, ...]:
+    return tuple(route for route in routes if isinstance(route, APIRoute))
 
 
-def _binding_route_keys(binding: DashboardBinding) -> set[tuple[str, str]]:
-    return {
-        (route.path, method)
-        for route in binding.routes
-        for method in route.methods
-    }
-
-
-def _require_route_keys_available(
+def _require_routes_available(
     binding: DashboardBinding,
-    occupied: set[tuple[str, str]],
+    occupied: list[APIRoute],
 ) -> None:
-    conflicts = sorted(_binding_route_keys(binding).intersection(occupied))
+    conflicts: list[str] = []
+    for index, route in enumerate(binding.routes):
+        for other in [*occupied, *binding.routes[:index]]:
+            methods = sorted(route.methods.intersection(other.methods))
+            if methods and _route_paths_overlap(route, other):
+                conflicts.append(
+                    f"{','.join(methods)} {route.path} <> {other.path}"
+                )
     if conflicts:
-        values = ", ".join(f"{method} {path}" for path, method in conflicts)
-        raise RuntimeError(f"dashboard route 冲突: {values}")
+        raise RuntimeError(f"dashboard route 冲突: {', '.join(conflicts)}")
+
+
+def _route_paths_overlap(first: APIRoute, second: APIRoute) -> bool:
+    first_sample = _sample_route_path(first)
+    second_sample = _sample_route_path(second)
+    return bool(
+        first.path_regex.fullmatch(second_sample)
+        or second.path_regex.fullmatch(first_sample)
+    )
+
+
+def _sample_route_path(route: APIRoute) -> str:
+    def replace(match: re.Match[str]) -> str:
+        convertor = route.param_convertors[match.group(1)]
+        regex = re.compile(f"^(?:{convertor.regex})$")
+        for candidate in ("x", "1", "1.0", "00000000-0000-0000-0000-000000000000", "x/y"):
+            if regex.fullmatch(candidate):
+                return candidate
+        raise RuntimeError(f"dashboard route convertor 不受支持: {route.path}")
+
+    return re.sub(r"\{([^}:]+)(?::[^}]+)?\}", replace, route.path)
+
+
+def _validate_closeables(closeables: list[object]) -> None:
+    if any(
+        inspect.iscoroutinefunction(getattr(closeable, "close", None))
+        for closeable in closeables
+    ):
+        raise RuntimeError("dashboard closeable.close 必须是同步函数")

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -241,9 +241,19 @@ def _require_routes_available(
 ) -> None:
     conflicts: list[str] = []
     for index, route in enumerate(binding.routes):
-        for other in [*occupied, *binding.routes[:index]]:
+        for other in occupied:
             methods = sorted(route.methods.intersection(other.methods))
             if methods and _route_paths_overlap(route, other):
+                conflicts.append(
+                    f"{','.join(methods)} {route.path} <> {other.path}"
+                )
+        for other in binding.routes[:index]:
+            methods = sorted(route.methods.intersection(other.methods))
+            if (
+                methods
+                and _route_paths_overlap(route, other)
+                and not _ordered_static_route_wins(other, route)
+            ):
                 conflicts.append(
                     f"{','.join(methods)} {route.path} <> {other.path}"
                 )
@@ -258,6 +268,10 @@ def _route_paths_overlap(first: APIRoute, second: APIRoute) -> bool:
         first.path_regex.fullmatch(second_sample)
         or second.path_regex.fullmatch(first_sample)
     )
+
+
+def _ordered_static_route_wins(first: APIRoute, second: APIRoute) -> bool:
+    return not first.param_convertors and bool(second.param_convertors)
 
 
 def _sample_route_path(route: APIRoute) -> str:

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -271,11 +271,11 @@ def _route_paths_overlap(first: APIRoute, second: APIRoute) -> bool:
 
 
 def _overlapping_methods(first: APIRoute, second: APIRoute) -> list[str]:
-    if first.methods is None and second.methods is None:
+    if not first.methods and not second.methods:
         return ["*"]
-    if first.methods is None:
+    if not first.methods:
         return sorted(second.methods or ())
-    if second.methods is None:
+    if not second.methods:
         return sorted(first.methods)
     return sorted(first.methods.intersection(second.methods))
 

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import logging
 import sys
 from dataclasses import dataclass
+from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any
 
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from starlette.routing import Match
 
 from agent.plugins.generation import PluginGeneration
@@ -23,8 +25,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class DashboardBinding:
+    plugin_id: str
     app: FastAPI
-    routes: tuple[object, ...]
+    routes: tuple[APIRoute, ...]
 
     def matches(self, scope: dict[str, Any]) -> bool:
         return any(route.matches(scope)[0] is Match.FULL for route in self.routes)
@@ -37,10 +40,12 @@ class PluginDashboardHost:
         workspace: Path,
         memory_admin: object,
         memory_store: object,
+        core_routes: tuple[object, ...],
     ) -> None:
         self._workspace = workspace
         self._memory_admin = memory_admin
         self._memory_store = memory_store
+        self._core_route_keys = _core_route_keys(core_routes)
         self._bindings: dict[str, DashboardBinding] = {}
         self._unavailable: set[str] = set()
 
@@ -57,6 +62,7 @@ class PluginDashboardHost:
         tolerate_failures: bool,
     ) -> None:
         bindings: list[DashboardBinding] = []
+        occupied = set(self._core_route_keys)
         for generation in snapshot.generations.values():
             module_path = generation.contributions.dashboard_module
             generation_id = generation.generation_id
@@ -65,7 +71,11 @@ class PluginDashboardHost:
             binding = self._bindings.get(generation_id)
             if binding is None:
                 try:
-                    binding = self._build_binding(generation, module_path)
+                    binding = self._build_binding(
+                        generation,
+                        module_path,
+                        occupied=occupied,
+                    )
                 except Exception as error:
                     if not tolerate_failures:
                         raise
@@ -97,13 +107,18 @@ class PluginDashboardHost:
                     "dashboard",
                     remove_binding,
                 )
+            else:
+                _require_route_keys_available(binding, occupied)
             bindings.append(binding)
+            occupied.update(_binding_route_keys(binding))
         snapshot.dashboard_bindings = tuple(bindings)
 
     def _build_binding(
         self,
         generation: PluginGeneration,
         module_path: Path,
+        *,
+        occupied: set[tuple[str, str]],
     ) -> DashboardBinding:
         app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
         app.state.memory_admin = self._memory_admin
@@ -113,6 +128,7 @@ class PluginDashboardHost:
         module.__file__ = str(module_path)
         module.__package__ = generation.module_path
         sys.modules[name] = module
+        closeables: list[object] = []
         try:
             source = module_path.read_text(encoding="utf-8")
             exec(compile(source, str(module_path), "exec"), module.__dict__)
@@ -125,7 +141,18 @@ class PluginDashboardHost:
                 if callable(enabled) and not enabled(app)
                 else _closeables(register(app, module_path.parent, self._workspace))
             )
+            if app.router.on_startup or app.router.on_shutdown:
+                raise RuntimeError("dashboard module 不支持 startup/shutdown hook")
+            routes = _plugin_routes(app.routes)
+            binding = DashboardBinding(
+                plugin_id=generation.plugin_id,
+                app=app,
+                routes=routes,
+            )
+            _require_route_keys_available(binding, occupied)
         except BaseException:
+            for closeable in reversed(closeables):
+                _ = closeable.close()  # type: ignore[attr-defined]
             _ = sys.modules.pop(name, None)
             raise
 
@@ -138,7 +165,7 @@ class PluginDashboardHost:
                 f"dashboard_closeable:{index}",
                 getattr(closeable, "close"),
             )
-        return DashboardBinding(app=app, routes=tuple(app.routes))
+        return binding
 
 
 class SnapshotDashboardMiddleware:
@@ -157,6 +184,8 @@ class SnapshotDashboardMiddleware:
                         if isinstance(binding, DashboardBinding) and binding.matches(scope):
                             await binding.app(scope, receive, send)
                             return
+                    await self._app(scope, receive, send)  # type: ignore[operator]
+                    return
                 finally:
                     reset_runtime_snapshot(token)
         await self._app(scope, receive, send)  # type: ignore[operator]
@@ -165,3 +194,36 @@ class SnapshotDashboardMiddleware:
 def _closeables(value: object) -> list[object]:
     values = value if isinstance(value, list) else [value]
     return [item for item in values if callable(getattr(item, "close", None))]
+
+
+def _plugin_routes(routes: Sequence[object]) -> tuple[APIRoute, ...]:
+    if any(not isinstance(route, APIRoute) for route in routes):
+        raise RuntimeError("dashboard module 只支持 HTTP API route")
+    return tuple(route for route in routes if isinstance(route, APIRoute))
+
+
+def _core_route_keys(routes: tuple[object, ...]) -> set[tuple[str, str]]:
+    return {
+        (route.path, method)
+        for route in routes
+        if isinstance(route, APIRoute)
+        for method in route.methods
+    }
+
+
+def _binding_route_keys(binding: DashboardBinding) -> set[tuple[str, str]]:
+    return {
+        (route.path, method)
+        for route in binding.routes
+        for method in route.methods
+    }
+
+
+def _require_route_keys_available(
+    binding: DashboardBinding,
+    occupied: set[tuple[str, str]],
+) -> None:
+    conflicts = sorted(_binding_route_keys(binding).intersection(occupied))
+    if conflicts:
+        values = ", ".join(f"{method} {path}" for path, method in conflicts)
+        raise RuntimeError(f"dashboard route 冲突: {values}")

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -215,15 +215,15 @@ def _plugin_routes(routes: Sequence[object]) -> tuple[APIRoute, ...]:
     if any(not isinstance(route, APIRoute) for route in routes):
         raise RuntimeError("dashboard module 只支持 HTTP API route")
     typed = tuple(route for route in routes if isinstance(route, APIRoute))
-    builtin_convertors = (
+    builtin_convertor_types = {
         StringConvertor,
         PathConvertor,
         IntegerConvertor,
         FloatConvertor,
         UUIDConvertor,
-    )
+    }
     if any(
-        not isinstance(convertor, builtin_convertors)
+        type(convertor) not in builtin_convertor_types
         for route in typed
         for convertor in route.param_convertors.values()
     ):

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import inspect
 import re
 import sys
 from dataclasses import dataclass
@@ -12,6 +11,13 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
+from starlette.convertors import (
+    FloatConvertor,
+    IntegerConvertor,
+    PathConvertor,
+    StringConvertor,
+    UUIDConvertor,
+)
 from starlette.routing import Match
 
 from agent.plugins.generation import PluginGeneration
@@ -23,6 +29,10 @@ from agent.plugins.snapshot import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _DashboardImportError(RuntimeError):
+    pass
 
 
 @dataclass
@@ -79,7 +89,10 @@ class PluginDashboardHost:
                         occupied=occupied,
                     )
                 except Exception as error:
-                    if not tolerate_failures:
+                    if not tolerate_failures or not isinstance(
+                        error,
+                        _DashboardImportError,
+                    ):
                         raise
                     self._unavailable.add(generation_id)
 
@@ -130,10 +143,12 @@ class PluginDashboardHost:
         module.__file__ = str(module_path)
         module.__package__ = generation.module_path
         sys.modules[name] = module
-        closeables: list[object] = []
         try:
             source = module_path.read_text(encoding="utf-8")
-            exec(compile(source, str(module_path), "exec"), module.__dict__)
+            try:
+                exec(compile(source, str(module_path), "exec"), module.__dict__)
+            except Exception as error:
+                raise _DashboardImportError(str(error)) from error
             register = getattr(module, "register", None)
             if not callable(register):
                 raise RuntimeError(f"dashboard module 缺少 register: {module_path}")
@@ -143,7 +158,11 @@ class PluginDashboardHost:
                 if callable(enabled) and not enabled(app)
                 else _closeables(register(app, module_path.parent, self._workspace))
             )
-            _validate_closeables(closeables)
+            for index, closeable in enumerate(closeables):
+                generation.scope.defer(
+                    f"dashboard_closeable:{index}",
+                    getattr(closeable, "close"),
+                )
             if app.router.on_startup or app.router.on_shutdown:
                 raise RuntimeError("dashboard module 不支持 startup/shutdown hook")
             routes = _plugin_routes(app.routes)
@@ -154,14 +173,6 @@ class PluginDashboardHost:
             )
             _require_routes_available(binding, occupied)
         except BaseException:
-            for closeable in reversed(closeables):
-                try:
-                    _ = closeable.close()  # type: ignore[attr-defined]
-                except Exception as cleanup_error:
-                    logger.warning(
-                        "dashboard closeable 清理失败: %s",
-                        cleanup_error,
-                    )
             _ = sys.modules.pop(name, None)
             raise
 
@@ -169,11 +180,6 @@ class PluginDashboardHost:
             _ = sys.modules.pop(name, None)
 
         generation.scope.defer("dashboard_module", remove_module)
-        for index, closeable in enumerate(closeables):
-            generation.scope.defer(
-                f"dashboard_closeable:{index}",
-                getattr(closeable, "close"),
-            )
         return binding
 
 
@@ -208,7 +214,21 @@ def _closeables(value: object) -> list[object]:
 def _plugin_routes(routes: Sequence[object]) -> tuple[APIRoute, ...]:
     if any(not isinstance(route, APIRoute) for route in routes):
         raise RuntimeError("dashboard module 只支持 HTTP API route")
-    return tuple(route for route in routes if isinstance(route, APIRoute))
+    typed = tuple(route for route in routes if isinstance(route, APIRoute))
+    builtin_convertors = (
+        StringConvertor,
+        PathConvertor,
+        IntegerConvertor,
+        FloatConvertor,
+        UUIDConvertor,
+    )
+    if any(
+        not isinstance(convertor, builtin_convertors)
+        for route in typed
+        for convertor in route.param_convertors.values()
+    ):
+        raise RuntimeError("dashboard route 只支持内建 path converter")
+    return typed
 
 
 def _core_routes(routes: tuple[object, ...]) -> tuple[APIRoute, ...]:
@@ -250,11 +270,3 @@ def _sample_route_path(route: APIRoute) -> str:
         raise RuntimeError(f"dashboard route convertor 不受支持: {route.path}")
 
     return re.sub(r"\{([^}:]+)(?::[^}]+)?\}", replace, route.path)
-
-
-def _validate_closeables(closeables: list[object]) -> None:
-    if any(
-        inspect.iscoroutinefunction(getattr(closeable, "close", None))
-        for closeable in closeables
-    ):
-        raise RuntimeError("dashboard closeable.close 必须是同步函数")

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -190,7 +190,7 @@ class SnapshotDashboardMiddleware:
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") == "http" and self._snapshot_store.current is not None:
-            lease = self._snapshot_store.lease()
+            lease = await self._snapshot_store.acquire()
             async with lease:
                 token = bind_runtime_snapshot(lease)
                 try:

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -242,17 +242,13 @@ def _require_routes_available(
     conflicts: list[str] = []
     for index, route in enumerate(binding.routes):
         for other in occupied:
-            methods = sorted(
-                (route.methods or set()).intersection(other.methods or set())
-            )
+            methods = _overlapping_methods(route, other)
             if methods and _route_paths_overlap(route, other):
                 conflicts.append(
                     f"{','.join(methods)} {route.path} <> {other.path}"
                 )
         for other in binding.routes[:index]:
-            methods = sorted(
-                (route.methods or set()).intersection(other.methods or set())
-            )
+            methods = _overlapping_methods(route, other)
             if (
                 methods
                 and _route_paths_overlap(route, other)
@@ -272,6 +268,16 @@ def _route_paths_overlap(first: APIRoute, second: APIRoute) -> bool:
         first.path_regex.fullmatch(second_sample)
         or second.path_regex.fullmatch(first_sample)
     )
+
+
+def _overlapping_methods(first: APIRoute, second: APIRoute) -> list[str]:
+    if first.methods is None and second.methods is None:
+        return ["*"]
+    if first.methods is None:
+        return sorted(second.methods or ())
+    if second.methods is None:
+        return sorted(first.methods)
+    return sorted(first.methods.intersection(second.methods))
 
 
 def _ordered_static_route_wins(first: APIRoute, second: APIRoute) -> bool:

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -242,13 +242,17 @@ def _require_routes_available(
     conflicts: list[str] = []
     for index, route in enumerate(binding.routes):
         for other in occupied:
-            methods = sorted(route.methods.intersection(other.methods))
+            methods = sorted(
+                (route.methods or set()).intersection(other.methods or set())
+            )
             if methods and _route_paths_overlap(route, other):
                 conflicts.append(
                     f"{','.join(methods)} {route.path} <> {other.path}"
                 )
         for other in binding.routes[:index]:
-            methods = sorted(route.methods.intersection(other.methods))
+            methods = sorted(
+                (route.methods or set()).intersection(other.methods or set())
+            )
             if (
                 methods
                 and _route_paths_overlap(route, other)

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from agent.plugins.specs import RegisteredProactiveSource
     from infra.channels.contract import Channel
     from agent.plugins.skill_host import PreparedSkillCatalog
+    from agent.plugins.mcp_host import PreparedMcpCatalog
 
 
 GateStatus = Literal["passed", "failed"]
@@ -73,5 +74,6 @@ class PluginGeneration:
     contributions: PluginContributions
     gate_result: GateResult
     skill_catalog: PreparedSkillCatalog | None = None
+    mcp_catalog: PreparedMcpCatalog | None = None
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -24,6 +24,12 @@ class PluginSemanticCheck:
 
 
 @dataclass(frozen=True)
+class PluginReadinessContext:
+    generation_id: str
+    mcp_catalog: PreparedMcpCatalog
+
+
+@dataclass(frozen=True)
 class GateCheckResult:
     check_id: str
     status: GateStatus

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from agent.plugins.skill_host import PreparedSkillCatalog
     from agent.plugins.mcp_host import PreparedMcpCatalog
     from agent.plugins.activity_host import PreparedJobCatalog, PreparedProactiveCatalog
+    from agent.plugins.snapshot import RuntimeSnapshot
 
 
 GateStatus = Literal["passed", "failed"]
@@ -86,5 +87,6 @@ class PluginGeneration:
     mcp_catalog: PreparedMcpCatalog | None = None
     job_catalog: PreparedJobCatalog | None = None
     proactive_catalog: PreparedProactiveCatalog | None = None
+    runtime_snapshot: RuntimeSnapshot | None = None
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from infra.channels.contract import Channel
     from agent.plugins.skill_host import PreparedSkillCatalog
     from agent.plugins.mcp_host import PreparedMcpCatalog
+    from agent.plugins.activity_host import PreparedJobCatalog, PreparedProactiveCatalog
 
 
 GateStatus = Literal["passed", "failed"]
@@ -27,6 +28,8 @@ class PluginSemanticCheck:
 class PluginReadinessContext:
     generation_id: str
     mcp_catalog: PreparedMcpCatalog
+    job_catalog: PreparedJobCatalog
+    proactive_catalog: PreparedProactiveCatalog
 
 
 @dataclass(frozen=True)
@@ -81,5 +84,7 @@ class PluginGeneration:
     gate_result: GateResult
     skill_catalog: PreparedSkillCatalog | None = None
     mcp_catalog: PreparedMcpCatalog | None = None
+    job_catalog: PreparedJobCatalog | None = None
+    proactive_catalog: PreparedProactiveCatalog | None = None
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from agent.plugins.scope import PluginScope
     from agent.plugins.specs import RegisteredProactiveSource
     from infra.channels.contract import Channel
+    from agent.plugins.skill_host import PreparedSkillCatalog
 
 
 GateStatus = Literal["passed", "failed"]
@@ -71,5 +72,6 @@ class PluginGeneration:
     scope: PluginScope
     contributions: PluginContributions
     gate_result: GateResult
+    skill_catalog: PreparedSkillCatalog | None = None
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -56,6 +56,7 @@ class PluginContributions:
     skill_roots: tuple[Path, ...] = ()
     drift_skill_roots: tuple[Path, ...] = ()
     mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    managed_services: dict[str, dict[str, Any]] = field(default_factory=dict)
     before_turn_modules: tuple[object, ...] = ()
     before_reasoning_modules: tuple[object, ...] = ()
     prompt_render_modules: tuple[object, ...] = ()

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -70,6 +70,7 @@ class PluginContributions:
     proactive_sources: tuple[RegisteredProactiveSource, ...] = ()
     jobs: tuple[RegisteredPluginJob, ...] = ()
     channels: tuple[Channel, ...] = ()
+    dashboard_module: Path | None = None
 
 
 @dataclass

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from agent.plugins.jobs import RegisteredPluginJob
+    from agent.plugins.scope import PluginScope
+    from agent.plugins.specs import RegisteredProactiveSource
+    from infra.channels.contract import Channel
+
+
+GateStatus = Literal["passed", "failed"]
+
+
+@dataclass(frozen=True)
+class PluginSemanticCheck:
+    check_id: str
+    passed: bool
+    evidence: object = ""
+
+
+@dataclass(frozen=True)
+class GateCheckResult:
+    check_id: str
+    status: GateStatus
+    evidence: object = ""
+
+
+@dataclass(frozen=True)
+class GateResult:
+    gate_id: str
+    plugin_id: str
+    candidate_revision: str
+    status: GateStatus
+    checks: tuple[GateCheckResult, ...]
+    failure_reason: str = ""
+
+
+@dataclass(frozen=True)
+class PluginContributions:
+    manifest: dict[str, object]
+    skill_roots: tuple[Path, ...] = ()
+    drift_skill_roots: tuple[Path, ...] = ()
+    mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    before_turn_modules: tuple[object, ...] = ()
+    before_reasoning_modules: tuple[object, ...] = ()
+    prompt_render_modules: tuple[object, ...] = ()
+    before_step_modules: tuple[object, ...] = ()
+    after_step_modules: tuple[object, ...] = ()
+    after_reasoning_modules: tuple[object, ...] = ()
+    after_turn_modules: tuple[object, ...] = ()
+    proactive_modules: tuple[object, ...] = ()
+    proactive_lifecycles: tuple[object, ...] = ()
+    proactive_module_factories: tuple[object, ...] = ()
+    proactive_runtime_factories: tuple[object, ...] = ()
+    proactive_sources: tuple[RegisteredProactiveSource, ...] = ()
+    jobs: tuple[RegisteredPluginJob, ...] = ()
+    channels: tuple[Channel, ...] = ()
+
+
+@dataclass
+class PluginGeneration:
+    plugin_id: str
+    generation_id: str
+    module_path: str
+    source_revision: str
+    config_revision: str
+    instance: object
+    scope: PluginScope
+    contributions: PluginContributions
+    gate_result: GateResult
+    state: str = "active"
+    lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -90,5 +90,6 @@ class PluginGeneration:
     runtime_snapshot: RuntimeSnapshot | None = None
     staged_event_bus: ScopedEventBus | None = None
     initialization_started: bool = False
+    minimum_resource_count: int = 0
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from agent.plugins.jobs import RegisteredPluginJob
-    from agent.plugins.scope import PluginScope
+    from agent.plugins.scope import PluginScope, ScopedEventBus
     from agent.plugins.specs import RegisteredProactiveSource
     from infra.channels.contract import Channel
     from agent.plugins.skill_host import PreparedSkillCatalog
@@ -88,5 +88,7 @@ class PluginGeneration:
     job_catalog: PreparedJobCatalog | None = None
     proactive_catalog: PreparedProactiveCatalog | None = None
     runtime_snapshot: RuntimeSnapshot | None = None
+    staged_event_bus: ScopedEventBus | None = None
+    initialization_started: bool = False
     state: str = "active"
     lease_count: int = 0

--- a/agent/plugins/importer.py
+++ b/agent/plugins/importer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+class FreshSourceLoader(importlib.abc.Loader):
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def create_module(self, spec: object) -> None:
+        return None
+
+    def exec_module(self, module: ModuleType) -> None:
+        source = self._path.read_bytes()
+        code = compile(source, str(self._path), "exec")
+        exec(code, module.__dict__)
+
+
+class FreshPluginImporter(importlib.abc.MetaPathFinder):
+    def __init__(self) -> None:
+        self._roots: dict[str, Path] = {}
+
+    def register(self, module_name: str, plugin_root: Path) -> None:
+        if not self._roots:
+            sys.meta_path.insert(0, self)
+        self._roots[module_name] = plugin_root.resolve(strict=False)
+
+    def unregister(self, module_name: str) -> None:
+        _ = self._roots.pop(module_name, None)
+        if not self._roots and self in sys.meta_path:
+            sys.meta_path.remove(self)
+
+    def root_spec(self, module_name: str, path: Path):
+        return importlib.util.spec_from_file_location(
+            module_name,
+            path,
+            loader=FreshSourceLoader(path),
+            submodule_search_locations=[str(path.parent)],
+        )
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: ModuleType | None = None,
+    ):
+        for module_name, plugin_root in self._roots.items():
+            prefix = f"{module_name}."
+            if not fullname.startswith(prefix):
+                continue
+            relative = fullname.removeprefix(prefix).split(".")
+            module_path = plugin_root.joinpath(*relative).with_suffix(".py")
+            if module_path.is_file():
+                self._require_inside(plugin_root, module_path)
+                return importlib.util.spec_from_file_location(
+                    fullname,
+                    module_path,
+                    loader=FreshSourceLoader(module_path),
+                )
+            package_dir = plugin_root.joinpath(*relative)
+            package_init = package_dir / "__init__.py"
+            if package_init.is_file():
+                self._require_inside(plugin_root, package_init)
+                return importlib.util.spec_from_file_location(
+                    fullname,
+                    package_init,
+                    loader=FreshSourceLoader(package_init),
+                    submodule_search_locations=[str(package_dir)],
+                )
+        return None
+
+    @staticmethod
+    def _require_inside(plugin_root: Path, path: Path) -> None:
+        try:
+            _ = path.resolve(strict=False).relative_to(plugin_root)
+        except ValueError as error:
+            raise ImportError(f"插件模块路径越界: {path}") from error

--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -10,7 +10,11 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from agent.plugins.manifest import upsert_plugin_manifest
+from agent.plugins.manifest import (
+    remove_plugin_manifest_entry,
+    set_plugin_enabled,
+    upsert_plugin_manifest,
+)
 from agent.plugins.registry import plugin_registry
 from agent.plugins.specs import McpServerSpec
 
@@ -37,6 +41,53 @@ def plugin_data_root(
     marketplace: str,
 ) -> Path:
     return aka_plugins_root() / "data" / f"{plugin_name}-{marketplace}"
+
+
+def set_installed_plugin_enabled(
+    plugin_id: str,
+    *,
+    enabled: bool,
+    plugins_home: Path | None = None,
+) -> Path:
+    home = plugins_home or aka_plugins_root()
+    _split_installed_plugin_id(plugin_id)
+    return set_plugin_enabled(
+        plugin_id,
+        enabled=enabled,
+        plugins_home=home,
+    )
+
+
+def uninstall_plugin(
+    plugin_id: str,
+    *,
+    plugins_home: Path | None = None,
+) -> tuple[Path, Path]:
+    home = plugins_home or aka_plugins_root()
+    plugin_name, marketplace = _split_installed_plugin_id(plugin_id)
+    cache_path = home / "cache" / marketplace / plugin_name
+    data_path = home / "data" / f"{plugin_name}-{marketplace}"
+    if not cache_path.is_dir():
+        raise ValueError(f"插件缓存不存在: {plugin_id}")
+    _ = set_plugin_enabled(plugin_id, enabled=False, plugins_home=home)
+    shutil.rmtree(cache_path)
+    _ = remove_plugin_manifest_entry(plugin_id, plugins_home=home)
+    return cache_path, data_path
+
+
+def _split_installed_plugin_id(plugin_id: str) -> tuple[str, str]:
+    plugin_name, separator, marketplace = plugin_id.rpartition("@")
+    if (
+        not separator
+        or not plugin_name
+        or not marketplace
+        or Path(plugin_name).name != plugin_name
+        or Path(marketplace).name != marketplace
+        or plugin_name in {".", ".."}
+        or marketplace in {".", ".."}
+    ):
+        raise ValueError(f"无效的已安装插件 ID: {plugin_id}")
+    return plugin_name, marketplace
 
 
 def install_git_plugin(

--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-import os
 import importlib.util
+import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -62,15 +64,17 @@ def uninstall_plugin(
     plugin_id: str,
     *,
     plugins_home: Path | None = None,
+    wait_until_disabled: Callable[[str], None] | None = None,
 ) -> tuple[Path, Path]:
     home = plugins_home or aka_plugins_root()
     plugin_name, marketplace = _split_installed_plugin_id(plugin_id)
     cache_path = home / "cache" / marketplace / plugin_name
     data_path = home / "data" / f"{plugin_name}-{marketplace}"
-    if not cache_path.is_dir():
-        raise ValueError(f"插件缓存不存在: {plugin_id}")
     _ = set_plugin_enabled(plugin_id, enabled=False, plugins_home=home)
-    shutil.rmtree(cache_path)
+    if wait_until_disabled is not None:
+        wait_until_disabled(plugin_id)
+    if cache_path.exists():
+        shutil.rmtree(cache_path)
     _ = remove_plugin_manifest_entry(plugin_id, plugins_home=home)
     return cache_path, data_path
 
@@ -81,10 +85,8 @@ def _split_installed_plugin_id(plugin_id: str) -> tuple[str, str]:
         not separator
         or not plugin_name
         or not marketplace
-        or Path(plugin_name).name != plugin_name
-        or Path(marketplace).name != marketplace
-        or plugin_name in {".", ".."}
-        or marketplace in {".", ".."}
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", plugin_name) is None
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", marketplace) is None
     ):
         raise ValueError(f"无效的已安装插件 ID: {plugin_id}")
     return plugin_name, marketplace

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from bus.event_bus import EventSubscription
+
+if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshotLease, RuntimeSnapshotStore
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +78,8 @@ class _JobRequest:
     key: str
     reason: str
     event: object | None
+    job: RegisteredPluginJob
+    snapshot_lease: RuntimeSnapshotLease | None
 
 
 class ProviderPluginLlmService:
@@ -115,24 +121,34 @@ class PluginJobRuntime:
         *,
         event_bus: Any,
         llm: PluginLlmService,
-        jobs: list[RegisteredPluginJob],
+        jobs: list[RegisteredPluginJob] | None = None,
+        snapshot_store: RuntimeSnapshotStore | None = None,
     ) -> None:
         self._event_bus = event_bus
         self._llm = llm
-        self._jobs = {plugin_job_key(job): job for job in jobs}
+        self._jobs = {plugin_job_key(job): job for job in jobs or []}
+        self._snapshot_store = snapshot_store
         self._queue: asyncio.Queue[_JobRequest | None] = asyncio.Queue()
         self._queued_keys: set[str] = set()
         self._last_run_at: dict[str, datetime] = {}
-        self._interval_tasks: list[asyncio.Task[None]] = []
+        self._interval_task: asyncio.Task[None] | None = None
+        self._interval_due: dict[tuple[str, int, int], float] = {}
         self._running = False
         self._bound = False
         self._subscriptions: list[EventSubscription] = []
+        self._stopped = asyncio.Event()
+        self._stopped.set()
 
     async def run(self) -> None:
         if self._running:
             return
         self._running = True
+        self._stopped.clear()
         self._bind_triggers()
+        self._interval_task = asyncio.create_task(
+            self._interval_loop(),
+            name="plugin_job_intervals",
+        )
         try:
             while self._running:
                 request = await self._queue.get()
@@ -144,10 +160,11 @@ class PluginJobRuntime:
                 finally:
                     self._queue.task_done()
         finally:
-            for task in self._interval_tasks:
-                _ = task.cancel()
-            _ = await asyncio.gather(*self._interval_tasks, return_exceptions=True)
-            self._interval_tasks.clear()
+            if self._interval_task is not None:
+                _ = self._interval_task.cancel()
+                _ = await asyncio.gather(self._interval_task, return_exceptions=True)
+                self._interval_task = None
+            self._interval_due.clear()
             for subscription in self._subscriptions:
                 subscription.close()
             self._subscriptions.clear()
@@ -157,13 +174,19 @@ class PluginJobRuntime:
                 request = self._queue.get_nowait()
                 if request is not None:
                     self._queued_keys.discard(request.key)
+                    if request.snapshot_lease is not None:
+                        await request.snapshot_lease.release()
                 self._queue.task_done()
+            self._stopped.set()
 
     def stop(self) -> None:
         if not self._running:
             return
         self._running = False
         _ = self._queue.put_nowait(None)
+
+    async def wait_stopped(self) -> None:
+        _ = await self._stopped.wait()
 
     def enqueue(
         self,
@@ -172,18 +195,30 @@ class PluginJobRuntime:
         reason: str,
         event: object | None = None,
     ) -> None:
-        job = self._jobs.get(key)
+        current = self._current_jobs().get(key)
+        if current is not None and current.spec.coalesce and key in self._queued_keys:
+            return
+        job, snapshot_lease = self._resolve_job(key)
         if job is None:
             return
-        if job.spec.coalesce and key in self._queued_keys:
-            return
         self._queued_keys.add(key)
-        self._queue.put_nowait(_JobRequest(key=key, reason=reason, event=event))
+        self._queue.put_nowait(
+            _JobRequest(
+                key=key,
+                reason=reason,
+                event=event,
+                job=job,
+                snapshot_lease=snapshot_lease,
+            )
+        )
 
     def _bind_triggers(self) -> None:
         if self._bound:
             return
         self._bound = True
+        if self._snapshot_store is not None:
+            self._subscriptions.append(self._event_bus.on_any(self._handle_event))
+            return
         for key, job in self._jobs.items():
             for trigger in job.spec.triggers:
                 if isinstance(trigger, EventTrigger):
@@ -191,13 +226,6 @@ class PluginJobRuntime:
                         self._event_bus.on(
                             trigger.event_type,
                             self._make_event_handler(key),
-                        )
-                    )
-                elif isinstance(trigger, IntervalTrigger):
-                    self._interval_tasks.append(
-                        asyncio.create_task(
-                            self._interval_loop(key, trigger.seconds),
-                            name=f"plugin_job_interval:{key}",
                         )
                     )
 
@@ -210,24 +238,42 @@ class PluginJobRuntime:
 
         return handler
 
-    async def _interval_loop(
-        self,
-        key: str,
-        seconds: int,
-    ) -> None:
-        interval = max(1, int(seconds))
+    def _handle_event(self, event: object) -> None:
+        for key, job in self._current_jobs().items():
+            if any(
+                isinstance(trigger, EventTrigger)
+                and isinstance(event, trigger.event_type)
+                for trigger in job.spec.triggers
+            ):
+                self.enqueue(key, reason="event", event=event)
+
+    async def _interval_loop(self) -> None:
         while self._running:
-            await asyncio.sleep(interval)
-            self.enqueue(key, reason="interval")
+            now = time.monotonic()
+            active: set[tuple[str, int, int]] = set()
+            for key, job in self._current_jobs().items():
+                for index, trigger in enumerate(job.spec.triggers):
+                    if not isinstance(trigger, IntervalTrigger):
+                        continue
+                    interval = max(1, int(trigger.seconds))
+                    schedule_key = (key, index, interval)
+                    active.add(schedule_key)
+                    due = self._interval_due.setdefault(schedule_key, now + interval)
+                    if now >= due:
+                        self.enqueue(key, reason="interval")
+                        self._interval_due[schedule_key] = now + interval
+            for schedule_key in self._interval_due.keys() - active:
+                del self._interval_due[schedule_key]
+            await asyncio.sleep(0.2)
 
     async def _run_one(
         self,
         request: _JobRequest,
     ) -> None:
-        job = self._jobs.get(request.key)
-        if job is None:
-            return
+        job = request.job
         if self._debounced(request.key, job.spec.debounce_seconds):
+            if request.snapshot_lease is not None:
+                await request.snapshot_lease.release()
             return
         ctx = PluginJobContext(
             plugin_id=job.plugin_id,
@@ -238,7 +284,7 @@ class PluginJobRuntime:
             triggered_at=datetime.now(timezone.utc),
         )
         try:
-            await job.spec.handler(ctx)
+            await self._invoke(request, ctx)
         except Exception:
             logger.exception(
                 "插件后台任务失败: plugin=%s job=%s reason=%s",
@@ -248,6 +294,47 @@ class PluginJobRuntime:
             )
         else:
             self._last_run_at[request.key] = ctx.triggered_at
+
+    async def _invoke(self, request: _JobRequest, ctx: PluginJobContext) -> None:
+        lease = request.snapshot_lease
+        if lease is None:
+            await request.job.spec.handler(ctx)
+            return
+        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+        async with lease:
+            token = bind_runtime_snapshot(lease)
+            try:
+                await request.job.spec.handler(ctx)
+            finally:
+                reset_runtime_snapshot(token)
+
+    def _current_jobs(self) -> dict[str, RegisteredPluginJob]:
+        if self._snapshot_store is None or self._snapshot_store.current is None:
+            return self._jobs
+        return dict(self._snapshot_store.current.jobs)
+
+    def _resolve_job(
+        self,
+        key: str,
+    ) -> tuple[RegisteredPluginJob | None, RuntimeSnapshotLease | None]:
+        if self._snapshot_store is None:
+            return self._jobs.get(key), None
+        from agent.plugins.snapshot import (
+            get_current_runtime_snapshot,
+            lease_current_runtime_snapshot,
+        )
+
+        snapshot = get_current_runtime_snapshot() or self._snapshot_store.current
+        if snapshot is None:
+            return None, None
+        job = snapshot.jobs.get(key)
+        if job is None:
+            return None, None
+        lease = lease_current_runtime_snapshot()
+        if lease is None:
+            lease = self._snapshot_store.lease(snapshot.snapshot_id)
+        return job, lease
 
     def _debounced(
         self,

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -136,6 +136,7 @@ class PluginJobRuntime:
         self._running = False
         self._bound = False
         self._subscriptions: list[EventSubscription] = []
+        self._pending_enqueue_tasks: set[asyncio.Task[None]] = set()
         self._stopped = asyncio.Event()
         self._stopped.set()
 
@@ -168,6 +169,14 @@ class PluginJobRuntime:
             for subscription in self._subscriptions:
                 subscription.close()
             self._subscriptions.clear()
+            for task in self._pending_enqueue_tasks:
+                _ = task.cancel()
+            if self._pending_enqueue_tasks:
+                _ = await asyncio.gather(
+                    *self._pending_enqueue_tasks,
+                    return_exceptions=True,
+                )
+            self._pending_enqueue_tasks.clear()
             self._bound = False
             self._running = False
             while not self._queue.empty():
@@ -195,6 +204,21 @@ class PluginJobRuntime:
         reason: str,
         event: object | None = None,
     ) -> None:
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        if (
+            self._snapshot_store is not None
+            and get_current_runtime_snapshot() is None
+            and self._snapshot_store.current is not None
+            and not self._snapshot_store.current.accepting_leases
+        ):
+            task = asyncio.create_task(
+                self._enqueue_after_admission(key, reason=reason, event=event),
+                name="plugin_job_enqueue_admission",
+            )
+            self._pending_enqueue_tasks.add(task)
+            task.add_done_callback(self._pending_enqueue_tasks.discard)
+            return
         job, snapshot_lease = self._resolve_job(key)
         if job is None:
             return
@@ -206,6 +230,30 @@ class PluginJobRuntime:
                 event=event,
                 job=job,
                 snapshot_lease=snapshot_lease,
+            )
+        )
+
+    async def _enqueue_after_admission(
+        self,
+        key: str,
+        *,
+        reason: str,
+        event: object | None,
+    ) -> None:
+        assert self._snapshot_store is not None
+        lease = await self._snapshot_store.acquire()
+        job = lease.snapshot.jobs.get(key)
+        if job is None or (job.spec.coalesce and key in self._queued_keys):
+            await lease.release()
+            return
+        self._queued_keys.add(key)
+        self._queue.put_nowait(
+            _JobRequest(
+                key=key,
+                reason=reason,
+                event=event,
+                job=job,
+                snapshot_lease=lease,
             )
         )
 

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -195,9 +195,6 @@ class PluginJobRuntime:
         reason: str,
         event: object | None = None,
     ) -> None:
-        current = self._current_jobs().get(key)
-        if current is not None and current.spec.coalesce and key in self._queued_keys:
-            return
         job, snapshot_lease = self._resolve_job(key)
         if job is None:
             return
@@ -242,7 +239,7 @@ class PluginJobRuntime:
         for key, job in self._current_jobs().items():
             if any(
                 isinstance(trigger, EventTrigger)
-                and isinstance(event, trigger.event_type)
+                and type(event) is trigger.event_type
                 for trigger in job.spec.triggers
             ):
                 self.enqueue(key, reason="event", event=event)
@@ -310,6 +307,12 @@ class PluginJobRuntime:
                 reset_runtime_snapshot(token)
 
     def _current_jobs(self) -> dict[str, RegisteredPluginJob]:
+        if self._snapshot_store is not None:
+            from agent.plugins.snapshot import get_current_runtime_snapshot
+
+            snapshot = get_current_runtime_snapshot()
+            if snapshot is not None:
+                return dict(snapshot.jobs)
         if self._snapshot_store is None or self._snapshot_store.current is None:
             return self._jobs
         return dict(self._snapshot_store.current.jobs)
@@ -330,6 +333,8 @@ class PluginJobRuntime:
             return None, None
         job = snapshot.jobs.get(key)
         if job is None:
+            return None, None
+        if job.spec.coalesce and key in self._queued_keys:
             return None, None
         lease = lease_current_runtime_snapshot()
         if lease is None:

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -322,7 +322,10 @@ class PluginJobRuntime:
         key: str,
     ) -> tuple[RegisteredPluginJob | None, RuntimeSnapshotLease | None]:
         if self._snapshot_store is None:
-            return self._jobs.get(key), None
+            job = self._jobs.get(key)
+            if job is not None and job.spec.coalesce and key in self._queued_keys:
+                return None, None
+            return job, None
         from agent.plugins.snapshot import (
             get_current_runtime_snapshot,
             lease_current_runtime_snapshot,

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -52,7 +52,7 @@ PluginJobHandler = Callable[[PluginJobContext], Awaitable[None]]
 @dataclass(frozen=True)
 class PluginJobSpec:
     id: str
-    triggers: list[PluginJobTrigger]
+    triggers: Sequence[PluginJobTrigger]
     handler: PluginJobHandler
     debounce_seconds: int = 0
     coalesce: bool = True

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -149,6 +149,11 @@ class PluginJobRuntime:
             self._subscriptions.clear()
             self._bound = False
             self._running = False
+            while not self._queue.empty():
+                request = self._queue.get_nowait()
+                if request is not None:
+                    self._queued_keys.discard(request.key)
+                self._queue.task_done()
 
     def stop(self) -> None:
         if not self._running:

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -65,6 +65,10 @@ class RegisteredPluginJob:
     spec: PluginJobSpec
 
 
+def plugin_job_key(job: RegisteredPluginJob) -> str:
+    return f"{job.plugin_id}:{job.spec.id}"
+
+
 @dataclass(frozen=True)
 class _JobRequest:
     key: str
@@ -115,7 +119,7 @@ class PluginJobRuntime:
     ) -> None:
         self._event_bus = event_bus
         self._llm = llm
-        self._jobs = {self._job_key(job): job for job in jobs}
+        self._jobs = {plugin_job_key(job): job for job in jobs}
         self._queue: asyncio.Queue[_JobRequest | None] = asyncio.Queue()
         self._queued_keys: set[str] = set()
         self._last_run_at: dict[str, datetime] = {}
@@ -257,7 +261,3 @@ class PluginJobRuntime:
             return False
         elapsed = (datetime.now(timezone.utc) - last).total_seconds()
         return elapsed < seconds
-
-    @staticmethod
-    def _job_key(job: RegisteredPluginJob) -> str:
-        return f"{job.plugin_id}:{job.spec.id}"

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
+from bus.event_bus import EventSubscription
+
 logger = logging.getLogger(__name__)
 
 
@@ -120,6 +122,7 @@ class PluginJobRuntime:
         self._interval_tasks: list[asyncio.Task[None]] = []
         self._running = False
         self._bound = False
+        self._subscriptions: list[EventSubscription] = []
 
     async def run(self) -> None:
         if self._running:
@@ -140,6 +143,10 @@ class PluginJobRuntime:
             for task in self._interval_tasks:
                 _ = task.cancel()
             _ = await asyncio.gather(*self._interval_tasks, return_exceptions=True)
+            for subscription in self._subscriptions:
+                subscription.close()
+            self._subscriptions.clear()
+            self._bound = False
 
     def stop(self) -> None:
         self._running = False
@@ -167,9 +174,11 @@ class PluginJobRuntime:
         for key, job in self._jobs.items():
             for trigger in job.spec.triggers:
                 if isinstance(trigger, EventTrigger):
-                    self._event_bus.on(
-                        trigger.event_type,
-                        self._make_event_handler(key),
+                    self._subscriptions.append(
+                        self._event_bus.on(
+                            trigger.event_type,
+                            self._make_event_handler(key),
+                        )
                     )
                 elif isinstance(trigger, IntervalTrigger):
                     self._interval_tasks.append(

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -143,12 +143,16 @@ class PluginJobRuntime:
             for task in self._interval_tasks:
                 _ = task.cancel()
             _ = await asyncio.gather(*self._interval_tasks, return_exceptions=True)
+            self._interval_tasks.clear()
             for subscription in self._subscriptions:
                 subscription.close()
             self._subscriptions.clear()
             self._bound = False
+            self._running = False
 
     def stop(self) -> None:
+        if not self._running:
+            return
         self._running = False
         _ = self._queue.put_nowait(None)
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -120,6 +120,7 @@ class PluginManager:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
         self._tool_registry = tool_registry
+        self._base_tool_registry: Any = None
         self._workspace = workspace
         self._session_manager = session_manager
         self._memory_engine = memory_engine
@@ -338,10 +339,12 @@ class PluginManager:
         return mods
 
     async def load_all(self) -> None:
+        self._ensure_base_tool_registry()
         for mod in self.discover():
             _ = await self._load_one(mod)
 
     async def prepare_candidate(self, plugin_id: str) -> PluginGeneration | None:
+        self._ensure_base_tool_registry()
         await self.discard_prepared(plugin_id)
         for mod in self.discover():
             if _resolve_plugin_id(mod) == plugin_id:
@@ -368,7 +371,7 @@ class PluginManager:
                 except (asyncio.CancelledError, Exception) as error:
                     self._cleanup_failures.append(
                         CleanupFailure(
-                            resource=f"plugin:{plugin_id}:terminate",
+                            resource=f"plugin:{generation.plugin_id}:terminate",
                             error=str(error) or type(error).__name__,
                         )
                     )
@@ -496,6 +499,7 @@ class PluginManager:
         context.tool_registry = self._tool_registry
         generation.initialization_started = True
         await instance.initialize()
+        generation.minimum_resource_count = generation.scope.resource_count
 
     async def _post_publish_invariants(
         self,
@@ -1167,10 +1171,12 @@ class PluginManager:
         generations = dict(self._active_generations)
         generations[generation.plugin_id] = generation
         try:
-            return self._snapshot_compiler.compile(
+            snapshot = self._snapshot_compiler.compile(
                 generations,
                 catalog_generation=generation,
             )
+            snapshot.tool_registry = self._compile_snapshot_tools(generations)
+            return snapshot
         except Exception as error:
             gate = _with_gate_check(
                 generation.gate_result,
@@ -1181,6 +1187,53 @@ class PluginManager:
             generation.gate_result = gate
             self._gate_results[generation.plugin_id] = gate
             raise _CandidateRejected(gate) from error
+
+    def _ensure_base_tool_registry(self) -> None:
+        if self._base_tool_registry is None and self._tool_registry is not None:
+            self._base_tool_registry = self._tool_registry.fork()
+
+    def _compile_snapshot_tools(
+        self,
+        generations: dict[str, PluginGeneration],
+    ) -> Any:
+        if self._base_tool_registry is None:
+            return None
+        registry = self._base_tool_registry.fork()
+        for generation in sorted(generations.values(), key=lambda item: item.plugin_id):
+            plugin_name = getattr(
+                generation.instance,
+                "name",
+                generation.plugin_id,
+            )
+            for md in plugin_registry.get_handlers_by_module_path(
+                generation.module_path
+            ):
+                if md.kind != MetadataKind.TOOL:
+                    continue
+                tool = _build_plugin_tool(generation.instance, md)
+                if registry.has_tool(tool.name):
+                    raise RuntimeError(f"插件工具名称重复: {tool.name}")
+                registry.register(
+                    tool,
+                    risk=md.tool_risk or "read-write",
+                    always_on=bool(md.tool_always_on),
+                    search_hint=md.tool_search_hint,
+                    source_type="plugin",
+                    source_name=plugin_name,
+                )
+            if generation.mcp_catalog is None:
+                continue
+            for server in generation.mcp_catalog.servers.values():
+                for tool in server.tools:
+                    if registry.has_tool(tool.name):
+                        raise RuntimeError(f"MCP 工具名称重复: {tool.name}")
+                    registry.register(
+                        tool,
+                        risk="external-side-effect",
+                        source_type="mcp",
+                        source_name=server.name,
+                    )
+        return registry
 
     async def _publish_committed_snapshot(
         self,
@@ -1573,33 +1626,19 @@ class PluginManager:
     ) -> None:
         if self._tool_registry is None:
             return
-        from agent.tools.base import Tool as AgentTool
         for md in plugin_registry.get_handlers_by_module_path(module_path):
             # 1. 只处理 TOOL 类型元数据
             if md.kind != MetadataKind.TOOL:
                 continue
-            bound = functools.partial(md.handler, instance, None)
-            tool_name = md.tool_name or md.handler_name
-            description = (md.handler.__doc__ or "").strip()
-            schema = md.tool_schema or {"type": "object", "properties": {}, "required": []}
-            # 2. 动态创建 Tool 子类并绑定 execute
-            ToolCls = type(
-                f"PluginTool_{tool_name}",
-                (AgentTool,),
-                {
-                    "name": tool_name,
-                    "description": description,
-                    "parameters": schema,
-                    "execute": _make_execute(bound),
-                },
-            )
+            tool = _build_plugin_tool(instance, md)
+            tool_name = tool.name
             # 3. 注册到 ToolRegistry，标记来源为 plugin
             plugin_name = getattr(instance, "name", None) or module_path
             if self._tool_registry.has_tool(tool_name):
                 raise RuntimeError(f"插件工具名称重复: {tool_name}")
             tool_names.append(tool_name)
             self._tool_registry.register(
-                ToolCls(),
+                tool,
                 risk=md.tool_risk or "read-write",
                 always_on=bool(md.tool_always_on),
                 search_hint=md.tool_search_hint,
@@ -1945,6 +1984,25 @@ def _collect_skill_names(skill_roots: tuple[Path, ...]) -> list[str]:
             seen.add(child.name)
             names.append(child.name)
     return names
+
+
+def _build_plugin_tool(instance: Any, metadata: Any) -> Any:
+    from agent.tools.base import Tool as AgentTool
+
+    bound = functools.partial(metadata.handler, instance, None)
+    tool_name = metadata.tool_name or metadata.handler_name
+    tool_class = type(
+        f"PluginTool_{tool_name}",
+        (AgentTool,),
+        {
+            "name": tool_name,
+            "description": (metadata.handler.__doc__ or "").strip(),
+            "parameters": metadata.tool_schema
+            or {"type": "object", "properties": {}, "required": []},
+            "execute": _make_execute(bound),
+        },
+    )
+    return tool_class()
 
 
 def _make_execute(bound: Any) -> Any:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -69,7 +69,6 @@ from agent.plugins.snapshot import (
     RuntimeSnapshotCompiler,
     RuntimeSnapshotStore,
 )
-from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
 from agent.tool_hooks.base import ToolHook
@@ -2035,7 +2034,9 @@ class PluginManager:
                     for generation in other_generations
                     for module in getattr(generation.contributions, field_name)
                 ]
-                _ = topo_sort_modules([*active_modules, *candidate_modules])
+                _ = RuntimeSnapshotCompiler.order_plugin_modules(
+                    tuple([*active_modules, *candidate_modules])
+                )
         except RuntimeError as error:
             check("phase_graph", False, str(error))
         else:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -424,7 +424,10 @@ class PluginManager:
 
         transaction = self._snapshot_store.begin_publish(snapshot)
         try:
-            self._validate_published_snapshot(generation, snapshot)
+            await asyncio.wait_for(
+                self._post_publish_invariants(generation, snapshot),
+                timeout=5,
+            )
             await self._snapshot_store.commit(transaction)
         except (asyncio.CancelledError, Exception):
             await self._snapshot_store.abort(transaction)
@@ -476,11 +479,14 @@ class PluginManager:
         generation.initialization_started = True
         await instance.initialize()
 
-    def _validate_published_snapshot(
+    async def _post_publish_invariants(
         self,
         generation: PluginGeneration,
         snapshot: RuntimeSnapshot,
     ) -> None:
+        await asyncio.sleep(0)
+        if generation.scope.closed:
+            raise RuntimeError("候选插件作用域已关闭")
         if self.current_snapshot is not snapshot:
             raise RuntimeError("RuntimeSnapshot 发布指针不一致")
         if snapshot.generations.get(generation.plugin_id) is not generation:
@@ -489,8 +495,11 @@ class PluginManager:
         if catalog_id is not None and self._skill_host.get(catalog_id) is None:
             raise RuntimeError("RuntimeSnapshot skill catalog 不可用")
         for generation_id in snapshot.mcp_catalog_generation_ids.values():
-            if self._mcp_host.get(generation_id) is None:
+            catalog = self._mcp_host.get(generation_id)
+            if catalog is None:
                 raise RuntimeError("RuntimeSnapshot MCP catalog 不可用")
+            if any(not server.client.connected for server in catalog.servers.values()):
+                raise RuntimeError("RuntimeSnapshot MCP client 已断开")
         for item in snapshot.generations.values():
             if item.job_catalog is not None and self._job_host.get(
                 item.generation_id

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 import os
+import secrets
 import sys
 import tomllib
 from dataclasses import dataclass, field
@@ -46,6 +47,7 @@ from agent.plugins.generation import (
     PluginGeneration,
     PluginSemanticCheck,
 )
+from agent.plugins.importer import FreshPluginImporter
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
@@ -127,6 +129,8 @@ class PluginManager:
         self._stable_aliases: dict[str, str] = {}
         self._generation_sequence = 0
         self._candidate_prepare_lock = asyncio.Lock()
+        self._fresh_importer = FreshPluginImporter()
+        self._manager_namespace = secrets.token_hex(4)
 
     @property
     def loaded_count(self) -> int:
@@ -330,10 +334,28 @@ class PluginManager:
                 source_revision = ""
                 config_revision = ""
             current_prepared = self._prepared_generations.get(plugin_id)
-            if (
+            matches_active = (
                 source_revision == active.source_revision
                 and config_revision == active.config_revision
-            ) or (
+            )
+            if matches_active:
+                if current_prepared is None:
+                    continue
+                await self.discard_prepared(plugin_id)
+                result = {
+                    "plugin_id": plugin_id,
+                    "active_generation": active.generation_id,
+                    "prepared_generation": None,
+                    "gate_status": "active",
+                    "candidate_revision": source_revision,
+                }
+                results.append(result)
+                logger.info(
+                    "plugin_candidate_status %s",
+                    json.dumps(result, ensure_ascii=False, sort_keys=True),
+                )
+                continue
+            if (
                 current_prepared is not None
                 and source_revision == current_prepared.source_revision
                 and config_revision == current_prepared.config_revision
@@ -421,7 +443,7 @@ class PluginManager:
         )
         mp = (
             f"{stable_module_path}__g{self._generation_sequence}_"
-            f"{source_revision[:8]}"
+            f"{source_revision[:8]}_{self._manager_namespace}"
         )
         try:
             self._import_plugin(mp, Path(module_path))
@@ -978,15 +1000,11 @@ class PluginManager:
         )
 
     def _import_plugin(self, module_name: str, path: Path) -> None:
-        # 1. 把 plugin.py 当成包入口加载，允许数字前缀目录里的插件使用相对 import。
-        spec = importlib.util.spec_from_file_location(
-            module_name,
-            path,
-            submodule_search_locations=[str(path.parent)],
-        )
+        self._fresh_importer.register(module_name, path.parent)
+        spec = self._fresh_importer.root_spec(module_name, path)
         if spec is None or spec.loader is None:
+            self._fresh_importer.unregister(module_name)
             raise ImportError(f"无法加载插件文件: {path}")
-        # 2. 先注册到 sys.modules 再执行，避免插件内部相对 import 找不到自身
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         try:
@@ -996,6 +1014,7 @@ class PluginManager:
             raise
 
     def _remove_module_tree(self, module_name: str) -> None:
+        self._fresh_importer.unregister(module_name)
         plugin_registry.remove_module_tree(module_name)
         for imported_name in tuple(sys.modules):
             if imported_name == module_name or imported_name.startswith(f"{module_name}."):

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1127,7 +1127,11 @@ class PluginManager:
             self._remove_module_tree(mp)
             stable_alias = self._stable_aliases.pop(mp, None)
             if stable_alias is not None:
-                self._remove_module_tree(stable_alias)
+                active_alias = plugin_registry.get_instance(stable_alias)
+                if active_alias is instance:
+                    self._remove_module_tree(stable_alias)
+                else:
+                    self._fresh_importer.unregister(stable_alias)
             if active_info is not None:
                 generation = self._active_generations.pop(active_info.plugin_id, None)
                 if generation is not None:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import hashlib
 import importlib.util
 import inspect
 import logging
@@ -37,6 +38,15 @@ from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registr
 from agent.plugins.source_resolver import resolve_plugin_sources
 from agent.plugins.jobs import PluginJobSpec, PluginLlmService, RegisteredPluginJob
 from agent.plugins.scope import CleanupFailure, PluginScope, ScopedEventBus
+from agent.plugins.generation import (
+    GateCheckResult,
+    GateResult,
+    PluginContributions,
+    PluginGeneration,
+    PluginSemanticCheck,
+)
+from agent.lifecycle.phase import topo_sort_modules
+from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import HookContext, HookOutcome
 from bus.event_bus import EventBus
@@ -109,6 +119,10 @@ class PluginManager:
         self._active_plugins: dict[str, ActivePluginInfo] = {}
         self._scopes: dict[str, PluginScope] = {}
         self._cleanup_failures: list[CleanupFailure] = []
+        self._active_generations: dict[str, PluginGeneration] = {}
+        self._gate_results: dict[str, GateResult] = {}
+        self._stable_aliases: dict[str, str] = {}
+        self._generation_sequence = 0
 
     @property
     def loaded_count(self) -> int:
@@ -193,6 +207,12 @@ class PluginManager:
     def cleanup_failures(self) -> list[CleanupFailure]:
         return list(self._cleanup_failures)
 
+    def generation(self, plugin_id: str) -> PluginGeneration | None:
+        return self._active_generations.get(plugin_id)
+
+    def latest_gate(self, plugin_id: str) -> GateResult | None:
+        return self._gate_results.get(plugin_id)
+
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
         for mod in self.discover():
@@ -260,11 +280,11 @@ class PluginManager:
             await self._load_one(mod)
 
     async def _load_one(self, mod: dict[str, str]) -> None:
-        mp = mod["import_path"]
+        stable_module_path = mod["import_path"]
         plugin_dir = Path(mod["plugin_root"])
         initial_plugin_id = _resolve_plugin_id(mod)
         # 1. 幂等：已加载过直接跳过
-        if mp in self._loaded:
+        if initial_plugin_id in self._active_generations:
             return
         plugin_manifest = load_plugin_manifest(_plugins_home(self._installed_cache_root))
         if plugin_manifest.get(initial_plugin_id, True) is False:
@@ -292,10 +312,34 @@ class PluginManager:
         job_count_before = len(self._jobs)
         module_path = mod["module_path"].strip()
         if module_path:
+            source_revision = _file_revision(Path(module_path))
+            config_revision = _file_revision(
+                _resolve_plugin_data_dir(
+                    mod["name"],
+                    mod,
+                    self._installed_cache_root,
+                )
+                / "config.local.toml"
+            )
+            self._generation_sequence += 1
+            generation_id = (
+                f"{initial_plugin_id}:{source_revision[:12]}:"
+                f"{self._generation_sequence}"
+            )
+            mp = (
+                f"{stable_module_path}__g{self._generation_sequence}_"
+                f"{source_revision[:8]}"
+            )
             try:
                 self._import_plugin(mp, Path(module_path))
             except Exception as e:
                 logger.warning("插件 %s 导入失败: %s", mod["name"], e)
+                self._record_failed_gate(
+                    plugin_id=initial_plugin_id,
+                    revision=source_revision,
+                    check_id="import",
+                    reason=str(e),
+                )
                 return
             cls = plugin_registry._classes.get(mp)
             if cls is None:
@@ -319,6 +363,13 @@ class PluginManager:
                 )
             except _PluginConfigError as e:
                 logger.warning("插件 %s 配置无效，跳过: %s", mod["name"], e)
+                plugin_registry.remove_plugin(mp)
+                self._record_failed_gate(
+                    plugin_id=plugin_id,
+                    revision=source_revision,
+                    check_id="config",
+                    reason=str(e),
+                )
                 return
             from agent.plugins.context import PluginContext, PluginKVStore
             scope = PluginScope(plugin_id)
@@ -335,12 +386,14 @@ class PluginManager:
                 memory_engine=self._memory_engine,
                 llm=self._llm,
                 scope=scope,
+                generation_id=generation_id,
             )
             plugin_registry.register_instance(mp, instance)
+            initialization_started = False
 
             async def rollback_load() -> None:
                 terminator = getattr(instance, "terminate", None)
-                if callable(terminator):
+                if initialization_started and callable(terminator):
                     try:
                         typed_terminator = cast(
                             Callable[[], Awaitable[None]],
@@ -356,6 +409,7 @@ class PluginManager:
                         )
                 self._cleanup_failures.extend(await scope.aclose())
                 plugin_registry.remove_plugin(mp)
+                _ = sys.modules.pop(mp, None)
                 for tool_name in tool_names:
                     if self._tool_registry is not None:
                         self._tool_registry.unregister(tool_name)
@@ -377,23 +431,28 @@ class PluginManager:
                 del self._jobs[job_count_before:]
 
             try:
+                contributions = self._collect_candidate_contributions(
+                    instance=instance,
+                    plugin_id=plugin_id,
+                    plugin_dir=plugin_dir,
+                    data_dir=data_dir,
+                    module_path=mp,
+                )
+                gate_result = self._validate_candidate(
+                    instance=instance,
+                    plugin_id=plugin_id,
+                    revision=source_revision,
+                    contributions=contributions,
+                )
+                self._gate_results[plugin_id] = gate_result
+                if gate_result.status == "failed":
+                    raise _CandidateRejected(gate_result)
                 self._bind_handlers(instance, mp, scope)
                 self._register_tools(instance, mp, tool_names)
                 self._bind_tool_hooks(instance, mp)
-                self._collect_before_turn_modules(instance)
-                self._collect_before_reasoning_modules(instance)
-                self._collect_prompt_render_modules(instance)
-                self._collect_before_step_modules(instance)
-                self._collect_after_step_modules(instance)
-                self._collect_after_reasoning_modules(instance)
-                self._collect_after_turn_modules(instance)
-                self._collect_proactive_modules(instance)
-                self._collect_proactive_lifecycles(instance)
-                self._collect_proactive_module_factories(instance)
-                self._collect_proactive_runtime_factories(instance)
-                self._collect_proactive_sources(instance, plugin_id)
-                self._collect_jobs(instance, plugin_id)
+                self._publish_contributions(contributions)
                 if hasattr(instance, "initialize"):
+                    initialization_started = True
                     await instance.initialize()
             except asyncio.CancelledError:
                 rollback_task = asyncio.create_task(
@@ -407,20 +466,34 @@ class PluginManager:
                         continue
                 await rollback_task
                 raise
+            except _CandidateRejected as error:
+                logger.warning(
+                    "插件 %s 候选验证失败: %s",
+                    mod["name"],
+                    error.gate.failure_reason,
+                )
+                await rollback_load()
+                return
             except Exception as e:
                 logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)
+                latest_gate = self._gate_results.get(plugin_id)
+                if (
+                    latest_gate is None
+                    or latest_gate.candidate_revision != source_revision
+                ):
+                    self._record_failed_gate(
+                        plugin_id=plugin_id,
+                        revision=source_revision,
+                        check_id="declarations",
+                        reason=str(e),
+                    )
                 await rollback_load()
                 return
             self._scopes[mp] = scope
-            manifest: dict[str, object] = {
-                "name": name,
-                "version": str(instance.version or ""),
-                "desc": str(instance.desc or ""),
-                "author": str(instance.author or ""),
-            }
-            skill_roots = _resolve_declared_roots(plugin_dir, cls.skill_roots())
-            drift_skill_roots = _resolve_declared_roots(plugin_dir, cls.drift_skill_roots())
-            mcp_servers = _resolve_mcp_servers(plugin_dir, data_dir, cls.mcp_servers())
+            manifest = contributions.manifest
+            skill_roots = contributions.skill_roots
+            drift_skill_roots = contributions.drift_skill_roots
+            mcp_servers = contributions.mcp_servers
         else:
             raise RuntimeError(f"插件缺少 plugin.py: {plugin_dir}")
         self._loaded.add(mp)
@@ -433,9 +506,292 @@ class PluginManager:
             drift_skill_roots=drift_skill_roots,
             mcp_servers=mcp_servers,
         )
+        generation = PluginGeneration(
+            plugin_id=plugin_id,
+            generation_id=generation_id,
+            module_path=mp,
+            source_revision=source_revision,
+            config_revision=config_revision,
+            instance=instance,
+            scope=scope,
+            contributions=contributions,
+            gate_result=gate_result,
+        )
+        self._active_generations[plugin_id] = generation
+        self._stable_aliases[mp] = stable_module_path
+        plugin_registry.register_instance(stable_module_path, instance)
+        sys.modules[stable_module_path] = sys.modules[mp]
         if instance is not None:
-            self._collect_channels(instance)
+            self._channels.extend(contributions.channels)
         logger.info("插件已加载: %s", mod["name"])
+
+    def _collect_candidate_contributions(
+        self,
+        *,
+        instance: Any,
+        plugin_id: str,
+        plugin_dir: Path,
+        data_dir: Path,
+        module_path: str,
+    ) -> PluginContributions:
+        cls = type(instance)
+        sources: list[RegisteredProactiveSource] = []
+        for source in _load_module_list(instance, "proactive_sources"):
+            if not isinstance(source, ProactiveSourceSpec):
+                raise RuntimeError(
+                    f"插件 {plugin_id}.proactive_sources 返回值不是 ProactiveSourceSpec"
+                )
+            sources.append(RegisteredProactiveSource(plugin_id=plugin_id, spec=source))
+        jobs: list[RegisteredPluginJob] = []
+        for spec in _load_module_list(instance, "jobs"):
+            if not isinstance(spec, PluginJobSpec):
+                raise RuntimeError(
+                    f"插件 {plugin_id}.jobs 返回值不是 PluginJobSpec"
+                )
+            jobs.append(
+                RegisteredPluginJob(
+                    plugin_id=plugin_id,
+                    plugin_context=instance.context,
+                    spec=spec,
+                )
+            )
+        return PluginContributions(
+            manifest={
+                "name": str(instance.name or ""),
+                "version": str(instance.version or ""),
+                "desc": str(instance.desc or ""),
+                "author": str(instance.author or ""),
+            },
+            skill_roots=_resolve_declared_roots(plugin_dir, cls.skill_roots()),
+            drift_skill_roots=_resolve_declared_roots(
+                plugin_dir,
+                cls.drift_skill_roots(),
+            ),
+            mcp_servers=_resolve_mcp_servers(
+                plugin_dir,
+                data_dir,
+                cls.mcp_servers(),
+            ),
+            before_turn_modules=tuple(
+                _load_module_list(instance, "before_turn_modules")
+            ),
+            before_reasoning_modules=tuple(
+                _load_module_list(instance, "before_reasoning_modules")
+            ),
+            prompt_render_modules=tuple(
+                _load_module_list(instance, "prompt_render_modules")
+            ),
+            before_step_modules=tuple(
+                _load_module_list(instance, "before_step_modules")
+            ),
+            after_step_modules=tuple(
+                _load_module_list(instance, "after_step_modules")
+            ),
+            after_reasoning_modules=tuple(
+                _load_module_list(instance, "after_reasoning_modules")
+            ),
+            after_turn_modules=tuple(
+                _load_module_list(instance, "after_turn_modules")
+            ),
+            proactive_modules=tuple(
+                _load_module_list(instance, "proactive_modules")
+            ),
+            proactive_lifecycles=tuple(
+                _load_module_list(instance, "proactive_lifecycles")
+            ),
+            proactive_module_factories=tuple(
+                _load_module_list(instance, "proactive_module_factories")
+            ),
+            proactive_runtime_factories=tuple(
+                _load_module_list(instance, "proactive_runtime_factories")
+            ),
+            proactive_sources=tuple(sources),
+            jobs=tuple(jobs),
+            channels=cast(
+                tuple[Channel, ...],
+                tuple(_load_module_list(instance, "channels")),
+            ),
+        )
+
+    def _validate_candidate(
+        self,
+        *,
+        instance: Any,
+        plugin_id: str,
+        revision: str,
+        contributions: PluginContributions,
+    ) -> GateResult:
+        checks: list[GateCheckResult] = []
+
+        def check(check_id: str, passed: bool, evidence: object = "") -> None:
+            checks.append(
+                GateCheckResult(
+                    check_id=check_id,
+                    status="passed" if passed else "failed",
+                    evidence=evidence,
+                )
+            )
+
+        check(
+            "api_version",
+            getattr(instance, "api_version", None) == 1,
+            getattr(instance, "api_version", None),
+        )
+        metadata = plugin_registry.get_handlers_by_module_path(type(instance).__module__)
+        tool_names = [
+            md.tool_name or md.handler_name
+            for md in metadata
+            if md.kind == MetadataKind.TOOL
+        ]
+        duplicate_tools = _duplicates(tool_names)
+        occupied_tools = (
+            sorted(name for name in tool_names if self._tool_registry.has_tool(name))
+            if self._tool_registry is not None
+            else []
+        )
+        check(
+            "tool_names",
+            not duplicate_tools and not occupied_tools,
+            {"duplicates": duplicate_tools, "occupied": occupied_tools},
+        )
+        source_ids = [source.spec.id for source in contributions.proactive_sources]
+        source_errors = [
+            source.spec.id
+            for source in contributions.proactive_sources
+            if not source.spec.id
+            or not source.spec.channels
+            or not source.spec.server
+            or not source.spec.fetch_tool
+            or source.spec.server not in contributions.mcp_servers
+        ]
+        check(
+            "proactive_sources",
+            not _duplicates(source_ids) and not source_errors,
+            {"duplicates": _duplicates(source_ids), "invalid": source_errors},
+        )
+        job_ids = [job.spec.id for job in contributions.jobs]
+        check(
+            "job_ids",
+            all(job_ids) and not _duplicates(job_ids) if job_ids else True,
+            _duplicates(job_ids),
+        )
+        channel_names = [
+            str(getattr(channel, "name", "")).strip()
+            for channel in contributions.channels
+        ]
+        occupied_channels = {
+            str(getattr(channel, "name", "")).strip() for channel in self._channels
+        }
+        check(
+            "channel_names",
+            (
+                all(channel_names)
+                and not _duplicates(channel_names)
+                and not occupied_channels.intersection(channel_names)
+            )
+            if channel_names
+            else True,
+            {
+                "duplicates": _duplicates(channel_names),
+                "occupied": sorted(occupied_channels.intersection(channel_names)),
+            },
+        )
+        phase_groups = (
+            contributions.before_turn_modules,
+            contributions.before_reasoning_modules,
+            contributions.prompt_render_modules,
+            contributions.before_step_modules,
+            contributions.after_step_modules,
+            contributions.after_reasoning_modules,
+            contributions.after_turn_modules,
+        )
+        try:
+            for modules in phase_groups:
+                _ = topo_sort_modules(modules)
+        except RuntimeError as error:
+            check("phase_graph", False, str(error))
+        else:
+            check("phase_graph", True)
+        lifecycle_ids = [
+            lifecycle.id
+            for lifecycle in contributions.proactive_lifecycles
+            if isinstance(lifecycle, ProactiveLifecycleSpec)
+        ]
+        check(
+            "proactive_lifecycles",
+            len(lifecycle_ids) == len(contributions.proactive_lifecycles)
+            and not _duplicates(lifecycle_ids),
+            _duplicates(lifecycle_ids),
+        )
+        try:
+            semantic_checks = instance.static_semantic_checks()
+        except Exception as error:
+            check("semantic_checks", False, str(error))
+        else:
+            invalid_semantic = [
+                semantic
+                for semantic in semantic_checks
+                if not isinstance(semantic, PluginSemanticCheck) or not semantic.passed
+            ]
+            check(
+                "semantic_checks",
+                not invalid_semantic,
+                [
+                    getattr(semantic, "evidence", repr(semantic))
+                    for semantic in invalid_semantic
+                ],
+            )
+        failed = [item for item in checks if item.status == "failed"]
+        return GateResult(
+            gate_id="G1/G3-static",
+            plugin_id=plugin_id,
+            candidate_revision=revision,
+            status="failed" if failed else "passed",
+            checks=tuple(checks),
+            failure_reason="; ".join(item.check_id for item in failed),
+        )
+
+    def _publish_contributions(self, contributions: PluginContributions) -> None:
+        self._before_turn_modules.extend(contributions.before_turn_modules)
+        self._before_reasoning_modules.extend(contributions.before_reasoning_modules)
+        self._prompt_render_modules.extend(contributions.prompt_render_modules)
+        self._before_step_modules.extend(contributions.before_step_modules)
+        self._after_step_modules.extend(contributions.after_step_modules)
+        self._after_reasoning_modules.extend(contributions.after_reasoning_modules)
+        self._after_turn_modules.extend(contributions.after_turn_modules)
+        self._proactive_modules.extend(contributions.proactive_modules)
+        self._proactive_lifecycles.extend(contributions.proactive_lifecycles)
+        self._proactive_module_factories.extend(
+            contributions.proactive_module_factories
+        )
+        self._proactive_runtime_factories.extend(
+            contributions.proactive_runtime_factories
+        )
+        self._proactive_sources.extend(contributions.proactive_sources)
+        self._jobs.extend(contributions.jobs)
+
+    def _record_failed_gate(
+        self,
+        *,
+        plugin_id: str,
+        revision: str,
+        check_id: str,
+        reason: str,
+    ) -> None:
+        self._gate_results[plugin_id] = GateResult(
+            gate_id="G1/G3-static",
+            plugin_id=plugin_id,
+            candidate_revision=revision,
+            status="failed",
+            checks=(
+                GateCheckResult(
+                    check_id=check_id,
+                    status="failed",
+                    evidence=reason,
+                ),
+            ),
+            failure_reason=reason,
+        )
 
     def _import_plugin(self, module_name: str, path: Path) -> None:
         # 1. 把 plugin.py 当成包入口加载，允许数字前缀目录里的插件使用相对 import。
@@ -449,7 +805,11 @@ class PluginManager:
         # 2. 先注册到 sys.modules 再执行，避免插件内部相对 import 找不到自身
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        try:
+            spec.loader.exec_module(module)  # type: ignore[union-attr]
+        except BaseException:
+            _ = sys.modules.pop(module_name, None)
+            raise
 
     def _register_tools(
         self,
@@ -525,130 +885,9 @@ class PluginManager:
             self._tool_hooks.append(hook)
             logger.info("插件 tool hook 已注册: %s", hook.name)
 
-    def _collect_before_turn_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "before_turn_modules",
-            self._before_turn_modules,
-        )
-
-    def _collect_before_reasoning_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "before_reasoning_modules",
-            self._before_reasoning_modules,
-        )
-
-    def _collect_prompt_render_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "prompt_render_modules",
-            self._prompt_render_modules,
-        )
-
-    def _collect_before_step_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "before_step_modules",
-            self._before_step_modules,
-        )
-
-    def _collect_after_step_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "after_step_modules",
-            self._after_step_modules,
-        )
-
-    def _collect_after_reasoning_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "after_reasoning_modules",
-            self._after_reasoning_modules,
-        )
-
-    def _collect_after_turn_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "after_turn_modules",
-            self._after_turn_modules,
-        )
-
-    def _collect_proactive_modules(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "proactive_modules",
-            self._proactive_modules,
-        )
-
-    def _collect_proactive_lifecycles(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "proactive_lifecycles",
-            self._proactive_lifecycles,
-        )
-
-    def _collect_proactive_module_factories(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "proactive_module_factories",
-            self._proactive_module_factories,
-        )
-
-    def _collect_proactive_runtime_factories(self, instance: Any) -> None:
-        self._collect_phase_modules(
-            instance,
-            "proactive_runtime_factories",
-            self._proactive_runtime_factories,
-        )
-
-    def _collect_proactive_sources(self, instance: Any, plugin_id: str) -> None:
-        seen = {source.spec.id for source in self._proactive_sources if source.plugin_id == plugin_id}
-        for source in _load_module_list(instance, "proactive_sources"):
-            if not isinstance(source, ProactiveSourceSpec):
-                raise RuntimeError(
-                    f"插件 {plugin_id}.proactive_sources 返回值不是 ProactiveSourceSpec"
-                )
-            if not source.id or source.id in seen:
-                raise RuntimeError(f"插件 {plugin_id} proactive source id 重复或为空: {source.id!r}")
-            if not source.channels or not source.server or not source.fetch_tool:
-                raise RuntimeError(f"插件 {plugin_id} proactive source 声明不完整: {source.id}")
-            seen.add(source.id)
-            self._proactive_sources.append(
-                RegisteredProactiveSource(plugin_id=plugin_id, spec=source)
-            )
-
-    def _collect_channels(self, instance: Any) -> None:
-        for channel in _load_module_list(instance, "channels"):
-            self._channels.append(cast(Channel, channel))
-
-    def _collect_jobs(self, instance: Any, plugin_id: str) -> None:
-        for spec in _load_module_list(instance, "jobs"):
-            if not isinstance(spec, PluginJobSpec):
-                logger.warning("插件 %s.jobs 返回值不是 PluginJobSpec", type(instance).__name__)
-                continue
-            job_id = str(getattr(spec, "id", "") or "").strip()
-            if not job_id:
-                logger.warning("插件 %s.jobs 返回了缺少 id 的任务", type(instance).__name__)
-                continue
-            self._jobs.append(
-                RegisteredPluginJob(
-                    plugin_id=plugin_id,
-                    plugin_context=instance.context,
-                    spec=spec,
-                )
-            )
-
-    def _collect_phase_modules(
-        self,
-        instance: Any,
-        attr_name: str,
-        target: list[object],
-    ) -> None:
-        target.extend(_load_module_list(instance, attr_name))
-
     async def terminate_all(self) -> None:
         for mp in list(self._loaded):
+            active_info = self._active_plugins.get(mp)
             instance = plugin_registry.get_instance(mp)
             terminator = getattr(instance, "terminate", None)
             if callable(terminator):
@@ -674,6 +913,13 @@ class PluginManager:
                 if md.kind == MetadataKind.TOOL and self._tool_registry is not None:
                     self._tool_registry.unregister(md.tool_name or md.handler_name)
             plugin_registry.remove_plugin(mp)
+            _ = sys.modules.pop(mp, None)
+            stable_alias = self._stable_aliases.pop(mp, None)
+            if stable_alias is not None:
+                plugin_registry.remove_plugin(stable_alias)
+                _ = sys.modules.pop(stable_alias, None)
+            if active_info is not None:
+                _ = self._active_generations.pop(active_info.plugin_id, None)
             _ = self._active_plugins.pop(mp, None)
         self._loaded.clear()
         self._active_plugins.clear()
@@ -693,10 +939,18 @@ class PluginManager:
         self._jobs.clear()
         self._channels.clear()
         self._scopes.clear()
+        self._active_generations.clear()
+        self._stable_aliases.clear()
 
 
 class _PluginConfigError(Exception):
     pass
+
+
+class _CandidateRejected(Exception):
+    def __init__(self, gate: GateResult) -> None:
+        super().__init__(gate.failure_reason)
+        self.gate = gate
 
 
 def _load_plugin_config(
@@ -928,6 +1182,26 @@ class _PluginToolHook(ToolHook):
         if isinstance(result, dict):
             return HookOutcome(updated_input=cast("dict[str, Any]", result))
         return HookOutcome()
+
+
+def _file_revision(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(path.resolve(strict=False)).encode())
+    if path.is_file():
+        digest.update(path.read_bytes())
+    else:
+        digest.update(b"<missing>")
+    return digest.hexdigest()
+
+
+def _duplicates(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return sorted(duplicates)
 
 
 def _is_plugin_disabled(plugin_dir: Path) -> bool:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ValidationError
 
 from agent.plugins.manifest import load_plugin_manifest, write_plugin_manifest
 from agent.plugins.specs import (
+    ManagedServiceSpec,
     McpServerSpec,
     ProactiveSourceSpec,
     RegisteredProactiveSource,
@@ -133,6 +134,10 @@ class PluginManager:
             Awaitable[None],
         ] | None = None
         self._dashboard_preparer: Callable[[RuntimeSnapshot], None] | None = None
+        self._service_switcher: Callable[
+            [str, dict[str, dict[str, Any]], dict[str, dict[str, Any]]],
+            Awaitable[None],
+        ] | None = None
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -280,6 +285,15 @@ class PluginManager:
         preparer: Callable[[RuntimeSnapshot], None],
     ) -> None:
         self._dashboard_preparer = preparer
+
+    def bind_service_switcher(
+        self,
+        switcher: Callable[
+            [str, dict[str, dict[str, Any]], dict[str, dict[str, Any]]],
+            Awaitable[None],
+        ],
+    ) -> None:
+        self._service_switcher = switcher
 
     def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
         return self._job_host.get(generation_id)
@@ -496,6 +510,32 @@ class PluginManager:
             )
             return result
 
+        old_services = (
+            active.contributions.managed_services if active is not None else {}
+        )
+        new_services = generation.contributions.managed_services
+        services_switched = False
+        if self._service_switcher is not None and old_services != new_services:
+            try:
+                await self._service_switcher(plugin_id, old_services, new_services)
+                services_switched = True
+            except (asyncio.CancelledError, Exception) as error:
+                self._record_failed_gate(
+                    plugin_id=plugin_id,
+                    revision=generation.source_revision,
+                    check_id="managed_services",
+                    reason=str(error) or type(error).__name__,
+                )
+                await self.discard_prepared(plugin_id)
+                if isinstance(error, asyncio.CancelledError):
+                    raise
+                return self._publication_status(
+                    plugin_id,
+                    active=active,
+                    candidate=generation,
+                    publication_state="failed",
+                )
+
         old_channels = active.contributions.channels if active is not None else ()
         new_channels = generation.contributions.channels
         channels_switched = False
@@ -510,9 +550,23 @@ class PluginManager:
                     check_id="channels",
                     reason=str(error) or type(error).__name__,
                 )
+                service_error: BaseException | None = None
+                if services_switched and self._service_switcher is not None:
+                    try:
+                        await self._service_switcher(
+                            plugin_id,
+                            new_services,
+                            old_services,
+                        )
+                    except BaseException as rollback_error:
+                        service_error = rollback_error
                 await self.discard_prepared(plugin_id)
                 if isinstance(error, asyncio.CancelledError):
                     raise
+                if service_error is not None:
+                    raise RuntimeError(
+                        "Channel Gate 失败后旧 managed service 恢复失败"
+                    ) from service_error
                 return self._publication_status(
                     plugin_id,
                     active=active,
@@ -537,11 +591,25 @@ class PluginManager:
                         await self._channel_switcher(plugin_id, new_channels, old_channels)
                     except BaseException as rollback_error:
                         channel_error = rollback_error
+                service_error: BaseException | None = None
+                if services_switched and self._service_switcher is not None:
+                    try:
+                        await self._service_switcher(
+                            plugin_id,
+                            new_services,
+                            old_services,
+                        )
+                    except BaseException as rollback_error:
+                        service_error = rollback_error
                 await self.discard_prepared(plugin_id)
                 if channel_error is not None:
                     raise RuntimeError(
                         "Dashboard Gate 失败后旧 Channel 恢复失败"
                     ) from channel_error
+                if service_error is not None:
+                    raise RuntimeError(
+                        "Dashboard Gate 失败后旧 managed service 恢复失败"
+                    ) from service_error
                 return self._publication_status(
                     plugin_id,
                     active=active,
@@ -566,9 +634,23 @@ class PluginManager:
                     await self._channel_switcher(plugin_id, new_channels, old_channels)
                 except BaseException as error:
                     channel_error = error
+            service_error: BaseException | None = None
+            if services_switched and self._service_switcher is not None:
+                try:
+                    await self._service_switcher(
+                        plugin_id,
+                        new_services,
+                        old_services,
+                    )
+                except BaseException as error:
+                    service_error = error
             await self._snapshot_store.abort(transaction)
             if channel_error is not None:
                 raise RuntimeError("Snapshot abort 后旧 Channel 恢复失败") from channel_error
+            if service_error is not None:
+                raise RuntimeError(
+                    "Snapshot abort 后旧 managed service 恢复失败"
+                ) from service_error
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
@@ -1058,6 +1140,7 @@ class PluginManager:
                 plugin_dir=plugin_dir,
                 data_dir=data_dir,
                 module_path=mp,
+                source_revision=source_revision,
             )
             gate_result = self._validate_candidate(
                 instance=instance,
@@ -1462,6 +1545,7 @@ class PluginManager:
         plugin_dir: Path,
         data_dir: Path,
         module_path: str,
+        source_revision: str,
     ) -> PluginContributions:
         cls = type(instance)
         sources: list[RegisteredProactiveSource] = []
@@ -1500,6 +1584,12 @@ class PluginManager:
                 plugin_dir,
                 data_dir,
                 cls.mcp_servers(),
+            ),
+            managed_services=_resolve_managed_services(
+                plugin_dir,
+                data_dir,
+                cls.managed_services(),
+                source_revision=source_revision,
             ),
             before_turn_modules=tuple(
                 _load_module_list(instance, "before_turn_modules")
@@ -2096,6 +2186,60 @@ def _resolve_dashboard_module(plugin_dir: Path, declared: str | None) -> Path | 
     if not path.is_relative_to(root) or path.suffix != ".py" or not path.is_file():
         raise RuntimeError(f"插件 dashboard module 无效: {declared}")
     return path
+
+
+def _resolve_managed_services(
+    plugin_dir: Path,
+    data_dir: Path,
+    declared: list[ManagedServiceSpec],
+    *,
+    source_revision: str,
+) -> dict[str, dict[str, Any]]:
+    services: dict[str, dict[str, Any]] = {}
+    plugin_root = plugin_dir.resolve(strict=False)
+    for spec in declared:
+        if (
+            not isinstance(spec, ManagedServiceSpec)
+            or not spec.id
+            or not spec.command
+            or spec.startup_timeout_seconds <= 0
+            or not all(isinstance(item, str) and item for item in spec.command)
+            or not all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in spec.env.items()
+            )
+            or not isinstance(spec.readiness_url, str)
+        ):
+            raise RuntimeError(f"插件 managed service 声明无效: {spec!r}")
+        if spec.id in services:
+            raise RuntimeError(f"插件 managed service 名称重复: {spec.id}")
+        command = [
+            _resolve_command_item(plugin_root, item, executable=index == 0)
+            for index, item in enumerate(spec.command)
+        ]
+        cwd_path = Path(spec.cwd)
+        resolved_cwd = (
+            cwd_path.resolve(strict=False)
+            if cwd_path.is_absolute()
+            else (plugin_root / cwd_path).resolve(strict=False)
+        )
+        _require_plugin_path(plugin_root, resolved_cwd, "managed service cwd")
+        cwd = str(resolved_cwd)
+        if _is_python_command(command[0]):
+            runtime_root = _resolve_mcp_runtime_root(plugin_dir, cwd, command)
+            if runtime_root is not None:
+                venv_python = _venv_python(runtime_root / ".venv")
+                if venv_python.exists():
+                    command[0] = str(venv_python)
+        services[spec.id] = {
+            "command": command,
+            "cwd": cwd,
+            "env": {**spec.env, "AKA_PLUGIN_DATA_DIR": str(data_dir)},
+            "readiness_url": spec.readiness_url,
+            "startup_timeout_seconds": spec.startup_timeout_seconds,
+            "revision": source_revision,
+        }
+    return services
 
 
 def _resolve_mcp_servers(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -35,6 +35,7 @@ from agent.lifecycle.types import (
 from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registry
 from agent.plugins.source_resolver import resolve_plugin_sources
 from agent.plugins.jobs import PluginJobSpec, PluginLlmService, RegisteredPluginJob
+from agent.plugins.scope import PluginScope, ScopedEventBus
 from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import HookContext, HookOutcome
 from bus.event_bus import EventBus
@@ -105,6 +106,7 @@ class PluginManager:
         self._proactive_sources: list[RegisteredProactiveSource] = []
         self._jobs: list[RegisteredPluginJob] = []
         self._active_plugins: dict[str, ActivePluginInfo] = {}
+        self._scopes: dict[str, PluginScope] = {}
 
     @property
     def loaded_count(self) -> int:
@@ -313,8 +315,9 @@ class PluginManager:
                 logger.warning("插件 %s 配置无效，跳过: %s", mod["name"], e)
                 return
             from agent.plugins.context import PluginContext, PluginKVStore
+            scope = PluginScope(plugin_id)
             instance.context = PluginContext(  # type: ignore[attr-defined]
-                event_bus=self._event_bus,
+                event_bus=ScopedEventBus(self._event_bus, scope),
                 tool_registry=self._tool_registry,
                 plugin_id=plugin_id,
                 plugin_dir=plugin_dir,
@@ -325,29 +328,31 @@ class PluginManager:
                 session_manager=self._session_manager,
                 memory_engine=self._memory_engine,
                 llm=self._llm,
+                scope=scope,
             )
             plugin_registry.register_instance(mp, instance)
-            self._bind_handlers(instance, mp)
-            tool_names = self._register_tools(instance, mp)
-            self._bind_tool_hooks(instance, mp)
-            self._collect_before_turn_modules(instance)
-            self._collect_before_reasoning_modules(instance)
-            self._collect_prompt_render_modules(instance)
-            self._collect_before_step_modules(instance)
-            self._collect_after_step_modules(instance)
-            self._collect_after_reasoning_modules(instance)
-            self._collect_after_turn_modules(instance)
-            self._collect_proactive_modules(instance)
-            self._collect_proactive_lifecycles(instance)
-            self._collect_proactive_module_factories(instance)
-            self._collect_proactive_runtime_factories(instance)
-            self._collect_proactive_sources(instance, plugin_id)
-            self._collect_jobs(instance, plugin_id)
             try:
+                self._bind_handlers(instance, mp, scope)
+                tool_names = self._register_tools(instance, mp)
+                self._bind_tool_hooks(instance, mp)
+                self._collect_before_turn_modules(instance)
+                self._collect_before_reasoning_modules(instance)
+                self._collect_prompt_render_modules(instance)
+                self._collect_before_step_modules(instance)
+                self._collect_after_step_modules(instance)
+                self._collect_after_reasoning_modules(instance)
+                self._collect_after_turn_modules(instance)
+                self._collect_proactive_modules(instance)
+                self._collect_proactive_lifecycles(instance)
+                self._collect_proactive_module_factories(instance)
+                self._collect_proactive_runtime_factories(instance)
+                self._collect_proactive_sources(instance, plugin_id)
+                self._collect_jobs(instance, plugin_id)
                 if hasattr(instance, "initialize"):
                     await instance.initialize()
             except Exception as e:
-                logger.warning("插件 %s 初始化失败，回滚: %s", mod["name"], e)
+                logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)
+                _ = await scope.aclose()
                 plugin_registry.remove_plugin(mp)
                 for tn in tool_names:
                     if self._tool_registry is not None:
@@ -367,6 +372,7 @@ class PluginManager:
                 del self._proactive_sources[proactive_source_count_before:]
                 del self._jobs[job_count_before:]
                 return
+            self._scopes[mp] = scope
             manifest: dict[str, object] = {
                 "name": name,
                 "version": str(instance.version or ""),
@@ -444,7 +450,12 @@ class PluginManager:
             logger.info("插件工具已注册: %s (来自 %s)", tool_name, plugin_name)
         return tool_names
 
-    def _bind_handlers(self, instance: Any, module_path: str) -> None:
+    def _bind_handlers(
+        self,
+        instance: Any,
+        module_path: str,
+        scope: PluginScope,
+    ) -> None:
         for md in plugin_registry.get_handlers_by_module_path(module_path):
             # 1. Phase 1 只绑定生命周期 handler，TOOL 类型留给后续 phase
             if md.kind != MetadataKind.LIFECYCLE:
@@ -455,7 +466,7 @@ class PluginManager:
                 continue
             # 3. 绑定 instance 为第一个参数，EventBus 已处理 sync/async，直接注册
             bound = functools.partial(md.handler, instance)
-            self._event_bus.on(ctx_type, bound)
+            _ = scope.subscribe(self._event_bus, ctx_type, bound)
 
     def _bind_tool_hooks(self, instance: Any, module_path: str) -> None:
         for md in plugin_registry.get_handlers_by_module_path(module_path):
@@ -600,6 +611,9 @@ class PluginManager:
                     await instance.terminate()
                 except Exception as e:
                     logger.warning("插件 terminate 失败 (%s): %s", mp, e)
+            scope = self._scopes.pop(mp, None)
+            if scope is not None:
+                _ = await scope.aclose()
             # 注销工具
             for md in plugin_registry.get_handlers_by_module_path(mp):
                 if md.kind == MetadataKind.TOOL and self._tool_registry is not None:
@@ -623,6 +637,7 @@ class PluginManager:
         self._proactive_sources.clear()
         self._jobs.clear()
         self._channels.clear()
+        self._scopes.clear()
 
 
 class _PluginConfigError(Exception):

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -358,6 +358,8 @@ class PluginManager:
                         if active.skill_catalog is not None
                         else []
                     ),
+                    "skill_descriptions": _skill_descriptions(active),
+                    "drift_skill_descriptions": _drift_skill_descriptions(active),
                 }
                 results.append(result)
                 logger.info(
@@ -387,6 +389,14 @@ class PluginManager:
                     list(prepared.skill_catalog.names)
                     if prepared is not None and prepared.skill_catalog is not None
                     else []
+                ),
+                "skill_descriptions": (
+                    _skill_descriptions(prepared) if prepared is not None else {}
+                ),
+                "drift_skill_descriptions": (
+                    _drift_skill_descriptions(prepared)
+                    if prepared is not None
+                    else {}
                 ),
             }
             results.append(result)
@@ -598,6 +608,7 @@ class PluginManager:
                 if active_generation.plugin_id != plugin_id
             ]
             catalog_generations.append(generation)
+            ignored_generations = [*self._active_generations.values(), generation]
             try:
                 skill_catalog = self._skill_host.prepare(
                     generation_id,
@@ -608,6 +619,16 @@ class PluginManager:
                     drift_roots=PluginSkillHost.roots_for(
                         catalog_generations,
                         drift=True,
+                    ),
+                    ignored_normal_roots=tuple(
+                        root
+                        for item in ignored_generations
+                        for root in item.contributions.skill_roots
+                    ),
+                    ignored_drift_roots=tuple(
+                        root
+                        for item in ignored_generations
+                        for root in item.contributions.drift_skill_roots
                     ),
                 )
             except Exception as error:
@@ -1572,6 +1593,26 @@ def _duplicates(values: list[str]) -> list[str]:
             duplicates.add(value)
         seen.add(value)
     return sorted(duplicates)
+
+
+def _skill_descriptions(generation: PluginGeneration) -> dict[str, str]:
+    catalog = generation.skill_catalog
+    if catalog is None:
+        return {}
+    return {
+        name: record.description
+        for name, record in sorted(catalog.normal.records.items())
+    }
+
+
+def _drift_skill_descriptions(generation: PluginGeneration) -> dict[str, str]:
+    catalog = generation.skill_catalog
+    if catalog is None:
+        return {}
+    return {
+        name: record.description
+        for name, record in sorted(catalog.drift.records.items())
+    }
 
 
 def _is_plugin_disabled(plugin_dir: Path) -> bool:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -120,6 +120,7 @@ class PluginManager:
         self._scopes: dict[str, PluginScope] = {}
         self._cleanup_failures: list[CleanupFailure] = []
         self._active_generations: dict[str, PluginGeneration] = {}
+        self._prepared_generations: dict[str, PluginGeneration] = {}
         self._gate_results: dict[str, GateResult] = {}
         self._stable_aliases: dict[str, str] = {}
         self._generation_sequence = 0
@@ -213,10 +214,13 @@ class PluginManager:
     def latest_gate(self, plugin_id: str) -> GateResult | None:
         return self._gate_results.get(plugin_id)
 
+    def prepared_generation(self, plugin_id: str) -> PluginGeneration | None:
+        return self._prepared_generations.get(plugin_id)
+
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
         for mod in self.discover():
-            entries.setdefault(_resolve_plugin_id(mod), True)
+            _ = entries.setdefault(_resolve_plugin_id(mod), True)
         return write_plugin_manifest(entries, plugins_home=plugins_home)
 
     def _registry_active(self, module_path: str) -> bool:
@@ -277,24 +281,40 @@ class PluginManager:
 
     async def load_all(self) -> None:
         for mod in self.discover():
-            await self._load_one(mod)
+            _ = await self._load_one(mod)
 
-    async def _load_one(self, mod: dict[str, str]) -> None:
+    async def prepare_candidate(self, plugin_id: str) -> PluginGeneration | None:
+        await self.discard_prepared(plugin_id)
+        for mod in self.discover():
+            if _resolve_plugin_id(mod) == plugin_id:
+                return await self._load_one(mod, activate=False)
+        raise KeyError(f"插件不存在: {plugin_id}")
+
+    async def discard_prepared(self, plugin_id: str) -> None:
+        generation = self._prepared_generations.pop(plugin_id, None)
+        if generation is None:
+            return
+        self._cleanup_failures.extend(await generation.scope.aclose())
+        self._remove_module_tree(generation.module_path)
+
+    async def _load_one(
+        self,
+        mod: dict[str, str],
+        *,
+        activate: bool = True,
+    ) -> PluginGeneration | None:
         stable_module_path = mod["import_path"]
         plugin_dir = Path(mod["plugin_root"])
         initial_plugin_id = _resolve_plugin_id(mod)
-        # 1. 幂等：已加载过直接跳过
-        if initial_plugin_id in self._active_generations:
-            return
+        if activate and initial_plugin_id in self._active_generations:
+            return self._active_generations[initial_plugin_id]
         plugin_manifest = load_plugin_manifest(_plugins_home(self._installed_cache_root))
         if plugin_manifest.get(initial_plugin_id, True) is False:
             logger.info("插件已禁用（manifest.toml）: %s", initial_plugin_id)
-            return
-        # 1b. 本地禁用标记存在时跳过
+            return None
         if _is_plugin_disabled(plugin_dir):
             logger.info("插件已禁用（plugin.disabled）: %s", mod["name"])
-            return
-        instance = None
+            return None
         tool_names: list[str] = []
         hook_count_before = len(self._tool_hooks)
         before_turn_count_before = len(self._before_turn_modules)
@@ -310,220 +330,225 @@ class PluginManager:
         proactive_runtime_factory_count_before = len(self._proactive_runtime_factories)
         proactive_source_count_before = len(self._proactive_sources)
         job_count_before = len(self._jobs)
+        channel_count_before = len(self._channels)
         module_path = mod["module_path"].strip()
-        if module_path:
-            source_revision = _file_revision(Path(module_path))
-            config_revision = _file_revision(
-                _resolve_plugin_data_dir(
-                    mod["name"],
-                    mod,
-                    self._installed_cache_root,
-                )
-                / "config.local.toml"
+        if not module_path:
+            raise RuntimeError(f"插件缺少 plugin.py: {plugin_dir}")
+        source_revision = _source_revision(plugin_dir)
+        data_dir = _resolve_plugin_data_dir(
+            mod["name"],
+            mod,
+            self._installed_cache_root,
+        )
+        config_revision = _file_revision(data_dir / "config.local.toml")
+        self._generation_sequence += 1
+        generation_id = (
+            f"{initial_plugin_id}:{source_revision[:12]}:{self._generation_sequence}"
+        )
+        mp = (
+            f"{stable_module_path}__g{self._generation_sequence}_"
+            f"{source_revision[:8]}"
+        )
+        try:
+            self._import_plugin(mp, Path(module_path))
+        except Exception as error:
+            logger.warning("插件 %s 导入失败: %s", mod["name"], error)
+            self._record_failed_gate(
+                plugin_id=initial_plugin_id,
+                revision=source_revision,
+                check_id="import",
+                reason=str(error),
             )
-            self._generation_sequence += 1
-            generation_id = (
-                f"{initial_plugin_id}:{source_revision[:12]}:"
-                f"{self._generation_sequence}"
+            return None
+        cls = plugin_registry.get_class(mp)
+        if cls is None:
+            logger.warning("插件 %s 未注册类", mod["name"])
+            self._remove_module_tree(mp)
+            self._record_failed_gate(
+                plugin_id=initial_plugin_id,
+                revision=source_revision,
+                check_id="plugin_class",
+                reason="plugin.py 未注册 Plugin 子类",
             )
-            mp = (
-                f"{stable_module_path}__g{self._generation_sequence}_"
-                f"{source_revision[:8]}"
-            )
-            try:
-                self._import_plugin(mp, Path(module_path))
-            except Exception as e:
-                logger.warning("插件 %s 导入失败: %s", mod["name"], e)
-                self._record_failed_gate(
-                    plugin_id=initial_plugin_id,
-                    revision=source_revision,
-                    check_id="import",
-                    reason=str(e),
-                )
-                return
-            cls = plugin_registry._classes.get(mp)
-            if cls is None:
-                logger.warning("插件 %s 未注册类", mod["name"])
-                return
+            return None
+        try:
             instance = cls()
             name = str(instance.name or mod["name"]).strip()
             if not name:
-                logger.warning("插件 %s 缺少 name", mod["name"])
-                return
+                raise RuntimeError("插件缺少 name")
             plugin_id = f"{name}@{mod['marketplace']}" if mod["marketplace"] else name
             if plugin_id != initial_plugin_id:
                 raise RuntimeError(
                     f"插件目录身份与声明不一致: directory={initial_plugin_id} declared={plugin_id}"
                 )
-            data_dir = _resolve_plugin_data_dir(name, mod, self._installed_cache_root)
-            try:
-                plugin_config = _load_plugin_config(
-                    data_dir,
-                    getattr(cls, "ConfigModel", None),
-                )
-            except _PluginConfigError as e:
-                logger.warning("插件 %s 配置无效，跳过: %s", mod["name"], e)
-                plugin_registry.remove_plugin(mp)
-                self._record_failed_gate(
-                    plugin_id=plugin_id,
-                    revision=source_revision,
-                    check_id="config",
-                    reason=str(e),
-                )
-                return
-            from agent.plugins.context import PluginContext, PluginKVStore
-            scope = PluginScope(plugin_id)
-            instance.context = PluginContext(  # type: ignore[attr-defined]
-                event_bus=ScopedEventBus(self._event_bus, scope),
-                tool_registry=self._tool_registry,
+            plugin_config = _load_plugin_config(
+                data_dir,
+                getattr(cls, "ConfigModel", None),
+            )
+        except Exception as error:
+            self._remove_module_tree(mp)
+            self._record_failed_gate(
+                plugin_id=initial_plugin_id,
+                revision=source_revision,
+                check_id=("config" if isinstance(error, _PluginConfigError) else "identity"),
+                reason=str(error),
+            )
+            return None
+        from agent.plugins.context import PluginContext, PluginKVStore
+        scope = PluginScope(plugin_id)
+        instance.context = PluginContext(  # type: ignore[attr-defined]
+            event_bus=None,  # type: ignore[arg-type]
+            tool_registry=None,
+            plugin_id=plugin_id,
+            plugin_dir=plugin_dir,
+            data_dir=data_dir,
+            kv_store=PluginKVStore(data_dir / ".kv.json", writable=False),
+            config=plugin_config,
+            workspace=self._workspace,
+            session_manager=None,
+            memory_engine=self._memory_engine,
+            llm=None,
+            scope=None,
+            generation_id=generation_id,
+        )
+        plugin_registry.register_instance(mp, instance)
+        initialization_started = False
+
+        async def rollback_load() -> None:
+            terminator = getattr(instance, "terminate", None)
+            if initialization_started and callable(terminator):
+                try:
+                    typed_terminator = cast(
+                        Callable[[], Awaitable[None]],
+                        terminator,
+                    )
+                    await typed_terminator()
+                except (asyncio.CancelledError, Exception) as terminate_error:
+                    self._cleanup_failures.append(
+                        CleanupFailure(
+                            resource=f"plugin:{plugin_id}:terminate",
+                            error=str(terminate_error) or type(terminate_error).__name__,
+                        )
+                    )
+            self._cleanup_failures.extend(await scope.aclose())
+            self._remove_module_tree(mp)
+            for tool_name in tool_names:
+                if self._tool_registry is not None:
+                    self._tool_registry.unregister(tool_name)
+            del self._tool_hooks[hook_count_before:]
+            del self._before_turn_modules[before_turn_count_before:]
+            del self._before_reasoning_modules[before_reasoning_count_before:]
+            del self._prompt_render_modules[prompt_render_count_before:]
+            del self._before_step_modules[before_step_count_before:]
+            del self._after_step_modules[after_step_count_before:]
+            del self._after_reasoning_modules[after_reasoning_count_before:]
+            del self._after_turn_modules[after_turn_count_before:]
+            del self._proactive_modules[proactive_module_count_before:]
+            del self._proactive_lifecycles[proactive_lifecycle_count_before:]
+            del self._proactive_module_factories[proactive_factory_count_before:]
+            del self._proactive_runtime_factories[proactive_runtime_factory_count_before:]
+            del self._proactive_sources[proactive_source_count_before:]
+            del self._jobs[job_count_before:]
+            del self._channels[channel_count_before:]
+
+        try:
+            load_phase = "declarations"
+            contributions = self._collect_candidate_contributions(
+                instance=instance,
                 plugin_id=plugin_id,
                 plugin_dir=plugin_dir,
                 data_dir=data_dir,
-                kv_store=PluginKVStore(data_dir / ".kv.json"),
-                config=plugin_config,
-                workspace=self._workspace,
-                session_manager=self._session_manager,
-                memory_engine=self._memory_engine,
-                llm=self._llm,
-                scope=scope,
-                generation_id=generation_id,
+                module_path=mp,
             )
-            plugin_registry.register_instance(mp, instance)
-            initialization_started = False
-
-            async def rollback_load() -> None:
-                terminator = getattr(instance, "terminate", None)
-                if initialization_started and callable(terminator):
-                    try:
-                        typed_terminator = cast(
-                            Callable[[], Awaitable[None]],
-                            terminator,
-                        )
-                        await typed_terminator()
-                    except (asyncio.CancelledError, Exception) as terminate_error:
-                        self._cleanup_failures.append(
-                            CleanupFailure(
-                                resource=f"plugin:{plugin_id}:terminate",
-                                error=str(terminate_error) or type(terminate_error).__name__,
-                            )
-                        )
-                self._cleanup_failures.extend(await scope.aclose())
-                plugin_registry.remove_plugin(mp)
-                _ = sys.modules.pop(mp, None)
-                for tool_name in tool_names:
-                    if self._tool_registry is not None:
-                        self._tool_registry.unregister(tool_name)
-                del self._tool_hooks[hook_count_before:]
-                del self._before_turn_modules[before_turn_count_before:]
-                del self._before_reasoning_modules[before_reasoning_count_before:]
-                del self._prompt_render_modules[prompt_render_count_before:]
-                del self._before_step_modules[before_step_count_before:]
-                del self._after_step_modules[after_step_count_before:]
-                del self._after_reasoning_modules[after_reasoning_count_before:]
-                del self._after_turn_modules[after_turn_count_before:]
-                del self._proactive_modules[proactive_module_count_before:]
-                del self._proactive_lifecycles[proactive_lifecycle_count_before:]
-                del self._proactive_module_factories[proactive_factory_count_before:]
-                del self._proactive_runtime_factories[
-                    proactive_runtime_factory_count_before:
-                ]
-                del self._proactive_sources[proactive_source_count_before:]
-                del self._jobs[job_count_before:]
-
-            try:
-                contributions = self._collect_candidate_contributions(
-                    instance=instance,
-                    plugin_id=plugin_id,
-                    plugin_dir=plugin_dir,
-                    data_dir=data_dir,
-                    module_path=mp,
-                )
-                gate_result = self._validate_candidate(
-                    instance=instance,
-                    plugin_id=plugin_id,
-                    revision=source_revision,
-                    contributions=contributions,
-                )
-                self._gate_results[plugin_id] = gate_result
-                if gate_result.status == "failed":
-                    raise _CandidateRejected(gate_result)
-                self._bind_handlers(instance, mp, scope)
-                self._register_tools(instance, mp, tool_names)
-                self._bind_tool_hooks(instance, mp)
-                self._publish_contributions(contributions)
-                if hasattr(instance, "initialize"):
-                    initialization_started = True
-                    await instance.initialize()
-            except asyncio.CancelledError:
-                rollback_task = asyncio.create_task(
-                    rollback_load(),
-                    name=f"plugin_rollback:{plugin_id}",
-                )
-                while not rollback_task.done():
-                    try:
-                        await asyncio.shield(rollback_task)
-                    except asyncio.CancelledError:
-                        continue
-                await rollback_task
-                raise
-            except _CandidateRejected as error:
-                logger.warning(
-                    "插件 %s 候选验证失败: %s",
-                    mod["name"],
-                    error.gate.failure_reason,
-                )
-                await rollback_load()
-                return
-            except Exception as e:
-                logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)
-                latest_gate = self._gate_results.get(plugin_id)
-                if (
-                    latest_gate is None
-                    or latest_gate.candidate_revision != source_revision
-                ):
-                    self._record_failed_gate(
-                        plugin_id=plugin_id,
-                        revision=source_revision,
-                        check_id="declarations",
-                        reason=str(e),
-                    )
-                await rollback_load()
-                return
-            self._scopes[mp] = scope
-            manifest = contributions.manifest
-            skill_roots = contributions.skill_roots
-            drift_skill_roots = contributions.drift_skill_roots
-            mcp_servers = contributions.mcp_servers
-        else:
-            raise RuntimeError(f"插件缺少 plugin.py: {plugin_dir}")
+            gate_result = self._validate_candidate(
+                instance=instance,
+                plugin_id=plugin_id,
+                revision=source_revision,
+                contributions=contributions,
+            )
+            self._gate_results[plugin_id] = gate_result
+            if gate_result.status == "failed":
+                raise _CandidateRejected(gate_result)
+            generation = PluginGeneration(
+                plugin_id=plugin_id,
+                generation_id=generation_id,
+                module_path=mp,
+                source_revision=source_revision,
+                config_revision=config_revision,
+                instance=instance,
+                scope=scope,
+                contributions=contributions,
+                gate_result=gate_result,
+                state="prepared" if not activate else "activating",
+            )
+            if not activate:
+                self._prepared_generations[plugin_id] = generation
+                return generation
+            staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
+            instance.context.event_bus = staged_event_bus
+            instance.context.kv_store = PluginKVStore(data_dir / ".kv.json")
+            instance.context.session_manager = self._session_manager
+            instance.context.llm = self._llm
+            instance.context.scope = scope
+            load_phase = "initialize"
+            initialization_started = True
+            await instance.initialize()
+            load_phase = "publish"
+            self._register_tools(instance, mp, tool_names)
+            self._bind_tool_hooks(instance, mp)
+            self._publish_contributions(contributions)
+            self._channels.extend(contributions.channels)
+            self._bind_handlers(instance, mp, scope)
+            staged_event_bus.activate()
+            instance.context.tool_registry = self._tool_registry
+        except asyncio.CancelledError:
+            rollback_task = asyncio.create_task(
+                rollback_load(),
+                name=f"plugin_rollback:{plugin_id}",
+            )
+            while not rollback_task.done():
+                try:
+                    await asyncio.shield(rollback_task)
+                except asyncio.CancelledError:
+                    continue
+            await rollback_task
+            raise
+        except _CandidateRejected as error:
+            logger.warning(
+                "插件 %s 候选验证失败: %s",
+                mod["name"],
+                error.gate.failure_reason,
+            )
+            await rollback_load()
+            return None
+        except Exception as error:
+            logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], error)
+            self._record_failed_gate(
+                plugin_id=plugin_id,
+                revision=source_revision,
+                check_id=load_phase,
+                reason=str(error),
+            )
+            await rollback_load()
+            return None
+        self._scopes[mp] = scope
         self._loaded.add(mp)
         self._active_plugins[mp] = ActivePluginInfo(
             plugin_id=plugin_id,
             plugin_dir=plugin_dir,
-            manifest=manifest,
+            manifest=contributions.manifest,
             module_path=mp,
-            skill_roots=skill_roots,
-            drift_skill_roots=drift_skill_roots,
-            mcp_servers=mcp_servers,
+            skill_roots=contributions.skill_roots,
+            drift_skill_roots=contributions.drift_skill_roots,
+            mcp_servers=contributions.mcp_servers,
         )
-        generation = PluginGeneration(
-            plugin_id=plugin_id,
-            generation_id=generation_id,
-            module_path=mp,
-            source_revision=source_revision,
-            config_revision=config_revision,
-            instance=instance,
-            scope=scope,
-            contributions=contributions,
-            gate_result=gate_result,
-        )
+        generation.state = "active"
         self._active_generations[plugin_id] = generation
         self._stable_aliases[mp] = stable_module_path
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]
-        if instance is not None:
-            self._channels.extend(contributions.channels)
         logger.info("插件已加载: %s", mod["name"])
+        return generation
 
     def _collect_candidate_contributions(
         self,
@@ -622,6 +647,12 @@ class PluginManager:
         contributions: PluginContributions,
     ) -> GateResult:
         checks: list[GateCheckResult] = []
+        current = self._active_generations.get(plugin_id)
+        other_generations = [
+            generation
+            for generation in self._active_generations.values()
+            if generation.plugin_id != plugin_id
+        ]
 
         def check(check_id: str, passed: bool, evidence: object = "") -> None:
             checks.append(
@@ -644,8 +675,23 @@ class PluginManager:
             if md.kind == MetadataKind.TOOL
         ]
         duplicate_tools = _duplicates(tool_names)
+        current_tool_names = (
+            {
+                metadata.tool_name or metadata.handler_name
+                for metadata in plugin_registry.get_handlers_by_module_path(
+                    current.module_path
+                )
+                if metadata.kind == MetadataKind.TOOL
+            }
+            if current is not None
+            else set()
+        )
         occupied_tools = (
-            sorted(name for name in tool_names if self._tool_registry.has_tool(name))
+            sorted(
+                name
+                for name in tool_names
+                if self._tool_registry.has_tool(name) and name not in current_tool_names
+            )
             if self._tool_registry is not None
             else []
         )
@@ -660,14 +706,26 @@ class PluginManager:
             for source in contributions.proactive_sources
             if not source.spec.id
             or not source.spec.channels
+            or not set(source.spec.channels).issubset({"alert", "content", "context"})
             or not source.spec.server
             or not source.spec.fetch_tool
+            or source.spec.poll_interval_seconds < 0
             or source.spec.server not in contributions.mcp_servers
         ]
         check(
             "proactive_sources",
             not _duplicates(source_ids) and not source_errors,
             {"duplicates": _duplicates(source_ids), "invalid": source_errors},
+        )
+        occupied_servers = {
+            server_name
+            for generation in other_generations
+            for server_name in generation.contributions.mcp_servers
+        }
+        check(
+            "mcp_servers",
+            not occupied_servers.intersection(contributions.mcp_servers),
+            sorted(occupied_servers.intersection(contributions.mcp_servers)),
         )
         job_ids = [job.spec.id for job in contributions.jobs]
         check(
@@ -680,7 +738,9 @@ class PluginManager:
             for channel in contributions.channels
         ]
         occupied_channels = {
-            str(getattr(channel, "name", "")).strip() for channel in self._channels
+            str(getattr(channel, "name", "")).strip()
+            for generation in other_generations
+            for channel in generation.contributions.channels
         }
         check(
             "channel_names",
@@ -697,17 +757,22 @@ class PluginManager:
             },
         )
         phase_groups = (
-            contributions.before_turn_modules,
-            contributions.before_reasoning_modules,
-            contributions.prompt_render_modules,
-            contributions.before_step_modules,
-            contributions.after_step_modules,
-            contributions.after_reasoning_modules,
-            contributions.after_turn_modules,
+            ("before_turn_modules", contributions.before_turn_modules),
+            ("before_reasoning_modules", contributions.before_reasoning_modules),
+            ("prompt_render_modules", contributions.prompt_render_modules),
+            ("before_step_modules", contributions.before_step_modules),
+            ("after_step_modules", contributions.after_step_modules),
+            ("after_reasoning_modules", contributions.after_reasoning_modules),
+            ("after_turn_modules", contributions.after_turn_modules),
         )
         try:
-            for modules in phase_groups:
-                _ = topo_sort_modules(modules)
+            for field_name, candidate_modules in phase_groups:
+                active_modules = [
+                    module
+                    for generation in other_generations
+                    for module in getattr(generation.contributions, field_name)
+                ]
+                _ = topo_sort_modules([*active_modules, *candidate_modules])
         except RuntimeError as error:
             check("phase_graph", False, str(error))
         else:
@@ -720,8 +785,24 @@ class PluginManager:
         check(
             "proactive_lifecycles",
             len(lifecycle_ids) == len(contributions.proactive_lifecycles)
-            and not _duplicates(lifecycle_ids),
-            _duplicates(lifecycle_ids),
+            and not _duplicates(lifecycle_ids)
+            and not {
+                lifecycle.id
+                for generation in other_generations
+                for lifecycle in generation.contributions.proactive_lifecycles
+                if isinstance(lifecycle, ProactiveLifecycleSpec)
+            }.intersection(lifecycle_ids),
+            {
+                "duplicates": _duplicates(lifecycle_ids),
+                "occupied": sorted(
+                    {
+                        lifecycle.id
+                        for generation in other_generations
+                        for lifecycle in generation.contributions.proactive_lifecycles
+                        if isinstance(lifecycle, ProactiveLifecycleSpec)
+                    }.intersection(lifecycle_ids)
+                ),
+            },
         )
         try:
             semantic_checks = instance.static_semantic_checks()
@@ -808,8 +889,14 @@ class PluginManager:
         try:
             spec.loader.exec_module(module)  # type: ignore[union-attr]
         except BaseException:
-            _ = sys.modules.pop(module_name, None)
+            self._remove_module_tree(module_name)
             raise
+
+    def _remove_module_tree(self, module_name: str) -> None:
+        plugin_registry.remove_module_tree(module_name)
+        for imported_name in tuple(sys.modules):
+            if imported_name == module_name or imported_name.startswith(f"{module_name}."):
+                _ = sys.modules.pop(imported_name, None)
 
     def _register_tools(
         self,
@@ -886,6 +973,8 @@ class PluginManager:
             logger.info("插件 tool hook 已注册: %s", hook.name)
 
     async def terminate_all(self) -> None:
+        for plugin_id in tuple(self._prepared_generations):
+            await self.discard_prepared(plugin_id)
         for mp in list(self._loaded):
             active_info = self._active_plugins.get(mp)
             instance = plugin_registry.get_instance(mp)
@@ -912,8 +1001,7 @@ class PluginManager:
             for md in plugin_registry.get_handlers_by_module_path(mp):
                 if md.kind == MetadataKind.TOOL and self._tool_registry is not None:
                     self._tool_registry.unregister(md.tool_name or md.handler_name)
-            plugin_registry.remove_plugin(mp)
-            _ = sys.modules.pop(mp, None)
+            self._remove_module_tree(mp)
             stable_alias = self._stable_aliases.pop(mp, None)
             if stable_alias is not None:
                 plugin_registry.remove_plugin(stable_alias)
@@ -940,6 +1028,7 @@ class PluginManager:
         self._channels.clear()
         self._scopes.clear()
         self._active_generations.clear()
+        self._prepared_generations.clear()
         self._stable_aliases.clear()
 
 
@@ -965,6 +1054,8 @@ def _load_plugin_config(
         except (OSError, tomllib.TOMLDecodeError) as e:
             raise _PluginConfigError(str(e)) from e
     if config_model is not None:
+        if not isinstance(config_model, type) or not issubclass(config_model, BaseModel):
+            raise _PluginConfigError("ConfigModel 必须继承 pydantic.BaseModel")
         try:
             return config_model.model_validate(raw_config)
         except ValidationError as e:
@@ -986,18 +1077,23 @@ def _load_module_list(instance: Any, method_name: str) -> list[object]:
     if provider is None:
         return []
     if not callable(provider):
-        logger.warning("插件 %s.%s 不是可调用对象", type(instance).__name__, method_name)
-        return []
+        raise RuntimeError(
+            f"插件 {type(instance).__name__}.{method_name} 不是可调用对象"
+        )
     try:
         loaded = provider()
     except Exception as e:
-        logger.warning("插件 %s.%s 加载失败: %s", type(instance).__name__, method_name, e)
-        return []
+        raise RuntimeError(
+            f"插件 {type(instance).__name__}.{method_name} 声明失败: {e}"
+        ) from e
     if loaded is None:
-        return []
+        raise RuntimeError(
+            f"插件 {type(instance).__name__}.{method_name} 返回值不能为 None"
+        )
     if not isinstance(loaded, list):
-        logger.warning("插件 %s.%s 返回值不是 list", type(instance).__name__, method_name)
-        return []
+        raise RuntimeError(
+            f"插件 {type(instance).__name__}.{method_name} 返回值不是 list"
+        )
     return loaded
 
 
@@ -1031,9 +1127,11 @@ def _resolve_declared_roots(
     plugin_dir: Path,
     declared: tuple[str, ...],
 ) -> tuple[Path, ...]:
+    plugin_root = plugin_dir.resolve(strict=False)
     roots: list[Path] = []
     for raw_path in declared:
         path = (plugin_dir / raw_path).resolve(strict=False)
+        _require_plugin_path(plugin_root, path, "能力目录")
         if not path.is_dir():
             raise RuntimeError(f"插件能力目录不存在: {path}")
         roots.append(path)
@@ -1046,18 +1144,31 @@ def _resolve_mcp_servers(
     declared: list[McpServerSpec],
 ) -> dict[str, dict[str, Any]]:
     servers: dict[str, dict[str, Any]] = {}
+    plugin_root = plugin_dir.resolve(strict=False)
     for spec in declared:
         if not isinstance(spec, McpServerSpec) or not spec.name or not spec.command:
             raise RuntimeError(f"插件 MCP server 声明无效: {spec!r}")
+        if not all(isinstance(item, str) and item for item in spec.command):
+            raise RuntimeError(f"插件 MCP command 声明无效: {spec.name}")
+        if not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in spec.env.items()
+        ):
+            raise RuntimeError(f"插件 MCP env 声明无效: {spec.name}")
         if spec.name in servers:
             raise RuntimeError(f"插件 MCP server 名称重复: {spec.name}")
-        command = [_resolve_command_item(plugin_dir, item) for item in spec.command]
+        command = [
+            _resolve_command_item(plugin_root, item, executable=index == 0)
+            for index, item in enumerate(spec.command)
+        ]
         cwd_path = Path(spec.cwd)
-        cwd = (
-            str(cwd_path)
+        resolved_cwd = (
+            cwd_path.resolve(strict=False)
             if cwd_path.is_absolute()
-            else str((plugin_dir / cwd_path).resolve(strict=False))
+            else (plugin_root / cwd_path).resolve(strict=False)
         )
+        _require_plugin_path(plugin_root, resolved_cwd, "MCP cwd")
+        cwd = str(resolved_cwd)
         env = {**spec.env, "AKA_PLUGIN_DATA_DIR": str(data_dir)}
         if _is_python_command(command[0]):
             runtime_root = _resolve_mcp_runtime_root(plugin_dir, cwd, command)
@@ -1069,11 +1180,31 @@ def _resolve_mcp_servers(
     return servers
 
 
-def _resolve_command_item(plugin_dir: Path, item: str) -> str:
+def _resolve_command_item(
+    plugin_dir: Path,
+    item: str,
+    *,
+    executable: bool,
+) -> str:
     path = Path(item)
-    if path.is_absolute() or ("/" not in item and "\\" not in item and not item.startswith(".")):
+    if executable and path.is_absolute():
         return item
-    return str((plugin_dir / path).resolve(strict=False))
+    if "/" not in item and "\\" not in item and not item.startswith("."):
+        return item
+    resolved = (
+        path.resolve(strict=False)
+        if path.is_absolute()
+        else (plugin_dir / path).resolve(strict=False)
+    )
+    _require_plugin_path(plugin_dir, resolved, "MCP command")
+    return str(resolved)
+
+
+def _require_plugin_path(plugin_dir: Path, path: Path, label: str) -> None:
+    try:
+        _ = path.relative_to(plugin_dir)
+    except ValueError as error:
+        raise RuntimeError(f"插件 {label} 越界: {path}") from error
 
 
 def _is_python_command(value: str) -> bool:
@@ -1191,6 +1322,35 @@ def _file_revision(path: Path) -> str:
         digest.update(path.read_bytes())
     else:
         digest.update(b"<missing>")
+    return digest.hexdigest()
+
+
+def _source_revision(plugin_dir: Path) -> str:
+    digest = hashlib.sha256()
+    root = plugin_dir.resolve(strict=False)
+    excluded = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
+    for path in sorted(plugin_dir.rglob("*")):
+        relative = path.relative_to(plugin_dir)
+        if any(part in excluded for part in relative.parts):
+            continue
+        if path.is_symlink():
+            digest.update(str(relative).encode())
+            digest.update(os.readlink(path).encode())
+            continue
+        if not path.is_file():
+            continue
+        resolved = path.resolve(strict=False)
+        _require_plugin_path(root, resolved, "源码文件")
+        digest.update(str(relative).encode())
+        digest.update(path.read_bytes())
     return digest.hexdigest()
 
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1212,6 +1212,7 @@ class PluginManager:
                 catalog_generation=generation,
             )
             snapshot.tool_registry = self._compile_snapshot_tools(generations)
+            snapshot.tool_hooks = self._compile_snapshot_tool_hooks(generations)
             return snapshot
         except Exception as error:
             gate = _with_gate_check(
@@ -1274,6 +1275,29 @@ class PluginManager:
                         source_name=server.name,
                     )
         return registry
+
+    def _compile_snapshot_tool_hooks(
+        self,
+        generations: dict[str, PluginGeneration],
+    ) -> tuple[ToolHook, ...]:
+        hooks: list[ToolHook] = []
+        for generation in sorted(generations.values(), key=lambda item: item.plugin_id):
+            for metadata in plugin_registry.get_handlers_by_module_path(
+                generation.module_path
+            ):
+                if metadata.kind != MetadataKind.TOOL_HOOK:
+                    continue
+                hooks.append(
+                    _PluginToolHook(
+                        name=(
+                            f"plugin:{getattr(generation.instance, 'name', generation.module_path)}:"
+                            f"{metadata.handler_name}"
+                        ),
+                        handler=functools.partial(metadata.handler, generation.instance),
+                        tool_name_filter=metadata.hook_tool_name,
+                    )
+                )
+        return tuple(hooks)
 
     async def _publish_committed_snapshot(
         self,

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -642,6 +642,7 @@ class PluginManager:
         generation.state = "active"
         self._active_generations[plugin_id] = generation
         self._stable_aliases[mp] = stable_module_path
+        self._remove_module_tree(stable_module_path)
         self._fresh_importer.register(stable_module_path, plugin_dir)
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -51,6 +51,12 @@ from agent.plugins.generation import (
 from agent.plugins.importer import FreshPluginImporter
 from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
 from agent.plugins.mcp_host import PluginMcpHost, PreparedMcpCatalog
+from agent.plugins.activity_host import (
+    PluginJobHost,
+    PluginProactiveHost,
+    PreparedJobCatalog,
+    PreparedProactiveCatalog,
+)
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
@@ -136,6 +142,8 @@ class PluginManager:
         self._manager_namespace = secrets.token_hex(4)
         self._skill_host = PluginSkillHost(workspace)
         self._mcp_host = PluginMcpHost()
+        self._job_host = PluginJobHost()
+        self._proactive_host = PluginProactiveHost()
 
     @property
     def loaded_count(self) -> int:
@@ -234,6 +242,15 @@ class PluginManager:
 
     def mcp_catalog(self, generation_id: str) -> PreparedMcpCatalog | None:
         return self._mcp_host.get(generation_id)
+
+    def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
+        return self._job_host.get(generation_id)
+
+    def proactive_catalog(
+        self,
+        generation_id: str,
+    ) -> PreparedProactiveCatalog | None:
+        return self._proactive_host.get(generation_id)
 
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
@@ -376,6 +393,8 @@ class PluginManager:
                         active,
                         "readiness_semantic_checks",
                     ),
+                    "jobs": _job_keys(active),
+                    "proactive_sources": _proactive_source_keys(active),
                 }
                 results.append(result)
                 logger.info(
@@ -427,6 +446,12 @@ class PluginManager:
                 "mcp_tools": _mcp_tool_names(prepared) if prepared is not None else [],
                 "readiness_checks": (
                     _gate_check_evidence(prepared, "readiness_semantic_checks")
+                    if prepared is not None
+                    else []
+                ),
+                "jobs": _job_keys(prepared) if prepared is not None else [],
+                "proactive_sources": (
+                    _proactive_source_keys(prepared)
                     if prepared is not None
                     else []
                 ),
@@ -685,6 +710,45 @@ class PluginManager:
                 "skill_catalog",
                 lambda: self._skill_host.close(generation_id),
             )
+            try:
+                job_catalog = self._job_host.prepare(
+                    generation_id,
+                    contributions.jobs,
+                )
+                scope.defer(
+                    "job_catalog",
+                    lambda: self._job_host.close(generation_id),
+                )
+                proactive_catalog = self._proactive_host.prepare(
+                    generation_id,
+                    contributions.proactive_sources,
+                )
+                scope.defer(
+                    "proactive_catalog",
+                    lambda: self._proactive_host.close(generation_id),
+                )
+            except Exception as error:
+                gate_result = _with_gate_check(
+                    gate_result,
+                    check_id="activity_catalogs",
+                    passed=False,
+                    evidence=str(error),
+                )
+                self._gate_results[plugin_id] = gate_result
+                raise _CandidateRejected(gate_result) from error
+            generation.job_catalog = job_catalog
+            generation.proactive_catalog = proactive_catalog
+            gate_result = _with_gate_check(
+                gate_result,
+                check_id="activity_catalogs",
+                passed=True,
+                evidence={
+                    "jobs": sorted(job_catalog.jobs),
+                    "proactive_sources": sorted(proactive_catalog.sources),
+                },
+            )
+            self._gate_results[plugin_id] = gate_result
+            generation.gate_result = gate_result
             if not activate:
                 try:
                     mcp_catalog = await self._mcp_host.prepare(
@@ -713,6 +777,8 @@ class PluginManager:
                         PluginReadinessContext(
                             generation_id=generation_id,
                             mcp_catalog=mcp_catalog,
+                            job_catalog=job_catalog,
+                            proactive_catalog=proactive_catalog,
                         )
                     )
                     if not isinstance(raw_readiness_checks, list):
@@ -1746,6 +1812,16 @@ def _skill_body_hashes(
 def _mcp_tool_names(generation: PluginGeneration) -> list[str]:
     catalog = generation.mcp_catalog
     return list(catalog.tool_names) if catalog is not None else []
+
+
+def _job_keys(generation: PluginGeneration) -> list[str]:
+    catalog = generation.job_catalog
+    return sorted(catalog.jobs) if catalog is not None else []
+
+
+def _proactive_source_keys(generation: PluginGeneration) -> list[str]:
+    catalog = generation.proactive_catalog
+    return sorted(catalog.sources) if catalog is not None else []
 
 
 def _gate_check_evidence(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -121,7 +121,6 @@ class PluginManager:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
         self._tool_registry = tool_registry
-        self._plugin_mcp_server_names: set[str] = set()
         self._workspace = workspace
         self._session_manager = session_manager
         self._memory_engine = memory_engine
@@ -459,9 +458,6 @@ class PluginManager:
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
-        self._plugin_mcp_server_names.update(
-            generation.contributions.mcp_servers
-        )
         self._scopes[generation.module_path] = generation.scope
         self._loaded.add(generation.module_path)
         generation.state = "active"
@@ -502,7 +498,7 @@ class PluginManager:
         context.memory_engine = self._memory_engine
         context.llm = self._llm
         context.scope = generation.scope
-        context.tool_registry = self._tool_registry
+        context.tool_registry = generation.runtime_snapshot.tool_registry
         generation.initialization_started = True
         await instance.initialize()
         generation.minimum_resource_count = generation.scope.resource_count
@@ -1137,6 +1133,7 @@ class PluginManager:
             instance.context.memory_engine = self._memory_engine
             instance.context.llm = self._llm
             instance.context.scope = scope
+            instance.context.tool_registry = generation.runtime_snapshot.tool_registry
             load_phase = "initialize"
             initialization_started = True
             await instance.initialize()
@@ -1146,7 +1143,6 @@ class PluginManager:
             self._publish_contributions(contributions)
             self._channels.extend(contributions.channels)
             staged_event_bus.publish()
-            instance.context.tool_registry = self._tool_registry
             generation.minimum_resource_count = scope.resource_count
         except asyncio.CancelledError:
             rollback_task = asyncio.create_task(
@@ -1191,7 +1187,6 @@ class PluginManager:
         )
         generation.state = "active"
         self._active_generations[plugin_id] = generation
-        self._plugin_mcp_server_names.update(contributions.mcp_servers)
         self._stable_aliases[mp] = stable_module_path
         self._remove_module_tree(stable_module_path)
         self._fresh_importer.register(stable_module_path, plugin_dir)
@@ -1235,14 +1230,8 @@ class PluginManager:
             return None
         plugin_mcp_sources = {
             ("mcp", server_name)
-            for server_name in {
-                *self._plugin_mcp_server_names,
-                *(
-                    server_name
-                    for generation in generations.values()
-                    for server_name in generation.contributions.mcp_servers
-                ),
-            }
+            for generation in generations.values()
+            for server_name in generation.contributions.mcp_servers
         }
         registry = self._tool_registry.fork(
             excluded_source_types={"plugin"},
@@ -1466,6 +1455,12 @@ class PluginManager:
             for generation in other_generations
             for server_name in generation.contributions.mcp_servers
         }
+        if self._tool_registry is not None:
+            occupied_servers.update(
+                document.source_name
+                for document in self._tool_registry.get_documents()
+                if document.source_type == "mcp"
+            )
         check(
             "mcp_servers",
             not occupied_servers.intersection(contributions.mcp_servers),

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -13,6 +13,7 @@ import sys
 import tomllib
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from types import MappingProxyType
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -160,6 +161,7 @@ class PluginManager:
         self._snapshot_compiler = RuntimeSnapshotCompiler()
         self._snapshot_drains: dict[str, tuple[PluginGeneration, ...]] = {}
         self._snapshot_store = RuntimeSnapshotStore(self._on_snapshot_drained)
+        self._event_bus.bind_runtime_snapshot_store(self._snapshot_store)
 
     @property
     def loaded_count(self) -> int:
@@ -439,6 +441,9 @@ class PluginManager:
             )
             return result
 
+        self._compile_snapshot_event_handlers(snapshot)
+        if generation.staged_event_bus is not None:
+            generation.staged_event_bus.publish()
         transaction = self._snapshot_store.begin_publish(snapshot)
         try:
             await asyncio.wait_for(
@@ -501,6 +506,32 @@ class PluginManager:
         generation.initialization_started = True
         await instance.initialize()
         generation.minimum_resource_count = generation.scope.resource_count
+
+    def _compile_snapshot_event_handlers(self, snapshot: RuntimeSnapshot) -> None:
+        handlers: dict[type[object], list[Any]] = {}
+        for generation in snapshot.generations.values():
+            for metadata in plugin_registry.get_handlers_by_module_path(
+                generation.module_path
+            ):
+                if metadata.kind != MetadataKind.LIFECYCLE:
+                    continue
+                event_type = _EVENT_TYPE_MAP.get(metadata.event_type)  # type: ignore[arg-type]
+                if event_type is None:
+                    continue
+                handlers.setdefault(event_type, []).append(
+                    functools.partial(metadata.handler, generation.instance)
+                )
+            staged = generation.staged_event_bus
+            if staged is None:
+                continue
+            for event_type, handler in staged.staged_handlers():
+                handlers.setdefault(event_type, []).append(handler)
+        snapshot.event_handlers = MappingProxyType(
+            {
+                event_type: tuple(event_handlers)
+                for event_type, event_handlers in handlers.items()
+            }
+        )
 
     async def _post_publish_invariants(
         self,
@@ -1099,6 +1130,7 @@ class PluginManager:
                     return generation
             generation.runtime_snapshot = self._compile_generation_snapshot(generation)
             staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
+            generation.staged_event_bus = staged_event_bus
             instance.context.event_bus = staged_event_bus
             instance.context.kv_store = PluginKVStore(data_dir / ".kv.json")
             instance.context.session_manager = self._session_manager
@@ -1113,8 +1145,7 @@ class PluginManager:
             self._bind_tool_hooks(instance, mp)
             self._publish_contributions(contributions)
             self._channels.extend(contributions.channels)
-            self._bind_handlers(instance, mp, scope)
-            staged_event_bus.activate()
+            staged_event_bus.publish()
             instance.context.tool_registry = self._tool_registry
             generation.minimum_resource_count = scope.resource_count
         except asyncio.CancelledError:
@@ -1167,6 +1198,7 @@ class PluginManager:
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]
         assert generation.runtime_snapshot is not None
+        self._compile_snapshot_event_handlers(generation.runtime_snapshot)
         await self._publish_committed_snapshot(generation.runtime_snapshot)
         logger.info("插件已加载: %s", mod["name"])
         return generation

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -360,6 +360,11 @@ class PluginManager:
                     ),
                     "skill_descriptions": _skill_descriptions(active),
                     "drift_skill_descriptions": _drift_skill_descriptions(active),
+                    "skill_body_hashes": _skill_body_hashes(active, drift=False),
+                    "drift_skill_body_hashes": _skill_body_hashes(
+                        active,
+                        drift=True,
+                    ),
                 }
                 results.append(result)
                 logger.info(
@@ -395,6 +400,16 @@ class PluginManager:
                 ),
                 "drift_skill_descriptions": (
                     _drift_skill_descriptions(prepared)
+                    if prepared is not None
+                    else {}
+                ),
+                "skill_body_hashes": (
+                    _skill_body_hashes(prepared, drift=False)
+                    if prepared is not None
+                    else {}
+                ),
+                "drift_skill_body_hashes": (
+                    _skill_body_hashes(prepared, drift=True)
                     if prepared is not None
                     else {}
                 ),
@@ -1612,6 +1627,21 @@ def _drift_skill_descriptions(generation: PluginGeneration) -> dict[str, str]:
     return {
         name: record.description
         for name, record in sorted(catalog.drift.records.items())
+    }
+
+
+def _skill_body_hashes(
+    generation: PluginGeneration,
+    *,
+    drift: bool,
+) -> dict[str, str]:
+    catalog = generation.skill_catalog
+    if catalog is None:
+        return {}
+    records = catalog.drift.records if drift else catalog.normal.records
+    return {
+        name: hashlib.sha256(record.content.encode()).hexdigest()
+        for name, record in sorted(records.items())
     }
 
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -132,6 +132,7 @@ class PluginManager:
             [str, tuple[Channel, ...], tuple[Channel, ...]],
             Awaitable[None],
         ] | None = None
+        self._dashboard_preparer: Callable[[RuntimeSnapshot], None] | None = None
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -274,6 +275,12 @@ class PluginManager:
         ],
     ) -> None:
         self._channel_switcher = switcher
+
+    def bind_dashboard_preparer(
+        self,
+        preparer: Callable[[RuntimeSnapshot], None],
+    ) -> None:
+        self._dashboard_preparer = preparer
 
     def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
         return self._job_host.get(generation_id)
@@ -480,6 +487,25 @@ class PluginManager:
                 )
 
         self._compile_snapshot_event_handlers(snapshot)
+        if self._dashboard_preparer is not None:
+            try:
+                self._dashboard_preparer(snapshot)
+            except Exception as error:
+                self._record_failed_gate(
+                    plugin_id=plugin_id,
+                    revision=generation.source_revision,
+                    check_id="dashboard",
+                    reason=str(error) or type(error).__name__,
+                )
+                await self.discard_prepared(plugin_id)
+                if channels_switched and self._channel_switcher is not None:
+                    await self._channel_switcher(plugin_id, new_channels, old_channels)
+                return self._publication_status(
+                    plugin_id,
+                    active=active,
+                    candidate=generation,
+                    publication_state="failed",
+                )
         if generation.staged_event_bus is not None:
             generation.staged_event_bus.publish()
         transaction = self._snapshot_store.begin_publish(snapshot)
@@ -493,9 +519,15 @@ class PluginManager:
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
             self._snapshot_drains[snapshot.snapshot_id] = (generation,)
-            await self._snapshot_store.abort(transaction)
+            channel_error: BaseException | None = None
             if channels_switched and self._channel_switcher is not None:
-                await self._channel_switcher(plugin_id, new_channels, old_channels)
+                try:
+                    await self._channel_switcher(plugin_id, new_channels, old_channels)
+                except BaseException as error:
+                    channel_error = error
+            await self._snapshot_store.abort(transaction)
+            if channel_error is not None:
+                raise RuntimeError("Snapshot abort 后旧 Channel 恢复失败") from channel_error
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
@@ -505,6 +537,11 @@ class PluginManager:
         self._active_generations[plugin_id] = generation
         if active is not None:
             active.state = "retained_compat"
+        self._channels = [
+            channel
+            for item in self._active_generations.values()
+            for channel in item.contributions.channels
+        ]
         result = self._publication_status(
             plugin_id,
             active=active,
@@ -1434,6 +1471,10 @@ class PluginManager:
                 tuple[Channel, ...],
                 tuple(_load_module_list(instance, "channels")),
             ),
+            dashboard_module=_resolve_dashboard_module(
+                plugin_dir,
+                cls.dashboard_module(),
+            ),
         )
 
     def _validate_candidate(
@@ -1976,6 +2017,16 @@ def _resolve_declared_roots(
             raise RuntimeError(f"插件能力目录不存在: {path}")
         roots.append(path)
     return tuple(roots)
+
+
+def _resolve_dashboard_module(plugin_dir: Path, declared: str | None) -> Path | None:
+    if declared is None:
+        return None
+    path = (plugin_dir / declared).resolve(strict=False)
+    root = plugin_dir.resolve(strict=False)
+    if not path.is_relative_to(root) or path.suffix != ".py" or not path.is_file():
+        raise RuntimeError(f"插件 dashboard module 无效: {declared}")
+    return path
 
 
 def _resolve_mcp_servers(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -48,6 +48,7 @@ from agent.plugins.generation import (
     PluginSemanticCheck,
 )
 from agent.plugins.importer import FreshPluginImporter
+from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
@@ -131,6 +132,7 @@ class PluginManager:
         self._candidate_prepare_lock = asyncio.Lock()
         self._fresh_importer = FreshPluginImporter()
         self._manager_namespace = secrets.token_hex(4)
+        self._skill_host = PluginSkillHost(workspace)
 
     @property
     def loaded_count(self) -> int:
@@ -223,6 +225,9 @@ class PluginManager:
 
     def prepared_generation(self, plugin_id: str) -> PluginGeneration | None:
         return self._prepared_generations.get(plugin_id)
+
+    def skill_catalog(self, generation_id: str) -> PreparedSkillCatalog | None:
+        return self._skill_host.get(generation_id)
 
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
@@ -348,6 +353,11 @@ class PluginManager:
                     "prepared_generation": None,
                     "gate_status": "active",
                     "candidate_revision": source_revision,
+                    "skills": (
+                        list(active.skill_catalog.names)
+                        if active.skill_catalog is not None
+                        else []
+                    ),
                 }
                 results.append(result)
                 logger.info(
@@ -372,6 +382,11 @@ class PluginManager:
                 "gate_status": gate.status if gate is not None else "failed",
                 "candidate_revision": (
                     gate.candidate_revision if gate is not None else ""
+                ),
+                "skills": (
+                    list(prepared.skill_catalog.names)
+                    if prepared is not None and prepared.skill_catalog is not None
+                    else []
                 ),
             }
             results.append(result)
@@ -576,6 +591,46 @@ class PluginManager:
                 contributions=contributions,
                 gate_result=gate_result,
                 state="prepared" if not activate else "activating",
+            )
+            catalog_generations = [
+                active_generation
+                for active_generation in self._active_generations.values()
+                if active_generation.plugin_id != plugin_id
+            ]
+            catalog_generations.append(generation)
+            try:
+                skill_catalog = self._skill_host.prepare(
+                    generation_id,
+                    normal_roots=PluginSkillHost.roots_for(
+                        catalog_generations,
+                        drift=False,
+                    ),
+                    drift_roots=PluginSkillHost.roots_for(
+                        catalog_generations,
+                        drift=True,
+                    ),
+                )
+            except Exception as error:
+                gate_result = _with_gate_check(
+                    gate_result,
+                    check_id="skill_catalog",
+                    passed=False,
+                    evidence=str(error),
+                )
+                self._gate_results[plugin_id] = gate_result
+                raise _CandidateRejected(gate_result) from error
+            gate_result = _with_gate_check(
+                gate_result,
+                check_id="skill_catalog",
+                passed=True,
+                evidence=list(skill_catalog.names),
+            )
+            self._gate_results[plugin_id] = gate_result
+            generation.gate_result = gate_result
+            generation.skill_catalog = skill_catalog
+            scope.defer(
+                "skill_catalog",
+                lambda: self._skill_host.close(generation_id),
             )
             if not activate:
                 self._prepared_generations[plugin_id] = generation
@@ -1169,6 +1224,30 @@ class _CandidateRejected(Exception):
     def __init__(self, gate: GateResult) -> None:
         super().__init__(gate.failure_reason)
         self.gate = gate
+
+
+def _with_gate_check(
+    gate: GateResult,
+    *,
+    check_id: str,
+    passed: bool,
+    evidence: object,
+) -> GateResult:
+    check = GateCheckResult(
+        check_id=check_id,
+        status="passed" if passed else "failed",
+        evidence=evidence,
+    )
+    checks = (*gate.checks, check)
+    failed = [item.check_id for item in checks if item.status == "failed"]
+    return GateResult(
+        gate_id=gate.gate_id,
+        plugin_id=gate.plugin_id,
+        candidate_revision=gate.candidate_revision,
+        status="failed" if failed else "passed",
+        checks=checks,
+        failure_reason="; ".join(failed),
+    )
 
 
 def _load_plugin_config(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import importlib.util
 import inspect
@@ -336,6 +337,45 @@ class PluginManager:
                 scope=scope,
             )
             plugin_registry.register_instance(mp, instance)
+
+            async def rollback_load() -> None:
+                terminator = getattr(instance, "terminate", None)
+                if callable(terminator):
+                    try:
+                        typed_terminator = cast(
+                            Callable[[], Awaitable[None]],
+                            terminator,
+                        )
+                        await typed_terminator()
+                    except (asyncio.CancelledError, Exception) as terminate_error:
+                        self._cleanup_failures.append(
+                            CleanupFailure(
+                                resource=f"plugin:{plugin_id}:terminate",
+                                error=str(terminate_error) or type(terminate_error).__name__,
+                            )
+                        )
+                self._cleanup_failures.extend(await scope.aclose())
+                plugin_registry.remove_plugin(mp)
+                for tool_name in tool_names:
+                    if self._tool_registry is not None:
+                        self._tool_registry.unregister(tool_name)
+                del self._tool_hooks[hook_count_before:]
+                del self._before_turn_modules[before_turn_count_before:]
+                del self._before_reasoning_modules[before_reasoning_count_before:]
+                del self._prompt_render_modules[prompt_render_count_before:]
+                del self._before_step_modules[before_step_count_before:]
+                del self._after_step_modules[after_step_count_before:]
+                del self._after_reasoning_modules[after_reasoning_count_before:]
+                del self._after_turn_modules[after_turn_count_before:]
+                del self._proactive_modules[proactive_module_count_before:]
+                del self._proactive_lifecycles[proactive_lifecycle_count_before:]
+                del self._proactive_module_factories[proactive_factory_count_before:]
+                del self._proactive_runtime_factories[
+                    proactive_runtime_factory_count_before:
+                ]
+                del self._proactive_sources[proactive_source_count_before:]
+                del self._jobs[job_count_before:]
+
             try:
                 self._bind_handlers(instance, mp, scope)
                 self._register_tools(instance, mp, tool_names)
@@ -355,42 +395,12 @@ class PluginManager:
                 self._collect_jobs(instance, plugin_id)
                 if hasattr(instance, "initialize"):
                     await instance.initialize()
+            except asyncio.CancelledError:
+                await asyncio.shield(rollback_load())
+                raise
             except Exception as e:
                 logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)
-                terminator = getattr(instance, "terminate", None)
-                if callable(terminator):
-                    try:
-                        typed_terminator = cast(
-                            Callable[[], Awaitable[None]],
-                            terminator,
-                        )
-                        await typed_terminator()
-                    except Exception as terminate_error:
-                        self._cleanup_failures.append(
-                            CleanupFailure(
-                                resource=f"plugin:{plugin_id}:terminate",
-                                error=str(terminate_error),
-                            )
-                        )
-                self._cleanup_failures.extend(await scope.aclose())
-                plugin_registry.remove_plugin(mp)
-                for tn in tool_names:
-                    if self._tool_registry is not None:
-                        self._tool_registry.unregister(tn)
-                del self._tool_hooks[hook_count_before:]
-                del self._before_turn_modules[before_turn_count_before:]
-                del self._before_reasoning_modules[before_reasoning_count_before:]
-                del self._prompt_render_modules[prompt_render_count_before:]
-                del self._before_step_modules[before_step_count_before:]
-                del self._after_step_modules[after_step_count_before:]
-                del self._after_reasoning_modules[after_reasoning_count_before:]
-                del self._after_turn_modules[after_turn_count_before:]
-                del self._proactive_modules[proactive_module_count_before:]
-                del self._proactive_lifecycles[proactive_lifecycle_count_before:]
-                del self._proactive_module_factories[proactive_factory_count_before:]
-                del self._proactive_runtime_factories[proactive_runtime_factory_count_before:]
-                del self._proactive_sources[proactive_source_count_before:]
-                del self._jobs[job_count_before:]
+                await rollback_load()
                 return
             self._scopes[mp] = scope
             manifest: dict[str, object] = {
@@ -462,6 +472,8 @@ class PluginManager:
             )
             # 3. 注册到 ToolRegistry，标记来源为 plugin
             plugin_name = getattr(instance, "name", None) or module_path
+            if self._tool_registry.has_tool(tool_name):
+                raise RuntimeError(f"插件工具名称重复: {tool_name}")
             tool_names.append(tool_name)
             self._tool_registry.register(
                 ToolCls(),

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -165,7 +165,6 @@ class PluginManager:
         self._job_host = PluginJobHost()
         self._proactive_host = PluginProactiveHost()
         self._snapshot_compiler = RuntimeSnapshotCompiler()
-        self._snapshot_drains: dict[str, tuple[PluginGeneration, ...]] = {}
         self._snapshot_store = RuntimeSnapshotStore(self._on_snapshot_drained)
         self._event_bus.bind_runtime_snapshot_store(self._snapshot_store)
 
@@ -383,6 +382,7 @@ class PluginManager:
         generation: PluginGeneration,
         *,
         state: str,
+        preserve_stable_alias: bool = False,
     ) -> None:
         if generation.initialization_started:
             terminator = getattr(generation.instance, "terminate", None)
@@ -397,13 +397,47 @@ class PluginManager:
                         )
                     )
         self._cleanup_failures.extend(await generation.scope.aclose())
+        _ = self._scopes.pop(generation.module_path, None)
+        self._loaded.discard(generation.module_path)
+        _ = self._active_plugins.pop(generation.module_path, None)
+        for metadata in plugin_registry.get_handlers_by_module_path(
+            generation.module_path
+        ):
+            if metadata.kind == MetadataKind.TOOL and self._tool_registry is not None:
+                self._tool_registry.unregister(
+                    metadata.tool_name or metadata.handler_name
+                )
         self._remove_module_tree(generation.module_path)
+        stable_alias = self._stable_aliases.get(generation.module_path)
+        if stable_alias is not None and not preserve_stable_alias:
+            _ = self._stable_aliases.pop(generation.module_path, None)
+            if plugin_registry.get_instance(stable_alias) is generation.instance:
+                self._remove_module_tree(stable_alias)
+            else:
+                self._fresh_importer.unregister(stable_alias)
         generation.state = state
 
     async def _on_snapshot_drained(self, snapshot: RuntimeSnapshot) -> None:
-        generations = self._snapshot_drains.pop(snapshot.snapshot_id, ())
-        for generation in generations:
-            await self._dispose_generation(generation, state=generation.state)
+        state = "aborted" if snapshot.state == "aborted" else "retired"
+        current = self._snapshot_store.current
+        for generation in snapshot.generations.values():
+            if self._snapshot_store.generation_is_referenced_elsewhere(
+                generation,
+                excluding_snapshot_id=snapshot.snapshot_id,
+            ):
+                continue
+            replacement = (
+                current.generations.get(generation.plugin_id)
+                if current is not None
+                else None
+            )
+            await self._dispose_generation(
+                generation,
+                state=state,
+                preserve_stable_alias=(
+                    replacement is not None and replacement is not generation
+                ),
+            )
 
     async def prepare_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
@@ -497,9 +531,17 @@ class PluginManager:
                     check_id="dashboard",
                     reason=str(error) or type(error).__name__,
                 )
-                await self.discard_prepared(plugin_id)
+                channel_error: BaseException | None = None
                 if channels_switched and self._channel_switcher is not None:
-                    await self._channel_switcher(plugin_id, new_channels, old_channels)
+                    try:
+                        await self._channel_switcher(plugin_id, new_channels, old_channels)
+                    except BaseException as rollback_error:
+                        channel_error = rollback_error
+                await self.discard_prepared(plugin_id)
+                if channel_error is not None:
+                    raise RuntimeError(
+                        "Dashboard Gate 失败后旧 Channel 恢复失败"
+                    ) from channel_error
                 return self._publication_status(
                     plugin_id,
                     active=active,
@@ -518,7 +560,6 @@ class PluginManager:
         except (asyncio.CancelledError, Exception):
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
-            self._snapshot_drains[snapshot.snapshot_id] = (generation,)
             channel_error: BaseException | None = None
             if channels_switched and self._channel_switcher is not None:
                 try:
@@ -536,7 +577,8 @@ class PluginManager:
         generation.state = "active"
         self._active_generations[plugin_id] = generation
         if active is not None:
-            active.state = "retained_compat"
+            active.state = "retired"
+        self._activate_published_generation(generation, active)
         self._channels = [
             channel
             for item in self._active_generations.values()
@@ -553,6 +595,32 @@ class PluginManager:
             json.dumps(result, ensure_ascii=False, sort_keys=True),
         )
         return result
+
+    def _activate_published_generation(
+        self,
+        generation: PluginGeneration,
+        previous: PluginGeneration | None,
+    ) -> None:
+        plugin_dir = Path(generation.instance.context.plugin_dir)
+        self._active_plugins[generation.module_path] = ActivePluginInfo(
+            plugin_id=generation.plugin_id,
+            plugin_dir=plugin_dir,
+            manifest=generation.contributions.manifest,
+            module_path=generation.module_path,
+            skill_roots=generation.contributions.skill_roots,
+            drift_skill_roots=generation.contributions.drift_skill_roots,
+            mcp_servers=generation.contributions.mcp_servers,
+        )
+        if previous is None:
+            return
+        stable_alias = self._stable_aliases.pop(previous.module_path, None)
+        if stable_alias is None:
+            return
+        self._stable_aliases[generation.module_path] = stable_alias
+        self._remove_module_tree(stable_alias)
+        self._fresh_importer.register(stable_alias, plugin_dir)
+        plugin_registry.register_instance(stable_alias, generation.instance)
+        sys.modules[stable_alias] = sys.modules[generation.module_path]
 
     async def _initialize_prepared_generation(
         self,
@@ -1214,6 +1282,7 @@ class PluginManager:
             instance.context.tool_registry = generation.runtime_snapshot.tool_registry
             load_phase = "initialize"
             initialization_started = True
+            generation.initialization_started = True
             await instance.initialize()
             load_phase = "publish"
             self._register_tools(instance, mp, tool_names)

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -349,6 +349,18 @@ class PluginManager:
         generation = self._prepared_generations.pop(plugin_id, None)
         if generation is None:
             return
+        if generation.initialization_started:
+            terminator = getattr(generation.instance, "terminate", None)
+            if callable(terminator):
+                try:
+                    await cast(Callable[[], Awaitable[None]], terminator)()
+                except (asyncio.CancelledError, Exception) as error:
+                    self._cleanup_failures.append(
+                        CleanupFailure(
+                            resource=f"plugin:{plugin_id}:terminate",
+                            error=str(error) or type(error).__name__,
+                        )
+                    )
         self._cleanup_failures.extend(await generation.scope.aclose())
         self._remove_module_tree(generation.module_path)
         generation.state = "discarded"
@@ -356,6 +368,158 @@ class PluginManager:
     async def prepare_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
             return await self._prepare_changed()
+
+    async def reconcile_changed(self) -> list[dict[str, object]]:
+        async with self._candidate_prepare_lock:
+            prepared = await self._prepare_changed()
+            results: list[dict[str, object]] = []
+            published: set[str] = set()
+            for result in prepared:
+                plugin_id = str(result["plugin_id"])
+                if result.get("prepared_generation") is None:
+                    results.append(result)
+                    continue
+                results.append(await self._publish_prepared(plugin_id))
+                published.add(plugin_id)
+            for plugin_id in tuple(self._prepared_generations):
+                if plugin_id not in published:
+                    results.append(await self._publish_prepared(plugin_id))
+            return results
+
+    async def publish_prepared(self, plugin_id: str) -> dict[str, object]:
+        async with self._candidate_prepare_lock:
+            return await self._publish_prepared(plugin_id)
+
+    async def _publish_prepared(self, plugin_id: str) -> dict[str, object]:
+        generation = self._prepared_generations.get(plugin_id)
+        if generation is None:
+            raise KeyError(f"插件没有待发布候选: {plugin_id}")
+        snapshot = generation.runtime_snapshot
+        if snapshot is None:
+            raise RuntimeError(f"插件候选缺少 RuntimeSnapshot: {plugin_id}")
+        active = self._active_generations.get(plugin_id)
+        try:
+            await self._initialize_prepared_generation(generation)
+        except (asyncio.CancelledError, Exception) as error:
+            self._record_failed_gate(
+                plugin_id=plugin_id,
+                revision=generation.source_revision,
+                check_id="initialize",
+                reason=str(error) or type(error).__name__,
+            )
+            await self.discard_prepared(plugin_id)
+            if isinstance(error, asyncio.CancelledError):
+                raise
+            result = self._publication_status(
+                plugin_id,
+                active=active,
+                candidate=generation,
+                publication_state="failed",
+            )
+            logger.info(
+                "plugin_snapshot_status %s",
+                json.dumps(result, ensure_ascii=False, sort_keys=True),
+            )
+            return result
+
+        transaction = self._snapshot_store.begin_publish(snapshot)
+        try:
+            self._validate_published_snapshot(generation, snapshot)
+            await self._snapshot_store.commit(transaction)
+        except (asyncio.CancelledError, Exception):
+            await self._snapshot_store.abort(transaction)
+            await self.discard_prepared(plugin_id)
+            raise
+
+        _ = self._prepared_generations.pop(plugin_id)
+        self._scopes[generation.module_path] = generation.scope
+        self._loaded.add(generation.module_path)
+        generation.state = "active"
+        self._active_generations[plugin_id] = generation
+        if active is not None:
+            active.state = "retained_compat"
+        result = self._publication_status(
+            plugin_id,
+            active=active,
+            candidate=generation,
+            publication_state="committed",
+        )
+        logger.info(
+            "plugin_snapshot_status %s",
+            json.dumps(result, ensure_ascii=False, sort_keys=True),
+        )
+        return result
+
+    async def _initialize_prepared_generation(
+        self,
+        generation: PluginGeneration,
+    ) -> None:
+        if generation.initialization_started:
+            return
+        from agent.plugins.context import PluginKVStore
+
+        instance = cast(Any, generation.instance)
+        context = instance.context
+        staged_event_bus = ScopedEventBus(
+            self._event_bus,
+            generation.scope,
+            staged=True,
+        )
+        generation.staged_event_bus = staged_event_bus
+        context.event_bus = staged_event_bus
+        context.kv_store = PluginKVStore(context.data_dir / ".kv.json")
+        context.session_manager = self._session_manager
+        context.memory_engine = self._memory_engine
+        context.llm = self._llm
+        context.scope = generation.scope
+        context.tool_registry = self._tool_registry
+        generation.initialization_started = True
+        await instance.initialize()
+
+    def _validate_published_snapshot(
+        self,
+        generation: PluginGeneration,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
+        if self.current_snapshot is not snapshot:
+            raise RuntimeError("RuntimeSnapshot 发布指针不一致")
+        if snapshot.generations.get(generation.plugin_id) is not generation:
+            raise RuntimeError("RuntimeSnapshot generation 不一致")
+        catalog_id = snapshot.skill_catalog_generation_id
+        if catalog_id is not None and self._skill_host.get(catalog_id) is None:
+            raise RuntimeError("RuntimeSnapshot skill catalog 不可用")
+        for generation_id in snapshot.mcp_catalog_generation_ids.values():
+            if self._mcp_host.get(generation_id) is None:
+                raise RuntimeError("RuntimeSnapshot MCP catalog 不可用")
+        for item in snapshot.generations.values():
+            if item.job_catalog is not None and self._job_host.get(
+                item.generation_id
+            ) is not item.job_catalog:
+                raise RuntimeError("RuntimeSnapshot Job catalog 不可用")
+            if item.proactive_catalog is not None and self._proactive_host.get(
+                item.generation_id
+            ) is not item.proactive_catalog:
+                raise RuntimeError("RuntimeSnapshot proactive catalog 不可用")
+
+    def _publication_status(
+        self,
+        plugin_id: str,
+        *,
+        active: PluginGeneration | None,
+        candidate: PluginGeneration,
+        publication_state: str,
+    ) -> dict[str, object]:
+        return {
+            "plugin_id": plugin_id,
+            "old_generation": active.generation_id if active is not None else None,
+            "new_generation": candidate.generation_id,
+            "snapshot_id": (
+                self.current_snapshot.snapshot_id
+                if self.current_snapshot is not None
+                else None
+            ),
+            "publication_state": publication_state,
+        }
 
     async def _prepare_changed(self) -> list[dict[str, object]]:
         results: list[dict[str, object]] = []
@@ -1473,8 +1637,9 @@ class PluginManager:
                 else:
                     self._fresh_importer.unregister(stable_alias)
             if active_info is not None:
-                generation = self._active_generations.pop(active_info.plugin_id, None)
-                if generation is not None:
+                generation = self._active_generations.get(active_info.plugin_id)
+                if generation is not None and generation.module_path == mp:
+                    _ = self._active_generations.pop(active_info.plugin_id)
                     generation.state = "retired"
             _ = self._active_plugins.pop(mp, None)
         self._loaded.clear()

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -396,7 +396,16 @@ class PluginManager:
                 if hasattr(instance, "initialize"):
                     await instance.initialize()
             except asyncio.CancelledError:
-                await asyncio.shield(rollback_load())
+                rollback_task = asyncio.create_task(
+                    rollback_load(),
+                    name=f"plugin_rollback:{plugin_id}",
+                )
+                while not rollback_task.done():
+                    try:
+                        await asyncio.shield(rollback_task)
+                    except asyncio.CancelledError:
+                        continue
+                await rollback_task
                 raise
             except Exception as e:
                 logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -120,7 +120,6 @@ class PluginManager:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
         self._tool_registry = tool_registry
-        self._base_tool_registry: Any = None
         self._workspace = workspace
         self._session_manager = session_manager
         self._memory_engine = memory_engine
@@ -339,12 +338,10 @@ class PluginManager:
         return mods
 
     async def load_all(self) -> None:
-        self._ensure_base_tool_registry()
         for mod in self.discover():
             _ = await self._load_one(mod)
 
     async def prepare_candidate(self, plugin_id: str) -> PluginGeneration | None:
-        self._ensure_base_tool_registry()
         await self.discard_prepared(plugin_id)
         for mod in self.discover():
             if _resolve_plugin_id(mod) == plugin_id:
@@ -1188,17 +1185,21 @@ class PluginManager:
             self._gate_results[generation.plugin_id] = gate
             raise _CandidateRejected(gate) from error
 
-    def _ensure_base_tool_registry(self) -> None:
-        if self._base_tool_registry is None and self._tool_registry is not None:
-            self._base_tool_registry = self._tool_registry.fork()
-
     def _compile_snapshot_tools(
         self,
         generations: dict[str, PluginGeneration],
     ) -> Any:
-        if self._base_tool_registry is None:
+        if self._tool_registry is None:
             return None
-        registry = self._base_tool_registry.fork()
+        plugin_mcp_sources = {
+            ("mcp", server_name)
+            for generation in generations.values()
+            for server_name in generation.contributions.mcp_servers
+        }
+        registry = self._tool_registry.fork(
+            excluded_source_types={"plugin"},
+            excluded_sources=plugin_mcp_sources,
+        )
         for generation in sorted(generations.values(), key=lambda item: item.plugin_id):
             plugin_name = getattr(
                 generation.instance,

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -642,6 +642,7 @@ class PluginManager:
         generation.state = "active"
         self._active_generations[plugin_id] = generation
         self._stable_aliases[mp] = stable_module_path
+        self._fresh_importer.register(stable_module_path, plugin_dir)
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]
         logger.info("插件已加载: %s", mod["name"])

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -894,7 +894,6 @@ class PluginManager:
             load_phase = "initialize"
             initialization_started = True
             await instance.initialize()
-            generation.runtime_snapshot = self._compile_generation_snapshot(generation)
             load_phase = "publish"
             self._register_tools(instance, mp, tool_names)
             self._bind_tool_hooks(instance, mp)

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1168,10 +1168,7 @@ class PluginManager:
                     ),
                 }
                 results.append(result)
-                logger.info(
-                    "plugin_candidate_status %s",
-                    json.dumps(result, ensure_ascii=False, sort_keys=True),
-                )
+                _log_candidate_status(result)
                 continue
             if (
                 current_prepared is not None
@@ -1241,10 +1238,7 @@ class PluginManager:
                 ),
             }
             results.append(result)
-            logger.info(
-                "plugin_candidate_status %s",
-                json.dumps(result, ensure_ascii=False, sort_keys=True),
-            )
+            _log_candidate_status(result)
         return results
 
     async def _load_one(
@@ -2853,6 +2847,27 @@ def _skill_body_hashes(
 def _mcp_tool_names(generation: PluginGeneration) -> list[str]:
     catalog = generation.mcp_catalog
     return list(catalog.tool_names) if catalog is not None else []
+
+
+def _log_candidate_status(result: dict[str, object]) -> None:
+    logger.info(
+        "plugin_candidate_status plugin=%s gate=%s active=%s prepared=%s "
+        "revision=%s counts=skills:%d,drift_skills:%d,mcp:%d,jobs:%d,sources:%d",
+        result["plugin_id"],
+        result["gate_status"],
+        result["active_generation"],
+        result["prepared_generation"] or "-",
+        str(result["candidate_revision"])[:12],
+        len(cast(list[object], result["skills"])),
+        len(cast(dict[object, object], result["drift_skill_descriptions"])),
+        len(cast(list[object], result["mcp_tools"])),
+        len(cast(list[object], result["jobs"])),
+        len(cast(list[object], result["proactive_sources"])),
+    )
+    logger.debug(
+        "plugin_candidate_status_detail %s",
+        json.dumps(result, ensure_ascii=False, sort_keys=True),
+    )
 
 
 def _job_keys(generation: PluginGeneration) -> list[str]:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -128,6 +128,10 @@ class PluginManager:
         self._llm = llm
         self._installed_cache_root = installed_cache_root
         self._user_mcp_server_names = user_mcp_server_names or set
+        self._channel_switcher: Callable[
+            [str, tuple[Channel, ...], tuple[Channel, ...]],
+            Awaitable[None],
+        ] | None = None
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -261,6 +265,15 @@ class PluginManager:
 
     def mcp_catalog(self, generation_id: str) -> PreparedMcpCatalog | None:
         return self._mcp_host.get(generation_id)
+
+    def bind_channel_switcher(
+        self,
+        switcher: Callable[
+            [str, tuple[Channel, ...], tuple[Channel, ...]],
+            Awaitable[None],
+        ],
+    ) -> None:
+        self._channel_switcher = switcher
 
     def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
         return self._job_host.get(generation_id)
@@ -442,6 +455,30 @@ class PluginManager:
             )
             return result
 
+        old_channels = active.contributions.channels if active is not None else ()
+        new_channels = generation.contributions.channels
+        channels_switched = False
+        if self._channel_switcher is not None and old_channels != new_channels:
+            try:
+                await self._channel_switcher(plugin_id, old_channels, new_channels)
+                channels_switched = True
+            except (asyncio.CancelledError, Exception) as error:
+                self._record_failed_gate(
+                    plugin_id=plugin_id,
+                    revision=generation.source_revision,
+                    check_id="channels",
+                    reason=str(error) or type(error).__name__,
+                )
+                await self.discard_prepared(plugin_id)
+                if isinstance(error, asyncio.CancelledError):
+                    raise
+                return self._publication_status(
+                    plugin_id,
+                    active=active,
+                    candidate=generation,
+                    publication_state="failed",
+                )
+
         self._compile_snapshot_event_handlers(snapshot)
         if generation.staged_event_bus is not None:
             generation.staged_event_bus.publish()
@@ -457,6 +494,8 @@ class PluginManager:
             generation.state = "aborted"
             self._snapshot_drains[snapshot.snapshot_id] = (generation,)
             await self._snapshot_store.abort(transaction)
+            if channels_switched and self._channel_switcher is not None:
+                await self._channel_switcher(plugin_id, new_channels, old_channels)
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
@@ -2091,6 +2130,7 @@ class _PluginToolHook(ToolHook):
     """将插件的 @on_tool_pre handler 适配为 ToolExecutor 的 ToolHook 接口。"""
 
     event = "pre_tool_use"
+    snapshot_managed = True
 
     def __init__(
         self,

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -117,6 +117,7 @@ class PluginManager:
         memory_engine: Any = None,
         llm: PluginLlmService | None = None,
         installed_cache_root: Path | None = None,
+        user_mcp_server_names: Callable[[], set[str]] | None = None,
     ) -> None:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
@@ -126,6 +127,7 @@ class PluginManager:
         self._memory_engine = memory_engine
         self._llm = llm
         self._installed_cache_root = installed_cache_root
+        self._user_mcp_server_names = user_mcp_server_names or set
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -1455,12 +1457,7 @@ class PluginManager:
             for generation in other_generations
             for server_name in generation.contributions.mcp_servers
         }
-        if self._tool_registry is not None:
-            occupied_servers.update(
-                document.source_name
-                for document in self._tool_registry.get_documents()
-                if document.source_type == "mcp"
-            )
+        occupied_servers.update(self._user_mcp_server_names())
         check(
             "mcp_servers",
             not occupied_servers.intersection(contributions.mcp_servers),

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -120,6 +120,7 @@ class PluginManager:
         self._dirs = plugin_dirs
         self._event_bus = event_bus
         self._tool_registry = tool_registry
+        self._plugin_mcp_server_names: set[str] = set()
         self._workspace = workspace
         self._session_manager = session_manager
         self._memory_engine = memory_engine
@@ -903,6 +904,7 @@ class PluginManager:
                 gate_result=gate_result,
                 state="prepared" if not activate else "activating",
             )
+            self._plugin_mcp_server_names.update(contributions.mcp_servers)
             catalog_generations = [
                 active_generation
                 for active_generation in self._active_generations.values()
@@ -1193,8 +1195,7 @@ class PluginManager:
             return None
         plugin_mcp_sources = {
             ("mcp", server_name)
-            for generation in generations.values()
-            for server_name in generation.contributions.mcp_servers
+            for server_name in self._plugin_mcp_server_names
         }
         registry = self._tool_registry.fork(
             excluded_source_types={"plugin"},

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -62,6 +62,11 @@ from agent.plugins.activity_host import (
     PreparedJobCatalog,
     PreparedProactiveCatalog,
 )
+from agent.plugins.snapshot import (
+    RuntimeSnapshot,
+    RuntimeSnapshotCompiler,
+    RuntimeSnapshotStore,
+)
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
@@ -149,6 +154,8 @@ class PluginManager:
         self._mcp_host = PluginMcpHost()
         self._job_host = PluginJobHost()
         self._proactive_host = PluginProactiveHost()
+        self._snapshot_compiler = RuntimeSnapshotCompiler()
+        self._snapshot_store = RuntimeSnapshotStore()
 
     @property
     def loaded_count(self) -> int:
@@ -256,6 +263,14 @@ class PluginManager:
         generation_id: str,
     ) -> PreparedProactiveCatalog | None:
         return self._proactive_host.get(generation_id)
+
+    @property
+    def current_snapshot(self) -> RuntimeSnapshot | None:
+        return self._snapshot_store.current
+
+    @property
+    def snapshot_store(self) -> RuntimeSnapshotStore:
+        return self._snapshot_store
 
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
@@ -402,6 +417,11 @@ class PluginManager:
                     "proactive_sources": _proactive_source_keys(active),
                     "job_specs": _job_spec_evidence(active),
                     "proactive_source_specs": _proactive_source_spec_evidence(active),
+                    "snapshot_id": (
+                        self.current_snapshot.snapshot_id
+                        if self.current_snapshot is not None
+                        else None
+                    ),
                 }
                 results.append(result)
                 logger.info(
@@ -469,6 +489,11 @@ class PluginManager:
                     _proactive_source_spec_evidence(prepared)
                     if prepared is not None
                     else {}
+                ),
+                "snapshot_id": (
+                    self.current_snapshot.snapshot_id
+                    if self.current_snapshot is not None
+                    else None
                 ),
             }
             results.append(result)
@@ -921,8 +946,23 @@ class PluginManager:
         self._fresh_importer.register(stable_module_path, plugin_dir)
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]
+        await self._refresh_committed_snapshot(generation)
         logger.info("插件已加载: %s", mod["name"])
         return generation
+
+    async def _refresh_committed_snapshot(
+        self,
+        catalog_generation: PluginGeneration,
+    ) -> None:
+        snapshot = self._snapshot_compiler.compile(
+            self._active_generations,
+            catalog_generation=catalog_generation,
+        )
+        if self._snapshot_store.current is None:
+            self._snapshot_store.install(snapshot)
+            return
+        transaction = self._snapshot_store.begin_publish(snapshot)
+        await self._snapshot_store.commit(transaction)
 
     def _collect_candidate_contributions(
         self,
@@ -1372,6 +1412,7 @@ class PluginManager:
             logger.info("插件 tool hook 已注册: %s", hook.name)
 
     async def terminate_all(self) -> None:
+        await self._snapshot_store.close()
         for plugin_id in tuple(self._prepared_generations):
             await self.discard_prepared(plugin_id)
         for mp in list(self._loaded):

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -9,7 +9,7 @@ import sys
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from pydantic import BaseModel, ValidationError
@@ -35,7 +35,7 @@ from agent.lifecycle.types import (
 from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registry
 from agent.plugins.source_resolver import resolve_plugin_sources
 from agent.plugins.jobs import PluginJobSpec, PluginLlmService, RegisteredPluginJob
-from agent.plugins.scope import PluginScope, ScopedEventBus
+from agent.plugins.scope import CleanupFailure, PluginScope, ScopedEventBus
 from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import HookContext, HookOutcome
 from bus.event_bus import EventBus
@@ -107,6 +107,7 @@ class PluginManager:
         self._jobs: list[RegisteredPluginJob] = []
         self._active_plugins: dict[str, ActivePluginInfo] = {}
         self._scopes: dict[str, PluginScope] = {}
+        self._cleanup_failures: list[CleanupFailure] = []
 
     @property
     def loaded_count(self) -> int:
@@ -186,6 +187,10 @@ class PluginManager:
             for module_path, plugin in self._active_plugins.items()
             if self._registry_active(module_path)
         ]
+
+    @property
+    def cleanup_failures(self) -> list[CleanupFailure]:
+        return list(self._cleanup_failures)
 
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
@@ -333,7 +338,7 @@ class PluginManager:
             plugin_registry.register_instance(mp, instance)
             try:
                 self._bind_handlers(instance, mp, scope)
-                tool_names = self._register_tools(instance, mp)
+                self._register_tools(instance, mp, tool_names)
                 self._bind_tool_hooks(instance, mp)
                 self._collect_before_turn_modules(instance)
                 self._collect_before_reasoning_modules(instance)
@@ -352,7 +357,22 @@ class PluginManager:
                     await instance.initialize()
             except Exception as e:
                 logger.warning("插件 %s 加载失败，回滚: %s", mod["name"], e)
-                _ = await scope.aclose()
+                terminator = getattr(instance, "terminate", None)
+                if callable(terminator):
+                    try:
+                        typed_terminator = cast(
+                            Callable[[], Awaitable[None]],
+                            terminator,
+                        )
+                        await typed_terminator()
+                    except Exception as terminate_error:
+                        self._cleanup_failures.append(
+                            CleanupFailure(
+                                resource=f"plugin:{plugin_id}:terminate",
+                                error=str(terminate_error),
+                            )
+                        )
+                self._cleanup_failures.extend(await scope.aclose())
                 plugin_registry.remove_plugin(mp)
                 for tn in tool_names:
                     if self._tool_registry is not None:
@@ -412,10 +432,14 @@ class PluginManager:
         sys.modules[module_name] = module
         spec.loader.exec_module(module)  # type: ignore[union-attr]
 
-    def _register_tools(self, instance: Any, module_path: str) -> list[str]:
-        tool_names: list[str] = []
+    def _register_tools(
+        self,
+        instance: Any,
+        module_path: str,
+        tool_names: list[str],
+    ) -> None:
         if self._tool_registry is None:
-            return tool_names
+            return
         from agent.tools.base import Tool as AgentTool
         for md in plugin_registry.get_handlers_by_module_path(module_path):
             # 1. 只处理 TOOL 类型元数据
@@ -438,6 +462,7 @@ class PluginManager:
             )
             # 3. 注册到 ToolRegistry，标记来源为 plugin
             plugin_name = getattr(instance, "name", None) or module_path
+            tool_names.append(tool_name)
             self._tool_registry.register(
                 ToolCls(),
                 risk=md.tool_risk or "read-write",
@@ -446,9 +471,7 @@ class PluginManager:
                 source_type="plugin",
                 source_name=plugin_name,
             )
-            tool_names.append(tool_name)
             logger.info("插件工具已注册: %s (来自 %s)", tool_name, plugin_name)
-        return tool_names
 
     def _bind_handlers(
         self,
@@ -606,14 +629,25 @@ class PluginManager:
     async def terminate_all(self) -> None:
         for mp in list(self._loaded):
             instance = plugin_registry.get_instance(mp)
-            if instance is not None and hasattr(instance, "terminate"):
+            terminator = getattr(instance, "terminate", None)
+            if callable(terminator):
                 try:
-                    await instance.terminate()
+                    typed_terminator = cast(
+                        Callable[[], Awaitable[None]],
+                        terminator,
+                    )
+                    await typed_terminator()
                 except Exception as e:
                     logger.warning("插件 terminate 失败 (%s): %s", mp, e)
+                    self._cleanup_failures.append(
+                        CleanupFailure(
+                            resource=f"plugin:{mp}:terminate",
+                            error=str(e),
+                        )
+                    )
             scope = self._scopes.pop(mp, None)
             if scope is not None:
-                _ = await scope.aclose()
+                self._cleanup_failures.extend(await scope.aclose())
             # 注销工具
             for md in plugin_registry.get_handlers_by_module_path(mp):
                 if md.kind == MetadataKind.TOOL and self._tool_registry is not None:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -49,6 +49,7 @@ from agent.plugins.generation import (
 )
 from agent.plugins.importer import FreshPluginImporter
 from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
+from agent.plugins.mcp_host import PluginMcpHost, PreparedMcpCatalog
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
 from proactive_v2.lifecycle import ProactiveLifecycleBuilder
@@ -133,6 +134,7 @@ class PluginManager:
         self._fresh_importer = FreshPluginImporter()
         self._manager_namespace = secrets.token_hex(4)
         self._skill_host = PluginSkillHost(workspace)
+        self._mcp_host = PluginMcpHost()
 
     @property
     def loaded_count(self) -> int:
@@ -228,6 +230,9 @@ class PluginManager:
 
     def skill_catalog(self, generation_id: str) -> PreparedSkillCatalog | None:
         return self._skill_host.get(generation_id)
+
+    def mcp_catalog(self, generation_id: str) -> PreparedMcpCatalog | None:
+        return self._mcp_host.get(generation_id)
 
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
@@ -365,6 +370,7 @@ class PluginManager:
                         active,
                         drift=True,
                     ),
+                    "mcp_tools": _mcp_tool_names(active),
                 }
                 results.append(result)
                 logger.info(
@@ -413,6 +419,7 @@ class PluginManager:
                     if prepared is not None
                     else {}
                 ),
+                "mcp_tools": _mcp_tool_names(prepared) if prepared is not None else [],
             }
             results.append(result)
             logger.info(
@@ -669,6 +676,65 @@ class PluginManager:
                 lambda: self._skill_host.close(generation_id),
             )
             if not activate:
+                try:
+                    mcp_catalog = await self._mcp_host.prepare(
+                        generation_id,
+                        server_specs=contributions.mcp_servers,
+                        proactive_sources=contributions.proactive_sources,
+                    )
+                except Exception as error:
+                    gate_result = _with_gate_check(
+                        gate_result,
+                        check_id="mcp_readiness",
+                        passed=False,
+                        evidence=str(error),
+                        gate_id="G1/G2/G3-readiness",
+                    )
+                    self._gate_results[plugin_id] = gate_result
+                    raise _CandidateRejected(gate_result) from error
+                generation.mcp_catalog = mcp_catalog
+                scope.defer(
+                    "mcp_catalog",
+                    lambda: self._mcp_host.close(generation_id),
+                )
+                try:
+                    raw_readiness_checks: object = instance.readiness_semantic_checks()
+                    if not isinstance(raw_readiness_checks, list):
+                        raise RuntimeError(
+                            "readiness_semantic_checks 返回值不是 list"
+                        )
+                    readiness_checks = cast(list[object], raw_readiness_checks)
+                except Exception as error:
+                    readiness_passed = False
+                    readiness_evidence: object = str(error)
+                else:
+                    invalid_readiness = [
+                        check
+                        for check in readiness_checks
+                        if not isinstance(check, PluginSemanticCheck) or not check.passed
+                    ]
+                    readiness_passed = not invalid_readiness
+                    readiness_evidence = [
+                        getattr(check, "evidence", repr(check))
+                        for check in invalid_readiness
+                    ]
+                gate_result = _with_gate_check(
+                    gate_result,
+                    check_id="mcp_readiness",
+                    passed=True,
+                    evidence=list(mcp_catalog.tool_names),
+                    gate_id="G1/G2/G3-readiness",
+                )
+                gate_result = _with_gate_check(
+                    gate_result,
+                    check_id="readiness_semantic_checks",
+                    passed=readiness_passed,
+                    evidence=readiness_evidence,
+                )
+                self._gate_results[plugin_id] = gate_result
+                generation.gate_result = gate_result
+                if gate_result.status == "failed":
+                    raise _CandidateRejected(gate_result)
                 self._prepared_generations[plugin_id] = generation
                 return generation
             staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
@@ -1268,6 +1334,7 @@ def _with_gate_check(
     check_id: str,
     passed: bool,
     evidence: object,
+    gate_id: str | None = None,
 ) -> GateResult:
     check = GateCheckResult(
         check_id=check_id,
@@ -1277,7 +1344,7 @@ def _with_gate_check(
     checks = (*gate.checks, check)
     failed = [item.check_id for item in checks if item.status == "failed"]
     return GateResult(
-        gate_id=gate.gate_id,
+        gate_id=gate_id or gate.gate_id,
         plugin_id=gate.plugin_id,
         candidate_revision=gate.candidate_revision,
         status="failed" if failed else "passed",
@@ -1643,6 +1710,11 @@ def _skill_body_hashes(
         name: hashlib.sha256(record.content.encode()).hexdigest()
         for name, record in sorted(records.items())
     }
+
+
+def _mcp_tool_names(generation: PluginGeneration) -> list[str]:
+    catalog = generation.mcp_catalog
+    return list(catalog.tool_names) if catalog is not None else []
 
 
 def _is_plugin_disabled(plugin_dir: Path) -> bool:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -45,6 +45,7 @@ from agent.plugins.generation import (
     GateResult,
     PluginContributions,
     PluginGeneration,
+    PluginReadinessContext,
     PluginSemanticCheck,
 )
 from agent.plugins.importer import FreshPluginImporter
@@ -371,6 +372,10 @@ class PluginManager:
                         drift=True,
                     ),
                     "mcp_tools": _mcp_tool_names(active),
+                    "readiness_checks": _gate_check_evidence(
+                        active,
+                        "readiness_semantic_checks",
+                    ),
                 }
                 results.append(result)
                 logger.info(
@@ -420,6 +425,11 @@ class PluginManager:
                     else {}
                 ),
                 "mcp_tools": _mcp_tool_names(prepared) if prepared is not None else [],
+                "readiness_checks": (
+                    _gate_check_evidence(prepared, "readiness_semantic_checks")
+                    if prepared is not None
+                    else []
+                ),
             }
             results.append(result)
             logger.info(
@@ -681,6 +691,7 @@ class PluginManager:
                         generation_id,
                         server_specs=contributions.mcp_servers,
                         proactive_sources=contributions.proactive_sources,
+                        scope=scope,
                     )
                 except Exception as error:
                     gate_result = _with_gate_check(
@@ -698,7 +709,12 @@ class PluginManager:
                     lambda: self._mcp_host.close(generation_id),
                 )
                 try:
-                    raw_readiness_checks: object = instance.readiness_semantic_checks()
+                    raw_readiness_checks: object = await instance.readiness_semantic_checks(
+                        PluginReadinessContext(
+                            generation_id=generation_id,
+                            mcp_catalog=mcp_catalog,
+                        )
+                    )
                     if not isinstance(raw_readiness_checks, list):
                         raise RuntimeError(
                             "readiness_semantic_checks 返回值不是 list"
@@ -714,10 +730,25 @@ class PluginManager:
                         if not isinstance(check, PluginSemanticCheck) or not check.passed
                     ]
                     readiness_passed = not invalid_readiness
-                    readiness_evidence = [
-                        getattr(check, "evidence", repr(check))
-                        for check in invalid_readiness
-                    ]
+                    normalized_readiness: list[dict[str, object]] = []
+                    for check in readiness_checks:
+                        if isinstance(check, PluginSemanticCheck):
+                            normalized_readiness.append(
+                                {
+                                    "check_id": check.check_id,
+                                    "passed": check.passed,
+                                    "evidence": check.evidence,
+                                }
+                            )
+                        else:
+                            normalized_readiness.append(
+                                {
+                                    "check_id": "invalid",
+                                    "passed": False,
+                                    "evidence": repr(check),
+                                }
+                            )
+                    readiness_evidence = normalized_readiness
                 gate_result = _with_gate_check(
                     gate_result,
                     check_id="mcp_readiness",
@@ -1715,6 +1746,16 @@ def _skill_body_hashes(
 def _mcp_tool_names(generation: PluginGeneration) -> list[str]:
     catalog = generation.mcp_catalog
     return list(catalog.tool_names) if catalog is not None else []
+
+
+def _gate_check_evidence(
+    generation: PluginGeneration,
+    check_id: str,
+) -> object:
+    for check in reversed(generation.gate_result.checks):
+        if check.check_id == check_id:
+            return check.evidence
+    return []
 
 
 def _is_plugin_disabled(plugin_dir: Path) -> bool:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -5,6 +5,7 @@ import functools
 import hashlib
 import importlib.util
 import inspect
+import json
 import logging
 import os
 import sys
@@ -47,6 +48,7 @@ from agent.plugins.generation import (
 )
 from agent.lifecycle.phase import topo_sort_modules
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
+from proactive_v2.lifecycle import ProactiveLifecycleBuilder
 from agent.tool_hooks.base import ToolHook
 from agent.tool_hooks.types import HookContext, HookOutcome
 from bus.event_bus import EventBus
@@ -124,6 +126,7 @@ class PluginManager:
         self._gate_results: dict[str, GateResult] = {}
         self._stable_aliases: dict[str, str] = {}
         self._generation_sequence = 0
+        self._candidate_prepare_lock = asyncio.Lock()
 
     @property
     def loaded_count(self) -> int:
@@ -296,6 +299,65 @@ class PluginManager:
             return
         self._cleanup_failures.extend(await generation.scope.aclose())
         self._remove_module_tree(generation.module_path)
+        generation.state = "discarded"
+
+    async def prepare_changed(self) -> list[dict[str, object]]:
+        async with self._candidate_prepare_lock:
+            return await self._prepare_changed()
+
+    async def _prepare_changed(self) -> list[dict[str, object]]:
+        results: list[dict[str, object]] = []
+        discovered = {
+            _resolve_plugin_id(mod): mod
+            for mod in self.discover()
+        }
+        for plugin_id, active in tuple(self._active_generations.items()):
+            mod = discovered.get(plugin_id)
+            if mod is None:
+                continue
+            plugin_dir = Path(mod["plugin_root"])
+            try:
+                source_revision = _source_revision(plugin_dir)
+                config_revision = _file_revision(
+                    _resolve_plugin_data_dir(
+                        mod["name"],
+                        mod,
+                        self._installed_cache_root,
+                    )
+                    / "config.local.toml"
+                )
+            except Exception:
+                source_revision = ""
+                config_revision = ""
+            current_prepared = self._prepared_generations.get(plugin_id)
+            if (
+                source_revision == active.source_revision
+                and config_revision == active.config_revision
+            ) or (
+                current_prepared is not None
+                and source_revision == current_prepared.source_revision
+                and config_revision == current_prepared.config_revision
+            ):
+                continue
+            prepared = await self.prepare_candidate(plugin_id)
+            gate = self.latest_gate(plugin_id)
+            result: dict[str, object] = {
+                "plugin_id": plugin_id,
+                "active_generation": active.generation_id,
+                "prepared_generation": (
+                    prepared.generation_id if prepared is not None else None
+                ),
+                "gate_status": gate.status if gate is not None else "failed",
+                "candidate_revision": (
+                    gate.candidate_revision if gate is not None else ""
+                ),
+            }
+            results.append(result)
+            logger.info(
+                "plugin_candidate_status %s",
+                json.dumps(result, ensure_ascii=False, sort_keys=True),
+            )
+        return results
 
     async def _load_one(
         self,
@@ -334,7 +396,19 @@ class PluginManager:
         module_path = mod["module_path"].strip()
         if not module_path:
             raise RuntimeError(f"插件缺少 plugin.py: {plugin_dir}")
-        source_revision = _source_revision(plugin_dir)
+        try:
+            source_revision = _source_revision(plugin_dir)
+        except Exception as error:
+            revision = hashlib.sha256(
+                f"{plugin_dir}:{error}".encode()
+            ).hexdigest()
+            self._record_failed_gate(
+                plugin_id=initial_plugin_id,
+                revision=revision,
+                check_id="source_boundary",
+                reason=str(error),
+            )
+            return None
         data_dir = _resolve_plugin_data_dir(
             mod["name"],
             mod,
@@ -406,7 +480,7 @@ class PluginManager:
             config=plugin_config,
             workspace=self._workspace,
             session_manager=None,
-            memory_engine=self._memory_engine,
+            memory_engine=None,
             llm=None,
             scope=None,
             generation_id=generation_id,
@@ -488,6 +562,7 @@ class PluginManager:
             instance.context.event_bus = staged_event_bus
             instance.context.kv_store = PluginKVStore(data_dir / ".kv.json")
             instance.context.session_manager = self._session_manager
+            instance.context.memory_engine = self._memory_engine
             instance.context.llm = self._llm
             instance.context.scope = scope
             load_phase = "initialize"
@@ -804,6 +879,34 @@ class PluginManager:
                 ),
             },
         )
+        lifecycle_structure_errors: list[str] = []
+        for lifecycle in contributions.proactive_lifecycles:
+            if not isinstance(lifecycle, ProactiveLifecycleSpec):
+                continue
+            if (
+                not lifecycle.id
+                or any(not value for value in lifecycle.initial_slots)
+                or any(not value for value in lifecycle.terminal_slots)
+                or len(set(lifecycle.initial_slots)) != len(lifecycle.initial_slots)
+                or len(set(lifecycle.terminal_slots)) != len(lifecycle.terminal_slots)
+            ):
+                lifecycle_structure_errors.append(f"{lifecycle.id}: slots")
+                continue
+            try:
+                _ = ProactiveLifecycleBuilder().build(
+                    ProactiveLifecycleSpec(
+                        id=lifecycle.id,
+                        modules=lifecycle.modules,
+                        initial_slots=lifecycle.initial_slots,
+                    )
+                )
+            except RuntimeError as error:
+                lifecycle_structure_errors.append(f"{lifecycle.id}: {error}")
+        check(
+            "proactive_lifecycle_structure",
+            not lifecycle_structure_errors,
+            lifecycle_structure_errors,
+        )
         try:
             semantic_checks = instance.static_semantic_checks()
         except Exception as error:
@@ -1004,10 +1107,11 @@ class PluginManager:
             self._remove_module_tree(mp)
             stable_alias = self._stable_aliases.pop(mp, None)
             if stable_alias is not None:
-                plugin_registry.remove_plugin(stable_alias)
-                _ = sys.modules.pop(stable_alias, None)
+                self._remove_module_tree(stable_alias)
             if active_info is not None:
-                _ = self._active_generations.pop(active_info.plugin_id, None)
+                generation = self._active_generations.pop(active_info.plugin_id, None)
+                if generation is not None:
+                    generation.state = "retired"
             _ = self._active_plugins.pop(mp, None)
         self._loaded.clear()
         self._active_plugins.clear()
@@ -1112,9 +1216,7 @@ def _resolve_plugin_data_dir(
 ) -> Path:
     marketplace = mod.get("marketplace", "").strip()
     suffix = marketplace or "builtin"
-    data_dir = _plugins_home(installed_cache_root) / "data" / f"{name}-{suffix}"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    return data_dir
+    return _plugins_home(installed_cache_root) / "data" / f"{name}-{suffix}"
 
 
 def _plugins_home(installed_cache_root: Path | None) -> Path:
@@ -1342,8 +1444,12 @@ def _source_revision(plugin_dir: Path) -> str:
         if any(part in excluded for part in relative.parts):
             continue
         if path.is_symlink():
+            resolved = path.resolve(strict=False)
+            _require_plugin_path(root, resolved, "源码符号链接")
             digest.update(str(relative).encode())
             digest.update(os.readlink(path).encode())
+            if resolved.is_file():
+                digest.update(resolved.read_bytes())
             continue
         if not path.is_file():
             continue

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -561,6 +561,21 @@ class PluginManager:
                 results.append(await self._publish_prepared(plugin_id))
             return results
 
+    async def reconcile_disabled_and_drain(self, plugin_id: str) -> None:
+        async with self._candidate_prepare_lock:
+            manifest = load_plugin_manifest(
+                _plugins_home(self._installed_cache_root)
+            )
+            if manifest.get(plugin_id, False):
+                raise RuntimeError(f"插件尚未禁用: {plugin_id}")
+            active = self._active_generations.get(plugin_id)
+            if active is None:
+                return
+            await self._deactivate_plugin(plugin_id)
+            await self._snapshot_store.wait_for_generation_drained(active)
+            if not active.scope.closed:
+                raise RuntimeError(f"插件旧代资源尚未关闭: {plugin_id}")
+
     async def _deactivate_plugin(self, plugin_id: str) -> dict[str, object]:
         active = self._active_generations[plugin_id]
         generations = {

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -371,19 +371,19 @@ class PluginManager:
 
     async def reconcile_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
-            prepared = await self._prepare_changed()
             results: list[dict[str, object]] = []
-            published: set[str] = set()
-            for result in prepared:
-                plugin_id = str(result["plugin_id"])
+            for plugin_id in sorted(tuple(self._active_generations)):
+                prepared = await self._prepare_changed(
+                    plugin_ids={plugin_id},
+                    force_reprepare=True,
+                )
+                if not prepared:
+                    continue
+                result = prepared[0]
                 if result.get("prepared_generation") is None:
                     results.append(result)
                     continue
                 results.append(await self._publish_prepared(plugin_id))
-                published.add(plugin_id)
-            for plugin_id in tuple(self._prepared_generations):
-                if plugin_id not in published:
-                    results.append(await self._publish_prepared(plugin_id))
             return results
 
     async def publish_prepared(self, plugin_id: str) -> dict[str, object]:
@@ -521,13 +521,20 @@ class PluginManager:
             "publication_state": publication_state,
         }
 
-    async def _prepare_changed(self) -> list[dict[str, object]]:
+    async def _prepare_changed(
+        self,
+        *,
+        plugin_ids: set[str] | None = None,
+        force_reprepare: bool = False,
+    ) -> list[dict[str, object]]:
         results: list[dict[str, object]] = []
         discovered = {
             _resolve_plugin_id(mod): mod
             for mod in self.discover()
         }
         for plugin_id, active in tuple(self._active_generations.items()):
+            if plugin_ids is not None and plugin_id not in plugin_ids:
+                continue
             mod = discovered.get(plugin_id)
             if mod is None:
                 continue
@@ -546,6 +553,9 @@ class PluginManager:
                 source_revision = ""
                 config_revision = ""
             current_prepared = self._prepared_generations.get(plugin_id)
+            if force_reprepare and current_prepared is not None:
+                await self.discard_prepared(plugin_id)
+                current_prepared = None
             matches_active = (
                 source_revision == active.source_revision
                 and config_revision == active.config_revision

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -878,8 +878,12 @@ class PluginManager:
                 generation.gate_result = gate_result
                 if gate_result.status == "failed":
                     raise _CandidateRejected(gate_result)
+                generation.runtime_snapshot = self._compile_generation_snapshot(
+                    generation
+                )
                 self._prepared_generations[plugin_id] = generation
                 return generation
+            generation.runtime_snapshot = self._compile_generation_snapshot(generation)
             staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
             instance.context.event_bus = staged_event_bus
             instance.context.kv_store = PluginKVStore(data_dir / ".kv.json")
@@ -890,6 +894,7 @@ class PluginManager:
             load_phase = "initialize"
             initialization_started = True
             await instance.initialize()
+            generation.runtime_snapshot = self._compile_generation_snapshot(generation)
             load_phase = "publish"
             self._register_tools(instance, mp, tool_names)
             self._bind_tool_hooks(instance, mp)
@@ -946,18 +951,37 @@ class PluginManager:
         self._fresh_importer.register(stable_module_path, plugin_dir)
         plugin_registry.register_instance(stable_module_path, instance)
         sys.modules[stable_module_path] = sys.modules[mp]
-        await self._refresh_committed_snapshot(generation)
+        assert generation.runtime_snapshot is not None
+        await self._publish_committed_snapshot(generation.runtime_snapshot)
         logger.info("插件已加载: %s", mod["name"])
         return generation
 
-    async def _refresh_committed_snapshot(
+    def _compile_generation_snapshot(
         self,
-        catalog_generation: PluginGeneration,
+        generation: PluginGeneration,
+    ) -> RuntimeSnapshot:
+        generations = dict(self._active_generations)
+        generations[generation.plugin_id] = generation
+        try:
+            return self._snapshot_compiler.compile(
+                generations,
+                catalog_generation=generation,
+            )
+        except Exception as error:
+            gate = _with_gate_check(
+                generation.gate_result,
+                check_id="runtime_snapshot",
+                passed=False,
+                evidence=str(error),
+            )
+            generation.gate_result = gate
+            self._gate_results[generation.plugin_id] = gate
+            raise _CandidateRejected(gate) from error
+
+    async def _publish_committed_snapshot(
+        self,
+        snapshot: RuntimeSnapshot,
     ) -> None:
-        snapshot = self._snapshot_compiler.compile(
-            self._active_generations,
-            catalog_generation=catalog_generation,
-        )
         if self._snapshot_store.current is None:
             self._snapshot_store.install(snapshot)
             return

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -138,6 +138,8 @@ class PluginManager:
             [str, dict[str, dict[str, Any]], dict[str, dict[str, Any]]],
             Awaitable[None],
         ] | None = None
+        self._endpoint_quiescer: Callable[[], Awaitable[None]] | None = None
+        self._endpoint_resumer: Callable[[], Awaitable[None]] | None = None
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -294,6 +296,15 @@ class PluginManager:
         ],
     ) -> None:
         self._service_switcher = switcher
+
+    def bind_endpoint_admission(
+        self,
+        *,
+        quiesce: Callable[[], Awaitable[None]],
+        resume: Callable[[], Awaitable[None]],
+    ) -> None:
+        self._endpoint_quiescer = quiesce
+        self._endpoint_resumer = resume
 
     def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
         return self._job_host.get(generation_id)
@@ -514,6 +525,24 @@ class PluginManager:
             active.contributions.managed_services if active is not None else {}
         )
         new_services = generation.contributions.managed_services
+        old_channels = active.contributions.channels if active is not None else ()
+        new_channels = generation.contributions.channels
+        quiesced_snapshot: RuntimeSnapshot | None = None
+        if old_services != new_services or old_channels != new_channels:
+            quiesced_snapshot = self._snapshot_store.pause_admission()
+            try:
+                if self._endpoint_quiescer is not None:
+                    await self._endpoint_quiescer()
+                if quiesced_snapshot is not None:
+                    await self._snapshot_store.wait_for_no_leases(
+                        quiesced_snapshot
+                    )
+            except BaseException:
+                await self._snapshot_store.resume(quiesced_snapshot)
+                if self._endpoint_resumer is not None:
+                    await self._endpoint_resumer()
+                await self.discard_prepared(plugin_id)
+                raise
         services_switched = False
         if self._service_switcher is not None and old_services != new_services:
             try:
@@ -527,6 +556,9 @@ class PluginManager:
                     reason=str(error) or type(error).__name__,
                 )
                 await self.discard_prepared(plugin_id)
+                await self._snapshot_store.resume(quiesced_snapshot)
+                if self._endpoint_resumer is not None:
+                    await self._endpoint_resumer()
                 if isinstance(error, asyncio.CancelledError):
                     raise
                 return self._publication_status(
@@ -536,8 +568,6 @@ class PluginManager:
                     publication_state="failed",
                 )
 
-        old_channels = active.contributions.channels if active is not None else ()
-        new_channels = generation.contributions.channels
         channels_switched = False
         if self._channel_switcher is not None and old_channels != new_channels:
             try:
@@ -561,6 +591,9 @@ class PluginManager:
                     except BaseException as rollback_error:
                         service_error = rollback_error
                 await self.discard_prepared(plugin_id)
+                await self._snapshot_store.resume(quiesced_snapshot)
+                if self._endpoint_resumer is not None:
+                    await self._endpoint_resumer()
                 if isinstance(error, asyncio.CancelledError):
                     raise
                 if service_error is not None:
@@ -602,6 +635,9 @@ class PluginManager:
                     except BaseException as rollback_error:
                         service_error = rollback_error
                 await self.discard_prepared(plugin_id)
+                await self._snapshot_store.resume(quiesced_snapshot)
+                if self._endpoint_resumer is not None:
+                    await self._endpoint_resumer()
                 if channel_error is not None:
                     raise RuntimeError(
                         "Dashboard Gate 失败后旧 Channel 恢复失败"
@@ -618,7 +654,10 @@ class PluginManager:
                 )
         if generation.staged_event_bus is not None:
             generation.staged_event_bus.publish()
-        transaction = self._snapshot_store.begin_publish(snapshot)
+        transaction = self._snapshot_store.begin_publish(
+            snapshot,
+            admission_gated=quiesced_snapshot is not None,
+        )
         try:
             await asyncio.wait_for(
                 self._post_publish_invariants(generation, snapshot),
@@ -645,6 +684,8 @@ class PluginManager:
                 except BaseException as error:
                     service_error = error
             await self._snapshot_store.abort(transaction)
+            if self._endpoint_resumer is not None:
+                await self._endpoint_resumer()
             if channel_error is not None:
                 raise RuntimeError("Snapshot abort 后旧 Channel 恢复失败") from channel_error
             if service_error is not None:
@@ -652,6 +693,9 @@ class PluginManager:
                     "Snapshot abort 后旧 managed service 恢复失败"
                 ) from service_error
             raise
+
+        if self._endpoint_resumer is not None and quiesced_snapshot is not None:
+            await self._endpoint_resumer()
 
         _ = self._prepared_generations.pop(plugin_id)
         self._scopes[generation.module_path] = generation.scope

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -103,6 +103,8 @@ class ActivePluginInfo:
 
 
 class PluginManager:
+    POST_PUBLISH_TIMEOUT_SECONDS = 5.0
+
     def __init__(
         self,
         plugin_dirs: list[Path],
@@ -155,7 +157,8 @@ class PluginManager:
         self._job_host = PluginJobHost()
         self._proactive_host = PluginProactiveHost()
         self._snapshot_compiler = RuntimeSnapshotCompiler()
-        self._snapshot_store = RuntimeSnapshotStore()
+        self._snapshot_drains: dict[str, tuple[PluginGeneration, ...]] = {}
+        self._snapshot_store = RuntimeSnapshotStore(self._on_snapshot_drained)
 
     @property
     def loaded_count(self) -> int:
@@ -349,6 +352,14 @@ class PluginManager:
         generation = self._prepared_generations.pop(plugin_id, None)
         if generation is None:
             return
+        await self._dispose_generation(generation, state="discarded")
+
+    async def _dispose_generation(
+        self,
+        generation: PluginGeneration,
+        *,
+        state: str,
+    ) -> None:
         if generation.initialization_started:
             terminator = getattr(generation.instance, "terminate", None)
             if callable(terminator):
@@ -363,7 +374,12 @@ class PluginManager:
                     )
         self._cleanup_failures.extend(await generation.scope.aclose())
         self._remove_module_tree(generation.module_path)
-        generation.state = "discarded"
+        generation.state = state
+
+    async def _on_snapshot_drained(self, snapshot: RuntimeSnapshot) -> None:
+        generations = self._snapshot_drains.pop(snapshot.snapshot_id, ())
+        for generation in generations:
+            await self._dispose_generation(generation, state=generation.state)
 
     async def prepare_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
@@ -426,12 +442,14 @@ class PluginManager:
         try:
             await asyncio.wait_for(
                 self._post_publish_invariants(generation, snapshot),
-                timeout=5,
+                timeout=self.POST_PUBLISH_TIMEOUT_SECONDS,
             )
             await self._snapshot_store.commit(transaction)
         except (asyncio.CancelledError, Exception):
+            _ = self._prepared_generations.pop(plugin_id, None)
+            generation.state = "aborted"
+            self._snapshot_drains[snapshot.snapshot_id] = (generation,)
             await self._snapshot_store.abort(transaction)
-            await self.discard_prepared(plugin_id)
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
@@ -485,8 +503,6 @@ class PluginManager:
         snapshot: RuntimeSnapshot,
     ) -> None:
         await asyncio.sleep(0)
-        if generation.scope.closed:
-            raise RuntimeError("候选插件作用域已关闭")
         if self.current_snapshot is not snapshot:
             raise RuntimeError("RuntimeSnapshot 发布指针不一致")
         if snapshot.generations.get(generation.plugin_id) is not generation:
@@ -501,6 +517,10 @@ class PluginManager:
             if any(not server.client.connected for server in catalog.servers.values()):
                 raise RuntimeError("RuntimeSnapshot MCP client 已断开")
         for item in snapshot.generations.values():
+            if item.scope.closed:
+                raise RuntimeError("RuntimeSnapshot 插件作用域已关闭")
+            if item.scope.resource_count < item.minimum_resource_count:
+                raise RuntimeError("RuntimeSnapshot 插件资源数量不足")
             if item.job_catalog is not None and self._job_host.get(
                 item.generation_id
             ) is not item.job_catalog:
@@ -1064,6 +1084,7 @@ class PluginManager:
                 generation.runtime_snapshot = self._compile_generation_snapshot(
                     generation
                 )
+                generation.minimum_resource_count = scope.resource_count
                 self._prepared_generations[plugin_id] = generation
                 return generation
             generation.runtime_snapshot = self._compile_generation_snapshot(generation)
@@ -1085,6 +1106,7 @@ class PluginManager:
             self._bind_handlers(instance, mp, scope)
             staged_event_bus.activate()
             instance.context.tool_registry = self._tool_registry
+            generation.minimum_resource_count = scope.resource_count
         except asyncio.CancelledError:
             rollback_task = asyncio.create_task(
                 rollback_load(),

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -381,7 +381,6 @@ class PluginManager:
             )
             digest.update(plugin_id.encode())
             digest.update(_source_metadata_revision(plugin_dir))
-            digest.update(_path_metadata(plugin_dir / "plugin.disabled"))
             digest.update(_path_metadata(data_dir / "config.local.toml"))
         return digest.hexdigest()
 
@@ -539,9 +538,8 @@ class PluginManager:
             )
             desired = {
                 plugin_id
-                for plugin_id, mod in discovered.items()
+                for plugin_id in discovered
                 if manifest.get(plugin_id, True)
-                and not _is_plugin_disabled(Path(mod["plugin_root"]))
             }
             for plugin_id in sorted(set(self._active_generations) - desired):
                 results.append(await self._deactivate_plugin(plugin_id))
@@ -1249,9 +1247,6 @@ class PluginManager:
         plugin_manifest = load_plugin_manifest(_plugins_home(self._installed_cache_root))
         if plugin_manifest.get(initial_plugin_id, True) is False:
             logger.info("插件已禁用（manifest.toml）: %s", initial_plugin_id)
-            return None
-        if _is_plugin_disabled(plugin_dir):
-            logger.info("插件已禁用（plugin.disabled）: %s", mod["name"])
             return None
         tool_names: list[str] = []
         hook_count_before = len(self._tool_hooks)
@@ -2900,7 +2895,3 @@ def _gate_check_evidence(
         if check.check_id == check_id:
             return check.evidence
     return []
-
-
-def _is_plugin_disabled(plugin_dir: Path) -> bool:
-    return (plugin_dir / "plugin.disabled").exists()

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -454,6 +454,9 @@ class PluginManager:
             raise
 
         _ = self._prepared_generations.pop(plugin_id)
+        self._plugin_mcp_server_names.update(
+            generation.contributions.mcp_servers
+        )
         self._scopes[generation.module_path] = generation.scope
         self._loaded.add(generation.module_path)
         generation.state = "active"
@@ -904,7 +907,6 @@ class PluginManager:
                 gate_result=gate_result,
                 state="prepared" if not activate else "activating",
             )
-            self._plugin_mcp_server_names.update(contributions.mcp_servers)
             catalog_generations = [
                 active_generation
                 for active_generation in self._active_generations.values()
@@ -1001,7 +1003,11 @@ class PluginManager:
             )
             self._gate_results[plugin_id] = gate_result
             generation.gate_result = gate_result
-            if not activate:
+            if (
+                not activate
+                or contributions.mcp_servers
+                or contributions.proactive_sources
+            ):
                 try:
                     mcp_catalog = await self._mcp_host.prepare(
                         generation_id,
@@ -1084,12 +1090,13 @@ class PluginManager:
                 generation.gate_result = gate_result
                 if gate_result.status == "failed":
                     raise _CandidateRejected(gate_result)
-                generation.runtime_snapshot = self._compile_generation_snapshot(
-                    generation
-                )
-                generation.minimum_resource_count = scope.resource_count
-                self._prepared_generations[plugin_id] = generation
-                return generation
+                if not activate:
+                    generation.runtime_snapshot = self._compile_generation_snapshot(
+                        generation
+                    )
+                    generation.minimum_resource_count = scope.resource_count
+                    self._prepared_generations[plugin_id] = generation
+                    return generation
             generation.runtime_snapshot = self._compile_generation_snapshot(generation)
             staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
             instance.context.event_bus = staged_event_bus
@@ -1153,6 +1160,7 @@ class PluginManager:
         )
         generation.state = "active"
         self._active_generations[plugin_id] = generation
+        self._plugin_mcp_server_names.update(contributions.mcp_servers)
         self._stable_aliases[mp] = stable_module_path
         self._remove_module_tree(stable_module_path)
         self._fresh_importer.register(stable_module_path, plugin_dir)
@@ -1195,7 +1203,14 @@ class PluginManager:
             return None
         plugin_mcp_sources = {
             ("mcp", server_name)
-            for server_name in self._plugin_mcp_server_names
+            for server_name in {
+                *self._plugin_mcp_server_names,
+                *(
+                    server_name
+                    for generation in generations.values()
+                    for server_name in generation.contributions.mcp_servers
+                ),
+            }
         }
         registry = self._tool_registry.fork(
             excluded_source_types={"plugin"},

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -11,7 +11,7 @@ import os
 import secrets
 import sys
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
@@ -38,7 +38,12 @@ from agent.lifecycle.types import (
 )
 from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registry
 from agent.plugins.source_resolver import resolve_plugin_sources
-from agent.plugins.jobs import PluginJobSpec, PluginLlmService, RegisteredPluginJob
+from agent.plugins.jobs import (
+    IntervalTrigger,
+    PluginJobSpec,
+    PluginLlmService,
+    RegisteredPluginJob,
+)
 from agent.plugins.scope import CleanupFailure, PluginScope, ScopedEventBus
 from agent.plugins.generation import (
     GateCheckResult,
@@ -395,6 +400,8 @@ class PluginManager:
                     ),
                     "jobs": _job_keys(active),
                     "proactive_sources": _proactive_source_keys(active),
+                    "job_specs": _job_spec_evidence(active),
+                    "proactive_source_specs": _proactive_source_spec_evidence(active),
                 }
                 results.append(result)
                 logger.info(
@@ -454,6 +461,14 @@ class PluginManager:
                     _proactive_source_keys(prepared)
                     if prepared is not None
                     else []
+                ),
+                "job_specs": (
+                    _job_spec_evidence(prepared) if prepared is not None else {}
+                ),
+                "proactive_source_specs": (
+                    _proactive_source_spec_evidence(prepared)
+                    if prepared is not None
+                    else {}
                 ),
             }
             results.append(result)
@@ -738,6 +753,12 @@ class PluginManager:
                 raise _CandidateRejected(gate_result) from error
             generation.job_catalog = job_catalog
             generation.proactive_catalog = proactive_catalog
+            contributions = replace(
+                contributions,
+                jobs=tuple(job_catalog.jobs.values()),
+                proactive_sources=tuple(proactive_catalog.sources.values()),
+            )
+            generation.contributions = contributions
             gate_result = _with_gate_check(
                 gate_result,
                 check_id="activity_catalogs",
@@ -1822,6 +1843,44 @@ def _job_keys(generation: PluginGeneration) -> list[str]:
 def _proactive_source_keys(generation: PluginGeneration) -> list[str]:
     catalog = generation.proactive_catalog
     return sorted(catalog.sources) if catalog is not None else []
+
+
+def _job_spec_evidence(generation: PluginGeneration) -> dict[str, object]:
+    catalog = generation.job_catalog
+    if catalog is None:
+        return {}
+    return {
+        key: [
+            (
+                {"type": "interval", "seconds": trigger.seconds}
+                if isinstance(trigger, IntervalTrigger)
+                else {
+                    "type": "event",
+                    "event": trigger.event_type.__name__,
+                }
+            )
+            for trigger in job.spec.triggers
+        ]
+        for key, job in sorted(catalog.jobs.items())
+    }
+
+
+def _proactive_source_spec_evidence(
+    generation: PluginGeneration,
+) -> dict[str, object]:
+    catalog = generation.proactive_catalog
+    if catalog is None:
+        return {}
+    return {
+        key: {
+            "server": source.spec.server,
+            "fetch_tool": source.spec.fetch_tool,
+            "ack_tool": source.spec.ack_tool,
+            "poll_tool": source.spec.poll_tool,
+            "poll_interval_seconds": source.spec.poll_interval_seconds,
+        }
+        for key, source in sorted(catalog.sources.items())
+    }
 
 
 def _gate_check_evidence(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -79,6 +79,18 @@ from infra.channels.contract import Channel
 
 logger = logging.getLogger(__name__)
 
+
+async def _complete_critical(awaitable: Awaitable[None]) -> bool:
+    task = asyncio.ensure_future(awaitable)
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    await task
+    return cancelled
+
 _EVENT_TYPE_MAP: dict[PluginEventType, type] = {
     PluginEventType.BEFORE_TURN: BeforeTurnCtx,
     PluginEventType.BEFORE_REASONING: BeforeReasoningCtx,
@@ -355,6 +367,24 @@ class PluginManager:
             _ = entries.setdefault(_resolve_plugin_id(mod), True)
         return write_plugin_manifest(entries, plugins_home=plugins_home)
 
+    def watch_revision(self) -> str:
+        digest = hashlib.sha256()
+        home = _plugins_home(self._installed_cache_root)
+        digest.update(_path_metadata(home / "manifest.toml"))
+        for mod in self.discover():
+            plugin_id = _resolve_plugin_id(mod)
+            plugin_dir = Path(mod["plugin_root"])
+            data_dir = _resolve_plugin_data_dir(
+                mod["name"],
+                mod,
+                self._installed_cache_root,
+            )
+            digest.update(plugin_id.encode())
+            digest.update(_source_metadata_revision(plugin_dir))
+            digest.update(_path_metadata(plugin_dir / "plugin.disabled"))
+            digest.update(_path_metadata(data_dir / "config.local.toml"))
+        return digest.hexdigest()
+
     def _registry_active(self, module_path: str) -> bool:
         if module_path not in self._active_plugins:
             return False
@@ -584,7 +614,6 @@ class PluginManager:
                 admission_gated=quiesced is not None,
             )
             await self._post_snapshot_invariants(snapshot)
-            await self._snapshot_store.commit(transaction)
         except BaseException:
             endpoint_error: BaseException | None = None
             if endpoints_switched:
@@ -609,21 +638,41 @@ class PluginManager:
             if endpoint_error is not None:
                 raise RuntimeError("禁用插件后旧端点恢复失败") from endpoint_error
             raise
-        if self._endpoint_resumer is not None and quiesced is not None:
-            await self._endpoint_resumer()
+
+        commit_error: BaseException | None = None
+        commit_cancelled = False
+        try:
+            assert transaction is not None
+            commit_cancelled = await _complete_critical(
+                self._snapshot_store.commit(transaction)
+            )
+        except BaseException as error:
+            commit_error = error
         _ = self._active_generations.pop(plugin_id)
         self._channels = [
             channel
             for generation in self._active_generations.values()
             for channel in generation.contributions.channels
         ]
-        return {
+        resume_cancelled = False
+        if self._endpoint_resumer is not None and quiesced is not None:
+            resume_cancelled = await _complete_critical(self._endpoint_resumer())
+        if commit_error is not None:
+            raise commit_error
+        if commit_cancelled or resume_cancelled:
+            raise asyncio.CancelledError
+        result = {
             "plugin_id": plugin_id,
             "old_generation": active.generation_id,
             "new_generation": None,
             "snapshot_id": snapshot.snapshot_id,
             "publication_state": "disabled",
         }
+        logger.info(
+            "plugin_snapshot_status %s",
+            json.dumps(result, ensure_ascii=False, sort_keys=True),
+        )
+        return result
 
     async def _switch_plugin_endpoints(
         self,
@@ -678,7 +727,10 @@ class PluginManager:
             ),
         )
         try:
-            snapshot = self._snapshot_compiler.compile(generations)
+            snapshot = self._snapshot_compiler.compile(
+                generations,
+                snapshot_revision=catalog_id,
+            )
             snapshot.skill_catalog_generation_id = catalog_id
             snapshot.plugin_skill_index = catalog.normal_plugins
             snapshot.tool_registry = self._compile_snapshot_tools(generations)
@@ -814,7 +866,6 @@ class PluginManager:
                 self._post_publish_invariants(generation, snapshot),
                 timeout=self.POST_PUBLISH_TIMEOUT_SECONDS,
             )
-            await self._snapshot_store.commit(transaction)
         except (asyncio.CancelledError, Exception):
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
@@ -837,8 +888,14 @@ class PluginManager:
                 raise RuntimeError("Snapshot abort 后旧端点恢复失败") from endpoint_error
             raise
 
-        if self._endpoint_resumer is not None and quiesced_snapshot is not None:
-            await self._endpoint_resumer()
+        commit_error: BaseException | None = None
+        commit_cancelled = False
+        try:
+            commit_cancelled = await _complete_critical(
+                self._snapshot_store.commit(transaction)
+            )
+        except BaseException as error:
+            commit_error = error
 
         _ = self._prepared_generations.pop(plugin_id)
         self._scopes[generation.module_path] = generation.scope
@@ -853,6 +910,13 @@ class PluginManager:
             for item in self._active_generations.values()
             for channel in item.contributions.channels
         ]
+        resume_cancelled = False
+        if self._endpoint_resumer is not None and quiesced_snapshot is not None:
+            resume_cancelled = await _complete_critical(self._endpoint_resumer())
+        if commit_error is not None:
+            raise commit_error
+        if commit_cancelled or resume_cancelled:
+            raise asyncio.CancelledError
         result = self._publication_status(
             plugin_id,
             active=active,
@@ -880,11 +944,23 @@ class PluginManager:
             drift_skill_roots=generation.contributions.drift_skill_roots,
             mcp_servers=generation.contributions.mcp_servers,
         )
-        if previous is None:
-            return
-        stable_alias = self._stable_aliases.pop(previous.module_path, None)
+        stable_alias = None
+        if previous is not None:
+            stable_alias = self._stable_aliases.pop(previous.module_path, None)
         if stable_alias is None:
-            return
+            retired_module = next(
+                (
+                    module_path
+                    for module_path, info in self._active_plugins.items()
+                    if module_path != generation.module_path
+                    and info.plugin_id == generation.plugin_id
+                ),
+                None,
+            )
+            if retired_module is not None:
+                stable_alias = self._stable_aliases.pop(retired_module, None)
+        if stable_alias is None:
+            stable_alias = generation.module_path.rsplit("__g", 1)[0]
         self._stable_aliases[generation.module_path] = stable_alias
         self._remove_module_tree(stable_alias)
         self._fresh_importer.register(stable_alias, plugin_dir)
@@ -2654,25 +2730,68 @@ def _source_revision(plugin_dir: Path) -> str:
         "__pycache__",
         "node_modules",
     }
-    for path in sorted(plugin_dir.rglob("*")):
-        relative = path.relative_to(plugin_dir)
-        if any(part in excluded for part in relative.parts):
-            continue
-        if path.is_symlink():
+    for current, directories, filenames in os.walk(plugin_dir, followlinks=False):
+        directories[:] = sorted(
+            name for name in directories if name not in excluded
+        )
+        current_path = Path(current)
+        for name in [*directories, *sorted(filenames)]:
+            path = current_path / name
+            relative = path.relative_to(plugin_dir)
+            if path.is_symlink():
+                resolved = path.resolve(strict=False)
+                _require_plugin_path(root, resolved, "源码符号链接")
+                digest.update(str(relative).encode())
+                digest.update(os.readlink(path).encode())
+                if resolved.is_file():
+                    digest.update(resolved.read_bytes())
+                continue
+            if not path.is_file():
+                continue
             resolved = path.resolve(strict=False)
-            _require_plugin_path(root, resolved, "源码符号链接")
+            _require_plugin_path(root, resolved, "源码文件")
             digest.update(str(relative).encode())
-            digest.update(os.readlink(path).encode())
-            if resolved.is_file():
-                digest.update(resolved.read_bytes())
-            continue
-        if not path.is_file():
-            continue
-        resolved = path.resolve(strict=False)
-        _require_plugin_path(root, resolved, "源码文件")
-        digest.update(str(relative).encode())
-        digest.update(path.read_bytes())
+            digest.update(path.read_bytes())
     return digest.hexdigest()
+
+
+def _source_metadata_revision(plugin_dir: Path) -> bytes:
+    digest = hashlib.sha256()
+    excluded = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
+    for current, directories, filenames in os.walk(plugin_dir, followlinks=False):
+        directories[:] = sorted(
+            name for name in directories if name not in excluded
+        )
+        current_path = Path(current)
+        for name in [*directories, *sorted(filenames)]:
+            path = current_path / name
+            relative = path.relative_to(plugin_dir)
+            try:
+                stat = path.lstat()
+            except FileNotFoundError:
+                continue
+            digest.update(str(relative).encode())
+            digest.update(str(stat.st_mtime_ns).encode())
+            digest.update(str(stat.st_size).encode())
+            if path.is_symlink():
+                digest.update(os.readlink(path).encode())
+    return digest.digest()
+
+
+def _path_metadata(path: Path) -> bytes:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return f"{path}:missing".encode()
+    return f"{path}:{stat.st_mtime_ns}:{stat.st_size}".encode()
 
 
 def _duplicates(values: list[str]) -> list[str]:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -140,6 +140,16 @@ class PluginManager:
         ] | None = None
         self._endpoint_quiescer: Callable[[], Awaitable[None]] | None = None
         self._endpoint_resumer: Callable[[], Awaitable[None]] | None = None
+        self._endpoint_switcher: Callable[
+            [
+                str,
+                dict[str, dict[str, Any]],
+                dict[str, dict[str, Any]],
+                tuple[Channel, ...],
+                tuple[Channel, ...],
+            ],
+            Awaitable[None],
+        ] | None = None
         self._loaded: set[str] = set()
         self._channels: list[Channel] = []
         self._tool_hooks: list[ToolHook] = []
@@ -173,6 +183,7 @@ class PluginManager:
         self._proactive_host = PluginProactiveHost()
         self._snapshot_compiler = RuntimeSnapshotCompiler()
         self._snapshot_store = RuntimeSnapshotStore(self._on_snapshot_drained)
+        self._snapshot_skill_catalogs: dict[str, str] = {}
         self._event_bus.bind_runtime_snapshot_store(self._snapshot_store)
 
     @property
@@ -305,6 +316,21 @@ class PluginManager:
     ) -> None:
         self._endpoint_quiescer = quiesce
         self._endpoint_resumer = resume
+
+    def bind_endpoint_switcher(
+        self,
+        switcher: Callable[
+            [
+                str,
+                dict[str, dict[str, Any]],
+                dict[str, dict[str, Any]],
+                tuple[Channel, ...],
+                tuple[Channel, ...],
+            ],
+            Awaitable[None],
+        ],
+    ) -> None:
+        self._endpoint_switcher = switcher
 
     def job_catalog(self, generation_id: str) -> PreparedJobCatalog | None:
         return self._job_host.get(generation_id)
@@ -443,6 +469,9 @@ class PluginManager:
         generation.state = state
 
     async def _on_snapshot_drained(self, snapshot: RuntimeSnapshot) -> None:
+        catalog_id = self._snapshot_skill_catalogs.pop(snapshot.snapshot_id, None)
+        if catalog_id is not None:
+            self._skill_host.close(catalog_id)
         state = "aborted" if snapshot.state == "aborted" else "retired"
         current = self._snapshot_store.current
         for generation in snapshot.generations.values():
@@ -471,7 +500,22 @@ class PluginManager:
     async def reconcile_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
             results: list[dict[str, object]] = []
-            for plugin_id in sorted(tuple(self._active_generations)):
+            discovered = {
+                _resolve_plugin_id(mod): mod
+                for mod in self.discover()
+            }
+            manifest = load_plugin_manifest(
+                _plugins_home(self._installed_cache_root)
+            )
+            desired = {
+                plugin_id
+                for plugin_id, mod in discovered.items()
+                if manifest.get(plugin_id, True)
+                and not _is_plugin_disabled(Path(mod["plugin_root"]))
+            }
+            for plugin_id in sorted(set(self._active_generations) - desired):
+                results.append(await self._deactivate_plugin(plugin_id))
+            for plugin_id in sorted(desired.intersection(self._active_generations)):
                 prepared = await self._prepare_changed(
                     plugin_ids={plugin_id},
                     force_reprepare=True,
@@ -483,7 +527,166 @@ class PluginManager:
                     results.append(result)
                     continue
                 results.append(await self._publish_prepared(plugin_id))
+            for plugin_id in sorted(desired - set(self._active_generations)):
+                generation = await self._load_one(discovered[plugin_id], activate=False)
+                if generation is None:
+                    continue
+                results.append(await self._publish_prepared(plugin_id))
             return results
+
+    async def _deactivate_plugin(self, plugin_id: str) -> dict[str, object]:
+        active = self._active_generations[plugin_id]
+        generations = {
+            key: generation
+            for key, generation in self._active_generations.items()
+            if key != plugin_id
+        }
+        snapshot, catalog_id = self._compile_topology_snapshot(generations)
+        try:
+            self._compile_snapshot_event_handlers(snapshot)
+            if self._dashboard_preparer is not None:
+                self._dashboard_preparer(snapshot)
+        except BaseException:
+            self._skill_host.close(catalog_id)
+            raise
+
+        old_services = active.contributions.managed_services
+        old_channels = active.contributions.channels
+        from agent.plugins.snapshot import get_current_runtime_lease
+
+        if (old_services or old_channels) and get_current_runtime_lease() is not None:
+            self._skill_host.close(catalog_id)
+            raise RuntimeError("持有 RuntimeSnapshot lease 时不能切换独占端点")
+        quiesced = (
+            self._snapshot_store.pause_admission()
+            if old_services or old_channels
+            else None
+        )
+        endpoints_switched = False
+        transaction = None
+        try:
+            if quiesced is not None:
+                if self._endpoint_quiescer is not None:
+                    await self._endpoint_quiescer()
+                await self._snapshot_store.wait_for_no_leases(quiesced)
+            if old_services or old_channels:
+                await self._switch_plugin_endpoints(
+                    plugin_id,
+                    old_services,
+                    {},
+                    old_channels,
+                    (),
+                )
+                endpoints_switched = True
+            self._snapshot_skill_catalogs[snapshot.snapshot_id] = catalog_id
+            transaction = self._snapshot_store.begin_publish(
+                snapshot,
+                admission_gated=quiesced is not None,
+            )
+            await self._post_snapshot_invariants(snapshot)
+            await self._snapshot_store.commit(transaction)
+        except BaseException:
+            endpoint_error: BaseException | None = None
+            if endpoints_switched:
+                try:
+                    await self._switch_plugin_endpoints(
+                        plugin_id,
+                        {},
+                        old_services,
+                        (),
+                        old_channels,
+                    )
+                except BaseException as error:
+                    endpoint_error = error
+            if transaction is not None and self._snapshot_store.current is snapshot:
+                await self._snapshot_store.abort(transaction)
+            else:
+                await self._snapshot_store.resume(quiesced)
+                _ = self._snapshot_skill_catalogs.pop(snapshot.snapshot_id, None)
+                self._skill_host.close(catalog_id)
+            if self._endpoint_resumer is not None and quiesced is not None:
+                await self._endpoint_resumer()
+            if endpoint_error is not None:
+                raise RuntimeError("禁用插件后旧端点恢复失败") from endpoint_error
+            raise
+        if self._endpoint_resumer is not None and quiesced is not None:
+            await self._endpoint_resumer()
+        _ = self._active_generations.pop(plugin_id)
+        self._channels = [
+            channel
+            for generation in self._active_generations.values()
+            for channel in generation.contributions.channels
+        ]
+        return {
+            "plugin_id": plugin_id,
+            "old_generation": active.generation_id,
+            "new_generation": None,
+            "snapshot_id": snapshot.snapshot_id,
+            "publication_state": "disabled",
+        }
+
+    async def _switch_plugin_endpoints(
+        self,
+        plugin_id: str,
+        old_services: dict[str, dict[str, Any]],
+        new_services: dict[str, dict[str, Any]],
+        old_channels: tuple[Channel, ...],
+        new_channels: tuple[Channel, ...],
+    ) -> None:
+        services_changed = old_services != new_services
+        channels_changed = old_channels != new_channels
+        if self._endpoint_switcher is not None:
+            await self._endpoint_switcher(
+                plugin_id,
+                old_services,
+                new_services,
+                old_channels,
+                new_channels,
+            )
+            return
+        if services_changed and channels_changed:
+            raise RuntimeError("同时切换 managed service 与 Channel 需要统一端点宿主")
+        if services_changed:
+            if self._service_switcher is None:
+                raise RuntimeError("managed service 宿主未绑定")
+            await self._service_switcher(plugin_id, old_services, new_services)
+        if channels_changed:
+            if self._channel_switcher is None:
+                raise RuntimeError("Channel 宿主未绑定")
+            await self._channel_switcher(plugin_id, old_channels, new_channels)
+
+    def _compile_topology_snapshot(
+        self,
+        generations: dict[str, PluginGeneration],
+    ) -> tuple[RuntimeSnapshot, str]:
+        self._generation_sequence += 1
+        catalog_id = f"topology:{self._generation_sequence}:{secrets.token_hex(4)}"
+        ordered = list(generations.values())
+        catalog = self._skill_host.prepare(
+            catalog_id,
+            normal_roots=PluginSkillHost.roots_for(ordered, drift=False),
+            drift_roots=PluginSkillHost.roots_for(ordered, drift=True),
+            ignored_normal_roots=tuple(
+                root
+                for generation in ordered
+                for root in generation.contributions.skill_roots
+            ),
+            ignored_drift_roots=tuple(
+                root
+                for generation in ordered
+                for root in generation.contributions.drift_skill_roots
+            ),
+        )
+        try:
+            snapshot = self._snapshot_compiler.compile(generations)
+            snapshot.skill_catalog_generation_id = catalog_id
+            snapshot.plugin_skill_index = catalog.normal_plugins
+            snapshot.tool_registry = self._compile_snapshot_tools(generations)
+            snapshot.tool_hooks = self._compile_snapshot_tool_hooks(generations)
+            return snapshot, catalog_id
+        except BaseException:
+            self._skill_host.close(catalog_id)
+            raise
 
     async def publish_prepared(self, plugin_id: str) -> dict[str, object]:
         async with self._candidate_prepare_lock:
@@ -527,8 +730,35 @@ class PluginManager:
         new_services = generation.contributions.managed_services
         old_channels = active.contributions.channels if active is not None else ()
         new_channels = generation.contributions.channels
+        endpoint_changed = (
+            old_services != new_services or old_channels != new_channels
+        )
+        self._compile_snapshot_event_handlers(snapshot)
+        if self._dashboard_preparer is not None:
+            try:
+                self._dashboard_preparer(snapshot)
+            except Exception as error:
+                self._record_failed_gate(
+                    plugin_id=plugin_id,
+                    revision=generation.source_revision,
+                    check_id="dashboard",
+                    reason=str(error) or type(error).__name__,
+                )
+                await self.discard_prepared(plugin_id)
+                return self._publication_status(
+                    plugin_id,
+                    active=active,
+                    candidate=generation,
+                    publication_state="failed",
+                )
+
         quiesced_snapshot: RuntimeSnapshot | None = None
-        if old_services != new_services or old_channels != new_channels:
+        if endpoint_changed:
+            from agent.plugins.snapshot import get_current_runtime_lease
+
+            if get_current_runtime_lease() is not None:
+                await self.discard_prepared(plugin_id)
+                raise RuntimeError("持有 RuntimeSnapshot lease 时不能切换独占端点")
             quiesced_snapshot = self._snapshot_store.pause_admission()
             try:
                 if self._endpoint_quiescer is not None:
@@ -543,109 +773,30 @@ class PluginManager:
                     await self._endpoint_resumer()
                 await self.discard_prepared(plugin_id)
                 raise
-        services_switched = False
-        if self._service_switcher is not None and old_services != new_services:
+        endpoints_switched = False
+        if endpoint_changed:
             try:
-                await self._service_switcher(plugin_id, old_services, new_services)
-                services_switched = True
+                await self._switch_plugin_endpoints(
+                    plugin_id,
+                    old_services,
+                    new_services,
+                    old_channels,
+                    new_channels,
+                )
+                endpoints_switched = True
             except (asyncio.CancelledError, Exception) as error:
                 self._record_failed_gate(
                     plugin_id=plugin_id,
                     revision=generation.source_revision,
-                    check_id="managed_services",
+                    check_id="endpoints",
                     reason=str(error) or type(error).__name__,
                 )
-                await self.discard_prepared(plugin_id)
                 await self._snapshot_store.resume(quiesced_snapshot)
                 if self._endpoint_resumer is not None:
                     await self._endpoint_resumer()
+                await self.discard_prepared(plugin_id)
                 if isinstance(error, asyncio.CancelledError):
                     raise
-                return self._publication_status(
-                    plugin_id,
-                    active=active,
-                    candidate=generation,
-                    publication_state="failed",
-                )
-
-        channels_switched = False
-        if self._channel_switcher is not None and old_channels != new_channels:
-            try:
-                await self._channel_switcher(plugin_id, old_channels, new_channels)
-                channels_switched = True
-            except (asyncio.CancelledError, Exception) as error:
-                self._record_failed_gate(
-                    plugin_id=plugin_id,
-                    revision=generation.source_revision,
-                    check_id="channels",
-                    reason=str(error) or type(error).__name__,
-                )
-                service_error: BaseException | None = None
-                if services_switched and self._service_switcher is not None:
-                    try:
-                        await self._service_switcher(
-                            plugin_id,
-                            new_services,
-                            old_services,
-                        )
-                    except BaseException as rollback_error:
-                        service_error = rollback_error
-                await self.discard_prepared(plugin_id)
-                await self._snapshot_store.resume(quiesced_snapshot)
-                if self._endpoint_resumer is not None:
-                    await self._endpoint_resumer()
-                if isinstance(error, asyncio.CancelledError):
-                    raise
-                if service_error is not None:
-                    raise RuntimeError(
-                        "Channel Gate 失败后旧 managed service 恢复失败"
-                    ) from service_error
-                return self._publication_status(
-                    plugin_id,
-                    active=active,
-                    candidate=generation,
-                    publication_state="failed",
-                )
-
-        self._compile_snapshot_event_handlers(snapshot)
-        if self._dashboard_preparer is not None:
-            try:
-                self._dashboard_preparer(snapshot)
-            except Exception as error:
-                self._record_failed_gate(
-                    plugin_id=plugin_id,
-                    revision=generation.source_revision,
-                    check_id="dashboard",
-                    reason=str(error) or type(error).__name__,
-                )
-                channel_error: BaseException | None = None
-                if channels_switched and self._channel_switcher is not None:
-                    try:
-                        await self._channel_switcher(plugin_id, new_channels, old_channels)
-                    except BaseException as rollback_error:
-                        channel_error = rollback_error
-                service_error: BaseException | None = None
-                if services_switched and self._service_switcher is not None:
-                    try:
-                        await self._service_switcher(
-                            plugin_id,
-                            new_services,
-                            old_services,
-                        )
-                    except BaseException as rollback_error:
-                        service_error = rollback_error
-                await self.discard_prepared(plugin_id)
-                await self._snapshot_store.resume(quiesced_snapshot)
-                if self._endpoint_resumer is not None:
-                    await self._endpoint_resumer()
-                if channel_error is not None:
-                    raise RuntimeError(
-                        "Dashboard Gate 失败后旧 Channel 恢复失败"
-                    ) from channel_error
-                if service_error is not None:
-                    raise RuntimeError(
-                        "Dashboard Gate 失败后旧 managed service 恢复失败"
-                    ) from service_error
                 return self._publication_status(
                     plugin_id,
                     active=active,
@@ -667,31 +818,23 @@ class PluginManager:
         except (asyncio.CancelledError, Exception):
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
-            channel_error: BaseException | None = None
-            if channels_switched and self._channel_switcher is not None:
+            endpoint_error: BaseException | None = None
+            if endpoints_switched:
                 try:
-                    await self._channel_switcher(plugin_id, new_channels, old_channels)
-                except BaseException as error:
-                    channel_error = error
-            service_error: BaseException | None = None
-            if services_switched and self._service_switcher is not None:
-                try:
-                    await self._service_switcher(
+                    await self._switch_plugin_endpoints(
                         plugin_id,
                         new_services,
                         old_services,
+                        new_channels,
+                        old_channels,
                     )
                 except BaseException as error:
-                    service_error = error
+                    endpoint_error = error
             await self._snapshot_store.abort(transaction)
             if self._endpoint_resumer is not None:
                 await self._endpoint_resumer()
-            if channel_error is not None:
-                raise RuntimeError("Snapshot abort 后旧 Channel 恢复失败") from channel_error
-            if service_error is not None:
-                raise RuntimeError(
-                    "Snapshot abort 后旧 managed service 恢复失败"
-                ) from service_error
+            if endpoint_error is not None:
+                raise RuntimeError("Snapshot abort 后旧端点恢复失败") from endpoint_error
             raise
 
         if self._endpoint_resumer is not None and quiesced_snapshot is not None:
@@ -806,11 +949,17 @@ class PluginManager:
         generation: PluginGeneration,
         snapshot: RuntimeSnapshot,
     ) -> None:
+        await self._post_snapshot_invariants(snapshot)
+        if snapshot.generations.get(generation.plugin_id) is not generation:
+            raise RuntimeError("RuntimeSnapshot generation 不一致")
+
+    async def _post_snapshot_invariants(
+        self,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
         await asyncio.sleep(0)
         if self.current_snapshot is not snapshot:
             raise RuntimeError("RuntimeSnapshot 发布指针不一致")
-        if snapshot.generations.get(generation.plugin_id) is not generation:
-            raise RuntimeError("RuntimeSnapshot generation 不一致")
         catalog_id = snapshot.skill_catalog_generation_id
         if catalog_id is not None and self._skill_host.get(catalog_id) is None:
             raise RuntimeError("RuntimeSnapshot skill catalog 不可用")

--- a/agent/plugins/manifest.py
+++ b/agent/plugins/manifest.py
@@ -45,6 +45,31 @@ def upsert_plugin_manifest(
     return write_plugin_manifest(entries, plugins_home=plugins_home)
 
 
+def set_plugin_enabled(
+    plugin_id: str,
+    *,
+    enabled: bool,
+    plugins_home: Path | None = None,
+) -> Path:
+    entries = load_plugin_manifest(plugins_home)
+    if plugin_id not in entries:
+        raise ValueError(f"插件未安装: {plugin_id}")
+    entries[plugin_id] = enabled
+    return write_plugin_manifest(entries, plugins_home=plugins_home)
+
+
+def remove_plugin_manifest_entry(
+    plugin_id: str,
+    *,
+    plugins_home: Path | None = None,
+) -> Path:
+    entries = load_plugin_manifest(plugins_home)
+    if plugin_id not in entries:
+        raise ValueError(f"插件未安装: {plugin_id}")
+    del entries[plugin_id]
+    return write_plugin_manifest(entries, plugins_home=plugins_home)
+
+
 def write_plugin_manifest(
     entries: Mapping[str, bool],
     *,
@@ -52,7 +77,7 @@ def write_plugin_manifest(
 ) -> Path:
     path = manifest_path(plugins_home)
     path.parent.mkdir(parents=True, exist_ok=True)
-    lines: list[str] = []
+    lines = ["[plugins]", ""]
     for plugin_id, enabled in sorted(entries.items()):
         escaped = plugin_id.replace("\\", "\\\\").replace('"', '\\"')
         lines.extend(

--- a/agent/plugins/manifest.py
+++ b/agent/plugins/manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import tempfile
 import tomllib
 from pathlib import Path
 from typing import Mapping, cast
@@ -87,5 +89,16 @@ def write_plugin_manifest(
                 "",
             ]
         )
-    path.write_text("\n".join(lines), encoding="utf-8")
+    content = "\n".join(lines)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix="manifest-",
+        suffix=".toml",
+        delete=False,
+    ) as stream:
+        _ = stream.write(content)
+        temporary = Path(stream.name)
+    os.replace(temporary, path)
     return path

--- a/agent/plugins/mcp_host.py
+++ b/agent/plugins/mcp_host.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import MappingProxyType
+from collections.abc import Mapping
+from typing import Any
+
+from agent.mcp.client import McpClient
+from agent.mcp.tool import McpToolWrapper
+from agent.plugins.specs import RegisteredProactiveSource
+
+
+@dataclass(frozen=True)
+class PreparedMcpServer:
+    name: str
+    client: McpClient
+    tools: tuple[McpToolWrapper, ...]
+
+    @property
+    def remote_tool_names(self) -> tuple[str, ...]:
+        return tuple(info.name for info in self.client.tool_infos)
+
+
+@dataclass(frozen=True)
+class PreparedMcpCatalog:
+    generation_id: str
+    servers: Mapping[str, PreparedMcpServer]
+
+    @property
+    def tool_names(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(tool.name for server in self.servers.values() for tool in server.tools)
+        )
+
+
+class PluginMcpHost:
+    def __init__(self) -> None:
+        self._catalogs: dict[str, PreparedMcpCatalog] = {}
+
+    async def prepare(
+        self,
+        generation_id: str,
+        *,
+        server_specs: dict[str, dict[str, Any]],
+        proactive_sources: tuple[RegisteredProactiveSource, ...],
+    ) -> PreparedMcpCatalog:
+        servers: dict[str, PreparedMcpServer] = {}
+        clients: list[McpClient] = []
+        try:
+            for server_name, spec in sorted(server_specs.items()):
+                client = McpClient(
+                    name=f"{server_name}@{generation_id}",
+                    command=list(spec["command"]),
+                    env=dict(spec.get("env") or {}),
+                    cwd=str(spec.get("cwd") or "") or None,
+                )
+                clients.append(client)
+                infos = await client.connect()
+                remote_names = [info.name for info in infos]
+                if len(remote_names) != len(set(remote_names)):
+                    raise RuntimeError(f"MCP server 工具名重复: {server_name}")
+                servers[server_name] = PreparedMcpServer(
+                    name=server_name,
+                    client=client,
+                    tools=tuple(
+                        McpToolWrapper(client, info, server_name=server_name)
+                        for info in infos
+                    ),
+                )
+            self._validate_sources(servers, proactive_sources)
+        except BaseException:
+            _ = await asyncio.gather(
+                *(client.disconnect() for client in clients),
+                return_exceptions=True,
+            )
+            raise
+        catalog = PreparedMcpCatalog(
+            generation_id=generation_id,
+            servers=MappingProxyType(servers),
+        )
+        self._catalogs[generation_id] = catalog
+        return catalog
+
+    async def close(self, generation_id: str) -> None:
+        catalog = self._catalogs.get(generation_id)
+        if catalog is None:
+            return
+        _ = await asyncio.gather(
+            *(server.client.disconnect() for server in catalog.servers.values())
+        )
+        _ = self._catalogs.pop(generation_id, None)
+
+    def get(self, generation_id: str) -> PreparedMcpCatalog | None:
+        return self._catalogs.get(generation_id)
+
+    @staticmethod
+    def _validate_sources(
+        servers: Mapping[str, PreparedMcpServer],
+        sources: tuple[RegisteredProactiveSource, ...],
+    ) -> None:
+        missing: list[str] = []
+        for source in sources:
+            server = servers.get(source.spec.server)
+            if server is None:
+                missing.append(f"{source.spec.id}:server:{source.spec.server}")
+                continue
+            available = set(server.remote_tool_names)
+            for role, tool_name in (
+                ("fetch", source.spec.fetch_tool),
+                ("ack", source.spec.ack_tool),
+                ("poll", source.spec.poll_tool),
+            ):
+                if tool_name and tool_name not in available:
+                    missing.append(f"{source.spec.id}:{role}:{tool_name}")
+        if missing:
+            raise RuntimeError(f"proactive source MCP tool 缺失: {', '.join(missing)}")

--- a/agent/plugins/mcp_host.py
+++ b/agent/plugins/mcp_host.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from types import MappingProxyType
 from collections.abc import Mapping
@@ -8,6 +7,7 @@ from typing import Any
 
 from agent.mcp.client import McpClient
 from agent.mcp.tool import McpToolWrapper
+from agent.plugins.scope import PluginScope
 from agent.plugins.specs import RegisteredProactiveSource
 
 
@@ -44,37 +44,30 @@ class PluginMcpHost:
         *,
         server_specs: dict[str, dict[str, Any]],
         proactive_sources: tuple[RegisteredProactiveSource, ...],
+        scope: PluginScope,
     ) -> PreparedMcpCatalog:
         servers: dict[str, PreparedMcpServer] = {}
-        clients: list[McpClient] = []
-        try:
-            for server_name, spec in sorted(server_specs.items()):
-                client = McpClient(
-                    name=f"{server_name}@{generation_id}",
-                    command=list(spec["command"]),
-                    env=dict(spec.get("env") or {}),
-                    cwd=str(spec.get("cwd") or "") or None,
-                )
-                clients.append(client)
-                infos = await client.connect()
-                remote_names = [info.name for info in infos]
-                if len(remote_names) != len(set(remote_names)):
-                    raise RuntimeError(f"MCP server 工具名重复: {server_name}")
-                servers[server_name] = PreparedMcpServer(
-                    name=server_name,
-                    client=client,
-                    tools=tuple(
-                        McpToolWrapper(client, info, server_name=server_name)
-                        for info in infos
-                    ),
-                )
-            self._validate_sources(servers, proactive_sources)
-        except BaseException:
-            _ = await asyncio.gather(
-                *(client.disconnect() for client in clients),
-                return_exceptions=True,
+        for server_name, spec in sorted(server_specs.items()):
+            client = McpClient(
+                name=f"{server_name}@{generation_id}",
+                command=list(spec["command"]),
+                env=dict(spec.get("env") or {}),
+                cwd=str(spec.get("cwd") or "") or None,
             )
-            raise
+            scope.defer(f"mcp_client:{server_name}", client.disconnect)
+            infos = await client.connect()
+            remote_names = [info.name for info in infos]
+            if len(remote_names) != len(set(remote_names)):
+                raise RuntimeError(f"MCP server 工具名重复: {server_name}")
+            servers[server_name] = PreparedMcpServer(
+                name=server_name,
+                client=client,
+                tools=tuple(
+                    McpToolWrapper(client, info, server_name=server_name)
+                    for info in infos
+                ),
+            )
+        self._validate_sources(servers, proactive_sources)
         catalog = PreparedMcpCatalog(
             generation_id=generation_id,
             servers=MappingProxyType(servers),
@@ -86,10 +79,19 @@ class PluginMcpHost:
         catalog = self._catalogs.get(generation_id)
         if catalog is None:
             return
-        _ = await asyncio.gather(
-            *(server.client.disconnect() for server in catalog.servers.values())
-        )
-        _ = self._catalogs.pop(generation_id, None)
+        failures: list[Exception] = []
+        for server in catalog.servers.values():
+            try:
+                await server.client.disconnect()
+            except Exception as error:
+                failures.append(error)
+        if not any(server.client.connected for server in catalog.servers.values()):
+            _ = self._catalogs.pop(generation_id, None)
+        if failures:
+            raise RuntimeError(
+                "MCP catalog 清理失败: "
+                + "; ".join(str(error) for error in failures)
+            )
 
     def get(self, generation_id: str) -> PreparedMcpCatalog | None:
         return self._catalogs.get(generation_id)

--- a/agent/plugins/mcp_host.py
+++ b/agent/plugins/mcp_host.py
@@ -80,12 +80,13 @@ class PluginMcpHost:
         if catalog is None:
             return
         failures: list[Exception] = []
-        for server in catalog.servers.values():
-            try:
-                await server.client.disconnect()
-            except Exception as error:
-                failures.append(error)
-        if not any(server.client.connected for server in catalog.servers.values()):
+        try:
+            for server in catalog.servers.values():
+                try:
+                    await server.client.disconnect()
+                except Exception as error:
+                    failures.append(error)
+        finally:
             _ = self._catalogs.pop(generation_id, None)
         if failures:
             raise RuntimeError(

--- a/agent/plugins/registry.py
+++ b/agent/plugins/registry.py
@@ -76,6 +76,13 @@ class PluginHandlerRegistry:
     def remove_by_module_path(self, mp: str) -> None:
         self._handlers = [h for h in self._handlers if h.plugin_module_path != mp]
 
+    def module_paths_under(self, root: str) -> set[str]:
+        return {
+            handler.plugin_module_path
+            for handler in self._handlers
+            if handler.plugin_module_path.startswith(f"{root}.")
+        }
+
 
 class PluginRegistry:
     def __init__(self) -> None:
@@ -88,6 +95,9 @@ class PluginRegistry:
 
     def register_instance(self, mp: str, inst: object) -> None:
         self._instances[mp] = inst
+
+    def get_class(self, mp: str) -> type | None:
+        return self._classes.get(mp)
 
     def get_instance(self, mp: str) -> object | None:
         return self._instances.get(mp)
@@ -102,6 +112,16 @@ class PluginRegistry:
         self._handlers.remove_by_module_path(mp)
         _ = self._classes.pop(mp, None)
         _ = self._instances.pop(mp, None)
+
+    def remove_module_tree(self, root: str) -> None:
+        module_paths = {
+            root,
+            *(path for path in self._classes if path.startswith(f"{root}.")),
+            *(path for path in self._instances if path.startswith(f"{root}.")),
+            *self._handlers.module_paths_under(root),
+        }
+        for module_path in module_paths:
+            self.remove_plugin(module_path)
 
 
 plugin_registry = PluginRegistry()

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import subprocess
+from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from bus.event_bus import EventBus, EventSubscription, Handler
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+Cleanup = Callable[[], Awaitable[None] | None]
+
+
+@dataclass(frozen=True)
+class CleanupFailure:
+    resource: str
+    error: str
+
+
+class PluginScope:
+    def __init__(self, plugin_id: str) -> None:
+        self.plugin_id = plugin_id
+        self._cleanups: list[tuple[str, Cleanup]] = []
+        self._closed = False
+
+    @property
+    def resource_count(self) -> int:
+        return len(self._cleanups)
+
+    def defer(self, resource: str, cleanup: Cleanup) -> None:
+        if self._closed:
+            raise RuntimeError(f"插件作用域已关闭: {self.plugin_id}")
+        self._cleanups.append((resource, cleanup))
+
+    def subscribe(
+        self,
+        event_bus: EventBus,
+        event_type: type[T],
+        handler: Handler[T],
+    ) -> EventSubscription:
+        subscription = event_bus.on(event_type, handler)
+        self.defer(
+            f"event:{event_type.__name__}",
+            subscription.close,
+        )
+        return subscription
+
+    def create_task(
+        self,
+        coroutine: Coroutine[Any, Any, T],
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[T]:
+        task = asyncio.create_task(coroutine, name=name)
+
+        async def cancel() -> None:
+            if not task.done():
+                _ = task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                return
+
+        self.defer(f"task:{name or task.get_name()}", cancel)
+        return task
+
+    def track_async_process(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        name: str,
+    ) -> None:
+        async def terminate() -> None:
+            if process.returncode is None:
+                process.terminate()
+            _ = await process.wait()
+
+        self.defer(f"process:{name}", terminate)
+
+    def track_process(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        name: str,
+        timeout: float = 5,
+    ) -> None:
+        async def terminate() -> None:
+            if process.poll() is not None:
+                return
+            process.terminate()
+            try:
+                _ = await asyncio.to_thread(process.wait, timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                _ = await asyncio.to_thread(process.wait)
+
+        self.defer(f"process:{name}", terminate)
+
+    async def aclose(self) -> list[CleanupFailure]:
+        if self._closed:
+            return []
+        self._closed = True
+        failures: list[CleanupFailure] = []
+        while self._cleanups:
+            resource, cleanup = self._cleanups.pop()
+            try:
+                result = cleanup()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as error:
+                failure = CleanupFailure(resource=resource, error=str(error))
+                failures.append(failure)
+                logger.warning(
+                    "插件资源清理失败: plugin=%s resource=%s error=%s",
+                    self.plugin_id,
+                    resource,
+                    error,
+                )
+        return failures
+
+
+class ScopedEventBus:
+    def __init__(self, event_bus: EventBus, scope: PluginScope) -> None:
+        self._event_bus = event_bus
+        self._scope = scope
+
+    def on(
+        self,
+        event_type: type[T],
+        handler: Handler[T],
+    ) -> EventSubscription:
+        return self._scope.subscribe(self._event_bus, event_type, handler)
+
+    async def emit(self, event: T) -> T:
+        return await self._event_bus.emit(event)
+
+    async def observe(self, event: object) -> None:
+        await self._event_bus.observe(event)
+
+    async def fanout(self, event: object) -> None:
+        await self._event_bus.fanout(event)
+
+    def enqueue(self, event: object) -> None:
+        self._event_bus.enqueue(event)

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -33,8 +33,7 @@ class PluginScope:
         return len(self._cleanups)
 
     def defer(self, resource: str, cleanup: Cleanup) -> None:
-        if self._closed:
-            raise RuntimeError(f"插件作用域已关闭: {self.plugin_id}")
+        self._ensure_open()
         self._cleanups.append((resource, cleanup))
 
     def subscribe(
@@ -43,6 +42,7 @@ class PluginScope:
         event_type: type[T],
         handler: Handler[T],
     ) -> EventSubscription:
+        self._ensure_open()
         subscription = event_bus.on(event_type, handler)
         self.defer(
             f"event:{event_type.__name__}",
@@ -56,6 +56,9 @@ class PluginScope:
         *,
         name: str | None = None,
     ) -> asyncio.Task[T]:
+        if self._closed:
+            coroutine.close()
+            self._ensure_open()
         task = asyncio.create_task(coroutine, name=name)
 
         async def cancel() -> None:
@@ -74,11 +77,16 @@ class PluginScope:
         process: asyncio.subprocess.Process,
         *,
         name: str,
+        timeout: float = 5,
     ) -> None:
         async def terminate() -> None:
             if process.returncode is None:
                 process.terminate()
-            _ = await process.wait()
+            try:
+                _ = await asyncio.wait_for(process.wait(), timeout=timeout)
+            except TimeoutError:
+                process.kill()
+                _ = await process.wait()
 
         self.defer(f"process:{name}", terminate)
 
@@ -122,6 +130,10 @@ class PluginScope:
                     error,
                 )
         return failures
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError(f"插件作用域已关闭: {self.plugin_id}")
 
 
 class ScopedEventBus:

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -114,21 +114,27 @@ class PluginScope:
             return []
         self._closed = True
         failures: list[CleanupFailure] = []
+        externally_cancelled = False
         while self._cleanups:
             resource, cleanup = self._cleanups.pop()
             try:
                 result = cleanup()
                 if inspect.isawaitable(result):
                     await result
-            except Exception as error:
+            except (asyncio.CancelledError, Exception) as error:
                 failure = CleanupFailure(resource=resource, error=str(error))
                 failures.append(failure)
+                if isinstance(error, asyncio.CancelledError):
+                    task = asyncio.current_task()
+                    externally_cancelled = task is not None and task.cancelling() > 0
                 logger.warning(
                     "插件资源清理失败: plugin=%s resource=%s error=%s",
                     self.plugin_id,
                     resource,
                     error,
                 )
+        if externally_cancelled:
+            raise asyncio.CancelledError
         return failures
 
     def _ensure_open(self) -> None:

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -166,6 +166,8 @@ class ScopedEventBus:
         handler: Handler[T],
     ) -> EventSubscription | _StagedEventSubscription[T]:
         if self._snapshot_managed:
+            if self._active:
+                raise RuntimeError("插件事件订阅只能在 initialize 中注册")
             subscription = _StagedEventSubscription(
                 self._event_bus,
                 event_type,
@@ -186,7 +188,7 @@ class ScopedEventBus:
 
     def staged_handlers(self) -> tuple[tuple[type[object], Handler[object]], ...]:
         return tuple(
-            (subscription.event_type, subscription.handler)
+            (subscription.event_type, subscription.dispatch)
             for subscription in self._pending
             if subscription.active
         )
@@ -241,9 +243,13 @@ class _StagedEventSubscription(Generic[T]):
     def event_type(self) -> type[object]:
         return self._event_type
 
-    @property
-    def handler(self) -> Handler[object]:
-        return cast(Handler[object], self._handler)
+    async def dispatch(self, event: object) -> object | None:
+        if not self._active:
+            return None
+        result = self._handler(cast(T, event))
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     def activate(self) -> None:
         if not self._active or self._subscription is not None:

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -32,6 +32,10 @@ class PluginScope:
     def resource_count(self) -> int:
         return len(self._cleanups)
 
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
     def defer(self, resource: str, cleanup: Cleanup) -> None:
         self._ensure_open()
         self._cleanups.append((resource, cleanup))

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 from bus.event_bus import EventBus, EventSubscription, Handler
 
@@ -157,6 +157,7 @@ class ScopedEventBus:
         self._event_bus = event_bus
         self._scope = scope
         self._active = not staged
+        self._snapshot_managed = staged
         self._pending: list[_StagedEventSubscription[Any]] = []
 
     def on(
@@ -164,7 +165,7 @@ class ScopedEventBus:
         event_type: type[T],
         handler: Handler[T],
     ) -> EventSubscription | _StagedEventSubscription[T]:
-        if not self._active:
+        if self._snapshot_managed:
             subscription = _StagedEventSubscription(
                 self._event_bus,
                 event_type,
@@ -177,6 +178,18 @@ class ScopedEventBus:
             )
             return subscription
         return self._scope.subscribe(self._event_bus, event_type, handler)
+
+    def publish(self) -> None:
+        if not self._snapshot_managed:
+            return
+        self._active = True
+
+    def staged_handlers(self) -> tuple[tuple[type[object], Handler[object]], ...]:
+        return tuple(
+            (subscription.event_type, subscription.handler)
+            for subscription in self._pending
+            if subscription.active
+        )
 
     def activate(self) -> None:
         if self._active:
@@ -223,6 +236,14 @@ class _StagedEventSubscription(Generic[T]):
     @property
     def active(self) -> bool:
         return self._active
+
+    @property
+    def event_type(self) -> type[object]:
+        return self._event_type
+
+    @property
+    def handler(self) -> Handler[object]:
+        return cast(Handler[object], self._handler)
 
     def activate(self) -> None:
         if not self._active or self._subscription is not None:

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from bus.event_bus import EventBus, EventSubscription, Handler
 
@@ -143,25 +143,91 @@ class PluginScope:
 
 
 class ScopedEventBus:
-    def __init__(self, event_bus: EventBus, scope: PluginScope) -> None:
+    def __init__(
+        self,
+        event_bus: EventBus,
+        scope: PluginScope,
+        *,
+        staged: bool = False,
+    ) -> None:
         self._event_bus = event_bus
         self._scope = scope
+        self._active = not staged
+        self._pending: list[_StagedEventSubscription[Any]] = []
 
     def on(
         self,
         event_type: type[T],
         handler: Handler[T],
-    ) -> EventSubscription:
+    ) -> EventSubscription | _StagedEventSubscription[T]:
+        if not self._active:
+            subscription = _StagedEventSubscription(
+                self._event_bus,
+                event_type,
+                handler,
+            )
+            self._pending.append(subscription)
+            self._scope.defer(
+                f"event:{event_type.__name__}",
+                subscription.close,
+            )
+            return subscription
         return self._scope.subscribe(self._event_bus, event_type, handler)
 
+    def activate(self) -> None:
+        if self._active:
+            return
+        self._active = True
+        for subscription in self._pending:
+            subscription.activate()
+        self._pending.clear()
+
     async def emit(self, event: T) -> T:
+        self._ensure_active()
         return await self._event_bus.emit(event)
 
     async def observe(self, event: object) -> None:
+        self._ensure_active()
         await self._event_bus.observe(event)
 
     async def fanout(self, event: object) -> None:
+        self._ensure_active()
         await self._event_bus.fanout(event)
 
     def enqueue(self, event: object) -> None:
+        self._ensure_active()
         self._event_bus.enqueue(event)
+
+    def _ensure_active(self) -> None:
+        if not self._active:
+            raise RuntimeError("候选插件尚未发布，不能发送事件")
+
+
+class _StagedEventSubscription(Generic[T]):
+    def __init__(
+        self,
+        event_bus: EventBus,
+        event_type: type[T],
+        handler: Handler[T],
+    ) -> None:
+        self._event_bus = event_bus
+        self._event_type = event_type
+        self._handler = handler
+        self._subscription: EventSubscription | None = None
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def activate(self) -> None:
+        if not self._active or self._subscription is not None:
+            return
+        self._subscription = self._event_bus.on(self._event_type, self._handler)
+
+    def close(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        if self._subscription is not None:
+            self._subscription.close()

--- a/agent/plugins/service_host.py
+++ b/agent/plugins/service_host.py
@@ -143,12 +143,21 @@ class PluginServiceHost:
         timeout = float(service.spec["startup_timeout_seconds"])
         deadline = asyncio.get_running_loop().time() + timeout
         readiness_url = str(service.spec.get("readiness_url") or "")
+        if not readiness_url:
+            try:
+                exit_code = await asyncio.wait_for(
+                    asyncio.shield(service.process.wait()),
+                    timeout=min(0.2, timeout),
+                )
+            except TimeoutError:
+                return
+            raise RuntimeError(f"managed service 启动失败: exit={exit_code}")
         while asyncio.get_running_loop().time() < deadline:
             if service.process.returncode is not None:
                 raise RuntimeError(
                     f"managed service 启动失败: exit={service.process.returncode}"
                 )
-            if not readiness_url or await asyncio.to_thread(
+            if await asyncio.to_thread(
                 _url_ready,
                 readiness_url,
             ):

--- a/agent/plugins/service_host.py
+++ b/agent/plugins/service_host.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class _RunningService:
+    spec: dict[str, Any]
+    process: asyncio.subprocess.Process
+
+
+class PluginServiceHost:
+    def __init__(self) -> None:
+        self._bindings: dict[str, dict[str, dict[str, Any]]] = {}
+        self._running: dict[tuple[str, str], _RunningService] = {}
+
+    def bind_plugin_services(
+        self,
+        services: dict[str, dict[str, dict[str, Any]]],
+    ) -> None:
+        self._bindings = {
+            plugin_id: dict(plugin_services)
+            for plugin_id, plugin_services in services.items()
+        }
+
+    async def start_all(self) -> None:
+        started: list[tuple[str, str]] = []
+        try:
+            for plugin_id, services in sorted(self._bindings.items()):
+                for service_id, spec in sorted(services.items()):
+                    await self._start(plugin_id, service_id, spec)
+                    started.append((plugin_id, service_id))
+        except BaseException:
+            for key in reversed(started):
+                await self._stop(*key)
+            raise
+
+    async def stop_all(self) -> None:
+        errors: list[str] = []
+        for plugin_id, service_id in reversed(tuple(self._running)):
+            try:
+                await self._stop(plugin_id, service_id)
+            except Exception as error:
+                errors.append(f"{plugin_id}:{service_id}: {error}")
+        if errors:
+            raise RuntimeError("managed service 停止失败: " + "; ".join(errors))
+
+    async def swap_plugin_services(
+        self,
+        plugin_id: str,
+        old_services: dict[str, dict[str, Any]],
+        new_services: dict[str, dict[str, Any]],
+    ) -> None:
+        if self._bindings.get(plugin_id, {}) != old_services:
+            raise RuntimeError(f"插件 managed service 代际不一致: {plugin_id}")
+        changed = {
+            service_id
+            for service_id in old_services.keys() | new_services.keys()
+            if old_services.get(service_id) != new_services.get(service_id)
+        }
+        stopped: list[str] = []
+        try:
+            for service_id in sorted(changed.intersection(old_services), reverse=True):
+                await self._stop(plugin_id, service_id)
+                stopped.append(service_id)
+        except BaseException as stop_error:
+            restore_errors = await self._restore(plugin_id, old_services, stopped)
+            if restore_errors:
+                raise RuntimeError(
+                    "旧 managed service 恢复失败: " + "; ".join(restore_errors)
+                ) from stop_error
+            raise
+
+        started: list[str] = []
+        try:
+            for service_id in sorted(changed.intersection(new_services)):
+                await self._start(plugin_id, service_id, new_services[service_id])
+                started.append(service_id)
+        except BaseException as start_error:
+            for service_id in reversed(started):
+                await self._stop(plugin_id, service_id)
+            restore_errors = await self._restore(plugin_id, old_services, stopped)
+            if restore_errors:
+                raise RuntimeError(
+                    "旧 managed service 恢复失败: " + "; ".join(restore_errors)
+                ) from start_error
+            raise
+        self._bindings[plugin_id] = dict(new_services)
+
+    async def _restore(
+        self,
+        plugin_id: str,
+        services: dict[str, dict[str, Any]],
+        service_ids: list[str],
+    ) -> list[str]:
+        errors: list[str] = []
+        for service_id in reversed(service_ids):
+            try:
+                await self._start(plugin_id, service_id, services[service_id])
+            except Exception as error:
+                errors.append(f"{service_id}: {error}")
+        return errors
+
+    async def _start(
+        self,
+        plugin_id: str,
+        service_id: str,
+        spec: dict[str, Any],
+    ) -> None:
+        key = (plugin_id, service_id)
+        if key in self._running:
+            raise RuntimeError(f"managed service 已运行: {plugin_id}:{service_id}")
+        process = await asyncio.create_subprocess_exec(
+            *spec["command"],
+            cwd=spec["cwd"],
+            env={**os.environ, **spec["env"]},
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        running = _RunningService(spec=spec, process=process)
+        self._running[key] = running
+        try:
+            await self._wait_ready(running)
+        except BaseException:
+            await self._stop(plugin_id, service_id)
+            raise
+
+    async def _wait_ready(self, service: _RunningService) -> None:
+        timeout = float(service.spec["startup_timeout_seconds"])
+        deadline = asyncio.get_running_loop().time() + timeout
+        readiness_url = str(service.spec.get("readiness_url") or "")
+        while asyncio.get_running_loop().time() < deadline:
+            if service.process.returncode is not None:
+                raise RuntimeError(
+                    f"managed service 启动失败: exit={service.process.returncode}"
+                )
+            if not readiness_url or await asyncio.to_thread(
+                _url_ready,
+                readiness_url,
+            ):
+                return
+            await asyncio.sleep(0.1)
+        raise RuntimeError("managed service 启动超时")
+
+    async def _stop(self, plugin_id: str, service_id: str) -> None:
+        running = self._running.get((plugin_id, service_id))
+        if running is None:
+            return
+        process = running.process
+        if process.returncode is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                _ = await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                _ = await process.wait()
+        _ = self._running.pop((plugin_id, service_id), None)
+
+
+def _url_ready(url: str) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=1):
+            return True
+    except OSError:
+        return False

--- a/agent/plugins/service_host.py
+++ b/agent/plugins/service_host.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
@@ -65,8 +66,11 @@ class PluginServiceHost:
         stopped: list[str] = []
         try:
             for service_id in sorted(changed.intersection(old_services), reverse=True):
-                await self._stop(plugin_id, service_id)
-                stopped.append(service_id)
+                try:
+                    await self._stop(plugin_id, service_id)
+                finally:
+                    if (plugin_id, service_id) not in self._running:
+                        stopped.append(service_id)
         except BaseException as stop_error:
             restore_errors = await self._restore(plugin_id, old_services, stopped)
             if restore_errors:
@@ -114,12 +118,18 @@ class PluginServiceHost:
         key = (plugin_id, service_id)
         if key in self._running:
             raise RuntimeError(f"managed service 已运行: {plugin_id}:{service_id}")
+        readiness_url = str(spec.get("readiness_url") or "")
+        if readiness_url and await asyncio.to_thread(_url_ready, readiness_url):
+            raise RuntimeError(
+                f"managed service readiness endpoint 已被占用: {readiness_url}"
+            )
         process = await asyncio.create_subprocess_exec(
             *spec["command"],
             cwd=spec["cwd"],
             env={**os.environ, **spec["env"]},
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=os.name != "nt",
         )
         running = _RunningService(spec=spec, process=process)
         self._running[key] = running
@@ -142,6 +152,11 @@ class PluginServiceHost:
                 _url_ready,
                 readiness_url,
             ):
+                await asyncio.sleep(0)
+                if service.process.returncode is not None:
+                    raise RuntimeError(
+                        f"managed service 启动失败: exit={service.process.returncode}"
+                    )
                 return
             await asyncio.sleep(0.1)
         raise RuntimeError("managed service 启动超时")
@@ -150,21 +165,27 @@ class PluginServiceHost:
         running = self._running.get((plugin_id, service_id))
         if running is None:
             return
-        process = running.process
-        if process.returncode is None:
+        key = (plugin_id, service_id)
+
+        async def reap() -> None:
+            process = running.process
             try:
-                process.terminate()
-            except ProcessLookupError:
-                pass
-            try:
-                _ = await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                try:
-                    process.kill()
-                except ProcessLookupError:
-                    pass
-                _ = await process.wait()
-        _ = self._running.pop((plugin_id, service_id), None)
+                if process.returncode is None:
+                    _signal_process(process, signal.SIGTERM)
+                    try:
+                        _ = await asyncio.wait_for(process.wait(), timeout=5)
+                    except TimeoutError:
+                        _signal_process(process, signal.SIGKILL)
+                        _ = await process.wait()
+            finally:
+                _ = self._running.pop(key, None)
+
+        task = asyncio.create_task(reap(), name=f"stop_service:{plugin_id}:{service_id}")
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _ = await task
+            raise
 
 
 def _url_ready(url: str) -> bool:
@@ -173,3 +194,16 @@ def _url_ready(url: str) -> bool:
             return True
     except OSError:
         return False
+
+
+def _signal_process(process: asyncio.subprocess.Process, sig: signal.Signals) -> None:
+    try:
+        if os.name == "nt":
+            if sig == signal.SIGTERM:
+                process.terminate()
+            else:
+                process.kill()
+        else:
+            os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -82,6 +82,7 @@ class PluginSkillHost:
                 workspace,
                 plugin_roots=frozen_normal,
                 ignored_workspace_symlink_roots=ignored_normal_roots,
+                runtime_catalog=None,
             ).build_index()
             drift = SkillsLoader(
                 workspace,
@@ -89,6 +90,7 @@ class PluginSkillHost:
                 workspace_skills_dir=workspace / "drift" / "skills",
                 plugin_roots=frozen_drift,
                 ignored_workspace_symlink_roots=ignored_drift_roots,
+                runtime_catalog=None,
             ).build_index()
             normal = self._freeze_index(snapshot_root / "selected-normal", normal)
             drift = self._freeze_index(snapshot_root / "selected-drift", drift)

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path
+import shutil
+import tempfile
 from typing import TYPE_CHECKING
 
 from agent.skills import SkillIndex, SkillsLoader
@@ -13,6 +16,7 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class PreparedSkillCatalog:
     generation_id: str
+    snapshot_root: Path
     normal: SkillIndex
     drift: SkillIndex
 
@@ -32,30 +36,40 @@ class PluginSkillHost:
         *,
         normal_roots: dict[str, tuple[Path, ...]],
         drift_roots: dict[str, tuple[Path, ...]],
+        ignored_normal_roots: tuple[Path, ...],
+        ignored_drift_roots: tuple[Path, ...],
     ) -> PreparedSkillCatalog:
         self._validate_unique_names(normal_roots)
         self._validate_unique_names(drift_roots)
         workspace = self._workspace or Path("/__akashic_no_workspace__")
-        normal_targets = tuple(
-            root for roots in normal_roots.values() for root in roots
-        )
-        drift_targets = tuple(
-            root for roots in drift_roots.values() for root in roots
-        )
-        normal = SkillsLoader(
-            workspace,
-            plugin_roots=normal_roots,
-            ignored_workspace_symlink_roots=normal_targets,
-        ).build_index()
-        drift = SkillsLoader(
-            workspace,
-            builtin_skills_dir=None,
-            workspace_skills_dir=workspace / "drift" / "skills",
-            plugin_roots=drift_roots,
-            ignored_workspace_symlink_roots=drift_targets,
-        ).build_index()
+        snapshot_root = Path(tempfile.mkdtemp(prefix="akashic-skill-catalog-"))
+        try:
+            frozen_normal = self._snapshot_roots(
+                snapshot_root / "normal",
+                normal_roots,
+            )
+            frozen_drift = self._snapshot_roots(
+                snapshot_root / "drift",
+                drift_roots,
+            )
+            normal = SkillsLoader(
+                workspace,
+                plugin_roots=frozen_normal,
+                ignored_workspace_symlink_roots=ignored_normal_roots,
+            ).build_index()
+            drift = SkillsLoader(
+                workspace,
+                builtin_skills_dir=None,
+                workspace_skills_dir=workspace / "drift" / "skills",
+                plugin_roots=frozen_drift,
+                ignored_workspace_symlink_roots=ignored_drift_roots,
+            ).build_index()
+        except BaseException:
+            shutil.rmtree(snapshot_root)
+            raise
         catalog = PreparedSkillCatalog(
             generation_id=generation_id,
+            snapshot_root=snapshot_root,
             normal=normal,
             drift=drift,
         )
@@ -66,7 +80,9 @@ class PluginSkillHost:
         return self._catalogs.get(generation_id)
 
     def close(self, generation_id: str) -> None:
-        _ = self._catalogs.pop(generation_id, None)
+        catalog = self._catalogs.pop(generation_id, None)
+        if catalog is not None:
+            shutil.rmtree(catalog.snapshot_root)
 
     @staticmethod
     def roots_for(
@@ -99,3 +115,19 @@ class PluginSkillHost:
                             f"插件 Skill 名称重复: {skill_dir.name} ({owner}, {plugin_id})"
                         )
                     owners[skill_dir.name] = plugin_id
+
+    @staticmethod
+    def _snapshot_roots(
+        snapshot_dir: Path,
+        plugin_roots: dict[str, tuple[Path, ...]],
+    ) -> dict[str, tuple[Path, ...]]:
+        frozen: dict[str, tuple[Path, ...]] = {}
+        for plugin_id, roots in sorted(plugin_roots.items()):
+            owner = hashlib.sha256(plugin_id.encode()).hexdigest()[:12]
+            copies: list[Path] = []
+            for index, root in enumerate(roots):
+                target = snapshot_dir / owner / str(index)
+                _ = shutil.copytree(root, target)
+                copies.append(target)
+            frozen[plugin_id] = tuple(copies)
+        return frozen

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent.skills import SkillIndex, SkillsLoader
+
+if TYPE_CHECKING:
+    from agent.plugins.generation import PluginGeneration
+
+
+@dataclass(frozen=True)
+class PreparedSkillCatalog:
+    generation_id: str
+    normal: SkillIndex
+    drift: SkillIndex
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted({*self.normal.records, *self.drift.records}))
+
+
+class PluginSkillHost:
+    def __init__(self, workspace: Path | None) -> None:
+        self._workspace = workspace
+        self._catalogs: dict[str, PreparedSkillCatalog] = {}
+
+    def prepare(
+        self,
+        generation_id: str,
+        *,
+        normal_roots: dict[str, tuple[Path, ...]],
+        drift_roots: dict[str, tuple[Path, ...]],
+    ) -> PreparedSkillCatalog:
+        self._validate_unique_names(normal_roots)
+        self._validate_unique_names(drift_roots)
+        workspace = self._workspace or Path("/__akashic_no_workspace__")
+        normal = SkillsLoader(
+            workspace,
+            plugin_roots=normal_roots,
+            ignore_workspace_symlinks=True,
+        ).build_index()
+        drift = SkillsLoader(
+            workspace,
+            builtin_skills_dir=None,
+            workspace_skills_dir=workspace / "drift" / "skills",
+            plugin_roots=drift_roots,
+            ignore_workspace_symlinks=True,
+        ).build_index()
+        catalog = PreparedSkillCatalog(
+            generation_id=generation_id,
+            normal=normal,
+            drift=drift,
+        )
+        self._catalogs[generation_id] = catalog
+        return catalog
+
+    def get(self, generation_id: str) -> PreparedSkillCatalog | None:
+        return self._catalogs.get(generation_id)
+
+    def close(self, generation_id: str) -> None:
+        _ = self._catalogs.pop(generation_id, None)
+
+    @staticmethod
+    def roots_for(
+        generations: list[PluginGeneration],
+        *,
+        drift: bool,
+    ) -> dict[str, tuple[Path, ...]]:
+        return {
+            generation.plugin_id: (
+                generation.contributions.drift_skill_roots
+                if drift
+                else generation.contributions.skill_roots
+            )
+            for generation in generations
+        }
+
+    @staticmethod
+    def _validate_unique_names(
+        plugin_roots: dict[str, tuple[Path, ...]],
+    ) -> None:
+        owners: dict[str, str] = {}
+        for plugin_id, roots in sorted(plugin_roots.items()):
+            for root in roots:
+                for skill_dir in sorted(root.iterdir()):
+                    if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").is_file():
+                        continue
+                    owner = owners.get(skill_dir.name)
+                    if owner is not None:
+                        raise RuntimeError(
+                            f"插件 Skill 名称重复: {skill_dir.name} ({owner}, {plugin_id})"
+                        )
+                    owners[skill_dir.name] = plugin_id

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import hashlib
 from pathlib import Path
 import shutil
 import tempfile
+import weakref
 from typing import TYPE_CHECKING
 
-from agent.skills import SkillIndex, SkillsLoader
+from agent.skills import SkillIndex, SkillRecord, SkillsLoader
 
 if TYPE_CHECKING:
     from agent.plugins.generation import PluginGeneration
@@ -16,13 +17,31 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class PreparedSkillCatalog:
     generation_id: str
-    snapshot_root: Path
+    snapshot: SkillSnapshot
     normal: SkillIndex
     drift: SkillIndex
 
     @property
     def names(self) -> tuple[str, ...]:
         return tuple(sorted({*self.normal.records, *self.drift.records}))
+
+    @property
+    def snapshot_root(self) -> Path:
+        return self.snapshot.root
+
+
+class SkillSnapshot:
+    def __init__(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="akashic-skill-catalog-"))
+        self._finalizer = weakref.finalize(
+            self,
+            shutil.rmtree,
+            self.root,
+            True,
+        )
+
+    def cleanup(self) -> None:
+        _ = self._finalizer()
 
 
 class PluginSkillHost:
@@ -42,7 +61,8 @@ class PluginSkillHost:
         self._validate_unique_names(normal_roots)
         self._validate_unique_names(drift_roots)
         workspace = self._workspace or Path("/__akashic_no_workspace__")
-        snapshot_root = Path(tempfile.mkdtemp(prefix="akashic-skill-catalog-"))
+        snapshot = SkillSnapshot()
+        snapshot_root = snapshot.root
         try:
             frozen_normal = self._snapshot_roots(
                 snapshot_root / "normal",
@@ -64,12 +84,14 @@ class PluginSkillHost:
                 plugin_roots=frozen_drift,
                 ignored_workspace_symlink_roots=ignored_drift_roots,
             ).build_index()
+            normal = self._freeze_index(snapshot_root / "selected-normal", normal)
+            drift = self._freeze_index(snapshot_root / "selected-drift", drift)
         except BaseException:
-            shutil.rmtree(snapshot_root)
+            snapshot.cleanup()
             raise
         catalog = PreparedSkillCatalog(
             generation_id=generation_id,
-            snapshot_root=snapshot_root,
+            snapshot=snapshot,
             normal=normal,
             drift=drift,
         )
@@ -82,7 +104,7 @@ class PluginSkillHost:
     def close(self, generation_id: str) -> None:
         catalog = self._catalogs.pop(generation_id, None)
         if catalog is not None:
-            shutil.rmtree(catalog.snapshot_root)
+            catalog.snapshot.cleanup()
 
     @staticmethod
     def roots_for(
@@ -131,3 +153,17 @@ class PluginSkillHost:
                 copies.append(target)
             frozen[plugin_id] = tuple(copies)
         return frozen
+
+    @staticmethod
+    def _freeze_index(snapshot_dir: Path, index: SkillIndex) -> SkillIndex:
+        records: dict[str, SkillRecord] = {}
+        for position, (name, record) in enumerate(sorted(index.records.items())):
+            key = hashlib.sha256(f"{position}:{name}".encode()).hexdigest()[:12]
+            target = snapshot_dir / key
+            _ = shutil.copytree(record.root_dir, target)
+            records[name] = replace(
+                record,
+                root_dir=target,
+                skill_file=target / "SKILL.md",
+            )
+        return SkillIndex(records)

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -41,7 +41,13 @@ class SkillSnapshot:
         )
 
     def cleanup(self) -> None:
-        _ = self._finalizer()
+        if not self._finalizer.alive:
+            return
+        try:
+            shutil.rmtree(self.root)
+        except FileNotFoundError:
+            pass
+        _ = self._finalizer.detach()
 
 
 class PluginSkillHost:

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -20,6 +20,7 @@ class PreparedSkillCatalog:
     snapshot: SkillSnapshot
     normal: SkillIndex
     drift: SkillIndex
+    normal_plugins: SkillIndex
 
     @property
     def names(self) -> tuple[str, ...]:
@@ -92,8 +93,19 @@ class PluginSkillHost:
                 ignored_workspace_symlink_roots=ignored_drift_roots,
                 runtime_catalog=None,
             ).build_index()
+            normal_plugins = SkillsLoader(
+                workspace,
+                builtin_skills_dir=None,
+                workspace_skills_dir=snapshot_root / "no-workspace-skills",
+                plugin_roots=frozen_normal,
+                runtime_catalog=None,
+            ).build_index()
             normal = self._freeze_index(snapshot_root / "selected-normal", normal)
             drift = self._freeze_index(snapshot_root / "selected-drift", drift)
+            normal_plugins = self._freeze_index(
+                snapshot_root / "selected-normal-plugins",
+                normal_plugins,
+            )
         except BaseException:
             snapshot.cleanup()
             raise
@@ -102,6 +114,7 @@ class PluginSkillHost:
             snapshot=snapshot,
             normal=normal,
             drift=drift,
+            normal_plugins=normal_plugins,
         )
         self._catalogs[generation_id] = catalog
         return catalog

--- a/agent/plugins/skill_host.py
+++ b/agent/plugins/skill_host.py
@@ -36,17 +36,23 @@ class PluginSkillHost:
         self._validate_unique_names(normal_roots)
         self._validate_unique_names(drift_roots)
         workspace = self._workspace or Path("/__akashic_no_workspace__")
+        normal_targets = tuple(
+            root for roots in normal_roots.values() for root in roots
+        )
+        drift_targets = tuple(
+            root for roots in drift_roots.values() for root in roots
+        )
         normal = SkillsLoader(
             workspace,
             plugin_roots=normal_roots,
-            ignore_workspace_symlinks=True,
+            ignored_workspace_symlink_roots=normal_targets,
         ).build_index()
         drift = SkillsLoader(
             workspace,
             builtin_skills_dir=None,
             workspace_skills_dir=workspace / "drift" / "skills",
             plugin_roots=drift_roots,
-            ignore_workspace_symlinks=True,
+            ignored_workspace_symlink_roots=drift_targets,
         ).build_index()
         catalog = PreparedSkillCatalog(
             generation_id=generation_id,

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -13,6 +13,7 @@ from agent.plugins.generation import PluginGeneration
 from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
 from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
 from agent.tools.registry import ToolRegistry
+from agent.skills import SkillIndex
 
 
 SnapshotState = Literal[
@@ -39,6 +40,8 @@ class RuntimeSnapshot:
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
     tool_registry: ToolRegistry | None = None
+    normal_skill_index: SkillIndex | None = None
+    drift_skill_index: SkillIndex | None = None
     state: SnapshotState = "compiled"
     lease_count: int = 0
     _store_token: object | None = field(default=None, repr=False)
@@ -129,6 +132,16 @@ class RuntimeSnapshotCompiler:
                 else None
             ),
             mcp_catalog_generation_ids=MappingProxyType(mcp_catalogs),
+            normal_skill_index=(
+                catalog_owner.skill_catalog.normal
+                if catalog_owner is not None and catalog_owner.skill_catalog is not None
+                else None
+            ),
+            drift_skill_index=(
+                catalog_owner.skill_catalog.drift
+                if catalog_owner is not None and catalog_owner.skill_catalog is not None
+                else None
+            ),
             before_turn_modules=phases["before_turn_modules"],
             before_reasoning_modules=phases["before_reasoning_modules"],
             prompt_render_modules=phases["prompt_render_modules"],

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -59,6 +59,7 @@ class RuntimeSnapshot:
     )
     state: SnapshotState = "compiled"
     lease_count: int = 0
+    accepting_leases: bool = True
     _store_token: object | None = field(default=None, repr=False)
 
     def claim(self, store_token: object) -> None:
@@ -345,6 +346,7 @@ class RuntimeSnapshotStore:
         self._pending: SnapshotTransaction | None = None
         self._on_drained = on_drained
         self._token = object()
+        self._condition = asyncio.Condition()
 
     @property
     def current(self) -> RuntimeSnapshot | None:
@@ -378,7 +380,12 @@ class RuntimeSnapshotStore:
         self._current = snapshot
         self._snapshots[snapshot.snapshot_id] = snapshot
 
-    def begin_publish(self, candidate: RuntimeSnapshot) -> SnapshotTransaction:
+    def begin_publish(
+        self,
+        candidate: RuntimeSnapshot,
+        *,
+        admission_gated: bool = False,
+    ) -> SnapshotTransaction:
         if self._pending is not None:
             raise RuntimeError("已有 RuntimeSnapshot 发布事务")
         if candidate.snapshot_id in self._snapshots:
@@ -386,6 +393,7 @@ class RuntimeSnapshotStore:
         self._adopt(candidate)
         transaction = SnapshotTransaction(previous=self._current, candidate=candidate)
         candidate.state = "published_pending"
+        candidate.accepting_leases = not admission_gated
         self._snapshots[candidate.snapshot_id] = candidate
         self._current = candidate
         self._pending = transaction
@@ -394,18 +402,75 @@ class RuntimeSnapshotStore:
     async def commit(self, transaction: SnapshotTransaction) -> None:
         self._require_pending(transaction)
         transaction.candidate.state = "committed"
+        transaction.candidate.accepting_leases = True
         self._pending = None
         previous = transaction.previous
         if previous is not None:
             previous.state = "retired"
             await self._drain_if_ready(previous)
+        async with self._condition:
+            self._condition.notify_all()
 
     async def abort(self, transaction: SnapshotTransaction) -> None:
         self._require_pending(transaction)
         transaction.candidate.state = "aborted"
+        transaction.candidate.accepting_leases = False
         self._current = transaction.previous
+        if transaction.previous is not None:
+            transaction.previous.accepting_leases = True
         self._pending = None
         await self._drain_if_ready(transaction.candidate)
+        async with self._condition:
+            self._condition.notify_all()
+
+    async def quiesce_current(self) -> RuntimeSnapshot | None:
+        snapshot = self.pause_admission()
+        if snapshot is None:
+            return None
+        try:
+            await self.wait_for_no_leases(snapshot)
+        except BaseException:
+            await self.resume(snapshot)
+            raise
+        return snapshot
+
+    def pause_admission(self) -> RuntimeSnapshot | None:
+        snapshot = self._current
+        if snapshot is not None:
+            snapshot.accepting_leases = False
+        return snapshot
+
+    async def wait_for_no_leases(self, snapshot: RuntimeSnapshot) -> None:
+        async with self._condition:
+            while snapshot.lease_count:
+                await self._condition.wait()
+
+    async def resume(self, snapshot: RuntimeSnapshot | None) -> None:
+        if snapshot is None:
+            return
+        if self._current is snapshot and snapshot.state == "committed":
+            snapshot.accepting_leases = True
+        async with self._condition:
+            self._condition.notify_all()
+
+    async def acquire(
+        self,
+        snapshot_id: str | None = None,
+    ) -> RuntimeSnapshotLease:
+        async with self._condition:
+            while True:
+                snapshot = (
+                    self._current
+                    if snapshot_id is None
+                    else self._snapshots.get(snapshot_id)
+                )
+                if snapshot is None:
+                    raise RuntimeError("RuntimeSnapshot 不可用")
+                if snapshot.state not in {"published_pending", "committed"}:
+                    raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
+                if snapshot.accepting_leases:
+                    return self._claim_lease(snapshot)
+                await self._condition.wait()
 
     async def close(self) -> None:
         if self._pending is not None:
@@ -434,6 +499,11 @@ class RuntimeSnapshotStore:
             raise RuntimeError("RuntimeSnapshot 不可用")
         if snapshot.state not in {"published_pending", "committed"}:
             raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
+        if not snapshot.accepting_leases:
+            raise RuntimeError("RuntimeSnapshot 暂停接收新 lease")
+        return self._claim_lease(snapshot)
+
+    def _claim_lease(self, snapshot: RuntimeSnapshot) -> RuntimeSnapshotLease:
         snapshot.lease_count += 1
         for generation in snapshot.generations.values():
             generation.lease_count += 1
@@ -454,6 +524,8 @@ class RuntimeSnapshotStore:
         snapshot.lease_count -= 1
         for generation in snapshot.generations.values():
             generation.lease_count -= 1
+        async with self._condition:
+            self._condition.notify_all()
         await self._drain_if_ready(snapshot)
 
     async def _drain_if_ready(self, snapshot: RuntimeSnapshot) -> None:

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -97,6 +97,7 @@ class RuntimeSnapshotCompiler:
         generations: Mapping[str, PluginGeneration],
         *,
         catalog_generation: PluginGeneration | None = None,
+        snapshot_revision: str = "",
     ) -> RuntimeSnapshot:
         ordered = [generations[key] for key in sorted(generations)]
         if any(generation.plugin_id != key for key, generation in generations.items()):
@@ -170,6 +171,7 @@ class RuntimeSnapshotCompiler:
             f"{plugin_id}:{generation_id}"
             for plugin_id, generation_id in sorted(mcp_catalogs.items())
         )
+        identity += f"|snapshot:{snapshot_revision}"
         snapshot_id = hashlib.sha256(identity.encode()).hexdigest()[:16]
         return RuntimeSnapshot(
             snapshot_id=snapshot_id,

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -14,6 +14,7 @@ from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
 from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
 from agent.tools.registry import ToolRegistry
 from agent.skills import SkillIndex
+from bus.event_bus import Handler
 
 
 SnapshotState = Literal[
@@ -41,6 +42,9 @@ class RuntimeSnapshot:
     mcp_catalog_generation_ids: Mapping[str, str]
     tool_registry: ToolRegistry | None = None
     plugin_skill_index: SkillIndex | None = None
+    event_handlers: Mapping[type[object], tuple[Handler[object], ...]] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
     state: SnapshotState = "compiled"
     lease_count: int = 0
     _store_token: object | None = field(default=None, repr=False)
@@ -208,6 +212,9 @@ class RuntimeSnapshotLease:
     def active(self) -> bool:
         return not self._released
 
+    def fork(self) -> RuntimeSnapshotLease:
+        return self._store.lease(self.snapshot.snapshot_id)
+
     async def __aenter__(self) -> RuntimeSnapshot:
         return self.snapshot
 
@@ -257,6 +264,17 @@ def get_current_runtime_snapshot() -> RuntimeSnapshot | None:
     ):
         return None
     return binding.lease.snapshot
+
+
+def lease_current_runtime_snapshot() -> RuntimeSnapshotLease | None:
+    binding = _current_runtime_binding.get()
+    if (
+        binding is None
+        or not binding.lease.active
+        or binding.owner_task is not asyncio.current_task()
+    ):
+        return None
+    return binding.lease.fork()
 
 
 class RuntimeSnapshotStore:

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -12,6 +12,7 @@ from agent.lifecycle.phase import topo_sort_modules
 from agent.plugins.generation import PluginGeneration
 from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
 from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
+from agent.tools.registry import ToolRegistry
 
 
 SnapshotState = Literal[
@@ -37,6 +38,7 @@ class RuntimeSnapshot:
     proactive_sources: Mapping[str, RegisteredProactiveSource]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
+    tool_registry: ToolRegistry | None = None
     state: SnapshotState = "compiled"
     lease_count: int = 0
     _store_token: object | None = field(default=None, repr=False)

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -343,6 +343,22 @@ class RuntimeSnapshotStore:
     def retained_snapshot_ids(self) -> tuple[str, ...]:
         return tuple(sorted(self._snapshots))
 
+    def generation_is_referenced_elsewhere(
+        self,
+        generation: PluginGeneration,
+        *,
+        excluding_snapshot_id: str,
+    ) -> bool:
+        return any(
+            snapshot.snapshot_id != excluding_snapshot_id
+            and (
+                snapshot.state in {"published_pending", "committed"}
+                or snapshot.lease_count > 0
+            )
+            and any(item is generation for item in snapshot.generations.values())
+            for snapshot in self._snapshots.values()
+        )
+
     def install(self, snapshot: RuntimeSnapshot) -> None:
         if self._current is not None or self._pending is not None:
             raise RuntimeError("RuntimeSnapshotStore 已安装初始快照")

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -20,9 +21,6 @@ SnapshotState = Literal[
     "aborted",
     "retired",
 ]
-
-current_runtime_snapshot: ContextVar[RuntimeSnapshot | None]
-
 
 @dataclass
 class RuntimeSnapshot:
@@ -47,9 +45,6 @@ class RuntimeSnapshot:
         if self.state != "compiled" or self.lease_count or self._store_token is not None:
             raise RuntimeError("RuntimeSnapshot 不是可发布的全新 compiled 快照")
         self._store_token = store_token
-
-
-current_runtime_snapshot = ContextVar("current_runtime_snapshot", default=None)
 
 
 @dataclass(frozen=True)
@@ -200,6 +195,10 @@ class RuntimeSnapshotLease:
         self.snapshot = snapshot
         self._released = False
 
+    @property
+    def active(self) -> bool:
+        return not self._released
+
     async def __aenter__(self) -> RuntimeSnapshot:
         return self.snapshot
 
@@ -211,6 +210,44 @@ class RuntimeSnapshotLease:
             return
         self._released = True
         await self._store.release_lease(self.snapshot)
+
+
+@dataclass(frozen=True)
+class _RuntimeSnapshotBinding:
+    lease: RuntimeSnapshotLease
+    owner_task: asyncio.Task[object] | None
+
+
+_current_runtime_binding: ContextVar[_RuntimeSnapshotBinding | None] = ContextVar(
+    "current_runtime_binding",
+    default=None,
+)
+
+
+def bind_runtime_snapshot(
+    lease: RuntimeSnapshotLease,
+) -> Token[_RuntimeSnapshotBinding | None]:
+    return _current_runtime_binding.set(
+        _RuntimeSnapshotBinding(
+            lease=lease,
+            owner_task=asyncio.current_task(),
+        )
+    )
+
+
+def reset_runtime_snapshot(token: Token[_RuntimeSnapshotBinding | None]) -> None:
+    _current_runtime_binding.reset(token)
+
+
+def get_current_runtime_snapshot() -> RuntimeSnapshot | None:
+    binding = _current_runtime_binding.get()
+    if (
+        binding is None
+        or not binding.lease.active
+        or binding.owner_task is not asyncio.current_task()
+    ):
+        return None
+    return binding.lease.snapshot
 
 
 class RuntimeSnapshotStore:

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+from contextvars import ContextVar
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Literal
+from typing import Literal, cast
 
 from agent.lifecycle.phase import topo_sort_modules
 from agent.plugins.generation import PluginGeneration
@@ -19,6 +20,8 @@ SnapshotState = Literal[
     "aborted",
     "retired",
 ]
+
+current_runtime_snapshot: ContextVar[RuntimeSnapshot | None]
 
 
 @dataclass
@@ -46,10 +49,20 @@ class RuntimeSnapshot:
         self._store_token = store_token
 
 
+current_runtime_snapshot = ContextVar("current_runtime_snapshot", default=None)
+
+
 @dataclass(frozen=True)
 class SnapshotTransaction:
     previous: RuntimeSnapshot | None
     candidate: RuntimeSnapshot
+
+
+@dataclass(frozen=True)
+class _SnapshotModuleOrder:
+    module: object
+    slot: str
+    requires: tuple[str, ...]
 
 
 class RuntimeSnapshotCompiler:
@@ -79,7 +92,7 @@ class RuntimeSnapshotCompiler:
                 for generation in ordered
                 for module in getattr(generation.contributions, field_name)
             )
-            phases[field_name] = tuple(topo_sort_modules(list(modules)))
+            phases[field_name] = self._order_plugin_modules(modules)
         jobs = self._compile_jobs(ordered)
         sources = self._compile_sources(ordered)
         catalog_owner = catalog_generation or next(
@@ -127,6 +140,28 @@ class RuntimeSnapshotCompiler:
             after_reasoning_modules=phases["after_reasoning_modules"],
             after_turn_modules=phases["after_turn_modules"],
         )
+
+    @staticmethod
+    def _order_plugin_modules(modules: tuple[object, ...]) -> tuple[object, ...]:
+        slots = {
+            str(slot)
+            for slot in (getattr(module, "slot", None) for module in modules)
+            if isinstance(slot, str) and slot
+        }
+        bindings = [
+            _SnapshotModuleOrder(
+                module=module,
+                slot=str(getattr(module, "slot", "")),
+                requires=tuple(
+                    str(required)
+                    for required in getattr(module, "requires", ())
+                    if str(required) in slots
+                ),
+            )
+            for module in modules
+        ]
+        ordered = cast(list[_SnapshotModuleOrder], topo_sort_modules(bindings))
+        return tuple(binding.module for binding in ordered)
 
     @staticmethod
     def _compile_jobs(

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -48,6 +48,7 @@ class RuntimeSnapshot:
     channels: Mapping[str, Channel]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
+    dashboard_bindings: tuple[object, ...] = ()
     tool_registry: ToolRegistry | None = None
     plugin_skill_index: SkillIndex | None = None
     event_handlers: Mapping[type[object], tuple[Handler[object], ...]] = field(

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -526,9 +526,18 @@ class RuntimeSnapshotStore:
         snapshot.lease_count -= 1
         for generation in snapshot.generations.values():
             generation.lease_count -= 1
+        await self._drain_if_ready(snapshot)
         async with self._condition:
             self._condition.notify_all()
-        await self._drain_if_ready(snapshot)
+
+    async def wait_for_generation_drained(
+        self,
+        generation: PluginGeneration,
+    ) -> None:
+        async with self._condition:
+            while generation.lease_count:
+                await self._condition.wait()
+        await self.retry_drains()
 
     async def _drain_if_ready(self, snapshot: RuntimeSnapshot) -> None:
         if snapshot.state not in {"retired", "aborted"} or snapshot.lease_count:

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+from agent.lifecycle.phase import topo_sort_modules
+from agent.plugins.generation import PluginGeneration
+from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
+from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
+
+
+SnapshotState = Literal[
+    "compiled",
+    "published_pending",
+    "committed",
+    "aborted",
+    "retired",
+]
+
+
+@dataclass
+class RuntimeSnapshot:
+    snapshot_id: str
+    generations: Mapping[str, PluginGeneration]
+    before_turn_modules: tuple[object, ...]
+    before_reasoning_modules: tuple[object, ...]
+    prompt_render_modules: tuple[object, ...]
+    before_step_modules: tuple[object, ...]
+    after_step_modules: tuple[object, ...]
+    after_reasoning_modules: tuple[object, ...]
+    after_turn_modules: tuple[object, ...]
+    jobs: Mapping[str, RegisteredPluginJob]
+    proactive_sources: Mapping[str, RegisteredProactiveSource]
+    skill_catalog_generation_id: str | None
+    mcp_catalog_generation_ids: Mapping[str, str]
+    state: SnapshotState = "compiled"
+    lease_count: int = 0
+
+
+@dataclass(frozen=True)
+class SnapshotTransaction:
+    previous: RuntimeSnapshot | None
+    candidate: RuntimeSnapshot
+
+
+class RuntimeSnapshotCompiler:
+    _PHASE_FIELDS = (
+        "before_turn_modules",
+        "before_reasoning_modules",
+        "prompt_render_modules",
+        "before_step_modules",
+        "after_step_modules",
+        "after_reasoning_modules",
+        "after_turn_modules",
+    )
+
+    def compile(
+        self,
+        generations: Mapping[str, PluginGeneration],
+        *,
+        catalog_generation: PluginGeneration | None = None,
+    ) -> RuntimeSnapshot:
+        ordered = [generations[key] for key in sorted(generations)]
+        if any(generation.plugin_id != key for key, generation in generations.items()):
+            raise RuntimeError("RuntimeSnapshot generation key 与 plugin_id 不一致")
+        phases: dict[str, tuple[object, ...]] = {}
+        for field_name in self._PHASE_FIELDS:
+            modules = tuple(
+                module
+                for generation in ordered
+                for module in getattr(generation.contributions, field_name)
+            )
+            _ = topo_sort_modules(list(modules))
+            phases[field_name] = modules
+        jobs = self._compile_jobs(ordered)
+        sources = self._compile_sources(ordered)
+        catalog_owner = catalog_generation or next(
+            (generation for generation in reversed(ordered) if generation.skill_catalog),
+            None,
+        )
+        mcp_catalogs = {
+            generation.plugin_id: generation.mcp_catalog.generation_id
+            for generation in ordered
+            if generation.mcp_catalog is not None
+        }
+        identity = "|".join(
+            f"{generation.plugin_id}:{generation.generation_id}:"
+            f"{generation.source_revision}:{generation.config_revision}"
+            for generation in ordered
+        )
+        snapshot_id = hashlib.sha256(identity.encode()).hexdigest()[:16]
+        return RuntimeSnapshot(
+            snapshot_id=snapshot_id,
+            generations=MappingProxyType(dict(generations)),
+            jobs=MappingProxyType(jobs),
+            proactive_sources=MappingProxyType(sources),
+            skill_catalog_generation_id=(
+                catalog_owner.skill_catalog.generation_id
+                if catalog_owner is not None and catalog_owner.skill_catalog is not None
+                else None
+            ),
+            mcp_catalog_generation_ids=MappingProxyType(mcp_catalogs),
+            before_turn_modules=phases["before_turn_modules"],
+            before_reasoning_modules=phases["before_reasoning_modules"],
+            prompt_render_modules=phases["prompt_render_modules"],
+            before_step_modules=phases["before_step_modules"],
+            after_step_modules=phases["after_step_modules"],
+            after_reasoning_modules=phases["after_reasoning_modules"],
+            after_turn_modules=phases["after_turn_modules"],
+        )
+
+    @staticmethod
+    def _compile_jobs(
+        generations: list[PluginGeneration],
+    ) -> dict[str, RegisteredPluginJob]:
+        jobs: dict[str, RegisteredPluginJob] = {}
+        for generation in generations:
+            catalog = generation.job_catalog
+            if catalog is None:
+                continue
+            for key, job in catalog.jobs.items():
+                if key in jobs or key != plugin_job_key(job):
+                    raise RuntimeError(f"RuntimeSnapshot Job 稳定键冲突: {key}")
+                jobs[key] = job
+        return jobs
+
+    @staticmethod
+    def _compile_sources(
+        generations: list[PluginGeneration],
+    ) -> dict[str, RegisteredProactiveSource]:
+        sources: dict[str, RegisteredProactiveSource] = {}
+        for generation in generations:
+            catalog = generation.proactive_catalog
+            if catalog is None:
+                continue
+            for key, source in catalog.sources.items():
+                if key in sources or key != proactive_source_key(source):
+                    raise RuntimeError(f"RuntimeSnapshot proactive 稳定键冲突: {key}")
+                sources[key] = source
+        return sources
+
+
+class RuntimeSnapshotLease:
+    def __init__(self, store: RuntimeSnapshotStore, snapshot: RuntimeSnapshot) -> None:
+        self._store = store
+        self.snapshot = snapshot
+        self._released = False
+
+    async def __aenter__(self) -> RuntimeSnapshot:
+        return self.snapshot
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.release()
+
+    async def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        await self._store.release_lease(self.snapshot)
+
+
+class RuntimeSnapshotStore:
+    def __init__(
+        self,
+        on_drained: Callable[[RuntimeSnapshot], Awaitable[None]] | None = None,
+    ) -> None:
+        self._current: RuntimeSnapshot | None = None
+        self._snapshots: dict[str, RuntimeSnapshot] = {}
+        self._pending: SnapshotTransaction | None = None
+        self._on_drained = on_drained
+
+    @property
+    def current(self) -> RuntimeSnapshot | None:
+        return self._current
+
+    def install(self, snapshot: RuntimeSnapshot) -> None:
+        if self._current is not None or self._pending is not None:
+            raise RuntimeError("RuntimeSnapshotStore 已安装初始快照")
+        snapshot.state = "committed"
+        self._current = snapshot
+        self._snapshots[snapshot.snapshot_id] = snapshot
+
+    def begin_publish(self, candidate: RuntimeSnapshot) -> SnapshotTransaction:
+        if self._pending is not None:
+            raise RuntimeError("已有 RuntimeSnapshot 发布事务")
+        if candidate.snapshot_id in self._snapshots:
+            raise RuntimeError(f"RuntimeSnapshot 已存在: {candidate.snapshot_id}")
+        transaction = SnapshotTransaction(previous=self._current, candidate=candidate)
+        candidate.state = "published_pending"
+        self._snapshots[candidate.snapshot_id] = candidate
+        self._current = candidate
+        self._pending = transaction
+        return transaction
+
+    async def commit(self, transaction: SnapshotTransaction) -> None:
+        self._require_pending(transaction)
+        transaction.candidate.state = "committed"
+        self._pending = None
+        previous = transaction.previous
+        if previous is not None:
+            previous.state = "retired"
+            await self._drain_if_ready(previous)
+
+    async def abort(self, transaction: SnapshotTransaction) -> None:
+        self._require_pending(transaction)
+        transaction.candidate.state = "aborted"
+        self._current = transaction.previous
+        self._pending = None
+        await self._drain_if_ready(transaction.candidate)
+
+    async def close(self) -> None:
+        if self._pending is not None:
+            raise RuntimeError("RuntimeSnapshot 发布事务尚未结束")
+        current = self._current
+        self._current = None
+        if current is not None:
+            current.state = "retired"
+            await self._drain_if_ready(current)
+
+    def lease(self, snapshot_id: str | None = None) -> RuntimeSnapshotLease:
+        snapshot = (
+            self._current
+            if snapshot_id is None
+            else self._snapshots.get(snapshot_id)
+        )
+        if snapshot is None:
+            raise RuntimeError("RuntimeSnapshot 不可用")
+        if snapshot.state not in {"published_pending", "committed"}:
+            raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
+        snapshot.lease_count += 1
+        for generation in snapshot.generations.values():
+            generation.lease_count += 1
+        return RuntimeSnapshotLease(self, snapshot)
+
+    async def release_lease(self, snapshot: RuntimeSnapshot) -> None:
+        if snapshot.lease_count <= 0:
+            raise RuntimeError(f"RuntimeSnapshot lease 计数失衡: {snapshot.snapshot_id}")
+        snapshot.lease_count -= 1
+        for generation in snapshot.generations.values():
+            generation.lease_count -= 1
+        await self._drain_if_ready(snapshot)
+
+    async def _drain_if_ready(self, snapshot: RuntimeSnapshot) -> None:
+        if snapshot.state not in {"retired", "aborted"} or snapshot.lease_count:
+            return
+        _ = self._snapshots.pop(snapshot.snapshot_id, None)
+        if self._on_drained is not None:
+            await self._on_drained(snapshot)
+
+    def _require_pending(self, transaction: SnapshotTransaction) -> None:
+        if self._pending is not transaction or self._current is not transaction.candidate:
+            raise RuntimeError("RuntimeSnapshot 发布事务已失效")

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -48,6 +48,9 @@ class RuntimeSnapshot:
     channels: Mapping[str, Channel]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
+    managed_services: Mapping[str, Mapping[str, object]] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
     dashboard_bindings: tuple[object, ...] = ()
     tool_registry: ToolRegistry | None = None
     plugin_skill_index: SkillIndex | None = None
@@ -145,6 +148,13 @@ class RuntimeSnapshotCompiler:
             for generation in ordered
             if generation.mcp_catalog is not None
         }
+        managed_services = {
+            generation.plugin_id: MappingProxyType(
+                dict(generation.contributions.managed_services)
+            )
+            for generation in ordered
+            if generation.contributions.managed_services
+        }
         identity = "|".join(
             f"{generation.plugin_id}:{generation.generation_id}:"
             f"{generation.source_revision}:{generation.config_revision}"
@@ -177,6 +187,7 @@ class RuntimeSnapshotCompiler:
                 else None
             ),
             mcp_catalog_generation_ids=MappingProxyType(mcp_catalogs),
+            managed_services=MappingProxyType(managed_services),
             plugin_skill_index=(
                 catalog_owner.skill_catalog.normal_plugins
                 if catalog_owner is not None and catalog_owner.skill_catalog is not None

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Literal
 
@@ -38,6 +38,12 @@ class RuntimeSnapshot:
     mcp_catalog_generation_ids: Mapping[str, str]
     state: SnapshotState = "compiled"
     lease_count: int = 0
+    _store_token: object | None = field(default=None, repr=False)
+
+    def claim(self, store_token: object) -> None:
+        if self.state != "compiled" or self.lease_count or self._store_token is not None:
+            raise RuntimeError("RuntimeSnapshot 不是可发布的全新 compiled 快照")
+        self._store_token = store_token
 
 
 @dataclass(frozen=True)
@@ -73,14 +79,15 @@ class RuntimeSnapshotCompiler:
                 for generation in ordered
                 for module in getattr(generation.contributions, field_name)
             )
-            _ = topo_sort_modules(list(modules))
-            phases[field_name] = modules
+            phases[field_name] = tuple(topo_sort_modules(list(modules)))
         jobs = self._compile_jobs(ordered)
         sources = self._compile_sources(ordered)
         catalog_owner = catalog_generation or next(
             (generation for generation in reversed(ordered) if generation.skill_catalog),
             None,
         )
+        if catalog_owner is not None and generations.get(catalog_owner.plugin_id) is not catalog_owner:
+            raise RuntimeError("RuntimeSnapshot catalog owner 不属于 generations")
         mcp_catalogs = {
             generation.plugin_id: generation.mcp_catalog.generation_id
             for generation in ordered
@@ -90,6 +97,15 @@ class RuntimeSnapshotCompiler:
             f"{generation.plugin_id}:{generation.generation_id}:"
             f"{generation.source_revision}:{generation.config_revision}"
             for generation in ordered
+        )
+        identity += "|skill:" + (
+            catalog_owner.skill_catalog.generation_id
+            if catalog_owner is not None and catalog_owner.skill_catalog is not None
+            else ""
+        )
+        identity += "|mcp:" + "|".join(
+            f"{plugin_id}:{generation_id}"
+            for plugin_id, generation_id in sorted(mcp_catalogs.items())
         )
         snapshot_id = hashlib.sha256(identity.encode()).hexdigest()[:16]
         return RuntimeSnapshot(
@@ -171,14 +187,20 @@ class RuntimeSnapshotStore:
         self._snapshots: dict[str, RuntimeSnapshot] = {}
         self._pending: SnapshotTransaction | None = None
         self._on_drained = on_drained
+        self._token = object()
 
     @property
     def current(self) -> RuntimeSnapshot | None:
         return self._current
 
+    @property
+    def retained_snapshot_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._snapshots))
+
     def install(self, snapshot: RuntimeSnapshot) -> None:
         if self._current is not None or self._pending is not None:
             raise RuntimeError("RuntimeSnapshotStore 已安装初始快照")
+        self._adopt(snapshot)
         snapshot.state = "committed"
         self._current = snapshot
         self._snapshots[snapshot.snapshot_id] = snapshot
@@ -188,6 +210,7 @@ class RuntimeSnapshotStore:
             raise RuntimeError("已有 RuntimeSnapshot 发布事务")
         if candidate.snapshot_id in self._snapshots:
             raise RuntimeError(f"RuntimeSnapshot 已存在: {candidate.snapshot_id}")
+        self._adopt(candidate)
         transaction = SnapshotTransaction(previous=self._current, candidate=candidate)
         candidate.state = "published_pending"
         self._snapshots[candidate.snapshot_id] = candidate
@@ -214,6 +237,14 @@ class RuntimeSnapshotStore:
     async def close(self) -> None:
         if self._pending is not None:
             raise RuntimeError("RuntimeSnapshot 发布事务尚未结束")
+        leased = [
+            snapshot.snapshot_id
+            for snapshot in self._snapshots.values()
+            if snapshot.lease_count
+        ]
+        if leased:
+            raise RuntimeError(f"RuntimeSnapshot 仍有 lease: {', '.join(sorted(leased))}")
+        await self.retry_drains()
         current = self._current
         self._current = None
         if current is not None:
@@ -246,10 +277,17 @@ class RuntimeSnapshotStore:
     async def _drain_if_ready(self, snapshot: RuntimeSnapshot) -> None:
         if snapshot.state not in {"retired", "aborted"} or snapshot.lease_count:
             return
-        _ = self._snapshots.pop(snapshot.snapshot_id, None)
         if self._on_drained is not None:
             await self._on_drained(snapshot)
+        _ = self._snapshots.pop(snapshot.snapshot_id, None)
+
+    async def retry_drains(self) -> None:
+        for snapshot in tuple(self._snapshots.values()):
+            await self._drain_if_ready(snapshot)
 
     def _require_pending(self, transaction: SnapshotTransaction) -> None:
         if self._pending is not transaction or self._current is not transaction.candidate:
             raise RuntimeError("RuntimeSnapshot 发布事务已失效")
+
+    def _adopt(self, snapshot: RuntimeSnapshot) -> None:
+        snapshot.claim(self._token)

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -16,6 +16,7 @@ from agent.tools.registry import ToolRegistry
 from agent.tool_hooks import ToolHook
 from agent.skills import SkillIndex
 from bus.event_bus import Handler
+from infra.channels.contract import Channel
 
 
 SnapshotState = Literal[
@@ -44,6 +45,7 @@ class RuntimeSnapshot:
     proactive_module_factories: tuple[object, ...]
     proactive_runtime_factories: tuple[object, ...]
     tool_hooks: tuple[ToolHook, ...]
+    channels: Mapping[str, Channel]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
     tool_registry: ToolRegistry | None = None
@@ -124,6 +126,13 @@ class RuntimeSnapshotCompiler:
             for generation in ordered
             for factory in generation.contributions.proactive_runtime_factories
         )
+        channels: dict[str, Channel] = {}
+        for generation in ordered:
+            for channel in generation.contributions.channels:
+                name = str(channel.name).strip()
+                if not name or name in channels:
+                    raise RuntimeError(f"RuntimeSnapshot Channel 名称冲突: {name}")
+                channels[name] = channel
         catalog_owner = catalog_generation or next(
             (generation for generation in reversed(ordered) if generation.skill_catalog),
             None,
@@ -160,6 +169,7 @@ class RuntimeSnapshotCompiler:
             proactive_module_factories=proactive_module_factories,
             proactive_runtime_factories=proactive_runtime_factories,
             tool_hooks=(),
+            channels=MappingProxyType(channels),
             skill_catalog_generation_id=(
                 catalog_owner.skill_catalog.generation_id
                 if catalog_owner is not None and catalog_owner.skill_catalog is not None

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -109,7 +109,7 @@ class RuntimeSnapshotCompiler:
                 for generation in ordered
                 for module in getattr(generation.contributions, field_name)
             )
-            phases[field_name] = self._order_plugin_modules(modules)
+            phases[field_name] = self.order_plugin_modules(modules)
         jobs = self._compile_jobs(ordered)
         sources = self._compile_sources(ordered)
         proactive_modules = tuple(
@@ -206,7 +206,7 @@ class RuntimeSnapshotCompiler:
         )
 
     @staticmethod
-    def _order_plugin_modules(modules: tuple[object, ...]) -> tuple[object, ...]:
+    def order_plugin_modules(modules: tuple[object, ...]) -> tuple[object, ...]:
         slots = {
             str(slot)
             for slot in (getattr(module, "slot", None) for module in modules)

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -40,8 +40,7 @@ class RuntimeSnapshot:
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
     tool_registry: ToolRegistry | None = None
-    normal_skill_index: SkillIndex | None = None
-    drift_skill_index: SkillIndex | None = None
+    plugin_skill_index: SkillIndex | None = None
     state: SnapshotState = "compiled"
     lease_count: int = 0
     _store_token: object | None = field(default=None, repr=False)
@@ -132,13 +131,8 @@ class RuntimeSnapshotCompiler:
                 else None
             ),
             mcp_catalog_generation_ids=MappingProxyType(mcp_catalogs),
-            normal_skill_index=(
-                catalog_owner.skill_catalog.normal
-                if catalog_owner is not None and catalog_owner.skill_catalog is not None
-                else None
-            ),
-            drift_skill_index=(
-                catalog_owner.skill_catalog.drift
+            plugin_skill_index=(
+                catalog_owner.skill_catalog.normal_plugins
                 if catalog_owner is not None and catalog_owner.skill_catalog is not None
                 else None
             ),

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -13,6 +13,7 @@ from agent.plugins.generation import PluginGeneration
 from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
 from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
 from agent.tools.registry import ToolRegistry
+from agent.tool_hooks import ToolHook
 from agent.skills import SkillIndex
 from bus.event_bus import Handler
 
@@ -38,6 +39,11 @@ class RuntimeSnapshot:
     after_turn_modules: tuple[object, ...]
     jobs: Mapping[str, RegisteredPluginJob]
     proactive_sources: Mapping[str, RegisteredProactiveSource]
+    proactive_modules: tuple[object, ...]
+    proactive_lifecycles: tuple[object, ...]
+    proactive_module_factories: tuple[object, ...]
+    proactive_runtime_factories: tuple[object, ...]
+    tool_hooks: tuple[ToolHook, ...]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
     tool_registry: ToolRegistry | None = None
@@ -98,6 +104,26 @@ class RuntimeSnapshotCompiler:
             phases[field_name] = self._order_plugin_modules(modules)
         jobs = self._compile_jobs(ordered)
         sources = self._compile_sources(ordered)
+        proactive_modules = tuple(
+            module
+            for generation in ordered
+            for module in generation.contributions.proactive_modules
+        )
+        proactive_lifecycles = tuple(
+            lifecycle
+            for generation in ordered
+            for lifecycle in generation.contributions.proactive_lifecycles
+        )
+        proactive_module_factories = tuple(
+            factory
+            for generation in ordered
+            for factory in generation.contributions.proactive_module_factories
+        )
+        proactive_runtime_factories = tuple(
+            factory
+            for generation in ordered
+            for factory in generation.contributions.proactive_runtime_factories
+        )
         catalog_owner = catalog_generation or next(
             (generation for generation in reversed(ordered) if generation.skill_catalog),
             None,
@@ -129,6 +155,11 @@ class RuntimeSnapshotCompiler:
             generations=MappingProxyType(dict(generations)),
             jobs=MappingProxyType(jobs),
             proactive_sources=MappingProxyType(sources),
+            proactive_modules=proactive_modules,
+            proactive_lifecycles=proactive_lifecycles,
+            proactive_module_factories=proactive_module_factories,
+            proactive_runtime_factories=proactive_runtime_factories,
+            tool_hooks=(),
             skill_catalog_generation_id=(
                 catalog_owner.skill_catalog.generation_id
                 if catalog_owner is not None and catalog_owner.skill_catalog is not None

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -213,7 +213,7 @@ class RuntimeSnapshotLease:
         return not self._released
 
     def fork(self) -> RuntimeSnapshotLease:
-        return self._store.lease(self.snapshot.snapshot_id)
+        return self._store.fork_lease(self)
 
     async def __aenter__(self) -> RuntimeSnapshot:
         return self.snapshot
@@ -267,6 +267,11 @@ def get_current_runtime_snapshot() -> RuntimeSnapshot | None:
 
 
 def lease_current_runtime_snapshot() -> RuntimeSnapshotLease | None:
+    lease = get_current_runtime_lease()
+    return lease.fork() if lease is not None else None
+
+
+def get_current_runtime_lease() -> RuntimeSnapshotLease | None:
     binding = _current_runtime_binding.get()
     if (
         binding is None
@@ -274,7 +279,7 @@ def lease_current_runtime_snapshot() -> RuntimeSnapshotLease | None:
         or binding.owner_task is not asyncio.current_task()
     ):
         return None
-    return binding.lease.fork()
+    return binding.lease
 
 
 class RuntimeSnapshotStore:
@@ -360,6 +365,15 @@ class RuntimeSnapshotStore:
             raise RuntimeError("RuntimeSnapshot 不可用")
         if snapshot.state not in {"published_pending", "committed"}:
             raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
+        snapshot.lease_count += 1
+        for generation in snapshot.generations.values():
+            generation.lease_count += 1
+        return RuntimeSnapshotLease(self, snapshot)
+
+    def fork_lease(self, source: RuntimeSnapshotLease) -> RuntimeSnapshotLease:
+        snapshot = source.snapshot
+        if not source.active or self._snapshots.get(snapshot.snapshot_id) is not snapshot:
+            raise RuntimeError("RuntimeSnapshot lease 不可复制")
         snapshot.lease_count += 1
         for generation in snapshot.generations.values():
             generation.lease_count += 1

--- a/agent/plugins/specs.py
+++ b/agent/plugins/specs.py
@@ -27,3 +27,7 @@ class ProactiveSourceSpec:
 class RegisteredProactiveSource:
     plugin_id: str
     spec: ProactiveSourceSpec
+
+
+def proactive_source_key(source: RegisteredProactiveSource) -> str:
+    return f"{source.plugin_id}:{source.spec.id}"

--- a/agent/plugins/specs.py
+++ b/agent/plugins/specs.py
@@ -13,6 +13,16 @@ class McpServerSpec:
 
 
 @dataclass(frozen=True)
+class ManagedServiceSpec:
+    id: str
+    command: tuple[str, ...]
+    env: dict[str, str] = field(default_factory=dict)
+    cwd: str = "."
+    readiness_url: str = ""
+    startup_timeout_seconds: float = 15
+
+
+@dataclass(frozen=True)
 class ProactiveSourceSpec:
     id: str
     channels: tuple[Literal["alert", "content", "context"], ...]

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -13,10 +13,12 @@ class PluginWatcher:
         self._manager = manager
         self._interval_seconds = interval_seconds
         self._wake = asyncio.Event()
+        self._forced = False
         self._running = True
         self._stopped = asyncio.Event()
 
     async def run(self) -> None:
+        revision = self._manager.watch_revision()
         try:
             while self._running:
                 try:
@@ -29,8 +31,14 @@ class PluginWatcher:
                 self._wake.clear()
                 if not self._running:
                     break
+                forced = self._forced
+                self._forced = False
+                current_revision = self._manager.watch_revision()
+                if not forced and current_revision == revision:
+                    continue
                 try:
                     await self._manager.reconcile_changed()
+                    revision = current_revision
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -39,6 +47,7 @@ class PluginWatcher:
             self._stopped.set()
 
     def wake(self) -> None:
+        self._forced = True
         self._wake.set()
 
     def stop(self) -> None:

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from agent.plugins.manager import PluginManager
+
+logger = logging.getLogger(__name__)
+
+
+class PluginWatcher:
+    def __init__(self, manager: PluginManager, *, interval_seconds: float = 1.0) -> None:
+        self._manager = manager
+        self._interval_seconds = interval_seconds
+        self._wake = asyncio.Event()
+        self._running = True
+        self._stopped = asyncio.Event()
+
+    async def run(self) -> None:
+        try:
+            while self._running:
+                try:
+                    await asyncio.wait_for(
+                        self._wake.wait(),
+                        timeout=self._interval_seconds,
+                    )
+                except TimeoutError:
+                    pass
+                self._wake.clear()
+                if not self._running:
+                    break
+                try:
+                    await self._manager.reconcile_changed()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("插件热重载扫描失败")
+        finally:
+            self._stopped.set()
+
+    def wake(self) -> None:
+        self._wake.set()
+
+    def stop(self) -> None:
+        self._running = False
+        self._wake.set()
+
+    async def wait_stopped(self) -> None:
+        await self._stopped.wait()

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -18,8 +18,14 @@ class PluginWatcher:
         self._stopped = asyncio.Event()
 
     async def run(self) -> None:
-        revision = self._manager.watch_revision()
+        revision: str | None = None
+        scan_failed = False
         try:
+            try:
+                revision = self._manager.watch_revision()
+            except Exception:
+                scan_failed = True
+                logger.exception("插件热重载状态扫描失败")
             while self._running:
                 try:
                     await asyncio.wait_for(
@@ -31,9 +37,19 @@ class PluginWatcher:
                 self._wake.clear()
                 if not self._running:
                     break
-                forced = self._forced
+                forced = self._forced or scan_failed
                 self._forced = False
-                current_revision = self._manager.watch_revision()
+                try:
+                    current_revision = self._manager.watch_revision()
+                except Exception:
+                    scan_failed = True
+                    logger.exception("插件热重载状态扫描失败")
+                    continue
+                scan_failed = False
+                if revision is None:
+                    revision = current_revision
+                    if not forced:
+                        continue
                 if not forced and current_revision == revision:
                     continue
                 try:

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -4,7 +4,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, Mapping, cast
 
 import yaml
 
@@ -43,13 +43,26 @@ class SkillIndex:
 
 
 class SkillsLoader:
-    def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        builtin_skills_dir: Path | None = BUILTIN_SKILLS_DIR,
+        *,
+        workspace_skills_dir: Path | None = None,
+        plugin_roots: Mapping[str, tuple[Path, ...]] | None = None,
+        ignore_workspace_symlinks: bool = False,
+    ):
         self.workspace = workspace
-        self.workspace_skills = workspace / "skills"
-        self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
+        self.workspace_skills = workspace_skills_dir or workspace / "skills"
+        self.builtin_skills = builtin_skills_dir
+        self.plugin_roots = dict(plugin_roots or {})
+        self.ignore_workspace_symlinks = ignore_workspace_symlinks
 
     def list_skill_records(self, filter_unavailable: bool = True) -> list[SkillRecord]:
-        return self._build_index().list_records(filter_unavailable=filter_unavailable)
+        return self.build_index().list_records(filter_unavailable=filter_unavailable)
+
+    def build_index(self) -> SkillIndex:
+        return self._build_index()
 
     def load_skills_for_context(self, skill_names: list[str]) -> str:
         parts: list[str] = []
@@ -110,8 +123,19 @@ class SkillsLoader:
             self.workspace_skills,
             source="workspace",
             source_id="workspace",
+            ignore_symlinks=self.ignore_workspace_symlinks,
         ):
             records[record.name] = record
+
+        for plugin_id, roots in sorted(self.plugin_roots.items()):
+            for root in roots:
+                for record in self._scan_skills_dir(
+                    root,
+                    source="plugin",
+                    source_id=plugin_id,
+                ):
+                    if record.name not in records:
+                        records[record.name] = record
 
         if self.builtin_skills:
             for record in self._scan_skills_dir(
@@ -131,12 +155,15 @@ class SkillsLoader:
         source: SkillSource,
         source_id: str,
         name_prefix: str = "",
+        ignore_symlinks: bool = False,
     ) -> list[SkillRecord]:
         if not skills_dir.exists():
             return []
 
         records: list[SkillRecord] = []
         for skill_dir in sorted(skills_dir.iterdir(), key=lambda item: item.name):
+            if ignore_symlinks and skill_dir.is_symlink():
+                continue
             if not skill_dir.is_dir():
                 continue
             skill_file = skill_dir / "SKILL.md"

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -20,6 +20,7 @@ class SkillRecord:
     source_id: str
     root_dir: Path
     skill_file: Path
+    content: str
     description: str
     when_to_use: str
     config: dict[str, Any]
@@ -79,8 +80,7 @@ class SkillsLoader:
         record = self.load_skill_record(name)
         if record is None:
             return None
-        content = record.skill_file.read_text(encoding="utf-8")
-        return self._strip_frontmatter(content)
+        return self._strip_frontmatter(record.content)
 
     def load_skill_record(self, name: str) -> SkillRecord | None:
         return self._build_index().get(name)
@@ -205,6 +205,7 @@ class SkillsLoader:
             source_id=source_id,
             root_dir=root_dir,
             skill_file=skill_file,
+            content=content,
             description=meta.get("description") or name,
             when_to_use=meta.get("when_to_use", ""),
             config=config,

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -52,7 +52,7 @@ class SkillsLoader:
         workspace_skills_dir: Path | None = None,
         plugin_roots: Mapping[str, tuple[Path, ...]] | None = None,
         ignored_workspace_symlink_roots: tuple[Path, ...] = (),
-        runtime_catalog: Literal["normal", "drift"] | None = "normal",
+        runtime_catalog: Literal["normal"] | None = None,
     ):
         self.workspace = workspace
         self.workspace_skills = workspace_skills_dir or workspace / "skills"
@@ -121,18 +121,13 @@ class SkillsLoader:
         return "\n".join(lines)
 
     def _build_index(self) -> SkillIndex:
-        if self.runtime_catalog is not None:
+        runtime_plugins: SkillIndex | None = None
+        if self.runtime_catalog == "normal":
             from agent.plugins.snapshot import get_current_runtime_snapshot
 
             snapshot = get_current_runtime_snapshot()
             if snapshot is not None:
-                index = (
-                    snapshot.normal_skill_index
-                    if self.runtime_catalog == "normal"
-                    else snapshot.drift_skill_index
-                )
-                if index is not None:
-                    return index
+                runtime_plugins = snapshot.plugin_skill_index
         records: dict[str, SkillRecord] = {}
 
         for record in self._scan_skills_dir(
@@ -143,15 +138,20 @@ class SkillsLoader:
         ):
             records[record.name] = record
 
-        for plugin_id, roots in sorted(self.plugin_roots.items()):
-            for root in roots:
-                for record in self._scan_skills_dir(
-                    root,
-                    source="plugin",
-                    source_id=plugin_id,
-                ):
-                    if record.name not in records:
-                        records[record.name] = record
+        if runtime_plugins is not None:
+            for record in runtime_plugins.records.values():
+                if record.name not in records:
+                    records[record.name] = record
+        else:
+            for plugin_id, roots in sorted(self.plugin_roots.items()):
+                for root in roots:
+                    for record in self._scan_skills_dir(
+                        root,
+                        source="plugin",
+                        source_id=plugin_id,
+                    ):
+                        if record.name not in records:
+                            records[record.name] = record
 
         if self.builtin_skills:
             for record in self._scan_skills_dir(

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -52,6 +52,7 @@ class SkillsLoader:
         workspace_skills_dir: Path | None = None,
         plugin_roots: Mapping[str, tuple[Path, ...]] | None = None,
         ignored_workspace_symlink_roots: tuple[Path, ...] = (),
+        runtime_catalog: Literal["normal", "drift"] | None = "normal",
     ):
         self.workspace = workspace
         self.workspace_skills = workspace_skills_dir or workspace / "skills"
@@ -60,6 +61,7 @@ class SkillsLoader:
         self.ignored_workspace_symlink_roots = tuple(
             root.resolve(strict=False) for root in ignored_workspace_symlink_roots
         )
+        self.runtime_catalog = runtime_catalog
 
     def list_skill_records(self, filter_unavailable: bool = True) -> list[SkillRecord]:
         return self.build_index().list_records(filter_unavailable=filter_unavailable)
@@ -119,6 +121,18 @@ class SkillsLoader:
         return "\n".join(lines)
 
     def _build_index(self) -> SkillIndex:
+        if self.runtime_catalog is not None:
+            from agent.plugins.snapshot import get_current_runtime_snapshot
+
+            snapshot = get_current_runtime_snapshot()
+            if snapshot is not None:
+                index = (
+                    snapshot.normal_skill_index
+                    if self.runtime_catalog == "normal"
+                    else snapshot.drift_skill_index
+                )
+                if index is not None:
+                    return index
         records: dict[str, SkillRecord] = {}
 
         for record in self._scan_skills_dir(

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -50,13 +50,15 @@ class SkillsLoader:
         *,
         workspace_skills_dir: Path | None = None,
         plugin_roots: Mapping[str, tuple[Path, ...]] | None = None,
-        ignore_workspace_symlinks: bool = False,
+        ignored_workspace_symlink_roots: tuple[Path, ...] = (),
     ):
         self.workspace = workspace
         self.workspace_skills = workspace_skills_dir or workspace / "skills"
         self.builtin_skills = builtin_skills_dir
         self.plugin_roots = dict(plugin_roots or {})
-        self.ignore_workspace_symlinks = ignore_workspace_symlinks
+        self.ignored_workspace_symlink_roots = tuple(
+            root.resolve(strict=False) for root in ignored_workspace_symlink_roots
+        )
 
     def list_skill_records(self, filter_unavailable: bool = True) -> list[SkillRecord]:
         return self.build_index().list_records(filter_unavailable=filter_unavailable)
@@ -123,7 +125,7 @@ class SkillsLoader:
             self.workspace_skills,
             source="workspace",
             source_id="workspace",
-            ignore_symlinks=self.ignore_workspace_symlinks,
+            ignored_symlink_roots=self.ignored_workspace_symlink_roots,
         ):
             records[record.name] = record
 
@@ -155,15 +157,17 @@ class SkillsLoader:
         source: SkillSource,
         source_id: str,
         name_prefix: str = "",
-        ignore_symlinks: bool = False,
+        ignored_symlink_roots: tuple[Path, ...] = (),
     ) -> list[SkillRecord]:
         if not skills_dir.exists():
             return []
 
         records: list[SkillRecord] = []
         for skill_dir in sorted(skills_dir.iterdir(), key=lambda item: item.name):
-            if ignore_symlinks and skill_dir.is_symlink():
-                continue
+            if skill_dir.is_symlink() and ignored_symlink_roots:
+                target = skill_dir.resolve(strict=False)
+                if any(target.is_relative_to(root) for root in ignored_symlink_roots):
+                    continue
             if not skill_dir.is_dir():
                 continue
             skill_file = skill_dir / "SKILL.md"

--- a/agent/skills.py
+++ b/agent/skills.py
@@ -136,6 +136,12 @@ class SkillsLoader:
             source_id="workspace",
             ignored_symlink_roots=self.ignored_workspace_symlink_roots,
         ):
+            if (
+                runtime_plugins is not None
+                and record.name in runtime_plugins.records
+                and record.root_dir.is_symlink()
+            ):
+                continue
             records[record.name] = record
 
         if runtime_plugins is not None:

--- a/agent/tool_hooks/executor.py
+++ b/agent/tool_hooks/executor.py
@@ -34,7 +34,12 @@ class ToolExecutor:
 
         snapshot = get_current_runtime_snapshot()
         if snapshot is not None:
-            return list(snapshot.tool_hooks)
+            fixed = [
+                hook
+                for hook in self._hooks
+                if not getattr(hook, "snapshot_managed", False)
+            ]
+            return [*fixed, *snapshot.tool_hooks]
         return self._hooks
 
     async def execute(

--- a/agent/tool_hooks/executor.py
+++ b/agent/tool_hooks/executor.py
@@ -29,6 +29,14 @@ class ToolExecutor:
     def add_hooks(self, hooks: Sequence[ToolHook]) -> None:
         self._hooks.extend(hooks)
 
+    def _runtime_hooks(self) -> list[ToolHook]:
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        snapshot = get_current_runtime_snapshot()
+        if snapshot is not None:
+            return list(snapshot.tool_hooks)
+        return self._hooks
+
     async def execute(
         self,
         request: ToolExecutionRequest,
@@ -189,7 +197,7 @@ class ToolExecutor:
         extra_messages: list[str],
         traces: list[HookTraceItem],
     ) -> tuple[str, dict[str, Any]]:
-        for hook in self._hooks:
+        for hook in self._runtime_hooks():
             if hook.event != "pre_tool_use":
                 continue
             ctx = HookContext(
@@ -241,7 +249,7 @@ class ToolExecutor:
         traces: list[HookTraceItem],
         fail_open: bool = False,
     ) -> None:
-        for hook in self._hooks:
+        for hook in self._runtime_hooks():
             if hook.event != ctx.event:
                 continue
             try:

--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -12,6 +12,20 @@ from bus.queue import ChatLane
 logger = logging.getLogger(__name__)
 
 
+class ChannelRegistration:
+    def __init__(self, tool: "MessagePushTool", channel: str, token: object) -> None:
+        self._tool = tool
+        self._channel = channel
+        self._token = token
+        self._active = True
+
+    def close(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        self._tool.unregister_channel(self._channel, self._token)
+
+
 class MessagePushTool(Tool):
     name = "message_push"
     description = (
@@ -49,6 +63,7 @@ class MessagePushTool(Tool):
     def __init__(self, chat_lane: ChatLane | None = None) -> None:
         # channel -> {type: sender_fn}
         self._senders: dict[str, dict[str, Callable[..., Awaitable[None]]]] = {}
+        self._registration_tokens: dict[str, object] = {}
         self._chat_lane = chat_lane
 
     def register_channel(
@@ -58,14 +73,18 @@ class MessagePushTool(Tool):
         stream_text: Callable[[str, str], Awaitable[None]] | None = None,
         file: Callable[[str, str, str | None], Awaitable[None]] | None = None,
         image: Callable[[str, str], Awaitable[None]] | None = None,
-    ) -> None:
+    ) -> ChannelRegistration:
         """注册渠道的各类 sender。
         - text(chat_id, message)
         - stream_text(chat_id, message)
         - file(chat_id, file_path, name=None)
         - image(chat_id, image_path_or_url)
         """
+        if channel in self._senders:
+            raise RuntimeError(f"message_push 渠道名称重复: {channel}")
         self._senders[channel] = {}
+        token = object()
+        self._registration_tokens[channel] = token
         if text:
             self._senders[channel]["text"] = text
         if stream_text:
@@ -77,6 +96,13 @@ class MessagePushTool(Tool):
         logger.debug(
             f"message_push: 注册渠道 {channel!r}  支持: {list(self._senders[channel])}"
         )
+        return ChannelRegistration(self, channel, token)
+
+    def unregister_channel(self, channel: str, token: object) -> None:
+        if self._registration_tokens.get(channel) is not token:
+            return
+        _ = self._registration_tokens.pop(channel, None)
+        _ = self._senders.pop(channel, None)
 
     async def execute(self, **kwargs: Any) -> str:
         channel: str = kwargs["channel"]

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -133,12 +133,12 @@ class ToolRegistry:
         cloned = ToolRegistry(backend=backend)
         excluded_types = excluded_source_types or set()
         excluded_pairs = excluded_sources or set()
-        names = {
+        names = [
             name
             for name, document in self._documents.items()
             if document.source_type not in excluded_types
             and (document.source_type, document.source_name) not in excluded_pairs
-        }
+        ]
         cloned._tools = {name: self._tools[name] for name in names}
         cloned._metadata = {name: self._metadata[name] for name in names}
         cloned._documents = {name: self._documents[name] for name in names}

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -121,12 +121,41 @@ class ToolRegistry:
         self._documents: dict[str, ToolDocument] = {}
         self._context: dict[str, str] = {}
         self._backend: SearchBackend = backend or KeywordSearchBackend()
+        self._snapshot_view = False
+
+    def fork(self) -> "ToolRegistry":
+        backend = deepcopy(self._backend)
+        cloned = ToolRegistry(backend=backend)
+        cloned._tools = dict(self._tools)
+        cloned._metadata = dict(self._metadata)
+        cloned._documents = dict(self._documents)
+        cloned._context = dict(self._context)
+        cloned._backend.rebuild(list(cloned._documents.values()))
+        cloned._snapshot_view = True
+        return cloned
+
+    def _runtime_view(self) -> "ToolRegistry":
+        if self._snapshot_view:
+            return self
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        snapshot = get_current_runtime_snapshot()
+        if snapshot is None or snapshot.tool_registry is None:
+            return self
+        return snapshot.tool_registry
 
     def set_context(self, **kwargs: str) -> None:
         """设置当前会话上下文（channel、chat_id 等），供工具按需读取。"""
+        view = self._runtime_view()
+        if view is not self:
+            view.set_context(**kwargs)
+            return
         self._context.update(kwargs)
 
     def get_context(self) -> dict[str, str]:
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_context()
         return self._context
 
     def register(
@@ -161,13 +190,22 @@ class ToolRegistry:
         logger.debug(f"注销工具: {name}")
 
     def has_tool(self, name: str) -> bool:
+        view = self._runtime_view()
+        if view is not self:
+            return view.has_tool(name)
         return name in self._tools
 
     def get_tool(self, name: str) -> "Tool | None":
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_tool(name)
         return self._tools.get(name)
 
     def get_registered_names(self) -> set[str]:
         """返回当前已注册工具名集合。"""
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_registered_names()
         return set(self._tools.keys())
 
     def get_schemas(
@@ -178,6 +216,9 @@ class ToolRegistry:
 
         names 为 None 时返回全量；传 set 时按注册顺序过滤；传 list/tuple 时按调用方顺序返回。
         """
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_schemas(names)
         if names is None:
             return [
                 _with_progress_description(t.to_schema(), t)
@@ -196,16 +237,25 @@ class ToolRegistry:
         ]
 
     def get_registered_order(self, names: AbstractSet[str] | None = None) -> list[str]:
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_registered_order(names)
         if names is None:
             return list(self._tools.keys())
         return [name for name in self._tools.keys() if name in names]
 
     def get_always_on_names(self) -> set[str]:
         """返回标记为 always_on 的工具名称集合。"""
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_always_on_names()
         return {name for name, meta in self._metadata.items() if meta.always_on}
 
     def get_documents(self) -> list[ToolDocument]:
         """返回所有已注册工具的索引文档列表。"""
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_documents()
         return list(self._documents.values())
 
     def get_deferred_names(
@@ -217,6 +267,9 @@ class ToolRegistry:
         deferred = 全量注册工具 - always_on - meta_tools - visible
         格式: {"builtin": [...], "mcp": {"server_name": [...], ...}}
         """
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_deferred_names(visible)
         always_on = self.get_always_on_names()
         excluded = always_on | _META_TOOLS | (visible or set())
         builtin: list[str] = []
@@ -242,6 +295,9 @@ class ToolRegistry:
         *,
         raise_errors: bool = False,
     ) -> str | ToolResult:
+        view = self._runtime_view()
+        if view is not self:
+            return await view.execute(name, arguments, raise_errors=raise_errors)
         tool = self._tools.get(name)
         if tool is None:
             if raise_errors:
@@ -265,6 +321,9 @@ class ToolRegistry:
 
         供 select: 精确加载路径使用，why_matched 固定为"名称:精确匹配"。
         """
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_schemas_as_doc_results(names)
         results: list[dict[str, Any]] = []
         for name in names:
             doc = self._documents.get(name)
@@ -282,6 +341,9 @@ class ToolRegistry:
 
     def get_mcp_server_names(self) -> set[str]:
         """返回当前已注册的所有 MCP server 名称。"""
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_mcp_server_names()
         return {
             doc.source_name
             for doc in self._documents.values()
@@ -290,6 +352,9 @@ class ToolRegistry:
 
     def get_tool_names_by_source(self, source_type: str, source_name: str) -> set[str]:
         """返回指定来源的所有工具名。"""
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_tool_names_by_source(source_type, source_name)
         return {
             name
             for name, doc in self._documents.items()
@@ -308,6 +373,9 @@ class ToolRegistry:
         excluded_names: 调用方（当前 turn）传入的排除集合，通常为已可见工具名。
         meta_tools 始终被排除。搜索逻辑委托给 SearchBackend。
         """
+        view = self._runtime_view()
+        if view is not self:
+            return view.search(query, top_k, allowed_risk, excluded_names)
         excluded = _META_TOOLS | (excluded_names or set())
         return cast(
             list[dict[str, Any]],

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -123,12 +123,25 @@ class ToolRegistry:
         self._backend: SearchBackend = backend or KeywordSearchBackend()
         self._snapshot_view = False
 
-    def fork(self) -> "ToolRegistry":
+    def fork(
+        self,
+        *,
+        excluded_source_types: set[str] | None = None,
+        excluded_sources: set[tuple[str, str]] | None = None,
+    ) -> "ToolRegistry":
         backend = deepcopy(self._backend)
         cloned = ToolRegistry(backend=backend)
-        cloned._tools = dict(self._tools)
-        cloned._metadata = dict(self._metadata)
-        cloned._documents = dict(self._documents)
+        excluded_types = excluded_source_types or set()
+        excluded_pairs = excluded_sources or set()
+        names = {
+            name
+            for name, document in self._documents.items()
+            if document.source_type not in excluded_types
+            and (document.source_type, document.source_name) not in excluded_pairs
+        }
+        cloned._tools = {name: self._tools[name] for name in names}
+        cloned._metadata = {name: self._metadata[name] for name in names}
+        cloned._documents = {name: self._documents[name] for name in names}
         cloned._context = dict(self._context)
         cloned._backend.rebuild(list(cloned._documents.values()))
         cloned._snapshot_view = True

--- a/agent/tools/spawn.py
+++ b/agent/tools/spawn.py
@@ -29,6 +29,9 @@ class SpawnTool(Tool):
     def add_tool_hooks(self, hooks: list[ToolHook]) -> None:
         self._manager.add_tool_hooks(hooks)
 
+    async def shutdown(self) -> None:
+        await self._manager.shutdown()
+
     @property
     def name(self) -> str:
         return "spawn"

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -305,7 +305,6 @@ class AppRuntime:
                     self.plugin_watcher.run(),
                     name="plugin_watcher",
                 )
-                self.tasks.append(self.plugin_watcher_task)
 
             self._install_plugin_reload_signal()
             self._started = True

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -161,6 +161,15 @@ class AppRuntime:
                 plugin_channels=plugin_channels,
             )
             await self.channel_host.start_all()
+            if plugin_manager is not None:
+                channel_bindings = {
+                    plugin_id: generation.contributions.channels
+                    for plugin_id, generation in plugin_manager.current_snapshot.generations.items()
+                } if plugin_manager.current_snapshot is not None else {}
+                self.channel_host.bind_plugin_channels(channel_bindings)
+                plugin_manager.bind_channel_switcher(
+                    self.channel_host.swap_plugin_channels
+                )
 
             self.tasks = [
                 self.agent_loop.run(),
@@ -298,12 +307,12 @@ class AppRuntime:
                     "plugin_jobs.stop",
                     _stop_plugin_jobs(self.plugin_job_runtime),
                 ),
-                ("core.stop", self.core.stop if self.core else _noop_async),
                 ("ipc.stop", self.ipc.stop if self.ipc else _noop_async),
                 (
                     "channels.stop",
                     self.channel_host.stop_all if self.channel_host else _noop_async,
                 ),
+                ("core.stop", self.core.stop if self.core else _noop_async),
                 (
                     "memory_runtime.aclose",
                     self.memory_runtime.aclose if self.memory_runtime else _noop_async,

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import signal
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
 from agent.config_models import Config
 from bootstrap.channel_host import ChannelHost
@@ -94,6 +95,8 @@ class AppRuntime:
         self._memory_optimizer = None
         self._shutdown = False
         self._started = False
+        self._plugin_candidate_tasks: set[asyncio.Task[Any]] = set()
+        self._plugin_reload_signal_installed = False
 
     async def start(self) -> None:
         if self._started:
@@ -121,6 +124,7 @@ class AppRuntime:
             self.peer_process_manager = self.core.peer_process_manager
             self.peer_poller = self.core.peer_poller
             await self.core.start()
+            self._install_plugin_reload_signal()
 
             plugin_manager = getattr(self.core, "plugin_manager", None)
             plugin_channels = list(plugin_manager.channels) if plugin_manager else []
@@ -250,6 +254,15 @@ class AppRuntime:
             return
         self._shutdown = True
         try:
+            self._remove_plugin_reload_signal()
+            for task in self._plugin_candidate_tasks:
+                _ = task.cancel()
+            if self._plugin_candidate_tasks:
+                _ = await asyncio.gather(
+                    *self._plugin_candidate_tasks,
+                    return_exceptions=True,
+                )
+            self._plugin_candidate_tasks.clear()
             if self.dashboard_server is not None:
                 self.dashboard_server.should_exit = True
             if self.chat_server is not None:
@@ -283,6 +296,44 @@ class AppRuntime:
             )
         finally:
             clear_default_shared_http_resources(self.http_resources)
+
+    def _install_plugin_reload_signal(self) -> None:
+        if not hasattr(signal, "SIGHUP"):
+            return
+        manager = getattr(self.core, "plugin_manager", None)
+        if manager is None:
+            return
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGHUP, self._schedule_plugin_candidate_scan)
+        self._plugin_reload_signal_installed = True
+
+    def _remove_plugin_reload_signal(self) -> None:
+        if not self._plugin_reload_signal_installed:
+            return
+        _ = asyncio.get_running_loop().remove_signal_handler(signal.SIGHUP)
+        self._plugin_reload_signal_installed = False
+
+    def _schedule_plugin_candidate_scan(self) -> None:
+        manager = getattr(self.core, "plugin_manager", None)
+        if manager is None or self._shutdown:
+            return
+        task = asyncio.create_task(
+            manager.prepare_changed(),
+            name="plugin_candidate_scan",
+        )
+        self._plugin_candidate_tasks.add(task)
+        task.add_done_callback(self._plugin_candidate_scan_done)
+
+    def _plugin_candidate_scan_done(self, task: asyncio.Task[Any]) -> None:
+        self._plugin_candidate_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "plugin candidate scan failed",
+                exc_info=(type(error), error, error.__traceback__),
+            )
 
 
 def build_app_runtime(config: Config, workspace: Path | None = None) -> AppRuntime:

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -58,6 +58,7 @@ def _stop_plugin_jobs(runtime: PluginJobRuntime | None) -> Callable[[], Awaitabl
     async def stop() -> None:
         if runtime is not None:
             runtime.stop()
+            await runtime.wait_stopped()
 
     return stop
 
@@ -157,15 +158,14 @@ class AppRuntime:
                 self.bus.dispatch_outbound(),
                 self.scheduler.run(),
             ]
-            plugin_jobs = plugin_manager.jobs if plugin_manager else []
-            if plugin_jobs:
+            if plugin_manager is not None:
                 assert self.core.plugin_manager is not None
                 llm = self.core.plugin_manager.llm
                 if llm is not None:
                     self.plugin_job_runtime = PluginJobRuntime(
                         event_bus=event_bus,
                         llm=llm,
-                        jobs=plugin_jobs,
+                        snapshot_store=plugin_manager.snapshot_store,
                     )
                     self.tasks.append(self.plugin_job_runtime.run())
             optimizer_tasks, self._memory_optimizer = build_memory_optimizer_task(

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 import sys
 from pathlib import Path
@@ -30,6 +31,9 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
     stream=sys.stdout,
     force=True,
+)
+logging.getLogger("agent.plugins.manager").setLevel(
+    os.environ.get("AKASHIC_PLUGIN_LOG_LEVEL", "INFO").upper()
 )
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("telegram").setLevel(logging.WARNING)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -318,8 +318,8 @@ class AppRuntime:
         if manager is None or self._shutdown:
             return
         task = asyncio.create_task(
-            manager.reconcile_changed(),
-            name="plugin_reconcile_changed",
+            manager.prepare_changed(),
+            name="plugin_candidate_scan",
         )
         self._plugin_candidate_tasks.add(task)
         task.add_done_callback(self._plugin_candidate_scan_done)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -17,6 +17,7 @@ from bootstrap.tools import CoreRuntime, build_core_runtime
 from bus.event_bus import EventBus
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.service_host import PluginServiceHost
+from agent.plugins.watcher import PluginWatcher
 from core.net.http import (
     SharedHttpResources,
     clear_default_shared_http_resources,
@@ -73,6 +74,17 @@ def _stop_proactive(runtime: object | None) -> Callable[[], Awaitable[None]]:
     return stop
 
 
+def _stop_plugin_watcher(
+    watcher: PluginWatcher | None,
+) -> Callable[[], Awaitable[None]]:
+    async def stop() -> None:
+        if watcher is not None:
+            watcher.stop()
+            await watcher.wait_stopped()
+
+    return stop
+
+
 class AppRuntime:
     def __init__(self, config: Config, workspace: Path) -> None:
         self.config = config
@@ -103,6 +115,8 @@ class AppRuntime:
         self.web_chat_channel = None
         self.plugin_job_runtime: PluginJobRuntime | None = None
         self.plugin_service_host: PluginServiceHost | None = None
+        self.plugin_watcher: PluginWatcher | None = None
+        self.plugin_watcher_task: asyncio.Task[None] | None = None
         self.tasks: list[Awaitable[None]] = []
         self._memory_optimizer = None
         self._shutdown = False
@@ -187,6 +201,9 @@ class AppRuntime:
                 self.channel_host.bind_plugin_channels(channel_bindings)
                 plugin_manager.bind_channel_switcher(
                     self.channel_host.swap_plugin_channels
+                )
+                plugin_manager.bind_endpoint_switcher(
+                    self._swap_plugin_endpoints
                 )
 
             self.tasks = [
@@ -282,6 +299,14 @@ class AppRuntime:
                         resume=self.proactive_loop.resume_after_reload,
                     )
 
+            if plugin_manager is not None:
+                self.plugin_watcher = PluginWatcher(plugin_manager)
+                self.plugin_watcher_task = asyncio.create_task(
+                    self.plugin_watcher.run(),
+                    name="plugin_watcher",
+                )
+                self.tasks.append(self.plugin_watcher_task)
+
             self._install_plugin_reload_signal()
             self._started = True
         except Exception:
@@ -324,6 +349,10 @@ class AppRuntime:
                 except asyncio.CancelledError:
                     pass
             await _run_cleanup_steps(
+                (
+                    "plugin_watcher.stop",
+                    _stop_plugin_watcher(self.plugin_watcher),
+                ),
                 (
                     "proactive.stop",
                     _stop_proactive(self.proactive_loop),
@@ -373,9 +402,12 @@ class AppRuntime:
         manager = getattr(self.core, "plugin_manager", None)
         if manager is None or self._shutdown:
             return
+        if self.plugin_watcher is not None:
+            self.plugin_watcher.wake()
+            return
         task = asyncio.create_task(
-            manager.prepare_changed(),
-            name="plugin_candidate_scan",
+            manager.reconcile_changed(),
+            name="plugin_reload_scan",
         )
         self._plugin_candidate_tasks.add(task)
         task.add_done_callback(self._plugin_candidate_scan_done)
@@ -390,6 +422,54 @@ class AppRuntime:
                 "plugin candidate scan failed",
                 exc_info=(type(error), error, error.__traceback__),
             )
+
+    async def _swap_plugin_endpoints(
+        self,
+        plugin_id: str,
+        old_services: dict[str, dict[str, Any]],
+        new_services: dict[str, dict[str, Any]],
+        old_channels: tuple[Any, ...],
+        new_channels: tuple[Any, ...],
+    ) -> None:
+        assert self.channel_host is not None
+        assert self.plugin_service_host is not None
+        swap = (
+            self.channel_host.prepare_plugin_swap(
+                plugin_id,
+                old_channels,
+                new_channels,
+            )
+            if old_channels != new_channels
+            else None
+        )
+        if swap is not None:
+            await self.channel_host.stop_plugin_swap(swap)
+        services_switched = False
+        try:
+            if old_services != new_services:
+                await self.plugin_service_host.swap_plugin_services(
+                    plugin_id,
+                    old_services,
+                    new_services,
+                )
+                services_switched = True
+            if swap is not None:
+                await self.channel_host.start_plugin_swap(swap)
+        except BaseException as error:
+            if services_switched:
+                await self.plugin_service_host.swap_plugin_services(
+                    plugin_id,
+                    new_services,
+                    old_services,
+                )
+            if swap is not None:
+                try:
+                    await self.channel_host.restore_plugin_swap(swap)
+                except BaseException as restore_error:
+                    raise RuntimeError("插件旧端点恢复失败") from restore_error
+            raise error
+        if swap is not None:
+            self.channel_host.commit_plugin_swap(swap)
 
 
 def build_app_runtime(config: Config, workspace: Path | None = None) -> AppRuntime:

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -136,7 +136,6 @@ class AppRuntime:
             self.peer_process_manager = self.core.peer_process_manager
             self.peer_poller = self.core.peer_poller
             await self.core.start()
-            self._install_plugin_reload_signal()
 
             plugin_manager = getattr(self.core, "plugin_manager", None)
             if plugin_manager is not None:
@@ -277,7 +276,13 @@ class AppRuntime:
             self.tasks.extend(proactive_tasks)
             if self.proactive_loop is not None:
                 self.ipc.set_proactive_loop(self.proactive_loop)
+                if plugin_manager is not None:
+                    plugin_manager.bind_endpoint_admission(
+                        quiesce=self.proactive_loop.quiesce_for_reload,
+                        resume=self.proactive_loop.resume_after_reload,
+                    )
 
+            self._install_plugin_reload_signal()
             self._started = True
         except Exception:
             await self.shutdown()

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -16,6 +16,7 @@ from bootstrap.proactive import build_memory_optimizer_task, build_proactive_run
 from bootstrap.tools import CoreRuntime, build_core_runtime
 from bus.event_bus import EventBus
 from agent.plugins.jobs import PluginJobRuntime
+from agent.plugins.service_host import PluginServiceHost
 from core.net.http import (
     SharedHttpResources,
     clear_default_shared_http_resources,
@@ -101,6 +102,7 @@ class AppRuntime:
         self.chat_task: asyncio.Task[None] | None = None
         self.web_chat_channel = None
         self.plugin_job_runtime: PluginJobRuntime | None = None
+        self.plugin_service_host: PluginServiceHost | None = None
         self.tasks: list[Awaitable[None]] = []
         self._memory_optimizer = None
         self._shutdown = False
@@ -137,6 +139,23 @@ class AppRuntime:
             self._install_plugin_reload_signal()
 
             plugin_manager = getattr(self.core, "plugin_manager", None)
+            if plugin_manager is not None:
+                self.plugin_service_host = PluginServiceHost()
+                snapshot = plugin_manager.current_snapshot
+                service_bindings = {
+                    plugin_id: {
+                        service_id: dict(spec)
+                        for service_id, spec in services.items()
+                    }
+                    for plugin_id, services in (
+                        snapshot.managed_services.items() if snapshot is not None else ()
+                    )
+                }
+                self.plugin_service_host.bind_plugin_services(service_bindings)
+                await self.plugin_service_host.start_all()
+                plugin_manager.bind_service_switcher(
+                    self.plugin_service_host.swap_plugin_services
+                )
             plugin_channels = list(plugin_manager.channels) if plugin_manager else []
             if self.config.channels.chat.enabled:
                 from infra.channels.web_chat_channel import WebChatChannel
@@ -312,6 +331,12 @@ class AppRuntime:
                 (
                     "channels.stop",
                     self.channel_host.stop_all if self.channel_host else _noop_async,
+                ),
+                (
+                    "plugin_services.stop",
+                    self.plugin_service_host.stop_all
+                    if self.plugin_service_host
+                    else _noop_async,
                 ),
                 ("core.stop", self.core.stop if self.core else _noop_async),
                 (

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -318,8 +318,8 @@ class AppRuntime:
         if manager is None or self._shutdown:
             return
         task = asyncio.create_task(
-            manager.prepare_changed(),
-            name="plugin_candidate_scan",
+            manager.reconcile_changed(),
+            name="plugin_reconcile_changed",
         )
         self._plugin_candidate_tasks.add(task)
         task.add_done_callback(self._plugin_candidate_scan_done)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -63,6 +63,15 @@ def _stop_plugin_jobs(runtime: PluginJobRuntime | None) -> Callable[[], Awaitabl
     return stop
 
 
+def _stop_proactive(runtime: object | None) -> Callable[[], Awaitable[None]]:
+    async def stop() -> None:
+        if runtime is not None:
+            runtime.stop()
+            await runtime.wait_stopped()
+
+    return stop
+
+
 class AppRuntime:
     def __init__(self, config: Config, workspace: Path) -> None:
         self.config = config
@@ -232,6 +241,9 @@ class AppRuntime:
                     if plugin_manager
                     else None
                 ),
+                runtime_snapshot_store=(
+                    plugin_manager.snapshot_store if plugin_manager else None
+                ),
             )
             self.tasks.extend(proactive_tasks)
             if self.proactive_loop is not None:
@@ -278,6 +290,10 @@ class AppRuntime:
                 except asyncio.CancelledError:
                     pass
             await _run_cleanup_steps(
+                (
+                    "proactive.stop",
+                    _stop_proactive(self.proactive_loop),
+                ),
                 (
                     "plugin_jobs.stop",
                     _stop_plugin_jobs(self.plugin_job_runtime),

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -198,6 +198,7 @@ class AppRuntime:
                 manual_memory_optimizer=self._memory_optimizer,
                 memory_admin=self.memory_runtime.engine,
                 memory_store=self.memory_runtime.markdown.store,
+                plugin_manager=plugin_manager,
             )
             self.dashboard_task = asyncio.create_task(
                 self.dashboard_server.serve(),

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -192,6 +192,11 @@ class AppRuntime:
                 interrupt_controller=self.agent_loop,
                 plugin_channels=plugin_channels,
             )
+            if plugin_manager is not None:
+                self.ipc.register_command(
+                    "plugin-disable-and-drain",
+                    self._disable_and_drain_plugin,
+                )
             await self.channel_host.start_all()
             if plugin_manager is not None:
                 channel_bindings = {
@@ -410,6 +415,16 @@ class AppRuntime:
         )
         self._plugin_candidate_tasks.add(task)
         task.add_done_callback(self._plugin_candidate_scan_done)
+
+    async def _disable_and_drain_plugin(self, data: dict[str, object]) -> str:
+        plugin_id = str(data.get("plugin_id", "")).strip()
+        if not plugin_id:
+            raise ValueError("缺少插件 ID")
+        manager = getattr(self.core, "plugin_manager", None)
+        if manager is None:
+            raise RuntimeError("插件 Runtime 不可用")
+        await manager.reconcile_disabled_and_drain(plugin_id)
+        return f"插件已停用并排空: {plugin_id}"
 
     def _plugin_candidate_scan_done(self, task: asyncio.Task[Any]) -> None:
         self._plugin_candidate_tasks.discard(task)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -456,18 +456,32 @@ class AppRuntime:
             if swap is not None:
                 await self.channel_host.start_plugin_swap(swap)
         except BaseException as error:
+            service_restore_error: BaseException | None = None
             if services_switched:
-                await self.plugin_service_host.swap_plugin_services(
-                    plugin_id,
-                    new_services,
-                    old_services,
-                )
+                try:
+                    await self.plugin_service_host.swap_plugin_services(
+                        plugin_id,
+                        new_services,
+                        old_services,
+                    )
+                except BaseException as restore_error:
+                    service_restore_error = restore_error
+            channel_restore_error: BaseException | None = None
             if swap is not None:
                 try:
                     await self.channel_host.restore_plugin_swap(swap)
                 except BaseException as restore_error:
-                    raise RuntimeError("插件旧端点恢复失败") from restore_error
-            raise error
+                    channel_restore_error = restore_error
+            if service_restore_error is not None or channel_restore_error is not None:
+                details: list[str] = []
+                if service_restore_error is not None:
+                    details.append(f"managed service: {service_restore_error}")
+                if channel_restore_error is not None:
+                    details.append(f"Channel: {channel_restore_error}")
+                raise RuntimeError(
+                    "插件旧端点恢复失败: " + "; ".join(details)
+                ) from error
+            raise
         if swap is not None:
             self.channel_host.commit_plugin_swap(swap)
 

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -57,6 +57,12 @@ class ChannelHost:
         current = self._plugin_channels.get(plugin_id, ())
         if current != old_channels:
             raise RuntimeError(f"插件 Channel 代际不一致: {plugin_id}")
+        retained_names = {
+            channel.name for channel in self._channels if channel not in old_channels
+        }
+        new_names = [channel.name for channel in new_channels]
+        if len(new_names) != len(set(new_names)) or retained_names.intersection(new_names):
+            raise RuntimeError(f"Channel 名称冲突: {', '.join(new_names)}")
         old_positions = [
             self._channels.index(channel)
             for channel in old_channels
@@ -65,8 +71,8 @@ class ChannelHost:
         stopped_old: list[Channel] = []
         try:
             for channel in reversed(old_channels):
-                stopped_old.append(channel)
                 await self._stop_channel(channel)
+                stopped_old.append(channel)
         except BaseException as stop_error:
             restore_errors = await self._restore_channels(reversed(stopped_old))
             if restore_errors:
@@ -125,13 +131,11 @@ class ChannelHost:
         self._started.add(id(channel))
 
     async def _stop_channel(self, channel: Channel) -> None:
-        try:
-            await channel.stop()
-        finally:
-            resources = self._resources.pop(id(channel), None)
-            if resources is not None:
-                resources.close()
-            self._started.discard(id(channel))
+        await channel.stop()
+        resources = self._resources.pop(id(channel), None)
+        if resources is not None:
+            resources.close()
+        self._started.discard(id(channel))
 
     @property
     def channels(self) -> list[Channel]:

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from collections.abc import Callable, Iterable
 
 from infra.channels.contract import Channel, ChannelContext
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChannelSwap:
+    plugin_id: str
+    old_channels: tuple[Channel, ...]
+    new_channels: tuple[Channel, ...]
+    old_positions: tuple[int, ...]
+    stopped_old: list[Channel] = field(default_factory=list)
+    started_new: list[Channel] = field(default_factory=list)
 
 
 class ChannelHost:
@@ -54,6 +65,21 @@ class ChannelHost:
         old_channels: tuple[Channel, ...],
         new_channels: tuple[Channel, ...],
     ) -> None:
+        swap = self.prepare_plugin_swap(plugin_id, old_channels, new_channels)
+        await self.stop_plugin_swap(swap)
+        try:
+            await self.start_plugin_swap(swap)
+        except BaseException:
+            await self.restore_plugin_swap(swap)
+            raise
+        self.commit_plugin_swap(swap)
+
+    def prepare_plugin_swap(
+        self,
+        plugin_id: str,
+        old_channels: tuple[Channel, ...],
+        new_channels: tuple[Channel, ...],
+    ) -> ChannelSwap:
         current = self._plugin_channels.get(plugin_id, ())
         if current != old_channels:
             raise RuntimeError(f"插件 Channel 代际不一致: {plugin_id}")
@@ -63,48 +89,60 @@ class ChannelHost:
         new_names = [channel.name for channel in new_channels]
         if len(new_names) != len(set(new_names)) or retained_names.intersection(new_names):
             raise RuntimeError(f"Channel 名称冲突: {', '.join(new_names)}")
-        old_positions = [
+        old_positions = tuple(
             self._channels.index(channel)
             for channel in old_channels
             if channel in self._channels
-        ]
-        stopped_old: list[Channel] = []
+        )
+        return ChannelSwap(plugin_id, old_channels, new_channels, old_positions)
+
+    async def stop_plugin_swap(self, swap: ChannelSwap) -> None:
         try:
-            for channel in reversed(old_channels):
+            for channel in reversed(swap.old_channels):
                 await self._stop_channel(channel)
-                stopped_old.append(channel)
+                swap.stopped_old.append(channel)
         except BaseException as stop_error:
-            restore_errors = await self._restore_channels(reversed(stopped_old))
+            restore_errors = await self._restore_channels(reversed(swap.stopped_old))
+            swap.stopped_old.clear()
             if restore_errors:
                 raise RuntimeError(
                     "旧 Channel 恢复失败: " + "; ".join(restore_errors)
                 ) from stop_error
             raise stop_error
-        started: list[Channel] = []
+
+    async def start_plugin_swap(self, swap: ChannelSwap) -> None:
         try:
-            for channel in new_channels:
-                started.append(channel)
+            for channel in swap.new_channels:
+                swap.started_new.append(channel)
                 await self._start_channel(channel)
         except BaseException as start_error:
-            for channel in reversed(started):
+            for channel in reversed(swap.started_new):
                 try:
                     if id(channel) in self._started:
                         await self._stop_channel(channel)
                 except Exception:
                     logger.exception("候选 Channel 清理失败: %s", channel.name)
-            restore_errors = await self._restore_channels(old_channels)
-            if restore_errors:
-                raise RuntimeError(
-                    "旧 Channel 恢复失败: " + "; ".join(restore_errors)
-                ) from start_error
+            swap.started_new.clear()
             raise start_error
-        for channel in old_channels:
+
+    async def restore_plugin_swap(self, swap: ChannelSwap) -> None:
+        for channel in reversed(swap.started_new):
+            if id(channel) in self._started:
+                await self._stop_channel(channel)
+        swap.started_new.clear()
+        restore_errors = await self._restore_channels(reversed(swap.stopped_old))
+        swap.stopped_old.clear()
+        if restore_errors:
+            raise RuntimeError("旧 Channel 恢复失败: " + "; ".join(restore_errors))
+
+    def commit_plugin_swap(self, swap: ChannelSwap) -> None:
+        for channel in swap.old_channels:
             if channel in self._channels:
                 self._channels.remove(channel)
-        insert_at = min(old_positions, default=len(self._channels))
-        for offset, channel in enumerate(new_channels):
+        insert_at = min(swap.old_positions, default=len(self._channels))
+        for offset, channel in enumerate(swap.new_channels):
             self._channels.insert(insert_at + offset, channel)
-        self._plugin_channels[plugin_id] = new_channels
+        self._plugin_channels[swap.plugin_id] = swap.new_channels
 
     async def _restore_channels(self, channels: Iterable[Channel]) -> list[str]:
         errors: list[str] = []

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from infra.channels.contract import Channel, ChannelContext
 
@@ -16,22 +16,29 @@ class ChannelHost:
         self._ctx_factory = ctx_factory
         self._channels: list[Channel] = []
         self._plugin_channels: dict[str, tuple[Channel, ...]] = {}
+        self._resources: dict[int, _ChannelResources] = {}
+        self._started: set[int] = set()
 
     def add(self, channel: Channel) -> None:
         self._channels.append(channel)
 
     async def start_all(self) -> None:
+        failures: list[str] = []
         for channel in self._channels:
             try:
-                await channel.start(self._ctx_factory(channel))
+                await self._start_channel(channel)
                 print(f"渠道已启动: {channel.name}")
             except Exception as e:
                 logger.error("渠道启动失败 %s: %s", channel.name, e)
+                failures.append(f"{channel.name}: {e}")
+        if failures:
+            raise RuntimeError("渠道启动失败: " + "; ".join(failures))
 
     async def stop_all(self) -> None:
         for channel in reversed(self._channels):
             try:
-                await channel.stop()
+                if id(channel) in self._started:
+                    await self._stop_channel(channel)
             except Exception as e:
                 logger.warning("渠道停止失败 %s: %s", channel.name, e)
 
@@ -59,22 +66,32 @@ class ChannelHost:
         try:
             for channel in reversed(old_channels):
                 stopped_old.append(channel)
-                await channel.stop()
-        except BaseException:
-            for channel in reversed(stopped_old):
-                await channel.start(self._ctx_factory(channel))
-            raise
+                await self._stop_channel(channel)
+        except BaseException as stop_error:
+            restore_errors = await self._restore_channels(reversed(stopped_old))
+            if restore_errors:
+                raise RuntimeError(
+                    "旧 Channel 恢复失败: " + "; ".join(restore_errors)
+                ) from stop_error
+            raise stop_error
         started: list[Channel] = []
         try:
             for channel in new_channels:
                 started.append(channel)
-                await channel.start(self._ctx_factory(channel))
-        except BaseException:
+                await self._start_channel(channel)
+        except BaseException as start_error:
             for channel in reversed(started):
-                await channel.stop()
-            for channel in old_channels:
-                await channel.start(self._ctx_factory(channel))
-            raise
+                try:
+                    if id(channel) in self._started:
+                        await self._stop_channel(channel)
+                except Exception:
+                    logger.exception("候选 Channel 清理失败: %s", channel.name)
+            restore_errors = await self._restore_channels(old_channels)
+            if restore_errors:
+                raise RuntimeError(
+                    "旧 Channel 恢复失败: " + "; ".join(restore_errors)
+                ) from start_error
+            raise start_error
         for channel in old_channels:
             if channel in self._channels:
                 self._channels.remove(channel)
@@ -83,6 +100,104 @@ class ChannelHost:
             self._channels.insert(insert_at + offset, channel)
         self._plugin_channels[plugin_id] = new_channels
 
+    async def _restore_channels(self, channels: Iterable[Channel]) -> list[str]:
+        errors: list[str] = []
+        for channel in channels:
+            try:
+                await self._start_channel(channel)
+            except Exception as error:
+                errors.append(f"{channel.name}: {error}")
+        return errors
+
+    async def _start_channel(self, channel: Channel) -> None:
+        resources = _ChannelResources(self._ctx_factory(channel))
+        self._resources[id(channel)] = resources
+        try:
+            await channel.start(resources.context)
+        except BaseException:
+            try:
+                await channel.stop()
+            except Exception:
+                logger.exception("Channel 部分启动清理失败: %s", channel.name)
+            resources.close()
+            _ = self._resources.pop(id(channel), None)
+            raise
+        self._started.add(id(channel))
+
+    async def _stop_channel(self, channel: Channel) -> None:
+        try:
+            await channel.stop()
+        finally:
+            resources = self._resources.pop(id(channel), None)
+            if resources is not None:
+                resources.close()
+            self._started.discard(id(channel))
+
     @property
     def channels(self) -> list[Channel]:
         return list(self._channels)
+
+
+class _ChannelResources:
+    def __init__(self, context: ChannelContext) -> None:
+        self._closeables: list[object] = []
+        self.context = ChannelContext(
+            bus=_ScopedBus(context.bus, self._closeables),  # type: ignore[arg-type]
+            session_manager=context.session_manager,
+            event_bus=_ScopedEventBus(context.event_bus, self._closeables),  # type: ignore[arg-type]
+            push_tool=_ScopedPushTool(context.push_tool, self._closeables),  # type: ignore[arg-type]
+            attachment_store=context.attachment_store,
+            http_resources=context.http_resources,
+            interrupt_controller=context.interrupt_controller,
+            bot_commands=context.bot_commands,
+            log=context.log,
+        )
+
+    def close(self) -> None:
+        for closeable in reversed(self._closeables):
+            close = getattr(closeable, "close", None)
+            if callable(close):
+                close()
+        self._closeables.clear()
+
+
+class _ScopedBus:
+    def __init__(self, target: object, closeables: list[object]) -> None:
+        self._target = target
+        self._closeables = closeables
+
+    def subscribe_outbound(self, channel: str, callback: object) -> object:
+        subscription = self._target.subscribe_outbound(channel, callback)  # type: ignore[attr-defined]
+        self._closeables.append(subscription)
+        return subscription
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._target, name)
+
+
+class _ScopedEventBus:
+    def __init__(self, target: object, closeables: list[object]) -> None:
+        self._target = target
+        self._closeables = closeables
+
+    def on(self, event_type: type[object], handler: object) -> object:
+        subscription = self._target.on(event_type, handler)  # type: ignore[attr-defined]
+        self._closeables.append(subscription)
+        return subscription
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._target, name)
+
+
+class _ScopedPushTool:
+    def __init__(self, target: object, closeables: list[object]) -> None:
+        self._target = target
+        self._closeables = closeables
+
+    def register_channel(self, channel: str, **senders: object) -> object:
+        registration = self._target.register_channel(channel, **senders)  # type: ignore[attr-defined]
+        self._closeables.append(registration)
+        return registration
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._target, name)

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -15,6 +15,7 @@ class ChannelHost:
     ) -> None:
         self._ctx_factory = ctx_factory
         self._channels: list[Channel] = []
+        self._plugin_channels: dict[str, tuple[Channel, ...]] = {}
 
     def add(self, channel: Channel) -> None:
         self._channels.append(channel)
@@ -33,6 +34,54 @@ class ChannelHost:
                 await channel.stop()
             except Exception as e:
                 logger.warning("渠道停止失败 %s: %s", channel.name, e)
+
+    def bind_plugin_channels(
+        self,
+        channels: dict[str, tuple[Channel, ...]],
+    ) -> None:
+        self._plugin_channels = dict(channels)
+
+    async def swap_plugin_channels(
+        self,
+        plugin_id: str,
+        old_channels: tuple[Channel, ...],
+        new_channels: tuple[Channel, ...],
+    ) -> None:
+        current = self._plugin_channels.get(plugin_id, ())
+        if current != old_channels:
+            raise RuntimeError(f"插件 Channel 代际不一致: {plugin_id}")
+        old_positions = [
+            self._channels.index(channel)
+            for channel in old_channels
+            if channel in self._channels
+        ]
+        stopped_old: list[Channel] = []
+        try:
+            for channel in reversed(old_channels):
+                stopped_old.append(channel)
+                await channel.stop()
+        except BaseException:
+            for channel in reversed(stopped_old):
+                await channel.start(self._ctx_factory(channel))
+            raise
+        started: list[Channel] = []
+        try:
+            for channel in new_channels:
+                started.append(channel)
+                await channel.start(self._ctx_factory(channel))
+        except BaseException:
+            for channel in reversed(started):
+                await channel.stop()
+            for channel in old_channels:
+                await channel.start(self._ctx_factory(channel))
+            raise
+        for channel in old_channels:
+            if channel in self._channels:
+                self._channels.remove(channel)
+        insert_at = min(old_positions, default=len(self._channels))
+        for offset, channel in enumerate(new_channels):
+            self._channels.insert(insert_at + offset, channel)
+        self._plugin_channels[plugin_id] = new_channels
 
     @property
     def channels(self) -> list[Channel]:

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -727,25 +727,6 @@ def create_dashboard_app(
     app = FastAPI(title="Akashic Dashboard API", lifespan=lifespan)
     app.state.memory_admin = memory_admin
     app.state.memory_store = memory_store or MemoryStore(workspace)
-    if plugin_manager is not None:
-        from agent.plugins.dashboard_host import (
-            PluginDashboardHost,
-            SnapshotDashboardMiddleware,
-        )
-
-        dashboard_host = PluginDashboardHost(
-            workspace=workspace,
-            memory_admin=memory_admin,
-            memory_store=app.state.memory_store,
-        )
-        snapshot = plugin_manager.current_snapshot
-        if snapshot is not None:
-            dashboard_host.prepare_initial_snapshot(snapshot)
-        plugin_manager.bind_dashboard_preparer(dashboard_host.prepare_snapshot)
-        app.add_middleware(
-            SnapshotDashboardMiddleware,
-            snapshot_store=plugin_manager.snapshot_store,
-        )
     # Vite build output is gitignored, so a fresh clone (or CI) may lack it. Keep
     # the directory present and mount without a dir check so app creation never
     # depends on the build having run; dashboard_index() reports if it's missing.
@@ -759,7 +740,7 @@ def create_dashboard_app(
 
     # Compile TypeScript plugin panels and mount plugin routes
     for _plugin_id, _plugin_dir in sorted(plugin_dirs.items()):
-        if not _plugin_dashboard_enabled(app, _plugin_dir):
+        if plugin_manager is None and not _plugin_dashboard_enabled(app, _plugin_dir):
             continue
         _build_plugin_panels_js(project_root, _plugin_dir)
         if plugin_manager is None and (_plugin_dir / "dashboard.py").exists():
@@ -785,7 +766,7 @@ def create_dashboard_app(
     def list_dashboard_plugins() -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         for plugin_id, plugin_dir in sorted(_dashboard_plugin_dirs(project_root).items()):
-            if not _plugin_dashboard_enabled(app, plugin_dir):
+            if not dashboard_plugin_enabled(plugin_id, plugin_dir):
                 continue
             _build_plugin_panels_js(project_root, plugin_dir)
             panels: list[dict[str, Any]] = []
@@ -808,7 +789,10 @@ def create_dashboard_app(
             _dashboard_plugin_dirs(project_root),
             plugin_id,
         )
-        if _is_plugin_disabled(plugin_dir) or not _plugin_dashboard_enabled(app, plugin_dir):
+        if _is_plugin_disabled(plugin_dir) or not dashboard_plugin_enabled(
+            plugin_id,
+            plugin_dir,
+        ):
             raise HTTPException(status_code=404, detail="plugin panel not found")
         _build_plugin_panels_js(project_root, plugin_dir)
         js_path = plugin_dir / f"{panel_name}.js"
@@ -824,7 +808,10 @@ def create_dashboard_app(
             _dashboard_plugin_dirs(project_root),
             plugin_id,
         )
-        if _is_plugin_disabled(plugin_dir) or not _plugin_dashboard_enabled(app, plugin_dir):
+        if _is_plugin_disabled(plugin_dir) or not dashboard_plugin_enabled(
+            plugin_id,
+            plugin_dir,
+        ):
             raise HTTPException(status_code=404, detail="plugin panel css not found")
         css_path = plugin_dir / f"{panel_name}.css"
         if not css_path.exists():
@@ -1284,6 +1271,42 @@ def create_dashboard_app(
             "total": len(steps),
             "tick_id": tick_id,
         }
+
+    if plugin_manager is not None:
+        from agent.plugins.dashboard_host import (
+            DashboardBinding,
+            PluginDashboardHost,
+            SnapshotDashboardMiddleware,
+        )
+
+        dashboard_host = PluginDashboardHost(
+            workspace=workspace,
+            memory_admin=memory_admin,
+            memory_store=app.state.memory_store,
+            core_routes=tuple(app.routes),
+        )
+        snapshot = plugin_manager.current_snapshot
+        if snapshot is not None:
+            dashboard_host.prepare_initial_snapshot(snapshot)
+        plugin_manager.bind_dashboard_preparer(dashboard_host.prepare_snapshot)
+        app.add_middleware(
+            SnapshotDashboardMiddleware,
+            snapshot_store=plugin_manager.snapshot_store,
+        )
+
+        def dashboard_plugin_enabled(plugin_id: str, plugin_dir: Path) -> bool:
+            _ = plugin_dir
+            current = plugin_manager.current_snapshot
+            return current is not None and any(
+                isinstance(binding, DashboardBinding)
+                and binding.plugin_id == plugin_id
+                and binding.routes
+                for binding in current.dashboard_bindings
+            )
+    else:
+        def dashboard_plugin_enabled(plugin_id: str, plugin_dir: Path) -> bool:
+            _ = plugin_id
+            return _plugin_dashboard_enabled(app, plugin_dir)
 
     return app
 

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -687,6 +687,7 @@ def create_dashboard_app(
     manual_memory_optimizer: ManualMemoryOptimizer | None = None,
     memory_admin: MemoryAdminApi,
     memory_store: MemoryStore | None = None,
+    plugin_manager: object | None = None,
 ) -> FastAPI:
     workspace.mkdir(parents=True, exist_ok=True)
     store = SessionStore(workspace / "sessions.db")
@@ -726,6 +727,25 @@ def create_dashboard_app(
     app = FastAPI(title="Akashic Dashboard API", lifespan=lifespan)
     app.state.memory_admin = memory_admin
     app.state.memory_store = memory_store or MemoryStore(workspace)
+    if plugin_manager is not None:
+        from agent.plugins.dashboard_host import (
+            PluginDashboardHost,
+            SnapshotDashboardMiddleware,
+        )
+
+        dashboard_host = PluginDashboardHost(
+            workspace=workspace,
+            memory_admin=memory_admin,
+            memory_store=app.state.memory_store,
+        )
+        snapshot = plugin_manager.current_snapshot
+        if snapshot is not None:
+            dashboard_host.prepare_initial_snapshot(snapshot)
+        plugin_manager.bind_dashboard_preparer(dashboard_host.prepare_snapshot)
+        app.add_middleware(
+            SnapshotDashboardMiddleware,
+            snapshot_store=plugin_manager.snapshot_store,
+        )
     # Vite build output is gitignored, so a fresh clone (or CI) may lack it. Keep
     # the directory present and mount without a dir check so app creation never
     # depends on the build having run; dashboard_index() reports if it's missing.
@@ -742,7 +762,7 @@ def create_dashboard_app(
         if not _plugin_dashboard_enabled(app, _plugin_dir):
             continue
         _build_plugin_panels_js(project_root, _plugin_dir)
-        if (_plugin_dir / "dashboard.py").exists():
+        if plugin_manager is None and (_plugin_dir / "dashboard.py").exists():
             plugin_closeables.extend(
                 _load_plugin_dashboard(app, _plugin_dir, workspace)
             )
@@ -1301,6 +1321,7 @@ def _build_dashboard_uvicorn_config(
     manual_memory_optimizer: ManualMemoryOptimizer | None = None,
     memory_admin: MemoryAdminApi,
     memory_store: MemoryStore | None = None,
+    plugin_manager: object | None = None,
 ) -> uvicorn.Config:
     config = uvicorn.Config(
         create_dashboard_app(
@@ -1309,6 +1330,7 @@ def _build_dashboard_uvicorn_config(
             manual_memory_optimizer=manual_memory_optimizer,
             memory_admin=memory_admin,
             memory_store=memory_store,
+            plugin_manager=plugin_manager,
         ),
         host=host,
         port=port,
@@ -1327,6 +1349,7 @@ def build_dashboard_server(
     manual_memory_optimizer: ManualMemoryOptimizer | None = None,
     memory_admin: MemoryAdminApi,
     memory_store: MemoryStore | None = None,
+    plugin_manager: object | None = None,
 ) -> uvicorn.Server:
     config = _build_dashboard_uvicorn_config(
         workspace=workspace,
@@ -1336,5 +1359,6 @@ def build_dashboard_server(
         manual_memory_optimizer=manual_memory_optimizer,
         memory_admin=memory_admin,
         memory_store=memory_store,
+        plugin_manager=plugin_manager,
     )
     return uvicorn.Server(config)

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -37,18 +37,21 @@ _DASHBOARD_ACCESS_PREFIXES = ("/api/dashboard", "/assets", "/plugins/")
 
 def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
     result: dict[str, Path] = {}
-    plugins_root = project_root / "plugins"
-    if plugins_root.is_dir():
-        for plugin_dir in sorted(plugins_root.iterdir()):
-            if not plugin_dir.is_dir():
-                continue
-            result[plugin_dir.name] = plugin_dir
-
     try:
         manifest = load_plugin_manifest()
     except Exception as e:
         logger.warning("插件清单读取失败: %s", e)
-        return result
+        manifest = {}
+    plugins_root = project_root / "plugins"
+    if plugins_root.is_dir():
+        for plugin_dir in sorted(plugins_root.iterdir()):
+            if (
+                not plugin_dir.is_dir()
+                or manifest.get(plugin_dir.name, True) is False
+            ):
+                continue
+            result[plugin_dir.name] = plugin_dir
+
     cache_root = Path.home() / ".akashic-plugin" / "cache"
     for source in resolve_plugin_sources([], installed_cache_root=cache_root):
         plugin_name = source.plugin_root.parent.name

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -35,16 +35,12 @@ logger = logging.getLogger(__name__)
 _DASHBOARD_ACCESS_PREFIXES = ("/api/dashboard", "/assets", "/plugins/")
 
 
-def _is_plugin_disabled(plugin_dir: Path) -> bool:
-    return (plugin_dir / "plugin.disabled").exists()
-
-
 def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
     result: dict[str, Path] = {}
     plugins_root = project_root / "plugins"
     if plugins_root.is_dir():
         for plugin_dir in sorted(plugins_root.iterdir()):
-            if not plugin_dir.is_dir() or _is_plugin_disabled(plugin_dir):
+            if not plugin_dir.is_dir():
                 continue
             result[plugin_dir.name] = plugin_dir
 
@@ -60,7 +56,7 @@ def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
         if manifest.get(plugin_id, True) is False:
             continue
         plugin_root = source.plugin_root.resolve(strict=False)
-        if not plugin_root.is_dir() or _is_plugin_disabled(plugin_root):
+        if not plugin_root.is_dir():
             continue
         result[plugin_id] = plugin_root
     return result
@@ -789,7 +785,7 @@ def create_dashboard_app(
             _dashboard_plugin_dirs(project_root),
             plugin_id,
         )
-        if _is_plugin_disabled(plugin_dir) or not dashboard_plugin_enabled(
+        if not dashboard_plugin_enabled(
             plugin_id,
             plugin_dir,
         ):
@@ -808,7 +804,7 @@ def create_dashboard_app(
             _dashboard_plugin_dirs(project_root),
             plugin_id,
         )
-        if _is_plugin_disabled(plugin_dir) or not dashboard_plugin_enabled(
+        if not dashboard_plugin_enabled(
             plugin_id,
             plugin_dir,
         ):

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -37,11 +37,7 @@ _DASHBOARD_ACCESS_PREFIXES = ("/api/dashboard", "/assets", "/plugins/")
 
 def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
     result: dict[str, Path] = {}
-    try:
-        manifest = load_plugin_manifest()
-    except Exception as e:
-        logger.warning("插件清单读取失败: %s", e)
-        manifest = {}
+    manifest = load_plugin_manifest()
     plugins_root = project_root / "plugins"
     if plugins_root.is_dir():
         for plugin_dir in sorted(plugins_root.iterdir()):

--- a/bootstrap/proactive.py
+++ b/bootstrap/proactive.py
@@ -17,6 +17,7 @@ from proactive_v2.state import ProactiveStateStore
 from session.manager import SessionManager
 
 if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshotStore
     from core.memory.markdown import MarkdownMemoryStore
     from core.memory.runtime import MemoryRuntime
 
@@ -57,6 +58,7 @@ def build_proactive_runtime(
     proactive_module_factories: list[object] | None = None,
     proactive_runtime_factories: list[object] | None = None,
     proactive_sources: list[RegisteredProactiveSource] | None = None,
+    runtime_snapshot_store: RuntimeSnapshotStore | None = None,
 ) -> tuple[list, ProactiveLoop | None]:
     tasks: list = []
     # 1. 总开关关闭时，主动链路完全不启动。
@@ -92,6 +94,7 @@ def build_proactive_runtime(
         proactive_module_factories=proactive_module_factories,
         proactive_runtime_factories=proactive_runtime_factories,
         proactive_sources=proactive_sources,
+        runtime_snapshot_store=runtime_snapshot_store,
     )
 
     # 4. 主动链路本体以后台任务方式常驻运行。

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import inspect
-
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -89,7 +87,7 @@ class CoreRuntime:
     workspace: Path | None = None
 
     async def start(self) -> None:
-        self.mcp_registry.start_connect_all_background()
+        await self.mcp_registry.load_and_connect_all()
 
         if (
             self.peer_poller is not None

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import inspect
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, cast
@@ -245,7 +247,9 @@ class CoreRuntime:
         spawn_tool = self.tools.get_tool("spawn")
         shutdown = getattr(spawn_tool, "shutdown", None)
         if callable(shutdown):
-            await shutdown()
+            result = shutdown()
+            if inspect.isawaitable(result):
+                await cast(Awaitable[object], result)
         await self.event_bus.aclose()
         if self.plugin_manager is not None:
             await self.plugin_manager.terminate_all()

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -242,6 +242,10 @@ class CoreRuntime:
         return "\n".join(parts)
 
     async def stop(self) -> None:
+        spawn_tool = self.tools.get_tool("spawn")
+        shutdown = getattr(spawn_tool, "shutdown", None)
+        if callable(shutdown):
+            await shutdown()
         await self.event_bus.aclose()
         if self.plugin_manager is not None:
             await self.plugin_manager.terminate_all()

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -137,27 +137,6 @@ class CoreRuntime:
                 manifest_path = sync_manifest()
                 logger.info("插件清单已同步: %s", manifest_path)
             logger.info("插件加载完成: %d 个", self.plugin_manager.loaded_count)
-            self.loop.add_before_turn_plugin_modules(
-                self.plugin_manager.before_turn_modules,
-            )
-            self.loop.add_before_reasoning_plugin_modules(
-                self.plugin_manager.before_reasoning_modules,
-            )
-            self.loop.add_prompt_render_plugin_modules(
-                self.plugin_manager.prompt_render_modules,
-            )
-            self.loop.add_before_step_plugin_modules(
-                self.plugin_manager.before_step_modules,
-            )
-            self.loop.add_after_step_plugin_modules(
-                self.plugin_manager.after_step_modules,
-            )
-            self.loop.add_after_reasoning_plugin_modules(
-                self.plugin_manager.after_reasoning_modules,
-            )
-            self.loop.add_after_turn_plugin_modules(
-                self.plugin_manager.after_turn_modules,
-            )
             if self.plugin_manager.tool_hooks:
                 self.loop.add_tool_hooks(self.plugin_manager.tool_hooks)
                 spawn_tool = self.tools.get_tool("spawn")
@@ -538,6 +517,7 @@ def build_core_runtime(
         ),
         installed_cache_root=_resolve_installed_plugin_cache_root(),
     )
+    loop.bind_runtime_snapshot_store(plugin_manager.snapshot_store)
 
     return CoreRuntime(
         config=config,

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -127,11 +127,6 @@ class CoreRuntime:
                     link_result.removed,
                     link_result.skipped,
                 )
-            sync_plugin_servers = getattr(self.mcp_registry, "sync_plugin_servers", None)
-            if callable(sync_plugin_servers):
-                sync_result = sync_plugin_servers(self.plugin_manager.active_plugins())
-                if inspect.isawaitable(sync_result):
-                    await sync_result
             sync_manifest = getattr(self.plugin_manager, "sync_manifest", None)
             if callable(sync_manifest):
                 manifest_path = sync_manifest()

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -509,6 +509,7 @@ def build_core_runtime(
             max_tokens=config.max_tokens,
         ),
         installed_cache_root=_resolve_installed_plugin_cache_root(),
+        user_mcp_server_names=mcp_registry.connected_server_names,
     )
     loop.bind_runtime_snapshot_store(plugin_manager.snapshot_store)
 

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -242,10 +242,10 @@ class CoreRuntime:
         return "\n".join(parts)
 
     async def stop(self) -> None:
+        await self.event_bus.aclose()
         if self.plugin_manager is not None:
             await self.plugin_manager.terminate_all()
         await self.mcp_registry.shutdown()
-        await self.event_bus.aclose()
         if self.peer_poller is not None:
             await self.peer_poller.stop()
         if self.peer_process_manager is not None:

--- a/bootstrap/toolsets/meta.py
+++ b/bootstrap/toolsets/meta.py
@@ -37,7 +37,7 @@ class CommonMetaToolsetProvider(ToolsetProvider):
             push_tool=deps.push_tool,
         )
         registry.register(
-            LoadSkillTool(SkillsLoader(deps.workspace)),
+            LoadSkillTool(SkillsLoader(deps.workspace, runtime_catalog="normal")),
             always_on=True,
             risk="read-only",
             search_hint="技能 skill SKILL.md 使用能力 先 load_skill 不要 read_file 猜路径",

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -16,6 +16,10 @@ E = TypeVar("E")
 Handler: TypeAlias = Callable[[E], Awaitable[E | None] | E | None]
 
 
+class _AnyEvent:
+    pass
+
+
 @dataclass(frozen=True)
 class _QueuedEvent:
     event: object
@@ -45,6 +49,11 @@ class EventBus:
         raw_handler = cast(Handler[object], handler)
         handlers.append(raw_handler)
         return EventSubscription(self, cast(type[object], event_type), raw_handler)
+
+    def on_any(self, handler: Handler[object]) -> EventSubscription:
+        handlers = self._handlers.setdefault(_AnyEvent, [])
+        handlers.append(handler)
+        return EventSubscription(self, _AnyEvent, handler)
 
     def handler_count(self) -> int:
         return sum(len(handlers) for handlers in self._handlers.values())
@@ -310,6 +319,7 @@ class EventBus:
 
     def _handlers_for(self, event_type: type[object]) -> list[Handler[object]]:
         handlers = list(self._handlers.get(event_type, []))
+        handlers.extend(self._handlers.get(_AnyEvent, []))
         from agent.plugins.snapshot import get_current_runtime_snapshot
 
         snapshot = get_current_runtime_snapshot()

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -198,14 +198,18 @@ class EventBus:
         event: object,
         handler: Handler[object],
     ) -> bool:
+        handler_task = asyncio.create_task(
+            self._invoke_observer(handler, event),
+            name=f"event_observer:{_handler_name(handler)}",
+        )
         try:
-            result = handler(event)
-            if inspect.isawaitable(result):
-                await result
+            await asyncio.shield(handler_task)
             return True
         except asyncio.CancelledError:
             task = asyncio.current_task()
             if task is not None and task.cancelling():
+                _ = handler_task.cancel()
+                _ = await asyncio.gather(handler_task, return_exceptions=True)
                 raise
             logger.warning(
                 "observer cancelled for %s handler=%s",
@@ -220,6 +224,15 @@ class EventBus:
                 _handler_name(handler),
             )
             return False
+
+    async def _invoke_observer(
+        self,
+        handler: Handler[object],
+        event: object,
+    ) -> None:
+        result = handler(event)
+        if inspect.isawaitable(result):
+            await result
 
     def _ensure_observe_queue(
         self,

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -35,6 +35,7 @@ class EventBus:
         self._observe_task: asyncio.Task[None] | None = None
         self._closed = False
         self._runtime_snapshot_store: RuntimeSnapshotStore | None = None
+        self._pending_enqueue_tasks: set[asyncio.Task[None]] = set()
 
     def bind_runtime_snapshot_store(self, store: RuntimeSnapshotStore) -> None:
         self._runtime_snapshot_store = store
@@ -77,7 +78,7 @@ class EventBus:
         self,
         event: E,
     ) -> E:
-        lease = self._runtime_lease()
+        lease = await self._runtime_lease()
         if lease is not None:
             from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 
@@ -101,7 +102,7 @@ class EventBus:
         self,
         event: object,
         ) -> None:
-        lease = self._runtime_lease()
+        lease = await self._runtime_lease()
         if lease is not None:
             from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 
@@ -120,7 +121,7 @@ class EventBus:
         self,
         event: object,
     ) -> None:
-        lease = self._runtime_lease()
+        lease = await self._runtime_lease()
         if lease is not None:
             from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 
@@ -166,6 +167,15 @@ class EventBus:
 
         snapshot_lease = lease_current_runtime_snapshot()
         if snapshot_lease is None and self._runtime_snapshot_store is not None:
+            snapshot = self._runtime_snapshot_store.current
+            if snapshot is not None and not snapshot.accepting_leases:
+                task = asyncio.create_task(
+                    self._enqueue_after_admission(event, queue),
+                    name="event_enqueue_admission",
+                )
+                self._pending_enqueue_tasks.add(task)
+                task.add_done_callback(self._pending_enqueue_tasks.discard)
+                return
             snapshot_lease = self._runtime_snapshot_store.lease()
         queue.put_nowait(
             _QueuedEvent(
@@ -174,7 +184,16 @@ class EventBus:
             )
         )
 
-    def _runtime_lease(self) -> RuntimeSnapshotLease | None:
+    async def _enqueue_after_admission(
+        self,
+        event: object,
+        queue: asyncio.Queue[_QueuedEvent],
+    ) -> None:
+        assert self._runtime_snapshot_store is not None
+        lease = await self._runtime_snapshot_store.acquire()
+        queue.put_nowait(_QueuedEvent(event=event, snapshot_lease=lease))
+
+    async def _runtime_lease(self) -> RuntimeSnapshotLease | None:
         if self._runtime_snapshot_store is None:
             return None
         from agent.plugins.snapshot import get_current_runtime_snapshot
@@ -183,7 +202,7 @@ class EventBus:
             return None
         if self._runtime_snapshot_store.current is None:
             return None
-        return self._runtime_snapshot_store.lease()
+        return await self._runtime_snapshot_store.acquire()
 
     async def drain(
         self,
@@ -198,6 +217,14 @@ class EventBus:
         self,
     ) -> None:
         self._closed = True
+        for task in self._pending_enqueue_tasks:
+            _ = task.cancel()
+        if self._pending_enqueue_tasks:
+            _ = await asyncio.gather(
+                *self._pending_enqueue_tasks,
+                return_exceptions=True,
+            )
+        self._pending_enqueue_tasks.clear()
         await self.drain()
         task = self._observe_task
         if task is None:

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -71,7 +71,7 @@ class EventBus:
         event: object,
         ) -> None:
         # 1. 依次执行观察者，单个观察者失败不打断主流程。
-        for handler in self._handlers.get(type(event), []):
+        for handler in list(self._handlers.get(type(event), [])):
             _ = await self._run_observer(event, handler)
 
     async def fanout(

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -126,8 +126,14 @@ class EventBus:
         handlers = self._handlers_for(type(event))
         if not handlers:
             return
+        from agent.plugins.snapshot import lease_current_runtime_snapshot
+
+        leases = [lease_current_runtime_snapshot() for _ in handlers]
         results = await asyncio.gather(
-            *(self._run_observer(event, handler) for handler in handlers)
+            *(
+                self._run_observer(event, handler, snapshot_lease)
+                for handler, snapshot_lease in zip(handlers, leases, strict=True)
+            )
         )
         failed_count = results.count(False)
         if failed_count:
@@ -197,9 +203,13 @@ class EventBus:
         self,
         event: object,
         handler: Handler[object],
+        snapshot_lease: RuntimeSnapshotLease | None = None,
     ) -> bool:
+        from agent.plugins.snapshot import lease_current_runtime_snapshot
+
+        snapshot_lease = snapshot_lease or lease_current_runtime_snapshot()
         handler_task = asyncio.create_task(
-            self._invoke_observer(handler, event),
+            self._invoke_observer(handler, event, snapshot_lease),
             name=f"event_observer:{_handler_name(handler)}",
         )
         try:
@@ -224,12 +234,26 @@ class EventBus:
                 _handler_name(handler),
             )
             return False
+        finally:
+            if snapshot_lease is not None and snapshot_lease.active:
+                await snapshot_lease.release()
 
     async def _invoke_observer(
         self,
         handler: Handler[object],
         event: object,
+        snapshot_lease: RuntimeSnapshotLease | None,
     ) -> None:
+        if snapshot_lease is not None:
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with snapshot_lease:
+                token = bind_runtime_snapshot(snapshot_lease)
+                try:
+                    await self._invoke_observer(handler, event, None)
+                finally:
+                    reset_runtime_snapshot(token)
+            return
         result = handler(event)
         if inspect.isawaitable(result):
             await result

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -25,17 +25,39 @@ class EventBus:
         self,
         event_type: type[E],
         handler: Handler[E],
-    ) -> None:
+    ) -> EventSubscription:
         # 1. 按注册顺序保存 handler，语义由 emit / observe 调用点决定。
         handlers = self._handlers.setdefault(cast(type[object], event_type), [])
-        handlers.append(cast(Handler[object], handler))
+        raw_handler = cast(Handler[object], handler)
+        handlers.append(raw_handler)
+        return EventSubscription(self, cast(type[object], event_type), raw_handler)
+
+    def handler_count(self) -> int:
+        return sum(len(handlers) for handlers in self._handlers.values())
+
+    def off(
+        self,
+        event_type: type[object],
+        handler: Handler[object],
+    ) -> None:
+        handlers = self._handlers.get(event_type)
+        if handlers is None:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            return
+        if not handlers:
+            del self._handlers[event_type]
 
     async def emit(
         self,
         event: E,
     ) -> E:
         # 1. 依次执行干预链，handler 返回新事件时替换当前事件。
-        for raw_handler in self._handlers.get(cast(type[object], type(event)), []):
+        for raw_handler in list(
+            self._handlers.get(cast(type[object], type(event)), [])
+        ):
             handler = cast(Handler[E], raw_handler)
             result = handler(event)
             if inspect.isawaitable(result):
@@ -179,6 +201,29 @@ class EventBus:
             )
         if self._observe_queue is not None:
             self._ensure_observe_task()
+
+
+class EventSubscription:
+    def __init__(
+        self,
+        bus: EventBus,
+        event_type: type[object],
+        handler: Handler[object],
+    ) -> None:
+        self._bus = bus
+        self._event_type = event_type
+        self._handler = handler
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def close(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        self._bus.off(self._event_type, self._handler)
 
 
 def _handler_name(handler: Handler[object]) -> str:

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -4,7 +4,11 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TypeAlias, TypeVar, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeAlias, TypeVar, cast
+
+if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshotLease, RuntimeSnapshotStore
 
 logger = logging.getLogger(__name__)
 
@@ -12,14 +16,24 @@ E = TypeVar("E")
 Handler: TypeAlias = Callable[[E], Awaitable[E | None] | E | None]
 
 
+@dataclass(frozen=True)
+class _QueuedEvent:
+    event: object
+    snapshot_lease: RuntimeSnapshotLease | None
+
+
 class EventBus:
     """Typed lifecycle hooks: observe + ordered intercept pipeline."""
 
     def __init__(self) -> None:
         self._handlers: dict[type[object], list[Handler[object]]] = {}
-        self._observe_queue: asyncio.Queue[object] | None = None
+        self._observe_queue: asyncio.Queue[_QueuedEvent] | None = None
         self._observe_task: asyncio.Task[None] | None = None
         self._closed = False
+        self._runtime_snapshot_store: RuntimeSnapshotStore | None = None
+
+    def bind_runtime_snapshot_store(self, store: RuntimeSnapshotStore) -> None:
+        self._runtime_snapshot_store = store
 
     def on(
         self,
@@ -54,10 +68,18 @@ class EventBus:
         self,
         event: E,
     ) -> E:
+        lease = self._runtime_lease()
+        if lease is not None:
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    return await self.emit(event)
+                finally:
+                    reset_runtime_snapshot(token)
         # 1. 依次执行干预链，handler 返回新事件时替换当前事件。
-        for raw_handler in list(
-            self._handlers.get(cast(type[object], type(event)), [])
-        ):
+        for raw_handler in self._handlers_for(cast(type[object], type(event))):
             handler = cast(Handler[E], raw_handler)
             result = handler(event)
             if inspect.isawaitable(result):
@@ -70,16 +92,38 @@ class EventBus:
         self,
         event: object,
         ) -> None:
+        lease = self._runtime_lease()
+        if lease is not None:
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    await self.observe(event)
+                    return
+                finally:
+                    reset_runtime_snapshot(token)
         # 1. 依次执行观察者，单个观察者失败不打断主流程。
-        for handler in list(self._handlers.get(type(event), [])):
+        for handler in self._handlers_for(type(event)):
             _ = await self._run_observer(event, handler)
 
     async def fanout(
         self,
         event: object,
     ) -> None:
+        lease = self._runtime_lease()
+        if lease is not None:
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    await self.fanout(event)
+                    return
+                finally:
+                    reset_runtime_snapshot(token)
         # 1. 并发执行观察者；每个观察者自己记录异常，fanout 只汇总失败数量。
-        handlers = list(self._handlers.get(type(event), []))
+        handlers = self._handlers_for(type(event))
         if not handlers:
             return
         results = await asyncio.gather(
@@ -103,7 +147,28 @@ class EventBus:
             logger.warning("event enqueue ignored after close: %s", type(event).__name__)
             return
         queue = self._ensure_observe_queue()
-        queue.put_nowait(event)
+        from agent.plugins.snapshot import lease_current_runtime_snapshot
+
+        snapshot_lease = lease_current_runtime_snapshot()
+        if snapshot_lease is None and self._runtime_snapshot_store is not None:
+            snapshot_lease = self._runtime_snapshot_store.lease()
+        queue.put_nowait(
+            _QueuedEvent(
+                event=event,
+                snapshot_lease=snapshot_lease,
+            )
+        )
+
+    def _runtime_lease(self) -> RuntimeSnapshotLease | None:
+        if self._runtime_snapshot_store is None:
+            return None
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        if get_current_runtime_snapshot() is not None:
+            return None
+        if self._runtime_snapshot_store.current is None:
+            return None
+        return self._runtime_snapshot_store.lease()
 
     async def drain(
         self,
@@ -148,7 +213,7 @@ class EventBus:
 
     def _ensure_observe_queue(
         self,
-    ) -> asyncio.Queue[object]:
+    ) -> asyncio.Queue[_QueuedEvent]:
         if self._observe_queue is None:
             self._observe_queue = asyncio.Queue()
         self._ensure_observe_task()
@@ -175,11 +240,34 @@ class EventBus:
             queue = self._observe_queue
             if queue is None:
                 return
-            event = await queue.get()
+            envelope = await queue.get()
             try:
-                await self.fanout(event)
+                await self._fanout_queued(envelope)
             finally:
                 queue.task_done()
+
+    async def _fanout_queued(self, envelope: _QueuedEvent) -> None:
+        lease = envelope.snapshot_lease
+        if lease is None:
+            await self.fanout(envelope.event)
+            return
+        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+        async with lease:
+            token = bind_runtime_snapshot(lease)
+            try:
+                await self.fanout(envelope.event)
+            finally:
+                reset_runtime_snapshot(token)
+
+    def _handlers_for(self, event_type: type[object]) -> list[Handler[object]]:
+        handlers = list(self._handlers.get(event_type, []))
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        snapshot = get_current_runtime_snapshot()
+        if snapshot is not None:
+            handlers.extend(snapshot.event_handlers.get(event_type, ()))
+        return handlers
 
     def _on_observe_task_done(
         self,

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -126,13 +126,13 @@ class EventBus:
         handlers = self._handlers_for(type(event))
         if not handlers:
             return
-        from agent.plugins.snapshot import lease_current_runtime_snapshot
+        from agent.plugins.snapshot import get_current_runtime_lease
 
-        leases = [lease_current_runtime_snapshot() for _ in handlers]
+        source_lease = get_current_runtime_lease()
         results = await asyncio.gather(
             *(
-                self._run_observer(event, handler, snapshot_lease)
-                for handler, snapshot_lease in zip(handlers, leases, strict=True)
+                self._run_observer(event, handler, source_lease)
+                for handler in handlers
             )
         )
         failed_count = results.count(False)
@@ -203,11 +203,12 @@ class EventBus:
         self,
         event: object,
         handler: Handler[object],
-        snapshot_lease: RuntimeSnapshotLease | None = None,
+        source_lease: RuntimeSnapshotLease | None = None,
     ) -> bool:
-        from agent.plugins.snapshot import lease_current_runtime_snapshot
+        from agent.plugins.snapshot import get_current_runtime_lease
 
-        snapshot_lease = snapshot_lease or lease_current_runtime_snapshot()
+        source_lease = source_lease or get_current_runtime_lease()
+        snapshot_lease = source_lease.fork() if source_lease is not None else None
         handler_task = asyncio.create_task(
             self._invoke_observer(handler, event, snapshot_lease),
             name=f"event_observer:{_handler_name(handler)}",

--- a/bus/event_bus.py
+++ b/bus/event_bus.py
@@ -182,8 +182,8 @@ class EventBus:
     async def aclose(
         self,
     ) -> None:
-        await self.drain()
         self._closed = True
+        await self.drain()
         task = self._observe_task
         if task is None:
             return
@@ -203,6 +203,16 @@ class EventBus:
             if inspect.isawaitable(result):
                 await result
             return True
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                raise
+            logger.warning(
+                "observer cancelled for %s handler=%s",
+                type(event).__name__,
+                _handler_name(handler),
+            )
+            return False
         except Exception:
             logger.exception(
                 "observer error for %s handler=%s",

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -119,6 +119,25 @@ class ChatLane:
                 state.condition.notify_all()
 
 
+class OutboundSubscription:
+    def __init__(
+        self,
+        bus: "MessageBus",
+        channel: str,
+        callback: Callable[[OutboundMessage], Awaitable[None]],
+    ) -> None:
+        self._bus = bus
+        self._channel = channel
+        self._callback = callback
+        self._active = True
+
+    def close(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        self._bus.unsubscribe_outbound(self._channel, self._callback)
+
+
 class MessageBus:
     """agent 与各 channel 之间的异步消息总线"""
 
@@ -152,9 +171,25 @@ class MessageBus:
         self,
         channel: str,
         callback: Callable[[OutboundMessage], Awaitable[None]],
-    ) -> None:
+    ) -> OutboundSubscription:
         """订阅某 channel 的出站消息"""
         self._subscribers.setdefault(channel, []).append(callback)
+        return OutboundSubscription(self, channel, callback)
+
+    def unsubscribe_outbound(
+        self,
+        channel: str,
+        callback: Callable[[OutboundMessage], Awaitable[None]],
+    ) -> None:
+        callbacks = self._subscribers.get(channel)
+        if callbacks is None:
+            return
+        try:
+            callbacks.remove(callback)
+        except ValueError:
+            return
+        if not callbacks:
+            del self._subscribers[channel]
 
     async def dispatch_outbound(self) -> None:
         """后台任务：将出站消息分发给对应 channel 的订阅者。

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -37,6 +37,37 @@ container
 - 启动脚本会拒绝 `/sandbox` 外的 config/workspace 路径。
 - `profiles/` 已加入 `.gitignore`，不要提交调试 bot token 和测试记忆。
 
+## 插件变更 Gate
+
+`akashic-plugin-gate` 用于在真实 Runtime 中验证插件系统改动。它不会复用普通调试容器的可写源码挂载或宿主插件缓存。
+
+```text
+┌─ 宿主
+│  ├─ akasic-agent             只读挂载到 /app
+│  └─ akashic-plugin/*         只读挂载到 /fixtures/plugins
+├─ 容器
+│  ├─ root filesystem          只读
+│  ├─ /tmp                     tmpfs
+│  └─ /sandbox                 唯一持久可写目录
+│     ├─ home/.akashic-plugin/cache
+│     ├─ workspace
+│     └─ reports
+└─ Compose project
+   └─ akashic-plugin-reload-gate
+```
+
+先运行完整性 Gate：
+
+```bash
+AKASHIC_DEBUG_PROFILE=plugin-reload-gate \
+docker compose -p akashic-plugin-reload-gate \
+  -f docker/debug/docker-compose.yml \
+  --profile plugin-gate run --rm akashic-plugin-gate \
+  python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity
+```
+
+该场景会检查挂载权限、沙盒路径和各 Git 仓库状态，并在隔离插件缓存中完成一次写入与更新。报告保存在 `docker/debug/profiles/plugin-reload-gate/reports/`。
+
 ## 第一次配置
 
 ```bash

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -56,17 +56,13 @@ container
    └─ akashic-plugin-reload-gate
 ```
 
-先运行完整性 Gate：
+从宿主运行完整性 Gate：
 
 ```bash
-AKASHIC_DEBUG_PROFILE=plugin-reload-gate \
-docker compose -p akashic-plugin-reload-gate \
-  -f docker/debug/docker-compose.yml \
-  --profile plugin-gate run --rm akashic-plugin-gate \
-  python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity
+python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity
 ```
 
-该场景会检查挂载权限、沙盒路径和各 Git 仓库状态，并在隔离插件缓存中完成一次写入与更新。报告保存在 `docker/debug/profiles/plugin-reload-gate/reports/`。
+宿主控制器会在 `/tmp` 创建唯一 sandbox，拒绝仓库内路径，再启动容器检查挂载权限和沙盒路径。它还会审计各 Git 仓库状态，并在隔离插件缓存中完成一次写入与更新。报告路径会在运行结果中给出；Compose 未收到控制器设置的 `AKASHIC_GATE_SANDBOX` 时会拒绝启动。
 
 ## 第一次配置
 

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -71,6 +71,13 @@ python docker/debug/plugin_hot_reload_probe.py \
   --scenario full-runtime --phase scope
 ```
 
+候选 Gate 场景会同时安装有效和无效插件，确认真实 Runtime 只初始化通过静态 Gate 的 generation：
+
+```bash
+python docker/debug/plugin_hot_reload_probe.py \
+  --scenario full-runtime --phase candidate
+```
+
 ## 第一次配置
 
 ```bash

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -62,7 +62,14 @@ container
 python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity
 ```
 
-宿主控制器会在 `/tmp` 创建唯一 sandbox，拒绝仓库内路径，再启动容器检查挂载权限和沙盒路径。它还会审计各 Git 仓库状态，并在隔离插件缓存中完成一次写入与更新。报告路径会在运行结果中给出；Compose 未收到控制器设置的 `AKASHIC_GATE_SANDBOX` 时会拒绝启动。
+宿主控制器会在 `/tmp` 创建唯一 sandbox，拒绝仓库内路径，再通过独立的 `docker-compose.plugin-gate.yml` 启动容器。普通 `docker-compose.yml` 不受 Gate 环境变量影响。控制器会审计各 Git 仓库状态，并在隔离插件缓存中完成一次写入与更新；Runtime 需要的 `static/` 也覆盖到外部 sandbox，不会写 `/app`。
+
+插件资源作用域场景会安装一次性测试插件，并在真实 `main.py` 的启动和关闭过程中验证订阅、任务与清理回调：
+
+```bash
+python docker/debug/plugin_hot_reload_probe.py \
+  --scenario full-runtime --phase scope
+```
 
 ## 第一次配置
 

--- a/docker/debug/docker-compose.plugin-gate.yml
+++ b/docker/debug/docker-compose.plugin-gate.yml
@@ -1,0 +1,22 @@
+services:
+  akashic-plugin-gate:
+    build:
+      context: ../..
+      dockerfile: docker/debug/Dockerfile
+    image: akashic-agent-plugin-gate:latest
+    working_dir: /app
+    read_only: true
+    environment:
+      AKASHIC_DEBUG_CONFIG: /sandbox/config.toml
+      AKASHIC_DEBUG_WORKSPACE: /sandbox/workspace
+      AKASHIC_HOST_GID: "${GID:?set by plugin_hot_reload_probe.py}"
+      AKASHIC_HOST_UID: "${UID:?set by plugin_hot_reload_probe.py}"
+      HOME: /sandbox/home
+      PYTHONUNBUFFERED: "1"
+    volumes:
+      - ../..:/app:ro
+      - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}:/sandbox
+      - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}/static:/app/static
+      - ${AKASHIC_PLUGIN_SOURCE:?set by plugin_hot_reload_probe.py}:/fixtures/plugins:ro
+    tmpfs:
+      - /tmp

--- a/docker/debug/docker-compose.plugin-gate.yml
+++ b/docker/debug/docker-compose.plugin-gate.yml
@@ -11,6 +11,7 @@ services:
       AKASHIC_DEBUG_WORKSPACE: /sandbox/workspace
       AKASHIC_HOST_GID: "${GID:?set by plugin_hot_reload_probe.py}"
       AKASHIC_HOST_UID: "${UID:?set by plugin_hot_reload_probe.py}"
+      AKASHIC_PLUGIN_LOG_LEVEL: DEBUG
       HOME: /sandbox/home
       PYTHONUNBUFFERED: "1"
     volumes:

--- a/docker/debug/docker-compose.yml
+++ b/docker/debug/docker-compose.yml
@@ -25,3 +25,26 @@ services:
       - "host.docker.internal:host-gateway"
     stdin_open: true
     tty: true
+
+  akashic-plugin-gate:
+    profiles:
+      - plugin-gate
+    build:
+      context: ../..
+      dockerfile: docker/debug/Dockerfile
+    image: akashic-agent-debug:latest
+    working_dir: /app
+    read_only: true
+    environment:
+      AKASHIC_DEBUG_CONFIG: /sandbox/config.toml
+      AKASHIC_DEBUG_WORKSPACE: /sandbox/workspace
+      AKASHIC_HOST_GID: "${GID:-1000}"
+      AKASHIC_HOST_UID: "${UID:-1000}"
+      HOME: /sandbox/home
+      PYTHONUNBUFFERED: "1"
+    volumes:
+      - ../..:/app:ro
+      - ./profiles/${AKASHIC_DEBUG_PROFILE:-plugin-reload-gate}:/sandbox
+      - ${AKASHIC_PLUGIN_SOURCE:-/mnt/data/coding/akashic-plugin}:/fixtures/plugins:ro
+    tmpfs:
+      - /tmp

--- a/docker/debug/docker-compose.yml
+++ b/docker/debug/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       PYTHONUNBUFFERED: "1"
     volumes:
       - ../..:/app:ro
-      - ./profiles/${AKASHIC_DEBUG_PROFILE:-plugin-reload-gate}:/sandbox
+      - ${AKASHIC_GATE_SANDBOX:?AKASHIC_GATE_SANDBOX must be set by plugin_hot_reload_probe.py}:/sandbox
       - ${AKASHIC_PLUGIN_SOURCE:-/mnt/data/coding/akashic-plugin}:/fixtures/plugins:ro
     tmpfs:
       - /tmp

--- a/docker/debug/docker-compose.yml
+++ b/docker/debug/docker-compose.yml
@@ -25,26 +25,3 @@ services:
       - "host.docker.internal:host-gateway"
     stdin_open: true
     tty: true
-
-  akashic-plugin-gate:
-    profiles:
-      - plugin-gate
-    build:
-      context: ../..
-      dockerfile: docker/debug/Dockerfile
-    image: akashic-agent-debug:latest
-    working_dir: /app
-    read_only: true
-    environment:
-      AKASHIC_DEBUG_CONFIG: /sandbox/config.toml
-      AKASHIC_DEBUG_WORKSPACE: /sandbox/workspace
-      AKASHIC_HOST_GID: "${GID:-1000}"
-      AKASHIC_HOST_UID: "${UID:-1000}"
-      HOME: /sandbox/home
-      PYTHONUNBUFFERED: "1"
-    volumes:
-      - ../..:/app:ro
-      - ${AKASHIC_GATE_SANDBOX:?AKASHIC_GATE_SANDBOX must be set by plugin_hot_reload_probe.py}:/sandbox
-      - ${AKASHIC_PLUGIN_SOURCE:-/mnt/data/coding/akashic-plugin}:/fixtures/plugins:ro
-    tmpfs:
-      - /tmp

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -533,6 +533,17 @@ def _install_candidate_plugins(
         "    print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n",
         encoding="utf-8",
     )
+    _ = (reload_plugin / "candidate_service.py").write_text(
+        "import os\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers()\n"
+        "        self.wfile.write(os.environ['CANDIDATE_VERSION'].encode())\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', 18767), Handler).serve_forever()\n",
+        encoding="utf-8",
+    )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
     (data / "candidate_reload-gate").mkdir(parents=True, exist_ok=True)
@@ -580,7 +591,7 @@ def _candidate_reload_source(version: str) -> str:
         "from agent.skills import SkillsLoader\n"
         "from agent.tool_hooks import ToolExecutionRequest, ToolExecutor\n"
         "from bus.events_lifecycle import TurnCommitted\n"
-        "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
+        "from agent.plugins import (IntervalTrigger, ManagedServiceSpec, McpServerSpec, Plugin, PluginJobSpec, "
         "PluginSemanticCheck, ProactiveSourceSpec, on_tool_pre, tool)\n"
         "class SnapshotBeforeTurn:\n"
         "    slot = 'candidate_reload.before_turn'\n"
@@ -619,6 +630,9 @@ def _candidate_reload_source(version: str) -> str:
         "    @classmethod\n"
         "    def mcp_servers(cls):\n"
         f"        return [McpServerSpec(name='candidate_feed', command=('python', 'candidate_mcp_server.py'), env={{'CANDIDATE_VERSION': '{version}'}})]\n"
+        "    @classmethod\n"
+        "    def managed_services(cls):\n"
+        f"        return [ManagedServiceSpec(id='candidate_http', command=('python', 'candidate_service.py'), env={{'CANDIDATE_VERSION': '{version}'}}, readiness_url='http://127.0.0.1:18767/')]\n"
         "    def proactive_sources(self):\n"
         "        return [ProactiveSourceSpec(id='candidate_feed', channels=('content',), "
         "server='candidate_feed', fetch_tool='fetch_events', ack_tool='ack_events', "
@@ -792,6 +806,28 @@ def _container_process_count(container_id: str, marker: str) -> int:
         return -1
 
 
+def _candidate_service_version(container_id: str) -> str:
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container_id,
+            "python",
+            "-c",
+            (
+                "import urllib.request; "
+                "print(urllib.request.urlopen('http://127.0.0.1:18767/', "
+                "timeout=2).read().decode())"
+            ),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
 def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
     script = (
         "import json, urllib.request\n"
@@ -906,6 +942,11 @@ def _exercise_snapshot_publish(
 ) -> dict[str, object]:
     initial = _read_json_object(state_path)
     initial_generation = initial.get("active_generation")
+    initial_service_version = _candidate_service_version(container_id)
+    initial_service_processes = _container_process_count(
+        container_id,
+        "candidate_service.py",
+    )
     baseline_before = _candidate_statuses(container_id)
     _ = source_path.write_text("not valid python !!!\n", encoding="utf-8")
     baseline_signal = subprocess.run(
@@ -945,15 +986,20 @@ def _exercise_snapshot_publish(
             after=len(candidate_before),
             gate_status="passed",
         )
+        _ = turn_release.write_text("released\n", encoding="utf-8")
+        old_response = old_turn.result(timeout=10)
         _, publish_status = _wait_snapshot_status(
             container_id,
             after=len(publish_before),
             publication_state="committed",
         )
-        _ = turn_release.write_text("released\n", encoding="utf-8")
-        old_response = old_turn.result(timeout=10)
 
     new_response = _ipc_roundtrip(socket_path, "snapshot after publish")
+    final_service_version = _candidate_service_version(container_id)
+    final_service_processes = _container_process_count(
+        container_id,
+        "candidate_service.py",
+    )
     _ = detached_release.write_text("released\n", encoding="utf-8")
     final_state = _wait_json_value(
         state_path,
@@ -976,6 +1022,10 @@ def _exercise_snapshot_publish(
         and current_snapshot != initial_snapshot
         and old_response.get("content") == "snapshot-v1"
         and new_response.get("content") == "snapshot-v2"
+        and initial_service_version == "v1"
+        and final_service_version == "v2"
+        and initial_service_processes == 1
+        and final_service_processes == 1
         and _integer(final_state.get("phase_runs_v1")) >= 1
         and _integer(final_state.get("phase_runs_v2")) >= 1
         and final_state.get("detached_snapshot_visible") is False
@@ -989,6 +1039,12 @@ def _exercise_snapshot_publish(
         "publish_status": publish_status,
         "old_response": old_response,
         "new_response": new_response,
+        "managed_service": {
+            "initial_version": initial_service_version,
+            "final_version": final_service_version,
+            "initial_processes": initial_service_processes,
+            "final_processes": final_service_processes,
+        },
         "final_state": final_state,
         "signal": signal_result.returncode,
     }

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from collections.abc import Callable
@@ -545,6 +546,11 @@ def _candidate_reload_source(version: str) -> str:
         f"        self.plugin.context.kv_store.increment('phase_runs_{version}')\n"
         "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"
+        f"        if '{version}' == 'v1' and ctx.content == 'block snapshot':\n"
+        "            self.plugin.context.kv_store.set('blocked_v1_turn', True)\n"
+        "            release = self.plugin.context.data_dir / 'release-v1-turn'\n"
+        "            while not release.exists():\n"
+        "                await asyncio.sleep(0.01)\n"
         "        ctx.abort = True\n"
         f"        ctx.abort_reply = 'snapshot-{version}'\n"
         "        return frame\n"
@@ -675,6 +681,29 @@ def _candidate_statuses(container_id: str) -> list[dict[str, object]]:
     return statuses
 
 
+def _snapshot_statuses(container_id: str) -> list[dict[str, object]]:
+    logs = subprocess.run(
+        ["docker", "logs", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).stdout
+    marker = "plugin_snapshot_status "
+    statuses: list[dict[str, object]] = []
+    for line in logs.splitlines():
+        if marker not in line:
+            continue
+        try:
+            raw: object = json.loads(line.split(marker, 1)[1].strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(raw, dict):
+            mapping = cast(dict[object, object], raw)
+            statuses.append({str(key): value for key, value in mapping.items()})
+    return statuses
+
+
 def _container_process_count(container_id: str, marker: str) -> int:
     script = (
         "import os\n"
@@ -762,6 +791,121 @@ def _wait_candidate_status(
                 return statuses, status
         time.sleep(0.1)
     return _candidate_statuses(container_id), {}
+
+
+def _wait_snapshot_status(
+    container_id: str,
+    *,
+    after: int,
+    publication_state: str,
+) -> tuple[list[dict[str, object]], dict[str, object]]:
+    deadline = time.monotonic() + 8
+    while time.monotonic() < deadline:
+        statuses = _snapshot_statuses(container_id)
+        for status in statuses[after:]:
+            if (
+                status.get("plugin_id") == "candidate_reload@gate"
+                and status.get("publication_state") == publication_state
+            ):
+                return statuses, status
+        time.sleep(0.1)
+    return _snapshot_statuses(container_id), {}
+
+
+def _exercise_snapshot_publish(
+    container_id: str,
+    source_path: Path,
+    state_path: Path,
+    socket_path: Path,
+) -> dict[str, object]:
+    initial = _read_json_object(state_path)
+    initial_generation = initial.get("active_generation")
+    baseline_before = _candidate_statuses(container_id)
+    _ = source_path.write_text("not valid python !!!\n", encoding="utf-8")
+    baseline_signal = subprocess.run(
+        ["docker", "kill", "--signal", "HUP", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    _, baseline_status = _wait_candidate_status(
+        container_id,
+        after=len(baseline_before),
+        gate_status="failed",
+    )
+    initial_snapshot = baseline_status.get("snapshot_id")
+    _ = source_path.write_text(_candidate_reload_source("v1"), encoding="utf-8")
+    turn_release = state_path.parent / "release-v1-turn"
+    detached_release = state_path.parent / "release-detached-probe"
+    turn_release.unlink(missing_ok=True)
+    detached_release.unlink(missing_ok=True)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        old_turn = executor.submit(_ipc_roundtrip, socket_path, "block snapshot")
+        blocked = _wait_json_value(state_path, "blocked_v1_turn", True)
+        _ = source_path.write_text(_candidate_reload_source("v2"), encoding="utf-8")
+        candidate_before = _candidate_statuses(container_id)
+        publish_before = _snapshot_statuses(container_id)
+        signal_result = subprocess.run(
+            ["docker", "kill", "--signal", "HUP", container_id],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        _, candidate_status = _wait_candidate_status(
+            container_id,
+            after=len(candidate_before),
+            gate_status="passed",
+        )
+        _, publish_status = _wait_snapshot_status(
+            container_id,
+            after=len(publish_before),
+            publication_state="committed",
+        )
+        _ = turn_release.write_text("released\n", encoding="utf-8")
+        old_response = old_turn.result(timeout=10)
+
+    new_response = _ipc_roundtrip(socket_path, "snapshot after publish")
+    _ = detached_release.write_text("released\n", encoding="utf-8")
+    final_state = _wait_json_value(
+        state_path,
+        "detached_snapshot_visible",
+        False,
+    )
+    current_snapshot = publish_status.get("snapshot_id")
+    passed = (
+        signal_result.returncode == 0
+        and baseline_signal.returncode == 0
+        and isinstance(initial_generation, str)
+        and blocked.get("blocked_v1_turn") is True
+        and candidate_status.get("active_generation") == initial_generation
+        and isinstance(candidate_status.get("prepared_generation"), str)
+        and publish_status.get("old_generation") == initial_generation
+        and publish_status.get("new_generation")
+        == candidate_status.get("prepared_generation")
+        and isinstance(current_snapshot, str)
+        and isinstance(initial_snapshot, str)
+        and current_snapshot != initial_snapshot
+        and old_response.get("content") == "snapshot-v1"
+        and new_response.get("content") == "snapshot-v2"
+        and _integer(final_state.get("phase_runs_v1")) >= 1
+        and _integer(final_state.get("phase_runs_v2")) >= 1
+        and final_state.get("detached_snapshot_visible") is False
+    )
+    return {
+        "passed": passed,
+        "initial_generation": initial_generation,
+        "initial_snapshot": initial_snapshot,
+        "blocked": blocked,
+        "candidate_status": candidate_status,
+        "publish_status": publish_status,
+        "old_response": old_response,
+        "new_response": new_response,
+        "final_state": final_state,
+        "signal": signal_result.returncode,
+    }
 
 
 def _exercise_candidate_prepare(
@@ -1038,7 +1182,7 @@ def _run_runtime_smoke(
     scope_state = _install_scope_plugin(sandbox) if phase == "scope" else None
     candidate_states = (
         _install_candidate_plugins(sandbox)
-        if phase in {"candidate", "capability-hosts"}
+        if phase in {"candidate", "capability-hosts", "snapshot"}
         else None
     )
     started = subprocess.run(
@@ -1108,12 +1252,20 @@ def _run_runtime_smoke(
         ).stdout
     candidate_prepare: dict[str, object] = {}
     if candidate_states is not None and container_id and runtime_stable:
-        candidate_prepare = _exercise_candidate_prepare(
-            container_id,
-            candidate_states[4],
-            candidate_states[5],
-            socket,
-        )
+        if phase == "snapshot":
+            candidate_prepare = _exercise_snapshot_publish(
+                container_id,
+                candidate_states[4],
+                candidate_states[5],
+                socket,
+            )
+        else:
+            candidate_prepare = _exercise_candidate_prepare(
+                container_id,
+                candidate_states[4],
+                candidate_states[5],
+                socket,
+            )
     logs = subprocess.run(
         [*compose, "logs", "--no-color", "--tail", "200", "akashic-plugin-gate"],
         cwd=repo,
@@ -1278,7 +1430,7 @@ def main() -> int:
     )
     _ = parser.add_argument(
         "--phase",
-        choices=("smoke", "scope", "candidate", "capability-hosts"),
+        choices=("smoke", "scope", "candidate", "capability-hosts", "snapshot"),
         default="smoke",
     )
     _ = parser.add_argument("--inside-container", action="store_true")

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -471,10 +471,11 @@ def _install_candidate_plugins(
             encoding="utf-8",
         )
     _ = (reload_plugin / "candidate_mcp_server.py").write_text(
-        "import json, sys\n"
+        "import json, os, sys\n"
+        "version = os.environ['CANDIDATE_VERSION']\n"
         "tools = [\n"
         "    {'name': name, 'description': name, 'inputSchema': {'type': 'object', 'properties': {}}}\n"
-        "    for name in ('fetch_events', 'ack_events', 'poll_events')\n"
+        "    for name in ('fetch_events', 'ack_events', 'poll_events', 'candidate_version')\n"
         "]\n"
         "for line in sys.stdin:\n"
         "    msg = json.loads(line)\n"
@@ -483,7 +484,9 @@ def _install_candidate_plugins(
         "    method = msg.get('method')\n"
         "    result = {'tools': tools} if method == 'tools/list' else {}\n"
         "    if method == 'tools/call':\n"
-        "        result = {'content': [{'type': 'text', 'text': '[]'}]}\n"
+        "        tool = msg.get('params', {}).get('name')\n"
+        "        text = version if tool == 'candidate_version' else '[]'\n"
+        "        result = {'content': [{'type': 'text', 'text': text}]}\n"
         "    print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n",
         encoding="utf-8",
     )
@@ -508,6 +511,10 @@ def _candidate_reload_source(version: str) -> str:
         "        while True:\n"
         "            self.context.kv_store.increment('heartbeats')\n"
         "            self.context.kv_store.set('active_generation', self.context.generation_id)\n"
+        "            registry = self.context.tool_registry\n"
+        "            if registry is not None and registry.has_tool('mcp_candidate_feed__candidate_version'):\n"
+        "                result = await registry.execute('mcp_candidate_feed__candidate_version', {}, raise_errors=True)\n"
+        "                self.context.kv_store.set('live_mcp_version', getattr(result, 'text', str(result)))\n"
         "            await asyncio.sleep(0.05)\n"
         if version == "v1"
         else "        self.context.kv_store.set('initialized_version', 'v2')\n"
@@ -523,17 +530,21 @@ def _candidate_reload_source(version: str) -> str:
     return (
         "from __future__ import annotations\n"
         "import asyncio\n"
-        "from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec, tool\n"
+        "from agent.plugins import McpServerSpec, Plugin, PluginSemanticCheck, ProactiveSourceSpec, tool\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
         f"{skills}"
         "    @classmethod\n"
         "    def mcp_servers(cls):\n"
-        "        return [McpServerSpec(name='candidate_feed', command=('python', 'candidate_mcp_server.py'))]\n"
+        f"        return [McpServerSpec(name='candidate_feed', command=('python', 'candidate_mcp_server.py'), env={{'CANDIDATE_VERSION': '{version}'}})]\n"
         "    def proactive_sources(self):\n"
         "        return [ProactiveSourceSpec(id='candidate_feed', channels=('content',), "
         "server='candidate_feed', fetch_tool='fetch_events', ack_tool='ack_events', "
         "poll_tool='poll_events')]\n"
+        "    async def readiness_semantic_checks(self, context):\n"
+        "        server = context.mcp_catalog.servers['candidate_feed']\n"
+        "        value = await server.client.call('candidate_version', {})\n"
+        f"        return [PluginSemanticCheck('candidate_mcp_version', value == '{version}', value)]\n"
         "    @tool(name='candidate_reload_tool')\n"
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
@@ -732,6 +743,7 @@ def _exercise_candidate_prepare(
         "candidate_mcp_server.py",
         lambda count: count == initial_mcp_processes,
     )
+    after_return = _read_json_object(state_path)
     valid_skills = valid_status.get("skills")
     valid_descriptions = valid_status.get("skill_descriptions")
     valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
@@ -740,6 +752,7 @@ def _exercise_candidate_prepare(
     return_body_hashes = return_status.get("skill_body_hashes")
     return_drift_body_hashes = return_status.get("drift_skill_body_hashes")
     valid_mcp_tools = valid_status.get("mcp_tools")
+    valid_readiness_checks = valid_status.get("readiness_checks")
     valid_description_map = (
         cast(dict[object, object], valid_descriptions)
         if isinstance(valid_descriptions, dict)
@@ -773,8 +786,18 @@ def _exercise_candidate_prepare(
         and valid_mcp_tools
         == [
             "mcp_candidate_feed__ack_events",
+            "mcp_candidate_feed__candidate_version",
             "mcp_candidate_feed__fetch_events",
             "mcp_candidate_feed__poll_events",
+        ]
+        and isinstance(valid_readiness_checks, list)
+        and valid_readiness_checks
+        == [
+            {
+                "check_id": "candidate_mcp_version",
+                "passed": True,
+                "evidence": "v2",
+            }
         ]
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
@@ -792,6 +815,8 @@ def _exercise_candidate_prepare(
         and after_invalid.get("active_generation") == initial_generation
         and after_valid.get("active_generation") == initial_generation
         and after_valid.get("initialized_version") == "v1"
+        and after_valid.get("live_mcp_version") == "v1"
+        and after_return.get("live_mcp_version") == "v1"
         and _integer(after_valid.get("heartbeats")) > initial_heartbeats
         and initial_mcp_processes >= 1
         and after_invalid_mcp_processes == initial_mcp_processes
@@ -806,6 +831,7 @@ def _exercise_candidate_prepare(
         "valid_status": valid_status,
         "after_valid": after_valid,
         "return_status": return_status,
+        "after_return": after_return,
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
         "return_signal": return_signal.returncode,

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -456,6 +456,12 @@ def _install_candidate_plugins(
         encoding="utf-8",
     )
     reload_source = reload_plugin / "plugin.py"
+    reload_skill = reload_plugin / "skills-v2" / "candidate-v2"
+    reload_skill.mkdir(parents=True)
+    _ = (reload_skill / "SKILL.md").write_text(
+        "---\ndescription: candidate v2 skill\n---\ncandidate v2\n",
+        encoding="utf-8",
+    )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
     return (
@@ -481,12 +487,20 @@ def _candidate_reload_source(version: str) -> str:
         if version == "v1"
         else "        self.context.kv_store.set('initialized_version', 'v2')\n"
     )
+    skills = (
+        "    @classmethod\n"
+        "    def skill_roots(cls):\n"
+        "        return ('skills-v2',)\n"
+        if version == "v2"
+        else ""
+    )
     return (
         "from __future__ import annotations\n"
         "import asyncio\n"
         "from agent.plugins import Plugin, tool\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
+        f"{skills}"
         "    @tool(name='candidate_reload_tool')\n"
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
@@ -614,6 +628,7 @@ def _exercise_candidate_prepare(
         after=len(valid_statuses),
         gate_status="active",
     )
+    valid_skills = valid_status.get("skills")
     passed = (
         invalid_signal.returncode == 0
         and valid_signal.returncode == 0
@@ -623,6 +638,8 @@ def _exercise_candidate_prepare(
         and invalid_status.get("prepared_generation") is None
         and valid_status.get("active_generation") == initial_generation
         and isinstance(valid_status.get("prepared_generation"), str)
+        and isinstance(valid_skills, list)
+        and "candidate-v2" in valid_skills
         and return_status.get("active_generation") == initial_generation
         and return_status.get("prepared_generation") is None
         and after_invalid.get("active_generation") == initial_generation
@@ -659,7 +676,9 @@ def _run_runtime_smoke(
     )
     scope_state = _install_scope_plugin(sandbox) if phase == "scope" else None
     candidate_states = (
-        _install_candidate_plugins(sandbox) if phase == "candidate" else None
+        _install_candidate_plugins(sandbox)
+        if phase in {"candidate", "capability-hosts"}
+        else None
     )
     started = subprocess.run(
         [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
@@ -897,7 +916,7 @@ def main() -> int:
     )
     _ = parser.add_argument(
         "--phase",
-        choices=("smoke", "scope", "candidate"),
+        choices=("smoke", "scope", "candidate", "capability-hosts"),
         default="smoke",
     )
     _ = parser.add_argument("--inside-container", action="store_true")

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -497,6 +497,7 @@ def _install_candidate_plugins(
     )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
+    (data / "candidate_reload-gate").mkdir(parents=True, exist_ok=True)
     return (
         data / "candidate_valid-gate/.kv.json",
         data / "candidate_invalid-gate/.kv.json",

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -594,21 +594,37 @@ def _exercise_candidate_prepare(
         stderr=subprocess.STDOUT,
         text=True,
     )
-    _, valid_status = _wait_candidate_status(
+    valid_statuses, valid_status = _wait_candidate_status(
         container_id,
         after=len(statuses),
         gate_status="passed",
     )
     time.sleep(0.2)
     after_valid = _read_json_object(state_path)
+    _ = source_path.write_text(_candidate_reload_source("v1"), encoding="utf-8")
+    return_signal = subprocess.run(
+        ["docker", "kill", "--signal", "HUP", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    _, return_status = _wait_candidate_status(
+        container_id,
+        after=len(valid_statuses),
+        gate_status="active",
+    )
     passed = (
         invalid_signal.returncode == 0
         and valid_signal.returncode == 0
+        and return_signal.returncode == 0
         and isinstance(initial_generation, str)
         and invalid_status.get("active_generation") == initial_generation
         and invalid_status.get("prepared_generation") is None
         and valid_status.get("active_generation") == initial_generation
         and isinstance(valid_status.get("prepared_generation"), str)
+        and return_status.get("active_generation") == initial_generation
+        and return_status.get("prepared_generation") is None
         and after_invalid.get("active_generation") == initial_generation
         and after_valid.get("active_generation") == initial_generation
         and after_valid.get("initialized_version") == "v1"
@@ -621,8 +637,10 @@ def _exercise_candidate_prepare(
         "after_invalid": after_invalid,
         "valid_status": valid_status,
         "after_valid": after_valid,
+        "return_status": return_status,
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
+        "return_signal": return_signal.returncode,
     }
 
 

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -7,11 +7,13 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import tempfile
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import cast
 
 
 @dataclass(frozen=True)
@@ -189,13 +191,14 @@ def _sandbox_integrity() -> GateResult:
     return result
 
 
-def _run_controller() -> int:
+def _run_controller(*, scenario: str, phase: str) -> int:
     repo = Path(__file__).resolve().parents[2]
     plugin_root = Path(
         os.environ.get("AKASHIC_PLUGIN_SOURCE", "/mnt/data/coding/akashic-plugin")
     ).resolve()
     host_cache = (Path.home() / ".akashic-plugin" / "cache").resolve()
     sandbox = Path(tempfile.mkdtemp(prefix="akashic-plugin-gate-", dir="/tmp")).resolve()
+    (sandbox / "static").mkdir()
     protected = [repo.resolve(), plugin_root, host_cache]
     if any(sandbox == path or sandbox.is_relative_to(path) for path in protected):
         shutil.rmtree(sandbox)
@@ -207,16 +210,17 @@ def _run_controller() -> int:
         **os.environ,
         "AKASHIC_GATE_SANDBOX": str(sandbox),
         "AKASHIC_PLUGIN_SOURCE": str(plugin_root),
+        "UID": str(os.getuid()),
+        "GID": str(os.getgid()),
     }
+    project = sandbox.name.replace("_", "-")
     compose = [
         "docker",
         "compose",
         "-p",
-        "akashic-plugin-reload-gate",
+        project,
         "-f",
-        str(repo / "docker/debug/docker-compose.yml"),
-        "--profile",
-        "plugin-gate",
+        str(repo / "docker/debug/docker-compose.plugin-gate.yml"),
     ]
     command = [
         *compose,
@@ -229,35 +233,69 @@ def _run_controller() -> int:
         "sandbox-integrity",
         "--inside-container",
     ]
-    integrity = subprocess.run(command, cwd=repo, env=env, check=False)
-    smoke_passed, smoke_evidence = _run_runtime_smoke(
-        repo=repo,
-        sandbox=sandbox,
-        compose=compose,
-        env=env,
-    )
-    _ = subprocess.run(
-        [*compose, "down", "--remove-orphans"],
-        cwd=repo,
-        env=env,
-        check=False,
-    )
+    build_returncode = -1
+    integrity_returncode = -1
+    smoke_passed = False
+    smoke_evidence: dict[str, object] = {"skipped": True}
+    cleanup_returncode = -1
+    controller_error = ""
+    try:
+        build = subprocess.run(
+            [*compose, "build", "akashic-plugin-gate"],
+            cwd=repo,
+            env=env,
+            check=False,
+        )
+        build_returncode = build.returncode
+        if build_returncode == 0:
+            integrity = subprocess.run(command, cwd=repo, env=env, check=False)
+            integrity_returncode = integrity.returncode
+        if integrity_returncode == 0:
+            smoke_passed, smoke_evidence = _run_runtime_smoke(
+                repo=repo,
+                sandbox=sandbox,
+                compose=compose,
+                env=env,
+                phase=phase if scenario == "full-runtime" else "smoke",
+            )
+    except Exception as error:
+        controller_error = f"{type(error).__name__}: {error}"
+    finally:
+        try:
+            cleanup = subprocess.run(
+                [*compose, "down", "--remove-orphans"],
+                cwd=repo,
+                env=env,
+                check=False,
+            )
+            cleanup_returncode = cleanup.returncode
+        except Exception as error:
+            suffix = f"{type(error).__name__}: {error}"
+            controller_error = f"{controller_error}; {suffix}".strip("; ")
     after = {str(path): _repository_digest(path) for path in repositories}
     unchanged = before == after
+    passed = (
+        build_returncode == 0
+        and integrity_returncode == 0
+        and smoke_passed
+        and cleanup_returncode == 0
+        and unchanged
+        and not controller_error
+    )
     report: dict[str, object] = {
-        "gate_id": "G-1-host",
-        "status": (
-            "passed"
-            if integrity.returncode == 0 and smoke_passed and unchanged
-            else "failed"
-        ),
+        "gate_id": "G-1-host" if scenario == "sandbox-integrity" else f"runtime:{phase}",
+        "status": "passed" if passed else "failed",
         "checks": {
-            "container_gate_passed": integrity.returncode == 0,
+            "image_build_passed": build_returncode == 0,
+            "container_gate_passed": integrity_returncode == 0,
             "runtime_smoke_passed": smoke_passed,
             "runtime": smoke_evidence,
+            "cleanup_passed": cleanup_returncode == 0,
             "repositories_unchanged": unchanged,
             "repositories": len(repositories),
             "sandbox": str(sandbox),
+            "compose_project": project,
+            "controller_error": controller_error,
         },
     }
     print(json.dumps(report, ensure_ascii=False, indent=2))
@@ -303,18 +341,55 @@ def _write_smoke_config(sandbox: Path) -> None:
     )
 
 
+def _install_scope_plugin(sandbox: Path) -> Path:
+    plugin_dir = (
+        sandbox
+        / "home/.akashic-plugin/cache/gate/scope_gate/1.0.0"
+    )
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from __future__ import annotations\n"
+        "import asyncio\n"
+        "from agent.plugins import Plugin\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class ScopeGatePlugin(Plugin):\n"
+        "    name = 'scope_gate'\n"
+        "    version = '1.0.0'\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('initialized', True)\n"
+        "        self.context.defer('subscription_check', self._check_subscription)\n"
+        "        self.subscription = self.context.event_bus.on(TurnCommitted, self._handle)\n"
+        "        self.context.create_task(self._worker(), name='scope-gate-worker')\n"
+        "    async def terminate(self):\n"
+        "        self.context.kv_store.set('terminated', True)\n"
+        "    async def _worker(self):\n"
+        "        try:\n"
+        "            await asyncio.Event().wait()\n"
+        "        finally:\n"
+        "            self.context.kv_store.set('task_cancelled', True)\n"
+        "    def _check_subscription(self):\n"
+        "        self.context.kv_store.set('subscription_closed', not self.subscription.active)\n"
+        "    def _handle(self, event):\n"
+        "        self.context.kv_store.increment('events')\n",
+        encoding="utf-8",
+    )
+    return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
+
+
 def _run_runtime_smoke(
     *,
     repo: Path,
     sandbox: Path,
     compose: list[str],
     env: dict[str, str],
+    phase: str,
 ) -> tuple[bool, dict[str, object]]:
     _write_smoke_config(sandbox)
     shutil.rmtree(
         sandbox / "home/.akashic-plugin/cache/gate",
         ignore_errors=True,
     )
+    scope_state = _install_scope_plugin(sandbox) if phase == "scope" else None
     started = subprocess.run(
         [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
         cwd=repo,
@@ -326,20 +401,40 @@ def _run_runtime_smoke(
     )
     socket = sandbox / "akashic.sock"
     container_id = ""
+    ipc_ready = False
+    dashboard_ready = False
+    stable_since: float | None = None
     deadline = time.monotonic() + 30
     while started.returncode == 0 and time.monotonic() < deadline:
         container_id = subprocess.run(
-            [*compose, "ps", "-q", "akashic-plugin-gate"],
+            [*compose, "ps", "-a", "-q", "akashic-plugin-gate"],
             cwd=repo,
             env=env,
             check=False,
             stdout=subprocess.PIPE,
             text=True,
         ).stdout.strip()
-        if socket.exists() and container_id:
+        if not container_id:
+            time.sleep(0.2)
+            continue
+        running = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Running}}", container_id],
+            check=False,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip() == "true"
+        if not running:
             break
+        ipc_ready = _ipc_ready(socket)
+        dashboard_ready = _dashboard_ready(container_id)
+        if ipc_ready and dashboard_ready:
+            stable_since = stable_since or time.monotonic()
+            if time.monotonic() - stable_since >= 1:
+                break
+        else:
+            stable_since = None
         time.sleep(0.2)
-    socket_ready = socket.exists()
+    runtime_stable = stable_since is not None and time.monotonic() - stable_since >= 1
     process = ""
     if container_id:
         process = subprocess.run(
@@ -388,38 +483,97 @@ def _run_runtime_smoke(
         ).stdout.strip()
         if raw_exit_code.isdigit():
             exit_code = int(raw_exit_code)
+    phase_passed = True
+    phase_evidence: object = {"phase": phase}
+    if scope_state is not None:
+        state: dict[str, object] = {}
+        if scope_state.exists():
+            raw_state: object = json.loads(scope_state.read_text(encoding="utf-8"))
+            if isinstance(raw_state, dict):
+                mapping = cast(dict[object, object], raw_state)
+                state = {str(key): value for key, value in mapping.items()}
+        expected = {
+            "initialized": True,
+            "terminated": True,
+            "task_cancelled": True,
+            "subscription_closed": True,
+        }
+        phase_passed = all(state.get(key) == value for key, value in expected.items())
+        phase_evidence = {"phase": phase, "state": state, "expected": expected}
     passed = (
         started.returncode == 0
-        and socket_ready
+        and ipc_ready
+        and dashboard_ready
+        and runtime_stable
         and "python main.py" in process
         and stopped.returncode == 0
         and exit_code == 0
+        and phase_passed
     )
     return passed, {
         "container_id": container_id,
-        "socket_ready": socket_ready,
+        "ipc_ready": ipc_ready,
+        "dashboard_ready": dashboard_ready,
+        "runtime_stable": runtime_stable,
         "pid1_is_main": "python main.py" in process,
         "pid1": process.strip(),
         "exit_code": exit_code,
         "start_output": started.stdout[-2000:],
         "stop_output": stopped.stdout[-2000:],
         "logs": logs[-4000:],
+        "phase": phase_evidence,
     }
+
+
+def _ipc_ready(path: Path) -> bool:
+    if not path.exists():
+        return False
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    try:
+        client.connect(str(path))
+        return True
+    except OSError:
+        return False
+    finally:
+        client.close()
+
+
+def _dashboard_ready(container_id: str) -> bool:
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container_id,
+            "python",
+            "-c",
+            (
+                "import urllib.request; "
+                "urllib.request.urlopen("
+                "'http://127.0.0.1:2236/api/dashboard/plugins', timeout=1).read()"
+            ),
+        ],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     _ = parser.add_argument(
         "--scenario",
-        choices=("sandbox-integrity",),
+        choices=("sandbox-integrity", "full-runtime"),
         default="sandbox-integrity",
     )
+    _ = parser.add_argument("--phase", choices=("smoke", "scope"), default="smoke")
     _ = parser.add_argument("--inside-container", action="store_true")
     args = parser.parse_args()
-    if args.scenario == "sandbox-integrity":
-        if args.inside_container:
-            return 0 if _sandbox_integrity().status == "passed" else 1
-        return _run_controller()
+    if args.inside_container:
+        return 0 if _sandbox_integrity().status == "passed" else 1
+    if args.scenario in ("sandbox-integrity", "full-runtime"):
+        return _run_controller(scenario=args.scenario, phase=args.phase)
     return 2
 
 

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -518,6 +518,14 @@ def _candidate_reload_source(version: str) -> str:
     )
 
 
+def _skill_fixture_hash(version: str, *, drift: bool) -> str:
+    label = f"candidate drift {version}" if drift else f"candidate {version} skill"
+    body = f"drift {version}" if drift else f"candidate {version}"
+    return hashlib.sha256(
+        f"---\ndescription: {label}\n---\n{body}\n".encode()
+    ).hexdigest()
+
+
 def _read_json_object(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
@@ -639,6 +647,10 @@ def _exercise_candidate_prepare(
     valid_skills = valid_status.get("skills")
     valid_descriptions = valid_status.get("skill_descriptions")
     valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
+    valid_body_hashes = valid_status.get("skill_body_hashes")
+    valid_drift_body_hashes = valid_status.get("drift_skill_body_hashes")
+    return_body_hashes = return_status.get("skill_body_hashes")
+    return_drift_body_hashes = return_status.get("drift_skill_body_hashes")
     valid_description_map = (
         cast(dict[object, object], valid_descriptions)
         if isinstance(valid_descriptions, dict)
@@ -649,6 +661,15 @@ def _exercise_candidate_prepare(
         if isinstance(valid_drift_descriptions, dict)
         else {}
     )
+    hash_maps = [
+        cast(dict[object, object], value) if isinstance(value, dict) else {}
+        for value in (
+            valid_body_hashes,
+            valid_drift_body_hashes,
+            return_body_hashes,
+            return_drift_body_hashes,
+        )
+    ]
     passed = (
         invalid_signal.returncode == 0
         and valid_signal.returncode == 0
@@ -662,6 +683,14 @@ def _exercise_candidate_prepare(
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"
+        and hash_maps[0].get("candidate-skill")
+        == _skill_fixture_hash("v2", drift=False)
+        and hash_maps[1].get("candidate-drift")
+        == _skill_fixture_hash("v2", drift=True)
+        and hash_maps[2].get("candidate-skill")
+        == _skill_fixture_hash("v1", drift=False)
+        and hash_maps[3].get("candidate-drift")
+        == _skill_fixture_hash("v1", drift=True)
         and return_status.get("active_generation") == initial_generation
         and return_status.get("prepared_generation") is None
         and after_invalid.get("active_generation") == initial_generation

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -304,7 +304,7 @@ def _run_controller(*, scenario: str, phase: str) -> int:
     return 0 if report["status"] == "passed" else 1
 
 
-def _write_smoke_config(sandbox: Path) -> None:
+def _write_smoke_config(sandbox: Path, *, proactive_enabled: bool = False) -> None:
     config = sandbox / "config.toml"
     _ = config.write_text(
         "\n".join(
@@ -322,7 +322,7 @@ def _write_smoke_config(sandbox: Path) -> None:
                 "[channels]",
                 'socket = "/sandbox/akashic.sock"',
                 "",
-                "[channels.chat]",
+            "[channels.chat]",
                 "enabled = false",
                 "",
                 "[channels.telegram]",
@@ -335,7 +335,7 @@ def _write_smoke_config(sandbox: Path) -> None:
                 "",
                 "[proactive]",
                 'profile = "quiet"',
-                "enabled = false",
+                f"enabled = {'true' if proactive_enabled else 'false'}",
                 "",
             ]
         ),
@@ -1119,6 +1119,11 @@ def _exercise_candidate_prepare(
             0,
         )
         == 1
+        and cast(dict[str, int], initial_calls.get("v1", {})).get(
+            "poll_events",
+            0,
+        )
+        >= 1
         and all(
             cast(dict[str, int], after_valid_calls.get("v2", {})).get(tool, 0)
             == 0
@@ -1199,7 +1204,10 @@ def _run_runtime_smoke(
     env: dict[str, str],
     phase: str,
 ) -> tuple[bool, dict[str, object]]:
-    _write_smoke_config(sandbox)
+    _write_smoke_config(
+        sandbox,
+        proactive_enabled=phase in {"capability-hosts", "snapshot"},
+    )
     shutil.rmtree(
         sandbox / "home/.akashic-plugin/cache/gate",
         ignore_errors=True,

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -384,16 +384,20 @@ def _install_scope_plugin(sandbox: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
 
 
-def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path, Path, Path]:
+def _install_candidate_plugins(
+    sandbox: Path,
+) -> tuple[Path, Path, Path, Path, Path, Path]:
     cache = sandbox / "home/.akashic-plugin/cache/gate"
     valid = cache / "candidate_valid/1.0.0"
     invalid = cache / "candidate_invalid/1.0.0"
     failed = cache / "candidate_failed/1.0.0"
     observer = cache / "candidate_observer/1.0.0"
+    reload_plugin = cache / "candidate_reload/1.0.0"
     valid.mkdir(parents=True, exist_ok=True)
     invalid.mkdir(parents=True, exist_ok=True)
     failed.mkdir(parents=True, exist_ok=True)
     observer.mkdir(parents=True, exist_ok=True)
+    reload_plugin.mkdir(parents=True, exist_ok=True)
     _ = (valid / "plugin.py").write_text(
         "from agent.plugins import Plugin\n"
         "class CandidateValidPlugin(Plugin):\n"
@@ -451,13 +455,169 @@ def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path, Path, Path]:
         "        self.context.kv_store.set('event_sent', True)\n",
         encoding="utf-8",
     )
+    reload_source = reload_plugin / "plugin.py"
+    _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
     return (
         data / "candidate_valid-gate/.kv.json",
         data / "candidate_invalid-gate/.kv.json",
         data / "candidate_failed-gate/.kv.json",
         data / "candidate_observer-gate/.kv.json",
+        reload_source,
+        data / "candidate_reload-gate/.kv.json",
     )
+
+
+def _candidate_reload_source(version: str) -> str:
+    initialize = (
+        "        self.context.kv_store.set('initialized_version', 'v1')\n"
+        "        self.context.kv_store.set('active_generation', self.context.generation_id)\n"
+        "        self.context.create_task(self._heartbeat(), name='candidate-reload-heartbeat')\n"
+        "    async def _heartbeat(self):\n"
+        "        while True:\n"
+        "            self.context.kv_store.increment('heartbeats')\n"
+        "            self.context.kv_store.set('active_generation', self.context.generation_id)\n"
+        "            await asyncio.sleep(0.05)\n"
+        if version == "v1"
+        else "        self.context.kv_store.set('initialized_version', 'v2')\n"
+    )
+    return (
+        "from __future__ import annotations\n"
+        "import asyncio\n"
+        "from agent.plugins import Plugin, tool\n"
+        "class CandidateReloadPlugin(Plugin):\n"
+        "    name = 'candidate_reload'\n"
+        "    @tool(name='candidate_reload_tool')\n"
+        "    async def run(self, event):\n"
+        "        \"\"\"Candidate reload tool.\"\"\"\n"
+        f"        return '{version}'\n"
+        "    async def initialize(self):\n"
+        f"{initialize}"
+    )
+
+
+def _read_json_object(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    raw: object = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return {}
+    mapping = cast(dict[object, object], raw)
+    return {str(key): value for key, value in mapping.items()}
+
+
+def _integer(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return 0
+
+
+def _candidate_statuses(container_id: str) -> list[dict[str, object]]:
+    logs = subprocess.run(
+        ["docker", "logs", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).stdout
+    marker = "plugin_candidate_status "
+    statuses: list[dict[str, object]] = []
+    for line in logs.splitlines():
+        if marker not in line:
+            continue
+        payload = line.split(marker, 1)[1].strip()
+        try:
+            raw: object = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(raw, dict):
+            mapping = cast(dict[object, object], raw)
+            statuses.append({str(key): value for key, value in mapping.items()})
+    return statuses
+
+
+def _wait_candidate_status(
+    container_id: str,
+    *,
+    after: int,
+    gate_status: str,
+) -> tuple[list[dict[str, object]], dict[str, object]]:
+    deadline = time.monotonic() + 8
+    while time.monotonic() < deadline:
+        statuses = _candidate_statuses(container_id)
+        for status in statuses[after:]:
+            if (
+                status.get("plugin_id") == "candidate_reload@gate"
+                and status.get("gate_status") == gate_status
+            ):
+                return statuses, status
+        time.sleep(0.1)
+    return _candidate_statuses(container_id), {}
+
+
+def _exercise_candidate_prepare(
+    container_id: str,
+    source_path: Path,
+    state_path: Path,
+) -> dict[str, object]:
+    initial = _read_json_object(state_path)
+    initial_generation = initial.get("active_generation")
+    initial_heartbeats = _integer(initial.get("heartbeats"))
+    _ = source_path.write_text("not valid python !!!\n", encoding="utf-8")
+    statuses_before = _candidate_statuses(container_id)
+    invalid_signal = subprocess.run(
+        ["docker", "kill", "--signal", "HUP", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    statuses, invalid_status = _wait_candidate_status(
+        container_id,
+        after=len(statuses_before),
+        gate_status="failed",
+    )
+    after_invalid = _read_json_object(state_path)
+    _ = source_path.write_text(_candidate_reload_source("v2"), encoding="utf-8")
+    valid_signal = subprocess.run(
+        ["docker", "kill", "--signal", "HUP", container_id],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    _, valid_status = _wait_candidate_status(
+        container_id,
+        after=len(statuses),
+        gate_status="passed",
+    )
+    time.sleep(0.2)
+    after_valid = _read_json_object(state_path)
+    passed = (
+        invalid_signal.returncode == 0
+        and valid_signal.returncode == 0
+        and isinstance(initial_generation, str)
+        and invalid_status.get("active_generation") == initial_generation
+        and invalid_status.get("prepared_generation") is None
+        and valid_status.get("active_generation") == initial_generation
+        and isinstance(valid_status.get("prepared_generation"), str)
+        and after_invalid.get("active_generation") == initial_generation
+        and after_valid.get("active_generation") == initial_generation
+        and after_valid.get("initialized_version") == "v1"
+        and _integer(after_valid.get("heartbeats")) > initial_heartbeats
+    )
+    return {
+        "passed": passed,
+        "initial": initial,
+        "invalid_status": invalid_status,
+        "after_invalid": after_invalid,
+        "valid_status": valid_status,
+        "after_valid": after_valid,
+        "invalid_signal": invalid_signal.returncode,
+        "valid_signal": valid_signal.returncode,
+    }
 
 
 def _run_runtime_smoke(
@@ -542,6 +702,13 @@ def _run_runtime_smoke(
             stderr=subprocess.STDOUT,
             text=True,
         ).stdout
+    candidate_prepare: dict[str, object] = {}
+    if candidate_states is not None and container_id and runtime_stable:
+        candidate_prepare = _exercise_candidate_prepare(
+            container_id,
+            candidate_states[4],
+            candidate_states[5],
+        )
     logs = subprocess.run(
         [*compose, "logs", "--no-color", "--tail", "200", "akashic-plugin-gate"],
         cwd=repo,
@@ -594,7 +761,14 @@ def _run_runtime_smoke(
         expected["generation"] = "scope_gate@gate:<revision>:<sequence>"
         phase_evidence = {"phase": phase, "state": state, "expected": expected}
     if candidate_states is not None:
-        valid_path, invalid_path, failed_path, observer_path = candidate_states
+        (
+            valid_path,
+            invalid_path,
+            failed_path,
+            observer_path,
+            _,
+            _,
+        ) = candidate_states
         valid_state: dict[str, object] = {}
         if valid_path.exists():
             raw_valid: object = json.loads(valid_path.read_text(encoding="utf-8"))
@@ -620,6 +794,7 @@ def _run_runtime_smoke(
             and not failed_path.exists()
             and observer_state.get("failed_tool_visible") is False
             and observer_state.get("event_sent") is True
+            and candidate_prepare.get("passed") is True
         )
         phase_evidence = {
             "phase": phase,
@@ -627,6 +802,7 @@ def _run_runtime_smoke(
             "invalid_initialized": invalid_path.exists(),
             "failed_candidate_state_exists": failed_path.exists(),
             "observer": observer_state,
+            "same_id_prepare": candidate_prepare,
         }
     passed = (
         started.returncode == 0

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -499,7 +499,13 @@ def _candidate_reload_source(version: str) -> str:
 def _read_json_object(path: Path) -> dict[str, object]:
     if not path.exists():
         return {}
-    raw: object = json.loads(path.read_text(encoding="utf-8"))
+    raw: object = {}
+    for _ in range(20):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            break
+        except json.JSONDecodeError:
+            time.sleep(0.01)
     if not isinstance(raw, dict):
         return {}
     mapping = cast(dict[object, object], raw)

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -413,6 +413,17 @@ def _install_scope_plugin(sandbox: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
 
 
+def _install_fitbit_plugin(sandbox: Path, plugin_root: Path) -> Path:
+    source = plugin_root / "fitbit-mcp"
+    target = sandbox / "home/.akashic-plugin/cache/gate/fitbit/1.1.0"
+    shutil.copytree(
+        source,
+        target,
+        ignore=shutil.ignore_patterns(".git", ".venv", "__pycache__", ".pytest_cache"),
+    )
+    return sandbox / "home/.akashic-plugin/data/fitbit-gate"
+
+
 def _install_candidate_plugins(
     sandbox: Path,
 ) -> tuple[Path, Path, Path, Path, Path, Path]:
@@ -779,6 +790,33 @@ def _container_process_count(container_id: str, marker: str) -> int:
         return int(result.stdout.strip())
     except ValueError:
         return -1
+
+
+def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
+    script = (
+        "import json, urllib.request\n"
+        "result = {}\n"
+        "for key, path in [('data', '/api/data'), ('snapshot', '/api/tool/fitbit_health_snapshot')]:\n"
+        "    with urllib.request.urlopen('http://127.0.0.1:18765' + path, timeout=3) as response:\n"
+        "        result[key] = json.loads(response.read())\n"
+        "print(json.dumps(result))\n"
+    )
+    result = subprocess.run(
+        ["docker", "exec", container_id, "python", "-c", script],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"error": result.stdout.strip()}
+    try:
+        raw: object = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"error": result.stdout.strip()}
+    if not isinstance(raw, dict):
+        return {"error": repr(raw)}
+    return {str(key): value for key, value in raw.items()}
 
 
 def _wait_process_count(
@@ -1238,13 +1276,18 @@ def _run_runtime_smoke(
 ) -> tuple[bool, dict[str, object]]:
     _write_smoke_config(
         sandbox,
-        proactive_enabled=phase in {"capability-hosts", "snapshot"},
+        proactive_enabled=phase in {"capability-hosts", "snapshot", "fitbit"},
     )
     shutil.rmtree(
         sandbox / "home/.akashic-plugin/cache/gate",
         ignore_errors=True,
     )
     scope_state = _install_scope_plugin(sandbox) if phase == "scope" else None
+    fitbit_data = (
+        _install_fitbit_plugin(sandbox, Path(env["AKASHIC_PLUGIN_SOURCE"]))
+        if phase == "fitbit"
+        else None
+    )
     candidate_states = (
         _install_candidate_plugins(sandbox)
         if phase in {"candidate", "capability-hosts", "snapshot"}
@@ -1316,6 +1359,11 @@ def _run_runtime_smoke(
             text=True,
         ).stdout
     candidate_prepare: dict[str, object] = {}
+    fitbit_probe: dict[str, object] = {}
+    fitbit_processes = -1
+    if fitbit_data is not None and container_id and runtime_stable:
+        fitbit_probe = _fitbit_runtime_probe(container_id)
+        fitbit_processes = _container_process_count(container_id, "monitor/server.py")
     if candidate_states is not None and container_id and runtime_stable:
         if phase == "snapshot":
             candidate_prepare = _exercise_snapshot_publish(
@@ -1438,6 +1486,20 @@ def _run_runtime_smoke(
             "observer": observer_state,
             "same_id_prepare": candidate_prepare,
         }
+    if fitbit_data is not None:
+        runtime_log = fitbit_data / "monitor.runtime.log"
+        phase_passed = (
+            fitbit_processes == 1
+            and isinstance(fitbit_probe.get("data"), dict)
+            and isinstance(fitbit_probe.get("snapshot"), dict)
+            and runtime_log.exists()
+        )
+        phase_evidence = {
+            "phase": phase,
+            "monitor_processes": fitbit_processes,
+            "probe": fitbit_probe,
+            "runtime_log": str(runtime_log),
+        }
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -1507,7 +1569,7 @@ def main() -> int:
     )
     _ = parser.add_argument(
         "--phase",
-        choices=("smoke", "scope", "candidate", "capability-hosts", "snapshot"),
+        choices=("smoke", "scope", "candidate", "capability-hosts", "snapshot", "fitbit"),
         default="smoke",
     )
     _ = parser.add_argument("--inside-container", action="store_true")

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -352,7 +352,7 @@ def _install_scope_plugin(sandbox: Path) -> Path:
     _ = (plugin_dir / "plugin.py").write_text(
         "from __future__ import annotations\n"
         "import asyncio\n"
-        "from agent.plugins import Plugin\n"
+        "from agent.plugins import ManagedServiceSpec, Plugin\n"
         "from bus.events_lifecycle import TurnCommitted\n"
         "class ScopeGateChannel:\n"
         "    name = 'scope-gate-channel'\n"
@@ -362,6 +362,9 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "class ScopeGatePlugin(Plugin):\n"
         "    name = 'scope_gate'\n"
         "    version = '1.0.0'\n"
+        "    @classmethod\n"
+        "    def managed_services(cls):\n"
+        "        return [ManagedServiceSpec(id='probe', command=('python', 'service.py'), readiness_url='http://127.0.0.1:18766/')]\n"
         "    def channels(self): return [ScopeGateChannel(self)]\n"
         "    async def initialize(self):\n"
         "        self.context.kv_store.set('initialized', True)\n"
@@ -389,6 +392,22 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "        self.context.kv_store.set('event_started', True)\n"
         "        await asyncio.sleep(2)\n"
         "        self.context.kv_store.increment('events')\n",
+        encoding="utf-8",
+    )
+    _ = (plugin_dir / "service.py").write_text(
+        "import os, signal, sys\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "from pathlib import Path\n"
+        "data = Path(os.environ['AKA_PLUGIN_DATA_DIR'])\n"
+        "(data / 'service.started').write_text('started')\n"
+        "def stop(*args):\n"
+        "    (data / 'service.stopped').write_text('stopped')\n"
+        "    sys.exit(0)\n"
+        "signal.signal(signal.SIGTERM, stop)\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self): self.send_response(200); self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', 18766), Handler).serve_forever()\n",
         encoding="utf-8",
     )
     return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
@@ -1354,6 +1373,8 @@ def _run_runtime_smoke(
             if isinstance(raw_state, dict):
                 mapping = cast(dict[object, object], raw_state)
                 state = {str(key): value for key, value in mapping.items()}
+        state["service_started"] = (scope_state.parent / "service.started").exists()
+        state["service_stopped"] = (scope_state.parent / "service.stopped").exists()
         expected: dict[str, object] = {
             "initialized": True,
             "event_started": True,
@@ -1363,6 +1384,8 @@ def _run_runtime_smoke(
             "task_cancelled": True,
             "subscription_closed": True,
             "events": 1,
+            "service_started": True,
+            "service_stopped": True,
         }
         phase_passed = all(state.get(key) == value for key, value in expected.items())
         generation = state.get("generation")

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -549,7 +549,7 @@ def _candidate_reload_source(version: str) -> str:
         f"        ctx.abort_reply = 'snapshot-{version}'\n"
         "        return frame\n"
         "    async def _probe_detached(self):\n"
-        "        await asyncio.sleep(0)\n"
+        "        await asyncio.sleep(0.1)\n"
         "        self.plugin.context.kv_store.set('detached_snapshot_visible', get_current_runtime_snapshot() is not None)\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -509,6 +509,7 @@ def _install_candidate_plugins(
 
 def _candidate_reload_source(version: str) -> str:
     initialize = (
+        "        self.context.event_bus.on(TurnCommitted, self._on_committed)\n"
         "        self.context.kv_store.set('initialized_version', 'v1')\n"
         "        self.context.kv_store.set('active_generation', self.context.generation_id)\n"
         "        self.context.create_task(self._heartbeat(), name='candidate-reload-heartbeat')\n"
@@ -522,7 +523,8 @@ def _candidate_reload_source(version: str) -> str:
         "                self.context.kv_store.set('live_mcp_version', getattr(result, 'text', str(result)))\n"
         "            await asyncio.sleep(0.05)\n"
         if version == "v1"
-        else "        self.context.kv_store.set('initialized_version', 'v2')\n"
+        else "        self.context.event_bus.on(TurnCommitted, self._on_committed)\n"
+        "        self.context.kv_store.set('initialized_version', 'v2')\n"
     )
     skills = (
         "    @classmethod\n"
@@ -537,6 +539,7 @@ def _candidate_reload_source(version: str) -> str:
         "import asyncio\n"
         "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
         "from agent.skills import SkillsLoader\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
         "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
         "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
         "class SnapshotBeforeTurn:\n"
@@ -551,6 +554,7 @@ def _candidate_reload_source(version: str) -> str:
         f"            self.plugin.context.kv_store.set('phase_tool_version_{version}', str(value))\n"
         "        skill_body = SkillsLoader(self.plugin.context.workspace, runtime_catalog='normal').load_skill_body('candidate-skill')\n"
         f"        self.plugin.context.kv_store.set('phase_skill_body_{version}', skill_body)\n"
+        "        await self.plugin.context.event_bus.fanout(TurnCommitted(session_key='gate:event', channel='gate', chat_id='event', input_message='event', persisted_user_message='event', assistant_response='event', tools_used=[]))\n"
         "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"
         f"        if '{version}' == 'v1' and ctx.content == 'block snapshot':\n"
@@ -599,6 +603,8 @@ def _candidate_reload_source(version: str) -> str:
         f"        return '{version}'\n"
         "    async def initialize(self):\n"
         f"{initialize}"
+        "    async def _on_committed(self, event):\n"
+        f"        self.context.kv_store.increment('phase_event_version_{version}')\n"
     )
 
 
@@ -1124,6 +1130,8 @@ def _exercise_candidate_prepare(
         and after_passive.get("phase_tool_version_v2") is None
         and after_passive.get("phase_skill_body_v1") == "candidate v1"
         and after_passive.get("phase_skill_body_v2") is None
+        and _integer(after_passive.get("phase_event_version_v1")) >= 1
+        and _integer(after_passive.get("phase_event_version_v2")) == 0
         and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -472,7 +472,9 @@ def _install_candidate_plugins(
         )
     _ = (reload_plugin / "candidate_mcp_server.py").write_text(
         "import json, os, sys\n"
+        "from pathlib import Path\n"
         "version = os.environ['CANDIDATE_VERSION']\n"
+        "calls = Path(os.environ['AKA_PLUGIN_DATA_DIR']) / 'candidate_mcp_calls.jsonl'\n"
         "tools = [\n"
         "    {'name': name, 'description': name, 'inputSchema': {'type': 'object', 'properties': {}}}\n"
         "    for name in ('fetch_events', 'ack_events', 'poll_events', 'candidate_version')\n"
@@ -485,6 +487,8 @@ def _install_candidate_plugins(
         "    result = {'tools': tools} if method == 'tools/list' else {}\n"
         "    if method == 'tools/call':\n"
         "        tool = msg.get('params', {}).get('name')\n"
+        "        with calls.open('a', encoding='utf-8') as stream:\n"
+        "            stream.write(json.dumps({'version': version, 'tool': tool}) + '\\n')\n"
         "        text = version if tool == 'candidate_version' else '[]'\n"
         "        result = {'content': [{'type': 'text', 'text': text}]}\n"
         "    print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n",
@@ -541,19 +545,22 @@ def _candidate_reload_source(version: str) -> str:
         "    def proactive_sources(self):\n"
         "        return [ProactiveSourceSpec(id='candidate_feed', channels=('content',), "
         "server='candidate_feed', fetch_tool='fetch_events', ack_tool='ack_events', "
-        "poll_tool='poll_events')]\n"
+        f"poll_tool='poll_events', poll_interval_seconds={1 if version == 'v1' else 2})]\n"
         "    def jobs(self):\n"
-        "        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)]\n"
+        f"        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger({1 if version == 'v1' else 2})], handler=self.refresh)]\n"
         "    async def refresh(self, context):\n"
-        "        return None\n"
+        f"        self.context.kv_store.increment('job_runs_{version}')\n"
         "    async def readiness_semantic_checks(self, context):\n"
         "        server = context.mcp_catalog.servers['candidate_feed']\n"
         "        value = await server.client.call('candidate_version', {})\n"
         "        job = context.job_catalog.jobs['candidate_reload@gate:refresh']\n"
         "        source = context.proactive_catalog.sources['candidate_reload@gate:candidate_feed']\n"
         "        owned = getattr(job.spec.handler, '__self__', None) is self\n"
-        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id}\n"
-        f"        return [PluginSemanticCheck('candidate_capabilities', value == '{version}' and owned, evidence)]\n"
+        "        job_interval = job.spec.triggers[0].seconds\n"
+        "        source_interval = source.spec.poll_interval_seconds\n"
+        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id, "
+        "'job_interval': job_interval, 'source_interval': source_interval}\n"
+        f"        return [PluginSemanticCheck('candidate_capabilities', value == '{version}' and owned and job_interval == {1 if version == 'v1' else 2} and source_interval == {1 if version == 'v1' else 2}, evidence)]\n"
         "    @tool(name='candidate_reload_tool')\n"
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
@@ -593,6 +600,26 @@ def _integer(value: object) -> int:
     if isinstance(value, str) and value.isdigit():
         return int(value)
     return 0
+
+
+def _mcp_call_counts(path: Path) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {}
+    if not path.exists():
+        return counts
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            raw: object = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(raw, dict):
+            continue
+        item = cast(dict[object, object], raw)
+        version = str(item.get("version") or "")
+        tool = str(item.get("tool") or "")
+        if version and tool:
+            version_counts = counts.setdefault(version, {})
+            version_counts[tool] = version_counts.get(tool, 0) + 1
+    return counts
 
 
 def _candidate_statuses(container_id: str) -> list[dict[str, object]]:
@@ -688,6 +715,8 @@ def _exercise_candidate_prepare(
     state_path: Path,
 ) -> dict[str, object]:
     initial = _read_json_object(state_path)
+    calls_path = state_path.parent / "candidate_mcp_calls.jsonl"
+    initial_calls = _mcp_call_counts(calls_path)
     initial_mcp_processes = _wait_process_count(
         container_id,
         "candidate_mcp_server.py",
@@ -727,8 +756,9 @@ def _exercise_candidate_prepare(
         after=len(statuses),
         gate_status="passed",
     )
-    time.sleep(0.2)
+    time.sleep(1.2)
     after_valid = _read_json_object(state_path)
+    after_valid_calls = _mcp_call_counts(calls_path)
     after_valid_mcp_processes = _wait_process_count(
         container_id,
         "candidate_mcp_server.py",
@@ -753,6 +783,7 @@ def _exercise_candidate_prepare(
         lambda count: count == initial_mcp_processes,
     )
     after_return = _read_json_object(state_path)
+    after_return_calls = _mcp_call_counts(calls_path)
     valid_skills = valid_status.get("skills")
     valid_descriptions = valid_status.get("skill_descriptions")
     valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
@@ -811,6 +842,8 @@ def _exercise_candidate_prepare(
                     "mcp": "v2",
                     "job_owned": True,
                     "source": "candidate_feed",
+                    "job_interval": 2,
+                    "source_interval": 2,
                 },
             }
         ]
@@ -819,6 +852,52 @@ def _exercise_candidate_prepare(
         and return_status.get("jobs") == ["candidate_reload@gate:refresh"]
         and return_status.get("proactive_sources")
         == ["candidate_reload@gate:candidate_feed"]
+        and valid_status.get("job_specs")
+        == {
+            "candidate_reload@gate:refresh": [
+                {"type": "interval", "seconds": 2}
+            ]
+        }
+        and valid_status.get("proactive_source_specs")
+        == {
+            "candidate_reload@gate:candidate_feed": {
+                "server": "candidate_feed",
+                "fetch_tool": "fetch_events",
+                "ack_tool": "ack_events",
+                "poll_tool": "poll_events",
+                "poll_interval_seconds": 2,
+            }
+        }
+        and return_status.get("job_specs")
+        == {
+            "candidate_reload@gate:refresh": [
+                {"type": "interval", "seconds": 1}
+            ]
+        }
+        and return_status.get("proactive_source_specs")
+        == {
+            "candidate_reload@gate:candidate_feed": {
+                "server": "candidate_feed",
+                "fetch_tool": "fetch_events",
+                "ack_tool": "ack_events",
+                "poll_tool": "poll_events",
+                "poll_interval_seconds": 1,
+            }
+        }
+        and cast(dict[str, int], after_valid_calls.get("v2", {})).get(
+            "candidate_version",
+            0,
+        )
+        == 1
+        and all(
+            cast(dict[str, int], after_valid_calls.get("v2", {})).get(tool, 0)
+            == 0
+            for tool in ("fetch_events", "poll_events", "ack_events")
+        )
+        and _integer(after_valid.get("job_runs_v1"))
+        > _integer(initial.get("job_runs_v1"))
+        and _integer(after_valid.get("job_runs_v2")) == 0
+        and after_return_calls.get("v2") == after_valid_calls.get("v2")
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"
@@ -852,6 +931,11 @@ def _exercise_candidate_prepare(
         "after_valid": after_valid,
         "return_status": return_status,
         "after_return": after_return,
+        "mcp_calls": {
+            "initial": initial_calls,
+            "after_valid": after_valid_calls,
+            "after_return": after_return_calls,
+        },
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
         "return_signal": return_signal.returncode,

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -33,6 +33,33 @@ class GateResult:
     checks: list[CheckResult]
 
 
+def _gate_status(checks: list[CheckResult]) -> str:
+    return "passed" if all(check.passed for check in checks) else "failed"
+
+
+def _sandbox_is_protected(sandbox: Path, protected: list[Path]) -> bool:
+    return any(sandbox == path or sandbox.is_relative_to(path) for path in protected)
+
+
+def _controller_gate_passed(
+    *,
+    build_returncode: int,
+    integrity_returncode: int,
+    smoke_passed: bool,
+    cleanup_returncode: int,
+    unchanged: bool,
+    controller_error: str,
+) -> bool:
+    return (
+        build_returncode == 0
+        and integrity_returncode == 0
+        and smoke_passed
+        and cleanup_returncode == 0
+        and unchanged
+        and not controller_error
+    )
+
+
 def _run(repo: Path, *args: str) -> bytes:
     return subprocess.run(
         ["git", "-C", str(repo), *args],
@@ -181,7 +208,7 @@ def _sandbox_integrity() -> GateResult:
             str(test_plugin),
         ),
     ]
-    status = "passed" if all(check.passed for check in checks) else "failed"
+    status = _gate_status(checks)
     result = GateResult(gate_id="G-1", status=status, checks=checks)
     report_dir = sandbox / "reports"
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -203,7 +230,7 @@ def _run_controller(*, scenario: str, phase: str) -> int:
     sandbox = Path(tempfile.mkdtemp(prefix="akashic-plugin-gate-", dir="/tmp")).resolve()
     (sandbox / "static").mkdir()
     protected = [repo.resolve(), plugin_root, host_cache]
-    if any(sandbox == path or sandbox.is_relative_to(path) for path in protected):
+    if _sandbox_is_protected(sandbox, protected):
         shutil.rmtree(sandbox)
         raise SystemExit(f"Gate sandbox 不能位于受保护路径内：{sandbox}")
 
@@ -277,13 +304,13 @@ def _run_controller(*, scenario: str, phase: str) -> int:
             controller_error = f"{controller_error}; {suffix}".strip("; ")
     after = {str(path): _repository_digest(path) for path in repositories}
     unchanged = before == after
-    passed = (
-        build_returncode == 0
-        and integrity_returncode == 0
-        and smoke_passed
-        and cleanup_returncode == 0
-        and unchanged
-        and not controller_error
+    passed = _controller_gate_passed(
+        build_returncode=build_returncode,
+        integrity_returncode=integrity_returncode,
+        smoke_passed=smoke_passed,
+        cleanup_returncode=cleanup_returncode,
+        unchanged=unchanged,
+        controller_error=controller_error,
     )
     report: dict[str, object] = {
         "gate_id": "G-1-host" if scenario == "sandbox-integrity" else f"runtime:{phase}",
@@ -525,6 +552,55 @@ def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
             ),
         )
     return observe_source
+
+
+def _install_all_plugins(
+    sandbox: Path,
+    plugin_root: Path,
+) -> tuple[dict[str, Path], Path]:
+    cache = sandbox / "home/.akashic-plugin/cache/gate"
+    sources: dict[str, Path] = {}
+    entries: list[str] = []
+    for source_name, plugin_name in (
+        ("calendar-mcp", "calendar"),
+        ("citation", "citation"),
+        ("context_pressure", "context_pressure"),
+        ("daynight_gate", "daynight_gate"),
+        ("emotion", "emotion"),
+        ("feed-mcp", "feed"),
+        ("feishu", "feishu"),
+        ("huayue-skills", "huayue-skills"),
+        ("meme", "meme"),
+        ("observe", "observe"),
+        ("plugin_undo", "plugin_undo"),
+        ("proactive_feedback", "proactive_feedback"),
+        ("qqbot", "qqbot"),
+        ("setup_helper", "setup_helper"),
+        ("shell_restore", "shell_restore"),
+        ("shell_safety", "shell_safety"),
+        ("status_commands", "status_commands"),
+        ("steam-mcp", "steam"),
+        ("tool_loop_guard", "tool_loop_guard"),
+    ):
+        target = cache / plugin_name / "1.0.0"
+        ignored = (
+            shutil.ignore_patterns(".git", "__pycache__", ".pytest_cache")
+            if source_name == "calendar-mcp"
+            else shutil.ignore_patterns(
+                ".git",
+                ".venv",
+                "__pycache__",
+                ".pytest_cache",
+            )
+        )
+        shutil.copytree(plugin_root / source_name, target, ignore=ignored)
+        plugin_id = f"{plugin_name}@gate"
+        sources[plugin_id] = target / "plugin.py"
+        entries.append(f'[plugins."{plugin_id}"]\nenabled = true\n')
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    _ = manifest.write_text("\n".join(entries), encoding="utf-8")
+    return sources, manifest
 
 
 def _install_candidate_plugins(
@@ -1042,6 +1118,77 @@ def _exercise_migrated_plugins(
     }
 
 
+def _exercise_all_plugins(
+    container_id: str,
+    sources: dict[str, Path],
+    manifest: Path,
+) -> dict[str, object]:
+    reloads: dict[str, object] = {}
+    disables: dict[str, object] = {}
+    for plugin_id, source in sources.items():
+        before = _snapshot_statuses(container_id)
+        _ = source.write_text(
+            source.read_text(encoding="utf-8") + "\n",
+            encoding="utf-8",
+        )
+        _, reloads[plugin_id] = _wait_snapshot_status(
+            container_id,
+            after=len(before),
+            publication_state="committed",
+            plugin_id=plugin_id,
+        )
+    manifest_text = manifest.read_text(encoding="utf-8")
+    for plugin_id in reversed(sources):
+        before = _snapshot_statuses(container_id)
+        manifest_text = manifest_text.replace(
+            f'[plugins."{plugin_id}"]\nenabled = true',
+            f'[plugins."{plugin_id}"]\nenabled = false',
+        )
+        _ = manifest.write_text(manifest_text, encoding="utf-8")
+        _, disables[plugin_id] = _wait_snapshot_status(
+            container_id,
+            after=len(before),
+            publication_state="disabled",
+            plugin_id=plugin_id,
+        )
+    passed = all(
+        isinstance(result, dict)
+        and result.get("publication_state") == "committed"
+        and result.get("old_generation") != result.get("new_generation")
+        for result in reloads.values()
+    ) and all(
+        isinstance(result, dict)
+        and result.get("publication_state") == "disabled"
+        for result in disables.values()
+    )
+    return {
+        "passed": passed,
+        "plugin_count": len(sources),
+        "reloaded": sorted(
+            plugin_id
+            for plugin_id, result in reloads.items()
+            if isinstance(result, dict)
+            and result.get("publication_state") == "committed"
+        ),
+        "disabled": sorted(
+            plugin_id
+            for plugin_id, result in disables.items()
+            if isinstance(result, dict)
+            and result.get("publication_state") == "disabled"
+        ),
+        "reload_failures": {
+            plugin_id: result
+            for plugin_id, result in reloads.items()
+            if not isinstance(result, dict)
+            or result.get("publication_state") != "committed"
+        },
+        "disable_failures": {
+            plugin_id: result
+            for plugin_id, result in disables.items()
+            if not isinstance(result, dict)
+            or result.get("publication_state") != "disabled"
+        },
+    }
 def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
     script = (
         "import json, urllib.request\n"
@@ -1067,6 +1214,14 @@ def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
     if not isinstance(raw, dict):
         return {"error": repr(raw)}
     return {str(key): value for key, value in raw.items()}
+
+
+def _persistent_file_hashes(root: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and path.name != "monitor.runtime.log"
+    }
 
 
 def _wait_process_count(
@@ -1690,6 +1845,14 @@ def _run_runtime_smoke(
         if phase == "plugins"
         else None
     )
+    all_plugins = (
+        _install_all_plugins(
+            sandbox,
+            Path(env["AKASHIC_PLUGIN_SOURCE"]),
+        )
+        if phase == "all-plugins"
+        else None
+    )
     candidate_states = (
         _install_candidate_plugins(sandbox)
         if phase in {"candidate", "capability-hosts", "snapshot", "topology"}
@@ -1762,11 +1925,58 @@ def _run_runtime_smoke(
         ).stdout
     candidate_prepare: dict[str, object] = {}
     migrated_probe: dict[str, object] = {}
+    all_plugins_probe: dict[str, object] = {}
     fitbit_probe: dict[str, object] = {}
     fitbit_processes = -1
+    fitbit_reload: dict[str, object] = {}
+    fitbit_disabled: dict[str, object] = {}
+    fitbit_disabled_processes = -1
+    fitbit_data_before: dict[str, str] = {}
+    fitbit_data_after: dict[str, str] = {}
     if fitbit_data is not None and container_id and runtime_stable:
+        fitbit_data_before = _persistent_file_hashes(fitbit_data)
         fitbit_probe = _fitbit_runtime_probe(container_id)
         fitbit_processes = _container_process_count(container_id, "monitor/server.py")
+        before = _snapshot_statuses(container_id)
+        fitbit_source = (
+            sandbox
+            / "home/.akashic-plugin/cache/gate/fitbit/1.1.0/plugin.py"
+        )
+        _ = fitbit_source.write_text(
+            fitbit_source.read_text(encoding="utf-8") + "\n",
+            encoding="utf-8",
+        )
+        _, fitbit_reload = _wait_snapshot_status(
+            container_id,
+            after=len(before),
+            publication_state="committed",
+            plugin_id="fitbit@gate",
+        )
+        fitbit_processes = _wait_process_count(
+            container_id,
+            "monitor/server.py",
+            lambda count: count == 1,
+        )
+        fitbit_probe = _fitbit_runtime_probe(container_id)
+        before = _snapshot_statuses(container_id)
+        manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        _ = manifest.write_text(
+            '[plugins."fitbit@gate"]\nenabled = false\n',
+            encoding="utf-8",
+        )
+        _, fitbit_disabled = _wait_snapshot_status(
+            container_id,
+            after=len(before),
+            publication_state="disabled",
+            plugin_id="fitbit@gate",
+        )
+        fitbit_disabled_processes = _wait_process_count(
+            container_id,
+            "monitor/server.py",
+            lambda count: count == 0,
+        )
+        fitbit_data_after = _persistent_file_hashes(fitbit_data)
     if candidate_states is not None and container_id and runtime_stable:
         if phase == "snapshot":
             candidate_prepare = _exercise_snapshot_publish(
@@ -1793,6 +2003,12 @@ def _run_runtime_smoke(
             container_id,
             migrated_observe,
             sandbox,
+        )
+    if all_plugins is not None and container_id and runtime_stable:
+        all_plugins_probe = _exercise_all_plugins(
+            container_id,
+            all_plugins[0],
+            all_plugins[1],
         )
     _ = (
         _wait_json_value(scope_state, "event_started", True)
@@ -1905,6 +2121,12 @@ def _run_runtime_smoke(
         runtime_log = fitbit_data / "monitor.runtime.log"
         phase_passed = (
             fitbit_processes == 1
+            and fitbit_reload.get("publication_state") == "committed"
+            and fitbit_reload.get("old_generation")
+            != fitbit_reload.get("new_generation")
+            and fitbit_disabled.get("publication_state") == "disabled"
+            and fitbit_disabled_processes == 0
+            and fitbit_data_before == fitbit_data_after
             and isinstance(fitbit_probe.get("data"), dict)
             and isinstance(fitbit_probe.get("snapshot"), dict)
             and runtime_log.exists()
@@ -1912,12 +2134,19 @@ def _run_runtime_smoke(
         phase_evidence = {
             "phase": phase,
             "monitor_processes": fitbit_processes,
+            "disabled_monitor_processes": fitbit_disabled_processes,
+            "reload": fitbit_reload,
+            "disabled": fitbit_disabled,
+            "persistent_data_unchanged": fitbit_data_before == fitbit_data_after,
             "probe": fitbit_probe,
             "runtime_log": str(runtime_log),
         }
     if migrated_observe is not None:
         phase_passed = migrated_probe.get("passed") is True
         phase_evidence = {"phase": phase, **migrated_probe}
+    if all_plugins is not None:
+        phase_passed = all_plugins_probe.get("passed") is True
+        phase_evidence = {"phase": phase, **all_plugins_probe}
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -1995,6 +2224,7 @@ def main() -> int:
             "snapshot",
             "topology",
             "plugins",
+            "all-plugins",
             "fitbit",
         ),
         default="smoke",

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -820,6 +820,9 @@ def _exercise_candidate_prepare(
         and return_signal.returncode == 0
         and isinstance(initial_generation, str)
         and invalid_status.get("active_generation") == initial_generation
+        and isinstance(invalid_status.get("snapshot_id"), str)
+        and valid_status.get("snapshot_id") == invalid_status.get("snapshot_id")
+        and return_status.get("snapshot_id") == invalid_status.get("snapshot_id")
         and invalid_status.get("prepared_generation") is None
         and valid_status.get("active_generation") == initial_generation
         and isinstance(valid_status.get("prepared_generation"), str)

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -589,6 +589,8 @@ def _candidate_reload_source(version: str) -> str:
         f"        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger({1 if version == 'v1' else 2})], handler=self.refresh)]\n"
         "    async def refresh(self, context):\n"
         f"        self.context.kv_store.increment('job_runs_{version}')\n"
+        "        snapshot = get_current_runtime_snapshot()\n"
+        f"        self.context.kv_store.set('job_snapshot_bound_{version}', snapshot is not None and snapshot.generations.get('candidate_reload@gate').instance is self)\n"
         "    async def readiness_semantic_checks(self, context):\n"
         "        server = context.mcp_catalog.servers['candidate_feed']\n"
         "        value = await server.client.call('candidate_version', {})\n"
@@ -1124,6 +1126,7 @@ def _exercise_candidate_prepare(
         )
         and _integer(after_valid.get("job_runs_v1"))
         > _integer(initial.get("job_runs_v1"))
+        and after_valid.get("job_snapshot_bound_v1") is True
         and _integer(after_valid.get("job_runs_v2")) == 0
         and after_return_calls.get("v2") == after_valid_calls.get("v2")
         and passive_response.get("content") == "snapshot-v1"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    check_id: str
+    passed: bool
+    evidence: object
+
+
+@dataclass(frozen=True)
+class GateResult:
+    gate_id: str
+    status: str
+    checks: list[CheckResult]
+
+
+def _run(repo: Path, *args: str) -> bytes:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout
+
+
+def _repository_digest(repo: Path) -> str:
+    digest = hashlib.sha256()
+    commands = (
+        ("status", "--porcelain=v1", "--untracked-files=all"),
+        ("diff", "--binary", "--no-ext-diff"),
+        ("diff", "--binary", "--cached", "--no-ext-diff"),
+        ("submodule", "status", "--recursive"),
+    )
+    for command in commands:
+        digest.update(b"\0".join(part.encode() for part in command))
+        digest.update(_run(repo, *command))
+    paths = _run(
+        repo,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    ).split(b"\0")
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        path = repo / os.fsdecode(raw_path)
+        if not path.is_file() or path.is_symlink():
+            continue
+        digest.update(raw_path)
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _repositories() -> list[Path]:
+    repositories = [Path("/app")]
+    plugin_root = Path("/fixtures/plugins")
+    repositories.extend(
+        path
+        for path in sorted(plugin_root.iterdir())
+        if path.is_dir() and (path / ".git").exists()
+    )
+    return repositories
+
+
+def _mount_options(path: Path) -> set[str]:
+    output = subprocess.run(
+        ["findmnt", "--target", str(path), "--noheadings", "--output", "OPTIONS"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
+    return set(output.split(","))
+
+
+def _path_check(check_id: str, actual: Path, expected: Path) -> CheckResult:
+    resolved = actual.resolve()
+    return CheckResult(
+        check_id=check_id,
+        passed=resolved == expected,
+        evidence={"actual": str(resolved), "expected": str(expected)},
+    )
+
+
+def _sandbox_integrity() -> GateResult:
+    repositories = _repositories()
+    before = {str(repo): _repository_digest(repo) for repo in repositories}
+
+    sandbox = Path("/sandbox")
+    cache = Path.home() / ".akashic-plugin" / "cache"
+    test_plugin = cache / "gate" / "integrity" / "1.0.0" / "plugin.py"
+    test_plugin.parent.mkdir(parents=True, exist_ok=True)
+    _ = test_plugin.write_text("REVISION = 1\n", encoding="utf-8")
+    _ = test_plugin.write_text("REVISION = 2\n", encoding="utf-8")
+
+    after = {str(repo): _repository_digest(repo) for repo in repositories}
+    app_options = _mount_options(Path("/app"))
+    fixtures_options = _mount_options(Path("/fixtures/plugins"))
+    sandbox_options = _mount_options(sandbox)
+    checks = [
+        CheckResult("app_read_only", "ro" in app_options, sorted(app_options)),
+        CheckResult(
+            "plugin_fixtures_read_only",
+            "ro" in fixtures_options,
+            sorted(fixtures_options),
+        ),
+        CheckResult("sandbox_writable", "rw" in sandbox_options, sorted(sandbox_options)),
+        _path_check("home_isolated", Path.home(), Path("/sandbox/home")),
+        _path_check(
+            "workspace_isolated",
+            Path(os.environ["AKASHIC_DEBUG_WORKSPACE"]),
+            Path("/sandbox/workspace"),
+        ),
+        _path_check(
+            "config_isolated",
+            Path(os.environ["AKASHIC_DEBUG_CONFIG"]),
+            Path("/sandbox/config.toml"),
+        ),
+        CheckResult(
+            "plugin_cache_isolated",
+            cache.resolve() == Path("/sandbox/home/.akashic-plugin/cache"),
+            str(cache.resolve()),
+        ),
+        CheckResult(
+            "repositories_unchanged",
+            before == after,
+            {
+                "repositories": len(repositories),
+                "before": before,
+                "after": after,
+            },
+        ),
+        CheckResult(
+            "isolated_plugin_updated",
+            test_plugin.read_text(encoding="utf-8") == "REVISION = 2\n",
+            str(test_plugin),
+        ),
+    ]
+    status = "passed" if all(check.passed for check in checks) else "failed"
+    result = GateResult(gate_id="G-1", status=status, checks=checks)
+    report_dir = sandbox / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report = json.dumps(asdict(result), ensure_ascii=False, indent=2)
+    _ = (report_dir / "sandbox-integrity.json").write_text(
+        report + "\n",
+        encoding="utf-8",
+    )
+    print(report)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument(
+        "--scenario",
+        choices=("sandbox-integrity",),
+        default="sandbox-integrity",
+    )
+    args = parser.parse_args()
+    if args.scenario == "sandbox-integrity":
+        return 0 if _sandbox_integrity().status == "passed" else 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -1288,6 +1288,11 @@ def _run_runtime_smoke(
                 candidate_states[5],
                 socket,
             )
+    _ = (
+        _wait_json_value(scope_state, "event_started", True)
+        if scope_state is not None and runtime_stable
+        else {}
+    )
     logs = subprocess.run(
         [*compose, "logs", "--no-color", "--tail", "200", "akashic-plugin-gate"],
         cwd=repo,
@@ -1327,6 +1332,7 @@ def _run_runtime_smoke(
                 state = {str(key): value for key, value in mapping.items()}
         expected: dict[str, object] = {
             "initialized": True,
+            "event_started": True,
             "terminated": True,
             "task_cancelled": True,
             "subscription_closed": True,

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -536,9 +536,21 @@ def _candidate_reload_source(version: str) -> str:
         "import asyncio\n"
         "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
         "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
+        "class SnapshotBeforeTurn:\n"
+        "    slot = 'candidate_reload.before_turn'\n"
+        "    requires = ('before_turn.emit',)\n"
+        "    def __init__(self, plugin): self.plugin = plugin\n"
+        "    async def run(self, frame):\n"
+        f"        self.plugin.context.kv_store.increment('phase_runs_{version}')\n"
+        "        ctx = frame.slots['session:ctx']\n"
+        "        ctx.abort = True\n"
+        f"        ctx.abort_reply = 'snapshot-{version}'\n"
+        "        return frame\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
         f"{skills}"
+        "    def before_turn_modules(self):\n"
+        "        return [SnapshotBeforeTurn(self)]\n"
         "    @classmethod\n"
         "    def mcp_servers(cls):\n"
         f"        return [McpServerSpec(name='candidate_feed', command=('python', 'candidate_mcp_server.py'), env={{'CANDIDATE_VERSION': '{version}'}})]\n"
@@ -690,6 +702,32 @@ def _wait_process_count(
     return count
 
 
+def _ipc_roundtrip(path: Path, content: str) -> dict[str, object]:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(15)
+    try:
+        client.connect(str(path))
+        payload = json.dumps(
+            {
+                "content": content,
+                "as_session_key": "cli:snapshot-gate",
+            }
+        )
+        client.sendall((payload + "\n").encode())
+        data = b""
+        while b"\n" not in data:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+        raw: object = json.loads(data.split(b"\n", 1)[0]) if data else {}
+        if not isinstance(raw, dict):
+            return {}
+        return {str(key): value for key, value in raw.items()}
+    finally:
+        client.close()
+
+
 def _wait_candidate_status(
     container_id: str,
     *,
@@ -713,6 +751,7 @@ def _exercise_candidate_prepare(
     container_id: str,
     source_path: Path,
     state_path: Path,
+    socket_path: Path,
 ) -> dict[str, object]:
     initial = _read_json_object(state_path)
     calls_path = state_path.parent / "candidate_mcp_calls.jsonl"
@@ -759,6 +798,8 @@ def _exercise_candidate_prepare(
     time.sleep(2.3)
     after_valid = _read_json_object(state_path)
     after_valid_calls = _mcp_call_counts(calls_path)
+    passive_response = _ipc_roundtrip(socket_path, "snapshot lease gate")
+    after_passive = _read_json_object(state_path)
     after_valid_mcp_processes = _wait_process_count(
         container_id,
         "candidate_mcp_server.py",
@@ -901,6 +942,9 @@ def _exercise_candidate_prepare(
         > _integer(initial.get("job_runs_v1"))
         and _integer(after_valid.get("job_runs_v2")) == 0
         and after_return_calls.get("v2") == after_valid_calls.get("v2")
+        and passive_response.get("content") == "snapshot-v1"
+        and _integer(after_passive.get("phase_runs_v1")) >= 1
+        and _integer(after_passive.get("phase_runs_v2")) == 0
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"
@@ -939,6 +983,8 @@ def _exercise_candidate_prepare(
             "after_valid": after_valid_calls,
             "after_return": after_return_calls,
         },
+        "passive_response": passive_response,
+        "after_passive": after_passive,
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
         "return_signal": return_signal.returncode,
@@ -1041,6 +1087,7 @@ def _run_runtime_smoke(
             container_id,
             candidate_states[4],
             candidate_states[5],
+            socket,
         )
     logs = subprocess.run(
         [*compose, "logs", "--no-color", "--tail", "200", "akashic-plugin-gate"],

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -12,6 +12,7 @@ import sqlite3
 import subprocess
 import tempfile
 import time
+import tomllib
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -459,14 +460,33 @@ def _install_management_plugin(sandbox: Path) -> tuple[Path, Path, Path]:
     cache.mkdir(parents=True, exist_ok=True)
     data.mkdir(parents=True, exist_ok=True)
     _ = (cache / "plugin.py").write_text(
-        "from agent.plugins import Plugin, tool\n"
+        "from agent.plugins import ManagedServiceSpec, Plugin, tool\n"
         "class ManagementPlugin(Plugin):\n"
         "    name = 'management'\n"
         "    version = '1.0.0'\n"
+        "    @classmethod\n"
+        "    def managed_services(cls):\n"
+        "        return [ManagedServiceSpec(id='probe', command=('python', 'management_service.py'), readiness_url='http://127.0.0.1:18768/')]\n"
         "    @tool(name='management_probe')\n"
         "    async def probe(self, event):\n"
         "        \"\"\"Return the management probe state.\"\"\"\n"
         "        return 'ok'\n",
+        encoding="utf-8",
+    )
+    _ = (cache / "management_service.py").write_text(
+        "import os, signal, sys\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "from pathlib import Path\n"
+        "data = Path(os.environ['AKA_PLUGIN_DATA_DIR'])\n"
+        "(data / 'service.started').write_text('started')\n"
+        "def stop(*args):\n"
+        "    (data / 'service.stopped').write_text('stopped')\n"
+        "    sys.exit(0)\n"
+        "signal.signal(signal.SIGTERM, stop)\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self): self.send_response(200); self.end_headers(); self.wfile.write(b'ok')\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', 18768), Handler).serve_forever()\n",
         encoding="utf-8",
     )
     _ = (data / "retained.txt").write_text("keep", encoding="utf-8")
@@ -1224,10 +1244,23 @@ def _exercise_plugin_management(
     manifest: Path,
 ) -> dict[str, object]:
     commands: dict[str, dict[str, object]] = {}
+    service_states = {"initial": _management_service_ready(container_id)}
 
     def run(command: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            ["docker", "exec", container_id, "python", "main.py", command, "management@gate"],
+            [
+                "docker",
+                "exec",
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",
+                container_id,
+                "python",
+                "main.py",
+                command,
+                "management@gate",
+                "--config",
+                "/sandbox/config.toml",
+            ],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -1247,6 +1280,12 @@ def _exercise_plugin_management(
         "output": disabled_command.stdout.strip(),
         "status": disabled,
     }
+    service_states["disabled"] = _wait_process_count(
+        container_id,
+        "management_service.py",
+        lambda count: count == 0,
+    ) == 0
+    (data / "service.stopped").unlink(missing_ok=True)
 
     before = len(_snapshot_statuses(container_id))
     enabled_command = run("plugin-enable")
@@ -1261,6 +1300,7 @@ def _exercise_plugin_management(
         "output": enabled_command.stdout.strip(),
         "status": enabled,
     }
+    service_states["enabled"] = _management_service_ready(container_id)
 
     before = len(_snapshot_statuses(container_id))
     uninstall_command = run("plugin-uninstall")
@@ -1275,23 +1315,55 @@ def _exercise_plugin_management(
         "output": uninstall_command.stdout.strip(),
         "status": uninstalled,
     }
-    manifest_text = manifest.read_text(encoding="utf-8")
+    service_states["uninstalled"] = _wait_process_count(
+        container_id,
+        "management_service.py",
+        lambda count: count == 0,
+    ) == 0
+    manifest_data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    manifest_plugins = manifest_data.get("plugins", {})
     passed = (
         all(item["returncode"] == 0 for item in commands.values())
         and disabled.get("publication_state") == "disabled"
         and enabled.get("publication_state") == "committed"
         and uninstalled.get("publication_state") == "disabled"
+        and service_states == {
+            "initial": True,
+            "disabled": True,
+            "enabled": True,
+            "uninstalled": True,
+        }
+        and (data / "service.stopped").exists()
         and not cache.exists()
         and (data / "retained.txt").read_text(encoding="utf-8") == "keep"
-        and "management@gate" not in manifest_text
+        and "management@gate" not in manifest_plugins
     )
     return {
         "passed": passed,
         "commands": commands,
+        "service_states": service_states,
+        "service_stopped": (data / "service.stopped").exists(),
         "cache_removed": not cache.exists(),
         "data_retained": (data / "retained.txt").exists(),
-        "manifest_entry_removed": "management@gate" not in manifest_text,
+        "manifest_entry_removed": "management@gate" not in manifest_plugins,
     }
+
+
+def _management_service_ready(container_id: str) -> bool:
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container_id,
+            "python",
+            "-c",
+            "import urllib.request; urllib.request.urlopen('http://127.0.0.1:18768/', timeout=2).read()",
+        ],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
     script = (
         "import json, urllib.request\n"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -530,7 +530,8 @@ def _candidate_reload_source(version: str) -> str:
     return (
         "from __future__ import annotations\n"
         "import asyncio\n"
-        "from agent.plugins import McpServerSpec, Plugin, PluginSemanticCheck, ProactiveSourceSpec, tool\n"
+        "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
+        "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
         f"{skills}"
@@ -541,10 +542,18 @@ def _candidate_reload_source(version: str) -> str:
         "        return [ProactiveSourceSpec(id='candidate_feed', channels=('content',), "
         "server='candidate_feed', fetch_tool='fetch_events', ack_tool='ack_events', "
         "poll_tool='poll_events')]\n"
+        "    def jobs(self):\n"
+        "        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)]\n"
+        "    async def refresh(self, context):\n"
+        "        return None\n"
         "    async def readiness_semantic_checks(self, context):\n"
         "        server = context.mcp_catalog.servers['candidate_feed']\n"
         "        value = await server.client.call('candidate_version', {})\n"
-        f"        return [PluginSemanticCheck('candidate_mcp_version', value == '{version}', value)]\n"
+        "        job = context.job_catalog.jobs['candidate_reload@gate:refresh']\n"
+        "        source = context.proactive_catalog.sources['candidate_reload@gate:candidate_feed']\n"
+        "        owned = getattr(job.spec.handler, '__self__', None) is self\n"
+        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id}\n"
+        f"        return [PluginSemanticCheck('candidate_capabilities', value == '{version}' and owned, evidence)]\n"
         "    @tool(name='candidate_reload_tool')\n"
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
@@ -753,6 +762,8 @@ def _exercise_candidate_prepare(
     return_drift_body_hashes = return_status.get("drift_skill_body_hashes")
     valid_mcp_tools = valid_status.get("mcp_tools")
     valid_readiness_checks = valid_status.get("readiness_checks")
+    valid_jobs = valid_status.get("jobs")
+    valid_sources = valid_status.get("proactive_sources")
     valid_description_map = (
         cast(dict[object, object], valid_descriptions)
         if isinstance(valid_descriptions, dict)
@@ -794,11 +805,20 @@ def _exercise_candidate_prepare(
         and valid_readiness_checks
         == [
             {
-                "check_id": "candidate_mcp_version",
+                "check_id": "candidate_capabilities",
                 "passed": True,
-                "evidence": "v2",
+                "evidence": {
+                    "mcp": "v2",
+                    "job_owned": True,
+                    "source": "candidate_feed",
+                },
             }
         ]
+        and valid_jobs == ["candidate_reload@gate:refresh"]
+        and valid_sources == ["candidate_reload@gate:candidate_feed"]
+        and return_status.get("jobs") == ["candidate_reload@gate:refresh"]
+        and return_status.get("proactive_sources")
+        == ["candidate_reload@gate:candidate_feed"]
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from collections.abc import Callable
 from typing import cast
 
 
@@ -469,6 +470,23 @@ def _install_candidate_plugins(
             f"---\ndescription: candidate drift {version}\n---\ndrift {version}\n",
             encoding="utf-8",
         )
+    _ = (reload_plugin / "candidate_mcp_server.py").write_text(
+        "import json, sys\n"
+        "tools = [\n"
+        "    {'name': name, 'description': name, 'inputSchema': {'type': 'object', 'properties': {}}}\n"
+        "    for name in ('fetch_events', 'ack_events', 'poll_events')\n"
+        "]\n"
+        "for line in sys.stdin:\n"
+        "    msg = json.loads(line)\n"
+        "    if 'id' not in msg:\n"
+        "        continue\n"
+        "    method = msg.get('method')\n"
+        "    result = {'tools': tools} if method == 'tools/list' else {}\n"
+        "    if method == 'tools/call':\n"
+        "        result = {'content': [{'type': 'text', 'text': '[]'}]}\n"
+        "    print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n",
+        encoding="utf-8",
+    )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
     return (
@@ -505,10 +523,17 @@ def _candidate_reload_source(version: str) -> str:
     return (
         "from __future__ import annotations\n"
         "import asyncio\n"
-        "from agent.plugins import Plugin, tool\n"
+        "from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec, tool\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
         f"{skills}"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='candidate_feed', command=('python', 'candidate_mcp_server.py'))]\n"
+        "    def proactive_sources(self):\n"
+        "        return [ProactiveSourceSpec(id='candidate_feed', channels=('content',), "
+        "server='candidate_feed', fetch_tool='fetch_events', ack_tool='ack_events', "
+        "poll_tool='poll_events')]\n"
         "    @tool(name='candidate_reload_tool')\n"
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
@@ -574,6 +599,50 @@ def _candidate_statuses(container_id: str) -> list[dict[str, object]]:
     return statuses
 
 
+def _container_process_count(container_id: str, marker: str) -> int:
+    script = (
+        "import os\n"
+        "from pathlib import Path\n"
+        "count = 0\n"
+        "for entry in Path('/proc').iterdir():\n"
+        "    if not entry.name.isdigit() or int(entry.name) == os.getpid():\n"
+        "        continue\n"
+        "    try:\n"
+        "        command = (entry / 'cmdline').read_bytes().replace(b'\\0', b' ').decode()\n"
+        "    except (FileNotFoundError, PermissionError, ProcessLookupError):\n"
+        "        continue\n"
+        f"    if {marker!r} in command:\n"
+        "        count += 1\n"
+        "print(count)\n"
+    )
+    result = subprocess.run(
+        ["docker", "exec", container_id, "python", "-c", script],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return -1
+
+
+def _wait_process_count(
+    container_id: str,
+    marker: str,
+    predicate: Callable[[int], bool],
+) -> int:
+    deadline = time.monotonic() + 8
+    count = -1
+    while time.monotonic() < deadline:
+        count = _container_process_count(container_id, marker)
+        if predicate(count):
+            return count
+        time.sleep(0.1)
+    return count
+
+
 def _wait_candidate_status(
     container_id: str,
     *,
@@ -599,6 +668,11 @@ def _exercise_candidate_prepare(
     state_path: Path,
 ) -> dict[str, object]:
     initial = _read_json_object(state_path)
+    initial_mcp_processes = _wait_process_count(
+        container_id,
+        "candidate_mcp_server.py",
+        lambda count: count >= 1,
+    )
     initial_generation = initial.get("active_generation")
     initial_heartbeats = _integer(initial.get("heartbeats"))
     _ = source_path.write_text("not valid python !!!\n", encoding="utf-8")
@@ -616,6 +690,10 @@ def _exercise_candidate_prepare(
         gate_status="failed",
     )
     after_invalid = _read_json_object(state_path)
+    after_invalid_mcp_processes = _container_process_count(
+        container_id,
+        "candidate_mcp_server.py",
+    )
     _ = source_path.write_text(_candidate_reload_source("v2"), encoding="utf-8")
     valid_signal = subprocess.run(
         ["docker", "kill", "--signal", "HUP", container_id],
@@ -631,6 +709,11 @@ def _exercise_candidate_prepare(
     )
     time.sleep(0.2)
     after_valid = _read_json_object(state_path)
+    after_valid_mcp_processes = _wait_process_count(
+        container_id,
+        "candidate_mcp_server.py",
+        lambda count: count >= initial_mcp_processes + 1,
+    )
     _ = source_path.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     return_signal = subprocess.run(
         ["docker", "kill", "--signal", "HUP", container_id],
@@ -644,6 +727,11 @@ def _exercise_candidate_prepare(
         after=len(valid_statuses),
         gate_status="active",
     )
+    after_return_mcp_processes = _wait_process_count(
+        container_id,
+        "candidate_mcp_server.py",
+        lambda count: count == initial_mcp_processes,
+    )
     valid_skills = valid_status.get("skills")
     valid_descriptions = valid_status.get("skill_descriptions")
     valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
@@ -651,6 +739,7 @@ def _exercise_candidate_prepare(
     valid_drift_body_hashes = valid_status.get("drift_skill_body_hashes")
     return_body_hashes = return_status.get("skill_body_hashes")
     return_drift_body_hashes = return_status.get("drift_skill_body_hashes")
+    valid_mcp_tools = valid_status.get("mcp_tools")
     valid_description_map = (
         cast(dict[object, object], valid_descriptions)
         if isinstance(valid_descriptions, dict)
@@ -680,6 +769,13 @@ def _exercise_candidate_prepare(
         and valid_status.get("active_generation") == initial_generation
         and isinstance(valid_status.get("prepared_generation"), str)
         and isinstance(valid_skills, list)
+        and isinstance(valid_mcp_tools, list)
+        and valid_mcp_tools
+        == [
+            "mcp_candidate_feed__ack_events",
+            "mcp_candidate_feed__fetch_events",
+            "mcp_candidate_feed__poll_events",
+        ]
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"
@@ -697,6 +793,10 @@ def _exercise_candidate_prepare(
         and after_valid.get("active_generation") == initial_generation
         and after_valid.get("initialized_version") == "v1"
         and _integer(after_valid.get("heartbeats")) > initial_heartbeats
+        and initial_mcp_processes >= 1
+        and after_invalid_mcp_processes == initial_mcp_processes
+        and after_valid_mcp_processes >= initial_mcp_processes + 1
+        and after_return_mcp_processes == initial_mcp_processes
     )
     return {
         "passed": passed,
@@ -709,6 +809,12 @@ def _exercise_candidate_prepare(
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
         "return_signal": return_signal.returncode,
+        "mcp_processes": {
+            "initial": initial_mcp_processes,
+            "after_invalid": after_invalid_mcp_processes,
+            "after_valid": after_valid_mcp_processes,
+            "after_return": after_return_mcp_processes,
+        },
     }
 
 

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -357,6 +357,7 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "    version = '1.0.0'\n"
         "    async def initialize(self):\n"
         "        self.context.kv_store.set('initialized', True)\n"
+        "        self.context.kv_store.set('generation', self.context.generation_id)\n"
         "        self.context.defer('subscription_check', self._check_subscription)\n"
         "        self.subscription = self.context.event_bus.on(TurnCommitted, self._handle)\n"
         "        self.context.create_task(self._worker(), name='scope-gate-worker')\n"
@@ -383,6 +384,37 @@ def _install_scope_plugin(sandbox: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
 
 
+def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path]:
+    cache = sandbox / "home/.akashic-plugin/cache/gate"
+    valid = cache / "candidate_valid/1.0.0"
+    invalid = cache / "candidate_invalid/1.0.0"
+    valid.mkdir(parents=True, exist_ok=True)
+    invalid.mkdir(parents=True, exist_ok=True)
+    _ = (valid / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class CandidateValidPlugin(Plugin):\n"
+        "    name = 'candidate_valid'\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('initialized', True)\n"
+        "        self.context.kv_store.set('generation', self.context.generation_id)\n",
+        encoding="utf-8",
+    )
+    _ = (invalid / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class CandidateInvalidPlugin(Plugin):\n"
+        "    name = 'candidate_invalid'\n"
+        "    api_version = 2\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('initialized', True)\n",
+        encoding="utf-8",
+    )
+    data = sandbox / "home/.akashic-plugin/data"
+    return (
+        data / "candidate_valid-gate/.kv.json",
+        data / "candidate_invalid-gate/.kv.json",
+    )
+
+
 def _run_runtime_smoke(
     *,
     repo: Path,
@@ -397,6 +429,9 @@ def _run_runtime_smoke(
         ignore_errors=True,
     )
     scope_state = _install_scope_plugin(sandbox) if phase == "scope" else None
+    candidate_states = (
+        _install_candidate_plugins(sandbox) if phase == "candidate" else None
+    )
     started = subprocess.run(
         [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
         cwd=repo,
@@ -507,7 +542,32 @@ def _run_runtime_smoke(
             "events": 1,
         }
         phase_passed = all(state.get(key) == value for key, value in expected.items())
+        generation = state.get("generation")
+        phase_passed = phase_passed and isinstance(generation, str) and generation.startswith(
+            "scope_gate@gate:"
+        )
+        expected["generation"] = "scope_gate@gate:<revision>:<sequence>"
         phase_evidence = {"phase": phase, "state": state, "expected": expected}
+    if candidate_states is not None:
+        valid_path, invalid_path = candidate_states
+        valid_state: dict[str, object] = {}
+        if valid_path.exists():
+            raw_valid: object = json.loads(valid_path.read_text(encoding="utf-8"))
+            if isinstance(raw_valid, dict):
+                mapping = cast(dict[object, object], raw_valid)
+                valid_state = {str(key): value for key, value in mapping.items()}
+        generation = valid_state.get("generation")
+        phase_passed = (
+            valid_state.get("initialized") is True
+            and isinstance(generation, str)
+            and generation.startswith("candidate_valid@gate:")
+            and not invalid_path.exists()
+        )
+        phase_evidence = {
+            "phase": phase,
+            "valid": valid_state,
+            "invalid_initialized": invalid_path.exists(),
+        }
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -575,7 +635,11 @@ def main() -> int:
         choices=("sandbox-integrity", "full-runtime"),
         default="sandbox-integrity",
     )
-    _ = parser.add_argument("--phase", choices=("smoke", "scope"), default="smoke")
+    _ = parser.add_argument(
+        "--phase",
+        choices=("smoke", "scope", "candidate"),
+        default="smoke",
+    )
     _ = parser.add_argument("--inside-container", action="store_true")
     args = parser.parse_args()
     if args.inside_container:

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -544,6 +544,10 @@ def _candidate_reload_source(version: str) -> str:
         "    def __init__(self, plugin): self.plugin = plugin\n"
         "    async def run(self, frame):\n"
         f"        self.plugin.context.kv_store.increment('phase_runs_{version}')\n"
+        "        registry = self.plugin.context.tool_registry\n"
+        "        if registry is not None:\n"
+        "            value = await registry.execute('candidate_reload_tool', {}, raise_errors=True)\n"
+        f"            self.plugin.context.kv_store.set('phase_tool_version_{version}', str(value))\n"
         "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"
         f"        if '{version}' == 'v1' and ctx.content == 'block snapshot':\n"
@@ -1113,6 +1117,8 @@ def _exercise_candidate_prepare(
         and passive_response.get("content") == "snapshot-v1"
         and _integer(after_passive.get("phase_runs_v1")) >= 1
         and _integer(after_passive.get("phase_runs_v2")) == 0
+        and after_passive.get("phase_tool_version_v1") == "v1"
+        and after_passive.get("phase_tool_version_v2") is None
         and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -456,12 +456,19 @@ def _install_candidate_plugins(
         encoding="utf-8",
     )
     reload_source = reload_plugin / "plugin.py"
-    reload_skill = reload_plugin / "skills-v2" / "candidate-v2"
-    reload_skill.mkdir(parents=True)
-    _ = (reload_skill / "SKILL.md").write_text(
-        "---\ndescription: candidate v2 skill\n---\ncandidate v2\n",
-        encoding="utf-8",
-    )
+    for version in ("v1", "v2"):
+        reload_skill = reload_plugin / f"skills-{version}" / "candidate-skill"
+        reload_skill.mkdir(parents=True)
+        _ = (reload_skill / "SKILL.md").write_text(
+            f"---\ndescription: candidate {version} skill\n---\ncandidate {version}\n",
+            encoding="utf-8",
+        )
+        reload_drift_skill = reload_plugin / f"drift-{version}" / "candidate-drift"
+        reload_drift_skill.mkdir(parents=True)
+        _ = (reload_drift_skill / "SKILL.md").write_text(
+            f"---\ndescription: candidate drift {version}\n---\ndrift {version}\n",
+            encoding="utf-8",
+        )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     data = sandbox / "home/.akashic-plugin/data"
     return (
@@ -490,9 +497,10 @@ def _candidate_reload_source(version: str) -> str:
     skills = (
         "    @classmethod\n"
         "    def skill_roots(cls):\n"
-        "        return ('skills-v2',)\n"
-        if version == "v2"
-        else ""
+        f"        return ('skills-{version}',)\n"
+        "    @classmethod\n"
+        "    def drift_skill_roots(cls):\n"
+        f"        return ('drift-{version}',)\n"
     )
     return (
         "from __future__ import annotations\n"
@@ -629,6 +637,18 @@ def _exercise_candidate_prepare(
         gate_status="active",
     )
     valid_skills = valid_status.get("skills")
+    valid_descriptions = valid_status.get("skill_descriptions")
+    valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
+    valid_description_map = (
+        cast(dict[object, object], valid_descriptions)
+        if isinstance(valid_descriptions, dict)
+        else {}
+    )
+    valid_drift_description_map = (
+        cast(dict[object, object], valid_drift_descriptions)
+        if isinstance(valid_drift_descriptions, dict)
+        else {}
+    )
     passed = (
         invalid_signal.returncode == 0
         and valid_signal.returncode == 0
@@ -639,7 +659,9 @@ def _exercise_candidate_prepare(
         and valid_status.get("active_generation") == initial_generation
         and isinstance(valid_status.get("prepared_generation"), str)
         and isinstance(valid_skills, list)
-        and "candidate-v2" in valid_skills
+        and "candidate-skill" in valid_skills
+        and valid_description_map.get("candidate-skill") == "candidate v2 skill"
+        and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"
         and return_status.get("active_generation") == initial_generation
         and return_status.get("prepared_generation") is None
         and after_invalid.get("active_generation") == initial_generation

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -333,41 +333,59 @@ def _run_controller(*, scenario: str, phase: str) -> int:
     return 0 if report["status"] == "passed" else 1
 
 
-def _write_smoke_config(sandbox: Path, *, proactive_enabled: bool = False) -> None:
+def _write_smoke_config(
+    sandbox: Path,
+    *,
+    proactive_enabled: bool = False,
+    fast_tick: bool = False,
+) -> None:
     config = sandbox / "config.toml"
-    _ = config.write_text(
-        "\n".join(
+    lines = [
+        'provider = "openai"',
+        'model = "plugin-gate"',
+        'api_key = "gate-not-used"',
+        'system_prompt = "plugin gate"',
+        "max_iterations = 1",
+        "max_tokens = 64",
+        "memory_window = 4",
+        "memory_optimizer_enabled = false",
+        "spawn_enabled = false",
+        "",
+        "[channels]",
+        'socket = "/sandbox/akashic.sock"',
+        "",
+        "[channels.chat]",
+        "enabled = false",
+        "",
+        "[channels.telegram]",
+        "enabled = false",
+        'token = ""',
+        "",
+        "[channels.qq]",
+        "enabled = false",
+        'bot_uin = ""',
+        "",
+        "[proactive]",
+        'profile = "quiet"',
+        f"enabled = {'true' if proactive_enabled else 'false'}",
+        "",
+    ]
+    if fast_tick:
+        lines.extend(
             [
-                'provider = "openai"',
-                'model = "plugin-gate"',
-                'api_key = "gate-not-used"',
-                'system_prompt = "plugin gate"',
-                "max_iterations = 1",
-                "max_tokens = 64",
-                "memory_window = 4",
-                "memory_optimizer_enabled = false",
-                "spawn_enabled = false",
+                "[proactive.overrides.trigger]",
+                "tick_interval_s0 = 1",
+                "tick_interval_s1 = 1",
+                "tick_jitter = 0.0",
                 "",
-                "[channels]",
-                'socket = "/sandbox/akashic.sock"',
-                "",
-            "[channels.chat]",
-                "enabled = false",
-                "",
-                "[channels.telegram]",
-                "enabled = false",
-                'token = ""',
-                "",
-                "[channels.qq]",
-                "enabled = false",
-                'bot_uin = ""',
-                "",
-                "[proactive]",
-                'profile = "quiet"',
-                f"enabled = {'true' if proactive_enabled else 'false'}",
+                "[proactive.target]",
+                'channel = "cli"',
+                'chat_id = "gate"',
                 "",
             ]
-        ),
+        )
+    _ = config.write_text(
+        "\n".join(lines),
         encoding="utf-8",
     )
 
@@ -496,6 +514,48 @@ def _install_management_plugin(sandbox: Path) -> tuple[Path, Path, Path]:
         encoding="utf-8",
     )
     return cache.parent, data, manifest
+
+
+def _install_proactive_fetch_plugin(sandbox: Path) -> Path:
+    cache = sandbox / "home/.akashic-plugin/cache/gate/proactive_fetch/1.0.0"
+    data = sandbox / "home/.akashic-plugin/data/proactive_fetch-gate"
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    cache.mkdir(parents=True, exist_ok=True)
+    data.mkdir(parents=True, exist_ok=True)
+    _ = (cache / "plugin.py").write_text(
+        "from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec\n"
+        "class ProactiveFetchPlugin(Plugin):\n"
+        "    name = 'proactive_fetch'\n"
+        "    version = '1.0.0'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='proactive_fetch', command=('python', 'mcp_server.py'))]\n"
+        "    def proactive_sources(self):\n"
+        "        return [ProactiveSourceSpec(id='context', channels=('context',), server='proactive_fetch', fetch_tool='get_context')]\n",
+        encoding="utf-8",
+    )
+    _ = (cache / "mcp_server.py").write_text(
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "calls = Path(os.environ['AKA_PLUGIN_DATA_DIR']) / 'fetch_calls.jsonl'\n"
+        "tools = [{'name': 'get_context', 'description': 'Get context.', 'inputSchema': {'type': 'object', 'properties': {}}}]\n"
+        "for line in sys.stdin:\n"
+        "    message = json.loads(line)\n"
+        "    if 'id' not in message: continue\n"
+        "    method = message.get('method')\n"
+        "    result = {'tools': tools} if method == 'tools/list' else {}\n"
+        "    if method == 'tools/call':\n"
+        "        with calls.open('a', encoding='utf-8') as stream: stream.write(json.dumps(message['params']['name']) + '\\n')\n"
+        "        result = {'content': [{'type': 'text', 'text': '{\"available\": true}'}]}\n"
+        "    print(json.dumps({'jsonrpc': '2.0', 'id': message['id'], 'result': result}), flush=True)\n",
+        encoding="utf-8",
+    )
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    _ = manifest.write_text(
+        '[plugins."proactive_fetch@gate"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    return data / "fetch_calls.jsonl"
 
 
 def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
@@ -2000,7 +2060,13 @@ def _run_runtime_smoke(
 ) -> tuple[bool, dict[str, object]]:
     _write_smoke_config(
         sandbox,
-        proactive_enabled=phase in {"capability-hosts", "snapshot", "fitbit"},
+        proactive_enabled=phase in {
+            "capability-hosts",
+            "snapshot",
+            "fitbit",
+            "proactive-fetch",
+        },
+        fast_tick=phase == "proactive-fetch",
     )
     shutil.rmtree(
         sandbox / "home/.akashic-plugin/cache/gate",
@@ -2013,6 +2079,11 @@ def _run_runtime_smoke(
         else None
     )
     management = _install_management_plugin(sandbox) if phase == "management" else None
+    proactive_fetch_calls = (
+        _install_proactive_fetch_plugin(sandbox)
+        if phase == "proactive-fetch"
+        else None
+    )
     migrated_observe = (
         _install_migrated_plugins(
             sandbox,
@@ -2103,6 +2174,7 @@ def _run_runtime_smoke(
     migrated_probe: dict[str, object] = {}
     all_plugins_probe: dict[str, object] = {}
     management_probe: dict[str, object] = {}
+    proactive_fetch_probe: dict[str, object] = {}
     fitbit_probe: dict[str, object] = {}
     fitbit_processes = -1
     fitbit_reload: dict[str, object] = {}
@@ -2194,6 +2266,19 @@ def _run_runtime_smoke(
             management[1],
             management[2],
         )
+    if proactive_fetch_calls is not None and container_id and runtime_stable:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not proactive_fetch_calls.exists():
+            time.sleep(0.1)
+        calls = (
+            proactive_fetch_calls.read_text(encoding="utf-8").splitlines()
+            if proactive_fetch_calls.exists()
+            else []
+        )
+        proactive_fetch_probe = {
+            "passed": '"get_context"' in calls,
+            "calls": calls,
+        }
     _ = (
         _wait_json_value(scope_state, "event_started", True)
         if scope_state is not None and runtime_stable
@@ -2334,6 +2419,9 @@ def _run_runtime_smoke(
     if management is not None:
         phase_passed = management_probe.get("passed") is True
         phase_evidence = {"phase": phase, **management_probe}
+    if proactive_fetch_calls is not None:
+        phase_passed = proactive_fetch_probe.get("passed") is True
+        phase_evidence = {"phase": phase, **proactive_fetch_probe}
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -2414,6 +2502,7 @@ def main() -> int:
             "all-plugins",
             "fitbit",
             "management",
+            "proactive-fetch",
         ),
         default="smoke",
     )

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -373,13 +373,15 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "            self.context.kv_store.set('task_cancelled', True)\n"
         "    async def _emit(self):\n"
         "        await asyncio.sleep(0)\n"
-        "        await self.context.event_bus.fanout(TurnCommitted(\n"
+        "        self.context.event_bus.enqueue(TurnCommitted(\n"
         "            session_key='gate:scope', channel='gate', chat_id='scope',\n"
         "            input_message='scope', persisted_user_message='scope',\n"
         "            assistant_response='scope', tools_used=[]))\n"
         "    def _check_subscription(self):\n"
         "        self.context.kv_store.set('subscription_closed', not self.subscription.active)\n"
-        "    def _handle(self, event):\n"
+        "    async def _handle(self, event):\n"
+        "        self.context.kv_store.set('event_started', True)\n"
+        "        await asyncio.sleep(2)\n"
         "        self.context.kv_store.increment('events')\n",
         encoding="utf-8",
     )

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -1023,7 +1023,7 @@ def _candidate_statuses(container_id: str) -> list[dict[str, object]]:
         stderr=subprocess.STDOUT,
         text=True,
     ).stdout
-    marker = "plugin_candidate_status "
+    marker = "plugin_candidate_status_detail "
     statuses: list[dict[str, object]] = []
     for line in logs.splitlines():
         if marker not in line:

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -534,6 +534,7 @@ def _candidate_reload_source(version: str) -> str:
     return (
         "from __future__ import annotations\n"
         "import asyncio\n"
+        "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
         "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
         "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
         "class SnapshotBeforeTurn:\n"
@@ -542,10 +543,14 @@ def _candidate_reload_source(version: str) -> str:
         "    def __init__(self, plugin): self.plugin = plugin\n"
         "    async def run(self, frame):\n"
         f"        self.plugin.context.kv_store.increment('phase_runs_{version}')\n"
+        "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"
         "        ctx.abort = True\n"
         f"        ctx.abort_reply = 'snapshot-{version}'\n"
         "        return frame\n"
+        "    async def _probe_detached(self):\n"
+        "        await asyncio.sleep(0)\n"
+        "        self.plugin.context.kv_store.set('detached_snapshot_visible', get_current_runtime_snapshot() is not None)\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
         f"{skills}"
@@ -799,6 +804,7 @@ def _exercise_candidate_prepare(
     after_valid = _read_json_object(state_path)
     after_valid_calls = _mcp_call_counts(calls_path)
     passive_response = _ipc_roundtrip(socket_path, "snapshot lease gate")
+    time.sleep(0.2)
     after_passive = _read_json_object(state_path)
     after_valid_mcp_processes = _wait_process_count(
         container_id,
@@ -945,6 +951,7 @@ def _exercise_candidate_prepare(
         and passive_response.get("content") == "snapshot-v1"
         and _integer(after_passive.get("phase_runs_v1")) >= 1
         and _integer(after_passive.get("phase_runs_v2")) == 0
+        and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
         and valid_drift_description_map.get("candidate-drift") == "candidate drift v2"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -536,6 +536,7 @@ def _candidate_reload_source(version: str) -> str:
         "from __future__ import annotations\n"
         "import asyncio\n"
         "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
+        "from agent.skills import SkillsLoader\n"
         "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
         "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
         "class SnapshotBeforeTurn:\n"
@@ -548,6 +549,8 @@ def _candidate_reload_source(version: str) -> str:
         "        if registry is not None:\n"
         "            value = await registry.execute('candidate_reload_tool', {}, raise_errors=True)\n"
         f"            self.plugin.context.kv_store.set('phase_tool_version_{version}', str(value))\n"
+        "        skill_body = SkillsLoader(self.plugin.context.workspace).load_skill_body('candidate-skill')\n"
+        f"        self.plugin.context.kv_store.set('phase_skill_body_{version}', skill_body)\n"
         "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"
         f"        if '{version}' == 'v1' and ctx.content == 'block snapshot':\n"
@@ -1119,6 +1122,8 @@ def _exercise_candidate_prepare(
         and _integer(after_passive.get("phase_runs_v2")) == 0
         and after_passive.get("phase_tool_version_v1") == "v1"
         and after_passive.get("phase_tool_version_v2") is None
+        and after_passive.get("phase_skill_body_v1") == "candidate v1"
+        and after_passive.get("phase_skill_body_v2") is None
         and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -452,6 +452,32 @@ def _install_fitbit_plugin(sandbox: Path, plugin_root: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/fitbit-gate"
 
 
+def _install_management_plugin(sandbox: Path) -> tuple[Path, Path, Path]:
+    cache = sandbox / "home/.akashic-plugin/cache/gate/management/1.0.0"
+    data = sandbox / "home/.akashic-plugin/data/management-gate"
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    cache.mkdir(parents=True, exist_ok=True)
+    data.mkdir(parents=True, exist_ok=True)
+    _ = (cache / "plugin.py").write_text(
+        "from agent.plugins import Plugin, tool\n"
+        "class ManagementPlugin(Plugin):\n"
+        "    name = 'management'\n"
+        "    version = '1.0.0'\n"
+        "    @tool(name='management_probe')\n"
+        "    async def probe(self, event):\n"
+        "        \"\"\"Return the management probe state.\"\"\"\n"
+        "        return 'ok'\n",
+        encoding="utf-8",
+    )
+    _ = (data / "retained.txt").write_text("keep", encoding="utf-8")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    _ = manifest.write_text(
+        '[plugins."management@gate"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    return cache.parent, data, manifest
+
+
 def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
     cache = sandbox / "home/.akashic-plugin/cache/gate"
     entries: list[str] = []
@@ -1189,6 +1215,83 @@ def _exercise_all_plugins(
             or result.get("publication_state") != "disabled"
         },
     }
+
+
+def _exercise_plugin_management(
+    container_id: str,
+    cache: Path,
+    data: Path,
+    manifest: Path,
+) -> dict[str, object]:
+    commands: dict[str, dict[str, object]] = {}
+
+    def run(command: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["docker", "exec", container_id, "python", "main.py", command, "management@gate"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    before = len(_snapshot_statuses(container_id))
+    disabled_command = run("plugin-disable")
+    _, disabled = _wait_snapshot_status(
+        container_id,
+        after=before,
+        publication_state="disabled",
+        plugin_id="management@gate",
+    )
+    commands["disable"] = {
+        "returncode": disabled_command.returncode,
+        "output": disabled_command.stdout.strip(),
+        "status": disabled,
+    }
+
+    before = len(_snapshot_statuses(container_id))
+    enabled_command = run("plugin-enable")
+    _, enabled = _wait_snapshot_status(
+        container_id,
+        after=before,
+        publication_state="committed",
+        plugin_id="management@gate",
+    )
+    commands["enable"] = {
+        "returncode": enabled_command.returncode,
+        "output": enabled_command.stdout.strip(),
+        "status": enabled,
+    }
+
+    before = len(_snapshot_statuses(container_id))
+    uninstall_command = run("plugin-uninstall")
+    _, uninstalled = _wait_snapshot_status(
+        container_id,
+        after=before,
+        publication_state="disabled",
+        plugin_id="management@gate",
+    )
+    commands["uninstall"] = {
+        "returncode": uninstall_command.returncode,
+        "output": uninstall_command.stdout.strip(),
+        "status": uninstalled,
+    }
+    manifest_text = manifest.read_text(encoding="utf-8")
+    passed = (
+        all(item["returncode"] == 0 for item in commands.values())
+        and disabled.get("publication_state") == "disabled"
+        and enabled.get("publication_state") == "committed"
+        and uninstalled.get("publication_state") == "disabled"
+        and not cache.exists()
+        and (data / "retained.txt").read_text(encoding="utf-8") == "keep"
+        and "management@gate" not in manifest_text
+    )
+    return {
+        "passed": passed,
+        "commands": commands,
+        "cache_removed": not cache.exists(),
+        "data_retained": (data / "retained.txt").exists(),
+        "manifest_entry_removed": "management@gate" not in manifest_text,
+    }
 def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
     script = (
         "import json, urllib.request\n"
@@ -1837,6 +1940,7 @@ def _run_runtime_smoke(
         if phase == "fitbit"
         else None
     )
+    management = _install_management_plugin(sandbox) if phase == "management" else None
     migrated_observe = (
         _install_migrated_plugins(
             sandbox,
@@ -1926,6 +2030,7 @@ def _run_runtime_smoke(
     candidate_prepare: dict[str, object] = {}
     migrated_probe: dict[str, object] = {}
     all_plugins_probe: dict[str, object] = {}
+    management_probe: dict[str, object] = {}
     fitbit_probe: dict[str, object] = {}
     fitbit_processes = -1
     fitbit_reload: dict[str, object] = {}
@@ -2009,6 +2114,13 @@ def _run_runtime_smoke(
             container_id,
             all_plugins[0],
             all_plugins[1],
+        )
+    if management is not None and container_id and runtime_stable:
+        management_probe = _exercise_plugin_management(
+            container_id,
+            management[0],
+            management[1],
+            management[2],
         )
     _ = (
         _wait_json_value(scope_state, "event_started", True)
@@ -2147,6 +2259,9 @@ def _run_runtime_smoke(
     if all_plugins is not None:
         phase_passed = all_plugins_probe.get("passed") is True
         phase_evidence = {"phase": phase, **all_plugins_probe}
+    if management is not None:
+        phase_passed = management_probe.get("passed") is True
+        phase_evidence = {"phase": phase, **management_probe}
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -2226,6 +2341,7 @@ def main() -> int:
             "plugins",
             "all-plugins",
             "fitbit",
+            "management",
         ),
         default="smoke",
     )

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -549,7 +549,7 @@ def _candidate_reload_source(version: str) -> str:
         "        if registry is not None:\n"
         "            value = await registry.execute('candidate_reload_tool', {}, raise_errors=True)\n"
         f"            self.plugin.context.kv_store.set('phase_tool_version_{version}', str(value))\n"
-        "        skill_body = SkillsLoader(self.plugin.context.workspace).load_skill_body('candidate-skill')\n"
+        "        skill_body = SkillsLoader(self.plugin.context.workspace, runtime_catalog='normal').load_skill_body('candidate-skill')\n"
         f"        self.plugin.context.kv_store.set('phase_skill_body_{version}', skill_body)\n"
         "        self.plugin.context.create_task(self._probe_detached(), name='snapshot-detached-probe')\n"
         "        ctx = frame.slots['session:ctx']\n"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -424,6 +424,34 @@ def _install_fitbit_plugin(sandbox: Path, plugin_root: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/fitbit-gate"
 
 
+def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
+    cache = sandbox / "home/.akashic-plugin/cache/gate"
+    entries: list[str] = []
+    observe_source = Path()
+    for source_name, plugin_name in (
+        ("emotion", "emotion"),
+        ("meme", "meme"),
+        ("observe", "observe"),
+        ("proactive_feedback", "proactive_feedback"),
+        ("status_commands", "status_commands"),
+    ):
+        target = cache / plugin_name / "1.0.0"
+        shutil.copytree(
+            plugin_root / source_name,
+            target,
+            ignore=shutil.ignore_patterns(".git", ".venv", "__pycache__", ".pytest_cache"),
+        )
+        entries.append(
+            f'[plugins."{plugin_name}@gate"]\nenabled = true\n'
+        )
+        if plugin_name == "observe":
+            observe_source = target / "plugin.py"
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    _ = manifest.write_text("\n".join(entries), encoding="utf-8")
+    return observe_source
+
+
 def _install_candidate_plugins(
     sandbox: Path,
 ) -> tuple[Path, Path, Path, Path, Path, Path]:
@@ -826,6 +854,72 @@ def _candidate_service_version(container_id: str) -> str:
         text=True,
     )
     return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _dashboard_plugins(container_id: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container_id,
+            "python",
+            "-c",
+            (
+                "import json, urllib.request; "
+                "items=json.loads(urllib.request.urlopen("
+                "'http://127.0.0.1:2236/api/dashboard/plugins', timeout=2).read()); "
+                "print(json.dumps(sorted(item['id'] for item in items)))"
+            ),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def _exercise_migrated_plugins(
+    container_id: str,
+    observe_source: Path,
+    sandbox: Path,
+) -> dict[str, object]:
+    before = _snapshot_statuses(container_id)
+    _ = observe_source.write_text(
+        observe_source.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    _, reloaded = _wait_snapshot_status(
+        container_id,
+        after=len(before),
+        publication_state="committed",
+        plugin_id="observe@gate",
+    )
+    plugins = _dashboard_plugins(container_id)
+    expected = {
+        "emotion@gate",
+        "meme@gate",
+        "observe@gate",
+        "proactive_feedback@gate",
+        "status_commands@gate",
+    }
+    observe_db = sandbox / "workspace/observe/observe.db"
+    passed = (
+        reloaded.get("old_generation") != reloaded.get("new_generation")
+        and isinstance(reloaded.get("new_generation"), str)
+        and expected.issubset(plugins)
+        and observe_db.exists()
+    )
+    return {
+        "passed": passed,
+        "reloaded": reloaded,
+        "dashboard_plugins": plugins,
+        "observe_db": observe_db.exists(),
+    }
 
 
 def _fitbit_runtime_probe(container_id: str) -> dict[str, object]:
@@ -1468,6 +1562,14 @@ def _run_runtime_smoke(
         if phase == "fitbit"
         else None
     )
+    migrated_observe = (
+        _install_migrated_plugins(
+            sandbox,
+            Path(env["AKASHIC_PLUGIN_SOURCE"]),
+        )
+        if phase == "plugins"
+        else None
+    )
     candidate_states = (
         _install_candidate_plugins(sandbox)
         if phase in {"candidate", "capability-hosts", "snapshot", "topology"}
@@ -1539,6 +1641,7 @@ def _run_runtime_smoke(
             text=True,
         ).stdout
     candidate_prepare: dict[str, object] = {}
+    migrated_probe: dict[str, object] = {}
     fitbit_probe: dict[str, object] = {}
     fitbit_processes = -1
     if fitbit_data is not None and container_id and runtime_stable:
@@ -1565,6 +1668,12 @@ def _run_runtime_smoke(
                 candidate_states[5],
                 socket,
             )
+    if migrated_observe is not None and container_id and runtime_stable:
+        migrated_probe = _exercise_migrated_plugins(
+            container_id,
+            migrated_observe,
+            sandbox,
+        )
     _ = (
         _wait_json_value(scope_state, "event_started", True)
         if scope_state is not None and runtime_stable
@@ -1686,6 +1795,9 @@ def _run_runtime_smoke(
             "probe": fitbit_probe,
             "runtime_log": str(runtime_log),
         }
+    if migrated_observe is not None:
+        phase_passed = migrated_probe.get("passed") is True
+        phase_evidence = {"phase": phase, **migrated_probe}
     passed = (
         started.returncode == 0
         and ipc_ready
@@ -1762,6 +1874,7 @@ def main() -> int:
             "capability-hosts",
             "snapshot",
             "topology",
+            "plugins",
             "fitbit",
         ),
         default="smoke",

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -360,6 +360,7 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "        self.context.defer('subscription_check', self._check_subscription)\n"
         "        self.subscription = self.context.event_bus.on(TurnCommitted, self._handle)\n"
         "        self.context.create_task(self._worker(), name='scope-gate-worker')\n"
+        "        self.context.create_task(self._emit(), name='scope-gate-emit')\n"
         "    async def terminate(self):\n"
         "        self.context.kv_store.set('terminated', True)\n"
         "    async def _worker(self):\n"
@@ -367,6 +368,12 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "            await asyncio.Event().wait()\n"
         "        finally:\n"
         "            self.context.kv_store.set('task_cancelled', True)\n"
+        "    async def _emit(self):\n"
+        "        await asyncio.sleep(0)\n"
+        "        await self.context.event_bus.fanout(TurnCommitted(\n"
+        "            session_key='gate:scope', channel='gate', chat_id='scope',\n"
+        "            input_message='scope', persisted_user_message='scope',\n"
+        "            assistant_response='scope', tools_used=[]))\n"
         "    def _check_subscription(self):\n"
         "        self.context.kv_store.set('subscription_closed', not self.subscription.active)\n"
         "    def _handle(self, event):\n"
@@ -492,11 +499,12 @@ def _run_runtime_smoke(
             if isinstance(raw_state, dict):
                 mapping = cast(dict[object, object], raw_state)
                 state = {str(key): value for key, value in mapping.items()}
-        expected = {
+        expected: dict[str, object] = {
             "initialized": True,
             "terminated": True,
             "task_cancelled": True,
             "subscription_closed": True,
+            "events": 1,
         }
         phase_passed = all(state.get(key) == value for key, value in expected.items())
         phase_evidence = {"phase": phase, "state": state, "expected": expected}

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -920,18 +920,142 @@ def _wait_snapshot_status(
     *,
     after: int,
     publication_state: str,
+    plugin_id: str = "candidate_reload@gate",
 ) -> tuple[list[dict[str, object]], dict[str, object]]:
     deadline = time.monotonic() + 8
     while time.monotonic() < deadline:
         statuses = _snapshot_statuses(container_id)
         for status in statuses[after:]:
             if (
-                status.get("plugin_id") == "candidate_reload@gate"
+                status.get("plugin_id") == plugin_id
                 and status.get("publication_state") == publication_state
             ):
                 return statuses, status
         time.sleep(0.1)
     return _snapshot_statuses(container_id), {}
+
+
+def _wait_service_version(container_id: str, expected: str) -> str:
+    deadline = time.monotonic() + 10
+    value = ""
+    while time.monotonic() < deadline:
+        value = _candidate_service_version(container_id)
+        if value == expected:
+            return value
+        time.sleep(0.1)
+    return value
+
+
+def _exercise_topology_watch(
+    container_id: str,
+    sandbox: Path,
+    state_path: Path,
+) -> dict[str, object]:
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    initial = _read_json_object(state_path)
+    initial_generation = initial.get("active_generation")
+
+    statuses = _snapshot_statuses(container_id)
+    _ = manifest.write_text(
+        '[plugins."candidate_reload@gate"]\nenabled = false\n',
+        encoding="utf-8",
+    )
+    statuses, disabled = _wait_snapshot_status(
+        container_id,
+        after=len(statuses),
+        publication_state="disabled",
+    )
+    disabled_processes = _wait_process_count(
+        container_id,
+        "candidate_service.py",
+        lambda count: count == 0,
+    )
+
+    _ = manifest.write_text(
+        '[plugins."candidate_reload@gate"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    statuses, enabled = _wait_snapshot_status(
+        container_id,
+        after=len(statuses),
+        publication_state="committed",
+    )
+    enabled_service = _wait_service_version(container_id, "v1")
+    enabled_state = _wait_json_value(state_path, "initialized_version", "v1")
+    enabled_generation = enabled.get("new_generation")
+
+    config = state_path.parent / "config.local.toml"
+    _ = config.write_text("probe = 1\n", encoding="utf-8")
+    statuses, configured = _wait_snapshot_status(
+        container_id,
+        after=len(statuses),
+        publication_state="committed",
+    )
+
+    added_root = (
+        sandbox
+        / "home/.akashic-plugin/cache/gate/topology_added/1.0.0"
+    )
+    added_root.mkdir(parents=True)
+    _ = (added_root / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class TopologyAddedPlugin(Plugin):\n"
+        "    name = 'topology_added'\n"
+        "    version = '1.0.0'\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('generation', self.context.generation_id)\n"
+        "    async def terminate(self):\n"
+        "        self.context.kv_store.set('terminated', True)\n",
+        encoding="utf-8",
+    )
+    added_state_path = (
+        sandbox / "home/.akashic-plugin/data/topology_added-gate/.kv.json"
+    )
+    added_state: dict[str, object] = {}
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        added_state = _read_json_object(added_state_path)
+        if isinstance(added_state.get("generation"), str):
+            break
+        time.sleep(0.1)
+    statuses = _snapshot_statuses(container_id)
+    shutil.rmtree(added_root)
+    _, removed = _wait_snapshot_status(
+        container_id,
+        after=len(statuses),
+        publication_state="disabled",
+        plugin_id="topology_added@gate",
+    )
+    removed_state = _wait_json_value(added_state_path, "terminated", True)
+
+    passed = (
+        isinstance(initial_generation, str)
+        and disabled.get("publication_state") == "disabled"
+        and disabled_processes == 0
+        and enabled.get("old_generation") is None
+        and isinstance(enabled_generation, str)
+        and enabled_generation != initial_generation
+        and enabled_service == "v1"
+        and enabled_state.get("initialized_version") == "v1"
+        and configured.get("old_generation") == enabled_generation
+        and isinstance(configured.get("new_generation"), str)
+        and configured.get("new_generation") != enabled_generation
+        and isinstance(added_state.get("generation"), str)
+        and removed.get("publication_state") == "disabled"
+        and removed_state.get("terminated") is True
+    )
+    return {
+        "passed": passed,
+        "initial_generation": initial_generation,
+        "disabled": disabled,
+        "disabled_service_processes": disabled_processes,
+        "enabled": enabled,
+        "enabled_service": enabled_service,
+        "configured": configured,
+        "added": added_state,
+        "removed": removed,
+        "removed_state": removed_state,
+    }
 
 
 def _exercise_snapshot_publish(
@@ -1346,7 +1470,7 @@ def _run_runtime_smoke(
     )
     candidate_states = (
         _install_candidate_plugins(sandbox)
-        if phase in {"candidate", "capability-hosts", "snapshot"}
+        if phase in {"candidate", "capability-hosts", "snapshot", "topology"}
         else None
     )
     started = subprocess.run(
@@ -1427,6 +1551,12 @@ def _run_runtime_smoke(
                 candidate_states[4],
                 candidate_states[5],
                 socket,
+            )
+        elif phase == "topology":
+            candidate_prepare = _exercise_topology_watch(
+                container_id,
+                sandbox,
+                candidate_states[5],
             )
         else:
             candidate_prepare = _exercise_candidate_prepare(
@@ -1625,7 +1755,15 @@ def main() -> int:
     )
     _ = parser.add_argument(
         "--phase",
-        choices=("smoke", "scope", "candidate", "capability-hosts", "snapshot", "fitbit"),
+        choices=(
+            "smoke",
+            "scope",
+            "candidate",
+            "capability-hosts",
+            "snapshot",
+            "topology",
+            "fitbit",
+        ),
         default="smoke",
     )
     _ = parser.add_argument("--inside-container", action="store_true")

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -354,9 +354,15 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "import asyncio\n"
         "from agent.plugins import Plugin\n"
         "from bus.events_lifecycle import TurnCommitted\n"
+        "class ScopeGateChannel:\n"
+        "    name = 'scope-gate-channel'\n"
+        "    def __init__(self, plugin): self.plugin = plugin\n"
+        "    async def start(self, ctx): self.plugin.context.kv_store.set('channel_started', True)\n"
+        "    async def stop(self): self.plugin.context.kv_store.set('channel_stopped', True)\n"
         "class ScopeGatePlugin(Plugin):\n"
         "    name = 'scope_gate'\n"
         "    version = '1.0.0'\n"
+        "    def channels(self): return [ScopeGateChannel(self)]\n"
         "    async def initialize(self):\n"
         "        self.context.kv_store.set('initialized', True)\n"
         "        self.context.kv_store.set('generation', self.context.generation_id)\n"
@@ -1351,6 +1357,8 @@ def _run_runtime_smoke(
         expected: dict[str, object] = {
             "initialized": True,
             "event_started": True,
+            "channel_started": True,
+            "channel_stopped": True,
             "terminated": True,
             "task_cancelled": True,
             "subscription_closed": True,

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -384,12 +384,16 @@ def _install_scope_plugin(sandbox: Path) -> Path:
     return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
 
 
-def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path]:
+def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path, Path, Path]:
     cache = sandbox / "home/.akashic-plugin/cache/gate"
     valid = cache / "candidate_valid/1.0.0"
     invalid = cache / "candidate_invalid/1.0.0"
+    failed = cache / "candidate_failed/1.0.0"
+    observer = cache / "candidate_observer/1.0.0"
     valid.mkdir(parents=True, exist_ok=True)
     invalid.mkdir(parents=True, exist_ok=True)
+    failed.mkdir(parents=True, exist_ok=True)
+    observer.mkdir(parents=True, exist_ok=True)
     _ = (valid / "plugin.py").write_text(
         "from agent.plugins import Plugin\n"
         "class CandidateValidPlugin(Plugin):\n"
@@ -408,10 +412,51 @@ def _install_candidate_plugins(sandbox: Path) -> tuple[Path, Path]:
         "        self.context.kv_store.set('initialized', True)\n",
         encoding="utf-8",
     )
+    _ = (failed / "plugin.py").write_text(
+        "from agent.plugins import Plugin, tool\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class CandidateFailedPlugin(Plugin):\n"
+        "    name = 'candidate_failed'\n"
+        "    @tool(name='candidate_failed_tool')\n"
+        "    async def failed_tool(self, event):\n"
+        "        \"\"\"Failed candidate tool.\"\"\"\n"
+        "        return 'leaked'\n"
+        "    async def initialize(self):\n"
+        "        self.context.event_bus.on(TurnCommitted, self._on_turn)\n"
+        "        raise RuntimeError('candidate init failed')\n"
+        "    def _on_turn(self, event):\n"
+        "        self.context.kv_store.set('handler_leaked', True)\n",
+        encoding="utf-8",
+    )
+    _ = (observer / "plugin.py").write_text(
+        "from __future__ import annotations\n"
+        "import asyncio\n"
+        "from agent.plugins import Plugin\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class CandidateObserverPlugin(Plugin):\n"
+        "    name = 'candidate_observer'\n"
+        "    async def initialize(self):\n"
+        "        self.context.create_task(self._verify(), name='candidate-observer')\n"
+        "    async def _verify(self):\n"
+        "        await asyncio.sleep(0.2)\n"
+        "        registry = self.context.tool_registry\n"
+        "        self.context.kv_store.set(\n"
+        "            'failed_tool_visible',\n"
+        "            registry is not None and registry.has_tool('candidate_failed_tool'),\n"
+        "        )\n"
+        "        await self.context.event_bus.fanout(TurnCommitted(\n"
+        "            session_key='gate:candidate', channel='gate', chat_id='candidate',\n"
+        "            input_message='candidate', persisted_user_message='candidate',\n"
+        "            assistant_response='candidate', tools_used=[]))\n"
+        "        self.context.kv_store.set('event_sent', True)\n",
+        encoding="utf-8",
+    )
     data = sandbox / "home/.akashic-plugin/data"
     return (
         data / "candidate_valid-gate/.kv.json",
         data / "candidate_invalid-gate/.kv.json",
+        data / "candidate_failed-gate/.kv.json",
+        data / "candidate_observer-gate/.kv.json",
     )
 
 
@@ -549,24 +594,39 @@ def _run_runtime_smoke(
         expected["generation"] = "scope_gate@gate:<revision>:<sequence>"
         phase_evidence = {"phase": phase, "state": state, "expected": expected}
     if candidate_states is not None:
-        valid_path, invalid_path = candidate_states
+        valid_path, invalid_path, failed_path, observer_path = candidate_states
         valid_state: dict[str, object] = {}
         if valid_path.exists():
             raw_valid: object = json.loads(valid_path.read_text(encoding="utf-8"))
             if isinstance(raw_valid, dict):
                 mapping = cast(dict[object, object], raw_valid)
                 valid_state = {str(key): value for key, value in mapping.items()}
+        observer_state: dict[str, object] = {}
+        if observer_path.exists():
+            raw_observer: object = json.loads(
+                observer_path.read_text(encoding="utf-8")
+            )
+            if isinstance(raw_observer, dict):
+                mapping = cast(dict[object, object], raw_observer)
+                observer_state = {
+                    str(key): value for key, value in mapping.items()
+                }
         generation = valid_state.get("generation")
         phase_passed = (
             valid_state.get("initialized") is True
             and isinstance(generation, str)
             and generation.startswith("candidate_valid@gate:")
             and not invalid_path.exists()
+            and not failed_path.exists()
+            and observer_state.get("failed_tool_visible") is False
+            and observer_state.get("event_sent") is True
         )
         phase_evidence = {
             "phase": phase,
             "valid": valid_state,
             "invalid_initialized": invalid_path.exists(),
+            "failed_candidate_state_exists": failed_path.exists(),
+            "observer": observer_state,
         }
     passed = (
         started.returncode == 0

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -542,9 +542,10 @@ def _candidate_reload_source(version: str) -> str:
         "import asyncio\n"
         "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
         "from agent.skills import SkillsLoader\n"
+        "from agent.tool_hooks import ToolExecutionRequest, ToolExecutor\n"
         "from bus.events_lifecycle import TurnCommitted\n"
         "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
-        "PluginSemanticCheck, ProactiveSourceSpec, tool)\n"
+        "PluginSemanticCheck, ProactiveSourceSpec, on_tool_pre, tool)\n"
         "class SnapshotBeforeTurn:\n"
         "    slot = 'candidate_reload.before_turn'\n"
         "    requires = ('before_turn.emit',)\n"
@@ -553,7 +554,8 @@ def _candidate_reload_source(version: str) -> str:
         f"        self.plugin.context.kv_store.increment('phase_runs_{version}')\n"
         "        registry = self.plugin.context.tool_registry\n"
         "        if registry is not None:\n"
-        "            value = await registry.execute('candidate_reload_tool', {}, raise_errors=True)\n"
+        "            execution = await ToolExecutor().execute(ToolExecutionRequest(call_id='gate', tool_name='candidate_reload_tool', arguments={}, source='passive'), lambda name, args: registry.execute(name, args, raise_errors=True))\n"
+        "            value = execution.output\n"
         f"            self.plugin.context.kv_store.set('phase_tool_version_{version}', str(value))\n"
         "        skill_body = SkillsLoader(self.plugin.context.workspace, runtime_catalog='normal').load_skill_body('candidate-skill')\n"
         f"        self.plugin.context.kv_store.set('phase_skill_body_{version}', skill_body)\n"
@@ -606,6 +608,9 @@ def _candidate_reload_source(version: str) -> str:
         "    async def run(self, event):\n"
         "        \"\"\"Candidate reload tool.\"\"\"\n"
         f"        return '{version}'\n"
+        "    @on_tool_pre(tool_name='candidate_reload_tool')\n"
+        "    async def before_candidate_tool(self, event):\n"
+        f"        self.context.kv_store.increment('phase_hook_version_{version}')\n"
         "    async def initialize(self):\n"
         f"{initialize}"
         "    async def _on_committed(self, event):\n"
@@ -1143,6 +1148,8 @@ def _exercise_candidate_prepare(
         and after_passive.get("phase_skill_body_v2") is None
         and _integer(after_passive.get("phase_event_version_v1")) >= 1
         and _integer(after_passive.get("phase_event_version_v2")) == 0
+        and _integer(after_passive.get("phase_hook_version_v1")) >= 1
+        and _integer(after_passive.get("phase_hook_version_v2")) == 0
         and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -756,7 +756,7 @@ def _exercise_candidate_prepare(
         after=len(statuses),
         gate_status="passed",
     )
-    time.sleep(1.2)
+    time.sleep(2.3)
     after_valid = _read_json_object(state_path)
     after_valid_calls = _mcp_call_counts(calls_path)
     after_valid_mcp_processes = _wait_process_count(

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import socket
+import sqlite3
 import subprocess
 import tempfile
 import time
@@ -429,6 +430,7 @@ def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
     entries: list[str] = []
     observe_source = Path()
     for source_name, plugin_name in (
+        ("citation", "citation"),
         ("emotion", "emotion"),
         ("meme", "meme"),
         ("observe", "observe"),
@@ -448,7 +450,80 @@ def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
             observe_source = target / "plugin.py"
     manifest = sandbox / "home/.akashic-plugin/manifest.toml"
     manifest.parent.mkdir(parents=True, exist_ok=True)
+    driver = cache / "zz_gate_driver" / "1.0.0"
+    driver.mkdir(parents=True)
+    _ = (driver / "plugin.py").write_text(
+        "from __future__ import annotations\n"
+        "import asyncio\n"
+        "import sqlite3\n"
+        "from agent.plugins import Plugin\n"
+        "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class InspectRuntimeModules:\n"
+        "    slot = 'gate_driver.inspect_runtime_modules'\n"
+        "    requires = ('before_turn.acquire_session',)\n"
+        "    def __init__(self, plugin): self.plugin = plugin\n"
+        "    async def run(self, frame):\n"
+        "        snapshot = get_current_runtime_snapshot()\n"
+        "        slots = [] if snapshot is None else [getattr(item, 'slot', '') for item in snapshot.before_turn_modules + snapshot.prompt_render_modules]\n"
+        "        self.plugin.context.kv_store.set('phase_slots', slots)\n"
+        "        return frame\n"
+        "class GateDriverPlugin(Plugin):\n"
+        "    name = 'zz_gate_driver'\n"
+        "    def before_turn_modules(self): return [InspectRuntimeModules(self)]\n"
+        "    async def initialize(self):\n"
+        "        self.context.create_task(self._drive_feedback(), name='gate-feedback-driver')\n"
+        "    async def _drive_feedback(self):\n"
+        "        await asyncio.sleep(0.2)\n"
+        "        content = '/memorystatus 被回复消息：这是一条用于验证主动反馈工作链路的提醒消息【你当前新消息】谢谢'\n"
+        "        with sqlite3.connect(self.context.workspace / 'sessions.db') as connection:\n"
+        "            connection.execute(\"INSERT INTO messages (id, session_key, seq, role, content, extra, ts) VALUES (?, ?, ?, ?, ?, ?, ?)\", ('cli:snapshot-gate:1', 'cli:snapshot-gate', 1, 'user', content, '{}', '2026-07-11T00:01:00+00:00'))\n"
+        "            connection.execute(\"INSERT INTO messages (id, session_key, seq, role, content, extra, ts) VALUES (?, ?, ?, ?, ?, ?, ?)\", ('cli:snapshot-gate:2', 'cli:snapshot-gate', 2, 'assistant', '状态回复', '{}', '2026-07-11T00:01:01+00:00'))\n"
+        "            connection.execute(\"UPDATE sessions SET next_seq = 3 WHERE key = ?\", ('cli:snapshot-gate',))\n"
+        "        await self.context.event_bus.fanout(TurnCommitted(session_key='cli:snapshot-gate', channel='cli', chat_id='snapshot-gate', input_message=content, persisted_user_message=content, assistant_response='状态回复', tools_used=[]))\n",
+        encoding="utf-8",
+    )
+    entries.append('[plugins."zz_gate_driver@gate"]\nenabled = true\n')
     _ = manifest.write_text("\n".join(entries), encoding="utf-8")
+    workspace = sandbox / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(workspace / "sessions.db") as connection:
+        _ = connection.execute(
+            "CREATE TABLE sessions (key TEXT PRIMARY KEY, created_at TEXT NOT NULL, "
+            "updated_at TEXT NOT NULL, last_consolidated INTEGER NOT NULL DEFAULT 0, "
+            "metadata TEXT, last_user_at TEXT, last_proactive_at TEXT, "
+            "next_seq INTEGER NOT NULL DEFAULT 0)"
+        )
+        _ = connection.execute(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, session_key TEXT NOT NULL, "
+            "seq INTEGER NOT NULL, role TEXT NOT NULL, content TEXT, tool_chain TEXT, "
+            "extra TEXT, ts TEXT NOT NULL, UNIQUE (session_key, seq))"
+        )
+        _ = connection.execute(
+            "INSERT INTO sessions "
+            "(key, created_at, updated_at, metadata, next_seq) VALUES (?, ?, ?, ?, ?)",
+            (
+                "cli:snapshot-gate",
+                "2026-07-11T00:00:00+00:00",
+                "2026-07-11T00:00:00+00:00",
+                "{}",
+                1,
+            ),
+        )
+        _ = connection.execute(
+            "INSERT INTO messages "
+            "(id, session_key, seq, role, content, extra, ts) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "cli:snapshot-gate:0",
+                "cli:snapshot-gate",
+                0,
+                "assistant",
+                "这是一条用于验证主动反馈工作链路的提醒消息",
+                '{"proactive": true}',
+                "2026-07-11T00:00:00+00:00",
+            ),
+        )
     return observe_source
 
 
@@ -883,11 +958,46 @@ def _dashboard_plugins(container_id: str) -> list[str]:
     return [str(item) for item in value] if isinstance(value, list) else []
 
 
+def _wait_sqlite_count(path: Path, query: str) -> int:
+    deadline = time.monotonic() + 8
+    count = 0
+    while time.monotonic() < deadline:
+        if path.exists():
+            try:
+                with sqlite3.connect(path) as connection:
+                    row = connection.execute(query).fetchone()
+                count = int(row[0]) if row is not None else 0
+            except sqlite3.OperationalError:
+                count = 0
+            if count:
+                return count
+        time.sleep(0.1)
+    return count
+
+
 def _exercise_migrated_plugins(
     container_id: str,
     observe_source: Path,
     sandbox: Path,
 ) -> dict[str, object]:
+    status_response = _ipc_roundtrip(
+        sandbox / "akashic.sock",
+        "/memorystatus 被回复消息：这是一条用于验证主动反馈工作链路的提醒消息"
+        "【你当前新消息】谢谢",
+    )
+    feedback_count = _wait_sqlite_count(
+        sandbox / "workspace/proactive_feedback/proactive_feedback.db",
+        "SELECT count(*) FROM proactive_feedback_events",
+    )
+    driver_state = _read_json_object(
+        sandbox / "home/.akashic-plugin/data/zz_gate_driver-gate/.kv.json"
+    )
+    raw_slots = driver_state.get("phase_slots", [])
+    lifecycle_slots = (
+        {str(item) for item in raw_slots if isinstance(item, str)}
+        if isinstance(raw_slots, list)
+        else set()
+    )
     before = _snapshot_statuses(container_id)
     _ = observe_source.write_text(
         observe_source.read_text(encoding="utf-8") + "\n",
@@ -909,13 +1019,23 @@ def _exercise_migrated_plugins(
     }
     observe_db = sandbox / "workspace/observe/observe.db"
     passed = (
-        reloaded.get("old_generation") != reloaded.get("new_generation")
+        str(status_response.get("content", "")).startswith("🧠 记忆整理状态")
+        and feedback_count >= 1
+        and {
+            "meme.prompt",
+            "status_commands.memory_status",
+            "gate_driver.inspect_runtime_modules",
+        }.issubset(lifecycle_slots)
+        and reloaded.get("old_generation") != reloaded.get("new_generation")
         and isinstance(reloaded.get("new_generation"), str)
         and expected.issubset(plugins)
         and observe_db.exists()
     )
     return {
         "passed": passed,
+        "status_response": status_response.get("content"),
+        "proactive_feedback_events": feedback_count,
+        "lifecycle_slots": sorted(lifecycle_slots),
         "reloaded": reloaded,
         "dashboard_plugins": plugins,
         "observe_db": observe_db.exists(),

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -5,7 +5,11 @@ import argparse
 import hashlib
 import json
 import os
+import re
+import shutil
 import subprocess
+import tempfile
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -73,6 +77,28 @@ def _repositories() -> list[Path]:
         for path in sorted(plugin_root.iterdir())
         if path.is_dir() and (path / ".git").exists()
     )
+    return repositories
+
+
+def _host_repositories(repo: Path, plugin_root: Path) -> list[Path]:
+    repositories = [repo]
+    repositories.extend(
+        path
+        for path in sorted(plugin_root.iterdir())
+        if path.is_dir() and (path / ".git").exists()
+    )
+    index = 0
+    while index < len(repositories):
+        parent = repositories[index]
+        output = _run(parent, "submodule", "status", "--recursive").decode()
+        for line in output.splitlines():
+            match = re.match(r"^[ +\-U]?[0-9a-f]{40} (.+?)(?: \(.+\))?$", line)
+            if match is None:
+                continue
+            submodule = (parent / match.group(1)).resolve()
+            if submodule not in repositories:
+                repositories.append(submodule)
+        index += 1
     return repositories
 
 
@@ -163,6 +189,224 @@ def _sandbox_integrity() -> GateResult:
     return result
 
 
+def _run_controller() -> int:
+    repo = Path(__file__).resolve().parents[2]
+    plugin_root = Path(
+        os.environ.get("AKASHIC_PLUGIN_SOURCE", "/mnt/data/coding/akashic-plugin")
+    ).resolve()
+    host_cache = (Path.home() / ".akashic-plugin" / "cache").resolve()
+    sandbox = Path(tempfile.mkdtemp(prefix="akashic-plugin-gate-", dir="/tmp")).resolve()
+    protected = [repo.resolve(), plugin_root, host_cache]
+    if any(sandbox == path or sandbox.is_relative_to(path) for path in protected):
+        shutil.rmtree(sandbox)
+        raise SystemExit(f"Gate sandbox 不能位于受保护路径内：{sandbox}")
+
+    repositories = _host_repositories(repo, plugin_root)
+    before = {str(path): _repository_digest(path) for path in repositories}
+    env = {
+        **os.environ,
+        "AKASHIC_GATE_SANDBOX": str(sandbox),
+        "AKASHIC_PLUGIN_SOURCE": str(plugin_root),
+    }
+    compose = [
+        "docker",
+        "compose",
+        "-p",
+        "akashic-plugin-reload-gate",
+        "-f",
+        str(repo / "docker/debug/docker-compose.yml"),
+        "--profile",
+        "plugin-gate",
+    ]
+    command = [
+        *compose,
+        "run",
+        "--rm",
+        "akashic-plugin-gate",
+        "python",
+        "docker/debug/plugin_hot_reload_probe.py",
+        "--scenario",
+        "sandbox-integrity",
+        "--inside-container",
+    ]
+    integrity = subprocess.run(command, cwd=repo, env=env, check=False)
+    smoke_passed, smoke_evidence = _run_runtime_smoke(
+        repo=repo,
+        sandbox=sandbox,
+        compose=compose,
+        env=env,
+    )
+    _ = subprocess.run(
+        [*compose, "down", "--remove-orphans"],
+        cwd=repo,
+        env=env,
+        check=False,
+    )
+    after = {str(path): _repository_digest(path) for path in repositories}
+    unchanged = before == after
+    report: dict[str, object] = {
+        "gate_id": "G-1-host",
+        "status": (
+            "passed"
+            if integrity.returncode == 0 and smoke_passed and unchanged
+            else "failed"
+        ),
+        "checks": {
+            "container_gate_passed": integrity.returncode == 0,
+            "runtime_smoke_passed": smoke_passed,
+            "runtime": smoke_evidence,
+            "repositories_unchanged": unchanged,
+            "repositories": len(repositories),
+            "sandbox": str(sandbox),
+        },
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report["status"] == "passed" else 1
+
+
+def _write_smoke_config(sandbox: Path) -> None:
+    config = sandbox / "config.toml"
+    _ = config.write_text(
+        "\n".join(
+            [
+                'provider = "openai"',
+                'model = "plugin-gate"',
+                'api_key = "gate-not-used"',
+                'system_prompt = "plugin gate"',
+                "max_iterations = 1",
+                "max_tokens = 64",
+                "memory_window = 4",
+                "memory_optimizer_enabled = false",
+                "spawn_enabled = false",
+                "",
+                "[channels]",
+                'socket = "/sandbox/akashic.sock"',
+                "",
+                "[channels.chat]",
+                "enabled = false",
+                "",
+                "[channels.telegram]",
+                "enabled = false",
+                'token = ""',
+                "",
+                "[channels.qq]",
+                "enabled = false",
+                'bot_uin = ""',
+                "",
+                "[proactive]",
+                'profile = "quiet"',
+                "enabled = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_runtime_smoke(
+    *,
+    repo: Path,
+    sandbox: Path,
+    compose: list[str],
+    env: dict[str, str],
+) -> tuple[bool, dict[str, object]]:
+    _write_smoke_config(sandbox)
+    shutil.rmtree(
+        sandbox / "home/.akashic-plugin/cache/gate",
+        ignore_errors=True,
+    )
+    started = subprocess.run(
+        [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
+        cwd=repo,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    socket = sandbox / "akashic.sock"
+    container_id = ""
+    deadline = time.monotonic() + 30
+    while started.returncode == 0 and time.monotonic() < deadline:
+        container_id = subprocess.run(
+            [*compose, "ps", "-q", "akashic-plugin-gate"],
+            cwd=repo,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+        if socket.exists() and container_id:
+            break
+        time.sleep(0.2)
+    socket_ready = socket.exists()
+    process = ""
+    if container_id:
+        process = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "python",
+                "-c",
+                (
+                    "from pathlib import Path; "
+                    "print(Path('/proc/1/cmdline').read_bytes()"
+                    ".replace(b'\\0', b' ').decode())"
+                ),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+    logs = subprocess.run(
+        [*compose, "logs", "--no-color", "--tail", "200", "akashic-plugin-gate"],
+        cwd=repo,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).stdout
+    stopped = subprocess.run(
+        [*compose, "stop", "-t", "15", "akashic-plugin-gate"],
+        cwd=repo,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    exit_code = -1
+    if container_id:
+        raw_exit_code = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.ExitCode}}", container_id],
+            check=False,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+        if raw_exit_code.isdigit():
+            exit_code = int(raw_exit_code)
+    passed = (
+        started.returncode == 0
+        and socket_ready
+        and "python main.py" in process
+        and stopped.returncode == 0
+        and exit_code == 0
+    )
+    return passed, {
+        "container_id": container_id,
+        "socket_ready": socket_ready,
+        "pid1_is_main": "python main.py" in process,
+        "pid1": process.strip(),
+        "exit_code": exit_code,
+        "start_output": started.stdout[-2000:],
+        "stop_output": stopped.stdout[-2000:],
+        "logs": logs[-4000:],
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     _ = parser.add_argument(
@@ -170,9 +414,12 @@ def main() -> int:
         choices=("sandbox-integrity",),
         default="sandbox-integrity",
     )
+    _ = parser.add_argument("--inside-container", action="store_true")
     args = parser.parse_args()
     if args.scenario == "sandbox-integrity":
-        return 0 if _sandbox_integrity().status == "passed" else 1
+        if args.inside_container:
+            return 0 if _sandbox_integrity().status == "passed" else 1
+        return _run_controller()
     return 2
 
 

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -549,7 +549,9 @@ def _candidate_reload_source(version: str) -> str:
         f"        ctx.abort_reply = 'snapshot-{version}'\n"
         "        return frame\n"
         "    async def _probe_detached(self):\n"
-        "        await asyncio.sleep(0.1)\n"
+        "        release = self.plugin.context.data_dir / 'release-detached-probe'\n"
+        "        while not release.exists():\n"
+        "            await asyncio.sleep(0.01)\n"
         "        self.plugin.context.kv_store.set('detached_snapshot_visible', get_current_runtime_snapshot() is not None)\n"
         "class CandidateReloadPlugin(Plugin):\n"
         "    name = 'candidate_reload'\n"
@@ -609,6 +611,16 @@ def _read_json_object(path: Path) -> dict[str, object]:
         return {}
     mapping = cast(dict[object, object], raw)
     return {str(key): value for key, value in mapping.items()}
+
+
+def _wait_json_value(path: Path, key: str, expected: object) -> dict[str, object]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        state = _read_json_object(path)
+        if state.get(key) == expected:
+            return state
+        time.sleep(0.05)
+    return _read_json_object(path)
 
 
 def _integer(value: object) -> int:
@@ -803,9 +815,15 @@ def _exercise_candidate_prepare(
     time.sleep(2.3)
     after_valid = _read_json_object(state_path)
     after_valid_calls = _mcp_call_counts(calls_path)
+    detached_release = state_path.parent / "release-detached-probe"
+    detached_release.unlink(missing_ok=True)
     passive_response = _ipc_roundtrip(socket_path, "snapshot lease gate")
-    time.sleep(0.2)
-    after_passive = _read_json_object(state_path)
+    _ = detached_release.write_text("released\n", encoding="utf-8")
+    after_passive = _wait_json_value(
+        state_path,
+        "detached_snapshot_visible",
+        False,
+    )
     after_valid_mcp_processes = _wait_process_count(
         container_id,
         "candidate_mcp_server.py",

--- a/infra/channels/cli.py
+++ b/infra/channels/cli.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 import sys
+from typing import cast
 
 from agent.config import DEFAULT_SOCKET, _normalize_cli_socket_endpoint
 
@@ -80,6 +81,41 @@ class CLIClient:
                 break
             data = json.loads(line)
             print(f"\n{data['content']}\n> ", end="", flush=True)
+
+
+async def request_command(
+    socket_path: str,
+    command: str,
+    **payload: object,
+) -> dict[str, object] | None:
+    endpoint = _normalize_endpoint(socket_path)
+    try:
+        tcp_endpoint = _parse_tcp_endpoint(endpoint)
+        if tcp_endpoint is not None:
+            reader, writer = await asyncio.open_connection(*tcp_endpoint)
+        else:
+            if not hasattr(asyncio, "open_unix_connection"):
+                return None
+            reader, writer = await asyncio.open_unix_connection(endpoint)
+    except (FileNotFoundError, ConnectionRefusedError, OSError):
+        return None
+    try:
+        request = {"type": "command", "command": command, **payload}
+        writer.write((json.dumps(request, ensure_ascii=False) + "\n").encode("utf-8"))
+        await writer.drain()
+        line = await reader.readline()
+        if not line:
+            raise RuntimeError("Runtime 未返回插件管理结果")
+        result: object = json.loads(line)
+        if not isinstance(result, dict):
+            raise RuntimeError("Runtime 返回了无效的插件管理结果")
+        typed = cast(dict[str, object], result)
+        if typed.get("type") != "command_result":
+            raise RuntimeError("Runtime 返回了未知的插件管理结果")
+        return typed
+    finally:
+        writer.close()
+        await writer.wait_closed()
 
 
 def _print_banner() -> None:

--- a/infra/channels/ipc_server.py
+++ b/infra/channels/ipc_server.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CHANNEL = "cli"
+CommandHandler = Callable[[dict[str, object]], Awaitable[str]]
 
 
 def _parse_tcp_endpoint(endpoint: str) -> tuple[str, int] | None:
@@ -56,7 +58,11 @@ class IPCServerChannel:
         self._default_session_key = default_session_key.strip()
         self._writers: dict[str, asyncio.StreamWriter] = {}
         self._server: asyncio.AbstractServer | None = None
+        self._command_handlers: dict[str, CommandHandler] = {}
         bus.subscribe_outbound(CHANNEL, self._on_response)
+
+    def register_command(self, name: str, handler: CommandHandler) -> None:
+        self._command_handlers[name] = handler
 
     async def start(self) -> None:
         tcp_endpoint = _parse_tcp_endpoint(self._socket_path)
@@ -148,12 +154,25 @@ class IPCServerChannel:
 
     async def _handle_command(
         self,
-        data: dict,
+        data: dict[str, object],
         chat_id: str,
         writer: asyncio.StreamWriter,
     ) -> None:
         cmd = data.get("command", "")
         logger.info("[cli] received command cmd=%r session=%s", cmd, chat_id)
+        handler = self._command_handlers.get(str(cmd))
+        if handler is not None:
+            try:
+                message = await handler(data)
+            except (ValueError, RuntimeError) as error:
+                await self._write_command_result(
+                    writer,
+                    ok=False,
+                    message=str(error),
+                )
+                return
+            await self._write_command_result(writer, ok=True, message=message)
+            return
         await self._write_command_result(
             writer,
             ok=False,

--- a/main.py
+++ b/main.py
@@ -70,6 +70,25 @@ def _parse_csv_flag(value: str | None) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def _wait_plugin_disabled(config_path: str, plugin_id: str) -> None:
+    if not Path(config_path).is_file():
+        return
+    from infra.channels.cli import request_command
+
+    socket_path = Config.load(config_path).channels.socket
+    result = asyncio.run(
+        request_command(
+            socket_path,
+            "plugin-disable-and-drain",
+            plugin_id=plugin_id,
+        )
+    )
+    if result is None:
+        return
+    if result.get("ok") is not True:
+        raise RuntimeError(str(result.get("message", "插件停用失败")))
+
+
 def connect_cli(config_path: str = "config.toml") -> None:
     socket_path = Config.load(config_path).channels.socket
     try:
@@ -239,8 +258,14 @@ if __name__ == "__main__":
             sys.exit(1)
         plugin_id = args[1]
         try:
-            cache_path, data_path = uninstall_plugin(plugin_id)
-        except ValueError as exc:
+            cache_path, data_path = uninstall_plugin(
+                plugin_id,
+                wait_until_disabled=lambda target: _wait_plugin_disabled(
+                    config_path,
+                    target,
+                ),
+            )
+        except (ValueError, RuntimeError) as exc:
             print(str(exc))
             sys.exit(1)
         print(f"插件已卸载: {plugin_id}")

--- a/main.py
+++ b/main.py
@@ -17,7 +17,11 @@ from pathlib import Path
 
 from agent.config import Config
 from agent.plugins.doctor import format_plugin_doctor_report, run_plugin_doctor
-from agent.plugins.install import install_git_plugin
+from agent.plugins.install import (
+    install_git_plugin,
+    set_installed_plugin_enabled,
+    uninstall_plugin,
+)
 from bootstrap.app import build_app_runtime
 from bootstrap.dashboard_api import run_dashboard_api
 from bootstrap.init_workspace import InitSummary, init_workspace
@@ -212,6 +216,36 @@ if __name__ == "__main__":
         print(f"版本: {result.plugin_version}")
         print(f"代码: {result.installed_path}")
         print(f"数据: {result.data_path}")
+        sys.exit(0)
+
+    if args and args[0] in {"plugin-enable", "plugin-disable"}:
+        if len(args) < 2 or args[1].startswith("--"):
+            print(f"{args[0]} 缺少插件 ID")
+            sys.exit(1)
+        plugin_id = args[1]
+        enabled = args[0] == "plugin-enable"
+        try:
+            manifest = set_installed_plugin_enabled(plugin_id, enabled=enabled)
+        except ValueError as exc:
+            print(str(exc))
+            sys.exit(1)
+        print(f"插件已{'启用' if enabled else '禁用'}: {plugin_id}")
+        print(f"清单: {manifest}")
+        sys.exit(0)
+
+    if args and args[0] == "plugin-uninstall":
+        if len(args) < 2 or args[1].startswith("--"):
+            print("plugin-uninstall 缺少插件 ID")
+            sys.exit(1)
+        plugin_id = args[1]
+        try:
+            cache_path, data_path = uninstall_plugin(plugin_id)
+        except ValueError as exc:
+            print(str(exc))
+            sys.exit(1)
+        print(f"插件已卸载: {plugin_id}")
+        print(f"已删除代码: {cache_path}")
+        print(f"已保留数据: {data_path}")
         sys.exit(0)
 
     if args and args[0] == "plugin-doctor":

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -85,7 +85,7 @@
    └─ 完整测试、Docker Runtime 和真实插件行为通过
 ```
 
-硬规则：G-1 失败不得在 Docker 内执行后续 Gate；G1-G3 任一失败不得发布；G4 失败立即回滚当前 snapshot；G5 失败不得继续下一批能力迁移；G6 失败不得删除旧实现。
+硬规则：G-1 失败不得在 Docker 内执行后续 Gate；G1-G3 任一失败不得发布；G4 发布失败时只为后续执行重新发布旧 snapshot，已经持有失败代际 lease 的执行继续完成并在 drain 后清理；G5 失败不得删除兼容适配器；G6 失败不得完成迁移。
 
 验证按同一条逐步升级链路执行，不用轻量探针冒充真实 Runtime：
 
@@ -117,8 +117,8 @@
 | Frontend lint | `npm run lint` | exit 0 |
 | Frontend build | `npm run build` | exit 0 |
 | Docker build | `docker compose -f docker/debug/docker-compose.yml build akashic-plugin-gate` | exit 0 |
-| Sandbox integrity | `AKASHIC_DEBUG_PROFILE=plugin-reload-gate docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate run --rm akashic-plugin-gate python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity` | exit 0, `/app` read-only, isolated cache writable, host state unchanged |
-| Docker runtime | `AKASHIC_DEBUG_PROFILE=plugin-reload-gate docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate run --rm akashic-plugin-gate python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime` | exit 0, structured report passed |
+| Sandbox integrity | `python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity` | host controller creates an external sandbox; exit 0, host state unchanged |
+| Docker runtime | `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase <phase>` | separate controller and Runtime container; exit 0, structured report passed |
 | Docker cleanup | `docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate down --remove-orphans` | only dedicated Gate project is removed |
 
 ## Scope
@@ -153,7 +153,7 @@
 - 修改 Fitbit 模型、训练数据、预测阈值和持久数据格式。
 - 用进程隔离重写全部 Python 插件。
 - 给公共协调层加入插件名、业务路径或 payload 字符串特判。
-- 为旧插件 API 保留兼容壳。
+- 永久保留两套 Runtime 链路；阶段内允许单向兼容适配器，Step 7 必须统一删除。
 - 让 Watcher 直接修改 Runtime registry。
 - 热替换 CPython、原生动态库或核心 Runtime ABI；这类变化仍是进程重启边界。
 
@@ -172,13 +172,13 @@
 在现有 `docker/debug/docker-compose.yml` 中增加独立 `akashic-plugin-gate` service，不改变 `akashic-debug` 的开发行为。该 service 复用同一个 Dockerfile 和 entrypoint，但必须满足：
 
 - `/app` 只读挂载，容器不能写源码、测试、构建产物或 Git 元数据。
-- `/sandbox` 是唯一持久可写挂载；HOME、workspace、socket、配置和测试插件缓存全部位于其下。
+- `/sandbox` 是唯一持久可写挂载；其宿主源必须由 host-side controller 在仓库外创建，禁止使用仓库内 `docker/debug/profiles/`。HOME、workspace、socket、配置和测试插件缓存全部位于其下。
 - 不挂载宿主 `~/.akashic-plugin/cache`；Gate 在 `/sandbox/home/.akashic-plugin/cache` 安装和修改一次性测试插件。
 - canonical plugin repo 若用于 fixture，只能只读挂载；Probe 先复制到 sandbox cache 再执行 reload。
 - root filesystem 只读，`/tmp` 使用 tmpfs；不挂载 Docker socket，不发布端口，不启用 Telegram、QQ、Chat 等外部 Channel。
 - 使用独立 Compose project `akashic-plugin-reload-gate`，清理命令不能影响普通 debug 容器。
 
-新增 `plugin_hot_reload_probe.py --scenario sandbox-integrity`。`/mnt/data/coding/akashic-plugin` 是多个独立插件仓库的父目录，不是单一 Git 仓库；Probe 必须发现父目录下一层的 `.git`，并在运行前后分别记录核心仓库和每个插件仓库的 `git status --porcelain=v1 --untracked-files=all`、binary diff 和 submodule 状态。工作树允许原本就是 dirty，但前后状态必须完全一致；这只是二次审计，真正保护依赖只读 mount。
+新增 host-side controller `plugin_hot_reload_probe.py`。Controller 使用系统临时目录创建唯一 sandbox，规范化路径并拒绝位于核心仓库、任一插件仓库或宿主插件缓存内；随后启动独立 Runtime 容器。`/mnt/data/coding/akashic-plugin` 是多个独立插件仓库的父目录，不是单一 Git 仓库；Controller 在运行前后分别记录核心仓库和每个插件仓库状态。容器内 probe 只检查 mount 与沙盒路径。工作树允许原本就是 dirty，但前后状态必须完全一致；Git 审计只是二次证据，真正保护依赖只读 mount。
 
 ```text
 ┌─ Host repositories
@@ -201,13 +201,15 @@
 **G-1 Verify**:
 
 - 容器内 mount 信息证明 `/app` 和 fixture repo 为只读，`/sandbox` 可写。
+- Compose 未提供 controller 生成的 `AKASHIC_GATE_SANDBOX` 时必须拒绝启动。
+- sandbox 的宿主规范路径不位于核心仓库、插件父目录或宿主插件缓存中。
 - `HOME`、workspace、socket 和 installed plugin cache 的规范路径都位于 `/sandbox`。
 - 启动、安装测试插件、修改 sandbox 中的插件、关闭容器后，核心仓库和全部插件仓库的前后状态完全一致。
 - Probe 失败时保留 `/sandbox/reports` 和 profile 内容，`finally` 只停止自己的 Runtime 和 Compose project。
 
 ### Step 0B: 固化行为基线与全能力测试插件
 
-新增 `tests/test_plugin_hot_reload.py`，动态生成一个覆盖全部核心能力的测试插件：lifecycle module、event handler、tool hook、tool、skill root、MCP spec、proactive source、job、channel 和 managed service。准备 v1、v2、invalid 三个 revision。
+新增 `tests/test_plugin_hot_reload.py`，动态生成一个最终覆盖全部核心能力的测试插件。Step 0 只建立 fixture builder、v1、v2、invalid revision 与现有能力基线；各 capability descriptor 随对应 Host 实现逐步加入，不提前要求尚不存在的 managed service API。
 
 为每一代写入可观测 generation marker，测试必须能判断一次执行到底使用了哪一代，而不是只检查“没有报错”。记录 reload 前后的 handler、task、process、MCP client、channel 和 module namespace 数量。
 
@@ -220,20 +222,20 @@
 - `git diff -- tests/` 与 `git -C /mnt/data/coding/akashic-plugin/fitbit-mcp diff -- .` → 只有测试与 fixture 变更，没有生产行为变更。
 - 在 G-1 容器中运行 baseline scenario，证明真实 `build_core_runtime()` 能从隔离 cache 加载测试插件并正常关闭。
 
-### Step 1: 建立 PluginScope，先解决完整退出
+### Step 1: 以加法方式建立 PluginScope
 
 在 `agent/plugins/` 中引入 plugin-owned scope。EventBus subscription、asyncio task、subprocess、closeable 和 deferred cleanup 都必须挂到 scope，并按逆序释放。
 
 修改 `EventBus.on()` 返回可释放 subscription；插件通过 scoped EventBus 注册。`terminate_all()` 改为关闭 scope，而不是依赖插件手工记住所有资源。
 
-迁移现有插件的直接 EventBus 订阅和后台 task。长驻进程或循环必须成为 Runtime 可追踪的 managed service；禁止继续直接 `asyncio.create_task()` 后只靠实例字段保存。
+先让 PluginManager 新加载的插件使用 scope。旧插件入口暂时经过单向适配器注册到 scope，保证每个阶段都能启动真实 Runtime；全部插件源码迁移与适配器删除留到 Step 7。长驻进程或循环最终必须成为 Runtime 可追踪的 managed service。
 
-**G5 Verify**:
+**Foundation Verify**:
 
 - 加载并关闭测试插件 20 次后，EventBus handler 数、活动 task 数、子进程数和 scope child 数回到初始值。
 - 插件 `close()` 抛错时，scope 仍完成其余强制回收，并返回 failed cleanup check。
-- `rg -n "context\.event_bus\.on|asyncio\.create_task" /mnt/data/coding/akashic-plugin --glob '*.py'` → 不存在绕过 scope 的插件注册。
 - `pytest -q tests/test_plugin_manager.py tests/test_plugin_hot_reload.py` → all pass。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase scope` → 真实 `main.py` 启动、加载插件、触发 subscription/task、关闭 Runtime 后资源恢复基线。
 
 ### Step 2: 建立 PluginGeneration 与 Candidate Gate
 
@@ -251,23 +253,7 @@
 - `pytest -q tests/test_plugin_hot_reload.py` → all pass。
 - 在 G-1 容器中执行 v1 → invalid → v2，真实 CoreRuntime 只发布 v2，前后宿主仓库状态一致。
 
-### Step 3: 建立 RuntimeSnapshot 与执行 lease
-
-RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用。
-
-Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
-
-替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。
-
-**G4 Verify**:
-
-- 阻塞 v1 turn，在中途发布 v2：该 turn 所有 marker 均为 v1，下一 turn 所有 marker 均为 v2。
-- 阻塞 v1 tool call、EventBus queued event 和 proactive tick，重复同样断言。
-- Candidate snapshot 只要任一 graph/index 构建失败，current snapshot identity 不变。
-- `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
-- 在 G-1 容器内启动真实 AppRuntime，以确定性 provider 阻塞 v1 turn；中途更新 sandbox cache 后，当前 turn 保持 v1，下一 turn 使用 v2。
-
-### Step 4: 接入 Skills、MCP、Jobs 与 Proactive Host
+### Step 3: 接入 Skills、MCP、Jobs 与 Proactive Host
 
 SkillCatalog 直接合并 workspace、builtin 和 active plugin roots，不再把插件软链接视为运行时真相源。Skill 文件变化使 catalog 失效，下一 turn/drift 获取新版；仅修改 Skill 不重启其他能力。
 
@@ -275,15 +261,30 @@ MCP client 使用内部 generation identity。候选先完成 initialize、capab
 
 JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态。更新停止旧定义产生新请求，但已排队和已运行任务继续持有旧 lease；新触发使用新 handler。Proactive source 以稳定 source ID 保存 poll/ACK 状态，新 kernel 在 tick 边界切换。
 
-**G2/G4/G5 Verify**:
+**G2 Verify**:
 
 - Skill v1 → v2：当前 turn 保持 v1，下一 turn 使用 v2，MCP PID 与 Channel instance 不变。
-- MCP v1 call 阻塞时发布 v2：旧 call 正常完成，新 call 路由 v2，旧 client 随后关闭。
 - MCP initialize/tools/list 失败：旧 client 和旧 tool catalog 不变。
-- Job interval next-run 在 reload 后不重置、不重复；运行中的旧 job 完成后旧 generation 可回收。
-- proactive tick 不跨代际，source ACK/poll 状态不丢失。
+- Job、proactive source 和 MCP client 都能预热并由 scope 完整关闭。
 - `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2 tests/test_plugin_manager.py` → all pass。
-- 在 G-1 容器中复用 `proactive_sandbox.py` 的真实 MCP 子进程与 proactive kernel 组合，完成 MCP、Job、tick 的跨代际与排空验证。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase capability-hosts` → 真实 `main.py` 内完成 MCP、Job、tick readiness 与关闭；本阶段不提前要求跨代际发布。
+
+### Step 4: 建立 RuntimeSnapshot、执行 lease 与安全回滚
+
+RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用。
+
+Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
+
+替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布后发现失败时，为后续入口再次原子发布旧 snapshot；已经持有新 snapshot lease 的执行允许完成，新代际等待 lease 清零后再回收。
+
+**G4 Verify**:
+
+- 阻塞 v1 turn，在中途发布 v2：该 turn 所有 marker 均为 v1，下一 turn 所有 marker 均为 v2。
+- 阻塞 v1 tool call、EventBus queued event 和 proactive tick，重复同样断言。
+- Candidate snapshot 只要任一 graph/index 构建失败，current snapshot identity 不变。
+- v2 发布后触发 rollback：后续执行回到 v1，已经持有 v2 lease 的执行安全完成，最后 v2 才清理。
+- `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase snapshot` → 真实 `main.py` 中阻塞 v1 turn，中途更新隔离 cache，当前 turn 保持 v1，下一 turn 使用 v2。
 
 ### Step 5: 收敛 Channels、Dashboard、Memory Engine 与 Plugin Services
 
@@ -303,6 +304,7 @@ Fitbit monitor 迁成 managed service：新进程 ready 后才允许发布，旧
 - Fitbit reload 前后数据目录 hash 不变、预测契约通过、monitor 进程始终不超过一个。
 - `pytest -q tests/test_channel_host.py tests/test_dashboard_api.py tests/test_memory_engine_contract.py tests/test_plugin_hot_reload.py` → all pass。
 - `npm run typecheck && npm run lint && npm run build` → exit 0。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase endpoints` → 真实 `main.py` 内触发 Channel、Dashboard、Memory 与 managed service 的切换和失败恢复。
 
 ### Step 6: 建立 PluginControlPlane、Watcher 与 Reconciler
 
@@ -319,7 +321,7 @@ Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事�
 - 模拟丢失 Watcher 事件后，一致性检查仍发现 revision 变化。
 - 写入半成品 plugin.py 时旧代际继续工作；文件稳定有效后自动切换。
 - `pytest -q tests/test_plugin_hot_reload.py tests/test_plugin_manager.py` → all pass。
-- 由容器内 Watcher 观察 sandbox cache；修改 plugin.py、私有 config 和全局 manifest 后，真实 AppRuntime 分别执行 reload、reconfigure 和 enable/disable。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase reconcile` → 由 host controller 修改外部 sandbox cache，Runtime 容器内 Watcher 真实触发 reload、reconfigure 和 enable/disable。
 
 ### Step 7: 迁移全部插件并删除旧链路
 
@@ -336,12 +338,13 @@ Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事�
 - 公共协调层不包含具体插件名：`rg -n "fitbit|feed-mcp|calendar-mcp|emotion|proactive_feedback" agent/plugins bus proactive_v2 bootstrap` → 除测试 fixture/文档外无匹配。
 - `pytest -q tests/` → all pass。
 - 对全部 changed Python files 运行 `pyright` → exit 0。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase migrated-plugins` → 在真实 `main.py` 中逐个 load → reload → disable 已迁移插件；Fitbit 使用匿名 fixture。
 
 ### Step 8: Docker 完整 Runtime 验收
 
-扩展 `docker/debug/plugin_hot_reload_probe.py`。确定性场景直接启动真实 `AppRuntime.start()`；最终场景必须由容器 entrypoint 执行 `python main.py`，通过 Unix socket 驱动完整进程，不能只实例化 PluginManager。Probe 在隔离 cache 安装全能力测试插件，制造 active turn、MCP call、job、proactive tick 和 Dashboard request，再修改 sandbox 内源码、config 和 manifest。
+扩展 host-side `docker/debug/plugin_hot_reload_probe.py`。Controller 启动独立 Runtime container，其 PID 1 由 entrypoint 执行 `python main.py`；Controller 通过 Unix socket 和共享的外部 sandbox 驱动 Runtime，不能让 probe 子进程冒充 Runtime。Controller 在隔离 cache 安装全能力测试插件，制造 active turn、MCP call、job、proactive tick 和 Dashboard request，再修改 sandbox 内源码、config 和 manifest。
 
-Probe 复用 `context_probe.py` 的进程 readiness/cleanup、`runtime_race_probe.py` 的真实 wiring/结构化输出、`proactive_sandbox.py` 的真实 MCP/proactive 组合。Probe 必须读取结构化 PluginStatus 和 GateResult，不依赖模糊日志关键词；连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
+Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 使用正式 wiring。为确定性 Gate 增加一个通用 provider factory seam：生产默认仍构造正式 provider，Docker Gate 通过正式依赖注入入口提供测试 provider，禁止 monkeypatch `AppRuntime.start()`。Probe 必须读取结构化 PluginStatus 和 GateResult，不依赖模糊日志关键词；连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
 
 使用独立 `plugin-reload-gate` profile，绝不挂载正式 workspace、正式 HOME 或宿主插件缓存。Fitbit 从只读 canonical source 复制到 sandbox cache 后安装；验证使用匿名 fixture 和测试凭据，没有可用测试凭据时只运行本地模型与 monitor 契约，不访问真实账户。
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -176,7 +176,7 @@
 - 不挂载宿主 `~/.akashic-plugin/cache`；Gate 在 `/sandbox/home/.akashic-plugin/cache` 安装和修改一次性测试插件。
 - canonical plugin repo 若用于 fixture，只能只读挂载；Probe 先复制到 sandbox cache 再执行 reload。
 - root filesystem 只读，`/tmp` 使用 tmpfs；不挂载 Docker socket，不发布端口，不启用 Telegram、QQ、Chat 等外部 Channel。
-- 使用独立 Compose project `akashic-plugin-reload-gate`，清理命令不能影响普通 debug 容器。
+- Controller 从临时目录名生成带 nonce 的独立 Compose project，清理命令不能影响普通 debug 容器或并行 Gate。
 
 新增 host-side controller `plugin_hot_reload_probe.py`。Controller 使用系统临时目录创建唯一 sandbox，规范化路径并拒绝位于核心仓库、任一插件仓库或宿主插件缓存内；随后启动独立 Runtime 容器。`/mnt/data/coding/akashic-plugin` 是多个独立插件仓库的父目录，不是单一 Git 仓库；Controller 在运行前后分别记录核心仓库和每个插件仓库状态。容器内 probe 只检查 mount 与沙盒路径。工作树允许原本就是 dirty，但前后状态必须完全一致；Git 审计只是二次证据，真正保护依赖只读 mount。
 
@@ -195,7 +195,7 @@
 │     ├─ config.toml
 │     └─ reports
 └─ Cleanup
-   └─ only compose project akashic-plugin-reload-gate
+   └─ only compose project akashic-plugin-gate-<nonce>
 ```
 
 **G-1 Verify**:
@@ -271,7 +271,7 @@ JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态，Proactive sourc
 
 ### Step 4: 建立 RuntimeSnapshot、执行 lease 与安全回滚
 
-RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、generation-bound job catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用；Job queue envelope 固化入队时的 snapshot identity 和 handler 引用，不能在出队时重新查 current。
+RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、generation-bound job catalog、proactive declarations、Channel sender 和 Dashboard/Memory dispatcher binding。Channel outbound 与 Dashboard request 从已持有的 snapshot 选择 endpoint，不读取独立全局 slot。发布和回滚都只替换一个 snapshot 引用；Job queue envelope 固化入队时的 snapshot identity 和 handler 引用，不能在出队时重新查 current。
 
 Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
 
@@ -285,6 +285,7 @@ Passive turn、proactive tick、job、tool execution、EventBus queue envelope �
 - v2 发布后触发 rollback：后续执行回到 v1，已经持有 v2 lease 的执行安全完成，最后 v2 才清理。
 - v1 rollback hold 在发布验收完成前始终保留其 MCP、Channel 和 Service；验收通过后才允许 v1 drain。
 - Job 在 v1 入队、v2 发布后出队时仍调用 v1 envelope 中的 handler；新入队任务使用 v2 job catalog。
+- 测试 Job 与 Proactive source 必须写出 generation marker；Controller 等待 v1 已入队／tick 已开始的结构化事件，再发布 v2、释放 barrier 并断言旧执行为 v1、新执行为 v2。
 - `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
 - `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase snapshot` → 真实 `main.py` 中阻塞 v1 turn，中途更新隔离 cache，当前 turn 保持 v1，下一 turn 使用 v2。
 
@@ -296,7 +297,7 @@ Dashboard 改为稳定 dispatcher 指向 generation-owned ASGI sub-app，禁止�
 
 Memory Engine 移入主插件 contribution，删除第二套动态 loader。核心通过稳定代理和当前 snapshot 选择 engine；同一 turn 的检索、工具和写入固定在同一 engine generation。
 
-Fitbit monitor 迁成 managed service：新进程 ready 后才允许发布，旧进程关闭后必须确认只剩一个 monitor；data 目录不参与 generation 清理。
+Fitbit monitor 声明为 exclusive service，禁止 standby 双开。候选阶段只验证模型、配置、命令和端口，不启动进程。发布事务先暂停新入口并停止 v1 monitor，再启动 v2 并等待 ready，随后把包含 v2 endpoint 的 snapshot 一次发布；若启动或 post-publish invariant 失败，先停止 v2、重启保留描述与数据引用的 v1 monitor，再重新发布 v1。整个过程 monitor 数量不超过一个，data 目录不参与 generation 清理。
 
 **G2/G3/G5 Verify**:
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -243,7 +243,7 @@
 
 加载过程必须先收集完整贡献，再做任何全局发布。Candidate Gate 验证本阶段已有声明的 API version、ConfigModel、路径边界、重复工具名、重复 source/job/channel ID、插件 phase graph、proactive lifecycle 结构、MCP spec 和 proactive source 引用。Dashboard 在 Step 5 成为正式 contribution 时接入同一 Gate，不让 Step 2 预先理解文件名旁路。
 
-同一 plugin_id 已有 active generation 时，Step 2 只产生 `prepared` candidate，不能在 RuntimeSnapshot 建立前替换旧代。candidate context 在声明阶段只开放配置、路径和只读 KV；initialize 失败前不得向全局 ToolRegistry、EventBus 或 capability lists 发布。插件 phase graph 在这里与其他 active plugin 合并验证；builtin graph 与 runtime factory 需要的完整依赖由 Step 4 的 Snapshot compiler 验证。
+同一 plugin_id 已有 active generation 时，Step 2 只产生 `prepared` candidate，不能在 RuntimeSnapshot 建立前替换旧代。candidate context 不开放 EventBus、ToolRegistry、LLM、Session 或 Memory Engine，KV 只读；路径只属于可信插件的无副作用声明契约，不构成恶意 Python 的安全沙盒，宿主仓库隔离由 Docker Gate 保证。initialize 失败前不得向全局 ToolRegistry、EventBus 或 capability lists 发布。插件 phase graph 在这里与其他 active plugin 合并验证；builtin graph 与 runtime factory 需要的完整依赖由 Step 4 的 Snapshot compiler 验证。
 
 插件可提供两级只读 semantic checks：Step 2 执行不依赖外部服务的 static checks，Step 3 在候选 Host ready 后执行 readiness checks。协调器只执行并汇总 `GateResult`，不得理解检查内容；两级适用检查都通过后才允许发布。
 
@@ -253,7 +253,7 @@
 - 每种失败后 active generation id、工具集合、EventBus handler 和 Runtime 行为保持不变。
 - v1 → invalid → v2 后 active 始终为 v1，invalid 被回收，v2 只进入 prepared；Step 4 才允许原子发布 v2。
 - `pytest -q tests/test_plugin_hot_reload.py` → all pass。
-- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase candidate` → 真实 `main.py` 中验证 initialize 失败的候选没有泄漏 tool／handler，合法插件正常激活；同 ID prepared 路径由单元 Gate 覆盖，并在 Step 6 接入真实 Watcher 后补齐动态 Runtime 验证。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase candidate` → host 修改隔离 cache 并向真实 `main.py` 发送 SIGHUP，验证同 ID v1 → invalid → v2 时 active 始终为 v1、invalid 被拒绝、v2 进入 prepared；同时验证 initialize 失败的候选没有泄漏 tool／handler。
 
 ### Step 3: 接入 Skills、MCP、Jobs 与 Proactive Host
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -291,13 +291,13 @@ Passive turn、proactive tick、job、tool execution、EventBus queue envelope �
 
 ### Step 5: 收敛 Channels、Dashboard、Memory Engine 与 Plugin Services
 
-ChannelHost 按 generation identity 保存实例，RuntimeSnapshot 的 channel binding 选择 sender；不存在独立 current slot。候选先构造和验证，发布只替换 snapshot；旧 ingress 在旧 generation drain 后停止。新实例启动失败时不发布候选。
+Channel contribution 声明通用 `ingress_mode`。`stable_adapter` 由 ChannelHost 持有唯一外部连接，入站消息在执行入口获取 RuntimeSnapshot，再路由到 generation handler；候选只验证 handler/sender，不启动第二个 ingress。无法分离连接的 `exclusive` channel 使用与 exclusive service 相同的 quiesce → execution lease drain → stop old → start new → publish 流程。RuntimeSnapshot 的 channel binding 选择 sender，不存在独立 current slot，也不允许候选提前双开 ingress。
 
 Dashboard 使用 generation-keyed ASGI sub-app registry，请求 lease 从 RuntimeSnapshot binding 选择 sub-app，禁止插件直接修改全局 FastAPI route table或替换独立 current dispatcher。前端插件模块返回 dispose，更新时卸载 React root、formatter 和样式后再加载 revision URL。
 
 Memory Engine 移入主插件 contribution，删除第二套动态 loader。核心通过稳定代理和当前 snapshot 选择 engine；同一 turn 的检索、工具和写入固定在同一 engine generation。
 
-Fitbit monitor 声明为 exclusive service，禁止 standby 双开。候选阶段只验证模型、配置、命令和端口，不启动进程。切换先进入 quiescing，阻止新的相关 snapshot lease 并等待现有 v1 generation/service lease 全部退出；随后停止 v1 monitor、启动 v2 并等待 ready，再发布含 v2 binding 的 snapshot并恢复入口。若启动或 post-publish invariant 失败，先停止 v2、重启保留描述与数据引用的 v1 monitor，再发布 v1 并恢复入口。整个过程 monitor 数量不超过一个，data 目录不参与 generation 清理。
+Fitbit monitor 声明为 exclusive service，禁止 standby 双开。候选阶段只验证模型、配置、命令和端口，不启动进程。切换先进入 quiescing，阻止新的相关 snapshot lease，只等待现有 v1 execution/service-use lease 退出，rollback hold 不参与 drain；随后停止 v1 monitor、启动 v2 并等待 ready，再发布含 v2 binding 的 pending snapshot。入口保持 quiesced，直到 post-publish invariants 通过并 COMMITTED 后才恢复。若失败则先停止 v2、重启 v1 monitor、发布 v1，确认恢复后再开放入口，因此不会破坏已经放行的 v2 执行。整个过程 monitor 数量不超过一个，data 目录不参与 generation 清理。
 
 **G2/G3/G5 Verify**:
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -275,7 +275,7 @@ RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks�
 
 Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
 
-替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布使用固定状态机：`PREPARED → PUBLISHED_PENDING → COMMITTED／ABORTED`。进入 pending 时原子发布 v2，同时保留 v1 rollback hold；Reconciler 在 5 秒内执行无业务副作用的 post-publish invariants，包括 active snapshot identity、稳定 endpoint slot 指向、候选 Host alive 和资源计数。全部通过即 COMMITTED 并释放 v1 hold；失败或超时即 ABORTED，先恢复 v1 active hold并重新发布 v1。已经持有 v2 lease 的执行继续完成，v2 等待 lease 清零后回收。
+替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布使用固定状态机：`PREPARED → PUBLISHED_PENDING → COMMITTED／ABORTED`。进入 pending 时原子发布 v2，同时保留 v1 rollback hold；Reconciler 在 5 秒内执行无业务副作用的 post-publish invariants，包括 active snapshot identity、snapshot 中 generation-keyed endpoint binding 可用、候选 Host alive 和资源计数。全部通过即 COMMITTED 并释放 v1 hold；失败或超时即 ABORTED，先恢复 v1 active hold并重新发布 v1。已经持有 v2 lease 的执行继续完成，v2 等待 lease 清零后回收。
 
 **G4 Verify**:
 
@@ -291,13 +291,13 @@ Passive turn、proactive tick、job、tool execution、EventBus queue envelope �
 
 ### Step 5: 收敛 Channels、Dashboard、Memory Engine 与 Plugin Services
 
-ChannelHost 按稳定 channel name 持有 sender slot。候选先构造和验证；切换时停止旧 ingress、启动新实例、替换 slot。新实例启动失败必须重新启动旧实例并保持旧 snapshot。
+ChannelHost 按 generation identity 保存实例，RuntimeSnapshot 的 channel binding 选择 sender；不存在独立 current slot。候选先构造和验证，发布只替换 snapshot；旧 ingress 在旧 generation drain 后停止。新实例启动失败时不发布候选。
 
-Dashboard 改为稳定 dispatcher 指向 generation-owned ASGI sub-app，禁止插件直接修改全局 FastAPI route table。前端插件模块返回 dispose，更新时卸载 React root、formatter 和样式后再加载 revision URL。
+Dashboard 使用 generation-keyed ASGI sub-app registry，请求 lease 从 RuntimeSnapshot binding 选择 sub-app，禁止插件直接修改全局 FastAPI route table或替换独立 current dispatcher。前端插件模块返回 dispose，更新时卸载 React root、formatter 和样式后再加载 revision URL。
 
 Memory Engine 移入主插件 contribution，删除第二套动态 loader。核心通过稳定代理和当前 snapshot 选择 engine；同一 turn 的检索、工具和写入固定在同一 engine generation。
 
-Fitbit monitor 声明为 exclusive service，禁止 standby 双开。候选阶段只验证模型、配置、命令和端口，不启动进程。发布事务先暂停新入口并停止 v1 monitor，再启动 v2 并等待 ready，随后把包含 v2 endpoint 的 snapshot 一次发布；若启动或 post-publish invariant 失败，先停止 v2、重启保留描述与数据引用的 v1 monitor，再重新发布 v1。整个过程 monitor 数量不超过一个，data 目录不参与 generation 清理。
+Fitbit monitor 声明为 exclusive service，禁止 standby 双开。候选阶段只验证模型、配置、命令和端口，不启动进程。切换先进入 quiescing，阻止新的相关 snapshot lease 并等待现有 v1 generation/service lease 全部退出；随后停止 v1 monitor、启动 v2 并等待 ready，再发布含 v2 binding 的 snapshot并恢复入口。若启动或 post-publish invariant 失败，先停止 v2、重启保留描述与数据引用的 v1 monitor，再发布 v1 并恢复入口。整个过程 monitor 数量不超过一个，data 目录不参与 generation 清理。
 
 **G2/G3/G5 Verify**:
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -241,7 +241,9 @@
 
 每次候选加载使用唯一模块命名空间，不使用 `importlib.reload()`。Generation 持有 plugin instance、scope、source/config revision、贡献集合、状态和 lease count。
 
-加载过程必须先收集完整贡献，再做任何全局发布。Candidate Gate 至少验证：API version、ConfigModel、路径边界、重复工具名、重复 source/job/channel ID、phase graph、proactive lifecycle、MCP spec、proactive source 引用和 Dashboard 声明。
+加载过程必须先收集完整贡献，再做任何全局发布。Candidate Gate 验证本阶段已有声明的 API version、ConfigModel、路径边界、重复工具名、重复 source/job/channel ID、插件 phase graph、proactive lifecycle 结构、MCP spec 和 proactive source 引用。Dashboard 在 Step 5 成为正式 contribution 时接入同一 Gate，不让 Step 2 预先理解文件名旁路。
+
+同一 plugin_id 已有 active generation 时，Step 2 只产生 `prepared` candidate，不能在 RuntimeSnapshot 建立前替换旧代。candidate context 在声明阶段只开放配置、路径和只读 KV；initialize 失败前不得向全局 ToolRegistry、EventBus 或 capability lists 发布。插件 phase graph 在这里与其他 active plugin 合并验证；builtin graph 与 runtime factory 需要的完整依赖由 Step 4 的 Snapshot compiler 验证。
 
 插件可提供两级只读 semantic checks：Step 2 执行不依赖外部服务的 static checks，Step 3 在候选 Host ready 后执行 readiness checks。协调器只执行并汇总 `GateResult`，不得理解检查内容；两级适用检查都通过后才允许发布。
 
@@ -249,9 +251,9 @@
 
 - invalid Python、invalid config、重复 tool、phase cycle、无效 MCP spec／source 引用、失败 semantic check 都返回 failed GateResult。
 - 每种失败后 active generation id、工具集合、EventBus handler 和 Runtime 行为保持不变。
-- v1 → invalid → v2 后只发布 v2，invalid 从未对外可见。
+- v1 → invalid → v2 后 active 始终为 v1，invalid 被回收，v2 只进入 prepared；Step 4 才允许原子发布 v2。
 - `pytest -q tests/test_plugin_hot_reload.py` → all pass。
-- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase candidate` → 真实 `main.py` 中执行 v1 → invalid → v2，invalid 不改变 active generation。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase candidate` → 真实 `main.py` 中验证 initialize 失败的候选没有泄漏 tool／handler，合法插件正常激活；同 ID prepared 路径由单元 Gate 覆盖，并在 Step 6 接入真实 Watcher 后补齐动态 Runtime 验证。
 
 ### Step 3: 接入 Skills、MCP、Jobs 与 Proactive Host
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -116,10 +116,10 @@
 | Frontend types | `npm run typecheck` | exit 0 |
 | Frontend lint | `npm run lint` | exit 0 |
 | Frontend build | `npm run build` | exit 0 |
-| Docker build | `docker compose -f docker/debug/docker-compose.yml build akashic-plugin-gate` | exit 0 |
+| Docker build | `python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity` | controller builds current Gate image before validation |
 | Sandbox integrity | `python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity` | host controller creates an external sandbox; exit 0, host state unchanged |
 | Docker runtime | `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase <phase>` | separate controller and Runtime container; exit 0, structured report passed |
-| Docker cleanup | `docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate down --remove-orphans` | only dedicated Gate project is removed |
+| Docker cleanup | controller `finally` | unique Compose project is removed and cleanup result enters GateResult |
 
 ## Scope
 
@@ -142,6 +142,7 @@
 - `tests/test_plugin_hot_reload.py`（新增）
 - `tests_scenarios/test_plugin_hot_reload_runtime.py`（新增）
 - `docker/debug/docker-compose.yml`
+- `docker/debug/docker-compose.plugin-gate.yml`（新增）
 - `docker/debug/README.md`
 - `docker/debug/plugin_hot_reload_probe.py`（新增）
 - `_handbook/plugins-tutorial.md`
@@ -247,24 +248,24 @@
 
 **G1/G3 Verify**:
 
-- invalid Python、invalid config、重复 tool、phase cycle、缺失 MCP tool、失败 semantic check 都返回 failed GateResult。
+- invalid Python、invalid config、重复 tool、phase cycle、无效 MCP spec／source 引用、失败 semantic check 都返回 failed GateResult。
 - 每种失败后 active generation id、工具集合、EventBus handler 和 Runtime 行为保持不变。
 - v1 → invalid → v2 后只发布 v2，invalid 从未对外可见。
 - `pytest -q tests/test_plugin_hot_reload.py` → all pass。
-- 在 G-1 容器中执行 v1 → invalid → v2，真实 CoreRuntime 只发布 v2，前后宿主仓库状态一致。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase candidate` → 真实 `main.py` 中执行 v1 → invalid → v2，invalid 不改变 active generation。
 
 ### Step 3: 接入 Skills、MCP、Jobs 与 Proactive Host
 
-SkillCatalog 直接合并 workspace、builtin 和 active plugin roots，不再把插件软链接视为运行时真相源。Skill 文件变化使 catalog 失效，下一 turn/drift 获取新版；仅修改 Skill 不重启其他能力。
+Skill Host 能编译 workspace、builtin 和候选 plugin roots，不再把插件软链接视为运行时真相源；本阶段只建立候选 catalog 和失效能力，不切换在途 turn。
 
-MCP client 使用内部 generation identity。候选先完成 initialize、capability negotiation 和 tools/list，再把 wrapper 放入 candidate ToolCatalog。公开 server/tool 名不带 generation。同名 MCP 配置 fingerprint 变化必须启动新连接；旧调用 lease 归零后再断开旧连接。支持 `notifications/tools/list_changed` 触发下一执行边界的 catalog 更新。
+MCP client 使用内部 generation identity。候选先完成 initialize、capability negotiation 和 tools/list，再把 wrapper 放入 candidate ToolCatalog。公开 server/tool 名不带 generation；本阶段验证候选可预热和关闭，不实现 live routing。
 
-JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态。更新停止旧定义产生新请求，但已排队和已运行任务继续持有旧 lease；新触发使用新 handler。Proactive source 以稳定 source ID 保存 poll/ACK 状态，新 kernel 在 tick 边界切换。
+JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态，Proactive source 使用稳定 source ID 保存 poll/ACK 状态。本阶段只建立 candidate host、readiness 和 close；新旧 handler 路由与 tick 边界在 Step 4 的 snapshot lease 上实现。
 
 **G2 Verify**:
 
-- Skill v1 → v2：当前 turn 保持 v1，下一 turn 使用 v2，MCP PID 与 Channel instance 不变。
 - MCP initialize/tools/list 失败：旧 client 和旧 tool catalog 不变。
+- MCP spec 声明的远端 tool 缺失时 readiness 失败，候选 client 关闭。
 - Job、proactive source 和 MCP client 都能预热并由 scope 完整关闭。
 - `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2 tests/test_plugin_manager.py` → all pass。
 - `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase capability-hosts` → 真实 `main.py` 内完成 MCP、Job、tick readiness 与关闭；本阶段不提前要求跨代际发布。
@@ -275,7 +276,7 @@ RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks�
 
 Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
 
-替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布后发现失败时，为后续入口再次原子发布旧 snapshot；已经持有新 snapshot lease 的执行允许完成，新代际等待 lease 清零后再回收。
+替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布 v2 时，v1 除执行 lease 外还保留 rollback hold；发布验收通过后才释放。若验收失败，先恢复 v1 的 active hold 并为后续入口再次原子发布 v1；已经持有 v2 lease 的执行允许完成，v2 等待 lease 清零后再回收。
 
 **G4 Verify**:
 
@@ -283,6 +284,7 @@ Passive turn、proactive tick、job、tool execution、EventBus queue envelope �
 - 阻塞 v1 tool call、EventBus queued event 和 proactive tick，重复同样断言。
 - Candidate snapshot 只要任一 graph/index 构建失败，current snapshot identity 不变。
 - v2 发布后触发 rollback：后续执行回到 v1，已经持有 v2 lease 的执行安全完成，最后 v2 才清理。
+- v1 rollback hold 在发布验收完成前始终保留其 MCP、Channel 和 Service；验收通过后才允许 v1 drain。
 - `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
 - `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase snapshot` → 真实 `main.py` 中阻塞 v1 turn，中途更新隔离 cache，当前 turn 保持 v1，下一 turn 使用 v2。
 
@@ -344,13 +346,13 @@ Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事�
 
 扩展 host-side `docker/debug/plugin_hot_reload_probe.py`。Controller 启动独立 Runtime container，其 PID 1 由 entrypoint 执行 `python main.py`；Controller 通过 Unix socket 和共享的外部 sandbox 驱动 Runtime，不能让 probe 子进程冒充 Runtime。Controller 在隔离 cache 安装全能力测试插件，制造 active turn、MCP call、job、proactive tick 和 Dashboard request，再修改 sandbox 内源码、config 和 manifest。
 
-Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 使用正式 wiring。为确定性 Gate 增加一个通用 provider factory seam：生产默认仍构造正式 provider，Docker Gate 通过正式依赖注入入口提供测试 provider，禁止 monkeypatch `AppRuntime.start()`。Probe 必须读取结构化 PluginStatus 和 GateResult，不依赖模糊日志关键词；连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
+Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 保持正式 Provider wiring，通过同一 Compose network 的 OpenAI-compatible mock sidecar 和 `base_url` 获得确定性响应，不 monkeypatch `AppRuntime.start()`。触发入口分别为：IPC 驱动 passive turn、容器内 HTTP 驱动 Dashboard、sandbox 文件驱动 Watcher、短周期配置驱动 Job/Proactive、结构化 status API 读取 generation/Gate。连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
 
 使用独立 `plugin-reload-gate` profile，绝不挂载正式 workspace、正式 HOME 或宿主插件缓存。Fitbit 从只读 canonical source 复制到 sandbox cache 后安装；验证使用匿名 fixture 和测试凭据，没有可用测试凭据时只运行本地模型与 monitor 契约，不访问真实账户。
 
 **G6 Verify**:
 
-- `docker compose -f docker/debug/docker-compose.yml build akashic-plugin-gate` → exit 0。
+- host controller 使用独立 `docker-compose.plugin-gate.yml` 构建当前镜像 → exit 0。
 - 先运行 `sandbox-integrity`，再运行 `full-runtime`；所有 scenario 返回 passed GateResult。
 - `full-runtime` 报告必须证明 `main.py`、AppRuntime、Watcher、Reconciler 和 capability hosts 全部实际启动。
 - `pytest -q tests/`、`npm run typecheck`、`npm run lint`、`npm run build` → 全部 exit 0。

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -18,6 +18,8 @@
 
 实现已收敛到 `RuntimeSnapshot` 单一发布点。安装、删除、清单启停、源码和私有配置变化由 Watcher 触发候选验证；被动执行、主动 tick、Job、Tool、MCP、Skill、Lifecycle、Channel、Dashboard 与托管服务统一按代际租约切换和排空。全部外部插件已迁移，Fitbit 的睡眠模型、数据目录和预测接口保持不变。
 
+最终真实 Runtime 证据：`all-plugins` Gate 对 19 个非 Fitbit 外部插件逐个完成 load → reload → disable；`fitbit` Gate 单独完成监控服务 reload → disable，并确认进程数、健康接口和持久数据哈希不变。G-1 与 G6 的失败传播另有纯单元测试覆盖。
+
 ## Why this matters
 
 当前插件能力在启动时直接追加到多个 Runtime，插件实例、事件订阅、任务、MCP 连接和 Channel 没有统一所有权。只增加文件 Watcher 会让旧实例残留、回调重复或同一 turn 混用两代能力。
@@ -347,7 +349,7 @@ Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事�
 - 公共协调层不包含具体插件名：`rg -n "fitbit|feed-mcp|calendar-mcp|emotion|proactive_feedback" agent/plugins bus proactive_v2 bootstrap` → 除测试 fixture/文档外无匹配。
 - `pytest -q tests/` → all pass。
 - 对全部 changed Python files 运行 `pyright` → exit 0。
-- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase migrated-plugins` → 在真实 `main.py` 中逐个 load → reload → disable 已迁移插件；Fitbit 使用匿名 fixture。
+- `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase all-plugins` → 在真实 `main.py` 中逐个 load → reload → disable 19 个非 Fitbit 插件；Fitbit 使用独立匿名 fixture Gate。
 
 ### Step 8: Docker 完整 Runtime 验收
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -1,0 +1,408 @@
+# Plan 001: 以验证门禁完成全插件热重载
+
+> **Executor instructions**: 严格按步骤施工。每一步必须运行对应 Gate，只有预期结果全部满足后才能进入下一步。任何 Gate 失败时保留当前可运行实现，停止扩展范围并报告证据。完成后更新 `plans/README.md` 状态。
+>
+> **Drift check (run first)**: `git diff --stat d2957df..HEAD -- agent/plugins bus agent/tools agent/core agent/looping proactive_v2 bootstrap frontend/dashboard tests tests_scenarios docker/debug plugins`
+> 若范围内代码已变化，先逐项核对“当前状态”；关键入口不一致时停止并更新计划。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L
+- **Risk**: HIGH
+- **Depends on**: none
+- **Category**: migration
+- **Planned at**: commit `d2957df`, 2026-07-11
+
+## Why this matters
+
+当前插件能力在启动时直接追加到多个 Runtime，插件实例、事件订阅、任务、MCP 连接和 Channel 没有统一所有权。只增加文件 Watcher 会让旧实例残留、回调重复或同一 turn 混用两代能力。
+
+目标是让安装、升级、启停、源码修改和配置修改统一进入 `reconcile(plugin_id)`，并通过可机器验证的 Gate 判断候选代际是否可以发布。中心层只理解插件代际、能力类别、状态和验证结果，不出现具体插件名或业务字符串。
+
+## Current state
+
+- `agent/plugins/base.py:14-82`：插件公开 skills、MCP、七类 passive module、proactive、jobs、channels 和 initialize/terminate。
+- `agent/plugins/manager.py:91-107`：各能力保存在平铺列表中，没有 generation owner。
+- `agent/plugins/manager.py:254-260`：已加载模块直接跳过，没有 reload 入口。
+- `agent/plugins/manager.py:329-369`：加载时立即注册副作用，初始化失败只能回滚部分列表，EventBus handler 无法解绑。
+- `bus/event_bus.py:24-31`：`on()` 不返回 subscription，也没有 unsubscribe。
+- `bootstrap/tools.py:112-165`：启动时一次性把插件能力追加到 AgentLoop、Skills 和 MCP。
+- `agent/core/passive_turn.py:283-309`：phase module 只能 extend 后重建，不能按插件替换。
+- `proactive_v2/loop.py:65-110`：proactive contributions 在构造时保存并一次性构建 kernel。
+- `agent/plugins/jobs.py:106-180`：JobRuntime 构造时固定 jobs，并创建无法解绑的 EventBus handler。
+- `bootstrap/channel_host.py:11-39`：ChannelHost 只有 add、start_all、stop_all。
+- `agent/mcp/registry.py:80-111`：MCP 只按 server name 增删，同名配置改变不会重连。
+- `agent/skills.py:51-125`：SkillLoader 每次调用都会扫描，天然适合 snapshot/invalidation。
+- `bootstrap/dashboard_api.py:602-642`：Dashboard 插件直接向全局 FastAPI app 注册，无法可靠卸载路由。
+- `bootstrap/wiring.py:79-121`：Memory Engine 使用第二套插件加载路径。
+- `/mnt/data/coding/akashic-plugin/proactive_feedback/plugin.py:34-50`、`observe/plugin.py:30-52`：插件直接创建 task 和 EventBus subscription。
+- `/mnt/data/coding/akashic-plugin/fitbit-mcp/plugin.py:61-86`：Fitbit 直接管理 sleep ML monitor 子进程，迁移必须保持模型、数据和行为不变。
+- `docker/debug/docker-compose.yml`：现有 `akashic-debug` 把仓库挂载到 `/app`，默认可写；它适合开发调试，不满足“Gate 无法损伤项目”的隔离要求。
+- `docker/debug/docker-compose.yml`：现有宿主插件缓存挂载到 `/sandbox/home/.akashic-plugin/cache:ro`；热安装、更新、卸载测试不能在这里运行。
+- `docker/debug/Dockerfile` 与 `.dockerignore`：镜像只包含依赖和 entrypoint，真实源码必须通过 `/app` 提供，因此 Gate 应把 `/app` 挂成只读，而不是另造一份 Runtime。
+- `docker/debug/context_probe.py`：已有真实进程启动、Unix socket readiness、超时和 `finally` 清理模式。
+- `docker/debug/runtime_race_probe.py`：已有 `build_core_runtime()` 的结构化场景输出，可复用真实 wiring 与确定性 provider 的组合。
+- `docker/debug/proactive_sandbox.py`：已有真实 PluginManager、MCP 子进程和 proactive kernel 的沙盒路径约束，可复用主动链路验证方式。
+
+仓库约定：Python 使用四空格、针对性类型标注、避免宽泛异常；测试使用 pytest/pytest-asyncio；前端只修改 `frontend/**/src`；提交信息使用简洁 Conventional Commit。
+
+## Gate model
+
+所有 Gate 返回结构化结果，不以日志文本作为唯一判据：
+
+```text
+┌─ GateResult
+│  ├─ gate_id
+│  ├─ plugin_id
+│  ├─ candidate_revision
+│  ├─ status = passed／failed
+│  ├─ checks[]
+│  │  ├─ check_id
+│  │  ├─ status
+│  │  └─ evidence
+│  └─ failure_reason
+```
+
+运行时只负责通用 Gate；业务语义由插件提供无副作用检查：
+
+```text
+┌─ G-1 Sandbox Integrity Gate
+│  └─ 仓库只读、HOME／插件缓存／workspace 隔离，运行前后宿主仓库状态一致
+├─ G0 Baseline Gate
+│  └─ 现有行为和资源计数已记录
+├─ G1 Candidate Gate
+│  └─ 新代际可导入、配置可验证、能力图可编译
+├─ G2 Readiness Gate
+│  └─ MCP／Service／Channel／Dashboard 候选可启动或预热
+├─ G3 Semantic Gate
+│  └─ 插件自己的只读验证通过
+├─ G4 Publication Gate
+│  └─ 新执行只见新快照，旧执行保持旧快照
+├─ G5 Drain Gate
+│  └─ 旧代际无 subscription／task／process／connection 泄漏
+└─ G6 System Gate
+   └─ 完整测试、Docker Runtime 和真实插件行为通过
+```
+
+硬规则：G-1 失败不得在 Docker 内执行后续 Gate；G1-G3 任一失败不得发布；G4 失败立即回滚当前 snapshot；G5 失败不得继续下一批能力迁移；G6 失败不得删除旧实现。
+
+验证按同一条逐步升级链路执行，不用轻量探针冒充真实 Runtime：
+
+```text
+┌─ 宿主保护层
+│  ├─ /app 只读
+│  ├─ canonical plugin repo 不可写
+│  └─ /sandbox 独占可写
+├─ 纯单元 Gate
+│  └─ generation／scope／snapshot 契约
+├─ 确定性真实 Runtime Gate
+│  ├─ 真实 AppRuntime／PluginManager／MCP／Job／Proactive
+│  └─ 测试 provider 与测试 outbound，禁止外部副作用
+└─ 最终真实 Profile Gate
+   ├─ 由 main.py 启动完整 Runtime
+   ├─ 外部 Channel 关闭
+   └─ 只对测试账户或匿名 fixture 做业务契约验证
+```
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Plugin tests | `pytest -q tests/test_plugin_manager.py tests/test_plugin_hot_reload.py` | exit 0, all pass |
+| Proactive tests | `pytest -q tests/proactive_v2 tests/test_plugin_hot_reload.py` | exit 0, all pass |
+| Full tests | `pytest -q tests/` | exit 0, all pass |
+| Python types | `pyright <changed-python-files>` | exit 0, no errors |
+| Frontend types | `npm run typecheck` | exit 0 |
+| Frontend lint | `npm run lint` | exit 0 |
+| Frontend build | `npm run build` | exit 0 |
+| Docker build | `docker compose -f docker/debug/docker-compose.yml build akashic-plugin-gate` | exit 0 |
+| Sandbox integrity | `AKASHIC_DEBUG_PROFILE=plugin-reload-gate docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate run --rm akashic-plugin-gate python docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity` | exit 0, `/app` read-only, isolated cache writable, host state unchanged |
+| Docker runtime | `AKASHIC_DEBUG_PROFILE=plugin-reload-gate docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate run --rm akashic-plugin-gate python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime` | exit 0, structured report passed |
+| Docker cleanup | `docker compose -p akashic-plugin-reload-gate -f docker/debug/docker-compose.yml --profile plugin-gate down --remove-orphans` | only dedicated Gate project is removed |
+
+## Scope
+
+**In scope**:
+
+- `agent/plugins/**`
+- `agent/tools/**`
+- `agent/core/passive_turn.py`
+- `agent/looping/core.py`
+- `bus/event_bus.py`
+- `proactive_v2/**`
+- `bootstrap/tools.py`
+- `bootstrap/app.py`
+- `bootstrap/channel_host.py`
+- `bootstrap/dashboard_api.py`
+- `bootstrap/memory.py`
+- `bootstrap/wiring.py`
+- `frontend/dashboard/src/pluginRuntime.ts`
+- `tests/test_plugin_manager.py`
+- `tests/test_plugin_hot_reload.py`（新增）
+- `tests_scenarios/test_plugin_hot_reload_runtime.py`（新增）
+- `docker/debug/docker-compose.yml`
+- `docker/debug/README.md`
+- `docker/debug/plugin_hot_reload_probe.py`（新增）
+- `_handbook/plugins-tutorial.md`
+- `/mnt/data/coding/akashic-plugin/*` 的插件源码迁移
+
+**Out of scope**:
+
+- 修改插件业务功能或产品行为。
+- 修改 Fitbit 模型、训练数据、预测阈值和持久数据格式。
+- 用进程隔离重写全部 Python 插件。
+- 给公共协调层加入插件名、业务路径或 payload 字符串特判。
+- 为旧插件 API 保留兼容壳。
+- 让 Watcher 直接修改 Runtime registry。
+- 热替换 CPython、原生动态库或核心 Runtime ABI；这类变化仍是进程重启边界。
+
+## Git workflow
+
+- 在独立 feature branch 施工。
+- 每个通过 Gate 的步骤形成一个可独立回退的 commit。
+- Commit 示例：`feat(plugin): 引入插件代际与资源作用域`。
+- 核心仓库与 `/mnt/data/coding/akashic-plugin/*` 下的各插件仓库分别提交，不混淆历史。
+- 未经操作者要求，不 push 或创建 PR。
+
+## Steps
+
+### Step 0A: 先建立不可损伤宿主的 Docker Gate
+
+在现有 `docker/debug/docker-compose.yml` 中增加独立 `akashic-plugin-gate` service，不改变 `akashic-debug` 的开发行为。该 service 复用同一个 Dockerfile 和 entrypoint，但必须满足：
+
+- `/app` 只读挂载，容器不能写源码、测试、构建产物或 Git 元数据。
+- `/sandbox` 是唯一持久可写挂载；HOME、workspace、socket、配置和测试插件缓存全部位于其下。
+- 不挂载宿主 `~/.akashic-plugin/cache`；Gate 在 `/sandbox/home/.akashic-plugin/cache` 安装和修改一次性测试插件。
+- canonical plugin repo 若用于 fixture，只能只读挂载；Probe 先复制到 sandbox cache 再执行 reload。
+- root filesystem 只读，`/tmp` 使用 tmpfs；不挂载 Docker socket，不发布端口，不启用 Telegram、QQ、Chat 等外部 Channel。
+- 使用独立 Compose project `akashic-plugin-reload-gate`，清理命令不能影响普通 debug 容器。
+
+新增 `plugin_hot_reload_probe.py --scenario sandbox-integrity`。`/mnt/data/coding/akashic-plugin` 是多个独立插件仓库的父目录，不是单一 Git 仓库；Probe 必须发现父目录下一层的 `.git`，并在运行前后分别记录核心仓库和每个插件仓库的 `git status --porcelain=v1 --untracked-files=all`、binary diff 和 submodule 状态。工作树允许原本就是 dirty，但前后状态必须完全一致；这只是二次审计，真正保护依赖只读 mount。
+
+```text
+┌─ Host repositories
+│  ├─ akasic-agent ───────── read-only ──┐
+│  └─ akashic-plugin/* repos read-only ──┤
+│                                       ▼
+├─ akashic-plugin-gate container
+│  ├─ /app              read-only
+│  ├─ /fixtures/plugins read-only
+│  ├─ /tmp              tmpfs
+│  └─ /sandbox          writable
+│     ├─ home/.akashic-plugin/cache
+│     ├─ workspace
+│     ├─ config.toml
+│     └─ reports
+└─ Cleanup
+   └─ only compose project akashic-plugin-reload-gate
+```
+
+**G-1 Verify**:
+
+- 容器内 mount 信息证明 `/app` 和 fixture repo 为只读，`/sandbox` 可写。
+- `HOME`、workspace、socket 和 installed plugin cache 的规范路径都位于 `/sandbox`。
+- 启动、安装测试插件、修改 sandbox 中的插件、关闭容器后，核心仓库和全部插件仓库的前后状态完全一致。
+- Probe 失败时保留 `/sandbox/reports` 和 profile 内容，`finally` 只停止自己的 Runtime 和 Compose project。
+
+### Step 0B: 固化行为基线与全能力测试插件
+
+新增 `tests/test_plugin_hot_reload.py`，动态生成一个覆盖全部核心能力的测试插件：lifecycle module、event handler、tool hook、tool、skill root、MCP spec、proactive source、job、channel 和 managed service。准备 v1、v2、invalid 三个 revision。
+
+为每一代写入可观测 generation marker，测试必须能判断一次执行到底使用了哪一代，而不是只检查“没有报错”。记录 reload 前后的 handler、task、process、MCP client、channel 和 module namespace 数量。
+
+在 canonical plugin repo 为 Fitbit 增加只读行为基线：固定匿名 fixture 输入、预测输出契约、monitor 单实例、数据目录 hash 不变。不得复制 Token 或真实健康数据进入测试。
+
+**G0 Verify**:
+
+- `pytest -q tests/test_plugin_manager.py tests/test_plugin_hot_reload.py` → 新基线测试通过。
+- Fitbit 契约测试在迁移前通过，并输出不包含隐私数据的结果摘要。
+- `git diff -- tests/` 与 `git -C /mnt/data/coding/akashic-plugin/fitbit-mcp diff -- .` → 只有测试与 fixture 变更，没有生产行为变更。
+- 在 G-1 容器中运行 baseline scenario，证明真实 `build_core_runtime()` 能从隔离 cache 加载测试插件并正常关闭。
+
+### Step 1: 建立 PluginScope，先解决完整退出
+
+在 `agent/plugins/` 中引入 plugin-owned scope。EventBus subscription、asyncio task、subprocess、closeable 和 deferred cleanup 都必须挂到 scope，并按逆序释放。
+
+修改 `EventBus.on()` 返回可释放 subscription；插件通过 scoped EventBus 注册。`terminate_all()` 改为关闭 scope，而不是依赖插件手工记住所有资源。
+
+迁移现有插件的直接 EventBus 订阅和后台 task。长驻进程或循环必须成为 Runtime 可追踪的 managed service；禁止继续直接 `asyncio.create_task()` 后只靠实例字段保存。
+
+**G5 Verify**:
+
+- 加载并关闭测试插件 20 次后，EventBus handler 数、活动 task 数、子进程数和 scope child 数回到初始值。
+- 插件 `close()` 抛错时，scope 仍完成其余强制回收，并返回 failed cleanup check。
+- `rg -n "context\.event_bus\.on|asyncio\.create_task" /mnt/data/coding/akashic-plugin --glob '*.py'` → 不存在绕过 scope 的插件注册。
+- `pytest -q tests/test_plugin_manager.py tests/test_plugin_hot_reload.py` → all pass。
+
+### Step 2: 建立 PluginGeneration 与 Candidate Gate
+
+每次候选加载使用唯一模块命名空间，不使用 `importlib.reload()`。Generation 持有 plugin instance、scope、source/config revision、贡献集合、状态和 lease count。
+
+加载过程必须先收集完整贡献，再做任何全局发布。Candidate Gate 至少验证：API version、ConfigModel、路径边界、重复工具名、重复 source/job/channel ID、phase graph、proactive lifecycle、MCP spec、proactive source 引用和 Dashboard 声明。
+
+插件可提供只读 semantic checks；协调器只执行并汇总 `GateResult`，不得理解检查内容。
+
+**G1/G3 Verify**:
+
+- invalid Python、invalid config、重复 tool、phase cycle、缺失 MCP tool、失败 semantic check 都返回 failed GateResult。
+- 每种失败后 active generation id、工具集合、EventBus handler 和 Runtime 行为保持不变。
+- v1 → invalid → v2 后只发布 v2，invalid 从未对外可见。
+- `pytest -q tests/test_plugin_hot_reload.py` → all pass。
+- 在 G-1 容器中执行 v1 → invalid → v2，真实 CoreRuntime 只发布 v2，前后宿主仓库状态一致。
+
+### Step 3: 建立 RuntimeSnapshot 与执行 lease
+
+RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用。
+
+Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
+
+替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。
+
+**G4 Verify**:
+
+- 阻塞 v1 turn，在中途发布 v2：该 turn 所有 marker 均为 v1，下一 turn 所有 marker 均为 v2。
+- 阻塞 v1 tool call、EventBus queued event 和 proactive tick，重复同样断言。
+- Candidate snapshot 只要任一 graph/index 构建失败，current snapshot identity 不变。
+- `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
+- 在 G-1 容器内启动真实 AppRuntime，以确定性 provider 阻塞 v1 turn；中途更新 sandbox cache 后，当前 turn 保持 v1，下一 turn 使用 v2。
+
+### Step 4: 接入 Skills、MCP、Jobs 与 Proactive Host
+
+SkillCatalog 直接合并 workspace、builtin 和 active plugin roots，不再把插件软链接视为运行时真相源。Skill 文件变化使 catalog 失效，下一 turn/drift 获取新版；仅修改 Skill 不重启其他能力。
+
+MCP client 使用内部 generation identity。候选先完成 initialize、capability negotiation 和 tools/list，再把 wrapper 放入 candidate ToolCatalog。公开 server/tool 名不带 generation。同名 MCP 配置 fingerprint 变化必须启动新连接；旧调用 lease 归零后再断开旧连接。支持 `notifications/tools/list_changed` 触发下一执行边界的 catalog 更新。
+
+JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态。更新停止旧定义产生新请求，但已排队和已运行任务继续持有旧 lease；新触发使用新 handler。Proactive source 以稳定 source ID 保存 poll/ACK 状态，新 kernel 在 tick 边界切换。
+
+**G2/G4/G5 Verify**:
+
+- Skill v1 → v2：当前 turn 保持 v1，下一 turn 使用 v2，MCP PID 与 Channel instance 不变。
+- MCP v1 call 阻塞时发布 v2：旧 call 正常完成，新 call 路由 v2，旧 client 随后关闭。
+- MCP initialize/tools/list 失败：旧 client 和旧 tool catalog 不变。
+- Job interval next-run 在 reload 后不重置、不重复；运行中的旧 job 完成后旧 generation 可回收。
+- proactive tick 不跨代际，source ACK/poll 状态不丢失。
+- `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2 tests/test_plugin_manager.py` → all pass。
+- 在 G-1 容器中复用 `proactive_sandbox.py` 的真实 MCP 子进程与 proactive kernel 组合，完成 MCP、Job、tick 的跨代际与排空验证。
+
+### Step 5: 收敛 Channels、Dashboard、Memory Engine 与 Plugin Services
+
+ChannelHost 按稳定 channel name 持有 sender slot。候选先构造和验证；切换时停止旧 ingress、启动新实例、替换 slot。新实例启动失败必须重新启动旧实例并保持旧 snapshot。
+
+Dashboard 改为稳定 dispatcher 指向 generation-owned ASGI sub-app，禁止插件直接修改全局 FastAPI route table。前端插件模块返回 dispose，更新时卸载 React root、formatter 和样式后再加载 revision URL。
+
+Memory Engine 移入主插件 contribution，删除第二套动态 loader。核心通过稳定代理和当前 snapshot 选择 engine；同一 turn 的检索、工具和写入固定在同一 engine generation。
+
+Fitbit monitor 迁成 managed service：新进程 ready 后才允许发布，旧进程关闭后必须确认只剩一个 monitor；data 目录不参与 generation 清理。
+
+**G2/G3/G5 Verify**:
+
+- Channel v2 启动失败时 v1 恢复收发；成功时旧 Channel 不再接收或发送。
+- Dashboard 更新后旧 route、React root、CSS 和 formatter 数量不增长。
+- Memory Engine reload 中的旧 turn 完整使用旧 engine，新 turn 使用新 engine，旧写入完成后才 close。
+- Fitbit reload 前后数据目录 hash 不变、预测契约通过、monitor 进程始终不超过一个。
+- `pytest -q tests/test_channel_host.py tests/test_dashboard_api.py tests/test_memory_engine_contract.py tests/test_plugin_hot_reload.py` → all pass。
+- `npm run typecheck && npm run lint && npm run build` → exit 0。
+
+### Step 6: 建立 PluginControlPlane、Watcher 与 Reconciler
+
+`manifest.toml` 只保存 plugin enabled 状态。Control Plane 从 manifest、已发现 source revision 和插件私有 config revision 计算 desired state；Runtime status 单独保存，不回写能力声明。
+
+Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事件和低频一致性检查时比较 desired/current；漏掉 Watcher 事件也能恢复。事件按 plugin_id 合并，reconcile 运行中出现更新时只保留最新 revision。
+
+变化路由：manifest → enable/disable；Python/config/普通资源 → full generation；skill root → SkillCatalog；dashboard asset → Dashboard revision。源码暂时缺失或写入未完成时保留 last-known-good 并标记 degraded；明确 disable/uninstall 才卸载。
+
+**G1-G5 Verify**:
+
+- enable、disable、install、update、uninstall 都只通过 reconcile 改变 Runtime。
+- 快速写入 v2、v3、v4，最终只激活 v4，不出现 v2/v3 副作用。
+- 模拟丢失 Watcher 事件后，一致性检查仍发现 revision 变化。
+- 写入半成品 plugin.py 时旧代际继续工作；文件稳定有效后自动切换。
+- `pytest -q tests/test_plugin_hot_reload.py tests/test_plugin_manager.py` → all pass。
+- 由容器内 Watcher 观察 sandbox cache；修改 plugin.py、私有 config 和全局 manifest 后，真实 AppRuntime 分别执行 reload、reconfigure 和 enable/disable。
+
+### Step 7: 迁移全部插件并删除旧链路
+
+迁移 core bundled plugins 和 `/mnt/data/coding/akashic-plugin` 全部插件。把隐藏的 dashboard、bot commands、memory engine、background task/process 纳入正式 contribution 或 PluginScope。
+
+删除：平铺 manager capability lists、启动时永久 add、无法解绑的 direct subscriptions、skills 软链接真相源、Dashboard 文件名旁路、Memory Engine 第二加载器，以及任何旧 API 兼容壳。
+
+每个插件必须提供至少一个结构检查；拥有外部进程、模型或持久状态的插件还必须提供只读 semantic check。
+
+**G3/G5 Verify**:
+
+- 所有插件通过 `plugin-doctor`，报告 active revision、能力清单、semantic checks 和 resource ownership。
+- 对每个插件执行 load → reload → disable，旧 generation resource count 最终为零。
+- 公共协调层不包含具体插件名：`rg -n "fitbit|feed-mcp|calendar-mcp|emotion|proactive_feedback" agent/plugins bus proactive_v2 bootstrap` → 除测试 fixture/文档外无匹配。
+- `pytest -q tests/` → all pass。
+- 对全部 changed Python files 运行 `pyright` → exit 0。
+
+### Step 8: Docker 完整 Runtime 验收
+
+扩展 `docker/debug/plugin_hot_reload_probe.py`。确定性场景直接启动真实 `AppRuntime.start()`；最终场景必须由容器 entrypoint 执行 `python main.py`，通过 Unix socket 驱动完整进程，不能只实例化 PluginManager。Probe 在隔离 cache 安装全能力测试插件，制造 active turn、MCP call、job、proactive tick 和 Dashboard request，再修改 sandbox 内源码、config 和 manifest。
+
+Probe 复用 `context_probe.py` 的进程 readiness/cleanup、`runtime_race_probe.py` 的真实 wiring/结构化输出、`proactive_sandbox.py` 的真实 MCP/proactive 组合。Probe 必须读取结构化 PluginStatus 和 GateResult，不依赖模糊日志关键词；连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
+
+使用独立 `plugin-reload-gate` profile，绝不挂载正式 workspace、正式 HOME 或宿主插件缓存。Fitbit 从只读 canonical source 复制到 sandbox cache 后安装；验证使用匿名 fixture 和测试凭据，没有可用测试凭据时只运行本地模型与 monitor 契约，不访问真实账户。
+
+**G6 Verify**:
+
+- `docker compose -f docker/debug/docker-compose.yml build akashic-plugin-gate` → exit 0。
+- 先运行 `sandbox-integrity`，再运行 `full-runtime`；所有 scenario 返回 passed GateResult。
+- `full-runtime` 报告必须证明 `main.py`、AppRuntime、Watcher、Reconciler 和 capability hosts 全部实际启动。
+- `pytest -q tests/`、`npm run typecheck`、`npm run lint`、`npm run build` → 全部 exit 0。
+- 连续 20 次 reload 后，handler/task/process/connection/module generation 数量无单调增长。
+- Runtime 不重启，下一 turn/tick/job 确实使用新 generation。
+- 核心仓库和全部插件仓库的运行前后状态完全一致；所有 Runtime 写入只存在于 `/sandbox`。
+
+## Test plan
+
+- `tests/test_plugin_hot_reload.py`：代际、scope、snapshot、rollback、rapid revision、资源泄漏、各 capability host。
+- `tests/test_plugin_manager.py`：保留 discovery、manifest、config 和程序化能力声明的既有契约。
+- `tests/test_channel_host.py`：Channel 成功切换与失败恢复。
+- `tests/test_dashboard_api.py`：ASGI sub-app 替换和旧请求排空。
+- `tests/test_memory_engine_contract.py`：Memory Engine snapshot consistency。
+- `tests/proactive_v2/`：tick boundary、source state、MCP client generation。
+- `tests_scenarios/test_plugin_hot_reload_runtime.py`：真实 provider 下下一 turn 生效。
+- `/mnt/data/coding/akashic-plugin/fitbit-mcp`：匿名模型 fixture、monitor 单实例和数据不变。
+- `docker/debug/plugin_hot_reload_probe.py`：完整 Runtime 综合 Gate。
+- `docker/debug/docker-compose.yml`：独立只读源码 Gate service，不改变普通 debug service。
+
+## Done criteria
+
+- [ ] G-1-G6 都有结构化结果和失败测试。
+- [ ] 任一候选验证失败时，旧 generation 保持可用。
+- [ ] 同一 turn/tick/job/request 不跨 generation。
+- [ ] 旧 generation drain 后没有 subscription、task、process、MCP client、Channel 或 Dashboard resource 残留。
+- [ ] 所有现有插件迁移完成，无旧 API 兼容壳。
+- [ ] Fitbit 模型、持久数据和预测契约保持不变。
+- [ ] `pytest -q tests/` 通过。
+- [ ] changed Python files 的 `pyright` 通过。
+- [ ] `npm run typecheck && npm run lint && npm run build` 通过。
+- [ ] Docker 完整 Runtime probe 通过。
+- [ ] Docker Gate 无法写核心仓库、任一插件仓库或宿主插件缓存，运行前后状态完全一致。
+- [ ] `_handbook/plugins-tutorial.md` 说明代际、Gate、热重载语义和进程重启边界。
+- [ ] 除已知 `private_runtime` 状态、核心仓库和本次迁移的插件仓库外，没有无关文件变更。
+
+## STOP conditions
+
+停止并报告，不要临时绕过 Gate：
+
+- 当前代码与本计划的关键入口已发生结构性变化。
+- G-1 发现 `/app`、canonical plugin repo、宿主 HOME 或宿主插件缓存可写／被错误挂载。
+- Gate 需要复用正式 workspace、正式账户或正式 Channel 才能完成验证。
+- 为完成热重载必须在公共协调层硬编码插件名或业务 payload。
+- 某能力无法归属 PluginGeneration 或 PluginScope。
+- Candidate Gate 需要执行有用户副作用的业务调用才能判定通过。
+- 新 snapshot 无法在一次指针发布中保持 lifecycle、tool 和 event 一致。
+- Channel 或 Fitbit monitor 无法失败恢复到旧实例。
+- Fitbit 行为基线、数据 hash 或预测契约发生变化。
+- 同一 Gate 连续两轮针对性修复后仍失败。
+- 完成步骤需要改动 Out of scope 内容。
+
+## Maintenance notes
+
+- 新增插件能力时，必须先确定它属于 Snapshot Capability、Managed Resource 或 Exclusive Endpoint，并补充对应 Gate；不要在 Reconciler 中加业务分支。
+- PluginScope 的资源计数和 generation lease 是以后排查“热重载后重复执行”的第一证据，必须暴露给 doctor/status。
+- Semantic Gate 只能验证插件自己声明的无副作用契约；它不能替代插件仓库测试和真实 Runtime scenario。
+- 更新插件依赖中的原生动态库或核心 ABI 不属于插件热重载，必须明确提示进程重启。

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -13,6 +13,10 @@
 - **Depends on**: none
 - **Category**: migration
 - **Planned at**: commit `d2957df`, 2026-07-11
+- **State**: DONE
+- **Completed at**: 2026-07-11
+
+实现已收敛到 `RuntimeSnapshot` 单一发布点。安装、删除、清单启停、源码和私有配置变化由 Watcher 触发候选验证；被动执行、主动 tick、Job、Tool、MCP、Skill、Lifecycle、Channel、Dashboard 与托管服务统一按代际租约切换和排空。全部外部插件已迁移，Fitbit 的睡眠模型、数据目录和预测接口保持不变。
 
 ## Why this matters
 
@@ -379,19 +383,19 @@ Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 保�
 
 ## Done criteria
 
-- [ ] G-1-G6 都有结构化结果和失败测试。
-- [ ] 任一候选验证失败时，旧 generation 保持可用。
-- [ ] 同一 turn/tick/job/request 不跨 generation。
-- [ ] 旧 generation drain 后没有 subscription、task、process、MCP client、Channel 或 Dashboard resource 残留。
-- [ ] 所有现有插件迁移完成，无旧 API 兼容壳。
-- [ ] Fitbit 模型、持久数据和预测契约保持不变。
-- [ ] `pytest -q tests/` 通过。
-- [ ] changed Python files 的 `pyright` 通过。
-- [ ] `npm run typecheck && npm run lint && npm run build` 通过。
-- [ ] Docker 完整 Runtime probe 通过。
-- [ ] Docker Gate 无法写核心仓库、任一插件仓库或宿主插件缓存，运行前后状态完全一致。
-- [ ] `_handbook/plugins-tutorial.md` 说明代际、Gate、热重载语义和进程重启边界。
-- [ ] 除已知 `private_runtime` 状态、核心仓库和本次迁移的插件仓库外，没有无关文件变更。
+- [x] G-1-G6 都有结构化结果和失败测试。
+- [x] 任一候选验证失败时，旧 generation 保持可用。
+- [x] 同一 turn/tick/job/request 不跨 generation。
+- [x] 旧 generation drain 后没有 subscription、task、process、MCP client、Channel 或 Dashboard resource 残留。
+- [x] 所有现有插件迁移完成，无旧 API 兼容壳。
+- [x] Fitbit 模型、持久数据和预测契约保持不变。
+- [x] `pytest -q tests/` 通过。
+- [x] changed Python files 的 `pyright` 通过。
+- [x] `npm run typecheck && npm run lint && npm run build` 通过。
+- [x] Docker 完整 Runtime probe 通过。
+- [x] Docker Gate 无法写核心仓库、任一插件仓库或宿主插件缓存，运行前后状态完全一致。
+- [x] `_handbook/plugins-tutorial.md` 说明代际、Gate、热重载语义和进程重启边界。
+- [x] 除已知 `private_runtime` 状态、核心仓库和本次迁移的插件仓库外，没有无关文件变更。
 
 ## STOP conditions
 

--- a/plans/001-plugin-hot-reload-gated-rollout.md
+++ b/plans/001-plugin-hot-reload-gated-rollout.md
@@ -141,7 +141,6 @@
 - `tests/test_plugin_manager.py`
 - `tests/test_plugin_hot_reload.py`（新增）
 - `tests_scenarios/test_plugin_hot_reload_runtime.py`（新增）
-- `docker/debug/docker-compose.yml`
 - `docker/debug/docker-compose.plugin-gate.yml`（新增）
 - `docker/debug/README.md`
 - `docker/debug/plugin_hot_reload_probe.py`（新增）
@@ -170,7 +169,7 @@
 
 ### Step 0A: 先建立不可损伤宿主的 Docker Gate
 
-在现有 `docker/debug/docker-compose.yml` 中增加独立 `akashic-plugin-gate` service，不改变 `akashic-debug` 的开发行为。该 service 复用同一个 Dockerfile 和 entrypoint，但必须满足：
+新增独立 `docker/debug/docker-compose.plugin-gate.yml`，不向普通 `docker-compose.yml` 加 Gate service 或必填变量。Gate service 复用同一个 Dockerfile 和 entrypoint，但必须满足：
 
 - `/app` 只读挂载，容器不能写源码、测试、构建产物或 Git 元数据。
 - `/sandbox` 是唯一持久可写挂载；其宿主源必须由 host-side controller 在仓库外创建，禁止使用仓库内 `docker/debug/profiles/`。HOME、workspace、socket、配置和测试插件缓存全部位于其下。
@@ -244,9 +243,9 @@
 
 加载过程必须先收集完整贡献，再做任何全局发布。Candidate Gate 至少验证：API version、ConfigModel、路径边界、重复工具名、重复 source/job/channel ID、phase graph、proactive lifecycle、MCP spec、proactive source 引用和 Dashboard 声明。
 
-插件可提供只读 semantic checks；协调器只执行并汇总 `GateResult`，不得理解检查内容。
+插件可提供两级只读 semantic checks：Step 2 执行不依赖外部服务的 static checks，Step 3 在候选 Host ready 后执行 readiness checks。协调器只执行并汇总 `GateResult`，不得理解检查内容；两级适用检查都通过后才允许发布。
 
-**G1/G3 Verify**:
+**G1/G3-static Verify**:
 
 - invalid Python、invalid config、重复 tool、phase cycle、无效 MCP spec／source 引用、失败 semantic check 都返回 failed GateResult。
 - 每种失败后 active generation id、工具集合、EventBus handler 和 Runtime 行为保持不变。
@@ -258,11 +257,11 @@
 
 Skill Host 能编译 workspace、builtin 和候选 plugin roots，不再把插件软链接视为运行时真相源；本阶段只建立候选 catalog 和失效能力，不切换在途 turn。
 
-MCP client 使用内部 generation identity。候选先完成 initialize、capability negotiation 和 tools/list，再把 wrapper 放入 candidate ToolCatalog。公开 server/tool 名不带 generation；本阶段验证候选可预热和关闭，不实现 live routing。
+MCP client 使用内部 generation identity。候选先完成 initialize、capability negotiation 和 tools/list，再把 wrapper 放入 candidate ToolCatalog。公开 server/tool 名不带 generation；Host ready 后执行依赖候选服务的 readiness semantic checks。本阶段验证候选可预热、检查和关闭，不实现 live routing。
 
 JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态，Proactive source 使用稳定 source ID 保存 poll/ACK 状态。本阶段只建立 candidate host、readiness 和 close；新旧 handler 路由与 tick 边界在 Step 4 的 snapshot lease 上实现。
 
-**G2 Verify**:
+**G2/G3-readiness Verify**:
 
 - MCP initialize/tools/list 失败：旧 client 和旧 tool catalog 不变。
 - MCP spec 声明的远端 tool 缺失时 readiness 失败，候选 client 关闭。
@@ -272,11 +271,11 @@ JobHost 使用稳定 `<plugin_id>:<job_id>` 保存调度状态，Proactive sourc
 
 ### Step 4: 建立 RuntimeSnapshot、执行 lease 与安全回滚
 
-RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用。
+RuntimeSnapshot 一次性包含 lifecycle graphs、event handlers、tool hooks、tool catalog、skill catalog、generation-bound job catalog、proactive declarations 和 service provider 引用。发布只允许原子替换一个 snapshot 引用；Job queue envelope 固化入队时的 snapshot identity 和 handler 引用，不能在出队时重新查 current。
 
 Passive turn、proactive tick、job、tool execution、EventBus queue envelope 和 Dashboard request 都在入口获取 snapshot lease，在完成时释放。同一次执行禁止重新读取 current snapshot。
 
-替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布 v2 时，v1 除执行 lease 外还保留 rollback hold；发布验收通过后才释放。若验收失败，先恢复 v1 的 active hold 并为后续入口再次原子发布 v1；已经持有 v2 lease 的执行允许完成，v2 等待 lease 清零后再回收。
+替换 `add_*_plugin_modules()` 的永久追加语义，改为从 snapshot 构建或选择 phase graph。Tool schema、tool search 和 tool execute 必须来自同一 snapshot。发布使用固定状态机：`PREPARED → PUBLISHED_PENDING → COMMITTED／ABORTED`。进入 pending 时原子发布 v2，同时保留 v1 rollback hold；Reconciler 在 5 秒内执行无业务副作用的 post-publish invariants，包括 active snapshot identity、稳定 endpoint slot 指向、候选 Host alive 和资源计数。全部通过即 COMMITTED 并释放 v1 hold；失败或超时即 ABORTED，先恢复 v1 active hold并重新发布 v1。已经持有 v2 lease 的执行继续完成，v2 等待 lease 清零后回收。
 
 **G4 Verify**:
 
@@ -285,6 +284,7 @@ Passive turn、proactive tick、job、tool execution、EventBus queue envelope �
 - Candidate snapshot 只要任一 graph/index 构建失败，current snapshot identity 不变。
 - v2 发布后触发 rollback：后续执行回到 v1，已经持有 v2 lease 的执行安全完成，最后 v2 才清理。
 - v1 rollback hold 在发布验收完成前始终保留其 MCP、Channel 和 Service；验收通过后才允许 v1 drain。
+- Job 在 v1 入队、v2 发布后出队时仍调用 v1 envelope 中的 handler；新入队任务使用 v2 job catalog。
 - `pytest -q tests/test_plugin_hot_reload.py tests/proactive_v2` → all pass。
 - `python docker/debug/plugin_hot_reload_probe.py --scenario full-runtime --phase snapshot` → 真实 `main.py` 中阻塞 v1 turn，中途更新隔离 cache，当前 turn 保持 v1，下一 turn 使用 v2。
 
@@ -346,7 +346,7 @@ Watcher 只发送 invalidation hint。Reconciler 必须在启动、Watcher 事�
 
 扩展 host-side `docker/debug/plugin_hot_reload_probe.py`。Controller 启动独立 Runtime container，其 PID 1 由 entrypoint 执行 `python main.py`；Controller 通过 Unix socket 和共享的外部 sandbox 驱动 Runtime，不能让 probe 子进程冒充 Runtime。Controller 在隔离 cache 安装全能力测试插件，制造 active turn、MCP call、job、proactive tick 和 Dashboard request，再修改 sandbox 内源码、config 和 manifest。
 
-Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 保持正式 Provider wiring，通过同一 Compose network 的 OpenAI-compatible mock sidecar 和 `base_url` 获得确定性响应，不 monkeypatch `AppRuntime.start()`。触发入口分别为：IPC 驱动 passive turn、容器内 HTTP 驱动 Dashboard、sandbox 文件驱动 Watcher、短周期配置驱动 Job/Proactive、结构化 status API 读取 generation/Gate。连续执行成功发布、失败回滚、disable/re-enable、rapid revisions 和进程重启后恢复。
+Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 保持正式 Provider wiring，通过同一 Compose network 的 OpenAI-compatible mock sidecar 和 `base_url` 获得确定性响应，不 monkeypatch `AppRuntime.start()`。新增 `docker/debug/model_gate.py`：`POST /control/scripts` 装载脚本化文本、tool-call 或 stream 响应；`/v1/chat/completions` 在命名 barrier 记录 request 后暂停；`POST /control/barriers/{id}/release` 释放；`GET /control/events` 返回结构化请求顺序。这样 Snapshot Gate 能确定性制造“v1 已进入、更新 v2、释放 v1”。触发入口分别为：IPC 驱动 passive turn、容器内 HTTP 驱动 Dashboard、sandbox 文件驱动 Watcher、短周期配置驱动 Job/Proactive、结构化 status API 读取 generation/Gate。
 
 使用独立 `plugin-reload-gate` profile，绝不挂载正式 workspace、正式 HOME 或宿主插件缓存。Fitbit 从只读 canonical source 复制到 sandbox cache 后安装；验证使用匿名 fixture 和测试凭据，没有可用测试凭据时只运行本地模型与 monitor 契约，不访问真实账户。
 
@@ -371,7 +371,8 @@ Controller 复用 `context_probe.py` 的进程 readiness/cleanup；Runtime 保�
 - `tests_scenarios/test_plugin_hot_reload_runtime.py`：真实 provider 下下一 turn 生效。
 - `/mnt/data/coding/akashic-plugin/fitbit-mcp`：匿名模型 fixture、monitor 单实例和数据不变。
 - `docker/debug/plugin_hot_reload_probe.py`：完整 Runtime 综合 Gate。
-- `docker/debug/docker-compose.yml`：独立只读源码 Gate service，不改变普通 debug service。
+- `docker/debug/docker-compose.plugin-gate.yml`：独立只读源码 Gate service，不改变普通 debug service。
+- `docker/debug/model_gate.py`：可控 OpenAI-compatible sidecar 与并发 barrier。
 
 ## Done criteria
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -6,7 +6,7 @@
 
 | Plan | Title | Priority | Effort | Depends on | Status |
 |---|---|---|---|---|---|
-| 001 | 以验证门禁完成全插件热重载 | P1 | L | — | TODO |
+| 001 | 以验证门禁完成全插件热重载 | P1 | L | — | DONE |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED | REJECTED
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,8 +17,8 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED | REJECTED
 └─ G-1 沙盒完整性
    └─ G0 基线
       └─ G1 候选验证
-         └─ G2 资源预热
-            └─ G3 插件语义验证
+         └─ G3 插件语义验证
+            └─ G2 资源预热
                └─ G4 原子发布
                   └─ G5 旧代际排空
                      └─ G6 完整 Runtime 验收

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,34 @@
+# Implementation Plans
+
+由 improve skill 于 2026-07-11 生成。按依赖顺序执行；每一步必须通过计划内 Gate，失败时停止并保留上一可运行状态。
+
+## Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|---|---|---|---|---|---|
+| 001 | 以验证门禁完成全插件热重载 | P1 | L | — | TODO |
+
+Status values: TODO | IN PROGRESS | DONE | BLOCKED | REJECTED
+
+## Dependency notes
+
+```text
+001
+└─ G-1 沙盒完整性
+   └─ G0 基线
+      └─ G1 候选验证
+         └─ G2 资源预热
+            └─ G3 插件语义验证
+               └─ G4 原子发布
+                  └─ G5 旧代际排空
+                     └─ G6 完整 Runtime 验收
+```
+
+任何 Gate 未通过时，不得继续后续步骤或删除旧实现。
+
+## Findings considered and rejected
+
+- 只增加文件 Watcher：无法注销旧事件、任务和运行时快照，会制造重复执行。
+- 使用 `importlib.reload()`：外部旧对象引用不会自动更新，无法保证同一 turn 一致。
+- 为每类能力分别实现 reload：会形成多套生命周期和回滚语义。
+- 先卸载旧插件再加载新插件：候选失败时失去 last-known-good，且 Channel、MCP 和主动链路产生不必要空窗。

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -40,6 +40,10 @@ class AkashaLastCommandModule:
 
 
 class AkashaPlugin(Plugin):
+    @classmethod
+    def dashboard_module(cls) -> str | None:
+        return "dashboard.py"
+
     name = "akasha"
 
     def telegram_bot_commands(self) -> list[tuple[str, str]]:

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -48,8 +48,6 @@ class AkashaPlugin(Plugin):
         return [("akashalast", "查看上一轮 Akasha 检索诊断")]
 
     def before_turn_modules(self) -> list[object]:
-        if not self.is_active():
-            return []
         return [AkashaLastCommandModule(self)]
 
     def is_active(self) -> bool:

--- a/plugins/default_memory/plugin.py
+++ b/plugins/default_memory/plugin.py
@@ -31,6 +31,10 @@ class ContextPrepareRecordModule:
 
 
 class DefaultMemoryInspector(Plugin):
+    @classmethod
+    def dashboard_module(cls) -> str | None:
+        return "dashboard.py"
+
     name = "default_memory"
 
     @classmethod

--- a/proactive_v2/lifecycle.py
+++ b/proactive_v2/lifecycle.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+import logging
 from typing import cast
 
 from agent.lifecycle.phase import inspect_phase, topo_sort_modules
 from proactive_v2.frame import ProactiveFrame
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -44,16 +47,36 @@ class CompiledProactiveLifecycle:
         self._modules = modules
 
     async def start(self) -> None:
-        for binding in self._modules:
-            starter = getattr(binding.module, "start", None)
-            if starter is not None:
-                await starter()
+        started: list[_CompiledModule] = []
+        try:
+            for binding in self._modules:
+                starter = getattr(binding.module, "start", None)
+                if starter is not None:
+                    await starter()
+                started.append(binding)
+        except BaseException:
+            for binding in reversed(started):
+                stopper = getattr(binding.module, "stop", None)
+                if stopper is None:
+                    continue
+                try:
+                    await stopper()
+                except Exception:
+                    logger.exception("主动 Lifecycle 启动回滚失败: %s", binding.slot)
+            raise
 
     async def stop(self) -> None:
+        first_error: Exception | None = None
         for binding in reversed(self._modules):
             stopper = getattr(binding.module, "stop", None)
             if stopper is not None:
-                await stopper()
+                try:
+                    await stopper()
+                except Exception as error:
+                    logger.exception("主动 Lifecycle 停止失败: %s", binding.slot)
+                    first_error = first_error or error
+        if first_error is not None:
+            raise first_error
 
     async def run(self, frame: ProactiveFrame) -> ProactiveFrame:
         for binding in self._modules:

--- a/proactive_v2/lifecycle.py
+++ b/proactive_v2/lifecycle.py
@@ -51,9 +51,9 @@ class CompiledProactiveLifecycle:
         try:
             for binding in self._modules:
                 starter = getattr(binding.module, "start", None)
+                started.append(binding)
                 if starter is not None:
                     await starter()
-                started.append(binding)
         except BaseException:
             for binding in reversed(started):
                 stopper = getattr(binding.module, "stop", None)

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -17,11 +17,15 @@ import random as _random_module
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 if TYPE_CHECKING:
     from core.memory.engine import MemoryRetrievalApi
-    from agent.plugins.snapshot import RuntimeSnapshot, RuntimeSnapshotStore
+    from agent.plugins.snapshot import (
+        RuntimeSnapshot,
+        RuntimeSnapshotLease,
+        RuntimeSnapshotStore,
+    )
 
 from core.error_context import current_session_key
 from agent.looping.ports import SessionServices
@@ -109,8 +113,7 @@ class ProactiveLoop:
         self._runtime_snapshot_store = runtime_snapshot_store
         self._active_snapshot_id: str | None = None
         self._kernel_started = False
-        if runtime_snapshot_store is not None and runtime_snapshot_store.current is not None:
-            self._apply_snapshot(runtime_snapshot_store.current)
+        self._active_kernel_lease: RuntimeSnapshotLease | None = None
         self._workspace_context_mtime_ns: int | None = None
         self._workspace_context_text: str = ""
         self._init_runtime_state(config)
@@ -276,7 +279,8 @@ class ProactiveLoop:
         # 3. 构建发送编排器、传感器、MCP runtime 和主动链路 kernel。
         self._turn_orchestrator = self._build_turn_orchestrator()
         self._sense = self._build_sense()
-        self._mcp_runtime = self._build_mcp_runtime()
+        self._mcp_runtime: McpRuntimeModule
+        self._proactive_kernel: ProactiveKernel
         self._scheduler = ProactiveScheduler(
             cfg=self._cfg,
             presence=self._presence,
@@ -284,7 +288,9 @@ class ProactiveLoop:
             target_session_key_fn=self._target_session_key,
             trace_fn=self._trace_proactive_rate_decision,
         )
-        self._proactive_kernel = self._build_kernel()
+        if self._runtime_snapshot_store is None:
+            self._mcp_runtime = self._build_mcp_runtime()
+            self._proactive_kernel = self._build_kernel()
         # 4. 启动时把当前 proactive 配置落一份 trace，方便回看。
         self._trace_proactive_config_snapshot()
 
@@ -377,18 +383,18 @@ class ProactiveLoop:
             f"ProactiveLoop 已启动  "
             f"目标={self._cfg.default_channel}:{self._cfg.default_chat_id}"
         )
-        if self._runtime_snapshot_store is not None:
-            await self._start_current_snapshot()
-        else:
-            await self._proactive_kernel.start()
-            self._kernel_started = True
         try:
+            if self._runtime_snapshot_store is not None:
+                await self._start_current_snapshot()
+            else:
+                await self._proactive_kernel.start()
+                self._kernel_started = True
             await self._run_loop()
         finally:
-            if self._kernel_started:
-                await self._proactive_kernel.stop()
-                self._kernel_started = False
-            self._stopped.set()
+            try:
+                await self._stop_active_kernel()
+            finally:
+                self._stopped.set()
 
     async def _run_loop(self) -> None:
         last_base_score: float | None = None
@@ -514,14 +520,79 @@ class ProactiveLoop:
     async def _switch_snapshot(self, snapshot: RuntimeSnapshot) -> None:
         if self._active_snapshot_id == snapshot.snapshot_id and self._kernel_started:
             return
-        if self._kernel_started:
-            await self._proactive_kernel.stop()
-        self._apply_snapshot(snapshot)
-        self._mcp_runtime = self._build_mcp_runtime()
-        self._proactive_kernel = self._build_kernel()
-        await self._proactive_kernel.start()
+        from agent.plugins.snapshot import get_current_runtime_lease
+
+        source_lease = get_current_runtime_lease()
+        if source_lease is None or source_lease.snapshot is not snapshot:
+            raise RuntimeError("主动 kernel 切换缺少目标 Snapshot lease")
+        old_kernel = self._proactive_kernel if self._kernel_started else None
+        old_lease = self._active_kernel_lease
+        if old_kernel is not None and old_lease is not None:
+            await self._run_with_lease(old_lease, old_kernel.stop)
+            self._kernel_started = False
+        candidate_lease = source_lease.fork()
+        try:
+            candidate_kernel = await self._build_and_start_kernel(
+                snapshot,
+                candidate_lease,
+            )
+        except BaseException:
+            await candidate_lease.release()
+            if old_kernel is not None and old_lease is not None:
+                await self._run_with_lease(old_lease, old_kernel.start)
+                self._kernel_started = True
+            raise
+        if old_lease is not None:
+            await old_lease.release()
+        self._proactive_kernel = candidate_kernel
+        self._active_kernel_lease = candidate_lease
         self._active_snapshot_id = snapshot.snapshot_id
         self._kernel_started = True
+
+    async def _build_and_start_kernel(
+        self,
+        snapshot: RuntimeSnapshot,
+        lease: RuntimeSnapshotLease,
+    ) -> ProactiveKernel:
+        async def build_and_start() -> ProactiveKernel:
+            self._apply_snapshot(snapshot)
+            self._mcp_runtime = self._build_mcp_runtime()
+            kernel = self._build_kernel()
+            await kernel.start()
+            return kernel
+
+        return await self._run_with_lease(lease, build_and_start)
+
+    async def _stop_active_kernel(self) -> None:
+        lease = self._active_kernel_lease
+        stopped = not self._kernel_started
+        try:
+            if self._kernel_started:
+                if lease is None:
+                    await self._proactive_kernel.stop()
+                else:
+                    await self._run_with_lease(lease, self._proactive_kernel.stop)
+                self._kernel_started = False
+                stopped = True
+        finally:
+            if stopped:
+                self._active_snapshot_id = None
+                self._active_kernel_lease = None
+            if stopped and lease is not None:
+                await lease.release()
+
+    async def _run_with_lease(
+        self,
+        lease: RuntimeSnapshotLease,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+        token = bind_runtime_snapshot(lease)
+        try:
+            return await operation()
+        finally:
+            reset_runtime_snapshot(token)
 
     def _apply_snapshot(self, snapshot: RuntimeSnapshot) -> None:
         self._plugin_proactive_modules = list(snapshot.proactive_modules)

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -122,6 +122,7 @@ class ProactiveLoop:
     def _init_runtime_state(self, config: ProactiveConfig) -> None:
         self._running = False
         self._wake = asyncio.Event()
+        self._reload_lock = asyncio.Lock()
         self._stopped = asyncio.Event()
         self._stopped.set()
 
@@ -443,8 +444,12 @@ class ProactiveLoop:
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
+        async with self._reload_lock:
+            return await self._tick_admitted()
+
+    async def _tick_admitted(self) -> float | None:
         if self._runtime_snapshot_store is not None:
-            lease = self._runtime_snapshot_store.lease()
+            lease = await self._runtime_snapshot_store.acquire()
             from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 
             async with lease:
@@ -455,6 +460,13 @@ class ProactiveLoop:
                 finally:
                     reset_runtime_snapshot(token)
         return await self._tick_bound()
+
+    async def quiesce_for_reload(self) -> None:
+        async with self._reload_lock:
+            await self._stop_active_kernel()
+
+    async def resume_after_reload(self) -> None:
+        self._wake.set()
 
     async def _tick_bound(self) -> float | None:
         # 给本 tick 打上 session 归属，供 observe 全局错误采集关联；
@@ -507,7 +519,7 @@ class ProactiveLoop:
 
     async def _start_current_snapshot(self) -> None:
         assert self._runtime_snapshot_store is not None
-        lease = self._runtime_snapshot_store.lease()
+        lease = await self._runtime_snapshot_store.acquire()
         from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 
         async with lease:

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -193,11 +193,21 @@ class ProactiveLoop:
         return factory(self._build_runtime_scope())
 
     def _build_mcp_runtime(self) -> McpRuntimeModule:
-        from agent.plugins.snapshot import get_current_runtime_lease
+        from agent.plugins.snapshot import (
+            get_current_runtime_lease,
+            get_current_runtime_snapshot,
+        )
+
+        snapshot = get_current_runtime_snapshot()
+        tools = (
+            snapshot.tool_registry
+            if snapshot is not None and snapshot.tool_registry is not None
+            else self._shared_tools
+        )
 
         gateway = SharedMcpGateway(
             Path(self._sessions.workspace),
-            self._shared_tools,
+            tools,
         )
         return McpRuntimeModule(
             gateway=gateway,

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -444,8 +444,20 @@ class ProactiveLoop:
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
-        async with self._reload_lock:
-            return await self._tick_admitted()
+        if self._runtime_snapshot_store is None:
+            async with self._reload_lock:
+                return await self._tick_bound()
+        lease = await self._runtime_snapshot_store.acquire()
+        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+        async with lease:
+            token = bind_runtime_snapshot(lease)
+            try:
+                async with self._reload_lock:
+                    await self._switch_snapshot(lease.snapshot)
+                    return await self._tick_bound()
+            finally:
+                reset_runtime_snapshot(token)
 
     async def _tick_admitted(self) -> float | None:
         if self._runtime_snapshot_store is not None:

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from core.memory.engine import MemoryRetrievalApi
+    from agent.plugins.snapshot import RuntimeSnapshot, RuntimeSnapshotStore
 
 from core.error_context import current_session_key
 from agent.looping.ports import SessionServices
@@ -84,6 +85,7 @@ class ProactiveLoop:
         proactive_module_factories: list[object] | None = None,
         proactive_runtime_factories: list[object] | None = None,
         proactive_sources: list[RegisteredProactiveSource] | None = None,
+        runtime_snapshot_store: RuntimeSnapshotStore | None = None,
     ) -> None:
         self._sessions = session_manager
         self._provider = provider
@@ -104,6 +106,11 @@ class ProactiveLoop:
         self._plugin_proactive_module_factories = proactive_module_factories or []
         self._plugin_proactive_runtime_factories = proactive_runtime_factories or []
         self._plugin_proactive_sources = proactive_sources or []
+        self._runtime_snapshot_store = runtime_snapshot_store
+        self._active_snapshot_id: str | None = None
+        self._kernel_started = False
+        if runtime_snapshot_store is not None and runtime_snapshot_store.current is not None:
+            self._apply_snapshot(runtime_snapshot_store.current)
         self._workspace_context_mtime_ns: int | None = None
         self._workspace_context_text: str = ""
         self._init_runtime_state(config)
@@ -111,6 +118,9 @@ class ProactiveLoop:
 
     def _init_runtime_state(self, config: ProactiveConfig) -> None:
         self._running = False
+        self._wake = asyncio.Event()
+        self._stopped = asyncio.Event()
+        self._stopped.set()
 
     def _build_state_store(
         self,
@@ -179,6 +189,8 @@ class ProactiveLoop:
         return factory(self._build_runtime_scope())
 
     def _build_mcp_runtime(self) -> McpRuntimeModule:
+        from agent.plugins.snapshot import get_current_runtime_lease
+
         gateway = SharedMcpGateway(
             Path(self._sessions.workspace),
             self._shared_tools,
@@ -186,6 +198,7 @@ class ProactiveLoop:
         return McpRuntimeModule(
             gateway=gateway,
             sources=self._plugin_proactive_sources,
+            runtime_snapshot_lease=get_current_runtime_lease(),
         )
 
     def _build_kernel(self) -> ProactiveKernel:
@@ -359,15 +372,23 @@ class ProactiveLoop:
 
     async def run(self) -> None:
         self._running = True
+        self._stopped.clear()
         logger.info(
             f"ProactiveLoop 已启动  "
             f"目标={self._cfg.default_channel}:{self._cfg.default_chat_id}"
         )
-        await self._proactive_kernel.start()
+        if self._runtime_snapshot_store is not None:
+            await self._start_current_snapshot()
+        else:
+            await self._proactive_kernel.start()
+            self._kernel_started = True
         try:
             await self._run_loop()
         finally:
-            await self._proactive_kernel.stop()
+            if self._kernel_started:
+                await self._proactive_kernel.stop()
+                self._kernel_started = False
+            self._stopped.set()
 
     async def _run_loop(self) -> None:
         last_base_score: float | None = None
@@ -379,7 +400,13 @@ class ProactiveLoop:
                 else self._next_interval(last_base_score)
             )
             logger.info("[proactive] 下次 tick 间隔=%ds", interval)
-            await asyncio.sleep(interval)
+            self._wake.clear()
+            try:
+                _ = await asyncio.wait_for(self._wake.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+            if not self._running:
+                return
             try:
                 last_base_score = await self._tick()
                 result = self._proactive_kernel.last_result
@@ -401,11 +428,29 @@ class ProactiveLoop:
 
     def stop(self) -> None:
         self._running = False
+        self._wake.set()
+
+    async def wait_stopped(self) -> None:
+        _ = await self._stopped.wait()
 
     # ── internal ──────────────────────────────────────────────────
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
+        if self._runtime_snapshot_store is not None:
+            lease = self._runtime_snapshot_store.lease()
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    await self._switch_snapshot(lease.snapshot)
+                    return await self._tick_bound()
+                finally:
+                    reset_runtime_snapshot(token)
+        return await self._tick_bound()
+
+    async def _tick_bound(self) -> float | None:
         # 给本 tick 打上 session 归属，供 observe 全局错误采集关联；
         # 纯埋点，依赖未就绪时静默跳过，绝不影响 tick 主流程。
         _ = current_session_key.set(self._target_session_key())
@@ -453,6 +498,42 @@ class ProactiveLoop:
                 )
             )
             return score
+
+    async def _start_current_snapshot(self) -> None:
+        assert self._runtime_snapshot_store is not None
+        lease = self._runtime_snapshot_store.lease()
+        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+        async with lease:
+            token = bind_runtime_snapshot(lease)
+            try:
+                await self._switch_snapshot(lease.snapshot)
+            finally:
+                reset_runtime_snapshot(token)
+
+    async def _switch_snapshot(self, snapshot: RuntimeSnapshot) -> None:
+        if self._active_snapshot_id == snapshot.snapshot_id and self._kernel_started:
+            return
+        if self._kernel_started:
+            await self._proactive_kernel.stop()
+        self._apply_snapshot(snapshot)
+        self._mcp_runtime = self._build_mcp_runtime()
+        self._proactive_kernel = self._build_kernel()
+        await self._proactive_kernel.start()
+        self._active_snapshot_id = snapshot.snapshot_id
+        self._kernel_started = True
+
+    def _apply_snapshot(self, snapshot: RuntimeSnapshot) -> None:
+        self._plugin_proactive_modules = list(snapshot.proactive_modules)
+        self._plugin_proactive_lifecycles = list(snapshot.proactive_lifecycles)
+        self._plugin_proactive_module_factories = list(
+            snapshot.proactive_module_factories
+        )
+        self._plugin_proactive_runtime_factories = list(
+            snapshot.proactive_runtime_factories
+        )
+        self._plugin_proactive_sources = list(snapshot.proactive_sources.values())
+        self._tool_hooks = list(snapshot.tool_hooks)
 
 
 def build_proactive_loop(**kwargs: Any) -> ProactiveLoop:

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any, Protocol
 
-from agent.plugins.specs import RegisteredProactiveSource
+from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
 from agent.tools.base import ToolResult
 from agent.tools.registry import ToolRegistry
 
@@ -58,7 +58,7 @@ class SharedMcpGateway:
 
 
 def source_key(source: RegisteredProactiveSource) -> str:
-    return f"{source.plugin_id}:{source.spec.id}"
+    return proactive_source_key(source)
 
 
 async def fetch_sources_async(

--- a/proactive_v2/modules_source.py
+++ b/proactive_v2/modules_source.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from agent.plugins.specs import RegisteredProactiveSource
 from proactive_v2 import mcp_sources
 from proactive_v2.frame import ProactiveFrame
 from proactive_v2.mcp_sources import McpGateway
+
+if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshotLease
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +23,13 @@ class McpRuntimeModule:
         *,
         gateway: McpGateway,
         sources: list[RegisteredProactiveSource],
+        runtime_snapshot_lease: RuntimeSnapshotLease | None = None,
     ) -> None:
         self._pool = gateway
         self._sources = [source for source in sources if source.spec.poll_tool]
         self._running = False
         self._tasks: list[asyncio.Task[None]] = []
+        self._runtime_snapshot_lease = runtime_snapshot_lease
 
     @property
     def pool(self) -> McpGateway:
@@ -31,21 +37,27 @@ class McpRuntimeModule:
 
     async def start(self) -> None:
         self._running = True
-        for source in self._sources:
-            await self._poll_once(source)
-            self._tasks.append(
-                asyncio.create_task(
-                    self._poll_loop(source),
-                    name=f"proactive_poll:{mcp_sources.source_key(source)}",
+        try:
+            for source in self._sources:
+                await self._poll_once(source)
+                ready = asyncio.Event()
+                self._tasks.append(
+                    asyncio.create_task(
+                        self._poll_loop(source, ready),
+                        name=f"proactive_poll:{mcp_sources.source_key(source)}",
+                    )
                 )
-            )
+                _ = await ready.wait()
+        except BaseException:
+            await self.stop()
+            raise
 
     async def stop(self) -> None:
         self._running = False
         for task in self._tasks:
-            task.cancel()
+            _ = task.cancel()
         if self._tasks:
-            await asyncio.gather(*self._tasks, return_exceptions=True)
+            _ = await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
 
     async def run(self, frame: ProactiveFrame) -> ProactiveFrame:
@@ -59,7 +71,28 @@ class McpRuntimeModule:
         except Exception as e:
             logger.warning("[proactive.source] poll 失败 %s: %s", key, e)
 
-    async def _poll_loop(self, source: RegisteredProactiveSource) -> None:
+    async def _poll_loop(
+        self,
+        source: RegisteredProactiveSource,
+        ready: asyncio.Event,
+    ) -> None:
+        source_lease = self._runtime_snapshot_lease
+        if source_lease is not None:
+            lease = source_lease.fork()
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                ready.set()
+                try:
+                    await self._poll_loop_bound(source)
+                finally:
+                    reset_runtime_snapshot(token)
+            return
+        ready.set()
+        await self._poll_loop_bound(source)
+
+    async def _poll_loop_bound(self, source: RegisteredProactiveSource) -> None:
         interval = max(1, int(source.spec.poll_interval_seconds))
         while self._running:
             await asyncio.sleep(interval)

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -36,6 +36,23 @@ python main.py plugin-install --source <repo_or_url> --marketplace github
 python main.py plugin-doctor --plugin <name>@github
 ```
 
+## 更新已有插件
+
+不要直接修改 `~/.akashic-plugin/cache`。先修改插件的可编辑源码仓库；个人插件通常位于 `/mnt/data/coding/akashic-plugin/<plugin-name>`。如果只知道已安装插件而找不到源码仓库，先确认其 Git remote 或向用户询问。
+
+```text
+┌─ 修改插件源码仓库
+├─ 运行插件自身测试
+├─ 提交并推送源码
+├─ 用原 source 与 marketplace 再次执行 plugin-install
+├─ watcher 自动准备并发布新代际
+└─ plugin-doctor 加一次真实行为验证
+```
+
+重新执行 `plugin-install` 即更新：它替换 cache 中的已安装版本，但保留 data 与配置。运行中的 watcher 会自动热重载，不要重启 Agent。
+
+如果用户指定把现有项目中的 skill 收入某个插件，应复制或适配到该插件源码的 `skills/<skill-name>/`，再走上述更新流程；不要改写原项目，也不要先落到 workspace。
+
 ## 启用与禁用
 
 使用管理命令修改 `manifest.toml` 对应条目的 `enabled`。运行中的 watcher 会自动完成启停，不需要重启进程。
@@ -75,7 +92,7 @@ python main.py plugin-uninstall demo@github
 ## 热重载验证
 
 ```text
-┌─ 修改 cache、manifest.toml 或 config.local.toml
+┌─ plugin-install 更新 cache，或修改 manifest.toml/config.local.toml
 ├─ 等待 watcher 生成候选代际
 ├─ 检查 candidate 与 snapshot Gate 日志
 ├─ 发起一次新请求验证新能力

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -33,7 +33,7 @@ python main.py plugin-install --source <repo_or_url> --marketplace github
 安装后检查 manifest、cache、data，并运行：
 
 ```bash
-python main.py plugin-doctor --plugin <name>@github
+python main.py plugin-doctor <name>@github
 ```
 
 ## 更新已有插件
@@ -46,7 +46,8 @@ python main.py plugin-doctor --plugin <name>@github
 ├─ 提交并推送源码
 ├─ 用原 source 与 marketplace 再次执行 plugin-install
 ├─ watcher 自动准备并发布新代际
-└─ plugin-doctor 加一次真实行为验证
+├─ 运行 plugin-doctor 检查结构与配置
+└─ 发起一次新请求验证真实行为
 ```
 
 重新执行 `plugin-install` 即更新：它替换 cache 中的已安装版本，但保留 data 与配置。运行中的 watcher 会自动热重载，不要重启 Agent。

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -68,7 +68,7 @@ python main.py plugin-doctor <name>@github
 ├─ 安装缓存
 │  └─ 目标能力的具体文件或声明确实存在
 ├─ Runtime
-│  ├─ candidate 与 snapshot 已发布
+│  ├─ candidate 已通过 Gate，snapshot 已发布
 │  └─ 新请求能实际使用目标能力
 └─ 外部依赖
    ├─ CLI 从稳定目录运行

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -40,6 +40,8 @@ python main.py plugin-doctor <name>@github
 
 不要直接修改 `~/.akashic-plugin/cache`。先修改插件的可编辑源码仓库；个人插件通常位于 `/mnt/data/coding/akashic-plugin/<plugin-name>`。如果只知道已安装插件而找不到源码仓库，先确认其 Git remote 或向用户询问。
 
+`plugin-install` 即使接收本地仓库路径，也会执行 `git clone`，只安装已提交的 Git HEAD，不会复制工作区里的未提交文件。必须先提交；需要从 GitHub 更新时，还必须先推送，再使用 GitHub source 安装。
+
 ```text
 ┌─ 修改插件源码仓库
 ├─ 运行插件自身测试
@@ -52,7 +54,28 @@ python main.py plugin-doctor <name>@github
 
 重新执行 `plugin-install` 即更新：它替换 cache 中的已安装版本，但保留 data 与配置。运行中的 watcher 会自动热重载，不要重启 Agent。
 
-如果用户指定把现有项目中的 skill 收入某个插件，应复制或适配到该插件源码的 `skills/<skill-name>/`，再走上述更新流程；不要改写原项目，也不要先落到 workspace。
+如果用户指定把现有项目中的 skill 收入某个插件，应复制或适配到该插件源码的 `skills/<skill-name>/`，再走上述更新流程；不要改写原项目，也不要先落到 workspace。若 skill 依赖外部项目或 CLI，把它安装到用户指定目录或稳定的数据目录，禁止让 wrapper、符号链接或服务依赖 `/tmp`。
+
+## 完成判定
+
+工具调用成功只代表命令退出码为零，不代表更新目标成立。汇报完成前必须从最终状态重新验收：
+
+```text
+┌─ 源码仓库
+│  ├─ 目标文件存在
+│  ├─ 预期改动已 commit
+│  └─ 要求发布时，远端已包含该 commit
+├─ 安装缓存
+│  └─ 目标能力的具体文件或声明确实存在
+├─ Runtime
+│  ├─ candidate 与 snapshot 已发布
+│  └─ 新请求能实际使用目标能力
+└─ 外部依赖
+   ├─ CLI 从稳定目录运行
+   └─ 用户要求常驻服务时，health 返回健康
+```
+
+`plugin-doctor` 只证明插件结构、根目录与声明可加载，不证明某个具体 skill 已安装，也不能代替真实行为验证。不要用中途检查、手动改 cache 后的结果或 doctor healthy 推断最终成功。
 
 ## 启用与禁用
 

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -38,7 +38,7 @@ python main.py plugin-doctor --plugin <name>@github
 
 ## 启用与禁用
 
-只修改 `manifest.toml` 对应条目的 `enabled`。启停后提醒用户重启运行进程。
+只修改 `manifest.toml` 对应条目的 `enabled`。运行中的 watcher 会自动完成启停，不需要重启进程。
 
 ```toml
 [plugins."demo@github"]
@@ -63,3 +63,13 @@ enabled = false
 ```
 
 插件能力全部由代码声明，公共 runtime 不应出现具体插件名或业务路径特判。
+
+## 热重载验证
+
+```text
+┌─ 修改 cache、manifest.toml 或 config.local.toml
+├─ 等待 watcher 生成候选代际
+├─ 检查 candidate 与 snapshot Gate 日志
+├─ 发起一次新请求验证新能力
+└─ 确认旧 MCP、任务、Channel 与服务已排空
+```

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -38,12 +38,20 @@ python main.py plugin-doctor --plugin <name>@github
 
 ## 启用与禁用
 
-只修改 `manifest.toml` 对应条目的 `enabled`。运行中的 watcher 会自动完成启停，不需要重启进程。
+使用管理命令修改 `manifest.toml` 对应条目的 `enabled`。运行中的 watcher 会自动完成启停，不需要重启进程。
 
-```toml
-[plugins."demo@github"]
-enabled = false
+```bash
+python main.py plugin-disable demo@github
+python main.py plugin-enable demo@github
 ```
+
+## 卸载
+
+```bash
+python main.py plugin-uninstall demo@github
+```
+
+卸载删除 manifest 条目与 cache，始终保留插件 data。不要手动删除 data、配置、Token、数据库或模型。
 
 ## 配置
 

--- a/tests/proactive_v2/test_integration.py
+++ b/tests/proactive_v2/test_integration.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
 
+from agent.plugins.snapshot import (
+    RuntimeSnapshotLease,
+    bind_runtime_snapshot,
+    reset_runtime_snapshot,
+)
+from agent.tools.base import Tool
+from agent.tools.registry import ToolRegistry
 from proactive_v2.config import ProactiveConfig
 from proactive_v2.loop import ProactiveLoop
+
+
+class SnapshotMcpTool(Tool):
+    name = "mcp_feed__get_proactive_events"
+    description = "Fetch proactive events."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: object) -> str:
+        return "[]"
 
 
 def make_loop() -> ProactiveLoop:
@@ -73,3 +91,36 @@ async def test_start_failure_always_marks_loop_stopped() -> None:
         await loop.run()
 
     assert loop._stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_mcp_runtime_keeps_snapshot_tools_in_gateway_child_task(
+    tmp_path: Path,
+) -> None:
+    base_tools = ToolRegistry()
+    snapshot_tools = ToolRegistry()
+    snapshot_tools.register(
+        SnapshotMcpTool(),
+        source_type="mcp",
+        source_name="feed",
+    )
+    snapshot = SimpleNamespace(tool_registry=snapshot_tools)
+    lease = cast(
+        RuntimeSnapshotLease,
+        SimpleNamespace(active=True, snapshot=snapshot),
+    )
+    loop = object.__new__(ProactiveLoop)
+    loop._sessions = SimpleNamespace(workspace=tmp_path)
+    loop._shared_tools = base_tools
+    loop._plugin_proactive_sources = []
+
+    token = bind_runtime_snapshot(lease)
+    try:
+        runtime = loop._build_mcp_runtime()
+    finally:
+        reset_runtime_snapshot(token)
+
+    result = await asyncio.create_task(
+        runtime.pool.call("feed", "get_proactive_events", {})
+    )
+    assert result == []

--- a/tests/proactive_v2/test_integration.py
+++ b/tests/proactive_v2/test_integration.py
@@ -16,6 +16,7 @@ def make_loop() -> ProactiveLoop:
     loop._sense = SimpleNamespace(target_session_key=lambda: "telegram:1")
     loop._proactive_kernel = SimpleNamespace(run_tick=AsyncMock(return_value=None))
     loop._runtime_snapshot_store = None
+    loop._reload_lock = asyncio.Lock()
     return loop
 
 

--- a/tests/proactive_v2/test_integration.py
+++ b/tests/proactive_v2/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -45,3 +46,29 @@ async def test_kernel_route_stable_across_multiple_ticks() -> None:
     await loop._tick()
 
     assert loop._proactive_kernel.run_tick.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_start_failure_always_marks_loop_stopped() -> None:
+    loop = make_loop()
+    loop._running = False
+    loop._stopped = asyncio.Event()
+    loop._kernel_started = False
+    loop._active_kernel_lease = None
+    loop._cfg.default_channel = "cli"
+    loop._cfg.default_chat_id = "test"
+    loop._runtime_snapshot_store = object()
+
+    async def fail_start() -> None:
+        raise RuntimeError("start failed")
+
+    async def stop_active() -> None:
+        return None
+
+    loop._start_current_snapshot = fail_start
+    loop._stop_active_kernel = stop_active
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await loop.run()
+
+    assert loop._stopped.is_set()

--- a/tests/proactive_v2/test_integration.py
+++ b/tests/proactive_v2/test_integration.py
@@ -14,6 +14,7 @@ def make_loop() -> ProactiveLoop:
     loop._cfg = ProactiveConfig()
     loop._sense = SimpleNamespace(target_session_key=lambda: "telegram:1")
     loop._proactive_kernel = SimpleNamespace(run_tick=AsyncMock(return_value=None))
+    loop._runtime_snapshot_store = None
     return loop
 
 

--- a/tests/proactive_v2/test_lifecycle_builder.py
+++ b/tests/proactive_v2/test_lifecycle_builder.py
@@ -130,4 +130,4 @@ async def test_start_failure_rolls_back_started_modules():
     with pytest.raises(RuntimeError, match="start failed"):
         await lifecycle.start()
 
-    assert calls == ["start:a", "start:b", "stop:a"]
+    assert calls == ["start:a", "start:b", "stop:b", "stop:a"]

--- a/tests/proactive_v2/test_lifecycle_builder.py
+++ b/tests/proactive_v2/test_lifecycle_builder.py
@@ -107,3 +107,27 @@ def test_missing_terminal_slot_fails_compilation():
                 terminal_slots=("run:next_wakeup",),
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_start_failure_rolls_back_started_modules():
+    calls: list[str] = []
+
+    class StartModule(_Module):
+        async def start(self) -> None:
+            calls.append(f"start:{self.slot}")
+            if self.slot == "b":
+                raise RuntimeError("start failed")
+
+        async def stop(self) -> None:
+            calls.append(f"stop:{self.slot}")
+
+    lifecycle = ProactiveLifecycleBuilder().build(
+        ProactiveLifecycleSpec(id="test"),
+        [StartModule("a", calls), StartModule("b", calls)],
+    )
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await lifecycle.start()
+
+    assert calls == ["start:a", "start:b", "stop:a"]

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1138,7 +1138,7 @@ def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> 
         store.close()
 
 
-def test_akashalast_command_only_registers_for_akasha_engine(tmp_path: Path) -> None:
+def test_akashalast_command_only_exposes_for_akasha_engine(tmp_path: Path) -> None:
     akasha = AkashaPlugin()
     akasha.context = PluginContext(
         event_bus=None,
@@ -1165,7 +1165,7 @@ def test_akashalast_command_only_registers_for_akasha_engine(tmp_path: Path) -> 
     assert akasha.telegram_bot_commands() == [("akashalast", "查看上一轮 Akasha 检索诊断")]
     assert len(akasha.before_turn_modules()) == 1
     assert default.telegram_bot_commands() == []
-    assert default.before_turn_modules() == []
+    assert len(default.before_turn_modules()) == 1
 
 
 def test_akashalast_renders_latest_query_log(tmp_path: Path) -> None:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1141,7 +1141,7 @@ def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> 
 def test_akashalast_command_only_exposes_for_akasha_engine(tmp_path: Path) -> None:
     akasha = AkashaPlugin()
     akasha.context = PluginContext(
-        event_bus=None,
+        event_bus=cast(Any, None),
         tool_registry=None,
         plugin_id="akasha",
         plugin_dir=tmp_path,
@@ -1152,7 +1152,7 @@ def test_akashalast_command_only_exposes_for_akasha_engine(tmp_path: Path) -> No
     )
     default = AkashaPlugin()
     default.context = PluginContext(
-        event_bus=None,
+        event_bus=cast(Any, None),
         tool_registry=None,
         plugin_id="akasha",
         plugin_dir=tmp_path,
@@ -1227,7 +1227,7 @@ def test_akashalast_renders_latest_query_log(tmp_path: Path) -> None:
 
     plugin = AkashaPlugin()
     plugin.context = PluginContext(
-        event_bus=None,
+        event_bus=cast(Any, None),
         tool_registry=None,
         plugin_id="akasha",
         plugin_dir=tmp_path,

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -57,8 +57,8 @@ class _DependentChannel:
         self._fail_start = fail_start
 
     async def start(self, _ctx: object) -> None:
-        assert self._service.version == self._expected
         self._events.append(f"start:{self.name}:{self._service.version}")
+        assert self._service.version == self._expected
         if self._fail_start:
             raise RuntimeError("dependent start failed")
 
@@ -358,3 +358,42 @@ async def test_endpoint_transaction_orders_channel_around_service_and_rolls_back
         "start:old:v1",
     ]
     await channel_host.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_transaction_attempts_channel_restore_when_service_restore_fails():
+    events: list[str] = []
+    service = SimpleNamespace(version="v1")
+    old = _DependentChannel("old", service, "v1", events)
+    failed = _DependentChannel("new", service, "v2", events, fail_start=True)
+    channel_host = ChannelHost(lambda _channel: _context(_channel))  # type: ignore[arg-type]
+    channel_host.add(old)  # type: ignore[arg-type]
+    channel_host.bind_plugin_channels({"combined": (old,)})  # type: ignore[arg-type]
+    await channel_host.start_all()
+    events.clear()
+
+    class ServiceHost:
+        async def swap_plugin_services(self, _plugin_id, before, after) -> None:
+            if before["worker"]["version"] == "v2":
+                events.append("service_restore_failed")
+                raise RuntimeError("restore failed")
+            service.version = after["worker"]["version"]
+            events.append(f"service:{service.version}")
+
+    runtime = object.__new__(AppRuntime)
+    runtime.channel_host = channel_host
+    runtime.plugin_service_host = ServiceHost()
+    v1 = {"worker": {"version": "v1"}}
+    v2 = {"worker": {"version": "v2"}}
+
+    with pytest.raises(RuntimeError, match="managed service.*Channel"):
+        await runtime._swap_plugin_endpoints(
+            "combined",
+            v1,
+            v2,
+            (old,),
+            (failed,),
+        )
+
+    assert "service_restore_failed" in events
+    assert "start:old:v2" in events

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -40,7 +40,9 @@ class _Event:
 
 
 class _RegisteredChannel:
-    name = "registered"
+    def __init__(self, *, fail_start: bool = False) -> None:
+        self.name = "registered"
+        self._fail_start = fail_start
 
     async def start(self, ctx: object) -> None:
         async def on_outbound(_message: object) -> None:
@@ -52,6 +54,8 @@ class _RegisteredChannel:
         ctx.event_bus.on(_Event, lambda event: event)
         ctx.bus.subscribe_outbound(self.name, on_outbound)
         ctx.push_tool.register_channel(self.name, text=send_text)
+        if self._fail_start:
+            raise RuntimeError("registered start failed")
 
     async def stop(self) -> None:
         return None
@@ -113,6 +117,8 @@ async def test_channel_host_swaps_plugin_generation():
     new = _Channel("new", events)
     host.add(old)  # type: ignore[arg-type]
     host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+    await host.start_all()
+    events.clear()
 
     await host.swap_plugin_channels("chat", (old,), (new,))  # type: ignore[arg-type]
 
@@ -128,6 +134,8 @@ async def test_channel_host_restores_old_generation_when_start_fails():
     failed = _Channel("new", events, fail_start=True, fail_stop=True)
     host.add(old)  # type: ignore[arg-type]
     host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+    await host.start_all()
+    events.clear()
 
     with pytest.raises(RuntimeError, match="start failed"):
         await host.swap_plugin_channels("chat", (old,), (failed,))  # type: ignore[arg-type]
@@ -142,7 +150,7 @@ async def test_channel_host_restores_old_generation_when_start_fails():
 
 
 @pytest.mark.asyncio
-async def test_channel_host_restores_every_old_channel_when_stop_fails():
+async def test_channel_host_keeps_failed_stop_channel_and_restores_stopped_ones():
     events: list[str] = []
     host = ChannelHost(_context)  # type: ignore[arg-type]
     first = _Channel("first", events, fail_stop=True)
@@ -151,6 +159,8 @@ async def test_channel_host_restores_every_old_channel_when_stop_fails():
     host.add(first)  # type: ignore[arg-type]
     host.add(second)  # type: ignore[arg-type]
     host.bind_plugin_channels({"chat": (first, second)})  # type: ignore[arg-type]
+    await host.start_all()
+    events.clear()
 
     with pytest.raises(RuntimeError, match="stop failed"):
         await host.swap_plugin_channels(  # type: ignore[arg-type]
@@ -163,9 +173,31 @@ async def test_channel_host_restores_every_old_channel_when_stop_fails():
     assert events == [
         "stop:second",
         "stop:first",
-        "start:first:ctx:first",
         "start:second:ctx:second",
     ]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_rejects_name_conflict_before_stopping_old():
+    events: list[str] = []
+    host = ChannelHost(_context)  # type: ignore[arg-type]
+    core = _Channel("core", events)
+    old = _Channel("old", events)
+    conflict = _Channel("core", events)
+    host.add(core)  # type: ignore[arg-type]
+    host.add(old)  # type: ignore[arg-type]
+    host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+    await host.start_all()
+    events.clear()
+
+    with pytest.raises(RuntimeError, match="名称冲突"):
+        await host.swap_plugin_channels(  # type: ignore[arg-type]
+            "chat",
+            (old,),
+            (conflict,),
+        )
+
+    assert events == []
 
 
 @pytest.mark.asyncio
@@ -207,3 +239,42 @@ async def test_channel_host_revokes_shared_registrations_on_stop():
         chat_id="1",
         message="hello",
     )
+
+
+@pytest.mark.asyncio
+async def test_channel_host_restores_shared_registrations_after_failed_swap():
+    event_bus = EventBus()
+    message_bus = MessageBus()
+    push_tool = MessagePushTool()
+    old = _RegisteredChannel()
+    failed = _RegisteredChannel(fail_start=True)
+    context = SimpleNamespace(
+        bus=message_bus,
+        session_manager=None,
+        event_bus=event_bus,
+        push_tool=push_tool,
+        attachment_store=None,
+        http_resources=None,
+        interrupt_controller=None,
+        bot_commands=[],
+        log="ctx:registered",
+    )
+    host = ChannelHost(lambda _channel: context)  # type: ignore[arg-type]
+    host.add(old)  # type: ignore[arg-type]
+    host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+    await host.start_all()
+
+    with pytest.raises(RuntimeError, match="registered start failed"):
+        await host.swap_plugin_channels(  # type: ignore[arg-type]
+            "chat",
+            (old,),
+            (failed,),
+        )
+
+    assert event_bus.handler_count() == 1
+    assert len(message_bus._subscribers["registered"]) == 1
+    assert await push_tool.execute(
+        channel="registered",
+        chat_id="1",
+        message="hello",
+    ) == "文本已发送"

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
+from agent.tools.message_push import MessagePushTool
 from bootstrap.channel_host import ChannelHost
+from bus.event_bus import EventBus
+from bus.queue import MessageBus
 
 
 class _Channel:
@@ -20,7 +25,7 @@ class _Channel:
         self._fail_stop = fail_stop
 
     async def start(self, ctx: object) -> None:
-        self._events.append(f"start:{self.name}:{ctx}")
+        self._events.append(f"start:{self.name}:{ctx.log}")
         if self._fail_start:
             raise RuntimeError("start failed")
 
@@ -30,19 +35,57 @@ class _Channel:
             raise RuntimeError("stop failed")
 
 
+class _Event:
+    pass
+
+
+class _RegisteredChannel:
+    name = "registered"
+
+    async def start(self, ctx: object) -> None:
+        async def on_outbound(_message: object) -> None:
+            return None
+
+        async def send_text(_chat_id: str, _message: str) -> None:
+            return None
+
+        ctx.event_bus.on(_Event, lambda event: event)
+        ctx.bus.subscribe_outbound(self.name, on_outbound)
+        ctx.push_tool.register_channel(self.name, text=send_text)
+
+    async def stop(self) -> None:
+        return None
+
+
+def _context(channel: _Channel) -> SimpleNamespace:
+    return SimpleNamespace(
+        bus=SimpleNamespace(),
+        session_manager=None,
+        event_bus=SimpleNamespace(),
+        push_tool=SimpleNamespace(),
+        attachment_store=None,
+        http_resources=None,
+        interrupt_controller=None,
+        bot_commands=[],
+        log=f"ctx:{channel.name}",
+    )
+
+
 @pytest.mark.asyncio
 async def test_channel_host_start_failure_does_not_block_others():
     events: list[str] = []
-    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host = ChannelHost(_context)  # type: ignore[arg-type]
     host.add(_Channel("a", events))  # type: ignore[arg-type]
     host.add(_Channel("b", events, fail_start=True))  # type: ignore[arg-type]
     host.add(_Channel("c", events))  # type: ignore[arg-type]
 
-    await host.start_all()
+    with pytest.raises(RuntimeError, match="start failed"):
+        await host.start_all()
 
     assert events == [
         "start:a:ctx:a",
         "start:b:ctx:b",
+        "stop:b",
         "start:c:ctx:c",
     ]
 
@@ -50,10 +93,12 @@ async def test_channel_host_start_failure_does_not_block_others():
 @pytest.mark.asyncio
 async def test_channel_host_stops_in_reverse_order():
     events: list[str] = []
-    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host = ChannelHost(_context)  # type: ignore[arg-type]
     host.add(_Channel("a", events))  # type: ignore[arg-type]
     host.add(_Channel("b", events, fail_stop=True))  # type: ignore[arg-type]
     host.add(_Channel("c", events))  # type: ignore[arg-type]
+    await host.start_all()
+    events.clear()
 
     await host.stop_all()
 
@@ -63,7 +108,7 @@ async def test_channel_host_stops_in_reverse_order():
 @pytest.mark.asyncio
 async def test_channel_host_swaps_plugin_generation():
     events: list[str] = []
-    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host = ChannelHost(_context)  # type: ignore[arg-type]
     old = _Channel("old", events)
     new = _Channel("new", events)
     host.add(old)  # type: ignore[arg-type]
@@ -78,9 +123,9 @@ async def test_channel_host_swaps_plugin_generation():
 @pytest.mark.asyncio
 async def test_channel_host_restores_old_generation_when_start_fails():
     events: list[str] = []
-    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    host = ChannelHost(_context)  # type: ignore[arg-type]
     old = _Channel("old", events)
-    failed = _Channel("new", events, fail_start=True)
+    failed = _Channel("new", events, fail_start=True, fail_stop=True)
     host.add(old)  # type: ignore[arg-type]
     host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
 
@@ -94,3 +139,71 @@ async def test_channel_host_restores_old_generation_when_start_fails():
         "stop:new",
         "start:old:ctx:old",
     ]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_restores_every_old_channel_when_stop_fails():
+    events: list[str] = []
+    host = ChannelHost(_context)  # type: ignore[arg-type]
+    first = _Channel("first", events, fail_stop=True)
+    second = _Channel("second", events)
+    replacement = _Channel("replacement", events)
+    host.add(first)  # type: ignore[arg-type]
+    host.add(second)  # type: ignore[arg-type]
+    host.bind_plugin_channels({"chat": (first, second)})  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await host.swap_plugin_channels(  # type: ignore[arg-type]
+            "chat",
+            (first, second),
+            (replacement,),
+        )
+
+    assert host.channels == [first, second]
+    assert events == [
+        "stop:second",
+        "stop:first",
+        "start:first:ctx:first",
+        "start:second:ctx:second",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_revokes_shared_registrations_on_stop():
+    event_bus = EventBus()
+    message_bus = MessageBus()
+    push_tool = MessagePushTool()
+    channel = _RegisteredChannel()
+    context = SimpleNamespace(
+        bus=message_bus,
+        session_manager=None,
+        event_bus=event_bus,
+        push_tool=push_tool,
+        attachment_store=None,
+        http_resources=None,
+        interrupt_controller=None,
+        bot_commands=[],
+        log="ctx:registered",
+    )
+    host = ChannelHost(lambda _channel: context)  # type: ignore[arg-type]
+    host.add(channel)  # type: ignore[arg-type]
+
+    await host.start_all()
+
+    assert event_bus.handler_count() == 1
+    assert "registered" in message_bus._subscribers
+    assert await push_tool.execute(
+        channel="registered",
+        chat_id="1",
+        message="hello",
+    ) == "文本已发送"
+
+    await host.stop_all()
+
+    assert event_bus.handler_count() == 0
+    assert "registered" not in message_bus._subscribers
+    assert "未注册" in await push_tool.execute(
+        channel="registered",
+        chat_id="1",
+        message="hello",
+    )

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -58,3 +58,39 @@ async def test_channel_host_stops_in_reverse_order():
     await host.stop_all()
 
     assert events == ["stop:c", "stop:b", "stop:a"]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_swaps_plugin_generation():
+    events: list[str] = []
+    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    old = _Channel("old", events)
+    new = _Channel("new", events)
+    host.add(old)  # type: ignore[arg-type]
+    host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+
+    await host.swap_plugin_channels("chat", (old,), (new,))  # type: ignore[arg-type]
+
+    assert host.channels == [new]
+    assert events == ["stop:old", "start:new:ctx:new"]
+
+
+@pytest.mark.asyncio
+async def test_channel_host_restores_old_generation_when_start_fails():
+    events: list[str] = []
+    host = ChannelHost(lambda channel: f"ctx:{channel.name}")  # type: ignore[arg-type]
+    old = _Channel("old", events)
+    failed = _Channel("new", events, fail_start=True)
+    host.add(old)  # type: ignore[arg-type]
+    host.bind_plugin_channels({"chat": (old,)})  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await host.swap_plugin_channels("chat", (old,), (failed,))  # type: ignore[arg-type]
+
+    assert host.channels == [old]
+    assert events == [
+        "stop:old",
+        "start:new:ctx:new",
+        "stop:new",
+        "start:old:ctx:old",
+    ]

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -6,6 +6,7 @@ import pytest
 
 from agent.tools.message_push import MessagePushTool
 from bootstrap.channel_host import ChannelHost
+from bootstrap.app import AppRuntime
 from bus.event_bus import EventBus
 from bus.queue import MessageBus
 
@@ -37,6 +38,33 @@ class _Channel:
 
 class _Event:
     pass
+
+
+class _DependentChannel:
+    def __init__(
+        self,
+        name: str,
+        service: SimpleNamespace,
+        expected: str,
+        events: list[str],
+        *,
+        fail_start: bool = False,
+    ) -> None:
+        self.name = name
+        self._service = service
+        self._expected = expected
+        self._events = events
+        self._fail_start = fail_start
+
+    async def start(self, _ctx: object) -> None:
+        assert self._service.version == self._expected
+        self._events.append(f"start:{self.name}:{self._service.version}")
+        if self._fail_start:
+            raise RuntimeError("dependent start failed")
+
+    async def stop(self) -> None:
+        assert self._service.version == self._expected
+        self._events.append(f"stop:{self.name}:{self._service.version}")
 
 
 class _RegisteredChannel:
@@ -278,3 +306,55 @@ async def test_channel_host_restores_shared_registrations_after_failed_swap():
         chat_id="1",
         message="hello",
     ) == "文本已发送"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_transaction_orders_channel_around_service_and_rolls_back():
+    events: list[str] = []
+    service = SimpleNamespace(version="v1")
+    old = _DependentChannel("old", service, "v1", events)
+    failed = _DependentChannel(
+        "new",
+        service,
+        "v2",
+        events,
+        fail_start=True,
+    )
+    channel_host = ChannelHost(lambda _channel: _context(_channel))  # type: ignore[arg-type]
+    channel_host.add(old)  # type: ignore[arg-type]
+    channel_host.bind_plugin_channels({"combined": (old,)})  # type: ignore[arg-type]
+    await channel_host.start_all()
+    events.clear()
+
+    class ServiceHost:
+        async def swap_plugin_services(self, _plugin_id, before, after) -> None:
+            assert service.version == before["worker"]["version"]
+            service.version = after["worker"]["version"]
+            events.append(f"service:{service.version}")
+
+    runtime = object.__new__(AppRuntime)
+    runtime.channel_host = channel_host
+    runtime.plugin_service_host = ServiceHost()
+    v1 = {"worker": {"version": "v1"}}
+    v2 = {"worker": {"version": "v2"}}
+
+    with pytest.raises(RuntimeError, match="dependent start failed"):
+        await runtime._swap_plugin_endpoints(
+            "combined",
+            v1,
+            v2,
+            (old,),
+            (failed,),
+        )
+
+    assert service.version == "v1"
+    assert channel_host.channels == [old]
+    assert events == [
+        "stop:old:v1",
+        "service:v2",
+        "start:new:v2",
+        "stop:new:v2",
+        "service:v1",
+        "start:old:v1",
+    ]
+    await channel_host.stop_all()

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -5,9 +5,11 @@ from concurrent.futures import ThreadPoolExecutor
 import json
 import sqlite3
 import threading
+import tomllib
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient as _RawTestClient
 
 from bootstrap.dashboard_api import (
@@ -822,6 +824,19 @@ def test_standalone_dashboard_honors_builtin_plugin_manifest(
 
     assert "akasha" not in plugins
     assert "default_memory" in plugins
+
+
+def test_standalone_dashboard_rejects_invalid_manifest(
+    tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    manifest_path = home / ".akashic-plugin" / "manifest.toml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("invalid = [\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+
+    with pytest.raises(tomllib.TOMLDecodeError):
+        _dashboard_plugin_dirs(Path.cwd())
 
 
 def test_installed_plugin_dashboard_supports_relative_imports(tmp_path, monkeypatch) -> None:

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -6,10 +6,14 @@ import json
 import sqlite3
 import threading
 from datetime import datetime
+from pathlib import Path
 
 from fastapi.testclient import TestClient as _RawTestClient
 
-from bootstrap.dashboard_api import create_dashboard_app as _create_dashboard_app
+from bootstrap.dashboard_api import (
+    _dashboard_plugin_dirs,
+    create_dashboard_app as _create_dashboard_app,
+)
 from plugins.default_memory.engine import DefaultMemoryEngine
 from memory2.store import MemoryStore2
 from proactive_v2.state import ProactiveStateStore
@@ -800,6 +804,24 @@ def test_dashboard_lists_installed_plugin_panels(tmp_path, monkeypatch) -> None:
             }
         ],
     }
+
+
+def test_standalone_dashboard_honors_builtin_plugin_manifest(
+    tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    manifest_path = home / ".akashic-plugin" / "manifest.toml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        '[plugins.akasha]\nenabled = false\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+
+    plugins = _dashboard_plugin_dirs(Path.cwd())
+
+    assert "akasha" not in plugins
+    assert "default_memory" in plugins
 
 
 def test_installed_plugin_dashboard_supports_relative_imports(tmp_path, monkeypatch) -> None:

--- a/tests/test_internal_events.py
+++ b/tests/test_internal_events.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass, field
 
 import pytest
@@ -130,3 +131,31 @@ async def test_event_bus_enqueue_runs_observers_in_background():
 
     assert observed == ["ok"]
     await event_bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_self_cancelled_observer_does_not_stall_close():
+    event_bus = EventBus()
+    observed: list[str] = []
+
+    async def cancel_self(event: _FakeLifecycleEvent) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        task.cancel()
+        await asyncio.sleep(0)
+
+    event_bus.on(_FakeLifecycleEvent, cancel_self)
+    event_bus.on(_FakeLifecycleEvent, lambda event: observed.append(event.content))
+    for content in ("first", "second"):
+        event_bus.enqueue(
+            _FakeLifecycleEvent(
+                session_key="telegram:123",
+                channel="telegram",
+                chat_id="123",
+                content=content,
+            )
+        )
+
+    await asyncio.wait_for(event_bus.aclose(), timeout=1)
+
+    assert observed == ["first", "second"]

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -571,6 +571,20 @@ async def test_mcp_client_disconnect_kills_after_terminate_timeout(
 
 
 @pytest.mark.asyncio
+async def test_mcp_client_disconnect_reports_cleanup_error() -> None:
+    proc = _Proc([])
+    proc.stdin.close = MagicMock(side_effect=OSError("stdin close failed"))
+    client = McpClient("docs", ["python", "server.py"])
+    client._process = proc
+
+    with pytest.raises(OSError, match="stdin close failed"):
+        await client.disconnect()
+
+    assert proc.killed is True
+    assert client._process is None
+
+
+@pytest.mark.asyncio
 async def test_mcp_client_serializes_calls_on_same_server():
     class ConcurrentReadPipe(_Pipe):
         def __init__(self) -> None:

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -363,6 +363,11 @@ async def test_ipc_server_channel_covers_connection_command_and_response(
     loop = SimpleNamespace()
     channel = IPCServerChannel(bus, str(tmp_path / "agent.sock"), None)
 
+    async def noop(data: dict[str, object]) -> str:
+        return str(data["command"])
+
+    channel.register_command("noop", noop)
+
     server = SimpleNamespace(close=MagicMock(), wait_closed=AsyncMock())
     chmod = MagicMock()
     monkeypatch.setattr("infra.channels.ipc_server.os.chmod", chmod)
@@ -411,6 +416,7 @@ async def test_ipc_server_channel_covers_connection_command_and_response(
     assert inbound.content == "hello"
     assert any("command_result" in payload.decode() for payload in writes)
     assert any('"ok": false' in payload.decode() for payload in writes)
+    assert any('"ok": true' in payload.decode() for payload in writes)
     assert any("unknown command" in payload.decode() for payload in writes)
 
     msg = OutboundMessage(channel="cli", chat_id="missing", content="hi")

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -585,6 +585,35 @@ async def test_mcp_client_disconnect_reports_cleanup_error() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["initialize", "tools/list"])
+async def test_mcp_client_rejects_json_rpc_error_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    responses = (
+        [b'{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"bad init"}}\n']
+        if stage == "initialize"
+        else [
+            b'{"jsonrpc":"2.0","id":1,"result":{}}\n',
+            b'{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"bad list"}}\n',
+        ]
+    )
+    proc = _Proc(responses)
+    monkeypatch.setattr(
+        "agent.mcp.client.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+    client = McpClient("broken", ["python", "server.py"])
+
+    with pytest.raises(RuntimeError, match=stage):
+        await client.connect()
+
+    assert client._process is None
+    assert client._stderr_task is None
+    assert proc.stdin.closed is True
+
+
+@pytest.mark.asyncio
 async def test_mcp_client_serializes_calls_on_same_server():
     class ConcurrentReadPipe(_Pipe):
         def __init__(self) -> None:

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -336,6 +336,13 @@ async def test_proactive_loop_wrapper_methods_cover_paths(tmp_path: Path):
         default_chat_id="42",
     )
     loop._running = False
+    loop._runtime_snapshot_store = None
+    loop._stopped = asyncio.Event()
+    loop._wake = asyncio.Event()
+    loop._reload_lock = asyncio.Lock()
+    loop._kernel_started = False
+    loop._active_kernel_lease = None
+    loop._active_snapshot_id = None
     loop._trace_proactive_rate_decision = MagicMock()
     loop._presence = SimpleNamespace(
         get_last_user_at=lambda session_key: datetime.now(timezone.utc)

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -7,12 +7,14 @@ import py_compile
 import shutil
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from agent.plugins.manager import PluginManager
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
+from agent.looping.core import AgentLoop
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
 
@@ -1319,4 +1321,62 @@ async def test_snapshot_compile_failure_does_not_publish_plugin(
     assert plugin_registry.get_instance("akasic_plugin_plugins_second_snapshot") is None
     state = tmp_path / "home" / "data" / "second_snapshot-builtin" / ".kv.json"
     assert not state.exists()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_passive_runtime_admission_holds_one_snapshot(tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "passive_snapshot",
+        "from agent.plugins import Plugin\n"
+        "class PassiveSnapshotPlugin(Plugin):\n"
+        "    name = 'passive_snapshot'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("passive_snapshot")
+    prepared = await manager.prepare_candidate("passive_snapshot")
+    assert active is not None and prepared is not None
+    compiler = RuntimeSnapshotCompiler()
+    v1 = compiler.compile({"passive_snapshot": active}, catalog_generation=active)
+    v2 = compiler.compile(
+        {"passive_snapshot": prepared},
+        catalog_generation=prepared,
+    )
+    store = RuntimeSnapshotStore()
+    store.install(v1)
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = store
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[str] = []
+
+    async def process(msg, **kwargs):
+        from agent.plugins.snapshot import current_runtime_snapshot
+
+        snapshot = current_runtime_snapshot.get()
+        assert snapshot is not None
+        seen.append(snapshot.snapshot_id)
+        entered.set()
+        await release.wait()
+        assert current_runtime_snapshot.get() is snapshot
+        seen.append(snapshot.snapshot_id)
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:snapshot")
+    running = asyncio.create_task(loop._process_with_runtime_admission(message))
+    await entered.wait()
+    transaction = store.begin_publish(v2)
+    await store.commit(transaction)
+    release.set()
+
+    assert await running == "done"
+    assert seen == [v1.snapshot_id, v1.snapshot_id]
+    await loop._process_with_runtime_admission(message)
+    assert seen[-2:] == [v2.snapshot_id, v2.snapshot_id]
+    await store.close()
+    await manager.discard_prepared("passive_snapshot")
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -217,3 +218,299 @@ async def test_same_source_gets_new_generation_namespace_after_restart(tmp_path:
     assert second is not None
     assert second.generation_id != first.generation_id
     assert second.module_path != first.module_path
+
+
+@pytest.mark.asyncio
+async def test_candidate_declaration_cannot_write_plugin_kv(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "readonly",
+        "from agent.plugins import Plugin\n"
+        "class ReadonlyPlugin(Plugin):\n"
+        "    name = 'readonly'\n"
+        "    def before_turn_modules(self):\n"
+        "        self.context.kv_store.set('leaked', True)\n"
+        "        return []\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("readonly")
+    kv_path = tmp_path / "home" / "data" / "readonly-builtin" / ".kv.json"
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "declarations"
+    assert not kv_path.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "declaration",
+    (
+        "raise RuntimeError('declaration failed')",
+        "return 'not-a-list'",
+        "return None",
+    ),
+)
+async def test_invalid_declaration_fails_gate(tmp_path: Path, declaration: str):
+    _write_plugin(
+        tmp_path / "plugins",
+        "invalid_declaration",
+        "from agent.plugins import Plugin\n"
+        "class InvalidDeclarationPlugin(Plugin):\n"
+        "    name = 'invalid_declaration'\n"
+        "    def before_turn_modules(self):\n"
+        f"        {declaration}\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("invalid_declaration")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "declarations"
+    assert manager.generation("invalid_declaration") is None
+
+
+@pytest.mark.asyncio
+async def test_candidate_phase_graph_includes_active_plugins(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "first",
+        "from agent.plugins import Plugin\n"
+        "class Module:\n"
+        "    slot = 'plugin.shared'\n"
+        "class FirstPlugin(Plugin):\n"
+        "    name = 'first'\n"
+        "    def before_turn_modules(self): return [Module()]\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    _write_plugin(
+        tmp_path / "plugins",
+        "second",
+        "from agent.plugins import Plugin\n"
+        "class Module:\n"
+        "    slot = 'plugin.shared'\n"
+        "class SecondPlugin(Plugin):\n"
+        "    name = 'second'\n"
+        "    def before_turn_modules(self): return [Module()]\n",
+    )
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("second")
+    assert manager.generation("first") is not None
+    assert manager.generation("second") is None
+    assert gate is not None and gate.status == "failed"
+    assert "phase_graph" in {
+        check.check_id for check in gate.checks if check.status == "failed"
+    }
+
+
+@pytest.mark.asyncio
+async def test_initialize_failure_replaces_passed_gate(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "init_failure",
+        "from agent.plugins import Plugin\n"
+        "class InitFailurePlugin(Plugin):\n"
+        "    name = 'init_failure'\n"
+        "    async def initialize(self): raise RuntimeError('init failed')\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("init_failure")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "initialize"
+    assert manager.generation("init_failure") is None
+
+
+@pytest.mark.asyncio
+async def test_generation_module_tree_is_removed_on_config_failure_and_terminate(
+    tmp_path: Path,
+):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "module_tree",
+        "from pydantic import BaseModel\n"
+        "from agent.plugins import Plugin\n"
+        "from . import child\n"
+        "class Config(BaseModel):\n"
+        "    required: str\n"
+        "class ModuleTreePlugin(Plugin):\n"
+        "    name = 'module_tree'\n"
+        "    ConfigModel = Config\n",
+    )
+    _ = (plugin_dir / "child.py").write_text("value = 1\n", encoding="utf-8")
+    config_dir = tmp_path / "home" / "data" / "module_tree-builtin"
+    config_dir.mkdir(parents=True)
+    _ = (config_dir / "config.local.toml").write_text("", encoding="utf-8")
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    assert manager.latest_gate("module_tree").status == "failed"  # type: ignore[union-attr]
+    assert not any("plugins_module_tree__g" in name for name in sys.modules)
+
+    _ = (config_dir / "config.local.toml").write_text(
+        "required = 'ok'\n",
+        encoding="utf-8",
+    )
+    await manager.load_all()
+    generation = manager.generation("module_tree")
+    assert generation is not None
+    assert f"{generation.module_path}.child" in sys.modules
+
+    await manager.terminate_all()
+
+    assert not any("plugins_module_tree__g" in name for name in sys.modules)
+
+
+@pytest.mark.asyncio
+async def test_candidate_is_not_published_before_initialize_finishes(tmp_path: Path):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "pending",
+        "import asyncio\n"
+        "from agent.plugins import Plugin, tool\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class PendingPlugin(Plugin):\n"
+        "    name = 'pending'\n"
+        "    @tool(name='pending_tool')\n"
+        "    async def pending_tool(self, event):\n"
+        "        \"\"\"Pending tool.\"\"\"\n"
+        "        return 'ready'\n"
+        "    async def initialize(self):\n"
+        "        self.context.event_bus.on(TurnCommitted, self.on_turn)\n"
+        "        while not (self.context.plugin_dir / 'release').exists():\n"
+        "            await asyncio.sleep(0.01)\n"
+        "    def on_turn(self, event): return None\n",
+    )
+    tools = ToolRegistry()
+    event_bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        tool_registry=tools,
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+
+    loading = asyncio.create_task(manager.load_all())
+    while manager.latest_gate("pending") is None:
+        await asyncio.sleep(0.01)
+
+    assert manager.latest_gate("pending").status == "passed"  # type: ignore[union-attr]
+    assert manager.generation("pending") is None
+    assert tools.get_tool("pending_tool") is None
+    assert event_bus.handler_count() == 0
+
+    _ = (plugin_dir / "release").write_text("ok", encoding="utf-8")
+    await loading
+
+    assert manager.generation("pending") is not None
+    assert tools.get_tool("pending_tool") is not None
+    assert event_bus.handler_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_same_plugin_keeps_active_generation_until_snapshot_publish(
+    tmp_path: Path,
+):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "replaceable",
+        "from agent.plugins import Plugin, tool\n"
+        "class ReplaceablePlugin(Plugin):\n"
+        "    name = 'replaceable'\n"
+        "    @tool(name='replaceable_tool')\n"
+        "    async def run(self, event):\n"
+        "        \"\"\"Replaceable tool.\"\"\"\n"
+        "        return 'v1'\n",
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+    active = manager.generation("replaceable")
+    assert active is not None
+
+    _ = (plugin_dir / "plugin.py").write_text("not valid python !!!\n", encoding="utf-8")
+    rejected = await manager.prepare_candidate("replaceable")
+
+    assert rejected is None
+    assert manager.generation("replaceable") is active
+    assert manager.prepared_generation("replaceable") is None
+    assert manager.latest_gate("replaceable").status == "failed"  # type: ignore[union-attr]
+    assert tools.get_tool("replaceable_tool") is not None
+
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin, tool\n"
+        "class ReplaceablePlugin(Plugin):\n"
+        "    name = 'replaceable'\n"
+        "    @tool(name='replaceable_tool')\n"
+        "    async def run(self, event):\n"
+        "        \"\"\"Replaceable tool.\"\"\"\n"
+        "        return 'v2'\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('initialized_v2', True)\n",
+        encoding="utf-8",
+    )
+    prepared = await manager.prepare_candidate("replaceable")
+
+    assert prepared is not None and prepared.state == "prepared"
+    assert manager.generation("replaceable") is active
+    assert manager.prepared_generation("replaceable") is prepared
+    assert manager.latest_gate("replaceable").status == "passed"  # type: ignore[union-attr]
+    assert not (
+        tmp_path / "home" / "data" / "replaceable-builtin" / ".kv.json"
+    ).exists()
+    assert tools.get_tool("replaceable_tool") is not None
+
+
+@pytest.mark.asyncio
+async def test_source_revision_includes_helper_changes(tmp_path: Path):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "revision",
+        "from agent.plugins import Plugin\n"
+        "from . import helper\n"
+        "class RevisionPlugin(Plugin):\n"
+        "    name = 'revision'\n",
+    )
+    helper = plugin_dir / "helper.py"
+    _ = helper.write_text("value = 1\n", encoding="utf-8")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("revision")
+    assert active is not None
+
+    _ = helper.write_text("value = 2\n", encoding="utf-8")
+    prepared = await manager.prepare_candidate("revision")
+
+    assert prepared is not None
+    assert prepared.source_revision != active.source_revision
+
+
+@pytest.mark.asyncio
+async def test_declared_paths_cannot_escape_plugin_root(tmp_path: Path):
+    outside = tmp_path / "plugins" / "outside" / "skill"
+    outside.mkdir(parents=True)
+    _ = (outside / "SKILL.md").write_text("# outside\n", encoding="utf-8")
+    _write_plugin(
+        tmp_path / "plugins",
+        "escaped",
+        "from agent.plugins import Plugin\n"
+        "class EscapedPlugin(Plugin):\n"
+        "    name = 'escaped'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('../outside',)\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("escaped")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "declarations"

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2722,11 +2722,20 @@ async def test_dashboard_candidate_cannot_override_core_route(tmp_path: Path) ->
         "    def dashboard_module(cls): return 'dashboard.py'\n",
     )
 
-    def write_dashboard(path: str) -> None:
+    def write_dashboard(path: str, *, async_close: bool = False) -> None:
+        cleanup = (
+            "    class Closeable:\n"
+            "        async def close(self):\n"
+            "            (workspace / 'async-dashboard-closed').write_text('closed')\n"
+            "    return Closeable()\n"
+            if async_close
+            else ""
+        )
         _ = (plugin_dir / "dashboard.py").write_text(
             "def register(app, plugin_dir, workspace):\n"
             f"    @app.get('{path}')\n"
-            "    def route(): return {'owner': 'plugin'}\n",
+            "    def route(): return {'owner': 'plugin'}\n"
+            f"{cleanup}",
             encoding="utf-8",
         )
 
@@ -2739,13 +2748,14 @@ async def test_dashboard_candidate_cannot_override_core_route(tmp_path: Path) ->
         memory_admin=SimpleNamespace(),
         plugin_manager=manager,
     )
-    write_dashboard("/api/dashboard/sessions")
+    write_dashboard("/api/dashboard/sessions", async_close=True)
     assert await manager.prepare_candidate("dashboard_conflict") is not None
 
     result = await manager.publish_prepared("dashboard_conflict")
 
     assert result["publication_state"] == "failed"
     assert manager.generation("dashboard_conflict") is old_generation
+    assert (tmp_path / "workspace" / "async-dashboard-closed").exists()
     assert TestClient(app).get("/api/dashboard/plugin-owned").json() == {
         "owner": "plugin"
     }

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1884,7 +1884,7 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     _ = (plugin_dir / "plugin.py").write_text(source("v2"), encoding="utf-8")
     candidate = await manager.prepare_candidate("snapshot_skill")
     assert candidate is not None
-    skills = SkillsLoader(workspace)
+    skills = SkillsLoader(workspace, runtime_catalog="normal")
     loop = object.__new__(AgentLoop)
     loop._passive_runtime_lock = asyncio.Lock()
     loop._runtime_snapshot_store = manager.snapshot_store
@@ -1910,4 +1910,50 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
 
     assert seen[:2] == ["body v1", "body v1"]
     assert seen[2:] == ["body v2", "body v2"]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_workspace_skill_updates_without_plugin_snapshot_reload(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "workspace_skill_snapshot",
+        "from agent.plugins import Plugin\n"
+        "class WorkspaceSkillSnapshotPlugin(Plugin):\n"
+        "    name = 'workspace_skill_snapshot'\n",
+    )
+    workspace = tmp_path / "workspace"
+    skill_dir = workspace / "skills" / "workspace-live"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    _ = skill_file.write_text(
+        "---\ndescription: workspace live\n---\nworkspace v1\n",
+        encoding="utf-8",
+    )
+    manager = _manager(tmp_path, workspace=workspace)
+    await manager.load_all()
+    snapshot = manager.current_snapshot
+    skills = SkillsLoader(workspace, runtime_catalog="normal")
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = manager.snapshot_store
+    seen: list[str | None] = []
+
+    async def process(msg, **kwargs):
+        seen.append(skills.load_skill_body("workspace-live"))
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:workspace-skill")
+    await loop._process_with_runtime_admission(message)
+    _ = skill_file.write_text(
+        "---\ndescription: workspace live\n---\nworkspace v2\n",
+        encoding="utf-8",
+    )
+    await loop._process_with_runtime_admission(message)
+
+    assert manager.current_snapshot is snapshot
+    assert seen == ["workspace v1", "workspace v2"]
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2217,6 +2217,36 @@ async def test_plugin_watcher_reconciles_change_arriving_during_scan() -> None:
     assert manager.calls >= 2
 
 
+@pytest.mark.asyncio
+async def test_plugin_watcher_recovers_after_revision_scan_error() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.scans = 0
+            self.calls = 0
+
+        def watch_revision(self) -> str:
+            self.scans += 1
+            if self.scans == 1:
+                raise PermissionError("transient")
+            return "ready"
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            self.calls += 1
+            return []
+
+    manager = Manager()
+    watcher = PluginWatcher(manager, interval_seconds=0.01)  # type: ignore[arg-type]
+    task = asyncio.create_task(watcher.run())
+    for _ in range(100):
+        if manager.calls:
+            break
+        await asyncio.sleep(0.01)
+
+    watcher.stop()
+    await task
+    assert manager.calls == 1
+
+
 def _snapshot_tool_source(version: str) -> str:
     return (
         "from agent.plugins import Plugin, tool\n"

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2282,6 +2282,57 @@ async def test_event_observers_keep_snapshot_binding_in_isolated_tasks() -> None
 
 
 @pytest.mark.asyncio
+async def test_cancelled_fanout_releases_unstarted_observer_leases() -> None:
+    event_bus = EventBus()
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({})
+    store.install(snapshot)
+    event_bus.bind_runtime_snapshot_store(store)
+
+    async def observe(_event: str) -> None:
+        await asyncio.sleep(0)
+
+    for _ in range(20):
+        event_bus.on(str, observe)
+
+    task = asyncio.current_task()
+    assert task is not None
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await event_bus.fanout("cancel")
+    await asyncio.sleep(0)
+
+    assert snapshot.lease_count == 0
+    await event_bus.aclose()
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_running_fanout_cancellation_releases_observer_leases() -> None:
+    event_bus = EventBus()
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({})
+    store.install(snapshot)
+    event_bus.bind_runtime_snapshot_store(store)
+    entered = asyncio.Event()
+
+    async def observe(_event: str) -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    event_bus.on(str, observe)
+    fanout = asyncio.create_task(event_bus.fanout("cancel"))
+    await entered.wait()
+    _ = fanout.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await fanout
+
+    assert snapshot.lease_count == 0
+    await event_bus.aclose()
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins" / "snapshot_skill"
     for version in ("v1", "v2"):

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2255,6 +2255,33 @@ async def test_event_bus_shutdown_drains_snapshot_lease_before_plugins(
 
 
 @pytest.mark.asyncio
+async def test_event_observers_keep_snapshot_binding_in_isolated_tasks() -> None:
+    event_bus = EventBus()
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({})
+    store.install(snapshot)
+    event_bus.bind_runtime_snapshot_store(store)
+    seen: list[str | None] = []
+
+    async def observe_snapshot(_event: str) -> None:
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        current = get_current_runtime_snapshot()
+        seen.append(current.snapshot_id if current is not None else None)
+
+    event_bus.on(str, observe_snapshot)
+
+    await event_bus.observe("observe")
+    await event_bus.fanout("fanout")
+    event_bus.enqueue("queued")
+    await event_bus.drain()
+
+    assert seen == [snapshot.snapshot_id] * 3
+    await event_bus.aclose()
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins" / "snapshot_skill"
     for version in ("v1", "v2"):

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1856,6 +1856,72 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
 
 
 @pytest.mark.asyncio
+async def test_removed_plugin_mcp_server_does_not_leak_from_live_registry(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "removed_mcp",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class RemovedMcpPlugin(Plugin):\n"
+        "    name = 'removed_mcp'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='removed_server', command=('python', 'server.py'))]\n",
+    )
+    _ = (plugin_dir / "server.py").write_text("", encoding="utf-8")
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+
+    class LegacyPluginMcpTool(Tool):
+        name = "mcp_removed_server__legacy"
+        description = "legacy"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self) -> str:
+            return "legacy"
+
+    tools.register(
+        LegacyPluginMcpTool(),
+        source_type="mcp",
+        source_name="removed_server",
+    )
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class RemovedMcpPlugin(Plugin):\n"
+        "    name = 'removed_mcp'\n",
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("removed_mcp")
+    assert candidate is not None and candidate.runtime_snapshot is not None
+    registry = candidate.runtime_snapshot.tool_registry
+    assert registry is not None
+    assert registry.has_tool("mcp_removed_server__legacy") is False
+    await manager.discard_prepared("removed_mcp")
+    await manager.terminate_all()
+
+
+def test_tool_registry_fork_preserves_registration_order() -> None:
+    registry = ToolRegistry()
+
+    class OrderedTool(Tool):
+        name = "ordered_base"
+        description = "ordered"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self) -> str:
+            return self.name
+
+    expected = [f"ordered_{index:02d}" for index in range(20)]
+    for name in expected:
+        tool_class = type(f"Tool_{name}", (OrderedTool,), {"name": name})
+        registry.register(tool_class())
+
+    assert registry.fork().get_registered_order() == expected
+
+
+@pytest.mark.asyncio
 async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins" / "snapshot_skill"
     for version in ("v1", "v2"):
@@ -1881,6 +1947,12 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     workspace.mkdir()
     manager = _manager(tmp_path, workspace=workspace)
     await manager.load_all()
+    workspace_skills = workspace / "skills"
+    workspace_skills.mkdir()
+    (workspace_skills / "snapshot-skill").symlink_to(
+        plugin_dir / "skills-v1" / "snapshot-skill",
+        target_is_directory=True,
+    )
     _ = (plugin_dir / "plugin.py").write_text(source("v2"), encoding="utf-8")
     candidate = await manager.prepare_candidate("snapshot_skill")
     assert candidate is not None
@@ -1904,6 +1976,10 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
     await entered.wait()
     await manager.publish_prepared("snapshot_skill")
+    _ = (plugin_dir / "skills-v1" / "snapshot-skill" / "SKILL.md").write_text(
+        "---\ndescription: mutated source\n---\nmutated v1\n",
+        encoding="utf-8",
+    )
     release.set()
     assert await old_turn == "done"
     await loop._process_with_runtime_admission(message)

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -643,23 +643,31 @@ async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path)
 
 @pytest.mark.asyncio
 async def test_terminating_one_manager_keeps_newer_stable_alias(tmp_path: Path):
-    _write_plugin(
+    plugin_dir = _write_plugin(
         tmp_path / "plugins",
         "shared_alias",
         "from agent.plugins import Plugin\n"
         "class SharedAliasPlugin(Plugin):\n"
         "    name = 'shared_alias'\n",
     )
+    child = plugin_dir / "child.py"
+    _ = child.write_text("value = 'v1'\n", encoding="utf-8")
     first_manager = _manager(tmp_path)
     second_manager = _manager(tmp_path)
     await first_manager.load_all()
+    stable_alias = "akasic_plugin_plugins_shared_alias"
+    first_child = importlib.import_module(f"{stable_alias}.child")
+    assert first_child.value == "v1"
+    _ = child.write_text("value = 'v2'\n", encoding="utf-8")
     await second_manager.load_all()
     second = second_manager.generation("shared_alias")
     assert second is not None
+    second_child = importlib.import_module(f"{stable_alias}.child")
+    assert second_child.value == "v2"
+    assert second_child is not first_child
 
     await first_manager.terminate_all()
 
-    stable_alias = "akasic_plugin_plugins_shared_alias"
     assert plugin_registry.get_instance(stable_alias) is second.instance
     assert sys.modules[stable_alias] is sys.modules[second.module_path]
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -922,28 +922,30 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "    name = 'mcp_ready'\n"
         "    def __init__(self):\n"
         "        self.job_spec = PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)\n"
+        "        self.source_spec = ProactiveSourceSpec(id='feed', channels=['content'], server='feed', fetch_tool='fetch_events', ack_tool='ack_events', poll_tool='poll_events')\n"
         "    @classmethod\n"
         "    def mcp_servers(cls):\n"
         "        return [McpServerSpec(name='feed', command=('python', 'server.py'))]\n"
         "    def proactive_sources(self):\n"
-        "        return [ProactiveSourceSpec(id='feed', channels=('content',), "
-        "server='feed', fetch_tool='fetch_events', ack_tool='ack_events', "
-        "poll_tool='poll_events')]\n"
+        "        return [self.source_spec]\n"
         "    def jobs(self):\n"
         "        return [self.job_spec]\n"
         "    async def initialize(self):\n"
         "        self.job_spec.triggers.append(object())\n"
+        "        self.source_spec.channels.append('invalid')\n"
         "    async def refresh(self, context):\n"
         "        return None\n"
         "    async def readiness_semantic_checks(self, context):\n"
         "        self.job_spec.triggers.append(object())\n"
+        "        self.source_spec.channels.append('invalid')\n"
         "        value = await context.mcp_catalog.servers['feed'].client.call('fetch_events', {})\n"
         "        job = context.job_catalog.jobs['mcp_ready:refresh']\n"
         "        source = context.proactive_catalog.sources['mcp_ready:feed']\n"
         "        owned = getattr(job.spec.handler, '__self__', None) is self\n"
         "        frozen = len(job.spec.triggers) == 1\n"
-        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id, 'frozen': frozen}\n"
-        "        return [PluginSemanticCheck('candidate_feed', value == '[]' and owned and frozen, evidence)]\n",
+        "        source_frozen = source.spec.channels == ('content',)\n"
+        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id, 'frozen': frozen, 'source_frozen': source_frozen}\n"
+        "        return [PluginSemanticCheck('candidate_feed', value == '[]' and owned and frozen and source_frozen, evidence)]\n",
     )
     _write_mcp_server(
         plugin_dir,
@@ -955,8 +957,10 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     active = manager.generation("mcp_ready")
     assert active is not None and active.job_catalog is not None
     active_job = manager.jobs[0]
+    active_source = manager.proactive_sources[0]
     assert isinstance(active_job.spec.triggers, tuple)
     assert len(active_job.spec.triggers) == 1
+    assert active_source.spec.channels == ("content",)
 
     prepared = await manager.prepare_candidate("mcp_ready")
 
@@ -980,6 +984,9 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     assert tuple(catalog.servers) == ("feed",)
     assert tuple(prepared.job_catalog.jobs) == ("mcp_ready:refresh",)
     assert tuple(prepared.proactive_catalog.sources) == ("mcp_ready:feed",)
+    assert prepared.proactive_catalog.sources["mcp_ready:feed"].spec.channels == (
+        "content",
+    )
     prepared_job = prepared.job_catalog.jobs["mcp_ready:refresh"]
     assert isinstance(prepared_job.spec.triggers, tuple)
     assert len(prepared_job.spec.triggers) == 1

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -12,6 +12,7 @@ import pytest
 
 from agent.plugins.manager import PluginManager
 from agent.plugins.registry import plugin_registry
+from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
 
@@ -1145,4 +1146,65 @@ async def test_candidate_mcp_cleanup_failure_is_reported_and_catalog_removed(
         and "mcp cleanup failed" in failure.error
         for failure in manager.cleanup_failures
     )
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotPlugin(Plugin):\n"
+        "    name = 'snapshot'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot")
+    installed = manager.current_snapshot
+    prepared = await manager.prepare_candidate("snapshot")
+    assert active is not None and prepared is not None and installed is not None
+    assert installed.generations["snapshot"] is active
+    assert installed.state == "committed"
+    assert manager.current_snapshot is installed
+    compiler = RuntimeSnapshotCompiler()
+    v1 = compiler.compile({"snapshot": active}, catalog_generation=active)
+    v2 = compiler.compile({"snapshot": prepared}, catalog_generation=prepared)
+    drained: list[str] = []
+
+    async def on_drained(snapshot) -> None:
+        drained.append(snapshot.snapshot_id)
+
+    store = RuntimeSnapshotStore(on_drained)
+    store.install(v1)
+    v1_lease = store.lease()
+    assert v1_lease.snapshot is v1
+    transaction = store.begin_publish(v2)
+    assert store.current is v2
+    v2_lease = store.lease()
+
+    await store.abort(transaction)
+
+    assert store.current is v1
+    assert drained == []
+    await v2_lease.release()
+    assert drained == [v2.snapshot_id]
+    await v1_lease.release()
+    assert active.lease_count == 0
+    assert prepared.lease_count == 0
+
+    next_v2 = compiler.compile({"snapshot": prepared}, catalog_generation=prepared)
+    held_v1 = store.lease()
+    committed = store.begin_publish(next_v2)
+    await store.commit(committed)
+
+    assert store.current is next_v2
+    assert drained == [v2.snapshot_id]
+    with pytest.raises(RuntimeError, match="不可租用"):
+        _ = store.lease(v1.snapshot_id)
+    await held_v1.release()
+    assert drained == [v2.snapshot_id, v1.snapshot_id]
+    await store.close()
+    assert drained == [v2.snapshot_id, v1.snapshot_id, next_v2.snapshot_id]
+    await manager.discard_prepared("snapshot")
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1295,7 +1295,9 @@ async def test_snapshot_compile_failure_does_not_publish_plugin(
         "second_snapshot",
         "from agent.plugins import Plugin\n"
         "class SecondSnapshotPlugin(Plugin):\n"
-        "    name = 'second_snapshot'\n",
+        "    name = 'second_snapshot'\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('initialized', True)\n",
     )
     compile_snapshot = manager._snapshot_compiler.compile
 
@@ -1315,4 +1317,6 @@ async def test_snapshot_compile_failure_does_not_publish_plugin(
     assert manager.loaded_count == 1
     assert manager.generation("second_snapshot") is None
     assert plugin_registry.get_instance("akasic_plugin_plugins_second_snapshot") is None
+    state = tmp_path / "home" / "data" / "second_snapshot-builtin" / ".kv.json"
+    assert not state.exists()
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -916,7 +916,8 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     plugin_dir = _write_plugin(
         tmp_path / "plugins",
         "mcp_ready",
-        "from agent.plugins import McpServerSpec, Plugin, PluginSemanticCheck, ProactiveSourceSpec\n"
+        "from agent.plugins import (IntervalTrigger, McpServerSpec, Plugin, PluginJobSpec, "
+        "PluginSemanticCheck, ProactiveSourceSpec)\n"
         "class McpReadyPlugin(Plugin):\n"
         "    name = 'mcp_ready'\n"
         "    @classmethod\n"
@@ -926,9 +927,17 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "        return [ProactiveSourceSpec(id='feed', channels=('content',), "
         "server='feed', fetch_tool='fetch_events', ack_tool='ack_events', "
         "poll_tool='poll_events')]\n"
+        "    def jobs(self):\n"
+        "        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)]\n"
+        "    async def refresh(self, context):\n"
+        "        return None\n"
         "    async def readiness_semantic_checks(self, context):\n"
         "        value = await context.mcp_catalog.servers['feed'].client.call('fetch_events', {})\n"
-        "        return [PluginSemanticCheck('candidate_feed', value == '[]', value)]\n",
+        "        job = context.job_catalog.jobs['mcp_ready:refresh']\n"
+        "        source = context.proactive_catalog.sources['mcp_ready:feed']\n"
+        "        owned = getattr(job.spec.handler, '__self__', None) is self\n"
+        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id}\n"
+        "        return [PluginSemanticCheck('candidate_feed', value == '[]' and owned, evidence)]\n",
     )
     _write_mcp_server(
         plugin_dir,
@@ -937,10 +946,18 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     tools = ToolRegistry()
     manager = _manager(tmp_path, tools=tools)
     await manager.load_all()
+    active = manager.generation("mcp_ready")
+    assert active is not None and active.job_catalog is not None
+    active_job = manager.jobs[0]
 
     prepared = await manager.prepare_candidate("mcp_ready")
 
-    assert prepared is not None and prepared.mcp_catalog is not None
+    assert (
+        prepared is not None
+        and prepared.mcp_catalog is not None
+        and prepared.job_catalog is not None
+        and prepared.proactive_catalog is not None
+    )
     catalog = prepared.mcp_catalog
     server = catalog.servers["feed"]
     assert server.client.name == f"feed@{prepared.generation_id}"
@@ -952,6 +969,13 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     assert not any(prepared.generation_id in name for name in catalog.tool_names)
     assert tools.get_registered_names() == set()
     assert await server.tools[1].execute() == "[]"
+    assert tuple(catalog.servers) == ("feed",)
+    assert tuple(prepared.job_catalog.jobs) == ("mcp_ready:refresh",)
+    assert tuple(prepared.proactive_catalog.sources) == ("mcp_ready:feed",)
+    prepared_job = prepared.job_catalog.jobs["mcp_ready:refresh"]
+    assert prepared_job.spec.handler.__self__ is prepared.instance  # type: ignore[attr-defined]
+    assert manager.jobs == [active_job]
+    assert active_job.spec.handler.__self__ is active.instance  # type: ignore[attr-defined]
     lifecycle = tmp_path / "home" / "data" / "mcp_ready-builtin" / "mcp-lifecycle.log"
     await _wait_for_log(lifecycle, ["started"])
 
@@ -959,9 +983,35 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
 
     await _wait_for_log(lifecycle, ["started", "stopped"])
     assert manager.mcp_catalog(prepared.generation_id) is None
+    assert manager.job_catalog(prepared.generation_id) is None
+    assert manager.proactive_catalog(prepared.generation_id) is None
     assert server.client._process is None
     assert server.client._stderr_task is None
     await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_invalid_job_structure_fails_activity_catalog_gate(tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "invalid_job",
+        "from agent.plugins import IntervalTrigger, Plugin, PluginJobSpec\n"
+        "class InvalidJobPlugin(Plugin):\n"
+        "    name = 'invalid_job'\n"
+        "    def jobs(self):\n"
+        "        return [PluginJobSpec(id='bad', triggers=[IntervalTrigger(0)], handler=self.run)]\n"
+        "    async def run(self, context):\n"
+        "        return None\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    assert manager.generation("invalid_job") is None
+    gate = manager.latest_gate("invalid_job")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[-1].check_id == "activity_catalogs"
+    assert manager.jobs == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import os
 import py_compile
+import shutil
 import sys
 from pathlib import Path
 
@@ -831,3 +832,37 @@ async def test_skill_catalog_freezes_generation_and_ignores_old_root_link(
 
     assert not active_snapshot.exists()
     assert not prepared_snapshot.exists()
+
+
+@pytest.mark.asyncio
+async def test_skill_catalog_cleanup_failure_is_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "skill_cleanup",
+        "from agent.plugins import Plugin\n"
+        "class SkillCleanupPlugin(Plugin):\n"
+        "    name = 'skill_cleanup'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    generation = manager.generation("skill_cleanup")
+    assert generation is not None and generation.skill_catalog is not None
+    snapshot_root = generation.skill_catalog.snapshot_root
+    real_rmtree = shutil.rmtree
+
+    def fail_snapshot_cleanup(path: Path, *args: object, **kwargs: object) -> None:
+        if Path(path) == snapshot_root and not args and not kwargs:
+            raise OSError("snapshot cleanup failed")
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", fail_snapshot_cleanup)
+    await manager.terminate_all()
+
+    assert any(
+        failure.resource == "skill_catalog"
+        and failure.error == "snapshot cleanup failed"
+        for failure in manager.cleanup_failures
+    )

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -49,6 +49,47 @@ def _manager(
     )
 
 
+def _write_mcp_server(plugin_dir: Path, tools: tuple[str, ...]) -> None:
+    tool_items = ", ".join(
+        repr(
+            {
+                "name": name,
+                "description": name,
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        )
+        for name in tools
+    )
+    _ = (plugin_dir / "server.py").write_text(
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "log = Path(os.environ['AKA_PLUGIN_DATA_DIR']) / 'mcp-lifecycle.log'\n"
+        "log.parent.mkdir(parents=True, exist_ok=True)\n"
+        "with log.open('a', encoding='utf-8') as f: f.write('started\\n')\n"
+        "try:\n"
+        "    for line in sys.stdin:\n"
+        "        msg = json.loads(line)\n"
+        "        if 'id' not in msg:\n"
+        "            continue\n"
+        "        method = msg.get('method')\n"
+        "        result = {}\n"
+        f"        if method == 'tools/list': result = {{'tools': [{tool_items}]}}\n"
+        "        elif method == 'tools/call': result = {'content': [{'type': 'text', 'text': '[]'}]}\n"
+        "        print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n"
+        "finally:\n"
+        "    with log.open('a', encoding='utf-8') as f: f.write('stopped\\n')\n",
+        encoding="utf-8",
+    )
+
+
+async def _wait_for_log(path: Path, expected: list[str]) -> None:
+    for _ in range(100):
+        if path.exists() and path.read_text(encoding="utf-8").splitlines() == expected:
+            return
+        await asyncio.sleep(0.01)
+    assert path.read_text(encoding="utf-8").splitlines() == expected
+
+
 @pytest.mark.asyncio
 async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
     _write_plugin(
@@ -866,3 +907,135 @@ async def test_skill_catalog_cleanup_failure_is_reported(
         and failure.error == "snapshot cleanup failed"
         for failure in manager.cleanup_failures
     )
+
+
+@pytest.mark.asyncio
+async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "mcp_ready",
+        "from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec\n"
+        "class McpReadyPlugin(Plugin):\n"
+        "    name = 'mcp_ready'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='feed', command=('python', 'server.py'))]\n"
+        "    def proactive_sources(self):\n"
+        "        return [ProactiveSourceSpec(id='feed', channels=('content',), "
+        "server='feed', fetch_tool='fetch_events', ack_tool='ack_events', "
+        "poll_tool='poll_events')]\n",
+    )
+    _write_mcp_server(
+        plugin_dir,
+        ("fetch_events", "ack_events", "poll_events"),
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+
+    prepared = await manager.prepare_candidate("mcp_ready")
+
+    assert prepared is not None and prepared.mcp_catalog is not None
+    catalog = prepared.mcp_catalog
+    server = catalog.servers["feed"]
+    assert server.client.name == f"feed@{prepared.generation_id}"
+    assert catalog.tool_names == (
+        "mcp_feed__ack_events",
+        "mcp_feed__fetch_events",
+        "mcp_feed__poll_events",
+    )
+    assert not any(prepared.generation_id in name for name in catalog.tool_names)
+    assert tools.get_registered_names() == set()
+    assert await server.tools[1].execute() == "[]"
+    lifecycle = tmp_path / "home" / "data" / "mcp_ready-builtin" / "mcp-lifecycle.log"
+    await _wait_for_log(lifecycle, ["started"])
+
+    await manager.discard_prepared("mcp_ready")
+
+    await _wait_for_log(lifecycle, ["started", "stopped"])
+    assert manager.mcp_catalog(prepared.generation_id) is None
+    assert server.client._process is None
+    assert server.client._stderr_task is None
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["missing_tool", "semantic"])
+async def test_candidate_mcp_readiness_failure_closes_process(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    readiness = (
+        "    def readiness_semantic_checks(self):\n"
+        "        return [PluginSemanticCheck('remote', False, 'not ready')]\n"
+        if failure == "semantic"
+        else ""
+    )
+    fetch_tool = "missing" if failure == "missing_tool" else "fetch_events"
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "mcp_rejected",
+        "from agent.plugins import (McpServerSpec, Plugin, PluginSemanticCheck, "
+        "ProactiveSourceSpec)\n"
+        "class McpRejectedPlugin(Plugin):\n"
+        "    name = 'mcp_rejected'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='feed', command=('python', 'server.py'))]\n"
+        "    def proactive_sources(self):\n"
+        f"        return [ProactiveSourceSpec(id='feed', channels=('content',), server='feed', fetch_tool='{fetch_tool}')]\n"
+        + readiness,
+    )
+    _write_mcp_server(plugin_dir, ("fetch_events",))
+    manager = _manager(tmp_path)
+    await manager.load_all()
+
+    prepared = await manager.prepare_candidate("mcp_rejected")
+
+    assert prepared is None
+    assert manager.prepared_generation("mcp_rejected") is None
+    gate = manager.latest_gate("mcp_rejected")
+    assert gate is not None and gate.status == "failed"
+    failed_checks = {check.check_id for check in gate.checks if check.status == "failed"}
+    assert (
+        "mcp_readiness" if failure == "missing_tool" else "readiness_semantic_checks"
+    ) in failed_checks
+    lifecycle = tmp_path / "home" / "data" / "mcp_rejected-builtin" / "mcp-lifecycle.log"
+    await _wait_for_log(lifecycle, ["started", "stopped"])
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_mcp_handshake_failure_closes_process(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "mcp_handshake",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class McpHandshakePlugin(Plugin):\n"
+        "    name = 'mcp_handshake'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='broken', command=('python', 'server.py'))]\n",
+    )
+    _ = (plugin_dir / "server.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "log = Path(os.environ['AKA_PLUGIN_DATA_DIR']) / 'mcp-lifecycle.log'\n"
+        "log.parent.mkdir(parents=True, exist_ok=True)\n"
+        "log.write_text('started\\nstopped\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+
+    prepared = await manager.prepare_candidate("mcp_handshake")
+
+    assert prepared is None
+    gate = manager.latest_gate("mcp_handshake")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[-1].check_id == "mcp_readiness"
+    lifecycle = tmp_path / "home" / "data" / "mcp_handshake-builtin" / "mcp-lifecycle.log"
+    await _wait_for_log(lifecycle, ["started", "stopped"])
+    await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1484,6 +1484,7 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     )
     candidate = await manager.prepare_candidate("snapshot_publish")
     assert candidate is not None
+
     assert candidate.initialization_started is False
 
     result = await manager.publish_prepared("snapshot_publish")
@@ -1560,6 +1561,11 @@ async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
     candidate = await manager.prepare_candidate("snapshot_publish")
     assert candidate is not None
 
+    async def fail_terminate() -> None:
+        raise RuntimeError("terminate failed")
+
+    candidate.instance.terminate = fail_terminate  # type: ignore[attr-defined]
+
     invariant_entered = asyncio.Event()
     invariant_release = asyncio.Event()
 
@@ -1587,6 +1593,10 @@ async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
     assert candidate.runtime_snapshot.state == "aborted"
     await candidate_lease.release()
     assert candidate.scope.closed is True
+    assert any(
+        failure.error == "terminate failed"
+        for failure in manager.cleanup_failures
+    )
     await manager.terminate_all()
 
 
@@ -1754,4 +1764,72 @@ async def test_reconcile_changed_publishes_multiple_plugins_from_latest_snapshot
         "snapshot_first": first,
         "snapshot_second": second,
     }
+    await manager.terminate_all()
+
+
+def _snapshot_tool_source(version: str) -> str:
+    return (
+        "from agent.plugins import Plugin, tool\n"
+        "class SnapshotToolPlugin(Plugin):\n"
+        "    name = 'snapshot_tool'\n"
+        "    @tool(name='snapshot_tool_value')\n"
+        "    async def value(self, event):\n"
+        f"        \"\"\"snapshot tool {version}\"\"\"\n"
+        f"        return '{version}'\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_schema_search_and_execute_share_snapshot_generation(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_tool",
+        _snapshot_tool_source("v1"),
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_tool_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_tool")
+    assert candidate is not None
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = manager.snapshot_store
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[tuple[str, str, str]] = []
+
+    async def process(msg, **kwargs):
+        schema = tools.get_schemas(["snapshot_tool_value"])[0]
+        search = tools.search("snapshot tool", top_k=1)[0]
+        before = str(await tools.execute("snapshot_tool_value", {}))
+        entered.set()
+        await release.wait()
+        after = str(await tools.execute("snapshot_tool_value", {}))
+        seen.append((schema["function"]["description"], search["name"], before))
+        seen.append((schema["function"]["description"], search["name"], after))
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:snapshot-tool")
+    old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
+    await entered.wait()
+    await manager.publish_prepared("snapshot_tool")
+    release.set()
+    assert await old_turn == "done"
+    await loop._process_with_runtime_admission(message)
+
+    assert seen[:2] == [
+        ("snapshot tool v1", "snapshot_tool_value", "v1"),
+        ("snapshot tool v1", "snapshot_tool_value", "v1"),
+    ]
+    assert seen[2:] == [
+        ("snapshot tool v2", "snapshot_tool_value", "v2"),
+        ("snapshot tool v2", "snapshot_tool_value", "v2"),
+    ]
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -750,18 +750,42 @@ async def test_skill_catalog_freezes_generation_and_ignores_old_root_link(
         encoding="utf-8",
     )
     workspace = tmp_path / "workspace"
+    workspace_skill = workspace / "skills" / "personal"
+    workspace_skill.mkdir(parents=True)
+    _ = (workspace_skill / "SKILL.md").write_text(
+        "---\ndescription: workspace one\n---\nworkspace body v1\n",
+        encoding="utf-8",
+    )
+    workspace_drift = workspace / "drift" / "skills" / "personal-drift"
+    workspace_drift.mkdir(parents=True)
+    _ = (workspace_drift / "SKILL.md").write_text(
+        "---\ndescription: drift workspace one\n---\ndrift workspace v1\n",
+        encoding="utf-8",
+    )
     manager = _manager(tmp_path, workspace=workspace)
     await manager.load_all()
     active = manager.generation("skill_reload")
     assert active is not None and active.skill_catalog is not None
     active_record = active.skill_catalog.normal.get("shared")
     assert active_record is not None
+    active_workspace = active.skill_catalog.normal.get("personal")
+    active_workspace_drift = active.skill_catalog.drift.get("personal-drift")
+    assert active_workspace is not None
+    assert active_workspace_drift is not None
 
     workspace_skills = workspace / "skills"
-    workspace_skills.mkdir(parents=True)
+    workspace_skills.mkdir(parents=True, exist_ok=True)
     (workspace_skills / "shared").symlink_to(v1_skill, target_is_directory=True)
     _ = (v1_skill / "SKILL.md").write_text(
         "---\ndescription: changed old source\n---\nchanged old body\n",
+        encoding="utf-8",
+    )
+    _ = (workspace_skill / "SKILL.md").write_text(
+        "---\ndescription: workspace two\n---\nworkspace body v2\n",
+        encoding="utf-8",
+    )
+    _ = (workspace_drift / "SKILL.md").write_text(
+        "---\ndescription: drift workspace two\n---\ndrift workspace v2\n",
         encoding="utf-8",
     )
     v2_skill = plugin_dir / "skills-v2" / "shared"
@@ -790,3 +814,20 @@ async def test_skill_catalog_freezes_generation_and_ignores_old_root_link(
     assert prepared_record.source == "plugin"
     assert "body v2" in prepared_record.skill_file.read_text(encoding="utf-8")
     assert active_record.root_dir != prepared_record.root_dir
+    prepared_workspace = prepared.skill_catalog.normal.get("personal")
+    prepared_workspace_drift = prepared.skill_catalog.drift.get("personal-drift")
+    assert prepared_workspace is not None
+    assert prepared_workspace_drift is not None
+    assert "workspace body v1" in active_workspace.content
+    assert "workspace body v1" in active_workspace.skill_file.read_text(encoding="utf-8")
+    assert "workspace body v2" in prepared_workspace.content
+    assert "drift workspace v1" in active_workspace_drift.content
+    assert "drift workspace v2" in prepared_workspace_drift.content
+    active_snapshot = active.skill_catalog.snapshot_root
+    prepared_snapshot = prepared.skill_catalog.snapshot_root
+
+    await manager.discard_prepared("skill_reload")
+    await manager.terminate_all()
+
+    assert not active_snapshot.exists()
+    assert not prepared_snapshot.exists()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -17,6 +17,8 @@ from fastapi.testclient import TestClient
 from starlette.convertors import CONVERTOR_TYPES, StringConvertor
 
 from agent.plugins.manager import PluginManager
+from agent.plugins.manifest import write_plugin_manifest
+from agent.plugins.watcher import PluginWatcher
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
@@ -1285,6 +1287,49 @@ async def test_snapshot_admission_waits_while_current_is_quiesced(
 
 
 @pytest.mark.asyncio
+async def test_proactive_quiesce_does_not_deadlock_with_paused_tick(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "proactive_admission",
+        "from agent.plugins import Plugin\n"
+        "class ProactiveAdmissionPlugin(Plugin):\n"
+        "    name = 'proactive_admission'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    loop = object.__new__(ProactiveLoop)
+    loop._runtime_snapshot_store = manager.snapshot_store
+    loop._reload_lock = asyncio.Lock()
+    stopped = asyncio.Event()
+
+    async def stop_active_kernel() -> None:
+        stopped.set()
+
+    async def switch_snapshot(_snapshot) -> None:
+        return None
+
+    async def tick_bound() -> float:
+        return 1.0
+
+    loop._stop_active_kernel = stop_active_kernel
+    loop._switch_snapshot = switch_snapshot
+    loop._tick_bound = tick_bound
+    snapshot = manager.snapshot_store.pause_admission()
+    tick = asyncio.create_task(loop._tick())
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(loop.quiesce_for_reload(), timeout=0.2)
+
+    assert stopped.is_set()
+    assert not tick.done()
+    await manager.snapshot_store.resume(snapshot)
+    assert await tick == 1.0
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_managed_service_publish_drains_old_snapshot_before_switch(
     tmp_path: Path,
 ) -> None:
@@ -1332,6 +1377,54 @@ async def test_managed_service_publish_drains_old_snapshot_before_switch(
     assert switched.is_set()
     assert admitted.snapshot is manager.current_snapshot
     await admitted.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_failure_resumes_admission_before_candidate_terminate(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "service_cleanup",
+        "from agent.plugins import ManagedServiceSpec, Plugin\n"
+        "class ServiceCleanupPlugin(Plugin):\n"
+        "    name = 'service_cleanup'\n"
+        "    version = 'v1'\n"
+        "    @classmethod\n"
+        "    def managed_services(cls):\n"
+        "        return [ManagedServiceSpec(id='worker', command=('python', 'service.py'))]\n",
+    )
+    _ = (plugin_dir / "service.py").write_text("pass\n", encoding="utf-8")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
+    _ = (plugin_dir / "plugin.py").write_text(
+        source.replace("version = 'v1'", "version = 'v2'"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("service_cleanup")
+    assert candidate is not None
+    terminated = asyncio.Event()
+
+    async def terminate() -> None:
+        lease = await manager.snapshot_store.acquire()
+        await lease.release()
+        terminated.set()
+
+    async def fail_switch(_plugin_id, _old, _new) -> None:
+        raise RuntimeError("endpoint failed")
+
+    candidate.instance.terminate = terminate  # type: ignore[method-assign]
+    manager.bind_service_switcher(fail_switch)
+
+    result = await asyncio.wait_for(
+        manager.publish_prepared("service_cleanup"),
+        timeout=1,
+    )
+
+    assert result["publication_state"] == "failed"
+    assert terminated.is_set()
     await manager.terminate_all()
 
 
@@ -1875,6 +1968,125 @@ async def test_reconcile_changed_publishes_multiple_plugins_from_latest_snapshot
         "snapshot_first": first,
         "snapshot_second": second,
     }
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_changed_disables_and_reenables_plugin_capabilities(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "topology",
+        "from agent.plugins import Plugin, tool\n"
+        "class TopologyPlugin(Plugin):\n"
+        "    name = 'topology'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('skills',)\n"
+        "    @tool(name='topology_value')\n"
+        "    async def value(self, event):\n"
+        "        \"\"\"Return topology value.\"\"\"\n"
+        "        return 'active'\n",
+    )
+    skill = plugin_dir / "skills" / "topology-skill"
+    skill.mkdir(parents=True)
+    _ = (skill / "SKILL.md").write_text(
+        "---\ndescription: topology\n---\ntopology\n",
+        encoding="utf-8",
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools, workspace=tmp_path / "workspace")
+    plugins_home = tmp_path / "home"
+    write_plugin_manifest({"topology": True}, plugins_home=plugins_home)
+    await manager.load_all()
+    assert tools.has_tool("topology_value")
+
+    write_plugin_manifest({"topology": False}, plugins_home=plugins_home)
+    disabled = await manager.reconcile_changed()
+
+    snapshot = manager.current_snapshot
+    assert disabled[0]["publication_state"] == "disabled"
+    assert snapshot is not None and snapshot.generations == {}
+    assert not snapshot.tool_registry.has_tool("topology_value")
+    assert "topology-skill" not in snapshot.plugin_skill_index.records
+    assert manager.generation("topology") is None
+
+    write_plugin_manifest({"topology": True}, plugins_home=plugins_home)
+    enabled = await manager.reconcile_changed()
+
+    snapshot = manager.current_snapshot
+    assert enabled[0]["publication_state"] == "committed"
+    assert snapshot is not None and "topology" in snapshot.generations
+    assert snapshot.tool_registry.has_tool("topology_value")
+    assert "topology-skill" in snapshot.plugin_skill_index.records
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_changed_adds_and_removes_discovered_plugin(
+    tmp_path: Path,
+) -> None:
+    plugins = tmp_path / "plugins"
+    _write_plugin(
+        plugins,
+        "anchor",
+        "from agent.plugins import Plugin\n"
+        "class AnchorPlugin(Plugin):\n"
+        "    name = 'anchor'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    added_dir = _write_plugin(
+        plugins,
+        "added",
+        "from agent.plugins import Plugin\n"
+        "class AddedPlugin(Plugin):\n"
+        "    name = 'added'\n",
+    )
+
+    added = await manager.reconcile_changed()
+    assert added[0]["publication_state"] == "committed"
+    assert manager.generation("added") is not None
+
+    shutil.rmtree(added_dir)
+    removed = await manager.reconcile_changed()
+    assert removed[0]["publication_state"] == "disabled"
+    assert manager.generation("added") is None
+    assert manager.current_snapshot is not None
+    assert set(manager.current_snapshot.generations) == {"anchor"}
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_plugin_watcher_reloads_source_without_signal(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "watched",
+        "from agent.plugins import Plugin\n"
+        "class WatchedPlugin(Plugin):\n"
+        "    name = 'watched'\n"
+        "    version = 'v1'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    watcher = PluginWatcher(manager, interval_seconds=0.01)
+    task = asyncio.create_task(watcher.run())
+    source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
+    _ = (plugin_dir / "plugin.py").write_text(
+        source.replace("version = 'v1'", "version = 'v2'"),
+        encoding="utf-8",
+    )
+
+    for _ in range(100):
+        generation = manager.generation("watched")
+        if generation is not None and generation.instance.version == "v2":
+            break
+        await asyncio.sleep(0.01)
+
+    generation = manager.generation("watched")
+    assert generation is not None and generation.instance.version == "v2"
+    watcher.stop()
+    await task
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -639,3 +639,28 @@ async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path)
     assert second_scan[0]["gate_status"] == "active"
     assert manager.prepared_generation("return_active") is None
     assert prepared.state == "discarded"
+
+
+@pytest.mark.asyncio
+async def test_terminating_one_manager_keeps_newer_stable_alias(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "shared_alias",
+        "from agent.plugins import Plugin\n"
+        "class SharedAliasPlugin(Plugin):\n"
+        "    name = 'shared_alias'\n",
+    )
+    first_manager = _manager(tmp_path)
+    second_manager = _manager(tmp_path)
+    await first_manager.load_all()
+    await second_manager.load_all()
+    second = second_manager.generation("shared_alias")
+    assert second is not None
+
+    await first_manager.terminate_all()
+
+    stable_alias = "akasic_plugin_plugins_shared_alias"
+    assert plugin_registry.get_instance(stable_alias) is second.instance
+    assert sys.modules[stable_alias] is sys.modules[second.module_path]
+
+    await second_manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent.plugins.manager import PluginManager
+from agent.plugins.registry import plugin_registry
+from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+    yield
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+
+
+def _write_plugin(root: Path, name: str, source: str) -> Path:
+    plugin_dir = root / name
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(source, encoding="utf-8")
+    return plugin_dir
+
+
+def _manager(tmp_path: Path, *, tools: ToolRegistry | None = None) -> PluginManager:
+    return PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=EventBus(),
+        tool_registry=tools,
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+
+
+@pytest.mark.asyncio
+async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "candidate",
+        "from agent.plugins import Plugin, PluginSemanticCheck\n"
+        "class CandidatePlugin(Plugin):\n"
+        "    name = 'candidate'\n"
+        "    def static_semantic_checks(self):\n"
+        "        return [PluginSemanticCheck('fixture', True, 'ok')]\n"
+        "    async def initialize(self):\n"
+        "        self.context.kv_store.set('generation', self.context.generation_id)\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    generation = manager.generation("candidate")
+    gate = manager.latest_gate("candidate")
+    assert generation is not None
+    assert gate is not None and gate.status == "passed"
+    assert generation.module_path.startswith("akasic_plugin_plugins_candidate__g")
+    assert generation.generation_id == generation.instance.context.generation_id
+    assert plugin_registry.get_instance("akasic_plugin_plugins_candidate") is generation.instance
+    assert generation.contributions.manifest["name"] == "candidate"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "source", "failed_check"),
+    [
+        (
+            "bad_api",
+            "from agent.plugins import Plugin\n"
+            "class BadApiPlugin(Plugin):\n"
+            "    name = 'bad_api'\n"
+            "    api_version = 2\n",
+            "api_version",
+        ),
+        (
+            "bad_semantic",
+            "from agent.plugins import Plugin, PluginSemanticCheck\n"
+            "class BadSemanticPlugin(Plugin):\n"
+            "    name = 'bad_semantic'\n"
+            "    def static_semantic_checks(self):\n"
+            "        return [PluginSemanticCheck('model', False, 'missing')]\n",
+            "semantic_checks",
+        ),
+        (
+            "bad_source",
+            "from agent.plugins import Plugin, ProactiveSourceSpec\n"
+            "class BadSourcePlugin(Plugin):\n"
+            "    name = 'bad_source'\n"
+            "    def proactive_sources(self):\n"
+            "        return [ProactiveSourceSpec(id='feed', channels=('content',), "
+            "server='missing', fetch_tool='fetch')]\n",
+            "proactive_sources",
+        ),
+        (
+            "phase_cycle",
+            "from agent.plugins import Plugin\n"
+            "class A:\n"
+            "    slot = 'plugin.a'\n"
+            "    requires = ('plugin.b',)\n"
+            "class B:\n"
+            "    slot = 'plugin.b'\n"
+            "    requires = ('plugin.a',)\n"
+            "class PhaseCyclePlugin(Plugin):\n"
+            "    name = 'phase_cycle'\n"
+            "    def before_turn_modules(self): return [A(), B()]\n",
+            "phase_graph",
+        ),
+        (
+            "duplicate_tool",
+            "from agent.plugins import Plugin, tool\n"
+            "class DuplicateToolPlugin(Plugin):\n"
+            "    name = 'duplicate_tool'\n"
+            "    @tool(name='same')\n"
+            "    async def first(self, event):\n"
+            "        \"\"\"First.\"\"\"\n"
+            "        return 'first'\n"
+            "    @tool(name='same')\n"
+            "    async def second(self, event):\n"
+            "        \"\"\"Second.\"\"\"\n"
+            "        return 'second'\n",
+            "tool_names",
+        ),
+    ],
+)
+async def test_failed_candidate_never_initializes(
+    tmp_path: Path,
+    name: str,
+    source: str,
+    failed_check: str,
+):
+    plugin_dir = _write_plugin(tmp_path / "plugins", name, source)
+    marker = plugin_dir / "initialized"
+    with (plugin_dir / "plugin.py").open("a", encoding="utf-8") as file:
+        _ = file.write(
+            "    async def initialize(self):\n"
+            f"        open({str(marker)!r}, 'w').write('bad')\n"
+        )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate(name)
+    assert manager.loaded_count == 0
+    assert manager.generation(name) is None
+    assert gate is not None and gate.status == "failed"
+    assert failed_check in {check.check_id for check in gate.checks if check.status == "failed"}
+    assert not marker.exists()
+    assert tools.get_registered_names() == set()
+    assert not any(module.startswith(f"akasic_plugin_plugins_{name}__g") for module in sys.modules)
+
+
+@pytest.mark.asyncio
+async def test_import_failure_returns_gate_result(tmp_path: Path):
+    _write_plugin(tmp_path / "plugins", "broken", "this is not python !!!\n")
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("broken")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "import"
+    assert not any(module.startswith("akasic_plugin_plugins_broken__g") for module in sys.modules)
+
+
+@pytest.mark.asyncio
+async def test_candidate_declarations_are_collected_once(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "once",
+        "from agent.plugins import Plugin\n"
+        "calls = 0\n"
+        "class Module:\n"
+        "    slot = 'plugin.once'\n"
+        "    requires = ()\n"
+        "class OncePlugin(Plugin):\n"
+        "    name = 'once'\n"
+        "    def before_turn_modules(self):\n"
+        "        global calls\n"
+        "        calls += 1\n"
+        "        return [Module()]\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    generation = manager.generation("once")
+    assert generation is not None
+    module = sys.modules[generation.module_path]
+    assert module.calls == 1
+    assert len(manager.before_turn_modules) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_source_gets_new_generation_namespace_after_restart(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "repeat",
+        "from agent.plugins import Plugin\n"
+        "class RepeatPlugin(Plugin):\n"
+        "    name = 'repeat'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    first = manager.generation("repeat")
+    assert first is not None
+
+    await manager.terminate_all()
+    await manager.load_all()
+
+    second = manager.generation("repeat")
+    assert second is not None
+    assert second.generation_id != first.generation_id
+    assert second.module_path != first.module_path

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import logging
 import os
 import py_compile
 import shutil
@@ -690,7 +691,10 @@ async def test_candidate_ignores_stale_bytecode_for_root_and_helper(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path):
+async def test_return_to_active_revision_discards_stale_prepared(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
     plugin_dir = _write_plugin(
         tmp_path / "plugins",
         "return_active",
@@ -703,6 +707,7 @@ async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path)
     active_source = plugin_file.read_text(encoding="utf-8")
     manager = _manager(tmp_path)
     await manager.load_all()
+    caplog.set_level(logging.INFO, logger="agent.plugins.manager")
     _ = plugin_file.write_text(
         active_source.replace("'v1'", "'v2'"),
         encoding="utf-8",
@@ -718,6 +723,14 @@ async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path)
     assert second_scan[0]["gate_status"] == "active"
     assert manager.prepared_generation("return_active") is None
     assert prepared.state == "discarded"
+    status_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("plugin_candidate_status ")
+    ]
+    assert status_logs
+    assert "counts=skills:" in status_logs[-1]
+    assert "skill_descriptions" not in status_logs[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import sys
 from pathlib import Path
 
@@ -216,6 +217,7 @@ async def test_same_source_gets_new_generation_namespace_after_restart(tmp_path:
 
     second = manager.generation("repeat")
     assert second is not None
+    assert first.state == "retired"
     assert second.generation_id != first.generation_id
     assert second.module_path != first.module_path
 
@@ -363,10 +365,13 @@ async def test_generation_module_tree_is_removed_on_config_failure_and_terminate
     generation = manager.generation("module_tree")
     assert generation is not None
     assert f"{generation.module_path}.child" in sys.modules
+    stable_child = importlib.import_module("akasic_plugin_plugins_module_tree.child")
+    assert stable_child.value == 1
 
     await manager.terminate_all()
 
     assert not any("plugins_module_tree__g" in name for name in sys.modules)
+    assert "akasic_plugin_plugins_module_tree.child" not in sys.modules
 
 
 @pytest.mark.asyncio
@@ -468,6 +473,11 @@ async def test_prepare_same_plugin_keeps_active_generation_until_snapshot_publis
     ).exists()
     assert tools.get_tool("replaceable_tool") is not None
 
+    await manager.discard_prepared("replaceable")
+
+    assert prepared.state == "discarded"
+    assert manager.prepared_generation("replaceable") is None
+
 
 @pytest.mark.asyncio
 async def test_source_revision_includes_helper_changes(tmp_path: Path):
@@ -514,3 +524,48 @@ async def test_declared_paths_cannot_escape_plugin_root(tmp_path: Path):
     gate = manager.latest_gate("escaped")
     assert gate is not None and gate.status == "failed"
     assert gate.checks[0].check_id == "declarations"
+
+
+@pytest.mark.asyncio
+async def test_proactive_lifecycle_structure_fails_static_gate(tmp_path: Path):
+    _write_plugin(
+        tmp_path / "plugins",
+        "bad_lifecycle",
+        "from agent.plugins import Plugin\n"
+        "from proactive_v2.lifecycle import ProactiveLifecycleSpec\n"
+        "class BadLifecyclePlugin(Plugin):\n"
+        "    name = 'bad_lifecycle'\n"
+        "    def proactive_lifecycles(self):\n"
+        "        return [ProactiveLifecycleSpec(id='bad', modules=(object(),))]\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("bad_lifecycle")
+    assert gate is not None and gate.status == "failed"
+    assert "proactive_lifecycle_structure" in {
+        check.check_id for check in gate.checks if check.status == "failed"
+    }
+
+
+@pytest.mark.asyncio
+async def test_source_symlink_cannot_escape_plugin_root(tmp_path: Path):
+    outside = tmp_path / "outside.py"
+    _ = outside.write_text("value = 1\n", encoding="utf-8")
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "linked_source",
+        "from agent.plugins import Plugin\n"
+        "from . import helper\n"
+        "class LinkedSourcePlugin(Plugin):\n"
+        "    name = 'linked_source'\n",
+    )
+    (plugin_dir / "helper.py").symlink_to(outside)
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("linked_source")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[0].check_id == "source_boundary"

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -26,7 +26,11 @@ from agent.looping.core import AgentLoop
 from agent.background.subagent_manager import SubagentManager
 from proactive_v2.loop import ProactiveLoop
 from bootstrap.dashboard_api import create_dashboard_app
-from agent.plugins.dashboard_host import _plugin_routes
+from agent.plugins.dashboard_host import (
+    DashboardBinding,
+    _plugin_routes,
+    _require_routes_available,
+)
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
@@ -3325,6 +3329,30 @@ def test_dashboard_rejects_custom_path_convertor(
 
     with pytest.raises(RuntimeError, match="内建 path converter"):
         _plugin_routes(app.routes)
+
+
+def test_dashboard_treats_missing_methods_as_wildcard() -> None:
+    core_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    plugin_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    @core_app.api_route("/api/dashboard/{rest:path}", methods=["GET"])
+    def core_route() -> dict[str, bool]:
+        return {"core": True}
+
+    @plugin_app.get("/api/dashboard/sessions")
+    def plugin_route() -> dict[str, bool]:
+        return {"plugin": True}
+
+    core_routes = _plugin_routes(core_app.routes)
+    core_routes[0].methods = None
+    binding = DashboardBinding(
+        plugin_id="wildcard",
+        app=plugin_app,
+        routes=_plugin_routes(plugin_app.routes),
+    )
+
+    with pytest.raises(RuntimeError, match="dashboard route 冲突"):
+        _require_routes_available(binding, list(core_routes))
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -33,11 +33,17 @@ def _write_plugin(root: Path, name: str, source: str) -> Path:
     return plugin_dir
 
 
-def _manager(tmp_path: Path, *, tools: ToolRegistry | None = None) -> PluginManager:
+def _manager(
+    tmp_path: Path,
+    *,
+    tools: ToolRegistry | None = None,
+    workspace: Path | None = None,
+) -> PluginManager:
     return PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=EventBus(),
         tool_registry=tools,
+        workspace=workspace,
         installed_cache_root=tmp_path / "home" / "cache",
     )
 
@@ -672,3 +678,53 @@ async def test_terminating_one_manager_keeps_newer_stable_alias(tmp_path: Path):
     assert sys.modules[stable_alias] is sys.modules[second.module_path]
 
     await second_manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_skill_catalog_rejects_cross_plugin_duplicates(tmp_path: Path):
+    first_dir = _write_plugin(
+        tmp_path / "plugins",
+        "first_skills",
+        "from agent.plugins import Plugin\n"
+        "class FirstSkillsPlugin(Plugin):\n"
+        "    name = 'first_skills'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('skills',)\n",
+    )
+    first_skill = first_dir / "skills" / "shared"
+    first_skill.mkdir(parents=True)
+    _ = (first_skill / "SKILL.md").write_text(
+        "---\ndescription: first\n---\nfirst\n",
+        encoding="utf-8",
+    )
+    manager = _manager(tmp_path, workspace=tmp_path / "workspace")
+    await manager.load_all()
+    first = manager.generation("first_skills")
+    assert first is not None and first.skill_catalog is not None
+    assert first.skill_catalog.normal.get("shared").source_id == "first_skills"  # type: ignore[union-attr]
+
+    second_dir = _write_plugin(
+        tmp_path / "plugins",
+        "second_skills",
+        "from agent.plugins import Plugin\n"
+        "class SecondSkillsPlugin(Plugin):\n"
+        "    name = 'second_skills'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('skills',)\n",
+    )
+    second_skill = second_dir / "skills" / "shared"
+    second_skill.mkdir(parents=True)
+    _ = (second_skill / "SKILL.md").write_text(
+        "---\ndescription: second\n---\nsecond\n",
+        encoding="utf-8",
+    )
+
+    await manager.load_all()
+
+    gate = manager.latest_gate("second_skills")
+    assert gate is not None and gate.status == "failed"
+    assert gate.checks[-1].check_id == "skill_catalog"
+    assert manager.generation("second_skills") is None
+    generation_id = first.generation_id
+    await manager.terminate_all()
+    assert manager.skill_catalog(generation_id) is None

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -21,6 +22,7 @@ from proactive_v2.loop import ProactiveLoop
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
+from agent.tool_hooks import ToolExecutionRequest, ToolExecutor
 from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
 
@@ -2530,6 +2532,98 @@ async def test_proactive_tick_keeps_one_snapshot_generation(tmp_path: Path) -> N
     await loop._tick()
 
     assert seen == [old_snapshot.snapshot_id, new_snapshot.snapshot_id]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_proactive_kernel_owns_snapshot_until_stopped(tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_kernel",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotKernelPlugin(Plugin):\n"
+        "    name = 'snapshot_kernel'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    snapshot = manager.current_snapshot
+    assert snapshot is not None
+    kernel = SimpleNamespace(stop=AsyncMock())
+    loop = object.__new__(ProactiveLoop)
+    loop._kernel_started = False
+    loop._active_kernel_lease = None
+    loop._active_snapshot_id = None
+
+    async def build_and_start(_snapshot, _lease):
+        return kernel
+
+    loop._build_and_start_kernel = build_and_start
+    from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+    admission = manager.snapshot_store.lease()
+    token = bind_runtime_snapshot(admission)
+    try:
+        await loop._switch_snapshot(snapshot)
+    finally:
+        reset_runtime_snapshot(token)
+        await admission.release()
+
+    assert snapshot.lease_count == 1
+    await loop._stop_active_kernel()
+    assert snapshot.lease_count == 0
+    kernel.stop.assert_awaited_once()
+    await manager.terminate_all()
+
+
+def _snapshot_hook_source(version: str) -> str:
+    return (
+        "from agent.plugins import Plugin, on_tool_pre\n"
+        "class SnapshotHookPlugin(Plugin):\n"
+        "    name = 'snapshot_hook'\n"
+        "    @on_tool_pre(tool_name='target')\n"
+        "    async def hook(self, event):\n"
+        f"        return {{**event.arguments, 'version': '{version}'}}\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_hooks_follow_bound_snapshot_generation(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_hook",
+        _snapshot_hook_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_lease = manager.snapshot_store.lease()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_hook_source("v2"),
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("snapshot_hook") is not None
+    await manager.publish_prepared("snapshot_hook")
+    executor = ToolExecutor()
+    request = ToolExecutionRequest(
+        call_id="hook",
+        tool_name="target",
+        arguments={},
+        source="passive",
+    )
+    from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+    async def execute(lease):
+        token = bind_runtime_snapshot(lease)
+        try:
+            return await executor.execute(request, lambda _name, args: asyncio.sleep(0, result=args))
+        finally:
+            reset_runtime_snapshot(token)
+            await lease.release()
+
+    old_result = await execute(old_lease)
+    new_result = await execute(manager.snapshot_store.lease())
+
+    assert old_result.final_arguments == {"version": "v1"}
+    assert new_result.final_arguments == {"version": "v2"}
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1517,7 +1517,7 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     assert manager.generation("snapshot_publish") is candidate
     assert manager.current_snapshot is candidate.runtime_snapshot
     assert candidate.initialization_started is True
-    assert active.state == "retained_compat"
+    assert active.state == "retired"
     assert old_lease.snapshot is old_snapshot
     assert old_lease.snapshot.before_turn_modules[0].version == "v1"
     next_lease = manager.snapshot_store.lease()
@@ -2670,7 +2670,11 @@ async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> No
             "from fastapi import FastAPI\n"
             "def register(app: FastAPI, plugin_dir, workspace):\n"
             "    @app.get('/api/dashboard/snapshot-version')\n"
-            f"    def version(): return {{'version': '{version}'}}\n",
+            f"    def version(): return {{'version': '{version}'}}\n"
+            "    class Closeable:\n"
+            "        def close(self):\n"
+            f"            (workspace / 'dashboard-{version}-closed').write_text('closed')\n"
+            "    return Closeable()\n",
             encoding="utf-8",
         )
 
@@ -2679,6 +2683,8 @@ async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> No
     await manager.load_all()
     old_snapshot = manager.current_snapshot
     assert old_snapshot is not None
+    old_generation = old_snapshot.generations["snapshot_dashboard"]
+    old_lease = manager.snapshot_store.lease()
     app = create_dashboard_app(
         tmp_path / "workspace",
         memory_admin=SimpleNamespace(),
@@ -2695,7 +2701,104 @@ async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> No
     assert TestClient(old_binding.app).get(  # type: ignore[attr-defined]
         "/api/dashboard/snapshot-version"
     ).json() == {"version": "v1"}
+    assert not (tmp_path / "workspace" / "dashboard-v1-closed").exists()
+    await old_lease.release()
+    assert (tmp_path / "workspace" / "dashboard-v1-closed").exists()
+    assert old_generation.scope.closed
+    assert f"{old_generation.module_path}.dashboard" not in sys.modules
     client.close()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_candidate_cannot_override_core_route(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "dashboard_conflict",
+        "from agent.plugins import Plugin\n"
+        "class DashboardConflictPlugin(Plugin):\n"
+        "    name = 'dashboard_conflict'\n"
+        "    @classmethod\n"
+        "    def dashboard_module(cls): return 'dashboard.py'\n",
+    )
+
+    def write_dashboard(path: str) -> None:
+        _ = (plugin_dir / "dashboard.py").write_text(
+            "def register(app, plugin_dir, workspace):\n"
+            f"    @app.get('{path}')\n"
+            "    def route(): return {'owner': 'plugin'}\n",
+            encoding="utf-8",
+        )
+
+    write_dashboard("/api/dashboard/plugin-owned")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_generation = manager.generation("dashboard_conflict")
+    app = create_dashboard_app(
+        tmp_path / "workspace",
+        memory_admin=SimpleNamespace(),
+        plugin_manager=manager,
+    )
+    write_dashboard("/api/dashboard/sessions")
+    assert await manager.prepare_candidate("dashboard_conflict") is not None
+
+    result = await manager.publish_prepared("dashboard_conflict")
+
+    assert result["publication_state"] == "failed"
+    assert manager.generation("dashboard_conflict") is old_generation
+    assert TestClient(app).get("/api/dashboard/plugin-owned").json() == {
+        "owner": "plugin"
+    }
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) -> None:
+    root = tmp_path / "plugins"
+    first_dir = _write_plugin(
+        root,
+        "dashboard_first",
+        "from agent.plugins import Plugin\n"
+        "class DashboardFirstPlugin(Plugin):\n"
+        "    name = 'dashboard_first'\n"
+        "    @classmethod\n"
+        "    def dashboard_module(cls): return 'dashboard.py'\n",
+    )
+    second_dir = _write_plugin(
+        root,
+        "dashboard_second",
+        "from agent.plugins import Plugin\n"
+        "class DashboardSecondPlugin(Plugin):\n"
+        "    name = 'dashboard_second'\n"
+        "    @classmethod\n"
+        "    def dashboard_module(cls): return 'dashboard.py'\n",
+    )
+
+    def write_dashboard(directory: Path, path: str) -> None:
+        _ = (directory / "dashboard.py").write_text(
+            "def register(app, plugin_dir, workspace):\n"
+            f"    @app.get('{path}')\n"
+            f"    def route(): return {{'owner': '{directory.name}'}}\n",
+            encoding="utf-8",
+        )
+
+    write_dashboard(first_dir, "/api/dashboard/first")
+    write_dashboard(second_dir, "/api/dashboard/second")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_generation = manager.generation("dashboard_second")
+    _ = create_dashboard_app(
+        tmp_path / "workspace",
+        memory_admin=SimpleNamespace(),
+        plugin_manager=manager,
+    )
+    write_dashboard(second_dir, "/api/dashboard/first")
+    assert await manager.prepare_candidate("dashboard_second") is not None
+
+    result = await manager.publish_prepared("dashboard_second")
+
+    assert result["publication_state"] == "failed"
+    assert manager.generation("dashboard_second") is old_generation
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -46,6 +46,7 @@ def _manager(
     *,
     tools: ToolRegistry | None = None,
     workspace: Path | None = None,
+    user_mcp_server_names=None,
 ) -> PluginManager:
     return PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
@@ -53,6 +54,7 @@ def _manager(
         tool_registry=tools,
         workspace=workspace,
         installed_cache_root=tmp_path / "home" / "cache",
+        user_mcp_server_names=user_mcp_server_names,
     )
 
 
@@ -1926,7 +1928,11 @@ async def test_plugin_mcp_server_cannot_replace_user_registry_server(
         "    name = 'mcp_collision'\n",
     )
     tools = ToolRegistry()
-    manager = _manager(tmp_path, tools=tools)
+    manager = _manager(
+        tmp_path,
+        tools=tools,
+        user_mcp_server_names=lambda: {"user_server"},
+    )
     await manager.load_all()
 
     class UserMcpTool(Tool):

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1539,6 +1539,46 @@ async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_publish")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None
+
+    async def fail_invariant(generation, snapshot) -> None:
+        assert manager.current_snapshot is snapshot
+        raise RuntimeError("post publish failed")
+
+    monkeypatch.setattr(manager, "_post_publish_invariants", fail_invariant)
+
+    with pytest.raises(RuntimeError, match="post publish failed"):
+        await manager.publish_prepared("snapshot_publish")
+
+    assert manager.current_snapshot is old_snapshot
+    assert manager.generation("snapshot_publish") is active
+    assert manager.prepared_generation("snapshot_publish") is None
+    assert candidate.state == "discarded"
+    assert candidate.runtime_snapshot is not None
+    assert candidate.runtime_snapshot.state == "aborted"
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_changed_publishes_multiple_plugins_from_latest_snapshot(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -16,6 +16,7 @@ from agent.plugins.manager import PluginManager
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
+from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
 
@@ -1832,4 +1833,62 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
         ("snapshot tool v2", "snapshot_tool_value", "v2"),
         ("snapshot tool v2", "snapshot_tool_value", "v2"),
     ]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins" / "snapshot_skill"
+    for version in ("v1", "v2"):
+        skill_dir = plugin_dir / f"skills-{version}" / "snapshot-skill"
+        skill_dir.mkdir(parents=True)
+        _ = (skill_dir / "SKILL.md").write_text(
+            f"---\ndescription: snapshot skill {version}\n---\nbody {version}\n",
+            encoding="utf-8",
+        )
+
+    def source(version: str) -> str:
+        return (
+            "from agent.plugins import Plugin\n"
+            "class SnapshotSkillPlugin(Plugin):\n"
+            "    name = 'snapshot_skill'\n"
+            "    @classmethod\n"
+            "    def skill_roots(cls):\n"
+            f"        return ('skills-{version}',)\n"
+        )
+
+    _ = (plugin_dir / "plugin.py").write_text(source("v1"), encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manager = _manager(tmp_path, workspace=workspace)
+    await manager.load_all()
+    _ = (plugin_dir / "plugin.py").write_text(source("v2"), encoding="utf-8")
+    candidate = await manager.prepare_candidate("snapshot_skill")
+    assert candidate is not None
+    skills = SkillsLoader(workspace)
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = manager.snapshot_store
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[str | None] = []
+
+    async def process(msg, **kwargs):
+        seen.append(skills.load_skill_body("snapshot-skill"))
+        entered.set()
+        await release.wait()
+        seen.append(skills.load_skill_body("snapshot-skill"))
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:snapshot-skill")
+    old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
+    await entered.wait()
+    await manager.publish_prepared("snapshot_skill")
+    release.set()
+    assert await old_turn == "done"
+    await loop._process_with_runtime_admission(message)
+
+    assert seen[:2] == ["body v1", "body v1"]
+    assert seen[2:] == ["body v2", "body v2"]
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import os
+import py_compile
 import sys
 from pathlib import Path
 
@@ -569,3 +571,71 @@ async def test_source_symlink_cannot_escape_plugin_root(tmp_path: Path):
     gate = manager.latest_gate("linked_source")
     assert gate is not None and gate.status == "failed"
     assert gate.checks[0].check_id == "source_boundary"
+
+
+@pytest.mark.asyncio
+async def test_candidate_ignores_stale_bytecode_for_root_and_helper(tmp_path: Path):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "fresh_source",
+        "from agent.plugins import Plugin\n"
+        "from . import helper\n"
+        "class FreshSourcePlugin(Plugin):\n"
+        "    name = 'fresh_source'\n"
+        "    version = 'v1'\n"
+        "    helper_value = helper.VALUE\n",
+    )
+    plugin_file = plugin_dir / "plugin.py"
+    helper_file = plugin_dir / "helper.py"
+    _ = helper_file.write_text("VALUE = 'v1'\n", encoding="utf-8")
+    plugin_stat = plugin_file.stat()
+    helper_stat = helper_file.stat()
+    _ = py_compile.compile(str(plugin_file), doraise=True)
+    _ = py_compile.compile(str(helper_file), doraise=True)
+    manager = _manager(tmp_path)
+    await manager.load_all()
+
+    _ = plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace("'v1'", "'v2'"),
+        encoding="utf-8",
+    )
+    _ = helper_file.write_text("VALUE = 'v2'\n", encoding="utf-8")
+    os.utime(plugin_file, ns=(plugin_stat.st_atime_ns, plugin_stat.st_mtime_ns))
+    os.utime(helper_file, ns=(helper_stat.st_atime_ns, helper_stat.st_mtime_ns))
+
+    prepared = await manager.prepare_candidate("fresh_source")
+
+    assert prepared is not None
+    assert prepared.instance.version == "v2"  # type: ignore[attr-defined]
+    assert prepared.instance.helper_value == "v2"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_return_to_active_revision_discards_stale_prepared(tmp_path: Path):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "return_active",
+        "from agent.plugins import Plugin\n"
+        "class ReturnActivePlugin(Plugin):\n"
+        "    name = 'return_active'\n"
+        "    version = 'v1'\n",
+    )
+    plugin_file = plugin_dir / "plugin.py"
+    active_source = plugin_file.read_text(encoding="utf-8")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    _ = plugin_file.write_text(
+        active_source.replace("'v1'", "'v2'"),
+        encoding="utf-8",
+    )
+    first_scan = await manager.prepare_changed()
+    prepared = manager.prepared_generation("return_active")
+    assert first_scan[0]["gate_status"] == "passed"
+    assert prepared is not None
+
+    _ = plugin_file.write_text(active_source, encoding="utf-8")
+    second_scan = await manager.prepare_changed()
+
+    assert second_scan[0]["gate_status"] == "active"
+    assert manager.prepared_generation("return_active") is None
+    assert prepared.state == "discarded"

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1560,21 +1560,149 @@ async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
     candidate = await manager.prepare_candidate("snapshot_publish")
     assert candidate is not None
 
+    invariant_entered = asyncio.Event()
+    invariant_release = asyncio.Event()
+
     async def fail_invariant(generation, snapshot) -> None:
         assert manager.current_snapshot is snapshot
+        invariant_entered.set()
+        await invariant_release.wait()
         raise RuntimeError("post publish failed")
 
     monkeypatch.setattr(manager, "_post_publish_invariants", fail_invariant)
 
+    publishing = asyncio.create_task(manager.publish_prepared("snapshot_publish"))
+    await invariant_entered.wait()
+    candidate_lease = manager.snapshot_store.lease()
+    invariant_release.set()
     with pytest.raises(RuntimeError, match="post publish failed"):
-        await manager.publish_prepared("snapshot_publish")
+        await publishing
 
     assert manager.current_snapshot is old_snapshot
     assert manager.generation("snapshot_publish") is active
     assert manager.prepared_generation("snapshot_publish") is None
-    assert candidate.state == "discarded"
+    assert candidate.state == "aborted"
+    assert candidate.scope.closed is False
     assert candidate.runtime_snapshot is not None
     assert candidate.runtime_snapshot.state == "aborted"
+    await candidate_lease.release()
+    assert candidate.scope.closed is True
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_post_publish_invariant_timeout_aborts_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_snapshot = manager.current_snapshot
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None and old_snapshot is not None
+
+    async def never_finishes(generation, snapshot) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(manager, "_post_publish_invariants", never_finishes)
+    manager.POST_PUBLISH_TIMEOUT_SECONDS = 0.01
+
+    with pytest.raises(TimeoutError):
+        await manager.publish_prepared("snapshot_publish")
+
+    assert manager.current_snapshot is old_snapshot
+    assert candidate.state == "aborted"
+    assert candidate.scope.closed is True
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_publish_waits_for_candidate_lease_before_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_snapshot = manager.current_snapshot
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None and old_snapshot is not None
+    entered = asyncio.Event()
+
+    async def wait_forever(generation, snapshot) -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(manager, "_post_publish_invariants", wait_forever)
+    publishing = asyncio.create_task(manager.publish_prepared("snapshot_publish"))
+    await entered.wait()
+    lease = manager.snapshot_store.lease()
+    publishing.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await publishing
+
+    assert manager.current_snapshot is old_snapshot
+    assert candidate.scope.closed is False
+    await lease.release()
+    assert candidate.scope.closed is True
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_dead_candidate_mcp_aborts_post_publish_invariant(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_mcp",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class SnapshotMcpPlugin(Plugin):\n"
+        "    name = 'snapshot_mcp'\n"
+        "    version = 'v1'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='snapshot', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(plugin_dir, ("version",))
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_snapshot = manager.current_snapshot
+    plugin_file = plugin_dir / "plugin.py"
+    _ = plugin_file.write_text(
+        plugin_file.read_text(encoding="utf-8").replace("'v1'", "'v2'"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_mcp")
+    assert candidate is not None and candidate.mcp_catalog is not None
+    client = candidate.mcp_catalog.servers["snapshot"].client
+    process = client._process
+    assert process is not None
+    process.kill()
+    await process.wait()
+    assert client.connected is False
+
+    with pytest.raises(RuntimeError, match="MCP client 已断开"):
+        await manager.publish_prepared("snapshot_mcp")
+
+    assert manager.current_snapshot is old_snapshot
+    assert candidate.scope.closed is True
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1155,8 +1155,15 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
         tmp_path / "plugins",
         "snapshot",
         "from agent.plugins import Plugin\n"
+        "class A:\n"
+        "    slot = 'snapshot.a'\n"
+        "    requires = ()\n"
+        "class B:\n"
+        "    slot = 'snapshot.b'\n"
+        "    requires = ('snapshot.a',)\n"
         "class SnapshotPlugin(Plugin):\n"
-        "    name = 'snapshot'\n",
+        "    name = 'snapshot'\n"
+        "    def before_turn_modules(self): return [B(), A()]\n",
     )
     manager = _manager(tmp_path)
     await manager.load_all()
@@ -1167,6 +1174,10 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
     assert installed.generations["snapshot"] is active
     assert installed.state == "committed"
     assert manager.current_snapshot is installed
+    assert [module.slot for module in installed.before_turn_modules] == [
+        "snapshot.a",
+        "snapshot.b",
+    ]
     compiler = RuntimeSnapshotCompiler()
     v1 = compiler.compile({"snapshot": active}, catalog_generation=active)
     v2 = compiler.compile({"snapshot": prepared}, catalog_generation=prepared)
@@ -1207,4 +1218,101 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
     await store.close()
     assert drained == [v2.snapshot_id, v1.snapshot_id, next_v2.snapshot_id]
     await manager.discard_prepared("snapshot")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_drain_retry_and_store_ownership(tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_owner",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotOwnerPlugin(Plugin):\n"
+        "    name = 'snapshot_owner'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_owner")
+    prepared = await manager.prepare_candidate("snapshot_owner")
+    assert active is not None and prepared is not None
+    compiler = RuntimeSnapshotCompiler()
+    v1 = compiler.compile({"snapshot_owner": active}, catalog_generation=active)
+    v2 = compiler.compile(
+        {"snapshot_owner": prepared},
+        catalog_generation=prepared,
+    )
+    attempts = 0
+
+    async def fail_once(snapshot) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("drain failed")
+
+    store = RuntimeSnapshotStore(fail_once)
+    store.install(v1)
+    lease = store.lease()
+    with pytest.raises(RuntimeError, match="仍有 lease"):
+        await store.close()
+    assert store.current is v1
+    await lease.release()
+    transaction = store.begin_publish(v2)
+
+    with pytest.raises(RuntimeError, match="drain failed"):
+        await store.commit(transaction)
+
+    assert store.current is v2
+    assert v1.snapshot_id in store.retained_snapshot_ids
+    await store.retry_drains()
+    assert v1.snapshot_id not in store.retained_snapshot_ids
+    other_store = RuntimeSnapshotStore()
+    with pytest.raises(RuntimeError, match="全新 compiled"):
+        other_store.install(v2)
+    await store.close()
+    await manager.discard_prepared("snapshot_owner")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_compile_failure_does_not_publish_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugins = tmp_path / "plugins"
+    _write_plugin(
+        plugins,
+        "first_snapshot",
+        "from agent.plugins import Plugin\n"
+        "class FirstSnapshotPlugin(Plugin):\n"
+        "    name = 'first_snapshot'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    current = manager.current_snapshot
+    assert current is not None
+    _write_plugin(
+        plugins,
+        "second_snapshot",
+        "from agent.plugins import Plugin\n"
+        "class SecondSnapshotPlugin(Plugin):\n"
+        "    name = 'second_snapshot'\n",
+    )
+    compile_snapshot = manager._snapshot_compiler.compile
+
+    def fail_second(generations, *, catalog_generation=None):
+        if "second_snapshot" in generations:
+            raise RuntimeError("snapshot compile failed")
+        return compile_snapshot(
+            generations,
+            catalog_generation=catalog_generation,
+        )
+
+    monkeypatch.setattr(manager._snapshot_compiler, "compile", fail_second)
+
+    await manager.load_all()
+
+    assert manager.current_snapshot is current
+    assert manager.loaded_count == 1
+    assert manager.generation("second_snapshot") is None
+    assert plugin_registry.get_instance("akasic_plugin_plugins_second_snapshot") is None
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 
 from agent.plugins.manager import PluginManager
+from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
@@ -2330,6 +2331,79 @@ async def test_running_fanout_cancellation_releases_observer_leases() -> None:
     assert snapshot.lease_count == 0
     await event_bus.aclose()
     await store.close()
+
+
+def _snapshot_job_source(version: str) -> str:
+    return (
+        "from agent.plugins import Plugin, PluginJobSpec\n"
+        "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
+        "class SnapshotJobPlugin(Plugin):\n"
+        "    name = 'snapshot_job'\n"
+        "    def jobs(self):\n"
+        "        return [PluginJobSpec(id='refresh', triggers=[], handler=self.refresh)]\n"
+        "    async def refresh(self, context):\n"
+        f"        self.context.kv_store.increment('job_{version}')\n"
+        "        snapshot = get_current_runtime_snapshot()\n"
+        f"        self.context.kv_store.set('snapshot_{version}', snapshot.snapshot_id if snapshot else None)\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_queue_envelope_keeps_enqueued_snapshot_generation(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_job",
+        _snapshot_job_source("v1"),
+    )
+    event_bus = EventBus()
+    llm = SimpleNamespace()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        llm=llm,
+        installed_cache_root=tmp_path / "home/cache",
+    )
+    await manager.load_all()
+    runtime = PluginJobRuntime(
+        event_bus=event_bus,
+        llm=llm,
+        snapshot_store=manager.snapshot_store,
+    )
+    runtime.enqueue("snapshot_job:refresh", reason="manual")
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_job_source("v2"),
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("snapshot_job") is not None
+    result = await manager.publish_prepared("snapshot_job")
+    assert result["publication_state"] == "committed"
+    running = asyncio.create_task(runtime.run())
+    state_path = tmp_path / "home/data/snapshot_job-builtin/.kv.json"
+    for _ in range(100):
+        if state_path.exists() and json.loads(
+            state_path.read_text(encoding="utf-8")
+        ).get("job_v1") == 1:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("v1 job did not run")
+
+    runtime.enqueue("snapshot_job:refresh", reason="manual")
+    for _ in range(100):
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        if state.get("job_v2") == 1:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("v2 job did not run")
+
+    assert state["snapshot_v1"] != state["snapshot_v2"]
+    runtime.stop()
+    await running
+    await event_bus.aclose()
+    await manager.terminate_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -18,6 +18,7 @@ from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
+from agent.tools.base import Tool
 from bus.event_bus import EventBus
 
 
@@ -493,6 +494,7 @@ async def test_prepare_same_plugin_keeps_active_generation_until_snapshot_publis
     tools = ToolRegistry()
     manager = _manager(tmp_path, tools=tools)
     await manager.load_all()
+
     active = manager.generation("replaceable")
     assert active is not None
 
@@ -1792,6 +1794,20 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
     tools = ToolRegistry()
     manager = _manager(tmp_path, tools=tools)
     await manager.load_all()
+
+    class LateMcpTool(Tool):
+        name = "mcp_late__value"
+        description = "late mcp"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self) -> str:
+            return "late"
+
+    tools.register(
+        LateMcpTool(),
+        source_type="mcp",
+        source_name="late",
+    )
     _ = (plugin_dir / "plugin.py").write_text(
         _snapshot_tool_source("v2"),
         encoding="utf-8",
@@ -1804,11 +1820,13 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
     entered = asyncio.Event()
     release = asyncio.Event()
     seen: list[tuple[str, str, str]] = []
+    late_seen: list[str] = []
 
     async def process(msg, **kwargs):
         schema = tools.get_schemas(["snapshot_tool_value"])[0]
         search = tools.search("snapshot tool", top_k=1)[0]
         before = str(await tools.execute("snapshot_tool_value", {}))
+        late_seen.append(str(await tools.execute("mcp_late__value", {})))
         entered.set()
         await release.wait()
         after = str(await tools.execute("snapshot_tool_value", {}))
@@ -1833,6 +1851,7 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
         ("snapshot tool v2", "snapshot_tool_value", "v2"),
         ("snapshot tool v2", "snapshot_tool_value", "v2"),
     ]
+    assert late_seen == ["工具 'mcp_late__value' 不存在", "late"]
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -12,7 +12,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.convertors import CONVERTOR_TYPES, StringConvertor
 
 from agent.plugins.manager import PluginManager
 from agent.plugins.jobs import PluginJobRuntime
@@ -22,6 +24,7 @@ from agent.looping.core import AgentLoop
 from agent.background.subagent_manager import SubagentManager
 from proactive_v2.loop import ProactiveLoop
 from bootstrap.dashboard_api import create_dashboard_app
+from agent.plugins.dashboard_host import _plugin_routes
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
@@ -2815,6 +2818,23 @@ async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) 
     assert result["publication_state"] == "failed"
     assert manager.generation("dashboard_second") is old_generation
     await manager.terminate_all()
+
+
+def test_dashboard_rejects_custom_path_convertor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CustomConvertor(StringConvertor):
+        regex = "(?:x|z)"
+
+    monkeypatch.setitem(CONVERTOR_TYPES, "custom_gate", CustomConvertor())
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    @app.get("/api/dashboard/{value:custom_gate}")
+    def route() -> dict[str, bool]:
+        return {"ok": True}
+
+    with pytest.raises(RuntimeError, match="内建 path converter"):
+        _plugin_routes(app.routes)
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1408,9 +1408,11 @@ async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
     loop._runtime_snapshot_store = store
     detached_seen: list[RuntimeSnapshot | None] = []
     detached_done = asyncio.Event()
+    detached_release = asyncio.Event()
+    detached_tasks: list[asyncio.Task[None]] = []
 
     async def detached() -> None:
-        await asyncio.sleep(0)
+        await detached_release.wait()
         from agent.plugins.snapshot import get_current_runtime_snapshot
 
         detached_seen.append(get_current_runtime_snapshot())
@@ -1420,14 +1422,16 @@ async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
         from agent.plugins.snapshot import get_current_runtime_snapshot
 
         assert get_current_runtime_snapshot() is snapshot
-        asyncio.create_task(detached())
-        await detached_done.wait()
-        assert get_current_runtime_snapshot() is snapshot
+        detached_tasks.append(asyncio.create_task(detached()))
         return "done"
 
     loop._process = process
     message = SimpleNamespace(session_key="cli:detached-snapshot")
     assert await loop._process_with_runtime_admission(message) == "done"
+    assert snapshot.lease_count == 0
+    detached_release.set()
+    await detached_done.wait()
     assert detached_seen == [None]
+    await detached_tasks[0]
     await store.close()
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2023,6 +2023,95 @@ async def test_reconcile_changed_disables_and_reenables_plugin_capabilities(
 
 
 @pytest.mark.asyncio
+async def test_repeated_disable_with_retained_snapshot_keeps_unique_id_and_alias(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "retained_topology",
+        "from agent.plugins import Plugin\n"
+        "class RetainedTopologyPlugin(Plugin):\n"
+        "    name = 'retained_topology'\n",
+    )
+    manager = _manager(tmp_path)
+    plugins_home = tmp_path / "home"
+    write_plugin_manifest({"retained_topology": True}, plugins_home=plugins_home)
+    await manager.load_all()
+    alias = "akasic_plugin_plugins_retained_topology"
+
+    write_plugin_manifest({"retained_topology": False}, plugins_home=plugins_home)
+    await manager.reconcile_changed()
+    first_disabled = manager.current_snapshot
+    assert first_disabled is not None
+    retained = manager.snapshot_store.lease()
+
+    write_plugin_manifest({"retained_topology": True}, plugins_home=plugins_home)
+    await manager.reconcile_changed()
+    reenabled = manager.generation("retained_topology")
+    assert reenabled is not None
+    assert sys.modules[alias] is sys.modules[reenabled.module_path]
+
+    write_plugin_manifest({"retained_topology": False}, plugins_home=plugins_home)
+    await manager.reconcile_changed()
+    second_disabled = manager.current_snapshot
+    assert second_disabled is not None
+    assert second_disabled.snapshot_id != first_disabled.snapshot_id
+
+    await retained.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_publish_cancellation_after_store_commit_keeps_manager_consistent(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "commit_cancel",
+        "from agent.plugins import Plugin\n"
+        "class CommitCancelPlugin(Plugin):\n"
+        "    name = 'commit_cancel'\n"
+        "    version = 'v1'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
+    _ = (plugin_dir / "plugin.py").write_text(
+        source.replace("version = 'v1'", "version = 'v2'"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("commit_cancel")
+    assert candidate is not None
+    committed = asyncio.Event()
+    release = asyncio.Event()
+    original_commit = manager.snapshot_store.commit
+
+    async def delayed_commit(transaction) -> None:
+        await original_commit(transaction)
+        committed.set()
+        await release.wait()
+
+    manager.snapshot_store.commit = delayed_commit  # type: ignore[method-assign]
+    publishing = asyncio.create_task(manager.publish_prepared("commit_cancel"))
+    await committed.wait()
+    publishing.cancel()
+    await asyncio.sleep(0)
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await publishing
+
+    active = manager.generation("commit_cancel")
+    alias = "akasic_plugin_plugins_commit_cancel"
+    assert active is candidate
+    assert manager.prepared_generation("commit_cancel") is None
+    assert manager.current_snapshot is candidate.runtime_snapshot
+    assert sys.modules[alias] is sys.modules[candidate.module_path]
+    manager.snapshot_store.commit = original_commit  # type: ignore[method-assign]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_changed_adds_and_removes_discovered_plugin(
     tmp_path: Path,
 ) -> None:
@@ -2071,6 +2160,7 @@ async def test_plugin_watcher_reloads_source_without_signal(tmp_path: Path) -> N
     await manager.load_all()
     watcher = PluginWatcher(manager, interval_seconds=0.01)
     task = asyncio.create_task(watcher.run())
+    await asyncio.sleep(0)
     source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
     _ = (plugin_dir / "plugin.py").write_text(
         source.replace("version = 'v1'", "version = 'v2'"),
@@ -2088,6 +2178,43 @@ async def test_plugin_watcher_reloads_source_without_signal(tmp_path: Path) -> N
     watcher.stop()
     await task
     await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_plugin_watcher_reconciles_change_arriving_during_scan() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.revision = "a"
+            self.calls = 0
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        def watch_revision(self) -> str:
+            return self.revision
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            self.calls += 1
+            if self.calls == 1:
+                self.started.set()
+                await self.release.wait()
+            return []
+
+    manager = Manager()
+    watcher = PluginWatcher(manager, interval_seconds=0.01)  # type: ignore[arg-type]
+    task = asyncio.create_task(watcher.run())
+    await asyncio.sleep(0)
+    manager.revision = "b"
+    await manager.started.wait()
+    manager.revision = "c"
+    manager.release.set()
+    for _ in range(100):
+        if manager.calls >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    watcher.stop()
+    await task
+    assert manager.calls >= 2
 
 
 def _snapshot_tool_source(version: str) -> str:

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -728,3 +728,65 @@ async def test_skill_catalog_rejects_cross_plugin_duplicates(tmp_path: Path):
     generation_id = first.generation_id
     await manager.terminate_all()
     assert manager.skill_catalog(generation_id) is None
+
+
+@pytest.mark.asyncio
+async def test_skill_catalog_freezes_generation_and_ignores_old_root_link(
+    tmp_path: Path,
+):
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "skill_reload",
+        "from agent.plugins import Plugin\n"
+        "class SkillReloadPlugin(Plugin):\n"
+        "    name = 'skill_reload'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('skills-v1',)\n",
+    )
+    v1_skill = plugin_dir / "skills-v1" / "shared"
+    v1_skill.mkdir(parents=True)
+    _ = (v1_skill / "SKILL.md").write_text(
+        "---\ndescription: version one\n---\nbody v1\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    manager = _manager(tmp_path, workspace=workspace)
+    await manager.load_all()
+    active = manager.generation("skill_reload")
+    assert active is not None and active.skill_catalog is not None
+    active_record = active.skill_catalog.normal.get("shared")
+    assert active_record is not None
+
+    workspace_skills = workspace / "skills"
+    workspace_skills.mkdir(parents=True)
+    (workspace_skills / "shared").symlink_to(v1_skill, target_is_directory=True)
+    _ = (v1_skill / "SKILL.md").write_text(
+        "---\ndescription: changed old source\n---\nchanged old body\n",
+        encoding="utf-8",
+    )
+    v2_skill = plugin_dir / "skills-v2" / "shared"
+    v2_skill.mkdir(parents=True)
+    _ = (v2_skill / "SKILL.md").write_text(
+        "---\ndescription: version two\n---\nbody v2\n",
+        encoding="utf-8",
+    )
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class SkillReloadPlugin(Plugin):\n"
+        "    name = 'skill_reload'\n"
+        "    @classmethod\n"
+        "    def skill_roots(cls): return ('skills-v2',)\n",
+        encoding="utf-8",
+    )
+
+    prepared = await manager.prepare_candidate("skill_reload")
+
+    assert prepared is not None and prepared.skill_catalog is not None
+    prepared_record = prepared.skill_catalog.normal.get("shared")
+    assert prepared_record is not None
+    assert active_record.description == "version one"
+    assert "body v1" in active_record.skill_file.read_text(encoding="utf-8")
+    assert prepared_record.description == "version two"
+    assert prepared_record.source == "plugin"
+    assert "body v2" in prepared_record.skill_file.read_text(encoding="utf-8")
+    assert active_record.root_dir != prepared_record.root_dir

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -916,7 +916,7 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     plugin_dir = _write_plugin(
         tmp_path / "plugins",
         "mcp_ready",
-        "from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec\n"
+        "from agent.plugins import McpServerSpec, Plugin, PluginSemanticCheck, ProactiveSourceSpec\n"
         "class McpReadyPlugin(Plugin):\n"
         "    name = 'mcp_ready'\n"
         "    @classmethod\n"
@@ -925,7 +925,10 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "    def proactive_sources(self):\n"
         "        return [ProactiveSourceSpec(id='feed', channels=('content',), "
         "server='feed', fetch_tool='fetch_events', ack_tool='ack_events', "
-        "poll_tool='poll_events')]\n",
+        "poll_tool='poll_events')]\n"
+        "    async def readiness_semantic_checks(self, context):\n"
+        "        value = await context.mcp_catalog.servers['feed'].client.call('fetch_events', {})\n"
+        "        return [PluginSemanticCheck('candidate_feed', value == '[]', value)]\n",
     )
     _write_mcp_server(
         plugin_dir,
@@ -968,7 +971,7 @@ async def test_candidate_mcp_readiness_failure_closes_process(
     failure: str,
 ) -> None:
     readiness = (
-        "    def readiness_semantic_checks(self):\n"
+        "    async def readiness_semantic_checks(self, context):\n"
         "        return [PluginSemanticCheck('remote', False, 'not ready')]\n"
         if failure == "semantic"
         else ""
@@ -1038,4 +1041,44 @@ async def test_candidate_mcp_handshake_failure_closes_process(tmp_path: Path) ->
     assert gate.checks[-1].check_id == "mcp_readiness"
     lifecycle = tmp_path / "home" / "data" / "mcp_handshake-builtin" / "mcp-lifecycle.log"
     await _wait_for_log(lifecycle, ["started", "stopped"])
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_mcp_cleanup_failure_is_reported_and_catalog_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "mcp_cleanup",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class McpCleanupPlugin(Plugin):\n"
+        "    name = 'mcp_cleanup'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='cleanup', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(plugin_dir, ("health",))
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    prepared = await manager.prepare_candidate("mcp_cleanup")
+    assert prepared is not None and prepared.mcp_catalog is not None
+    client = prepared.mcp_catalog.servers["cleanup"].client
+    disconnect = client.disconnect
+
+    async def fail_after_disconnect() -> None:
+        await disconnect()
+        raise OSError("mcp cleanup failed")
+
+    monkeypatch.setattr(client, "disconnect", fail_after_disconnect)
+    await manager.discard_prepared("mcp_cleanup")
+
+    assert manager.mcp_catalog(prepared.generation_id) is None
+    assert client.connected is False
+    assert any(
+        failure.resource == "mcp_catalog"
+        and "mcp cleanup failed" in failure.error
+        for failure in manager.cleanup_failures
+    )
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -920,6 +920,8 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "PluginSemanticCheck, ProactiveSourceSpec)\n"
         "class McpReadyPlugin(Plugin):\n"
         "    name = 'mcp_ready'\n"
+        "    def __init__(self):\n"
+        "        self.job_spec = PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)\n"
         "    @classmethod\n"
         "    def mcp_servers(cls):\n"
         "        return [McpServerSpec(name='feed', command=('python', 'server.py'))]\n"
@@ -928,16 +930,20 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "server='feed', fetch_tool='fetch_events', ack_tool='ack_events', "
         "poll_tool='poll_events')]\n"
         "    def jobs(self):\n"
-        "        return [PluginJobSpec(id='refresh', triggers=[IntervalTrigger(3600)], handler=self.refresh)]\n"
+        "        return [self.job_spec]\n"
+        "    async def initialize(self):\n"
+        "        self.job_spec.triggers.append(object())\n"
         "    async def refresh(self, context):\n"
         "        return None\n"
         "    async def readiness_semantic_checks(self, context):\n"
+        "        self.job_spec.triggers.append(object())\n"
         "        value = await context.mcp_catalog.servers['feed'].client.call('fetch_events', {})\n"
         "        job = context.job_catalog.jobs['mcp_ready:refresh']\n"
         "        source = context.proactive_catalog.sources['mcp_ready:feed']\n"
         "        owned = getattr(job.spec.handler, '__self__', None) is self\n"
-        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id}\n"
-        "        return [PluginSemanticCheck('candidate_feed', value == '[]' and owned, evidence)]\n",
+        "        frozen = len(job.spec.triggers) == 1\n"
+        "        evidence = {'mcp': value, 'job_owned': owned, 'source': source.spec.id, 'frozen': frozen}\n"
+        "        return [PluginSemanticCheck('candidate_feed', value == '[]' and owned and frozen, evidence)]\n",
     )
     _write_mcp_server(
         plugin_dir,
@@ -949,6 +955,8 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     active = manager.generation("mcp_ready")
     assert active is not None and active.job_catalog is not None
     active_job = manager.jobs[0]
+    assert isinstance(active_job.spec.triggers, tuple)
+    assert len(active_job.spec.triggers) == 1
 
     prepared = await manager.prepare_candidate("mcp_ready")
 
@@ -973,6 +981,8 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     assert tuple(prepared.job_catalog.jobs) == ("mcp_ready:refresh",)
     assert tuple(prepared.proactive_catalog.sources) == ("mcp_ready:feed",)
     prepared_job = prepared.job_catalog.jobs["mcp_ready:refresh"]
+    assert isinstance(prepared_job.spec.triggers, tuple)
+    assert len(prepared_job.spec.triggers) == 1
     assert prepared_job.spec.handler.__self__ is prepared.instance  # type: ignore[attr-defined]
     assert manager.jobs == [active_job]
     assert active_job.spec.handler.__self__ is active.instance  # type: ignore[attr-defined]

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -20,6 +20,7 @@ from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
 from bus.event_bus import EventBus
+from bus.events_lifecycle import TurnCommitted
 
 
 @pytest.fixture(autouse=True)
@@ -473,7 +474,7 @@ async def test_candidate_is_not_published_before_initialize_finishes(tmp_path: P
 
     assert manager.generation("pending") is not None
     assert tools.get_tool("pending_tool") is not None
-    assert event_bus.handler_count() == 1
+    assert event_bus.handler_count() == 0
 
 
 @pytest.mark.asyncio
@@ -2029,6 +2030,87 @@ async def test_initial_plugin_mcp_tool_is_visible_in_first_snapshot(
 
     assert seen == ["[]"]
     await manager.terminate_all()
+
+
+def _snapshot_event_source(version: str) -> str:
+    wait = (
+        "        self.context.kv_store.set('event_entered_v1', True)\n"
+        "        release = self.context.data_dir / 'release-event-v1'\n"
+        "        while not release.exists():\n"
+        "            await asyncio.sleep(0.01)\n"
+        if version == "v1"
+        else ""
+    )
+    return (
+        "import asyncio\n"
+        "from agent.plugins import Plugin\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class SnapshotEventPlugin(Plugin):\n"
+        "    name = 'snapshot_event'\n"
+        "    async def initialize(self):\n"
+        "        self.context.event_bus.on(TurnCommitted, self.handle)\n"
+        "    async def handle(self, event):\n"
+        f"{wait}"
+        f"        self.context.kv_store.increment('event_finished_{version}')\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_event_keeps_enqueued_snapshot_generation(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_event",
+        _snapshot_event_source("v1"),
+    )
+    event_bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_event_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_event")
+    assert candidate is not None
+    event = TurnCommitted(
+        session_key="cli:event",
+        channel="cli",
+        chat_id="event",
+        input_message="event",
+        persisted_user_message="event",
+        assistant_response="event",
+        tools_used=[],
+    )
+    event_bus.enqueue(event)
+    state_path = tmp_path / "home" / "data" / "snapshot_event-builtin" / ".kv.json"
+    for _ in range(100):
+        if state_path.exists():
+            state: object = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(state, dict) and state.get("event_entered_v1") is True:
+                break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("v1 queued event did not start")
+
+    await manager.publish_prepared("snapshot_event")
+    _ = (state_path.parent / "release-event-v1").write_text(
+        "released\n",
+        encoding="utf-8",
+    )
+    await event_bus.drain()
+    await event_bus.fanout(event)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert state["event_finished_v1"] == 1
+    assert state["event_finished_v2"] == 1
+    assert event_bus.handler_count() == 0
+    await manager.terminate_all()
+    await event_bus.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1536,3 +1536,54 @@ async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
     assert manager.prepared_generation("snapshot_publish") is None
     assert candidate.state == "discarded"
     await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_changed_publishes_multiple_plugins_from_latest_snapshot(
+    tmp_path: Path,
+) -> None:
+    plugins = tmp_path / "plugins"
+
+    def source(name: str, version: str) -> str:
+        class_name = "".join(part.title() for part in name.split("_"))
+        return (
+            "from agent.plugins import Plugin\n"
+            f"class {class_name}Plugin(Plugin):\n"
+            f"    name = '{name}'\n"
+            f"    version = '{version}'\n"
+        )
+
+    first_dir = _write_plugin(plugins, "snapshot_first", source("snapshot_first", "v1"))
+    second_dir = _write_plugin(
+        plugins,
+        "snapshot_second",
+        source("snapshot_second", "v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    _ = (first_dir / "plugin.py").write_text(
+        source("snapshot_first", "v2"),
+        encoding="utf-8",
+    )
+    _ = (second_dir / "plugin.py").write_text(
+        source("snapshot_second", "v2"),
+        encoding="utf-8",
+    )
+
+    results = await manager.reconcile_changed()
+
+    assert [result["publication_state"] for result in results] == [
+        "committed",
+        "committed",
+    ]
+    first = manager.generation("snapshot_first")
+    second = manager.generation("snapshot_second")
+    snapshot = manager.current_snapshot
+    assert first is not None and second is not None and snapshot is not None
+    assert first.instance.version == "v2"  # type: ignore[attr-defined]
+    assert second.instance.version == "v2"  # type: ignore[attr-defined]
+    assert snapshot.generations == {
+        "snapshot_first": first,
+        "snapshot_second": second,
+    }
+    await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1065,13 +1065,10 @@ async def test_candidate_mcp_cleanup_failure_is_reported_and_catalog_removed(
     prepared = await manager.prepare_candidate("mcp_cleanup")
     assert prepared is not None and prepared.mcp_catalog is not None
     client = prepared.mcp_catalog.servers["cleanup"].client
-    disconnect = client.disconnect
-
-    async def fail_after_disconnect() -> None:
-        await disconnect()
+    async def fail_before_disconnect() -> None:
         raise OSError("mcp cleanup failed")
 
-    monkeypatch.setattr(client, "disconnect", fail_after_disconnect)
+    monkeypatch.setattr(client, "disconnect", fail_before_disconnect)
     await manager.discard_prepared("mcp_cleanup")
 
     assert manager.mcp_catalog(prepared.generation_id) is None

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import os
 import py_compile
 import shutil
@@ -1434,4 +1435,104 @@ async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
     assert detached_seen == [None]
     await detached_tasks[0]
     await store.close()
+    await manager.terminate_all()
+
+
+def _snapshot_publish_source(version: str, *, fail_initialize: bool = False) -> str:
+    initialize = (
+        "        self.context.kv_store.set('initialized', 'v2')\n"
+        "        raise RuntimeError('initialize failed')\n"
+        if fail_initialize
+        else f"        self.context.kv_store.set('initialized', '{version}')\n"
+    )
+    return (
+        "from agent.plugins import Plugin\n"
+        "class SnapshotModule:\n"
+        "    slot = 'snapshot_publish.before_turn'\n"
+        "    requires = ('before_turn.emit',)\n"
+        f"    version = '{version}'\n"
+        "    async def run(self, frame): return frame\n"
+        "class SnapshotPublishPlugin(Plugin):\n"
+        "    name = 'snapshot_publish'\n"
+        "    def before_turn_modules(self): return [SnapshotModule()]\n"
+        "    async def initialize(self):\n"
+        f"{initialize}"
+        "    async def terminate(self):\n"
+        "        self.context.kv_store.set('terminated', True)\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_prepared_switches_snapshot_after_initialize(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_publish")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    old_lease = manager.snapshot_store.lease()
+
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None
+    assert candidate.initialization_started is False
+
+    result = await manager.publish_prepared("snapshot_publish")
+
+    assert result["publication_state"] == "committed"
+    assert manager.generation("snapshot_publish") is candidate
+    assert manager.current_snapshot is candidate.runtime_snapshot
+    assert candidate.initialization_started is True
+    assert active.state == "retained_compat"
+    assert old_lease.snapshot is old_snapshot
+    assert old_lease.snapshot.before_turn_modules[0].version == "v1"
+    next_lease = manager.snapshot_store.lease()
+    assert next_lease.snapshot.before_turn_modules[0].version == "v2"
+    state = tmp_path / "home" / "data" / "snapshot_publish-builtin" / ".kv.json"
+    state_value: object = json.loads(state.read_text(encoding="utf-8"))
+    assert isinstance(state_value, dict)
+    assert state_value["initialized"] == "v2"
+
+    await next_lease.release()
+    await old_lease.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_publish")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2", fail_initialize=True),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None
+
+    result = await manager.publish_prepared("snapshot_publish")
+
+    assert result["publication_state"] == "failed"
+    assert manager.generation("snapshot_publish") is active
+    assert manager.current_snapshot is old_snapshot
+    assert manager.prepared_generation("snapshot_publish") is None
+    assert candidate.state == "discarded"
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2749,6 +2749,11 @@ async def test_dashboard_candidate_cannot_override_core_route(tmp_path: Path) ->
     assert TestClient(app).get("/api/dashboard/plugin-owned").json() == {
         "owner": "plugin"
     }
+    write_dashboard("/api/dashboard/{rest:path}")
+    assert await manager.prepare_candidate("dashboard_conflict") is not None
+    wildcard_result = await manager.publish_prepared("dashboard_conflict")
+    assert wildcard_result["publication_state"] == "failed"
+    assert manager.generation("dashboard_conflict") is old_generation
     await manager.terminate_all()
 
 
@@ -2782,7 +2787,7 @@ async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) 
             encoding="utf-8",
         )
 
-    write_dashboard(first_dir, "/api/dashboard/first")
+    write_dashboard(first_dir, "/api/dashboard/items/{id}")
     write_dashboard(second_dir, "/api/dashboard/second")
     manager = _manager(tmp_path)
     await manager.load_all()
@@ -2792,7 +2797,7 @@ async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) 
         memory_admin=SimpleNamespace(),
         plugin_manager=manager,
     )
-    write_dashboard(second_dir, "/api/dashboard/first")
+    write_dashboard(second_dir, "/api/dashboard/items/{name}")
     assert await manager.prepare_candidate("dashboard_second") is not None
 
     result = await manager.publish_prepared("dashboard_second")

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.testclient import TestClient
 
 from agent.plugins.manager import PluginManager
 from agent.plugins.jobs import PluginJobRuntime
@@ -20,6 +21,7 @@ from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
 from agent.background.subagent_manager import SubagentManager
 from proactive_v2.loop import ProactiveLoop
+from bootstrap.dashboard_api import create_dashboard_app
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
@@ -2649,6 +2651,52 @@ async def test_subagent_shutdown_releases_unstarted_snapshot_lease() -> None:
 
     assert snapshot.lease_count == 0
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_dashboard",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotDashboardPlugin(Plugin):\n"
+        "    name = 'snapshot_dashboard'\n"
+        "    @classmethod\n"
+        "    def dashboard_module(cls): return 'dashboard.py'\n",
+    )
+
+    def write_dashboard(version: str) -> None:
+        _ = (plugin_dir / "dashboard.py").write_text(
+            "from fastapi import FastAPI\n"
+            "def register(app: FastAPI, plugin_dir, workspace):\n"
+            "    @app.get('/api/dashboard/snapshot-version')\n"
+            f"    def version(): return {{'version': '{version}'}}\n",
+            encoding="utf-8",
+        )
+
+    write_dashboard("v1")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_snapshot = manager.current_snapshot
+    assert old_snapshot is not None
+    app = create_dashboard_app(
+        tmp_path / "workspace",
+        memory_admin=SimpleNamespace(),
+        plugin_manager=manager,
+    )
+    client = TestClient(app)
+    assert client.get("/api/dashboard/snapshot-version").json() == {"version": "v1"}
+    write_dashboard("v2")
+    assert await manager.prepare_candidate("snapshot_dashboard") is not None
+    await manager.publish_prepared("snapshot_dashboard")
+
+    assert client.get("/api/dashboard/snapshot-version").json() == {"version": "v2"}
+    old_binding = old_snapshot.dashboard_bindings[0]
+    assert TestClient(old_binding.app).get(  # type: ignore[attr-defined]
+        "/api/dashboard/snapshot-version"
+    ).json() == {"version": "v1"}
+    client.close()
+    await manager.terminate_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -3331,7 +3331,10 @@ def test_dashboard_rejects_custom_path_convertor(
         _plugin_routes(app.routes)
 
 
-def test_dashboard_treats_missing_methods_as_wildcard() -> None:
+@pytest.mark.parametrize("wildcard_methods", [None, set()])
+def test_dashboard_treats_missing_methods_as_wildcard(
+    wildcard_methods: set[str] | None,
+) -> None:
     core_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
     plugin_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
 
@@ -3344,7 +3347,7 @@ def test_dashboard_treats_missing_methods_as_wildcard() -> None:
         return {"plugin": True}
 
     core_routes = _plugin_routes(core_app.routes)
-    core_routes[0].methods = None
+    core_routes[0].methods = wildcard_methods
     binding = DashboardBinding(
         plugin_id="wildcard",
         app=plugin_app,

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -18,6 +18,7 @@ from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
+from agent.background.subagent_manager import SubagentManager
 from proactive_v2.loop import ProactiveLoop
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
@@ -2625,6 +2626,29 @@ async def test_tool_hooks_follow_bound_snapshot_generation(tmp_path: Path) -> No
     assert old_result.final_arguments == {"version": "v1"}
     assert new_result.final_arguments == {"version": "v2"}
     await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_subagent_shutdown_releases_unstarted_snapshot_lease() -> None:
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({})
+    store.install(snapshot)
+    snapshot_lease = store.lease()
+    manager = object.__new__(SubagentManager)
+    manager._running_tasks = {}
+    manager._running_jobs = {}
+    manager._cancel_announced = set()
+    manager._snapshot_release_tasks = set()
+    task = asyncio.create_task(asyncio.Event().wait())
+    manager._running_tasks["job"] = task
+    task.add_done_callback(
+        lambda _: manager._finish_background_job("job", snapshot_lease)
+    )
+
+    await manager.shutdown()
+
+    assert snapshot.lease_count == 0
+    await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -17,6 +17,7 @@ from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from agent.looping.core import AgentLoop
+from proactive_v2.loop import ProactiveLoop
 from agent.skills import SkillsLoader
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool
@@ -2333,14 +2334,16 @@ async def test_running_fanout_cancellation_releases_observer_leases() -> None:
     await store.close()
 
 
-def _snapshot_job_source(version: str) -> str:
+def _snapshot_job_source(version: str, *, event_trigger: bool = False) -> str:
+    triggers = "[EventTrigger(TurnCommitted)]" if event_trigger else "[]"
     return (
-        "from agent.plugins import Plugin, PluginJobSpec\n"
+        "from agent.plugins import EventTrigger, Plugin, PluginJobSpec\n"
         "from agent.plugins.snapshot import get_current_runtime_snapshot\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
         "class SnapshotJobPlugin(Plugin):\n"
         "    name = 'snapshot_job'\n"
         "    def jobs(self):\n"
-        "        return [PluginJobSpec(id='refresh', triggers=[], handler=self.refresh)]\n"
+        f"        return [PluginJobSpec(id='refresh', triggers={triggers}, handler=self.refresh)]\n"
         "    async def refresh(self, context):\n"
         f"        self.context.kv_store.increment('job_{version}')\n"
         "        snapshot = get_current_runtime_snapshot()\n"
@@ -2403,6 +2406,130 @@ async def test_job_queue_envelope_keeps_enqueued_snapshot_generation(
     runtime.stop()
     await running
     await event_bus.aclose()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_job_event_trigger_uses_event_snapshot_catalog(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_job",
+        _snapshot_job_source("v1", event_trigger=True),
+    )
+    event_bus = EventBus()
+    llm = SimpleNamespace()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        llm=llm,
+        installed_cache_root=tmp_path / "home/cache",
+    )
+    await manager.load_all()
+    old_lease = manager.snapshot_store.lease()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_job_source("v2", event_trigger=False),
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("snapshot_job") is not None
+    await manager.publish_prepared("snapshot_job")
+    runtime = PluginJobRuntime(
+        event_bus=event_bus,
+        llm=llm,
+        snapshot_store=manager.snapshot_store,
+    )
+    running = asyncio.create_task(runtime.run())
+    await asyncio.sleep(0)
+    from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+    token = bind_runtime_snapshot(old_lease)
+    try:
+        await event_bus.fanout(
+            TurnCommitted(
+                session_key="cli:event",
+                channel="cli",
+                chat_id="event",
+                input_message="event",
+                persisted_user_message="event",
+                assistant_response="event",
+                tools_used=[],
+            )
+        )
+    finally:
+        reset_runtime_snapshot(token)
+        await old_lease.release()
+    state_path = tmp_path / "home/data/snapshot_job-builtin/.kv.json"
+    for _ in range(100):
+        if state_path.exists() and json.loads(
+            state_path.read_text(encoding="utf-8")
+        ).get("job_v1") == 1:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("v1 event job did not run")
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state.get("job_v2") is None
+    runtime.stop()
+    await running
+    await event_bus.aclose()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_proactive_tick_keeps_one_snapshot_generation(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_tick",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotTickPlugin(Plugin):\n"
+        "    name = 'snapshot_tick'\n"
+        "    version = 'v1'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    old_snapshot = manager.current_snapshot
+    assert old_snapshot is not None
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[str] = []
+
+    async def run_tick(_session_key: str) -> None:
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        snapshot = get_current_runtime_snapshot()
+        assert snapshot is not None
+        seen.append(snapshot.snapshot_id)
+        if len(seen) == 1:
+            entered.set()
+            await release.wait()
+
+    loop = object.__new__(ProactiveLoop)
+    loop._runtime_snapshot_store = manager.snapshot_store
+    loop._sense = SimpleNamespace(target_session_key=lambda: "cli:tick")
+    loop._proactive_kernel = SimpleNamespace(run_tick=run_tick)
+
+    async def switch_snapshot(_snapshot) -> None:
+        return None
+
+    loop._switch_snapshot = switch_snapshot
+    first_tick = asyncio.create_task(loop._tick())
+    await entered.wait()
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class SnapshotTickPlugin(Plugin):\n"
+        "    name = 'snapshot_tick'\n"
+        "    version = 'v2'\n",
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("snapshot_tick") is not None
+    await manager.publish_prepared("snapshot_tick")
+    new_snapshot = manager.current_snapshot
+    assert new_snapshot is not None
+    release.set()
+    await first_tick
+    await loop._tick()
+
+    assert seen == [old_snapshot.snapshot_id, new_snapshot.snapshot_id]
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1252,6 +1252,90 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_snapshot_admission_waits_while_current_is_quiesced(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_admission",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotAdmissionPlugin(Plugin):\n"
+        "    name = 'snapshot_admission'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    snapshot = manager.current_snapshot
+    assert snapshot is not None
+    held = manager.snapshot_store.lease()
+    quiescing = asyncio.create_task(manager.snapshot_store.quiesce_current())
+    waiting = asyncio.create_task(manager.snapshot_store.acquire())
+    await asyncio.sleep(0)
+    assert not quiescing.done()
+    assert not waiting.done()
+
+    await held.release()
+    assert await quiescing is snapshot
+    assert not waiting.done()
+    await manager.snapshot_store.resume(snapshot)
+    admitted = await waiting
+    assert admitted.snapshot is snapshot
+
+    await admitted.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_publish_drains_old_snapshot_before_switch(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "service_admission",
+        "from agent.plugins import ManagedServiceSpec, Plugin\n"
+        "class ServiceAdmissionPlugin(Plugin):\n"
+        "    name = 'service_admission'\n"
+        "    version = 'v1'\n"
+        "    @classmethod\n"
+        "    def managed_services(cls):\n"
+        "        return [ManagedServiceSpec(id='worker', command=('python', 'service.py'))]\n",
+    )
+    _ = (plugin_dir / "service.py").write_text("pass\n", encoding="utf-8")
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    held = manager.snapshot_store.lease()
+    switched = asyncio.Event()
+
+    async def switch_services(plugin_id, old_services, new_services) -> None:
+        assert plugin_id == "service_admission"
+        assert old_services["worker"]["revision"] != new_services["worker"]["revision"]
+        switched.set()
+
+    manager.bind_service_switcher(switch_services)
+    source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
+    _ = (plugin_dir / "plugin.py").write_text(
+        source.replace("version = 'v1'", "version = 'v2'"),
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("service_admission") is not None
+    publishing = asyncio.create_task(manager.publish_prepared("service_admission"))
+    await asyncio.sleep(0)
+    waiting = asyncio.create_task(manager.snapshot_store.acquire())
+    await asyncio.sleep(0)
+    assert not switched.is_set()
+    assert not waiting.done()
+
+    await held.release()
+    result = await publishing
+    admitted = await waiting
+
+    assert result["publication_state"] == "committed"
+    assert switched.is_set()
+    assert admitted.snapshot is manager.current_snapshot
+    await admitted.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_runtime_snapshot_drain_retry_and_store_ownership(tmp_path: Path) -> None:
     _write_plugin(
         tmp_path / "plugins",
@@ -2513,6 +2597,7 @@ async def test_proactive_tick_keeps_one_snapshot_generation(tmp_path: Path) -> N
 
     loop = object.__new__(ProactiveLoop)
     loop._runtime_snapshot_store = manager.snapshot_store
+    loop._reload_lock = asyncio.Lock()
     loop._sense = SimpleNamespace(target_session_key=lambda: "cli:tick")
     loop._proactive_kernel = SimpleNamespace(run_tick=run_tick)
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -21,7 +22,11 @@ from agent.plugins.manifest import write_plugin_manifest
 from agent.plugins.watcher import PluginWatcher
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
-from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
+from agent.plugins.snapshot import (
+    RuntimeSnapshot,
+    RuntimeSnapshotCompiler,
+    RuntimeSnapshotStore,
+)
 from agent.looping.core import AgentLoop
 from agent.background.subagent_manager import SubagentManager
 from proactive_v2.loop import ProactiveLoop
@@ -920,7 +925,7 @@ async def test_skill_catalog_cleanup_failure_is_reported(
     snapshot_root = generation.skill_catalog.snapshot_root
     real_rmtree = shutil.rmtree
 
-    def fail_snapshot_cleanup(path: Path, *args: object, **kwargs: object) -> None:
+    def fail_snapshot_cleanup(path: Path, *args: Any, **kwargs: Any) -> None:
         if Path(path) == snapshot_root and not args and not kwargs:
             raise OSError("snapshot cleanup failed")
         real_rmtree(path, *args, **kwargs)
@@ -1575,7 +1580,7 @@ async def test_passive_runtime_admission_holds_one_snapshot(tmp_path: Path) -> N
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:snapshot")
+    message = cast(Any, SimpleNamespace(session_key="cli:snapshot"))
     running = asyncio.create_task(loop._process_with_runtime_admission(message))
     await entered.wait()
     transaction = store.begin_publish(v2)
@@ -1635,7 +1640,7 @@ async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:detached-snapshot")
+    message = cast(Any, SimpleNamespace(session_key="cli:detached-snapshot"))
     assert await loop._process_with_runtime_admission(message) == "done"
     assert snapshot.lease_count == 0
     detached_release.set()
@@ -2316,7 +2321,7 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:snapshot-tool")
+    message = cast(Any, SimpleNamespace(session_key="cli:snapshot-tool"))
     old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
     await entered.wait()
     await manager.publish_prepared("snapshot_tool")
@@ -2538,7 +2543,7 @@ async def test_initial_plugin_mcp_tool_is_visible_in_first_snapshot(
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:initial-mcp")
+    message = cast(Any, SimpleNamespace(session_key="cli:initial-mcp"))
     await loop._process_with_runtime_admission(message)
 
     assert seen == ["[]"]
@@ -2617,7 +2622,10 @@ async def test_queued_event_keeps_enqueued_snapshot_generation(
     )
     await event_bus.drain()
     await event_bus.fanout(event)
-    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state = cast(
+        dict[str, object],
+        json.loads(state_path.read_text(encoding="utf-8")),
+    )
 
     assert state["event_finished_v1"] == 1
     assert state["event_finished_v2"] == 1
@@ -2826,7 +2834,7 @@ async def test_job_queue_envelope_keeps_enqueued_snapshot_generation(
         _snapshot_job_source("v1"),
     )
     event_bus = EventBus()
-    llm = SimpleNamespace()
+    llm = cast(Any, SimpleNamespace())
     manager = PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
@@ -2882,7 +2890,7 @@ async def test_job_event_trigger_uses_event_snapshot_catalog(tmp_path: Path) -> 
         _snapshot_job_source("v1", event_trigger=True),
     )
     event_bus = EventBus()
-    llm = SimpleNamespace()
+    llm = cast(Any, SimpleNamespace())
     manager = PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
@@ -3102,7 +3110,10 @@ async def test_subagent_shutdown_releases_unstarted_snapshot_lease() -> None:
     manager._running_jobs = {}
     manager._cancel_announced = set()
     manager._snapshot_release_tasks = set()
-    task = asyncio.create_task(asyncio.Event().wait())
+    async def wait_forever() -> None:
+        _ = await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever())
     manager._running_tasks["job"] = task
     task.add_done_callback(
         lambda _: manager._finish_background_job("job", snapshot_lease)
@@ -3148,7 +3159,7 @@ async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> No
     old_lease = manager.snapshot_store.lease()
     app = create_dashboard_app(
         tmp_path / "workspace",
-        memory_admin=SimpleNamespace(),
+        memory_admin=cast(Any, SimpleNamespace()),
         plugin_manager=manager,
     )
     client = TestClient(app)
@@ -3206,7 +3217,7 @@ async def test_dashboard_candidate_cannot_override_core_route(tmp_path: Path) ->
     old_generation = manager.generation("dashboard_conflict")
     app = create_dashboard_app(
         tmp_path / "workspace",
-        memory_admin=SimpleNamespace(),
+        memory_admin=cast(Any, SimpleNamespace()),
         plugin_manager=manager,
     )
     write_dashboard("/api/dashboard/sessions", async_close=True)
@@ -3265,7 +3276,7 @@ async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) 
     old_generation = manager.generation("dashboard_second")
     _ = create_dashboard_app(
         tmp_path / "workspace",
-        memory_admin=SimpleNamespace(),
+        memory_admin=cast(Any, SimpleNamespace()),
         plugin_manager=manager,
     )
     write_dashboard(second_dir, "/api/dashboard/items/{name}")
@@ -3301,7 +3312,7 @@ async def test_dashboard_allows_static_route_before_dynamic_route(tmp_path: Path
     await manager.load_all()
     app = create_dashboard_app(
         tmp_path / "workspace",
-        memory_admin=SimpleNamespace(),
+        memory_admin=cast(Any, SimpleNamespace()),
         plugin_manager=manager,
     )
     client = TestClient(app)
@@ -3409,7 +3420,7 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:snapshot-skill")
+    message = cast(Any, SimpleNamespace(session_key="cli:snapshot-skill"))
     old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
     await entered.wait()
     await manager.publish_prepared("snapshot_skill")
@@ -3459,7 +3470,7 @@ async def test_workspace_skill_updates_without_plugin_snapshot_reload(
         return "done"
 
     loop._process = process
-    message = SimpleNamespace(session_key="cli:workspace-skill")
+    message = cast(Any, SimpleNamespace(session_key="cli:workspace-skill"))
     await loop._process_with_runtime_admission(message)
     _ = skill_file.write_text(
         "---\ndescription: workspace live\n---\nworkspace v2\n",

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2154,6 +2154,101 @@ async def test_queued_event_keeps_enqueued_snapshot_generation(
 
 
 @pytest.mark.asyncio
+async def test_snapshot_event_subscription_close_takes_effect_immediately(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_event",
+        "from agent.plugins import Plugin\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class SnapshotEventPlugin(Plugin):\n"
+        "    name = 'snapshot_event'\n"
+        "    async def initialize(self):\n"
+        "        self.subscription = self.context.event_bus.on(TurnCommitted, self.handle)\n"
+        "    def handle(self, event):\n"
+        "        self.context.kv_store.increment('events')\n",
+    )
+    event_bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    generation = manager.generation("snapshot_event")
+    assert generation is not None
+    generation.instance.subscription.close()
+    event = TurnCommitted(
+        session_key="cli:event",
+        channel="cli",
+        chat_id="event",
+        input_message="event",
+        persisted_user_message="event",
+        assistant_response="event",
+        tools_used=[],
+    )
+
+    await event_bus.fanout(event)
+
+    state_path = tmp_path / "home/data/snapshot_event-builtin/.kv.json"
+    assert not state_path.exists()
+    with pytest.raises(RuntimeError, match="只能在 initialize"):
+        generation.instance.context.event_bus.on(TurnCommitted, lambda _: None)
+    await event_bus.aclose()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_shutdown_drains_snapshot_lease_before_plugins(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_event",
+        _snapshot_event_source("v1"),
+    )
+    event_bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=event_bus,
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    event_bus.enqueue(
+        TurnCommitted(
+            session_key="cli:event",
+            channel="cli",
+            chat_id="event",
+            input_message="event",
+            persisted_user_message="event",
+            assistant_response="event",
+            tools_used=[],
+        )
+    )
+    state_path = tmp_path / "home/data/snapshot_event-builtin/.kv.json"
+    for _ in range(100):
+        if state_path.exists() and json.loads(
+            state_path.read_text(encoding="utf-8")
+        ).get("event_entered_v1") is True:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("queued event did not start")
+
+    closing = asyncio.create_task(event_bus.aclose())
+    await asyncio.sleep(0)
+    assert closing.done() is False
+    _ = (state_path.parent / "release-event-v1").write_text(
+        "released\n",
+        encoding="utf-8",
+    )
+    await closing
+    await manager.terminate_all()
+    assert manager.snapshot_store.current is None
+
+
+@pytest.mark.asyncio
 async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugins" / "snapshot_skill"
     for version in ("v1", "v2"):

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1354,14 +1354,14 @@ async def test_passive_runtime_admission_holds_one_snapshot(tmp_path: Path) -> N
     seen: list[str] = []
 
     async def process(msg, **kwargs):
-        from agent.plugins.snapshot import current_runtime_snapshot
+        from agent.plugins.snapshot import get_current_runtime_snapshot
 
-        snapshot = current_runtime_snapshot.get()
+        snapshot = get_current_runtime_snapshot()
         assert snapshot is not None
         seen.append(snapshot.snapshot_id)
         entered.set()
         await release.wait()
-        assert current_runtime_snapshot.get() is snapshot
+        assert get_current_runtime_snapshot() is snapshot
         seen.append(snapshot.snapshot_id)
         return "done"
 
@@ -1379,4 +1379,55 @@ async def test_passive_runtime_admission_holds_one_snapshot(tmp_path: Path) -> N
     assert seen[-2:] == [v2.snapshot_id, v2.snapshot_id]
     await store.close()
     await manager.discard_prepared("passive_snapshot")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "detached_snapshot",
+        "from agent.plugins import Plugin\n"
+        "class DetachedSnapshotPlugin(Plugin):\n"
+        "    name = 'detached_snapshot'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    generation = manager.generation("detached_snapshot")
+    assert generation is not None
+    snapshot = RuntimeSnapshotCompiler().compile(
+        {"detached_snapshot": generation},
+        catalog_generation=generation,
+    )
+    store = RuntimeSnapshotStore()
+    store.install(snapshot)
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = store
+    detached_seen: list[RuntimeSnapshot | None] = []
+    detached_done = asyncio.Event()
+
+    async def detached() -> None:
+        await asyncio.sleep(0)
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        detached_seen.append(get_current_runtime_snapshot())
+        detached_done.set()
+
+    async def process(msg, **kwargs):
+        from agent.plugins.snapshot import get_current_runtime_snapshot
+
+        assert get_current_runtime_snapshot() is snapshot
+        asyncio.create_task(detached())
+        await detached_done.wait()
+        assert get_current_runtime_snapshot() is snapshot
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:detached-snapshot")
+    assert await loop._process_with_runtime_admission(message) == "done"
+    assert detached_seen == [None]
+    await store.close()
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1001,11 +1001,11 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     assert manager.jobs == [active_job]
     assert active_job.spec.handler.__self__ is active.instance  # type: ignore[attr-defined]
     lifecycle = tmp_path / "home" / "data" / "mcp_ready-builtin" / "mcp-lifecycle.log"
-    await _wait_for_log(lifecycle, ["started"])
+    await _wait_for_log(lifecycle, ["started", "started"])
 
     await manager.discard_prepared("mcp_ready")
 
-    await _wait_for_log(lifecycle, ["started", "stopped"])
+    await _wait_for_log(lifecycle, ["started", "started", "stopped"])
     assert manager.mcp_catalog(prepared.generation_id) is None
     assert manager.job_catalog(prepared.generation_id) is None
     assert manager.proactive_catalog(prepared.generation_id) is None
@@ -1066,8 +1066,19 @@ async def test_candidate_mcp_readiness_failure_closes_process(
         + readiness,
     )
     _write_mcp_server(plugin_dir, ("fetch_events",))
+    invalid_source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class McpRejectedPlugin(Plugin):\n"
+        "    name = 'mcp_rejected'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='feed', command=('python', 'server.py'))]\n",
+        encoding="utf-8",
+    )
     manager = _manager(tmp_path)
     await manager.load_all()
+    _ = (plugin_dir / "plugin.py").write_text(invalid_source, encoding="utf-8")
 
     prepared = await manager.prepare_candidate("mcp_rejected")
 
@@ -1080,7 +1091,7 @@ async def test_candidate_mcp_readiness_failure_closes_process(
         "mcp_readiness" if failure == "missing_tool" else "readiness_semantic_checks"
     ) in failed_checks
     lifecycle = tmp_path / "home" / "data" / "mcp_rejected-builtin" / "mcp-lifecycle.log"
-    await _wait_for_log(lifecycle, ["started", "stopped"])
+    await _wait_for_log(lifecycle, ["started", "started", "stopped"])
     await manager.terminate_all()
 
 
@@ -1869,7 +1880,7 @@ async def test_removed_plugin_mcp_server_does_not_leak_from_live_registry(
         "    def mcp_servers(cls):\n"
         "        return [McpServerSpec(name='removed_server', command=('python', 'server.py'))]\n",
     )
-    _ = (plugin_dir / "server.py").write_text("", encoding="utf-8")
+    _write_mcp_server(plugin_dir, ("legacy",))
     tools = ToolRegistry()
     manager = _manager(tmp_path, tools=tools)
     await manager.load_all()
@@ -1919,6 +1930,105 @@ def test_tool_registry_fork_preserves_registration_order() -> None:
         registry.register(tool_class())
 
     assert registry.fork().get_registered_order() == expected
+
+
+@pytest.mark.asyncio
+async def test_failed_candidate_mcp_name_does_not_hide_user_mcp(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "candidate_mcp_pollution",
+        "from agent.plugins import Plugin\n"
+        "class CandidateMcpPollutionPlugin(Plugin):\n"
+        "    name = 'candidate_mcp_pollution'\n"
+        "    version = 'v1'\n",
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+
+    class UserMcpTool(Tool):
+        name = "mcp_candidate_failed__user"
+        description = "user mcp"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self) -> str:
+            return "user"
+
+    tools.register(
+        UserMcpTool(),
+        source_type="mcp",
+        source_name="candidate_failed",
+    )
+    _ = (plugin_dir / "fail.py").write_text(
+        "raise RuntimeError('candidate failed')\n",
+        encoding="utf-8",
+    )
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class CandidateMcpPollutionPlugin(Plugin):\n"
+        "    name = 'candidate_mcp_pollution'\n"
+        "    version = 'v2'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='candidate_failed', command=('python', 'fail.py'))]\n",
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("candidate_mcp_pollution") is None
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class CandidateMcpPollutionPlugin(Plugin):\n"
+        "    name = 'candidate_mcp_pollution'\n"
+        "    version = 'v3'\n",
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("candidate_mcp_pollution")
+    assert candidate is not None and candidate.runtime_snapshot is not None
+    registry = candidate.runtime_snapshot.tool_registry
+    assert registry is not None
+    assert registry.has_tool("mcp_candidate_failed__user") is True
+    await manager.discard_prepared("candidate_mcp_pollution")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_initial_plugin_mcp_tool_is_visible_in_first_snapshot(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "initial_mcp_snapshot",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class InitialMcpSnapshotPlugin(Plugin):\n"
+        "    name = 'initial_mcp_snapshot'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='initial_snapshot', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(plugin_dir, ("version",))
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+    generation = manager.generation("initial_mcp_snapshot")
+    assert generation is not None and generation.mcp_catalog is not None
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = manager.snapshot_store
+    seen: list[str] = []
+
+    async def process(msg, **kwargs):
+        seen.append(
+            str(await tools.execute("mcp_initial_snapshot__version", {}))
+        )
+        return "done"
+
+    loop._process = process
+    message = SimpleNamespace(session_key="cli:initial-mcp")
+    await loop._process_with_runtime_admission(message)
+
+    assert seen == ["[]"]
+    await manager.terminate_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1868,7 +1868,7 @@ async def test_tool_schema_search_and_execute_share_snapshot_generation(
 
 
 @pytest.mark.asyncio
-async def test_removed_plugin_mcp_server_does_not_leak_from_live_registry(
+async def test_removed_plugin_mcp_server_releases_name_for_user_registry(
     tmp_path: Path,
 ) -> None:
     plugin_dir = _write_plugin(
@@ -1909,8 +1909,48 @@ async def test_removed_plugin_mcp_server_does_not_leak_from_live_registry(
     assert candidate is not None and candidate.runtime_snapshot is not None
     registry = candidate.runtime_snapshot.tool_registry
     assert registry is not None
-    assert registry.has_tool("mcp_removed_server__legacy") is False
+    assert registry.has_tool("mcp_removed_server__legacy") is True
     await manager.discard_prepared("removed_mcp")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_plugin_mcp_server_cannot_replace_user_registry_server(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "mcp_collision",
+        "from agent.plugins import Plugin\n"
+        "class McpCollisionPlugin(Plugin):\n"
+        "    name = 'mcp_collision'\n",
+    )
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    await manager.load_all()
+
+    class UserMcpTool(Tool):
+        name = "mcp_user_server__value"
+        description = "user"
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self) -> str:
+            return "user"
+
+    tools.register(UserMcpTool(), source_type="mcp", source_name="user_server")
+    _write_mcp_server(plugin_dir, ("value",))
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class McpCollisionPlugin(Plugin):\n"
+        "    name = 'mcp_collision'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='user_server', command=('python', 'server.py'))]\n",
+        encoding="utf-8",
+    )
+
+    assert await manager.prepare_candidate("mcp_collision") is None
+    assert await tools.execute("mcp_user_server__value", {}) == "user"
     await manager.terminate_all()
 
 

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -3274,6 +3274,42 @@ async def test_dashboard_candidate_cannot_override_other_plugin(tmp_path: Path) 
     await manager.terminate_all()
 
 
+@pytest.mark.asyncio
+async def test_dashboard_allows_static_route_before_dynamic_route(tmp_path: Path) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "dashboard_ordered",
+        "from agent.plugins import Plugin\n"
+        "class DashboardOrderedPlugin(Plugin):\n"
+        "    name = 'dashboard_ordered'\n"
+        "    @classmethod\n"
+        "    def dashboard_module(cls): return 'dashboard.py'\n",
+    )
+    _ = (plugin_dir / "dashboard.py").write_text(
+        "def register(app, plugin_dir, workspace):\n"
+        "    @app.get('/api/dashboard/items/overview')\n"
+        "    def overview(): return {'route': 'overview'}\n"
+        "    @app.get('/api/dashboard/items/{item_id}')\n"
+        "    def detail(item_id): return {'route': item_id}\n",
+        encoding="utf-8",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    app = create_dashboard_app(
+        tmp_path / "workspace",
+        memory_admin=SimpleNamespace(),
+        plugin_manager=manager,
+    )
+    client = TestClient(app)
+
+    assert client.get("/api/dashboard/items/overview").json() == {
+        "route": "overview"
+    }
+    assert client.get("/api/dashboard/items/42").json() == {"route": "42"}
+    client.close()
+    await manager.terminate_all()
+
+
 def test_dashboard_rejects_custom_path_convertor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_plugin_hot_reload_probe.py
+++ b/tests/test_plugin_hot_reload_probe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_PROBE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docker/debug/plugin_hot_reload_probe.py"
+)
+_SPEC = importlib.util.spec_from_file_location("plugin_hot_reload_probe", _PROBE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+probe = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = probe
+_SPEC.loader.exec_module(probe)
+
+
+def test_integrity_gate_fails_when_any_check_fails() -> None:
+    checks = [
+        probe.CheckResult("read_only", True, {}),
+        probe.CheckResult("repositories_unchanged", False, {}),
+    ]
+
+    assert probe._gate_status(checks) == "failed"
+
+
+def test_controller_rejects_protected_sandbox() -> None:
+    root = Path("/workspace").resolve()
+
+    assert probe._sandbox_is_protected(root / "gate", [root])
+    assert not probe._sandbox_is_protected(Path("/tmp/gate"), [root])
+
+
+def test_system_gate_propagates_subgate_failure() -> None:
+    baseline = {
+        "build_returncode": 0,
+        "integrity_returncode": 0,
+        "smoke_passed": True,
+        "cleanup_returncode": 0,
+        "unchanged": True,
+        "controller_error": "",
+    }
+    assert probe._controller_gate_passed(**baseline)
+
+    for key, value in (
+        ("build_returncode", 1),
+        ("integrity_returncode", 1),
+        ("smoke_passed", False),
+        ("cleanup_returncode", 1),
+        ("unchanged", False),
+        ("controller_error", "boom"),
+    ):
+        failed = {**baseline, key: value}
+        assert not probe._controller_gate_passed(**failed)

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -6,7 +6,11 @@ import tomllib
 from pathlib import Path
 
 import agent.plugins.install as install_module
-from agent.plugins.install import install_git_plugin
+from agent.plugins.install import (
+    install_git_plugin,
+    set_installed_plugin_enabled,
+    uninstall_plugin,
+)
 
 
 def test_install_git_plugin_uses_programmatic_declaration(tmp_path: Path) -> None:
@@ -79,6 +83,66 @@ def test_install_git_plugin_prepares_declared_mcp_runtime(
         ("feed pip install", result.installed_path / "mcp"),
     ]
     assert not (result.installed_path / "mcp" / "servers.json").exists()
+
+
+def test_plugin_enable_disable_and_uninstall_preserve_data(tmp_path: Path) -> None:
+    home = tmp_path / "plugins-home"
+    cache = home / "cache" / "github" / "fitbit" / "1.0.0"
+    data = home / "data" / "fitbit-github"
+    cache.mkdir(parents=True)
+    data.mkdir(parents=True)
+    (cache / "plugin.py").write_text("", encoding="utf-8")
+    state = data / "sleep-model.bin"
+    state.write_bytes(b"model")
+    (home / "manifest.toml").write_text(
+        '[plugins."fitbit@github"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+
+    set_installed_plugin_enabled(
+        "fitbit@github",
+        enabled=False,
+        plugins_home=home,
+    )
+    manifest = tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8"))
+    assert manifest["plugins"]["fitbit@github"]["enabled"] is False
+
+    set_installed_plugin_enabled(
+        "fitbit@github",
+        enabled=True,
+        plugins_home=home,
+    )
+    removed_cache, retained_data = uninstall_plugin(
+        "fitbit@github",
+        plugins_home=home,
+    )
+
+    assert removed_cache == home / "cache" / "github" / "fitbit"
+    assert not removed_cache.exists()
+    assert retained_data == data
+    assert state.read_bytes() == b"model"
+    assert tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8")) == {
+        "plugins": {}
+    }
+
+
+def test_plugin_management_rejects_non_installed_plugin_id(tmp_path: Path) -> None:
+    home = tmp_path / "plugins-home"
+    (home / "cache" / "github" / "fitbit").mkdir(parents=True)
+    (home / "manifest.toml").parent.mkdir(parents=True, exist_ok=True)
+    (home / "manifest.toml").write_text("", encoding="utf-8")
+
+    for plugin_id in ("fitbit", "../fitbit@github", "fitbit@../github"):
+        try:
+            set_installed_plugin_enabled(
+                plugin_id,
+                enabled=False,
+                plugins_home=home,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"应拒绝插件 ID: {plugin_id}")
 
 
 def _commit(repo: Path) -> None:

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -112,11 +112,25 @@ def test_plugin_enable_disable_and_uninstall_preserve_data(tmp_path: Path) -> No
         enabled=True,
         plugins_home=home,
     )
+    disabled_before_removal = False
+
+    def wait_until_disabled(plugin_id: str) -> None:
+        nonlocal disabled_before_removal
+        current = tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8"))
+        disabled_before_removal = (
+            plugin_id == "fitbit@github"
+            and current["plugins"][plugin_id]["enabled"] is False
+            and cache.parent.exists()
+            and state.exists()
+        )
+
     removed_cache, retained_data = uninstall_plugin(
         "fitbit@github",
         plugins_home=home,
+        wait_until_disabled=wait_until_disabled,
     )
 
+    assert disabled_before_removal
     assert removed_cache == home / "cache" / "github" / "fitbit"
     assert not removed_cache.exists()
     assert retained_data == data
@@ -132,7 +146,12 @@ def test_plugin_management_rejects_non_installed_plugin_id(tmp_path: Path) -> No
     (home / "manifest.toml").parent.mkdir(parents=True, exist_ok=True)
     (home / "manifest.toml").write_text("", encoding="utf-8")
 
-    for plugin_id in ("fitbit", "../fitbit@github", "fitbit@../github"):
+    for plugin_id in (
+        "fitbit",
+        "../fitbit@github",
+        "fitbit@../github",
+        "fitbit\ncorrupt@github",
+    ):
         try:
             set_installed_plugin_enabled(
                 plugin_id,
@@ -143,6 +162,27 @@ def test_plugin_management_rejects_non_installed_plugin_id(tmp_path: Path) -> No
             pass
         else:
             raise AssertionError(f"应拒绝插件 ID: {plugin_id}")
+
+
+def test_uninstall_converges_when_cache_is_already_missing(tmp_path: Path) -> None:
+    home = tmp_path / "plugins-home"
+    data = home / "data" / "feed-github"
+    data.mkdir(parents=True)
+    state = data / "state.db"
+    state.write_bytes(b"keep")
+    (home / "manifest.toml").write_text(
+        '[plugins."feed@github"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+
+    cache, retained = uninstall_plugin("feed@github", plugins_home=home)
+
+    assert not cache.exists()
+    assert retained == data
+    assert state.read_bytes() == b"keep"
+    assert tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8")) == {
+        "plugins": {}
+    }
 
 
 def _commit(repo: Path) -> None:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -19,10 +19,11 @@ import pytest
 from agent.core.passive_turn import ContextStore as _  # noqa: F401
 from agent.lifecycle.types import AfterStepCtx, AfterToolResultCtx, BeforeToolCallCtx, BeforeTurnCtx
 from agent.plugins.manager import PluginManager
-from agent.plugins.jobs import PluginJobRuntime
+from agent.plugins.jobs import PluginJobRuntime, PluginJobSpec, RegisteredPluginJob
 from agent.plugins.registry import plugin_registry
 from agent.plugins.scope import PluginScope
 from agent.tool_hooks import ToolHook
+from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
 from agent.tools.search_backend import KeywordSearchBackend
 from bus.event_bus import EventBus
@@ -239,6 +240,40 @@ async def test_plugin_job_runtime_runs_event_job():
 
 
 @pytest.mark.asyncio
+async def test_plugin_job_runtime_restarts_after_stop_during_job():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_context: Any) -> None:
+        started.set()
+        await release.wait()
+
+    job = RegisteredPluginJob(
+        plugin_id="blocking",
+        plugin_context=None,
+        spec=PluginJobSpec(id="blocking", triggers=[], handler=handler),
+    )
+    runtime = PluginJobRuntime(
+        event_bus=EventBus(),
+        llm=_FakePluginLlm(),
+        jobs=[job],
+    )
+    running = asyncio.create_task(runtime.run())
+    await asyncio.sleep(0)
+    runtime.enqueue("blocking:blocking", reason="test")
+    await started.wait()
+
+    runtime.stop()
+    release.set()
+    await running
+
+    restarted = asyncio.create_task(runtime.run())
+    await asyncio.sleep(0)
+    assert not restarted.done()
+    runtime.stop()
+    await restarted
+
+@pytest.mark.asyncio
 async def test_event_subscription_can_be_closed():
     bus = EventBus()
     called: list[str] = []
@@ -291,6 +326,24 @@ async def test_plugin_scope_cleans_in_reverse_order_after_failure():
         ("failure", "cleanup failed")
     ]
     assert scope.resource_count == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_scope_continues_after_cancelled_cleanup():
+    scope = PluginScope("cancelled-cleanup")
+    cleaned: list[str] = []
+
+    def cancelled() -> None:
+        raise asyncio.CancelledError
+
+    scope.defer("last", lambda: cleaned.append("last"))
+    scope.defer("cancelled", cancelled)
+    scope.defer("first", lambda: cleaned.append("first"))
+
+    failures = await scope.aclose()
+
+    assert cleaned == ["first", "last"]
+    assert [failure.resource for failure in failures] == ["cancelled"]
 
 
 @pytest.mark.asyncio
@@ -412,6 +465,52 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "cancelled"
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "import asyncio\n"
+        "from contextlib import suppress\n"
+        "from agent.plugins import Plugin\n"
+        "started = asyncio.Event()\n"
+        "tasks = []\n"
+        "class CancelledPlugin(Plugin):\n"
+        "    name = 'cancelled'\n"
+        "    async def initialize(self):\n"
+        "        self.task = asyncio.create_task(asyncio.Event().wait())\n"
+        "        tasks.append(self.task)\n"
+        "        started.set()\n"
+        "        await asyncio.Event().wait()\n"
+        "    async def terminate(self):\n"
+        "        self.task.cancel()\n"
+        "        with suppress(asyncio.CancelledError):\n"
+        "            await self.task\n",
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[plugin_root],
+        event_bus=bus,
+        installed_cache_root=tmp_path / "cache",
+    )
+    loading = asyncio.create_task(manager.load_all())
+    while "akasic_plugin_plugins_cancelled" not in sys.modules:
+        await asyncio.sleep(0)
+    module = sys.modules["akasic_plugin_plugins_cancelled"]
+    await module.started.wait()
+
+    loading.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await loading
+
+    assert manager.loaded_count == 0
+    assert plugin_registry.get_instance("akasic_plugin_plugins_cancelled") is None
+    assert module.tasks[0].done()
+    assert bus.handler_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
     class FailingBackend(KeywordSearchBackend):
         def __init__(self) -> None:
@@ -433,13 +532,16 @@ async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
         "    name = 'tool_failure'\n"
         "    @tool(name='first')\n"
         "    async def first(self, event):\n"
+        "        \"\"\"First tool.\"\"\"\n"
         "        return 'first'\n"
         "    @tool(name='second')\n"
         "    async def second(self, event):\n"
+        "        \"\"\"Second tool.\"\"\"\n"
         "        return 'second'\n",
         encoding="utf-8",
     )
-    tools = ToolRegistry(backend=FailingBackend())
+    backend = FailingBackend()
+    tools = ToolRegistry(backend=backend)
     manager = PluginManager(
         plugin_dirs=[plugin_root],
         event_bus=EventBus(),
@@ -451,6 +553,46 @@ async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
 
     assert manager.loaded_count == 0
     assert tools.get_registered_names() == set()
+    assert backend.add_count == 2
+
+
+@pytest.mark.asyncio
+async def test_plugin_duplicate_tool_preserves_existing_tool(tmp_path: Path):
+    class ExistingTool(Tool):
+        name = "existing"
+        description = "Existing tool."
+        parameters = {"type": "object", "properties": {}}
+
+        async def execute(self, **kwargs: Any) -> str:
+            return "existing"
+
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "duplicate_tool"
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin, tool\n"
+        "class DuplicateToolPlugin(Plugin):\n"
+        "    name = 'duplicate_tool'\n"
+        "    @tool(name='existing')\n"
+        "    async def existing(self, event):\n"
+        "        \"\"\"Duplicate tool.\"\"\"\n"
+        "        return 'plugin'\n",
+        encoding="utf-8",
+    )
+    tools = ToolRegistry()
+    existing = ExistingTool()
+    tools.register(existing)
+    manager = PluginManager(
+        plugin_dirs=[plugin_root],
+        event_bus=EventBus(),
+        tool_registry=tools,
+        installed_cache_root=tmp_path / "cache",
+    )
+
+    await manager.load_all()
+
+    assert manager.loaded_count == 0
+    assert tools.get_tool("existing") is existing
 
 
 # ── lifecycle hook 触发测试 ────────────────────────────────────────────────────

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1166,11 +1166,16 @@ async def test_plugin_toml_overrides_defaults():
 
 
 @pytest.mark.asyncio
-async def test_plugin_disabled_marker_skips_plugin():
+async def test_manifest_disables_builtin_plugin():
     bus = EventBus()
     with tempfile.TemporaryDirectory() as tmp:
         shutil.copytree(FIXTURES_DIR / "configured", Path(tmp) / "configured")
-        (Path(tmp) / "configured" / "plugin.disabled").write_text("", encoding="utf-8")
+        from agent.plugins.manifest import write_plugin_manifest
+
+        write_plugin_manifest(
+            {"configured": False},
+            plugins_home=TEST_PLUGIN_HOME,
+        )
         mgr = _make_manager([Path(tmp)], event_bus=bus)
         await mgr.load_all()
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -777,10 +777,18 @@ async def test_loads_installed_programmatic_plugin():
             "    def skill_roots(cls): return ('skills',)\n"
             "    @classmethod\n"
             "    def mcp_servers(cls):\n"
-            "        return [McpServerSpec(name='feed', command=('run_mcp.py',))]\n",
+            "        return [McpServerSpec(name='feed', command=('python', 'run_mcp.py'))]\n",
             encoding="utf-8",
         )
-        (plugin_root / "run_mcp.py").write_text("print('ok')\n", encoding="utf-8")
+        (plugin_root / "run_mcp.py").write_text(
+            "import json, sys\n"
+            "for line in sys.stdin:\n"
+            "    msg = json.loads(line)\n"
+            "    if 'id' not in msg: continue\n"
+            "    result = {'tools': []} if msg.get('method') == 'tools/list' else {}\n"
+            "    print(json.dumps({'jsonrpc': '2.0', 'id': msg['id'], 'result': result}), flush=True)\n",
+            encoding="utf-8",
+        )
 
         mgr = PluginManager(
             plugin_dirs=[],
@@ -795,6 +803,7 @@ async def test_loads_installed_programmatic_plugin():
         assert active[0].skill_roots == (plugin_root / "skills",)
         assert "feed" in active[0].mcp_servers
         assert mgr.loaded_count == 1
+        await mgr.terminate_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1558,6 +1558,8 @@ async def test_add_tool_hooks_propagates_to_tool_executor():
 async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
     from bootstrap.tools import CoreRuntime
 
+    startup_order: list[str] = []
+
     class FakePluginManager:
         def __init__(self) -> None:
             self.tool_hooks = [object()]
@@ -1571,6 +1573,7 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.loaded_count = 0
 
         async def load_all(self) -> None:
+            startup_order.append("plugins")
             self.loaded_count = 1
 
     class FakeLoop:
@@ -1637,7 +1640,8 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
             self.received_hooks = list(hooks)
 
     class FakeMcpRegistry:
-        def start_connect_all_background(self) -> None:
+        async def load_and_connect_all(self) -> None:
+            startup_order.append("mcp")
             return None
 
         async def shutdown(self) -> None:
@@ -1669,6 +1673,7 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
 
     await runtime.start()
 
+    assert startup_order == ["mcp", "plugins"]
     assert plugin_manager.loaded_count == 1
     assert loop.received_before_turn is None
     assert loop.received_before_reasoning is None

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -474,6 +474,8 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
         "from contextlib import suppress\n"
         "from agent.plugins import Plugin\n"
         "started = asyncio.Event()\n"
+        "terminate_started = asyncio.Event()\n"
+        "release_terminate = asyncio.Event()\n"
         "tasks = []\n"
         "class CancelledPlugin(Plugin):\n"
         "    name = 'cancelled'\n"
@@ -483,6 +485,8 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
         "        started.set()\n"
         "        await asyncio.Event().wait()\n"
         "    async def terminate(self):\n"
+        "        terminate_started.set()\n"
+        "        await release_terminate.wait()\n"
         "        self.task.cancel()\n"
         "        with suppress(asyncio.CancelledError):\n"
         "            await self.task\n",
@@ -501,6 +505,11 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
     await module.started.wait()
 
     loading.cancel()
+    await module.terminate_started.wait()
+    loading.cancel()
+    await asyncio.sleep(0)
+    assert not loading.done()
+    module.release_terminate.set()
     with pytest.raises(asyncio.CancelledError):
         await loading
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1657,12 +1657,12 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
     await runtime.start()
 
     assert plugin_manager.loaded_count == 1
-    assert loop.received_before_turn == plugin_manager.before_turn_modules
-    assert loop.received_before_reasoning == plugin_manager.before_reasoning_modules
-    assert loop.received_prompt_render == plugin_manager.prompt_render_modules
-    assert loop.received_before_step == plugin_manager.before_step_modules
-    assert loop.received_after_step == plugin_manager.after_step_modules
-    assert loop.received_after_reasoning == plugin_manager.after_reasoning_modules
-    assert loop.received_after_turn == plugin_manager.after_turn_modules
+    assert loop.received_before_turn is None
+    assert loop.received_before_reasoning is None
+    assert loop.received_prompt_render is None
+    assert loop.received_before_step is None
+    assert loop.received_after_step is None
+    assert loop.received_after_reasoning is None
+    assert loop.received_after_turn is None
     assert loop.received_hooks == plugin_manager.tool_hooks
     assert spawn_tool.received_hooks == plugin_manager.tool_hooks

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -415,7 +415,7 @@ async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
         instance = plugin_registry.get_instance("akasic_plugin_plugins_scoped")
         assert instance is not None
         task = instance.task
-        assert bus.handler_count() == 1
+        assert bus.handler_count() == 0
 
         await manager.terminate_all()
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -433,8 +433,10 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
     plugin_root = tmp_path / "plugins"
     plugin_dir = plugin_root / "failing"
     plugin_dir.mkdir(parents=True)
+    marker = tmp_path / "terminated"
     _ = (plugin_dir / "plugin.py").write_text(
         "import asyncio\n"
+        "from pathlib import Path\n"
         "from contextlib import suppress\n"
         "from agent.plugins import Plugin\n"
         "tasks = []\n"
@@ -447,7 +449,8 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
         "    async def terminate(self):\n"
         "        self.task.cancel()\n"
         "        with suppress(asyncio.CancelledError):\n"
-        "            await self.task\n",
+        "            await self.task\n"
+        f"        Path({str(marker)!r}).write_text(str(self.task.done()))\n",
         encoding="utf-8",
     )
     manager = PluginManager(
@@ -458,10 +461,8 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
 
     await manager.load_all()
 
-    module = sys.modules["akasic_plugin_plugins_failing"]
     assert manager.loaded_count == 0
-    assert len(module.tasks) == 1
-    assert module.tasks[0].done()
+    assert marker.read_text(encoding="utf-8") == "True"
 
 
 @pytest.mark.asyncio
@@ -499,9 +500,15 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
         installed_cache_root=tmp_path / "cache",
     )
     loading = asyncio.create_task(manager.load_all())
-    while "akasic_plugin_plugins_cancelled" not in sys.modules:
+    module_names: list[str] = []
+    while not module_names:
         await asyncio.sleep(0)
-    module = sys.modules["akasic_plugin_plugins_cancelled"]
+        module_names = [
+            name
+            for name in sys.modules
+            if name.startswith("akasic_plugin_plugins_cancelled__g")
+        ]
+    module = sys.modules[module_names[0]]
     await module.started.wait()
 
     loading.cancel()
@@ -935,6 +942,7 @@ from agent.plugins import Plugin
 
 
 class EarlyModule:
+    slot = "plugin.early"
     requires = ("session:session",)
 
     async def run(self, frame):
@@ -942,56 +950,69 @@ class EarlyModule:
 
 
 class LateModule:
+    slot = "plugin.late"
     requires = ("session:ctx",)
 
     async def run(self, frame):
         return frame
 
 class PromptTopModule:
+    slot = "plugin.prompt_top"
     async def run(self, frame):
         return frame
 
 class PromptBottomModule:
+    slot = "plugin.prompt_bottom"
     async def run(self, frame):
         return frame
 
 class BeforeReasoningBeforeEmitModule:
+    slot = "plugin.before_reasoning_before_emit"
     async def run(self, frame):
         return frame
 
 class BeforeReasoningAfterEmitModule:
+    slot = "plugin.before_reasoning_after_emit"
     async def run(self, frame):
         return frame
 
 class BeforeStepBeforeEmitModule:
+    slot = "plugin.before_step_before_emit"
     async def run(self, frame):
         return frame
 
 class BeforeStepAfterEmitModule:
+    slot = "plugin.before_step_after_emit"
     async def run(self, frame):
         return frame
 
 class AfterStepBeforeFanoutModule:
+    slot = "plugin.after_step_before_fanout"
     async def run(self, frame):
         return frame
 
 class AfterStepAfterFanoutModule:
+    slot = "plugin.after_step_after_fanout"
     async def run(self, frame):
         return frame
 
 class AfterReasoningBeforeEmitModule:
+    slot = "plugin.after_reasoning_before_emit"
     async def run(self, frame):
         return frame
 
 class AfterReasoningBeforePersistModule:
+    slot = "plugin.after_reasoning_before_persist"
     async def run(self, frame):
         return frame
 
 class AfterTurnBeforeCommitModule:
+    slot = "plugin.after_turn_before_commit"
     async def run(self, frame):
         return frame
 
 class AfterTurnBeforeFanoutModule:
+    slot = "plugin.after_turn_before_fanout"
     async def run(self, frame):
         return frame
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -5,6 +5,8 @@ import json
 import os
 import shlex
 import shutil
+import subprocess
+import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +21,7 @@ from agent.lifecycle.types import AfterStepCtx, AfterToolResultCtx, BeforeToolCa
 from agent.plugins.manager import PluginManager
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.registry import plugin_registry
+from agent.plugins.scope import PluginScope
 from agent.tool_hooks import ToolHook
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
@@ -200,6 +203,7 @@ async def test_plugin_job_runtime_runs_event_job():
         llm=llm,
         jobs=[job],
     )
+    handler_count = bus.handler_count()
     task = asyncio.create_task(runtime.run())
     await asyncio.sleep(0)
     await bus.fanout(
@@ -222,6 +226,106 @@ async def test_plugin_job_runtime_runs_event_job():
         "reason": "event",
         "has_event": True,
         "context_llm": True,
+    }
+    assert bus.handler_count() == handler_count
+
+
+@pytest.mark.asyncio
+async def test_event_subscription_can_be_closed():
+    bus = EventBus()
+    called: list[str] = []
+    subscription = bus.on(str, lambda event: called.append(event))
+
+    await bus.fanout("first")
+    subscription.close()
+    await bus.fanout("second")
+
+    assert called == ["first"]
+    assert bus.handler_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_scope_cleans_in_reverse_order_after_failure():
+    scope = PluginScope("scope-test")
+    cleaned: list[str] = []
+
+    def fail() -> None:
+        cleaned.append("fail")
+        raise RuntimeError("cleanup failed")
+
+    scope.defer("first", lambda: cleaned.append("first"))
+    scope.defer("failure", fail)
+    scope.defer("last", lambda: cleaned.append("last"))
+
+    failures = await scope.aclose()
+
+    assert cleaned == ["last", "fail", "first"]
+    assert [(item.resource, item.error) for item in failures] == [
+        ("failure", "cleanup failed")
+    ]
+    assert scope.resource_count == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_scope_terminates_process():
+    scope = PluginScope("process-test")
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    scope.track_process(process, name="sleep")
+
+    failures = await scope.aclose()
+
+    assert failures == []
+    assert process.poll() is not None
+
+
+@pytest.mark.asyncio
+async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "scoped"
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from __future__ import annotations\n"
+        "import asyncio\n"
+        "from agent.plugins import Plugin\n"
+        "from bus.events_lifecycle import TurnCommitted\n"
+        "class ScopedPlugin(Plugin):\n"
+        "    name = 'scoped'\n"
+        "    async def initialize(self):\n"
+        "        self.context.event_bus.on(TurnCommitted, self._handle)\n"
+        "        self.task = self.context.create_task(self._run(), name='scoped-worker')\n"
+        "        self.context.defer('marker', lambda: self.context.kv_store.set('closed', True))\n"
+        "    async def terminate(self):\n"
+        "        raise RuntimeError('terminate failed')\n"
+        "    async def _run(self):\n"
+        "        await asyncio.Event().wait()\n"
+        "    def _handle(self, event):\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    manager = PluginManager(
+        plugin_dirs=[plugin_root],
+        event_bus=bus,
+        installed_cache_root=tmp_path / "cache",
+    )
+    for _ in range(20):
+        await manager.load_all()
+        instance = plugin_registry.get_instance("akasic_plugin_plugins_scoped")
+        assert instance is not None
+        task = instance.task
+        assert bus.handler_count() == 1
+
+        await manager.terminate_all()
+
+        assert bus.handler_count() == 0
+        assert task.done()
+    data_dir = tmp_path / "data" / "scoped-builtin"
+    assert json.loads((data_dir / ".kv.json").read_text(encoding="utf-8")) == {
+        "closed": True
     }
 
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -273,6 +273,34 @@ async def test_plugin_job_runtime_restarts_after_stop_during_job():
     runtime.stop()
     await restarted
 
+
+@pytest.mark.asyncio
+async def test_plugin_job_runtime_coalesces_legacy_queue():
+    calls = 0
+
+    async def handler(_context: Any) -> None:
+        nonlocal calls
+        calls += 1
+
+    job = RegisteredPluginJob(
+        plugin_id="coalesce",
+        plugin_context=None,
+        spec=PluginJobSpec(id="refresh", triggers=[], handler=handler),
+    )
+    runtime = PluginJobRuntime(
+        event_bus=EventBus(),
+        llm=_FakePluginLlm(),
+        jobs=[job],
+    )
+    runtime.enqueue("coalesce:refresh", reason="test")
+    runtime.enqueue("coalesce:refresh", reason="test")
+    running = asyncio.create_task(runtime.run())
+    await asyncio.sleep(0.05)
+    runtime.stop()
+    await running
+
+    assert calls == 1
+
 @pytest.mark.asyncio
 async def test_event_subscription_can_be_closed():
     bus = EventBus()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -569,7 +569,11 @@ async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
 
     assert manager.loaded_count == 0
     assert tools.get_registered_names() == set()
-    assert backend.add_count == 2
+    assert backend.add_count == 0
+    gate = manager.latest_gate("tool_failure")
+    assert gate is not None
+    assert gate.status == "failed"
+    assert any(check.check_id == "runtime_snapshot" for check in gate.checks)
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -24,6 +24,7 @@ from agent.plugins.registry import plugin_registry
 from agent.plugins.scope import PluginScope
 from agent.tool_hooks import ToolHook
 from agent.tools.registry import ToolRegistry
+from agent.tools.search_backend import KeywordSearchBackend
 from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
 from core.memory.events import MemoryWritten, RetrievalCompleted, RetrievalHitSummary
@@ -229,6 +230,13 @@ async def test_plugin_job_runtime_runs_event_job():
     }
     assert bus.handler_count() == handler_count
 
+    restarted = asyncio.create_task(runtime.run())
+    await asyncio.sleep(0)
+    assert not restarted.done()
+    runtime.stop()
+    await restarted
+    assert bus.handler_count() == handler_count
+
 
 @pytest.mark.asyncio
 async def test_event_subscription_can_be_closed():
@@ -242,6 +250,25 @@ async def test_event_subscription_can_be_closed():
 
     assert called == ["first"]
     assert bus.handler_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_observe_keeps_current_handler_snapshot():
+    bus = EventBus()
+    called: list[str] = []
+    first = None
+
+    def close_first(_event: str) -> None:
+        called.append("first")
+        assert first is not None
+        first.close()
+
+    first = bus.on(str, close_first)
+    _ = bus.on(str, lambda _event: called.append("second"))
+
+    await bus.observe("event")
+
+    assert called == ["first", "second"]
 
 
 @pytest.mark.asyncio
@@ -280,6 +307,24 @@ async def test_plugin_scope_terminates_process():
 
     assert failures == []
     assert process.poll() is not None
+
+
+@pytest.mark.asyncio
+async def test_closed_plugin_scope_does_not_create_resources():
+    scope = PluginScope("closed")
+    bus = EventBus()
+    _ = await scope.aclose()
+
+    with pytest.raises(RuntimeError, match="作用域已关闭"):
+        _ = scope.subscribe(bus, str, lambda _event: None)
+
+    async def wait() -> None:
+        await asyncio.Event().wait()
+
+    with pytest.raises(RuntimeError, match="作用域已关闭"):
+        _ = scope.create_task(wait())
+
+    assert bus.handler_count() == 0
 
 
 @pytest.mark.asyncio
@@ -327,6 +372,85 @@ async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
     assert json.loads((data_dir / ".kv.json").read_text(encoding="utf-8")) == {
         "closed": True
     }
+    assert len(manager.cleanup_failures) == 20
+
+
+@pytest.mark.asyncio
+async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "failing"
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "import asyncio\n"
+        "from contextlib import suppress\n"
+        "from agent.plugins import Plugin\n"
+        "tasks = []\n"
+        "class FailingPlugin(Plugin):\n"
+        "    name = 'failing'\n"
+        "    async def initialize(self):\n"
+        "        self.task = asyncio.create_task(asyncio.Event().wait())\n"
+        "        tasks.append(self.task)\n"
+        "        raise RuntimeError('init failed')\n"
+        "    async def terminate(self):\n"
+        "        self.task.cancel()\n"
+        "        with suppress(asyncio.CancelledError):\n"
+        "            await self.task\n",
+        encoding="utf-8",
+    )
+    manager = PluginManager(
+        plugin_dirs=[plugin_root],
+        event_bus=EventBus(),
+        installed_cache_root=tmp_path / "cache",
+    )
+
+    await manager.load_all()
+
+    module = sys.modules["akasic_plugin_plugins_failing"]
+    assert manager.loaded_count == 0
+    assert len(module.tasks) == 1
+    assert module.tasks[0].done()
+
+
+@pytest.mark.asyncio
+async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
+    class FailingBackend(KeywordSearchBackend):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_count = 0
+
+        def add(self, document: Any) -> None:
+            self.add_count += 1
+            if self.add_count == 2:
+                raise RuntimeError("index failed")
+            super().add(document)
+
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "tool_failure"
+    plugin_dir.mkdir(parents=True)
+    _ = (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin, tool\n"
+        "class ToolFailurePlugin(Plugin):\n"
+        "    name = 'tool_failure'\n"
+        "    @tool(name='first')\n"
+        "    async def first(self, event):\n"
+        "        return 'first'\n"
+        "    @tool(name='second')\n"
+        "    async def second(self, event):\n"
+        "        return 'second'\n",
+        encoding="utf-8",
+    )
+    tools = ToolRegistry(backend=FailingBackend())
+    manager = PluginManager(
+        plugin_dirs=[plugin_root],
+        event_bus=EventBus(),
+        tool_registry=tools,
+        installed_cache_root=tmp_path / "cache",
+    )
+
+    await manager.load_all()
+
+    assert manager.loaded_count == 0
+    assert tools.get_registered_names() == set()
 
 
 # ── lifecycle hook 触发测试 ────────────────────────────────────────────────────

--- a/tests/test_plugin_service_host.py
+++ b/tests/test_plugin_service_host.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import socket
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from agent.plugins.service_host import PluginServiceHost
+
+
+def _free_port() -> int:
+    with socket.socket() as server:
+        server.bind(("127.0.0.1", 0))
+        return int(server.getsockname()[1])
+
+
+def _service_spec(script: Path, port: int, version: str) -> dict[str, object]:
+    return {
+        "command": [sys.executable, str(script)],
+        "cwd": str(script.parent),
+        "env": {"PORT": str(port), "VERSION": version},
+        "readiness_url": f"http://127.0.0.1:{port}/",
+        "startup_timeout_seconds": 3,
+        "revision": version,
+    }
+
+
+def _read(port: int) -> str:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=1) as response:
+        return response.read().decode()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_swaps_generation(tmp_path: Path) -> None:
+    script = tmp_path / "service.py"
+    _ = script.write_text(
+        "import os\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers()\n"
+        "        self.wfile.write(os.environ['VERSION'].encode())\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', int(os.environ['PORT'])), Handler).serve_forever()\n",
+        encoding="utf-8",
+    )
+    port = _free_port()
+    first = {"monitor": _service_spec(script, port, "v1")}
+    second = {"monitor": _service_spec(script, port, "v2")}
+    host = PluginServiceHost()
+    host.bind_plugin_services({"health": first})  # type: ignore[arg-type]
+    await host.start_all()
+    assert _read(port) == "v1"
+
+    await host.swap_plugin_services("health", first, second)  # type: ignore[arg-type]
+
+    assert _read(port) == "v2"
+    await host.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_restores_old_generation_on_failure(
+    tmp_path: Path,
+) -> None:
+    service = tmp_path / "service.py"
+    failed = tmp_path / "failed.py"
+    _ = service.write_text(
+        "import os\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200); self.end_headers()\n"
+        "        self.wfile.write(os.environ['VERSION'].encode())\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', int(os.environ['PORT'])), Handler).serve_forever()\n",
+        encoding="utf-8",
+    )
+    _ = failed.write_text("raise RuntimeError('failed')\n", encoding="utf-8")
+    port = _free_port()
+    old = {"monitor": _service_spec(service, port, "v1")}
+    new = {"monitor": _service_spec(failed, port, "v2")}
+    host = PluginServiceHost()
+    host.bind_plugin_services({"health": old})  # type: ignore[arg-type]
+    await host.start_all()
+
+    with pytest.raises(RuntimeError, match="启动失败"):
+        await host.swap_plugin_services("health", old, new)  # type: ignore[arg-type]
+
+    assert _read(port) == "v1"
+    await host.stop_all()

--- a/tests/test_plugin_service_host.py
+++ b/tests/test_plugin_service_host.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+import asyncio
 import sys
 import urllib.request
 from pathlib import Path
@@ -90,3 +91,68 @@ async def test_managed_service_restores_old_generation_on_failure(
 
     assert _read(port) == "v1"
     await host.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_rejects_occupied_readiness_endpoint(
+    tmp_path: Path,
+) -> None:
+    service = tmp_path / "service.py"
+    failed = tmp_path / "failed.py"
+    _ = service.write_text(
+        "import os\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self): self.send_response(200); self.end_headers()\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', int(os.environ['PORT'])), Handler).serve_forever()\n",
+        encoding="utf-8",
+    )
+    _ = failed.write_text("raise SystemExit(7)\n", encoding="utf-8")
+    port = _free_port()
+    existing = {"server": _service_spec(service, port, "existing")}
+    collision = {"server": _service_spec(failed, port, "candidate")}
+    host = PluginServiceHost()
+    host.bind_plugin_services({"existing": existing})  # type: ignore[arg-type]
+    await host.start_all()
+
+    with pytest.raises(RuntimeError, match="已被占用"):
+        await host.swap_plugin_services(  # type: ignore[arg-type]
+            "candidate",
+            {},
+            collision,
+        )
+
+    assert _read(port) == ""
+    await host.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_stop_finishes_when_cancelled(tmp_path: Path) -> None:
+    service = tmp_path / "slow_stop.py"
+    _ = service.write_text(
+        "import os, signal, time\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "def stop(*args): time.sleep(0.2); raise SystemExit(0)\n"
+        "signal.signal(signal.SIGTERM, stop)\n"
+        "class Handler(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self): self.send_response(200); self.end_headers()\n"
+        "    def log_message(self, *args): pass\n"
+        "HTTPServer(('127.0.0.1', int(os.environ['PORT'])), Handler).serve_forever()\n",
+        encoding="utf-8",
+    )
+    port = _free_port()
+    services = {"server": _service_spec(service, port, "v1")}
+    host = PluginServiceHost()
+    host.bind_plugin_services({"slow": services})  # type: ignore[arg-type]
+    await host.start_all()
+    stopping = asyncio.create_task(host.stop_all())
+    await asyncio.sleep(0.05)
+    stopping.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stopping
+
+    assert host._running == {}
+    with pytest.raises(OSError):
+        _read(port)

--- a/tests/test_plugin_service_host.py
+++ b/tests/test_plugin_service_host.py
@@ -156,3 +156,28 @@ async def test_managed_service_stop_finishes_when_cancelled(tmp_path: Path) -> N
     assert host._running == {}
     with pytest.raises(OSError):
         _read(port)
+
+
+@pytest.mark.asyncio
+async def test_managed_service_without_readiness_rejects_fast_exit(
+    tmp_path: Path,
+) -> None:
+    failed = tmp_path / "failed.py"
+    _ = failed.write_text("raise SystemExit(7)\n", encoding="utf-8")
+    spec = {
+        "worker": {
+            "command": [sys.executable, str(failed)],
+            "cwd": str(tmp_path),
+            "env": {},
+            "readiness_url": "",
+            "startup_timeout_seconds": 1,
+            "revision": "failed",
+        }
+    }
+    host = PluginServiceHost()
+    host.bind_plugin_services({"failed": {}})
+
+    with pytest.raises(RuntimeError, match="exit=7"):
+        await host.swap_plugin_services("failed", {}, spec)  # type: ignore[arg-type]
+
+    assert host._running == {}

--- a/tests/test_recall_inspector_plugin.py
+++ b/tests/test_recall_inspector_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -21,7 +22,7 @@ async def test_recall_inspector_records_context_and_recall(tmp_path: Path) -> No
 
     plugin = DefaultMemoryInspector()
     plugin.context = PluginContext(
-        event_bus=None,
+        event_bus=cast(Any, None),
         tool_registry=None,
         plugin_id="default_memory",
         plugin_dir=plugin_dir,
@@ -87,7 +88,7 @@ async def test_recall_inspector_uses_workspace_data_path(tmp_path: Path) -> None
 
     plugin = DefaultMemoryInspector()
     plugin.context = PluginContext(
-        event_bus=None,
+        event_bus=cast(Any, None),
         tool_registry=None,
         plugin_id="default_memory",
         plugin_dir=plugin_dir,

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -200,6 +200,9 @@ async def test_serve_smoke_loads_config_and_runs_shutdown(monkeypatch, tmp_path)
         def stop(self) -> None:
             return None
 
+        async def wait_stopped(self) -> None:
+            return None
+
     monkeypatch.setattr(bootstrap_app, "PluginJobRuntime", _FakePluginJobRuntime)
     monkeypatch.setattr(main.Path, "home", lambda: tmp_path)
 

--- a/tests/test_skills_loader.py
+++ b/tests/test_skills_loader.py
@@ -141,3 +141,24 @@ def test_always_skill_still_loads_into_context(tmp_path: Path):
 
     assert loader.get_always_skills() == ["memory"]
     assert "always body" in loader.load_skills_for_context(["memory"])
+
+
+def test_plugin_roots_do_not_depend_on_workspace_symlinks(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    plugin_root = tmp_path / "plugin-skills"
+    skill_dir = _write_skill(plugin_root, "plugin-skill", body="plugin body")
+    workspace_skills = workspace / "skills"
+    workspace_skills.mkdir(parents=True)
+    (workspace_skills / "legacy-link").symlink_to(skill_dir, target_is_directory=True)
+
+    loader = SkillsLoader(
+        workspace,
+        builtin_skills_dir=None,
+        plugin_roots={"demo": (plugin_root,)},
+        ignore_workspace_symlinks=True,
+    )
+
+    records = loader.build_index().records
+    assert set(records) == {"plugin-skill"}
+    assert records["plugin-skill"].source == "plugin"
+    assert records["plugin-skill"].source_id == "demo"

--- a/tests/test_skills_loader.py
+++ b/tests/test_skills_loader.py
@@ -150,15 +150,25 @@ def test_plugin_roots_do_not_depend_on_workspace_symlinks(tmp_path: Path):
     workspace_skills = workspace / "skills"
     workspace_skills.mkdir(parents=True)
     (workspace_skills / "legacy-link").symlink_to(skill_dir, target_is_directory=True)
+    personal_target = _write_skill(
+        tmp_path / "personal-skills",
+        "personal-target",
+        body="personal body",
+    )
+    (workspace_skills / "personal-link").symlink_to(
+        personal_target,
+        target_is_directory=True,
+    )
 
     loader = SkillsLoader(
         workspace,
         builtin_skills_dir=None,
         plugin_roots={"demo": (plugin_root,)},
-        ignore_workspace_symlinks=True,
+        ignored_workspace_symlink_roots=(plugin_root,),
     )
 
     records = loader.build_index().records
-    assert set(records) == {"plugin-skill"}
+    assert set(records) == {"personal-link", "plugin-skill"}
+    assert records["personal-link"].source == "workspace"
     assert records["plugin-skill"].source == "plugin"
     assert records["plugin-skill"].source_id == "demo"

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -681,7 +681,7 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     class _Skills:
-        def __init__(self, workspace: Path) -> None:
+        def __init__(self, workspace: Path, **_: object) -> None:
             self.workspace = workspace
 
         def get_always_skills(self) -> list[str]:
@@ -862,7 +862,7 @@ def test_context_builder_reproduces_temporal_conflict_baseline(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     class _Skills:
-        def __init__(self, workspace: Path) -> None:
+        def __init__(self, workspace: Path, **_: object) -> None:
             self.workspace = workspace
 
         def get_always_skills(self) -> list[str]:

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -67,6 +67,10 @@ async def test_outbound_limiter_retries_after_cooling_down(monkeypatch):
     )
     sleep_mock = AsyncMock()
     monkeypatch.setattr("infra.channels.telegram_utils.asyncio.sleep", sleep_mock)
+    monkeypatch.setattr(
+        "infra.channels.telegram_utils.asyncio.get_running_loop",
+        lambda: SimpleNamespace(time=lambda: 100.0),
+    )
     calls = 0
 
     async def action():
@@ -80,7 +84,7 @@ async def test_outbound_limiter_retries_after_cooling_down(monkeypatch):
 
     assert result == "ok"
     assert calls == 2
-    assert sleep_mock.await_args_list[0].args[0] >= 3.9
+    assert sleep_mock.await_args_list[0].args[0] == 4.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -119,6 +119,7 @@ def test_stream_event_sink_respects_suppression_flag():
 async def test_process_direct_suppresses_stream_and_memory_when_requested():
     loop = object.__new__(AgentLoop)
     loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = None
     loop._process = AsyncMock(
         return_value=OutboundMessage(
             channel="telegram",
@@ -155,6 +156,7 @@ async def test_process_direct_suppresses_stream_and_memory_when_requested():
 async def test_process_direct_waits_for_passive_runtime_admission():
     loop = object.__new__(AgentLoop)
     loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = None
     events: list[str] = []
 
     async def _process(


### PR DESCRIPTION
## 背景

插件能力原先在启动时分散注册，源码、配置、MCP、Skill、Job、主动链路、Channel 与服务无法作为一个整体安全替换；旧代资源也可能残留。本次升级把插件能力收敛到统一代际与运行时快照，并完成全部现有插件迁移。

## 改动

- 引入 PluginScope、PluginGeneration、Candidate Gate、RuntimeSnapshot 与执行租约。
- 安装、删除、`manifest.toml` 启停、源码和 `config.local.toml` 修改均由 Watcher 自动发现并原子热重载。
- MCP、Skill、Tool、Lifecycle、Job、Proactive、Channel、Dashboard 与 managed service 统一按快照切换和排空。
- `manifest.toml` 只保存插件 enabled 状态；插件能力和私有配置由插件自行声明。
- 增加 `plugin-enable`、`plugin-disable` 与 `plugin-uninstall`；在线卸载先等待旧代 lease 和资源排空，再删除 cache，始终保留 data。
- Proactive kernel 固定使用所属快照的 MCP Tool Registry，DataGateway 子任务不会丢失插件工具或跨代漂移。
- 迁移全部外部插件；Fitbit monitor 改由插件宿主管理，睡眠 ML、数据目录、阈值和接口行为保持不变。
- Calendar 的固定端口 HTTP 服务改由 managed service 独占托管；MCP 仅保留 stdio bridge，数据目录语义不变（外部插件提交 `1c65157`、`e00af48`）。
- 修正 Drift 跨轮次续接认知，并补充真实 Docker Runtime Gate 与 Handbook。

## Breaking changes

- 删除旧 JSON/YAML manifest 能力声明和 `plugin.disabled` 标记；全局启停只认 `~/.akashic-plugin/manifest.toml`。
- 插件后台资源必须归属 PluginScope，独占进程使用 `managed_services()`，短期任务使用 `context.create_task()`。
- 插件变更不再要求重启 Runtime；候选失败时继续保留上一可用代际。

## 验证

- `pytest -q tests/`：1398 passed。
- `pyright --level error` 与测试专用 pyright 配置：0 errors。
- `npm run typecheck && npm run lint && npm run build`：通过（仅 3 条既有 Hook warning）。
- Docker PID1 `python main.py` Gate：snapshot、topology、plugins、Fitbit 均通过。
- all-plugins Gate：19 个非 Fitbit 外部插件逐个 load → reload → disable 全部通过。
- plugins Gate 实际验证 status 命令、meme/status lifecycle、proactive_feedback 落库、observe 无信号换代和 Dashboard。
- Fitbit Gate 验证 reload 后 monitor 单实例、disable 后进程归零、`/api/data`、`/api/tool/fitbit_health_snapshot`、持久数据哈希及仓库不变。
- management Gate 在真实 PID1 Runtime 内验证 disable → enable → uninstall、托管服务退出、cache 删除与 data 保留。
- proactive-fetch Gate 真实执行 DataGateway 子任务与 stdio MCP `get_context`，确认 context 拉取成功且仓库不变。
- 核心热重载、插件迁移与最终清理均经过独立子代理复审。
