### PR TITLE
perf(config): reuse runtime modality validation

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -214,7 +214,7 @@ def load_config(
             ),
             field="agent.dev_mode",
         ),
-        multimodal=_load_multimodal(llm_main),
+        multimodal="image" in model_runtimes[runtime_id].input_modalities,
         vl_model=str(llm_vl.get("model") or ""),
         vl_api_key=_load_api_key(
             auth_id=str(llm_vl.get("auth") or ""),
@@ -612,15 +612,6 @@ def _load_memory_window(data: dict, agent_context: dict, llm_main: dict) -> int:
         return 40
     effective_percent = float(llm_main.get("effective_context_percent", 0.9))
     return recommended_context_settings(context_window, effective_percent).memory_window
-
-
-def _load_multimodal(llm_main: dict) -> bool:
-    modalities = llm_main.get("input_modalities")
-    if modalities is not None:
-        if not isinstance(modalities, list) or not all(isinstance(v, str) for v in modalities):
-            raise ValueError("llm.main.input_modalities 必须是字符串数组")
-        return "image" in modalities
-    return False
 
 
 def _load_role_runtime(

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -698,6 +698,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、database rows/schema、服务、网络、外部发送、generation/snapshot/lease/event、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr39-session-manager.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-logic-modules.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-session-store.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-ledger.md.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr39-session-manager-before-order-fix-20260723`、`/tmp/akashic-less-is-more-backups/pr39-test-logic-before-order-fix-20260723`、`/tmp/akashic-less-is-more-backups/pr39-ledger-before-order-fix-20260723`；回滚点为本 PR 单提交 revert。
 - 残余风险：微基准使用 fake store，真实 SQLite lock、transaction、FTS、触发器与并发 seq 仍由既有 session tests/Gate 覆盖；若未来消息核心字段变化，应在 SessionStore payload 合同 owner 中同步更新 `_MSG_KEYS` 与独立 row oracle，而不是恢复 private wrapper。
 
+## 2026-07-23 less-is-more PR40：复用主 runtime 模态校验结果
+
+### `PR40` `perf(config): reuse validated runtime modalities`
+
+- base：PR39 committed HEAD `4659afdbbc0420d6cd626cdd0acb5b00d3fa2b72`，分支 `refactor/less-is-more-pr40-dedupe-multimodal`。
+- allowed_paths：`agent/config.py` 的 `load_config` multimodal 赋值与 `_load_multimodal` 删除、`tests/test_model_runtime.py` 的 Config/error parity oracle、本账本；`capability_owner`：`_load_llm_runtimes` 的 named runtime 配置边界。未修改 API key 解析、provider/model/base_url、runtime 角色、schema、manifest、迁移或正式 runtime workspace。
+- 历史与不可达性：`_load_multimodal` 由 `59788ffe` runtime 统一迁移引入，当前只有 `load_config` 一处 caller；AST/精确文本、`getattr`/`setattr`/`import_module`、export/re-export、测试、SDK、plugin manifest 与 `/home/huashen/.akashic-plugin/cache` 扫描确认没有其他 consumer。`_load_llm_runtimes` 已为每个 runtime 构造 `ModelRuntimeConfig` 并拥有 `input_modalities` 类型/元素校验，候选直接读取 `model_runtimes[runtime_id].input_modalities`。
+- 语义与错误边界：`change_type: performance`，`semantic_delta: none`。默认缺省仍为 `("text",)`；image 只由 named main runtime 决定，多 runtime 的非 main 模态不影响 `Config.multimodal`；provider/model/config fields 与公开 Config static semantics 不变。非法非 list、非 string 列表仍在 `_load_llm_runtimes` 以原 `ValueError` 类型、消息和时机失败，未新增 `try/except`、fallback、默认值、动态兼容层或 API key 候选逻辑。
+- 范围与计量：PR39 base source-set digest `57c649022745f485bffbbae8b3bdfb63ef0fe0481673bb5dd4deb76eb6fea235`、文件数 `378`、Python SLOC `77,342`、`agent` `28,750`、total production SLOC `85,793`；candidate source-set digest `16471ad673a0b2ef81069577db7cd64f2483513d8b83a19d077c5ec87a5531e8`、文件数 `378`、Python SLOC `77,335`、`agent` `28,743`、total `85,786`；production 净减少 `7` SLOC。
+- Config/error parity：base/candidate 固定 TOML 回放覆盖默认 text、image main、非 main image、provider/model/base_url/API key fields 及 main/non-main 非法 modalities；Config 选定字段 JSON、异常类型、消息和抛出阶段完全相等。未触碰 API key 候选 B。
+- 性能回放：同一进程、固定 CPU 核心、monkeypatched 同一 parsed config，预热后每次 `20,000` 次、7 次重复 `load_config`；base 中位数 `39.514 µs/call`，candidate `39.315 µs/call`，中位数变化 `-0.50%`。这是配置对象构造 CPU 微基准，不宣称 TOML I/O、凭据读取或端到端启动收益。
+- 测试与静态验证：`pytest -q tests/test_model_runtime.py tests/test_fresh_configuration_matrix.py -k 'test_model_runtime or test_fresh_init_core_configuration_matrix and not akasha'` 为 `32 passed, 9 deselected in 2.13s`；完整 fresh matrix 另外运行结果为 `35 passed, 6 failed`，6 个失败均为环境中 jieba 0.42.1 在 CPython 3.13 的 `SyntaxError: invalid escape sequence '\\.'`，不经过 PR40 配置改动；相关源码/测试 `compileall` 通过；候选 config source Pyright `0 errors`（384 warnings，base 389 warnings）；base/candidate Config/error parity、migration append-only、`git diff --check` 通过。未删除保护 runtime/provider 测试，未修改正式 runtime workspace。
+- Gate：已在 committed HEAD 对 PR39 base `4659afdbbc0420d6cd626cdd0acb5b00d3fa2b72` 运行公开 Gate 并通过；private contract 状态为 `pending_maintainer`，不把运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、database rows/schema、服务、网络、外部发送、generation/snapshot/lease/event、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr40-agent-config.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-test-model-runtime.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-test-fresh-config.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
+- 残余风险：微基准使用 monkeypatched parsed config，真实 TOML 读取、凭据边界、provider profile 与 runtime startup 仍由既有 tests/Gate 覆盖；若未来 `ModelRuntimeConfig.input_modalities` 合同变化，应在 runtime config owner 更新字段校验与 Config projection，而不是恢复重复 raw dict guard。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -425,6 +425,72 @@ def test_named_runtime_config_and_setup_keep_secrets_out_of_toml(
     assert config.memory_window == 40
 
 
+def test_config_multimodal_uses_main_runtime_and_keeps_other_runtime_isolated(
+    tmp_path: Path,
+) -> None:
+    template = """
+[llm]
+main = "{main}"
+
+[llm.runtimes.main]
+provider = "openai"
+model = "text-model"
+api_key = "key"
+context_window = 64000
+max_output_tokens = 4096
+
+[llm.runtimes.vl]
+provider = "openai"
+model = "vision-model"
+api_key = "key"
+context_window = 64000
+max_output_tokens = 4096
+input_modalities = ["text", "image"]
+"""
+
+    text_path = tmp_path / "text.toml"
+    text_path.write_text(template.format(main="main"), encoding="utf-8")
+    text_config = load_config(text_path, workspace=tmp_path)
+    assert text_config.multimodal is False
+    assert text_config.model_runtimes["vl"].input_modalities == ("text", "image")
+
+    image_path = tmp_path / "image.toml"
+    image_path.write_text(template.format(main="vl"), encoding="utf-8")
+    image_config = load_config(image_path, workspace=tmp_path)
+    assert image_config.multimodal is True
+    assert image_config.provider == "openai"
+    assert image_config.model == "vision-model"
+
+
+@pytest.mark.parametrize("modalities", ['"image"', "[1]"])
+def test_config_rejects_invalid_runtime_modalities_before_config_build(
+    tmp_path: Path,
+    modalities: str,
+) -> None:
+    path = tmp_path / "invalid.toml"
+    path.write_text(
+        f"""
+[llm]
+main = "main"
+
+[llm.runtimes.main]
+provider = "openai"
+model = "model"
+api_key = "key"
+context_window = 64000
+max_output_tokens = 4096
+input_modalities = {modalities}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="llm\\.runtimes\\.main\\.input_modalities 必须是字符串数组",
+    ):
+        load_config(path, workspace=tmp_path)
+
+
 def test_config_accepts_api_compatible_provider(tmp_path: Path) -> None:
     template = """
 [llm]


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`_load_llm_runtimes` 已校验并构造 main `ModelRuntimeConfig.input_modalities`，`_load_multimodal` 又对同一 raw list 重复校验一次。
- 用户可见结果：默认 text、main image、非 main image 与非法配置行为不变；production SLOC `85,793 → 85,786`，净删 `7`。
- 性能：配置对象构造微基准约 `39.514 → 39.315 µs/call`（`-0.50%`）；主要收益是删除重复 owner，不宣称启动提速。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：`_load_llm_runtimes` / `ModelRuntimeConfig` 的 named runtime 配置边界。
- `consumer_scope`：被删 `_load_multimodal` 只有 `load_config` 一个 caller；无动态/export/plugin-cache consumer。
- `runtime_patch`：`none`
- 关联不变量：default `("text",)`、main runtime selection、provider/model/base_url/API key fields、非法 modalities 的异常类型/消息/时机不变。
- `protected_state`：配置/secret/workspace、runtime roles、provider identity、正式 workspace。
- 允许的副作用：少一次已建立 runtime 之后的重复 raw-list 校验。
- 禁止的副作用：不得改变 Config public fields、role selection、secret read 或接受的配置集合。

## 改动范围

- 主要文件：`agent/config.py` 直接以 `"image" in model_runtimes[runtime_id].input_modalities` 构造 `Config.multimodal` 并删除 helper；`tests/test_model_runtime.py` 增加 main/non-main/error oracle；追加账本。
- Config/error parity：默认、image main、非 main image、provider/model/base_url/API key fields、main/non-main 非法 modalities 的选定 Config JSON、异常类型/消息/阶段完全相同。
- 错误处理：非法非 list/非 string 元素仍由 `_load_llm_runtimes` 的 canonical parser 先 fail-fast；不新增 catch/fallback/default。
- production 计量：PR39 `85,793` → PR40 `85,786`，净删 `7`；candidate digest `16471ad673a0b2ef81069577db7cd64f2483513d8b83a19d077c5ec87a5531e8`。
- 性能回放：monkeypatched 同一 parsed config、固定 CPU、`20,000` calls × 7；只声明 config construction CPU，不外推 TOML/secret/startup latency。
- 回滚方式：revert 单提交 `94f18387e517a1818eba1ed1cd1715f6ded902fa`；备份 `/tmp/akashic-less-is-more-backups/pr40-agent-config.py.bak-20260723`、`pr40-test-model-runtime.py.bak-20260723`、`pr40-test-fresh-config.py.bak-20260723`、`pr40-ledger.md.bak-20260723`、`pr40-ledger-pre-gate-reconcile-20260723.bak`。

## 验证

- [x] `tests/test_model_runtime.py`：`26 passed`；精确 model-runtime/fresh-core 组合：`32 passed, 9 deselected`。
- [x] base/candidate Config/error parity；compileall；config Pyright `0 errors`。
- [x] dynamic/export/plugin-cache、migration append-only、SLOC 与 `git diff --check` 通过。
- [x] committed HEAD Gate 对 PR39 base 运行并通过。
- `sourceDigest`：`d392fbb81fa7042f8aae226f037abb5913986020460c51636a674569cc11adc5`
- `planDigest`：`ef98d29b778fd80896e4d574d9cec0dff3e06c83219d3651dedee3d52afed717`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-084127-14822919`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 环境说明：完整 fresh matrix 另有 `35 passed, 6 failed`；6 个失败均为 Akasha 导入的 jieba 0.42.1 在 CPython 3.13 抛 `SyntaxError: invalid escape sequence`，不经过本 PR 配置路径，未以跳过/放宽获得假绿。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对配置 owner、相关 projectneed 条款与 `NOW.md`。
- [x] 配置错误、secret/provider boundary 与公开 Config fields 已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git refs。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；Config/error parity、canonical owner、静态 consumer、SLOC/微基准与 exact Gate 均复核通过。
- less-is-more PR1～PR40 相对 PR0 baseline 净减少 `1,754` production SLOC（`87,540 → 85,786`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
