### PR TITLE
fix(akasha): persist pattern-completion history

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "41ae40f6ffbe88be6fe5ed76630e556bcf3785d9",
+  "commit": "5201f39f6bc397b7cdae375c4b20156c167fded0",
   "source_subtree": "src/akasha",
-  "source_tree": "eee68bc4bcb78e4be0aae0ad29afc0e0ab503eec",
-  "source_sha256": "4c2db36463d351f121cff3c609f557f9928eafb74e7e5f23489f9747d80bd76d"
+  "source_tree": "bf496cc865604fe3fce62e6d12d7df75cbafc2b0",
+  "source_sha256": "5e2abb488c523d755507eb3ce75a9098c0d77daf4250f50e4fa04907645a8b10"
 }

--- a/plugins/akasha/application/cycle.py
+++ b/plugins/akasha/application/cycle.py
@@ -222,7 +222,6 @@ class MemoryCycle:
         if recomputed:
             selected = self.retrieve(
                 causal_turn,
-                include_completion=False,
             )
         else:
             if ticket is None:

--- a/plugins/akasha/application/rebuild.py
+++ b/plugins/akasha/application/rebuild.py
@@ -144,7 +144,7 @@ def _replay(
         ticket = cycle.retrieve(
             turn,
             capture_paths=event in targets,
-            include_completion=event in targets,
+            include_completion=True,
             isolate_graph=False,
         )
         committed = cycle.commit(

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -243,7 +243,6 @@ class OnlineMemoryRuntime:
                 turn,
                 cycle.retrieve(
                     turn,
-                    include_completion=False,
                     isolate_graph=False,
                 ),
             )

--- a/plugins/akasha/dashboard_panel_inspector.ts
+++ b/plugins/akasha/dashboard_panel_inspector.ts
@@ -24,6 +24,7 @@ interface InspectorRow {
   query_text: string;
   seed_count: number;
   activation_capture_available: boolean;
+  recall_capture_available: boolean;
   activation_count: number;
   completion_count: number;
   pushes: number;
@@ -44,8 +45,12 @@ interface InspectorDetail extends InspectorRow {
   activation_items: InspectorItem[];
   left: InspectorItem[];
   right: InspectorItem[];
+  tool_left: InspectorItem[];
+  tool_right: InspectorItem[];
   left_count: number;
   right_count: number;
+  tool_left_count: number;
+  tool_right_count: number;
   inject_chars: number;
   text_block_preview: string;
 }
@@ -184,7 +189,13 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
             ? `${item.graph_only_count} 个仅由图关系抵达`
             : "这一轮没有保存逐节点扩散路径",
         )}
-        ${metric("模式补全", item.right_count, `${item.basin_count} 个活跃情景 basin`)}
+        ${metric(
+          "模式补全",
+          item.recall_capture_available ? item.right_count : "未记录",
+          item.recall_capture_available
+            ? `${item.basin_count} 个活跃情景 basin`
+            : "旧重放没有保存这一轮的补全读出",
+        )}
         ${metric("残余", fixed(item.residual_l1, 6), `${item.pushes} 次 residual push`)}
       </dl>
 
@@ -217,6 +228,30 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
         </header>
         ${renderItems(item.right, "没有产生模式补全。")}
       </section>
+
+      ${item.tool_left_count
+        ? `
+          <section class="akasha-section akasha-lane">
+            <header>
+              <div><h3>工具精确回忆</h3><p>本轮 recall_memory 的 Dense 结果</p></div>
+              <span>${item.tool_left_count}</span>
+            </header>
+            ${renderItems(item.tool_left, "工具没有产生 Dense 命中。")}
+          </section>
+        `
+        : ""}
+
+      ${item.tool_right_count
+        ? `
+          <section class="akasha-section akasha-lane">
+            <header>
+              <div><h3>工具模式补全</h3><p>本轮 recall_memory 的显式图结果</p></div>
+              <span>${item.tool_right_count}</span>
+            </header>
+            ${renderItems(item.tool_right, "工具没有产生模式补全。")}
+          </section>
+        `
+        : ""}
 
       <details class="akasha-learning">
         <summary>本轮如何改变记忆</summary>

--- a/plugins/akasha/inspector.py
+++ b/plugins/akasha/inspector.py
@@ -173,6 +173,8 @@ class AkashaInspectorReader:
                         AS residual_l1,
                     COALESCE(recall.active_basin_count, 0)
                         AS basin_count,
+                    recall.query_turn_node_id IS NOT NULL
+                        AS recall_capture_available,
                     (
                         SELECT COUNT(*)
                         FROM recall_items AS item
@@ -193,7 +195,12 @@ class AkashaInspectorReader:
                 """,
                 [*values, page_size, (page - 1) * page_size],
             ).fetchall()
-        return [dict(row) for row in rows], total
+        items = [dict(row) for row in rows]
+        for item in items:
+            item["recall_capture_available"] = bool(
+                item["recall_capture_available"]
+            )
+        return items, total
 
     def get_turn(self, query_id: str) -> dict[str, object] | None:
         """Return one retrieval with seeds, paths, prompt lanes, and learning."""
@@ -207,6 +214,9 @@ class AkashaInspectorReader:
             seeds = self._load_seeds(connection, node_id)
             activations = self._load_activations(connection, node_id)
             completions = self._load_completions(connection, node_id)
+        tool_left, tool_right = _tool_recall_lanes(
+            run.pop("tool_chain_json")
+        )
 
         # 2. Reconstruct the host-visible lanes from frozen prior turns.
         dense = self._dense_items(node_id)
@@ -237,6 +247,10 @@ class AkashaInspectorReader:
             "right": right,
             "left_count": len(dense),
             "right_count": len(right),
+            "tool_left": tool_left,
+            "tool_right": tool_right,
+            "tool_left_count": len(tool_left),
+            "tool_right_count": len(tool_right),
             "inject_chars": len(text_block),
             "text_block_preview": text_block,
         }
@@ -295,6 +309,10 @@ class AkashaInspectorReader:
             "ATTACH DATABASE ? AS sparse",
             (f"file:{self.paths.index}?mode=ro",),
         )
+        _ = connection.execute(
+            "ATTACH DATABASE ? AS sessions",
+            (f"file:{self.workspace / 'sessions.db'}?mode=ro",),
+        )
         _ = connection.execute("PRAGMA query_only = ON")
         return connection
 
@@ -315,6 +333,7 @@ class AkashaInspectorReader:
                 turn.started_at AS ts,
                 sparse_turn.user_text AS query_text,
                 sparse_turn.assistant_text,
+                assistant.tool_chain AS tool_chain_json,
                 event.time_prior,
                 event.continuation,
                 COALESCE(activation.pushes, event.pushes) AS pushes,
@@ -323,6 +342,8 @@ class AkashaInspectorReader:
                 event.seed_support AS seed_count,
                 activation.query_turn_node_id IS NOT NULL
                     AS activation_capture_available,
+                recall.query_turn_node_id IS NOT NULL
+                    AS recall_capture_available,
                 COALESCE(
                     activation.completion_support,
                     (
@@ -366,6 +387,8 @@ class AkashaInspectorReader:
               ON turn.node_id = event.current_turn_node_id
             JOIN sparse.sparse_turns AS sparse_turn
               ON sparse_turn.turn_id = turn.turn_id
+            LEFT JOIN sessions.messages AS assistant
+              ON assistant.id = turn.assistant_message_id
             LEFT JOIN activation_runs AS activation
               ON activation.query_turn_node_id = turn.node_id
             LEFT JOIN recall_runs AS recall
@@ -379,6 +402,9 @@ class AkashaInspectorReader:
         item = dict(row)
         item["activation_capture_available"] = bool(
             item["activation_capture_available"]
+        )
+        item["recall_capture_available"] = bool(
+            item["recall_capture_available"]
         )
         return item
 
@@ -660,6 +686,9 @@ def mobile_summary(item: dict[str, object]) -> dict[str, object]:
         "activation_capture_available": item[
             "activation_capture_available"
         ],
+        "recall_capture_available": item[
+            "recall_capture_available"
+        ],
         "activation_count": item["activation_count"],
         "left_count": item["left_count"],
         "right_count": item["right_count"],
@@ -667,7 +696,97 @@ def mobile_summary(item: dict[str, object]) -> dict[str, object]:
         "residual_l1": item["residual_l1"],
         "left": item["left"],
         "right": item["right"],
+        "tool_left_count": item["tool_left_count"],
+        "tool_right_count": item["tool_right_count"],
+        "tool_left": item["tool_left"],
+        "tool_right": item["tool_right"],
     }
+
+
+def _tool_recall_lanes(
+    raw_tool_chain: object,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """Project persisted recall_memory results without changing graph state."""
+
+    # 1. Decode only successful recall_memory tool results.
+    if raw_tool_chain is None:
+        return [], []
+    chain = json.loads(str(raw_tool_chain))
+    if not isinstance(chain, list):
+        raise ValueError("assistant tool_chain must encode a JSON array")
+    items: list[dict[str, object]] = []
+    for step in chain:
+        if not isinstance(step, dict):
+            raise ValueError("assistant tool_chain step must be an object")
+        calls = step.get("calls", [])
+        if not isinstance(calls, list):
+            raise ValueError("assistant tool_chain calls must be an array")
+        for call in calls:
+            if not isinstance(call, dict):
+                raise ValueError("assistant tool call must be an object")
+            if call.get("name") != "recall_memory":
+                continue
+            if call.get("status") != "success":
+                continue
+            result = call.get("result")
+            if not isinstance(result, str):
+                raise ValueError("recall_memory result must be JSON text")
+            payload = json.loads(result)
+            if not isinstance(payload, dict):
+                raise ValueError("recall_memory result must encode an object")
+            recalled = payload.get("items")
+            if not isinstance(recalled, list):
+                raise ValueError("recall_memory items must be an array")
+            items.extend(_tool_recall_item(item) for item in recalled)
+
+    # 2. Keep the first stable occurrence in each visible lane.
+    left = _dedupe_tool_lane(items, "dense")
+    right = _dedupe_tool_lane(items, "completion")
+    return left, right
+
+
+def _tool_recall_item(raw: object) -> dict[str, object]:
+    if not isinstance(raw, dict):
+        raise ValueError("recall_memory item must be an object")
+    signals = raw.get("signals")
+    if not isinstance(signals, dict):
+        raise ValueError("recall_memory item signals must be an object")
+    lane = signals.get("lane")
+    if lane not in {"dense", "completion"}:
+        raise ValueError(f"recall_memory item lane is invalid: {lane}")
+    item_id = raw.get("id")
+    if not isinstance(item_id, str) or not item_id:
+        raise ValueError("recall_memory item id must be non-empty")
+    sources = signals.get("sources", [])
+    if not isinstance(sources, list):
+        raise ValueError("recall_memory item sources must be an array")
+    return {
+        "query_id": item_id,
+        "session_key": raw.get("source_ref", ""),
+        "ts": signals.get("started_at", ""),
+        "user_text": signals.get("user_text", ""),
+        "assistant_preview": signals.get("assistant_preview", ""),
+        "score": raw.get("score"),
+        "sources": sources,
+        "lane": lane,
+    }
+
+
+def _dedupe_tool_lane(
+    items: list[dict[str, object]],
+    lane: str,
+) -> list[dict[str, object]]:
+    seen: set[str] = set()
+    result: list[dict[str, object]] = []
+    for item in items:
+        if item["lane"] != lane:
+            continue
+        item_id = str(item["query_id"])
+        if item_id in seen:
+            continue
+        seen.add(item_id)
+        result.append(item)
+    return result
 
 
 def _dense_matrix(

--- a/plugins/akasha/mobile_ui.css
+++ b/plugins/akasha/mobile_ui.css
@@ -52,9 +52,24 @@
 }
 
 .akasha-mobile-recall summary b {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   color: var(--akasha-mobile-accent);
   font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
+}
+
+.akasha-mobile-recall summary b::after {
+  display: inline-block;
+  color: var(--m-on-surface-variant);
+  content: "⌄";
+  font-size: 0.9rem;
+  transition: rotate 150ms ease-out;
+}
+
+.akasha-mobile-recall[open] summary b::after {
+  rotate: 180deg;
 }
 
 .akasha-mobile-memories {

--- a/plugins/akasha/mobile_ui.js
+++ b/plugins/akasha/mobile_ui.js
@@ -42,14 +42,18 @@ function memoryList(items, empty) {
   `;
 }
 
-function recallSection(title, items) {
+function recallSection(title, items, captureAvailable = true) {
+  const count = captureAvailable ? items.length : "未记录";
+  const empty = captureAvailable
+    ? "本轮没有命中"
+    : "这一轮没有保存模式补全读出";
   return `
-    <details class="akasha-mobile-recall">
+    <details class="akasha-mobile-recall" ${items.length ? "open" : ""}>
       <summary>
         <span>${escapeHtml(title)}</span>
-        <b>${items.length}</b>
+        <b>${escapeHtml(count)}</b>
       </summary>
-      ${memoryList(items, "本轮没有命中")}
+      ${memoryList(items, empty)}
     </details>
   `;
 }
@@ -73,7 +77,7 @@ function renderRecent(items, total) {
           <li>
             <button type="button" data-akasha-query="${escapeHtml(item.query_id)}">
               <span>${escapeHtml(item.query_preview || item.query_text || "（空消息）")}</span>
-              <small>${escapeHtml(shortTime(item.ts))} · ${Number(item.seed_count || 0)} seeds · ${Number(item.completion_count || 0)} recall</small>
+              <small>${escapeHtml(shortTime(item.ts))} · ${Number(item.seed_count || 0)} seeds · ${item.recall_capture_available === false ? "未记录 recall" : `${Number(item.completion_count || 0)} recall`}</small>
             </button>
           </li>
         `).join("")}
@@ -85,6 +89,9 @@ function renderRecent(items, total) {
 function renderDetail(item) {
   const left = Array.isArray(item.left) ? item.left : [];
   const right = Array.isArray(item.right) ? item.right : [];
+  const toolLeft = Array.isArray(item.tool_left) ? item.tool_left : [];
+  const toolRight = Array.isArray(item.tool_right) ? item.tool_right : [];
+  const recallCaptured = item.recall_capture_available !== false;
   return `
     <section class="akasha-mobile-inspector">
       <button class="akasha-mobile-back" type="button" data-akasha-back>返回检索列表</button>
@@ -95,12 +102,14 @@ function renderDetail(item) {
           <div><dt>线索</dt><dd>${Number(item.seed_count || 0)}</dd></div>
           <div><dt>补全</dt><dd>${Number(item.activation_count || 0)}</dd></div>
           <div><dt>左脑</dt><dd>${left.length}</dd></div>
-          <div><dt>右脑</dt><dd>${right.length}</dd></div>
+          <div><dt>右脑</dt><dd>${recallCaptured ? right.length : "—"}</dd></div>
         </dl>
       </header>
       <div class="akasha-mobile-detail-lanes">
         ${recallSection("左脑 · 精确回忆", left)}
-        ${recallSection("右脑 · 模式补全", right)}
+        ${recallSection("右脑 · 模式补全", right, recallCaptured)}
+        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft) : ""}
+        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight) : ""}
       </div>
       <p class="akasha-mobile-convergence">${Number(item.pushes || 0)} 次扩散，残余 ${Number(item.residual_l1 || 0).toExponential(2)}</p>
     </section>
@@ -118,10 +127,15 @@ function mountRecall(host, context) {
     if (!active) return;
     const left = Array.isArray(result.left) ? result.left : [];
     const right = Array.isArray(result.right) ? result.right : [];
+    const toolLeft = Array.isArray(result.tool_left) ? result.tool_left : [];
+    const toolRight = Array.isArray(result.tool_right) ? result.tool_right : [];
+    const recallCaptured = result.recall_capture_available !== false;
     host.innerHTML = `
       <div class="akasha-mobile-recall-group">
         ${recallSection("左脑 · 精确回忆", left)}
-        ${recallSection("右脑 · 模式补全", right)}
+        ${recallSection("右脑 · 模式补全", right, recallCaptured)}
+        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft) : ""}
+        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight) : ""}
       </div>
     `;
   }).catch((error) => {

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -136,8 +136,13 @@ class AkashaPlugin(Plugin):
             return {"left": [], "right": []}
         return {
             "query_id": item["query_id"],
+            "recall_capture_available": item[
+                "recall_capture_available"
+            ],
             "left": item["left"],
             "right": item["right"],
+            "tool_left": item["tool_left"],
+            "tool_right": item["tool_right"],
         }
 
     def _inspector(self) -> AkashaInspectorReader:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -144,6 +144,35 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert context.text_block.startswith("# Akasha memory now=07-06")
     assert "## 左脑记忆：精确回忆" in context.text_block
     assert f'assistant="{"A" * 50}..."' in context.text_block
+    tool_payload = dict(rendered)
+    tool_payload["items"] = [
+        *cast(list[dict[str, object]], rendered["items"]),
+        {
+            "id": "tool:completion",
+            "score": 0.25,
+            "source_ref": "test:one",
+            "signals": {
+                "lane": "completion",
+                "sources": ["basin_completion"],
+                "started_at": started.isoformat(),
+                "user_text": "associated memory",
+                "assistant_preview": "associated answer",
+            },
+        },
+    ]
+    tool_chain = json.dumps(
+        [
+            {
+                "calls": [
+                    {
+                        "name": "recall_memory",
+                        "status": "success",
+                        "result": json.dumps(tool_payload),
+                    }
+                ]
+            }
+        ]
+    )
 
     # 4. Commit the second turn and compare online learned state with replay.
     _append_turn(
@@ -152,6 +181,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
         user="alpha follow",
         assistant="second answer",
         started=next_time,
+        assistant_tool_chain=tool_chain,
     )
     await engine._on_turn_committed(  # noqa: SLF001
         _event(
@@ -170,6 +200,15 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert logical_state_sha256(
         tmp_path / "memory" / "akasha.db"
     ) == logical_state_sha256(replay)
+    with closing(
+        sqlite3.connect(tmp_path / "memory" / "akasha.db")
+    ) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM recall_runs"
+        ).fetchone() == (2,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM activation_runs"
+        ).fetchone() == (0,)
 
     # 5. Inspector reconstructs the exact prior-only lanes without writes.
     _write_inspector_config(tmp_path)
@@ -184,7 +223,10 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert total == 1
     assert detail is not None
     assert detail["query_text"] == "alpha follow"
+    assert detail["recall_capture_available"] is True
     assert detail["left_count"] == 1
+    assert detail["tool_left_count"] == 1
+    assert detail["tool_right_count"] == 1
     assert cast(list[dict[str, object]], detail["left"])[0][
         "user_text"
     ] == "alpha start"
@@ -244,6 +286,8 @@ async def test_online_turn_recall_and_replay_share_one_state(
         turn_id=None,
     )
     assert len(cast(list[object], mobile["left"])) == 1
+    assert len(cast(list[object], mobile["tool_left"])) == 1
+    assert len(cast(list[object], mobile["tool_right"])) == 1
     assert recent["total"] == 2
     assert mobile_detail["query_text"] == "alpha follow"
     _close_engine(engine)
@@ -430,6 +474,7 @@ def _append_turn(
     started: datetime,
     session_key: str = "test:one",
     with_embeddings: bool = False,
+    assistant_tool_chain: str | None = None,
 ) -> None:
     assistant_time = started + timedelta(seconds=10)
     with closing(sqlite3.connect(path)) as connection, connection:
@@ -456,7 +501,7 @@ def _append_turn(
                     sequence + 1,
                     "assistant",
                     assistant,
-                    None,
+                    assistant_tool_chain,
                     None,
                     assistant_time.isoformat(),
                 ),


### PR DESCRIPTION
## Summary
- sync Akasha engine upstream `5201f39` and persist completion readouts for every replay/live fallback turn
- show historical capture absence as `未记录` instead of a false zero
- expose persisted `recall_memory` tool Dense/completion lanes in desktop and mobile Inspector views
- preserve path capture as an opt-in report/debug cost

## Root cause
The rebuild pipeline tied completion execution to optional `--seq` report targets. The production rebuild had zero targets, so it built hubs and relations but stored zero recall runs. The UI then coalesced a missing run to zero.

## Verification
- mirror: 31 files, source tree `bf496cc865604fe3fce62e6d12d7df75cbafc2b0`
- `pytest -q tests/test_akasha_plugin.py tests/test_memory_engine_contract.py` — 34 passed
- pyright — 0 errors
- `npm run build:plugins` — passed
- real 500-turn replay — 500 recall runs, 497 with items, 0 activation runs
- formal read-only Inspector probe recovered 5 persisted tool pattern-completion items from the screenshot turn
