### PR TITLE
refactor(telegram): remove unreachable retry helper

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -83,6 +83,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、schema、数据库、正式 workspace、服务、远端数据或 Git refs。
 - 残余风险与回滚点：private contract 仍需维护者按最终 plan digest 完成或明确状态；合并前可把 stacked 分支恢复到基线 `c294db8c20a3766baa5cb069bb62caa265ff06ac`，合并后使用单提交 revert。执行前备份为 `/tmp/less-is-more-pr1-finish-OK1QvV`，主审对账前备份为 `/tmp/less-is-more-pr1-main-review-VDPIcO`。
 
+## 2026-07-23 less-is-more PR2：删除 Telegram 不可达重试 helper
+
+### `PR2` `refactor(telegram): remove unreachable retry helper`
+
+- 范围：`infra/channels/telegram_utils.py` 中历史遗留的私有重试 helper；未修改发送、编辑、stream、`TelegramOutboundLimiter`、测试或 Gate catalog。
+- `change_type`：`refactor`；`semantic_delta`：`none`。
+- 历史与调用链：helper 最初随 Telegram 基础发送代码引入（`d7209415d4672`）；限流改造（`99ca25959def6`）后，生产入口统一经过 `_run_outbound`，有 limiter 时进入 `TelegramOutboundLimiter.run`，无 limiter 时进入现存的结果型 retry helper。全库静态搜索确认旧 helper 只有历史定义、无调用、无导出或动态反射读取，因此删除不改变任何可达路径。
+- 错误处理与不变量：可达路径的 `RetryAfter`、`TimedOut`、`NetworkError` 重试次数、backoff、日志、最后异常重抛和 fallback 均由原有结果型 helper/limiter 继续拥有；发送、编辑、stream、thinking block 的调用顺序和外部效果不变。删除的旧 helper 本身不可达，未移除任何能力。
+- baseline：source-set digest `d3fae9c398b6a61e1a540af489726c41329926415f46b3a625e4911e7ce55a4e`，文件数 `385`，Python SLOC `78,867`，TypeScript/TSX SLOC `8,644`，total production SLOC `87,511`。
+- candidate：source-set digest `91dd82e44398bc153bda147c9d175a3bd0299396228c370c13113e4395f371ac`，文件数 `385`，Python SLOC `78,825`，TypeScript/TSX SLOC `8,644`，total production SLOC `87,469`。
+- 目标与实际 SLOC 变化：`infra` 生产 SLOC 从 `11,394` 降至 `11,352`，总 production SLOC 净减少 `42`（raw diff `44 deletions`）；满足相对 PR1 基线至少减少 30 行的验收目标。运行时调用次数、重试等待和发送结果没有变化，不宣称额外性能收益。
+- Redis 式 God file 判断：保留 `infra/channels/telegram_utils.py`；删除不可达定义降低阅读成本，不拆分 Telegram 状态机、发送边界或错误 owner。
+- 测试与真实验证：项目 venv `pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py` 为 `29 passed`；修改文件 pyright `0 errors, 18 warnings`；`python scripts/check_migrations_append_only.py --base refactor/less-is-more-pr1` 通过；`git diff --check` 通过；全库搜索确认旧 helper 名称零残留，且没有动态导出/反射命中。
+- Gate：候选代码完成后的 preflight `python docker/debug/gate.py run --base refactor/less-is-more-pr1` 为 `passed`，公开场景按 `channel` 变更选择并要求 private Gate；账本不回填该次 source/plan digest，避免提交账本后产生 sourceDigest 自引用。最终 committed-head Gate、digest 和 private 状态由主 Agent 在提交后重跑并写入 PR。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送或 Git refs。
+- 残余风险与回滚点：仅保留结果型 retry helper 与 limiter 两套既有实现的职责边界；若后续发现外部反射依赖，应停止而非恢复兼容层。执行前备份为 `/tmp/less-is-more-pr2-finish-pW1LgA`；提交后可用单提交 revert `refactor(telegram): remove unreachable retry helper` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/channels/telegram_utils.py
+++ b/infra/channels/telegram_utils.py
@@ -234,50 +234,6 @@ async def _run_outbound(
     return await _send_with_retry_result(action, label=label)
 
 
-async def _send_with_retry(
-    send_coro_factory,
-    *,
-    label: str,
-    max_attempts: int = 3,
-    base_delay: float = 0.8,
-) -> None:
-    last_err: Exception | None = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            await send_coro_factory()
-            return
-        except RetryAfter as e:
-            last_err = e
-            if attempt >= max_attempts:
-                break
-            delay = max(float(getattr(e, "retry_after", 1.0) or 1.0), base_delay)
-            logger.warning(
-                "[telegram] %s 命中限流，准备重试 attempt=%d/%d delay=%.1fs err=%s",
-                label,
-                attempt,
-                max_attempts,
-                delay,
-                e,
-            )
-            await asyncio.sleep(delay)
-        except (TimedOut, NetworkError) as e:
-            last_err = e
-            if attempt >= max_attempts:
-                break
-            delay = base_delay * (2 ** (attempt - 1))
-            logger.warning(
-                "[telegram] %s 发送失败，准备重试 attempt=%d/%d delay=%.1fs err=%s",
-                label,
-                attempt,
-                max_attempts,
-                delay,
-                e,
-            )
-            await asyncio.sleep(delay)
-    if last_err is not None:
-        raise last_err
-
-
 def _serialize_entities(entities: list[MessageEntity]) -> list[dict] | None:
     return [entity.to_dict() for entity in entities] if entities else None
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Telegram 发送模块同时保留旧的无返回值 retry helper 和当前结果型 retry helper；旧 helper 在限流改造后已失去所有调用者，继续重复维护 42 SLOC 的重试、backoff、日志和异常代码。
- 用户可见结果：无能力变化；删除全库零调用的旧私有 helper，生产 SLOC 净减少 42 行。
- 本 PR 不处理：不改 live `_send_with_retry_result`、`TelegramOutboundLimiter`、发送/编辑/stream/thinking 路径、错误处理、测试或 Gate catalog。
- Stacked 依赖：base 为 PR #148 的 `refactor/less-is-more-pr1@57b6478adcd0e6381971e63d1b783e4feb972ee0`。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`core`
- `consumer_scope`：Telegram channel outbound
- `runtime_patch`：`none`
- `runtime_patch_reason`：只删除不可达私有定义，不改变任何可达 runtime 路径
- `authoritative_state_owner`：`not_applicable`
- `client_only_alternative`：`not_applicable`
- 关联不变量：OBJ-003、ERR-001、RUN-001、RUN-002、OUT-001、TST-001、TST-004
- `protected_state`：可达 retry 次数、RetryAfter/TimedOut/NetworkError 分类、backoff、日志、最后重抛、fallback、发送顺序和外部发送 write set
- 允许的副作用：两份仓库文件、单个 commit、分支、PR、隔离测试和忽略的 Gate 报告
- 禁止的副作用：live Telegram helper/limiter 修改、测试或 oracle 修改、数据库/workspace/service/network/外部发送

## 改动范围

- 主要文件：`infra/channels/telegram_utils.py`、`docs/refactor/clean-code-ledger.md`
- 配置或迁移影响：无；migration append-only 检查通过
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `57b6478adcd0e6381971e63d1b783e4feb972ee0`；candidate `5760cd1899a968e2afdcb15a3f4b59f4274cbfe7`
- 回滚方式：合并前关闭本 PR；合并后 revert `5760cd18`

## 死代码证据

- `_send_with_retry` 由 `d7209415d4672` 引入；`99ca25959def6` 的限流改造把生产入口统一到 `_run_outbound`。
- 当前 `_run_outbound` 有 limiter 时调用 `TelegramOutboundLimiter.run`，无 limiter 时调用 `_send_with_retry_result`。
- base 全库精确搜索仅命中旧 helper 定义；candidate 精确 symbol 搜索零残留。
- 没有 `__all__`、字符串注册、`getattr`、反射、测试 monkeypatch 或插件入口引用该私有名称。
- 删除内容不可达，因此 live 调用次数、等待时间和性能不变；不宣称运行时提速。

## 计量

- baseline：385 files / 87,511 production SLOC / digest `d3fae9c398b6a61e1a540af489726c41329926415f46b3a625e4911e7ce55a4e`。
- candidate：385 files / 87,469 production SLOC / digest `91dd82e44398bc153bda147c9d175a3bd0299396228c370c13113e4395f371ac`。
- 本 PR 净减少 42 SLOC（raw diff 44 deletions）；PR1+PR2 累计净减少 71 SLOC。

## 验证

- [x] Luna：`pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py` → `29 passed`
- [x] 主 Agent 独立复跑同一套 channel tests → `29 passed`
- [x] `.venv/bin/pyright infra/channels/telegram_utils.py` → `0 errors, 18 warnings`
- [x] migration append-only 与 `git diff --check` 通过
- [x] committed-head `python docker/debug/gate.py run --base refactor/less-is-more-pr1` → 7 个公开场景全部通过
- 最终 Gate report：`docker/debug/reports/change-gate/20260723-014112-e0076a3a`
- `sourceDigest`：`86b614d814f1aba77b476ec2ba54ee7abd4085d07727196c985ba84de4ab893a`
- `planDigest`：`42dabb2771764ebdfbb8cb7659b9ba7bef057d575981d68b468b77885be4b228`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate identity：`head=5760cd1899a968e2afdcb15a3f4b59f4274cbfe7`，`dirtyStatus=[]`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；无客户端、APK、设备或实时 Gateway 改动
- 未运行项与原因：private companion 需要维护者私有 provider；公开工作树不读取其身份或源码

## 工作手册

- [x] 已核对 `projectneed.md`、相关设计、`NOW.md` 和 clean-code ledger
- [x] 本次没有长期语义变化
- [x] 跨仓库或客户端改动不适用
- [x] 当前没有对应 `NOW.md` 完成事项

完整历史、错误处理、SLOC、测试、持久化与回滚记录见 `docs/refactor/clean-code-ledger.md`。
