### PR TITLE
fix(proactive): route wake events through llm

### DIFF
--- a/plugin_packages/wake-proactive/dashboard_panel_meter.tsx
+++ b/plugin_packages/wake-proactive/dashboard_panel_meter.tsx
@@ -102,7 +102,8 @@ function MeterPage(): ReactElement {
       <div><span><i className="tone-cobalt" />持续蓄积</span><strong>{data.hazard_after.toFixed(3)}</strong></div>
       <div><span><i className="tone-amber" />瞬时兴趣推力</span><strong>{data.preference_pressure.toFixed(3)}</strong></div>
       <div><span>未读内容</span><strong>{data.unread_count}</strong><small>{data.candidate_count} 条参与本轮</small></div>
-      <div><span>最近判断</span><strong>{data.last_action || "尚未触发"}</strong><small>{shortTime(data.evaluated_at)}</small></div>
+      <div><span>最近计算</span><strong>{shortTime(data.evaluated_at)}</strong><small>{data.candidate_count} 条已计算</small></div>
+      <div><span>最近 LLM 判断</span><strong>{data.last_action || "尚未触发"}</strong><small>{shortTime(data.last_action_at)}</small></div>
     </Stack>
     <footer className="meter-footnote">
       <span>越线只代表允许唤醒 LLM 判断，不等于一定推送。</span>

--- a/plugins/wake_proactive/event_tools.py
+++ b/plugins/wake_proactive/event_tools.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+EVENT_TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "send_event",
+            "description": "发送根据本轮单条 alert 或 context 写成的自然主动消息。",
+            "parameters": {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "skip_event",
+            "description": "当前 ContextEvent 不值得单独打扰用户，保持安静。",
+            "parameters": {
+                "type": "object",
+                "properties": {"reason": {"type": "string"}},
+                "required": ["reason"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+
+@dataclass(frozen=True, slots=True)
+class EventToolResult:
+    decision: Literal["reply", "skip"]
+    message: str
+
+
+def execute_event_tool(name: str, arguments: dict[str, Any]) -> EventToolResult:
+    if name == "skip_event":
+        return EventToolResult(decision="skip", message="")
+    if name != "send_event":
+        raise ValueError(f"unknown wake event tool: {name}")
+    message = str(arguments.get("message") or "").strip()
+    if not message:
+        raise ValueError("send_event message 不能为空")
+    return EventToolResult(decision="reply", message=message)

--- a/plugins/wake_proactive/prompt.py
+++ b/plugins/wake_proactive/prompt.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Any, Literal
 
 from plugins.wake_proactive.context import WakeContext
+
+
+PromptMode = Literal["content", "alert", "context"]
+
+_SYSTEM_PROMPT = (
+    "你正在处理一次主动唤醒。运行时会明确给出 mode，并且只开放当前 mode 可用的工具。"
+    "不要在输出中提及记忆、画像、分数或筛选流程。长期记忆不只影响是否分享，也可以让表达"
+    "带有自然的理解和共情：可以顺着用户稳定的喜好、期待和经历说话，但不要列档案、逐句"
+    "复述旧对话，或用‘你之前说过’来证明自己记得。涉及焦虑、健康、财务或私密关系时，"
+    "只在与当前事实直接相关且能带来帮助时轻柔提及，不得放大情绪、替用户定义感受、做疾病"
+    "推断，或把敏感经历和脆弱经历当作吸引注意的钩子。关于用户此刻是否睡眠、忙碌、离线或在游戏，"
+    "只允许依据当前 ContextEvent；ContextEvent 为 unknown 时不得根据时间、历史习惯或语气"
+    "猜测当前状态，unknown 时保持中性。\n\n"
+    "mode=alert：只处理本轮给出的一条告警。忠实保留告警事实和不确定性，将结构化输入改写成"
+    "自然、克制、对用户有帮助的一条消息，然后调用 send_event；不得混入内容池中的其他资讯。\n"
+    "mode=context：只判断本轮给出的单条 ContextEvent 变化是否自然且值得主动告诉用户。值得时"
+    "调用 send_event，不值得时调用 skip_event；不得为了展示感知能力而打扰用户。\n"
+    "mode=content：候选按来源分组，来源内部按 published_at 倒序。先快速阅读全部标题，再调用"
+    "一次 scratchpad，只记录最多八条确实值得查正文或需要确认用户兴趣的候选。"
+    "likely_interesting 用于已有明确兴趣依据的内容；uncertain 用于需要 RecallMemory 确认的"
+    "内容。宁可少选，不要为了覆盖资讯而选择，也不要把预测当成用户反馈。"
+)
 
 
 def build_messages(
@@ -12,8 +35,37 @@ def build_messages(
     proactive_context: str,
     recent_session: str,
     current_context: str = "unknown（没有可靠 ContextEvent）",
+    mode: PromptMode = "content",
+    event: dict[str, Any] | None = None,
 ) -> list[dict[str, str]]:
-    lines: list[str] = []
+    """用稳定前缀渲染 content、alert 或 context 主动唤醒输入。"""
+
+    # 1. 渲染所有 mode 共用的用户上下文
+    sections = [
+        f"【固定 MEMORY.md】\n{memory_text}",
+        f"【固定 PROACTIVE_CONTEXT.md】\n{proactive_context}",
+        f"【截至当前时间的最近对话】\n{recent_session}",
+        f"【当前 ContextEvent】\n{current_context}",
+        f"【本轮任务】\nmode={mode}",
+    ]
+
+    # 2. 把变化最频繁的事件数据放在 prompt 尾部
+    if mode == "content":
+        sections.append(_render_content_window(ctx))
+    else:
+        if event is None:
+            raise ValueError(f"mode={mode} requires one event")
+        sections.append(
+            "【本轮单条事件】\n"
+            + json.dumps(event, ensure_ascii=False, sort_keys=True, default=str)
+        )
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": "\n\n".join(sections)},
+    ]
+
+
+def _render_content_window(ctx: WakeContext) -> str:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for event in ctx.content_events:
         source_id = str(
@@ -23,11 +75,11 @@ def build_messages(
             or "unknown"
         )
         grouped.setdefault(source_id, []).append(event)
+
+    lines: list[str] = []
     for source_id, events in grouped.items():
         source_name = str(
-            events[0].get("source_name")
-            or events[0].get("source")
-            or source_id
+            events[0].get("source_name") or events[0].get("source") or source_id
         )
         lines.append(f"来源：{source_name}")
         for event in sorted(
@@ -47,28 +99,7 @@ def build_messages(
                     )
                 )
             )
-
-    system = (
-        "你正在处理一次主动内容窗口。候选已经按来源分组，每个来源内部严格按 "
-        "published_at 倒序；预处理和唤醒分数不会提供给你。先结合 MEMORY、"
-        "PROACTIVE_CONTEXT 和最近对话快速阅读全部标题，再调用一次 scratchpad，"
-        "只记录最多八条确实值得查正文或需要确认用户兴趣的候选。"
-        "likely_interesting 用于已有明确兴趣依据的内容；uncertain 用于需要 RecallMemory "
-        "确认的内容。宁可少选，不要为了覆盖资讯而选择。不要把预测当成用户反馈，"
-        "不要在输出中提及记忆、画像、分数或筛选流程。长期记忆不只影响是否分享，"
-        "也可以让表达带有自然的理解和共情：可以顺着用户稳定的喜好、期待和经历说话，"
-        "但不要列档案、逐句复述旧对话，或用‘你之前说过’来证明自己记得。"
-        "涉及焦虑、健康、财务或私密关系时，只在与当前事实直接相关且能带来帮助时轻柔提及，"
-        "不得放大情绪、替用户定义感受或把脆弱经历当作吸引注意的钩子。"
-        "关于用户此刻是否睡眠、忙碌、离线或在游戏，只允许依据当前 ContextEvent；"
-        "ContextEvent 为 unknown 时不得根据时间、历史习惯或语气猜测当前状态。"
+    return (
+        f"【本次标题页：{len(ctx.content_events)} 条，窗口内未展示 "
+        f"{ctx.content_backlog_count} 条】\n" + "\n".join(lines)
     )
-    user = (
-        f"【固定 MEMORY.md】\n{memory_text}\n\n"
-        f"【固定 PROACTIVE_CONTEXT.md】\n{proactive_context}\n\n"
-        f"【截至当前时间的最近对话】\n{recent_session}\n\n"
-        f"【当前 ContextEvent】\n{current_context}\n\n"
-        f"【本次标题页：{len(ctx.content_events)} 条，窗口内未展示 {getattr(ctx, 'content_backlog_count', 0)} 条】\n"
-        + "\n".join(lines)
-    )
-    return [{"role": "system", "content": system}, {"role": "user", "content": user}]

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -10,7 +10,7 @@ from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable, cast
+from typing import Any, Awaitable, Callable, Literal, cast
 
 from agent.turns.result import TurnOutbound, TurnResult, TurnTrace
 from core.clock import Clock, ReplayClock, clock_from_env
@@ -18,6 +18,11 @@ from plugins.wake_proactive.context import WakeContext
 from plugins.wake_proactive.context_drive import ContextDriveResult, NormalizedContext
 from plugins.wake_proactive.drift_drive import DriftDriveResult, advance_drift_drive
 from plugins.wake_proactive.drift_prompt import build_drift_messages
+from plugins.wake_proactive.event_tools import (
+    EVENT_TOOL_SCHEMAS,
+    EventToolResult,
+    execute_event_tool,
+)
 from plugins.wake_proactive.hazard import (
     WAKE_ADMISSION_FLOOR,
     HazardResult,
@@ -39,7 +44,7 @@ _MAX_HAZARD_THRESHOLD = 2.0
 _SEMANTIC_CALIBRATION_POWER = 4
 _SCHEMA_BY_NAME = {
     schema["function"]["name"]: schema
-    for schema in TOOL_SCHEMAS
+    for schema in [*TOOL_SCHEMAS, *EVENT_TOOL_SCHEMAS]
 }
 
 
@@ -62,8 +67,10 @@ class WakeRunState:
     hazard_result: HazardResult | None = None
     context_results: list[ContextDriveResult] | None = None
     context_reevaluate: bool = False
+    context_event: dict[str, Any] | None = None
     drift_result: DriftDriveResult | None = None
     content_completed: bool = False
+    new_alert_count: int = 0
     new_content_count: int = 0
 
 
@@ -134,40 +141,100 @@ class WakeRuntime:
         )
 
     async def ingest(self, state: WakeRunState) -> None:
+        """拉取三类 source，持久化新事件并输出一条可读摘要。"""
+
+        # 1. 拉取所有 source，并刷新本轮运行状态
         await self._flush_pending_acknowledgements()
-        channels = await mcp_sources.fetch_sources_async(
-            self._scope.mcp_gateway,
-            self._scope.proactive_sources,
-        )
-        _ = self._state.ingest("alert", channels["alert"], state.ctx.now_utc)
-        state.new_content_count = self._state.ingest(
-            "content", channels["content"], state.ctx.now_utc
-        )
-        state.context_results = self._state.ingest_context(
-            channels["context"], state.ctx.now_utc
-        )
-        has_context_transition = any(
-            result.signal == "reevaluate" for result in state.context_results
-        )
-        state.context_reevaluate = (
-            self._state.claim_context_reevaluation(state.ctx.now_utc)
-            if has_context_transition
-            else False
-        )
-        state.alerts = self._state.unread("alert")
-        state.contents = self._state.unread("content")
+        channels = await self._fetch_source_channels()
+        self._ingest_source_channels(state, channels)
+        self._log_source_summary(state, channels)
+
+        # 2. Alert 不依赖内容向量；普通轮次再刷新内容兴趣
         if state.alerts:
             return
         await self._cache_event_embeddings()
         state.contents = self._state.unread("content")
         self._apply_semantic_interest(state.contents, state.ctx.now_utc)
 
+    async def _fetch_source_channels(self) -> dict[str, list[dict[str, Any]]]:
+        """拉取所有 source；全量失败时保留原始异常。"""
+
+        try:
+            return await mcp_sources.fetch_sources_async(
+                self._scope.mcp_gateway,
+                self._scope.proactive_sources,
+            )
+        except Exception:
+            logger.exception(
+                "[wake.source] poll failed sources=%d",
+                len(self._scope.proactive_sources),
+            )
+            raise
+
+    def _ingest_source_channels(
+        self,
+        state: WakeRunState,
+        channels: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        """持久化三类 source，并填充本轮单条事件状态。"""
+
+        state.new_alert_count = self._state.ingest(
+            "alert", channels["alert"], state.ctx.now_utc
+        )
+        state.new_content_count = self._state.ingest(
+            "content", channels["content"], state.ctx.now_utc
+        )
+        state.context_results = self._state.ingest_context(
+            channels["context"], state.ctx.now_utc
+        )
+        state.context_event = next(
+            (
+                snapshot
+                for snapshot, result in zip(
+                    channels["context"], state.context_results, strict=False
+                )
+                if result.signal == "reevaluate"
+            ),
+            None,
+        )
+        state.context_reevaluate = (
+            self._state.claim_context_reevaluation(state.ctx.now_utc)
+            if state.context_event is not None
+            else False
+        )
+        state.alerts = self._state.unread("alert")
+        state.contents = self._state.unread("content")
+
+    def _log_source_summary(
+        self,
+        state: WakeRunState,
+        channels: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        logger.info(
+            "[wake.source] poll ok received=alerts:%d,content:%d,context:%d "
+            "new=alerts:%d,content:%d unread=alerts:%d,content:%d "
+            "context_reevaluate=%s samples=%s",
+            len(channels["alert"]),
+            len(channels["content"]),
+            len(channels["context"]),
+            state.new_alert_count,
+            state.new_content_count,
+            len(state.alerts),
+            len(state.contents),
+            state.context_reevaluate,
+            _source_samples(channels),
+        )
+
     async def decide_content(self, state: WakeRunState) -> bool:
         if state.alerts:
-            await self._deliver_alert(state, state.alerts[0])
+            await self._decide_event(state, "alert", state.alerts[0])
             state.next_interval_seconds = (
                 1 if len(state.alerts) > 1 else self._tick_interval_seconds
             )
+            return True
+        if state.context_reevaluate and state.context_event is not None:
+            await self._decide_event(state, "context", state.context_event)
+            state.next_interval_seconds = self._tick_interval_seconds
             return True
         if state.contents:
             ranked = rank_events(state.contents, now=state.ctx.now_utc)
@@ -328,10 +395,14 @@ class WakeRuntime:
             self._tool_deps,
         )
         final_messages = [
+            base_messages[0],
             {
-                "role": "system",
+                "role": "user",
                 "content": (
-                    "标题初筛和并发调查已经完成。现在只做最终判断：调用 "
+                    f"{base_messages[1]['content']}\n\n"
+                    "【已执行的初筛与并发调查结果】\n"
+                    f"{investigation}\n\n"
+                    "【本轮最终任务】\n标题初筛和并发调查已经完成。现在只做最终判断：调用 "
                     "share_content 分享有正文证据且此刻值得告诉用户的内容，或调用 "
                     "skip_content 保持安静。通常分享一到三条；只有同时出现多个彼此独立、"
                     "都高度相关的重要变化时才可扩展到五条。不要重复标题。"
@@ -347,14 +418,6 @@ class WakeRuntime:
                     "只有当前 ContextEvent 明确支持时，才能描述用户正在睡眠、忙碌、"
                     "离线或游戏；unknown 时保持中性。唤醒只代表允许判断，不代表必须分享；"
                     "缺少新事实、用户已经知道、只有营销或泛泛观点时应调用 skip_content。"
-                ),
-            },
-            {
-                "role": "user",
-                "content": (
-                    f"{base_messages[1]['content']}\n\n"
-                    "【已执行的初筛与并发调查结果】\n"
-                    f"{investigation}\n\n请做最终判断。"
                 ),
             },
         ]
@@ -374,6 +437,18 @@ class WakeRuntime:
         allowed: set[str],
         forced_name: str | None,
     ) -> None:
+        call = await self._call_tool(messages, allowed, forced_name)
+        _ = await execute(call.name, call.arguments, ctx, self._tool_deps)
+
+    async def _call_tool(
+        self,
+        messages: list[dict[str, Any]],
+        allowed: set[str],
+        forced_name: str | None,
+    ) -> Any:
+        """调用一次带工具约束的 LLM，并返回经过校验的工具调用。"""
+
+        # 1. 为当前 mode 选择最小工具集合
         schemas = [_SCHEMA_BY_NAME[name] for name in sorted(allowed)]
         tool_choice: str | dict[str, Any] = "required"
         if forced_name is not None:
@@ -395,12 +470,14 @@ class WakeRuntime:
             except JSONDecodeError:
                 if attempt == 1:
                     raise
+
+        # 2. 拒绝缺失或越权的工具调用
         if not response.tool_calls:
             raise RuntimeError("wake proactive phase requires one tool call")
         call = response.tool_calls[0]
         if call.name not in allowed:
             raise RuntimeError(f"wake proactive unexpected tool in phase: {call.name}")
-        _ = await execute(call.name, call.arguments, ctx, self._tool_deps)
+        return call
 
     async def _commit_content_decision(self, state: WakeRunState) -> bool:
         events = list(state.contents)
@@ -553,24 +630,119 @@ class WakeRuntime:
         timestamped.sort(key=lambda item: (item[0], item[1], item[2]))
         return [item[3] for item in timestamped[-256:]]
 
-    async def _deliver_alert(
-        self, state: WakeRunState, alert: dict[str, Any]
+    async def _decide_event(
+        self,
+        state: WakeRunState,
+        kind: Literal["alert", "context"],
+        event: dict[str, Any],
     ) -> None:
-        title = str(alert.get("title") or "提醒").strip()
-        body = str(alert.get("content") or alert.get("body") or "").strip()
-        message = title if not body else f"{title}\n\n{body}"
-        item_id = str(alert["id"])
-        result = TurnResult(
-            decision="reply",
-            outbound=TurnOutbound(session_key=state.ctx.session_key, content=message),
-            evidence=[item_id],
-            trace=TurnTrace(source="proactive", extra={"source_refs": []}),
-            success_side_effects=[
-                AsyncEffect(lambda: self._ack_and_consume([alert], state.ctx.now_utc))
-            ],
+        """让 LLM 独立处理一条 alert 或 context，并提交发送结果。"""
+
+        # 1. 用统一 prompt 渲染单条事件并在调用前落审计
+        messages = self._build_event_messages(state, kind, event)
+        item_id = str(event.get("id") or event.get("event_id") or "")
+        self._record_event_observation(state, kind, event, item_id, messages)
+        logger.info(
+            "[wake.event] llm start kind=%s event_id=%s title=%r",
+            kind,
+            item_id,
+            str(event.get("title") or event.get("topic") or "")[:120],
         )
-        orchestrator = self._require_orchestrator()
-        await orchestrator.handle_proactive_turn(
+
+        # 2. Alert 必须自然化后发送；context 可以判断保持安静
+        allowed = {"send_event"} if kind == "alert" else {"send_event", "skip_event"}
+        call = await self._call_tool(
+            messages,
+            allowed,
+            "send_event" if kind == "alert" else None,
+        )
+        decision = execute_event_tool(call.name, call.arguments)
+        await self._commit_event_decision(state, kind, event, item_id, decision)
+        logger.info(
+            "[wake.event] llm done kind=%s event_id=%s decision=%s message=%r",
+            kind,
+            item_id,
+            decision.decision,
+            decision.message[:160],
+        )
+
+    def _build_event_messages(
+        self,
+        state: WakeRunState,
+        kind: Literal["alert", "context"],
+        event: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        return build_messages(
+            ctx=state.ctx,
+            memory_text=self._read_memory(),
+            proactive_context=str(self._scope.workspace_context_fn() or ""),
+            recent_session=self._read_recent_session(
+                state.ctx.session_key, state.ctx.now_utc
+            ),
+            current_context=self._current_context_text(state.ctx.now_utc),
+            mode=kind,
+            event=event,
+        )
+
+    def _record_event_observation(
+        self,
+        state: WakeRunState,
+        kind: Literal["alert", "context"],
+        event: dict[str, Any],
+        item_id: str,
+        messages: list[dict[str, str]],
+    ) -> None:
+        self._state.record_observation(
+            wake_id=state.ctx.wake_id,
+            session_key=state.ctx.session_key,
+            kind=kind,
+            now=state.ctx.now_utc,
+            trigger={"event_id": item_id, "source": _event_source(event)},
+            candidates=[event],
+            llm_input=messages,
+        )
+
+    async def _commit_event_decision(
+        self,
+        state: WakeRunState,
+        kind: Literal["alert", "context"],
+        event: dict[str, Any],
+        item_id: str,
+        decision: EventToolResult,
+    ) -> None:
+        """持久化单事件决策，并通过统一 orchestrator 提交副作用。"""
+
+        # 1. 保存 LLM 决策，供 Dashboard 与审计读取
+        state.ctx.terminal_action = decision.decision
+        state.ctx.final_message = decision.message
+        state.ctx.cited_item_ids = [item_id] if kind == "alert" and item_id else []
+        self._state.save(state.ctx)
+
+        # 2. 只在发送成功后消费 alert；context 不参与 reservoir ack
+        effects = (
+            [AsyncEffect(lambda: self._ack_and_consume([event], state.ctx.now_utc))]
+            if kind == "alert"
+            else []
+        )
+        result = TurnResult(
+            decision=decision.decision,
+            outbound=(
+                TurnOutbound(
+                    session_key=state.ctx.session_key,
+                    content=decision.message,
+                )
+                if decision.decision == "reply"
+                else None
+            ),
+            evidence=list(state.ctx.cited_item_ids),
+            trace=TurnTrace(
+                source="proactive",
+                extra={"source_refs": [], "event_kind": kind},
+            ),
+            side_effects=effects if decision.decision == "skip" else [],
+            success_side_effects=effects if decision.decision == "reply" else [],
+        )
+        await self._require_orchestrator().handle_proactive_turn(
             result=result,
             session_key=state.ctx.session_key,
             channel=str(getattr(self._scope.cfg, "default_channel", "")),
@@ -787,6 +959,34 @@ def _parse_optional_time(value: object) -> datetime | None:
     if value is None or not str(value).strip():
         return None
     return datetime.fromisoformat(str(value))
+
+
+def _source_samples(channels: dict[str, list[dict[str, Any]]]) -> str:
+    samples: list[str] = []
+    for kind in ("alert", "content", "context"):
+        for event in channels[kind]:
+            label = str(
+                event.get("title")
+                or event.get("topic")
+                or event.get("summary")
+                or event.get("event_id")
+                or ""
+            ).strip()
+            if label:
+                samples.append(f"{kind}:{label[:80]}")
+            if len(samples) == 3:
+                return repr(samples)
+    return repr(samples)
+
+
+def _event_source(event: dict[str, Any]) -> str:
+    return str(
+        event.get("_reservoir_original_source_id")
+        or event.get("source_id")
+        or event.get("source_name")
+        or event.get("_source")
+        or ""
+    )
 
 
 def _preprocess_interest(event: dict[str, Any]) -> float:

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -49,6 +49,11 @@ class FakeContextGateway:
         raise AssertionError(tool_name)
 
 
+class FailingGateway:
+    async def call(self, server, tool_name, args, *, timeout=None):
+        raise RuntimeError("source unavailable")
+
+
 class FlakyAckGateway(FakeGateway):
     def __init__(self, events: list[dict]) -> None:
         super().__init__(events)
@@ -424,6 +429,47 @@ async def test_shared_ack_route_keeps_original_source_grouping_and_order(
     assert gateway.acks == [{"event_ids": ["a-new", "a-old", "b-new"]}]
 
 
+@pytest.mark.parametrize("mode", ["content", "alert", "context"])
+def test_unified_prompt_always_exposes_current_context(mode) -> None:
+    ctx = WakeContext(
+        content_events=[
+            {
+                "id": "feed:item",
+                "title": "已有 content 标题",
+                "published_at": "2026-07-12T00:00:00+00:00",
+            }
+        ]
+    )
+    event = (
+        None
+        if mode == "content"
+        else {"event_id": "event-1", "summary": "本轮单条事件"}
+    )
+
+    messages = build_messages(
+        ctx=ctx,
+        memory_text="memory",
+        proactive_context="proactive context",
+        recent_session="recent session",
+        current_context="presence=active | confidence=0.90",
+        mode=cast(Any, mode),
+        event=event,
+    )
+
+    assert "【当前 ContextEvent】" in messages[1]["content"]
+    assert "presence=active | confidence=0.90" in messages[1]["content"]
+    assert f"mode={mode}" in messages[1]["content"]
+    assert all(
+        marker in messages[0]["content"]
+        for marker in ("mode=content", "mode=alert", "mode=context")
+    )
+    if mode == "content":
+        assert "已有 content 标题" in messages[1]["content"]
+        assert "scratchpad" in messages[0]["content"]
+    else:
+        assert "本轮单条事件" in messages[1]["content"]
+
+
 def test_legacy_reservoir_migrates_ack_and_original_sources(tmp_path) -> None:
     path = tmp_path / "legacy.db"
     connection = sqlite3.connect(path)
@@ -471,13 +517,28 @@ def test_legacy_reservoir_migrates_ack_and_original_sources(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_alerts_are_delivered_one_per_tick_without_feedback_label(tmp_path, request):
+async def test_alerts_are_naturalized_by_one_llm_call_per_tick(
+    tmp_path, request, caplog
+):
     events = [
         {"kind": "alert", "event_id": "a1", "title": "提醒一", "body": "内容一"},
         {"kind": "alert", "event_id": "a2", "title": "提醒二", "body": "内容二"},
     ]
     gateway = FakeGateway(events)
-    provider = SimpleNamespace(chat=AsyncMock())
+    provider = SimpleNamespace(
+        chat=AsyncMock(
+            return_value=LLMResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        "alert",
+                        "send_event",
+                        {"message": "这几天恢复状态有些往下走，今晚尽量早点休息。"},
+                    )
+                ],
+            )
+        )
+    )
     orchestrator = FakeOrchestrator()
     scope = _scope(tmp_path, gateway, provider, orchestrator, _source("alert"))
     scope.memory.embedding_api.embed_batch.side_effect = RuntimeError("embedding down")
@@ -490,16 +551,25 @@ async def test_alerts_are_delivered_one_per_tick_without_feedback_label(tmp_path
     frame = new_proactive_frame("telegram:1")
     state = runtime.begin(frame)
 
-    await runtime.ingest(state)
-    await runtime.decide(state)
+    with caplog.at_level("INFO", logger="plugins.wake_proactive.runtime"):
+        await runtime.ingest(state)
+        await runtime.decide(state)
 
     assert len(orchestrator.results) == 1
-    assert orchestrator.results[0].outbound.content in {"提醒一\n\n内容一", "提醒二\n\n内容二"}
+    assert orchestrator.results[0].outbound.content == "这几天恢复状态有些往下走，今晚尽量早点休息。"
+    assert provider.chat.await_count == 1
+    request_messages = provider.chat.await_args.kwargs["messages"]
+    assert "mode=alert" in request_messages[1]["content"]
+    assert any(title in request_messages[1]["content"] for title in ("提醒一", "提醒二"))
     assert state.next_interval_seconds == 1
     assert len(gateway.acks) == 1
     assert set(gateway.acks[0]) == {"event_ids"}
     assert len(runtime._state.unread("alert")) == 1
     assert scope.memory.embedding_api.embed_batch.await_count == 0
+    assert "[wake.source] poll ok" in caplog.text
+    assert "new=alerts:2,content:0" in caplog.text
+    assert "[wake.event] llm done kind=alert" in caplog.text
+    assert len(runtime._state.observations("alert")) == 1
 
 
 @pytest.mark.asyncio
@@ -517,7 +587,20 @@ async def test_ack_failure_does_not_repeat_delivered_alert_and_retries_next_tick
         _scope(
             tmp_path,
             gateway,
-            SimpleNamespace(chat=AsyncMock()),
+            SimpleNamespace(
+                chat=AsyncMock(
+                    return_value=LLMResponse(
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                "alert",
+                                "send_event",
+                                {"message": "这是一条只发送一次的自然提醒。"},
+                            )
+                        ],
+                    )
+                )
+            ),
             orchestrator,
             _source("alert"),
         ),
@@ -542,6 +625,57 @@ async def test_ack_failure_does_not_repeat_delivered_alert_and_retries_next_tick
     assert store.pending_acknowledgements() == {}
     assert store.unread("alert") == []
     assert len(orchestrator.results) == 1
+
+
+@pytest.mark.asyncio
+async def test_alert_llm_failure_keeps_event_unread_for_retry(tmp_path, request):
+    gateway = FakeGateway(
+        [{"kind": "alert", "event_id": "a1", "title": "需要自然处理"}]
+    )
+    orchestrator = FakeOrchestrator()
+    runtime = WakeRuntime(
+        _scope(
+            tmp_path,
+            gateway,
+            SimpleNamespace(chat=AsyncMock(side_effect=RuntimeError("llm down"))),
+            orchestrator,
+            _source("alert"),
+        ),
+        state_store=WakeStateStore(tmp_path / "wake.db"),
+        clock=FixedClock(datetime(2026, 7, 12, tzinfo=UTC)),
+    )
+    request.addfinalizer(runtime.close)
+    state = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(state)
+
+    with pytest.raises(RuntimeError, match="llm down"):
+        await runtime.decide(state)
+
+    assert len(runtime._state.unread("alert")) == 1
+    assert orchestrator.results == []
+    assert len(runtime._state.observations("alert")) == 1
+
+
+@pytest.mark.asyncio
+async def test_source_poll_failure_is_visible_in_main_log(tmp_path, request, caplog):
+    runtime = WakeRuntime(
+        _scope(
+            tmp_path,
+            FailingGateway(),
+            SimpleNamespace(chat=AsyncMock()),
+            FakeOrchestrator(),
+            _source("alert"),
+        ),
+        state_store=WakeStateStore(tmp_path / "wake.db"),
+        clock=FixedClock(datetime(2026, 7, 12, tzinfo=UTC)),
+    )
+    request.addfinalizer(runtime.close)
+
+    with caplog.at_level("INFO", logger="plugins.wake_proactive.runtime"):
+        with pytest.raises(RuntimeError, match="所有 proactive sources 拉取失败"):
+            await runtime.ingest(runtime.begin(new_proactive_frame("telegram:1")))
+
+    assert "[wake.source] poll failed sources=1" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -977,7 +1111,20 @@ async def test_context_snapshot_without_event_id_only_reevaluates_queued_content
             "expires_at": (now + timedelta(minutes=15)).isoformat(),
         }
     )
-    provider = SimpleNamespace(chat=AsyncMock())
+    provider = SimpleNamespace(
+        chat=AsyncMock(
+            return_value=LLMResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        "context",
+                        "skip_event",
+                        {"reason": "用户醒来本身不值得打扰"},
+                    )
+                ],
+            )
+        )
+    )
     orchestrator = FakeOrchestrator()
     store = WakeStateStore(tmp_path / "wake.db")
     scope = _scope(tmp_path, gateway, provider, orchestrator, _source("context"))
@@ -1026,13 +1173,15 @@ async def test_context_snapshot_without_event_id_only_reevaluates_queued_content
     await runtime.decide(second)
 
     assert second.context_reevaluate is True
-    assert second.hazard_result is not None
-    assert second.hazard_result.hazard_after > 0
+    assert second.hazard_result is None
     assert store.load_context("feed_plugin:main").presence == "active"
     assert "presence=active" in runtime._current_context_text(now)
     assert len(store.unread("content")) == 1
-    assert provider.chat.await_count == 0
-    assert orchestrator.results == []
+    assert provider.chat.await_count == 1
+    assert "mode=context" in provider.chat.await_args.kwargs["messages"][1]["content"]
+    assert len(orchestrator.results) == 1
+    assert orchestrator.results[0].decision == "skip"
+    assert len(store.observations("context")) == 1
 
     clock.advance(timedelta(hours=1))
     third = runtime.begin(new_proactive_frame("telegram:1"))
@@ -1042,10 +1191,64 @@ async def test_context_snapshot_without_event_id_only_reevaluates_queued_content
     assert third.context_reevaluate is False
     assert runtime._current_context_text(clock.now()).startswith("unknown")
     assert third.hazard_result is not None
-    assert third.hazard_result.hazard_after > second.hazard_result.hazard_after
+    assert third.hazard_result.hazard_after > 0
     assert len(store.unread("content")) == 1
-    assert provider.chat.await_count == 0
-    assert orchestrator.results == []
+    assert provider.chat.await_count == 1
+    assert len(orchestrator.results) == 1
+
+
+@pytest.mark.asyncio
+async def test_context_transition_can_be_shared_by_single_llm_call(tmp_path, request):
+    now = datetime(2026, 7, 12, 12, tzinfo=UTC)
+    gateway = FakeContextGateway(
+        {
+            "presence": "sleeping",
+            "confidence": 0.9,
+            "summary": "用户当前可能已经睡着",
+            "observed_at": now.isoformat(),
+            "expires_at": (now + timedelta(minutes=15)).isoformat(),
+        }
+    )
+    provider = SimpleNamespace(
+        chat=AsyncMock(
+            return_value=LLMResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        "context",
+                        "send_event",
+                        {"message": "醒啦？如果刚起来，先慢慢缓一会儿。"},
+                    )
+                ],
+            )
+        )
+    )
+    orchestrator = FakeOrchestrator()
+    runtime = WakeRuntime(
+        _scope(tmp_path, gateway, provider, orchestrator, _source("context")),
+        state_store=WakeStateStore(tmp_path / "wake.db"),
+        clock=FixedClock(now),
+    )
+    request.addfinalizer(runtime.close)
+
+    await runtime.ingest(runtime.begin(new_proactive_frame("telegram:1")))
+    gateway.snapshot = {
+        "presence": "active",
+        "confidence": 0.9,
+        "summary": "用户当前更可能醒着",
+        "transition": "sleeping->active",
+        "observed_at": now.isoformat(),
+        "expires_at": (now + timedelta(minutes=15)).isoformat(),
+    }
+    state = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(state)
+    await runtime.decide(state)
+
+    assert provider.chat.await_count == 1
+    prompt = provider.chat.await_args.kwargs["messages"][1]["content"]
+    assert "mode=context" in prompt
+    assert "用户当前更可能醒着" in prompt
+    assert orchestrator.results[0].outbound.content == "醒啦？如果刚起来，先慢慢缓一会儿。"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

Wake proactive 收到 alert 后直接拼接 `title + content` 发送，没有经过 LLM；context transition 也只更新调度状态，无法独立判断是否值得自然触达。与此同时，source 轮询缺少可读摘要，Dashboard 还把最近一次 LLM action 和最近一次 hazard 计算时间拼在一起展示，容易误判为运行停滞。

## 改动

- 为 content、alert、context 提供统一、缓存友好的稳定 prompt 前缀，动态事件放在 user 消息尾部。
- Alert 每个 tick 只取一条，强制调用 `send_event` 自然化后发送，不进入 content 蓄水池。
- Meaningful context transition 使用相同单事件链路，可调用 `send_event` 或 `skip_event`。
- LLM 或发送失败时不静默回退到原始告警；alert 保持 unread，等待后续重试。
- 主程序输出 source poll 成功/失败、三通道返回数、新增数、未读数、context 重评状态和最多三条样本。
- Alert/context 在 LLM 前写入 wake observation，最终决策写入 wake run。
- Dashboard 分开显示“最近计算”和“最近 LLM 判断”的真实时间。

## 验证

- `pytest tests/`：1487 passed
- `pytest -q tests/wake_proactive/test_runtime.py`：27 passed
- `pyright plugins/wake_proactive/runtime.py plugins/wake_proactive/prompt.py plugins/wake_proactive/event_tools.py tests/wake_proactive/test_runtime.py`
- `npm run typecheck`
- `npm run lint`：0 errors，保留主分支已有 3 warnings
- `npm run build`
- Docker debug profile `wake-event-alert-pr` 启动真实 `main.py`、真实 provider、真实 replay MCP 与 capture channel：
  - 注入 `recovery_debt` alert 后只调用一次 LLM，生成自然中文并发送一次。
  - replay ack 包含对应 event id，reservoir 状态为 consumed，下一 tick 不重复发送。
  - 注入 `sleeping -> active` context transition 后只调用一次 context LLM，模型选择 skip，outbox 未新增消息。
  - 日志完整展示 poll 摘要和 event LLM start/done。
