### PR TITLE
refactor(frontend): 建立可扩展的插件样式契约

### DIFF
--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -24,6 +24,52 @@ class DemoPlugin(Plugin):
     desc = "最小插件"
 ```
 
+## Dashboard 前端插件样式契约
+
+Dashboard 插件的前端样式分为两层：主程序提供公共 preset，插件保留自己的 CSS 扩展能力。
+
+```text
+┌─ Host CSS
+│  └─ Dashboard 私有实现，插件不能依赖
+├─ Dashboard UI SDK
+│  ├─ @akashic/dashboard-ui 组件
+│  ├─ ak-plugin-* 布局与 token preset
+│  └─ api、格式化器和共享 React 实例
+└─ Plugin CSS
+   └─ 可选，放在 dashboard_panel.css，并限定在插件根节点内
+```
+
+插件可以直接使用 `@akashic/dashboard-ui` 的 `Grid`、`Stack`、`Panel`、`Toolbar`、`Chip` 和图表组件，也可以使用 `window.AkashicDashboard.ui.cx` 返回的公共 class。插件不应依赖主程序内部的 Tailwind utility class；需要特殊布局或动画时，在自己的 `dashboard_panel.css` 中实现。
+
+运行时会为每个插件面板提供根节点：
+
+```html
+<div data-akashic-plugin="observe">
+  <!-- plugin panel -->
+</div>
+```
+
+插件 CSS 应以根节点限定范围：
+
+```css
+[data-akashic-plugin="observe"] .observe-filter {
+  display: flex;
+  gap: 0.75rem;
+}
+```
+
+主程序构建 Dashboard 时会生成并加载公共 preset CSS。preset 只包含主程序和已安装插件声明的公共 utility；插件新增的特殊样式仍然应该随插件 CSS 发布。主程序不再把外部插件源码并入自己的 Tailwind bundle，也不维护逐插件 safelist。
+
+插件前端修改后的检查顺序：
+
+```bash
+npm run build:plugin-preset
+npm run build:dashboard
+python main.py plugin-install --source https://github.com/akashic-plugins/<plugin> --marketplace github
+```
+
+安装完成后刷新 Dashboard；插件 CSS 会和面板 JS 一起按版本加载。插件自己的配置、数据库和日志仍然保存在独立 data 目录，不随前端资源替换。
+
 目录名、`name` 与安装后的插件身份必须一致。安装到 `github` 市场后，插件 ID 是 `demo@github`。
 
 ## 全局启停清单

--- a/frontend/chat/src/components/ai-elements/attachments.tsx
+++ b/frontend/chat/src/components/ai-elements/attachments.tsx
@@ -176,7 +176,7 @@ export const Attachment = ({
           variant === "inline" && [
             "flex h-8 cursor-pointer select-none items-center gap-1.5",
             "rounded-md border border-border px-1.5",
-            "font-medium text-sm transition-all",
+            "font-medium text-sm transition-colors",
             "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
           ],
           variant === "list" && [
@@ -294,7 +294,7 @@ export const AttachmentRemove = ({
       className={cn(
         variant === "grid" && [
           "absolute top-2 right-2 size-6 rounded-full p-0",
-          "bg-background/80 backdrop-blur-sm",
+          "bg-background/90",
           "opacity-0 transition-opacity group-hover:opacity-100",
           "hover:bg-background",
           "[&>svg]:size-3",

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -23,7 +23,7 @@
   --border: 0 0% 12%;
   --input: 0 0% 18%;
   --ring: 132 42% 37%;
-  --radius: 1rem;
+  --radius: 0.75rem;
 }
 
 * {
@@ -185,14 +185,7 @@ input {
   width: min(100%, 820px);
   height: 1px;
   margin: -6px 0;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(148, 148, 148, 0.18) 18%,
-    rgba(148, 148, 148, 0.28) 50%,
-    rgba(148, 148, 148, 0.18) 82%,
-    transparent
-  );
+  background: rgba(148, 148, 148, 0.24);
 }
 
 .user-divider {
@@ -209,7 +202,7 @@ input {
 
 .user-bubble {
   max-width: min(74%, 720px);
-  border-radius: 24px;
+  border-radius: 14px;
   padding: 14px 22px;
   color: #eaf6ed;
   background: #2f7d3e;
@@ -256,7 +249,7 @@ input {
   margin: 0 auto;
   border-radius: 12px;
   object-fit: contain;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .agent-row {
@@ -322,11 +315,7 @@ input {
   bottom: 13px;
   left: 8px;
   width: 1px;
-  background: linear-gradient(
-    180deg,
-    rgba(120, 120, 120, 0.16),
-    rgba(120, 120, 120, 0.42)
-  );
+  background: rgba(120, 120, 120, 0.3);
   transform-origin: top;
   animation: trace-grow 360ms ease-out both;
 }
@@ -370,7 +359,7 @@ input {
 
 .process-item.active .process-node {
   background: #78b883;
-  box-shadow: 0 0 0 4px #000, 0 0 18px rgba(120, 184, 131, 0.34);
+  box-shadow: 0 0 0 4px #000;
 }
 
 .process-item.active .process-node.diamond {
@@ -474,10 +463,20 @@ input {
 .composer {
   min-height: 66px;
   border: 1px solid #303030;
-  border-radius: 32px;
+  border-radius: 18px;
   padding: 4px 9px;
   background: #242424;
-  box-shadow: 0 10px 42px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.composer:focus-within {
+  border-color: hsl(var(--ring) / 0.72);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28), 0 0 0 1px hsl(var(--ring) / 0.18);
+}
+
+form.composer:focus-within [data-slot="input-group"] {
+  box-shadow: none;
 }
 
 .composer textarea {

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -7,7 +7,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="%BASE_URL%sdk/preset.css">
   <!-- Shared singletons for dynamically-imported plugin modules: resolves the
        plugin's react / react-dom / @akashic/dashboard-ui imports to host-backed
        shims so plugins reuse the host's single React instance and UI library. -->

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="%BASE_URL%sdk/preset.css">
   <!-- Shared singletons for dynamically-imported plugin modules: resolves the
        plugin's react / react-dom / @akashic/dashboard-ui imports to host-backed
        shims so plugins reuse the host's single React instance and UI library. -->

--- a/frontend/dashboard/public/sdk/preset.css
+++ b/frontend/dashboard/public/sdk/preset.css
@@ -1,0 +1,1260 @@
+.container {
+  width: 100%
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px
+  }
+}
+
+.pointer-events-none {
+  pointer-events: none
+}
+
+.\!visible {
+  visibility: visible !important
+}
+
+.visible {
+  visibility: visible
+}
+
+.static {
+  position: static
+}
+
+.fixed {
+  position: fixed
+}
+
+.absolute {
+  position: absolute
+}
+
+.relative {
+  position: relative
+}
+
+.inset-0 {
+  inset: 0px
+}
+
+.left-2\.5 {
+  left: 0.625rem
+}
+
+.left-\[68px\] {
+  left: 68px
+}
+
+.right-2 {
+  right: 0.5rem
+}
+
+.right-2\.5 {
+  right: 0.625rem
+}
+
+.right-4 {
+  right: 1rem
+}
+
+.top-1\/2 {
+  top: 50%
+}
+
+.top-4 {
+  top: 1rem
+}
+
+.top-\[18px\] {
+  top: 18px
+}
+
+.z-10 {
+  z-index: 10
+}
+
+.z-30 {
+  z-index: 30
+}
+
+.z-40 {
+  z-index: 40
+}
+
+.m-0 {
+  margin: 0px
+}
+
+.-mb-px {
+  margin-bottom: -1px
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem
+}
+
+.mb-4 {
+  margin-bottom: 1rem
+}
+
+.ml-2 {
+  margin-left: 0.5rem
+}
+
+.mt-0\.5 {
+  margin-top: 0.125rem
+}
+
+.mt-1 {
+  margin-top: 0.25rem
+}
+
+.mt-1\.5 {
+  margin-top: 0.375rem
+}
+
+.mt-2 {
+  margin-top: 0.5rem
+}
+
+.mt-3 {
+  margin-top: 0.75rem
+}
+
+.mt-4 {
+  margin-top: 1rem
+}
+
+.mt-5 {
+  margin-top: 1.25rem
+}
+
+.block {
+  display: block
+}
+
+.inline-block {
+  display: inline-block
+}
+
+.inline {
+  display: inline
+}
+
+.flex {
+  display: flex
+}
+
+.inline-flex {
+  display: inline-flex
+}
+
+.table {
+  display: table
+}
+
+.table-row {
+  display: table-row
+}
+
+.grid {
+  display: grid
+}
+
+.hidden {
+  display: none
+}
+
+.h-1\.5 {
+  height: 0.375rem
+}
+
+.h-10 {
+  height: 2.5rem
+}
+
+.h-2 {
+  height: 0.5rem
+}
+
+.h-3 {
+  height: 0.75rem
+}
+
+.h-3\.5 {
+  height: 0.875rem
+}
+
+.h-5 {
+  height: 1.25rem
+}
+
+.h-7 {
+  height: 1.75rem
+}
+
+.h-8 {
+  height: 2rem
+}
+
+.h-9 {
+  height: 2.25rem
+}
+
+.h-\[132px\] {
+  height: 132px
+}
+
+.h-\[218px\] {
+  height: 218px
+}
+
+.h-\[22px\] {
+  height: 22px
+}
+
+.h-full {
+  height: 100%
+}
+
+.max-h-\[280px\] {
+  max-height: 280px
+}
+
+.max-h-\[42vh\] {
+  max-height: 42vh
+}
+
+.min-h-0 {
+  min-height: 0px
+}
+
+.w-1\.5 {
+  width: 0.375rem
+}
+
+.w-2 {
+  width: 0.5rem
+}
+
+.w-3 {
+  width: 0.75rem
+}
+
+.w-3\.5 {
+  width: 0.875rem
+}
+
+.w-48 {
+  width: 12rem
+}
+
+.w-56 {
+  width: 14rem
+}
+
+.w-64 {
+  width: 16rem
+}
+
+.w-7 {
+  width: 1.75rem
+}
+
+.w-8 {
+  width: 2rem
+}
+
+.w-\[280px\] {
+  width: 280px
+}
+
+.w-\[62px\] {
+  width: 62px
+}
+
+.w-full {
+  width: 100%
+}
+
+.min-w-0 {
+  min-width: 0px
+}
+
+.min-w-\[1\.25rem\] {
+  min-width: 1.25rem
+}
+
+.flex-1 {
+  flex: 1 1 0%
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0
+}
+
+.-translate-x-full {
+  --tw-translate-x: -100%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+}
+
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+}
+
+@keyframes fade-up {
+  0% {
+    opacity: 0;
+    transform: translateY(8px)
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0)
+  }
+}
+
+.animate-fade-up {
+  animation: fade-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both
+}
+
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0
+  }
+}
+
+.animate-ping {
+  animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 0.4;
+    transform: scale(0.95)
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.05)
+  }
+}
+
+.animate-pulse-dot {
+  animation: pulse-dot 1.6s ease-in-out infinite
+}
+
+@keyframes scan {
+  0% {
+    transform: translateX(-100%)
+  }
+
+  100% {
+    transform: translateX(100%)
+  }
+}
+
+.animate-scan {
+  animation: scan 3s ease-in-out infinite
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg)
+  }
+}
+
+.animate-spin {
+  animation: spin 1s linear infinite
+}
+
+.cursor-pointer {
+  cursor: pointer
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none
+}
+
+.resize {
+  resize: both
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr))
+}
+
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr))
+}
+
+.grid-cols-\[340px_1fr\] {
+  grid-template-columns: 340px 1fr
+}
+
+.grid-cols-\[9px_1fr_auto\] {
+  grid-template-columns: 9px 1fr auto
+}
+
+.grid-cols-\[auto_1fr_auto\] {
+  grid-template-columns: auto 1fr auto
+}
+
+.flex-col {
+  flex-direction: column
+}
+
+.flex-wrap {
+  flex-wrap: wrap
+}
+
+.place-items-center {
+  place-items: center
+}
+
+.items-end {
+  align-items: flex-end
+}
+
+.items-center {
+  align-items: center
+}
+
+.items-baseline {
+  align-items: baseline
+}
+
+.justify-center {
+  justify-content: center
+}
+
+.justify-between {
+  justify-content: space-between
+}
+
+.gap-1 {
+  gap: 0.25rem
+}
+
+.gap-1\.5 {
+  gap: 0.375rem
+}
+
+.gap-2 {
+  gap: 0.5rem
+}
+
+.gap-2\.5 {
+  gap: 0.625rem
+}
+
+.gap-3 {
+  gap: 0.75rem
+}
+
+.gap-3\.5 {
+  gap: 0.875rem
+}
+
+.gap-4 {
+  gap: 1rem
+}
+
+.gap-px {
+  gap: 1px
+}
+
+.overflow-auto {
+  overflow: auto
+}
+
+.overflow-hidden {
+  overflow: hidden
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap
+}
+
+.whitespace-nowrap {
+  white-space: nowrap
+}
+
+.break-all {
+  word-break: break-all
+}
+
+.rounded {
+  border-radius: 4px
+}
+
+.rounded-2xl {
+  border-radius: 14px
+}
+
+.rounded-\[4px\] {
+  border-radius: 4px
+}
+
+.rounded-full {
+  border-radius: 9999px
+}
+
+.rounded-lg {
+  border-radius: 10px
+}
+
+.rounded-md {
+  border-radius: 6px
+}
+
+.rounded-sm {
+  border-radius: 2px
+}
+
+.border {
+  border-width: 1px
+}
+
+.border-b {
+  border-bottom-width: 1px
+}
+
+.border-b-2 {
+  border-bottom-width: 2px
+}
+
+.border-r {
+  border-right-width: 1px
+}
+
+.border-t {
+  border-top-width: 1px
+}
+
+.border-accent {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent-rgb) / var(--tw-border-opacity, 1))
+}
+
+.border-accent-deep {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent-deep-rgb) / var(--tw-border-opacity, 1))
+}
+
+.border-border {
+  border-color: var(--color-border)
+}
+
+.border-border-strong {
+  border-color: var(--color-border-strong)
+}
+
+.border-current {
+  border-color: currentColor
+}
+
+.border-danger\/30 {
+  border-color: rgb(var(--color-danger-rgb) / 0.3)
+}
+
+.border-success\/25 {
+  border-color: rgb(var(--color-success-rgb) / 0.25)
+}
+
+.border-transparent {
+  border-color: transparent
+}
+
+.border-t-transparent {
+  border-top-color: transparent
+}
+
+.bg-accent {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-accent-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-accent-soft {
+  background-color: var(--color-accent-soft)
+}
+
+.bg-bg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-bg-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-black\/55 {
+  background-color: rgb(0 0 0 / 0.55)
+}
+
+.bg-border {
+  background-color: var(--color-border)
+}
+
+.bg-danger {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-danger-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-danger\/10 {
+  background-color: rgb(var(--color-danger-rgb) / 0.1)
+}
+
+.bg-danger\/15 {
+  background-color: rgb(var(--color-danger-rgb) / 0.15)
+}
+
+.bg-danger\/20 {
+  background-color: rgb(var(--color-danger-rgb) / 0.2)
+}
+
+.bg-muted {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-muted-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-subtle {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-subtle-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-success {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-success-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-success\/10 {
+  background-color: rgb(var(--color-success-rgb) / 0.1)
+}
+
+.bg-success\/15 {
+  background-color: rgb(var(--color-success-rgb) / 0.15)
+}
+
+.bg-surface {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-surface-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-surface-2 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-surface-2-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-surface-3 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-surface-3-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-transparent {
+  background-color: transparent
+}
+
+.bg-warning {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-warning-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.bg-warning\/15 {
+  background-color: rgb(var(--color-warning-rgb) / 0.15)
+}
+
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-stops))
+}
+
+.from-transparent {
+  --tw-gradient-from: transparent var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to)
+}
+
+.via-white\/\[0\.04\] {
+  --tw-gradient-to: rgb(255 255 255 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(255 255 255 / 0.04) var(--tw-gradient-via-position), var(--tw-gradient-to)
+}
+
+.to-transparent {
+  --tw-gradient-to: transparent var(--tw-gradient-to-position)
+}
+
+.p-0\.5 {
+  padding: 0.125rem
+}
+
+.p-1 {
+  padding: 0.25rem
+}
+
+.p-1\.5 {
+  padding: 0.375rem
+}
+
+.p-3 {
+  padding: 0.75rem
+}
+
+.p-4 {
+  padding: 1rem
+}
+
+.p-5 {
+  padding: 1.25rem
+}
+
+.p-6 {
+  padding: 1.5rem
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem
+}
+
+.px-1\.5 {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem
+}
+
+.px-2\.5 {
+  padding-left: 0.625rem;
+  padding-right: 0.625rem
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem
+}
+
+.px-3\.5 {
+  padding-left: 0.875rem;
+  padding-right: 0.875rem
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem
+}
+
+.py-0\.5 {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem
+}
+
+.py-1\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem
+}
+
+.py-2\.5 {
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem
+}
+
+.py-px {
+  padding-top: 1px;
+  padding-bottom: 1px
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem
+}
+
+.pl-3 {
+  padding-left: 0.75rem
+}
+
+.pl-8 {
+  padding-left: 2rem
+}
+
+.pr-16 {
+  padding-right: 4rem
+}
+
+.pr-3 {
+  padding-right: 0.75rem
+}
+
+.pr-8 {
+  padding-right: 2rem
+}
+
+.pt-3 {
+  padding-top: 0.75rem
+}
+
+.text-left {
+  text-align: left
+}
+
+.text-right {
+  text-align: right
+}
+
+.font-mono {
+  font-family: JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace
+}
+
+.font-sans {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif
+}
+
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem
+}
+
+.text-\[10\.5px\] {
+  font-size: 10.5px
+}
+
+.text-\[10px\] {
+  font-size: 10px
+}
+
+.text-\[11\.5px\] {
+  font-size: 11.5px
+}
+
+.text-\[11px\] {
+  font-size: 11px
+}
+
+.text-\[12\.5px\] {
+  font-size: 12.5px
+}
+
+.text-\[12px\] {
+  font-size: 12px
+}
+
+.text-\[13px\] {
+  font-size: 13px
+}
+
+.text-\[14px\] {
+  font-size: 14px
+}
+
+.text-\[15px\] {
+  font-size: 15px
+}
+
+.text-\[18px\] {
+  font-size: 18px
+}
+
+.text-\[19px\] {
+  font-size: 19px
+}
+
+.text-\[26px\] {
+  font-size: 26px
+}
+
+.text-\[8\.5px\] {
+  font-size: 8.5px
+}
+
+.text-\[9\.5px\] {
+  font-size: 9.5px
+}
+
+.text-\[9px\] {
+  font-size: 9px
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem
+}
+
+.font-medium {
+  font-weight: 500
+}
+
+.font-semibold {
+  font-weight: 600
+}
+
+.uppercase {
+  text-transform: uppercase
+}
+
+.tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction)
+}
+
+.leading-none {
+  line-height: 1
+}
+
+.leading-relaxed {
+  line-height: 1.625
+}
+
+.tracking-\[0\.12em\] {
+  letter-spacing: 0.12em
+}
+
+.tracking-\[0\.14em\] {
+  letter-spacing: 0.14em
+}
+
+.tracking-\[0\.2em\] {
+  letter-spacing: 0.2em
+}
+
+.tracking-tight {
+  letter-spacing: -0.015em
+}
+
+.tracking-wide {
+  letter-spacing: 0.025em
+}
+
+.text-\[\#c4c4cc\] {
+  --tw-text-opacity: 1;
+  color: rgb(196 196 204 / var(--tw-text-opacity, 1))
+}
+
+.text-\[\#dfe3ff\] {
+  --tw-text-opacity: 1;
+  color: rgb(223 227 255 / var(--tw-text-opacity, 1))
+}
+
+.text-accent {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-accent-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-accent-ink {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-accent-ink-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-danger {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-danger-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-fg {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-fg-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-muted {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-muted-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-subtle {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-subtle-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-success {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-success-rgb) / var(--tw-text-opacity, 1))
+}
+
+.text-warning {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-warning-rgb) / var(--tw-text-opacity, 1))
+}
+
+.opacity-0 {
+  opacity: 0
+}
+
+.opacity-60 {
+  opacity: 0.6
+}
+
+.shadow-\[0_1px_0_0_rgba\(255\2c 255\2c 255\2c 0\.12\)_inset\] {
+  --tw-shadow: 0 1px 0 0 rgba(255,255,255,0.12) inset;
+  --tw-shadow-colored: inset 0 1px 0 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.shadow-\[inset_0_0_0_1px_var\(--color-border-strong\)\] {
+  --tw-shadow: inset 0 0 0 1px var(--color-border-strong);
+  --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.shadow-inset-hairline {
+  --tw-shadow: inset 0 1px 0 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.02);
+  --tw-shadow-colored: inset 0 1px 0 0 var(--tw-shadow-color), inset 0 0 0 1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.shadow-lift-md {
+  --tw-shadow: 0 1px 0 0 rgba(255,255,255,0.06) inset, 0 2px 8px -1px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05);
+  --tw-shadow-colored: inset 0 1px 0 0 var(--tw-shadow-color), 0 2px 8px -1px var(--tw-shadow-color), 0 0 0 1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.shadow-lift-sm {
+  --tw-shadow: 0 1px 0 0 rgba(255,255,255,0.05) inset, 0 1px 2px 0 rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04);
+  --tw-shadow-colored: inset 0 1px 0 0 var(--tw-shadow-color), 0 1px 2px 0 var(--tw-shadow-color), 0 0 0 1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px
+}
+
+.blur {
+  --tw-blur: blur(8px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)
+}
+
+.\!filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important
+}
+
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)
+}
+
+.backdrop-blur-\[2px\] {
+  --tw-backdrop-blur: blur(2px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)
+}
+
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-\[box-shadow\2c border-color\] {
+  transition-property: box-shadow,border-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-\[filter\2c transform\2c opacity\] {
+  transition-property: filter,transform,opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-opacity {
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms
+}
+
+.duration-150 {
+  transition-duration: 150ms
+}
+
+.duration-200 {
+  transition-duration: 200ms
+}
+
+.duration-\[420ms\] {
+  transition-duration: 420ms
+}
+
+.placeholder\:text-subtle::-moz-placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-subtle-rgb) / var(--tw-text-opacity, 1))
+}
+
+.placeholder\:text-subtle::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-subtle-rgb) / var(--tw-text-opacity, 1))
+}
+
+.last\:border-b-0:last-child {
+  border-bottom-width: 0px
+}
+
+.hover\:-translate-y-0\.5:hover {
+  --tw-translate-y: -0.125rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))
+}
+
+.hover\:border-border:hover {
+  border-color: var(--color-border)
+}
+
+.hover\:border-border-strong:hover {
+  border-color: var(--color-border-strong)
+}
+
+.hover\:border-danger\/40:hover {
+  border-color: rgb(var(--color-danger-rgb) / 0.4)
+}
+
+.hover\:bg-danger\/30:hover {
+  background-color: rgb(var(--color-danger-rgb) / 0.3)
+}
+
+.hover\:bg-surface-2:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-surface-2-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.hover\:bg-surface-3:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-surface-3-rgb) / var(--tw-bg-opacity, 1))
+}
+
+.hover\:text-danger:hover {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-danger-rgb) / var(--tw-text-opacity, 1))
+}
+
+.hover\:text-fg:hover {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-fg-rgb) / var(--tw-text-opacity, 1))
+}
+
+.hover\:shadow-lift-md:hover {
+  --tw-shadow: 0 1px 0 0 rgba(255,255,255,0.06) inset, 0 2px 8px -1px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05);
+  --tw-shadow-colored: inset 0 1px 0 0 var(--tw-shadow-color), 0 2px 8px -1px var(--tw-shadow-color), 0 0 0 1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)
+}
+
+.hover\:brightness-110:hover {
+  --tw-brightness: brightness(1.1);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)
+}
+
+.focus\:border-accent-deep:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent-deep-rgb) / var(--tw-border-opacity, 1))
+}
+
+.focus\:border-border-strong:focus {
+  border-color: var(--color-border-strong)
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px
+}
+
+.active\:bg-danger\/25:active {
+  background-color: rgb(var(--color-danger-rgb) / 0.25)
+}
+
+.active\:brightness-95:active {
+  --tw-brightness: brightness(.95);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)
+}
+
+.disabled\:cursor-not-allowed:disabled {
+  cursor: not-allowed
+}
+
+.disabled\:opacity-40:disabled {
+  opacity: 0.4
+}
+
+.group:hover .group-hover\:opacity-100 {
+  opacity: 1
+}

--- a/frontend/dashboard/public/sdk/ui.js
+++ b/frontend/dashboard/public/sdk/ui.js
@@ -2,7 +2,7 @@
 // implementations. Plugins import named components from here.
 const U = window.__akashicRuntime.UI;
 export const {
-  ShortcutKey, Label, FieldLabel, Tile, Btn, Chip, Input, SearchInput, Select,
+  ShortcutKey, Label, FieldLabel, Tile, Stack, Grid, Panel, Toolbar, Btn, Chip, Input, SearchInput, Select,
   BrandMark, useTheme, ThemeToggle, cn, Pie, MetricTile, Sparkline, TrendChart,
   api, asPageResult, pageCount,
 } = U;

--- a/frontend/dashboard/src/PluginDetail.tsx
+++ b/frontend/dashboard/src/PluginDetail.tsx
@@ -21,9 +21,13 @@ export function PluginDetail(props: {
 
   // 2. Otherwise fall back to the legacy DOM render contract.
   if (Detail) {
-    return <Detail item={props.item} dispatch={props.dispatch} />;
+    return (
+      <div className="plugin-workbench-root" data-akashic-plugin={props.plugin.id}>
+        <Detail item={props.item} dispatch={props.dispatch} />
+      </div>
+    );
   }
-  return <div ref={ref} />;
+  return <div ref={ref} data-akashic-plugin={props.plugin.id} />;
 }
 
 export function PluginMain(props: {
@@ -41,7 +45,11 @@ export function PluginMain(props: {
   }, [Main, props.plugin, props.dispatch]);
 
   if (Main) {
-    return <div className="plugin-workbench-root"><Main dispatch={props.dispatch} /></div>;
+    return (
+      <div className="plugin-workbench-root" data-akashic-plugin={props.plugin.id}>
+        <Main dispatch={props.dispatch} />
+      </div>
+    );
   }
-  return <div className="plugin-workbench-root" ref={ref} />;
+  return <div className="plugin-workbench-root" ref={ref} data-akashic-plugin={props.plugin.id} />;
 }

--- a/frontend/dashboard/src/design/charts.tsx
+++ b/frontend/dashboard/src/design/charts.tsx
@@ -26,11 +26,10 @@ const TONE_RGB: Record<ChartTone, string> = {
 
 const toneColor = (tone: ChartTone): string => `rgb(${TONE_RGB[tone]})`;
 
-const AXIS_TICK = { fontSize: 10, fill: "rgba(138,138,143,0.6)", fontFamily: "JetBrains Mono, monospace" };
+const AXIS_TICK = { fontSize: 10, fill: "rgba(138,138,143,0.6)", fontFamily: "var(--sans)" };
 const GRID_STROKE = "rgba(255,255,255,0.07)";
 
-// Hand-rolled SVG pie — a 2-slice hit/miss filled pie with a glossy, dimensional
-// finish (radial sheen + drop shadow + rim) and a sweep-in animation on mount.
+// Hand-rolled SVG pie — a 2-slice hit/miss chart with a sweep-in animation on mount.
 export function Pie({
   rate,
   hit,
@@ -50,8 +49,6 @@ export function Pie({
   size?: number;
   className?: string;
 }) {
-  const uid = useId().replace(/:/g, "");
-
   // 1. Resolve the ratio: explicit rate wins, else derive from hit/miss totals.
   const total = hit + miss;
   const ratio = rate != null ? Math.max(0, Math.min(1, rate)) : total > 0 ? hit / total : 0;
@@ -88,42 +85,22 @@ export function Pie({
   return (
     <div className={cn("flex flex-col items-center gap-3", className)}>
       {title && (
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-subtle">{title}</span>
+        <span className="font-sans text-[11px] font-medium tracking-wide text-subtle">{title}</span>
       )}
       <svg
         width={size}
         height={size}
         viewBox={`0 0 ${size} ${size}`}
-        style={{ filter: "drop-shadow(0 6px 14px rgba(0,0,0,0.55))" }}
       >
-        <defs>
-          <radialGradient id={`hit-${uid}`} cx="36%" cy="30%" r="78%">
-            <stop offset="0%" stopColor="rgb(var(--color-success-rgb))" stopOpacity="1" />
-            <stop offset="100%" stopColor="rgb(var(--color-success-rgb))" stopOpacity="0.72" />
-          </radialGradient>
-          <radialGradient id={`miss-${uid}`} cx="36%" cy="30%" r="80%">
-            <stop offset="0%" stopColor="rgb(var(--color-surface-3-rgb))" stopOpacity="1" />
-            <stop offset="100%" stopColor="rgb(var(--color-bg-rgb))" stopOpacity="1" />
-          </radialGradient>
-          <radialGradient id={`gloss-${uid}`} cx="32%" cy="24%" r="62%">
-            <stop offset="0%" stopColor="#ffffff" stopOpacity="0.22" />
-            <stop offset="55%" stopColor="#ffffff" stopOpacity="0.04" />
-            <stop offset="100%" stopColor="#ffffff" stopOpacity="0" />
-          </radialGradient>
-        </defs>
-        <circle cx={cx} cy={cx} r={r} fill={`url(#miss-${uid})`} />
+        <circle cx={cx} cy={cx} r={r} fill="rgb(var(--color-surface-3-rgb))" />
         {shown >= 0.999 ? (
-          <circle cx={cx} cy={cx} r={r} fill={`url(#hit-${uid})`} />
+          <circle cx={cx} cy={cx} r={r} fill="rgb(var(--color-success-rgb))" />
         ) : shown > 0.001 ? (
-          <path d={slice} fill={`url(#hit-${uid})`} />
+          <path d={slice} fill="rgb(var(--color-success-rgb))" />
         ) : null}
-        {/* glossy sheen for the dimensional / glass finish */}
-        <circle cx={cx} cy={cx} r={r} fill={`url(#gloss-${uid})`} />
-        {/* crisp rim + inner top highlight */}
-        <circle cx={cx} cy={cx} r={r} fill="none" stroke="rgba(0,0,0,0.35)" strokeWidth={1.5} />
-        <circle cx={cx} cy={cx} r={r - 1} fill="none" stroke="rgba(255,255,255,0.10)" strokeWidth={1} />
+        <circle cx={cx} cy={cx} r={r} fill="none" stroke="var(--color-border-strong)" strokeWidth={1} />
       </svg>
-      <div className="flex w-full items-center justify-center gap-4 font-mono text-[11px] tabular-nums">
+      <div className="flex w-full items-center justify-center gap-4 font-sans text-[11px] tabular-nums">
         <span className="flex items-center gap-1.5 text-success">
           <span className="h-2 w-2 rounded-full bg-success" />
           {hitLabel} {fmt(hit)} · {pct}%
@@ -160,11 +137,11 @@ export function MetricTile({
   className?: string;
 }) {
   return (
-    <div className={cn("relative overflow-hidden rounded-2xl border border-border bg-surface p-5 shadow-lift-sm", className)}>
+    <div className={cn("relative overflow-hidden rounded-lg border border-border bg-surface p-5 shadow-lift-sm", className)}>
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{label}</span>
+        <span className="font-sans text-[11px] font-medium tracking-wide text-muted">{label}</span>
         {typeof delta === "number" && (
-          <span className={cn("font-mono text-[11px] tabular-nums", delta >= 0 ? "text-success" : "text-danger")}>
+          <span className={cn("font-sans text-[11px] tabular-nums", delta >= 0 ? "text-success" : "text-danger")}>
             {delta >= 0 ? "+" : ""}
             {delta.toFixed(1)}%
           </span>
@@ -172,9 +149,9 @@ export function MetricTile({
       </div>
       <div className="mt-3 flex items-baseline gap-1.5">
         <span className="font-sans text-4xl font-semibold leading-none tracking-tight tabular-nums text-fg">{value}</span>
-        {unit && <span className="font-mono text-[11px] text-subtle">{unit}</span>}
+        {unit && <span className="font-sans text-[11px] text-subtle">{unit}</span>}
       </div>
-      {sub && <div className="mt-2 font-mono text-[11px] tabular-nums text-muted">{sub}</div>}
+      {sub && <div className="mt-2 font-sans text-[11px] tabular-nums text-muted">{sub}</div>}
       {spark && spark.length > 1 && (
         <Sparkline data={spark} tone={tone} className="mt-4 w-full" height={40} />
       )}
@@ -235,9 +212,9 @@ const TOOLTIP_CONTENT_STYLE = {
   border: "1px solid var(--color-border-strong)",
   borderRadius: 8,
   fontSize: 11,
-  fontFamily: "JetBrains Mono, monospace",
+  fontFamily: "var(--sans)",
   padding: "6px 10px",
-  boxShadow: "0 8px 24px -6px rgba(0,0,0,0.6)",
+  boxShadow: "0 2px 8px rgba(0,0,0,0.35)",
 };
 
 // TrendChart — a recharts area/bar time series with a dashed horizontal grid,

--- a/frontend/dashboard/src/design/plugin-preset.css
+++ b/frontend/dashboard/src/design/plugin-preset.css
@@ -1,0 +1,2 @@
+@tailwind components;
+@tailwind utilities;

--- a/frontend/dashboard/src/design/ui.tsx
+++ b/frontend/dashboard/src/design/ui.tsx
@@ -23,13 +23,13 @@ export function ShortcutKey({ children, className }: { children: ReactNode; clas
 
 export function Label({ children }: { children: ReactNode }) {
   return (
-    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">{children}</span>
+    <span className="font-sans text-[11px] font-medium tracking-wide text-subtle">{children}</span>
   );
 }
 
 export function FieldLabel({ children }: { children: ReactNode }) {
   return (
-    <label className="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-muted">
+    <label className="mb-2 block font-sans text-[11px] font-medium tracking-wide text-muted">
       {children}
     </label>
   );
@@ -73,7 +73,7 @@ const BTN_SIZES: Record<BtnSize, string> = {
 
 const BTN_VARIANTS: Record<BtnVariant, string> = {
   primary:
-    "bg-accent text-accent-ink hover:brightness-110 active:brightness-95 shadow-[0_1px_0_0_rgba(255,255,255,0.12)_inset,0_6px_14px_-6px_rgba(72,90,226,0.55)]",
+    "bg-accent text-accent-ink hover:brightness-110 active:brightness-95 shadow-[0_1px_0_0_rgba(255,255,255,0.12)_inset]",
   secondary: "bg-transparent text-fg border border-border hover:border-border-strong",
   ghost: "bg-transparent text-fg hover:bg-surface-2",
   danger: "bg-danger/20 text-danger hover:bg-danger/30 active:bg-danger/25",
@@ -104,7 +104,7 @@ export function Btn({
       onClick={onClick}
       disabled={disabled || loading}
       className={cn(
-        "inline-flex select-none items-center gap-2 rounded-md font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40",
+        "inline-flex select-none items-center gap-2 rounded-md font-medium tracking-tight transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40",
         BTN_SIZES[size],
         BTN_VARIANTS[variant],
         className,
@@ -156,7 +156,7 @@ export function Chip({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-mono text-[11px] tabular-nums",
+        "inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-sans text-[11px] tabular-nums",
         CHIP_TONES[tone],
         className,
       )}

--- a/frontend/dashboard/src/design/ui.tsx
+++ b/frontend/dashboard/src/design/ui.tsx
@@ -58,6 +58,30 @@ export function Tile({
   );
 }
 
+export function Stack({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("ak-plugin-stack", className)}>{children}</div>;
+}
+
+export function Grid({
+  children,
+  columns = 2,
+  className,
+}: {
+  children: ReactNode;
+  columns?: 2 | 3 | 4;
+  className?: string;
+}) {
+  return <div className={cn("ak-plugin-grid", `ak-plugin-grid-${columns}`, className)}>{children}</div>;
+}
+
+export function Panel({ children, className }: { children: ReactNode; className?: string }) {
+  return <section className={cn("ak-plugin-panel", className)}>{children}</section>;
+}
+
+export function Toolbar({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("ak-plugin-toolbar", className)}>{children}</div>;
+}
+
 // ---------------------------------------------------------------------------
 // Buttons
 // ---------------------------------------------------------------------------

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -35,6 +35,11 @@ import type {
   ViewMode,
 } from "./types";
 
+const pluginPreset = document.createElement("link");
+pluginPreset.rel = "stylesheet";
+pluginPreset.href = "/assets/sdk/preset.css";
+document.head.appendChild(pluginPreset);
+
 // Creates a PluginDispatch bound to the given plugin + latest state getter.
 function makeDispatch(
   plugin: PluginConfig,

--- a/frontend/dashboard/src/pluginRuntime.ts
+++ b/frontend/dashboard/src/pluginRuntime.ts
@@ -104,8 +104,8 @@ export function attachJsonViewers(container: ParentNode): void {
 }
 
 // ---------------------------------------------------------------------------
-// Shared visual vocabulary (industrial design system) handed to plugin panels.
-// Class strings are full literals so Tailwind's content scanner keeps them.
+// Shared visual vocabulary handed to plugin panels. Preset layout classes are
+// semantic and independent from the host's Tailwind implementation.
 // ---------------------------------------------------------------------------
 
 // Tone -> background + text classes, mirroring design/ui.tsx Chip.
@@ -140,6 +140,10 @@ const UI_BTN_VARIANTS: Record<UiBtnVariant, string> = {
   danger: "bg-danger/20 text-danger hover:bg-danger/30 active:bg-danger/25",
 };
 
+const UI_STACK = "ak-plugin-stack";
+const UI_GRID = "ak-plugin-grid";
+const UI_PANEL = "ak-plugin-panel";
+const UI_TOOLBAR = "ak-plugin-toolbar";
 const UI_BADGE_BASE = "inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-sans text-[11px] tabular-nums";
 const UI_BTN_BASE = "inline-flex select-none items-center gap-2 rounded-md font-medium tracking-tight transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40";
 const UI_INPUT = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none";
@@ -169,6 +173,26 @@ function createDashboardUi(): DashboardUi {
     return span;
   };
   return {
+    stack(className) {
+      const div = document.createElement("div");
+      div.className = className ? `${UI_STACK} ${className}` : UI_STACK;
+      return div;
+    },
+    grid(columns = 2, className) {
+      const div = document.createElement("div");
+      div.className = className ? `${UI_GRID} ${UI_GRID}-${columns} ${className}` : `${UI_GRID} ${UI_GRID}-${columns}`;
+      return div;
+    },
+    panel(className) {
+      const section = document.createElement("section");
+      section.className = className ? `${UI_PANEL} ${className}` : UI_PANEL;
+      return section;
+    },
+    toolbar(className) {
+      const div = document.createElement("div");
+      div.className = className ? `${UI_TOOLBAR} ${className}` : UI_TOOLBAR;
+      return div;
+    },
     badge: makeBadge,
     chip: makeBadge,
     btn(text, opts) {
@@ -197,6 +221,12 @@ function createDashboardUi(): DashboardUi {
       return span;
     },
     cx: {
+      stack: UI_STACK,
+      grid(columns = 2) {
+        return `${UI_GRID} ${UI_GRID}-${columns}`;
+      },
+      panel: UI_PANEL,
+      toolbar: UI_TOOLBAR,
       badge: badgeClass,
       btn: btnClass,
       input: UI_INPUT,

--- a/frontend/dashboard/src/pluginRuntime.ts
+++ b/frontend/dashboard/src/pluginRuntime.ts
@@ -140,11 +140,11 @@ const UI_BTN_VARIANTS: Record<UiBtnVariant, string> = {
   danger: "bg-danger/20 text-danger hover:bg-danger/30 active:bg-danger/25",
 };
 
-const UI_BADGE_BASE = "inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-mono text-[11px] tabular-nums";
-const UI_BTN_BASE = "inline-flex select-none items-center gap-2 rounded-md font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40";
+const UI_BADGE_BASE = "inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-sans text-[11px] tabular-nums";
+const UI_BTN_BASE = "inline-flex select-none items-center gap-2 rounded-md font-medium tracking-tight transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40";
 const UI_INPUT = "h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none";
 const UI_TILE = "relative rounded-lg border border-border bg-surface p-5";
-const UI_LABEL = "font-mono text-[10px] uppercase tracking-[0.2em] text-subtle";
+const UI_LABEL = "font-sans text-[11px] font-medium tracking-wide text-subtle";
 const UI_MONO = "font-mono tabular-nums";
 
 function badgeClass(tone: UiTone = "neutral"): string {

--- a/frontend/dashboard/src/styles.css
+++ b/frontend/dashboard/src/styles.css
@@ -124,8 +124,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: radial-gradient(circle at 50% 0%, var(--color-surface-2) 0%, var(--color-bg) 100%);
-  background-attachment: fixed;
+  background: var(--color-bg);
   color: var(--color-fg);
 }
 
@@ -186,12 +185,10 @@ body {
   .topbar {
     @apply flex h-[60px] flex-shrink-0 items-center gap-4 px-6 z-10;
     margin: 12px 16px 0 16px;
-    border-radius: 16px;
-    background-color: rgb(var(--color-surface-rgb) / 0.5);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+    box-shadow: var(--shadow);
   }
 
   .brand {
@@ -372,34 +369,28 @@ body {
   .sessions-pane {
     @apply flex min-h-0 flex-shrink-0 flex-col bg-surface-2 overflow-hidden;
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
     width: clamp(260px, 20vw, 320px);
-    background: rgb(var(--color-surface-2-rgb) / 0.6);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+    background: var(--color-surface-2);
+    box-shadow: var(--shadow);
   }
 
   .messages-pane {
     @apply flex min-h-0 min-w-0 flex-1 flex-col bg-surface overflow-hidden;
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
     border: 1px solid var(--color-border);
-    background: rgb(var(--color-surface-rgb) / 0.7);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    box-shadow: 0 12px 48px rgba(0,0,0,0.5);
+    background: var(--color-surface);
+    box-shadow: var(--shadow);
   }
 
   .detail-pane {
     @apply min-h-0 flex-shrink-0 overflow-y-auto bg-surface overflow-hidden;
     position: relative;
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
     border: 1px solid var(--color-border);
     width: clamp(360px, 26vw, 460px);
-    background: rgb(var(--color-surface-rgb) / 0.7);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    box-shadow: 0 12px 48px rgba(0,0,0,0.5);
+    background: var(--color-surface);
+    box-shadow: var(--shadow);
     transition: width 0.35s cubic-bezier(0.2, 1, 0.3, 1), opacity 0.3s ease, margin 0.35s ease;
   }
 
@@ -418,7 +409,7 @@ body {
     justify-content: center;
     cursor: pointer;
     z-index: 100;
-    transition: all 0.2s ease;
+    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
   }
   .detail-close-btn:hover {
     background: rgba(255, 255, 255, 0.15);
@@ -437,12 +428,10 @@ body {
 
   .plugin-workbench-pane {
     @apply min-h-0 min-w-0 flex-1 overflow-y-auto bg-bg;
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
     border: 1px solid var(--color-border);
-    background: rgb(var(--color-bg-rgb) / 0.7);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    box-shadow: 0 12px 48px rgba(0,0,0,0.5);
+    background: var(--color-bg);
+    box-shadow: var(--shadow);
   }
 
   .plugin-workbench-root {
@@ -456,7 +445,7 @@ body {
   }
 
   .pane-kicker {
-    @apply font-mono text-[10px] uppercase tracking-[0.14em] text-subtle;
+    @apply font-sans text-[11px] font-medium tracking-wide text-subtle;
   }
 
   .pane-title {
@@ -520,7 +509,7 @@ body {
   }
 
   .nav-section-divider span {
-    @apply whitespace-nowrap font-mono text-[9.5px] uppercase tracking-[0.14em];
+    @apply whitespace-nowrap font-sans text-[10px] font-medium uppercase tracking-wide;
   }
 
   .nav-group {
@@ -653,7 +642,8 @@ body {
   }
 
   .session-actions {
-    @apply flex -translate-x-1 gap-1 opacity-0 transition-all;
+    @apply flex -translate-x-1 gap-1 opacity-0;
+    transition: opacity 150ms ease, transform 150ms ease;
   }
 
   .session-item:hover .session-actions {
@@ -748,7 +738,8 @@ body {
   /* ── Batch bar ── */
 
   .batch-bar {
-    @apply flex max-h-10 min-h-[40px] items-center gap-3 overflow-hidden border-b border-border-strong bg-accent-soft px-4 py-2 transition-all;
+    @apply flex max-h-10 min-h-[40px] items-center gap-3 overflow-hidden border-b border-border-strong bg-accent-soft px-4 py-2;
+    transition: max-height 150ms ease, min-height 150ms ease, padding 150ms ease, opacity 150ms ease, border-color 150ms ease;
   }
 
   .batch-bar.hidden {
@@ -803,10 +794,9 @@ body {
 
   /* Machined header strip: hairline top highlight, defined bottom edge */
   .table-head {
-    @apply sticky top-0 z-[1] min-h-[36px] px-5 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle;
+    @apply sticky top-0 z-[1] min-h-[36px] px-5 font-sans text-[10px] font-medium uppercase tracking-wide text-subtle;
     border-bottom: 1px solid var(--color-border-strong);
-    background: rgb(var(--color-surface-2-rgb) / 0.85);
-    backdrop-filter: blur(12px);
+    background: var(--color-surface-2);
     box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.04), 0 1px 0 0 rgba(0, 0, 0, 0.35);
   }
 
@@ -828,7 +818,8 @@ body {
   }
 
   .table-row {
-    @apply relative min-h-[44px] cursor-pointer transition-all;
+    @apply relative min-h-[44px] cursor-pointer;
+    transition: background-color 150ms ease, border-color 150ms ease;
     margin: 4px 12px;
     border-radius: 8px;
     padding: 0 8px;
@@ -844,15 +835,12 @@ body {
 
   .table-row:hover {
     background: rgba(255, 255, 255, 0.04);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
     border: 1px solid var(--color-border);
   }
 
   /* Restrained selection: background handled by magic indicator */
   .table-row.active {
     border: 1px solid rgb(var(--color-accent-rgb) / 0.2);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   }
 
   /* selected (batch pick) -> warning wash so it reads apart from active */
@@ -1006,9 +994,7 @@ body {
     @apply flex items-center justify-between gap-2 border-b border-border;
     margin: -16px -16px 16px -16px;
     padding: 16px;
-    background: rgba(var(--color-surface-rgb), 0.85);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
+    background: var(--color-surface);
     position: sticky;
     top: -16px;
     z-index: 50;
@@ -1029,7 +1015,7 @@ body {
   }
 
   .detail-label {
-    @apply mb-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-subtle;
+    @apply mb-1.5 font-sans text-[11px] font-medium tracking-wide text-subtle;
   }
 
   .detail-content {
@@ -1123,7 +1109,7 @@ body {
   }
 
   .detail-chip {
-    @apply inline-flex items-center rounded-sm border border-border bg-surface-2 px-2.5 py-1 font-mono text-[11px] text-fg;
+    @apply inline-flex items-center rounded-sm border border-border bg-surface-2 px-2.5 py-1 font-sans text-[11px] text-fg;
   }
 
   /* ── Proactive board ── */
@@ -1146,7 +1132,7 @@ body {
   }
 
   .proactive-metric-label {
-    @apply font-mono text-[10px] uppercase tracking-[0.14em] text-subtle;
+    @apply font-sans text-[11px] font-medium tracking-wide text-subtle;
   }
 
   .proactive-metric-value {
@@ -1215,7 +1201,6 @@ body {
   .modal-backdrop {
     @apply fixed inset-0 z-[400];
     background: rgba(0, 0, 0, 0.55);
-    backdrop-filter: blur(4px);
   }
 
   .modal {
@@ -1358,10 +1343,10 @@ body {
   box-shadow: inset 0 0 0 1px rgba(var(--color-accent-rgb), 0.2);
   pointer-events: none;
   z-index: 0;
-  transition: transform 0.3s cubic-bezier(0.25, 1.2, 0.5, 1),
-              width 0.3s cubic-bezier(0.25, 1.2, 0.5, 1),
-              height 0.3s cubic-bezier(0.25, 1.2, 0.5, 1),
-              opacity 0.2s ease;
+  transition: transform 180ms ease-out,
+              width 180ms ease-out,
+              height 180ms ease-out,
+              opacity 120ms ease;
 }
 
 .magic-indicator::before {

--- a/frontend/dashboard/src/styles.css
+++ b/frontend/dashboard/src/styles.css
@@ -128,6 +128,43 @@ body {
   color: var(--color-fg);
 }
 
+/* Public plugin preset. Plugins may use these classes or the matching SDK components. */
+.ak-plugin-stack {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ak-plugin-grid {
+  display: grid;
+  min-width: 0;
+  gap: 1rem;
+}
+
+.ak-plugin-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.ak-plugin-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ak-plugin-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+.ak-plugin-panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.ak-plugin-toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.ak-plugin-pre-wrap { white-space: pre-wrap; }
+
 ::selection {
   background: var(--color-accent);
   color: var(--color-accent-ink);

--- a/frontend/dashboard/src/types.ts
+++ b/frontend/dashboard/src/types.ts
@@ -177,12 +177,20 @@ export type UiBtnVariant = "primary" | "secondary" | "ghost" | "danger";
 export type UiBtnSize = "sm" | "md" | "lg";
 
 export interface DashboardUi {
+  stack(className?: string): HTMLDivElement;
+  grid(columns?: 2 | 3 | 4, className?: string): HTMLDivElement;
+  panel(className?: string): HTMLElement;
+  toolbar(className?: string): HTMLDivElement;
   badge(text: string, opts?: { tone?: UiTone; dot?: boolean }): HTMLSpanElement;
   chip(text: string, opts?: { tone?: UiTone; dot?: boolean }): HTMLSpanElement;
   btn(label: string, opts?: { variant?: UiBtnVariant; size?: UiBtnSize; onClick?: (e: MouseEvent) => void }): HTMLButtonElement;
   tile(opts?: { label?: string; className?: string }): HTMLDivElement;
   label(text: string): HTMLSpanElement;
   cx: {
+    stack: string;
+    grid(columns?: 2 | 3 | 4): string;
+    panel: string;
+    toolbar: string;
     badge(tone?: UiTone): string;
     btn(variant?: UiBtnVariant, size?: UiBtnSize): string;
     input: string;

--- a/frontend/dashboard/tailwind.config.ts
+++ b/frontend/dashboard/tailwind.config.ts
@@ -1,37 +1,20 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { homedir } from "node:os";
 import type { Config } from "tailwindcss";
 
 // Content globs are resolved against this config's own location so scanning
 // works regardless of the process cwd (npm runs from the repo root).
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
-const externalPluginRoots = [
-  resolve(repoRoot, "..", "akashic-plugin"),
-  resolve(homedir(), ".akashic-plugin", "cache"),
-];
 
 // Industrial / precision-instrument design tokens. Solid colors use RGB-triplet
 // vars (see src/styles.css) so opacity modifiers like bg-danger/20 work.
-// Plugin panels are scanned too so their utility classes survive purging.
+// Plugin panels use the public preset or their own CSS. They are not part of
+// the host bundle's Tailwind content contract.
 export default {
   content: [
     resolve(here, "index.html"),
     resolve(here, "src/**/*.{ts,tsx}"),
-    resolve(repoRoot, "plugins/**/*.{ts,tsx}"),
-    resolve(repoRoot, "akashic-plugin/**/*.{ts,tsx}"),
-    ...externalPluginRoots.map((root) => resolve(root, "**/*.{ts,tsx}")),
-  ],
-  // Installed plugin panels are compiled at runtime, so their layout utilities
-  // cannot be discovered by the static content scan.
-  safelist: [
-    "grid-cols-2",
-    "grid-cols-3",
-    "grid-cols-4",
-    "grid-cols-[340px_1fr]",
-    "grid-cols-[9px_1fr_auto]",
-    "grid-cols-[auto_1fr_auto]",
   ],
   theme: {
     extend: {

--- a/frontend/dashboard/tailwind.config.ts
+++ b/frontend/dashboard/tailwind.config.ts
@@ -1,11 +1,16 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
 import type { Config } from "tailwindcss";
 
 // Content globs are resolved against this config's own location so scanning
 // works regardless of the process cwd (npm runs from the repo root).
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
+const externalPluginRoots = [
+  resolve(repoRoot, "..", "akashic-plugin"),
+  resolve(homedir(), ".akashic-plugin", "cache"),
+];
 
 // Industrial / precision-instrument design tokens. Solid colors use RGB-triplet
 // vars (see src/styles.css) so opacity modifiers like bg-danger/20 work.
@@ -16,6 +21,17 @@ export default {
     resolve(here, "src/**/*.{ts,tsx}"),
     resolve(repoRoot, "plugins/**/*.{ts,tsx}"),
     resolve(repoRoot, "akashic-plugin/**/*.{ts,tsx}"),
+    ...externalPluginRoots.map((root) => resolve(root, "**/*.{ts,tsx}")),
+  ],
+  // Installed plugin panels are compiled at runtime, so their layout utilities
+  // cannot be discovered by the static content scan.
+  safelist: [
+    "grid-cols-2",
+    "grid-cols-3",
+    "grid-cols-4",
+    "grid-cols-[340px_1fr]",
+    "grid-cols-[9px_1fr_auto]",
+    "grid-cols-[auto_1fr_auto]",
   ],
   theme: {
     extend: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "npm run build:dashboard && npm run build:chat && npm run build:plugins",
-    "build:dashboard": "vite build --config frontend/dashboard/vite.config.ts",
+    "build:dashboard": "npm run build:plugin-preset && vite build --config frontend/dashboard/vite.config.ts",
+    "build:plugin-preset": "node scripts/build-plugin-preset.mjs",
     "build:dashboard:watch": "vite build --config frontend/dashboard/vite.config.ts --watch",
     "build:chat": "vite build --config frontend/chat/vite.config.ts",
     "build:chat:watch": "vite build --config frontend/chat/vite.config.ts --watch",

--- a/scripts/build-plugin-preset.mjs
+++ b/scripts/build-plugin-preset.mjs
@@ -1,0 +1,46 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const tailwind = join(projectRoot, "node_modules", ".bin", process.platform === "win32" ? "tailwindcss.cmd" : "tailwindcss");
+const input = resolve(projectRoot, "frontend/dashboard/src/design/plugin-preset.css");
+const output = resolve(projectRoot, "frontend/dashboard/public/sdk/preset.css");
+const sourceRoots = [
+  resolve(projectRoot, "frontend/dashboard/src"),
+  resolve(projectRoot, "plugins"),
+  resolve(projectRoot, "..", "akashic-plugin"),
+  resolve(process.env.HOME ?? tmpdir(), ".akashic-plugin/cache"),
+].filter(existsSync);
+
+function sourceFiles(root) {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return /\.(ts|tsx)$/.test(entry.name) ? [path] : [];
+  });
+}
+
+if (!existsSync(tailwind)) {
+  throw new Error(`找不到 Tailwind CLI: ${tailwind}`);
+}
+
+mkdirSync(dirname(output), { recursive: true });
+const contentFile = join(tmpdir(), `akasic-plugin-preset-${process.pid}.tsx`);
+writeFileSync(contentFile, sourceRoots.flatMap(sourceFiles).map((path) => readFileSync(path, "utf8")).join("\n"));
+try {
+  const args = [
+    "-i", input,
+    "-o", output,
+    "-c", resolve(projectRoot, "frontend/dashboard/tailwind.config.ts"),
+    "--content", contentFile,
+  ];
+  const result = spawnSync(tailwind, args, { cwd: projectRoot, stdio: "inherit", shell: false });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+} finally {
+  rmSync(contentFile, { force: true });
+}


### PR DESCRIPTION
## 变更范围

### 主程序

- 建立 `@akashic/dashboard-ui` 的公共插件 preset。
- 增加 `Stack`、`Grid`、`Panel`、`Toolbar` 布局组件。
- 为运行时插件根节点增加 `data-akashic-plugin` 作用域。
- 运行 Dashboard 构建时生成并加载独立的 `preset.css`。
- 移除宿主 Tailwind 对外部插件源码的 content 扫描和逐插件 safelist。
- 保留插件自有 CSS 的动态加载能力。
- 在 handbook 中记录插件前端样式契约、作用域规则和迁移方式。

### 私有插件

以下插件已完成独立 commit、push，并重新安装到本机插件缓存：

- observe：使用公共 `Grid` 组件替代关键 KPI/趋势布局 utility。
- status_commands：使用公共 `Grid`，并将自有 CSS 限定在插件根节点。
- emotion：使用公共插件换行 preset。
- proactive_feedback：使用公共插件换行 preset。

对应插件仓库的编译 bundle 也已重新生成并推送。

## 架构边界

```text
Host CSS
  └─ 主程序私有实现

Dashboard UI SDK
  ├─ 公共 token 与 preset CSS
  ├─ 基础布局和数据组件
  └─ 共享 React/API 运行时

Plugin CSS
  └─ 可选、自有、通过 data-akashic-plugin 限定作用域
```

插件不再依赖宿主 Tailwind 的隐式扫描结果；插件可以使用 SDK preset，也可以携带自己的 CSS。

## 验证

- `npm run build:dashboard`
- `npm run build:chat`
- `npm run build:plugins`
- `npm run lint`
- `npx tsc --noEmit --skipLibCheck --pretty false`
- `git diff --check`
- 真实运行时 `/api/dashboard/plugins` 已返回更新后的插件清单和缓存 bundle。

Lint 无错误，只有原有的 3 个 `main.tsx` React Hook 警告。