### PR TITLE
feat(backup): add generic rolling snapshot utility

### DIFF
--- a/scripts/rolling_backup.example.toml
+++ b/scripts/rolling_backup.example.toml
@@ -1,0 +1,13 @@
+# 通用滚动备份配置。路径支持 ~ 展开，快照内 name 必须是相对安全路径。
+destination = "~/backups/rolling"
+retention = 14
+
+[[sources]]
+name = "documents/important.md"
+kind = "file"
+path = "~/documents/important.md"
+
+[[sources]]
+name = "databases/app.db"
+kind = "sqlite"
+path = "~/data/app.db"

--- a/scripts/rolling_backup.py
+++ b/scripts/rolling_backup.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""为任意文件和 SQLite 数据库创建一致性滚动快照。"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import time
+import tomllib
+from collections.abc import Iterable
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+DEFAULT_RETENTION = 14
+
+
+@dataclass(frozen=True)
+class BackupSource:
+    """描述一个快照内名称、源路径和复制方式。"""
+
+    name: str
+    path: Path
+    kind: str
+
+
+def _parse_source(raw: str, *, kind: str) -> BackupSource:
+    name, separator, path = raw.partition("=")
+    if not separator or not name.strip() or not path.strip():
+        raise ValueError(f"源参数必须是 NAME=PATH: {raw!r}")
+    return BackupSource(
+        name=_validate_snapshot_name(name.strip()),
+        path=Path(path).expanduser().resolve(),
+        kind=kind,
+    )
+
+
+def _validate_snapshot_name(name: str) -> str:
+    path = PurePosixPath(name)
+    if path.is_absolute() or name in {"", "."} or ".." in path.parts:
+        raise ValueError(f"快照内名称必须是相对安全路径: {name!r}")
+    return str(path)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="把任意文件和 SQLite 数据库备份成滚动快照"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="TOML 配置文件；使用配置时不再需要逐项传入源路径",
+    )
+    parser.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="复制普通文件，可重复传入",
+    )
+    parser.add_argument(
+        "--sqlite",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="使用 SQLite 在线备份 API 复制数据库，可重复传入",
+    )
+    parser.add_argument("--destination", type=Path)
+    parser.add_argument("--retention", type=int)
+    return parser.parse_args()
+
+
+def _config_string(config: dict[str, Any], key: str) -> str:
+    value = config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"备份配置 {key!r} 必须是非空字符串")
+    return value.strip()
+
+
+def _sources_from_config(raw_sources: object) -> list[BackupSource]:
+    if not isinstance(raw_sources, list):
+        raise ValueError("备份配置 sources 必须是数组")
+    sources: list[BackupSource] = []
+    for raw in raw_sources:
+        if not isinstance(raw, dict):
+            raise ValueError("备份配置中的 source 必须是对象")
+        kind = _config_string(raw, "kind")
+        if kind not in {"file", "sqlite"}:
+            raise ValueError(f"备份配置 source.kind 无效: {kind!r}")
+        sources.append(
+            BackupSource(
+                name=_validate_snapshot_name(_config_string(raw, "name")),
+                path=Path(_config_string(raw, "path")).expanduser().resolve(),
+                kind=kind,
+            )
+        )
+    return sources
+
+
+def _load_config(path: Path) -> tuple[Path, int, list[BackupSource]]:
+    """读取通用 TOML 配置并转换成备份计划。"""
+
+    # 1. 读取显式配置，缺失字段直接失败。
+    with path.expanduser().open("rb") as handle:
+        raw = tomllib.load(handle)
+    if not isinstance(raw, dict):
+        raise ValueError("备份配置根节点必须是对象")
+    destination = Path(_config_string(raw, "destination")).expanduser()
+    retention_value = raw.get("retention", DEFAULT_RETENTION)
+    if not isinstance(retention_value, int):
+        raise ValueError("备份配置 retention 必须是整数")
+
+    # 2. 转换并校验源声明，源的语义完全由配置决定。
+    sources = _sources_from_config(raw.get("sources"))
+    return destination, retention_value, sources
+
+
+def _validate_sources(sources: Iterable[BackupSource]) -> list[BackupSource]:
+    validated = list(sources)
+    names = [source.name for source in validated]
+    if len(names) != len(set(names)):
+        raise ValueError("快照内名称不能重复")
+    if not validated:
+        raise ValueError("至少需要一个 --file 或 --sqlite 源")
+    for source in validated:
+        _ = _validate_snapshot_name(source.name)
+        if source.kind not in {"file", "sqlite"}:
+            raise ValueError(f"未知备份类型: {source.kind}")
+        if not source.path.is_file():
+            raise FileNotFoundError(
+                f"备份源不存在或不是文件: {source.name} -> {source.path}"
+            )
+    return validated
+
+
+def _copy_sqlite(source: Path, destination: Path) -> None:
+    """使用 SQLite 在线备份 API 生成一致性数据库快照。"""
+
+    source_uri = f"file:{source}?mode=ro"
+    with closing(sqlite3.connect(source_uri, uri=True)) as source_db:
+        with closing(sqlite3.connect(destination)) as destination_db:
+            # 1. 从运行中的数据库复制一致性快照，不直接复制主文件/WAL。
+            source_db.backup(destination_db, pages=256, sleep=0.1)
+
+            # 2. 备份完成后验证目标库，损坏时让调用方失败。
+            result = destination_db.execute("PRAGMA integrity_check").fetchone()
+            if result is None or result[0] != "ok":
+                raise sqlite3.DatabaseError(
+                    f"备份数据库完整性检查失败: {destination} ({result})"
+                )
+            destination_db.commit()
+
+
+def _copy_source(source: BackupSource, snapshot: Path) -> None:
+    destination = snapshot / source.name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.kind == "sqlite":
+        _copy_sqlite(source.path, destination)
+        return
+    shutil.copy2(source.path, destination)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_manifest(snapshot: Path, sources: Iterable[BackupSource]) -> None:
+    manifest = {
+        "created_at": datetime.now().astimezone().isoformat(),
+        "files": {
+            source.name: {
+                "kind": source.kind,
+                "source": str(source.path),
+                "size": (snapshot / source.name).stat().st_size,
+                "sha256": _sha256(snapshot / source.name),
+            }
+            for source in sources
+        },
+    }
+    (snapshot / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _prune(destination: Path, retention: int) -> None:
+    snapshots = sorted(
+        (path for path in destination.glob("snapshot-*") if path.is_dir()),
+        key=lambda path: path.stat().st_mtime_ns,
+        reverse=True,
+    )
+    for path in snapshots[retention:]:
+        shutil.rmtree(path)
+
+
+def create_snapshot(
+    *,
+    sources: Iterable[BackupSource],
+    destination: Path,
+    retention: int = DEFAULT_RETENTION,
+) -> Path:
+    """创建所有源的一致性快照，并清理超出保留数的旧快照。"""
+
+    # 1. 校验配置和所有源，避免生成半套快照。
+    if retention < 1:
+        raise ValueError("retention 必须大于等于 1")
+    validated_sources = _validate_sources(sources)
+    destination = destination.expanduser().resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+
+    # 2. 用锁阻止并发备份写入同一个目标目录。
+    lock_path = destination / ".backup.lock"
+    with lock_path.open("a+") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeError(f"已有备份任务正在运行: {lock_path}") from exc
+
+        timestamp = datetime.now().astimezone().strftime("%Y%m%d-%H%M%S")
+        temporary = destination / f".snapshot-{timestamp}-{os.getpid()}.tmp"
+        snapshot = destination / f"snapshot-{timestamp}"
+        if snapshot.exists():
+            timestamp = f"{timestamp}-{time.time_ns() % 1_000_000:06d}"
+            snapshot = destination / f"snapshot-{timestamp}"
+        committed = False
+        try:
+            # 3. 先写临时目录，完成所有源和 manifest 后再原子发布。
+            temporary.mkdir()
+            for source in validated_sources:
+                _copy_source(source, temporary)
+            _write_manifest(temporary, validated_sources)
+            os.replace(temporary, snapshot)
+            committed = True
+
+            # 4. 只在新快照完整发布后滚动删除旧快照。
+            _prune(destination, retention)
+            return snapshot
+        finally:
+            if not committed and temporary.exists():
+                shutil.rmtree(temporary)
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.config is not None:
+        if (
+            args.file
+            or args.sqlite
+            or args.destination is not None
+            or args.retention is not None
+        ):
+            raise ValueError(
+                "--config 不能和 --file/--sqlite/--destination/--retention 同时使用"
+            )
+        destination, retention, sources = _load_config(args.config)
+    else:
+        if args.destination is None:
+            raise ValueError("未提供 --config 或 --destination")
+        sources = [
+            *(_parse_source(raw, kind="file") for raw in args.file),
+            *(_parse_source(raw, kind="sqlite") for raw in args.sqlite),
+        ]
+        destination = args.destination
+        retention = (
+            DEFAULT_RETENTION if args.retention is None else args.retention
+        )
+    snapshot = create_snapshot(
+        sources=sources,
+        destination=destination,
+        retention=retention,
+    )
+    print(f"备份完成: {snapshot}")
+
+
+if __name__ == "__main__":
+    main()

--- a/systemd/rolling-backup.service
+++ b/systemd/rolling-backup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Generic rolling backup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 %h/.local/share/rolling-backup/rolling_backup.py --config %h/.config/rolling-backup/config.toml
+Restart=on-failure
+RestartSec=5min
+NoNewPrivileges=true
+PrivateTmp=true

--- a/systemd/rolling-backup.timer
+++ b/systemd/rolling-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run generic rolling backup every 12 hours
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=12h
+Persistent=true
+Unit=rolling-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_rolling_backup.py
+++ b/tests/test_rolling_backup.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+from scripts.rolling_backup import BackupSource, _load_config, create_snapshot
+
+
+def _create_database(path: Path, value: str) -> None:
+    with closing(sqlite3.connect(path)) as db:
+        db.execute("CREATE TABLE records (value TEXT NOT NULL)")
+        db.execute("INSERT INTO records VALUES (?)", (value,))
+        db.commit()
+
+
+def test_create_snapshot_copies_files_and_sqlite_consistently(tmp_path: Path) -> None:
+    source_file = tmp_path / "memory.md"
+    source_file.write_text("memory\n", encoding="utf-8")
+    source_db = tmp_path / "source.db"
+    _create_database(source_db, "session")
+
+    snapshot = create_snapshot(
+        sources=[
+            BackupSource("docs/memory.md", source_file, "file"),
+            BackupSource("data/sessions.db", source_db, "sqlite"),
+        ],
+        destination=tmp_path / "backups",
+    )
+
+    assert (snapshot / "docs/memory.md").read_text(encoding="utf-8") == "memory\n"
+    manifest = json.loads((snapshot / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["files"]["data/sessions.db"]["kind"] == "sqlite"
+    with closing(sqlite3.connect(snapshot / "data/sessions.db")) as db:
+        assert db.execute("SELECT value FROM records").fetchone() == ("session",)
+
+
+def test_create_snapshot_prunes_only_after_a_complete_snapshot(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("content\n", encoding="utf-8")
+    sources = [BackupSource("source.txt", source, "file")]
+    destination = tmp_path / "backups"
+
+    snapshots = [
+        create_snapshot(sources=sources, destination=destination, retention=10)
+        for _ in range(3)
+    ]
+    latest = create_snapshot(sources=sources, destination=destination, retention=2)
+
+    assert not snapshots[0].exists()
+    assert latest.exists()
+    assert len(list(destination.glob("snapshot-*"))) == 2
+    assert not list(destination.glob(".snapshot-*.tmp"))
+
+
+def test_source_names_must_not_escape_snapshot_root(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("content\n", encoding="utf-8")
+
+    try:
+        create_snapshot(
+            sources=[BackupSource("../outside.txt", source, "file")],
+            destination=tmp_path / "backups",
+        )
+    except ValueError as exc:
+        assert "相对安全路径" in str(exc)
+    else:
+        raise AssertionError("不安全的快照内路径应被拒绝")
+
+
+def test_load_config_defines_paths_and_backup_kinds(tmp_path: Path) -> None:
+    config = tmp_path / "backup.toml"
+    config.write_text(
+        f'''destination = "{tmp_path / "backups"}"
+retention = 3
+
+[[sources]]
+name = "notes.md"
+kind = "file"
+path = "{tmp_path / "notes.md"}"
+''',
+        encoding="utf-8",
+    )
+    (tmp_path / "notes.md").write_text("notes\n", encoding="utf-8")
+
+    destination, retention, sources = _load_config(config)
+
+    assert destination == tmp_path / "backups"
+    assert retention == 3
+    assert sources == [BackupSource("notes.md", tmp_path / "notes.md", "file")]


### PR DESCRIPTION
## What changed

- add a generic rolling backup CLI for ordinary files and SQLite databases
- support TOML configuration and direct CLI source declarations
- use SQLite online backup, integrity checks, SHA-256 manifest, atomic publish, locking, and retention pruning
- add generic user-level systemd service and 12-hour timer templates
- add focused tests for snapshots, pruning, path safety, and TOML loading

## Why

The previous unit embedded a specific repository worktree and Akashic paths, so it could not be reused by another checkout or user. The new unit only references standard per-user install/config locations; application-specific paths live in the user-owned TOML config.

## Validation

- `/mnt/data/coding/akasic-agent/.venv/bin/python -m pytest -q tests/test_rolling_backup.py` — 4 passed
- `/mnt/data/coding/akasic-agent/.venv/bin/pyright scripts/rolling_backup.py` — 0 errors
- `systemd-analyze verify systemd/rolling-backup.service systemd/rolling-backup.timer`
- local user timer enabled and active; latest sessions.db and akasha.db snapshots passed `PRAGMA integrity_check`
