### PR TITLE
fix: default model output limit to provider

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -102,11 +102,19 @@ def load_config(
     data = _load_config_data(path)
 
     llm = _as_dict(data.get("llm"), field="llm")
-    runtime_id, llm_main, model_runtimes = _load_llm_runtimes(llm, workspace_path)
+    agent_cfg = _as_dict(data.get("agent"), field="agent")
+    legacy_max_output_tokens = agent_cfg.get(
+        "max_tokens",
+        data.get("max_tokens"),
+    )
+    runtime_id, llm_main, model_runtimes = _load_llm_runtimes(
+        llm,
+        workspace_path,
+        legacy_main_max_output_tokens=legacy_max_output_tokens,
+    )
     fast_runtime_id, llm_fast = _load_role_runtime(llm, "fast", runtime_id)
     agent_runtime_id, llm_agent = _load_role_runtime(llm, "agent", runtime_id)
     vl_runtime_id, llm_vl = _load_role_runtime(llm, "vl", runtime_id)
-    agent_cfg = _as_dict(data.get("agent"), field="agent")
     agent_context = _as_dict(agent_cfg.get("context"), field="agent.context")
     agent_tools = _as_dict(agent_cfg.get("tools"), field="agent.tools")
     agent_maintenance = _as_dict(
@@ -146,12 +154,7 @@ def load_config(
             agent_cfg.get("system_prompt")
             or data.get("system_prompt", "You are a helpful assistant.")
         ),
-        max_tokens=int(
-            llm_main.get(
-                "max_output_tokens",
-                agent_cfg.get("max_tokens", data.get("max_tokens", 8192)),
-            )
-        ),
+        max_tokens=model_runtimes[runtime_id].max_output_tokens,
         max_iterations=int(
             agent_cfg.get("max_iterations", data.get("max_iterations", 10))
         ),
@@ -542,6 +545,8 @@ def _load_extra_body(data: dict, llm_main: dict | None = None) -> dict:
 def _load_llm_runtimes(
     llm: dict,
     workspace: Path,
+    *,
+    legacy_main_max_output_tokens: object | None = None,
 ) -> tuple[str, dict, dict[str, ModelRuntimeConfig]]:
     """在配置边界解析 named runtimes，并拒绝未迁移的旧结构。"""
     main_value = llm.get("main")
@@ -559,6 +564,14 @@ def _load_llm_runtimes(
             raise ValueError(f"llm.runtimes.{runtime_id}.input_modalities 必须是字符串数组")
         provider = str(item.get("provider") or "").lower()
         auth_id = str(item.get("auth") or "")
+        configured_max_output_tokens = item.get("max_output_tokens")
+        if configured_max_output_tokens is None:
+            configured_max_output_tokens = (
+                legacy_main_max_output_tokens
+                if runtime_id == main_value
+                and legacy_main_max_output_tokens is not None
+                else 0
+            )
         parsed[runtime_id] = ModelRuntimeConfig(
             runtime_id=runtime_id,
             provider=provider,
@@ -576,7 +589,10 @@ def _load_llm_runtimes(
             base_url=_model_base_url(provider, item.get("base_url")),
             reasoning_effort=str(item.get("reasoning_effort") or ""),
             context_window=int(item.get("context_window") or 0),
-            max_output_tokens=int(item.get("max_output_tokens", 8192)),
+            max_output_tokens=_as_output_token_limit(
+                configured_max_output_tokens,
+                field=f"llm.runtimes.{runtime_id}.max_output_tokens",
+            ),
             input_modalities=tuple(modalities),
             effective_context_percent=float(item.get("effective_context_percent", 0.9)),
             use_responses_lite=_as_bool(
@@ -672,6 +688,14 @@ def _model_base_url(provider: str, configured: object) -> str:
 def _as_bool(value: object, *, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{field} 必须是布尔值")
+    return value
+
+
+def _as_output_token_limit(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} 必须是整数")
+    if value < 0:
+        raise ValueError(f"{field} 不能小于 0")
     return value
 
 

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -132,7 +132,7 @@ class ModelRuntimeConfig:
     reasoning_effort: str = ""
     context_window: int = 0
     # 0 表示不向 provider 发送输出上限，由模型服务自身边界负责。
-    max_output_tokens: int = 8192
+    max_output_tokens: int = 0
     input_modalities: tuple[str, ...] = ("text",)
     effective_context_percent: float = 0.9
     use_responses_lite: bool = False
@@ -177,7 +177,7 @@ class Config:
     model: str
     api_key: str
     system_prompt: str
-    max_tokens: int = 8192
+    max_tokens: int = 0
     max_iterations: int = 10
     memory_window: int = 40
     base_url: str | None = None

--- a/agent/looping/ports.py
+++ b/agent/looping/ports.py
@@ -29,7 +29,7 @@ class LLMConfig:
     model: str = "deepseek-chat"
     light_model: str = ""
     max_iterations: int = 10
-    max_tokens: int = 8192
+    max_tokens: int = 0
     tool_search_enabled: bool = False
     multimodal: bool = True
     vl_available: bool = False

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -110,7 +110,7 @@ class ProviderPluginLlmService:
             messages=messages,
             tools=[],
             model=model or self._model,
-            max_tokens=max_tokens or self._max_tokens,
+            max_tokens=self._max_tokens if max_tokens is None else max_tokens,
         )
         return str(resp.content or "").strip()
 

--- a/agent/subagent.py
+++ b/agent/subagent.py
@@ -103,7 +103,7 @@ class SubAgent:
         *,
         system_prompt: str = "",
         max_iterations: int = 30,
-        max_tokens: int = 8192,
+        max_tokens: int = 0,
         mandatory_exit_tools: Sequence[str] = (),
     ) -> None:
         self._provider = provider
@@ -266,7 +266,11 @@ class SubAgent:
                 messages=messages + [{"role": "user", "content": prompt}],
                 tools=[],
                 model=self._model,
-                max_tokens=min(_SUMMARY_MAX_TOKENS, self._max_tokens),
+                max_tokens=(
+                    min(_SUMMARY_MAX_TOKENS, self._max_tokens)
+                    if self._max_tokens > 0
+                    else _SUMMARY_MAX_TOKENS
+                ),
             )
             text = (resp.content or "").strip()
             if text:
@@ -291,7 +295,11 @@ class SubAgent:
                 messages=messages + [{"role": "user", "content": prompt}],
                 tools=[],
                 model=self._model,
-                max_tokens=min(_SUMMARY_MAX_TOKENS, self._max_tokens),
+                max_tokens=(
+                    min(_SUMMARY_MAX_TOKENS, self._max_tokens)
+                    if self._max_tokens > 0
+                    else _SUMMARY_MAX_TOKENS
+                ),
             )
             text = (resp.content or "").strip()
             if text:

--- a/bootstrap/settings_api.py
+++ b/bootstrap/settings_api.py
@@ -272,8 +272,20 @@ def _read_settings_state(
     try:
         if isinstance(active, str):
             runtimes_raw = llm.get("runtimes") if isinstance(llm.get("runtimes"), dict) else {}
+            agent = raw.get("agent") if isinstance(raw.get("agent"), dict) else {}
+            legacy_max_output_tokens = agent.get(
+                "max_tokens",
+                raw.get("max_tokens", 0),
+            )
             runtimes = [
-                _runtime_summary(runtime_id, value, credential_meta)
+                _runtime_summary(
+                    runtime_id,
+                    value,
+                    credential_meta,
+                    missing_max_output_tokens=(
+                        legacy_max_output_tokens if runtime_id == active else 0
+                    ),
+                )
                 for runtime_id, value in runtimes_raw.items()
                 if isinstance(runtime_id, str) and isinstance(value, dict)
             ]
@@ -306,9 +318,14 @@ def _runtime_summary(
     runtime_id: str,
     raw: dict[str, object],
     credential_meta: dict[str, dict[str, str]],
+    *,
+    missing_max_output_tokens: object = 0,
 ) -> dict[str, object]:
     context_window = raw.get("context_window", 0)
-    max_output_tokens = raw.get("max_output_tokens", 0)
+    max_output_tokens = raw.get(
+        "max_output_tokens",
+        missing_max_output_tokens,
+    )
     input_modalities = raw.get("input_modalities", ["text"])
     if isinstance(context_window, bool) or not isinstance(context_window, int):
         raise ValueError(f"runtime {runtime_id} 的 context_window 必须是整数")

--- a/bootstrap/setup_wizard.py
+++ b/bootstrap/setup_wizard.py
@@ -41,7 +41,7 @@ class WizardAnswers:
     reasoning_effort: str = ""
     context_window: int = 0
     effective_context_percent: float = 0.9
-    max_output_tokens: int = 8192
+    max_output_tokens: int = 0
     memory_window: int = 40
     enable_thinking: bool = False
     multimodal: bool = False
@@ -340,15 +340,11 @@ def _phase_api_key_llm(a: WizardAnswers) -> None:
     a.context_window = click.prompt("上下文大小（tokens）", type=int, default=64000)
     if a.context_window <= 0:
         raise click.BadParameter("上下文大小必须大于 0")
-    from agent.model_runtime.context_policy import recommended_context_settings
-
     a.max_output_tokens = click.prompt(
-        "最大输出 tokens",
-        type=click.IntRange(min=1),
-        default=recommended_context_settings(a.context_window).output_reserve,
+        "最大输出 tokens（0 由 Provider 决定）",
+        type=click.IntRange(min=0),
+        default=0,
     )
-    if a.max_output_tokens <= 0:
-        raise click.BadParameter("最大输出 tokens 必须大于 0")
     a.multimodal = (
         False
         if a.provider == "opencode-go"
@@ -380,7 +376,6 @@ def _phase_codex_llm(
     a: WizardAnswers, *, reuse_existing_auth: bool = False
 ) -> None:
     """完成 Codex 登录并从目录选择模型能力。"""
-    from agent.model_runtime.context_policy import recommended_context_settings
     from agent.model_runtime.auth.codex import CodexAuthDriver
     from agent.model_runtime.auth.store import CredentialStore
     from agent.model_runtime.catalog.codex import CodexModelCatalog
@@ -435,13 +430,7 @@ def _phase_codex_llm(
         default=capabilities.context_window,
     )
     a.effective_context_percent = capabilities.effective_context_percent
-    a.max_output_tokens = min(
-        capabilities.max_output_tokens,
-        recommended_context_settings(
-            a.context_window,
-            a.effective_context_percent,
-        ).output_reserve,
-    )
+    a.max_output_tokens = 0
     detected_image = "image" in capabilities.input_modalities
     if not selected.input_modalities_known:
         _warn("模型目录未提供多模态元数据，请手工确认")
@@ -457,7 +446,11 @@ def _phase_codex_manual(a: WizardAnswers) -> None:
     a.reasoning_effort = click.prompt("推理强度", default="medium")
     a.reasoning_summary = "auto"
     a.context_window = click.prompt("上下文大小（tokens）", type=int)
-    a.max_output_tokens = click.prompt("最大输出 tokens", type=int, default=8192)
+    a.max_output_tokens = click.prompt(
+        "最大输出 tokens（0 由 Provider 决定）",
+        type=click.IntRange(min=0),
+        default=0,
+    )
     a.multimodal = click.confirm("主模型支持图片输入？", default=False)
 
 
@@ -476,9 +469,9 @@ def _phase_vl_model(a: WizardAnswers) -> None:
         default=a.context_window,
     )
     a.vl_max_output_tokens = click.prompt(
-        "视觉模型最大输出 tokens",
-        type=click.IntRange(min=1),
-        default=min(a.max_output_tokens, 8192),
+        "视觉模型最大输出 tokens（0 由 Provider 决定）",
+        type=click.IntRange(min=0),
+        default=0,
     )
 
 
@@ -506,9 +499,9 @@ def _phase_fast_model(a: WizardAnswers) -> None:
         default=min(a.context_window, 128_000),
     )
     a.fast_max_output_tokens = click.prompt(
-        "轻量模型最大输出 tokens",
-        type=click.IntRange(min=1),
-        default=min(a.max_output_tokens, 4096),
+        "轻量模型最大输出 tokens（0 由 Provider 决定）",
+        type=click.IntRange(min=0),
+        default=0,
     )
 
 
@@ -942,7 +935,7 @@ def _render_llm(a: WizardAnswers) -> str:
             f'model = "{a.fast_model}"',
             f'base_url = "{a.fast_base_url}"',
             f"context_window = {a.fast_context_window or a.context_window}",
-            f"max_output_tokens = {a.fast_max_output_tokens or a.max_output_tokens}",
+            f"max_output_tokens = {a.fast_max_output_tokens}",
             'input_modalities = ["text"]',
             "",
         ])
@@ -955,7 +948,7 @@ def _render_llm(a: WizardAnswers) -> str:
             f'model = "{a.vl_model}"',
             f'base_url = "{a.vl_base_url}"',
             f"context_window = {a.vl_context_window or a.context_window}",
-            f"max_output_tokens = {a.vl_max_output_tokens or a.max_output_tokens}",
+            f"max_output_tokens = {a.vl_max_output_tokens}",
             'input_modalities = ["text", "image"]',
             "",
         ])

--- a/config.example.toml
+++ b/config.example.toml
@@ -24,7 +24,8 @@ enable_thinking = true
 reasoning_effort = "high"
 context_window = 128000
 effective_context_percent = 0.9
-max_output_tokens = 8192
+# 0 表示不发送 provider 输出上限；正整数表示显式上限。
+max_output_tokens = 0
 input_modalities = ["text"]
 
 [llm.runtimes.qwen_fast]
@@ -34,7 +35,7 @@ model = "qwen-flash"
 api_key = "sk-..."
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 context_window = 128000
-max_output_tokens = 4096
+max_output_tokens = 0
 input_modalities = ["text"]
 
 [llm.runtimes.qwen_vl]
@@ -44,7 +45,7 @@ model = "qwen-vl-plus"
 api_key = "sk-..."
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 context_window = 128000
-max_output_tokens = 4096
+max_output_tokens = 0
 input_modalities = ["text", "image"]
 
 # =============================================================================
@@ -53,7 +54,7 @@ input_modalities = ["text", "image"]
 
 [agent]
 system_prompt = "You are Akashic, a helpful AI assistant with access to tools. Always respond in the same language the user uses."
-max_tokens = 8192
+max_tokens = 0
 # 设为 0 表示不限制迭代轮数；长任务仍可用 /stop 中断。
 max_iterations = 40
 dev_mode = false

--- a/frontend/chat/src/settings-app.tsx
+++ b/frontend/chat/src/settings-app.tsx
@@ -92,7 +92,7 @@ export function SettingsApp() {
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("");
   const [contextWindow, setContextWindow] = useState("128000");
-  const [maxOutputTokens, setMaxOutputTokens] = useState("8192");
+  const [maxOutputTokens, setMaxOutputTokens] = useState("0");
   const [models, setModels] = useState<ModelOption[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -133,7 +133,7 @@ export function SettingsApp() {
     setBaseUrl(runtime.baseUrl);
     setModel(runtime.model);
     setContextWindow(String(runtime.contextWindow || 128000));
-    setMaxOutputTokens(String(runtime.maxOutputTokens || 8192));
+    setMaxOutputTokens(String(runtime.maxOutputTokens ?? 0));
     setApiKey("");
     setModels([]);
   }
@@ -154,17 +154,18 @@ export function SettingsApp() {
       setBaseUrl("https://opencode.ai/zen/go/v1");
       setModel("");
       setContextWindow("128000");
-      setMaxOutputTokens("8192");
+      setMaxOutputTokens("0");
     } else if (next === "codex") {
       setProvider("codex");
       setBaseUrl("");
       setModel("");
       setContextWindow("128000");
-      setMaxOutputTokens("8192");
+      setMaxOutputTokens("0");
     } else {
       setProvider("openai");
       setBaseUrl("https://api.openai.com/v1");
       setModel("");
+      setMaxOutputTokens("0");
     }
   }
 
@@ -193,7 +194,6 @@ export function SettingsApp() {
   function applyModel(option: ModelOption) {
     setModel(option.id);
     if (option.contextWindow) setContextWindow(String(option.contextWindow));
-    if (option.maxOutputTokens) setMaxOutputTokens(String(option.maxOutputTokens));
   }
 
   async function save() {
@@ -374,7 +374,7 @@ export function SettingsApp() {
 
             <div className="field-grid two-columns">
               <Field label="上下文窗口"><Input inputMode="numeric" value={contextWindow} onChange={(event) => setContextWindow(event.target.value)} /></Field>
-              <Field label="最大输出"><Input inputMode="numeric" value={maxOutputTokens} onChange={(event) => setMaxOutputTokens(event.target.value)} /></Field>
+              <Field label="最大输出（0 由 Provider 决定）"><Input inputMode="numeric" value={maxOutputTokens} onChange={(event) => setMaxOutputTokens(event.target.value)} /></Field>
             </div>
 
             {error && <div className="settings-error" role="alert">{error}</div>}

--- a/plugins/default_proactive/deduper.py
+++ b/plugins/default_proactive/deduper.py
@@ -61,7 +61,9 @@ class MessageDeduper:
             messages=messages,
             tools=[],
             model=self._model,
-            max_tokens=min(128, self._max_tokens),
+            max_tokens=(
+                min(128, self._max_tokens) if self._max_tokens > 0 else 128
+            ),
         )
         payload = extract_json_object((response.content or "").strip())
         if "is_duplicate" not in payload or not isinstance(

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -85,6 +85,12 @@ def test_context_budget_and_runtime_config_share_the_same_boundary() -> None:
         context_window=10_000,
         max_output_tokens=0,
     ).max_output_tokens == 0
+    assert ModelRuntimeConfig(
+        runtime_id="default",
+        provider="openai",
+        model="model",
+        context_window=10_000,
+    ).max_output_tokens == 0
     with pytest.raises(ValueError, match="不能小于 0"):
         ModelRuntimeConfig(
             runtime_id="negative",
@@ -500,6 +506,57 @@ max_output_tokens = 0
 
     assert config.max_tokens == 0
     assert config.model_runtimes["main"].max_output_tokens == 0
+
+
+def test_config_defaults_missing_output_limit_to_provider_boundary(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "main"
+
+[llm.runtimes.main]
+provider = "openai"
+model = "model"
+api_key = "key"
+context_window = 64000
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path, workspace=tmp_path)
+
+    assert config.max_tokens == 0
+    assert config.model_runtimes["main"].max_output_tokens == 0
+
+
+def test_config_preserves_explicit_legacy_output_limit_for_main_runtime(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+main = "main"
+
+[llm.runtimes.main]
+provider = "openai"
+model = "model"
+api_key = "key"
+context_window = 64000
+
+[agent]
+max_tokens = 8192
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(path, workspace=tmp_path)
+
+    assert config.max_tokens == 8192
+    assert config.model_runtimes["main"].max_output_tokens == 8192
 
 
 @pytest.mark.parametrize("modalities", ['"image"', "[1]"])

--- a/tests/test_plugin_jobs.py
+++ b/tests/test_plugin_jobs.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.plugins.jobs import ProviderPluginLlmService
+
+
+@pytest.mark.asyncio
+async def test_plugin_job_distinguishes_default_and_explicit_zero_limit() -> None:
+    provider = AsyncMock()
+    provider.chat.return_value = SimpleNamespace(content="done")
+    service = ProviderPluginLlmService(
+        provider,
+        model="main",
+        max_tokens=256,
+    )
+
+    assert await service.generate_text(prompt="bounded") == "done"
+    assert provider.chat.await_args.kwargs["max_tokens"] == 256
+
+    assert await service.generate_text(prompt="provider", max_tokens=0) == "done"
+    assert provider.chat.await_args.kwargs["max_tokens"] == 0

--- a/tests/test_proactive_deduper.py
+++ b/tests/test_proactive_deduper.py
@@ -102,3 +102,27 @@ async def test_programming_error_propagates() -> None:
             "new",
             [RecentProactiveMessage(content="old")],
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("configured", "expected"), [(0, 128), (64, 64)])
+async def test_deduper_keeps_its_local_output_limit(
+    configured: int,
+    expected: int,
+) -> None:
+    provider = AsyncMock()
+    provider.chat.return_value = SimpleNamespace(
+        content='{"is_duplicate": false, "reason": "new"}'
+    )
+    deduper = MessageDeduper(
+        provider=cast(Any, provider),
+        model="test-model",
+        max_tokens=configured,
+    )
+
+    await deduper.is_duplicate(
+        "new",
+        [RecentProactiveMessage(content="old")],
+    )
+
+    assert provider.chat.await_args.kwargs["max_tokens"] == expected

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -54,6 +54,53 @@ def test_state_never_returns_saved_api_key(tmp_path: Path) -> None:
     }
 
 
+def test_settings_round_trip_preserves_explicit_legacy_output_limit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    legacy = _config().replace(
+        "max_output_tokens = 8192\n",
+        "",
+    ).replace(
+        "[agent.context]",
+        "[agent]\nmax_tokens = 8192\n\n[agent.context]",
+    )
+    config_path.write_text(legacy, encoding="utf-8")
+
+    async def validate(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr("bootstrap.settings_api._validate_live_candidate", validate)
+    app = create_settings_app(
+        config_path,
+        tmp_path / "workspace",
+        credential_store=CredentialStore(tmp_path / "auth" / "auth.json"),
+    )
+    client = TestClient(app)
+    state = client.get("/api/settings/state").json()
+
+    assert state["runtimes"][0]["maxOutputTokens"] == 8192
+
+    response = client.post(
+        "/api/settings/apply",
+        headers={"Origin": "http://testserver", "X-Akasic-CSRF": "1"},
+        json={
+            "provider": "deepseek",
+            "model": "deepseek-chat",
+            "api_key": "",
+            "base_url": "https://api.deepseek.com/v1",
+            "context_window": 64000,
+            "max_output_tokens": state["runtimes"][0]["maxOutputTokens"],
+            "input_modalities": ["text"],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["llm"]["runtimes"]["deepseek_main"]["max_output_tokens"] == 8192
+
+
 def test_state_marks_invalid_runtime_fields_for_repair(tmp_path: Path) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text(

--- a/tests/test_setup_main.py
+++ b/tests/test_setup_main.py
@@ -155,6 +155,7 @@ def test_codex_setup_reuses_existing_login_and_catalog(
     _phase_codex_llm(answers, reuse_existing_auth=True)
 
     assert (answers.model, answers.context_window) == ("gpt-test", 128_000)
+    assert answers.max_output_tokens == 0
     assert answers.reasoning_summary == "auto"
 
 
@@ -194,5 +195,6 @@ def test_opencode_go_setup_uses_dynamic_catalog_and_forces_text_only(
     assert answers.provider == "opencode-go"
     assert answers.model == "glm-5.99"
     assert answers.base_url == "https://opencode.ai/zen/go/v1"
+    assert answers.max_output_tokens == 0
     assert answers.multimodal is False
     assert "主模型原生支持图片输入？" not in confirms

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -24,6 +24,40 @@ def test_setup_wizard_renders_web_chat_config() -> None:
     assert 'channel_name = "web"' in text
 
 
+def test_setup_wizard_defaults_all_runtime_output_limits_to_provider() -> None:
+    answers = WizardAnswers(
+        fast_model="fast",
+        fast_provider="openai",
+        fast_context_window=64_000,
+        vl_model="vision",
+        vl_provider="openai",
+        vl_context_window=64_000,
+    )
+
+    text = _render_config(answers)
+
+    assert text.count("max_output_tokens = 0") == 3
+    assert "max_tokens = 0" in text
+
+
+def test_setup_wizard_preserves_explicit_role_output_limits() -> None:
+    answers = WizardAnswers(
+        fast_model="fast",
+        fast_provider="openai",
+        fast_context_window=64_000,
+        fast_max_output_tokens=2048,
+        vl_model="vision",
+        vl_provider="openai",
+        vl_context_window=64_000,
+        vl_max_output_tokens=4096,
+    )
+
+    text = _render_config(answers)
+
+    assert "max_output_tokens = 2048" in text
+    assert "max_output_tokens = 4096" in text
+
+
 @pytest.mark.asyncio
 async def test_qqbot_openid_fetch_times_out_without_ws_frames(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_tool_loop_guard.py
+++ b/tests/test_tool_loop_guard.py
@@ -732,6 +732,7 @@ def test_subagent_max_iterations_returns_summary_and_reason():
     assert "最大迭代" not in result
     assert "下一步" in result
     assert provider.calls[-1]["tools"] == []
+    assert provider.calls[-1]["max_tokens"] == 512
 
 
 def test_subagent_max_iterations_summary_failure_uses_fallback():


### PR DESCRIPTION
Stacked on #245.

## 问题与结果

- 解决的问题：Akasic 虽已支持 `max_output_tokens = 0` 省略 Chat Completions 的输出上限，但配置模型、缺省加载、setup wizard 和 Settings UI 仍默认 `8192`，长工具任务会被应用层提前截断。
- 用户可见结果：新配置默认 `0`；显式正整数继续保留；负数仍在边界失败；Settings 不再把明确的 `0` 显示/保存成 `8192`。
- 同时修复两个由 `0` 暴露的通用问题：SubAgent summary 和 proactive deduper 保持局部 512/128 上限；plugin job 区分未传 `None` 与显式 `0`。
- 本 PR 不处理：Codex Responses wire 的显式正输出上限。本机 Codex canonical `ResponsesApiRequest` 本身没有该字段，Akasic 维持现有 provider-specific 行为，不声称正值在 Codex wire 生效。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`（已批准的缺省行为变化；显式存量值保持）
- `capability_owner`：`core`
- `consumer_scope`：模型 runtime、setup wizard、Settings UI、SubAgent、proactive deduper 和 plugin job LLM service。
- `runtime_patch`：`required`
- `runtime_patch_reason`：真实 benchmark trace 证明固定 8,192 会在原生 tool call 前截断 reasoning；默认值必须统一在配置和所有入口生效。
- `authoritative_state_owner`：runtime config owner；本 PR 不自动写正式 config。
- `client_only_alternative`：仅改 benchmark config 会让正式 runtime 继续保留错误默认，不能解决通用故障。
- 关联不变量：RUN-006、ERR-001、GOV-001～GOV-004。
- `protected_state`：正式 workspace/config、存量显式正整数、局部 summary/JSON helper 预算。
- 允许的副作用：新建配置和缺字段配置按0解释；用户显式保存 Settings 时写所选值。
- 禁止的副作用：自动迁移/改写存量配置、取消局部内部预算、benchmark task-specific 条件。

## 改动范围

- 主要文件：`agent/config*.py`、`agent/looping/ports.py`、setup/settings、Chat Settings UI，以及局部 LLM helper 和测试。
- 配置或迁移影响：无自动迁移。缺字段默认0；active main runtime 可继承显式 legacy `[agent].max_tokens`，Settings state→apply round-trip 保持该正值；非主 runtime 缺字段仍为0。
- 已知 schema lineage 与最终 schema identity：无数据库 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `31d56403b99bcf3608b0982ab1037d377fb827fd`；Chat Completions 的0省略行为由 #244 已有 wire test保护；Codex 对照 `/mnt/data/source-code/codex` canonical request 未暴露 output limit。
- 回滚方式：revert `48b1e880`；不会修改已经存在的正式配置文件。

## 验证

- [x] 109 个相关 pytest 通过。
- [x] `npm run typecheck` 与 `npm run lint` 通过。
- [x] Pyright：0 errors。
- [x] `python docker/debug/gate.py run --base 31d56403b99bcf3608b0982ab1037d377fb827fd`：8 个公开场景通过。
- [x] 两位只读 reviewer 复核；legacy runtime/Settings 分裂 finding 已修复并复核通过；未发现 benchmark 特化或自动迁移。
- `sourceDigest`：`c319505b29b49b0cc383ddcd5140944adfad16d50ee6218a33e99870727e1e74`
- `planDigest`：`746d61788ac9385f9e45a5a2621b2185d984e1954744743d53d25458bd5fa503`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用。
- 未运行项与原因：正式完整 89 题 eval 不在本 PR 授权范围；线上 runtime/config 未切换。

## 工作手册

- [x] 已核对 RUN-006、TST-009、0010、诊断循环设计和 persistence state map。
- [x] 长期语义变化已由用户确认，并先放在 #245。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有需要写入 `NOW.md` 的对应未完成产品事项。