### PR TITLE
test(gate): enforce MCP process lifecycle

### DIFF
--- a/tests/semantic/test_contract_oracles.py
+++ b/tests/semantic/test_contract_oracles.py
@@ -10,6 +10,7 @@ from tests_scenarios.contracts.oracles import (
     assert_atomic_generation_switch,
     assert_isolated_gate_paths,
     assert_paths_retained,
+    assert_process_resources_released,
     assert_rows_unchanged,
 )
 
@@ -57,6 +58,20 @@ def test_call_finality_rejects_background_refresh_mutant() -> None:
         await asyncio.gather(*tasks)
 
     asyncio.run(scenario())
+
+
+def test_process_lifecycle_oracle_rejects_leader_only_cleanup_mutant() -> None:
+    """leader 退出不能被误判为整个 owned process tree 已释放。"""
+    leader_alive = False
+    live_descendants = [18000]
+    listening_ports = [18765]
+
+    assert leader_alive is False
+    with pytest.raises(AssertionError, match="仍持有运行资源"):
+        assert_process_resources_released(
+            live_descendant_pids=live_descendants,
+            listening_ports=listening_ports,
+        )
 
 
 def test_plugin_publication_oracle_rejects_early_switch_mutant() -> None:

--- a/tests_scenarios/contracts/coverage-baseline.json
+++ b/tests_scenarios/contracts/coverage-baseline.json
@@ -1,13 +1,14 @@
 {
   "acceptedGaps": [],
   "base": "d627fa600781855770a5ede752f268982b68ebf9",
-  "catalogDigest": "1132a1b767f3589936af0491c8cead1c628eb1e1115be68c8ecae107d83476e7",
+  "catalogDigest": "6008cf3992eb450c9d26ac78e626ddea3ad6ac610682d39c3b6221df1eac2c20",
   "coveredP0": {
     "context_projection": [
       "context_history_nondestructive"
     ],
     "mcp": [
-      "mcp_call_finality"
+      "mcp_call_finality",
+      "mcp_process_lifecycle"
     ],
     "memory": [
       "memory_persistence_contract"
@@ -20,7 +21,8 @@
       "mobile_realtime_contract"
     ],
     "plugin": [
-      "plugin_generation_contract"
+      "plugin_generation_contract",
+      "mcp_process_lifecycle"
     ],
     "session_persistence": [
       "context_history_nondestructive"

--- a/tests_scenarios/contracts/impact.toml
+++ b/tests_scenarios/contracts/impact.toml
@@ -93,7 +93,7 @@ paths = [
   "tests/test_workspace_mcp_reload_probe.py",
 ]
 depends_on = ["plugin", "lifecycle"]
-scenarios = ["mcp_call_finality"]
+scenarios = ["mcp_call_finality", "mcp_process_lifecycle"]
 
 [groups.plugin]
 priority = "p0"
@@ -108,7 +108,7 @@ paths = [
   "tests/test_plugin_*.py",
 ]
 depends_on = ["lifecycle"]
-scenarios = ["plugin_generation_contract"]
+scenarios = ["plugin_generation_contract", "mcp_process_lifecycle"]
 
 [groups.lifecycle]
 priority = "p1"
@@ -217,7 +217,7 @@ paths = [
   "utils/**",
 ]
 depends_on = ["events", "session_persistence"]
-scenarios = ["contract_catalog"]
+scenarios = ["contract_catalog", "mcp_process_lifecycle"]
 
 [groups.migrations]
 priority = "p0"

--- a/tests_scenarios/contracts/oracles.py
+++ b/tests_scenarios/contracts/oracles.py
@@ -62,6 +62,19 @@ async def assert_call_finality(
     return result
 
 
+def assert_process_resources_released(
+    *,
+    live_descendant_pids: Sequence[int],
+    listening_ports: Sequence[int],
+) -> None:
+    """断言 owned process leader 退出后没有后代或监听端口残留。"""
+    if live_descendant_pids or listening_ports:
+        raise AssertionError(
+            "owned process tree 仍持有运行资源: "
+            f"pids={list(live_descendant_pids)}, ports={list(listening_ports)}"
+        )
+
+
 def assert_snapshot_fields(
     snapshot: Mapping[str, object],
     expected: Mapping[str, object],

--- a/tests_scenarios/contracts/scenarios.toml
+++ b/tests_scenarios/contracts/scenarios.toml
@@ -5,6 +5,7 @@ async_accepted_before_visible = "tests/semantic/test_contract_oracles.py::test_c
 candidate_visible_before_activation = "tests/semantic/test_contract_oracles.py::test_plugin_publication_oracle_rejects_early_switch_mutant"
 derived_state_overwrites_session_source = "tests/semantic/test_contract_oracles.py::test_memory_oracle_rejects_derived_state_overwrite_mutant"
 historical_session_delete = "tests/semantic/test_context_history_contract.py::test_history_oracle_rejects_historical_delete_mutant"
+leader_exit_assumed_tree_exit = "tests/semantic/test_contract_oracles.py::test_process_lifecycle_oracle_rejects_leader_only_cleanup_mutant"
 missing_p0_mutant = "tests/semantic/test_change_gate.py::test_every_p0_oracle_declares_a_known_wrong_mutant"
 official_workspace_path = "tests/semantic/test_contract_oracles.py::test_workspace_oracle_rejects_official_path_mutant"
 plugin_uninstall_deletes_data = "tests/semantic/test_contract_oracles.py::test_plugin_data_oracle_rejects_uninstall_delete_mutant"
@@ -72,6 +73,25 @@ command = [
 ]
 observes = ["call_return", "immediate_read_after_call"]
 mutants = ["async_accepted_before_visible"]
+
+[scenarios.mcp_process_lifecycle]
+requirements = ["PLG-004", "PLG-009", "RUN-001", "RUN-002", "TST-001", "TST-003"]
+groups = ["mcp", "plugin", "runtime"]
+environment = "public_clean_workspace"
+timeout_seconds = 60
+command = [
+  "python",
+  "-m",
+  "pytest",
+  "-q",
+  "tests/test_io_modules.py::test_mcp_client_cleans_wrapper_process_group",
+  "tests/test_io_modules.py::test_mcp_client_retains_ownership_when_process_group_cleanup_fails",
+  "tests/test_plugin_service_host.py::test_managed_service_rejects_occupied_port_without_http_readiness",
+  "tests/test_plugin_service_host.py::test_managed_service_cleans_listener_after_leader_exit",
+  "tests/test_agent_restart.py::test_supervisor_cleans_orphaned_boot_listener",
+]
+observes = ["leader_exit", "descendant_exit", "listener_release", "foreign_listener_survival", "cleanup_ownership"]
+mutants = ["leader_exit_assumed_tree_exit"]
 
 [scenarios.plugin_generation_contract]
 requirements = ["PLG-001", "PLG-004"]


### PR DESCRIPTION
## Stack

- Implementation #234: merged as `a6e334a5`
- This PR: protected Gate contract only, rebased onto current `main`

本 PR 与生产实现分层，避免同一 change-impact plan 同时修改 production source 与 protected contract。

## Summary

- 新增公共场景 `mcp_process_lifecycle`，归属 `mcp`、`plugin`、`runtime`
- 在干净 Docker workspace 中精确执行 6 个故障注入：
  - MCP 显式 disconnect 清理 wrapper 后代
  - MCP leader 意外退出清理 wrapper 后代
  - 清理失败时保留 ownership
  - 未知 listener 占用端口时 fail-loud 且不接管
  - managed-service leader 退出后释放 listener 孙进程与端口
  - Supervisor 清理旧 boot 遗留 listener
- 新增 `leader_exit_assumed_tree_exit` mutant，证明 Gate 不会把 leader 退出误判为整个进程树已释放
- 更新 P0 coverage baseline，要求 MCP 与 plugin 变更持续运行该场景

## Verification

- dedicated scenario nodes: `6 passed`
- lifecycle mutant: `1 passed`
- semantic tests: `27 passed, 1 skipped`
- full pytest: `2419 passed, 1 skipped`
- tests Pyright: `0 errors, 0 warnings`
- catalog audit: passed
- post-rebase public change-impact Gate: passed, 8 scenarios
  - report: `docker/debug/reports/change-gate/20260729-112757-e1854d28`
  - base: `a6e334a500d8abe127c8f5e5d620c7a3922bbadf`
  - head: `b6f18ea01ee7134874d10b9a67d3970d5be04e53`
  - plan digest: `57a9062d2a426235a20404765cbc7952809e1fb3a0eadd294a3ce2b0963bf82b`
  - source digest: `46cd5684c0c4f41d6d48f9c629288f75af0b3b48e1623ebdbc31c4c84c0326ec`
  - lifecycle scenario: `6 passed`, no residual containers/networks/volumes
- private contract gate: required / pending maintainer

## Rollback

Revert commit `b6f18ea0`.