### PR TITLE
refactor(channels): remove empty startup exception wrapper

### DIFF
--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from agent.config_models import Config
 from agent.looping.interrupt import InterruptController
 from agent.tools.message_push import MessagePushTool
 from bootstrap.channel_host import ChannelHost
-from bootstrap.cleanup import run_cleanup_steps
 from bus.event_bus import EventBus
 from bus.queue import MessageBus
 from core.net.http import SharedHttpResources
@@ -29,58 +27,55 @@ async def start_channels(
     interrupt_controller: InterruptController | None = None,
     plugin_channels: list[Channel] | None = None,
 ) -> ChannelHost:
-    try:
-        attachment_store = AttachmentStore(session_manager.workspace / "uploads")
+    attachment_store = AttachmentStore(session_manager.workspace / "uploads")
 
-        def _ctx_factory(channel: Channel) -> ChannelContext:
-            return ChannelContext(
-                bus=bus,
-                session_manager=session_manager,
-                event_bus=event_bus,
-                push_tool=push_tool,
-                attachment_store=attachment_store,
-                http_resources=http_resources,
-                interrupt_controller=interrupt_controller,
-                mobile_bot_commands=mobile_bot_commands or [],
-                log=logging.getLogger(f"channels.{channel.name}"),
-            )
+    def _ctx_factory(channel: Channel) -> ChannelContext:
+        return ChannelContext(
+            bus=bus,
+            session_manager=session_manager,
+            event_bus=event_bus,
+            push_tool=push_tool,
+            attachment_store=attachment_store,
+            http_resources=http_resources,
+            interrupt_controller=interrupt_controller,
+            mobile_bot_commands=mobile_bot_commands or [],
+            log=logging.getLogger(f"channels.{channel.name}"),
+        )
 
-        host = ChannelHost(_ctx_factory)
+    host = ChannelHost(_ctx_factory)
 
-        if config.channels.telegram and config.channels.telegram.token:
-            from infra.channels.telegram_channel import TelegramChannel
+    if config.channels.telegram and config.channels.telegram.token:
+        from infra.channels.telegram_channel import TelegramChannel
 
-            tg = config.channels.telegram
-            host.add(TelegramChannel(
-                token=tg.token,
-                bus=bus,
-                session_manager=session_manager,
-                allow_from=tg.allow_from,
-                bot_commands=telegram_bot_commands,
-                event_bus=event_bus,
-                interrupt_controller=interrupt_controller,
-                channel_name=tg.channel_name,
-            ))
+        tg = config.channels.telegram
+        host.add(TelegramChannel(
+            token=tg.token,
+            bus=bus,
+            session_manager=session_manager,
+            allow_from=tg.allow_from,
+            bot_commands=telegram_bot_commands,
+            event_bus=event_bus,
+            interrupt_controller=interrupt_controller,
+            channel_name=tg.channel_name,
+        ))
 
-        if config.channels.qq and config.channels.qq.bot_uin:
-            from infra.channels.qq_channel import QQChannel
+    if config.channels.qq and config.channels.qq.bot_uin:
+        from infra.channels.qq_channel import QQChannel
 
-            qq = config.channels.qq
-            host.add(QQChannel(
-                bot_uin=qq.bot_uin,
-                bus=bus,
-                session_manager=session_manager,
-                allow_from=qq.allow_from,
-                groups=qq.groups,
-                websocket_open_timeout_seconds=qq.websocket_open_timeout_seconds,
-                http_requester=http_resources.external_default,
-                event_bus=event_bus,
-                interrupt_controller=interrupt_controller,
-            ))
+        qq = config.channels.qq
+        host.add(QQChannel(
+            bot_uin=qq.bot_uin,
+            bus=bus,
+            session_manager=session_manager,
+            allow_from=qq.allow_from,
+            groups=qq.groups,
+            websocket_open_timeout_seconds=qq.websocket_open_timeout_seconds,
+            http_requester=http_resources.external_default,
+            event_bus=event_bus,
+            interrupt_controller=interrupt_controller,
+        ))
 
-        for channel in plugin_channels or []:
-            host.add(channel)
+    for channel in plugin_channels or []:
+        host.add(channel)
 
-        return host
-    except (asyncio.CancelledError, Exception) as start_error:
-        raise
+    return host

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -759,6 +759,21 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；执行前备份：`/tmp/akashic-less-is-more-backups/pr44-dashboard-api-before-change-20260723.py`、`/tmp/akashic-less-is-more-backups/pr44-clean-code-ledger-before-change-20260723.md`；回滚点为本 PR 单提交 revert。
 - 残余风险：无已知风险；若未来重新引入 preview 格式化，应由实际消费者就近拥有，不恢复零调用的 Dashboard 全局 helper。
 
+## 2026-07-23 less-is-more PR45：删除 Channel 启动遗留异常空壳
+
+### `PR45` `refactor(channels): remove empty startup exception wrapper`
+
+- base：PR44 committed HEAD `edb5fb6b8700a24907de6099e72c06019f066160`，分支 `refactor/less-is-more-pr45-remove-empty-channel-catch`。
+- allowed_paths：`bootstrap/channels.py` 与本账本；`capability_owner`：ChannelHost 构造以及内建/插件 Channel 注册。未修改 Channel start/stop、runtime caller、测试、schema、manifest、迁移或正式 runtime workspace。
+- 历史与不可达性：`9f0faeee` 引入的 `try/except` 原本在 Channel 启动失败时调用 `run_cleanup_steps` 清理 IPC；`89ceaf29` 移除 IPC、start await 与清理逻辑后，只留下捕获 `CancelledError`/`Exception` 再原样 `raise` 的空壳，以及仅由空壳引用的 `asyncio` 和已完全未使用的 `run_cleanup_steps` import。CodeGraph、精确/dynamic/export/plugin-cache 扫描均未发现模块属性 consumer。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。候选只取消函数主体缩进并删除空壳/import；普通异常和取消仍以同一对象、类型、参数、cause、context、suppress-context 与 traceback 函数帧向上传播。`start_channels` 当前没有 await，也没有在异常时需要回滚的已取得资源；AttachmentStore 只保存路径，Channel 构造失败前未启动 Channel。
+- 范围与计量：base source-set digest `ea1ce757552ff59c11048dd8ecdbbb53177a86c24c4fb7eb18787e76f2c39b86`，文件数 `378`，Python SLOC `77,321`，`bootstrap` `6,304`，total production SLOC `85,772`；candidate digest `3050a573e13b6734b402011897d04a61449657feff39c6a8b777d6e881a9c4a9`，文件数 `378`，Python SLOC `77,316`，`bootstrap` `6,299`，total `85,767`；production 净减少 `5` SLOC，系列相对 PR0 累计净减少 `1,773` SLOC。
+- 差分回放：对 `RuntimeError` 与 `asyncio.CancelledError` 在首个 workspace 读取处注入同一异常对象；base/candidate 的对象身份、类型、args、cause、context、suppress-context 和 traceback 函数名序列完全相等。focused microbenchmark 噪声大且未显示稳定收益，因此不宣称端到端性能提升。
+- 测试与静态验证：`tests/test_runtime_smoke.py tests/test_more_support_modules.py tests/test_channel_host.py` 完整文件级回归为 `76 passed in 2.60s`；production SLOC 与 migration append-only 为 `14 passed`；相关源码 `compileall` 通过，Pyright `0 errors, 0 warnings`；动态/module-attribute consumer scan 与 `git diff --check` 通过。
+- Gate：已在 committed HEAD 对 PR44 base `edb5fb6b8700a24907de6099e72c06019f066160` 运行公开 Gate 并通过；private contract 状态为 `pending_maintainer`，不把运行后的 report/source/plan digest 回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；执行前备份：`/tmp/akashic-less-is-more-backups/pr45-channels-before-change-20260723.py`、`/tmp/akashic-less-is-more-backups/pr45-clean-code-ledger-before-change-20260723.md`；回滚点为本 PR 单提交 revert。
+- 残余风险：删除两个 incidental module attributes；它们没有 `__all__`、文档、caller、动态读取或插件依赖证据，不属于已记录静态语义。后续若重新引入启动期资源，清理必须由实际资源 owner 明确实现，不能恢复空 catch。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`start_channels` 保留了旧 IPC 清理迁移后的空 `try/except`，两个异常分支只做原样 `raise`，并遗留两个无用途 imports。
- 用户可见结果：内建/插件 Channel 注册、返回的 ChannelHost、普通异常与取消传播完全不变；production SLOC `85,772 → 85,767`，净删 `5`。
- 性能：删除无动作异常匹配和无用 import；focused microbenchmark 噪声大且没有稳定收益，因此不宣称端到端性能提升。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：ChannelHost 构造以及内建/插件 Channel 注册。
- `consumer_scope`：`start_channels` 的 runtime caller、内建 Telegram/QQ 和 plugin channels；两个 incidental module attributes 无静态、动态、export 或 plugin consumer。
- `runtime_patch`：`none`
- 关联不变量：Channel 构造/注册顺序、返回值、异常对象、type/args/cause/context、取消传播、traceback 函数帧与副作用不变。
- `protected_state`：Channel start/stop、正式 workspace、uploads、session、服务、网络、外部发送、plugin generation/snapshot。
- 禁止的副作用：不修改实际清理 owner、Channel 生命周期、错误分类、日志、schema、migration 或测试 oracle。

## 改动范围

- `bootstrap/channels.py`：删除空 `try/except`、`asyncio` 和 `run_cleanup_steps` imports，并仅取消原函数主体的一层缩进。
- `docs/refactor/clean-code-ledger.md`：记录迁移历史、异常 parity、计量、验证、Gate、备份和回滚。
- 历史证据：`9f0faeee` 的 wrapper 原本清理 IPC；`89ceaf29` 删除 IPC/start await/cleanup 后留下空 catch。本函数当前无 await，也没有异常时需要回滚的已取得资源。
- whitespace 说明：raw diff 因取消缩进较大；`git diff --ignore-all-space` 仅显示两个 imports、`try` 与两行 `except/raise` 被删除。
- 差分回放：`RuntimeError`/`CancelledError` 的对象身份、类型、args、cause、context、suppress-context 与 traceback 函数名序列逐项一致。
- production 计量：PR44 `85,772` → PR45 `85,767`；candidate source-set digest `3050a573e13b6734b402011897d04a61449657feff39c6a8b777d6e881a9c4a9`。
- 回滚方式：revert 单提交 `b86dec53f4af90695f0ad105a801a50f59e518e0`；备份 `/tmp/akashic-less-is-more-backups/pr45-channels-before-change-20260723.py`、`pr45-clean-code-ledger-before-change-20260723.md`。

## 验证

- [x] runtime smoke + bootstrap support + ChannelHost 完整文件级回归：`76 passed`。
- [x] production SLOC + migration append-only：`14 passed`。
- [x] base/candidate exception parity；compileall；Pyright `0 errors, 0 warnings`；dynamic/module-attribute scan；`git diff --check`。
- [x] committed HEAD Gate 对 PR44 base 运行并通过。
- `sourceDigest`：`6f71bd5ae939b49af653f2e30e70091a27bfc7967686f4a88b153fcf8e0e5969`
- `planDigest`：`8348435e84cdfa0894512af72625fe83a3d2b66577c3308cf691fe1b0c2329a2`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-205931-038e2657`；7 个公开 scenarios 全部通过，base/HEAD 精确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。

## 工作手册

- [x] 已核对 GOV-001～005、ERR-001、RUN-002、TST-004/TST-006、`NOW.md` 与真实实现/历史。
- [x] 未修改正式 workspace、数据库、服务、网络、外部发送、generation/snapshot/lease/event 或 Git migration。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- 独立 `gpt-5.6-luna` xhigh post-review：`ACCEPT`；复核 IPC 历史、异常 parity、资源 owner、76 个回归、SLOC、final Gate 与工作树均通过。
- less-is-more PR1～PR45（PR41 rejected/no change）相对 PR0 baseline 净减少 `1,773` production SLOC（`87,540 → 85,767`）；另有 PR27 `7` eval runner SLOC，核心能力不变。
