### PR TITLE
fix(context): bound persisted tool results

### DIFF
--- a/agent/looping/ports.py
+++ b/agent/looping/ports.py
@@ -37,7 +37,7 @@ class LLMConfig:
 
 @dataclass
 class MemoryConfig:
-    window: int = 40
+    window: int = 20
 
     @property
     def keep_count(self) -> int:

--- a/session/manager.py
+++ b/session/manager.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import mimetypes
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -16,6 +17,7 @@ from agent.prompting import (
 from session.store import SessionStore
 
 _TOOL_RESULT_CHAR_BUDGET = 10000
+_STORED_TOOL_RESULT_CHAR_BUDGET = 20000
 _PROACTIVE_HISTORY_CHAR_BUDGET = 360
 _PROACTIVE_META_HISTORY_CHAR_BUDGET = 1200
 _MSG_KEYS = {"id", "session_key", "seq", "role", "content", "timestamp", "tool_chain"}
@@ -37,6 +39,39 @@ def _truncate_tool_result(content: object) -> str:
     tail = keep - head
     truncated = text[:head] + marker + (text[-tail:] if tail else "")
     return f"Total output lines: {len(text.splitlines())}\n\n{truncated}"
+
+
+def _truncate_tool_chain_for_storage(tool_chain: object) -> object:
+    """Copy a tool chain and bound every persisted tool result."""
+
+    if tool_chain is None:
+        return None
+
+    # 1. Preserve the caller-owned runtime trace while preparing durable data.
+    stored = deepcopy(cast(list[dict[str, object]], tool_chain))
+
+    # 2. Truncate each result independently so one tool cannot dominate a turn.
+    for group in stored:
+        calls = cast(list[dict[str, object]], group["calls"])
+        for call in calls:
+            result = call.get("result")
+            if (
+                not isinstance(result, str)
+                or len(result) <= _STORED_TOOL_RESULT_CHAR_BUDGET
+            ):
+                continue
+            omitted = len(result) - _STORED_TOOL_RESULT_CHAR_BUDGET
+            while True:
+                marker = f"…{omitted} chars truncated before persistence…"
+                keep = max(0, _STORED_TOOL_RESULT_CHAR_BUDGET - len(marker))
+                actual_omitted = len(result) - keep
+                if actual_omitted == omitted:
+                    break
+                omitted = actual_omitted
+            head = keep // 2
+            tail = keep - head
+            call["result"] = result[:head] + marker + (result[-tail:] if tail else "")
+    return stored
 
 
 def _append_proactive_meta(content: str, msg: dict[str, object]) -> str:
@@ -450,7 +485,9 @@ class SessionManager:
                     "role": str(msg.get("role") or "assistant"),
                     "content": content,
                     "timestamp": ts,
-                    "tool_chain": msg.get("tool_chain"),
+                    "tool_chain": _truncate_tool_chain_for_storage(
+                        msg.get("tool_chain")
+                    ),
                     "extra": {k: v for k, v in msg.items() if k not in _MSG_KEYS},
                 }
             )

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -23,6 +23,7 @@ from proactive_v2.memory_optimizer import (
 from session.manager import (
     Session,
     SessionManager,
+    _STORED_TOOL_RESULT_CHAR_BUDGET,
     _TOOL_RESULT_CHAR_BUDGET,
 )
 from session.store import SessionStore
@@ -246,6 +247,58 @@ async def test_session_batch_persistence_uses_one_commit(tmp_path: Path) -> None
     await manager.append_messages(session, session.messages)
 
     assert statements.count("COMMIT") == 1
+
+
+@pytest.mark.asyncio
+async def test_session_persistence_truncates_each_large_tool_result(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("telegram:bounded-tool-result")
+    long_result = (
+        "head-"
+        + "x" * (_STORED_TOOL_RESULT_CHAR_BUDGET + 200)
+        + "-tail"
+    )
+    session.add_message("assistant", "结论")
+    session.messages[-1]["tool_chain"] = [
+        {
+            "text": "查询",
+            "calls": [
+                {
+                    "call_id": "call-1",
+                    "name": "shell",
+                    "arguments": {},
+                    "result": long_result,
+                },
+                {
+                    "call_id": "call-2",
+                    "name": "shell",
+                    "arguments": {},
+                    "result": "small",
+                },
+            ],
+        }
+    ]
+
+    await manager.append_messages(session, session.messages)
+    manager.close()
+    reloaded_manager = SessionManager(tmp_path)
+    stored_session = reloaded_manager.get_existing(session.key)
+    stored_chain = cast(
+        list[dict[str, object]],
+        stored_session.messages[0]["tool_chain"],
+    )
+    stored_calls = cast(list[dict[str, object]], stored_chain[0]["calls"])
+    stored_result = cast(str, stored_calls[0]["result"])
+
+    assert len(stored_result) == _STORED_TOOL_RESULT_CHAR_BUDGET
+    assert stored_result.startswith("head-")
+    assert stored_result.endswith("-tail")
+    assert "chars truncated before persistence" in stored_result
+    assert stored_calls[1]["result"] == "small"
+    assert long_result.endswith("-tail")
+    reloaded_manager.close()
 
 
 def test_session_manager_preserves_message_extra_payload_order(tmp_path: Path) -> None:

--- a/tests/test_memory_window_alignment.py
+++ b/tests/test_memory_window_alignment.py
@@ -2,6 +2,7 @@ from agent.looping.ports import MemoryConfig
 
 
 def test_memory_window_is_the_actual_even_message_limit() -> None:
+    assert MemoryConfig().keep_count == 20
     assert MemoryConfig(window=2).keep_count == 2
     assert MemoryConfig(window=6).keep_count == 6
     assert MemoryConfig(window=24).keep_count == 24


### PR DESCRIPTION
## Summary
- truncate each persisted tool result to 20,000 characters at the session persistence boundary
- keep the stricter existing 10,000-character model projection cap
- reduce the default hot memory window from 40 messages to 20

## Validation
- `2371 passed, 1 skipped`
- Pyright: 0 errors
- change Gate passed
- `programmatic_control_probe.py --gate memory-context` passed

Existing persisted history is not rewritten.