### PR TITLE
refactor(proactive): inline prompt memory reads

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -560,6 +560,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-agent-pr30-constants.py.bak`、`/tmp/akashic-agent-pr30-ledger.md.bak`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 或外部未跟踪副本可能保留旧常量文本，但 current source 与 enabled plugin cache 没有 consumer；若未来需要新的 loop owner，应在 active `passive_turn`/`subagent` 或明确新模块中设计合同，不恢复无调用残片。
 
+## 2026-07-23 less-is-more PR31：内联主动上下文的记忆读取
+
+### `PR31` `refactor(proactive): inline prompt memory reads`
+
+- base：PR30 committed HEAD `c98849813a954b5383b96bfd4af3bab9fb8b262d`，分支 `refactor/less-is-more-pr31-inline-proactive-prompt-memory-reads`。
+- allowed_paths：`plugins/proactive_flow/prompt.py` 仅将 `_read_self_text`、`_read_long_term_text` 内联到唯一 caller `ProactivePromptBuilder.build_runtime_context_message`，删除两个 module-private helper；本账本。未修改 prompt 文本、区块顺序、`MemoryProfileApi`、active proactive engine/judge、plugin lifecycle、schema、manifest、缓存或 tests。
+- 历史与唯一 caller：CodeGraph 与 AST/精确调用扫描确认两个 helper 各只有 `build_runtime_context_message` 的一处调用；仓库字符串扫描、动态 import/getattr/export/reflection 与 `/home/huashen/.akashic-plugin/cache` 扫描无其他 consumer；`git log -S` 只显示旧定义迁移提交 `f91cf993`、`869260b8`，未发现额外生产 caller。删除后两个 helper 名称在当前源（账本外）为零残留。
+- 语义与错误边界：`memory = self._memory` 后，`None` 分支仍将 self/long/recent 三个区块置空；非空分支严格按 self→long→recent 顺序执行 `str(value or "").strip()`，异常原样传播。内联不改变 prompt section 名称、内容、顺序、时钟、workspace 或 gateway 数据；`semantic_delta: none`，不新增 fallback、try/except、默认值、兼容层或 mock success 路径。
+- 性能与注释：删除两个无独立 owner 的 module-private forwarding frame 与函数对象；active caller 少一层 Python call/return，读取调用数、分配、等待、I/O、持久化、网络、事件和 write set 不变，不宣称端到端提速。保留阶段 2 注释，不新增冗余注释或错误处理。
+- 范围与计量：删除前 source-set digest `47bccf4f112ea8e0ac0212f88298406bd1a9975a23be2de1fc175973dfa18435`，文件数 `378`，Python SLOC `77,412`，`plugins` SLOC `17,128`，total production SLOC `85,863`；删除后 digest `5ffee260c8a177bb2c5dfed4e7ec90e6a91993acb1415d20f51ce0d44a09adbe`，文件数 `378`，Python SLOC `77,404`，`plugins` SLOC `17,120`，total `85,855`；production 净减少 `8` SLOC。
+- 测试与静态验证：prompt/proactive context、judge/tool、plugin lifecycle 与 agent loop 定向回归 `172 passed in 1.60s`，lifecycle builder/kernel/factory `22 passed in 1.11s`；production SLOC、migration append-only 与 change-gate 选择 `24 passed in 1.73s`；prompt/相关测试 compileall 通过；pyright `0 errors, 12 warnings`，与 PR30 base 完全一致；`git diff --check` 通过。对 PR30 base 与 candidate 使用相同固定 tick/gateway/memory 输入，`None`、普通值、falsey 值的完整 prompt output 字节相同；调用序列均为 `self → long → recent`，self 失败时只调用 self 且原异常文本相同。Black diff 仅报告 base 已存在的其他三处格式差异，PR31 新增区块无需重排。
+- Gate：待 committed HEAD 对 PR30 base `c98849813a954b5383b96bfd4af3bab9fb8b262d` 运行公开 Gate；private required 状态记录为 `pending_maintainer`，不把运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/less-is-more-pr31-prompt.py.bak`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint 可能保留旧 helper 文本，但当前 canonical source、CodeGraph/AST、历史调用面与 enabled plugin cache 无 consumer；若未来需要独立复用记忆读取，应在 active memory owner 中重新设计明确合同，不恢复无调用 wrapper。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/proactive_flow/prompt.py
+++ b/plugins/proactive_flow/prompt.py
@@ -153,13 +153,13 @@ class ProactivePromptBuilder:
         ]
 
         # 2. 读取用户画像与近期上下文
-        self_content = _read_self_text(self._memory).strip()
-        memory_block = _read_long_term_text(self._memory).strip()
-        recent_context_block = (
-            str(self._memory.read_recent_context() or "").strip()
-            if self._memory is not None
-            else ""
-        )
+        memory = self._memory
+        if memory is None:
+            self_content = memory_block = recent_context_block = ""
+        else:
+            self_content = str(memory.read_self() or "").strip()
+            memory_block = str(memory.read_long_term() or "").strip()
+            recent_context_block = str(memory.read_recent_context() or "").strip()
 
         # 3. 追加本轮所有非空动态区块
         for name, content in (
@@ -250,15 +250,3 @@ class ProactivePromptBuilder:
             + json.dumps(annotated_context, ensure_ascii=False)[:900]
             + "\n\n"
         )
-
-
-def _read_long_term_text(memory: MemoryProfileApi | None) -> str:
-    if memory is not None:
-        return str(memory.read_long_term() or "")
-    return ""
-
-
-def _read_self_text(memory: MemoryProfileApi | None) -> str:
-    if memory is not None:
-        return str(memory.read_self() or "")
-    return ""


### PR DESCRIPTION
## 问题与结果

- 解决的问题：主动上下文的 self/long-term memory 各经过一个只有单一 caller 的 module-private forwarding helper。
- 用户可见结果：None/empty 转换、读取顺序 `self → long → recent`、异常传播与最终 prompt 字节完全不变；production SLOC `85,863 → 85,855`，净删 `8`。
- 第一版处理：因重复 ternary 让主流程更臃肿被退回；最终用单一显式 memory 分支收敛三个读取。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`ProactivePromptBuilder.build_runtime_context_message`。
- `consumer_scope`：两个私有 helper 各只有一个 caller；dynamic/export/reflection/plugin-cache 无 consumer。
- `runtime_patch`：`none`
- `authoritative_state_owner`：MemoryProfileApi 与 proactive prompt owner 无变化。
- 关联不变量：None/falsey/str/strip、调用次数/顺序、prompt sections、异常文本保持。
- `protected_state`：memory profile、proactive prompt、正式 workspace、外部插件。
- 允许的副作用：删除两个私有函数对象与 call frame。
- 禁止的副作用：不得改变 prompt 文本、memory I/O、fallback 或吞错。

## 改动范围

- 主要文件：`plugins/proactive_flow/prompt.py` 在阶段 2 用显式 None/else 分支读取 self/long/recent，删除 `_read_self_text`、`_read_long_term_text`；追加账本。
- 静态证据：两个 helper exact/AST/dynamic/export/plugin-cache 仅唯一 caller；历史无其他 owner。
- 配置或迁移影响：无；未修改 schema、manifest、migration 或 workspace。
- 错误处理：self 失败时仍只调用 self 并原样抛出相同异常；不新增 catch/fallback。
- production 计量：PR30 `85,863` → PR31 `85,855`，Python/plugins `-8`；candidate digest `5ffee260c8a177bb2c5dfed4e7ec90e6a91993acb1415d20f51ce0d44a09adbe`。
- 性能：active caller 少两个 Python forwarding frame；读取/I/O/分配不变，不声明端到端提速。
- 回滚方式：revert 单提交 `b1e99dcb6496b0d42005b6adca5dc767f86c0018`；备份 `/tmp/less-is-more-pr31-prompt.py.bak`。

## 验证

- [x] prompt/context/judge/plugin/loop：`172 passed`；lifecycle builder/kernel/factory：`22 passed`。
- [x] 独立复核扩展 proactive/plugin-hot-reload：`499 passed`。
- [x] production SLOC/migration/change-gate tests：`24 passed`。
- [x] compileall；Pyright `0 errors, 12 existing warnings`。
- [x] 固定输入下 None/普通/falsey 的完整 prompt 字节、调用顺序与异常对比一致。
- [x] 新增区块无 Black 重排；exact/dynamic/plugin-cache scan、`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base c98849813a954b5383b96bfd4af3bab9fb8b262d` 已在 committed HEAD 运行并通过。
- `sourceDigest`：`060e4454737baf51c63ce101acc6b602515201415a548ea76c2b75e74e2f8744`
- `planDigest`：`25e5592b694dd5fdd50914d838c2ef0c4e52fef7ebfdd3c2bd199bc8b0ed610a`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-065637-7b3f491f`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Proactive/Prompt/Memory owner、相关 projectneed 条款与 `NOW.md`。
- [x] 本次没有长期语义变化；prompt 字节、读取/错误处理与外部插件边界已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；无 blocking finding，prompt bytes/read order/error/formatting 语义保持。
- less-is-more PR1～PR31 相对 PR0 baseline 净减少 `1,685` production SLOC（`87,540 → 85,855`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
