### PR TITLE
fix(mcp): clean up owned process groups

### DIFF
--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -9,6 +9,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from utils.process_group import (
+    OwnedProcessGroup,
+    owned_process_env,
+    process_group_spawn_kwargs,
+)
+
 logger = logging.getLogger(__name__)
 
 _RECV_TIMEOUT = 30.0
@@ -47,6 +53,21 @@ def _infer_cwd(command: list[str]) -> str | None:
     return None
 
 
+async def _wait_for_leader_exit(process: asyncio.subprocess.Process) -> int | None:
+    """等待 leader returncode，不被仍持有 stdio pipe 的孙进程阻塞。"""
+    wait_task = asyncio.create_task(process.wait())
+    try:
+        while process.returncode is None and not wait_task.done():
+            await asyncio.sleep(0.05)
+        if wait_task.done():
+            _ = await wait_task
+        return process.returncode
+    finally:
+        if not wait_task.done():
+            _ = wait_task.cancel()
+            _ = await asyncio.gather(wait_task, return_exceptions=True)
+
+
 class McpClient:
     """启动并管理一个 stdio MCP server 子进程，处理 JSON-RPC 通信。"""
 
@@ -69,6 +90,10 @@ class McpClient:
         self._recent_stdout: deque[str] = deque(maxlen=8)
         self._recent_stderr: deque[str] = deque(maxlen=8)
         self._stderr_task: asyncio.Task[None] | None = None
+        self._process_group: OwnedProcessGroup | None = None
+        self._process_watch_task: asyncio.Task[None] | None = None
+        self._disconnect_task: asyncio.Task[None] | None = None
+        self._disconnecting = False
         self._protocol_version: str | None = None
 
     @property
@@ -91,7 +116,7 @@ class McpClient:
 
     async def _connect_impl(self) -> list[McpToolInfo]:
         """启动子进程，完成握手，获取工具列表。"""
-        proc_env = {**os.environ, **self.env}
+        proc_env = owned_process_env(self.env)
         logger.debug("[mcp] 启动 %r: %s  cwd=%s", self.name, self.command, self.cwd)
         self._process = await asyncio.create_subprocess_exec(
             *self.command,
@@ -101,11 +126,18 @@ class McpClient:
             env=proc_env,
             cwd=self.cwd,
             limit=_STREAM_LIMIT,
+            **process_group_spawn_kwargs(),
         )
+        self._process_group = OwnedProcessGroup.from_process(self._process)
         self._stderr_task = asyncio.create_task(
             self._drain_stderr(),
             name=f"mcp_stderr:{self.name}",
         )
+        if self._process_group.group_id is not None:
+            self._process_watch_task = asyncio.create_task(
+                self._watch_process_exit(self._process, self._process_group),
+                name=f"mcp_process:{self.name}",
+            )
 
         # initialize 握手
         init_id = self._new_id()
@@ -337,48 +369,113 @@ class McpClient:
         )
 
     async def disconnect(self) -> None:
-        """终止子进程。"""
-        if self._process is None:
-            return
+        """抗取消地终止 MCP 进程组，并只在回收成功后释放 ownership。"""
+        task = self._disconnect_task
+        if task is None:
+            if self._process is None:
+                return
+            task = asyncio.create_task(
+                self._disconnect_impl(),
+                name=f"mcp_disconnect:{self.name}",
+            )
+            self._disconnect_task = task
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _ = await task
+            raise
+        finally:
+            if task.done() and self._disconnect_task is task:
+                self._disconnect_task = None
+
+    async def _disconnect_impl(self) -> None:
+        """关闭 stdio 后清理稳定 PGID，并聚合通信与回收错误。"""
         process = self._process
-        stopped = False
+        if process is None:
+            return
+        process_group = self._process_group or OwnedProcessGroup.from_process(process)
+        self._process_group = process_group
+        self._disconnecting = True
+        errors: list[BaseException] = []
+        hard_kill = False
+        cleanup_succeeded = False
+
+        # 1. 先关闭 stdin，给规范 MCP server 一个自然退出机会
         try:
             if process.stdin is not None:
                 process.stdin.close()
+        except BaseException as error:
+            errors.append(error)
+            hard_kill = True
+        if not hard_kill and os.name != "nt":
             try:
                 _ = await asyncio.wait_for(
-                    process.wait(),
+                    _wait_for_leader_exit(process),
                     timeout=_DISCONNECT_TIMEOUT,
                 )
-                stopped = True
-            except asyncio.TimeoutError:
-                process.terminate()
-                try:
-                    _ = await asyncio.wait_for(
-                        process.wait(),
-                        timeout=_DISCONNECT_TIMEOUT,
-                    )
-                    stopped = True
-                except asyncio.TimeoutError:
-                    process.kill()
-                    _ = await process.wait()
-                    stopped = True
-        finally:
-            try:
-                if not stopped:
-                    process.kill()
-                    _ = await process.wait()
-                    stopped = True
-            finally:
-                if stopped:
-                    self._process = None
-                    self._protocol_version = None
-                stderr_task = self._stderr_task
-                self._stderr_task = None
-                if stderr_task is not None:
-                    if not stderr_task.done():
-                        _ = stderr_task.cancel()
-                    _ = await asyncio.gather(stderr_task, return_exceptions=True)
+            except TimeoutError:
+                pass
+            except BaseException as error:
+                errors.append(error)
+                hard_kill = True
+
+        # 2. leader 即使已经退出，仍按保存的 PGID 回收 wrapper 后代
+        try:
+            if hard_kill:
+                await process_group.kill(timeout_s=_DISCONNECT_TIMEOUT)
+            else:
+                await process_group.terminate(timeout_s=_DISCONNECT_TIMEOUT)
+        except BaseException as error:
+            errors.append(error)
+        else:
+            cleanup_succeeded = True
+
+        # 3. 只有进程组回收成功，才释放 process 与诊断 watcher ownership
+        if cleanup_succeeded:
+            self._process = None
+            self._process_group = None
+            self._protocol_version = None
+            process_watch_task = self._process_watch_task
+            self._process_watch_task = None
+            if process_watch_task is not None:
+                _ = await asyncio.gather(process_watch_task, return_exceptions=True)
+            stderr_task = self._stderr_task
+            self._stderr_task = None
+            if stderr_task is not None:
+                if not stderr_task.done():
+                    _ = stderr_task.cancel()
+                _ = await asyncio.gather(stderr_task, return_exceptions=True)
+        self._disconnecting = False
+
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise BaseExceptionGroup(f"MCP server {self.name!r} 清理失败", errors)
+
+    async def _watch_process_exit(
+        self,
+        process: asyncio.subprocess.Process,
+        process_group: OwnedProcessGroup,
+    ) -> None:
+        """leader 意外退出后立即清理仍存活的 wrapper 后代。"""
+        while process.returncode is None:
+            await asyncio.sleep(0.05)
+        exit_code = process.returncode
+        if self._process is not process or self._disconnecting:
+            return
+        logger.error(
+            "[mcp] %r 进程意外退出: exit=%s，开始清理进程组 %s",
+            self.name,
+            exit_code,
+            process_group.group_id,
+        )
+        try:
+            await process_group.terminate(timeout_s=_DISCONNECT_TIMEOUT)
+        except Exception:
+            logger.exception(
+                "[mcp] %r 意外退出后的进程组清理失败",
+                self.name,
+            )
 
     def _new_id(self) -> int:
         i = self._next_id

--- a/agent/plugins/service_host.py
+++ b/agent/plugins/service_host.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
 import asyncio
-import os
-import signal
+import logging
+import socket
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
+
+from utils.process_group import (
+    OwnedProcessGroup,
+    owned_process_env,
+    process_group_spawn_kwargs,
+)
+
+logger = logging.getLogger(__name__)
+_STOP_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass
 class _RunningService:
     spec: dict[str, Any]
     process: asyncio.subprocess.Process
+    process_group: OwnedProcessGroup
+    watch_task: asyncio.Task[None] | None = None
+    stopping: bool = False
 
 
 class PluginServiceHost:
@@ -134,25 +147,36 @@ class PluginServiceHost:
         if key in self._running:
             raise RuntimeError(f"managed service 已运行: {plugin_id}:{service_id}")
         readiness_url = str(spec.get("readiness_url") or "")
-        if readiness_url and await asyncio.to_thread(_url_ready, readiness_url):
+        if readiness_url and await asyncio.to_thread(
+            _endpoint_listening,
+            readiness_url,
+        ):
             raise RuntimeError(
-                f"managed service readiness endpoint 已被占用: {readiness_url}"
+                f"managed service readiness 监听端口已被占用: {readiness_url}"
             )
         process = await asyncio.create_subprocess_exec(
             *spec["command"],
             cwd=spec["cwd"],
-            env={**os.environ, **spec["env"]},
+            env=owned_process_env(spec["env"]),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
-            start_new_session=os.name != "nt",
+            **process_group_spawn_kwargs(),
         )
-        running = _RunningService(spec=spec, process=process)
+        running = _RunningService(
+            spec=spec,
+            process=process,
+            process_group=OwnedProcessGroup.from_process(process),
+        )
         self._running[key] = running
         try:
             await self._wait_ready(running)
         except BaseException:
             await self._stop(plugin_id, service_id)
             raise
+        running.watch_task = asyncio.create_task(
+            self._watch_process_exit(key, running),
+            name=f"managed_service:{plugin_id}:{service_id}",
+        )
 
     async def _wait_ready(self, service: _RunningService) -> None:
         timeout = float(service.spec["startup_timeout_seconds"])
@@ -190,26 +214,62 @@ class PluginServiceHost:
         if running is None:
             return
         key = (plugin_id, service_id)
+        running.stopping = True
 
         async def reap() -> None:
-            process = running.process
             try:
-                if process.returncode is None:
-                    _signal_process(process, signal.SIGTERM)
-                    try:
-                        _ = await asyncio.wait_for(process.wait(), timeout=5)
-                    except TimeoutError:
-                        _signal_process(process, signal.SIGKILL)
-                        _ = await process.wait()
-            finally:
-                _ = self._running.pop(key, None)
+                await running.process_group.terminate(
+                    timeout_s=_STOP_TIMEOUT_SECONDS,
+                )
+                if running.watch_task is not None:
+                    _ = await asyncio.gather(
+                        running.watch_task,
+                        return_exceptions=True,
+                    )
+            except BaseException:
+                running.stopping = False
+                raise
+            if self._running.get(key) is running:
+                del self._running[key]
 
-        task = asyncio.create_task(reap(), name=f"stop_service:{plugin_id}:{service_id}")
+        task = asyncio.create_task(
+            reap(), name=f"stop_service:{plugin_id}:{service_id}"
+        )
         try:
             await asyncio.shield(task)
         except asyncio.CancelledError:
             _ = await task
             raise
+
+    async def _watch_process_exit(
+        self,
+        key: tuple[str, str],
+        running: _RunningService,
+    ) -> None:
+        """leader 意外退出后清理同组后代，并保留失败 ownership。"""
+        exit_code = await running.process.wait()
+        if running.stopping or self._running.get(key) is not running:
+            return
+        logger.error(
+            "managed service 意外退出: %s:%s exit=%s，开始清理进程组 %s",
+            key[0],
+            key[1],
+            exit_code,
+            running.process_group.group_id,
+        )
+        try:
+            await running.process_group.terminate(
+                timeout_s=_STOP_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.exception(
+                "managed service 意外退出后的进程组清理失败: %s:%s",
+                key[0],
+                key[1],
+            )
+            return
+        if self._running.get(key) is running:
+            del self._running[key]
 
 
 def _url_ready(url: str) -> bool:
@@ -220,14 +280,19 @@ def _url_ready(url: str) -> bool:
         return False
 
 
-def _signal_process(process: asyncio.subprocess.Process, sig: signal.Signals) -> None:
+def _endpoint_listening(url: str) -> bool:
+    """验证 HTTP readiness endpoint，并判断其监听端口是否已被占用。"""
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise RuntimeError(f"managed service readiness_url 无效: {url}")
     try:
-        if os.name == "nt":
-            if sig == signal.SIGTERM:
-                process.terminate()
-            else:
-                process.kill()
-        else:
-            os.killpg(process.pid, sig)
-    except ProcessLookupError:
-        pass
+        port = parsed.port
+    except ValueError as error:
+        raise RuntimeError(f"managed service readiness_url 无效: {url}") from error
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=1):
+            return True
+    except OSError:
+        return False

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 RESTART_EXIT_CODE = 75
 SUPERVISOR_FAILURE_EXIT_CODE = 70
+_BOOT_CLEANUP_TIMEOUT_SECONDS = 5.0
 
 
 class _SupervisorLock:
@@ -114,6 +115,160 @@ class _SettingsRestartBridge:
         with self._condition:
             self._completed[generation] = success
             self._condition.notify_all()
+
+
+def _cleanup_boot_processes(
+    *,
+    boot_id: str,
+    gateway_group_id: int,
+    timeout_s: float = _BOOT_CLEANUP_TIMEOUT_SECONDS,
+) -> None:
+    """清理指定 boot 的全部进程组，保证下一代启动前旧端口已释放。"""
+
+    if os.name == "nt":
+        result = subprocess.run(
+            ["taskkill", "/PID", str(gateway_group_id), "/T", "/F"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode not in {0, 128}:
+            raise RuntimeError(
+                f"boot {boot_id} Windows 进程树清理失败: exit={result.returncode}"
+            )
+        return
+
+    # 1. gateway 自身是独立组；Linux 再用唯一 boot ID 找到 MCP/service 子组
+    groups = {gateway_group_id}
+    direct_pids: set[int] = set()
+    if _wait_boot_targets(
+        boot_id,
+        groups,
+        direct_pids,
+        signal.SIGTERM,
+        timeout_s,
+    ):
+        return
+
+    # 2. 宽限期结束后升级为 KILL，并以仍存活的 PID/PGID 作为失败证据
+    if _wait_boot_targets(
+        boot_id,
+        groups,
+        direct_pids,
+        signal.SIGKILL,
+        timeout_s,
+    ):
+        return
+    alive_groups = sorted(group_id for group_id in groups if _group_exists(group_id))
+    alive_pids = sorted(pid for pid in direct_pids if _pid_exists(pid))
+    raise RuntimeError(
+        f"boot {boot_id} 进程清理失败: groups={alive_groups}, pids={alive_pids}"
+    )
+
+
+def _wait_boot_targets(
+    boot_id: str,
+    groups: set[int],
+    direct_pids: set[int],
+    sig: signal.Signals,
+    timeout_s: float,
+) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while True:
+        _discover_boot_targets(boot_id, groups, direct_pids)
+        _signal_targets(groups, direct_pids, sig)
+        if not any(_group_exists(group_id) for group_id in groups) and not any(
+            _pid_exists(pid) for pid in direct_pids
+        ):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+
+
+def _discover_boot_targets(
+    boot_id: str,
+    groups: set[int],
+    direct_pids: set[int],
+) -> None:
+    if not sys.platform.startswith("linux"):
+        return
+    expected = f"AKASHIC_BOOT_ID={boot_id}".encode()
+    own_group = os.getpgrp()
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        try:
+            environ = (entry / "environ").read_bytes().split(b"\0")
+            if expected not in environ:
+                continue
+            group_id = os.getpgid(pid)
+        except (OSError, ProcessLookupError):
+            continue
+        if group_id == own_group:
+            direct_pids.add(pid)
+        else:
+            groups.add(group_id)
+
+
+def _signal_targets(
+    groups: set[int],
+    direct_pids: set[int],
+    sig: signal.Signals,
+) -> None:
+    for group_id in groups:
+        try:
+            os.killpg(group_id, sig)
+        except ProcessLookupError:
+            pass
+    for pid in direct_pids:
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            pass
+
+
+def _group_exists(group_id: int) -> bool:
+    if sys.platform.startswith("linux"):
+        return _linux_group_has_live_members(group_id)
+    try:
+        os.killpg(group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pid_exists(pid: int) -> bool:
+    if sys.platform.startswith("linux"):
+        try:
+            fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+        except OSError:
+            return False
+        return fields[0] != "Z"
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _linux_group_has_live_members(group_id: int) -> bool:
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+        except (OSError, IndexError):
+            continue
+        if len(fields) >= 3 and int(fields[2]) == group_id and fields[0] != "Z":
+            return True
+    return False
 
 
 def run_supervisor(
@@ -217,6 +372,7 @@ def run_supervisor(
                             pass_fds=(write_fd,),
                             # supervisor 单线程；exec 前只恢复继承的 signal mask。
                             preexec_fn=restore_child_signal_mask,
+                            start_new_session=True,
                         )
                     except BaseException:
                         os.close(read_fd)
@@ -240,19 +396,50 @@ def run_supervisor(
                 ):
                     child.send_signal(stopping_signal)
                 child.wait()
+                try:
+                    _cleanup_boot_processes(
+                        boot_id=boot_id,
+                        gateway_group_id=child.pid,
+                    )
+                except RuntimeError as error:
+                    print(str(error), file=sys.stderr)
+                    return SUPERVISOR_FAILURE_EXIT_CODE
                 os.close(read_fd)
                 child = None
                 return 0
-            result = _wait_child(
-                child,
-                read_fd=read_fd,
-                workspace=workspace,
-                boot_id=boot_id,
-                nonce=nonce,
-                readiness_timeout_s=readiness_timeout_s,
-                settings_bridge=settings_bridge,
-                report_settings_generation=report_settings_generation,
-            )
+            try:
+                result = _wait_child(
+                    child,
+                    read_fd=read_fd,
+                    workspace=workspace,
+                    boot_id=boot_id,
+                    nonce=nonce,
+                    readiness_timeout_s=readiness_timeout_s,
+                    settings_bridge=settings_bridge,
+                    report_settings_generation=report_settings_generation,
+                )
+            except BaseException as wait_error:
+                try:
+                    _cleanup_boot_processes(
+                        boot_id=boot_id,
+                        gateway_group_id=child.pid,
+                    )
+                except BaseException as cleanup_error:
+                    raise BaseExceptionGroup(
+                        "Supervisor 等待 gateway 与 boot 清理均失败",
+                        [wait_error, cleanup_error],
+                    ) from wait_error
+                raise
+            try:
+                _cleanup_boot_processes(
+                    boot_id=boot_id,
+                    gateway_group_id=child.pid,
+                )
+            except RuntimeError as error:
+                print(str(error), file=sys.stderr)
+                if result.settings_generation:
+                    settings_bridge.complete(result.settings_generation, False)
+                return SUPERVISOR_FAILURE_EXIT_CODE
             if report_settings_generation:
                 report_settings_generation = 0
             child = None

--- a/tests/test_agent_restart.py
+++ b/tests/test_agent_restart.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -533,6 +534,78 @@ class _RunningSupervisorChild(_FakeSupervisorChild):
         if self.running:
             raise AssertionError("child must receive pending stop before wait")
         return self.returncode
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="依赖 /proc boot identity"
+)
+def test_supervisor_cleans_orphaned_boot_listener(tmp_path: Path) -> None:
+    """gateway 退出后 Supervisor 必须回收独立 service 进程组及其端口。"""
+    script = tmp_path / "orphan_listener.py"
+    child_pid_file = tmp_path / "child.pid"
+    _ = script.write_text(
+        "import os, socket, time\n"
+        "from pathlib import Path\n"
+        "pid = os.fork()\n"
+        "if pid == 0:\n"
+        "    listener = socket.socket()\n"
+        "    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+        "    listener.bind(('127.0.0.1', int(os.environ['PORT'])))\n"
+        "    listener.listen()\n"
+        "    while True:\n"
+        "        connection, _ = listener.accept()\n"
+        "        connection.close()\n"
+        "Path(os.environ['CHILD_PID_FILE']).write_text(str(pid))\n"
+        "time.sleep(0.2)\n"
+        "raise SystemExit(17)\n",
+        encoding="utf-8",
+    )
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = int(probe.getsockname()[1])
+    boot_id = "test-orphan-listener"
+    env = {
+        **os.environ,
+        "AKASHIC_BOOT_ID": boot_id,
+        "CHILD_PID_FILE": str(child_pid_file),
+        "PORT": str(port),
+    }
+    leader = subprocess.Popen(
+        [sys.executable, str(script)],
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        assert leader.wait(timeout=3) == 17
+        child_pid = int(child_pid_file.read_text())
+        _wait_for_listener(port)
+
+        supervisor_module._cleanup_boot_processes(
+            boot_id=boot_id,
+            gateway_group_id=999_999_999,
+            timeout_s=2,
+        )
+
+        assert not supervisor_module._pid_exists(child_pid)
+        with pytest.raises(OSError):
+            socket.create_connection(("127.0.0.1", port), timeout=0.2)
+    finally:
+        try:
+            os.killpg(leader.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def _wait_for_listener(port: int) -> None:
+    deadline = time.monotonic() + 2
+    while True:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise AssertionError("listener did not start before timeout")
+            time.sleep(0.02)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io_modules.py
+++ b/tests/test_io_modules.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
+import signal
 import stat
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -60,6 +63,7 @@ class _Proc:
         self.stdin = _Pipe()
         self.stdout = _Pipe(stdout_lines)
         self.stderr = _Pipe(stderr_lines)
+        self.returncode: int | None = None
         self.terminated = False
         self.killed = False
 
@@ -70,6 +74,7 @@ class _Proc:
         self.killed = True
 
     async def wait(self) -> None:
+        self.returncode = 0
         return None
 
 
@@ -489,10 +494,18 @@ async def test_mcp_client_and_loop_factory_cover_core_paths(
         ],
         [b"warn\n", b""],
     )
-    monkeypatch.setattr("agent.mcp.client.asyncio.create_subprocess_exec", AsyncMock(return_value=proc))
-    client = McpClient("docs", ["python", str(script)], env={"X": "1"})
+    spawn = AsyncMock(return_value=proc)
+    monkeypatch.setattr("agent.mcp.client.asyncio.create_subprocess_exec", spawn)
+    monkeypatch.setenv("AKASHIC_BOOT_ID", "owned-boot")
+    client = McpClient(
+        "docs",
+        ["python", str(script)],
+        env={"X": "1", "AKASHIC_BOOT_ID": "spoofed-boot"},
+    )
     infos = await client.connect()
     assert infos[0].name == "tool1"
+    assert spawn.await_args.kwargs["env"]["X"] == "1"
+    assert spawn.await_args.kwargs["env"]["AKASHIC_BOOT_ID"] == "owned-boot"
     initialize = json.loads(proc.stdin.writes[0])
     assert initialize["params"]["protocolVersion"] == "2025-11-25"
     assert await client.call("tool1", {"q": "x"}) == "ok"
@@ -506,6 +519,91 @@ async def test_mcp_client_and_loop_factory_cover_core_paths(
     client._process = proc
     with pytest.raises(ConnectionError):
         await client._recv(expected_id=1)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows 使用 taskkill /T 覆盖进程树")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_after_list", [False, True])
+async def test_mcp_client_cleans_wrapper_process_group(
+    tmp_path: Path,
+    exit_after_list: bool,
+) -> None:
+    """显式断开和 leader 意外退出都必须回收 stdio wrapper 后代。"""
+    script = tmp_path / "mcp_wrapper.py"
+    child_pid_file = tmp_path / "child.pid"
+    _ = script.write_text(
+        "import json, os, subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(300)'])\n"
+        "Path(os.environ['CHILD_PID_FILE']).write_text(str(child.pid))\n"
+        "for raw in sys.stdin:\n"
+        "    message = json.loads(raw)\n"
+        "    method = message.get('method')\n"
+        "    if method == 'initialize':\n"
+        "        result = {'protocolVersion': '2025-11-25'}\n"
+        "    elif method == 'tools/list':\n"
+        "        result = {'tools': []}\n"
+        "    else:\n"
+        "        continue\n"
+        "    print(json.dumps({'jsonrpc': '2.0', 'id': message['id'], "
+        "'result': result}), flush=True)\n"
+        "    if method == 'tools/list' and "
+        "os.environ['EXIT_AFTER_LIST'] == '1':\n"
+        "        time.sleep(0.2)\n"
+        "        raise SystemExit(17)\n",
+        encoding="utf-8",
+    )
+    client = McpClient(
+        "wrapper",
+        [sys.executable, str(script)],
+        env={
+            "CHILD_PID_FILE": str(child_pid_file),
+            "EXIT_AFTER_LIST": "1" if exit_after_list else "0",
+        },
+    )
+    child_pid = 0
+    try:
+        _ = await client.connect()
+        child_pid = int(child_pid_file.read_text())
+        assert _process_exists(child_pid)
+
+        if exit_after_list:
+            await _wait_until(lambda: not client.connected)
+            await _wait_until(lambda: not _process_exists(child_pid))
+        else:
+            await client.disconnect()
+            await _wait_until(lambda: not _process_exists(child_pid))
+    finally:
+        await client.disconnect()
+        if child_pid and _process_exists(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        stat_fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+        if stat_fields[0] == "Z":
+            return False
+    except OSError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 5.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition did not become true before timeout")
+        await asyncio.sleep(0.05)
 
 
 @pytest.mark.asyncio
@@ -685,6 +783,30 @@ async def test_mcp_client_disconnect_reports_cleanup_error() -> None:
 
     assert proc.killed is True
     assert client._process is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_retains_ownership_when_process_group_cleanup_fails() -> None:
+    proc = _Proc([])
+    client = McpClient("docs", ["python", "server.py"])
+    client._process = proc
+
+    class FailingProcessGroup:
+        async def terminate(self, *, timeout_s: float) -> None:
+            raise RuntimeError(f"cleanup failed after {timeout_s}s")
+
+        async def kill(self, *, timeout_s: float) -> None:
+            raise RuntimeError(f"cleanup failed after {timeout_s}s")
+
+    client._process_group = FailingProcessGroup()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await client.disconnect()
+
+    assert client._process is proc
+    assert client._process_group is not None
+    client._process_group = None
+    await client.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_service_host.py
+++ b/tests/test_plugin_service_host.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import socket
 import asyncio
+import os
+import socket
 import sys
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -125,6 +127,109 @@ async def test_managed_service_rejects_occupied_readiness_endpoint(
 
     assert _read(port) == ""
     await host.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_rejects_occupied_port_without_http_readiness(
+    tmp_path: Path,
+) -> None:
+    """未知 listener 即使不返回健康 HTTP，也不能被启动流程接管。"""
+    failed = tmp_path / "failed.py"
+    _ = failed.write_text("raise AssertionError('must not spawn')\n", encoding="utf-8")
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = int(listener.getsockname()[1])
+    host = PluginServiceHost()
+    try:
+        with pytest.raises(RuntimeError, match="监听端口已被占用"):
+            await host.swap_plugin_services(
+                "candidate",
+                {},
+                {"server": _service_spec(failed, port, "candidate")},
+            )
+    finally:
+        listener.close()
+        await host.stop_all()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="依赖 POSIX 进程组")
+@pytest.mark.asyncio
+async def test_managed_service_cleans_listener_after_leader_exit(
+    tmp_path: Path,
+) -> None:
+    """ready 后 leader 意外退出时必须回收仍监听端口的同组后代。"""
+    wrapper = tmp_path / "wrapper.py"
+    child_pid_file = tmp_path / "child.pid"
+    _ = wrapper.write_text(
+        "import os, time, urllib.request\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "from pathlib import Path\n"
+        "pid = os.fork()\n"
+        "if pid == 0:\n"
+        "    class Handler(BaseHTTPRequestHandler):\n"
+        "        def do_GET(self):\n"
+        "            self.send_response(200); self.end_headers()\n"
+        "            self.wfile.write(b'child')\n"
+        "        def log_message(self, *args): pass\n"
+        "    HTTPServer(('127.0.0.1', int(os.environ['PORT'])), "
+        "Handler).serve_forever()\n"
+        "Path(os.environ['CHILD_PID_FILE']).write_text(str(pid))\n"
+        "url = 'http://127.0.0.1:' + os.environ['PORT'] + '/'\n"
+        "for _ in range(100):\n"
+        "    try:\n"
+        "        urllib.request.urlopen(url, timeout=0.1).close()\n"
+        "        break\n"
+        "    except OSError:\n"
+        "        time.sleep(0.02)\n"
+        "time.sleep(0.5)\n"
+        "raise SystemExit(17)\n",
+        encoding="utf-8",
+    )
+    port = _free_port()
+    spec = _service_spec(wrapper, port, "wrapper")
+    env = spec["env"]
+    assert isinstance(env, dict)
+    env["CHILD_PID_FILE"] = str(child_pid_file)
+    host = PluginServiceHost()
+    host.bind_plugin_services({"wrapper": {"server": spec}})  # type: ignore[arg-type]
+    try:
+        await host.start_all()
+        assert _read(port) == "child"
+        child_pid = int(child_pid_file.read_text())
+
+        await _wait_until(lambda: host._running == {})
+        await _wait_until(lambda: not _process_exists(child_pid))
+        with pytest.raises(OSError):
+            _read(port)
+    finally:
+        await host.stop_all()
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        stat_fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+        if stat_fields[0] == "Z":
+            return False
+    except OSError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 5.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition did not become true before timeout")
+        await asyncio.sleep(0.05)
 
 
 @pytest.mark.asyncio

--- a/utils/process_group.py
+++ b/utils/process_group.py
@@ -1,0 +1,177 @@
+"""为本地子进程提供可重试的进程组终止语义。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+_RUNTIME_IDENTITY_ENV = ("AKASHIC_BOOT_ID", "AKASHIC_SUPERVISED")
+
+
+def process_group_spawn_kwargs() -> dict[str, Any]:
+    """返回让子进程成为独立进程组 owner 的平台参数。"""
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def owned_process_env(overrides: dict[str, str]) -> dict[str, str]:
+    """合并子进程环境，并保留 Supervisor 拥有的 boot identity。"""
+    env = {**os.environ, **overrides}
+    for name in _RUNTIME_IDENTITY_ENV:
+        if name in os.environ:
+            env[name] = os.environ[name]
+    return env
+
+
+@dataclass
+class OwnedProcessGroup:
+    """终止一个已取得 ownership 的子进程组，并等待全部成员退出。"""
+
+    process: asyncio.subprocess.Process
+    group_id: int | None
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+    @classmethod
+    def from_process(cls, process: asyncio.subprocess.Process) -> "OwnedProcessGroup":
+        pid = getattr(process, "pid", None)
+        return cls(process=process, group_id=pid if isinstance(pid, int) else None)
+
+    async def terminate(self, *, timeout_s: float) -> None:
+        """先发送 TERM，超时后发送 KILL，并完成 direct child wait。"""
+        async with self._lock:
+            if os.name == "nt" and self.group_id is not None:
+                await self._terminate_windows()
+                return
+            if os.name != "nt" and self.group_id is not None:
+                await self._terminate_posix(timeout_s=timeout_s, force=False)
+                return
+            await self._terminate_direct(timeout_s=timeout_s, force=False)
+
+    async def kill(self, *, timeout_s: float) -> None:
+        """立即杀死整个进程组，并完成 direct child wait。"""
+        async with self._lock:
+            if os.name == "nt" and self.group_id is not None:
+                await self._terminate_windows()
+                return
+            if os.name != "nt" and self.group_id is not None:
+                await self._terminate_posix(timeout_s=timeout_s, force=True)
+                return
+            await self._terminate_direct(timeout_s=timeout_s, force=True)
+
+    async def _terminate_windows(self) -> None:
+        """使用 taskkill /T /F 回收 Windows direct child 及其后代。"""
+        assert self.group_id is not None
+        taskkill = await asyncio.create_subprocess_exec(
+            "taskkill",
+            "/PID",
+            str(self.group_id),
+            "/T",
+            "/F",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        exit_code = await taskkill.wait()
+        if exit_code != 0 and getattr(self.process, "returncode", None) is None:
+            self.process.kill()
+        _ = await self.process.wait()
+
+    async def _terminate_posix(self, *, timeout_s: float, force: bool) -> None:
+        """按稳定 PGID 清理 Unix 进程组，即使 leader 已经退出。"""
+
+        # 1. 对完整进程组发信号，不能用 leader.returncode 推断后代已退出
+        assert self.group_id is not None
+        first_signal = signal.SIGKILL if force else signal.SIGTERM
+        _signal_posix_group(self.group_id, first_signal)
+        if await _wait_posix_group_exit(self.group_id, timeout_s):
+            _ = await self.process.wait()
+            return
+
+        # 2. TERM 宽限期结束后升级为 KILL，并验证进程组确实消失
+        if not force:
+            _signal_posix_group(self.group_id, signal.SIGKILL)
+            if await _wait_posix_group_exit(self.group_id, timeout_s):
+                _ = await self.process.wait()
+                return
+        raise RuntimeError(f"进程组 {self.group_id} 在 SIGKILL 后仍未退出")
+
+    async def _terminate_direct(self, *, timeout_s: float, force: bool) -> None:
+        """为无 PGID 的测试替身和非 Unix 平台保留 direct child 回收。"""
+        if getattr(self.process, "returncode", None) is not None:
+            _ = await self.process.wait()
+            return
+        try:
+            if force:
+                self.process.kill()
+            else:
+                self.process.terminate()
+        except ProcessLookupError:
+            pass
+        try:
+            _ = await asyncio.wait_for(self.process.wait(), timeout=timeout_s)
+        except TimeoutError:
+            if force:
+                raise RuntimeError("子进程在 SIGKILL 后仍未退出")
+            try:
+                self.process.kill()
+            except ProcessLookupError:
+                pass
+            _ = await self.process.wait()
+
+
+def _signal_posix_group(group_id: int, sig: signal.Signals) -> None:
+    try:
+        os.killpg(group_id, sig)
+    except ProcessLookupError:
+        pass
+
+
+async def _wait_posix_group_exit(group_id: int, timeout_s: float) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while _posix_group_exists(group_id):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        await asyncio.sleep(min(0.05, remaining))
+    return True
+
+
+def _posix_group_exists(group_id: int) -> bool:
+    if sys.platform.startswith("linux"):
+        return _linux_group_has_live_members(group_id)
+    try:
+        os.killpg(group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _linux_group_has_live_members(group_id: int) -> bool:
+    """将只剩 zombie 的组视为已释放，避免容器 PID 1 延迟回收误报。"""
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text()
+        except OSError:
+            continue
+        command_end = stat.rfind(")")
+        if command_end < 0:
+            continue
+        fields = stat[command_end + 2 :].split()
+        if len(fields) < 3 or int(fields[2]) != group_id:
+            continue
+        if fields[0] != "Z":
+            return True
+    return False


### PR DESCRIPTION
## Stack

- This PR: MCP/process lifecycle implementation
- Follow-up protected Gate contract: #235

## Summary

- 为 stdio MCP 和 managed service 建立稳定的进程组 ownership，显式关闭时按 PGID 发送 TERM，超时升级 KILL
- 增加 leader 意外退出 watcher：wrapper 退出后仍会回收继承端口或 stdio 的后代进程
- Supervisor 用唯一 `AKASHIC_BOOT_ID` 做最后一道 boot 级清理，旧 boot 未释放时禁止进入下一代启动
- 启动 managed service 前检查 readiness 对应 TCP 端口；未知进程占用时 fail loud，不 kill、不接管

实现参考 Codex 的 stdio MCP 生命周期方案：独立 process group、保存稳定 PGID、显式 shutdown、异常退出/Drop 兜底清理（Codex `82c981cafc`, `4e0cf945b7`）。

## Root cause

此前清理逻辑只可靠覆盖 direct child：

- MCP client 没有独立进程组和异常退出 watcher
- managed service 的 leader 已退出时，`_stop` 会跳过整个进程组清理
- Supervisor 只监管 gateway，而 MCP/service 会进入独立 session，gateway 异常退出后仍可能留下监听 18000/18765 的后代
- readiness 预检只判断健康 HTTP，端口已监听但不返回正确 HTTP 时仍会继续 spawn

## Verification

- `python -m pytest -q` → `2418 passed, 1 skipped`
- production Pyright → `0 errors, 0 warnings`
- tests Pyright → `0 errors, 0 warnings`
- public change-impact Gate → passed, 7 scenarios
  - report: `docker/debug/reports/change-gate/20260729-105829-c077e5ee`
  - plan digest: `8c8bcff5c3ce4df783f4e33b939e431236d6b09a51f4ee70b6e225b655b30499`
  - source digest: `08a3445b504bde9d1e863e7873988f831f284f875ed2a6bd12081d9f4a557729`
- private contract gate: required / pending maintainer

故障注入覆盖：显式 disconnect、MCP leader 意外退出、managed-service leader 意外退出但 listener grandchild 仍持有端口、旧 boot 遗留端口、未知进程预占端口。

## Rollback

Revert commit `fdc52559`.