### PR TITLE
feat(runtime): add extensible Codex authentication

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -211,6 +211,18 @@ def load_config(path: str | Path = "config.toml") -> Config:
         reasoning_effort=str(llm_main.get("reasoning_effort") or ""),
         input_modalities=tuple(str(item) for item in llm_main.get("input_modalities", ["text"])),
         effective_context_percent=float(llm_main.get("effective_context_percent", 0.9)),
+        use_responses_lite=_as_bool(
+            llm_main.get("use_responses_lite", False),
+            field="llm.main.use_responses_lite",
+        ),
+        supports_parallel_tool_calls=_as_bool(
+            llm_main.get("supports_parallel_tool_calls", True),
+            field="llm.main.supports_parallel_tool_calls",
+        ),
+        reasoning_summary=_as_reasoning_summary(
+            llm_main.get("reasoning_summary"),
+            field="llm.main.reasoning_summary",
+        ),
         model_runtimes=model_runtimes,
         fast_runtime_id=fast_runtime_id,
         agent_runtime_id=agent_runtime_id,
@@ -449,6 +461,18 @@ def _load_llm_runtimes(
             max_output_tokens=int(item.get("max_output_tokens") or 8192),
             input_modalities=tuple(modalities),
             effective_context_percent=float(item.get("effective_context_percent", 0.9)),
+            use_responses_lite=_as_bool(
+                item.get("use_responses_lite", False),
+                field=f"llm.runtimes.{runtime_id}.use_responses_lite",
+            ),
+            supports_parallel_tool_calls=_as_bool(
+                item.get("supports_parallel_tool_calls", True),
+                field=f"llm.runtimes.{runtime_id}.supports_parallel_tool_calls",
+            ),
+            reasoning_summary=_as_reasoning_summary(
+                item.get("reasoning_summary"),
+                field=f"llm.runtimes.{runtime_id}.reasoning_summary",
+            ),
         )
     return main_value, raw_main, parsed
 
@@ -508,6 +532,13 @@ def _as_bool(value: object, *, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{field} 必须是布尔值")
     return value
+
+
+def _as_reasoning_summary(value: object, *, field: str) -> str:
+    summary = str(value or "none")
+    if summary not in {"none", "auto", "concise", "detailed"}:
+        raise ValueError(f"{field} 必须是 none、auto、concise 或 detailed")
+    return summary
 
 
 def _normalize_optional_config_text(value: str) -> str:

--- a/agent/config.py
+++ b/agent/config.py
@@ -19,6 +19,7 @@ from agent.config_models import (
     Config,
     MemoryConfig,
     MemoryEmbeddingConfig,
+    ModelRuntimeConfig,
     PeerAgentConfig,
     QQChannelConfig,
     QQGroupConfig,
@@ -28,6 +29,8 @@ from agent.config_models import (
 )
 from proactive_v2.config import ProactiveConfig
 from proactive_v2.config_loader import ProactiveConfigError, load_proactive_config
+from agent.model_runtime.auth import ApiKeyAuthDriver, CredentialStore
+from agent.model_runtime.registry import SUPPORTED_PROVIDER_PRESETS
 
 _PRESETS: dict[str, str] = {
     "qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
@@ -89,17 +92,19 @@ def load_config(path: str | Path = "config.toml") -> Config:
     data = _load_config_data(path)
 
     llm = _as_dict(data.get("llm"), field="llm")
-    llm_main = _as_dict(llm.get("main"), field="llm.main")
-    llm_fast = _as_dict(llm.get("fast"), field="llm.fast")
-    llm_agent = _as_dict(llm.get("agent"), field="llm.agent")
-    llm_vl = _as_dict(llm.get("vl"), field="llm.vl")
+    runtime_id, llm_main, model_runtimes = _load_llm_runtimes(llm)
+    fast_runtime_id, llm_fast = _load_role_runtime(llm, "fast", runtime_id)
+    agent_runtime_id, llm_agent = _load_role_runtime(llm, "agent", runtime_id)
+    vl_runtime_id, llm_vl = _load_role_runtime(llm, "vl", runtime_id)
     agent_cfg = _as_dict(data.get("agent"), field="agent")
     agent_context = _as_dict(agent_cfg.get("context"), field="agent.context")
     agent_tools = _as_dict(agent_cfg.get("tools"), field="agent.tools")
     agent_maintenance = _as_dict(
         agent_cfg.get("maintenance"), field="agent.maintenance"
     )
-    provider = str(llm.get("provider") or data["provider"])
+    provider = str(llm_main.get("provider") or llm.get("provider") or data.get("provider") or "")
+    if not provider:
+        raise ValueError("必须配置 llm provider")
     channels = _load_channels_config(data)
     proactive = _load_proactive_config(data)
     memory = _load_memory_config(data)
@@ -108,21 +113,39 @@ def load_config(path: str | Path = "config.toml") -> Config:
 
     return Config(
         provider=provider,
-        model=str(llm_main.get("model") or data["model"]),
-        api_key=_resolve(str(llm_main.get("api_key") or data.get("api_key", ""))),
+        model=str(llm_main.get("model") or data.get("model") or ""),
+        api_key=(
+            ""
+            if provider == "codex"
+            else _load_api_key(
+                auth_id=str(llm_main.get("auth") or ""),
+                inline_value=str(llm_main.get("api_key") or data.get("api_key", "")),
+            )
+        ),
         system_prompt=str(
             agent_cfg.get("system_prompt")
             or data.get("system_prompt", "You are a helpful assistant.")
         ),
-        max_tokens=int(agent_cfg.get("max_tokens", data.get("max_tokens", 8192))),
+        max_tokens=int(
+            llm_main.get(
+                "max_output_tokens",
+                agent_cfg.get("max_tokens", data.get("max_tokens", 8192)),
+            )
+        ),
         max_iterations=int(
             agent_cfg.get("max_iterations", data.get("max_iterations", 10))
         ),
         memory_window=int(
             agent_context.get("memory_window", data.get("memory_window", 40))
         ),
-        base_url=str(llm_main.get("base_url") or data.get("base_url") or _PRESETS.get(provider) or ""),
-        extra_body=_load_extra_body(data),
+        base_url=str(
+            llm_main.get("base_url")
+            or data.get("base_url")
+            or ("https://chatgpt.com/backend-api/codex" if provider == "codex" else "")
+            or _PRESETS.get(provider)
+            or ""
+        ),
+        extra_body=_load_extra_body(data, llm_main),
         channels=channels,
         proactive=proactive,
         memory_optimizer_enabled=_as_bool(
@@ -139,15 +162,17 @@ def load_config(path: str | Path = "config.toml") -> Config:
             )
         ),
         light_model=str(llm_fast.get("model") or data.get("light_model", "")),
-        light_api_key=_resolve(
-            str(llm_fast.get("api_key") or data.get("light_api_key", ""))
+        light_api_key=_load_api_key(
+            auth_id=str(llm_fast.get("auth") or ""),
+            inline_value=str(llm_fast.get("api_key") or data.get("light_api_key", "")),
         ),
         light_base_url=str(
             llm_fast.get("base_url") or data.get("light_base_url", "")
         ),
         agent_model=str(llm_agent.get("model") or data.get("agent_model", "")),
-        agent_api_key=_resolve(
-            str(llm_agent.get("api_key") or data.get("agent_api_key", ""))
+        agent_api_key=_load_api_key(
+            auth_id=str(llm_agent.get("auth") or ""),
+            inline_value=str(llm_agent.get("api_key") or data.get("agent_api_key", "")),
         ),
         agent_base_url=str(
             llm_agent.get("base_url") or data.get("agent_base_url", "")
@@ -171,14 +196,25 @@ def load_config(path: str | Path = "config.toml") -> Config:
             ),
             field="agent.dev_mode",
         ),
-        multimodal=_as_bool(
-            llm_main.get("multimodal", True), field="llm.main.multimodal"
-        ),
+        multimodal=_load_multimodal(llm_main),
         vl_model=str(llm_vl.get("model") or data.get("vl_model", "")),
-        vl_api_key=_resolve(str(llm_vl.get("api_key") or data.get("vl_api_key", ""))),
+        vl_api_key=_load_api_key(
+            auth_id=str(llm_vl.get("auth") or ""),
+            inline_value=str(llm_vl.get("api_key") or data.get("vl_api_key", "")),
+        ),
         vl_base_url=str(llm_vl.get("base_url") or data.get("vl_base_url", "")),
         peer_agents=peer_agents,
         wiring=wiring,
+        runtime_id=runtime_id,
+        auth_id=str(llm_main.get("auth") or ""),
+        context_window=int(llm_main.get("context_window") or 0),
+        reasoning_effort=str(llm_main.get("reasoning_effort") or ""),
+        input_modalities=tuple(str(item) for item in llm_main.get("input_modalities", ["text"])),
+        effective_context_percent=float(llm_main.get("effective_context_percent", 0.9)),
+        model_runtimes=model_runtimes,
+        fast_runtime_id=fast_runtime_id,
+        agent_runtime_id=agent_runtime_id,
+        vl_runtime_id=vl_runtime_id,
     )
 
 
@@ -290,9 +326,13 @@ def _load_memory_config(data: dict) -> MemoryConfig:
         engine=str(memory.get("engine", "") or ""),
         embedding=MemoryEmbeddingConfig(
             model=str(embedding.get("model", "text-embedding-v3")),
-            api_key=_resolve(str(embedding.get("api_key", ""))),
+            api_key=_load_api_key(
+                auth_id=str(embedding.get("auth") or ""),
+                inline_value=str(embedding.get("api_key", "")),
+            ),
             base_url=str(embedding.get("base_url", "")),
             output_dimensionality=output_dimensionality,
+            auth=str(embedding.get("auth") or ""),
         ),
     )
 
@@ -344,9 +384,10 @@ def _load_wiring_config(data: dict) -> WiringConfig:
     )
 
 
-def _load_extra_body(data: dict) -> dict:
+def _load_extra_body(data: dict, llm_main: dict | None = None) -> dict:
     llm = _as_dict(data.get("llm"), field="llm")
-    llm_main = _as_dict(llm.get("main"), field="llm.main")
+    if llm_main is None:
+        llm_main = _as_dict(llm.get("main"), field="llm.main")
     extra_body = dict(_as_dict(data.get("extra_body"), field="extra_body"))
     thinking = llm_main.get("thinking")
     if thinking is not None and not isinstance(thinking, dict):
@@ -362,6 +403,78 @@ def _load_extra_body(data: dict) -> dict:
         if effort:
             extra_body["reasoning_effort"] = effort
     return extra_body
+
+
+def _load_llm_runtimes(
+    llm: dict,
+) -> tuple[str, dict, dict[str, ModelRuntimeConfig]]:
+    """在配置边界把新版 runtime 与旧版 llm.main 统一。"""
+    main_value = llm.get("main")
+    if not isinstance(main_value, str):
+        return "main", _as_dict(main_value, field="llm.main"), {}
+    runtimes = _as_dict(llm.get("runtimes"), field="llm.runtimes")
+    raw_main = _as_dict(runtimes.get(main_value), field=f"llm.runtimes.{main_value}")
+    if not raw_main:
+        raise ValueError(f"llm.main 引用不存在的 runtime: {main_value}")
+    parsed: dict[str, ModelRuntimeConfig] = {}
+    for runtime_id, raw in runtimes.items():
+        item = _as_dict(raw, field=f"llm.runtimes.{runtime_id}")
+        modalities = item.get("input_modalities", ["text"])
+        if not isinstance(modalities, list) or not all(isinstance(v, str) for v in modalities):
+            raise ValueError(f"llm.runtimes.{runtime_id}.input_modalities 必须是字符串数组")
+        provider = str(item.get("provider") or "")
+        if provider.lower() not in SUPPORTED_PROVIDER_PRESETS:
+            supported = ", ".join(sorted(SUPPORTED_PROVIDER_PRESETS))
+            raise ValueError(
+                f"llm.runtimes.{runtime_id}.provider 不受支持: {provider!r}; "
+                f"可选值: {supported}"
+            )
+        auth_id = str(item.get("auth") or "")
+        parsed[runtime_id] = ModelRuntimeConfig(
+            runtime_id=runtime_id,
+            provider=provider,
+            model=str(item.get("model") or ""),
+            auth=auth_id,
+            api_key=(
+                ""
+                if provider == "codex"
+                else _load_api_key(
+                    auth_id=auth_id,
+                    inline_value=str(item.get("api_key") or ""),
+                )
+            ),
+            base_url=str(item.get("base_url") or ""),
+            reasoning_effort=str(item.get("reasoning_effort") or ""),
+            context_window=int(item.get("context_window") or 0),
+            max_output_tokens=int(item.get("max_output_tokens") or 8192),
+            input_modalities=tuple(modalities),
+            effective_context_percent=float(item.get("effective_context_percent", 0.9)),
+        )
+    return main_value, raw_main, parsed
+
+
+def _load_multimodal(llm_main: dict) -> bool:
+    modalities = llm_main.get("input_modalities")
+    if modalities is not None:
+        if not isinstance(modalities, list) or not all(isinstance(v, str) for v in modalities):
+            raise ValueError("llm.main.input_modalities 必须是字符串数组")
+        return "image" in modalities
+    return _as_bool(llm_main.get("multimodal", True), field="llm.main.multimodal")
+
+
+def _load_role_runtime(
+    llm: dict, role: str, main_runtime_id: str
+) -> tuple[str, dict]:
+    value = llm.get(role)
+    if not isinstance(value, str):
+        return "", _as_dict(value, field=f"llm.{role}")
+    if value == main_runtime_id:
+        return value, {}
+    runtimes = _as_dict(llm.get("runtimes"), field="llm.runtimes")
+    runtime = _as_dict(runtimes.get(value), field=f"llm.runtimes.{value}")
+    if not runtime:
+        raise ValueError(f"llm.{role} 引用不存在的 runtime: {value}")
+    return value, runtime
 
 
 def _as_dict(value: object, *, field: str) -> dict:
@@ -383,6 +496,12 @@ def _resolve(value: str) -> str:
         if key_file.exists():
             resolved = key_file.read_text(encoding="utf-8").strip()
     return resolved
+
+
+def _load_api_key(*, auth_id: str, inline_value: str) -> str:
+    if auth_id:
+        return ApiKeyAuthDriver(CredentialStore(), auth_id).api_key()
+    return _resolve(inline_value)
 
 
 def _as_bool(value: object, *, field: str) -> bool:

--- a/agent/config.py
+++ b/agent/config.py
@@ -30,6 +30,7 @@ from agent.config_models import (
 from proactive_v2.config import ProactiveConfig
 from proactive_v2.config_loader import ProactiveConfigError, load_proactive_config
 from agent.model_runtime.auth import ApiKeyAuthDriver, CredentialStore
+from agent.model_runtime.context_policy import recommended_memory_window
 from agent.model_runtime.registry import SUPPORTED_PROVIDER_PRESETS
 
 _PRESETS: dict[str, str] = {
@@ -135,9 +136,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         max_iterations=int(
             agent_cfg.get("max_iterations", data.get("max_iterations", 10))
         ),
-        memory_window=int(
-            agent_context.get("memory_window", data.get("memory_window", 40))
-        ),
+        memory_window=_load_memory_window(data, agent_context, llm_main),
         base_url=str(
             llm_main.get("base_url")
             or data.get("base_url")
@@ -220,7 +219,10 @@ def load_config(path: str | Path = "config.toml") -> Config:
             field="llm.main.supports_parallel_tool_calls",
         ),
         reasoning_summary=_as_reasoning_summary(
-            llm_main.get("reasoning_summary"),
+            llm_main.get(
+                "reasoning_summary",
+                "auto" if provider == "codex" else None,
+            ),
             field="llm.main.reasoning_summary",
         ),
         model_runtimes=model_runtimes,
@@ -458,6 +460,11 @@ def _load_llm_runtimes(
             base_url=str(item.get("base_url") or ""),
             reasoning_effort=str(item.get("reasoning_effort") or ""),
             context_window=int(item.get("context_window") or 0),
+            max_context_window=(
+                int(item["max_context_window"])
+                if item.get("max_context_window") is not None
+                else None
+            ),
             max_output_tokens=int(item.get("max_output_tokens") or 8192),
             input_modalities=tuple(modalities),
             effective_context_percent=float(item.get("effective_context_percent", 0.9)),
@@ -470,11 +477,30 @@ def _load_llm_runtimes(
                 field=f"llm.runtimes.{runtime_id}.supports_parallel_tool_calls",
             ),
             reasoning_summary=_as_reasoning_summary(
-                item.get("reasoning_summary"),
+                item.get(
+                    "reasoning_summary",
+                    "auto" if provider == "codex" else None,
+                ),
                 field=f"llm.runtimes.{runtime_id}.reasoning_summary",
             ),
         )
     return main_value, raw_main, parsed
+
+
+def _load_memory_window(data: dict, agent_context: dict, llm_main: dict) -> int:
+    """显式配置优先，否则根据主模型有效上下文推导历史窗口。"""
+
+    # 1. 保留现有配置的精确覆盖语义。
+    configured = agent_context.get("memory_window", data.get("memory_window"))
+    if configured is not None:
+        return int(configured)
+
+    # 2. 新 runtime 自动使用统一上下文策略；旧配置继续沿用 40。
+    context_window = int(llm_main.get("context_window") or 0)
+    if context_window <= 0:
+        return 40
+    effective_percent = float(llm_main.get("effective_context_percent", 0.9))
+    return recommended_memory_window(context_window, effective_percent)
 
 
 def _load_multimodal(llm_main: dict) -> bool:

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -97,6 +97,7 @@ class ModelRuntimeConfig:
     base_url: str = ""
     reasoning_effort: str = ""
     context_window: int = 0
+    max_context_window: int | None = None
     max_output_tokens: int = 8192
     input_modalities: tuple[str, ...] = ("text",)
     effective_context_percent: float = 0.9
@@ -111,6 +112,13 @@ class ModelRuntimeConfig:
             raise ValueError(f"Codex runtime {self.runtime_id} 必须配置 auth")
         if self.context_window <= 0:
             raise ValueError(f"runtime {self.runtime_id} 的 context_window 必须大于 0")
+        if (
+            self.max_context_window is not None
+            and self.max_context_window < self.context_window
+        ):
+            raise ValueError(
+                f"runtime {self.runtime_id} 的 max_context_window 不能小于 context_window"
+            )
         if self.max_output_tokens <= 0:
             raise ValueError(f"runtime {self.runtime_id} 的 max_output_tokens 必须大于 0")
         if "text" not in self.input_modalities:
@@ -118,6 +126,12 @@ class ModelRuntimeConfig:
         if not 0 < self.effective_context_percent <= 1:
             raise ValueError(
                 f"runtime {self.runtime_id} 的 effective_context_percent 必须在 (0, 1] 内"
+            )
+        if self.max_output_tokens >= int(
+            self.context_window * self.effective_context_percent
+        ):
+            raise ValueError(
+                f"runtime {self.runtime_id} 的 max_output_tokens 必须小于有效上下文"
             )
 
 

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -51,6 +51,7 @@ class MemoryEmbeddingConfig:
     api_key: str = ""
     base_url: str = ""
     output_dimensionality: int | None = None
+    auth: str = ""
 
 
 @dataclass
@@ -86,6 +87,37 @@ class WiringConfig:
     )
 
 
+@dataclass(frozen=True)
+class ModelRuntimeConfig:
+    runtime_id: str
+    provider: str
+    model: str
+    auth: str = ""
+    api_key: str = ""
+    base_url: str = ""
+    reasoning_effort: str = ""
+    context_window: int = 0
+    max_output_tokens: int = 8192
+    input_modalities: tuple[str, ...] = ("text",)
+    effective_context_percent: float = 0.9
+
+    def __post_init__(self) -> None:
+        if not self.provider or not self.model:
+            raise ValueError(f"runtime {self.runtime_id} 必须配置 provider 和 model")
+        if self.provider == "codex" and not self.auth:
+            raise ValueError(f"Codex runtime {self.runtime_id} 必须配置 auth")
+        if self.context_window <= 0:
+            raise ValueError(f"runtime {self.runtime_id} 的 context_window 必须大于 0")
+        if self.max_output_tokens <= 0:
+            raise ValueError(f"runtime {self.runtime_id} 的 max_output_tokens 必须大于 0")
+        if "text" not in self.input_modalities:
+            raise ValueError(f"runtime {self.runtime_id} 的 input_modalities 必须包含 text")
+        if not 0 < self.effective_context_percent <= 1:
+            raise ValueError(
+                f"runtime {self.runtime_id} 的 effective_context_percent 必须在 (0, 1] 内"
+            )
+
+
 @dataclass
 class Config:
     provider: str
@@ -117,6 +149,16 @@ class Config:
     dev_mode: bool = False
     peer_agents: list[PeerAgentConfig] = field(default_factory=list)
     wiring: WiringConfig = field(default_factory=WiringConfig)
+    runtime_id: str = "main"
+    auth_id: str = ""
+    context_window: int = 0
+    reasoning_effort: str = ""
+    input_modalities: tuple[str, ...] = ("text",)
+    effective_context_percent: float = 0.9
+    model_runtimes: dict[str, ModelRuntimeConfig] = field(default_factory=dict)
+    fast_runtime_id: str = ""
+    agent_runtime_id: str = ""
+    vl_runtime_id: str = ""
 
     @classmethod
     def load(cls, path: str | Path = "config.toml") -> Config:
@@ -130,6 +172,7 @@ __all__ = [
     "Config",
     "MemoryConfig",
     "MemoryEmbeddingConfig",
+    "ModelRuntimeConfig",
     "PeerAgentConfig",
     "QQChannelConfig",
     "QQGroupConfig",

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -100,6 +100,9 @@ class ModelRuntimeConfig:
     max_output_tokens: int = 8192
     input_modalities: tuple[str, ...] = ("text",)
     effective_context_percent: float = 0.9
+    use_responses_lite: bool = False
+    supports_parallel_tool_calls: bool = True
+    reasoning_summary: str = "none"
 
     def __post_init__(self) -> None:
         if not self.provider or not self.model:
@@ -155,6 +158,9 @@ class Config:
     reasoning_effort: str = ""
     input_modalities: tuple[str, ...] = ("text",)
     effective_context_percent: float = 0.9
+    use_responses_lite: bool = False
+    supports_parallel_tool_calls: bool = True
+    reasoning_summary: str = "none"
     model_runtimes: dict[str, ModelRuntimeConfig] = field(default_factory=dict)
     fast_runtime_id: str = ""
     agent_runtime_id: str = ""

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1811,7 +1811,11 @@ class DefaultReasoner(Reasoner):
                     "[空回复重试] 第%d轮，content为空但thinking非空，触发一次重试",
                     iteration + 1,
                 )
-                messages.append({"role": "assistant", "content": ""})
+                retry_assistant: dict[str, Any] = {"role": "assistant", "content": ""}
+                model_state = response.provider_fields.get("model_state")
+                if isinstance(model_state, dict):
+                    retry_assistant["model_state"] = model_state
+                messages.append(retry_assistant)
                 messages.append({
                     "role": "user",
                     "content": "你刚才只输出了思考过程，没有给出正式回复。请直接回复用户，不要重复思考。",

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1363,6 +1363,7 @@ class DefaultReasoner(Reasoner):
                 max_tokens=self._llm_config.max_tokens,
                 tool_choice="auto",
                 on_content_delta=on_content_delta,
+                cache_namespace=tool_event_session_key,
             )
             react_usages.append(response.usage or ModelUsage())
             if on_content_delta is not None and response.content:
@@ -1826,6 +1827,7 @@ class DefaultReasoner(Reasoner):
                     model=self._llm_config.model,
                     max_tokens=self._llm_config.max_tokens,
                     on_content_delta=on_content_delta,
+                    cache_namespace=tool_event_session_key,
                 )
                 react_usages.append(retry_response.usage or ModelUsage())
                 if retry_response.cache_prompt_tokens is not None:

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -17,6 +17,8 @@ from agent.core.types import (
     ReasonerResult,
 )
 from agent.prompting import DEFAULT_CONTEXT_TRIM_PLANS, is_context_frame
+from agent.model_runtime.types import ModelUsage
+from agent.model_runtime.usage import aggregate_usage
 from agent.provider import ContentSafetyError, ContextLengthError
 from agent.retrieval.protocol import RetrievalRequest, RetrievalResult
 from agent.tool_hooks import ToolExecutionRequest, ToolExecutionResult, ToolExecutor
@@ -1197,6 +1199,7 @@ class DefaultReasoner(Reasoner):
                 if isinstance(llm_context_frame, str) and llm_context_frame.strip():
                     retry_trace["llm_context_frame"] = llm_context_frame
                 retry_trace["react_stats"] = dict(result.metadata.get("react_stats") or {})
+                raw_model_state = result.metadata.get("model_state")
                 return TurnRunResult(
                     reply=result.reply,
                     tools_used=tools_used,
@@ -1205,6 +1208,11 @@ class DefaultReasoner(Reasoner):
                     thinking=result.thinking,
                     streamed=result.streamed,
                     context_retry=retry_trace,
+                    model_state=(
+                        cast(dict[str, object], raw_model_state)
+                        if isinstance(raw_model_state, dict)
+                        else None
+                    ),
                 )
             except ContentSafetyError:
                 if attempt < len(attempts) - 1:
@@ -1274,6 +1282,7 @@ class DefaultReasoner(Reasoner):
         react_cache_prompt_tokens = 0
         react_cache_hit_tokens = 0
         react_cache_seen = False
+        react_usages: list[ModelUsage] = []
         disabled = set(disabled_tools or set())
         before_step_phase, after_step_phase = self._runtime_step_phases()
         if self._tool_search_enabled:
@@ -1330,6 +1339,7 @@ class DefaultReasoner(Reasoner):
                     cache_hit_tokens=react_cache_hit_tokens,
                     cache_seen=react_cache_seen,
                     tools_unlocked=tools_unlocked,
+                    model_usages=react_usages,
                 )
             # 4. 调用 LLM，带上当前可见工具 schema。
             react_input_samples.append(step_ctx.input_tokens_estimate)
@@ -1354,6 +1364,7 @@ class DefaultReasoner(Reasoner):
                 tool_choice="auto",
                 on_content_delta=on_content_delta,
             )
+            react_usages.append(response.usage or ModelUsage())
             if on_content_delta is not None and response.content:
                 streamed = True
             if response.cache_prompt_tokens is not None:
@@ -1513,6 +1524,7 @@ class DefaultReasoner(Reasoner):
                                 cache_hit_tokens=react_cache_hit_tokens,
                                 cache_seen=react_cache_seen,
                                 tools_unlocked=tools_unlocked,
+                                model_usages=react_usages,
                             )
                         logger.warning(
                             "[工具未解锁] LLM 尝试调用 '%s'，但该工具 schema 不可见，引导模型先 tool_search",
@@ -1736,12 +1748,16 @@ class DefaultReasoner(Reasoner):
                             cache_hit_tokens=react_cache_hit_tokens,
                             cache_seen=react_cache_seen,
                             tools_unlocked=tools_unlocked,
+                            model_usages=react_usages,
                         )
 
                 # 7. 本轮工具执行完后，记录 tool_chain。
                 tool_chain_group = {"text": response.content, "calls": iter_calls}
                 if response.thinking is not None:
                     tool_chain_group["reasoning_content"] = response.thinking
+                model_state = response.provider_fields.get("model_state")
+                if isinstance(model_state, dict):
+                    tool_chain_group["model_state"] = model_state
                 tool_chain.append(tool_chain_group)
                 pressure_tokens = support.estimate_messages_tokens(messages)
                 # 7a. AfterStep 模块链（工具分支）：通知观察者本轮工具执行完毕。
@@ -1784,6 +1800,7 @@ class DefaultReasoner(Reasoner):
                         cache_hit_tokens=react_cache_hit_tokens,
                         cache_seen=react_cache_seen,
                         tools_unlocked=tools_unlocked,
+                        model_usages=react_usages,
                     )
                 continue
 
@@ -1806,6 +1823,7 @@ class DefaultReasoner(Reasoner):
                     max_tokens=self._llm_config.max_tokens,
                     on_content_delta=on_content_delta,
                 )
+                react_usages.append(retry_response.usage or ModelUsage())
                 if retry_response.cache_prompt_tokens is not None:
                     react_cache_seen = True
                     react_cache_prompt_tokens += retry_response.cache_prompt_tokens
@@ -1852,6 +1870,12 @@ class DefaultReasoner(Reasoner):
                 cache_hit_tokens=react_cache_hit_tokens,
                 cache_seen=react_cache_seen,
                 tools_unlocked=tools_unlocked,
+                model_usages=react_usages,
+                model_state=(
+                    cast(dict[str, object], response.provider_fields["model_state"])
+                    if isinstance(response.provider_fields.get("model_state"), dict)
+                    else None
+                ),
             )
 
         # 9. 达到最大迭代次数后，生成不完整进展总结。
@@ -1879,6 +1903,7 @@ class DefaultReasoner(Reasoner):
             cache_hit_tokens=react_cache_hit_tokens,
             cache_seen=react_cache_seen,
             tools_unlocked=tools_unlocked,
+            model_usages=react_usages,
         )
 
     async def _observe_tool_call_started(
@@ -1996,6 +2021,8 @@ class DefaultReasoner(Reasoner):
         cache_hit_tokens: int,
         cache_seen: bool,
         tools_unlocked: list[str] | None = None,
+        model_state: dict[str, object] | None = None,
+        model_usages: list[ModelUsage] | None = None,
     ) -> ReasonerResult:
         # 1. 先把 tool_chain 扁平化成 invocations。
         invocations: list[LLMToolCall] = []
@@ -2011,7 +2038,7 @@ class DefaultReasoner(Reasoner):
                 )
 
         # 2. 再把运行时元数据统一塞进 metadata。
-        react_stats = {
+        react_stats: dict[str, object] = {
             "iteration_count": len(react_input_samples),
             "turn_input_sum_tokens": sum(react_input_samples),
             "turn_input_peak_tokens": max(react_input_samples, default=0),
@@ -2031,6 +2058,16 @@ class DefaultReasoner(Reasoner):
                 cache_hit_tokens,
                 hit_rate * 100,
             )
+        usage = aggregate_usage(model_usages or [])
+        react_stats["model_usage"] = {
+            "input_tokens": usage.input_tokens,
+            "cached_input_tokens": usage.cached_input_tokens,
+            "output_tokens": usage.output_tokens,
+            "reasoning_output_tokens": usage.reasoning_output_tokens,
+            "request_count": usage.request_count,
+            "covered_request_count": usage.covered_request_count,
+            "coverage": usage.coverage.value,
+        }
         metadata = {
             "tools_used": list(tools_used),
             "tools_unlocked": list(tools_unlocked or []),
@@ -2038,6 +2075,7 @@ class DefaultReasoner(Reasoner):
             "media": list(media),
             "visible_names": set(visible_names) if visible_names is not None else None,
             "react_stats": react_stats,
+            "model_state": model_state,
         }
 
         # 3. 最后返回标准 ReasonerResult。

--- a/agent/core/runtime_support.py
+++ b/agent/core/runtime_support.py
@@ -181,6 +181,7 @@ class TurnRunResult:
     thinking: str | None = None
     streamed: bool = False
     context_retry: dict[str, object] = field(default_factory=dict[str, object])
+    model_state: dict[str, object] | None = None
 
 
 class AgentLoopRunner(Protocol):

--- a/agent/lifecycle/phases/after_reasoning.py
+++ b/agent/lifecycle/phases/after_reasoning.py
@@ -42,7 +42,7 @@ _PERSIST_USER_PREFIX = "persist:user:"
 _PERSIST_ASSISTANT_PREFIX = "persist:assistant:"
 _OUTBOUND_METADATA_PREFIX = "outbound:metadata:"
 _OUTBOUND_MEDIA_PREFIX = "outbound:media:"
-_ASSISTANT_FIXED_FIELDS = {"tools_used", "tool_chain", "reasoning_content"}
+_ASSISTANT_FIXED_FIELDS = {"tools_used", "tool_chain", "reasoning_content", "model_state"}
 _USER_FIXED_FIELDS = {"media"}
 
 
@@ -153,6 +153,8 @@ class _PersistAssistantMessageModule:
             assistant_kwargs["turn_duration_ms"] = turn_duration_ms
         if ctx.thinking is not None:
             assistant_kwargs["reasoning_content"] = ctx.thinking
+        if frame.input.turn_result.model_state is not None:
+            assistant_kwargs["model_state"] = frame.input.turn_result.model_state
         assistant_kwargs.update(_collect_persist_assistant_slots(frame.slots))
         if frame.input.state.persistence.persist_assistant:
             session.add_message(

--- a/agent/looping/ports.py
+++ b/agent/looping/ports.py
@@ -42,8 +42,7 @@ class MemoryConfig:
     @property
     def keep_count(self) -> int:
         """上下文携带条数，也是 consolidation 后 session 保留条数。"""
-        aligned_window = max(4, ((max(1, self.window) + 3) // 4) * 4)
-        return aligned_window // 2
+        return max(2, ((max(1, self.window) + 1) // 2) * 2)
 
 
 # ── 服务对象分组（仅放对象，不放配置参数）──────────────────────────────────────

--- a/agent/model_runtime/__init__.py
+++ b/agent/model_runtime/__init__.py
@@ -1,0 +1,23 @@
+"""提供与厂商无关的模型运行时协议。"""
+
+from .types import (
+    CapabilitySource,
+    ContinuationState,
+    LLMResponse,
+    ModelCapabilities,
+    ModelRequest,
+    ModelUsage,
+    ToolCall,
+    UsageCoverage,
+)
+
+__all__ = [
+    "CapabilitySource",
+    "ContinuationState",
+    "LLMResponse",
+    "ModelCapabilities",
+    "ModelRequest",
+    "ModelUsage",
+    "ToolCall",
+    "UsageCoverage",
+]

--- a/agent/model_runtime/auth/__init__.py
+++ b/agent/model_runtime/auth/__init__.py
@@ -1,0 +1,24 @@
+from .codex import CodexAuthDriver, DeviceCode
+from .store import Credential, CredentialStore
+
+
+class ApiKeyAuthDriver:
+    """从统一凭据存储取得 API key。"""
+
+    def __init__(self, store: CredentialStore, credential_id: str) -> None:
+        self.store = store
+        self.credential_id = credential_id
+
+    def api_key(self) -> str:
+        credential = self.store.get(self.credential_id)
+        if credential.driver != "api_key" or not credential.access_token:
+            raise ValueError(f"凭据 {self.credential_id} 不是有效 API key")
+        return credential.access_token
+
+__all__ = [
+    "ApiKeyAuthDriver",
+    "CodexAuthDriver",
+    "Credential",
+    "CredentialStore",
+    "DeviceCode",
+]

--- a/agent/model_runtime/auth/codex.py
+++ b/agent/model_runtime/auth/codex.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+import httpx
+
+from agent.model_runtime.errors import AuthenticationError, RateLimitError
+
+from .store import Credential, CredentialStore
+
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_AUTH_BASE = "https://auth.openai.com"
+CODEX_TOKEN_URL = f"{CODEX_AUTH_BASE}/oauth/token"
+CODEX_API_BASE = "https://chatgpt.com/backend-api/codex"
+_REFRESH_SKEW_SECONDS = 120
+
+
+@dataclass(frozen=True)
+class DeviceCode:
+    user_code: str
+    device_auth_id: str
+    verification_uri: str
+    interval: int
+
+
+class CodexAuthDriver:
+    """执行 Codex device-code 登录并提供可刷新的请求头。"""
+
+    def __init__(self, store: CredentialStore, credential_id: str) -> None:
+        self.store = store
+        self.credential_id = credential_id
+
+    def begin_device_login(self) -> DeviceCode:
+        response = httpx.post(
+            f"{CODEX_AUTH_BASE}/api/accounts/deviceauth/usercode",
+            json={"client_id": CODEX_CLIENT_ID},
+            timeout=15,
+        )
+        if response.status_code == 429:
+            raise RateLimitError("Codex 登录请求被限流，请稍后重试")
+        self._require_success(response, "获取 Codex device code 失败")
+        data = response.json()
+        try:
+            return DeviceCode(
+                user_code=str(data["user_code"]),
+                device_auth_id=str(data["device_auth_id"]),
+                verification_uri=f"{CODEX_AUTH_BASE}/codex/device",
+                interval=max(3, int(data.get("interval", 5))),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise AuthenticationError("Codex device code 响应结构无效") from exc
+
+    def complete_device_login(
+        self,
+        code: DeviceCode,
+        *,
+        timeout_seconds: int = 900,
+        on_wait: Callable[[], None] | None = None,
+    ) -> Credential:
+        """轮询授权结果、交换 token 并保存独立凭据。"""
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            time.sleep(code.interval)
+            if on_wait is not None:
+                on_wait()
+            response = httpx.post(
+                f"{CODEX_AUTH_BASE}/api/accounts/deviceauth/token",
+                json={"device_auth_id": code.device_auth_id, "user_code": code.user_code},
+                timeout=15,
+            )
+            if response.status_code in {403, 404}:
+                continue
+            self._require_success(response, "Codex 登录轮询失败")
+            credential = self._exchange_code(response.json())
+            self.store.put(self.credential_id, credential)
+            return credential
+        raise AuthenticationError("Codex 登录等待超时")
+
+    def headers(self, *, force_refresh: bool = False) -> dict[str, str]:
+        credential = self.store.get(self.credential_id)
+        if force_refresh or self._expires_soon(credential):
+            credential = self.refresh()
+        headers = {"Authorization": f"Bearer {credential.access_token}"}
+        if credential.account_id:
+            headers["ChatGPT-Account-ID"] = credential.account_id
+        return headers
+
+    def refresh(self) -> Credential:
+        """在跨进程锁内刷新并原子保存 rotation token。"""
+        with self.store.locked():
+            current = self.store.get(self.credential_id)
+            if not current.refresh_token:
+                raise AuthenticationError("Codex refresh token 缺失，请重新登录")
+            response = httpx.post(
+                CODEX_TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": current.refresh_token,
+                    "client_id": CODEX_CLIENT_ID,
+                },
+                timeout=20,
+            )
+            if response.status_code == 429:
+                raise RateLimitError("Codex token 刷新被限流")
+            self._require_success(response, "Codex token 刷新失败，请重新登录")
+            refreshed = self._credential_from_token(response.json(), current.account_id)
+            self.store.replace_locked(self.credential_id, refreshed)
+            return refreshed
+
+    def _exchange_code(self, data: dict) -> Credential:
+        try:
+            authorization_code = str(data["authorization_code"])
+            code_verifier = str(data["code_verifier"])
+        except (KeyError, TypeError) as exc:
+            raise AuthenticationError("Codex 授权响应结构无效") from exc
+        response = httpx.post(
+            CODEX_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": f"{CODEX_AUTH_BASE}/deviceauth/callback",
+                "client_id": CODEX_CLIENT_ID,
+                "code_verifier": code_verifier,
+            },
+            timeout=20,
+        )
+        self._require_success(response, "Codex token 交换失败")
+        return self._credential_from_token(response.json())
+
+    @staticmethod
+    def _credential_from_token(data: dict, account_id: str = "") -> Credential:
+        access_token = str(data.get("access_token") or "")
+        refresh_token = str(data.get("refresh_token") or "")
+        if not access_token or not refresh_token:
+            raise AuthenticationError("Codex token 响应缺少必要字段")
+        resolved_account_id = account_id
+        if not resolved_account_id:
+            id_token = str(data.get("id_token") or "")
+            if not id_token:
+                raise AuthenticationError("Codex token 响应缺少 id_token")
+            resolved_account_id = _account_id_from_jwt(id_token)
+        expires_in = int(data.get("expires_in") or 3600)
+        now = datetime.now(timezone.utc)
+        return Credential(
+            driver="codex",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            account_id=resolved_account_id,
+            expires_at=(now + timedelta(seconds=expires_in)).isoformat(),
+            updated_at=now.isoformat(),
+        )
+
+    @staticmethod
+    def _expires_soon(credential: Credential) -> bool:
+        if not credential.expires_at:
+            return True
+        expires = datetime.fromisoformat(credential.expires_at.replace("Z", "+00:00"))
+        return expires <= datetime.now(timezone.utc) + timedelta(seconds=_REFRESH_SKEW_SECONDS)
+
+    @staticmethod
+    def _require_success(response: httpx.Response, message: str) -> None:
+        if response.status_code < 400:
+            return
+        raise AuthenticationError(f"{message} (HTTP {response.status_code})")
+
+
+def _account_id_from_jwt(token: str) -> str:
+    """只解析账号路由声明，不验证已由 OAuth 端点签发的 token。"""
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (IndexError, ValueError, json.JSONDecodeError) as exc:
+        raise AuthenticationError("Codex access token 不是有效 JWT") from exc
+    auth_claims = claims.get("https://api.openai.com/auth", {})
+    account_id = auth_claims.get("chatgpt_account_id")
+    if not isinstance(account_id, str) or not account_id:
+        raise AuthenticationError("Codex token 缺少 chatgpt_account_id")
+    return account_id

--- a/agent/model_runtime/auth/codex.py
+++ b/agent/model_runtime/auth/codex.py
@@ -17,6 +17,7 @@ CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_AUTH_BASE = "https://auth.openai.com"
 CODEX_TOKEN_URL = f"{CODEX_AUTH_BASE}/oauth/token"
 CODEX_API_BASE = "https://chatgpt.com/backend-api/codex"
+CODEX_CLIENT_VERSION = "0.144.1"
 _REFRESH_SKEW_SECONDS = 120
 
 
@@ -83,6 +84,7 @@ class CodexAuthDriver:
 
     def headers(self, *, force_refresh: bool = False) -> dict[str, str]:
         credential = self.store.get(self.credential_id)
+        self._validate_credential(credential)
         if force_refresh or self._expires_soon(credential):
             credential = self.refresh()
         headers = {"Authorization": f"Bearer {credential.access_token}"}
@@ -108,7 +110,9 @@ class CodexAuthDriver:
             if response.status_code == 429:
                 raise RateLimitError("Codex token 刷新被限流")
             self._require_success(response, "Codex token 刷新失败，请重新登录")
-            refreshed = self._credential_from_token(response.json(), current.account_id)
+            refreshed = self._credential_from_token(
+                response.json(), fallback_account_id=current.account_id
+            )
             self.store.replace_locked(self.credential_id, refreshed)
             return refreshed
 
@@ -133,17 +137,20 @@ class CodexAuthDriver:
         return self._credential_from_token(response.json())
 
     @staticmethod
-    def _credential_from_token(data: dict, account_id: str = "") -> Credential:
+    def _credential_from_token(
+        data: dict, fallback_account_id: str = ""
+    ) -> Credential:
         access_token = str(data.get("access_token") or "")
         refresh_token = str(data.get("refresh_token") or "")
         if not access_token or not refresh_token:
             raise AuthenticationError("Codex token 响应缺少必要字段")
-        resolved_account_id = account_id
-        if not resolved_account_id:
-            id_token = str(data.get("id_token") or "")
-            if not id_token:
-                raise AuthenticationError("Codex token 响应缺少 id_token")
+        id_token = str(data.get("id_token") or "")
+        if id_token:
             resolved_account_id = _account_id_from_jwt(id_token)
+        elif fallback_account_id:
+            resolved_account_id = fallback_account_id
+        else:
+            raise AuthenticationError("Codex token 响应缺少 id_token")
         expires_in = int(data.get("expires_in") or 3600)
         now = datetime.now(timezone.utc)
         return Credential(
@@ -161,6 +168,13 @@ class CodexAuthDriver:
             return True
         expires = datetime.fromisoformat(credential.expires_at.replace("Z", "+00:00"))
         return expires <= datetime.now(timezone.utc) + timedelta(seconds=_REFRESH_SKEW_SECONDS)
+
+    @staticmethod
+    def _validate_credential(credential: Credential) -> None:
+        if credential.driver != "codex":
+            raise AuthenticationError("Codex auth 引用了非 Codex 凭据")
+        if not credential.access_token or not credential.account_id:
+            raise AuthenticationError("Codex 凭据缺少 access_token 或 account_id")
 
     @staticmethod
     def _require_success(response: httpx.Response, message: str) -> None:

--- a/agent/model_runtime/auth/codex.py
+++ b/agent/model_runtime/auth/codex.py
@@ -100,7 +100,7 @@ class CodexAuthDriver:
                 raise AuthenticationError("Codex refresh token 缺失，请重新登录")
             response = httpx.post(
                 CODEX_TOKEN_URL,
-                data={
+                json={
                     "grant_type": "refresh_token",
                     "refresh_token": current.refresh_token,
                     "client_id": CODEX_CLIENT_ID,
@@ -111,7 +111,9 @@ class CodexAuthDriver:
                 raise RateLimitError("Codex token 刷新被限流")
             self._require_success(response, "Codex token 刷新失败，请重新登录")
             refreshed = self._credential_from_token(
-                response.json(), fallback_account_id=current.account_id
+                response.json(),
+                fallback_account_id=current.account_id,
+                fallback_refresh_token=current.refresh_token,
             )
             self.store.replace_locked(self.credential_id, refreshed)
             return refreshed
@@ -138,10 +140,12 @@ class CodexAuthDriver:
 
     @staticmethod
     def _credential_from_token(
-        data: dict, fallback_account_id: str = ""
+        data: dict,
+        fallback_account_id: str = "",
+        fallback_refresh_token: str = "",
     ) -> Credential:
         access_token = str(data.get("access_token") or "")
-        refresh_token = str(data.get("refresh_token") or "")
+        refresh_token = str(data.get("refresh_token") or fallback_refresh_token)
         if not access_token or not refresh_token:
             raise AuthenticationError("Codex token 响应缺少必要字段")
         id_token = str(data.get("id_token") or "")

--- a/agent/model_runtime/auth/store.py
+++ b/agent/model_runtime/auth/store.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import shutil
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterator
+
+import fcntl
+
+from agent.model_runtime.errors import AuthenticationError
+
+
+@dataclass(frozen=True)
+class Credential:
+    driver: str
+    access_token: str
+    refresh_token: str = ""
+    account_id: str = ""
+    expires_at: str = ""
+    updated_at: str = ""
+
+
+class CredentialStore:
+    """安全地读取和原子更新用户凭据。"""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or Path.home() / ".akashic" / "auth.json"
+        self.lock_path = self.path.with_suffix(".lock")
+
+    def get(self, credential_id: str) -> Credential:
+        data = self._read_document()
+        raw = data["credentials"].get(credential_id)
+        if not isinstance(raw, dict):
+            raise AuthenticationError(f"凭据不存在: {credential_id}")
+        try:
+            return Credential(**raw)
+        except TypeError as exc:
+            raise AuthenticationError(f"凭据结构无效: {credential_id}") from exc
+
+    def put(self, credential_id: str, credential: Credential) -> None:
+        self.put_many({credential_id: credential})
+
+    def put_many(self, credentials: dict[str, Credential]) -> None:
+        """在一次锁和原子替换中保存一组凭据。"""
+        with self.locked():
+            data = self._read_document()
+            for credential_id, credential in credentials.items():
+                data["credentials"][credential_id] = asdict(credential)
+            self._write_document(data)
+
+    def replace_locked(self, credential_id: str, credential: Credential) -> None:
+        """调用方持有 store 锁时替换一条凭据。"""
+        data = self._read_document()
+        data["credentials"][credential_id] = asdict(credential)
+        self._write_document(data)
+
+    @contextmanager
+    def locked(self) -> Iterator[None]:
+        """持有跨进程独占锁，供刷新网络请求和持久化共同使用。"""
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.path.parent, 0o700)
+        lock_file = self.lock_path.open("a+", encoding="utf-8")
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+
+    def _read_document(self) -> dict:
+        if not self.path.exists():
+            return {"version": 1, "credentials": {}}
+        self._validate_permissions()
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise AuthenticationError(f"凭据文件 JSON 损坏: {self.path}") from exc
+        if (
+            not isinstance(raw, dict)
+            or raw.get("version") != 1
+            or not isinstance(raw.get("credentials"), dict)
+        ):
+            raise AuthenticationError(f"凭据文件结构或版本无效: {self.path}")
+        return raw
+
+    def _write_document(self, data: dict) -> None:
+        """fsync 后原子替换凭据文件。"""
+        fd, temp_name = tempfile.mkstemp(prefix="auth-", dir=self.path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temp_name, 0o600)
+            if self.path.exists():
+                shutil.copy2(self.path, self.path.with_name("auth.json.before-write.bak"))
+            os.replace(temp_name, self.path)
+            os.chmod(self.path, 0o600)
+        finally:
+            if os.path.exists(temp_name):
+                os.unlink(temp_name)
+
+    def _validate_permissions(self) -> None:
+        parent_mode = self.path.parent.stat().st_mode & 0o777
+        file_mode = self.path.stat().st_mode & 0o777
+        if parent_mode & 0o077:
+            raise AuthenticationError("auth.json 父目录权限过宽，必须为 0700")
+        if file_mode & 0o077:
+            raise AuthenticationError("auth.json 权限过宽，必须为 0600")

--- a/agent/model_runtime/catalog/__init__.py
+++ b/agent/model_runtime/catalog/__init__.py
@@ -1,0 +1,3 @@
+from .codex import CodexModel, CodexModelCatalog
+
+__all__ = ["CodexModel", "CodexModelCatalog"]

--- a/agent/model_runtime/catalog/codex.py
+++ b/agent/model_runtime/catalog/codex.py
@@ -27,7 +27,7 @@ class CodexModelCatalog:
         auth: CodexAuthDriver,
         *,
         base_url: str = CODEX_API_BASE,
-        client_version: str = "0.1.0",
+        client_version: str = "0.0.0",
     ) -> None:
         self.auth = auth
         self.base_url = base_url.rstrip("/")

--- a/agent/model_runtime/catalog/codex.py
+++ b/agent/model_runtime/catalog/codex.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from agent.model_runtime.auth.codex import CODEX_API_BASE, CodexAuthDriver
+from agent.model_runtime.errors import AuthenticationError, TransportError
+from agent.model_runtime.types import CapabilitySource, ModelCapabilities
+
+
+@dataclass(frozen=True)
+class CodexModel:
+    slug: str
+    display_name: str
+    description: str
+    capabilities: ModelCapabilities
+    input_modalities_known: bool
+
+
+class CodexModelCatalog:
+    """从 Codex `/models` 边界加载并校验模型元数据。"""
+
+    def __init__(
+        self,
+        auth: CodexAuthDriver,
+        *,
+        base_url: str = CODEX_API_BASE,
+        client_version: str = "0.1.0",
+    ) -> None:
+        self.auth = auth
+        self.base_url = base_url.rstrip("/")
+        self.client_version = client_version
+
+    async def list_models(self) -> list[CodexModel]:
+        headers = self.auth.headers()
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.get(
+                f"{self.base_url}/models",
+                params={"client_version": self.client_version},
+                headers=headers,
+            )
+        if response.status_code == 401:
+            headers = self.auth.headers(force_refresh=True)
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(
+                    f"{self.base_url}/models",
+                    params={"client_version": self.client_version},
+                    headers=headers,
+                )
+        if response.status_code in {401, 403}:
+            raise AuthenticationError("Codex 模型目录认证失败，请重新登录")
+        if response.status_code >= 400:
+            raise TransportError(f"Codex 模型目录请求失败 (HTTP {response.status_code})")
+        payload = response.json()
+        raw_models = payload.get("models")
+        if not isinstance(raw_models, list):
+            raise TransportError("Codex 模型目录响应缺少 models 数组")
+        return [self._parse_model(item) for item in raw_models]
+
+    @staticmethod
+    def _parse_model(raw: Any) -> CodexModel:
+        if not isinstance(raw, dict) or not isinstance(raw.get("slug"), str):
+            raise TransportError("Codex 模型目录包含无效模型项")
+        context_window = raw.get("context_window") or raw.get("max_context_window")
+        if not isinstance(context_window, int) or context_window <= 0:
+            raise TransportError(f"模型 {raw['slug']} 缺少有效 context_window")
+        modalities = raw.get("input_modalities")
+        modalities_known = isinstance(modalities, list)
+        parsed_modalities = (
+            tuple(str(item) for item in modalities)
+            if isinstance(modalities, list)
+            else ("text",)
+        )
+        efforts = raw.get("supported_reasoning_levels") or []
+        effort_names = tuple(
+            str(item.get("effort"))
+            for item in efforts
+            if isinstance(item, dict) and item.get("effort")
+        )
+        percent = int(raw.get("effective_context_window_percent", 90)) / 100
+        capabilities = ModelCapabilities(
+            context_window=context_window,
+            max_output_tokens=min(32768, context_window // 4),
+            effective_context_percent=percent,
+            supported_reasoning_efforts=effort_names,
+            default_reasoning_effort=raw.get("default_reasoning_level"),
+            input_modalities=parsed_modalities,
+            supports_image_original_detail=bool(raw.get("supports_image_detail_original")),
+            supports_parallel_tool_calls=bool(raw.get("supports_parallel_tool_calls")),
+            supports_prompt_cache=True,
+            continuation_mode="responses_items",
+            source=CapabilitySource.CATALOG,
+        )
+        return CodexModel(
+            slug=raw["slug"],
+            display_name=str(raw.get("display_name") or raw["slug"]),
+            description=str(raw.get("description") or ""),
+            capabilities=capabilities,
+            input_modalities_known=modalities_known,
+        )

--- a/agent/model_runtime/catalog/codex.py
+++ b/agent/model_runtime/catalog/codex.py
@@ -11,6 +11,7 @@ from agent.model_runtime.auth.codex import (
     CodexAuthDriver,
 )
 from agent.model_runtime.errors import AuthenticationError, TransportError
+from agent.model_runtime.context_policy import recommended_output_reserve
 from agent.model_runtime.types import CapabilitySource, ModelCapabilities
 
 
@@ -76,6 +77,12 @@ class CodexModelCatalog:
         context_window = raw.get("context_window") or raw.get("max_context_window")
         if not isinstance(context_window, int) or context_window <= 0:
             raise TransportError(f"模型 {raw['slug']} 缺少有效 context_window")
+        max_context_window = raw.get("max_context_window") or context_window
+        if (
+            not isinstance(max_context_window, int)
+            or max_context_window < context_window
+        ):
+            raise TransportError(f"模型 {raw['slug']} 的 max_context_window 无效")
         modalities = raw.get("input_modalities")
         modalities_known = isinstance(modalities, list)
         parsed_modalities = (
@@ -92,14 +99,20 @@ class CodexModelCatalog:
         percent = int(raw.get("effective_context_window_percent", 90)) / 100
         capabilities = ModelCapabilities(
             context_window=context_window,
-            max_output_tokens=min(32768, context_window // 4),
+            max_output_tokens=recommended_output_reserve(max_context_window, percent),
+            max_context_window=max_context_window,
             effective_context_percent=percent,
             supported_reasoning_efforts=effort_names,
             default_reasoning_effort=raw.get("default_reasoning_level"),
             input_modalities=parsed_modalities,
             supports_image_original_detail=bool(raw.get("supports_image_detail_original")),
             supports_parallel_tool_calls=bool(raw.get("supports_parallel_tool_calls")),
-            supports_reasoning_summaries=bool(raw.get("supports_reasoning_summaries")),
+            supports_reasoning_summaries=bool(
+                raw.get(
+                    "supports_reasoning_summary_parameter",
+                    raw.get("supports_reasoning_summaries", False),
+                )
+            ),
             default_reasoning_summary=str(raw.get("default_reasoning_summary") or "none"),
             supports_prompt_cache=True,
             use_responses_lite=bool(raw.get("use_responses_lite")),

--- a/agent/model_runtime/catalog/codex.py
+++ b/agent/model_runtime/catalog/codex.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import httpx
 
-from agent.model_runtime.auth.codex import CODEX_API_BASE, CodexAuthDriver
+from agent.model_runtime.auth.codex import (
+    CODEX_API_BASE,
+    CODEX_CLIENT_VERSION,
+    CodexAuthDriver,
+)
 from agent.model_runtime.errors import AuthenticationError, TransportError
 from agent.model_runtime.types import CapabilitySource, ModelCapabilities
 
@@ -27,7 +31,7 @@ class CodexModelCatalog:
         auth: CodexAuthDriver,
         *,
         base_url: str = CODEX_API_BASE,
-        client_version: str = "0.0.0",
+        client_version: str = CODEX_CLIENT_VERSION,
     ) -> None:
         self.auth = auth
         self.base_url = base_url.rstrip("/")
@@ -57,7 +61,13 @@ class CodexModelCatalog:
         raw_models = payload.get("models")
         if not isinstance(raw_models, list):
             raise TransportError("Codex 模型目录响应缺少 models 数组")
-        return [self._parse_model(item) for item in raw_models]
+        parsed_models = [self._parse_model(item) for item in raw_models]
+        return [
+            model
+            for raw, model in zip(raw_models, parsed_models, strict=True)
+            if raw.get("visibility", "list") == "list"
+            and raw.get("supported_in_api", True) is not False
+        ]
 
     @staticmethod
     def _parse_model(raw: Any) -> CodexModel:
@@ -89,7 +99,10 @@ class CodexModelCatalog:
             input_modalities=parsed_modalities,
             supports_image_original_detail=bool(raw.get("supports_image_detail_original")),
             supports_parallel_tool_calls=bool(raw.get("supports_parallel_tool_calls")),
+            supports_reasoning_summaries=bool(raw.get("supports_reasoning_summaries")),
+            default_reasoning_summary=str(raw.get("default_reasoning_summary") or "none"),
             supports_prompt_cache=True,
+            use_responses_lite=bool(raw.get("use_responses_lite")),
             continuation_mode="responses_items",
             source=CapabilitySource.CATALOG,
         )

--- a/agent/model_runtime/context_policy.py
+++ b/agent/model_runtime/context_policy.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+
+from .types import ModelCapabilities
+
+
+def recommended_memory_window(context_window: int) -> int:
+    """根据模型上下文给出有界的历史消息建议值。"""
+    if context_window <= 0:
+        raise ValueError("context_window 必须大于 0")
+    return max(20, min(160, round(context_window / 1600)))
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    effective_context: int
+    input_budget: int
+    reserved_output: int
+
+
+class ApproximateTokenEstimator:
+    quality = "approximate"
+
+    def estimate_messages(self, messages: list[dict]) -> int:
+        payload = json.dumps(messages, ensure_ascii=False, separators=(",", ":"))
+        return max(1, len(payload) // 3)
+
+
+def build_context_budget(capabilities: ModelCapabilities, max_output_tokens: int) -> ContextBudget:
+    """预留输出容量并计算本次请求的输入预算。"""
+    output = min(max_output_tokens, capabilities.max_output_tokens)
+    effective = math.floor(
+        capabilities.context_window * capabilities.effective_context_percent
+    )
+    if output >= effective:
+        raise ValueError("max_output_tokens 必须小于有效上下文")
+    return ContextBudget(effective, effective - output, output)

--- a/agent/model_runtime/context_policy.py
+++ b/agent/model_runtime/context_policy.py
@@ -7,11 +7,80 @@ from dataclasses import dataclass
 from .types import ModelCapabilities
 
 
-def recommended_memory_window(context_window: int) -> int:
-    """根据模型上下文给出有界的历史消息建议值。"""
+_REFERENCE_CONTEXT_WINDOW = 1_000_000
+_REFERENCE_EFFECTIVE_CONTEXT_PERCENT = 0.9
+_REFERENCE_MEMORY_WINDOW = 640
+_REFERENCE_OUTPUT_RESERVE = 32_768
+_MIN_MEMORY_WINDOW = 20
+_MIN_OUTPUT_RESERVE = 4_096
+
+
+@dataclass(frozen=True)
+class ContextWindowSettings:
+    memory_window: int
+    output_reserve: int
+
+
+def recommended_context_settings(
+    context_window: int,
+    effective_context_percent: float = _REFERENCE_EFFECTIVE_CONTEXT_PERCENT,
+) -> ContextWindowSettings:
+    """按 1M 基准等比例计算历史窗口与输出预留。"""
+
+    # 1. 在配置边界拒绝无效模型容量。
     if context_window <= 0:
         raise ValueError("context_window 必须大于 0")
-    return max(20, min(160, round(context_window / 1600)))
+    if not 0 < effective_context_percent <= 1:
+        raise ValueError("effective_context_percent 必须在 (0, 1] 内")
+
+    effective_context = context_window * effective_context_percent
+    reference_effective_context = (
+        _REFERENCE_CONTEXT_WINDOW * _REFERENCE_EFFECTIVE_CONTEXT_PERCENT
+    )
+
+    # 2. 历史条数按四条对齐，避免不同上下文档位产生细碎配置。
+    scaled_memory = round(
+        effective_context * _REFERENCE_MEMORY_WINDOW / reference_effective_context
+    )
+    memory_window = max(_MIN_MEMORY_WINDOW, _align_nearest(scaled_memory, 4))
+
+    # 3. 输出预留按 1024 tokens 向下对齐，且不超过 1M 基准值。
+    scaled_output = int(
+        effective_context * _REFERENCE_OUTPUT_RESERVE / reference_effective_context
+    )
+    output_reserve = max(
+        _MIN_OUTPUT_RESERVE,
+        min(_REFERENCE_OUTPUT_RESERVE, _align_down(scaled_output, 1024)),
+    )
+    return ContextWindowSettings(memory_window, output_reserve)
+
+
+def recommended_memory_window(
+    context_window: int,
+    effective_context_percent: float = _REFERENCE_EFFECTIVE_CONTEXT_PERCENT,
+) -> int:
+    """根据模型上下文返回历史消息建议值。"""
+    return recommended_context_settings(
+        context_window, effective_context_percent
+    ).memory_window
+
+
+def recommended_output_reserve(
+    context_window: int,
+    effective_context_percent: float = _REFERENCE_EFFECTIVE_CONTEXT_PERCENT,
+) -> int:
+    """根据模型上下文返回本地输出预留建议值。"""
+    return recommended_context_settings(
+        context_window, effective_context_percent
+    ).output_reserve
+
+
+def _align_nearest(value: int, step: int) -> int:
+    return ((value + step // 2) // step) * step
+
+
+def _align_down(value: int, step: int) -> int:
+    return value // step * step
 
 
 @dataclass(frozen=True)
@@ -32,9 +101,21 @@ class ApproximateTokenEstimator:
 def build_context_budget(capabilities: ModelCapabilities, max_output_tokens: int) -> ContextBudget:
     """预留输出容量并计算本次请求的输入预算。"""
     output = min(max_output_tokens, capabilities.max_output_tokens)
-    effective = math.floor(
-        capabilities.context_window * capabilities.effective_context_percent
+    return build_runtime_context_budget(
+        capabilities.context_window,
+        capabilities.effective_context_percent,
+        output,
     )
+
+
+def build_runtime_context_budget(
+    context_window: int,
+    effective_context_percent: float,
+    max_output_tokens: int,
+) -> ContextBudget:
+    """按 runtime 实际配置计算统一输入预算。"""
+    effective = math.floor(context_window * effective_context_percent)
+    output = max_output_tokens
     if output >= effective:
         raise ValueError("max_output_tokens 必须小于有效上下文")
     return ContextBudget(effective, effective - output, output)

--- a/agent/model_runtime/errors.py
+++ b/agent/model_runtime/errors.py
@@ -1,0 +1,26 @@
+class ModelRuntimeError(Exception):
+    """模型运行时可归类错误的基类。"""
+
+
+class AuthenticationError(ModelRuntimeError):
+    """认证缺失、过期或刷新失败。"""
+
+
+class RateLimitError(ModelRuntimeError):
+    """服务端限流。"""
+
+
+class QuotaError(ModelRuntimeError):
+    """账号额度耗尽。"""
+
+
+class UnsupportedCapabilityError(ModelRuntimeError):
+    """请求使用了模型不支持的能力。"""
+
+
+class TransportError(ModelRuntimeError):
+    """请求或响应协议错误。"""
+
+
+class ContextWindowError(ModelRuntimeError):
+    """模型服务拒绝超出上下文窗口的请求。"""

--- a/agent/model_runtime/fallback.py
+++ b/agent/model_runtime/fallback.py
@@ -65,6 +65,7 @@ class ResilientLightProvider(LLMProvider):
         extra_body: dict | None = None,
         disable_thinking: bool = False,
         on_content_delta: Callable[[StreamDelta], Awaitable[None]] | None = None,
+        cache_namespace: str = "",
     ) -> LLMResponse:
         """先调用轻量模型；未输出 delta 的可恢复故障才切换主模型。"""
 
@@ -90,6 +91,7 @@ class ResilientLightProvider(LLMProvider):
                 extra_body=extra_body,
                 disable_thinking=disable_thinking,
                 on_content_delta=callback,
+                cache_namespace=cache_namespace,
             )
         except _RUNTIME_FAILURE_TYPES as exc:
             if emitted or not _is_recoverable_runtime_error(exc):
@@ -113,6 +115,7 @@ class ResilientLightProvider(LLMProvider):
                 extra_body=extra_body,
                 disable_thinking=disable_thinking,
                 on_content_delta=on_content_delta,
+                cache_namespace=cache_namespace,
             )
 
 
@@ -156,7 +159,16 @@ def _is_connection_transport_error(exc: TransportError) -> bool:
     ):
         return True
     text = str(exc).lower()
-    return any(marker in text for marker in ("连接失败", "connection", "timeout", "超时"))
+    return any(
+        marker in text
+        for marker in (
+            "连接失败",
+            "connection",
+            "timeout",
+            "超时",
+            "暂时失败",
+        )
+    )
 
 
 def _looks_like_quota_error(exc: BaseException) -> bool:

--- a/agent/model_runtime/fallback.py
+++ b/agent/model_runtime/fallback.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+import httpx
+import openai
+
+from agent.model_runtime.errors import RateLimitError, TransportError
+from agent.provider import LLMProvider, LLMResponse, StreamDelta
+
+logger = logging.getLogger("agent.model_runtime.fallback")
+
+
+def _openai_error_types(*names: str) -> tuple[type[BaseException], ...]:
+    return tuple(
+        error_type
+        for name in names
+        if isinstance((error_type := getattr(openai, name, None)), type)
+        and issubclass(error_type, BaseException)
+    )
+
+
+_OPENAI_CONNECTION_ERROR_TYPES = _openai_error_types(
+    "APIConnectionError",
+    "APITimeoutError",
+)
+_OPENAI_STATUS_ERROR_TYPES = _openai_error_types("APIStatusError")
+_RUNTIME_FAILURE_TYPES = (
+    TimeoutError,
+    httpx.TimeoutException,
+    httpx.ConnectError,
+    RateLimitError,
+    TransportError,
+    *_OPENAI_CONNECTION_ERROR_TYPES,
+    *_OPENAI_STATUS_ERROR_TYPES,
+)
+
+
+class ResilientLightProvider(LLMProvider):
+    """让独立轻量模型仅在可恢复运行故障时回退主模型。"""
+
+    def __init__(
+        self,
+        *,
+        primary: LLMProvider,
+        primary_runtime_id: str,
+        primary_model: str,
+        fallback: LLMProvider,
+        fallback_model: str,
+    ) -> None:
+        self.primary = primary
+        self.primary_runtime_id = primary_runtime_id
+        self.primary_model = primary_model
+        self.fallback = fallback
+        self.fallback_model = fallback_model
+
+    async def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        model: str,
+        max_tokens: int,
+        tool_choice: str | dict = "auto",
+        extra_body: dict | None = None,
+        disable_thinking: bool = False,
+        on_content_delta: Callable[[StreamDelta], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        """先调用轻量模型；未输出 delta 的可恢复故障才切换主模型。"""
+
+        # 1. 代理 delta 并记录是否已经向调用方产生可见输出。
+        emitted = False
+
+        async def track_delta(delta: StreamDelta) -> None:
+            nonlocal emitted
+            emitted = emitted or _has_visible_delta(delta)
+            if on_content_delta is not None:
+                await on_content_delta(delta)
+
+        callback = track_delta if on_content_delta is not None else None
+
+        # 2. 主路径保留独立 light model，其余调用参数原样传递。
+        try:
+            return await self.primary.chat(
+                messages=messages,
+                tools=tools,
+                model=self.primary_model,
+                max_tokens=max_tokens,
+                tool_choice=tool_choice,
+                extra_body=extra_body,
+                disable_thinking=disable_thinking,
+                on_content_delta=callback,
+            )
+        except _RUNTIME_FAILURE_TYPES as exc:
+            if emitted or not _is_recoverable_runtime_error(exc):
+                raise
+
+            # 3. 只替换模型和 provider，避免改变上层任务语义。
+            logger.warning(
+                "[light.fallback] primary_runtime=%s primary_model=%s err_type=%s "
+                "fallback_model=%s",
+                self.primary_runtime_id,
+                self.primary_model,
+                type(exc).__name__,
+                self.fallback_model,
+            )
+            return await self.fallback.chat(
+                messages=messages,
+                tools=tools,
+                model=self.fallback_model,
+                max_tokens=max_tokens,
+                tool_choice=tool_choice,
+                extra_body=extra_body,
+                disable_thinking=disable_thinking,
+                on_content_delta=on_content_delta,
+            )
+
+
+def _has_visible_delta(delta: StreamDelta) -> bool:
+    if isinstance(delta, str):
+        return bool(delta)
+    return any(
+        isinstance(delta.get(key), str) and bool(delta[key])
+        for key in ("content_delta", "thinking_delta")
+    )
+
+
+def _is_recoverable_runtime_error(exc: BaseException) -> bool:
+    """只认可超时、连接、限流和服务端瞬时故障。"""
+    if isinstance(exc, (TimeoutError, httpx.TimeoutException, httpx.ConnectError)):
+        return True
+    if isinstance(exc, _OPENAI_CONNECTION_ERROR_TYPES):
+        return True
+    if isinstance(exc, RateLimitError):
+        return True
+    if isinstance(exc, TransportError):
+        return _is_connection_transport_error(exc)
+    if isinstance(exc, _OPENAI_STATUS_ERROR_TYPES):
+        status_code = int(getattr(exc, "status_code"))
+        if status_code == 429:
+            return not _looks_like_quota_error(exc)
+        return 500 <= status_code < 600
+    return False
+
+
+def _is_connection_transport_error(exc: TransportError) -> bool:
+    cause = exc.__cause__
+    if isinstance(
+        cause,
+        (
+            TimeoutError,
+            httpx.TimeoutException,
+            httpx.ConnectError,
+            *_OPENAI_CONNECTION_ERROR_TYPES,
+        ),
+    ):
+        return True
+    text = str(exc).lower()
+    return any(marker in text for marker in ("连接失败", "connection", "timeout", "超时"))
+
+
+def _looks_like_quota_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    body = getattr(exc, "body", None)
+    combined = f"{text} {body!r}".lower()
+    return any(
+        marker in combined
+        for marker in ("insufficient_quota", "quota exceeded", "billing", "credits")
+    )
+
+
+__all__ = ["ResilientLightProvider"]

--- a/agent/model_runtime/registry.py
+++ b/agent/model_runtime/registry.py
@@ -51,6 +51,9 @@ class ModelRuntimeRegistry:
         read_timeout_s: float,
         write_timeout_s: float,
         pool_timeout_s: float,
+        use_responses_lite: bool,
+        supports_parallel_tool_calls: bool,
+        reasoning_summary: str,
     ) -> CodexResponsesTransport:
         assembly = self.assembly("codex")
         if assembly.transport != "responses":
@@ -64,6 +67,9 @@ class ModelRuntimeRegistry:
             read_timeout_s=read_timeout_s,
             write_timeout_s=write_timeout_s,
             pool_timeout_s=pool_timeout_s,
+            use_responses_lite=use_responses_lite,
+            supports_parallel_tool_calls=supports_parallel_tool_calls,
+            reasoning_summary=reasoning_summary,
         )
 
     def build_runtime(
@@ -77,6 +83,9 @@ class ModelRuntimeRegistry:
         read_timeout_s: float,
         write_timeout_s: float,
         pool_timeout_s: float,
+        use_responses_lite: bool,
+        supports_parallel_tool_calls: bool,
+        reasoning_summary: str,
         chat_factory: Callable[[str], Any],
     ) -> ModelRuntime:
         """按 preset 选择 transport/profile，并返回统一 runtime。"""
@@ -90,6 +99,9 @@ class ModelRuntimeRegistry:
                 read_timeout_s=read_timeout_s,
                 write_timeout_s=write_timeout_s,
                 pool_timeout_s=pool_timeout_s,
+                use_responses_lite=use_responses_lite,
+                supports_parallel_tool_calls=supports_parallel_tool_calls,
+                reasoning_summary=reasoning_summary,
             )
             return ResponsesRuntime(transport)
         if assembly.transport == "chat_completions":

--- a/agent/model_runtime/registry.py
+++ b/agent/model_runtime/registry.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from agent.model_runtime.auth import CodexAuthDriver, CredentialStore
+from agent.model_runtime.runtime import ChatRuntimeAdapter, ModelRuntime, ResponsesRuntime
+from agent.model_runtime.transports import CodexResponsesTransport
+
+
+@dataclass(frozen=True)
+class RuntimeAssembly:
+    auth_driver: str
+    catalog: str
+    transport: str
+    profile: str
+
+
+_BUILTIN_ASSEMBLIES = {
+    "codex": RuntimeAssembly("codex", "codex", "responses", "codex"),
+    "openai": RuntimeAssembly("api_key", "manual", "chat_completions", "openai_compatible"),
+    "deepseek": RuntimeAssembly("api_key", "manual", "chat_completions", "deepseek"),
+    "qwen": RuntimeAssembly("api_key", "manual", "chat_completions", "dashscope"),
+}
+SUPPORTED_PROVIDER_PRESETS = frozenset(_BUILTIN_ASSEMBLIES)
+
+
+class ModelRuntimeRegistry:
+    """按 provider preset 组装认证、目录、profile 与 transport。"""
+
+    def __init__(self, credential_store: CredentialStore | None = None) -> None:
+        self.credential_store = credential_store or CredentialStore()
+
+    def assembly(self, provider: str) -> RuntimeAssembly:
+        if not provider:
+            return RuntimeAssembly(
+                "api_key", "manual", "chat_completions", "legacy_auto"
+            )
+        return _BUILTIN_ASSEMBLIES.get(
+            provider.lower(),
+            _BUILTIN_ASSEMBLIES["openai"],
+        )
+
+    def build_codex_transport(
+        self,
+        *,
+        auth_id: str,
+        runtime_id: str,
+        base_url: str,
+        connect_timeout_s: float,
+        read_timeout_s: float,
+        write_timeout_s: float,
+        pool_timeout_s: float,
+    ) -> CodexResponsesTransport:
+        assembly = self.assembly("codex")
+        if assembly.transport != "responses":
+            raise RuntimeError("Codex preset transport 不变量被破坏")
+        auth = CodexAuthDriver(self.credential_store, auth_id)
+        return CodexResponsesTransport(
+            auth,
+            runtime_id=runtime_id,
+            base_url=base_url,
+            connect_timeout_s=connect_timeout_s,
+            read_timeout_s=read_timeout_s,
+            write_timeout_s=write_timeout_s,
+            pool_timeout_s=pool_timeout_s,
+        )
+
+    def build_runtime(
+        self,
+        *,
+        provider: str,
+        auth_id: str,
+        runtime_id: str,
+        base_url: str,
+        connect_timeout_s: float,
+        read_timeout_s: float,
+        write_timeout_s: float,
+        pool_timeout_s: float,
+        chat_factory: Callable[[str], Any],
+    ) -> ModelRuntime:
+        """按 preset 选择 transport/profile，并返回统一 runtime。"""
+        assembly = self.assembly(provider)
+        if assembly.transport == "responses":
+            transport = self.build_codex_transport(
+                auth_id=auth_id,
+                runtime_id=runtime_id,
+                base_url=base_url or "https://chatgpt.com/backend-api/codex",
+                connect_timeout_s=connect_timeout_s,
+                read_timeout_s=read_timeout_s,
+                write_timeout_s=write_timeout_s,
+                pool_timeout_s=pool_timeout_s,
+            )
+            return ResponsesRuntime(transport)
+        if assembly.transport == "chat_completions":
+            return ChatRuntimeAdapter(chat_factory(assembly.profile))
+        raise ValueError(f"不支持的模型 transport: {assembly.transport}")
+
+
+__all__ = ["ModelRuntimeRegistry", "RuntimeAssembly", "SUPPORTED_PROVIDER_PRESETS"]

--- a/agent/model_runtime/runtime.py
+++ b/agent/model_runtime/runtime.py
@@ -17,6 +17,7 @@ class ChatRuntimeAdapter:
         self.implementation = implementation
 
     async def send(self, request: ModelRequest) -> LLMResponse:
+        # Chat Completions 厂商按 prompt 前缀自动缓存，不接收 Responses 的 cache key。
         return await self.implementation.chat(
             messages=request.messages,
             tools=request.tools,

--- a/agent/model_runtime/runtime.py
+++ b/agent/model_runtime/runtime.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from agent.model_runtime.transports import CodexResponsesTransport
+from agent.model_runtime.types import LLMResponse, ModelRequest
+
+
+class ModelRuntime(Protocol):
+    async def send(self, request: ModelRequest) -> LLMResponse: ...
+
+
+class ChatRuntimeAdapter:
+    """把既有 Chat Completions 实现适配为规范化 runtime。"""
+
+    def __init__(self, implementation: Any) -> None:
+        self.implementation = implementation
+
+    async def send(self, request: ModelRequest) -> LLMResponse:
+        return await self.implementation.chat(
+            messages=request.messages,
+            tools=request.tools,
+            model=request.model,
+            max_tokens=request.max_output_tokens,
+            tool_choice=request.tool_choice,
+            extra_body=request.extra_body,
+            disable_thinking=request.disable_thinking,
+            on_content_delta=request.on_delta,
+        )
+
+
+class ResponsesRuntime:
+    """把 Responses transport 适配为规范化 runtime。"""
+
+    def __init__(self, transport: CodexResponsesTransport) -> None:
+        self.transport = transport
+
+    async def send(self, request: ModelRequest) -> LLMResponse:
+        return await self.transport.send(request)

--- a/agent/model_runtime/transports/__init__.py
+++ b/agent/model_runtime/transports/__init__.py
@@ -1,0 +1,3 @@
+from .responses import CodexResponsesTransport
+
+__all__ = ["CodexResponsesTransport"]

--- a/agent/model_runtime/transports/responses.py
+++ b/agent/model_runtime/transports/responses.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
+import uuid
 from typing import Any, cast
 
 import httpx
 import openai
 from openai import AsyncOpenAI
 
-from agent.model_runtime.auth.codex import CODEX_API_BASE, CodexAuthDriver
+from agent.model_runtime.auth.codex import (
+    CODEX_API_BASE,
+    CODEX_CLIENT_VERSION,
+    CodexAuthDriver,
+)
 from agent.model_runtime.errors import (
     AuthenticationError,
     ContextWindowError,
@@ -39,10 +43,20 @@ class CodexResponsesTransport:
         read_timeout_s: float = 120,
         write_timeout_s: float = 30,
         pool_timeout_s: float = 30,
+        use_responses_lite: bool = False,
+        supports_parallel_tool_calls: bool = True,
+        reasoning_summary: str = "none",
     ) -> None:
         self.auth = auth
         self.runtime_id = runtime_id
         self.base_url = base_url
+        self.use_responses_lite = use_responses_lite
+        self.supports_parallel_tool_calls = supports_parallel_tool_calls
+        self.reasoning_summary = reasoning_summary
+        self.installation_id = str(uuid.uuid4())
+        self.session_id = str(uuid.uuid4())
+        self.thread_id = str(uuid.uuid4())
+        self.window_id = str(uuid.uuid4())
         self.network_timeout = httpx.Timeout(
             connect=connect_timeout_s,
             read=read_timeout_s,
@@ -60,13 +74,21 @@ class CodexResponsesTransport:
         self, request: ModelRequest, *, force_refresh: bool
     ) -> LLMResponse:
         headers = await asyncio.to_thread(self.auth.headers, force_refresh=force_refresh)
+        default_headers = {
+            "ChatGPT-Account-ID": headers.get("ChatGPT-Account-ID", ""),
+            "originator": "codex_cli_rs",
+            "User-Agent": f"codex_cli_rs/{CODEX_CLIENT_VERSION}",
+            "x-codex-installation-id": self.installation_id,
+            "session-id": self.session_id,
+            "thread-id": self.thread_id,
+            "x-codex-window-id": self.window_id,
+        }
+        if self.use_responses_lite:
+            default_headers["x-openai-internal-codex-responses-lite"] = "true"
         client = AsyncOpenAI(
             api_key=headers["Authorization"].removeprefix("Bearer "),
             base_url=self.base_url,
-            default_headers={
-                "ChatGPT-Account-ID": headers.get("ChatGPT-Account-ID", ""),
-                "OpenAI-Beta": "responses=experimental",
-            },
+            default_headers=default_headers,
             timeout=self.network_timeout,
             max_retries=0,
         )
@@ -98,24 +120,35 @@ class CodexResponsesTransport:
             runtime_id=self.runtime_id,
             model=request.model,
         )
+        tools = _responses_tools(request.tools)
+        tool_choice, tools = _normalize_tool_choice(request.tool_choice, tools)
+        if self.use_responses_lite:
+            messages = _responses_lite_input(messages, instructions, tools)
+            instructions = ""
         payload: dict[str, Any] = {
             "model": request.model,
             "instructions": instructions,
             "input": messages,
-            "max_output_tokens": request.max_output_tokens,
+            "tool_choice": tool_choice,
+            "parallel_tool_calls": (
+                self.supports_parallel_tool_calls and not self.use_responses_lite
+            ),
             "store": False,
             "stream": True,
             "include": ["reasoning.encrypted_content"],
         }
+        reasoning: dict[str, str] = {}
         if request.reasoning_effort:
-            payload["reasoning"] = {
-                "effort": _normalize_effort(request.reasoning_effort),
-                "summary": "auto",
-            }
-        tools = _responses_tools(request.tools)
-        if tools:
-            payload.update(tools=tools, tool_choice=request.tool_choice, parallel_tool_calls=True)
-        cache_key = request.prompt_cache_key or _prompt_cache_key(instructions, tools)
+            reasoning["effort"] = _normalize_effort(request.reasoning_effort)
+        if self.reasoning_summary != "none":
+            reasoning["summary"] = self.reasoning_summary
+        if self.use_responses_lite:
+            reasoning["context"] = "all_turns"
+        if reasoning:
+            payload["reasoning"] = reasoning
+        if tools and not self.use_responses_lite:
+            payload["tools"] = tools
+        cache_key = request.prompt_cache_key or self.thread_id
         if cache_key:
             payload["prompt_cache_key"] = cache_key
         return payload
@@ -127,6 +160,7 @@ class CodexResponsesTransport:
         tool_args: dict[str, dict[str, str]] = {}
         output_items: list[dict[str, Any]] = []
         usage: ModelUsage | None = None
+        completed = False
         iterator = aiter(stream)
         while True:
             try:
@@ -143,6 +177,15 @@ class CodexResponsesTransport:
                 thinking.append(delta)
                 if request.on_delta:
                     await request.on_delta({"thinking_delta": delta})
+            elif event_type == "response.reasoning_summary_text.done":
+                done_text = _field(event, "text")
+                current = "".join(thinking)
+                if isinstance(done_text, str) and done_text.startswith(current):
+                    suffix = done_text[len(current) :]
+                    if suffix:
+                        thinking.append(suffix)
+                        if request.on_delta:
+                            await request.on_delta({"thinking_delta": suffix})
             elif event_type == "response.function_call_arguments.delta":
                 item_id = str(_field(event, "item_id") or _field(event, "output_index") or "")
                 slot = tool_args.setdefault(item_id, {"arguments": ""})
@@ -151,7 +194,7 @@ class CodexResponsesTransport:
                 item = _dump(_field(event, "item"))
                 if item:
                     if item.get("type") == "reasoning":
-                        output_items.append(item)
+                        output_items.append(_sanitize_replay_item(item))
                     if item.get("type") == "function_call":
                         item_id = str(item.get("id") or item.get("call_id") or "")
                         tool_args[item_id] = {
@@ -162,10 +205,14 @@ class CodexResponsesTransport:
             elif event_type == "response.completed":
                 response = _field(event, "response")
                 usage = _parse_usage(_field(response, "usage"))
+                completed = True
+                break
             elif event_type in {"response.failed", "response.incomplete"}:
                 response = _field(event, "response")
                 error = _field(response, "error") or _field(response, "incomplete_details")
-                raise TransportError(f"Codex Responses 未完成: {error}")
+                _raise_stream_error(error)
+        if not completed:
+            raise TransportError("Codex Responses 在 completed 事件前断流")
         calls = [_tool_call(value) for value in tool_args.values() if value.get("name")]
         continuation = ContinuationState(
             runtime_id=self.runtime_id,
@@ -204,7 +251,11 @@ def _responses_input(
         if _matches_continuation(state, runtime_id=runtime_id, model=model):
             items = state.get("items")
             if isinstance(items, list):
-                result.extend(items)
+                result.extend(
+                    _sanitize_replay_item(item)
+                    for item in items
+                    if isinstance(item, dict)
+                )
         if role == "tool":
             result.append(
                 {
@@ -291,11 +342,71 @@ def _responses_tools(tools: list[dict]) -> list[dict]:
     return result
 
 
-def _prompt_cache_key(instructions: str, tools: list[dict]) -> str | None:
-    if not instructions and not tools:
-        return None
-    static = instructions + "\0" + json.dumps(tools, sort_keys=True, ensure_ascii=False)
-    return "pck_" + hashlib.sha256(static.encode()).hexdigest()[:24]
+def _normalize_tool_choice(
+    tool_choice: str | dict[str, Any], tools: list[dict]
+) -> tuple[str, list[dict]]:
+    """把 Chat Completions 工具选择收敛为 Codex Responses 字符串契约。"""
+    if isinstance(tool_choice, str):
+        if tool_choice not in {"auto", "none", "required"}:
+            raise TransportError(f"Responses 不支持的 tool_choice: {tool_choice}")
+        return tool_choice, tools
+    function = tool_choice.get("function")
+    name = function.get("name") if isinstance(function, dict) else tool_choice.get("name")
+    if tool_choice.get("type") != "function" or not isinstance(name, str) or not name:
+        raise TransportError("Responses 命名 tool_choice 结构无效")
+    selected = [tool for tool in tools if tool.get("name") == name]
+    if not selected:
+        raise TransportError(f"Responses 命名 tool_choice 引用了未知工具: {name}")
+    return "required", selected
+
+
+def _responses_lite_input(
+    messages: list[dict], instructions: str, tools: list[dict]
+) -> list[dict]:
+    """按 Codex Responses Lite 契约内嵌工具和开发者指令。"""
+    prefix: list[dict] = [
+        {"type": "additional_tools", "role": "developer", "tools": tools}
+    ]
+    if instructions:
+        prefix.append(
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": instructions}],
+            }
+        )
+    return [*prefix, *_strip_image_details(messages)]
+
+
+def _strip_image_details(items: list[dict]) -> list[dict]:
+    """复制 Lite input，并移除后端不接受的图片 detail。"""
+    copied = json.loads(json.dumps(items, ensure_ascii=False))
+    for item in copied:
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "input_image":
+                _ = block.pop("detail", None)
+    return cast(list[dict], copied)
+
+
+def _sanitize_replay_item(item: dict[str, Any]) -> dict[str, Any]:
+    """只保留 reasoning 重放契约允许的字段。"""
+    if item.get("type") != "reasoning":
+        raise TransportError(f"Responses continuation 包含不支持的 item: {item.get('type')}")
+    allowed = {"type", "summary", "content", "encrypted_content"}
+    return {key: value for key, value in item.items() if key in allowed}
+
+
+def _raise_stream_error(error: Any) -> None:
+    code = str(_field(error, "code") or "").lower()
+    message = str(_field(error, "message") or error or "未知错误")
+    if code in {"context_length_exceeded", "context_window_exceeded"}:
+        raise ContextWindowError(f"Codex 请求超过上下文窗口: {message}")
+    if code in {"rate_limit_exceeded", "rate_limit_error", "insufficient_quota"}:
+        raise RateLimitError(f"Codex 请求受限: {message}")
+    raise TransportError(f"Codex Responses 未完成 code={code or '-'}: {message}")
 
 
 def _normalize_effort(value: str) -> str:

--- a/agent/model_runtime/transports/responses.py
+++ b/agent/model_runtime/transports/responses.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from typing import Any, cast
+
+import httpx
+import openai
+from openai import AsyncOpenAI
+
+from agent.model_runtime.auth.codex import CODEX_API_BASE, CodexAuthDriver
+from agent.model_runtime.errors import (
+    AuthenticationError,
+    ContextWindowError,
+    RateLimitError,
+    TransportError,
+)
+from agent.model_runtime.types import (
+    ContinuationState,
+    LLMResponse,
+    ModelRequest,
+    ModelUsage,
+    ToolCall,
+    UsageCoverage,
+)
+
+
+class CodexResponsesTransport:
+    """把规范化模型请求映射到 Codex Responses 流。"""
+
+    def __init__(
+        self,
+        auth: CodexAuthDriver,
+        *,
+        runtime_id: str,
+        base_url: str = CODEX_API_BASE,
+        connect_timeout_s: float = 30,
+        read_timeout_s: float = 120,
+        write_timeout_s: float = 30,
+        pool_timeout_s: float = 30,
+    ) -> None:
+        self.auth = auth
+        self.runtime_id = runtime_id
+        self.base_url = base_url
+        self.network_timeout = httpx.Timeout(
+            connect=connect_timeout_s,
+            read=read_timeout_s,
+            write=write_timeout_s,
+            pool=pool_timeout_s,
+        )
+
+    async def send(self, request: ModelRequest) -> LLMResponse:
+        try:
+            return await self._send_once(request, force_refresh=False)
+        except AuthenticationError:
+            return await self._send_once(request, force_refresh=True)
+
+    async def _send_once(
+        self, request: ModelRequest, *, force_refresh: bool
+    ) -> LLMResponse:
+        headers = await asyncio.to_thread(self.auth.headers, force_refresh=force_refresh)
+        client = AsyncOpenAI(
+            api_key=headers["Authorization"].removeprefix("Bearer "),
+            base_url=self.base_url,
+            default_headers={
+                "ChatGPT-Account-ID": headers.get("ChatGPT-Account-ID", ""),
+                "OpenAI-Beta": "responses=experimental",
+            },
+            timeout=self.network_timeout,
+            max_retries=0,
+        )
+        try:
+            stream = await client.responses.create(**self._build_payload(request))
+            return await self._consume_stream(cast(Any, stream), request)
+        except openai.APIStatusError as exc:
+            status_code = exc.status_code
+            error_text = str(exc).lower()
+            if status_code == 401:
+                raise AuthenticationError("Codex 请求认证失败") from exc
+            if status_code == 429:
+                raise RateLimitError("Codex 请求被限流") from exc
+            if status_code == 400 and any(
+                marker in error_text
+                for marker in ("context_length", "context window", "too many tokens")
+            ):
+                raise ContextWindowError("Codex 请求超过上下文窗口") from exc
+            raise
+        except (openai.APIConnectionError, openai.APITimeoutError) as exc:
+            raise TransportError("Codex Responses 连接失败") from exc
+        finally:
+            await client.close()
+
+    def _build_payload(self, request: ModelRequest) -> dict[str, Any]:
+        messages, instructions = _responses_input(
+            request.messages,
+            request.system_prompt,
+            runtime_id=self.runtime_id,
+            model=request.model,
+        )
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "instructions": instructions,
+            "input": messages,
+            "max_output_tokens": request.max_output_tokens,
+            "store": False,
+            "stream": True,
+            "include": ["reasoning.encrypted_content"],
+        }
+        if request.reasoning_effort:
+            payload["reasoning"] = {
+                "effort": _normalize_effort(request.reasoning_effort),
+                "summary": "auto",
+            }
+        tools = _responses_tools(request.tools)
+        if tools:
+            payload.update(tools=tools, tool_choice=request.tool_choice, parallel_tool_calls=True)
+        cache_key = request.prompt_cache_key or _prompt_cache_key(instructions, tools)
+        if cache_key:
+            payload["prompt_cache_key"] = cache_key
+        return payload
+
+    async def _consume_stream(self, stream: Any, request: ModelRequest) -> LLMResponse:
+        """消费 SSE 事件并保留后续重放必需的 output item。"""
+        content: list[str] = []
+        thinking: list[str] = []
+        tool_args: dict[str, dict[str, str]] = {}
+        output_items: list[dict[str, Any]] = []
+        usage: ModelUsage | None = None
+        iterator = aiter(stream)
+        while True:
+            try:
+                event = await anext(iterator)
+            except StopAsyncIteration:
+                break
+            event_type = str(_field(event, "type") or "")
+            delta = _field(event, "delta")
+            if event_type == "response.output_text.delta" and isinstance(delta, str):
+                content.append(delta)
+                if request.on_delta:
+                    await request.on_delta({"content_delta": delta})
+            elif event_type == "response.reasoning_summary_text.delta" and isinstance(delta, str):
+                thinking.append(delta)
+                if request.on_delta:
+                    await request.on_delta({"thinking_delta": delta})
+            elif event_type == "response.function_call_arguments.delta":
+                item_id = str(_field(event, "item_id") or _field(event, "output_index") or "")
+                slot = tool_args.setdefault(item_id, {"arguments": ""})
+                slot["arguments"] += str(delta or "")
+            elif event_type == "response.output_item.done":
+                item = _dump(_field(event, "item"))
+                if item:
+                    if item.get("type") == "reasoning":
+                        output_items.append(item)
+                    if item.get("type") == "function_call":
+                        item_id = str(item.get("id") or item.get("call_id") or "")
+                        tool_args[item_id] = {
+                            "id": str(item.get("call_id") or item_id),
+                            "name": str(item.get("name") or ""),
+                            "arguments": str(item.get("arguments") or "{}"),
+                        }
+            elif event_type == "response.completed":
+                response = _field(event, "response")
+                usage = _parse_usage(_field(response, "usage"))
+            elif event_type in {"response.failed", "response.incomplete"}:
+                response = _field(event, "response")
+                error = _field(response, "error") or _field(response, "incomplete_details")
+                raise TransportError(f"Codex Responses 未完成: {error}")
+        calls = [_tool_call(value) for value in tool_args.values() if value.get("name")]
+        continuation = ContinuationState(
+            runtime_id=self.runtime_id,
+            transport="responses",
+            model=request.model,
+            items=tuple(output_items),
+        )
+        return LLMResponse(
+            content="".join(content).strip() or None,
+            tool_calls=calls,
+            thinking="".join(thinking).strip() or None,
+            provider_fields={"model_state": continuation.to_dict()},
+            cache_prompt_tokens=usage.input_tokens if usage else None,
+            cache_hit_tokens=usage.cached_input_tokens if usage else None,
+            usage=usage,
+            continuation=continuation,
+        )
+
+
+def _responses_input(
+    messages: list[dict],
+    system_prompt: str,
+    *,
+    runtime_id: str = "",
+    model: str = "",
+) -> tuple[list[dict], str]:
+    """转换 Chat 历史，并原样重放同 transport 的 opaque item。"""
+    result: list[dict] = []
+    instructions = system_prompt
+    for message in messages:
+        role = message.get("role")
+        if role == "system":
+            instructions = f"{instructions}\n\n{message.get('content', '')}".strip()
+            continue
+        state = message.get("model_state")
+        if _matches_continuation(state, runtime_id=runtime_id, model=model):
+            items = state.get("items")
+            if isinstance(items, list):
+                result.extend(items)
+        if role == "tool":
+            result.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(message.get("tool_call_id") or ""),
+                    "output": str(message.get("content") or ""),
+                }
+            )
+            continue
+        tool_calls = message.get("tool_calls")
+        if role == "assistant" and isinstance(tool_calls, list):
+            for call in tool_calls:
+                function = call.get("function") or {}
+                result.append(
+                    {
+                        "type": "function_call",
+                        "call_id": str(call.get("id") or ""),
+                        "name": str(function.get("name") or ""),
+                        "arguments": str(function.get("arguments") or "{}"),
+                    }
+                )
+        content = message.get("content")
+        if content not in (None, ""):
+            result.append({"role": role, "content": _responses_content(role, content)})
+    return result, instructions
+
+
+def _matches_continuation(value: object, *, runtime_id: str, model: str) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return (
+        value.get("schema_version") == 1
+        and value.get("runtime_id") == runtime_id
+        and value.get("transport") == "responses"
+        and value.get("model") == model
+    )
+
+
+def _responses_content(role: object, content: object) -> object:
+    """按消息角色把 Chat content blocks 转为 Responses blocks。"""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        raise TransportError("消息 content 必须是字符串或数组")
+    converted: list[dict[str, Any]] = []
+    for raw in content:
+        if not isinstance(raw, dict):
+            raise TransportError("消息 content block 必须是对象")
+        block_type = raw.get("type")
+        if block_type in {"input_text", "output_text", "input_image"}:
+            converted.append(raw)
+        elif block_type == "text":
+            target = "output_text" if role == "assistant" else "input_text"
+            converted.append({"type": target, "text": str(raw.get("text") or "")})
+        elif block_type == "image_url" and role == "user":
+            image = raw.get("image_url")
+            image_url = image.get("url") if isinstance(image, dict) else image
+            if not isinstance(image_url, str) or not image_url:
+                raise TransportError("image_url block 缺少 URL")
+            item: dict[str, Any] = {"type": "input_image", "image_url": image_url}
+            if isinstance(image, dict) and image.get("detail"):
+                item["detail"] = image["detail"]
+            converted.append(item)
+        else:
+            raise TransportError(f"Responses 不支持的 content block: {block_type}")
+    return converted
+
+
+def _responses_tools(tools: list[dict]) -> list[dict]:
+    result: list[dict] = []
+    for tool in tools:
+        function = tool.get("function") if tool.get("type") == "function" else tool
+        if not isinstance(function, dict) or not function.get("name"):
+            raise TransportError("工具 schema 缺少函数名")
+        result.append(
+            {
+                "type": "function",
+                "name": function["name"],
+                "description": function.get("description", ""),
+                "parameters": function.get("parameters", {"type": "object", "properties": {}}),
+                "strict": bool(function.get("strict", False)),
+            }
+        )
+    return result
+
+
+def _prompt_cache_key(instructions: str, tools: list[dict]) -> str | None:
+    if not instructions and not tools:
+        return None
+    static = instructions + "\0" + json.dumps(tools, sort_keys=True, ensure_ascii=False)
+    return "pck_" + hashlib.sha256(static.encode()).hexdigest()[:24]
+
+
+def _normalize_effort(value: str) -> str:
+    return {"ultra": "max"}.get(value, value)
+
+
+def _field(value: Any, name: str) -> Any:
+    return value.get(name) if isinstance(value, dict) else getattr(value, name, None)
+
+
+def _dump(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if value is None:
+        return {}
+    dumped = value.model_dump(mode="json")
+    return cast(dict[str, Any], dumped)
+
+
+def _tool_call(raw: dict[str, str]) -> ToolCall:
+    try:
+        arguments = json.loads(raw.get("arguments") or "{}")
+    except json.JSONDecodeError as exc:
+        raise TransportError("Codex 工具调用参数不是有效 JSON") from exc
+    if not isinstance(arguments, dict):
+        raise TransportError("Codex 工具调用参数必须是 JSON 对象")
+    return ToolCall(id=raw.get("id", ""), name=raw["name"], arguments=arguments)
+
+
+def _parse_usage(raw: Any) -> ModelUsage | None:
+    if raw is None:
+        return None
+    input_tokens = _field(raw, "input_tokens")
+    output_tokens = _field(raw, "output_tokens")
+    input_details = _field(raw, "input_tokens_details")
+    output_details = _field(raw, "output_tokens_details")
+    return ModelUsage(
+        input_tokens=int(input_tokens) if input_tokens is not None else None,
+        cached_input_tokens=_optional_int(_field(input_details, "cached_tokens")),
+        output_tokens=int(output_tokens) if output_tokens is not None else None,
+        reasoning_output_tokens=_optional_int(_field(output_details, "reasoning_tokens")),
+        covered_request_count=1 if input_tokens is not None and output_tokens is not None else 0,
+        coverage=(
+            UsageCoverage.EXACT
+            if input_tokens is not None and output_tokens is not None
+            else UsageCoverage.PARTIAL
+            if input_tokens is not None or output_tokens is not None
+            else UsageCoverage.UNAVAILABLE
+        ),
+        raw_usage=_dump(raw),
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None

--- a/agent/model_runtime/transports/responses.py
+++ b/agent/model_runtime/transports/responses.py
@@ -17,6 +17,7 @@ from agent.model_runtime.auth.codex import (
 from agent.model_runtime.errors import (
     AuthenticationError,
     ContextWindowError,
+    QuotaError,
     RateLimitError,
     TransportError,
 )
@@ -101,6 +102,11 @@ class CodexResponsesTransport:
             if status_code == 401:
                 raise AuthenticationError("Codex 请求认证失败") from exc
             if status_code == 429:
+                if any(
+                    marker in error_text
+                    for marker in ("insufficient_quota", "quota exceeded", "billing")
+                ):
+                    raise QuotaError("Codex 账号额度不足") from exc
                 raise RateLimitError("Codex 请求被限流") from exc
             if status_code == 400 and any(
                 marker in error_text
@@ -129,6 +135,14 @@ class CodexResponsesTransport:
             "model": request.model,
             "instructions": instructions,
             "input": messages,
+            "extra_body": {
+                "client_metadata": {
+                    "x-codex-installation-id": self.installation_id,
+                    "session-id": self.session_id,
+                    "thread-id": self.thread_id,
+                    "x-codex-window-id": self.window_id,
+                }
+            },
             "tool_choice": tool_choice,
             "parallel_tool_calls": (
                 self.supports_parallel_tool_calls and not self.use_responses_lite
@@ -173,7 +187,20 @@ class CodexResponsesTransport:
                 content.append(delta)
                 if request.on_delta:
                     await request.on_delta({"content_delta": delta})
+            elif event_type == "response.output_text.done":
+                done_text = _field(event, "text")
+                current = "".join(content)
+                if isinstance(done_text, str) and done_text.startswith(current):
+                    suffix = done_text[len(current) :]
+                    if suffix:
+                        content.append(suffix)
+                        if request.on_delta:
+                            await request.on_delta({"content_delta": suffix})
             elif event_type == "response.reasoning_summary_text.delta" and isinstance(delta, str):
+                thinking.append(delta)
+                if request.on_delta:
+                    await request.on_delta({"thinking_delta": delta})
+            elif event_type == "response.reasoning_text.delta" and isinstance(delta, str):
                 thinking.append(delta)
                 if request.on_delta:
                     await request.on_delta({"thinking_delta": delta})
@@ -404,9 +431,15 @@ def _raise_stream_error(error: Any) -> None:
     message = str(_field(error, "message") or error or "未知错误")
     if code in {"context_length_exceeded", "context_window_exceeded"}:
         raise ContextWindowError(f"Codex 请求超过上下文窗口: {message}")
-    if code in {"rate_limit_exceeded", "rate_limit_error", "insufficient_quota"}:
+    if code in {"insufficient_quota", "usage_not_included"}:
+        raise QuotaError(f"Codex 账号额度不足: {message}")
+    if code in {"rate_limit_exceeded", "rate_limit_error"}:
         raise RateLimitError(f"Codex 请求受限: {message}")
-    raise TransportError(f"Codex Responses 未完成 code={code or '-'}: {message}")
+    if code in {"invalid_prompt", "bio_policy", "cyber_policy", "policy_violation"}:
+        raise TransportError(f"Codex Responses 请求被拒绝 code={code}: {message}")
+    raise TransportError(
+        f"Codex Responses 暂时失败 code={code or '-'}: {message}"
+    )
 
 
 def _normalize_effort(value: str) -> str:

--- a/agent/model_runtime/types.py
+++ b/agent/model_runtime/types.py
@@ -44,6 +44,7 @@ class ModelCapabilities:
     context_window: int
     max_output_tokens: int
     effective_context_percent: float = 0.9
+    max_context_window: int | None = None
     supported_reasoning_efforts: tuple[str, ...] = ()
     default_reasoning_effort: str | None = None
     input_modalities: tuple[str, ...] = ("text",)
@@ -63,6 +64,11 @@ class ModelCapabilities:
     def __post_init__(self) -> None:
         if self.context_window <= 0:
             raise ValueError("context_window 必须大于 0")
+        if (
+            self.max_context_window is not None
+            and self.max_context_window < self.context_window
+        ):
+            raise ValueError("max_context_window 不能小于 context_window")
         if self.max_output_tokens <= 0:
             raise ValueError("max_output_tokens 必须大于 0")
         if not 0 < self.effective_context_percent <= 1:

--- a/agent/model_runtime/types.py
+++ b/agent/model_runtime/types.py
@@ -50,10 +50,13 @@ class ModelCapabilities:
     supports_image_original_detail: bool = False
     supports_tool_calling: bool = True
     supports_parallel_tool_calls: bool = True
+    supports_reasoning_summaries: bool = False
+    default_reasoning_summary: str = "none"
     supported_tool_choices: tuple[str, ...] = ("auto", "none", "required")
     supports_streaming: bool = True
     supports_stream_usage: bool = True
     supports_prompt_cache: bool = False
+    use_responses_lite: bool = False
     continuation_mode: str = "messages"
     source: CapabilitySource = CapabilitySource.MANUAL
 

--- a/agent/model_runtime/types.py
+++ b/agent/model_runtime/types.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Awaitable, Callable
+
+
+class CapabilitySource(StrEnum):
+    """标记模型能力值的来源。"""
+
+    CATALOG = "catalog"
+    OVERRIDE = "override"
+    MANUAL = "manual"
+    UNKNOWN = "unknown"
+
+
+class UsageCoverage(StrEnum):
+    EXACT = "exact"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class ModelUsage:
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_output_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    request_count: int = 1
+    covered_request_count: int = 0
+    coverage: UsageCoverage = UsageCoverage.UNAVAILABLE
+    raw_usage: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_tokens(self) -> int | None:
+        if self.input_tokens is None or self.output_tokens is None:
+            return None
+        return self.input_tokens + self.output_tokens
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    context_window: int
+    max_output_tokens: int
+    effective_context_percent: float = 0.9
+    supported_reasoning_efforts: tuple[str, ...] = ()
+    default_reasoning_effort: str | None = None
+    input_modalities: tuple[str, ...] = ("text",)
+    supports_image_original_detail: bool = False
+    supports_tool_calling: bool = True
+    supports_parallel_tool_calls: bool = True
+    supported_tool_choices: tuple[str, ...] = ("auto", "none", "required")
+    supports_streaming: bool = True
+    supports_stream_usage: bool = True
+    supports_prompt_cache: bool = False
+    continuation_mode: str = "messages"
+    source: CapabilitySource = CapabilitySource.MANUAL
+
+    def __post_init__(self) -> None:
+        if self.context_window <= 0:
+            raise ValueError("context_window 必须大于 0")
+        if self.max_output_tokens <= 0:
+            raise ValueError("max_output_tokens 必须大于 0")
+        if not 0 < self.effective_context_percent <= 1:
+            raise ValueError("effective_context_percent 必须在 (0, 1] 内")
+        if "text" not in self.input_modalities:
+            raise ValueError("input_modalities 必须包含 text")
+
+
+@dataclass(frozen=True)
+class ContinuationState:
+    runtime_id: str
+    transport: str
+    model: str
+    items: tuple[dict[str, Any], ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("不支持的 model_state schema_version")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "runtime_id": self.runtime_id,
+            "transport": self.transport,
+            "model": self.model,
+            "items": list(self.items),
+        }
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class LLMResponse:
+    content: str | None
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    thinking: str | None = None
+    provider_fields: dict[str, Any] = field(default_factory=dict)
+    cache_prompt_tokens: int | None = None
+    cache_hit_tokens: int | None = None
+    usage: ModelUsage | None = None
+    continuation: ContinuationState | None = None
+
+
+StreamCallback = Callable[[dict[str, str]], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]]
+    model: str
+    max_output_tokens: int
+    system_prompt: str = ""
+    tool_choice: str | dict[str, Any] = "auto"
+    reasoning_effort: str | None = None
+    prompt_cache_key: str | None = None
+    continuation: ContinuationState | None = None
+    on_delta: StreamCallback | None = None
+    extra_body: dict[str, Any] = field(default_factory=dict)
+    disable_thinking: bool = False

--- a/agent/model_runtime/usage.py
+++ b/agent/model_runtime/usage.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from .types import ModelUsage, UsageCoverage
+
+
+def aggregate_usage(items: list[ModelUsage]) -> ModelUsage:
+    """聚合多次模型请求，并保留未知字段的未知语义。"""
+
+    def total(field: str) -> int | None:
+        values = [getattr(item, field) for item in items]
+        known = [value for value in values if value is not None]
+        return sum(known) if known else None
+
+    if not items:
+        return ModelUsage(request_count=0)
+    request_count = sum(item.request_count for item in items)
+    covered = sum(item.covered_request_count for item in items)
+    coverage = (
+        UsageCoverage.UNAVAILABLE
+        if covered == 0
+        else UsageCoverage.EXACT
+        if covered == request_count and all(item.coverage is UsageCoverage.EXACT for item in items)
+        else UsageCoverage.PARTIAL
+    )
+    return ModelUsage(
+        input_tokens=total("input_tokens"),
+        cached_input_tokens=total("cached_input_tokens"),
+        output_tokens=total("output_tokens"),
+        reasoning_output_tokens=total("reasoning_output_tokens"),
+        cache_write_tokens=total("cache_write_tokens"),
+        request_count=request_count,
+        covered_request_count=covered,
+        coverage=coverage,
+        raw_usage={},
+    )
+
+
+def cache_hit_rate(usage: ModelUsage) -> float | None:
+    if usage.input_tokens in (None, 0) or usage.cached_input_tokens is None:
+        return None
+    return usage.cached_input_tokens / usage.input_tokens

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -525,6 +525,9 @@ class LLMProvider:
         runtime_id: str = "main",
         context_window: int = 0,
         effective_context_percent: float = 0.9,
+        use_responses_lite: bool = False,
+        supports_parallel_tool_calls: bool = True,
+        reasoning_summary: str = "none",
         force_disable_thinking: bool = False,
         payload_snapshot_enabled: bool | None = None,
     ) -> None:
@@ -546,6 +549,9 @@ class LLMProvider:
             read_timeout_s=read_timeout_s,
             write_timeout_s=write_timeout_s,
             pool_timeout_s=pool_timeout_s,
+            use_responses_lite=use_responses_lite,
+            supports_parallel_tool_calls=supports_parallel_tool_calls,
+            reasoning_summary=reasoning_summary,
             chat_factory=lambda profile_name: ChatCompletionsRuntime(
                 api_key=api_key,
                 base_url=base_url,
@@ -605,16 +611,48 @@ class LLMProvider:
             return
         effective = math.floor(self._context_window * self._effective_context_percent)
         input_budget = effective - max_tokens
-        payload = json.dumps(
-            {"system": self._system, "messages": messages, "tools": tools},
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-        estimated = max(1, len(payload) // 3)
+        estimated = _estimate_context_tokens(self._system, messages, tools)
         if input_budget <= 0 or estimated > input_budget:
             raise ContextLengthError(
                 f"上下文估算超限 estimated={estimated} budget={input_budget} quality=approximate"
             )
+
+
+def _estimate_context_tokens(
+    system_prompt: str, messages: list[dict], tools: list[dict]
+) -> int:
+    """估算文本与图片块预算，避免把 data URI 当作文本 token。"""
+    text_chars = len(system_prompt) + len(
+        json.dumps(tools, ensure_ascii=False, separators=(",", ":"))
+    )
+    image_tokens = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") in {
+                    "image_url",
+                    "input_image",
+                }:
+                    detail = block.get("detail")
+                    image = block.get("image_url")
+                    if isinstance(image, dict):
+                        detail = image.get("detail", detail)
+                    image_tokens += 1024 if detail == "low" else 8192
+                    continue
+                text_chars += len(
+                    json.dumps(block, ensure_ascii=False, separators=(",", ":"))
+                )
+        elif content is not None:
+            text_chars += len(str(content))
+        text_chars += len(
+            json.dumps(
+                {key: value for key, value in message.items() if key != "content"},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+    return max(1, text_chars // 3 + image_tokens)
 
 
 def _get_field(delta: Any, name: str) -> Any:

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -12,14 +12,24 @@ import logging
 import os
 import re
 import tempfile
+import math
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, cast
 
 import httpx
 from openai import AsyncOpenAI
+
+from agent.model_runtime.registry import ModelRuntimeRegistry
+from agent.model_runtime.errors import ContextWindowError
+from agent.model_runtime.types import (
+    LLMResponse,
+    ModelRequest,
+    ModelUsage,
+    ToolCall,
+    UsageCoverage,
+)
 
 _THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 
@@ -58,23 +68,6 @@ class ContextLengthError(Exception):
 
 class LLMNetworkTimeoutError(TimeoutError):
     """LLM provider 在网络连接或读取边界超时。"""
-
-
-@dataclass
-class ToolCall:
-    id: str
-    name: str
-    arguments: dict
-
-
-@dataclass
-class LLMResponse:
-    content: str | None
-    tool_calls: list[ToolCall] = field(default_factory=list)
-    thinking: str | None = None
-    provider_fields: dict[str, Any] = field(default_factory=dict)
-    cache_prompt_tokens: int | None = None
-    cache_hit_tokens: int | None = None
 
 
 class ProviderStrategy:
@@ -200,7 +193,7 @@ class DashScopeStrategy(ProviderStrategy):
             kwargs["extra_body"] = extra_body
 
 
-class LLMProvider:
+class ChatCompletionsRuntime:
     def __init__(
         self,
         api_key: str,
@@ -213,6 +206,7 @@ class LLMProvider:
         pool_timeout_s: float = 30.0,
         max_retries: int = 1,
         provider_name: str = "",
+        profile_name: str = "",
         force_disable_thinking: bool = False,
         payload_snapshot_enabled: bool | None = None,
     ) -> None:
@@ -224,13 +218,14 @@ class LLMProvider:
             pool=max(0.001, float(pool_timeout_s)),
         )
         self._client = AsyncOpenAI(
-            api_key=api_key,
+            api_key=api_key or "credential-store",
             base_url=normalized_base_url,
             timeout=network_timeout,
             max_retries=0,
         )
         self._base_url = normalized_base_url or ""
         self._provider_name = provider_name
+        self._profile_name = profile_name
         self._system = system_prompt
         self._extra_body = extra_body or {}
         self._max_retries = max(0, int(max_retries))
@@ -252,7 +247,8 @@ class LLMProvider:
         disable_thinking: bool = False,
         on_content_delta: Callable[[StreamDelta], Awaitable[None]] | None = None,
     ) -> LLMResponse:
-        strategy = _select_provider_strategy(
+        strategy = _strategy_from_profile(
+            self._profile_name,
             provider_name=self._provider_name,
             base_url=self._base_url,
             model=model,
@@ -300,6 +296,7 @@ class LLMProvider:
         cache_prompt_tokens, cache_hit_tokens = _extract_cache_usage(
             getattr(resp, "usage", None)
         )
+        usage = _extract_model_usage(getattr(resp, "usage", None))
         if tool_calls:
             provider_fields = strategy.provider_fields_for_tool_call(
                 provider_fields,
@@ -312,6 +309,7 @@ class LLMProvider:
             provider_fields=provider_fields,
             cache_prompt_tokens=cache_prompt_tokens,
             cache_hit_tokens=cache_hit_tokens,
+            usage=usage,
         )
 
     async def _chat_streaming(
@@ -333,6 +331,7 @@ class LLMProvider:
         tool_call_seen = False
         cache_prompt_tokens: int | None = None
         cache_hit_tokens: int | None = None
+        usage: ModelUsage | None = None
 
         try:
             stream_iter = aiter(stream)
@@ -341,7 +340,9 @@ class LLMProvider:
                     chunk = await anext(stream_iter)
                 except StopAsyncIteration:
                     break
-                except httpx.TimeoutException as exc:
+                except Exception as exc:
+                    if not self._is_network_timeout(exc):
+                        raise
                     raise LLMNetworkTimeoutError("LLM 流读取网络超时") from exc
                 prompt_tokens, hit_tokens = _extract_cache_usage(
                     getattr(chunk, "usage", None)
@@ -349,6 +350,7 @@ class LLMProvider:
                 if prompt_tokens is not None:
                     cache_prompt_tokens = prompt_tokens
                     cache_hit_tokens = hit_tokens
+                    usage = _extract_model_usage(getattr(chunk, "usage", None))
                 choices = getattr(chunk, "choices", None) or []
                 if not choices:
                     continue
@@ -418,6 +420,7 @@ class LLMProvider:
             provider_fields=provider_fields,
             cache_prompt_tokens=cache_prompt_tokens,
             cache_hit_tokens=cache_hit_tokens,
+            usage=usage,
         )
 
     async def _create_with_retry(self, kwargs: dict) -> object:
@@ -473,7 +476,7 @@ class LLMProvider:
 
     @staticmethod
     def _is_retryable(err: Exception) -> bool:
-        if LLMProvider._is_network_timeout(err):
+        if ChatCompletionsRuntime._is_network_timeout(err):
             return True
         status_code = getattr(err, "status_code", None)
         if status_code in {429, 500, 502, 503, 504}:
@@ -500,7 +503,118 @@ class LLMProvider:
         return isinstance(
             err,
             (TimeoutError, httpx.TimeoutException),
+        ) or type(err).__name__ == "APITimeoutError"
+
+
+class LLMProvider:
+    """兼容旧调用签名并统一委托 ModelRuntime。"""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str | None = None,
+        system_prompt: str = "",
+        extra_body: dict | None = None,
+        connect_timeout_s: float = 30.0,
+        read_timeout_s: float = 90.0,
+        write_timeout_s: float = 30.0,
+        pool_timeout_s: float = 30.0,
+        max_retries: int = 1,
+        provider_name: str = "",
+        auth_id: str = "",
+        runtime_id: str = "main",
+        context_window: int = 0,
+        effective_context_percent: float = 0.9,
+        force_disable_thinking: bool = False,
+        payload_snapshot_enabled: bool | None = None,
+    ) -> None:
+        self._system = system_prompt
+        self._extra_body = dict(extra_body or {})
+        self._context_window = int(context_window)
+        self._effective_context_percent = float(effective_context_percent)
+        self._force_disable_thinking = force_disable_thinking
+        if self._context_window < 0:
+            raise ValueError("context_window 不能小于 0")
+        if not 0 < self._effective_context_percent <= 1:
+            raise ValueError("effective_context_percent 必须在 (0, 1] 内")
+        self._runtime = ModelRuntimeRegistry().build_runtime(
+            provider=provider_name,
+            auth_id=auth_id,
+            runtime_id=runtime_id,
+            base_url=base_url or "",
+            connect_timeout_s=connect_timeout_s,
+            read_timeout_s=read_timeout_s,
+            write_timeout_s=write_timeout_s,
+            pool_timeout_s=pool_timeout_s,
+            chat_factory=lambda profile_name: ChatCompletionsRuntime(
+                api_key=api_key,
+                base_url=base_url,
+                system_prompt=system_prompt,
+                extra_body=extra_body,
+                connect_timeout_s=connect_timeout_s,
+                read_timeout_s=read_timeout_s,
+                write_timeout_s=write_timeout_s,
+                pool_timeout_s=pool_timeout_s,
+                max_retries=max_retries,
+                provider_name=provider_name,
+                profile_name=profile_name,
+                force_disable_thinking=force_disable_thinking,
+                payload_snapshot_enabled=payload_snapshot_enabled,
+            ),
         )
+
+    async def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        model: str,
+        max_tokens: int,
+        tool_choice: str | dict = "auto",
+        extra_body: dict | None = None,
+        disable_thinking: bool = False,
+        on_content_delta: Callable[[StreamDelta], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        self._enforce_context_budget(messages, tools, max_tokens)
+        merged_extra = {**self._extra_body, **(extra_body or {})}
+        effort = merged_extra.get("reasoning_effort")
+        request = ModelRequest(
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_output_tokens=max_tokens,
+            system_prompt=self._system,
+            tool_choice=tool_choice,
+            reasoning_effort=(
+                None
+                if self._force_disable_thinking or disable_thinking
+                else str(effort or "") or None
+            ),
+            on_delta=on_content_delta,
+            extra_body=dict(extra_body or {}),
+            disable_thinking=self._force_disable_thinking or disable_thinking,
+        )
+        try:
+            return await self._runtime.send(request)
+        except ContextWindowError as exc:
+            raise ContextLengthError(str(exc)) from exc
+
+    def _enforce_context_budget(
+        self, messages: list[dict], tools: list[dict], max_tokens: int
+    ) -> None:
+        if not self._context_window:
+            return
+        effective = math.floor(self._context_window * self._effective_context_percent)
+        input_budget = effective - max_tokens
+        payload = json.dumps(
+            {"system": self._system, "messages": messages, "tools": tools},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        estimated = max(1, len(payload) // 3)
+        if input_budget <= 0 or estimated > input_budget:
+            raise ContextLengthError(
+                f"上下文估算超限 estimated={estimated} budget={input_budget} quality=approximate"
+            )
 
 
 def _get_field(delta: Any, name: str) -> Any:
@@ -563,6 +677,36 @@ def _extract_cache_usage(usage: Any) -> tuple[int | None, int | None]:
     if prompt_tokens is None or cached_tokens is None:
         return None, None
     return prompt_tokens, cached_tokens
+
+
+def _extract_model_usage(usage: Any) -> ModelUsage | None:
+    """把 Chat Completions usage 映射为规范化用量。"""
+    if usage is None:
+        return None
+    prompt_tokens = _coerce_int(_get_field(usage, "prompt_tokens"))
+    completion_tokens = _coerce_int(_get_field(usage, "completion_tokens"))
+    prompt_details = _get_field(usage, "prompt_tokens_details")
+    completion_details = _get_field(usage, "completion_tokens_details")
+    cached_tokens = _coerce_int(_get_field(prompt_details, "cached_tokens"))
+    if cached_tokens is None:
+        _, cached_tokens = _extract_cache_usage(usage)
+    reasoning_tokens = _coerce_int(_get_field(completion_details, "reasoning_tokens"))
+    raw_usage = usage if isinstance(usage, dict) else {}
+    return ModelUsage(
+        input_tokens=prompt_tokens,
+        cached_input_tokens=cached_tokens,
+        output_tokens=completion_tokens,
+        reasoning_output_tokens=reasoning_tokens,
+        covered_request_count=1 if prompt_tokens is not None and completion_tokens is not None else 0,
+        coverage=(
+            UsageCoverage.EXACT
+            if prompt_tokens is not None and completion_tokens is not None
+            else UsageCoverage.PARTIAL
+            if prompt_tokens is not None or completion_tokens is not None
+            else UsageCoverage.UNAVAILABLE
+        ),
+        raw_usage=raw_usage,
+    )
 
 
 def _iter_tool_call_deltas(delta: Any) -> list[dict[str, str | int]]:
@@ -660,6 +804,29 @@ def _select_provider_strategy(
     ):
         return DashScopeStrategy()
     return ProviderStrategy()
+
+
+def _strategy_from_profile(
+    profile_name: str,
+    *,
+    provider_name: str,
+    base_url: str,
+    model: str,
+) -> ProviderStrategy:
+    """把 registry 已确认的 profile 映射到 Chat 请求语义。"""
+    if profile_name == "deepseek":
+        return DeepSeekStrategy()
+    if profile_name == "dashscope":
+        return DashScopeStrategy()
+    if profile_name == "openai_compatible":
+        return ProviderStrategy()
+    if profile_name == "legacy_auto":
+        return _select_provider_strategy(
+            provider_name=provider_name,
+            base_url=base_url,
+            model=model,
+        )
+    raise ValueError(f"未知 Chat provider profile: {profile_name}")
 
 
 def _drop_thinking_keys(extra_body: dict[str, Any]) -> None:

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -6,13 +6,13 @@ LLM Provider — OpenAI 兼容格式
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import itertools
 import json
 import logging
 import os
 import re
 import tempfile
-import math
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 from pathlib import Path
@@ -22,6 +22,7 @@ import httpx
 from openai import AsyncOpenAI
 
 from agent.model_runtime.registry import ModelRuntimeRegistry
+from agent.model_runtime.context_policy import build_runtime_context_budget
 from agent.model_runtime.errors import ContextWindowError
 from agent.model_runtime.types import (
     LLMResponse,
@@ -128,10 +129,13 @@ class DeepSeekStrategy(ProviderStrategy):
         thinking_requested = bool(thinking_enabled) or bool(reasoning_effort)
         if _deepseek_thinking_enabled(extra_body):
             thinking_requested = True
-        if disable_thinking:
+        named_tool_choice = isinstance(kwargs.get("tool_choice"), dict)
+        if disable_thinking or named_tool_choice:
             extra_body["thinking"] = {"type": "disabled"}
             reasoning_effort = None
             thinking_requested = False
+            if named_tool_choice and not disable_thinking:
+                logger.info("[deepseek] 命名 tool_choice 要求本次关闭 thinking")
         elif thinking_enabled is not None and "thinking" not in extra_body:
             extra_body["thinking"] = {
                 "type": "enabled" if bool(thinking_enabled) else "disabled"
@@ -532,6 +536,7 @@ class LLMProvider:
         payload_snapshot_enabled: bool | None = None,
     ) -> None:
         self._system = system_prompt
+        self._runtime_id = runtime_id
         self._extra_body = dict(extra_body or {})
         self._context_window = int(context_window)
         self._effective_context_percent = float(effective_context_percent)
@@ -579,6 +584,7 @@ class LLMProvider:
         extra_body: dict | None = None,
         disable_thinking: bool = False,
         on_content_delta: Callable[[StreamDelta], Awaitable[None]] | None = None,
+        cache_namespace: str = "",
     ) -> LLMResponse:
         self._enforce_context_budget(messages, tools, max_tokens)
         merged_extra = {**self._extra_body, **(extra_body or {})}
@@ -595,6 +601,11 @@ class LLMProvider:
                 if self._force_disable_thinking or disable_thinking
                 else str(effort or "") or None
             ),
+            prompt_cache_key=(
+                _stable_prompt_cache_key(self._runtime_id, model, cache_namespace)
+                if cache_namespace
+                else None
+            ),
             on_delta=on_content_delta,
             extra_body=dict(extra_body or {}),
             disable_thinking=self._force_disable_thinking or disable_thinking,
@@ -609,12 +620,15 @@ class LLMProvider:
     ) -> None:
         if not self._context_window:
             return
-        effective = math.floor(self._context_window * self._effective_context_percent)
-        input_budget = effective - max_tokens
+        budget = build_runtime_context_budget(
+            self._context_window,
+            self._effective_context_percent,
+            max_tokens,
+        )
         estimated = _estimate_context_tokens(self._system, messages, tools)
-        if input_budget <= 0 or estimated > input_budget:
+        if estimated > budget.input_budget:
             raise ContextLengthError(
-                f"上下文估算超限 estimated={estimated} budget={input_budget} quality=approximate"
+                f"上下文估算超限 estimated={estimated} budget={budget.input_budget} quality=approximate"
             )
 
 
@@ -653,6 +667,12 @@ def _estimate_context_tokens(
             )
         )
     return max(1, text_chars // 3 + image_tokens)
+
+
+def _stable_prompt_cache_key(runtime_id: str, model: str, namespace: str) -> str:
+    """生成不泄露 session 标识的稳定缓存路由键。"""
+    raw = f"{runtime_id}\0{model}\0{namespace}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
 
 
 def _get_field(delta: Any, name: str) -> Any:

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -17,6 +17,8 @@ from urllib.parse import urlsplit, urlunsplit
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, cast
+
+import httpx
 from openai import AsyncOpenAI
 
 _THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
@@ -52,6 +54,10 @@ class ContentSafetyError(Exception):
 
 class ContextLengthError(Exception):
     """LLM provider 因上下文超长拒绝请求"""
+
+
+class LLMNetworkTimeoutError(TimeoutError):
+    """LLM provider 在网络连接或读取边界超时。"""
 
 
 @dataclass
@@ -201,28 +207,32 @@ class LLMProvider:
         base_url: str | None = None,
         system_prompt: str = "",
         extra_body: dict | None = None,
-        request_timeout_s: float = 90.0,
-        stream_idle_timeout_s: float | None = None,
+        connect_timeout_s: float = 30.0,
+        read_timeout_s: float = 90.0,
+        write_timeout_s: float = 30.0,
+        pool_timeout_s: float = 30.0,
         max_retries: int = 1,
         provider_name: str = "",
         force_disable_thinking: bool = False,
         payload_snapshot_enabled: bool | None = None,
     ) -> None:
         normalized_base_url = _normalize_openai_base_url(base_url)
-        self._client = AsyncOpenAI(api_key=api_key, base_url=normalized_base_url)
+        network_timeout = httpx.Timeout(
+            connect=max(0.001, float(connect_timeout_s)),
+            read=max(0.001, float(read_timeout_s)),
+            write=max(0.001, float(write_timeout_s)),
+            pool=max(0.001, float(pool_timeout_s)),
+        )
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=normalized_base_url,
+            timeout=network_timeout,
+            max_retries=0,
+        )
         self._base_url = normalized_base_url or ""
         self._provider_name = provider_name
         self._system = system_prompt
         self._extra_body = extra_body or {}
-        self._request_timeout_s = max(1.0, float(request_timeout_s))
-        self._stream_idle_timeout_s = max(
-            0.001,
-            float(
-                request_timeout_s
-                if stream_idle_timeout_s is None
-                else stream_idle_timeout_s
-            ),
-        )
         self._max_retries = max(0, int(max_retries))
         self._force_disable_thinking = force_disable_thinking
         self._payload_snapshot_enabled = (
@@ -312,7 +322,7 @@ class LLMProvider:
     ) -> LLMResponse:
         """消费单个 provider stream 并组装最终响应。"""
 
-        # 1. 创建并消费流，保持既有 delta 顺序与超时语义
+        # 1. 创建并消费流，网络 idle 超时由 SDK read timeout 统一拥有。
         stream = cast(
             Any,
             await self._create_with_retry(strategy.prepare_stream_request(kwargs)),
@@ -328,12 +338,11 @@ class LLMProvider:
             stream_iter = aiter(stream)
             while True:
                 try:
-                    chunk = await asyncio.wait_for(
-                        anext(stream_iter),
-                        timeout=self._stream_idle_timeout_s,
-                    )
+                    chunk = await anext(stream_iter)
                 except StopAsyncIteration:
                     break
+                except httpx.TimeoutException as exc:
+                    raise LLMNetworkTimeoutError("LLM 流读取网络超时") from exc
                 prompt_tokens, hit_tokens = _extract_cache_usage(
                     getattr(chunk, "usage", None)
                 )
@@ -416,10 +425,7 @@ class LLMProvider:
         last_err: Exception | None = None
         for attempt in range(self._max_retries + 1):
             try:
-                return await asyncio.wait_for(
-                    self._client.chat.completions.create(**kwargs),
-                    timeout=self._request_timeout_s,
-                )
+                return await self._client.chat.completions.create(**kwargs)
             except Exception as e:
                 last_err = e
                 logger.warning(
@@ -439,6 +445,8 @@ class LLMProvider:
                 retryable = self._is_retryable(e)
                 exhausted = attempt >= self._max_retries
                 if (not retryable) or exhausted:
+                    if self._is_network_timeout(e):
+                        raise LLMNetworkTimeoutError("LLM 请求网络超时") from e
                     raise
                 wait_s = min(8.0, 1.0 * (2**attempt))
                 logger.warning(
@@ -465,7 +473,7 @@ class LLMProvider:
 
     @staticmethod
     def _is_retryable(err: Exception) -> bool:
-        if isinstance(err, TimeoutError):
+        if LLMProvider._is_network_timeout(err):
             return True
         status_code = getattr(err, "status_code", None)
         if status_code in {429, 500, 502, 503, 504}:
@@ -486,6 +494,13 @@ class LLMProvider:
             "too many requests",
         )
         return any(k in text for k in keywords)
+
+    @staticmethod
+    def _is_network_timeout(err: Exception) -> bool:
+        return isinstance(
+            err,
+            (TimeoutError, httpx.TimeoutException),
+        )
 
 
 def _get_field(delta: Any, name: str) -> Any:

--- a/bootstrap/memory.py
+++ b/bootstrap/memory.py
@@ -179,5 +179,4 @@ def build_memory_admin_runtime(
 
 
 def _memory_keep_count(window: int) -> int:
-    aligned_window = max(4, ((max(1, window) + 3) // 4) * 4)
-    return aligned_window // 2
+    return max(2, ((max(1, window) + 1) // 2) * 2)

--- a/bootstrap/providers.py
+++ b/bootstrap/providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from agent.config_models import Config
+from agent.config_models import Config, ModelRuntimeConfig
+from agent.model_runtime.fallback import ResilientLightProvider
 from infra.providers.llm_provider import LLMProvider
 
 _MAIN_NETWORK_READ_TIMEOUT_S = 120.0
@@ -22,11 +23,21 @@ def build_providers(
         extra_body=main_extra,
         read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
         provider_name=config.provider,
+        auth_id=config.auth_id,
+        runtime_id=config.runtime_id,
+        context_window=config.context_window,
+        effective_context_percent=config.effective_context_percent,
         payload_snapshot_enabled=payload_snapshot_enabled,
     )
 
-    light_provider: LLMProvider | None = None
-    if config.light_model and (config.light_api_key or config.light_base_url):
+    light_provider = _build_named_role_provider(
+        config,
+        config.fast_runtime_id,
+        system_prompt=config.system_prompt,
+        read_timeout_s=_LIGHT_NETWORK_READ_TIMEOUT_S,
+        force_disable_thinking=True,
+    )
+    if light_provider is None and config.light_model and (config.light_api_key or config.light_base_url):
         light_url = config.light_base_url or config.base_url or ""
         light_extra: dict[str, object] = (
             {}
@@ -46,9 +57,24 @@ def build_providers(
             force_disable_thinking=True,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
+    if light_provider is not None:
+        primary_runtime_id = config.fast_runtime_id or "legacy-fast"
+        primary_model = config.light_model
+        light_provider = ResilientLightProvider(
+            primary=light_provider,
+            primary_runtime_id=primary_runtime_id,
+            primary_model=primary_model,
+            fallback=provider,
+            fallback_model=config.model,
+        )
 
-    agent_provider: LLMProvider | None = None
-    if config.agent_model and (config.agent_api_key or config.agent_base_url):
+    agent_provider = _build_named_role_provider(
+        config,
+        config.agent_runtime_id,
+        system_prompt=config.system_prompt,
+        read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
+    )
+    if agent_provider is None and config.agent_model and (config.agent_api_key or config.agent_base_url):
         agent_url = config.agent_base_url or config.base_url or ""
         agent_extra = _sanitize_extra_body(base_url=agent_url, extra_body={})
         agent_provider = LLMProvider(
@@ -66,6 +92,14 @@ def build_providers(
 def build_vl_provider(config: Config) -> LLMProvider | None:
     """构建 VL 视觉模型 provider，仅当主模型不支持多模态且配置了 vl_model 时返回。"""
     if not config.multimodal and config.vl_model:
+        named = _build_named_role_provider(
+            config,
+            config.vl_runtime_id,
+            system_prompt="",
+            read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
+        )
+        if named is not None:
+            return named
         payload_snapshot_enabled = config.dev_mode
         vl_url = config.vl_base_url or config.base_url or ""
         vl_extra = _sanitize_extra_body(base_url=vl_url, extra_body={})
@@ -78,6 +112,58 @@ def build_vl_provider(config: Config) -> LLMProvider | None:
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
     return None
+
+
+def _build_named_role_provider(
+    config: Config,
+    runtime_id: str,
+    *,
+    system_prompt: str,
+    read_timeout_s: float,
+    force_disable_thinking: bool = False,
+) -> LLMProvider | None:
+    """为独立 named runtime 组装完整 provider；复用 main 时返回空。"""
+    if not runtime_id or runtime_id == config.runtime_id:
+        return None
+    runtime = config.model_runtimes[runtime_id]
+    extra_body: dict[str, object] = (
+        {}
+        if force_disable_thinking
+        else ({"reasoning_effort": runtime.reasoning_effort} if runtime.reasoning_effort else {})
+    )
+    return _provider_from_runtime(
+        runtime,
+        system_prompt=system_prompt,
+        extra_body=extra_body,
+        read_timeout_s=read_timeout_s,
+        force_disable_thinking=force_disable_thinking,
+        payload_snapshot_enabled=config.dev_mode,
+    )
+
+
+def _provider_from_runtime(
+    runtime: ModelRuntimeConfig,
+    *,
+    system_prompt: str,
+    extra_body: dict[str, object],
+    read_timeout_s: float,
+    force_disable_thinking: bool,
+    payload_snapshot_enabled: bool,
+) -> LLMProvider:
+    return LLMProvider(
+        api_key=runtime.api_key,
+        base_url=runtime.base_url or None,
+        system_prompt=system_prompt,
+        extra_body=extra_body,
+        read_timeout_s=read_timeout_s,
+        provider_name=runtime.provider,
+        auth_id=runtime.auth,
+        runtime_id=runtime.runtime_id,
+        context_window=runtime.context_window,
+        effective_context_percent=runtime.effective_context_percent,
+        force_disable_thinking=force_disable_thinking,
+        payload_snapshot_enabled=payload_snapshot_enabled,
+    )
 
 
 def _sanitize_extra_body(

--- a/bootstrap/providers.py
+++ b/bootstrap/providers.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from agent.config_models import Config
 from infra.providers.llm_provider import LLMProvider
 
-_MAIN_PROVIDER_TIMEOUT_S = 300.0
-_LIGHT_PROVIDER_TIMEOUT_S = 180.0
-_MAIN_STREAM_IDLE_TIMEOUT_S = 120.0
-_LIGHT_STREAM_IDLE_TIMEOUT_S = 60.0
+_MAIN_NETWORK_READ_TIMEOUT_S = 120.0
+_LIGHT_NETWORK_READ_TIMEOUT_S = 60.0
 
 
 def build_providers(
@@ -22,8 +20,7 @@ def build_providers(
         base_url=config.base_url,
         system_prompt=config.system_prompt,
         extra_body=main_extra,
-        request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
-        stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
+        read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
         provider_name=config.provider,
         payload_snapshot_enabled=payload_snapshot_enabled,
     )
@@ -45,8 +42,7 @@ def build_providers(
             base_url=config.light_base_url or config.base_url,
             system_prompt=config.system_prompt,
             extra_body=light_extra,
-            request_timeout_s=_LIGHT_PROVIDER_TIMEOUT_S,
-            stream_idle_timeout_s=_LIGHT_STREAM_IDLE_TIMEOUT_S,
+            read_timeout_s=_LIGHT_NETWORK_READ_TIMEOUT_S,
             force_disable_thinking=True,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
@@ -60,8 +56,7 @@ def build_providers(
             base_url=agent_url,
             system_prompt=config.system_prompt,
             extra_body=agent_extra,
-            request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
-            stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
+            read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
 
@@ -79,8 +74,7 @@ def build_vl_provider(config: Config) -> LLMProvider | None:
             base_url=config.vl_base_url or config.base_url,
             system_prompt="",
             extra_body=vl_extra,
-            request_timeout_s=_MAIN_PROVIDER_TIMEOUT_S,
-            stream_idle_timeout_s=_MAIN_STREAM_IDLE_TIMEOUT_S,
+            read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
             payload_snapshot_enabled=payload_snapshot_enabled,
         )
     return None

--- a/bootstrap/providers.py
+++ b/bootstrap/providers.py
@@ -27,6 +27,9 @@ def build_providers(
         runtime_id=config.runtime_id,
         context_window=config.context_window,
         effective_context_percent=config.effective_context_percent,
+        use_responses_lite=config.use_responses_lite,
+        supports_parallel_tool_calls=config.supports_parallel_tool_calls,
+        reasoning_summary=config.reasoning_summary,
         payload_snapshot_enabled=payload_snapshot_enabled,
     )
 
@@ -161,6 +164,9 @@ def _provider_from_runtime(
         runtime_id=runtime.runtime_id,
         context_window=runtime.context_window,
         effective_context_percent=runtime.effective_context_percent,
+        use_responses_lite=runtime.use_responses_lite,
+        supports_parallel_tool_calls=runtime.supports_parallel_tool_calls,
+        reasoning_summary=runtime.reasoning_summary,
         force_disable_thinking=force_disable_thinking,
         payload_snapshot_enabled=payload_snapshot_enabled,
     )

--- a/bootstrap/setup_main.py
+++ b/bootstrap/setup_main.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+from agent.config import Config
+from agent.model_runtime.auth import Credential, CredentialStore
+from bootstrap.setup_wizard import (
+    WizardAnswers,
+    _atomic_write_with_backup,
+    _phase_main_llm,
+)
+
+_HEADER_RE = re.compile(r"^\s*\[([^\[\]]+)\]\s*(?:#.*)?$")
+_MANAGED_RUNTIME_KEYS = {
+    "provider",
+    "auth",
+    "model",
+    "base_url",
+    "reasoning_effort",
+    "enable_thinking",
+    "context_window",
+    "max_output_tokens",
+    "input_modalities",
+}
+
+
+def run_main_model_setup(config_path: Path) -> None:
+    """交互式切换主模型，同时保留其余配置和 runtime。"""
+
+    # 1. 只收集主模型，不进入频道、插件、memory 或其他角色流程。
+    if not config_path.is_file():
+        raise click.ClickException(f"配置文件不存在: {config_path}")
+    click.echo(click.style("\n══ akashic 主模型切换 ══\n", bold=True))
+    answers = WizardAnswers()
+    _phase_main_llm(
+        answers,
+        configure_vl=False,
+        prompt_memory_window=False,
+        reuse_codex_auth=True,
+    )
+    if answers.provider != "codex":
+        _persist_main_api_key(answers)
+
+    # 2. 在内存中定点更新并先完成 TOML/schema 验证。
+    original = config_path.read_text(encoding="utf-8")
+    updated = patch_main_model_config(original, answers)
+    _validate_candidate(config_path, updated)
+
+    # 3. 明确备份后原子替换，不触碰任何外部配置文件。
+    mode = config_path.stat().st_mode & 0o777
+    _atomic_write_with_backup(
+        config_path,
+        updated,
+        mode=mode,
+        backup_name=f"{config_path.name}.before-setup-main.bak",
+    )
+    click.echo(f"主模型已更新，备份位于 {config_path}.before-setup-main.bak")
+
+
+def patch_main_model_config(original: str, answers: WizardAnswers) -> str:
+    """只更新主角色、稳定主 runtime 和主上下文窗口。"""
+
+    # 1. 旧版 llm.main table 与新版 main 字符串冲突，原文归档为注释。
+    text = _archive_table(original, "llm.main")
+    runtime_id = "codex_main" if answers.provider == "codex" else "api_main"
+
+    # 2. 更新稳定 runtime；未管理字段和其他 table 原样保留。
+    modalities = ["text", "image"] if answers.multimodal else ["text"]
+    values = {
+        "provider": _toml_string(answers.provider),
+        "auth": _toml_string(answers.auth_id),
+        "model": _toml_string(answers.model),
+        "base_url": _toml_string(answers.base_url),
+        "context_window": str(answers.context_window),
+        "max_output_tokens": str(answers.max_output_tokens),
+        "input_modalities": json.dumps(modalities, ensure_ascii=False),
+    }
+    if answers.reasoning_effort:
+        values["reasoning_effort"] = _toml_string(answers.reasoning_effort)
+    if answers.enable_thinking:
+        values["enable_thinking"] = "true"
+    text = _replace_table_keys(
+        text,
+        f"llm.runtimes.{runtime_id}",
+        values,
+        _MANAGED_RUNTIME_KEYS,
+    )
+
+    # 3. 角色只切 main；历史窗口根据新上下文自动更新。
+    text = _upsert_table_key(text, "llm", "main", _toml_string(runtime_id))
+    text = _upsert_table_key(
+        text,
+        "agent.context",
+        "memory_window",
+        str(answers.memory_window),
+    )
+    return text
+
+
+def _persist_main_api_key(answers: WizardAnswers) -> None:
+    if not answers.auth_id or not answers.api_key:
+        raise click.BadParameter("主模型 API key 不能为空")
+    CredentialStore().put(
+        answers.auth_id,
+        Credential(
+            driver="api_key",
+            access_token=answers.api_key,
+            updated_at=datetime.now(timezone.utc).isoformat(),
+        ),
+    )
+
+
+def _validate_candidate(config_path: Path, content: str) -> None:
+    """在替换正式配置前验证 TOML 和完整 Config schema。"""
+    _ = tomllib.loads(content)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{config_path.name}.setup-main-",
+        suffix=".toml",
+        dir=config_path.parent,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _ = Config.load(temp_name)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+def _archive_table(text: str, table: str) -> str:
+    lines = text.splitlines(keepends=True)
+    span = _find_table(lines, table)
+    if span is None:
+        return text
+    start, end = span
+    archived = [
+        line if not line.strip() else f"# setup-main archived: {line}"
+        for line in lines[start:end]
+    ]
+    return "".join([*lines[:start], *archived, *lines[end:]])
+
+
+def _replace_table_keys(
+    text: str,
+    table: str,
+    values: dict[str, str],
+    managed_keys: set[str],
+) -> str:
+    lines = text.splitlines(keepends=True)
+    newline = _newline(text)
+    span = _find_table(lines, table)
+    rendered = [f"{key} = {value}{newline}" for key, value in values.items()]
+    if span is None:
+        return _append_table(text, table, rendered)
+    start, end = span
+    kept = [
+        line
+        for line in lines[start + 1 : end]
+        if _assignment_key(line) not in managed_keys
+    ]
+    return "".join([*lines[: start + 1], *rendered, *kept, *lines[end:]])
+
+
+def _upsert_table_key(text: str, table: str, key: str, value: str) -> str:
+    lines = text.splitlines(keepends=True)
+    newline = _newline(text)
+    span = _find_table(lines, table)
+    if span is None:
+        return _insert_missing_table(text, table, [f"{key} = {value}{newline}"])
+    start, end = span
+    for index in range(start + 1, end):
+        if _assignment_key(lines[index]) == key:
+            indent = lines[index][: len(lines[index]) - len(lines[index].lstrip())]
+            comment = _inline_comment(lines[index].rstrip("\r\n"))
+            lines[index] = f"{indent}{key} = {value}{comment}{newline}"
+            return "".join(lines)
+    lines.insert(start + 1, f"{key} = {value}{newline}")
+    return "".join(lines)
+
+
+def _find_table(lines: list[str], table: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        match = _HEADER_RE.match(line.rstrip("\r\n"))
+        if match is None or match.group(1).strip() != table:
+            continue
+        end = index + 1
+        while end < len(lines) and _HEADER_RE.match(lines[end].rstrip("\r\n")) is None:
+            end += 1
+        return index, end
+    return None
+
+
+def _insert_missing_table(text: str, table: str, body: list[str]) -> str:
+    if table == "llm":
+        lines = text.splitlines(keepends=True)
+        for index, line in enumerate(lines):
+            match = _HEADER_RE.match(line.rstrip("\r\n"))
+            if match is not None and match.group(1).strip().startswith("llm."):
+                newline = _newline(text)
+                block = [f"[llm]{newline}", *body, newline]
+                return "".join([*lines[:index], *block, *lines[index:]])
+    return _append_table(text, table, body)
+
+
+def _append_table(text: str, table: str, body: list[str]) -> str:
+    newline = _newline(text)
+    prefix = text
+    if prefix and not prefix.endswith(("\n", "\r")):
+        prefix += newline
+    if prefix and not prefix.endswith(newline * 2):
+        prefix += newline
+    return f"{prefix}[{table}]{newline}{''.join(body)}"
+
+
+def _assignment_key(line: str) -> str | None:
+    match = re.match(r"^\s*([A-Za-z0-9_-]+)\s*=", line)
+    return match.group(1) if match is not None else None
+
+
+def _inline_comment(line: str) -> str:
+    quoted = False
+    escaped = False
+    for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quoted:
+            escaped = True
+            continue
+        if char == '"':
+            quoted = not quoted
+            continue
+        if char == "#" and not quoted:
+            return " " + line[index:].lstrip()
+    return ""
+
+
+def _newline(text: str) -> str:
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+__all__ = ["patch_main_model_config", "run_main_model_setup"]

--- a/bootstrap/setup_main.py
+++ b/bootstrap/setup_main.py
@@ -29,6 +29,9 @@ _MANAGED_RUNTIME_KEYS = {
     "context_window",
     "max_output_tokens",
     "input_modalities",
+    "use_responses_lite",
+    "supports_parallel_tool_calls",
+    "reasoning_summary",
 }
 
 
@@ -87,6 +90,12 @@ def patch_main_model_config(original: str, answers: WizardAnswers) -> str:
         values["reasoning_effort"] = _toml_string(answers.reasoning_effort)
     if answers.enable_thinking:
         values["enable_thinking"] = "true"
+    if answers.use_responses_lite:
+        values["use_responses_lite"] = "true"
+    if not answers.supports_parallel_tool_calls:
+        values["supports_parallel_tool_calls"] = "false"
+    if answers.reasoning_summary != "none":
+        values["reasoning_summary"] = _toml_string(answers.reasoning_summary)
     text = _replace_table_keys(
         text,
         f"llm.runtimes.{runtime_id}",

--- a/bootstrap/setup_main.py
+++ b/bootstrap/setup_main.py
@@ -27,6 +27,8 @@ _MANAGED_RUNTIME_KEYS = {
     "reasoning_effort",
     "enable_thinking",
     "context_window",
+    "max_context_window",
+    "effective_context_percent",
     "max_output_tokens",
     "input_modalities",
     "use_responses_lite",
@@ -83,6 +85,10 @@ def patch_main_model_config(original: str, answers: WizardAnswers) -> str:
         "model": _toml_string(answers.model),
         "base_url": _toml_string(answers.base_url),
         "context_window": str(answers.context_window),
+        "max_context_window": str(
+            answers.max_context_window or answers.context_window
+        ),
+        "effective_context_percent": str(answers.effective_context_percent),
         "max_output_tokens": str(answers.max_output_tokens),
         "input_modalities": json.dumps(modalities, ensure_ascii=False),
     }

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import shutil
 import sys
 import select
+import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
@@ -34,14 +37,23 @@ class WizardAnswers:
     model: str = ""
     api_key: str = ""
     base_url: str = ""
+    auth_id: str = ""
+    reasoning_effort: str = ""
+    context_window: int = 0
+    max_output_tokens: int = 8192
+    memory_window: int = 40
     enable_thinking: bool = False
     multimodal: bool = False
     vl_model: str = ""
     vl_api_key: str = ""
     vl_base_url: str = ""
+    vl_auth_id: str = ""
+    vl_provider: str = "openai"
     fast_model: str = ""
     fast_api_key: str = ""
     fast_base_url: str = ""
+    fast_auth_id: str = ""
+    fast_provider: str = "openai"
     tg_token: str = ""
     tg_allow_from: list[str] = field(default_factory=_empty_str_list)
     proactive_enabled: bool = False
@@ -53,6 +65,7 @@ class WizardAnswers:
     embed_model: str = ""
     embed_api_key: str = ""
     embed_base_url: str = ""
+    embed_auth_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -211,20 +224,20 @@ def run_setup_wizard(config_path: Path, workspace: Path) -> None:
     _divider()
     click.echo("\n正在生成配置并初始化工作区...")
 
+    _persist_answer_credentials(answers)
     toml_str = _render_config(answers)
-    _ = config_path.write_text(toml_str, encoding="utf-8")
+    _atomic_write_with_backup(config_path, toml_str, mode=0o600)
     _ok(f"{config_path} 已生成")
     memory_config_path = _default_memory_local_config_path()
     memory_config_path.parent.mkdir(parents=True, exist_ok=True)
-    _ = memory_config_path.write_text(
+    _atomic_write_with_backup(
+        memory_config_path,
         _render_default_memory_config(),
-        encoding="utf-8",
     )
     _ok(f"{memory_config_path} 已生成")
     qqbot_config_path = _qqbot_local_config_path()
     qqbot_config_path.parent.mkdir(parents=True, exist_ok=True)
-    _ = qqbot_config_path.write_text(_render_qqbot_config(answers), encoding="utf-8")
-    qqbot_config_path.chmod(0o600)
+    _atomic_write_with_backup(qqbot_config_path, _render_qqbot_config(answers), mode=0o600)
     _ok(f"{qqbot_config_path} 已生成")
 
     _validate_config(config_path)
@@ -250,29 +263,144 @@ def _collect_answers() -> WizardAnswers:
     return a
 
 
-def _phase_main_llm(a: WizardAnswers) -> None:
+def _phase_main_llm(
+    a: WizardAnswers,
+    *,
+    configure_vl: bool = True,
+    prompt_memory_window: bool = True,
+    reuse_codex_auth: bool = False,
+) -> None:
     _section_header("1/4", "主模型")
+
+    auth_mode = click.prompt(
+        "认证方式",
+        type=click.Choice(["codex", "api-key"], case_sensitive=False),
+        default="codex",
+    )
+    if auth_mode == "codex":
+        _phase_codex_llm(a, reuse_existing_auth=reuse_codex_auth)
+    else:
+        _phase_api_key_llm(a)
+
+    from agent.model_runtime.context_policy import recommended_memory_window
+
+    suggested = recommended_memory_window(a.context_window)
+    a.memory_window = (
+        click.prompt("历史消息窗口", type=int, default=suggested)
+        if prompt_memory_window
+        else suggested
+    )
+    if a.memory_window <= 0:
+        raise click.BadParameter("历史消息窗口必须大于 0")
+
+    if configure_vl and not a.multimodal:
+        _phase_vl_model(a)
+
+
+def _phase_api_key_llm(a: WizardAnswers) -> None:
+    """收集 OpenAI-compatible API Key 模型配置。"""
 
     a.model = click.prompt("模型名")
     a.base_url = click.prompt("base_url（OpenAI 兼容格式）")
     a.api_key = _secret_prompt("API key")
+    a.auth_id = "main_default"
     a.provider = "openai"
     a.enable_thinking = click.confirm("开启 thinking 模式？", default=False)
+    a.reasoning_effort = (
+        click.prompt("推理强度", default="medium") if a.enable_thinking else ""
+    )
+    a.context_window = click.prompt("上下文大小（tokens）", type=int, default=64000)
+    if a.context_window <= 0:
+        raise click.BadParameter("上下文大小必须大于 0")
     a.multimodal = click.confirm("主模型原生支持图片输入？", default=False)
 
-    if not a.multimodal:
-        if click.confirm("配置独立视觉模型？", default=False):
-            a.vl_model = click.prompt("视觉模型名")
-            a.vl_base_url = click.prompt(
-                "base_url（回车 = 复用主模型 base_url）",
-                default="",
-                show_default=False,
-            ) or a.base_url
-            a.vl_api_key = _secret_prompt(
-                "API key（回车 = 复用主模型 key）",
-                default="",
-                show_default=False,
-            ) or a.api_key
+
+def _phase_codex_llm(
+    a: WizardAnswers, *, reuse_existing_auth: bool = False
+) -> None:
+    """完成 Codex 登录并从目录选择模型能力。"""
+    from agent.model_runtime.auth import CodexAuthDriver, CredentialStore
+    from agent.model_runtime.catalog import CodexModelCatalog
+    from agent.model_runtime.errors import AuthenticationError, TransportError
+    import httpx
+
+    a.provider = "codex"
+    a.auth_id = "codex_default"
+    a.base_url = "https://chatgpt.com/backend-api/codex"
+    store = CredentialStore()
+    auth = CodexAuthDriver(store, a.auth_id)
+    login_required = True
+    if reuse_existing_auth:
+        try:
+            credential = store.get(a.auth_id)
+        except AuthenticationError:
+            pass
+        else:
+            if credential.driver == "codex" and credential.access_token:
+                login_required = not click.confirm(
+                    "检测到已有 codex_default 登录，直接复用？",
+                    default=True,
+                )
+    if login_required:
+        code = auth.begin_device_login()
+        click.echo(f"请打开 {code.verification_uri} 并输入代码：{code.user_code}")
+        _ = auth.complete_device_login(code)
+    try:
+        models = asyncio.run(CodexModelCatalog(auth).list_models())
+    except (AuthenticationError, TransportError, httpx.HTTPError) as exc:
+        _err(f"Codex 模型目录加载失败：{exc}")
+        if not click.confirm("显式进入手动模式？", default=False):
+            raise click.ClickException("未取得模型目录，初始化已停止") from exc
+        _phase_codex_manual(a)
+        return
+    if not models:
+        raise click.ClickException("Codex 模型目录为空")
+    choices = {model.slug: model for model in models}
+    a.model = click.prompt("模型", type=click.Choice(list(choices)), default=models[0].slug)
+    selected = choices[a.model]
+    capabilities = selected.capabilities
+    efforts = capabilities.supported_reasoning_efforts
+    if efforts:
+        default_effort = capabilities.default_reasoning_effort or efforts[0]
+        a.reasoning_effort = click.prompt(
+            "推理强度", type=click.Choice(list(efforts)), default=default_effort
+        )
+    a.context_window = click.prompt(
+        "上下文大小（tokens）", type=int, default=capabilities.context_window
+    )
+    detected_image = "image" in capabilities.input_modalities
+    if not selected.input_modalities_known:
+        _warn("模型目录未提供多模态元数据，请手工确认")
+    a.multimodal = click.confirm("主模型支持图片输入？", default=detected_image)
+
+
+def _phase_codex_manual(a: WizardAnswers) -> None:
+    a.model = click.prompt("模型名")
+    a.reasoning_effort = click.prompt("推理强度", default="medium")
+    a.context_window = click.prompt("上下文大小（tokens）", type=int)
+    a.max_output_tokens = click.prompt("最大输出 tokens", type=int, default=8192)
+    a.multimodal = click.confirm("主模型支持图片输入？", default=False)
+
+
+def _phase_vl_model(a: WizardAnswers) -> None:
+    if not click.confirm("配置独立视觉模型？", default=False):
+        return
+    a.vl_model = click.prompt("视觉模型名")
+    if a.provider == "codex":
+        a.vl_base_url = click.prompt("OpenAI-compatible base_url")
+        a.vl_api_key = _secret_prompt("API key")
+    else:
+        a.vl_base_url = click.prompt(
+            "base_url（回车 = 复用主模型 base_url）",
+            default="",
+            show_default=False,
+        ) or a.base_url
+        a.vl_api_key = _secret_prompt(
+            "API key（回车 = 复用主模型 key）",
+            default="",
+            show_default=False,
+        ) or a.api_key
+    a.vl_auth_id = "vl_default"
 
 
 def _phase_fast_model(a: WizardAnswers) -> None:
@@ -283,16 +411,21 @@ def _phase_fast_model(a: WizardAnswers) -> None:
         return
 
     a.fast_model = click.prompt("模型名")
-    a.fast_base_url = click.prompt(
-        "base_url（回车 = 复用主模型 base_url）",
-        default="",
-        show_default=False,
-    ) or a.base_url
-    a.fast_api_key = _secret_prompt(
-        "API key（回车 = 复用主模型 key）",
-        default="",
-        show_default=False,
-    ) or a.api_key
+    if a.provider == "codex":
+        a.fast_base_url = click.prompt("OpenAI-compatible base_url")
+        a.fast_api_key = _secret_prompt("API key")
+    else:
+        a.fast_base_url = click.prompt(
+            "base_url（回车 = 复用主模型 base_url）",
+            default="",
+            show_default=False,
+        ) or a.base_url
+        a.fast_api_key = _secret_prompt(
+            "API key（回车 = 复用主模型 key）",
+            default="",
+            show_default=False,
+        ) or a.api_key
+    a.fast_auth_id = "fast_default"
 
 
 def _phase_telegram(a: WizardAnswers) -> None:
@@ -402,6 +535,7 @@ def _phase_memory(a: WizardAnswers) -> None:
 
     a.embed_model = click.prompt("Embedding 模型名")
     a.embed_api_key = _secret_prompt("Embedding API key")
+    a.embed_auth_id = "embedding_default"
     a.embed_base_url = click.prompt("Embedding base_url")
 
 
@@ -623,7 +757,7 @@ def _validate_config(config_path: Path) -> None:
 def _render_config(a: WizardAnswers) -> str:
     return "\n".join([
         _render_llm(a),
-        _render_agent(),
+        _render_agent(a),
         _render_channels(a),
         _render_memory(a),
         _render_proactive(a),
@@ -632,70 +766,142 @@ def _render_config(a: WizardAnswers) -> str:
 
 
 def _render_llm(a: WizardAnswers) -> str:
-    lines: list[str] = [
+    """把向导答案渲染为角色引用与 named runtimes。"""
+
+    # 1. 角色只引用 runtime ID，跳过独立模型时复用 main。
+    lines = [
         "[llm]",
-        f'provider = "{a.provider}"',
-        "",
-        "[llm.main]",
-        f'model = "{a.model}"',
-        f'api_key = "{a.api_key}"',
-        f'base_url = "{a.base_url}"',
+        'main = "main"',
+        f'fast = "{"fast" if a.fast_model else "main"}"',
+        'agent = "main"',
     ]
-    if a.enable_thinking:
-        lines.append("enable_thinking = true")
-    lines.append(f"multimodal = {'true' if a.multimodal else 'false'}")
+    if a.multimodal:
+        lines.append('vl = "main"')
+    elif a.vl_model:
+        lines.append('vl = "vl"')
     lines.append("")
 
+    # 2. 主 runtime 完整声明认证、能力与上下文边界。
+    main_modalities = '["text", "image"]' if a.multimodal else '["text"]'
+    lines.extend([
+        "[llm.runtimes.main]",
+        f'provider = "{a.provider}"',
+        f'auth = "{a.auth_id}"',
+        f'model = "{a.model}"',
+        f'base_url = "{a.base_url}"',
+    ])
+    if a.enable_thinking:
+        lines.append("enable_thinking = true")
+    if a.reasoning_effort:
+        lines.append(f'reasoning_effort = "{a.reasoning_effort}"')
+    lines.extend([
+        f"context_window = {a.context_window}",
+        f"max_output_tokens = {a.max_output_tokens}",
+        f"input_modalities = {main_modalities}",
+        "",
+    ])
+
+    # 3. 独立角色使用完整 OpenAI-compatible runtime，不继承主端点。
     if a.fast_model:
-        lines += [
-            "[llm.fast]",
+        lines.extend([
+            "[llm.runtimes.fast]",
+            f'provider = "{a.fast_provider}"',
+            f'auth = "{a.fast_auth_id}"',
             f'model = "{a.fast_model}"',
-            f'api_key = "{a.fast_api_key}"',
             f'base_url = "{a.fast_base_url}"',
+            f"context_window = {a.context_window}",
+            f"max_output_tokens = {a.max_output_tokens}",
+            'input_modalities = ["text"]',
             "",
-        ]
-    else:
-        lines += [
-            "# 轻量模型未配置，memory gate / HyDE 将使用主模型",
-            "# [llm.fast]",
-            "# model = \"\"",
-            "",
-        ]
+        ])
 
     if a.vl_model:
-        lines += [
-            "[llm.vl]",
+        lines.extend([
+            "[llm.runtimes.vl]",
+            f'provider = "{a.vl_provider}"',
+            f'auth = "{a.vl_auth_id}"',
             f'model = "{a.vl_model}"',
-            f'api_key = "{a.vl_api_key}"',
             f'base_url = "{a.vl_base_url}"',
+            f"context_window = {a.context_window}",
+            f"max_output_tokens = {a.max_output_tokens}",
+            'input_modalities = ["text", "image"]',
             "",
-        ]
-    else:
-        lines += [
-            "# 视觉模型未配置",
-            "# [llm.vl]",
-            "# model = \"\"",
-            "",
-        ]
+        ])
 
     return "\n".join(lines)
 
 
-def _render_agent() -> str:
-    return """\
+def _render_agent(a: WizardAnswers) -> str:
+    return f"""\
 [agent]
 system_prompt = "You are Akashic, a helpful AI assistant with access to tools. Always respond in the same language the user uses."
-max_tokens = 8192
+max_tokens = {a.max_output_tokens}
 # 设为 0 表示不限制迭代轮数；长任务仍可用 /stop 中断。
 max_iterations = 40
 dev_mode = false
 
 [agent.context]
-memory_window = 40
+memory_window = {a.memory_window}
 
 [agent.tools]
 search_enabled = true
 """
+
+
+def _atomic_write_with_backup(
+    path: Path,
+    content: str,
+    *,
+    mode: int = 0o644,
+    backup_name: str | None = None,
+) -> None:
+    """备份旧文件后 fsync 并原子替换目标配置。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_name(backup_name or f"{path.name}.before-setup.bak")
+        shutil.copy2(path, backup)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, mode)
+        os.replace(temp_name, path)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+def _persist_answer_credentials(a: WizardAnswers) -> None:
+    """问答全部完成后一次性持久化向导收集的 API key。"""
+    from datetime import datetime, timezone
+    from agent.model_runtime.auth import Credential, CredentialStore
+
+    raw = {
+        a.auth_id: a.api_key if a.provider != "codex" else "",
+        a.fast_auth_id: a.fast_api_key,
+        a.vl_auth_id: a.vl_api_key,
+        a.embed_auth_id: a.embed_api_key,
+    }
+    credentials = {
+        credential_id: Credential(
+            driver="api_key",
+            access_token=api_key,
+            updated_at=datetime.now(timezone.utc).isoformat(),
+        )
+        for credential_id, api_key in raw.items()
+        if credential_id and api_key
+    }
+    if a.provider != "codex" and a.auth_id not in credentials:
+        raise click.BadParameter("主模型 API key 不能为空")
+    if a.embed_auth_id not in credentials:
+        raise click.BadParameter("Embedding API key 不能为空")
+    if a.fast_model and a.fast_auth_id not in credentials:
+        raise click.BadParameter("独立轻量模型 API key 不能为空")
+    if a.vl_model and a.vl_auth_id not in credentials:
+        raise click.BadParameter("独立视觉模型 API key 不能为空")
+    CredentialStore().put_many(credentials)
 
 
 def _render_channels(a: WizardAnswers) -> str:
@@ -767,7 +973,11 @@ def _render_memory(a: WizardAnswers) -> str:
         "",
         "[memory.embedding]",
         f'model = "{a.embed_model}"',
-        f'api_key = "{a.embed_api_key}"',
+        (
+            f'auth = "{a.embed_auth_id}"'
+            if a.embed_auth_id
+            else f'api_key = "{a.embed_api_key}"'
+        ),
         f'base_url = "{a.embed_base_url}"',
         "",
     ])

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -40,6 +40,8 @@ class WizardAnswers:
     auth_id: str = ""
     reasoning_effort: str = ""
     context_window: int = 0
+    max_context_window: int = 0
+    effective_context_percent: float = 0.9
     max_output_tokens: int = 8192
     memory_window: int = 40
     enable_thinking: bool = False
@@ -52,11 +54,15 @@ class WizardAnswers:
     vl_base_url: str = ""
     vl_auth_id: str = ""
     vl_provider: str = "openai"
+    vl_context_window: int = 0
+    vl_max_output_tokens: int = 0
     fast_model: str = ""
     fast_api_key: str = ""
     fast_base_url: str = ""
     fast_auth_id: str = ""
     fast_provider: str = "openai"
+    fast_context_window: int = 0
+    fast_max_output_tokens: int = 0
     tg_token: str = ""
     tg_allow_from: list[str] = field(default_factory=_empty_str_list)
     proactive_enabled: bool = False
@@ -285,13 +291,16 @@ def _phase_main_llm(
     else:
         _phase_api_key_llm(a)
 
-    from agent.model_runtime.context_policy import recommended_memory_window
+    from agent.model_runtime.context_policy import recommended_context_settings
 
-    suggested = recommended_memory_window(a.context_window)
+    suggested = recommended_context_settings(
+        a.context_window,
+        a.effective_context_percent,
+    )
     a.memory_window = (
-        click.prompt("历史消息窗口", type=int, default=suggested)
+        click.prompt("历史消息窗口", type=int, default=suggested.memory_window)
         if prompt_memory_window
-        else suggested
+        else suggested.memory_window
     )
     if a.memory_window <= 0:
         raise click.BadParameter("历史消息窗口必须大于 0")
@@ -313,8 +322,18 @@ def _phase_api_key_llm(a: WizardAnswers) -> None:
         click.prompt("推理强度", default="medium") if a.enable_thinking else ""
     )
     a.context_window = click.prompt("上下文大小（tokens）", type=int, default=64000)
+    a.max_context_window = a.context_window
     if a.context_window <= 0:
         raise click.BadParameter("上下文大小必须大于 0")
+    from agent.model_runtime.context_policy import recommended_output_reserve
+
+    a.max_output_tokens = click.prompt(
+        "最大输出 tokens",
+        type=click.IntRange(min=1),
+        default=recommended_output_reserve(a.context_window),
+    )
+    if a.max_output_tokens <= 0:
+        raise click.BadParameter("最大输出 tokens 必须大于 0")
     a.multimodal = click.confirm("主模型原生支持图片输入？", default=False)
 
 
@@ -368,8 +387,22 @@ def _phase_codex_llm(
         a.reasoning_effort = click.prompt(
             "推理强度", type=click.Choice(list(efforts)), default=default_effort
         )
+    max_context_window = capabilities.max_context_window or capabilities.context_window
     a.context_window = click.prompt(
-        "上下文大小（tokens）", type=int, default=capabilities.context_window
+        "上下文大小（tokens）",
+        type=click.IntRange(min=1, max=max_context_window),
+        default=capabilities.context_window,
+    )
+    a.max_context_window = max_context_window
+    a.effective_context_percent = capabilities.effective_context_percent
+    from agent.model_runtime.context_policy import recommended_output_reserve
+
+    a.max_output_tokens = min(
+        capabilities.max_output_tokens,
+        recommended_output_reserve(
+            a.context_window,
+            a.effective_context_percent,
+        ),
     )
     detected_image = "image" in capabilities.input_modalities
     if not selected.input_modalities_known:
@@ -386,6 +419,7 @@ def _phase_codex_manual(a: WizardAnswers) -> None:
     a.reasoning_effort = click.prompt("推理强度", default="medium")
     a.reasoning_summary = "auto"
     a.context_window = click.prompt("上下文大小（tokens）", type=int)
+    a.max_context_window = a.context_window
     a.max_output_tokens = click.prompt("最大输出 tokens", type=int, default=8192)
     a.multimodal = click.confirm("主模型支持图片输入？", default=False)
 
@@ -409,6 +443,16 @@ def _phase_vl_model(a: WizardAnswers) -> None:
             show_default=False,
         ) or a.api_key
     a.vl_auth_id = "vl_default"
+    a.vl_context_window = click.prompt(
+        "视觉模型上下文大小（tokens）",
+        type=click.IntRange(min=1),
+        default=a.context_window,
+    )
+    a.vl_max_output_tokens = click.prompt(
+        "视觉模型最大输出 tokens",
+        type=click.IntRange(min=1),
+        default=min(a.max_output_tokens, 8192),
+    )
 
 
 def _phase_fast_model(a: WizardAnswers) -> None:
@@ -434,6 +478,16 @@ def _phase_fast_model(a: WizardAnswers) -> None:
             show_default=False,
         ) or a.api_key
     a.fast_auth_id = "fast_default"
+    a.fast_context_window = click.prompt(
+        "轻量模型上下文大小（tokens）",
+        type=click.IntRange(min=1),
+        default=min(a.context_window, 128_000),
+    )
+    a.fast_max_output_tokens = click.prompt(
+        "轻量模型最大输出 tokens",
+        type=click.IntRange(min=1),
+        default=min(a.max_output_tokens, 4096),
+    )
 
 
 def _phase_telegram(a: WizardAnswers) -> None:
@@ -802,6 +856,8 @@ def _render_llm(a: WizardAnswers) -> str:
         lines.append("enable_thinking = true")
     if a.reasoning_effort:
         lines.append(f'reasoning_effort = "{a.reasoning_effort}"')
+    if a.effective_context_percent != 0.9:
+        lines.append(f"effective_context_percent = {a.effective_context_percent}")
     if a.use_responses_lite:
         lines.append("use_responses_lite = true")
     if not a.supports_parallel_tool_calls:
@@ -810,6 +866,7 @@ def _render_llm(a: WizardAnswers) -> str:
         lines.append(f'reasoning_summary = "{a.reasoning_summary}"')
     lines.extend([
         f"context_window = {a.context_window}",
+        f"max_context_window = {a.max_context_window or a.context_window}",
         f"max_output_tokens = {a.max_output_tokens}",
         f"input_modalities = {main_modalities}",
         "",
@@ -823,8 +880,9 @@ def _render_llm(a: WizardAnswers) -> str:
             f'auth = "{a.fast_auth_id}"',
             f'model = "{a.fast_model}"',
             f'base_url = "{a.fast_base_url}"',
-            f"context_window = {a.context_window}",
-            f"max_output_tokens = {a.max_output_tokens}",
+            f"context_window = {a.fast_context_window or a.context_window}",
+            f"max_context_window = {a.fast_context_window or a.context_window}",
+            f"max_output_tokens = {a.fast_max_output_tokens or a.max_output_tokens}",
             'input_modalities = ["text"]',
             "",
         ])
@@ -836,8 +894,9 @@ def _render_llm(a: WizardAnswers) -> str:
             f'auth = "{a.vl_auth_id}"',
             f'model = "{a.vl_model}"',
             f'base_url = "{a.vl_base_url}"',
-            f"context_window = {a.context_window}",
-            f"max_output_tokens = {a.max_output_tokens}",
+            f"context_window = {a.vl_context_window or a.context_window}",
+            f"max_context_window = {a.vl_context_window or a.context_window}",
+            f"max_output_tokens = {a.vl_max_output_tokens or a.max_output_tokens}",
             'input_modalities = ["text", "image"]',
             "",
         ])

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -44,6 +44,9 @@ class WizardAnswers:
     memory_window: int = 40
     enable_thinking: bool = False
     multimodal: bool = False
+    use_responses_lite: bool = False
+    supports_parallel_tool_calls: bool = True
+    reasoning_summary: str = "none"
     vl_model: str = ""
     vl_api_key: str = ""
     vl_base_url: str = ""
@@ -372,11 +375,16 @@ def _phase_codex_llm(
     if not selected.input_modalities_known:
         _warn("模型目录未提供多模态元数据，请手工确认")
     a.multimodal = click.confirm("主模型支持图片输入？", default=detected_image)
+    a.use_responses_lite = capabilities.use_responses_lite
+    a.supports_parallel_tool_calls = capabilities.supports_parallel_tool_calls
+    if capabilities.supports_reasoning_summaries:
+        a.reasoning_summary = "auto"
 
 
 def _phase_codex_manual(a: WizardAnswers) -> None:
     a.model = click.prompt("模型名")
     a.reasoning_effort = click.prompt("推理强度", default="medium")
+    a.reasoning_summary = "auto"
     a.context_window = click.prompt("上下文大小（tokens）", type=int)
     a.max_output_tokens = click.prompt("最大输出 tokens", type=int, default=8192)
     a.multimodal = click.confirm("主模型支持图片输入？", default=False)
@@ -794,6 +802,12 @@ def _render_llm(a: WizardAnswers) -> str:
         lines.append("enable_thinking = true")
     if a.reasoning_effort:
         lines.append(f'reasoning_effort = "{a.reasoning_effort}"')
+    if a.use_responses_lite:
+        lines.append("use_responses_lite = true")
+    if not a.supports_parallel_tool_calls:
+        lines.append("supports_parallel_tool_calls = false")
+    if a.reasoning_summary != "none":
+        lines.append(f'reasoning_summary = "{a.reasoning_summary}"')
     lines.extend([
         f"context_window = {a.context_window}",
         f"max_output_tokens = {a.max_output_tokens}",

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,32 +1,47 @@
 # =============================================================================
 # 必填：LLM 配置
+# 最省事的切换方式：只修改 main 指向的 runtime。
 # api_key 可以直接填字符串，也可以用 ${ENV_VAR} 引用环境变量。
 # =============================================================================
 
 [llm]
-provider = "deepseek"
+main = "deepseek_main"
+fast = "qwen_fast"
+agent = "deepseek_main"
+vl = "qwen_vl"
 
-[llm.main]
+[llm.runtimes.deepseek_main]
 # 主模型，必填。推荐 deepseek-v4-flash（agent 能力强、价格低）。
+provider = "deepseek"
 model = "deepseek-v4-flash"
 api_key = "sk-..."
 base_url = "https://api.deepseek.com/v1"
 enable_thinking = true
-multimodal = false
+reasoning_effort = "high"
+context_window = 128000
+effective_context_percent = 0.9
+max_output_tokens = 8192
+input_modalities = ["text"]
 
-[llm.fast]
+[llm.runtimes.qwen_fast]
 # 轻量模型，用于 memory gate / query rewrite / HyDE。
-# 不填则退回主模型，但延迟会稍高。
+provider = "qwen"
 model = "qwen-flash"
 api_key = "sk-..."
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+context_window = 128000
+max_output_tokens = 4096
+input_modalities = ["text"]
 
-[llm.vl]
-# 视觉模型，仅在 llm.main.multimodal = false 时需要。
-# model 留空则不启用，图片会作为路径传给主模型。
+[llm.runtimes.qwen_vl]
+# 视觉模型，仅在主 runtime 不支持图片时需要。
+provider = "qwen"
 model = "qwen-vl-plus"
 api_key = "sk-..."
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+context_window = 128000
+max_output_tokens = 4096
+input_modalities = ["text", "image"]
 
 # =============================================================================
 # Agent 行为
@@ -40,7 +55,8 @@ max_iterations = 40
 dev_mode = false
 
 [agent.context]
-memory_window = 40
+# 默认按主模型有效上下文自动推导；取消注释可显式覆盖。
+# memory_window = 84
 
 [agent.tools]
 search_enabled = true

--- a/infra/providers/llm_provider.py
+++ b/infra/providers/llm_provider.py
@@ -1,6 +1,7 @@
 from agent.provider import (
     ContentSafetyError,
     ContextLengthError,
+    LLMNetworkTimeoutError,
     LLMProvider,
     LLMResponse,
     ToolCall,
@@ -9,6 +10,7 @@ from agent.provider import (
 __all__ = [
     "ContentSafetyError",
     "ContextLengthError",
+    "LLMNetworkTimeoutError",
     "LLMProvider",
     "LLMResponse",
     "ToolCall",

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ _HELP = """\
 
 命令:
   setup                         运行交互式初始化向导
+  setup-main                    仅切换主模型并保留其他配置
   init                          非交互初始化配置和工作区
   gateway                       启动 Agent 服务
   cli                           连接运行中的 Agent
@@ -255,6 +256,12 @@ if __name__ == "__main__":
             config_path=Path(config_path),
             workspace=workspace or _default_workspace(),
         )
+        sys.exit(0)
+
+    if args and args[0] == "setup-main":
+        from bootstrap.setup_main import run_main_model_setup
+
+        run_main_model_setup(Path(config_path))
         sys.exit(0)
 
     if args and args[0] == "init":

--- a/main.py
+++ b/main.py
@@ -15,6 +15,37 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 
+
+def _run_lightweight_setup_command() -> bool:
+    """在加载 Agent runtime 依赖前分发纯配置命令。"""
+    args = sys.argv[1:]
+    if not args or args[0] != "setup-main":
+        return False
+    config_path = "config.toml"
+    if "--config" in args:
+        index = args.index("--config")
+        if index + 1 >= len(args):
+            raise SystemExit("参数 --config 缺少值")
+        config_path = args[index + 1]
+    import click
+
+    from bootstrap.setup_main import run_main_model_setup
+
+    try:
+        run_main_model_setup(Path(config_path))
+    except click.ClickException as exc:
+        exc.show()
+        raise SystemExit(exc.exit_code) from exc
+    except click.Abort as exc:
+        click.echo("已取消。", err=True)
+        raise SystemExit(1) from exc
+    return True
+
+
+if __name__ == "__main__" and _run_lightweight_setup_command():
+    raise SystemExit(0)
+
+
 from agent.config import Config, resolve_cli_socket_endpoint
 from agent.plugins.doctor import format_plugin_doctor_report, run_plugin_doctor
 from agent.plugins.install import (

--- a/session/manager.py
+++ b/session/manager.py
@@ -280,6 +280,9 @@ class Session:
                 reasoning_content = group.get("reasoning_content")
                 if reasoning_content is not None:
                     assistant_msg["reasoning_content"] = reasoning_content
+                model_state = group.get("model_state")
+                if model_state is not None:
+                    assistant_msg["model_state"] = model_state
                 out.append(assistant_msg)
                 for c in calls:
                     out.append(
@@ -301,6 +304,9 @@ class Session:
             reasoning_content = m.get("reasoning_content")
             if reasoning_content is not None:
                 assistant_msg["reasoning_content"] = reasoning_content
+            model_state = m.get("model_state")
+            if model_state is not None:
+                assistant_msg["model_state"] = model_state
             out.append(assistant_msg)
 
         return out

--- a/session/store.py
+++ b/session/store.py
@@ -89,7 +89,27 @@ def _decode_message_extra(
         value = extra_dict.get(field)
         if field in extra_dict and not isinstance(value, str):
             raise ValueError(f"message {field} 必须是字符串: {message_id}")
+    if "model_state" in extra_dict:
+        _validate_model_state(extra_dict["model_state"], message_id)
     return extra_dict
+
+
+def _validate_model_state(value: object, message_id: str) -> None:
+    """在数据库边界校验 Responses continuation state。"""
+    if not isinstance(value, dict):
+        raise ValueError(f"message model_state 必须是 JSON object: {message_id}")
+    state = cast(dict[str, object], value)
+    if state.get("schema_version") != 1:
+        raise ValueError(f"message model_state schema_version 无效: {message_id}")
+    for field in ("runtime_id", "transport", "model"):
+        if not isinstance(state.get(field), str) or not state[field]:
+            raise ValueError(f"message model_state.{field} 必须是非空字符串: {message_id}")
+    items = state.get("items")
+    if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
+        raise ValueError(f"message model_state.items 必须是对象数组: {message_id}")
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) > 2 * 1024 * 1024:
+        raise ValueError(f"message model_state 超过 2 MiB: {message_id}")
 
 
 def _decode_json_payload(
@@ -174,6 +194,8 @@ def _decode_message_tool_chain(
                 raise ValueError(
                     f"message tool_chain[{group_index}].{field} 必须是字符串: {message_id}"
                 )
+        if "model_state" in group:
+            _validate_model_state(group["model_state"], message_id)
     return cast(list[dict[str, object]], tool_chain)
 
 

--- a/tests/test_light_fallback.py
+++ b/tests/test_light_fallback.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import cast
+
+import httpx
+import pytest
+
+import agent.model_runtime.fallback as fallback_module
+from agent.model_runtime.errors import RateLimitError, TransportError
+from agent.model_runtime.fallback import ResilientLightProvider
+from agent.provider import ContentSafetyError, ContextLengthError, LLMProvider, LLMResponse
+
+
+class _Provider:
+    def __init__(self, outcome: LLMResponse | BaseException, *, emit: bool = False) -> None:
+        self.outcome = outcome
+        self.emit = emit
+        self.calls: list[dict] = []
+
+    async def chat(self, **kwargs) -> LLMResponse:
+        self.calls.append(kwargs)
+        callback = kwargs.get("on_content_delta")
+        if self.emit and callback is not None:
+            await callback({"content_delta": "partial"})
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        return self.outcome
+
+
+class _HangingProvider(_Provider):
+    async def chat(self, **kwargs) -> LLMResponse:
+        self.calls.append(kwargs)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _StatusError(Exception):
+    def __init__(self, status_code: int, body: object | None = None) -> None:
+        super().__init__(f"status={status_code}")
+        self.status_code = status_code
+        self.body = body
+
+
+@pytest.fixture(autouse=True)
+def _register_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fallback_module, "_OPENAI_STATUS_ERROR_TYPES", (_StatusError,))
+    monkeypatch.setattr(
+        fallback_module,
+        "_RUNTIME_FAILURE_TYPES",
+        (*fallback_module._RUNTIME_FAILURE_TYPES, _StatusError),
+    )
+
+
+def _provider(
+    primary: _Provider, fallback: _Provider
+) -> ResilientLightProvider:
+    return ResilientLightProvider(
+        primary=cast(LLMProvider, primary),
+        primary_runtime_id="fast",
+        primary_model="fast-model",
+        fallback=cast(LLMProvider, fallback),
+        fallback_model="main-model",
+    )
+
+
+def test_light_wrapper_does_not_own_a_total_deadline() -> None:
+    source = inspect.getsource(ResilientLightProvider.chat)
+    assert "wait_for" not in source
+    assert "create_task" not in source
+    assert ".cancel(" not in source
+
+
+async def _chat(provider: ResilientLightProvider, **kwargs) -> LLMResponse:
+    return await provider.chat(
+        messages=kwargs.get("messages", [{"role": "user", "content": "hi"}]),
+        tools=kwargs.get("tools", [{"type": "function"}]),
+        model="caller-model",
+        max_tokens=kwargs.get("max_tokens", 128),
+        tool_choice=kwargs.get("tool_choice", "required"),
+        disable_thinking=kwargs.get("disable_thinking", True),
+        on_content_delta=kwargs.get("on_content_delta"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_light_primary_success_does_not_call_main() -> None:
+    primary = _Provider(LLMResponse(content="fast"))
+    fallback = _Provider(LLMResponse(content="main"))
+
+    result = await _chat(_provider(primary, fallback))
+
+    assert result.content == "fast"
+    assert primary.calls[0]["model"] == "fast-model"
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("timeout"),
+        httpx.ConnectError(
+            "connection", request=httpx.Request("POST", "https://light.example/v1")
+        ),
+        _StatusError(429),
+        _StatusError(503),
+        RateLimitError("Codex 请求被限流"),
+        TransportError("Codex Responses 连接失败"),
+    ],
+    ids=["timeout", "connection", "429", "5xx", "codex-rate-limit", "codex-transport"],
+)
+async def test_light_recoverable_failure_falls_back_with_main_model(
+    error: BaseException,
+) -> None:
+    primary = _Provider(error)
+    fallback = _Provider(LLMResponse(content="main"))
+    messages = [{"role": "user", "content": "same"}]
+    tools = [{"type": "function", "function": {"name": "x"}}]
+
+    result = await _chat(
+        _provider(primary, fallback),
+        messages=messages,
+        tools=tools,
+        max_tokens=321,
+    )
+
+    assert result.content == "main"
+    call = fallback.calls[0]
+    assert call["model"] == "main-model"
+    assert call["messages"] == messages
+    assert call["tools"] == tools
+    assert call["max_tokens"] == 321
+    assert call["tool_choice"] == "required"
+    assert call["disable_thinking"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        _StatusError(401),
+        _StatusError(400),
+        _StatusError(404),
+        _StatusError(429, body={"error": {"code": "insufficient_quota"}}),
+        ContextLengthError("too long"),
+        ContentSafetyError("unsafe"),
+        TransportError("响应 JSON 损坏"),
+    ],
+    ids=[
+        "401",
+        "invalid-request",
+        "unknown-model",
+        "quota",
+        "context",
+        "safety",
+        "protocol",
+    ],
+)
+async def test_light_nonrecoverable_failure_stays_fail_loud(
+    error: BaseException,
+) -> None:
+    fallback = _Provider(LLMResponse(content="main"))
+
+    with pytest.raises(type(error)):
+        await _chat(_provider(_Provider(error), fallback))
+
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_light_does_not_replay_after_visible_delta() -> None:
+    primary = _Provider(TimeoutError("timeout"), emit=True)
+    fallback = _Provider(LLMResponse(content="main"))
+    deltas: list[dict[str, str]] = []
+
+    async def on_delta(delta: dict[str, str]) -> None:
+        deltas.append(delta)
+
+    with pytest.raises(TimeoutError):
+        await _chat(_provider(primary, fallback), on_content_delta=on_delta)
+
+    assert deltas == [{"content_delta": "partial"}]
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upper_deadline_cancellation_does_not_trigger_fallback() -> None:
+    primary = _HangingProvider(LLMResponse(content="unused"))
+    fallback = _Provider(LLMResponse(content="main"))
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(_chat(_provider(primary, fallback)), timeout=0.01)
+
+    assert fallback.calls == []

--- a/tests/test_light_fallback.py
+++ b/tests/test_light_fallback.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 import agent.model_runtime.fallback as fallback_module
-from agent.model_runtime.errors import RateLimitError, TransportError
+from agent.model_runtime.errors import QuotaError, RateLimitError, TransportError
 from agent.model_runtime.fallback import ResilientLightProvider
 from agent.provider import ContentSafetyError, ContextLengthError, LLMProvider, LLMResponse
 
@@ -81,6 +81,7 @@ async def _chat(provider: ResilientLightProvider, **kwargs) -> LLMResponse:
         tool_choice=kwargs.get("tool_choice", "required"),
         disable_thinking=kwargs.get("disable_thinking", True),
         on_content_delta=kwargs.get("on_content_delta"),
+        cache_namespace=kwargs.get("cache_namespace", "session"),
     )
 
 
@@ -108,8 +109,17 @@ async def test_light_primary_success_does_not_call_main() -> None:
         _StatusError(503),
         RateLimitError("Codex 请求被限流"),
         TransportError("Codex Responses 连接失败"),
+        TransportError("Codex Responses 暂时失败 code=server_error"),
     ],
-    ids=["timeout", "connection", "429", "5xx", "codex-rate-limit", "codex-transport"],
+    ids=[
+        "timeout",
+        "connection",
+        "429",
+        "5xx",
+        "codex-rate-limit",
+        "codex-transport",
+        "codex-transient",
+    ],
 )
 async def test_light_recoverable_failure_falls_back_with_main_model(
     error: BaseException,
@@ -134,6 +144,7 @@ async def test_light_recoverable_failure_falls_back_with_main_model(
     assert call["max_tokens"] == 321
     assert call["tool_choice"] == "required"
     assert call["disable_thinking"] is True
+    assert call["cache_namespace"] == "session"
 
 
 @pytest.mark.asyncio
@@ -146,7 +157,9 @@ async def test_light_recoverable_failure_falls_back_with_main_model(
         _StatusError(429, body={"error": {"code": "insufficient_quota"}}),
         ContextLengthError("too long"),
         ContentSafetyError("unsafe"),
+        QuotaError("quota"),
         TransportError("响应 JSON 损坏"),
+        TransportError("Codex Responses 请求被拒绝 code=invalid_prompt"),
     ],
     ids=[
         "401",
@@ -155,7 +168,9 @@ async def test_light_recoverable_failure_falls_back_with_main_model(
         "quota",
         "context",
         "safety",
+        "typed-quota",
         "protocol",
+        "codex-invalid-prompt",
     ],
 )
 async def test_light_nonrecoverable_failure_stays_fail_loud(

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_setup_main_does_not_import_agent_runtime(tmp_path: Path) -> None:
+    """setup-main 应在完整 Agent runtime 依赖加载前完成分发。"""
+    missing_config = tmp_path / "missing.toml"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parents[1] / "main.py"),
+            "setup-main",
+            "--config",
+            str(missing_config),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "配置文件不存在" in output
+    assert "apscheduler" not in output

--- a/tests/test_memory_window_alignment.py
+++ b/tests/test_memory_window_alignment.py
@@ -1,9 +1,9 @@
 from agent.looping.ports import MemoryConfig
 
 
-def test_memory_window_aligns_keep_count_to_context_frame_turns() -> None:
+def test_memory_window_is_the_actual_even_message_limit() -> None:
     assert MemoryConfig(window=2).keep_count == 2
-    assert MemoryConfig(window=6).keep_count == 4
-    assert MemoryConfig(window=24).keep_count == 12
-    assert MemoryConfig(window=40).keep_count == 20
-    assert MemoryConfig(window=43).keep_count == 22
+    assert MemoryConfig(window=6).keep_count == 6
+    assert MemoryConfig(window=24).keep_count == 24
+    assert MemoryConfig(window=40).keep_count == 40
+    assert MemoryConfig(window=43).keep_count == 44

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -1,0 +1,708 @@
+from __future__ import annotations
+
+import base64
+import inspect
+import json
+import os
+from pathlib import Path
+
+import pytest
+import click
+
+from agent.config import load_config
+from agent.model_runtime.auth.codex import CodexAuthDriver
+from agent.model_runtime.auth.store import Credential, CredentialStore
+from agent.model_runtime.errors import AuthenticationError
+from agent.model_runtime.fallback import ResilientLightProvider
+from agent.model_runtime.catalog.codex import CodexModelCatalog
+from agent.model_runtime.context_policy import (
+    build_context_budget,
+    recommended_memory_window,
+)
+from agent.model_runtime.transports.responses import (
+    CodexResponsesTransport,
+    _parse_usage,
+    _responses_input,
+    _responses_tools,
+)
+from agent.model_runtime.runtime import ChatRuntimeAdapter, ResponsesRuntime
+from agent.model_runtime.types import (
+    CapabilitySource,
+    ModelCapabilities,
+    ModelRequest,
+    ModelUsage,
+    UsageCoverage,
+)
+from agent.model_runtime.usage import aggregate_usage
+from agent.config_models import Config, ModelRuntimeConfig
+from bootstrap.providers import build_providers, build_vl_provider
+from bootstrap.setup_wizard import (
+    WizardAnswers,
+    _persist_answer_credentials,
+    _render_config,
+    run_setup_wizard,
+)
+from session.manager import SessionManager
+from session.store import _decode_message_extra
+
+
+def test_recommended_memory_window_is_bounded() -> None:
+    assert recommended_memory_window(32_000) == 20
+    assert recommended_memory_window(64_000) == 40
+    assert recommended_memory_window(128_000) == 80
+    assert recommended_memory_window(272_000) == 160
+    assert recommended_memory_window(400_000) == 160
+
+
+def test_context_budget_reserves_output() -> None:
+    capabilities = ModelCapabilities(
+        context_window=100_000,
+        max_output_tokens=10_000,
+        effective_context_percent=0.9,
+    )
+    budget = build_context_budget(capabilities, 8_000)
+    assert budget.effective_context == 90_000
+    assert budget.input_budget == 82_000
+
+
+def test_credential_store_writes_private_atomic_document(tmp_path: Path) -> None:
+    path = tmp_path / "auth" / "auth.json"
+    store = CredentialStore(path)
+    credential = Credential(driver="codex", access_token="secret", refresh_token="rotation")
+
+    store.put("codex_default", credential)
+
+    assert store.get("codex_default") == credential
+    assert os.stat(path).st_mode & 0o777 == 0o600
+    assert json.loads(path.read_text())["version"] == 1
+
+
+def test_codex_account_id_comes_from_id_token() -> None:
+    claims = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "account-from-id"}
+    }
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    id_token = f"header.{payload}.signature"
+
+    credential = CodexAuthDriver._credential_from_token(
+        {
+            "id_token": id_token,
+            "access_token": "opaque-access-token",
+            "refresh_token": "refresh-token",
+        }
+    )
+
+    assert credential.account_id == "account-from-id"
+
+
+def test_codex_catalog_maps_reasoning_context_and_modalities() -> None:
+    model = CodexModelCatalog._parse_model(
+        {
+            "slug": "gpt-test",
+            "display_name": "GPT Test",
+            "description": "test",
+            "context_window": 272_000,
+            "effective_context_window_percent": 90,
+            "default_reasoning_level": "high",
+            "supported_reasoning_levels": [
+                {"effort": "medium", "description": ""},
+                {"effort": "high", "description": ""},
+            ],
+            "input_modalities": ["text", "image"],
+            "supports_parallel_tool_calls": True,
+        }
+    )
+
+    assert model.capabilities.context_window == 272_000
+    assert model.capabilities.input_modalities == ("text", "image")
+    assert model.capabilities.supported_reasoning_efforts == ("medium", "high")
+    assert model.capabilities.source is CapabilitySource.CATALOG
+    assert model.input_modalities_known is True
+
+
+def test_responses_adapter_preserves_tools_and_usage() -> None:
+    messages, instructions = _responses_input(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "hello"},
+            {"role": "tool", "tool_call_id": "c1", "content": "done"},
+        ],
+        "identity",
+    )
+    tools = _responses_tools(
+        [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}]
+    )
+    usage = _parse_usage(
+        {
+            "input_tokens": 100,
+            "input_tokens_details": {"cached_tokens": 70},
+            "output_tokens": 20,
+            "output_tokens_details": {"reasoning_tokens": 8},
+        }
+    )
+
+    assert instructions == "identity\n\nsystem"
+    assert messages[-1] == {"type": "function_call_output", "call_id": "c1", "output": "done"}
+    assert tools[0]["name"] == "lookup"
+    assert usage is not None
+    assert usage.cached_input_tokens == 70
+    assert usage.reasoning_output_tokens == 8
+    assert usage.total_tokens == 120
+
+
+def test_responses_transport_only_owns_network_timeouts() -> None:
+    class _Auth:
+        pass
+
+    transport = CodexResponsesTransport(
+        _Auth(),  # type: ignore[arg-type]
+        runtime_id="main",
+        connect_timeout_s=11,
+        read_timeout_s=22,
+        write_timeout_s=33,
+        pool_timeout_s=44,
+    )
+
+    assert transport.network_timeout.connect == 11
+    assert transport.network_timeout.read == 22
+    assert transport.network_timeout.write == 33
+    assert transport.network_timeout.pool == 44
+    assert "wait_for" not in inspect.getsource(CodexResponsesTransport)
+
+
+def test_new_runtime_config_loads_and_roles_can_reuse_main(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "codex_main"
+fast = "codex_main"
+agent = "codex_main"
+vl = "codex_main"
+
+[llm.runtimes.codex_main]
+provider = "codex"
+auth = "codex_default"
+model = "gpt-test"
+reasoning_effort = "high"
+context_window = 272000
+max_output_tokens = 8192
+input_modalities = ["text", "image"]
+
+[agent]
+system_prompt = "test"
+
+[agent.context]
+memory_window = 160
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.provider == "codex"
+    assert config.runtime_id == "codex_main"
+    assert config.auth_id == "codex_default"
+    assert config.context_window == 272_000
+    assert config.multimodal is True
+    assert config.light_model == ""
+
+
+def test_session_boundary_rejects_invalid_continuation_state() -> None:
+    payload = json.dumps(
+        {
+            "model_state": {
+                "schema_version": 2,
+                "runtime_id": "main",
+                "transport": "responses",
+                "model": "gpt-test",
+                "items": [],
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="schema_version"):
+        _decode_message_extra(payload, "session:1")
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_builds_tool_usage_and_reasoning_state() -> None:
+    class _Auth:
+        pass
+
+    async def events():
+        yield {"type": "response.reasoning_summary_text.delta", "delta": "分析"}
+        yield {"type": "response.output_text.delta", "delta": "结果"}
+        yield {
+            "type": "response.output_item.done",
+            "item": {"type": "reasoning", "id": "r1", "encrypted_content": "opaque"},
+        }
+        yield {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "lookup",
+                "arguments": '{"q":"x"}',
+            },
+        }
+        yield {
+            "type": "response.completed",
+            "response": {
+                "usage": {
+                    "input_tokens": 50,
+                    "input_tokens_details": {"cached_tokens": 20},
+                    "output_tokens": 10,
+                }
+            },
+        }
+
+    transport = CodexResponsesTransport(_Auth(), runtime_id="main")  # type: ignore[arg-type]
+    result = await transport._consume_stream(
+        events(),
+        ModelRequest(messages=[], tools=[], model="gpt-test", max_output_tokens=100),
+    )
+
+    assert result.content == "结果"
+    assert result.thinking == "分析"
+    assert result.tool_calls[0].arguments == {"q": "x"}
+    assert result.cache_hit_tokens == 20
+    assert result.continuation is not None
+    assert result.continuation.items == (
+        {"type": "reasoning", "id": "r1", "encrypted_content": "opaque"},
+    )
+
+
+def _state(runtime: str, model: str, item_id: str) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "runtime_id": runtime,
+        "transport": "responses",
+        "model": model,
+        "items": [{"type": "reasoning", "id": item_id, "encrypted_content": "opaque"}],
+    }
+
+
+def test_session_round_trip_restores_tool_and_final_continuation(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("chat:1")
+    session.add_message("user", "hello")
+    session.add_message(
+        "assistant",
+        "final",
+        tool_chain=[
+            {
+                "text": None,
+                "calls": [
+                    {"call_id": "c1", "name": "lookup", "arguments": {}, "result": "ok"}
+                ],
+                "model_state": _state("main", "gpt-test", "tool-reasoning"),
+            },
+            {
+                "text": "next",
+                "calls": [
+                    {"call_id": "c2", "name": "lookup", "arguments": {"n": 2}, "result": "ok2"}
+                ],
+                "model_state": _state("main", "gpt-test", "tool-reasoning-2"),
+            },
+        ],
+        model_state=_state("main", "gpt-test", "final-reasoning"),
+    )
+    manager.save(session)
+    manager.close()
+
+    reloaded = SessionManager(tmp_path)
+    history = reloaded.get_or_create("chat:1").get_history()
+    reloaded.close()
+
+    assistants = [item for item in history if item["role"] == "assistant"]
+    assert assistants[0]["model_state"] == _state("main", "gpt-test", "tool-reasoning")
+    assert assistants[1]["model_state"] == _state("main", "gpt-test", "tool-reasoning-2")
+    assert assistants[-1]["model_state"] == _state("main", "gpt-test", "final-reasoning")
+
+
+def test_responses_replays_only_matching_runtime_transport_and_model() -> None:
+    matching = _state("main", "gpt-test", "keep")
+    foreign = _state("other", "gpt-test", "drop")
+    messages = [
+        {"role": "assistant", "content": "one", "model_state": matching},
+        {"role": "assistant", "content": "two", "model_state": foreign},
+    ]
+
+    converted, _ = _responses_input(messages, "", runtime_id="main", model="gpt-test")
+
+    reasoning_ids = [item["id"] for item in converted if item.get("type") == "reasoning"]
+    assert reasoning_ids == ["keep"]
+    assert [item["content"] for item in converted if item.get("role") == "assistant"] == [
+        "one",
+        "two",
+    ]
+
+
+def test_responses_converts_chat_multimodal_blocks_by_role() -> None:
+    converted, _ = _responses_input(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "看图"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA", "detail": "high"}},
+                ],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "看到了"}]},
+        ],
+        "",
+        runtime_id="main",
+        model="gpt-test",
+    )
+
+    assert converted[0]["content"] == [
+        {"type": "input_text", "text": "看图"},
+        {"type": "input_image", "image_url": "data:image/png;base64,AA", "detail": "high"},
+    ]
+    assert converted[1]["content"] == [{"type": "output_text", "text": "看到了"}]
+
+
+@pytest.mark.asyncio
+async def test_chat_runtime_adapter_uses_canonical_request_contract() -> None:
+    class _Chat:
+        async def chat(self, **kwargs):
+            self.kwargs = kwargs
+            from agent.model_runtime.types import LLMResponse
+
+            return LLMResponse(content="ok")
+
+    implementation = _Chat()
+    request = ModelRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        model="chat-model",
+        max_output_tokens=100,
+    )
+    result = await ChatRuntimeAdapter(implementation).send(request)
+    assert result.content == "ok"
+    assert implementation.kwargs["model"] == "chat-model"
+
+
+def test_distinct_named_roles_build_their_own_runtime() -> None:
+    api_runtime = ModelRuntimeConfig(
+        runtime_id="fast_api",
+        provider="openai",
+        model="fast-model",
+        api_key="fast-key",
+        base_url="https://example.test/v1",
+        context_window=64_000,
+    )
+    codex_runtime = ModelRuntimeConfig(
+        runtime_id="vl_codex",
+        provider="codex",
+        model="codex-vl",
+        auth="codex_other",
+        context_window=128_000,
+        input_modalities=("text", "image"),
+    )
+    config = Config(
+        provider="openai",
+        model="main",
+        api_key="main-key",
+        system_prompt="system",
+        light_model="fast-model",
+        vl_model="codex-vl",
+        multimodal=False,
+        model_runtimes={"fast_api": api_runtime, "vl_codex": codex_runtime},
+        fast_runtime_id="fast_api",
+        vl_runtime_id="vl_codex",
+    )
+
+    _, light, _ = build_providers(config)
+    vl = build_vl_provider(config)
+
+    assert isinstance(light, ResilientLightProvider)
+    assert isinstance(light.primary._runtime, ChatRuntimeAdapter)
+    assert vl is not None and isinstance(vl._runtime, ResponsesRuntime)
+
+
+def test_missing_named_role_reference_fails_loud(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "main"
+fast = "missing"
+[llm.runtimes.main]
+provider = "openai"
+model = "main"
+api_key = "key"
+context_window = 64000
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="llm.fast 引用不存在"):
+        load_config(path)
+
+
+def test_setup_render_never_contains_new_api_key_secrets() -> None:
+    answers = WizardAnswers(
+        provider="openai",
+        model="main",
+        api_key="main-secret",
+        auth_id="main_default",
+        base_url="https://example.test/v1",
+        context_window=64_000,
+        fast_model="fast",
+        fast_api_key="fast-secret",
+        fast_auth_id="fast_default",
+        fast_base_url="https://example.test/v1",
+        vl_model="vision",
+        vl_api_key="vl-secret",
+        vl_auth_id="vl_default",
+        vl_base_url="https://example.test/v1",
+        embed_model="embed",
+        embed_api_key="embed-secret",
+        embed_auth_id="embedding_default",
+        embed_base_url="https://example.test/v1",
+    )
+    rendered = _render_config(answers)
+    for secret in ("main-secret", "fast-secret", "vl-secret", "embed-secret"):
+        assert secret not in rendered
+
+
+def test_setup_cancel_before_completion_does_not_persist_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import bootstrap.setup_wizard as wizard
+
+    persisted = False
+
+    def abort_collection():
+        raise click.Abort()
+
+    def mark_persisted(_: WizardAnswers) -> None:
+        nonlocal persisted
+        persisted = True
+
+    monkeypatch.setattr(wizard, "_collect_answers", abort_collection)
+    monkeypatch.setattr(wizard, "_persist_answer_credentials", mark_persisted)
+    with pytest.raises(click.Abort):
+        run_setup_wizard(tmp_path / "config.toml", tmp_path / "workspace")
+    assert persisted is False
+
+
+def test_credential_store_rejects_world_readable_token_file(tmp_path: Path) -> None:
+    parent = tmp_path / "auth"
+    parent.mkdir(mode=0o700)
+    path = parent / "auth.json"
+    path.write_text('{"version":1,"credentials":{}}', encoding="utf-8")
+    path.chmod(0o644)
+    with pytest.raises(AuthenticationError, match="权限过宽"):
+        CredentialStore(path).get("missing")
+
+
+def test_credential_store_wraps_corrupt_json_with_path(tmp_path: Path) -> None:
+    parent = tmp_path / "auth"
+    parent.mkdir(mode=0o700)
+    path = parent / "auth.json"
+    path.write_text("{broken", encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(AuthenticationError, match=rf"JSON 损坏: {path}"):
+        CredentialStore(path).get("missing")
+
+
+def test_named_runtime_rejects_unknown_provider(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "main"
+[llm.runtimes.main]
+provider = "opneai"
+model = "main"
+auth = "main_default"
+context_window = 64000
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="provider 不受支持.*opneai"):
+        load_config(path)
+
+
+def test_legacy_role_auth_references_load_api_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CredentialStore().put_many(
+        {
+            "fast_default": Credential(driver="api_key", access_token="fast-secret"),
+            "vl_default": Credential(driver="api_key", access_token="vl-secret"),
+        }
+    )
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+provider = "openai"
+[llm.main]
+model = "main"
+api_key = "main-secret"
+base_url = "https://main.example/v1"
+context_window = 64000
+multimodal = false
+[llm.fast]
+model = "fast"
+auth = "fast_default"
+base_url = "https://fast.example/v1"
+[llm.vl]
+model = "vision"
+auth = "vl_default"
+base_url = "https://vl.example/v1"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.light_api_key == "fast-secret"
+    assert config.vl_api_key == "vl-secret"
+
+
+def test_setup_api_key_named_runtimes_load_and_build_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    answers = WizardAnswers(
+        provider="openai",
+        model="main-model",
+        api_key="main-secret",
+        auth_id="main_default",
+        base_url="https://main.example/v1",
+        context_window=64_000,
+        fast_model="fast-model",
+        fast_api_key="fast-secret",
+        fast_auth_id="fast_default",
+        fast_base_url="https://fast.example/v1",
+        vl_model="vl-model",
+        vl_api_key="vl-secret",
+        vl_auth_id="vl_default",
+        vl_base_url="https://vl.example/v1",
+        embed_model="embed-model",
+        embed_api_key="embed-secret",
+        embed_auth_id="embedding_default",
+        embed_base_url="https://embed.example/v1",
+    )
+    _persist_answer_credentials(answers)
+    rendered = _render_config(answers)
+    path = tmp_path / "config.toml"
+    path.write_text(rendered, encoding="utf-8")
+
+    config = load_config(path)
+    main, fast, _ = build_providers(config)
+    vl = build_vl_provider(config)
+
+    assert config.runtime_id == "main"
+    assert config.fast_runtime_id == "fast"
+    assert config.vl_runtime_id == "vl"
+    assert (
+        config.model_runtimes["main"].provider,
+        config.model_runtimes["main"].auth,
+        config.model_runtimes["main"].api_key,
+        config.model_runtimes["main"].base_url,
+    ) == ("openai", "main_default", "main-secret", "https://main.example/v1")
+    assert (
+        config.model_runtimes["fast"].provider,
+        config.model_runtimes["fast"].auth,
+        config.model_runtimes["fast"].base_url,
+    ) == ("openai", "fast_default", "https://fast.example/v1")
+    assert (
+        config.model_runtimes["vl"].provider,
+        config.model_runtimes["vl"].auth,
+        config.model_runtimes["vl"].base_url,
+    ) == ("openai", "vl_default", "https://vl.example/v1")
+    assert config.model_runtimes["vl"].input_modalities == ("text", "image")
+    assert isinstance(main._runtime, ChatRuntimeAdapter)
+    assert main._runtime.implementation._provider_name == "openai"
+    assert isinstance(fast, ResilientLightProvider)
+    assert isinstance(fast.primary._runtime, ChatRuntimeAdapter)
+    assert vl is not None
+    assert isinstance(vl._runtime, ChatRuntimeAdapter)
+    assert fast.primary._runtime.implementation._base_url == "https://fast.example/v1"
+    assert vl._runtime.implementation._base_url == "https://vl.example/v1"
+    for secret in ("main-secret", "fast-secret", "vl-secret", "embed-secret"):
+        assert secret not in rendered
+
+
+def test_setup_codex_main_with_api_vl_loads_correct_transports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CredentialStore().put(
+        "codex_default",
+        Credential(driver="codex", access_token="codex-secret"),
+    )
+    answers = WizardAnswers(
+        provider="codex",
+        model="gpt-codex",
+        auth_id="codex_default",
+        base_url="https://chatgpt.com/backend-api/codex",
+        reasoning_effort="high",
+        context_window=128_000,
+        vl_model="vl-model",
+        vl_api_key="vl-secret",
+        vl_auth_id="vl_default",
+        vl_base_url="https://vl.example/v1",
+        embed_model="embed-model",
+        embed_api_key="embed-secret",
+        embed_auth_id="embedding_default",
+        embed_base_url="https://embed.example/v1",
+    )
+    _persist_answer_credentials(answers)
+    rendered = _render_config(answers)
+    path = tmp_path / "config.toml"
+    path.write_text(rendered, encoding="utf-8")
+
+    config = load_config(path)
+    main, fast, _ = build_providers(config)
+    vl = build_vl_provider(config)
+
+    assert (
+        config.model_runtimes["main"].provider,
+        config.model_runtimes["main"].auth,
+        config.model_runtimes["main"].base_url,
+    ) == (
+        "codex",
+        "codex_default",
+        "https://chatgpt.com/backend-api/codex",
+    )
+    assert (
+        config.model_runtimes["vl"].provider,
+        config.model_runtimes["vl"].auth,
+        config.model_runtimes["vl"].base_url,
+    ) == ("openai", "vl_default", "https://vl.example/v1")
+    assert config.model_runtimes["vl"].api_key == "vl-secret"
+    assert isinstance(main._runtime, ResponsesRuntime)
+    assert main._runtime.transport.base_url == "https://chatgpt.com/backend-api/codex"
+    assert fast is None
+    assert vl is not None
+    assert isinstance(vl._runtime, ChatRuntimeAdapter)
+    assert vl._runtime.implementation._base_url == "https://vl.example/v1"
+    assert "vl-secret" not in rendered
+
+
+def test_usage_aggregation_reports_partial_coverage_without_zero_filling() -> None:
+    usage = aggregate_usage(
+        [
+            ModelUsage(
+                input_tokens=100,
+                output_tokens=20,
+                request_count=1,
+                covered_request_count=1,
+                coverage=UsageCoverage.EXACT,
+            ),
+            ModelUsage(request_count=1),
+        ]
+    )
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 20
+    assert usage.request_count == 2
+    assert usage.covered_request_count == 1
+    assert usage.coverage is UsageCoverage.PARTIAL

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -12,7 +12,12 @@ import click
 from agent.config import load_config
 from agent.model_runtime.auth.codex import CodexAuthDriver
 from agent.model_runtime.auth.store import Credential, CredentialStore
-from agent.model_runtime.errors import AuthenticationError
+from agent.model_runtime.errors import (
+    AuthenticationError,
+    ContextWindowError,
+    RateLimitError,
+    TransportError,
+)
 from agent.model_runtime.fallback import ResilientLightProvider
 from agent.model_runtime.catalog.codex import CodexModelCatalog
 from agent.model_runtime.context_policy import (
@@ -126,7 +131,39 @@ def test_codex_catalog_uses_backend_compatible_client_version() -> None:
 
     catalog = CodexModelCatalog(_Auth())  # type: ignore[arg-type]
 
-    assert catalog.client_version == "0.0.0"
+    assert catalog.client_version == "0.144.1"
+
+
+@pytest.mark.asyncio
+async def test_codex_catalog_only_returns_api_selectable_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Auth:
+        def headers(self, *, force_refresh: bool = False) -> dict[str, str]:
+            return {"Authorization": "Bearer test"}
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            base = {"context_window": 128_000}
+            return {
+                "models": [
+                    {**base, "slug": "visible"},
+                    {**base, "slug": "hidden", "visibility": "hide"},
+                    {**base, "slug": "unsupported", "supported_in_api": False},
+                ]
+            }
+
+    async def fake_get(self: object, *args: object, **kwargs: object) -> _Response:
+        return _Response()
+
+    monkeypatch.setattr("httpx.AsyncClient.get", fake_get)
+
+    models = await CodexModelCatalog(_Auth()).list_models()  # type: ignore[arg-type]
+
+    assert [model.slug for model in models] == ["visible"]
 
 
 def test_responses_adapter_preserves_tools_and_usage() -> None:
@@ -157,6 +194,90 @@ def test_responses_adapter_preserves_tools_and_usage() -> None:
     assert usage.cached_input_tokens == 70
     assert usage.reasoning_output_tokens == 8
     assert usage.total_tokens == 120
+
+
+def test_codex_payload_matches_chatgpt_responses_contract() -> None:
+    class _Auth:
+        pass
+
+    transport = CodexResponsesTransport(_Auth(), runtime_id="main")  # type: ignore[arg-type]
+    payload = transport._build_payload(
+        ModelRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            model="gpt-test",
+            max_output_tokens=8192,
+        )
+    )
+
+    assert "max_output_tokens" not in payload
+    assert payload["tool_choice"] == "auto"
+    assert payload["parallel_tool_calls"] is True
+
+
+def test_codex_lite_payload_embeds_tools_and_instructions() -> None:
+    class _Auth:
+        pass
+
+    transport = CodexResponsesTransport(
+        _Auth(), runtime_id="main", use_responses_lite=True  # type: ignore[arg-type]
+    )
+    payload = transport._build_payload(
+        ModelRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            model="gpt-test",
+            max_output_tokens=8192,
+            system_prompt="system",
+            reasoning_effort="high",
+        )
+    )
+
+    assert payload["instructions"] == ""
+    assert "tools" not in payload
+    assert payload["input"][0]["type"] == "additional_tools"
+    assert payload["input"][1]["role"] == "developer"
+    assert payload["parallel_tool_calls"] is False
+    assert payload["reasoning"]["context"] == "all_turns"
+
+
+def test_codex_lite_keeps_reasoning_context_without_explicit_effort() -> None:
+    class _Auth:
+        pass
+
+    transport = CodexResponsesTransport(
+        _Auth(),  # type: ignore[arg-type]
+        runtime_id="main",
+        use_responses_lite=True,
+        reasoning_summary="auto",
+    )
+    payload = transport._build_payload(
+        ModelRequest(messages=[], tools=[], model="gpt-test", max_output_tokens=8192)
+    )
+
+    assert payload["reasoning"] == {"summary": "auto", "context": "all_turns"}
+
+
+def test_codex_named_tool_choice_filters_and_requires_tool() -> None:
+    class _Auth:
+        pass
+
+    transport = CodexResponsesTransport(_Auth(), runtime_id="main")  # type: ignore[arg-type]
+    payload = transport._build_payload(
+        ModelRequest(
+            messages=[],
+            tools=[
+                {"type": "function", "function": {"name": "first"}},
+                {"type": "function", "function": {"name": "finish"}},
+            ],
+            model="gpt-test",
+            max_output_tokens=100,
+            tool_choice={"type": "function", "function": {"name": "finish"}},
+        )
+    )
+
+    assert payload["tool_choice"] == "required"
+    assert [tool["name"] for tool in payload["tools"]] == ["finish"]
 
 
 def test_responses_transport_only_owns_network_timeouts() -> None:
@@ -217,6 +338,30 @@ memory_window = 160
     assert config.light_model == ""
 
 
+def test_runtime_config_rejects_unknown_reasoning_summary(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "codex_main"
+
+[llm.runtimes.codex_main]
+provider = "codex"
+auth = "codex_default"
+model = "gpt-test"
+reasoning_summary = "verbose"
+context_window = 128000
+
+[agent]
+system_prompt = "test"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="reasoning_summary"):
+        load_config(path)
+
+
 def test_session_boundary_rejects_invalid_continuation_state() -> None:
     payload = json.dumps(
         {
@@ -243,7 +388,13 @@ async def test_responses_stream_builds_tool_usage_and_reasoning_state() -> None:
         yield {"type": "response.output_text.delta", "delta": "结果"}
         yield {
             "type": "response.output_item.done",
-            "item": {"type": "reasoning", "id": "r1", "encrypted_content": "opaque"},
+            "item": {
+                "type": "reasoning",
+                "id": "r1",
+                "status": "completed",
+                "summary": [],
+                "encrypted_content": "opaque",
+            },
         }
         yield {
             "type": "response.output_item.done",
@@ -277,8 +428,52 @@ async def test_responses_stream_builds_tool_usage_and_reasoning_state() -> None:
     assert result.cache_hit_tokens == 20
     assert result.continuation is not None
     assert result.continuation.items == (
-        {"type": "reasoning", "id": "r1", "encrypted_content": "opaque"},
+        {"type": "reasoning", "summary": [], "encrypted_content": "opaque"},
     )
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_rejects_eof_before_completed() -> None:
+    class _Auth:
+        pass
+
+    async def events():
+        yield {"type": "response.output_text.delta", "delta": "partial"}
+
+    transport = CodexResponsesTransport(_Auth(), runtime_id="main")  # type: ignore[arg-type]
+    with pytest.raises(TransportError, match="completed 事件前断流"):
+        await transport._consume_stream(
+            events(),
+            ModelRequest(messages=[], tools=[], model="gpt-test", max_output_tokens=100),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("code", "error_type"),
+    [
+        ("context_length_exceeded", ContextWindowError),
+        ("rate_limit_exceeded", RateLimitError),
+    ],
+)
+async def test_responses_stream_classifies_terminal_errors(
+    code: str, error_type: type[Exception]
+) -> None:
+    class _Auth:
+        pass
+
+    async def events():
+        yield {
+            "type": "response.failed",
+            "response": {"error": {"code": code, "message": "failed"}},
+        }
+
+    transport = CodexResponsesTransport(_Auth(), runtime_id="main")  # type: ignore[arg-type]
+    with pytest.raises(error_type):
+        await transport._consume_stream(
+            events(),
+            ModelRequest(messages=[], tools=[], model="gpt-test", max_output_tokens=100),
+        )
 
 
 def _state(runtime: str, model: str, item_id: str) -> dict[str, object]:
@@ -339,8 +534,8 @@ def test_responses_replays_only_matching_runtime_transport_and_model() -> None:
 
     converted, _ = _responses_input(messages, "", runtime_id="main", model="gpt-test")
 
-    reasoning_ids = [item["id"] for item in converted if item.get("type") == "reasoning"]
-    assert reasoning_ids == ["keep"]
+    reasoning_items = [item for item in converted if item.get("type") == "reasoning"]
+    assert reasoning_items == [{"type": "reasoning", "encrypted_content": "opaque"}]
     assert [item["content"] for item in converted if item.get("role") == "assistant"] == [
         "one",
         "two",

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -10,11 +10,13 @@ import pytest
 import click
 
 from agent.config import load_config
+from agent.provider import LLMProvider
 from agent.model_runtime.auth.codex import CodexAuthDriver
 from agent.model_runtime.auth.store import Credential, CredentialStore
 from agent.model_runtime.errors import (
     AuthenticationError,
     ContextWindowError,
+    QuotaError,
     RateLimitError,
     TransportError,
 )
@@ -22,7 +24,9 @@ from agent.model_runtime.fallback import ResilientLightProvider
 from agent.model_runtime.catalog.codex import CodexModelCatalog
 from agent.model_runtime.context_policy import (
     build_context_budget,
+    recommended_context_settings,
     recommended_memory_window,
+    recommended_output_reserve,
 )
 from agent.model_runtime.transports.responses import (
     CodexResponsesTransport,
@@ -40,6 +44,7 @@ from agent.model_runtime.types import (
 )
 from agent.model_runtime.usage import aggregate_usage
 from agent.config_models import Config, ModelRuntimeConfig
+from agent.looping.ports import MemoryConfig as LoopMemoryConfig
 from bootstrap.providers import build_providers, build_vl_provider
 from bootstrap.setup_wizard import (
     WizardAnswers,
@@ -51,12 +56,19 @@ from session.manager import SessionManager
 from session.store import _decode_message_extra
 
 
-def test_recommended_memory_window_is_bounded() -> None:
+def test_recommended_context_settings_scale_from_one_million_baseline() -> None:
     assert recommended_memory_window(32_000) == 20
     assert recommended_memory_window(64_000) == 40
-    assert recommended_memory_window(128_000) == 80
-    assert recommended_memory_window(272_000) == 160
-    assert recommended_memory_window(400_000) == 160
+    assert recommended_memory_window(128_000) == 84
+    assert recommended_memory_window(272_000) == 176
+    assert recommended_memory_window(1_000_000) == 640
+    assert recommended_output_reserve(64_000) == 4096
+    assert recommended_output_reserve(272_000) == 8192
+    assert recommended_output_reserve(1_000_000) == 32768
+    assert recommended_context_settings(2_000_000).output_reserve == 32768
+    assert recommended_memory_window(1_000_000, 0.8) == 568
+    assert recommended_memory_window(272_000, 0.95) == 184
+    assert LoopMemoryConfig(window=recommended_memory_window(1_000_000)).keep_count == 640
 
 
 def test_context_budget_reserves_output() -> None:
@@ -68,6 +80,51 @@ def test_context_budget_reserves_output() -> None:
     budget = build_context_budget(capabilities, 8_000)
     assert budget.effective_context == 90_000
     assert budget.input_budget == 82_000
+
+
+def test_runtime_config_rejects_output_reserve_over_effective_context() -> None:
+    with pytest.raises(ValueError, match="max_output_tokens 必须小于有效上下文"):
+        ModelRuntimeConfig(
+            runtime_id="bad",
+            provider="openai",
+            model="model",
+            context_window=10_000,
+            effective_context_percent=0.8,
+            max_output_tokens=8_000,
+        )
+
+
+@pytest.mark.asyncio
+async def test_provider_hashes_session_cache_namespace() -> None:
+    class _Runtime:
+        request: ModelRequest | None = None
+
+        async def send(self, request: ModelRequest):
+            self.request = request
+            from agent.model_runtime.types import LLMResponse
+
+            return LLMResponse(content="ok")
+
+    provider = LLMProvider(
+        api_key="key",
+        provider_name="openai",
+        runtime_id="main",
+    )
+    runtime = _Runtime()
+    provider._runtime = runtime  # type: ignore[assignment]
+
+    await provider.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        model="model",
+        max_tokens=100,
+        cache_namespace="web:private-session",
+    )
+
+    assert runtime.request is not None
+    assert runtime.request.prompt_cache_key is not None
+    assert "private-session" not in runtime.request.prompt_cache_key
+    assert len(runtime.request.prompt_cache_key) == 64
 
 
 def test_credential_store_writes_private_atomic_document(tmp_path: Path) -> None:
@@ -107,6 +164,7 @@ def test_codex_catalog_maps_reasoning_context_and_modalities() -> None:
             "display_name": "GPT Test",
             "description": "test",
             "context_window": 272_000,
+            "max_context_window": 1_000_000,
             "effective_context_window_percent": 90,
             "default_reasoning_level": "high",
             "supported_reasoning_levels": [
@@ -115,14 +173,100 @@ def test_codex_catalog_maps_reasoning_context_and_modalities() -> None:
             ],
             "input_modalities": ["text", "image"],
             "supports_parallel_tool_calls": True,
+            "supports_reasoning_summaries": True,
         }
     )
 
     assert model.capabilities.context_window == 272_000
+    assert model.capabilities.max_context_window == 1_000_000
     assert model.capabilities.input_modalities == ("text", "image")
     assert model.capabilities.supported_reasoning_efforts == ("medium", "high")
+    assert model.capabilities.supports_reasoning_summaries is True
     assert model.capabilities.source is CapabilitySource.CATALOG
     assert model.input_modalities_known is True
+
+
+def test_codex_catalog_does_not_invent_reasoning_summary_support() -> None:
+    model = CodexModelCatalog._parse_model(
+        {"slug": "legacy", "context_window": 128_000}
+    )
+
+    assert model.capabilities.supports_reasoning_summaries is False
+
+
+def test_codex_refresh_uses_json_oauth_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = CredentialStore(tmp_path / "auth.json")
+    store.put(
+        "codex_default",
+        Credential(
+            driver="codex",
+            access_token="old",
+            refresh_token="rotation",
+            account_id="account",
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {
+                "access_token": "new",
+                "refresh_token": "next",
+                "expires_in": 3600,
+            }
+
+    def fake_post(url: str, **kwargs: object) -> _Response:
+        captured.update({"url": url, **kwargs})
+        return _Response()
+
+    monkeypatch.setattr("agent.model_runtime.auth.codex.httpx.post", fake_post)
+
+    refreshed = CodexAuthDriver(store, "codex_default").refresh()
+
+    assert refreshed.access_token == "new"
+    assert captured["json"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "rotation",
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+    }
+    assert "data" not in captured
+
+
+def test_codex_refresh_keeps_previous_rotation_token_when_omitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = CredentialStore(tmp_path / "auth.json")
+    store.put(
+        "codex_default",
+        Credential(
+            driver="codex",
+            access_token="old",
+            refresh_token="rotation",
+            account_id="account",
+        ),
+    )
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"access_token": "new", "expires_in": 3600}
+
+    monkeypatch.setattr(
+        "agent.model_runtime.auth.codex.httpx.post",
+        lambda *args, **kwargs: _Response(),
+    )
+
+    refreshed = CodexAuthDriver(store, "codex_default").refresh()
+
+    assert refreshed.access_token == "new"
+    assert refreshed.refresh_token == "rotation"
 
 
 def test_codex_catalog_uses_backend_compatible_client_version() -> None:
@@ -213,6 +357,12 @@ def test_codex_payload_matches_chatgpt_responses_contract() -> None:
     assert "max_output_tokens" not in payload
     assert payload["tool_choice"] == "auto"
     assert payload["parallel_tool_calls"] is True
+    assert payload["extra_body"]["client_metadata"] == {
+        "x-codex-installation-id": transport.installation_id,
+        "session-id": transport.session_id,
+        "thread-id": transport.thread_id,
+        "x-codex-window-id": transport.window_id,
+    }
 
 
 def test_codex_lite_payload_embeds_tools_and_instructions() -> None:
@@ -336,6 +486,72 @@ memory_window = 160
     assert config.context_window == 272_000
     assert config.multimodal is True
     assert config.light_model == ""
+    assert config.reasoning_summary == "auto"
+
+
+def test_codex_runtime_can_explicitly_disable_reasoning_summary(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "codex_main"
+
+[llm.runtimes.codex_main]
+provider = "codex"
+auth = "codex_default"
+model = "gpt-test"
+context_window = 128000
+reasoning_summary = "none"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.reasoning_summary == "none"
+
+
+def test_config_derives_memory_window_from_effective_context(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "codex_main"
+
+[llm.runtimes.codex_main]
+provider = "codex"
+auth = "codex_default"
+model = "gpt-test"
+context_window = 272000
+effective_context_percent = 0.95
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.memory_window == 184
+
+
+def test_runtime_config_persists_max_context_window(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "codex_main"
+[llm.runtimes.codex_main]
+provider = "codex"
+auth = "codex_default"
+model = "gpt-test"
+context_window = 272000
+max_context_window = 1000000
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config.model_runtimes["codex_main"].max_context_window == 1_000_000
 
 
 def test_runtime_config_rejects_unknown_reasoning_summary(tmp_path: Path) -> None:
@@ -385,7 +601,9 @@ async def test_responses_stream_builds_tool_usage_and_reasoning_state() -> None:
 
     async def events():
         yield {"type": "response.reasoning_summary_text.delta", "delta": "分析"}
-        yield {"type": "response.output_text.delta", "delta": "结果"}
+        yield {"type": "response.reasoning_text.delta", "delta": "过程"}
+        yield {"type": "response.output_text.delta", "delta": "结"}
+        yield {"type": "response.output_text.done", "text": "结果"}
         yield {
             "type": "response.output_item.done",
             "item": {
@@ -423,7 +641,7 @@ async def test_responses_stream_builds_tool_usage_and_reasoning_state() -> None:
     )
 
     assert result.content == "结果"
-    assert result.thinking == "分析"
+    assert result.thinking == "分析过程"
     assert result.tool_calls[0].arguments == {"q": "x"}
     assert result.cache_hit_tokens == 20
     assert result.continuation is not None
@@ -454,6 +672,9 @@ async def test_responses_stream_rejects_eof_before_completed() -> None:
     [
         ("context_length_exceeded", ContextWindowError),
         ("rate_limit_exceeded", RateLimitError),
+        ("insufficient_quota", QuotaError),
+        ("server_error", TransportError),
+        ("invalid_prompt", TransportError),
     ],
 )
 async def test_responses_stream_classifies_terminal_errors(
@@ -785,10 +1006,14 @@ def test_setup_api_key_named_runtimes_load_and_build_end_to_end(
         fast_api_key="fast-secret",
         fast_auth_id="fast_default",
         fast_base_url="https://fast.example/v1",
+        fast_context_window=32_000,
+        fast_max_output_tokens=2048,
         vl_model="vl-model",
         vl_api_key="vl-secret",
         vl_auth_id="vl_default",
         vl_base_url="https://vl.example/v1",
+        vl_context_window=128_000,
+        vl_max_output_tokens=4096,
         embed_model="embed-model",
         embed_api_key="embed-secret",
         embed_auth_id="embedding_default",
@@ -806,6 +1031,10 @@ def test_setup_api_key_named_runtimes_load_and_build_end_to_end(
     assert config.runtime_id == "main"
     assert config.fast_runtime_id == "fast"
     assert config.vl_runtime_id == "vl"
+    assert config.model_runtimes["fast"].context_window == 32_000
+    assert config.model_runtimes["fast"].max_output_tokens == 2048
+    assert config.model_runtimes["vl"].context_window == 128_000
+    assert config.model_runtimes["vl"].max_output_tokens == 4096
     assert (
         config.model_runtimes["main"].provider,
         config.model_runtimes["main"].auth,

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -120,6 +120,15 @@ def test_codex_catalog_maps_reasoning_context_and_modalities() -> None:
     assert model.input_modalities_known is True
 
 
+def test_codex_catalog_uses_backend_compatible_client_version() -> None:
+    class _Auth:
+        pass
+
+    catalog = CodexModelCatalog(_Auth())  # type: ignore[arg-type]
+
+    assert catalog.client_version == "0.0.0"
+
+
 def test_responses_adapter_preserves_tools_and_usage() -> None:
     messages, instructions = _responses_input(
         [

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import asyncio
+import httpx
 import json
 import runpy
 import sys
@@ -19,6 +20,7 @@ from agent.plugins.manager import ActivePluginInfo
 from agent.provider import (
     ContextLengthError,
     ContentSafetyError,
+    LLMNetworkTimeoutError,
     LLMProvider,
     _normalize_openai_base_url,
 )
@@ -85,7 +87,10 @@ class _FakeStream:
             raise StopAsyncIteration
         if self._delay_s:
             await asyncio.sleep(self._delay_s)
-        return self._chunks.pop(0)
+        chunk = self._chunks.pop(0)
+        if isinstance(chunk, BaseException):
+            raise chunk
+        return chunk
 
     async def close(self) -> None:
         self.closed = True
@@ -95,7 +100,7 @@ class _FakeStream:
 async def test_provider_chat_and_retry_paths(monkeypatch: pytest.MonkeyPatch):
     fake = _FakeClient(
         [
-            RuntimeError("timeout"),
+            httpx.ReadTimeout("request idle"),
             _Response(
                 content="done",
                 tool_calls=[_ToolCall("1", "search", {"q": "x"})],
@@ -114,7 +119,6 @@ async def test_provider_chat_and_retry_paths(monkeypatch: pytest.MonkeyPatch):
         base_url="https://example.com",
         system_prompt="system",
         extra_body={"x": 1},
-        request_timeout_s=3,
         max_retries=1,
     )
     result = await provider.chat(
@@ -195,6 +199,84 @@ async def test_provider_chat_and_retry_paths(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
     with pytest.raises(RuntimeError):
         await LLMProvider(api_key="k", max_retries=0).chat([], [], "m", 1)
+
+
+@pytest.mark.asyncio
+async def test_provider_create_has_no_internal_total_wait_for(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _FakeClient([_Response(content="ok")])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+
+    async def _reject_wait_for(*_args, **_kwargs):
+        raise AssertionError("provider 不应拥有业务总时限")
+
+    monkeypatch.setattr("agent.provider.asyncio.wait_for", _reject_wait_for)
+
+    result = await LLMProvider(api_key="k").chat([], [], "m", 1)
+
+    assert result.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_provider_outer_deadline_cancels_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    calls = 0
+
+    async def _blocking_create(**_kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.set()
+
+    fake = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_blocking_create))
+    )
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    provider = LLMProvider(api_key="k", max_retries=2)
+
+    task = asyncio.create_task(provider.chat([], [], "m", 1))
+    await started.wait()
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(task, timeout=0.01)
+
+    assert cancelled.is_set()
+    assert calls == 1
+
+
+def test_provider_configures_sdk_network_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+
+    def _build_client(**kwargs):
+        captured.update(kwargs)
+        return _FakeClient([])
+
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", _build_client)
+
+    LLMProvider(
+        api_key="k",
+        connect_timeout_s=3,
+        read_timeout_s=4,
+        write_timeout_s=5,
+        pool_timeout_s=6,
+    )
+
+    timeout = cast(httpx.Timeout, captured["timeout"])
+    assert (timeout.connect, timeout.read, timeout.write, timeout.pool) == (
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+    )
+    assert captured["max_retries"] == 0
 
 
 def test_normalize_openai_base_url_trims_endpoint_suffix():
@@ -381,28 +463,15 @@ async def test_provider_chat_stream_extracts_openai_cached_tokens(
 
 
 @pytest.mark.asyncio
-async def test_provider_chat_stream_times_out_when_idle(
+async def test_provider_chat_stream_propagates_sdk_read_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    stream = _FakeStream(
-        [
-            SimpleNamespace(
-                choices=[
-                    SimpleNamespace(delta=SimpleNamespace(content="慢", tool_calls=[]))
-                ]
-            )
-        ],
-        delay_s=0.05,
-    )
+    stream = _FakeStream([httpx.ReadTimeout("stream idle")])
     fake = _FakeClient([stream])
     monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
 
-    provider = LLMProvider(
-        api_key="k",
-        stream_idle_timeout_s=0.01,
-        max_retries=0,
-    )
-    with pytest.raises(asyncio.TimeoutError):
+    provider = LLMProvider(api_key="k", read_timeout_s=0.01, max_retries=0)
+    with pytest.raises(LLMNetworkTimeoutError, match="流读取网络超时") as exc_info:
         await provider.chat(
             messages=[{"role": "user", "content": "hi"}],
             tools=[],
@@ -410,6 +479,7 @@ async def test_provider_chat_stream_times_out_when_idle(
             max_tokens=10,
             on_content_delta=lambda chunk: _collect_delta([], chunk),
         )
+    assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
     assert stream.closed is True
 
 
@@ -500,7 +570,7 @@ async def test_provider_stream_closes_when_delta_callback_fails(
     assert stream.closed is True
 
 
-def test_bootstrap_providers_set_stream_idle_timeout(
+def test_bootstrap_providers_set_network_read_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ):
     created: list[dict] = []
@@ -533,7 +603,7 @@ def test_bootstrap_providers_set_stream_idle_timeout(
     build_providers(cfg)
     build_vl_provider(cfg)
 
-    assert [item["stream_idle_timeout_s"] for item in created] == [
+    assert [item["read_timeout_s"] for item in created] == [
         120.0,
         60.0,
         120.0,

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -659,6 +659,30 @@ async def test_deepseek_strategy_disables_thinking(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_deepseek_named_tool_choice_disables_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _FakeClient([_Response(content="ok")])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    provider = LLMProvider(
+        api_key="k",
+        provider_name="deepseek",
+        extra_body={"enable_thinking": True, "reasoning_effort": "high"},
+    )
+
+    await provider.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "probe"}}],
+        model="deepseek-v4-pro",
+        max_tokens=10,
+        tool_choice={"type": "function", "function": {"name": "probe"}},
+    )
+
+    assert fake.calls[-1]["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert "reasoning_effort" not in fake.calls[-1]
+
+
+@pytest.mark.asyncio
 async def test_token_plan_strategy_disables_thinking(monkeypatch: pytest.MonkeyPatch):
     fake = _FakeClient([_Response(content="ok")])
     monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -714,8 +714,8 @@ def test_init_workspace_creates_expected_assets(tmp_path):
 
     assert config_path.exists()
     config_text = config_path.read_text(encoding="utf-8")
-    assert "multimodal = false" in config_text
-    assert "[llm.vl]" in config_text
+    assert 'input_modalities = ["text"]' in config_text
+    assert "[llm.runtimes.qwen_vl]" in config_text
     assert 'model = "qwen-vl-plus"' in config_text
     assert "[channels.chat]" in config_text
     assert "port = 6322" in config_text

--- a/tests/test_setup_main.py
+++ b/tests/test_setup_main.py
@@ -74,6 +74,7 @@ def _api_answers() -> WizardAnswers:
         auth_id="main_default",
         base_url="https://new.example/v1",
         context_window=64_000,
+        max_context_window=128_000,
         max_output_tokens=8192,
         memory_window=40,
     )
@@ -88,6 +89,7 @@ def test_patch_main_preserves_non_main_config_and_comments() -> None:
     assert parsed["llm"]["agent"] == "agent"
     assert parsed["llm"]["vl"] == "vl"
     assert parsed["llm"]["runtimes"]["api_main"]["model"] == "new-main"
+    assert parsed["llm"]["runtimes"]["api_main"]["max_context_window"] == 128_000
     assert parsed["agent"]["context"]["memory_window"] == 40
     assert parsed["agent"]["max_tokens"] == 777
     assert "# fast 注释必须原样保留" in updated
@@ -153,6 +155,9 @@ def test_codex_phase_reuses_existing_auth_by_default(
         supported_reasoning_efforts=(),
         default_reasoning_effort="",
         context_window=128_000,
+        max_context_window=1_000_000,
+        max_output_tokens=32_768,
+        effective_context_percent=0.95,
         input_modalities=("text",),
         use_responses_lite=False,
         supports_parallel_tool_calls=True,
@@ -189,4 +194,7 @@ def test_codex_phase_reuses_existing_auth_by_default(
     assert login_started is False
     assert answers.model == "gpt-test"
     assert answers.context_window == 128_000
+    assert answers.max_context_window == 1_000_000
+    assert answers.effective_context_percent == 0.95
+    assert answers.max_output_tokens == 4096
     assert answers.reasoning_summary == "auto"

--- a/tests/test_setup_main.py
+++ b/tests/test_setup_main.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.config import load_config
+from agent.model_runtime.auth import Credential, CredentialStore
+from bootstrap.setup_main import patch_main_model_config, run_main_model_setup
+from bootstrap.setup_wizard import WizardAnswers, _phase_codex_llm
+
+
+_CONFIG = """\
+# 顶部说明必须保留
+[llm]
+main = "old_main" # 当前主模型
+fast = "fast"
+agent = "agent"
+vl = "vl"
+
+[llm.runtimes.old_main]
+provider = "openai"
+model = "old-model"
+api_key = "old-secret"
+base_url = "https://old.example/v1"
+context_window = 32000
+
+# fast 注释必须原样保留
+[llm.runtimes.fast]
+provider = "openai"
+model = "fast-model"
+api_key = "fast-secret"
+base_url = "https://fast.example/v1"
+context_window = 16000
+
+[llm.runtimes.agent]
+provider = "openai"
+model = "agent-model"
+api_key = "agent-secret"
+base_url = "https://agent.example/v1"
+context_window = 64000
+
+[llm.runtimes.vl]
+provider = "openai"
+model = "vl-model"
+api_key = "vl-secret"
+base_url = "https://vl.example/v1"
+context_window = 64000
+input_modalities = ["text", "image"]
+
+[agent]
+max_tokens = 777 # 不由 setup-main 修改
+
+[agent.context]
+memory_window = 20 # 根据主上下文更新
+
+[channels.telegram]
+enabled = false
+token = "telegram-stays"
+
+# plugin/default-memory 自定义配置文本
+[plugins.custom]
+enabled = true
+"""
+
+
+def _api_answers() -> WizardAnswers:
+    return WizardAnswers(
+        provider="openai",
+        model="new-main",
+        api_key="new-secret",
+        auth_id="main_default",
+        base_url="https://new.example/v1",
+        context_window=64_000,
+        max_output_tokens=8192,
+        memory_window=40,
+    )
+
+
+def test_patch_main_preserves_non_main_config_and_comments() -> None:
+    updated = patch_main_model_config(_CONFIG, _api_answers())
+    parsed = tomllib.loads(updated)
+
+    assert parsed["llm"]["main"] == "api_main"
+    assert parsed["llm"]["fast"] == "fast"
+    assert parsed["llm"]["agent"] == "agent"
+    assert parsed["llm"]["vl"] == "vl"
+    assert parsed["llm"]["runtimes"]["api_main"]["model"] == "new-main"
+    assert parsed["agent"]["context"]["memory_window"] == 40
+    assert parsed["agent"]["max_tokens"] == 777
+    assert "# fast 注释必须原样保留" in updated
+    assert 'token = "telegram-stays"' in updated
+    assert "# plugin/default-memory 自定义配置文本" in updated
+    assert "new-secret" not in updated
+
+
+def test_patch_main_is_idempotent_without_duplicate_runtime() -> None:
+    once = patch_main_model_config(_CONFIG, _api_answers())
+    twice = patch_main_model_config(once, _api_answers())
+
+    assert twice == once
+    assert twice.count("[llm.runtimes.api_main]") == 1
+    assert tomllib.loads(twice)["llm"]["main"] == "api_main"
+
+
+def test_run_main_setup_backs_up_and_only_rewrites_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_CONFIG, encoding="utf-8")
+    original = config_path.read_text(encoding="utf-8")
+
+    def fill_answers(answers: WizardAnswers, **_: object) -> None:
+        selected = _api_answers()
+        answers.__dict__.update(selected.__dict__)
+
+    monkeypatch.setattr("bootstrap.setup_main._phase_main_llm", fill_answers)
+
+    run_main_model_setup(config_path)
+
+    backup = tmp_path / "config.toml.before-setup-main.bak"
+    assert backup.read_text(encoding="utf-8") == original
+    config = load_config(config_path)
+    assert config.runtime_id == "api_main"
+    assert config.model == "new-main"
+    assert config.fast_runtime_id == "fast"
+    assert CredentialStore().get("main_default").access_token == "new-secret"
+
+
+def test_codex_phase_reuses_existing_auth_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CredentialStore().put(
+        "codex_default",
+        Credential(driver="codex", access_token="existing-token"),
+    )
+    login_started = False
+
+    class FakeAuth:
+        def __init__(self, store: CredentialStore, credential_id: str) -> None:
+            assert credential_id == "codex_default"
+
+        def begin_device_login(self):
+            nonlocal login_started
+            login_started = True
+            raise AssertionError("不应重新登录")
+
+    capabilities = SimpleNamespace(
+        supported_reasoning_efforts=(),
+        default_reasoning_effort="",
+        context_window=128_000,
+        input_modalities=("text",),
+    )
+    model = SimpleNamespace(
+        slug="gpt-test",
+        capabilities=capabilities,
+        input_modalities_known=True,
+    )
+
+    class FakeCatalog:
+        def __init__(self, auth: FakeAuth) -> None:
+            pass
+
+        async def list_models(self):
+            return [model]
+
+    monkeypatch.setattr("agent.model_runtime.auth.CodexAuthDriver", FakeAuth)
+    monkeypatch.setattr("agent.model_runtime.catalog.CodexModelCatalog", FakeCatalog)
+    monkeypatch.setattr(
+        "bootstrap.setup_wizard.click.prompt",
+        lambda _text, **kwargs: kwargs.get("default", ""),
+    )
+    monkeypatch.setattr(
+        "bootstrap.setup_wizard.click.confirm",
+        lambda _text, *, default=False: default,
+    )
+    answers = WizardAnswers()
+
+    _phase_codex_llm(answers, reuse_existing_auth=True)
+
+    assert login_started is False
+    assert answers.model == "gpt-test"
+    assert answers.context_window == 128_000

--- a/tests/test_setup_main.py
+++ b/tests/test_setup_main.py
@@ -154,6 +154,10 @@ def test_codex_phase_reuses_existing_auth_by_default(
         default_reasoning_effort="",
         context_window=128_000,
         input_modalities=("text",),
+        use_responses_lite=False,
+        supports_parallel_tool_calls=True,
+        supports_reasoning_summaries=True,
+        default_reasoning_summary="none",
     )
     model = SimpleNamespace(
         slug="gpt-test",
@@ -185,3 +189,4 @@ def test_codex_phase_reuses_existing_auth_by_default(
     assert login_started is False
     assert answers.model == "gpt-test"
     assert answers.context_window == 128_000
+    assert answers.reasoning_summary == "auto"

--- a/tests_scenarios/model_runtime_live_probe.py
+++ b/tests_scenarios/model_runtime_live_probe.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+from pathlib import Path
+
+from agent.config import Config
+from agent.provider import LLMProvider, LLMResponse
+from bootstrap.providers import build_providers
+
+
+def _tools() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "probe_add",
+                "description": "Add two integers.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"},
+                    },
+                    "required": ["a", "b"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "probe_echo",
+                "description": "Echo text.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    ]
+
+
+async def _call(
+    provider: LLMProvider,
+    config: Config,
+    messages: list[dict],
+    *,
+    tools: list[dict] | None = None,
+    tool_choice: str | dict = "auto",
+    disable_thinking: bool = False,
+    reasoning_effort: str | None = None,
+    stream: bool = False,
+) -> tuple[LLMResponse, list[str]]:
+    """发送单次真实请求并记录 delta 类型。"""
+    delta_types: list[str] = []
+
+    async def on_delta(delta: dict[str, str]) -> None:
+        delta_types.extend(delta)
+
+    response = await provider.chat(
+        messages=messages,
+        tools=tools or [],
+        model=config.model,
+        max_tokens=min(config.max_tokens, 1024),
+        tool_choice=tool_choice,
+        extra_body=(
+            {"reasoning_effort": reasoning_effort}
+            if reasoning_effort is not None
+            else None
+        ),
+        disable_thinking=disable_thinking,
+        on_content_delta=on_delta if stream else None,
+        cache_namespace="model-runtime-live-probe",
+    )
+    return response, delta_types
+
+
+def _assistant_tool_message(response: LLMResponse) -> dict:
+    message: dict[str, object] = {
+        "role": "assistant",
+        "content": response.content or "",
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": json.dumps(call.arguments),
+                },
+            }
+            for call in response.tool_calls
+        ],
+    }
+    message.update(response.provider_fields)
+    return message
+
+
+def _usage(response: LLMResponse) -> dict[str, int | str | None]:
+    usage = response.usage
+    return {
+        "input": usage.input_tokens if usage else None,
+        "cached": usage.cached_input_tokens if usage else None,
+        "output": usage.output_tokens if usage else None,
+        "reasoning": usage.reasoning_output_tokens if usage else None,
+        "coverage": usage.coverage.value if usage else None,
+    }
+
+
+async def run_probe(config_path: Path, expected_provider: str) -> dict[str, object]:
+    """覆盖文本、推理、流式、工具、续接、缓存和图片请求。"""
+
+    # 1. 从真实配置装配统一 provider。
+    config = Config.load(config_path)
+    if config.provider != expected_provider:
+        raise ValueError(
+            f"provider 不匹配: expected={expected_provider} actual={config.provider}"
+        )
+    provider, _, _ = build_providers(config)
+    base_messages = [{"role": "user", "content": "Reply with exactly: probe-ok"}]
+
+    # 2. 覆盖普通、流式、推理强度和关闭推理。
+    plain, _ = await _call(provider, config, base_messages)
+    streamed, delta_types = await _call(
+        provider,
+        config,
+        base_messages,
+        reasoning_effort="low",
+        stream=True,
+    )
+    disabled, _ = await _call(
+        provider,
+        config,
+        base_messages,
+        disable_thinking=True,
+    )
+
+    # 3. 强制命名工具并回放 tool output，验证 continuation。
+    tool_messages = [
+        {
+            "role": "user",
+            "content": (
+                "First call probe_add with a=2 and b=3. After receiving the tool result, "
+                "reply with exactly: result=5"
+            ),
+        }
+    ]
+    tool_response, _ = await _call(
+        provider,
+        config,
+        tool_messages,
+        tools=_tools(),
+        tool_choice={"type": "function", "function": {"name": "probe_add"}},
+    )
+    if len(tool_response.tool_calls) != 1:
+        raise RuntimeError("命名 tool_choice 未返回单个工具调用")
+    call = tool_response.tool_calls[0]
+    continuation_messages = [
+        *tool_messages,
+        _assistant_tool_message(tool_response),
+        {
+            "role": "tool",
+            "tool_call_id": call.id,
+            "name": call.name,
+            "content": "5",
+        },
+    ]
+    continued, _ = await _call(
+        provider,
+        config,
+        continuation_messages,
+        tools=_tools(),
+        tool_choice="none",
+    )
+
+    # 4. 重复稳定前缀以读取厂商真实缓存 usage。
+    cache_messages = [
+        {
+            "role": "user",
+            "content": f"{'stable-cache-prefix ' * 800}\nReply with exactly: cache-ok",
+        }
+    ]
+    cache_first, _ = await _call(provider, config, cache_messages)
+    cache_second, _ = await _call(provider, config, cache_messages)
+
+    # 5. 仅对声明支持图片的 runtime 发送一张 1x1 PNG。
+    image_ok: bool | None = None
+    if config.multimodal:
+        png = base64.b64encode(
+            base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+            )
+        ).decode()
+        image_response, _ = await _call(
+            provider,
+            config,
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image in one word."},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{png}"},
+                        },
+                    ],
+                }
+            ],
+        )
+        image_ok = bool(image_response.content)
+
+    return {
+        "provider": config.provider,
+        "model": config.model,
+        "plain": bool(plain.content),
+        "stream": bool(streamed.content),
+        "delta_types": sorted(set(delta_types)),
+        "reasoning_visible": bool(
+            streamed.thinking or tool_response.thinking or continued.thinking
+        ),
+        "disable_thinking_reply": bool(disabled.content),
+        "tool": call.name,
+        "tool_arguments": call.arguments,
+        "continuation": bool(continued.content),
+        "continuation_content": continued.content,
+        "continuation_thinking": continued.thinking,
+        "continuation_tools": [item.name for item in continued.tool_calls],
+        "continuation_state": bool(tool_response.provider_fields.get("model_state")),
+        "cache_first": _usage(cache_first),
+        "cache_second": _usage(cache_second),
+        "image": image_ok,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--provider", required=True)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            asyncio.run(run_probe(args.config, args.provider)),
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 问题

现有模型调用链围绕 DeepSeek Chat Completions 构建，无法直接使用 Codex OAuth/Responses，模型上下文、推理摘要、多模态、缓存和 light fallback 也缺少统一契约。

## 范围

- 引入可扩展 auth / catalog / transport / runtime 分层，支持 Codex device auth 与 ChatGPT Responses。
- 增加 `setup-main` 主模型切换入口；只修改 `[llm].main` 即可在已配置 runtime 间切换。
- 按 1M 上下文基准等比例推导 history window 与输出预留，并保留显式覆盖。
- 支持 Codex reasoning summary、工具 continuation、图片输入、client metadata 和缓存 usage。
- 保持 DeepSeek thinking/stream/cache 行为；命名 tool choice 自动关闭不兼容的 thinking。
- light model 仅在连接、限流和服务端瞬时故障时回退主模型；额度、策略和非法请求继续 fail-loud。

## 配置影响

新增 named runtimes、`context_window`、`max_context_window`、`effective_context_percent`、`max_output_tokens` 与 `input_modalities`。旧 DeepSeek 配置继续兼容；`agent.context.memory_window` 显式配置仍优先。

## 验证

- `.venv/bin/pytest -q tests/`：2017 passed
- `.venv/bin/pyright <changed-files>`：0 errors
- `git diff --check`：通过
- Docker/debug 真实 Codex：文本、流式、reasoning summary、命名工具、continuation、缓存命中、图片输入通过
- Docker/debug 真实 DeepSeek：文本、流式 reasoning_content、thinking 开关、命名工具、continuation、缓存命中通过
