### PR TITLE
test(runtime): gate private cross-repository contracts

### DIFF
--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -63,7 +63,7 @@ async def fetch_sources_async(
     sources: list[RegisteredProactiveSource],
 ) -> dict[str, list[dict[str, Any]]]:
     results = await asyncio.gather(
-        *(_fetch_source_async(pool, source) for source in sources),
+        *(fetch_source_strict_async(pool, source) for source in sources),
         return_exceptions=True,
     )
     channels: dict[str, list[dict[str, Any]]] = {
@@ -87,10 +87,12 @@ async def fetch_sources_async(
     return channels
 
 
-async def _fetch_source_async(
+async def fetch_source_strict_async(
     pool: McpGateway,
     source: RegisteredProactiveSource,
 ) -> dict[str, list[dict[str, Any]]]:
+    """拉取并严格校验单个 source，保留原始失败。"""
+
     spec = source.spec
     key = source_key(source)
     result: dict[str, list[dict[str, Any]]] = {

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -184,7 +184,7 @@ async def test_fetch_source_rejects_corrupt_event_items(
     item = source("feed", "content", ("content",), "feed", "events")
 
     with pytest.raises(RuntimeError, match=error):
-        await mcp_sources._fetch_source_async(cast(Any, pool), item)
+        await mcp_sources.fetch_source_strict_async(cast(Any, pool), item)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

个人安装的外置插件不属于公开项目的默认运行集合。把 provider 清单、安装版本和 live 验收逻辑放进公开 CI，会让未使用这些插件的用户承担无关依赖，也会公开个人 runtime 结构。

## 改动

- 将跨仓库契约目录、验证记录、provider 测试和 live MCP 编排放入既有私有 `private_runtime` submodule。
- 公开仓库只更新私有 gitlink，不包含个人 provider 清单、验证记录或验收脚本。
- 将单 source 严格拉取函数公开给私有验收 runtime；原批量拉取的容错语义保持不变。

## 验证

- `pytest tests/`：1945 passed（相同公开代码改动）
- `pytest tests/test_mcp_sources_async.py`：10 passed
- 公开改动 Pyright：0 errors
- 私有 runtime 测试：7 passed
- 私有跨仓库组合审计：PASS 20
- 私有 provider 自测和真实只读 MCP 验收：全部通过
- 私有 runtime Pyright：0 errors
- `git diff --check`：通过

私有 submodule PR 应先于本 PR 合并。
