### PR TITLE
perf(tool-search): remove redundant explanation dedupe

### DIFF
--- a/agent/tools/search_backend.py
+++ b/agent/tools/search_backend.py
@@ -180,8 +180,8 @@ def _score(doc: "ToolDocument", keywords: set[str]) -> int:
       search_hint → +4
       description → +2
     """
-    name_parts = [p for p in doc.name.lower().split("_") if p]
     name_lower = doc.name.lower()
+    name_parts = [p for p in name_lower.split("_") if p]
     hint_lower = (doc.search_hint or "").lower()
     desc_lower = doc.description.lower()
     is_mcp = doc.source_type == "mcp"
@@ -207,30 +207,24 @@ def _score(doc: "ToolDocument", keywords: set[str]) -> int:
 
 def _explain(doc: "ToolDocument", keywords: set[str]) -> list[str]:
     """生成 why_matched 解释（与 _score 解耦）。"""
-    name_parts = [p for p in doc.name.lower().split("_") if p]
     name_lower = doc.name.lower()
+    name_parts = [p for p in name_lower.split("_") if p]
     hint_lower = (doc.search_hint or "").lower()
     desc_lower = doc.description.lower()
 
     reasons: list[str] = []
-    seen: set[str] = set()
-
-    def _add(r: str) -> None:
-        if r not in seen:
-            seen.add(r)
-            reasons.append(r)
 
     for kw in keywords:
         if kw in name_parts:
-            _add(f"名称精确:{kw}")
+            reasons.append(f"名称精确:{kw}")
         elif any(kw in part or part in kw for part in name_parts):
-            _add(f"名称部分:{kw}")
+            reasons.append(f"名称部分:{kw}")
         elif kw in name_lower:
-            _add(f"名称:{kw}")
+            reasons.append(f"名称:{kw}")
 
         if hint_lower and kw in hint_lower:
-            _add(f"提示:{kw}")
+            reasons.append(f"提示:{kw}")
         if kw in desc_lower:
-            _add(f"描述:{kw}")
+            reasons.append(f"描述:{kw}")
 
     return reasons

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -714,6 +714,22 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改 migration、database rows/schema、服务、网络、外部发送、generation/snapshot/lease/event、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr40-agent-config.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-test-model-runtime.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-test-fresh-config.py.bak-20260723`、`/tmp/akashic-less-is-more-backups/pr40-ledger.md.bak-20260723`；回滚点为本 PR 单提交 revert。
 - 残余风险：微基准使用 monkeypatched parsed config，真实 TOML 读取、凭据边界、provider profile 与 runtime startup 仍由既有 tests/Gate 覆盖；若未来 `ModelRuntimeConfig.input_modalities` 合同变化，应在 runtime config owner 更新字段校验与 Config projection，而不是恢复重复 raw dict guard。
 
+## 2026-07-23 less-is-more PR42：简化工具搜索解释热路径
+
+### `PR42` `perf(tool-search): remove redundant explanation dedupe`
+
+- base：PR40 committed HEAD `94f18387e517a1818eba1ed1cd1715f6ded902fa`，分支 `refactor/less-is-more-pr42-simplify-search-explain`。PR41 的重复 API-key 读取候选因凭据边界可变而判定 `REJECT`，未修改代码、未占用 production 变更。
+- allowed_paths：`agent/tools/search_backend.py` 的 `_score`/`_explain`、`tests/test_tool_search.py` 的 live-document oracle、本账本；`capability_owner`：`KeywordSearchBackend` 的实时评分、解释与排序。未修改 registry、tool schema、snapshot/fork、risk、exact select、top-k、manifest、迁移或正式 runtime workspace。
+- 原问题与证据：`keywords` 是已去重的 `set[str]`；同一 keyword 的名称解释只会命中 `if/elif` 三分支之一，且名称、提示、描述 reason 使用不同前缀，因此 `_explain` 的 `seen`/嵌套 `_add` 没有可达重复项。`_score` 与 `_explain` 还分别对同一 `doc.name` 调用两次 `lower()`；候选先计算 `name_lower` 再 split。
+- 语义与错误边界：`change_type: performance`，`semantic_delta: none`。score、名称 tie-break、result list/dict、`why_matched` 字符串与顺序、exact fast path、正/零/负 `top_k`、risk/excluded 行为保持；没有新增 catch、fallback、缓存、默认值或兼容层。`ToolDocument` 仍在每次搜索读取，description/search_hint 运行时变更可立即观察。
+- 范围与计量：PR40 base source-set digest `16471ad673a0b2ef81069577db7cd64f2483513d8b83a19d077c5ec87a5531e8`、文件数 `378`、Python SLOC `77,335`、`agent` `28,743`、total production SLOC `85,786`；candidate source-set digest `651479e168200238e5b75ff471d15e8baec318599fec62c13520de23f2d6713b`、文件数 `378`、Python SLOC `77,330`、`agent` `28,738`、total `85,781`；production 净减少 `5` SLOC。
+- parity：固定 `PYTHONHASHSEED=0` 的 base/candidate 共 `10,002` 次 search 回放逐项相等，覆盖 CJK、空串、MCP、None hint、exact/nonmatch、top-k、risk/excluded 与 live `ToolDocument` mutation；返回顺序、字段和 why list 完全相同。
+- 性能回放：同一 2,000 docs/4 keywords workload，预热后 `_score` 全量中位数 `5.000025 → 4.898831 ms`（`-2.02%`），单项 `_explain` 中位数 `3.551934 → 2.672931 µs`（`-24.75%`）。完整 search 微基准受本机调度噪声影响未形成稳定收益，因此不声明端到端搜索延迟变化。
+- 测试与静态验证：tool search、plugin hot reload/manager、support、loop visibility 与 discovery routing 定向回归 `266 passed in 6.61s`；相关源码/测试 `compileall`、Pyright `0 errors`、migration append-only 与 `git diff --check` 通过。未删除保护活跃合同的测试。
+- Gate：已在 committed HEAD 对 PR40 base `94f18387e517a1818eba1ed1cd1715f6ded902fa` 运行公开 Gate 并通过；private contract 状态为 `pending_maintainer`，不把运行后的 source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-less-is-more-backups/pr42-search_backend.py.bak-20260723`、`pr42-test_tool_search.py.bak-20260723`、`pr42-ledger.md.bak-20260723`、`pr42-ledger-before-root-entry-20260723.bak`；回滚点为本 PR 单提交 revert。
+- 残余风险：`ToolDocument` 是可变对象，不能把 normalized fields 缓存到 backend 或 snapshot 外；本 PR 刻意只删除不可达 dedupe 并复用单次 lower。若未来 `keywords` 改为保留重复的 sequence，必须重新建立 why 去重合同，不能直接复用当前证明。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -22,8 +22,8 @@ import pytest
 from agent.mcp.client import McpToolInfo
 from agent.mcp.tool import McpToolWrapper
 from agent.tools.base import Tool
-from agent.tools.registry import ToolRegistry
-from agent.tools.search_backend import _default_normalize
+from agent.tools.registry import ToolDocument, ToolRegistry
+from agent.tools.search_backend import KeywordSearchBackend, _default_normalize
 from agent.tools.tool_search import ToolSearchTool
 
 # ── 辅助工具桩 ────────────────────────────────────────────────────────────────
@@ -201,6 +201,29 @@ async def test_registry_keeps_real_description_parameter() -> None:
     )
 
     assert result == "业务描述"
+
+
+def test_search_reads_live_tool_document_fields_after_mutation() -> None:
+    backend = KeywordSearchBackend()
+    document = ToolDocument(
+        name="mutable_tool",
+        description="legacyalpha",
+        risk="read-only",
+        always_on=False,
+        search_hint=None,
+        source_type="builtin",
+        source_name="",
+    )
+    backend.add(document)
+
+    assert backend.search("legacyalpha")[0]["name"] == "mutable_tool"
+
+    document.description = "freshbeta"
+    document.search_hint = "aliasomega"
+
+    assert backend.search("legacyalpha") == []
+    assert backend.search("freshbeta")[0]["summary"] == "freshbeta"
+    assert backend.search("aliasomega")[0]["why_matched"] == ["提示:aliasomega"]
 
 
 # ── _default_normalize 单元测试 ───────────────────────────────────────────────


### PR DESCRIPTION
## 问题与结果

- 解决的问题：tool search explanation 为已经唯一的 reason 维护不可命中的 `seen/_add` 去重，并在 score/explain 内对同一 name 重复 `lower()`。
- 用户可见结果：结果顺序、score/tie-break、`why_matched` 与 live document 行为不变；production SLOC `85,786 → 85,781`，净删 `5`。
- 性能：2,000 docs focused workload 中 `_score` `5.000025 → 4.898831 ms`（`-2.02%`），单项 `_explain` `3.551934 → 2.672931 µs`（`-24.75%`）；不宣称完整搜索端到端收益。

## Change intent

- `change_type`：`performance`
- `semantic_delta`：`none`
- `capability_owner`：`KeywordSearchBackend` 实时评分、解释与排序。
- `consumer_scope`：tool_search/registry/snapshot/fork 路径仍调用同一 backend；private helpers 无动态/plugin-cache consumer。
- `runtime_patch`：`none`
- 关联不变量：score、registration-key tie-break、result fields/order、why strings/order、exact path、top-k、risk/excluded 与 mutable document 可见性不变。
- `protected_state`：tool registry/runtime snapshot/plugin generation、正式 workspace。
- 允许的副作用：少做不可达 reason 去重和重复 lowercase。
- 禁止的副作用：不得缓存 normalized fields、冻结 `ToolDocument`、改变 custom backend 边界或排序。

## 改动范围

- 主要文件：`agent/tools/search_backend.py` 删除 `seen/_add`、复用 `name_lower`；`tests/test_tool_search.py` 增加 live mutation oracle；追加账本。
- 不可达性证明：keywords 为 set；每个 kw 的名称分支互斥；名称/提示/描述 reason 前缀不同，因此同一 reason 不会重复。
- parity：固定 hash seed 的 `10,002` 次 base/candidate search 回放逐项一致，覆盖 CJK、空串、MCP、None hint、exact/nonmatch、top-k、risk/excluded 和 document mutation。
- 错误处理：不改异常边界，不新增 catch/fallback/default。
- production 计量：PR40 `85,786` → PR42 `85,781`，净删 `5`；candidate digest `651479e168200238e5b75ff471d15e8baec318599fec62c13520de23f2d6713b`。
- PR41 说明：重复 API-key 读取候选因 credential source 在单次 load 中可变、会改变结果/错误时机而 `REJECT`，没有代码变更或 PR。
- 回滚方式：revert 单提交 `67bb7cf4bd08d233160aa079def6a4dae20fcd8b`；备份 `/tmp/akashic-less-is-more-backups/pr42-search_backend.py.bak-20260723`、`pr42-test_tool_search.py.bak-20260723`、`pr42-ledger.md.bak-20260723`、`pr42-ledger-before-root-entry-20260723.bak`、`pr42-ledger-pre-gate-reconcile-20260723.bak`。

## 验证

- [x] tool search、plugin hot reload/manager、support、loop visibility、discovery routing：`266 passed`。
- [x] 10,002 parity + live mutation；compileall；Pyright `0 errors`。
- [x] migration append-only、production SLOC、`git diff --check` 通过。
- [x] committed HEAD Gate 对 PR40 base 运行并通过。
- `sourceDigest`：`73dc198a5e51744a70008ee12960d16112549d8e597966609a993b4f490473c0`
- `planDigest`：`34e9ed0e083a78a2e097a76f774cd71b1c7bda9267d0d37123ef24ff8c5788d1`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-090029-b1d15a1e`；7 个公开 scenarios 全部通过，base/HEAD 正确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 tool search owner、相关 projectneed 条款与 `NOW.md`。
- [x] live mutable docs、snapshot/generation 与结果排序已对账。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送状态、generation/snapshot/lease/event 或 Git refs。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；复核 diff 边界、10,002 次 parity、64 个 focused tests、SLOC、Gate 与工作树均通过。
- less-is-more PR1～PR42（PR41 rejected/no change）相对 PR0 baseline 净减少 `1,759` production SLOC（`87,540 → 85,781`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
