### PR TITLE
refactor(telegram): inline final thinking send

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -635,6 +635,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr35-telegram_channel.py.bak-20260723`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 与外部插件 cache 可能继续保留同名 helper，但当前 canonical Telegram source 没有 consumer；若未来需要全局 drain 语义，应在各 channel 自己的 lifecycle owner 中建立明确合同，不从 Telegram private helper 恢复跨 channel 兼容层。
 
+## 2026-07-23 less-is-more PR36：内联 Telegram final thinking 发送
+
+### `PR36` `refactor(telegram): inline final thinking send`
+
+- base：PR35 committed HEAD `7c06599bb757a361228349416e1aeab0c77e935a`，分支 `refactor/less-is-more-pr36-inline-final-thinking`。
+- allowed_paths：`infra/channels/telegram_channel.py`（删除 `_send_final_thinking`，将其唯一 caller 的 guard 与 `send_thinking_block` 原位内联）、本账本；`capability_owner`：`TelegramChannel._on_response` final thinking 出站阶段。未修改 `send_thinking_block`、limiter、reply/stream/live-edit/error 路径、public API、测试、schema、manifest、迁移或正式 workspace。
+- 历史与不可达性：PR35 基线的 CodeGraph、AST、精确源码/测试/SDK/plugin manifest、动态 `getattr`/`setattr`/`import_module`/导出/反射与 `/home/huashen/.akashic-plugin/cache` 扫描确认 `_send_final_thinking` 只有一个私有定义和 `_on_response` 唯一 caller；候选源码与测试中该 symbol 为零残留。helper 的 `chat_id` 参数只被接收、不参与发送；内联保留顶部 `_resolve_chat_id` 的 fail-fast 校验，并继续将原始 `msg.chat_id` 传给 `send_thinking_block`。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。`final_thinking` 的 truthy guard、`send_thinking_block` 的 bot/chat/text/limiter 参数顺序、`had_live` 分支与正文/工具快照/stream/media 顺序保持不变；未知 alias 仍在 `_resolve_chat_id` 边界抛出原 `ValueError`，发送 helper 抛出的异常在 base/candidate 均原样向上传播（同一 RuntimeError sentinel 回归均 `1 passed`）。没有新增 catch、fallback、默认值、兼容层或 mock success。
+- 范围与计量：删除 helper 17 个 production SLOC，内联 6 行并保留一行 canonical chat-id fail-fast 校验；PR35 base source-set digest `14ce051648906cd87d04ec3328acfb6c110206e58afaef3cf31f89e690f3673d`，文件数 `378`，Python SLOC `77,357`，`infra` SLOC `11,294`，total production SLOC `85,808`；candidate source-set digest `b2f5c29d4452a05b78211047a5cc137538547e0296e7660210f0eac5491b672b`，文件数 `378`，Python SLOC `77,348`，`infra` SLOC `11,285`，total production SLOC `85,799`；production 净减少 `9` SLOC（代码 raw diff `17 deletions`/`7 insertions`，另加 ledger `15 insertions`）。
+- 性能与调用轨迹：删除一次不可达 helper coroutine 调用；不移除既有 chat-id 解析、校验或发送参数。临时 oracle 对 `thinking="trace"` 与空 thinking 两次独立 `_on_response` 调用逐次记录 resolver：base/candidate 每次恰好一次；合并输出为 `['123', '123']` 只是两种输入各一次的串联结果。两者 thinking send 均为 `[('123', 'trace', limiter)]`，空 thinking 均不发送 thinking block。该回放只证明调用序列与发送参数，不宣称端到端 Telegram latency 收益。
+- 测试与静态验证：Telegram channel/client、channel host/base、Telegram utility、mobile realtime channel/gateway 定向回归 `122 passed in 4.21s`；base/candidate 调用轨迹和异常传播临时 oracle 各 `1 passed`；相关源码与测试 `compileall` 通过；候选 pyright `0 errors, 67 warnings`（`telegram_channel.py` 51、`telegram_utils.py` 16，均为 PR35 基线既有诊断）；exact/AST/dynamic/export/plugin-cache scan、migration append-only 与 `git diff --check` 通过。未修改正式 runtime workspace。
+- Gate：已在 committed HEAD 对 PR35 base `7c06599bb757a361228349416e1aeab0c77e935a` 运行公开 Gate并通过；private contract 状态为 `pending_maintainer`，不把 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr36-telegram_channel.py.bak-20260723`、`/tmp/akashic-less-is-more-pr36-clean-code-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
+- 残余风险：历史 checkpoint 或外部未跟踪副本可能保留 helper 文本，但当前 canonical source、测试、动态调用面与 enabled plugin cache 没有 consumer；若未来需要独立 final-thinking policy，应在 `_on_response` 或 `send_thinking_block` owner 中重新设计显式合同，不恢复无调用 wrapper。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -691,21 +691,6 @@ class TelegramChannel:
             return f"{streamed}\n\n{final}"
         return streamed or final
 
-    async def _send_final_thinking(
-        self,
-        chat_id: int,
-        original_chat_id: str,
-        thinking: str,
-    ) -> None:
-        if not thinking:
-            return
-        await send_thinking_block(
-            self._app.bot,
-            original_chat_id,
-            thinking,
-            self._telegram_outbound_limiter,
-        )
-
     async def _send_final_tool_snapshot(
         self,
         session_key: str,
@@ -776,7 +761,7 @@ class TelegramChannel:
     async def _on_response(self, msg: OutboundMessage) -> None:
         preview = msg.content[:60] + "..." if len(msg.content) > 60 else msg.content
         logger.info(f"[telegram] 发送回复  chat_id={msg.chat_id}  内容: {preview!r}")
-        cid = int(self._resolve_chat_id(msg.chat_id))
+        _ = int(self._resolve_chat_id(msg.chat_id))
         session_key = f"{self._channel}:{msg.chat_id}"
         had_live = self._has_live_messages(session_key)
         has_live_tasks = bool(self._live_tasks_by_session.get(session_key))
@@ -815,7 +800,12 @@ class TelegramChannel:
                     self._telegram_outbound_limiter,
                 )
         if final_thinking and not had_live:
-            await self._send_final_thinking(cid, msg.chat_id, final_thinking)
+            await send_thinking_block(
+                self._app.bot,
+                msg.chat_id,
+                final_thinking,
+                self._telegram_outbound_limiter,
+            )
         self._reply_buffers.pop(session_key, None)
         self._thinking_buffers.pop(session_key, None)
         _ = self._thinking_live_next_at.pop(session_key, None)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`TelegramChannel._send_final_thinking` 只有 `_on_response` 一个 caller，却保留了未消费的 `chat_id` 参数和一层异步转发。
- 用户可见结果：final thinking 的 guard、chat-id 校验、发送目标、limiter、顺序与错误传播不变；production SLOC `85,808 → 85,799`，净删 `9`。
- 本 PR 不处理：live thinking、tool snapshot、正文/stream/media、Telegram public API 或其他 channel。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`TelegramChannel._on_response` final thinking 出站阶段。
- `consumer_scope`：被删 private helper 只有一个 caller；source/tests/dynamic/export/plugin cache 没有其他 consumer。
- `runtime_patch`：`none`
- 关联不变量：未知 alias 仍由 `_resolve_chat_id` fail-fast；发送仍使用原始 `msg.chat_id`；truthy/empty thinking、`had_live`、limiter 与异常传播不变。
- `protected_state`：reply/thinking/live task buffers、stream、media、正式 workspace 与外部 channel plugins。
- 允许的副作用：减少一次私有 coroutine dispatch 和无意义参数转发。
- 禁止的副作用：不得改变发送字节、目标 chat、时序、cleanup 或错误边界。

## 改动范围

- 主要文件：`infra/channels/telegram_channel.py` 删除 `_send_final_thinking` 并在唯一 caller 原位发送；追加账本。
- 静态证据：CodeGraph、AST、exact/dynamic/export/plugin-cache scan 确认唯一 caller；候选 symbol 零残留。
- 错误处理：顶部 `int(self._resolve_chat_id(msg.chat_id))` 校验仍恰好执行一次；未知 alias 的 `ValueError` 与 send 的异常均原样传播，不新增 catch/fallback。
- 调用轨迹：truthy 与 empty thinking 两次独立回放中，base/candidate 每次各解析一次；thinking send 参数完全相同。
- production 计量：PR35 `85,808` → PR36 `85,799`，净删 `9`；candidate digest `b2f5c29d4452a05b78211047a5cc137538547e0296e7660210f0eac5491b672b`；代码 raw diff `7 insertions / 17 deletions`。
- 性能：移除一次私有 coroutine dispatch；不宣称端到端 Telegram latency 收益。
- 回滚方式：revert 单提交 `f1ac8fb34cc37021238de41af0f3470c57466444`；备份 `/tmp/akashic-less-is-more-pr36-telegram_channel.py.bak-20260723`、`/tmp/akashic-less-is-more-pr36-clean-code-ledger.md.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr36-ledger-pre-gate-reconcile-20260723.bak`。

## 验证

- [x] Telegram channel/client/host/base/utility 与 mobile realtime：`122 passed`。
- [x] base/candidate truthy/empty trace、send exception、unknown alias oracle 通过。
- [x] compileall；Pyright `0 errors, 67 existing warnings`。
- [x] exact/AST/dynamic/export/plugin-cache、migration append-only、SLOC 与 `git diff --check` 通过。
- [x] committed HEAD Gate 对 PR35 base 运行并通过。
- `sourceDigest`：`28f123c200c4e70743ff396a7510fd2b10d2c8b488520a4b764987214b063311`
- `planDigest`：`2806b62ddfd470c20dd878a49d2d94ff193fb92d94d2f30495c39e73a981f90b`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-073957-c7b855d3`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 Telegram/Channel lifecycle owner、相关 projectneed 条款与 `NOW.md`。
- [x] 没有长期语义变化；发送参数、error 与外部 plugin boundary 已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git refs。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；逐场景确认 chat-id、thinking、had-live、stream、snapshot、media 与错误轨迹等价。Review 指出的 Gate 文档未对账已修正，amend 后 committed-head Gate 重跑通过。
- less-is-more PR1～PR36 相对 PR0 baseline 净减少 `1,741` production SLOC（`87,540 → 85,799`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
