### PR TITLE
fix(memory): protect profile rewrites from destructive output

### DIFF
--- a/agent/memory.py
+++ b/agent/memory.py
@@ -3,6 +3,7 @@ import sqlite3
 import threading
 from pathlib import Path
 
+from infra.persistence.json_store import atomic_write_text
 from utils.helpers import ensure_dir
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ class MemoryStore:
         return ""
 
     def write_long_term(self, content: str) -> None:
-        self.memory_file.write_text(content, encoding="utf-8")
+        atomic_write_text(self.memory_file, content, domain="memory")
 
     # ── RECENT_CONTEXT.md（压缩后的近期语境）──────────────
 
@@ -65,7 +66,7 @@ class MemoryStore:
         return ""
 
     def write_recent_context(self, content: str) -> None:
-        self.recent_context_file.write_text(content, encoding="utf-8")
+        atomic_write_text(self.recent_context_file, content, domain="memory")
 
     # ── SELF.md（Akashic 自我模型）─────────────────────────────
 
@@ -75,7 +76,7 @@ class MemoryStore:
         return ""
 
     def write_self(self, content: str) -> None:
-        self.self_file.write_text(content, encoding="utf-8")
+        atomic_write_text(self.self_file, content, domain="memory")
 
     # ── 待处理事实（对话 → optimizer 缓冲区）───────────
 
@@ -90,8 +91,9 @@ class MemoryStore:
         """追加对话中提取的增量事实片段，不触碰 MEMORY.md。"""
         if not facts or not facts.strip():
             return
-        with open(self.pending_file, "a", encoding="utf-8") as f:
-            f.write(facts.rstrip() + "\n")
+        with self._consolidation_lock:
+            with open(self.pending_file, "a", encoding="utf-8") as f:
+                _ = f.write(facts.rstrip() + "\n")
 
     def append_pending_once(
         self,
@@ -114,7 +116,8 @@ class MemoryStore:
 
     def clear_pending(self) -> None:
         """optimizer 归档后清空 PENDING.md。"""
-        self.pending_file.write_text("", encoding="utf-8")
+        with self._consolidation_lock:
+            atomic_write_text(self.pending_file, "", domain="memory")
 
     # ── 两阶段提交（供 MemoryOptimizer 使用）──────────────────────
 
@@ -130,38 +133,43 @@ class MemoryStore:
         调用前会自动处理上次崩溃遗留的 snapshot。
         """
         self._recover_pending_snapshot()
-        if not self.pending_file.exists() or self.pending_file.stat().st_size == 0:
-            return ""
-        # POSIX rename 是原子操作：rename 完成后新追加写入全新的 PENDING.md
-        self.pending_file.rename(self._snapshot_path)
-        return self._strip_consolidation_markers(
-            self._snapshot_path.read_text(encoding="utf-8")
-        )
+        with self._consolidation_lock:
+            if not self.pending_file.exists() or self.pending_file.stat().st_size == 0:
+                return ""
+            # POSIX rename 是原子操作：rename 完成后新追加写入全新的 PENDING.md
+            _ = self.pending_file.rename(self._snapshot_path)
+            return self._strip_consolidation_markers(
+                self._snapshot_path.read_text(encoding="utf-8")
+            )
 
     def commit_pending_snapshot(self) -> None:
         """Phase-2 成功：merge 已完成，删除快照。"""
-        if self._snapshot_path.exists():
-            self._snapshot_path.unlink()
-        # 保持 PENDING.md 常驻，避免“已归档后文件消失”带来的状态歧义
-        if not self.pending_file.exists():
-            self.pending_file.touch()
+        with self._consolidation_lock:
+            if self._snapshot_path.exists():
+                self._snapshot_path.unlink()
+            # 保持 PENDING.md 常驻，避免“已归档后文件消失”带来的状态歧义
+            if not self.pending_file.exists():
+                self.pending_file.touch()
 
     def rollback_pending_snapshot(self) -> None:
         """Phase-2 失败：将快照内容合并回 PENDING.md，不丢失任何数据。
 
         快照（较旧）在前，运行期新追加（较新）在后。
         """
-        if not self._snapshot_path.exists():
-            return
-        snap_text = self._snapshot_path.read_text(encoding="utf-8")
-        new_text = (
-            self.pending_file.read_text(encoding="utf-8")
-            if self.pending_file.exists()
-            else ""
-        )
-        merged = snap_text.rstrip() + "\n" + new_text if new_text.strip() else snap_text
-        self.pending_file.write_text(merged, encoding="utf-8")
-        self._snapshot_path.unlink()
+        with self._consolidation_lock:
+            if not self._snapshot_path.exists():
+                return
+            snap_text = self._snapshot_path.read_text(encoding="utf-8")
+            new_text = (
+                self.pending_file.read_text(encoding="utf-8")
+                if self.pending_file.exists()
+                else ""
+            )
+            merged = (
+                snap_text.rstrip() + "\n" + new_text if new_text.strip() else snap_text
+            )
+            atomic_write_text(self.pending_file, merged, domain="memory")
+            self._snapshot_path.unlink()
         logger.info("[memory] PENDING snapshot 已回滚合并")
 
     def _recover_pending_snapshot(self) -> None:

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 import logging
 import re
-import shutil
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable
@@ -19,6 +18,7 @@ from agent.prompting import is_context_frame
 from agent.provider import LLMProvider
 from bus.events_lifecycle import TurnCommitted
 from core.memory.events import ConsolidationCommitted
+from infra.persistence.json_store import atomic_write_text
 
 if TYPE_CHECKING:
     from bus.event_bus import EventBus
@@ -70,6 +70,8 @@ class MemoryProfileApi(Protocol):
     def write_recent_context(self, content: str) -> None: ...
 
     def backup_long_term(self, backup_name: str = "MEMORY.bak.md") -> None: ...
+
+    def backup_self(self, backup_name: str = "SELF.bak.md") -> None: ...
 
     def get_memory_context(self) -> str: ...
 
@@ -1001,11 +1003,33 @@ history_entries.emotional_weight 规则：
 
 class MarkdownMemoryStore(MemoryStore):
     def backup_long_term(self, backup_name: str = "MEMORY.bak.md") -> None:
-        if self.memory_file.exists():
-            shutil.copyfile(
-                self.memory_file,
-                self.memory_file.with_name(backup_name),
-            )
+        self._backup_profile(self.memory_file, backup_name)
+
+    def backup_self(self, backup_name: str = "SELF.bak.md") -> None:
+        self._backup_profile(self.self_file, backup_name)
+
+    def _backup_profile(self, source: Path, latest_name: str) -> None:
+        """原子保存最新备份和不可覆盖的历史版本。"""
+        if not source.exists():
+            return
+
+        # 1. 先保存唯一历史版本，保证后续优化无法覆盖恢复点
+        content = source.read_text(encoding="utf-8")
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        nanoseconds = time.time_ns() % 1_000_000_000
+        history_path = (
+            self.memory_dir
+            / "backups"
+            / f"{source.stem}.{timestamp}-{nanoseconds:09d}.bak{source.suffix}"
+        )
+        atomic_write_text(history_path, content, domain="memory_backup")
+
+        # 2. 刷新固定名称，保留现有手工恢复入口
+        atomic_write_text(
+            source.with_name(latest_name),
+            content,
+            domain="memory_backup",
+        )
 
     def has_long_term_memory(self) -> bool:
         return bool(self.read_long_term().strip())

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -26,6 +26,10 @@ class MemoryOptimizerBusy(RuntimeError):
     pass
 
 
+class MemoryOptimizerOutputError(ValueError):
+    pass
+
+
 # ── 提示词 ──────────────────────────────────────────────────────
 
 _MERGE_SYSTEM = (
@@ -196,6 +200,72 @@ _SELF_PROMPT = """\
 {pending}
 """
 
+_MEMORY_REQUIRED_HEADINGS = (
+    "# 用户长期记忆",
+    "## 用户事实",
+    "## 用户偏好",
+    "## 用户明确要求长期记住的关键内容",
+)
+_MEMORY_OPTIONAL_HEADING = "## 助手操作上下文"
+_SELF_REQUIRED_HEADINGS = (
+    "# Akashic 的自我认知",
+    "## 人格与形象",
+    "## 我对当前用户的理解",
+    "## 我们关系的定义",
+)
+
+
+def _markdown_headings(content: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in content.splitlines()
+        if line.lstrip().startswith("#")
+    )
+
+
+def _validate_memory_output(content: str) -> None:
+    """拒绝不符合长期记忆完整档案契约的模型输出。"""
+    # 1. 标题只能是规定的三节，加末尾可选的操作上下文
+    headings = _markdown_headings(content)
+    valid_headings = (
+        _MEMORY_REQUIRED_HEADINGS,
+        _MEMORY_REQUIRED_HEADINGS + (_MEMORY_OPTIONAL_HEADING,),
+    )
+    first_line = content.splitlines()[0].strip() if content else ""
+    if (
+        first_line != _MEMORY_REQUIRED_HEADINGS[0]
+        or headings not in valid_headings
+        or "```" in content
+    ):
+        raise MemoryOptimizerOutputError("MEMORY.md 模型输出格式无效")
+
+    # 2. 非空输入不得被悄悄改写成只有标题的空档案
+    if not any(line.lstrip().startswith("- ") for line in content.splitlines()):
+        raise MemoryOptimizerOutputError("MEMORY.md 模型输出不包含任何记忆条目")
+
+
+def _validate_self_output(content: str) -> None:
+    """拒绝缺节、增节或空节的 SELF 模型输出。"""
+    # 1. SELF 只能保留既定标题，禁止模型扩展文档结构
+    lines = content.splitlines()
+    first_line = lines[0].strip() if lines else ""
+    if (
+        first_line != _SELF_REQUIRED_HEADINGS[0]
+        or _markdown_headings(content) != _SELF_REQUIRED_HEADINGS
+        or "```" in content
+    ):
+        raise MemoryOptimizerOutputError("SELF.md 模型输出格式无效")
+
+    # 2. 每个自我认知 section 必须保留至少一条内容
+    positions = [lines.index(heading) for heading in _SELF_REQUIRED_HEADINGS]
+    positions.append(len(lines))
+    for index in range(1, len(_SELF_REQUIRED_HEADINGS)):
+        section = lines[positions[index] + 1 : positions[index + 1]]
+        if not any(line.lstrip().startswith("- ") for line in section):
+            raise MemoryOptimizerOutputError(
+                f"SELF.md 模型输出 section 为空: {_SELF_REQUIRED_HEADINGS[index]}"
+            )
+
 # ── MemoryOptimizer ───────────────────────────────────────────────
 
 
@@ -242,6 +312,7 @@ class MemoryOptimizer:
 
             merged_memory = await self._merge_memory(current_memory, pending)
             if merged_memory:
+                _validate_memory_output(merged_memory)
                 if current_memory:
                     self._memory.backup_long_term()
                 self._memory.write_long_term(merged_memory)
@@ -294,6 +365,8 @@ class MemoryOptimizer:
             max_tokens=2048,
         )
         if updated:
+            _validate_self_output(updated)
+            self._memory.backup_self()
             self._memory.write_self(updated)
             logger.info("[memory_optimizer] SELF.md 已更新")
 

--- a/tests/memory_fakes.py
+++ b/tests/memory_fakes.py
@@ -92,6 +92,9 @@ class FakeMemoryEngine:
     def backup_long_term(self, backup_name: str = "MEMORY.bak.md") -> None:
         return None
 
+    def backup_self(self, backup_name: str = "SELF.bak.md") -> None:
+        return None
+
     def get_memory_context(self) -> str:
         return self._store.get_memory_context() if self._store is not None else ""
 

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -79,14 +79,28 @@ async def test_memory_optimizer_loop_and_memory_port_cover_paths(tmp_path: Path)
     provider = MagicMock()
     provider.chat = AsyncMock(
         side_effect=[
-            LLMResponse(content="merged"),
-            LLMResponse(content="updated self"),
+            LLMResponse(
+                content=(
+                    "# 用户长期记忆\n\n"
+                    "## 用户事实\n- x\n\n"
+                    "## 用户偏好\n- y\n\n"
+                    "## 用户明确要求长期记住的关键内容\n- z"
+                )
+            ),
+            LLMResponse(
+                content=(
+                    "# Akashic 的自我认知\n\n"
+                    "## 人格与形象\n- x\n\n"
+                    "## 我对当前用户的理解\n- y\n\n"
+                    "## 我们关系的定义\n- z"
+                )
+            ),
         ]
     )
     opt = MemoryOptimizer(memory, provider, "m", max_tokens=100)
     opt._STEP_DELAY_SECONDS = 0
     await opt.optimize()
-    memory.write_long_term.assert_called_once_with("merged")
+    memory.write_long_term.assert_called_once()
     memory.write_self.assert_called_once()
 
     loop = MemoryOptimizerLoop(opt, interval_seconds=10, _now_fn=lambda: datetime(2025, 1, 1, 0, 0, 1))

--- a/tests/test_memory_optimizer.py
+++ b/tests/test_memory_optimizer.py
@@ -11,6 +11,7 @@ import pytest
 from proactive_v2.memory_optimizer import (
     MemoryOptimizerBusy,
     MemoryOptimizer,
+    MemoryOptimizerOutputError,
     MemoryOptimizerLoop,
 )
 from core.memory.markdown import MarkdownMemoryStore
@@ -19,6 +20,31 @@ from core.memory.markdown import MarkdownMemoryStore
 class _Resp:
     def __init__(self, content: str) -> None:
         self.content = content
+
+
+_VALID_MEMORY = """# 用户长期记忆
+
+## 用户事实
+- 新版事实
+
+## 用户偏好
+- 新版偏好
+
+## 用户明确要求长期记住的关键内容
+- 新版要求
+"""
+
+_VALID_SELF = """# Akashic 的自我认知
+
+## 人格与形象
+- 新版人格
+
+## 我对当前用户的理解
+- 新版理解
+
+## 我们关系的定义
+- 新版关系
+"""
 
 
 def _provider_with_responses(*responses: str) -> object:
@@ -62,12 +88,34 @@ def test_optimize_rewrites_memory_from_first_llm_call(tmp_path):
     memory = MarkdownMemoryStore(tmp_path)
     memory.write_long_term("old profile")
 
-    provider = _provider_with_responses("## 用户画像\n- 新版本\n", "")
+    provider = _provider_with_responses(_VALID_MEMORY, "")
     optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
     optimizer._STEP_DELAY_SECONDS = 0
     asyncio.run(optimizer.optimize())
 
-    assert memory.read_long_term().strip() == "## 用户画像\n- 新版本"
+    assert memory.read_long_term().strip() == _VALID_MEMORY.strip()
+    assert (memory.memory_dir / "MEMORY.bak.md").read_text(encoding="utf-8") == (
+        "old profile"
+    )
+    history = list((memory.memory_dir / "backups").glob("MEMORY.*.bak.md"))
+    assert len(history) == 1
+    assert history[0].read_text(encoding="utf-8") == "old profile"
+
+
+def test_optimize_rejects_invalid_memory_and_restores_pending(tmp_path):
+    memory = MarkdownMemoryStore(tmp_path)
+    memory.write_long_term(_VALID_MEMORY)
+    memory.append_pending("- [identity] 新身份")
+    provider = _provider_with_responses("好的，已经整理完成。")
+    optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
+    optimizer._STEP_DELAY_SECONDS = 0
+
+    with pytest.raises(MemoryOptimizerOutputError, match="MEMORY.md"):
+        asyncio.run(optimizer.optimize())
+
+    assert memory.read_long_term() == _VALID_MEMORY
+    assert "新身份" in memory.read_pending()
+    assert not (memory.memory_dir / "MEMORY.bak.md").exists()
 
 
 def test_optimize_rolls_back_snapshot_when_merge_returns_empty(tmp_path):
@@ -107,7 +155,7 @@ def test_optimize_rolls_back_snapshot_when_memory_write_fails(tmp_path):
 
     async def break_memory_file(**_kwargs: Any) -> _Resp:
         memory.memory_file.mkdir()
-        return _Resp("## 新记忆")
+        return _Resp(_VALID_MEMORY)
 
     provider = types.SimpleNamespace()
     provider.chat = AsyncMock(side_effect=break_memory_file)
@@ -139,12 +187,12 @@ def test_optimize_propagates_cancellation_and_restores_pending(tmp_path):
 def test_optimize_updates_self_using_pending_only(tmp_path):
     memory = MarkdownMemoryStore(tmp_path)
     memory.write_long_term("old")
-    memory.write_self("## 原 SELF")
+    memory.write_self("原 SELF")
     memory.append_pending("- [preference] 回复保持简洁。")
 
     provider = _provider_with_responses(
-        "## 新记忆",
-        "# Akashic 的自我认知\n\n## 人格与形象\n\n- 新版人格\n\n## 我对当前用户的理解\n\n- 新版理解\n\n## 我们关系的定义\n\n- 新版关系\n",
+        _VALID_MEMORY,
+        _VALID_SELF,
     )
     optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
     optimizer._STEP_DELAY_SECONDS = 0
@@ -152,6 +200,12 @@ def test_optimize_updates_self_using_pending_only(tmp_path):
 
     assert memory.read_self().strip().startswith("# Akashic 的自我认知")
     assert "新版理解" in memory.read_self()
+    assert (memory.memory_dir / "SELF.bak.md").read_text(encoding="utf-8") == (
+        "原 SELF"
+    )
+    history = list((memory.memory_dir / "backups").glob("SELF.*.bak.md"))
+    assert len(history) == 1
+    assert history[0].read_text(encoding="utf-8") == "原 SELF"
 
     self_prompt = provider.chat.await_args_list[1].kwargs["messages"][1]["content"]
     assert "- [preference] 回复保持简洁。" in self_prompt
@@ -164,7 +218,7 @@ def test_optimize_propagates_self_update_failure(tmp_path):
     memory.append_pending("- [preference] 回复保持简洁。")
     provider = types.SimpleNamespace()
     provider.chat = AsyncMock(
-        side_effect=[_Resp("## 新记忆"), RuntimeError("self update failed")]
+        side_effect=[_Resp(_VALID_MEMORY), RuntimeError("self update failed")]
     )
     optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
     optimizer._STEP_DELAY_SECONDS = 0
@@ -172,8 +226,24 @@ def test_optimize_propagates_self_update_failure(tmp_path):
     with pytest.raises(RuntimeError, match="self update failed"):
         asyncio.run(optimizer.optimize())
 
-    assert memory.read_long_term().strip() == "## 新记忆"
+    assert memory.read_long_term().strip() == _VALID_MEMORY.strip()
     assert memory.read_self().strip() == "## 原 SELF"
+
+
+def test_optimize_rejects_invalid_self_without_overwriting_file(tmp_path):
+    memory = MarkdownMemoryStore(tmp_path)
+    memory.write_long_term("old")
+    memory.write_self(_VALID_SELF)
+    memory.append_pending("- [preference] 回复保持简洁。")
+    provider = _provider_with_responses(_VALID_MEMORY, "# Akashic 的自我认知")
+    optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
+    optimizer._STEP_DELAY_SECONDS = 0
+
+    with pytest.raises(MemoryOptimizerOutputError, match="SELF.md"):
+        asyncio.run(optimizer.optimize())
+
+    assert memory.read_self() == _VALID_SELF
+    assert not (memory.memory_dir / "SELF.bak.md").exists()
 
 
 def test_merge_memory_ignores_history_and_only_uses_pending(tmp_path):
@@ -181,7 +251,7 @@ def test_merge_memory_ignores_history_and_only_uses_pending(tmp_path):
     memory.write_long_term("old profile")
     memory.append_pending("- [identity] 新身份")
 
-    provider = _provider_with_responses("## 用户画像\n- 新版本\n", "")
+    provider = _provider_with_responses(_VALID_MEMORY, "")
     optimizer = MemoryOptimizer(memory, cast(Any, provider), "test-model")
     optimizer._STEP_DELAY_SECONDS = 0
     asyncio.run(optimizer.optimize())

--- a/tests/test_memory_store_questions.py
+++ b/tests/test_memory_store_questions.py
@@ -2,6 +2,7 @@
 
 import builtins
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +38,49 @@ def test_snapshot_and_rollback_merges_new_pending(tmp_path):
     pending = store.read_pending()
     assert "- old" in pending
     assert "- new" in pending
+
+
+def test_snapshot_rollback_replace_failure_keeps_both_recovery_files(
+    tmp_path, monkeypatch
+):
+    store = MemoryStore(tmp_path)
+    store.append_pending("- old")
+    _ = store.snapshot_pending()
+    store.append_pending("- new")
+    original_replace = Path.replace
+
+    def fail_pending_replace(path: Path, target: Path) -> Path:
+        if target == store.pending_file:
+            raise OSError("replace failed")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_pending_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        store.rollback_pending_snapshot()
+
+    assert "- old" in store._snapshot_path.read_text(encoding="utf-8")
+    assert "- new" in store.pending_file.read_text(encoding="utf-8")
+    assert not list(store.memory_dir.glob("PENDING.md.*.tmp"))
+
+
+def test_profile_replace_failure_preserves_existing_file(tmp_path, monkeypatch):
+    store = MemoryStore(tmp_path)
+    store.write_long_term("old profile")
+    original_replace = Path.replace
+
+    def fail_memory_replace(path: Path, target: Path) -> Path:
+        if target == store.memory_file:
+            raise OSError("replace failed")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_memory_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        store.write_long_term("new profile")
+
+    assert store.read_long_term() == "old profile"
+    assert not list(store.memory_dir.glob("MEMORY.md.*.tmp"))
 
 
 def test_get_memory_context_empty_and_nonempty(tmp_path):


### PR DESCRIPTION
## 问题

Memory optimizer 只判断模型输出是否非空，随后直接整文件覆盖 `MEMORY.md` 和 `SELF.md`。因此格式错误、截断或只有说明文字的响应也会替换用户持久化数据。Markdown profile 与 PENDING 回滚还使用非原子写，写入失败时可能留下截断文件。

## 改动

- 在 LLM 输出边界校验 MEMORY/SELF 的完整 Markdown 结构
- 格式无效时 fail-loud，并在 MEMORY 阶段恢复 PENDING snapshot
- MEMORY、SELF、RECENT_CONTEXT 和 PENDING 回滚统一使用原子文本写入
- PENDING 快照、追加和回滚共用文件所有权锁
- 每次 optimizer 覆盖 MEMORY/SELF 前保存固定名称备份和带时间戳的不可覆盖历史备份
- 不修改插件 skill 覆盖语义和显式文件工具覆盖语义

## 影响

- 无配置变更
- 合法 optimizer 输出行为保持不变
- 非法输出不再覆盖持久化 profile
- 历史恢复点写入 `memory/backups/`

## 验证

- `.venv/bin/pytest -q tests/` — 2111 passed
- `.venv/bin/pyright agent/memory.py core/memory/markdown.py proactive_v2/memory_optimizer.py` — 0 errors
- `git diff --check`