### PR TITLE
fix(akasha): pin merged engine revision

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,6 +1,6 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "b8e133722e03174494719ab80f1e3349ea752d35",
+  "commit": "39d4850ce0fc2a3e55494d9547e31f4f9455f282",
   "source_subtree": "src/akasha",
   "source_tree": "4c05c5efbbad76710c9729164053b1b897148a70",
   "source_sha256": "8f639849d807207e53c88774566c20b9d89fd5c010efc01af0f38cafd7199e91"


### PR DESCRIPTION
## Summary
- update `plugins/akasha/UPSTREAM.json` from the feature branch head to the merged engine revision from akasha-v2-engine#8
- keep the mirrored source tree and digest unchanged

## Why
The strict mirror checker compares the recorded upstream commit with the checked-out engine revision. After merging engine PR #8, the source content is identical but the merge commit identity changed.

## Validation
- `git diff --check`
- `/mnt/data/coding/akasic-agent/.venv/bin/python scripts/check_akasha_v2_mirror.py --upstream /mnt/data/coding/akasha-v2-engine`