### PR TITLE
[codex] isolate mobile command catalog scope

### DIFF
--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -102,6 +102,12 @@ class Plugin(ABC):
     def channels(self) -> list["Channel"]:
         return []
 
+    def telegram_bot_commands(self) -> list[tuple[str, str]]:
+        return []
+
+    def mobile_bot_commands(self) -> list[tuple[str, str]]:
+        return []
+
     @classmethod
     def dashboard_module(cls) -> str | None:
         return None

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -589,12 +589,21 @@ class PluginManager:
 
     @property
     def telegram_bot_commands(self) -> list[tuple[str, str]]:
+        return self._declared_bot_commands("telegram_bot_commands")
+
+    @property
+    def mobile_bot_commands(self) -> list[tuple[str, str]]:
+        return self._declared_bot_commands("mobile_bot_commands")
+
+    def _declared_bot_commands(self, getter_name: str) -> list[tuple[str, str]]:
+        """聚合当前插件代际为指定渠道显式声明的命令。"""
+
         commands: list[tuple[str, str]] = []
         for generation in self._active_generations.values():
             if not self._registry_active(generation.module_path):
                 continue
             instance = generation.instance
-            getter = getattr(instance, "telegram_bot_commands", None)
+            getter = getattr(instance, getter_name, None)
             if getter is None:
                 continue
             typed_getter = cast(Callable[[], list[tuple[str, str]]], getter)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -406,8 +406,13 @@ class AppRuntime:
                 push_tool=self.push_tool,
                 http_resources=self.http_resources,
                 event_bus=event_bus,
-                bot_commands=(
+                telegram_bot_commands=(
                     plugin_manager.telegram_bot_commands
+                    if plugin_manager
+                    else None
+                ),
+                mobile_bot_commands=(
+                    plugin_manager.mobile_bot_commands
                     if plugin_manager
                     else None
                 ),

--- a/bootstrap/channel_host.py
+++ b/bootstrap/channel_host.py
@@ -209,7 +209,7 @@ class _ChannelResources:
             attachment_store=context.attachment_store,
             http_resources=context.http_resources,
             interrupt_controller=context.interrupt_controller,
-            bot_commands=context.bot_commands,
+            mobile_bot_commands=context.mobile_bot_commands,
             log=context.log,
         )
 

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -24,7 +24,8 @@ async def start_channels(
     push_tool: MessagePushTool,
     http_resources: SharedHttpResources,
     event_bus: EventBus,
-    bot_commands: list[tuple[str, str]] | None = None,
+    telegram_bot_commands: list[tuple[str, str]] | None = None,
+    mobile_bot_commands: list[tuple[str, str]] | None = None,
     interrupt_controller: InterruptController | None = None,
     plugin_channels: list[Channel] | None = None,
 ) -> ChannelHost:
@@ -40,7 +41,7 @@ async def start_channels(
                 attachment_store=attachment_store,
                 http_resources=http_resources,
                 interrupt_controller=interrupt_controller,
-                bot_commands=bot_commands or [],
+                mobile_bot_commands=mobile_bot_commands or [],
                 log=logging.getLogger(f"channels.{channel.name}"),
             )
 
@@ -55,7 +56,7 @@ async def start_channels(
                 bus=bus,
                 session_manager=session_manager,
                 allow_from=tg.allow_from,
-                bot_commands=bot_commands,
+                bot_commands=telegram_bot_commands,
                 event_bus=event_bus,
                 interrupt_controller=interrupt_controller,
                 channel_name=tg.channel_name,

--- a/infra/channels/contract.py
+++ b/infra/channels/contract.py
@@ -29,5 +29,5 @@ class ChannelContext:
     attachment_store: AttachmentStore
     http_resources: SharedHttpResources
     interrupt_controller: InterruptController | None
-    bot_commands: list[tuple[str, str]]
+    mobile_bot_commands: list[tuple[str, str]]
     log: logging.Logger

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -487,7 +487,7 @@ class MobileRealtimeChannel:
         _expect_keys(frame.payload, set())
         items: list[dict[str, str]] = []
         seen: set[str] = set()
-        for raw_command, raw_description in self._require_ctx().bot_commands:
+        for raw_command, raw_description in self._require_ctx().mobile_bot_commands:
             command = raw_command.strip().removeprefix("/")
             description = raw_description.strip()
             if not _BOT_COMMAND_PATTERN.fullmatch(command):

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -62,6 +62,11 @@ class AkashaPlugin(Plugin):
             return []
         return [("akashalast", "查看上一轮 Akasha 检索诊断")]
 
+    def mobile_bot_commands(self) -> list[tuple[str, str]]:
+        if not self.is_active():
+            return []
+        return [("akashalast", "查看上一轮 Akasha 检索诊断")]
+
     def before_turn_modules(self) -> list[object]:
         return [AkashaLastCommandModule(self)]
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -246,6 +246,7 @@ def _message_frame(
     session_id: str,
     epoch: int = 1,
     reply_to: dict[str, object] | None = None,
+    text: str = "你好",
 ) -> MessageSendCommand:
     frame = parse_frame(
         json.dumps(
@@ -259,7 +260,7 @@ def _message_frame(
                 "payload": {
                     "client_message_id": frame_id,
                     "session_id": session_id,
-                    "text": "你好",
+                    "text": text,
                     "media_refs": [],
                     "client_created_at": datetime.now(timezone.utc).isoformat(),
                     **({"reply_to": reply_to} if reply_to is not None else {}),
@@ -1305,7 +1306,7 @@ async def test_turn_stop_idle_result_still_closes_stale_mobile_turn(tmp_path: Pa
                     ),
                 ),
                 attachment_store=AttachmentStore(tmp_path / "uploads"),
-                bot_commands=[],
+                mobile_bot_commands=[],
             ),
         )
     )
@@ -1357,7 +1358,7 @@ async def test_command_list_uses_active_channel_catalog_without_stop(tmp_path: P
                 push_tool=_PushTool(),
                 interrupt_controller=None,
                 attachment_store=AttachmentStore(tmp_path / "uploads"),
-                bot_commands=[
+                mobile_bot_commands=[
                     ("undo", "撤销上一轮对话"),
                     ("/memorystatus", "查看记忆整理状态"),
                     ("stop", "中断当前回复"),
@@ -1382,6 +1383,48 @@ async def test_command_list_uses_active_channel_catalog_without_stop(tmp_path: P
         ]
     }
     await channel.stop()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_message_send_preserves_mobile_slash_command_for_bus(tmp_path: Path) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    manager = SessionManager(tmp_path / "workspace")
+    bus = _Bus()
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=bus,
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+                mobile_bot_commands=[("undo", "撤销上一轮对话")],
+            ),
+        )
+    )
+    session_id = f"mobile:{uuid4()}"
+
+    reply = await channel.handle_command(
+        device_id=device_id,
+        frame=_message_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAY",
+            session_id=session_id,
+            text="/undo",
+        ),
+    )
+
+    assert reply.type == "message.send.ok"
+    assert len(bus.inbound) == 1
+    assert cast(Any, bus.inbound[0]).content == "/undo"
+    await channel.stop()
+    manager.close()
     storage.close()
 
 

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -2031,8 +2031,10 @@ def test_akashalast_command_only_exposes_for_akasha_engine(tmp_path: Path) -> No
     )
 
     assert akasha.telegram_bot_commands() == [("akashalast", "查看上一轮 Akasha 检索诊断")]
+    assert akasha.mobile_bot_commands() == [("akashalast", "查看上一轮 Akasha 检索诊断")]
     assert len(akasha.before_turn_modules()) == 1
     assert default.telegram_bot_commands() == []
+    assert default.mobile_bot_commands() == []
     assert len(default.before_turn_modules()) == 1
 
 

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -99,7 +99,7 @@ def _context(channel: _Channel) -> SimpleNamespace:
         attachment_store=None,
         http_resources=None,
         interrupt_controller=None,
-        bot_commands=[],
+        mobile_bot_commands=[],
         log=f"ctx:{channel.name}",
     )
 
@@ -263,7 +263,7 @@ async def test_channel_host_revokes_shared_registrations_on_stop():
         attachment_store=None,
         http_resources=None,
         interrupt_controller=None,
-        bot_commands=[],
+        mobile_bot_commands=[],
         log="ctx:registered",
     )
     host = ChannelHost(lambda _channel: context)  # type: ignore[arg-type]
@@ -305,7 +305,7 @@ async def test_channel_host_restores_shared_registrations_after_failed_swap():
         attachment_store=None,
         http_resources=None,
         interrupt_controller=None,
-        bot_commands=[],
+        mobile_bot_commands=[],
         log="ctx:registered",
     )
     host = ChannelHost(lambda _channel: context)  # type: ignore[arg-type]

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2207,6 +2207,7 @@ async def test_current_plugin_views_ignore_retained_old_generation(
     assert len(active) == 1
     assert active[0].manifest["version"] == "v2"
     assert manager.telegram_bot_commands == [("view-v2", "v2")]
+    assert manager.mobile_bot_commands == []
 
     write_plugin_manifest(
         {"current_view": False},
@@ -2215,8 +2216,45 @@ async def test_current_plugin_views_ignore_retained_old_generation(
     await manager.reconcile_changed()
     assert manager.active_plugins() == []
     assert manager.telegram_bot_commands == []
+    assert manager.mobile_bot_commands == []
 
     await retained.release()
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_bot_command_catalogs_require_explicit_channel_declarations(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "a_telegram_only",
+        "from agent.plugins import Plugin\n"
+        "class TelegramOnlyPlugin(Plugin):\n"
+        "    name = 'a_telegram_only'\n"
+        "    def telegram_bot_commands(self):\n"
+        "        return [('telegram_only', '仅 Telegram')]\n",
+    )
+    _write_plugin(
+        tmp_path / "plugins",
+        "b_shared",
+        "from agent.plugins import Plugin\n"
+        "class SharedCommandPlugin(Plugin):\n"
+        "    name = 'b_shared'\n"
+        "    def telegram_bot_commands(self):\n"
+        "        return [('shared', '共享命令')]\n"
+        "    def mobile_bot_commands(self):\n"
+        "        return [('shared', '共享命令')]\n",
+    )
+    manager = _manager(tmp_path)
+
+    await manager.load_all()
+
+    assert manager.telegram_bot_commands == [
+        ("telegram_only", "仅 Telegram"),
+        ("shared", "共享命令"),
+    ]
+    assert manager.mobile_bot_commands == [("shared", "共享命令")]
     await manager.terminate_all()
 
 

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -881,6 +881,7 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
     starts: list[str] = []
     registrations: list[tuple[str, list[str]]] = []
     attachment_roots: list[Path] = []
+    mobile_catalogs: list[list[tuple[str, str]]] = []
     fake_telegram = types.ModuleType("infra.channels.telegram_channel")
     fake_qq = types.ModuleType("infra.channels.qq_channel")
 
@@ -947,6 +948,7 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
         async def start(self, ctx: Any) -> None:
             starts.append("plugin")
             attachment_roots.append(ctx.attachment_store.root)
+            mobile_catalogs.append(ctx.mobile_bot_commands)
             ctx.push_tool.register_channel(self.name, text=self.send)
 
         async def stop(self) -> None:
@@ -988,6 +990,8 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
         push_tool=cast(Any, _PushTool()),
         http_resources=resources,
         event_bus=event_bus,
+        telegram_bot_commands=[("telegram_only", "仅 Telegram")],
+        mobile_bot_commands=[("mobile_only", "仅 mobile")],
         interrupt_controller=cast(Any, controller),
         plugin_channels=[cast(Any, _PluginChannel())],
     )
@@ -1003,9 +1007,11 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
         ]
         assert telegram.kwargs["event_bus"] is event_bus
         assert telegram.kwargs["interrupt_controller"] is controller
+        assert telegram.kwargs["bot_commands"] == [("telegram_only", "仅 Telegram")]
         assert qq.kwargs["interrupt_controller"] is controller
         assert plugin.name == "plugin"
         assert attachment_roots == [tmp_path / "uploads"]
+        assert mobile_catalogs == [[("mobile_only", "仅 mobile")]]
     finally:
         await host.stop_all()
         await resources.aclose()

--- a/tests_scenarios/mobile_isolated_gateway.py
+++ b/tests_scenarios/mobile_isolated_gateway.py
@@ -298,7 +298,7 @@ async def run_harness(args: argparse.Namespace) -> None:
                 push_tool=PushTool(),
                 interrupt_controller=None,
                 attachment_store=AttachmentStore(root / "attachments"),
-                bot_commands=(("memorystatus", "查看隔离命令入口"),),
+                mobile_bot_commands=(("memorystatus", "查看隔离命令入口"),),
             ),
         )
     )


### PR DESCRIPTION
## 问题

mobile `command.list` 复用了 `PluginManager.telegram_bot_commands`，因此只面向 Telegram 声明的插件命令会泄漏到移动端目录。

## 修改

- 在插件 API 和 `PluginManager` 中分离 `telegram_bot_commands` 与 `mobile_bot_commands`
- `start_channels` 分别注入 Telegram 目录和 mobile 目录，`MobileRealtimeChannel` 只读取 mobile 声明
- Akasha 对两个渠道显式声明同一个 `akashalast` 命令
- 保持 mobile realtime 协议 schema 不变
- 增加命令作用域、`stop` 过滤和 `/undo` 经 `message.send` 原样进入 bus 的测试

## 影响

Telegram-only 插件不再出现在 mobile 命令面板；插件若要暴露移动命令，必须显式实现 `mobile_bot_commands`。

## 验证

- `pytest -q tests/mobile_realtime/test_channel.py tests/test_plugin_hot_reload.py tests/test_akasha_plugin.py tests/test_channel_host.py tests/test_runtime_smoke.py` — 252 passed
- 相关新增 runtime smoke 单测 — passed
- `pyright`（全部改动 Python 文件）— 0 errors
- `git diff --check` — passed