### PR TITLE
perf(default-memory): parse summary metadata once

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -214,6 +214,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、协议、网络或外部发送；测试临时对象只在一次性 pytest/benchmark 进程内存中存在。
 - 残余风险与回滚点：基准只覆盖 fake append 与 lock/batch 逻辑，真实 SQLite/network latency 未测量；若后续发现 lock map 需要跨调用持有，应停止并重新核对 owner/生命周期，不恢复 eager 分配。执行前备份为 `/tmp/less-is-more-pr8-finish-Dmxutr`；提交后可用单提交 revert `perf(mobile): avoid eager delta lock allocation` 回滚。
 
+## 2026-07-23 less-is-more PR9：复用默认记忆摘要解析结果
+
+### `PR9` `perf(default-memory): parse summary metadata once`
+
+- base：PR8 commit `f070f09149e634c72b4e53bddb460fd8a55f9de3`，分支 `perf/less-is-more-pr9-default-memory-summary-parse`。
+- allowed_paths：`plugins/default_memory/plugin.py`、`tests/test_recall_inspector_plugin.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：default memory inspector JSONL record parser；未修改 Memory2 canonical store、dashboard API schema、workspace 数据或外部插件。
+- 范围：`_items_from_block` 对每个 summary 只调用一次 `_split_summary_meta`，将返回的清理文本和标签解包后复用；补充直接 oracle，验证每个 item 只解析一次且完整输出逐项相等。未修改 JSONL 字段、标签顺序、记录顺序、写入集合、错误传播、日志、fallback 或调用链。
+- 真实调用链与不变量：active `DefaultMemoryInspector.record_context_prepare` 在每个 before-turn 通过 `_items_from_block` 记录注入视图；`_split_summary_meta` 是无状态纯解析器，返回值由当前 record parser 唯一消费。每个输入 item 必须保留相同 `id`、清理后的 `summary`、metadata `tags`、section 和 `injected=True`。
+- 语义与状态核对：`change_type: performance`，`semantic_delta: none`；只减少同一解析结果的重复计算，不改变 `observe/recall_inspector.jsonl` 的 durable write set、schema、事件顺序或错误语义。
+- baseline：source-set digest `d1c327a2598d8b8ce5e44d43fc33290720e0ed294ae0ae50546a1de20e3bc6e8`，文件数 `384`，Python SLOC `78,737`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,232`，total production SLOC `87,188`。
+- candidate：source-set digest `9a8dd2535342f38ded0c6f4016d9838743137cb5cbc4cdb43b60d99d05c20f85`，文件数 `384`，Python SLOC `78,738`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,233`，total production SLOC `87,189`；production 净增加 `1` 行，仅为显式解包赋值，不扩展运行时能力。
+- 性能回放：同一 cwd、同一 Python 进程内将 base `f070f091` 的 `_items_from_block` 与 candidate 当前函数加载为可调用函数，输入均为 metadata-rich summaries，预热不参与计量；每种规模 `2000 calls/repeat × 7 repeats`，只测 parser microbenchmark，不含文件 I/O/JSONL 写入。n=8：base raw `0.039063,0.040108,0.040440,0.040510,0.040652,0.040651,0.041119`，candidate raw `0.024958,0.025409,0.026081,0.034540,0.026720,0.023878,0.024057`，median `0.040510 → 0.025409s`（`-37.28%`）；n=40：base `0.188550,0.190675,0.189952,0.189686,0.189028,0.189443,0.196048`，candidate `0.120203,0.121178,0.120315,0.119864,0.126648,0.121127,0.120967`，median `0.189686 → 0.120967s`（`-36.23%`）；n=100：base `0.564673,0.515514,0.504761,0.510649,0.593235,0.575341,0.539586`，candidate `0.342459,0.321077,0.321924,0.305007,0.301139,0.300263,0.302883`，median `0.539586 → 0.305007s`（`-43.47%`）。三种规模均先断言 base/candidate 输出完全相等。
+- 测试与真实验证：`pytest -q tests/test_recall_inspector_plugin.py tests/test_default_memory_plugin_config.py tests/test_memory_engine_contract.py` 为 `54 passed`；新增 oracle 用真实 parser wrapper 计数，确认两个 item 恰好两次调用且每 item 一次；修改文件 pyright 为 `0 errors`（plugin 的 11 个 warning 为既有诊断）；migration append-only、`git diff --check`、production SLOC 与 committed-head Gate 均通过。
+- Gate：按 WORKFLOW 在本候选提交前以 base `refactor/less-is-more-pr8-mobile-delta-lock-allocation` 运行；本条不回填运行产生的 `sourceDigest`/`planDigest`，避免账本自引用，最终 committed-head digest 与 private 状态由交付报告记录。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 memory2.db、observe JSONL、migration、正式 workspace、服务、网络、外部发送或 Git refs。
+- 残余风险与回滚点：benchmark 只覆盖 parser CPU，不宣称端到端日志 I/O 提速；若未来 parser 改为有状态或 metadata 解析需要独立副作用，必须恢复单一 owner 语义并重新核对调用次数。执行前备份为 `/tmp/less-is-more-pr9-finish-5v9PHx`；提交后可用单提交 revert `perf(default-memory): parse summary metadata once` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/default_memory/plugin.py
+++ b/plugins/default_memory/plugin.py
@@ -173,11 +173,12 @@ def _items_from_block(block: str) -> list[dict[str, Any]]:
         if not match:
             continue
         item_id, summary = match.groups()
+        clean_summary, tags = _split_summary_meta(summary)
         items.append(
             {
                 "id": item_id.strip(),
-                "summary": _split_summary_meta(summary)[0],
-                "tags": _split_summary_meta(summary)[1],
+                "summary": clean_summary,
+                "tags": tags,
                 "section": section,
                 "injected": True,
             }

--- a/tests/test_recall_inspector_plugin.py
+++ b/tests/test_recall_inspector_plugin.py
@@ -11,6 +11,7 @@ from agent.lifecycle.types import AfterToolResultCtx, BeforeTurnCtx
 from agent.plugins.context import PluginContext, PluginKVStore
 from plugins.default_memory.dashboard import RecallInspectorDashboardReader
 from plugins.default_memory.engine import DefaultMemoryEngine
+from plugins.default_memory import plugin as default_memory_plugin
 from plugins.default_memory.plugin import DefaultMemoryInspector
 
 
@@ -77,6 +78,46 @@ async def test_recall_inspector_records_context_and_recall(tmp_path: Path) -> No
     assert items[0]["recall_memory_count"] == 1
     assert items[0]["context_prepare"]["items"][0]["id"] == "m1"
     assert items[0]["recall_memory_calls"][0]["items"][0]["id"] == "m3"
+
+
+def test_items_from_block_parses_each_summary_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    original = default_memory_plugin._split_summary_meta
+
+    def record_call(summary: str) -> tuple[str, list[str]]:
+        calls.append(summary)
+        return original(summary)
+
+    monkeypatch.setattr(default_memory_plugin, "_split_summary_meta", record_call)
+
+    block = (
+        "## 【相关历史】\n"
+        "- [m1] 用户偏好中文回复（证据: 可回源原文；src: [m1]；有印象）\n"
+        "- [m2] 用户喜欢短答案（证据: 记忆摘要；不确定）\n"
+    )
+
+    assert default_memory_plugin._items_from_block(block) == [
+        {
+            "id": "m1",
+            "summary": "用户偏好中文回复",
+            "tags": ["可回源原文", "有印象"],
+            "section": "【相关历史】",
+            "injected": True,
+        },
+        {
+            "id": "m2",
+            "summary": "用户喜欢短答案",
+            "tags": ["记忆摘要", "不确定"],
+            "section": "【相关历史】",
+            "injected": True,
+        },
+    ]
+    assert calls == [
+        "用户偏好中文回复（证据: 可回源原文；src: [m1]；有印象）",
+        "用户喜欢短答案（证据: 记忆摘要；不确定）",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：default memory inspector 对每个注入摘要连续执行两次相同的 metadata parser，只为分别取 summary 与 tags。
- 用户可见结果：inspector JSONL 内容、顺序和能力不变；parser 微基准在 n=8/40/100 时中位耗时分别降低 `37.28%/36.23%/43.47%`。
- 本 PR 不处理：Memory2 检索、JSONL I/O、dashboard schema、engine 中 injected-id set 优化或无关 dead helper。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：default memory inspector record parser
- `consumer_scope`：active `record_context_prepare → _items_from_block` 的注入视图记录。
- `runtime_patch`：`none`
- `authoritative_state_owner`：`DefaultMemoryInspector` 继续拥有 `observe/recall_inspector.jsonl` 写入；Memory2 canonical store 未改。
- 关联不变量：每个 item 的 id、clean summary、tags、section、`injected=True`、记录顺序和错误传播不变。
- `protected_state`：inspector JSONL schema/write set、workspace memory、dashboard 读取与现有日志。
- 允许的副作用：同一 summary 每 item 只解析一次。
- 禁止的副作用：不得改变 parser 规则、字段、顺序、fallback、I/O、异常或外部插件 API。

## 改动范围

- 主要文件：`plugin.py` 用一次显式解包复用 parser 结果；直接测试用调用原 parser 的 spy 验证两个 item 恰好两次调用并逐项断言完整输出；ledger 记录证据。
- 配置或迁移影响：无；migration append-only 检查通过。
- production 计量：PR8 `87,188` → PR9 `87,189`，净增 `1`；Python/plugins 各 `+1`，files/TS 不变；candidate source-set digest `9a8dd2535342f38ded0c6f4016d9838743137cb5cbc4cdb43b60d99d05c20f85`。
- 错误处理：不新增或删除 catch/fallback；原 parser 的所有返回和异常仍由同一 owner 直接传播。
- 回滚方式：revert 单提交 `ab2dcd9f7986816c8d3e1f9ad9d4d0d8d6a752ad`；执行前备份 `/tmp/less-is-more-pr9-finish-5v9PHx`。

## 验证

- [x] `pytest -q tests/test_recall_inspector_plugin.py tests/test_default_memory_plugin_config.py tests/test_memory_engine_contract.py`：主 Agent复跑 `54 passed in 0.65s`
- [x] `pyright --venvpath /mnt/data/coding/akasic-agent plugins/default_memory/plugin.py tests/test_recall_inspector_plugin.py`：`0 errors`；plugin 的 11 个 warning 为既有诊断。
- [x] migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] parser microbenchmark：同一 Python 进程加载 base/current 函数，三种规模先 assert 输出完全相等；每种 `2000 calls × 7 repeats`。
- 性能结果：n=8 median `0.040510 → 0.025409s`（`-37.28%`）；n=40 `0.189686 → 0.120967s`（`-36.23%`）；n=100 `0.539586 → 0.305007s`（`-43.47%`）。仅为 parser CPU 观察，不宣称 JSONL I/O 或端到端提升。
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr8-mobile-delta-lock-allocation` 已运行并通过。
- `sourceDigest`：`4be6cc0d5698a11d2441634b5137c98b167dd43686014c903464deb64a2d53db`
- `planDigest`：`bb9d787d5f506bcca1fb34cdb8f9c79dc0ad687da8acc21777722d4d0854a52a`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-032012-78b0b219`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 `projectneed.md`、MEM/PER 相关条款、持久状态图与 `NOW.md`。
- [x] 本次没有长期语义变化，错误处理和外部边界不变。
- [x] 未修改正式 workspace、数据库、JSONL、服务、网络、外部发送或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 blocking finding；AST differential、异常传播、spy teardown、SLOC、stack 与 committed-head Gate 均已核对，独立 benchmark 三档约 `-40%`。
- less-is-more PR1～PR9 相对 PR0 baseline 净减少 `351` production SLOC（`87,540 → 87,189`）；本 PR 的 `+1` 如实计入，不为计量压缩可读性。
