### PR TITLE
[codex] remove full Akasha SQLite integrity scans

### DIFF
--- a/docs/design/akasha-v2-runtime-migration.md
+++ b/docs/design/akasha-v2-runtime-migration.md
@@ -90,6 +90,8 @@
    重新 retrieve 后提交。
 5. adapter 先把 embedding 和因果 turn 持久化到稀疏索引；这是回复终态之前的
    durable recovery boundary。
+   在线加载不执行全库 `PRAGMA integrity_check`；只保留 schema、版本、稳定
+   message ID、快照身份、外键与向量形状校验，SQLite 读取错误继续直接传播。
 6. 单写者后台任务执行 `MemoryCycle.commit`，完成 Hebbian 关联、时序方向、连接
    预算、衰减与激活恢复，再原子发布 `akasha.db`。
 7. 下一次 context/recall query 通过 publication fence 等待上一份 staged suffix

--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "3f65eeb7f0f7f436fbdeb11b4d99ced863cfec4c",
+  "commit": "47c22896bf9dde454a9458622d6292565d392490",
   "source_subtree": "src/akasha",
-  "source_tree": "b1dd3c4f728f7d8772312b44a9646f45bc47f0bd",
-  "source_sha256": "a94675317c7e73da42c609729a18e763a4b4c51c490e0557e35eabe33d033bae"
+  "source_tree": "358d983af4987ff4d0a685481c106682a54ffe4b",
+  "source_sha256": "e824bf056f4fad0db937e970f6ed91ac09b52c013386662cbebe0643af5637d7"
 }

--- a/plugins/akasha/infrastructure/loader.py
+++ b/plugins/akasha/infrastructure/loader.py
@@ -46,9 +46,6 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
 def _validate_index(connection: sqlite3.Connection) -> None:
     """Validate the read-only sparse-index trust boundary."""
 
-    integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
-    if integrity != "ok":
-        raise sqlite3.DatabaseError(integrity)
     required = {"sparse_turns", "turn_dense", "turn_terms"}
     actual = {
         row[0]

--- a/plugins/akasha/infrastructure/persistence.py
+++ b/plugins/akasha/infrastructure/persistence.py
@@ -562,9 +562,6 @@ def _verify(connection: sqlite3.Connection) -> None:
     violations = connection.execute("PRAGMA foreign_key_check").fetchall()
     if violations:
         raise sqlite3.IntegrityError(f"foreign key violations: {violations[:3]}")
-    integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
-    if integrity != "ok":
-        raise sqlite3.DatabaseError(integrity)
 
 
 def _validate_snapshot_identity(


### PR DESCRIPTION
## Prerequisite

- kachofugetsu09/akasha-v2-engine#5 — merged
- Pinned canonical source commit: `47c22896bf9dde454a9458622d6292565d392490`

## What changed

- Mirror the canonical removal of every Akasha `PRAGMA integrity_check`.
- Keep schema, version, stable message ID, snapshot identity, foreign-key, and vector-shape checks.
- Update immutable upstream commit/tree/content-digest metadata.
- Document that online loading no longer performs proactive whole-database scans.

## Why

A full integrity scan of the 326 MB derived sparse index ran in the `TurnCommitted` path before `message.final`. The scan is not part of Akasha learning semantics and took about 3.54 seconds even with a warm cache, contributing substantially more after restart.

## Behavior change

Physical SQLite corruption that does not affect the pages read by the current operation may be detected later. SQLite read failures and all explicit Akasha invariants still fail loud. Database formats, learning, recall, recovery staging, meme, and citation behavior are unchanged.

## Validation

- Canonical upstream suite: `36 passed`
- Relevant host suites: `83 passed`
- Upstream host contract checker: passed
- Upstream host behavior checker: passed
- Mirror checker: 31 files, exact commit/tree/digest
- Public Change Gate: passed, report `docker/debug/reports/change-gate/20260728-233147-0260474e`
- Private gate: required by catalog, not available in this environment
- Live 326 MB index, read-only post-change `load_turns`: about 1.37 seconds

## Rollback

Revert this PR and restart the runtime. No database migration or state replacement is required.