### PR TITLE
docs: define benchmark diagnostic contract

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -109,7 +109,7 @@
 | Workspace、配置、凭据、迁移、备份 | `projectneed` 第 6、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [0005](decisions/0005-git-cursor-drives-one-shot-migrations.md) → [迁移维护手册](design/git-migration-authoring.md) → [Git 一次性迁移设计](spark/2026-07-21-git-backed-one-shot-migrations-design.md) | `main.py`、`bootstrap/init_workspace.py`、`agent/config.py`、`agent/migrations/`、`migrations/`、`agent/model_runtime/auth/store.py`、`scripts/rolling_backup.py` |
 | 高风险 refactor、语义不变重构、CI oracle | `projectneed` 第 4～6、13～14 节 → [综合重构账本](refactor/clean-code-ledger.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → 相关决策 | 改动前后的完整 diff、semantic tests、write set、故障注入 |
 | 变更影响 Gate、跨仓库插件契约 | `projectneed` 第 10、13～14 节 → [0004](decisions/0004-cross-repository-evidence-is-an-immutable-combination.md) → [移动端与跨仓库 Gate](design/mobile-cross-repository-semantic-gate.md) → [Gate 总体设计](spark/2026-07-16-change-impact-contract-gate.md) → [持久化状态地图](design/persistence-state-map.md) | `tests_scenarios/contracts/`、`docker/debug/gate.py`、`private_runtime/` |
-| Harness benchmark、独立 runtime trial、证据驱动优化 | `projectneed` 第 8～14 节 → [V4 Flash Harness Benchmark 设计](spark/2026-07-30-v4flash-harness-benchmark-design.md) → [实验 ledger](benchmark/v4flash-harness-experiment-ledger.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/control/`、`bootstrap/control_execution.py`、`docker/debug/`、一次性 workspace 与 experiment ledger |
+| Harness benchmark、独立 runtime trial、证据驱动优化 | `projectneed` 第 8～14 节 → [V4 Flash Harness Benchmark 设计](spark/2026-07-30-v4flash-harness-benchmark-design.md) → [Benchmark 诊断循环设计](spark/2026-07-30-agent-benchmark-diagnostic-loop-design.md) → [0010](decisions/0010-provider-default-output-and-benchmark-diagnostics.md) → [实验 ledger](benchmark/v4flash-harness-experiment-ledger.md) → [持久化状态地图](design/persistence-state-map.md) | `benchmark/harbor_v4flash/`、`agent/control/`、`bootstrap/control_execution.py`、`docker/debug/`、独立 artifact store 与 experiment ledger |
 | 移动端、客户端协议、跨仓库 runtime patch 或 stacked PR 评审 | `projectneed` MOB-001～MOB-006、GOV-001～GOV-005、TST-001～TST-008 → [0003](decisions/0003-core-capability-ownership-is-semantic.md) → [0004](decisions/0004-cross-repository-evidence-is-an-immutable-combination.md) → [0007](decisions/0007-mobile-plugin-control-and-data-planes-are-explicit.md) → [0009](decisions/0009-akasha-mobile-recall-preserves-semantic-lanes.md) → [移动端与跨仓库 Gate](design/mobile-cross-repository-semantic-gate.md) → [`templates/review-contract.md`](templates/review-contract.md) | 每层 `base..head`、最终累计 diff、所有 schema lineage、协议 source、runtime/provider/scenario identity 和设备隔离证据 |
 | 新增或修改项目文档 | 本索引 → [`writing-rules.md`](writing-rules.md) → 目标文档的权威上游 | 所有相对链接、重复规则、过时入口和 Git diff |
 | Dashboard、Chat UI | `projectneed` 公共合同 → `NOW.md` 对应事项 → 相关设计 | `frontend/**/src`、真实构建和渲染结果 |
@@ -189,7 +189,8 @@ docs/
 │   ├── 0006-akasha-v2-is-the-canonical-explicit-memory-engine.md
 │   ├── 0007-mobile-plugin-control-and-data-planes-are-explicit.md
 │   ├── 0008-plugin-runtime-publishes-only-committed-snapshots.md
-│   └── 0009-akasha-mobile-recall-preserves-semantic-lanes.md
+│   ├── 0009-akasha-mobile-recall-preserves-semantic-lanes.md
+│   └── 0010-provider-default-output-and-benchmark-diagnostics.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── mobile-cross-repository-semantic-gate.md
@@ -201,7 +202,8 @@ docs/
 │   ├── 2026-07-16-change-impact-contract-gate.md
 │   ├── 2026-07-21-web-settings-provider-switching-design.md
 │   ├── 2026-07-21-git-backed-one-shot-migrations-design.md
-│   └── 2026-07-30-v4flash-harness-benchmark-design.md
+│   ├── 2026-07-30-v4flash-harness-benchmark-design.md
+│   └── 2026-07-30-agent-benchmark-diagnostic-loop-design.md
 ├── refactor/
 │   └── clean-code-ledger.md
 └── templates/

--- a/docs/decisions/0010-provider-default-output-and-benchmark-diagnostics.md
+++ b/docs/decisions/0010-provider-default-output-and-benchmark-diagnostics.md
@@ -1,0 +1,45 @@
+# 0010 · Provider 默认输出边界与 Benchmark 诊断边界
+
+- 状态：accepted
+- 日期：2026-07-30
+- 关联条款：RUN-006、TST-009
+- supersedes：无
+- superseded by：无
+
+## 背景
+
+Akasic 已经支持以 `max_output_tokens = 0` 省略 provider 输出上限字段，但配置模型、缺省加载、安装向导和设置界面仍使用 `8192`。这一默认值会在长工具任务中提前截断 runtime，掩盖 Agent 是否能够完成任务。
+
+Terminal-Bench 2.1 的 89 个 case 可以暴露 Agent 与 harness 的工程故障，也会带来按公开题目刷分、混合无效 run 和把模型问题误判成 runtime 问题的风险。维护者已批准把这些 case 用作诊断探针，而不是产品目标或自动自优化器。
+
+## 决定
+
+新建或缺省配置使用 `max_output_tokens = 0`，请求端不发送 provider 输出上限字段。显式正整数继续代表用户选择的上限，存量正整数不自动迁移；负数在配置边界失败。内部 summary 等小任务继续拥有独立局部上限。
+
+Benchmark 控制面只负责隔离运行、封存证据、归因、消融和候选 Gate。每个 attempt 使用独立 Docker runtime 与 workspace；分析只读取终态证据。生产修改必须解释不依赖具体 case 的现实价值，优化后的完整 89 题 eval 只在维护者再次明确授权后运行。
+
+## 理由
+
+由 provider 拥有缺省输出边界可以避免 Agent 在不知情时被固定应用层上限截断，同时保留显式成本和延迟控制。局部内部任务继续有界，避免把主 runtime 的选择扩散到无关调用。
+
+把 benchmark 定义成诊断输入而非目标函数，可以保留失败样本的工程价值，又不允许 task-specific 条件、选择性拼分或降低 verifier 约束进入生产代码。独立的 reality controls 和项目 Gate 承担泛化判断。
+
+## 影响
+
+- 正面影响：长工具任务默认不再受应用层 `8192` 输出上限；89 个 case 可以形成可审计的 Agent/harness 故障样本。
+- 兼容性：显式正整数配置保持原值；`0` 仍受 provider/model 自身边界约束。
+- 数据和迁移：不自动改写任何正式 workspace 或存量配置；benchmark evidence 写入独立 artifact store，不进入长期记忆。
+- 失败与回滚：默认值实现可回退到本决定前 commit；每个 benchmark 候选和失败 attempt 独立留痕，不通过修改 oracle 获得全绿。
+
+## 验收
+
+- [ ] 缺省配置、setup wizard 和 settings UI 都生成 `0`，显式正整数保持不变，负数失败。
+- [ ] provider 请求在值为 `0` 时省略输出上限字段，正整数时继续发送。
+- [ ] summary 等局部内部调用仍保持独立上限。
+- [ ] 诊断控制面限制最多三个独立 attempt，封存终态后才允许归因，并保留 invalid 与有效失败的差别。
+- [ ] 超过五次的重复尝试要求新的可证伪证据，不能机械重试。
+- [ ] 正式完整 89 题 eval 不属于自动调度动作。
+
+## 未决问题
+
+- 全部 89 题初始诊断结束后，停止容器、volume 和冷证据的删除范围由维护者另行批准。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,6 +15,7 @@
 | [0007](0007-mobile-plugin-control-and-data-planes-are-explicit.md) | accepted | 移动插件控制面与查询数据面显式分离 | MOB-001、MOB-003、MOB-006、PLG-003、PLG-011、TST-006～TST-008 |
 | [0008](0008-plugin-runtime-publishes-only-committed-snapshots.md) | accepted | 插件运行时只发布已提交快照 | PLG-001～PLG-008、GOV-005、TST-006～TST-008 |
 | [0009](0009-akasha-mobile-recall-preserves-semantic-lanes.md) | accepted | Akasha 移动卡片完整保留有界召回 lane | MOB-006、PLG-011、TST-006～TST-008 |
+| [0010](0010-provider-default-output-and-benchmark-diagnostics.md) | accepted | Provider 默认输出边界与 Benchmark 诊断边界 | RUN-006、TST-009 |
 
 ## 新增规则
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -363,6 +363,12 @@ AgentLoop 唯一拥有活动 turn task 的取消和 cleanup。无论成功、失
 
 内建 provider 的默认端点、输入模态、模型家族协议和请求字段映射由 core runtime 的 provider profile 拥有。模型目录可以在初始化时动态读取；同一已知 Chat Completions 家族的新版本无需维护静态型号表。使用其他 wire protocol 的家族和未知家族必须在配置边界 fail-closed，不能试发、静默 fallback 或把目录结果持久化成新的权威状态。
 
+### RUN-006 模型输出上限显式区分 provider 默认值
+
+新建配置和缺少该字段的配置默认使用 `max_output_tokens = 0`。`0` 表示请求不发送 provider 的输出 token 上限字段，由 provider 和模型自身边界负责；它不表示无限输出。正整数继续表示显式输出上限，负数在配置边界 fail-fast。已经显式配置正整数的存量配置必须保持原值，不能因默认值变化被自动改写。
+
+主 runtime 的默认值不拥有 summary、标题生成或其他内部小任务的局部预算。内部任务可以继续使用独立正整数上限，主 runtime 为 `0` 时不能把这些局部上限一并取消。
+
 ### OUT-001 被动按 Turn 提交，主动按送达提交
 
 被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，user 与 assistant 消息共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
@@ -542,6 +548,12 @@ P0 不变量必须由受保护的 semantic test、policy 或黑盒观察器验�
 `adb shell am instrument` 的进程退出码不能单独充当 oracle；Gate 必须核对声明的测试数量、指定方法、开始/成功状态和失败标记，0 test、crash、aborted 或 assertion failure 都不能记为通过。测试阶段通过后仍不能提前声明 Gate 通过；清理完成后才能写唯一终态。清理失败必须非零退出、标记 `gate_result=failed_cleanup` 并列出残留 package。
 
 正式应用及设备上既有 package 属于受保护状态。Gate 必须记录测试前后的 package、版本、安装身份和可观察数据身份，且不得覆盖、卸载、清空或连接正式应用状态。`base.apk` 只能恢复 binary，不能代替 app data 备份；若任务确实需要触碰既有 package，必须另获授权并先取得经过恢复演练的数据级备份，否则 blocked。测试结束还要证明 run-specific app/test package、ADB reverse、容器和测试 workspace 已清理。CI 继续承担固定逻辑的可重复 Gate，维护者设备只补充 OS lifecycle、Room migration、通知、文件系统和真实 Compose 交互证据。涉及实时 Gateway 的设备证据还必须绑定 Mobile Lab core SHA、run ID 和非正式配对来源；客户端 package 隔离不能证明服务端 workspace 已隔离。
+
+### TST-009 Benchmark 只作为通用故障诊断探针
+
+公开 benchmark case 可以用于发现 Agent 和 harness 的通用功能缺陷、鲁棒性问题、模型边界和环境问题，但不得驱动 task name、题面、expected output 或 verifier 特化的生产行为。Scoring runtime 每个 attempt 使用独立 runtime 与 workspace，封存终态证据后分析；基础设施无效、模型能力不足、task 问题、功能性 bug、鲁棒性优化和行为语义改变必须分开归因。
+
+诊断结果不能从不同 candidate 或 attempt 选择最好结果后拼成总分。生产候选必须先用与 benchmark 无关的 synthetic、现实 control 和项目 Gate 证明通用机制；行为语义改变先单独批准。优化后的正式完整 eval 只有维护者明确授权后才能从冻结 artifact 重新运行。
 
 ## 14. 需求变更流程
 

--- a/docs/spark/2026-07-30-agent-benchmark-diagnostic-loop-design.md
+++ b/docs/spark/2026-07-30-agent-benchmark-diagnostic-loop-design.md
@@ -1,0 +1,458 @@
+# Akasic Agent Benchmark 诊断与持续改进循环设计
+
+日期：2026-07-30
+
+状态：用户已逐节批准，实施中
+
+关联设计：
+
+- [V4 Flash 完整 Runtime Harness Benchmark 设计](2026-07-30-v4flash-harness-benchmark-design.md)
+- [V4 Flash Harness 实验 Ledger](../benchmark/v4flash-harness-experiment-ledger.md)
+
+## 1. 目标
+
+本系统使用 Terminal-Bench 2.1 的 89 个 case 发现 Akasic Agent 与 harness 的通用
+工程问题，持续完成以下循环：
+
+1. 在独立环境中运行真实 Akasic + Akasha。
+2. 封存 trace、runtime、verifier、usage 和隔离证据。
+3. 让只读分析 agent 提出可证伪假设。
+4. 由 Root Coordinator 审核归因、实验和停止条件。
+5. 实施最小通用候选。
+6. 通过 synthetic、case 消融、现实 controls 和项目 Gate 验证。
+7. 对成立的功能性修复或鲁棒性优化提交 draft PR。
+8. 对失败方向、模型边界、task 问题和语义待定项同等留痕。
+
+Terminal-Bench 是工程诊断探针，不是产品目标。优化阶段不追求、计算或发布一个由不同
+candidate、不同 attempt 最好结果拼成的总分。
+
+最终完整 89 题 eval 不属于自动循环。只有用户明确授权后，才冻结最终 artifact，
+从零运行一次完整协议。
+
+## 2. 非目标与禁止行为
+
+本设计明确不做：
+
+- 为提高 Terminal-Bench 分数添加 task name、题面内容或 expected output 检测。
+- 把 task 解法、文件名、命令、flag、verifier 细节写进生产代码或 prompt。
+- 读取隐藏 verifier 来推导生产行为。
+- 修改 dataset、task、verifier、reward、资源或 timeout 来制造提升。
+- 选择性拼接多个 attempt 的最好结果。
+- 把 invalid infra attempt 解释为模型或 Agent 能力失败。
+- 为难以解决的 case 无限重复相同尝试。
+- 把单题翻转直接宣传为通用 Agent 改进。
+- 让 scoring runtime 读取其他 case 的 trace、分析结论或共享 Akasha。
+- 在用户授权前执行优化后的正式完整 89 题 eval。
+- 自动合并 PR、修改正式 workspace 或切换线上 runtime。
+
+所有生产改动都必须能够在不提 Terminal-Bench 的情况下解释其现实价值。
+
+## 3. 已批准的长期配置语义
+
+`max_output_tokens` 的默认值改为 `0`：
+
+- `0` 表示请求不发送 provider output-token 参数，由 provider/model 自身边界负责。
+- `0` 不表示模型拥有无限输出。
+- 正整数继续表示显式输出上限。
+- 负数在配置边界 fail-fast。
+- 缺少该字段的新配置、setup wizard、settings UI 和 runtime config 默认使用 `0`。
+- 已经显式配置正整数的存量配置不自动改写。
+- summary、标题生成或其他内部小任务可以继续拥有独立局部上限；这些局部上限不能被
+  主 runtime 的 `0` 意外取消。
+
+这是行为语义改变，不伪装成普通重构。用户已批准该默认变化。实施时同时更新
+`projectneed` 的增量默认规则和存量配置解释。
+
+## 4. 系统架构与角色
+
+```text
+┌──────────────────────────────────────────────────┐
+│ Root Coordinator / LLM Gate                      │
+│ 冻结协议、调度任务、审核归因、批准实验、决定停止 │
+└───────────────┬──────────────────────────────────┘
+                │ 最多并发 3
+       ┌────────┼────────┐
+       ▼        ▼        ▼
+┌──────────┐ ┌──────────┐ ┌──────────┐
+│ Case A   │ │ Case B   │ │ Case C   │
+│ 独立容器 │ │ 独立容器 │ │ 独立容器 │
+│ 独立Akasha│ │ 独立Akasha│ │ 独立Akasha│
+└────┬─────┘ └────┬─────┘ └────┬─────┘
+     │ terminal 后封存，不实时干预
+     └─────────────┼─────────────┘
+                   ▼
+┌──────────────────────────────────────────────────┐
+│ Evidence Store                                   │
+│ trace、payload、usage、runtime、verifier、identity│
+└───────────────┬──────────────────────────────────┘
+                ▼
+┌──────────────────────────────────────────────────┐
+│ Terra High Analysis Pool                         │
+│ 每个副手只读一个 case 或一个故障簇               │
+└───────────────┬──────────────────────────────────┘
+                ▼
+┌──────────────────────────────────────────────────┐
+│ Root LLM Gate                                    │
+│ 复核结论，合并共同根因，拒绝 benchmark hack      │
+└───────────────┬──────────────────────────────────┘
+                ▼
+┌──────────────────────────────────────────────────┐
+│ 独立实现 Worktree                                │
+│ 一个通用机制、一个 writer、可审阅 commit         │
+└───────────────┬──────────────────────────────────┘
+                ▼
+┌──────────────────────────────────────────────────┐
+│ Synthetic + Ablation + Controls + CI Gate        │
+└───────────────┬──────────────────────────────────┘
+                ▼
+        Draft PR 或失败实验归档
+```
+
+### 4.1 Root Coordinator / LLM Gate
+
+Root 是唯一实验调度者和最终归因 owner，职责包括：
+
+- 冻结每个 attempt 的 candidate、配置、环境和 task identity。
+- 控制三个 Docker slot。
+- 指派只读 trace 分析。
+- 核对分析 agent 的证据、反例和代码 owner。
+- 判断问题分类、实验是否可证伪、是否继续尝试。
+- 阻止 benchmark-specific 修改。
+- 审核语义 delta、现实泛化证据和 PR 范围。
+- 维护跨 case failure cluster。
+
+分析 agent 的输出只是建议，不能自动触发代码修改。
+
+### 4.2 Case Runtime
+
+每个 attempt 使用独立 Docker 容器、workspace、HOME、配置、Akasha 和 runtime：
+
+- 只接收标准 task instruction。
+- 不接收其他 case 的 trace 或分析结论。
+- 不共享 scoring Akasha。
+- 不挂载正式 workspace 或 Docker socket。
+- 不发布 host port。
+- 任务进行期间不接受候选代码更新。
+- 完成后先停止但不删除。
+
+### 4.3 Analysis Pool
+
+默认使用 Terra High 分析已封存 trace：
+
+- 一个副手只读一个 case 或一个明确故障簇。
+- 只输出证据、分类、假设、反例、最小复现和停止建议。
+- 不修改 scoring 容器、verifier、task 或候选 worktree。
+- 不在 attempt 结束前读取实时 pass/fail 并指导当前模型。
+- 不把 task 解法写入生产建议。
+
+父 agent 必须复核真实 trace 与代码，不能以多数投票替代判断。
+
+### 4.4 实现与评审
+
+- 每个候选使用独立 Git worktree。
+- 同一语义合同、PR 和权威文档同时只有一个 writer。
+- 一个 candidate 只测试一个通用机制。
+- 独立只读 reviewer 检查 diff、权限、写集合、错误语义和 benchmark 特化。
+
+## 5. Attempt 有效性 Gate
+
+任何失败归因前，先证明 attempt 有效：
+
+1. dataset、task、image、verifier 和资源身份正确。
+2. candidate commit/tree、source digest 和 runtime config 已记录。
+3. 实际 model route、effort 和请求策略已记录。
+4. Akasic turn、tool lifecycle 和 terminal 状态可读取。
+5. trace、usage、runtime log、verifier 和 result artifact 齐全。
+6. 容器停止，正式 workspace、线上 PID 和源码摘要未变化。
+
+失败处理：
+
+- runner、镜像、网络、provider 或 setup 失败标记为 `invalid_infra`。
+- turn 已持久化但 terminal notification 丢失时，记录 delivery gap，并用权威
+  `turn/read` 收束；backpressure 作为独立问题保留。
+- 中断 attempt 永不与后来重跑结果拼接。
+- invalid attempt 不完成该 case 的首次扫描，修复后需要重新运行。
+
+## 6. 证据模型
+
+每个有效 attempt 至少记录：
+
+- case、attempt、generation 和 run identity。
+- candidate commit、tree、bundle/image/container digest。
+- task/image/verifier/dataset identity。
+- 实际模型 route、effort、payload policy 和响应元数据。
+- terminal、exception、verifier、duration 和 usage。
+- 工具调用序列与 task 文件实际变化。
+- 最后一次有效进展、重复动作与停止原因。
+- trace、runtime log、workspace snapshot 和 checksum。
+- analyzer 结论、反例与置信度。
+- Root Gate 最终分类。
+- 关联 hypothesis、candidate、PR 或停止记录。
+
+不同 candidate/generation 的 evidence 可以共同用于诊断，但不能拼成一个分数。
+
+## 7. 故障分类
+
+失败归因与候选语义变化分开记录。
+
+| 分类 | 证据门槛 | 自动处理 |
+|---|---|---|
+| Harness 功能性 bug | 违反已有合同；无模型或受控模型可稳定复现 | 修复、测试、消融、draft PR |
+| 鲁棒性优化 | 存在通用可恢复路径；不掩盖永久错误 | 最小候选、controls、现实泛化 |
+| 行为语义改变 | 改变权限、重试/费用、停止、上下文、记忆、持久化或用户结果 | 已确认项可实施；不确定项延后 |
+| LLM 能力不足 | runtime、工具、提交链正常；失败来自规划、推理或执行 | 记录，不为提分改 harness |
+| Task/环境问题 | 题面、镜像、资源或 verifier 无法一致满足 | 留证，不算 Akasic 修复 |
+| 证据不足 | trace 不完整或多个根因不可区分 | 改善观测或设计新 reproduction |
+
+### 7.1 功能性 bug
+
+必须指出：
+
+- 被违反的现有合同。
+- 真实可达的触发路径。
+- 当前错误如何导致 case 失败。
+- 无 Terminal-Bench 解法的最小复现。
+- 修复前后错误、持久化和外部副作用。
+
+### 7.2 鲁棒性优化
+
+如果新实现保留所有旧的合法输入、权限、失败暴露、持久化和取消语义，只扩大成功处理
+范围，则可以称为鲁棒性优化。
+
+如果扩大成功范围需要更多请求、费用、等待、权限或不同终态，则仍有行为语义 delta，
+不能仅因更容易成功而称为纯优化。
+
+### 7.3 行为语义改变
+
+- 已由用户确认的变化可以进入实现、`projectneed` 和 PR。
+- Root 能明确从已有合同推出的修复按对应 bug/优化流程处理。
+- Root 仍拿不准的变化可以在隔离实验分支验证，但不进入 incumbent、不提生产 PR、
+  不更新长期需求。
+- 所有不确定项进入 `semantic-pending`，89 题扫描完成后统一与用户讨论。
+
+## 8. 调度策略
+
+系统维护两条共享三个 Docker slot 的队列：
+
+```text
+Discovery Queue                 Validation Queue
+尚未扫描的 89 个 case           已有明确假设的 case + controls
+        │                               │
+        └──────────┬────────────────────┘
+                   ▼
+           Scheduler，max=3
+```
+
+默认调度：
+
+- `2 discovery + 1 validation`。
+- 没有成熟假设时，三个 slot 都扫描未见 case。
+- 出现会让大量 attempt 无效的基础设施问题时，暂停新任务并先恢复有效性。
+- trace 分析不占 Docker slot。
+- 已失败 case 的重复尝试不能长期挤占尚未扫描 case，除非它阻塞所有任务。
+
+每个 attempt 使用启动时冻结的 candidate。incumbent 更新只影响之后创建的实例。
+优化阶段允许不同 case 属于不同 generation，但必须显式记录，且不得汇总为统一成绩。
+
+## 9. 单 case 实验循环
+
+1. 完成第一次有效 discovery run。
+2. 封存 evidence。
+3. Terra 分析 trace。
+4. Root Gate 归因并建立一个 falsifiable hypothesis。
+5. 没有明确 harness hypothesis 时不盲目重跑。
+6. 先做 synthetic 或 fault-injection reproduction。
+7. 在独立 worktree 实施单一最小 candidate。
+8. 重跑受影响 case，并加入至少一个稳定 control。
+9. 比较机制证据、task 行为、usage、异常和现实影响。
+10. 决定保留、修改、回滚、待定或关闭。
+
+### 9.1 尝试次数
+
+单个 case 不设机械 attempt 上限。
+
+从第六次 attempt 开始，每次继续前必须有 escalation record：
+
+- 前五次分别排除了什么。
+- 新增了什么 trace、机制、反例或最小复现。
+- 为什么仍属于 harness，而不是 LLM、task 或语义待定。
+- 这次实验与前一次的唯一因果差异。
+- 继续尝试的现实泛化价值。
+
+以下情况关闭当前方向：
+
+- 最近两次尝试没有增加信息。
+- 无法建立稳定的最小复现。
+- 唯一剩余方案是 task-specific patch。
+- controls 出现受保护语义回归。
+- 证据支持 LLM 能力不足或 task 问题。
+- 需要用户决定的语义改变。
+
+关闭不是永久删除。后续跨 case 的新证据可以重新打开。
+
+## 10. 故障簇与优先级
+
+多个题面不同的 case 如果共享同一机制，合并成一个 failure cluster。
+
+优先级：
+
+1. 会让 trial 无效、trace 丢失或产生假成功的基础设施/harness bug。
+2. 同时影响多个 case 的功能性缺陷。
+3. 可能造成现实任务数据损坏、错误执行、无限循环或静默失败的问题。
+4. 通用鲁棒性、成本和效率问题。
+5. 单 case、低置信度问题。
+6. LLM 能力不足和 task-specific 问题只记录。
+
+PR 的单位是通用机制，不是 case。
+
+## 11. 消融与现实泛化
+
+每个候选按以下顺序晋级：
+
+```text
+机制 reproduction
+  → candidate vs candidate-without-feature
+  → 受影响 case
+  → 稳定 controls
+  → 无 TB 解法的现实 shadow scenario
+  → 项目 semantic Gate
+```
+
+现实 shadow scenario 应覆盖问题机制，而不是复制 task：
+
+- 长工具输出。
+- 慢任务或后台进程。
+- provider 短暂失败。
+- 断线或迟到 terminal event。
+- context/compaction 后继续执行。
+- 工具调用格式错误。
+- 取消、重启或恢复。
+- 持久状态和外部副作用。
+
+没有机制证据的单题翻转只算相关性，不足以保留候选。
+
+## 12. CI、Review 与 PR Gate
+
+每个保留候选至少通过：
+
+- 直接相关单元测试和集成测试。
+- Pyright/typecheck 和仓库要求的 lint。
+- Change-impact public Gate。
+- 所需 private Gate 的准确状态。
+- 独立只读 cumulative diff review。
+- 正式 workspace、线上 PID、源码和外部插件不变检查。
+- task ID、expected output、verifier path、Terminal-Bench prompt 和条件分支搜索。
+
+PR 要求：
+
+- 一个 draft PR 只承载一个通用机制。
+- case 名只能出现在证据和实验记录，不得成为生产条件。
+- 描述问题、失败路径、修改、消融、现实泛化和语义 delta。
+- 功能性 bug 和鲁棒性优化必须明确区分。
+- 不确定的行为语义改变不提生产 PR。
+- 不自动 merge。
+
+## 13. 文档与状态 owner
+
+| 文档或对象 | 负责内容 |
+|---|---|
+| `experiment-ledger` | 每个 attempt、失败、消融、usage 和决策 |
+| `failure-catalog` | 跨 case 故障簇、影响面、owner 和状态 |
+| `hypothesis-registry` | 假设、反例、实验次数、继续或停止理由 |
+| `semantic-pending` | 最终需要用户确认的语义变化 |
+| PR | 已保留机制的可审阅实现与验证 |
+| `projectneed` | 已确认的长期产品语义 |
+| artifact store | 大 trace、workspace、payload 和容器证据 |
+
+实验文档不能把分数或临时假设升级成产品需求。
+
+实施阶段确认更新 `projectneed`：
+
+1. `max_output_tokens=0` 的 provider-default 长期语义及存量兼容规则。
+2. Benchmark 用于发现通用 Agent/harness 缺陷，不得驱动 task-specific 生产行为；
+   行为语义改变与纯鲁棒性优化必须区分。
+
+## 14. 状态机与恢复
+
+```text
+prepared
+   → running
+   → terminal_sealed
+   → analysis_pending
+   → classified
+   → experiment_active
+   → closed_fixed / closed_model / closed_task
+                  / closed_no_evidence / semantic_pending
+```
+
+- analyzer 失败只重启分析，不重跑 case。
+- candidate 测试失败保留 diff 和 evidence，不修改 oracle 获取全绿。
+- 正式 workspace、线上 PID 或源码摘要变化时停止调度，进入只读事故调查。
+- Docker 地址池、磁盘或 provider 可用性危及证据时暂停发新任务，不中止正常收束中的
+  attempt。
+- 所有重启、恢复和 aggregate repair 都必须显式记录，不能伪装成原 run 自然完成。
+
+## 15. Evidence 保留策略
+
+采用用户批准的策略 A。
+
+### Hot evidence
+
+- 停止的 container。
+- volume 和独立 workspace。
+- runtime stdout/stderr 和完整现场。
+
+### Cold evidence
+
+- trace、payload 摘要、usage 和 verifier。
+- manifest、源码/image/container identity。
+- 文件 checksum、归因和实验记录。
+
+规则：
+
+- attempt 完成后 stop-retain。
+- 问题关闭后完成 cold archive，但 container 仍保留。
+- 89 题初始扫描完成前不自动删除 container 或 volume。
+- 空且无 endpoint 的 benchmark network 可以在记录后删除，以释放 Docker 地址池。
+- 全部扫描结束后汇总磁盘占用、待定问题和保留价值，再由用户批准是否删除。
+
+## 16. 89 题完成条件
+
+自动诊断阶段只有同时满足以下条件才结束：
+
+- 89 个 case 都至少完成一次有效 discovery attempt。
+- 所有 invalid case 已重跑或有明确外部 blocker。
+- 所有 failure cluster 已处于 fixed、model、task、no-evidence 或
+  semantic-pending。
+- 没有仍在运行、未封存或无人归因的 attempt。
+- 所有保留修复都有 synthetic、消融、controls、现实泛化和 CI evidence。
+- 所有失败方向都有停止理由。
+- draft PR、failure catalog、experiment ledger 和 semantic-pending 已对账。
+- 正式 workspace 和线上 runtime 未受影响。
+
+随后向用户提交：
+
+- 已修复的通用问题及 PR。
+- 失败实验和回滚。
+- LLM 能力边界。
+- Task/环境问题。
+- 不确定的行为语义改变。
+- 仍未解决的问题及继续成本。
+- 容器、volume 和 artifact 保留清单。
+
+Root 不自动启动优化后完整 89 题 eval。只有用户审阅上述结果并明确授权后，才建立
+独立 final-eval 合同。
+
+## 17. 验收标准
+
+本设计的成功不以 Terminal-Bench 分数定义，而以流程和产品证据定义：
+
+- 所有 89 个 case 被用作独立故障探针。
+- 每个生产修改都对应可复现的通用机制。
+- 没有 task-specific hack、选择性拼分或隐藏无效 run。
+- 功能性 bug、鲁棒性优化和行为语义改变被准确区分。
+- 超过五次的 case 没有机械重试。
+- LLM 和 task 边界被诚实关闭，而不是强行改 harness。
+- 每个 PR 都能说明现实场景价值并通过项目 Gate。
+- 不确定语义集中留待用户最终决策。
+- 正式完整 eval 仅在用户明确授权后执行。


### PR DESCRIPTION
Stacked on #244.

## 问题与结果

- 解决的问题：现有 harness 能隔离执行 trial，但缺少已经批准的长期诊断边界，容易把公开 benchmark 误用成分数目标或把默认 8,192 输出上限当成模型失败。
- 用户可见结果：明确 `max_output_tokens = 0` 的 provider-default 语义、存量正值兼容、局部内部预算边界，以及 89 个 case 仅作为 Agent/harness 通用故障探针的规则。
- 本 PR 不处理：任何生产实现、自动完整 89 题 eval、容器/volume 清理、benchmark task-specific 行为。

## Change intent

- `change_type`：`docs`
- `semantic_delta`：`compatible`（先批准后续实现的默认行为变化）
- `capability_owner`：`core`
- `consumer_scope`：模型 runtime 配置与隔离 benchmark 诊断控制面。
- `runtime_patch`：`none`
- `runtime_patch_reason`：本 PR 只固化已批准合同；实现放在后续 stacked PR。
- `authoritative_state_owner`：模型 runtime 配置由 core config owner；benchmark events 由后续独立 diagnostic store owner。
- `client_only_alternative`：不适用。
- 关联不变量：RUN-006、TST-009、GOV-001～GOV-004、ERR-001。
- `protected_state`：正式 workspace、线上 runtime、存量显式正整数配置、benchmark task/verifier。
- 允许的副作用：仓库工作手册与技术设计变更。
- 禁止的副作用：修改正式 workspace/config、启动正式 eval、删除任何 benchmark 容器或 volume。

## 改动范围

- 主要文件：`docs/projectneed.md`、`docs/decisions/0010-provider-default-output-and-benchmark-diagnostics.md`、诊断循环设计和索引。
- 配置或迁移影响：本 PR 无实现、无迁移；后续实现不得自动改写存量正整数。
- 已知 schema lineage 与最终 schema identity：不适用。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `e9c0b23119ac7265da211c243a26e173451b66ac`；实现仍使用 #244 冻结的 Harbor/Terminal-Bench/V4 Flash 协议。
- 回滚方式：revert `31d56403`。

## 验证

- [x] `tests/semantic/test_project_workflow_contract.py`: 8 passed。
- [x] 文档 diff 通过 `git diff --check`。
- [x] `python docker/debug/gate.py run --base e9c0b23119ac7265da211c243a26e173451b66ac`：8 个公开场景通过。
- `sourceDigest`：`f960325c1ff0a065222f1d70dd061142435ad5e1e6ec573a3ce7109bc8a5d6c6`
- `planDigest`：`980da8666265d35aed5d16220b078ca14640b50467fc8f245b87a17c3dba0885`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用。
- 未运行项与原因：没有生产代码，因此类型检查不适用；private Gate 需要维护者 provider 身份。

## 工作手册

- [x] 已核对 `docs/INDEX.md`、`docs/WORKFLOW.md`、`docs/projectneed.md`、`docs/NOW.md`、writing rules 和 persistence state map。
- [x] RUN-006 与 TST-009 已由用户逐节确认。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有需要写入 `NOW.md` 的对应未完成产品事项。