### PR TITLE
perf(plugins): reuse discovered package map

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -28,7 +28,10 @@ from agent.plugins.manifest import (
     write_package_manifest,
     write_plugin_manifest,
 )
-from agent.plugins.packages import discover_plugin_packages, enabled_plugin_packages
+from agent.plugins.packages import (
+    _select_enabled_plugin_packages,  # pyright: ignore[reportPrivateUsage]
+    discover_plugin_packages,
+)
 from agent.plugins.specs import (
     ManagedServiceSpec,
     McpServerSpec,
@@ -618,8 +621,8 @@ class PluginManager:
         project_root = _package_project_root(self._dirs)
         packages = discover_plugin_packages(project_root) if project_root else {}
         enabled_packages = (
-            enabled_plugin_packages(
-                project_root,
+            _select_enabled_plugin_packages(
+                packages,
                 load_package_manifest(_plugins_home(self._installed_cache_root)),
             )
             if project_root

--- a/agent/plugins/packages.py
+++ b/agent/plugins/packages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tomllib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -63,7 +64,16 @@ def enabled_plugin_packages(
     project_root: Path,
     entries: dict[str, bool],
 ) -> dict[str, PluginPackage]:
-    packages = discover_plugin_packages(project_root)
+    return _select_enabled_plugin_packages(
+        discover_plugin_packages(project_root),
+        entries,
+    )
+
+
+def _select_enabled_plugin_packages(
+    packages: Mapping[str, PluginPackage],
+    entries: Mapping[str, bool],
+) -> dict[str, PluginPackage]:
     enabled = {
         package_id: package
         for package_id, package in packages.items()

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -281,6 +281,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、正式 workspace、服务、网络、外部发送或 Git refs。备份：`/tmp/less-is-more-pr12-backup/`。回滚点：本 PR 单提交 revert。
 - 残余风险：取消 oracle 启动真实 `sleep`，依赖当前 POSIX/Windows shell 可执行环境；测试等待 options/pump instrumentation 后再取消，未放宽取消或进程组合同。
 
+## 2026-07-23 less-is-more PR13：复用插件包 discovery 映射
+
+### `PR13` `perf(plugins): reuse discovered package map`
+
+- base：PR12 commit `9ad4daff3b1f79150e6007727f60846ab40a784b`，分支 `perf/less-is-more-pr13-reuse-plugin-package-discovery`。
+- allowed_paths：`agent/plugins/packages.py`、`agent/plugins/manager.py`、`tests/test_plugin_packages.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：插件包 discovery 与 manager 同轮 enable 选择；未修改 dashboard public API/generation/snapshot/lease/event、插件 manifest schema 或 hot-reload 生命周期。
+- 原问题与实现：`PluginManager.discover()` 已得到完整 package map，却再次从 project root 读取并解析每个 `package.toml`。保留 public `enabled_plugin_packages(project_root, entries)`，新增接收 `Mapping` 的私有 `_select_enabled_plugin_packages`，manager 将同轮 discovery map 直接传入；不跨轮缓存、不重复校验、不新增 catch/fallback。
+- 不变量与错误语义：启用筛选的 insertion order、disabled member 过滤、原 capability conflict 文本与 fail-fast 传播保持不变；`Mapping` 接受只读视图但本轮 map 仍由 discovery 唯一拥有。插件 topology/order、package_id、manifest/provides schema、dashboard 调用路径均未改动。
+- baseline：source-set digest `b86f87caa1b51f15c040fdfb3009c4f9f5eeef38d4a76cd09baecea370d098dd`，文件数 `384`，Python SLOC `78,622`，TypeScript/TSX SLOC `8,451`，total production SLOC `87,073`。
+- candidate：source-set digest `e49e6f60681efe5b7dcfca789b5c4767b12f4b357ce20647d2517442802abf99`，文件数 `384`，Python SLOC `78,633`，TypeScript/TSX SLOC `8,451`，total production SLOC `87,084`；`agent` 从 `28,747` 增至 `28,758`，production 净增加 `11` 行，属于保留 public wrapper、Mapping helper 和类型边界的最小实现。
+- 性能回放：同一 cwd fixture、同一 `.venv` 与临时 workspace/cache，500 轮 `PluginManager.discover()`；package.toml reads/parses 从 `4 → 2`/round（总计 `2,000 → 1,000`），两条路径各保持每轮一次读取；观察性 wall-time `219.672 → 171.849 ms`（约 `-21.77%`），仅作为本机 parser/discovery 观测，不宣称端到端 runtime 提速。
+- 测试与静态验证：`pytest -q tests/test_plugin_packages.py tests/test_plugin_manager.py tests/test_plugin_hot_reload.py tests/test_plugin_skill_links.py` 为 `189 passed in 10.78s`；新增真实 manager `package.toml` 每路径一次读取 oracle，并断言默认 manifest 下 package members 被过滤且非包插件 topology/order/identity 保持；保留 public conflict/malformed/disabled 覆盖；目标文件 pyright `0 errors, 14 warnings`，与 base warning 数一致；migration append-only、`git diff --check` 与 production SLOC 通过。
+- Gate：按 WORKFLOW 以 PR12 base 运行 committed-head 公开 Gate 并通过；private Gate 状态 `pending_maintainer`。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event 或 Git refs。执行前备份：`/tmp/less-is-more-pr13-backup-QPS3Qt/`；回滚点为本 PR 单提交 revert。
+- 残余风险：wall-time 仅覆盖同步 discovery/parser；若未来 discovery map 跨 round 共享或 package schema 改为有状态解析，必须重新核对 PLG-002 的 round snapshot 与错误 owner，不应把本 helper 变成跨轮缓存。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/tests/test_plugin_packages.py
+++ b/tests/test_plugin_packages.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -27,6 +28,39 @@ def test_repository_declares_two_proactive_packages() -> None:
         "wake_proactive_flow",
         "wake_drift_flow",
     )
+
+
+def test_manager_discover_reads_each_package_file_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    manager = PluginManager(
+        [root / "plugins"],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "cache",
+    )
+    original_read_text = Path.read_text
+    reads: list[Path] = []
+
+    def record_read(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path.name == "package.toml":
+            reads.append(path)
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", record_read)
+
+    mods = manager.discover()
+
+    assert reads == [
+        root / "plugin_packages" / "default-proactive" / "package.toml",
+        root / "plugin_packages" / "wake-proactive" / "package.toml",
+    ]
+    assert [(mod["name"], mod["package_id"], mod["source_type"]) for mod in mods] == [
+        ("akasha", "", "builtin"),
+        ("default_memory", "", "builtin"),
+    ]
 
 
 def test_proactive_runtime_is_exclusive(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`PluginManager.discover()` 已读取完整 package map，随后 `enabled_plugin_packages()` 又从磁盘读取并解析同一批 `package.toml`，同轮 topology 可能来自两个时刻。
- 用户可见结果：插件启用、顺序与能力不变；每轮 package TOML reads/parses `4→2`，500 轮本机观察耗时降低 `21.77%`，并让同轮 discovery 使用同一 topology。
- 本 PR 不处理：dashboard 公共 API、generation/snapshot/lease/event、hot-reload transaction、manifest schema 或跨轮缓存。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：插件 package discovery 与 manager 同轮 enable selection
- `consumer_scope`：`PluginManager.discover/watch_revision/load_all/prepare_changed`；dashboard 继续使用原 public wrapper。
- `runtime_patch`：`none`
- `authoritative_state_owner`：每轮 `discover_plugin_packages()` 结果继续拥有该轮 package topology；manifest 继续拥有 enable flags。
- 关联不变量：package id/members/provides、insertion order、disabled filtering、capability conflict 文本与 fail-loud 传播不变。
- `protected_state`：plugin generation、snapshot、lease、event handlers、dashboard bindings、manifest 与 hot-reload rollback。
- 允许的副作用：同轮复用已发现 map，删除第二轮磁盘读取/parse。
- 禁止的副作用：不得跨轮缓存、改变 public 签名/schema/order/error、generation/lease/event/write set。

## 改动范围

- 主要文件：`packages.py` 保留 public `enabled_plugin_packages(project_root, entries)`，新增接受 `Mapping` 的 package 内私有 selector；`manager.py` 将同轮 map 传入；直接测试锁住读取次数与最终 topology/order；ledger 记录证据。
- 配置或迁移影响：无；migration append-only 检查通过。
- 错误处理：不新增 catch/fallback，不跳过 `_validate_packages`；malformed schema、duplicate member 与 capability conflict 继续在原 owner fail-loud。
- production 计量：PR12 `87,073` → PR13 `87,084`，净增 `11`；Python/agent 各 `+11`，files/TS 不变；candidate source-set digest `e49e6f60681efe5b7dcfca789b5c4767b12f4b357ce20647d2517442802abf99`。
- 性能回放：同一 fixture 500 rounds，reads/parses `2,000→1,000`（每轮 `4→2`），wall `219.672→171.849 ms`（`-21.77%`）。仅为同步 parser/discovery 观察，不宣称端到端 runtime 提速。
- 回滚方式：revert 单提交 `b3614d6a38931bc264ce8135ea525753255edb61`；备份 `/tmp/less-is-more-pr13-backup-QPS3Qt/`、`/tmp/less-is-more-pr13-topology-backup-6VpQv2/`。

## 验证

- [x] `pytest -q tests/test_plugin_packages.py tests/test_plugin_manager.py tests/test_plugin_hot_reload.py tests/test_plugin_skill_links.py`：主 Agent复跑 `189 passed in 3.87s`
- [x] direct oracle：两条 package.toml 各读一次；默认 manifest 下 package members 过滤不变；非包插件 `akasha/default_memory` topology/order/identity 不变。
- [x] 保留 public conflict/malformed/disabled tests；reconcile multi-plugin/latest snapshot oracle 不变。
- [x] `pyright --venvpath /mnt/data/coding/akasic-agent agent/plugins/packages.py agent/plugins/manager.py tests/test_plugin_packages.py`：`0 errors, 14 warnings`，与 base 一致。
- [x] migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] `python docker/debug/gate.py run --base refactor/less-is-more-pr12-remove-dead-shell` 已运行并通过。
- `sourceDigest`：`e20efa5af68386b2d8e06375afc18b8e524b11bc7c5d3095759f04d847b7e421`
- `planDigest`：`84355e5d1a35bb6f223a32348afca13c34e0d5b39db53a1e05b3c21db7daa8c9`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-041900-62ffb3da`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 `projectneed.md`、PLG-002/003/007/PER 相关条款与 `NOW.md`。
- [x] 本次没有长期语义变化；错误处理、拓扑 owner、注释与公共 API 已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；无 blocking finding，公开 API、排序、逐轮刷新与 fail-loud 错误语义保持。
- less-is-more PR1～PR13 相对 PR0 baseline 净减少 `456` production SLOC（`87,540 → 87,084`）；本 PR `+11` 如实计入。
