### PR TITLE
fix(context): 保留完整主动历史正文

### DIFF
--- a/session/manager.py
+++ b/session/manager.py
@@ -18,7 +18,6 @@ from session.store import SessionStore
 
 _TOOL_RESULT_CHAR_BUDGET = 10000
 _STORED_TOOL_RESULT_CHAR_BUDGET = 20000
-_PROACTIVE_HISTORY_CHAR_BUDGET = 360
 _PROACTIVE_META_HISTORY_CHAR_BUDGET = 1200
 _MSG_KEYS = {"id", "session_key", "seq", "role", "content", "timestamp", "tool_chain"}
 
@@ -105,13 +104,17 @@ def _build_proactive_history_messages(
     content: str,
     msg: dict[str, object],
 ) -> list[dict[str, object]]:
-    preview = _truncate_text(content, _PROACTIVE_HISTORY_CHAR_BUDGET)
+    """将已送达的主动消息完整投影为历史正文和来源 frame。"""
+
+    # 1. 保留完整正文，让后续指代可以命中主动消息中的任意内容。
     messages: list[dict[str, object]] = [
         {
             "role": "assistant",
-            "content": f"[主动推送] {preview}" if preview else "[主动推送]",
+            "content": f"[主动推送] {content}" if content else "[主动推送]",
         }
     ]
+
+    # 2. 追加独立 metadata frame，保持来源不伪装成用户陈述。
     meta = _append_proactive_meta("", msg).strip()
     if not meta:
         return messages

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -674,11 +674,17 @@ def test_session_get_history_skips_cached_llm_frame_by_default():
     ]
 
 
-def test_session_get_history_replays_proactive_as_short_assistant_with_meta_frame():
+def test_session_get_history_replays_full_proactive_with_meta_frame():
     session = Session("cli:1")
+    proactive_content = (
+        "第一篇 TokenMem 介绍知识注入。\n\n"
+        + "第二篇情景记忆包含较长正文。" * 30
+        + "\n\n第三篇 HCG-RAG 使用模式约束因果图。"
+    )
+    assert len(proactive_content) > 360
     session.add_message(
         "assistant",
-        "这是一条主动消息",
+        proactive_content,
         proactive=True,
         source_refs=[
             {
@@ -692,7 +698,10 @@ def test_session_get_history_replays_proactive_as_short_assistant_with_meta_fram
     history = session.get_history()
 
     assert len(history) == 2
-    assert history[0] == {"role": "assistant", "content": "[主动推送] 这是一条主动消息"}
+    assert history[0] == {
+        "role": "assistant",
+        "content": f"[主动推送] {proactive_content}",
+    }
     assert history[1]["role"] == "user"
     content = str(history[1]["content"])
     assert is_context_frame(content)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：已送达的 proactive assistant 消息在进入后续被动对话 prompt history 时被专属的 360 字预算截成头部 preview，用户指代第二、第三项内容时首轮模型看不到原文。
- 用户可见结果：主动历史正文与普通 assistant 历史一样完整进入选中的 prompt history；整体请求超限仍由通用 context retry 按完整语义边界缩窗。
- 本 PR 不处理：`recent_proactive_message_meta` 的独立 1200 字预算和来源展示策略。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：被动对话 prompt history
- `runtime_patch`：`none`
- `runtime_patch_reason`：核心 Session prompt 投影直接拥有该行为
- `authoritative_state_owner`：`sessions.db/messages` 仍由 SessionStore 拥有；Prompt history 是只读临时投影
- `client_only_alternative`：不适用
- 关联不变量：CTX-001、CTX-002、CTX-003、SES-005；合同已由 #232 合入
- `protected_state`：完整持久消息、消息身份与 seq、投递状态、正式 workspace
- 允许的副作用：删除 proactive 专属正文预算；更新普通回归测试
- 禁止的副作用：修改数据库、持久消息、投递协议、外部发送或运行中进程

## 改动范围

- 主要文件：`session/manager.py`、`tests/test_logic_modules.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用，数据库 schema 不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `5e674a26`，head `97d4fd12`
- 回滚方式：revert commit `97d4fd12`；原始基线另保留在 `backup/proactive-history-truncation-before-20260729`

## 验证

- [x] 相关 targeted tests 已通过：`70 passed`。
- [x] Pyright 已通过：`0 errors, 0 warnings`。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`f4f9a8bb96a76bcd0232cc6c68dc99cd20b199e921d2c993bf798f5574f79554`
- `planDigest`：`5a587ed5d101337233ffcaa3f4edb589171500dcd3ccb059c787e91a913c0182`
- `private-contract-gate`：`pending_maintainer`
- 真实 case 证据：只读加载正式 `sessions.db` 的 seq 549；持久正文 782 字，候选实现投影正文仍为 782 字，并包含尾部“模式约束”。没有写入正式 workspace。
- 真实设备证据：不适用
- 未运行项与原因：私有 companion 旧审计目录仍引用已移除的 `agent/plugins/mcp_host.py`，无法形成与本 planDigest 绑定的私有通过报告，因此未伪报为 passed。

## 工作手册

- [x] 已核对 `projectneed.md`、0002 决策、相关设计和 `NOW.md`。
- [x] 长期语义变化已由维护者确认，并先通过 #232 合入 CTX-003。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有对应 NOW 事项。