### PR TITLE
fix(mobile): isolate plugin UI failures

### DIFF
--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -58,7 +58,12 @@ class _AcquireSessionModule:
 
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
         state = frame.input
-        session = self._session_manager.get_or_create(state.session_key)
+        require_existing = state.msg.metadata.pop("require_existing_session", False) is True
+        session = (
+            self._session_manager.get_existing(state.session_key)
+            if require_existing
+            else self._session_manager.get_or_create(state.session_key)
+        )
         state.session = session
         frame.slots[_SESSION_SLOT] = session
         return frame

--- a/agent/plugins/mobile_ui.py
+++ b/agent/plugins/mobile_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Mapping
 from typing import Protocol, cast
 
@@ -11,6 +12,7 @@ from agent.plugins.manager import PluginManager
 from agent.plugins.snapshot import RuntimeSnapshot
 
 MOBILE_UI_RPC_TIMEOUT_SECONDS = 20.0
+logger = logging.getLogger(__name__)
 
 
 class MobileUiProvider(Protocol):
@@ -83,17 +85,22 @@ class PluginMobileUiProvider:
                     )
             except TimeoutError as error:
                 raise MobileUiRpcTimeout(f"插件 mobile UI RPC 超时: {plugin_id}.{method}") from error
-            if not isinstance(result, Mapping):
-                raise RuntimeError(f"插件 mobile UI RPC 必须返回对象: {plugin_id}.{method}")
-            normalized = cast(dict[str, object], dict(result))
-            encoded = json.dumps(
-                normalized,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                allow_nan=False,
-            )
-            if len(encoded.encode("utf-8")) > 192 * 1024:
-                raise RuntimeError(f"插件 mobile UI RPC 返回超过 192 KiB: {plugin_id}.{method}")
+            except MobileUiRpcInvalidRequest as error:
+                raise MobileUiRpcInvalidRequest(
+                    f"插件 mobile UI RPC 参数无效: {plugin_id}.{method}"
+                ) from error
+            except Exception as error:
+                logger.exception("插件 mobile UI RPC 执行失败: %s.%s", plugin_id, method)
+                raise MobileUiRpcExecutionError(
+                    f"插件 mobile UI RPC 执行失败: {plugin_id}.{method}"
+                ) from error
+            try:
+                normalized = _normalize_rpc_result(result, plugin_id=plugin_id, method=method)
+            except Exception as error:
+                logger.exception("插件 mobile UI RPC 返回无效: %s.%s", plugin_id, method)
+                raise MobileUiRpcExecutionError(
+                    f"插件 mobile UI RPC 返回无效: {plugin_id}.{method}"
+                ) from error
             return normalized
 
     def _require_snapshot(self) -> RuntimeSnapshot:
@@ -131,3 +138,35 @@ class MobileUiRpcTimeout(TimeoutError):
 
 class MobileUiRpcInvalidRequest(ValueError):
     pass
+
+
+class MobileUiRpcExecutionError(RuntimeError):
+    pass
+
+
+def _normalize_rpc_result(
+    result: object,
+    *,
+    plugin_id: str,
+    method: str,
+) -> dict[str, object]:
+    """校验并规范化插件 RPC 返回对象。"""
+
+    # 1. 校验返回结构和 JSON 可编码性
+    if not isinstance(result, Mapping):
+        raise TypeError(f"插件 mobile UI RPC 必须返回对象: {plugin_id}.{method}")
+    mapping = cast(Mapping[object, object], result)
+    if any(not isinstance(key, str) for key in mapping):
+        raise TypeError(f"插件 mobile UI RPC 返回键必须是字符串: {plugin_id}.{method}")
+    normalized = {cast(str, key): value for key, value in mapping.items()}
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+    # 2. 限制移动端单次响应体积
+    if len(encoded.encode("utf-8")) > 192 * 1024:
+        raise ValueError(f"插件 mobile UI RPC 返回超过 192 KiB: {plugin_id}.{method}")
+    return normalized

--- a/clients/android/app/schemas/com.akashic.mobile.data.local.AppDatabase/6.json
+++ b/clients/android/app/schemas/com.akashic.mobile.data.local.AppDatabase/6.json
@@ -1,0 +1,876 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "03cc0f09755804228889915fe4add644",
+    "entities": [
+      {
+        "tableName": "server_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `deviceId` TEXT NOT NULL, `keyAlias` TEXT NOT NULL, `applicationKeyFingerprint` TEXT NOT NULL, `lanEndpointsJson` TEXT NOT NULL, `tunnelEndpointsJson` TEXT NOT NULL, `tlsSpkiPinsJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyAlias",
+            "columnName": "keyAlias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "applicationKeyFingerprint",
+            "columnName": "applicationKeyFingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lanEndpointsJson",
+            "columnName": "lanEndpointsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tunnelEndpointsJson",
+            "columnName": "tunnelEndpointsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tlsSpkiPinsJson",
+            "columnName": "tlsSpkiPinsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId"
+          ]
+        }
+      },
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `title` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `remoteKnown` INTEGER NOT NULL, PRIMARY KEY(`sessionId`), FOREIGN KEY(`serverId`) REFERENCES `server_profiles`(`serverId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteKnown",
+            "columnName": "remoteKnown",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversations_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `clientMessageId` TEXT, `sessionId` TEXT NOT NULL, `role` TEXT NOT NULL, `text` TEXT NOT NULL, `deliveryState` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `serverSeq` INTEGER, `replyToMessageId` TEXT, `replyRole` TEXT, `replyPreview` TEXT, PRIMARY KEY(`messageId`), FOREIGN KEY(`sessionId`) REFERENCES `conversations`(`sessionId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientMessageId",
+            "columnName": "clientMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveryState",
+            "columnName": "deliveryState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverSeq",
+            "columnName": "serverSeq",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "replyToMessageId",
+            "columnName": "replyToMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyRole",
+            "columnName": "replyRole",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyPreview",
+            "columnName": "replyPreview",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_messages_clientMessageId",
+            "unique": true,
+            "columnNames": [
+              "clientMessageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_messages_clientMessageId` ON `${TABLE_NAME}` (`clientMessageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "turn_blocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`blockId` TEXT NOT NULL, `messageId` TEXT NOT NULL, `turnId` TEXT NOT NULL, `ordinal` INTEGER NOT NULL, `kind` TEXT NOT NULL, `status` TEXT NOT NULL, `content` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`blockId`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`messageId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "blockId",
+            "columnName": "blockId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "turnId",
+            "columnName": "turnId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordinal",
+            "columnName": "ordinal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "blockId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_turn_blocks_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_turn_blocks_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_turn_blocks_turnId_ordinal",
+            "unique": true,
+            "columnNames": [
+              "turnId",
+              "ordinal"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_turn_blocks_turnId_ordinal` ON `${TABLE_NAME}` (`turnId`, `ordinal`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "messageId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outbox_commands",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`commandId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `envelopeJson` TEXT NOT NULL, `state` TEXT NOT NULL, `attemptCount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `lastAttemptAt` INTEGER, PRIMARY KEY(`commandId`), FOREIGN KEY(`serverId`) REFERENCES `server_profiles`(`serverId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "commandId",
+            "columnName": "commandId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "envelopeJson",
+            "columnName": "envelopeJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "commandId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outbox_commands_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outbox_commands_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_outbox_commands_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outbox_commands_state_createdAt` ON `${TABLE_NAME}` (`state`, `createdAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachment_transfers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`attachmentId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `filename` TEXT NOT NULL, `contentType` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `sha256` TEXT NOT NULL, `transferredBytes` INTEGER NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`attachmentId`), FOREIGN KEY(`serverId`) REFERENCES `server_profiles`(`serverId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "attachmentId",
+            "columnName": "attachmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferredBytes",
+            "columnName": "transferredBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "attachmentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_attachment_transfers_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachment_transfers_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_attachment_transfers_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachment_transfers_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "realtime_cursors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`deviceId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `lastAcknowledgedEventSeq` INTEGER NOT NULL, `connectionEpoch` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`deviceId`), FOREIGN KEY(`serverId`) REFERENCES `server_profiles`(`serverId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAcknowledgedEventSeq",
+            "columnName": "lastAcknowledgedEventSeq",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectionEpoch",
+            "columnName": "connectionEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "deviceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_realtime_cursors_serverId",
+            "unique": true,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_realtime_cursors_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`attachmentId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `filename` TEXT NOT NULL, `contentType` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `sha256` TEXT NOT NULL, `transferredBytes` INTEGER NOT NULL, `state` TEXT NOT NULL, `cachePath` TEXT NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`attachmentId`), FOREIGN KEY(`serverId`) REFERENCES `server_profiles`(`serverId`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sessionId`) REFERENCES `conversations`(`sessionId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "attachmentId",
+            "columnName": "attachmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferredBytes",
+            "columnName": "transferredBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachePath",
+            "columnName": "cachePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "attachmentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_attachments_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_attachments_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_media_attachments_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_attachments_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_media_attachments_state",
+            "unique": false,
+            "columnNames": [
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_attachments_state` ON `${TABLE_NAME}` (`state`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "serverId"
+            ]
+          },
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `attachmentId` TEXT NOT NULL, `ordinal` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `attachmentId`), FOREIGN KEY(`messageId`) REFERENCES `messages`(`messageId`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`attachmentId`) REFERENCES `media_attachments`(`attachmentId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachmentId",
+            "columnName": "attachmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordinal",
+            "columnName": "ordinal",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId",
+            "attachmentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_attachments_attachmentId",
+            "unique": false,
+            "columnNames": [
+              "attachmentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_attachments_attachmentId` ON `${TABLE_NAME}` (`attachmentId`)"
+          },
+          {
+            "name": "index_message_attachments_messageId_ordinal",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "ordinal"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_attachments_messageId_ordinal` ON `${TABLE_NAME}` (`messageId`, `ordinal`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "messageId"
+            ]
+          },
+          {
+            "table": "media_attachments",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "attachmentId"
+            ],
+            "referencedColumns": [
+              "attachmentId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "conversation_read_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `lastReadAt` INTEGER NOT NULL, `anchorMessageId` TEXT, `anchorOffsetPx` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `conversations`(`sessionId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anchorMessageId",
+            "columnName": "anchorMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "anchorOffsetPx",
+            "columnName": "anchorOffsetPx",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "sessionId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '03cc0f09755804228889915fe4add644')"
+    ]
+  }
+}

--- a/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/AppDatabaseMigrationTest.kt
+++ b/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/AppDatabaseMigrationTest.kt
@@ -20,7 +20,8 @@ class AppDatabaseMigrationTest {
     @After
     fun removeTestDatabases() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        listOf(DATABASE_1_2, DATABASE_2_3, DATABASE_3_4, DATABASE_4_5).forEach(context::deleteDatabase)
+        listOf(DATABASE_1_2, DATABASE_2_3, DATABASE_3_4, DATABASE_4_5, DATABASE_5_6)
+            .forEach(context::deleteDatabase)
     }
 
     @Test
@@ -150,10 +151,91 @@ class AppDatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrate5To6PersistsKnownRemoteConversationIdentity() {
+        helper.createDatabase(DATABASE_5_6, 5).apply {
+            execSQL(
+                "INSERT INTO server_profiles VALUES('server', '电脑', 'device', 'alias', 'pin', '[]', '[]', '[]', 1)",
+            )
+            execSQL("INSERT INTO conversations VALUES('mobile:remote', 'server', '远端会话', 2)")
+            execSQL("INSERT INTO conversations VALUES('mobile:live', 'server', '实时会话', 3)")
+            execSQL("INSERT INTO conversations VALUES('mobile:local', 'server', '本机会话', 3)")
+            execSQL("INSERT INTO conversations VALUES('mobile:failed', 'server', '失败草稿', 3)")
+            execSQL(
+                """
+                INSERT INTO messages(
+                    messageId, clientMessageId, sessionId, role, text, deliveryState,
+                    createdAt, updatedAt, serverSeq, replyToMessageId, replyRole, replyPreview
+                ) VALUES(
+                    'remote-message', NULL, 'mobile:remote', 'assistant', '旧消息', 'complete',
+                    4, 4, 1, NULL, NULL, NULL
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO messages(
+                    messageId, clientMessageId, sessionId, role, text, deliveryState,
+                    createdAt, updatedAt, serverSeq, replyToMessageId, replyRole, replyPreview
+                ) VALUES(
+                    'live-final', NULL, 'mobile:live', 'assistant', '刚完成的回答', 'complete',
+                    5, 5, NULL, NULL, NULL, NULL
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO messages(
+                    messageId, clientMessageId, sessionId, role, text, deliveryState,
+                    createdAt, updatedAt, serverSeq, replyToMessageId, replyRole, replyPreview
+                ) VALUES(
+                    'local-pending', 'local-client', 'mobile:local', 'user', '还没发送', 'pending',
+                    6, 6, NULL, NULL, NULL, NULL
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO messages(
+                    messageId, clientMessageId, sessionId, role, text, deliveryState,
+                    createdAt, updatedAt, serverSeq, replyToMessageId, replyRole, replyPreview
+                ) VALUES(
+                    'failed-assistant', NULL, 'mobile:failed', 'assistant', '', 'failed',
+                    7, 7, NULL, NULL, NULL, NULL
+                )
+                """.trimIndent(),
+            )
+            close()
+        }
+
+        helper.runMigrationsAndValidate(
+            DATABASE_5_6,
+            6,
+            true,
+            AppDatabase.MIGRATION_5_6,
+        ).use { database ->
+            database.query("SELECT sessionId, remoteKnown FROM conversations ORDER BY sessionId").use { cursor ->
+                check(cursor.moveToFirst())
+                assertEquals("mobile:failed", cursor.getString(0))
+                assertEquals(0, cursor.getInt(1))
+                check(cursor.moveToNext())
+                assertEquals("mobile:live", cursor.getString(0))
+                assertEquals(1, cursor.getInt(1))
+                check(cursor.moveToNext())
+                assertEquals("mobile:local", cursor.getString(0))
+                assertEquals(0, cursor.getInt(1))
+                check(cursor.moveToNext())
+                assertEquals("mobile:remote", cursor.getString(0))
+                assertEquals(1, cursor.getInt(1))
+            }
+        }
+    }
+
     private companion object {
         const val DATABASE_1_2 = "migration-1-2"
         const val DATABASE_2_3 = "migration-2-3"
         const val DATABASE_3_4 = "migration-3-4"
         const val DATABASE_4_5 = "migration-4-5"
+        const val DATABASE_5_6 = "migration-5-6"
     }
 }

--- a/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
+++ b/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
@@ -78,6 +78,141 @@ class LocalDeliveryStoreTest {
     }
 
     @Test
+    fun removesUnavailableRemoteProjectionAndKeepsLocalWork() = runBlocking {
+        assertEquals(1, database.conversations().markRemoteKnown("mobile:test"))
+        database.messages().upsert(
+            MessageEntity(
+                "remote-history",
+                null,
+                "mobile:test",
+                "assistant",
+                "历史",
+                "complete",
+                1,
+                1,
+                serverSeq = 1,
+            ),
+        )
+
+        assertEquals(
+            RemoveUnavailableConversationResult.REMOVED,
+            store.removeUnavailableConversation("server", "mobile:test"),
+        )
+        assertEquals(null, database.conversations().get("mobile:test"))
+        assertEquals(0, database.messages().countForSession("mobile:test"))
+
+        database.conversations().upsert(
+            ConversationEntity("mobile:pending", "server", "待发送", 2, remoteKnown = true),
+        )
+        database.messages().upsert(
+            MessageEntity(
+                "remote-pending",
+                null,
+                "mobile:pending",
+                "assistant",
+                "历史",
+                "complete",
+                2,
+                2,
+                serverSeq = 1,
+            ),
+        )
+        database.messages().upsert(
+            MessageEntity(
+                "user:pending",
+                "pending",
+                "mobile:pending",
+                "user",
+                "尚未发送",
+                "pending",
+                3,
+                3,
+            ),
+        )
+
+        assertEquals(
+            RemoveUnavailableConversationResult.HAS_LOCAL_WORK,
+            store.removeUnavailableConversation("server", "mobile:pending"),
+        )
+        assertNotNull(database.conversations().get("mobile:pending"))
+    }
+
+    @Test
+    fun keepsUnavailableConversationWithAttachmentDraft() = runBlocking {
+        assertEquals(1, database.conversations().markRemoteKnown("mobile:test"))
+        database.messages().upsert(
+            MessageEntity(
+                "remote-history",
+                null,
+                "mobile:test",
+                "assistant",
+                "历史",
+                "complete",
+                1,
+                1,
+                serverSeq = 1,
+            ),
+        )
+        database.attachmentTransfers().upsert(
+            AttachmentTransferEntity(
+                attachmentId = "draft",
+                serverId = "server",
+                sessionId = "mobile:test",
+                filename = "draft.txt",
+                contentType = "text/plain",
+                sizeBytes = 4,
+                sha256 = "a".repeat(64),
+                transferredBytes = 0,
+                state = "ready",
+                updatedAt = 2,
+            ),
+        )
+
+        assertEquals(
+            RemoveUnavailableConversationResult.HAS_LOCAL_WORK,
+            store.removeUnavailableConversation("server", "mobile:test"),
+        )
+        assertNotNull(database.conversations().get("mobile:test"))
+    }
+
+    @Test
+    fun conversationSummarySeparatesRemoteHistoryFromLocalWork() = runBlocking {
+        assertEquals(1, database.conversations().markRemoteKnown("mobile:test"))
+        database.messages().upsert(
+            MessageEntity(
+                "remote-history",
+                null,
+                "mobile:test",
+                "assistant",
+                "历史",
+                "complete",
+                1,
+                1,
+                serverSeq = 1,
+            ),
+        )
+        val remote = database.conversations().observeSummaries("server").first().single()
+        assertTrue(remote.remoteKnown)
+        assertEquals(false, remote.hasLocalWork)
+
+        database.messages().upsert(
+            MessageEntity(
+                "user:failed",
+                "failed",
+                "mobile:test",
+                "user",
+                "失败草稿",
+                "failed_retryable",
+                2,
+                2,
+            ),
+        )
+        val pending = database.conversations().observeSummaries("server").first().single()
+        assertTrue(pending.remoteKnown)
+        assertTrue(pending.hasLocalWork)
+    }
+
+    @Test
     fun reducerPreservesThinkingToolThinkingOrder() = runBlocking {
         val events = listOf(
             event(1, "turn.started", buildJsonObject {}),
@@ -100,6 +235,7 @@ class LocalDeliveryStoreTest {
         )
         events.forEach { store.applyEvent("server", "device", it, it.eventSeq!!) }
 
+        assertTrue(requireNotNull(database.conversations().get("mobile:test")).remoteKnown)
         val blocks = database.messages().getBlocks("assistant:turn")
         assertEquals(listOf("think-1", "tool-1", "think-2"), blocks.map { it.blockId })
         assertEquals(listOf("completed", "completed", "running"), blocks.map { it.status })
@@ -114,6 +250,18 @@ class LocalDeliveryStoreTest {
             decodeStoredToolBlock(blocks[1].content),
         )
         assertEquals("答案", database.messages().get("assistant:turn")!!.text)
+    }
+
+    @Test
+    fun firstRemoteTurnCreatesConversationBeforeAssistantProjection() = runBlocking {
+        assertEquals(1, database.conversations().delete("server", "mobile:test"))
+
+        store.applyEvent("server", "device", event(1, "turn.started", buildJsonObject {}), 2)
+
+        val conversation = requireNotNull(database.conversations().get("mobile:test"))
+        assertTrue(conversation.remoteKnown)
+        assertEquals("streaming", database.messages().get("assistant:turn")!!.deliveryState)
+        assertEquals(1, database.realtimeCursors().get("device")!!.lastAcknowledgedEventSeq)
     }
 
     @Test
@@ -813,6 +961,7 @@ class LocalDeliveryStoreTest {
             store.acknowledgeOutbox(command.id, 3),
         )
         assertEquals("sent", database.attachmentTransfers().get("attachment")!!.state)
+        assertTrue(database.conversations().get("mobile:test")!!.remoteKnown)
         assertEquals(
             listOf("attachment"),
             database.mediaAttachments().forMessage("user:${payload.clientMessageId}").map { it.attachmentId },
@@ -839,6 +988,17 @@ class LocalDeliveryStoreTest {
         assertEquals(2_000, command.createdAt)
         assertEquals(null, database.outbox().get(oldCommandId))
         assertEquals(1, database.messages().countForSession("mobile:test"))
+    }
+
+    @Test
+    fun unavailableSessionRetainsPendingOutboxBeforeTransportAttempt() = runBlocking {
+        val commandId = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        enqueueRetryableMessage(commandId, createdAt = 2_000)
+
+        store.retainUnsentOutbox(commandId, updatedAt = 2_100)
+
+        assertEquals("failed_retryable", database.messages().get("visual-message")!!.deliveryState)
+        assertEquals("failed_retryable", database.outbox().get(commandId)!!.state)
     }
 
     @Test
@@ -1014,6 +1174,48 @@ class LocalDeliveryStoreTest {
             listOf(largeId),
             database.mediaAttachments().pendingDownloads("server").map { it.attachmentId },
         )
+    }
+
+    @Test
+    fun unavailableSessionDownloadDoesNotBlockAnotherConversation() = runBlocking {
+        val unavailableId = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        val availableId = "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+        database.conversations().upsert(
+            ConversationEntity("mobile:stale", "server", "stale", 2, remoteKnown = true),
+        )
+        database.mediaAttachments().upsertAll(
+            listOf(
+                mediaAttachment(unavailableId).copy(
+                    sessionId = "mobile:stale",
+                    sizeBytes = 1,
+                    transferredBytes = 0,
+                    state = "pending",
+                    cachePath = mediaCache.cachePath(unavailableId),
+                    updatedAt = 1,
+                ),
+                mediaAttachment(availableId).copy(
+                    sizeBytes = 1,
+                    transferredBytes = 0,
+                    state = "pending",
+                    cachePath = mediaCache.cachePath(availableId),
+                    updatedAt = 2,
+                ),
+            ),
+        )
+        val sentSessions = mutableListOf<String>()
+        val downloads = AttachmentDownloadCoordinator(
+            database.mediaAttachments(),
+            mediaCache,
+            sendCommand = { _, _, sessionId, _ -> sentSessions += sessionId; true },
+            onTransportUnavailable = {},
+            onDownloadFailed = {},
+            canTransfer = { it.sessionId != "mobile:stale" },
+        )
+
+        downloads.onConnectionReady("server")
+
+        assertEquals(listOf("mobile:test"), sentSessions)
+        assertEquals("pending", database.mediaAttachments().get(unavailableId)!!.state)
     }
 
     @Test

--- a/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
+++ b/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
@@ -78,6 +78,25 @@ class LocalDeliveryStoreTest {
     }
 
     @Test
+    fun deliberateConversationEntryClearsAnchorWithoutAdvancingReadWatermark() = runBlocking {
+        database.messages().upsert(
+            MessageEntity("already-read", null, "mobile:test", "assistant", "已读", "complete", 10, 10),
+        )
+        database.messages().upsert(
+            MessageEntity("still-unread", null, "mobile:test", "assistant", "未读", "complete", 20, 20),
+        )
+        store.markSessionReadThrough("mobile:test", 10, "server", 21)
+        assertTrue(store.saveReadingPosition("mobile:test", "already-read", -24, "server", 22))
+
+        store.clearReadingPosition("mobile:test", "server", 23)
+
+        val summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals(null, summary.anchorMessageId)
+        assertEquals(0, summary.anchorOffsetPx)
+        assertEquals(1, summary.unreadCount)
+    }
+
+    @Test
     fun removesUnavailableRemoteProjectionAndKeepsLocalWork() = runBlocking {
         assertEquals(1, database.conversations().markRemoteKnown("mobile:test"))
         database.messages().upsert(

--- a/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
+++ b/clients/android/app/src/androidTest/java/com/akashic/mobile/data/local/LocalDeliveryStoreTest.kt
@@ -53,6 +53,31 @@ class LocalDeliveryStoreTest {
     fun tearDown() = database.close()
 
     @Test
+    fun reachingConversationTailClearsPersistedReadingAnchor() = runBlocking {
+        database.messages().upsert(
+            MessageEntity("message-in-history", null, "mobile:test", "assistant", "历史", "complete", 1, 1),
+        )
+        assertTrue(store.saveReadingPosition(
+            sessionId = "mobile:test",
+            messageId = "message-in-history",
+            offsetPx = -24,
+            expectedServerId = "server",
+            updatedAt = 2,
+        ))
+
+        store.markSessionReadThrough(
+            sessionId = "mobile:test",
+            readAt = 3,
+            expectedServerId = "server",
+            updatedAt = 3,
+        )
+
+        val summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals(null, summary.anchorMessageId)
+        assertEquals(0, summary.anchorOffsetPx)
+    }
+
+    @Test
     fun reducerPreservesThinkingToolThinkingOrder() = runBlocking {
         val events = listOf(
             event(1, "turn.started", buildJsonObject {}),
@@ -1056,7 +1081,7 @@ class LocalDeliveryStoreTest {
                 1,
             ),
         )
-        database.conversationReadStates().savePosition("mobile:test", optimisticId, -12, 2)
+        assertTrue(store.saveReadingPosition("mobile:test", optimisticId, -12, "server", 2))
         store.applyEvent(
             "server",
             "device",
@@ -1082,10 +1107,14 @@ class LocalDeliveryStoreTest {
         var summary = database.conversations().observeSummaries("server").first().single()
         assertEquals("mobile:test:user:canonical", summary.anchorMessageId)
         assertEquals(-12, summary.anchorOffsetPx)
+        assertTrue(store.saveReadingPosition("mobile:test", optimisticId, -30, "server", 4))
+        summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals("mobile:test:user:canonical", summary.anchorMessageId)
+        assertEquals(-30, summary.anchorOffsetPx)
 
         // 2. 最终事件将 streaming 助手消息与阅读锚点一起迁移
         store.applyEvent("server", "device", event(2, "turn.started", buildJsonObject {}), 4)
-        database.conversationReadStates().savePosition("mobile:test", "assistant:turn", -20, 5)
+        assertTrue(store.saveReadingPosition("mobile:test", "assistant:turn", -20, "server", 5))
         store.applyEvent(
             "server",
             "device",
@@ -1098,6 +1127,67 @@ class LocalDeliveryStoreTest {
         summary = database.conversations().observeSummaries("server").first().single()
         assertEquals("mobile:test:assistant:canonical", summary.anchorMessageId)
         assertEquals(-20, summary.anchorOffsetPx)
+        assertTrue(store.saveReadingPosition("mobile:test", "assistant:turn", -40, "server", 7))
+        summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals("mobile:test:assistant:canonical", summary.anchorMessageId)
+        assertEquals(-40, summary.anchorOffsetPx)
+    }
+
+    @Test
+    fun lateFirstReadingSaveResolvesCanonicalAlias() = runBlocking {
+        store.applyEvent("server", "device", event(1, "turn.started", buildJsonObject {}), 2)
+        store.applyEvent(
+            "server",
+            "device",
+            event(2, "message.final", buildJsonObject {
+                put("message_id", "mobile:test:assistant:canonical")
+                put("content", "最终回答")
+            }),
+            3,
+        )
+
+        assertTrue(store.saveReadingPosition("mobile:test", "assistant:turn", -18, "server", 4))
+        val summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals("mobile:test:assistant:canonical", summary.anchorMessageId)
+        assertEquals(-18, summary.anchorOffsetPx)
+    }
+
+    @Test
+    fun lateReadingSaveResolvesTwoStageCanonicalAlias() = runBlocking {
+        val completedAt = Instant.parse("2026-07-14T16:00:05Z").toEpochMilli()
+        store.applyEvent("server", "device", event(1, "turn.started", buildJsonObject {}), completedAt - 100)
+        store.applyEvent(
+            "server",
+            "device",
+            event(2, "message.final", buildJsonObject { put("content", "两段迁移回答") }),
+            completedAt,
+        )
+        store.applyEvent(
+            "server",
+            "device",
+            event(3, "history.page", buildJsonObject {
+                put("total", 1)
+                put("page", 1)
+                put("page_size", 10)
+                put("items", buildJsonArray {
+                    add(buildJsonObject {
+                        put("id", "mobile:test:assistant:history-canonical")
+                        put("session_key", "mobile:test")
+                        put("seq", 1)
+                        put("role", "assistant")
+                        put("content", "两段迁移回答")
+                        put("extra", buildJsonObject {})
+                        put("ts", "2026-07-14T16:00:05Z")
+                    })
+                })
+            }),
+            completedAt + 1,
+        )
+
+        assertTrue(store.saveReadingPosition("mobile:test", "assistant:turn", -22, "server", completedAt + 2))
+        val summary = database.conversations().observeSummaries("server").first().single()
+        assertEquals("mobile:test:assistant:history-canonical", summary.anchorMessageId)
+        assertEquals(-22, summary.anchorOffsetPx)
     }
 
     private fun transfer(state: String, offset: Long, id: String = "attachment") = AttachmentTransferEntity(

--- a/clients/android/app/src/main/java/com/akashic/mobile/MainActivity.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/MainActivity.kt
@@ -138,6 +138,7 @@ class MainActivity : ComponentActivity() {
                         MobileWebChat(
                             state = conversation,
                             onSelectSession = viewModel::selectSession,
+                            onRemoveUnavailableSession = viewModel::removeUnavailableSession,
                             onNewSession = viewModel::createSession,
                             onRestartPairing = viewModel::restartPairing,
                             onReloadFromServer = viewModel::reloadFromServer,

--- a/clients/android/app/src/main/java/com/akashic/mobile/MainViewModel.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/MainViewModel.kt
@@ -30,6 +30,7 @@ import com.akashic.mobile.ui.conversation.PluginUiResponseUi
 import com.akashic.mobile.ui.conversation.PendingMessageUi
 import com.akashic.mobile.ui.conversation.SessionUi
 import com.akashic.mobile.ui.conversation.TransferStatusUi
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.SharingStarted
@@ -262,36 +263,26 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun selectSession(sessionId: String) = container.realtimeSession.selectSession(sessionId)
 
+    /** 按桥接调用顺序校验并保存会话阅读锚点。 */
     fun saveReadingPosition(sessionId: String, messageId: String, offsetPx: Int) {
-        viewModelScope.launch {
-            require(offsetPx in -10_000..10_000) { "阅读锚点偏移超出范围" }
-            val conversation = requireNotNull(container.database.conversations().get(sessionId)) {
-                "阅读位置会话不存在: $sessionId"
-            }
-            require(conversation.serverId == sessionState.value.serverId) { "阅读位置会话不属于当前电脑" }
-            val message = requireNotNull(container.database.messages().get(messageId)) {
-                "阅读锚点消息不存在: $messageId"
-            }
-            require(message.sessionId == sessionId) { "阅读锚点不属于当前会话" }
-            container.database.conversationReadStates().savePosition(
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            container.deliveryStore.saveReadingPosition(
                 sessionId = sessionId,
                 messageId = messageId,
                 offsetPx = offsetPx,
+                expectedServerId = sessionState.value.serverId,
                 updatedAt = System.currentTimeMillis(),
             )
         }
     }
 
+    /** 按桥接调用顺序推进已读水位并清除旧锚点。 */
     fun markSessionReadThrough(sessionId: String, readAtMillis: Long) {
-        viewModelScope.launch {
-            require(readAtMillis >= 0) { "已读水位不能为负数" }
-            val conversation = requireNotNull(container.database.conversations().get(sessionId)) {
-                "已读水位会话不存在: $sessionId"
-            }
-            require(conversation.serverId == sessionState.value.serverId) { "已读水位会话不属于当前电脑" }
-            container.database.conversationReadStates().markReadThrough(
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            container.deliveryStore.markSessionReadThrough(
                 sessionId = sessionId,
                 readAt = readAtMillis,
+                expectedServerId = sessionState.value.serverId,
                 updatedAt = System.currentTimeMillis(),
             )
         }

--- a/clients/android/app/src/main/java/com/akashic/mobile/MainViewModel.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/MainViewModel.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.akashic.mobile.data.local.MessageWithBlocks
+import com.akashic.mobile.data.local.canRemoveFrom
+import com.akashic.mobile.data.local.isRemoteMissingIn
 import com.akashic.mobile.data.local.MessageAttachmentWithMedia
 import com.akashic.mobile.data.local.decodeStoredToolBlock
 import com.akashic.mobile.data.realtime.TransferNetworkKind
@@ -121,13 +123,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 requiresMeteredApproval = requiresApproval,
             )
         }
+        val mobileConversations = conversations.filter { it.sessionId.startsWith("mobile:") }
+        val selectedRemoteMissing = mobileConversations
+            .firstOrNull { it.sessionId == session.currentSessionId }
+            ?.isRemoteMissingIn(session.remoteSessionIds) == true
         ConversationUiState(
             connectionLabel = connection.label,
             connectionStatus = connection.status,
             connectionNotice = connection.notice,
             errorNotice = session.errorMessage,
-            sessions = conversations
-                .filter { it.sessionId.startsWith("mobile:") }
+            sessions = mobileConversations
                 .map {
                     SessionUi(
                         sessionId = it.sessionId,
@@ -136,6 +141,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         lastMessageAtMillis = it.lastMessageAt,
                         unreadCount = it.unreadCount,
                         isRunning = it.sessionId in session.activeSessionIds,
+                        isAvailable = !it.isRemoteMissingIn(session.remoteSessionIds),
+                        canRemove = it.canRemoveFrom(session.remoteSessionIds),
                     )
                 },
             selectedSessionId = session.currentSessionId,
@@ -175,7 +182,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             canStop = session.activeTurnId != null &&
                 session.connection.phase == ConnectionPhase.READY &&
                 !session.isStopping,
-            canSend = session.hasProfile && composerAttachments.all { it.state == ComposerAttachmentState.READY },
+            canSend = session.hasProfile &&
+                !selectedRemoteMissing &&
+                composerAttachments.all { it.state == ComposerAttachmentState.READY },
         )
     }.stateIn(
         viewModelScope,
@@ -262,6 +271,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun createSession() = container.realtimeSession.createSession()
 
     fun selectSession(sessionId: String) = container.realtimeSession.selectSession(sessionId)
+
+    fun removeUnavailableSession(sessionId: String) =
+        container.realtimeSession.removeUnavailableSession(sessionId)
 
     /** 按桥接调用顺序校验并保存会话阅读锚点。 */
     fun saveReadingPosition(sessionId: String, messageId: String, offsetPx: Int) {

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/AppDatabase.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/AppDatabase.kt
@@ -20,7 +20,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MessageAttachmentEntity::class,
         ConversationReadStateEntity::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -45,7 +45,13 @@ abstract class AppDatabase : RoomDatabase() {
             context.applicationContext,
             AppDatabase::class.java,
             "akashic-mobile.db",
-        ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5).build()
+        ).addMigrations(
+            MIGRATION_1_2,
+            MIGRATION_2_3,
+            MIGRATION_3_4,
+            MIGRATION_4_5,
+            MIGRATION_5_6,
+        ).build()
 
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(db: SupportSQLiteDatabase) {
@@ -116,6 +122,35 @@ abstract class AppDatabase : RoomDatabase() {
                         `updatedAt` INTEGER NOT NULL,
                         PRIMARY KEY(`sessionId`),
                         FOREIGN KEY(`sessionId`) REFERENCES `conversations`(`sessionId`) ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `conversations` ADD COLUMN `remoteKnown` INTEGER NOT NULL DEFAULT 0",
+                )
+                db.execSQL(
+                    """
+                    UPDATE conversations
+                    SET remoteKnown = 1
+                    WHERE EXISTS (
+                        SELECT 1 FROM messages
+                        WHERE messages.sessionId = conversations.sessionId
+                          AND (
+                              messages.serverSeq IS NOT NULL
+                              OR (
+                                  messages.role = 'assistant'
+                                  AND messages.deliveryState IN ('streaming', 'complete', 'interrupted')
+                              )
+                              OR (
+                                  messages.role = 'user'
+                                  AND messages.deliveryState = 'sent'
+                              )
+                          )
                     )
                     """.trimIndent(),
                 )

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
@@ -144,6 +144,8 @@ interface ConversationReadStateDao {
         ) VALUES (:sessionId, :readAt, NULL, 0, :updatedAt)
         ON CONFLICT(sessionId) DO UPDATE SET
           lastReadAt = MAX(lastReadAt, excluded.lastReadAt),
+          anchorMessageId = NULL,
+          anchorOffsetPx = 0,
           updatedAt = excluded.updatedAt
         """,
     )

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
@@ -161,6 +161,17 @@ interface ConversationReadStateDao {
 
     @Query(
         """
+        UPDATE conversation_read_states
+        SET anchorMessageId = NULL,
+            anchorOffsetPx = 0,
+            updatedAt = :updatedAt
+        WHERE sessionId = :sessionId
+        """,
+    )
+    suspend fun clearPosition(sessionId: String, updatedAt: Long): Int
+
+    @Query(
+        """
         INSERT INTO conversation_read_states (
           sessionId, lastReadAt, anchorMessageId, anchorOffsetPx, updatedAt
         ) VALUES (:sessionId, :readAt, NULL, 0, :updatedAt)

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/Daos.kt
@@ -75,7 +75,23 @@ interface ConversationDao {
               AND message.deliveryState = 'streaming'
           ) AS isRunning,
           read_state.anchorMessageId AS anchorMessageId,
-          COALESCE(read_state.anchorOffsetPx, 0) AS anchorOffsetPx
+          COALESCE(read_state.anchorOffsetPx, 0) AS anchorOffsetPx,
+          conversation.remoteKnown AS remoteKnown,
+          (
+            EXISTS (
+              SELECT 1 FROM messages AS message
+              WHERE message.sessionId = conversation.sessionId
+                AND message.clientMessageId IS NOT NULL
+                AND message.deliveryState IN (
+                  'pending', 'sent', 'failed', 'failed_retryable', 'outcome_unknown'
+                )
+            ) OR EXISTS (
+              SELECT 1 FROM attachment_transfers AS transfer
+              WHERE transfer.serverId = conversation.serverId
+                AND transfer.sessionId = conversation.sessionId
+                AND transfer.state IN ('pending', 'uploading', 'finishing', 'ready', 'failed')
+            )
+          ) AS hasLocalWork
         FROM conversations AS conversation
         LEFT JOIN conversation_read_states AS read_state
           ON read_state.sessionId = conversation.sessionId
@@ -87,6 +103,12 @@ interface ConversationDao {
 
     @Query("SELECT * FROM conversations WHERE sessionId = :sessionId")
     suspend fun get(sessionId: String): ConversationEntity?
+
+    @Query("UPDATE conversations SET remoteKnown = 1 WHERE sessionId = :sessionId")
+    suspend fun markRemoteKnown(sessionId: String): Int
+
+    @Query("DELETE FROM conversations WHERE serverId = :serverId AND sessionId = :sessionId")
+    suspend fun delete(serverId: String, sessionId: String): Int
 
     @Query(
         """
@@ -235,6 +257,16 @@ interface MessageDao {
     @Query("SELECT COUNT(*) FROM messages WHERE sessionId = :sessionId")
     suspend fun countForSession(sessionId: String): Int
 
+    @Query(
+        """
+        SELECT COUNT(*) FROM messages
+        WHERE sessionId = :sessionId
+          AND clientMessageId IS NOT NULL
+          AND deliveryState IN ('pending', 'sent', 'failed', 'failed_retryable', 'outcome_unknown')
+        """,
+    )
+    suspend fun countLocalWorkForSession(sessionId: String): Int
+
     @Query("SELECT * FROM turn_blocks WHERE blockId = :blockId")
     suspend fun getBlock(blockId: String): TurnBlockEntity?
 
@@ -353,6 +385,15 @@ interface OutboxDao {
 
     @Query("UPDATE outbox_commands SET state = :failureState WHERE commandId = :commandId AND state = 'in_flight'")
     suspend fun markFailed(commandId: String, failureState: String): Int
+
+    @Query(
+        """
+        UPDATE outbox_commands
+        SET state = 'failed_retryable'
+        WHERE commandId = :commandId AND state IN ('pending', 'retry')
+        """,
+    )
+    suspend fun markUnsentFailed(commandId: String): Int
 
     @Query("UPDATE outbox_commands SET state = 'retry' WHERE commandId = :commandId AND state = 'outcome_unknown'")
     suspend fun recheckUnknown(commandId: String): Int
@@ -473,6 +514,9 @@ interface AttachmentTransferDao {
 
     @Query("DELETE FROM attachment_transfers WHERE state = 'sent'")
     suspend fun deleteSent(): Int
+
+    @Query("DELETE FROM attachment_transfers WHERE serverId = :serverId AND sessionId = :sessionId AND state = 'sent'")
+    suspend fun deleteSentForSession(serverId: String, sessionId: String): Int
 }
 
 @Dao

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/Entities.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/Entities.kt
@@ -37,6 +37,7 @@ data class ConversationEntity(
     val serverId: String,
     val title: String,
     val updatedAt: Long,
+    val remoteKnown: Boolean = false,
 )
 
 @Entity(
@@ -67,7 +68,17 @@ data class ConversationSummary(
     val isRunning: Boolean,
     val anchorMessageId: String?,
     val anchorOffsetPx: Int,
+    val remoteKnown: Boolean,
+    val hasLocalWork: Boolean,
 )
+
+fun ConversationSummary.isRemoteMissingIn(remoteSessionIds: Set<String>?): Boolean =
+    remoteSessionIds != null &&
+        sessionId !in remoteSessionIds &&
+        remoteKnown
+
+fun ConversationSummary.canRemoveFrom(remoteSessionIds: Set<String>?): Boolean =
+    isRemoteMissingIn(remoteSessionIds) && !hasLocalWork
 
 @Entity(
     tableName = "messages",

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
@@ -26,6 +26,12 @@ import kotlinx.serialization.json.longOrNull
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+enum class RemoveUnavailableConversationResult {
+    REMOVED,
+    HAS_LOCAL_WORK,
+    NOT_REMOTE,
+}
+
 private const val TOOL_BLOCK_V1_PREFIX = "tool.v1:"
 private const val LEGACY_IDENTITY_LOOKBACK_MS = 60 * 60 * 1_000L
 private const val MAX_CANONICAL_MESSAGE_ALIASES = 256
@@ -143,6 +149,38 @@ class LocalDeliveryStore(
         mediaCache.reconcile()
     }
 
+    /** 删除服务端已不存在、且没有未发送工作的本机会话副本。 */
+    suspend fun removeUnavailableConversation(
+        serverId: String,
+        sessionId: String,
+    ): RemoveUnavailableConversationResult = readingStateMutex.withLock {
+        // 1. 在持久化边界重新确认会话归属和可删除状态
+        val result = database.withTransaction {
+            val conversation = requireNotNull(database.conversations().get(sessionId)) {
+                "Unknown conversation: $sessionId"
+            }
+            require(conversation.serverId == serverId) { "Conversation belongs to another server" }
+            if (!conversation.remoteKnown) {
+                return@withTransaction RemoveUnavailableConversationResult.NOT_REMOTE
+            }
+            if (
+                database.messages().countLocalWorkForSession(sessionId) > 0 ||
+                database.attachmentTransfers().drafts(serverId, sessionId).isNotEmpty()
+            ) {
+                return@withTransaction RemoveUnavailableConversationResult.HAS_LOCAL_WORK
+            }
+
+            // 2. 删除本地投影，依靠外键清理消息、已读锚点和媒体描述符
+            database.attachmentTransfers().deleteSentForSession(serverId, sessionId)
+            check(database.conversations().delete(serverId, sessionId) == 1)
+            RemoveUnavailableConversationResult.REMOVED
+        }
+
+        // 3. 删除失去数据库引用的缓存文件
+        if (result == RemoveUnavailableConversationResult.REMOVED) mediaCache.reconcile()
+        result
+    }
+
     /** 在同一事务应用有序事件并推进持久化 cursor。 */
     suspend fun applyEvent(
         serverId: String,
@@ -174,6 +212,11 @@ class LocalDeliveryStore(
             }
 
             if (envelope.type == "message.final") finalMessageAttention(envelope.payload)
+            envelope.sessionId?.let { sessionId ->
+                if (envelope.type in REMOTE_SESSION_EVENTS) {
+                    ensureRemoteConversation(serverId, sessionId, updatedAt)
+                }
+            }
             applyEventContent(serverId, envelope, updatedAt)
             val changed = database.realtimeCursors().advance(
                 deviceId = deviceId,
@@ -201,6 +244,9 @@ class LocalDeliveryStore(
             val command = requireNotNull(database.outbox().get(commandId)) { "Unknown outbox command: $commandId" }
             val envelope = ProtocolCodec.decode(command.envelopeJson)
             val payload = ProtocolCodec.decodePayload<com.akashic.mobile.data.realtime.MessageSendPayload>(envelope.payload)
+            check(database.conversations().markRemoteKnown(requireNotNull(envelope.sessionId)) == 1) {
+                "Outbox ACK 对应的会话投影不存在: ${envelope.sessionId}"
+            }
             val changed = database.messages().updateDelivery(payload.clientMessageId, "sent", updatedAt)
             check(changed == 1) { "Outbox message is missing: ${payload.clientMessageId}" }
             if (payload.mediaRefs.isNotEmpty()) {
@@ -228,6 +274,20 @@ class LocalDeliveryStore(
                 check(database.attachmentTransfers().restoreReady(payload.mediaRefs, updatedAt) == payload.mediaRefs.size)
             }
             check(database.outbox().markFailed(commandId, state) == 1)
+        }
+    }
+
+    /** 在写入 WebSocket 前保留已失效会话的待发命令。 */
+    suspend fun retainUnsentOutbox(commandId: String, updatedAt: Long) {
+        database.withTransaction {
+            val command = requireNotNull(database.outbox().get(commandId)) { "Unknown outbox command: $commandId" }
+            val envelope = ProtocolCodec.decode(command.envelopeJson)
+            val payload = ProtocolCodec.decodePayload<com.akashic.mobile.data.realtime.MessageSendPayload>(envelope.payload)
+            check(database.messages().updateDelivery(payload.clientMessageId, "failed_retryable", updatedAt) == 1)
+            if (payload.mediaRefs.isNotEmpty()) {
+                check(database.attachmentTransfers().restoreReady(payload.mediaRefs, updatedAt) == payload.mediaRefs.size)
+            }
+            check(database.outbox().markUnsentFailed(commandId) == 1)
         }
     }
 
@@ -373,6 +433,7 @@ class LocalDeliveryStore(
                     serverId = serverId,
                     title = item.title,
                     updatedAt = Instant.parse(item.updatedAt).toEpochMilli(),
+                    remoteKnown = true,
                 ),
             )
         }
@@ -386,8 +447,16 @@ class LocalDeliveryStore(
         val payload = ProtocolCodec.decodePayload<HistoryPagePayload>(envelope.payload)
         if (database.conversations().get(sessionId) == null) {
             database.conversations().upsert(
-                ConversationEntity(sessionId, serverId, "新对话", System.currentTimeMillis()),
+                ConversationEntity(
+                    sessionId,
+                    serverId,
+                    "新对话",
+                    System.currentTimeMillis(),
+                    remoteKnown = true,
+                ),
             )
+        } else {
+            check(database.conversations().markRemoteKnown(sessionId) == 1)
         }
         payload.items.forEach { remote ->
             require(remote.sessionKey == sessionId) { "History item session mismatch" }
@@ -523,8 +592,23 @@ class LocalDeliveryStore(
                 serverId = current?.serverId ?: serverId,
                 title = payloadText(envelope, "title") ?: current?.title ?: "新对话",
                 updatedAt = updatedAt,
+                remoteKnown = true,
             ),
         )
+    }
+
+    private suspend fun ensureRemoteConversation(serverId: String, sessionId: String, updatedAt: Long) {
+        val current = database.conversations().get(sessionId)
+        if (current == null) {
+            database.conversations().upsert(
+                ConversationEntity(sessionId, serverId, "新对话", updatedAt, remoteKnown = true),
+            )
+            return
+        }
+        require(current.serverId == serverId) { "远端事件会话不属于当前电脑" }
+        if (!current.remoteKnown) {
+            check(database.conversations().markRemoteKnown(sessionId) == 1)
+        }
     }
 
     private suspend fun ensureAssistantTurn(envelope: WireEnvelope, updatedAt: Long): MessageEntity {
@@ -899,6 +983,13 @@ class LocalDeliveryStore(
     private companion object {
         const val MAX_ATTACHMENT_BYTES = 50L * 1024 * 1024
         const val AUTO_DOWNLOAD_LIMIT_BYTES = 10L * 1024 * 1024
+        val REMOTE_SESSION_EVENTS = setOf(
+            "session.created",
+            "session.updated",
+            "history.page",
+            "turn.started",
+            "message.proactive",
+        )
         val MIME_TYPE = Regex("^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
         val FRAME_ID = Regex(
             "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-" +

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
@@ -85,6 +85,19 @@ class LocalDeliveryStore(
         true
     }
 
+    /** 用户主动进入会话时清除旧锚点，但不提前推进已读水位。 */
+    suspend fun clearReadingPosition(
+        sessionId: String,
+        expectedServerId: String?,
+        updatedAt: Long,
+    ) = readingStateMutex.withLock {
+        val conversation = requireNotNull(database.conversations().get(sessionId)) {
+            "阅读位置会话不存在: $sessionId"
+        }
+        require(conversation.serverId == expectedServerId) { "阅读位置会话不属于当前电脑" }
+        database.conversationReadStates().clearPosition(sessionId, updatedAt)
+    }
+
     /** 串行推进已读水位并清除旧阅读锚点。 */
     suspend fun markSessionReadThrough(
         sessionId: String,

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/local/LocalDeliveryStore.kt
@@ -23,9 +23,12 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private const val TOOL_BLOCK_V1_PREFIX = "tool.v1:"
 private const val LEGACY_IDENTITY_LOOKBACK_MS = 60 * 60 * 1_000L
+private const val MAX_CANONICAL_MESSAGE_ALIASES = 256
 
 @Serializable
 internal data class StoredToolBlock(
@@ -50,6 +53,50 @@ class LocalDeliveryStore(
     private val database: AppDatabase,
     private val mediaCache: MediaCacheStore,
 ) {
+    private val readingStateMutex = Mutex()
+    private val canonicalMessageAliases = linkedMapOf<String, String>()
+
+    /** 串行校验并保存 WebView 当前可见消息锚点。 */
+    suspend fun saveReadingPosition(
+        sessionId: String,
+        messageId: String,
+        offsetPx: Int,
+        expectedServerId: String?,
+        updatedAt: Long,
+    ): Boolean = readingStateMutex.withLock {
+        // 1. 校验当前投影边界；canonical 迁移后的旧 UI 写入已失效
+        require(offsetPx in -10_000..10_000) { "阅读锚点偏移超出范围" }
+        val conversation = requireNotNull(database.conversations().get(sessionId)) {
+            "阅读位置会话不存在: $sessionId"
+        }
+        require(conversation.serverId == expectedServerId) { "阅读位置会话不属于当前电脑" }
+        val resolvedMessageId = canonicalMessageAliases[messageId] ?: messageId
+        val message = database.messages().get(resolvedMessageId) ?: return@withLock false
+        require(message.sessionId == sessionId) { "阅读锚点不属于当前会话" }
+
+        // 2. 在 canonical 迁移共用的锁内持久化，避免写回已删除身份
+        database.conversationReadStates().savePosition(sessionId, resolvedMessageId, offsetPx, updatedAt)
+        true
+    }
+
+    /** 串行推进已读水位并清除旧阅读锚点。 */
+    suspend fun markSessionReadThrough(
+        sessionId: String,
+        readAt: Long,
+        expectedServerId: String?,
+        updatedAt: Long,
+    ) = readingStateMutex.withLock {
+        // 1. 校验 WebView 边界输入与当前电脑身份
+        require(readAt >= 0) { "已读水位不能为负数" }
+        val conversation = requireNotNull(database.conversations().get(sessionId)) {
+            "已读水位会话不存在: $sessionId"
+        }
+        require(conversation.serverId == expectedServerId) { "已读水位会话不属于当前电脑" }
+
+        // 2. 与保存及 canonical 迁移共用同一写序
+        database.conversationReadStates().markReadThrough(sessionId, readAt, updatedAt)
+    }
+
     suspend fun savePairedProfile(profile: ServerProfileEntity, cursor: RealtimeCursorEntity) {
         database.withTransaction {
             database.serverProfiles().upsert(profile)
@@ -85,9 +132,11 @@ class LocalDeliveryStore(
     /** 清除可从服务端恢复的投影与附件缓存，同时保留配对和未发送工作。 */
     suspend fun clearReloadableCache(serverId: String, preservedSessionId: String?) {
         // 1. 原子移除已提交消息，保留待发送消息、草稿和连接身份
-        database.withTransaction {
-            database.messages().deleteReloadableServerCache(serverId)
-            database.conversations().deleteEmptyProjection(serverId, preservedSessionId)
+        readingStateMutex.withLock {
+            database.withTransaction {
+                database.messages().deleteReloadableServerCache(serverId)
+                database.conversations().deleteEmptyProjection(serverId, preservedSessionId)
+            }
         }
 
         // 2. 删除失去消息引用的附件文件和描述符
@@ -101,11 +150,11 @@ class LocalDeliveryStore(
         envelope: WireEnvelope,
         updatedAt: Long,
         preservedSessionId: String? = null,
-    ): Long {
+    ): Long = readingStateMutex.withLock {
         require(envelope.kind == WireKind.EVENT) { "Only event envelopes can advance the cursor" }
         val eventSeq = requireNotNull(envelope.eventSeq)
         val connectionEpoch = requireNotNull(envelope.connectionEpoch)
-        return database.withTransaction {
+        database.withTransaction {
             val cursor = requireNotNull(database.realtimeCursors().get(deviceId)) {
                 "Realtime cursor is missing for device $deviceId"
             }
@@ -723,6 +772,13 @@ class LocalDeliveryStore(
         messages.moveBlocks(sourceId, canonical.messageId)
         media.moveLinks(sourceId, canonical.messageId)
         check(messages.delete(sourceId) == 1) { "Source message disappeared during canonical merge" }
+        canonicalMessageAliases.entries.forEach { alias ->
+            if (alias.value == sourceId) alias.setValue(canonical.messageId)
+        }
+        canonicalMessageAliases[sourceId] = canonical.messageId
+        if (canonicalMessageAliases.size > MAX_CANONICAL_MESSAGE_ALIASES) {
+            canonicalMessageAliases.remove(canonicalMessageAliases.keys.first())
+        }
     }
 
     private suspend fun interruptTurn(envelope: WireEnvelope, updatedAt: Long) {

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/AttachmentDownloadCoordinator.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/AttachmentDownloadCoordinator.kt
@@ -16,6 +16,7 @@ class AttachmentDownloadCoordinator(
     private val onTransportUnavailable: (String) -> Unit,
     private val onDownloadFailed: (String) -> Unit,
     private val onStateChanged: (Boolean) -> Unit = {},
+    private val canTransfer: suspend (MediaAttachmentEntity) -> Boolean = { true },
 ) {
     private data class ActiveDownload(
         val commandId: String,
@@ -44,9 +45,10 @@ class AttachmentDownloadCoordinator(
     }
 
     suspend fun retry(attachmentId: String) {
+        val current = requireNotNull(dao.get(attachmentId)) { "附件不存在: $attachmentId" }
+        require(canTransfer(current)) { "这段会话已不在电脑上，无法下载附件" }
         val changed = dao.requestDownload(attachmentId, System.currentTimeMillis())
         if (changed == 0) {
-            val current = requireNotNull(dao.get(attachmentId)) { "附件不存在: $attachmentId" }
             check(current.state in setOf("pending", "downloading", "cached")) {
                 "附件当前不可开始下载: $attachmentId"
             }
@@ -109,7 +111,7 @@ class AttachmentDownloadCoordinator(
         if (active != null) return
         var reconciled: MediaAttachmentEntity
         while (true) {
-            val transfer = dao.pendingDownloads(currentServerId).firstOrNull() ?: return
+            val transfer = dao.pendingDownloads(currentServerId).firstOrNull { canTransfer(it) } ?: return
             try {
                 reconciled = reconcilePartial(transfer)
                 if (reconciled.transferredBytes == reconciled.sizeBytes) {

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/AttachmentUploadCoordinator.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/AttachmentUploadCoordinator.kt
@@ -17,7 +17,7 @@ class AttachmentUploadCoordinator(
     private val sendBinary: (okio.ByteString) -> Boolean,
     private val onTransportUnavailable: (String) -> Unit,
     private val onUploadFailed: (String) -> Unit,
-    private val canTransfer: (AttachmentTransferEntity) -> Boolean = { true },
+    private val canTransfer: suspend (AttachmentTransferEntity) -> Boolean = { true },
 ) {
     private data class PendingCommand(val type: String, val attachmentId: String)
 
@@ -127,7 +127,7 @@ class AttachmentUploadCoordinator(
         if (active != null || pendingCommands.isNotEmpty()) return
         var transfer: AttachmentTransferEntity
         while (true) {
-            transfer = dao.pendingUploads(currentServer).firstOrNull(canTransfer) ?: return
+            transfer = dao.pendingUploads(currentServer).firstOrNull { canTransfer(it) } ?: return
             if (dao.claimUploading(transfer.attachmentId, System.currentTimeMillis()) == 1) break
         }
         val commandId = Ulid.next()

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/RealtimeSession.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/RealtimeSession.kt
@@ -11,10 +11,13 @@ import com.akashic.mobile.data.local.AppPreferences
 import com.akashic.mobile.data.local.ConversationEntity
 import com.akashic.mobile.data.local.LocalDeliveryStore
 import com.akashic.mobile.data.local.MessageEntity
+import com.akashic.mobile.data.local.MediaAttachmentEntity
 import com.akashic.mobile.data.local.MediaCacheStore
 import com.akashic.mobile.data.local.OutboxCommandEntity
 import com.akashic.mobile.data.local.RealtimeCursorEntity
+import com.akashic.mobile.data.local.RemoveUnavailableConversationResult
 import com.akashic.mobile.data.local.ServerProfileEntity
+import com.akashic.mobile.data.local.isRemoteMissingIn
 import com.akashic.mobile.domain.model.ConnectionPhase
 import com.akashic.mobile.domain.model.ConnectionState
 import com.akashic.mobile.domain.model.EndpointRoute
@@ -62,6 +65,7 @@ data class MobileSessionState(
     val serverId: String? = null,
     val pairingConfirmationCode: String? = null,
     val currentSessionId: String? = null,
+    val remoteSessionIds: Set<String>? = null,
     val activeTurnId: String? = null,
     val activeSessionIds: Set<String> = emptySet(),
     val hasActiveAttachmentDownload: Boolean = false,
@@ -151,6 +155,7 @@ class RealtimeSession(
             mutableState.value = mutableState.value.copy(errorMessage = message)
         },
         onStateChanged = ::publishDownloadState,
+        canTransfer = ::canDownloadAttachment,
     )
     private val stops = TurnStopCoordinator(
         send = ::sendTurnStopCommand,
@@ -351,7 +356,11 @@ class RealtimeSession(
             try {
                 val target = mutex.withLock {
                     val currentProfile = requireNotNull(profile) { "Pair a server before attaching" }
-                    currentProfile.serverId to ensureCurrentSession(currentProfile)
+                    val sessionId = ensureCurrentSession(currentProfile)
+                    require(!isRemoteMissingSession(currentProfile.serverId, sessionId)) {
+                        "这段会话已不在电脑上，请新建会话后添加附件"
+                    }
+                    currentProfile.serverId to sessionId
                 }
                 attachmentOperations.perform {
                     attachmentDrafts.import(
@@ -396,14 +405,26 @@ class RealtimeSession(
 
     fun retryAttachment(attachmentId: String) {
         scope.launch {
-            attachmentOperations.perform {
-                attachmentDrafts.retry(attachmentId, System.currentTimeMillis())
-            }
-            mutex.withLock {
-                profile?.serverId?.let { serverId ->
-                    if (mutableState.value.connection.phase == ConnectionPhase.READY) {
-                        uploads.resumeIfIdle(serverId)
+            try {
+                attachmentOperations.perform {
+                    val transfer = requireNotNull(database.attachmentTransfers().get(attachmentId)) {
+                        "Unknown attachment: $attachmentId"
                     }
+                    require(!isRemoteMissingSession(transfer.serverId, transfer.sessionId)) {
+                        "这段会话已不在电脑上，请新建会话后添加附件"
+                    }
+                    attachmentDrafts.retry(attachmentId, System.currentTimeMillis())
+                }
+                mutex.withLock {
+                    profile?.serverId?.let { serverId ->
+                        if (mutableState.value.connection.phase == ConnectionPhase.READY) {
+                            uploads.resumeIfIdle(serverId)
+                        }
+                    }
+                }
+            } catch (error: IllegalArgumentException) {
+                mutex.withLock {
+                    mutableState.value = mutableState.value.copy(errorMessage = error.message)
                 }
             }
         }
@@ -431,6 +452,16 @@ class RealtimeSession(
     fun retryFailedMessage(messageId: String) {
         scope.launch {
             mutex.withLock {
+                val message = requireNotNull(database.messages().get(messageId)) {
+                    "Unknown failed message: $messageId"
+                }
+                val currentProfile = requireNotNull(profile) { "Pair a server before retrying" }
+                if (isRemoteMissingSession(currentProfile.serverId, message.sessionId)) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = "这段会话已不在电脑上，请新建会话后继续",
+                    )
+                    return@withLock
+                }
                 val now = System.currentTimeMillis()
                 deliveryStore.retryFailedMessage(messageId, Ulid.next(now), now)
                 mutableState.value = mutableState.value.copy(errorMessage = null)
@@ -441,8 +472,14 @@ class RealtimeSession(
 
     fun retryDownloadedAttachment(attachmentId: String) {
         scope.launch {
-            mutex.withLock {
-                downloads.retry(attachmentId)
+            try {
+                mutex.withLock {
+                    downloads.retry(attachmentId)
+                }
+            } catch (error: IllegalArgumentException) {
+                mutex.withLock {
+                    mutableState.value = mutableState.value.copy(errorMessage = error.message)
+                }
             }
         }
     }
@@ -506,6 +543,14 @@ class RealtimeSession(
                 if (requestId.length !in 1..128) return@withLock
                 if (sessionId != null && !MOBILE_SESSION.matches(sessionId)) {
                     appendPluginUiError(requestId, "插件请求的会话无效")
+                    return@withLock
+                }
+                val currentProfile = profile
+                if (
+                    sessionId != null && currentProfile != null &&
+                    isRemoteMissingSession(currentProfile.serverId, sessionId)
+                ) {
+                    appendPluginUiError(requestId, "会话已不在电脑上")
                     return@withLock
                 }
                 if (turnId != null && turnId.length !in 1..512) {
@@ -581,6 +626,13 @@ class RealtimeSession(
                     require(conversation.serverId == currentProfile.serverId) {
                         "Notification session belongs to another server"
                     }
+                }
+                if (isRemoteMissingSession(currentProfile.serverId, sessionId)) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = "这段会话已不在电脑上，请新建会话后继续",
+                    )
+                    reportResult(false)
+                    return@withLock
                 }
                 val attachments = if (includeDraftAttachments) {
                     database.attachmentTransfers().drafts(currentProfile.serverId, sessionId)
@@ -733,16 +785,72 @@ class RealtimeSession(
             mutex.withLock {
                 // 1. 创建本地会话
                 val currentProfile = requireNotNull(profile) { "Pair a server before creating a session" }
-                val now = System.currentTimeMillis()
-                val sessionId = "mobile:${UUID.randomUUID()}"
-                database.conversations().upsert(
-                    ConversationEntity(sessionId, currentProfile.serverId, "新对话", now),
-                )
+                val sessionId = createLocalSession(currentProfile)
 
                 // 2. 切换当前会话
                 preferences.selectSession(sessionId)
                 mutableState.value = mutableState.value.copy(currentSessionId = sessionId)
                 publishTurnState()
+            }
+        }
+    }
+
+    /** 删除电脑端已不存在的本机会话副本，并选择下一段可用会话。 */
+    fun removeUnavailableSession(sessionId: String) {
+        scope.launch {
+            mutex.withLock {
+                // 1. 重新核对服务端目录，避免删除刚恢复的会话
+                require(MOBILE_SESSION.matches(sessionId)) { "Invalid mobile session_id" }
+                val currentProfile = requireNotNull(profile) { "Pair a server before removing a session" }
+                val remoteSessionIds = mutableState.value.remoteSessionIds
+                if (remoteSessionIds == null || sessionId in remoteSessionIds) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = "会话状态已经更新，请重新打开会话列表",
+                    )
+                    return@withLock
+                }
+                if (sessionId in stops.activeSessionIds()) {
+                    mutableState.value = mutableState.value.copy(errorMessage = "会话仍在运行，暂时不能移除")
+                    return@withLock
+                }
+
+                // 2. 删除无待发送工作的本地投影
+                val result = try {
+                    deliveryStore.removeUnavailableConversation(currentProfile.serverId, sessionId)
+                } catch (error: IOException) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = "清理会话缓存失败：${error.message}",
+                    )
+                    return@withLock
+                } catch (error: SecurityException) {
+                    mutableState.value = mutableState.value.copy(errorMessage = "会话缓存路径不安全")
+                    return@withLock
+                }
+                if (result != RemoveUnavailableConversationResult.REMOVED) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = when (result) {
+                            RemoveUnavailableConversationResult.HAS_LOCAL_WORK ->
+                                "会话还有未发送的消息或附件，暂时不能移除"
+                            RemoveUnavailableConversationResult.NOT_REMOTE ->
+                                "这是本机新建的会话，不需要清理"
+                            RemoveUnavailableConversationResult.REMOVED -> error("unreachable")
+                        },
+                    )
+                    return@withLock
+                }
+
+                // 3. 当前会话被移除时，切到最近可用会话；没有则创建新会话
+                if (mutableState.value.currentSessionId == sessionId) {
+                    val nextSessionId = database.conversations()
+                        .observeSummaries(currentProfile.serverId)
+                        .first()
+                        .firstOrNull { !it.isRemoteMissingIn(remoteSessionIds) }
+                        ?.sessionId
+                        ?: createLocalSession(currentProfile)
+                    preferences.selectSession(nextSessionId)
+                    mutableState.value = mutableState.value.copy(currentSessionId = nextSessionId)
+                    publishTurnState()
+                }
             }
         }
     }
@@ -1021,6 +1129,7 @@ class RealtimeSession(
                 endpoint = candidateEndpoints[candidateId],
                 connectionEpoch = accepted.connectionEpoch,
             ),
+            remoteSessionIds = null,
             errorMessage = null,
         )
         database.outbox().resetInFlight(currentProfile.serverId)
@@ -1041,15 +1150,19 @@ class RealtimeSession(
                 )
                 recordAck(eventSeq)
                 when (envelope.type) {
-                    "turn.started" -> stops.onTurnStarted(
-                        requireNotNull(envelope.sessionId),
-                        requireNotNull(envelope.turnId),
-                    )
+                    "turn.started" -> {
+                        rememberRemoteSession(requireNotNull(envelope.sessionId))
+                        stops.onTurnStarted(
+                            requireNotNull(envelope.sessionId),
+                            requireNotNull(envelope.turnId),
+                        )
+                    }
                     "turn.interrupted" -> stops.onTurnTerminal(
                         requireNotNull(envelope.sessionId),
                         requireNotNull(envelope.turnId),
                     )
                     "message.final" -> {
+                        rememberRemoteSession(requireNotNull(envelope.sessionId))
                         stops.onTurnTerminal(
                             requireNotNull(envelope.sessionId),
                             requireNotNull(envelope.turnId),
@@ -1060,32 +1173,29 @@ class RealtimeSession(
                     "sync.completed" -> {
                         if (completedSyncGeneration == syncGeneration) return
                         completedSyncGeneration = syncGeneration
-                        mutableState.value = mutableState.value.copy(
-                            connection = mutableState.value.connection.copy(phase = ConnectionPhase.READY),
-                        )
                         requestSessionList()
-                        requestCommandList()
-                        requestPluginUiList()
-                        uploads.onConnectionReady(currentProfile.serverId)
-                        downloads.onConnectionReady(currentProfile.serverId)
-                        stops.onConnectionReady()
-                        flushOutbox()
                     }
                     "sync.reset_required" -> beginResetRebuild()
                     "session.list" -> {
+                        applyRemoteSessionList(envelope)
                         if (hasPendingSyncCommand("session.list")) {
                             requestAllHistory(envelope)
                         }
                     }
                     "history.page" -> {
+                        rememberRemoteSession(requireNotNull(envelope.sessionId))
                         requestNextHistoryPage(envelope)
                         downloads.resumeIfIdle(currentProfile.serverId)
                     }
                     "attachment.progress" -> uploads.onProgress(
                         ProtocolCodec.decodePayload(envelope.payload),
                     )
-                    "message.proactive" ->
+                    "message.proactive" -> {
+                        rememberRemoteSession(requireNotNull(envelope.sessionId))
                         downloads.resumeIfIdle(currentProfile.serverId)
+                    }
+                    "session.created", "session.updated" ->
+                        rememberRemoteSession(requireNotNull(envelope.sessionId))
                     "plugin.ui.changed" -> requestPluginUiList()
                     "connection.degraded" -> mutableState.value = mutableState.value.copy(
                         connection = mutableState.value.connection.copy(phase = ConnectionPhase.DEGRADED),
@@ -1176,7 +1286,8 @@ class RealtimeSession(
                     mutableState.value = mutableState.value.copy(
                         errorMessage = envelope.payload["message"]?.toString()?.trim('"') ?: "历史同步失败",
                     )
-                    finishResetRebuildIfComplete()
+                    socket.close(reason = "history sync rejected")
+                    scheduleReconnect("历史同步失败，正在重新连接")
                     return
                 }
                 when (envelope.type) {
@@ -1191,6 +1302,20 @@ class RealtimeSession(
                         require(id == activeOutboxCommandId) { "收到非活动 outbox 命令的错误: $id" }
                         val code = envelope.payload["code"]?.jsonPrimitive?.content
                             ?: error("message.send.error 缺少 code")
+                        if (code == "session_not_found") {
+                            val sessionId = requireNotNull(envelope.sessionId) {
+                                "session_not_found 缺少 session_id"
+                            }
+                            check(database.conversations().markRemoteKnown(sessionId) == 1) {
+                                "session_not_found 对应的会话投影不存在: $sessionId"
+                            }
+                            val remoteIds = requireNotNull(mutableState.value.remoteSessionIds) {
+                                "session_not_found 发生在会话目录同步完成前"
+                            }
+                            mutableState.value = mutableState.value.copy(
+                                remoteSessionIds = remoteIds - sessionId,
+                            )
+                        }
                         deliveryStore.retainFailedOutbox(
                             id,
                             outcomeUnknown = code == "command_outcome_unknown",
@@ -1421,6 +1546,19 @@ class RealtimeSession(
         }
     }
 
+    private fun applyRemoteSessionList(envelope: WireEnvelope) {
+        val payload = ProtocolCodec.decodePayload<SessionListPayload>(envelope.payload)
+        mutableState.value = mutableState.value.copy(
+            remoteSessionIds = payload.items.mapTo(linkedSetOf()) { it.sessionId },
+        )
+    }
+
+    private fun rememberRemoteSession(sessionId: String) {
+        val remoteSessionIds = mutableState.value.remoteSessionIds ?: return
+        if (sessionId in remoteSessionIds) return
+        mutableState.value = mutableState.value.copy(remoteSessionIds = remoteSessionIds + sessionId)
+    }
+
     private fun requestNextHistoryPage(envelope: WireEnvelope) {
         val sessionId = requireNotNull(envelope.sessionId) { "History page has no session_id" }
         val payload = ProtocolCodec.decodePayload<HistoryPagePayload>(envelope.payload)
@@ -1490,7 +1628,7 @@ class RealtimeSession(
                 "历史同步 reply page 不匹配"
             }
         }
-        finishResetRebuildIfComplete()
+        finishSessionSyncIfComplete()
     }
 
     private fun publishFinalMessage(envelope: WireEnvelope) {
@@ -1523,14 +1661,18 @@ class RealtimeSession(
         mutableState.value = mutableState.value.copy(
             projectionGeneration = mutableState.value.projectionGeneration + 1,
             connection = mutableState.value.connection.copy(phase = ConnectionPhase.SYNCING),
+            remoteSessionIds = null,
             errorMessage = null,
         )
         requestSessionList()
     }
 
-    private suspend fun finishResetRebuildIfComplete() {
-        if (resetRebuildGeneration != syncGeneration || pendingSyncCommands.isNotEmpty()) return
-        resetRebuildGeneration = null
+    /** 最新代际目录和历史完整落地后，才恢复上传、停止命令与 outbox。 */
+    private suspend fun finishSessionSyncIfComplete() {
+        if (completedSyncGeneration != syncGeneration) return
+        if (mutableState.value.remoteSessionIds == null || pendingSyncCommands.isNotEmpty()) return
+        if (mutableState.value.connection.phase == ConnectionPhase.READY) return
+        if (resetRebuildGeneration == syncGeneration) resetRebuildGeneration = null
         val currentProfile = requireNotNull(profile)
         mutableState.value = mutableState.value.copy(
             connection = mutableState.value.connection.copy(phase = ConnectionPhase.READY),
@@ -1539,6 +1681,7 @@ class RealtimeSession(
         requestPluginUiList()
         uploads.onConnectionReady(currentProfile.serverId)
         downloads.onConnectionReady(currentProfile.serverId)
+        stops.onConnectionReady()
         flushOutbox()
     }
 
@@ -1587,14 +1730,29 @@ class RealtimeSession(
         val currentProfile = requireNotNull(profile)
         val epoch = activeEpoch ?: return
         val candidate = activeCandidate ?: return
-        val command = database.outbox().pending(currentProfile.serverId).firstOrNull() ?: return
-        val stored = ProtocolCodec.decode(command.envelopeJson)
-        val wire = stored.copy(connectionEpoch = epoch)
-        deliveryStore.markOutboxAttempt(command.commandId, System.currentTimeMillis())
-        activeOutboxCommandId = command.commandId
-        if (!socket.send(candidate, wire)) {
-            activeOutboxCommandId = null
-            deliveryStore.retryOutbox(command.commandId)
+        while (true) {
+            val command = database.outbox().pending(currentProfile.serverId).firstOrNull() ?: return
+            val stored = ProtocolCodec.decode(command.envelopeJson)
+            val sessionId = stored.sessionId
+            if (
+                stored.type == "message.send" &&
+                sessionId != null &&
+                isRemoteMissingSession(currentProfile.serverId, sessionId)
+            ) {
+                deliveryStore.retainUnsentOutbox(command.commandId, System.currentTimeMillis())
+                mutableState.value = mutableState.value.copy(
+                    errorMessage = "电脑端已删除一段会话，未发送内容仍保留在本机",
+                )
+                continue
+            }
+            val wire = stored.copy(connectionEpoch = epoch)
+            deliveryStore.markOutboxAttempt(command.commandId, System.currentTimeMillis())
+            activeOutboxCommandId = command.commandId
+            if (!socket.send(candidate, wire)) {
+                activeOutboxCommandId = null
+                deliveryStore.retryOutbox(command.commandId)
+            }
+            return
         }
     }
 
@@ -1667,20 +1825,38 @@ class RealtimeSession(
         } else {
             current.title
         }
-        return ConversationEntity(sessionId, currentProfile.serverId, title, now)
+        return ConversationEntity(
+            sessionId,
+            currentProfile.serverId,
+            title,
+            now,
+            remoteKnown = current?.remoteKnown ?: false,
+        )
     }
 
     private suspend fun ensureCurrentSession(currentProfile: ServerProfileEntity): String {
         val existing = mutableState.value.currentSessionId
         if (existing != null) return existing
-        val sessionId = "mobile:${UUID.randomUUID()}"
-        val now = System.currentTimeMillis()
-        database.conversations().upsert(
-            ConversationEntity(sessionId, currentProfile.serverId, "新对话", now),
-        )
+        val sessionId = createLocalSession(currentProfile)
         preferences.selectSession(sessionId)
         mutableState.value = mutableState.value.copy(currentSessionId = sessionId)
         return sessionId
+    }
+
+    private suspend fun createLocalSession(currentProfile: ServerProfileEntity): String {
+        val sessionId = "mobile:${UUID.randomUUID()}"
+        database.conversations().upsert(
+            ConversationEntity(sessionId, currentProfile.serverId, "新对话", System.currentTimeMillis()),
+        )
+        return sessionId
+    }
+
+    private suspend fun isRemoteMissingSession(serverId: String, sessionId: String): Boolean {
+        val remoteSessionIds = mutableState.value.remoteSessionIds ?: return false
+        if (sessionId in remoteSessionIds) return false
+        val conversation = database.conversations().get(sessionId) ?: return false
+        require(conversation.serverId == serverId) { "Conversation belongs to another server" }
+        return conversation.remoteKnown
     }
 
     private fun scheduleReconnect(message: String) {
@@ -1844,10 +2020,16 @@ class RealtimeSession(
         }
     }
 
-    private fun canUploadAttachment(transfer: AttachmentTransferEntity): Boolean =
-        transfer.sizeBytes < LARGE_TRANSFER_BYTES ||
-            transferNetwork.value.kind != TransferNetworkKind.METERED ||
-            meteredLargeTransferApproved
+    private suspend fun canUploadAttachment(transfer: AttachmentTransferEntity): Boolean =
+        !isRemoteMissingSession(transfer.serverId, transfer.sessionId) &&
+            (
+                transfer.sizeBytes < LARGE_TRANSFER_BYTES ||
+                    transferNetwork.value.kind != TransferNetworkKind.METERED ||
+                    meteredLargeTransferApproved
+                )
+
+    private suspend fun canDownloadAttachment(transfer: MediaAttachmentEntity): Boolean =
+        !isRemoteMissingSession(transfer.serverId, transfer.sessionId)
 
     private fun control(type: String, payload: kotlinx.serialization.json.JsonObject) = WireEnvelope(
         v = WIRE_PROTOCOL_VERSION,

--- a/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/RealtimeSession.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/data/realtime/RealtimeSession.kt
@@ -890,7 +890,16 @@ class RealtimeSession(
                 }
                 require(conversation.serverId == currentProfile.serverId) { "Mobile session belongs to another server" }
 
-                // 2. 持久化选择
+                // 2. 用户从列表主动进入时从最新消息开始，应用重启仍保留原阅读恢复语义
+                if (mutableState.value.currentSessionId != sessionId) {
+                    deliveryStore.clearReadingPosition(
+                        sessionId = sessionId,
+                        expectedServerId = currentProfile.serverId,
+                        updatedAt = System.currentTimeMillis(),
+                    )
+                }
+
+                // 3. 持久化选择
                 preferences.selectSession(sessionId)
                 mutableState.value = mutableState.value.copy(currentSessionId = sessionId)
                 publishTurnState()

--- a/clients/android/app/src/main/java/com/akashic/mobile/ui/conversation/ConversationModels.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/ui/conversation/ConversationModels.kt
@@ -73,6 +73,8 @@ data class SessionUi(
     val lastMessageAtMillis: Long?,
     val unreadCount: Int,
     val isRunning: Boolean,
+    val isAvailable: Boolean,
+    val canRemove: Boolean = false,
 )
 
 data class ReadingPositionUi(
@@ -229,9 +231,9 @@ internal val PreviewConversationState = ConversationUiState(
     connectionNotice = "网络不稳 · 消息已缓存，正在续传",
     errorNotice = "附件读取失败，请重新选择文件。",
     sessions = listOf(
-        SessionUi("mobile:preview-1", "Android 会话设计", "正在检查实时链路", 1_752_681_601_000, 0, true),
-        SessionUi("mobile:preview-2", "网络抖动恢复策略", "恢复窗口已经确认", 1_752_681_500_000, 2, false),
-        SessionUi("mobile:preview-3", "Material 3 交互细节", null, null, 0, false),
+        SessionUi("mobile:preview-1", "Android 会话设计", "正在检查实时链路", 1_752_681_601_000, 0, true, true),
+        SessionUi("mobile:preview-2", "网络抖动恢复策略", "恢复窗口已经确认", 1_752_681_500_000, 2, false, true),
+        SessionUi("mobile:preview-3", "Material 3 交互细节", null, null, 0, false, true),
     ),
     selectedSessionId = "mobile:preview-1",
     readingPosition = null,

--- a/clients/android/app/src/main/java/com/akashic/mobile/ui/web/MobileWebChat.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/ui/web/MobileWebChat.kt
@@ -70,6 +70,7 @@ private const val MOBILE_WEB_RENDER_DEADLINE_MILLIS = 10_000L
 fun MobileWebChat(
     state: ConversationUiState,
     onSelectSession: (String) -> Unit,
+    onRemoveUnavailableSession: (String) -> Unit,
     onNewSession: () -> Unit,
     onRestartPairing: () -> Unit,
     onReloadFromServer: () -> Unit,
@@ -105,6 +106,7 @@ fun MobileWebChat(
     val callbacks by rememberUpdatedState(
         MobileWebCallbacks(
             onSelectSession = onSelectSession,
+            onRemoveUnavailableSession = onRemoveUnavailableSession,
             onNewSession = onNewSession,
             onRestartPairing = onRestartPairing,
             onReloadFromServer = onReloadFromServer,
@@ -259,6 +261,7 @@ fun MobileWebChat(
 
 private data class MobileWebCallbacks(
     val onSelectSession: (String) -> Unit,
+    val onRemoveUnavailableSession: (String) -> Unit,
     val onNewSession: () -> Unit,
     val onRestartPairing: () -> Unit,
     val onReloadFromServer: () -> Unit,
@@ -301,6 +304,11 @@ private class MobileWebBridge(
 
     @JavascriptInterface
     fun selectSession(sessionId: String) = dispatch { it.onSelectSession(sessionId) }
+
+    @JavascriptInterface
+    fun removeUnavailableSession(sessionId: String) = dispatch {
+        it.onRemoveUnavailableSession(sessionId)
+    }
 
     @JavascriptInterface
     fun createSession() = dispatch { it.onNewSession() }

--- a/clients/android/app/src/main/java/com/akashic/mobile/ui/web/MobileWebSnapshot.kt
+++ b/clients/android/app/src/main/java/com/akashic/mobile/ui/web/MobileWebSnapshot.kt
@@ -80,6 +80,8 @@ data class MobileWebSession(
     val lastMessageAt: Long?,
     val unreadCount: Int,
     val isRunning: Boolean,
+    val isAvailable: Boolean,
+    val canRemove: Boolean,
 )
 
 @Serializable
@@ -206,7 +208,7 @@ data class MobileWebTransferStatus(
 
 /** 把原生持久化投影转换为版本化 WebView 快照。 */
 fun ConversationUiState.toMobileWebSnapshot(): MobileWebSnapshot = MobileWebSnapshot(
-    protocolVersion = 3,
+    protocolVersion = 4,
     connection = MobileWebConnection(
         label = connectionLabel,
         status = connectionStatus.toMobileWebStatus(),
@@ -257,6 +259,8 @@ private fun SessionUi.toMobileWebSession() = MobileWebSession(
     lastMessageAt = lastMessageAtMillis,
     unreadCount = unreadCount,
     isRunning = isRunning,
+    isAvailable = isAvailable,
+    canRemove = canRemove,
 )
 
 private fun ReadingPositionUi.toMobileWebReadingPosition() =

--- a/clients/android/app/src/test/java/com/akashic/mobile/MainViewModelTest.kt
+++ b/clients/android/app/src/test/java/com/akashic/mobile/MainViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.akashic.mobile
 
+import com.akashic.mobile.data.local.ConversationSummary
+import com.akashic.mobile.data.local.canRemoveFrom
+import com.akashic.mobile.data.local.isRemoteMissingIn
 import com.akashic.mobile.domain.model.ConnectionPhase
 import com.akashic.mobile.domain.model.ConnectionState
 import com.akashic.mobile.ui.conversation.ConnectionStatusUi
@@ -59,5 +62,31 @@ class MainViewModelTest {
         assertEquals(false, userMessageCanReply("sent"))
         assertEquals(false, userMessageCanReply("failed"))
         assertEquals(true, userMessageCanReply("complete"))
+    }
+
+    @Test
+    fun remoteMissingBlocksSendingWhileLocalWorkOnlyBlocksRemoval() {
+        val remote = ConversationSummary(
+            sessionId = "mobile:remote",
+            title = "旧会话",
+            lastMessagePreview = "历史",
+            lastMessageAt = 1,
+            unreadCount = 0,
+            isRunning = false,
+            anchorMessageId = null,
+            anchorOffsetPx = 0,
+            remoteKnown = true,
+            hasLocalWork = false,
+        )
+        val local = remote.copy(sessionId = "mobile:local", remoteKnown = false)
+        val pending = remote.copy(sessionId = "mobile:pending", hasLocalWork = true)
+
+        assertEquals(false, remote.isRemoteMissingIn(null))
+        assertEquals(false, remote.isRemoteMissingIn(setOf("mobile:remote")))
+        assertEquals(true, remote.isRemoteMissingIn(emptySet()))
+        assertEquals(false, local.isRemoteMissingIn(emptySet()))
+        assertEquals(true, pending.isRemoteMissingIn(emptySet()))
+        assertEquals(true, remote.canRemoveFrom(emptySet()))
+        assertEquals(false, pending.canRemoveFrom(emptySet()))
     }
 }

--- a/clients/android/app/src/test/java/com/akashic/mobile/data/realtime/AttachmentUploadCoordinatorTest.kt
+++ b/clients/android/app/src/test/java/com/akashic/mobile/data/realtime/AttachmentUploadCoordinatorTest.kt
@@ -340,6 +340,8 @@ class AttachmentUploadCoordinatorTest {
 
         override suspend fun deleteSent(): Int = 0
 
+        override suspend fun deleteSentForSession(serverId: String, sessionId: String): Int = 0
+
         private fun updateMany(ids: List<String>, state: String, updatedAt: Long): Int {
             var changed = 0
             ids.forEach { id ->

--- a/clients/android/app/src/test/java/com/akashic/mobile/ui/web/MobileWebSnapshotTest.kt
+++ b/clients/android/app/src/test/java/com/akashic/mobile/ui/web/MobileWebSnapshotTest.kt
@@ -41,6 +41,7 @@ class MobileWebSnapshotTest {
                     lastMessageAtMillis = 1_752_681_601_000,
                     unreadCount = 1,
                     isRunning = true,
+                    isAvailable = false,
                 ),
             ),
             selectedSessionId = "mobile:test",
@@ -103,10 +104,11 @@ class MobileWebSnapshotTest {
 
         val encoded = Json.encodeToString(snapshot)
 
-        assertEquals(3, snapshot.protocolVersion)
+        assertEquals(4, snapshot.protocolVersion)
         assertEquals(7, snapshot.projectionGeneration)
         assertEquals(MobileWebConnectionStatus.RECONNECTING, snapshot.connection.status)
         assertTrue(snapshot.sessions.single().isRunning)
+        assertTrue(!snapshot.sessions.single().isAvailable)
         assertEquals(listOf("message-1", "message-2"), snapshot.messages.map { it.id })
         assertEquals(
             listOf(1_752_681_600_100, 1_752_681_601_200),
@@ -129,7 +131,7 @@ class MobileWebSnapshotTest {
         assertEquals(-18, snapshot.readingPosition?.offsetPx)
         assertEquals("message-2", snapshot.navigationTarget?.messageId)
         assertEquals("message-1", snapshot.composer.pendingMessages.single().messageId)
-        assertEquals(3, Json.parseToJsonElement(encoded).jsonObject
+        assertEquals(4, Json.parseToJsonElement(encoded).jsonObject
             .getValue("protocolVersion").jsonPrimitive.content.toInt())
         assertTrue(encoded.contains("\"status\":\"reconnecting\""))
         assertTrue(encoded.contains("\"deliveryAction\":\"retry\""))

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -425,3 +425,10 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - `npm run typecheck`、`npm run lint`、20 项 mobile web state 测试、`git diff --check` 和 `clients/android/scripts/build-release.sh` 通过；release unit、Lint、R8、assemble 与 v2 签名验证成功，最终验收 APK SHA-256 为 `885366a6…cf22`。
 - Pixel 7 已用最终签名 APK 无损安装并验证：单选截图 `/tmp/pixel7-selection-final-one.png`；单选引用进入 composer 的截图 `/tmp/pixel7-selection-final-reply3.png`；双选截图 `/tmp/pixel7-selection-final-two3.png`；Android 剪贴板预览显示按顺序复制的两条消息，截图 `/tmp/pixel7-selection-final-copy.png`；返回键恢复常态输入区，截图 `/tmp/pixel7-selection-final-back2.png`。对应 logcat 无 FATAL、RenderProcessGone 或 event sequence gap。
 - Kill AI Slop 扫描为 38 个文件、10 组、58 个机械命中；相对本组实施前只多出 `-webkit-touch-callout: none` 被“left-border callout”规则按字符串误报，实际没有新增 callout、渐变、玻璃拟态、发光点、卡片墙或胶囊堆叠。完整批次记录见 `docs/mobile-batches/2026-07-17-message-selection.md`。
+
+## 2026-07-17 主动反馈插件移动面板
+
+- `proactive_feedback` 通过既有移动 UI 生命周期注册插件自有看板；核心没有新增插件业务、数据库路径或专用样式。移动端复用既有 Dashboard reader，只把“主动消息是否被继续”投影成任务优先的概览和关联链路。
+- 主概览用青绿表达继续率、紫色表达明确引用、蓝色表达高可信信号；最近回应保持平面列表，筛选是单一 segmented control，展开后才显示“主动发出 → 用户回应 → 助手继续”。
+- Pixel 7 真实空态、707 条只读样本、三种筛选和展开/收起均通过。真机发现折叠详情仍泄漏到 Android 无障碍树后补齐 `inert + aria-hidden`；复测确认折叠、展开、再次收起的可访问树与视觉状态一致。
+- 插件 Python `12 passed`、Node `5 passed`、Pyright 0 错误；源码 PR #2 已合入，Docker Mobile Lab 最终缓存 HEAD 为 `3fa085e`。完整设计、备份和截图证据见 `docs/mobile-batches/2026-07-17-proactive-feedback-panel.md`。

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -432,3 +432,12 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - 主概览用青绿表达继续率、紫色表达明确引用、蓝色表达高可信信号；最近回应保持平面列表，筛选是单一 segmented control，展开后才显示“主动发出 → 用户回应 → 助手继续”。
 - Pixel 7 真实空态、707 条只读样本、三种筛选和展开/收起均通过。真机发现折叠详情仍泄漏到 Android 无障碍树后补齐 `inert + aria-hidden`；复测确认折叠、展开、再次收起的可访问树与视觉状态一致。
 - 插件 Python `12 passed`、Node `5 passed`、Pyright 0 错误；源码 PR #2 已合入，Docker Mobile Lab 最终缓存 HEAD 为 `3fa085e`。完整设计、备份和截图证据见 `docs/mobile-batches/2026-07-17-proactive-feedback-panel.md`。
+
+## 2026-07-17 Emotion 主动状态移动面板
+
+- `emotion` 通过既有移动 UI 生命周期注册插件自有“主动状态”看板；核心没有新增插件名、数据库路径、阈值规则或专用样式。
+- 手机只回答“当前会怎么表现”和“哪些反馈真正改变了它”：当前语气、主动门槛、有效影响组成一个指标组，VAD 默认折叠，最近影响保持平面列表。
+- 领域层新增唯一 `describe_behavior()` owner，主动 effect 和移动 overview 共同复用；移动端不再用可能过期的 last effect 冒充当前状态。
+- Pixel 7 使用只读正式快照验证：`3630` 条周期 effect 没有进入列表，`28` 条反馈中只显示 `26` 条非零影响；真实状态为“自然 / 保持门槛”。
+- 真机展开指标后可读愉悦度、活跃度和主动把握，收起后原始指标从 Android 无障碍树消失；服务端与应用日志无 FATAL、RenderProcessGone、event gap 或插件 RPC 异常。
+- 插件 Python `3 passed`、Node `4 passed`、Pyright 0 错误；源码 PR #2 已合入，Docker Mobile Lab 最终缓存 HEAD 为 `0db706f`。完整设计、隔离、备份和截图证据见 `docs/mobile-batches/2026-07-17-emotion-state-panel.md`。

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -441,3 +441,14 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - Pixel 7 使用只读正式快照验证：`3630` 条周期 effect 没有进入列表，`28` 条反馈中只显示 `26` 条非零影响；真实状态为“自然 / 保持门槛”。
 - 真机展开指标后可读愉悦度、活跃度和主动把握，收起后原始指标从 Android 无障碍树消失；服务端与应用日志无 FATAL、RenderProcessGone、event gap 或插件 RPC 异常。
 - 插件 Python `3 passed`、Node `4 passed`、Pyright 0 错误；源码 PR #2 已合入，Docker Mobile Lab 最终缓存 HEAD 为 `0db706f`。完整设计、隔离、备份和截图证据见 `docs/mobile-batches/2026-07-17-emotion-state-panel.md`。
+
+## 2026-07-17 电脑端已不存在会话的本地收口
+
+- Room schema v6 用持久化 `remoteKnown` 区分“服务端确认过的会话”和纯本地新会话；migration 同时识别历史序号与可证明的 live-only 投影，首个跨设备 `turn.started` 也会先建立 conversation。收到完整 `session.list` 后，远端缺失会话立即停止消息、附件和 Turn 插件请求，本地工作只决定能否删除。
+- 重连必须完成当前 generation 的 `session.list` 和全部 history reply 才进入 READY、恢复附件和 flush outbox；同步失败直接重连。服务端 mobile 边界同时拒绝已有 claim 但 canonical session 已删除的发送，避免 `get_or_create` 复活旧会话。
+- 抽屉用 warning 状态替换普通预览；进入后历史保持可读。有待发消息或附件时原 composer 位置解释“已停止发送”并提供“新聊天”，没有本地工作时才提供“从本机移除”。确认删除只清理本机投影和缓存。
+- 已失效会话不挂载本轮插件 slot，Observe 等插件不会再对不存在的服务端 Turn 请求数据；插件目录与全局看板不受影响。
+- UI 复用 Radix Dialog 与现有原生桥，采用 Material 3 状态面、28dp modal、32% scrim 和 48dp 文字动作；没有增加 warning 卡、badge 或新的业务色。warning 在浅容器上的对比度由约 `4.18:1` 提升到 `4.55:1`。
+- 自动门禁通过 Web typecheck、ESLint、20 项 mobile state、Android JVM/debug/androidTest/release 构建、Pyright、131 项 Python realtime/protocol/lifecycle 定向测试和 v2 签名；Pixel 7 Room instrumentation 为 `39/39`。
+- 独立复核进一步收口 pending outbox 的状态 owner、失效会话对其他附件下载的阻塞、首次 claim 排队后删除与所有 mobile admission 的 existing-only 约束。隔离数据库回滚时又真实触发客户端 ACK 高于 durable cursor；Gateway 现先于 retention 检查处理 ACK 超前，把 cursor 前移与精确下一序号的 `sync.reset_required` 在同一 SQLite 事务落盘，并把恢复 ACK 限在 SQLite 64 位空间的一半。进程在提交后立即退出、回退事件同时超过保留期，或使用最大合法 ACK 完成下一次 resume，都不会形成 ASGI 异常重连环或误报同步完成。
+- Pixel 7 在隔离 Mobile Lab 中覆盖无本地工作移除闭环，以及“待发消息/附件 + tunnel 502 → 重连完成目录同步 → 不发送旧 outbox → 服务端不重建”的弱网闭环。最终画面保持“连接正常”，不再出现误导性的 Turn token 插件错误；服务端读回 `sessions=0 / messages=0`，正式 workspace 未读写。完整设计和证据见 `docs/mobile-batches/2026-07-17-unavailable-sessions.md`。

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -378,11 +378,18 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - mobile channel 比较插件 ID、source revision 与资产 SHA-256，只有目录真实变化才向当前连接中明确声明支持热更新的设备并发发送有超时上限的非持久化控制帧；断线重连由既有首次目录同步取得最新内容。新版 Android 仍能消费并 ACK `0.7.10` 可能留下的 legacy durable event，升级不会形成重连循环。
 - Android 若在旧目录或资产批次尚未结束时收到通知，会排队一次刷新，当前批次完整收束后再拉新目录，不清空进行中的请求，也不会产生未知 reply。
 - 目录列出插件后、资产拉取前插件被移除时，`plugin_unavailable` 被视为目录已过期；客户端等待同批其余 reply 收束后只重拉一次目录，不显示伪错误也不触发断线重连。
+
 - `0.7.10 (19)` 已发布，APK 为 8,306,622 bytes，SHA-256 `a02c4da4333ae9e135cf874609afb50c2a28611c550757d3eeab709b041397bd`。后续验收发现该版本尚未完成客户端 capability 订阅；本轮补上协商、旧服务端 fallback 与连接 epoch 隔离后，才把热更新视为可用能力。
 - 线上核心已重启一次以加载新协议，Observe `5c7442f`、writer 与 mobile channel 均正常启动。完成 capability 修复后，支持热更新的客户端不再需要重启 runtime 或手机；旧 Android 客户端继续使用首次同步，不会收到 `plugin.ui.changed`。
 - Pixel 7 使用隔离 Mobile Lab 验证最终契约：Observe 禁用时抽屉显示“插件 0”，运行中直接启用后原位变为“插件 1”，没有重启手机、Android 服务或 runtime。
 - 同一 Pixel 7 连接在切换前后的 durable cursor 均为 `next_event_seq=10 / sent=9 / acknowledged=9`，`mobile_device_inbox` 保持为空；这证明 `plugin.ui.changed` 没有进入持久化序列，也没有产生 4406 或 event sequence gap。
 - 隔离 tunnel 曾因本机透明代理路由中断返回 Cloudflare 1033/HTTP 530；重启 tunnel connector 后恢复。该故障发生在配对 WebSocket 建立前，与插件热更新协议无关，验收只在 tunnel 恢复并完成真实 WSS 配对后计入。
+
+## 2026-07-17 阅读位置闭环
+
+- 会话恢复从“一次定位”改为同一投影代次同步期间持续校准；原生明确结束重同步后再等待 320ms DOM 稳定。用户 touch/wheel 会立即取得视口所有权，插件看板返回和 WebView history 不再覆盖阅读位置。
+- 锚点按真实 DOM 几何选择；回到底部清理 Room 锚点。`LocalDeliveryStore` 统一串行保存、清除、投影重建和 canonical identity 迁移，WebView 不再维护会覆盖原生迁移结果的第二份 Map；effect 卸载也不再用旧 session 读取共享的新会话 DOM。
+- Pixel 7 隔离真机覆盖中段进程重启、插件往返、回到底部后重启、IME 开合、真实模型流式跟随、流式期间手动上滑与同会话清缓存重同步；真机发现并修复空投影误清锚点后复跑通过。完整设计、截图和验证命令见 `docs/mobile-batches/2026-07-17-reading-position.md`。
 
 ## 2026-07-17 大附件按需下载与抖动保护
 

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -459,3 +459,9 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - 原生只清除阅读锚点，不推进已读水位；React 恢复流程同时接受原生把在途锚点明确清空，解决 Room 已到底但 WebView 仍按旧锚点定位的竞态。
 - 没有增加按钮、提示、协议字段、migration 或 Agent 核心改动。21 项移动 Web 状态测试、TypeScript、ESLint、移动 Web 生产构建和 Android release 全链通过。
 - Pixel 7 使用最终签名 APK 验证：停在旧位置后冷启动仍恢复；抽屉切走再切回后最新一轮完整可见且没有“到底部”按钮。完整记录见 `docs/mobile-batches/2026-07-17-session-entry-position.md`。
+
+## 2026-07-17 插件移动 UI 失败隔离
+
+- Fitbit 真机验收暴露插件异常会越过命令边界并关闭整条 WebSocket；宿主现在在插件调用边界记录 traceback，并把执行异常和返回契约错误转换为可持久化的 `plugin_failed` reply。
+- 输入错误、超时、执行失败继续拥有不同错误码；输入错误文案由宿主重建，插件的超长文本或非法 Unicode 不会进入回复帧。插件内部细节不发给手机，宿主取消也不会被吞掉。
+- 33 项插件 UI provider 与 mobile channel 测试通过，Pyright 0 错误、0 警告。Pixel7 在 generation 1、epoch 275 的同一 WebSocket 中真实触发 Fitbit 401，收到 `plugin_failed` 后恢复令牌并原位重试成功；期间没有 `device.proof`、`resume` 或历史重拉。正式 workspace 未读写，完整契约与截图见 `docs/mobile-batches/2026-07-17-plugin-ui-failure-isolation.md`。

--- a/docs/mobile-agent-im-implementation-log.md
+++ b/docs/mobile-agent-im-implementation-log.md
@@ -452,3 +452,10 @@ Android 重新请求 list → asset → WebView 按 sha256 原位替换
 - 自动门禁通过 Web typecheck、ESLint、20 项 mobile state、Android JVM/debug/androidTest/release 构建、Pyright、131 项 Python realtime/protocol/lifecycle 定向测试和 v2 签名；Pixel 7 Room instrumentation 为 `39/39`。
 - 独立复核进一步收口 pending outbox 的状态 owner、失效会话对其他附件下载的阻塞、首次 claim 排队后删除与所有 mobile admission 的 existing-only 约束。隔离数据库回滚时又真实触发客户端 ACK 高于 durable cursor；Gateway 现先于 retention 检查处理 ACK 超前，把 cursor 前移与精确下一序号的 `sync.reset_required` 在同一 SQLite 事务落盘，并把恢复 ACK 限在 SQLite 64 位空间的一半。进程在提交后立即退出、回退事件同时超过保留期，或使用最大合法 ACK 完成下一次 resume，都不会形成 ASGI 异常重连环或误报同步完成。
 - Pixel 7 在隔离 Mobile Lab 中覆盖无本地工作移除闭环，以及“待发消息/附件 + tunnel 502 → 重连完成目录同步 → 不发送旧 outbox → 服务端不重建”的弱网闭环。最终画面保持“连接正常”，不再出现误导性的 Turn token 插件错误；服务端读回 `sessions=0 / messages=0`，正式 workspace 未读写。完整设计和证据见 `docs/mobile-batches/2026-07-17-unavailable-sessions.md`。
+
+## 2026-07-17 显式进入会话的阅读位置
+
+- 冷启动与主动选择现在拥有不同语义：冷启动恢复上次阅读锚点；用户从抽屉明确进入另一个会话时直接打开最新消息。
+- 原生只清除阅读锚点，不推进已读水位；React 恢复流程同时接受原生把在途锚点明确清空，解决 Room 已到底但 WebView 仍按旧锚点定位的竞态。
+- 没有增加按钮、提示、协议字段、migration 或 Agent 核心改动。21 项移动 Web 状态测试、TypeScript、ESLint、移动 Web 生产构建和 Android release 全链通过。
+- Pixel 7 使用最终签名 APK 验证：停在旧位置后冷启动仍恢复；抽屉切走再切回后最新一轮完整可见且没有“到底部”按钮。完整记录见 `docs/mobile-batches/2026-07-17-session-entry-position.md`。

--- a/docs/mobile-batches/2026-07-17-emotion-state-panel.md
+++ b/docs/mobile-batches/2026-07-17-emotion-state-panel.md
@@ -1,0 +1,70 @@
+# Emotion 主动状态移动面板
+
+## 目标与所有权
+
+这组能力回答一个 Akashic 特有的手机端任务：Agent 当前会采用什么语气，真实反馈又如何
+改变下一次主动发送的把握。数据解释、RPC、移动模块和样式全部由 `emotion` 插件拥有；
+Agent 核心继续只负责通用插件目录、资产分发和 `plugin.ui.call`。
+
+桌面 Dashboard 保留完整的 VAD、事件与 effect 审计。手机不复制每次 proactive tick 生成
+的 effect 表，只显示真正造成 valence 或 dominance 增量的反馈。
+
+```text
+┌─ 插件目录：主动状态
+│
+├─ 当前语气 ───────┬─ 主动发送门槛
+│  唯一主指标       └─ 有效影响数量
+│
+├─ 查看状态指标
+│  └─ 愉悦度 / 活跃度 / 主动把握（按需展开）
+│
+└─ 最近影响（平面列表）
+   ├─ 反馈类型 + 用户原话预览
+   └─ 主动把握增减
+```
+
+## Task-first Material 3
+
+- 蓝色表达当前中性状态，青绿色表达更愿意继续，深琥珀表达降低主动把握；颜色只承担状态语义。
+- 当前语气、主动门槛和有效影响组成同一个指标组；最近影响保持平面列表，没有把 26 条反馈做成卡片墙。
+- 原始 VAD 默认折叠，不让内部模型指标抢过“现在会怎么表现”这一主任务；折叠态同步 `inert` 与 `aria-hidden`。
+- 当前行为由 `db.py` 的 `describe_behavior()` 统一解释，主动 effect 和移动 overview 复用同一个领域 owner，UI 不复制阈值规则。
+- 字体沿用 Roboto / Noto Sans SC，状态数字使用 tabular figures；无渐变、阴影、玻璃拟态、发光点或装饰性胶囊。
+- fallback 颜色对浅色 surface 的对比度为 `5.31:1` 至 `6.21:1`，满足正文可读性要求。
+
+## 实施与验证
+
+插件源码提交 `48f18d0` 已通过
+[PR #2](https://github.com/akashic-plugins/emotion/pull/2) 合入 `main`，merge commit 为
+`0db706f`。Docker Mobile Lab 最终从远端 `main` 重新安装，缓存 HEAD 与 merge commit 一致；
+正式插件缓存和正式 workspace 均未写入。
+
+- Python 插件测试：`3 passed`。测试真实构造 10 条周期 effect 噪声、4 条非零反馈和 1 条零增量反馈，移动列表只返回 4 条有效影响。
+- 移动模块测试：`4 passed`，覆盖任务文案、状态映射、插件所有权和指标 disclosure 的 inert 行为。
+- Pyright：`0 errors`；存在 3 个仓库既有/低优先级 warning，没有用 fallback 掩盖。
+- 独立 review 两轮通过；当前状态不再使用可能过期的 last effect，噪声过滤和零增量过滤均有回归测试。
+- `plugin-doctor emotion@mobile-lab` 的安装、策略、MCP 均为 ok；实验环境未挂载 `feedback-preference-context` drift skill，因此整体报告 degraded，这与移动看板无关。
+
+Pixel 7 连接独立 Mobile Lab 后验证：
+
+1. 插件目录从 2 个原位更新为 3 个，并出现插件自有“主动状态”入口。
+2. 只读复制正式 emotion DB 后，概览显示“自然 / 保持门槛 / 26 个有效影响”。
+3. 正式快照包含 `3630` 条周期 effect 和 `28` 条反馈事件；移动端只显示其中 `26` 条非零影响，没有复制 tick 噪声。
+4. 最近影响显示真实用户原话预览，并用青绿或深琥珀分别表达主动把握增加和减少。
+5. 展开状态指标后显示愉悦度、活跃度和主动把握；再次收起后三个原始指标从 Android 无障碍树消失。
+6. 从远端 `main` 回装插件后重新进入面板，真实状态和 26 条影响保持一致。
+7. Android 和服务端日志无 FATAL、RenderProcessGone、event sequence gap、插件 RPC 或 WebView 异常。
+
+截图证据：
+
+- `/tmp/pixel7-plugin-directory-emotion.png`
+- `/tmp/pixel7-emotion-populated.png`
+- `/tmp/pixel7-emotion-metrics-expanded.png`
+
+## 隔离与恢复
+
+- 正式 `/home/huashen/.akashic/workspace` 只通过 SQLite `.backup` 读取快照，没有写操作。
+- Mobile Lab 插件目录备份：`/mnt/data/coding/backups/mobile-lab-plugin-home-before-emotion-20260717-075649.tar.gz`。
+- Mobile Lab 数据备份：`/mnt/data/coding/backups/mobile-lab-emotion-data-before-20260717-075701/`。
+- 实施日志备份：`/mnt/data/coding/backups/mobile-agent-im-implementation-log-before-emotion-20260717-080146.md`。
+- 所有可变验证只发生在隔离 workspace；正式会话和手机日用会话不受影响。

--- a/docs/mobile-batches/2026-07-17-plugin-ui-failure-isolation.md
+++ b/docs/mobile-batches/2026-07-17-plugin-ui-failure-isolation.md
@@ -1,0 +1,33 @@
+# 插件移动 UI 失败隔离
+
+## 问题
+
+Pixel7 在 Fitbit 面板请求一个当前分钟的睡眠片段时，插件投影抛出 `ValueError`。异常越过移动插件边界、命令通道和 ASGI WebSocket，导致整个 IM 连接断开；手机需要重新完成 proof、resume、目录和历史同步。
+
+```text
+plugin.ui.call
+└── 插件异常
+    ├── 修复前：逃逸到 ASGI → WebSocket EOF → 全量重连
+    └── 修复后：plugin_failed reply → 面板原位错误 → IM 连接保持
+```
+
+## 所有权
+
+- 插件输入错误继续使用 `MobileUiRpcInvalidRequest`，映射为 `plugin_invalid_request`；面向手机的文案由宿主重建，插件不能注入超长文本或非法 Unicode 破坏回复帧。
+- 超时继续由 `PluginMobileUiProvider` 拥有，映射为 `plugin_timeout`。
+- 插件代码异常及返回契约错误由插件调用边界统一记录并转换为 `MobileUiRpcExecutionError`，移动通道持久化为 `plugin_failed`。
+- `CancelledError` 不被捕获，宿主关闭和任务取消仍按生命周期传播。
+- 客户端只获得插件和方法标识，不泄漏内部异常细节；完整 traceback 保留在服务端日志。
+
+## 验收
+
+```bash
+/mnt/data/coding/akasic-agent/.venv/bin/python -m pytest -q \
+  tests/test_plugin_mobile_ui.py tests/mobile_realtime/test_channel.py
+/mnt/data/coding/akasic-agent/.venv/bin/pyright \
+  agent/plugins/mobile_ui.py infra/mobile_realtime/channel.py
+```
+
+Pixel7 在隔离 Mobile Lab 中完成端到端验证：连接保持 generation 1、epoch 275 时，临时移走隔离 Fitbit 令牌触发真实 401。手机收到 `plugin_failed` 并原位显示可重试错误，服务端只记录插件边界 traceback；Android 没有重新发送 `device.proof`、`resume` 或重拉历史。恢复令牌后在同一 WebSocket 点按重试即返回真实健康数据，generation 与 epoch 均未变化。截图为 `/tmp/pixel7-plugin-isolation-error.png`、`/tmp/pixel7-plugin-isolation-retry-success.png`。
+
+验证结束后令牌已恢复；正式 workspace 全程未读写。

--- a/docs/mobile-batches/2026-07-17-proactive-feedback-panel.md
+++ b/docs/mobile-batches/2026-07-17-proactive-feedback-panel.md
@@ -1,0 +1,76 @@
+# 主动反馈移动面板
+
+## 目标与所有权
+
+这组能力回答一个 Akashic 特有的手机端任务：主动消息发出后，用户是否真的继续了这个
+话题，以及系统为什么把它判断为继续、明确引用或没有继续。
+
+数据、RPC、移动模块和样式全部由 `proactive_feedback` 插件拥有。Agent 核心继续只负责
+通用的插件目录、资产分发和 `plugin.ui.call`，没有新增插件名、数据库路径或业务分支。
+移动端复用插件既有 `ProactiveFeedbackDashboardReader`，桌面 Dashboard 保留完整审计表，
+手机不复制桌面表格。
+
+```text
+┌─ 插件目录：主动反馈
+│
+├─ 继续率 ─────────┬─ 明确引用
+│  唯一主指标       └─ 高可信信号
+│
+└─ 最近回应（平面列表）
+   ├─ 全部 / 继续 / 引用
+   └─ 点开一条
+      主动发出
+          │
+      用户回应
+          │
+      助手继续
+```
+
+## Task-first Material 3
+
+- 青绿色只表达“话题被继续”，紫色只表达明确引用，蓝色只表达高可信信号；没有用颜色装饰普通列表。
+- 三个指标是同一语义组，最近回应保持平面列表；只有用户主动展开时才出现关联时间线，没有事件卡片墙。
+- 筛选使用一个 Material 3 segmented control，不把每个状态做成独立胶囊或 badge。
+- 关系详情使用插件已有预览，不新增第二套持久化；折叠态同步 `inert` 与 `aria-hidden`，隐藏内容不会留在键盘或 Android 无障碍树。
+- “未能判断”使用深琥珀文字而不是错误红；fallback 文字对浅色 surface 的对比度为 `7.20:1`。
+- 字体沿用 Roboto / Noto Sans SC，数字使用 tabular figures；无渐变、阴影、玻璃拟态、发光状态点或装饰图标。
+
+## 实施与验证
+
+插件源码提交 `153be14` 已通过
+[PR #2](https://github.com/akashic-plugins/proactive_feedback/pull/2) 合入 `main`，merge commit
+为 `3fa085e`。Docker Mobile Lab 最终从远端 `main` 安装，缓存 HEAD 与 merge commit 一致；
+正式插件缓存和正式 workspace 均未写入。
+
+- Python 插件测试：`12 passed`。
+- 移动模块测试：`5 passed`，覆盖类型语义、展开 ARIA/inert、筛选失败后恢复成功。
+- Pyright：`0 errors, 0 warnings`。
+- `plugin-doctor proactive_feedback@mobile-lab`：healthy。
+- watcher 热加载 generation 6，再以无障碍修复更新为 generation 7；没有重启 Agent、Android Activity 或 WebSocket。
+
+Pixel 7 连接独立 Mobile Lab 后验证：
+
+1. 插件目录从 1 个运行中插件原位更新为 2 个，并出现插件自有“主动反馈”入口。
+2. 空数据库显示真实空态，不伪造继续率或事件。
+3. 只读复制正式反馈 DB 到隔离 workspace 后，概览显示 `707` 条、`30%` 继续率、`53` 次明确引用和 `158` 个高可信信号。
+4. “全部 / 继续 / 引用”筛选通过真实 `plugin.ui.call` 返回 `707 / 160 / 53` 条。
+5. 展开真实事件后显示“主动发出 → 用户回应 → 助手继续”，再次点击收起。
+6. 第一轮真机发现视觉折叠内容仍进入 Android 无障碍树；补 `inert + aria-hidden` 后，折叠态不再出现三个关系节点，展开态只暴露当前一条，收起后再次消失。
+7. Android 和服务端日志无 FATAL、RenderProcessGone、协议间隙、插件 RPC 或 WebView 异常。
+
+截图证据：
+
+- `/tmp/pixel7-proactive-plugin-list.png`
+- `/tmp/pixel7-proactive-empty-panel2.png`
+- `/tmp/pixel7-proactive-populated.png`
+- `/tmp/pixel7-proactive-filter-follow.png`
+- `/tmp/pixel7-proactive-expanded-final.png`
+- `/tmp/pixel7-proactive-a11y-collapsed.png`
+
+## 隔离与恢复
+
+- 正式 `/home/huashen/.akashic/workspace` 只通过 SQLite 只读快照读取，没有写操作。
+- Mobile Lab 插件目录备份：`/mnt/data/coding/backups/mobile-lab-plugin-home-before-proactive-feedback-20260717-0737.tar.gz`。
+- Mobile Lab 数据备份：`/mnt/data/coding/backups/mobile-lab-proactive-data-before-20260717-0740/`。
+- 隔离 workspace 只导入最近 30 条反馈对应的 90 条消息预览；正式会话和手机日用会话不受影响。
+

--- a/docs/mobile-batches/2026-07-17-reading-position.md
+++ b/docs/mobile-batches/2026-07-17-reading-position.md
@@ -1,0 +1,76 @@
+# 2026-07-17 移动端阅读位置闭环
+
+本批补完会话进入、历史分页、插件看板返回、输入法开合、流式跟随和进程重启之间的视口所有权。只复用既有 Room 阅读状态与 WebView 消息投影，没有修改消息协议或 Akashic Agent 核心。
+
+## 问题与根因
+
+1. `markReadThrough` 只推进已读时间，没有清除 Room 中的消息锚点；用户明确回到底部后，重启仍会回到旧位置。
+2. WebView 曾按消息数组顺序寻找首个可见元素，而 canonical/history 合并后的数组顺序不等于真实 DOM 几何顺序。
+3. 锚点只恢复一次；随后到达的历史分页会把视口再次推走，浏览器的 history restoration 也可能覆盖应用恢复结果。
+4. 页面底部的视觉状态与 `useStickToBottom` 的状态可能短暂不同，导致真实到达底部却没有清除原生锚点。
+5. 投影重建后，服务端可能不再返回旧锚点消息；无限等待旧消息会让该会话停止保存新的阅读位置。
+
+## 视口所有权
+
+```text
+┌─ 进入会话
+│
+├─ 有有效锚点 ── 同一投影代次重复校准 ── 同步完成 ── 320 ms 布局稳定 ── 最终校准
+│       │                                                   │
+│       └─ touch / wheel ──────────────── 立即交给用户 ─────┤
+│                                                           ▼
+├─ 旧锚点失效 ─────────────────────── instant 到最新消息 ──┤
+│                                                           │
+└─ 无锚点 ─────────────────────────── instant 到最新消息 ──┘
+                                                            │
+                                  用户上滑 ── 保存 DOM 几何锚点
+                                                            │
+                                  到达底部 ── 清锚点并推进已读
+```
+
+- `window.history.scrollRestoration = "manual"` 只在移动聊天应用存活期间生效，卸载时恢复原值。
+- Room 是阅读锚点的唯一事实源；插件看板往返、进程死亡和 canonical identity 迁移都读取同一状态，不在 WebView 另存可能过期的副本。
+- 恢复期间禁止写回中间位置；稳定后主动派发一次滚动事件，把最终位置交给既有持久化链路。
+- 首个可见消息按实际 DOM `rect.top` 选择，不信任上游数组顺序。
+- 到底部以真实 `scrollHeight - scrollTop - clientHeight <= 2` 为准，同一会话和已读时间通过幂等 key 去重。
+- 只有原生明确结束该投影代次的重同步后，旧锚点仍不存在才回到底部；320ms 只等待 DOM 布局稳定，不猜测网络分页何时完成。
+- 原生保存、清除、投影重建和 canonical identity 迁移由 `LocalDeliveryStore` 的唯一 Mutex 串行拥有；所有路径保持 `reading mutex → Room transaction` 的固定锁序。WebView 回调在 UI 分发栈内以 `UNDISPATCHED` 进入 owner，旧消息 ID 的迟到写入通过有界短期 alias 落到 canonical 消息，不持久化第二份映射。
+- 普通断线重连即使不增加投影代次，也会在 `resyncing` 开始时撤销已稳定标记；只有当前会话与投影 key 的 timer、animation frame 和 promise 才能完成恢复。
+- effect 卸载只取消尚未稳定的 debounce，不再拿旧 session 闭包读取父级共享的新会话 DOM。
+- 重同步期间消息投影可能暂时为空；该窗口禁止保存或清除阅读状态，不能把空列表误判为真实会话尾部。
+
+## ExtraGram 与五项 UI 复核
+
+- ExtraGram/Telegram 的 `ChatActivity` 把手动滚动与程序定位分开，并只在明确动作后定位最新消息。本批沿用这条所有权原则，没有照搬视觉组件。
+- Better UI：恢复为 instant，不播放无意义的长距离动画；touch/wheel 可中断，操作响应不等待定时器结束。
+- Better Colors：没有新增颜色。回到底部继续使用既有蓝灰 surface，运行态继续由亮紫承担，避免新增一套滚动状态色。
+- Better Typography：没有新增标签、徽章或辅助文案；正文、时间与输入栏继续使用现有系统字体层级。
+- Material 3：复用现有 48dp 回到底部圆形动作；阅读位置是行为状态，不新增卡片或浮层。
+- Kill AI Slop：本批没有渐变、玻璃拟态、发光点、胶囊提示或装饰性 surface；所有变化都服务于阅读任务。
+
+## 自动验证
+
+- `npm run typecheck`：通过。
+- `npm run lint`：通过。
+- `npm run test:mobile-web-state`：15 passed。
+- Pixel 7 执行完整 `LocalDeliveryStoreTest`：28 passed，覆盖旧消息 ID 的单段与两段迟到写入都解析到最终 canonical 锚点；原始输出保存在 `/tmp/pixel7-local-delivery-store-20260717.txt`。
+- 签名 release 构建、R8 和 APK v2 签名验证：通过。
+
+## Pixel 7 隔离真机闭环
+
+设备连接 Docker Mobile Lab，正式 workspace 未参与本批请求。
+
+| 场景 | 结果 | 证据 |
+| --- | --- | --- |
+| 中段强停并重启 | 首屏恢复到相同消息与偏移 | `/tmp/pixel7-v5-before-restart.png`、`/tmp/pixel7-v5-after-restart.png` |
+| 插件目录与 Observe 看板往返 | 返回聊天后保持原阅读位置 | `/tmp/pixel7-v7c-launch.png`、`/tmp/pixel7-v7c-directory.png`、`/tmp/pixel7-v5-dashboard.png`、`/tmp/pixel7-v7c-after-plugin.png` |
+| 回到底部后强停并重启 | 仍在最新回答，旧锚点没有复活 | `/tmp/pixel7-v8-tail-before-restart.png`、`/tmp/pixel7-v8-tail-after-restart.png` |
+| 输入法开合 | composer 紧贴 IME；关闭后只增加可见内容，不跳历史 | `/tmp/pixel7-v8-ime-open.png`、`/tmp/pixel7-v8-ime-closed.png` |
+| 真实模型流式输出 | token 增长时持续跟随尾部 | `/tmp/pixel7-stream-autofollow-1.png` 至 `/tmp/pixel7-stream-autofollow-3.png` |
+| 流式期间手动上滑 | 间隔 3 秒的两帧保持相同视口，并显示回到底部动作 | `/tmp/pixel7-stream-manual-hold-1.png`、`/tmp/pixel7-stream-manual-hold-2.png` |
+| 同会话清缓存重同步 | 空投影和逐页历史期间不写阅读状态；同步完成后回到 `remoteok12345` 与同一附件附近 | `/tmp/pixel7-reading-resync-v2-before.png`、`/tmp/pixel7-reading-resync-v2-early.png`、`/tmp/pixel7-reading-resync-v2-mid.png`、`/tmp/pixel7-reading-resync-v2-after.png` |
+| 分页同步中手动滚动 | touch 后移动到 `unreadgamma` 附近；后续分页与同步完成没有夺回视口 | `/tmp/pixel7-reading-round3-sync-before-touch.png`、`/tmp/pixel7-reading-round3-sync-after-touch.png`、`/tmp/pixel7-reading-round3-sync-settled.png` |
+| 普通网络断线重连 | Wi-Fi 关闭、连接重置、恢复同步到连接正常，全程保持同一消息与偏移 | `/tmp/pixel7-reading-final-before-reconnect.png`、`/tmp/pixel7-reading-final-offline.png`、`/tmp/pixel7-reading-final-after-reconnect-ready.png` |
+| 最终 release 重启与插件往返 | 中段强停重启保持位置；进入 Observe KV Cache 看板再返回仍保持位置 | `/tmp/pixel7-reading-final-before-restart.png`、`/tmp/pixel7-reading-final-after-restart.png`、`/tmp/pixel7-reading-final-dashboard.png`、`/tmp/pixel7-reading-final-after-plugin.png` |
+
+第一次重同步实测曾暴露空投影在 180ms 后被误判成尾部，修复为 `resyncing` 全程停写后重跑通过。最终签名 APK SHA-256 为 `391fefeec0c4a44dabfc3fdff69093fa055ce5c6e10cb48bfb4c0958b89e987f`；logcat 未出现应用 FATAL、阅读锚点跨会话异常、WebView render crash、event sequence gap 或协议错误。网络断线只暴露真实 `Connection reset` 并成功恢复，流式快照持续交付，回到底部后最终回答可见。

--- a/docs/mobile-batches/2026-07-17-session-entry-position.md
+++ b/docs/mobile-batches/2026-07-17-session-entry-position.md
@@ -1,0 +1,39 @@
+# 显式进入会话的阅读位置
+
+## 问题
+
+Android 会为冷启动持久化每个会话的阅读锚点，但抽屉中主动选择一个会话时也恢复该锚点。用户明确进入会话后仍停在旧消息，并需要再次点击“到底部”。
+
+## 交互语义
+
+```text
+应用冷启动 ────────────────→ 恢复上次阅读锚点
+
+抽屉主动选择另一个会话 ───→ 打开最新消息
+                              └─ 不提前改变未读水位
+```
+
+这是导航状态修复，不增加按钮、提示、卡片、颜色或动画。Material 3 的任务优先原则在这里体现为：让现有进入动作产生用户预期的结果，而不是再叠一层补救控件。
+
+## 实施
+
+- Room 只清除目标会话的 `anchorMessageId` 与 `anchorOffsetPx`，保留 `lastReadAt`，因此不会把尚未看到的助手消息伪装成已读。
+- `RealtimeSession.selectSession` 仅在用户确实切换到另一个会话时清除锚点；应用恢复当前会话不走该动作，继续保留冷启动恢复。
+- WebView 阅读位置 hook 现在接受原生快照把锚点明确清为 `null`。修复前，恢复已开始后只接受另一个非空锚点，导致 Room 已要求到底部，React 仍按旧锚点定位。
+- 没有新增协议字段、数据库 migration、Akashic Agent 核心能力或持久化副本。
+
+## 验证
+
+- `npm run test:mobile-web-state`：21 项通过。
+- `npm run typecheck`、`npm run lint`、`npm run build:mobile-web`：通过。
+- Android debug unit 与 androidTest 编译、release unit/Lint/R8/assemble、v2 签名：通过。
+- Pixel 7 安装最终签名 APK，SHA-256 为 `eec2630fc8d19cb9e59eccf2f3c5f6a16b5e022041b67e93e09043573e2562e9`。
+- 真机先停在旧锚点并重启，仍恢复原位置；随后从抽屉切到 `cycle2alpha`，再主动进入 `attachment_test_session`，最新一轮完整可见且“到底部”按钮消失。
+- 真机证据：`/tmp/pixel7-entry-fix-launch-settled.png`、`/tmp/pixel7-entry-fix-cycle-real.png`、`/tmp/pixel7-entry-fix-explicit-tail-real.png`。
+- 最终 logcat 没有 Akashic 应用 FATAL、RenderProcessGone、协议校验或 event sequence 错误。`uiautomator dump` 自身曾因 `Bad file descriptor` 崩溃，进程属于 Android UiAutomation，不属于 Akashic，后续验收改用截图和应用日志。
+
+## 设计复核
+
+- Better UI / Material 3：修正入口行为，不增加补救 UI。
+- Better Colors / Better Typography：没有新增视觉语义，因此不引入新 token 或排版层级。
+- Kill AI Slop：没有新增卡片、胶囊、阴影、渐变或状态装饰。

--- a/docs/mobile-batches/2026-07-17-unavailable-sessions.md
+++ b/docs/mobile-batches/2026-07-17-unavailable-sessions.md
@@ -1,0 +1,82 @@
+# 电脑端已不存在会话的本地收口
+
+## 问题与边界
+
+手机会长期保存已同步的对话投影。电脑端删除会话或更换 workspace 后，旧会话仍可能留在手机上；如果客户端继续发送，旧实现会得到“会话不可用”，更危险的路径还可能重新创建已经删除的会话。
+
+本组不在 Agent 核心增加移动端 tombstone。Android 用持久化的 `remoteKnown` 记录“这段会话曾被服务端确认存在”，再用当前连接完整的 `session.list` 判断它是否已经从电脑端消失：
+
+1. `remoteKnown = true`，且当前服务端目录不再包含该会话时，立即停止消息、附件和插件 Turn 请求；
+2. 有 pending、retryable、outcome unknown 消息或未发送附件时，历史和本地工作全部保留，只允许新建聊天；
+3. 没有本地工作和运行中 Turn 时，允许从手机移除本地投影；
+4. 本机新建、尚未被服务端确认的会话不参与缺失判断；重连尚未取得完整目录时也不推断。
+
+## Task-first 交互
+
+```text
+完整 session.list
+        │
+        ├─ 服务端仍存在 ───────────────→ 正常聊天
+        │
+        └─ remoteKnown 且目录缺失
+                    │
+          ┌─────────┴─────────┐
+          │                   │
+       有本地工作          无本地工作
+          │                   │
+┌─────────▼──────────┐  ┌─────▼────────────┐
+│ 历史与草稿保持可读  │  │ 历史保持可读      │
+│ 已停止发送          │  │ 从本机移除        │
+│ 新聊天              │  │ Material 3 确认层 │
+└────────────────────┘  └──────────────────┘
+```
+
+- 抽屉保持平面列表，只用 warning 文案替换异常会话的普通预览，不增加卡片、badge 或发光状态点。
+- 底部状态面原位接管 composer 的任务位置。有本地工作时给出“新聊天”；只有可安全删除时才出现“从本机移除”。
+- warning 暖橙只表达远端目录缺失，主蓝只表达普通导航和下一步操作，error 只用于删除确认。
+- 删除确认复用既有 Radix Dialog，使用 Material 3 `28dp` modal、32% scrim、48dp 文字动作和单层容器，没有手搓第二套焦点管理。
+- warning token 为 `oklch(0.54 0.14 72)`，在 `surface-container-low` 上约 `4.55:1`。正文继续沿用现有中文系统字体和舒展行高，没有用胶囊或等宽字体制造层级。
+- 已失效会话不再挂载本轮插件 slot。插件目录和全局面板仍可用，但 Observe 等 Turn 级 UI 不会拿不存在的服务端 owner 发请求，也不会渲染误导性的红色错误。
+
+## 实现所有权
+
+- Room schema v6 由 `ConversationEntity.remoteKnown` 持久拥有服务端身份；5→6 migration 用既有 `serverSeq`，以及可证明已进入实时链路的 assistant streaming/complete/interrupted、user sent 投影回填，pending/failed 本地工作不会被误标。此后由 `session.list`、history 和实时 session/turn/message 事件显式确认。
+- `ConversationSummary` 同时暴露 `remoteKnown` 和 `hasLocalWork`。前者决定是否缺失，后者只决定能否删除；两者不再混为一个 `isAvailable` 条件。
+- `RealtimeSession` 在每个连接 generation 内先获取 `session.list` 和所有历史页，完成前不进入 READY；重连后不恢复上传、下载、stop 和 outbox 队列，READY 前不 flush outbox。目录同步失败直接重连，不拿旧目录继续发送。
+- send、retry、附件导入/重试、通知快捷回复、Turn 插件 RPC 和 outbox 都在同一个 Android owner 上核对目录。outbox 遇到旧会话时用独立的 pending/retry 状态迁移把该消息标记为可重试并跳过，不借用 in-flight 失败路径，也不阻塞其他会话；下载队列会跳过失效会话，继续处理其他会话的附件。
+- WebView snapshot v4 显式携带 `isAvailable` 与 `canRemove`；React 只表达状态、确认和任务动作，不自行推断服务端目录。
+- 服务端主要在 mobile 边界保护：已有 mobile claim 但 canonical `SessionManager` 中不存在的会话返回 `session_not_found`。Agent 生命周期只增加可复用的 existing-only admission，不增加移动端 tombstone，也不改变 session 持久化和插件协议。
+- 多设备首次看到另一台手机的新会话时，Android 在同一 Room 事务先建立 `remoteKnown` conversation，再应用 `turn.started` 并推进 cursor，避免外键失败后无限重放。发送 ACK、history、实时事件和 `session_not_found` 都由同一 Room owner 确认该持久身份；已进入 mobile channel 的入站消息统一携带“必须已存在”不变量，before-turn 消费后只走 `SessionManager.get_existing`，首次 claim 排队后或检查后并发删除都不会进入创建路径。
+- 隔离数据库回滚可能让客户端 `last_ack` 高于服务端 durable cursor。检测到已认证客户端 ACK 高于服务端 cursor 时，Gateway 选择以客户端已应用序号为恢复基准，原子清理回退 inbox、前移 cursor，并在下一个精确序号持久化 `sync.reset_required`；协议与存储边界把恢复 ACK 限在 SQLite 64 位序号空间的一半，为 reset、completed 和后续日常事件保留充足余量。普通 resume 和服务端领先客户端的路径不变。
+
+## 验证
+
+### 自动门禁
+
+- `npm run typecheck`、`npm run lint`：通过。
+- `npm run test:mobile-web-state`：20 passed。
+- Kill AI Slop 扫描 `frontend/chat/src` 为 38 个文件、10 组、58 个机械命中；本组没有新增渐变、玻璃拟态、发光点、卡片墙或胶囊状态，命中均来自既有组件、圆形图标按钮、代码等宽字体和 `touch-callout` 误报。
+- Android `:app:testDebugUnitTest`、`assembleDebug`、`assembleDebugAndroidTest`：通过。
+- Pixel 7 Room instrumentation：39 passed，包含 schema 5→6 live-only 回填、首个远端 Turn 建立 conversation、持久化 `remoteKnown` 和本地工作分流。
+- Pyright 0 error/0 warning；mobile gateway、channel、storage、protocol 与 lifecycle 定向测试合计 131 passed，包含首次 claim 排队后删除、检查后并发删除、客户端 ACK 超前的原子恢复、进程重启、过期 inbox 组合、最大合法 ACK 完整恢复和 existing-only lifecycle。
+- `clients/android/scripts/build-release.sh`：release unit、Lint、R8、assemble 与 APK v2 签名通过；最终 `0.7.11 (20)` APK 为 8,326,778 bytes，SHA-256 `fca7ad58fe9880543116b4e12386b33643445cdc35edc0d127f5c27f015dc000`。
+
+### Pixel 7 / 隔离 Mobile Lab
+
+1. 正式 workspace 全程未写入；隔离 `sessions.db` 与 `mobile_realtime.db` 在破坏性测试前备份到 `/mnt/data/coding/backups/mobile-lab-stale-session-review-fixes-before-20260717-091000/`，最终删除前的已知完好副本另存到 `/mnt/data/coding/backups/mobile-lab-final-stale-before-20260717-094443/`。
+2. 签名 release APK 覆盖安装后，真实 Room 5→6 migration 成功；客户端先完成当前 generation 的目录与历史同步，再进入 READY。
+3. 隔离服务端删除 `mobile:74cf8e16-a7ab-4077-b58e-b057480b91ac`，同时保留手机上的待发消息和附件。重连期间实际经历 tunnel 502，恢复后客户端没有发送 `message.send`；服务端 `sessions` 与 `messages` 均为 0。
+4. 手机历史保持可读，底部显示“电脑端已不存在 / 未发送的消息或附件仍保留在本机；已停止发送，避免重新创建会话 / 新聊天”，截图 `/tmp/pixel7-stale-session-local-work-after-reconnect.png`。
+5. 恢复隔离数据库时真实触发“客户端 ACK 高于服务端 durable cursor”；旧循环断线被 `sync.reset_required` 收口，Pixel 7 回到“连接正常”，截图 `/tmp/pixel7-stale-session-final-rebased-healthy.png`。独立复核随后要求把 cursor 前移与 reset 入箱合并为同一事务，并补齐提交后立即进程退出、重启仍只先发送 reset，以及回退事件同时超过保留期的组合回归。
+6. 再次删除服务端会话后，最终 APK 冷启动保持连接正常，Turn 级 Observe slot 已隐藏，不再出现“Token 统计不可用：会话不存在”；最终截图 `/tmp/pixel7-stale-session-final-reviewed-v2.png`。随后 Mobile Lab 明确改挂本 worktree 最新代码并重建三个容器，Pixel 7 再次冷启动仍保持同一状态，截图 `/tmp/pixel7-stale-session-latest-server.png`；容器内外 gateway/storage SHA-256 一致，服务端再次读回 `sessions=0 / messages=0`。应用 PID 与容器日志无 FATAL、RenderProcessGone、event gap、协议校验、ASGI 异常或旧会话 `message.send`。
+7. 无本地工作的另一条隔离会话完成“抽屉提示 → 保留历史 → Material 3 确认 → 从本机移除 → 自动切换 → 服务端恢复后重新同步”闭环，证据为 `/tmp/pixel7-stale-drawer-detected.png`、`/tmp/pixel7-stale-session-dialog-final.png`、`/tmp/pixel7-stale-session-drawer-after-remove2.png` 和 `/tmp/pixel7-stale-session-restored-server.png`。
+
+## 五项 UI 审阅结论
+
+- Better UI：状态面放在原 composer 任务位置，动作随可恢复性变化；没有叠加 toast、banner 和卡片。
+- Better Colors：主蓝、warning、error 和 Agent 紫保持单一语义，不用默认“彩色状态大全”。
+- Better Typography：标题、解释和动作三层足以完成决策；数字与代码不存在时不强加 tabular 或 monospace。
+- Material 3：复用 dialog、state layer、48dp action 和既有 surface 层级，返回与焦点语义由成熟组件承担。
+- Kill AI Slop：没有新增渐变、玻璃拟态、发光点、圆角卡片墙、图标彩色方块或胶囊堆叠。
+
+状态：独立复核发现的 crash-consistency 与整数边界已修复并重新送审。本组已修复 live-only migration、多设备首事件外键、pending outbox 状态所有权、下载队列阻塞、所有 mobile admission 的 existing-only 约束、claimed-session 并发删除和 durable cursor 回滚边界，并通过自动门禁、隔离弱网重连和 Pixel 7 签名 release 验收。

--- a/frontend/chat/src/components/ui/dialog.tsx
+++ b/frontend/chat/src/components/ui/dialog.tsx
@@ -29,14 +29,15 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   showCloseButton?: boolean
+  overlayClassName?: string
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, showCloseButton = true, ...props }, ref) => (
+>(({ className, children, showCloseButton = true, overlayClassName, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/frontend/chat/src/mobile-message-state.test.mjs
+++ b/frontend/chat/src/mobile-message-state.test.mjs
@@ -11,9 +11,18 @@ import {
   reconcileMobileMessageSelection,
   reconcileAssistantMessageIds,
   selectableMobileMessages,
+  updateMobileReadingRestoreTarget,
   updateMobileUnreadMessageIds,
   updateMobileSearchIndex,
 } from "./mobile-message-state.ts";
+
+test("clearing a persisted reading anchor changes an in-flight restore to the conversation tail", () => {
+  const anchor = { messageId: "message-1", offsetPx: -18 };
+
+  assert.equal(updateMobileReadingRestoreTarget(anchor, undefined), null);
+  assert.deepEqual(updateMobileReadingRestoreTarget(null, anchor), anchor);
+  assert.equal(updateMobileReadingRestoreTarget(anchor, { ...anchor }), anchor);
+});
 
 function selectableMessage(id, role, content, streaming = false) {
   return {

--- a/frontend/chat/src/mobile-message-state.ts
+++ b/frontend/chat/src/mobile-message-state.ts
@@ -46,6 +46,11 @@ export interface MobileProjectionBaselineState {
   rebuilding: boolean;
 }
 
+export interface MobileReadingAnchor {
+  messageId: string;
+  offsetPx: number;
+}
+
 export function allMobileAttachmentsReady(attachments: readonly { state: string }[]) {
   return attachments.every((attachment) => attachment.state === "ready");
 }
@@ -53,6 +58,19 @@ export function allMobileAttachmentsReady(attachments: readonly { state: string 
 export function isMobileImageViewerHistoryState(state: unknown, attachmentId: string) {
   if (typeof state !== "object" || state === null) return false;
   return "akashicImageViewer" in state && state.akashicImageViewer === attachmentId;
+}
+
+/** 同步原生阅读锚点，并把明确清除锚点解释为回到会话末尾。 */
+export function updateMobileReadingRestoreTarget<T extends MobileReadingAnchor>(
+  current: T | null | undefined,
+  next: T | undefined,
+) {
+  const normalized = next ?? null;
+  if (
+    current?.messageId === normalized?.messageId
+    && current?.offsetPx === normalized?.offsetPx
+  ) return current ?? null;
+  return normalized;
 }
 
 export function normalizeMobileSearchText(value: string) {

--- a/frontend/chat/src/mobile-native.css
+++ b/frontend/chat/src/mobile-native.css
@@ -45,7 +45,7 @@
   --m-trace-soft: #e5dbfc;
   --m-error: #be241f;
   --m-error-container: #ffddd7;
-  --m-warning: #a45f00;
+  --m-warning: #9f5d00;
   --m-shape-extra-small: 4px;
   --m-shape-small: 8px;
   --m-shape-medium: 12px;
@@ -75,7 +75,7 @@
     --m-trace-soft: oklch(0.91 0.045 300);
     --m-error: oklch(0.52 0.19 28);
     --m-error-container: oklch(0.93 0.045 28);
-    --m-warning: oklch(0.56 0.14 72);
+    --m-warning: oklch(0.54 0.14 72);
     --m-shadow: oklch(0 0 0 / 0.16);
     --m-image-outline: oklch(0 0 0 / 0.1);
   }
@@ -619,6 +619,10 @@ button {
 
 .mobile-main-content.queueing .mobile-conversation {
   padding-block-end: calc(276px + env(safe-area-inset-bottom));
+}
+
+.mobile-main-content.session-unavailable .mobile-conversation {
+  padding-block-end: calc(122px + env(safe-area-inset-bottom));
 }
 
 .mobile-conversation__content {
@@ -1597,6 +1601,129 @@ button.tool-step-summary:active {
   background: color-mix(in oklch, var(--m-surface) 96%, transparent);
 }
 
+.mobile-unavailable-session {
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 35;
+  display: flex;
+  min-height: 86px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--m-outline-variant);
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom)) 20px;
+  color: var(--m-on-surface);
+  background: color-mix(in oklch, var(--m-surface-container-low) 96%, transparent);
+}
+
+.mobile-unavailable-session > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.mobile-unavailable-session strong {
+  font-size: 0.875rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.mobile-unavailable-session small {
+  color: var(--m-on-surface-variant);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  text-wrap: pretty;
+}
+
+.mobile-unavailable-session > button {
+  flex: 0 0 auto;
+}
+
+.mobile-unavailable-session button {
+  min-height: 48px;
+  border: 0;
+  border-radius: 999px;
+  padding-inline: 16px;
+  color: var(--m-warning);
+  background: transparent;
+  font-size: 0.875rem;
+  font-weight: 650;
+  white-space: nowrap;
+  transition: background-color 150ms cubic-bezier(0.2, 0, 0, 1), scale 150ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.mobile-unavailable-session button:active {
+  scale: 0.97;
+  background: color-mix(in oklch, var(--m-warning) 12%, transparent);
+}
+
+.mobile-unavailable-session button.new-session {
+  color: var(--m-primary);
+}
+
+.mobile-unavailable-session button.new-session:active {
+  background: color-mix(in oklch, var(--m-primary) 12%, transparent);
+}
+
+.mobile-session-remove-overlay {
+  background: rgb(0 0 0 / 0.32);
+}
+
+.mobile-session-remove-dialog {
+  width: calc(100% - 48px);
+  max-width: 360px;
+  gap: 14px;
+  border: 0;
+  border-radius: 28px;
+  padding: 24px;
+  color: var(--m-on-surface);
+  background: var(--m-surface-container-high);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.16);
+}
+
+.mobile-session-remove-dialog > h2 {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+
+.mobile-session-remove-dialog > p {
+  margin: 0;
+  color: var(--m-on-surface-variant);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.mobile-session-remove-dialog__actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.mobile-session-remove-dialog__actions button {
+  min-height: 48px;
+  border: 0;
+  border-radius: 999px;
+  padding-inline: 18px;
+  color: var(--m-primary);
+  background: transparent;
+  font-size: 0.875rem;
+  font-weight: 650;
+}
+
+.mobile-session-remove-dialog__actions button.destructive {
+  color: var(--m-error);
+}
+
+.mobile-session-remove-dialog__actions button:active {
+  background: color-mix(in oklch, currentColor 12%, transparent);
+}
+
 .mobile-composer-frame {
   overflow: hidden;
   border-radius: 29px;
@@ -2341,6 +2468,11 @@ button.tool-step-summary:active {
   min-height: 44px;
   place-items: center;
   gap: 3px;
+}
+
+.mobile-session-row.unavailable .mobile-session-row__copy small,
+.mobile-session-row.unavailable .mobile-session-row__state {
+  color: var(--m-warning);
 }
 
 .session-running {

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -74,6 +74,7 @@ import {
   normalizeMobileSearchText,
   reconcileMobileMessageSelection,
   selectableMobileMessages,
+  updateMobileReadingRestoreTarget,
   updateMobileSearchIndex,
   type MobileSearchIndexEntry,
 } from "./mobile-message-state";
@@ -2455,14 +2456,11 @@ function useMobileReadingPosition(
       if (restoreFrameRef.current !== null) window.cancelAnimationFrame(restoreFrameRef.current);
       restoringProjectionRef.current = projectionKey;
       restoreTargetRef.current = readingPosition ?? null;
-    } else if (
-      readingPosition
-      && (
-        restoreTargetRef.current?.messageId !== readingPosition.messageId
-        || restoreTargetRef.current.offsetPx !== readingPosition.offsetPx
-      )
-    ) {
-      restoreTargetRef.current = readingPosition;
+    } else {
+      restoreTargetRef.current = updateMobileReadingRestoreTarget(
+        restoreTargetRef.current,
+        readingPosition,
+      );
     }
     if (messages.length === 0) return;
     const scrollElement = scrollRef.current;

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -556,6 +556,8 @@ function MobileNativeApp() {
       window.AkashicNative?.requestSnapshot();
       requestTimer = window.setTimeout(requestSnapshot, 250);
     };
+    const previousScrollRestoration = window.history.scrollRestoration;
+    window.history.scrollRestoration = "manual";
     replaceMobileSurface(window.history, { kind: "chat" });
     const handlePopState = (event: PopStateEvent) => {
       const next = readMobileSurfaceHistoryState(event.state);
@@ -640,6 +642,7 @@ function MobileNativeApp() {
       if (frame !== null) cancelAnimationFrame(frame);
       if (requestTimer !== null) window.clearTimeout(requestTimer);
       window.removeEventListener("popstate", handlePopState);
+      window.history.scrollRestoration = previousScrollRestoration;
       delete window.AkashicMobile;
     };
   }, []);
@@ -1034,7 +1037,11 @@ function MobileNativeApp() {
           </section>
         ) : (
         <div className={`mobile-main-content ${replyTarget ? "replying" : ""} ${searchOpen ? "searching" : ""} ${selectionActive ? "selecting" : ""} ${queueOpen && snapshot.composer.pendingMessages.length > 1 ? "queueing" : ""}`} inert={drawerOpen ? true : undefined}>
-          <Conversation key={snapshot.selectedSessionId ?? "empty"} className="mobile-conversation">
+          <Conversation
+            key={snapshot.selectedSessionId ?? "empty"}
+            className="mobile-conversation"
+            initial="instant"
+          >
             <ConversationContent className="mobile-conversation__content">
               {messages.length === 0 ? (
                 <ConversationEmptyState className="mobile-empty">
@@ -2317,7 +2324,15 @@ function MobileConversationBehavior({
     onUnreadChange,
   );
   useMobileAutoScroll(sessionId, chatMessages, streaming, suspended, forceScrollToken);
-  useMobileReadingPosition(sessionId, sourceMessages, readingPosition, messageElementsRef, suspended);
+  useMobileReadingPosition(
+    sessionId,
+    sourceMessages,
+    projectionGeneration,
+    resyncing,
+    readingPosition,
+    messageElementsRef,
+    suspended,
+  );
   return null;
 }
 
@@ -2325,51 +2340,173 @@ function MobileConversationBehavior({
 function useMobileReadingPosition(
   sessionId: string | undefined,
   messages: MobileMessage[],
+  projectionGeneration: number,
+  resyncing: boolean,
   readingPosition: MobileReadingPosition | undefined,
   messageElementsRef: React.RefObject<Map<string, HTMLDivElement>>,
   suspended: boolean,
 ) {
-  const { isAtBottom, scrollRef, stopScroll } = useStickToBottomContext();
-  const restoredSessionRef = useRef<string | undefined>(undefined);
+  const { isAtBottom, scrollRef, scrollToBottom, stopScroll } = useStickToBottomContext();
+  const restoredProjectionRef = useRef<string | undefined>(undefined);
+  const restoringProjectionRef = useRef<string | undefined>(undefined);
+  const restoreTargetRef = useRef<MobileReadingPosition | null | undefined>(undefined);
+  const restoreTimerRef = useRef<number | null>(null);
+  const restoreFrameRef = useRef<number | null>(null);
+  const syncPhaseRef = useRef<{ projectionKey?: string; active: boolean }>({ active: false });
   const saveTimerRef = useRef<number | null>(null);
   const lastSavedRef = useRef("");
   const lastReadAtRef = useRef(0);
-
-  useLayoutEffect(() => {
-    // 1. 每次进入会话只恢复一次已持久化锚点
-    if (!sessionId || restoredSessionRef.current === sessionId || messages.length === 0) return;
-    if (!readingPosition) {
-      restoredSessionRef.current = sessionId;
-      return;
-    }
-    const element = messageElementsRef.current.get(readingPosition.messageId);
-    const scrollElement = scrollRef.current;
-    if (!element || !scrollElement) return;
-    restoredSessionRef.current = sessionId;
-    stopScroll();
-    element.scrollIntoView({ block: "start", behavior: "auto" });
-    scrollElement.scrollTop -= readingPosition.offsetPx;
-  }, [messageElementsRef, messages.length, readingPosition, scrollRef, sessionId, stopScroll]);
+  const messagesRef = useRef(messages);
 
   useEffect(() => {
-    // 2. 滚动停止后记录首个可见消息和相对偏移，避免按绝对 scrollTop 恢复后被乱序归位破坏
+    messagesRef.current = messages;
+  }, [messages]);
+  useLayoutEffect(() => {
+    // 1. 同一投影代次同步完成前持续校准，避免网络分页把视口推走
+    if (!sessionId) return;
+    const projectionKey = `${sessionId}\u001f${projectionGeneration}`;
+    const syncStarting = resyncing && (
+      syncPhaseRef.current.projectionKey !== projectionKey || !syncPhaseRef.current.active
+    );
+    syncPhaseRef.current = { projectionKey, active: resyncing };
+    if (syncStarting) {
+      if (restoreTimerRef.current !== null) window.clearTimeout(restoreTimerRef.current);
+      if (restoreFrameRef.current !== null) window.cancelAnimationFrame(restoreFrameRef.current);
+      restoreTimerRef.current = null;
+      restoreFrameRef.current = null;
+      if (restoredProjectionRef.current === projectionKey) restoredProjectionRef.current = undefined;
+    }
+    if (restoredProjectionRef.current === projectionKey) return;
+    if (restoringProjectionRef.current !== projectionKey) {
+      if (restoreTimerRef.current !== null) window.clearTimeout(restoreTimerRef.current);
+      if (restoreFrameRef.current !== null) window.cancelAnimationFrame(restoreFrameRef.current);
+      restoringProjectionRef.current = projectionKey;
+      restoreTargetRef.current = readingPosition ?? null;
+    } else if (
+      readingPosition
+      && (
+        restoreTargetRef.current?.messageId !== readingPosition.messageId
+        || restoreTargetRef.current.offsetPx !== readingPosition.offsetPx
+      )
+    ) {
+      restoreTargetRef.current = readingPosition;
+    }
+    if (messages.length === 0) return;
     const scrollElement = scrollRef.current;
-    if (!sessionId || !scrollElement || suspended) return;
+    const target = restoreTargetRef.current;
+    if (!scrollElement || target === undefined) return;
+    if (target) {
+      const element = messageElementsRef.current.get(target.messageId);
+      if (element) {
+        stopScroll();
+        element.scrollIntoView({ block: "start", behavior: "auto" });
+        scrollElement.scrollTop -= target.offsetPx;
+      }
+    }
+    if (resyncing) return;
+    if (restoreTimerRef.current !== null) window.clearTimeout(restoreTimerRef.current);
+    restoreTimerRef.current = window.setTimeout(() => {
+      const settle = () => {
+        if (restoringProjectionRef.current !== projectionKey) return;
+        restoredProjectionRef.current = projectionKey;
+        restoringProjectionRef.current = undefined;
+        restoreTargetRef.current = undefined;
+        restoreTimerRef.current = null;
+        restoreFrameRef.current = null;
+        scrollElement.dispatchEvent(new Event("scroll"));
+      };
+      if (restoringProjectionRef.current !== projectionKey) return;
+      if (target) {
+        const element = messageElementsRef.current.get(target.messageId);
+        if (element) {
+          stopScroll();
+          element.scrollIntoView({ block: "start", behavior: "auto" });
+          scrollElement.scrollTop -= target.offsetPx;
+          restoreFrameRef.current = requestAnimationFrame(settle);
+          return;
+        }
+      }
+      void Promise.resolve(scrollToBottom({ animation: "instant", ignoreEscapes: true })).then(() => {
+        if (restoringProjectionRef.current === projectionKey) settle();
+      });
+    }, 320);
+  }, [
+    messageElementsRef,
+    messages.length,
+    projectionGeneration,
+    readingPosition,
+    resyncing,
+    scrollRef,
+    scrollToBottom,
+    sessionId,
+    stopScroll,
+  ]);
+
+  useEffect(() => {
+    // 2. 历史装载期间若用户主动触摸，立即把视口所有权交还给用户
+    const scrollElement = scrollRef.current;
+    if (!sessionId || !scrollElement) return;
+    const projectionKey = `${sessionId}\u001f${projectionGeneration}`;
+    const interruptRestore = () => {
+      if (restoringProjectionRef.current !== projectionKey) return;
+      if (restoreTimerRef.current !== null) window.clearTimeout(restoreTimerRef.current);
+      if (restoreFrameRef.current !== null) window.cancelAnimationFrame(restoreFrameRef.current);
+      restoredProjectionRef.current = projectionKey;
+      restoringProjectionRef.current = undefined;
+      restoreTargetRef.current = undefined;
+      restoreTimerRef.current = null;
+      restoreFrameRef.current = null;
+    };
+    scrollElement.addEventListener("touchstart", interruptRestore, { passive: true });
+    scrollElement.addEventListener("wheel", interruptRestore, { passive: true });
+    return () => {
+      scrollElement.removeEventListener("touchstart", interruptRestore);
+      scrollElement.removeEventListener("wheel", interruptRestore);
+      if (restoringProjectionRef.current === projectionKey && restoreTimerRef.current !== null) {
+        window.clearTimeout(restoreTimerRef.current);
+      }
+      if (restoringProjectionRef.current === projectionKey && restoreFrameRef.current !== null) {
+        window.cancelAnimationFrame(restoreFrameRef.current);
+      }
+    };
+  }, [projectionGeneration, scrollRef, sessionId]);
+
+  useEffect(() => {
+    // 3. 滚动停止后记录首个可见消息和相对偏移，避免按绝对 scrollTop 恢复后被乱序归位破坏
+    const scrollElement = scrollRef.current;
+    if (!sessionId || !scrollElement || resyncing || suspended) return;
     const persist = () => {
       saveTimerRef.current = null;
+      const projectionKey = `${sessionId}\u001f${projectionGeneration}`;
+      if (restoringProjectionRef.current === projectionKey) return;
+      const distanceFromBottom = scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight;
+      if (distanceFromBottom <= 2) {
+        const readAt = messagesRef.current.reduce(
+          (latest, message) => message.role === "assistant" ? Math.max(latest, message.createdAt) : latest,
+          0,
+        );
+        const tailKey = `${sessionId}\u001ftail\u001f${readAt}`;
+        if (tailKey !== lastSavedRef.current) {
+          lastSavedRef.current = tailKey;
+          lastReadAtRef.current = Math.max(lastReadAtRef.current, readAt);
+          window.AkashicNative?.markSessionReadThrough(sessionId, readAt);
+        }
+        return;
+      }
       const viewportTop = scrollElement.getBoundingClientRect().top;
-      const anchor = messages.find((message) => {
-        const element = messageElementsRef.current.get(message.id);
-        return element ? element.getBoundingClientRect().bottom > viewportTop + 1 : false;
-      });
+      let anchor: { messageId: string; element: HTMLDivElement; top: number } | undefined;
+      for (const [messageId, element] of messageElementsRef.current) {
+        const rect = element.getBoundingClientRect();
+        if (rect.bottom <= viewportTop + 1 || (anchor && rect.top >= anchor.top)) continue;
+        anchor = { messageId, element, top: rect.top };
+      }
       if (!anchor) return;
-      const element = messageElementsRef.current.get(anchor.id);
-      if (!element) return;
+      const { element, messageId } = anchor;
       const offsetPx = Math.round(element.getBoundingClientRect().top - viewportTop);
-      const key = `${sessionId}\u001f${anchor.id}\u001f${offsetPx}`;
+      const key = `${sessionId}\u001f${messageId}\u001f${offsetPx}`;
       if (key === lastSavedRef.current) return;
       lastSavedRef.current = key;
-      window.AkashicNative?.saveReadingPosition(sessionId, anchor.id, offsetPx);
+      window.AkashicNative?.saveReadingPosition(sessionId, messageId, offsetPx);
     };
     const schedulePersist = () => {
       if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
@@ -2381,22 +2518,28 @@ function useMobileReadingPosition(
       scrollElement.removeEventListener("scroll", schedulePersist);
       if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
     };
-  }, [messageElementsRef, messages, scrollRef, sessionId, suspended]);
+  }, [messageElementsRef, projectionGeneration, resyncing, scrollRef, sessionId, suspended]);
 
   useEffect(() => {
-    // 3. 真正回到底部时推进该会话的持久化已读水位
+    // 4. 真正回到底部时推进该会话的持久化已读水位
     const scrollElement = scrollRef.current;
-    if (!sessionId || !isAtBottom || suspended || !scrollElement) return;
+    if (!sessionId || resyncing || suspended || !scrollElement) return;
+    const projectionKey = `${sessionId}\u001f${projectionGeneration}`;
+    if (restoringProjectionRef.current === projectionKey) return;
     const distanceFromBottom = scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight;
-    if (distanceFromBottom > 2) return;
+    if (!isAtBottom || distanceFromBottom > 2) {
+      return;
+    }
     const readAt = messages.reduce(
       (latest, message) => message.role === "assistant" ? Math.max(latest, message.createdAt) : latest,
       0,
     );
-    if (readAt <= lastReadAtRef.current) return;
-    lastReadAtRef.current = readAt;
+    const tailKey = `${sessionId}\u001ftail\u001f${readAt}`;
+    if (tailKey === lastSavedRef.current && readAt <= lastReadAtRef.current) return;
+    lastSavedRef.current = tailKey;
+    lastReadAtRef.current = Math.max(lastReadAtRef.current, readAt);
     window.AkashicNative?.markSessionReadThrough(sessionId, readAt);
-  }, [isAtBottom, messages, scrollRef, sessionId, suspended]);
+  }, [isAtBottom, messages, projectionGeneration, resyncing, scrollRef, sessionId, suspended]);
 }
 
 /** 按顶层助手消息追踪当前阅读位置之后的未读集合。 */

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -13,6 +13,7 @@ import {
 import { useStickToBottomContext } from "use-stick-to-bottom";
 import {
   AlertCircle,
+  ArchiveX,
   ArrowLeft,
   Check,
   ChevronRight,
@@ -45,7 +46,10 @@ import {
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
@@ -151,6 +155,8 @@ interface MobileSession {
   lastMessageAt?: number;
   unreadCount: number;
   isRunning: boolean;
+  isAvailable: boolean;
+  canRemove: boolean;
 }
 
 interface MobileReadingPosition {
@@ -170,7 +176,7 @@ interface MobilePendingMessage {
 }
 
 export interface MobileSnapshot {
-  protocolVersion: 3;
+  protocolVersion: 4;
   connection: {
     label: string;
     status: ConnectionStatus;
@@ -202,6 +208,7 @@ interface NativeBridge {
   reportReady(): void;
   requestSnapshot(): void;
   selectSession(sessionId: string): void;
+  removeUnavailableSession(sessionId: string): void;
   createSession(): void;
   restartPairing(): void;
   reloadFromServer(): void;
@@ -393,7 +400,7 @@ function parseTransferStatus(value: unknown): MobileTransferStatus {
 function parseMobileSnapshot(value: unknown): MobileSnapshot {
   // 1. 校验协议版本与根对象
   const raw = requireRecord(value, "snapshot");
-  if (raw.protocolVersion !== 3) throw new Error(`不支持的移动端协议版本: ${String(raw.protocolVersion)}`);
+  if (raw.protocolVersion !== 4) throw new Error(`不支持的移动端协议版本: ${String(raw.protocolVersion)}`);
   const connection = requireRecord(raw.connection, "connection");
   const status = requireString(connection.status, "connection.status");
   if (!["connecting", "ready", "degraded", "reconnecting", "disconnected"].includes(status)) {
@@ -413,6 +420,8 @@ function parseMobileSnapshot(value: unknown): MobileSnapshot {
       lastMessageAt,
       unreadCount: requireNonNegativeInteger(session.unreadCount, `sessions[${index}].unreadCount`),
       isRunning: requireBoolean(session.isRunning, `sessions[${index}].isRunning`),
+      isAvailable: requireBoolean(session.isAvailable, `sessions[${index}].isAvailable`),
+      canRemove: requireBoolean(session.canRemove, `sessions[${index}].canRemove`),
     };
   });
   const messages = requireArray(raw.messages, "messages", parseMessage);
@@ -450,7 +459,7 @@ function parseMobileSnapshot(value: unknown): MobileSnapshot {
       };
     })();
   return {
-    protocolVersion: 3,
+    protocolVersion: 4,
     connection: {
       label: requireString(connection.label, "connection.label"),
       status: status as ConnectionStatus,
@@ -813,6 +822,8 @@ function MobileNativeApp() {
       </main>
     );
   }
+  const selectedSession = snapshot.sessions.find((session) => session.id === snapshot.selectedSessionId);
+  const selectedSessionUnavailable = selectedSession?.isAvailable === false;
 
   const send = () => {
     const text = input.trim();
@@ -1036,7 +1047,7 @@ function MobileNativeApp() {
             <MobilePluginDashboard pluginId={surface.pluginId} />
           </section>
         ) : (
-        <div className={`mobile-main-content ${replyTarget ? "replying" : ""} ${searchOpen ? "searching" : ""} ${selectionActive ? "selecting" : ""} ${queueOpen && snapshot.composer.pendingMessages.length > 1 ? "queueing" : ""}`} inert={drawerOpen ? true : undefined}>
+        <div className={`mobile-main-content ${replyTarget ? "replying" : ""} ${searchOpen ? "searching" : ""} ${selectionActive ? "selecting" : ""} ${queueOpen && snapshot.composer.pendingMessages.length > 1 ? "queueing" : ""} ${selectedSessionUnavailable ? "session-unavailable" : ""}`} inert={drawerOpen ? true : undefined}>
           <Conversation
             key={snapshot.selectedSessionId ?? "empty"}
             className="mobile-conversation"
@@ -1081,7 +1092,7 @@ function MobileNativeApp() {
                             onCopyToolDetail={copyToolDetail}
                             leadingContent={source.reply ? <MessageReplyReference reply={source.reply} /> : undefined}
                             attachmentContent={<MobileMessageAttachments attachments={source.attachments} />}
-                            processStartContent={isPluginTurnMessage(message) ? (
+                            processStartContent={!selectedSessionUnavailable && isPluginTurnMessage(message) ? (
                               <MobilePluginSlot
                                 name="turn.before_reasoning"
                                 sessionId={source.sessionId}
@@ -1089,7 +1100,7 @@ function MobileNativeApp() {
                                 turnId={pluginTurnId(message)}
                               />
                             ) : undefined}
-                            beforeProcessBlock={(block) => isPluginTurnMessage(message) && block.kind === "tool" ? (
+                            beforeProcessBlock={(block) => !selectedSessionUnavailable && isPluginTurnMessage(message) && block.kind === "tool" ? (
                               <MobilePluginSlot
                                 name="turn.before_tool"
                                 sessionId={source.sessionId}
@@ -1098,7 +1109,7 @@ function MobileNativeApp() {
                                 block={block}
                               />
                             ) : null}
-                            answerEndContent={isPluginTurnMessage(message) ? (
+                            answerEndContent={!selectedSessionUnavailable && isPluginTurnMessage(message) ? (
                               <MobilePluginSlot
                                 name="turn.after_answer"
                                 sessionId={source.sessionId}
@@ -1160,7 +1171,9 @@ function MobileNativeApp() {
               onPrevious={() => moveSearch(-1)}
               onNext={() => moveSearch(1)}
             />
-          ) : selectionActive ? null : (
+          ) : selectionActive ? null : selectedSessionUnavailable && selectedSession ? (
+            <UnavailableSessionFooter key={selectedSession.id} session={selectedSession} />
+          ) : (
             <MobileComposer
               snapshot={snapshot}
               input={input}
@@ -1413,7 +1426,7 @@ function MobileDrawer({
         <nav className="mobile-session-list">
           {snapshot.sessions.map((session) => (
             <button
-              className={`mobile-session-row ${session.id === snapshot.selectedSessionId ? "active" : ""}`}
+              className={`mobile-session-row ${session.id === snapshot.selectedSessionId ? "active" : ""} ${session.isAvailable ? "" : "unavailable"}`}
               type="button"
               key={session.id}
               onClick={() => {
@@ -1426,15 +1439,19 @@ function MobileDrawer({
                   <strong>{session.title || "未命名会话"}</strong>
                   {session.lastMessageAt ? <time>{formatDrawerTime(session.lastMessageAt)}</time> : null}
                 </span>
-                <small>{session.lastMessagePreview || "还没有消息"}</small>
+                <small>{session.isAvailable
+                  ? session.lastMessagePreview || "还没有消息"
+                  : "电脑端已不存在 · 本机保留历史"}</small>
               </span>
               <span className="mobile-session-row__state">
-                {session.isRunning ? <span className="session-running" aria-label="Agent 正在处理" /> : null}
-                {session.unreadCount > 0 ? (
+                {!session.isAvailable ? (
+                  <ArchiveX size={19} aria-label="电脑端已不存在" />
+                ) : session.isRunning ? <span className="session-running" aria-label="Agent 正在处理" /> : null}
+                {session.isAvailable && session.unreadCount > 0 ? (
                   <strong className="session-unread" aria-label={`${session.unreadCount} 条未读`}>
                     {session.unreadCount > 99 ? "99+" : session.unreadCount}
                   </strong>
-                ) : session.id === snapshot.selectedSessionId ? <Check size={18} /> : null}
+                ) : session.isAvailable && session.id === snapshot.selectedSessionId ? <Check size={18} /> : null}
               </span>
             </button>
           ))}
@@ -1463,6 +1480,62 @@ function MobileDrawer({
           </button>
         </div>
       </aside>
+    </div>
+  );
+}
+
+function UnavailableSessionFooter({ session }: { session: MobileSession }) {
+  if (!session.canRemove) {
+    return (
+      <div className="mobile-unavailable-session" role="status">
+        <span>
+          <strong>电脑端已不存在</strong>
+          <small>未发送的消息或附件仍保留在本机；已停止发送，避免重新创建会话。</small>
+        </span>
+        <button className="new-session" type="button" onClick={() => window.AkashicNative?.createSession()}>
+          新聊天
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="mobile-unavailable-session" role="status">
+      <span>
+        <strong>电脑端已不存在</strong>
+        <small>历史仍保存在这台手机上，但不能继续发送。</small>
+      </span>
+      <Dialog>
+        <DialogTrigger asChild>
+          <button type="button">从本机移除</button>
+        </DialogTrigger>
+        <DialogContent
+          className="mobile-session-remove-dialog"
+          overlayClassName="mobile-session-remove-overlay"
+          showCloseButton={false}
+        >
+          <DialogTitle>移除本机会话？</DialogTitle>
+          <DialogDescription>
+            “{session.title || "未命名会话"}”的本地历史和已缓存附件会被删除，电脑端数据不会受到影响。
+          </DialogDescription>
+          <DialogFooter className="mobile-session-remove-dialog__actions">
+            <DialogClose asChild>
+              <button type="button">取消</button>
+            </DialogClose>
+            <DialogClose asChild>
+              <button
+                className="destructive"
+                type="button"
+                onClick={() => {
+                  window.AkashicNative?.performActionHaptic();
+                  window.AkashicNative?.removeUnavailableSession(session.id);
+                }}
+              >
+                移除
+              </button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -766,6 +766,13 @@ class MobileRealtimeChannel:
             )
         if not frame.payload.text.strip() and not frame.payload.media_refs:
             raise MobileCommandError("empty_message", "文字和附件不能同时为空")
+        ctx = self._require_ctx()
+        claimed_session = self._runtime.storage.has_session_claim(session_id)
+        if claimed_session and not ctx.session_manager.session_exists(session_id):
+            raise MobileCommandError(
+                "session_not_found",
+                "会话已从电脑端删除，请在手机上新建会话后继续",
+            )
         try:
             media = self._require_attachments().resolve_uploads(
                 device_id=device_id,
@@ -774,7 +781,6 @@ class MobileRealtimeChannel:
             )
         except (AttachmentRequestError, AttachmentStateError) as error:
             raise MobileCommandError("attachment_not_ready", str(error)) from error
-        ctx = self._require_ctx()
         reply = self._resolve_reply(session_id, frame.payload.reply_to)
         inbound_content = frame.payload.text
         metadata: dict[str, object] = {
@@ -782,6 +788,7 @@ class MobileRealtimeChannel:
             "client_message_id": frame.payload.client_message_id,
             "client_created_at": frame.payload.client_created_at,
             "device_id": device_id,
+            "require_existing_session": True,
         }
         if reply is not None:
             metadata.update(
@@ -802,7 +809,8 @@ class MobileRealtimeChannel:
             session_id=session_id,
             created_at=_utc_now(),
         )
-        _ = ctx.session_manager.get_or_create(session_id)
+        if not claimed_session:
+            _ = ctx.session_manager.get_or_create(session_id)
         await ctx.bus.publish_inbound(
             InboundMessage(
                 channel=self.name,

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -21,6 +21,7 @@ from bus.events_lifecycle import (
 )
 from agent.plugins.mobile_ui import (
     MobileUiPluginUnavailable,
+    MobileUiRpcExecutionError,
     MobileUiRpcInvalidRequest,
     MobileUiRpcTimeout,
 )
@@ -522,6 +523,8 @@ class MobileRealtimeChannel:
             raise MobileCommandError("plugin_invalid_request", str(error)) from error
         except MobileUiRpcTimeout as error:
             raise MobileCommandError("plugin_timeout", str(error)) from error
+        except MobileUiRpcExecutionError as error:
+            raise MobileCommandError("plugin_failed", str(error)) from error
         return CommandReply(type="plugin.ui.call.ok", payload={"result": result})
 
     def _require_mobile_ui_provider(self) -> MobileUiProvider:

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -601,9 +601,25 @@ class MobileGatewayRuntime:
             )
             return last_ack, last_ack, terminal
 
-        # 2. 验证保留窗口并冻结当前已分配序号上限
+        # 2. 先冻结当前已分配上限；服务端回退必须早于旧窗口保留期判断
+        replay_through = cursor.next_event_seq - 1
+        if last_ack > replay_through:
+            event_id = _new_ulid()
+            terminal = self.inbox.rebase_with_event(
+                device_id=device_id,
+                through_event_seq=last_ack,
+                event_id=event_id,
+                envelope_json=_encode_stored_event(
+                    event_id=event_id,
+                    event_type="sync.reset_required",
+                    payload={"reason": "client_ack_ahead_of_server_cursor"},
+                ),
+            )
+            return last_ack, last_ack, terminal
+
+        # 3. 验证保留窗口；回退恢复之外不能重放已经过期的 durable 事件
         try:
-            _ = self.inbox.replay(
+            replay = self.inbox.replay(
                 device_id,
                 after_event_seq=last_ack,
                 limit=1,
@@ -615,9 +631,12 @@ class MobileGatewayRuntime:
                 payload={"reason": "inbox_retention_exceeded"},
             )
             return last_ack, last_ack, terminal
-        replay_through = cursor.next_event_seq - 1
 
-        # 3. 持久化窗口已有缺口时必须重建，不能把后续事件伪装成连续重放
+        # 已原子落盘但尚未送达的 reset 仍是唯一终止帧，不能追加完成帧掩盖它
+        if replay.events and _stored_event_type(replay.events[0]) == "sync.reset_required":
+            return last_ack, last_ack, replay.events[0]
+
+        # 4. 持久化窗口已有缺口时必须重建，不能把后续事件伪装成连续重放
         if not self.storage.durable_event_range_is_contiguous(
             device_id,
             after_event_seq=last_ack,
@@ -630,7 +649,7 @@ class MobileGatewayRuntime:
             )
             return last_ack, last_ack, terminal
 
-        # 4. 终止帧先占号，随后并发 publish 只能排在它之后
+        # 5. 终止帧先占号，随后并发 publish 只能排在它之后
         terminal = self._enqueue_event(
             device_id=device_id,
             event_type="sync.completed",
@@ -1325,6 +1344,16 @@ def _encode_stored_event(
     )
     _ = _stored_event_to_wire(encoded, event_seq=1, connection_epoch=1)
     return encoded
+
+
+def _stored_event_type(event: DurableInboxEvent) -> str:
+    """读取已经过入箱校验的 durable 事件类型。"""
+
+    body = json.loads(event.envelope_json)
+    event_type = body["type"]
+    if not isinstance(event_type, str):
+        raise TypeError("durable event type 必须为文本")
+    return event_type
 
 
 def _stored_event_to_wire(

--- a/infra/mobile_realtime/inbox.py
+++ b/infra/mobile_realtime/inbox.py
@@ -52,6 +52,24 @@ class DurableInboxManager:
             created_at=self._now(),
         )
 
+    def rebase_with_event(
+        self,
+        *,
+        device_id: str,
+        through_event_seq: int,
+        event_id: str,
+        envelope_json: str,
+    ) -> DurableInboxEvent:
+        """原子重定位回退游标，并持久化下一条重建事件。"""
+
+        return self._storage.rebase_cursor_with_durable_event(
+            device_id,
+            through_event_seq=through_event_seq,
+            event_id=event_id,
+            envelope_json=envelope_json,
+            created_at=self._now(),
+        )
+
     def replay(
         self,
         device_id: str,

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -19,6 +19,7 @@ from pydantic import (
 
 PROTOCOL_VERSION = 1
 MAX_JSON_FRAME_BYTES = 256 * 1024
+_MAX_REBASE_ACK = 1 << 62
 
 COMMAND_TYPES = frozenset(
     {
@@ -230,7 +231,7 @@ class AuthAcceptedPayload(ProtocolModel):
 
 
 class ResumePayload(ProtocolModel):
-    last_ack: int = Field(ge=0)
+    last_ack: int = Field(ge=0, le=_MAX_REBASE_ACK)
     active_turns: list[NonEmptyId] = Field(max_length=128)
 
 

--- a/infra/mobile_realtime/storage.py
+++ b/infra/mobile_realtime/storage.py
@@ -14,6 +14,7 @@ from typing import Literal, cast
 PairingStatus = Literal["pending", "confirmed", "consumed", "expired"]
 AttachmentDirection = Literal["upload", "outbound"]
 AttachmentState = Literal["transferring", "ready", "failed"]
+_MAX_REBASE_ACK = 1 << 62
 
 
 class MobileStorageError(RuntimeError):
@@ -444,6 +445,74 @@ class MobileRealtimeStorage:
             raise UnknownDeviceError(f"设备不存在或缺少 cursor: {device_id}")
         return _cursor_from_row(row)
 
+    def rebase_cursor_with_durable_event(
+        self,
+        device_id: str,
+        *,
+        through_event_seq: int,
+        event_id: str,
+        envelope_json: str,
+        created_at: datetime,
+    ) -> DurableInboxEvent:
+        """原子重定位回退游标，并写入要求客户端重建的 durable 事件。"""
+
+        # 1. 固化事件字段，并只允许向前跨过服务端当前已分配范围
+        device_key = _require_text(device_id, "device_id")
+        event_key = _require_text(event_id, "event_id")
+        envelope = _require_text(envelope_json, "envelope_json")
+        timestamp = _serialize_datetime(created_at, "created_at")
+        if not 0 <= through_event_seq <= _MAX_REBASE_ACK:
+            raise ValueError("through_event_seq 超出可恢复的 SQLite 序号范围")
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            row = self._db.execute(
+                """
+                SELECT device_id, next_event_seq, sent_event_seq,
+                       acknowledged_event_seq
+                FROM mobile_device_cursors
+                WHERE device_id = ?
+                """,
+                (device_key,),
+            ).fetchone()
+            if row is None:
+                raise UnknownDeviceError(f"设备不存在或缺少 cursor: {device_key}")
+            cursor = _cursor_from_row(row)
+            if through_event_seq < cursor.next_event_seq:
+                raise ValueError("客户端 ACK 没有领先服务端 cursor")
+
+            # 2. 丢弃回退窗口，并在同一事务写入紧接客户端 ACK 的 reset
+            event_seq = through_event_seq + 1
+            _ = self._db.execute(
+                "DELETE FROM mobile_device_inbox WHERE device_id = ?",
+                (device_key,),
+            )
+            _ = self._db.execute(
+                """
+                INSERT INTO mobile_device_inbox(
+                    device_id, event_seq, event_id, priority,
+                    envelope_json, created_at
+                ) VALUES(?, ?, ?, 'P0', ?, ?)
+                """,
+                (device_key, event_seq, event_key, envelope, timestamp),
+            )
+            _ = self._db.execute(
+                """
+                UPDATE mobile_device_cursors
+                SET next_event_seq = ?, sent_event_seq = ?, acknowledged_event_seq = ?
+                WHERE device_id = ?
+                """,
+                (event_seq + 1, through_event_seq, through_event_seq, device_key),
+            )
+
+        return DurableInboxEvent(
+            device_id=device_key,
+            event_seq=event_seq,
+            event_id=event_key,
+            priority="P0",
+            envelope_json=envelope,
+            created_at=_parse_datetime(timestamp, "created_at"),
+        )
+
     def append_durable_event(
         self,
         *,
@@ -752,6 +821,17 @@ class MobileRealtimeStorage:
                 """,
                 (device_key, session_key, timestamp),
             )
+
+    def has_session_claim(self, session_id: str) -> bool:
+        """判断移动会话是否曾在服务端建立过持久化身份。"""
+
+        session_key = _require_text(session_id, "session_id")
+        with self._lock:
+            row = self._db.execute(
+                "SELECT 1 FROM mobile_device_sessions WHERE session_id = ?",
+                (session_key,),
+            ).fetchone()
+        return row is not None
 
     def require_session_owner(self, *, device_id: str, session_id: str) -> None:
         device_key = _require_text(device_id, "device_id")

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -1235,6 +1235,7 @@
             "type": "array"
           },
           "last_ack": {
+            "maximum": 4611686018427387904,
             "minimum": 0,
             "title": "Last Ack",
             "type": "integer"

--- a/session/manager.py
+++ b/session/manager.py
@@ -347,6 +347,25 @@ class SessionManager:
         self._cache[key] = session
         return session
 
+    def get_existing(self, key: str) -> Session:
+        """读取仍存在的会话，禁止把已删除身份重新创建。"""
+
+        # 1. 先以持久化 owner 核对身份，缓存不能覆盖删除事实
+        if not self._store.session_exists(key):
+            self.invalidate(key)
+            raise KeyError(f"session 不存在: {key}")
+
+        # 2. 复用缓存或装载持久化会话，不进入创建路径
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        session = self._load(key)
+        if session is None:
+            raise KeyError(f"session 不存在: {key}")
+        self._cache[key] = session
+        return session
+
+
     def peek_next_message_id(self, session_key: str) -> str:
         next_seq = self._store.next_seq(session_key)
         return f"{session_key}:{next_seq}"

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -350,6 +350,55 @@ async def test_message_send_is_idempotent_and_session_is_shared_between_devices(
 
 
 @pytest.mark.asyncio
+async def test_message_send_does_not_recreate_a_deleted_claimed_session(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    manager = SessionManager(tmp_path / "workspace")
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    bus = _Bus()
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=bus,
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+    session_id = f"mobile:{uuid4()}"
+    manager.save(manager.get_or_create(session_id))
+    storage.claim_session(
+        device_id=device_id,
+        session_id=session_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    assert manager.delete_session(session_id)
+
+    reply = await channel.handle_command(
+        device_id=device_id,
+        frame=_message_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FBA",
+            session_id=session_id,
+        ),
+    )
+
+    assert reply.type == "message.send.error"
+    assert reply.payload["code"] == "session_not_found"
+    assert not manager.session_exists(session_id)
+    assert bus.inbound == []
+    manager.close()
+    storage.close()
+
+
+@pytest.mark.asyncio
 async def test_message_send_recovers_processing_receipt_from_persisted_user(
     tmp_path: Path,
 ) -> None:
@@ -605,6 +654,7 @@ async def test_message_send_resolves_reply_into_agent_context_and_metadata(
     assert inbound.metadata["reply_to_message_id"] == target["id"]
     assert inbound.metadata["reply_role"] == "assistant"
     assert inbound.metadata["reply_preview"] == " ".join(target_content.split())[:512]
+    assert inbound.metadata["require_existing_session"] is True
 
     user_target = session.add_message(
         "user",
@@ -623,6 +673,7 @@ async def test_message_send_resolves_reply_into_agent_context_and_metadata(
         ),
     )
     assert second.type == "message.send.ok"
+    assert bus.inbound[1].metadata["require_existing_session"] is True
     assert bus.inbound[1].metadata["reply_to_message_id"] == user_target["id"]
     assert "被回复消息（来自 你）：\n之前的问题" in bus.inbound[1].content
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1431,6 +1431,38 @@ async def test_plugin_ui_invalid_request_becomes_durable_error_reply(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_plugin_ui_execution_failure_becomes_durable_error_reply(tmp_path: Path) -> None:
+    class _FailedProvider:
+        def catalog(self) -> list[dict[str, object]]:
+            return []
+
+        async def call(self, *args: object, **kwargs: object) -> dict[str, object]:
+            raise channel_module.MobileUiRpcExecutionError(
+                "插件 mobile UI RPC 执行失败: sample@github.recall.current"
+            )
+
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
+    channel.bind_mobile_ui_provider(cast(Any, _FailedProvider()))
+    frame = _generic_frame(
+        frame_id="01ARZ3NDEKTSV4RRFFQ69G5FB4",
+        command_type="plugin.ui.call",
+        payload={"plugin_id": "sample@github", "method": "recall.current", "payload": {}},
+    )
+
+    reply = await channel.handle_command(device_id=device_id, frame=frame)
+
+    assert reply.type == "plugin.ui.call.error"
+    assert reply.payload == {
+        "code": "plugin_failed",
+        "message": "插件 mobile UI RPC 执行失败: sample@github.recall.current",
+    }
+    storage.close()
+
+
+@pytest.mark.asyncio
 async def test_turn_stop_rejects_missing_or_stale_turn_identity(tmp_path: Path) -> None:
     storage = MobileRealtimeStorage(tmp_path / "mobile.db")
     device_id = uuid4().hex

--- a/tests/mobile_realtime/test_gateway.py
+++ b/tests/mobile_realtime/test_gateway.py
@@ -8,7 +8,7 @@ import secrets
 import sqlite3
 from collections import deque
 from contextlib import closing
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -294,6 +294,193 @@ def test_resume_reset_terminal_explicitly_bridges_client_sequence_gap(
         stored = json.loads(terminal.envelope_json)
         assert stored["type"] == "sync.reset_required"
         assert stored["payload"]["reason"] == "client_ack_behind_server_cursor"
+    finally:
+        runtime.close()
+
+
+def test_resume_rebases_when_authenticated_client_ack_is_ahead(
+    tmp_path: Path,
+) -> None:
+    """服务端 durable DB 回退后，下一帧继续客户端序号并要求全量重建。"""
+
+    async def build():
+        return build_mobile_gateway_runtime(
+            _config(),
+            tmp_path,
+            master_keys=_EphemeralMasterKeys(),
+        )
+
+    runtime, _ = asyncio.run(build())
+    device_id = uuid4().hex
+    _register_test_device(runtime, device_id)
+    try:
+        runtime._enqueue_event(
+            device_id=device_id,
+            event_type="message.final",
+            payload={"content": "rolled-back"},
+        )
+
+        replay_after, replay_through, terminal = runtime._prepare_resume(
+            device_id=device_id,
+            last_ack=5,
+        )
+
+        assert (replay_after, replay_through) == (5, 5)
+        assert terminal.event_seq == 6
+        stored = json.loads(terminal.envelope_json)
+        assert stored["type"] == "sync.reset_required"
+        assert stored["payload"]["reason"] == "client_ack_ahead_of_server_cursor"
+        cursor = runtime.storage.read_cursor(device_id)
+        assert cursor.next_event_seq == 7
+        assert cursor.sent_event_seq == 5
+        assert cursor.acknowledged_event_seq == 5
+        assert [event.event_seq for event in runtime.storage.read_durable_events(
+            device_id,
+            after_event_seq=5,
+            limit=10,
+        )] == [6]
+    finally:
+        runtime.close()
+
+
+def test_rebased_reset_survives_runtime_restart(tmp_path: Path) -> None:
+    """游标重定位提交后即使进程退出，重连也只能先收到已落盘 reset。"""
+
+    async def build():
+        return build_mobile_gateway_runtime(
+            _config(),
+            tmp_path,
+            master_keys=master_keys,
+        )
+
+    master_keys = _EphemeralMasterKeys()
+    device_id = uuid4().hex
+    runtime, _ = asyncio.run(build())
+    _register_test_device(runtime, device_id)
+    runtime._enqueue_event(
+        device_id=device_id,
+        event_type="message.final",
+        payload={"content": "rolled-back"},
+    )
+    _, _, reset = runtime._prepare_resume(device_id=device_id, last_ack=5)
+    assert reset.event_seq == 6
+    runtime.close()
+
+    restarted, _ = asyncio.run(build())
+    try:
+        replay_after, replay_through, terminal = restarted._prepare_resume(
+            device_id=device_id,
+            last_ack=5,
+        )
+
+        assert (replay_after, replay_through) == (5, 5)
+        assert terminal.event_seq == 6
+        assert json.loads(terminal.envelope_json)["type"] == "sync.reset_required"
+        assert restarted.storage.read_cursor(device_id).next_event_seq == 7
+    finally:
+        restarted.close()
+
+
+def test_rebase_storage_rejects_ack_outside_sqlite_range(tmp_path: Path) -> None:
+    """存储 owner 不接受无法继续分配 reset 的客户端序号。"""
+
+    async def build():
+        return build_mobile_gateway_runtime(
+            _config(),
+            tmp_path,
+            master_keys=_EphemeralMasterKeys(),
+        )
+
+    runtime, _ = asyncio.run(build())
+    device_id = uuid4().hex
+    _register_test_device(runtime, device_id)
+    try:
+        with pytest.raises(ValueError, match="SQLite 序号范围"):
+            runtime.storage.rebase_cursor_with_durable_event(
+                device_id,
+                through_event_seq=(1 << 63) - 2,
+                event_id=uuid4().hex,
+                envelope_json='{"type":"sync.reset_required"}',
+                created_at=datetime.now(timezone.utc),
+            )
+    finally:
+        runtime.close()
+
+
+def test_maximum_rebase_ack_can_complete_next_resume(tmp_path: Path) -> None:
+    """最大合法恢复 ACK 仍为 reset 确认后的完成帧保留充足序号空间。"""
+
+    async def build():
+        return build_mobile_gateway_runtime(
+            _config(),
+            tmp_path,
+            master_keys=_EphemeralMasterKeys(),
+        )
+
+    runtime, _ = asyncio.run(build())
+    device_id = uuid4().hex
+    _register_test_device(runtime, device_id)
+    maximum_ack = 1 << 62
+    try:
+        _, _, reset = runtime._prepare_resume(
+            device_id=device_id,
+            last_ack=maximum_ack,
+        )
+        assert reset.event_seq == maximum_ack + 1
+        runtime.storage.mark_events_sent(
+            device_id,
+            through_event_seq=reset.event_seq,
+        )
+        runtime.storage.acknowledge_durable_events(
+            device_id,
+            through_event_seq=reset.event_seq,
+        )
+
+        replay_after, replay_through, completed = runtime._prepare_resume(
+            device_id=device_id,
+            last_ack=reset.event_seq,
+        )
+
+        assert (replay_after, replay_through) == (reset.event_seq, reset.event_seq)
+        assert completed.event_seq == maximum_ack + 2
+        assert json.loads(completed.envelope_json)["type"] == "sync.completed"
+    finally:
+        runtime.close()
+
+
+def test_ahead_ack_rebases_before_expired_inbox_check(tmp_path: Path) -> None:
+    """服务端回退与旧事件过期并存时，仍按客户端下一序号原子 reset。"""
+
+    async def build():
+        return build_mobile_gateway_runtime(
+            _config(),
+            tmp_path,
+            master_keys=_EphemeralMasterKeys(),
+        )
+
+    runtime, _ = asyncio.run(build())
+    device_id = uuid4().hex
+    _register_test_device(runtime, device_id)
+    runtime.storage.append_durable_event(
+        device_id=device_id,
+        event_id=uuid4().hex,
+        envelope_json='{"type":"message.final"}',
+        created_at=datetime.now(timezone.utc) - timedelta(days=8),
+    )
+    try:
+        replay_after, replay_through, terminal = runtime._prepare_resume(
+            device_id=device_id,
+            last_ack=5,
+        )
+
+        assert (replay_after, replay_through) == (5, 5)
+        assert terminal.event_seq == 6
+        assert json.loads(terminal.envelope_json)["type"] == "sync.reset_required"
+        assert [event.event_seq for event in runtime.storage.read_durable_events(
+            device_id,
+            after_event_seq=5,
+            limit=10,
+        )] == [6]
     finally:
         runtime.close()
 

--- a/tests/mobile_realtime/test_mobile_realtime_protocol.py
+++ b/tests/mobile_realtime/test_mobile_realtime_protocol.py
@@ -35,6 +35,14 @@ def test_golden_frames_round_trip() -> None:
     assert [json.loads(frame_to_json(frame)) for frame in parsed] == frames
 
 
+def test_resume_rejects_ack_that_cannot_fit_sqlite_sequence() -> None:
+    frame = _golden_frame(5)
+    frame["payload"]["last_ack"] = (1 << 63) - 2
+
+    with pytest.raises(ValidationError, match="less than or equal"):
+        parse_frame(json.dumps(frame))
+
+
 def test_message_send_rejects_mismatched_session() -> None:
     frame = _golden_frame(0)
     frame["session_id"] = "mobile:other"

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -335,6 +335,33 @@ async def test_before_turn_setup_fills_turn_state():
 
 
 @pytest.mark.asyncio
+async def test_before_turn_existing_admission_never_creates_deleted_session():
+    bus = EventBus()
+    session = _DummySession("mobile:deleted")
+    get_existing = Mock(return_value=session)
+    get_or_create = Mock(side_effect=AssertionError("不得重建已删除会话"))
+    session_mgr = SimpleNamespace(get_existing=get_existing, get_or_create=get_or_create)
+    ctx_store = SimpleNamespace(prepare=AsyncMock(return_value=ContextBundle()))
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = _inbound()
+    msg.metadata = {"require_existing_session": True}
+    state = TurnState(msg=msg, session_key="mobile:deleted", dispatch_outbound=True)
+
+    await phase.run(state)
+
+    get_existing.assert_called_once_with("mobile:deleted")
+    get_or_create.assert_not_called()
+    assert "require_existing_session" not in msg.metadata
+
+
+@pytest.mark.asyncio
 async def test_before_turn_uses_cli_session_override_context():
     bus = EventBus()
     session = _DummySession("telegram:7674283004")

--- a/tests/test_plugin_mobile_ui.py
+++ b/tests/test_plugin_mobile_ui.py
@@ -8,6 +8,8 @@ import pytest
 
 from agent.plugins.mobile_ui import (
     MobileUiPluginUnavailable,
+    MobileUiRpcExecutionError,
+    MobileUiRpcInvalidRequest,
     MobileUiRpcTimeout,
     PluginMobileUiProvider,
 )
@@ -35,20 +37,24 @@ class _MobilePlugin:
 class _Lease:
     def __init__(self, snapshot: object) -> None:
         self.snapshot = snapshot
+        self.released = False
 
     async def __aenter__(self):
         return self.snapshot
 
     async def __aexit__(self, *args: object) -> None:
+        self.released = True
         return None
 
 
 class _Store:
     def __init__(self, snapshot: object) -> None:
         self.snapshot = snapshot
+        self.last_lease: _Lease | None = None
 
     async def acquire(self) -> _Lease:
-        return _Lease(self.snapshot)
+        self.last_lease = _Lease(self.snapshot)
+        return self.last_lease
 
 
 def _provider() -> PluginMobileUiProvider:
@@ -131,6 +137,113 @@ async def test_mobile_ui_rpc_timeout_releases_snapshot_lease(monkeypatch: pytest
     monkeypatch.setattr(mobile_ui_module, "MOBILE_UI_RPC_TIMEOUT_SECONDS", 0.01)
 
     with pytest.raises(MobileUiRpcTimeout):
+        await provider.call(
+            "sample@github",
+            "recall.current",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+    assert cast(Any, provider)._manager.snapshot_store.last_lease.released is True
+
+
+@pytest.mark.asyncio
+async def test_mobile_ui_rpc_external_cancellation_propagates_and_releases_lease() -> None:
+    provider = _provider()
+    entered = asyncio.Event()
+
+    async def waits(*args: object, **kwargs: object) -> dict[str, object]:
+        entered.set()
+        await asyncio.Event().wait()
+        return {}
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_call = waits
+    task = asyncio.create_task(
+        provider.call(
+            "sample@github",
+            "recall.current",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+    )
+    await entered.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cast(Any, provider)._manager.snapshot_store.last_lease.released is True
+
+
+@pytest.mark.asyncio
+async def test_mobile_ui_rpc_failure_isolated_from_transport() -> None:
+    provider = _provider()
+
+    async def fails(*args: object, **kwargs: object) -> dict[str, object]:
+        raise RuntimeError("plugin bug detail")
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_call = fails
+
+    with pytest.raises(MobileUiRpcExecutionError, match="sample@github.recall.current"):
+        await provider.call(
+            "sample@github",
+            "recall.current",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message", ["x" * 300_000, "\ud800"])
+async def test_mobile_ui_invalid_request_message_is_owned_by_host(message: str) -> None:
+    provider = _provider()
+
+    async def rejects(*args: object, **kwargs: object) -> dict[str, object]:
+        raise MobileUiRpcInvalidRequest(message)
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_call = rejects
+
+    with pytest.raises(
+        MobileUiRpcInvalidRequest,
+        match=r"^插件 mobile UI RPC 参数无效: sample@github\.recall\.current$",
+    ) as captured:
+        await provider.call(
+            "sample@github",
+            "recall.current",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+    assert captured.value.args == (
+        "插件 mobile UI RPC 参数无效: sample@github.recall.current",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mobile_ui_rpc_recursive_result_isolated_from_transport() -> None:
+    provider = _provider()
+    recursive: dict[str, object] = {}
+    cursor = recursive
+    for _ in range(20_000):
+        nested: dict[str, object] = {}
+        cursor["nested"] = nested
+        cursor = nested
+
+    async def returns_recursive(*args: object, **kwargs: object) -> dict[str, object]:
+        return recursive
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_call = returns_recursive
+
+    with pytest.raises(MobileUiRpcExecutionError, match="sample@github.recall.current"):
         await provider.call(
             "sample@github",
             "recall.current",


### PR DESCRIPTION
## Summary
- convert plugin execution and return-contract failures into durable `plugin_failed` replies
- preserve cancellation and timeout ownership while always releasing snapshot leases
- rebuild invalid-request messages at the host boundary so plugin text cannot break reply encoding
- record same-WebSocket Pixel 7 failure/retry evidence

## Verification
- `pytest -q tests/test_plugin_mobile_ui.py tests/mobile_realtime/test_channel.py` (37 passed)
- `pyright agent/plugins/mobile_ui.py infra/mobile_realtime/channel.py` (0 errors)
- Pixel 7: same generation/epoch across real Fitbit 401 and successful retry