### PR TITLE
refactor(session): inline message extra extraction

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -682,6 +682,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr38-agent-tools-shell.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr38-test-shell-tool.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr38-test-mid-modules.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr38-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
 - 残余风险：微基准只覆盖本地 tokenization 与护栏 CPU；真实 shell 调度、OS 进程、超时、后台生命周期仍由既有测试/Gate 覆盖。若未来网络护栏需要不同 token 视图，应在该 owner 明确新的解析合同，不恢复无证据的重复 split。
 
+## 2026-07-23 less-is-more PR39：内联 session extra 提取
+
+### `PR39` `refactor(session): inline message extra extraction`
+
+- base：PR38 committed HEAD `13d7e2d2a76dff8e5483ce49cdcbc9a2c4d043cc`，分支 `refactor/less-is-more-pr39-inline-session-extra`。
+- allowed_paths：`session/manager.py` 的 `_persist_session` 与消息 extra skip keys、`tests/test_logic_modules.py` 的最小 DB payload/order oracle、本账本；`capability_owner`：SessionManager 会话消息 payload 组装。未修改 `SessionStore` 事务、SQLite schema、消息/turn/附件、metadata、seq/cursor、迁移或正式 runtime workspace。
+- 历史与不可达性：`_extract_extra` 由 `708d6f25` 的 session phase2 迁移引入；CodeGraph、AST/精确文本、`getattr`/`setattr`/`import_module`、export/re-export、测试、SDK、plugin manifest 与 `/home/huashen/.akashic-plugin/cache` 扫描确认当前只有 `_persist_session` 一处 caller，未发现 helper monkeypatch 或外部 owner。候选删除 helper，在模块级 `_MSG_KEYS` 与唯一 caller 内联 comprehension。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。skip keys、key/value 选择、dict 插入顺序、metadata payload、每条 pending message 的收集顺序、`SessionStore.persist_session` 入参、同一事务/append-only/seq/cursor、异常传播与数据库 write set 完全保持；`pending_messages.append(msg)` 仍先于 extra 计算。没有新增 `try/except`、fallback、默认值、动态兼容层或 mock success；模块级 `_MSG_KEYS` 没有生产 mutation path。
+- 范围与计量：PR38 base source-set digest `75d1cadaefac41bda06d0eee28e805450cf964adddc2cb20be8fc8469bdb73fd`、文件数 `378`、Python SLOC `77,352`、`session` `2,526`、total production SLOC `85,803`；candidate source-set digest `57c649022745f485bffbbae8b3bdfb63ef0fe0481673bb5dd4deb76eb6fea235`、文件数 `378`、Python SLOC `77,342`、`session` `2,516`、total `85,793`；production 净减少 `10` SLOC（helper 物理删除，单一 caller 保留同等 comprehension）。
+- payload/row/DB parity：base/candidate 在固定时间、metadata、Unicode/non-string content、所有 skip keys、ordered custom extras、tool_chain、proactive、media、reasoning/model_state 和两次 persist 的回放中，`persist_session` 捕获 payload、`sessions`/`messages` 真实 SQLite rows、行数与 raw `extra` JSON 完全相等；`Trace(dict subclass)` oracle 固定 `get:id → get:timestamp → get:content → get:role → get:tool_chain → items` 字段求值顺序与 base 一致；最小测试固定检查 `extra` JSON 的 key 顺序与 stable role/content/seq。
+- 性能与分配回放：同一 fake store、16 条消息、固定 CPU 核心预热后每次 `100,000` 次、7 次重复的 `_persist_session` CPU 微基准，base 中位数 `10.600 µs/call`，candidate `9.399 µs/call`，中位数变化 `-11.33%`；同一热循环 `5,000` 次、7 次的 tracemalloc 峰值中位数 `1,010 B → 665 B`（`-34.16%`）。这是本地 payload 组装 CPU/短暂分配微基准，不宣称 SQLite/端到端收益。
+- 测试与静态验证：session manager/store 定向回归 `69 passed in 0.57s`；相关源码/测试 `compileall` 通过；`session/manager.py` Pyright `0 errors, 0 warnings`，直接相关测试 Pyright `0 errors, 279 warnings`（既有测试动态/unused-call 诊断）；base/candidate payload/row/DB parity、Trace evaluation order、migration append-only、`git diff --check` 通过。未删除保护活跃合同的测试，未修改正式 runtime workspace。
+- Gate：已在 committed HEAD 对 PR38 base `13d7e2d2a76dff8e5483ce49cdcbc9a2c4d043cc` 运行公开 Gate 并通过；private contract 状态为 `pending_maintainer`，不把运行后的 report、source 或 plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、database rows/schema、服务、网络、外部发送、generation/snapshot/lease/event、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr39-session-manager.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-logic-modules.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-session-store.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-ledger.md.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-session-manager-before-order-fix-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-logic-before-order-fix-20260723`、`/tmp/akashic-less-is-more-backups/pr39-ledger-before-order-fix-20260723`；回滚点为本 PR 单提交 revert。
+- 残余风险：微基准使用 fake store，真实 SQLite lock、transaction、FTS、触发器与并发 seq 仍由既有 session tests/Gate 覆盖；若未来消息核心字段变化，应在 SessionStore payload 合同 owner 中同步更新 `_MSG_KEYS` 与独立 row oracle，而不是恢复 private wrapper。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/session/manager.py
+++ b/session/manager.py
@@ -18,6 +18,7 @@ from session.store import SessionStore
 _TOOL_RESULT_CHAR_BUDGET = 10000
 _PROACTIVE_HISTORY_CHAR_BUDGET = 360
 _PROACTIVE_META_HISTORY_CHAR_BUDGET = 1200
+_MSG_KEYS = {"id", "session_key", "seq", "role", "content", "timestamp", "tool_chain"}
 
 
 def _truncate_tool_result(content: object) -> str:
@@ -417,18 +418,6 @@ class SessionManager:
             metadata=session.metadata,
         )
 
-    def _extract_extra(self, msg: dict[str, object]) -> dict[str, object]:
-        skip = {
-            "id",
-            "session_key",
-            "seq",
-            "role",
-            "content",
-            "timestamp",
-            "tool_chain",
-        }
-        return {k: v for k, v in msg.items() if k not in skip}
-
     def _persist_session(
         self,
         session: Session,
@@ -462,7 +451,7 @@ class SessionManager:
                     "content": content,
                     "timestamp": ts,
                     "tool_chain": msg.get("tool_chain"),
-                    "extra": self._extract_extra(msg),
+                    "extra": {k: v for k, v in msg.items() if k not in _MSG_KEYS},
                 }
             )
 

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import asyncio
+import json
 import logging
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
@@ -245,6 +246,73 @@ async def test_session_batch_persistence_uses_one_commit(tmp_path: Path) -> None
     await manager.append_messages(session, session.messages)
 
     assert statements.count("COMMIT") == 1
+
+
+def test_session_manager_preserves_message_extra_payload_order(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("telegram:extra-order")
+    session.messages.append(
+        {
+            "role": "user",
+            "custom_first": "先",
+            "session_key": "must-skip",
+            "content": "正文",
+            "custom_second": {"nested": "值"},
+            "seq": 999,
+            "timestamp": "2026-07-23T00:00:00+00:00",
+            "tool_chain": None,
+        }
+    )
+
+    manager.save(session)
+
+    row = manager._store._conn.execute(
+        "SELECT role, content, seq, extra FROM messages WHERE session_key = ?",
+        (session.key,),
+    ).fetchone()
+    assert row is not None
+    assert tuple(row[:3]) == ("user", "正文", 0)
+    assert row[3] == json.dumps(
+        {"custom_first": "先", "custom_second": {"nested": "值"}},
+        ensure_ascii=False,
+    )
+
+
+def test_session_manager_preserves_message_field_evaluation_order(
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+
+    class TraceMessage(dict[str, object]):
+        def get(self, key: str, default: object = None) -> object:
+            events.append(f"get:{key}")
+            return super().get(key, default)
+
+        def items(self):
+            events.append("items")
+            return super().items()
+
+    manager = SessionManager(tmp_path)
+    manager._store.persist_session = lambda *args, **kwargs: []
+    fixed = datetime(2026, 7, 23, tzinfo=timezone.utc)
+    session = Session("telegram:extra-order", created_at=fixed, updated_at=fixed)
+    message = TraceMessage(
+        role="user",
+        content="正文",
+        timestamp=fixed.isoformat(),
+        custom="extra",
+    )
+
+    manager._persist_session(session, [message], updated_at=fixed)
+
+    assert events == [
+        "get:id",
+        "get:timestamp",
+        "get:content",
+        "get:role",
+        "get:tool_chain",
+        "items",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`SessionManager._extract_extra` 只有一个 caller，却为每条待持久化消息重新创建相同的 skip set。
- 用户可见结果：message extra 的 key/value/order、payload 与 SQLite rows 不变；production SLOC `85,803 → 85,793`，净删 `10`。
- 性能：payload 组装微基准 `10.600 → 9.399 µs/call`（`-11.33%`），tracemalloc 峰值中位数 `1,010 → 665 B`（`-34.16%`）。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：SessionManager 待持久化 message payload 组装。
- `consumer_scope`：被删 private helper 仅 `_persist_session` 一个 caller；无动态/export/plugin-cache consumer。
- `runtime_patch`：`none`
- 关联不变量：skip keys、dict 插入顺序、pending message 顺序、transaction、append-only、seq/cursor、异常传播与 write set 不变。
- `protected_state`：`sessions.db/messages`、turn/attachment/embedding、migration、正式 workspace。
- 允许的副作用：模块级复用一份 `_MSG_KEYS`，每条消息少一次 set 分配。
- 禁止的副作用：不得改变 extra JSON、消息正文、id/seq、事务边界或数据库减少条件。

## 改动范围

- 主要文件：`session/manager.py` 删除 `_extract_extra`，一行 `_MSG_KEYS` + 唯一 caller 的局部 comprehension；`tests/test_logic_modules.py` 增加真实 row/order oracle；追加账本。
- 求值顺序：`pending_messages.append(msg)` 仍先发生，再提取 extra，再组装 pending payload。
- payload/DB parity：固定 metadata、Unicode/non-string content、全部 skip keys、ordered extras、tool_chain/proactive/media/reasoning/model_state 与两次 persist 的捕获 payload、sessions/messages rows、raw extra JSON 完全相等。
- 错误处理：不新增 catch/fallback/default；SessionStore 事务与损坏数据边界未改。
- production 计量：PR38 `85,803` → PR39 `85,793`，净删 `10`；candidate digest `57c649022745f485bffbbae8b3bdfb63ef0fe0481673bb5dd4deb76eb6fea235`。
- 性能回放：同一 fake store/16 messages/fixed CPU，`100,000` calls × 7；只声明 payload CPU 与短暂分配，不外推 SQLite latency。
- 回滚方式：revert 单提交 `4659afdbbc0420d6cd626cdd0acb5b00d3fa2b72`；备份 `/tmp/akashic-less-is-more-backups/pr39-session-manager.py.bak-20260723`、`pr39-test-logic-modules.py.bak-20260723`、`pr39-test-session-store.py.bak-20260723`、`pr39-ledger.md.bak-20260723`。

## 验证

- [x] session manager/store 定向：`69 passed`。
- [x] base/candidate payload、真实 SQLite row/raw JSON/order parity 通过。
- [x] compileall；manager Pyright `0 errors, 0 warnings`。
- [x] exact/AST/dynamic/export/plugin-cache、migration append-only、SLOC 与 `git diff --check` 通过。
- [x] committed HEAD Gate 对 PR38 base 运行并通过。
- `sourceDigest`：`322ad63a83d9a973c46a5872b5a20b0f1f7757ee0c8ed489b33cdf330aaa0a75`
- `planDigest`：`3871b8eb6aa933c9200363decc5f04f21b549898ef69ae2286b190ed7380fdcb`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-082145-d1c1dd11`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 session owner、持久化地图、相关 projectneed 条款与 `NOW.md`。
- [x] append-only、错误边界、write set 和 SQLite row 已对账。
- [x] 未修改正式 workspace、现存数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git refs。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；先发现并拒绝自定义 dict 的求值顺序差异，修正后 Trace/payload/SQLite/Gate 全部等价，最终 HEAD 仅再做 Gate 文档对账。
- less-is-more PR1～PR39 相对 PR0 baseline 净减少 `1,747` production SLOC（`87,540 → 85,793`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
