### PR TITLE
refactor(telegram): unify HTML message helpers

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -248,6 +248,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 `wake_proactive.db`、`sessions.db`、schema/migration、正式 workspace、服务、网络、ACK、消息或外部发送；测试只使用一次性 temp SQLite。
 - 残余风险与回滚点：benchmark 仅覆盖 state read path；若未来允许同一 store 跨线程或在列表读取中插入 await，必须重新核对 snapshot/locking 语义，不恢复 N+1 作为隐式一致性机制。执行前备份为 `/tmp/less-is-more-pr10-finish-P4kmur`；提交后可用单提交 revert `perf(wake): eliminate context list N+1 query` 回滚。
 
+## 2026-07-23 less-is-more PR11：收敛 Telegram HTML 消息 helper
+
+### `PR11` `refactor(telegram): unify HTML message helpers`
+
+- base：PR10 commit `9897e77ced5d01cd8d9f91c2cdc0b2df04fd52ca`，分支 `refactor/less-is-more-pr11-telegram-html-helpers`。
+- allowed_paths：`infra/channels/telegram_utils.py`、`tests/test_telegram_utils.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：Telegram live/preview HTML send/edit 边界；未修改 limiter、queue、retry、channel runtime、媒体、文件或持久化。
+- 范围：将四个本模块私有 `_send/_edit_live/preview_message` 收敛为 `_send_html_message` 与 `_edit_html_message`，调用点通过 `Literal["live", "preview"]` 保留渠道策略；helper production SLOC 从 `101` 降至 `51`，加入类型与调用参数后 `telegram_utils.py` 从 `1,098` 降至 `1,056`。
+- 调用链与不变量：`TelegramLiveTextMessage.update` 和 `TelegramStreamMessage._send_or_edit/_try_edit_preview_message` 继续通过既有 queue/limiter 发起同样的 Telegram API 调用；HTML kwargs、HTML→plain 调用顺序、send Message 返回、edit live `True`/preview `None`、message-id 更新和外层 retry 状态不变。
+- 错误与日志语义：只在 `_is_telegram_html_parse_error` 为真时执行一次纯文本降级；所有非解析异常原样传播。not-modified 仍由 live 静默返回、preview 输出原 debug 后返回；四条 live/preview send/edit warning 渲染文本保持不变，没有新增 catch、fallback 或假成功路径。
+- 语义与状态核对：`change_type: refactor`，`semantic_delta: none`；网络发送次数/顺序、RetryAfter/TimedOut/NetworkError owner、stream 状态、消息内容、日志级别、外部发送与 write set 均不变。
+- baseline：source-set digest `72c2547763ee40f090e516be6e0438a847d1c1216b18d9f9f962b76e22e2a1d4`，文件数 `384`，Python SLOC `78,734`，TypeScript/TSX SLOC `8,451`，infra SLOC `11,353`，total production SLOC `87,185`。
+- candidate：source-set digest `e330b219d28313c506271787ca200d3c03eb0c0d725faf0cfab81d9c616eb2fb`，文件数 `384`，Python SLOC `78,692`，TypeScript/TSX SLOC `8,451`，infra SLOC `11,311`，total production SLOC `87,143`；production 净减少 `42` 行，不宣称独立端到端性能收益。
+- 测试与真实验证：新增 live/preview send parse fallback、send 非解析异常、edit parse fallback/渠道返回、edit 非解析异常、not-modified no-plain-retry 与日志 oracle；`pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py` 为 `39 passed`；范围 pyright `0 errors`，warning 从 base `18` 降至 candidate `16`；legacy helper 全库零残留，migration append-only、`git diff --check` 与 production SLOC 均通过。
+- Gate：按 WORKFLOW 以 base `perf/less-is-more-pr10-wake-context-single-query` 运行；本条不回填运行产生的 source/plan digest，最终 committed-head 与 private 状态由交付报告记录。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、正式 workspace、服务、配置、协议、媒体文件、消息记录或 Git refs；测试 fake bot 只记录内存中的调用参数。
+- 残余风险与回滚点：渠道差异显式受 `Literal` 和直接 oracle 约束；若 Telegram 新增第三种 HTML 策略，应扩展明确合同而非依赖默认 fallback。主 Agent收尾前备份 `/tmp/less-is-more-pr11-root-finish-gx1INm`；提交后可用单提交 revert `refactor(telegram): unify HTML message helpers` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/channels/telegram_utils.py
+++ b/infra/channels/telegram_utils.py
@@ -13,7 +13,7 @@ import logging
 import re
 import weakref
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import Any, Literal, cast
 from typing import TypeVar
 
 from telegram import Bot, MessageEntity as TgEntity
@@ -639,11 +639,12 @@ class TelegramLiveTextMessage:
             sent = await self._queue.run(
                 self._chat_id,
                 label="send_message(live)",
-                action=lambda: _send_live_message(
+                action=lambda: _send_html_message(
                     self._bot,
                     self._chat_id,
                     html_body,
                     plain,
+                    channel="live",
                 ),
             )
             if sent is None:
@@ -655,12 +656,13 @@ class TelegramLiveTextMessage:
             self._chat_id,
             label="edit_message(live)",
             force=force,
-            action=lambda: _edit_live_message(
+            action=lambda: _edit_html_message(
                 self._bot,
                 self._chat_id,
                 self._message_id,
                 html_body,
                 plain,
+                channel="live",
             ),
         )
         if ok:
@@ -698,12 +700,17 @@ def _clip_live_text(text: str) -> str:
     cut = _utf16_cut(text, _LIVE_MESSAGE_LIMIT - len(suffix))
     return text[:cut] + suffix
 
-async def _send_live_message(
+async def _send_html_message(
     bot: Bot,
     chat_id: int,
     html_text: str,
     plain_text: str,
+    *,
+    channel: Literal["live", "preview"],
 ) -> object:
+    """发送 HTML 文本，仅在解析失败时降级为纯文本。"""
+
+    # 1. 先发送 Telegram HTML 消息。
     try:
         return await bot.send_message(
             chat_id=chat_id,
@@ -711,19 +718,26 @@ async def _send_live_message(
             parse_mode="HTML",
         )
     except Exception as e:
+        # 2. 解析失败才按原顺序降级为纯文本，其他异常继续暴露。
         if not _is_telegram_html_parse_error(e):
             raise
-        logger.warning("[telegram] live HTML 解析失败，降级纯文本: %s", e)
+        logger.warning("[telegram] %s HTML 解析失败，降级纯文本: %s", channel, e)
         return await bot.send_message(chat_id=chat_id, text=plain_text)
 
 
-async def _edit_live_message(
+async def _edit_html_message(
     bot: Bot,
     chat_id: int,
     message_id: int | None,
     html_text: str,
     plain_text: str,
-) -> bool:
+    *,
+    channel: Literal["live", "preview"],
+) -> bool | None:
+    """编辑 HTML 文本，并保留渠道特定的无操作返回值。"""
+
+    # 1. 先发送 Telegram HTML 编辑请求。
+    result = True if channel == "live" else None
     try:
         await bot.edit_message_text(
             chat_id=chat_id,
@@ -731,29 +745,23 @@ async def _edit_live_message(
             text=html_text,
             parse_mode="HTML",
         )
-        return True
-    except BadRequest as e:
-        if _is_telegram_message_not_modified_error(e):
-            return True
-        if not _is_telegram_html_parse_error(e):
-            raise
-        logger.warning("[telegram] live edit HTML 解析失败，降级纯文本: %s", e)
-        await bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=plain_text,
-        )
-        return True
+        return result
     except Exception as e:
+        # 2. 只吞掉已知的 not-modified 或解析错误路径。
+        if isinstance(e, BadRequest) and _is_telegram_message_not_modified_error(e):
+            if channel == "preview":
+                logger.debug("[telegram] preview edit skipped: %s", e)
+            return result
         if not _is_telegram_html_parse_error(e):
             raise
-        logger.warning("[telegram] live edit HTML 解析失败，降级纯文本: %s", e)
+        # 3. 解析失败才执行一次纯文本编辑。
+        logger.warning("[telegram] %s edit HTML 解析失败，降级纯文本: %s", channel, e)
         await bot.edit_message_text(
             chat_id=chat_id,
             message_id=message_id,
             text=plain_text,
         )
-        return True
+        return result
 
 
 class TelegramStreamMessage:
@@ -883,8 +891,12 @@ class TelegramStreamMessage:
                 self._chat_id,
                 kind="send",
                 label="send_message(stream_start)",
-                action=lambda: _send_preview_message(
-                    self._bot, self._chat_id, html_text, plain_text
+                action=lambda: _send_html_message(
+                    self._bot,
+                    self._chat_id,
+                    html_text,
+                    plain_text,
+                    channel="preview",
                 ),
             )
             self._message_id = int(getattr(sent, "message_id", 0) or 0) or None
@@ -900,12 +912,13 @@ class TelegramStreamMessage:
     ) -> bool:
         try:
             if self._limiter is None:
-                await _edit_preview_message(
+                await _edit_html_message(
                     self._bot,
                     self._chat_id,
                     self._message_id,
                     html_text,
                     plain_text,
+                    channel="preview",
                 )
             else:
                 await _run_outbound(
@@ -913,12 +926,13 @@ class TelegramStreamMessage:
                     self._chat_id,
                     kind="edit",
                     label="edit_message_text(stream)",
-                    action=lambda: _edit_preview_message(
+                    action=lambda: _edit_html_message(
                         self._bot,
                         self._chat_id,
                         self._message_id,
                         html_text,
                         plain_text,
+                        channel="preview",
                     ),
                 )
             return True
@@ -995,57 +1009,6 @@ def _iter_stream_chunks(text: str) -> list[str]:
         chunks.append(text[start:end])
         start = end
     return chunks
-
-
-async def _send_preview_message(bot: Bot, chat_id: int, html_text: str, plain_text: str):
-    try:
-        return await bot.send_message(
-            chat_id=chat_id,
-            text=html_text,
-            parse_mode="HTML",
-        )
-    except Exception as e:
-        if not _is_telegram_html_parse_error(e):
-            raise
-        logger.warning("[telegram] preview HTML 解析失败，降级纯文本: %s", e)
-        return await bot.send_message(chat_id=chat_id, text=plain_text)
-
-
-async def _edit_preview_message(
-    bot: Bot,
-    chat_id: int,
-    message_id: int | None,
-    html_text: str,
-    plain_text: str,
-) -> None:
-    try:
-        await bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=html_text,
-            parse_mode="HTML",
-        )
-    except BadRequest as e:
-        if _is_telegram_message_not_modified_error(e):
-            logger.debug("[telegram] preview edit skipped: %s", e)
-            return
-        if not _is_telegram_html_parse_error(e):
-            raise
-        logger.warning("[telegram] preview edit HTML 解析失败，降级纯文本: %s", e)
-        await bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=plain_text,
-        )
-    except Exception as e:
-        if not _is_telegram_html_parse_error(e):
-            raise
-        logger.warning("[telegram] preview edit HTML 解析失败，降级纯文本: %s", e)
-        await bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=plain_text,
-        )
 
 
 def _is_telegram_html_parse_error(err: Exception) -> bool:

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any, cast
 from types import SimpleNamespace
 
@@ -37,6 +38,174 @@ class BotStub:
 
     async def send_photo(self, **kwargs):
         self.photo_calls += 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel", ["live", "preview"])
+async def test_html_send_helper_falls_back_and_returns_message(channel, caplog):
+    bot = BotStub()
+    calls = []
+    expected = SimpleNamespace(message_id=9)
+
+    async def send_message(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("parse_mode") == "HTML":
+            raise RuntimeError("can't parse entities")
+        return expected
+
+    bot.send_message = send_message
+
+    with caplog.at_level(logging.WARNING, logger=telegram_utils_module.logger.name):
+        result = await telegram_utils_module._send_html_message(
+            cast(Any, bot),
+            123,
+            "<b>hello</b>",
+            "hello",
+            channel=channel,
+        )
+
+    assert result is expected
+    assert (
+        f"[telegram] {channel} HTML 解析失败，降级纯文本: can't parse entities"
+        in caplog.text
+    )
+    assert calls == [
+        {"chat_id": 123, "text": "<b>hello</b>", "parse_mode": "HTML"},
+        {"chat_id": 123, "text": "hello"},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel", ["live", "preview"])
+async def test_html_send_helper_propagates_non_parse_error(channel):
+    bot = BotStub()
+    calls = []
+
+    async def send_message(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("transport failed")
+
+    bot.send_message = send_message
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        await telegram_utils_module._send_html_message(
+            cast(Any, bot),
+            123,
+            "<b>hello</b>",
+            "hello",
+            channel=channel,
+        )
+
+    assert calls == [{"chat_id": 123, "text": "<b>hello</b>", "parse_mode": "HTML"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("channel", "expected_result"),
+    [("live", True), ("preview", None)],
+)
+async def test_html_edit_helper_falls_back_with_channel_result(
+    channel, expected_result, caplog
+):
+    bot = BotStub()
+    calls = []
+
+    async def edit_message_text(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("parse_mode") == "HTML":
+            raise RuntimeError("can't parse entities")
+
+    bot.edit_message_text = edit_message_text
+
+    with caplog.at_level(logging.WARNING, logger=telegram_utils_module.logger.name):
+        result = await telegram_utils_module._edit_html_message(
+            cast(Any, bot),
+            123,
+            9,
+            "<b>hello</b>",
+            "hello",
+            channel=channel,
+        )
+
+    assert result is expected_result
+    assert calls == [
+        {
+            "chat_id": 123,
+            "message_id": 9,
+            "text": "<b>hello</b>",
+            "parse_mode": "HTML",
+        },
+        {"chat_id": 123, "message_id": 9, "text": "hello"},
+    ]
+    assert f"[telegram] {channel} edit HTML 解析失败" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel", ["live", "preview"])
+async def test_html_edit_helper_propagates_non_parse_error(channel):
+    bot = BotStub()
+    calls = []
+
+    async def edit_message_text(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("transport failed")
+
+    bot.edit_message_text = edit_message_text
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        await telegram_utils_module._edit_html_message(
+            cast(Any, bot),
+            123,
+            9,
+            "<b>hello</b>",
+            "hello",
+            channel=channel,
+        )
+
+    assert calls == [
+        {
+            "chat_id": 123,
+            "message_id": 9,
+            "text": "<b>hello</b>",
+            "parse_mode": "HTML",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("channel", "expected_result"),
+    [("live", True), ("preview", None)],
+)
+async def test_html_edit_helper_skips_not_modified_without_plain_retry(
+    channel, expected_result, caplog
+):
+    bot = BotStub()
+    bot.edit_message_text = AsyncMock(
+        side_effect=telegram_utils_module.BadRequest("Message is NOT modified")
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=telegram_utils_module.logger.name):
+        result = await telegram_utils_module._edit_html_message(
+            cast(Any, bot),
+            123,
+            9,
+            "<b>hello</b>",
+            "hello",
+            channel=channel,
+        )
+
+    assert result is expected_result
+    bot.edit_message_text.assert_awaited_once_with(
+        chat_id=123,
+        message_id=9,
+        text="<b>hello</b>",
+        parse_mode="HTML",
+    )
+    if channel == "preview":
+        assert "[telegram] preview edit skipped" in caplog.text
+    else:
+        assert "edit skipped" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Telegram live/preview 各自维护几乎相同的 HTML send/edit helper，四份 parse fallback 与 not-modified 分支重复演进。
- 用户可见结果：消息内容、API 调用、日志、retry 和返回值不变；四个私有 helper 收敛为两个，production 净减少 `42` 行。
- 本 PR 不处理：outbound limiter、queue、retry/backoff、Lock、TelegramChannel runtime、媒体/文件或协议。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：Telegram live/preview HTML send/edit 边界
- `consumer_scope`：`TelegramLiveTextMessage` 与 `TelegramStreamMessage` 的本模块私有调用。
- `runtime_patch`：`none`
- `authoritative_state_owner`：既有 live queue/stream message 继续拥有 message-id、force、retry 与发送状态。
- 关联不变量：HTML kwargs、HTML→plain 调用顺序、send Message、edit live `True`/preview `None`、not-modified 行为和日志保持不变。
- `protected_state`：消息文本、API 调用次数/顺序、message-id、外层 retry、网络/媒体/文件与持久化 write set。
- 允许的副作用：删除重复 helper 分支与重复维护成本。
- 禁止的副作用：不得改变 limiter、queue、retry、异常分类、日志级别/渲染文本、外部发送或 state。

## 改动范围

- 主要文件：`telegram_utils.py` 将四个私有 helper 收敛为 `_send_html_message/_edit_html_message`，通过 `Literal["live", "preview"]` 保留渠道策略；直接测试补齐两种渠道的行为矩阵；ledger 记录证据。
- 配置或迁移影响：无；migration append-only 检查通过。
- 错误处理：仅 `_is_telegram_html_parse_error` 触发一次纯文本降级；非解析异常原样传播。not-modified 仍由 live 静默返回、preview 输出原 debug 后返回，不新增 catch 或假成功。
- production 计量：PR10 `87,185` → PR11 `87,143`，净减少 `42`；Python/infra 各 `-42`，files/TS 不变；candidate source-set digest `e330b219d28313c506271787ca200d3c03eb0c0d725faf0cfab81d9c616eb2fb`。
- helper 计量：旧四 helper `101` SLOC → 新两 helper `51` SLOC；加入类型与调用参数后，`telegram_utils.py` `1,098 → 1,056`。
- 回滚方式：revert 单提交 `08c4af2739e53801c7ad7db3fe5f90adea6f4ab0`；主 Agent收尾前备份 `/tmp/less-is-more-pr11-root-finish-gx1INm`。

## 验证

- [x] `pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py`：主 Agent复跑 `39 passed in 2.65s`
- [x] 直接 oracle：live/preview send parse fallback + Message/call order、send 非解析异常、edit parse fallback + 渠道返回、edit 非解析异常、not-modified no-plain-retry + 日志。
- [x] `pyright --venvpath /mnt/data/coding/akasic-agent infra/channels/telegram_utils.py tests/test_telegram_utils.py`：`0 errors`；warnings `18 → 16`。
- [x] legacy 四 helper 全库零残留；migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] `python docker/debug/gate.py run --base perf/less-is-more-pr10-wake-context-single-query` 已运行并通过。
- `sourceDigest`：`c6e2fc23cc2f8bde549bf8227c21a6cbb83413be3219ee979fe7cb351d0608ff`
- `planDigest`：`0f9920245efebe7806252a8454beb1ee7575b1c67f48ba07bdd2800fc855f922`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-034735-0327dd53`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 `projectneed.md`、CHA/ERR 相关条款与 `NOW.md`。
- [x] 本次没有长期语义变化；错误处理、注释、日志与外部边界已对账。
- [x] 未修改正式 workspace、数据库、服务、配置、协议、媒体文件、消息记录或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`，无 blocking finding；逐项核对 API kwargs/order、渠道返回、日志/异常、boundary tests、SLOC、stack 与 committed-head Gate。
- less-is-more PR1～PR11 相对 PR0 baseline 净减少 `397` production SLOC（`87,540 → 87,143`）。
