### PR TITLE
[codex] Wake 使用最近主动历史判断重复内容

### DIFF
--- a/core/memory/engine.py
+++ b/core/memory/engine.py
@@ -9,6 +9,7 @@ from typing import Literal, Protocol, runtime_checkable
 
 MemoryQueryIntent = Literal["context", "answer", "timeline", "interest", "procedure"]
 MemoryQueryEffect = Literal["stateful", "read_only"]
+MemoryRelevanceFloor = Literal["engine_default", "strong"]
 
 
 class EngineProfile(str, Enum):
@@ -90,9 +91,14 @@ class MemoryQueryFilters:
     kinds: tuple[str, ...] = ()
     time_start: datetime | None = None
     time_end: datetime | None = None
+    relevance_floor: MemoryRelevanceFloor = "engine_default"
     hints: Mapping[str, object] = field(default_factory=lambda: MappingProxyType({}))
 
     def __post_init__(self) -> None:
+        if self.relevance_floor not in {"engine_default", "strong"}:
+            raise ValueError(
+                f"unsupported memory relevance floor: {self.relevance_floor}"
+            )
         object.__setattr__(
             self,
             "kinds",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -99,10 +99,10 @@
 | 任务 | 必读顺序 | 随后检查的真实入口 |
 |---|---|---|
 | 任何会修改仓库文件的任务 | 本索引 → [`WORKFLOW.md`](WORKFLOW.md) → 下方对应领域 | 当前分支、目标分支、完整 diff、验证报告 |
-| Prompt、上下文窗口、历史裁切、重试 | `projectneed` 第 5～7、13 节 → [0002](decisions/0002-context-reduction-is-a-nondestructive-projection.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) | `agent/core/passive_turn.py`、`agent/prompting/`、`session/manager.py`、`session/store.py` |
+| Prompt、上下文窗口、历史裁切、重试 | `projectneed` 第 5～7、13 节 → [0002](decisions/0002-context-reduction-is-a-nondestructive-projection.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `agent/core/passive_turn.py`、`agent/prompting/`、`session/manager.py`、`session/store.py` |
 | 会话、消息、turn、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
 | Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
-| 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
+| 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 插件安装、热重载、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、10～13 节 → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/skill_links.py`、`agent/mcp/host.py` |
 | Workspace、配置、凭据、迁移、备份 | `projectneed` 第 6、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `main.py`、`bootstrap/init_workspace.py`、`agent/config.py`、`agent/model_runtime/auth/store.py`、`scripts/rolling_backup.py` |
 | 高风险 refactor、语义不变重构、CI oracle | `projectneed` 第 4～6、13～14 节 → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → 相关决策 | 改动前后的完整 diff、semantic tests、write set、故障注入 |
@@ -185,7 +185,8 @@ docs/
 ├── design/
 │   ├── mobile-cross-repository-semantic-gate.md
 │   ├── project-workbook-and-semantic-safety.md
-│   └── persistence-state-map.md
+│   ├── persistence-state-map.md
+│   └── wake-recent-delivery-context.md
 ├── spark/
 │   └── 2026-07-16-change-impact-contract-gate.md
 └── templates/

--- a/docs/design/wake-recent-delivery-context.md
+++ b/docs/design/wake-recent-delivery-context.md
@@ -1,0 +1,77 @@
+# Wake 最近主动消息上下文
+
+- 状态：implemented in candidate，pending merge
+- 确认日期：2026-07-18
+- 关联条款：PRM-008、STA-002、CTX-004、SES-005、PRO-001、PRO-003、TST-001
+
+## 1. 问题和用户意图
+
+Wake 当前只向模型提供目标 session 的最近普通对话，并明确排除历史主动消息。真实数据中，Telegram 已经发送的 GPT-5.6 文件删除消息，之后又由 Mobile session 以另一个 Feed event 再次发送；Kimi K3 的多个不同测评也在短时间内重复占用主动消息。
+
+用户希望模型继续结合长期偏好自主判断。额度重置等反复发生但具有实际价值的消息仍可发送，Kimi 测评等边际信息较低的内容则由模型结合最近发送记录判断。本次不增加 URL、主题、冷却时间或重要性硬规则。
+
+## 2. 当前调用链和状态 owner
+
+```text
+sessions.db/messages
+        │ WakeRuntime 只读
+        ▼
+_read_recent_passive_conversation(session_key, now)
+        │ 排除 extra.proactive=true
+        ▼
+build_messages(recent_session=...)
+        │
+        ▼
+Wake 标题初筛与最终决策
+```
+
+`sessions.db/messages` 是已经持久化的对话事实，由 Session store 拥有；Wake 只获得窄的只读查询。`PromptContext` 是临时运行时视图，不拥有消息写入、更新或删除权限。
+
+## 3. 目标结构
+
+```text
+当前目标 session 的被动对话 ──►【截至当前时间的最近被动对话】
+
+workspace 内跨 session 的主动消息 ──►【截至当前时间已经发送的主动消息】
+                                          │ 每条带发送时间和 session
+                                          ▼
+                        MEMORY + 两类历史 + 当前候选
+                                          │
+                                          ▼
+                               Wake 自主 share / skip
+```
+
+主动消息区块陈述已经发送的事实，并明确它不是用户陈述或本轮候选。区块让模型理解自己最近主动和用户聊过什么；曾经聊过什么只是连续性的事实背景，不是内容价值的扣分表。模型每次重新理解当前事件此刻对用户意味着什么，话题、结论或事件相近不自动禁止再次分享，也不预先标记重复、不重要或应跳过。模型始终对用户本人和他在意的一切保持真诚好奇，这种好奇不会因话题已经聊过、结论相同或事件反复发生而耗尽，但也不因此强行提问或打扰。模型继续使用现有 `scratchpad`、调查结果和终态工具自主判断。
+
+初筛后的入选候选如果共同依赖一种内容形态或打扰类型的偏好，而固定记忆和最近上下文没有直接证据，可以生成一个批次级 `preference_probe`。主题兴趣和内容形态偏好是两个独立参考维度，任何一方都不预设 share 或 skip 倾向。正文事实足以解决歧义或上下文已有直接证据时不查询。探针不复述新闻标题；运行时随后执行一次 `intent=interest`、`effect=read_only`、`relevance_floor=strong` 的查询。Akasha 的 strong 只返回超过 `dense_seed_threshold` 的 Dense 证据，不把 Ripple、Graph 或 BlackHole 当作态度依据；其他 memory engine 使用各自拥有的原生强相关阈值。
+
+## 4. 查询和边界
+
+- 被动对话保持当前目标 `session_key`、截至 `now`、最近 20 行和 3,000 字符预算；历史主动消息不混入该区块。
+- 主动消息查询整个 workspace 中 `role=assistant` 且 `extra.proactive=true` 的消息，严格限制 `ts <= now`，按时间倒序取最近 30 条，再恢复为时间正序。
+- 主动消息只保留最近 7 天，并受独立字符预算约束；每条包含 ISO 时间、`session_key` 和真实消息正文预览。
+- 数据库不存在时返回空；SQL、JSON 或数据库损坏继续 fail-loud，不伪装成没有历史。
+- 同一轮标题初筛和最终判断复用同一份主动消息快照，避免两个阶段观察到不同历史。
+- 偏好查询发生在标题初筛之后、最终判断之前；每轮最多一次，返回数量由 engine 的 strong 阈值决定，`limit=12` 只作为异常上限。
+
+## 5. 状态变化和副作用
+
+本次不改变对话、记忆和主动投递的权威持久化协议：
+
+- `sessions.db/messages`：正常发送仍只 INSERT；Wake 新查询不执行 INSERT、UPDATE 或 DELETE。
+- `wake_proactive.db`：run、observation、reservoir、hazard 和消费状态维持现有协议。当前 wake 的 `scratchpad_json` 与 `investigations_json` 诊断快照增加批次级探针和偏好证据；同一 run 仍按现有 UPSERT 更新，旧 run 不迁移、不覆盖、不删除。
+- `MEMORY.md` 与 `PROACTIVE_CONTEXT.md`：只读且不修改。
+- 外部发送：生产提交路径不变；Docker 验证使用 `replay_debug` CaptureChannel，只写隔离 outbox。
+
+正常运行会继续追加新 message、wake run 和 observation；本次没有新增逻辑失效或物理减少路径。只有原有的用户删除、ack、消费和进程生命周期 owner 能按状态地图改变相应状态。恢复证据是冻结的 SQLite 备份、基线提交和 CaptureChannel outbox；正式 workspace 不参与回放写入。
+
+回滚点是 `backup/wake-recent-delivery-context-before-20260718` 和基线提交 `6db411ac`。
+
+## 6. 验收
+
+1. 单元测试证明两个 section 分开渲染，主动消息带时间和 session，且不会进入被动对话区块。
+2. 单元测试证明主动消息跨 session 可见、未来消息不可见、七天窗口和数量上限生效。
+3. 单元测试证明偏好探针每轮最多执行一次只读查询，Akasha 只返回超过原生阈值的 Dense 证据，其他引擎使用自身原生强相关阈值。
+4. 同一冻结 `sessions.db`、`MEMORY.md`、Akasha 和 Wake reservoir 在 Docker 中回放；base 与 candidate 的已声明差异是新增主动消息区块与单次偏好探针。
+5. GPT-5.6 重复消息、Kimi K3 连续测评和 Tibo 额度重置分别记录模型的 `scratchpad`、偏好证据、`share/skip`、最终消息与 capture outbox，不把某个主题硬编码成固定结果。
+6. 正式 workspace、正式 Mobile gateway 和正式 server 在验证前后保持不变。

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -441,6 +441,10 @@ sensor、session、context 和 store 故障不得伪装成“无事件”。deci
 
 `proactive.db`、`wake_proactive.db` 和 `drift/drift.db` 中影响 delivery dedupe、cooldown、pending ack、reservoir consumption、hazard timer、cursor、journal 和下一轮选择的内容属于运行连续性。启用对应功能时，备份和恢复必须保留这些状态；日志表与连续性表可以制定不同 retention，但不得把整库按诊断日志清空。
 
+### PRO-003 Wake 用主动历史保持连续性而不预设重复惩罚
+
+Wake 判断内容时必须把最近被动对话与已经送达的主动消息作为两个明确区分的运行时区块；主动消息保留实际发送时间，不能伪装成用户陈述或本轮候选。模型把主动历史作为理解近期连续性的背景，并保持对用户及其关注事项的开放好奇；话题聊过、结论相同、事件反复发生或发送次数较多，都不能单独推导出用户疲劳、不感兴趣或禁止再次分享。当前事件是否值得主动告诉用户仍由模型结合正文证据、长期偏好、真实用户反馈、最近上下文和时机自主判断，不增加按主题、URL、相似度或次数硬编码的 share/skip 规则。
+
 ### BAK-001 备份必须能验证和恢复
 
 普通文件完整复制，SQLite 使用 backup API 与 integrity check；临时 snapshot、manifest 和 hash 全部完成后原子发布，新快照成功后才 prune。必须定期恢复到隔离 workspace 并运行应用级只读 smoke。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -330,18 +330,26 @@ class AkashaMemoryEngine:
             limit=dense_limit,
             cutoff=datetime.fromtimestamp(now_ts, timezone.utc).isoformat(),
         )
-        dense_keys = {card.key for card in dense_cards}
-        dense_pairs = {_card_dedupe_key(card) for card in dense_cards}
-        ripple_cards = self._cards_from_keys(
-            [
-                (item.key, item.score, "ripple", _candidate_signals(item))
-                for item in result.ripple_items
-                if item.key not in dense_keys
-            ],
-            limit=ripple_limit,
-            skip_pairs=dense_pairs,
-            cutoff=datetime.fromtimestamp(now_ts, timezone.utc).isoformat(),
-        )
+        if request.filters.relevance_floor == "strong":
+            dense_cards = [
+                card
+                for card in dense_cards
+                if card.score >= self._akasha_config.dense_seed_threshold
+            ]
+            ripple_cards = []
+        else:
+            dense_keys = {card.key for card in dense_cards}
+            dense_pairs = {_card_dedupe_key(card) for card in dense_cards}
+            ripple_cards = self._cards_from_keys(
+                [
+                    (item.key, item.score, "ripple", _candidate_signals(item))
+                    for item in result.ripple_items
+                    if item.key not in dense_keys
+                ],
+                limit=ripple_limit,
+                skip_pairs=dense_pairs,
+                cutoff=datetime.fromtimestamp(now_ts, timezone.utc).isoformat(),
+            )
         text_block = (
             self._format_context_block(dense_cards, ripple_cards, now_ts=now_ts)
             if request.intent == "context"
@@ -368,6 +376,12 @@ class AkashaMemoryEngine:
                 "profile": self.DESCRIPTOR.profile.value,
                 "intent": request.intent,
                 "effect": request.effect,
+                "relevance_floor": request.filters.relevance_floor,
+                "native_dense_threshold": (
+                    self._akasha_config.dense_seed_threshold
+                    if request.filters.relevance_floor == "strong"
+                    else None
+                ),
                 "dense_count": len(dense_cards),
                 "ripple_count": len(ripple_cards),
                 "activation_count": len(result.activation_items),

--- a/plugins/default_memory/engine.py
+++ b/plugins/default_memory/engine.py
@@ -1240,6 +1240,10 @@ class DefaultMemoryEngine:
         request: MemoryQuery,
     ) -> MemoryQueryResult:
         scope = resolve_memory_scope(request.scope)
+        score_threshold = None
+        if request.filters.relevance_floor == "strong":
+            thresholds = self._default_config.retrieval.thresholds
+            score_threshold = max(thresholds.preference, thresholds.profile)
         hits = await self._retrieve_related(
             request.text,
             memory_types=["preference", "profile"],
@@ -1247,6 +1251,7 @@ class DefaultMemoryEngine:
             scope_channel=scope.channel or None,
             scope_chat_id=scope.chat_id or None,
             require_scope_match=should_require_scope_match(request, scope),
+            score_threshold=score_threshold,
         )
         records = [self._build_record(item) for item in hits]
         texts = [record.summary for record in records]
@@ -1257,6 +1262,8 @@ class DefaultMemoryEngine:
                 "source": self.DESCRIPTOR.name,
                 "intent": "interest",
                 "effect": request.effect,
+                "relevance_floor": request.filters.relevance_floor,
+                "native_score_threshold": score_threshold,
             },
             raw={"items": list(hits)},
         )

--- a/plugins/wake_proactive/context.py
+++ b/plugins/wake_proactive/context.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 
 InitialInterest = Literal["likely_interesting", "not_interesting", "uncertain"]
-InvestigationKind = Literal["none", "content", "recall", "both"]
 
 
 def _event_list() -> list[dict[str, Any]]:
@@ -38,9 +37,14 @@ def _source_ref_list() -> list[dict[str, Any]]:
 class ScratchItem:
     item_id: str
     initial_interest: InitialInterest
-    investigate: InvestigationKind
     question: str = ""
-    recall_query: str = ""
+
+
+@dataclass(slots=True)
+class PreferenceProbe:
+    candidate_ids: tuple[str, ...]
+    topic: str
+    query: str
 
 
 @dataclass(slots=True)
@@ -51,8 +55,10 @@ class WakeContext:
     content_events: list[dict[str, Any]] = field(default_factory=_event_list)
     content_backlog_count: int = 0
     scratchpad: dict[str, ScratchItem] = field(default_factory=_scratch_dict)
+    preference_probe: PreferenceProbe | None = None
     screening_completed: bool = False
     investigation_results: dict[str, dict[str, Any]] = field(default_factory=_result_dict)
+    preference_evidence: dict[str, Any] = field(default_factory=dict[str, Any])
     investigation_completed: bool = False
     final_message: str = ""
     cited_item_ids: list[str] = field(default_factory=_string_list)

--- a/plugins/wake_proactive/prompt.py
+++ b/plugins/wake_proactive/prompt.py
@@ -16,6 +16,10 @@ ContentPhase = Literal["screen", "final"]
 
 _SYSTEM_PROMPT = (
     "你正在处理一次主动唤醒。运行时会明确给出 mode，并且只开放当前 mode 可用的工具。"
+    "你始终对用户本人和他在意的一切保持真诚好奇，始终想更了解他。这种好奇不会因为一个"
+    "话题已经聊过、结论相同或事件反复发生而耗尽；不要急着假定你已经知道用户会怎么看，"
+    "先重新理解这一次对他意味着什么。把好奇用于理解用户，而不是把用户当成画像、为了收集"
+    "信息强行提问，或仅凭好奇就打扰他。"
     "不要在输出中提及记忆、画像、分数或筛选流程。长期记忆不只影响是否分享，也可以让表达"
     "带有自然的理解和共情：可以顺着用户稳定的喜好、期待和经历说话，但不要列档案、逐句"
     "复述旧对话，或用‘你之前说过’来证明自己记得。涉及焦虑、健康、财务或私密关系时，"
@@ -38,8 +42,18 @@ _CONTEXT_PROMPT = (
 _CONTENT_SCREEN_PROMPT = (
     "mode=content：候选按来源分组，来源内部按 published_at 倒序。先快速阅读全部标题，再调用"
     "一次 scratchpad，只记录最多八条确实值得查正文或需要确认用户兴趣的候选。"
-    "likely_interesting 用于已有明确兴趣依据的内容；uncertain 用于需要 RecallMemory 确认的"
-    "内容。宁可少选，不要为了覆盖资讯而选择，也不要把预测当成用户反馈。"
+    "likely_interesting 用于已有明确兴趣依据的内容；uncertain 用于仍需正文或偏好证据确认的"
+    "内容。初筛完成后，如果入选候选的最终价值取决于用户对一种内容形态或打扰类型的态度，"
+    "而固定 MEMORY 和最近上下文没有直接证据，可以填写一个覆盖相关候选的 preference_probe。"
+    "主题兴趣和内容形态偏好是两个可分别参考的维度，不能从其中一个直接推定另一个。query "
+    "应查询用户对"
+    "内容形态和打扰价值的真实态度，不要复述新闻标题，也不要为了每个候选分别查询；正文事实"
+    "足以解决歧义或上下文已有直接证据时不要查询。"
+    "<example>固定上下文只说明用户长期关注主题 X，本轮候选属于 X 下的内容形态 Y；如果最终"
+    "决策取决于 Y 是否值得主动打扰，可以查询用户过去对 Y 类主动消息的真实反馈，而不是再次"
+    "查询用户是否关注 X。</example>"
+    "根据本轮候选自行决定调查范围，不要把候选与历史消息的差异大小当成筛选条件，也不要把"
+    "预测当成用户反馈。"
 )
 
 _CONTENT_FINAL_PROMPT = (
@@ -55,7 +69,10 @@ _CONTENT_FINAL_PROMPT = (
     "敏感经历时允许共情，但必须与当前事实直接相关、轻柔且有帮助，不能替用户定义感受或把"
     "焦虑当作推送理由。不要制造紧迫感，不强行提问。只有当前 ContextEvent 明确支持时，才能"
     "描述用户正在睡眠、忙碌、离线或游戏；unknown 时保持中性。唤醒只代表允许判断，不代表"
-    "必须分享；缺少新事实、用户已经知道、只有营销或泛泛观点时应调用 skip_content。"
+    "必须分享，也没有默认的 share 或 skip 倾向。每次都重新判断这件事此刻对用户意味着什么，"
+    "再综合实用价值、用户偏好、最近已送达内容和当前时机自行决定。熟悉的话题、相同结论或"
+    "反复发生的事情可以再次分享，也可以保持安静；发送次数本身不是用户的态度，不要据此"
+    "假定疲劳或不感兴趣。"
 )
 
 
@@ -64,7 +81,8 @@ def build_messages(
     ctx: WakeContext,
     memory_text: str,
     proactive_context: str,
-    recent_session: str,
+    recent_passive_conversation: str,
+    recent_proactive_messages: str,
     current_context: str = "unknown（没有可靠 ContextEvent）",
     mode: PromptMode = "content",
     event: dict[str, Any] | None = None,
@@ -76,7 +94,16 @@ def build_messages(
     sections = [
         f"【固定 MEMORY.md】\n{memory_text}",
         f"【固定 PROACTIVE_CONTEXT.md】\n{proactive_context}",
-        f"【截至当前时间的最近对话】\n{recent_session}",
+        f"【截至当前时间的最近被动对话】\n{recent_passive_conversation}",
+        (
+            "【截至当前时间已经发送的主动消息】\n"
+            "以下内容已经由 assistant 主动发送给用户，并标明了当时的发送时间；它们不是"
+            "用户陈述，也不是本轮候选。请用它们理解你最近主动和用户聊过什么，再判断本轮"
+            "是否还值得主动找他。请把这些记录用于保持对话连续性：每次事件都按它此刻对用户"
+            "的意义重新理解；曾经聊过什么只是事实背景，不是内容价值的扣分表。话题、结论或"
+            "事件相近都不自动禁止再次分享。\n"
+            f"{recent_proactive_messages}"
+        ),
         f"【当前 ContextEvent】\n{current_context}",
         f"【本轮任务】\nmode={mode}",
     ]

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -52,6 +52,9 @@ _MAX_TITLES_PER_WAKE = 120
 _SEMANTIC_CALIBRATION_POWER = 4
 _CONTENT_MIN_RESIDENCE = timedelta(hours=24)
 _CONTENT_MAX_AGE = timedelta(days=14)
+_RECENT_PROACTIVE_WINDOW = timedelta(days=7)
+_RECENT_PROACTIVE_LIMIT = 30
+_RECENT_PROACTIVE_CHAR_BUDGET = 8_000
 _SCHEMA_BY_NAME = {
     schema["function"]["name"]: schema
     for schema in [*TOOL_SCHEMAS, *EVENT_TOOL_SCHEMAS]
@@ -347,7 +350,12 @@ class WakeRuntime:
             ctx=ctx,
             memory_text=self._read_memory(),
             proactive_context=str(self._scope.workspace_context_fn() or ""),
-            recent_session=self._read_recent_session(ctx.session_key, ctx.now_utc),
+            recent_passive_conversation=self._read_recent_passive_conversation(
+                ctx.session_key, ctx.now_utc
+            ),
+            recent_proactive_messages=self._read_recent_proactive_messages(
+                ctx.now_utc
+            ),
             current_context=self._current_context_text(ctx.now_utc),
         )
         candidates = [
@@ -386,13 +394,17 @@ class WakeRuntime:
         # 1. 固定本轮上下文，避免两个 LLM 阶段读取到不同快照
         memory_text = self._read_memory()
         proactive_context = str(self._scope.workspace_context_fn() or "")
-        recent_session = self._read_recent_session(ctx.session_key, ctx.now_utc)
+        recent_passive_conversation = self._read_recent_passive_conversation(
+            ctx.session_key, ctx.now_utc
+        )
+        recent_proactive_messages = self._read_recent_proactive_messages(ctx.now_utc)
         current_context = self._current_context_text(ctx.now_utc)
         base_messages = build_messages(
             ctx=ctx,
             memory_text=memory_text,
             proactive_context=proactive_context,
-            recent_session=recent_session,
+            recent_passive_conversation=recent_passive_conversation,
+            recent_proactive_messages=recent_proactive_messages,
             current_context=current_context,
         )
 
@@ -408,7 +420,8 @@ class WakeRuntime:
             ctx=ctx,
             memory_text=memory_text,
             proactive_context=proactive_context,
-            recent_session=recent_session,
+            recent_passive_conversation=recent_passive_conversation,
+            recent_proactive_messages=recent_proactive_messages,
             current_context=current_context,
             content_phase="final",
         )
@@ -686,8 +699,11 @@ class WakeRuntime:
             ctx=state.ctx,
             memory_text=self._read_memory(),
             proactive_context=str(self._scope.workspace_context_fn() or ""),
-            recent_session=self._read_recent_session(
+            recent_passive_conversation=self._read_recent_passive_conversation(
                 state.ctx.session_key, state.ctx.now_utc
+            ),
+            recent_proactive_messages=self._read_recent_proactive_messages(
+                state.ctx.now_utc
             ),
             current_context=self._current_context_text(state.ctx.now_utc),
             mode=kind,
@@ -1023,12 +1039,10 @@ class WakeRuntime:
         reader = getattr(self._scope.memory, "read_long_term", None)
         return str(reader() or "") if callable(reader) else ""
 
-    def _read_recent_session(
+    def _read_recent_passive_conversation(
         self,
         session_key: str,
         now: datetime,
-        *,
-        include_proactive: bool = False,
     ) -> str:
         if not self._session_db_path.exists():
             return ""
@@ -1048,11 +1062,51 @@ class WakeRuntime:
             proactive = role == "assistant" and _is_proactive_message(extra_json)
             if role != "user" and role != "assistant":
                 continue
-            if proactive and not include_proactive:
+            if proactive:
                 continue
-            label = "assistant(proactive)" if proactive else role
-            lines.append(f"{label}: {str(content or '')[:300]}")
+            lines.append(f"{role}: {str(content or '')[:300]}")
         return "\n".join(lines)[:3_000]
+
+    def _read_recent_proactive_messages(self, now: datetime) -> str:
+        """读取整个 workspace 最近已发送的主动消息，并保留最新记录。"""
+
+        # 1. 在权威消息表上建立带时间边界的只读视图
+        if not self._session_db_path.exists():
+            return ""
+        cutoff = now - _RECENT_PROACTIVE_WINDOW
+        with closing(sqlite3.connect(str(self._session_db_path))) as db:
+            rows = db.execute(
+                """
+                SELECT session_key, content, ts
+                FROM messages
+                WHERE role = 'assistant'
+                  AND json_extract(extra, '$.proactive') = 1
+                  AND julianday(ts) >= julianday(?)
+                  AND julianday(ts) <= julianday(?)
+                ORDER BY julianday(ts) DESC, session_key DESC, seq DESC
+                LIMIT ?
+                """,
+                (cutoff.isoformat(), now.isoformat(), _RECENT_PROACTIVE_LIMIT),
+            ).fetchall()
+
+        # 2. 从最新消息向前占用预算，再按时间正序交给模型
+        selected: list[str] = []
+        used_chars = 0
+        for session_key, content, ts in rows:
+            line = (
+                f"{ts} | session={session_key} | "
+                f"assistant(proactive): {str(content or '')[:500]}"
+            )
+            remaining = _RECENT_PROACTIVE_CHAR_BUDGET - used_chars
+            if remaining <= 0:
+                break
+            if len(line) > remaining:
+                if selected:
+                    break
+                line = line[:remaining]
+            selected.append(line)
+            used_chars += len(line) + 1
+        return "\n".join(reversed(selected))
 
     def _require_orchestrator(self) -> Any:
         if self._scope.turn_orchestrator is None:

--- a/plugins/wake_proactive/state.py
+++ b/plugins/wake_proactive/state.py
@@ -219,14 +219,27 @@ class WakeStateStore:
             )
 
     def save(self, ctx: WakeContext) -> None:
-        scratchpad = {
-            item_id: {
-                "initial_interest": item.initial_interest,
-                "investigate": item.investigate,
-                "question": item.question,
-                "recall_query": item.recall_query,
-            }
-            for item_id, item in ctx.scratchpad.items()
+        scratchpad: dict[str, Any] = {
+            "items": {
+                item_id: {
+                    "initial_interest": item.initial_interest,
+                    "question": item.question,
+                }
+                for item_id, item in ctx.scratchpad.items()
+            },
+            "preference_probe": (
+                {
+                    "candidate_ids": list(ctx.preference_probe.candidate_ids),
+                    "topic": ctx.preference_probe.topic,
+                    "query": ctx.preference_probe.query,
+                }
+                if ctx.preference_probe is not None
+                else None
+            ),
+        }
+        investigations: dict[str, Any] = {
+            "items": ctx.investigation_results,
+            "preference_evidence": ctx.preference_evidence,
         }
         _ = self._conn.execute(
             """
@@ -251,7 +264,7 @@ class WakeStateStore:
                 ctx.session_key,
                 ctx.now_utc.isoformat(),
                 json.dumps(scratchpad, ensure_ascii=False),
-                json.dumps(ctx.investigation_results, ensure_ascii=False),
+                json.dumps(investigations, ensure_ascii=False),
                 ctx.final_message,
                 json.dumps(ctx.cited_item_ids, ensure_ascii=False),
                 json.dumps(ctx.display_event_map, ensure_ascii=False),

--- a/plugins/wake_proactive/tools.py
+++ b/plugins/wake_proactive/tools.py
@@ -6,8 +6,9 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from core.memory.engine import MemoryQuery
+from core.memory.engine import MemoryQuery, MemoryQueryFilters
 from plugins.wake_proactive.context import (
+    PreferenceProbe,
     ScratchItem,
     WakeContext,
     content_candidate_map,
@@ -68,18 +69,36 @@ TOOL_SCHEMAS = [
                                 "enum": ["likely_interesting", "uncertain"],
                             },
                             "question": {"type": "string"},
-                            "recall_query": {"type": "string"},
                         },
                         "required": ["item_id", "initial_interest"],
                     },
-                }
+                },
+                "preference_probe": {
+                    "type": "object",
+                    "description": (
+                        "可选且每轮最多一个。入选候选的价值取决于用户对一种内容形态或打扰"
+                        "类型的态度，且固定上下文没有直接证据时可以填写。主题兴趣和内容形态"
+                        "偏好是不同维度；query 查询真实态度和打扰价值，不复述新闻标题。"
+                    ),
+                    "properties": {
+                        "candidate_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "maxItems": MAX_INVESTIGATION_CANDIDATES,
+                        },
+                        "topic": {"type": "string"},
+                        "query": {"type": "string"},
+                    },
+                    "required": ["candidate_ids", "topic", "query"],
+                },
             },
             "required": ["items"],
         },
     ),
     _schema(
         "investigate_candidates",
-        "按 scratchpad 一次并发完成全部正文抓取和兴趣记忆查询，结果按 item_id 合并。",
+        "按 scratchpad 并发抓取全部正文，并在存在 preference_probe 时只执行一次只读兴趣查询。",
         {"type": "object", "properties": {}, "required": []},
     ),
     _schema(
@@ -167,17 +186,22 @@ def _scratchpad(ctx: WakeContext, args: dict[str, Any], deps: ToolDeps) -> str:
             continue
         if interest not in allowed_interest:
             raise ValueError(f"invalid scratchpad decision for {item_id}")
-        recall_query = str(raw.get("recall_query") or "").strip()
-        if interest == "uncertain" and not recall_query:
-            recall_query = str(candidate_map[candidate_ref].get("title") or item_id)
         planned[item_id] = ScratchItem(
             item_id=item_id,
             initial_interest=cast(Any, interest),
-            investigate="content" if interest == "likely_interesting" else "both",
             question=str(raw.get("question") or "").strip(),
-            recall_query=recall_query,
         )
     ctx.scratchpad = planned
+    planned_candidate_refs = {
+        candidate_ref
+        for candidate_ref, item_id in zip(raw_item_ids, item_ids, strict=True)
+        if item_id in planned
+    }
+    ctx.preference_probe = _preference_probe(
+        args.get("preference_probe"),
+        planned_candidate_refs=planned_candidate_refs,
+        candidate_map=candidate_map,
+    )
     ctx.screening_completed = True
     _save(ctx, deps)
     return json.dumps(
@@ -186,6 +210,7 @@ def _scratchpad(ctx: WakeContext, args: dict[str, Any], deps: ToolDeps) -> str:
             "screened": len(valid_ids),
             "planned": len(ctx.scratchpad),
             "to_investigate": len(ctx.scratchpad),
+            "preference_probe": ctx.preference_probe is not None,
         },
         ensure_ascii=False,
     )
@@ -215,11 +240,60 @@ async def _fetch_content(
         return {"error": str(exc), "url": url}
 
 
-async def _recall(
+def _preference_probe(
+    raw_probe: object,
+    *,
+    planned_candidate_refs: set[str],
+    candidate_map: dict[str, dict[str, Any]],
+) -> PreferenceProbe | None:
+    """校验一次批次级偏好探针，并转换候选引用。"""
+
+    # 1. 没有关键偏好歧义时不触发任何记忆查询
+    if raw_probe is None:
+        return None
+    if not isinstance(raw_probe, dict):
+        raise ValueError("preference_probe must be an object")
+    probe_payload = cast(dict[str, object], raw_probe)
+
+    # 2. 探针只能引用本轮已经入选调查的候选
+    raw_candidate_ids = probe_payload.get("candidate_ids")
+    if not isinstance(raw_candidate_ids, list):
+        raise ValueError("preference_probe candidate_ids must be an array")
+    raw_ids = [
+        str(item).strip()
+        for item in cast(list[object], raw_candidate_ids)
+    ]
+    if not raw_ids or len(raw_ids) != len(set(raw_ids)):
+        raise ValueError("preference_probe candidate_ids must be unique and non-empty")
+    unknown = sorted(set(raw_ids) - planned_candidate_refs)
+    if unknown:
+        raise ValueError(
+            f"preference_probe contains unplanned candidate_id: {unknown}"
+        )
+    topic = str(probe_payload.get("topic") or "").strip()
+    query = str(probe_payload.get("query") or "").strip()
+    if not topic or not query:
+        raise ValueError("preference_probe requires topic and query")
+    return PreferenceProbe(
+        candidate_ids=tuple(
+            _canonical_item_id(candidate_map, candidate_id)
+            for candidate_id in raw_ids
+        ),
+        topic=topic,
+        query=query,
+    )
+
+
+async def _recall_preference(
     query: str, *, ctx: WakeContext, deps: ToolDeps, semaphore: asyncio.Semaphore
 ) -> dict[str, Any]:
     if deps.memory is None:
-        return {"hits": 0, "result": ""}
+        return {
+            "hits": 0,
+            "records": [],
+            "trace": {},
+            "error": "memory not configured",
+        }
     try:
         async with semaphore:
             result = await deps.memory.query(
@@ -227,20 +301,37 @@ async def _recall(
                     text=query,
                     intent="interest",
                     effect="read_only",
-                    limit=2,
+                    filters=MemoryQueryFilters(relevance_floor="strong"),
+                    limit=12,
                     timestamp=ctx.now_utc,
                 )
             )
         records = list(result.records)
         return {
             "hits": len(records),
-            "result": "\n---\n".join(
-                str(record.summary) for record in records if str(record.summary).strip()
-            ),
+            "records": [
+                {
+                    "id": record.id,
+                    "summary": str(record.summary)[:600],
+                    "engine": record.engine_kind,
+                }
+                for record in records
+                if str(record.summary).strip()
+            ],
+            "trace": {
+                key: result.trace.get(key)
+                for key in (
+                    "engine",
+                    "relevance_floor",
+                    "native_dense_threshold",
+                    "native_score_threshold",
+                )
+                if key in result.trace
+            },
         }
     except Exception as exc:
         logger.warning("wake proactive recall failed query=%r error=%s", query, exc)
-        return {"hits": 0, "result": "", "error": str(exc)}
+        return {"hits": 0, "records": [], "trace": {}, "error": str(exc)}
 
 
 async def _investigate_candidates(ctx: WakeContext, deps: ToolDeps) -> str:
@@ -260,17 +351,32 @@ async def _investigate_candidates(ctx: WakeContext, deps: ToolDeps) -> str:
             "initial_interest": item.initial_interest,
             "question": item.question,
         }
-        operations: list[tuple[str, Any]] = []
-        if item.investigate in {"content", "both"}:
-            operations.append(("content", _fetch_content(events[item.item_id], deps=deps, semaphore=semaphore)))
-        if item.investigate in {"recall", "both"}:
-            operations.append(("memory", _recall(item.recall_query, ctx=ctx, deps=deps, semaphore=semaphore)))
-        if operations:
-            values = await asyncio.gather(*(operation for _, operation in operations))
-            result.update({name: value for (name, _), value in zip(operations, values)})
+        result["content"] = await _fetch_content(
+            events[item.item_id], deps=deps, semaphore=semaphore
+        )
         return item.item_id, result
 
-    pairs = await asyncio.gather(*(investigate(item) for item in ctx.scratchpad.values()))
+    item_task = asyncio.gather(*(investigate(item) for item in ctx.scratchpad.values()))
+    probe = ctx.preference_probe
+    if probe is None:
+        pairs = await item_task
+        ctx.preference_evidence = {}
+    else:
+        pairs, evidence = await asyncio.gather(
+            item_task,
+            _recall_preference(
+                probe.query,
+                ctx=ctx,
+                deps=deps,
+                semaphore=semaphore,
+            ),
+        )
+        ctx.preference_evidence = {
+            "topic": probe.topic,
+            "candidate_ids": list(probe.candidate_ids),
+            "query": probe.query,
+            **evidence,
+        }
     ctx.investigation_results = dict(pairs)
     ctx.investigation_completed = True
     _save(ctx, deps)
@@ -282,7 +388,11 @@ async def _investigate_candidates(ctx: WakeContext, deps: ToolDeps) -> str:
         and str(result["content"].get("text") or "").strip()
     }
     return json.dumps(
-        {"items": verified_results, "count": len(verified_results)},
+        {
+            "items": verified_results,
+            "count": len(verified_results),
+            "preference_evidence": ctx.preference_evidence,
+        },
         ensure_ascii=False,
     )
 

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -19,7 +19,12 @@ from fastapi import FastAPI
 
 from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
-from core.memory.engine import MemoryQuery, MemoryQueryIntent, MemoryScope
+from core.memory.engine import (
+    MemoryQuery,
+    MemoryQueryFilters,
+    MemoryQueryIntent,
+    MemoryScope,
+)
 from agent.plugins.context import PluginContext, PluginKVStore
 from agent.config_models import Config, MemoryConfig, MemoryEmbeddingConfig
 from plugins.akasha.config import (
@@ -1899,6 +1904,67 @@ async def test_read_only_query_skips_akasha_state_effects(tmp_path: Path) -> Non
 
     assert update_state_values == [False, False]
     assert side_effects == []
+
+
+@pytest.mark.asyncio
+async def test_strong_interest_query_keeps_only_native_dense_hits(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "s:4",
+                "s",
+                4,
+                "user",
+                "第三条较弱的用户消息",
+                QUERY_TS.isoformat(),
+            ),
+        )
+
+    engine = cast(Any, AkashaMemoryEngine.__new__(AkashaMemoryEngine))
+    engine._akasha_config = AkashaConfig()
+    engine._session_db_path = db_path
+    engine._embedder = FakeEmbedder()
+
+    def fake_retrieve(
+        query: str,
+        query_vec: np.ndarray,
+        request: MemoryQuery,
+        *,
+        now_ts: float,
+        update_state: bool,
+    ) -> _AkashaRetrieval:
+        _ = (query, query_vec, request, now_ts, update_state)
+        return _AkashaRetrieval(
+            dense_items=[_candidate("s:0", 0.8), _candidate("s:4", 0.6)],
+            ripple_items=[_candidate("s:2", 0.95)],
+            activation_items=[],
+            trace=ActivationTrace(seed_count=2, pool_count=3),
+            seq=5,
+        )
+
+    engine._retrieve = fake_retrieve
+    engine._remember_pending_activation = lambda *_, **__: None
+    engine._write_query_log = lambda *_, **__: None
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户对 benchmark 类主动消息的真实评价",
+            intent="interest",
+            effect="read_only",
+            filters=MemoryQueryFilters(relevance_floor="strong"),
+            limit=12,
+            scope=MemoryScope(session_key="s"),
+            timestamp=QUERY_TS,
+        )
+    )
+
+    assert [record.id for record in result.records] == ["s:0"]
+    assert result.trace["dense_count"] == 1
+    assert result.trace["ripple_count"] == 0
+    assert result.trace["native_dense_threshold"] == 0.675
 
 
 def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> None:

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -13,6 +13,7 @@ from bus.events_lifecycle import TurnCommitted
 from agent.config_models import Config, MemoryConfig
 from agent.tools.registry import ToolRegistry
 from bootstrap.memory import build_memory_runtime
+from plugins.default_memory.config import DefaultMemoryConfig
 from plugins.default_memory.engine import DefaultMemoryEngine
 from core.memory.engine import (
     EngineProfile,
@@ -50,6 +51,7 @@ def _make_default_engine(
 ):
     engine = DefaultMemoryEngine.__new__(DefaultMemoryEngine)
     engine._config = config or SimpleNamespace(model="lm")
+    engine._default_config = DefaultMemoryConfig()
     engine._workspace = Path(".")
     engine._provider = provider
     engine._light_provider = None
@@ -188,6 +190,27 @@ async def test_default_memory_engine_interest_preserves_read_only_effect():
     assert result.trace["effect"] == "read_only"
     assert result.records[0].id == "p1"
     retriever.retrieve.assert_awaited_once()
+
+
+async def test_default_memory_engine_strong_interest_uses_native_threshold():
+    retriever = SimpleNamespace(
+        retrieve=AsyncMock(return_value=[]),
+        build_injection_block=lambda items: ("", []),
+    )
+    engine = _make_default_engine(retriever=cast(Any, retriever))
+
+    result = await engine.query(
+        MemoryQuery(
+            text="用户对 benchmark 类主动消息的真实评价",
+            intent="interest",
+            effect="read_only",
+            filters=MemoryQueryFilters(relevance_floor="strong"),
+        )
+    )
+
+    assert retriever.retrieve.await_args.kwargs["score_threshold"] == 0.5
+    assert result.trace["relevance_floor"] == "strong"
+    assert result.trace["native_score_threshold"] == 0.5
 
 
 async def test_default_memory_engine_retrieve_falls_back_to_session_scope():

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -327,7 +327,7 @@ async def test_content_vertical_slice_filters_investigates_and_shares(
     assert "preprocess_score" not in first_prompt
     assert "scratchpad" not in system_prompt
     assert "scratchpad" in llm_input[2]["content"]
-    assert "宁可少选" in llm_input[2]["content"]
+    assert "自行决定调查范围" in llm_input[2]["content"]
     assert "当前 ContextEvent" in first_prompt
     assert "没有有效 ContextEvent" in first_prompt
     final_prompt = provider.chat.await_args_list[1].kwargs["messages"][0]["content"]
@@ -484,7 +484,8 @@ async def test_shared_ack_route_keeps_original_source_grouping_and_order(
         ctx=WakeContext(content_events=unread),
         memory_text="",
         proactive_context="",
-        recent_session="",
+        recent_passive_conversation="",
+        recent_proactive_messages="",
     )[1]["content"]
 
     assert prompt.index("来源：source-a") < prompt.index("来源：source-b")
@@ -516,13 +517,24 @@ def test_prompt_exposes_current_context_and_only_selected_mode(mode) -> None:
         ctx=ctx,
         memory_text="memory",
         proactive_context="proactive context",
-        recent_session="recent session",
+        recent_passive_conversation="recent passive conversation",
+        recent_proactive_messages=(
+            "2026-07-12T00:00:00+00:00 | session=mobile:owner | "
+            "assistant(proactive): recent proactive message"
+        ),
         current_context="presence=active | confidence=0.90",
         mode=cast(Any, mode),
         event=event,
     )
 
     assert "【当前 ContextEvent】" in messages[1]["content"]
+    assert "【截至当前时间的最近被动对话】" in messages[1]["content"]
+    assert "recent passive conversation" in messages[1]["content"]
+    assert "【截至当前时间已经发送的主动消息】" in messages[1]["content"]
+    assert "理解你最近主动和用户聊过什么" in messages[1]["content"]
+    assert "不是内容价值的扣分表" in messages[1]["content"]
+    assert "话题、结论或事件相近都不自动禁止再次分享" in messages[1]["content"]
+    assert "recent proactive message" in messages[1]["content"]
     assert "presence=active | confidence=0.90" in messages[1]["content"]
     assert f"mode={mode}" in messages[1]["content"]
     assert "mode=content" not in messages[0]["content"]
@@ -536,8 +548,29 @@ def test_prompt_exposes_current_context_and_only_selected_mode(mode) -> None:
     if mode == "content":
         assert "已有 content 标题" in messages[1]["content"]
         assert "scratchpad" in messages[2]["content"]
+        assert "<example>" in messages[2]["content"]
+        assert "主题 X" in messages[2]["content"]
+        assert "内容形态 Y" in messages[2]["content"]
+        assert "自行决定调查范围" in messages[2]["content"]
     else:
         assert "本轮单条事件" in messages[1]["content"]
+
+
+def test_content_final_prompt_has_no_default_share_or_skip_tendency() -> None:
+    messages = build_messages(
+        ctx=WakeContext(content_events=[]),
+        memory_text="",
+        proactive_context="",
+        recent_passive_conversation="",
+        recent_proactive_messages="",
+        content_phase="final",
+    )
+
+    assert "没有默认的 share 或 skip 倾向" in messages[2]["content"]
+    assert "每次都重新判断这件事此刻对用户意味着什么" in messages[2]["content"]
+    assert "发送次数本身不是用户的态度" in messages[2]["content"]
+    assert "始终对用户本人和他在意的一切保持真诚好奇" in messages[0]["content"]
+    assert "这种好奇不会因为一个话题已经聊过" in messages[0]["content"]
 
 
 def test_legacy_reservoir_migrates_ack_and_original_sources(tmp_path) -> None:
@@ -1049,10 +1082,97 @@ def test_future_message_embeddings_do_not_affect_current_interest(tmp_path, requ
 
     assert current_event["_wake_interest_score"] == pytest.approx(0.1)
     assert future_event["_wake_interest_score"] > 0.99
-    recent = runtime._read_recent_session("s", datetime(2026, 7, 12, tzinfo=UTC))
+    now = datetime(2026, 7, 12, tzinfo=UTC)
+    recent = runtime._read_recent_passive_conversation("s", now)
     assert "主动推送" not in recent
     assert "过去用户" in recent
     assert "未来用户" not in recent
+    proactive = runtime._read_recent_proactive_messages(now)
+    assert "2026-07-09T00:01:00+00:00" in proactive
+    assert "session=s" in proactive
+    assert "主动推送" in proactive
+    assert "未来助手" not in proactive
+
+
+def test_recent_proactive_messages_are_workspace_wide_and_bounded(tmp_path, request):
+    session_db = tmp_path / "sessions.db"
+    now = datetime(2026, 7, 12, tzinfo=UTC)
+    recent_rows = [
+        (
+            f"p{index}",
+            f"mobile:{index % 2}",
+            index,
+            "assistant",
+            f"最近主动消息 {index}",
+            '{"proactive": true}',
+            (now - timedelta(hours=32 - index)).isoformat(),
+        )
+        for index in range(32)
+    ]
+    boundary_rows = [
+        (
+            "old",
+            "telegram:old",
+            1,
+            "assistant",
+            "窗口外主动消息",
+            '{"proactive": true}',
+            (now - timedelta(days=8)).isoformat(),
+        ),
+        (
+            "future",
+            "telegram:future",
+            1,
+            "assistant",
+            "未来主动消息",
+            '{"proactive": true}',
+            (now + timedelta(minutes=1)).isoformat(),
+        ),
+    ]
+    with closing(sqlite3.connect(session_db)) as db:
+        db.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                extra TEXT,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        db.executemany(
+            "INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [*recent_rows, *boundary_rows],
+        )
+        db.commit()
+
+    runtime = WakeRuntime(
+        _scope(
+            tmp_path,
+            FakeGateway([]),
+            SimpleNamespace(chat=AsyncMock()),
+            FakeOrchestrator(),
+            _source("content"),
+        ),
+        clock=FixedClock(now),
+    )
+    request.addfinalizer(runtime.close)
+
+    proactive = runtime._read_recent_proactive_messages(now)
+    proactive_lines = proactive.splitlines()
+
+    assert len(proactive_lines) == 30
+    assert not any(line.endswith("最近主动消息 0") for line in proactive_lines)
+    assert not any(line.endswith("最近主动消息 1") for line in proactive_lines)
+    assert any(line.endswith("最近主动消息 2") for line in proactive_lines)
+    assert any(line.endswith("最近主动消息 31") for line in proactive_lines)
+    assert "session=mobile:0" in proactive
+    assert "session=mobile:1" in proactive
+    assert "窗口外主动消息" not in proactive
+    assert "未来主动消息" not in proactive
 
 
 def test_semantic_interest_keeps_moderate_match_meaningful(tmp_path, request):

--- a/tests/wake_proactive/test_tools.py
+++ b/tests/wake_proactive/test_tools.py
@@ -41,9 +41,13 @@ def _plan() -> dict:
                 "item_id": "candidate_1",
                 "initial_interest": "uncertain",
                 "question": "是否有可复用的唤醒方法",
-                "recall_query": "用户是否关心主动唤醒架构",
             },
-        ]
+        ],
+        "preference_probe": {
+            "candidate_ids": ["candidate_1"],
+            "topic": "主动唤醒架构",
+            "query": "用户对主动唤醒架构类消息的真实兴趣和打扰价值评价",
+        },
     }
 
 
@@ -91,7 +95,13 @@ async def test_scratchpad_records_only_candidates_without_training_side_effect()
     ctx = WakeContext(content_events=_events())
     deps = ToolDeps()
     result = json.loads(await execute("scratchpad", _plan(), ctx, deps))
-    assert result == {"ok": True, "screened": 2, "planned": 1, "to_investigate": 1}
+    assert result == {
+        "ok": True,
+        "screened": 2,
+        "planned": 1,
+        "to_investigate": 1,
+        "preference_probe": True,
+    }
     assert ctx.terminal_action is None
     assert ctx.cited_item_ids == []
 
@@ -229,7 +239,7 @@ async def test_empty_scratchpad_can_investigate_then_skip():
     )
 
     assert result["screened"] == 2
-    assert investigation == {"items": {}, "count": 0}
+    assert investigation == {"items": {}, "count": 0, "preference_evidence": {}}
     assert skipped["decision"] == "skip"
 
 
@@ -245,7 +255,6 @@ async def test_scratchpad_rejects_invalid_interest():
                     {
                         "item_id": "candidate_1",
                         "initial_interest": "maybe",
-                        "recall_query": "query",
                     }
                 ]
             },
@@ -255,7 +264,7 @@ async def test_scratchpad_rejects_invalid_interest():
 
 
 @pytest.mark.asyncio
-async def test_scratchpad_derives_investigation_and_recall_query():
+async def test_scratchpad_keeps_uncertain_candidate_for_content_investigation():
     ctx = WakeContext(content_events=[{"id": "feed:a", "title": "Agent memory"}])
 
     await execute(
@@ -265,8 +274,58 @@ async def test_scratchpad_derives_investigation_and_recall_query():
         ToolDeps(),
     )
 
-    assert ctx.scratchpad["feed:a"].investigate == "both"
-    assert ctx.scratchpad["feed:a"].recall_query == "Agent memory"
+    assert ctx.scratchpad["feed:a"].initial_interest == "uncertain"
+    assert ctx.preference_probe is None
+
+
+@pytest.mark.asyncio
+async def test_preference_probe_only_accepts_shortlisted_candidates():
+    ctx = WakeContext(content_events=_events())
+
+    with pytest.raises(ValueError, match="unplanned candidate_id"):
+        await execute(
+            "scratchpad",
+            {
+                "items": [
+                    {
+                        "item_id": "candidate_1",
+                        "initial_interest": "uncertain",
+                    }
+                ],
+                "preference_probe": {
+                    "candidate_ids": ["candidate_2"],
+                    "topic": "benchmark",
+                    "query": "用户对 benchmark 类主动消息的真实评价",
+                },
+            },
+            ctx,
+            ToolDeps(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_preference_probe_rejects_discarded_candidate():
+    ctx = WakeContext(content_events=_events())
+
+    with pytest.raises(ValueError, match="unplanned candidate_id"):
+        await execute(
+            "scratchpad",
+            {
+                "items": [
+                    {
+                        "item_id": "candidate_1",
+                        "initial_interest": "not_interesting",
+                    }
+                ],
+                "preference_probe": {
+                    "candidate_ids": ["candidate_1"],
+                    "topic": "benchmark",
+                    "query": "用户对 benchmark 类主动消息的真实评价",
+                },
+            },
+            ctx,
+            ToolDeps(),
+        )
 
 
 @pytest.mark.asyncio
@@ -289,7 +348,7 @@ async def test_scratchpad_ignores_explicit_not_interesting_item():
 
 
 @pytest.mark.asyncio
-async def test_investigate_candidates_fetches_and_recalls_concurrently():
+async def test_investigate_candidates_fetches_and_recalls_once_concurrently():
     active = 0
     peak = 0
 
@@ -308,7 +367,14 @@ async def test_investigate_candidates_fetches_and_recalls_concurrently():
         await asyncio.sleep(0)
         active -= 1
         return SimpleNamespace(
-            records=[SimpleNamespace(summary="用户关心 agent 架构")]
+            records=[
+                SimpleNamespace(
+                    id="m1",
+                    summary="用户关心 agent 架构",
+                    engine_kind="test",
+                )
+            ],
+            trace={"engine": "test", "relevance_floor": "strong"},
         )
 
     web = MagicMock()
@@ -323,10 +389,16 @@ async def test_investigate_candidates_fetches_and_recalls_concurrently():
 
     assert result["count"] == 1
     assert result["items"]["candidate_1"]["content"]["text"] == "正文"
-    assert result["items"]["candidate_1"]["memory"]["hits"] == 1
+    assert result["preference_evidence"]["hits"] == 1
+    assert result["preference_evidence"]["records"][0]["id"] == "m1"
     assert peak == 2
     web.execute.assert_awaited_once()
     memory.query.assert_awaited_once()
+    request = memory.query.await_args.args[0]
+    assert request.effect == "read_only"
+    assert request.intent == "interest"
+    assert request.filters.relevance_floor == "strong"
+    assert request.limit == 12
 
 
 @pytest.mark.asyncio
@@ -367,6 +439,10 @@ async def test_share_content_renders_one_message_and_stable_mapping(tmp_path):
     saved = store.get(ctx.wake_id)
     assert saved is not None
     assert json.loads(saved["display_event_map_json"]) == {"1": "feed:a"}
+    saved_scratchpad = json.loads(saved["scratchpad_json"])
+    assert saved_scratchpad["preference_probe"]["candidate_ids"] == ["feed:a"]
+    saved_investigations = json.loads(saved["investigations_json"])
+    assert saved_investigations["preference_evidence"]["topic"] == "主动唤醒架构"
     store.close()
 
 
@@ -401,17 +477,18 @@ async def test_investigate_failure_is_evidence_gap_not_negative_label():
     web = MagicMock()
     web.execute = AsyncMock(side_effect=RuntimeError("timeout"))
     memory = MagicMock()
-    memory.query = AsyncMock(return_value=SimpleNamespace(records=[]))
+    memory.query = AsyncMock(return_value=SimpleNamespace(records=[], trace={}))
     ctx = WakeContext(content_events=_events())
     deps = ToolDeps(web_fetch_tool=web, memory=memory)
     await execute("scratchpad", _plan(), ctx, deps)
 
     result = json.loads(await execute("investigate_candidates", {}, ctx, deps))
 
-    assert result == {"items": {}, "count": 0}
+    assert result["items"] == {}
+    assert result["count"] == 0
+    assert result["preference_evidence"]["hits"] == 0
     item = ctx.investigation_results["feed:a"]
     assert item["content"]["error"] == "timeout"
-    assert item["memory"]["hits"] == 0
     assert ctx.terminal_action is None
     assert ctx.cited_item_ids == []
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Wake 只看到目标 session 的最近被动对话，无法知道自己在其他 session 最近主动发送过什么；模型因此可能反复讲同类内容，也无法结合真实长期偏好区分额度重置与重复 benchmark。
- 用户可见结果：Wake 分开看到最近被动对话和 workspace 范围内最近已送达的主动消息；主动记录带发送时间和 session。模型在标题初筛后可以执行一次批次级只读偏好召回，并自主决定 share 或 skip。历史只作为连续性背景，不按主题、相似度或次数施加硬规则。
- 本 PR 不处理：Feed/MCP 对不同来源但内容相同的内容级去重；已经由 #138 处理的同一来源消费映射；模型在 `ContextEvent=unknown` 时偶发推断用户当前状态的独立问题。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：`wake_proactive` 的 content 决策和已安装 memory engine
- `runtime_patch`：`required`
- `runtime_patch_reason`：最近主动消息的权威事实位于服务端 `sessions.db/messages`，最终 Wake 决策也在服务端插件内完成。
- `authoritative_state_owner`：`SessionStore` 拥有消息事实；memory engine 拥有各自的强相关阈值；Wake 只读取并保存本轮诊断快照。
- `client_only_alternative`：客户端无法可靠汇总 workspace 跨 session 的主动历史，也不拥有 Wake 决策点。
- 关联不变量：PRM-008、STA-002、CTX-004、SES-005、PRO-001、PRO-003、TST-001。
- `protected_state`：`sessions.db/messages` 只追加；`MEMORY.md`、`PROACTIVE_CONTEXT.md` 和 Akasha 权威输入只读；已有 reservoir、ack、hazard 和消费协议不变。
- 允许的副作用：Wake 当前 run 的 `scratchpad_json`、`investigations_json` 增加偏好探针和证据；隔离 Docker CaptureChannel 写入测试 outbox。
- 禁止的副作用：验证期间向正式 Mobile/Telegram 发送消息、修改正式 workspace、重启正式服务、删除或重写既有消息、用 RecallMemory 改变记忆激活状态。

## 改动范围

- 主要文件：`plugins/wake_proactive/{prompt,runtime,context,state,tools}.py`、`core/memory/engine.py`、`plugins/{default_memory,akasha}/engine.py` 及相关测试和工作手册。
- 配置或迁移影响：无配置变更，无数据库 schema 迁移。旧 Wake run 不迁移；新诊断字段保持 JSON 兼容。
- 已知 schema lineage 与最终 schema identity：不适用，持久表 schema 未改变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：core `1922039f`；公开 Gate 使用下方 source/plan digest；Docker replay provider identity 保持私有。
- 回滚方式：revert `1922039f`；实现前恢复分支为 `backup/wake-recent-delivery-context-before-20260718`，基线为 `6db411ac`。

## 验证

- [x] 相关 targeted tests 已通过：141 passed。
- [x] Python 类型检查已通过：Pyright 0 errors、0 warnings。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`cf32d47ff7fe292e3916f43ed7fc69c1ac56c190f2116207750fb187930b73b3`
- `planDigest`：`e18a25063b0bbb8cf8da9e39156f546f96e48962f4cf555255f3a82124a3a106`
- `private-contract-gate`：`pending_maintainer`
- Docker 真实运行时回放：完全重复的 GPT-5.6 事件保持 skip；保留更早额度历史、仅移除本轮已送达行的额度重置反事实选择 reply；Kimi K3 的重复 benchmark/showcase 选择 skip。全部使用 CaptureChannel，正式手机 outbox 和 server 未参与。额度场景只提高预处理分数以确定越过随机 Wake 门，候选正文、历史、MEMORY、Akasha 和 LLM 决策 prompt 不变。
- 真实设备证据：不适用；本 PR 不修改客户端或设备协议，也禁止验证发送到正式设备。
- 未运行项与原因：私有 provider Gate 需要维护者环境，公开 Gate 已标记 required。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已由维护者确认，新增 PRO-003，并增加 `docs/design/wake-recent-delivery-context.md` 与索引入口。
- [x] 跨仓库或客户端改动不适用；能力 owner 为服务端 Wake 插件。
- [x] `NOW.md` 当前没有对应事项，不新增或保留完成流水账。
