### PR TITLE
fix(ui): polish Akasha and Wake Proactive dashboard panels

### DIFF
--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -1134,7 +1134,13 @@ function toggleSet(id: string, checked: boolean, source: Set<string>, update: (v
 }
 
 function gridTemplate(columns: DashboardColumn[]): string {
-  return columns.map((col) => col.flex ? "1fr" : col.width ? `${col.width}px` : "auto").join(" ");
+  return columns
+    .map((col) => {
+      if (col.flex) return "minmax(0, 1fr)";
+      if (col.width) return `minmax(0, ${col.width}px)`;
+      return "minmax(0, auto)";
+    })
+    .join(" ");
 }
 
 function formatPluginCell(plugin: PluginConfig, column: DashboardColumn, item: Record<string, unknown>): string {
@@ -1145,6 +1151,10 @@ function formatPluginCell(plugin: PluginConfig, column: DashboardColumn, item: R
 
 function columnCellClass(column: DashboardColumn): string {
   const classes = [column.cellClass ?? ""];
+  if (!column.cellClass && column.fmt === "text-preview") classes.push("content-preview");
+  if (!column.cellClass && (column.fmt === "mono-session" || column.fmt === "mono-time")) {
+    classes.push(column.fmt === "mono-session" ? "mono cell-session" : "mono cell-time");
+  }
   if (column.align === "right") classes.push("align-right");
   return classes.filter(Boolean).join(" ");
 }

--- a/plugin_packages/wake-proactive/dashboard_panel.css
+++ b/plugin_packages/wake-proactive/dashboard_panel.css
@@ -1,92 +1,747 @@
-[data-akashic-plugin="wake-proactive"] .wake-detail { gap: 12px; padding: 16px; }
-[data-akashic-plugin="wake-proactive"] .wake-empty { padding: 28px; color: var(--color-muted); }
-[data-akashic-plugin="wake-proactive"] .wake-summary { display: flex; align-items: center; justify-content: space-between; padding: 14px; }
-[data-akashic-plugin="wake-proactive"] .wake-summary div { display: flex; flex-direction: column; gap: 4px; }
+/* Wake Proactive — host industrial tokens, content-first. */
+
+/* ── Run detail ─────────────────────────────────────────────── */
+
+[data-akashic-plugin="wake-proactive"] .wake-detail {
+  gap: 12px;
+  padding: 12px 4px 16px;
+  font-synthesis: none;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-empty {
+  padding: 28px 16px;
+  color: var(--color-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-summary div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
 [data-akashic-plugin="wake-proactive"] .wake-summary span,
 [data-akashic-plugin="wake-proactive"] .wake-message > span,
-[data-akashic-plugin="wake-proactive"] .wake-phase-title { color: var(--color-muted); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
-[data-akashic-plugin="wake-proactive"] .wake-summary strong { font-size: 16px; }
-[data-akashic-plugin="wake-proactive"] .wake-message { padding: 14px; }
-[data-akashic-plugin="wake-proactive"] .wake-message .ak-markdown { margin-top: 8px; }
-[data-akashic-plugin="wake-proactive"] .wake-phase { gap: 8px; }
-[data-akashic-plugin="wake-proactive"] .wake-phase-title { padding: 4px 2px; }
-[data-akashic-plugin="wake-proactive"] .wake-audit { border: 1px solid var(--color-border); border-radius: 6px; background: var(--color-surface); overflow: hidden; }
-[data-akashic-plugin="wake-proactive"] .wake-audit summary { display: flex; align-items: center; justify-content: space-between; padding: 11px 12px; cursor: pointer; color: var(--color-fg); font-size: 13px; }
-[data-akashic-plugin="wake-proactive"] .wake-audit[open] > summary { border-bottom: 1px solid var(--color-border); }
-[data-akashic-plugin="wake-proactive"] .wake-audit > .json-tree { max-height: 420px; overflow: auto; border: 0; border-radius: 0; }
+[data-akashic-plugin="wake-proactive"] .wake-phase-title {
+  color: var(--color-subtle);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
 
-[data-akashic-plugin="wake-meter"] { min-height: 100%; background: #0d1014; }
-[data-akashic-plugin="wake-meter"] .meter-loading { padding: 32px; color: var(--color-muted); font: 12px ui-monospace, monospace; }
-[data-akashic-plugin="wake-meter"] .excitement-console { min-height: 100%; padding: 28px; color: #edf2f5; background: #0d1014; }
-[data-akashic-plugin="wake-meter"] .meter-header { display: flex; align-items: end; justify-content: space-between; max-width: 940px; margin: 0 auto 22px; }
-[data-akashic-plugin="wake-meter"] .meter-header span { color: #7e8993; font: 700 10px/1.2 ui-monospace, monospace; letter-spacing: .16em; }
-[data-akashic-plugin="wake-meter"] .meter-header h2 { margin: 5px 0 0; font-size: 24px; font-weight: 750; letter-spacing: -.03em; }
-[data-akashic-plugin="wake-meter"] .meter-state { display: flex; align-items: center; gap: 8px; border: 2px solid #07090c; border-radius: 999px; padding: 7px 12px; background: #bcefff; color: #10232d; box-shadow: 3px 3px 0 #07090c; font: 800 11px ui-monospace, monospace; }
-[data-akashic-plugin="wake-meter"] .meter-state i { width: 8px; height: 8px; border: 2px solid #07090c; border-radius: 50%; background: #39b8e8; }
-[data-akashic-plugin="wake-meter"] .is-crossed .meter-state { background: #ff826d; color: #32100a; }
-[data-akashic-plugin="wake-meter"] .is-crossed .meter-state i { background: #fff3a8; }
+[data-akashic-plugin="wake-proactive"] .wake-summary strong {
+  color: var(--color-fg);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
 
-[data-akashic-plugin="wake-meter"] .meter-machine { position: relative; display: grid; grid-template-columns: minmax(280px, 400px) minmax(230px, 1fr); align-items: center; gap: 58px; max-width: 940px; min-height: 430px; margin: 0 auto; padding: 38px 62px; border: 3px solid #07090c; border-radius: 26px; background: #1a2027; box-shadow: 9px 9px 0 #07090c; }
-[data-akashic-plugin="wake-meter"] .meter-machine::after { content: "LIVE WATERLINE"; position: absolute; right: 24px; bottom: 18px; color: #68737d; font: 800 9px ui-monospace, monospace; letter-spacing: .14em; }
-[data-akashic-plugin="wake-meter"] .meter-chamber-wrap { position: relative; width: 250px; height: 350px; margin: 0 auto; }
-[data-akashic-plugin="wake-meter"] .tank-rim { position: absolute; left: 29px; top: 12px; z-index: 8; width: 174px; height: 18px; border: 4px solid #07090c; border-radius: 12px; background: #f5fafb; box-shadow: 4px 4px 0 #07090c; }
-[data-akashic-plugin="wake-meter"] .meter-chamber { position: absolute; inset: 23px 43px 8px 18px; overflow: hidden; border: 5px solid #07090c; border-radius: 10px 10px 24px 24px; background: #dff5f7; box-shadow: 5px 6px 0 #07090c; }
-[data-akashic-plugin="wake-meter"] .tank-zone { position: absolute; left: 0; right: 0; z-index: 0; pointer-events: none; }
-[data-akashic-plugin="wake-meter"] .overflow-zone { top: 0; height: 20%; background: #ffd8d0; }
-[data-akashic-plugin="wake-meter"] .overflow-zone span { position: absolute; right: 10px; top: 11px; color: #b94332; font: 800 9px ui-monospace, monospace; letter-spacing: .08em; }
-[data-akashic-plugin="wake-meter"] .warm-zone { bottom: 20%; height: 30%; background: #fff0b8; }
-[data-akashic-plugin="wake-meter"] .meter-fluid { position: absolute; left: 0; right: 0; z-index: 2; transition: height .65s cubic-bezier(.2,.8,.2,1), bottom .65s cubic-bezier(.2,.8,.2,1); }
-[data-akashic-plugin="wake-meter"] .meter-fluid.accumulated { bottom: 0; background: #41b8e7; }
-[data-akashic-plugin="wake-meter"] .meter-fluid.pressure { background: #ffc84b; }
-[data-akashic-plugin="wake-meter"] .is-crossed .meter-fluid.pressure { background: #ff6f5a; }
-[data-akashic-plugin="wake-meter"] .water-surface { position: absolute; left: -3px; right: -3px; z-index: 5; height: 18px; color: #8be0f6; transition: bottom .65s cubic-bezier(.2,.8,.2,1); animation: water-bob 2.2s ease-in-out infinite alternate; }
-[data-akashic-plugin="wake-meter"] .water-surface svg { display: block; width: 100%; height: 18px; overflow: visible; }
-[data-akashic-plugin="wake-meter"] .water-surface path { fill: currentColor; stroke: #07090c; stroke-width: 3px; vector-effect: non-scaling-stroke; }
-[data-akashic-plugin="wake-meter"] .water-surface.pressure-surface { color: #ffe08a; }
-[data-akashic-plugin="wake-meter"] .is-crossed .water-surface { color: #ff9b87; }
-[data-akashic-plugin="wake-meter"] .water-bubbles { position: absolute; inset: 0; z-index: 4; pointer-events: none; }
-[data-akashic-plugin="wake-meter"] .water-bubbles i { position: absolute; width: 9px; height: 9px; border: 3px solid #087ca9; border-radius: 50%; }
-[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(1) { left: 28px; bottom: 18%; }
-[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(2) { right: 25px; bottom: 31%; width: 6px; height: 6px; }
-[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(3) { left: 76px; bottom: 9%; width: 5px; height: 5px; }
-[data-akashic-plugin="wake-meter"] .meter-threshold { position: absolute; left: 0; right: 0; bottom: 80%; z-index: 7; border-top: 3px dashed #d84532; }
-[data-akashic-plugin="wake-meter"] .meter-threshold span { position: absolute; left: 8px; top: 6px; padding: 2px 5px; border: 2px solid #07090c; border-radius: 5px; background: #fff7e4; color: #a52d20; font: 800 9px ui-monospace, monospace; white-space: nowrap; }
-[data-akashic-plugin="wake-meter"] .meter-scale { position: absolute; right: 0; top: 29px; bottom: 17px; display: flex; flex-direction: column; justify-content: space-between; color: #7d8992; font: 800 9px ui-monospace, monospace; }
-[data-akashic-plugin="wake-meter"] .meter-scale span:nth-child(2) { color: #ff806b; }
+[data-akashic-plugin="wake-proactive"] .wake-message {
+  padding: 14px 16px;
+}
 
-[data-akashic-plugin="wake-meter"] .meter-burst { position: absolute; left: 18px; top: -12px; z-index: 12; width: 190px; height: 90px; opacity: 0; }
-[data-akashic-plugin="wake-meter"] .is-crossed .meter-burst { opacity: 1; animation: splash-pop .7s cubic-bezier(.2,1.4,.3,1) infinite alternate; }
-[data-akashic-plugin="wake-meter"] .meter-burst i { position: absolute; width: 16px; height: 23px; border: 3px solid #07090c; border-radius: 55% 45% 60% 40%; background: #ff806b; }
-[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(1) { left: 82px; top: 3px; }
-[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(2) { left: 38px; top: 26px; transform: rotate(-38deg) scale(.8); }
-[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(3) { right: 37px; top: 23px; transform: rotate(34deg) scale(.75); }
-[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(4) { left: 7px; top: 56px; transform: rotate(-62deg) scale(.55); }
-[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(5) { right: 8px; top: 53px; transform: rotate(64deg) scale(.55); }
-@keyframes water-bob { from { transform: translateX(-2px) rotate(-1deg); } to { transform: translateX(2px) rotate(1deg); } }
-@keyframes splash-pop { from { transform: translateY(5px) scale(.9); } to { transform: translateY(-4px) scale(1.05); } }
+[data-akashic-plugin="wake-proactive"] .wake-message .ak-markdown {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
 
-[data-akashic-plugin="wake-meter"] .meter-readout { padding-left: 42px; border-left: 3px solid #07090c; }
-[data-akashic-plugin="wake-meter"] .meter-readout > span { display: block; color: #81909a; font: 800 10px ui-monospace, monospace; letter-spacing: .14em; }
-[data-akashic-plugin="wake-meter"] .meter-readout strong { display: inline-block; margin-top: 8px; color: #f5fafb; font: 800 72px/.9 ui-monospace, monospace; letter-spacing: -.08em; }
-[data-akashic-plugin="wake-meter"] .meter-readout em { margin-left: 12px; color: #84919a; font: normal 18px ui-monospace, monospace; }
-[data-akashic-plugin="wake-meter"] .meter-readout p { max-width: 340px; margin: 18px 0 0; color: #aeb8bf; font-size: 13px; line-height: 1.6; }
-[data-akashic-plugin="wake-meter"] .is-crossed .meter-readout strong { color: #ff806b; }
+[data-akashic-plugin="wake-proactive"] .wake-phase {
+  gap: 8px;
+}
 
-[data-akashic-plugin="wake-meter"] .meter-telemetry { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; max-width: 940px; margin: 18px auto 0; }
-[data-akashic-plugin="wake-meter"] .meter-telemetry > div { position: relative; min-width: 0; padding: 15px 17px; border: 2px solid #07090c; border-radius: 12px; background: #1a2027; box-shadow: 4px 4px 0 #07090c; }
-[data-akashic-plugin="wake-meter"] .meter-telemetry span { display: flex; align-items: center; gap: 7px; color: #7d8992; font-size: 10px; }
-[data-akashic-plugin="wake-meter"] .meter-telemetry strong { display: block; margin-top: 6px; overflow: hidden; color: #e9eff2; font: 700 16px ui-monospace, monospace; text-overflow: ellipsis; }
-[data-akashic-plugin="wake-meter"] .meter-telemetry small { display: block; margin-top: 4px; color: #68747d; font-size: 9px; }
-[data-akashic-plugin="wake-meter"] .meter-telemetry span i { flex: 0 0 auto; width: 9px; height: 9px; border: 2px solid #07090c; border-radius: 50%; }
-[data-akashic-plugin="wake-meter"] .tone-cobalt { background: #41b8e7; }
-[data-akashic-plugin="wake-meter"] .tone-amber { background: #ffc84b; }
-[data-akashic-plugin="wake-meter"] .meter-footnote { display: flex; justify-content: space-between; gap: 20px; max-width: 940px; margin: 15px auto 0; color: #69757e; font-size: 10px; }
-[data-akashic-plugin="wake-meter"] .meter-footnote code { max-width: 48%; overflow: hidden; color: #78858e; font: 9px ui-monospace, monospace; text-overflow: ellipsis; white-space: nowrap; }
+[data-akashic-plugin="wake-proactive"] .wake-phase-title {
+  padding: 2px 2px 0;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 6px);
+  background: var(--color-surface);
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit summary {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px;
+  color: var(--color-fg);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  list-style: none;
+  user-select: none;
+  transition-property: background-color, color;
+  transition-duration: var(--t-fast, 140ms);
+  transition-timing-function: var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit summary::-webkit-details-marker {
+  display: none;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit summary::before {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 0.7em;
+  margin-inline-end: 6px;
+  color: var(--color-subtle);
+  content: "▸";
+  font-size: 12px;
+  line-height: 1;
+  transition: rotate var(--t-fast, 140ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit[open] summary::before {
+  rotate: 90deg;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit summary:hover {
+  background: var(--color-surface-2);
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit summary:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit[open] > summary {
+  border-bottom: 1px solid var(--color-border);
+}
+
+[data-akashic-plugin="wake-proactive"] .wake-audit > .json-tree {
+  max-height: 420px;
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+}
+
+/* ── Excitement meter ───────────────────────────────────────── */
+
+[data-akashic-plugin="wake-meter"] {
+  --wm-ink: var(--color-fg);
+  --wm-muted: var(--color-muted);
+  --wm-subtle: var(--color-subtle);
+  --wm-surface: var(--color-surface);
+  --wm-surface-2: var(--color-surface-2);
+  --wm-surface-3: var(--color-surface-3);
+  --wm-rule: var(--color-border);
+  --wm-rule-strong: var(--color-border-strong);
+  --wm-fluid: var(--color-accent);
+  --wm-fluid-soft: var(--color-accent-soft);
+  --wm-pressure: var(--color-warning);
+  --wm-crossed: var(--color-danger);
+  --wm-tank: color-mix(in oklab, var(--color-surface-2) 88%, var(--color-accent));
+  --wm-overflow: color-mix(in oklab, var(--color-danger) 14%, var(--color-surface-2));
+  --wm-warm: color-mix(in oklab, var(--color-warning) 12%, var(--color-surface-2));
+  --wm-radius: var(--radius-lg, 10px);
+  --wm-radius-sm: var(--radius, 6px);
+  --wm-ease: var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+  --wm-t: 520ms;
+  min-height: 100%;
+  color: var(--wm-ink);
+  background: var(--color-bg);
+  font-synthesis: none;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-loading {
+  padding: 32px 20px;
+  color: var(--wm-muted);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+[data-akashic-plugin="wake-meter"] .excitement-console {
+  min-height: 100%;
+  gap: 16px;
+  padding: 20px 18px 28px;
+  color: var(--wm-ink);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-header {
+  display: flex;
+  max-width: 920px;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 auto;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-header span {
+  color: var(--wm-subtle);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-header h2 {
+  margin: 4px 0 0;
+  color: var(--wm-ink);
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 650;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-state {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--wm-rule-strong);
+  border-radius: 9999px;
+  color: var(--wm-ink);
+  background: var(--wm-surface);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  user-select: none;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-state i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--wm-fluid);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--wm-fluid) 22%, transparent);
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .meter-state {
+  border-color: color-mix(in oklab, var(--wm-crossed) 45%, var(--wm-rule));
+  color: var(--wm-crossed);
+  background: color-mix(in oklab, var(--wm-crossed) 10%, var(--wm-surface));
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .meter-state i {
+  background: var(--wm-crossed);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--wm-crossed) 22%, transparent);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-machine {
+  position: relative;
+  display: grid;
+  max-width: 920px;
+  min-height: 0;
+  margin: 0 auto;
+  grid-template-columns: minmax(240px, 340px) minmax(0, 1fr);
+  align-items: center;
+  gap: 36px;
+  padding: 28px 32px;
+  border: 1px solid var(--wm-rule);
+  border-radius: var(--wm-radius);
+  background: var(--wm-surface);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-machine::after {
+  position: absolute;
+  right: 18px;
+  bottom: 14px;
+  color: var(--wm-subtle);
+  content: "live waterline";
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-chamber-wrap {
+  position: relative;
+  width: min(220px, 100%);
+  height: 320px;
+  margin: 0 auto;
+}
+
+[data-akashic-plugin="wake-meter"] .tank-rim {
+  position: absolute;
+  left: 24px;
+  top: 10px;
+  z-index: 8;
+  width: 152px;
+  height: 14px;
+  border: 1px solid var(--wm-rule-strong);
+  border-radius: var(--wm-radius-sm);
+  background: var(--wm-surface-3);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-chamber {
+  position: absolute;
+  inset: 20px 36px 10px 16px;
+  overflow: hidden;
+  border: 1px solid var(--wm-rule-strong);
+  border-radius: var(--wm-radius-sm) var(--wm-radius-sm) 18px 18px;
+  background: var(--wm-tank);
+}
+
+[data-akashic-plugin="wake-meter"] .tank-zone {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+[data-akashic-plugin="wake-meter"] .overflow-zone {
+  top: 0;
+  height: 20%;
+  background: var(--wm-overflow);
+}
+
+[data-akashic-plugin="wake-meter"] .overflow-zone span {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  color: var(--wm-crossed);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+[data-akashic-plugin="wake-meter"] .warm-zone {
+  bottom: 20%;
+  height: 30%;
+  background: var(--wm-warm);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-fluid {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  transition-property: height, bottom;
+  transition-duration: var(--wm-t);
+  transition-timing-function: var(--wm-ease);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-fluid.accumulated {
+  bottom: 0;
+  background: color-mix(in oklab, var(--wm-fluid) 72%, var(--wm-surface));
+}
+
+[data-akashic-plugin="wake-meter"] .meter-fluid.pressure {
+  background: color-mix(in oklab, var(--wm-pressure) 78%, var(--wm-surface));
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .meter-fluid.pressure {
+  background: color-mix(in oklab, var(--wm-crossed) 78%, var(--wm-surface));
+}
+
+[data-akashic-plugin="wake-meter"] .water-surface {
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  z-index: 5;
+  height: 14px;
+  color: color-mix(in oklab, var(--wm-fluid) 55%, white);
+  transition-property: bottom;
+  transition-duration: var(--wm-t);
+  transition-timing-function: var(--wm-ease);
+  animation: wake-water-bob 2.4s ease-in-out infinite alternate;
+}
+
+[data-akashic-plugin="wake-meter"] .water-surface svg {
+  display: block;
+  width: 100%;
+  height: 14px;
+  overflow: visible;
+}
+
+[data-akashic-plugin="wake-meter"] .water-surface path {
+  fill: currentColor;
+  stroke: color-mix(in oklab, var(--wm-ink) 35%, transparent);
+  stroke-width: 1.25px;
+  vector-effect: non-scaling-stroke;
+}
+
+[data-akashic-plugin="wake-meter"] .water-surface.pressure-surface {
+  color: color-mix(in oklab, var(--wm-pressure) 60%, white);
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .water-surface {
+  color: color-mix(in oklab, var(--wm-crossed) 55%, white);
+}
+
+[data-akashic-plugin="wake-meter"] .water-bubbles {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+[data-akashic-plugin="wake-meter"] .water-bubbles i {
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border: 1px solid color-mix(in oklab, var(--wm-fluid) 55%, var(--wm-ink));
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--wm-fluid) 18%, transparent);
+}
+
+[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(1) {
+  left: 26px;
+  bottom: 18%;
+}
+
+[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(2) {
+  right: 22px;
+  bottom: 31%;
+  width: 5px;
+  height: 5px;
+}
+
+[data-akashic-plugin="wake-meter"] .water-bubbles i:nth-child(3) {
+  left: 68px;
+  bottom: 10%;
+  width: 4px;
+  height: 4px;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-threshold {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 80%;
+  z-index: 7;
+  border-top: 1px dashed color-mix(in oklab, var(--wm-crossed) 70%, var(--wm-rule));
+}
+
+[data-akashic-plugin="wake-meter"] .meter-threshold span {
+  position: absolute;
+  left: 6px;
+  top: 5px;
+  padding: 2px 6px;
+  border: 1px solid var(--wm-rule);
+  border-radius: 4px;
+  color: var(--wm-crossed);
+  background: var(--wm-surface);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-scale {
+  position: absolute;
+  right: 0;
+  top: 26px;
+  bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  color: var(--wm-subtle);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1;
+  text-align: end;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-scale span:nth-child(2) {
+  color: var(--wm-crossed);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst {
+  position: absolute;
+  left: 14px;
+  top: -8px;
+  z-index: 12;
+  width: 170px;
+  height: 72px;
+  opacity: 0;
+  pointer-events: none;
+  transition-property: opacity;
+  transition-duration: 180ms;
+  transition-timing-function: var(--wm-ease);
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .meter-burst {
+  opacity: 1;
+  animation: wake-splash-pop 0.8s var(--wm-ease) infinite alternate;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i {
+  position: absolute;
+  width: 12px;
+  height: 18px;
+  border: 1px solid color-mix(in oklab, var(--wm-crossed) 55%, var(--wm-ink));
+  border-radius: 55% 45% 60% 40%;
+  background: color-mix(in oklab, var(--wm-crossed) 72%, var(--wm-surface));
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(1) {
+  left: 74px;
+  top: 2px;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(2) {
+  left: 34px;
+  top: 22px;
+  transform: rotate(-38deg) scale(0.8);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(3) {
+  right: 32px;
+  top: 20px;
+  transform: rotate(34deg) scale(0.75);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(4) {
+  left: 6px;
+  top: 48px;
+  transform: rotate(-62deg) scale(0.55);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-burst i:nth-child(5) {
+  right: 6px;
+  top: 46px;
+  transform: rotate(64deg) scale(0.55);
+}
+
+@keyframes wake-water-bob {
+  from {
+    transform: translateX(-1px);
+  }
+  to {
+    transform: translateX(1px);
+  }
+}
+
+@keyframes wake-splash-pop {
+  from {
+    transform: translateY(3px) scale(0.96);
+  }
+  to {
+    transform: translateY(-2px) scale(1.02);
+  }
+}
+
+[data-akashic-plugin="wake-meter"] .meter-readout {
+  min-width: 0;
+  padding-inline-start: 28px;
+  border-inline-start: 1px solid var(--wm-rule);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-readout > span {
+  display: block;
+  color: var(--wm-subtle);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-readout strong {
+  display: inline-block;
+  margin-top: 8px;
+  color: var(--wm-ink);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: clamp(2.75rem, 6vw, 3.75rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-readout em {
+  margin-inline-start: 10px;
+  color: var(--wm-muted);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 1.125rem;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-readout p {
+  max-width: 36ch;
+  margin: 14px 0 0;
+  color: var(--wm-muted);
+  font-size: 13px;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+[data-akashic-plugin="wake-meter"] .is-crossed .meter-readout strong {
+  color: var(--wm-crossed);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry {
+  display: grid;
+  max-width: 920px;
+  margin: 0 auto;
+  grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));
+  gap: 10px;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry > div {
+  min-width: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--wm-rule);
+  border-radius: var(--wm-radius-sm);
+  background: var(--wm-surface);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--wm-subtle);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry strong {
+  display: block;
+  margin-top: 6px;
+  overflow: hidden;
+  color: var(--wm-ink);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry small {
+  display: block;
+  margin-top: 3px;
+  color: var(--wm-subtle);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.35;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-telemetry span i {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+[data-akashic-plugin="wake-meter"] .tone-cobalt {
+  background: var(--wm-fluid);
+}
+
+[data-akashic-plugin="wake-meter"] .tone-amber {
+  background: var(--wm-pressure);
+}
+
+[data-akashic-plugin="wake-meter"] .meter-footnote {
+  display: flex;
+  max-width: 920px;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 auto;
+  color: var(--wm-subtle);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-footnote span {
+  min-width: 0;
+  text-wrap: pretty;
+}
+
+[data-akashic-plugin="wake-meter"] .meter-footnote code {
+  max-width: 42%;
+  overflow: hidden;
+  color: var(--wm-muted);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 @media (max-width: 900px) {
-  [data-akashic-plugin="wake-meter"] .excitement-console { padding: 18px; }
-  [data-akashic-plugin="wake-meter"] .meter-machine { grid-template-columns: 1fr; gap: 24px; padding: 34px; }
-  [data-akashic-plugin="wake-meter"] .meter-readout { padding: 22px 0 0; border-top: 3px solid #07090c; border-left: 0; text-align: center; }
-  [data-akashic-plugin="wake-meter"] .meter-readout p { margin-left: auto; margin-right: auto; }
-  [data-akashic-plugin="wake-meter"] .meter-telemetry { grid-template-columns: repeat(2, 1fr); }
+  [data-akashic-plugin="wake-meter"] .excitement-console {
+    padding: 16px 12px 24px;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-machine {
+    grid-template-columns: 1fr;
+    gap: 20px;
+    padding: 22px 18px 36px;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-readout {
+    padding-block-start: 18px;
+    padding-inline-start: 0;
+    border-inline-start: 0;
+    border-block-start: 1px solid var(--wm-rule);
+    text-align: center;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-readout p {
+    margin-inline: auto;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-footnote {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-footnote code {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-akashic-plugin="wake-meter"] .water-surface,
+  [data-akashic-plugin="wake-meter"] .is-crossed .meter-burst {
+    animation: none;
+  }
+
+  [data-akashic-plugin="wake-meter"] .meter-fluid,
+  [data-akashic-plugin="wake-meter"] .water-surface,
+  [data-akashic-plugin="wake-meter"] .meter-burst {
+    transition-duration: 0ms;
+  }
+
+  [data-akashic-plugin="wake-proactive"] .wake-audit summary,
+  [data-akashic-plugin="wake-proactive"] .wake-audit summary::before {
+    transition-duration: 0ms;
+  }
 }

--- a/plugin_packages/wake-proactive/dashboard_panel.tsx
+++ b/plugin_packages/wake-proactive/dashboard_panel.tsx
@@ -8,10 +8,16 @@ interface Page {
 }
 
 function shortTime(value: unknown): string {
-  const date = new Date(String(value || ""));
-  return Number.isNaN(date.getTime())
-    ? String(value || "-")
-    : `${date.getMonth() + 1}-${String(date.getDate()).padStart(2, "0")} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+  if (!value) return "—";
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return String(value);
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
 }
 
 function count(value: unknown): number {
@@ -20,33 +26,57 @@ function count(value: unknown): number {
 }
 
 function JsonSection({ title, value, open = false }: { title: string; value: unknown; open?: boolean }): ReactElement {
-  return <details className="wake-audit" open={open}>
-    <summary><span>{title}</span><Chip tone="muted">{count(value)}</Chip></summary>
-    <JsonView value={value} />
-  </details>;
+  return (
+    <details className="wake-audit" open={open}>
+      <summary>
+        <span>{title}</span>
+        <Chip tone="muted">{count(value)}</Chip>
+      </summary>
+      <JsonView value={value} />
+    </details>
+  );
 }
 
 function Detail({ item }: { item: Record<string, unknown> | null }): ReactElement {
-  if (!item) return <div className="wake-empty">选择一次唤醒查看完整判断链。</div>;
-  const observations = Array.isArray(item.observations) ? item.observations as Record<string, unknown>[] : [];
-  return <Stack className="wake-detail">
-    <Panel className="wake-summary">
-      <div><span>WAKE RUN</span><strong>{shortTime(item.now_utc)}</strong></div>
-      <Chip tone={item.terminal_action === "skip" ? "muted" : "accent"} dot>{String(item.terminal_action || "pending")}</Chip>
-    </Panel>
-    <Panel className="wake-message"><span>最终行为</span><Markdown>{String(item.final_message || "本轮决定不主动打扰。")}</Markdown></Panel>
-    {observations.map((observation, index) => <Stack className="wake-phase" key={`${String(observation.kind)}-${index}`}>
-      <div className="wake-phase-title">触发观测 · {String(observation.kind || "unknown")}</div>
-      <JsonSection title="触发原因" value={observation.trigger} open />
-      <JsonSection title="进入判断的候选" value={observation.candidates} />
-      <JsonSection title="送给 LLM 的输入" value={observation.llm_input} />
-    </Stack>)}
-    <JsonSection title="初筛计划 Scratchpad" value={item.scratchpad} open />
-    <JsonSection title="正文与记忆调查结果" value={item.investigations} />
-    <JsonSection title="最终引用 ID" value={item.cited_ids} />
-    <JsonSection title="展示序号映射" value={item.display_event_map} />
-    <JsonSection title="来源引用" value={item.source_refs} />
-  </Stack>;
+  if (!item) {
+    return <div className="wake-empty">选择一次唤醒，查看完整判断链。</div>;
+  }
+  const observations = Array.isArray(item.observations)
+    ? item.observations as Record<string, unknown>[]
+    : [];
+  const action = String(item.terminal_action || "pending");
+  return (
+    <Stack className="wake-detail">
+      <Panel className="wake-summary">
+        <div>
+          <span>Wake run</span>
+          <strong>{shortTime(item.now_utc)}</strong>
+        </div>
+        <Chip tone={action === "skip" ? "muted" : "accent"} dot>
+          {action}
+        </Chip>
+      </Panel>
+      <Panel className="wake-message">
+        <span>最终行为</span>
+        <Markdown>{String(item.final_message || "本轮决定不主动打扰。")}</Markdown>
+      </Panel>
+      {observations.map((observation, index) => (
+        <Stack className="wake-phase" key={`${String(observation.kind)}-${index}`}>
+          <div className="wake-phase-title">
+            触发观测 · {String(observation.kind || "unknown")}
+          </div>
+          <JsonSection title="触发原因" value={observation.trigger} open />
+          <JsonSection title="进入判断的候选" value={observation.candidates} />
+          <JsonSection title="送给 LLM 的输入" value={observation.llm_input} />
+        </Stack>
+      ))}
+      <JsonSection title="初筛计划 Scratchpad" value={item.scratchpad} open />
+      <JsonSection title="正文与记忆调查结果" value={item.investigations} />
+      <JsonSection title="最终引用 ID" value={item.cited_ids} />
+      <JsonSection title="展示序号映射" value={item.display_event_map} />
+      <JsonSection title="来源引用" value={item.source_refs} />
+    </Stack>
+  );
 }
 
 window.AkashicDashboard.registerPlugin({
@@ -58,10 +88,45 @@ window.AkashicDashboard.registerPlugin({
   defaultSortBy: "now_utc",
   defaultSortOrder: "desc",
   columns: [
-    { key: "session_key", label: "Session", width: 170, fmt: "mono-session", rawTitle: true },
-    { key: "now_utc", label: "Wake time", width: 112, fmt: "wake-time", rawTitle: true },
-    { key: "terminal_action", label: "Action", width: 88 },
-    { key: "final_message", label: "Message", flex: true, fmt: "text-preview" },
+    {
+      key: "session_key",
+      label: "Session",
+      width: 170,
+      fmt: "mono-session",
+      cellClass: "mono cell-session",
+      rawTitle: true,
+    },
+    {
+      key: "now_utc",
+      label: "Wake time",
+      width: 112,
+      fmt: "wake-time",
+      cellClass: "mono cell-time",
+      rawTitle: true,
+    },
+    {
+      key: "terminal_action",
+      label: "Action",
+      width: 88,
+      cellClass: "cell-status",
+      renderCell(value) {
+        const action = String(value || "pending");
+        const tone = action === "reply"
+          ? "proactive-result-reply"
+          : action === "skip"
+            ? "proactive-result-skip"
+            : "proactive-result-unknown";
+        return `<span class="status-pill ${tone}">${escapeHtml(action)}</span>`;
+      },
+    },
+    {
+      key: "final_message",
+      label: "Message",
+      flex: true,
+      fmt: "text-preview",
+      cellClass: "content-preview",
+      rawTitle: true,
+    },
   ],
   async getCount() {
     const data = await api<{ total: number }>("/api/dashboard/wake-proactive/runs?page=1&page_size=1");
@@ -71,7 +136,9 @@ window.AkashicDashboard.registerPlugin({
     return api<Page>(`/api/dashboard/wake-proactive/runs?page=${page}&page_size=${pageSize}`);
   },
   async fetchDetail(item) {
-    return api<Record<string, unknown>>(`/api/dashboard/wake-proactive/runs/${encodeURIComponent(String(item.wake_id))}`);
+    return api<Record<string, unknown>>(
+      `/api/dashboard/wake-proactive/runs/${encodeURIComponent(String(item.wake_id))}`,
+    );
   },
   Detail,
   formatters: { "wake-time": shortTime },

--- a/plugin_packages/wake-proactive/dashboard_panel_meter.tsx
+++ b/plugin_packages/wake-proactive/dashboard_panel_meter.tsx
@@ -19,22 +19,32 @@ interface MeterData {
 }
 
 function shortTime(value: unknown): string {
-  const date = new Date(String(value || ""));
-  return Number.isNaN(date.getTime())
-    ? String(value || "-")
-    : `${date.getMonth() + 1}-${String(date.getDate()).padStart(2, "0")} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+  if (!value) return "—";
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return String(value);
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
 }
 
 function meterStatus(data: MeterData): { label: string; detail: string } {
   if (data.should_wake) {
-    return { label: "已冲破", detail: "信息压力已越线，进入 LLM 最终判断" };
+    return { label: "已冲破", detail: "信息压力已越线，进入 LLM 最终判断。" };
   }
   const ratio = data.threshold > 0
     ? (data.hazard_after + data.preference_pressure) / data.threshold
     : 0;
-  if (ratio >= 0.75) return { label: "临界蓄压", detail: "再出现一条强相关信息就可能越线" };
-  if (ratio >= 0.35) return { label: "持续积累", detail: "兴趣证据正在蓄水池中累积" };
-  return { label: "低压稳定", detail: "当前信息不足以打扰用户" };
+  if (ratio >= 0.75) {
+    return { label: "临界蓄压", detail: "再出现一条强相关信息就可能越线。" };
+  }
+  if (ratio >= 0.35) {
+    return { label: "持续积累", detail: "兴趣证据正在蓄水池中累积。" };
+  }
+  return { label: "低压稳定", detail: "当前信息不足以打扰用户。" };
 }
 
 function percent(value: number, threshold: number): number {
@@ -58,58 +68,124 @@ function MeterPage(): ReactElement {
     };
   }, []);
 
-  if (!data) return <div className="meter-loading">正在读取压力传感器…</div>;
+  if (!data) {
+    return <div className="meter-loading">正在读取压力传感器…</div>;
+  }
+
   const accumulated = percent(data.hazard_after, data.threshold);
-  const pressure = Math.min(100 - accumulated, percent(data.preference_pressure, data.threshold));
+  const pressure = Math.min(
+    100 - accumulated,
+    percent(data.preference_pressure, data.threshold),
+  );
   const total = data.hazard_after + data.preference_pressure;
   const status = meterStatus(data);
   const crossed = Boolean(data.should_wake);
-  return <Stack className={`excitement-console ${crossed ? "is-crossed" : ""}`}>
-    <header className="meter-header">
-      <div><span>WAKE RESERVOIR</span><h2>兴奋水位</h2></div>
-      <div className="meter-state"><i />{status.label}</div>
-    </header>
-    <Panel className="meter-machine">
-      <div className="meter-chamber-wrap" role="img" aria-label={`当前水位 ${total.toFixed(2)}，阈值 ${data.threshold.toFixed(2)}`}>
-        <div className="meter-burst"><i /><i /><i /><i /><i /></div>
-        <div className="tank-rim" />
-        <div className="meter-chamber">
-          <div className="tank-zone overflow-zone"><span>冲破区</span></div>
-          <div className="tank-zone warm-zone" />
-          <div className="meter-threshold"><span>兴奋阈值 {data.threshold.toFixed(2)}</span></div>
-          <div className="meter-fluid accumulated" style={{ height: `${accumulated}%` }} />
-          <div className="meter-fluid pressure" style={{ bottom: `${accumulated}%`, height: `${pressure}%` }} />
-          <div
-            className={`water-surface ${data.preference_pressure > 0 ? "pressure-surface" : ""}`}
-            style={{ bottom: `${Math.min(98, accumulated + pressure)}%` }}
-          >
-            <svg viewBox="0 0 180 18" preserveAspectRatio="none" aria-hidden="true">
-              <path d="M0 10 Q22 2 45 10 T90 10 T135 10 T180 10 V18 H0 Z" />
-            </svg>
-          </div>
-          <div className="water-bubbles"><i /><i /><i /></div>
+  const surfaceClass = data.preference_pressure > 0
+    ? "water-surface pressure-surface"
+    : "water-surface";
+
+  return (
+    <Stack className={`excitement-console${crossed ? " is-crossed" : ""}`}>
+      <header className="meter-header">
+        <div>
+          <span>Wake reservoir</span>
+          <h2>兴奋水位</h2>
         </div>
-        <div className="meter-scale"><span>125%</span><span>阈值</span><span>50%</span><span>0</span></div>
+        <div className="meter-state" aria-live="polite">
+          <i aria-hidden="true" />
+          {status.label}
+        </div>
+      </header>
+
+      <Panel className="meter-machine">
+        <div
+          className="meter-chamber-wrap"
+          role="img"
+          aria-label={`当前水位 ${total.toFixed(2)}，阈值 ${data.threshold.toFixed(2)}`}
+        >
+          <div className="meter-burst" aria-hidden="true">
+            <i /><i /><i /><i /><i />
+          </div>
+          <div className="tank-rim" aria-hidden="true" />
+          <div className="meter-chamber">
+            <div className="tank-zone overflow-zone">
+              <span>冲破区</span>
+            </div>
+            <div className="tank-zone warm-zone" aria-hidden="true" />
+            <div className="meter-threshold">
+              <span>阈值 {data.threshold.toFixed(2)}</span>
+            </div>
+            <div
+              className="meter-fluid accumulated"
+              style={{ height: `${accumulated}%` }}
+            />
+            <div
+              className="meter-fluid pressure"
+              style={{ bottom: `${accumulated}%`, height: `${pressure}%` }}
+            />
+            <div
+              className={surfaceClass}
+              style={{ bottom: `${Math.min(98, accumulated + pressure)}%` }}
+              aria-hidden="true"
+            >
+              <svg viewBox="0 0 180 18" preserveAspectRatio="none">
+                <path d="M0 10 Q22 2 45 10 T90 10 T135 10 T180 10 V18 H0 Z" />
+              </svg>
+            </div>
+            <div className="water-bubbles" aria-hidden="true">
+              <i /><i /><i />
+            </div>
+          </div>
+          <div className="meter-scale" aria-hidden="true">
+            <span>125%</span>
+            <span>阈值</span>
+            <span>50%</span>
+            <span>0</span>
+          </div>
+        </div>
+
+        <div className="meter-readout">
+          <span>当前水位</span>
+          <strong>{total.toFixed(2)}</strong>
+          <em>/ {data.threshold.toFixed(2)}</em>
+          <p>{status.detail}</p>
+        </div>
+      </Panel>
+
+      <div className="meter-telemetry">
+        <div>
+          <span><i className="tone-cobalt" aria-hidden="true" />持续蓄积</span>
+          <strong>{data.hazard_after.toFixed(3)}</strong>
+        </div>
+        <div>
+          <span><i className="tone-amber" aria-hidden="true" />瞬时兴趣推力</span>
+          <strong>{data.preference_pressure.toFixed(3)}</strong>
+        </div>
+        <div>
+          <span>未读内容</span>
+          <strong>{data.unread_count}</strong>
+          <small>{data.candidate_count} 条参与本轮</small>
+        </div>
+        <div>
+          <span>最近计算</span>
+          <strong title={String(data.evaluated_at || "")}>{shortTime(data.evaluated_at)}</strong>
+          <small>{data.candidate_count} 条已计算</small>
+        </div>
+        <div>
+          <span>最近 LLM 判断</span>
+          <strong>{data.last_action || "尚未触发"}</strong>
+          <small title={String(data.last_action_at || "")}>{shortTime(data.last_action_at)}</small>
+        </div>
       </div>
-      <div className="meter-readout">
-        <span>当前水位</span>
-        <strong>{total.toFixed(2)}</strong>
-        <em>/ {data.threshold.toFixed(2)}</em>
-        <p>{status.detail}</p>
-      </div>
-    </Panel>
-    <Stack className="meter-telemetry">
-      <div><span><i className="tone-cobalt" />持续蓄积</span><strong>{data.hazard_after.toFixed(3)}</strong></div>
-      <div><span><i className="tone-amber" />瞬时兴趣推力</span><strong>{data.preference_pressure.toFixed(3)}</strong></div>
-      <div><span>未读内容</span><strong>{data.unread_count}</strong><small>{data.candidate_count} 条参与本轮</small></div>
-      <div><span>最近计算</span><strong>{shortTime(data.evaluated_at)}</strong><small>{data.candidate_count} 条已计算</small></div>
-      <div><span>最近 LLM 判断</span><strong>{data.last_action || "尚未触发"}</strong><small>{shortTime(data.last_action_at)}</small></div>
+
+      <footer className="meter-footnote">
+        <span>越线只代表允许唤醒 LLM 判断，不等于一定推送。</span>
+        <code title={data.driver_item_id || "NO ACTIVE DRIVER"}>
+          {data.driver_item_id || "NO ACTIVE DRIVER"}
+        </code>
+      </footer>
     </Stack>
-    <footer className="meter-footnote">
-      <span>越线只代表允许唤醒 LLM 判断，不等于一定推送。</span>
-      <code>{data.driver_item_id || "NO ACTIVE DRIVER"}</code>
-    </footer>
-  </Stack>;
+  );
 }
 
 window.AkashicDashboard.registerPlugin({
@@ -123,6 +199,8 @@ window.AkashicDashboard.registerPlugin({
     const data = await api<MeterData>("/api/dashboard/wake-proactive/meter");
     return data.unread_count;
   },
-  async fetchPage() { return { items: [], total: 0 }; },
+  async fetchPage() {
+    return { items: [], total: 0 };
+  },
   Main: MeterPage,
 });

--- a/plugins/akasha/dashboard_panel_inspector.css
+++ b/plugins/akasha/dashboard_panel_inspector.css
@@ -1,70 +1,68 @@
+/* Akasha Inspector — host industrial tokens, content-first, no private palette. */
+
 .akasha-inspector {
-  --akasha-accent: oklch(0.76 0.11 235);
-  --akasha-accent-soft: oklch(0.76 0.11 235 / 0.12);
-  --akasha-ink: oklch(0.94 0.008 235);
-  --akasha-muted: oklch(0.72 0.015 235);
-  --akasha-subtle: oklch(0.68 0.014 235);
-  --akasha-surface: oklch(0.19 0.008 235);
-  --akasha-surface-raised: oklch(0.225 0.01 235);
-  --akasha-rule: oklch(1 0 0 / 0.08);
-  --akasha-rule-strong: oklch(1 0 0 / 0.14);
-  --akasha-shadow:
-    0 0 0 1px oklch(1 0 0 / 0.07),
-    0 1px 2px oklch(0 0 0 / 0.22);
+  --akasha-ink: var(--color-fg);
+  --akasha-muted: var(--color-muted);
+  --akasha-subtle: var(--color-subtle);
+  --akasha-surface: var(--color-surface);
+  --akasha-surface-2: var(--color-surface-2);
+  --akasha-surface-3: var(--color-surface-3);
+  --akasha-rule: var(--color-border);
+  --akasha-rule-strong: var(--color-border-strong);
+  --akasha-accent: var(--color-accent);
+  --akasha-accent-soft: var(--color-accent-soft);
+  --akasha-lane-seed: var(--color-accent);
+  --akasha-lane-precise: var(--color-success);
+  --akasha-lane-completion: var(--color-warning);
+  --akasha-lane-activation: var(--color-accent);
+  --akasha-radius: var(--radius-lg, 10px);
+  --akasha-radius-sm: var(--radius, 6px);
+  --akasha-ease: var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+  --akasha-t: var(--t-fast, 140ms);
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 20px;
-  padding: 16px;
+  gap: 14px;
+  padding: 4px 2px 12px;
   color: var(--akasha-ink);
-}
-
-:root[data-theme="light"] .akasha-inspector {
-  --akasha-accent: oklch(0.43 0.12 235);
-  --akasha-accent-soft: oklch(0.43 0.12 235 / 0.09);
-  --akasha-ink: oklch(0.24 0.014 235);
-  --akasha-muted: oklch(0.42 0.018 235);
-  --akasha-subtle: oklch(0.46 0.014 235);
-  --akasha-surface: oklch(0.985 0.003 235);
-  --akasha-surface-raised: oklch(0.955 0.006 235);
-  --akasha-rule: oklch(0 0 0 / 0.08);
-  --akasha-rule-strong: oklch(0 0 0 / 0.14);
-  --akasha-shadow:
-    0 0 0 1px oklch(0 0 0 / 0.06),
-    0 1px 2px -1px oklch(0 0 0 / 0.06),
-    0 2px 4px oklch(0 0 0 / 0.04);
+  font-family: var(--sans, inherit);
+  font-synthesis: none;
 }
 
 .akasha-query {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  padding: 18px;
-  border-radius: 12px;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: var(--akasha-radius);
   background: var(--akasha-surface);
-  box-shadow: var(--akasha-shadow);
 }
 
 .akasha-query > div {
   min-width: 0;
-}
-
-.akasha-query h2 {
-  margin: 4px 0 10px;
-  color: var(--akasha-ink);
-  font-size: clamp(19px, 2.1vw, 25px);
-  font-weight: 650;
-  line-height: 1.35;
-  letter-spacing: -0.018em;
-  overflow-wrap: anywhere;
+  flex: 1;
 }
 
 .akasha-query-meta {
   margin: 0;
-  color: var(--akasha-muted);
-  font-size: 11px;
+  color: var(--akasha-subtle);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+}
+
+.akasha-query h2 {
+  margin: 6px 0 8px;
+  color: var(--akasha-ink);
+  font-size: clamp(1.125rem, 1.8vw, 1.375rem);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
 }
 
 .akasha-query-answer {
@@ -74,31 +72,35 @@
   color: var(--akasha-muted);
   font-size: 13px;
   line-height: 1.55;
+  text-wrap: pretty;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
 }
 
 .akasha-close {
   display: grid;
-  width: 40px;
-  height: 40px;
-  flex: 0 0 40px;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
   place-items: center;
-  border: 0;
-  border-radius: 8px;
+  margin-block-start: 2px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: var(--akasha-radius-sm);
   color: var(--akasha-muted);
-  background: var(--akasha-surface-raised);
-  box-shadow: 0 0 0 1px var(--akasha-rule);
+  background: var(--akasha-surface-2);
   cursor: pointer;
-  font-size: 19px;
-  transition-property: color, background-color, scale, box-shadow;
-  transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  font-size: 18px;
+  line-height: 1;
+  user-select: none;
+  transition-property: color, background-color, border-color, scale;
+  transition-duration: var(--akasha-t);
+  transition-timing-function: var(--akasha-ease);
 }
 
 .akasha-close:hover {
   color: var(--akasha-ink);
-  box-shadow: 0 0 0 1px var(--akasha-rule-strong);
+  border-color: var(--akasha-rule-strong);
+  background: var(--akasha-surface-3);
 }
 
 .akasha-close:active {
@@ -110,14 +112,14 @@
   margin: 0;
   overflow: hidden;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-radius: 12px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: var(--akasha-radius);
   background: var(--akasha-surface);
-  box-shadow: var(--akasha-shadow);
 }
 
 .akasha-metric {
   min-width: 0;
-  padding: 14px 16px;
+  padding: 12px 14px;
   border-right: 1px solid var(--akasha-rule);
 }
 
@@ -126,60 +128,109 @@
 }
 
 .akasha-metric dt {
-  color: var(--akasha-muted);
-  font-size: 11px;
-  font-weight: 560;
+  color: var(--akasha-subtle);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
 }
 
 .akasha-metric dd {
-  margin: 5px 0 4px;
+  margin: 6px 0 4px;
   color: var(--akasha-ink);
-  font-size: 21px;
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 1.25rem;
   font-variant-numeric: tabular-nums;
-  line-height: 1;
+  font-weight: 550;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
 }
 
 .akasha-metric p {
   margin: 0;
   color: var(--akasha-subtle);
-  font-size: 10.5px;
+  font-size: 12px;
   line-height: 1.4;
+  text-wrap: pretty;
 }
 
 .akasha-section {
   overflow: hidden;
-  border-radius: 12px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: var(--akasha-radius);
   background: var(--akasha-surface);
-  box-shadow: var(--akasha-shadow);
 }
 
 .akasha-section > header {
   display: flex;
-  min-height: 52px;
+  min-height: 48px;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 10px 16px;
+  gap: 12px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--akasha-rule);
+  background: var(--akasha-surface-2);
 }
 
 .akasha-section h3 {
   margin: 0;
   color: var(--akasha-ink);
-  font-size: 14px;
-  font-weight: 640;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 
 .akasha-section header p {
   margin: 2px 0 0;
   color: var(--akasha-subtle);
-  font-size: 11px;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .akasha-section header > span {
-  color: var(--akasha-accent);
-  font-size: 13px;
+  flex: 0 0 auto;
+  min-width: 1.75rem;
+  padding: 2px 8px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: 9999px;
+  color: var(--akasha-muted);
+  background: var(--akasha-surface);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
+  font-weight: 550;
+  line-height: 1.4;
+  text-align: center;
+}
+
+/* Lane accents: seed / precise / completion / activation */
+.akasha-lane {
+  --akasha-lane: var(--akasha-lane-seed);
+  box-shadow: inset 3px 0 0 var(--akasha-lane);
+}
+
+.akasha-lane--seed {
+  --akasha-lane: var(--akasha-lane-seed);
+}
+
+.akasha-lane--activation {
+  --akasha-lane: var(--akasha-lane-activation);
+}
+
+.akasha-lane--precise {
+  --akasha-lane: var(--akasha-lane-precise);
+}
+
+.akasha-lane--completion {
+  --akasha-lane: var(--akasha-lane-completion);
+}
+
+.akasha-lane > header > span {
+  color: var(--akasha-lane);
+  border-color: color-mix(in oklab, var(--akasha-lane) 28%, var(--akasha-rule));
+  background: color-mix(in oklab, var(--akasha-lane) 10%, var(--akasha-surface));
 }
 
 .akasha-evidence-list {
@@ -190,9 +241,9 @@
 
 .akasha-evidence {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(150px, 0.34fr);
-  gap: 20px;
-  padding: 13px 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(148px, 0.32fr);
+  gap: 12px 16px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--akasha-rule);
 }
 
@@ -204,79 +255,133 @@
   margin: 0;
   color: var(--akasha-ink);
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.55;
   overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 .akasha-evidence-main .akasha-assistant {
-  margin-top: 5px;
+  margin-top: 4px;
   color: var(--akasha-muted);
-  font-size: 11.5px;
+  font-size: 12.5px;
+  line-height: 1.5;
 }
 
 .akasha-evidence-meta {
   display: flex;
   min-width: 0;
   align-content: flex-start;
-  align-items: baseline;
+  align-items: center;
   justify-content: flex-end;
-  gap: 8px 12px;
+  gap: 6px;
   flex-wrap: wrap;
   color: var(--akasha-subtle);
-  font-size: 10px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-align: end;
 }
 
-.akasha-evidence-meta b {
-  color: var(--akasha-accent);
-  font-size: 11px;
-  font-weight: 650;
+.akasha-chip {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 7px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: 9999px;
+  color: var(--akasha-muted);
+  background: var(--akasha-surface-2);
+  font-size: 12px;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.akasha-chip--score {
+  color: var(--akasha-ink);
+  border-color: var(--akasha-rule-strong);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-weight: 550;
+}
+
+.akasha-chip--time {
+  font-family: var(--mono, ui-monospace, monospace);
 }
 
 .akasha-path {
   width: 100%;
   overflow: hidden;
-  font-family: var(--mono);
+  color: var(--akasha-subtle);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  text-align: end;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .akasha-empty {
   margin: 0;
-  padding: 22px 16px;
+  padding: 18px 14px;
   color: var(--akasha-subtle);
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .akasha-learning,
 .akasha-prompt {
   overflow: hidden;
-  border-radius: 12px;
+  border: 1px solid var(--akasha-rule);
+  border-radius: var(--akasha-radius);
   background: var(--akasha-surface);
-  box-shadow: var(--akasha-shadow);
 }
 
 .akasha-learning summary,
 .akasha-prompt summary {
   display: flex;
-  min-height: 48px;
+  min-height: 44px;
   align-items: center;
-  padding: 0 16px;
+  gap: 8px;
+  padding: 0 14px;
   color: var(--akasha-ink);
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
-  list-style-position: inside;
+  list-style: none;
+  user-select: none;
   transition-property: color, background-color;
-  transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  transition-duration: var(--akasha-t);
+  transition-timing-function: var(--akasha-ease);
+}
+
+.akasha-learning summary::-webkit-details-marker,
+.akasha-prompt summary::-webkit-details-marker {
+  display: none;
+}
+
+.akasha-learning summary::before,
+.akasha-prompt summary::before {
+  display: inline-block;
+  width: 0.65em;
+  color: var(--akasha-subtle);
+  content: "▸";
+  font-size: 12px;
+  line-height: 1;
+  transition: rotate var(--akasha-t) var(--akasha-ease);
+}
+
+.akasha-learning[open] summary::before,
+.akasha-prompt[open] summary::before {
+  rotate: 90deg;
 }
 
 .akasha-learning summary:hover,
 .akasha-prompt summary:hover {
-  color: var(--akasha-accent);
-  background: var(--akasha-accent-soft);
+  background: var(--akasha-surface-2);
+}
+
+.akasha-learning summary:focus-visible,
+.akasha-prompt summary:focus-visible {
+  outline: 1px solid var(--akasha-accent);
+  outline-offset: -1px;
 }
 
 .akasha-learning dl {
@@ -298,12 +403,12 @@
   max-height: 440px;
   margin: 0;
   overflow: auto;
-  padding: 16px;
+  padding: 14px;
   border-top: 1px solid var(--akasha-rule);
   color: var(--akasha-muted);
-  background: var(--akasha-surface-raised);
-  font-family: var(--mono);
-  font-size: 11px;
+  background: var(--akasha-surface-2);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
   line-height: 1.65;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -320,28 +425,53 @@
   min-width: min(420px, 70vw);
   gap: 5px;
   color: var(--color-muted);
-  font-size: 11px;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .akasha-filter input {
   min-height: 40px;
+  width: 100%;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 6px);
+  color: var(--color-fg);
+  background: var(--color-surface);
+  font: inherit;
+  font-size: 16px;
+}
+
+@media (min-width: 640px) {
+  .akasha-filter input {
+    font-size: 13px;
+  }
+}
+
+.akasha-filter input:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 1px;
 }
 
 .akasha-filter button {
   min-width: 52px;
   min-height: 40px;
-  border: 0;
-  border-radius: 6px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 6px);
   color: var(--color-fg);
   background: var(--color-surface-2);
-  box-shadow: 0 0 0 1px var(--color-border);
   cursor: pointer;
-  transition-property: background-color, scale, opacity;
-  transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  user-select: none;
+  transition-property: background-color, border-color, scale, opacity;
+  transition-duration: var(--t-fast, 140ms);
+  transition-timing-function: var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .akasha-filter button:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
   background: var(--color-surface-3);
 }
 
@@ -374,7 +504,23 @@
 
   .akasha-evidence-meta {
     justify-content: flex-start;
-    text-align: left;
+    text-align: start;
+  }
+
+  .akasha-path {
+    text-align: start;
+  }
+
+  .akasha-learning dl {
+    grid-template-columns: 1fr;
+  }
+
+  .akasha-learning .akasha-metric {
+    border-right: 0;
+  }
+
+  .akasha-learning .akasha-metric:nth-child(n + 2) {
+    border-top: 1px solid var(--akasha-rule);
   }
 }
 
@@ -382,7 +528,9 @@
   .akasha-close,
   .akasha-filter button,
   .akasha-learning summary,
-  .akasha-prompt summary {
+  .akasha-prompt summary,
+  .akasha-learning summary::before,
+  .akasha-prompt summary::before {
     transition-duration: 0ms;
   }
 }

--- a/plugins/akasha/dashboard_panel_inspector.ts
+++ b/plugins/akasha/dashboard_panel_inspector.ts
@@ -95,7 +95,7 @@ function renderItems(items: InspectorItem[], empty: string): string {
       ${items.map((item) => {
         const score = item.score ?? item.value ?? item.completion_mass ?? item.seed_score;
         const path = item.relation_path?.length
-          ? `<span class="akasha-path">${escapeHtml(item.relation_path.join(" → "))}</span>`
+          ? `<span class="akasha-path" title="${escapeHtml(item.relation_path.join(" → "))}">${escapeHtml(item.relation_path.join(" → "))}</span>`
           : "";
         return `
           <li class="akasha-evidence">
@@ -106,9 +106,9 @@ function renderItems(items: InspectorItem[], empty: string): string {
                 : ""}
             </div>
             <div class="akasha-evidence-meta">
-              <time>${escapeHtml(shortTime(item.ts))}</time>
-              <span>${escapeHtml(sourceText(item))}</span>
-              ${score == null ? "" : `<b>${fixed(score)}</b>`}
+              <time class="akasha-chip akasha-chip--time">${escapeHtml(shortTime(item.ts))}</time>
+              <span class="akasha-chip">${escapeHtml(sourceText(item))}</span>
+              ${score == null ? "" : `<b class="akasha-chip akasha-chip--score">${fixed(score)}</b>`}
               ${path}
             </div>
           </li>
@@ -199,21 +199,21 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
         ${metric("残余", fixed(item.residual_l1, 6), `${item.pushes} 次 residual push`)}
       </dl>
 
-      <section class="akasha-section">
+      <section class="akasha-section akasha-lane akasha-lane--seed">
         <header><h3>直接线索</h3><span>${item.seeds.length}</span></header>
         ${renderItems(item.seeds, "这一轮没有形成可持久化 seed。")}
       </section>
 
       ${item.activation_capture_available
         ? `
-          <section class="akasha-section">
+          <section class="akasha-section akasha-lane akasha-lane--activation">
             <header><h3>扩散激活</h3><span>${item.activation_items.length}</span></header>
             ${renderItems(item.activation_items, "图扩散没有增加候选。")}
           </section>
         `
         : ""}
 
-      <section class="akasha-section akasha-lane">
+      <section class="akasha-section akasha-lane akasha-lane--precise">
         <header>
           <div><h3>左脑记忆</h3><p>Embedding 精确回忆</p></div>
           <span>${item.left_count}</span>
@@ -221,7 +221,7 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
         ${renderItems(item.left, "没有 Dense 直接命中。")}
       </section>
 
-      <section class="akasha-section akasha-lane">
+      <section class="akasha-section akasha-lane akasha-lane--completion">
         <header>
           <div><h3>右脑联想</h3><p>显式图模式补全，已与左脑去重</p></div>
           <span>${item.right_count}</span>
@@ -231,7 +231,7 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
 
       ${item.tool_left_count
         ? `
-          <section class="akasha-section akasha-lane">
+          <section class="akasha-section akasha-lane akasha-lane--precise">
             <header>
               <div><h3>工具精确回忆</h3><p>本轮 recall_memory 的 Dense 结果</p></div>
               <span>${item.tool_left_count}</span>
@@ -243,7 +243,7 @@ function renderDetail(item: InspectorDetail, closePane?: () => void): string {
 
       ${item.tool_right_count
         ? `
-          <section class="akasha-section akasha-lane">
+          <section class="akasha-section akasha-lane akasha-lane--completion">
             <header>
               <div><h3>工具模式补全</h3><p>本轮 recall_memory 的显式图结果</p></div>
               <span>${item.tool_right_count}</span>

--- a/plugins/akasha/mobile_ui.css
+++ b/plugins/akasha/mobile_ui.css
@@ -26,10 +26,15 @@
       var(--m-trace, oklch(0.56 0.18 300)) 64%,
       var(--m-on-surface)
     );
+  --akasha-mobile-radius: var(--m-shape-medium, 12px);
+  --akasha-mobile-radius-sm: var(--m-shape-small, 8px);
+  --akasha-mobile-ease: cubic-bezier(0.2, 0, 0, 1);
+  --akasha-mobile-t: 160ms;
   --akasha-mobile-shadow:
-    0 1px 2px color-mix(in oklch, oklch(0 0 0) 14%, transparent),
-    0 3px 8px color-mix(in oklch, oklch(0 0 0) 7%, transparent);
+    0 1px 2px color-mix(in oklch, oklch(0 0 0) 12%, transparent),
+    0 2px 6px color-mix(in oklch, oklch(0 0 0) 6%, transparent);
   color: var(--m-on-surface);
+  font-synthesis: none;
 }
 
 .akasha-mobile-recall-group {
@@ -45,7 +50,7 @@
   --akasha-mobile-lane-on-container:
     var(--akasha-mobile-precise-on-container);
   overflow: hidden;
-  border-radius: var(--m-shape-medium, 12px);
+  border-radius: var(--akasha-mobile-radius);
   background:
     color-mix(
       in oklch,
@@ -77,17 +82,26 @@
       var(--m-surface-container)
     );
   cursor: pointer;
-  font-size: 0.84rem;
-  font-weight: 650;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
   list-style: none;
+  user-select: none;
   transition-property: color, background-color;
-  transition-duration: 160ms;
-  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+  transition-duration: var(--akasha-mobile-t);
+  transition-timing-function: var(--akasha-mobile-ease);
+}
+
+.akasha-mobile-recall summary > span:first-of-type {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .akasha-mobile-recall summary::before {
   width: 4px;
-  height: 20px;
+  height: 18px;
   border-radius: var(--m-shape-full, 9999px);
   background: var(--akasha-mobile-lane);
   content: "";
@@ -110,7 +124,7 @@
   background:
     color-mix(
       in oklch,
-      var(--akasha-mobile-lane) 17%,
+      var(--akasha-mobile-lane) 16%,
       var(--m-surface-container)
     );
 }
@@ -126,21 +140,23 @@
   min-height: 28px;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: 6px;
   border-radius: var(--m-shape-full, 9999px);
   padding: 0 8px;
   color: var(--akasha-mobile-lane-on-container);
   background: var(--akasha-mobile-lane-container);
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   font-variant-numeric: tabular-nums;
+  font-weight: 600;
 }
 
 .akasha-mobile-recall summary b::after {
   display: inline-block;
   color: var(--m-on-surface-variant);
   content: "⌄";
-  font-size: 0.9rem;
-  transition: rotate 150ms ease-out;
+  font-size: 0.875rem;
+  font-weight: 400;
+  transition: rotate 150ms var(--akasha-mobile-ease);
 }
 
 .akasha-mobile-recall[open] summary b::after {
@@ -154,7 +170,7 @@
   background:
     color-mix(
       in oklch,
-      var(--akasha-mobile-lane) 3%,
+      var(--akasha-mobile-lane) 2.5%,
       var(--m-surface-container-low)
     );
   list-style: none;
@@ -163,7 +179,7 @@
 .akasha-mobile-memories li {
   display: grid;
   gap: 6px;
-  padding: 11px 13px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--akasha-mobile-rule);
 }
 
@@ -174,34 +190,39 @@
 .akasha-mobile-memories p {
   margin: 0;
   color: var(--m-on-surface);
-  font-size: 0.82rem;
-  line-height: 1.48;
+  font-size: 0.875rem;
+  line-height: 1.5;
   overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 .akasha-mobile-memories .akasha-mobile-assistant {
-  margin-top: 3px;
+  margin-top: 2px;
   color: var(--m-on-surface-variant);
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
 }
 
 .akasha-mobile-memories li > span {
   color: var(--m-on-surface-variant);
-  font-size: 0.68rem;
+  font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
+  line-height: 1.35;
 }
 
 .akasha-mobile-empty,
 .akasha-mobile-loading,
 .akasha-mobile-error {
   margin: 0;
-  padding: 12px 2px 15px;
+  padding: 14px 4px 16px;
   color: var(--m-on-surface-variant);
-  font-size: 0.8rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  text-wrap: pretty;
 }
 
 .akasha-mobile-recall .akasha-mobile-empty {
-  padding: 14px 13px;
+  padding: 14px;
   border-top: 1px solid var(--akasha-mobile-rule);
 }
 
@@ -213,13 +234,13 @@
   display: flex;
   min-height: 100%;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
   padding: 4px 2px 24px;
 }
 
 .akasha-mobile-inspector > header {
-  padding: 15px;
-  border-radius: 14px;
+  padding: 14px 16px;
+  border-radius: var(--akasha-mobile-radius);
   background: var(--m-surface-container);
   box-shadow: var(--akasha-mobile-shadow);
 }
@@ -227,32 +248,36 @@
 .akasha-mobile-inspector h2 {
   margin: 0;
   color: var(--m-on-surface);
-  font-size: 1.18rem;
-  font-weight: 680;
-  line-height: 1.35;
-  letter-spacing: -0.016em;
+  font-size: 1.125rem;
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
   overflow-wrap: anywhere;
+  text-wrap: balance;
 }
 
 .akasha-mobile-inspector header > p {
-  margin: 7px 0 0;
+  margin: 6px 0 0;
   color: var(--m-on-surface-variant);
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   line-height: 1.5;
+  text-wrap: pretty;
 }
 
 .akasha-mobile-inspector header .akasha-mobile-time {
-  margin: 0 0 5px;
+  margin: 0 0 6px;
   color: var(--akasha-mobile-accent);
-  font-size: 0.71rem;
+  font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  letter-spacing: 0.01em;
 }
 
 .akasha-mobile-turns {
   margin: 0;
   overflow: hidden;
   padding: 0;
-  border-radius: 14px;
+  border-radius: var(--akasha-mobile-radius);
   background: var(--m-surface-container);
   box-shadow: var(--akasha-mobile-shadow);
   list-style: none;
@@ -271,16 +296,16 @@
   width: 100%;
   min-height: 56px;
   gap: 5px;
-  padding: 11px 13px;
+  padding: 12px 14px;
   border: 0;
   color: var(--m-on-surface);
   background: transparent;
   cursor: pointer;
   font: inherit;
-  text-align: left;
+  text-align: start;
   transition-property: background-color, scale;
   transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  transition-timing-function: var(--akasha-mobile-ease);
 }
 
 .akasha-mobile-turns button:hover {
@@ -291,10 +316,15 @@
   scale: 0.96;
 }
 
+.akasha-mobile-turns button:focus-visible {
+  outline: 2px solid var(--akasha-mobile-accent);
+  outline-offset: -2px;
+}
+
 .akasha-mobile-turns button > span {
   display: -webkit-box;
   overflow: hidden;
-  font-size: 0.84rem;
+  font-size: 0.875rem;
   line-height: 1.45;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
@@ -302,26 +332,28 @@
 
 .akasha-mobile-turns button small {
   color: var(--m-on-surface-variant);
-  font-size: 0.68rem;
+  font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
+  line-height: 1.35;
 }
 
 .akasha-mobile-back {
   width: fit-content;
   min-height: 44px;
-  padding: 0 13px;
+  padding: 0 14px;
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--akasha-mobile-radius-sm);
   color: var(--m-on-surface);
   background: var(--m-surface-container);
   box-shadow: 0 0 0 1px var(--akasha-mobile-rule);
   cursor: pointer;
   font: inherit;
-  font-size: 0.78rem;
-  font-weight: 620;
+  font-size: 0.875rem;
+  font-weight: 600;
+  user-select: none;
   transition-property: background-color, scale, box-shadow;
   transition-duration: 150ms;
-  transition-timing-function: ease-out;
+  transition-timing-function: var(--akasha-mobile-ease);
 }
 
 .akasha-mobile-back:hover {
@@ -333,36 +365,59 @@
   scale: 0.96;
 }
 
+.akasha-mobile-back:focus-visible {
+  outline: 2px solid var(--akasha-mobile-accent);
+  outline-offset: 2px;
+}
+
 .akasha-mobile-metrics {
   display: grid;
   margin: 14px 0 0;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
   border-top: 1px solid var(--akasha-mobile-rule);
 }
 
 .akasha-mobile-metrics > div {
-  padding: 11px 8px 0;
+  padding: 12px 10px 0 0;
+  border-bottom: 1px solid var(--akasha-mobile-rule);
+}
+
+.akasha-mobile-metrics > div:nth-child(odd) {
+  padding-right: 12px;
   border-right: 1px solid var(--akasha-mobile-rule);
 }
 
-.akasha-mobile-metrics > div:first-child {
-  padding-left: 0;
+.akasha-mobile-metrics > div:nth-child(even) {
+  padding-left: 12px;
+  padding-right: 0;
 }
 
-.akasha-mobile-metrics > div:last-child {
-  border-right: 0;
+.akasha-mobile-metrics > div:nth-last-child(-n + 2) {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.akasha-mobile-metrics > div:nth-child(n + 3) {
+  padding-top: 12px;
 }
 
 .akasha-mobile-metrics dt {
   color: var(--m-on-surface-variant);
-  font-size: 0.66rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
 }
 
 .akasha-mobile-metrics dd {
-  margin: 3px 0 0;
+  margin: 4px 0 0;
   color: var(--m-on-surface);
-  font-size: 1rem;
+  font-size: 1.125rem;
   font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
 }
 
 .akasha-mobile-detail-lanes {
@@ -373,9 +428,35 @@
 .akasha-mobile-convergence {
   margin: 0;
   color: var(--m-on-surface-variant);
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
+  line-height: 1.4;
   text-align: center;
+}
+
+@media (min-width: 420px) {
+  .akasha-mobile-metrics {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .akasha-mobile-metrics > div,
+  .akasha-mobile-metrics > div:nth-child(odd),
+  .akasha-mobile-metrics > div:nth-child(even),
+  .akasha-mobile-metrics > div:nth-child(n + 3),
+  .akasha-mobile-metrics > div:nth-last-child(-n + 2) {
+    padding: 12px 8px 0;
+    border-right: 1px solid var(--akasha-mobile-rule);
+    border-bottom: 0;
+  }
+
+  .akasha-mobile-metrics > div:first-child {
+    padding-left: 0;
+  }
+
+  .akasha-mobile-metrics > div:last-child {
+    border-right: 0;
+    padding-right: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/plugins/akasha/mobile_ui.js
+++ b/plugins/akasha/mobile_ui.js
@@ -62,7 +62,10 @@ function renderRecent(items, total) {
   if (!items.length) {
     return `
       <section class="akasha-mobile-inspector">
-        <header><h2>Akasha Inspector</h2><p>还没有可检查的检索记录。</p></header>
+        <header>
+          <h2>Akasha Inspector</h2>
+          <p>还没有可检查的检索记录。</p>
+        </header>
       </section>
     `;
   }

--- a/scripts/build-plugins.mjs
+++ b/scripts/build-plugins.mjs
@@ -5,6 +5,7 @@ import { spawn, spawnSync } from "node:child_process";
 
 const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const pluginsRoot = join(projectRoot, "plugins");
+const pluginPackagesRoot = join(projectRoot, "plugin_packages");
 const isWindows = process.platform === "win32";
 const localEsbuild = join(
   projectRoot,
@@ -25,12 +26,12 @@ function resolveEsbuildCommand() {
   return ["npx", "--yes", "esbuild"];
 }
 
-function listPluginPanels() {
-  if (!existsSync(pluginsRoot)) {
+function listPanelsInRoot(root) {
+  if (!existsSync(root)) {
     return [];
   }
-  return readdirSync(pluginsRoot)
-    .map((name) => join(pluginsRoot, name))
+  return readdirSync(root)
+    .map((name) => join(root, name))
     .filter((path) => statSync(path, { throwIfNoEntry: false })?.isDirectory())
     .flatMap((pluginDir) =>
       readdirSync(pluginDir)
@@ -41,6 +42,13 @@ function listPluginPanels() {
           jsPath: join(pluginDir, name.replace(/\.tsx?$/, ".js")),
         })),
     );
+}
+
+function listPluginPanels() {
+  return [
+    ...listPanelsInRoot(pluginsRoot),
+    ...listPanelsInRoot(pluginPackagesRoot),
+  ];
 }
 
 // Plugins build as ESM modules that bundle their own code but keep react /


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha / Wake Proactive 插件面板与宿主工业风脱节；Wake 列表长 Message 撑破表格行；兴奋水位页硬编码粗野风且不跟主题。
- 用户可见结果：面板对齐宿主 token；Wake 表格 Message 单行截断、Action pill；水位仪表跟 light/dark；mobile Akasha 字号与布局更稳。
- 本 PR 不处理：业务语义、API、持久化、兴奋阈值计算逻辑。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`plugin`
- `consumer_scope`：dashboard 宿主 + akasha / wake-proactive 插件面板；mobile Akasha recall/inspector 样式
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅前端展示与宿主表格 grid 截断，不改协议或 runtime 状态
- `authoritative_state_owner`：不适用（无权威状态变更）
- `client_only_alternative`：不适用
- 关联不变量：无
- `protected_state`：sessions/messages、wake_proactive.db、akasha 检索语义与 API 响应形状
- 允许的副作用：插件 CSS/TSX/JS 展示层；dashboard `gridTemplate` / 默认 cell class；`build-plugins` 扫描 `plugin_packages`
- 禁止的副作用：改写持久化数据、插件 API、memory/proactive 运行时行为

## 改动范围

- 主要文件：
  - `plugins/akasha/dashboard_panel_inspector.{css,ts}`、`mobile_ui.{css,js}`
  - `plugin_packages/wake-proactive/dashboard_panel.{css,tsx}`、`dashboard_panel_meter.tsx`
  - `frontend/dashboard/src/main.tsx`（plugin 表格 `minmax(0, …)` + text-preview 默认截断）
  - `scripts/build-plugins.mjs`（编译 `plugin_packages/`）
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用
- 回滚方式：revert 本 PR

## 验证

- [x] 相关 targeted tests 已通过。
- [ ] Python 类型检查或前端 typecheck/lint 已通过；不适用项已说明。
- [ ] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：未运行
- `planDigest`：未运行
- `private-contract-gate`：`not_required`（预期；纯 UI）
- 真实设备证据：不适用（desktop dashboard + 既有 mobile CSS 约束测试）
- 未运行项与原因：
  - `node --test tests/test_akasha_mobile_ui.mjs`：3/3 通过
  - `npm run build:plugins` / dashboard build：本地已通过
  - Gate 未跑：无后端/协议语义变更；合并前可由 CI 或维护者补跑

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。