### PR TITLE
test(runtime): add combined MCP and restart lifecycle gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,54 @@ jobs:
         with:
           name: programmatic-control-gate
           path: docker/debug/reports/programmatic-control/
+
+  runtime-extension-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run workspace MCP lifecycle gate
+        run: python docker/debug/workspace_mcp_reload_probe.py
+
+      - name: Run restart and MCP soak gate
+        run: python docker/debug/restart_probe.py --soak
+
+      - name: Verify combined source and cleanup evidence
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          def latest(pattern: str) -> dict[str, object]:
+              reports = list(Path("docker/debug/reports").glob(pattern))
+              if not reports:
+                  raise SystemExit(f"缺少 Gate 报告: {pattern}")
+              path = max(reports, key=lambda item: item.stat().st_mtime_ns)
+              return json.loads(path.read_text(encoding="utf-8"))
+
+          mcp = latest("workspace-mcp/*/gate.json")
+          restart = latest("restart/*/gate.json")
+          restart_digest = restart["sourceDigest"]
+          assert isinstance(restart_digest, dict)
+          assert mcp["status"] == restart["status"] == "passed"
+          assert mcp["head"] == restart["head"] == os.environ["GITHUB_SHA"]
+          assert mcp["sourceDigest"] == restart_digest["sha256"]
+          assert mcp["dirtyStatus"] == restart["dirtyStatus"] == []
+          assert not any(
+              mcp[name]
+              for name in ("residualContainers", "residualNetworks", "residualVolumes")
+          )
+          assert not any(restart["residualResources"].values())
+          PY
+
+      - name: Upload runtime extension evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-extension-gate
+          path: |
+            docker/debug/reports/workspace-mcp/
+            docker/debug/reports/restart/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install runtime dependencies
+        run: python -m pip install -r requirements.txt
+
       - name: Run workspace MCP lifecycle gate
         run: python docker/debug/workspace_mcp_reload_probe.py
 

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -21,6 +21,40 @@ failure，并检查 RSS、fd、线程与 DB 非终态阈值。
 每次运行的证据位于
 `docker/debug/reports/programmatic-control/<run-id>/`。
 
+## Runtime 扩展生命周期验收门
+
+workspace MCP 和 agent restart 共用 `docker-compose.control-gate.yml`，但每次运行都会创建
+独立 Compose project 与 sandbox。Gate 复制当前 tracked 和 non-ignored untracked 源码，记录
+Git HEAD、工作树状态、源码摘要、容器 `/app` 摘要与 image ID；运行结束后按 Compose project
+label 检查容器、网络和卷均无残留。
+
+```text
+┌─ workspace MCP Gate
+│  ├─ v1 → v2 → watched-content reload
+│  ├─ 旧 turn lease 与新 generation 隔离
+│  ├─ 坏声明整批 rollback、修复后自动恢复
+│  └─ 删除声明后工具与真实 MCP 进程全部退出
+└─ restart + MCP 组合 Gate
+   ├─ tool_search → agent_restart → terminal delivery
+   ├─ supervisor 固定、child/boot ID 更换、session resume
+   ├─ MCP 热更后跨进程重启恢复，旧 MCP PID 退出
+   ├─ 裸 exit 75、stale readiness、断线和 SIGTERM 失败矩阵
+   └─ 20 轮 FD、线程、zombie 与非终态 turn 资源门禁
+```
+
+本地合并前运行：
+
+```bash
+python docker/debug/workspace_mcp_reload_probe.py
+python docker/debug/restart_probe.py --soak
+```
+
+验收以两个 host `gate.json` 的 `status=passed` 为准，不能只使用容器内
+`restart-gate.json`。两份报告必须来自同一 HEAD、相同 source digest；CI 还要求工作树为空。
+20 轮 soak 的阈值为 supervisor FD 增量不超过 2、线程增量为 0，child FD 增量不超过 4、
+线程增量不超过 2；supervisor 与新 child 的 sampled RSS 增量及内核记录的 HWM 增量分别
+不超过 64 MiB，并要求无 zombie、无 `queued/in_progress` turn。
+
 确定性模型 sidecar 的控制协议：
 
 - `PUT /control/script`：装载一个脚本对象或脚本数组。`mode` 支持 `complete`、

--- a/docker/debug/restart_probe.py
+++ b/docker/debug/restart_probe.py
@@ -1,0 +1,1315 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, cast
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from docker.debug.programmatic_control_probe import (
+    CheckResult,
+    GateFailure,
+    JsonRpcSocketClient,
+    _connect_client,
+    _event_turn,
+    _extract_id,
+    _http_json,
+    _model_requests,
+    _prepare_host_sandbox,
+    _recorded_turn_notifications,
+    _repository_digest,
+    _start_thread,
+    _terminal_status,
+    _wait_barrier,
+    _wait_http_ready,
+    _wait_socket,
+    _write_json,
+)
+
+
+READINESS_DEADLINE_S = 30.0
+MODEL_URL = "http://model-gate:8090"
+ENDPOINT = Path("/sandbox/akashic.sock")
+WORKSPACE = Path("/sandbox/workspace")
+
+MCP_SERVER_SOURCE = r'''from __future__ import annotations
+import json
+import os
+from pathlib import Path
+import sys
+
+log = Path(os.environ["LIFECYCLE_LOG"])
+version = os.environ["VERSION"]
+pid = os.getpid()
+
+def record(event: str) -> None:
+    with log.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps({"event": event, "pid": pid, "version": version}) + "\n")
+
+record("started")
+try:
+    for line in sys.stdin:
+        message = json.loads(line)
+        if "id" not in message:
+            continue
+        method = message.get("method")
+        if method == "initialize":
+            result = {"protocolVersion": "2025-11-25"}
+        elif method == "tools/list":
+            result = {"tools": [{"name": "version", "description": "Return version", "inputSchema": {"type": "object", "properties": {}}}]}
+        elif method == "tools/call":
+            result = {"content": [{"type": "text", "text": version}]}
+        else:
+            result = {}
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+finally:
+    record("stopped")
+'''
+
+
+def _load_scripts(scripts: list[dict[str, object]]) -> int:
+    payload = _http_json("PUT", f"{MODEL_URL}/control/script", scripts)
+    loaded = cast(dict[str, object], payload)["loaded"]
+    if not isinstance(loaded, int):
+        raise GateFailure(f"model gate loaded 响应非法: {payload!r}")
+    return loaded
+
+
+def _requests() -> list[dict[str, Any]]:
+    return cast(
+        list[dict[str, Any]],
+        _model_requests(_http_json("GET", f"{MODEL_URL}/control/requests")),
+    )
+
+
+def _start_probe_turn(
+    client: JsonRpcSocketClient,
+    thread_id: str,
+    text: str,
+) -> str:
+    return _extract_id(
+        client.request(
+            "turn/start",
+            {
+                "threadId": thread_id,
+                "input": text,
+                "metadata": {"skip_memory_context_guard": True},
+            },
+        ),
+        "turn",
+    )
+
+
+def _tool_names(request: dict[str, Any]) -> set[str]:
+    payload = request.get("payload")
+    if not isinstance(payload, dict):
+        raise GateFailure(f"model request 缺少 payload: {request!r}")
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return set()
+    return {
+        str(item.get("function", {}).get("name"))
+        for item in tools
+        if isinstance(item, dict) and isinstance(item.get("function"), dict)
+    }
+
+
+def _read_ready() -> dict[str, Any]:
+    path = WORKSPACE / ".runtime-ready.json"
+    deadline = time.monotonic() + READINESS_DEADLINE_S
+    while time.monotonic() < deadline:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            time.sleep(0.02)
+            continue
+        if payload.get("state") == "ready":
+            return cast(dict[str, Any], payload)
+        time.sleep(0.02)
+    raise GateFailure("runtime readiness 超时")
+
+
+def _connect_new_boot(old_boot: str, events_path: Path) -> tuple[JsonRpcSocketClient, dict[str, Any]]:
+    deadline = time.monotonic() + READINESS_DEADLINE_S
+    while time.monotonic() < deadline:
+        ready = _read_ready()
+        if ready.get("bootId") != old_boot:
+            try:
+                return _connect_client(ENDPOINT, events_path), ready
+            except (ConnectionError, OSError, GateFailure):
+                pass
+        time.sleep(0.02)
+    raise GateFailure(f"等待新 boot 超时: old={old_boot}")
+
+
+def _restart_scripts(index: int, barrier: str) -> list[dict[str, object]]:
+    return [
+        {
+            "mode": "stream",
+            "deltas": [],
+            "tool_calls": [
+                {
+                    "id": f"call_search_{index}",
+                    "name": "tool_search",
+                    "arguments": {"query": "select:agent_restart"},
+                }
+            ],
+        },
+        {
+            "mode": "stream",
+            "deltas": [],
+            "tool_calls": [
+                {
+                    "id": f"call_restart_{index}",
+                    "name": "agent_restart",
+                    "arguments": {"reason": f"restart gate iteration {index}"},
+                }
+            ],
+        },
+        {
+            "mode": "complete",
+            "content": f"restart-complete-{index}",
+            "barrier": barrier,
+        },
+    ]
+
+
+def _mcp_scripts(version: str) -> list[dict[str, object]]:
+    return [
+        {
+            "mode": "stream",
+            "deltas": [],
+            "tool_calls": [{
+                "id": f"call_mcp_search_{version}",
+                "name": "tool_search",
+                "arguments": {"query": "select:mcp_restart_probe__version"},
+            }],
+        },
+        {
+            "mode": "stream",
+            "deltas": [],
+            "tool_calls": [{
+                "id": f"call_mcp_version_{version}",
+                "name": "mcp_restart_probe__version",
+                "arguments": {},
+            }],
+        },
+        {"mode": "complete", "content": f"mcp-{version}"},
+    ]
+
+
+def _process_identity(pid: int) -> dict[str, int]:
+    stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    fields = stat[stat.rfind(")") + 2 :].split()
+    return {"pid": pid, "starttime": int(fields[19])}
+
+
+def _identity_alive(identity: dict[str, int]) -> bool:
+    try:
+        return _process_identity(identity["pid"]) == identity
+    except FileNotFoundError:
+        return False
+
+
+def _running_mcp_identity(
+    version: str,
+    *,
+    workspace: Path = WORKSPACE,
+    previous: dict[str, int] | None = None,
+) -> dict[str, int]:
+    deadline = time.monotonic() + READINESS_DEADLINE_S
+    lifecycle = workspace / "mcp/restart-probe-lifecycle.jsonl"
+    while time.monotonic() < deadline:
+        records = (
+            [json.loads(line) for line in lifecycle.read_text().splitlines() if line]
+            if lifecycle.exists()
+            else []
+        )
+        started = [
+            int(item["pid"])
+            for item in records
+            if item["event"] == "started" and item["version"] == version
+        ]
+        for pid in reversed(started):
+            try:
+                identity = _process_identity(pid)
+            except FileNotFoundError:
+                continue
+            if identity != previous:
+                return identity
+        time.sleep(0.02)
+    raise GateFailure(f"MCP {version} 子进程未启动")
+
+
+def _wait_identity_exit(identity: dict[str, int]) -> None:
+    deadline = time.monotonic() + READINESS_DEADLINE_S
+    while time.monotonic() < deadline:
+        if not _identity_alive(identity):
+            return
+        time.sleep(0.02)
+    raise GateFailure(f"旧进程 identity 未退出: {identity}")
+
+
+def _write_mcp_declaration(version: str, *, workspace: Path = WORKSPACE) -> None:
+    root = workspace / "mcp"
+    declarations = root / "servers"
+    declarations.mkdir(parents=True, exist_ok=True)
+    server = root / "restart_probe_server.py"
+    server.write_text(MCP_SERVER_SOURCE, encoding="utf-8")
+    lifecycle = root / "restart-probe-lifecycle.jsonl"
+    (declarations / "restart_probe.toml").write_text(
+        "schema_version = 1\n"
+        'name = "restart_probe"\n'
+        f'command = ["{sys.executable}", "{server}"]\n'
+        "[env]\n"
+        f'VERSION = "{version}"\n'
+        f'LIFECYCLE_LOG = "{lifecycle}"\n',
+        encoding="utf-8",
+    )
+
+
+def _run_mcp_call(
+    client: JsonRpcSocketClient,
+    version: str,
+    label: str,
+) -> CheckResult:
+    before = len(_requests())
+    _load_scripts(_mcp_scripts(version))
+    thread_id = _start_thread(client, f"mcp-{label}")
+    turn_id = _start_probe_turn(client, thread_id, f"call MCP {version}")
+    terminal = client.wait_terminal(turn_id)
+    requests = _requests()[before:]
+    payload = _event_turn(terminal)
+    calls = [
+        item for item in payload.get("items", [])
+        if isinstance(item, dict) and item.get("type") == "toolCall"
+    ]
+    version_call = next(
+        (item for item in calls if item.get("data", {}).get("name") == "mcp_restart_probe__version"),
+        None,
+    )
+    passed = (
+        len(requests) == 3
+        and "mcp_restart_probe__version" not in _tool_names(requests[0])
+        and "mcp_restart_probe__version" in _tool_names(requests[1])
+        and version_call is not None
+        and version_call.get("data", {}).get("status") == "success"
+        and version_call.get("data", {}).get("resultPreview") == version
+        and _terminal_status(terminal) == "completed"
+    )
+    return CheckResult(
+        f"MCP-{label}",
+        passed,
+        {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "version": version,
+            "initialTools": sorted(_tool_names(requests[0])) if requests else [],
+            "postSearchTools": sorted(_tool_names(requests[1])) if len(requests) > 1 else [],
+            "toolCall": version_call,
+        },
+    )
+
+
+def _database_turn(turn_id: str) -> dict[str, Any]:
+    with sqlite3.connect(WORKSPACE / "sessions.db") as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            "SELECT id, status, final_response FROM turns WHERE id = ?",
+            (turn_id,),
+        ).fetchone()
+    if row is None:
+        raise GateFailure(f"DB 缺少 turn: {turn_id}")
+    return dict(row)
+
+
+def _sample_supervisor_children(
+    supervisor_pid: int,
+    stop: threading.Event,
+    samples: list[int],
+) -> None:
+    path = Path(f"/proc/{supervisor_pid}/task/{supervisor_pid}/children")
+    while not stop.is_set():
+        try:
+            pids = path.read_text(encoding="utf-8").split()
+        except FileNotFoundError:
+            pids = []
+        samples.append(sum(Path(f"/proc/{pid}").exists() for pid in pids))
+        stop.wait(0.002)
+
+
+def _run_restart_iteration(
+    index: int,
+    client: JsonRpcSocketClient,
+    thread_id: str,
+    report_dir: Path,
+) -> tuple[JsonRpcSocketClient, CheckResult]:
+    before = _requests()
+    ready_before = _read_ready()
+    supervisor_pid = int((WORKSPACE / ".supervisor.pid").read_text())
+    child_samples: list[int] = []
+    stop_sampling = threading.Event()
+    sampler = threading.Thread(
+        target=_sample_supervisor_children,
+        args=(supervisor_pid, stop_sampling, child_samples),
+        daemon=True,
+    )
+    sampler.start()
+    barrier = f"restart-final-{index}-{uuid.uuid4().hex[:8]}"
+    _http_json("PUT", f"{MODEL_URL}/control/barriers/{barrier}")
+    _load_scripts(_restart_scripts(index, barrier))
+    turn_id = _start_probe_turn(client, thread_id, f"restart iteration {index}")
+    terminal_holder: dict[str, Any] = {}
+
+    def wait_terminal() -> None:
+        terminal_holder["event"] = client.wait_terminal(
+            turn_id,
+            timeout=READINESS_DEADLINE_S,
+        )
+
+    waiter = threading.Thread(target=wait_terminal, daemon=True)
+    waiter.start()
+    _wait_barrier(MODEL_URL, barrier)
+
+    # admission 已由 agent_restart 冻结，另一连接必须拿到 retryable error。
+    concurrent = _connect_client(ENDPOINT, report_dir / f"events-{index}-concurrent.jsonl")
+    try:
+        other_thread = _start_thread(concurrent, f"restart-concurrent-{index}")
+        rejected = concurrent.request_raw(
+            "turn/start",
+            {"threadId": other_thread, "input": "must retry", "metadata": {}},
+        )
+    finally:
+        concurrent.close()
+    _http_json("POST", f"{MODEL_URL}/control/barriers/{barrier}/release")
+    waiter.join(timeout=READINESS_DEADLINE_S)
+    if waiter.is_alive() or "event" not in terminal_holder:
+        raise GateFailure(f"restart terminal 超时: {turn_id}")
+    terminal = cast(dict[str, Any], terminal_holder["event"])
+    terminal_payload = _event_turn(terminal)
+    old_child_alive_at_terminal = Path(f"/proc/{ready_before['pid']}").exists()
+    client.close()
+
+    new_client, ready_after = _connect_new_boot(
+        str(ready_before["bootId"]),
+        report_dir / f"events-{index}-after.jsonl",
+    )
+    stop_sampling.set()
+    sampler.join(timeout=2)
+    max_concurrent_child = max(child_samples, default=0)
+    time.sleep(0.1)
+    stable_ready = _read_ready()
+    after = _requests()
+    iteration_requests = after[len(before):]
+    if len(iteration_requests) != 3:
+        raise GateFailure(f"restart model request 数量异常: {len(iteration_requests)}")
+    called_tools = {
+        str(item.get("data", {}).get("name"))
+        for item in terminal_payload.get("items", [])
+        if isinstance(item, dict) and item.get("type") == "toolCall"
+    }
+    turn_read = new_client.request(
+        "turn/read",
+        {"threadId": thread_id, "turnId": turn_id},
+    )
+    db_turn = _database_turn(turn_id)
+    error = rejected.get("error")
+    passed = (
+        "agent_restart" not in _tool_names(iteration_requests[0])
+        and "agent_restart" in _tool_names(iteration_requests[1])
+        and {"tool_search", "agent_restart"} <= called_tools
+        and _terminal_status(terminal) == "completed"
+        and terminal_payload.get("finalResponse") == f"restart-complete-{index}"
+        and turn_read.get("result") == terminal_payload
+        and db_turn["status"] == "completed"
+        and db_turn["final_response"] == f"restart-complete-{index}"
+        and old_child_alive_at_terminal
+        and ready_after["bootId"] != ready_before["bootId"]
+        and ready_after["pid"] != ready_before["pid"]
+        and int((WORKSPACE / ".supervisor.pid").read_text()) == supervisor_pid
+        and max_concurrent_child == 1
+        and stable_ready["bootId"] == ready_after["bootId"]
+        and stable_ready["pid"] == ready_after["pid"]
+        and isinstance(error, dict)
+        and error.get("data", {}).get("retryable") is True
+    )
+    return new_client, CheckResult(
+        f"RESTART-{index}",
+        passed,
+        {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "before": ready_before,
+            "after": ready_after,
+            "supervisorPid": supervisor_pid,
+            "maxConcurrentChild": max_concurrent_child,
+            "restartCount": 1,
+            "stableAfterRestart": stable_ready,
+            "oldChildAliveAtTerminal": old_child_alive_at_terminal,
+            "initialTools": sorted(_tool_names(iteration_requests[0])),
+            "postSearchTools": sorted(_tool_names(iteration_requests[1])),
+            "calledTools": sorted(called_tools),
+            "concurrentResponse": rejected,
+            "database": db_turn,
+        },
+    )
+
+
+def _disconnect_before_terminal_check(report_dir: Path) -> CheckResult:
+    client = _connect_client(ENDPOINT, report_dir / "events-disconnect.jsonl")
+    ready_before = _read_ready()
+    thread_id = _start_thread(client, "restart-disconnect")
+    barrier = f"restart-disconnect-{uuid.uuid4().hex[:8]}"
+    _http_json("PUT", f"{MODEL_URL}/control/barriers/{barrier}")
+    _load_scripts(_restart_scripts(999, barrier))
+    turn_id = _start_probe_turn(client, thread_id, "disconnect before terminal")
+    _wait_barrier(MODEL_URL, barrier)
+    client.close()
+    disconnected_at = time.monotonic()
+    _http_json("POST", f"{MODEL_URL}/control/barriers/{barrier}/release")
+
+    recovery = _connect_client(ENDPOINT, report_dir / "events-recovery.jsonl")
+    recovery_thread = _start_thread(recovery, "restart-disconnect-recovery")
+    _load_scripts([{"mode": "complete", "content": "admission-restored"}])
+    deadline = time.monotonic() + 3
+    rejected: list[dict[str, Any]] = []
+    recovery_turn = ""
+    while time.monotonic() < deadline:
+        response = recovery.request_raw(
+            "turn/start",
+            {
+                "threadId": recovery_thread,
+                "input": "recovery after disconnect",
+                "metadata": {},
+            },
+        )
+        if "result" in response:
+            recovery_turn = _extract_id(response, "turn")
+            break
+        rejected.append(response)
+        time.sleep(0.02)
+    if not recovery_turn:
+        raise GateFailure("disconnect 后 admission 未在 3 秒内恢复")
+    terminal = recovery.wait_terminal(recovery_turn)
+    recovery.close()
+    elapsed = time.monotonic() - disconnected_at
+    ready_after = _read_ready()
+    return CheckResult(
+        "RESTART-DISCONNECT",
+        _terminal_status(terminal) == "completed"
+        and _event_turn(terminal).get("finalResponse") == "admission-restored"
+        and ready_after["bootId"] == ready_before["bootId"]
+        and ready_after["pid"] == ready_before["pid"]
+        and elapsed < 3,
+        {
+            "restartTurnId": turn_id,
+            "recoveryTurnId": recovery_turn,
+            "before": ready_before,
+            "after": ready_after,
+            "recoverySeconds": elapsed,
+            "rejectedBeforeRecovery": rejected,
+        },
+    )
+
+
+def _process_metrics(pid: int) -> dict[str, int]:
+    status = {}
+    for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key in {"VmRSS", "VmHWM"}:
+            status[key] = int(value.split()[0])
+    return {
+        "pid": pid,
+        "fds": len(list(Path(f"/proc/{pid}/fd").iterdir())),
+        "threads": len(list(Path(f"/proc/{pid}/task").iterdir())),
+        "vmRssKiB": status["VmRSS"],
+        "vmHwmKiB": status["VmHWM"],
+    }
+
+
+def _descendant_pids(pid: int) -> set[int]:
+    descendants: set[int] = set()
+    pending = [pid]
+    while pending:
+        parent = pending.pop()
+        path = Path(f"/proc/{parent}/task/{parent}/children")
+        if not path.exists():
+            continue
+        children = {int(item) for item in path.read_text().split()}
+        new = children - descendants
+        descendants.update(new)
+        pending.extend(new)
+    return descendants
+
+
+def _zombie_descendants(supervisor_pid: int) -> list[int]:
+    zombies: list[int] = []
+    for pid in _descendant_pids(supervisor_pid):
+        stat = Path(f"/proc/{pid}/stat")
+        if stat.exists() and stat.read_text().split()[2] == "Z":
+            zombies.append(pid)
+    return sorted(zombies)
+
+
+def _peak_memory_deltas(
+    supervisor_before: dict[str, int],
+    child_before: dict[str, int],
+    resource_samples: list[dict[str, dict[str, int]]],
+) -> dict[str, int]:
+    """计算各进程跨轮次 RSS 与 HWM 最大增量。"""
+
+    return {
+        "supervisorRssKiB": max(
+            sample["supervisor"]["vmRssKiB"] - supervisor_before["vmRssKiB"]
+            for sample in resource_samples
+        ),
+        "supervisorHwmKiB": max(
+            sample["supervisor"]["vmHwmKiB"] - supervisor_before["vmHwmKiB"]
+            for sample in resource_samples
+        ),
+        "childRssKiB": max(
+            sample["child"]["vmRssKiB"] - child_before["vmRssKiB"]
+            for sample in resource_samples
+        ),
+        "childHwmKiB": max(
+            sample["child"]["vmHwmKiB"] - child_before["vmHwmKiB"]
+            for sample in resource_samples
+        ),
+    }
+
+
+def _memory_within_limit(deltas: dict[str, int], limit_kib: int = 64 * 1024) -> bool:
+    return all(delta <= limit_kib for delta in deltas.values())
+
+
+def _active_turn_count() -> int:
+    with sqlite3.connect(WORKSPACE / "sessions.db") as connection:
+        row = connection.execute(
+            "SELECT COUNT(*) FROM turns WHERE status IN ('queued', 'in_progress')"
+        ).fetchone()
+    return int(row[0])
+
+
+def _resource_check(
+    supervisor_before: dict[str, int],
+    child_before: dict[str, int],
+    zombie_samples: list[list[int]],
+    resource_samples: list[dict[str, dict[str, int]]],
+) -> CheckResult:
+    time.sleep(0.2)
+    supervisor_after = _process_metrics(supervisor_before["pid"])
+    child_after = _process_metrics(int(_read_ready()["pid"]))
+    supervisor_delta = {
+        "fds": supervisor_after["fds"] - supervisor_before["fds"],
+        "threads": supervisor_after["threads"] - supervisor_before["threads"],
+    }
+    child_delta = {
+        "fds": child_after["fds"] - child_before["fds"],
+        "threads": child_after["threads"] - child_before["threads"],
+    }
+    memory_deltas = _peak_memory_deltas(
+        supervisor_before, child_before, resource_samples
+    )
+    zombies = _zombie_descendants(supervisor_before["pid"])
+    active_turns = _active_turn_count()
+    return CheckResult(
+        "RESTART-SOAK-RESOURCES",
+        supervisor_delta["fds"] <= 2
+        and supervisor_delta["threads"] <= 0
+        and child_delta["fds"] <= 4
+        and child_delta["threads"] <= 2
+        and _memory_within_limit(memory_deltas)
+        and not zombies
+        and not any(zombie_samples)
+        and active_turns == 0,
+        {
+            "supervisorBefore": supervisor_before,
+            "supervisorAfter": supervisor_after,
+            "supervisorDelta": supervisor_delta,
+            "childBefore": child_before,
+            "childAfter": child_after,
+            "childDelta": child_delta,
+            "resourceSamples": resource_samples,
+            "peakMemoryDeltasKiB": memory_deltas,
+            "zombies": zombies,
+            "zombieSamples": zombie_samples,
+            "activeTurns": active_turns,
+            "thresholds": {
+                "supervisorFds": 2,
+                "supervisorThreads": 0,
+                "childFds": 4,
+                "childThreads": 2,
+                "supervisorRssKiB": 64 * 1024,
+                "supervisorHwmKiB": 64 * 1024,
+                "childRssKiB": 64 * 1024,
+                "childHwmKiB": 64 * 1024,
+            },
+        },
+    )
+
+
+def _unsupervised_tool_absence_check(report_dir: Path) -> CheckResult:
+    config = Path("/sandbox/config.toml").read_text(encoding="utf-8")
+    config = config.replace(
+        'listen = "/sandbox/akashic.sock"',
+        'listen = "/sandbox/unsupervised.sock"',
+    ).replace(
+        "[channels.chat]\nenabled = true",
+        "[channels.chat]\nenabled = false",
+    )
+    config_path = Path("/sandbox/unsupervised.toml")
+    workspace = Path("/sandbox/unsupervised-workspace")
+    endpoint = Path("/sandbox/unsupervised.sock")
+    config_path.write_text(config, encoding="utf-8")
+    workspace.mkdir(exist_ok=True)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "main.py",
+            "gateway",
+            "--config",
+            str(config_path),
+            "--workspace",
+            str(workspace),
+        ]
+    )
+    try:
+        _wait_socket(endpoint, READINESS_DEADLINE_S)
+        client = _connect_client(endpoint, report_dir / "events-unsupervised.jsonl")
+        before = len(_requests())
+        _load_scripts(
+            [
+                {
+                    "mode": "stream",
+                    "deltas": [],
+                    "tool_calls": [
+                        {
+                            "id": "call_unsupervised_search",
+                            "name": "tool_search",
+                            "arguments": {"query": "select:agent_restart"},
+                        }
+                    ],
+                },
+                {"mode": "complete", "content": "unsupervised-complete"},
+            ]
+        )
+        thread_id = _start_thread(client, "restart-unsupervised")
+        turn_id = _start_probe_turn(client, thread_id, "find restart")
+        terminal = client.wait_terminal(turn_id)
+        client.close()
+        requests = _requests()[before:]
+        notifications = _recorded_turn_notifications(
+            report_dir / "events-unsupervised.jsonl",
+            turn_id,
+        )
+        previews = [
+            str(event.get("params", {}).get("item", {}).get("data", {}).get("resultPreview") or "")
+            for event in notifications
+            if event.get("method") == "item/completed"
+        ]
+        passed = (
+            _terminal_status(terminal) == "completed"
+            and all("agent_restart" not in _tool_names(request) for request in requests)
+            and any("未找到工具: agent_restart" in preview for preview in previews)
+        )
+        return CheckResult(
+            "RESTART-UNSUPERVISED",
+            passed,
+            {
+                "turnId": turn_id,
+                "requestTools": [sorted(_tool_names(item)) for item in requests],
+                "previews": previews,
+            },
+        )
+    finally:
+        process.send_signal(signal.SIGTERM)
+        process.wait(timeout=15)
+        endpoint.unlink(missing_ok=True)
+
+
+def _inside(iterations: int, report_dir: Path, *, resource_gate: bool) -> int:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    _wait_http_ready(f"{MODEL_URL}/readyz", READINESS_DEADLINE_S)
+    _wait_socket(ENDPOINT, READINESS_DEADLINE_S)
+    events_path = report_dir / "events.jsonl"
+    client = _connect_client(ENDPOINT, events_path)
+    checks: list[CheckResult] = []
+    try:
+        isolation = {
+            "extraPluginDirs": os.environ.get("AKASHIC_EXTRA_PLUGIN_DIRS"),
+            "pluginCacheExists": Path("/sandbox/home/.akashic-plugin/cache").exists(),
+        }
+        checks.append(
+            CheckResult(
+                "RESTART-ISOLATION",
+                isolation["extraPluginDirs"] is None
+                and isolation["pluginCacheExists"] is False,
+                isolation,
+            )
+        )
+        previous_mcp_identity: dict[str, int] | None = None
+        supervisor_baseline: dict[str, int] | None = None
+        child_baseline: dict[str, int] | None = None
+        zombie_samples: list[list[int]] = []
+        resource_samples: list[dict[str, dict[str, int]]] = []
+        for index in range(iterations):
+            version = f"v{index + 1}"
+            _write_mcp_declaration(version)
+            mcp_identity = _running_mcp_identity(
+                version, previous=previous_mcp_identity
+            )
+            if previous_mcp_identity is not None:
+                _wait_identity_exit(previous_mcp_identity)
+            checks.append(_run_mcp_call(client, version, f"{index}-HOT"))
+
+            if supervisor_baseline is None:
+                supervisor_pid = int((WORKSPACE / ".supervisor.pid").read_text())
+                supervisor_baseline = _process_metrics(supervisor_pid)
+                child_baseline = _process_metrics(int(_read_ready()["pid"]))
+
+            thread_id = _start_thread(client, f"restart-gate-{index}")
+            client, result = _run_restart_iteration(
+                index,
+                client,
+                thread_id,
+                report_dir,
+            )
+            checks.append(result)
+            recovered_mcp_identity = _running_mcp_identity(
+                version, previous=mcp_identity
+            )
+            _wait_identity_exit(mcp_identity)
+            checks.append(
+                CheckResult(
+                    f"MCP-{index}-RECOVERED",
+                    recovered_mcp_identity != mcp_identity,
+                    {
+                        "version": version,
+                        "oldIdentity": mcp_identity,
+                        "oldIdentityAlive": _identity_alive(mcp_identity),
+                        "newIdentity": recovered_mcp_identity,
+                    },
+                )
+            )
+            checks.append(_run_mcp_call(client, version, f"{index}-AFTER-RESTART"))
+            previous_mcp_identity = recovered_mcp_identity
+            zombie_samples.append(_zombie_descendants(supervisor_baseline["pid"]))
+
+            # 同 thread resume，同时证明新 turn 首次 payload 再次不含 restart。
+            before = len(_requests())
+            _load_scripts([{"mode": "complete", "content": f"resume-{index}"}])
+            resumed = client.request("thread/resume", {"threadId": thread_id})
+            if resumed.get("result", {}).get("id") != thread_id:
+                raise GateFailure(f"thread resume 不一致: {resumed!r}")
+            resume_turn = _start_probe_turn(client, thread_id, f"resume {index}")
+            resume_terminal = client.wait_terminal(resume_turn)
+            request = _requests()[before]
+            checks.append(
+                CheckResult(
+                    f"RESTART-{index}-RESUME",
+                    _terminal_status(resume_terminal) == "completed"
+                    and _event_turn(resume_terminal).get("finalResponse") == f"resume-{index}"
+                    and "agent_restart" not in _tool_names(request),
+                    {
+                        "threadId": thread_id,
+                        "turnId": resume_turn,
+                        "initialTools": sorted(_tool_names(request)),
+                    },
+                )
+            )
+            resource_samples.append(
+                {
+                    "supervisor": _process_metrics(supervisor_baseline["pid"]),
+                    "child": _process_metrics(int(_read_ready()["pid"])),
+                }
+            )
+        checks.append(_disconnect_before_terminal_check(report_dir))
+        if resource_gate:
+            if supervisor_baseline is None or child_baseline is None:
+                raise GateFailure("soak resource baseline 缺失")
+            checks.append(
+                _resource_check(
+                    supervisor_baseline,
+                    child_baseline,
+                    zombie_samples,
+                    resource_samples,
+                )
+            )
+    finally:
+        client.close()
+
+    report = {
+        "gate": "restart",
+        "iterations": iterations,
+        "status": "passed" if all(check.passed for check in checks) else "failed",
+        "checks": [asdict(check) for check in checks],
+    }
+    _write_json(report_dir / "restart-gate.json", report)
+    print(json.dumps(report, ensure_ascii=False))
+    return 0 if report["status"] == "passed" else 1
+
+
+def _inside_unsupervised(report_dir: Path) -> int:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    check = _unsupervised_tool_absence_check(report_dir)
+    _write_json(report_dir / "unsupervised.json", asdict(check))
+    print(json.dumps(asdict(check), ensure_ascii=False))
+    return 0 if check.passed else 1
+
+
+def _isolated_config(name: str) -> tuple[Path, Path, Path]:
+    source = Path("/sandbox/config.toml").read_text(encoding="utf-8")
+    endpoint = Path(f"/sandbox/{name}.sock")
+    source = source.replace(
+        'listen = "/sandbox/akashic.sock"',
+        f'listen = "{endpoint}"',
+    ).replace(
+        "[channels.chat]\nenabled = true",
+        "[channels.chat]\nenabled = false",
+    )
+    config = Path(f"/sandbox/{name}.toml")
+    workspace = Path(f"/sandbox/{name}-workspace")
+    config.write_text(source, encoding="utf-8")
+    workspace.mkdir(exist_ok=True)
+    return config, workspace, endpoint
+
+
+def _install_startup_plugin(home: Path, name: str, source: str) -> None:
+    cache = home / f".akashic-plugin/cache/gate/{name}/1.0.0"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "plugin.py").write_text(source, encoding="utf-8")
+    manifest = home / ".akashic-plugin/manifest.toml"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        f'[plugins."{name}@gate"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+
+
+def _failure_mode_checks(report_dir: Path) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+
+    # 1. child 裸 75 没有私有 commit，supervisor 必须以 70 失败且只启动一次。
+    naked_config, naked_workspace, _ = _isolated_config("naked75")
+    naked_home = Path("/sandbox/naked75-home")
+    count_path = Path("/sandbox/naked75-count.txt")
+    _install_startup_plugin(
+        naked_home,
+        "naked75",
+        "import os, pathlib\n"
+        f"p=pathlib.Path({str(count_path)!r})\n"
+        "p.write_text((p.read_text() if p.exists() else '') + '1\\n')\n"
+        "os._exit(75)\n",
+    )
+    naked = subprocess.run(
+        [
+            sys.executable,
+            "main.py",
+            "supervise",
+            "--config",
+            str(naked_config),
+            "--workspace",
+            str(naked_workspace),
+        ],
+        env={**os.environ, "HOME": str(naked_home)},
+        timeout=20,
+    )
+    naked_starts = count_path.read_text().splitlines() if count_path.exists() else []
+    checks.append(
+        CheckResult(
+            "RESTART-NAKED-75",
+            naked.returncode == 70 and len(naked_starts) == 1,
+            {"returncode": naked.returncode, "childStarts": len(naked_starts)},
+        )
+    )
+
+    # 2. stale readiness 不能满足新 boot；startup 卡住后必须走 15 秒失败门。
+    stale_config, stale_workspace, _ = _isolated_config("stale-ready")
+    stale_home = Path("/sandbox/stale-ready-home")
+    stale_payload = {"bootId": "stale", "pid": 1, "state": "ready"}
+    (stale_workspace / ".runtime-ready.json").write_text(json.dumps(stale_payload))
+    _install_startup_plugin(stale_home, "stale_ready", "import time\ntime.sleep(30)\n")
+    stale_started = time.monotonic()
+    stale = subprocess.run(
+        [
+            sys.executable,
+            "main.py",
+            "supervise",
+            "--config",
+            str(stale_config),
+            "--workspace",
+            str(stale_workspace),
+        ],
+        env={**os.environ, "HOME": str(stale_home)},
+        timeout=25,
+    )
+    stale_duration = time.monotonic() - stale_started
+    stale_after = json.loads(
+        (stale_workspace / ".runtime-ready.json").read_text(encoding="utf-8")
+    )
+    checks.append(
+        CheckResult(
+            "RESTART-STALE-READY",
+            stale.returncode == 70
+            and stale_duration >= 14
+            and stale_after == stale_payload,
+            {
+                "returncode": stale.returncode,
+                "durationSeconds": stale_duration,
+                "readiness": stale_after,
+            },
+        )
+    )
+
+    # 3. supervisor SIGTERM 必须清理 gateway、MCP 及全部既有后代。
+    stop_config, stop_workspace, _ = _isolated_config("supervisor-stop")
+    stop_home = Path("/sandbox/supervisor-stop-home")
+    stop_home.mkdir(exist_ok=True)
+    _write_mcp_declaration("sigterm", workspace=stop_workspace)
+    supervisor = subprocess.Popen(
+        [
+            sys.executable,
+            "main.py",
+            "supervise",
+            "--config",
+            str(stop_config),
+            "--workspace",
+            str(stop_workspace),
+        ],
+        env={**os.environ, "HOME": str(stop_home)},
+    )
+    ready_path = stop_workspace / ".runtime-ready.json"
+    deadline = time.monotonic() + READINESS_DEADLINE_S
+    while not ready_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    ready = json.loads(ready_path.read_text(encoding="utf-8"))
+    child_identity = _process_identity(int(ready["pid"]))
+    mcp_identity = _running_mcp_identity("sigterm", workspace=stop_workspace)
+    descendant_identities = [
+        _process_identity(pid) for pid in _descendant_pids(supervisor.pid)
+    ]
+    supervisor.send_signal(signal.SIGTERM)
+    stop_exit = supervisor.wait(timeout=15)
+    _wait_identity_exit(child_identity)
+    _wait_identity_exit(mcp_identity)
+    live_descendants = [
+        identity for identity in descendant_identities if _identity_alive(identity)
+    ]
+    checks.append(
+        CheckResult(
+            "RESTART-SUPERVISOR-SIGTERM",
+            stop_exit == 0
+            and not _identity_alive(child_identity)
+            and not _identity_alive(mcp_identity)
+            and not live_descendants
+            and not ready_path.exists(),
+            {
+                "returncode": stop_exit,
+                "childIdentity": child_identity,
+                "childAlive": _identity_alive(child_identity),
+                "mcpIdentity": mcp_identity,
+                "mcpAlive": _identity_alive(mcp_identity),
+                "descendantIdentities": descendant_identities,
+                "liveDescendants": live_descendants,
+                "readinessExists": ready_path.exists(),
+            },
+        )
+    )
+    _write_json(
+        report_dir / "failure-modes.json",
+        {"checks": [asdict(check) for check in checks]},
+    )
+    return checks
+
+
+def _inside_failures(report_dir: Path) -> int:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    checks = _failure_mode_checks(report_dir)
+    passed = all(check.passed for check in checks)
+    print(json.dumps({"status": "passed" if passed else "failed", "checks": [asdict(check) for check in checks]}, ensure_ascii=False))
+    return 0 if passed else 1
+
+
+def _configure_restart_gate(sandbox: Path) -> None:
+    config = sandbox / "config.toml"
+    text = config.read_text(encoding="utf-8")
+    text = text.replace("max_iterations = 2", "max_iterations = 5")
+    text += "\n[agent.tools]\nsearch_enabled = true\n"
+    config.write_text(text, encoding="utf-8")
+
+
+def _digest_summary(files: dict[str, str]) -> dict[str, object]:
+    encoded = json.dumps(files, sort_keys=True, separators=(",", ":")).encode()
+    return {"sha256": hashlib.sha256(encoded).hexdigest(), "fileCount": len(files)}
+
+
+def _copied_source_digests(
+    source: dict[str, str],
+    app: Path,
+) -> tuple[dict[str, object], dict[str, object], list[str]]:
+    """按同一 source manifest 比较宿主源码与 sandbox app。"""
+
+    manifest = {path: digest for path, digest in source.items() if not path.startswith("static/")}
+    app_files = {
+        path: hashlib.sha256((app / path).read_bytes()).hexdigest()
+        for path in manifest
+        if (app / path).is_file() and not (app / path).is_symlink()
+    }
+    missing = sorted(set(manifest) - set(app_files))
+    return _digest_summary(manifest), _digest_summary(app_files), missing
+
+
+def _host(iterations: int, *, soak: bool) -> int:
+    repo = Path(__file__).resolve().parents[2]
+    run_id = f"{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    report_dir = repo / "docker/debug/reports/restart" / run_id
+    report_dir.mkdir(parents=True)
+    sandbox = Path(tempfile.mkdtemp(prefix="akashic-restart-gate-", dir="/tmp"))
+    _prepare_host_sandbox(sandbox, repo)
+    _configure_restart_gate(sandbox)
+    before = _repository_digest(repo)
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    dirty_status = subprocess.run(
+        ["git", "-C", str(repo), "status", "--short"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.splitlines()
+    source_digest, app_digest, app_missing = _copied_source_digests(
+        before, sandbox / "app"
+    )
+    env = {
+        **os.environ,
+        "AKASHIC_CONTROL_SANDBOX": str(sandbox),
+        "UID": str(os.getuid()),
+        "GID": str(os.getgid()),
+    }
+    env.pop("AKASHIC_EXTRA_PLUGIN_DIRS", None)
+    project = f"akashic-restart-{run_id.lower()}"
+    compose = [
+        "docker",
+        "compose",
+        "-p",
+        project,
+        "-f",
+        str(repo / "docker/debug/docker-compose.control-gate.yml"),
+    ]
+    error = ""
+    inside_returncode = -1
+    unsupervised_returncode = -1
+    failures_returncode = -1
+    cleanup_returncode = -1
+    residual: dict[str, list[str]] = {
+        "containers": [],
+        "networks": [],
+        "volumes": [],
+    }
+    image: dict[str, object] = {}
+    try:
+        build = subprocess.run([*compose, "build", "model-gate"], cwd=repo, env=env)
+        if build.returncode != 0:
+            raise GateFailure(f"image build failed: {build.returncode}")
+        image_inspect = subprocess.run(
+            [
+                "docker", "image", "inspect", "akashic-agent-control-gate:latest",
+                "--format", '{{json .}}',
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        inspected = json.loads(image_inspect.stdout)
+        image = {
+            "name": "akashic-agent-control-gate:latest",
+            "id": inspected["Id"],
+            "repoDigests": inspected.get("RepoDigests", []),
+        }
+        up = subprocess.run(
+            [*compose, "up", "-d", "model-gate", "akashic-control-gate"],
+            cwd=repo,
+            env=env,
+        )
+        if up.returncode != 0:
+            raise GateFailure(f"compose up failed: {up.returncode}")
+        inside_command = [
+                *compose,
+                "exec",
+                "-T",
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",
+                "akashic-control-gate",
+                "python",
+                "docker/debug/restart_probe.py",
+                "--inside",
+                "--iterations",
+                str(iterations),
+                "--report-dir",
+                "/sandbox/reports/restart",
+            ]
+        if soak:
+            inside_command.append("--resource-gate")
+        inside = subprocess.run(
+            inside_command,
+            cwd=repo,
+            env=env,
+        )
+        inside_returncode = inside.returncode
+        if inside.returncode != 0:
+            raise GateFailure(f"inside gate failed: {inside.returncode}")
+        unsupervised = subprocess.run(
+            [
+                *compose,
+                "run",
+                "--rm",
+                "-T",
+                "--no-deps",
+                "control-probe",
+                "python",
+                "docker/debug/restart_probe.py",
+                "--inside-unsupervised",
+                "--report-dir",
+                "/sandbox/reports/restart",
+            ],
+            cwd=repo,
+            env=env,
+        )
+        unsupervised_returncode = unsupervised.returncode
+        if unsupervised.returncode != 0:
+            raise GateFailure(
+                f"unsupervised gate failed: {unsupervised.returncode}"
+            )
+        failures = subprocess.run(
+            [
+                *compose,
+                "run",
+                "--rm",
+                "-T",
+                "--no-deps",
+                "control-probe",
+                "python",
+                "docker/debug/restart_probe.py",
+                "--inside-failures",
+                "--report-dir",
+                "/sandbox/reports/restart",
+            ],
+            cwd=repo,
+            env=env,
+        )
+        failures_returncode = failures.returncode
+        if failures.returncode != 0:
+            raise GateFailure(f"failure modes failed: {failures.returncode}")
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        logs = subprocess.run(
+            [*compose, "logs", "--no-color"],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        (report_dir / "compose.log").write_text(logs.stdout, encoding="utf-8")
+        if (sandbox / "reports/restart").exists():
+            shutil.copytree(
+                sandbox / "reports/restart",
+                report_dir,
+                dirs_exist_ok=True,
+            )
+        cleanup = subprocess.run(
+            [*compose, "down", "--remove-orphans", "--volumes"],
+            cwd=repo,
+            env=env,
+        )
+        cleanup_returncode = cleanup.returncode
+        for kind, command in {
+            "containers": ["docker", "ps", "-aq", "--filter", f"label=com.docker.compose.project={project}"],
+            "networks": ["docker", "network", "ls", "-q", "--filter", f"label=com.docker.compose.project={project}"],
+            "volumes": ["docker", "volume", "ls", "-q", "--filter", f"label=com.docker.compose.project={project}"],
+        }.items():
+            result = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE)
+            residual[kind] = result.stdout.split()
+
+    after = _repository_digest(repo)
+    passed = (
+        not error
+        and inside_returncode == 0
+        and unsupervised_returncode == 0
+        and failures_returncode == 0
+        and cleanup_returncode == 0
+        and not any(residual.values())
+        and before == after
+        and source_digest == app_digest
+        and not app_missing
+    )
+    report = {
+        "runId": run_id,
+        "gate": "restart",
+        "head": head,
+        "dirtyStatus": dirty_status,
+        "sourceDigest": source_digest,
+        "sandboxAppDigest": app_digest,
+        "sandboxMissingSourceFiles": app_missing,
+        "composeProject": project,
+        "image": image,
+        "iterations": iterations,
+        "status": "passed" if passed else "failed",
+        "insideReturncode": inside_returncode,
+        "unsupervisedReturncode": unsupervised_returncode,
+        "failuresReturncode": failures_returncode,
+        "cleanupReturncode": cleanup_returncode,
+        "residualResources": residual,
+        "repositoriesUnchanged": before == after,
+        "error": error,
+        "reportDir": str(report_dir),
+    }
+    _write_json(report_dir / "gate.json", report)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    shutil.rmtree(sandbox)
+    return 0 if passed else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="restart Docker 真实验收 Gate")
+    parser.add_argument("--inside", action="store_true")
+    parser.add_argument("--inside-unsupervised", action="store_true")
+    parser.add_argument("--inside-failures", action="store_true")
+    parser.add_argument("--resource-gate", action="store_true")
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--soak", action="store_true")
+    parser.add_argument("--report-dir", type=Path, default=Path("/sandbox/reports/restart"))
+    args = parser.parse_args()
+    iterations = 20 if args.soak else args.iterations
+    if iterations < 1:
+        raise SystemExit("--iterations 必须大于 0")
+    if args.inside:
+        return _inside(iterations, args.report_dir, resource_gate=args.resource_gate)
+    if args.inside_unsupervised:
+        return _inside_unsupervised(args.report_dir)
+    if args.inside_failures:
+        return _inside_failures(args.report_dir)
+    return _host(iterations, soak=args.soak)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/debug/workspace_mcp_reload_probe.py
+++ b/docker/debug/workspace_mcp_reload_probe.py
@@ -1,0 +1,865 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Iterator
+from uuid import uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import bootstrap.app as bootstrap_app
+from agent.config_models import (
+    AppServerConfig,
+    ChannelsConfig,
+    Config,
+    WebChatConfig,
+)
+from agent.plugins.manager import PluginManager
+from agent.tools.base import ToolResult
+from proactive_v2.config import ProactiveConfig
+from docker.debug.programmatic_control_probe import (
+    _prepare_host_sandbox,
+    _repository_digest,
+)
+
+
+SERVER_SOURCE = r'''from __future__ import annotations
+import json
+import os
+from pathlib import Path
+import sys
+
+log = Path(os.environ["LIFECYCLE_LOG"])
+version = os.environ["VERSION"]
+instance = os.environ["INSTANCE"]
+pid = os.getpid()
+starttime = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()[19]
+marker = Path(os.environ["MARKER_PATH"]).read_text(encoding="utf-8").strip()
+
+def record(event: str) -> None:
+    with log.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps({"event": event, "pid": pid, "starttime": starttime, "version": version, "instance": instance}) + "\n")
+
+record("started")
+try:
+    for line in sys.stdin:
+        message = json.loads(line)
+        if "id" not in message:
+            continue
+        method = message.get("method")
+        if method == "initialize":
+            result = {"protocolVersion": "2025-11-25"}
+        elif method == "tools/list":
+            result = {"tools": [{"name": "version", "description": "Return server version", "inputSchema": {"type": "object", "properties": {}}}]}
+        elif method == "tools/call":
+            result = {"content": [{"type": "text", "text": f"{version}:{marker}"}]}
+        else:
+            result = {}
+        print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+finally:
+    record("stopped")
+'''
+
+
+def _config() -> Config:
+    return Config(
+        provider="openai",
+        model="workspace-mcp-gate",
+        api_key="gate",
+        system_prompt="workspace MCP gate",
+        base_url="http://127.0.0.1:9/v1",
+        channels=ChannelsConfig(chat=WebChatConfig(enabled=False)),
+        app_server=AppServerConfig(enabled=False),
+        proactive=ProactiveConfig(enabled=False),
+        memory_optimizer_enabled=False,
+        multimodal=False,
+        spawn_enabled=False,
+    )
+
+
+@contextmanager
+def _ephemeral_dashboard() -> Iterator[None]:
+    """让真实 AppRuntime 的 dashboard 绑定随机端口。"""
+
+    original = bootstrap_app.build_dashboard_server
+
+    def build(**kwargs: Any) -> object:
+        return original(host="127.0.0.1", port=0, **kwargs)
+
+    bootstrap_app.build_dashboard_server = build  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        bootstrap_app.build_dashboard_server = original
+
+
+def _write_server(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "watch.txt").write_text("one", encoding="utf-8")
+    server = root / "synthetic_mcp.py"
+    server.write_text(SERVER_SOURCE, encoding="utf-8")
+    return server
+
+
+def _write_declaration(
+    declarations: Path,
+    name: str,
+    server: Path,
+    lifecycle: Path,
+    version: str,
+    *,
+    watch_path: str = "",
+) -> Path:
+    declarations.mkdir(parents=True, exist_ok=True)
+    watch = f'watch_paths = ["{watch_path}"]\n' if watch_path else ""
+    path = declarations / f"{name}.toml"
+    path.write_text(
+        "schema_version = 1\n"
+        f'name = "{name}"\n'
+        f'command = ["{sys.executable}", "{server}"]\n'
+        f"{watch}"
+        "[env]\n"
+        f'VERSION = "{version}"\n'
+        f'INSTANCE = "{name}"\n'
+        f'LIFECYCLE_LOG = "{lifecycle}"\n'
+        f'MARKER_PATH = "{server.parent / "watch.txt"}"\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _lifecycle(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+def _pid_starttime(pid: int) -> str | None:
+    stat = Path(f"/proc/{pid}/stat")
+    try:
+        content = stat.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    return content.rsplit(")", 1)[1].split()[19]
+
+
+def _running_pids(
+    path: Path,
+    *,
+    instance: str = "",
+    version: str = "",
+) -> list[int]:
+    """按 PID 与 starttime 判断 fixture 启动的同一进程是否仍存活。"""
+
+    started = [
+        item
+        for item in _lifecycle(path)
+        if item["event"] == "started"
+        and (not instance or item["instance"] == instance)
+        and (not version or item["version"] == version)
+    ]
+    return sorted(
+        {
+            int(item["pid"])
+            for item in started
+            if _pid_starttime(int(item["pid"])) == item["starttime"]
+        }
+    )
+
+
+async def _wait_until(predicate: Any, label: str, timeout: float = 8.0) -> None:
+    """在固定 deadline 内等待真实 watcher 状态。"""
+
+    async with asyncio.timeout(timeout):
+        while not predicate():
+            await asyncio.sleep(0.02)
+    if not predicate():
+        raise AssertionError(f"等待失败: {label}")
+
+
+async def _call_version(lease: Any, server_name: str = "docs") -> str:
+    registry = lease.snapshot.tool_registry
+    if registry is None:
+        raise AssertionError("snapshot 缺少 tool registry")
+    result = await registry.execute(
+        f"mcp_{server_name}__version",
+        {},
+        raise_errors=True,
+    )
+    return result.text if isinstance(result, ToolResult) else result
+
+
+def _check(checks: list[dict[str, object]], name: str, passed: bool, **evidence: object) -> None:
+    checks.append({"name": name, "passed": passed, "evidence": evidence})
+    if not passed:
+        raise AssertionError(f"{name}: {evidence}")
+
+
+async def _run_reload_sequence(root: Path, checks: list[dict[str, object]]) -> None:
+    workspace = root / "workspace"
+    mcp_root = workspace / "mcp"
+    declarations = mcp_root / "servers"
+    runtime_root = mcp_root / "synthetic"
+    lifecycle = root / "lifecycle.jsonl"
+    server = _write_server(runtime_root)
+    marker = runtime_root / "watch.txt"
+    marker.write_text("one", encoding="utf-8")
+    _write_declaration(
+        declarations,
+        "docs",
+        server,
+        lifecycle,
+        "v1",
+        watch_path="../synthetic/watch.txt",
+    )
+    (workspace / "mcp_servers.json").write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "legacy": {
+                        "command": [sys.executable, str(server)],
+                        "env": {
+                            "VERSION": "legacy",
+                            "INSTANCE": "legacy",
+                            "LIFECYCLE_LOG": str(lifecycle),
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    app = bootstrap_app.AppRuntime(_config(), workspace)
+    with _ephemeral_dashboard():
+        await app.start()
+    manager = app.core.plugin_manager
+    if manager is None:
+        raise AssertionError("AppRuntime 缺少 PluginManager")
+    try:
+        first = manager.active_workspace_mcp
+        _check(
+            checks,
+            "initial-v1",
+            first is not None and await _current_version(manager) == "v1:one",
+            generation=first.generation_id if first else None,
+        )
+        legacy_started = [
+            item
+            for item in _lifecycle(lifecycle)
+            if item["event"] == "started" and item["instance"] == "legacy"
+        ]
+        _check(
+            checks,
+            "legacy-json-ignored",
+            "mcp_legacy__version" not in manager.current_snapshot.tool_registry.get_registered_names()  # type: ignore[union-attr]
+            and not legacy_started,
+            path=str(workspace / "mcp_servers.json"),
+            lifecycle=legacy_started,
+        )
+
+        old_turn_started = asyncio.Event()
+        release_old_turn = asyncio.Event()
+
+        async def old_turn() -> tuple[str, str]:
+            lease = await manager.snapshot_store.acquire()
+            old_turn_started.set()
+            await release_old_turn.wait()
+            try:
+                return await _call_version(lease), lease.snapshot.snapshot_id
+            finally:
+                await lease.release()
+
+        old_turn_task = asyncio.create_task(old_turn(), name="workspace-mcp-old-turn")
+        await old_turn_started.wait()
+        old_generation = manager.active_workspace_mcp
+        _write_declaration(
+            declarations,
+            "docs",
+            server,
+            lifecycle,
+            "v2",
+            watch_path="../synthetic/watch.txt",
+        )
+        await _wait_until(
+            lambda: manager.active_workspace_mcp is not old_generation,
+            "v2 generation",
+        )
+        new_lease = await manager.snapshot_store.acquire()
+        new_version = await _call_version(new_lease)
+        new_snapshot_id = new_lease.snapshot.snapshot_id
+        await new_lease.release()
+        release_old_turn.set()
+        old_version, old_snapshot_id = await old_turn_task
+        _check(
+            checks,
+            "old-new-isolation",
+            old_version == "v1:one" and new_version == "v2:one",
+            oldTurnResult=old_version,
+            oldSnapshot=old_snapshot_id,
+            newSnapshot=new_snapshot_id,
+        )
+        await _wait_until(
+            lambda: not _running_pids(lifecycle, version="v1"),
+            "v1 lease drain",
+        )
+
+        before_watch = manager.active_workspace_mcp
+        marker.write_text("two", encoding="utf-8")
+        await _wait_until(
+            lambda: manager.active_workspace_mcp is not before_watch,
+            "watch content generation",
+        )
+        _check(
+            checks,
+            "watch-content-reload",
+            await _current_version(manager) == "v2:two",
+            before=before_watch.generation_id if before_watch else None,
+            after=manager.active_workspace_mcp.generation_id,
+            toolResult=await _current_version(manager),
+        )
+
+        stable = manager.active_workspace_mcp
+        docs = declarations / "docs.toml"
+        docs.write_text("schema_version = 1\nname = [\n", encoding="utf-8")
+        watcher = app.core.workspace_mcp_watcher
+        await _wait_until(lambda: watcher.last_error is not None, "bad TOML rejection")
+        _check(
+            checks,
+            "bad-toml-rollback",
+            manager.active_workspace_mcp is stable
+            and await _current_version(manager) == "v2:two",
+            error=watcher.last_error,
+        )
+
+        _write_declaration(declarations, "a_good", server, lifecycle, "partial")
+        _write_declaration(
+            declarations,
+            "z_bad",
+            root / "missing-server.py",
+            lifecycle,
+            "bad",
+        )
+        _write_declaration(
+            declarations,
+            "docs",
+            server,
+            lifecycle,
+            "v2",
+            watch_path="../synthetic/watch.txt",
+        )
+        previous_error = watcher.last_error
+        await _wait_until(
+            lambda: watcher.last_error is not None
+            and watcher.last_error != previous_error,
+            "partial candidate rejection",
+        )
+        await _wait_until(
+            lambda: not _running_pids(lifecycle, instance="a_good"),
+            "partial candidate process cleanup",
+        )
+        _check(
+            checks,
+            "partial-candidate-cleanup",
+            manager.active_workspace_mcp is stable
+            and not _running_pids(lifecycle, instance="a_good"),
+            error=watcher.last_error,
+            runningCandidatePids=_running_pids(
+                lifecycle,
+                instance="a_good",
+            ),
+            lifecycle=_lifecycle(lifecycle),
+        )
+
+        _write_declaration(declarations, "z_bad", server, lifecycle, "repaired")
+        await _wait_until(
+            lambda: manager.active_workspace_mcp is not stable
+            and watcher.last_error is None,
+            "automatic recovery",
+        )
+        repaired_lease = await manager.snapshot_store.acquire()
+        _check(
+            checks,
+            "automatic-recovery",
+            await _call_version(repaired_lease, "z_bad") == "repaired:two",
+            generation=manager.active_workspace_mcp.generation_id,
+        )
+
+        for declaration in declarations.glob("*.toml"):
+            declaration.unlink()
+        repaired_generation = manager.active_workspace_mcp
+        await _wait_until(
+            lambda: manager.active_workspace_mcp is not repaired_generation
+            and not manager.active_workspace_mcp.catalog.servers,
+            "empty generation",
+        )
+        empty_lease = await manager.snapshot_store.acquire()
+        empty_registry = empty_lease.snapshot.tool_registry
+        if empty_registry is None:
+            raise AssertionError("empty snapshot 缺少 tool registry")
+        empty_names = sorted(empty_registry.get_registered_names())
+        await empty_lease.release()
+        leased_pids = _running_pids(lifecycle)
+        await repaired_lease.release()
+        await _wait_until(lambda: not _running_pids(lifecycle), "empty lease drain")
+        _check(
+            checks,
+            "delete-all-drains",
+            bool(leased_pids)
+            and not manager.active_workspace_mcp.catalog.servers
+            and "mcp_docs__version" not in empty_names
+            and "mcp_a_good__version" not in empty_names
+            and "mcp_z_bad__version" not in empty_names,
+            leasedPids=leased_pids,
+            emptyRegistryNames=empty_names,
+            lifecycle=_lifecycle(lifecycle),
+        )
+    finally:
+        await app.shutdown()
+    _check(
+        checks,
+        "shutdown-no-residual",
+        app.core.workspace_mcp_watcher_task.done()
+        and not _running_pids(lifecycle)
+        and not [
+            task.get_name()
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+            and task.get_name() == "workspace_mcp_watcher"
+            and not task.done()
+        ],
+        runningPids=_running_pids(lifecycle),
+    )
+
+
+async def _current_version(manager: PluginManager) -> str:
+    lease = await manager.snapshot_store.acquire()
+    try:
+        return await _call_version(lease)
+    finally:
+        await lease.release()
+
+
+async def _run_plugin_conflict(root: Path, checks: list[dict[str, object]]) -> None:
+    workspace = root / "conflict-workspace"
+    declarations = workspace / "mcp" / "servers"
+    server = _write_server(workspace / "mcp" / "server")
+    lifecycle = root / "conflict-lifecycle.jsonl"
+    _write_declaration(declarations, "docs", server, lifecycle, "workspace")
+    plugins = root / "conflict-plugins"
+    plugin = plugins / "collision"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.py").write_text(
+        "from agent.plugins import McpServerSpec, Plugin\n"
+        "class CollisionPlugin(Plugin):\n"
+        "    name = 'collision'\n"
+        "    @classmethod\n"
+        "    def mcp_servers(cls):\n"
+        "        return [McpServerSpec(name='docs', command=('python', 'unused.py'))]\n",
+        encoding="utf-8",
+    )
+    previous = os.environ.get("AKASHIC_EXTRA_PLUGIN_DIRS")
+    os.environ["AKASHIC_EXTRA_PLUGIN_DIRS"] = str(plugins)
+    app = bootstrap_app.AppRuntime(_config(), workspace)
+    error = ""
+    try:
+        with _ephemeral_dashboard():
+            await app.start()
+    except RuntimeError as caught:
+        error = str(caught)
+    finally:
+        if previous is None:
+            os.environ.pop("AKASHIC_EXTRA_PLUGIN_DIRS", None)
+        else:
+            os.environ["AKASHIC_EXTRA_PLUGIN_DIRS"] = previous
+    _check(
+        checks,
+        "plugin-name-conflict-fail-loud",
+        "workspace MCP 与插件声明冲突" in error
+        and not _running_pids(lifecycle),
+        error=error,
+        runningPids=_running_pids(lifecycle),
+    )
+
+
+async def _run_watcher_fault(root: Path, checks: list[dict[str, object]]) -> None:
+    import agent.mcp.watcher as watcher_module
+
+    workspace = root / "fault-workspace"
+    app = bootstrap_app.AppRuntime(_config(), workspace)
+    original = watcher_module.declarations_input_revision
+
+    def fail(*_args: object, **_kwargs: object) -> str:
+        raise KeyError("synthetic watcher fault")
+
+    watcher_module.declarations_input_revision = fail
+    error = ""
+    try:
+        with _ephemeral_dashboard():
+            await asyncio.wait_for(app.run(), timeout=8)
+    except KeyError as caught:
+        error = str(caught)
+    finally:
+        watcher_module.declarations_input_revision = original
+    task = app.core.workspace_mcp_watcher_task
+    _check(
+        checks,
+        "watcher-fault-supervised",
+        "synthetic watcher fault" in error and task is not None and task.done(),
+        error=error,
+        taskDone=task.done() if task else None,
+    )
+
+
+async def run_gate(root: Path) -> dict[str, object]:
+    """运行完整 AppRuntime workspace MCP Docker gate。"""
+
+    checks: list[dict[str, object]] = []
+    run_root = root / f"run-{uuid4().hex}"
+    home = run_root / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    previous_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(home)
+    try:
+        await _run_reload_sequence(run_root, checks)
+        await _run_plugin_conflict(run_root, checks)
+        await _run_watcher_fault(run_root, checks)
+    finally:
+        if previous_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = previous_home
+    return {"status": "passed", "checks": checks, "root": str(run_root)}
+
+
+def _manifest_digest(manifest: dict[str, str]) -> str:
+    return hashlib.sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _sandbox_manifest(app_root: Path, source: dict[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative in source:
+        path = app_root / relative
+        if not path.is_file() or path.is_symlink():
+            raise RuntimeError(f"sandbox 源码缺失: {relative}")
+        result[relative] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def _git_state(repo: Path) -> tuple[str, str]:
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    dirty = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    return head, dirty
+
+
+def _compose_command(repo: Path, project: str) -> list[str]:
+    return [
+        "docker",
+        "compose",
+        "-p",
+        project,
+        "-f",
+        str(repo / "docker/debug/docker-compose.control-gate.yml"),
+    ]
+
+
+def _compose_environment(sandbox: Path) -> dict[str, str]:
+    env = {
+        **os.environ,
+        "AKASHIC_CONTROL_SANDBOX": str(sandbox),
+        "UID": str(os.getuid()),
+        "GID": str(os.getgid()),
+    }
+    env.pop("AKASHIC_EXTRA_PLUGIN_DIRS", None)
+    return env
+
+
+def _project_resources(resource: str, project: str) -> list[str]:
+    """按 Compose project 标签返回指定类型的残留资源。"""
+
+    list_flags = "-aq" if resource == "container" else "-q"
+    command = [
+        "docker",
+        resource,
+        "ls",
+        list_flags,
+        "--filter",
+        f"label=com.docker.compose.project={project}",
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Docker {resource} residual query failed: {completed.stderr.strip()}"
+        )
+    return completed.stdout.split()
+
+
+def _run_host(report_root: Path | None) -> int:
+    """在独立 Compose project 中运行只读 sandbox gate。"""
+
+    repo = Path(__file__).resolve().parents[2]
+    run_id = f"{time.strftime('%Y%m%d-%H%M%S')}-{uuid4().hex[:8]}"
+    report_dir = (
+        report_root / run_id
+        if report_root is not None
+        else repo / "docker/debug/reports/workspace-mcp" / run_id
+    )
+    report_dir.mkdir(parents=True)
+    sandbox = Path(tempfile.mkdtemp(prefix="akashic-workspace-mcp-gate-", dir="/tmp"))
+    _prepare_host_sandbox(sandbox, repo)
+
+    head_before, dirty_before = _git_state(repo)
+    source_before = _repository_digest(repo)
+    app_before = _sandbox_manifest(sandbox / "app", source_before)
+    project = f"akashic-workspace-mcp-{run_id.lower()}"
+    compose = _compose_command(repo, project)
+    env = _compose_environment(sandbox)
+    image = "akashic-agent-control-gate:latest"
+    controller_error = ""
+    internal: dict[str, object] = {}
+    cleanup_returncode = -1
+    residual_containers: list[str] = []
+    residual_networks: list[str] = []
+    residual_volumes: list[str] = []
+    image_id = ""
+    try:
+        build = subprocess.run(
+            [*compose, "build", "model-gate"],
+            cwd=repo,
+            env=env,
+            check=False,
+        )
+        if build.returncode != 0:
+            raise RuntimeError(f"control-gate image build failed: {build.returncode}")
+        inspected = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{.Id}}", image],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        image_id = inspected.stdout.strip()
+        completed = subprocess.run(
+            [
+                *compose,
+                "run",
+                "--rm",
+                "-T",
+                "--no-deps",
+                "-e",
+                "AKASHIC_WORKSPACE_MCP_DOCKER_GATE=1",
+                "control-probe",
+                "python",
+                "docker/debug/workspace_mcp_reload_probe.py",
+                "--internal",
+                "--workspace",
+                "/sandbox/workspace-mcp-gate",
+                "--report",
+                "/sandbox/reports/inside.json",
+            ],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+            check=False,
+        )
+        (report_dir / "container.stdout.log").write_text(
+            completed.stdout,
+            encoding="utf-8",
+        )
+        (report_dir / "container.stderr.log").write_text(
+            completed.stderr,
+            encoding="utf-8",
+        )
+        inside_path = sandbox / "reports/inside.json"
+        if inside_path.exists():
+            internal = json.loads(inside_path.read_text(encoding="utf-8"))
+            shutil.copy2(inside_path, report_dir / "inside.json")
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"container gate failed: {completed.returncode}; "
+                f"stderr={completed.stderr[-2000:]}"
+            )
+    except Exception as error:
+        controller_error = f"{type(error).__name__}: {error}"
+    finally:
+        cleanup = subprocess.run(
+            [*compose, "down", "--remove-orphans", "--volumes"],
+            cwd=repo,
+            env=env,
+            check=False,
+        )
+        cleanup_returncode = cleanup.returncode
+        residual_containers = _project_resources("container", project)
+        residual_networks = _project_resources("network", project)
+        residual_volumes = _project_resources("volume", project)
+
+    head_after, dirty_after = _git_state(repo)
+    source_after = _repository_digest(repo)
+    app_after = _sandbox_manifest(sandbox / "app", source_before)
+    source_digest = _manifest_digest(source_before)
+    app_digest = _manifest_digest(app_before)
+    integrity = (
+        head_before == head_after
+        and dirty_before == dirty_after
+        and source_before == source_after
+        and source_before == app_before == app_after
+        and cleanup_returncode == 0
+        and not residual_containers
+        and not residual_networks
+        and not residual_volumes
+    )
+    isolation = internal.get("isolation")
+    passed = (
+        not controller_error
+        and internal.get("status") == "passed"
+        and isinstance(isolation, dict)
+        and isolation.get("passed") is True
+        and integrity
+    )
+    report = {
+        "status": "passed" if passed else "failed",
+        "runId": run_id,
+        "head": head_before,
+        "dirtyStatus": dirty_before.splitlines(),
+        "sourceDigest": source_digest,
+        "sourceFileCount": len(source_before),
+        "sandboxAppDigest": app_digest,
+        "composeProject": project,
+        "composeFile": str(repo / "docker/debug/docker-compose.control-gate.yml"),
+        "image": image,
+        "imageId": image_id,
+        "sandbox": str(sandbox),
+        "controllerError": controller_error,
+        "cleanupReturncode": cleanup_returncode,
+        "residualContainers": residual_containers,
+        "residualNetworks": residual_networks,
+        "residualVolumes": residual_volumes,
+        "repositoryUnchanged": integrity,
+        "internal": internal,
+        "reportDir": str(report_dir),
+    }
+    encoded = json.dumps(report, ensure_ascii=False, indent=2)
+    (report_dir / "gate.json").write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    shutil.rmtree(sandbox)
+    return 0 if passed else 1
+
+
+def _container_isolation() -> dict[str, object]:
+    docker_gate = os.environ.get("AKASHIC_WORKSPACE_MCP_DOCKER_GATE") == "1"
+    extra_present = "AKASHIC_EXTRA_PLUGIN_DIRS" in os.environ
+    mountinfo = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+    host_cache_mounts = [
+        line
+        for line in mountinfo.splitlines()
+        if ".akashic-plugin/cache" in line
+    ]
+    home = str(Path.home())
+    passed = (
+        not docker_gate
+        or (
+            not extra_present
+            and home == "/sandbox/home"
+            and not host_cache_mounts
+        )
+    )
+    return {
+        "passed": passed,
+        "dockerGate": docker_gate,
+        "home": home,
+        "extraPluginDirsPresent": extra_present,
+        "hostPluginCacheMounts": host_cache_mounts,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="workspace MCP 真实 Docker 热重载 gate")
+    parser.add_argument("--internal", action="store_true")
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--report-root", type=Path)
+    return parser
+
+
+def _run_internal(workspace: Path | None, report: Path | None) -> int:
+    temporary: tempfile.TemporaryDirectory[str] | None = None
+    root = workspace
+    if root is None:
+        temporary = tempfile.TemporaryDirectory(prefix="workspace-mcp-gate-")
+        root = Path(temporary.name)
+    try:
+        payload = asyncio.run(run_gate(root.resolve()))
+        payload["isolation"] = _container_isolation()
+        if not payload["isolation"]["passed"]:  # type: ignore[index]
+            raise RuntimeError(f"container isolation failed: {payload['isolation']}")
+        exit_code = 0
+    except Exception as error:
+        payload = {
+            "status": "failed",
+            "error": {"type": type(error).__name__, "message": str(error)},
+            "root": str(root),
+        }
+        exit_code = 1
+    finally:
+        if temporary is not None:
+            temporary.cleanup()
+    encoded = json.dumps(payload, ensure_ascii=False, indent=2)
+    print(encoded)
+    if report is not None:
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(encoded + "\n", encoding="utf-8")
+    return exit_code
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if args.internal:
+        return _run_internal(args.workspace, args.report)
+    if args.workspace is not None or args.report is not None:
+        raise SystemExit("--workspace/--report 仅供 --internal 使用")
+    return _run_host(args.report_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_restart_probe.py
+++ b/tests/test_restart_probe.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from docker.debug.programmatic_control_probe import _prepare_host_sandbox
+from docker.debug.restart_probe import (
+    _copied_source_digests,
+    _configure_restart_gate,
+    _mcp_scripts,
+    _identity_alive,
+    _memory_within_limit,
+    _peak_memory_deltas,
+    _process_identity,
+    _process_metrics,
+    _restart_scripts,
+    _tool_names,
+)
+
+
+def test_restart_gate_enables_search_and_multi_step_tool_loop(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "main.py").write_text("", encoding="utf-8")
+    sandbox = tmp_path / "sandbox"
+    _prepare_host_sandbox(sandbox, source)
+    (sandbox / "config.toml").write_text(
+        "max_iterations = 2\n",
+        encoding="utf-8",
+    )
+
+    _configure_restart_gate(sandbox)
+
+    config = (sandbox / "config.toml").read_text(encoding="utf-8")
+    assert "max_iterations = 5" in config
+    assert "[agent.tools]\nsearch_enabled = true" in config
+
+
+def test_restart_scripts_unlock_before_restart_and_gate_final_reply() -> None:
+    scripts = _restart_scripts(3, "final-barrier")
+
+    assert scripts[0]["tool_calls"] == [
+        {
+            "id": "call_search_3",
+            "name": "tool_search",
+            "arguments": {"query": "select:agent_restart"},
+        }
+    ]
+    assert scripts[1]["tool_calls"] == [
+        {
+            "id": "call_restart_3",
+            "name": "agent_restart",
+            "arguments": {"reason": "restart gate iteration 3"},
+        }
+    ]
+    assert scripts[2]["barrier"] == "final-barrier"
+    assert scripts[2]["content"] == "restart-complete-3"
+
+
+def test_mcp_scripts_unlock_call_and_complete() -> None:
+    scripts = _mcp_scripts("v7")
+
+    assert scripts[0]["tool_calls"][0]["name"] == "tool_search"  # type: ignore[index]
+    assert scripts[1]["tool_calls"][0]["name"] == "mcp_restart_probe__version"  # type: ignore[index]
+    assert scripts[2]["content"] == "mcp-v7"
+
+
+def test_sandbox_digest_uses_same_source_manifest(tmp_path: Path) -> None:
+    app = tmp_path / "app"
+    app.mkdir()
+    (app / "main.py").write_text("same", encoding="utf-8")
+    source = {
+        "main.py": hashlib.sha256(b"same").hexdigest(),
+        "static/generated.js": hashlib.sha256(b"ignored").hexdigest(),
+    }
+
+    source_digest, app_digest, missing = _copied_source_digests(source, app)
+
+    assert source_digest == app_digest
+    assert missing == []
+
+
+def test_process_identity_rejects_reused_pid_counterexample() -> None:
+    identity = _process_identity(os.getpid())
+
+    assert _identity_alive(identity)
+    assert not _identity_alive(
+        {"pid": identity["pid"], "starttime": identity["starttime"] + 1}
+    )
+
+
+def test_process_metrics_include_rss_and_high_water_mark() -> None:
+    metrics = _process_metrics(os.getpid())
+
+    assert metrics["vmRssKiB"] > 0
+    assert metrics["vmHwmKiB"] >= metrics["vmRssKiB"]
+    assert metrics["fds"] > 0
+    assert metrics["threads"] > 0
+
+
+def test_hwm_peak_over_limit_fails_after_rss_recovers() -> None:
+    supervisor = {"vmRssKiB": 100, "vmHwmKiB": 200}
+    child = {"vmRssKiB": 300, "vmHwmKiB": 400}
+    samples = [
+        {
+            "supervisor": {"vmRssKiB": 110, "vmHwmKiB": 200 + 200 * 1024},
+            "child": {"vmRssKiB": 310, "vmHwmKiB": 410},
+        }
+    ]
+
+    deltas = _peak_memory_deltas(supervisor, child, samples)
+
+    assert deltas["supervisorRssKiB"] == 10
+    assert deltas["supervisorHwmKiB"] == 200 * 1024
+    assert not _memory_within_limit(deltas)
+
+
+def test_tool_names_reads_real_openai_payload_shape() -> None:
+    request = {
+        "payload": {
+            "tools": [
+                {"type": "function", "function": {"name": "tool_search"}},
+                {"type": "function", "function": {"name": "agent_restart"}},
+            ]
+        }
+    }
+
+    assert _tool_names(request) == {"tool_search", "agent_restart"}
+
+
+def test_restart_probe_defaults_are_pr_gate_and_soak_compatible() -> None:
+    source = Path("docker/debug/restart_probe.py").read_text(encoding="utf-8")
+    assert 'parser.add_argument("--iterations", type=int, default=3)' in source
+    assert "iterations = 20 if args.soak else args.iterations" in source
+    assert 'inside_command.append("--resource-gate")' in source
+    assert '"supervisorRssKiB": 64 * 1024' in source
+    assert '"supervisorHwmKiB": 64 * 1024' in source
+    assert '"childRssKiB": 64 * 1024' in source
+    assert '"childHwmKiB": 64 * 1024' in source
+    json.dumps({"status": "passed", "iterations": 3})

--- a/tests/test_workspace_mcp_reload_probe.py
+++ b/tests/test_workspace_mcp_reload_probe.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from docker.debug.workspace_mcp_reload_probe import (
+    _build_parser,
+    _compose_command,
+    _compose_environment,
+    _pid_starttime,
+    _running_pids,
+)
+
+
+def test_workspace_mcp_reload_probe_runs_real_app_runtime(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "docker/debug/workspace_mcp_reload_probe.py",
+            "--internal",
+            "--workspace",
+            str(tmp_path / "gate"),
+            "--report",
+            str(report),
+        ],
+        cwd=Path(__file__).parents[1],
+        text=True,
+        capture_output=True,
+        timeout=45,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["status"] == "passed"
+    checks = {item["name"]: item for item in payload["checks"]}
+    assert all(item["passed"] for item in checks.values())
+    assert {
+        "initial-v1",
+        "old-new-isolation",
+        "watch-content-reload",
+        "bad-toml-rollback",
+        "partial-candidate-cleanup",
+        "automatic-recovery",
+        "delete-all-drains",
+        "plugin-name-conflict-fail-loud",
+        "watcher-fault-supervised",
+        "shutdown-no-residual",
+        "legacy-json-ignored",
+    } <= set(checks)
+    assert checks["watch-content-reload"]["evidence"]["toolResult"] == "v2:two"
+    assert checks["legacy-json-ignored"]["evidence"]["lifecycle"] == []
+    assert "mcp_docs__version" not in checks["delete-all-drains"]["evidence"][
+        "emptyRegistryNames"
+    ]
+
+
+def test_running_pids_uses_proc_identity_not_stopped_event(tmp_path: Path) -> None:
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        starttime = _pid_starttime(process.pid)
+        assert starttime is not None
+        lifecycle = tmp_path / "lifecycle.jsonl"
+        records = [
+            {
+                "event": event,
+                "pid": process.pid,
+                "starttime": starttime,
+                "version": "test",
+                "instance": "docs",
+            }
+            for event in ("started", "stopped")
+        ]
+        lifecycle.write_text(
+            "".join(json.dumps(record) + "\n" for record in records),
+            encoding="utf-8",
+        )
+        assert _running_pids(lifecycle) == [process.pid]
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+    assert _running_pids(lifecycle) == []
+
+
+def test_workspace_mcp_probe_separates_host_and_internal_arguments(
+    tmp_path: Path,
+) -> None:
+    parser = _build_parser()
+    host = parser.parse_args([])
+    assert host.internal is False
+    assert host.workspace is None
+    internal = parser.parse_args(
+        ["--internal", "--workspace", str(tmp_path), "--report", str(tmp_path / "r.json")]
+    )
+    assert internal.internal is True
+    assert internal.workspace == tmp_path
+    compose = _compose_command(tmp_path, "gate-project")
+    assert compose[:5] == ["docker", "compose", "-p", "gate-project", "-f"]
+    assert compose[-1].endswith("docker/debug/docker-compose.control-gate.yml")
+    environment = _compose_environment(tmp_path / "sandbox")
+    assert "AKASHIC_EXTRA_PLUGIN_DIRS" not in environment


### PR DESCRIPTION
## Problem

MCP hot reload and supervised `agent_restart` need real-process acceptance gates. Unit coverage alone cannot prove generation drain, terminal delivery ordering, process ownership, cleanup, or session continuity across a restart.

## Scope

- add an isolated workspace MCP lifecycle Docker gate
- add a programmatic `tool_search -> MCP call -> agent_restart -> resume` gate
- cover invalid declaration rollback, automatic recovery, exit-75 authorization, stale readiness, disconnect, unsupervised absence, and SIGTERM cleanup
- run a 20-generation soak with FD, thread, RSS, HWM, zombie, and active-turn thresholds
- compare Git HEAD and tracked/non-ignored source digests with the read-only container app
- require zero residual Compose containers, networks, and volumes
- add a combined CI job and document the acceptance contract

## Breaking-change context

This PR is stacked on the declaration-only workspace MCP runtime and supervised restart PRs. It does not restore legacy `mcp_servers.json` or add a migration command.

## Verification

- `pytest -q -W error tests/` -> 2098 passed
- full source pyright -> 0 errors
- full tests pyright -> 0 errors
- `python docker/debug/workspace_mcp_reload_probe.py` -> passed
- `python docker/debug/restart_probe.py` -> passed
- `python docker/debug/restart_probe.py --soak` -> passed (20 iterations)

Final Docker reports all use HEAD `1e3532dc`, source digest `480935e0...`, a clean worktree, and zero residual Compose resources.