### PR TITLE
refactor(proactive): remove private fetch aliases

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -590,6 +590,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、database rows/schema、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、manifest 或 Git refs。执行前备份：`/tmp/less-is-more-pr32-storage.py.before`、`/tmp/less-is-more-pr32-ledger.md.before`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 或外部未跟踪副本可能保留旧 ownership 名称，但当前 canonical source、历史迁移后的生产调用面与 enabled plugin cache 没有 owner；若未来引入真正的会话授权边界，应在认证/协议 owner 中设计新的显式合同，不恢复这三个无调用存储 API。
 
+## 2026-07-23 less-is-more PR33：删除主动上下文的私有预取别名
+
+### `PR33` `refactor(proactive): remove private fetch aliases`
+
+- base：PR32 committed HEAD `ce534155d3e0a2d7d70fe0cb5eefc3dd938f8b70`，分支 `refactor/less-is-more-pr33-remove-private-proactive-fetch-aliases`。
+- allowed_paths：`plugins/default_proactive/context.py` 删除 `_alerts_fetched`、`_contents_fetched`、`_context_fetched` 三组 private property/setter aliases；`tests/proactive_v2/test_context.py` 删除三个仅验证 aliases 默认值的专属测试；本账本。`capability_owner`：`AgentTickContext` 预取完成状态；未修改公开 `alerts_fetched`/`contents_fetched`/`context_fetched` 字段、`mark_*_prefetched` 方法、tools/runtime/wake 调用、schema、manifest、迁移或正式 workspace。
+- 历史与不可达性：aliases 由 `1f8df5e1` 为旧 `proactive_v2` 路径引入，随 `869260b8` 迁移到 `plugins/default_proactive/context.py` 后未出现生产调用。PR32 基线的 CodeGraph、AST attribute/name、精确文本、`getattr`/`setattr`/`import_module`/动态文件加载、export/reflection、tests、SDK、plugin manifest 与 `/home/huashen/.akashic-plugin/cache` 扫描仅命中待删定义和其三项专属测试；外部 plugin cache 没有 underscore consumer。内部 underscore 名称不属于公开 API，且没有发现可达迁移 owner；删除后 source/tests/plugin cache 中为零残留。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。删除的 aliases 只转发到对应公开 bool 字段，当前生产路径由 `mark_*_prefetched` 直接设置公开字段；正常 fetch、skip、runtime/wake、错误传播、持久化、事件和外部发送均不变。未新增 `try/except`、默认值、fallback、动态兼容层或 mock success；内部契约继续 fail-fast。
+- 范围与计量：删除 `plugins/default_proactive/context.py` 18 个 production SLOC、24 个物理行；删除 17 个测试物理行。PR32 base source-set digest `69eb782867e5bbf19fcbd2497dc273121da828985cff15da4c29edaaf3704cb0`、文件数 `378`、Python SLOC `77,384`、`plugins` SLOC `17,120`、total production SLOC `85,835`；candidate source-set digest `8cb775f6ef590183c2008116e3dbfc02d73c72f968548d3cb264da63e8a8adf3`、文件数 `378`、Python SLOC `77,366`、`plugins` SLOC `17,102`、total `85,817`；production 净减少 `18` SLOC。
+- 性能与注释：模块导入不再创建三个不可达 property descriptor/getter/setter 组；主动预取热路径的字段读取、写入、调用次数、分配、等待、I/O、SQL、网络、事件和 write set 不变，不宣称端到端提速。删除与内部 aliases 绑定的 stale 测试注释，不新增冗余注释或错误处理。
+- 测试与静态验证：context/source/gateway/proactive runtime/tools/lifecycle 与 wake context/runtime 定向回归 `181 passed in 1.30s`；`plugins/default_proactive`、`tests/proactive_v2`、`tests/wake_proactive` `compileall` 通过；修改文件 Pyright `0 errors, 18 warnings`（与 PR32 base 相同的既有 `dict`/unknown container warnings）；exact source/AST/dynamic/export/reflection/plugin-cache alias scan、migration append-only、production SLOC 与 `git diff --check` 通过。未修改真实 runtime workspace。
+- Gate：已在 committed HEAD 对 PR32 base `ce534155d3e0a2d7d70fe0cb5eefc3dd938f8b70` 运行公开 Gate；private required 状态记录为 `pending_maintainer`，不把运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema 或 manifest。执行前备份：`/tmp/akashic-agent-less-is-more-pr33-backup/`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint、日志或外部未跟踪副本可能保留旧 alias 文本，但当前 canonical source、生产调用面与 enabled plugin cache 没有 owner；若未来需要公开预取状态 API，应在 `AgentTickContext` 的公开字段/方法合同中重新设计，不恢复 module-private aliases。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/default_proactive/context.py
+++ b/plugins/default_proactive/context.py
@@ -76,27 +76,3 @@ class AgentTickContext:
     def mark_context_prefetched(self, context_rows: list[dict]) -> None:
         self.fetched_context = context_rows
         self.context_fetched = True
-
-    @property
-    def _alerts_fetched(self) -> bool:
-        return self.alerts_fetched
-
-    @_alerts_fetched.setter
-    def _alerts_fetched(self, value: bool) -> None:
-        self.alerts_fetched = value
-
-    @property
-    def _contents_fetched(self) -> bool:
-        return self.contents_fetched
-
-    @_contents_fetched.setter
-    def _contents_fetched(self, value: bool) -> None:
-        self.contents_fetched = value
-
-    @property
-    def _context_fetched(self) -> bool:
-        return self.context_fetched
-
-    @_context_fetched.setter
-    def _context_fetched(self, value: bool) -> None:
-        self.context_fetched = value

--- a/tests/proactive_v2/test_context.py
+++ b/tests/proactive_v2/test_context.py
@@ -111,23 +111,6 @@ def test_fetched_context_defaults_empty_list():
     assert ctx.fetched_context == []
 
 
-# ── _fetch 保护字段 ───────────────────────────────────────────────────────
-
-def test_alerts_fetched_defaults_false():
-    ctx = AgentTickContext()
-    assert ctx._alerts_fetched is False
-
-
-def test_contents_fetched_defaults_false():
-    ctx = AgentTickContext()
-    assert ctx._contents_fetched is False
-
-
-def test_context_fetched_defaults_false():
-    ctx = AgentTickContext()
-    assert ctx._context_fetched is False
-
-
 # ── 实例隔离（shared default mutable 不能共享） ────────────────────────────
 
 def test_interesting_set_is_independent_per_instance():


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`AgentTickContext` 保留了 3 组旧 `_..._fetched` property/setter aliases；生产路径只使用公开字段和 mark methods。
- 用户可见结果：alerts/contents/context fetch 状态、runtime/wake 与错误传播不变；production SLOC `85,835 → 85,817`，净删 `18`。
- 测试处理：删除 3 个只验证 private aliases 默认值的专属测试；真实 context/source/gateway/runtime tests 保留。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：AgentTickContext 公开预取状态字段/mark methods。
- `consumer_scope`：三个 underscore aliases 在 production、dynamic/export/reflection、SDK/manifest/plugin cache 中无 consumer。
- `runtime_patch`：`none`
- `authoritative_state_owner`：public fetched fields 与 active tools/runtime/wake 无变化。
- 关联不变量：fetch/skip/mark、错误传播、事件、持久化与外部发送保持。
- `protected_state`：proactive context、正式 workspace、external plugin state。
- 允许的副作用：删除 3 个私有 property descriptors/getters/setters 及自证式测试。
- 禁止的副作用：不得修改公开字段、mark methods 或边界 fallback。

## 改动范围

- 主要文件：`plugins/default_proactive/context.py` 删除 `_alerts_fetched`、`_contents_fetched`、`_context_fetched`；测试删除 3 个专属 alias cases；追加账本。
- 历史证据：`1f8df5e1` 旧迁移兼容引入后无生产调用；current exact/AST/dynamic/export/plugin-cache 扫描为零。
- 配置或迁移影响：无；未修改 schema、manifest、migration 或 workspace。
- 错误处理：active fetch/gateway/runtime 错误语义不变，不新增 catch/fallback。
- production 计量：PR32 `85,835` → PR33 `85,817`，Python/plugins `-18`；candidate digest `8cb775f6ef590183c2008116e3dbfc02d73c72f968548d3cb264da63e8a8adf3`。
- 性能：模块导入少创建 3 组 property/getter/setter 对象；热路径字段读写次数不变。
- 回滚方式：revert 单提交 `8e481f0b5074ac64131ea162728db07387b2dc06`；备份 `/tmp/akashic-agent-less-is-more-pr33-backup/`。

## 验证

- [x] context/source/gateway/proactive runtime/tools/lifecycle/wake：`181 passed`。
- [x] compileall；修改文件 Pyright `0 errors, 18 existing warnings`。
- [x] exact/AST/dynamic/export/reflection/plugin-cache scan、migration append-only、`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base ce534155d3e0a2d7d70fe0cb5eefc3dd938f8b70` 已在 committed HEAD 运行并通过。
- `sourceDigest`：`2150d0cb5a63d6886e747634802a72cb279cf309bdf3a56f0bc89c34ff5c2fba`
- `planDigest`：`06959eba37257f3fc748d2ba0f526e81a807229234c1453befbae3210937cb33`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-070920-67bc8455`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Proactive/Context owner、相关 projectneed 条款与 `NOW.md`。
- [x] 本次没有长期语义变化；public field、错误处理、外部插件与持久化边界已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；无 blocking finding，public fields/mark/runtime/wake/error 语义保持。
- less-is-more PR1～PR33 相对 PR0 baseline 净减少 `1,723` production SLOC（`87,540 → 85,817`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
