### PR TITLE
[codex] 隔离无状态 scheduler 执行

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -94,7 +94,7 @@ logger = logging.getLogger(__name__)
 def _persistence_from_metadata(metadata: dict[str, Any] | None) -> TurnPersistencePolicy:
     return TurnPersistencePolicy(
         persist_user=not bool((metadata or {}).get("omit_user_turn")),
-        persist_assistant=True,
+        persist_assistant=not bool((metadata or {}).get("omit_assistant_turn")),
     )
 
 
@@ -777,7 +777,11 @@ class DefaultContextStore(ContextStore):
         session: "SessionLike",
     ) -> ContextBundle:
         # 1. 先读取 session history，并转换成 retrieval pipeline 需要的结构。
-        raw_history = list(session.get_history())
+        raw_history = (
+            []
+            if bool((msg.metadata or {}).get("skip_session_history"))
+            else list(session.get_history())
+        )
         history_messages = support.to_history_messages(raw_history)
 
         # 2. 系统轮次可显式跳过预检索，避免污染检索诊断和激活状态。

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -754,6 +754,7 @@ class AgentLoop:
         sender: str = "user",
         media: list[str] | None = None,
         turn_id: str = "",
+        stateless: bool = False,
     ) -> str:
         response = await self.process_direct_message(
             content,
@@ -769,6 +770,7 @@ class AgentLoop:
             sender=sender,
             media=media,
             turn_id=turn_id,
+            stateless=stateless,
         )
         return response.content
 
@@ -788,10 +790,22 @@ class AgentLoop:
         media: list[str] | None = None,
         metadata: dict[str, object] | None = None,
         turn_id: str = "",
+        stateless: bool = False,
     ) -> OutboundMessage:
-        """执行直接消息并保留渠道可观察的完整输出。"""
+        """执行直接消息，并按需隔离会话历史与持久化。"""
 
         inbound_metadata = dict(metadata or {})
+        if stateless:
+            inbound_metadata.update(
+                {
+                    "omit_user_turn": True,
+                    "omit_assistant_turn": True,
+                    "skip_session_history": True,
+                    "skip_memory_context_guard": True,
+                    "skip_post_memory": True,
+                    "skip_memory_retrieval": True,
+                }
+            )
         if omit_user_turn:
             inbound_metadata["omit_user_turn"] = True
         if skip_post_memory:

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -34,6 +34,7 @@ from core.common.timekit import parse_iso as _parse_iso
 from infra.persistence.json_store import atomic_save_json
 
 logger = logging.getLogger(__name__)
+_SCHEDULER_EXECUTION_CHANNEL = "scheduler"
 
 
 # ── LatencyTracker ───────────────────────────────────────────────
@@ -663,13 +664,11 @@ class SchedulerService:
             t0 = time.monotonic()
             content = await loop.process_direct(
                 content=job.prompt,
-                channel=job.channel,
-                chat_id=job.chat_id,
+                channel=_SCHEDULER_EXECUTION_CHANNEL,
+                chat_id=job.id,
                 session_key=f"scheduler:{job.id}",
                 busy_session_key=f"{job.channel}:{job.chat_id}",
-                omit_user_turn=True,
-                skip_post_memory=True,
-                skip_memory_retrieval=True,
+                stateless=True,
                 disabled_tools=[
                     "message_push",
                     "recall_memory",

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -455,6 +455,10 @@ old text 不存在时失败；多次匹配而未声明 replace-all 时拒绝猜�
 
 add、cancel 和 reschedule 先构造 candidate，持久化成功后才替换内存。stop 后不再产生新 tick；关闭回收 in-flight，停止期间周期任务不重排。
 
+### SCH-003 Soft 调度任务是无状态原子执行
+
+每次 soft job 只使用当前 prompt、系统能力和工具完成一次独立推理，不读取同一 job 的历史窗口，不把内部 user 或 assistant turn 写入会话历史，也不把内部 turn 事件发布到目标 channel。目标 channel 只负责调度时的 busy admission 与最终发送；推理成功且结果非空时只产生一次外部推送，失败或空结果不得伪装成已送达。
+
 ### PRO-001 主动流程的空、跳过和失败可区分
 
 sensor、session、context 和 store 故障不得伪装成“无事件”。decision、dedupe、presence 和成功状态只在真实送达后提交；合法 skip 带 reason，内部错误可观察。

--- a/tests/test_agent_core_p3_context_store.py
+++ b/tests/test_agent_core_p3_context_store.py
@@ -162,6 +162,36 @@ async def test_default_context_store_prepare_skips_retrieval_when_requested():
 
 
 @pytest.mark.asyncio
+async def test_default_context_store_prepare_skips_session_history_when_requested():
+    retrieval = SimpleNamespace(retrieve=AsyncMock())
+    context = SimpleNamespace(
+        skills=SimpleNamespace(list_skill_records=MagicMock(return_value=[]))
+    )
+    store = DefaultContextStore(retrieval=cast(Any, retrieval), context=cast(Any, context))
+    session = _DummySession()
+    msg = InboundMessage(
+        channel="scheduler",
+        sender="scheduler",
+        chat_id="job-1",
+        content="查询北京天气",
+        metadata={
+            "skip_session_history": True,
+            "skip_memory_retrieval": True,
+        },
+    )
+
+    bundle = await store.prepare(
+        msg=msg,
+        session_key="scheduler:job-1",
+        session=cast(Any, session),
+    )
+
+    retrieval.retrieve.assert_not_awaited()
+    assert bundle.history == []
+    assert bundle.history_messages == []
+
+
+@pytest.mark.asyncio
 async def test_default_context_store_uses_cli_context_override_for_retrieval():
     retrieval = SimpleNamespace(
         retrieve=AsyncMock(

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -85,11 +85,11 @@ async def test_soft_calls_process_direct_not_push_directly(
     mock_loop.process_direct.assert_called_once()
     call_kwargs = mock_loop.process_direct.call_args
     assert call_kwargs.kwargs["content"] == "查询北京天气"
-    assert call_kwargs.kwargs["channel"] == "telegram"
-    assert call_kwargs.kwargs["chat_id"] == "123"
+    assert call_kwargs.kwargs["channel"] == "scheduler"
+    assert call_kwargs.kwargs["chat_id"] == job.id
+    assert call_kwargs.kwargs["session_key"] == f"scheduler:{job.id}"
     assert call_kwargs.kwargs["busy_session_key"] == "telegram:123"
-    assert call_kwargs.kwargs["skip_post_memory"] is True
-    assert call_kwargs.kwargs["skip_memory_retrieval"] is True
+    assert call_kwargs.kwargs["stateless"] is True
     assert call_kwargs.kwargs["disabled_tools"] == [
         "message_push",
         "recall_memory",

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.core.passive_turn import _persistence_from_metadata
 from agent.core.runtime_support import SessionLike, TurnRunResult
 from agent.looping.core import AgentLoop, _supports_stream_events
 from agent.looping.interrupt import TurnInterruptState
@@ -154,6 +155,43 @@ async def test_process_direct_suppresses_stream_and_memory_when_requested():
         "disabled_tools": ["message_push"],
     }
     assert loop._process.await_args.kwargs["dispatch_outbound"] is False
+
+
+@pytest.mark.asyncio
+async def test_process_direct_stateless_turn_has_no_history_or_persistence():
+    loop = object.__new__(AgentLoop)
+    loop._passive_runtime_lock = asyncio.Lock()
+    loop._runtime_snapshot_store = None
+    loop._process = AsyncMock(
+        return_value=OutboundMessage(
+            channel="scheduler",
+            chat_id="job-1",
+            content="ok",
+        )
+    )
+
+    await AgentLoop.process_direct(
+        loop,
+        content="天气",
+        session_key="scheduler:job-1",
+        channel="scheduler",
+        chat_id="job-1",
+        stateless=True,
+    )
+
+    msg = loop._process.await_args.args[0]
+    assert msg.metadata == {
+        "omit_user_turn": True,
+        "omit_assistant_turn": True,
+        "skip_session_history": True,
+        "skip_memory_context_guard": True,
+        "skip_post_memory": True,
+        "skip_memory_retrieval": True,
+        "suppress_stream_events": True,
+    }
+    persistence = _persistence_from_metadata(msg.metadata)
+    assert persistence.persist_user is False
+    assert persistence.persist_assistant is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 改动

- soft scheduler 固定使用内部 `scheduler` channel，不再向目标 channel 泄漏内部 turn 事件
- 增加 `stateless` direct turn：不读取 session history、不做记忆检索、不持久化 user/assistant
- 保留目标会话 busy admission，并仅在成功且结果非空时发送最终 proactive 消息
- 将无状态原子任务语义写入 `SCH-003`

## 根因

旧实现用目标 `mobile` channel 执行 scheduler 内部推理，客户端收到 `turn.started`；但 direct turn 禁止最终 outbound dispatch，导致 scheduler session 永久缺少 `message.final`，下一周期形成重叠 turn。

## 验证

- `83 passed`：scheduler、turn pipeline、context store、mobile realtime channel
- public change-impact Gate passed
- private provider Gate required，等待维护者环境执行

## 回滚

回滚本 PR commit 即可恢复旧执行路径；本 PR 不迁移或删除正式 workspace 数据。