### PR TITLE
feat(mcp): add agent-managed workspace servers

### DIFF
--- a/agent/mcp/admin.py
+++ b/agent/mcp/admin.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+from agent.mcp.watcher import WorkspaceMcpWatcher
+from infra.persistence.json_store import atomic_write_text
+
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_MAX_COMMAND_ITEMS = 32
+_MAX_ENV_ITEMS = 64
+_MAX_WATCH_PATHS = 64
+
+
+class WorkspaceMcpAdmin:
+    """持久化 workspace MCP 声明并通过 watcher 原子发布结果。"""
+
+    def __init__(self, workspace: Path, watcher: WorkspaceMcpWatcher) -> None:
+        self._mcp_root = workspace / "mcp"
+        self._declarations_dir = self._mcp_root / "servers"
+        self._backup_root = self._mcp_root / "backups"
+        self._watcher = watcher
+        self._mutation_lock = asyncio.Lock()
+
+    async def apply(
+        self,
+        *,
+        name: str,
+        command: list[str],
+        cwd: str | None,
+        env: dict[str, str],
+        watch_paths: list[str],
+    ) -> dict[str, Any]:
+        """写入一个声明，确认候选可用后返回已发布代际。"""
+
+        # 1. 在工具边界校验结构，路径边界交给声明加载器统一拥有。
+        self._validate_spec(name, command, cwd, env, watch_paths)
+        content = _render_declaration(name, command, cwd, env, watch_paths)
+        path = self._declaration_path(name)
+
+        # 2. 备份并原子替换声明，再由 watcher 完成完整连接和发布。
+        async with self._mutation_lock:
+            previous = path.read_text(encoding="utf-8") if path.exists() else None
+            backup = self._backup(name, previous) if previous is not None else None
+            atomic_write_text(path, content, domain="workspace_mcp_admin")
+            try:
+                _ = await self._watcher.reconcile()
+            except (OSError, ValueError, RuntimeError) as error:
+                await self._rollback(path, previous)
+                raise RuntimeError(
+                    f"workspace MCP 发布失败，声明已回滚: {error}"
+                ) from error
+
+        return {
+            "status": "active",
+            "name": name,
+            "declaration": str(path),
+            "backup": str(backup) if backup is not None else None,
+            "runtime": self._watcher.status(),
+            "effectiveFrom": "next_turn",
+        }
+
+    async def remove(self, name: str) -> dict[str, Any]:
+        """删除一个声明，确认空缺代际发布后返回排空状态。"""
+
+        self._validate_name(name)
+        path = self._declaration_path(name)
+        async with self._mutation_lock:
+            previous = path.read_text(encoding="utf-8")
+            backup = self._backup(name, previous)
+            path.unlink()
+            try:
+                _ = await self._watcher.reconcile()
+            except (OSError, ValueError, RuntimeError) as error:
+                await self._rollback(path, previous)
+                raise RuntimeError(
+                    f"workspace MCP 删除发布失败，声明已恢复: {error}"
+                ) from error
+
+        return {
+            "status": "removed",
+            "name": name,
+            "backup": str(backup),
+            "runtime": self._watcher.status(),
+            "effectiveFrom": "next_turn",
+        }
+
+    def status(self, name: str | None = None) -> dict[str, Any]:
+        """列出声明及已发布代际，环境变量只暴露名称。"""
+
+        if name is not None:
+            self._validate_name(name)
+        active = self._watcher.status()
+        active_servers = set(active["servers"])
+        declarations: list[dict[str, Any]] = []
+        if name is not None:
+            paths = [self._declaration_path(name)]
+        elif self._declarations_dir.is_dir():
+            paths = sorted(self._declarations_dir.glob("*.toml"))
+        else:
+            paths = []
+        for path in paths:
+            if not path.exists():
+                continue
+            try:
+                raw = tomllib.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+                declarations.append(
+                    {
+                        "name": path.stem,
+                        "path": str(path),
+                        "state": "invalid",
+                        "error": str(error),
+                    }
+                )
+                continue
+            declared_name = str(raw.get("name", path.stem))
+            env_value = raw.get("env", {})
+            env = cast(dict[str, object], env_value) if isinstance(env_value, dict) else {}
+            declarations.append(
+                {
+                    "name": declared_name,
+                    "path": str(path),
+                    "state": "active" if declared_name in active_servers else "declared",
+                    "command": raw.get("command"),
+                    "cwd": raw.get("cwd"),
+                    "watchPaths": raw.get("watch_paths", []),
+                    "envKeys": sorted(env) if isinstance(env, dict) else [],
+                }
+            )
+        return {"declarations": declarations, "runtime": active}
+
+    async def _rollback(self, path: Path, previous: str | None) -> None:
+        """恢复声明文件，并重新确认恢复后的代际可发布。"""
+
+        if previous is None:
+            path.unlink(missing_ok=True)
+        else:
+            atomic_write_text(path, previous, domain="workspace_mcp_admin")
+        try:
+            _ = await self._watcher.reconcile()
+        except (OSError, ValueError, RuntimeError) as rollback_error:
+            raise RuntimeError(
+                f"workspace MCP 声明回滚后仍不可发布: {rollback_error}"
+            ) from rollback_error
+
+    def _backup(self, name: str, content: str) -> Path:
+        stamp = f"{time.strftime('%Y%m%d-%H%M%S')}-{time.time_ns()}"
+        path = self._backup_root / name / f"{stamp}.toml"
+        atomic_write_text(path, content, domain="workspace_mcp_admin_backup")
+        return path
+
+    def _declaration_path(self, name: str) -> Path:
+        return self._declarations_dir / f"{name}.toml"
+
+    @staticmethod
+    def _validate_name(name: str) -> None:
+        if not _NAME_PATTERN.fullmatch(name):
+            raise ValueError("MCP name 必须以小写字母开头，且只含小写字母、数字、_、-")
+
+    @classmethod
+    def _validate_spec(
+        cls,
+        name: str,
+        command: list[str],
+        cwd: str | None,
+        env: dict[str, str],
+        watch_paths: list[str],
+    ) -> None:
+        cls._validate_name(name)
+        if not command or len(command) > _MAX_COMMAND_ITEMS or not all(
+            isinstance(item, str) and item for item in command
+        ):
+            raise ValueError("MCP command 必须包含 1-32 个非空字符串")
+        if cwd is not None and (not isinstance(cwd, str) or not cwd):
+            raise ValueError("MCP cwd 必须是非空字符串")
+        if len(env) > _MAX_ENV_ITEMS or not all(
+            isinstance(key, str) and key and isinstance(value, str)
+            for key, value in env.items()
+        ):
+            raise ValueError("MCP env 最多 64 项，键必须非空且值必须是字符串")
+        if len(watch_paths) > _MAX_WATCH_PATHS or not all(
+            isinstance(item, str) and item for item in watch_paths
+        ):
+            raise ValueError("MCP watch_paths 最多 64 项且必须是非空字符串")
+
+
+def _render_declaration(
+    name: str,
+    command: list[str],
+    cwd: str | None,
+    env: dict[str, str],
+    watch_paths: list[str],
+) -> str:
+    """把已校验参数编码成稳定 TOML 声明。"""
+
+    lines = [
+        "schema_version = 1",
+        f"name = {_toml_string(name)}",
+        f"command = [{', '.join(_toml_string(item) for item in command)}]",
+    ]
+    if cwd is not None:
+        lines.append(f"cwd = {_toml_string(cwd)}")
+    if watch_paths:
+        rendered = ", ".join(_toml_string(item) for item in watch_paths)
+        lines.append(f"watch_paths = [{rendered}]")
+    if env:
+        lines.extend(["", "[env]"])
+        lines.extend(
+            f"{_toml_string(key)} = {_toml_string(value)}"
+            for key, value in sorted(env.items())
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)

--- a/agent/mcp/watcher.py
+++ b/agent/mcp/watcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from typing import Any
 
 from agent.mcp.declarations import (
     declarations_input_revision,
@@ -34,28 +35,47 @@ class WorkspaceMcpWatcher:
         self._forced = False
         self._last_input_revision: str | None = None
         self._stopped = asyncio.Event()
+        self._reconcile_lock = asyncio.Lock()
         self.last_error: str | None = None
+        self._active_generation_id: str | None = None
+        self._active_servers: tuple[str, ...] = ()
+        self._active_tools: tuple[str, ...] = ()
 
     async def reconcile(self) -> bool:
         """发布变化后的完整声明；失败时调用方获得原始异常。"""
 
-        desired = load_workspace_mcp_declarations(
-            self._declarations_dir,
-            mcp_root=self._mcp_root,
-        )
-        if desired.revision == self._active_revision:
-            return False
-        await self._manager.prepare_workspace_mcp(
-            desired.specs,
-            revision=desired.revision,
-        )
-        if not self._running:
-            await self._manager.discard_workspace_mcp_candidate()
-            return False
-        await self._manager.publish_workspace_mcp()
-        self._active_revision = desired.revision
-        self.last_error = None
-        return True
+        async with self._reconcile_lock:
+            desired = load_workspace_mcp_declarations(
+                self._declarations_dir,
+                mcp_root=self._mcp_root,
+            )
+            if desired.revision == self._active_revision:
+                return False
+            await self._manager.prepare_workspace_mcp(
+                desired.specs,
+                revision=desired.revision,
+            )
+            if not self._running:
+                await self._manager.discard_workspace_mcp_candidate()
+                return False
+            generation = await self._manager.publish_workspace_mcp()
+            self._active_revision = desired.revision
+            self._active_generation_id = generation.generation_id
+            self._active_servers = tuple(sorted(generation.catalog.servers))
+            self._active_tools = generation.catalog.tool_names
+            self.last_error = None
+            return True
+
+    def status(self) -> dict[str, Any]:
+        """返回当前已发布 workspace MCP 代际的只读状态。"""
+
+        return {
+            "generationId": self._active_generation_id,
+            "revision": self._active_revision,
+            "servers": list(self._active_servers),
+            "tools": list(self._active_tools),
+            "lastError": self.last_error,
+        }
 
     async def run(self) -> None:
         """持续检查内容 revision，并允许失败版本在修复后恢复。"""

--- a/agent/tools/workspace_mcp.py
+++ b/agent/tools/workspace_mcp.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.mcp.admin import WorkspaceMcpAdmin
+from agent.tools.base import Tool
+
+
+class WorkspaceMcpApplyTool(Tool):
+    name = "workspace_mcp_apply"
+    description = (
+        "创建或更新一个非插件 workspace MCP server 声明，立即校验并热发布。"
+        "不修改 config.toml，也不需要重启 Agent；新工具从下一轮开始可用。"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "minLength": 1, "maxLength": 64},
+            "command": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
+            "cwd": {"type": "string", "minLength": 1},
+            "env": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+            "watch_paths": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+            },
+        },
+        "required": ["name", "command"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, admin: WorkspaceMcpAdmin) -> None:
+        self._admin = admin
+
+    async def execute(self, **kwargs: Any) -> str:
+        result = await self._admin.apply(
+            name=str(kwargs["name"]),
+            command=list(kwargs["command"]),
+            cwd=kwargs.get("cwd"),
+            env=dict(kwargs.get("env", {})),
+            watch_paths=list(kwargs.get("watch_paths", [])),
+        )
+        return json.dumps(result, ensure_ascii=False)
+
+
+class WorkspaceMcpRemoveTool(Tool):
+    name = "workspace_mcp_remove"
+    description = (
+        "删除一个非插件 workspace MCP server 声明并热发布；旧代际会在已有 turn 释放后排空。"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "minLength": 1, "maxLength": 64},
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, admin: WorkspaceMcpAdmin) -> None:
+        self._admin = admin
+
+    async def execute(self, **kwargs: Any) -> str:
+        result = await self._admin.remove(str(kwargs["name"]))
+        return json.dumps(result, ensure_ascii=False)
+
+
+class WorkspaceMcpStatusTool(Tool):
+    name = "workspace_mcp_status"
+    description = (
+        "查看非插件 workspace MCP 声明、已发布 generation、工具列表和最近热加载错误；"
+        "环境变量只显示键名。"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "minLength": 1, "maxLength": 64},
+        },
+        "additionalProperties": False,
+    }
+
+    def __init__(self, admin: WorkspaceMcpAdmin) -> None:
+        self._admin = admin
+
+    async def execute(self, **kwargs: Any) -> str:
+        result = self._admin.status(kwargs.get("name"))
+        return json.dumps(result, ensure_ascii=False)

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -597,6 +597,37 @@ def build_core_runtime(
         workspace / "mcp" / "servers",
         mcp_root=workspace / "mcp",
     )
+    if config.tool_search_enabled:
+        from agent.mcp.admin import WorkspaceMcpAdmin
+        from agent.tools.workspace_mcp import (
+            WorkspaceMcpApplyTool,
+            WorkspaceMcpRemoveTool,
+            WorkspaceMcpStatusTool,
+        )
+
+        workspace_mcp_admin = WorkspaceMcpAdmin(workspace, workspace_mcp_watcher)
+        tools.register(
+            WorkspaceMcpApplyTool(workspace_mcp_admin),
+            risk="external-side-effect",
+            always_on=False,
+            preloadable=False,
+            requires_turn_search=True,
+            search_hint="安装 注册 更新 添加 MCP server 常驻服务 热重载",
+        )
+        tools.register(
+            WorkspaceMcpRemoveTool(workspace_mcp_admin),
+            risk="external-side-effect",
+            always_on=False,
+            preloadable=False,
+            requires_turn_search=True,
+            search_hint="删除 卸载 移除 MCP server 停止常驻服务",
+        )
+        tools.register(
+            WorkspaceMcpStatusTool(workspace_mcp_admin),
+            risk="read-only",
+            always_on=False,
+            search_hint="查看 列出 诊断 MCP server generation 热加载错误",
+        )
 
     return CoreRuntime(
         config=config,

--- a/docker/debug/workspace_mcp_reload_probe.py
+++ b/docker/debug/workspace_mcp_reload_probe.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import bootstrap.app as bootstrap_app
+from agent.control.context import current_turn_id
 from agent.config_models import (
     AppServerConfig,
     ChannelsConfig,
@@ -26,6 +27,7 @@ from agent.config_models import (
 )
 from agent.plugins.manager import PluginManager
 from agent.tools.base import ToolResult
+from core.error_context import current_session_key
 from proactive_v2.config import ProactiveConfig
 from docker.debug.programmatic_control_probe import (
     _prepare_host_sandbox,
@@ -84,6 +86,7 @@ def _config() -> Config:
         memory_optimizer_enabled=False,
         multimodal=False,
         spawn_enabled=False,
+        tool_search_enabled=True,
     )
 
 
@@ -201,6 +204,37 @@ async def _call_version(lease: Any, server_name: str = "docs") -> str:
         raise_errors=True,
     )
     return result.text if isinstance(result, ToolResult) else result
+
+
+async def _execute_admin_tool(
+    registry: Any,
+    *,
+    turn_id: str,
+    name: str,
+    arguments: dict[str, object],
+) -> str:
+    """模拟真实 turn 的搜索授权后调用一个 workspace MCP 管理工具。"""
+
+    session_key = "programmatic:workspace-mcp-admin-gate"
+    turn_token = current_turn_id.set(turn_id)
+    session_token = current_session_key.set(session_key)
+    scope = registry.begin_turn_search_scope(
+        turn_id=turn_id,
+        session_key=session_key,
+        attempt=0,
+    )
+    try:
+        _ = await registry.execute(
+            "tool_search",
+            {"query": f"select:{name}"},
+            raise_errors=True,
+        )
+        result = await registry.execute(name, arguments, raise_errors=True)
+        return result.text if isinstance(result, ToolResult) else result
+    finally:
+        registry.end_turn_search_scope(scope)
+        current_session_key.reset(session_token)
+        current_turn_id.reset(turn_token)
 
 
 def _check(checks: list[dict[str, object]], name: str, passed: bool, **evidence: object) -> None:
@@ -427,6 +461,95 @@ async def _run_reload_sequence(root: Path, checks: list[dict[str, object]]) -> N
             leasedPids=leased_pids,
             emptyRegistryNames=empty_names,
             lifecycle=_lifecycle(lifecycle),
+        )
+
+        # 管理工具必须走真实 search grant，并保持当前 turn 的旧快照隔离。
+        admin_lease = await manager.snapshot_store.acquire()
+        try:
+            admin_registry = admin_lease.snapshot.tool_registry
+            if admin_registry is None:
+                raise AssertionError("admin snapshot 缺少 tool registry")
+            admin_error = ""
+            try:
+                _ = await _execute_admin_tool(
+                    admin_registry,
+                    turn_id="turn:admin-failed-apply",
+                    name="workspace_mcp_apply",
+                    arguments={
+                        "name": "broken",
+                        "command": [sys.executable, str(root / "missing-admin.py")],
+                    },
+                )
+            except RuntimeError as error:
+                admin_error = str(error)
+            _check(
+                checks,
+                "admin-tool-failure-rollback",
+                "声明已回滚" in admin_error
+                and not (declarations / "broken.toml").exists()
+                and not manager.active_workspace_mcp.catalog.servers,
+                error=admin_error,
+            )
+            applied = json.loads(
+                await _execute_admin_tool(
+                    admin_registry,
+                    turn_id="turn:admin-apply",
+                    name="workspace_mcp_apply",
+                    arguments={
+                        "name": "admin",
+                        "command": [sys.executable, str(server)],
+                        "env": {
+                            "VERSION": "managed",
+                            "INSTANCE": "admin",
+                            "LIFECYCLE_LOG": str(lifecycle),
+                            "MARKER_PATH": str(marker),
+                        },
+                        "watch_paths": ["../synthetic/watch.txt"],
+                    },
+                )
+            )
+            _check(
+                checks,
+                "admin-tool-apply-next-turn",
+                applied["status"] == "active"
+                and applied["effectiveFrom"] == "next_turn"
+                and "mcp_admin__version" not in admin_registry.get_registered_names(),
+                result=applied,
+            )
+        finally:
+            await admin_lease.release()
+
+        managed_lease = await manager.snapshot_store.acquire()
+        try:
+            managed_registry = managed_lease.snapshot.tool_registry
+            if managed_registry is None:
+                raise AssertionError("managed snapshot 缺少 tool registry")
+            managed_result = await _call_version(managed_lease, "admin")
+            removed = json.loads(
+                await _execute_admin_tool(
+                    managed_registry,
+                    turn_id="turn:admin-remove",
+                    name="workspace_mcp_remove",
+                    arguments={"name": "admin"},
+                )
+            )
+            leased_admin_pids = _running_pids(lifecycle, instance="admin")
+            _check(
+                checks,
+                "admin-tool-remove-drains-lease",
+                managed_result == "managed:two"
+                and removed["status"] == "removed"
+                and removed["runtime"]["servers"] == []
+                and bool(leased_admin_pids),
+                toolResult=managed_result,
+                result=removed,
+                leasedPids=leased_admin_pids,
+            )
+        finally:
+            await managed_lease.release()
+        await _wait_until(
+            lambda: not _running_pids(lifecycle, instance="admin"),
+            "admin tool lease drain",
         )
     finally:
         await app.shutdown()

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,8 +31,12 @@
   - 文件：`skills/skill-creater/SKILL.md`
 
 - `plugin-system`
-  - 说明并执行 Akashic 插件系统的安装、加载、启停、配置、MCP、skill、lifecycle 与 registry。
+  - 说明并执行 Akashic 插件系统的安装、加载、启停、配置、插件内 MCP、skill 与 lifecycle。
   - 文件：`skills/plugin-system/SKILL.md`
+
+- `manage-workspace-mcp`
+  - 注册、热重载、移除和诊断非插件 workspace MCP server。
+  - 文件：`skills/manage-workspace-mcp/SKILL.md`
 
 - `summarize`
   - 总结 URL/文件/YouTube 内容，支持提取转写。

--- a/skills/manage-workspace-mcp/SKILL.md
+++ b/skills/manage-workspace-mcp/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: manage-workspace-mcp
+description: 安装、注册、更新、移除和诊断 Akashic 的独立 workspace MCP server。用户要求把 binary、CLI、脚本或本地项目做成常驻 MCP，询问 MCP 热重载、MCP 工具为何没出现，或需要查看非插件 MCP 状态时使用。插件自带 MCP 改用 plugin-system。
+---
+
+# 管理 Workspace MCP
+
+使用声明式管理工具完成非插件 MCP 的全生命周期，不直接编辑运行时配置。
+
+## 路由
+
+- 独立 binary、CLI、脚本、本地项目：使用本 skill。
+- 已安装插件自带的 MCP：加载 `plugin-system`，修改插件源码并重新安装。
+- 不确定归属时，先用 `workspace_mcp_status` 查看；不要根据现有 MCP 工具名前缀猜注册方式。
+
+## 工作流
+
+1. 确认入口命令可以非交互启动，并通过 stdio 实现 MCP；不要把单独启动后等待 `initialize` 当成失败。
+2. 用 `tool_search` 解锁 `workspace_mcp_apply` 和 `workspace_mcp_status`。
+3. 调用 `workspace_mcp_apply`；优先使用稳定的绝对可执行路径。`cwd` 与 `watch_paths` 必须位于 workspace 的 `mcp/` 根内。
+4. 检查返回的 generation、server 和工具列表。发布失败时保留真实错误，工具会恢复原声明。
+5. 告知用户新 MCP 工具从下一轮开始可用；当前 turn 固定使用进入时的旧快照，不要在本轮反复搜索新工具。
+6. 下一轮用 `workspace_mcp_status` 确认 active，再按返回的准确工具名执行真实调用。
+
+删除时解锁并调用 `workspace_mcp_remove`。旧 generation 会等已有 turn 释放 lease 后排空，不要额外重启。
+
+## 禁止旧路径
+
+- 不要添加 `[mcp_servers]` 到 `config.toml`。
+- 不要读写 `mcp_servers.json`。
+- 不要搜索或调用 `mcp_add`、`mcp_list`、`mcp_remove`；这些旧工具不存在。
+- 不要为了独立 MCP 创建 `plugin.json`、插件目录或修改插件缓存。
+- MCP 和插件改动可热重载，不要调用 `agent_restart`。
+
+## 参数原则
+
+- `name` 使用稳定的小写名称，可含数字、`_`、`-`。
+- `command` 是 argv 数组，不是 shell 字符串；不要嵌入 `&`、管道或重定向。
+- Node wrapper 若依赖不稳定的 `PATH`，使用绝对 `node` 路径加脚本路径。
+- `env` 只写 server 必需值；`workspace_mcp_status` 只展示环境变量键名。
+- 代码内容变化需要触发重载时，把对应文件或目录放进 `watch_paths`。

--- a/skills/manage-workspace-mcp/agents/openai.yaml
+++ b/skills/manage-workspace-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Manage Workspace MCP"
+  short_description: "Install and hot-reload standalone MCP servers"
+  default_prompt: "Use $manage-workspace-mcp to register and verify a standalone MCP server without restarting Akashic."

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: plugin-system
-description: 说明并执行 Akashic 插件安装、加载、启停、配置、MCP、skill、生命周期与 manifest 管理。
-when_to_use: 用户询问或要求处理 Akashic 插件、marketplace、MCP、skill、插件配置、安装、更新、启用、禁用或排障时。
+description: 说明并执行 Akashic 插件安装、加载、启停、配置、插件内 MCP、skill、生命周期与 manifest 管理。
+when_to_use: 用户询问或要求处理 Akashic 插件、marketplace、插件自带 MCP、skill、插件配置、安装、更新、启用、禁用或排障时。独立本地 MCP server 使用 manage-workspace-mcp。
 metadata: {"akashic": {"always": false}}
 ---
 
 # Akashic 插件系统
 
 优先直接完成明确的插件管理请求，并在修改后验证。
+
+独立 binary、脚本或本地项目需要作为 MCP 常驻时，加载 `manage-workspace-mcp`；
+不要为它创建插件，也不要修改主 `config.toml`。
 
 ## 事实来源
 

--- a/tests/test_builtin_manage_workspace_mcp_skill.py
+++ b/tests/test_builtin_manage_workspace_mcp_skill.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from agent.skills import SkillsLoader
+
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+def test_manage_workspace_mcp_is_discoverable_builtin(tmp_path: Path) -> None:
+    loader = SkillsLoader(tmp_path, builtin_skills_dir=REPO_ROOT / "skills")
+    record = loader.load_skill_record("manage-workspace-mcp")
+
+    assert record is not None
+    assert record.source == "builtin"
+    assert record.available is True
+    for trigger in (
+        "常驻 MCP",
+        "MCP 热重载",
+        "MCP 工具为何没出现",
+        "非插件 MCP",
+    ):
+        assert trigger in record.description
+
+
+def test_manage_workspace_mcp_forbids_legacy_paths(tmp_path: Path) -> None:
+    loader = SkillsLoader(tmp_path, builtin_skills_dir=REPO_ROOT / "skills")
+    body = loader.load_skill_body("manage-workspace-mcp")
+
+    assert body is not None
+    for contract in (
+        "`workspace_mcp_apply`",
+        "`workspace_mcp_status`",
+        "`workspace_mcp_remove`",
+        "下一轮开始可用",
+        "不要添加 `[mcp_servers]`",
+        "不要调用 `agent_restart`",
+    ):
+        assert contract in body
+
+
+def test_plugin_skill_routes_standalone_mcp_to_workspace_skill(tmp_path: Path) -> None:
+    loader = SkillsLoader(tmp_path, builtin_skills_dir=REPO_ROOT / "skills")
+    record = loader.load_skill_record("plugin-system")
+    body = loader.load_skill_body("plugin-system")
+
+    assert record is not None and body is not None
+    assert "插件内 MCP" in record.description
+    assert "独立本地 MCP server 使用 manage-workspace-mcp" in record.when_to_use
+    assert "加载 `manage-workspace-mcp`" in body

--- a/tests/test_fresh_configuration_matrix.py
+++ b/tests/test_fresh_configuration_matrix.py
@@ -143,6 +143,11 @@ async def test_fresh_init_core_configuration_matrix(
 
     try:
         await runtime.start()
+        assert {
+            "workspace_mcp_apply",
+            "workspace_mcp_remove",
+            "workspace_mcp_status",
+        } <= runtime.tools.get_registered_names()
         assert runtime.memory_runtime.engine.describe().name == memory_name
         expected_lifecycles = [] if proactive_name == "off" else [proactive_name]
         assert [

--- a/tests/test_mcp_declarations.py
+++ b/tests/test_mcp_declarations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -497,8 +498,11 @@ async def test_watcher_keeps_latest_change_and_deduplicates_failed_revision(
             if command.endswith("bad.py"):
                 raise RuntimeError("bad")
 
-        async def publish_workspace_mcp(self) -> None:
-            return None
+        async def publish_workspace_mcp(self) -> Any:
+            return SimpleNamespace(
+                generation_id=f"test:{len(calls)}",
+                catalog=SimpleNamespace(servers={"docs": object()}, tool_names=()),
+            )
 
     watcher = WorkspaceMcpWatcher(Manager(), declarations, interval_seconds=0.01)  # type: ignore[arg-type]
     _declare(declarations, "docs", server)

--- a/tests/test_workspace_mcp_admin.py
+++ b/tests/test_workspace_mcp_admin.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent.mcp.admin import WorkspaceMcpAdmin
+from agent.mcp.watcher import WorkspaceMcpWatcher
+from agent.plugins.manager import PluginManager
+from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
+
+
+def _server(root: Path, tool_name: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "server.py"
+    path.write_text(
+        "import json, sys\n"
+        "for line in sys.stdin:\n"
+        " message=json.loads(line)\n"
+        " if 'id' not in message: continue\n"
+        " method=message.get('method')\n"
+        " if method == 'initialize': result={'protocolVersion':'2025-11-25'}\n"
+        f" elif method == 'tools/list': result={{'tools':[{{'name':'{tool_name}','description':'probe','inputSchema':{{'type':'object','properties':{{}}}}}}]}}\n"
+        " else: result={'content':[{'type':'text','text':'ok'}]}\n"
+        " print(json.dumps({'jsonrpc':'2.0','id':message['id'],'result':result}),flush=True)\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _manager(workspace: Path) -> PluginManager:
+    return PluginManager(
+        plugin_dirs=[workspace / "plugins"],
+        event_bus=EventBus(),
+        tool_registry=ToolRegistry(),
+        workspace=workspace,
+        installed_cache_root=workspace / "cache",
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_apply_status_failed_update_rollback_and_remove(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    manager = _manager(workspace)
+    watcher = WorkspaceMcpWatcher(
+        manager,
+        workspace / "mcp" / "servers",
+        mcp_root=workspace / "mcp",
+    )
+    admin = WorkspaceMcpAdmin(workspace, watcher)
+    await watcher.reconcile()
+    server = _server(workspace / "mcp" / "probe", "inspect")
+
+    applied = await admin.apply(
+        name="desktop",
+        command=[sys.executable, str(server)],
+        cwd=None,
+        env={"SECRET_TOKEN": "never-return-this"},
+        watch_paths=["../probe/server.py"],
+    )
+
+    declaration = workspace / "mcp" / "servers" / "desktop.toml"
+    original = declaration.read_text(encoding="utf-8")
+    assert applied["status"] == "active"
+    assert applied["effectiveFrom"] == "next_turn"
+    assert applied["runtime"]["servers"] == ["desktop"]
+    assert applied["runtime"]["tools"] == ["mcp_desktop__inspect"]
+    status = admin.status("desktop")
+    assert status["declarations"][0]["envKeys"] == ["SECRET_TOKEN"]
+    assert "never-return-this" not in json.dumps(status)
+
+    active = manager.active_workspace_mcp
+    with pytest.raises(RuntimeError, match="声明已回滚"):
+        await admin.apply(
+            name="desktop",
+            command=[sys.executable, str(workspace / "mcp" / "missing.py")],
+            cwd=None,
+            env={},
+            watch_paths=[],
+        )
+    assert declaration.read_text(encoding="utf-8") == original
+    assert manager.active_workspace_mcp is active
+    assert list((workspace / "mcp" / "backups" / "desktop").glob("*.toml"))
+
+    removed = await admin.remove("desktop")
+    assert removed["status"] == "removed"
+    assert removed["runtime"]["servers"] == []
+    assert not declaration.exists()
+    assert admin.status("desktop")["declarations"] == []
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_admin_rejects_invalid_name_and_outside_watch_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    manager = _manager(workspace)
+    watcher = WorkspaceMcpWatcher(
+        manager,
+        workspace / "mcp" / "servers",
+        mcp_root=workspace / "mcp",
+    )
+    admin = WorkspaceMcpAdmin(workspace, watcher)
+    await watcher.reconcile()
+    server = _server(workspace / "mcp" / "probe", "inspect")
+
+    with pytest.raises(ValueError, match="MCP name"):
+        await admin.apply(
+            name="../escape",
+            command=[sys.executable, str(server)],
+            cwd=None,
+            env={},
+            watch_paths=[],
+        )
+    with pytest.raises(RuntimeError, match="声明已回滚"):
+        await admin.apply(
+            name="escape",
+            command=[sys.executable, str(server)],
+            cwd=None,
+            env={},
+            watch_paths=["../../../outside"],
+        )
+    assert not (workspace / "mcp" / "servers" / "escape.toml").exists()
+    await manager.terminate_all()


### PR DESCRIPTION
## What changed

- add builtin `manage-workspace-mcp` guidance for standalone MCP lifecycle management
- expose `workspace_mcp_apply`, `workspace_mcp_remove`, and `workspace_mcp_status` behind tool search
- publish declarations atomically with backups, rollback, generation status, and next-turn snapshot semantics
- route plugin-owned MCP work back to the plugin system and forbid obsolete config/restart paths
- extend the Docker gate through real tool-search authorization, apply failure rollback, lease isolation, and removal drain

## Why

Recent live conversations showed Akashic could restart itself, but did not know that standalone MCP servers are hot-reloadable. It edited ignored `config.toml`, restarted unnecessarily, and searched for obsolete `mcp_add` tools. This gives the model both the correct operating knowledge and callable management surface.

## Verification

- `pytest -q tests/` - 2104 passed
- targeted `pyright` - 0 errors
- `quick_validate.py skills/manage-workspace-mcp` - valid
- `python docker/debug/workspace_mcp_reload_probe.py` - passed; no residual containers, networks, volumes, or MCP processes
