### PR TITLE
[codex] define the canonical Akasha V2 runtime contract

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -101,7 +101,7 @@
 | 任何会修改仓库文件的任务 | 本索引 → [`WORKFLOW.md`](WORKFLOW.md) → 下方对应领域 | 当前分支、目标分支、完整 diff、验证报告 |
 | Prompt、上下文窗口、历史裁切、重试 | `projectneed` 第 5～7、13 节 → [0002](decisions/0002-context-reduction-is-a-nondestructive-projection.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `agent/core/passive_turn.py`、`agent/prompting/`、`session/manager.py`、`session/store.py` |
 | 会话、消息、turn、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
-| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
+| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
 | 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
 | 插件安装、热重载、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、10～13 节 → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/skill_links.py`、`agent/mcp/host.py` |
@@ -183,8 +183,10 @@ docs/
 │   ├── 0002-context-reduction-is-a-nondestructive-projection.md
 │   ├── 0003-core-capability-ownership-is-semantic.md
 │   ├── 0004-cross-repository-evidence-is-an-immutable-combination.md
-│   └── 0005-git-cursor-drives-one-shot-migrations.md
+│   ├── 0005-git-cursor-drives-one-shot-migrations.md
+│   └── 0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
 ├── design/
+│   ├── akasha-v2-runtime-migration.md
 │   ├── mobile-cross-repository-semantic-gate.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── persistence-state-map.md

--- a/docs/decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
+++ b/docs/decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
@@ -27,8 +27,9 @@
 4. `sessions.db/messages` 和匹配的 `message_embeddings` 是固定重建输入。
    `akasha.db` 与稀疏索引都是派生 sidecar。完整重建在首次备份或目标写入前审计全部
    合法对话向量，缺失、错模型、错维度、非有限或零向量都 fail-loud。
-5. scheduler 与带 `skip_post_memory` 的消息既不在线学习，也不进入重放，避免两条路径
-   对学习样本的定义不同。
+5. scheduler、带 `skip_post_memory` 的消息以及没有完成 assistant 回复的中断 turn
+   既不在线学习，也不进入重放。新中断占位使用结构化 `skip_post_memory`；历史
+   assistant 占位只兼容精确正文 `[interrupted]`，避免两条路径对学习样本的定义不同。
 6. 用户可见结果保留“左脑记忆：精确回忆”和“右脑记忆：联想补全”两条 lane。
    左脑最多五条 dense 命中；右脑按稳定 turn ID 去重后排除左脑项。每条 lane 内按时间
    从近到远显示，日期为 `MM-DD`，assistant 正文最多 50 个字符。
@@ -43,8 +44,9 @@
 重排下一轮学习输入。
 
 固定 upstream 身份避免宿主镜像悄悄漂移。严格向量预检保护 MEM-009：重放不能以
-“成功退出”掩盖缺少历史 turn。把 scheduler 排除规则放在在线和重放共同边界，则避免
-重复任务把图的连接预算占满。
+“成功退出”掩盖合法学习样本的向量缺口。把 scheduler 和未完成 turn 的排除规则放在
+在线与重放共同边界，可以避免重复任务占满连接预算，也避免补算一个从未在线学习的
+中断事件。
 
 ## 影响
 
@@ -61,6 +63,7 @@
 - 同一隔离 `sessions.db` 的在线提交与干净重放得到相同 canonical logical state。
 - 不同 `PYTHONHASHSEED` 的完整重放得到相同 logical state。
 - 缺少合法对话 embedding 时，重建在备份和目标数据库写入前失败并生成缺口报告。
+- 中断 turn 保留原始消息，但不产生 embedding 要求、稀疏节点、hub 或图关系。
 - Docker runtime 使用独立 workspace 完成 query、持久化、自动上下文、显式 recall 和
   下一轮提交；正式 workspace 的文件摘要与 mtime 不变。
 

--- a/docs/decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
+++ b/docs/decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
@@ -1,0 +1,68 @@
+# 0006 · Akasha V2 是显式记忆的唯一算法实现
+
+- 状态：accepted
+- 日期：2026-07-27
+- 关联条款：MEM-009、SES-003、GOV-005、TST-002、TST-005
+
+## 背景
+
+旧 Akasha 把在线插件、重放脚本、图快照、Dashboard 检查器和实验性 fast/slow
+路径放在同一个宿主目录。在线增长与重放分别维护相似但不相同的状态转换，难以证明
+同一组 turn 会得到同一张图。显式 recall 还可能与自动上下文查询共享可变状态，使一次
+只读工具调用影响下一次学习。
+
+独立仓库 `akasha-v2-engine` 已经把稀疏索引、模式补全、突触可塑性、遗忘和确定性
+持久化整理为一条 `MemoryCycle`。宿主需要采用这条实现，同时保留当前 memory engine
+协议和 Agent 的输出约定。
+
+## 决定
+
+1. `akasha-v2-engine/src/akasha` 是 Akasha 算法的唯一源码。宿主只保存字节一致的镜像，
+   并在 `plugins/akasha/UPSTREAM.json` 固定 upstream commit、Git tree 和内容摘要。
+2. 在线提交与离线重放都调用同一个 `MemoryCycle.retrieve → MemoryCycle.commit`，
+   不在宿主重写图学习或遗忘规则。
+3. 自动 `intent=context` 查询可以产生一次临时 retrieval ticket。只有对应
+   `TurnCommitted` 可以消费它并学习；`recall_memory` 使用 `effect=read_only`，
+   不替换 ticket，也不更新图。
+4. `sessions.db/messages` 和匹配的 `message_embeddings` 是固定重建输入。
+   `akasha.db` 与稀疏索引都是派生 sidecar。完整重建在首次备份或目标写入前审计全部
+   合法对话向量，缺失、错模型、错维度、非有限或零向量都 fail-loud。
+5. scheduler 与带 `skip_post_memory` 的消息既不在线学习，也不进入重放，避免两条路径
+   对学习样本的定义不同。
+6. 用户可见结果保留“左脑记忆：精确回忆”和“右脑记忆：联想补全”两条 lane。
+   左脑最多五条 dense 命中；右脑按稳定 turn ID 去重后排除左脑项。每条 lane 内按时间
+   从近到远显示，日期为 `MM-DD`，assistant 正文最多 50 个字符。
+7. 旧 `/akashalast`、Akasha 图 Dashboard 和移动端检查器不再属于运行时接口。空
+   `AkashaPlugin` 只维持宿主插件发现合同；记忆能力由 `MemoryPlugin` 提供。
+
+## 理由
+
+单一 `MemoryCycle` 把“同算法”从代码相似提升为同一个状态机。临时 ticket 与提交事件
+形成 read-before-write 边界：模型看到的自动记忆可以参与当前回答，只有真实持久化
+完成的 turn 才改变未来检索。显式 recall 保持只读后，Agent 是否调用工具不会偷偷
+重排下一轮学习输入。
+
+固定 upstream 身份避免宿主镜像悄悄漂移。严格向量预检保护 MEM-009：重放不能以
+“成功退出”掩盖缺少历史 turn。把 scheduler 排除规则放在在线和重放共同边界，则避免
+重复任务把图的连接预算占满。
+
+## 影响
+
+- 宿主 memory engine 仍使用 `engine = "akasha"`，调用者不需要认识 V2 内部类型。
+- 更新算法必须先在 upstream 提交，再重新镜像并更新三项身份；禁止直接改宿主镜像。
+- 现存旧 Akasha 配置和数据库不能被新 loader 猜测兼容。部署前需要在隔离快照完成
+  embedding 审计、全量重建和原子 sidecar 切换；本决策不授权修改正式 workspace。
+- Dashboard 不再提供 Akasha 私有图检查入口；诊断以重放报告、数据库查询和测试证据为准。
+
+## 验收
+
+- 镜像校验能发现 commit、tree、文件集合或任一字节差异。
+- 真实宿主插件动态加载、fresh runtime 启停和 `recall_memory` 工具调用通过。
+- 同一隔离 `sessions.db` 的在线提交与干净重放得到相同 canonical logical state。
+- 不同 `PYTHONHASHSEED` 的完整重放得到相同 logical state。
+- 缺少合法对话 embedding 时，重建在备份和目标数据库写入前失败并生成缺口报告。
+- Docker runtime 使用独立 workspace 完成 query、持久化、自动上下文、显式 recall 和
+  下一轮提交；正式 workspace 的文件摘要与 mtime 不变。
+
+完整调用链、状态所有权和迁移 Gate 见
+[`../design/akasha-v2-runtime-migration.md`](../design/akasha-v2-runtime-migration.md)。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,6 +11,7 @@
 | [0003](0003-core-capability-ownership-is-semantic.md) | accepted | 核心能力归属由权威语义决定 | MOB-001、GOV-001～GOV-005 |
 | [0004](0004-cross-repository-evidence-is-an-immutable-combination.md) | accepted | 跨仓库证据绑定不可变组合 | GOV-005、MOB-002～MOB-004、TST-006～TST-008 |
 | [0005](0005-git-cursor-drives-one-shot-migrations.md) | accepted | Git cursor 驱动一次性兼容迁移 | MIG-001、MIG-002、WSP-003、BAK-001 |
+| [0006](0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) | accepted | Akasha V2 是显式记忆的唯一算法实现 | MEM-009、SES-003、GOV-005、TST-002、TST-005 |
 
 ## 新增规则
 

--- a/docs/design/akasha-v2-runtime-migration.md
+++ b/docs/design/akasha-v2-runtime-migration.md
@@ -101,6 +101,8 @@ reinforce 或检查器兼容层。旧配置和旧 sidecar 的正式切换必须�
 
 - `session_key` 前缀为 `scheduler` 的 turn 不查询学习状态，也不进入 replay。
 - user 或 assistant 的持久 metadata 含 `skip_post_memory` 时，同样排除。
+- 中断占位 turn 不进入学习样本。新数据通过 assistant 的 `skip_post_memory` 表达；
+  历史数据仅把 assistant 正文精确等于 `[interrupted]` 的 pair 视为中断。
 - user 与 assistant 都没有文本的纯媒体 turn 不进入索引。
 - 单边文本为空时，只要求非空一侧有 embedding；不得为纯空内容生成假向量。
 
@@ -140,6 +142,10 @@ dense / BM25 / burst / temporal evidence
 ```text
 只读打开 sessions.db
         │
+        ▼
+分类完成与中断 turn
+        │
+        ├─ 中断/显式跳过 ─► 保留原消息，不要求 embedding
         ▼
 审计所有 eligible message embeddings
         │

--- a/docs/design/akasha-v2-runtime-migration.md
+++ b/docs/design/akasha-v2-runtime-migration.md
@@ -1,0 +1,272 @@
+# Akasha V2 在线运行与确定性重放设计
+
+- 状态：accepted；实现在 stacked follow-up，正式 workspace 尚未部署
+- 日期：2026-07-27
+- 决策：[0006](../decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md)
+- 需求：MEM-009、SES-003、GOV-005、TST-002、TST-005
+
+## 1. 目标与边界
+
+本迁移把独立 `akasha-v2-engine` 接入 Akasic Agent，保留宿主的 MemoryPlugin、
+自动上下文和 `recall_memory` 接口。完成后的可观察行为是：
+
+- 每一轮合法 user/assistant turn 只在消息持久化成功后学习一次；
+- 当前 query 可以看到历史 dense 精确命中和显式图的模式补全；
+- 显式 recall 本身不学习、不改变待提交上下文；
+- 在线逐轮增长与对同一份历史做全量 replay 得到相同逻辑状态；
+- 重建、Docker 和报告都使用独立 workspace，不读写正式派生库。
+
+这次不部署正式 workspace，不迁移旧 Akasha 私有 Dashboard，也不保留旧 fast/slow、
+reinforce 或检查器兼容层。旧配置和旧 sidecar 的正式切换必须作为独立数据迁移执行。
+
+## 2. 状态所有权
+
+| 对象 | 性质 | 正常增加 | 允许原位更新 | 减少与恢复 |
+|---|---|---|---|---|
+| `sessions.db/messages` | 对话事实 | 宿主提交 user、assistant、tool 消息 | 本迁移不允许 | 只有用户数据管理操作可减少；SQLite backup 恢复 |
+| `message_embeddings` | 固定重建输入 | turn commit 对真实落库文本计算并 upsert | 同 message/model 内容变化时由拥有者更新 | 完整重建不得补算；独立 embedding 迁移可在快照中补齐 |
+| `akasha-v2-index.db` | 因果稀疏索引 | 每个 committed turn 增加 dense 指针、BM25 和时序统计 | 在线统计增量维护 | 可从固定 sessions 输入重建 |
+| `akasha.db` | 派生显式记忆 | 每个 commit 增加/更新 hub、关系、激活与遗忘状态 | `MemoryCycle` 原子发布全状态 | 部署前备份；可由稀疏索引重放恢复 |
+| pending retrieval ticket | 进程内临时状态 | 自动 context query 产生 | 同 session 新 context 可替换 | commit 消费；scheduler/skip 清除；进程退出可丢弃 |
+| recall trace/report | 诊断证据 | query 或重建生成 | 不参与图状态 | 按独立诊断 retention 管理 |
+
+`sessions.db` 是唯一历史事实源。Akasha 不保存一份可独立修改的消息正文，也不因检索、
+遗忘或图清理删除原始消息。
+
+## 3. 组件结构
+
+```text
+┌──────────────────────── Akasic Agent ────────────────────────┐
+│                                                             │
+│  Prompt context ── intent=context/effect=stateful ─┐         │
+│                                                    ▼         │
+│  recall_memory ── intent=answer/effect=read_only ─► query    │
+│                                                    │         │
+│  SessionStore ── INSERT user/assistant ──► TurnCommitted     │
+│                                                    │         │
+│                                                    ▼         │
+│                       plugins/akasha/MemoryPlugin adapter     │
+└────────────────────────────────┬────────────────────────────┘
+                                 │ byte-identical mirror
+                                 ▼
+┌────────────────────── akasha-v2-engine ──────────────────────┐
+│ SparseIndexBuilder → MemoryCycle.retrieve → RetrievalTicket  │
+│                                      │                       │
+│ TurnCommitted → MemoryCycle.commit ──┴→ graph/plasticity     │
+│                                      │                       │
+│                              deterministic persistence       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+宿主适配器只做五件事：读取宿主配置、调用 embedding provider、解析宿主事件、把
+`MemoryRecord` 渲染成上下文、把 engine lifecycle 注册回宿主。稀疏特征、扩散、
+连接预算、衰减、抑制和重放顺序都由 upstream 拥有。
+
+## 4. 一轮在线闭环
+
+### 4.1 自动上下文查询
+
+1. 宿主在模型调用前构造 `MemoryQuery(intent="context", effect="stateful")`。
+2. adapter 对 query 计算 dense，构造不属于历史的 cue turn。
+3. `MemoryCycle.retrieve` 从 dense、BM25、burst/时序和已有关系形成 seed，再做局部
+   residual diffusion，返回直接证据、模式补全和 retrieval ticket。
+4. adapter 只为有稳定 `session_key` 的 context 查询保存 ticket。
+5. 输出分成两条 lane：
+   - 左脑：按 dense 分数选最多五个稳定 turn；
+   - 右脑：按 completion 证据选候选，去掉已在左脑出现的 turn。
+6. 选取完成后，每条 lane 按 turn 时间从近到远显示，不把算法分数误当时间顺序。
+
+### 4.2 持久化与学习
+
+1. 宿主先把 user 和 assistant 精确正文写入 `sessions.db`。
+2. `TurnCommitted` 必须携带两个稳定 message ID；缺少 ID 直接失败。
+3. adapter 对精确落库正文生成并保存 embedding。若 pending query 文本与落库 user
+   正文一致，复用 query dense，只计算 assistant；否则两条正文重新 batch embed。
+4. pending ticket 仍匹配时交给 `MemoryCycle.commit`；不存在或不匹配时在最新图状态上
+   重新 retrieve 后提交。
+5. commit 将当前 turn 加入稀疏索引和图，执行 Hebbian 关联、时序方向、连接预算、
+   衰减与激活恢复，再原子发布 sidecar。
+
+这个顺序保证“检索影响回答，已完成回答影响未来检索”，不会让未落库或失败的 turn
+提前进入图。
+
+### 4.3 显式 recall
+
+`recall_memory` 构造 `intent="answer", effect="read_only"`。它可以读取同一张图并
+返回记录，但 adapter 不保存 ticket，`MemoryCycle` 不 commit，已有 context pending
+也保持对象身份不变。因此模型在一轮里是否调用 recall 只改变收到的上下文，不改变
+图状态。
+
+### 4.4 排除路径
+
+- `session_key` 前缀为 `scheduler` 的 turn 不查询学习状态，也不进入 replay。
+- user 或 assistant 的持久 metadata 含 `skip_post_memory` 时，同样排除。
+- user 与 assistant 都没有文本的纯媒体 turn 不进入索引。
+- 单边文本为空时，只要求非空一侧有 embedding；不得为纯空内容生成假向量。
+
+## 5. 稀疏编码与模式补全
+
+一个历史 turn 是稳定原子节点。它携带原始 message 指针、user/assistant dense、
+增量 BM25 词项、时间与 burst 统计。检索先形成非负 seed，再进入同一 `MemoryCycle`：
+
+```text
+dense / BM25 / burst / temporal evidence
+                    │
+                    ▼
+              sparse seed mass
+                    │
+                    ▼
+        residual diffusion with restart
+                    │
+         ┌──────────┴──────────┐
+         ▼                     ▼
+   settled lower bound    remaining residual
+         │                     │
+         └──── residual ≤ tolerance ────► stop
+```
+
+每次 commit 用已激活模式形成稀疏 hub membership，不展开全连接 clique。短时间内的
+正向关系强于反向关系；同一连接预算内，反复共同激活的关系获得份额，未共同激活关系
+相对受抑制。遗忘按事件时间与重复激活共同决定，而不是只按数据库年龄单调删除。
+
+在线与 replay 均按 `(timestamp, session_key bytes, user_seq, turn_id bytes)` 建立全局
+因果顺序。所有 set/dict 到持久化输出前都有稳定排序；重放进程固定 BLAS 线程数，
+不同 `PYTHONHASHSEED` 不得改变 canonical logical state。
+
+## 6. 重建合同
+
+`scripts/build_akasha_db.py` 只负责把宿主入口转发给 upstream CLI。完整重建分四段：
+
+```text
+只读打开 sessions.db
+        │
+        ▼
+审计所有 eligible message embeddings
+        │
+        ├─ 缺失/损坏 ─► 写 JSON 缺口报告，fail-loud
+        │                 不备份、不创建目标 DB
+        ▼
+临时目录构建 sparse index
+        │
+        ▼
+同一个 MemoryCycle 全量 replay
+        │
+        ▼
+备份旧 sidecar → staging 完整写入 → 原子替换 → 输出 run report
+```
+
+重建不调用 embedding provider。若历史确有缺口，必须由独立 embedding 迁移在源库副本
+或经明确授权的正式库中补齐，之后重新执行严格重建。这样可以区分“固定输入重放”和
+“改变固定输入”两种不同权限。
+
+## 7. 在线与 replay 等价
+
+比较对象不是 SQLite 文件字节，而是排除运行诊断时间、文件布局和查询 trace 后的
+canonical logical state：
+
+- turn 与 source message 身份；
+- hub membership 与强度；
+- 有向关系、连接预算和遗忘状态；
+- context/burst 状态；
+- 已提交 activation/plasticity 结果。
+
+最小等价场景按下面顺序执行：
+
+1. 空隔离 workspace 启动真实宿主 plugin。
+2. context query 产生 pending。
+3. 通过正式 session API 持久化 user/assistant。
+4. 发出 `TurnCommitted`，确认状态版本增加。
+5. 产生第二个 context pending。
+6. 通过真实 `RecallMemoryTool` 调用 read-only recall，确认 sidecar logical hash 和
+   pending 对象不变。
+7. 提交第二轮。
+8. 从同一 `sessions.db` 的干净索引全量 replay。
+9. 比较 online 与 replay canonical logical hash。
+
+全量 Gate 再对真实历史快照使用两个不同 `PYTHONHASHSEED` 重放，要求逻辑摘要一致。
+
+## 8. Docker 与正式 workspace 隔离
+
+Docker Gate 的 source、config、workspace、HOME、socket 和报告都位于唯一 `/tmp`
+sandbox。正式 workspace 只在宿主侧通过 SQLite online backup 生成快照；容器不挂载
+正式路径。Gate 前后记录以下正式文件证据：
+
+- `sessions.db` SHA256、size、mtime；
+- `memory/akasha.db` SHA256、size、mtime。
+
+容器中的 scripted chat provider 只控制 Agent 回复与工具选择。Akasha embedding 使用
+明确配置的真实 debug embedding endpoint；凭据只写权限为 `0600` 的临时配置，不进入
+仓库、日志或报告。若 endpoint 或凭据不可用，Docker Gate 返回 blocked/failed，不能
+用固定假向量声称在线路径通过。
+
+Docker 场景必须观察：
+
+- 第一次 user 输入进入 provider，assistant 落库，图状态版本增加；
+- 第二次自动 context 确实进入 provider payload；
+- provider 调用 `recall_memory`，工具返回且 sidecar 状态不变；
+- 工具结果后的 assistant 正常提交并影响下一轮图；
+- 容器停止后从其 `sessions.db` replay，逻辑状态与在线库一致；
+- Compose 无残留容器，仓库与正式 workspace 摘要不变。
+
+## 9. 输出合同
+
+自动上下文沿用现有认知命名，不给每条记录标“语义”或“联想”：
+
+```text
+# Akasha memory now=07-06
+
+## 左脑记忆：精确回忆
+[07-06] user="..." assistant="最多 50 字..."
+
+## 右脑联想：潜意识第一反应
+[06-28] user="..." assistant="最多 50 字..."
+```
+
+两条 lane 先按各自证据选取，再按时间展示。去重使用稳定 turn ID，不用截断文本或
+字符串相等；同一 turn 即使两侧分数不同也只出现一次。
+
+## 10. 失败、回滚与部署前置
+
+- upstream 镜像校验失败：停止构建，不从宿主镜像继续开发。
+- embedding audit 失败：保留报告，不触碰现存 sidecar。
+- replay 中断：目标 staging 不发布；现存 sidecar 的时间戳备份可恢复。
+- online commit 失败：异常上抛，不能把空结果当成功；原始 session 消息仍保留。
+- 正式部署前：备份旧 `config.local.toml` 和 `akasha.db`，在只读快照完成全量 Gate，
+  再把规范 V2 config 与已验证 sidecar 作为同一个维护操作原子切换。
+- 回滚时同时恢复旧插件代码、旧 config 和旧 sidecar；不能只切代码后继续打开另一代
+  schema。
+
+本分支只交付代码、隔离证据和迁移设计，不修改正式 workspace，也不把 PR 合入运行中
+分支。
+
+## 11. 验收命令
+
+```bash
+# upstream
+pytest -q
+python scripts/check_akasic_contract.py
+python scripts/check_akasic_behavior.py
+
+# host mirror and tests
+.venv/bin/python scripts/check_akasha_v2_mirror.py \
+  --upstream /mnt/data/coding/akasha-v2-engine
+.venv/bin/python -m pytest -q
+
+# strict isolated replay
+PYTHONHASHSEED=1 .venv/bin/python scripts/build_akasha_db.py \
+  --sessions-db /tmp/<run>/sessions.db \
+  --db-path /tmp/<run>/akasha-seed1.db \
+  --embedding-model text-embedding-v4 \
+  --embedding-dim 1024 \
+  --require-complete-embeddings
+
+PYTHONHASHSEED=987654321 .venv/bin/python scripts/build_akasha_db.py \
+  --sessions-db /tmp/<run>/sessions.db \
+  --db-path /tmp/<run>/akasha-seed2.db \
+  --embedding-model text-embedding-v4 \
+  --embedding-dim 1024 \
+  --require-complete-embeddings
+
+# public runtime gate
+python docker/debug/gate.py run --base origin/main
+```

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -273,13 +273,13 @@ workspace 之外还有两组明确的全局状态：
 
 ### 8.3 `memory/akasha.db`
 
-`AkashaStore` 保存 query log、nodes、edges、activation events、salience、migration、source snapshot、embedding cache 和 FTS IDF。`AkashaEngine` 的代码注释、describe metadata 和 [`plugins/akasha/REBUILD.md`](../../plugins/akasha/REBUILD.md) 都明确说明：原始正文必须回 `sessions.db` 读取，Akasha sidecar 不充当事实来源。
+Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activation/plasticity 事件和因果上下文。宿主 adapter 与重建 CLI 都只从 `sessions.db` 读取原始正文；Akasha sidecar 不充当事实来源。完整调用链见 [Akasha V2 在线与确定性重放设计](akasha-v2-runtime-migration.md)。
 
-**F-007：** `akasha.db` 是由 `sessions.db/messages`、`sessions.db/message_embeddings`、固定算法和固定配置得到的索引与图；`akasha_graph_snapshot.json` 又是供 dashboard 使用的派生快照。标准 rebuild 复用已有 embedding，不调用 LLM，也不让模型重新解释历史。
+**F-007：** `akasha.db` 与 `akasha-v2-index.db` 是由 `sessions.db/messages`、`sessions.db/message_embeddings`、固定算法和固定配置得到的派生索引与图。标准 rebuild 复用已有 embedding，不调用 LLM，也不让模型重新解释历史。旧 `akasha_graph_snapshot.json` 和私有图 Dashboard 已退出 V2 运行时接口。
 
 **F-007A：** 同一份 messages、匹配的 message embeddings、算法和配置必须得到可复现的图。算法与配置要作为重建输入固定；改变它们属于显式图迁移，不是同输入重建。
 
-**G-003：** 当前 `build_akasha_db.py` 在 embedding cache miss 时会跳过消息，可能生成残缺图。完整重建合同要求 miss 或模型不匹配时 fail-loud；修复前不能仅凭脚本退出成功声称已经完整重建。
+**F-007B：** 当前 `build_akasha_db.py` 在备份和目标数据库写入前审计全部合法对话 embedding。缺失、内容 hash 不匹配、模型/维度不匹配、非有限或零向量会写出确定性缺口报告并 fail-loud；scheduler、显式 `skip_post_memory` 和双方都为空的纯媒体 turn 不属于学习输入。
 
 ## 9. 主动流程、Wake、Drift 与调度
 
@@ -442,7 +442,6 @@ workspace 之外还有两组明确的全局状态：
 5. SQLite 分别 backup 时，每个文件内部一致，但多个数据库与普通文件之间没有全局事务时点。
 6. 备份范围没有明确包含或排除 `.app-server-token`、diagnostic traces、全局凭据和全局插件 manifest。
 7. `mcp/servers/*.toml` 与 workspace 手工 skill 目录仍绕过插件安装系统，形成第二套能力 owner；现存内容尚未迁移。
-8. Akasha rebuild 遇到 embedding miss 时仍会跳过消息，尚未满足 MEM-009 的完整重建失败语义。
 
 这些缺口正是 `BAK-001` 和 `NOW.md` 中恢复演练事项尚未完成的部分。
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -331,7 +331,7 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 
 ### MEM-009 Akasha 使用固定输入确定性重建
 
-`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。同一组输入必须得到可复现的图；缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过消息后仍声称成功。
+`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有完成的 user/assistant turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
 
 ## 9. 运行时、并发和出站
 


### PR DESCRIPTION
## What changed

- Record Akasha V2 as the canonical explicit-memory engine.
- Define online/replay ownership, query and commit semantics, scheduler exclusion, presentation rules, and deterministic replay acceptance criteria.
- Update the documentation index and persistence-state map.

## Why

The runtime migration changes protected memory and persistence contracts. Keeping the contract in a documentation-only PR lets maintainers review and accept those semantics before the implementation stack.

## Impact

This PR changes documentation only. It does not deploy or replace the formal workspace database.

## Validation

- Public change Gate accepts this documentation-only scope.
- The implementation and runtime evidence are intentionally stacked in the follow-up PR from `feature/akasha-v2-runtime-integration`.
