### PR TITLE
refactor(akasha): inline message parser alias

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -839,6 +839,24 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - Redis 式 God file 判断：保留 `agent/tools/recall_memory.py`；intent canonicalization 与 `RecallMemoryTool` 构造 `MemoryQuery` 同属工具边界，删除 helper 并把 immutable table 放在模块顶部降低热路径分配和跨函数跳转，不拆文件。
 - 残余风险与回滚点：只读 map 的构造从调用期提前到 import 期；若以后 intent 协议新增值，必须同时修改 `MemoryQueryIntent` 与此 canonical table。提交后可用单提交 revert `perf(recall): reuse read-only intent map` 回滚。
 
+## 2026-07-24 less-is-more PR50：内联 Akasha message parser 私有别名
+
+### `PR50` `refactor(akasha): inline message parser alias`
+
+- base：PR49 committed HEAD `782ae3fd85f452539319bd008c1261453ff99dfc`，分支 `perf/less-is-more-pr49-reuse-readonly-intent-map`；本 PR 分支 `refactor/less-is-more-pr50-inline-akasha-message-parser`，唯一 writer 为本任务 agent。
+- allowed_paths：`plugins/akasha/engine.py` 的 `_parse_message_id` 唯一 caller 与私有 helper、本账本；`capability_owner`：`AkashaMemoryEngine.undo_by_message_sources` 的 message ID → affected turn key 映射。未修改测试、oracle、`_parse_turn_key`、`_possible_turn_keys`、store、schema、migration、NOW、projectneed 或正式 runtime workspace。
+- 历史与消费者：`6310c87e` 在接入 Akasha 引擎时直接把 `_parse_message_id` 建成 `_parse_turn_key(message_id)` 的无状态转发，此后没有独立语义演进。同模块已在 undo 删除、turn card 回源和 batch load 路径直接使用 `_parse_turn_key`；全仓精确 consumer、export/re-export、动态属性/import 与已安装 plugin cache 扫描确认旧 helper 只有一处静态 caller，没有外部 seam。
+- 语义与错误边界：`change_type: refactor`，`semantic_delta: none`。caller 在相同循环位置直接执行同一 module-global `_parse_turn_key(message_id)` lookup；参数求值次数、global parser lookup 次数、tuple/`None` 返回对象、无分隔符和非整数 suffix 的 `None` 分类保持不变。`undo_by_message_sources` 已先用 `str(item).strip()` 把输入规范化为普通 `str`，因此 parser 不接收带自定义 `rpartition` 的 `str` subclass。唯一诊断差异是恶意 monkeypatch 让 canonical parser 抛错时，traceback 少一个已删除的 alias frame；异常对象、类型、参数、cause/context 与传播时机不变。
+- 持久化与 write set：`none`。affected turn key 集合保持相同，`delete_items_batch`、query state、`message_embeddings`、内存 nodes/edges/cache 的调用条件、参数、顺序和 dry-run 行为均未修改；没有数据库、文件、事件、网络、服务或外部发送变化。
+- 性能、注释与 God file：仅减少 uncached undo fallback 的一次 Python 私有 helper 跳转，不做端到端性能宣称。删除的 helper 没有 docstring、约束或 workaround 注释；保留 affected-turn、undo 与 parser owner 的现有注释。`engine.py` 内的 undo、turn-key 解析与相邻 key 推导属于同一高内聚状态映射，删除别名比拆分文件更少跨文件跳转，符合 Redis 式 God file 原则。
+- baseline：source-set digest `7c1e257cc42facb2dd9a7190d0ab665a46d9b2fcd3a1536f90ffaa33851d016d`，文件数 `378`，Python SLOC `77,310`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,102`，total production SLOC `85,761`。
+- candidate：source-set digest `162b04642ed2734a0b2a7c9b8a1e51a51e74a3632995a13f85a3b677478386f0`，文件数 `378`，Python SLOC `77,308`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,100`，total production SLOC `85,759`；production 净减少 `2` SLOC，系列相对 PR0 累计净减少 `1,781` SLOC。
+- parity：一次性 base/candidate 脚本覆盖 uncached 合法 ID、多冒号 session key、非法 suffix、相邻删除 ID 与 cached mapping 五组输入，结果逐项相同；module-global spy 确认 parser 参数与调用次数相同；`str` subclass 经 undo 边界规范化后的结果和 `__str__` 调用次数相同；异常注入确认对象身份、类型和参数相同，traceback 仅移除 `_parse_message_id` frame。脚本未提交。
+- 测试与静态验证：既有 Akasha undo 定向测试 `1 passed`，完整 `tests/test_akasha_plugin.py` 为 `65 passed`；未修改、新增或删除测试。目标文件 `compileall` 通过，Pyright `0 errors, 0 warnings`；migration append-only 脚本与 `tests/test_migration_append_only.py`（`5 passed`）通过；生产源码、测试、SDK、plugin consumer/export/dynamic scan 除本账本历史记录外零残留，installed plugin cache 旧 symbol 扫描零残留，production SLOC 和 `git diff --check` 通过。
+- Gate：已在 committed HEAD 对 PR49 base `782ae3fd85f452539319bd008c1261453ff99dfc` 运行公开 Gate，7 个场景全部通过；private contract 状态为 `pending_maintainer`，不把运行后的 report/source/plan digest 回填到账本以避免 source 自引用。
+- 备份与回滚：执行前备份为 `/tmp/akashic-less-is-more-backups/pr50/engine.py.base-782ae3fd`（SHA-256 `1e6b40c25fe8e1ef514b612785d866efd69a6c0ec43877362d6e2ece109f2b6f`）与 `/tmp/akashic-less-is-more-backups/pr50/clean-code-ledger.md.base-782ae3fd`（SHA-256 `4ff24e3f939af69944f853639b6e4bd55e4fa56c4fc7c725d17d6de58edf4773`）；Gate 对账前账本备份为 `/tmp/akashic-less-is-more-backups/pr50/clean-code-ledger.md.pre-final-gate-06a2b9e6`（SHA-256 `751182d9af315cc6f4cfd900bd269ecffb622082e2b1ce057ba96c64d54b9890`）。提交后可用单提交 revert `refactor(akasha): inline message parser alias` 回滚。
+- 残余风险：若未来 `_parse_message_id` 需要独立输入协议、审计或错误转换，应在真实 owner 边界重新引入有职责的函数；不能仅为保留额外 traceback frame 恢复纯转发别名。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1073,7 +1073,7 @@ class AkashaMemoryEngine:
             if cached and cached in existing_keys:
                 affected.add(cached)
                 continue
-            parsed = _parse_message_id(message_id)
+            parsed = _parse_turn_key(message_id)
             if parsed is None:
                 continue
             session_key, seq = parsed
@@ -1521,10 +1521,6 @@ def _load_turn_card(
         lane=lane,
         signals=signals,
     )
-
-
-def _parse_message_id(message_id: str) -> tuple[str, int] | None:
-    return _parse_turn_key(message_id)
 
 
 def _possible_turn_keys(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha undo 的 uncached message ID fallback 经过 `_parse_message_id`，而该私有 helper 从引入起就只原样转发同模块 canonical `_parse_turn_key`，只有一个 caller、没有独立规则。
- 用户可见结果：合法/非法 message ID、affected turn key、dry-run 与真实 undo 的返回和持久化结果不变；production SLOC `85,761 → 85,759`，净删 `2`。
- 本 PR 不处理：不修改 `_parse_turn_key`、`_possible_turn_keys`、undo write set、store/schema/migration、测试 oracle或正式 workspace；不宣称端到端性能提升。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`core`
- `consumer_scope`：`_parse_message_id` 只有 `AkashaMemoryEngine._affected_turn_keys` 一个静态 caller，无 export、dynamic、SDK、测试或 installed plugin-cache consumer。
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅删除 Akasha engine 内部无状态 parser alias。
- `authoritative_state_owner`：Akasha store、SessionDB message embeddings 与 `AkashaMemoryEngine.undo_by_message_sources` 各自保持原 owner；本 PR 不改变状态。
- `client_only_alternative`：不适用；没有客户端或协议变化。
- 关联不变量：message ID 先经 `str(item).strip()` 规范化；canonical parser 调用一次；tuple/`None` 分类、affected key 集合、写入条件/参数/顺序和错误传播不变。
- `protected_state`：Akasha nodes/edges/query logs、session message embeddings、memory/session 数据、正式 workspace、migration 和外部副作用。
- 允许的副作用：uncached fallback 少一次 Python 私有 helper 跳转。
- 禁止的副作用：不新增 catch、fallback、默认兼容层、删除路径、数据库/文件/事件/网络/服务或消息发送变化。

## 改动范围

- `plugins/akasha/engine.py`：唯一 caller 直接调用 `_parse_turn_key(message_id)`，删除两行 `_parse_message_id` alias。
- `docs/refactor/clean-code-ledger.md`：新增 PR50 的历史、owner、语义、错误处理、持久化、注释、God file、计量、差分回放、Gate、备份与回滚记录。
- 历史：alias 由 `6310c87e` 初次接入 Akasha 时建立，此后没有独立语义演进；同模块其他路径已经直接使用 `_parse_turn_key`。
- 错误与诊断：canonical parser 对无分隔符和非法 suffix 继续返回 `None`；异常对象、类型、参数、cause/context 和调用时机保持不变。若测试主动 monkeypatch canonical parser 抛错，traceback 仅少已删除的 alias frame。
- 持久化：`delete_items_batch`、query state、`message_embeddings`、nodes/edges/cache 的调用条件、参数、顺序和 dry-run 行为不变，write set 为 `none`。
- 配置或迁移影响：`none`
- 已知 schema lineage 与最终 schema identity：不适用；未修改 schema。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用；未修改跨仓库协议或 provider。
- 回滚方式：revert 单提交 `b2c0bf3d4f125e981c1da029ddfbf6f600be3c72`；恢复点位于 `/tmp/akashic-less-is-more-backups/pr50/`。

## 验证

- [x] 完整 `tests/test_akasha_plugin.py`：`65 passed`。
- [x] migration append-only 检查及 `tests/test_migration_append_only.py`：`5 passed`。
- [x] base/candidate 六组 `_affected_turn_keys` fallback、spy、`str` subclass 和异常对象差分回放；规范化结果完全一致，traceback 仅少 alias frame。
- [x] 修改文件 compileall；Pyright `0 errors, 0 warnings`。
- [x] consumer/export/dynamic/installed-cache scan、production SLOC 与 `git diff --check`。
- [x] `/mnt/data/coding/akasic-agent/.venv/bin/python docker/debug/gate.py run --base 782ae3fd85f452539319bd008c1261453ff99dfc` 已在最终 committed HEAD 运行。
- `sourceDigest`：`d0bbdd074e93e6207c12471f76005885e39195b1ac564b71c02a8e0312d09ef2`
- `planDigest`：`47d6afda5c8fe3ced1fc5d6b98f687ef3cc57e9c9e2967589d34646fade58ab5`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260724-015838-c3b7c962`；7 个公开 scenarios 全部通过，base/HEAD 精确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。
- 未运行项与原因：private provider 保持私有，由维护者使用同一 plan 执行。

## 工作手册

- [x] 已核对 GOV-001～005、ERR-001、TST-004/TST-006、`NOW.md`、写作规则与真实实现/历史。
- [x] 没有长期语义变化；静态语义与唯一诊断差异均已记录。
- [x] 跨仓库或客户端改动不适用；未修改正式 workspace、数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git migration。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- implementation：`githubluna` profile（`gpt-5.6-luna`、xhigh）；主 agent 独立复核完整相邻 diff、真实历史、consumer、差分回放、70 项测试、Pyright、SLOC、最终 Gate 与远端基线。
- less-is-more PR1～PR50（PR41 rejected/no change）相对 PR0 baseline 累计净减少 `1,781` production SLOC（`87,540 → 85,759`）。