### PR TITLE
perf(telegram): avoid eager lock allocation

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -343,6 +343,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event 或 Git refs。执行前备份：`/tmp/less-is-more-pr16-backup-20260723-043500/`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 或外部未跟踪副本可能保留旧 helper 文本，但当前 Git source 与动态调用面没有 consumer；若未来恢复旧 admission 链路，应从 active `_tick` owner 重新设计，不复活该 dead helper。
 
+## 2026-07-23 less-is-more PR17：避免 Telegram 锁的命中路径 eager 分配
+
+### `PR17` `perf(telegram): avoid eager lock allocation`
+
+- base：PR16 committed HEAD `9d37ce7ea21540564baa86fd519c0d266dea620c`，分支 `perf/less-is-more-pr17-telegram-lock-allocation`。
+- allowed_paths：`infra/channels/telegram_utils.py`、`tests/test_telegram_utils.py`、`docs/refactor/clean-code-ledger.md`；`capability_owner`：Telegram 出站 limiter 与 live edit queue 的 per-chat 锁；未修改 retry/flood/clock/cleanup/API、锁 map 声明、数据库、网络或正式 workspace。
+- 原问题与真实路径：Python 会先求值 `mapping.setdefault(key, asyncio.Lock())` 的默认参数，即使 key 已命中也构造并丢弃一个 `Lock`。四处命中分别是 `TelegramOutboundLimiter._chat_locks`、`_typing_locks`（`WeakValueDictionary`）以及 `TelegramLiveEditQueue._locks` 的 `reserve`/无 limiter `run` 分支（普通 `dict`）。
+- 范围与语义：四处统一为 `lock = mapping.get(key)`，仅在 `None` 时构造并写回；没有改用 `defaultdict`，也未抽兼容 helper。`get` 与插入之间无 `await`，单事件循环下的 identity、同 chat 串行、RetryAfter/cooldown/backoff、flood/clock/cleanup 和外部发送顺序保持不变。`WeakValueDictionary` 弱生命周期与普通 dict 的具体类型均保持。
+- 真实 oracle：新增测试用计数 Lock factory 预置 existing key，先执行 limiter send/typing 与 queue reserve/run 四条命中路径并断言 `constructions == 0`，再执行四条 miss 路径并断言总构造数为 `4`，同时保留 existing lock identity。未新增 absence、fallback 或 fake success 测试。
+- baseline：source-set digest `483b61c61b7c5a1377a198ff4ea6e2ff98c062df41a3b72ff1780aa533c7b137`，文件数 `383`，Python SLOC `78,318`，`infra` SLOC `11,311`，total production SLOC `86,769`。
+- candidate：source-set digest `8d5219c387c8b77a6619c1eca82087194a8cf5c8649380f5778b316f8b29442a`，文件数 `383`，Python SLOC `78,330`，`infra` SLOC `11,323`，total production SLOC `86,781`；production 净增加 `12` 行，均为四处显式 miss 分支。
+- 同 workload microbench：使用相同 Python `3.13.7`、同一进程脚本，每个 map 跑 `10,000` 个 existing-key hit 加 `1` 个 miss，并计数 map lookup/hit/miss 与 Lock 构造；Weak chat/typing 两张 map 各为 `lookups 10,001 / hits 10,000 / misses 1 / constructions 10,001 → 1`，普通 dict 的 `reserve`/`run` 两张 map 同样为 `10,001 / 10,000 / 1 / 10,001 → 1`。聚合构造数：Weak `20,002 → 2`，普通 `20,002 → 2`。这是 lookup/allocation microbench，仅声明锁对象分配变化，不宣称网络吞吐或端到端 Telegram 延迟。
+- 测试与静态验证：`pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py` 为 `40 passed`；`python -m compileall -q infra/channels/telegram_utils.py tests/test_telegram_utils.py` 通过；`pyright --venvpath /mnt/data/coding/akasic-agent infra/channels/telegram_utils.py tests/test_telegram_utils.py` 为 `0 errors, 16 warnings`（均为 telegram_utils 既有第三方/动态类型告警，测试文件无诊断）；精确 `setdefault(... asyncio.Lock())` 搜索为零，consumer/type/Weak-map allocation/concurrency preservation oracle、migration append-only、`git diff --check` 均通过。
+- Gate：按 WORKFLOW 在提交后以 committed HEAD 对 PR16 base `9d37ce7ea21540564baa86fd519c0d266dea620c` 运行公开 Gate；private required 状态记录为 `pending_maintainer`，不把运行后 digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、SQLite、正式 workspace、服务、外部网络或 Git refs。执行前备份：`/tmp/less-is-more-pr17-backup-GxyTZW/`；回滚点为本 PR 单提交 revert。
+- 残余风险：microbench 只覆盖 map lookup 与锁对象分配；若未来把 map 访问跨线程化或在 get/insert 之间引入 await，必须重新核对并发身份语义，不恢复 eager 分配作为同步手段。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/channels/telegram_utils.py
+++ b/infra/channels/telegram_utils.py
@@ -91,7 +91,10 @@ class TelegramOutboundLimiter:
         if kind == "typing":
             return await self._run_typing(cid, label=label, action=action)
         attempts = max_attempts or self._max_attempts
-        lock = self._chat_locks.setdefault(cid, asyncio.Lock())
+        lock = self._chat_locks.get(cid)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._chat_locks[cid] = lock
         async with lock:
             last_err: Exception | None = None
             for attempt in range(1, attempts + 1):
@@ -142,7 +145,10 @@ class TelegramOutboundLimiter:
         label: str,
         action: Callable[[], Awaitable[_T]],
     ) -> _T:
-        lock = self._typing_locks.setdefault(chat_id, asyncio.Lock())
+        lock = self._typing_locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._typing_locks[chat_id] = lock
         async with lock:
             now = asyncio.get_running_loop().time()
             wait_s = self._next_typing_at.get(chat_id, 0.0) - now
@@ -488,7 +494,10 @@ class TelegramLiveEditQueue:
         self._current_interval_s: dict[int, float] = {}
 
     async def reserve(self, chat_id: int, *, label: str) -> None:
-        lock = self._locks.setdefault(chat_id, asyncio.Lock())
+        lock = self._locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[chat_id] = lock
         async with lock:
             await self._wait_for_slot(chat_id)
             self._mark_used(chat_id)
@@ -535,7 +544,10 @@ class TelegramLiveEditQueue:
             except (TimedOut, NetworkError) as e:
                 logger.warning("[telegram] %s live 更新失败，已跳过: %s", label, e)
                 return None
-        lock = self._locks.setdefault(chat_id, asyncio.Lock())
+        lock = self._locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[chat_id] = lock
         async with lock:
             strikes = self._flood_strikes.get(chat_id, 0)
             if strikes >= _LIVE_MAX_FLOOD_STRIKES and not force:

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -274,6 +274,48 @@ async def test_outbound_limiter_typing_does_not_delay_send(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_lock_maps_allocate_only_for_missing_keys(monkeypatch):
+    original_lock = telegram_utils_module.asyncio.Lock
+    constructions = 0
+
+    def counting_lock():
+        nonlocal constructions
+        constructions += 1
+        return original_lock()
+
+    limiter = TelegramOutboundLimiter(
+        send_interval_s=0.0,
+        typing_interval_s=0.0,
+        global_interval_s=0.0,
+    )
+    existing_chat_lock = original_lock()
+    existing_typing_lock = original_lock()
+    limiter._chat_locks[123] = existing_chat_lock
+    limiter._typing_locks[123] = existing_typing_lock
+    queue = TelegramLiveEditQueue(min_interval_s=0.0)
+    existing_queue_lock = original_lock()
+    queue._locks[123] = existing_queue_lock
+
+    monkeypatch.setattr(telegram_utils_module.asyncio, "Lock", counting_lock)
+    await limiter.run(123, kind="send", label="send", action=AsyncMock(return_value=True))
+    await limiter.run(123, kind="typing", label="typing", action=AsyncMock(return_value=True))
+    await queue.reserve(123, label="existing")
+    await queue.run(123, label="existing", action=AsyncMock(return_value=True))
+
+    assert constructions == 0
+
+    await limiter.run(456, kind="send", label="send", action=AsyncMock(return_value=True))
+    await limiter.run(456, kind="typing", label="typing", action=AsyncMock(return_value=True))
+    await queue.reserve(456, label="missing")
+    await queue.run(789, label="missing", action=AsyncMock(return_value=True))
+
+    assert constructions == 4
+    assert limiter._chat_locks[123] is existing_chat_lock
+    assert limiter._typing_locks[123] is existing_typing_lock
+    assert queue._locks[123] is existing_queue_lock
+
+
+@pytest.mark.asyncio
 async def test_outbound_limiter_global_slot_covers_action():
     limiter = TelegramOutboundLimiter(
         send_interval_s=0.0,


### PR DESCRIPTION
## 问题与结果

- 解决的问题：四处 `mapping.setdefault(key, asyncio.Lock())` 在 key 已存在时仍会先构造并丢弃一个 Lock，给 Telegram limiter/live edit 命中路径制造无用分配。
- 用户可见结果：发送、typing、live edit、重试与退避能力不变；同一 workload 每张 map 的 Lock 构造 `10,001 → 1`。
- 本 PR 不处理：retry/flood/clock/cleanup/API、Weak/normal map 声明、网络调用或持久化。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：Telegram outbound limiter 与 live edit queue 的 per-chat lock。
- `consumer_scope`：send、typing、reserve、无 limiter live-edit run 四条路径。
- `runtime_patch`：`none`
- `authoritative_state_owner`：锁 map、cooldown/flood/clock owner 不变。
- 关联不变量：WeakValueDictionary 弱生命周期、normal dict type、lock identity、RetryAfter/cooldown/backoff、发送顺序保持。
- `protected_state`：Telegram 外部发送、per-chat/global pacing、live edit flood state。
- 允许的副作用：命中时不再创建临时 Lock；miss 时仍创建并保存一个 Lock。
- 禁止的副作用：不得改为 defaultdict、改变锁类型/作用域、跨线程契约或错误降级。

## 改动范围

- 主要文件：四处改为显式 `get`，仅在 `None` 时构造/insert；一个紧凑 oracle 覆盖 existing 四路径零构造、missing 四路径四次构造及既有 identity。
- 并发依据：四条路径均运行在单事件循环，get 与 insert 之间没有 await；不改变协作式调度下同 key lock identity。
- 配置或迁移影响：无；migration append-only 检查通过。
- 错误处理：不改 RetryAfter/TimedOut/NetworkError/flood 分支，不新增 catch/fallback。
- production 计量：PR16 `86,769` → PR17 `86,781`，Python/infra `+12`；属于四处显式 miss 分支，candidate digest `8d5219c387c8b77a6619c1eca82087194a8cf5c8649380f5778b316f8b29442a`。
- 性能回放：每张 map 相同 `10,000` existing hits + `1` miss，lookups/hits/misses=`10,001/10,000/1`；Weak chat/typing 与 normal reserve/run 的构造均 `10,001 → 1`，聚合 Weak `20,002 → 2`、normal `20,002 → 2`。仅声明 lookup/allocation，不宣称网络吞吐或端到端延迟。
- 回滚方式：revert 单提交 `0f1c8c132f65a1cae71b8d84f26f97a92256fd9c`；备份 `/tmp/less-is-more-pr17-backup-GxyTZW/`。

## 验证

- [x] `pytest -q tests/test_telegram_utils.py tests/test_channel_clients.py`：主 Agent复跑 `40 passed in 2.58s`。
- [x] `compileall` 覆盖 source 与 oracle。
- [x] source/test Pyright：`0 errors, 16 warnings`；均为 source 既有第三方/动态类型告警。
- [x] oracle：existing 四路径构造 0，missing 四路径构造 4，既有 Lock identity 保持。
- [x] migration append-only、production SLOC、`git diff --check` 全部通过。
- [x] `python docker/debug/gate.py run --base 9d37ce7ea21540564baa86fd519c0d266dea620c` 已运行并通过。
- `sourceDigest`：`1cd195d2a6712c821a18d019340b8c4b2fad515aa527340d72f8488eb3c3ee81`
- `planDigest`：`cfb75390e37893b58b5ebc717caf560695ca35d42d6a14976c5a2f195870d4a9`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-045332-dc495ff9`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client/APK；Telegram 网络未压测。

## 工作手册

- [x] 已核对 `projectneed.md`、Channel/Performance 相关条款与 `NOW.md`。
- [x] 本次没有长期语义变化；锁生命周期、错误处理、外部发送与注释已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：代码与语义 `ACCEPT`；无 blocking finding，private Gate 继续 `pending_maintainer`。
- less-is-more PR1～PR17 相对 PR0 baseline 净减少 `759` production SLOC（`87,540 → 86,781`）；本 PR `+12` 如实计入。
