### PR TITLE
feat(dev): add graceful workspace stop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ channel_name = "web"
 uv run python main.py
 ```
 
+从终端或 supervisor 切换到 PyCharm 前，先优雅停止当前 workspace 的 runtime：
+
+```bash
+./stop.sh
+```
+
+脚本遵循 `--workspace`、`AKASHIC_WORKSPACE`、`config.toml` 的 workspace
+优先级，优先停止 supervisor，并等待 runtime 真正释放实例锁。它不会删除锁文件，
+也不会在超时后自动强制终止进程。PyCharm 仍直接运行 `main.py`；也可以把
+`stop.sh` 配置为 Run Configuration 的 Before Launch external tool。
+
 打开 `http://127.0.0.1:6322` 可以使用 Web Chatbox；如果配置了 Telegram / QQ，也可以直接给 bot 发一条消息开始对话。
 
 ---

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ uv run python main.py
 从终端或 supervisor 切换到 PyCharm 前，先优雅停止当前 workspace 的 runtime：
 
 ```bash
-./stop.sh
+./scripts/stop-runtime.sh
 ```
 
 脚本遵循 `--workspace`、`AKASHIC_WORKSPACE`、`config.toml` 的 workspace
 优先级，优先停止 supervisor，并等待 runtime 真正释放实例锁。它不会删除锁文件，
 也不会在超时后自动强制终止进程。PyCharm 仍直接运行 `main.py`；也可以把
-`stop.sh` 配置为 Run Configuration 的 Before Launch external tool。
+`scripts/stop-runtime.sh` 配置为 Run Configuration 的 Before Launch external tool。
 
 打开 `http://127.0.0.1:6322` 可以使用 Web Chatbox；如果配置了 Telegram / QQ，也可以直接给 bot 发一条消息开始对话。
 

--- a/scripts/stop-runtime.sh
+++ b/scripts/stop-runtime.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 config_path="$project_root/config.toml"
 workspace_override=""
 
 usage() {
     cat <<'EOF'
-Usage: ./stop.sh [--config PATH] [--workspace PATH]
+Usage: ./scripts/stop-runtime.sh [--config PATH] [--workspace PATH]
 
 Gracefully stop the supervisor or runtime that owns the selected workspace.
 EOF
 }
 
 die() {
-    printf 'stop.sh: %s\n' "$*" >&2
+    printf 'stop-runtime.sh: %s\n' "$*" >&2
     exit 1
 }
 

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_path="$project_root/config.toml"
+workspace_override=""
+
+usage() {
+    cat <<'EOF'
+Usage: ./stop.sh [--config PATH] [--workspace PATH]
+
+Gracefully stop the supervisor or runtime that owns the selected workspace.
+EOF
+}
+
+die() {
+    printf 'stop.sh: %s\n' "$*" >&2
+    exit 1
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --config)
+            (($# >= 2)) || die "--config requires a path"
+            config_path="$2"
+            shift 2
+            ;;
+        --workspace)
+            (($# >= 2)) || die "--workspace requires a path"
+            workspace_override="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unsupported argument: $1"
+            ;;
+    esac
+done
+
+command -v flock >/dev/null 2>&1 || die "flock is required"
+command -v fuser >/dev/null 2>&1 || die "fuser is required"
+
+python_bin="${AKASHIC_PYTHON:-$project_root/.venv/bin/python}"
+if [[ ! -x "$python_bin" ]]; then
+    python_bin="$(command -v python3 || true)"
+fi
+[[ -n "$python_bin" ]] || die "Python 3 is required to resolve the workspace"
+
+cd "$project_root"
+workspace="$("$python_bin" - "$config_path" "$workspace_override" <<'PY'
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+workspace_override = sys.argv[2]
+workspace_value = workspace_override or os.environ.get("AKASHIC_WORKSPACE", "")
+if not workspace_value.strip():
+    with config_path.open("rb") as stream:
+        runtime = tomllib.load(stream).get("runtime")
+    if not isinstance(runtime, dict):
+        raise SystemExit(f"配置文件 {config_path} 缺少 [runtime] table")
+    configured = runtime.get("workspace")
+    if not isinstance(configured, str) or not configured.strip():
+        raise SystemExit(f"配置文件 {config_path} 缺少 runtime.workspace")
+    workspace_value = configured
+print(Path(workspace_value.strip()).expanduser().resolve())
+PY
+)"
+
+supervisor_lock="$workspace/.supervisor.lock"
+runtime_lock="$workspace/.instance.lock"
+
+lock_is_free() {
+    local lock_path="$1"
+    [[ ! -e "$lock_path" ]] || flock -n "$lock_path" -c true
+}
+
+lock_owner() {
+    local lock_path="$1"
+    fuser "$lock_path" 2>/dev/null | tr ' ' '\n' | sed '/^$/d'
+}
+
+target_lock=""
+if ! lock_is_free "$supervisor_lock"; then
+    target_lock="$supervisor_lock"
+elif ! lock_is_free "$runtime_lock"; then
+    target_lock="$runtime_lock"
+else
+    printf 'workspace 未运行: %s\n' "$workspace"
+    exit 0
+fi
+
+mapfile -t owner_pids < <(lock_owner "$target_lock")
+((${#owner_pids[@]} == 1)) ||
+    die "无法确定唯一锁 owner: $target_lock owners=${owner_pids[*]:-unknown}"
+owner_pid="${owner_pids[0]}"
+[[ "$owner_pid" =~ ^[0-9]+$ ]] || die "锁 owner 不是有效 PID: $owner_pid"
+
+printf '正在停止 workspace runtime: %s pid=%s\n' "$workspace" "$owner_pid"
+kill -TERM "$owner_pid"
+
+readonly deadline=$((SECONDS + 30))
+while ! lock_is_free "$supervisor_lock" || ! lock_is_free "$runtime_lock"; do
+    ((SECONDS < deadline)) ||
+        die "runtime 在 30 秒内未释放 workspace；未执行强制终止"
+    sleep 0.2
+done
+
+printf 'workspace 已停止: %s\n' "$workspace"

--- a/tests/test_stop_script.py
+++ b/tests/test_stop_script.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+STOP_SCRIPT = PROJECT_ROOT / "stop.sh"
+LOCK_HOLDER_CODE = """
+import fcntl
+import signal
+import sys
+
+stream = open(sys.argv[1], "a+")
+fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+signal.pause()
+"""
+SUPERVISOR_CODE = f"""
+import fcntl
+import signal
+import subprocess
+import sys
+
+stream = open(sys.argv[1], "a+")
+fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+child = subprocess.Popen([sys.executable, "-c", {LOCK_HOLDER_CODE!r}, sys.argv[2]])
+
+def stop(*_args):
+    child.terminate()
+    child.wait(timeout=5)
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, stop)
+child.wait()
+"""
+
+
+def _wait_until_locked(lock_path: Path, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError("fixture process exited before acquiring its lock")
+        probe = subprocess.run(
+            ["flock", "-n", str(lock_path), "-c", "true"],
+            check=False,
+        )
+        if probe.returncode != 0:
+            return
+        time.sleep(0.05)
+    process.terminate()
+    process.wait(timeout=5)
+    raise AssertionError("fixture process did not acquire its lock")
+
+
+def _start_lock_holder(lock_path: Path) -> subprocess.Popen[str]:
+    lock_path.parent.mkdir(parents=True)
+    process = subprocess.Popen(
+        [sys.executable, "-c", LOCK_HOLDER_CODE, str(lock_path)],
+        text=True,
+    )
+    _wait_until_locked(lock_path, process)
+    return process
+
+
+def test_stops_runtime_lock_owner(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    process = _start_lock_holder(workspace / ".instance.lock")
+    try:
+        result = subprocess.run(
+            [str(STOP_SCRIPT), "--workspace", str(workspace)],
+            cwd=PROJECT_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "workspace 已停止" in result.stdout
+        process.wait(timeout=5)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)
+
+
+def test_keeps_stale_lock_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    lock_path = workspace / ".instance.lock"
+    lock_path.write_text("stale-owner", encoding="utf-8")
+
+    result = subprocess.run(
+        [str(STOP_SCRIPT), "--workspace", str(workspace)],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "AKASHIC_WORKSPACE": ""},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "workspace 未运行" in result.stdout
+    assert lock_path.read_text(encoding="utf-8") == "stale-owner"
+
+
+def test_stops_supervisor_before_runtime_child(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    supervisor_lock = workspace / ".supervisor.lock"
+    runtime_lock = workspace / ".instance.lock"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            SUPERVISOR_CODE,
+            str(supervisor_lock),
+            str(runtime_lock),
+        ],
+        text=True,
+    )
+    try:
+        _wait_until_locked(supervisor_lock, process)
+        _wait_until_locked(runtime_lock, process)
+        result = subprocess.run(
+            [str(STOP_SCRIPT), "--workspace", str(workspace)],
+            cwd=PROJECT_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert f"pid={process.pid}" in result.stdout
+        process.wait(timeout=5)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)

--- a/tests/test_stop_script.py
+++ b/tests/test_stop_script.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-STOP_SCRIPT = PROJECT_ROOT / "stop.sh"
+STOP_SCRIPT = PROJECT_ROOT / "scripts" / "stop-runtime.sh"
 LOCK_HOLDER_CODE = """
 import fcntl
 import signal


### PR DESCRIPTION
## Problem

Switching an existing runtime workspace to a PyCharm-launched process currently fails on the instance lock, and stale lock-file contents can be mistaken for a live owner.

## Change

- add a root-level `stop.sh` that resolves workspace with the runtime precedence
- stop the supervisor owner first, otherwise the direct runtime owner
- wait for both kernel locks to be released without deleting lock files or escalating to SIGKILL
- document PyCharm Before Launch usage
- verify direct runtime, supervised runtime, and stale lock behavior with real flock processes

## Verification

- `bash -n stop.sh`
- `shellcheck stop.sh`
- `pytest tests/test_stop_script.py -q` (3 passed)
- `pyright tests/test_stop_script.py` (0 errors)