### PR TITLE
[codex] limit provider migration to config

### DIFF
--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -65,7 +65,7 @@ python docker/debug/migration_probe.py
 
 它覆盖 fresh/legacy 分类、固定 baseline、快速路径、顺序执行、merge、纯代码提交、
 blocked/apply/verify/cursor 写入失败与安全重试、分支分叉、shallow history、并发锁、
-两类旧 provider 配置、显式恢复、Akasha staging 重建和 append-only policy。每个 pytest
+两类旧 provider 配置、显式恢复、Akasha 状态零读写和 append-only policy。每个 pytest
 case 及源码不变性、Compose cleanup 结果记录在
 `docker/debug/reports/migrations/<run-id>/gate.json`。新增 migration bundle 前先按
 [迁移维护手册](../../docs/design/git-migration-authoring.md)补齐来源 lineage 和相应 case。

--- a/docs/design/git-migration-authoring.md
+++ b/docs/design/git-migration-authoring.md
@@ -73,6 +73,8 @@
 7. `apply` 必须可重试：发布后、cursor 前崩溃时，下次 `assess` 应识别已完成效果，`verify` 成功后推进，而不是重复产生业务变化。
 8. 不在迁移脚本中调用网络、LLM、provider 或易变的 runtime/UI 内部实现。历史迁移必须能在未来 checkout 中离线执行。
 
+如果已合入的 bundle 本身会在 correction 运行前产生不可接受的副作用，修正原脚本是唯一可恢复方案。此时必须新增 `migrations/repairs/<语义名称>.toml`，用 `path`、`base_sha256` 和 `head_sha256` 锁定唯一允许的字节变化，并记录 `reason`。repair 声明本身仍只追加；hash 不匹配或未实际修改目标都会使 Gate 失败。不得用 repair 变更已经成功发布的业务语义。
+
 ## 4. 代码评审检查表
 
 评审每个迁移时逐项回答：
@@ -126,7 +128,7 @@ Docker probe 复用 runtime control Gate 镜像，把候选源码只读挂载到
 | nested legacy provider 配置 | role、字段、secret 和未知配置无损进入 named runtimes |
 | root-level legacy 模型字段 | 一次迁移为 named runtimes |
 | legacy 与 named runtime 混杂 | blocked，不猜测合并 |
-| 旧 Akasha DB | staging rebuild、原库备份、marker/integrity 通过，sessions 消息不变 |
+| 现存 Akasha DB | provider 配置迁移不读写、不备份、不重建 Akasha 状态 |
 | 人工 revert | 从对应 backup 精确恢复旧配置字节 |
 | append-only policy | 允许新 bundle，拒绝修改旧 bundle 或追加 helper |
 

--- a/docs/spark/2026-07-21-git-backed-one-shot-migrations-design.md
+++ b/docs/spark/2026-07-21-git-backed-one-shot-migrations-design.md
@@ -260,8 +260,8 @@ runner 在 runtime 初始化和 provider 构造之前运行。配置迁移完成
 |---|---|---|---|
 | `config.toml` | 经 bundle 声明的字段映射，原子替换，保留未迁移字段 | 静默删除未知字段、泄露 API key、用模板覆盖旧配置 | 权限受限的原文件备份、前后结构摘要、最终 Config load |
 | cursor sidecar | 首次创建；成功后原子推进 SHA | verify 前越过提交、失败时写成 `HEAD`、自动删除 | cursor 文件及 Git ancestry |
-| `sessions.db`/消息 | 首批迁移默认只读 | UPDATE/DELETE 历史消息、因派生重建改变正文 | SQLite backup、integrity check、规范化 write set |
-| `akasha.db` | 由固定 sessions/embedding 输入重建并原子替换 | embedding 缺失时跳过后声称成功；直接清空正式库再重建 | 旧库 backup、新库 integrity/parity、原子 swap manifest |
+| `sessions.db`/消息 | 本 bundle 不读写 | 任何 UPDATE/DELETE 或派生重建 | 迁移前后文件摘要 |
+| `akasha.db` | 本 bundle 不读写 | 备份、重建、marker、替换或删除 | 迁移前后文件摘要 |
 | migration backups | 每次实际 apply 前增加唯一快照 | 自动按启动次数或年龄删除 | manifest、hash、SQLite integrity check、隔离恢复 smoke |
 
 备份目录和包含 secret 的临时文件使用目录模式 `0700`、文件模式 `0600`。自动迁移不 prune 历史备份；清理由以后独立、显式的数据管理操作负责。
@@ -278,15 +278,7 @@ runner 在 runtime 初始化和 provider 构造之前运行。配置迁移完成
 - legacy 与新结构混杂且无法确定优先级时返回 `BLOCKED`，不猜测覆盖。
 - 发布后使用当前配置边界重新加载，并证明角色都能解析到预期 runtime。
 
-### 11.2 Akasha 派生库重建
-
-- `sessions.db/messages` 和已有 `message_embeddings` 是固定输入，迁移不得调用 LLM 或重新解释历史。
-- 没有 `akasha.db` 时返回 `SATISFIED`；现存库需要按新 turn 语义重建。
-- 先备份原库，再在唯一 staging 路径调用重建逻辑。
-- 任一 embedding miss、模型不匹配、SQLite integrity 失败或图 parity 失败都中止发布。
-- staging 验证完成后原子替换 `akasha.db`；旧库保留在 migration backup 中。
-
-两个阶段中任何一个失败，首个 migration commit 的 cursor 都不推进。重试时已成功发布的前一阶段通过 `assess`/`verify` 识别，不重复产生有效变化。
+Akasha 派生库与 provider runtime 配置没有同一个不变量，不属于本 bundle。需要重建时必须由独立、显式的数据管理操作发起，不得阻塞常规 runtime 启动。
 
 ## 12. 性能模型
 

--- a/migrations/provider_runtimes_and_akasha/migration.py
+++ b/migrations/provider_runtimes_and_akasha/migration.py
@@ -6,12 +6,8 @@ import json
 import os
 import re
 import shutil
-import sqlite3
-import subprocess
-import sys
 import tempfile
 from collections.abc import MutableMapping
-from contextlib import closing
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,12 +17,8 @@ from uuid import uuid4
 import tomlkit
 
 from agent.config import Config
-from plugins.akasha.config import load_akasha_config, resolve_akasha_db_path
 
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_AKASHA_MARKER = "012e37c8-akasha-complete-turns-v1"
-_MARKER_TABLE = "akashic_migration_markers"
 _ROLE_NAMES = ("main", "fast", "agent", "vl")
 _RUNTIME_ID_RE = re.compile(r"[^a-z0-9_]+")
 _ROOT_ROLE_FIELDS = {
@@ -275,134 +267,6 @@ def _backup_file(source: Path, destination: Path) -> dict[str, str]:
     }
 
 
-def _backup_sqlite(source: Path, destination: Path) -> dict[str, str]:
-    with closing(sqlite3.connect(source)) as source_db, closing(
-        sqlite3.connect(destination)
-    ) as backup_db:
-        _ = source_db.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
-        source_db.backup(backup_db)
-        integrity = backup_db.execute("PRAGMA integrity_check").fetchone()
-    if integrity != ("ok",):
-        raise RuntimeError(f"SQLite 备份完整性检查失败: {destination}")
-    os.chmod(destination, 0o600)
-    return {
-        "source": str(source),
-        "backup": str(destination),
-        "sha256": _sha256(destination),
-    }
-
-
-def _akasha_db_path(workspace: Path) -> Path:
-    config = load_akasha_config(workspace=workspace)
-    return resolve_akasha_db_path(workspace=workspace, akasha_config=config)
-
-
-def _akasha_has_marker(db_path: Path) -> bool:
-    if not db_path.exists():
-        return True
-    with closing(
-        sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    ) as database:
-        table = database.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
-            (_MARKER_TABLE,),
-        ).fetchone()
-        if table is None:
-            return False
-        row = database.execute(
-            f"SELECT 1 FROM {_MARKER_TABLE} WHERE migration_id = ?",
-            (_AKASHA_MARKER,),
-        ).fetchone()
-    return row is not None
-
-
-def _embedding_model(context: MigrationContext, db_path: Path) -> str:
-    if context.config_path.exists():
-        return Config.load(
-            context.config_path, workspace=context.workspace
-        ).memory.embedding.model
-    with closing(
-        sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    ) as database:
-        row = database.execute(
-            """
-            SELECT embedding_model
-            FROM akasha_migration_runs
-            WHERE embedding_model != ''
-            ORDER BY started_at DESC
-            LIMIT 1
-            """
-        ).fetchone()
-    if row is None:
-        raise RuntimeError("缺少 config.toml，且旧 Akasha 库没有 embedding model 记录")
-    return str(row[0])
-
-
-def _rebuild_akasha(
-    context: MigrationContext,
-    db_path: Path,
-    records: list[dict[str, str]],
-) -> None:
-    assert context.backup_dir is not None
-    backup_path = context.backup_dir / "akasha.db"
-    records.append(_backup_sqlite(db_path, backup_path))
-    staging = db_path.with_name(f".{db_path.name}.migration-{uuid4().hex}.tmp")
-    command = [
-        sys.executable,
-        str(_PROJECT_ROOT / "scripts" / "build_akasha_db.py"),
-        "--config",
-        str(context.config_path),
-        "--workspace",
-        str(context.workspace),
-        "--db-path",
-        str(staging),
-        "--embedding-model",
-        _embedding_model(context, db_path),
-    ]
-    try:
-        result = subprocess.run(
-            command,
-            cwd=_PROJECT_ROOT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip()
-            raise RuntimeError(f"Akasha staging 重建失败: {detail[-4000:]}")
-        with closing(sqlite3.connect(staging)) as database:
-            _ = database.execute(
-                f"""
-                CREATE TABLE IF NOT EXISTS {_MARKER_TABLE} (
-                    migration_id TEXT PRIMARY KEY,
-                    migration_commit TEXT NOT NULL
-                )
-                """
-            )
-            _ = database.execute(
-                f"INSERT OR REPLACE INTO {_MARKER_TABLE} VALUES (?, ?)",
-                (_AKASHA_MARKER, context.migration_commit),
-            )
-            database.commit()
-            integrity = database.execute("PRAGMA integrity_check").fetchone()
-        if integrity != ("ok",):
-            raise RuntimeError(f"Akasha staging 完整性检查失败: {staging}")
-        os.replace(staging, db_path)
-        for suffix in ("-wal", "-shm"):
-            sidecar = Path(f"{db_path}{suffix}")
-            if sidecar.exists():
-                sidecar.unlink()
-        _fsync_directory(db_path.parent)
-    finally:
-        if staging.exists():
-            staging.unlink()
-        for suffix in ("-wal", "-shm"):
-            sidecar = Path(f"{staging}{suffix}")
-            if sidecar.exists():
-                sidecar.unlink()
-
-
 def _apply(context: MigrationContext) -> None:
     if context.backup_dir is None:
         raise RuntimeError("apply 缺少 --backup-dir")
@@ -429,11 +293,6 @@ def _apply(context: MigrationContext) -> None:
             if candidate.exists():
                 candidate.unlink()
 
-    # 2. Akasha 只从 sessions 和 embedding cache 构建 staging 后原子发布。
-    db_path = _akasha_db_path(context.workspace)
-    if db_path.exists() and not _akasha_has_marker(db_path):
-        _rebuild_akasha(context, db_path, records)
-
     manifest = {
         "migrationCommit": context.migration_commit,
         "files": records,
@@ -450,17 +309,6 @@ def _verify(context: MigrationContext) -> None:
         raise RuntimeError(f"配置迁移验证失败: {assessment.reason or assessment.state}")
     if assessment.state == "current":
         _ = Config.load(context.config_path, workspace=context.workspace)
-    db_path = _akasha_db_path(context.workspace)
-    if not db_path.exists():
-        return
-    if not _akasha_has_marker(db_path):
-        raise RuntimeError(f"Akasha 迁移 marker 缺失: {db_path}")
-    with closing(
-        sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    ) as database:
-        integrity = database.execute("PRAGMA integrity_check").fetchone()
-    if integrity != ("ok",):
-        raise RuntimeError(f"Akasha 完整性检查失败: {db_path}")
 
 
 def _restore_file(backup: Path, target: Path) -> None:
@@ -473,18 +321,13 @@ def _revert(context: MigrationContext) -> None:
     config_backup = context.backup_dir / "config.toml"
     if config_backup.exists():
         _restore_file(config_backup, context.config_path)
-    akasha_backup = context.backup_dir / "akasha.db"
-    if akasha_backup.exists():
-        _restore_file(akasha_backup, _akasha_db_path(context.workspace))
 
 
 def _assess(context: MigrationContext) -> dict[str, str]:
     assessment = _config_assessment(context.config_path)
     if assessment.state == "blocked":
         return {"status": "blocked", "reason": assessment.reason}
-    db_path = _akasha_db_path(context.workspace)
-    akasha_needed = db_path.exists() and not _akasha_has_marker(db_path)
-    if assessment.state == "legacy" or akasha_needed:
+    if assessment.state == "legacy":
         return {"status": "needed"}
     return {"status": "satisfied"}
 

--- a/migrations/repairs/provider-runtimes-config-only.toml
+++ b/migrations/repairs/provider-runtimes-config-only.toml
@@ -1,0 +1,4 @@
+path = "migrations/provider_runtimes_and_akasha/migration.py"
+base_sha256 = "9ae54327438a55cfaecf62ac6d7a3bc4d7385eedb0ca6ec8a47fcc6d5aa5cd29"
+head_sha256 = "01c2394aa2e8bda5c0839b44537d052dba849e20ac01319296f85c6947d30fcf"
+reason = "Provider runtime adoption must not rebuild or mutate Akasha state."

--- a/scripts/check_migrations_append_only.py
+++ b/scripts/check_migrations_append_only.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import subprocess
+import tomllib
 from pathlib import Path
 
 
@@ -39,12 +41,56 @@ def _framework_exists(base: str) -> bool:
     return result.returncode == 0
 
 
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _authorized_repairs(base: str) -> dict[str, tuple[str, str]]:
+    """读取本 diff 新增的精确 hash 修复声明。"""
+
+    output = _git(
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{base}...HEAD",
+        "--",
+        "migrations/repairs/*.toml",
+    )
+    repairs: dict[str, tuple[str, str]] = {}
+    for raw_path in output.splitlines():
+        document = tomllib.loads(Path(raw_path).read_text(encoding="utf-8"))
+        path = str(document["path"])
+        repairs[path] = (
+            str(document["base_sha256"]),
+            str(document["head_sha256"]),
+        )
+    return repairs
+
+
+def _matches_repair(base: str, path: str, hashes: tuple[str, str]) -> bool:
+    base_content = subprocess.run(
+        ["git", "show", f"{base}:{path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if base_content.returncode != 0:
+        return False
+    current = Path(path)
+    return current.is_file() and hashes == (
+        _sha256_bytes(base_content.stdout),
+        _sha256_bytes(current.read_bytes()),
+    )
+
+
 def check_append_only(base: str) -> list[str]:
     """返回违反迁移历史只追加规则的 Git diff 记录。"""
 
     if not _framework_exists(base):
         return []
     existing_bundles = _base_bundles(base)
+    repairs = _authorized_repairs(base)
+    used_repairs: set[str] = set()
     output = _git(
         "diff",
         "--name-status",
@@ -57,6 +103,14 @@ def check_append_only(base: str) -> list[str]:
         fields = line.split("\t")
         status = fields[0]
         paths = fields[1:]
+        if (
+            status == "M"
+            and len(paths) == 1
+            and paths[0] in repairs
+            and _matches_repair(base, paths[0], repairs[paths[0]])
+        ):
+            used_repairs.add(paths[0])
+            continue
         if status != "A":
             violations.append(line)
             continue
@@ -65,6 +119,8 @@ def check_append_only(base: str) -> list[str]:
             if len(parts) < 3 or parts[1] in existing_bundles:
                 violations.append(line)
                 break
+    for path in sorted(repairs.keys() - used_repairs):
+        violations.append(f"unused repair declaration\t{path}")
     return violations
 
 

--- a/tests/test_migration_append_only.py
+++ b/tests/test_migration_append_only.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -75,3 +76,54 @@ def test_existing_bundle_cannot_gain_helper(
 
     assert len(violations) == 1
     assert "migrations/existing/helper.py" in violations[0]
+
+
+def test_exact_hash_repair_can_change_existing_bundle(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    repo, base = _repository(tmp_path)
+    migration = repo / "migrations" / "existing" / "migration.py"
+    before = hashlib.sha256(migration.read_bytes()).hexdigest()
+    migration.write_text("print('repaired')\n", encoding="utf-8")
+    after = hashlib.sha256(migration.read_bytes()).hexdigest()
+    repairs = repo / "migrations" / "repairs"
+    repairs.mkdir()
+    (repairs / "existing-config-only.toml").write_text(
+        f'''path = "migrations/existing/migration.py"
+base_sha256 = "{before}"
+head_sha256 = "{after}"
+reason = "Remove an unintended workspace side effect."
+''',
+        encoding="utf-8",
+    )
+    _ = _git(repo, "add", "migrations")
+    _ = _git(repo, "commit", "-m", "repair migration")
+    monkeypatch.chdir(repo)
+
+    assert check_append_only(base) == []
+
+
+def test_repair_hash_mismatch_is_rejected(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    repo, base = _repository(tmp_path)
+    migration = repo / "migrations" / "existing" / "migration.py"
+    before = hashlib.sha256(migration.read_bytes()).hexdigest()
+    migration.write_text("print('unreviewed')\n", encoding="utf-8")
+    repairs = repo / "migrations" / "repairs"
+    repairs.mkdir()
+    (repairs / "bad.toml").write_text(
+        f'''path = "migrations/existing/migration.py"
+base_sha256 = "{before}"
+head_sha256 = "{'0' * 64}"
+reason = "Incorrect digest."
+''',
+        encoding="utf-8",
+    )
+    _ = _git(repo, "add", "migrations")
+    _ = _git(repo, "commit", "-m", "bad repair")
+    monkeypatch.chdir(repo)
+
+    violations = check_append_only(base)
+
+    assert any("migrations/existing/migration.py" in item for item in violations)

--- a/tests/test_provider_runtime_akasha_migration.py
+++ b/tests/test_provider_runtime_akasha_migration.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
-import sqlite3
 import tomllib
-from contextlib import closing
 from pathlib import Path
 
 from agent.config import Config
 from migrations.provider_runtimes_and_akasha.migration import (
     MigrationContext,
-    _akasha_db_path,
-    _akasha_has_marker,
     _apply,
     _config_assessment,
     _verify,
     _revert,
 )
-from plugins.akasha.store import AkashaStore
-from session.store import SessionStore
 
 _LEGACY_CONFIG = """\
 [runtime]
@@ -148,27 +142,16 @@ def test_explicit_revert_restores_exact_legacy_config(tmp_path: Path) -> None:
     assert _config_assessment(context.config_path).state == "legacy"
 
 
-def test_akasha_rebuild_uses_staging_and_marks_completed(tmp_path: Path) -> None:
+def test_config_migration_does_not_touch_akasha_state(tmp_path: Path) -> None:
     context = _context(tmp_path)
     context.config_path.write_text(_LEGACY_CONFIG, encoding="utf-8")
-    context.workspace.mkdir(parents=True)
-    session_store = SessionStore(context.workspace / "sessions.db")
-    session_store.close()
-    db_path = _akasha_db_path(context.workspace)
+    db_path = context.workspace / "memory" / "akasha.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    AkashaStore(db_path).close()
-    with closing(sqlite3.connect(context.workspace / "sessions.db")) as database:
-        before_messages = database.execute(
-            "SELECT id, session_key, seq, role, content FROM messages ORDER BY id"
-        ).fetchall()
+    original = b"akasha-state-must-remain-opaque"
+    db_path.write_bytes(original)
 
     _apply(context)
     _verify(context)
 
-    assert _akasha_has_marker(db_path)
-    assert (context.backup_dir / "akasha.db").exists()
-    with closing(sqlite3.connect(context.workspace / "sessions.db")) as database:
-        after_messages = database.execute(
-            "SELECT id, session_key, seq, role, content FROM messages ORDER BY id"
-        ).fetchall()
-    assert after_messages == before_messages
+    assert db_path.read_bytes() == original
+    assert not (context.backup_dir / "akasha.db").exists()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：provider runtime adoption migration 在转换 `config.toml` 后错误同步重建正式 `akasha.db`，导致启动长时间阻塞。
- 用户可见结果：旧配置仅转换为 named runtimes；迁移不再读写、备份或重建 Akasha 状态。
- 本 PR 不处理：Akasha 离线重建和派生数据语义升级。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：旧 provider 配置的一次性 adoption
- `runtime_patch`：`required`
- `runtime_patch_reason`：启动前 migration 是错误副作用的 owner
- `authoritative_state_owner`：`config.toml` 由 Config loader 拥有；Akasha 状态不在本迁移范围
- `client_only_alternative`：不适用
- 关联不变量：provider 配置迁移不得改变 workspace 派生状态
- `protected_state`：`sessions.db`、`memory/akasha.db`、既有 migration backup
- 允许的副作用：备份并原子替换 legacy `config.toml`，推进 migration cursor
- 禁止的副作用：启动 `build_akasha_db.py`，读写或替换 Akasha DB

## 改动范围

- 主要文件：`migrations/provider_runtimes_and_akasha/migration.py`、`scripts/check_migrations_append_only.py`、相关测试与迁移手册
- 配置或迁移影响：保留 provider runtime 字段映射，删除 Akasha rebuild/marker/verify/revert 路径
- 已知 schema lineage 与最终 schema identity：legacy root/nested LLM 字段到当前 named runtime schema
- 协议 source、runtime、provider 与 scenario 的不可变 revision：`639b0a2b5b9cfde79ff4745f14a4d7c0dd36c98b`
- 回滚方式：revert 本提交；已转换配置可使用迁移 backup 显式恢复

## 验证

- [x] 27 个 migration/runner/startup targeted tests 通过。
- [x] Pyright 0 errors。
- [x] `python docker/debug/migration_probe.py` 通过，27/27 cases，容器清理成功且候选仓库摘要不变。
- [x] `python docker/debug/gate.py run --base origin/main` 通过。
- [x] 真实环境启动验证：runtime 成功 ready，无 migration/build 子进程，`akasha.db` size/mtime 不变。
- `sourceDigest`：`134c7e310d1aa80b9e36772dfe0fc9f8d0477cecea7d4fe1dd18ccb639d4ba98`
- `planDigest`：`32a6070bb31c4af372ad50d9eb44a5cadae0d78afadd0cb36a0c48ad90237c32`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项：private provider identity Gate 待维护者执行

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次是把已确认范围收窄为 config-only，已同步设计和维护手册。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 无对应未完成事项。
