### PR TITLE
fix(mobile): render complete Akasha recall lanes

### DIFF
--- a/plugins/akasha/UPSTREAM.json
+++ b/plugins/akasha/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "git@github.com:kachofugetsu09/akasha-v2-engine.git",
-  "commit": "39d4850ce0fc2a3e55494d9547e31f4f9455f282",
+  "commit": "372672ba5575064a24f3bcf4eecd21050b0366c3",
   "source_subtree": "src/akasha",
-  "source_tree": "4c05c5efbbad76710c9729164053b1b897148a70",
-  "source_sha256": "8f639849d807207e53c88774566c20b9d89fd5c010efc01af0f38cafd7199e91"
+  "source_tree": "af0cd675dc073498d0a746f8dde4fc231dd18463",
+  "source_sha256": "a1fc7246940d2c8ab2fa969d0d7b36e98c51dc4541bcc7b38a30005c72270aa9"
 }

--- a/plugins/akasha/mobile_ui.css
+++ b/plugins/akasha/mobile_ui.css
@@ -181,6 +181,8 @@
   gap: 6px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--akasha-mobile-rule);
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 94px;
 }
 
 .akasha-mobile-memories li:last-child {

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -15,7 +15,6 @@ from .inspector import AkashaInspectorReader, mobile_summary
 from .memory_plugin import MemoryPlugin
 
 _MOBILE_RECALL_SCHEMA = "akasha.recall-card.v1"
-_MOBILE_RECALL_MAX_ITEMS_PER_LANE = 5
 _MOBILE_RECALL_USER_PREVIEW_CHARS = 100
 _MOBILE_RECALL_ASSISTANT_PREVIEW_CHARS = 50
 
@@ -224,10 +223,10 @@ def _empty_mobile_recall() -> dict[str, object]:
 def _mobile_recall_lane(
     value: list[dict[str, object]],
 ) -> list[dict[str, object]]:
-    """把 Inspector 行裁成移动卡片真正渲染的有界字段。"""
+    """把语义层已选出的整条 lane 投影成移动卡片字段。"""
 
     projected: list[dict[str, object]] = []
-    for raw in value[:_MOBILE_RECALL_MAX_ITEMS_PER_LANE]:
+    for raw in value:
         item: dict[str, object] = {
             "user_preview": _clip(
                 cast(str, raw["user_text"]),

--- a/tests/test_akasha_mobile_ui.mjs
+++ b/tests/test_akasha_mobile_ui.mjs
@@ -31,11 +31,14 @@ test("Akasha contributes current-turn recall and a mobile Inspector", () => {
 
 test("mobile UI keeps graph out and uses restrained interaction styles", () => {
   assert.doesNotMatch(source, /akasha-graph|graph\.(global|query|rebuild)/);
+  assert.doesNotMatch(source, /\.slice\(/);
   assert.doesNotMatch(styles, /linear-gradient|radial-gradient|backdrop-filter/);
   assert.doesNotMatch(styles, /transition:\s*all|transition-property:\s*all/);
   assert.match(styles, /color-mix\(in oklch/);
   assert.match(styles, /min-height:\s*44px/);
   assert.match(styles, /scale:\s*0\.96/);
+  assert.match(styles, /content-visibility:\s*auto/);
+  assert.match(styles, /contain-intrinsic-block-size:\s*auto 94px/);
 });
 
 test("recall lanes use distinct Material tonal semantics", () => {

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -379,7 +379,7 @@ async def test_feedback_markers_change_future_recall_and_replay_identically(
     _close_engine(engine)
 
 
-def test_mobile_recall_card_projection_is_bounded() -> None:
+def test_mobile_recall_card_projection_preserves_bounded_lanes() -> None:
     lane = _mobile_recall_lane(
         [
             {
@@ -389,7 +389,7 @@ def test_mobile_recall_card_projection_is_bounded() -> None:
                 "ts": "2026-07-28T00:00:00Z",
                 "score": 0.5,
             }
-            for _ in range(20)
+            for _ in range(40)
         ]
     )
     card = {
@@ -402,7 +402,7 @@ def test_mobile_recall_card_projection_is_bounded() -> None:
         "tool_right": lane,
     }
 
-    assert len(lane) == 5
+    assert len(lane) == 40
     assert all(len(str(item["user_preview"])) == 103 for item in lane)
     assert all(len(str(item["assistant_preview"])) == 53 for item in lane)
     assert "assistant_text" not in json.dumps(card, ensure_ascii=False)
@@ -414,7 +414,7 @@ def test_mobile_recall_card_projection_is_bounded() -> None:
                 separators=(",", ":"),
             ).encode("utf-8")
         )
-        < 16 * 1024
+        < 192 * 1024
     )
 
 

--- a/tests_scenarios/mobile_isolated_gateway.py
+++ b/tests_scenarios/mobile_isolated_gateway.py
@@ -240,7 +240,7 @@ class IsolatedAkashaMobileUiProvider:
                     "ts": "2026-07-28T00:00:00Z",
                     "score": 0.5,
                 }
-                for _ in range(20)
+                for _ in range(40)
             ]
         )
         result: dict[str, object] = {
@@ -257,8 +257,8 @@ class IsolatedAkashaMobileUiProvider:
             ensure_ascii=False,
             separators=(",", ":"),
         ).encode()
-        if len(encoded) >= 16 * 1024:
-            raise RuntimeError("隔离 Akasha card 超过 16 KiB")
+        if len(encoded) >= 192 * 1024:
+            raise RuntimeError("隔离 Akasha card 超过 192 KiB")
         return result
 
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha mobile DTO 在领域召回之后再次把每条 lane 裁成五条。
- 用户可见结果：移动端收到并创建上游 lane 的全部 N 个列表项；长列表通过离屏 layout/paint 保持滚动和首屏性能。
- 本 PR 不处理：召回算法、排序、Agent Prompt、桌面 Inspector 或持久状态。

Contract #241 and upstream kachofugetsu09/akasha-v2-engine#9 are merged.

## Change intent

- `change_type`：fix
- `semantic_delta`：compatible
- `capability_owner`：plugin
- `consumer_scope`：Akasha mobile recall card
- `runtime_patch`：required
- `runtime_patch_reason`：内建 Akasha 插件由 Agent 仓库镜像并由既有 plugin mobile query 路径发布。
- `authoritative_state_owner`：Akasha lane producer；Mobile 只展示 DTO。
- `client_only_alternative`：不可行，客户端无法恢复服务端 top-5 后丢失的条目。
- 关联不变量：MOB-006、PLG-011、TST-006～TST-008
- `protected_state`：sessions、Akasha 图、召回排序、Agent Prompt、桌面 Inspector
- 允许的副作用：响应与 DOM 随有界 N 增长。
- 禁止的副作用：尾部丢弃、分页、图写入、协议 schema 变化。

## 改动范围

- 主要文件：`plugins/akasha/plugin.py`、`mobile_ui.css` 和对应测试/Gateway fixture
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：`akasha.recall-card.v1` 不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：upstream `372672ba5575064a24f3bcf4eecd21050b0366c3` / source tree `af0cd675dc073498d0a746f8dde4fc231dd18463`
- 回滚方式：revert `11b37c2f2a9f0a3d6caddad4acbe45966dc8f33e`，无数据回滚。

## 性能证据

- 真实库中实际 Agent 自动 lane 上界为左 5 / 右 40；历史 tool lane 最大左 38 / 右 37。
- 四条 lane 各 40 条最坏 Unicode 预览：160 项全部保留，110,373B；低于 192KiB response boundary。
- 每个 list item 使用 `content-visibility: auto` 与 intrinsic block size，DOM 保留全部 N 条，离屏项延后 layout/paint。

## 验证

- [x] `pytest tests/test_akasha_plugin.py tests/mobile_realtime tests/semantic/test_project_workflow_contract.py -q`：205 passed
- [x] `node --test tests/test_akasha_mobile_ui.mjs`：3 passed
- [x] upstream full suite：53 passed
- [x] Akasha mirror Gate：31 files byte-identical
- [x] `python docker/debug/gate.py run --base origin/main` 已通过 8 个公开场景
- `sourceDigest`：`375d36544bc16241d5d42292fdae76d6a6d47f71031e8f84387190045789ebd5`
- `planDigest`：`4cbfc932c83e5057812a569674ae1c72ab113b983d705ea633c9e524390490fb`
- `private-contract-gate`：pending_maintainer
- 真实设备证据：未运行；没有触碰正式设备，隔离 Gateway fixture 已更新并由 public Gate 覆盖。
- 未运行项与原因：ruff 未安装在仓库 venv；相关 pytest、Node、镜像和 Docker Gate 均通过。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义由已合并 #241 单独批准。
- [x] 已按 MOB-001 核对能力 owner。
- [x] 当前没有对应 NOW 事项。