### PR TITLE
[codex] sync Akasha retrieval transactions

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "47c22896bf9dde454a9458622d6292565d392490",
+  "commit": "b88ac1c6b05e2e493ca5b0c3ccd0b19112eafe7a",
   "source_subtree": "src/akasha",
-  "source_tree": "358d983af4987ff4d0a685481c106682a54ffe4b",
-  "source_sha256": "e824bf056f4fad0db937e970f6ed91ac09b52c013386662cbebe0643af5637d7"
+  "source_tree": "c697d9412c5857b4c143da48376332a386a3e7f2",
+  "source_sha256": "02edf3446ae71dc162a408de2c0eadd0a218314aedff90d480be2fd5599b58e5"
 }

--- a/plugins/akasha/application/cycle.py
+++ b/plugins/akasha/application/cycle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 from dataclasses import dataclass, replace
 
 import numpy as np
@@ -12,7 +11,7 @@ from ..domain.features import (
     BurstAwareFeaturePool,
     BurstDecision,
 )
-from ..domain.graph import DynamicMemoryGraph
+from ..domain.graph import DynamicMemoryGraph, RetrievalState
 from ..domain.readout import (
     PatternCompletion,
     RecallCapture,
@@ -42,7 +41,8 @@ class RetrievalTicket:
     evidence: SeedEvidence
     diffusion: DiffusionResult
     completion: PatternCompletion
-    prepared_graph: DynamicMemoryGraph
+    prepared_turn_capacity: int
+    prepared_state: RetrievalState
 
 
 @dataclass(frozen=True)
@@ -128,7 +128,6 @@ class MemoryCycle:
         *,
         capture_paths: bool = False,
         include_completion: bool = True,
-        isolate_graph: bool = True,
     ) -> RetrievalTicket:
         """Read the current state and return a non-mutating retrieval ticket."""
 
@@ -148,47 +147,49 @@ class MemoryCycle:
         )
         evidence = decision.evidence
 
-        # 3. Advance an isolated graph copy and settle its local fixed point.
+        # 3. Advance topology and causal clocks inside a reversible read frame.
         previous_turn_capacity = self.graph.turn_count
-        prepared = (
-            copy.deepcopy(self.graph)
-            if isolate_graph
-            else self.graph
-        )
-        if event >= prepared.turn_count:
-            prepared.grow_turn_capacity(event + 1)
-        prepared.prepare_retrieval(
-            event,
-            turn.inter_gap_seconds,
-            evidence,
-        )
-        diffusion = residual_push(
-            prepared,
-            evidence.seed,
-            event,
-            restart=self.config.restart,
-            tolerance=self.config.tolerance,
-            capture_paths=capture_paths,
-        )
-        completion = (
-            _empty_completion(diffusion)
-            if event == 0 or not include_completion
-            else read_pattern_completion(
-                graph=prepared,
-                pool=pool,
-                query=turn,
-                context=decision.context,
-                evidence=evidence,
-                diffusion=diffusion,
-                historical_surprise=_historical_surprise(
-                    self.evidence
-                ),
-                config=self.config,
-                context_dependence=decision.context_dependence,
-                visible_nodes=decision.visible_nodes,
-                burst_continued=decision.continued,
+        published_state = self.graph.capture_retrieval_state()
+        try:
+            if event >= self.graph.turn_count:
+                self.graph.grow_turn_capacity(event + 1)
+            self.graph.prepare_retrieval(
+                event,
+                turn.inter_gap_seconds,
+                evidence,
             )
-        )
+            prepared_turn_capacity = self.graph.turn_count
+            prepared_state = self.graph.capture_retrieval_state()
+            diffusion = residual_push(
+                self.graph,
+                evidence.seed,
+                event,
+                restart=self.config.restart,
+                tolerance=self.config.tolerance,
+                capture_paths=capture_paths,
+            )
+            completion = (
+                _empty_completion(diffusion)
+                if event == 0 or not include_completion
+                else read_pattern_completion(
+                    graph=self.graph,
+                    pool=pool,
+                    query=turn,
+                    context=decision.context,
+                    evidence=evidence,
+                    diffusion=diffusion,
+                    historical_surprise=_historical_surprise(
+                        self.evidence
+                    ),
+                    config=self.config,
+                    context_dependence=decision.context_dependence,
+                    visible_nodes=decision.visible_nodes,
+                    burst_continued=decision.continued,
+                )
+            )
+        finally:
+            self.graph.apply_retrieval_state(published_state)
+            self.graph.restore_turn_capacity(previous_turn_capacity)
         return RetrievalTicket(
             state_version=event,
             previous_turn_capacity=previous_turn_capacity,
@@ -200,7 +201,8 @@ class MemoryCycle:
             evidence=evidence,
             diffusion=diffusion,
             completion=completion,
-            prepared_graph=prepared,
+            prepared_turn_capacity=prepared_turn_capacity,
+            prepared_state=prepared_state,
         )
 
     def commit(
@@ -233,9 +235,13 @@ class MemoryCycle:
                 "retrieval ticket turn identity does not match committed turn"
             )
 
-        # 2. Remap historical event references to the prepared graph capacity.
+        # 2. Materialize the accepted read frame on the committed graph.
+        if selected.prepared_turn_capacity < self.graph.turn_count:
+            raise RuntimeError("committed memory cycle cannot shrink capacity")
+        self.graph.grow_turn_capacity(selected.prepared_turn_capacity)
+        self.graph.apply_retrieval_state(selected.prepared_state)
         offset = (
-            selected.prepared_graph.turn_count
+            selected.prepared_turn_capacity
             - selected.previous_turn_capacity
         )
         if offset < 0:
@@ -253,8 +259,7 @@ class MemoryCycle:
                 for event in self.events
             ]
 
-        # 3. Adopt the prepared state and learn the settled activity once.
-        self.graph = selected.prepared_graph
+        # 3. Learn the accepted retrieval activity exactly once.
         plasticity = replace(
             self.graph.learn(
                 self.state_version,

--- a/plugins/akasha/application/rebuild.py
+++ b/plugins/akasha/application/rebuild.py
@@ -145,7 +145,6 @@ def _replay(
             turn,
             capture_paths=event in targets,
             include_completion=True,
-            isolate_graph=False,
         )
         committed = cycle.commit(
             turn,

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import copy
 import math
+import threading
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -65,6 +65,7 @@ class OnlineMemoryRuntime:
         self.embedding_dimension = embedding_dimension
         self.config = config
         self._writer_lease = WriterLease(memory_path)
+        self._state_lock = threading.RLock()
         self.cycle = self._restore_or_replay()
 
     def close(self) -> None:
@@ -84,7 +85,6 @@ class OnlineMemoryRuntime:
         # 1. Validate and normalize the external embedding boundary.
         vector = _unit_dense(dense)
         started = _as_utc(timestamp)
-        gap = _global_gap(self.cycle.turns, started)
         terms = tuple(
             sorted(
                 tokenize(text).items(),
@@ -92,29 +92,31 @@ class OnlineMemoryRuntime:
             )
         )
 
-        # 2. Build the next causal turn shell and run the shared cycle.
-        event = self.cycle.state_version
-        turn = Turn(
-            node_id=event,
-            turn_id=f"pending:{session_key}:{started.isoformat()}",
-            session_key=session_key,
-            user_seq=-1,
-            user_message_id=f"pending:user:{event}",
-            assistant_message_id=f"pending:assistant:{event}",
-            started_at=started.isoformat(),
-            committed_at=started.isoformat(),
-            user_text=text,
-            assistant_text="",
-            user_dense=vector,
-            assistant_dense=None,
-            user_terms=terms,
-            assistant_terms=(),
-            inter_gap_seconds=gap,
-        )
-        return turn, self.cycle.retrieve(
-            turn,
-            capture_paths=capture_paths,
-        )
+        # 2. Preview the mutable graph under its owning runtime lock.
+        with self._state_lock:
+            gap = _global_gap(self.cycle.turns, started)
+            event = self.cycle.state_version
+            turn = Turn(
+                node_id=event,
+                turn_id=f"pending:{session_key}:{started.isoformat()}",
+                session_key=session_key,
+                user_seq=-1,
+                user_message_id=f"pending:user:{event}",
+                assistant_message_id=f"pending:assistant:{event}",
+                started_at=started.isoformat(),
+                committed_at=started.isoformat(),
+                user_text=text,
+                assistant_text="",
+                user_dense=vector,
+                assistant_dense=None,
+                user_terms=terms,
+                assistant_terms=(),
+                inter_gap_seconds=gap,
+            )
+            return turn, self.cycle.retrieve(
+                turn,
+                capture_paths=capture_paths,
+            )
 
     def commit_from_source(
         self,
@@ -176,50 +178,62 @@ class OnlineMemoryRuntime:
     ) -> OnlineCommit:
         """Apply one staged suffix and atomically publish its graph snapshot."""
 
-        # 1. Reject overlapping writers before cloning the published state.
+        with self._state_lock:
+            return self._publish_staged_locked(staged)
+
+    def _publish_staged_locked(
+        self,
+        staged: StagedOnlineCommit,
+    ) -> OnlineCommit:
+        """Publish one staged suffix while holding the graph ownership lock."""
+
+        # 1. Reject overlapping writers before mutating the published cache.
         if self.cycle.state_version != staged.base_version:
             raise RuntimeError(
                 "staged Akasha commit no longer matches published state"
             )
-        candidate = copy.deepcopy(self.cycle)
         last_commit: CycleCommit | None = None
         last_turn: Turn | None = None
-        for turn in staged.turns:
-            selected = _matching_ticket(
-                turn,
-                staged.user_message_id,
-                staged.assistant_message_id,
-                staged.ticket,
-            )
-            last_commit = candidate.commit(turn, selected)
-            last_turn = turn
-        if last_commit is None or last_turn is None:
-            raise RuntimeError("online commit produced no memory event")
-        if (
-            last_turn.user_message_id != staged.user_message_id
-            or last_turn.assistant_message_id != staged.assistant_message_id
-        ):
-            raise ValueError(
-                "TurnCommitted is not the latest canonical sparse turn"
-            )
+        try:
+            for turn in staged.turns:
+                selected = _matching_ticket(
+                    turn,
+                    staged.user_message_id,
+                    staged.assistant_message_id,
+                    staged.ticket,
+                )
+                last_commit = self.cycle.commit(turn, selected)
+                last_turn = turn
+            if last_commit is None or last_turn is None:
+                raise RuntimeError("online commit produced no memory event")
+            if (
+                last_turn.user_message_id != staged.user_message_id
+                or last_turn.assistant_message_id
+                != staged.assistant_message_id
+            ):
+                raise ValueError(
+                    "TurnCommitted is not the latest canonical sparse turn"
+                )
 
-        # 2. Publish one complete SQLite snapshot before adopting memory state.
-        if candidate.context is None:
-            raise RuntimeError("committed memory state has no context")
-        write_memory_database(
-            self.memory_path,
-            turns=candidate.turns,
-            graph=candidate.graph,
-            events=candidate.events,
-            evidence=candidate.evidence,
-            captures=[],
-            context=candidate.context,
-            burst_members=candidate.burst_members,
-            config=self.config,
-            metadata=deterministic_metadata(self.index_path),
-            recalls=candidate.recalls,
-        )
-        self.cycle = candidate
+            # 2. Publish durable state before exposing the completed transaction.
+            if self.cycle.context is None:
+                raise RuntimeError("committed memory state has no context")
+            write_memory_database(
+                self.memory_path,
+                turns=self.cycle.turns,
+                graph=self.cycle.graph,
+                events=self.cycle.events,
+                evidence=self.cycle.evidence,
+                captures=[],
+                context=self.cycle.context,
+                burst_members=self.cycle.burst_members,
+                config=self.config,
+                metadata=deterministic_metadata(self.index_path),
+                recalls=self.cycle.recalls,
+            )
+        except Exception:
+            self.cycle = self._restore_persisted_cycle()
+            raise
         return OnlineCommit(last_turn, last_commit)
 
     def _restore_or_replay(self) -> MemoryCycle:
@@ -248,6 +262,25 @@ class OnlineMemoryRuntime:
             return self._catch_up(cycle, turns)
 
         # 2. Restore the persisted prefix and replay only crash-window suffixes.
+        cycle, suffix = self._load_persisted_prefix(turns)
+        return self._catch_up(cycle, suffix)
+
+    def _restore_persisted_cycle(self) -> MemoryCycle:
+        """Reload exactly the durable prefix after an in-memory write failure."""
+
+        if not self.memory_path.exists():
+            return MemoryCycle(self.config)
+        turns = load_turns(self.index_path)
+        cycle, _ = self._load_persisted_prefix(turns)
+        cycle.feature_pool = None
+        return cycle
+
+    def _load_persisted_prefix(
+        self,
+        turns: list[Turn],
+    ) -> tuple[MemoryCycle, list[Turn]]:
+        """Restore the durable prefix and return its unprocessed source suffix."""
+
         persisted = memory_turn_count(self.memory_path)
         if persisted > len(turns):
             raise ValueError(
@@ -282,7 +315,7 @@ class OnlineMemoryRuntime:
             if turns
             else None
         )
-        return self._catch_up(cycle, turns[persisted:])
+        return cycle, turns[persisted:]
 
     def _catch_up(
         self,
@@ -294,10 +327,7 @@ class OnlineMemoryRuntime:
         for turn in turns:
             cycle.commit(
                 turn,
-                cycle.retrieve(
-                    turn,
-                    isolate_graph=False,
-                ),
+                cycle.retrieve(turn),
             )
         cycle.feature_pool = None
         if not turns:

--- a/plugins/akasha/domain/graph.py
+++ b/plugins/akasha/domain/graph.py
@@ -26,6 +26,29 @@ class HubRecord:
     member_edge_ids: tuple[int, ...]
 
 
+@dataclass(frozen=True)
+class RetrievalState:
+    """Capture the small causal state advanced by one speculative retrieval."""
+
+    elapsed_seconds: float
+    short_log_gap: float | None
+    long_log_gap: float | None
+    short_gap_count: int
+    long_gap_count: int
+    short_recurrence_log_gap: float | None
+    long_recurrence_log_gap: float | None
+    short_recurrence_log_m2: float
+    long_recurrence_log_m2: float
+    short_recurrence_weight: float
+    long_recurrence_weight: float
+    recurrence_log_mean: float | None
+    recurrence_log_m2: float
+    recurrence_weight: float
+    last_external_seed_seconds: tuple[tuple[int, float], ...]
+    current_external: tuple[tuple[int, float], ...]
+    current_event: int
+
+
 class DynamicMemoryGraph:
     """Learn one bounded relation weight from every settled retrieval event."""
 
@@ -78,9 +101,24 @@ class DynamicMemoryGraph:
     def grow_turn_capacity(self, turn_count: int) -> None:
         """Grow turn slots and remap engram nodes without changing relations."""
 
-        # 1. Reject shrinkage because persisted turn identities are append-only.
+        # 1. Reject shrinkage at the public append-only boundary.
         if turn_count < self.turn_count:
             raise ValueError("memory graph turn capacity cannot shrink")
+        self._resize_turn_capacity(turn_count)
+
+    def restore_turn_capacity(self, turn_count: int) -> None:
+        """Undo speculative capacity growth before the graph is published."""
+
+        if turn_count > self.turn_count:
+            raise ValueError("restored memory graph capacity cannot grow")
+        if self.current_event >= turn_count:
+            raise ValueError("cannot remove a committed memory turn slot")
+        self._resize_turn_capacity(turn_count)
+
+    def _resize_turn_capacity(self, turn_count: int) -> None:
+        """Remap the disjoint turn and engram namespaces to one capacity."""
+
+        # 1. Return early when the namespace boundary is unchanged.
         if turn_count == self.turn_count:
             return
         old_turn_count = self.turn_count
@@ -119,6 +157,55 @@ class DynamicMemoryGraph:
             self.adjacency[source].append(edge_id)
             if bidirectional:
                 self.adjacency[target].append(edge_id)
+
+    def capture_retrieval_state(self) -> RetrievalState:
+        """Snapshot causal clocks without copying graph topology or weights."""
+
+        return RetrievalState(
+            elapsed_seconds=self.elapsed_seconds,
+            short_log_gap=self.short_log_gap,
+            long_log_gap=self.long_log_gap,
+            short_gap_count=self.short_gap_count,
+            long_gap_count=self.long_gap_count,
+            short_recurrence_log_gap=self.short_recurrence_log_gap,
+            long_recurrence_log_gap=self.long_recurrence_log_gap,
+            short_recurrence_log_m2=self.short_recurrence_log_m2,
+            long_recurrence_log_m2=self.long_recurrence_log_m2,
+            short_recurrence_weight=self.short_recurrence_weight,
+            long_recurrence_weight=self.long_recurrence_weight,
+            recurrence_log_mean=self.recurrence_log_mean,
+            recurrence_log_m2=self.recurrence_log_m2,
+            recurrence_weight=self.recurrence_weight,
+            last_external_seed_seconds=tuple(
+                sorted(self.last_external_seed_seconds.items())
+            ),
+            current_external=tuple(sorted(self.current_external.items())),
+            current_event=self.current_event,
+        )
+
+    def apply_retrieval_state(self, state: RetrievalState) -> None:
+        """Adopt one versioned retrieval frame and invalidate read caches."""
+
+        self.elapsed_seconds = state.elapsed_seconds
+        self.short_log_gap = state.short_log_gap
+        self.long_log_gap = state.long_log_gap
+        self.short_gap_count = state.short_gap_count
+        self.long_gap_count = state.long_gap_count
+        self.short_recurrence_log_gap = state.short_recurrence_log_gap
+        self.long_recurrence_log_gap = state.long_recurrence_log_gap
+        self.short_recurrence_log_m2 = state.short_recurrence_log_m2
+        self.long_recurrence_log_m2 = state.long_recurrence_log_m2
+        self.short_recurrence_weight = state.short_recurrence_weight
+        self.long_recurrence_weight = state.long_recurrence_weight
+        self.recurrence_log_mean = state.recurrence_log_mean
+        self.recurrence_log_m2 = state.recurrence_log_m2
+        self.recurrence_weight = state.recurrence_weight
+        self.last_external_seed_seconds = dict(
+            state.last_external_seed_seconds
+        )
+        self.current_external = dict(state.current_external)
+        self.current_event = state.current_event
+        self._transition_cache.clear()
 
     @property
     def resource_tau_seconds(self) -> float:


### PR DESCRIPTION
## 变更

- 将宿主 Akasha 镜像同步到 canonical engine `b88ac1c6b05e2e493ca5b0c3ccd0b19112eafe7a`
- 用可逆 retrieval frame 取代 query/publish 路径上的整图 `deepcopy`
- 用 runtime owner `RLock` 串行化同一内存图的 retrieve/commit
- publish 先更新内存、再原子持久化；持久化失败时从 durable prefix 重载
- 保留 #236 的 Active Recall 精确 turn 绑定

本 MR **不包含** reinforce / forget / toolchain 实验代码。

## 验证

- canonical engine：`41 passed`
- 宿主插件：`6 passed`
- 变更文件 Pyright：`0 errors`
- mirror checker：31 files 与上游 source tree/hash 完全一致
- 冻结线上只读副本全量 replay：16 张逻辑表逐行一致，状态 hash 均为 `c5628119...8c8c`
- 真实持久图基准：query median `0.845s -> 0.769s`（约 9%）；publish median `3.636s -> 1.650s`（约 55%）

Canonical engine PR: #6, #7