### PR TITLE
fix(session): preserve history during context trimming

### DIFF
--- a/session/manager.py
+++ b/session/manager.py
@@ -399,9 +399,8 @@ class SessionManager:
         *,
         updated_at: datetime,
         last_consolidated: int | None = None,
-        retained_message_ids: set[str] | None = None,
     ) -> int:
-        """准备待写消息并原子追加；传保留 ID 时在同一事务内替换消息集合。"""
+        """准备待写消息并原子追加 session 元数据和消息。"""
 
         effective_last_consolidated = (
             session.last_consolidated
@@ -438,7 +437,6 @@ class SessionManager:
             last_consolidated=effective_last_consolidated,
             metadata=session.metadata,
             messages=pending_payloads,
-            retained_message_ids=retained_message_ids,
         )
         for msg, row in zip(pending_messages, rows):
             msg.update(row)
@@ -483,29 +481,23 @@ class SessionManager:
         *,
         last_consolidated: int = 0,
     ) -> None:
-        """在同一事务中裁剪 session 历史，并在成功后更新内存。"""
+        """只裁剪运行时上下文，并保留 sessions.db 中的完整历史。"""
 
         # 1. 在 session owner 的写锁内计算替换结果，避免覆盖并发追加。
         async with self._lock(session.key):
             retained = (
                 list(session.messages[-keep_count:]) if keep_count > 0 else []
             )
-            retained_ids = {
-                str(message["id"])
-                for message in retained
-                if message.get("id")
-            }
 
-            # 2. 先让 SQLite 原子提交删除、追加和 cursor 更新。
+            # 2. 只更新 session 元数据；不传 retained IDs，禁止触发历史删除。
             _ = self._persist_session(
                 session,
                 retained,
                 updated_at=datetime.now(UTC),
                 last_consolidated=last_consolidated,
-                retained_message_ids=retained_ids,
             )
 
-            # 3. 数据库成功后再提交内存视图，失败时调用方仍持有原历史。
+            # 3. 数据库成功后再提交运行时上下文视图。
             session.messages[:] = retained
             session.last_consolidated = int(last_consolidated)
             self._cache[session.key] = session

--- a/session/store.py
+++ b/session/store.py
@@ -1304,9 +1304,8 @@ class SessionStore:
         last_consolidated: int,
         metadata: dict[str, Any],
         messages: list[dict[str, Any]],
-        retained_message_ids: set[str] | None = None,
     ) -> list[dict[str, Any]]:
-        """原子更新 session 元数据并追加消息，传保留 ID 时替换该 session 的消息集合。"""
+        """原子更新 session 元数据并追加新消息。"""
 
         metadata_payload = json.dumps(metadata, ensure_ascii=False)
         result_rows: list[dict[str, Any]] = []
@@ -1326,11 +1325,6 @@ class SessionStore:
                     """,
                     (key, created_at, updated_at, int(last_consolidated), metadata_payload),
                 )
-                if retained_message_ids is not None:
-                    self._delete_messages_not_retained_locked(
-                        key,
-                        retained_message_ids,
-                    )
                 if messages:
                     start_seq = self._next_seq_locked(key)
                     insert_rows, result_rows = self._prepare_message_batch(
@@ -1355,34 +1349,6 @@ class SessionStore:
                         (next_seq, next_seq, key),
                     )
         return result_rows
-
-    def _delete_messages_not_retained_locked(
-        self,
-        session_key: str,
-        retained_message_ids: set[str],
-    ) -> None:
-        """删除同一 session 中不在替换结果里的旧消息。"""
-
-        # 1. 在当前事务内确定需要移除的消息，避免删除其他 session 的记录。
-        rows = self._conn.execute(
-            "SELECT id FROM messages WHERE session_key = ?",
-            (session_key,),
-        ).fetchall()
-        removed_ids = [
-            str(row["id"])
-            for row in rows
-            if str(row["id"]) not in retained_message_ids
-        ]
-        if not removed_ids:
-            return
-
-        # 2. 同步清理消息及其 embedding，事务失败时由调用方统一回滚。
-        placeholders = ",".join("?" for _ in removed_ids)
-        self._conn.execute(
-            f"DELETE FROM messages WHERE session_key = ? AND id IN ({placeholders})",
-            (session_key, *removed_ids),
-        )
-        self._delete_message_embeddings_locked(removed_ids)
 
     def fetch_session_messages(self, session_key: str) -> list[dict[str, Any]]:
         with self._lock:

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -237,7 +237,7 @@ async def test_session_batch_persistence_uses_one_commit(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_session_trim_replaces_history_and_preserves_sequence_ids(
+async def test_session_trim_keeps_database_history_and_preserves_sequence_ids(
     tmp_path: Path,
 ) -> None:
     manager = SessionManager(tmp_path)
@@ -265,7 +265,7 @@ async def test_session_trim_replaces_history_and_preserves_sequence_ids(
         "telegram:trim:3",
     ]
     assert session.last_consolidated == 0
-    assert manager._store.count_messages(session.key) == 2
+    assert manager._store.count_messages(session.key) == 4
     assert manager._store.get_session_meta(session.key)["last_consolidated"] == 0
     embedding_rows = {
         str(row["message_id"]): bytes(row["embedding"])
@@ -274,6 +274,8 @@ async def test_session_trim_replaces_history_and_preserves_sequence_ids(
         ).fetchall()
     }
     assert embedding_rows == {
+        "telegram:trim:0": b"embedding:telegram:trim:0",
+        "telegram:trim:1": b"embedding:telegram:trim:1",
         "telegram:trim:2": b"embedding:telegram:trim:2",
         "telegram:trim:3": b"embedding:telegram:trim:3",
         "telegram:other:0": b"embedding:telegram:other:0",
@@ -281,7 +283,7 @@ async def test_session_trim_replaces_history_and_preserves_sequence_ids(
 
     manager.invalidate(session.key)
     reloaded = manager.get_or_create(session.key)
-    assert [message["content"] for message in reloaded.messages] == ["2", "3"]
+    assert [message["content"] for message in reloaded.messages] == ["0", "1", "2", "3"]
     reloaded.add_message("assistant", "4")
     manager.save(reloaded)
     assert reloaded.messages[-1]["id"] == "telegram:trim:4"
@@ -289,7 +291,7 @@ async def test_session_trim_replaces_history_and_preserves_sequence_ids(
 
 
 @pytest.mark.asyncio
-async def test_session_trim_failure_keeps_memory_and_database_unchanged(
+async def test_session_trim_never_deletes_database_history(
     tmp_path: Path,
 ) -> None:
     manager = SessionManager(tmp_path)
@@ -300,7 +302,6 @@ async def test_session_trim_failure_keeps_memory_and_database_unchanged(
     session.last_consolidated = 2
     manager.save(session)
     original_messages = list(session.messages)
-    before_meta = manager._store.get_session_meta(session.key)
     _seed_message_embeddings(
         manager._store,
         [str(message["id"]) for message in session.messages],
@@ -315,24 +316,12 @@ async def test_session_trim_failure_keeps_memory_and_database_unchanged(
             """
         ).fetchall()
     ]
-    manager._store._conn.execute(
-        """
-        CREATE TRIGGER reject_history_trim
-        BEFORE DELETE ON messages
-        BEGIN
-            SELECT RAISE(ABORT, '测试裁剪失败');
-        END
-        """
-    )
-    manager._store._conn.commit()
+    await manager.trim_history_async(session, 2, last_consolidated=0)
 
-    with pytest.raises(sqlite3.IntegrityError, match="测试裁剪失败"):
-        await manager.trim_history_async(session, 2, last_consolidated=0)
-
-    assert session.messages == original_messages
-    assert session.last_consolidated == 2
+    assert session.messages == original_messages[-2:]
+    assert session.last_consolidated == 0
     assert manager._store.count_messages(session.key) == 4
-    assert manager._store.get_session_meta(session.key) == before_meta
+    assert manager._store.get_session_meta(session.key)["last_consolidated"] == 0
     assert [
         message["content"]
         for message in manager._store.fetch_session_messages(session.key)


### PR DESCRIPTION
## 变更
- 禁止上下文裁剪逻辑删除 sessions.db 中的旧消息和 message_embeddings。
- 从私有备份恢复 Telegram 可用历史。
- 从当前/私有 Akasha embedding cache 恢复 7710 条可验证消息向量。
- 保留显式删除 API，不影响用户主动删除。

## 根因
上下文超限重试路径调用 trim_history_async，原实现把保留窗口外的消息从 sessions.db 物理删除。

## 验证
- `./.venv/bin/python -m pytest -q tests/test_logic_modules.py tests/test_akasha_plugin.py`
- 103 passed
- sessions.db integrity_check: ok
- Telegram messages: 10689
- Telegram message_embeddings: 8240
- 无法从现有/私有 cache 恢复的 Telegram embedding: 2449