### PR TITLE
refactor(proactive): remove dead tools surface

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -529,6 +529,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、SQLite、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr28-backup-1784759365/`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint、`/mnt/data/coding/akasha` 的未提交副本或外部运行日志可能保留旧 helper 文本，但 current PR27 source、历史 Git consumer scan 与 plugin cache 没有 owner；若未来需要 message-id 映射、展示卡片或 sidecar loader，应在 active engine/store/replay owner 中重新设计显式合同，不恢复这些无调用的旧 helper。
 
+## 2026-07-23 less-is-more PR29：删除 proactive tools 的不可达终止 schema 与 execute wrapper
+
+### `PR29` `refactor(proactive): remove dead tools surface`
+
+- base：PR28 committed HEAD `56232addfb7364f849140f7af6c0dc41cc00e2e9`，分支 `refactor/less-is-more-pr29-remove-dead-proactive-tools-surface`。
+- allowed_paths：`plugins/proactive_flow/tools.py` 仅删除 exact-zero `TERMINAL_TOOL_SCHEMAS` 与顶层 `execute()` 转发 wrapper；`tests/proactive_v2/test_tools.py` 删除 `execute` 专属测试 9 项并将未知工具错误测试直接绑定 `dispatch`；本账本；`capability_owner`：proactive judge 的 `ToolExecutionRequest`→`dispatch` 工具执行边界。未修改 `TOOL_SCHEMAS`、`dispatch` 分支、judge/tool executor、工具参数/结果、步骤计数 owner、plugin manifest、schema 或运行 workspace。
+- 历史与不可达性：`TERMINAL_TOOL_SCHEMAS` 与 `execute()` 随迁移提交 `f91cf993` 保留，但当前生产 judge 在 `plugins/proactive_flow/judge.py:150-158` 由 `ToolExecutor.execute` 直接回调 `dispatch`；CodeGraph、AST、精确 import/attribute、动态 `getattr`/`import_module`/export/reflection、tests、SDK、plugin/manifest 与 `/home/huashen/.akashic-plugin/cache`、`/mnt/data/coding/akasha` 扫描均未发现旧 schema/wrapper consumer。`git log -S` 复核确认迁移后只剩定义与专属测试；wake 的同名 `execute` 属独立插件工具，不在本次范围。
+- active owner 与语义：`TOOL_SCHEMAS` 仍由 ProactiveJudge 发送给 LLM；`dispatch` 仍拥有 12 个工具的分支、unknown-tool `ValueError` 和真实工具错误传播；`ctx.steps_taken` 仍由 judge 在构造 `ToolExecutionRequest` 前递增，不依赖已删除 wrapper。`TERMINAL_TOOL_SCHEMAS` 没有 registry/count/manifest owner。`change_type: refactor`，`semantic_delta: none`；不新增 fallback、try/except、默认值、兼容层或 mock success。
+- 范围与测试：删除 `TERMINAL_TOOL_SCHEMAS` 5 个 production SLOC 与 `execute()` wrapper 3 个 production SLOC；删除 9 个仅验证 wrapper 转发/计数的测试，保留并改为直接验证 `dispatch` unknown-tool fail-fast 的测试及其余真实 helper/schema/tool contract 测试。生产逻辑、步骤计数、schema 数量、错误路径与外部副作用均不变。
+- 计量：删除前 source-set digest `8dc2e7c38387a8ae910ea75a87765c5ab8b525627e263aab93095b894d3e4a86`，文件数 `378`，Python SLOC `77,432`，`plugins` SLOC `17,136`，total production SLOC `85,883`；删除后 source-set digest、SLOC 与 total 由 committed-head Gate 绑定记录，预期 `plugins` SLOC `17,128`、total `85,875`，production 净减少 `8` SLOC。测试删除的 wrapper 专属源码不计入 production SLOC。
+- 性能、错误与注释：模块导入少创建一个无调用 schema 列表和一个 async 转发函数；judge 热路径不增加调用、分配、等待、I/O、持久化、网络或事件，避免一层无效 await/call frame，不宣称端到端提速。删除 stale `execute` 注释并保留 `dispatch` 阶段注释；没有放宽错误处理，unknown tool 继续 fail-fast。
+- 测试与静态验证：项目 venv `pytest -q tests/proactive_v2/test_tools.py` 为 `60 passed in 0.18s`；judge/proactive tick/plugin lifecycle 定向回归 `127 passed in 3.35s`；相关 compileall 通过；`plugins/proactive_flow/tools.py`、`judge.py` pyright `0 errors, 164 warnings`（既有动态 dict warnings，base 同范围 171 warnings，无新增 error）；精确 consumer/dynamic/export/plugin-cache scan、migration append-only 与 `git diff --check` 通过。未删除真实 `dispatch`/schema/工具 contract 覆盖。
+- Gate：在 committed HEAD 对 PR28 base `56232addfb7364f849140f7af6c0dc41cc00e2e9` 运行公开 Gate；private required 状态记录为 `pending_maintainer`，不把运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、SQLite、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr29-backup-qj4rUK/`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint 或外部未跟踪副本可能保留旧 schema/wrapper 文本，但 current source、迁移历史、dynamic scan 与 external plugin cache 没有 consumer；若未来需要 terminal-only schema projection，应由 judge/registry owner 重新设计显式公开合同，不恢复无调用 surface。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/proactive_flow/tools.py
+++ b/plugins/proactive_flow/tools.py
@@ -1,5 +1,5 @@
 """
-proactive_v2/tools.py — Tool schemas + execute dispatcher
+proactive_v2/tools.py — Tool schemas + dispatch dispatcher
 
 数据层已由 DataGateway 预取，agent 只需：
   recall_memory  — 检索偏好记忆（HyDE 正/负假设）
@@ -193,13 +193,6 @@ TOOL_SCHEMAS: list[dict] = [
                 }
             ]}),
 ]
-
-TERMINAL_TOOL_SCHEMAS: list[dict] = [
-    schema
-    for schema in TOOL_SCHEMAS
-    if schema.get("function", {}).get("name") in {"finish_turn"}
-]
-
 
 # ── 工具实现 ──────────────────────────────────────────────────────────────
 
@@ -434,7 +427,7 @@ def _message_push(ctx: AgentTickContext, args: dict) -> str:
     return json.dumps({"ok": True}, ensure_ascii=False)
 
 
-# ── execute 分发 ──────────────────────────────────────────────────────────
+# ── 工具分发 ──────────────────────────────────────────────────────────────
 
 async def dispatch(tool_name: str, args: dict, ctx: AgentTickContext, deps: ToolDeps) -> str:
     if tool_name == "get_alert_events":
@@ -474,8 +467,3 @@ async def dispatch(tool_name: str, args: dict, ctx: AgentTickContext, deps: Tool
         return _finish_turn(ctx, args)
 
     raise ValueError(f"unknown tool: {tool_name!r}")
-
-
-async def execute(tool_name: str, args: dict, ctx: AgentTickContext, deps: ToolDeps) -> str:
-    ctx.steps_taken += 1
-    return await dispatch(tool_name, args, ctx, deps)

--- a/tests/proactive_v2/test_tools.py
+++ b/tests/proactive_v2/test_tools.py
@@ -9,7 +9,7 @@ TDD — Phase 3: proactive_v2/tools.py
   - _mark_not_interesting: 写 ctx.discarded_item_ids
   - _get_alert_events / _get_content_events: 缓存保护
   - _get_context_data: 最多调用一次
-  - execute(): 分发 + steps_taken 递增
+  - dispatch(): 未知工具错误契约
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from plugins.default_proactive.context import AgentTickContext
 from plugins.proactive_flow.tools import (
     TOOL_SCHEMAS,
     ToolDeps,
-    execute,
+    dispatch,
     _web_fetch,
     _web_search,
     _recall_memory,
@@ -624,100 +624,9 @@ async def test_get_recent_chat_returns_json():
     assert json.loads(raw) == msgs
 
 
-# ── execute() 分发 ────────────────────────────────────────────────────────
-
 @pytest.mark.asyncio
-async def test_execute_increments_steps_taken():
-    ctx = AgentTickContext()
-    deps = ToolDeps()
-    await execute("get_alert_events", {}, ctx, deps)
-    assert ctx.steps_taken == 1
-
-
-@pytest.mark.asyncio
-async def test_execute_increments_each_call():
-    ctx = AgentTickContext()
-    deps = ToolDeps()
-    await execute("get_alert_events", {}, ctx, deps)
-    await execute("get_content_events", {}, ctx, deps)
-    assert ctx.steps_taken == 2
-
-
-@pytest.mark.asyncio
-async def test_execute_dispatches_message_push():
-    ctx = AgentTickContext()
-    ctx.fetched_contents = [{"ack_server": "feed-mcp", "event_id": "1"}]
-    deps = ToolDeps()
-    await execute("message_push", {"message": "hi", "evidence": ["feed-mcp:1"]}, ctx, deps)
-    assert ctx.draft_message == "hi"
-
-
-@pytest.mark.asyncio
-async def test_execute_dispatches_finish_turn_reply():
-    ctx = AgentTickContext()
-    deps = ToolDeps()
-    await execute("message_push", {"message": "hi", "evidence": []}, ctx, deps)
-    await execute("finish_turn", {"decision": "reply"}, ctx, deps)
-    assert ctx.terminal_action == "reply"
-
-
-@pytest.mark.asyncio
-async def test_execute_dispatches_finish_turn_skip():
-    ctx = AgentTickContext()
-    deps = ToolDeps()
-    await execute("finish_turn", {"decision": "skip", "reason": "no_content"}, ctx, deps)
-    assert ctx.terminal_action == "skip"
-
-
-@pytest.mark.asyncio
-async def test_execute_dispatches_mark_not_interesting():
-    ctx = AgentTickContext()
-    deps = ToolDeps()
-    await execute("mark_not_interesting", {"item_ids": ["feed-mcp:1"]}, ctx, deps)
-    assert "feed-mcp:1" in ctx.discarded_item_ids
-
-
-@pytest.mark.asyncio
-async def test_execute_unknown_tool_raises():
+async def test_dispatch_unknown_tool_raises():
     ctx = AgentTickContext()
     deps = ToolDeps()
     with pytest.raises(ValueError, match="unknown tool"):
-        await execute("nonexistent_tool", {}, ctx, deps)
-
-
-@pytest.mark.asyncio
-async def test_execute_web_fetch_uses_max_chars_from_deps():
-    fake_tool = AsyncMock()
-    fake_tool.execute.return_value = json.dumps({"url": "x", "text": "z" * 5_000, "truncated": False})
-    ctx = AgentTickContext()
-    deps = ToolDeps(web_fetch_tool=fake_tool, max_chars=2_000)
-    raw = await execute("web_fetch", {"url": "https://x.com"}, ctx, deps)
-    result = json.loads(raw)
-    assert len(result["text"]) == 2_000
-
-
-@pytest.mark.asyncio
-async def test_execute_web_search_uses_tool_from_deps():
-    fake_tool = AsyncMock()
-    fake_tool.execute.return_value = json.dumps({"query": "aurora furia", "result": "..."})
-    ctx = AgentTickContext()
-    deps = ToolDeps(web_search_tool=fake_tool)
-    raw = await execute("web_search", {"query": "aurora furia", "type": "fast"}, ctx, deps)
-    result = json.loads(raw)
-    assert result["query"] == "aurora furia"
-    fake_tool.execute.assert_called_once_with(query="aurora furia", type="fast")
-
-
-@pytest.mark.asyncio
-async def test_execute_recall_memory_uses_memory_from_deps():
-    fake_memory = MagicMock()
-    fake_memory.query = AsyncMock(
-        return_value=SimpleNamespace(
-            records=[SimpleNamespace(id="m1", summary="pref", score=0.9)]
-        )
-    )
-    ctx = AgentTickContext()
-    deps = ToolDeps(memory=fake_memory)
-    raw = await execute("recall_memory", {"query": "test"}, ctx, deps)
-    result = json.loads(raw)
-    assert result["hits"] == 1
+        await dispatch("nonexistent_tool", {}, ctx, deps)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：proactive tools 保留了无人读取的 terminal schema 列表和无人调用的 async `execute()` wrapper；生产 judge 早已直连 `dispatch`。
- 用户可见结果：LLM tool schemas、12 个 dispatch 分支、steps owner 与错误传播不变；production SLOC `85,883 → 85,875`，净删 `8`。
- 测试处理：删除 9 个只验证死 wrapper 的用例；保留 unknown-tool oracle 并改为直接验证 active `dispatch` fail-fast。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：ProactiveJudge/ToolExecutor→`dispatch` 工具执行边界。
- `consumer_scope`：被删 schema/wrapper 在 current production、dynamic/export/reflection、canonical Akasha 与 plugin cache 中无 consumer。
- `runtime_patch`：`none`
- `authoritative_state_owner`：TOOL_SCHEMAS/dispatch/judge step count 无变化。
- 关联不变量：工具参数/结果、unknown-tool ValueError、真实工具异常、step count 与 plugin lifecycle 保持。
- `protected_state`：proactive context、tool effects、正式 workspace、外置插件。
- 允许的副作用：删除不可达列表/函数对象及其自证式测试。
- 禁止的副作用：不得删 dispatch/schema/tool contract oracle 或改变外部副作用。

## 改动范围

- 主要文件：`plugins/proactive_flow/tools.py` 删除 `TERMINAL_TOOL_SCHEMAS` 与顶层 `execute()`；`tests/proactive_v2/test_tools.py` 删除 9 个 wrapper 测试并保留 direct dispatch error oracle；追加账本。
- 历史证据：`f91cf993` 迁移后 production judge 直连 dispatch；current exact/dynamic/export/plugin-cache 扫描为零。
- 配置或迁移影响：无；未修改 schema、manifest、migration 或 workspace。
- 错误处理：unknown tool 与真实工具错误继续 fail-fast/fail-loud，不新增 catch/fallback。
- production 计量：PR28 `85,883` → PR29 `85,875`，Python/plugins `-8`；candidate digest `21bf798339056cdabe75da06f5b6ca6ba3cd9dd267f36359f91ee375cf20c104`。
- 性能：模块导入少创建一个无调用列表和 async wrapper；生产热路径本来不经过 wrapper，不声明端到端提速。
- 回滚方式：revert 单提交 `12abbe5e6754283ea9f616cc7dd64c8f784be118`；备份 `/tmp/akashic-less-is-more-pr29-backup-qj4rUK/`。

## 验证

- [x] proactive tools：`60 passed`。
- [x] judge/tick/plugin lifecycle：`127 passed`。
- [x] 相关 compileall；Pyright `0 errors`，既有 warnings `171 → 164`。
- [x] exact/dynamic/export/external plugin-cache scan、migration append-only、`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base 56232addfb7364f849140f7af6c0dc41cc00e2e9` 已在 committed HEAD 运行并通过。
- `sourceDigest`：`6026d7086bdba955eebf66cb613810c6d387fa931e783569a09160fd76062927`
- `planDigest`：`9c8e8453939a6cb1e431af7bb26ebf1c51c13e5cded399e65ab26b7fabe99b16`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-064158-bb996718`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Proactive/Tool owner、相关 projectneed 条款与 `NOW.md`。
- [x] 本次没有长期语义变化；active owner、错误处理、测试 oracle 与外部插件边界已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；无 blocking finding，dispatch/schema/steps/error 与保留 oracle 语义保持。
- less-is-more PR1～PR29 相对 PR0 baseline 净减少 `1,665` production SLOC（`87,540 → 85,875`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
