### PR TITLE
[codex] 修复 Wake 候选重复消费

### DIFF
--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -473,7 +473,7 @@ AKASHIC_RACE_WORKSPACE 指定临时 workspace；不指定时使用临时目录
    └─ state
       ├─ proactive.db
       ├─ sessions.db
-      ├─ feed-data/feed_mcp.sqlite3
+      ├─ plugin-data/feed-github/feed_mcp.sqlite3
       └─ drift/drift.db
 ```
 

--- a/docker/debug/proactive_sandbox.py
+++ b/docker/debug/proactive_sandbox.py
@@ -147,6 +147,10 @@ def _assert_sandbox_path(path: Path) -> None:
         raise RuntimeError(f"沙盒路径必须位于 /sandbox: {resolved}")
 
 
+def _feed_db_path(workspace: Path) -> Path:
+    return workspace / "plugin-data" / "feed-github" / "feed_mcp.sqlite3"
+
+
 def reset(workspace: Path) -> None:
     _assert_sandbox_path(workspace)
     shutil.rmtree(workspace, ignore_errors=True)
@@ -171,7 +175,7 @@ def reset(workspace: Path) -> None:
 
 def inject_content(workspace: Path) -> None:
     workspace.mkdir(parents=True, exist_ok=True)
-    db_path = workspace / "feed-data" / "feed_mcp.sqlite3"
+    db_path = _feed_db_path(workspace)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     now = datetime.now(UTC).isoformat()
     with sqlite3.connect(db_path) as conn:
@@ -224,7 +228,7 @@ def inject_content(workspace: Path) -> None:
 
 
 def clear_content(workspace: Path) -> None:
-    db_path = workspace / "feed-data" / "feed_mcp.sqlite3"
+    db_path = _feed_db_path(workspace)
     if not db_path.exists():
         return
     with sqlite3.connect(db_path) as conn:
@@ -436,6 +440,7 @@ async def tick(
 
     push.register_channel("sandbox", text=send_text)
     await plugins.load_all()
+    runtime_sources = plugins.proactive_sources
     if isinstance(provider, SandboxProvider):
         feed_sources = [
             source
@@ -449,8 +454,11 @@ async def tick(
             )
         source = feed_sources[0]
         provider.content_item_id = (
-            f"{source.plugin_id}:{source.spec.id}:{EVENT_ID}"
+            "candidate_1"
+            if lifecycle == "wake"
+            else f"{source.plugin_id}:{source.spec.id}:{EVENT_ID}"
         )
+        runtime_sources = feed_sources
     snapshot = plugins.current_snapshot
     snapshot_tools = snapshot.tool_registry if snapshot is not None else None
     registered_names = (
@@ -474,14 +482,14 @@ async def tick(
         model=model,
         max_tokens=max_tokens,
         state_store=state,
-        rng=random.Random(0),
-        shared_tools=tools,
+        rng=random.Random(1 if lifecycle == "wake" else 0),
+        shared_tools=snapshot_tools or tools,
         event_bus=event_bus,
         proactive_modules=plugins.proactive_modules,
         proactive_lifecycles=plugins.proactive_lifecycles,
         proactive_module_factories=plugins.proactive_module_factories,
         proactive_runtime_factories=plugins.proactive_runtime_factories,
-        proactive_sources=plugins.proactive_sources,
+        proactive_sources=runtime_sources,
     )
     try:
         await loop._proactive_kernel.start()
@@ -513,13 +521,21 @@ async def tick(
 def status(workspace: Path) -> dict[str, Any]:
     return {
         "feed": _query_one(
-            workspace / "feed-data" / "feed_mcp.sqlite3",
+            _feed_db_path(workspace),
             "SELECT event_id, interest_ok, interest_scored_at FROM items WHERE event_id = ?",
             (EVENT_ID,),
         ),
         "feed_ack": _query_one(
-            workspace / "feed-data" / "feed_mcp.sqlite3",
+            _feed_db_path(workspace),
             "SELECT event_id, acked_at FROM acked_items WHERE event_id = ?",
+            (EVENT_ID,),
+        ),
+        "wake_reservoir": _query_one(
+            workspace / "wake_proactive.db",
+            """
+            SELECT item_id, source_event_id, status, consumed_at
+            FROM reservoir_events WHERE source_event_id = ?
+            """,
             (EVENT_ID,),
         ),
         "tick": _query_one(
@@ -606,6 +622,9 @@ async def run_all(
     if lifecycle == "wake":
         if not content_status["feed_ack"]:
             raise AssertionError("Wake content ACK 未写回 Feed MCP")
+        reservoir = content_status["wake_reservoir"] or {}
+        if reservoir.get("status") != "consumed" or not reservoir.get("consumed_at"):
+            raise AssertionError(f"Wake content 未按 canonical ID 消费: {reservoir}")
     else:
         if content_result["decision"] != "reply":
             raise AssertionError("default content 未以 reply 收尾")

--- a/plugins/wake_proactive/context.py
+++ b/plugins/wake_proactive/context.py
@@ -70,12 +70,16 @@ def event_item_id(event: dict[str, Any]) -> str:
     return item_id
 
 
-def event_item_aliases(event: dict[str, Any]) -> set[str]:
+def content_candidate_map(ctx: WakeContext) -> dict[str, dict[str, Any]]:
+    """为本轮内容候选分配只在当前 Wake 内有效的模型引用。"""
+
     return {
-        value
-        for value in (
-            event_item_id(event),
-            str(event.get("_reservoir_source_event_id") or "").strip(),
-        )
-        if value
+        f"candidate_{index}": event
+        for index, event in enumerate(ctx.content_events, 1)
     }
+
+
+def content_event_map(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """按 reservoir canonical ID 索引已验证的内部事件。"""
+
+    return {event_item_id(event): event for event in events}

--- a/plugins/wake_proactive/prompt.py
+++ b/plugins/wake_proactive/prompt.py
@@ -8,7 +8,7 @@ from agent.prompting import (
     build_context_frame_content,
     build_context_frame_message,
 )
-from plugins.wake_proactive.context import WakeContext
+from plugins.wake_proactive.context import WakeContext, content_candidate_map
 
 
 PromptMode = Literal["content", "alert", "context"]
@@ -119,33 +119,37 @@ def build_messages(
 
 
 def _render_content_window(ctx: WakeContext) -> str:
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for event in ctx.content_events:
+    grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for candidate_ref, event in content_candidate_map(ctx).items():
         source_id = str(
             event.get("_reservoir_original_source_id")
             or event.get("source_id")
             or event.get("source")
             or "unknown"
         )
-        grouped.setdefault(source_id, []).append(event)
+        grouped.setdefault(source_id, []).append((candidate_ref, event))
 
     lines: list[str] = []
-    for source_id, events in grouped.items():
+    for source_id, candidates in grouped.items():
         source_name = str(
-            events[0].get("source_name") or events[0].get("source") or source_id
+            candidates[0][1].get("source_name")
+            or candidates[0][1].get("source")
+            or source_id
         )
         lines.append(f"来源：{source_name}")
-        for event in sorted(
-            events,
+        for candidate_ref, event in sorted(
+            candidates,
             key=lambda item: str(
-                item.get("published_at") or item.get("first_seen_at") or ""
+                item[1].get("published_at")
+                or item[1].get("first_seen_at")
+                or ""
             ),
             reverse=True,
         ):
             lines.append(
                 " | ".join(
                     (
-                        f"id={event['id']}",
+                        f"item_id={candidate_ref}",
                         f"published_at={event.get('published_at') or event.get('first_seen_at') or ''}",
                         f"title={event.get('title') or ''}",
                         f"source_name={event.get('source_name') or event.get('source') or ''}",

--- a/plugins/wake_proactive/renderer.py
+++ b/plugins/wake_proactive/renderer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from plugins.wake_proactive.context import event_item_aliases
+from plugins.wake_proactive.context import content_event_map
 
 
 @dataclass(slots=True)
@@ -22,11 +22,7 @@ def render_share(
     closing: str,
     events: list[dict[str, Any]],
 ) -> RenderedShare:
-    event_map = {
-        alias: event
-        for event in events
-        for alias in event_item_aliases(event)
-    }
+    event_map = content_event_map(events)
     blocks: list[str] = []
     opening = opening.strip()
     closing = closing.strip()

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -505,6 +505,10 @@ class WakeRuntime:
             for event in state.contents
             if str(event.get("id") or "") in selected_ids
         ]
+        if len(selected_events) != len(selected_ids):
+            raise RuntimeError(
+                "wake proactive cited content does not match canonical candidates"
+            )
         effect = AsyncEffect(
             lambda: self._consume_events(selected_events, state.ctx.now_utc)
         )

--- a/plugins/wake_proactive/state.py
+++ b/plugins/wake_proactive/state.py
@@ -413,15 +413,21 @@ class WakeStateStore:
     def consume(self, item_ids: list[str], now: datetime) -> None:
         if not item_ids:
             return
-        placeholders = ",".join("?" for _ in item_ids)
-        _ = self._conn.execute(
+        unique_item_ids = list(dict.fromkeys(item_ids))
+        placeholders = ",".join("?" for _ in unique_item_ids)
+        cursor = self._conn.execute(
             f"""
             UPDATE reservoir_events
             SET status = 'consumed', consumed_at = ?
             WHERE item_id IN ({placeholders})
             """,
-            (now.isoformat(), *item_ids),
+            (now.isoformat(), *unique_item_ids),
         )
+        if cursor.rowcount != len(unique_item_ids):
+            self._conn.rollback()
+            raise RuntimeError(
+                "wake reservoir consume did not match every canonical item_id"
+            )
         self._conn.commit()
 
     def expire(self, item_ids: list[str], now: datetime) -> None:

--- a/plugins/wake_proactive/tools.py
+++ b/plugins/wake_proactive/tools.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from core.memory.engine import MemoryQuery
-from plugins.wake_proactive.context import ScratchItem, WakeContext, event_item_aliases
+from plugins.wake_proactive.context import (
+    ScratchItem,
+    WakeContext,
+    content_candidate_map,
+    content_event_map,
+    event_item_id,
+)
 from plugins.wake_proactive.renderer import render_share
 
 if TYPE_CHECKING:
@@ -53,7 +59,10 @@ TOOL_SCHEMAS = [
                     "items": {
                         "type": "object",
                         "properties": {
-                            "item_id": {"type": "string"},
+                            "item_id": {
+                                "type": "string",
+                                "description": "本轮标题页中的 candidate_N 引用。",
+                            },
                             "initial_interest": {
                                 "type": "string",
                                 "enum": ["likely_interesting", "uncertain"],
@@ -90,7 +99,10 @@ TOOL_SCHEMAS = [
                     "items": {
                         "type": "object",
                         "properties": {
-                            "item_id": {"type": "string"},
+                            "item_id": {
+                                "type": "string",
+                                "description": "本轮标题页中的 candidate_N 引用。",
+                            },
                             "summary": {"type": "string"},
                             "why_it_matters": {"type": "string"},
                         },
@@ -114,12 +126,10 @@ TOOL_SCHEMAS = [
 ]
 
 
-def _event_map(ctx: WakeContext) -> dict[str, dict[str, Any]]:
-    return {
-        alias: event
-        for event in ctx.content_events
-        for alias in event_item_aliases(event)
-    }
+def _canonical_item_id(
+    candidate_map: dict[str, dict[str, Any]], candidate_ref: str
+) -> str:
+    return event_item_id(candidate_map[candidate_ref])
 
 
 def _save(ctx: WakeContext, deps: ToolDeps) -> None:
@@ -130,23 +140,28 @@ def _save(ctx: WakeContext, deps: ToolDeps) -> None:
 def _scratchpad(ctx: WakeContext, args: dict[str, Any], deps: ToolDeps) -> str:
     if ctx.screening_completed:
         raise ValueError("scratchpad already recorded for this wake")
-    valid_ids = set(_event_map(ctx))
-    raw_items = list(args.get("items") or [])
+    candidate_map = content_candidate_map(ctx)
+    valid_ids = set(candidate_map)
+    raw_items = cast(list[dict[str, Any]], list(args.get("items") or []))
     if len(raw_items) > MAX_INVESTIGATION_CANDIDATES:
         raise ValueError(
             f"scratchpad supports at most {MAX_INVESTIGATION_CANDIDATES} candidates"
         )
-    item_ids = [str(item.get("item_id") or "").strip() for item in raw_items]
-    if len(item_ids) != len(set(item_ids)):
-        raise ValueError("scratchpad contains duplicate item_id")
-    unknown = sorted(set(item_ids) - valid_ids)
+    raw_item_ids = [str(item.get("item_id") or "").strip() for item in raw_items]
+    unknown = sorted(set(raw_item_ids) - valid_ids)
     if unknown:
         raise ValueError(f"scratchpad contains unknown item_id: {unknown}")
+    item_ids = [
+        _canonical_item_id(candidate_map, raw_item_id) for raw_item_id in raw_item_ids
+    ]
+    if len(item_ids) != len(set(item_ids)):
+        raise ValueError("scratchpad contains duplicate item_id")
 
     allowed_interest = {"likely_interesting", "uncertain"}
     planned: dict[str, ScratchItem] = {}
-    for raw in raw_items:
-        item_id = str(raw["item_id"]).strip()
+    for raw, candidate_ref, item_id in zip(
+        raw_items, raw_item_ids, item_ids, strict=True
+    ):
         interest = str(raw["initial_interest"])
         if interest == "not_interesting":
             continue
@@ -154,7 +169,7 @@ def _scratchpad(ctx: WakeContext, args: dict[str, Any], deps: ToolDeps) -> str:
             raise ValueError(f"invalid scratchpad decision for {item_id}")
         recall_query = str(raw.get("recall_query") or "").strip()
         if interest == "uncertain" and not recall_query:
-            recall_query = str(_event_map(ctx)[item_id].get("title") or item_id)
+            recall_query = str(candidate_map[candidate_ref].get("title") or item_id)
         planned[item_id] = ScratchItem(
             item_id=item_id,
             initial_interest=cast(Any, interest),
@@ -233,7 +248,11 @@ async def _investigate_candidates(ctx: WakeContext, deps: ToolDeps) -> str:
         raise ValueError("investigate_candidates requires scratchpad first")
     if ctx.investigation_completed:
         raise ValueError("investigate_candidates already called this wake")
-    events = _event_map(ctx)
+    events = content_event_map(ctx.content_events)
+    candidate_refs = {
+        event_item_id(event): candidate_ref
+        for candidate_ref, event in content_candidate_map(ctx).items()
+    }
     semaphore = asyncio.Semaphore(max(1, deps.max_concurrency))
 
     async def investigate(item: ScratchItem) -> tuple[str, dict[str, Any]]:
@@ -256,7 +275,7 @@ async def _investigate_candidates(ctx: WakeContext, deps: ToolDeps) -> str:
     ctx.investigation_completed = True
     _save(ctx, deps)
     verified_results = {
-        item_id: result
+        candidate_refs[item_id]: result
         for item_id, result in ctx.investigation_results.items()
         if isinstance(result.get("content"), dict)
         and not result["content"].get("error")
@@ -273,18 +292,28 @@ def _share_content(ctx: WakeContext, args: dict[str, Any], deps: ToolDeps) -> st
         raise ValueError("wake already finished")
     if not ctx.screening_completed or not ctx.investigation_completed:
         raise ValueError("share_content requires scratchpad and investigate_candidates first")
-    items = list(args.get("items") or [])
-    if not items:
+    raw_items = cast(list[dict[str, Any]], list(args.get("items") or []))
+    if not raw_items:
         raise ValueError("share_content requires at least one item")
-    if len(items) > MAX_SHARE_ITEMS:
+    if len(raw_items) > MAX_SHARE_ITEMS:
         raise ValueError("share_content supports at most 5 items")
-    valid_ids = set(_event_map(ctx))
-    item_ids = [str(item.get("item_id") or "").strip() for item in items]
-    if len(item_ids) != len(set(item_ids)):
-        raise ValueError("share_content contains duplicate item_id")
-    unknown = sorted(set(item_ids) - valid_ids)
+    candidate_map = content_candidate_map(ctx)
+    raw_item_ids = [
+        str(item.get("item_id") or "").strip() for item in raw_items
+    ]
+    unknown = sorted(set(raw_item_ids) - set(candidate_map))
     if unknown:
         raise ValueError(f"share_content contains unknown item_id: {unknown}")
+    item_ids = [
+        _canonical_item_id(candidate_map, raw_item_id) for raw_item_id in raw_item_ids
+    ]
+    if len(item_ids) != len(set(item_ids)):
+        raise ValueError("share_content contains duplicate item_id")
+    items: list[dict[str, Any]] = []
+    for raw_item, item_id in zip(raw_items, item_ids, strict=True):
+        item = dict(raw_item)
+        item["item_id"] = item_id
+        items.append(item)
     with_evidence: list[dict[str, Any]] = []
     for item_id in item_ids:
         planned = ctx.scratchpad[item_id]

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -140,6 +140,29 @@ class FixedClock:
         self._now += delta
 
 
+def test_consume_rejects_unknown_item_without_partial_update(tmp_path):
+    now = datetime(2026, 7, 18, tzinfo=UTC)
+    store = WakeStateStore(tmp_path / "wake.db")
+    store.ingest_with_ids(
+        "content",
+        [
+            {
+                "event_id": "known",
+                "source_id": "source-a",
+                "ack_server": "feed_plugin:main",
+                "published_at": now.isoformat(),
+            }
+        ],
+        now,
+    )
+
+    with pytest.raises(RuntimeError, match="every canonical item_id"):
+        store.consume(["feed_plugin:main:known", "feed_plugin:main:missing"], now)
+
+    assert store.unread("content")[0]["id"] == "feed_plugin:main:known"
+    store.close()
+
+
 def _source(channel: Literal["alert", "content", "context"]) -> RegisteredProactiveSource:
     return RegisteredProactiveSource(
         plugin_id="feed_plugin",
@@ -233,7 +256,7 @@ async def test_content_vertical_slice_filters_investigates_and_shares(
                             {
                                 "items": [
                                     {
-                                        "item_id": ids[0],
+                                        "item_id": "candidate_1",
                                         "initial_interest": "likely_interesting",
                                     }
                                 ]
@@ -251,7 +274,7 @@ async def test_content_vertical_slice_filters_investigates_and_shares(
                                 "opening": "这个变化值得留意。",
                                 "items": [
                                     {
-                                        "item_id": ids[0],
+                                        "item_id": "candidate_1",
                                         "summary": "新内容已经发布。",
                                         "why_it_matters": "符合你最近关注的方向",
                                     }
@@ -290,6 +313,7 @@ async def test_content_vertical_slice_filters_investigates_and_shares(
     assert provider.chat.await_count == 2
     assert len(orchestrator.results) == 1
     assert orchestrator.results[0].decision == "reply"
+    assert orchestrator.results[0].evidence == [ids[0]]
     assert "符合你最近关注的方向" in orchestrator.results[0].outbound.content
     observations = runtime._state.observations("content")
     assert len(observations) == 1
@@ -465,6 +489,8 @@ async def test_shared_ack_route_keeps_original_source_grouping_and_order(
 
     assert prompt.index("来源：source-a") < prompt.index("来源：source-b")
     assert prompt.index("A新") < prompt.index("A旧")
+    assert "item_id=candidate_1" in prompt
+    assert "feed_plugin:main:" not in prompt
     await runtime._ack_and_consume(unread, now)
     assert gateway.acks == [{"event_ids": ["a-new", "a-old", "b-new"]}]
 
@@ -751,7 +777,7 @@ async def test_replay_content_only_draws_again_when_a_new_event_arrives(
                             {
                                 "items": [
                                     {
-                                        "item_id": item_id,
+                                        "item_id": "candidate_2",
                                         "initial_interest": "likely_interesting",
                                     }
                                 ]
@@ -769,7 +795,7 @@ async def test_replay_content_only_draws_again_when_a_new_event_arrives(
                                 "opening": "时间推进后，这条达到了唤醒阈值。",
                                 "items": [
                                     {
-                                        "item_id": item_id,
+                                        "item_id": "candidate_2",
                                         "summary": "回放 hazard 已跨 tick 累积。",
                                         "why_it_matters": "验证模拟时间有效",
                                     }

--- a/tests/wake_proactive/test_tools.py
+++ b/tests/wake_proactive/test_tools.py
@@ -38,7 +38,7 @@ def _plan() -> dict:
     return {
         "items": [
             {
-                "item_id": "feed:a",
+                "item_id": "candidate_1",
                 "initial_interest": "uncertain",
                 "question": "是否有可复用的唤醒方法",
                 "recall_query": "用户是否关心主动唤醒架构",
@@ -75,10 +75,10 @@ async def test_scratchpad_rejects_too_many_candidates():
             {
                 "items": [
                     {
-                        "item_id": event["id"],
+                        "item_id": f"candidate_{index}",
                         "initial_interest": "likely_interesting",
                     }
-                    for event in events
+                    for index, _event in enumerate(events, 1)
                 ]
             },
             ctx,
@@ -94,6 +94,127 @@ async def test_scratchpad_records_only_candidates_without_training_side_effect()
     assert result == {"ok": True, "screened": 2, "planned": 1, "to_investigate": 1}
     assert ctx.terminal_action is None
     assert ctx.cited_item_ids == []
+
+
+@pytest.mark.asyncio
+async def test_wake_candidate_ref_is_canonicalized_before_consumption():
+    canonical_id = "feed@github:subscriptions:fmcp_ab9a"
+    source_event_id = "fmcp_ab9a"
+    ctx = WakeContext(
+        content_events=[
+            {
+                "id": canonical_id,
+                "_reservoir_source_event_id": source_event_id,
+                "title": "GPT-Red",
+                "url": "https://example.com/gpt-red",
+            }
+        ]
+    )
+    web = MagicMock()
+    web.execute = AsyncMock(return_value=json.dumps({"text": "正文", "url": ""}))
+    deps = ToolDeps(web_fetch_tool=web)
+
+    await execute(
+        "scratchpad",
+        {
+            "items": [
+                {
+                    "item_id": "candidate_1",
+                    "initial_interest": "likely_interesting",
+                }
+            ]
+        },
+        ctx,
+        deps,
+    )
+    await execute("investigate_candidates", {}, ctx, deps)
+    await execute(
+        "share_content",
+        {
+            "message": "GPT-Red 发布了。",
+            "items": [{"item_id": "candidate_1", "summary": "GPT-Red"}],
+        },
+        ctx,
+        deps,
+    )
+
+    assert list(ctx.scratchpad) == [canonical_id]
+    assert ctx.cited_item_ids == [canonical_id]
+    assert ctx.display_event_map == {1: canonical_id}
+    assert ctx.source_refs[0]["event_id"] == canonical_id
+
+
+@pytest.mark.asyncio
+async def test_candidate_refs_disambiguate_equal_source_event_ids():
+    github_id = "feed@github:subscriptions:fmcp_same"
+    lab_id = "feed@lab:subscriptions:fmcp_same"
+    ctx = WakeContext(
+        content_events=[
+            {
+                "id": github_id,
+                "_reservoir_source_event_id": "fmcp_same",
+                "title": "GitHub Feed",
+                "content": "github 正文",
+            },
+            {
+                "id": lab_id,
+                "_reservoir_source_event_id": "fmcp_same",
+                "title": "Lab Feed",
+                "content": "lab 正文",
+            },
+        ]
+    )
+    deps = ToolDeps()
+
+    await execute(
+        "scratchpad",
+        {
+            "items": [
+                {
+                    "item_id": "candidate_2",
+                    "initial_interest": "likely_interesting",
+                }
+            ]
+        },
+        ctx,
+        deps,
+    )
+    investigation = json.loads(
+        await execute("investigate_candidates", {}, ctx, deps)
+    )
+    await execute(
+        "share_content",
+        {
+            "message": "Lab Feed 发布了。",
+            "items": [{"item_id": "candidate_2", "summary": "Lab Feed"}],
+        },
+        ctx,
+        deps,
+    )
+
+    assert list(ctx.scratchpad) == [lab_id]
+    assert list(investigation["items"]) == ["candidate_2"]
+    assert ctx.cited_item_ids == [lab_id]
+
+
+@pytest.mark.asyncio
+async def test_source_event_id_is_not_accepted_as_candidate_ref():
+    ctx = WakeContext(content_events=_events())
+
+    with pytest.raises(ValueError, match="unknown item_id"):
+        await execute(
+            "scratchpad",
+            {
+                "items": [
+                    {
+                        "item_id": "feed:a",
+                        "initial_interest": "likely_interesting",
+                    }
+                ]
+            },
+            ctx,
+            ToolDeps(),
+        )
 
 
 @pytest.mark.asyncio
@@ -122,7 +243,7 @@ async def test_scratchpad_rejects_invalid_interest():
             {
                 "items": [
                     {
-                        "item_id": "feed:a",
+                        "item_id": "candidate_1",
                         "initial_interest": "maybe",
                         "recall_query": "query",
                     }
@@ -139,7 +260,7 @@ async def test_scratchpad_derives_investigation_and_recall_query():
 
     await execute(
         "scratchpad",
-        {"items": [{"item_id": "feed:a", "initial_interest": "uncertain"}]},
+        {"items": [{"item_id": "candidate_1", "initial_interest": "uncertain"}]},
         ctx,
         ToolDeps(),
     )
@@ -156,7 +277,7 @@ async def test_scratchpad_ignores_explicit_not_interesting_item():
         "scratchpad",
         {
             "items": [
-                {"item_id": "feed:a", "initial_interest": "not_interesting"}
+                {"item_id": "candidate_1", "initial_interest": "not_interesting"}
             ]
         },
         ctx,
@@ -201,8 +322,8 @@ async def test_investigate_candidates_fetches_and_recalls_concurrently():
     result = json.loads(await execute("investigate_candidates", {}, ctx, deps))
 
     assert result["count"] == 1
-    assert result["items"]["feed:a"]["content"]["text"] == "正文"
-    assert result["items"]["feed:a"]["memory"]["hits"] == 1
+    assert result["items"]["candidate_1"]["content"]["text"] == "正文"
+    assert result["items"]["candidate_1"]["memory"]["hits"] == 1
     assert peak == 2
     web.execute.assert_awaited_once()
     memory.query.assert_awaited_once()
@@ -225,7 +346,7 @@ async def test_share_content_renders_one_message_and_stable_mapping(tmp_path):
                 "opening": "我挑出两条里真正值得看的一条。",
                 "items": [
                     {
-                        "item_id": "feed:a",
+                        "item_id": "candidate_1",
                         "summary": "它把时间因素放进了唤醒判断。",
                         "why_it_matters": "可以直接用于现在的主动 agent。",
                     }
@@ -263,7 +384,7 @@ async def test_share_content_accepts_natural_message_with_evidence_sources():
             "share_content",
             {
                 "message": "刚看到一个挺对你胃口的设计：它把时间本身放进了唤醒判断。",
-                "items": [{"item_id": "feed:a", "summary": "不会显示的模板摘要"}],
+                "items": [{"item_id": "candidate_1", "summary": "不会显示的模板摘要"}],
             },
             ctx,
             deps,
@@ -300,7 +421,7 @@ async def test_investigate_failure_is_evidence_gap_not_negative_label():
             {
                 "items": [
                     {
-                        "item_id": "feed:a",
+                        "item_id": "candidate_1",
                         "summary": "没有正文证据时不能分享",
                     }
                 ]


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Wake 在模型返回 MCP 原始短 ID 时可能无法命中本地 reservoir canonical ID，导致消息已发送但事件仍为 `unread`，后续再次进入候选池；短 ID 在多个 proactive source 之间还可能发生碰撞。
- 用户可见结果：模型只使用本轮 `candidate_N` 引用，发送成功后 Wake 精确消费对应 canonical event，同一来源事件不再因本地消费失败而重复入池。
- 本 PR 不处理：不同 Feed 事件但 URL、主题或正文相同的内容级去重；近期主动消息语义去重；移动端单条消息的渠道级重复投递。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Wake proactive lifecycle 的所有 content proactive source；不改变 alert/context 单事件路径。
- `runtime_patch`：`required`
- `runtime_patch_reason`：候选身份解析、证据提交和 reservoir 消费都由核心 Wake runtime 拥有，客户端或 Feed MCP 无法修复本地 `unread` 状态。
- `authoritative_state_owner`：`WakeStateStore.reservoir_events`
- `client_only_alternative`：无；客户端去重不能修复服务端候选池状态。
- 关联不变量：模型引用只在当前 Wake 有效；内部状态只保存 canonical ID；发送成功后的消费必须命中全部所选 canonical ID，否则回滚并 fail-loud。
- `protected_state`：正式 `sessions.db` 追加历史、正式 Feed plugin-data、未选中的 reservoir event、外部发送提交顺序。
- 允许的副作用：既有发送成功 effect 将所选 reservoir 行更新为 `consumed` 并写入 `consumed_at`；既有 Feed ACK 行为保持不变。
- 禁止的副作用：不删除或改写 session 正文，不做 URL/内容/主题去重，不写正式 workspace，不改变 Feed 排名与时间衰减。

## 改动范围

- 主要文件：`plugins/wake_proactive/{context,prompt,tools,renderer,runtime,state}.py`、Wake 测试及 `docker/debug/proactive_sandbox.py`。
- 配置或迁移影响：无配置变化，无数据库迁移。
- 已知 schema lineage 与最终 schema identity：`wake_proactive.db` schema 不变；继续使用现有 `reservoir_events.item_id/status/consumed_at`。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：core `9d7fc024`；Docker 使用隔离的 Feed plugin `1.2.0` 和确定性 SandboxProvider；公开 Gate 报告见验证段。
- 回滚方式：revert commit `9d7fc024`；无需数据回滚或 schema 回滚。

## 验证

- [x] 相关 targeted tests 已通过：`55 passed`（`tests/wake_proactive`）。
- [x] Python 编译检查已通过：`python -m compileall -q plugins/wake_proactive docker/debug/proactive_sandbox.py`；宿主未安装 `ruff`，lint 未运行。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`b8f4d4472ab78f95debefb2de6876e1997327de58db7b1a07eb17f6d71a7567e`
- `planDigest`：`b93c64f39548d68c223561078ad136c85d44d41a2b356ab8183d63848a25d657`
- `private-contract-gate`：`pending_maintainer`
- Docker 完整运行时：真实 PluginManager、Feed MCP stdio、Wake lifecycle、正文抓取、消息提交、session evidence、Feed ACK 全部通过；隔离 reservoir 最终为 `feed@github:subscriptions:sandbox_content_001 | consumed`。
- 真实设备证据：不适用，本 PR 不修改移动端或渠道协议。
- 未运行项与原因：Private Gate 需要维护者 provider 环境；`ruff` 不在宿主环境中。

## 工作手册

- [x] 已核对 `projectneed.md`、相关持久化设计和 `NOW.md`。
- [x] 本次没有新增长期产品语义；实现遵循已确认的 Wake 本地消费 owner。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 当前没有对应待办，无需修改。
