### PR TITLE
fix(proactive): 统一移动端主动消息投递身份

### DIFF
--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -4,7 +4,7 @@
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 from agent.tools.base import Tool
 from bus.queue import ChatLane
@@ -71,6 +71,9 @@ class MessagePushTool(Tool):
         channel: str,
         text: Callable[[str, str], Awaitable[None]] | None = None,
         stream_text: Callable[[str, str], Awaitable[None]] | None = None,
+        text_with_metadata: (
+            Callable[[str, str, dict[str, object]], Awaitable[None]] | None
+        ) = None,
         file: Callable[[str, str, str | None], Awaitable[None]] | None = None,
         image: Callable[[str, str], Awaitable[None]] | None = None,
     ) -> ChannelRegistration:
@@ -89,6 +92,8 @@ class MessagePushTool(Tool):
             self._senders[channel]["text"] = text
         if stream_text:
             self._senders[channel]["stream_text"] = stream_text
+        if text_with_metadata:
+            self._senders[channel]["text_with_metadata"] = text_with_metadata
         if file:
             self._senders[channel]["file"] = file
         if image:
@@ -111,6 +116,13 @@ class MessagePushTool(Tool):
         file: str | None = kwargs.get("file")
         image: str | None = kwargs.get("image")
         commit_role = str(kwargs.get("_commit_role") or "").strip()
+        raw_outbound_metadata = kwargs.get("_outbound_metadata", {})
+        if not isinstance(raw_outbound_metadata, dict):
+            raise TypeError("message_push _outbound_metadata 必须是字符串键对象")
+        metadata_object = cast(dict[object, object], raw_outbound_metadata)
+        if not all(isinstance(key, str) for key in metadata_object):
+            raise TypeError("message_push _outbound_metadata 必须是字符串键对象")
+        outbound_metadata = cast(dict[str, object], metadata_object)
 
         if not message and not file and not image:
             return "错误：message、file、image 至少提供一个"
@@ -127,6 +139,7 @@ class MessagePushTool(Tool):
                 file=file,
                 image=image,
                 senders=senders,
+                outbound_metadata=outbound_metadata,
             )
 
         if self._chat_lane is not None and commit_role != "passive":
@@ -142,13 +155,21 @@ class MessagePushTool(Tool):
         file: str | None,
         image: str | None,
         senders: dict[str, Callable[..., Awaitable[None]]],
+        outbound_metadata: dict[str, object],
     ) -> str:
 
         results: list[str] = []
         try:
             if message and "text" in senders:
-                sender_name = "stream_text" if "stream_text" in senders else "text"
-                await senders[sender_name](chat_id, message)
+                if outbound_metadata and "text_with_metadata" in senders:
+                    await senders["text_with_metadata"](
+                        chat_id,
+                        message,
+                        dict(outbound_metadata),
+                    )
+                else:
+                    sender_name = "stream_text" if "stream_text" in senders else "text"
+                    await senders[sender_name](chat_id, message)
                 preview = message[:60] + "..." if len(message) > 60 else message
                 logger.info(f"[message_push] {channel}:{chat_id} ← text: {preview!r}")
                 results.append("文本已发送")

--- a/agent/turns/orchestrator.py
+++ b/agent/turns/orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from agent.turns.result import TurnResult, TurnSideEffect
@@ -43,6 +44,7 @@ class TurnOrchestrator:
 
         content = result.outbound.content
         media = list(result.outbound.media or [])
+        delivery_id = uuid4().hex
         sent = False
         try:
             # 2. 先执行发送前 side_effects，再真正 dispatch 到 outbound。
@@ -52,7 +54,7 @@ class TurnOrchestrator:
                     channel=channel,
                     chat_id=chat_id,
                     content=content,
-                    metadata={},
+                    metadata={"delivery_id": delivery_id},
                     media=media,
                 )
             )
@@ -67,6 +69,7 @@ class TurnOrchestrator:
                 content=content,
                 media=media,
                 result=result,
+                delivery_id=delivery_id,
             )
             await self._session.session_manager.append_messages(
                 session, session.messages[-1:]
@@ -96,6 +99,7 @@ class TurnOrchestrator:
         content: str,
         media: list[str],
         result: TurnResult,
+        delivery_id: str,
     ) -> None:
         source_refs = []
         state_summary_tag = "none"
@@ -104,11 +108,12 @@ class TurnOrchestrator:
             if isinstance(raw_refs, list):
                 source_refs = [ref for ref in raw_refs if isinstance(ref, dict)]
             state_summary_tag = str(result.trace.extra.get("state_summary_tag", "none"))
-        session.add_message(
+        _ = session.add_message(
             "assistant",
             content,
             media=media if media else None,
             proactive=True,
+            delivery_id=delivery_id,
             tools_used=["message_push"],
             evidence_item_ids=[str(item_id) for item_id in result.evidence],
             source_refs=source_refs,

--- a/agent/turns/outbound.py
+++ b/agent/turns/outbound.py
@@ -57,6 +57,7 @@ class PushToolOutboundPort:
             chat_id=chat_id,
             message=message,
             image=media[0] if media else None,
+            _outbound_metadata=dict(outbound.metadata),
         )
         for image in media[1:]:
             result = await self._push.execute(

--- a/docs/design/mobile-cross-repository-semantic-gate.md
+++ b/docs/design/mobile-cross-repository-semantic-gate.md
@@ -120,6 +120,25 @@ public PR6 v3: media + server sequence
 
 **F（历史 PR6 迁移证据）：** `3f81275` 在 Pixel 7 上逐条重跑的 schema v5 迁移矩阵覆盖 final PR5 v4、reviewed PR6 v4、original public PR6 v3 和 canonical 1→5，并分别证明 partial v3 与 partial v4 fail-loud。当前独立移动仓库已演进到 schema v10；这组证据只负责旧分叉的汇合，后续 5→10 仍由当前仓库的逐版本 migration tests 负责。
 
+### 2.6 主动消息的实时与历史身份
+
+**C：** 被动消息按完整 Turn 提交，主动消息只在 dispatch 明确成功后追加到 SessionDB。主动实时事件不是第二条会话事实，而是同一条已发送消息的客户端投影。
+
+```text
+Core proactive delivery_id
+          ├─ message.proactive payload
+          └─ SessionDB message extra → history.page extra
+                                │
+                                ▼
+                    Android 精确合并为一条消息
+```
+
+**I：** Core 在一次主动发送尝试开始时生成 `delivery_id`，通过只对内部出站调用开放的 metadata 通道交给支持该能力的 channel；dispatch 成功后把同一值随 assistant 消息追加到 SessionDB。该字段不改变 SessionDB message ID，也不提前创建会话消息。
+
+**C：** Android 收到两种投影时优先按 `delivery_id` 合并。只有旧事件或旧历史没有该字段时，才允许使用带 `proactive=true`、相同文本、限定时间窗且唯一最近候选的兼容规则；候选不唯一时保留两条，不能猜测身份。
+
+当前接受的边缘窗口是：Mobile 已接收后 Core 在追加历史前崩溃，该主动消息可能只保留在手机投影中。当前方案不为这个窗口新增 outbox、重试状态机或 SessionDB 表。
+
 ## 3. 协议与外部仓库版本固定
 
 ### 3.1 客户端协议快照

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -343,9 +343,11 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 
 AgentLoop 唯一拥有活动 turn task 的取消和 cleanup。无论成功、失败或取消，都恢复临时 session context。terminal event、inbound complete 和 delivery ack 各自由一个层提交，保证恰好一次。
 
-### OUT-001 未送达内容不得进入可见历史
+### OUT-001 被动按 Turn 提交，主动按送达提交
 
-dispatch 明确成功是写入用户可见历史、presence、dedupe 和 success 状态的前置条件。部分送达必须有独立状态，不能冒充成功或完全失败。
+被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，user 与 assistant 消息共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
+
+同一条主动消息的实时事件与发送成功后的历史投影必须携带同一个稳定投递身份。客户端优先用该身份精确合并；内容与时间匹配只能兼容缺少稳定身份的旧消息。部分送达和结果不明必须有独立状态，不能冒充成功或完全失败。
 
 ### OUT-002 回合副作用的顺序和分支确定
 

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -219,6 +219,7 @@ class MobileRealtimeChannel:
             self.name,
             text=self.send,
             stream_text=self.send_stream,
+            text_with_metadata=self.send_with_metadata,
         )
 
     async def stop(self) -> None:
@@ -434,16 +435,47 @@ class MobileRealtimeChannel:
         return _reply_from_receipt(completed)
 
     async def send(self, chat_id: str, message: str) -> None:
+        await self._send_proactive(chat_id, message, delivery_id=None)
+
+    async def send_with_metadata(
+        self,
+        chat_id: str,
+        message: str,
+        metadata: dict[str, object],
+    ) -> None:
+        """发送携带核心主动投递身份的消息。"""
+
+        delivery_id = metadata.get("delivery_id")
+        if (
+            not isinstance(delivery_id, str)
+            or not delivery_id
+            or len(delivery_id) > 128
+        ):
+            raise ValueError("mobile proactive delivery_id 无效")
+        await self._send_proactive(chat_id, message, delivery_id=delivery_id)
+
+    async def _send_proactive(
+        self,
+        chat_id: str,
+        message: str,
+        *,
+        delivery_id: str | None,
+    ) -> None:
+        """把主动文字发布为移动端持久事件。"""
+
         self._raise_delta_failure()
         session_id = self._session_id(chat_id)
+        payload: dict[str, object] = {
+            "content": message,
+            "attachments": [],
+            "metadata": {"source": "message_push"},
+        }
+        if delivery_id is not None:
+            payload["delivery_id"] = delivery_id
         await self._runtime.publish_event(
             event_type="message.proactive",
             session_id=session_id,
-            payload={
-                "content": message,
-                "attachments": [],
-                "metadata": {"source": "message_push"},
-            },
+            payload=payload,
         )
 
     async def send_stream(self, chat_id: str, message: str) -> None:
@@ -1574,9 +1606,9 @@ def _mobile_history_item(item: Mapping[str, object]) -> dict[str, object]:
     """裁剪服务端内部字段，只向手机同步可展示历史。"""
 
     mobile_extra: dict[str, object] = {}
-    for field in ("reasoning_content", "turn_duration_ms"):
+    for field in ("reasoning_content", "turn_duration_ms", "proactive", "delivery_id"):
         value = item.get(field)
-        if isinstance(value, (str, int, float)):
+        if isinstance(value, (str, int, float, bool)):
             mobile_extra[field] = value
 
     result: dict[str, object] = {

--- a/session/store.py
+++ b/session/store.py
@@ -106,6 +106,11 @@ def _decode_message_extra(
     proactive = extra_dict.get("proactive")
     if "proactive" in extra_dict and not isinstance(proactive, bool):
         raise ValueError(f"message proactive 必须是布尔值: {message_id}")
+    delivery_id = extra_dict.get("delivery_id")
+    if "delivery_id" in extra_dict and (
+        not isinstance(delivery_id, str) or not delivery_id or len(delivery_id) > 128
+    ):
+        raise ValueError(f"message delivery_id 必须是 1..128 字符串: {message_id}")
     for field in ("state_summary_tag", "reasoning_content"):
         value = extra_dict.get(field)
         if field in extra_dict and not isinstance(value, str):

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -154,6 +154,26 @@ def test_mobile_tool_arguments_are_bounded_for_phone_storage() -> None:
     assert len(encoded.encode("utf-8")) < 256 * 1024
 
 
+def test_mobile_history_projects_proactive_delivery_identity() -> None:
+    projected = channel_module._mobile_history_item(
+        {
+            "id": "mobile:test:1",
+            "session_key": "mobile:test",
+            "seq": 1,
+            "role": "assistant",
+            "content": "主动提醒",
+            "timestamp": "2026-07-19T00:00:00+00:00",
+            "proactive": True,
+            "delivery_id": "delivery-1",
+        }
+    )
+
+    assert projected["extra"] == {
+        "proactive": True,
+        "delivery_id": "delivery-1",
+    }
+
+
 def test_mobile_history_tool_arguments_fit_real_event_frame() -> None:
     calls = [
         {
@@ -1916,5 +1936,39 @@ async def test_proactive_sender_uses_mobile_event_path(tmp_path: Path) -> None:
             },
         }
     ]
+    await channel.stop()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_proactive_metadata_sender_forwards_delivery_id(tmp_path: Path) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    push = _PushTool()
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=_Bus(),
+                session_manager=SessionManager(tmp_path / "workspace"),
+                event_bus=_EventBus(),
+                push_tool=push,
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+    chat_id = str(uuid4())
+    sender = cast(Any, push.registered["mobile"]["text_with_metadata"])
+
+    await sender(chat_id, "该休息一下了", {"delivery_id": "delivery-1"})
+
+    assert runtime.events[-1]["payload"] == {
+        "content": "该休息一下了",
+        "attachments": [],
+        "metadata": {"source": "message_push"},
+        "delivery_id": "delivery-1",
+    }
     await channel.stop()
     storage.close()

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -146,6 +146,38 @@ async def test_message_push_tool_covers_success_failure_and_fallbacks():
 
 
 @pytest.mark.asyncio
+async def test_message_push_routes_internal_metadata_only_to_capable_sender():
+    tool = MessagePushTool()
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    async def text(_chat_id: str, _message: str) -> None:
+        raise AssertionError("metadata-capable sender should own this dispatch")
+
+    async def text_with_metadata(
+        chat_id: str,
+        message: str,
+        metadata: dict[str, object],
+    ) -> None:
+        calls.append((chat_id, message, metadata))
+
+    tool.register_channel(
+        "mobile",
+        text=text,
+        text_with_metadata=text_with_metadata,
+    )
+
+    result = await tool.execute(
+        channel="mobile",
+        chat_id="123",
+        message="hello",
+        _outbound_metadata={"delivery_id": "delivery-1"},
+    )
+
+    assert result == "文本已发送"
+    assert calls == [("123", "hello", {"delivery_id": "delivery-1"})]
+
+
+@pytest.mark.asyncio
 async def test_message_push_non_passive_waits_for_passive_reply():
     bus = MessageBus()
     tool = MessagePushTool(chat_lane=bus.chat_lane)

--- a/tests/turns/test_orchestrator.py
+++ b/tests/turns/test_orchestrator.py
@@ -73,6 +73,7 @@ async def test_orchestrator_skip_runs_side_effects_without_dispatch():
 async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success_effects():
     order: list[str] = []
     session = _DummySession("telegram:123")
+    dispatched_delivery_ids: list[str] = []
 
     class _Effect:
         def __init__(self, name: str) -> None:
@@ -85,6 +86,10 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
         async def dispatch(self, outbound: OutboundDispatch) -> bool:
             order.append("dispatch")
             assert outbound.content == "hello"
+            delivery_id = outbound.metadata["delivery_id"]
+            assert isinstance(delivery_id, str)
+            assert len(delivery_id) == 32
+            dispatched_delivery_ids.append(delivery_id)
             return True
 
     presence = SimpleNamespace(record_proactive_sent=lambda _key: order.append("presence"))
@@ -124,6 +129,7 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
     assert sent is True
     assert session.messages[0]["proactive"] is True
     assert session.messages[0]["content"] == "hello"
+    assert session.messages[0]["delivery_id"] == dispatched_delivery_ids[0]
     assert order == ["side_effect", "dispatch", "persist", "presence", "success_effect"]
 
 
@@ -175,6 +181,30 @@ async def test_push_outbound_port_propagates_unexpected_tool_error():
                 content="hello",
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_push_outbound_port_forwards_internal_metadata():
+    push_tool = SimpleNamespace(execute=AsyncMock(return_value="文本已发送"))
+    port = PushToolOutboundPort(push_tool)
+
+    sent = await port.dispatch(
+        OutboundDispatch(
+            channel="mobile",
+            chat_id="123",
+            content="hello",
+            metadata={"delivery_id": "delivery-1"},
+        )
+    )
+
+    assert sent is True
+    push_tool.execute.assert_awaited_once_with(
+        channel="mobile",
+        chat_id="123",
+        message="hello",
+        image=None,
+        _outbound_metadata={"delivery_id": "delivery-1"},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：同一次 Mobile 主动投递的实时事件与 SessionDB 历史投影缺少共同身份，Android 可能展示两条。
- 用户可见结果：Core 为一次主动发送生成稳定 delivery_id，实时事件与发送成功后追加的历史消息携带同一值。
- 本 PR 不处理：不引入 outbox、发送状态机或 Telegram 专用逻辑；不合并两个独立 wake 执行。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Mobile 精确投影；其他 channel 行为保持不变
- `runtime_patch`：`required`
- `runtime_patch_reason`：稳定投递身份由发起主动发送并拥有 SessionDB 历史的 Core 生成，客户端无法可靠反推。
- `authoritative_state_owner`：Core SessionDB；Android Room 仅保存客户端投影
- `client_only_alternative`：内容与时间启发式匹配，仅保留为旧协议兼容，不能提供精确身份。
- 关联不变量：被动按 Turn 提交；主动仅在 sent=true 后追加历史；sessions.db/messages 正常路径只追加。
- `protected_state`：既有会话、历史、Telegram 行为和正式 workspace。
- 允许的副作用：主动 Mobile 实时 payload 与发送成功后的 assistant extra 增加 delivery_id。
- 禁止的副作用：提前落库、删除或重写历史、重复发送、正式环境切换。

## 改动范围

- 主要文件：agent/turns、agent/tools/message_push.py、infra/mobile_realtime/channel.py、session/store.py 及对应测试和工作手册。
- 配置或迁移影响：无 schema 迁移；旧消息保持可读。
- 已知 schema lineage 与最终 schema identity：SessionDB schema 不变，delivery_id 位于既有 message extra。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：本 PR head 3b523d9f8e87344cbcc0b245fa64247b8d3bd5e2；Mobile 消费 PR 将固定此 revision。
- 回滚方式：revert 3b523d9f；备份分支 backup/proactive-delivery-id-core-20260719。

## 验证

- [x] 相关 targeted tests 已通过：80 passed。
- [x] Core 全量测试：2375 passed, 1 skipped。
- [x] Pyright：0 errors（3 个既有 unknown warnings）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：以报告 docker/debug/reports/change-gate/20260719-014012-bf4ab5a4 为准
- `planDigest`：043d2d5aab9a303b31f5f28a6fb7642c3694914ed48ec0efd257440486b57478
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：由 Mobile PR 的隔离 Pixel 7 Gate 提供。
- 未运行项与原因：私有 provider Gate 尚未取得同一 plan 的外部报告。

## 工作手册

- [x] 已核对 projectneed.md、相关决策和 NOW.md。
- [x] 长期语义变化已获得维护者确认。
- [x] 已按 MOB-001 核对能力 owner。
- [x] 当前 NOW.md 没有对应完成事项。