### PR TITLE
feat(akasha): sync semantic recall UI

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "5201f39f6bc397b7cdae375c4b20156c167fded0",
+  "commit": "da23f932fc0e91d75d6557f3dbea4b4d72daeb14",
   "source_subtree": "src/akasha",
-  "source_tree": "bf496cc865604fe3fce62e6d12d7df75cbafc2b0",
-  "source_sha256": "5e2abb488c523d755507eb3ce75a9098c0d77daf4250f50e4fa04907645a8b10"
+  "source_tree": "cab08799852ddf1b8e9e1725dd04127152d3cf69",
+  "source_sha256": "484cd218174132c6199df6c1910d4cf8e2c08f28272e101e7033d2eec8b78c9e"
 }

--- a/plugins/akasha/mobile_ui.css
+++ b/plugins/akasha/mobile_ui.css
@@ -7,40 +7,90 @@
   --akasha-mobile-accent: var(--m-primary);
   --akasha-mobile-accent-soft:
     color-mix(in oklch, var(--m-primary) 11%, var(--m-surface));
+  --akasha-mobile-precise: var(--m-primary);
+  --akasha-mobile-precise-container:
+    color-mix(in oklch, var(--m-primary) 14%, var(--m-surface-container));
+  --akasha-mobile-precise-on-container:
+    var(--m-on-primary-container, oklch(0.34 0.1 255));
+  --akasha-mobile-completion:
+    var(--m-trace, oklch(0.56 0.18 300));
+  --akasha-mobile-completion-container:
+    color-mix(
+      in oklch,
+      var(--m-trace, oklch(0.56 0.18 300)) 14%,
+      var(--m-surface-container)
+    );
+  --akasha-mobile-completion-on-container:
+    color-mix(
+      in oklch,
+      var(--m-trace, oklch(0.56 0.18 300)) 64%,
+      var(--m-on-surface)
+    );
   --akasha-mobile-shadow:
-    0 0 0 1px color-mix(in oklch, var(--m-on-surface) 7%, transparent),
-    0 1px 2px color-mix(in oklch, oklch(0 0 0) 12%, transparent);
+    0 1px 2px color-mix(in oklch, oklch(0 0 0) 14%, transparent),
+    0 3px 8px color-mix(in oklch, oklch(0 0 0) 7%, transparent);
   color: var(--m-on-surface);
 }
 
 .akasha-mobile-recall-group {
   display: grid;
-  gap: 8px;
+  min-width: 0;
+  gap: 10px;
   margin: 2px 0 14px;
 }
 
 .akasha-mobile-recall {
+  --akasha-mobile-lane: var(--akasha-mobile-precise);
+  --akasha-mobile-lane-container: var(--akasha-mobile-precise-container);
+  --akasha-mobile-lane-on-container:
+    var(--akasha-mobile-precise-on-container);
   overflow: hidden;
-  border-radius: 12px;
-  background: var(--m-surface-container);
+  border-radius: var(--m-shape-medium, 12px);
+  background:
+    color-mix(
+      in oklch,
+      var(--akasha-mobile-lane) 4%,
+      var(--m-surface-container-low)
+    );
   box-shadow: var(--akasha-mobile-shadow);
 }
 
+.akasha-mobile-recall--completion {
+  --akasha-mobile-lane: var(--akasha-mobile-completion);
+  --akasha-mobile-lane-container: var(--akasha-mobile-completion-container);
+  --akasha-mobile-lane-on-container:
+    var(--akasha-mobile-completion-on-container);
+}
+
 .akasha-mobile-recall summary {
-  display: flex;
+  display: grid;
   min-height: 44px;
+  grid-template-columns: 4px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 13px;
+  gap: 10px;
+  padding: 0 10px 0 12px;
   color: var(--m-on-surface);
+  background:
+    color-mix(
+      in oklch,
+      var(--akasha-mobile-lane) 7%,
+      var(--m-surface-container)
+    );
   cursor: pointer;
   font-size: 0.84rem;
-  font-weight: 620;
+  font-weight: 650;
   list-style: none;
   transition-property: color, background-color;
-  transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  transition-duration: 160ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.akasha-mobile-recall summary::before {
+  width: 4px;
+  height: 20px;
+  border-radius: var(--m-shape-full, 9999px);
+  background: var(--akasha-mobile-lane);
+  content: "";
 }
 
 .akasha-mobile-recall summary::-webkit-details-marker {
@@ -48,14 +98,39 @@
 }
 
 .akasha-mobile-recall summary:hover {
-  background: var(--akasha-mobile-accent-soft);
+  background:
+    color-mix(
+      in oklch,
+      var(--akasha-mobile-lane) 12%,
+      var(--m-surface-container)
+    );
+}
+
+.akasha-mobile-recall summary:active {
+  background:
+    color-mix(
+      in oklch,
+      var(--akasha-mobile-lane) 17%,
+      var(--m-surface-container)
+    );
+}
+
+.akasha-mobile-recall summary:focus-visible {
+  outline: 2px solid var(--akasha-mobile-lane);
+  outline-offset: -2px;
 }
 
 .akasha-mobile-recall summary b {
   display: inline-flex;
+  min-width: 36px;
+  min-height: 28px;
   align-items: center;
+  justify-content: center;
   gap: 7px;
-  color: var(--akasha-mobile-accent);
+  border-radius: var(--m-shape-full, 9999px);
+  padding: 0 8px;
+  color: var(--akasha-mobile-lane-on-container);
+  background: var(--akasha-mobile-lane-container);
   font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
 }
@@ -76,6 +151,12 @@
   margin: 0;
   padding: 0;
   border-top: 1px solid var(--akasha-mobile-rule);
+  background:
+    color-mix(
+      in oklch,
+      var(--akasha-mobile-lane) 3%,
+      var(--m-surface-container-low)
+    );
   list-style: none;
 }
 
@@ -301,6 +382,10 @@
   .akasha-mobile-recall summary,
   .akasha-mobile-turns button,
   .akasha-mobile-back {
+    transition-duration: 0ms;
+  }
+
+  .akasha-mobile-recall summary b::after {
     transition-duration: 0ms;
   }
 }

--- a/plugins/akasha/mobile_ui.js
+++ b/plugins/akasha/mobile_ui.js
@@ -42,13 +42,13 @@ function memoryList(items, empty) {
   `;
 }
 
-function recallSection(title, items, captureAvailable = true) {
+function recallSection(title, items, lane, captureAvailable = true) {
   const count = captureAvailable ? items.length : "未记录";
   const empty = captureAvailable
     ? "本轮没有命中"
     : "这一轮没有保存模式补全读出";
   return `
-    <details class="akasha-mobile-recall" ${items.length ? "open" : ""}>
+    <details class="akasha-mobile-recall akasha-mobile-recall--${escapeHtml(lane)}" ${items.length ? "open" : ""}>
       <summary>
         <span>${escapeHtml(title)}</span>
         <b>${escapeHtml(count)}</b>
@@ -106,10 +106,10 @@ function renderDetail(item) {
         </dl>
       </header>
       <div class="akasha-mobile-detail-lanes">
-        ${recallSection("左脑 · 精确回忆", left)}
-        ${recallSection("右脑 · 模式补全", right, recallCaptured)}
-        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft) : ""}
-        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight) : ""}
+        ${recallSection("左脑 · 精确回忆", left, "precise")}
+        ${recallSection("右脑 · 模式补全", right, "completion", recallCaptured)}
+        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft, "precise") : ""}
+        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight, "completion") : ""}
       </div>
       <p class="akasha-mobile-convergence">${Number(item.pushes || 0)} 次扩散，残余 ${Number(item.residual_l1 || 0).toExponential(2)}</p>
     </section>
@@ -132,10 +132,10 @@ function mountRecall(host, context) {
     const recallCaptured = result.recall_capture_available !== false;
     host.innerHTML = `
       <div class="akasha-mobile-recall-group">
-        ${recallSection("左脑 · 精确回忆", left)}
-        ${recallSection("右脑 · 模式补全", right, recallCaptured)}
-        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft) : ""}
-        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight) : ""}
+        ${recallSection("左脑 · 精确回忆", left, "precise")}
+        ${recallSection("右脑 · 模式补全", right, "completion", recallCaptured)}
+        ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft, "precise") : ""}
+        ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight, "completion") : ""}
       </div>
     `;
   }).catch((error) => {

--- a/tests/test_akasha_mobile_ui.mjs
+++ b/tests/test_akasha_mobile_ui.mjs
@@ -37,3 +37,12 @@ test("mobile UI keeps graph out and uses restrained interaction styles", () => {
   assert.match(styles, /min-height:\s*44px/);
   assert.match(styles, /scale:\s*0\.96/);
 });
+
+test("recall lanes use distinct Material tonal semantics", () => {
+  assert.match(source, /left,\s*"precise"/);
+  assert.match(source, /right,\s*"completion"/);
+  assert.match(styles, /--akasha-mobile-precise:\s*var\(--m-primary\)/);
+  assert.match(styles, /--akasha-mobile-completion:/);
+  assert.match(styles, /var\(--m-trace,\s*oklch\(0\.56 0\.18 300\)\)/);
+  assert.match(styles, /grid-template-columns:\s*4px minmax\(0, 1fr\) auto/);
+});


### PR DESCRIPTION
## What changed

- sync Akasha mobile UI from canonical `akasha-v2-engine` commit `da23f932`
- pin the new upstream commit, subtree, and content digest
- add host regression assertions for precise and completion lane semantics

## Why

The Akasha inline recall cards need Material 3 semantic styling while preserving the canonical-engine ownership boundary. Blue now identifies precise evidence and violet identifies associative pattern completion.

## User impact

Recall cards are easier to scan and use accessible tonal count pills. Retrieval, persistence, prompt composition, and plugin protocol behavior are unchanged.

## Validation

- mirror identity check — 31 files byte-identical
- `node --test tests/test_akasha_mobile_ui.mjs` — 3 passed
- plugin tests — 15 passed
- visual fixture count contrast: 8.20:1 precise, 4.73:1 completion

## Dependency

- merged upstream: kachofugetsu09/akasha-v2-engine#3