### PR TITLE
fix: prevent orphan tool messages during context retry

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -2144,7 +2144,24 @@ class DefaultReasoner(Reasoner):
             return []
         if window >= total_history:
             return source_history
-        return source_history[-window:]
+
+        # 1. 先按 provider 消息预算取得候选后缀。
+        candidate = source_history[-window:]
+        if candidate[0].get("role") != "tool":
+            return candidate
+
+        # 2. 若切在工具结果中间，则丢弃残缺工具链并前移到合法回合。
+        for index, message in enumerate(candidate):
+            if message.get("role") == "user":
+                return candidate[index:]
+            content = message.get("content")
+            if (
+                message.get("role") == "assistant"
+                and isinstance(content, str)
+                and content.startswith("[主动推送]")
+            ):
+                return candidate[index:]
+        return []
 
     @staticmethod
     def _build_attempt_plans(total_history: int) -> list[dict]:

--- a/tests/test_safety_retry_service.py
+++ b/tests/test_safety_retry_service.py
@@ -176,3 +176,56 @@ def test_reasoner_run_turn_context_length_trims_dynamic_sections_before_history(
     assert calls[0]["disabled_sections"] == set()
     assert calls[1]["history_len"] == 6
     assert calls[1]["disabled_sections"] == {"skills_catalog"}
+
+
+def test_context_retry_starts_after_long_tool_chain_boundary():
+    history: list[dict] = [
+        {"role": "user", "content": "older-user"},
+        {"role": "assistant", "content": "older-answer"},
+        {"role": "user", "content": "tool-heavy-user"},
+    ]
+    for index in range(13):
+        call_id = f"call-{index}"
+        history.extend(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": f"result-{index}",
+                },
+            ]
+        )
+    history.extend(
+        [
+            {"role": "assistant", "content": "tool-heavy-answer"},
+            {"role": "user", "content": "recent-user"},
+            {"role": "assistant", "content": "recent-answer"},
+        ]
+    )
+
+    reduced_plan = next(
+        plan
+        for plan in DefaultReasoner._build_attempt_plans(len(history))
+        if plan["history_window"] < len(history)
+    )
+    window = cast(int, reduced_plan["history_window"])
+    assert window == 16
+    assert history[-window]["role"] == "tool"
+
+    projected = DefaultReasoner._slice_history(history, window)
+
+    assert projected == [
+        {"role": "user", "content": "recent-user"},
+        {"role": "assistant", "content": "recent-answer"},
+    ]


### PR DESCRIPTION
## 问题

长会话重启后，上下文超限重试会直接按展开后的 provider 消息数量截取后缀。当窗口边界落在长工具链中间时，请求可能以孤立的 `role=tool` 开始，provider 因找不到前置 `assistant.tool_calls` 而返回 400。

## 修复

- 保留现有上下文退化顺序。
- 当重试后缀首条为 `tool` 时，丢弃残缺工具链，前移到最近的 `user` 或明确的主动 assistant 边界。
- 不修改 `sessions.db` 或既有持久历史。

## CI 回归

新增 13 组工具调用的回归用例，刻意让 50% 历史窗口落在 `tool` result 上，断言最终投影从最近完整 user 回合开始。该用例由现有 `check-and-test` GitHub Actions job 的全量 pytest 强制执行。

## 本地验证

- `pytest -q -W error tests/`：2431 passed, 1 skipped
- `pyright --level error`：0 errors
- `pyright --project pyrightconfig.tests.json --level error`：0 errors
- `python scripts/generate_control_schema.py --check`：通过
- `python docker/debug/gate.py run --base origin/main`：GATE PASSED

## 后续边界

本 PR 不修改受保护的 CTX-001 oracle，也不顺带完成 `DefaultReasoner` 与 `SessionManager` 解耦；后者继续留在现有 P0，避免在同一实现 PR 中改写验收标准。