### PR TITLE
perf(mobile): avoid eager delta lock allocation

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -197,6 +197,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、消息或 Git refs。
 - 残余风险与回滚点：无 tracked lockfile 时无法把本次变化解释为精确安装字节收益；若后续新增真实 `cmdk` consumer，应恢复依赖并先走调用链证据。执行前备份为 `/tmp/less-is-more-pr7-finish-mmpaHV`；提交后可用单提交 revert `chore(chat): remove unused cmdk dependency` 回滚。
 
+## 2026-07-23 less-is-more PR8：避免 mobile delta 锁的 eager 分配
+
+### `PR8` `perf(mobile): avoid eager delta lock allocation`
+
+- base：PR7 commit `b9bf20a10c1e6b7c826348cb90af20488806794d`，分支 `refactor/less-is-more-pr8-mobile-delta-lock-allocation`。
+- allowed_paths：`infra/mobile_realtime/channel.py`、`tests/mobile_realtime/test_channel.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：core mobile realtime delta batching；没有 mobile 仓库、协议 schema 或其他权威文档改动。
+- 范围：仅将 `_delta_locks` 改为以 `asyncio.Lock` 为 factory 的 `defaultdict`，并让 `_buffer_delta`、`_flush_deltas` 直接按 key 取锁；未抽 helper，未修改 lock 生命周期、timer、batch、顺序、SQLite、event、network、cleanup 或 error semantics。existing key 只做一次映射查找，缺失 key 才由 factory 创建并写回同一 map。
+- 真实违反路径与不变量：Python 会先求值 `setdefault` 的默认参数，因此每次已有 key 的 delta 也会构造并丢弃新的 `asyncio.Lock`；当前 lock map 由 channel 拥有，batch flush 后仍按原逻辑 pop。窄回归预置 existing key、把 map factory 换成计数函数并提交 4KiB delta，证明 `_buffer_delta → _flush_deltas` 整条路径分配数为 `0`、事件仍只追加原有一次。
+- 语义与状态核对：`change_type: performance`，`semantic_delta: none`；同一 key 的互斥、delta 合并、4KiB/50ms flush、timer cancel、事件 payload/order、SQLite durable state、网络发送、失败传播和 stop cleanup 均保持不变。测试仅观察 fake runtime 的 append，不修改生产 write set。
+- baseline：source-set digest `57450e582acc0b3ac1076049a19c0c341e2b8960a2fd68c702256d4ba8c04c78`，文件数 `384`，Python SLOC `78,736`，TypeScript/TSX SLOC `8,451`，infra SLOC `11,352`，total production SLOC `87,187`。
+- candidate：source-set digest `d1c327a2598d8b8ce5e44d43fc33290720e0ed294ae0ae50546a1de20e3bc6e8`，文件数 `384`，Python SLOC `78,737`，TypeScript/TSX SLOC `8,451`，infra SLOC `11,353`，total production SLOC `87,188`；production 净增加 `1` 行，属于该性能修复允许的最小 manifest，不倒算前序删除收益。
+- 性能回放：base 与 candidate 均使用 `/mnt/data/coding/akasic-agent/.venv/bin/python`（Python `3.13.7`）、`taskset -c 0`，分别在各自 checkout cwd 中先预热 3 次，再运行 30 次相同的 10,000 个一字符 stream delta；fake runtime 只 append 事件（每次 3 个事件），不触碰 DB、SQLite、网络或真实 gateway。base median/p95 为 `8.465644/8.954338 ms`，candidate 为 `7.3659155/7.669912 ms`，相对变化分别为 `-12.99%/-14.34%`；同 workload 的 Lock 构造数从 `10,003` 降至 `3`，事件数保持 `3`。这是锁对象分配微基准，不宣称端到端 DB/network 性能收益。
+- 测试与真实验证：窄锁分配回归与原 delta batching 回归 `2 passed`；`pytest -q tests/mobile_realtime/test_channel.py tests/mobile_realtime/test_gateway.py tests/mobile_realtime/test_storage.py` 为 `75 passed in 1.04s`；`pyright --venvpath /mnt/data/coding/akasic-agent infra/mobile_realtime/channel.py` 为 `0 errors, 0 warnings, 0 informations`；migration append-only 与 `git diff --check` 通过。
+- Gate：按 WORKFLOW 在本候选提交前以 base `refactor/less-is-more-pr7-remove-unused-cmdk` 运行 preflight；本条不回填运行产生的 `sourceDigest`/`planDigest`，提交后绑定 committed HEAD 重跑，private 状态按报告记录。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、协议、网络或外部发送；测试临时对象只在一次性 pytest/benchmark 进程内存中存在。
+- 残余风险与回滚点：基准只覆盖 fake append 与 lock/batch 逻辑，真实 SQLite/network latency 未测量；若后续发现 lock map 需要跨调用持有，应停止并重新核对 owner/生命周期，不恢复 eager 分配。执行前备份为 `/tmp/less-is-more-pr8-finish-Dmxutr`；提交后可用单提交 revert `perf(mobile): avoid eager delta lock allocation` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import re
+from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -157,7 +158,7 @@ class MobileRealtimeChannel:
         self._active_turn_ids: dict[str, str] = {}
         self._process_turns: dict[tuple[str, str], _ProcessTurnState] = {}
         self._delta_batches: dict[tuple[str, str], _DeltaBatch] = {}
-        self._delta_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        self._delta_locks = defaultdict[tuple[str, str], asyncio.Lock](asyncio.Lock)
         self._delta_failure: BaseException | None = None
         self._attachments: AttachmentTransferService | None = None
         self._mobile_ui_provider: MobileUiProvider | None = None
@@ -1343,7 +1344,7 @@ class MobileRealtimeChannel:
         """按 50ms 或 4KiB 合并连续 delta，限制 SQLite 写入频率。"""
 
         key = (session_id, turn_id)
-        lock = self._delta_locks.setdefault(key, asyncio.Lock())
+        lock = self._delta_locks[key]
         flush_now = False
         async with lock:
             batch = self._delta_batches.get(key)
@@ -1391,7 +1392,7 @@ class MobileRealtimeChannel:
         """按原始顺序发布一个 turn 当前已聚合的 delta 段。"""
 
         key = (session_id, turn_id)
-        lock = self._delta_locks.setdefault(key, asyncio.Lock())
+        lock = self._delta_locks[key]
         async with lock:
             batch = self._delta_batches.pop(key, None)
             if batch is None:

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1760,6 +1760,44 @@ async def test_turn_stop_rejects_missing_or_stale_turn_identity(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None:
+    runtime = _Runtime(cast(MobileRealtimeStorage, object()))
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    key = ("mobile:test", "turn-1")
+    existing_lock = asyncio.Lock()
+    channel._delta_locks[key] = existing_lock
+
+    real_lock = channel_module.asyncio.Lock
+    allocations = 0
+
+    def counting_lock() -> asyncio.Lock:
+        nonlocal allocations
+        allocations += 1
+        return real_lock()
+
+    channel._delta_locks.default_factory = counting_lock
+    await channel._buffer_delta(
+        session_id=key[0],
+        turn_id=key[1],
+        event_type="answer.delta",
+        delta="x" * 4096,
+        block_id=None,
+        ordinal=None,
+    )
+
+    assert allocations == 0
+    assert channel._delta_locks == {}
+    assert runtime.events == [
+        {
+            "event_type": "answer.delta",
+            "session_id": key[0],
+            "turn_id": key[1],
+            "payload": {"delta": "x" * 4096},
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_deltas_batch_at_50ms_and_flush_before_tool_and_final(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 问题与结果

- 解决的问题：mobile delta 热路径使用 `dict.setdefault(key, asyncio.Lock())`；Python 会在 key 已存在时仍构造并立即丢弃默认 Lock。
- 用户可见结果：delta 合并、顺序和输出不变；10,000 delta 微基准中 Lock 构造 `10,003 → 3`，中位耗时降低 `12.99%`。
- 本 PR 不处理：SQLite/network/gateway 端到端性能、batch 策略、timer 时长、协议或 mobile 独立仓库代码。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：core mobile realtime delta batching
- `consumer_scope`：`MobileRealtimeChannel._buffer_delta/_flush_deltas` 的内部 lock map。
- `runtime_patch`：`none`
- `authoritative_state_owner`：channel 继续拥有每个 `(session_id, turn_id)` 的 delta batch、timer 与 lock 生命周期。
- 关联不变量：同 key 互斥、4KiB/50ms flush、segment 合并、timer cancel、payload/order、失败传播和 stop cleanup 不变。
- `protected_state`：SQLite durable state、事件序列、网络发送、delta 文本和 batch write set。
- 允许的副作用：删除 existing-key 路径上的临时 Lock 分配和第二次映射工作。
- 禁止的副作用：不得改变 DB、协议、事件数量/顺序、外部发送、error semantics 或持久化状态。

## 改动范围

- 主要文件：`channel.py` 将 lock map 收敛为 `defaultdict(asyncio.Lock)`，两条热路径各做一次 key lookup；直接回归测试观察 existing-key 路径零新分配；ledger 记录证据。
- 配置或迁移影响：无；migration append-only 检查通过。
- production 计量：PR7 `87,187` → PR8 `87,188`，净增 `1`；Python `78,736 → 78,737`，infra `11,352 → 11,353`，files/TS 不变；candidate source-set digest `d1c327a2598d8b8ce5e44d43fc33290720e0ed294ae0ae50546a1de20e3bc6e8`。
- 并发边界：lock factory 只在 async channel 所属 event loop 中、第一次 key lookup 时同步执行；factory 返回并写回前没有 `await`，不会扩大竞争窗口。
- 回滚方式：revert 单提交 `f070f09149e634c72b4e53bddb460fd8a55f9de3`；原实现备份 `/tmp/less-is-more-pr8-finish-Dmxutr`，主 Agent修订前备份 `/tmp/less-is-more-pr8-root-amend-bUnsdZ`。

## 验证

- [x] 窄分配测试 + 原 batching 回归：`2 passed`
- [x] `pytest -q tests/mobile_realtime/test_channel.py tests/mobile_realtime/test_gateway.py tests/mobile_realtime/test_storage.py`：主 Agent复跑 `75 passed in 0.91s`
- [x] `pyright --venvpath /mnt/data/coding/akasic-agent infra/mobile_realtime/channel.py`：`0 errors, 0 warnings, 0 informations`
- [x] migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] 微基准分别在 PR7/PR8 checkout cwd、同一 Python 3.13.7、`taskset -c 0`，各预热 3 次后 30 samples；fake runtime 只 append，不触碰 DB/network/gateway。
- 性能结果：median `8.465644 → 7.3659155 ms`（`-12.99%`），nearest-rank p95 `8.954338 → 7.669912 ms`（`-14.34%`）；Lock 构造 `10,003 → 3`；每次仍产生 3 个合并事件（4096 + 4096 + 1808）。不宣称端到端 DB/network 收益。
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr7-remove-unused-cmdk` 已运行并通过。
- `sourceDigest`：`1538a4d904e1fb79f8cca7384e74b9cfc53900ae4726dba9f8c8e3fb640a410c`
- `planDigest`：`b0e91d873cf6b3e66eca98ec60196bbfa04617e81788d84c95f857668f124951`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-031033-acb54150`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 Android/mobile client source 或协议。

## 工作手册

- [x] 已核对 `projectneed.md`、MOB 相关决策、持久状态图和 `NOW.md`。
- [x] 本次没有长期语义变化；错误处理与注释均未改变。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 blocking finding；独立复跑确认 Lock/事件计数和提速方向，绝对耗时存在正常进程间漂移，因此只保留固定微基准 claim。
- less-is-more PR1～PR8 相对 PR0 baseline 净减少 `352` production SLOC（`87,540 → 87,188`）；本 PR 的 `+1` 如实计入，不用性能收益掩盖删除目标。
