### PR TITLE
refactor(telegram): remove dead live task drain helper

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -620,6 +620,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema 或 manifest。执行前备份：`/tmp/akashic-less-is-more-pr34-backup.*`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 或外部未跟踪副本可能保留旧 helper 文本，但当前 canonical source、动态调用面与 enabled plugin cache 没有 owner；若未来需要不同的等待策略，应在 `TelegramOutboundLimiter` 的 chat-slot owner 中重新设计显式合同，不恢复重复 private helper。
 
+## 2026-07-23 less-is-more PR35：删除 Telegram 不可达 live task drain helper
+
+### `PR35` `refactor(telegram): remove dead live task drain helper`
+
+- base：PR34 committed HEAD `b153bfc4495914b086439e003a942fcb5762e5c1`，分支 `refactor/less-is-more-pr35-remove-dead-telegram-drain`。
+- allowed_paths：`infra/channels/telegram_channel.py` 仅删除 `_drain_live_tasks`；本账本。`capability_owner`：TelegramChannel live task lifecycle；未修改 `_live_tasks` 索引/创建/取消/stop、`TelegramLiveEditQueue`、其他 channel、public API、测试、schema、manifest、迁移或正式 workspace。
+- 历史与不可达性：当前 canonical TelegramChannel 中 `_drain_live_tasks` 只有一个私有定义、无调用、无导出或反射命中；`stop()` 及响应/终止路径仍通过按 session 的 `_cancel_live_tasks()` 取消并等待任务。CodeGraph、AST、精确字符串、`getattr`/`setattr`/`import_module`/动态文件加载、导出/反射与仓库测试扫描均确认零 caller。启用的外部 `feishu@github` 与 `qqbot@github` cache 各自定义独立的 `FeishuChannel`/`QQBotChannel`，仍有自己的 `_drain_live_tasks` caller；它们不导入或继承 `TelegramChannel`，本 PR 不触碰外部 plugin cache。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。删除的 helper 不在当前 production path，故不改变 live task 创建、session 索引回收、取消、等待、错误日志、Telegram API 调用、消息状态、持久化、事件或外部效果；可达 cleanup 继续由 `_cancel_live_tasks` 拥有。未新增 `try/except`、默认值、fallback、兼容层或 mock success 路径。
+- 范围与计量：PR34 base source-set digest `65f75da5cd20738193099c8b4ba736ced1457ef71d5bdf393d3492621043614c`，文件数 `378`，Python SLOC `77,361`，`infra` SLOC `11,298`，total production SLOC `85,812`；candidate source-set digest `14ce051648906cd87d04ec3328acfb6c110206e58afaef3cf31f89e690f3673d`，文件数 `378`，Python SLOC `77,357`，`infra` SLOC `11,294`，total production SLOC `85,808`；production 净减少 `4` SLOC（raw diff `5 deletions`）。
+- 性能、错误与注释：模块导入不再创建一个不可达 async 函数对象；可达 task index、cancel/gather、stop 等待与异常日志没有新增调用、分配、等待或 I/O，不宣称端到端性能收益。删除 stale helper 本身没有有效注释，不新增冗余注释或错误处理。
+- 测试与静态验证：Telegram channel/client、channel host/base、mobile realtime channel 定向回归 `59 passed in 1.38s`；相关源码与测试 `compileall` 通过；`telegram_channel.py` Pyright `0 errors, 51 warnings`（均为 PR34 基线既有动态 Telegram/stub 诊断）；legacy symbol 的 repo exact/AST scan 为零残留，外部 Feishu/QQBot cache 的同名 helper 仍保留且有独立 caller；migration append-only、`git diff --check` 与 production SLOC 计量通过。未修改测试或正式 runtime workspace。
+- Gate：待本提交 committed HEAD 对 PR34 base 运行公开 Gate；private contract 状态为 `pending_maintainer`，不将运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr35-telegram_channel.py.bak-20260723`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint 与外部插件 cache 可能继续保留同名 helper，但当前 canonical Telegram source 没有 consumer；若未来需要全局 drain 语义，应在各 channel 自己的 lifecycle owner 中建立明确合同，不从 Telegram private helper 恢复跨 channel 兼容层。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -676,11 +676,6 @@ class TelegramChannel:
         if message is not None and await message.delete():
             self._live_messages.pop(session_key, None)
 
-    async def _drain_live_tasks(self) -> None:
-        tasks = [task for task in self._live_tasks if not task.done()]
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-
     def _final_thinking_text(
         self,
         session_key: str,


### PR DESCRIPTION
## 问题与结果

- 解决的问题：TelegramChannel 保留了全仓零 caller 的 `_drain_live_tasks`；可达 cleanup 已由按 session 的 `_cancel_live_tasks` 拥有。
- 用户可见结果：live task 创建、索引、取消、等待、stop 与错误日志不变；production SLOC `85,812 → 85,808`，净删 `4`。
- 本 PR 不处理：Feishu/QQBot 各自同名但有 caller 的实现、TelegramLiveEditQueue 或 public channel API。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：TelegramChannel `_cancel_live_tasks` lifecycle。
- `consumer_scope`：被删 private helper 在 source/tests/dynamic/export/reflection 中零 caller；外部同名实现属于独立类。
- `runtime_patch`：`none`
- `authoritative_state_owner`：`_live_tasks` 索引与 cleanup 无变化。
- 关联不变量：task cancel/gather、session cleanup、stop、error logging 与 Telegram effects 保持。
- `protected_state`：live task state、正式 workspace、外部 channel plugins。
- 允许的副作用：删除不可达 async function object。
- 禁止的副作用：不得改变 `_cancel_live_tasks`、stop 或跨 channel 生命周期。

## 改动范围

- 主要文件：`infra/channels/telegram_channel.py` 删除 `_drain_live_tasks`；追加账本。
- 静态证据：CodeGraph/AST/exact/dynamic/export scan 零 caller；Feishu/QQBot cache 不导入/继承 TelegramChannel。
- 配置或迁移影响：无；未修改 schema、manifest、migration 或 workspace。
- 错误处理：可达 cleanup/logging 不变，不新增 catch/fallback。
- production 计量：PR34 `85,812` → PR35 `85,808`，Python/infra `-4`；candidate digest `14ce051648906cd87d04ec3328acfb6c110206e58afaef3cf31f89e690f3673d`。
- 性能：模块导入少创建一个不可达 async function；可达 cancel/gather I/O 不变。
- 回滚方式：revert 单提交 `7c06599bb757a361228349416e1aeab0c77e935a`；备份 `/tmp/akashic-less-is-more-backups/pr35-telegram_channel.py.bak-20260723`。

## 验证

- [x] Telegram channel/client/host/base/mobile realtime channel：`59 passed`。
- [x] compileall；Pyright `0 errors, 51 existing warnings`。
- [x] exact/AST scan 零残留；外部同名 helpers 保留且有 caller。
- [x] migration append-only、production SLOC、`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base b153bfc4495914b086439e003a942fcb5762e5c1` 已在 committed HEAD 运行并通过。
- `sourceDigest`：`c04156cb49f18052d3b10b71cd8bbaf0ff3859b25dd4d91c329893fddf8b5a5d`
- `planDigest`：`94b9df9cc19f659a1c7640f9c3162a11506ee55c17c8a3fd5eea5903d75a58c8`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-072028-a12f4254`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Telegram/Channel lifecycle owner、相关 projectneed 条款与 `NOW.md`。
- [x] 本次没有长期语义变化；task cleanup、error 与外部 plugin boundary 已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git cursor。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；确认零 caller、Telegram 生命周期完整、跨 channel 同名实现未误删，SLOC 与 Gate 一致。
- less-is-more PR1～PR35 相对 PR0 baseline 净减少 `1,732` production SLOC（`87,540 → 85,808`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
