### PR TITLE
refactor(mcp): unify generation snapshot ownership

### DIFF
--- a/agent/mcp/generation.py
+++ b/agent/mcp/generation.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from agent.mcp.host import PreparedMcpCatalog
+from agent.plugins.scope import PluginScope
+
+if TYPE_CHECKING:
+    from agent.plugins.snapshot import RuntimeSnapshot
+
+
+@dataclass
+class WorkspaceMcpGeneration:
+    generation_id: str
+    revision: str
+    scope: PluginScope
+    catalog: PreparedMcpCatalog
+    runtime_snapshot: RuntimeSnapshot | None = None
+    state: str = "prepared"
+    lease_count: int = 0

--- a/agent/mcp/host.py
+++ b/agent/mcp/host.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from collections.abc import Mapping
 from typing import Any
 
 from agent.mcp.client import McpClient
 from agent.mcp.tool import McpToolWrapper
 from agent.plugins.scope import PluginScope
-from agent.plugins.specs import RegisteredProactiveSource
 
 
 @dataclass(frozen=True)
@@ -34,7 +33,9 @@ class PreparedMcpCatalog:
         )
 
 
-class PluginMcpHost:
+class McpGenerationHost:
+    """准备并按代际持有 MCP catalog。"""
+
     def __init__(self) -> None:
         self._catalogs: dict[str, PreparedMcpCatalog] = {}
 
@@ -42,10 +43,13 @@ class PluginMcpHost:
         self,
         generation_id: str,
         *,
-        server_specs: dict[str, dict[str, Any]],
-        proactive_sources: tuple[RegisteredProactiveSource, ...],
+        server_specs: Mapping[str, Mapping[str, Any]],
+        required_tools: Mapping[str, tuple[str, ...]],
         scope: PluginScope,
     ) -> PreparedMcpCatalog:
+        """连接候选 MCP，并在完整校验后登记 catalog。"""
+
+        # 1. 连接全部候选 server，并立即把客户端纳入作用域清理
         servers: dict[str, PreparedMcpServer] = {}
         for server_name, spec in sorted(server_specs.items()):
             client = McpClient(
@@ -67,7 +71,9 @@ class PluginMcpHost:
                     for info in infos
                 ),
             )
-        self._validate_sources(servers, proactive_sources)
+
+        # 2. 验证上层声明依赖的远端工具，再发布不可变 catalog
+        self._validate_required_tools(servers, required_tools)
         catalog = PreparedMcpCatalog(
             generation_id=generation_id,
             servers=MappingProxyType(servers),
@@ -90,30 +96,28 @@ class PluginMcpHost:
             _ = self._catalogs.pop(generation_id, None)
         if failures:
             raise RuntimeError(
-                "MCP catalog 清理失败: "
-                + "; ".join(str(error) for error in failures)
+                "MCP catalog 清理失败: " + "; ".join(str(error) for error in failures)
             )
 
     def get(self, generation_id: str) -> PreparedMcpCatalog | None:
         return self._catalogs.get(generation_id)
 
     @staticmethod
-    def _validate_sources(
+    def _validate_required_tools(
         servers: Mapping[str, PreparedMcpServer],
-        sources: tuple[RegisteredProactiveSource, ...],
+        required_tools: Mapping[str, tuple[str, ...]],
     ) -> None:
         missing: list[str] = []
-        for source in sources:
-            server = servers.get(source.spec.server)
+        for server_name, tool_names in required_tools.items():
+            server = servers.get(server_name)
             if server is None:
-                missing.append(f"{source.spec.id}:server:{source.spec.server}")
+                missing.append(f"server:{server_name}")
                 continue
             available = set(server.remote_tool_names)
-            for role, tool_name in (
-                ("fetch", source.spec.fetch_tool),
-                ("ack", source.spec.ack_tool),
-            ):
-                if tool_name and tool_name not in available:
-                    missing.append(f"{source.spec.id}:{role}:{tool_name}")
+            missing.extend(
+                f"{server_name}:{tool_name}"
+                for tool_name in tool_names
+                if tool_name not in available
+            )
         if missing:
-            raise RuntimeError(f"proactive source MCP tool 缺失: {', '.join(missing)}")
+            raise RuntimeError(f"MCP 依赖工具缺失: {', '.join(missing)}")

--- a/agent/mcp/registry.py
+++ b/agent/mcp/registry.py
@@ -5,9 +5,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from agent.mcp.client import McpClient, McpToolInfo
+from agent.mcp.client import McpClient
 from agent.mcp.tool import McpToolWrapper
-from agent.plugins.manager import ActivePluginInfo
 from agent.tools.registry import ToolRegistry
 from infra.persistence.json_store import atomic_save_json, load_json
 
@@ -35,7 +34,6 @@ class McpServerRegistry:
         self._server_tools: dict[str, list[str]] = (
             {}
         )  # server_name -> 已注册的工具名列表
-        self._plugin_server_names: set[str] = set()
         self._connect_task: asyncio.Task[None] | None = None
 
     async def load_and_connect_all(self) -> None:
@@ -71,44 +69,10 @@ class McpServerRegistry:
         clients = list(self._clients.values())
         self._clients.clear()
         self._server_tools.clear()
-        self._plugin_server_names.clear()
         await asyncio.gather(
             *(client.disconnect() for client in clients),
             return_exceptions=True,
         )
-
-    async def sync_plugin_servers(
-        self,
-        active_plugins: list[ActivePluginInfo],
-    ) -> None:
-        desired: dict[str, dict[str, Any]] = {}
-        for plugin in active_plugins:
-            for server_name, config in plugin.mcp_servers.items():
-                if server_name in desired:
-                    logger.warning("[mcp] 插件 MCP server 名称冲突，保留第一项: %s", server_name)
-                    continue
-                desired[server_name] = config
-
-        for server_name in sorted(self._plugin_server_names - desired.keys()):
-            await self._disconnect_server(server_name)
-            self._plugin_server_names.discard(server_name)
-
-        for server_name in sorted(desired.keys() - self._plugin_server_names):
-            if server_name in self._clients:
-                logger.warning("[mcp] 插件 MCP server 已存在，跳过: %s", server_name)
-                continue
-            config = desired[server_name]
-            try:
-                await self._connect(
-                    server_name,
-                    list(config.get("command") or []),
-                    dict(config.get("env") or {}),
-                    str(config.get("cwd") or "") or None,
-                )
-            except Exception as e:
-                logger.warning("[mcp] 插件 MCP server 启动失败 (%s): %s", server_name, e)
-                continue
-            self._plugin_server_names.add(server_name)
 
     async def add(
         self,
@@ -133,7 +97,6 @@ class McpServerRegistry:
         if name not in self._clients:
             return f"MCP server {name!r} 不存在，当前已注册：{list(self._clients.keys()) or '无'}"
         await self._disconnect_server(name)
-        self._plugin_server_names.discard(name)
         self._save()
         return f"已注销 MCP server {name!r}。"
 
@@ -239,7 +202,6 @@ class McpServerRegistry:
                 "cwd": client.cwd,
             }
             for name, client in self._clients.items()
-            if name not in self._plugin_server_names
         }
         atomic_save_json(
             self._config_path,

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from agent.plugins.specs import RegisteredProactiveSource
     from infra.channels.contract import Channel
     from agent.plugins.skill_host import PreparedSkillCatalog
-    from agent.plugins.mcp_host import PreparedMcpCatalog
+    from agent.mcp.host import PreparedMcpCatalog
     from agent.plugins.activity_host import PreparedJobCatalog, PreparedProactiveCatalog
     from agent.plugins.snapshot import RuntimeSnapshot
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -14,7 +14,7 @@ import tomllib
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import MappingProxyType
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, ValidationError
@@ -63,7 +63,8 @@ from agent.plugins.generation import (
 )
 from agent.plugins.importer import FreshPluginImporter
 from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
-from agent.plugins.mcp_host import PluginMcpHost, PreparedMcpCatalog
+from agent.mcp.generation import WorkspaceMcpGeneration
+from agent.mcp.host import McpGenerationHost, PreparedMcpCatalog
 from agent.plugins.activity_host import (
     PluginJobHost,
     PluginProactiveHost,
@@ -211,7 +212,9 @@ class PluginManager:
         self._fresh_importer = FreshPluginImporter()
         self._manager_namespace = secrets.token_hex(4)
         self._skill_host = PluginSkillHost(workspace)
-        self._mcp_host = PluginMcpHost()
+        self._mcp_host = McpGenerationHost()
+        self._active_workspace_mcp: WorkspaceMcpGeneration | None = None
+        self._prepared_workspace_mcp: WorkspaceMcpGeneration | None = None
         self._job_host = PluginJobHost()
         self._proactive_host = PluginProactiveHost()
         self._snapshot_compiler = RuntimeSnapshotCompiler()
@@ -316,6 +319,138 @@ class PluginManager:
 
     def mcp_catalog(self, generation_id: str) -> PreparedMcpCatalog | None:
         return self._mcp_host.get(generation_id)
+
+    @property
+    def active_workspace_mcp(self) -> WorkspaceMcpGeneration | None:
+        return self._active_workspace_mcp
+
+    @property
+    def prepared_workspace_mcp(self) -> WorkspaceMcpGeneration | None:
+        return self._prepared_workspace_mcp
+
+    async def prepare_workspace_mcp(
+        self,
+        server_specs: dict[str, dict[str, Any]],
+        *,
+        revision: str,
+    ) -> WorkspaceMcpGeneration:
+        """准备 workspace MCP 候选，不改变当前运行快照。"""
+
+        async with self._candidate_prepare_lock:
+            await self._discard_workspace_mcp_candidate()
+            self._check_workspace_mcp_name_conflicts(server_specs)
+
+            # 1. 完整连接候选 catalog，任何失败都回收候选作用域
+            self._generation_sequence += 1
+            generation_id = (
+                f"workspace-mcp:{self._generation_sequence}:{secrets.token_hex(4)}"
+            )
+            scope = PluginScope("workspace-mcp")
+            try:
+                catalog = await self._mcp_host.prepare(
+                    generation_id,
+                    server_specs=server_specs,
+                    required_tools={},
+                    scope=scope,
+                )
+                scope.defer(
+                    "mcp_catalog",
+                    lambda: self._mcp_host.close(generation_id),
+                )
+            except BaseException:
+                cleanup_failures = await scope.aclose()
+                self._cleanup_failures.extend(cleanup_failures)
+                raise
+
+            # 2. 基于锁内最新插件 generations 编译候选 snapshot
+            generation = WorkspaceMcpGeneration(
+                generation_id=generation_id,
+                revision=revision,
+                scope=scope,
+                catalog=catalog,
+            )
+            try:
+                generation.runtime_snapshot = self._compile_workspace_mcp_snapshot(
+                    generation
+                )
+            except BaseException:
+                await self._dispose_workspace_mcp(generation, state="rejected")
+                raise
+            self._prepared_workspace_mcp = generation
+            return generation
+
+    async def publish_workspace_mcp(self) -> WorkspaceMcpGeneration:
+        """原子发布 workspace MCP 候选，并让旧代际随 lease 排空。"""
+
+        async with self._candidate_prepare_lock:
+            generation = self._prepared_workspace_mcp
+            if generation is None or generation.runtime_snapshot is None:
+                raise RuntimeError("workspace MCP 没有可发布候选")
+            try:
+                self._check_workspace_mcp_name_conflicts(generation.catalog.servers)
+                snapshot = self._compile_workspace_mcp_snapshot(generation)
+                generation.runtime_snapshot = snapshot
+                self._validate_workspace_mcp_generation(generation)
+            except BaseException:
+                await self._discard_workspace_mcp_candidate()
+                raise
+
+            # 1. 首个快照直接安装；已有快照使用可回滚发布事务
+            if self._snapshot_store.current is None:
+                self._snapshot_store.install(snapshot)
+            else:
+                transaction = self._snapshot_store.begin_publish(snapshot)
+                try:
+                    await self._post_snapshot_invariants(snapshot)
+                except BaseException:
+                    self._prepared_workspace_mcp = None
+                    await _complete_critical(self._snapshot_store.abort(transaction))
+                    raise
+                self._active_workspace_mcp = generation
+                self._prepared_workspace_mcp = None
+                generation.state = "active"
+                _, commit_cancelled = await _complete_critical(
+                    self._snapshot_store.commit(transaction)
+                )
+                if commit_cancelled:
+                    raise asyncio.CancelledError
+                return generation
+
+            self._active_workspace_mcp = generation
+            self._prepared_workspace_mcp = None
+            generation.state = "active"
+            return generation
+
+    async def discard_workspace_mcp_candidate(self) -> None:
+        async with self._candidate_prepare_lock:
+            await self._discard_workspace_mcp_candidate()
+
+    async def _discard_workspace_mcp_candidate(self) -> None:
+        generation = self._prepared_workspace_mcp
+        self._prepared_workspace_mcp = None
+        if generation is None:
+            return
+        await self._dispose_workspace_mcp(generation, state="discarded")
+
+    def _check_workspace_mcp_name_conflicts(
+        self,
+        server_specs: Mapping[str, object],
+    ) -> None:
+        occupied = {
+            server_name
+            for generation in self._active_generations.values()
+            for server_name in generation.contributions.mcp_servers
+        }
+        occupied.update(
+            server_name
+            for generation in self._prepared_generations.values()
+            for server_name in generation.contributions.mcp_servers
+        )
+        conflicts = sorted(occupied.intersection(server_specs))
+        if conflicts:
+            raise RuntimeError(
+                f"workspace MCP 与插件 server 名称冲突: {', '.join(conflicts)}"
+            )
 
     def bind_channel_switcher(
         self,
@@ -594,6 +729,25 @@ class PluginManager:
                     replacement is not None and replacement is not generation
                 ),
             )
+        workspace_mcp = snapshot.workspace_mcp_generation
+        if (
+            workspace_mcp is not None
+            and not self._snapshot_store.workspace_mcp_is_referenced_elsewhere(
+                workspace_mcp,
+                excluding_snapshot_id=snapshot.snapshot_id,
+            )
+        ):
+            await self._dispose_workspace_mcp(workspace_mcp, state=state)
+
+    async def _dispose_workspace_mcp(
+        self,
+        generation: WorkspaceMcpGeneration,
+        *,
+        state: str,
+    ) -> None:
+        cleanup_failures, _ = await _complete_critical(generation.scope.aclose())
+        self._cleanup_failures.extend(cleanup_failures)
+        generation.state = state
 
     async def prepare_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
@@ -821,10 +975,14 @@ class PluginManager:
             snapshot = self._snapshot_compiler.compile(
                 generations,
                 snapshot_revision=catalog_id,
+                workspace_mcp_generation=self._active_workspace_mcp,
             )
             snapshot.skill_catalog_generation_id = catalog_id
             snapshot.plugin_skill_index = catalog.normal_plugins
-            snapshot.tool_registry = self._compile_snapshot_tools(generations)
+            snapshot.tool_registry = self._compile_snapshot_tools(
+                generations,
+                self._active_workspace_mcp,
+            )
             snapshot.tool_hooks = self._compile_snapshot_tool_hooks(generations)
             return snapshot, catalog_id
         except BaseException:
@@ -839,9 +997,38 @@ class PluginManager:
         generation = self._prepared_generations.get(plugin_id)
         if generation is None:
             raise KeyError(f"插件没有待发布候选: {plugin_id}")
-        snapshot = generation.runtime_snapshot
-        if snapshot is None:
-            raise RuntimeError(f"插件候选缺少 RuntimeSnapshot: {plugin_id}")
+        try:
+            workspace_generations = tuple(
+                item
+                for item in (
+                    self._active_workspace_mcp,
+                    self._prepared_workspace_mcp,
+                )
+                if item is not None
+            )
+            conflicts = sorted(
+                set(generation.contributions.mcp_servers).intersection(
+                    server_name
+                    for item in workspace_generations
+                    for server_name in item.catalog.servers
+                )
+            )
+            if conflicts:
+                raise RuntimeError(
+                    f"插件 MCP 与 workspace server 名称冲突: {', '.join(conflicts)}"
+                )
+            generation.runtime_snapshot = self._compile_generation_snapshot(generation)
+            snapshot = generation.runtime_snapshot
+            cast(Any, generation.instance).context.tool_registry = snapshot.tool_registry
+        except (asyncio.CancelledError, Exception) as error:
+            self._record_failed_gate(
+                plugin_id=plugin_id,
+                revision=generation.source_revision,
+                check_id="publish_rebase",
+                reason=str(error) or type(error).__name__,
+            )
+            await self.discard_prepared(plugin_id)
+            raise
         active = self._active_generations.get(plugin_id)
         try:
             await self._initialize_prepared_generation(generation)
@@ -1136,6 +1323,11 @@ class PluginManager:
                 raise RuntimeError("RuntimeSnapshot MCP catalog 不可用")
             if any(not server.client.connected for server in catalog.servers.values()):
                 raise RuntimeError("RuntimeSnapshot MCP client 已断开")
+        workspace_mcp = snapshot.workspace_mcp_generation
+        if workspace_mcp is not None:
+            if self._mcp_host.get(workspace_mcp.generation_id) is not workspace_mcp.catalog:
+                raise RuntimeError("RuntimeSnapshot workspace MCP catalog 不可用")
+            self._validate_workspace_mcp_generation(workspace_mcp)
         for item in snapshot.generations.values():
             if item.scope.closed:
                 raise RuntimeError("RuntimeSnapshot 插件作用域已关闭")
@@ -1617,7 +1809,9 @@ class PluginManager:
                     mcp_catalog = await self._mcp_host.prepare(
                         generation_id,
                         server_specs=contributions.mcp_servers,
-                        proactive_sources=contributions.proactive_sources,
+                        required_tools=_required_mcp_tools(
+                            contributions.proactive_sources
+                        ),
                         scope=scope,
                     )
                 except Exception as error:
@@ -1787,8 +1981,12 @@ class PluginManager:
             snapshot = self._snapshot_compiler.compile(
                 generations,
                 catalog_generation=generation,
+                workspace_mcp_generation=self._active_workspace_mcp,
             )
-            snapshot.tool_registry = self._compile_snapshot_tools(generations)
+            snapshot.tool_registry = self._compile_snapshot_tools(
+                generations,
+                self._active_workspace_mcp,
+            )
             snapshot.tool_hooks = self._compile_snapshot_tool_hooks(generations)
             return snapshot
         except Exception as error:
@@ -1805,6 +2003,7 @@ class PluginManager:
     def _compile_snapshot_tools(
         self,
         generations: dict[str, PluginGeneration],
+        workspace_mcp: WorkspaceMcpGeneration | None = None,
     ) -> Any:
         if self._tool_registry is None:
             return None
@@ -1813,9 +2012,17 @@ class PluginManager:
             for generation in generations.values()
             for server_name in generation.contributions.mcp_servers
         }
+        workspace_mcp_sources: set[tuple[str, str]] = (
+            {
+                ("mcp", server_name)
+                for server_name in workspace_mcp.catalog.servers
+            }
+            if workspace_mcp is not None
+            else set()
+        )
         registry = self._tool_registry.fork(
             excluded_source_types={"plugin"},
-            excluded_sources=plugin_mcp_sources,
+            excluded_sources=plugin_mcp_sources | workspace_mcp_sources,
         )
         for generation in sorted(generations.values(), key=lambda item: item.plugin_id):
             plugin_name = getattr(
@@ -1851,7 +2058,49 @@ class PluginManager:
                         source_type="mcp",
                         source_name=server.name,
                     )
+        if workspace_mcp is not None:
+            for server in workspace_mcp.catalog.servers.values():
+                for tool in server.tools:
+                    if registry.has_tool(tool.name):
+                        raise RuntimeError(f"workspace MCP 工具名称重复: {tool.name}")
+                    registry.register(
+                        tool,
+                        risk="external-side-effect",
+                        source_type="mcp",
+                        source_name=server.name,
+                    )
         return registry
+
+    def _compile_workspace_mcp_snapshot(
+        self,
+        generation: WorkspaceMcpGeneration,
+    ) -> RuntimeSnapshot:
+        snapshot = self._snapshot_compiler.compile(
+            self._active_generations,
+            snapshot_revision=generation.revision,
+            workspace_mcp_generation=generation,
+        )
+        snapshot.tool_registry = self._compile_snapshot_tools(
+            self._active_generations,
+            generation,
+        )
+        snapshot.tool_hooks = self._compile_snapshot_tool_hooks(
+            self._active_generations
+        )
+        self._compile_snapshot_event_handlers(snapshot)
+        return snapshot
+
+    @staticmethod
+    def _validate_workspace_mcp_generation(
+        generation: WorkspaceMcpGeneration,
+    ) -> None:
+        if generation.scope.closed:
+            raise RuntimeError("workspace MCP 候选作用域已关闭")
+        if any(
+            not server.client.connected
+            for server in generation.catalog.servers.values()
+        ):
+            raise RuntimeError("workspace MCP 候选 client 已断开")
 
     def _compile_snapshot_tool_hooks(
         self,
@@ -2000,6 +2249,11 @@ class PluginManager:
             for generation in self._active_generations.values()
             if generation.plugin_id != plugin_id
         ]
+        other_generations.extend(
+            generation
+            for prepared_id, generation in self._prepared_generations.items()
+            if prepared_id != plugin_id
+        )
 
         def check(check_id: str, passed: bool, evidence: object = "") -> None:
             checks.append(
@@ -2070,6 +2324,8 @@ class PluginManager:
             for server_name in generation.contributions.mcp_servers
         }
         occupied_servers.update(self._user_mcp_server_names())
+        if self._active_workspace_mcp is not None:
+            occupied_servers.update(self._active_workspace_mcp.catalog.servers)
         check(
             "mcp_servers",
             not occupied_servers.intersection(contributions.mcp_servers),
@@ -2343,6 +2599,11 @@ class PluginManager:
         for plugin_id in tuple(self._prepared_generations):
             _, cancelled = await _complete_critical(self.discard_prepared(plugin_id))
             externally_cancelled = externally_cancelled or cancelled
+        if self._prepared_workspace_mcp is not None:
+            _, cancelled = await _complete_critical(
+                self._discard_workspace_mcp_candidate()
+            )
+            externally_cancelled = externally_cancelled or cancelled
 
         # 2. 逐插件终止并消费全部 cleanup failures
         for mp in list(self._loaded):
@@ -2414,6 +2675,8 @@ class PluginManager:
         self._scopes.clear()
         self._active_generations.clear()
         self._prepared_generations.clear()
+        self._active_workspace_mcp = None
+        self._prepared_workspace_mcp = None
         self._stable_aliases.clear()
         if externally_cancelled:
             raise asyncio.CancelledError
@@ -2943,6 +3206,21 @@ def _skill_body_hashes(
 def _mcp_tool_names(generation: PluginGeneration) -> list[str]:
     catalog = generation.mcp_catalog
     return list(catalog.tool_names) if catalog is not None else []
+
+
+def _required_mcp_tools(
+    sources: tuple[RegisteredProactiveSource, ...],
+) -> dict[str, tuple[str, ...]]:
+    required: dict[str, list[str]] = {}
+    for source in sources:
+        names = required.setdefault(source.spec.server, [])
+        names.append(source.spec.fetch_tool)
+        if source.spec.ack_tool:
+            names.append(source.spec.ack_tool)
+    return {
+        server_name: tuple(tool_names)
+        for server_name, tool_names in required.items()
+    }
 
 
 def _log_candidate_status(result: dict[str, object]) -> None:

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import Literal, cast
 
 from agent.lifecycle.phase import topo_sort_modules
+from agent.mcp.generation import WorkspaceMcpGeneration
 from agent.plugins.generation import PluginGeneration
 from agent.plugins.jobs import RegisteredPluginJob, plugin_job_key
 from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
@@ -47,6 +48,7 @@ class RuntimeSnapshot:
     channels: Mapping[str, Channel]
     skill_catalog_generation_id: str | None
     mcp_catalog_generation_ids: Mapping[str, str]
+    workspace_mcp_generation: WorkspaceMcpGeneration | None = None
     managed_services: Mapping[str, Mapping[str, object]] = field(
         default_factory=lambda: MappingProxyType({})
     )
@@ -114,6 +116,7 @@ class RuntimeSnapshotCompiler:
         *,
         catalog_generation: PluginGeneration | None = None,
         snapshot_revision: str = "",
+        workspace_mcp_generation: WorkspaceMcpGeneration | None = None,
     ) -> RuntimeSnapshot:
         ordered = [generations[key] for key in sorted(generations)]
         if any(generation.plugin_id != key for key, generation in generations.items()):
@@ -187,6 +190,11 @@ class RuntimeSnapshotCompiler:
             f"{plugin_id}:{generation_id}"
             for plugin_id, generation_id in sorted(mcp_catalogs.items())
         )
+        identity += "|workspace-mcp:" + (
+            workspace_mcp_generation.generation_id
+            if workspace_mcp_generation is not None
+            else ""
+        )
         identity += f"|snapshot:{snapshot_revision}"
         snapshot_id = hashlib.sha256(identity.encode()).hexdigest()[:16]
         return RuntimeSnapshot(
@@ -206,6 +214,7 @@ class RuntimeSnapshotCompiler:
                 else None
             ),
             mcp_catalog_generation_ids=MappingProxyType(mcp_catalogs),
+            workspace_mcp_generation=workspace_mcp_generation,
             managed_services=MappingProxyType(managed_services),
             plugin_skill_index=(
                 catalog_owner.skill_catalog.normal_plugins
@@ -390,6 +399,22 @@ class RuntimeSnapshotStore:
             for snapshot in self._snapshots.values()
         )
 
+    def workspace_mcp_is_referenced_elsewhere(
+        self,
+        generation: WorkspaceMcpGeneration,
+        *,
+        excluding_snapshot_id: str,
+    ) -> bool:
+        return any(
+            snapshot.snapshot_id != excluding_snapshot_id
+            and (
+                snapshot.state in {"published_pending", "committed"}
+                or snapshot.lease_count > 0
+            )
+            and snapshot.workspace_mcp_generation is generation
+            for snapshot in self._snapshots.values()
+        )
+
     def install(self, snapshot: RuntimeSnapshot) -> None:
         if self._current is not None or self._pending is not None:
             raise RuntimeError("RuntimeSnapshotStore 已安装初始快照")
@@ -525,6 +550,8 @@ class RuntimeSnapshotStore:
         snapshot.lease_count += 1
         for generation in snapshot.generations.values():
             generation.lease_count += 1
+        if snapshot.workspace_mcp_generation is not None:
+            snapshot.workspace_mcp_generation.lease_count += 1
         return RuntimeSnapshotLease(self, snapshot)
 
     def fork_lease(self, source: RuntimeSnapshotLease) -> RuntimeSnapshotLease:
@@ -534,6 +561,8 @@ class RuntimeSnapshotStore:
         snapshot.lease_count += 1
         for generation in snapshot.generations.values():
             generation.lease_count += 1
+        if snapshot.workspace_mcp_generation is not None:
+            snapshot.workspace_mcp_generation.lease_count += 1
         return RuntimeSnapshotLease(self, snapshot)
 
     async def release_lease(self, snapshot: RuntimeSnapshot) -> None:
@@ -542,6 +571,8 @@ class RuntimeSnapshotStore:
         snapshot.lease_count -= 1
         for generation in snapshot.generations.values():
             generation.lease_count -= 1
+        if snapshot.workspace_mcp_generation is not None:
+            snapshot.workspace_mcp_generation.lease_count -= 1
         await self._drain_if_ready(snapshot)
         async with self._condition:
             self._condition.notify_all()

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -16,7 +16,6 @@ import pytest
 import agent.provider as provider_module
 from agent.config_models import Config as ConfigModel
 from agent.mcp.registry import McpServerRegistry
-from agent.plugins.manager import ActivePluginInfo
 from agent.provider import (
     ContextLengthError,
     ContentSafetyError,
@@ -841,54 +840,6 @@ async def test_mcp_registry_anyaction_and_sampler_cover_core_paths(
     assert meta["reason"] == "probability"
     gate.record_action(now_utc=now)
 
-
-@pytest.mark.asyncio
-async def test_mcp_registry_syncs_plugin_servers(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-):
-    class _Client:
-        def __init__(self, name: str, command: list[str], env=None, cwd=None):
-            self.name = name
-            self.command = command
-            self.env = env
-            self.cwd = cwd
-
-        async def connect(self):
-            return [SimpleNamespace(name="tool", description="desc")]
-
-        async def disconnect(self):
-            return None
-
-    class _Wrapper:
-        def __init__(self, client, info):
-            self.name = f"mcp_{client.name}__{info.name}"
-            self.description = info.description
-            self.parameters = {"type": "object", "properties": {}, "required": []}
-
-    monkeypatch.setattr("agent.mcp.registry.McpClient", _Client)
-    monkeypatch.setattr("agent.mcp.registry.McpToolWrapper", _Wrapper)
-    tools = MagicMock()
-    registry = McpServerRegistry(tmp_path / "mcp.json", tools)
-    plugin = ActivePluginInfo(
-        plugin_id="feed@lab",
-        plugin_dir=tmp_path / "feed",
-        manifest={},
-        module_path="feed",
-        mcp_servers={
-            "feed": {
-                "command": ["python", "run_mcp.py"],
-                "env": {"A": "1"},
-                "cwd": str(tmp_path),
-            }
-        },
-    )
-
-    await registry.sync_plugin_servers([plugin])
-    assert "feed（1 个工具）" in registry.list_servers()
-
-    await registry.sync_plugin_servers([])
-    assert registry.list_servers() == "当前没有已注册的 MCP server。"
 
 @pytest.mark.asyncio
 async def test_app_runtime_start_passes_markdown_store_to_memory_optimizer(

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.convertors import CONVERTOR_TYPES, StringConvertor
 
-from agent.plugins.manager import PluginManager
+from agent.plugins.manager import PluginManager, _CandidateRejected
 from agent.plugins.manifest import write_plugin_manifest
 from agent.plugins.watcher import PluginWatcher
 from agent.plugins.jobs import PluginJobRuntime
@@ -112,6 +112,22 @@ def _write_mcp_server(plugin_dir: Path, tools: tuple[str, ...]) -> None:
         "    with log.open('a', encoding='utf-8') as f: f.write('stopped\\n')\n",
         encoding="utf-8",
     )
+
+
+def _workspace_mcp_spec(
+    server_dir: Path,
+    *,
+    tool_name: str,
+) -> dict[str, dict[str, object]]:
+    server_dir.mkdir(parents=True, exist_ok=True)
+    _write_mcp_server(server_dir, (tool_name,))
+    return {
+        "workspace": {
+            "command": [sys.executable, str(server_dir / "server.py")],
+            "env": {"AKA_PLUGIN_DATA_DIR": str(server_dir / "data")},
+            "cwd": str(server_dir),
+        }
+    }
 
 
 async def _wait_for_log(path: Path, expected: list[str]) -> None:
@@ -2753,6 +2769,314 @@ async def test_initial_plugin_mcp_tool_is_visible_in_first_snapshot(
     await loop._process_with_runtime_admission(message)
 
     assert seen == ["[]"]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_workspace_mcp_generation_publish_preserves_old_turn_lease(
+    tmp_path: Path,
+) -> None:
+    from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    first = await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "workspace-v1", tool_name="version_v1"),
+        revision="v1",
+    )
+    await manager.publish_workspace_mcp()
+    old_client = first.catalog.servers["workspace"].client
+    old_lease = await manager.snapshot_store.acquire()
+    old_fork = old_lease.fork()
+    token = bind_runtime_snapshot(old_lease)
+    try:
+        assert await tools.execute("mcp_workspace__version_v1", {}) == "[]"
+        second = await manager.prepare_workspace_mcp(
+            _workspace_mcp_spec(tmp_path / "workspace-v2", tool_name="version_v2"),
+            revision="v2",
+        )
+        await manager.publish_workspace_mcp()
+        assert manager.active_workspace_mcp is second
+        assert old_client.connected is True
+        assert await tools.execute("mcp_workspace__version_v1", {}) == "[]"
+        assert tools.has_tool("mcp_workspace__version_v2") is False
+        new_lease = await manager.snapshot_store.acquire()
+        new_token = bind_runtime_snapshot(new_lease)
+        try:
+            assert await tools.execute("mcp_workspace__version_v2", {}) == "[]"
+        finally:
+            reset_runtime_snapshot(new_token)
+            await new_lease.release()
+    finally:
+        reset_runtime_snapshot(token)
+        await old_lease.release()
+
+    assert old_client.connected is True
+    await old_fork.release()
+    assert old_client.connected is False
+    new_lease = await manager.snapshot_store.acquire()
+    token = bind_runtime_snapshot(new_lease)
+    try:
+        assert tools.has_tool("mcp_workspace__version_v1") is False
+        assert await tools.execute("mcp_workspace__version_v2", {}) == "[]"
+    finally:
+        reset_runtime_snapshot(token)
+        await new_lease.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_workspace_mcp_candidate_failure_keeps_active_and_cleans_partial(
+    tmp_path: Path,
+) -> None:
+    tools = ToolRegistry()
+    manager = _manager(tmp_path, tools=tools)
+    first = await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "active", tool_name="active"),
+        revision="active",
+    )
+    await manager.publish_workspace_mcp()
+    current = manager.current_snapshot
+
+    good_dir = tmp_path / "candidate-good"
+    good_spec = _workspace_mcp_spec(good_dir, tool_name="candidate")
+    specs = {
+        "a_good": next(iter(good_spec.values())),
+        "z_bad": {"command": [str(tmp_path / "missing-command")]},
+    }
+    with pytest.raises(FileNotFoundError):
+        await manager.prepare_workspace_mcp(specs, revision="broken")
+
+    await _wait_for_log(
+        good_dir / "data" / "mcp-lifecycle.log",
+        ["started", "stopped"],
+    )
+    assert manager.current_snapshot is current
+    assert manager.active_workspace_mcp is first
+    assert manager.prepared_workspace_mcp is None
+    assert first.catalog.servers["workspace"].client.connected is True
+
+    candidate = await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "candidate-dead", tool_name="dead"),
+        revision="dead",
+    )
+    process = candidate.catalog.servers["workspace"].client._process
+    assert process is not None
+    process.kill()
+    await process.wait()
+    with pytest.raises(RuntimeError, match="client 已断开"):
+        await manager.publish_workspace_mcp()
+    assert candidate.scope.closed is True
+    assert manager.current_snapshot is current
+    assert manager.active_workspace_mcp is first
+    assert manager.prepared_workspace_mcp is None
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_workspace_mcp_and_plugin_mcp_names_conflict_both_directions(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "plugin_owner",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class PluginOwner(Plugin):\n"
+        "    name = 'plugin_owner'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='shared', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(plugin_dir, ("value",))
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    await manager.load_all()
+    workspace_spec = _workspace_mcp_spec(tmp_path / "workspace", tool_name="value")
+    shared_spec = {"shared": next(iter(workspace_spec.values()))}
+    with pytest.raises(RuntimeError, match="名称冲突"):
+        await manager.prepare_workspace_mcp(shared_spec, revision="workspace")
+    await manager.terminate_all()
+
+    other = _manager(tmp_path / "other", tools=ToolRegistry())
+    active_spec = _workspace_mcp_spec(tmp_path / "active-user", tool_name="value")
+    active_spec = {"shared": next(iter(active_spec.values()))}
+    await other.prepare_workspace_mcp(active_spec, revision="user")
+    await other.publish_workspace_mcp()
+    other_plugin = _write_plugin(
+        tmp_path / "other" / "plugins",
+        "plugin_candidate",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class PluginCandidate(Plugin):\n"
+        "    name = 'plugin_candidate'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='shared', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(other_plugin, ("value",))
+    assert await other.prepare_candidate("plugin_candidate") is None
+    await other.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_plugin_publish_rebases_latest_workspace_mcp_generation(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "v1", tool_name="v1"), revision="v1"
+    )
+    await manager.publish_workspace_mcp()
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "late_plugin",
+        "from agent.plugins import Plugin\n"
+        "class LatePlugin(Plugin):\n"
+        "    name = 'late_plugin'\n",
+    )
+    candidate = await manager.prepare_candidate("late_plugin")
+    assert candidate is not None
+    await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "v2", tool_name="v2"), revision="v2"
+    )
+    latest = await manager.publish_workspace_mcp()
+    await manager.publish_prepared("late_plugin")
+    assert manager.current_snapshot is not None
+    assert manager.current_snapshot.workspace_mcp_generation is latest
+    assert candidate.runtime_snapshot is manager.current_snapshot
+    assert candidate.instance.context.tool_registry is manager.current_snapshot.tool_registry
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("publish_owner", ["workspace", "plugin"])
+async def test_later_mcp_publish_revalidates_prepared_name_conflict(
+    tmp_path: Path,
+    publish_owner: str,
+) -> None:
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    workspace = _workspace_mcp_spec(tmp_path / "workspace", tool_name="value")
+    await manager.prepare_workspace_mcp(
+        {"shared": next(iter(workspace.values()))}, revision="workspace"
+    )
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "prepared_plugin",
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class PreparedPlugin(Plugin):\n"
+        "    name = 'prepared_plugin'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='shared', command=('python', 'server.py'))]\n",
+    )
+    _write_mcp_server(plugin_dir, ("value",))
+    plugin = await manager.prepare_candidate("prepared_plugin")
+    assert plugin is not None
+    current = manager.current_snapshot
+    with pytest.raises(RuntimeError, match="名称冲突"):
+        if publish_owner == "workspace":
+            await manager.publish_workspace_mcp()
+        else:
+            await manager.publish_prepared("prepared_plugin")
+    assert manager.current_snapshot is current
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_workspace_mcp_publish_cancellation_aborts_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    first = await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "active-cancel", tool_name="active"),
+        revision="active",
+    )
+    await manager.publish_workspace_mcp()
+    current = manager.current_snapshot
+    candidate = await manager.prepare_workspace_mcp(
+        _workspace_mcp_spec(tmp_path / "candidate-cancel", tool_name="candidate"),
+        revision="candidate",
+    )
+    entered = asyncio.Event()
+
+    async def wait_invariant(snapshot: RuntimeSnapshot) -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(manager, "_post_snapshot_invariants", wait_invariant)
+    task = asyncio.create_task(manager.publish_workspace_mcp())
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager.current_snapshot is current
+    assert manager.snapshot_store._pending is None
+    assert manager.active_workspace_mcp is first
+    assert manager.prepared_workspace_mcp is None
+    assert candidate.scope.closed is True
+    assert candidate.catalog.servers["workspace"].client.connected is False
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_prepared_plugin_mcp_namespace_rejects_second_candidate_early(
+    tmp_path: Path,
+) -> None:
+    source = lambda class_name, name: (
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        f"class {class_name}(Plugin):\n"
+        f"    name = '{name}'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='shared_plugin', command=('python', 'server.py'))]\n"
+    )
+    for name, class_name in (("owner_a", "OwnerA"), ("owner_b", "OwnerB")):
+        plugin_dir = _write_plugin(
+            tmp_path / "plugins", name, source(class_name, name)
+        )
+        _write_mcp_server(plugin_dir, ("value",))
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    assert await manager.prepare_candidate("owner_a") is not None
+    assert await manager.prepare_candidate("owner_b") is None
+    assert manager.prepared_generation("owner_a") is not None
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_plugin_publish_rebase_conflict_discards_stale_candidate(
+    tmp_path: Path,
+) -> None:
+    def source(class_name: str, name: str) -> str:
+        return (
+            "from agent.plugins import McpServerSpec, Plugin\n"
+            f"class {class_name}(Plugin):\n"
+            f"    name = '{name}'\n"
+            "    @classmethod\n"
+            "    def mcp_servers(cls):\n"
+            "        return [McpServerSpec(name='shared_plugin', command=('python', 'server.py'))]\n"
+        )
+
+    for name, class_name in (("owner_a", "OwnerA"), ("owner_b", "OwnerB")):
+        plugin_dir = _write_plugin(tmp_path / "plugins", name, source(class_name, name))
+        _write_mcp_server(plugin_dir, ("value",))
+    manager = _manager(tmp_path, tools=ToolRegistry())
+    stale = await manager.prepare_candidate("owner_b")
+    assert stale is not None and stale.mcp_catalog is not None
+    _ = manager._prepared_generations.pop("owner_b")
+    owner = await manager.prepare_candidate("owner_a")
+    assert owner is not None
+    await manager.publish_prepared("owner_a")
+    current = manager.current_snapshot
+    manager._prepared_generations["owner_b"] = stale
+    client = stale.mcp_catalog.servers["shared_plugin"].client
+    with pytest.raises(_CandidateRejected):
+        await manager.publish_prepared("owner_b")
+    assert manager.prepared_generation("owner_b") is None
+    assert client.connected is False
+    assert stale.scope.closed is True
+    assert manager.current_snapshot is current
+    assert manager.generation("owner_a") is owner
+    assert manager.generation("owner_b") is None
+    assert manager.latest_gate("owner_b").checks[0].check_id == "publish_rebase"
     await manager.terminate_all()
 
 


### PR DESCRIPTION
## Problem

Workspace MCP and plugin MCP used separate lifecycle paths, so a later declaration hot-reload layer could not publish tools through the same turn-pinned runtime snapshot.

## Scope

- move MCP host ownership into the shared `agent.mcp` layer
- add workspace MCP generations to `RuntimeSnapshot` lease/drain semantics
- publish workspace MCP candidates transactionally through `PluginManager`
- rebase plugin publications against the latest workspace MCP generation
- enforce one MCP server namespace across active and prepared candidates

This PR is the runtime foundation only. Declaration files, watchers, and removal of `mcp_servers.json` are intentionally in the next stacked PR.

## Verification

- `pytest -q -W error tests/` — 2054 passed
- `pyright agent/mcp/registry.py agent/mcp/generation.py agent/mcp/host.py agent/plugins/generation.py agent/plugins/manager.py agent/plugins/snapshot.py` — 0 errors
- `git diff --check`

## Review notes

Regression coverage includes old/new turn lease overlap, forked leases, plugin/workspace publish interleavings, name conflicts, cancellation rollback, stale snapshot rebasing, and failed rebase process cleanup.