### PR TITLE
[codex] expose Akasha remember and forget tools

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "4419ba06953ce045203f1ea6a5738450160b1acb",
+  "commit": "b8e133722e03174494719ab80f1e3349ea752d35",
   "source_subtree": "src/akasha",
-  "source_tree": "dc69e989b9a2eb048560cb85e018dbd548608478",
-  "source_sha256": "05b3da0fa8f00064465050e82fc4c02c7587a9f00a5aefece073dfb1b93c8ed3"
+  "source_tree": "4c05c5efbbad76710c9729164053b1b897148a70",
+  "source_sha256": "8f639849d807207e53c88774566c20b9d89fd5c010efc01af0f38cafd7199e91"
 }

--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "b88ac1c6b05e2e493ca5b0c3ccd0b19112eafe7a",
+  "commit": "4419ba06953ce045203f1ea6a5738450160b1acb",
   "source_subtree": "src/akasha",
-  "source_tree": "c697d9412c5857b4c143da48376332a386a3e7f2",
-  "source_sha256": "02edf3446ae71dc162a408de2c0eadd0a218314aedff90d480be2fd5599b58e5"
+  "source_tree": "dc69e989b9a2eb048560cb85e018dbd548608478",
+  "source_sha256": "05b3da0fa8f00064465050e82fc4c02c7587a9f00a5aefece073dfb1b93c8ed3"
 }

--- a/plugins/akasha/application/cycle.py
+++ b/plugins/akasha/application/cycle.py
@@ -24,6 +24,7 @@ from ..domain.model import (
     PlasticityResult,
     SeedEvidence,
     Turn,
+    TurnFeedback,
 )
 
 
@@ -79,6 +80,7 @@ class MemoryCycle:
         self.evidence: list[SeedEvidence] = []
         self.recalls: list[RecallCapture] = []
         self.burst_members: dict[str, list[int]] = {}
+        self.inhibited_nodes: set[int] = set()
 
     @classmethod
     def restore(
@@ -116,6 +118,7 @@ class MemoryCycle:
             session: list(members)
             for session, members in burst_members.items()
         }
+        cycle.inhibited_nodes = _feedback_state(turns)
         return cycle
 
     @property
@@ -145,6 +148,7 @@ class MemoryCycle:
             turn,
             capture_paths,
         )
+        inhibited = frozenset(self.inhibited_nodes)
         evidence = decision.evidence
 
         # 3. Advance topology and causal clocks inside a reversible read frame.
@@ -185,6 +189,7 @@ class MemoryCycle:
                     context_dependence=decision.context_dependence,
                     visible_nodes=decision.visible_nodes,
                     burst_continued=decision.continued,
+                    inhibited_nodes=inhibited,
                 )
             )
         finally:
@@ -259,19 +264,39 @@ class MemoryCycle:
                 for event in self.events
             ]
 
-        # 3. Learn the accepted retrieval activity exactly once.
+        # 3. Apply durable feedback only after the pre-feedback read has ended.
+        feedback = causal_turn.feedback
+        _validate_feedback(feedback, self.state_version)
+        self.inhibited_nodes.update(feedback.forget_nodes)
+        self.inhibited_nodes.difference_update(feedback.remember_nodes)
+        inhibited = frozenset(self.inhibited_nodes)
+        self.graph.apply_feedback_inhibition(inhibited)
+        learning_evidence = selected.evidence
+        learning_diffusion = selected.diffusion
+
+        # 4. Learn retrieved activity, then reinforce only the addressed episode.
         plasticity = replace(
             self.graph.learn(
                 self.state_version,
-                selected.evidence,
-                selected.diffusion,
+                learning_evidence,
+                learning_diffusion,
             ),
-            pushes=selected.diffusion.pushes,
-            residual_l1=selected.diffusion.residual_l1,
+            pushes=learning_diffusion.pushes,
+            residual_l1=learning_diffusion.residual_l1,
+        )
+        self.graph.reinforce_feedback_nodes(
+            feedback.remember_nodes,
+            feedback.remember_boost,
         )
         self.turns.append(causal_turn)
 
-        # 4. Advance only the committed turn's stream-local visible burst.
+        # 5. Advance only the committed turn's stream-local visible burst.
+        for active in self.burst_members.values():
+            active[:] = [
+                node
+                for node in active
+                if node not in self.inhibited_nodes
+            ]
         members = self.burst_members.setdefault(
             causal_turn.session_key,
             [],
@@ -282,10 +307,14 @@ class MemoryCycle:
             members[:] = [causal_turn.node_id]
         pool = self.feature_pool or BurstAwareFeaturePool(self.turns)
         self.context = pool.build_context(
-            tuple((node, 1.0) for node in members)
+            tuple(
+                (node, 1.0)
+                for node in members
+                if node not in self.inhibited_nodes
+            )
         )
         self.events.append(plasticity)
-        self.evidence.append(selected.evidence)
+        self.evidence.append(learning_evidence)
         if selected.completion_evaluated:
             self.recalls.append(
                 RecallCapture(
@@ -295,8 +324,8 @@ class MemoryCycle:
             )
         return CycleCommit(
             event=plasticity,
-            evidence=selected.evidence,
-            diffusion=selected.diffusion,
+            evidence=learning_evidence,
+            diffusion=learning_diffusion,
             retrieval_recomputed=recomputed,
         )
 
@@ -327,7 +356,11 @@ class MemoryCycle:
                 visible_nodes=(),
                 context=ContextState((), None, ()),
             )
-        visible = tuple(self.burst_members.get(turn.session_key, ()))
+        visible = tuple(
+            node
+            for node in self.burst_members.get(turn.session_key, ())
+            if node not in self.inhibited_nodes
+        )
         context = (
             pool.build_context(
                 tuple((node, 1.0) for node in visible)
@@ -341,6 +374,28 @@ class MemoryCycle:
             visible,
             capture_channels,
         )
+
+
+def _feedback_state(turns: list[Turn]) -> set[int]:
+    inhibited: set[int] = set()
+    for event, turn in enumerate(turns):
+        _validate_feedback(turn.feedback, event)
+        inhibited.update(turn.feedback.forget_nodes)
+        inhibited.difference_update(turn.feedback.remember_nodes)
+    return inhibited
+
+
+def _validate_feedback(feedback: TurnFeedback, event: int) -> None:
+    remember = feedback.remember_nodes
+    forget = feedback.forget_nodes
+    if set(remember) & set(forget):
+        raise ValueError("remember and forget targets cannot overlap")
+    if any(node < 0 or node > event for node in remember):
+        raise ValueError("remember targets must be causally available")
+    if any(node < 0 or node >= event for node in forget):
+        raise ValueError("forget targets must be historical")
+    if not 1.0 <= feedback.remember_boost <= 3.0:
+        raise ValueError("remember boost must be in [1, 3]")
 
 
 def _empty_completion(

--- a/plugins/akasha/domain/graph.py
+++ b/plugins/akasha/domain/graph.py
@@ -328,6 +328,67 @@ class DynamicMemoryGraph:
         self._transition_cache[node_id] = result
         return result
 
+    def apply_feedback_inhibition(
+        self,
+        inhibited_nodes: frozenset[int],
+    ) -> None:
+        """Remove suppressed turns from independent plasticity support."""
+
+        for node_id in inhibited_nodes:
+            _ = self.current_external.pop(node_id, None)
+
+    def reinforce_feedback_nodes(
+        self,
+        node_ids: tuple[int, ...],
+        boost: float,
+    ) -> None:
+        """Strengthen each target's membership in its own episode."""
+
+        if boost == 1.0:
+            return
+
+        # 1. Resolve only the episode created by the addressed turn itself.
+        own_hubs = {
+            hub.created_event: hub
+            for hub in self.hubs
+            if hub.created_event in node_ids
+        }
+        gain = boost ** self.config.learning_rate
+        credit = math.log(gain)
+        affected_hubs: set[int] = set()
+        affected_sources: set[int] = set()
+        self._transition_cache.clear()
+
+        # 2. Potentiate the target membership without creating neighbor relations.
+        for node_id in sorted(node_ids):
+            own_hub = own_hubs.get(node_id)
+            if own_hub is None:
+                continue
+            target_edges = tuple(
+                edge
+                for edge in own_hub.member_edge_ids
+                if self.source[edge] == node_id
+            )
+            if len(target_edges) != 1:
+                raise RuntimeError(
+                    "own episode must contain exactly one target membership"
+                )
+            edge_id = target_edges[0]
+            self.weight[edge_id] = min(
+                1.0,
+                self.weight[edge_id] * gain,
+            )
+            self.last_updated[edge_id] = self.current_event
+            self._support_edge(edge_id, credit, credit)
+            affected_hubs.add(self.target[edge_id])
+            affected_sources.add(node_id)
+
+        # 3. Preserve the existing per-episode and per-source conductance budgets.
+        for hub_node in sorted(affected_hubs):
+            _ = self._normalize_hub(hub_node)
+        for source in sorted(affected_sources):
+            _ = self._normalize_membership_source(source)
+
     def learn(
         self,
         event: int,

--- a/plugins/akasha/domain/model.py
+++ b/plugins/akasha/domain/model.py
@@ -43,6 +43,15 @@ class MemoryConfig:
 
 
 @dataclass(frozen=True)
+class TurnFeedback:
+    """Carry canonical Message-level feedback into one causal commit."""
+
+    remember_nodes: tuple[int, ...] = ()
+    forget_nodes: tuple[int, ...] = ()
+    remember_boost: float = 1.0
+
+
+@dataclass(frozen=True)
 class Turn:
     """Hold one committed user/assistant turn in global causal order."""
 
@@ -61,6 +70,7 @@ class Turn:
     user_terms: tuple[tuple[str, int], ...]
     assistant_terms: tuple[tuple[str, int], ...]
     inter_gap_seconds: float | None
+    feedback: TurnFeedback = TurnFeedback()
 
 
 @dataclass(frozen=True)

--- a/plugins/akasha/domain/readout.py
+++ b/plugins/akasha/domain/readout.py
@@ -135,35 +135,42 @@ def read_pattern_completion(
     context_dependence: float,
     visible_nodes: tuple[int, ...] = (),
     burst_continued: bool = True,
+    inhibited_nodes: frozenset[int] = frozenset(),
 ) -> PatternCompletion:
     """Read contextual and independent basin routes without mutating memory."""
 
     # 1. Preserve the contextual V8 route as the non-destructive baseline.
-    contextual = _read_contextual_route(
-        graph=graph,
-        pool=pool,
-        query=query,
-        context=context,
-        evidence=evidence,
-        diffusion=diffusion,
-        historical_surprise=historical_surprise,
-        config=config,
-        visible_nodes=visible_nodes,
-        burst_continued=burst_continued,
+    contextual = _exclude_recall_items(
+        _read_contextual_route(
+            graph=graph,
+            pool=pool,
+            query=query,
+            context=context,
+            evidence=evidence,
+            diffusion=diffusion,
+            historical_surprise=historical_surprise,
+            config=config,
+            visible_nodes=visible_nodes,
+            burst_continued=burst_continued,
+        ),
+        inhibited_nodes,
     )
 
     # 2. Inhibit query-only routing when the cue depends on its active context.
     address_mass = _independent_address_mass(context_dependence)
     if address_mass == 0.0:
         return contextual
-    address = _read_independent_route(
-        graph=graph,
-        pool=pool,
-        query=query,
-        surprise=evidence.surprise,
-        historical_surprise=historical_surprise,
-        config=config,
-        visible_nodes=visible_nodes,
+    address = _exclude_recall_items(
+        _read_independent_route(
+            graph=graph,
+            pool=pool,
+            query=query,
+            surprise=evidence.surprise,
+            historical_surprise=historical_surprise,
+            config=config,
+            visible_nodes=visible_nodes,
+        ),
+        inhibited_nodes,
     )
 
     # 3. Let address-only completions compete without evicting baseline items.
@@ -171,6 +178,40 @@ def read_pattern_completion(
         contextual,
         address,
         address_mass,
+    )
+
+
+def _exclude_recall_items(
+    completion: PatternCompletion,
+    excluded_nodes: frozenset[int],
+) -> PatternCompletion:
+    """Hide suppressed turns after they have served as graph bridges."""
+
+    if not excluded_nodes:
+        return completion
+    items = tuple(
+        item
+        for item in completion.items
+        if item.node_id not in excluded_nodes
+    )
+    counts = {
+        source: sum(source in item.sources for item in items)
+        for source in (
+            "sharp_completion",
+            "basin_direct",
+            "basin_completion",
+            "relative_tail",
+        )
+    }
+    return PatternCompletion(
+        items=items,
+        active_basin_count=completion.active_basin_count,
+        sharp_completion_count=counts["sharp_completion"],
+        basin_direct_count=counts["basin_direct"],
+        basin_completion_count=counts["basin_completion"],
+        relative_tail_count=counts["relative_tail"],
+        pushes=completion.pushes,
+        residual_l1=completion.residual_l1,
     )
 
 
@@ -222,11 +263,7 @@ def _read_independent_route(
 ) -> PatternCompletion:
     """Settle a query-only graph-address route without active context."""
 
-    fields = _evidence_fields(
-        pool,
-        query.node_id,
-        ContextState((), None, ()),
-    )
+    fields = _evidence_fields(pool, query.node_id, ContextState((), None, ()))
     seed = _sparsemax(fields["current"])
     diffusion = residual_push(
         graph,

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -187,9 +187,7 @@ class AkashaFeedbackPersistModule:
     async def run(self, frame: Any) -> Any:
         engine = self._plugin.context.memory_engine
         if engine is None or engine.describe().name != "akasha":
-            raise RuntimeError(
-                "Akasha feedback persistence requires AkashaMemoryEngine"
-            )
+            return frame
         markers = cast(
             AkashaMemoryEngine,
             engine,

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -10,12 +10,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from time import monotonic
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from zoneinfo import ZoneInfo
 
 import numpy as np
 
 from agent.config_models import Config
+from agent.control.context import current_turn_id
+from agent.tools.base import Tool
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import (
     EngineProfile,
@@ -81,6 +83,122 @@ class ActiveRecallSnapshot:
     records: RetrievalRecords
 
 
+@dataclass(frozen=True)
+class AkashaFeedbackMarker:
+    """Persist one agent-selected Message-level feedback event."""
+
+    action: Literal["remember", "forget"]
+    target_message_ids: tuple[str, ...]
+    target_turn_ids: tuple[str, ...]
+    reason: str
+
+    @property
+    def extra_key(self) -> str:
+        return (
+            "akasha_reinforce"
+            if self.action == "remember"
+            else "akasha_forget"
+        )
+
+    def payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": 1,
+            "action": self.action,
+            "target_message_ids": list(self.target_message_ids),
+            "target_turn_ids": list(self.target_turn_ids),
+            "source": f"agent.{self.action}_memory",
+        }
+        if self.reason:
+            payload["reason"] = self.reason
+        if self.action == "remember":
+            payload["boost"] = 3.0
+        return payload
+
+
+class _AkashaFeedbackTool(Tool):
+    """Stage one of the two Message-level feedback primitives."""
+
+    name = "_akasha_feedback"
+    action: Literal["remember", "forget"]
+    description = "由 Akasha tool_profile 注入工具描述。"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "message_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+            },
+            "reason": {"type": "string"},
+        },
+        "required": ["message_ids"],
+        "additionalProperties": False,
+    }
+
+    def __init__(
+        self,
+        memory: AkashaMemoryEngine,
+        spec: MemoryToolSpec,
+    ) -> None:
+        self._memory = memory
+        self.description = spec.description
+        self.parameters = spec.parameters
+
+    async def execute(
+        self,
+        message_ids: list[str],
+        reason: str = "",
+        **_: Any,
+    ) -> str:
+        return json.dumps(
+            self._memory.stage_feedback(
+                turn_id=current_turn_id.get(),
+                action=self.action,
+                message_ids=message_ids,
+                reason=reason,
+            ),
+            ensure_ascii=False,
+        )
+
+
+class AkashaRememberTool(_AkashaFeedbackTool):
+    """Strengthen selected history or the user's current correction."""
+
+    name = "remember_memory"
+    action = "remember"
+
+
+class AkashaForgetTool(_AkashaFeedbackTool):
+    """Suppress selected history without inventing a replacement."""
+
+    name = "forget_memory"
+    action = "forget"
+
+
+class AkashaFeedbackPersistModule:
+    """Export staged feedback markers into the current user message."""
+
+    slot = "akasha.feedback.persist"
+    requires = ("after_reasoning.emit", "reasoning:ctx")
+
+    def __init__(self, plugin: Any) -> None:
+        self._plugin = plugin
+
+    async def run(self, frame: Any) -> Any:
+        engine = self._plugin.context.memory_engine
+        if engine is None or engine.describe().name != "akasha":
+            raise RuntimeError(
+                "Akasha feedback persistence requires AkashaMemoryEngine"
+            )
+        markers = cast(
+            AkashaMemoryEngine,
+            engine,
+        ).take_staged_feedback(current_turn_id.get())
+        for marker in markers:
+            frame.slots[f"persist:user:{marker.extra_key}"] = marker.payload()
+        return frame
+
+
 class AkashaMemoryEngine:
     """Adapt the standalone explicit memory runtime to Akasic Agent."""
 
@@ -100,7 +218,8 @@ class AkashaMemoryEngine:
         notes={
             "truth": "sessions.db/messages",
             "learning": "unsupervised_memory_cycle",
-            "external_reinforcement": "ignored_by_design",
+            "message_feedback": "remember_and_forget_markers",
+            "legacy_item_reinforcement": "ignored_by_design",
         },
     )
 
@@ -161,6 +280,10 @@ class AkashaMemoryEngine:
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
+        self._staged_feedback: dict[
+            str,
+            dict[Literal["remember", "forget"], AkashaFeedbackMarker],
+        ] = {}
         self.closeables: list[object] = [
             self._runtime,
             self._embedding_store,
@@ -360,7 +483,182 @@ class AkashaMemoryEngine:
                     "required": ["query"],
                 },
                 search_hint="历史对话 情景回忆 关联记忆",
+            ),
+            tools=(
+                MemoryToolSpec(
+                    name="remember_memory",
+                    description=(
+                        "记住或强化用户明确确认正确、有用、以后应优先的内容。"
+                        "参数接受 fetch_messages 返回的 Message ID；如果正确内容就在"
+                        "用户当前消息里，传保留值 current_user_message。"
+                        "不要传 recall_memory 的记忆条目 id、会话 source_ref 或 "
+                        "Akasha 图节点 id。"
+                        "调用前必须先用 recall_memory 或 search_messages 找候选，再用 "
+                        "fetch_messages 读取原文并取得 messages[].id。"
+                        "recall_memory 返回的 evidence[].refs 是可回源的 Message ID；"
+                        "不要把仅表示会话的 evidence[].source_ref 当作 Message ID。"
+                        "用户纠正旧内容时，用 forget_memory 忘记旧 Message，再用本工具"
+                        "记住正确 Message 或 current_user_message；没有第三种 correct 动作。"
+                        "仅仅回答了一个问题、召回了一段历史或模型自行觉得重要，不得调用。"
+                    ),
+                    parameters=AkashaRememberTool.parameters,
+                    risk="write",
+                    search_hint="记住 强化 偏好 正确纠正",
+                    tool_class=AkashaRememberTool,
+                ),
+                MemoryToolSpec(
+                    name="forget_memory",
+                    description=(
+                        "忘记或抑制用户明确要求撤回、判错、过时或不再使用的历史内容。"
+                        "参数只接受 fetch_messages 返回的旧 Message ID；"
+                        "不要传 recall_memory 记忆条目 id、会话 source_ref、"
+                        "Akasha 图节点 id 或 current_user_message。"
+                        "调用前必须先 recall_memory 或 search_messages，再用 "
+                        "fetch_messages 读原文并取得 messages[].id。"
+                        "如果用户同时给出正确替代，先用本工具忘记旧 Message，"
+                        "再调用 remember_memory 记住正确 Message 或 "
+                        "current_user_message；没有第三种 correct 动作。"
+                        "如果只是纯忘记，只调用本工具，并在成功后中性确认；"
+                        "不得把被忘内容的反命题当成新事实或新偏好。"
+                        "上一段对话已经结束也不受影响：定位旧 Message ID 后在本轮调用，"
+                        "系统会把它转换成 Akasha turn。"
+                    ),
+                    parameters=AkashaForgetTool.parameters,
+                    risk="write",
+                    search_hint="忘记 撤回 错误 过时 不要再提",
+                    tool_class=AkashaForgetTool,
+                ),
+            ),
+        )
+
+    def stage_feedback(
+        self,
+        *,
+        turn_id: str,
+        action: str,
+        message_ids: list[str],
+        reason: str,
+    ) -> dict[str, object]:
+        """Resolve Message IDs and stage one marker for this active turn."""
+
+        # 1. Validate the agent tool boundary before resolving graph identity.
+        clean_ids = _clean_feedback_message_ids(message_ids)
+        clean_reason = reason.strip()
+        error = _feedback_request_error(
+            turn_id=turn_id,
+            action=action,
+            message_ids=clean_ids,
+            reason=clean_reason,
+        )
+        if error is not None:
+            return error
+
+        # 2. Convert public Message identities to canonical Akasha turns.
+        resolved = self._resolve_and_stage_feedback(
+            turn_id=turn_id,
+            action=cast(
+                Literal["remember", "forget"],
+                action,
+            ),
+            message_ids=clean_ids,
+            reason=clean_reason,
+        )
+        if isinstance(resolved, dict):
+            return resolved
+        marker = resolved
+
+        # 3. Report staging honestly; persistence happens after reasoning.
+        return {
+            "status": "staged",
+            "action": marker.action,
+            "target_message_ids": list(marker.target_message_ids),
+            "target_turn_ids": list(marker.target_turn_ids),
+            "applies_after": "current_turn_commit",
+        }
+
+    def _resolve_and_stage_feedback(
+        self,
+        *,
+        turn_id: str,
+        action: Literal["remember", "forget"],
+        message_ids: list[str],
+        reason: str,
+    ) -> AkashaFeedbackMarker | dict[str, object]:
+        """Resolve Message IDs and atomically merge one active-turn marker."""
+
+        with self._lock:
+            turns_by_message = {
+                message_id: turn
+                for turn in self._runtime.cycle.turns
+                for message_id in (
+                    turn.user_message_id,
+                    turn.assistant_message_id,
+                )
+            }
+            missing = [
+                message_id
+                for message_id in message_ids
+                if (
+                    message_id not in turns_by_message
+                    and not (
+                        action == "remember"
+                        and message_id == "current_user_message"
+                    )
+                )
+            ]
+            if missing:
+                return _missing_feedback_messages(missing)
+            marker = AkashaFeedbackMarker(
+                action=action,
+                target_message_ids=tuple(message_ids),
+                target_turn_ids=tuple(
+                    dict.fromkeys(
+                        (
+                            "current_turn"
+                            if message_id == "current_user_message"
+                            else turns_by_message[message_id].turn_id
+                        )
+                        for message_id in message_ids
+                    )
+                ),
+                reason=reason,
             )
+            staged = self._staged_feedback.setdefault(turn_id, {})
+            opposite = staged.get(
+                "forget" if action == "remember" else "remember"
+            )
+            overlap = (
+                set(marker.target_turn_ids)
+                & set(opposite.target_turn_ids)
+                if opposite is not None
+                else set()
+            )
+            if overlap:
+                return {
+                    "status": "not_staged",
+                    "error": "conflicting_feedback_actions",
+                    "target_turn_ids": sorted(overlap),
+                }
+            previous = staged.get(action)
+            if previous is not None:
+                marker = _merge_feedback_markers(previous, marker)
+            staged[action] = marker
+            return marker
+
+    def take_staged_feedback(
+        self,
+        turn_id: str,
+    ) -> tuple[AkashaFeedbackMarker, ...]:
+        """Consume both marker primitives owned by one active host turn."""
+
+        if not turn_id:
+            return ()
+        with self._lock:
+            staged = self._staged_feedback.pop(turn_id, {})
+        return tuple(
+            staged[action]
+            for action in ("forget", "remember")
+            if action in staged
         )
 
     def keyword_match_procedures(
@@ -606,6 +904,8 @@ class AkashaMemoryEngine:
         }
         dense_candidates = []
         for turn in turns:
+            if turn.node_id in self._runtime.cycle.inhibited_nodes:
+                continue
             score = _dense_score(cue.user_dense, turn)
             if score is None or not _matches_filters(
                 turn,
@@ -878,6 +1178,92 @@ def _format_records(
 
 def _json_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
+
+
+def _clean_feedback_message_ids(message_ids: list[str]) -> list[str]:
+    clean: list[str] = []
+    seen: set[str] = set()
+    for raw in message_ids:
+        message_id = str(raw).strip()
+        if message_id and message_id not in seen:
+            seen.add(message_id)
+            clean.append(message_id)
+    return clean
+
+
+def _feedback_request_error(
+    *,
+    turn_id: str,
+    action: str,
+    message_ids: list[str],
+    reason: str,
+) -> dict[str, object] | None:
+    if not turn_id:
+        return {"status": "not_staged", "error": "no_active_turn"}
+    if action not in {"remember", "forget"}:
+        return {"status": "not_staged", "error": "invalid_action"}
+    if not message_ids:
+        return {"status": "not_staged", "error": "message_ids_required"}
+    if len(message_ids) > 20:
+        return {
+            "status": "not_staged",
+            "error": "too_many_message_ids",
+            "maximum": 20,
+        }
+    if action == "forget" and "current_user_message" in message_ids:
+        return {
+            "status": "not_staged",
+            "error": "cannot_forget_current_user_message",
+        }
+    if len(reason) > 500:
+        return {
+            "status": "not_staged",
+            "error": "reason_too_long",
+            "maximum": 500,
+        }
+    return None
+
+
+def _missing_feedback_messages(
+    message_ids: list[str],
+) -> dict[str, object]:
+    return {
+        "status": "not_staged",
+        "error": "messages_not_in_akasha",
+        "missing_message_ids": message_ids,
+        "hint": (
+            "请重新 fetch_messages，并只选择完整 "
+            "user/assistant 回合中的消息 ID。"
+        ),
+    }
+
+
+def _merge_feedback_markers(
+    previous: AkashaFeedbackMarker,
+    current: AkashaFeedbackMarker,
+) -> AkashaFeedbackMarker:
+    if previous.action != current.action:
+        raise ValueError("feedback marker actions must match")
+    return AkashaFeedbackMarker(
+        action=current.action,
+        target_message_ids=tuple(
+            dict.fromkeys(
+                [
+                    *previous.target_message_ids,
+                    *current.target_message_ids,
+                ]
+            )
+        ),
+        target_turn_ids=tuple(
+            dict.fromkeys(
+                [
+                    *previous.target_turn_ids,
+                    *current.target_turn_ids,
+                ]
+            )
+        ),
+        reason=current.reason or previous.reason,
+    )
 
 
 def _parse_turn_time(value: str) -> datetime:

--- a/plugins/akasha/infrastructure/loader.py
+++ b/plugins/akasha/infrastructure/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import sqlite3
 from collections import defaultdict
@@ -11,7 +12,8 @@ from zoneinfo import ZoneInfo
 
 import numpy as np
 
-from ..domain.model import Turn
+from ..domain.model import Turn, TurnFeedback
+from .sparse_index.schema import INDEX_VERSION
 
 
 def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
@@ -25,7 +27,9 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
             """
             SELECT turn_id, session_key, user_seq,
                    user_message_id, assistant_message_id,
-                   started_at, committed_at, user_text, assistant_text
+                   started_at, committed_at, user_text, assistant_text,
+                   remember_targets_json, forget_targets_json,
+                   remember_boost
             FROM sparse_turns
             ORDER BY started_at, session_key, user_seq, turn_id
             """
@@ -46,7 +50,7 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
 def _validate_index(connection: sqlite3.Connection) -> None:
     """Validate the read-only sparse-index trust boundary."""
 
-    required = {"sparse_turns", "turn_dense", "turn_terms"}
+    required = {"metadata", "sparse_turns", "turn_dense", "turn_terms"}
     actual = {
         row[0]
         for row in connection.execute(
@@ -56,6 +60,14 @@ def _validate_index(connection: sqlite3.Connection) -> None:
     missing = required - actual
     if missing:
         raise ValueError(f"sparse index is missing tables: {sorted(missing)}")
+    row = connection.execute(
+        "SELECT value FROM metadata WHERE key='index_version'"
+    ).fetchone()
+    if row is None or str(row[0]) != INDEX_VERSION:
+        actual_version = None if row is None else str(row[0])
+        raise ValueError(
+            f"unsupported sparse index version: {actual_version}"
+        )
 
 
 def _load_dense(
@@ -108,6 +120,10 @@ def _materialize_turns(
     """Attach validated features and derive global causal gaps."""
 
     turns: list[Turn] = []
+    node_by_turn = {
+        str(row["turn_id"]): node_id
+        for node_id, row in enumerate(rows)
+    }
     previous: datetime | None = None
     for node_id, row in enumerate(rows):
         started = _as_utc(row["started_at"])
@@ -117,6 +133,18 @@ def _materialize_turns(
         turn_id = row["turn_id"]
         user_dense = dense.get((turn_id, "user"))
         assistant_dense = dense.get((turn_id, "assistant"))
+        remember_nodes = _feedback_nodes(
+            row["remember_targets_json"],
+            node_by_turn,
+            turn_id,
+            "remember",
+        )
+        forget_nodes = _feedback_nodes(
+            row["forget_targets_json"],
+            node_by_turn,
+            turn_id,
+            "forget",
+        )
         turns.append(
             Turn(
                 node_id=node_id,
@@ -134,10 +162,37 @@ def _materialize_turns(
                 user_terms=terms.get((turn_id, "user"), ()),
                 assistant_terms=terms.get((turn_id, "assistant"), ()),
                 inter_gap_seconds=gap,
+                feedback=TurnFeedback(
+                    remember_nodes=remember_nodes,
+                    forget_nodes=forget_nodes,
+                    remember_boost=float(row["remember_boost"]),
+                ),
             )
         )
         previous = started
     return turns
+
+
+def _feedback_nodes(
+    raw: str,
+    node_by_turn: dict[str, int],
+    carrier_turn_id: str,
+    action: str,
+) -> tuple[int, ...]:
+    targets = json.loads(raw)
+    if (
+        not isinstance(targets, list)
+        or any(not isinstance(target, str) for target in targets)
+    ):
+        raise ValueError(
+            f"invalid {action} targets at turn {carrier_turn_id}"
+        )
+    try:
+        return tuple(node_by_turn[target] for target in targets)
+    except KeyError as error:
+        raise ValueError(
+            f"missing {action} target at turn {carrier_turn_id}: {error.args[0]}"
+        ) from error
 
 
 def _turn_sort_key(row: sqlite3.Row) -> tuple[datetime, bytes, int, bytes]:

--- a/plugins/akasha/infrastructure/persistence.py
+++ b/plugins/akasha/infrastructure/persistence.py
@@ -60,6 +60,7 @@ def write_memory_database(
         _initialize(connection)
         _write_metadata(connection, metadata, turns, graph, config)
         _write_turns(connection, turns)
+        _write_feedback_events(connection, turns)
         _write_graph(connection, graph)
         _write_events(connection, events, evidence)
         _write_captures(connection, turns, graph, captures, config.restart)
@@ -206,7 +207,7 @@ def _write_metadata(
     values = {
         **metadata,
         "config_json": canonical_json(asdict(config)),
-        "engine": "single_state_empirical_recurrence_survival_v8",
+        "engine": "single_state_empirical_recurrence_survival_v9_feedback",
         "graph_turn_capacity": str(graph.turn_count),
         "hub_count": str(len(graph.hubs)),
         "relation_count": str(len(graph.source)),
@@ -239,6 +240,37 @@ def _write_turns(connection: sqlite3.Connection, turns: list[Turn]) -> None:
             )
             for turn in turns
         ],
+    )
+
+
+def _write_feedback_events(
+    connection: sqlite3.Connection,
+    turns: list[Turn],
+) -> None:
+    """Persist the canonical marker inputs that produced graph control."""
+
+    rows = []
+    for turn in turns:
+        rows.extend(
+            (
+                turn.node_id,
+                "remember",
+                target,
+                turn.feedback.remember_boost,
+            )
+            for target in turn.feedback.remember_nodes
+        )
+        rows.extend(
+            (turn.node_id, "forget", target, 1.0)
+            for target in turn.feedback.forget_nodes
+        )
+    connection.executemany(
+        """
+        INSERT INTO feedback_events(
+            event_id, action, target_turn_node_id, boost
+        ) VALUES (?, ?, ?, ?)
+        """,
+        rows,
     )
 
 
@@ -615,6 +647,48 @@ def _validate_snapshot_identity(
     )
     if actual != wanted:
         raise ValueError("memory snapshot turn bindings differ from source index")
+    _validate_feedback_bindings(connection, turns)
+
+
+def _validate_feedback_bindings(
+    connection: sqlite3.Connection,
+    turns: list[Turn],
+) -> None:
+    actual = tuple(
+        tuple(row)
+        for row in connection.execute(
+            """
+            SELECT event_id, action, target_turn_node_id, boost
+            FROM feedback_events
+            ORDER BY event_id, action, target_turn_node_id
+            """
+        )
+    )
+    wanted_rows = []
+    for turn in turns:
+        wanted_rows.extend(
+            (
+                turn.node_id,
+                "remember",
+                target,
+                turn.feedback.remember_boost,
+            )
+            for target in turn.feedback.remember_nodes
+        )
+        wanted_rows.extend(
+            (turn.node_id, "forget", target, 1.0)
+            for target in turn.feedback.forget_nodes
+        )
+    wanted = tuple(
+        sorted(
+            wanted_rows,
+            key=lambda row: (row[0], row[1], row[2]),
+        )
+    )
+    if actual != wanted:
+        raise ValueError(
+            "memory snapshot feedback bindings differ from source index"
+        )
 
 
 def memory_turn_count(memory_path: Path) -> int:
@@ -973,6 +1047,7 @@ def _load_context(
 
 _LOGICAL_STATE_TABLES = (
     "turn_nodes",
+    "feedback_events",
     "hub_nodes",
     "hub_memberships",
     "temporal_edges",
@@ -989,7 +1064,7 @@ _LOGICAL_STATE_TABLES = (
 
 _SCHEMA = """
 PRAGMA application_id = 1095452754;
-PRAGMA user_version = 1;
+PRAGMA user_version = 2;
 
 CREATE TABLE metadata (
     key TEXT PRIMARY KEY,
@@ -1007,6 +1082,14 @@ CREATE TABLE turn_nodes (
     committed_at TEXT NOT NULL,
     inter_gap_seconds REAL
 );
+
+CREATE TABLE feedback_events (
+    event_id INTEGER NOT NULL REFERENCES turn_nodes(node_id),
+    action TEXT NOT NULL CHECK(action IN ('remember', 'forget')),
+    target_turn_node_id INTEGER NOT NULL REFERENCES turn_nodes(node_id),
+    boost REAL NOT NULL CHECK(boost >= 1.0 AND boost <= 3.0),
+    PRIMARY KEY (event_id, action, target_turn_node_id)
+) WITHOUT ROWID;
 
 CREATE TABLE hub_nodes (
     node_id INTEGER PRIMARY KEY,

--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -7,7 +7,7 @@ import hashlib
 import math
 import sqlite3
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -16,10 +16,9 @@ import numpy as np
 
 from .encoding import LexicalState, lexical_identity, tokenize
 from .model import CanonicalTurn, SessionState, SparseFeature, TimeStats
-from .schema import SCHEMA
+from .schema import INDEX_VERSION, SCHEMA
 
 LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
-INDEX_VERSION = "7"
 INTERRUPTED_ASSISTANT_MARKER = "[interrupted]"
 
 
@@ -281,6 +280,7 @@ def _load_canonical_turns(
             turn.turn_id.encode("utf-8"),
         )
     )
+    turns = _resolve_feedback_targets(turns)
     return turns, missing_embeddings, excluded_interrupted
 
 
@@ -331,15 +331,19 @@ def _excluded_session(session_key: str) -> bool:
 
 
 def _skip_post_memory(message: sqlite3.Row) -> bool:
+    return bool(_message_extra(message).get("skip_post_memory"))
+
+
+def _message_extra(message: sqlite3.Row) -> dict[str, object]:
     raw = message["extra"]
     if not raw:
-        return False
+        return {}
     payload = json.loads(str(raw))
     if not isinstance(payload, dict):
         raise ValueError(
             f"message extra must be an object: {message['id']}"
         )
-    return bool(payload.get("skip_post_memory"))
+    return payload
 
 
 def _message_text(message: sqlite3.Row) -> str:
@@ -507,8 +511,23 @@ def _make_turn(
     assistant: sqlite3.Row,
     embeddings: dict[str, np.ndarray],
 ) -> CanonicalTurn:
+    turn_id = f"{user['id']}::{assistant['id']}"
+    remember_targets, remember_boost = _feedback_marker(
+        user,
+        key="akasha_reinforce",
+        action="remember",
+        carrier_turn_id=turn_id,
+        target_required=False,
+    )
+    forget_targets, _ = _feedback_marker(
+        user,
+        key="akasha_forget",
+        action="forget",
+        carrier_turn_id=turn_id,
+        target_required=True,
+    )
     return CanonicalTurn(
-        turn_id=f"{user['id']}::{assistant['id']}",
+        turn_id=turn_id,
         session_key=user["session_key"],
         user_seq=user["seq"],
         user_message_id=user["id"],
@@ -519,7 +538,148 @@ def _make_turn(
         assistant_text=assistant["content"] or "",
         user_embedding=embeddings.get(user["id"]),
         assistant_embedding=embeddings.get(assistant["id"]),
+        remember_target_turn_ids=remember_targets,
+        forget_target_turn_ids=forget_targets,
+        remember_boost=remember_boost,
     )
+
+
+def _feedback_marker(
+    message: sqlite3.Row,
+    *,
+    key: str,
+    action: str,
+    carrier_turn_id: str,
+    target_required: bool,
+) -> tuple[tuple[str, ...], float]:
+    """Validate one persisted marker and retain only graph-relevant fields."""
+
+    # 1. Distinguish absence from malformed marker data at the source boundary.
+    raw = _message_extra(message).get(key)
+    if raw is None:
+        return (), 1.0
+    if not isinstance(raw, dict):
+        raise ValueError(f"{key} must be an object: {message['id']}")
+    schema_version = raw.get("schema_version")
+    if schema_version not in (None, 1):
+        raise ValueError(
+            f"{key} has unsupported schema_version: {message['id']}"
+        )
+    marker_action = raw.get("action")
+    if marker_action is not None and marker_action != action:
+        raise ValueError(f"{key} action mismatch: {message['id']}")
+
+    # 2. Canonicalize stable turn targets; legacy reinforce marks its carrier.
+    target_value = raw.get("target_turn_ids")
+    if target_value is None:
+        if target_required:
+            raise ValueError(
+                f"{key} requires target_turn_ids: {message['id']}"
+            )
+        targets = (carrier_turn_id,)
+    else:
+        if (
+            not isinstance(target_value, list)
+            or not target_value
+            or any(
+                not isinstance(value, str) or not value.strip()
+                for value in target_value
+            )
+        ):
+            raise ValueError(
+                f"{key} target_turn_ids must be non-empty strings: "
+                f"{message['id']}"
+            )
+        targets = tuple(
+            dict.fromkeys(value.strip() for value in target_value)
+        )
+
+    # 3. Bound reinforcement gain before it can affect graph plasticity.
+    if action == "forget":
+        return targets, 1.0
+    boost_value = raw.get("boost", 3.0)
+    if isinstance(boost_value, bool) or not isinstance(
+        boost_value,
+        (int, float),
+    ):
+        raise ValueError(f"{key} boost must be numeric: {message['id']}")
+    boost = float(boost_value)
+    if not math.isfinite(boost) or not 1.0 <= boost <= 3.0:
+        raise ValueError(f"{key} boost must be in [1, 3]: {message['id']}")
+    return targets, boost
+
+
+def _resolve_feedback_targets(
+    turns: list[CanonicalTurn],
+) -> list[CanonicalTurn]:
+    """Resolve stable target turn IDs after establishing causal node order."""
+
+    positions = {turn.turn_id: index for index, turn in enumerate(turns)}
+    resolved = []
+    for event, turn in enumerate(turns):
+        remember = _resolve_marker_targets(
+            turn.remember_target_turn_ids,
+            carrier=turn,
+            event=event,
+            positions=positions,
+            allow_current=True,
+            action="remember",
+        )
+        forget = _resolve_marker_targets(
+            turn.forget_target_turn_ids,
+            carrier=turn,
+            event=event,
+            positions=positions,
+            allow_current=False,
+            action="forget",
+        )
+        overlap = set(remember) & set(forget)
+        if overlap:
+            raise ValueError(
+                f"feedback actions overlap at turn {turn.turn_id}: "
+                f"{sorted(overlap)}"
+            )
+        resolved.append(
+            replace(
+                turn,
+                remember_target_turn_ids=remember,
+                forget_target_turn_ids=forget,
+            )
+        )
+    return resolved
+
+
+def _resolve_marker_targets(
+    targets: tuple[str, ...],
+    *,
+    carrier: CanonicalTurn,
+    event: int,
+    positions: dict[str, int],
+    allow_current: bool,
+    action: str,
+) -> tuple[str, ...]:
+    canonical = tuple(
+        carrier.turn_id if target == "current_turn" else target
+        for target in targets
+    )
+    missing = sorted(set(canonical) - positions.keys())
+    if missing:
+        raise ValueError(
+            f"{action} target turns are not indexed at {carrier.turn_id}: "
+            f"{missing}"
+        )
+    future = sorted(
+        target
+        for target in set(canonical)
+        if positions[target] > event
+        or (positions[target] == event and not allow_current)
+    )
+    if future:
+        raise ValueError(
+            f"{action} target turns are not causally available at "
+            f"{carrier.turn_id}: {future}"
+        )
+    return tuple(sorted(set(canonical), key=positions.__getitem__))
 
 
 def _decode_embedding(blob: bytes, dimension: int) -> np.ndarray:
@@ -787,7 +947,15 @@ def _persist_sparse_payload(
     """Persist canonical text plus every non-zero sparse dimension."""
 
     connection.execute(
-        "INSERT INTO sparse_turns VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        """
+        INSERT INTO sparse_turns(
+            turn_id, session_key, user_seq,
+            user_message_id, assistant_message_id,
+            started_at, committed_at, user_text, assistant_text,
+            remember_targets_json, forget_targets_json,
+            remember_boost, source_digest
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
         (
             turn.turn_id,
             turn.session_key,
@@ -798,6 +966,17 @@ def _persist_sparse_payload(
             turn.committed_at,
             turn.user_text,
             turn.assistant_text,
+            json.dumps(
+                turn.remember_target_turn_ids,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            json.dumps(
+                turn.forget_target_turn_ids,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            turn.remember_boost,
             _turn_digest(turn),
         ),
     )
@@ -830,6 +1009,17 @@ def _turn_digest(turn: CanonicalTurn) -> str:
         turn.committed_at,
         turn.user_text,
         turn.assistant_text,
+        json.dumps(
+            turn.remember_target_turn_ids,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        json.dumps(
+            turn.forget_target_turn_ids,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        turn.remember_boost.hex(),
     ):
         encoded = value.encode("utf-8")
         digest.update(len(encoded).to_bytes(8, "big"))

--- a/plugins/akasha/infrastructure/sparse_index/model.py
+++ b/plugins/akasha/infrastructure/sparse_index/model.py
@@ -22,6 +22,9 @@ class CanonicalTurn:
     assistant_text: str
     user_embedding: np.ndarray | None
     assistant_embedding: np.ndarray | None
+    remember_target_turn_ids: tuple[str, ...]
+    forget_target_turn_ids: tuple[str, ...]
+    remember_boost: float
 
 
 @dataclass(frozen=True)

--- a/plugins/akasha/infrastructure/sparse_index/schema.py
+++ b/plugins/akasha/infrastructure/sparse_index/schema.py
@@ -1,5 +1,7 @@
 """SQLite schema for the derived sparse turn index."""
 
+INDEX_VERSION = "8"
+
 SCHEMA = """
 PRAGMA foreign_keys = ON;
 
@@ -18,6 +20,11 @@ CREATE TABLE IF NOT EXISTS sparse_turns (
     committed_at         TEXT NOT NULL,
     user_text            TEXT NOT NULL,
     assistant_text       TEXT NOT NULL,
+    remember_targets_json TEXT NOT NULL,
+    forget_targets_json   TEXT NOT NULL,
+    remember_boost        REAL NOT NULL CHECK (
+        remember_boost >= 1.0 AND remember_boost <= 3.0
+    ),
     source_digest        TEXT NOT NULL
 );
 

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -1,4 +1,4 @@
-"""Plugin discovery and read-only inspection surfaces for Akasha V2."""
+"""Plugin lifecycle and read-only inspection surfaces for Akasha V2."""
 
 from typing import cast
 
@@ -10,7 +10,7 @@ from agent.plugins import (
 from agent.plugins.mobile_ui import MobileUiRpcInvalidRequest
 from core.memory.engine import MemoryRecord
 
-from .engine import AkashaMemoryEngine
+from .engine import AkashaFeedbackPersistModule, AkashaMemoryEngine
 from .inspector import AkashaInspectorReader, mobile_summary
 from .memory_plugin import MemoryPlugin
 
@@ -21,13 +21,16 @@ _MOBILE_RECALL_ASSISTANT_PREVIEW_CHARS = 50
 
 
 class AkashaPlugin(Plugin):
-    """Register V2 memory inspection without exposing graph mutation."""
+    """Register Message feedback persistence and read-only inspection."""
 
     api_version = 2
     name = "akasha"
 
     def __init__(self) -> None:
         self._reader: AkashaInspectorReader | None = None
+
+    def after_reasoning_modules(self) -> list[object]:
+        return [AkashaFeedbackPersistModule(self)]
 
     @classmethod
     def dashboard_module(cls) -> str:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -20,6 +20,7 @@ from agent.config_models import (
     MemoryConfig as HostMemoryConfig,
     MemoryEmbeddingConfig,
 )
+from agent.control.context import current_turn_id
 from agent.looping.ports import MemoryServices
 from agent.plugins import Plugin
 from agent.plugins.context import PluginContext, PluginKVStore
@@ -30,13 +31,18 @@ from agent.plugins.manifest import (
 from agent.tools.recall_memory import RecallMemoryTool
 from agent.retrieval.default_pipeline import DefaultMemoryRetrievalPipeline
 from agent.retrieval.protocol import RetrievalRequest
+from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryScope
 from core.memory.plugin import MemoryPlugin as MemoryPluginProtocol
 from plugins.akasha.application.rebuild import rebuild_memory
 from plugins.akasha.config import AkashaConfig, render_akasha_config
 from plugins.akasha.dashboard import register as register_dashboard
-from plugins.akasha.engine import ActiveRecallSnapshot, AkashaMemoryEngine
+from plugins.akasha.engine import (
+    ActiveRecallSnapshot,
+    AkashaFeedbackPersistModule,
+    AkashaMemoryEngine,
+)
 from plugins.akasha.inspector import AkashaInspectorReader
 from plugins.akasha.infrastructure.persistence import (
     logical_state_sha256,
@@ -73,6 +79,7 @@ def test_akasha_v2_registers_both_host_protocols() -> None:
     assert isinstance(plugin, Plugin)
     assert isinstance(MemoryPlugin(), MemoryPluginProtocol)
     assert MemoryPlugin.plugin_id == "akasha"
+    assert len(plugin.after_reasoning_modules()) == 1
     assert plugin.dashboard_module() == "dashboard.py"
     mobile = plugin.mobile_ui()
     assert mobile.module == "mobile_ui.js"
@@ -80,6 +87,283 @@ def test_akasha_v2_registers_both_host_protocols() -> None:
     assert mobile.slots == ("turn.before_reasoning",)
     assert mobile.navigation is not None
     assert mobile.navigation.label == "Akasha Inspector"
+
+
+def test_feedback_marker_is_exported_before_user_message_persistence() -> None:
+    # Import after passive-turn modules settle their lifecycle import cycle.
+    from agent.lifecycle.phases import default_after_reasoning_modules
+
+    plugin = AkashaPlugin()
+    modules = default_after_reasoning_modules(
+        EventBus(),
+        cast(Any, SimpleNamespace()),
+        plugin.after_reasoning_modules(),
+    )
+    slots = [module.slot for module in modules]
+
+    assert slots.index("akasha.feedback.persist") < slots.index(
+        "after_reasoning.persist_user"
+    )
+
+
+@pytest.mark.asyncio
+async def test_feedback_tools_compose_correction_from_two_markers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compose correction from forget plus remember without a third action."""
+
+    # 1. Build one historical turn addressable by either Message ID.
+    _create_sessions(tmp_path / "sessions.db")
+    monkeypatch.setattr("plugins.akasha.engine.Embedder", _Embedder)
+    engine = _engine(tmp_path)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    _append_turn(
+        tmp_path / "sessions.db",
+        sequence=0,
+        user="old wrong answer",
+        assistant="incorrect detail",
+        started=started,
+    )
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=0,
+            user="old wrong answer",
+            assistant="incorrect detail",
+            started=started,
+        )
+    )
+    await engine._wait_for_publication()  # noqa: SLF001
+
+    # 2. Forget the old Message and remember the current user correction.
+    specs = {spec.name: spec for spec in engine.tool_profile().tools}
+    assert set(specs) == {"remember_memory", "forget_memory"}
+    forget_spec = specs["forget_memory"]
+    remember_spec = specs["remember_memory"]
+    assert forget_spec.risk == "write"
+    assert remember_spec.risk == "write"
+    assert forget_spec.tool_class is not None
+    assert remember_spec.tool_class is not None
+    forget = forget_spec.tool_class(engine, forget_spec)
+    remember = remember_spec.tool_class(engine, remember_spec)
+    token = current_turn_id.set("turn:feedback")
+    try:
+        forgotten = json.loads(
+            await forget.execute(
+                message_ids=["message:1"],
+                reason="old assistant answer is wrong",
+            )
+        )
+        reinforced = json.loads(
+            await remember.execute(
+                message_ids=["current_user_message"],
+                reason="the current user message supplies the correction",
+            )
+        )
+        assert forgotten == {
+            "status": "staged",
+            "action": "forget",
+            "target_message_ids": ["message:1"],
+            "target_turn_ids": ["message:0::message:1"],
+            "applies_after": "current_turn_commit",
+        }
+        assert reinforced == {
+            "status": "staged",
+            "action": "remember",
+            "target_message_ids": ["current_user_message"],
+            "target_turn_ids": ["current_turn"],
+            "applies_after": "current_turn_commit",
+        }
+
+        # 3. Export both independent markers onto the current user Message.
+        frame = SimpleNamespace(slots={})
+        owner = SimpleNamespace(
+            context=SimpleNamespace(memory_engine=engine)
+        )
+        await AkashaFeedbackPersistModule(owner).run(frame)
+        forgotten_marker = frame.slots["persist:user:akasha_forget"]
+        remembered_marker = frame.slots["persist:user:akasha_reinforce"]
+        assert forgotten_marker["action"] == "forget"
+        assert forgotten_marker["target_message_ids"] == ["message:1"]
+        assert forgotten_marker["target_turn_ids"] == [
+            "message:0::message:1"
+        ]
+        assert remembered_marker["action"] == "remember"
+        assert remembered_marker["target_message_ids"] == [
+            "current_user_message"
+        ]
+        assert remembered_marker["target_turn_ids"] == ["current_turn"]
+        assert engine.take_staged_feedback("turn:feedback") == ()
+    finally:
+        current_turn_id.reset(token)
+        _close_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_feedback_tool_rejects_memory_item_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Require Message identities even when the turn ID looks plausible."""
+
+    _create_sessions(tmp_path / "sessions.db")
+    monkeypatch.setattr("plugins.akasha.engine.Embedder", _Embedder)
+    engine = _engine(tmp_path)
+    try:
+        spec = next(
+            spec
+            for spec in engine.tool_profile().tools
+            if spec.name == "forget_memory"
+        )
+        assert spec.tool_class is not None
+        tool = spec.tool_class(engine, spec)
+        token = current_turn_id.set("turn:feedback")
+        try:
+            result = json.loads(
+                await tool.execute(
+                    message_ids=["message:0::message:1"],
+                )
+            )
+        finally:
+            current_turn_id.reset(token)
+        assert result["status"] == "not_staged"
+        assert result["error"] == "messages_not_in_akasha"
+
+        token = current_turn_id.set("turn:feedback")
+        try:
+            current = json.loads(
+                await tool.execute(
+                    message_ids=["current_user_message"],
+                )
+            )
+        finally:
+            current_turn_id.reset(token)
+        assert current["status"] == "not_staged"
+        assert current["error"] == "cannot_forget_current_user_message"
+    finally:
+        _close_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_feedback_markers_change_future_recall_and_replay_identically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persist tool markers, suppress future recall, and reproduce the graph."""
+
+    # 1. Commit one wrong historical turn, then stage a current correction.
+    sessions = tmp_path / "sessions.db"
+    _create_sessions(sessions)
+    monkeypatch.setattr("plugins.akasha.engine.Embedder", _Embedder)
+    engine = _engine(tmp_path)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    _append_turn(
+        sessions,
+        sequence=0,
+        user="alpha old wrong claim",
+        assistant="wrong answer",
+        started=started,
+    )
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=0,
+            user="alpha old wrong claim",
+            assistant="wrong answer",
+            started=started,
+        )
+    )
+    await engine._wait_for_publication()  # noqa: SLF001
+    specs = {spec.name: spec for spec in engine.tool_profile().tools}
+    forget_spec = specs["forget_memory"]
+    remember_spec = specs["remember_memory"]
+    assert forget_spec.tool_class is not None
+    assert remember_spec.tool_class is not None
+    forget = forget_spec.tool_class(engine, forget_spec)
+    remember = remember_spec.tool_class(engine, remember_spec)
+    token = current_turn_id.set("turn:correction")
+    try:
+        assert json.loads(
+            await forget.execute(message_ids=["message:1"])
+        )["status"] == "staged"
+        assert json.loads(
+            await remember.execute(
+                message_ids=["current_user_message"]
+            )
+        )["status"] == "staged"
+        frame = SimpleNamespace(slots={})
+        owner = SimpleNamespace(
+            context=SimpleNamespace(memory_engine=engine)
+        )
+        await AkashaFeedbackPersistModule(owner).run(frame)
+    finally:
+        current_turn_id.reset(token)
+
+    # 2. Persist those marker fields on the next canonical user Message.
+    correction_time = started + timedelta(minutes=5)
+    user_extra = {
+        key.removeprefix("persist:user:"): value
+        for key, value in frame.slots.items()
+    }
+    _append_turn(
+        sessions,
+        sequence=2,
+        user="beta corrected claim",
+        assistant="correction accepted",
+        started=correction_time,
+        user_extra=user_extra,
+    )
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=2,
+            user="beta corrected claim",
+            assistant="correction accepted",
+            started=correction_time,
+        )
+    )
+    await engine._wait_for_publication()  # noqa: SLF001
+
+    assert engine._runtime.cycle.inhibited_nodes == {0}  # noqa: SLF001
+    correction = engine._runtime.cycle.turns[1]  # noqa: SLF001
+    assert correction.feedback.forget_nodes == (0,)
+    assert correction.feedback.remember_nodes == (1,)
+    with closing(
+        sqlite3.connect(tmp_path / "memory" / "akasha.db")
+    ) as connection:
+        assert connection.execute(
+            """
+            SELECT event_id, action, target_turn_node_id, boost
+            FROM feedback_events
+            ORDER BY event_id, action, target_turn_node_id
+            """
+        ).fetchall() == [
+            (1, "forget", 0, 1.0),
+            (1, "remember", 1, 3.0),
+        ]
+
+    # 3. Future direct-dense and graph completion lanes hide the old turn.
+    recalled = await engine.query(
+        _query(
+            "alpha old wrong claim",
+            correction_time + timedelta(minutes=5),
+            intent="answer",
+        )
+    )
+    assert all(
+        record.id != "message:0::message:1"
+        for record in recalled.records
+    )
+
+    # 4. A clean replay consumes the marker and hashes identically.
+    replay = tmp_path / "memory" / "feedback-replay.db"
+    rebuild_memory(
+        tmp_path / "memory" / "akasha-v2-index.db",
+        replay,
+        target_sequences=(),
+    )
+    assert logical_state_sha256(
+        tmp_path / "memory" / "akasha.db"
+    ) == logical_state_sha256(replay)
+    _close_engine(engine)
 
 
 def test_mobile_recall_card_projection_is_bounded() -> None:
@@ -669,6 +953,7 @@ def _append_turn(
     session_key: str = "test:one",
     with_embeddings: bool = False,
     assistant_tool_chain: str | None = None,
+    user_extra: dict[str, object] | None = None,
 ) -> None:
     assistant_time = started + timedelta(seconds=10)
     with closing(sqlite3.connect(path)) as connection, connection:
@@ -684,7 +969,11 @@ def _append_turn(
                     "user",
                     user,
                     None,
-                    None,
+                    (
+                        None
+                        if user_extra is None
+                        else json.dumps(user_extra)
+                    ),
                     started.isoformat(),
                 ),
                 (

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -107,6 +107,19 @@ def test_feedback_marker_is_exported_before_user_message_persistence() -> None:
 
 
 @pytest.mark.asyncio
+async def test_feedback_persistence_is_inert_when_akasha_is_not_active() -> None:
+    frame = SimpleNamespace(slots={"existing": "value"})
+    owner = SimpleNamespace(
+        context=SimpleNamespace(memory_engine=None)
+    )
+
+    result = await AkashaFeedbackPersistModule(owner).run(frame)
+
+    assert result is frame
+    assert frame.slots == {"existing": "value"}
+
+
+@pytest.mark.asyncio
 async def test_feedback_tools_compose_correction_from_two_markers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -97,7 +97,7 @@ def test_feedback_marker_is_exported_before_user_message_persistence() -> None:
     modules = default_after_reasoning_modules(
         EventBus(),
         cast(Any, SimpleNamespace()),
-        plugin.after_reasoning_modules(),
+        cast(Any, plugin.after_reasoning_modules()),
     )
     slots = [module.slot for module in modules]
 


### PR DESCRIPTION
## Depends on

- kachofugetsu09/akasha-v2-engine#8

This PR pins engine commit `b8e133722e03174494719ab80f1e3349ea752d35`. Merge the engine PR first so the vendored identity remains resolvable.

## Summary

- sync the canonical Akasha Message-feedback implementation without reverting the panel/mobile UI already merged in host PR #238
- expose only `remember_memory` and `forget_memory` to the agent
- require the agent to recall/search, fetch original Messages, and pass stable Message IDs; graph IDs, memory item IDs, and session refs are rejected
- allow `current_user_message` only for remember, so a correction is composed as forget old Message + remember current/correct Message
- export staged markers before `after_reasoning.persist_user`, then let the normal Message persistence boundary store them in `messages.extra`
- remain inert when the Akasha plugin is discovered but another memory engine is active
- preserve online/replay parity and keep `tool_chain` out of the feedback source

## Behavior boundary

- remember strengthens only the target Turns membership in its own episode and normalizes local conductance budgets
- forget leaves the Turn in graph propagation but removes it from dense/completion readout, independent support, and burst context
- forget is not physical Message deletion; the source remains fetchable and auditable

## Verification

- mirror identity check passed: 31 files, exact source tree and SHA-256
- focused Akasha plugin suite: 11 passed
- local full host suite: 2,423 passed, 1 skipped
- strict tests Pyright: 0 errors
- local Docker smoke gate passed after the inactive-engine boundary fix
- all GitHub checks passed, including full check-and-test, Docker control, locked runtime, runtime extension, change impact, contracts, and mobile plugin contract
- engine contract and behavior checks passed against this checkout

No live database, running process, or deployment was changed.