### PR TITLE
refactor(akasha): remove dead core database helpers

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -514,6 +514,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、外部网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr27-backup-1784758748/`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 可能保留旧 wrapper 文本，但 current canonical source、调用面与外部 plugin cache 没有 consumer；若未来 PersonaMem 需要把 persona profile 注入 runtime，应在 benchmark owner 中设计显式参数与语义合同，不恢复无效转发层。
 
+## 2026-07-23 less-is-more PR28：删除 Akasha core 中四个不可达 DB helper
+
+### `PR28` `refactor(akasha): remove dead core database helpers`
+
+- base：PR27 committed HEAD `e229001bdf9983e07410cf6dbcdad7343baab7aa`，分支 `refactor/less-is-more-pr28-remove-dead-akasha-core-helpers`。
+- allowed_paths：`plugins/akasha/core.py` 仅删除 `message_id_to_key_from_db`、`open_source_db`、`get_turn_context`、`load_state` 四个 exact-zero 顶层函数；本账本；`capability_owner`：Akasha active engine/store/replay 的核心算法与读取 owner。未修改 active `engine._affected_turn_keys`/`_load_turn_card`、`replay._turn_messages`、`AkashaStore.list_nodes`/`load_edges_with_meta`/`_load_graph_cache`、共享 `sqlite3`/`turn_key`/`deserialize_f32` imports、SQL、embedding/cache、错误处理、schema、migration、manifest、tests 或 canonical 外部仓库。
+- 历史与不可达性：四个 helper 在首次引入 `6310c87e` 后的 Git 历史中只保留定义，`git log -S` 与初始提交源码核对未发现生产 caller。当前 PR27 worktree 的 CodeGraph、AST call/attribute/import scan、精确文本/动态 `getattr`/export/reflection scan 仅命中待删定义；`engine.py`、`store.py`、`replay.py` 的 active owner 使用各自现有读取路径。只读扫描 `/mnt/data/coding/akasha`（当前有维护者未提交改动）及 `/home/huashen/.akashic-plugin/cache` 未发现四个名称的 consumer；缓存中无对应 enabled plugin owner。
+- 语义与错误边界：这些函数分别是旧 message-id 反查（含未命中时返回原 ID 的降级）、sqlite-vec 源库开启、展示用 user/assistant 文本裁切和旧 sidecar 全量状态读取；当前没有调用者、导出或反射 owner，因此删除不会改变 active turn identity、replay card、节点/边加载、向量反序列化、SQL/write set、错误传播或持久化结果。`change_type: refactor`，`semantic_delta: none`；不删除仍被 `engine/store/replay` 使用的共享数据库和算法 helper，不新增 fallback、try/except、兼容层、absence oracle 或 mock success 路径。
+- 范围与计量：删除 `plugins/akasha/core.py` 107 个物理行、97 个非空非注释行；按 `scripts/measure_production_sloc.py`，删除前 source-set digest `b4ac1af9d07d23f933ef471f8bfad26befa8db18834faa0b78bfe758f2a159eb`、文件数 `378`、Python SLOC `77,525`、`plugins` SLOC `17,229`、total production SLOC `85,976`；删除后 digest `8dc2e7c38387a8ae910ea75a87765c5ab8b525627e263aab93095b894d3e4a86`、文件数 `378`、Python SLOC `77,432`、`plugins` SLOC `17,136`、total `85,883`；production 净减少 `93` SLOC。无测试源码变更。
+- 性能与状态：模块导入时少创建四个不可达函数对象；旧 helper 的 sqlite connection、cursor、查询和向量扩展加载路径不再可从当前代码触发。没有新增模型调用、SQL、I/O、等待、持久化、网络、事件、write set 或 schema 变化，不宣称端到端性能收益；正式 workspace、数据库和缓存均未写入。
+- 测试与静态验证：项目 venv `pytest -q -W error tests/test_akasha_plugin.py tests/test_fast_rebuild_parity.py` 为 `68 passed in 1.02s`；相关 replay/full-run/provider migration 回归 `29 passed in 1.48s`；`tests/test_production_sloc.py tests/semantic/test_change_gate.py tests/test_migration_append_only.py` 为 `24 passed in 2.07s`；`plugins/akasha` 与相关 tests `compileall` 通过；修改文件 `plugins/akasha/core.py` pyright `0 errors, 0 warnings`，engine/store/replay 联合检查 `0 errors, 2 warnings`（replay.py:291/294 既有 unknown-type warnings）；AST/精确 consumer/dynamic/export/plugin-cache scan、protected-path/migration/SLOC、`git diff --check` 通过。
+- Gate：待提交后以 committed HEAD 对 PR27 base `e229001bdf9983e07410cf6dbcdad7343baab7aa` 运行公开 Gate；private required 状态记录为 `pending_maintainer`，不把运行后 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、SQLite、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr28-backup-1784759365/`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint、`/mnt/data/coding/akasha` 的未提交副本或外部运行日志可能保留旧 helper 文本，但 current PR27 source、历史 Git consumer scan 与 plugin cache 没有 owner；若未来需要 message-id 映射、展示卡片或 sidecar loader，应在 active engine/store/replay owner 中重新设计显式合同，不恢复这些无调用的旧 helper。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/akasha/core.py
+++ b/plugins/akasha/core.py
@@ -598,30 +598,7 @@ def parse_ts_unix(value: str) -> float:
         raise ValueError(f"无效时间戳: {value}") from exc
 
 
-def message_id_to_key_from_db(cursor: sqlite3.Cursor, message_id: str) -> str:
-    """从 messages 表反查 message id 对应的 turn key。"""
-    _ = cursor.execute(
-        "SELECT session_key, seq, role FROM messages WHERE id = ?",
-        (message_id,),
-    )
-    row = cursor.fetchone()
-    if row:
-        _, _, key = turn_key(str(row[0]), int(row[1]), str(row[2] or ""))
-        return key
-    return message_id  # 降级返回
-
-
 # ── DB 工具函数 ───────────────────────────────────────────────────────
-
-
-def open_source_db(path: str) -> sqlite3.Connection:
-    """打开带 sqlite-vec 的源数据库。"""
-    import sqlite_vec
-    db = sqlite3.connect(path)
-    db.enable_load_extension(True)
-    sqlite_vec.load(db)
-    db.enable_load_extension(False)
-    return db
 
 
 def has_user_turn(cursor: sqlite3.Cursor | None, key: str) -> bool:
@@ -637,90 +614,6 @@ def has_user_turn(cursor: sqlite3.Cursor | None, key: str) -> bool:
         (session_key, seq),
     )
     return cursor.fetchone() is not None
-
-
-def get_turn_context(cursor: sqlite3.Cursor, key: str) -> tuple[str, str]:
-    """从 messages 表读取 user/assistant 消息内容（用于展示）。"""
-    parsed = parse_turn_key(key)
-    if parsed is None:
-        return "", ""
-    session_key, seq = parsed
-    _ = cursor.execute(
-        "SELECT content FROM messages WHERE session_key = ? AND seq = ? AND role = 'user'",
-        (session_key, seq),
-    )
-    user_row = cursor.fetchone()
-    _ = cursor.execute(
-        "SELECT content FROM messages WHERE session_key = ? AND seq = ? AND role = 'assistant'",
-        (session_key, seq + 1),
-    )
-    assistant_row = cursor.fetchone()
-    user_text = (user_row[0] if user_row else "") or ""
-    assistant_text = (assistant_row[0] if assistant_row else "") or ""
-    user_text = user_text.replace("\n", " ").strip()
-    assistant_text = assistant_text.replace("\n", " ").strip()
-    if len(user_text) > 58:
-        user_text = user_text[:55] + "..."
-    if len(assistant_text) > 58:
-        assistant_text = assistant_text[:55] + "..."
-    return user_text, assistant_text
-
-
-def load_state(
-    path: str,
-) -> tuple[dict[str, AkashaNode], dict[tuple[str, str], float], dict[str, tuple[int, int]]]:
-    """从 sidecar DB 加载全部节点、边和激活统计。"""
-    db = sqlite3.connect(path)
-    cursor = db.cursor()
-    _ = cursor.execute(
-        """
-        SELECT key, anchor_id, session_key, turn_seq, first_ts_unix, salience,
-               strength, resource, recall_count, last_activated_ts,
-               last_strength_ts, last_resource_ts, embedding, emb_count
-        FROM akasha_nodes
-        """
-    )
-    nodes: dict[str, AkashaNode] = {}
-    for row in cursor.fetchall():
-        (
-            key, anchor_id, session_key, turn_seq, first_ts_unix,
-            salience, strength, resource, recall_count,
-            last_activated_ts, last_strength_ts, last_resource_ts,
-            embedding_blob, emb_count,
-        ) = row
-        embedding = deserialize_f32(embedding_blob)
-        if embedding.size == 0:
-            continue
-        nodes[key] = AkashaNode(
-            key=key,
-            anchor_id=anchor_id,
-            session_key=session_key,
-            turn_seq=turn_seq,
-            first_ts_unix=first_ts_unix,
-            salience=salience,
-            strength=strength,
-            resource=resource,
-            recall_count=recall_count,
-            last_activated_ts=last_activated_ts,
-            last_strength_ts=last_strength_ts,
-            last_resource_ts=last_resource_ts,
-            embedding=embedding,
-            emb_count=emb_count,
-        )
-
-    _ = cursor.execute("SELECT src_key, dst_key, weight FROM akasha_edges")
-    edges = {(str(src_key), str(dst_key)): float(weight) for src_key, dst_key, weight in cursor.fetchall()}
-
-    _ = cursor.execute(
-        """
-        SELECT activated_key, COUNT(*) AS c, MAX(seq) AS last_seq
-        FROM akasha_activation_events
-        GROUP BY activated_key
-        """
-    )
-    activation_stats = {str(key): (int(count), int(last_seq)) for key, count, last_seq in cursor.fetchall()}
-    db.close()
-    return nodes, edges, activation_stats
 
 
 # ── 状态计算辅助函数 ──────────────────────────────────────────────────


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`plugins/akasha/core.py` 中 4 个旧 DB/state helper 从首次引入起就没有生产消费者，active owner 已在 engine/store/replay。
- 用户可见结果：Akasha turn identity、card/replay、节点/边缓存、embedding、SQL/write/error 行为不变；production SLOC `85,976 → 85,883`，净删 `93`。
- 本 PR 不处理：active engine/store/replay、共享 DB/算法 imports、schema、migration、manifest、tests 或 canonical 外部 Akasha 仓库。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：Akasha active engine/store/replay。
- `consumer_scope`：四个 helper 从 `6310c87e` 引入至今无 caller；current AST/dynamic/export/reflection、canonical Akasha 与 plugin cache 均无 consumer。
- `runtime_patch`：`none`
- `authoritative_state_owner`：AkashaStore/engine/replay schema、SQL、cache/write set 无变化。
- 关联不变量：message→turn、turn card、replay messages、node/edge graph cache、vector decode 与错误传播保持。
- `protected_state`：Akasha DB、session messages、embedding/cache、正式 workspace、外部 canonical repo。
- 允许的副作用：删除 4 个不可达函数对象。
- 禁止的副作用：不得删除 shared imports 或修改 active DB/query/embedding/error 路径。

## 改动范围

- 主要文件：`plugins/akasha/core.py` 仅删除 `message_id_to_key_from_db`、`open_source_db`、`get_turn_context`、`load_state`；追加账本。
- 历史证据：`git log -S` 与初始提交核对只有定义；现行 owner 分别为 `_affected_turn_keys`、`_load_turn_card`、`replay._turn_messages`、AkashaStore/load graph cache。
- 配置或迁移影响：无；未修改 schema、manifest、migration、workspace 或 canonical 外部仓库。
- 错误处理：旧 fallback/DB helper 没有可达 caller；active fail-loud 查询与错误传播不变，不新增 catch/fallback。
- production 计量：PR27 `85,976` → PR28 `85,883`，Python/plugins `-93`；candidate digest `8dc2e7c38387a8ae910ea75a87765c5ab8b525627e263aab93095b894d3e4a86`。
- 性能：模块导入少创建 4 个不可达函数；不可达 sqlite/vector/query 路径不再占源码表面积，不声明端到端收益。
- 回滚方式：revert 单提交 `56232addfb7364f849140f7af6c0dc41cc00e2e9`；备份 `/tmp/akashic-less-is-more-pr28-backup-1784759365/`。

## 验证

- [x] Akasha plugin/fast rebuild parity：`68 passed`。
- [x] replay/full-run/provider migration：`29 passed`。
- [x] production SLOC/change-gate/migration：`24 passed`。
- [x] Akasha/tests compileall；core Pyright `0 errors, 0 warnings`，联合检查 `0 errors, 2 existing warnings`。
- [x] exact/AST/dynamic/export/canonical/plugin-cache scan、protected paths、`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base e229001bdf9983e07410cf6dbcdad7343baab7aa` 已在 committed HEAD 运行并通过。
- `sourceDigest`：`0294f75a22f8c63a8bba3bc8c0df33a011ccf5ddabadab069f5be0a59c7d121f`
- `planDigest`：`7d5930c21e95b837d5cdb5aa530c7d01532ac35f94d82dadd07af67217a87d6b`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-063332-e29c8d7c`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Akasha/Persistence owner、相关 projectneed 条款与 `NOW.md`。
- [x] 本次没有长期语义变化；active owner、错误处理、持久化、canonical repo 与插件边界已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；无 blocking finding，active engine/store/replay/SQL/schema/write/error 语义保持。
- less-is-more PR1～PR28 相对 PR0 baseline 净减少 `1,657` production SLOC（`87,540 → 85,883`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
