### PR TITLE
feat(runtime): add supervised agent restart

### DIFF
--- a/agent/control/protocol/router.py
+++ b/agent/control/protocol/router.py
@@ -218,9 +218,16 @@ class ConnectionRouter:
         try:
             async for event in handle.events():
                 await self._send(event.to_notification())
+                if event.method == "turn/completed":
+                    self._service.notify_turn_delivered(handle.id)
         except asyncio.CancelledError:
+            self._service.notify_turn_delivery_failed(
+                handle.id,
+                "connection closed before terminal delivery",
+            )
             raise
-        except Exception:
+        except Exception as exc:
+            self._service.notify_turn_delivery_failed(handle.id, str(exc))
             logger.exception("turn event forwarding failed turn=%s", handle.id)
 
     async def close(self) -> None:

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -25,6 +25,7 @@ from agent.control.models import (
     TurnStatus,
 )
 from agent.control.ports import ControlExecutionResult, TurnExecutor
+from agent.restart import RestartCoordinator
 from session.store import SessionStore
 from agent.looping.interrupt import InterruptResult
 
@@ -63,6 +64,7 @@ class ConversationRuntime:
         executor: TurnExecutor,
         *,
         subscriber_queue_size: int = 256,
+        restart_coordinator: RestartCoordinator | None = None,
     ) -> None:
         if subscriber_queue_size < 2:
             raise ValueError("subscriber_queue_size 必须至少为 2")
@@ -78,12 +80,15 @@ class ConversationRuntime:
         self._interrupt_requested: set[str] = set()
         self._thread_idle: dict[str, asyncio.Event] = {}
         self._closed = False
+        self._accepting_turns = True
+        self._restart_owner_turn_id: str | None = None
+        self._restart_coordinator = restart_coordinator
 
     async def start_turn(self, request: TurnRequest) -> TurnHandle:
         """持久化 queued turn 并立即返回可操作句柄。"""
 
         # 1. 在唯一 owner 处拒绝同 thread 并发。
-        if self._closed:
+        if self._closed or not self._accepting_turns:
             raise RuntimeClosedError("conversation runtime is shutting down")
         if request.thread_id in self._active_by_thread:
             raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
@@ -326,6 +331,11 @@ class ConversationRuntime:
             # 3. terminal 是唯一结束通知；结果 future 与 active owner 一起收束。
             future = self._results[turn_id]
             if terminal is not None:
+                if self._restart_coordinator is not None:
+                    self._restart_coordinator.mark_turn_terminal(
+                        turn_id,
+                        terminal.status.value,
+                    )
                 event = TurnEvent.create("turn/completed", request.thread_id, turn_id, turn=terminal.to_dict())
                 self._publish(event)
                 if not future.done():
@@ -402,6 +412,38 @@ class ConversationRuntime:
 
     def is_thread_active(self, thread_id: str) -> bool:
         return thread_id in self._active_by_thread
+
+    def quiesce_for_restart(self, caller_turn_id: str) -> None:
+        """仅在 caller 是唯一 turn 时冻结新的 turn 准入。"""
+
+        # 1. caller 必须是当前 runtime 唯一已经持久化的 turn。
+        active_turns = set(self._tasks)
+        if caller_turn_id not in active_turns:
+            raise RuntimeClosedError(f"restart caller turn 不在当前 runtime: {caller_turn_id}")
+        others = active_turns - {caller_turn_id}
+        if others:
+            raise RuntimeClosedError(
+                f"仍有其他 turn 等待或执行，拒绝重启: {sorted(others)}"
+            )
+        if not self._accepting_turns:
+            if self._restart_owner_turn_id == caller_turn_id:
+                return
+            raise RuntimeClosedError("conversation runtime 已在排空")
+
+        # 2. 不获取全局 admission，避免 caller 在工具执行中自锁。
+        self._accepting_turns = False
+        self._restart_owner_turn_id = caller_turn_id
+
+    def resume_after_restart_cancel(self, caller_turn_id: str) -> None:
+        """只允许原 restart owner 在提交前恢复准入。"""
+
+        if self._restart_owner_turn_id != caller_turn_id:
+            raise RuntimeError(
+                f"restart admission owner 不匹配: {caller_turn_id}"
+            )
+        self._restart_owner_turn_id = None
+        if not self._closed:
+            self._accepting_turns = True
 
     async def wait_thread_available(self, thread_id: str) -> None:
         """等待当前 thread owner 释放，不获取新的 owner。"""

--- a/agent/control/service.py
+++ b/agent/control/service.py
@@ -14,6 +14,7 @@ from agent.control.models import ThreadRecord, ThreadSource, TurnRequest
 from agent.control.protocol.models import InitializeParams
 from agent.control.protocol.errors import JsonRpcError, UNAUTHORIZED
 from agent.control.runtime import ConversationRuntime, TurnHandle
+from agent.restart import RestartCoordinator
 from session.manager import SessionManager
 
 
@@ -29,6 +30,9 @@ class ControlService:
         plugin_drain: Callable[[str], Awaitable[str]] | None = None,
         consolidate: Callable[[str], Awaitable[bool]] | None = None,
         workspace_token: str | None = None,
+        restart_coordinator: RestartCoordinator | None = None,
+        boot_id: str | None = None,
+        ready: Callable[[], bool] | None = None,
     ) -> None:
         self.runtime = runtime
         self.sessions = sessions
@@ -36,6 +40,9 @@ class ControlService:
         self._plugin_drain = plugin_drain
         self._consolidate = consolidate
         self._workspace_token = workspace_token
+        self._restart_coordinator = restart_coordinator
+        self._boot_id = boot_id
+        self._ready = ready
         self._operation_tasks: set[asyncio.Task[dict[str, object]]] = set()
 
     def initialize(self, params: InitializeParams) -> dict[str, object]:
@@ -56,7 +63,20 @@ class ControlService:
         }
 
     def status(self) -> dict[str, object]:
-        return {"ready": True, "workspace": str(self.workspace), "protocolVersion": "1.0"}
+        return {
+            "ready": self._ready() if self._ready is not None else True,
+            "bootId": self._boot_id,
+            "workspace": str(self.workspace),
+            "protocolVersion": "1.0",
+        }
+
+    def notify_turn_delivered(self, turn_id: str) -> None:
+        if self._restart_coordinator is not None:
+            self._restart_coordinator.mark_delivered(turn_id)
+
+    def notify_turn_delivery_failed(self, turn_id: str, reason: str) -> None:
+        if self._restart_coordinator is not None:
+            self._restart_coordinator.mark_delivery_failed(turn_id, reason)
 
     def start_thread(self, metadata: dict[str, Any]) -> dict[str, object]:
         thread_id = new_thread_id()

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -29,6 +29,7 @@ from agent.tool_runtime import (
     tool_call_batch_snapshot,
 )
 from agent.tools.base import normalize_tool_result
+from agent.tools.registry import begin_turn_search_scope, end_turn_search_scope
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from bus.event_bus import EventBus
 from bus.events import InboundMessage, OutboundMessage
@@ -892,6 +893,7 @@ class DefaultReasoner(Reasoner):
         context: "ContextBuilder | None" = None,
         session_manager: "SessionManager | None" = None,
         event_bus: "EventBus | None" = None,
+        non_preloadable_names: Callable[[], set[str]] | None = None,
     ) -> None:
         self._llm = llm
         self._llm_config = llm_config
@@ -902,6 +904,7 @@ class DefaultReasoner(Reasoner):
         self._context = context
         self._session_manager = session_manager
         self._event_bus = event_bus
+        self._non_preloadable_names = non_preloadable_names or set
         self._prompt_render_plugin_modules: list[object] = []
         self._before_step_plugin_modules: list[object] = []
         self._after_step_plugin_modules: list[object] = []
@@ -1156,18 +1159,26 @@ class DefaultReasoner(Reasoner):
                 initial_messages
             )
             try:
-                result = await self.run(
-                    initial_messages,
-                    request_time=msg.timestamp,
-                    preloaded_tools=preloaded,
-                    preloaded_tool_order=preloaded_order,
-                    preflight_injected=True,
-                    on_content_delta=stream_sink,
-                    tool_event_session_key=session.key,
-                    tool_event_channel=msg.channel,
-                    tool_event_chat_id=msg.chat_id,
-                    disabled_tools=disabled_tools,
+                search_scope = begin_turn_search_scope(
+                    turn_id=current_turn_id.get(),
+                    session_key=session.key,
+                    attempt=attempt,
                 )
+                try:
+                    result = await self.run(
+                        initial_messages,
+                        request_time=msg.timestamp,
+                        preloaded_tools=preloaded,
+                        preloaded_tool_order=preloaded_order,
+                        preflight_injected=True,
+                        on_content_delta=stream_sink,
+                        tool_event_session_key=session.key,
+                        tool_event_channel=msg.channel,
+                        tool_event_chat_id=msg.chat_id,
+                        disabled_tools=disabled_tools,
+                    )
+                finally:
+                    end_turn_search_scope(search_scope)
                 tools_used = list(result.metadata.get("tools_used") or [])
                 tools_unlocked = list(result.metadata.get("tools_unlocked") or [])
                 tool_chain = list(result.metadata.get("tool_chain") or [])
@@ -1193,6 +1204,7 @@ class DefaultReasoner(Reasoner):
                         session.key,
                         [*tools_unlocked, *tools_used],
                         self._tools.get_always_on_names(),
+                        self._non_preloadable_names(),
                     )
                 if attempt == 0:
                     retry_trace["selected_plan"] = plan["name"]

--- a/agent/core/runtime_support.py
+++ b/agent/core/runtime_support.py
@@ -97,11 +97,17 @@ class ToolDiscoveryState:
 
         return set(self.unlock_names_from_result(result_json))
 
-    def update(self, session_key: str, tools_used: list[str], always_on: set[str]) -> None:
+    def update(
+        self,
+        session_key: str,
+        tools_used: list[str],
+        always_on: set[str],
+        non_preloadable: set[str] | None = None,
+    ) -> None:
         """更新单个 session 的工具 LRU，并跳过常驻工具。"""
 
         # 1. 过滤不应缓存的工具，避免创建空 session 项。
-        skip = always_on | {"tool_search"}
+        skip = always_on | {"tool_search"} | (non_preloadable or set())
         cacheable = [name for name in tools_used if name not in skip]
         if not cacheable:
             self._touch_session(session_key)

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -304,6 +304,7 @@ class AgentLoop:
             context=self._context,
             session_manager=self.session_manager,
             event_bus=self._event_bus,
+            non_preloadable_names=deps.tools.get_non_preloadable_names,
         )
 
         # 3. 最后串 passive prepare / execute / commit 主链。

--- a/agent/restart.py
+++ b/agent/restart.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from uuid import uuid4
+
+
+logger = logging.getLogger(__name__)
+
+
+class RestartState(StrEnum):
+    IDLE = "idle"
+    ARMED = "armed"
+    WAITING_DELIVERY = "waiting_delivery"
+    COMMITTED = "committed"
+    CANCELLED = "cancelled"
+
+
+class RestartRejectedError(RuntimeError):
+    """表示当前 runtime 明确拒绝了一次重启请求。"""
+
+
+@dataclass(frozen=True)
+class RestartRequest:
+    id: str
+    boot_id: str
+    turn_id: str
+    session_key: str
+    channel: str
+    chat_id: str
+    reason: str
+
+
+class SupervisorCommitChannel:
+    """向 supervisor 的继承私有管道写入当前 boot 提交证据。"""
+
+    def __init__(self, fd: int, boot_id: str, nonce: str) -> None:
+        if fd <= 2:
+            raise ValueError("restart commit fd 必须是继承的私有描述符")
+        if not boot_id or len(nonce) < 32:
+            raise ValueError("restart commit channel 身份无效")
+        os.fstat(fd)
+        self.fd = fd
+        self.boot_id = boot_id
+        self.nonce = nonce
+
+    @classmethod
+    def from_environment(cls) -> SupervisorCommitChannel | None:
+        supervised = os.environ.get("AKASHIC_SUPERVISED") == "1"
+        if not supervised:
+            return None
+        raw_fd = os.environ.get("AKASHIC_RESTART_COMMIT_FD")
+        boot_id = os.environ.get("AKASHIC_BOOT_ID", "")
+        nonce = os.environ.get("AKASHIC_RESTART_NONCE", "")
+        if raw_fd is None:
+            raise RuntimeError("supervised child 缺少 restart commit fd")
+        try:
+            fd = int(raw_fd)
+        except ValueError as exc:
+            raise RuntimeError("restart commit fd 不是整数") from exc
+        return cls(fd, boot_id, nonce)
+
+    def commit(self, request: RestartRequest) -> None:
+        """单次写入小于 PIPE_BUF 的结构化提交证据。"""
+
+        if request.boot_id != self.boot_id:
+            raise RuntimeError("restart request boot_id 与 commit channel 不匹配")
+        payload = (
+            json.dumps(
+                {
+                    "type": "restart_commit",
+                    "bootId": self.boot_id,
+                    "nonce": self.nonce,
+                    "requestId": request.id,
+                },
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+        written = os.write(self.fd, payload)
+        if written != len(payload):
+            raise RuntimeError("restart commit pipe 发生短写")
+
+
+class RestartCoordinator:
+    """协调重启请求，直到正式 turn 与传输确认都完成。"""
+
+    def __init__(
+        self,
+        boot_id: str,
+        *,
+        supervised: bool,
+        commit: Callable[[RestartRequest], None] | None = None,
+        delivery_timeout_s: float = 15.0,
+    ) -> None:
+        if not boot_id.strip():
+            raise ValueError("boot_id 不能为空")
+        if delivery_timeout_s <= 0:
+            raise ValueError("delivery_timeout_s 必须大于 0")
+        self.boot_id = boot_id
+        self.supervised = supervised
+        if supervised != (commit is not None):
+            raise ValueError("supervised 与 restart commit channel 必须同时成立")
+        self._commit = commit
+        self.delivery_timeout_s = delivery_timeout_s
+        self.state = RestartState.IDLE
+        self.pending: RestartRequest | None = None
+        self.last_error: str | None = None
+        self._turn_completed = False
+        self._delivered = False
+        self._committed = asyncio.Event()
+        self._timeout_task: asyncio.Task[None] | None = None
+        self._quiesce: Callable[[str], None] | None = None
+        self._resume: Callable[[str], None] | None = None
+
+    def bind_admission(
+        self,
+        *,
+        quiesce: Callable[[str], None],
+        resume: Callable[[str], None],
+    ) -> None:
+        """绑定唯一 ConversationRuntime 的准入控制。"""
+
+        if self._quiesce is not None or self._resume is not None:
+            raise RuntimeError("restart admission 已绑定")
+        self._quiesce = quiesce
+        self._resume = resume
+
+    def arm(
+        self,
+        *,
+        turn_id: str,
+        session_key: str,
+        channel: str,
+        chat_id: str,
+        reason: str,
+    ) -> RestartRequest:
+        """冻结新 turn，并为当前唯一 caller 建立幂等请求。"""
+
+        # 1. 校验 supervisor 与调用上下文。
+        if not self.supervised:
+            raise RestartRejectedError("当前进程未由 supervisor 托管")
+        if self._quiesce is None or self._resume is None:
+            raise RuntimeError("restart admission 尚未绑定")
+        clean_reason = reason.strip()
+        if not 1 <= len(clean_reason) <= 300:
+            raise ValueError("reason 长度必须为 1..300")
+        if not turn_id or not session_key or not channel or not chat_id:
+            raise RestartRejectedError("重启工具缺少完整 turn 上下文")
+
+        # 2. 同 caller 幂等，其他 caller 明确拒绝。
+        pending = self.pending
+        if pending is not None:
+            if pending.turn_id == turn_id:
+                return pending
+            raise RestartRejectedError(
+                f"已有重启请求等待提交: {pending.id}"
+            )
+
+        # 3. 先冻结准入，成功后才发布 pending 状态。
+        self._quiesce(turn_id)
+        request = RestartRequest(
+            id=f"restart_{uuid4().hex}",
+            boot_id=self.boot_id,
+            turn_id=turn_id,
+            session_key=session_key,
+            channel=channel,
+            chat_id=chat_id,
+            reason=clean_reason,
+        )
+        self.pending = request
+        self.state = RestartState.ARMED
+        self.last_error = None
+        self._turn_completed = False
+        self._delivered = False
+        self._timeout_task = asyncio.create_task(
+            self._delivery_watchdog(request.id),
+            name=f"restart-delivery-timeout:{request.id}",
+        )
+        return request
+
+    def mark_turn_terminal(self, turn_id: str, status: str) -> None:
+        """记录正式 control turn 终态，失败时恢复准入。"""
+
+        if self.state is RestartState.COMMITTED:
+            return
+        pending = self.pending
+        if pending is None or pending.turn_id != turn_id:
+            return
+        if status != "completed":
+            self._cancel(f"restart caller turn ended as {status}")
+            return
+        self._turn_completed = True
+        self.state = RestartState.WAITING_DELIVERY
+        self._commit_if_ready()
+
+    def mark_delivered(self, turn_id: str) -> None:
+        """记录 caller 最终响应已由 transport 实际写出。"""
+
+        if self.state is RestartState.COMMITTED:
+            return
+        pending = self.pending
+        if pending is None or pending.turn_id != turn_id:
+            return
+        self._delivered = True
+        self._commit_if_ready()
+
+    def mark_delivery_failed(self, turn_id: str, reason: str) -> None:
+        """记录传输失败并恢复 turn admission。"""
+
+        if self.state is RestartState.COMMITTED:
+            return
+        pending = self.pending
+        if pending is None or pending.turn_id != turn_id:
+            return
+        self._cancel(f"restart response delivery failed: {reason}")
+
+    async def wait_committed(self) -> RestartRequest:
+        """等待一次安全提交并返回其不可变请求。"""
+
+        await self._committed.wait()
+        pending = self.pending
+        if pending is None or self.state is not RestartState.COMMITTED:
+            raise RuntimeError("restart committed event 缺少正式请求")
+        return pending
+
+    def _commit_if_ready(self) -> None:
+        if self.state is RestartState.COMMITTED:
+            return
+        if not self._turn_completed or not self._delivered:
+            return
+        pending = self.pending
+        if pending is None or self._commit is None:
+            raise RuntimeError("restart commit 缺少正式请求或私有通道")
+        try:
+            self._commit(pending)
+        except Exception as exc:
+            self._cancel(f"supervisor commit failed: {exc}")
+            return
+        self.state = RestartState.COMMITTED
+        timeout_task = self._timeout_task
+        self._timeout_task = None
+        if timeout_task is not None:
+            timeout_task.cancel()
+        self._committed.set()
+
+    def _cancel(self, reason: str) -> None:
+        pending = self.pending
+        if pending is None:
+            return
+        timeout_task = self._timeout_task
+        self._timeout_task = None
+        if timeout_task is not None and timeout_task is not asyncio.current_task():
+            timeout_task.cancel()
+        self.state = RestartState.CANCELLED
+        self.last_error = reason
+        self.pending = None
+        self._turn_completed = False
+        self._delivered = False
+        assert self._resume is not None
+        self._resume(pending.turn_id)
+        logger.error("restart request cancelled id=%s reason=%s", pending.id, reason)
+
+    async def _delivery_watchdog(self, request_id: str) -> None:
+        await asyncio.sleep(self.delivery_timeout_s)
+        pending = self.pending
+        if pending is None or pending.id != request_id:
+            return
+        self._cancel(
+            f"delivery acknowledgement timed out after {self.delivery_timeout_s:g}s"
+        )

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import FrameType
+from typing import IO
+from uuid import uuid4
+
+
+RESTART_EXIT_CODE = 75
+SUPERVISOR_FAILURE_EXIT_CODE = 70
+
+
+class _SupervisorLock:
+    """保证一个 workspace 只有一个 supervisor。"""
+
+    def __init__(self, workspace: Path) -> None:
+        self.path = workspace / ".supervisor.lock"
+        self.pid_path = workspace / ".supervisor.pid"
+        self._stream: IO[str] | None = None
+
+    def acquire(self) -> None:
+        import fcntl
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        stream = self.path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            stream.close()
+            raise RuntimeError(f"workspace supervisor 已在运行: {self.path}") from exc
+        stream.seek(0)
+        stream.truncate()
+        stream.write(str(os.getpid()))
+        stream.flush()
+        temporary = self.pid_path.with_name(f".{self.pid_path.name}.{os.getpid()}.tmp")
+        temporary.write_text(str(os.getpid()), encoding="utf-8")
+        os.replace(temporary, self.pid_path)
+        self._stream = stream
+
+    def release(self) -> None:
+        import fcntl
+
+        stream = self._stream
+        self._stream = None
+        if stream is None:
+            return
+        try:
+            if self.pid_path.exists() and self.pid_path.read_text(
+                encoding="utf-8"
+            ).strip() == str(os.getpid()):
+                self.pid_path.unlink()
+            fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+        finally:
+            stream.close()
+
+
+@dataclass(frozen=True)
+class _ChildResult:
+    exit_code: int
+    ready: bool
+    commit_valid: bool
+
+
+def run_supervisor(
+    *,
+    config_path: Path,
+    workspace: Path,
+    readiness_timeout_s: float = 15.0,
+) -> int:
+    """监管固定 gateway child，并只接受当前 boot 的私有重启提交。"""
+
+    if readiness_timeout_s <= 0:
+        raise ValueError("readiness_timeout_s 必须大于 0")
+    project_root = Path(__file__).resolve().parent.parent
+    main_path = project_root / "main.py"
+    config_path = config_path.expanduser().resolve()
+    workspace = workspace.expanduser().resolve()
+    lock = _SupervisorLock(workspace)
+    lock.acquire()
+    stopping_signal: int | None = None
+    child: subprocess.Popen[bytes] | None = None
+    forwarded_stop: tuple[subprocess.Popen[bytes], int] | None = None
+    stop_signals = {signal.SIGINT, signal.SIGTERM}
+
+    def forward_stop(signum: int, _frame: FrameType | None) -> None:
+        nonlocal stopping_signal, forwarded_stop
+        stopping_signal = signum
+        if child is not None and child.poll() is None:
+            child.send_signal(signum)
+            forwarded_stop = (child, signum)
+
+    previous_handlers = {
+        sig: signal.signal(sig, forward_stop)
+        for sig in stop_signals
+    }
+    try:
+        while True:
+            # 1. child 代际之间收到停止信号时，禁止创建下一代进程。
+            if stopping_signal is not None:
+                return 0
+            boot_id = uuid4().hex
+            nonce = secrets.token_hex(32)
+            read_fd, write_fd = os.pipe()
+            os.set_blocking(read_fd, False)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "AKASHIC_SUPERVISED": "1",
+                    "AKASHIC_BOOT_ID": boot_id,
+                    "AKASHIC_RESTART_COMMIT_FD": str(write_fd),
+                    "AKASHIC_RESTART_NONCE": nonce,
+                }
+            )
+            argv = [
+                sys.executable,
+                str(main_path),
+                "gateway",
+                "--config",
+                str(config_path),
+                "--workspace",
+                str(workspace),
+            ]
+            # 2. 屏蔽 stop handler，直到 Popen 返回且 child 所有权已建立。
+            spawn_blocked = False
+            previous_mask = signal.pthread_sigmask(
+                signal.SIG_BLOCK,
+                stop_signals,
+            )
+            try:
+                pending_stops = signal.sigpending() & stop_signals
+                if stopping_signal is not None or pending_stops:
+                    spawn_blocked = True
+                else:
+                    def restore_child_signal_mask() -> None:
+                        signal.pthread_sigmask(
+                            signal.SIG_SETMASK,
+                            previous_mask,
+                        )
+
+                    try:
+                        child = subprocess.Popen(
+                            argv,
+                            cwd=project_root,
+                            env=env,
+                            pass_fds=(write_fd,),
+                            # supervisor 单线程；exec 前只恢复继承的 signal mask。
+                            preexec_fn=restore_child_signal_mask,
+                        )
+                    except BaseException:
+                        os.close(read_fd)
+                        raise
+            finally:
+                _ = signal.pthread_sigmask(
+                    signal.SIG_SETMASK,
+                    previous_mask,
+                )
+                os.close(write_fd)
+            if spawn_blocked:
+                os.close(read_fd)
+                return 0
+
+            # 3. pending signal 恢复时 child 已有唯一 owner，可精确转发并收束。
+            assert child is not None
+            if stopping_signal is not None:
+                if (
+                    child.poll() is None
+                    and forwarded_stop != (child, stopping_signal)
+                ):
+                    child.send_signal(stopping_signal)
+                child.wait()
+                os.close(read_fd)
+                child = None
+                return 0
+            result = _wait_child(
+                child,
+                read_fd=read_fd,
+                workspace=workspace,
+                boot_id=boot_id,
+                nonce=nonce,
+                readiness_timeout_s=readiness_timeout_s,
+            )
+            child = None
+            if stopping_signal is not None:
+                return 0
+            if result.exit_code != RESTART_EXIT_CODE:
+                return _portable_exit_code(result.exit_code)
+            if not result.ready or not result.commit_valid:
+                return SUPERVISOR_FAILURE_EXIT_CODE
+    finally:
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+        lock.release()
+
+
+def _wait_child(
+    child: subprocess.Popen[bytes],
+    *,
+    read_fd: int,
+    workspace: Path,
+    boot_id: str,
+    nonce: str,
+    readiness_timeout_s: float,
+) -> _ChildResult:
+    """等待 child 退出，同时验证 readiness 与唯一 commit frame。"""
+
+    readiness_path = workspace / ".runtime-ready.json"
+    deadline = time.monotonic() + readiness_timeout_s
+    ready = False
+    buffer = bytearray()
+    try:
+        while child.poll() is None:
+            _read_available(read_fd, buffer)
+            if not ready:
+                ready = _matches_readiness(
+                    readiness_path,
+                    boot_id=boot_id,
+                    pid=child.pid,
+                )
+                if not ready and time.monotonic() >= deadline:
+                    child.terminate()
+                    try:
+                        child.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        child.kill()
+                        child.wait(timeout=5)
+                    return _ChildResult(
+                        SUPERVISOR_FAILURE_EXIT_CODE,
+                        False,
+                        False,
+                    )
+            time.sleep(0.02)
+        _read_available(read_fd, buffer)
+        if not ready:
+            ready = _matches_readiness(
+                readiness_path,
+                boot_id=boot_id,
+                pid=child.pid,
+            )
+        return _ChildResult(
+            child.returncode,
+            ready,
+            _valid_commit(bytes(buffer), boot_id=boot_id, nonce=nonce),
+        )
+    finally:
+        os.close(read_fd)
+
+
+def _read_available(fd: int, buffer: bytearray) -> None:
+    while True:
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            return
+        if not chunk:
+            return
+        buffer.extend(chunk)
+
+
+def _matches_readiness(path: Path, *, boot_id: str, pid: int) -> bool:
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return payload == {"bootId": boot_id, "pid": pid, "state": "ready"}
+
+
+def _valid_commit(payload: bytes, *, boot_id: str, nonce: str) -> bool:
+    lines = [line for line in payload.splitlines() if line]
+    if len(lines) != 1:
+        return False
+    try:
+        frame = json.loads(lines[0])
+    except json.JSONDecodeError:
+        return False
+    return (
+        isinstance(frame, dict)
+        and frame.get("type") == "restart_commit"
+        and frame.get("bootId") == boot_id
+        and secrets.compare_digest(str(frame.get("nonce") or ""), nonce)
+        and str(frame.get("requestId") or "").startswith("restart_")
+    )
+
+
+def _portable_exit_code(code: int) -> int:
+    if code >= 0:
+        return code
+    return 128 + abs(code)

--- a/agent/tools/agent_restart.py
+++ b/agent/tools/agent_restart.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.control.context import current_turn_id
+from agent.restart import RestartCoordinator
+from agent.tools.base import Tool
+from core.error_context import current_session_key
+
+
+class AgentRestartTool(Tool):
+    name = "agent_restart"
+    description = (
+        "安全重启当前 Akashic Agent。仅在核心代码或主配置必须重新加载时使用；"
+        "MCP 与插件可热重载时不要调用。执行后会等待本轮回复持久化并送达。"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "reason": {
+                "type": "string",
+                "description": "需要完整重启 Agent 的具体原因",
+                "minLength": 1,
+                "maxLength": 300,
+            }
+        },
+        "required": ["reason"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, coordinator: RestartCoordinator) -> None:
+        self._coordinator = coordinator
+
+    async def execute(
+        self,
+        reason: str,
+        channel: str = "",
+        chat_id: str = "",
+        **_: Any,
+    ) -> str:
+        request = self._coordinator.arm(
+            turn_id=current_turn_id.get(),
+            session_key=current_session_key.get() or "",
+            channel=channel,
+            chat_id=chat_id,
+            reason=reason,
+        )
+        return json.dumps(
+            {
+                "status": "scheduled",
+                "requestId": request.id,
+                "message": "将在本轮回复持久化并送达后重启。",
+            },
+            ensure_ascii=False,
+        )

--- a/agent/tools/base.py
+++ b/agent/tools/base.py
@@ -133,6 +133,10 @@ class Tool(ABC):
                     errors.extend(
                         self._validate(v, props[k], f"{path}.{k}" if path else k)
                     )
+                elif schema.get("additionalProperties") is False:
+                    errors.append(
+                        f"不允许额外字段：{path + '.' + k if path else k}"
+                    )
 
         if t == "array" and "items" in schema:
             array_value = cast(list[Any], val)

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 from collections.abc import Iterable, Set as AbstractSet
+from contextvars import ContextVar, Token
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TypedDict, cast
 
 from agent.tools.base import Tool, ToolResult
@@ -71,6 +73,8 @@ def _with_progress_description(schema: dict[str, Any], tool: Tool) -> dict[str, 
 class ToolMeta:
     risk: str = "read-only"  # "read-only" | "write" | "external-side-effect"
     always_on: bool = False
+    preloadable: bool = True
+    requires_turn_search: bool = False
     # 可选：3–10 词短语，补充工具名和描述中没有的别名或口语化表达。
     # 不需要重复名称或描述里已有的词——搜索后端自动索引 name + description。
     search_hint: str | None = None
@@ -112,6 +116,40 @@ class ToolDocument:
             source_type=source_type,
             source_name=source_name,
         )
+
+
+@dataclass
+class _TurnSearchScope:
+    turn_id: str
+    session_key: str
+    attempt: int
+    granted: set[str] = field(default_factory=lambda: set[str]())
+
+
+_TURN_SEARCH_SCOPE: ContextVar[_TurnSearchScope | None] = ContextVar(
+    "akashic_turn_search_scope",
+    default=None,
+)
+
+
+def begin_turn_search_scope(
+    *,
+    turn_id: str,
+    session_key: str,
+    attempt: int,
+) -> Token[_TurnSearchScope | None]:
+    """为一次 reasoner attempt 建立独立 search 授权域。"""
+
+    if not session_key or attempt < 0:
+        raise ValueError("turn search scope 参数无效")
+    effective_turn_id = turn_id or f"local:{id(asyncio.current_task())}"
+    return _TURN_SEARCH_SCOPE.set(
+        _TurnSearchScope(effective_turn_id, session_key, attempt)
+    )
+
+
+def end_turn_search_scope(token: Token[_TurnSearchScope | None]) -> None:
+    _TURN_SEARCH_SCOPE.reset(token)
 
 
 # ── ToolRegistry ──────────────────────────────────────────────────────────────
@@ -181,12 +219,42 @@ class ToolRegistry:
             return view.get_context()
         return self._context
 
+    def begin_turn_search_scope(
+        self,
+        *,
+        turn_id: str,
+        session_key: str,
+        attempt: int,
+    ) -> Token[_TurnSearchScope | None]:
+        """为一次 reasoner attempt 建立独立 search 授权域。"""
+
+        return begin_turn_search_scope(
+            turn_id=turn_id,
+            session_key=session_key,
+            attempt=attempt,
+        )
+
+    def end_turn_search_scope(
+        self,
+        token: Token[_TurnSearchScope | None],
+    ) -> None:
+        end_turn_search_scope(token)
+
+    def grant_current_turn_search(self, names: list[str]) -> None:
+        """只在当前 attempt 内授权 tool_search 的真实结果。"""
+
+        scope = _TURN_SEARCH_SCOPE.get()
+        if scope is not None:
+            scope.granted.update(names)
+
     def register(
         self,
         tool: Tool,
         *,
         risk: str = "read-only",
         always_on: bool = False,
+        preloadable: bool = True,
+        requires_turn_search: bool = False,
         search_hint: str | None = None,
         source_type: str = "builtin",
         source_name: str = "",
@@ -195,6 +263,8 @@ class ToolRegistry:
         meta = ToolMeta(
             risk=risk,
             always_on=always_on,
+            preloadable=preloadable,
+            requires_turn_search=requires_turn_search,
             search_hint=search_hint,
         )
         self._metadata[tool.name] = meta
@@ -274,6 +344,16 @@ class ToolRegistry:
             return view.get_always_on_names()
         return {name for name, meta in self._metadata.items() if meta.always_on}
 
+    def get_non_preloadable_names(self) -> set[str]:
+        """返回每个新 turn 都必须重新发现的工具。"""
+
+        view = self._runtime_view()
+        if view is not self:
+            return view.get_non_preloadable_names()
+        return {
+            name for name, meta in self._metadata.items() if not meta.preloadable
+        }
+
     def get_documents(self) -> list[ToolDocument]:
         """返回所有已注册工具的索引文档列表。"""
         view = self._runtime_view()
@@ -339,6 +419,41 @@ class ToolRegistry:
             if raise_errors:
                 raise RuntimeError(f"工具 '{name}' 不存在")
             return f"工具 '{name}' 不存在"
+        meta = self._metadata[name]
+        if meta.requires_turn_search:
+            scope = _TURN_SEARCH_SCOPE.get()
+            from agent.control.context import current_turn_id
+            from core.error_context import current_session_key
+
+            active_turn_id = current_turn_id.get()
+            active_session_key = current_session_key.get()
+            scope_matches_caller = (
+                scope is not None
+                and bool(active_turn_id)
+                and scope.turn_id == active_turn_id
+                and scope.session_key == active_session_key
+            )
+            if (
+                not scope_matches_caller
+                or scope is None
+                or name not in scope.granted
+            ):
+                message = (
+                    f"工具 '{name}' 必须在当前 turn 的当前 attempt 中先通过 "
+                    f'tool_search(query="select:{name}") 解锁'
+                )
+                if raise_errors:
+                    raise RuntimeError(message)
+                return message
+            validation_arguments = dict(arguments)
+            if not _tool_defines_parameter(tool, _PROGRESS_DESCRIPTION_FIELD):
+                validation_arguments.pop(_PROGRESS_DESCRIPTION_FIELD, None)
+            validation_errors = tool.validate_params(validation_arguments)
+            if validation_errors:
+                message = "; ".join(validation_errors)
+                if raise_errors:
+                    raise ValueError(message)
+                return f"工具参数无效: {message}"
         try:
             # 将会话上下文（channel、chat_id）作为低优先级默认值合并进 kwargs，
             # 工具可按需读取，不感知此机制的工具会直接忽略多余的 key。

--- a/agent/tools/tool_search.py
+++ b/agent/tools/tool_search.py
@@ -122,6 +122,7 @@ class ToolSearchTool(Tool):
             for item in results
             if isinstance(item.get("name"), str) and item["name"]
         ]
+        self._registry.grant_current_turn_search(unlocked)
         return json.dumps(
             {
                 "matched": results,
@@ -190,6 +191,7 @@ class ToolSearchTool(Tool):
                     found.append(name)
 
         matched = self._registry.get_schemas_as_doc_results(found)
+        self._registry.grant_current_turn_search(found)
         result: dict[str, Any] = {
             "matched": matched,
             "unlocked": found,

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -13,6 +13,7 @@ from agent.config import resolve_app_server_endpoint
 from agent.control.models import TurnRequest
 from agent.control.runtime import ConversationRuntime
 from agent.control.service import ControlService
+from agent.restart import RestartCoordinator
 from agent.config_models import Config
 from bootstrap.channel_host import ChannelHost
 from bootstrap.channels import start_channels
@@ -21,6 +22,7 @@ from bootstrap.cleanup import run_cleanup_steps
 from bootstrap.control_execution import execute_control_turn
 from bootstrap.dashboard_api import build_dashboard_server
 from bootstrap.proactive import build_memory_optimizer_task, build_proactive_runtime
+from bootstrap.runtime_readiness import RuntimeReadiness
 from bootstrap.passive_worker import PassiveMessageWorker
 from bootstrap.tools import CoreRuntime, build_core_runtime
 from bootstrap.workspace_lock import WorkspaceInstanceLock
@@ -71,6 +73,16 @@ def _release_workspace_lock(
         lock.release()
 
     return release
+
+
+def _clear_readiness(
+    readiness: RuntimeReadiness | None,
+) -> Callable[[], Awaitable[None]]:
+    async def clear() -> None:
+        if readiness is not None:
+            readiness.clear()
+
+    return clear
 
 
 def _raise_unexpected_task_errors(name: str, results: list[object]) -> None:
@@ -165,9 +177,18 @@ def _wait_server_task(
 
 
 class AppRuntime:
-    def __init__(self, config: Config, workspace: Path) -> None:
+    def __init__(
+        self,
+        config: Config,
+        workspace: Path,
+        *,
+        restart_coordinator: RestartCoordinator | None = None,
+        readiness: RuntimeReadiness | None = None,
+    ) -> None:
         self.config = config
         self.workspace = workspace
+        self.restart_coordinator = restart_coordinator
+        self.readiness = readiness
         self.http_resources = SharedHttpResources()
         self.app_server: SocketAppServer | None = None
         self.conversation_runtime: ConversationRuntime | None = None
@@ -215,10 +236,16 @@ class AppRuntime:
         self._workspace_lock.acquire()
         try:
             configure_default_shared_http_resources(self.http_resources)
+            core_kwargs = (
+                {"restart_coordinator": self.restart_coordinator}
+                if self.restart_coordinator is not None
+                else {}
+            )
             self.core = build_core_runtime(
                 self.config,
                 self.workspace,
                 self.http_resources,
+                **core_kwargs,
             )
             self.agent_loop = self.core.loop
             self.bus = self.core.bus
@@ -250,7 +277,13 @@ class AppRuntime:
             self.conversation_runtime = ConversationRuntime(
                 self.session_manager.control_store,
                 _execute_control_request,
+                restart_coordinator=self.restart_coordinator,
             )
+            if self.restart_coordinator is not None:
+                self.restart_coordinator.bind_admission(
+                    quiesce=self.conversation_runtime.quiesce_for_restart,
+                    resume=self.conversation_runtime.resume_after_restart_cancel,
+                )
             app_server_endpoint: str | None = None
             workspace_token: str | None = None
             if self.config.app_server.enabled:
@@ -271,12 +304,34 @@ class AppRuntime:
                     else None
                 ),
                 workspace_token=workspace_token,
+                restart_coordinator=self.restart_coordinator,
+                boot_id=self.readiness.boot_id if self.readiness else None,
+                ready=(lambda: self.readiness.ready) if self.readiness else None,
             )
             self.passive_worker = PassiveMessageWorker(
                 self.bus,
                 self.conversation_runtime,
                 self.agent_loop,
             )
+            if self.restart_coordinator is not None:
+                coordinator = self.restart_coordinator
+
+                async def observe_delivery(
+                    message: Any,
+                    delivered: bool,
+                ) -> None:
+                    turn_id = str(message.control_turn_id or "")
+                    if not turn_id:
+                        return
+                    if delivered:
+                        coordinator.mark_delivered(turn_id)
+                    else:
+                        coordinator.mark_delivery_failed(
+                            turn_id,
+                            "channel callback did not deliver original response",
+                        )
+
+                self.bus.bind_outbound_delivery_observer(observe_delivery)
             if self.config.app_server.enabled:
                 assert app_server_endpoint is not None
                 self.app_server = SocketAppServer(
@@ -472,10 +527,17 @@ class AppRuntime:
                 )
                 if task is not None
             }
-            done, _ = await asyncio.wait(
-                {self._primary_task, *watched_tasks},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            supervised_tasks = {self._primary_task, *watched_tasks}
+
+            # runtime task 获得一次调度机会后仍存活，才对外发布 ready。
+            done, _ = await asyncio.wait(supervised_tasks, timeout=0)
+            if not done:
+                if self.readiness is not None:
+                    self.readiness.mark_ready()
+                done, _ = await asyncio.wait(
+                    supervised_tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
             if self._primary_task in done:
                 await self._primary_task
             else:
@@ -644,6 +706,10 @@ class AppRuntime:
                     else _noop_async,
                 ),
                 ("http_resources.aclose", self.http_resources.aclose),
+                (
+                    "runtime_readiness.clear",
+                    _clear_readiness(self.readiness),
+                ),
                 ("workspace_lock.release", _release_workspace_lock(self._workspace_lock)),
             )
         finally:
@@ -763,5 +829,16 @@ class AppRuntime:
             self.channel_host.commit_plugin_swap(swap)
 
 
-def build_app_runtime(config: Config, workspace: Path | None = None) -> AppRuntime:
-    return AppRuntime(config, workspace or (Path.home() / ".akashic" / "workspace"))
+def build_app_runtime(
+    config: Config,
+    workspace: Path | None = None,
+    *,
+    restart_coordinator: RestartCoordinator | None = None,
+    readiness: RuntimeReadiness | None = None,
+) -> AppRuntime:
+    return AppRuntime(
+        config,
+        workspace or (Path.home() / ".akashic" / "workspace"),
+        restart_coordinator=restart_coordinator,
+        readiness=readiness,
+    )

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Any, cast
 
-from agent.control.errors import ThreadBusyError
+from agent.control.errors import RuntimeClosedError, ThreadBusyError
 from agent.control.models import TurnRequest, TurnStatus
 from agent.control.runtime import ConversationRuntime
 from agent.looping.core import AgentLoop
@@ -103,6 +103,15 @@ class PassiveMessageWorker:
                     handle = await self._runtime.start_turn(request)
                 except ThreadBusyError:
                     continue
+                except RuntimeClosedError:
+                    await self._bus.publish_outbound(
+                        OutboundMessage(
+                            channel=item.channel,
+                            chat_id=item.chat_id,
+                            content="服务正在重启，请稍后重发这条消息。",
+                        )
+                    )
+                    return
                 break
             result = await handle.result()
 
@@ -120,6 +129,7 @@ class PassiveMessageWorker:
                     reply_to=cast(str | None, data.get("replyTo")),
                     media=list(cast(list[str], data.get("media", []))),
                     metadata=dict(cast(dict[str, Any], data.get("metadata", {}))),
+                    control_turn_id=handle.id,
                 )
             elif result.status is TurnStatus.FAILED:
                 outbound = OutboundMessage(

--- a/bootstrap/runtime_readiness.py
+++ b/bootstrap/runtime_readiness.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+class RuntimeReadiness:
+    """发布并清理当前 supervised boot 的完整启动状态。"""
+
+    def __init__(self, workspace: Path, boot_id: str) -> None:
+        if not boot_id:
+            raise ValueError("boot_id 不能为空")
+        self.path = workspace / ".runtime-ready.json"
+        self.boot_id = boot_id
+        self.pid = os.getpid()
+        self.ready = False
+
+    def mark_ready(self) -> None:
+        """在完整 AppRuntime.start 成功后原子发布 readiness。"""
+
+        payload = {
+            "bootId": self.boot_id,
+            "pid": self.pid,
+            "state": "ready",
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(
+            f".{self.path.name}.{self.pid}.{self.boot_id}.tmp"
+        )
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(temporary, self.path)
+        self.ready = True
+
+    def clear(self) -> None:
+        """仅删除仍属于当前 boot 的 readiness 文件。"""
+
+        self.ready = False
+        if not self.path.exists():
+            return
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        if payload.get("bootId") == self.boot_id and payload.get("pid") == self.pid:
+            self.path.unlink()

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 if TYPE_CHECKING:
     from agent.plugins.manager import PluginManager
+    from agent.restart import RestartCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -323,6 +324,7 @@ def build_registered_tools(
     tools: ToolRegistry | None = None,
     event_publisher=None,
     agent_loop_provider: Callable[[], Any] | None = None,
+    restart_coordinator: "RestartCoordinator | None" = None,
 ) -> tuple[
     ToolRegistry,
     MessagePushTool,
@@ -393,6 +395,23 @@ def build_registered_tools(
                 scheduler=scheduler,
                 event_publisher=event_publisher,
             ),
+        )
+
+    # 3. 自重启只在 supervisor 与 tool_search 两个边界都成立时注册。
+    if (
+        restart_coordinator is not None
+        and restart_coordinator.supervised
+        and config.tool_search_enabled
+    ):
+        from agent.tools.agent_restart import AgentRestartTool
+
+        tools.register(
+            AgentRestartTool(restart_coordinator),
+            risk="external-side-effect",
+            always_on=False,
+            preloadable=False,
+            requires_turn_search=True,
+            search_hint="重启 akashic agent 服务 重新加载核心配置",
         )
 
     return (
@@ -488,6 +507,7 @@ def build_core_runtime(
     config: Config,
     workspace: Path,
     http_resources: SharedHttpResources,
+    restart_coordinator: "RestartCoordinator | None" = None,
 ) -> CoreRuntime:
     """构造核心运行时及其插件快照依赖。"""
 
@@ -513,6 +533,7 @@ def build_core_runtime(
             session_store=session_manager._store,
             event_publisher=event_bus,
             agent_loop_provider=lambda: loop_ref.get("loop"),
+            restart_coordinator=restart_coordinator,
         )
     )
     presence = PresenceStore(session_manager._store)

--- a/bus/events.py
+++ b/bus/events.py
@@ -57,6 +57,7 @@ class OutboundMessage:
     reply_to: str | None = None
     media: list[str] = field(default_factory=_empty_media)
     metadata: dict[str, Any] = field(default_factory=_empty_metadata)
+    control_turn_id: str | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -188,6 +188,19 @@ class MessageBus:
         ] = {}
         self._chat_lane = chat_lane or ChatLane()
         self._running = False
+        self._delivery_observer: (
+            Callable[[OutboundMessage, bool], Awaitable[None]] | None
+        ) = None
+
+    def bind_outbound_delivery_observer(
+        self,
+        callback: Callable[[OutboundMessage, bool], Awaitable[None]],
+    ) -> None:
+        """绑定唯一出站送达观察者。"""
+
+        if self._delivery_observer is not None:
+            raise RuntimeError("outbound delivery observer 已绑定")
+        self._delivery_observer = callback
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
@@ -239,16 +252,22 @@ class MessageBus:
         while self._running:
             try:
                 msg = await asyncio.wait_for(self._outbound.get(), timeout=1.0)
-                await self._chat_lane.run_passive(
+                delivered = await self._chat_lane.run_passive(
                     msg.channel,
                     msg.chat_id,
                     lambda: self._send_outbound(msg),
                 )
+                if self._delivery_observer is not None:
+                    await self._delivery_observer(msg, delivered)
             except asyncio.TimeoutError:
                 continue
 
-    async def _send_outbound(self, msg: OutboundMessage) -> None:
-        for cb in tuple(self._subscribers.get(msg.channel, [])):
+    async def _send_outbound(self, msg: OutboundMessage) -> bool:
+        """发送原始消息，并区分原消息与降级文案的结果。"""
+
+        callbacks = tuple(self._subscribers.get(msg.channel, []))
+        delivered = bool(callbacks)
+        for cb in callbacks:
             try:
                 await cb(msg)
             except Exception as first_err:
@@ -259,6 +278,7 @@ class MessageBus:
                 try:
                     await cb(msg)
                 except Exception as second_err:
+                    delivered = False
                     logger.error(
                         f"分发消息到 {msg.channel} 重试仍失败，发送降级通知: {second_err}"
                     )
@@ -274,6 +294,7 @@ class MessageBus:
                             f"降级通知也失败，消息彻底丢失  channel={msg.channel} "
                             f"chat_id={msg.chat_id}"
                         )
+        return delivered
 
     def stop(self) -> None:
         self._running = False

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -138,6 +138,19 @@ docker compose -f docker/debug/docker-compose.yml up akashic-debug
 
 此时向调试 Telegram bot 发消息或图片，所有会话和记忆都会进入 `docker/debug/profiles/default/workspace`。
 
+调试容器现在通过固定 supervisor 启动 gateway。supervisor 只会在当前 boot 已 ready、
+`agent_restart` 的最终回复已经实际送达、child 向继承私有管道提交一次匹配证据，且 child
+以 75 退出时拉起下一代进程。普通退出、崩溃、伪造 75、断线和送达超时都不会触发重启。
+
+本机若仍由忽略版本控制的 `start.sh` 启动，应把最终执行命令迁移为：
+
+```bash
+python main.py supervise --config /absolute/config.toml --workspace /absolute/workspace
+```
+
+不要在外层脚本再做 `while`、`pgrep` 或“任意非零退出就重启”；进程唯一性、信号转发、
+readiness 和重启授权均由 supervisor 持有。
+
 ## 多套调试配置
 
 不同功能可以用不同 profile 保存配置和 workspace：

--- a/docker/debug/entrypoint.sh
+++ b/docker/debug/entrypoint.sh
@@ -94,7 +94,7 @@ case "$cmd" in
             echo "缺少 $CONFIG，请先运行 setup。" >&2
             exit 2
         fi
-        exec_as_host python main.py gateway \
+        exec_as_host python main.py supervise \
             --config "$CONFIG" \
             --workspace "$WORKSPACE" \
             "$@"

--- a/infra/control/connection.py
+++ b/infra/control/connection.py
@@ -11,7 +11,7 @@ from agent.control.service import ControlService
 @dataclass(frozen=True)
 class _PendingFrame:
     payload: bytes
-    written: asyncio.Future[None]
+    written: asyncio.Future[None] | None
 
 
 class NdjsonConnection:
@@ -42,13 +42,18 @@ class NdjsonConnection:
 
     async def send(self, message: dict[str, object]) -> None:
         encoded = (json.dumps(message, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
-        written = asyncio.get_running_loop().create_future()
+        written = (
+            asyncio.get_running_loop().create_future()
+            if message.get("method") == "turn/completed"
+            else None
+        )
         try:
             self._queue.put_nowait(_PendingFrame(encoded, written))
         except asyncio.QueueFull as exc:
             self._writer.close()
             raise ConnectionError("client outbound queue is full") from exc
-        await asyncio.shield(written)
+        if written is not None:
+            await asyncio.shield(written)
 
     async def run(self) -> None:
         writer_task = asyncio.create_task(self._write_loop(), name="control-writer")
@@ -100,15 +105,19 @@ class NdjsonConnection:
                 self._writer.write(frame.payload)
                 await self._writer.drain()
             except BaseException as exc:
-                if not frame.written.done():
+                if frame.written is not None and not frame.written.done():
                     frame.written.set_exception(exc)
                 self._fail_pending_frames(exc)
                 raise
-            if not frame.written.done():
+            if frame.written is not None and not frame.written.done():
                 frame.written.set_result(None)
 
     def _fail_pending_frames(self, error: BaseException) -> None:
         while not self._queue.empty():
             frame = self._queue.get_nowait()
-            if frame is not None and not frame.written.done():
+            if (
+                frame is not None
+                and frame.written is not None
+                and not frame.written.done()
+            ):
                 frame.written.set_exception(error)

--- a/infra/control/connection.py
+++ b/infra/control/connection.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
 
 from agent.control.protocol.router import ConnectionRouter
 from agent.control.service import ControlService
+
+
+@dataclass(frozen=True)
+class _PendingFrame:
+    payload: bytes
+    written: asyncio.Future[None]
 
 
 class NdjsonConnection:
@@ -22,7 +29,9 @@ class NdjsonConnection:
     ) -> None:
         self._reader = reader
         self._writer = writer
-        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue(outbound_queue_size)
+        self._queue: asyncio.Queue[_PendingFrame | None] = asyncio.Queue(
+            outbound_queue_size
+        )
         self._max_message_bytes = max_message_bytes
         self._router = ConnectionRouter(
             service,
@@ -33,11 +42,13 @@ class NdjsonConnection:
 
     async def send(self, message: dict[str, object]) -> None:
         encoded = (json.dumps(message, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+        written = asyncio.get_running_loop().create_future()
         try:
-            self._queue.put_nowait(encoded)
+            self._queue.put_nowait(_PendingFrame(encoded, written))
         except asyncio.QueueFull as exc:
             self._writer.close()
             raise ConnectionError("client outbound queue is full") from exc
+        await asyncio.shield(written)
 
     async def run(self) -> None:
         writer_task = asyncio.create_task(self._write_loop(), name="control-writer")
@@ -82,8 +93,22 @@ class NdjsonConnection:
 
     async def _write_loop(self) -> None:
         while True:
-            payload = await self._queue.get()
-            if payload is None:
+            frame = await self._queue.get()
+            if frame is None:
                 return
-            self._writer.write(payload)
-            await self._writer.drain()
+            try:
+                self._writer.write(frame.payload)
+                await self._writer.drain()
+            except BaseException as exc:
+                if not frame.written.done():
+                    frame.written.set_exception(exc)
+                self._fail_pending_frames(exc)
+                raise
+            if not frame.written.done():
+                frame.written.set_result(None)
+
+    def _fail_pending_frames(self, error: BaseException) -> None:
+        while not self._queue.empty():
+            frame = self._queue.get_nowait()
+            if frame is not None and not frame.written.done():
+                frame.written.set_exception(error)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 
 主要模式：
   python main.py gateway            启动完整 agent 与 app-server
+  python main.py supervise          以固定 supervisor 托管 gateway
   python main.py app-server --stdio 启动父进程托管控制面
   python main.py exec ...           非交互执行一个 turn
 """
@@ -49,6 +50,8 @@ if __name__ == "__main__" and _run_lightweight_setup_command():
 
 from agent.config import Config, resolve_app_server_endpoint
 from agent.control.client import ControlClient, RemoteControlError
+from agent.restart import RestartCoordinator, SupervisorCommitChannel
+from agent.supervisor import RESTART_EXIT_CODE, run_supervisor
 from agent.plugins.doctor import format_plugin_doctor_report, run_plugin_doctor
 from agent.plugins.install import (
     install_git_plugin,
@@ -59,6 +62,7 @@ from bootstrap.app import build_app_runtime
 from bootstrap.dashboard_api import run_dashboard_api
 from bootstrap.init_workspace import InitSummary, init_workspace
 from bootstrap.memory import build_memory_admin_runtime
+from bootstrap.runtime_readiness import RuntimeReadiness
 from bootstrap.workspace_token import read_workspace_token
 from bootstrap.providers import build_providers
 from core.net.http import SharedHttpResources
@@ -73,6 +77,7 @@ _HELP = """\
   setup-main                    仅切换主模型并保留其他配置
   init                          非交互初始化配置和工作区
   gateway                       启动 Agent 服务
+  supervise                     以固定 supervisor 托管 Agent 服务
   app-server --stdio            在 stdio 上运行程序化控制面
   exec --new|--thread ID PROMPT 执行一个非交互 turn
   dashboard                     单独启动 Dashboard
@@ -102,6 +107,21 @@ def _get_flag_value(args: list[str], flag: str) -> str | None:
     if idx + 1 >= len(args):
         raise ValueError(f"参数 {flag} 缺少值")
     return args[idx + 1]
+
+
+def _validate_supervise_args(args: list[str]) -> None:
+    """限制 supervise 只能接收固定 gateway 所需路径参数。"""
+
+    index = 0
+    seen: set[str] = set()
+    while index < len(args):
+        flag = args[index]
+        if flag not in {"--config", "--workspace"}:
+            raise ValueError(f"supervise 不支持参数: {flag}")
+        if flag in seen or index + 1 >= len(args):
+            raise ValueError(f"supervise 参数无效: {flag}")
+        seen.add(flag)
+        index += 2
 
 
 def _print_init_summary(summary: InitSummary) -> None:
@@ -298,11 +318,29 @@ async def inspect_modules(
 async def serve(
     config_path: str = "config.toml",
     workspace: Path | None = None,
-) -> None:
+) -> int:
     config = Config.load(config_path)
+    workspace = workspace or _default_workspace()
+    commit_channel = SupervisorCommitChannel.from_environment()
+    restart_coordinator = (
+        RestartCoordinator(
+            commit_channel.boot_id,
+            supervised=True,
+            commit=commit_channel.commit,
+        )
+        if commit_channel is not None
+        else None
+    )
+    readiness = (
+        RuntimeReadiness(workspace, commit_channel.boot_id)
+        if commit_channel is not None
+        else None
+    )
     runtime = build_app_runtime(
         config,
-        workspace=workspace or _default_workspace(),
+        workspace=workspace,
+        restart_coordinator=restart_coordinator,
+        readiness=readiness,
     )
     loop = asyncio.get_running_loop()
     stop_event = asyncio.Event()
@@ -321,18 +359,34 @@ async def serve(
 
     runtime_task = asyncio.create_task(runtime.run(), name="app_runtime")
     stop_task = asyncio.create_task(stop_event.wait(), name="shutdown_signal")
+    restart_task = (
+        asyncio.create_task(
+            restart_coordinator.wait_committed(),
+            name="restart_committed",
+        )
+        if restart_coordinator is not None
+        else None
+    )
     try:
+        watched = {runtime_task, stop_task}
+        if restart_task is not None:
+            watched.add(restart_task)
         done, _ = await asyncio.wait(
-            {runtime_task, stop_task},
+            watched,
             return_when=asyncio.FIRST_COMPLETED,
         )
         if runtime_task in done:
             _ = stop_task.cancel()
             await runtime_task
-            return
+            return 0
+        restart_requested = False
+        if restart_task is not None and restart_task in done:
+            await restart_task
+            restart_requested = True
         _ = runtime_task.cancel()
         with suppress(asyncio.CancelledError):
             await runtime_task
+        return RESTART_EXIT_CODE if restart_requested else 0
     finally:
         if signal_handlers_registered:
             for sig in watched_signals:
@@ -340,6 +394,10 @@ async def serve(
         _ = stop_task.cancel()
         with suppress(asyncio.CancelledError):
             await stop_task
+        if restart_task is not None:
+            _ = restart_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await restart_task
 
 
 if __name__ == "__main__":
@@ -467,9 +525,21 @@ if __name__ == "__main__":
             print(format_plugin_doctor_report(report))
         sys.exit(1 if report.get("status") == "broken" else 0)
 
+    if args and args[0] == "supervise":
+        try:
+            _validate_supervise_args(args[1:])
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(2)
+        sys.exit(
+            run_supervisor(
+                config_path=Path(config_path),
+                workspace=workspace or _default_workspace(),
+            )
+        )
+
     if args and args[0] == "gateway":
-        asyncio.run(serve(config_path, workspace))
-        sys.exit(0)
+        sys.exit(asyncio.run(serve(config_path, workspace)))
 
     if args and args[0] == "app-server":
         if "--stdio" not in args:

--- a/tests/test_agent_restart.py
+++ b/tests/test_agent_restart.py
@@ -1,0 +1,725 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from agent.control.context import current_turn_id
+from agent.control.errors import RuntimeClosedError
+from agent.control.models import TurnRequest
+from agent.control.protocol.router import ConnectionRouter
+from agent.control.runtime import ConversationRuntime
+from agent.restart import (
+    RestartCoordinator,
+    RestartRejectedError,
+    RestartState,
+    SupervisorCommitChannel,
+)
+import agent.supervisor as supervisor_module
+from agent.supervisor import RESTART_EXIT_CODE, _wait_child, run_supervisor
+from agent.tools.agent_restart import AgentRestartTool
+from agent.tools.registry import ToolRegistry
+from agent.tools.tool_search import ToolSearchTool
+from bootstrap.runtime_readiness import RuntimeReadiness
+from bootstrap.app import AppRuntime
+from core.error_context import current_session_key
+from infra.control.connection import NdjsonConnection
+from session.store import SessionStore
+
+
+class _Admission:
+    def __init__(self) -> None:
+        self.quiesced: list[str] = []
+        self.resumed: list[str] = []
+
+    def quiesce(self, turn_id: str) -> None:
+        self.quiesced.append(turn_id)
+
+    def resume(self, turn_id: str) -> None:
+        self.resumed.append(turn_id)
+
+
+def _coordinator(
+    *,
+    timeout: float = 1.0,
+) -> tuple[RestartCoordinator, _Admission, list[str]]:
+    admission = _Admission()
+    commits: list[str] = []
+    coordinator = RestartCoordinator(
+        "boot-a",
+        supervised=True,
+        commit=lambda request: commits.append(request.id),
+        delivery_timeout_s=timeout,
+    )
+    coordinator.bind_admission(
+        quiesce=admission.quiesce,
+        resume=admission.resume,
+    )
+    return coordinator, admission, commits
+
+
+@pytest.mark.asyncio
+async def test_restart_commits_only_after_terminal_and_delivery() -> None:
+    coordinator, admission, commits = _coordinator()
+
+    request = coordinator.arm(
+        turn_id="turn-a",
+        session_key="programmatic:one",
+        channel="programmatic",
+        chat_id="one",
+        reason="reload core",
+    )
+    same_request = coordinator.arm(
+        turn_id="turn-a",
+        session_key="programmatic:one",
+        channel="programmatic",
+        chat_id="one",
+        reason="ignored by idempotency",
+    )
+    with pytest.raises(RestartRejectedError):
+        coordinator.arm(
+            turn_id="turn-b",
+            session_key="programmatic:two",
+            channel="programmatic",
+            chat_id="two",
+            reason="competing request",
+        )
+
+    assert same_request is request
+    assert admission.quiesced == ["turn-a"]
+    coordinator.mark_delivered("turn-a")
+    assert commits == []
+    coordinator.mark_turn_terminal("turn-a", "completed")
+
+    assert await coordinator.wait_committed() is request
+    assert commits == [request.id]
+    assert coordinator.state is RestartState.COMMITTED
+
+    coordinator.mark_turn_terminal("turn-a", "completed")
+    coordinator.mark_delivered("turn-a")
+    assert commits == [request.id]
+
+
+@pytest.mark.asyncio
+async def test_restart_failure_and_timeout_restore_admission() -> None:
+    coordinator, admission, _ = _coordinator(timeout=0.01)
+    coordinator.arm(
+        turn_id="turn-failed",
+        session_key="telegram:1",
+        channel="telegram",
+        chat_id="1",
+        reason="reload core",
+    )
+    coordinator.mark_turn_terminal("turn-failed", "failed")
+
+    assert coordinator.pending is None
+    assert admission.resumed == ["turn-failed"]
+
+    coordinator.arm(
+        turn_id="turn-timeout",
+        session_key="telegram:1",
+        channel="telegram",
+        chat_id="1",
+        reason="reload core",
+    )
+    coordinator.mark_turn_terminal("turn-timeout", "completed")
+    await asyncio.sleep(0.03)
+
+    assert coordinator.pending is None
+    assert admission.resumed == ["turn-failed", "turn-timeout"]
+    assert "timed out" in str(coordinator.last_error)
+
+
+@pytest.mark.asyncio
+async def test_conversation_runtime_drains_before_restart_commit(
+    tmp_path: Path,
+) -> None:
+    commits: list[str] = []
+    coordinator = RestartCoordinator(
+        "boot-a",
+        supervised=True,
+        commit=lambda request: commits.append(request.id),
+    )
+    store = SessionStore(tmp_path / "sessions.db")
+    armed = asyncio.Event()
+    release = asyncio.Event()
+    turn_holder: dict[str, str] = {}
+
+    async def execute(_request: TurnRequest) -> str:
+        coordinator.arm(
+            turn_id=turn_holder["id"],
+            session_key="programmatic:one",
+            channel="programmatic",
+            chat_id="one",
+            reason="reload core",
+        )
+        armed.set()
+        await release.wait()
+        return "restart scheduled"
+
+    runtime = ConversationRuntime(
+        store,
+        execute,
+        restart_coordinator=coordinator,
+    )
+    coordinator.bind_admission(
+        quiesce=runtime.quiesce_for_restart,
+        resume=runtime.resume_after_restart_cancel,
+    )
+    handle = await runtime.start_turn(TurnRequest("programmatic:one", "restart"))
+    turn_holder["id"] = handle.id
+    await armed.wait()
+
+    with pytest.raises(RuntimeClosedError):
+        await runtime.start_turn(TurnRequest("programmatic:two", "late"))
+    release.set()
+    result = await handle.result()
+    assert result.status.value == "completed"
+    assert commits == []
+
+    coordinator.mark_delivered(handle.id)
+    assert (await coordinator.wait_committed()).turn_id == handle.id
+    assert len(commits) == 1
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_router_disconnect_restores_admission_immediately() -> None:
+    coordinator, admission, _ = _coordinator(timeout=60)
+    coordinator.arm(
+        turn_id="turn-disconnect",
+        session_key="programmatic:one",
+        channel="programmatic",
+        chat_id="one",
+        reason="reload core",
+    )
+    coordinator.mark_turn_terminal("turn-disconnect", "completed")
+    entered = asyncio.Event()
+
+    class _Handle:
+        id = "turn-disconnect"
+
+        async def events(self):
+            entered.set()
+            await asyncio.Event().wait()
+            yield None
+
+    class _Service:
+        def notify_turn_delivery_failed(self, turn_id: str, reason: str) -> None:
+            coordinator.mark_delivery_failed(turn_id, reason)
+
+    async def send(_message: dict[str, object]) -> None:
+        raise AssertionError("terminal frame must not be sent")
+
+    router = ConnectionRouter(cast(Any, _Service()), send)
+    task = asyncio.create_task(router._forward_events(_Handle()))
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert coordinator.pending is None
+    assert admission.resumed == ["turn-disconnect"]
+    assert "connection closed" in str(coordinator.last_error)
+
+
+@pytest.mark.asyncio
+async def test_agent_restart_requires_current_attempt_search_grant() -> None:
+    coordinator, _, _ = _coordinator()
+    registry = ToolRegistry()
+    registry.register(ToolSearchTool(registry), always_on=True)
+    registry.register(
+        AgentRestartTool(coordinator),
+        risk="external-side-effect",
+        preloadable=False,
+        requires_turn_search=True,
+    )
+    registry.set_context(channel="programmatic", chat_id="one")
+    turn_token = current_turn_id.set("turn-a")
+    session_token = current_session_key.set("programmatic:one")
+    scope = registry.begin_turn_search_scope(
+        turn_id="turn-a",
+        session_key="programmatic:one",
+        attempt=0,
+    )
+    try:
+        denied = await registry.execute("agent_restart", {"reason": "reload"})
+        assert "必须在当前 turn" in str(denied)
+
+        _ = await registry.execute(
+            "tool_search",
+            {"query": "select:agent_restart"},
+            raise_errors=True,
+        )
+        with pytest.raises(ValueError, match="不允许额外字段"):
+            await registry.execute(
+                "agent_restart",
+                {"reason": "reload", "command": "rm -rf /"},
+                raise_errors=True,
+            )
+        scheduled = await registry.execute(
+            "agent_restart",
+            {"reason": "reload"},
+            raise_errors=True,
+        )
+        assert json.loads(str(scheduled))["status"] == "scheduled"
+    finally:
+        registry.end_turn_search_scope(scope)
+        current_session_key.reset(session_token)
+        current_turn_id.reset(turn_token)
+
+    assert "agent_restart" in registry.get_non_preloadable_names()
+    assert "agent_restart" not in registry.get_always_on_names()
+
+
+def test_supervisor_commit_channel_uses_inherited_fd(monkeypatch: pytest.MonkeyPatch) -> None:
+    read_fd, write_fd = os.pipe()
+    monkeypatch.setenv("AKASHIC_SUPERVISED", "1")
+    monkeypatch.setenv("AKASHIC_BOOT_ID", "boot-a")
+    monkeypatch.setenv("AKASHIC_RESTART_NONCE", "n" * 64)
+    monkeypatch.setenv("AKASHIC_RESTART_COMMIT_FD", str(write_fd))
+    try:
+        channel = SupervisorCommitChannel.from_environment()
+        assert channel is not None
+        assert channel.fd == write_fd
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+    monkeypatch.setenv("AKASHIC_RESTART_COMMIT_FD", str(write_fd))
+    with pytest.raises(OSError):
+        SupervisorCommitChannel.from_environment()
+
+
+def _spawn_supervisor_child(
+    tmp_path: Path,
+    *,
+    boot_id: str,
+    nonce: str,
+    frame_count: int,
+    exit_code: int = RESTART_EXIT_CODE,
+) -> tuple[subprocess.Popen[bytes], int]:
+    read_fd, write_fd = os.pipe()
+    code = """
+import json, os, pathlib, sys, time
+workspace = pathlib.Path(sys.argv[1])
+boot_id, nonce, write_fd, frame_count, exit_code = sys.argv[2:]
+payload = {'bootId': boot_id, 'pid': os.getpid(), 'state': 'ready'}
+temporary = workspace / f'.runtime-ready.{os.getpid()}.tmp'
+temporary.write_text(json.dumps(payload))
+os.replace(temporary, workspace / '.runtime-ready.json')
+frame = {'type': 'restart_commit', 'bootId': boot_id, 'nonce': nonce, 'requestId': 'restart_test'}
+for _ in range(int(frame_count)):
+    os.write(int(write_fd), (json.dumps(frame) + '\\n').encode())
+time.sleep(0.05)
+raise SystemExit(int(exit_code))
+"""
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            code,
+            str(tmp_path),
+            boot_id,
+            nonce,
+            str(write_fd),
+            str(frame_count),
+            str(exit_code),
+        ],
+        pass_fds=(write_fd,),
+    )
+    os.close(write_fd)
+    return child, read_fd
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "expected"),
+    [(1, True), (0, False), (2, False)],
+)
+def test_real_child_exit_75_requires_unique_private_commit(
+    tmp_path: Path,
+    frame_count: int,
+    expected: bool,
+) -> None:
+    child, read_fd = _spawn_supervisor_child(
+        tmp_path,
+        boot_id="boot-live",
+        nonce="secret-nonce",
+        frame_count=frame_count,
+    )
+
+    result = _wait_child(
+        child,
+        read_fd=read_fd,
+        workspace=tmp_path,
+        boot_id="boot-live",
+        nonce="secret-nonce",
+        readiness_timeout_s=2,
+    )
+
+    assert result.exit_code == RESTART_EXIT_CODE
+    assert result.ready is True
+    assert result.commit_valid is expected
+
+
+def test_runtime_readiness_is_boot_and_pid_scoped(tmp_path: Path) -> None:
+    readiness = RuntimeReadiness(tmp_path, "boot-current")
+    readiness.mark_ready()
+
+    assert readiness.ready is True
+    payload = json.loads((tmp_path / ".runtime-ready.json").read_text())
+    assert payload == {
+        "bootId": "boot-current",
+        "pid": os.getpid(),
+        "state": "ready",
+    }
+
+    (tmp_path / ".runtime-ready.json").write_text(
+        json.dumps({"bootId": "other", "pid": 1, "state": "ready"})
+    )
+    readiness.clear()
+    assert (tmp_path / ".runtime-ready.json").exists()
+
+
+def test_stale_readiness_cannot_satisfy_new_boot(tmp_path: Path) -> None:
+    (tmp_path / ".runtime-ready.json").write_text(
+        json.dumps({"bootId": "old", "pid": 1, "state": "ready"})
+    )
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(2)"])
+
+    result = _wait_child(
+        child,
+        read_fd=read_fd,
+        workspace=tmp_path,
+        boot_id="new",
+        nonce="secret",
+        readiness_timeout_s=0.05,
+    )
+
+    assert result.ready is False
+    assert child.poll() is not None
+
+
+class _ReadinessProbe:
+    def __init__(self) -> None:
+        self.ready = False
+        self.marked = asyncio.Event()
+
+    def mark_ready(self) -> None:
+        self.ready = True
+        self.marked.set()
+
+
+def _runtime_with_probe(tmp_path: Path) -> tuple[AppRuntime, _ReadinessProbe]:
+    runtime = AppRuntime(cast(Any, object()), tmp_path)
+    probe = _ReadinessProbe()
+    runtime.readiness = cast(Any, probe)
+
+    async def start() -> None:
+        runtime._started = True
+
+    async def shutdown() -> None:
+        runtime._started = False
+
+    runtime.start = start  # type: ignore[method-assign]
+    runtime.shutdown = shutdown  # type: ignore[method-assign]
+    return runtime, probe
+
+
+@pytest.mark.asyncio
+async def test_runtime_schedule_failure_never_publishes_ready(tmp_path: Path) -> None:
+    runtime, probe = _runtime_with_probe(tmp_path)
+
+    def fail_schedule() -> list[asyncio.Future[Any]]:
+        raise RuntimeError("schedule failed")
+
+    runtime._schedule_runtime_tasks = fail_schedule  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="schedule failed"):
+        await runtime.run()
+    assert probe.ready is False
+
+
+@pytest.mark.asyncio
+async def test_primary_immediate_failure_never_publishes_ready(tmp_path: Path) -> None:
+    runtime, probe = _runtime_with_probe(tmp_path)
+
+    async def fail_immediately() -> None:
+        raise RuntimeError("primary failed")
+
+    runtime._schedule_runtime_tasks = (  # type: ignore[method-assign]
+        lambda: [asyncio.create_task(fail_immediately())]
+    )
+    with pytest.raises(RuntimeError, match="primary failed"):
+        await runtime.run()
+    assert probe.ready is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_publishes_ready_only_after_tasks_survive_gate(
+    tmp_path: Path,
+) -> None:
+    runtime, probe = _runtime_with_probe(tmp_path)
+    release = asyncio.Event()
+
+    async def stay_running() -> None:
+        await release.wait()
+
+    runtime._schedule_runtime_tasks = (  # type: ignore[method-assign]
+        lambda: [asyncio.create_task(stay_running())]
+    )
+    run_task = asyncio.create_task(runtime.run())
+    assert probe.ready is False
+    await probe.marked.wait()
+    assert probe.ready is True
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+
+class _FakeSupervisorChild:
+    def __init__(self, exit_code: int) -> None:
+        self.pid = 4242
+        self.returncode = exit_code
+        self.signals: list[int] = []
+
+    def poll(self) -> int:
+        return self.returncode
+
+    def send_signal(self, signum: int) -> None:
+        self.signals.append(signum)
+
+    def wait(self) -> int:
+        return self.returncode
+
+
+class _RunningSupervisorChild(_FakeSupervisorChild):
+    def __init__(self) -> None:
+        super().__init__(0)
+        self.running = True
+
+    def poll(self) -> int | None:
+        return None if self.running else self.returncode
+
+    def send_signal(self, signum: int) -> None:
+        super().send_signal(signum)
+        self.running = False
+        self.returncode = -signum
+
+    def wait(self) -> int:
+        if self.running:
+            raise AssertionError("child must receive pending stop before wait")
+        return self.returncode
+
+
+@pytest.mark.parametrize(
+    ("child_result", "expected"),
+    [
+        (supervisor_module._ChildResult(2, False, False), 2),
+        (supervisor_module._ChildResult(RESTART_EXIT_CODE, False, False), 70),
+    ],
+)
+def test_supervisor_exit_code_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    child_result: supervisor_module._ChildResult,
+    expected: int,
+) -> None:
+    child = _FakeSupervisorChild(child_result.exit_code)
+    monkeypatch.setattr(
+        supervisor_module.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: child,
+    )
+
+    def wait_child(_child: Any, *, read_fd: int, **_kwargs: Any):
+        os.close(read_fd)
+        return child_result
+
+    monkeypatch.setattr(supervisor_module, "_wait_child", wait_child)
+
+    assert run_supervisor(
+        config_path=tmp_path / "config.toml",
+        workspace=tmp_path,
+    ) == expected
+
+
+def test_supervisor_stop_between_generations_does_not_spawn_child_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child = _FakeSupervisorChild(RESTART_EXIT_CODE)
+    spawns: list[_FakeSupervisorChild] = []
+
+    def launch(*_args: Any, **_kwargs: Any) -> _FakeSupervisorChild:
+        spawns.append(child)
+        return child
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", launch)
+
+    def wait_child(_child: Any, *, read_fd: int, **_kwargs: Any):
+        os.close(read_fd)
+        return supervisor_module._ChildResult(
+            RESTART_EXIT_CODE,
+            True,
+            True,
+        )
+
+    monkeypatch.setattr(supervisor_module, "_wait_child", wait_child)
+    uuid_calls = 0
+
+    def next_boot_id() -> SimpleNamespace:
+        nonlocal uuid_calls
+        uuid_calls += 1
+        if uuid_calls == 2:
+            os.kill(os.getpid(), signal.SIGTERM)
+        return SimpleNamespace(hex=f"boot-{uuid_calls}")
+
+    monkeypatch.setattr(supervisor_module, "uuid4", next_boot_id)
+
+    assert run_supervisor(
+        config_path=tmp_path / "config.toml",
+        workspace=tmp_path,
+    ) == 0
+    assert len(spawns) == 1
+
+
+def test_supervisor_signal_inside_popen_waits_for_child_ownership(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child = _RunningSupervisorChild()
+    handler_ran_inside_popen = False
+
+    def launch(*_args: Any, **_kwargs: Any) -> _RunningSupervisorChild:
+        nonlocal handler_ran_inside_popen
+        os.kill(os.getpid(), signal.SIGTERM)
+        handler_ran_inside_popen = bool(child.signals)
+        return child
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", launch)
+
+    def unexpected_wait_child(*_args: Any, **_kwargs: Any):
+        raise AssertionError("stopping child must not enter readiness or restart gate")
+
+    monkeypatch.setattr(supervisor_module, "_wait_child", unexpected_wait_child)
+
+    assert run_supervisor(
+        config_path=tmp_path / "config.toml",
+        workspace=tmp_path,
+    ) == 0
+    assert handler_ran_inside_popen is False
+    assert child.signals == [signal.SIGTERM]
+    assert child.running is False
+
+
+def test_supervisor_child_does_not_inherit_blocked_stop_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_popen = subprocess.Popen
+    probe_path = tmp_path / "child-status.txt"
+    observed: dict[str, int] = {}
+
+    def launch(_argv: list[str], **kwargs: Any) -> subprocess.Popen[bytes]:
+        code = """
+import pathlib, sys, time
+pathlib.Path(sys.argv[1]).write_text(pathlib.Path('/proc/self/status').read_text())
+time.sleep(30)
+"""
+        return real_popen(
+            [sys.executable, "-c", code, str(probe_path)],
+            **kwargs,
+        )
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", launch)
+
+    def inspect_and_stop(
+        child: subprocess.Popen[bytes],
+        *,
+        read_fd: int,
+        **_kwargs: Any,
+    ) -> supervisor_module._ChildResult:
+        deadline = time.monotonic() + 2
+        while not probe_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        status = probe_path.read_text()
+        sigblk_line = next(
+            line for line in status.splitlines() if line.startswith("SigBlk:")
+        )
+        blocked = int(sigblk_line.split()[1], 16)
+        observed["blocked"] = blocked
+        child.send_signal(signal.SIGTERM)
+        exit_code = child.wait(timeout=2)
+        os.close(read_fd)
+        return supervisor_module._ChildResult(exit_code, False, False)
+
+    monkeypatch.setattr(supervisor_module, "_wait_child", inspect_and_stop)
+
+    assert run_supervisor(
+        config_path=tmp_path / "config.toml",
+        workspace=tmp_path,
+    ) == 128 + signal.SIGTERM
+    stop_mask = (1 << (signal.SIGINT - 1)) | (1 << (signal.SIGTERM - 1))
+    assert observed["blocked"] & stop_mask == 0
+
+
+class _DrainWriter:
+    def __init__(self, gate: asyncio.Event, *, fail: bool = False) -> None:
+        self.gate = gate
+        self.fail = fail
+        self.frames: list[bytes] = []
+
+    def write(self, payload: bytes) -> None:
+        self.frames.append(payload)
+
+    async def drain(self) -> None:
+        await self.gate.wait()
+        if self.fail:
+            raise ConnectionError("disconnected")
+
+
+@pytest.mark.asyncio
+async def test_ndjson_send_receipt_waits_for_writer_drain() -> None:
+    connection = object.__new__(NdjsonConnection)
+    connection._queue = asyncio.Queue(2)
+    gate = asyncio.Event()
+    connection._writer = _DrainWriter(gate)
+    writer_task = asyncio.create_task(connection._write_loop())
+    send_task = asyncio.create_task(connection.send({"method": "turn/completed"}))
+    await asyncio.sleep(0)
+
+    assert send_task.done() is False
+    gate.set()
+    await send_task
+    await connection._queue.put(None)
+    await writer_task
+    assert connection._writer.frames == [b'{"method":"turn/completed"}\n']
+
+
+@pytest.mark.asyncio
+async def test_ndjson_disconnect_fails_delivery_receipt() -> None:
+    connection = object.__new__(NdjsonConnection)
+    connection._queue = asyncio.Queue(2)
+    gate = asyncio.Event()
+    connection._writer = _DrainWriter(gate, fail=True)
+    writer_task = asyncio.create_task(connection._write_loop())
+    send_task = asyncio.create_task(connection.send({"method": "turn/completed"}))
+    await asyncio.sleep(0)
+    gate.set()
+
+    with pytest.raises(ConnectionError, match="disconnected"):
+        await send_task
+    with pytest.raises(ConnectionError, match="disconnected"):
+        await writer_task

--- a/tests/test_agent_restart.py
+++ b/tests/test_agent_restart.py
@@ -638,9 +638,12 @@ import pathlib, sys, time
 pathlib.Path(sys.argv[1]).write_text(pathlib.Path('/proc/self/status').read_text())
 time.sleep(30)
 """
-        return real_popen(
-            [sys.executable, "-c", code, str(probe_path)],
-            **kwargs,
+        return cast(
+            "subprocess.Popen[bytes]",
+            real_popen(
+                [sys.executable, "-c", code, str(probe_path)],
+                **kwargs,
+            ),
         )
 
     monkeypatch.setattr(supervisor_module.subprocess, "Popen", launch)
@@ -706,6 +709,23 @@ async def test_ndjson_send_receipt_waits_for_writer_drain() -> None:
     await connection._queue.put(None)
     await writer_task
     assert connection._writer.frames == [b'{"method":"turn/completed"}\n']
+
+
+@pytest.mark.asyncio
+async def test_ndjson_stream_frame_does_not_wait_for_writer_drain() -> None:
+    connection = object.__new__(NdjsonConnection)
+    connection._queue = asyncio.Queue(2)
+    gate = asyncio.Event()
+    connection._writer = _DrainWriter(gate)
+    writer_task = asyncio.create_task(connection._write_loop())
+
+    await connection.send({"method": "item/completed"})
+    await asyncio.sleep(0)
+    assert connection._writer.frames == [b'{"method":"item/completed"}\n']
+
+    gate.set()
+    await connection._queue.put(None)
+    await writer_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Stack

Depends on #120 (which depends on #119). Review only the diff from `refactor/mcp-declarations-hot-reload`.

## Outcome

Adds a narrow `agent_restart(reason)` builtin that is available only in a supervised gateway and only after `tool_search` unlocks it in the current turn attempt. The tool never invokes shell commands, signals, PID operations, or `start.sh`.

## Safety contract

- quiesce new turn admission and require the caller to be the only turn
- persist the caller terminal state before restart eligibility
- require the final channel callback or programmatic NDJSON `writer.drain()` to complete
- cancel and restore admission on failed delivery, disconnect, non-completed turn, or timeout
- write one boot-scoped commit frame through an inherited private pipe
- require matching readiness, exactly one valid commit, and child exit 75
- never restart on normal exit, crash, bare exit 75, stale readiness, or supervisor SIGTERM
- use a workspace supervisor lock and a fixed gateway argv only
- require a fresh turn/attempt-scoped tool search grant; session LRU cannot bypass execution authorization

## Verification

- `pytest -q -W error tests/` — 2086 passed
- focused restart/control/runtime suite — 103 passed
- changed-file pyright — 0 errors
- `git diff --check`
- `bash -n docker/debug/entrypoint.sh`

The ignored machine-local `start.sh` is intentionally not force-added. It will be backed up and directly migrated after the stacked Docker combination gate in the fourth PR.