### PR TITLE
refactor(memory2): deduplicate embedding row decoding

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -63,6 +63,26 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none` / `PENDING`
 - 残余风险与回滚点：`PENDING`
 
+## 2026-07-22 less-is-more PR1：收敛 Memory2 embedding row 解码
+
+### `PR1` `refactor(memory2): deduplicate embedding row decoding`
+
+- 范围：`memory2/store.py` 中 `MemoryStore2.get_all_with_embedding` 与 `_get_embedding_rows_by_time_filter` 的 embedding DB row → `_EmbeddingRow` 解码；未修改测试文件。
+- `change_type`：`refactor`；`semantic_delta`：`none`。
+- 不变量与拥有层：`MemoryStore2` 继续拥有 SQL 行到 `_EmbeddingRow` 的解码、持久化 JSON/embedding 错误传播和内部 metadata 注入；查询 SQL 的 active/superseded、scope/time 过滤、vector dispatch/fallback、打分、写入、事务和 schema 仍由原有路径拥有。time-filter 路径仍先执行 `_is_memory_time_in_range`，范围外行不会进入 JSON 解码。
+- 实现：新增单一私有 `_decode_embedding_row` helper，合并原来重复的十列解包、embedding/extra JSON 解码、三项内部 metadata 注入和 tuple 构造；不增加动态 getattr、fallback 或新的抽象边界。
+- 错误语义：`_json_embedding` 与 `_json_object` 的异常类型及 `memory item <id> embedding/extra_json` context 文本保持不变；损坏数据继续 fail-fast。
+- baseline：source-set digest `9ade919edae8ca6fb7f0a7b778f367111f7a09b129b8d0dbab14ddede5e9f049`，文件数 `385`，Python SLOC `78,896`，memory2 SLOC `4,884`，total production SLOC `87,540`。
+- candidate：source-set digest `d3fae9c398b6a61e1a540af489726c41329926415f46b3a625e4911e7ce55a4e`，文件数 `385`，Python SLOC `78,867`，memory2 SLOC `4,855`，total production SLOC `87,511`。
+- 目标与实际 SLOC 变化：production 净减少 `29` 行；raw diff 为 `46 insertions(+), 67 deletions(-)`。未达到净减少则停止的条件已满足。
+- Redis 式 God file 判断：保留 `memory2/store.py`；解码 helper 与 SQL 查询、范围过滤和存储错误 owner 同属 `MemoryStore2`，拆到其他文件会增加跨文件跳转且没有新的 owner 边界。
+- 测试与真实验证：项目 venv 的 Memory2/recall/检索/持久化相关选择共 `73 passed`；覆盖两个 batch reuse、extra_json corruption、embedding corruption、time range、scope、候选上限、共享连接写入、consolidation idempotency 和 retrieval baseline；Pyright（正确 venvPath）为 `0 errors, 64 warnings`，无 helper 新诊断；`python scripts/measure_production_sloc.py --json` 与上述候选计量一致；`git diff --check` 通过。系统 Python 因缺少 `apscheduler` 无法收集测试，未将该环境失败计为代码失败。
+- 性能回放：同一临时 SQLite workload（2,000 rows、`vec_dim=2`、15 次预热、60 轮、CPU 固定、3 个交错 batch）分别覆盖 `get_all_with_embedding`、`_get_embedding_rows_by_time_filter` 和公开 `vector_search(time_start/time_end)`。candidate/base 中位数相对变化分别为 `+0.38%`（各 batch `+0.29%～+1.30%`）、`+0.64%`（`+0.08%～+0.84%`）和 `-0.08%`（`-0.17%～+0.55%`）；各场景 p10/p90 与 stdev 重叠，无稳定且实质性回退。
+- 测试调整：无；现有四个点名回归和直接相关 MemoryStore 测试已覆盖本次调用路径，未修改受保护 semantic tests。
+- Gate：Luna 交接前的候选 Gate 为 7 个公开场景全部通过、`privateGateRequired=true`，但其后发生了本段证据对账，因此只作为 preflight。最终 Gate 必须在本条目固化并提交后绑定 committed HEAD 重跑；为避免把运行后生成的 `sourceDigest` 回填到源文件、再次使报告失效，最终 report path、digest 和 private Gate 状态只记录在对应 PR 描述与 CI，不回写本账本。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、schema、数据库、正式 workspace、服务、远端数据或 Git refs。
+- 残余风险与回滚点：private contract 仍需维护者按最终 plan digest 完成或明确状态；合并前可把 stacked 分支恢复到基线 `c294db8c20a3766baa5cb069bb62caa265ff06ac`，合并后使用单提交 revert。执行前备份为 `/tmp/less-is-more-pr1-finish-OK1QvV`，主审对账前备份为 `/tmp/less-is-more-pr1-main-review-VDPIcO`。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/memory2/store.py
+++ b/memory2/store.py
@@ -1086,6 +1086,47 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
         filtered = [item for item in results if item.get("id") != item_id]
         return filtered[: max(1, top_k)]
 
+    @staticmethod
+    def _decode_embedding_row(row: tuple[object, ...]) -> _EmbeddingRow:
+        """将 embedding 查询行解码为统一的检索行。"""
+
+        # 1. 解包 embedding 查询所需的存储列
+        (
+            row_id,
+            mtype,
+            summary,
+            emb_json,
+            extra_json,
+            happened_at,
+            reinforcement,
+            updated_at,
+            source_ref,
+            emotional_weight,
+        ) = row
+
+        # 2. 在存储边界解析 JSON，保留原有错误上下文
+        emb = _json_embedding(
+            emb_json,
+            context=f"memory item {row_id} embedding",
+        )
+        extra = _json_object(
+            extra_json, context=f"memory item {row_id} extra_json"
+        )
+
+        # 3. 注入内部 metadata 并构造统一结果
+        extra["_reinforcement"] = _coerce_int(reinforcement, 1)
+        extra["_updated_at"] = str(updated_at) if updated_at else ""
+        extra["_emotional_weight"] = _coerce_emotional_weight(emotional_weight)
+        return (
+            str(row_id),
+            str(mtype),
+            str(summary),
+            emb,
+            extra,
+            str(happened_at) if happened_at else None,
+            str(source_ref) if source_ref else None,
+        )
+
     @_synchronized
     def get_all_with_embedding(self, include_superseded: bool = False) -> list[_EmbeddingRow]:
         """返回 [(id, memory_type, summary, embedding_list, extra_json_dict, happened_at, source_ref)]
@@ -1099,40 +1140,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
             f"FROM memory_items WHERE embedding IS NOT NULL {where}"
         ).fetchall())
         result: list[_EmbeddingRow] = []
+        decode_row = self._decode_embedding_row
         for row in rows:
-            (
-                row_id,
-                mtype,
-                summary,
-                emb_json,
-                extra_json,
-                happened_at,
-                reinforcement,
-                updated_at,
-                source_ref,
-                emotional_weight,
-            ) = row
-            emb = _json_embedding(
-                emb_json,
-                context=f"memory item {row_id} embedding",
-            )
-            extra = _json_object(
-                extra_json, context=f"memory item {row_id} extra_json"
-            )
-            extra["_reinforcement"] = _coerce_int(reinforcement, 1)
-            extra["_updated_at"] = str(updated_at) if updated_at else ""
-            extra["_emotional_weight"] = _coerce_emotional_weight(emotional_weight)
-            result.append(
-                (
-                    str(row_id),
-                    str(mtype),
-                    str(summary),
-                    emb,
-                    extra,
-                    str(happened_at) if happened_at else None,
-                    str(source_ref) if source_ref else None,
-                )
-            )
+            result.append(decode_row(row))
         return result
 
     def _get_embedding_rows_by_time_filter(
@@ -1175,42 +1185,11 @@ CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
             tuple(params),
         ).fetchall())
         result: list[_EmbeddingRow] = []
+        decode_row = self._decode_embedding_row
         for row in rows:
-            (
-                row_id,
-                mtype,
-                summary,
-                emb_json,
-                extra_json,
-                happened_at,
-                reinforcement,
-                updated_at,
-                source_ref,
-                emotional_weight,
-            ) = row
-            if not _is_memory_time_in_range(happened_at, time_start, time_end):
+            if not _is_memory_time_in_range(row[5], time_start, time_end):
                 continue
-            emb = _json_embedding(
-                emb_json,
-                context=f"memory item {row_id} embedding",
-            )
-            extra = _json_object(
-                extra_json, context=f"memory item {row_id} extra_json"
-            )
-            extra["_reinforcement"] = _coerce_int(reinforcement, 1)
-            extra["_updated_at"] = str(updated_at) if updated_at else ""
-            extra["_emotional_weight"] = _coerce_emotional_weight(emotional_weight)
-            result.append(
-                (
-                    str(row_id),
-                    str(mtype),
-                    str(summary),
-                    emb,
-                    extra,
-                    str(happened_at) if happened_at else None,
-                    str(source_ref) if source_ref else None,
-                )
-            )
+            result.append(decode_row(row))
         return result
 
     @_synchronized


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`MemoryStore2` 的两条 embedding 查询路径重复维护同一套十列解包、JSON 解码、内部 metadata 注入和结果构造，容易让持久化错误语义随两份实现漂移。
- 用户可见结果：无能力变化；两条查询路径复用同一个同文件解码 owner，生产 SLOC 净减少 29 行。
- 本 PR 不处理：不改查询条件、排序、向量路径、schema、迁移、持久数据、测试 oracle 或任何外部发送。
- Stacked 依赖：base 为 PR #146 的 `refactor/less-is-more-pr0@c294db8c20a3766baa5cb069bb62caa265ff06ac`。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`core`
- `consumer_scope`：Memory2 检索、召回和 dashboard 相似项查询
- `runtime_patch`：`none`
- `runtime_patch_reason`：只收敛 MemoryStore2 内部重复解码，不新增或改变核心能力
- `authoritative_state_owner`：`MemoryStore2.memory_items`；`vec_items` 仍只是派生索引
- `client_only_alternative`：`not_applicable`
- 关联不变量：OBJ-003、STA-001～STA-003、ERR-001、MEM-005、MEM-006、MEM-008、TST-001、TST-004
- `protected_state`：memory2 schema 与行内容、active/superseded 与 scope/time 过滤、结果顺序、JSON 损坏异常类型和上下文、数据库 write set、正式 workspace
- 允许的副作用：两份仓库文件、单个 commit、分支、PR、隔离测试和忽略的 Gate 报告
- 禁止的副作用：测试或语义 oracle 修改、migration/schema/数据库写入、正式 workspace、服务切换和外部发送

## 改动范围

- 主要文件：`memory2/store.py`、`docs/refactor/clean-code-ledger.md`
- 配置或迁移影响：无；migration append-only 检查通过
- 已知 schema lineage 与最终 schema identity：不适用，未修改 schema 或 migration
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `c294db8c20a3766baa5cb069bb62caa265ff06ac`；candidate `57b6478adcd0e6381971e63d1b783e4feb972ee0`；公开 Gate 使用仓库内固定 catalog，未读取 private provider identity
- 回滚方式：合并前关闭本 PR；合并后 revert `57b6478a`

## 语义与性能证据

- 两条 SQL 仍返回同样的十列；time-filter 路径仍在 JSON 解码前排除范围外行。
- `_json_embedding`、`_json_object`、错误上下文和 fail-fast 行为保持不变。
- production baseline：385 files / 87,540 SLOC / digest `9ade919edae8ca6fb7f0a7b778f367111f7a09b129b8d0dbab14ddede5e9f049`。
- production candidate：385 files / 87,511 SLOC / digest `d3fae9c398b6a61e1a540af489726c41329926415f46b3a625e4911e7ce55a4e`。
- 同一 2,000-row SQLite workload、15 次预热、60 轮、3 个交错 batch：`get_all_with_embedding` 中位数 `+0.38%`，time-filter helper `+0.64%`，公开 time-filter vector search `-0.08%`；p10/p90 与标准差重叠，没有稳定且实质性的性能回退。
- 测试未新增或删除；既有 corruption、time/scope、batch reuse、检索和持久化测试覆盖本次路径。

## 验证

- [x] Luna 定向回归：`73 passed`
- [x] 主 Agent 独立复跑关键时间/错误路径：`5 passed`
- [x] `.venv/bin/pyright memory2/store.py`：`0 errors, 64 warnings`，没有本 helper 新诊断
- [x] `python scripts/check_migrations_append_only.py --base refactor/less-is-more-pr0`：passed
- [x] `git diff --check refactor/less-is-more-pr0..HEAD`：passed
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr0`：7 个公开场景全部通过
- 最终 committed-head Gate report：`docker/debug/reports/change-gate/20260723-013029-b919a5b0`
- `sourceDigest`：`6684b574b4d9ea54f303ea4d55f6bdcafe8e8b8e5652432397fbc6de0372048a`
- `planDigest`：`2c9f4daf8eca89cfe80197fc21e482555cf4dfb28753917ec94c5f3fa2dea881`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate identity：`head=57b6478adcd0e6381971e63d1b783e4feb972ee0`，`dirtyStatus=[]`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；无客户端、APK、设备或实时 Gateway 改动
- 未运行项与原因：private companion 需要维护者私有 provider；公开工作树不读取其身份或源码

## 工作手册

- [x] 已核对 `projectneed.md`、相关设计、`NOW.md` 与持久化状态地图
- [x] 本次没有长期语义变化
- [x] 跨仓库或客户端改动不适用
- [x] 当前没有对应 `NOW.md` 完成事项

完整 SLOC、错误处理、注释、性能、测试和回滚记录见 `docs/refactor/clean-code-ledger.md`。
