### PR TITLE
perf(wake): eliminate context list N+1 query

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -231,6 +231,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 memory2.db、observe JSONL、migration、正式 workspace、服务、网络、外部发送或 Git refs。
 - 残余风险与回滚点：benchmark 只覆盖 parser CPU，不宣称端到端日志 I/O 提速；若未来 parser 改为有状态或 metadata 解析需要独立副作用，必须恢复单一 owner 语义并重新核对调用次数。执行前备份为 `/tmp/less-is-more-pr9-finish-5v9PHx`；提交后可用单提交 revert `perf(default-memory): parse summary metadata once` 回滚。
 
+## 2026-07-23 less-is-more PR10：Wake context 列表复用单次查询
+
+### `PR10` `perf(wake): eliminate context list N+1 query`
+
+- base：PR9 commit `ab2dcd9f7986816c8d3e1f9ad9d4d0d8d6a752ad`，分支 `perf/less-is-more-pr10-wake-context-single-query`。
+- allowed_paths：`plugins/wake_proactive/state.py`、`tests/wake_proactive/test_state.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：WakeStateStore context_state read path；未修改 wake runtime/prompt、ACK 状态机、schema、migration、协议或外部发送。
+- 范围：`list_contexts()` 改为一次 `SELECT * FROM context_state ORDER BY source_id`，新增最小 `_decode_context_row(sqlite3.Row)`，由 `load_context()` 与列表路径共同复用；保留缺失行 `None`、source_id 升序、float/optional time/JSON/presence 解码及原异常传播。新增空表、排序/roundtrip、missing、JSON/time 损坏 fail-loud 和 SQLite trace oracle。
+- 连接与并发边界：`WakeStateStore` 使用默认 `sqlite3.connect(..., check_same_thread=True)`，没有线程/`to_thread`/executor 调用；`WakeRuntime._active_contexts()` 是同步消费，`list_contexts()` 内没有 await 或外部交错点。旧路径的首个 source-id SELECT 与后续 load SELECT 不能在同一调用内被并发插入；单语句读取因此不引入新的可观察并发 snapshot 语义。
+- 语义与状态核对：`change_type: performance`，`semantic_delta: none`；`context_state` canonical 行、提交/写集、schema、排序、runtime active/expired filter、错误类型与传播均保持不变。读路径仍不写 `wake_proactive.db`。
+- baseline：source-set digest `9a8dd2535342f38ded0c6f4016d9838743137cb5cbc4cdb43b60d99d05c20f85`，文件数 `384`，Python SLOC `78,738`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,233`，total production SLOC `87,189`。
+- candidate：source-set digest `72c2547763ee40f090e516be6e0438a847d1c1216b18d9f9f962b76e22e2a1d4`，文件数 `384`，Python SLOC `78,734`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,229`，total production SLOC `87,185`；production 净减少 `4` 行，全部来自重复 row decode 收敛。
+- 数据库读回放：base 与 candidate 分别在各自 cwd、同一 Python `3.13.7`/`.venv`、`taskset -c 0` 下对临时 SQLite，预热 15 次后计时 60 次；每次预置 N 行、只测 `list_contexts()` DB read，不含初始化/写入。N=64：查询数 `65 → 1`，输出 `64` 条，output SHA-256 `07c14be65ccb350d9da749b077bc8866e382f6fc35543177f06831c2b20fb55c` 相同，median `0.700603 → 0.271058 ms`（`-61.18%`），p95 `0.870249 → 0.309028 ms`（`-64.49%`）；N=256：查询数 `257 → 1`，输出 `256` 条，output SHA-256 `d0f28c2e0b21d45d7a2f5f138ae4465dcb92c8f6c735b51c90c8a122a78b0c42` 相同，median `2.895594 → 1.055964 ms`（`-63.53%`），p95 `3.393665 → 1.166783 ms`（`-65.63%`）。这是 SQLite read microbenchmark，不宣称端到端 wake latency。
+- 测试与真实验证：`pytest -q tests/wake_proactive` 为 `63 passed in 0.56s`；修改文件与直接 state oracle pyright `0 errors, 0 warnings, 0 informations`；migration append-only、`git diff --check`、production SLOC 与 committed-head Gate 均通过。
+- Gate：按 WORKFLOW 在本候选提交前以 base `perf/less-is-more-pr9-default-memory-summary-parse` 运行；本条不回填 Gate 产生的 source/plan digest，最终 committed-head 与 private 状态由交付报告记录。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 `wake_proactive.db`、`sessions.db`、schema/migration、正式 workspace、服务、网络、ACK、消息或外部发送；测试只使用一次性 temp SQLite。
+- 残余风险与回滚点：benchmark 仅覆盖 state read path；若未来允许同一 store 跨线程或在列表读取中插入 await，必须重新核对 snapshot/locking 语义，不恢复 N+1 作为隐式一致性机制。执行前备份为 `/tmp/less-is-more-pr10-finish-P4kmur`；提交后可用单提交 revert `perf(wake): eliminate context list N+1 query` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/wake_proactive/state.py
+++ b/plugins/wake_proactive/state.py
@@ -709,27 +709,13 @@ class WakeStateStore:
             "SELECT * FROM context_state WHERE source_id = ?",
             (source_id,),
         ).fetchone()
-        if row is None:
-            return None
-        return NormalizedContext(
-            presence=cast(Presence, row["presence"]),
-            interruptibility=float(row["interruptibility"]),
-            confidence=float(row["confidence"]),
-            transition=str(row["transition_name"]),
-            observed_at=_parse_optional_time(row["observed_at"]),
-            expires_at=_parse_optional_time(row["expires_at"]),
-            raw=cast(dict[str, Any], json.loads(str(row["payload_json"]))),
-        )
+        return _decode_context_row(row) if row is not None else None
 
     def list_contexts(self) -> list[NormalizedContext]:
         rows = self._conn.execute(
-            "SELECT source_id FROM context_state ORDER BY source_id"
+            "SELECT * FROM context_state ORDER BY source_id"
         ).fetchall()
-        return [
-            context
-            for row in rows
-            if (context := self.load_context(str(row["source_id"]))) is not None
-        ]
+        return [_decode_context_row(row) for row in rows]
 
     def claim_context_reevaluation(
         self,
@@ -912,3 +898,17 @@ def _parse_optional_time(value: object) -> datetime | None:
     if value is None or not str(value).strip():
         return None
     return datetime.fromisoformat(str(value))
+
+
+def _decode_context_row(row: sqlite3.Row) -> NormalizedContext:
+    """解码一行 context_state，并保留原有持久化错误。"""
+
+    return NormalizedContext(
+        presence=cast(Presence, row["presence"]),
+        interruptibility=float(row["interruptibility"]),
+        confidence=float(row["confidence"]),
+        transition=str(row["transition_name"]),
+        observed_at=_parse_optional_time(row["observed_at"]),
+        expires_at=_parse_optional_time(row["expires_at"]),
+        raw=cast(dict[str, Any], json.loads(str(row["payload_json"]))),
+    )

--- a/tests/wake_proactive/test_state.py
+++ b/tests/wake_proactive/test_state.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from plugins.wake_proactive.state import WakeStateStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    state = WakeStateStore(tmp_path / "wake.db")
+    try:
+        yield state
+    finally:
+        state.close()
+
+
+def _snapshot(source_id: str, now: datetime, *, expires_at: datetime | None = None) -> dict:
+    return {
+        "_source": source_id,
+        "presence": "active",
+        "interruptibility": 0.75,
+        "confidence": 0.9,
+        "observed_at": now.isoformat(),
+        "expires_at": expires_at.isoformat() if expires_at is not None else None,
+    }
+
+
+def test_list_contexts_reads_one_ordered_snapshot_and_roundtrips(store: WakeStateStore) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0)
+
+    assert store.list_contexts() == []
+    store.ingest_context(
+        [
+            _snapshot("z-source", now, expires_at=now + timedelta(minutes=5)),
+            _snapshot("a-source", now),
+        ],
+        now,
+    )
+
+    statements: list[str] = []
+    store._conn.set_trace_callback(statements.append)
+    contexts = store.list_contexts()
+    store._conn.set_trace_callback(None)
+
+    assert [context.raw["_source"] for context in contexts] == [
+        "a-source",
+        "z-source",
+    ]
+    assert contexts[0].interruptibility == 0.75
+    assert contexts[1].expires_at == now + timedelta(minutes=5)
+    select_statements = [
+        statement
+        for statement in statements
+        if statement.lstrip().upper().startswith("SELECT")
+    ]
+    assert select_statements == [
+        "SELECT * FROM context_state ORDER BY source_id"
+    ]
+
+
+def test_load_context_missing_returns_none(store: WakeStateStore) -> None:
+    assert store.load_context("missing-source") is None
+
+
+@pytest.mark.parametrize(
+    ("column", "value", "error_type"),
+    [
+        ("payload_json", "not-json", json.JSONDecodeError),
+        ("observed_at", "not-time", ValueError),
+    ],
+)
+def test_context_row_corruption_fails_loud(
+    store: WakeStateStore,
+    column: str,
+    value: str,
+    error_type: type[Exception],
+) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0)
+    store.ingest_context([_snapshot("broken-source", now)], now)
+    _ = store._conn.execute(
+        f"UPDATE context_state SET {column} = ? WHERE source_id = ?",
+        (value, "broken-source"),
+    )
+    store._conn.commit()
+
+    with pytest.raises(error_type):
+        store.list_contexts()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`WakeStateStore.list_contexts()` 先读 source ids，再逐条调用 `load_context()`，形成稳定的 `1+N` SQLite SELECT。
- 用户可见结果：context 内容、排序、过滤与错误语义不变；64/256 行查询数从 `65/257 → 1`，中位读耗时降低 `61.18%/63.53%`。
- 本 PR 不处理：wake prompt/runtime 逻辑、ACK 状态机、schema/migration、写路径或端到端 wake latency。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：`WakeStateStore.context_state` 读取路径
- `consumer_scope`：`list_contexts → WakeRuntime._active_contexts` 的同步读取；`load_context` 继续支持单条读取。
- `runtime_patch`：`none`
- `authoritative_state_owner`：`context_state` SQLite 表与既有 store 继续拥有 canonical 行和提交边界。
- 关联不变量：missing→None、source_id 升序、float/time/JSON/presence decode、active/expired filter 和 fail-loud 异常不变。
- `protected_state`：`wake_proactive.db`、context write set、prompt/context 内容、事件与外部发送。
- 允许的副作用：列表读取由 N+1 收敛为单条有序 SELECT。
- 禁止的副作用：不得改变 schema、数据、排序、异常类型、事务、runtime/prompt、ACK、消息或网络。

## 改动范围

- 主要文件：`state.py` 增加最小 `_decode_context_row`，由 `load_context/list_contexts` 共用；列表直接解码一次 SELECT 的有序 rows；新增直接 state oracle；ledger 记录证据。
- 配置或迁移影响：无；migration append-only 检查通过。
- 并发边界：store 使用默认 `sqlite3.connect(..., check_same_thread=True)`；调用链同步且无 await/to_thread/executor，旧 N+1 之间也没有可达同线程并发写入点。
- production 计量：PR9 `87,189` → PR10 `87,185`，净减少 `4`；Python/plugins 各 `-4`，files/TS 不变；candidate source-set digest `72c2547763ee40f090e516be6e0438a847d1c1216b18d9f9f962b76e22e2a1d4`。
- 错误处理：不新增 fallback/catch；损坏 JSON 继续抛 `JSONDecodeError`，非法时间继续 fail-loud `ValueError`。
- 回滚方式：revert 单提交 `9897e77ced5d01cd8d9f91c2cdc0b2df04fd52ca`；执行前备份 `/tmp/less-is-more-pr10-finish-P4kmur`。

## 验证

- [x] `pytest -q tests/wake_proactive`：主 Agent复跑 `63 passed in 0.63s`
- [x] `pyright --venvpath /mnt/data/coding/akasic-agent plugins/wake_proactive/state.py tests/wake_proactive/test_state.py`：`0 errors, 0 warnings, 0 informations`
- [x] 直接 oracle：空表、missing、两行 roundtrip/source_id 排序、SQLite trace 单 SELECT、JSON/时间损坏 fail-loud。
- [x] migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] SQLite read microbenchmark：base/candidate 各自 checkout cwd，同一 Python 3.13.7、`taskset -c 0`，15 warmups + 60 samples；输出 hash 完全相同。
- N=64：queries `65 → 1`，median `0.700603 → 0.271058 ms`（`-61.18%`），p95 `0.870249 → 0.309028 ms`（`-64.49%`）。
- N=256：queries `257 → 1`，median `2.895594 → 1.055964 ms`（`-63.53%`），p95 `3.393665 → 1.166783 ms`（`-65.63%`）。仅为临时 SQLite read workload，不宣称端到端 wake latency。
- [x] `python docker/debug/gate.py run --base perf/less-is-more-pr9-default-memory-summary-parse` 已运行并通过。
- `sourceDigest`：`9d0b71189309f0fd3424d12dc3639ee9990c14a8accfe62f03aaa1d214785abd`
- `planDigest`：`0a749d80d668e9d7c47fe896fcbcc68301e016ab23d43e7e969100f602f06543`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-032801-ae9a2c80`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 `projectneed.md`、WAK/PRO/PER 相关条款、持久状态图与 `NOW.md`。
- [x] 本次没有长期语义变化；错误处理、注释与静态语义已对账。
- [x] 未修改正式 workspace、数据库、schema、服务、网络、消息、ACK 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 blocking finding；独立复跑确认查询数、输出 hash 与提速方向，逐字段核对 decode、排序、并发边界、write set、SLOC 与 committed-head Gate。
- less-is-more PR1～PR10 相对 PR0 baseline 净减少 `355` production SLOC（`87,540 → 87,185`）。
