### PR TITLE
fix(proactive): 透传 MCP 轮询超时

### DIFF
--- a/agent/mcp/tool.py
+++ b/agent/mcp/tool.py
@@ -38,3 +38,14 @@ class McpToolWrapper(Tool):
 
     async def execute(self, **kwargs: Any) -> str:
         return await self._client.call(self._info.name, kwargs)
+
+    async def execute_with_timeout(
+        self,
+        arguments: dict[str, Any],
+        execution_timeout: float | None = None,
+    ) -> str:
+        return await self._client.call(
+            self._info.name,
+            arguments,
+            timeout=execution_timeout,
+        )

--- a/agent/tools/base.py
+++ b/agent/tools/base.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -71,6 +72,16 @@ class Tool(ABC):
     @abstractmethod
     async def execute(self, **kwargs: Any) -> str | ToolResult:
         """执行工具，返回字符串结果"""
+
+    async def execute_with_timeout(
+        self,
+        arguments: dict[str, Any],
+        execution_timeout: float | None = None,
+    ) -> str | ToolResult:
+        execution = self.execute(**arguments)
+        if execution_timeout is None:
+            return await execution
+        return await asyncio.wait_for(execution, timeout=execution_timeout)
 
     def validate_params(self, params: dict[str, Any]) -> list[str]:
         """校验参数，返回错误列表（空列表表示校验通过）"""

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -307,10 +307,16 @@ class ToolRegistry:
         arguments: dict[str, Any],
         *,
         raise_errors: bool = False,
+        execution_timeout: float | None = None,
     ) -> str | ToolResult:
         view = self._runtime_view()
         if view is not self:
-            return await view.execute(name, arguments, raise_errors=raise_errors)
+            return await view.execute(
+                name,
+                arguments,
+                raise_errors=raise_errors,
+                execution_timeout=execution_timeout,
+            )
         tool = self._tools.get(name)
         if tool is None:
             if raise_errors:
@@ -322,7 +328,10 @@ class ToolRegistry:
             merged: dict[str, Any] = {**self._context, **arguments}
             if not _tool_defines_parameter(tool, _PROGRESS_DESCRIPTION_FIELD):
                 merged.pop(_PROGRESS_DESCRIPTION_FIELD, None)
-            return await tool.execute(**merged)
+            return await tool.execute_with_timeout(
+                merged,
+                execution_timeout=execution_timeout,
+            )
         except Exception as e:
             logger.error(f"工具 {name} 执行出错: {e}", exc_info=True)
             if raise_errors:

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -45,11 +45,11 @@ class SharedMcpGateway:
         registered_name = tool_name if tool_name in names else f"mcp_{server}__{tool_name}"
         if registered_name not in names:
             raise RuntimeError(f"MCP tool 不可用: {server}.{tool_name}")
-        execution = self._tools.execute(registered_name, args, raise_errors=True)
-        result = (
-            await asyncio.wait_for(execution, timeout=timeout)
-            if timeout is not None
-            else await execution
+        result = await self._tools.execute(
+            registered_name,
+            args,
+            raise_errors=True,
+            execution_timeout=timeout,
         )
         text = result.text if isinstance(result, ToolResult) else str(result)
         if text.strip().startswith(("[", "{")):

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
+from agent.mcp.client import McpClient, McpToolInfo
+from agent.mcp.tool import McpToolWrapper
 from agent.plugins.specs import ProactiveSourceSpec, RegisteredProactiveSource
 from agent.tools.base import Tool
 from agent.tools.registry import ToolRegistry
@@ -75,6 +78,38 @@ async def test_shared_mcp_gateway_applies_timeout(tmp_path: Path) -> None:
     gateway = mcp_sources.SharedMcpGateway(tmp_path, tools)
     with pytest.raises(asyncio.TimeoutError):
         await gateway.call("feed", "get_proactive_events", {}, timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_shared_mcp_gateway_forwards_timeout_to_mcp_client(
+    tmp_path: Path,
+) -> None:
+    client = AsyncMock()
+    client.name = "feed"
+    client.call.return_value = "[]"
+    tool = McpToolWrapper(
+        cast(McpClient, client),
+        McpToolInfo(
+            name="get_proactive_events",
+            description="test",
+            input_schema={"type": "object", "properties": {}},
+        ),
+    )
+    tools = ToolRegistry()
+    tools.register(tool, source_type="mcp", source_name="feed")
+    gateway = mcp_sources.SharedMcpGateway(tmp_path, tools)
+
+    assert await gateway.call(
+        "feed",
+        "get_proactive_events",
+        {},
+        timeout=12.0,
+    ) == []
+    client.call.assert_awaited_once_with(
+        "get_proactive_events",
+        {},
+        timeout=12.0,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

主动轮询虽然声明了 180 秒预算，但共享 ToolRegistry 没有把预算传给 MCP 客户端，传输层仍在 30 秒后提前超时。

## 修改

- 为通用工具执行链增加 execution_timeout
- MCP 工具将预算传给 McpClient.call
- proactive source 通过统一执行链使用轮询预算
- 增加 MCP 超时透传回归测试

## 验证

- `pytest tests/ -q`：1399 passed
- `pyright agent/tools/base.py agent/tools/registry.py agent/mcp/tool.py proactive_v2/mcp_sources.py tests/test_mcp_sources_async.py`：0 errors