### PR TITLE
[codex] 移除移动端流式输出固定延迟

### DIFF
--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -100,7 +100,6 @@ class _ProcessTurnState:
     tool_blocks: dict[str, tuple[str, int, float]]
 
 
-_DELTA_FLUSH_SECONDS = 1 / 30
 _DELTA_FLUSH_BYTES = 4 * 1024
 _MAX_DELTA_BATCHES = 256
 _BOT_COMMAND_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
@@ -1341,7 +1340,7 @@ class MobileRealtimeChannel:
         block_id: str | None,
         ordinal: int | None,
     ) -> None:
-        """按一帧或 4KiB 合并连续 delta，兼顾视觉连续性与 SQLite 写入频率。"""
+        """在下一个事件循环轮次或 4KiB 时发布连续 delta。"""
 
         key = (session_id, turn_id)
         lock = self._delta_locks[key]
@@ -1352,7 +1351,7 @@ class MobileRealtimeChannel:
                 if len(self._delta_batches) >= _MAX_DELTA_BATCHES:
                     raise RuntimeError("mobile delta batch 已达到 256 个活跃 turn 上限")
                 timer = asyncio.create_task(
-                    self._flush_after_delay(key),
+                    self._flush_next_loop(key),
                     name=f"mobile-delta-flush:{turn_id}",
                 )
                 timer.add_done_callback(self._on_delta_timer_done)
@@ -1384,8 +1383,8 @@ class MobileRealtimeChannel:
         if flush_now:
             await self._flush_deltas(session_id, turn_id)
 
-    async def _flush_after_delay(self, key: tuple[str, str]) -> None:
-        await asyncio.sleep(_DELTA_FLUSH_SECONDS)
+    async def _flush_next_loop(self, key: tuple[str, str]) -> None:
+        await asyncio.sleep(0)
         await self._flush_deltas(*key)
 
     async def _flush_deltas(self, session_id: str, turn_id: str) -> None:

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1798,7 +1798,7 @@ async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None
 
 
 @pytest.mark.asyncio
-async def test_stream_deltas_batch_at_30fps_and_flush_before_tool_and_final(
+async def test_stream_deltas_batch_within_one_event_loop_turn_and_flush_before_tool_and_final(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1851,7 +1851,7 @@ async def test_stream_deltas_batch_at_30fps_and_flush_before_tool_and_final(
             )
         )
     assert [event["event_type"] for event in runtime.events] == ["turn.started"]
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.01)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",


### PR DESCRIPTION
## 问题与结果

- 解决的问题：mobile realtime 在每批 thinking / answer delta 前固定等待 33ms，把服务端发送节奏硬限制在约 30Hz，并在上游本来已经稀疏时继续增加延迟。
- 用户可见结果：连续 delta 只在同一个事件循环轮次内合并；没有后续同步 burst 时立即发布，不再附加固定毫秒延迟。
- 本 PR 不处理：WebView / React 历史消息渲染；对应优化在独立 mobile PR。

## Change intent

- `change_type`：`perf`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Android mobile realtime 客户端
- `runtime_patch`：`required`
- `runtime_patch_reason`：流式事件进入 durable inbox 前的聚合策略属于 core runtime owner。
- `authoritative_state_owner`：mobile realtime durable inbox
- `client_only_alternative`：客户端无法消除服务端固定 33ms 的出包等待。
- 关联不变量：每设备 `event_seq` 严格递增；P0 durable event 先持久化再推送；tool/final 之前先 flush 所有 delta。
- `protected_state`：正式 workspace、现有消息、pairing/OAuth、ACK/cursor、事件类型与顺序。
- 允许的副作用：降低 delta 首包和连续包等待；同事件循环 burst 仍合并，4KiB 仍立即 flush。
- 禁止的副作用：丢失或重排事件、改变协议、减少已有消息、写入正式 workspace。

## 改动范围

- 主要文件：`infra/mobile_realtime/channel.py`、`tests/mobile_realtime/test_channel.py`。
- 配置、schema 或迁移影响：无。
- base：`61d946733193042fb5c86d2dd0077545cdb08fa0`。
- 回滚方式：revert commit `905f954d`，无需数据回滚。

## 验证

- [x] `tests/mobile_realtime/test_channel.py`：35 passed。
- [x] `git diff --check`。
- [x] `python docker/debug/gate.py run --base origin/main`：公开 Gate 通过；其中 mobile realtime 200 passed，全部 sandbox cleanup 完成。
- `sourceDigest`：`6e59d61e8b0c29468a85987ccc40f4fe63fe2cbc6de95039f9205b5dd84f91d1`
- `planDigest`：`c35fa8859e33c9a681c9527ee2294215c338cc2a2dff84bb4904e10221e24f5c`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；本 PR 不修改 APK。

## 工作手册

- 已核对 `projectneed.md`、MOB owner 决策、跨仓库 Gate 设计与 `NOW.md`。
- 本次没有长期协议或持久化语义变化。