### PR TITLE
refactor(akasha): inline replay preview alias

### DIFF
--- a/docs/refactor/clean-code-ledger.md
+++ b/docs/refactor/clean-code-ledger.md
@@ -894,6 +894,25 @@ SLOC 是有内容的源码行：Python 使用 AST 标出完整 docstring 表达�
 - 备份与回滚：执行前备份为 `/tmp/akashic-less-is-more-backups/pr52/gateway.py.base-77d0fc1d`（SHA-256 `e4368dcf98ca1cf2e377beffb7a61894da25b188de7bec087faf46cfb4e5f2b4`）与 `/tmp/akashic-less-is-more-backups/pr52/clean-code-ledger.md.base-77d0fc1d`（SHA-256 `1be68dc5a6761f5e89fd37213fb722b02820f907d609bef8536d3327a4b820b7`）；Gate 对账前账本备份为 `/tmp/akashic-less-is-more-backups/pr52/clean-code-ledger.md.pre-final-gate-1727e7c5`（SHA-256 `61d7ffbafd33cbdd6a2c9cff1a301e8d45da21b3f3c2ff5574480c6fe318e337`）。提交后可用单提交 revert `refactor(mobile): inline initial frame receive alias` 回滚。
 - 残余风险：若未来初始握手需要独立收帧协议、超时、审计或错误转换，应在 mobile gateway 边界重新引入有职责的函数；不能仅为保留额外 coroutine/traceback frame 恢复纯转发别名。
 
+## 2026-07-24 less-is-more PR53：内联 Akasha replay query preview 私有别名
+
+### `PR53` `refactor(akasha): inline replay preview alias`
+
+- base：PR52 final HEAD `a6a47b6b8d1ae2cc14aa56ec3a7865a286b12539`，分支 `refactor/less-is-more-pr52-inline-mobile-receive-frame`；本 PR 分支 `refactor/less-is-more-pr53-inline-akasha-replay-preview`，唯一 writer 为本任务 agent。
+- allowed_paths：`plugins/akasha/replay.py` 的 `_preview_text_block` 唯一 caller 与私有 helper、本账本；`capability_owner`：`AkashaReplayRuntime._write_query_log` 拥有 replay query log 的完整 payload，包括 500 字符 `text_block_preview` 投影策略。未修改测试、store、schema、migration、session truth、NOW、projectneed 或正式 runtime workspace。
+- 候选拒绝与选择：拒绝 `_create_pinned_backend`，因为把 wrapper 替换为 `PinnedNetworkBackend` 会让 class 捕获从逐跳 DNS await 后提前到下载开始前，跨越真实 suspension；lambda 只会把具名别名改成更隐晦的匿名别名。所选 `_preview_text_block` 由 `6310c87e` 与唯一 caller 同时引入，此后始终只是 `text_block[:500].rstrip() + ("..." if len(text_block) > 500 else "")`，没有独立校验、恢复、日志或副作用。
+- 历史与消费者：全仓生产源码、测试、SDK、plugin package、export/re-export、动态属性/import、monkeypatch、字符串引用与 `/home/huashen/.akashic-plugin/cache` 扫描确认旧 symbol 只有一处静态 caller，没有函数身份、名称、缓存或热替换消费者。500 字符 preview policy 现在由原 `insert_query_log` caller 就地持有，不迁移到 store、dashboard 或第二个 owner。
+- 输入、求值与错误边界：`change_type: refactor`，`semantic_delta: none`。`text_block` 仍由 `_format_context_block` 构造成普通 `str`；slice、`rstrip`、`len`、条件选择和字符串加法的次序、次数与参数保持不变。`text_block_preview` 仍是 `insert_query_log` 的最后一个 keyword，外层 bound method 与此前所有 keyword 仍按相同顺序求值；只有已删除 helper 的 global lookup/call/frame 消失。正常返回类型和值不变，异常对象、类型、cause/context 与 DB 调用前传播时机不变；traceback、trace/profile 只少 `_preview_text_block` frame。
+- 持久化与外部效果：`AkashaStore.insert_query_log` 仍对同一 `query_id` 执行一次 `INSERT OR REPLACE` 并 commit，18 个参数、字段顺序和值逐项不变；preview 计算失败时两侧都不会尝试 DB 写入。`akasha_query_log` 的正常增加/同 ID replace、其他 graph/node/edge/activation 写入及调用顺序均未改变，没有 DELETE、文件写入、事件、网络、消息发送或服务状态变化，正式 workspace write set 为 `none`。
+- 性能、注释与 God file：仅移除 replay query-log 路径的一次 Python 私有函数转发，不宣称端到端性能收益。删除的 helper 没有 docstring、约束或 workaround 注释；500 字符规则在唯一使用点更直接可见。`replay.py` 继续集中拥有 replay 激活、提交和诊断日志，删除无职责别名减少同一高内聚流程内跳转，不为行数目标拆文件。
+- baseline：source-set digest `92fe8f346580f3416f8635a7145fb8f5d2229ebd35f2a11fbbe33becfebba019`，文件数 `378`，Python SLOC `77,301`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,095`，total production SLOC `85,752`。
+- candidate：格式化后的 caller expression 为 `2` 个 production SLOC，替代原 caller 的 `1` 行并删除 helper 的 `2` 行；source-set digest `fe85be21772a637d35c30bdd834426c8cbe9ac1687791d0f6acbdba6c1ec9123`，文件数 `378`，Python SLOC `77,300`，TypeScript/TSX SLOC `8,451`，plugins SLOC `17,094`，total production SLOC `85,751`；production 真净减少 `1` SLOC，系列相对 PR0 累计净减少 `1,789` SLOC。
+- parity：一次性脚本从 exact base AST 提取 `_preview_text_block`，从 candidate AST 提取 `text_block_preview` keyword RHS；覆盖空串、短串、尾部空白、恰好/超过 500 字符、Unicode 与换行边界，并用 probe 覆盖 slice、`rstrip`、`len`、add 的操作轨迹和逐阶段异常。结果、类型、调用轨迹、异常对象身份及 cause/context 逐项相同，规范化 digest 为 `8979bb0c431bf5b8254047139f99cac8c0723b17e674f9b35a893e03b606fce5`，过滤函数框架指令后的 bytecode opcode/arg 序列相同；脚本未提交。
+- 测试与静态验证：完整 `tests/test_akasha_plugin.py` 为 `65 passed`，与 production SLOC、migration append-only 合并回归为 `79 passed`；真实临时 Akasha DB 测试覆盖 query log 写入与读取。未修改、新增或删除测试。目标源码与直接测试 `compileall` 通过；目标 Pyright candidate/base 均为 `0 errors, 2 warnings`（相同的 NumPy unknown-type 既有诊断）；migration append-only 脚本、consumer/export/dynamic/cache scan、production SLOC 计量和 `git diff --check` 通过。
+- Gate：已在 committed HEAD 对 PR52 base `a6a47b6b8d1ae2cc14aa56ec3a7865a286b12539` 运行公开 Gate，7 个场景全部通过；private contract 状态为 `pending_maintainer`，不把运行后的 report/source/plan digest 回填到账本以避免 source 自引用。
+- 备份与回滚：执行前备份为 `/tmp/akashic-less-is-more-backups/pr53/replay.py.base-a6a47b6b`（SHA-256 `a69cef18a3a81de054a66e1df1261a0cc105c178489292f7939eff0a54a2120c`）与 `/tmp/akashic-less-is-more-backups/pr53/clean-code-ledger.md.base-a6a47b6b`（SHA-256 `a15374b5c62f6addb25054a2dc2a119c9b25ff3c1e8282a4b249dbd994dd9c4b`）；Gate 对账前账本备份为 `/tmp/akashic-less-is-more-backups/pr53/clean-code-ledger.md.pre-final-gate-7d65b41d`（SHA-256 `fa69b520d351c05978b9b2a083ed3d1015abc5c9c7a4cb690bbb53f7ef00e9fe`）。提交后可用单提交 revert `refactor(akasha): inline replay preview alias` 回滚。
+- 残余风险：若以后 replay preview 需要独立复用、不同长度策略、审计或错误转换，应在 query-log payload owner 边界重新引入有职责的函数；不能仅为保留额外 traceback frame 恢复纯转发别名。
+
 ## 基线
 
 - 基准提交：`3b456e7b`（PR #109 合并后）

--- a/plugins/akasha/replay.py
+++ b/plugins/akasha/replay.py
@@ -370,7 +370,8 @@ class AkashaReplayRuntime:
                 [_card_to_log_item(card) for card in ripple_cards],
                 ensure_ascii=False,
             ),
-            text_block_preview=_preview_text_block(text_block),
+            text_block_preview=text_block[:500].rstrip()
+            + ("..." if len(text_block) > 500 else ""),
         )
 
 
@@ -507,10 +508,6 @@ def _card_to_log_item(card: AkashaCard) -> dict[str, object]:
     }
     item.update(card.signals)
     return item
-
-
-def _preview_text_block(text_block: str) -> str:
-    return text_block[:500].rstrip() + ("..." if len(text_block) > 500 else "")
 
 
 def _turn_messages(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha replay query log 的 `text_block_preview` 经过 `_preview_text_block`，而该模块级私有 helper 从引入起只包含唯一 caller 使用的一条 500 字符截断表达式。
- 用户可见结果：query log 的 18 个参数、preview 值、DB 写入和提交顺序不变；格式化后 production SLOC `85,752 → 85,751`，真实净删 `1`。
- 本 PR 不处理：不修改 replay 激活、store/schema/migration、测试 oracle 或正式 workspace；不宣称端到端性能提升。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`AkashaReplayRuntime._write_query_log`
- `consumer_scope`：旧 helper 只有一个静态 caller，无 export、dynamic、SDK、测试、monkeypatch 或 installed plugin-cache consumer。
- `runtime_patch`：`none`
- `authoritative_state_owner`：replay query-log payload 与 `AkashaStore.insert_query_log` 各自保持原 owner；本 PR 不改变状态。
- 关联不变量：slice、`rstrip`、`len`、条件选择和加法的顺序/次数不变；preview 仍是最后一个 keyword；DB 调用参数和异常传播不变。
- `protected_state`：Akasha query log、nodes/edges/activation、session/message 数据、正式 workspace、migration 和外部副作用。
- 允许的副作用：replay query-log 路径少一次 Python 私有 helper 调用。
- 禁止的副作用：不新增 catch、fallback、默认兼容层、数据库/文件/事件/网络发送或服务状态变化。

## 改动范围

- `plugins/akasha/replay.py`：把原 preview RHS 原样放回唯一 `text_block_preview` keyword，删除纯转发 helper。
- `docs/refactor/clean-code-ledger.md`：新增 PR53 的历史、候选拒绝、owner、语义、错误处理、持久化、计量、差分回放、Gate、备份与回滚记录。
- 历史：helper 由 `6310c87e` 与唯一 caller 一起建立，此后没有独立演进。
- 错误与诊断：返回值、类型和异常对象/type/cause/context/时机不变；唯一差异是 traceback/profiler 少一个已删除 helper frame。
- 持久化：同一 `query_id` 仍执行一次 `INSERT OR REPLACE` 并 commit，18 个参数、字段顺序和值不变，write set 为 `none`。
- 配置或迁移影响：`none`
- 回滚方式：revert 单提交 `da0846c9e4f7f17776901f02d0c90a486e2c95f6`；恢复点位于 `/tmp/akashic-less-is-more-backups/pr53/`。

## 验证

- [x] 完整 `tests/test_akasha_plugin.py`：`65 passed`；migration：`5 passed`。
- [x] base/candidate 覆盖空串、500 边界、Unicode、换行、尾空白，以及 slice/rstrip/len/add 正常与逐阶段异常；轨迹和对象身份完全一致，digest `2220a2e162ce2643f8e0092f9dc0de400a6f5404dcc92b2216fede11053ec1bc`。
- [x] compileall；candidate/base Pyright 同为 `0 errors, 2 warnings`，均为未触碰的 NumPy unknown-type 既有诊断。
- [x] consumer/export/dynamic/cache scan、migration append-only、production SLOC 与 `git diff --check` 通过。
- [x] Gate 已在最终 committed HEAD 对 PR52 base `a6a47b6b8d1ae2cc14aa56ec3a7865a286b12539` 运行。
- `sourceDigest`：`182d536bb358746176edc8f42fbebdd99871c4ef5d57bab70948ee71c67a68b3`
- `planDigest`：`b532d0e249b66c79ca5481ac3f848b79198f726ef2bb7161b630de2c06365e94`
- `impactCatalogDigest`：`1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7`
- Gate report：`docker/debug/reports/change-gate/20260724-025153-9e618ca2`；7 个公开 scenarios 全部通过，base/HEAD 精确，dirty status 与 residual resources 为空。
- `private-contract-gate`：`pending_maintainer`（报告标记 required；公开 Gate 不冒充 private pass）。
- 真实设备证据：不适用；协议、客户端和 APK 均未修改。
- 未运行项与原因：private provider 保持私有，由维护者使用同一 plan 执行。

## 工作手册

- [x] 已核对相关 projectneed、持久化状态图、`NOW.md`、写作规则与真实实现/历史。
- [x] 没有长期语义变化；静态语义与唯一诊断差异均已记录。
- [x] 未修改正式 workspace、数据库、文件状态、服务、网络发送、schema、manifest 或 Git migration。

## Review 与系列进度

- implementation：`githubluna` profile（`gpt-5.6-luna`、xhigh）；主 agent 独立复核完整相邻 diff、历史/消费者、逐操作与异常差分、70 项测试、base/candidate Pyright、SLOC、最终 Gate 与远端基线。
- review 拒绝了 `_create_pinned_backend` 候选：直接保存 class 会把 global 捕获提前跨越真实 await。
- less-is-more PR1～PR53（PR41 rejected/no change）相对 PR0 baseline 累计净减少 `1,789` production SLOC（`87,540 → 85,751`）。
