### PR TITLE
[codex] 修复 Akasha 引用回复轮次漏向量

### DIFF
--- a/agent/lifecycle/phases/after_turn.py
+++ b/agent/lifecycle/phases/after_turn.py
@@ -122,6 +122,7 @@ class _BuildTurnCommittedModule:
             if isinstance(raw_react_stats, dict)
             else None
         )
+        raw_user_message_id = snap.outbound.metadata.get("persisted_user_message_id")
         frame.slots[_TURN_COMMITTED_SLOT] = TurnCommitted(
             session_key=state.session_key,
             channel=msg.channel,
@@ -131,6 +132,11 @@ class _BuildTurnCommittedModule:
             assistant_response=snap.ctx.reply,
             tools_used=list(snap.ctx.tools_used),
             turn_id=current_turn_id.get(),
+            persisted_user_message_id=(
+                raw_user_message_id
+                if isinstance(raw_user_message_id, str) and raw_user_message_id
+                else None
+            ),
             assistant_message_id=snap.outbound.session_message_id,
             thinking=snap.ctx.thinking,
             raw_reply=snap.ctx.response_metadata.raw_text,

--- a/bus/events_lifecycle.py
+++ b/bus/events_lifecycle.py
@@ -72,6 +72,7 @@ class TurnCommitted:
     assistant_response: str
     tools_used: list[str]
     turn_id: str = ""
+    persisted_user_message_id: str | None = None
     assistant_message_id: str | None = None
     thinking: str | None = None
     raw_reply: str | None = None

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1407,54 +1407,54 @@ def _load_committed_turn_messages(
     session_db_path: Path,
     event: TurnCommitted,
 ) -> list[SourceMessage]:
-    # 1. after-turn 发生在 append_messages 后，这里用内容和相邻 seq 反查稳定 id。
-    if not session_db_path.exists() or not (event.persisted_user_message or event.input_message):
+    """按权威持久化消息 ID 读取已提交的一轮消息。"""
+
+    # 1. 不持久化 user 的系统轮次没有可写入 Akasha 的消息。
+    if event.persisted_user_message is None:
         return []
-    user_text = event.persisted_user_message or event.input_message
+    if not session_db_path.exists():
+        raise FileNotFoundError(session_db_path)
+    if not event.persisted_user_message_id:
+        raise ValueError("TurnCommitted 缺少 persisted_user_message_id")
+    if not event.assistant_message_id:
+        raise ValueError("TurnCommitted 缺少 assistant_message_id")
+
+    # 2. 稳定 ID 是提交边界拥有的不变量；正文可能是引用回复增强后的运行时视图。
     with closing(sqlite3.connect(str(session_db_path))) as db:
         db.row_factory = sqlite3.Row
-        row = db.execute(
+        rows = db.execute(
             """
-            SELECT
-                u.id AS user_id, u.session_key AS session_key, u.seq AS user_seq,
-                u.content AS user_content, u.ts AS user_ts,
-                a.id AS assistant_id, a.seq AS assistant_seq,
-                a.content AS assistant_content, a.ts AS assistant_ts
-            FROM messages u
-            LEFT JOIN messages a
-                ON a.session_key = u.session_key
-               AND a.seq = u.seq + 1
-               AND a.role = 'assistant'
-               AND a.content = ?
-            WHERE u.session_key = ?
-              AND u.role = 'user'
-              AND u.content = ?
-            ORDER BY u.seq DESC
-            LIMIT 1
+            SELECT id, session_key, seq, role, content, ts
+            FROM messages
+            WHERE id IN (?, ?)
             """,
-            (event.assistant_response, event.session_key, user_text),
-        ).fetchone()
-    if row is None:
-        return []
-    messages = [
-        SourceMessage(
-            id=str(row["user_id"]),
-            session_key=str(row["session_key"]),
-            seq=int(row["user_seq"]),
-            role="user",
-            content=str(row["user_content"] or ""),
-            ts=str(row["user_ts"] or ""),
-        )
-    ]
-    if row["assistant_id"] is not None:
+            (event.persisted_user_message_id, event.assistant_message_id),
+        ).fetchall()
+    by_id = {str(row["id"]): row for row in rows}
+
+    # 3. ID 已声明持久化成功，缺行或身份错位属于内部契约违反。
+    expected = (
+        (event.persisted_user_message_id, "user"),
+        (event.assistant_message_id, "assistant"),
+    )
+    messages: list[SourceMessage] = []
+    for message_id, role in expected:
+        row = by_id.get(message_id)
+        if row is None:
+            raise ValueError(f"TurnCommitted 消息不存在: {message_id}")
+        if row["session_key"] != event.session_key or row["role"] != role:
+            raise ValueError(
+                "TurnCommitted 消息身份不匹配: "
+                f"id={message_id} session={row['session_key']} role={row['role']}"
+            )
         messages.append(
             SourceMessage(
-                id=str(row["assistant_id"]),
+                id=message_id,
                 session_key=str(row["session_key"]),
-                seq=int(row["assistant_seq"]),
-                role="assistant",
-                content=str(row["assistant_content"] or ""),
-                ts=str(row["assistant_ts"] or ""),
+                seq=int(row["seq"]),
+                role=role,
+                content=str(row["content"] or ""),
+                ts=str(row["ts"] or ""),
             )
         )
     return messages

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -47,6 +47,7 @@ from plugins.akasha.engine import (
     PendingActivation,
     _AkashaRetrieval,
     _compute_candidates,
+    _load_committed_turn_messages,
     _load_turn_card,
 )
 from plugins.akasha.core import (
@@ -1274,16 +1275,22 @@ async def test_runtime_writes_message_embeddings_to_sessions_db(tmp_path: Path) 
     engine._message_turn_keys = {}
     engine._message_timestamps = {}
     engine._message_index = build_dense_message_index({})
+    enriched_input = (
+        "【你正在回复一条历史消息】\n旧回答\n\n"
+        "【你当前新消息】\n第一条用户消息需要完整展示"
+    )
     try:
         await engine._on_turn_committed(
             TurnCommitted(
                 session_key="s",
                 channel="telegram",
                 chat_id="1",
-                input_message="第一条用户消息需要完整展示",
-                persisted_user_message="第一条用户消息需要完整展示",
+                input_message=enriched_input,
+                persisted_user_message=enriched_input,
                 assistant_response="第一条助手回复会被截断展示并保留引用",
                 tools_used=[],
+                persisted_user_message_id="s:0",
+                assistant_message_id="s:1",
             )
         )
 
@@ -1334,6 +1341,8 @@ async def test_runtime_rejects_partial_embedding_batch(tmp_path: Path) -> None:
                     persisted_user_message="第一条用户消息需要完整展示",
                     assistant_response="第一条助手回复会被截断展示并保留引用",
                     tools_used=[],
+                    persisted_user_message_id="s:0",
+                    assistant_message_id="s:1",
                 )
             )
 
@@ -1345,6 +1354,25 @@ async def test_runtime_rejects_partial_embedding_batch(tmp_path: Path) -> None:
     finally:
         embedding_store.close()
         graph_store.close()
+
+
+def test_load_committed_turn_messages_requires_stable_ids(tmp_path: Path) -> None:
+    db_path = tmp_path / "sessions.db"
+    _init_sessions_db(db_path)
+
+    with pytest.raises(ValueError, match="persisted_user_message_id"):
+        _load_committed_turn_messages(
+            db_path,
+            TurnCommitted(
+                session_key="s",
+                channel="mobile",
+                chat_id="1",
+                input_message="增强后的运行时输入",
+                persisted_user_message="增强后的运行时输入",
+                assistant_response="第一条助手回复会被截断展示并保留引用",
+                tools_used=[],
+            ),
+        )
 
 
 def test_load_turn_card_uses_full_user_and_short_assistant(tmp_path: Path) -> None:

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -1667,6 +1667,7 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
                 channel=msg.channel,
                 chat_id=msg.chat_id,
                 content="reply",
+                metadata={"persisted_user_message_id": "telegram:123:0"},
                 session_message_id="telegram:123:1",
             ),
             ctx=ctx,
@@ -1674,5 +1675,6 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
     )
 
     assert committed_extra[0]["plugin_flag"] == "extra"
+    assert committed_events[0].persisted_user_message_id == "telegram:123:0"
     assert committed_events[0].assistant_message_id == "telegram:123:1"
     assert after_turn_metadata == [{"plugin_flag": "telemetry"}]


### PR DESCRIPTION
## 问题与结果

- 解决的问题：移动端引用回复会把增强后的运行时输入写入 `TurnCommitted`，Akasha 再按正文精确反查持久化消息；数据库只保存展示原文，因此整轮反查为空并漏写 user/assistant 向量。
- 用户可见结果：已持久化的引用回复轮次按 canonical message ID 进入公共 embedding cache 和 Akasha 图，不再依赖正文或相邻序号猜测身份。
- 本 PR 不处理：embedding 最终失败后的持久化补偿队列，以及 assistant-only 主动消息是否进入公共 embedding cache。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Core TurnCommitted 生命周期事件与 Akasha memory plugin
- `runtime_patch`：`required`
- `runtime_patch_reason`：canonical user message ID 由 Core 的持久化提交边界拥有，插件不能从正文可靠重建。
- `authoritative_state_owner`：`sessions.db/messages` 由 SessionManager 拥有；`message_embeddings` 与 Akasha 图是受保护派生索引。
- `client_only_alternative`：不适用；移动端已经正确传递原文和 reply identity，缺陷位于服务端提交事件与插件消费边界。
- 关联不变量：消息正文只追加；运行时增强视图不得反向替代权威消息身份；内部持久化身份违反必须 fail-loud。
- `protected_state`：既有消息正文、顺序、turn 状态、其他 embedding、正式 Akasha 图。
- 允许的副作用：后续已提交引用回复正常新增对应消息向量和图节点。
- 禁止的副作用：修改或删除既有消息；用正文、相邻 seq 或静默 fallback 掩盖缺失 ID。

## 改动范围

- 主要文件：`bus/events_lifecycle.py`、`agent/lifecycle/phases/after_turn.py`、`plugins/akasha/engine.py` 及对应测试。
- 配置或迁移影响：无配置和 schema 迁移。
- 已知 schema lineage 与最终 schema identity：不适用，未修改 schema。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `6b731a901afb67ae800a9dd574cac9a3617f077f`，head `b701dbeb`；公开 Gate report `20260722-235402-731b368c`。
- 回滚方式：revert 本提交；没有权威消息数据迁移需要回滚。

## 验证

- [x] 相关 targeted tests 已通过：`97 passed`。
- [x] Python 类型检查已通过：`basedpyright` 为 `0 errors`（5 条既有 Unknown 类型 warning）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过全部选中公开场景。
- `sourceDigest`：`49e8a90303b7cdc190a30f0f4d40049c872cf229090bb3e987ce38693a49fac5`
- `planDigest`：`f3abbaecea74ab1168a02f5cb937dfc2e48f30172b181dc17768dc55b12ca8e1`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；服务端持久化身份与 Akasha 插件回归由 isolated tests 和公开 mobile contract Gate 覆盖。
- 未运行项与原因：私有 Gate 需要维护者侧 provider identity。

## 工作手册

- [x] 已核对 `projectneed.md`、持久化状态地图和 `NOW.md`。
- [x] 本次修复既有不变量，没有新增长期产品语义。
- [x] 已按 MOB-001 核对：客户端无需改动，服务端 Core 拥有 canonical persisted ID。
- [x] 当前 `NOW.md` 没有对应完成事项需要删除。
