### PR TITLE
ci(plugins): enforce the locked API v2 release gate

### DIFF
--- a/.github/workflows/plugin-api-v2.yml
+++ b/.github/workflows/plugin-api-v2.yml
@@ -3,6 +3,8 @@ name: plugin-api-v2
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/plugin-api-v2.yml
+++ b/.github/workflows/plugin-api-v2.yml
@@ -34,6 +34,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/plugin-api-v2.yml
+++ b/.github/workflows/plugin-api-v2.yml
@@ -1,0 +1,47 @@
+name: plugin-api-v2
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: akashic-plugins/plugin-contracts
+          ref: 24543445c7b99ca63fcd90b5828f754a148b184c
+          path: .plugin-contracts
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Check built-in Plugin API v2
+        env:
+          PYTHONPATH: .plugin-contracts
+        run: >-
+          python -m akashic_plugin_contracts check
+          plugins/*/plugin.py
+          docker/debug/plugins/*/plugin.py
+
+  locked-runtime:
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Verify locked external plugins in Docker Debug
+        run: python docker/debug/plugin_api_v2_gate.py --require-clean-core
+      - name: Upload Plugin API v2 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-api-v2
+          path: docker/debug/reports/plugin-api-v2/

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -104,7 +104,7 @@
 | Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
 | 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
-| 插件安装、热重载、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、10～13 节 → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/skill_links.py`、`agent/mcp/host.py` |
+| 插件安装、热重载、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、10～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/reload_journal.py`、`agent/plugins/skill_links.py`、`agent/mcp/host.py` |
 | 移动端查看 Markdown、定时任务、插件、Skill、MCP | `projectneed` 第 6、10～13 节 → [移动端运行时检查](design/mobile-runtime-inspection.md) → [持久化状态地图](design/persistence-state-map.md) | `infra/mobile_realtime/runtime_inspection.py`、`infra/mobile_realtime/protocol.py`、`infra/mobile_realtime/channel.py` |
 | Workspace、配置、凭据、迁移、备份 | `projectneed` 第 6、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [0005](decisions/0005-git-cursor-drives-one-shot-migrations.md) → [迁移维护手册](design/git-migration-authoring.md) → [Git 一次性迁移设计](spark/2026-07-21-git-backed-one-shot-migrations-design.md) | `main.py`、`bootstrap/init_workspace.py`、`agent/config.py`、`agent/migrations/`、`migrations/`、`agent/model_runtime/auth/store.py`、`scripts/rolling_backup.py` |
 | 高风险 refactor、语义不变重构、CI oracle | `projectneed` 第 4～6、13～14 节 → [综合重构账本](refactor/clean-code-ledger.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → 相关决策 | 改动前后的完整 diff、semantic tests、write set、故障注入 |
@@ -186,7 +186,8 @@ docs/
 │   ├── 0004-cross-repository-evidence-is-an-immutable-combination.md
 │   ├── 0005-git-cursor-drives-one-shot-migrations.md
 │   ├── 0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
-│   └── 0007-mobile-plugin-control-and-data-planes-are-explicit.md
+│   ├── 0007-mobile-plugin-control-and-data-planes-are-explicit.md
+│   └── 0008-plugin-runtime-publishes-only-committed-snapshots.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── mobile-cross-repository-semantic-gate.md

--- a/docs/decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md
+++ b/docs/decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md
@@ -1,0 +1,70 @@
+# 0008 · 插件运行时只发布已提交快照
+
+- 状态：accepted
+- 日期：2026-07-28
+- 关联条款：PLG-001～PLG-008、GOV-005、TST-006～TST-008
+
+## 背景
+
+旧插件生命周期用一个 `initialize()` 同时承担候选准备、正式数据访问和后台任务启动。
+候选快照在最终校验期间还会短暂成为普通 reader 的 current snapshot。进程内回滚可以恢复
+部分内存指针，却无法说明进程在端点切换、快照提交或旧代排空之间崩溃后应该恢复哪一代。
+
+插件位于多个独立仓库。只在核心仓库复制接口测试，或让 CI 跟随插件默认分支，无法证明
+某个确定的核心版本与确定的插件组合能够一起发布。
+
+## 决定
+
+1. 插件只支持 API v2。插件类显式声明 `api_version = 2`；旧 `initialize()` 不再兼容。
+2. `prepare()` 只使用候选代际的 KV staging、事件 staging 和资源 scope，不取得正式
+   `data_dir`、session、memory 或 LLM，也不启动后台任务。
+3. 所有门控通过后，`activate()` 在同步提交临界区取得正式资源并启动新代任务。随后只做
+   一次 current snapshot 指针切换；普通 reader 永远只能租用 committed snapshot。
+4. 指针切换后同步调用旧代 `retire()`，阻止它再接新工作；已有 lease 继续使用原快照。
+   lease 排空后再调用 `terminate()` 并逆序清理 scope。
+5. 每次热重载把阶段写入 workspace 内独立 SQLite journal。启动时丢弃未提交候选；已经提交
+   但未完成 drain 的事务必须按精确 source revision 恢复，否则启动失败并暴露不一致。
+6. 核心和外部插件使用一个发布锁固定合同检查器与全部插件的完整 commit SHA。CI 从公开
+   HTTPS 仓库检出这组提交，在只读源码挂载和一次性 workspace 中运行静态合同、原子热重载、
+   全插件启停和 Fitbit 托管进程场景。
+
+```text
+┌──────────────┐    ┌────────────────┐    ┌──────────────┐
+│ prepare shadow│───▶│ validate gates │───▶│ commit pointer│
+└──────────────┘    └────────────────┘    └──────┬───────┘
+                                                  ▼
+                                        ┌──────────────────┐
+                                        │ retire old       │
+                                        │ wait old leases  │
+                                        │ terminate + clean│
+                                        └──────────────────┘
+```
+
+## 理由
+
+这把用户可见的提交点收敛为一个动作：新请求要么完整看到旧代，要么完整看到新代。候选失败
+不会产生普通流量可见的脏读，旧请求也不会因为新代发布而丢失自己的 handler、skill、tool、
+job、MCP 或 dashboard 绑定。
+
+API v2 把可暂存工作与正式副作用分开，使 Core 能在候选失败时清除资源而不伪装外部效果已经
+回滚。journal 不承诺撤销已经发生的远端效果；它负责让重启后的恢复选择明确、可检查且
+fail-loud。
+
+## 影响
+
+- 插件作者必须把纯准备放入 `prepare()`，把 task 和正式路径相关动作放入 `activate()`。
+- `retire()` 是同步停止接新工作的通知；`terminate()` 是 drain 后的异步最终清理。
+- 没有写过 KV 的候选提交不会创建空 `.kv.json`；确实发生的候选 KV 修改只在 commit 落盘。
+- watcher 只负责发现 revision；业务请求仍以 snapshot lease 决定所见代际。
+- `docker/debug/plugin-api-v2.lock.json` 是本次跨仓库发布组合身份，不能使用 branch 或 tag
+  代替完整 SHA。
+
+## 验收
+
+- 校验期间 current snapshot 仍是旧代，且 validating snapshot 无法被普通 reader 租用。
+- 无效源码、prepare 失败、activate 失败和提交失败都保留旧代及原 plugin-data。
+- 新代提交后，tool、event、job、skill、MCP、service 和请求在同一快照切换；旧代 writer
+  被 fence，旧 lease 排空后资源只清理一次。
+- 进程在 journal 各阶段重启时得到确定的 discard、restore 或 fail-loud 结果。
+- 锁定的 21 个插件全部通过 API v2 静态合同；Docker Gate 能完成原子热重载、19 个可运行
+  外部插件全量启停，以及 Fitbit 进程单实例、热重载、禁用和用户数据不变检查。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -13,6 +13,7 @@
 | [0005](0005-git-cursor-drives-one-shot-migrations.md) | accepted | Git cursor 驱动一次性兼容迁移 | MIG-001、MIG-002、WSP-003、BAK-001 |
 | [0006](0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) | accepted | Akasha V2 是显式记忆的唯一算法实现 | MEM-009、SES-003、GOV-005、TST-002、TST-005 |
 | [0007](0007-mobile-plugin-control-and-data-planes-are-explicit.md) | accepted | 移动插件控制面与查询数据面显式分离 | MOB-001、MOB-003、MOB-006、PLG-003、PLG-011、TST-006～TST-008 |
+| [0008](0008-plugin-runtime-publishes-only-committed-snapshots.md) | accepted | 插件运行时只发布已提交快照 | PLG-001～PLG-008、GOV-005、TST-006～TST-008 |
 
 ## 新增规则
 


### PR DESCRIPTION
## What changed

- Add the required Core workflow for built-in Plugin API v2 checks and the locked cross-repository Docker runtime gate.
- Pin the public contract checker to an immutable commit.
- Record the accepted runtime publication decision as ADR 0008 and route plugin-runtime work through it.
- Run feature heads once through `pull_request`; reserve `push` execution for `main`, removing the duplicate full Docker Gate.

## Stack

Depends on #230. This PR is intentionally separated because the repository change-impact policy rejects protected contract/workflow files mixed with production source in one diff.

## Validation

- Built-in contract check: 9 plugin classes, 0 violations
- Change-impact Gate against `feat/plugin-runtime-v2`: passed, plan `2f04c2a9ba9e5c65d2d55349f2734593bf9d0510515857184cde9590744a57c7`
- GitHub locked runtime run `30385624487`: `atomic-reload`, `all-plugins`, and `fitbit` passed against all 21 pinned plugin commits
- Existing `runtime-extension-gate` retained because it independently protects supervisor restart, workspace MCP watcher, and soak behavior
- Official private companion: `pending_maintainer`

## Merge order

Merge #230 first, retarget this PR to `main`, then merge #231. External plugin PRs remain independently reviewable and should land with the same locked commit combination.