### PR TITLE
fix(memory): restore Akasha across equivalent indexes

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "ba20ce6c4485ade261d64569c8304304c440e151",
+  "commit": "41ae40f6ffbe88be6fe5ed76630e556bcf3785d9",
   "source_subtree": "src/akasha",
-  "source_tree": "93b1a9b75eda801a316a09dafc10281b1e899ae0",
-  "source_sha256": "d998d5f79faa791e64f03185b283b9b9cea19b004f683d402dbadf8b2bc9f599"
+  "source_tree": "eee68bc4bcb78e4be0aae0ad29afc0e0ab503eec",
+  "source_sha256": "4c2db36463d351f121cff3c609f557f9928eafb74e7e5f23489f9747d80bd76d"
 }

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -18,7 +18,6 @@ from ..infrastructure.lease import WriterLease
 from ..infrastructure.persistence import (
     load_memory_state,
     memory_turn_count,
-    sha256_file,
     write_memory_database,
 )
 from ..infrastructure.sparse_index import BuildConfig, build_sparse_index
@@ -202,11 +201,6 @@ class OnlineMemoryRuntime:
                 "memory snapshot contains more turns than sessions source"
             )
         prefix = turns[:persisted]
-        exact_hash = (
-            sha256_file(self.index_path)
-            if persisted == len(turns)
-            else None
-        )
         (
             graph,
             events,
@@ -218,7 +212,7 @@ class OnlineMemoryRuntime:
             self.memory_path,
             turns=prefix,
             config=self.config,
-            source_index_sha256=exact_hash,
+            source_index_sha256=None,
         )
         cycle = MemoryCycle.restore(
             config=self.config,


### PR DESCRIPTION
## Summary
- update the vendored Akasha V2 engine to upstream `41ae40f`
- stop treating SQLite physical page identity as sparse-evidence identity during online restore
- retain strict config, turn-count, and ordered turn/message-binding validation

## Root cause
Akasha rebuilds its derived sparse index during startup. SQLite can produce a different file SHA for the same logical evidence, causing a valid replay snapshot to fail before the process could start.

## Validation
- upstream regression: `uv run pytest -q` (28 passed)
- host plugin: `pytest -q tests/test_akasha_plugin.py` (4 passed)
- host pyright: 0 errors
- mirror checker: exact upstream commit/tree/content match
- `git diff --check`