### PR TITLE
refactor(akasha): inline reinforce boost alias

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -857,6 +857,25 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 备份与回滚：执行前备份为 `/tmp/akashic-less-is-more-backups/pr50/engine.py.base-782ae3fd`（SHA-256 `1e6b40c25fe8e1ef514b612785d866efd69a6c0ec43877362d6e2ece109f2b6f`）与 `/tmp/akashic-less-is-more-backups/pr50/clean-code-ledger.md.base-782ae3fd`（SHA-256 `4ff24e3f939af69944f853639b6e4bd55e4fa56c4fc7c725d17d6de58edf4773`）；Gate 对账前账本备份为 `/tmp/akashic-less-is-more-backups/pr50/clean-code-ledger.md.pre-final-gate-06a2b9e6`（SHA-256 `751182d9af315cc6f4cfd900bd269ecffb622082e2b1ce057ba96c64d54b9890`）。提交后可用单提交 revert `refactor(akasha): inline message parser alias` 回滚。
 - 残余风险：若未来 `_parse_message_id` 需要独立输入协议、审计或错误转换，应在真实 owner 边界重新引入有职责的函数；不能仅为保留额外 traceback frame 恢复纯转发别名。
 
+## 2026-07-24 less-is-more PR51：内联 Akasha reinforce boost 私有别名
+
+### `PR51` `refactor(akasha): inline reinforce boost alias`
+
+- base：PR50 committed HEAD `b2c0bf3d4f125e981c1da029ddfbf6f600be3c72`，分支 `refactor/less-is-more-pr50-inline-akasha-message-parser`；本 PR 分支 `refactor/less-is-more-pr51-inline-reinforce-boost-alias`，唯一 writer 为本任务 agent。
+- allowed_paths：`plugins/akasha/engine.py` 的 `_reinforce_boost_for_turn` 唯一 caller 与私有 helper、本账本；`capability_owner`：`plugins.akasha.core.reinforce_boost_from_payload` 拥有 `TurnCommitted.extra` 与 `tool_chain_raw` 到 reinforce boost 的纯计算。未修改 import、注释、测试、oracle、store、schema、migration、NOW、projectneed 或正式 runtime workspace。
+- 历史与消费者：`92cf0ca3` 在接入 reinforce 闭环时创建 `_reinforce_boost_for_turn`，其函数体从引入起始终只转发同一 module-global `_reinforce_boost_from_payload`，没有独立校验、转换、恢复或副作用。全仓生产源码、测试、SDK、plugin package、export/re-export、动态属性/import 与 `/home/huashen/.akashic-plugin/cache` 扫描确认旧 helper 只有一处静态 caller，没有 monkeypatch、外部 seam 或已安装缓存消费者。
+- 输入与纯计算边界：`change_type: refactor`，`semantic_delta: none`。正常 owner `_BuildTurnCommittedModule` 把 `extra` 构造成普通 `dict`，把 `tool_chain_raw` 构造成 `copy.deepcopy` 后的 `list[dict]`；canonical 函数只解析这两个 payload、计算 extra/tool-chain boost 的 `max` 并返回结果，不读取或写入数据库、文件、事件、网络或运行时状态。契约外的 `None`、JSON string、坏 JSON 与非目标 tool call 仍由同一 canonical 函数按原规则处理，没有新增或删除 fallback。
+- 求值与错误边界：caller 在相同位置直接调用 `_reinforce_boost_from_payload(event.extra, event.tool_chain_raw)`；两个字段仍按从左到右顺序各求值一次，参数对象身份、位置、canonical 调用次数和返回对象身份保持不变。异常对象、类型、参数、cause、context 与传播时机保持不变；唯一诊断差异是异常 traceback 少一个已删除的 `_reinforce_boost_for_turn` frame。
+- 持久化与 write set：boost 仍在 message/embedding sidecar 写入和 message index 重建之后、`_pending_by_session.pop` 之前计算；`current_key and pending is not None` 提交条件不变。传入 `_reinforced_activation_items` 与 `_activation_edge_updates` 的 boost、`upsert_edges`、内存 edge 更新、previous activation cluster、activation events 及其顺序和参数均不变；没有 INSERT、UPDATE、DELETE、文件写入、事件、外部发送或服务状态差异。
+- 性能、注释与 God file：仅移除 committed-turn 路径的一次 Python 私有转发调用，不宣称端到端性能收益。删除的 helper 没有 docstring、约束或 workaround 注释；caller 上方关于 tool-chain/extra 来源和 live/replay 一致性的现有注释完整保留。`engine.py` 继续集中拥有 Akasha ingest、图更新和持久化阶段；删除无职责别名减少同一高内聚 God file 内的跳转，不为行数目标拆文件。
+- baseline：source-set digest `162b04642ed2734a0b2a7c9b8a1e51a51e74a3632995a13f85a3b677478386f0`，文件数 `378`，Python SLOC `77,308`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,100`，total production SLOC `85,759`。
+- candidate：source-set digest `a13e92ccf141b9f0ab668898913ade7b7db0b6042b04484e2fc723cceb9e3b22`，文件数 `378`，Python SLOC `77,303`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,095`，total production SLOC `85,754`；production 净减少 `5` SLOC，系列相对 PR0 累计净减少 `1,786` SLOC。
+- parity：一次性 base/candidate 脚本覆盖 `extra` 的 `None`、dict 与 JSON string，`tool_chain` 的 list 与 JSON string，共 `16` 组组合；规范化结果 digest 为 `3529c0952394b39e3bd2959cf3152696a6f7238d73ae329f18800048ea754e32`。module-global spy 确认参数对象身份、求值顺序、调用次数和返回对象身份相同；异常注入确认异常对象、类型、参数、cause/context 相同，traceback 仅移除 wrapper frame。脚本未提交。
+- 测试与静态验证：三项 Akasha 定向回归 `3 passed`，完整 `tests/test_akasha_plugin.py` 为 `65 passed`；未修改、新增或删除测试。目标文件 `compileall` 通过，目标 Pyright `0 errors, 0 warnings`；migration append-only 脚本与 `tests/test_migration_append_only.py`（`5 passed`）通过；consumer/export/dynamic/cache scan、production SLOC 计量和 `git diff --check` 通过。
+- Gate：已在 committed HEAD 对 PR50 base `b2c0bf3d4f125e981c1da029ddfbf6f600be3c72` 运行公开 Gate，7 个场景全部通过；private contract 状态为 `pending_maintainer`，不把运行后的 report/source/plan digest 回填到账本以避免 source 自引用。
+- 备份与回滚：执行前备份为 `/tmp/akashic-less-is-more-backups/pr51/engine.py.base-b2c0bf3d`（SHA-256 `6aa57f36da2a0482aaa8a2151f50b045fbe8e899a12bc641a980cba230a4df11`）与 `/tmp/akashic-less-is-more-backups/pr51/clean-code-ledger.md.base-b2c0bf3d`（SHA-256 `9f95cd330cbfbeafbf8f6fd4eb05ae31b3622505974f68f3bd749a90bd92228b`）；Gate 对账前账本备份为 `/tmp/akashic-less-is-more-backups/pr51/clean-code-ledger.md.pre-final-gate-287c65c4`（SHA-256 `88c09d7d43060b44f548399401cc6abfe955431af3e07d27d02642e6c1324b2a`）。提交后可用单提交 revert `refactor(akasha): inline reinforce boost alias` 回滚。
+- 残余风险：若未来 committed-turn boost 需要独立输入协议、审计或错误转换，应在真实 owner 边界重新引入有职责的函数；不能仅为保留额外 traceback frame 恢复纯转发别名。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -716,7 +716,7 @@ class AkashaMemoryEngine:
         # 3. 用真实 current_key 建边，并记录激活诊断。
         #    reinforce 标记 = 本轮调用了 reinforce_memory 工具(记在 tool_chain)或 extra 回填；
         #    与离线重建(build._load_reinforce_boosts)读同一来源，live 与重放一致。
-        reinforce_boost = _reinforce_boost_for_turn(
+        reinforce_boost = _reinforce_boost_from_payload(
             event.extra,
             event.tool_chain_raw,
         )
@@ -1248,13 +1248,6 @@ class _AkashaRetrieval:
     trace: ActivationTrace
     seq: int
     budget: RecallBudget = RecallBudget(10, 10, 8, 0.0, 0, 0.0)
-
-
-def _reinforce_boost_for_turn(
-    event_extra: dict[str, object] | None,
-    tool_chain: list[dict[str, object]],
-) -> float:
-    return _reinforce_boost_from_payload(event_extra, tool_chain)
 
 
 def _core_config(config: AkashaConfig) -> CoreConfig:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha committed-turn 的 reinforce boost 经过 `_reinforce_boost_for_turn`，而该私有 helper 从引入起就只原样转发同模块 canonical `_reinforce_boost_from_payload`，只有一个 caller、没有独立规则。
- 用户可见结果：extra/tool-chain payload 的解析、boost 计算、图更新、activation event 和持久化顺序不变；production SLOC `85,759 → 85,754`，净删 `5`。
- 本 PR 不处理：不修改 canonical parser、提交条件、store/schema/migration、测试 oracle 或正式 workspace；不宣称端到端性能提升。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`plugins.akasha.core.reinforce_boost_from_payload`
- `consumer_scope`：`_reinforce_boost_for_turn` 只有 committed-turn 路径一个静态 caller，无 export、dynamic、SDK、测试或 installed plugin-cache consumer。
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅删除 Akasha engine 内部无状态 boost alias。
- `authoritative_state_owner`：Akasha store、SessionDB message embeddings 与 committed-turn ingest 各自保持原 owner；本 PR 不改变状态。
- `client_only_alternative`：不适用；没有客户端或协议变化。
- 关联不变量：两个字段仍从左到右各求值一次；canonical 函数调用一次；参数对象、返回对象、boost、写入条件/参数/顺序和错误传播不变。
- `protected_state`：Akasha nodes/edges/query logs、session message embeddings、memory/session 数据、正式 workspace、migration 和外部副作用。
- 允许的副作用：committed-turn 路径少一次 Python 私有 helper 跳转。
- 禁止的副作用：不新增 catch、fallback、默认兼容层、删除路径、数据库/文件/事件/网络/服务或消息发送变化。

## 改动范围

- `plugins/akasha/engine.py`：唯一 caller 直接调用 `_reinforce_boost_from_payload(event.extra, event.tool_chain_raw)`，删除五行纯转发 alias。
- `docs/refactor/clean-code-ledger.md`：新增 PR51 的历史、owner、语义、错误处理、持久化、注释、God file、计量、差分回放、Gate、备份与回滚记录。
- 历史：alias 由 `92cf0ca3` 接入 reinforce 闭环时建立，此后没有独立语义演进。
- 错误与诊断：`None`、dict/list、JSON string、坏 JSON 和非目标 tool call 继续由同一 canonical 函数处理；异常对象、类型、参数、cause/context 和传播时机保持不变，traceback 仅少已删除的 alias frame。
- 持久化：boost 计算仍位于 message/embedding sidecar 与 index rebuild 之后、pending pop 之前；edges、activation cluster/events 的条件、参数和顺序不变，write set 为 `none`。
- 配置或迁移影响：`none`
- 已知 schema lineage 与最终 schema identity：不适用；未修改 schema。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用；未修改跨仓库协议或 provider。
- 回滚方式：revert 单提交 `77d0fc1dee76049156aa313f5cf927ef695f8335`；恢复点位于 `/tmp/akashic-less-is-more-backups/pr51/`。

## 验证

- [x] 完整 `tests/test_akasha_plugin.py`：`65 passed`。
- [x] migration append-only 检查及 `tests/test_migration_append_only.py`：`5 passed`。
- [x] base/candidate 25 组 extra/tool-chain 输入、module-global spy 和异常对象差分回放；规范化结果完全一致，traceback 仅少 alias frame。
- [x] Pyright `0 errors, 0 warnings`；consumer scan、production SLOC 与 `git diff --check` 通过。
- [x] `/mnt/data/coding/akasic-agent/.venv/bin/python docker/debug/gate.py run --base b2c0bf3d4f125e981c1da029ddfbf6f600be3c72` 已在最终 committed HEAD 运行。
- `sourceDigest`：`e49c04e8e5144708a550acd4f43253779800607ef0e9eaa9c814ce192dcf6ca9`
- `planDigest`：`85861c7275c1d8f309f81e6dc85a27c80b154c8aff298d6f52597e16b88c72bb`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260724-022048-3d5ca0f1`；7 个公开 scenarios 全部通过，base/HEAD 精确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；未改 mobile client、协议或 APK。
- 未运行项与原因：private provider 保持私有，由维护者使用同一 plan 执行。

## 工作手册

- [x] 已核对相关 projectneed、持久化状态图、`NOW.md`、写作规则与真实实现/历史。
- [x] 没有长期语义变化；静态语义与唯一诊断差异均已记录。
- [x] 跨仓库或客户端改动不适用；未修改正式 workspace、数据库、文件状态、服务、网络、外部发送、generation/snapshot/lease/event、schema、manifest 或 Git migration。
- [x] `NOW.md` 当前没有对应事项，无需删除。

## Review 与系列进度

- implementation：`githubluna` profile（`gpt-5.6-luna`、xhigh）；主 agent 独立复核完整相邻 diff、真实历史、consumer、25 组差分回放、70 项测试、Pyright、SLOC、最终 Gate 与远端基线。
- less-is-more PR1～PR51（PR41 rejected/no change）相对 PR0 baseline 累计净减少 `1,786` production SLOC（`87,540 → 85,754`）。
