### PR TITLE
[codex] isolate runtime state by workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Akashic 理想上的动作应该是：
 git clone <this-repo>
 cd akashic-agent
 uv venv && uv pip install -r requirements.txt
-export AKASHIC_WORKSPACE="$PWD/.runtime/workspace"
 ```
 
 没有 uv？先 `pip install uv`。
@@ -68,6 +67,17 @@ export AKASHIC_WORKSPACE="$PWD/.runtime/workspace"
 uv run python main.py setup    # 交互向导（推荐）
 uv run python main.py init     # 非交互，CI/自动化用
 ```
+
+`init` 生成的 `config.toml` 默认包含：
+
+```toml
+[runtime]
+workspace = "~/.akashic/workspace"
+```
+
+因此直接运行 `python main.py` 或在 PyCharm 中直接启动 `main.py` 都不需要重复填写
+workspace。临时切换隔离环境时传 `--workspace PATH`；它的优先级高于
+`AKASHIC_WORKSPACE` 和 `config.toml`。
 
 **2. 填写 config.toml**
 
@@ -197,8 +207,10 @@ akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/
 
 ## 工作区
 
-所有运行时数据都在显式选择的 `$AKASHIC_WORKSPACE` 下；也可以为每条命令传入
-`--workspace /absolute/path`。不同测试环境使用不同目录，不共享会话、记忆、附件或插件数据。
+所有运行时数据都在 `[runtime].workspace` 指定的目录下。默认值是
+`~/.akashic/workspace`；可设置 `AKASHIC_WORKSPACE`，也可以为单条命令传入
+`--workspace /absolute/path`。优先级为 `--workspace`、`AKASHIC_WORKSPACE`、
+`config.toml`。不同测试环境使用不同目录，不共享会话、记忆、附件或插件数据。
 插件代码缓存和启停清单默认仍位于 `$HOME/.akashic-plugin`；需要完整隔离插件安装状态时，
 额外设置 `AKASHIC_PLUGIN_HOME=/absolute/test/plugin-home`。
 
@@ -206,7 +218,7 @@ akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/
 
 ```bash
 uv run python scripts/migrate_plugin_data.py \
-  --workspace "$AKASHIC_WORKSPACE" \
+  --workspace "$HOME/.akashic/workspace" \
   --plugins-home "$HOME/.akashic-plugin"
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Akashic 理想上的动作应该是：
 git clone <this-repo>
 cd akashic-agent
 uv venv && uv pip install -r requirements.txt
+export AKASHIC_WORKSPACE="$PWD/.runtime/workspace"
 ```
 
 没有 uv？先 `pip install uv`。
@@ -196,7 +197,18 @@ akashic_RUN_SCENARIOS=1 pytest -c pytest-scenarios.ini tests_scenarios/
 
 ## 工作区
 
-所有运行时数据在 `~/.akashic/workspace/`。
+所有运行时数据都在显式选择的 `$AKASHIC_WORKSPACE` 下；也可以为每条命令传入
+`--workspace /absolute/path`。不同测试环境使用不同目录，不共享会话、记忆、附件或插件数据。
+插件代码缓存和启停清单默认仍位于 `$HOME/.akashic-plugin`；需要完整隔离插件安装状态时，
+额外设置 `AKASHIC_PLUGIN_HOME=/absolute/test/plugin-home`。
+
+从旧版升级时，第一次重启前显式复制旧插件数据；命令保留旧目录，目标已存在时拒绝覆盖：
+
+```bash
+uv run python scripts/migrate_plugin_data.py \
+  --workspace "$AKASHIC_WORKSPACE" \
+  --plugins-home "$HOME/.akashic-plugin"
+```
 
 程序化客户端连接 workspace 下的 `akashic.sock`，先完成 JSON-RPC
 `initialize`/`initialized`，再使用 `thread/start`、`turn/start`、`turn/read` 和

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -7,7 +7,7 @@ Akashic 插件采用“全局只管启停，插件自己声明能力”的模型
 │  └─ 只记录 plugin_id 与 enabled
 ├─ ~/.akashic-plugin/cache/<marketplace>/<plugin>/<version>/
 │  └─ 从 Git 仓库安装的只读代码与 MCP 虚拟环境
-└─ ~/.akashic-plugin/data/<plugin>-<marketplace>/
+└─ <workspace>/plugin-data/<plugin>-<marketplace>/
    ├─ config.local.toml
    └─ 数据库、Token、模型与日志等持久状态
 ```
@@ -109,7 +109,7 @@ class DemoPlugin(Plugin):
 对应配置：
 
 ```toml
-# ~/.akashic-plugin/data/demo-github/config.local.toml
+# <workspace>/plugin-data/demo-github/config.local.toml
 [proactive]
 enabled = false
 ```

--- a/_handbook/proactive-guide.md
+++ b/_handbook/proactive-guide.md
@@ -61,7 +61,7 @@ class SourcePlugin(Plugin):
 ## 插件内关闭主动链路
 
 ```toml
-# ~/.akashic-plugin/data/source-github/config.local.toml
+# <workspace>/plugin-data/source-github/config.local.toml
 [proactive]
 enabled = false
 ```

--- a/_handbook/programmatic-control-migration.md
+++ b/_handbook/programmatic-control-migration.md
@@ -28,7 +28,8 @@ outbound_queue_size = 512
 ## 调用
 
 ```bash
-python main.py gateway --config config.toml --workspace ~/.akashic/workspace
+export AKASHIC_WORKSPACE=/absolute/workspace
+python main.py gateway --config config.toml
 python main.py exec --new --json "总结最近上下文"
 python main.py exec --thread programmatic:THREAD_ID --final-only - < prompt.txt
 python main.py app-server --stdio --config config.toml --workspace /isolated/workspace

--- a/agent/config.py
+++ b/agent/config.py
@@ -89,11 +89,16 @@ def _validated_timezone(tz_name: str, *, enabled: bool) -> str:
         ) from exc
 
 
-def load_config(path: str | Path = "config.toml") -> Config:
+def load_config(
+    path: str | Path = "config.toml",
+    *,
+    workspace: str | Path,
+) -> Config:
+    workspace_path = Path(workspace)
     data = _load_config_data(path)
 
     llm = _as_dict(data.get("llm"), field="llm")
-    runtime_id, llm_main, model_runtimes = _load_llm_runtimes(llm)
+    runtime_id, llm_main, model_runtimes = _load_llm_runtimes(llm, workspace_path)
     fast_runtime_id, llm_fast = _load_role_runtime(llm, "fast", runtime_id)
     agent_runtime_id, llm_agent = _load_role_runtime(llm, "agent", runtime_id)
     vl_runtime_id, llm_vl = _load_role_runtime(llm, "vl", runtime_id)
@@ -106,10 +111,10 @@ def load_config(path: str | Path = "config.toml") -> Config:
     provider = str(llm_main.get("provider") or llm.get("provider") or data.get("provider") or "").lower()
     if not provider:
         raise ValueError("必须配置 llm provider")
-    channels = _load_channels_config(data)
+    channels = _load_channels_config(data, workspace_path)
     app_server = _load_app_server_config(data)
     proactive = _load_proactive_config(data)
-    memory = _load_memory_config(data)
+    memory = _load_memory_config(data, workspace_path)
     peer_agents = _load_peer_agents_config(data)
     wiring = _load_wiring_config(data)
 
@@ -122,6 +127,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
             else _load_api_key(
                 auth_id=str(llm_main.get("auth") or ""),
                 inline_value=str(llm_main.get("api_key") or data.get("api_key", "")),
+                workspace=workspace_path,
             )
         ),
         system_prompt=str(
@@ -162,6 +168,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         light_api_key=_load_api_key(
             auth_id=str(llm_fast.get("auth") or ""),
             inline_value=str(llm_fast.get("api_key") or data.get("light_api_key", "")),
+            workspace=workspace_path,
         ),
         light_base_url=str(
             llm_fast.get("base_url") or data.get("light_base_url", "")
@@ -170,6 +177,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         agent_api_key=_load_api_key(
             auth_id=str(llm_agent.get("auth") or ""),
             inline_value=str(llm_agent.get("api_key") or data.get("agent_api_key", "")),
+            workspace=workspace_path,
         ),
         agent_base_url=str(
             llm_agent.get("base_url") or data.get("agent_base_url", "")
@@ -198,6 +206,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         vl_api_key=_load_api_key(
             auth_id=str(llm_vl.get("auth") or ""),
             inline_value=str(llm_vl.get("api_key") or data.get("vl_api_key", "")),
+            workspace=workspace_path,
         ),
         vl_base_url=str(llm_vl.get("base_url") or data.get("vl_base_url", "")),
         peer_agents=peer_agents,
@@ -230,13 +239,15 @@ def load_config(path: str | Path = "config.toml") -> Config:
     )
 
 
-def _load_channels_config(data: dict) -> ChannelsConfig:
+def _load_channels_config(data: dict, workspace: Path) -> ChannelsConfig:
     channels_data = _as_dict(data.get("channels"), field="channels")
 
     telegram = None
     tg = _as_dict(channels_data.get("telegram"), field="channels.telegram")
     if tg:
-        token = _normalize_optional_config_text(_resolve(str(tg.get("token", ""))))
+        token = _normalize_optional_config_text(
+            _resolve(str(tg.get("token", "")), workspace)
+        )
         if _as_bool(
             tg.get("enabled", True), field="channels.telegram.enabled"
         ) and token:
@@ -333,7 +344,7 @@ def _load_proactive_config(data: dict) -> ProactiveConfig:
     return proactive
 
 
-def _load_memory_config(data: dict) -> MemoryConfig:
+def _load_memory_config(data: dict, workspace: Path) -> MemoryConfig:
     memory = _as_dict(data.get("memory"), field="memory")
     embedding = _as_dict(memory.get("embedding"), field="memory.embedding")
     raw_output_dimensionality = embedding.get("output_dimensionality")
@@ -352,6 +363,7 @@ def _load_memory_config(data: dict) -> MemoryConfig:
             api_key=_load_api_key(
                 auth_id=str(embedding.get("auth") or ""),
                 inline_value=str(embedding.get("api_key", "")),
+                workspace=workspace,
             ),
             base_url=str(embedding.get("base_url", "")),
             output_dimensionality=output_dimensionality,
@@ -430,6 +442,7 @@ def _load_extra_body(data: dict, llm_main: dict | None = None) -> dict:
 
 def _load_llm_runtimes(
     llm: dict,
+    workspace: Path,
 ) -> tuple[str, dict, dict[str, ModelRuntimeConfig]]:
     """在配置边界把新版 runtime 与旧版 llm.main 统一。"""
     main_value = llm.get("main")
@@ -458,6 +471,7 @@ def _load_llm_runtimes(
                 else _load_api_key(
                     auth_id=auth_id,
                     inline_value=str(item.get("api_key") or ""),
+                    workspace=workspace,
                 )
             ),
             base_url=_model_base_url(provider, item.get("base_url")),
@@ -533,23 +547,23 @@ def _as_dict(value: object, *, field: str) -> dict:
     return value
 
 
-def _resolve(value: str) -> str:
+def _resolve(value: str, workspace: Path) -> str:
     resolved = re.sub(
         r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), m.group(0)), value
     )
     # 若仍是未展开的占位符，尝试从 workspace/memory/<VAR_NAME> 文件读取
     m = re.fullmatch(r"\$\{(\w+)\}", resolved)
     if m:
-        key_file = Path.home() / ".akashic" / "workspace" / "memory" / m.group(1)
+        key_file = workspace / "memory" / m.group(1)
         if key_file.exists():
             resolved = key_file.read_text(encoding="utf-8").strip()
     return resolved
 
 
-def _load_api_key(*, auth_id: str, inline_value: str) -> str:
+def _load_api_key(*, auth_id: str, inline_value: str, workspace: Path) -> str:
     if auth_id:
         return CredentialStore().api_key(auth_id)
-    return _resolve(inline_value)
+    return _resolve(inline_value, workspace)
 
 
 def _model_base_url(provider: str, configured: object) -> str:

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -181,10 +181,15 @@ class Config:
     vl_runtime_id: str = ""
 
     @classmethod
-    def load(cls, path: str | Path = "config.toml") -> Config:
+    def load(
+        cls,
+        path: str | Path = "config.toml",
+        *,
+        workspace: str | Path,
+    ) -> Config:
         from importlib import import_module
 
-        return import_module("agent.config").load_config(path)
+        return import_module("agent.config").load_config(path, workspace=workspace)
 
 
 __all__ = [

--- a/agent/plugins/doctor.py
+++ b/agent/plugins/doctor.py
@@ -17,11 +17,11 @@ def run_plugin_doctor(
     *,
     plugin_id: str = "",
     config_path: str = "config.toml",
-    workspace: Path | None = None,
+    workspace: Path,
     plugins_home: Path | None = None,
 ) -> dict[str, Any]:
-    resolved_workspace = workspace or Path.home() / ".akashic" / "workspace"
-    config = Config.load(config_path)
+    resolved_workspace = workspace
+    config = Config.load(config_path, workspace=resolved_workspace)
     memory_engine = (config.memory.engine or "").strip() or "default"
     manifest = load_plugin_manifest(plugins_home)
     selected = [plugin_id] if plugin_id else sorted(manifest)

--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -14,11 +14,14 @@ from pathlib import Path
 from typing import cast
 
 from agent.plugins.manifest import (
+    ensure_workspace_plugin_data_dir,
     load_package_manifest,
     load_plugin_manifest,
     remove_plugin_manifest_entry,
     set_plugin_enabled,
     upsert_plugin_manifest,
+    plugins_root,
+    workspace_plugin_data_dir,
 )
 from agent.plugins.registry import plugin_registry
 from agent.plugins.specs import McpServerSpec
@@ -59,7 +62,7 @@ class _CacheActivation:
 
 
 def aka_plugins_root() -> Path:
-    return Path.home() / ".akashic-plugin"
+    return plugins_root()
 
 
 def installed_cache_root() -> Path:
@@ -69,8 +72,10 @@ def installed_cache_root() -> Path:
 def plugin_data_root(
     plugin_name: str,
     marketplace: str,
+    *,
+    workspace: Path,
 ) -> Path:
-    return aka_plugins_root() / "data" / f"{plugin_name}-{marketplace}"
+    return workspace_plugin_data_dir(workspace, plugin_name, marketplace)
 
 
 def set_installed_plugin_enabled(
@@ -91,13 +96,14 @@ def set_installed_plugin_enabled(
 def uninstall_plugin(
     plugin_id: str,
     *,
+    workspace: Path,
     plugins_home: Path | None = None,
     wait_until_disabled: Callable[[str], None] | None = None,
 ) -> tuple[Path, Path]:
     home = plugins_home or aka_plugins_root()
     plugin_name, marketplace = _split_installed_plugin_id(plugin_id)
     cache_path = home / "cache" / marketplace / plugin_name
-    data_path = home / "data" / f"{plugin_name}-{marketplace}"
+    data_path = workspace_plugin_data_dir(workspace, plugin_name, marketplace)
     _ = set_plugin_enabled(plugin_id, enabled=False, plugins_home=home)
     if wait_until_disabled is not None:
         wait_until_disabled(plugin_id)
@@ -122,6 +128,7 @@ def _split_installed_plugin_id(plugin_id: str) -> tuple[str, str]:
 
 def install_git_plugin(
     *,
+    workspace: Path,
     source: str,
     marketplace: str,
     ref_name: str = "",
@@ -143,10 +150,8 @@ def install_git_plugin(
         raise ValueError("插件 sparse path 必须是非空字符串")
     marketplace_root = home / "marketplaces" / marketplace
     cache_root = home / "cache" / marketplace
-    data_root = home / "data"
     _ensure_directory_tree(home, marketplace_root)
     _ensure_directory_tree(home, cache_root)
-    _ensure_directory_tree(home, data_root)
 
     # 1. 在任何 cache 改动前校验 manifest，避免坏配置把安装事务推到半路
     _ = load_plugin_manifest(home)
@@ -178,7 +183,8 @@ def install_git_plugin(
             marketplace=marketplace,
             clone_root=clone_root,
             cache_root=cache_root,
-            data_root=data_root,
+            data_root=workspace.resolve(strict=False) / "plugin-data",
+            workspace=workspace,
         )
         plugin_id = f"{plugin_name}@{marketplace}"
         try:
@@ -266,12 +272,13 @@ def _activate_plugin_version(
     clone_root: Path,
     cache_root: Path,
     data_root: Path,
+    workspace: Path,
 ) -> _CacheActivation:
     """准备新版本并以可回滚的目录替换发布到 cache。"""
 
     # 1. 创建受保护的数据目录和 cache 父目录
     data_path = data_root / f"{plugin_name}-{marketplace}"
-    _ensure_directory(data_path)
+    ensure_workspace_plugin_data_dir(data_path, workspace)
     plugin_base = cache_root / plugin_name
     target_root = plugin_base / plugin_version
     _ensure_directory(plugin_base)

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -20,8 +20,11 @@ from typing import Any, TypeVar, cast
 from pydantic import BaseModel, ValidationError
 
 from agent.plugins.manifest import (
+    ensure_workspace_plugin_data_dir,
     load_package_manifest,
     load_plugin_manifest,
+    plugins_root,
+    workspace_plugin_data_dir,
     write_package_manifest,
     write_plugin_manifest,
 )
@@ -146,8 +149,8 @@ class PluginManager:
         plugin_dirs: list[Path],
         *,
         event_bus: EventBus,
+        workspace: Path,
         tool_registry: Any = None,
-        workspace: Path | None = None,
         session_manager: Any = None,
         memory_engine: Any = None,
         llm: PluginLlmService | None = None,
@@ -567,7 +570,7 @@ class PluginManager:
             data_dir = _resolve_plugin_data_dir(
                 mod["name"],
                 mod,
-                self._installed_cache_root,
+                self._workspace,
             )
             digest.update(plugin_id.encode())
             digest.update(_source_metadata_revision(plugin_dir))
@@ -1403,7 +1406,7 @@ class PluginManager:
                     _resolve_plugin_data_dir(
                         mod["name"],
                         mod,
-                        self._installed_cache_root,
+                        self._workspace,
                     )
                     / "config.local.toml"
                 )
@@ -1580,8 +1583,9 @@ class PluginManager:
         data_dir = _resolve_plugin_data_dir(
             mod["name"],
             mod,
-            self._installed_cache_root,
+            self._workspace,
         )
+        ensure_workspace_plugin_data_dir(data_dir, self._workspace)
         config_revision = _file_revision(data_dir / "config.local.toml")
         self._generation_sequence += 1
         generation_id = (
@@ -2201,11 +2205,13 @@ class PluginManager:
             mcp_servers=_resolve_mcp_servers(
                 plugin_dir,
                 data_dir,
+                self._workspace,
                 cls.mcp_servers(),
             ),
             managed_services=_resolve_managed_services(
                 plugin_dir,
                 data_dir,
+                self._workspace,
                 cls.managed_services(),
                 source_revision=source_revision,
             ),
@@ -2802,17 +2808,20 @@ def _resolve_plugin_id(mod: dict[str, str]) -> str:
 def _resolve_plugin_data_dir(
     name: str,
     mod: dict[str, str],
-    installed_cache_root: Path | None,
+    workspace: Path,
 ) -> Path:
+    """把插件可写数据固定到当前 workspace 的独立目录。"""
+
+    # 1. 交给统一路径边界校验插件身份
     marketplace = mod.get("marketplace", "").strip()
     suffix = marketplace or "builtin"
-    return _plugins_home(installed_cache_root) / "data" / f"{name}-{suffix}"
+    return workspace_plugin_data_dir(workspace, name, suffix)
 
 
 def _plugins_home(installed_cache_root: Path | None) -> Path:
     if installed_cache_root is not None:
         return installed_cache_root.parent
-    return Path.home() / ".akashic-plugin"
+    return plugins_root()
 
 
 def _resolve_declared_roots(
@@ -2843,6 +2852,7 @@ def _resolve_dashboard_module(plugin_dir: Path, declared: str | None) -> Path | 
 def _resolve_managed_services(
     plugin_dir: Path,
     data_dir: Path,
+    workspace: Path,
     declared: list[ManagedServiceSpec],
     *,
     source_revision: str,
@@ -2886,7 +2896,11 @@ def _resolve_managed_services(
         services[spec.id] = {
             "command": command,
             "cwd": cwd,
-            "env": {**spec.env, "AKA_PLUGIN_DATA_DIR": str(data_dir)},
+            "env": {
+                **spec.env,
+                "AKA_PLUGIN_DATA_DIR": str(data_dir),
+                "AKASHIC_WORKSPACE": str(workspace),
+            },
             "readiness_url": spec.readiness_url,
             "startup_timeout_seconds": spec.startup_timeout_seconds,
             "revision": source_revision,
@@ -2897,6 +2911,7 @@ def _resolve_managed_services(
 def _resolve_mcp_servers(
     plugin_dir: Path,
     data_dir: Path,
+    workspace: Path,
     declared: list[McpServerSpec],
 ) -> dict[str, dict[str, Any]]:
     servers: dict[str, dict[str, Any]] = {}
@@ -2925,7 +2940,11 @@ def _resolve_mcp_servers(
         )
         _require_plugin_path(plugin_root, resolved_cwd, "MCP cwd")
         cwd = str(resolved_cwd)
-        env = {**spec.env, "AKA_PLUGIN_DATA_DIR": str(data_dir)}
+        env = {
+            **spec.env,
+            "AKA_PLUGIN_DATA_DIR": str(data_dir),
+            "AKASHIC_WORKSPACE": str(workspace),
+        }
         if _is_python_command(command[0]):
             runtime_root = _resolve_mcp_runtime_root(plugin_dir, cwd, command)
             if runtime_root is not None:

--- a/agent/plugins/manifest.py
+++ b/agent/plugins/manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import re
 import tomllib
 from pathlib import Path
 from typing import Mapping, cast
@@ -8,7 +10,15 @@ from infra.persistence.json_store import atomic_write_text
 
 
 def plugins_root(plugins_home: Path | None = None) -> Path:
-    return plugins_home or Path.home() / ".akashic-plugin"
+    if plugins_home is not None:
+        return plugins_home
+    configured = os.environ.get("AKASHIC_PLUGIN_HOME")
+    if configured is not None:
+        configured = configured.strip()
+        if not configured:
+            raise ValueError("AKASHIC_PLUGIN_HOME 不能为空")
+        return Path(configured).expanduser().resolve(strict=False)
+    return Path.home() / ".akashic-plugin"
 
 
 def manifest_path(plugins_home: Path | None = None) -> Path:
@@ -17,11 +27,53 @@ def manifest_path(plugins_home: Path | None = None) -> Path:
 
 def builtin_plugin_data_dir(
     plugin_name: str,
-    plugins_home: Path | None = None,
+    workspace: Path,
 ) -> Path:
-    """返回内置插件的用户数据目录。"""
+    """返回当前 workspace 内的内置插件数据目录。"""
 
-    return plugins_root(plugins_home) / "data" / f"{plugin_name}-builtin"
+    return workspace_plugin_data_dir(workspace, plugin_name, "builtin")
+
+
+def workspace_plugin_data_dir(
+    workspace: Path,
+    plugin_name: str,
+    marketplace: str,
+) -> Path:
+    """解析 workspace 内的插件数据目录，不创建或迁移数据。"""
+
+    # 1. 插件身份只能形成单一路径段
+    for label, value in (("name", plugin_name), ("marketplace", marketplace)):
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value) is None:
+            raise ValueError(f"插件 {label} 不是安全路径段: {value!r}")
+
+    # 2. 数据根始终归属于显式 workspace
+    return workspace.resolve(strict=False) / "plugin-data" / f"{plugin_name}-{marketplace}"
+
+
+def ensure_workspace_plugin_data_dir(path: Path, workspace: Path) -> None:
+    """安全创建 workspace 内的数据目录，并拒绝中间符号链接。"""
+
+    validate_workspace_plugin_data_path(path, workspace)
+    path.mkdir(parents=True, exist_ok=True)
+    validate_workspace_plugin_data_path(path, workspace)
+
+
+def validate_workspace_plugin_data_path(path: Path, workspace: Path) -> None:
+    """校验插件数据路径归属 workspace，且现有路径不穿过符号链接。"""
+
+    # 1. 校验目标仍归属于 workspace
+    root = workspace.resolve(strict=False)
+    try:
+        relative = path.relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"插件数据目录越界: {path}") from error
+
+    # 2. 逐级拒绝现有符号链接
+    current = root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"插件数据目录不能穿过符号链接: {current}")
 
 
 def load_plugin_manifest(

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -831,14 +831,14 @@ class AppRuntime:
 
 def build_app_runtime(
     config: Config,
-    workspace: Path | None = None,
+    workspace: Path,
     *,
     restart_coordinator: RestartCoordinator | None = None,
     readiness: RuntimeReadiness | None = None,
 ) -> AppRuntime:
     return AppRuntime(
         config,
-        workspace or (Path.home() / ".akashic" / "workspace"),
+        workspace,
         restart_coordinator=restart_coordinator,
         readiness=readiness,
     )

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -29,7 +29,7 @@ async def start_channels(
     plugin_channels: list[Channel] | None = None,
 ) -> ChannelHost:
     try:
-        attachment_store = AttachmentStore()
+        attachment_store = AttachmentStore(session_manager.workspace / "uploads")
 
         def _ctx_factory(channel: Channel) -> ChannelContext:
             return ChannelContext(

--- a/bootstrap/chat_api.py
+++ b/bootstrap/chat_api.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from infra.channels.base import AttachmentStore
 from infra.channels.web_chat_channel import WebChatChannel
 
 
@@ -16,6 +17,7 @@ def create_chat_app(
     workspace: Path,
     channel: WebChatChannel,
 ) -> FastAPI:
+    channel.bind_attachment_store(AttachmentStore(workspace / "uploads"))
     app = FastAPI(title="Akashic Chat API")
     app.state.workspace = workspace
     app.state.channel = channel

--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -22,7 +22,11 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from agent.plugins.manifest import load_package_manifest, load_plugin_manifest
+from agent.plugins.manifest import (
+    load_package_manifest,
+    load_plugin_manifest,
+    plugins_root as resolve_plugins_root,
+)
 from agent.plugins.packages import enabled_plugin_packages
 from agent.plugins.source_resolver import resolve_plugin_sources
 from bootstrap.cleanup import run_cleanup_steps
@@ -40,9 +44,9 @@ _DASHBOARD_ACCESS_PREFIXES = ("/api/dashboard", "/assets", "/plugins/")
 def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
     result: dict[str, Path] = {}
     manifest = load_plugin_manifest()
-    plugins_root = project_root / "plugins"
-    if plugins_root.is_dir():
-        for plugin_dir in sorted(plugins_root.iterdir()):
+    builtin_root = project_root / "plugins"
+    if builtin_root.is_dir():
+        for plugin_dir in sorted(builtin_root.iterdir()):
             if (
                 not plugin_dir.is_dir()
                 or manifest.get(plugin_dir.name, True) is False
@@ -50,7 +54,7 @@ def _dashboard_plugin_dirs(project_root: Path) -> dict[str, Path]:
                 continue
             result[plugin_dir.name] = plugin_dir
 
-    cache_root = Path.home() / ".akashic-plugin" / "cache"
+    cache_root = resolve_plugins_root() / "cache"
     for source in resolve_plugin_sources([], installed_cache_root=cache_root):
         plugin_name = source.plugin_root.parent.name
         plugin_id = f"{plugin_name}@{source.marketplace}"

--- a/bootstrap/init_workspace.py
+++ b/bootstrap/init_workspace.py
@@ -176,7 +176,7 @@ def init_workspace(
 
     _ensure_config(config_path, force=force, summary=summary)
 
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     _ensure_workspace_text_assets(workspace, force=force, summary=summary)
     _ensure_workspace_json_assets(workspace, force=force, summary=summary)
     _ensure_workspace_directories(workspace, summary=summary)

--- a/bootstrap/setup_main.py
+++ b/bootstrap/setup_main.py
@@ -34,7 +34,7 @@ _MANAGED_KEYS = {
 }
 
 
-def run_main_model_setup(config_path: Path) -> None:
+def run_main_model_setup(config_path: Path, workspace: Path) -> None:
     """交互式切换主模型，并原子保留其余 TOML 配置。"""
 
     # 1. 只收集主模型答案和对应凭据。
@@ -55,7 +55,7 @@ def run_main_model_setup(config_path: Path) -> None:
     updated = patch_main_model_config(
         config_path.read_text(encoding="utf-8"), answers
     )
-    _validate_candidate(config_path, updated)
+    _validate_candidate(config_path, updated, workspace)
 
     # 3. 明确备份后原子替换，不触碰其他配置文件。
     _atomic_write_with_backup(
@@ -132,7 +132,7 @@ def _persist_main_api_key(answers: WizardAnswers) -> None:
     )
 
 
-def _validate_candidate(config_path: Path, content: str) -> None:
+def _validate_candidate(config_path: Path, content: str, workspace: Path) -> None:
     """在正式替换前验证 TOML 与完整配置边界。"""
     tomllib.loads(content)
     fd, temp_name = tempfile.mkstemp(
@@ -145,7 +145,7 @@ def _validate_candidate(config_path: Path, content: str) -> None:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        Config.load(temp_name)
+        Config.load(temp_name, workspace=workspace)
     finally:
         if os.path.exists(temp_name):
             os.unlink(temp_name)

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -19,7 +19,11 @@ from pathlib import Path
 from typing import cast
 
 import click
-from agent.plugins.manifest import builtin_plugin_data_dir
+from agent.plugins.manifest import (
+    builtin_plugin_data_dir,
+    ensure_workspace_plugin_data_dir,
+    workspace_plugin_data_dir,
+)
 from plugins.default_memory.config import render_default_memory_config
 
 
@@ -236,25 +240,25 @@ def run_setup_wizard(config_path: Path, workspace: Path) -> None:
     toml_str = _render_config(answers)
     _atomic_write_with_backup(config_path, toml_str, mode=0o600)
     _ok(f"{config_path} 已生成")
-    memory_config_path = _default_memory_local_config_path()
-    memory_config_path.parent.mkdir(parents=True, exist_ok=True)
+    memory_config_path = _default_memory_local_config_path(workspace)
+    ensure_workspace_plugin_data_dir(memory_config_path.parent, workspace)
     _atomic_write_with_backup(
         memory_config_path,
         _render_default_memory_config(),
     )
     _ok(f"{memory_config_path} 已生成")
-    qqbot_config_path = _qqbot_local_config_path()
-    qqbot_config_path.parent.mkdir(parents=True, exist_ok=True)
+    qqbot_config_path = _qqbot_local_config_path(workspace)
+    ensure_workspace_plugin_data_dir(qqbot_config_path.parent, workspace)
     _atomic_write_with_backup(qqbot_config_path, _render_qqbot_config(answers), mode=0o600)
     _ok(f"{qqbot_config_path} 已生成")
 
-    _validate_config(config_path)
+    _validate_config(config_path, workspace)
 
     from bootstrap.init_workspace import init_workspace
     _ = init_workspace(config_path=config_path, workspace=workspace)
     _ok(f"{workspace} 已初始化")
 
-    _print_completion(answers)
+    _print_completion(answers, workspace)
 
 
 # ---------------------------------------------------------------------------
@@ -795,10 +799,10 @@ async def _async_fetch_qqbot_openid(
 # Config 验证
 # ---------------------------------------------------------------------------
 
-def _validate_config(config_path: Path) -> None:
+def _validate_config(config_path: Path, workspace: Path) -> None:
     try:
         from agent.config import Config
-        _ = Config.load(config_path)
+        _ = Config.load(config_path, workspace=workspace)
         _ok("配置验证通过")
     except KeyError as e:
         _err(f"配置缺少必填字段：{e}")
@@ -1027,8 +1031,8 @@ def _render_qqbot_config(a: WizardAnswers) -> str:
     ])
 
 
-def _qqbot_local_config_path() -> Path:
-    return Path.home() / ".akashic-plugin" / "data" / "qqbot-github" / "config.local.toml"
+def _qqbot_local_config_path(workspace: Path) -> Path:
+    return workspace_plugin_data_dir(workspace, "qqbot", "github") / "config.local.toml"
 
 
 def _render_memory(a: WizardAnswers) -> str:
@@ -1053,8 +1057,8 @@ def _render_default_memory_config() -> str:
     return render_default_memory_config()
 
 
-def _default_memory_local_config_path() -> Path:
-    return builtin_plugin_data_dir("default_memory") / "config.local.toml"
+def _default_memory_local_config_path(workspace: Path) -> Path:
+    return builtin_plugin_data_dir("default_memory", workspace) / "config.local.toml"
 
 
 def _render_proactive(a: WizardAnswers) -> str:
@@ -1102,7 +1106,7 @@ def _render_integrations() -> str:
 # 完成提示
 # ---------------------------------------------------------------------------
 
-def _print_completion(a: WizardAnswers) -> None:
+def _print_completion(a: WizardAnswers, workspace: Path) -> None:
     click.echo(click.style("\n══ 配置完成 ══\n", bold=True))
     click.echo("启动 agent：")
     click.echo(click.style("  uv run python main.py", bold=True))
@@ -1113,7 +1117,7 @@ def _print_completion(a: WizardAnswers) -> None:
         if a.proactive_channel == "qqbot" or (not a.tg_token and a.qqbot_app_id):
             _hint("启动后向 bot 发任意消息，日志中会出现 user_openid")
             _hint("将其填入 config.toml：")
-            _hint("~/.akashic-plugin/data/qqbot-github/config.local.toml")
+            _hint(str(_qqbot_local_config_path(workspace)))
             _hint('allow_from = ["<user_openid>"]')
             _hint("[proactive.target]")
             _hint('channel = "qqbot"')
@@ -1131,5 +1135,5 @@ def _print_completion(a: WizardAnswers) -> None:
         click.echo()
         _warn("QQBot allow_from 为空，启动后所有私聊请求会被拒绝")
         _hint("向 bot 发一条消息，日志里找到 user_openid，填入 config.toml：")
-        _hint("~/.akashic-plugin/data/qqbot-github/config.local.toml")
+        _hint(str(_qqbot_local_config_path(workspace)))
         _hint('allow_from = ["<user_openid>"]')

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 from agent.config_models import Config
+from agent.plugins.manifest import plugins_root
 from agent.context import ContextBuilder
 from agent.peer_agent.process_manager import PeerProcessManager
 from agent.peer_agent.poller import PeerAgentPoller
@@ -666,4 +667,4 @@ def _resolve_plugin_dirs(workspace: Path) -> list[Path]:
 
 
 def _resolve_installed_plugin_cache_root() -> Path:
-    return Path.home() / ".akashic-plugin" / "cache"
+    return plugins_root() / "cache"

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,6 +4,10 @@
 # api_key 可以直接填字符串，也可以用 ${ENV_VAR} 引用环境变量。
 # =============================================================================
 
+[runtime]
+# 未传 --workspace 且未设置 AKASHIC_WORKSPACE 时使用；~ 会在启动时展开。
+workspace = "~/.akashic/workspace"
+
 [llm]
 main = "deepseek_main"
 fast = "qwen_fast"

--- a/config.example.toml
+++ b/config.example.toml
@@ -111,7 +111,7 @@ max_connections = 32
 ingress_queue_size = 128
 outbound_queue_size = 512
 
-# 插件配置位于 ~/.akashic-plugin/data/<插件名>-<市场>/config.local.toml。
+# 插件配置位于 <workspace>/plugin-data/<插件名>-<市场>/config.local.toml。
 
 # =============================================================================
 # 语义记忆

--- a/docker/debug/entrypoint.sh
+++ b/docker/debug/entrypoint.sh
@@ -50,12 +50,11 @@ PY
 ensure_sandbox_path "$CONFIG"
 ensure_sandbox_path "$WORKSPACE"
 ensure_sandbox_path "$SOCKET"
-mkdir -p /sandbox "$WORKSPACE" /sandbox/home/.akashic-plugin/data
+mkdir -p /sandbox "$WORKSPACE" /sandbox/home/.akashic-plugin
 chown "$HOST_UID:$HOST_GID" \
     /sandbox \
     /sandbox/home \
-    /sandbox/home/.akashic-plugin \
-    /sandbox/home/.akashic-plugin/data
+    /sandbox/home/.akashic-plugin
 chown -R "$HOST_UID:$HOST_GID" "$WORKSPACE"
 if [ -f "$WORKSPACE/replay/clock.json" ]; then
     export AKASHIC_REPLAY_CLOCK_FILE="$WORKSPACE/replay/clock.json"

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -118,7 +118,7 @@ def _mounted_tree_digest(root: Path, *, excluded_roots: set[Path] | None = None)
         names[:] = sorted(
             name
             for name in names
-            if name not in {".git", "__pycache__"}
+            if name not in {".codegraph", ".git", "__pycache__"}
             and (current / name).resolve() not in excluded
         )
         for name in sorted(files):
@@ -129,6 +129,8 @@ def _mounted_tree_digest(root: Path, *, excluded_roots: set[Path] | None = None)
             digest.update(os.fsencode(relative))
             if path.is_symlink():
                 digest.update(b"symlink\0" + os.fsencode(os.readlink(path)))
+                continue
+            if not path.is_file():
                 continue
             with path.open("rb") as file:
                 for chunk in iter(lambda: file.read(1024 * 1024), b""):
@@ -191,7 +193,11 @@ def _path_check(check_id: str, actual: Path, expected: Path) -> CheckResult:
 
 def _sandbox_integrity() -> GateResult:
     repositories = _repositories()
-    excluded = {Path("/app/static").resolve()}
+    excluded = {
+        Path("/app/docker/debug/profiles").resolve(),
+        Path("/app/logs").resolve(),
+        Path("/app/static").resolve(),
+    }
     before = {
         str(repo): _mounted_tree_digest(
             repo,
@@ -511,7 +517,7 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "HTTPServer(('127.0.0.1', 18766), Handler).serve_forever()\n",
         encoding="utf-8",
     )
-    return sandbox / "home/.akashic-plugin/data/scope_gate-gate/.kv.json"
+    return sandbox / "workspace/plugin-data/scope_gate-gate/.kv.json"
 
 
 def _install_fitbit_plugin(sandbox: Path, plugin_root: Path) -> Path:
@@ -522,12 +528,12 @@ def _install_fitbit_plugin(sandbox: Path, plugin_root: Path) -> Path:
         target,
         ignore=shutil.ignore_patterns(".git", ".venv", "__pycache__", ".pytest_cache"),
     )
-    return sandbox / "home/.akashic-plugin/data/fitbit-gate"
+    return sandbox / "workspace/plugin-data/fitbit-gate"
 
 
 def _install_management_plugin(sandbox: Path) -> tuple[Path, Path, Path]:
     cache = sandbox / "home/.akashic-plugin/cache/gate/management/1.0.0"
-    data = sandbox / "home/.akashic-plugin/data/management-gate"
+    data = sandbox / "workspace/plugin-data/management-gate"
     manifest = sandbox / "home/.akashic-plugin/manifest.toml"
     cache.mkdir(parents=True, exist_ok=True)
     data.mkdir(parents=True, exist_ok=True)
@@ -572,7 +578,7 @@ def _install_management_plugin(sandbox: Path) -> tuple[Path, Path, Path]:
 
 def _install_proactive_fetch_plugin(sandbox: Path) -> Path:
     cache = sandbox / "home/.akashic-plugin/cache/gate/proactive_fetch/1.0.0"
-    data = sandbox / "home/.akashic-plugin/data/proactive_fetch-gate"
+    data = sandbox / "workspace/plugin-data/proactive_fetch-gate"
     manifest = sandbox / "home/.akashic-plugin/manifest.toml"
     cache.mkdir(parents=True, exist_ok=True)
     data.mkdir(parents=True, exist_ok=True)
@@ -884,7 +890,7 @@ def _install_candidate_plugins(
         encoding="utf-8",
     )
     _ = reload_source.write_text(_candidate_reload_source("v1"), encoding="utf-8")
-    data = sandbox / "home/.akashic-plugin/data"
+    data = sandbox / "workspace/plugin-data"
     (data / "candidate_reload-gate").mkdir(parents=True, exist_ok=True)
     return (
         data / "candidate_valid-gate/.kv.json",
@@ -1224,7 +1230,7 @@ def _exercise_migrated_plugins(
         "SELECT count(*) FROM proactive_feedback_events",
     )
     driver_state = _read_json_object(
-        sandbox / "home/.akashic-plugin/data/zz_gate_driver-gate/.kv.json"
+        sandbox / "workspace/plugin-data/zz_gate_driver-gate/.kv.json"
     )
     raw_slots = driver_state.get("phase_slots", [])
     lifecycle_slots = (
@@ -1665,7 +1671,7 @@ def _exercise_topology_watch(
         encoding="utf-8",
     )
     added_state_path = (
-        sandbox / "home/.akashic-plugin/data/topology_added-gate/.kv.json"
+        sandbox / "workspace/plugin-data/topology_added-gate/.kv.json"
     )
     added_state: dict[str, object] = {}
     deadline = time.monotonic() + 10

--- a/docker/debug/proactive_sandbox.py
+++ b/docker/debug/proactive_sandbox.py
@@ -407,7 +407,7 @@ async def tick(
     model = "sandbox-model"
     max_tokens = 1024
     if config_path is not None:
-        app_config = Config.load(config_path)
+        app_config = Config.load(config_path, workspace=workspace)
         main_provider, _, _ = build_providers(app_config)
         provider = _build_proactive_provider(app_config, main_provider)
         proactive_config = app_config.proactive

--- a/docker/debug/run_consolidation_then_optimizer.py
+++ b/docker/debug/run_consolidation_then_optimizer.py
@@ -106,7 +106,7 @@ CONVERSATION: list[dict[str, str]] = [
 
 async def main(config_path: str, workspace_str: str) -> None:
     workspace = Path(workspace_str)
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     http_resources = SharedHttpResources()
     provider, light_provider, _ = build_providers(config)
     memory_runtime = build_memory_admin_runtime(

--- a/docker/debug/run_optimizer_once.py
+++ b/docker/debug/run_optimizer_once.py
@@ -23,7 +23,7 @@ from proactive_v2.memory_optimizer import MemoryOptimizer
 
 async def main(config_path: str, workspace_str: str) -> None:
     workspace = Path(workspace_str)
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     http_resources = SharedHttpResources()
     provider, _, _ = build_providers(config)
     memory_runtime = build_memory_admin_runtime(

--- a/docker/debug/runtime_race_probe.py
+++ b/docker/debug/runtime_race_probe.py
@@ -258,13 +258,13 @@ class RaceHarness:
                 ),
                 encoding="utf-8",
             )
-        return Config.load(self.config_path)
+        return Config.load(self.config_path, workspace=self.workspace)
 
     def load_repo_config(self) -> Config:
         path = self.config_path if self._config_explicit else Path.cwd() / "config.toml"
         if not path.exists():
             raise AssertionError(f"config.toml not found: {path}")
-        return Config.load(path)
+        return Config.load(path, workspace=self.workspace)
 
     def register_runtime_channel(
         self,

--- a/docker/debug/tool_search_unlock_probe.py
+++ b/docker/debug/tool_search_unlock_probe.py
@@ -78,7 +78,7 @@ async def _run(args: argparse.Namespace) -> None:
     profile_dir = _profile_dir(args.profile)
     config_path = args.config or profile_dir / "config.toml"
     workspace = args.workspace or profile_dir / "workspace"
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     if config.model != "mimo-v2.5":
         raise SystemExit(f"主模型必须是 mimo-v2.5，当前是 {config.model!r}")
     if config.light_model != "qwen-flash":

--- a/eval/longmemeval/run.py
+++ b/eval/longmemeval/run.py
@@ -388,7 +388,7 @@ async def _run(args: argparse.Namespace) -> None:
     base_workspace = args.workspace
     base_workspace.mkdir(parents=True, exist_ok=True)
 
-    bench_config = load_config(args.config)
+    bench_config = load_config(args.config, workspace=base_workspace)
     judge_model = bench_config.model
 
     console = Console()

--- a/eval/longmemeval/run_one_qa.py
+++ b/eval/longmemeval/run_one_qa.py
@@ -32,7 +32,7 @@ async def _run(args: argparse.Namespace) -> None:
     rt = await create_runtime(args.config, args.workspace)
     try:
         result = await run_qa_instance(rt, inst, timeout_s=args.timeout)
-        cfg = load_config(args.config)
+        cfg = load_config(args.config, workspace=args.workspace)
         result["judge_correct"] = await judge_answer(
             rt.core.provider,
             cfg.model,

--- a/eval/longmemeval/runtime.py
+++ b/eval/longmemeval/runtime.py
@@ -80,7 +80,7 @@ async def create_runtime(config_path: Path, workspace: Path) -> BenchmarkRuntime
     from core.net.http import SharedHttpResources
     from memory2.profile_extractor import ProfileFactExtractor
 
-    config = load_config(config_path)
+    config = load_config(config_path, workspace=workspace)
 
     # 1. Initialise workspace files (empty memory/SELF.md etc.).
     #    force=False so repeated calls on same workspace are idempotent.

--- a/infra/channels/base.py
+++ b/infra/channels/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from collections import deque
 from pathlib import Path
@@ -9,42 +8,24 @@ from uuid import uuid4
 
 from session.manager import SessionManager
 
-_DEFAULT_UPLOAD_DIR = Path.home() / ".akashic" / "workspace" / "uploads"
 _MISSING_METADATA = object()
-logger = logging.getLogger(__name__)
 
 
 class AttachmentStore:
     """为 channel 媒体文件提供统一的持久化落盘目录。"""
 
-    def __init__(self, root: Path | None = None) -> None:
-        self.root = root or _DEFAULT_UPLOAD_DIR
+    def __init__(self, root: Path) -> None:
+        self.root = root
 
     def _resolve_root(self) -> Path:
-        reason = "目录不可写"
-        try:
-            self.root.mkdir(parents=True, exist_ok=True)
-            if os.access(self.root, os.W_OK):
-                return self.root
-        except OSError as error:
-            reason = str(error)
-        fallback = Path("/tmp/akashic_uploads")
-        fallback.mkdir(parents=True, exist_ok=True)
-        if os.access(fallback, os.W_OK):
-            logger.warning(
-                "附件目录不可用，使用降级目录 path=%s fallback=%s reason=%s",
-                self.root,
-                fallback,
-                reason,
-            )
-            return fallback
-        try:
-            test = fallback / ".write_test"
-            test.write_text("", encoding="utf-8")
-            test.unlink(missing_ok=True)
-            return fallback
-        except OSError:
-            return self.root
+        if self.root.is_symlink():
+            raise ValueError(f"附件目录不能是符号链接: {self.root}")
+        self.root.mkdir(parents=True, exist_ok=True)
+        if self.root.is_symlink():
+            raise ValueError(f"附件目录不能是符号链接: {self.root}")
+        if not os.access(self.root, os.W_OK):
+            raise PermissionError(f"附件目录不可写: {self.root}")
+        return self.root
 
     def create_path(self, prefix: str, suffix: str) -> Path:
         root = self._resolve_root()
@@ -52,21 +33,8 @@ class AttachmentStore:
 
     def write_bytes(self, data: bytes, *, prefix: str, suffix: str) -> Path:
         path = self.create_path(prefix, suffix)
-        try:
-            path.write_bytes(data)
-            return path
-        except OSError as error:
-            fallback = Path("/tmp/akashic_uploads")
-            fallback.mkdir(parents=True, exist_ok=True)
-            alt = fallback / f"{prefix}{uuid4().hex}{suffix}"
-            logger.warning(
-                "附件写入失败，使用降级目录 path=%s fallback=%s reason=%s",
-                path,
-                fallback,
-                error,
-            )
-            alt.write_bytes(data)
-            return alt
+        path.write_bytes(data)
+        return path
 
 
 class SessionIdentityIndex:

--- a/infra/channels/qq_channel.py
+++ b/infra/channels/qq_channel.py
@@ -256,13 +256,12 @@ def _extract_cq_images(raw: str) -> tuple[str, list[str]]:
 async def _download_to_temp(
     urls: list[str],
     requester: HttpRequester,
-    attachments: AttachmentStore | None = None,
+    attachments: AttachmentStore,
 ) -> list[str]:
     """下载图片到临时文件，返回本地路径列表"""
     if not urls:
         return []
     paths: list[str] = []
-    attachment_store = attachments or AttachmentStore()
     ext_map = {
         "image/jpeg": ".jpg",
         "image/png": ".png",
@@ -281,7 +280,7 @@ async def _download_to_temp(
             resp.raise_for_status()
             ct = resp.headers.get("content-type", "image/jpeg").split(";")[0].strip()
             ext = ext_map.get(ct, ".jpg")
-            path = attachment_store.write_bytes(
+            path = attachments.write_bytes(
                 resp.content,
                 prefix="akashic_qq_",
                 suffix=ext,
@@ -318,9 +317,8 @@ class QQChannel:
         self._allow_from: set[str] = set(allowed_users)
         self._websocket_open_timeout_seconds = float(websocket_open_timeout_seconds)
         self._interrupt_controller = interrupt_controller
-        ws = getattr(session_manager, "workspace", None)
-        self._workspace = Path(ws) if ws else None
-        self._attachments = AttachmentStore(Path(ws) / "uploads" if ws else None)
+        self._workspace = session_manager.workspace
+        self._attachments = AttachmentStore(session_manager.workspace / "uploads")
         self._trace_actor_name_cache: str | None = None
         self._identity_index = SessionIdentityIndex(
             session_manager,

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -88,8 +88,7 @@ class TelegramChannel:
         self.name = channel_name
         self._allow_from: set[str] = set(allow_from) if allow_from else set()
         self._message_deduper = MessageDeduper(_SEEN_MSG_MAXSIZE)
-        ws = getattr(session_manager, "workspace", None)
-        self._attachments = AttachmentStore(Path(ws) / "uploads" if ws else None)
+        self._attachments = AttachmentStore(session_manager.workspace / "uploads")
         self._identity_index = SessionIdentityIndex(
             session_manager,
             channel=channel_name,

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -27,7 +27,7 @@ class WebChatChannel:
     def __init__(self, channel_name: str = "web") -> None:
         self.name = channel_name
         self._ctx: ChannelContext | None = None
-        self._attachments = AttachmentStore()
+        self._attachments: AttachmentStore | None = None
         self._connections: dict[str, set[WebSocket]] = {}
         self._active_turn_ids: dict[str, str] = {}
         self._media_paths: set[str] = set()
@@ -54,6 +54,12 @@ class WebChatChannel:
             file=self.send_file,
             image=self.send_image,
         )
+
+    def bind_attachment_store(self, store: AttachmentStore) -> None:
+        """在 channel 启动前为独立 Chat API 绑定显式附件目录。"""
+
+        if self._attachments is None:
+            self._attachments = store
 
     async def stop(self) -> None:
         async with self._connection_lock:
@@ -92,7 +98,11 @@ class WebChatChannel:
         if not suffix:
             guessed = mimetypes.guess_extension(mimetypes.guess_type(filename)[0] or "")
             suffix = guessed or ".bin"
-        path = self._attachments.write_bytes(data, prefix="web_", suffix=suffix)
+        path = self._require_attachment_store().write_bytes(
+            data,
+            prefix="web_",
+            suffix=suffix,
+        )
         return {
             "filename": filename,
             "upload_path": str(path),
@@ -100,10 +110,12 @@ class WebChatChannel:
         }
 
     def upload_roots(self) -> list[Path]:
-        return [
-            self._attachments.root,
-            Path("/tmp") / "akashic_uploads",
-        ]
+        return [self._require_attachment_store().root]
+
+    def _require_attachment_store(self) -> AttachmentStore:
+        if self._attachments is None:
+            raise RuntimeError("WebChatChannel 尚未绑定附件目录")
+        return self._attachments
 
     def remember_media(self, paths: list[str]) -> None:
         for path in paths:

--- a/main.py
+++ b/main.py
@@ -12,10 +12,27 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import signal
 import sys
 from contextlib import suppress
 from pathlib import Path
+
+
+def _workspace_from_args(args: list[str]) -> Path:
+    """解析显式 workspace，缺失时直接拒绝运行。"""
+
+    if "--workspace" in args:
+        index = args.index("--workspace")
+        if index + 1 >= len(args):
+            raise ValueError("参数 --workspace 缺少值")
+        value = args[index + 1]
+    else:
+        value = os.environ.get("AKASHIC_WORKSPACE", "")
+    value = value.strip()
+    if not value:
+        raise ValueError("缺少 --workspace PATH（或 AKASHIC_WORKSPACE）")
+    return Path(value).expanduser().resolve()
 
 
 def _run_lightweight_setup_command() -> bool:
@@ -29,12 +46,16 @@ def _run_lightweight_setup_command() -> bool:
         if index + 1 >= len(args):
             raise SystemExit("参数 --config 缺少值")
         config_path = args[index + 1]
+    try:
+        workspace = _workspace_from_args(args)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     import click
 
     from bootstrap.setup_main import run_main_model_setup
 
     try:
-        run_main_model_setup(Path(config_path))
+        run_main_model_setup(Path(config_path), workspace)
     except click.ClickException as exc:
         exc.show()
         raise SystemExit(exc.exit_code) from exc
@@ -89,15 +110,11 @@ _HELP = """\
 
 通用选项:
   --config PATH                 配置文件，默认 config.toml
-  --workspace PATH              工作区，默认 ~/.akashic/workspace
+  --workspace PATH              工作区；也可设置 AKASHIC_WORKSPACE
   -h, --help                    显示帮助
 
 无命令时启动 Agent 服务。
 """
-
-
-def _default_workspace() -> Path:
-    return Path.home() / ".akashic" / "workspace"
 
 
 def _get_flag_value(args: list[str], flag: str) -> str | None:
@@ -154,18 +171,16 @@ def _parse_csv_flag(value: str | None) -> list[str]:
 def _wait_plugin_disabled(
     config_path: str,
     plugin_id: str,
-    workspace: Path | None = None,
+    workspace: Path,
 ) -> None:
     if not Path(config_path).is_file():
         return
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     endpoint = resolve_app_server_endpoint(
         config.app_server.listen,
-        workspace or _default_workspace(),
+        workspace,
     )
-    asyncio.run(
-        _request_plugin_drain(endpoint, plugin_id, workspace or _default_workspace())
-    )
+    asyncio.run(_request_plugin_drain(endpoint, plugin_id, workspace))
 
 
 async def _request_plugin_drain(
@@ -212,7 +227,7 @@ async def run_exec(args: list[str], config_path: str, workspace: Path) -> int:
         raise ValueError("exec 的 --json 与 --final-only 不能同时使用")
     endpoint = _get_flag_value(args, "--endpoint")
     if endpoint is None:
-        config = Config.load(config_path)
+        config = Config.load(config_path, workspace=workspace)
         endpoint = resolve_app_server_endpoint(config.app_server.listen, workspace)
 
     # 2. turn events 与最终文本严格按选定 stdout 模式输出。
@@ -289,20 +304,17 @@ async def run_exec(args: list[str], config_path: str, workspace: Path) -> int:
         return 1
 
 
-async def inspect_modules(
-    config_path: str = "config.toml",
-    workspace: Path | None = None,
-) -> None:
+async def inspect_modules(config_path: str, workspace: Path) -> None:
     import logging
     from bootstrap.cleanup import run_cleanup_steps
     from bootstrap.tools import build_core_runtime
 
     logging.getLogger().setLevel(logging.WARNING)
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     http_resources = SharedHttpResources()
     runtime = build_core_runtime(
         config,
-        workspace or _default_workspace(),
+        workspace,
         http_resources,
     )
     try:
@@ -315,12 +327,8 @@ async def inspect_modules(
         )
 
 
-async def serve(
-    config_path: str = "config.toml",
-    workspace: Path | None = None,
-) -> int:
-    config = Config.load(config_path)
-    workspace = workspace or _default_workspace()
+async def serve(config_path: str, workspace: Path) -> int:
+    config = Config.load(config_path, workspace=workspace)
     commit_channel = SupervisorCommitChannel.from_environment()
     restart_coordinator = (
         RestartCoordinator(
@@ -406,14 +414,14 @@ if __name__ == "__main__":
         print(_HELP)
         sys.exit(0)
     config_path = "config.toml"
-    workspace: Path | None = None
+    workspace: Path
     force = "--force" in args
     dashboard_host = "0.0.0.0"
     dashboard_port = 2236
 
     try:
         config_value = _get_flag_value(args, "--config")
-        workspace_value = _get_flag_value(args, "--workspace")
+        workspace = _workspace_from_args(args)
         host_value = _get_flag_value(args, "--host")
         port_value = _get_flag_value(args, "--port")
         source_value = _get_flag_value(args, "--source")
@@ -424,10 +432,9 @@ if __name__ == "__main__":
         print(str(exc))
         sys.exit(1)
 
+    os.environ["AKASHIC_WORKSPACE"] = str(workspace)
     if config_value is not None:
         config_path = config_value
-    if workspace_value is not None:
-        workspace = Path(workspace_value)
     if host_value is not None:
         dashboard_host = host_value
     if port_value is not None:
@@ -437,20 +444,20 @@ if __name__ == "__main__":
         from bootstrap.setup_wizard import run_setup_wizard
         run_setup_wizard(
             config_path=Path(config_path),
-            workspace=workspace or _default_workspace(),
+            workspace=workspace,
         )
         sys.exit(0)
 
     if args and args[0] == "setup-main":
         from bootstrap.setup_main import run_main_model_setup
 
-        run_main_model_setup(Path(config_path))
+        run_main_model_setup(Path(config_path), workspace)
         sys.exit(0)
 
     if args and args[0] == "init":
         summary = init_workspace(
             config_path=config_path,
-            workspace=workspace or _default_workspace(),
+            workspace=workspace,
             force=force,
         )
         _print_init_summary(summary)
@@ -462,6 +469,7 @@ if __name__ == "__main__":
             sys.exit(1)
         marketplace = marketplace_value or "local"
         result = install_git_plugin(
+            workspace=workspace,
             source=source_value,
             marketplace=marketplace,
             ref_name=ref_value or "",
@@ -496,6 +504,7 @@ if __name__ == "__main__":
         try:
             cache_path, data_path = uninstall_plugin(
                 plugin_id,
+                workspace=workspace,
                 wait_until_disabled=lambda target: _wait_plugin_disabled(
                     config_path,
                     target,
@@ -517,7 +526,7 @@ if __name__ == "__main__":
         report = run_plugin_doctor(
             plugin_id=target_plugin_id,
             config_path=config_path,
-            workspace=workspace or _default_workspace(),
+            workspace=workspace,
         )
         if "--json" in args:
             print(json.dumps(report, ensure_ascii=False, indent=2))
@@ -534,7 +543,7 @@ if __name__ == "__main__":
         sys.exit(
             run_supervisor(
                 config_path=Path(config_path),
-                workspace=workspace or _default_workspace(),
+                workspace=workspace,
             )
         )
 
@@ -547,14 +556,14 @@ if __name__ == "__main__":
             sys.exit(2)
         from bootstrap.app_server import run_stdio_app_server
 
-        config = Config.load(config_path)
-        asyncio.run(run_stdio_app_server(config, workspace or _default_workspace()))
+        config = Config.load(config_path, workspace=workspace)
+        asyncio.run(run_stdio_app_server(config, workspace))
         sys.exit(0)
 
     if args and args[0] == "exec":
         try:
             exit_code = asyncio.run(
-                run_exec(args, config_path, workspace or _default_workspace())
+                run_exec(args, config_path, workspace)
             )
         except (ValueError, ConnectionError, OSError, RemoteControlError) as exc:
             print(str(exc), file=sys.stderr)
@@ -562,8 +571,8 @@ if __name__ == "__main__":
         sys.exit(exit_code)
 
     if args and args[0] == "dashboard":
-        config = Config.load(config_path)
-        dashboard_workspace = workspace or _default_workspace()
+        config = Config.load(config_path, workspace=workspace)
+        dashboard_workspace = workspace
         http_resources = SharedHttpResources()
         provider, light_provider, _ = build_providers(config)
         memory_runtime = build_memory_admin_runtime(

--- a/main.py
+++ b/main.py
@@ -15,13 +15,38 @@ import json
 import os
 import signal
 import sys
+import tomllib
 from contextlib import suppress
 from pathlib import Path
+from typing import cast
 
 
-def _workspace_from_args(args: list[str]) -> Path:
-    """解析显式 workspace，缺失时直接拒绝运行。"""
+_DEFAULT_WORKSPACE = "~/.akashic/workspace"
 
+
+def _workspace_from_config(config_path: Path) -> str:
+    """从主配置读取 workspace，并拒绝缺失或错误的边界值。"""
+
+    with config_path.open("rb") as stream:
+        data = tomllib.load(stream)
+    runtime: object = data.get("runtime")
+    if not isinstance(runtime, dict):
+        raise ValueError(f"配置文件 {config_path!s} 缺少 [runtime] table")
+    workspace: object = cast(dict[str, object], runtime).get("workspace")
+    if not isinstance(workspace, str) or not workspace.strip():
+        raise ValueError(f"配置文件 {config_path!s} 缺少 runtime.workspace")
+    return workspace
+
+
+def _workspace_from_args(
+    args: list[str],
+    config_path: Path,
+    *,
+    allow_default: bool = False,
+) -> Path:
+    """按命令行、环境变量、配置文件的顺序解析 workspace。"""
+
+    # 1. 显式启动参数拥有最高优先级
     if "--workspace" in args:
         index = args.index("--workspace")
         if index + 1 >= len(args):
@@ -29,9 +54,18 @@ def _workspace_from_args(args: list[str]) -> Path:
         value = args[index + 1]
     else:
         value = os.environ.get("AKASHIC_WORKSPACE", "")
+
+    # 2. 环境变量为空时读取 config.toml；首次初始化使用可移植默认值
+    if not value.strip():
+        if config_path.exists():
+            value = _workspace_from_config(config_path)
+        elif allow_default:
+            value = _DEFAULT_WORKSPACE
+        else:
+            raise ValueError(
+                f"找不到配置文件 {config_path!s}，且未指定 --workspace PATH"
+            )
     value = value.strip()
-    if not value:
-        raise ValueError("缺少 --workspace PATH（或 AKASHIC_WORKSPACE）")
     return Path(value).expanduser().resolve()
 
 
@@ -47,7 +81,7 @@ def _run_lightweight_setup_command() -> bool:
             raise SystemExit("参数 --config 缺少值")
         config_path = args[index + 1]
     try:
-        workspace = _workspace_from_args(args)
+        workspace = _workspace_from_args(args, Path(config_path))
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     import click
@@ -110,7 +144,7 @@ _HELP = """\
 
 通用选项:
   --config PATH                 配置文件，默认 config.toml
-  --workspace PATH              工作区；也可设置 AKASHIC_WORKSPACE
+  --workspace PATH              覆盖 config.toml 中的 runtime.workspace
   -h, --help                    显示帮助
 
 无命令时启动 Agent 服务。
@@ -421,7 +455,14 @@ if __name__ == "__main__":
 
     try:
         config_value = _get_flag_value(args, "--config")
-        workspace = _workspace_from_args(args)
+        if config_value is not None:
+            config_path = config_value
+        bootstrap_command = bool(args and args[0] in {"setup", "init"})
+        workspace = _workspace_from_args(
+            args,
+            Path(config_path),
+            allow_default=bootstrap_command,
+        )
         host_value = _get_flag_value(args, "--host")
         port_value = _get_flag_value(args, "--port")
         source_value = _get_flag_value(args, "--source")
@@ -433,8 +474,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     os.environ["AKASHIC_WORKSPACE"] = str(workspace)
-    if config_value is not None:
-        config_path = config_value
     if host_value is not None:
         dashboard_host = host_value
     if port_value is not None:

--- a/plugins/akasha/config.py
+++ b/plugins/akasha/config.py
@@ -6,7 +6,10 @@ from math import isfinite
 from pathlib import Path
 from typing import cast
 
-from agent.plugins.manifest import builtin_plugin_data_dir
+from agent.plugins.manifest import (
+    builtin_plugin_data_dir,
+    ensure_workspace_plugin_data_dir,
+)
 from infra.persistence.json_store import atomic_write_text
 
 
@@ -27,10 +30,11 @@ class AkashaConfig:
 # 读取 Akasha 插件配置文件。
 def load_akasha_config(
     *,
+    workspace: Path | None = None,
     plugin_dir: Path | None = None,
 ) -> AkashaConfig:
     # 1. 读取插件目录下的本地配置。
-    root = plugin_dir or builtin_plugin_data_dir("akasha")
+    root = _config_root(workspace=workspace, plugin_dir=plugin_dir)
     payload = _read_toml(root / "config.local.toml")
 
     # 2. 把 TOML 字段收敛成强类型配置。
@@ -67,17 +71,22 @@ def render_akasha_config(config: AkashaConfig | None = None) -> str:
     ])
 
 
-def ensure_akasha_config_file(*, plugin_dir: Path | None = None) -> Path:
+def ensure_akasha_config_file(
+    *,
+    workspace: Path | None = None,
+    plugin_dir: Path | None = None,
+) -> Path:
     """迁移或创建 Akasha 的用户配置。"""
 
     # 1. 已有用户配置直接复用
-    root = plugin_dir or builtin_plugin_data_dir("akasha")
+    root = _config_root(workspace=workspace, plugin_dir=plugin_dir)
+    if plugin_dir is None:
+        ensure_workspace_plugin_data_dir(root, cast(Path, workspace))
     path = root / "config.local.toml"
     if path.exists():
         return path
 
     # 2. 首次迁移保留旧目录配置，否则写入默认配置
-    root.mkdir(parents=True, exist_ok=True)
     legacy_path = Path(__file__).resolve().parent / "config.local.toml"
     content = (
         legacy_path.read_text(encoding="utf-8")
@@ -88,19 +97,27 @@ def ensure_akasha_config_file(*, plugin_dir: Path | None = None) -> Path:
     return path
 
 
+def _config_root(*, workspace: Path | None, plugin_dir: Path | None) -> Path:
+    if plugin_dir is not None:
+        return plugin_dir
+    if workspace is None:
+        raise RuntimeError("Akasha 配置缺少 workspace")
+    return builtin_plugin_data_dir("akasha", workspace)
+
+
 # 解析 Akasha sidecar 数据库路径。
 def resolve_akasha_db_path(
     *,
     workspace: Path,
     akasha_config: AkashaConfig,
 ) -> Path:
-    # 1. 默认落在 workspace/memory/akasha.db。
-    if not akasha_config.db_path:
-        return workspace / "memory" / "akasha.db"
-
-    # 2. 相对路径以 workspace 为根，绝对路径原样使用。
-    path = Path(akasha_config.db_path)
-    return path if path.is_absolute() else workspace / path
+    # 1. 默认路径和显式路径都必须归属于当前 workspace。
+    root = workspace.resolve(strict=False)
+    configured = akasha_config.db_path or "memory/akasha.db"
+    path = (root / configured).resolve(strict=False)
+    if not path.is_relative_to(root):
+        raise ValueError(f"akasha.db_path 必须位于 workspace 内: {configured}")
+    return path
 
 
 # 读取 TOML 文件为普通 dict。

--- a/plugins/akasha/dashboard.py
+++ b/plugins/akasha/dashboard.py
@@ -404,7 +404,7 @@ class AkashaGraphReader:
 
 
 def register(app: FastAPI, _plugin_dir: Path, workspace: Path) -> list[object]:
-    akasha_config = load_akasha_config()
+    akasha_config = load_akasha_config(workspace=workspace)
     akasha_db_path = resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config)
     store = AkashaStore(akasha_db_path)
     reader = AkashaInspectorReader(store)

--- a/plugins/akasha/memory_plugin.py
+++ b/plugins/akasha/memory_plugin.py
@@ -24,8 +24,8 @@ class MemoryPlugin:
     ) -> list[tuple[Path, bool]]:
         # 1. 确保插件配置存在，并按配置解析数据库路径。
         _ = config
-        _ = ensure_akasha_config_file()
-        akasha_config = load_akasha_config()
+        _ = ensure_akasha_config_file(workspace=workspace)
+        akasha_config = load_akasha_config(workspace=workspace)
         db_path = resolve_akasha_db_path(
             workspace=workspace,
             akasha_config=akasha_config,
@@ -45,8 +45,8 @@ class MemoryPlugin:
         deps: MemoryPluginBuildDeps,
     ) -> MemoryPluginRuntime:
         # 1. Akasha 是独立 memory engine，不继承 default_memory 的 store/retriever。
-        _ = ensure_akasha_config_file()
-        akasha_config = load_akasha_config()
+        _ = ensure_akasha_config_file(workspace=deps.workspace)
+        akasha_config = load_akasha_config(workspace=deps.workspace)
         engine = AkashaMemoryEngine(
             config=deps.config,
             akasha_config=akasha_config,

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -60,10 +60,13 @@ class AkashaPlugin(Plugin):
         workspace = self.context.workspace
         if workspace is None:
             return "Akasha 诊断不可用：workspace 不存在。"
+        data_dir = self.context.data_dir
+        if data_dir is None:
+            return "Akasha 诊断不可用：插件数据目录不存在。"
         store = AkashaStore(
             resolve_akasha_db_path(
                 workspace=workspace,
-                akasha_config=load_akasha_config(),
+                akasha_config=load_akasha_config(plugin_dir=data_dir),
             )
         )
         try:
@@ -81,7 +84,6 @@ class AkashaPlugin(Plugin):
         if raw is None:
             return "暂无 Akasha 检索诊断记录。"
         return _render_query_detail(raw)
-
 
 def _render_query_detail(raw: dict[str, object]) -> str:
     activation_items = _json_items(raw.get("activation_items_json"))

--- a/plugins/default_memory/config.py
+++ b/plugins/default_memory/config.py
@@ -6,7 +6,10 @@ from math import isfinite
 from pathlib import Path
 from typing import cast
 
-from agent.plugins.manifest import builtin_plugin_data_dir
+from agent.plugins.manifest import (
+    builtin_plugin_data_dir,
+    ensure_workspace_plugin_data_dir,
+)
 from infra.persistence.json_store import atomic_write_text
 
 
@@ -47,9 +50,10 @@ class DefaultMemoryConfig:
 
 def load_default_memory_config(
     *,
+    workspace: Path | None = None,
     plugin_dir: Path | None = None,
 ) -> DefaultMemoryConfig:
-    root = plugin_dir or builtin_plugin_data_dir("default_memory")
+    root = _config_root(workspace=workspace, plugin_dir=plugin_dir)
     payload = _read_toml(root / "config.local.toml")
     return _build_config(payload)
 
@@ -82,17 +86,22 @@ def render_default_memory_config(config: DefaultMemoryConfig | None = None) -> s
     ])
 
 
-def ensure_default_memory_config_file(*, plugin_dir: Path | None = None) -> Path:
+def ensure_default_memory_config_file(
+    *,
+    workspace: Path | None = None,
+    plugin_dir: Path | None = None,
+) -> Path:
     """迁移或创建 default memory 的用户配置。"""
 
     # 1. 已有用户配置直接复用
-    root = plugin_dir or builtin_plugin_data_dir("default_memory")
+    root = _config_root(workspace=workspace, plugin_dir=plugin_dir)
+    if plugin_dir is None:
+        ensure_workspace_plugin_data_dir(root, cast(Path, workspace))
     path = root / "config.local.toml"
     if path.exists():
         return path
 
     # 2. 首次迁移保留旧目录配置，否则写入默认配置
-    root.mkdir(parents=True, exist_ok=True)
     legacy_path = Path(__file__).resolve().parent / "config.local.toml"
     content = (
         legacy_path.read_text(encoding="utf-8")
@@ -103,15 +112,25 @@ def ensure_default_memory_config_file(*, plugin_dir: Path | None = None) -> Path
     return path
 
 
+def _config_root(*, workspace: Path | None, plugin_dir: Path | None) -> Path:
+    if plugin_dir is not None:
+        return plugin_dir
+    if workspace is None:
+        raise RuntimeError("default_memory 配置缺少 workspace")
+    return builtin_plugin_data_dir("default_memory", workspace)
+
+
 def resolve_memory_db_path(
     *,
     workspace: Path,
     default_config: DefaultMemoryConfig,
 ) -> Path:
-    if not default_config.db_path:
-        return workspace / "memory" / "memory2.db"
-    path = Path(default_config.db_path)
-    return path if path.is_absolute() else workspace / path
+    root = workspace.resolve(strict=False)
+    configured = default_config.db_path or "memory/memory2.db"
+    path = (root / configured).resolve(strict=False)
+    if not path.is_relative_to(root):
+        raise ValueError(f"default_memory.db_path 必须位于 workspace 内: {configured}")
+    return path
 
 
 def _build_config(payload: dict[str, object]) -> DefaultMemoryConfig:

--- a/plugins/default_memory/memory_plugin.py
+++ b/plugins/default_memory/memory_plugin.py
@@ -24,8 +24,8 @@ class MemoryPlugin:
         config: Config,
         workspace: Path,
     ) -> list[tuple[Path, bool]]:
-        _ = ensure_default_memory_config_file()
-        default_config = load_default_memory_config()
+        _ = ensure_default_memory_config_file(workspace=workspace)
+        default_config = load_default_memory_config(workspace=workspace)
         db_path = resolve_memory_db_path(
             workspace=workspace,
             default_config=default_config,
@@ -42,8 +42,8 @@ class MemoryPlugin:
         self,
         deps: MemoryPluginBuildDeps,
     ) -> MemoryPluginRuntime:
-        _ = ensure_default_memory_config_file()
-        default_config = load_default_memory_config()
+        _ = ensure_default_memory_config_file(workspace=deps.workspace)
+        default_config = load_default_memory_config(workspace=deps.workspace)
         engine = DefaultMemoryEngine(
             config=deps.config,
             default_config=default_config,

--- a/scripts/build_akasha_db.py
+++ b/scripts/build_akasha_db.py
@@ -63,7 +63,8 @@ def _parse_args() -> argparse.Namespace:
     _ = parser.add_argument("--config", default="config.toml", help="主配置文件路径")
     _ = parser.add_argument(
         "--workspace",
-        default=str(Path.home() / ".akashic" / "workspace"),
+        type=Path,
+        required=True,
         help="Akashic workspace 路径",
     )
     _ = parser.add_argument("--sessions-db", default="", help="原始 sessions.db 路径")
@@ -80,10 +81,11 @@ def _parse_args() -> argparse.Namespace:
 # 构造 Akasha 配置，并允许命令行覆盖 db_path。
 def _load_script_config(
     *,
+    workspace: Path,
     db_path: str,
 ) -> AkashaConfig:
-    # 1. 插件配置仍从 plugins/akasha/config.local.toml 读取。
-    config = load_akasha_config()
+    # 1. 插件配置始终从目标 workspace 的 runtime 数据目录读取。
+    config = load_akasha_config(workspace=workspace)
     if db_path.strip():
         return replace(config, db_path=db_path)
     return config
@@ -268,7 +270,10 @@ def _run() -> MigrationStats:
     args = _parse_args()
     workspace = Path(str(args.workspace)).expanduser()
     sessions_db = Path(str(args.sessions_db)).expanduser() if args.sessions_db else workspace / "sessions.db"
-    akasha_config = _load_script_config(db_path=str(args.db_path or ""))
+    akasha_config = _load_script_config(
+        workspace=workspace,
+        db_path=str(args.db_path or ""),
+    )
     db_path = resolve_akasha_db_path(workspace=workspace, akasha_config=akasha_config)
     if not sessions_db.exists():
         raise FileNotFoundError(f"sessions.db 不存在: {sessions_db}")
@@ -281,7 +286,7 @@ def _run() -> MigrationStats:
     if str(args.embedding_model).strip():
         embedding_model = str(args.embedding_model).strip()  # 离线重建：免读 config
     else:
-        config = Config.load(str(args.config))
+        config = Config.load(str(args.config), workspace=workspace)
         embedding_model = config.memory.embedding.model
     run_id = store.start_migration_run(
         source_db_path=sessions_db,

--- a/scripts/build_fts_idf.py
+++ b/scripts/build_fts_idf.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import argparse
 import math
 import sqlite3
 import sys
@@ -11,10 +12,6 @@ from collections import defaultdict
 from pathlib import Path
 
 import jieba
-
-AKASHA_DB = Path.home() / ".akashic" / "workspace" / "memory" / "akasha.db"
-SESSIONS_DB = Path.home() / ".akashic" / "workspace" / "sessions.db"
-
 
 def tokenize(text: str) -> set[str]:
     out: set[str] = set()
@@ -29,12 +26,17 @@ def tokenize(text: str) -> set[str]:
 
 
 def main() -> None:
-    if not AKASHA_DB.exists():
-        print(f"❌ {AKASHA_DB} 不存在"); sys.exit(1)
-    if not SESSIONS_DB.exists():
-        print(f"❌ {SESSIONS_DB} 不存在"); sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, required=True)
+    args = parser.parse_args()
+    akasha_db = args.workspace / "memory" / "akasha.db"
+    sessions_db = args.workspace / "sessions.db"
+    if not akasha_db.exists():
+        print(f"❌ {akasha_db} 不存在"); sys.exit(1)
+    if not sessions_db.exists():
+        print(f"❌ {sessions_db} 不存在"); sys.exit(1)
 
-    sconn = sqlite3.connect(SESSIONS_DB)
+    sconn = sqlite3.connect(sessions_db)
     cur = sconn.cursor()
     print("[scan] messages ...")
     df: dict[str, int] = defaultdict(int)
@@ -53,7 +55,7 @@ def main() -> None:
         idf[tok] = math.log((n_docs + 1) / (freq + 1)) + 1
 
     # 写入 akasha.db
-    aconn = sqlite3.connect(AKASHA_DB)
+    aconn = sqlite3.connect(akasha_db)
     aconn.execute("""
         CREATE TABLE IF NOT EXISTS fts_token_idf (
             token TEXT PRIMARY KEY,

--- a/scripts/cleanup_internal_user_markers.py
+++ b/scripts/cleanup_internal_user_markers.py
@@ -11,7 +11,7 @@ def main() -> None:
     _ = parser.add_argument(
         "--workspace",
         type=Path,
-        default=Path.home() / ".akashic" / "workspace",
+        required=True,
     )
     _ = parser.add_argument("--apply", action="store_true")
     args = parser.parse_args()

--- a/scripts/migrate_plugin_data.py
+++ b/scripts/migrate_plugin_data.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""把旧全局插件数据复制到显式 workspace，并保留原目录。"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sqlite3
+import uuid
+from contextlib import closing
+from pathlib import Path
+
+from agent.plugins.manifest import (
+    ensure_workspace_plugin_data_dir,
+    validate_workspace_plugin_data_path,
+)
+from bootstrap.workspace_lock import WorkspaceInstanceLock
+
+
+_SQLITE_SUFFIXES = {".db", ".sqlite", ".sqlite3"}
+
+
+def _copy_sqlite(source: Path, destination: Path) -> None:
+    """使用 SQLite 在线备份生成一致副本并立即校验。"""
+
+    source_uri = f"file:{source}?mode=ro"
+    with closing(sqlite3.connect(source_uri, uri=True)) as source_db:
+        with closing(sqlite3.connect(destination)) as destination_db:
+            source_db.backup(destination_db, pages=256, sleep=0.1)
+            result = destination_db.execute("PRAGMA integrity_check").fetchone()
+            if result is None or result[0] != "ok":
+                raise sqlite3.DatabaseError(
+                    f"迁移数据库完整性检查失败: {source} ({result})"
+                )
+            destination_db.commit()
+
+
+def _copy_tree(source: Path, destination: Path) -> None:
+    """复制一个插件数据目录，拒绝符号链接和特殊文件。"""
+
+    destination.mkdir(parents=True)
+    for entry in sorted(source.iterdir(), key=lambda item: item.name):
+        if entry.is_symlink():
+            raise ValueError(f"插件数据迁移不接受符号链接: {entry}")
+        target = destination / entry.name
+        if entry.is_dir():
+            _copy_tree(entry, target)
+        elif entry.is_file():
+            if entry.suffix.lower() in _SQLITE_SUFFIXES:
+                _copy_sqlite(entry, target)
+            else:
+                shutil.copy2(entry, target)
+        else:
+            raise ValueError(f"插件数据迁移不接受特殊文件: {entry}")
+
+
+def migrate_plugin_data(*, workspace: Path, plugins_home: Path) -> list[Path]:
+    """持有 workspace 独占锁复制旧插件数据，失败时不保留目标。"""
+
+    lock = WorkspaceInstanceLock(workspace)
+    lock.acquire()
+    try:
+        return _migrate_plugin_data_locked(
+            workspace=workspace,
+            plugins_home=plugins_home,
+        )
+    finally:
+        lock.release()
+
+
+def _migrate_plugin_data_locked(
+    *,
+    workspace: Path,
+    plugins_home: Path,
+) -> list[Path]:
+    """先完整预复制全部目录，再把验证后的结果发布到 workspace。"""
+
+    # 1. 校验源和目标，避免半迁移后才发现名称冲突
+    source_root = plugins_home.expanduser().resolve() / "data"
+    workspace_root = workspace.expanduser().resolve()
+    target_root = workspace_root / "plugin-data"
+    validate_workspace_plugin_data_path(target_root, workspace_root)
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"旧插件数据目录不存在: {source_root}")
+    entries = sorted(source_root.iterdir(), key=lambda entry: entry.name)
+    for entry in entries:
+        if entry.is_symlink():
+            raise ValueError(f"插件数据迁移不接受符号链接: {entry}")
+    sources = [entry for entry in entries if entry.is_dir()]
+    if not sources:
+        raise ValueError(f"旧插件数据目录为空: {source_root}")
+    if target_root.exists():
+        raise FileExistsError(f"目标插件数据根已存在，拒绝覆盖: {target_root}")
+
+    # 2. 独占锁内完成全部复制和 SQLite 校验，不暴露半成品
+    staging_root = workspace_root / f".plugin-data-migrate-{uuid.uuid4().hex}"
+    ensure_workspace_plugin_data_dir(staging_root, workspace_root)
+    try:
+        for source in sources:
+            _copy_tree(source, staging_root / source.name)
+
+        # 3. 用一次原子 rename 发布整个数据根，发布后不再执行可失败步骤
+        os.replace(staging_root, target_root)
+    finally:
+        if staging_root.exists():
+            shutil.rmtree(staging_root)
+    return [target_root / source.name for source in sources]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--plugins-home", type=Path, required=True)
+    args = parser.parse_args()
+    migrated = migrate_plugin_data(
+        workspace=args.workspace,
+        plugins_home=args.plugins_home,
+    )
+    for path in migrated:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/create-proactive-source/SKILL.md
+++ b/skills/create-proactive-source/SKILL.md
@@ -60,7 +60,7 @@ ACK 工具接收 `event_ids: list[str]`，并只确认成功投递的原始 ID�
 enabled = true
 ```
 
-文件位于 `~/.akashic-plugin/data/<plugin>-<marketplace>/config.local.toml`。关闭 proactive 只移除主动 source，不关闭插件其他能力。
+文件位于 `<workspace>/plugin-data/<plugin>-<marketplace>/config.local.toml`。关闭 proactive 只移除主动 source，不关闭插件其他能力。
 
 ## 验证
 

--- a/skills/plugin-system/SKILL.md
+++ b/skills/plugin-system/SKILL.md
@@ -19,7 +19,7 @@ metadata: {"akashic": {"always": false}}
 │  └─ 全局安装清单与 enabled
 ├─ ~/.akashic-plugin/cache/<marketplace>/<plugin>/<version>/plugin.py
 │  └─ 插件能力声明与代码
-└─ ~/.akashic-plugin/data/<plugin>-<marketplace>/config.local.toml
+└─ <workspace>/plugin-data/<plugin>-<marketplace>/config.local.toml
    └─ 插件配置和持久状态
 ```
 

--- a/tests/control/test_exec_cli.py
+++ b/tests/control/test_exec_cli.py
@@ -35,6 +35,8 @@ async def test_exec_remote_error_exits_two_without_traceback(tmp_path: Path) -> 
             "programmatic:missing",
             "--endpoint",
             str(server.endpoint),
+            "--workspace",
+            str(tmp_path),
             "hello",
             cwd=Path(__file__).resolve().parents[2],
             stdout=asyncio.subprocess.PIPE,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -99,20 +99,26 @@ def test_akasha_config_uses_defaults_only_for_missing_fields(tmp_path: Path) -> 
     assert config.assistant_preview_chars == AkashaConfig().assistant_preview_chars
 
 
-def test_akasha_config_migrates_to_user_data_dir(
+def test_akasha_config_creates_workspace_data_dir(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    target = tmp_path / "data" / "akasha-builtin"
-    monkeypatch.setattr(
-        "plugins.akasha.config.builtin_plugin_data_dir",
-        lambda _name: target,
-    )
+    target = tmp_path / "plugin-data" / "akasha-builtin"
 
-    path = ensure_akasha_config_file()
+    path = ensure_akasha_config_file(workspace=tmp_path)
 
     assert path == target / "config.local.toml"
-    assert load_akasha_config() == AkashaConfig()
+    assert load_akasha_config(workspace=tmp_path) == AkashaConfig()
+
+
+def test_akasha_config_rejects_symlink_data_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "plugin-data").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="符号链接"):
+        ensure_akasha_config_file(workspace=tmp_path)
+
+    assert list(outside.iterdir()) == []
 
 
 @pytest.mark.parametrize(
@@ -143,16 +149,14 @@ def test_akasha_config_rejects_invalid_present_fields(
 
 def test_akasha_dashboard_exposes_invalid_plugin_config(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        "plugins.akasha.config.builtin_plugin_data_dir",
-        lambda _name: tmp_path,
-    )
-    (tmp_path / "config.local.toml").write_text("db_path = [", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    data_dir = workspace / "plugin-data" / "akasha-builtin"
+    data_dir.mkdir(parents=True)
+    (data_dir / "config.local.toml").write_text("db_path = [", encoding="utf-8")
 
     with pytest.raises(tomllib.TOMLDecodeError):
-        register_akasha_dashboard(FastAPI(), tmp_path, tmp_path / "workspace")
+        register_akasha_dashboard(FastAPI(), tmp_path, workspace)
 
 
 def test_graph_snapshot_distinguishes_missing_from_corruption(tmp_path: Path) -> None:

--- a/tests/test_bootstrap_wiring_p2.py
+++ b/tests/test_bootstrap_wiring_p2.py
@@ -107,7 +107,7 @@ def test_config_load_reads_wiring_block(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.wiring.context == "default"
     assert cfg.wiring.memory == "default"
@@ -123,14 +123,14 @@ def test_config_load_rejects_invalid_wiring_toolsets(
     _write_wiring_config(cfg_path, {"toolsets": toolsets})
 
     with pytest.raises(ValueError, match="agent.wiring.toolsets 必须是字符串数组"):
-        Config.load(cfg_path)
+        Config.load(cfg_path, workspace=tmp_path)
 
 
 def test_config_load_preserves_empty_wiring_toolsets(tmp_path: Path):
     cfg_path = tmp_path / "config.toml"
     _write_wiring_config(cfg_path, {"toolsets": []})
 
-    assert Config.load(cfg_path).wiring.toolsets == []
+    assert Config.load(cfg_path, workspace=tmp_path).wiring.toolsets == []
 
 
 def test_config_load_rejects_invalid_wiring_table(tmp_path: Path):
@@ -138,7 +138,7 @@ def test_config_load_rejects_invalid_wiring_table(tmp_path: Path):
     _write_wiring_config(cfg_path, "invalid")
 
     with pytest.raises(ValueError, match="agent.wiring 必须是 TOML table"):
-        Config.load(cfg_path)
+        Config.load(cfg_path, workspace=tmp_path)
 
 
 def test_config_load_reads_memory_engine_selector(tmp_path: Path):
@@ -161,7 +161,7 @@ def test_config_load_reads_memory_engine_selector(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.memory.enabled is True
     assert cfg.memory.engine == "memu"
@@ -191,7 +191,7 @@ def test_config_load_ignores_wiring_memory_engine(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.memory.enabled is True
     assert cfg.memory.engine == ""
@@ -216,7 +216,7 @@ def test_config_load_ignores_legacy_memory_v2_enabled(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert not hasattr(cfg, "memory_v2")
     assert cfg.memory.enabled is False
@@ -253,7 +253,7 @@ def test_config_load_reads_embedding_and_ignores_private_memory_sections(tmp_pat
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.memory.enabled is True
     assert cfg.memory.engine == ""
@@ -286,7 +286,7 @@ def test_config_load_reads_memory_window_and_app_server(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.memory_window == 20
     assert cfg.app_server.listen == "/tmp/dev-akashic.sock"
@@ -311,7 +311,7 @@ def test_config_load_reads_agent_dev_mode(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.dev_mode is True
 
@@ -335,7 +335,7 @@ def test_config_load_accepts_dev_model_alias(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.dev_mode is True
 
@@ -368,7 +368,7 @@ def test_config_load_skips_unfilled_channels(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.channels.telegram is None
     assert cfg.channels.qq is None
@@ -401,7 +401,7 @@ listen = "/tmp/toml-akashic.sock"
         encoding="utf-8",
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.provider == "openai"
     assert cfg.model == "m"
@@ -425,7 +425,7 @@ def test_config_rejects_legacy_cli_socket(tmp_path: Path):
         },
     )
     with pytest.raises(ValueError, match="app_server"):
-        _ = Config.load(cfg_path)
+        _ = Config.load(cfg_path, workspace=tmp_path)
 
 
 def test_config_load_reads_qq_websocket_timeout(tmp_path: Path):
@@ -453,7 +453,7 @@ def test_config_load_reads_qq_websocket_timeout(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.channels.qq is not None
     assert cfg.channels.qq.websocket_open_timeout_seconds == 9.5
@@ -485,7 +485,7 @@ def test_config_load_reads_web_chat_config(tmp_path: Path):
         },
     )
 
-    cfg = Config.load(cfg_path)
+    cfg = Config.load(cfg_path, workspace=tmp_path)
 
     assert cfg.channels.chat.enabled is True
     assert cfg.channels.chat.host == "127.0.0.2"

--- a/tests/test_channel_base.py
+++ b/tests/test_channel_base.py
@@ -16,20 +16,25 @@ def test_attachment_store_writes_under_configured_root(tmp_path: Path):
     assert path.read_bytes() == b"hello"
 
 
-def test_attachment_store_logs_fallback_reason(tmp_path: Path, caplog):
+def test_attachment_store_fails_when_root_is_not_a_directory(tmp_path: Path):
     root = tmp_path / "not-a-directory"
     root.write_text("occupied", encoding="utf-8")
     store = AttachmentStore(root)
 
-    with caplog.at_level("WARNING", logger="infra.channels.base"):
-        path = store.write_bytes(b"hello", prefix="img_", suffix=".png")
+    with pytest.raises(FileExistsError):
+        store.write_bytes(b"hello", prefix="img_", suffix=".png")
 
-    try:
-        assert path.parent == Path("/tmp/akashic_uploads")
-        assert str(root) in caplog.text
-        assert "使用降级目录" in caplog.text
-    finally:
-        path.unlink(missing_ok=True)
+
+def test_attachment_store_rejects_symlink_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "uploads"
+    root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="符号链接"):
+        AttachmentStore(root).write_bytes(b"hello", prefix="img_", suffix=".png")
+
+    assert list(outside.iterdir()) == []
 
 
 def test_message_deduper_evicts_oldest_keys():

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -38,7 +38,8 @@ class _Bus:
 
 
 class _SessionManager:
-    def __init__(self) -> None:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
         self.sessions = {}
         self.saved = []
 
@@ -341,7 +342,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     mod = _import_telegram_channel(monkeypatch)
     bus = _Bus()
     event_bus = EventBus()
-    session_manager = _SessionManager()
+    session_manager = _SessionManager(tmp_path)
     interrupt_controller = MagicMock()
     interrupt_controller.request_interrupt.return_value = SimpleNamespace(
         status="interrupted",
@@ -749,7 +750,7 @@ async def test_telegram_live_message_is_retained_when_delete_fails(monkeypatch):
 async def test_qq_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     mod = _import_qq_channel(monkeypatch)
     bus = _Bus()
-    session_manager = _SessionManager()
+    session_manager = _SessionManager(tmp_path)
     async def _request_get(url, **kwargs):
         if url.endswith("a.jpg") or url.endswith("a.png"):
             return SimpleNamespace(
@@ -853,7 +854,7 @@ async def test_qq_private_trace_sends_forward_then_final_and_clears_state(
 ):
     mod = _import_qq_channel(monkeypatch)
     bus = _Bus()
-    session_manager = _SessionManager()
+    session_manager = _SessionManager(tmp_path)
     event_bus = EventBus()
     channel = mod.QQChannel(
         "42",
@@ -947,10 +948,13 @@ async def test_qq_private_trace_sends_forward_then_final_and_clears_state(
 
 
 @pytest.mark.asyncio
-async def test_qq_private_trace_skips_empty_trace(monkeypatch: pytest.MonkeyPatch):
+async def test_qq_private_trace_skips_empty_trace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
     mod = _import_qq_channel(monkeypatch)
     bus = _Bus()
-    session_manager = _SessionManager()
+    session_manager = _SessionManager(tmp_path)
     event_bus = EventBus()
     channel = mod.QQChannel(
         "42",

--- a/tests/test_default_memory_plugin_config.py
+++ b/tests/test_default_memory_plugin_config.py
@@ -12,28 +12,34 @@ from plugins.default_memory.config import (
 )
 
 
-def test_default_memory_config_reads_example_defaults() -> None:
-    cfg = load_default_memory_config()
+def test_default_memory_config_reads_example_defaults(tmp_path: Path) -> None:
+    cfg = load_default_memory_config(workspace=tmp_path)
 
     assert cfg.retrieval.top_k_history == 8
     assert cfg.retrieval.thresholds.procedure == 0.66
     assert cfg.retrieval.inject.max_chars == 6000
 
 
-def test_default_memory_config_migrates_to_user_data_dir(
+def test_default_memory_config_creates_workspace_data_dir(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    target = tmp_path / "data" / "default_memory-builtin"
-    monkeypatch.setattr(
-        "plugins.default_memory.config.builtin_plugin_data_dir",
-        lambda _name: target,
-    )
+    target = tmp_path / "plugin-data" / "default_memory-builtin"
 
-    path = ensure_default_memory_config_file()
+    path = ensure_default_memory_config_file(workspace=tmp_path)
 
     assert path == target / "config.local.toml"
-    assert load_default_memory_config().retrieval.top_k_history == 8
+    assert load_default_memory_config(workspace=tmp_path).retrieval.top_k_history == 8
+
+
+def test_default_memory_config_rejects_symlink_data_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "plugin-data").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="符号链接"):
+        ensure_default_memory_config_file(workspace=tmp_path)
+
+    assert list(outside.iterdir()) == []
 
 
 def test_default_memory_config_local_overrides(tmp_path: Path) -> None:

--- a/tests/test_fresh_configuration_matrix.py
+++ b/tests/test_fresh_configuration_matrix.py
@@ -137,7 +137,7 @@ async def test_fresh_init_core_configuration_matrix(
         proactive_lifecycle=proactive_lifecycle,
         proactive_package=package,
     )
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     resources = SharedHttpResources()
     runtime = build_core_runtime(config, workspace, resources)
 
@@ -202,7 +202,10 @@ async def test_fresh_init_runtime_start_stop_matrix(
         raise AssertionError("不可达")
 
     monkeypatch.setattr(ProactiveLoop, "_tick", _wait_for_cancel)
-    runtime = bootstrap_app.build_app_runtime(Config.load(config_path), workspace=workspace)
+    runtime = bootstrap_app.build_app_runtime(
+        Config.load(config_path, workspace=workspace),
+        workspace=workspace,
+    )
     task = asyncio.create_task(runtime.run())
     try:
         for _ in range(100):
@@ -223,5 +226,5 @@ async def test_fresh_init_runtime_start_stop_matrix(
 
     assert not (workspace / "akashic.sock").exists()
     plugin_name = "default_memory" if memory_name == "default" else memory_name
-    config_dir = home / ".akashic-plugin" / "data" / f"{plugin_name}-builtin"
+    config_dir = workspace / "plugin-data" / f"{plugin_name}-builtin"
     assert (config_dir / "config.local.toml").is_file()

--- a/tests/test_http_migrations.py
+++ b/tests/test_http_migrations.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 
 from agent.tools.web_fetch import WebFetchTool
+from infra.channels.base import AttachmentStore
 from infra.channels.qq_channel import _download_to_temp
 from core.net.http import (
     HttpRequester,
@@ -79,7 +80,11 @@ async def test_download_to_temp_uses_injected_requester(tmp_path: Path):
 
     requester = _build_requester(_handler)
     try:
-        paths = await _download_to_temp(["https://example.com/image.png"], requester)
+        paths = await _download_to_temp(
+            ["https://example.com/image.png"],
+            requester,
+            AttachmentStore(tmp_path / "uploads"),
+        )
         assert len(paths) == 1
         path = Path(paths[0])
         assert path.suffix == ".png"

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -16,6 +16,8 @@ def test_setup_main_does_not_import_agent_runtime(tmp_path: Path) -> None:
             "setup-main",
             "--config",
             str(missing_config),
+            "--workspace",
+            str(tmp_path / "workspace"),
         ],
         capture_output=True,
         text=True,

--- a/tests/test_migrate_plugin_data.py
+++ b/tests/test_migrate_plugin_data.py
@@ -1,0 +1,130 @@
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from bootstrap.workspace_lock import WorkspaceInstanceLock
+from scripts import migrate_plugin_data as migration_module
+from scripts.migrate_plugin_data import migrate_plugin_data
+
+
+def test_migrate_plugin_data_copies_files_and_live_sqlite(tmp_path: Path) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    source = plugins_home / "data" / "feed-github"
+    source.mkdir(parents=True)
+    (source / "config.local.toml").write_text("enabled = true\n", encoding="utf-8")
+    database = source / "feed.sqlite3"
+    connection = sqlite3.connect(database)
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("CREATE TABLE items (value TEXT NOT NULL)")
+    connection.execute("INSERT INTO items VALUES ('kept')")
+    connection.commit()
+
+    workspace = tmp_path / "workspace"
+    try:
+        migrated = migrate_plugin_data(
+            workspace=workspace,
+            plugins_home=plugins_home,
+        )
+    finally:
+        connection.close()
+
+    target = workspace / "plugin-data" / "feed-github"
+    assert migrated == [target]
+    assert (target / "config.local.toml").read_text(encoding="utf-8") == "enabled = true\n"
+    with closing(sqlite3.connect(target / "feed.sqlite3")) as copied:
+        assert copied.execute("SELECT value FROM items").fetchone() == ("kept",)
+        assert copied.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+
+
+def test_migrate_plugin_data_refuses_existing_target(tmp_path: Path) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    source = plugins_home / "data" / "feed-github"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("{}\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    target = workspace / "plugin-data" / "feed-github"
+    target.mkdir(parents=True)
+    marker = target / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="拒绝覆盖"):
+        migrate_plugin_data(workspace=workspace, plugins_home=plugins_home)
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_migrate_plugin_data_rolls_back_published_targets_on_failure(
+    tmp_path: Path,
+) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    first = plugins_home / "data" / "a-github"
+    second = plugins_home / "data" / "b-github"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "state.json").write_text("{}\n", encoding="utf-8")
+    (second / "escape").symlink_to(tmp_path / "outside")
+    workspace = tmp_path / "workspace"
+
+    with pytest.raises(ValueError, match="符号链接"):
+        migrate_plugin_data(workspace=workspace, plugins_home=plugins_home)
+
+    assert not (workspace / "plugin-data").exists()
+
+
+def test_migrate_plugin_data_rejects_symlink_target_root(tmp_path: Path) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    source = plugins_home / "data" / "feed-github"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("{}\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (workspace / "plugin-data").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="符号链接"):
+        migrate_plugin_data(workspace=workspace, plugins_home=plugins_home)
+
+    assert list(outside.iterdir()) == []
+
+
+def test_migrate_plugin_data_requires_idle_workspace(tmp_path: Path) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    source = plugins_home / "data" / "feed-github"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("{}\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    lock = WorkspaceInstanceLock(workspace)
+    lock.acquire()
+    try:
+        with pytest.raises(RuntimeError, match="其他 runtime 占用"):
+            migrate_plugin_data(workspace=workspace, plugins_home=plugins_home)
+    finally:
+        lock.release()
+
+    assert not (workspace / "plugin-data").exists()
+
+
+def test_migrate_plugin_data_publish_failure_never_exposes_partial_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugins_home = tmp_path / "plugins-home"
+    for name in ("calendar-github", "feed-github"):
+        source = plugins_home / "data" / name
+        source.mkdir(parents=True)
+        (source / "state.json").write_text("{}\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+
+    def fail_publish(_source: Path, _destination: Path) -> None:
+        raise OSError("publish failed")
+
+    monkeypatch.setattr(migration_module.os, "replace", fail_publish)
+
+    with pytest.raises(OSError, match="publish failed"):
+        migrate_plugin_data(workspace=workspace, plugins_home=plugins_home)
+
+    assert not (workspace / "plugin-data").exists()
+    assert list(workspace.glob(".plugin-data-migrate-*")) == []

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -331,7 +331,7 @@ def test_named_runtime_config_and_setup_keep_secrets_out_of_toml(
     rendered = _render_config(answers)
     path = tmp_path / "config.toml"
     path.write_text(rendered, encoding="utf-8")
-    config = load_config(path)
+    config = load_config(path, workspace=tmp_path)
 
     assert "main-secret" not in rendered
     assert config.model_runtimes["main"].provider == "deepseek"
@@ -353,7 +353,7 @@ reasoning_summary = "{summary}"
 """
     path = tmp_path / "config.toml"
     path.write_text(template.format(provider="CustomAPI", summary="none"), encoding="utf-8")
-    assert load_config(path).model_runtimes["main"].provider == "customapi"
+    assert load_config(path, workspace=tmp_path).model_runtimes["main"].provider == "customapi"
 
 
 def test_usage_keeps_partial_coverage_unknown() -> None:

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -905,7 +905,11 @@ async def test_bootstrap_trigger_and_entrypoints_cover_paths(
     assert item.id == "1"
 
     monkeypatch.setattr("pathlib.Path.exists", lambda self: False)
-    monkeypatch.setattr(sys, "argv", ["main.py", "--config", "missing.json"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["main.py", "--config", "missing.json", "--workspace", str(tmp_path)],
+    )
     with pytest.raises(SystemExit) as exc:
         runpy.run_module("main", run_name="__main__")
     assert exc.value.code == 1
@@ -919,7 +923,7 @@ async def test_bootstrap_trigger_and_entrypoints_cover_paths(
     monkeypatch.setattr(
         "agent.config.Config.load",
         classmethod(
-            lambda cls, path="config.toml": SimpleNamespace(
+            lambda cls, path="config.toml", *, workspace: SimpleNamespace(
                 app_server=SimpleNamespace(listen="/tmp/control.sock")
             )
         ),
@@ -928,7 +932,11 @@ async def test_bootstrap_trigger_and_entrypoints_cover_paths(
         "bootstrap.app.build_app_runtime",
         lambda *args, **kwargs: SimpleNamespace(run=AsyncMock()),
     )
-    monkeypatch.setattr(sys, "argv", ["main.py"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["main.py", "--workspace", str(tmp_path)],
+    )
     runpy.run_module("main", run_name="__main__")
 
 

--- a/tests/test_plugin_config_schema.py
+++ b/tests/test_plugin_config_schema.py
@@ -54,7 +54,8 @@ def _get_instance(name: str):
 async def test_plugin_config_model_validates_and_injects_config(tmp_path: Path):
     _write_typed_plugin(tmp_path)
     plugins_home = tmp_path / ".akashic-plugin"
-    data_dir = plugins_home / "data" / "typed-builtin"
+    workspace = tmp_path / "workspace"
+    data_dir = workspace / "plugin-data" / "typed-builtin"
     data_dir.mkdir(parents=True)
     (data_dir / "config.local.toml").write_text(
         'api_key = "secret"\nmax_results = 9\n',
@@ -63,6 +64,7 @@ async def test_plugin_config_model_validates_and_injects_config(tmp_path: Path):
     manager = PluginManager(
         plugin_dirs=[tmp_path],
         event_bus=EventBus(),
+        workspace=workspace,
         installed_cache_root=plugins_home / "cache",
     )
 
@@ -77,12 +79,14 @@ async def test_plugin_config_model_validates_and_injects_config(tmp_path: Path):
 async def test_plugin_config_model_failure_skips_plugin(tmp_path: Path):
     _write_typed_plugin(tmp_path)
     plugins_home = tmp_path / ".akashic-plugin"
-    data_dir = plugins_home / "data" / "typed-builtin"
+    workspace = tmp_path / "workspace"
+    data_dir = workspace / "plugin-data" / "typed-builtin"
     data_dir.mkdir(parents=True)
     (data_dir / "config.local.toml").write_text('max_results = "bad"\n', encoding="utf-8")
     manager = PluginManager(
         plugin_dirs=[tmp_path],
         event_bus=EventBus(),
+        workspace=workspace,
         installed_cache_root=plugins_home / "cache",
     )
 
@@ -119,6 +123,6 @@ allow_from = ["user-openid"]
     monkeypatch.setenv("PLUGIN_TOKEN", "plugin-secret")
     monkeypatch.setenv("QQBOT_SECRET", "qq-secret")
 
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=tmp_path)
 
     assert not hasattr(config, "plugins")

--- a/tests/test_plugin_doctor.py
+++ b/tests/test_plugin_doctor.py
@@ -55,6 +55,7 @@ def test_plugin_doctor_reports_broken_declaration(tmp_path: Path) -> None:
         plugin_id="demo@github",
         config_path=str(_init_config(tmp_path)),
         plugins_home=plugins_home,
+        workspace=tmp_path / "workspace",
     )
 
     assert report["status"] == "broken"

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -73,7 +73,7 @@ def _manager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=EventBus(),
         tool_registry=tools,
-        workspace=workspace,
+        workspace=workspace or tmp_path / "workspace",
         installed_cache_root=tmp_path / "home" / "cache",
     )
 
@@ -335,7 +335,7 @@ async def test_candidate_declaration_cannot_write_plugin_kv(tmp_path: Path):
     await manager.load_all()
 
     gate = manager.latest_gate("readonly")
-    kv_path = tmp_path / "home" / "data" / "readonly-builtin" / ".kv.json"
+    kv_path = tmp_path / "workspace" / "plugin-data" / "readonly-builtin" / ".kv.json"
     assert gate is not None and gate.status == "failed"
     assert gate.checks[0].check_id == "declarations"
     assert not kv_path.exists()
@@ -443,7 +443,7 @@ async def test_generation_module_tree_is_removed_on_config_failure_and_terminate
         "    ConfigModel = Config\n",
     )
     _ = (plugin_dir / "child.py").write_text("value = 1\n", encoding="utf-8")
-    config_dir = tmp_path / "home" / "data" / "module_tree-builtin"
+    config_dir = tmp_path / "workspace" / "plugin-data" / "module_tree-builtin"
     config_dir.mkdir(parents=True)
     _ = (config_dir / "config.local.toml").write_text("", encoding="utf-8")
     manager = _manager(tmp_path)
@@ -496,6 +496,7 @@ async def test_candidate_is_not_published_before_initialize_finishes(tmp_path: P
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
         tool_registry=tools,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home" / "cache",
     )
 
@@ -566,7 +567,7 @@ async def test_prepare_same_plugin_keeps_active_generation_until_snapshot_publis
     assert manager.prepared_generation("replaceable") is prepared
     assert manager.latest_gate("replaceable").status == "passed"  # type: ignore[union-attr]
     assert not (
-        tmp_path / "home" / "data" / "replaceable-builtin" / ".kv.json"
+        tmp_path / "workspace" / "plugin-data" / "replaceable-builtin" / ".kv.json"
     ).exists()
     assert tools.get_tool("replaceable_tool") is not None
 
@@ -1051,7 +1052,7 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
     assert prepared_job.spec.handler.__self__ is prepared.instance  # type: ignore[attr-defined]
     assert manager.jobs == [active_job]
     assert active_job.spec.handler.__self__ is active.instance  # type: ignore[attr-defined]
-    lifecycle = tmp_path / "home" / "data" / "mcp_ready-builtin" / "mcp-lifecycle.log"
+    lifecycle = tmp_path / "workspace" / "plugin-data" / "mcp_ready-builtin" / "mcp-lifecycle.log"
     await _wait_for_log(lifecycle, ["started", "started"])
 
     await manager.discard_prepared("mcp_ready")
@@ -1141,7 +1142,7 @@ async def test_candidate_mcp_readiness_failure_closes_process(
     assert (
         "mcp_readiness" if failure == "missing_tool" else "readiness_semantic_checks"
     ) in failed_checks
-    lifecycle = tmp_path / "home" / "data" / "mcp_rejected-builtin" / "mcp-lifecycle.log"
+    lifecycle = tmp_path / "workspace" / "plugin-data" / "mcp_rejected-builtin" / "mcp-lifecycle.log"
     await _wait_for_log(lifecycle, ["started", "started", "stopped"])
     await manager.terminate_all()
 
@@ -1175,7 +1176,7 @@ async def test_candidate_mcp_handshake_failure_closes_process(tmp_path: Path) ->
     gate = manager.latest_gate("mcp_handshake")
     assert gate is not None and gate.status == "failed"
     assert gate.checks[-1].check_id == "mcp_readiness"
-    lifecycle = tmp_path / "home" / "data" / "mcp_handshake-builtin" / "mcp-lifecycle.log"
+    lifecycle = tmp_path / "workspace" / "plugin-data" / "mcp_handshake-builtin" / "mcp-lifecycle.log"
     await _wait_for_log(lifecycle, ["started", "stopped"])
     await manager.terminate_all()
 
@@ -1560,7 +1561,7 @@ async def test_snapshot_compile_failure_does_not_publish_plugin(
     assert manager.loaded_count == 1
     assert manager.generation("second_snapshot") is None
     assert plugin_registry.get_instance("akasic_plugin_plugins_second_snapshot") is None
-    state = tmp_path / "home" / "data" / "second_snapshot-builtin" / ".kv.json"
+    state = tmp_path / "workspace" / "plugin-data" / "second_snapshot-builtin" / ".kv.json"
     assert not state.exists()
     await manager.terminate_all()
 
@@ -1738,7 +1739,7 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     assert old_lease.snapshot.before_turn_modules[0].version == "v1"
     next_lease = manager.snapshot_store.lease()
     assert next_lease.snapshot.before_turn_modules[0].version == "v2"
-    state = tmp_path / "home" / "data" / "snapshot_publish-builtin" / ".kv.json"
+    state = tmp_path / "workspace" / "plugin-data" / "snapshot_publish-builtin" / ".kv.json"
     state_value: object = json.loads(state.read_text(encoding="utf-8"))
     assert isinstance(state_value, dict)
     assert state_value["initialized"] == "v2"
@@ -3072,6 +3073,7 @@ async def test_queued_event_keeps_enqueued_snapshot_generation(
     manager = PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home" / "cache",
     )
     await manager.load_all()
@@ -3091,7 +3093,7 @@ async def test_queued_event_keeps_enqueued_snapshot_generation(
         tools_used=[],
     )
     event_bus.enqueue(event)
-    state_path = tmp_path / "home" / "data" / "snapshot_event-builtin" / ".kv.json"
+    state_path = tmp_path / "workspace" / "plugin-data" / "snapshot_event-builtin" / ".kv.json"
     for _ in range(100):
         if state_path.exists():
             state: object = json.loads(state_path.read_text(encoding="utf-8"))
@@ -3140,6 +3142,7 @@ async def test_snapshot_event_subscription_close_takes_effect_immediately(
     manager = PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home" / "cache",
     )
     await manager.load_all()
@@ -3158,7 +3161,7 @@ async def test_snapshot_event_subscription_close_takes_effect_immediately(
 
     await event_bus.fanout(event)
 
-    state_path = tmp_path / "home/data/snapshot_event-builtin/.kv.json"
+    state_path = tmp_path / "workspace/plugin-data/snapshot_event-builtin/.kv.json"
     assert not state_path.exists()
     with pytest.raises(RuntimeError, match="只能在 initialize"):
         generation.instance.context.event_bus.on(TurnCommitted, lambda _: None)
@@ -3179,6 +3182,7 @@ async def test_event_bus_shutdown_drains_snapshot_lease_before_plugins(
     manager = PluginManager(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home" / "cache",
     )
     await manager.load_all()
@@ -3193,7 +3197,7 @@ async def test_event_bus_shutdown_drains_snapshot_lease_before_plugins(
             tools_used=[],
         )
     )
-    state_path = tmp_path / "home/data/snapshot_event-builtin/.kv.json"
+    state_path = tmp_path / "workspace/plugin-data/snapshot_event-builtin/.kv.json"
     for _ in range(100):
         if state_path.exists() and json.loads(
             state_path.read_text(encoding="utf-8")
@@ -3325,6 +3329,7 @@ async def test_job_queue_envelope_keeps_enqueued_snapshot_generation(
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
         llm=llm,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home/cache",
     )
     await manager.load_all()
@@ -3342,7 +3347,7 @@ async def test_job_queue_envelope_keeps_enqueued_snapshot_generation(
     result = await manager.publish_prepared("snapshot_job")
     assert result["publication_state"] == "committed"
     running = asyncio.create_task(runtime.run())
-    state_path = tmp_path / "home/data/snapshot_job-builtin/.kv.json"
+    state_path = tmp_path / "workspace/plugin-data/snapshot_job-builtin/.kv.json"
     for _ in range(100):
         if state_path.exists() and json.loads(
             state_path.read_text(encoding="utf-8")
@@ -3381,6 +3386,7 @@ async def test_job_event_trigger_uses_event_snapshot_catalog(tmp_path: Path) -> 
         plugin_dirs=[tmp_path / "plugins"],
         event_bus=event_bus,
         llm=llm,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "home/cache",
     )
     await manager.load_all()
@@ -3416,7 +3422,7 @@ async def test_job_event_trigger_uses_event_snapshot_catalog(tmp_path: Path) -> 
     finally:
         reset_runtime_snapshot(token)
         await old_lease.release()
-    state_path = tmp_path / "home/data/snapshot_job-builtin/.kv.json"
+    state_path = tmp_path / "workspace/plugin-data/snapshot_job-builtin/.kv.json"
     for _ in range(100):
         if state_path.exists() and json.loads(
             state_path.read_text(encoding="utf-8")

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -14,7 +14,27 @@ from agent.plugins.install import (
     set_installed_plugin_enabled,
     uninstall_plugin,
 )
+from agent.plugins.manifest import plugins_root
 from agent.plugins.source_resolver import resolve_plugin_sources
+
+
+def test_plugins_root_honors_explicit_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "isolated-plugin-home"
+    monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(target))
+
+    assert plugins_root() == target
+
+
+def test_plugins_root_rejects_blank_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AKASHIC_PLUGIN_HOME", "   ")
+
+    with pytest.raises(ValueError, match="不能为空"):
+        plugins_root()
 
 
 def test_install_git_plugin_uses_programmatic_declaration(tmp_path: Path) -> None:
@@ -34,11 +54,17 @@ def test_install_git_plugin_uses_programmatic_declaration(tmp_path: Path) -> Non
     _commit(repo)
 
     home = tmp_path / "plugins-home"
-    data_dir = home / "data" / "feed-lab"
+    workspace = tmp_path / "workspace"
+    data_dir = workspace / "plugin-data" / "feed-lab"
     data_dir.mkdir(parents=True)
     (data_dir / "state.json").write_text('{"keep":true}\n', encoding="utf-8")
 
-    result = install_git_plugin(source=str(repo), marketplace="lab", plugins_home=home)
+    result = install_git_plugin(
+        workspace=workspace,
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
 
     assert result.installed_path == home / "cache" / "lab" / "feed" / "1.0.0"
     assert (result.installed_path / "plugin.py").exists()
@@ -77,6 +103,7 @@ def test_install_git_plugin_prepares_declared_mcp_runtime(
 
     monkeypatch.setattr(install_module, "_run_command", fake_run)
     result = install_git_plugin(
+        workspace=tmp_path / "workspace",
         source=str(repo),
         marketplace="lab",
         plugins_home=tmp_path / "plugins-home",
@@ -94,8 +121,9 @@ def test_install_git_plugin_prepares_declared_mcp_runtime(
 
 def test_plugin_enable_disable_and_uninstall_preserve_data(tmp_path: Path) -> None:
     home = tmp_path / "plugins-home"
+    workspace = tmp_path / "workspace"
     cache = home / "cache" / "github" / "fitbit" / "1.0.0"
-    data = home / "data" / "fitbit-github"
+    data = workspace / "plugin-data" / "fitbit-github"
     cache.mkdir(parents=True)
     data.mkdir(parents=True)
     (cache / "plugin.py").write_text("", encoding="utf-8")
@@ -133,6 +161,7 @@ def test_plugin_enable_disable_and_uninstall_preserve_data(tmp_path: Path) -> No
 
     removed_cache, retained_data = uninstall_plugin(
         "fitbit@github",
+        workspace=workspace,
         plugins_home=home,
         wait_until_disabled=wait_until_disabled,
     )
@@ -188,7 +217,12 @@ def test_install_failure_restores_previous_cache_and_manifest(
     )
     _commit(repo)
     home = tmp_path / "plugins-home"
-    first = install_git_plugin(source=str(repo), marketplace="lab", plugins_home=home)
+    first = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
     old_content = (first.installed_path / "plugin.py").read_text(encoding="utf-8")
 
     plugin_path.write_text(
@@ -209,7 +243,12 @@ def test_install_failure_restores_previous_cache_and_manifest(
 
     monkeypatch.setattr(install_module, "_prepare_plugin_mcp_runtimes", fail_prepare)
     with pytest.raises(RuntimeError, match="prepare failed"):
-        install_git_plugin(source=str(repo), marketplace="lab", plugins_home=home)
+        install_git_plugin(
+            workspace=tmp_path / "workspace",
+            source=str(repo),
+            marketplace="lab",
+            plugins_home=home,
+        )
 
     assert (first.installed_path / "plugin.py").read_text(encoding="utf-8") == old_content
     assert tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8")) == {
@@ -227,7 +266,12 @@ def test_install_failure_restores_previous_cache_and_manifest(
 
     monkeypatch.setattr(install_module, "upsert_plugin_manifest", fail_manifest)
     with pytest.raises(OSError, match="manifest write failed"):
-        install_git_plugin(source=str(repo), marketplace="lab", plugins_home=home)
+        install_git_plugin(
+            workspace=tmp_path / "workspace",
+            source=str(repo),
+            marketplace="lab",
+            plugins_home=home,
+        )
     assert (first.installed_path / "plugin.py").read_text(encoding="utf-8") == old_content
 
 
@@ -245,6 +289,7 @@ def test_install_rejects_unsafe_path_metadata(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="安全的单一路径段"):
         install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="../outside",
             plugins_home=tmp_path / "plugins-home",
@@ -252,6 +297,7 @@ def test_install_rejects_unsafe_path_metadata(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="安全的单一路径段"):
         install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="lab",
             plugins_home=tmp_path / "plugins-home",
@@ -275,7 +321,12 @@ def test_install_rejects_visible_nonversion_cache_entry(tmp_path: Path) -> None:
     invalid_entry.write_text("broken", encoding="utf-8")
 
     with pytest.raises(ValueError, match="cache 版本不是目录"):
-        install_git_plugin(source=str(repo), marketplace="lab", plugins_home=home)
+        install_git_plugin(
+            workspace=tmp_path / "workspace",
+            source=str(repo),
+            marketplace="lab",
+            plugins_home=home,
+        )
 
     assert invalid_entry.read_text(encoding="utf-8") == "broken"
     assert not (invalid_entry.parent / "1.0.0").exists()
@@ -296,6 +347,7 @@ def test_install_allows_internal_source_symlink(tmp_path: Path) -> None:
     _commit(repo)
 
     result = install_git_plugin(
+        workspace=tmp_path / "workspace",
         source=str(repo),
         marketplace="lab",
         plugins_home=tmp_path / "plugins-home",
@@ -323,6 +375,7 @@ def test_install_rejects_source_symlink_escape(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="符号链接越界"):
         install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="lab",
             plugins_home=tmp_path / "plugins-home",
@@ -386,6 +439,7 @@ def test_install_accepts_branch_tag_and_commit_refs(tmp_path: Path) -> None:
         (initial_sha, "initial"),
     ):
         result = install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="lab",
             ref_name=ref_name,
@@ -397,6 +451,7 @@ def test_install_accepts_branch_tag_and_commit_refs(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="命令选项"):
         install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="lab",
             ref_name="-bad",
@@ -404,6 +459,7 @@ def test_install_accepts_branch_tag_and_commit_refs(tmp_path: Path) -> None:
         )
     with pytest.raises(ValueError, match="首尾空白"):
         install_git_plugin(
+            workspace=tmp_path / "workspace",
             source=str(repo),
             marketplace="lab",
             ref_name=" release",
@@ -413,16 +469,22 @@ def test_install_accepts_branch_tag_and_commit_refs(tmp_path: Path) -> None:
 
 def test_uninstall_converges_when_cache_is_already_missing(tmp_path: Path) -> None:
     home = tmp_path / "plugins-home"
-    data = home / "data" / "feed-github"
+    workspace = tmp_path / "workspace"
+    data = workspace / "plugin-data" / "feed-github"
     data.mkdir(parents=True)
     state = data / "state.db"
     state.write_bytes(b"keep")
+    home.mkdir(parents=True)
     (home / "manifest.toml").write_text(
         '[plugins."feed@github"]\nenabled = true\n',
         encoding="utf-8",
     )
 
-    cache, retained = uninstall_plugin("feed@github", plugins_home=home)
+    cache, retained = uninstall_plugin(
+        "feed@github",
+        workspace=workspace,
+        plugins_home=home,
+    )
 
     assert not cache.exists()
     assert retained == data

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -60,6 +60,7 @@ def _make_manager(plugin_dirs: list[Path], *, event_bus: EventBus, tools: ToolRe
         plugin_dirs=plugin_dirs,
         event_bus=event_bus,
         tool_registry=tools,
+        workspace=TEST_PLUGIN_HOME / "workspace",
         installed_cache_root=TEST_PLUGIN_HOME / "cache",
     )
 
@@ -231,6 +232,7 @@ async def test_installed_plugin_shadows_builtin_with_same_name(tmp_path: Path):
         plugin_dirs=[builtin_root],
         installed_cache_root=installed_root,
         event_bus=bus,
+        workspace=tmp_path / "workspace",
     )
     mods = mgr.discover()
     assert [mod["source_type"] for mod in mods] == ["installed"]
@@ -246,6 +248,7 @@ async def test_plugin_job_runtime_runs_event_job():
         plugin_dirs=[FIXTURES_DIR],
         event_bus=bus,
         llm=llm,
+        workspace=TEST_PLUGIN_HOME / "workspace",
         installed_cache_root=TEST_PLUGIN_HOME / "cache",
     )
     await mgr.load_all()
@@ -624,6 +627,7 @@ async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
     manager = PluginManager(
         plugin_dirs=[plugin_root],
         event_bus=bus,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
     for _ in range(20):
@@ -637,7 +641,7 @@ async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
 
         assert bus.handler_count() == 0
         assert task.done()
-    data_dir = tmp_path / "data" / "scoped-builtin"
+    data_dir = tmp_path / "workspace" / "plugin-data" / "scoped-builtin"
     assert json.loads((data_dir / ".kv.json").read_text(encoding="utf-8")) == {
         "closed": True
     }
@@ -671,6 +675,7 @@ async def test_plugin_manager_consumes_scope_failures_after_terminate_cancellati
     manager = PluginManager(
         plugin_dirs=[plugin_root],
         event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
     await manager.load_all()
@@ -718,6 +723,7 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
     manager = PluginManager(
         plugin_dirs=[plugin_root],
         event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
 
@@ -759,6 +765,7 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
     manager = PluginManager(
         plugin_dirs=[plugin_root],
         event_bus=bus,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
     loading = asyncio.create_task(manager.load_all())
@@ -824,6 +831,7 @@ async def test_plugin_tool_registration_failure_rolls_back(tmp_path: Path):
         plugin_dirs=[plugin_root],
         event_bus=EventBus(),
         tool_registry=tools,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
 
@@ -868,6 +876,7 @@ async def test_plugin_duplicate_tool_preserves_existing_tool(tmp_path: Path):
         plugin_dirs=[plugin_root],
         event_bus=EventBus(),
         tool_registry=tools,
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
 
@@ -965,7 +974,7 @@ async def test_kv_store_persists_across_manager_instances():
         result = await bus2.emit(ctx)
         assert result.extra_metadata["turn_count"] == 2
 
-        kv_path = TEST_PLUGIN_HOME / "data" / "counter-builtin" / ".kv.json"
+        kv_path = TEST_PLUGIN_HOME / "workspace" / "plugin-data" / "counter-builtin" / ".kv.json"
         assert kv_path.exists()
         data = json.loads(kv_path.read_text())
         assert data["turn_count"] == 2
@@ -1066,6 +1075,7 @@ async def test_loads_installed_programmatic_plugin():
             plugin_dirs=[],
             installed_cache_root=cache_root,
             event_bus=bus,
+            workspace=Path(tmp) / "workspace",
         )
         await mgr.load_all()
 
@@ -1106,6 +1116,7 @@ async def test_sync_manifest_covers_builtin_and_installed_plugins(tmp_path: Path
         plugin_dirs=[builtin_root],
         installed_cache_root=cache_root,
         event_bus=bus,
+        workspace=tmp_path / "workspace",
     )
     await mgr.load_all()
 
@@ -1206,7 +1217,7 @@ async def test_installed_plugin_reads_own_toml_config(tmp_path: Path):
         "        return [DemoModule(self.context.config.value)]\n",
         encoding="utf-8",
     )
-    data_dir = tmp_path / "data" / "demo-github"
+    data_dir = tmp_path / "workspace" / "plugin-data" / "demo-github"
     data_dir.mkdir(parents=True)
     (data_dir / "config.local.toml").write_text("value = 7\n", encoding="utf-8")
 
@@ -1214,6 +1225,7 @@ async def test_installed_plugin_reads_own_toml_config(tmp_path: Path):
         plugin_dirs=[],
         installed_cache_root=cache_root,
         event_bus=bus,
+        workspace=tmp_path / "workspace",
     )
     await mgr.load_all()
 
@@ -1440,7 +1452,7 @@ async def test_plugin_toml_overrides_defaults():
     bus = EventBus()
     with tempfile.TemporaryDirectory() as tmp:
         shutil.copytree(FIXTURES_DIR / "configured", Path(tmp) / "configured")
-        data_dir = TEST_PLUGIN_HOME / "data" / "configured-builtin"
+        data_dir = TEST_PLUGIN_HOME / "workspace" / "plugin-data" / "configured-builtin"
         data_dir.mkdir(parents=True)
         (data_dir / "config.local.toml").write_text(
             'api_key = "override-key"\nenabled = false\n',

--- a/tests/test_plugin_packages.py
+++ b/tests/test_plugin_packages.py
@@ -63,6 +63,7 @@ def test_sync_manifest_migrates_legacy_proactive_members(tmp_path: Path) -> None
     manager = PluginManager(
         [root / "plugins"],
         event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
         installed_cache_root=tmp_path / "cache",
     )
 

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -213,6 +213,53 @@ def test_main_help_does_not_start_runtime() -> None:
     assert "Agent 已启动" not in result.stdout
 
 
+def test_workspace_selection_prefers_cli_then_env_then_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[runtime]\nworkspace = "~/configured-workspace"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("AKASHIC_WORKSPACE", raising=False)
+
+    assert main._workspace_from_args([], config_path) == (
+        tmp_path / "configured-workspace"
+    ).resolve()
+
+    environment_workspace = tmp_path / "environment-workspace"
+    monkeypatch.setenv("AKASHIC_WORKSPACE", str(environment_workspace))
+    assert main._workspace_from_args(
+        [],
+        config_path,
+    ) == environment_workspace.resolve()
+
+    cli_workspace = tmp_path / "cli-workspace"
+    assert main._workspace_from_args(
+        ["--workspace", str(cli_workspace)],
+        config_path,
+    ) == cli_workspace.resolve()
+
+
+def test_workspace_selection_uses_default_only_for_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "missing.toml"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("AKASHIC_WORKSPACE", raising=False)
+
+    assert main._workspace_from_args(
+        [],
+        config_path,
+        allow_default=True,
+    ) == (tmp_path / ".akashic" / "workspace").resolve()
+    with pytest.raises(ValueError, match="找不到配置文件"):
+        main._workspace_from_args([], config_path)
+
+
 @pytest.mark.asyncio
 async def test_inspect_modules_closes_all_owned_resources(
     monkeypatch: pytest.MonkeyPatch,
@@ -780,6 +827,8 @@ def test_init_workspace_creates_expected_assets(tmp_path):
     assert 'model = "qwen-vl-plus"' in config_text
     assert "[channels.chat]" in config_text
     assert "port = 6322" in config_text
+    assert '[runtime]\n' in config_text
+    assert 'workspace = "~/.akashic/workspace"' in config_text
     assert any("http://127.0.0.1:6322" in step for step in summary.next_steps)
     assert (workspace / "sessions.db").exists()
     assert (workspace / "observe").is_dir()

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -120,7 +120,7 @@ system_prompt = "test"
         encoding="utf-8",
     )
 
-    cfg = load_config(config_path)
+    cfg = load_config(config_path, workspace=tmp_path)
 
     assert cfg.max_iterations == 10
 
@@ -143,10 +143,52 @@ system_prompt = "test"
         encoding="utf-8",
     )
 
-    cfg = load_config(config_path)
+    cfg = load_config(config_path, workspace=tmp_path)
 
     assert cfg.memory_window == 40
     assert cfg.memory_optimizer_interval_seconds == 64800
+
+
+def test_config_load_resolves_secrets_from_explicit_workspace(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    for workspace, api_key, token in (
+        (first_workspace, "first-key", "first-token"),
+        (second_workspace, "second-key", "second-token"),
+    ):
+        memory = workspace / "memory"
+        memory.mkdir(parents=True)
+        (memory / "API_KEY").write_text(api_key, encoding="utf-8")
+        (memory / "TG_TOKEN").write_text(token, encoding="utf-8")
+    config_path.write_text(
+        """
+[llm]
+provider = "openai"
+
+[llm.main]
+model = "test-model"
+api_key = "${API_KEY}"
+
+[agent]
+system_prompt = "test"
+
+[channels.telegram]
+token = "${TG_TOKEN}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    first = load_config(config_path, workspace=first_workspace)
+    second = Config.load(config_path, workspace=second_workspace)
+
+    assert first.api_key == "first-key"
+    assert first.channels.telegram is not None
+    assert first.channels.telegram.token == "first-token"
+    assert second.api_key == "second-key"
+    assert second.channels.telegram is not None
+    assert second.channels.telegram.token == "second-token"
 
 
 def test_default_socket_is_derived_from_workspace(tmp_path: Path) -> None:
@@ -174,6 +216,7 @@ def test_main_help_does_not_start_runtime() -> None:
 @pytest.mark.asyncio
 async def test_inspect_modules_closes_all_owned_resources(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     closed: list[str] = []
 
@@ -194,14 +237,18 @@ async def test_inspect_modules_closes_all_owned_resources(
         async def aclose(self) -> None:
             closed.append("http")
 
-    monkeypatch.setattr(main.Config, "load", lambda _path: object())
+    monkeypatch.setattr(
+        main.Config,
+        "load",
+        lambda _path, **_kwargs: object(),
+    )
     monkeypatch.setattr(main, "SharedHttpResources", _Resources)
     monkeypatch.setattr(
         "bootstrap.tools.build_core_runtime",
         lambda *_args: _Runtime(),
     )
 
-    await main.inspect_modules()
+    await main.inspect_modules("config.toml", tmp_path)
 
     assert closed == ["core", "memory", "http"]
 
@@ -230,7 +277,7 @@ def test_load_config_rejects_non_table_sections(
     )
 
     with pytest.raises(ValueError, match="必须是 TOML table") as exc_info:
-        load_config(config_path)
+        load_config(config_path, workspace=tmp_path)
 
     assert field in str(exc_info.value)
 
@@ -256,7 +303,7 @@ def test_load_config_rejects_string_booleans(
     )
 
     with pytest.raises(ValueError, match=field.replace(".", r"\.")):
-        load_config(config_path)
+        load_config(config_path, workspace=tmp_path)
 
 
 @pytest.mark.parametrize("tz_name", ["", "Not/AZone"])
@@ -328,7 +375,7 @@ async def test_serve_smoke_loads_config_and_runs_shutdown(monkeypatch, tmp_path)
     monkeypatch.setattr(bootstrap_app, "PluginJobRuntime", _FakePluginJobRuntime)
     monkeypatch.setattr(main.Path, "home", lambda: tmp_path)
 
-    await main.serve(str(config_path))
+    await main.serve(str(config_path), tmp_path)
 
     assert socket_path.exists() is False
     assert "scheduler" in observed
@@ -780,9 +827,11 @@ def test_init_workspace_respects_force_for_text_assets(tmp_path):
 @pytest.mark.asyncio
 async def test_start_channels_wires_telegram_qq_and_plugin(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     starts: list[str] = []
     registrations: list[tuple[str, list[str]]] = []
+    attachment_roots: list[Path] = []
     fake_telegram = types.ModuleType("infra.channels.telegram_channel")
     fake_qq = types.ModuleType("infra.channels.qq_channel")
 
@@ -848,6 +897,7 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
 
         async def start(self, ctx: Any) -> None:
             starts.append("plugin")
+            attachment_roots.append(ctx.attachment_store.root)
             ctx.push_tool.register_channel(self.name, text=self.send)
 
         async def stop(self) -> None:
@@ -885,7 +935,7 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
     host = await start_channels(
         config,
         bus=cast(Any, object()),
-        session_manager=cast(Any, object()),
+        session_manager=cast(Any, types.SimpleNamespace(workspace=tmp_path)),
         push_tool=cast(Any, _PushTool()),
         http_resources=resources,
         event_bus=event_bus,
@@ -906,13 +956,14 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
         assert telegram.kwargs["interrupt_controller"] is controller
         assert qq.kwargs["interrupt_controller"] is controller
         assert plugin.name == "plugin"
+        assert attachment_roots == [tmp_path / "uploads"]
     finally:
         await host.stop_all()
         await resources.aclose()
 
 
 @pytest.mark.asyncio
-async def test_start_channels_skips_unfilled_optional_channels() -> None:
+async def test_start_channels_skips_unfilled_optional_channels(tmp_path: Path) -> None:
     config = Config(
         provider="openai",
         model="m",
@@ -925,7 +976,7 @@ async def test_start_channels_skips_unfilled_optional_channels() -> None:
         host = await start_channels(
             config,
             bus=cast(Any, object()),
-            session_manager=cast(Any, object()),
+            session_manager=cast(Any, types.SimpleNamespace(workspace=tmp_path)),
             push_tool=cast(Any, object()),
             http_resources=resources,
             event_bus=EventBus(),

--- a/tests/test_setup_main.py
+++ b/tests/test_setup_main.py
@@ -80,10 +80,11 @@ def test_setup_main_backs_up_config_and_persists_credential(
         target.__dict__.update(_answers().__dict__)
 
     monkeypatch.setattr("bootstrap.setup_main._phase_main_llm", fill)
-    run_main_model_setup(path)
+    workspace = tmp_path / "workspace"
+    run_main_model_setup(path, workspace)
 
     assert path.with_name("config.toml.before-setup-main.bak").read_text() == _CONFIG
-    config = load_config(path)
+    config = load_config(path, workspace=workspace)
     assert (config.model, config.fast_runtime_id) == ("new-main", "fast")
     assert CredentialStore().get("main_default").access_token == "new-secret"
 

--- a/tests/test_shell_rm_hook.py
+++ b/tests/test_shell_rm_hook.py
@@ -32,7 +32,12 @@ def _clean_registry() -> Iterator[None]:
 
 
 def _make_manager(plugin_dirs: list[Path], *, event_bus: EventBus, tools: Any = None) -> PluginManager:
-    return PluginManager(plugin_dirs=plugin_dirs, event_bus=event_bus, tool_registry=tools)
+    return PluginManager(
+        plugin_dirs=plugin_dirs,
+        event_bus=event_bus,
+        tool_registry=tools,
+        workspace=plugin_dirs[0].parent / "workspace",
+    )
 
 
 async def _invoke(tool_name: str, arguments: dict[str, Any]) -> Any:

--- a/tests_scenarios/model_runtime_live_probe.py
+++ b/tests_scenarios/model_runtime_live_probe.py
@@ -81,11 +81,15 @@ def _usage(response: LLMResponse) -> dict[str, int | str | None]:
     }
 
 
-async def run_probe(config_path: Path, expected_provider: str) -> dict[str, object]:
+async def run_probe(
+    config_path: Path,
+    workspace: Path,
+    expected_provider: str,
+) -> dict[str, object]:
     """实测文本、推理、流式、工具续接、缓存和图片矩阵。"""
 
     # 1. 由真实配置构建统一 provider。
-    config = Config.load(config_path)
+    config = Config.load(config_path, workspace=workspace)
     if config.provider != expected_provider:
         raise ValueError(
             f"provider 不匹配: expected={expected_provider} actual={config.provider}"
@@ -171,10 +175,11 @@ async def run_probe(config_path: Path, expected_provider: str) -> dict[str, obje
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
     parser.add_argument("--provider", required=True)
     args = parser.parse_args()
     print(json.dumps(
-        asyncio.run(run_probe(args.config, args.provider)),
+        asyncio.run(run_probe(args.config, args.workspace, args.provider)),
         ensure_ascii=False,
         indent=2,
     ))


### PR DESCRIPTION
## 问题

运行时仍有配置密钥、附件和插件数据依赖默认 HOME 路径，隔离测试可能读写正式 workspace；插件子进程也没有统一继承权威 workspace。

## 改动

- 所有 Config.load/load_config、runtime、CLI 与维护脚本显式接收 workspace
- 会话附件、内置插件配置、插件 KV/config/service/MCP 数据写入 workspace 下的独立目录
- 通过 AKASHIC_PLUGIN_HOME 隔离插件 cache 与 manifest
- 拒绝 plugin-data/uploads 符号链接逃逸以及数据库路径越界
- 新增旧 ~/.akashic-plugin/data 到 workspace/plugin-data 的离线迁移工具：持有 workspace lock、SQLite 在线备份校验、整根 staging 单次原子发布、拒绝覆盖
- Docker gate 使用隔离 HOME/workspace，并验证只读源码、控制 socket、Dashboard 与稳定退出
- 更新 private_runtime submodule 到关联脚本修复

## 数据与部署影响

- 不自动迁移、不删除旧数据
- 首次使用本版本前需停止 runtime，再显式运行 scripts/migrate_plugin_data.py
- 目标 plugin-data 已存在时迁移会 fail-loud，不覆盖
- 当前生产 workspace 未迁移、生产 runtime 未重启

## 验证

- feature 分支隔离 HOME/workspace：2248 passed
- origin/main 干净 worktree：2124 passed
- targeted symlink/migration review：86 passed，实际模拟 publish 失败与非锁 writer 竞争
- pyright changed core files：0 errors
- git diff --check
- docker/debug/plugin_hot_reload_probe.py --scenario sandbox-integrity：passed（runtime smoke、dashboard/control ready、23 repositories unchanged）

## 关联 PR

- private runtime: https://github.com/kachofugetsu09/mcp_server/pull/2
- calendar: https://github.com/akashic-plugins/calendar-mcp/pull/1
- feed: https://github.com/akashic-plugins/feed-mcp/pull/1
- proactive feedback: https://github.com/akashic-plugins/proactive_feedback/pull/1
- huayue skills: https://github.com/akashic-plugins/huayue-skills/pull/1
- setup helper: https://github.com/akashic-plugins/setup_helper/pull/1
- shell restore: https://github.com/akashic-plugins/shell_restore/pull/1

> 合并顺序：先合并 private runtime 与插件 PR，再合并本 PR；安装缓存和正式数据迁移另行执行。