### PR TITLE
test(context): enforce nondestructive retry projection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           python docker/debug/programmatic_control_probe.py --gate smoke
           python docker/debug/programmatic_control_probe.py --gate failure-matrix
+          python docker/debug/programmatic_control_probe.py --gate memory-context
 
       - name: Upload control gate evidence
         if: always()

--- a/docs/decisions/0002-context-reduction-is-a-nondestructive-projection.md
+++ b/docs/decisions/0002-context-reduction-is-a-nondestructive-projection.md
@@ -47,7 +47,7 @@ Destructive session port ─────► 只供用户主动撤销或删除使
 - `semantic_delta: none` 的上下文重构不能修改数据库历史或降低 CTX-001 oracle。
 - 对话归档、用户删除和索引重建另设明确入口，不能复用上下文预算函数。
 
-迁移采用 expand/migrate/contract 三阶段：先让受保护 oracle 同时识别旧的 runtime 裁切结果和新的只读投影结果；实现切换并取得 Docker 证据后，立即收紧 oracle，只接受 `session.messages` 与 `last_consolidated` 均不变。过渡 oracle 不作为最终合同。
+expand/migrate/contract 迁移已由 PR #220 和 PR #221 完成。受保护 oracle 只接受 `session.messages` 与 `last_consolidated` 均不变；旧的 runtime 裁切结果不再属于兼容行为。
 
 ## 验收
 

--- a/tests/semantic/test_context_history_contract.py
+++ b/tests/semantic/test_context_history_contract.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -100,6 +99,7 @@ def _seed_session(workspace: Path) -> tuple[SessionManager, str]:
     for index in range(6):
         role = "user" if index % 2 == 0 else "assistant"
         session.add_message(role, f"message-{index}")
+    session.last_consolidated = 4
     manager.save(session)
     _seed_embeddings(
         manager,
@@ -108,10 +108,7 @@ def _seed_session(workspace: Path) -> tuple[SessionManager, str]:
     return manager, session_key
 
 
-def _reasoner(
-    manager: SessionManager,
-    history_windows: list[int],
-) -> DefaultReasoner:
+def _reasoner(history_windows: list[int]) -> DefaultReasoner:
     def render(request: ContextRequest, **_kwargs: object) -> ContextRenderResult:
         history_windows.append(len(request.history))
         return ContextRenderResult(
@@ -128,28 +125,25 @@ def _reasoner(
         get_schemas=lambda names=None: [],
         get_tool=lambda name: None,
     )
-    kwargs: dict[str, object] = {
-        "llm": cast(
+    return DefaultReasoner(
+        llm=cast(
             Any,
             LLMServices(
                 provider=SimpleNamespace(chat=AsyncMock()),
                 light_provider=SimpleNamespace(),
             ),
         ),
-        "llm_config": LLMConfig(
+        llm_config=LLMConfig(
             model="semantic-gate",
             max_iterations=1,
             max_tokens=128,
         ),
-        "tools": cast(Any, tools),
-        "discovery": ToolDiscoveryState(),
-        "tool_search_enabled": False,
-        "memory_window": 40,
-        "context": cast(Any, SimpleNamespace(render=render)),
-    }
-    if "session_manager" in inspect.signature(DefaultReasoner).parameters:
-        kwargs["session_manager"] = manager
-    return DefaultReasoner(**cast(Any, kwargs))
+        tools=cast(Any, tools),
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=False,
+        memory_window=40,
+        context=cast(Any, SimpleNamespace(render=render)),
+    )
 
 
 def _message() -> SimpleNamespace:
@@ -166,13 +160,15 @@ def _message() -> SimpleNamespace:
 def test_context_retry_is_projection_over_append_only_history(tmp_path: Path) -> None:
     manager, session_key = _seed_session(tmp_path)
     session = manager.get_or_create(session_key)
+    before_runtime_messages = list(session.messages)
+    before_last_consolidated = session.last_consolidated
     before_messages = _messages_snapshot(manager, session_key)
     before_embeddings = _embeddings_snapshot(manager)
     before_highwater = max(cast(int, row[2]) for row in before_messages)
     statements: list[str] = []
     manager._store._conn.set_trace_callback(statements.append)
     windows: list[int] = []
-    reasoner = _reasoner(manager, windows)
+    reasoner = _reasoner(windows)
     reasoner.run = AsyncMock(
         side_effect=[
             ContextLengthError("too long"),
@@ -184,14 +180,19 @@ def test_context_retry_is_projection_over_append_only_history(tmp_path: Path) ->
         ]
     )
 
-    result = asyncio.run(reasoner.run_turn(msg=_message(), session=session))
+    result = asyncio.run(
+        reasoner.run_turn(
+            msg=_message(),
+            session=session,
+            base_history=list(session.messages),
+        )
+    )
 
     assert result.reply == "ok"
     assert windows[:5] == [6, 6, 6, 6, 6]
     assert windows[5] == 3
-    # Expand phase: old main trims the runtime mirror; the next implementation
-    # keeps all six. The contract PR following migration removes the old branch.
-    assert len(session.messages) in {3, 6}
+    assert session.messages == before_runtime_messages
+    assert session.last_consolidated == before_last_consolidated == 4
     assert_rows_unchanged(
         before_messages,
         _messages_snapshot(manager, session_key),
@@ -214,6 +215,7 @@ def test_context_retry_is_projection_over_append_only_history(tmp_path: Path) ->
     assert [message["content"] for message in reloaded.messages] == [
         f"message-{index}" for index in range(6)
     ]
+    assert reloaded.last_consolidated == 4
     reloaded.add_message("assistant", "message-6")
     reloaded_manager.save(reloaded)
     assert reloaded.messages[-1]["seq"] == before_highwater + 1


### PR DESCRIPTION
## Summary
- close the expand/migrate/contract transition from #220 and #221
- require context retry to preserve both `session.messages` and `last_consolidated`
- enable the deterministic Docker `memory-context` gate in CI

## Docker contract
- MC-01: paginated consolidation keeps 24 messages and advances cursor 0 -> 20 across two pages
- MC-02: scripted context error retries successfully, appends exactly two messages, and preserves cursor 4

## Validation
- `pytest -q tests/semantic/test_context_history_contract.py tests/semantic/test_change_gate.py`
- `pyright tests/semantic/test_context_history_contract.py --level error`
- protected-only change-impact plan