### PR TITLE
perf(recall): reuse read-only intent map

### DIFF
--- a/agent/tools/recall_memory.py
+++ b/agent/tools/recall_memory.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timedelta
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
@@ -25,6 +27,15 @@ _RECENT_PRESETS = {
     "recent_7d": 7,
     "recent_30d": 30,
 }
+_INTENTS: Mapping[str, MemoryQueryIntent] = MappingProxyType(
+    {
+        "context": "context",
+        "answer": "answer",
+        "timeline": "timeline",
+        "interest": "interest",
+        "procedure": "procedure",
+    }
+)
 
 class RecallMemoryTool(Tool):
     name = "recall_memory"
@@ -65,7 +76,7 @@ class RecallMemoryTool(Tool):
         result = await self._memory.query(
             MemoryQuery(
                 text=text,
-                intent=_normalize_intent(intent),
+                intent=_INTENTS.get(intent, "answer"),
                 scope=MemoryScope(
                     session_key=f"{channel}:{chat_id}" if channel and chat_id else "",
                     channel=channel or "",
@@ -145,19 +156,6 @@ def _first_source_ref(evidence: list[dict[str, object]]) -> str:
                 if text:
                     return text
     return ""
-
-
-def _normalize_intent(
-    value: str,
-) -> MemoryQueryIntent:
-    intents: dict[str, MemoryQueryIntent] = {
-        "context": "context",
-        "answer": "answer",
-        "timeline": "timeline",
-        "interest": "interest",
-        "procedure": "procedure",
-    }
-    return intents.get(value, "answer")
 
 
 def _memory_kinds(memory_kind: str) -> tuple[str, ...]:

--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -822,6 +822,23 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 迁移/持久化/运行 workspace 变化：`none`；未修改数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git refs。执行前备份：`/tmp/akashic-pr48-backup-20260723213421/setup_wizard.py`、`/tmp/akashic-pr48-backup-20260723213421/clean-code-ledger.md`；回滚点为本 PR 单提交 revert。
 - 残余风险：无已知风险；若未来默认记忆 renderer 需要参数、审计副作用或独立错误转换，应由 canonical renderer owner 重新建立命名边界，不能恢复纯转发别名。
 
+## 2026-07-23 less-is-more PR49：复用只读 intent 映射
+
+### `PR49` `perf(recall): reuse read-only intent map`
+
+- base：PR48 committed HEAD `fb37e37b3e5f955a52d2e9044bd5a2b92da8b577`，分支 `refactor/less-is-more-pr48-inline-memory-config-renderer`；本 PR 分支 `perf/less-is-more-pr49-reuse-readonly-intent-map`，唯一 writer 为本任务 agent。
+- 范围：`agent/tools/recall_memory.py` 的 `_normalize_intent`；每次调用原地构造的五项 intent dict 改为模块私有 `MappingProxyType`，`RecallMemoryTool.execute` 唯一调用方直接执行 `_INTENTS.get(intent, "answer")`，删除 helper；未修改测试 oracle、query、scope、filters、limit、timestamp、memory engine、持久化、网络或插件导出。
+- `semantic_delta`：`none`。五个合法 intent、未知/空/`None` 默认值、不可哈希 list/dict 的 `TypeError`、`str` 子类的 hash/equality 调用顺序与 canonical base `str` 返回值保持不变；静态映射底层 dict 不泄露，`MappingProxyType` 不可赋值。诊断差异仅为 traceback 不再包含已删除的私有 helper frame；模块导入时多一次静态构造，极端 OOM 的失败时机提前，除此之外没有新的可观察副作用。
+- 不变量与拥有层：`MemoryQueryIntent` 仍由 `core.memory.engine` 的 `Literal` 定义；`_INTENTS` 只保存该类型的 canonical 字符串，`RecallMemoryTool.execute` 继续在构造 `MemoryQuery` 前归一化 intent。内部错误不新增 fallback：不可哈希值仍由映射 lookup fail-fast。
+- baseline：source-set digest `12cd4dc6dbdf434bedc9fd95b1aac486aa8cee017836766c413b250d4a9faf32`，文件数 `378`，Python SLOC `77,310`，TypeScript/TSX SLOC `8,451`，total production SLOC `85,761`。
+- candidate：source-set digest `7c1e257cc42facb2dd9a7190d0ab665a46d9b2fcd3a1536f90ffaa33851d016d`，文件数 `378`，Python SLOC `77,310`，TypeScript/TSX SLOC `8,451`，total production SLOC `85,761`（模块级映射初始化抵消了已删除 helper 的 source lines；运行时每次调用不再分配 intent dict）。
+- 性能：固定六种输入（五个命中与一个未知）共 60 万次 lookup，交错 9 轮中位 CPU 由 `75.622 ms` 降至 `31.865 ms`，局部 lookup 约 `-57.86%`；该结果只代表 intent lookup 热点，不外推为端到端 recall/search 提速。
+- 测试新增/删除：无；现有 recall 与 memory-engine oracle 未改动。一次性 parity 脚本额外核对五个合法 intent、未知/空/`None`、不可哈希 list/dict、`str` 子类 hash/equality side effects、canonical base `str` 返回值和 `MappingProxyType` 不可赋值。
+- 验证结果：recall 定向 `27 passed`；`tests/test_memory_engine_contract.py` + recall 组合 `57 passed`；修改文件 `compileall` 通过；Pyright `0 errors, 0 warnings`；migration append-only、consumer/export/dynamic/cache scan 和 `git diff --check` 通过。已在 committed HEAD 对 PR48 base 运行公开 Gate 并通过；private contract 状态为 `pending_maintainer`，report/source/plan digest 不回填到账本以避免 source 自引用。
+- 迁移/持久化/运行 workspace 变化：`none`；执行前备份为 `/tmp/akashic-pr49-recall_memory.py.RlbTf4` 与 `/tmp/akashic-pr49-clean-code-ledger.md.0r3Qc1`，未修改 migration、数据库、正式 workspace、服务、远端数据或 Git refs。
+- Redis 式 God file 判断：保留 `agent/tools/recall_memory.py`；intent canonicalization 与 `RecallMemoryTool` 构造 `MemoryQuery` 同属工具边界，删除 helper 并把 immutable table 放在模块顶部降低热路径分配和跨函数跳转，不拆文件。
+- 残余风险与回滚点：只读 map 的构造从调用期提前到 import 期；若以后 intent 协议新增值，必须同时修改 `MemoryQueryIntent` 与此 canonical table。提交后可用单提交 revert `perf(recall): reuse read-only intent map` 回滚。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`RecallMemoryTool.execute` 每次归一化 intent 都构造同一份五项字典，并经过一个只有单一调用方的私有 helper。
- 用户可见结果：五个合法 intent、未知/空/`None` 默认行为、不可哈希输入错误和查询构造均不变；固定 60 万次 lookup 的局部 CPU 中位数由 `75.622 ms` 降至 `31.865 ms`，约 `-57.86%`。
- 本 PR 不处理：不修改 memory engine、query/scope/filter/limit/timestamp、持久化、协议或测试 oracle；局部 lookup 数据不外推为端到端 recall/search 提速。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`core`
- `consumer_scope`：`_normalize_intent` 只有 `RecallMemoryTool.execute` 一个静态 caller，无 export、dynamic、SDK 或 plugin-cache consumer。
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅优化 core recall 工具内部的 canonical intent lookup。
- `authoritative_state_owner`：`core.memory.engine.MemoryQueryIntent`
- `client_only_alternative`：不适用；没有客户端或协议变化。
- 关联不变量：五个 canonical intent、未知值回落到 `answer`、不可哈希输入 fail-fast、`str` 子类 hash/equality 顺序与 canonical base `str` 返回值不变。
- `protected_state`：memory query 语义、session/memory 持久状态、插件数据、正式 workspace、迁移和外部副作用。
- 允许的副作用：模块导入时构造一次只读 canonical map；每次调用不再分配五项 dict。
- 禁止的副作用：不新增 catch、fallback、默认兼容层、可变全局协议或错误吞隐。

## 改动范围

- `agent/tools/recall_memory.py`：将重复构造的 dict 提升为模块私有 `MappingProxyType`，唯一 caller 直接 lookup，删除无状态 helper。
- `docs/refactor/clean-code-ledger.md`：记录 owner、静态语义、错误处理、性能、注释、God file 组织判断、计量、Gate、备份与回滚。
- 错误与诊断：不可哈希 list/dict 继续抛 `TypeError`；不新增恢复路径。traceback 仅少已删除的私有 helper frame。只读 map 从调用期提前到 import 期，因此极端 OOM 的失败时机也会提前，已显式记录。
- 静态只读性：底层 dict 不向外暴露，`MappingProxyType` 不允许赋值。
- production 计量：PR48 `85,761` → PR49 `85,761`，净 `0`；模块级初始化行抵消已删除 helper 的源码行，但热路径不再重复分配。
- 配置或迁移影响：`none`
- 已知 schema lineage 与最终 schema identity：不适用；未修改 schema。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用；未修改跨仓库协议或 runtime provider。
- 回滚方式：revert 单提交 `782ae3fd85f452539319bd008c1261453ff99dfc`；执行前备份 `/tmp/akashic-pr49-recall_memory.py.RlbTf4`、`/tmp/akashic-pr49-clean-code-ledger.md.0r3Qc1`，账本归位前备份 `/tmp/akashic-less-is-more-backups/pr49-ledger-before-section-move-20260723.md`。

## 验证

- [x] recall 定向 `27 passed`；recall + memory-engine contract 合计 `57 passed`。
- [x] 五个合法 intent、未知/空/`None`、不可哈希 list/dict、`str` 子类 side effects、canonical `str` 与只读赋值 parity。
- [x] 修改文件 compileall；Pyright `0 errors, 0 warnings`。
- [x] consumer/export/dynamic/cache scan、migration append-only、production SLOC 与 `git diff --check`。
- [x] `/mnt/data/coding/akasic-agent/.venv/bin/python docker/debug/gate.py run --base fb37e37b3e5f955a52d2e9044bd5a2b92da8b577` 已在 committed HEAD 运行。
- `sourceDigest`：`ab01117bca1ee0ad3b4338a7771f720816df3eeaa20f366ac2bfb13928c8df75`
- `planDigest`：`7774ddd4c81d8ff012c0d2fa3dcc5272a4dd7d3afa324a46a7eecf0f4ebfefe5`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260723-215817-25968624`；7 个公开 scenarios 全部通过，base/HEAD 精确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。
- 未运行项与原因：private provider 保持私有，由维护者使用同一 plan 执行。

## 工作手册

- [x] 已核对相关 projectneed、错误边界、持久化边界、`NOW.md` 与真实实现/历史。
- [x] 没有长期语义变化；静态语义与有限诊断差异均已记录。
- [x] 跨仓库或客户端改动不适用；未修改正式 workspace、数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git migration。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- writer：`gpt-5.6-luna` xhigh；独立 `gpt-5.6-luna` xhigh post-review 在最终 committed HEAD 上结论为 `ACCEPT`。
- less-is-more PR1～PR49（PR41 rejected/no change）相对 PR0 baseline 累计净减少 `1,779` production SLOC（`87,540 → 85,761`）；PR49 是性能型等量重构，不虚报净删除。