### PR TITLE
fix(akasha): bind active recall card to turn

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -797,6 +797,7 @@ class DefaultContextStore(ContextStore):
                     session_metadata=(
                         session.metadata if isinstance(session.metadata, dict) else {}
                     ),
+                    turn_id=current_turn_id.get(),
                     timestamp=msg.timestamp,
                 )
             )

--- a/agent/retrieval/default_pipeline.py
+++ b/agent/retrieval/default_pipeline.py
@@ -41,6 +41,7 @@ class DefaultMemoryRetrievalPipeline(MemoryRetrievalPipeline):
                 context={
                     "history": request.history,
                     "session_metadata": request.session_metadata,
+                    "turn_id": request.turn_id,
                 },
                 filters=MemoryQueryFilters(hints=dict(request.extra or {})),
                 timestamp=request.timestamp,

--- a/agent/retrieval/protocol.py
+++ b/agent/retrieval/protocol.py
@@ -16,6 +16,7 @@ class RetrievalRequest:
     history: list[HistoryMessage]  # 完整会话历史，无截窗。pipeline 实现负责自行决定使用范围。
     # DefaultMemoryRetrievalPipeline 内部截取末尾 MemoryConfig.window 条后使用。
     session_metadata: dict[str, object]
+    turn_id: str = ""
     timestamp: datetime | None = None
     extra: dict[str, object] = field(default_factory=dict[str, object])
 

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -9,6 +9,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING, cast
 from zoneinfo import ZoneInfo
 
@@ -49,16 +50,6 @@ class UnsupportedOperationError(RuntimeError):
 
 
 @dataclass(frozen=True)
-class PendingRetrieval:
-    """Bind one stateful query to the later committed source turn."""
-
-    ticket: RetrievalTicket
-    query_timestamp: datetime
-    query_text: str
-    query_dense: np.ndarray
-
-
-@dataclass(frozen=True)
 class RetrievalRecords:
     """Keep direct dense recall separate from explicit pattern completion."""
 
@@ -68,6 +59,26 @@ class RetrievalRecords:
     @property
     def combined(self) -> list[MemoryRecord]:
         return [*self.dense, *self.completion]
+
+
+@dataclass(frozen=True)
+class PendingRetrieval:
+    """Bind one stateful query and its prompt lanes to the active host turn."""
+
+    ticket: RetrievalTicket
+    query_timestamp: datetime
+    query_text: str
+    query_dense: np.ndarray
+    turn_id: str
+    records: RetrievalRecords
+
+
+@dataclass(frozen=True)
+class ActiveRecallSnapshot:
+    """Expose the exact pending prompt lanes without mutable graph state."""
+
+    query_id: str
+    records: RetrievalRecords
 
 
 class AkashaMemoryEngine:
@@ -146,6 +157,7 @@ class AkashaMemoryEngine:
 
         # 2. Keep one global graph writer and one pending query per session.
         self._lock = threading.RLock()
+        self._pending_changed = threading.Condition(self._lock)
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
@@ -220,12 +232,20 @@ class AkashaMemoryEngine:
                         raise RuntimeError(
                             "stateful context query lost its session key"
                         )
+                    turn_id = request.context.get("turn_id", "")
+                    if not isinstance(turn_id, str):
+                        raise ValueError(
+                            "Akasha context turn_id must be a string"
+                        )
                     self._pending[session_key] = PendingRetrieval(
                         ticket,
                         request.timestamp,
                         text,
                         dense.copy(),
+                        turn_id,
+                        lanes,
                     )
+                    self._pending_changed.notify_all()
         # 3. Render context only for the runtime context-injection intent.
         text_block = (
             self._context_block(lanes, request.timestamp)
@@ -252,6 +272,29 @@ class AkashaMemoryEngine:
                 "residual_l1": ticket.completion.residual_l1,
             },
         )
+
+    def wait_for_active_recall(
+        self,
+        session_key: str,
+        turn_id: str,
+        *,
+        timeout: float = 15.0,
+    ) -> ActiveRecallSnapshot | None:
+        """Wait for and return only the retrieval bound to one active turn."""
+
+        deadline = monotonic() + max(0.0, timeout)
+        with self._pending_changed:
+            while True:
+                pending = self._pending.get(session_key)
+                if pending is not None and pending.turn_id == turn_id:
+                    return ActiveRecallSnapshot(
+                        query_id=pending.ticket.turn_id,
+                        records=pending.records,
+                    )
+                remaining = deadline - monotonic()
+                if remaining <= 0.0:
+                    return None
+                self._pending_changed.wait(remaining)
 
     async def ingest(
         self,

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -8,7 +8,9 @@ from agent.plugins import (
     Plugin,
 )
 from agent.plugins.mobile_ui import MobileUiRpcInvalidRequest
+from core.memory.engine import MemoryRecord
 
+from .engine import AkashaMemoryEngine
 from .inspector import AkashaInspectorReader, mobile_summary
 from .memory_plugin import MemoryPlugin
 
@@ -128,11 +130,34 @@ class AkashaPlugin(Plugin):
                 "Akasha recall.current 的 message_id 必须是字符串"
             )
 
-        # 2. Synthetic active messages use the latest committed session turn.
+        # 2. Synthetic active messages resolve only their exact pending retrieval.
         if isinstance(message_id, str) and message_id.startswith("assistant:"):
             if turn_id is None or message_id != f"assistant:{turn_id}":
                 return _empty_mobile_recall()
-            item = self._inspector().latest_for_session(session_id)
+            engine = cast(
+                AkashaMemoryEngine,
+                self.context.memory_engine,
+            )
+            if engine.describe().name != "akasha":
+                raise RuntimeError(
+                    "Akasha active recall requires AkashaMemoryEngine"
+                )
+            pending = engine.wait_for_active_recall(session_id, turn_id)
+            if pending is None:
+                return _empty_mobile_recall()
+            return {
+                "schema": _MOBILE_RECALL_SCHEMA,
+                "query_id": pending.query_id,
+                "recall_capture_available": True,
+                "left": _mobile_recall_records(
+                    pending.records.dense
+                ),
+                "right": _mobile_recall_records(
+                    pending.records.completion
+                ),
+                "tool_left": [],
+                "tool_right": [],
+            }
         elif isinstance(message_id, str):
             item = self._inspector().for_assistant_message(
                 session_id,
@@ -216,3 +241,23 @@ def _mobile_recall_lane(
             item["score"] = score
         projected.append(item)
     return projected
+
+
+def _mobile_recall_records(
+    records: tuple[MemoryRecord, ...],
+) -> list[dict[str, object]]:
+    """Project frozen runtime records through the same bounded card shape."""
+
+    return _mobile_recall_lane(
+        [
+            {
+                "user_text": record.signals["user_text"],
+                "assistant_preview": record.signals[
+                    "assistant_preview"
+                ],
+                "ts": record.signals["started_at"],
+                "score": record.score,
+            }
+            for record in records
+        ]
+    )

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -20,6 +20,7 @@ from agent.config_models import (
     MemoryConfig as HostMemoryConfig,
     MemoryEmbeddingConfig,
 )
+from agent.looping.ports import MemoryServices
 from agent.plugins import Plugin
 from agent.plugins.context import PluginContext, PluginKVStore
 from agent.plugins.manifest import (
@@ -27,13 +28,15 @@ from agent.plugins.manifest import (
     ensure_workspace_plugin_data_dir,
 )
 from agent.tools.recall_memory import RecallMemoryTool
+from agent.retrieval.default_pipeline import DefaultMemoryRetrievalPipeline
+from agent.retrieval.protocol import RetrievalRequest
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryScope
 from core.memory.plugin import MemoryPlugin as MemoryPluginProtocol
 from plugins.akasha.application.rebuild import rebuild_memory
 from plugins.akasha.config import AkashaConfig, render_akasha_config
 from plugins.akasha.dashboard import register as register_dashboard
-from plugins.akasha.engine import AkashaMemoryEngine
+from plugins.akasha.engine import ActiveRecallSnapshot, AkashaMemoryEngine
 from plugins.akasha.inspector import AkashaInspectorReader
 from plugins.akasha.infrastructure.persistence import (
     logical_state_sha256,
@@ -157,9 +160,64 @@ async def test_online_turn_recall_and_replay_share_one_state(
 
     # 3. Explicit recall is read-only and cannot replace context learning.
     next_time = started + timedelta(minutes=5)
-    context = await engine.query(
-        _query("alpha follow", next_time, intent="context")
+    active_turn_id = "turn:alpha-follow"
+    plugin = AkashaPlugin()
+    plugin.context = PluginContext(
+        event_bus=cast(Any, None),
+        tool_registry=None,
+        plugin_id="akasha",
+        plugin_dir=Path("plugins/akasha"),
+        data_dir=builtin_plugin_data_dir("akasha", tmp_path),
+        kv_store=PluginKVStore(tmp_path / ".kv.json"),
+        workspace=tmp_path,
+        memory_engine=engine,
     )
+    wait_started = threading.Event()
+    wait_for_active_recall = engine.wait_for_active_recall
+
+    def marked_wait_for_active_recall(
+        session_key: str,
+        turn_id: str,
+        *,
+        timeout: float = 15.0,
+    ) -> ActiveRecallSnapshot | None:
+        wait_started.set()
+        return wait_for_active_recall(
+            session_key,
+            turn_id,
+            timeout=timeout,
+        )
+
+    monkeypatch.setattr(
+        engine,
+        "wait_for_active_recall",
+        marked_wait_for_active_recall,
+    )
+    active_query = asyncio.create_task(
+        asyncio.to_thread(
+            plugin.mobile_ui_query,
+            "recall.current",
+            {"message_id": f"assistant:{active_turn_id}"},
+            session_id="test:one",
+            turn_id=active_turn_id,
+        )
+    )
+    assert await asyncio.to_thread(wait_started.wait, 1.0)
+    context = await DefaultMemoryRetrievalPipeline(
+        MemoryServices(engine=engine)
+    ).retrieve(
+        RetrievalRequest(
+            message="alpha follow",
+            session_key="test:one",
+            channel="test",
+            chat_id="one",
+            history=[],
+            session_metadata={},
+            turn_id=active_turn_id,
+            timestamp=next_time,
+        )
+    )
+    active_mobile = await active_query
     pending = engine._pending["test:one"]  # noqa: SLF001
     tool = RecallMemoryTool(
         engine,
@@ -183,9 +241,25 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert rendered["count"] == 1
     assert before_recall == after_recall
     assert engine._pending["test:one"] is pending  # noqa: SLF001
-    assert context.text_block.startswith("# Akasha memory now=07-06")
-    assert "## 左脑记忆：精确回忆" in context.text_block
-    assert f'assistant="{"A" * 50}..."' in context.text_block
+    assert context.block.startswith("# Akasha memory now=07-06")
+    assert "## 左脑记忆：精确回忆" in context.block
+    assert f'assistant="{"A" * 50}..."' in context.block
+    assert (
+        engine.wait_for_active_recall(
+            "test:one",
+            "turn:other",
+            timeout=0,
+        )
+        is None
+    )
+
+    assert [
+        item["user_preview"]
+        for item in cast(
+            list[dict[str, object]],
+            active_mobile["left"],
+        )
+    ] == ["alpha start"]
     tool_payload = dict(rendered)
     tool_payload["items"] = [
         *cast(list[dict[str, object]], rendered["items"]),
@@ -299,17 +373,6 @@ async def test_online_turn_recall_and_replay_share_one_state(
         assert api_detail.json()["left_count"] == 1
 
     # 7. Mobile projections resolve the same committed assistant message.
-    plugin = AkashaPlugin()
-    plugin.context = PluginContext(
-        event_bus=cast(Any, None),
-        tool_registry=None,
-        plugin_id="akasha",
-        plugin_dir=Path("plugins/akasha"),
-        data_dir=builtin_plugin_data_dir("akasha", tmp_path),
-        kv_store=PluginKVStore(tmp_path / ".kv.json"),
-        workspace=tmp_path,
-        memory_engine=engine,
-    )
     mobile = plugin.mobile_ui_query(
         "recall.current",
         {"message_id": "message:3"},
@@ -334,6 +397,8 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert mobile["schema"] == "akasha.recall-card.v1"
     mobile_left = cast(list[dict[str, object]], mobile["left"])
     assert mobile_left[0]["user_preview"] == "alpha start"
+    assert active_mobile["left"] == mobile["left"]
+    assert active_mobile["right"] == mobile["right"]
     assert "user_text" not in mobile_left[0]
     assert "assistant_text" not in json.dumps(mobile, ensure_ascii=False)
     assert (

--- a/tests/test_turn_pipelines.py
+++ b/tests/test_turn_pipelines.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.control.context import current_turn_id
 from agent.core.passive_turn import _persistence_from_metadata
 from agent.core.runtime_support import SessionLike, TurnRunResult
 from agent.looping.core import AgentLoop, _supports_stream_events
@@ -377,10 +378,15 @@ def test_agent_loop_uses_custom_retrieval_pipeline(tmp_path: Path):
     loop._reasoner.run_turn = AsyncMock(return_value=TurnRunResult(reply="ok"))
 
     msg = InboundMessage(channel="cli", sender="u", chat_id="1", content="hello")
-    asyncio.run(loop._core_runner.process(msg, msg.session_key))
+    turn_token = current_turn_id.set("turn:test-retrieval")
+    try:
+        asyncio.run(loop._core_runner.process(msg, msg.session_key))
+    finally:
+        current_turn_id.reset(turn_token)
 
     assert custom_retrieval.requests
     assert custom_retrieval.requests[0].message == "hello"
+    assert custom_retrieval.requests[0].turn_id == "turn:test-retrieval"
     run_kwargs = loop._reasoner.run_turn.await_args.kwargs
     assert "base_history" in run_kwargs
     assert run_kwargs["base_history"] is None


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha 卡片在 assistant 运行中把 synthetic message 映射到 session 最新已提交 turn，导致显示上一轮召回；回答结束后又按持久化 assistant message ID 显示当前轮，因此前后不一致。
- 用户可见结果：运行中的卡片只等待并读取当前 `turn_id` 对应的 pending retrieval；回答持久化后继续按同一轮的持久化记录投影，左右脑召回保持一致。
- 本 PR 不处理：移动端视觉样式、Akasha 检索算法、持久化 schema、tool recall 的运行中实时展示。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Akasha mobile `recall.current` 与默认 memory retrieval pipeline
- `runtime_patch`：`required`
- `runtime_patch_reason`：当前 turn identity 由 Core 创建，Akasha pending retrieval 由运行时插件持有；客户端无法可靠推导或读取尚未提交的 retrieval。
- `authoritative_state_owner`：运行中由 Akasha `PendingRetrieval(turn_id)` 拥有；提交后由 TurnCommitted + Akasha Inspector 按持久化 assistant message ID 拥有。
- `client_only_alternative`：客户端继续轮询只能看到旧的 persisted turn，无法修复当前 pending retrieval 的身份绑定。
- 关联不变量：active card 不回退到其他 turn；final card 只按持久化 message ID；`sessions.db/messages` 只追加。
- `protected_state`：既有 session message、Akasha graph/sidecar、memory algorithm 与历史 recall capture。
- 允许的副作用：内存中保存当前 retrieval 的只读投影；mobile query 最多等待 15 秒让当前 retrieval 建立。
- 禁止的副作用：不 UPDATE/DELETE 消息，不改数据库/schema，不返回上一轮卡片，不改变检索结果。

## 改动范围

- 主要文件：`agent/retrieval/protocol.py`、`agent/core/passive_turn.py`、`agent/retrieval/default_pipeline.py`、`plugins/akasha/engine.py`、`plugins/akasha/plugin.py` 及对应测试。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用；没有 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：core/runtime `e55e593e1719f176c31619be3fd8403abe37b8f5`；public Gate report `20260729-121624-5f051b3a`。
- 回滚方式：revert `e55e593e1719f176c31619be3fd8403abe37b8f5`；没有数据回滚步骤。

## 验证

- [x] 相关 targeted tests 已通过：22 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过；生产与测试 Pyright 均为 0 error，模块 compileall 通过；本次无前端源码改动。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行；8 个 selected public scenarios 通过。
- `sourceDigest`：`347978763618e426e80b4555532883155ec4ef55522e61f77d9d02fff6b94d88`
- `planDigest`：`f7bf7d70648646d7f2151f423066bf96607c58a093dbfe6b63b68d9075e2cabf`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：未运行真实设备；本次只改服务端投影，mobile realtime contract 已由公开 Gate 覆盖。
- 其他验证：`pytest -q -W error tests/` 为 2419 passed, 1 skipped；Python SDK 为 6 passed；control schema check 通过。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次为既有“当前卡片对应当前 prompt”语义的 bugfix，没有新增长期产品语义。
- [x] 已按 MOB-001 核对能力 owner；身份由 Core 提供，pending/final 投影由 Akasha plugin 拥有。
- [x] 当前没有对应 NOW 事项，不适用。