### PR TITLE
feat(plugins): publish Runtime API v2 atomically

### DIFF
--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class Plugin(ABC):
-    api_version: int = 1
+    api_version: int = 2
     name: str | None = None
     version: str | None = None
     desc: str | None = None
@@ -32,8 +32,17 @@ class Plugin(ABC):
         from agent.plugins.registry import plugin_registry
         plugin_registry.register_class(cls)
 
-    async def initialize(self) -> None: ...
-    async def terminate(self) -> None: ...
+    async def prepare(self) -> None:
+        return None
+
+    def activate(self) -> None:
+        return None
+
+    def retire(self) -> None:
+        return None
+
+    async def terminate(self) -> None:
+        return None
 
     def static_semantic_checks(self) -> list["PluginSemanticCheck"]:
         return []

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
-from collections.abc import Coroutine
-from dataclasses import dataclass
+from collections.abc import Callable, Coroutine, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from infra.persistence.json_store import atomic_save_json, load_json
 
 T = TypeVar("T")
+_CLEANUP_WRITER_ID: ContextVar[str] = ContextVar(
+    "plugin_cleanup_writer_id",
+    default="",
+)
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -33,6 +39,10 @@ class PluginContext:
     llm: "PluginLlmService | None" = None
     scope: "PluginScope | None" = None
     generation_id: str = ""
+    _can_start_tasks: Callable[[], bool] | None = field(
+        default=None,
+        repr=False,
+    )
 
     def create_task(
         self,
@@ -42,6 +52,9 @@ class PluginContext:
     ) -> asyncio.Task[T]:
         if self.scope is None:
             raise RuntimeError(f"插件缺少资源作用域: {self.plugin_id}")
+        if self._can_start_tasks is None or not self._can_start_tasks():
+            coroutine.close()
+            raise RuntimeError("prepare 阶段禁止启动后台任务")
         return self.scope.create_task(coroutine, name=name)
 
     def defer(self, resource: str, cleanup: "Cleanup") -> None:
@@ -61,10 +74,30 @@ class PluginContext:
         self.scope.track_process(process, name=name, timeout=timeout)
 
 
+@contextmanager
+def allow_plugin_cleanup_writes(writer_id: str) -> Iterator[None]:
+    """只允许当前清理 task 使用指定 generation 的 KV writer。"""
+
+    token = _CLEANUP_WRITER_ID.set(writer_id)
+    try:
+        yield
+    finally:
+        _CLEANUP_WRITER_ID.reset(token)
+
+
 class PluginKVStore:
-    def __init__(self, path: Path, *, writable: bool = True) -> None:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        writable: bool = True,
+        can_write: Callable[[], bool] | None = None,
+        writer_id: str = "",
+    ) -> None:
         self._path = path
         self._writable = writable
+        self._can_write = can_write
+        self._writer_id = writer_id
 
     def get(self, key: str, default: Any = None) -> Any:
         return self._read().get(key, default)
@@ -104,3 +137,55 @@ class PluginKVStore:
     def _require_writable(self) -> None:
         if not self._writable:
             raise RuntimeError("候选声明阶段禁止写入插件 KV")
+        cleanup_write = _CLEANUP_WRITER_ID.get() == self._writer_id
+        if self._can_write is not None and not self._can_write() and not cleanup_write:
+            raise RuntimeError(
+                f"已退役 generation 禁止写入插件 KV: {self._writer_id}"
+            )
+
+
+class PreparedPluginKVStore(PluginKVStore):
+    """Stage candidate KV changes until the generation is committed."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        can_write: Callable[[], bool],
+        writer_id: str,
+    ) -> None:
+        super().__init__(
+            path,
+            can_write=can_write,
+            writer_id=writer_id,
+        )
+        self._prepared_data = super()._read()
+        self._is_committed = False
+        self._is_dirty = False
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if self._is_committed:
+            return super().get(key, default)
+        return self._prepared_data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        if self._is_committed:
+            super().set(key, value)
+            return
+        self._prepared_data[key] = value
+        self._is_dirty = True
+
+    def increment(self, key: str, delta: int = 1) -> int:
+        if self._is_committed:
+            return super().increment(key, delta)
+        new_value = int(self._prepared_data.get(key, 0)) + delta
+        self._prepared_data[key] = new_value
+        self._is_dirty = True
+        return new_value
+
+    def commit(self) -> None:
+        if self._is_committed:
+            return
+        if self._is_dirty:
+            super()._write(self._prepared_data)
+        self._is_committed = True

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -95,6 +95,7 @@ class PluginGeneration:
     module_path: str
     source_revision: str
     config_revision: str
+    data_dir: Path
     instance: object
     scope: PluginScope
     contributions: PluginContributions
@@ -105,7 +106,9 @@ class PluginGeneration:
     proactive_catalog: PreparedProactiveCatalog | None = None
     runtime_snapshot: RuntimeSnapshot | None = None
     staged_event_bus: ScopedEventBus | None = None
-    initialization_started: bool = False
+    prepare_started: bool = False
+    retire_started: bool = False
     minimum_resource_count: int = 0
     state: str = "active"
     lease_count: int = 0
+    reload_tx_id: str | None = None

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -70,6 +70,7 @@ from agent.plugins.generation import (
     PluginSemanticCheck,
 )
 from agent.plugins.importer import FreshPluginImporter
+from agent.plugins.reload_journal import ReloadJournal, ReloadPhase
 from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
 from agent.mcp.generation import WorkspaceMcpGeneration
 from agent.mcp.host import McpGenerationHost, PreparedMcpCatalog
@@ -83,6 +84,7 @@ from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotCompiler,
     RuntimeSnapshotStore,
+    get_current_runtime_snapshot,
     plugin_is_active,
 )
 from proactive_v2.lifecycle import ProactiveLifecycleSpec
@@ -94,6 +96,16 @@ from infra.channels.contract import Channel
 
 logger = logging.getLogger(__name__)
 U = TypeVar("U")
+
+
+def _generation_can_write(generation: PluginGeneration) -> bool:
+    if generation.state in {"activating", "active"}:
+        return True
+    snapshot = get_current_runtime_snapshot()
+    return (
+        snapshot is not None
+        and snapshot.generations.get(generation.plugin_id) is generation
+    )
 
 
 def _package_project_root(plugin_dirs: list[Path]) -> Path | None:
@@ -226,6 +238,9 @@ class PluginManager:
         self._snapshot_compiler = RuntimeSnapshotCompiler()
         self._snapshot_store = RuntimeSnapshotStore(self._on_snapshot_drained)
         self._snapshot_skill_catalogs: dict[str, str] = {}
+        self._reload_journal = ReloadJournal(workspace)
+        self._drain_transactions: dict[str, str] = {}
+        self._drained_before_journal: set[str] = set()
         self._event_bus.bind_runtime_snapshot_store(self._snapshot_store)
 
     @property
@@ -234,62 +249,92 @@ class PluginManager:
 
     @property
     def tool_hooks(self) -> list[ToolHook]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.tool_hooks)
         return list(self._tool_hooks)
 
     @property
     def channels(self) -> list[Channel]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.channels.values())
         return list(self._channels)
 
     @property
     def before_turn_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.before_turn_modules)
         return list(self._before_turn_modules)
 
     @property
     def before_reasoning_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.before_reasoning_modules)
         return list(self._before_reasoning_modules)
 
     @property
     def prompt_render_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.prompt_render_modules)
         return list(self._prompt_render_modules)
 
     @property
     def before_step_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.before_step_modules)
         return list(self._before_step_modules)
 
     @property
     def after_step_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.after_step_modules)
         return list(self._after_step_modules)
 
     @property
     def after_reasoning_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.after_reasoning_modules)
         return list(self._after_reasoning_modules)
 
     @property
     def after_turn_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.after_turn_modules)
         return list(self._after_turn_modules)
 
     @property
     def proactive_modules(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.proactive_modules)
         return list(self._proactive_modules)
 
     @property
     def proactive_lifecycles(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.proactive_lifecycles)
         return list(self._proactive_lifecycles)
 
     @property
     def proactive_module_factories(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.proactive_module_factories)
         return list(self._proactive_module_factories)
 
     @property
     def proactive_runtime_factories(self) -> list[object]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.proactive_runtime_factories)
         return list(self._proactive_runtime_factories)
 
     @property
     def proactive_sources(self) -> list[RegisteredProactiveSource]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.proactive_sources.values())
         return list(self._proactive_sources)
 
     @property
     def jobs(self) -> list[RegisteredPluginJob]:
+        if self.current_snapshot is not None:
+            return list(self.current_snapshot.jobs.values())
         return list(self._jobs)
 
     @property
@@ -545,6 +590,10 @@ class PluginManager:
     def snapshot_store(self) -> RuntimeSnapshotStore:
         return self._snapshot_store
 
+    @property
+    def reload_journal(self) -> ReloadJournal:
+        return self._reload_journal
+
     def sync_manifest(self, *, plugins_home: Path | None = None) -> Path:
         entries = load_plugin_manifest(plugins_home)
         project_root = _package_project_root(self._dirs)
@@ -665,8 +714,42 @@ class PluginManager:
         return mods
 
     async def load_all(self) -> None:
-        for mod in self.discover():
+        discovered = tuple(self.discover())
+        discovered_by_id = {
+            _resolve_plugin_id(mod): mod
+            for mod in discovered
+        }
+        recovery = self._reload_journal.pending_recovery()
+        for action in recovery:
+            if action.action != "restore_committed":
+                continue
+            mod = discovered_by_id.get(action.plugin_id)
+            if mod is None:
+                raise RuntimeError(
+                    f"ReloadTransaction 恢复缺少插件: {action.plugin_id}"
+                )
+            source_revision = _source_revision(Path(mod["plugin_root"]))
+            if source_revision != action.source_revision:
+                raise RuntimeError(
+                    "ReloadTransaction 恢复源码不一致: "
+                    f"{action.plugin_id} expected={action.source_revision} "
+                    f"actual={source_revision}"
+                )
+        for action in recovery:
+            if action.action == "discard_candidate":
+                self._reload_journal.finish_recovery(action)
+        for mod in discovered:
             _ = await self._load_one(mod)
+        for action in recovery:
+            if action.action != "restore_committed":
+                continue
+            generation = self._active_generations.get(action.plugin_id)
+            if generation is None:
+                raise RuntimeError(
+                    f"ReloadTransaction 恢复缺少插件: {action.plugin_id}"
+                )
+            assert generation.source_revision == action.source_revision
+            self._reload_journal.finish_recovery(action)
 
     async def prepare_candidate(self, plugin_id: str) -> PluginGeneration | None:
         await self.discard_prepared(plugin_id)
@@ -679,6 +762,7 @@ class PluginManager:
         generation = self._prepared_generations.pop(plugin_id, None)
         if generation is None:
             return
+        self._abort_reload(generation, error="candidate discarded")
         await self._dispose_generation(generation, state="discarded")
 
     async def _dispose_generation(
@@ -690,15 +774,18 @@ class PluginManager:
     ) -> None:
         """完成插件终止、作用域清理和注册表卸载。"""
 
+        from agent.plugins.context import allow_plugin_cleanup_writes
+
         # 1. 终止生命周期对象，并在调用方取消后继续完成它
         externally_cancelled = False
-        if generation.initialization_started:
+        if generation.prepare_started:
             terminator = getattr(generation.instance, "terminate", None)
             if callable(terminator):
                 try:
-                    _, terminator_cancelled = await _complete_critical(
-                        cast(Callable[[], Awaitable[None]], terminator)()
-                    )
+                    with allow_plugin_cleanup_writes(generation.generation_id):
+                        _, terminator_cancelled = await _complete_critical(
+                            cast(Callable[[], Awaitable[None]], terminator)()
+                        )
                     externally_cancelled = terminator_cancelled
                 except (asyncio.CancelledError, Exception) as error:
                     current = asyncio.current_task()
@@ -713,9 +800,10 @@ class PluginManager:
                     )
 
         # 2. 收集作用域失败，确保外部取消不会截断资源清理
-        cleanup_failures, cleanup_cancelled = await _complete_critical(
-            generation.scope.aclose()
-        )
+        with allow_plugin_cleanup_writes(generation.generation_id):
+            cleanup_failures, cleanup_cancelled = await _complete_critical(
+                generation.scope.aclose()
+            )
         self._cleanup_failures.extend(cleanup_failures)
         externally_cancelled = externally_cancelled or cleanup_cancelled
 
@@ -741,6 +829,29 @@ class PluginManager:
         generation.state = state
         if externally_cancelled:
             raise asyncio.CancelledError
+
+    def _retire_generation(self, generation: PluginGeneration) -> None:
+        """通知已关闭 admission 的 generation 进入退役状态。"""
+
+        if generation.retire_started:
+            return
+        generation.retire_started = True
+        generation.state = "retired"
+        try:
+            cast(Any, generation.instance).retire()
+        except Exception as error:
+            error_text = str(error) or type(error).__name__
+            logger.warning(
+                "插件 retire 失败 (%s): %s",
+                generation.plugin_id,
+                error_text,
+            )
+            self._cleanup_failures.append(
+                CleanupFailure(
+                    resource=f"plugin:{generation.plugin_id}:retire",
+                    error=error_text,
+                )
+            )
 
     async def _on_snapshot_drained(self, snapshot: RuntimeSnapshot) -> None:
         catalog_id = self._snapshot_skill_catalogs.pop(snapshot.snapshot_id, None)
@@ -775,6 +886,7 @@ class PluginManager:
             )
         ):
             await self._dispose_workspace_mcp(workspace_mcp, state=state)
+        self._finish_drained_reload(snapshot.snapshot_id)
 
     async def _dispose_workspace_mcp(
         self,
@@ -796,6 +908,7 @@ class PluginManager:
 
     async def reconcile_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
+            await self._snapshot_store.retry_drains()
             results: list[dict[str, object]] = []
             discovered = {
                 _resolve_plugin_id(mod): mod
@@ -909,7 +1022,7 @@ class PluginManager:
                     )
                 except BaseException as error:
                     endpoint_error = error
-            if transaction is not None and self._snapshot_store.current is snapshot:
+            if transaction is not None:
                 await self._snapshot_store.abort(transaction)
             else:
                 await self._snapshot_store.resume(quiesced)
@@ -926,7 +1039,10 @@ class PluginManager:
         try:
             assert transaction is not None
             _, commit_cancelled = await _complete_critical(
-                self._snapshot_store.commit(transaction)
+                self._snapshot_store.commit(
+                    transaction,
+                    after_open=lambda: self._retire_generation(active),
+                )
             )
         except BaseException as error:
             commit_error = error
@@ -1068,12 +1184,12 @@ class PluginManager:
             raise
         active = self._active_generations.get(plugin_id)
         try:
-            await self._initialize_prepared_generation(generation)
+            await self._prepare_generation(generation)
         except (asyncio.CancelledError, Exception) as error:
             self._record_failed_gate(
                 plugin_id=plugin_id,
                 revision=generation.source_revision,
-                check_id="initialize",
+                check_id="prepare",
                 reason=str(error) or type(error).__name__,
             )
             await self.discard_prepared(plugin_id)
@@ -1170,11 +1286,14 @@ class PluginManager:
                     candidate=generation,
                     publication_state="failed",
                 )
-        if generation.staged_event_bus is not None:
-            generation.staged_event_bus.publish()
         transaction = self._snapshot_store.begin_publish(
             snapshot,
             admission_gated=quiesced_snapshot is not None,
+        )
+        self._advance_reload(
+            generation,
+            "validating",
+            candidate_snapshot_id=snapshot.snapshot_id,
         )
         try:
             await asyncio.wait_for(
@@ -1197,6 +1316,10 @@ class PluginManager:
                 except BaseException as error:
                     endpoint_error = error
             await self._snapshot_store.abort(transaction)
+            self._abort_reload(
+                generation,
+                error="post-publish invariant failed",
+            )
             if self._endpoint_resumer is not None:
                 await self._endpoint_resumer()
             if endpoint_error is not None:
@@ -1205,13 +1328,84 @@ class PluginManager:
 
         commit_error: BaseException | None = None
         commit_cancelled = False
+        from agent.plugins.context import PreparedPluginKVStore
+
+        def open_candidate() -> None:
+            self._advance_reload(generation, "commit_started")
+            context = cast(Any, generation.instance).context
+            context.data_dir = generation.data_dir
+            context.session_manager = self._session_manager
+            context.memory_engine = self._memory_engine
+            context.llm = self._llm
+            generation.state = "activating"
+            try:
+                cast(Any, generation.instance).activate()
+            except BaseException:
+                context.data_dir = None
+                raise
+            if isinstance(context.kv_store, PreparedPluginKVStore):
+                context.kv_store.commit()
+            if generation.staged_event_bus is not None:
+                generation.staged_event_bus.publish()
+            generation.state = "active"
+
+        previous_snapshot = transaction.previous
+        if generation.reload_tx_id is not None and previous_snapshot is not None:
+            self._drain_transactions[previous_snapshot.snapshot_id] = (
+                generation.reload_tx_id
+            )
         try:
             _, commit_cancelled = await _complete_critical(
-                self._snapshot_store.commit(transaction)
+                self._snapshot_store.commit(
+                    transaction,
+                    before_open=open_candidate,
+                    after_open=(
+                        None
+                        if active is None
+                        else lambda: self._retire_generation(active)
+                    ),
+                )
             )
         except BaseException as error:
             commit_error = error
 
+        if (
+            commit_error is not None
+            and self._snapshot_store.pending_candidate is snapshot
+        ):
+            if previous_snapshot is not None:
+                _ = self._drain_transactions.pop(
+                    previous_snapshot.snapshot_id,
+                    None,
+                )
+            _ = self._prepared_generations.pop(plugin_id, None)
+            generation.state = "aborted"
+            endpoint_error: BaseException | None = None
+            if endpoints_switched:
+                try:
+                    await self._switch_plugin_endpoints(
+                        plugin_id,
+                        new_services,
+                        old_services,
+                        new_channels,
+                        old_channels,
+                    )
+                except BaseException as error:
+                    endpoint_error = error
+            await self._snapshot_store.abort(transaction)
+            self._abort_reload(
+                generation,
+                error=str(commit_error) or type(commit_error).__name__,
+            )
+            if self._endpoint_resumer is not None:
+                await self._endpoint_resumer()
+            if endpoint_error is not None:
+                raise RuntimeError(
+                    "Snapshot commit 失败后旧端点恢复失败"
+                ) from endpoint_error
+            raise commit_error
+
+        self._track_reload_drain(generation, previous_snapshot)
         _ = self._prepared_generations.pop(plugin_id)
         self._scopes[generation.module_path] = generation.scope
         self._loaded.add(generation.module_path)
@@ -1282,13 +1476,13 @@ class PluginManager:
         plugin_registry.register_instance(stable_alias, generation.instance)
         sys.modules[stable_alias] = sys.modules[generation.module_path]
 
-    async def _initialize_prepared_generation(
+    async def _prepare_generation(
         self,
         generation: PluginGeneration,
     ) -> None:
-        if generation.initialization_started:
+        if generation.prepare_started:
             return
-        from agent.plugins.context import PluginKVStore
+        from agent.plugins.context import PreparedPluginKVStore
 
         instance = cast(Any, generation.instance)
         context = instance.context
@@ -1299,14 +1493,19 @@ class PluginManager:
         )
         generation.staged_event_bus = staged_event_bus
         context.event_bus = staged_event_bus
-        context.kv_store = PluginKVStore(context.data_dir / ".kv.json")
-        context.session_manager = self._session_manager
-        context.memory_engine = self._memory_engine
-        context.llm = self._llm
+        context.kv_store = PreparedPluginKVStore(
+            generation.data_dir / ".kv.json",
+            can_write=lambda: _generation_can_write(generation),
+            writer_id=generation.generation_id,
+        )
+        context._can_start_tasks = lambda: generation.state in {
+            "activating",
+            "active",
+        }
         context.scope = generation.scope
         context.tool_registry = generation.runtime_snapshot.tool_registry
-        generation.initialization_started = True
-        await instance.initialize()
+        generation.prepare_started = True
+        await instance.prepare()
         generation.minimum_resource_count = generation.scope.resource_count
 
     def _compile_snapshot_event_handlers(self, snapshot: RuntimeSnapshot) -> None:
@@ -1349,8 +1548,14 @@ class PluginManager:
         snapshot: RuntimeSnapshot,
     ) -> None:
         await asyncio.sleep(0)
-        if self.current_snapshot is not snapshot:
-            raise RuntimeError("RuntimeSnapshot 发布指针不一致")
+        if snapshot.state == "committed":
+            if self.current_snapshot is not snapshot:
+                raise RuntimeError("RuntimeSnapshot 已提交指针不一致")
+        elif (
+            snapshot.state != "validating"
+            or self._snapshot_store.pending_candidate is not snapshot
+        ):
+            raise RuntimeError("RuntimeSnapshot 候选事务不一致")
         catalog_id = snapshot.skill_catalog_generation_id
         if catalog_id is not None and self._skill_host.get(catalog_id) is None:
             raise RuntimeError("RuntimeSnapshot skill catalog 不可用")
@@ -1378,6 +1583,82 @@ class PluginManager:
                 item.generation_id
             ) is not item.proactive_catalog:
                 raise RuntimeError("RuntimeSnapshot proactive catalog 不可用")
+
+    def _begin_reload(self, generation: PluginGeneration) -> None:
+        base = self.current_snapshot
+        generation.reload_tx_id = self._reload_journal.begin(
+            plugin_id=generation.plugin_id,
+            base_snapshot_id=base.snapshot_id if base is not None else None,
+            generation_id=generation.generation_id,
+            source_revision=generation.source_revision,
+            config_revision=generation.config_revision,
+        )
+
+    def _advance_reload(
+        self,
+        generation: PluginGeneration,
+        phase: ReloadPhase,
+        *,
+        candidate_snapshot_id: str | None = None,
+        error: str = "",
+    ) -> None:
+        tx_id = generation.reload_tx_id
+        if tx_id is None:
+            return
+        self._reload_journal.advance(
+            tx_id,
+            phase,
+            candidate_snapshot_id=candidate_snapshot_id,
+            error=error,
+        )
+
+    def _abort_reload(
+        self,
+        generation: PluginGeneration,
+        *,
+        error: str,
+    ) -> None:
+        tx_id = generation.reload_tx_id
+        if tx_id is None:
+            return
+        phase = self._reload_journal.get(tx_id).phase
+        if phase in {"complete", "aborted", "recovered"}:
+            return
+        self._advance_reload(generation, "aborted", error=error)
+
+    def _track_reload_drain(
+        self,
+        generation: PluginGeneration,
+        previous_snapshot: RuntimeSnapshot | None,
+    ) -> None:
+        tx_id = generation.reload_tx_id
+        if tx_id is None:
+            return
+        self._advance_reload(generation, "committed")
+        if previous_snapshot is None:
+            self._advance_reload(generation, "complete")
+            return
+        snapshot_id = previous_snapshot.snapshot_id
+        if snapshot_id in self._drained_before_journal:
+            self._drained_before_journal.remove(snapshot_id)
+            self._advance_reload(generation, "complete")
+            return
+        self._advance_reload(generation, "draining")
+        self._drain_transactions[snapshot_id] = tx_id
+
+    def _finish_drained_reload(self, snapshot_id: str) -> None:
+        tx_id = self._drain_transactions.pop(snapshot_id, None)
+        if tx_id is None:
+            return
+        record = self._reload_journal.get(tx_id)
+        if record.phase == "commit_started":
+            self._drained_before_journal.add(snapshot_id)
+            return
+        if record.phase == "committed":
+            self._reload_journal.advance(tx_id, "draining")
+            record = self._reload_journal.get(tx_id)
+        if record.phase == "draining":
+            self._reload_journal.advance(tx_id, "complete")
 
     def _publication_status(
         self,
@@ -1661,7 +1942,7 @@ class PluginManager:
             tool_registry=None,
             plugin_id=plugin_id,
             plugin_dir=plugin_dir,
-            data_dir=data_dir,
+            data_dir=None,
             kv_store=PluginKVStore(data_dir / ".kv.json", writable=False),
             config=plugin_config,
             workspace=self._workspace,
@@ -1672,11 +1953,20 @@ class PluginManager:
             generation_id=generation_id,
         )
         plugin_registry.register_instance(mp, instance)
-        initialization_started = False
+        prepare_started = False
+        reload_tx_id: str | None = None
 
         async def rollback_load() -> None:
+            if reload_tx_id is not None:
+                phase = self._reload_journal.get(reload_tx_id).phase
+                if phase not in {"complete", "aborted", "recovered"}:
+                    self._reload_journal.advance(
+                        reload_tx_id,
+                        "aborted",
+                        error=f"candidate {load_phase} failed",
+                    )
             terminator = getattr(instance, "terminate", None)
-            if initialization_started and callable(terminator):
+            if prepare_started and callable(terminator):
                 try:
                     typed_terminator = cast(
                         Callable[[], Awaitable[None]],
@@ -1736,12 +2026,16 @@ class PluginManager:
                 module_path=mp,
                 source_revision=source_revision,
                 config_revision=config_revision,
+                data_dir=data_dir,
                 instance=instance,
                 scope=scope,
                 contributions=contributions,
                 gate_result=gate_result,
-                state="prepared" if not activate else "activating",
+                state="prepared",
             )
+            if not activate:
+                self._begin_reload(generation)
+                reload_tx_id = generation.reload_tx_id
             catalog_generations = [
                 active_generation
                 for active_generation in self._active_generations.values()
@@ -1931,29 +2225,35 @@ class PluginManager:
                     generation.runtime_snapshot = self._compile_generation_snapshot(
                         generation
                     )
+                    self._advance_reload(
+                        generation,
+                        "prepared",
+                        candidate_snapshot_id=generation.runtime_snapshot.snapshot_id,
+                    )
                     generation.minimum_resource_count = scope.resource_count
                     self._prepared_generations[plugin_id] = generation
                     return generation
             generation.runtime_snapshot = self._compile_generation_snapshot(generation)
-            staged_event_bus = ScopedEventBus(self._event_bus, scope, staged=True)
-            generation.staged_event_bus = staged_event_bus
-            instance.context.event_bus = staged_event_bus
-            instance.context.kv_store = PluginKVStore(data_dir / ".kv.json")
+            from agent.plugins.context import PreparedPluginKVStore
+
+            load_phase = "prepare"
+            prepare_started = True
+            await self._prepare_generation(generation)
+            instance.context.data_dir = data_dir
             instance.context.session_manager = self._session_manager
             instance.context.memory_engine = self._memory_engine
             instance.context.llm = self._llm
-            instance.context.scope = scope
-            instance.context.tool_registry = generation.runtime_snapshot.tool_registry
-            load_phase = "initialize"
-            initialization_started = True
-            generation.initialization_started = True
-            await instance.initialize()
+            generation.state = "activating"
+            instance.activate()
+            if isinstance(instance.context.kv_store, PreparedPluginKVStore):
+                instance.context.kv_store.commit()
             load_phase = "publish"
             self._register_tools(instance, mp, tool_names)
             self._bind_tool_hooks(instance, mp)
             self._publish_contributions(contributions)
             self._channels.extend(contributions.channels)
-            staged_event_bus.publish()
+            assert generation.staged_event_bus is not None
+            generation.staged_event_bus.publish()
             generation.minimum_resource_count = scope.resource_count
         except asyncio.CancelledError:
             rollback_task = asyncio.create_task(
@@ -2311,8 +2611,23 @@ class PluginManager:
 
         check(
             "api_version",
-            getattr(instance, "api_version", None) == 1,
+            getattr(instance, "api_version", None) == 2,
             getattr(instance, "api_version", None),
+        )
+        lifecycle_type = type(instance)
+        legacy_lifecycle = [
+            name
+            for name in ("initialize",)
+            if name in lifecycle_type.__dict__
+        ]
+        check(
+            "lifecycle_api",
+            not legacy_lifecycle
+            and inspect.iscoroutinefunction(instance.prepare)
+            and not inspect.iscoroutinefunction(instance.activate)
+            and not inspect.iscoroutinefunction(instance.retire)
+            and inspect.iscoroutinefunction(instance.terminate),
+            {"legacy": legacy_lifecycle},
         )
         metadata = plugin_registry.get_handlers_by_module_path(type(instance).__module__)
         tool_names = [
@@ -2618,7 +2933,11 @@ class PluginManager:
     async def terminate_all(self) -> None:
         """完成快照、插件生命周期和作用域资源的全量关闭。"""
 
-        # 1. 先完成快照回收，再处理候选代际
+        from agent.plugins.context import allow_plugin_cleanup_writes
+
+        # 1. 先关闭当前 generation admission，再完成快照回收
+        for generation in self._active_generations.values():
+            self._retire_generation(generation)
         _, externally_cancelled = await _complete_critical(
             self._snapshot_store.close()
         )
@@ -2642,7 +2961,14 @@ class PluginManager:
                         Callable[[], Awaitable[None]],
                         terminator,
                     )
-                    _, cancelled = await _complete_critical(typed_terminator())
+                    generation = (
+                        None
+                        if active_info is None
+                        else self._active_generations.get(active_info.plugin_id)
+                    )
+                    writer_id = "" if generation is None else generation.generation_id
+                    with allow_plugin_cleanup_writes(writer_id):
+                        _, cancelled = await _complete_critical(typed_terminator())
                     externally_cancelled = externally_cancelled or cancelled
                 except (asyncio.CancelledError, Exception) as error:
                     current = asyncio.current_task()
@@ -2659,7 +2985,16 @@ class PluginManager:
                     )
             scope = self._scopes.pop(mp, None)
             if scope is not None:
-                cleanup_failures, cancelled = await _complete_critical(scope.aclose())
+                generation = (
+                    None
+                    if active_info is None
+                    else self._active_generations.get(active_info.plugin_id)
+                )
+                writer_id = "" if generation is None else generation.generation_id
+                with allow_plugin_cleanup_writes(writer_id):
+                    cleanup_failures, cancelled = await _complete_critical(
+                        scope.aclose()
+                    )
                 self._cleanup_failures.extend(cleanup_failures)
                 externally_cancelled = externally_cancelled or cancelled
 

--- a/agent/plugins/reload_journal.py
+++ b/agent/plugins/reload_journal.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, cast
+
+
+ReloadPhase = Literal[
+    "preparing",
+    "prepared",
+    "validating",
+    "commit_started",
+    "committed",
+    "draining",
+    "complete",
+    "aborted",
+    "recovered",
+]
+RecoveryActionName = Literal["discard_candidate", "restore_committed"]
+_TERMINAL_PHASES = frozenset({"complete", "aborted", "recovered"})
+_TRANSITIONS: dict[str, frozenset[str]] = {
+    "preparing": frozenset({"prepared", "aborted"}),
+    "prepared": frozenset({"validating", "aborted"}),
+    "validating": frozenset({"commit_started", "aborted"}),
+    "commit_started": frozenset({"committed", "aborted", "recovered"}),
+    "committed": frozenset({"draining", "complete", "recovered"}),
+    "draining": frozenset({"complete", "recovered"}),
+}
+
+
+@dataclass(frozen=True)
+class ReloadTransactionRecord:
+    tx_id: str
+    plugin_id: str
+    base_snapshot_id: str | None
+    candidate_snapshot_id: str | None
+    generation_id: str
+    source_revision: str
+    config_revision: str
+    phase: ReloadPhase
+    started_at: str
+    updated_at: str
+    error: str
+
+
+@dataclass(frozen=True)
+class ReloadJournalEvent:
+    sequence: int
+    phase: ReloadPhase
+    details: dict[str, object]
+    created_at: str
+
+
+@dataclass(frozen=True)
+class ReloadRecoveryAction:
+    tx_id: str
+    plugin_id: str
+    generation_id: str
+    source_revision: str
+    action: RecoveryActionName
+
+
+class ReloadJournal:
+    """Persist plugin reload phases and expose deterministic crash recovery work."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.path = workspace / "runtime" / "plugin-reloads.sqlite3"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def begin(
+        self,
+        *,
+        plugin_id: str,
+        base_snapshot_id: str | None,
+        generation_id: str,
+        source_revision: str,
+        config_revision: str,
+    ) -> str:
+        now = _now()
+        tx_id = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO reload_transactions (
+                    tx_id, plugin_id, base_snapshot_id, candidate_snapshot_id,
+                    generation_id, source_revision, config_revision, phase,
+                    started_at, updated_at, error
+                ) VALUES (?, ?, ?, NULL, ?, ?, ?, 'preparing', ?, ?, '')
+                """,
+                (
+                    tx_id,
+                    plugin_id,
+                    base_snapshot_id,
+                    generation_id,
+                    source_revision,
+                    config_revision,
+                    now,
+                    now,
+                ),
+            )
+            self._append_event(conn, tx_id, "preparing", {}, now)
+        return tx_id
+
+    def advance(
+        self,
+        tx_id: str,
+        phase: ReloadPhase,
+        *,
+        candidate_snapshot_id: str | None = None,
+        details: dict[str, object] | None = None,
+        error: str = "",
+    ) -> None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT phase FROM reload_transactions WHERE tx_id = ?",
+                (tx_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"ReloadTransaction 不存在: {tx_id}")
+            current = str(row[0])
+            if phase not in _TRANSITIONS.get(current, frozenset()):
+                raise RuntimeError(
+                    f"ReloadTransaction 状态跳转无效: {current} -> {phase}"
+                )
+            now = _now()
+            conn.execute(
+                """
+                UPDATE reload_transactions
+                SET phase = ?,
+                    candidate_snapshot_id = COALESCE(?, candidate_snapshot_id),
+                    updated_at = ?,
+                    error = ?
+                WHERE tx_id = ?
+                """,
+                (phase, candidate_snapshot_id, now, error, tx_id),
+            )
+            self._append_event(conn, tx_id, phase, details or {}, now)
+
+    def get(self, tx_id: str) -> ReloadTransactionRecord:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT tx_id, plugin_id, base_snapshot_id, candidate_snapshot_id,
+                       generation_id, source_revision, config_revision, phase,
+                       started_at, updated_at, error
+                FROM reload_transactions
+                WHERE tx_id = ?
+                """,
+                (tx_id,),
+            ).fetchone()
+        if row is None:
+            raise KeyError(f"ReloadTransaction 不存在: {tx_id}")
+        return _record(row)
+
+    def events(self, tx_id: str) -> tuple[ReloadJournalEvent, ...]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT sequence, phase, details_json, created_at
+                FROM reload_events
+                WHERE tx_id = ?
+                ORDER BY sequence
+                """,
+                (tx_id,),
+            ).fetchall()
+        return tuple(
+            ReloadJournalEvent(
+                sequence=int(row[0]),
+                phase=cast(ReloadPhase, str(row[1])),
+                details=cast(dict[str, object], json.loads(str(row[2]))),
+                created_at=str(row[3]),
+            )
+            for row in rows
+        )
+
+    def pending_recovery(self) -> tuple[ReloadRecoveryAction, ...]:
+        placeholders = ", ".join("?" for _ in _TERMINAL_PHASES)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT tx_id, plugin_id, generation_id, source_revision, phase
+                FROM reload_transactions
+                WHERE phase NOT IN ({placeholders})
+                ORDER BY started_at, tx_id
+                """,
+                tuple(sorted(_TERMINAL_PHASES)),
+            ).fetchall()
+        actions = [
+            ReloadRecoveryAction(
+                tx_id=str(row[0]),
+                plugin_id=str(row[1]),
+                generation_id=str(row[2]),
+                source_revision=str(row[3]),
+                action=(
+                    "restore_committed"
+                    if str(row[4]) in {"commit_started", "committed", "draining"}
+                    else "discard_candidate"
+                ),
+            )
+            for row in rows
+        ]
+        return tuple(
+            sorted(
+                actions,
+                key=lambda item: (item.action != "restore_committed", item.tx_id),
+            )
+        )
+
+    def finish_recovery(self, action: ReloadRecoveryAction) -> None:
+        phase: ReloadPhase = (
+            "recovered" if action.action == "restore_committed" else "aborted"
+        )
+        self.advance(
+            action.tx_id,
+            phase,
+            details={"recovery_action": action.action},
+            error="startup recovery",
+        )
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS reload_transactions (
+                    tx_id TEXT PRIMARY KEY,
+                    plugin_id TEXT NOT NULL,
+                    base_snapshot_id TEXT,
+                    candidate_snapshot_id TEXT,
+                    generation_id TEXT NOT NULL,
+                    source_revision TEXT NOT NULL,
+                    config_revision TEXT NOT NULL,
+                    phase TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    error TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS reload_events (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tx_id TEXT NOT NULL REFERENCES reload_transactions(tx_id),
+                    phase TEXT NOT NULL,
+                    details_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_reload_transactions_phase
+                ON reload_transactions(phase);
+                CREATE INDEX IF NOT EXISTS idx_reload_events_tx
+                ON reload_events(tx_id, sequence);
+                """
+            )
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.path)
+        try:
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA synchronous = FULL")
+            conn.execute("PRAGMA foreign_keys = ON")
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _append_event(
+        conn: sqlite3.Connection,
+        tx_id: str,
+        phase: ReloadPhase,
+        details: dict[str, object],
+        created_at: str,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO reload_events (tx_id, phase, details_json, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                tx_id,
+                phase,
+                json.dumps(details, ensure_ascii=False, sort_keys=True),
+                created_at,
+            ),
+        )
+
+
+def _record(row: sqlite3.Row | tuple[object, ...]) -> ReloadTransactionRecord:
+    return ReloadTransactionRecord(
+        tx_id=str(row[0]),
+        plugin_id=str(row[1]),
+        base_snapshot_id=None if row[2] is None else str(row[2]),
+        candidate_snapshot_id=None if row[3] is None else str(row[3]),
+        generation_id=str(row[4]),
+        source_revision=str(row[5]),
+        config_revision=str(row[6]),
+        phase=cast(ReloadPhase, str(row[7])),
+        started_at=str(row[8]),
+        updated_at=str(row[9]),
+        error=str(row[10]),
+    )
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/agent/plugins/scope.py
+++ b/agent/plugins/scope.py
@@ -240,7 +240,7 @@ class ScopedEventBus:
     ) -> EventSubscription | _StagedEventSubscription[T]:
         if self._snapshot_managed:
             if self._active:
-                raise RuntimeError("插件事件订阅只能在 initialize 中注册")
+                raise RuntimeError("插件事件订阅必须在 generation 开放前注册")
             subscription = _StagedEventSubscription(
                 self._event_bus,
                 event_type,

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -21,7 +21,7 @@ from infra.channels.contract import Channel
 
 SnapshotState = Literal[
     "compiled",
-    "published_pending",
+    "validating",
     "committed",
     "aborted",
     "retired",
@@ -374,10 +374,18 @@ class RuntimeSnapshotStore:
         self._on_drained = on_drained
         self._token = object()
         self._condition = asyncio.Condition()
+        self._drain_tasks: dict[str, asyncio.Task[None]] = {}
+        self._drain_failures: dict[str, BaseException] = {}
 
     @property
     def current(self) -> RuntimeSnapshot | None:
         return self._current
+
+    @property
+    def pending_candidate(self) -> RuntimeSnapshot | None:
+        if self._pending is None:
+            return None
+        return self._pending.candidate
 
     @property
     def retained_snapshot_ids(self) -> tuple[str, ...]:
@@ -392,7 +400,7 @@ class RuntimeSnapshotStore:
         return any(
             snapshot.snapshot_id != excluding_snapshot_id
             and (
-                snapshot.state in {"published_pending", "committed"}
+                snapshot.state in {"validating", "committed"}
                 or snapshot.lease_count > 0
             )
             and any(item is generation for item in snapshot.generations.values())
@@ -408,7 +416,7 @@ class RuntimeSnapshotStore:
         return any(
             snapshot.snapshot_id != excluding_snapshot_id
             and (
-                snapshot.state in {"published_pending", "committed"}
+                snapshot.state in {"validating", "committed"}
                 or snapshot.lease_count > 0
             )
             and snapshot.workspace_mcp_generation is generation
@@ -435,22 +443,32 @@ class RuntimeSnapshotStore:
             raise RuntimeError(f"RuntimeSnapshot 已存在: {candidate.snapshot_id}")
         self._adopt(candidate)
         transaction = SnapshotTransaction(previous=self._current, candidate=candidate)
-        candidate.state = "published_pending"
-        candidate.accepting_leases = not admission_gated
+        candidate.state = "validating"
+        candidate.accepting_leases = False
         self._snapshots[candidate.snapshot_id] = candidate
-        self._current = candidate
         self._pending = transaction
         return transaction
 
-    async def commit(self, transaction: SnapshotTransaction) -> None:
+    async def commit(
+        self,
+        transaction: SnapshotTransaction,
+        *,
+        before_open: Callable[[], None] | None = None,
+        after_open: Callable[[], None] | None = None,
+    ) -> None:
         self._require_pending(transaction)
+        if before_open is not None:
+            before_open()
         transaction.candidate.state = "committed"
         transaction.candidate.accepting_leases = True
+        self._current = transaction.candidate
         self._pending = None
         previous = transaction.previous
         if previous is not None:
             previous.state = "retired"
-            await self._drain_if_ready(previous)
+            if after_open is not None:
+                after_open()
+            self._schedule_drain(previous)
         async with self._condition:
             self._condition.notify_all()
 
@@ -458,11 +476,12 @@ class RuntimeSnapshotStore:
         self._require_pending(transaction)
         transaction.candidate.state = "aborted"
         transaction.candidate.accepting_leases = False
-        self._current = transaction.previous
-        if transaction.previous is not None:
+        if self._current is transaction.previous and transaction.previous is not None:
             transaction.previous.accepting_leases = True
         self._pending = None
-        await self._drain_if_ready(transaction.candidate)
+        self._schedule_drain(transaction.candidate)
+        await self._await_drain_tasks((transaction.candidate.snapshot_id,))
+        self._raise_drain_failures((transaction.candidate.snapshot_id,))
         async with self._condition:
             self._condition.notify_all()
 
@@ -509,7 +528,7 @@ class RuntimeSnapshotStore:
                 )
                 if snapshot is None:
                     raise RuntimeError("RuntimeSnapshot 不可用")
-                if snapshot.state not in {"published_pending", "committed"}:
+                if snapshot.state != "committed":
                     raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
                 if snapshot.accepting_leases:
                     return self._claim_lease(snapshot)
@@ -530,7 +549,8 @@ class RuntimeSnapshotStore:
         self._current = None
         if current is not None:
             current.state = "retired"
-            await self._drain_if_ready(current)
+            self._schedule_drain(current)
+            await self.retry_drains()
 
     def lease(self, snapshot_id: str | None = None) -> RuntimeSnapshotLease:
         snapshot = (
@@ -540,7 +560,7 @@ class RuntimeSnapshotStore:
         )
         if snapshot is None:
             raise RuntimeError("RuntimeSnapshot 不可用")
-        if snapshot.state not in {"published_pending", "committed"}:
+        if snapshot.state != "committed":
             raise RuntimeError(f"RuntimeSnapshot 不可租用: {snapshot.state}")
         if not snapshot.accepting_leases:
             raise RuntimeError("RuntimeSnapshot 暂停接收新 lease")
@@ -573,7 +593,7 @@ class RuntimeSnapshotStore:
             generation.lease_count -= 1
         if snapshot.workspace_mcp_generation is not None:
             snapshot.workspace_mcp_generation.lease_count -= 1
-        await self._drain_if_ready(snapshot)
+        self._schedule_drain(snapshot)
         async with self._condition:
             self._condition.notify_all()
 
@@ -586,19 +606,61 @@ class RuntimeSnapshotStore:
                 await self._condition.wait()
         await self.retry_drains()
 
-    async def _drain_if_ready(self, snapshot: RuntimeSnapshot) -> None:
+    def _schedule_drain(self, snapshot: RuntimeSnapshot) -> None:
         if snapshot.state not in {"retired", "aborted"} or snapshot.lease_count:
             return
-        if self._on_drained is not None:
-            await self._on_drained(snapshot)
-        _ = self._snapshots.pop(snapshot.snapshot_id, None)
+        existing = self._drain_tasks.get(snapshot.snapshot_id)
+        if existing is not None and not existing.done():
+            return
+        _ = self._drain_failures.pop(snapshot.snapshot_id, None)
+        self._drain_tasks[snapshot.snapshot_id] = asyncio.create_task(
+            self._run_drain(snapshot),
+            name=f"runtime_snapshot_drain:{snapshot.snapshot_id}",
+        )
+
+    async def _run_drain(self, snapshot: RuntimeSnapshot) -> None:
+        try:
+            if self._on_drained is not None:
+                await self._on_drained(snapshot)
+        except (asyncio.CancelledError, Exception) as error:
+            self._drain_failures[snapshot.snapshot_id] = error
+        else:
+            _ = self._snapshots.pop(snapshot.snapshot_id, None)
+        finally:
+            _ = self._drain_tasks.pop(snapshot.snapshot_id, None)
+            async with self._condition:
+                self._condition.notify_all()
 
     async def retry_drains(self) -> None:
+        await self._await_drain_tasks(tuple(self._drain_tasks))
         for snapshot in tuple(self._snapshots.values()):
-            await self._drain_if_ready(snapshot)
+            self._schedule_drain(snapshot)
+        attempted = tuple(self._drain_tasks)
+        await self._await_drain_tasks(attempted)
+        self._raise_drain_failures(attempted)
+
+    async def _await_drain_tasks(self, snapshot_ids: tuple[str, ...]) -> None:
+        tasks = [
+            task
+            for snapshot_id in snapshot_ids
+            if (task := self._drain_tasks.get(snapshot_id)) is not None
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    def _raise_drain_failures(self, snapshot_ids: tuple[str, ...]) -> None:
+        failures = [
+            (snapshot_id, self._drain_failures[snapshot_id])
+            for snapshot_id in snapshot_ids
+            if snapshot_id in self._drain_failures
+        ]
+        if not failures:
+            return
+        snapshot_id, error = failures[0]
+        raise RuntimeError(f"RuntimeSnapshot drain 失败: {snapshot_id}") from error
 
     def _require_pending(self, transaction: SnapshotTransaction) -> None:
-        if self._pending is not transaction or self._current is not transaction.candidate:
+        if self._pending is not transaction:
             raise RuntimeError("RuntimeSnapshot 发布事务已失效")
 
     def _adopt(self, snapshot: RuntimeSnapshot) -> None:

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -14,10 +14,12 @@ class PluginWatcher:
         self,
         manager: PluginManager,
         *,
+        baseline_revision: str,
         interval_seconds: float = 1.0,
         after_reconcile: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         self._manager = manager
+        self._baseline_revision = baseline_revision
         self._interval_seconds = interval_seconds
         self._after_reconcile = after_reconcile
         self._wake = asyncio.Event()
@@ -31,16 +33,12 @@ class PluginWatcher:
     async def run(self) -> None:
         """轮询插件文件状态，并在变化后执行一次热重载。"""
 
-        revision: str | None = None
+        revision = self._baseline_revision
         self._run_started = True
         try:
             # 1. 启动前已停止时，不再触碰 manager
             if not self._running:
                 return
-            try:
-                revision = self._manager.watch_revision()
-            except OSError:
-                logger.exception("插件热重载状态扫描失败")
             while self._running:
                 # 2. 等待定时轮询或外部唤醒
                 try:
@@ -57,14 +55,13 @@ class PluginWatcher:
                 self._forced = False
                 # 3. 读取最新状态；单次文件竞争交给下一轮恢复
                 try:
-                    current_revision = self._manager.watch_revision()
+                    current_revision = await asyncio.to_thread(
+                        self._manager.watch_revision
+                    )
                 except OSError:
                     self._forced = self._forced or forced
                     logger.exception("插件热重载状态扫描失败")
                     continue
-                if revision is None:
-                    revision = current_revision
-                    forced = True
                 changed = forced or current_revision != revision
                 if not changed and not self._notification_pending:
                     continue

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -568,12 +568,14 @@ class AppRuntime:
                 )
                 self.plugin_watcher = PluginWatcher(
                     plugin_manager,
+                    baseline_revision="",
                     after_reconcile=mobile_ui_refresh,
                 )
                 self.plugin_watcher_task = asyncio.create_task(
                     self.plugin_watcher.run(),
                     name="plugin_watcher",
                 )
+                self.plugin_watcher.wake()
 
             self._install_plugin_reload_signal()
             self._started = True

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -28,7 +28,7 @@ COPY requirements.txt requirements-dev.txt /tmp/
 RUN python -m venv /opt/venv \
     && python -m pip install --upgrade pip \
     && python -m pip install -r /tmp/requirements-dev.txt \
-    && python -m pip install mcp
+    && python -m pip install mcp==1.28.1
 
 COPY docker/debug/entrypoint.sh /usr/local/bin/akashic-debug
 RUN chmod +x /usr/local/bin/akashic-debug

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -220,12 +220,40 @@ python docker/debug/plugin_hot_reload_probe.py \
   --scenario full-runtime --phase scope
 ```
 
-候选 Gate 场景会同时安装有效和无效插件，确认真实 Runtime 只初始化通过静态 Gate 的 generation：
+原子热重载场景会构造失败源码、有效新代和回切旧代，确认校验期间旧代仍服务，提交后
+request、skill、tool、job、event、MCP 与 service 同时换代，旧代 writer 被 fence，journal
+最终完成：
 
 ```bash
 python docker/debug/plugin_hot_reload_probe.py \
-  --scenario full-runtime --phase candidate
+  --scenario full-runtime --phase atomic-reload
 ```
+
+### Plugin API v2 发布组合 Gate
+
+`plugin-api-v2.lock.json` 固定合同检查器与 21 个外部插件的完整 commit SHA。Gate 只从公开
+GitHub HTTPS 地址获取这些对象，不读取宿主插件 cache、正式 workspace 或正式配置。
+
+```text
+┌─ 静态合同
+│  ├─ 拒绝 API v1 / initialize
+│  ├─ prepare 不得取得 data_dir 或启动 task
+│  └─ lifecycle task 必须归 generation scope
+└─ Docker Debug
+   ├─ atomic-reload   失败保旧、成功原子切换、WAL 完成
+   ├─ all-plugins     19 个可运行插件逐个热重载和禁用
+   └─ fitbit          monitor 单实例、重载、停机、用户数据不变
+```
+
+本地运行：
+
+```bash
+python docker/debug/plugin_api_v2_gate.py
+```
+
+CI 使用 `--require-clean-core`，并上传 `docker/debug/reports/plugin-api-v2/`。任何锁内仓库缺失、
+SHA 不可获取、静态合同失败、容器退出异常、源码挂载被修改或业务 oracle 不成立都会返回非零
+退出码。
 
 ### 移动插件发布组合 Gate
 

--- a/docker/debug/docker-compose.plugin-gate.yml
+++ b/docker/debug/docker-compose.plugin-gate.yml
@@ -16,8 +16,7 @@ services:
       PYTHONPATH: /sandbox/python-packages:/app
       PYTHONUNBUFFERED: "1"
     volumes:
-      - ../..:/app:ro
-      - ${AKASHIC_GATE_GIT_COMMON_DIR:?set by plugin_hot_reload_probe.py}:${AKASHIC_GATE_GIT_COMMON_DIR:?set by plugin_hot_reload_probe.py}:ro
+      - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}/app:/app:ro
       - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}:/sandbox
       - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}/static:/app/static
       - ${AKASHIC_PLUGIN_SOURCE:?set by plugin_hot_reload_probe.py}:/fixtures/plugins:ro

--- a/docker/debug/docker-compose.plugin-gate.yml
+++ b/docker/debug/docker-compose.plugin-gate.yml
@@ -13,9 +13,11 @@ services:
       AKASHIC_HOST_UID: "${UID:?set by plugin_hot_reload_probe.py}"
       AKASHIC_PLUGIN_LOG_LEVEL: DEBUG
       HOME: /sandbox/home
+      PYTHONPATH: /sandbox/python-packages:/app
       PYTHONUNBUFFERED: "1"
     volumes:
       - ../..:/app:ro
+      - ${AKASHIC_GATE_GIT_COMMON_DIR:?set by plugin_hot_reload_probe.py}:${AKASHIC_GATE_GIT_COMMON_DIR:?set by plugin_hot_reload_probe.py}:ro
       - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}:/sandbox
       - ${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}/static:/app/static
       - ${AKASHIC_PLUGIN_SOURCE:?set by plugin_hot_reload_probe.py}:/fixtures/plugins:ro

--- a/docker/debug/plugin-api-v2.lock.json
+++ b/docker/debug/plugin-api-v2.lock.json
@@ -9,7 +9,7 @@
     {
       "id": "calendar-mcp",
       "repository": "https://github.com/akashic-plugins/calendar-mcp",
-      "commit": "5b9069213ac48ad18aa5d53f50a413ca81b55e63"
+      "commit": "b83502367cd869a78b2a9cd019ae6e152a661096"
     },
     {
       "id": "citation",
@@ -39,7 +39,7 @@
     {
       "id": "feed-mcp",
       "repository": "https://github.com/akashic-plugins/feed-mcp",
-      "commit": "bcbaf4166902c925bf1c1c8b1f78865688c76de4"
+      "commit": "e4028236e5b8ac65c5741ca6e8908115bdea6d31"
     },
     {
       "id": "feishu",
@@ -104,7 +104,7 @@
     {
       "id": "steam-mcp",
       "repository": "https://github.com/akashic-plugins/steam-mcp",
-      "commit": "a2739c3f9608be260ec056c7ee8f39d64015695d"
+      "commit": "0e3dbfb1250b5b1f0d0f8ca268d1ad1c5dfd4a17"
     },
     {
       "id": "tool_loop_guard",

--- a/docker/debug/plugin-api-v2.lock.json
+++ b/docker/debug/plugin-api-v2.lock.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 1,
+  "contract": {
+    "id": "plugin-contracts",
+    "repository": "https://github.com/akashic-plugins/plugin-contracts",
+    "commit": "24543445c7b99ca63fcd90b5828f754a148b184c"
+  },
+  "plugins": [
+    {
+      "id": "calendar-mcp",
+      "repository": "https://github.com/akashic-plugins/calendar-mcp",
+      "commit": "5b9069213ac48ad18aa5d53f50a413ca81b55e63"
+    },
+    {
+      "id": "citation",
+      "repository": "https://github.com/akashic-plugins/citation",
+      "commit": "4ba720a0bd0608997ea29655026cead715873b96"
+    },
+    {
+      "id": "computer-use-linux",
+      "repository": "https://github.com/akashic-plugins/computer-use-linux",
+      "commit": "387b2e399f0ceaffc4108862022e454ec0a10fb2"
+    },
+    {
+      "id": "context_pressure",
+      "repository": "https://github.com/akashic-plugins/context_pressure",
+      "commit": "19e02a8fba3355ea98902db04dc96ce7a25bead4"
+    },
+    {
+      "id": "daynight_gate",
+      "repository": "https://github.com/akashic-plugins/daynight_gate",
+      "commit": "bc485e1cf1c7518728cfb2cda75cf11c339f368c"
+    },
+    {
+      "id": "emotion",
+      "repository": "https://github.com/akashic-plugins/emotion",
+      "commit": "1f638cfaa1ef4396d93dc75917b242012d83620a"
+    },
+    {
+      "id": "feed-mcp",
+      "repository": "https://github.com/akashic-plugins/feed-mcp",
+      "commit": "bcbaf4166902c925bf1c1c8b1f78865688c76de4"
+    },
+    {
+      "id": "feishu",
+      "repository": "https://github.com/akashic-plugins/feishu",
+      "commit": "101a1d2402e251312a2ad5e5ffa050f337d00aed"
+    },
+    {
+      "id": "fitbit-mcp",
+      "repository": "https://github.com/akashic-plugins/fitbit-mcp",
+      "commit": "4fc865e44c0197db05e138a157aff32f37574dca"
+    },
+    {
+      "id": "huayue-skills",
+      "repository": "https://github.com/akashic-plugins/huayue-skills",
+      "commit": "e6a34b4ddffcfd51984a24896164bc42855215ac"
+    },
+    {
+      "id": "meme",
+      "repository": "https://github.com/akashic-plugins/meme",
+      "commit": "2a5d4e327e171c8d82a0c4589da614ed1e731e76"
+    },
+    {
+      "id": "observe",
+      "repository": "https://github.com/akashic-plugins/observe",
+      "commit": "84947957b52a2ef9f913b4d15f72c0fc54366b34"
+    },
+    {
+      "id": "plugin_undo",
+      "repository": "https://github.com/akashic-plugins/plugin_undo",
+      "commit": "34add1e85f96587fa487466eda4bf25f17785f75"
+    },
+    {
+      "id": "proactive_feedback",
+      "repository": "https://github.com/akashic-plugins/proactive_feedback",
+      "commit": "f84e0d767aaa517e50e4ff757445ec8c963385f5"
+    },
+    {
+      "id": "qqbot",
+      "repository": "https://github.com/akashic-plugins/qqbot",
+      "commit": "9f8f72c125113738c66bbf5d1f59206c276bfd56"
+    },
+    {
+      "id": "setup_helper",
+      "repository": "https://github.com/akashic-plugins/setup_helper",
+      "commit": "21e324ae29bef5f7266797e6dc4e35b0ad9fddeb"
+    },
+    {
+      "id": "shell_restore",
+      "repository": "https://github.com/akashic-plugins/shell_restore",
+      "commit": "3f0b7abb54f6f70df4e0f2f5c7d812666f4e61fc"
+    },
+    {
+      "id": "shell_safety",
+      "repository": "https://github.com/akashic-plugins/shell_safety",
+      "commit": "b6ae2775d1870d0ada710b5c3c3cc0b0da93d975"
+    },
+    {
+      "id": "status_commands",
+      "repository": "https://github.com/akashic-plugins/status_commands",
+      "commit": "96628c9c8ba99c3c665bfa730da9e428151c2ec8"
+    },
+    {
+      "id": "steam-mcp",
+      "repository": "https://github.com/akashic-plugins/steam-mcp",
+      "commit": "a2739c3f9608be260ec056c7ee8f39d64015695d"
+    },
+    {
+      "id": "tool_loop_guard",
+      "repository": "https://github.com/akashic-plugins/tool_loop_guard",
+      "commit": "a099cb4a311448bba2bcaf060c9ee90bfb446794"
+    }
+  ]
+}

--- a/docker/debug/plugin-api-v2.lock.json
+++ b/docker/debug/plugin-api-v2.lock.json
@@ -9,107 +9,107 @@
     {
       "id": "calendar-mcp",
       "repository": "https://github.com/akashic-plugins/calendar-mcp",
-      "commit": "b83502367cd869a78b2a9cd019ae6e152a661096"
+      "commit": "33097acac778ea75a2d26733acb79726c2fdb396"
     },
     {
       "id": "citation",
       "repository": "https://github.com/akashic-plugins/citation",
-      "commit": "4ba720a0bd0608997ea29655026cead715873b96"
+      "commit": "bf56c30df144f36e640174c5c8fe0723fc20fa02"
     },
     {
       "id": "computer-use-linux",
       "repository": "https://github.com/akashic-plugins/computer-use-linux",
-      "commit": "387b2e399f0ceaffc4108862022e454ec0a10fb2"
+      "commit": "31325bb0552455fd4cc5d29efafc1477a7b10bc0"
     },
     {
       "id": "context_pressure",
       "repository": "https://github.com/akashic-plugins/context_pressure",
-      "commit": "19e02a8fba3355ea98902db04dc96ce7a25bead4"
+      "commit": "dbb969f5a70fbfcd50a9f22239b7d9082168f5b2"
     },
     {
       "id": "daynight_gate",
       "repository": "https://github.com/akashic-plugins/daynight_gate",
-      "commit": "bc485e1cf1c7518728cfb2cda75cf11c339f368c"
+      "commit": "2b95c6aed10d7ebd671a50ad215a61934f10e363"
     },
     {
       "id": "emotion",
       "repository": "https://github.com/akashic-plugins/emotion",
-      "commit": "1f638cfaa1ef4396d93dc75917b242012d83620a"
+      "commit": "4193c26e47725775ea636f5d76abd16b2e89c787"
     },
     {
       "id": "feed-mcp",
       "repository": "https://github.com/akashic-plugins/feed-mcp",
-      "commit": "e4028236e5b8ac65c5741ca6e8908115bdea6d31"
+      "commit": "2c36b11b0736adcf5e023524c13cf2bb9318cb95"
     },
     {
       "id": "feishu",
       "repository": "https://github.com/akashic-plugins/feishu",
-      "commit": "101a1d2402e251312a2ad5e5ffa050f337d00aed"
+      "commit": "b33bf07c4d791201e2fbcb8c889fd095e382ce7b"
     },
     {
       "id": "fitbit-mcp",
       "repository": "https://github.com/akashic-plugins/fitbit-mcp",
-      "commit": "4fc865e44c0197db05e138a157aff32f37574dca"
+      "commit": "9df248985c68049b938e349d0e135216b10ab25f"
     },
     {
       "id": "huayue-skills",
       "repository": "https://github.com/akashic-plugins/huayue-skills",
-      "commit": "e6a34b4ddffcfd51984a24896164bc42855215ac"
+      "commit": "503a511bbad37362b6e06af40ee98d90b91e97c0"
     },
     {
       "id": "meme",
       "repository": "https://github.com/akashic-plugins/meme",
-      "commit": "2a5d4e327e171c8d82a0c4589da614ed1e731e76"
+      "commit": "9eed402ab797cd4d57037031fea8e3bc4a060f0d"
     },
     {
       "id": "observe",
       "repository": "https://github.com/akashic-plugins/observe",
-      "commit": "84947957b52a2ef9f913b4d15f72c0fc54366b34"
+      "commit": "9556b317c04afc8874bf6f0116f76001e0394cbb"
     },
     {
       "id": "plugin_undo",
       "repository": "https://github.com/akashic-plugins/plugin_undo",
-      "commit": "34add1e85f96587fa487466eda4bf25f17785f75"
+      "commit": "2b2d90e4f3dbf211a127ed3fdde8194f812c642e"
     },
     {
       "id": "proactive_feedback",
       "repository": "https://github.com/akashic-plugins/proactive_feedback",
-      "commit": "f84e0d767aaa517e50e4ff757445ec8c963385f5"
+      "commit": "563f3dff99d3386ec304ed0e71b69e664b85ba01"
     },
     {
       "id": "qqbot",
       "repository": "https://github.com/akashic-plugins/qqbot",
-      "commit": "9f8f72c125113738c66bbf5d1f59206c276bfd56"
+      "commit": "97234e9fac0007356300d1411c8432060efb883c"
     },
     {
       "id": "setup_helper",
       "repository": "https://github.com/akashic-plugins/setup_helper",
-      "commit": "21e324ae29bef5f7266797e6dc4e35b0ad9fddeb"
+      "commit": "c3dcd813473f60f77cb384b75461a92611a1bb28"
     },
     {
       "id": "shell_restore",
       "repository": "https://github.com/akashic-plugins/shell_restore",
-      "commit": "3f0b7abb54f6f70df4e0f2f5c7d812666f4e61fc"
+      "commit": "3ff62e7182681857dac35c2e386c28ef19117c1e"
     },
     {
       "id": "shell_safety",
       "repository": "https://github.com/akashic-plugins/shell_safety",
-      "commit": "b6ae2775d1870d0ada710b5c3c3cc0b0da93d975"
+      "commit": "84ddac1573cc34bb49df1243b3beda579dcea5ef"
     },
     {
       "id": "status_commands",
       "repository": "https://github.com/akashic-plugins/status_commands",
-      "commit": "96628c9c8ba99c3c665bfa730da9e428151c2ec8"
+      "commit": "c6c85915487f1d94ea2e8e95ba60341b1a0d849d"
     },
     {
       "id": "steam-mcp",
       "repository": "https://github.com/akashic-plugins/steam-mcp",
-      "commit": "0e3dbfb1250b5b1f0d0f8ca268d1ad1c5dfd4a17"
+      "commit": "d4b7bed3d22f228351836eaaf734dd4b91f3cf7b"
     },
     {
       "id": "tool_loop_guard",
       "repository": "https://github.com/akashic-plugins/tool_loop_guard",
-      "commit": "a099cb4a311448bba2bcaf060c9ee90bfb446794"
+      "commit": "f31992dfa64b91377559163ef54b6bbe505f68f0"
     }
   ]
 }

--- a/docker/debug/plugin_api_v2_gate.py
+++ b/docker/debug/plugin_api_v2_gate.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK = ROOT / "docker" / "debug" / "plugin-api-v2.lock.json"
+DEFAULT_REPORT = (
+    ROOT / "docker" / "debug" / "reports" / "plugin-api-v2" / "gate.json"
+)
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+REPOSITORY_PATTERN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+RUNTIME_PHASES = ("atomic-reload", "all-plugins", "fitbit")
+EXPECTED_PLUGIN_IDS = {
+    "calendar-mcp",
+    "citation",
+    "computer-use-linux",
+    "context_pressure",
+    "daynight_gate",
+    "emotion",
+    "feed-mcp",
+    "feishu",
+    "fitbit-mcp",
+    "huayue-skills",
+    "meme",
+    "observe",
+    "plugin_undo",
+    "proactive_feedback",
+    "qqbot",
+    "setup_helper",
+    "shell_restore",
+    "shell_safety",
+    "status_commands",
+    "steam-mcp",
+    "tool_loop_guard",
+}
+
+
+@dataclass(frozen=True)
+class LockedRepository:
+    id: str
+    repository: str
+    commit: str
+
+
+@dataclass(frozen=True)
+class PluginApiV2Lock:
+    contract: LockedRepository
+    plugins: tuple[LockedRepository, ...]
+
+
+def main() -> int:
+    """检出不可变发布组合并运行静态合同与隔离 Runtime Gate。"""
+
+    # 1. 固定输入和核心源码身份
+    args = _parse_args()
+    report_path = args.report.resolve()
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    core_status = _git_output(ROOT, "status", "--porcelain").splitlines()
+    report: dict[str, object] = {
+        "status": "failed",
+        "checked_at": datetime.now(UTC).isoformat(),
+        "core_head": _git_output(ROOT, "rev-parse", "HEAD"),
+        "core_dirty_status": core_status,
+        "lock": str(args.lock.resolve()),
+        "lock_sha256": hashlib.sha256(args.lock.read_bytes()).hexdigest(),
+        "runtime_phases": {},
+    }
+
+    # 2. 在一次性目录精确检出合同和所有插件
+    try:
+        if args.require_clean_core and core_status:
+            raise RuntimeError(f"核心工作树不干净: {core_status}")
+        release = _load_lock(args.lock.resolve())
+        report["contract"] = asdict(release.contract)
+        report["plugins"] = [asdict(item) for item in release.plugins]
+        with tempfile.TemporaryDirectory(prefix="akashic-plugin-api-v2-") as raw_temp:
+            temp_root = Path(raw_temp)
+            contract_root = temp_root / "contract"
+            plugin_root = temp_root / "plugins"
+            _checkout_locked_commit(release.contract, contract_root)
+            for plugin in release.plugins:
+                _checkout_locked_commit(plugin, plugin_root / plugin.id)
+
+            # 3. 先做全量静态合同，再运行三个真实业务 Gate
+            static_report = _run_static_contract(
+                contract_root=contract_root,
+                plugin_root=plugin_root,
+                plugins=release.plugins,
+                report_dir=report_path.parent,
+            )
+            report["static_contract"] = static_report
+            if static_report["returncode"] != 0:
+                raise RuntimeError("Plugin API v2 静态合同失败")
+
+            phase_reports = cast(dict[str, object], report["runtime_phases"])
+            for phase in RUNTIME_PHASES:
+                phase_report = _run_runtime_phase(
+                    phase=phase,
+                    plugin_root=plugin_root,
+                    report_dir=report_path.parent,
+                )
+                phase_reports[phase] = phase_report
+                if phase_report["returncode"] != 0:
+                    raise RuntimeError(f"Runtime Gate 失败: {phase}")
+        report["status"] = "passed"
+    except Exception as error:
+        report["error"] = f"{type(error).__name__}: {error}"
+
+    # 4. 无论成功失败都留下可上传的精确组合证据
+    report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if report["status"] != "passed":
+        print(f"plugin api v2 gate failed: {report.get('error')}", file=sys.stderr)
+        print(f"evidence: {report_path}", file=sys.stderr)
+        return 1
+    print(f"plugin api v2 gate passed: {report_path}")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="验证固定 Core 与外部插件组合的 Plugin API v2 合同",
+    )
+    parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--require-clean-core", action="store_true")
+    return parser.parse_args()
+
+
+def _load_lock(path: Path) -> PluginApiV2Lock:
+    """严格解析发布锁，不接受缺仓库、额外字段或浮动引用。"""
+
+    # 1. 校验发布锁根结构
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or set(raw) != {
+        "schema_version",
+        "contract",
+        "plugins",
+    }:
+        raise ValueError("Plugin API v2 发布锁根结构无效")
+    if raw["schema_version"] != 1:
+        raise ValueError(f"不支持的 Plugin API v2 发布锁版本: {raw['schema_version']}")
+    plugins_raw = raw["plugins"]
+    if not isinstance(plugins_raw, list):
+        raise ValueError("Plugin API v2 发布锁 plugins 必须是数组")
+
+    # 2. 每个远端只能由 HTTPS 地址和完整 commit 标识
+    contract = _parse_repository(raw["contract"])
+    plugins = tuple(_parse_repository(item) for item in plugins_raw)
+    ids = [plugin.id for plugin in plugins]
+    if len(ids) != len(set(ids)):
+        raise ValueError("Plugin API v2 发布锁包含重复插件")
+    actual_ids = set(ids)
+    if actual_ids != EXPECTED_PLUGIN_IDS:
+        missing = sorted(EXPECTED_PLUGIN_IDS - actual_ids)
+        extra = sorted(actual_ids - EXPECTED_PLUGIN_IDS)
+        raise ValueError(f"Plugin API v2 发布锁插件集合错误: missing={missing} extra={extra}")
+    if contract.id != "plugin-contracts":
+        raise ValueError("Plugin API v2 发布锁 contract id 必须是 plugin-contracts")
+    return PluginApiV2Lock(contract=contract, plugins=plugins)
+
+
+def _parse_repository(raw: object) -> LockedRepository:
+    expected = {"id", "repository", "commit"}
+    if not isinstance(raw, dict) or set(raw) != expected:
+        raise ValueError(f"Plugin API v2 仓库字段无效: {raw}")
+    item = cast(dict[str, object], raw)
+    values: dict[str, str] = {}
+    for name in expected:
+        value = item[name]
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Plugin API v2 仓库字段必须是非空字符串: {name}")
+        values[name] = value
+    if REPOSITORY_PATTERN.fullmatch(values["repository"]) is None:
+        raise ValueError(f"插件仓库必须是 GitHub HTTPS 地址: {values['repository']}")
+    if COMMIT_PATTERN.fullmatch(values["commit"]) is None:
+        raise ValueError(f"插件 commit 必须是完整 SHA: {values['commit']}")
+    return LockedRepository(**values)
+
+
+def _checkout_locked_commit(repository: LockedRepository, checkout: Path) -> None:
+    """只获取发布锁声明的公开 Git 对象。"""
+
+    # 1. 创建不复用宿主 checkout 的临时仓库
+    _run(("git", "init", "--quiet", str(checkout)), cwd=ROOT)
+    _run(
+        ("git", "remote", "add", "origin", repository.repository),
+        cwd=checkout,
+    )
+
+    # 2. 精确获取并核对完整 SHA
+    _run(
+        ("git", "fetch", "--quiet", "--depth=1", "origin", repository.commit),
+        cwd=checkout,
+    )
+    _run(("git", "checkout", "--quiet", "--detach", "FETCH_HEAD"), cwd=checkout)
+    actual = _git_output(checkout, "rev-parse", "HEAD")
+    if actual != repository.commit:
+        raise RuntimeError(
+            f"检出提交与发布锁不一致: {repository.id} expected={repository.commit} actual={actual}"
+        )
+    if _git_output(checkout, "status", "--porcelain"):
+        raise RuntimeError(f"插件检出后工作树不干净: {repository.id}")
+
+
+def _run_static_contract(
+    *,
+    contract_root: Path,
+    plugin_root: Path,
+    plugins: tuple[LockedRepository, ...],
+    report_dir: Path,
+) -> dict[str, object]:
+    """用锁定版本的合同检查器验证全部插件入口。"""
+
+    output_path = report_dir / "static-contract.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(contract_root)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "akashic_plugin_contracts",
+            "check",
+            *(str(plugin_root / plugin.id / "plugin.py") for plugin in plugins),
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    output_path.write_text(result.stdout, encoding="utf-8")
+    return {
+        "returncode": result.returncode,
+        "report": output_path.name,
+        "sha256": hashlib.sha256(result.stdout.encode()).hexdigest(),
+    }
+
+
+def _run_runtime_phase(
+    *,
+    phase: str,
+    plugin_root: Path,
+    report_dir: Path,
+) -> dict[str, object]:
+    """在 Docker Debug sandbox 运行一个可观察的插件业务场景。"""
+
+    output_path = report_dir / f"runtime-{phase}.log"
+    env = os.environ.copy()
+    env["AKASHIC_PLUGIN_SOURCE"] = str(plugin_root)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "docker" / "debug" / "plugin_hot_reload_probe.py"),
+            "--scenario",
+            "full-runtime",
+            "--phase",
+            phase,
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    output_path.write_text(result.stdout, encoding="utf-8")
+    print(f"runtime {phase}: {'passed' if result.returncode == 0 else 'failed'}")
+    return {
+        "returncode": result.returncode,
+        "report": output_path.name,
+        "sha256": hashlib.sha256(result.stdout.encode()).hexdigest(),
+    }
+
+
+def _run(command: tuple[str, ...], *, cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", "-C", str(repo), *args),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -76,9 +76,89 @@ def _run(repo: Path, *args: str) -> bytes:
     ).stdout
 
 
-def _git_common_dir(repo: Path) -> str:
-    raw = _run(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    return str(Path(os.fsdecode(raw).strip()).resolve())
+def _copy_candidate_source(repo: Path, app: Path) -> None:
+    """复制完整历史，并把当前未提交候选覆盖到目标目录。"""
+
+    # 1. 独立 Git 对象库保留迁移 baseline，不依赖宿主 worktree 元数据。
+    _ = subprocess.run(
+        ["git", "clone", "--no-hardlinks", "--quiet", str(repo), str(app)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # 2. 只覆盖 Git 候选文件，排除 ignored 运行产物。
+    paths = _run(
+        repo,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    ).split(b"\0")
+    present_paths: set[Path] = set()
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        source = repo / relative
+        if not source.is_file() and not source.is_symlink():
+            continue
+        present_paths.add(relative)
+        target = app / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            if target.exists() or target.is_symlink():
+                target.unlink()
+            _ = target.symlink_to(os.readlink(source))
+        else:
+            _ = shutil.copy2(source, target)
+
+    # 3. staged 与 unstaged 删除都由候选实际存在集合决定。
+    baseline_paths = _run(app, "ls-files", "-z").split(b"\0")
+    for raw_path in baseline_paths:
+        if not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        if relative in present_paths:
+            continue
+        target = app / relative
+        if target.is_file() or target.is_symlink():
+            target.unlink()
+
+
+def _commit_gate_candidate(app: Path) -> None:
+    """提交隔离候选，让容器中的 HEAD 精确表示 Gate 输入。"""
+
+    (app / "static").mkdir(exist_ok=True)
+    _ = subprocess.run(["git", "add", "--all"], cwd=app, check=True)
+    _ = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Akashic Plugin Gate",
+            "-c",
+            "user.email=plugin-gate@invalid",
+            "commit",
+            "--allow-empty",
+            "-qm",
+            "plugin gate candidate",
+        ],
+        cwd=app,
+        check=True,
+    )
+
+
+def _prepare_gate_sandbox(sandbox: Path, repo: Path) -> None:
+    """复制候选源码，并建立只属于 Gate 的静态资源挂载点。"""
+
+    # 1. 源码、Git 历史与候选提交都封装在 sandbox。
+    app = sandbox / "app"
+    _copy_candidate_source(repo, app)
+    _commit_gate_candidate(app)
+
+    # 2. 外部可写静态目录不落入候选提交。
+    (sandbox / "static").mkdir()
 
 
 def _repository_digest(repo: Path) -> str:
@@ -291,18 +371,17 @@ def _run_controller(*, scenario: str, phase: str) -> int:
     sandbox = Path(
         tempfile.mkdtemp(prefix="akashic-plugin-gate-", dir="/tmp")
     ).resolve()
-    (sandbox / "static").mkdir()
     protected = [repo.resolve(), plugin_root, host_cache]
     if _sandbox_is_protected(sandbox, protected):
         shutil.rmtree(sandbox)
         raise SystemExit(f"Gate sandbox 不能位于受保护路径内：{sandbox}")
+    _prepare_gate_sandbox(sandbox, repo)
 
     repositories = _host_repositories(repo, plugin_root)
     before = {str(path): _repository_digest(path) for path in repositories}
     env = {
         **os.environ,
         "AKASHIC_GATE_SANDBOX": str(sandbox),
-        "AKASHIC_GATE_GIT_COMMON_DIR": _git_common_dir(repo),
         "AKASHIC_PLUGIN_SOURCE": str(plugin_root),
         "UID": str(os.getuid()),
         "GID": str(os.getgid()),

--- a/docker/debug/plugin_hot_reload_probe.py
+++ b/docker/debug/plugin_hot_reload_probe.py
@@ -76,6 +76,11 @@ def _run(repo: Path, *args: str) -> bytes:
     ).stdout
 
 
+def _git_common_dir(repo: Path) -> str:
+    raw = _run(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    return str(Path(os.fsdecode(raw).strip()).resolve())
+
+
 def _repository_digest(repo: Path) -> str:
     digest = hashlib.sha256()
     commands = (
@@ -297,6 +302,7 @@ def _run_controller(*, scenario: str, phase: str) -> int:
     env = {
         **os.environ,
         "AKASHIC_GATE_SANDBOX": str(sandbox),
+        "AKASHIC_GATE_GIT_COMMON_DIR": _git_common_dir(repo),
         "AKASHIC_PLUGIN_SOURCE": str(plugin_root),
         "UID": str(os.getuid()),
         "GID": str(os.getgid()),
@@ -453,6 +459,26 @@ def _write_smoke_config(
     )
 
 
+def _write_smoke_package_selection(
+    sandbox: Path,
+    *,
+    proactive_enabled: bool,
+) -> None:
+    """把 Gate 所需的 proactive 实现写成显式插件包选择。"""
+
+    manifest = sandbox / "home/.akashic-plugin/manifest.toml"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    content = manifest.read_text(encoding="utf-8") if manifest.exists() else "[plugins]\n"
+    content = content.rstrip() + "\n\n"
+    content += (
+        '[packages."default-proactive"]\n'
+        f"enabled = {'true' if proactive_enabled else 'false'}\n\n"
+        '[packages."wake-proactive"]\n'
+        "enabled = false\n"
+    )
+    _ = manifest.write_text(content, encoding="utf-8")
+
+
 def _install_scope_plugin(sandbox: Path) -> Path:
     plugin_dir = sandbox / "home/.akashic-plugin/cache/gate/scope_gate/1.0.0"
     plugin_dir.mkdir(parents=True, exist_ok=True)
@@ -473,11 +499,12 @@ def _install_scope_plugin(sandbox: Path) -> Path:
         "    def managed_services(cls):\n"
         "        return [ManagedServiceSpec(id='probe', command=('python', 'service.py'), readiness_url='http://127.0.0.1:18766/')]\n"
         "    def channels(self): return [ScopeGateChannel(self)]\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('initialized', True)\n"
         "        self.context.kv_store.set('generation', self.context.generation_id)\n"
         "        self.context.defer('subscription_check', self._check_subscription)\n"
         "        self.subscription = self.context.event_bus.on(TurnCommitted, self._handle)\n"
+        "    def activate(self):\n"
         "        self.context.create_task(self._worker(), name='scope-gate-worker')\n"
         "        self.context.create_task(self._emit(), name='scope-gate-emit')\n"
         "    async def terminate(self):\n"
@@ -667,7 +694,7 @@ def _install_migrated_plugins(sandbox: Path, plugin_root: Path) -> Path:
         "class GateDriverPlugin(Plugin):\n"
         "    name = 'zz_gate_driver'\n"
         "    def before_turn_modules(self): return [InspectRuntimeModules(self)]\n"
-        "    async def initialize(self):\n"
+        "    def activate(self):\n"
         "        self.context.create_task(self._drive_feedback(), name='gate-feedback-driver')\n"
         "    async def _drive_feedback(self):\n"
         "        await asyncio.sleep(0.2)\n"
@@ -790,7 +817,7 @@ def _install_candidate_plugins(
         "from agent.plugins import Plugin\n"
         "class CandidateValidPlugin(Plugin):\n"
         "    name = 'candidate_valid'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('initialized', True)\n"
         "        self.context.kv_store.set('generation', self.context.generation_id)\n",
         encoding="utf-8",
@@ -799,8 +826,8 @@ def _install_candidate_plugins(
         "from agent.plugins import Plugin\n"
         "class CandidateInvalidPlugin(Plugin):\n"
         "    name = 'candidate_invalid'\n"
-        "    api_version = 2\n"
-        "    async def initialize(self):\n"
+        "    api_version = 1\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('initialized', True)\n",
         encoding="utf-8",
     )
@@ -813,9 +840,9 @@ def _install_candidate_plugins(
         "    async def failed_tool(self, event):\n"
         '        """Failed candidate tool."""\n'
         "        return 'leaked'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.event_bus.on(TurnCommitted, self._on_turn)\n"
-        "        raise RuntimeError('candidate init failed')\n"
+        "        raise RuntimeError('candidate prepare failed')\n"
         "    def _on_turn(self, event):\n"
         "        self.context.kv_store.set('handler_leaked', True)\n",
         encoding="utf-8",
@@ -827,7 +854,7 @@ def _install_candidate_plugins(
         "from bus.events_lifecycle import TurnCommitted\n"
         "class CandidateObserverPlugin(Plugin):\n"
         "    name = 'candidate_observer'\n"
-        "    async def initialize(self):\n"
+        "    def activate(self):\n"
         "        self.context.create_task(self._verify(), name='candidate-observer')\n"
         "    async def _verify(self):\n"
         "        await asyncio.sleep(0.2)\n"
@@ -871,7 +898,8 @@ def _install_candidate_plugins(
         "    if 'id' not in msg:\n"
         "        continue\n"
         "    method = msg.get('method')\n"
-        "    result = {'tools': tools} if method == 'tools/list' else {}\n"
+        "    result = {'protocolVersion': '2025-11-25'} if method == 'initialize' else {}\n"
+        "    if method == 'tools/list': result = {'tools': tools}\n"
         "    if method == 'tools/call':\n"
         "        tool = msg.get('params', {}).get('name')\n"
         "        with calls.open('a', encoding='utf-8') as stream:\n"
@@ -906,11 +934,21 @@ def _install_candidate_plugins(
 
 
 def _candidate_reload_source(version: str) -> str:
-    initialize = (
+    prepare_body = (
         "        self.context.event_bus.on(TurnCommitted, self._on_committed)\n"
         "        self.context.kv_store.set('initialized_version', 'v1')\n"
         "        self.context.kv_store.set('active_generation', self.context.generation_id)\n"
+        if version == "v1"
+        else "        self.context.event_bus.on(TurnCommitted, self._on_committed)\n"
+        "        self.context.kv_store.set('initialized_version', 'v2')\n"
+        "        self.context.kv_store.set('active_generation', self.context.generation_id)\n"
+    )
+    activate_body = (
         "        self.context.create_task(self._heartbeat(), name='candidate-reload-heartbeat')\n"
+        if version == "v1"
+        else "        return None\n"
+    )
+    heartbeat = (
         "    async def _heartbeat(self):\n"
         "        while True:\n"
         "            self.context.kv_store.increment('heartbeats')\n"
@@ -921,8 +959,7 @@ def _candidate_reload_source(version: str) -> str:
         "                self.context.kv_store.set('live_mcp_version', getattr(result, 'text', str(result)))\n"
         "            await asyncio.sleep(0.05)\n"
         if version == "v1"
-        else "        self.context.event_bus.on(TurnCommitted, self._on_committed)\n"
-        "        self.context.kv_store.set('initialized_version', 'v2')\n"
+        else ""
     )
     skills = (
         "    @classmethod\n"
@@ -1007,8 +1044,11 @@ def _candidate_reload_source(version: str) -> str:
         "    @on_tool_pre(tool_name='candidate_reload_tool')\n"
         "    async def before_candidate_tool(self, event):\n"
         f"        self.context.kv_store.increment('phase_hook_version_{version}')\n"
-        "    async def initialize(self):\n"
-        f"{initialize}"
+        "    async def prepare(self):\n"
+        f"{prepare_body}"
+        "    def activate(self):\n"
+        f"{activate_body}"
+        f"{heartbeat}"
         "    async def _on_committed(self, event):\n"
         f"        self.context.kv_store.increment('phase_event_version_{version}')\n"
     )
@@ -1046,6 +1086,61 @@ def _wait_json_value(path: Path, key: str, expected: object) -> dict[str, object
             return state
         time.sleep(0.05)
     return _read_json_object(path)
+
+
+def _wait_reload_transactions(
+    path: Path,
+    plugin_id: str,
+    *,
+    count: int,
+) -> list[dict[str, object]]:
+    """Wait for committed reloads to drain and return their persisted phase history."""
+
+    deadline = time.monotonic() + 8
+    transactions: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        if not path.exists():
+            time.sleep(0.05)
+            continue
+        with sqlite3.connect(path) as connection:
+            rows = connection.execute(
+                """
+                SELECT tx_id, generation_id, candidate_snapshot_id, phase
+                FROM reload_transactions
+                WHERE plugin_id = ?
+                ORDER BY rowid
+                """,
+                (plugin_id,),
+            ).fetchall()
+            transactions = []
+            for tx_id, generation_id, snapshot_id, phase in rows:
+                event_rows = connection.execute(
+                    """
+                    SELECT phase
+                    FROM reload_events
+                    WHERE tx_id = ?
+                    ORDER BY sequence
+                    """,
+                    (tx_id,),
+                ).fetchall()
+                transactions.append(
+                    {
+                        "tx_id": str(tx_id),
+                        "generation_id": str(generation_id),
+                        "snapshot_id": (
+                            None if snapshot_id is None else str(snapshot_id)
+                        ),
+                        "phase": str(phase),
+                        "events": [str(item[0]) for item in event_rows],
+                    }
+                )
+        if (
+            len(transactions) >= count
+            and all(item["phase"] == "complete" for item in transactions[-count:])
+        ):
+            return transactions
+        time.sleep(0.05)
+    return transactions
 
 
 def _integer(value: object) -> int:
@@ -1655,7 +1750,7 @@ def _exercise_topology_watch(
         "class TopologyAddedPlugin(Plugin):\n"
         "    name = 'topology_added'\n"
         "    version = '1.0.0'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('generation', self.context.generation_id)\n"
         "    async def terminate(self):\n"
         "        self.context.kv_store.set('terminated', True)\n",
@@ -1827,14 +1922,18 @@ def _exercise_snapshot_publish(
     }
 
 
-def _exercise_candidate_prepare(
+def _exercise_atomic_reload(
     container_id: str,
     source_path: Path,
     state_path: Path,
     socket_path: Path,
 ) -> dict[str, object]:
+    """Verify failed, committed, and rolled-forward reloads at the runtime boundary."""
+
+    # 1. A broken source must fail without moving the active catalog.
     initial = _read_json_object(state_path)
     calls_path = state_path.parent / "candidate_mcp_calls.jsonl"
+    journal_path = state_path.parents[2] / "runtime/plugin-reloads.sqlite3"
     initial_calls = _mcp_call_counts(calls_path)
     initial_mcp_processes = _wait_process_count(
         container_id,
@@ -1862,6 +1961,9 @@ def _exercise_candidate_prepare(
         container_id,
         "candidate_mcp_server.py",
     )
+
+    # 2. A valid v2 source prepares against the old snapshot, then commits once.
+    snapshots_before_valid = _snapshot_statuses(container_id)
     _ = source_path.write_text(_candidate_reload_source("v2"), encoding="utf-8")
     valid_signal = subprocess.run(
         ["docker", "kill", "--signal", "HUP", container_id],
@@ -1875,23 +1977,41 @@ def _exercise_candidate_prepare(
         after=len(statuses),
         gate_status="passed",
     )
+    _, valid_commit = _wait_snapshot_status(
+        container_id,
+        after=len(snapshots_before_valid),
+        publication_state="committed",
+    )
+    valid_generation = valid_commit.get("new_generation")
+    after_valid = _wait_json_value(
+        state_path,
+        "initialized_version",
+        "v2",
+    )
+    valid_service_version = _wait_service_version(container_id, "v2")
+    after_valid_mcp_processes = _wait_process_count(
+        container_id,
+        "candidate_mcp_server.py",
+        lambda count: count == initial_mcp_processes,
+    )
     time.sleep(2.3)
     after_valid = _read_json_object(state_path)
     after_valid_calls = _mcp_call_counts(calls_path)
     detached_release = state_path.parent / "release-detached-probe"
     detached_release.unlink(missing_ok=True)
-    passive_response = _control_roundtrip(socket_path, "snapshot lease gate")
+    valid_passive_response = _control_roundtrip(socket_path, "snapshot lease gate")
     _ = detached_release.write_text("released\n", encoding="utf-8")
     after_passive = _wait_json_value(
         state_path,
         "detached_snapshot_visible",
         False,
     )
-    after_valid_mcp_processes = _wait_process_count(
-        container_id,
-        "candidate_mcp_server.py",
-        lambda count: count >= initial_mcp_processes + 1,
-    )
+    fenced_before = _read_json_object(state_path)
+    time.sleep(0.3)
+    fenced_after = _read_json_object(state_path)
+
+    # 3. Returning to v1 is another commit, not resurrection of the old generation.
+    snapshots_before_return = _snapshot_statuses(container_id)
     _ = source_path.write_text(_candidate_reload_source("v1"), encoding="utf-8")
     return_signal = subprocess.run(
         ["docker", "kill", "--signal", "HUP", container_id],
@@ -1903,15 +2023,35 @@ def _exercise_candidate_prepare(
     _, return_status = _wait_candidate_status(
         container_id,
         after=len(valid_statuses),
-        gate_status="active",
+        gate_status="passed",
     )
+    _, return_commit = _wait_snapshot_status(
+        container_id,
+        after=len(snapshots_before_return),
+        publication_state="committed",
+    )
+    return_generation = return_commit.get("new_generation")
+    after_return = _wait_json_value(
+        state_path,
+        "initialized_version",
+        "v1",
+    )
+    return_service_version = _wait_service_version(container_id, "v1")
     after_return_mcp_processes = _wait_process_count(
         container_id,
         "candidate_mcp_server.py",
         lambda count: count == initial_mcp_processes,
     )
+    return_passive_response = _control_roundtrip(socket_path, "snapshot lease gate")
     after_return = _read_json_object(state_path)
     after_return_calls = _mcp_call_counts(calls_path)
+    reload_transactions = _wait_reload_transactions(
+        journal_path,
+        "candidate_reload@gate",
+        count=2,
+    )
+
+    # 4. Compare the capability catalogs and durable transaction history.
     valid_skills = valid_status.get("skills")
     valid_descriptions = valid_status.get("skill_descriptions")
     valid_drift_descriptions = valid_status.get("drift_skill_descriptions")
@@ -1942,6 +2082,23 @@ def _exercise_candidate_prepare(
             return_drift_body_hashes,
         )
     ]
+    committed_transactions = reload_transactions[-2:]
+    required_phases = [
+        "preparing",
+        "prepared",
+        "validating",
+        "commit_started",
+        "committed",
+    ]
+    journal_complete = len(committed_transactions) == 2 and all(
+        isinstance(item.get("events"), list)
+        and cast(list[object], item["events"])[:5] == required_phases
+        and cast(list[object], item["events"])[-1] == "complete"
+        and set(cast(list[object], item["events"])[5:]).issubset(
+            {"draining", "complete"}
+        )
+        for item in committed_transactions
+    )
     passed = (
         invalid_signal.returncode == 0
         and valid_signal.returncode == 0
@@ -1950,10 +2107,20 @@ def _exercise_candidate_prepare(
         and invalid_status.get("active_generation") == initial_generation
         and isinstance(invalid_status.get("snapshot_id"), str)
         and valid_status.get("snapshot_id") == invalid_status.get("snapshot_id")
-        and return_status.get("snapshot_id") == invalid_status.get("snapshot_id")
         and invalid_status.get("prepared_generation") is None
         and valid_status.get("active_generation") == initial_generation
-        and isinstance(valid_status.get("prepared_generation"), str)
+        and valid_status.get("prepared_generation") == valid_generation
+        and isinstance(valid_generation, str)
+        and valid_generation != initial_generation
+        and valid_commit.get("old_generation") == initial_generation
+        and valid_commit.get("snapshot_id") != invalid_status.get("snapshot_id")
+        and return_status.get("active_generation") == valid_generation
+        and return_status.get("prepared_generation") == return_generation
+        and return_status.get("snapshot_id") == valid_commit.get("snapshot_id")
+        and isinstance(return_generation, str)
+        and return_generation not in {initial_generation, valid_generation}
+        and return_commit.get("old_generation") == valid_generation
+        and return_commit.get("snapshot_id") != valid_commit.get("snapshot_id")
         and isinstance(valid_skills, list)
         and isinstance(valid_mcp_tools, list)
         and valid_mcp_tools
@@ -2012,22 +2179,18 @@ def _exercise_candidate_prepare(
             cast(dict[str, int], after_valid_calls.get("v2", {})).get(tool, 0) == 0
             for tool in ("fetch_events", "ack_events")
         )
-        and _integer(after_valid.get("job_runs_v1"))
-        > _integer(initial.get("job_runs_v1"))
-        and after_valid.get("job_snapshot_bound_v1") is True
-        and _integer(after_valid.get("job_runs_v2")) == 0
+        and _integer(after_invalid.get("job_runs_v1"))
+        >= _integer(initial.get("job_runs_v1"))
+        and _integer(after_valid.get("job_runs_v2")) >= 1
+        and after_valid.get("job_snapshot_bound_v2") is True
         and after_return_calls.get("v2") == after_valid_calls.get("v2")
-        and passive_response.get("content") == "snapshot-v1"
-        and _integer(after_passive.get("phase_runs_v1")) >= 1
-        and _integer(after_passive.get("phase_runs_v2")) == 0
-        and after_passive.get("phase_tool_version_v1") == "v1"
-        and after_passive.get("phase_tool_version_v2") is None
-        and after_passive.get("phase_skill_body_v1") == "candidate v1"
-        and after_passive.get("phase_skill_body_v2") is None
-        and _integer(after_passive.get("phase_event_version_v1")) >= 1
-        and _integer(after_passive.get("phase_event_version_v2")) == 0
-        and _integer(after_passive.get("phase_hook_version_v1")) >= 1
-        and _integer(after_passive.get("phase_hook_version_v2")) == 0
+        and valid_passive_response.get("content") == "snapshot-v2"
+        and return_passive_response.get("content") == "snapshot-v1"
+        and _integer(after_passive.get("phase_runs_v2")) >= 1
+        and after_passive.get("phase_tool_version_v2") == "v2"
+        and after_passive.get("phase_skill_body_v2") == "candidate v2"
+        and _integer(after_passive.get("phase_event_version_v2")) >= 1
+        and _integer(after_passive.get("phase_hook_version_v2")) >= 1
         and after_passive.get("detached_snapshot_visible") is False
         and "candidate-skill" in valid_skills
         and valid_description_map.get("candidate-skill") == "candidate v2 skill"
@@ -2038,45 +2201,116 @@ def _exercise_candidate_prepare(
         and hash_maps[2].get("candidate-skill")
         == _skill_fixture_hash("v1", drift=False)
         and hash_maps[3].get("candidate-drift") == _skill_fixture_hash("v1", drift=True)
-        and return_status.get("active_generation") == initial_generation
-        and return_status.get("prepared_generation") is None
         and after_invalid.get("active_generation") == initial_generation
-        and after_valid.get("active_generation") == initial_generation
-        and after_valid.get("initialized_version") == "v1"
-        and after_valid.get("live_mcp_version") == "v1"
+        and after_valid.get("active_generation") == valid_generation
+        and after_valid.get("initialized_version") == "v2"
+        and fenced_before.get("active_generation") == valid_generation
+        and fenced_after.get("active_generation") == valid_generation
+        and fenced_after.get("heartbeats") == fenced_before.get("heartbeats")
+        and after_return.get("active_generation") == return_generation
+        and after_return.get("initialized_version") == "v1"
         and after_return.get("live_mcp_version") == "v1"
-        and _integer(after_valid.get("heartbeats")) > initial_heartbeats
+        and _integer(fenced_before.get("heartbeats")) > initial_heartbeats
+        and valid_service_version == "v2"
+        and return_service_version == "v1"
         and initial_mcp_processes >= 1
         and after_invalid_mcp_processes == initial_mcp_processes
-        and after_valid_mcp_processes >= initial_mcp_processes + 1
+        and after_valid_mcp_processes == initial_mcp_processes
         and after_return_mcp_processes == initial_mcp_processes
+        and journal_complete
+        and [item.get("generation_id") for item in committed_transactions]
+        == [valid_generation, return_generation]
+        and [item.get("snapshot_id") for item in committed_transactions]
+        == [valid_commit.get("snapshot_id"), return_commit.get("snapshot_id")]
     )
     return {
         "passed": passed,
         "initial": initial,
         "invalid_status": invalid_status,
         "after_invalid": after_invalid,
-        "valid_status": valid_status,
+        "valid_candidate": valid_status,
+        "valid_commit": valid_commit,
         "after_valid": after_valid,
-        "return_status": return_status,
+        "writer_fence": {
+            "before": fenced_before,
+            "after": fenced_after,
+        },
+        "return_candidate": return_status,
+        "return_commit": return_commit,
         "after_return": after_return,
         "mcp_calls": {
             "initial": initial_calls,
             "after_valid": after_valid_calls,
             "after_return": after_return_calls,
         },
-        "passive_response": passive_response,
+        "valid_passive_response": valid_passive_response,
+        "return_passive_response": return_passive_response,
         "after_passive": after_passive,
         "invalid_signal": invalid_signal.returncode,
         "valid_signal": valid_signal.returncode,
         "return_signal": return_signal.returncode,
+        "service_versions": {
+            "after_valid": valid_service_version,
+            "after_return": return_service_version,
+        },
         "mcp_processes": {
             "initial": initial_mcp_processes,
             "after_invalid": after_invalid_mcp_processes,
             "after_valid": after_valid_mcp_processes,
             "after_return": after_return_mcp_processes,
         },
+        "reload_transactions": reload_transactions,
     }
+
+
+def _install_all_plugin_dependencies(
+    *,
+    repo: Path,
+    sandbox: Path,
+    compose: list[str],
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Install runtime-only MCP dependencies into the disposable sandbox."""
+
+    # 1. Keep the image's tested Core stack and add only packages absent from it.
+    target = sandbox / "python-packages"
+    target.mkdir()
+    packages = (
+        "google-api-python-client",
+        "google-auth-oauthlib",
+        "google-auth-httplib2",
+        "python-dateutil",
+        "python-dotenv",
+        "email-validator",
+        "feedparser==6.0.12",
+    )
+
+    # 2. The source mounts remain read-only; every installed file stays in /sandbox.
+    return subprocess.run(
+        [
+            *compose,
+            "run",
+            "--rm",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--entrypoint",
+            "python",
+            "akashic-plugin-gate",
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--target",
+            "/sandbox/python-packages",
+            *packages,
+        ],
+        cwd=repo,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
 
 
 def _run_runtime_smoke(
@@ -2128,20 +2362,47 @@ def _run_runtime_smoke(
         if phase == "all-plugins"
         else None
     )
-    candidate_states = (
-        _install_candidate_plugins(sandbox)
-        if phase in {"candidate", "capability-hosts", "snapshot", "topology"}
+    _write_smoke_package_selection(
+        sandbox,
+        proactive_enabled=phase
+        in {
+            "capability-hosts",
+            "snapshot",
+            "fitbit",
+            "proactive-fetch",
+        },
+    )
+    dependency_setup = (
+        _install_all_plugin_dependencies(
+            repo=repo,
+            sandbox=sandbox,
+            compose=compose,
+            env=env,
+        )
+        if all_plugins is not None
         else None
     )
-    started = subprocess.run(
-        [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
-        cwd=repo,
-        env=env,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
+    candidate_states = (
+        _install_candidate_plugins(sandbox)
+        if phase in {"atomic-reload", "capability-hosts", "snapshot", "topology"}
+        else None
     )
+    if dependency_setup is None or dependency_setup.returncode == 0:
+        started = subprocess.run(
+            [*compose, "up", "-d", "--no-build", "akashic-plugin-gate"],
+            cwd=repo,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    else:
+        started = subprocess.CompletedProcess(
+            args=compose,
+            returncode=dependency_setup.returncode,
+            stdout=dependency_setup.stdout,
+        )
     socket = sandbox / "akashic.sock"
     container_id = ""
     control_ready = False
@@ -2241,7 +2502,9 @@ def _run_runtime_smoke(
         manifest = sandbox / "home/.akashic-plugin/manifest.toml"
         manifest.parent.mkdir(parents=True, exist_ok=True)
         _ = manifest.write_text(
-            '[plugins."fitbit@gate"]\nenabled = false\n',
+            '[plugins."fitbit@gate"]\nenabled = false\n\n'
+            '[packages."default-proactive"]\nenabled = true\n\n'
+            '[packages."wake-proactive"]\nenabled = false\n',
             encoding="utf-8",
         )
         _, fitbit_disabled = _wait_snapshot_status(
@@ -2271,7 +2534,7 @@ def _run_runtime_smoke(
                 candidate_states[5],
             )
         else:
-            candidate_prepare = _exercise_candidate_prepare(
+            candidate_prepare = _exercise_atomic_reload(
                 container_id,
                 candidate_states[4],
                 candidate_states[5],
@@ -2469,6 +2732,14 @@ def _run_runtime_smoke(
         "pid1": process.strip(),
         "exit_code": exit_code,
         "start_output": started.stdout[-2000:],
+        "dependency_setup": (
+            None
+            if dependency_setup is None
+            else {
+                "returncode": dependency_setup.returncode,
+                "output": dependency_setup.stdout[-2000:],
+            }
+        ),
         "stop_output": stopped.stdout[-2000:],
         "logs": logs[-4000:],
         "phase": phase_evidence,
@@ -2522,7 +2793,7 @@ def main() -> int:
         choices=(
             "smoke",
             "scope",
-            "candidate",
+            "atomic-reload",
             "capability-hosts",
             "snapshot",
             "topology",

--- a/docker/debug/plugins/replay_debug/plugin.py
+++ b/docker/debug/plugins/replay_debug/plugin.py
@@ -70,6 +70,7 @@ class CaptureChannel:
 
 
 class ReplayDebugPlugin(Plugin):
+    api_version = 2
     name = "replay_debug"
 
     def channels(self) -> list[CaptureChannel]:

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -89,6 +89,7 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 | `proactive_quota.json` | 动作增加当前窗口计数 | 新窗口滚动时重置计数并更新当前状态 | 这是当前计数器的状态迁移，不是用户历史删除；损坏不得静默重置 |
 | `PROACTIVE_CONTEXT.md` | workspace 初始化时只在缺失时写入模板 | runtime 只读；用户或获授权文件工具可以修改规则面板 | 当前没有 runtime 自动清空或删除协议；代码升级不得用默认模板覆盖已有内容 |
 | `plugin-data/` | 已激活插件在自己的 opaque 目录增加数据 | 由插件 schema 和 owner 决定 | 普通卸载只删除代码和能力投影，保留数据；永久删除必须使用名称不同的用户操作、影响预览、备份和再次确认 |
+| `runtime/plugin-reloads.sqlite3` | 每次热重载增加 transaction 与阶段事件 | 同一 transaction 按状态机更新当前 phase、snapshot identity 和错误 | 当前没有自动 retention；恢复和事故审计仍依赖的记录不得自动删除 |
 | 插件贡献的 Skill/Drift skill | 插件 source 持有 skill 正文；安装把版本化副本发布到 cache，generation 从 `skill_roots` 建 catalog | workspace `skills/` 和 `drift/skills/` 软链接随 active generation 重建 | 禁用/卸载插件可以移除已安装副本、catalog 和软链接；外部 canonical source 不归 workspace 或卸载流程所有 |
 | 插件贡献的 MCP | 插件安装读取 `mcp_servers()` 并准备 runtime，generation readiness 通过后发布 MCP catalog | 插件升级或热重载按 generation 原子替换，旧代随 lease 排空 | 禁用/卸载插件移除 MCP catalog 和 runtime；plugin-data 不级联删除 |
 | `mcp/servers/*.toml` 与手工 skill 目录 | 当前代码仍允许绕过插件直接声明或放置能力 | watcher/loader 可以热加载这些兼容内容 | 目标架构不再扩展这条路径；应迁移成插件并删除第二套 owner，迁移完成前不得把兼容目录写成 canonical 产品资产 |
@@ -204,6 +205,8 @@ workspace 之外还有两组明确的全局状态：
 ├── observe/
 │   └── recall_inspector.jsonl         default memory inspector 启用时
 ├── subagent-runs/<job-id>/            子任务产物
+├── runtime/
+│   └── plugin-reloads.sqlite3         插件热重载事务与恢复阶段
 ├── memes/manifest.json
 ├── .app-server-token
 ├── .instance.lock
@@ -339,7 +342,10 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 - `.kv.json`：`PluginKVStore` 的原子 JSON 状态。
 - 插件自定义数据库、附件、游标或其他文件。
 
-候选插件 generation 的 KV 是只读的，正式发布后才获得可写 store。卸载流程删除全局 cache 和 manifest entry，但只返回 workspace data path，没有删除该目录。
+候选插件 generation 只能修改内存中的 KV staging；校验失败不写正式 `.kv.json`，commit
+时只落盘实际发生过的修改。正式发布后，同一个 store 才转为受 generation fencing 约束的
+直接写入。卸载流程删除全局 cache 和 manifest entry，但只返回 workspace data path，
+没有删除该目录。
 
 **F-012：** plugin-data 与插件代码生命周期分离，当前卸载会保留数据。备份系统不能只列出已知内置文件；整个目录对 core 来说必须按 opaque plugin-owned state 处理。
 

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -21,6 +21,7 @@ _MOBILE_RECALL_ASSISTANT_PREVIEW_CHARS = 50
 class AkashaPlugin(Plugin):
     """Register V2 memory inspection without exposing graph mutation."""
 
+    api_version = 2
     name = "akasha"
 
     def __init__(self) -> None:

--- a/plugins/default_memory/plugin.py
+++ b/plugins/default_memory/plugin.py
@@ -31,6 +31,8 @@ class ContextPrepareRecordModule:
 
 
 class DefaultMemoryInspector(Plugin):
+    api_version = 2
+
     @classmethod
     def dashboard_module(cls) -> str | None:
         return "dashboard.py"
@@ -41,7 +43,7 @@ class DefaultMemoryInspector(Plugin):
     def drift_skill_roots(cls) -> tuple[str, ...]:
         return ("drift/skills",)
 
-    async def initialize(self) -> None:
+    def activate(self) -> None:
         self._active = _is_memory_engine(self.context.memory_engine, "default")
         self._lock = threading.RLock()
         self._active_turns: dict[str, str] = {}

--- a/plugins/default_proactive/plugin.py
+++ b/plugins/default_proactive/plugin.py
@@ -27,6 +27,7 @@ class DefaultModuleFactory:
 
 
 class DefaultProactivePlugin(Plugin):
+    api_version = 2
     name = "default_proactive"
 
     def proactive_lifecycles(self) -> list[object]:

--- a/plugins/drift_flow/plugin.py
+++ b/plugins/drift_flow/plugin.py
@@ -15,6 +15,7 @@ class DriftModuleFactory:
 
 
 class DriftFlowPlugin(Plugin):
+    api_version = 2
     name = "drift_flow"
 
     def proactive_module_factories(self) -> list[object]:

--- a/plugins/proactive_flow/plugin.py
+++ b/plugins/proactive_flow/plugin.py
@@ -15,6 +15,7 @@ class ProactiveModuleFactory:
 
 
 class ProactiveFlowPlugin(Plugin):
+    api_version = 2
     name = "proactive_flow"
 
     def proactive_module_factories(self) -> list[object]:

--- a/plugins/wake_drift_flow/plugin.py
+++ b/plugins/wake_drift_flow/plugin.py
@@ -15,6 +15,7 @@ class WakeDriftModuleFactory:
 
 
 class WakeDriftFlowPlugin(Plugin):
+    api_version = 2
     name = "wake_drift_flow"
 
     def proactive_module_factories(self) -> list[object]:

--- a/plugins/wake_proactive/plugin.py
+++ b/plugins/wake_proactive/plugin.py
@@ -24,6 +24,7 @@ class WakeProactiveModuleFactory:
 
 
 class WakeProactivePlugin(Plugin):
+    api_version = 2
     name = "wake_proactive"
 
     def proactive_module_factories(self) -> list[object]:

--- a/plugins/wake_proactive_flow/plugin.py
+++ b/plugins/wake_proactive_flow/plugin.py
@@ -15,6 +15,7 @@ class WakeContentModuleFactory:
 
 
 class WakeProactiveFlowPlugin(Plugin):
+    api_version = 2
     name = "wake_proactive_flow"
 
     def proactive_module_factories(self) -> list[object]:

--- a/tests/test_mcp_declarations.py
+++ b/tests/test_mcp_declarations.py
@@ -211,6 +211,7 @@ async def test_real_workspace_mcp_declaration_reconcile_and_empty_delete(
     await watcher.reconcile()
     assert first.catalog.servers["docs"].client.connected is True
     await old_lease.release()
+    await manager.snapshot_store.retry_drains()
     assert first.catalog.servers["docs"].client.connected is False
     for path in declarations.glob("*.toml"):
         path.unlink()

--- a/tests/test_plugin_api_v2_gate.py
+++ b/tests/test_plugin_api_v2_gate.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+_GATE_PATH = Path(__file__).resolve().parents[1] / "docker/debug/plugin_api_v2_gate.py"
+_SPEC = importlib.util.spec_from_file_location("plugin_api_v2_gate", _GATE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+gate = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = gate
+_SPEC.loader.exec_module(gate)
+
+
+def test_release_lock_pins_every_external_plugin() -> None:
+    release = gate._load_lock(gate.DEFAULT_LOCK)
+
+    assert {plugin.id for plugin in release.plugins} == gate.EXPECTED_PLUGIN_IDS
+    assert release.contract.id == "plugin-contracts"
+    assert all(len(plugin.commit) == 40 for plugin in release.plugins)
+
+
+def test_release_lock_rejects_missing_plugin(tmp_path: Path) -> None:
+    raw = json.loads(gate.DEFAULT_LOCK.read_text(encoding="utf-8"))
+    raw["plugins"].pop()
+    lock = tmp_path / "lock.json"
+    lock.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="插件集合错误"):
+        gate._load_lock(lock)
+
+
+def test_release_lock_rejects_floating_reference(tmp_path: Path) -> None:
+    raw = json.loads(gate.DEFAULT_LOCK.read_text(encoding="utf-8"))
+    raw["plugins"][0]["commit"] = "main"
+    lock = tmp_path / "lock.json"
+    lock.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="完整 SHA"):
+        gate._load_lock(lock)
+
+
+def test_runtime_gate_uses_business_named_phases() -> None:
+    assert gate.RUNTIME_PHASES == ("atomic-reload", "all-plugins", "fitbit")

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -8,6 +8,7 @@ import os
 import py_compile
 import shutil
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -146,7 +147,7 @@ async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
         "    name = 'candidate'\n"
         "    def static_semantic_checks(self):\n"
         "        return [PluginSemanticCheck('fixture', True, 'ok')]\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('generation', self.context.generation_id)\n",
     )
     manager = _manager(tmp_path)
@@ -172,7 +173,7 @@ async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
             "from agent.plugins import Plugin\n"
             "class BadApiPlugin(Plugin):\n"
             "    name = 'bad_api'\n"
-            "    api_version = 2\n",
+            "    api_version = 1\n",
             "api_version",
         ),
         (
@@ -183,6 +184,15 @@ async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
             "    def static_semantic_checks(self):\n"
             "        return [PluginSemanticCheck('model', False, 'missing')]\n",
             "semantic_checks",
+        ),
+        (
+            "legacy_lifecycle",
+            "from agent.plugins import Plugin\n"
+            "class LegacyLifecyclePlugin(Plugin):\n"
+            "    name = 'legacy_lifecycle'\n"
+            "    async def initialize(self):\n"
+            "        raise RuntimeError('legacy lifecycle ran')\n",
+            "lifecycle_api",
         ),
         (
             "bad_source",
@@ -225,7 +235,7 @@ async def test_candidate_gate_publishes_unique_generation(tmp_path: Path):
         ),
     ],
 )
-async def test_failed_candidate_never_initializes(
+async def test_failed_candidate_never_prepares(
     tmp_path: Path,
     name: str,
     source: str,
@@ -235,7 +245,7 @@ async def test_failed_candidate_never_initializes(
     marker = plugin_dir / "initialized"
     with (plugin_dir / "plugin.py").open("a", encoding="utf-8") as file:
         _ = file.write(
-            "    async def initialize(self):\n"
+            "    async def prepare(self):\n"
             f"        open({str(marker)!r}, 'w').write('bad')\n"
         )
     tools = ToolRegistry()
@@ -470,14 +480,14 @@ async def test_candidate_phase_graph_includes_active_plugins(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_initialize_failure_replaces_passed_gate(tmp_path: Path):
+async def test_prepare_failure_replaces_passed_gate(tmp_path: Path):
     _write_plugin(
         tmp_path / "plugins",
         "init_failure",
         "from agent.plugins import Plugin\n"
         "class InitFailurePlugin(Plugin):\n"
         "    name = 'init_failure'\n"
-        "    async def initialize(self): raise RuntimeError('init failed')\n",
+        "    async def prepare(self): raise RuntimeError('init failed')\n",
     )
     manager = _manager(tmp_path)
 
@@ -485,7 +495,7 @@ async def test_initialize_failure_replaces_passed_gate(tmp_path: Path):
 
     gate = manager.latest_gate("init_failure")
     assert gate is not None and gate.status == "failed"
-    assert gate.checks[0].check_id == "initialize"
+    assert gate.checks[0].check_id == "prepare"
     assert manager.generation("init_failure") is None
 
 
@@ -534,7 +544,7 @@ async def test_generation_module_tree_is_removed_on_config_failure_and_terminate
 
 
 @pytest.mark.asyncio
-async def test_candidate_is_not_published_before_initialize_finishes(tmp_path: Path):
+async def test_candidate_is_not_published_before_prepare_finishes(tmp_path: Path):
     plugin_dir = _write_plugin(
         tmp_path / "plugins",
         "pending",
@@ -547,7 +557,7 @@ async def test_candidate_is_not_published_before_initialize_finishes(tmp_path: P
         "    async def pending_tool(self, event):\n"
         "        \"\"\"Pending tool.\"\"\"\n"
         "        return 'ready'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.event_bus.on(TurnCommitted, self.on_turn)\n"
         "        while not (self.context.plugin_dir / 'release').exists():\n"
         "            await asyncio.sleep(0.01)\n"
@@ -619,7 +629,7 @@ async def test_prepare_same_plugin_keeps_active_generation_until_snapshot_publis
         "    async def run(self, event):\n"
         "        \"\"\"Replaceable tool.\"\"\"\n"
         "        return 'v2'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('initialized_v2', True)\n",
         encoding="utf-8",
     )
@@ -1053,7 +1063,7 @@ async def test_candidate_mcp_catalog_uses_stable_public_names_and_closes(
         "        return [self.source_spec]\n"
         "    def jobs(self):\n"
         "        return [self.job_spec]\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.job_spec.triggers.append(object())\n"
         "        self.source_spec.channels.append('invalid')\n"
         "    async def refresh(self, context):\n"
@@ -1323,14 +1333,13 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
     v1_lease = store.lease()
     assert v1_lease.snapshot is v1
     transaction = store.begin_publish(v2)
-    assert store.current is v2
-    v2_lease = store.lease()
+    assert store.current is v1
+    with pytest.raises(RuntimeError, match="不可租用"):
+        _ = store.lease(v2.snapshot_id)
 
     await store.abort(transaction)
 
     assert store.current is v1
-    assert drained == []
-    await v2_lease.release()
     assert drained == [v2.snapshot_id]
     await v1_lease.release()
     assert active.lease_count == 0
@@ -1346,6 +1355,7 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="不可租用"):
         _ = store.lease(v1.snapshot_id)
     await held_v1.release()
+    await store.retry_drains()
     assert drained == [v2.snapshot_id, v1.snapshot_id]
     await store.close()
     assert drained == [v2.snapshot_id, v1.snapshot_id, next_v2.snapshot_id]
@@ -1529,7 +1539,9 @@ async def test_endpoint_failure_resumes_admission_before_candidate_terminate(
 
 
 @pytest.mark.asyncio
-async def test_runtime_snapshot_drain_retry_and_store_ownership(tmp_path: Path) -> None:
+async def test_runtime_snapshot_commit_does_not_wait_for_drain(
+    tmp_path: Path,
+) -> None:
     _write_plugin(
         tmp_path / "plugins",
         "snapshot_owner",
@@ -1549,10 +1561,14 @@ async def test_runtime_snapshot_drain_retry_and_store_ownership(tmp_path: Path) 
         catalog_generation=prepared,
     )
     attempts = 0
+    drain_started = asyncio.Event()
+    allow_drain = asyncio.Event()
 
     async def fail_once(snapshot) -> None:
         nonlocal attempts
         attempts += 1
+        drain_started.set()
+        await allow_drain.wait()
         if attempts == 1:
             raise RuntimeError("drain failed")
 
@@ -1565,11 +1581,11 @@ async def test_runtime_snapshot_drain_retry_and_store_ownership(tmp_path: Path) 
     await lease.release()
     transaction = store.begin_publish(v2)
 
-    with pytest.raises(RuntimeError, match="drain failed"):
-        await store.commit(transaction)
-
+    await asyncio.wait_for(store.commit(transaction), timeout=0.1)
     assert store.current is v2
+    await drain_started.wait()
     assert v1.snapshot_id in store.retained_snapshot_ids
+    allow_drain.set()
     await store.retry_drains()
     assert v1.snapshot_id not in store.retained_snapshot_ids
     other_store = RuntimeSnapshotStore()
@@ -1603,7 +1619,7 @@ async def test_snapshot_compile_failure_does_not_publish_plugin(
         "from agent.plugins import Plugin\n"
         "class SecondSnapshotPlugin(Plugin):\n"
         "    name = 'second_snapshot'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.kv_store.set('initialized', True)\n",
     )
     compile_snapshot = manager._snapshot_compiler.compile
@@ -1742,12 +1758,22 @@ async def test_passive_runtime_snapshot_does_not_leak_to_detached_task(
     await manager.terminate_all()
 
 
-def _snapshot_publish_source(version: str, *, fail_initialize: bool = False) -> str:
-    initialize = (
+def _snapshot_publish_source(
+    version: str,
+    *,
+    fail_prepare: bool = False,
+    fail_activate: bool = False,
+) -> str:
+    prepare_body = (
         "        self.context.kv_store.set('initialized', 'v2')\n"
-        "        raise RuntimeError('initialize failed')\n"
-        if fail_initialize
+        "        raise RuntimeError('prepare failed')\n"
+        if fail_prepare
         else f"        self.context.kv_store.set('initialized', '{version}')\n"
+    )
+    activate_body = (
+        "        raise RuntimeError('activate failed')\n"
+        if fail_activate
+        else ""
     )
     return (
         "from agent.plugins import Plugin\n"
@@ -1759,15 +1785,22 @@ def _snapshot_publish_source(version: str, *, fail_initialize: bool = False) -> 
         "class SnapshotPublishPlugin(Plugin):\n"
         "    name = 'snapshot_publish'\n"
         "    def before_turn_modules(self): return [SnapshotModule()]\n"
-        "    async def initialize(self):\n"
-        f"{initialize}"
+        "    async def prepare(self):\n"
+        "        self.data_dir_hidden_during_prepare = self.context.data_dir is None\n"
+        f"{prepare_body}"
+        "    def activate(self):\n"
+        "        if self.context.data_dir is None:\n"
+        "            raise RuntimeError('plugin data unavailable during activation')\n"
+        f"{activate_body}"
+        "    def retire(self):\n"
+        "        self.retired = True\n"
         "    async def terminate(self):\n"
         "        self.context.kv_store.set('terminated', True)\n"
     )
 
 
 @pytest.mark.asyncio
-async def test_publish_prepared_switches_snapshot_after_initialize(
+async def test_publish_prepared_switches_snapshot_after_prepare(
     tmp_path: Path,
 ) -> None:
     plugin_dir = _write_plugin(
@@ -1780,6 +1813,7 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     active = manager.generation("snapshot_publish")
     old_snapshot = manager.current_snapshot
     assert active is not None and old_snapshot is not None
+    assert active.instance.data_dir_hidden_during_prepare is True
     old_lease = manager.snapshot_store.lease()
 
     _ = (plugin_dir / "plugin.py").write_text(
@@ -1788,16 +1822,20 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     )
     candidate = await manager.prepare_candidate("snapshot_publish")
     assert candidate is not None
+    assert candidate.reload_tx_id is not None
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "prepared"
 
-    assert candidate.initialization_started is False
+    assert candidate.prepare_started is False
 
     result = await manager.publish_prepared("snapshot_publish")
 
     assert result["publication_state"] == "committed"
     assert manager.generation("snapshot_publish") is candidate
     assert manager.current_snapshot is candidate.runtime_snapshot
-    assert candidate.initialization_started is True
+    assert candidate.prepare_started is True
+    assert candidate.instance.data_dir_hidden_during_prepare is True
     assert active.state == "retired"
+    assert active.instance.retired is True
     assert old_lease.snapshot is old_snapshot
     assert old_lease.snapshot.before_turn_modules[0].version == "v1"
     next_lease = manager.snapshot_store.lease()
@@ -1806,14 +1844,20 @@ async def test_publish_prepared_switches_snapshot_after_initialize(
     state_value: object = json.loads(state.read_text(encoding="utf-8"))
     assert isinstance(state_value, dict)
     assert state_value["initialized"] == "v2"
+    with pytest.raises(RuntimeError, match="已退役 generation"):
+        active.instance.context.kv_store.set("stale_write", True)
+    assert "stale_write" not in json.loads(state.read_text(encoding="utf-8"))
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "draining"
 
     await next_lease.release()
     await old_lease.release()
+    await manager.snapshot_store.retry_drains()
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "complete"
     await manager.terminate_all()
 
 
 @pytest.mark.asyncio
-async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
+async def test_publish_prepared_prepare_failure_keeps_active_snapshot(
     tmp_path: Path,
 ) -> None:
     plugin_dir = _write_plugin(
@@ -1826,8 +1870,16 @@ async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
     active = manager.generation("snapshot_publish")
     old_snapshot = manager.current_snapshot
     assert active is not None and old_snapshot is not None
+    state_path = (
+        tmp_path
+        / "workspace"
+        / "plugin-data"
+        / "snapshot_publish-builtin"
+        / ".kv.json"
+    )
+    state_before = state_path.read_bytes()
     _ = (plugin_dir / "plugin.py").write_text(
-        _snapshot_publish_source("v2", fail_initialize=True),
+        _snapshot_publish_source("v2", fail_prepare=True),
         encoding="utf-8",
     )
     candidate = await manager.prepare_candidate("snapshot_publish")
@@ -1840,11 +1892,221 @@ async def test_publish_prepared_initialize_failure_keeps_active_snapshot(
     assert manager.current_snapshot is old_snapshot
     assert manager.prepared_generation("snapshot_publish") is None
     assert candidate.state == "discarded"
+    assert state_path.read_bytes() == state_before
     await manager.terminate_all()
 
 
 @pytest.mark.asyncio
-async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
+async def test_startup_recovers_committed_reload_by_exact_source_revision(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v2"),
+    )
+    first_manager = _manager(tmp_path)
+    await first_manager.load_all()
+    generation = first_manager.generation("snapshot_publish")
+    snapshot = first_manager.current_snapshot
+    assert generation is not None and snapshot is not None
+    source_revision = generation.source_revision
+    await first_manager.terminate_all()
+
+    tx_id = first_manager.reload_journal.begin(
+        plugin_id="snapshot_publish",
+        base_snapshot_id="snapshot-v1",
+        generation_id="snapshot_publish:source-v2:2",
+        source_revision=source_revision,
+        config_revision=generation.config_revision,
+    )
+    first_manager.reload_journal.advance(
+        tx_id,
+        "prepared",
+        candidate_snapshot_id=snapshot.snapshot_id,
+    )
+    first_manager.reload_journal.advance(tx_id, "validating")
+    first_manager.reload_journal.advance(tx_id, "commit_started")
+
+    restarted = _manager(tmp_path)
+    await restarted.load_all()
+
+    assert restarted.reload_journal.get(tx_id).phase == "recovered"
+    assert restarted.generation("snapshot_publish") is not None
+    await restarted.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_activate_failure_keeps_previous_snapshot_and_plugin_data(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_publish")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    state_path = (
+        tmp_path
+        / "workspace"
+        / "plugin-data"
+        / "snapshot_publish-builtin"
+        / ".kv.json"
+    )
+    state_before = state_path.read_bytes()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2", fail_activate=True),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None
+
+    with pytest.raises(RuntimeError, match="activate failed"):
+        await manager.publish_prepared("snapshot_publish")
+
+    assert manager.current_snapshot is old_snapshot
+    assert manager.generation("snapshot_publish") is active
+    assert candidate.instance.context.data_dir is None
+    assert candidate.scope.closed is True
+    assert state_path.read_bytes() == state_before
+    assert candidate.reload_tx_id is not None
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "aborted"
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_startup_fails_when_committed_reload_source_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v2"),
+    )
+    manager = _manager(tmp_path)
+    tx_id = manager.reload_journal.begin(
+        plugin_id="snapshot_publish",
+        base_snapshot_id="snapshot-v1",
+        generation_id="snapshot_publish:missing:2",
+        source_revision="missing-source-revision",
+        config_revision="",
+    )
+    manager.reload_journal.advance(
+        tx_id,
+        "prepared",
+        candidate_snapshot_id="snapshot-v2",
+    )
+    manager.reload_journal.advance(tx_id, "validating")
+    manager.reload_journal.advance(tx_id, "commit_started")
+
+    with pytest.raises(
+        RuntimeError,
+        match="ReloadTransaction 恢复源码不一致",
+    ):
+        await manager.load_all()
+
+    assert manager.generation("snapshot_publish") is None
+    assert manager.reload_journal.get(tx_id).phase == "commit_started"
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_kv_commit_failure_keeps_previous_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.plugins.context import PreparedPluginKVStore
+
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_publish",
+        _snapshot_publish_source("v1"),
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_publish")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    state_path = (
+        tmp_path
+        / "workspace"
+        / "plugin-data"
+        / "snapshot_publish-builtin"
+        / ".kv.json"
+    )
+    state_before = state_path.read_bytes()
+    _ = (plugin_dir / "plugin.py").write_text(
+        _snapshot_publish_source("v2"),
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("snapshot_publish")
+    assert candidate is not None
+
+    def fail_commit(_store: PreparedPluginKVStore) -> None:
+        raise OSError("candidate KV commit failed")
+
+    monkeypatch.setattr(PreparedPluginKVStore, "commit", fail_commit)
+
+    with pytest.raises(OSError, match="candidate KV commit failed"):
+        await manager.publish_prepared("snapshot_publish")
+
+    assert manager.current_snapshot is old_snapshot
+    assert manager.generation("snapshot_publish") is active
+    assert manager.prepared_generation("snapshot_publish") is None
+    assert candidate.scope.closed is True
+    assert state_path.read_bytes() == state_before
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_prepare_cannot_start_generation_task_at_runtime(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_plugin(
+        tmp_path / "plugins",
+        "prepare_task",
+        "from agent.plugins import Plugin\n"
+        "class PrepareTaskPlugin(Plugin):\n"
+        "    name = 'prepare_task'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("prepare_task")
+    old_snapshot = manager.current_snapshot
+    assert active is not None and old_snapshot is not None
+    _ = (plugin_dir / "plugin.py").write_text(
+        "import asyncio\n"
+        "from agent.plugins import Plugin\n"
+        "class PrepareTaskPlugin(Plugin):\n"
+        "    name = 'prepare_task'\n"
+        "    async def prepare(self):\n"
+        "        self.context.create_task(self._run(), name='forbidden-prepare-task')\n"
+        "    async def _run(self):\n"
+        "        await asyncio.Event().wait()\n",
+        encoding="utf-8",
+    )
+    candidate = await manager.prepare_candidate("prepare_task")
+    assert candidate is not None
+
+    result = await manager.publish_prepared("prepare_task")
+
+    assert result["publication_state"] == "failed"
+    assert manager.generation("prepare_task") is active
+    assert manager.current_snapshot is old_snapshot
+    assert candidate.scope.closed is True
+    gate = manager.latest_gate("prepare_task")
+    assert gate is not None
+    assert gate.checks[-1].check_id == "prepare"
+    assert "prepare 阶段禁止启动后台任务" in gate.failure_reason
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_is_hidden_until_commit_and_failure_keeps_previous_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1874,7 +2136,6 @@ async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
     invariant_release = asyncio.Event()
 
     async def fail_invariant(generation, snapshot) -> None:
-        assert manager.current_snapshot is snapshot
         invariant_entered.set()
         await invariant_release.wait()
         raise RuntimeError("post publish failed")
@@ -1883,20 +2144,25 @@ async def test_post_publish_invariant_failure_aborts_to_previous_snapshot(
 
     publishing = asyncio.create_task(manager.publish_prepared("snapshot_publish"))
     await invariant_entered.wait()
-    candidate_lease = manager.snapshot_store.lease()
+    visible_snapshot = manager.current_snapshot
+    ordinary_lease = manager.snapshot_store.lease()
     invariant_release.set()
     with pytest.raises(RuntimeError, match="post publish failed"):
         await publishing
+    leased_snapshot = ordinary_lease.snapshot
+    await ordinary_lease.release()
 
+    assert visible_snapshot is old_snapshot
+    assert leased_snapshot is old_snapshot
     assert manager.current_snapshot is old_snapshot
     assert manager.generation("snapshot_publish") is active
     assert manager.prepared_generation("snapshot_publish") is None
     assert candidate.state == "aborted"
-    assert candidate.scope.closed is False
     assert candidate.runtime_snapshot is not None
     assert candidate.runtime_snapshot.state == "aborted"
-    await candidate_lease.release()
     assert candidate.scope.closed is True
+    assert candidate.reload_tx_id is not None
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "aborted"
     assert any(
         failure.error == "terminate failed"
         for failure in manager.cleanup_failures
@@ -1940,7 +2206,7 @@ async def test_post_publish_invariant_timeout_aborts_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_cancelled_publish_waits_for_candidate_lease_before_cleanup(
+async def test_cancelled_publish_never_leases_candidate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1968,14 +2234,14 @@ async def test_cancelled_publish_waits_for_candidate_lease_before_cleanup(
     publishing = asyncio.create_task(manager.publish_prepared("snapshot_publish"))
     await entered.wait()
     lease = manager.snapshot_store.lease()
+    assert lease.snapshot is old_snapshot
     publishing.cancel()
     with pytest.raises(asyncio.CancelledError):
         await publishing
 
     assert manager.current_snapshot is old_snapshot
-    assert candidate.scope.closed is False
-    await lease.release()
     assert candidate.scope.closed is True
+    await lease.release()
     await manager.terminate_all()
 
 
@@ -2097,7 +2363,9 @@ async def test_reconcile_changed_disables_and_reenables_plugin_capabilities(
         "    @tool(name='topology_value')\n"
         "    async def value(self, event):\n"
         "        \"\"\"Return topology value.\"\"\"\n"
-        "        return 'active'\n",
+        "        return 'active'\n"
+        "    def retire(self):\n"
+        "        self.retired = True\n",
     )
     skill = plugin_dir / "skills" / "topology-skill"
     skill.mkdir(parents=True)
@@ -2111,6 +2379,8 @@ async def test_reconcile_changed_disables_and_reenables_plugin_capabilities(
     write_plugin_manifest({"topology": True}, plugins_home=plugins_home)
     await manager.load_all()
     assert tools.has_tool("topology_value")
+    active = manager.generation("topology")
+    assert active is not None
 
     write_plugin_manifest({"topology": False}, plugins_home=plugins_home)
     disabled = await manager.reconcile_changed()
@@ -2121,6 +2391,8 @@ async def test_reconcile_changed_disables_and_reenables_plugin_capabilities(
     assert not snapshot.tool_registry.has_tool("topology_value")
     assert "topology-skill" not in snapshot.plugin_skill_index.records
     assert manager.generation("topology") is None
+    assert active.retire_started is True
+    assert active.instance.retired is True
 
     write_plugin_manifest({"topology": True}, plugins_home=plugins_home)
     enabled = await manager.reconcile_changed()
@@ -2283,8 +2555,17 @@ async def test_publish_cancellation_after_store_commit_keeps_manager_consistent(
     release = asyncio.Event()
     original_commit = manager.snapshot_store.commit
 
-    async def delayed_commit(transaction) -> None:
-        await original_commit(transaction)
+    async def delayed_commit(
+        transaction,
+        *,
+        before_open=None,
+        after_open=None,
+    ) -> None:
+        await original_commit(
+            transaction,
+            before_open=before_open,
+            after_open=after_open,
+        )
         committed.set()
         await release.wait()
 
@@ -2355,7 +2636,12 @@ async def test_plugin_watcher_reloads_source_without_signal(tmp_path: Path) -> N
     )
     manager = _manager(tmp_path)
     await manager.load_all()
-    watcher = PluginWatcher(manager, interval_seconds=0.01)
+    baseline_revision = await asyncio.to_thread(manager.watch_revision)
+    watcher = PluginWatcher(
+        manager,
+        baseline_revision=baseline_revision,
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     await asyncio.sleep(0)
     source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
@@ -2378,6 +2664,39 @@ async def test_plugin_watcher_reloads_source_without_signal(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_plugin_watcher_scans_files_outside_event_loop_thread() -> None:
+    event_loop_thread = threading.get_ident()
+
+    class Manager:
+        def __init__(self) -> None:
+            self.scan_threads: list[int] = []
+
+        def watch_revision(self) -> str:
+            self.scan_threads.append(threading.get_ident())
+            return "stable"
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            return []
+
+    manager = Manager()
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+    )
+    task = asyncio.create_task(watcher.run())
+    for _ in range(100):
+        if manager.scan_threads:
+            break
+        await asyncio.sleep(0.01)
+
+    watcher.stop()
+    await task
+    assert manager.scan_threads
+    assert all(thread_id != event_loop_thread for thread_id in manager.scan_threads)
+
+
+@pytest.mark.asyncio
 async def test_plugin_watcher_reconciles_change_arriving_during_scan() -> None:
     class Manager:
         def __init__(self) -> None:
@@ -2397,7 +2716,11 @@ async def test_plugin_watcher_reconciles_change_arriving_during_scan() -> None:
             return []
 
     manager = Manager()
-    watcher = PluginWatcher(cast(PluginManager, manager), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="a",
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     await asyncio.sleep(0)
     manager.revision = "b"
@@ -2412,6 +2735,33 @@ async def test_plugin_watcher_reconciles_change_arriving_during_scan() -> None:
     watcher.stop()
     await task
     assert manager.calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_plugin_watcher_forced_wake_reconciles_unchanged_revision() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.called = asyncio.Event()
+
+        def watch_revision(self) -> str:
+            return "stable"
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            self.called.set()
+            return []
+
+    manager = Manager()
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=60,
+    )
+    task = asyncio.create_task(watcher.run())
+    watcher.wake()
+    await asyncio.wait_for(manager.called.wait(), timeout=1)
+
+    watcher.stop()
+    await task
 
 
 @pytest.mark.asyncio
@@ -2432,7 +2782,11 @@ async def test_plugin_watcher_recovers_after_revision_scan_error() -> None:
             return []
 
     manager = Manager()
-    watcher = PluginWatcher(cast(PluginManager, manager), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="",
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     for _ in range(100):
         if manager.calls:
@@ -2462,7 +2816,11 @@ async def test_plugin_watcher_does_not_reconcile_after_recovered_scan_error() ->
             return []
 
     manager = Manager()
-    watcher = PluginWatcher(cast(PluginManager, manager), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     for _ in range(100):
         if manager.scans >= 3:
@@ -2504,6 +2862,7 @@ async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
 
     watcher = PluginWatcher(
         cast(PluginManager, manager),
+        baseline_revision="stable",
         interval_seconds=0.01,
         after_reconcile=after_reconcile,
     )
@@ -2551,6 +2910,7 @@ async def test_plugin_watcher_retries_notification_without_reconciling_again() -
 
     watcher = PluginWatcher(
         cast(PluginManager, manager),
+        baseline_revision="stable",
         interval_seconds=0.01,
         after_reconcile=after_reconcile,
     )
@@ -2589,6 +2949,7 @@ async def test_plugin_watcher_confirms_disabled_result_against_stable_revision()
 
     watcher = PluginWatcher(
         cast(PluginManager, manager),
+        baseline_revision="stable",
         interval_seconds=0.01,
         after_reconcile=notify,
     )
@@ -2630,6 +2991,7 @@ async def test_plugin_watcher_notifies_explicit_disable_after_confirmation() -> 
 
     watcher = PluginWatcher(
         cast(PluginManager, manager),
+        baseline_revision="stable",
         interval_seconds=0.01,
         after_reconcile=notify,
     )
@@ -2673,6 +3035,7 @@ async def test_plugin_watcher_retries_failed_disabled_confirmation() -> None:
 
     watcher = PluginWatcher(
         cast(PluginManager, manager),
+        baseline_revision="stable",
         interval_seconds=0.01,
         after_reconcile=notify,
     )
@@ -2708,7 +3071,11 @@ async def test_plugin_watcher_propagates_cancellation_and_marks_stopped() -> Non
             return []
 
     manager = Manager()
-    watcher = PluginWatcher(cast(PluginManager, manager), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     await asyncio.sleep(0)
     manager.revision = "changed"
@@ -2732,7 +3099,11 @@ async def test_plugin_watcher_stop_before_run_skips_initial_scan() -> None:
             return "stable"
 
     manager = Manager()
-    watcher = PluginWatcher(cast(PluginManager, manager), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+    )
     watcher.stop()
 
     await watcher.run()
@@ -2746,7 +3117,11 @@ async def test_plugin_watcher_cancellation_before_start_does_not_leak_waiter() -
         def watch_revision(self) -> str:
             raise AssertionError("未启动的 watcher 不应扫描")
 
-    watcher = PluginWatcher(cast(PluginManager, Manager()), interval_seconds=0.01)
+    watcher = PluginWatcher(
+        cast(PluginManager, Manager()),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+    )
     task = asyncio.create_task(watcher.run())
     watcher.stop()
     task.cancel()
@@ -3047,6 +3422,7 @@ async def test_workspace_mcp_generation_publish_preserves_old_turn_lease(
 
     assert old_client.connected is True
     await old_fork.release()
+    await manager.snapshot_store.retry_drains()
     assert old_client.connected is False
     new_lease = await manager.snapshot_store.acquire()
     token = bind_runtime_snapshot(new_lease)
@@ -3331,7 +3707,7 @@ def _snapshot_event_source(version: str) -> str:
         "from bus.events_lifecycle import TurnCommitted\n"
         "class SnapshotEventPlugin(Plugin):\n"
         "    name = 'snapshot_event'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.context.event_bus.on(TurnCommitted, self.handle)\n"
         "    async def handle(self, event):\n"
         f"{wait}"
@@ -3412,7 +3788,7 @@ async def test_snapshot_event_subscription_close_takes_effect_immediately(
         "from bus.events_lifecycle import TurnCommitted\n"
         "class SnapshotEventPlugin(Plugin):\n"
         "    name = 'snapshot_event'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.subscription = self.context.event_bus.on(TurnCommitted, self.handle)\n"
         "    def handle(self, event):\n"
         "        self.context.kv_store.increment('events')\n",
@@ -3442,7 +3818,7 @@ async def test_snapshot_event_subscription_close_takes_effect_immediately(
 
     state_path = tmp_path / "workspace/plugin-data/snapshot_event-builtin/.kv.json"
     assert not state_path.exists()
-    with pytest.raises(RuntimeError, match="只能在 initialize"):
+    with pytest.raises(RuntimeError, match="必须在 generation 开放前"):
         generation.instance.context.event_bus.on(TurnCommitted, lambda _: None)
     await event_bus.aclose()
     await manager.terminate_all()
@@ -3946,6 +4322,7 @@ async def test_dashboard_routes_follow_snapshot_generation(tmp_path: Path) -> No
     ).json() == {"version": "v1"}
     assert not (tmp_path / "workspace" / "dashboard-v1-closed").exists()
     await old_lease.release()
+    await manager.snapshot_store.retry_drains()
     assert (tmp_path / "workspace" / "dashboard-v1-closed").exists()
     assert old_generation.scope.closed
     assert f"{old_generation.module_path}.dashboard" not in sys.modules

--- a/tests/test_plugin_hot_reload_probe.py
+++ b/tests/test_plugin_hot_reload_probe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import sys
 
 _PROBE_PATH = (
@@ -28,6 +29,62 @@ def test_controller_rejects_protected_sandbox() -> None:
 
     assert probe._sandbox_is_protected(root / "gate", [root])
     assert not probe._sandbox_is_protected(Path("/tmp/gate"), [root])
+
+
+def test_gate_sandbox_prepares_static_mountpoint_outside_clean_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "clean-checkout"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "removed.py").write_text("obsolete = True\n", encoding="utf-8")
+    subprocess.run(["git", "add", "removed.py"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Plugin Gate Test",
+            "-c",
+            "user.email=plugin-gate-test@invalid",
+            "commit",
+            "-qm",
+            "baseline",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    (repo / "removed.py").unlink()
+    (repo / "main.py").write_text("print('clean')\n", encoding="utf-8")
+    (repo / "current").symlink_to("main.py")
+    subprocess.run(["git", "add", "--all"], cwd=repo, check=True)
+    assert not (repo / "static").exists()
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    probe._prepare_gate_sandbox(sandbox, repo)
+    compose = (
+        Path(__file__).parents[1] / "docker/debug/docker-compose.plugin-gate.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (sandbox / "app/main.py").read_text(encoding="utf-8") == "print('clean')\n"
+    assert (sandbox / "app/current").readlink() == Path("main.py")
+    assert not (sandbox / "app/removed.py").exists()
+    assert (sandbox / "app/static").is_dir()
+    assert (sandbox / "static").is_dir()
+    assert not (repo / "static").exists()
+    assert (
+        subprocess.run(
+            ["git", "-C", str(sandbox / "app"), "rev-parse", "--verify", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    assert (
+        "${AKASHIC_GATE_SANDBOX:?set by plugin_hot_reload_probe.py}"
+        "/app:/app:ro"
+    ) in compose
+    assert "../..:/app:ro" not in compose
 
 
 def test_system_gate_propagates_subgate_failure() -> None:

--- a/tests/test_plugin_hot_reload_probe.py
+++ b/tests/test_plugin_hot_reload_probe.py
@@ -87,6 +87,14 @@ def test_gate_sandbox_prepares_static_mountpoint_outside_clean_checkout(
     assert "../..:/app:ro" not in compose
 
 
+def test_plugin_gate_pins_fastmcp_compatible_runtime() -> None:
+    dockerfile = (
+        Path(__file__).parents[1] / "docker/debug/Dockerfile"
+    ).read_text(encoding="utf-8")
+
+    assert "python -m pip install mcp==1.28.1" in dockerfile
+
+
 def test_system_gate_propagates_subgate_failure() -> None:
     baseline = {
         "build_returncode": 0,

--- a/tests/test_plugin_hot_reload_probe.py
+++ b/tests/test_plugin_hot_reload_probe.py
@@ -79,6 +79,22 @@ def test_smoke_config_uses_app_server_control_endpoint(tmp_path: Path) -> None:
     assert "[channels]" not in config
 
 
+def test_smoke_package_selection_enables_default_proactive(tmp_path: Path) -> None:
+    manifest = tmp_path / "home/.akashic-plugin/manifest.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        '[plugins."fitbit@gate"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+
+    probe._write_smoke_package_selection(tmp_path, proactive_enabled=True)
+
+    content = manifest.read_text(encoding="utf-8")
+    assert '[plugins."fitbit@gate"]' in content
+    assert '[packages."default-proactive"]\nenabled = true' in content
+    assert '[packages."wake-proactive"]\nenabled = false' in content
+
+
 def test_migrated_plugin_gate_uses_mobile_catalog_not_dashboard(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -20,7 +20,7 @@ import pytest
 from agent.core.passive_turn import ContextStore as _  # noqa: F401
 from agent.config_models import Config
 from agent.lifecycle.types import AfterStepCtx, AfterToolResultCtx, BeforeToolCallCtx, BeforeTurnCtx
-from agent.plugins.context import PluginKVStore
+from agent.plugins.context import PluginKVStore, PreparedPluginKVStore
 from agent.plugins.manager import PluginManager
 from agent.plugins.manifest import write_package_manifest
 from agent.plugins.jobs import PluginJobRuntime, PluginJobSpec, RegisteredPluginJob
@@ -610,10 +610,11 @@ async def test_plugin_manager_scope_cleans_legacy_resources(tmp_path: Path):
         "from agent.plugins import Plugin\n"
         "from bus.events_lifecycle import TurnCommitted\n"
         "class ScopedPlugin(Plugin):\n"
-        "    name = 'scoped'\n"
-        "    async def initialize(self):\n"
-        "        self.context.event_bus.on(TurnCommitted, self._handle)\n"
-        "        self.task = self.context.create_task(self._run(), name='scoped-worker')\n"
+            "    name = 'scoped'\n"
+            "    async def prepare(self):\n"
+            "        self.context.event_bus.on(TurnCommitted, self._handle)\n"
+            "    def activate(self):\n"
+            "        self.task = self.context.create_task(self._run(), name='scoped-worker')\n"
         "        self.context.defer('marker', lambda: self.context.kv_store.set('closed', True))\n"
         "    async def terminate(self):\n"
         "        raise RuntimeError('terminate failed')\n"
@@ -662,7 +663,7 @@ async def test_plugin_manager_consumes_scope_failures_after_terminate_cancellati
         "release = asyncio.Event()\n"
         "class CancelledClosePlugin(Plugin):\n"
         "    name = 'cancelled_close'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        async def slow_cleanup():\n"
         "            entered.set()\n"
         "            await release.wait()\n"
@@ -696,7 +697,7 @@ async def test_plugin_manager_consumes_scope_failures_after_terminate_cancellati
 
 
 @pytest.mark.asyncio
-async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
+async def test_plugin_prepare_failure_calls_terminate(tmp_path: Path):
     plugin_root = tmp_path / "plugins"
     plugin_dir = plugin_root / "failing"
     plugin_dir.mkdir(parents=True)
@@ -709,7 +710,7 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
         "tasks = []\n"
         "class FailingPlugin(Plugin):\n"
         "    name = 'failing'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.task = asyncio.create_task(asyncio.Event().wait())\n"
         "        tasks.append(self.task)\n"
         "        raise RuntimeError('init failed')\n"
@@ -734,7 +735,7 @@ async def test_plugin_initialize_failure_calls_terminate(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
+async def test_plugin_prepare_cancellation_rolls_back(tmp_path: Path):
     plugin_root = tmp_path / "plugins"
     plugin_dir = plugin_root / "cancelled"
     plugin_dir.mkdir(parents=True)
@@ -748,7 +749,7 @@ async def test_plugin_initialize_cancellation_rolls_back(tmp_path: Path):
         "tasks = []\n"
         "class CancelledPlugin(Plugin):\n"
         "    name = 'cancelled'\n"
-        "    async def initialize(self):\n"
+        "    async def prepare(self):\n"
         "        self.task = asyncio.create_task(asyncio.Event().wait())\n"
         "        tasks.append(self.task)\n"
         "        started.set()\n"
@@ -987,6 +988,21 @@ def test_kv_store_rejects_non_object_root(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="插件 KV 根节点必须是对象"):
         store.get("turn_count")
+
+
+def test_unmodified_candidate_kv_commit_does_not_create_state_file(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / ".kv.json"
+    store = PreparedPluginKVStore(
+        path,
+        can_write=lambda: True,
+        writer_id="candidate:1",
+    )
+
+    store.commit()
+
+    assert not path.exists()
 
 
 # ── 程序化身份声明测试 ────────────────────────────────────────────────────────

--- a/tests/test_plugin_reload_journal.py
+++ b/tests/test_plugin_reload_journal.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+
+from agent.plugins.reload_journal import ReloadJournal
+
+
+def test_reload_journal_records_durable_transaction_phases(tmp_path: Path) -> None:
+    journal = ReloadJournal(tmp_path / "workspace")
+    tx_id = journal.begin(
+        plugin_id="weather",
+        base_snapshot_id="snapshot-v1",
+        generation_id="weather:source-v2:2",
+        source_revision="source-v2",
+        config_revision="config-v2",
+    )
+
+    journal.advance(
+        tx_id,
+        "prepared",
+        candidate_snapshot_id="snapshot-v2",
+    )
+    journal.advance(tx_id, "validating")
+    journal.advance(tx_id, "commit_started")
+    journal.advance(tx_id, "committed")
+    journal.advance(tx_id, "draining")
+
+    record = journal.get(tx_id)
+    assert record.phase == "draining"
+    assert record.plugin_id == "weather"
+    assert record.base_snapshot_id == "snapshot-v1"
+    assert record.candidate_snapshot_id == "snapshot-v2"
+    assert record.source_revision == "source-v2"
+    assert [event.phase for event in journal.events(tx_id)] == [
+        "preparing",
+        "prepared",
+        "validating",
+        "commit_started",
+        "committed",
+        "draining",
+    ]
+
+    reopened = ReloadJournal(tmp_path / "workspace")
+    assert reopened.get(tx_id) == record
+
+
+def test_reload_journal_rejects_invalid_phase_transition(tmp_path: Path) -> None:
+    journal = ReloadJournal(tmp_path / "workspace")
+    tx_id = journal.begin(
+        plugin_id="weather",
+        base_snapshot_id="snapshot-v1",
+        generation_id="weather:source-v2:2",
+        source_revision="source-v2",
+        config_revision="config-v2",
+    )
+
+    with pytest.raises(RuntimeError, match="ReloadTransaction 状态跳转无效"):
+        journal.advance(tx_id, "committed")
+
+
+def test_reload_journal_builds_crash_recovery_plan(tmp_path: Path) -> None:
+    journal = ReloadJournal(tmp_path / "workspace")
+    prepared = journal.begin(
+        plugin_id="weather",
+        base_snapshot_id="snapshot-v1",
+        generation_id="weather:source-v2:2",
+        source_revision="source-v2",
+        config_revision="config-v2",
+    )
+    journal.advance(prepared, "prepared")
+    committed = journal.begin(
+        plugin_id="calendar",
+        base_snapshot_id="snapshot-v1",
+        generation_id="calendar:source-v3:3",
+        source_revision="source-v3",
+        config_revision="config-v3",
+    )
+    journal.advance(
+        committed,
+        "prepared",
+        candidate_snapshot_id="snapshot-v3",
+    )
+    journal.advance(committed, "validating")
+    journal.advance(committed, "commit_started")
+
+    actions = journal.pending_recovery()
+
+    assert [(action.tx_id, action.action) for action in actions] == [
+        (committed, "restore_committed"),
+        (prepared, "discard_candidate"),
+    ]
+    journal.finish_recovery(actions[0])
+    journal.finish_recovery(actions[1])
+    assert journal.get(committed).phase == "recovered"
+    assert journal.get(prepared).phase == "aborted"
+    assert journal.pending_recovery() == ()

--- a/tests/test_recall_inspector_plugin.py
+++ b/tests/test_recall_inspector_plugin.py
@@ -32,7 +32,7 @@ async def test_recall_inspector_records_context_and_recall(tmp_path: Path) -> No
         workspace=tmp_path,
         memory_engine=DefaultMemoryEngine.__new__(DefaultMemoryEngine),
     )
-    await plugin.initialize()
+    plugin.activate()
 
     ctx = BeforeTurnCtx(
         session_key="cli:1",
@@ -138,7 +138,7 @@ async def test_recall_inspector_uses_workspace_data_path(tmp_path: Path) -> None
         workspace=workspace,
         memory_engine=DefaultMemoryEngine.__new__(DefaultMemoryEngine),
     )
-    await plugin.initialize()
+    plugin.activate()
 
     plugin.record_context_prepare(
         BeforeTurnCtx(
@@ -197,7 +197,7 @@ async def test_recall_inspector_is_inactive_without_memory_engine(tmp_path: Path
         memory_engine=None,
     )
 
-    await plugin.initialize()
+    plugin.activate()
 
     assert plugin.is_active() is False
     plugin.record_context_prepare(


### PR DESCRIPTION
## What changed

- Publish only committed runtime snapshots; validating candidates never become visible to ordinary readers.
- Replace legacy `initialize()` with explicit API v2 lifecycle: `prepare`, `activate`, `retire`, `terminate`.
- Stage candidate KV and event state, fence retired writers, and drain old generations in the background.
- Persist reload phases in a SQLite journal for deterministic restart recovery.
- Add an exact cross-repository lock for the contract checker and 21 external plugin commits, plus isolated Docker Debug probes.
- Keep the clean-checkout Docker mount self-contained and pin the FastMCP-compatible runtime to `mcp==1.28.1`.

## User impact

Plugin reloads now behave as an atomic switch: active requests stay on the old generation, new requests enter the committed generation, and a failed candidate cannot leak partial tools, events, jobs, MCP bindings, UI bindings, or plugin data changes.

## Validation

- `pytest -q`: 2410 passed, 1 skipped
- Pyright core: 0 errors
- Pyright tests: 0 errors
- Public change-impact Gate: passed
- Locked Plugin API v2 Gate: 21 static contracts + `atomic-reload` + `all-plugins` + `fitbit`, all passed
- GitHub CI: all 5 existing jobs passed
- Official private companion: `pending_maintainer` because `private_runtime/` contains no provider implementation in this checkout

## Rollback

Revert `acd7878b`, `2c14581d`, `f0417a97`, and `6964db78` in reverse order; external plugin branches remain independently reviewable and the pre-change states are retained under local backup refs.