### PR TITLE
refactor(plugins): remove dead manager helpers

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -2599,24 +2599,6 @@ class PluginManager:
             )
             logger.info("插件工具已注册: %s (来自 %s)", tool_name, plugin_name)
 
-    def _bind_handlers(
-        self,
-        instance: Any,
-        module_path: str,
-        scope: PluginScope,
-    ) -> None:
-        for md in plugin_registry.get_handlers_by_module_path(module_path):
-            # 1. Phase 1 只绑定生命周期 handler，TOOL 类型留给后续 phase
-            if md.kind != MetadataKind.LIFECYCLE:
-                continue
-            # 2. 跳过当前 phase 尚未支持的事件类型
-            ctx_type = _EVENT_TYPE_MAP.get(md.event_type)  # type: ignore[arg-type]
-            if ctx_type is None:
-                continue
-            # 3. 绑定 instance 为第一个参数，EventBus 已处理 sync/async，直接注册
-            bound = functools.partial(md.handler, instance)
-            _ = scope.subscribe(self._event_bus, ctx_type, bound)
-
     def _bind_tool_hooks(self, instance: Any, module_path: str) -> None:
         for md in plugin_registry.get_handlers_by_module_path(module_path):
             if md.kind != MetadataKind.TOOL_HOOK:
@@ -3106,22 +3088,6 @@ def _venv_python(venv_dir: Path) -> Path:
     if os.name == "nt":
         return venv_dir / "Scripts" / "python.exe"
     return venv_dir / "bin" / "python"
-
-
-def _collect_skill_names(skill_roots: tuple[Path, ...]) -> list[str]:
-    names: list[str] = []
-    seen: set[str] = set()
-    for root in skill_roots:
-        if not root.is_dir():
-            continue
-        for child in sorted(root.iterdir()):
-            if not child.is_dir() or not (child / "SKILL.md").exists():
-                continue
-            if child.name in seen:
-                continue
-            seen.add(child.name)
-            names.append(child.name)
-    return names
 
 
 def _build_plugin_tool(instance: Any, metadata: Any) -> Any:

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -135,6 +135,34 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、网络、外部发送或 Git refs。
 - 残余风险与回滚点：若未来出现外部反射依赖，应停止并补充真实迁移证据，不恢复兼容 helper；执行前备份为 `/tmp/less-is-more-pr4-finish-Jdazid`；提交后可用单提交 revert `refactor(provider): remove dead diagnostics helpers` 回滚。
 
+## 2026-07-23 less-is-more PR5：删除 PluginManager 不可达旧 helper
+
+### `PR5` `refactor(plugins): remove dead manager helpers`
+
+- base：PR4 commit `521db7f19bbfe02122578c620ec7040c31c89975`，分支 `refactor/less-is-more-pr5-plugin-manager-dead-helpers`。
+- allowed_paths：`agent/plugins/manager.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：PluginManager 的 event snapshot 与 skill catalog 迁移边界。
+- 范围：只删除 `_bind_handlers` 与 `_collect_skill_names` 两个完整不可达定义及相邻空行；未修改 `_bind_tool_hooks`、`_compile_snapshot_event_handlers`、`ScopedEventBus.staged_handlers`、`RuntimeSnapshot.event_handlers`、`PluginSkillHost`、`PreparedSkillCatalog`、`SkillsLoader`、`sync_manifest`、测试或 import。
+
+#### 子项 A：`PluginManager._bind_handlers`
+
+- 独立历史与当前 owner：`57a3cee5`（#105 全能力热重载/代际迁移）移除旧 caller，并以 `_compile_snapshot_event_handlers` 汇总静态 lifecycle metadata 与 staged `ScopedEventBus.staged_handlers`，写入 `RuntimeSnapshot.event_handlers`；当前事件 handler owner 为 snapshot compiler + staged event bus，旧方法仅保留定义。
+- 不变量与证据：全库 source/string/AST/`getattr`/reflection/export/plugin/external-test 搜索只见定义、零调用；删除不改变事件顺序、错误传播、hot-reload/generation/lease/rollback、静态事件注册、staged event bus 或 snapshot publish/write set；无 persistence、manifest、network 或外部发送变化。复活 helper 反而会绕过 staging 并重复 handler，故不加兼容层。
+
+#### 子项 B：`_collect_skill_names`
+
+- 独立历史与当前 owner：`7d9f4c15`（#104 程序化能力声明迁移）删除 `sync_global_registry` caller；当前 skill owner 为 `PluginSkillHost`、`PreparedSkillCatalog` 与 `SkillsLoader`，`sync_manifest` 只维护 enabled manifest。该 helper 仅保留定义，不能与子项 A 合称同一迁移。
+- 不变量与证据：全库 source/string/AST/`getattr`/reflection/export/plugin/external-test 搜索只见定义、零调用；删除不改变 skill roots、catalog generation/readiness、workspace skill 投影、manifest 写入、hot-reload/generation/lease/rollback、错误传播或 write set；无 persistence、network 或外部发送变化，不改可达 skill host/manifest 路径。
+
+- 语义与状态核对：两项均为旧迁移后的不可达定义，`semantic_delta: none`；事件、skill、错误、hot-reload、generation、lease、rollback、manifest、持久化、网络和 write set 均保持不变。
+- baseline：source-set digest `ad3078aab802bb5021f413348ced99899feaca742325bdaf666a22eece8f86fd`，文件数 `385`，Python SLOC `78,764`，TypeScript/TSX SLOC `8,644`，total production SLOC `87,408`。
+- candidate：source-set digest `6586123102dce5eb3f460c0b90d12c82990bf4ea1b323dcf5fc7ee53ae4b4ba6`，文件数 `385`，Python SLOC `78,736`，TypeScript/TSX SLOC `8,644`，total production SLOC `87,380`。
+- 目标与实际 SLOC 变化：`agent` 生产 SLOC 从 `28,845` 降至 `28,817`，production 净减少 `28` 行（`manager.py` raw diff 为 34 deletions，含相邻空行）。
+- 性能影响：只减少 module/class definition 对象；两个 helper 不进入请求或热重载热路径，没有新增调用、分配、等待或 I/O，不宣称 benchmark 收益。
+- 测试与真实验证：项目 venv `pytest -q tests/test_plugin_manager.py tests/test_plugin_hot_reload.py tests/test_plugin_skill_links.py tests/test_plugin_packages.py` 为 `188 passed in 9.88s`；修改文件 Pyright `--level error`：base/candidate 均 `0 errors, 0 warnings`；默认级别：base/candidate 均 `0 errors, 14 warnings`，六类诊断计数一致、无新增告警；legacy names 精确搜索在本账本之外零残留；`scripts/check_migrations_append_only.py --base refactor/less-is-more-pr4-provider-dead-diagnostics` 与 `git diff --check` 均通过。
+- Gate：按 WORKFLOW 在本候选提交前以 base `refactor/less-is-more-pr4-provider-dead-diagnostics` 运行 preflight；本条不回填运行产生的 `sourceDigest`/`planDigest`，避免账本自引用使报告失效，最终 committed-head digest 与 private 状态由主 Agent 在提交后重跑并写入 PR。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migrations、数据库、正式 workspace、服务、网络、外部发送或 Git refs。
+- 残余风险与回滚点：两个旧 helper 若未来出现外部反射依赖，应停止并分别补充对应迁移证据，不恢复兼容层；执行前备份为 `/tmp/less-is-more-pr5-finish-MSn37L`；提交后可用单提交 revert `refactor(plugins): remove dead manager helpers` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`PluginManager` 同一文件中保留了两段不同迁移完成后已不可达的旧 helper。
- 用户可见结果：插件事件、skill catalog、manifest 与热重载行为不变；production SLOC 从 87,408 降至 87,380，净减少 28。
- 本 PR 不处理：事件/skill 协议改写、文件拆分、import 清理、兼容 fallback 或测试重构。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`plugin`
- `consumer_scope`：PluginManager event snapshot/staged event bus 与 skill catalog/manifest 路径。
- `runtime_patch`：`none`
- `runtime_patch_reason`：只删除两个无调用、无导出、无动态引用的私有定义；现有 owner 未改变。
- `authoritative_state_owner`：事件由 snapshot compiler + staged `ScopedEventBus` + `RuntimeSnapshot.event_handlers` 拥有；skill 由 `PluginSkillHost`/`PreparedSkillCatalog`/`SkillsLoader` 拥有；enabled manifest 由 `sync_manifest` 拥有。
- `client_only_alternative`：不适用；这是插件 runtime 内部死代码删除。
- 关联不变量：候选事件在发布前 staged，运行轮次按 snapshot lease 取 handler；skill catalog 按 generation 冻结；manifest 只维护启用状态。
- `protected_state`：event subscriptions/order、snapshot/generation/lease/drain/rollback、skill roots/catalog、manifest、workspace projection。
- 允许的副作用：无。
- 禁止的副作用：不得直绑 global EventBus、重复 handler、改变 skill catalog/manifest、写数据库/workspace、发送网络请求或外部消息。

## 改动范围

- 主要文件：`agent/plugins/manager.py`；`docs/refactor/clean-code-ledger.md` 分别记录两个迁移的历史与 owner。
- 配置或迁移影响：无；migration append-only 检查通过。
- 已知 schema lineage 与最终 schema identity：`_bind_handlers` 的 caller 在 #105 `57a3cee5` 迁移到 generation snapshot/staged event；`_collect_skill_names` 的 callers 在 #104 `7d9f4c15` 迁移到 programmatic manifest/skill catalog。两项不是同一迁移，当前 schema/identity 不变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source/runtime HEAD `650ddf0ac0a61ff352d0a0569197684bb567453e`；provider 不适用；公开 scenario 绑定 plan digest `06410f902b292d06c9e495d94cb7da177305587d4d61f32f6afd0eb65be39e20`。
- 回滚方式：revert 单提交 `650ddf0ac0a61ff352d0a0569197684bb567453e`；执行前备份 `/tmp/less-is-more-pr5-finish-MSn37L`，review 文档备份 `/tmp/less-is-more-pr5-review-0ek5AQ`。

## 验证

- [x] 相关 targeted tests 已通过：plugin manager/hot reload/skill links/packages 共 `188 passed`；主 Agent 独立复跑为 `188 passed in 3.89s`。
- [x] Python 类型检查已通过：修改文件 base/candidate 的 `pyright --level error` 均为 `0 errors`；默认级别均 `0 errors, 14 warnings`，无新增。
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr4-provider-dead-diagnostics` 已运行并通过。
- `sourceDigest`：`d13ad6bf070a1ef4b5e3b308088b41b47f7fba717a0d55105a4ea4efb8b7dd71`
- `planDigest`：`06410f902b292d06c9e495d94cb7da177305587d4d61f32f6afd0eb65be39e20`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-022613-81fdcfab`；7 个公开 scenarios 全部通过，dirty status 为空，报告 HEAD 与本 PR HEAD 一致。
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；无设备、客户端或 APK 改动。
- 未运行项与原因：私有 provider identity Gate 不在公开仓库，等待维护者基于同一 plan digest 验收。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] MOB-001 不适用；无跨仓库或客户端改动。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 finding。
- 两项迁移证据分别核对；候选 tree 中两个 legacy symbol 零残留。恢复旧 `_bind_handlers` caller 会绕过 staged snapshot，因此本 PR 不增加兼容层。
- less-is-more PR1～PR5 累计净减少 160 production SLOC（87,540 → 87,380）；继续以语义证据优先推进，不用行数覆盖 owner 与状态机边界。
