### PR TITLE
perf(mcp): reuse serialized outbound payload

### DIFF
--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -387,14 +387,13 @@ class McpClient:
 
     async def _send(self, payload: dict[str, Any]) -> None:
         assert self._process and self._process.stdin
+        serialized = json.dumps(payload, ensure_ascii=False)
         logger.debug(
             "[mcp:%s] -> %s",
             self.name,
-            json.dumps(payload, ensure_ascii=False)[:400],
+            serialized[:400],
         )
-        self._process.stdin.write(
-            (json.dumps(payload, ensure_ascii=False) + "\n").encode()
-        )
+        self._process.stdin.write((serialized + "\n").encode())
         await self._process.stdin.drain()
 
     async def _recv(

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -650,6 +650,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、正式 workspace、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-pr36-telegram_channel.py.bak-20260723`、`/tmp/akashic-less-is-more-pr36-clean-code-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
 - 残余风险：历史 checkpoint 或外部未跟踪副本可能保留 helper 文本，但当前 canonical source、测试、动态调用面与 enabled plugin cache 没有 consumer；若未来需要独立 final-thinking policy，应在 `_on_response` 或 `send_thinking_block` owner 中重新设计显式合同，不恢复无调用 wrapper。
 
+## 2026-07-23 less-is-more PR37：复用 MCP 出站 JSON 序列化
+
+### `PR37` `perf(mcp): reuse serialized outbound payload`
+
+- base：PR36 committed HEAD `f1ac8fb34cc37021238de41af0f3470c57466444`，分支 `refactor/less-is-more-pr37-reuse-mcp-serialization`。
+- allowed_paths：`agent/mcp/client.py` 的 `McpClient._send`、`tests/test_io_modules.py` 的直接 oracle、本账本；`capability_owner`：MCP stdio client 出站 JSON-RPC 帧。没有 Content-Length header；未修改协议字段、子进程、锁、stdout/stderr、超时、连接生命周期、重试、schema、manifest、迁移或正式 workspace。
+- 原问题与证据：PR36 基线 `_send` 对同一 payload 分别为 debug preview 与 wire body 调用两次 `json.dumps(payload, ensure_ascii=False)`；CodeGraph/源码调用链确认该重复只在 `McpClient._send`，所有 `McpClient` request/call/initialize/tools/list 路径都经过同一 owner。候选先计算一次 `serialized`，再复用其 `[:400]` 和 `(serialized + "\\n").encode()`。
+- 语义与错误边界：`change_type: performance`，`semantic_delta: none`。序列化仍发生在 logger 与 stdin write 之前；Unicode、默认 JSON separators、末尾 newline、UTF-8 字节、debug 预览、write→drain 顺序和所有异常传播保持不变。unsupported object 仍在序列化边界抛出 `TypeError`，不会调用 logger 或产生任何 write；没有新增 catch、fallback、默认值、兼容层或 mock success。
+- 范围与计量：候选仅将两次序列化收敛为一次，生产代码净减少 `1` SLOC。PR36 base source-set digest `b2f5c29d4452a05b78211047a5cc137538547e0296e7660210f0eac5491b672b`，文件数 `378`，Python SLOC `77,348`，`infra` `11,285`，total production SLOC `85,799`；candidate source-set digest `cae774b4ad3044f6131d77f74f59ef926fbd31c1ba7a7c73f4c7bf08bc1b6441`，文件数 `378`，Python SLOC `77,347`，`infra` `11,285`，total production SLOC `85,798`。
+- 字节/日志 parity：同一 Unicode payload 在 base/candidate 的 wire bytes 完全相等，长度 `354`，SHA-256 `c3a5d61a5233db4731ff24c2d2a9c3d33a94ccc0014eddeaddfede1e17348577`；长 Unicode payload 的 logger 参数与 wire 解码前 `400` 字符前缀完全相等，预览长度保持 `400`，newline 只出现在 wire frame。
+- 性能回放：相同 fake stdin、同一进程、logger no-op、同一 payload，预热后每次 `3,000` 次 `_send`、`7` 次重复；base 样本中位数 `0.021347s`，candidate `0.011584s`，中位数变化 `-45.73%`。这是 JSON 序列化/内存 pipe 微基准，不宣称真实子进程或网络端到端收益。
+- 测试与静态验证：MCP/IO 定向 `70 passed in 8.45s`（含单次 dumps、wire/log parity、write→drain 顺序和 unsupported object no-write oracle）；相关源码与测试 compileall、pyright、migration append-only、`git diff --check` 与 committed-head Gate 均通过。未修改正式 runtime workspace。
+- Gate：已在最终 committed HEAD 对 PR36 base 运行公开 Gate，公开结果 `passed`；private contract 状态为 `pending_maintainer`，不把 provider identity 当作公开证据。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr37-agent-mcp-client.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr37-test-io-modules.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr37-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
+- 残余风险：基准只覆盖 JSON CPU 与 fake pipe；真实 MCP server 的调度、OS pipe backpressure 和子进程退出仍由既有测试/Gate 覆盖。若未来 debug 与 wire 需要不同序列化选项，应在该 owner 明确拆分协议，而不是恢复无证据重复 dumps。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -509,6 +509,62 @@ async def test_mcp_client_and_loop_factory_cover_core_paths(
 
 
 @pytest.mark.asyncio
+async def test_mcp_send_serializes_once_before_logging_and_writing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class TrackingPipe(_Pipe):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events: list[tuple[str, bytes | None]] = []
+
+        def write(self, data: bytes) -> None:
+            self.events.append(("write", data))
+            super().write(data)
+
+        async def drain(self) -> None:
+            self.events.append(("drain", None))
+            await super().drain()
+
+    proc = _Proc([])
+    proc.stdin = TrackingPipe()
+    client = McpClient("docs", ["python", "server.py"])
+    client._process = proc
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "测试",
+        "params": {"text": "🙂中文" * 200},
+    }
+    original_dumps = mcp_client_module.json.dumps
+    dump_calls: list[dict[str, object]] = []
+
+    def counting_dumps(value, *args, **kwargs):
+        if value is payload:
+            dump_calls.append(kwargs)
+        return original_dumps(value, *args, **kwargs)
+
+    debug = MagicMock()
+    monkeypatch.setattr(mcp_client_module.json, "dumps", counting_dumps)
+    monkeypatch.setattr(mcp_client_module.logger, "debug", debug)
+
+    await client._send(payload)
+
+    serialized = original_dumps(payload, ensure_ascii=False)
+    assert dump_calls == [{"ensure_ascii": False}]
+    assert proc.stdin.writes == [(serialized + "\n").encode()]
+    assert proc.stdin.events == [("write", proc.stdin.writes[0]), ("drain", None)]
+    debug.assert_called_once_with("[mcp:%s] -> %s", "docs", serialized[:400])
+
+    unsupported = _Proc([])
+    unsupported_client = McpClient("docs", ["python", "server.py"])
+    unsupported_client._process = unsupported
+    debug.reset_mock()
+    with pytest.raises(TypeError):
+        await unsupported_client._send({"unsupported": object()})
+    assert unsupported.stdin.writes == []
+    debug.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_mcp_client_rejects_unsupported_protocol_version(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`McpClient._send` 为同一 JSON-RPC payload 分别给 debug preview 和 wire body 执行两次相同的 `json.dumps`。
- 用户可见结果：协议字节、日志、异常和写入顺序不变；JSON 序列化/fake-pipe 微基准中位数 `0.021347s → 0.011584s`（`-45.73%`）；production SLOC `85,799 → 85,798`。
- 本 PR 不处理：MCP Content-Length（当前协议没有该 header）、子进程调度、pipe backpressure、连接/重试/超时或服务端。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：MCP stdio client 出站 newline-delimited JSON-RPC frame。
- `consumer_scope`：initialize、initialized notification、tools/list 和 tools/call 统一经过 `_send`；没有第二套发送 helper。
- `runtime_patch`：`none`
- 关联不变量：`ensure_ascii=False`、默认 separators、debug 前 400 字符、UTF-8、末尾 newline、logger→write→drain、异常传播与 call lock 不变。
- `protected_state`：MCP process/generation、stdout/stderr、连接状态、正式 workspace 与外部 server。
- 允许的副作用：每帧减少一次重复 JSON 序列化。
- 禁止的副作用：不得改变 wire bytes、序列化/编码异常时机、write/drain 次数或协议字段。

## 改动范围

- 主要文件：`agent/mcp/client.py` 复用 `serialized`；`tests/test_io_modules.py` 增加直接协议 oracle；追加账本。
- 协议 parity：Unicode payload base/candidate wire 都是 `354` bytes，SHA-256 `c3a5d61a5233db4731ff24c2d2a9c3d33a94ccc0014eddeaddfede1e17348577`；preview 都是 400 字符。
- 错误处理：unsupported object 仍在首次 serialization 抛 `TypeError`，不记录 debug、不 write/drain；不新增 catch/fallback。
- production 计量：PR36 `85,799` → PR37 `85,798`，净删 `1`；candidate digest `cae774b4ad3044f6131d77f74f59ef926fbd31c1ba7a7c73f4c7bf08bc1b6441`。
- 性能回放：同一 fake stdin/logger no-op/payload，预热后 `3,000` sends × `7` repeats，中位数 `0.021347s → 0.011584s`；只声明 serialization/fake-pipe CPU，不外推端到端网络延迟。
- 回滚方式：revert 单提交 `2a360df0e8dc41825c8d8fc6cbe36b4ca158e4bf`；备份 `/tmp/akashic-less-is-more-backups/pr37-agent-mcp-client.py.bak-20260723`、`pr37-test-io-modules.py.bak-20260723`、`pr37-ledger.md.bak-20260723`。

## 验证

- [x] MCP/IO/declarations/workspace 定向：`70 passed`。
- [x] 单次 dumps、wire/log parity、write→drain 与 TypeError no-write oracle 通过。
- [x] compileall；Pyright `0 errors, 0 warnings`。
- [x] migration append-only、production SLOC、`git diff --check` 通过。
- [x] committed HEAD Gate 对 PR36 base 运行并通过。
- `sourceDigest`：`7849c7b2dd77bbd4bb9fc480221e292394f06b69f13293d38acf969602f6940d`
- `planDigest`：`f8ea3cbe38a2a239d9130b809616593e2229974e927a35de78b3ddd4ec2200f9`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-074247-338bffb8`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 MCP owner、调用链、相关 projectneed 条款与 `NOW.md`。
- [x] 协议字节、错误时机、并发串行和外部 generation boundary 已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git refs。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；复测 Unicode/lone-surrogate/unsupported、wire/preview、write→drain、并发锁与 exact Gate 均等价。
- less-is-more PR1～PR37 相对 PR0 baseline 净减少 `1,742` production SLOC（`87,540 → 85,798`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
