### PR TITLE
chore(chat): remove unused cmdk dependency

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -181,6 +181,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、外部网络或 Git refs；保留 `cmdk` package dependency 供后续独立治理。
 - 残余风险与回滚点：若未来发现 command adapter 通过未检出的动态入口被依赖，应停止并补充真实迁移证据，不恢复兼容层；执行前备份为 `/tmp/less-is-more-pr6-finish-2iGCHh`；提交后可用单提交 revert `refactor(chat): remove dead command adapters` 回滚。
 
+## 2026-07-23 less-is-more PR7：移除未使用的 cmdk 根依赖
+
+### `PR7` `chore(chat): remove unused cmdk dependency`
+
+- base：PR6 commit `631fc199c6e8fe2ce7d1b3d4f2b9152efe4ca1fb`，分支 `refactor/less-is-more-pr7-remove-unused-cmdk`。
+- allowed_paths：`package.json`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：core chat dependency manifest；根包为 private 且无 exports，未修改 lockfile、CSS、source、mobile repo 或生成 bundle。
+- 范围：删除根 `package.json` dependencies 中唯一的 `"cmdk": "^1.1.1"` 声明。PR6 后 core source 已无 `cmdk` import、command module 或 `PromptInputCommand` consumer；`frontend/chat/src/styles.css` 的 incidental `[cmdk-root]` selector 保留，因为它不是 package consumer。plugins 无 manifest consumer；mobile stable 是独立仓库，保留其自身 source/lock 与依赖边界。
+- 语义与状态核对：`change_type: dependency cleanup`，`semantic_delta: none`；运行时模块解析、DOM/a11y、事件、网络、storage、stream 顺序、持久化 write set、CSS 和输出 bundle 均保持不变。此次只改变根包 install graph，不新增 fallback 或兼容层；共享 Radix 依赖仍由其他包使用。
+- baseline/candidate：production source-set 与 PR6 完全相同，文件数 `384`，Python SLOC `78,736`，TypeScript/TSX SLOC `8,451`，total production SLOC `87,187`，source-set digest `57450e582acc0b3ac1076049a19c0c341e2b8960a2fd68c702256d4ba8c04c78`；production SLOC 净变化 `0`。Git tracked 中无 package-lock/pnpm-lock/yarn.lock，未宣称精确 clean-install bytes delta。
+- footprint 观察：当前主 repo 已安装 `node_modules/cmdk` 的 `du -sB1` 观察值为 `126,976` bytes、`13` files；该值仅说明本机现有安装 footprint，不等同于无 lock/floating range 下的可复现 clean-install 节省量。
+- 构建对账：以 PR6 相同 workload 运行 `npm run build:chat -- --outDir <temporary> --logLevel error`；候选应与 PR6 构建 byte-identical（`367` files、raw `14,147,448` bytes、per-file gzip `3,167,344` bytes、entry `573,145` bytes、digest `293c6b1eab1572e4d22598af1fcf69a9d01de021bc69dce37ac0faac305d57d0`），仅验证未使用依赖移除没有影响构建产物。
+- 测试与真实验证：`jq empty package.json` 通过；精确 source/package consumer 搜索在 ledger 外零残留（CSS `[cmdk-root]` 保留且未改）；`npm run typecheck`、`npm run lint`、chat build、production SLOC、migration append-only 与 `git diff --check` 均通过。Gate 不回填 digest，提交后绑定 committed HEAD 重跑。
+- Gate：按 WORKFLOW 在本候选提交前以 base `refactor/less-is-more-pr6-chat-dead-command-adapters` 运行 preflight；private contract 状态单独记录，不把 public Gate 当作 private pass。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、消息或 Git refs。
+- 残余风险与回滚点：无 tracked lockfile 时无法把本次变化解释为精确安装字节收益；若后续新增真实 `cmdk` consumer，应恢复依赖并先走调用链证据。执行前备份为 `/tmp/less-is-more-pr7-finish-mmpaHV`；提交后可用单提交 revert `chore(chat): remove unused cmdk dependency` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ai": "^7.0.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "cmdk": "^1.1.1",
     "lucide-react": "^1.23.0",
     "micromark": "^4.0.2",
     "micromark-extension-gfm": "^3.0.0",


### PR DESCRIPTION
## 问题与结果

- 解决的问题：PR6 删除 chat command 适配层后，根 manifest 仍声明已无消费者的 `cmdk`，继续扩大安装图。
- 用户可见结果：chat DOM、交互、构建产物与能力不变；根安装图不再主动安装 `cmdk`。
- 本 PR 不处理：新增 lockfile、CSS 清理、mobile 独立仓库依赖或 composer 重设计。

## Change intent

- `change_type`：`dependency cleanup`
- `semantic_delta`：`none`
- `capability_owner`：core chat dependency manifest
- `consumer_scope`：根 private package；无 exports/library build，core source、plugins 与 mobile 均无该根依赖消费者。
- `runtime_patch`：`none`
- `authoritative_state_owner`：`package.json` 继续拥有根 install graph；chat runtime 由 PR6 后的可达 source graph 拥有。
- 关联不变量：现有 composer DOM/a11y、键鼠事件、stream/提交顺序、网络、storage、持久化 write set 和 CSS 不变。
- 允许的副作用：后续根安装不再因 manifest 主动引入 `cmdk`。
- 禁止的副作用：不得改变 source、bundle、协议、事件时序、mobile repo 或生成资产。

## 改动范围

- 主要文件：`package.json` 删除唯一的 `"cmdk": "^1.1.1"`；ledger 记录证据。
- 配置或迁移影响：无；Git tracked 中没有 package-lock、pnpm-lock 或 yarn.lock，migration append-only 检查通过。
- 消费者证据：PR6 后精确 source/package 搜索零运行时消费者；保留的 `.composer [cmdk-root]` 是普通 CSS attribute selector，不触发模块解析。
- production 计量：文件数 `384`、Python `78,736`、TypeScript/TSX `8,451`、total `87,187`、source-set digest `57450e582acc0b3ac1076049a19c0c341e2b8960a2fd68c702256d4ba8c04c78`，均与 PR6 相同。
- footprint 观察：当前机器既有 `node_modules/cmdk` 为 `126,976` allocated bytes / `13` files；无 tracked lock 且版本范围浮动，因此不宣称精确 clean-install 节省量。
- 回滚方式：revert 单提交 `b9bf20a10c1e6b7c826348cb90af20488806794d`；执行前备份 `/tmp/less-is-more-pr7-finish-mmpaHV`。

## 验证

- [x] `jq empty package.json`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build:chat -- --outDir <temporary> --logLevel error`
- [x] `python scripts/check_migrations_append_only.py --base refactor/less-is-more-pr6-chat-dead-command-adapters`
- [x] `python scripts/measure_production_sloc.py --json`
- [x] `git diff --check refactor/less-is-more-pr6-chat-dead-command-adapters...HEAD`
- [x] 主 Agent分别从 PR6、PR7 构建到独立临时目录并逐文件 `diff -qr`：完全一致；两侧 digest 均为 `293c6b1eab1572e4d22598af1fcf69a9d01de021bc69dce37ac0faac305d57d0`。
- 构建指标：`367` files、raw `14,147,448` bytes、逐文件 gzip `3,167,344` bytes、entry `573,145` bytes。
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr6-chat-dead-command-adapters` 已运行并通过。
- `sourceDigest`：`8a9160e35cc53a87207bda26b3630fad0107be93e355524282700ca58c74e362`
- `planDigest`：`3b6b8c7c48254d45502964cdf898c7ef379c5562e9f2e9633e48c3c74647b15c`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-025119-27509a03`；2 个 tooling scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`not_required`（仅 tooling manifest 与 ledger，无 production/protected paths）。
- 真实设备证据：不适用；无 Android/mobile source、协议或 APK 改动。

## 工作手册

- [x] 已核对 `projectneed.md`、相关 UI/MOB 决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] mobile stable 是独立仓库与历史 source copy，本 PR 不迁移、不修改其依赖。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 blocking finding；核对了依赖消费者、独立 mobile 边界、ledger、stack ancestry 与 committed-head Gate。
- less-is-more PR1～PR6 累计净减少 `353` production SLOC；本 PR production SLOC 变化为 `0`，单独治理安装图，不虚增删除计量。
