### PR TITLE
[codex] 平滑移动端实时流式投递

### DIFF
--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -100,7 +100,7 @@ class _ProcessTurnState:
     tool_blocks: dict[str, tuple[str, int, float]]
 
 
-_DELTA_FLUSH_SECONDS = 0.05
+_DELTA_FLUSH_SECONDS = 1 / 30
 _DELTA_FLUSH_BYTES = 4 * 1024
 _MAX_DELTA_BATCHES = 256
 _BOT_COMMAND_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
@@ -1341,7 +1341,7 @@ class MobileRealtimeChannel:
         block_id: str | None,
         ordinal: int | None,
     ) -> None:
-        """按 50ms 或 4KiB 合并连续 delta，限制 SQLite 写入频率。"""
+        """按一帧或 4KiB 合并连续 delta，兼顾视觉连续性与 SQLite 写入频率。"""
 
         key = (session_id, turn_id)
         lock = self._delta_locks[key]

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -805,12 +805,13 @@ class MobileGatewayRuntime:
                 target_device_ids = tuple(
                     device.device_id for device in self.storage.list_active_devices()
                 )
-            for target_device_id in target_device_ids:
-                event = self.inbox.enqueue(
-                    device_id=target_device_id,
-                    event_id=event_id,
-                    envelope_json=stored,
-                )
+            events = self.inbox.enqueue_many(
+                device_ids=target_device_ids,
+                event_id=event_id,
+                envelope_json=stored,
+            )
+            for event in events:
+                target_device_id = event.device_id
                 connection = self._connections.get(target_device_id)
                 if connection is None:
                     continue

--- a/infra/mobile_realtime/inbox.py
+++ b/infra/mobile_realtime/inbox.py
@@ -52,6 +52,22 @@ class DurableInboxManager:
             created_at=self._now(),
         )
 
+    def enqueue_many(
+        self,
+        *,
+        device_ids: tuple[str, ...],
+        event_id: str,
+        envelope_json: str,
+    ) -> tuple[DurableInboxEvent, ...]:
+        """用同一提交时间原子写入一个事件的全部设备副本。"""
+
+        return self._storage.append_durable_events(
+            device_ids=device_ids,
+            event_id=event_id,
+            envelope_json=envelope_json,
+            created_at=self._now(),
+        )
+
     def rebase_with_event(
         self,
         *,

--- a/infra/mobile_realtime/storage.py
+++ b/infra/mobile_realtime/storage.py
@@ -519,55 +519,85 @@ class MobileRealtimeStorage:
     ) -> DurableInboxEvent:
         """在同一写事务分配 event_seq 并插入 P0 durable event。"""
 
-        # 1. 固化内部已验证的事件字段
-        device_key = _require_text(device_id, "device_id")
+        return self.append_durable_events(
+            device_ids=(device_id,),
+            event_id=event_id,
+            envelope_json=envelope_json,
+            created_at=created_at,
+        )[0]
+
+    def append_durable_events(
+        self,
+        *,
+        device_ids: tuple[str, ...],
+        event_id: str,
+        envelope_json: str,
+        created_at: datetime,
+    ) -> tuple[DurableInboxEvent, ...]:
+        """在一个写事务中为多个设备分配序号并插入同一 P0 事件。"""
+
+        # 1. 固化内部已验证的广播目标和事件字段
+        device_keys = tuple(
+            _require_text(device_id, "device_id") for device_id in device_ids
+        )
+        if len(set(device_keys)) != len(device_keys):
+            raise ValueError("durable event 广播设备不能重复")
         event_key = _require_text(event_id, "event_id")
         envelope = _require_text(envelope_json, "envelope_json")
         timestamp = _serialize_datetime(created_at, "created_at")
+        if not device_keys:
+            return ()
 
-        # 2. 锁定 cursor 并分配严格递增序号
+        # 2. 锁定全部 cursor，并为每个设备分配自己的严格递增序号
+        allocated: list[tuple[str, int]] = []
         with self._lock, self._db:
             _ = self._db.execute("BEGIN IMMEDIATE")
-            row = self._db.execute(
-                """
-                SELECT next_event_seq
-                FROM mobile_device_cursors
-                WHERE device_id = ?
-                """,
-                (device_key,),
-            ).fetchone()
-            if row is None:
-                raise UnknownDeviceError(f"设备不存在或缺少 cursor: {device_key}")
-            event_seq = _row_positive_int(row, "next_event_seq")
+            for device_key in device_keys:
+                row = self._db.execute(
+                    """
+                    SELECT next_event_seq
+                    FROM mobile_device_cursors
+                    WHERE device_id = ?
+                    """,
+                    (device_key,),
+                ).fetchone()
+                if row is None:
+                    raise UnknownDeviceError(f"设备不存在或缺少 cursor: {device_key}")
+                allocated.append((device_key, _row_positive_int(row, "next_event_seq")))
 
-            # 3. 同事务写入 durable event 后推进 cursor
-            _ = self._db.execute(
-                """
-                INSERT INTO mobile_device_inbox(
-                    device_id, event_seq, event_id, priority,
-                    envelope_json, created_at
-                ) VALUES(?, ?, ?, 'P0', ?, ?)
-                """,
-                (device_key, event_seq, event_key, envelope, timestamp),
-            )
-            updated = self._db.execute(
-                """
-                UPDATE mobile_device_cursors
-                SET next_event_seq = ?
-                WHERE device_id = ? AND next_event_seq = ?
-                """,
-                (event_seq + 1, device_key, event_seq),
-            )
-            if updated.rowcount != 1:
-                raise RuntimeError(f"设备 event_seq 分配发生并发冲突: {device_key}")
+            # 3. 同事务写入全部 durable event 后推进各设备 cursor
+            for device_key, event_seq in allocated:
+                _ = self._db.execute(
+                    """
+                    INSERT INTO mobile_device_inbox(
+                        device_id, event_seq, event_id, priority,
+                        envelope_json, created_at
+                    ) VALUES(?, ?, ?, 'P0', ?, ?)
+                    """,
+                    (device_key, event_seq, event_key, envelope, timestamp),
+                )
+                updated = self._db.execute(
+                    """
+                    UPDATE mobile_device_cursors
+                    SET next_event_seq = ?
+                    WHERE device_id = ? AND next_event_seq = ?
+                    """,
+                    (event_seq + 1, device_key, event_seq),
+                )
+                if updated.rowcount != 1:
+                    raise RuntimeError(f"设备 event_seq 分配发生并发冲突: {device_key}")
 
-        return DurableInboxEvent(
-            device_id=device_key,
-            event_seq=event_seq,
-            event_id=event_key,
-            priority="P0",
-            envelope_json=envelope,
-            created_at=_parse_datetime(timestamp, "created_at"),
+        created = _parse_datetime(timestamp, "created_at")
+        return tuple(
+            DurableInboxEvent(
+                device_id=device_key,
+                event_seq=event_seq,
+                event_id=event_key,
+                priority="P0",
+                envelope_json=envelope,
+                created_at=created,
+            )
+            for device_key, event_seq in allocated
         )
 
     def read_durable_events(

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1798,7 +1798,7 @@ async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None
 
 
 @pytest.mark.asyncio
-async def test_stream_deltas_batch_at_50ms_and_flush_before_tool_and_final(
+async def test_stream_deltas_batch_at_30fps_and_flush_before_tool_and_final(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1851,7 +1851,7 @@ async def test_stream_deltas_batch_at_50ms_and_flush_before_tool_and_final(
             )
         )
     assert [event["event_type"] for event in runtime.events] == ["turn.started"]
-    await asyncio.sleep(0.07)
+    await asyncio.sleep(0.05)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",

--- a/tests/mobile_realtime/test_inbox.py
+++ b/tests/mobile_realtime/test_inbox.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from infra.mobile_realtime.inbox import DurableInboxManager, InboxResetRequired
-from infra.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
+from infra.mobile_realtime.storage import (
+    DeviceRecord,
+    MobileRealtimeStorage,
+    UnknownDeviceError,
+)
 
 
 NOW = datetime(2026, 7, 14, 9, 30, tzinfo=timezone.utc)
@@ -63,6 +67,53 @@ def test_inbox_replays_in_sequence_and_acknowledges_p0(tmp_path: Path) -> None:
         ack = manager.acknowledge("device-1", through_event_seq=2)
         assert ack.deleted_events == 2
         assert storage.count_durable_events("device-1") == 0
+    finally:
+        storage.close()
+
+
+def test_inbox_enqueues_broadcast_in_one_atomic_write(tmp_path: Path) -> None:
+    storage = _build_storage(tmp_path)
+    storage.register_device(
+        DeviceRecord(
+            device_id="device-2",
+            public_key="public-key-2",
+            display_name="Tablet",
+            created_at=NOW,
+            revoked_at=None,
+            capabilities=("chat",),
+        )
+    )
+    try:
+        manager = DurableInboxManager(storage, clock=lambda: NOW)
+        events = manager.enqueue_many(
+            device_ids=("device-1", "device-2"),
+            event_id="event-shared",
+            envelope_json=_envelope("event-shared"),
+        )
+
+        assert [event.device_id for event in events] == ["device-1", "device-2"]
+        assert [event.event_seq for event in events] == [1, 1]
+        assert events[0].created_at == events[1].created_at == NOW
+        assert storage.read_cursor("device-1").next_event_seq == 2
+        assert storage.read_cursor("device-2").next_event_seq == 2
+    finally:
+        storage.close()
+
+
+def test_inbox_broadcast_rolls_back_all_devices_when_one_is_unknown(tmp_path: Path) -> None:
+    storage = _build_storage(tmp_path)
+    try:
+        manager = DurableInboxManager(storage, clock=lambda: NOW)
+
+        with pytest.raises(UnknownDeviceError, match="设备不存在或缺少 cursor"):
+            manager.enqueue_many(
+                device_ids=("device-1", "missing-device"),
+                event_id="event-shared",
+                envelope_json=_envelope("event-shared"),
+            )
+
+        assert storage.count_durable_events("device-1") == 0
+        assert storage.read_cursor("device-1").next_event_seq == 1
     finally:
         storage.close()
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：移动端 thinking / answer 流式事件按 50ms 聚合，广播时还会为每台设备分别提交 SQLite 事务，增加视觉间隔与多设备写放大。
- 用户可见结果：连续 delta 改为约 30fps 的帧节奏；同一事件面向多设备时由一个原子事务写入，降低持久化抖动。
- 本 PR 不处理：移动端 WebView 的全量快照与 React 渲染开销；对应改动在独立 mobile PR。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Android mobile realtime 客户端
- `runtime_patch`：`required`
- `runtime_patch_reason`：流式事件的聚合节奏和 durable inbox 广播提交都属于 core runtime owner。
- `authoritative_state_owner`：`sessions.db` / mobile realtime durable inbox
- `client_only_alternative`：客户端只能缓解渲染，无法消除服务端 50ms 出包间隔与多设备事务写放大。
- 关联不变量：每设备 `event_seq` 严格递增；P0 durable event 先持久化再推送；任一目标设备无效时整次广播回滚。
- `protected_state`：正式 workspace、现有消息、pairing/OAuth、ACK/cursor 语义。
- 允许的副作用：提高 streaming delta 出包频率；一个事件的设备副本在同一 SQLite 事务提交。
- 禁止的副作用：修改协议事件类型、丢失/重排事件、减少已有消息、写入正式 workspace。

## 改动范围

- 主要文件：`infra/mobile_realtime/channel.py`、`gateway.py`、`inbox.py`、`storage.py` 及对应测试。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：SQLite schema 不变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：mobile realtime wire protocol 不变；base `480348f27b9b10488d6d6bad192bf2f0fee29358`。
- 回滚方式：revert commit `f703b2be`，无需数据回滚或迁移。

## 验证

- [x] 相关 targeted tests 已通过：71 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过；本改动无独立类型检查项，`git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：公开 Gate 通过，mobile realtime 场景 200 passed，所有 sandbox cleanup 完成且无残留资源。
- `sourceDigest`：`0215ef50861b10ca8a7fa2593a82e1296dc42df1540a735a14051446e335008a`
- `planDigest`：`6fe16e1bc1301c8a8581a6453439fce4cd71aeb23c809653be8f916c0f8f4ad6`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；本 PR 为 core runtime，未修改 APK。
- 未运行项与原因：私有 companion 不在公开仓库中，由维护者消费同一 `plan.json` 运行。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 已按 MOB-001 核对能力 owner；core runtime patch 有明确必要性。
- [x] 当前没有对应 `NOW.md` 事项，不适用。