### PR TITLE
[codex] release replies after durable Akasha staging

### DIFF
--- a/docs/design/akasha-v2-runtime-migration.md
+++ b/docs/design/akasha-v2-runtime-migration.md
@@ -88,11 +88,16 @@
    正文一致，复用 query dense，只计算 assistant；否则两条正文重新 batch embed。
 4. pending ticket 仍匹配时交给 `MemoryCycle.commit`；不存在或不匹配时在最新图状态上
    重新 retrieve 后提交。
-5. commit 将当前 turn 加入稀疏索引和图，执行 Hebbian 关联、时序方向、连接预算、
-   衰减与激活恢复，再原子发布 sidecar。
+5. adapter 先把 embedding 和因果 turn 持久化到稀疏索引；这是回复终态之前的
+   durable recovery boundary。
+6. 单写者后台任务执行 `MemoryCycle.commit`，完成 Hebbian 关联、时序方向、连接
+   预算、衰减与激活恢复，再原子发布 `akasha.db`。
+7. 下一次 context/recall query 通过 publication fence 等待上一份 staged suffix
+   发布完成；后台失败时异常继续传播，不允许读取落后的图状态。
 
 这个顺序保证“检索影响回答，已完成回答影响未来检索”，不会让未落库或失败的 turn
-提前进入图。
+提前进入图。若进程在 stage 后、publish 前退出，启动恢复会从已持久化稀疏 suffix
+重放同一个 `MemoryCycle`，不需要重新调用 embedding provider。
 
 ### 4.3 显式 recall
 
@@ -273,6 +278,8 @@ Git 忽略的派生产物。镜像校验只排除这个明确命名的构建产�
 - embedding audit 失败：保留报告，不触碰现存 sidecar。
 - replay 中断：目标 staging 不发布；现存 sidecar 的时间戳备份可恢复。
 - online commit 失败：异常上抛，不能把空结果当成功；原始 session 消息仍保留。
+- staged graph publish 失败：当前回复事实与 embedding/sparse suffix 保留；下一次
+  Akasha query 和 runtime close 传播同一失败。进程重启从 suffix 确定性补齐。
 - 正式部署前：备份旧 `config.local.toml` 和 `akasha.db`，在只读快照完成全量 Gate，
   再把规范 V2 config 与已验证 sidecar 作为同一个维护操作原子切换。
 - 回滚时同时恢复旧插件代码、旧 config 和旧 sidecar；不能只切代码后继续打开另一代

--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "76c6c891769f1a8f8e1b483eabd25df956348c90",
+  "commit": "3f65eeb7f0f7f436fbdeb11b4d99ced863cfec4c",
   "source_subtree": "src/akasha",
-  "source_tree": "145a4796d4f046ccce69a115e2ceced4832f5aa4",
-  "source_sha256": "2cde44b0029f8763188f7fe1e64a05089f485d9357b29c94105475c78d83c979"
+  "source_tree": "b1dd3c4f728f7d8772312b44a9646f45bc47f0bd",
+  "source_sha256": "a94675317c7e73da42c609729a18e763a4b4c51c490e0557e35eabe33d033bae"
 }

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -34,6 +34,17 @@ class OnlineCommit:
     cycle: CycleCommit
 
 
+@dataclass(frozen=True)
+class StagedOnlineCommit:
+    """Hold one durable sparse-index suffix until graph publication."""
+
+    base_version: int
+    turns: tuple[Turn, ...]
+    user_message_id: str
+    assistant_message_id: str
+    ticket: RetrievalTicket | None
+
+
 class OnlineMemoryRuntime:
     """Serve online retrieval and persist the same state produced by replay."""
 
@@ -114,7 +125,23 @@ class OnlineMemoryRuntime:
     ) -> OnlineCommit:
         """Append canonical source turns and atomically publish their state."""
 
-        # 1. Increment the causal feature index from sessions.db.
+        staged = self.stage_from_source(
+            user_message_id=user_message_id,
+            assistant_message_id=assistant_message_id,
+            ticket=ticket,
+        )
+        return self.publish_staged(staged)
+
+    def stage_from_source(
+        self,
+        *,
+        user_message_id: str,
+        assistant_message_id: str,
+        ticket: RetrievalTicket | None,
+    ) -> StagedOnlineCommit:
+        """Persist the causal sparse suffix without publishing graph state."""
+
+        # 1. Increment the durable causal feature index from sessions.db.
         build_sparse_index(
             self.sessions_path,
             self.index_path,
@@ -126,31 +153,57 @@ class OnlineMemoryRuntime:
         turns = load_turns(self.index_path)
         if len(turns) <= self.cycle.state_version:
             raise ValueError("TurnCommitted did not append a new sparse turn")
+        suffix = tuple(turns[self.cycle.state_version :])
+        latest = suffix[-1]
+        if (
+            latest.user_message_id != user_message_id
+            or latest.assistant_message_id != assistant_message_id
+        ):
+            raise ValueError(
+                "TurnCommitted is not the latest canonical sparse turn"
+            )
+        return StagedOnlineCommit(
+            base_version=self.cycle.state_version,
+            turns=suffix,
+            user_message_id=user_message_id,
+            assistant_message_id=assistant_message_id,
+            ticket=ticket,
+        )
 
-        # 2. Apply missing source turns to an isolated candidate state.
+    def publish_staged(
+        self,
+        staged: StagedOnlineCommit,
+    ) -> OnlineCommit:
+        """Apply one staged suffix and atomically publish its graph snapshot."""
+
+        # 1. Reject overlapping writers before cloning the published state.
+        if self.cycle.state_version != staged.base_version:
+            raise RuntimeError(
+                "staged Akasha commit no longer matches published state"
+            )
         candidate = copy.deepcopy(self.cycle)
         last_commit: CycleCommit | None = None
         last_turn: Turn | None = None
-        for turn in turns[self.cycle.state_version :]:
+        for turn in staged.turns:
             selected = _matching_ticket(
                 turn,
-                user_message_id,
-                assistant_message_id,
-                ticket,
+                staged.user_message_id,
+                staged.assistant_message_id,
+                staged.ticket,
             )
             last_commit = candidate.commit(turn, selected)
             last_turn = turn
         if last_commit is None or last_turn is None:
             raise RuntimeError("online commit produced no memory event")
         if (
-            last_turn.user_message_id != user_message_id
-            or last_turn.assistant_message_id != assistant_message_id
+            last_turn.user_message_id != staged.user_message_id
+            or last_turn.assistant_message_id != staged.assistant_message_id
         ):
             raise ValueError(
                 "TurnCommitted is not the latest canonical sparse turn"
             )
 
-        # 3. Publish one complete SQLite snapshot before adopting memory state.
+        # 2. Publish one complete SQLite snapshot before adopting memory state.
         if candidate.context is None:
             raise RuntimeError("committed memory state has no context")
         write_memory_database(

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import threading
@@ -34,7 +35,7 @@ from memory2.embedder import Embedder
 from session.embedding_store import MessageEmbeddingStore
 
 from .application.cycle import RetrievalTicket
-from .application.runtime import OnlineMemoryRuntime
+from .application.runtime import OnlineMemoryRuntime, StagedOnlineCommit
 from .config import AkashaConfig, resolve_workspace_path
 from .domain.model import Turn
 
@@ -145,11 +146,14 @@ class AkashaMemoryEngine:
 
         # 2. Keep one global graph writer and one pending query per session.
         self._lock = threading.RLock()
+        self._commit_gate = asyncio.Lock()
+        self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
         self.closeables: list[object] = [
             self._runtime,
             self._embedding_store,
             self._embedder,
+            self,
         ]
         if event_publisher is not None:
             self.closeables.append(
@@ -190,36 +194,38 @@ class AkashaMemoryEngine:
             if value is not None and value.tzinfo is None:
                 raise ValueError(f"Akasha {name} must be timezone-aware")
 
-        # 2. Embed the cue and run a non-mutating shared MemoryCycle read.
+        # 2. Embed without blocking commits, then fence the shared graph read.
         dense = np.asarray(
             await self._embedder.embed(text),
             dtype=np.float32,
         )
-        with self._lock:
-            cue, ticket = self._runtime.query_turn(
-                text=text,
-                dense=dense,
-                session_key=request.scope.session_key,
-                timestamp=request.timestamp,
-            )
-            lanes = self._records(ticket, cue, request)
-            retains_ticket = (
-                request.intent == "context"
-                and request.effect == "stateful"
-                and bool(request.scope.session_key)
-            )
-            if retains_ticket:
-                session_key = request.scope.session_key
-                if not session_key:
-                    raise RuntimeError(
-                        "stateful context query lost its session key"
-                    )
-                self._pending[session_key] = PendingRetrieval(
-                    ticket,
-                    request.timestamp,
-                    text,
-                    dense.copy(),
+        async with self._commit_gate:
+            await self._wait_for_publication()
+            with self._lock:
+                cue, ticket = self._runtime.query_turn(
+                    text=text,
+                    dense=dense,
+                    session_key=request.scope.session_key,
+                    timestamp=request.timestamp,
                 )
+                lanes = self._records(ticket, cue, request)
+                retains_ticket = (
+                    request.intent == "context"
+                    and request.effect == "stateful"
+                    and bool(request.scope.session_key)
+                )
+                if retains_ticket:
+                    session_key = request.scope.session_key
+                    if not session_key:
+                        raise RuntimeError(
+                            "stateful context query lost its session key"
+                        )
+                    self._pending[session_key] = PendingRetrieval(
+                        ticket,
+                        request.timestamp,
+                        text,
+                        dense.copy(),
+                    )
         # 3. Render context only for the runtime context-injection intent.
         text_block = (
             self._context_block(lanes, request.timestamp)
@@ -451,7 +457,7 @@ class AkashaMemoryEngine:
         )[:top_k]
 
     async def _on_turn_committed(self, event: TurnCommitted) -> None:
-        """Persist embeddings and apply one canonical MemoryCycle commit."""
+        """Stage one committed turn and publish its graph asynchronously."""
 
         # 1. Respect the host's explicit exclusion and validate stable IDs.
         if (
@@ -468,7 +474,7 @@ class AkashaMemoryEngine:
                 "TurnCommitted requires persisted user and assistant IDs"
             )
 
-        # 2. Embed exact persisted text and update the canonical embedding cache.
+        # 2. Embed exact persisted text without blocking other provider calls.
         messages = _load_messages(
             self._sessions_path,
             event.session_key,
@@ -499,15 +505,42 @@ class AkashaMemoryEngine:
             vectors,
         )
 
-        # 3. Commit the matching ticket or recompute on the latest state.
-        with self._lock:
-            if self._pending.get(event.session_key) is pending:
-                self._pending.pop(event.session_key, None)
-            self._runtime.commit_from_source(
-                user_message_id=user_id,
-                assistant_message_id=assistant_id,
-                ticket=None if pending is None else pending.ticket,
+        # 3. Serialize durable staging behind the prior graph publication.
+        async with self._commit_gate:
+            await self._wait_for_publication()
+            with self._lock:
+                if self._pending.get(event.session_key) is pending:
+                    self._pending.pop(event.session_key, None)
+                staged = self._runtime.stage_from_source(
+                    user_message_id=user_id,
+                    assistant_message_id=assistant_id,
+                    ticket=None if pending is None else pending.ticket,
+                )
+            self._publish_task = asyncio.create_task(
+                asyncio.to_thread(self._publish_staged, staged),
+                name="akasha-publish-staged",
             )
+
+    async def aclose(self) -> None:
+        """Drain a staged graph publication before closing owned resources."""
+
+        await self._wait_for_publication()
+
+    async def _wait_for_publication(self) -> None:
+        """Wait for the current graph snapshot and preserve its failure."""
+
+        task = self._publish_task
+        if task is None:
+            return
+        await asyncio.shield(task)
+        if self._publish_task is task:
+            self._publish_task = None
+
+    def _publish_staged(self, staged: StagedOnlineCommit) -> None:
+        """Publish one staged suffix under the shared runtime lock."""
+
+        with self._lock:
+            self._runtime.publish_staged(staged)
 
     def _records(
         self,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import sqlite3
+import threading
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -111,6 +113,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
             started=started,
         )
     )
+    await engine._wait_for_publication()  # noqa: SLF001
     assert engine._runtime.cycle.state_version == 1  # noqa: SLF001
 
     # 3. Explicit recall is read-only and cannot replace context learning.
@@ -191,6 +194,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
             started=next_time,
         )
     )
+    await engine._wait_for_publication()  # noqa: SLF001
     replay = tmp_path / "memory" / "replay.db"
     rebuild_memory(
         tmp_path / "memory" / "akasha-v2-index.db",
@@ -290,6 +294,77 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert len(cast(list[object], mobile["tool_right"])) == 1
     assert recent["total"] == 2
     assert mobile_detail["query_text"] == "alpha follow"
+    _close_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_turn_commit_returns_before_graph_publish_and_fences_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release the host turn after durable staging while fencing the next read."""
+
+    # 1. Block only graph publication after the source and embedding are durable.
+    _create_sessions(tmp_path / "sessions.db")
+    monkeypatch.setattr("plugins.akasha.engine.Embedder", _Embedder)
+    engine = _engine(tmp_path)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    _append_turn(
+        tmp_path / "sessions.db",
+        sequence=0,
+        user="alpha start",
+        assistant="first answer",
+        started=started,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    publish = engine._runtime.publish_staged  # noqa: SLF001
+
+    def blocked_publish(staged: object) -> object:
+        entered.set()
+        if not release.wait(timeout=5):
+            raise TimeoutError("test graph publication was not released")
+        return publish(cast(Any, staged))
+
+    monkeypatch.setattr(
+        engine._runtime,  # noqa: SLF001
+        "publish_staged",
+        blocked_publish,
+    )
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=0,
+            user="alpha start",
+            assistant="first answer",
+            started=started,
+        )
+    )
+    assert await asyncio.to_thread(entered.wait, 1)
+    assert engine._runtime.cycle.state_version == 0  # noqa: SLF001
+    with closing(
+        sqlite3.connect(tmp_path / "memory" / "akasha-v2-index.db")
+    ) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sparse_turns"
+        ).fetchone() == (1,)
+
+    # 2. The next query waits until the staged graph becomes visible.
+    query = asyncio.create_task(
+        engine.query(
+            _query(
+                "alpha follow",
+                started + timedelta(minutes=5),
+                intent="context",
+            )
+        )
+    )
+    await asyncio.sleep(0)
+    assert not query.done()
+    release.set()
+    result = await query
+
+    assert engine._runtime.cycle.state_version == 1  # noqa: SLF001
+    assert result.trace["state_version"] == 1
     _close_engine(engine)
 
 


### PR DESCRIPTION
## Prerequisite

- kachofugetsu09/akasha-v2-engine#4 — merged; pinned source commit `3f65eeb7f0f7f436fbdeb11b4d99ced863cfec4c`

## What changed

- Mirror the staged-publication Akasha runtime from the canonical engine repository.
- Return from `TurnCommitted` after embeddings and the recoverable sparse index are durable.
- Publish the expensive graph snapshot in a background task.
- Fence subsequent Akasha context/recall queries behind the pending publication.
- Update the pinned upstream commit, tree, and SHA-256 metadata.

## Why

The server emitted `message.final` only after synchronous Akasha graph publication. Runtime traces showed meme/citation postprocessing finishing in milliseconds, while the Akasha post-turn hook added roughly 13–22 seconds. Mobile therefore kept offering Stop after the visible reply was already complete.

This moves only the durable graph publication off the response-critical path; meme, citation, attachment, embedding, and recovery-input processing remain before finalization.

## Behavior change

- `message.final` now means the reply and Akasha recovery input are durable; the graph file may still be publishing.
- Runtime Akasha queries wait for publication, so the next context/recall does not read stale state.
- Direct inspection of `akasha.db` can briefly observe the previous published snapshot.
- Publication failures surface on the next Akasha query or graceful shutdown.

No Android or mobile WebView change is required.

## Validation

- Relevant core suites: `82 passed`
- Public change-impact Gate: passed, report `docker/debug/reports/change-gate/20260728-231110-38dfd4d6`
- Private gate: required by catalog, not available in this environment
- Upstream host contract checker: passed
- Upstream host behavior checker: passed
- Mirror commit/tree/SHA-256 check: passed
- Read-only sealed-snapshot A/B: old synchronous commit and new stage+publish produced the same canonical logical SQLite hash

## Rollback

Revert this PR and restart the runtime. That restores synchronous graph publication before `message.final`; persisted index and graph formats remain compatible.