### PR TITLE
feat: schedule benchmark diagnostic waves

### DIFF
--- a/benchmark/harbor_v4flash/campaign.py
+++ b/benchmark/harbor_v4flash/campaign.py
@@ -26,13 +26,39 @@ def validate_campaign_request(task_dirs: list[Path], max_concurrent: int) -> Non
 
     # 2. 一个 case 对应一个独立 task 实例，不接受重复路径。
     resolved = [path.resolve() for path in task_dirs]
-    if len(resolved) < 2:
-        raise ValueError("campaign 至少需要两个 task；单 task 请使用 smoke")
+    if not resolved:
+        raise ValueError("campaign 至少需要一个 task")
     if len(set(resolved)) != len(resolved):
         raise ValueError("campaign 不允许重复 task")
     missing = [str(path) for path in resolved if not path.is_dir()]
     if missing:
         raise FileNotFoundError(f"task 目录不存在：{missing}")
+
+
+def plan_diagnostic_wave(
+    discovery_dirs: list[Path],
+    validation_dirs: list[Path],
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """规划单波最多三项任务，validation 最多占一个 slot。"""
+
+    # 1. 有 validation 时固定 2 discovery + 1 validation；无 validation 时借给 discovery。
+    scheduled: list[dict[str, object]] = []
+    if validation_dirs:
+        scheduled.append({"mode": "validation", "task": validation_dirs[0]})
+    discovery_slots = 3 - len(scheduled)
+    scheduled.extend(
+        {"mode": "discovery", "task": task} for task in discovery_dirs[:discovery_slots]
+    )
+
+    # 2. 未进入本波的任务保持显式 pending，由 Root 决定下一次调度。
+    pending = [
+        *(
+            {"mode": "discovery", "task": task}
+            for task in discovery_dirs[discovery_slots:]
+        ),
+        *({"mode": "validation", "task": task} for task in validation_dirs[1:]),
+    ]
+    return scheduled, pending
 
 
 def find_open_concurrency_gate(runs_root: Path) -> dict[str, Any]:

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -22,7 +22,9 @@ from harbor.trial.trial import Trial
 from benchmark.harbor_v4flash import HARNESS_VERSION
 from benchmark.harbor_v4flash.agent import AkashicHarborAgent
 from benchmark.harbor_v4flash.campaign import (
+    CampaignGateError,
     find_open_concurrency_gate,
+    plan_diagnostic_wave,
     task_slug,
     validate_campaign_request,
 )
@@ -194,9 +196,7 @@ async def run_trial(
                 "source_head": source_bundle["head"],
                 "uv_binary": str(uv_binary),
                 "allowed_bind_root": str(trial_dir),
-                "forbidden_host_paths": [
-                    str(path) for path in DEFAULT_FORBIDDEN_PATHS
-                ],
+                "forbidden_host_paths": [str(path) for path in DEFAULT_FORBIDDEN_PATHS],
                 "source_digest": before_source,
                 "install_timeout_sec": 900,
             },
@@ -304,20 +304,24 @@ async def run_smoke(args: argparse.Namespace, task_dir: Path) -> int:
 
 async def run_campaign(
     args: argparse.Namespace,
-    task_dirs: list[Path],
+    discovery_dirs: list[Path],
+    validation_dirs: list[Path],
 ) -> int:
-    """按硬上限三并发运行 diagnostic tasks，并冻结 campaign 汇总。"""
+    """按 2 discovery + 1 validation 调度单波任务并冻结结果。"""
 
-    # 1. 只有已完成 smoke 能打开并发，且整个 campaign 再次冻结源码和线上 owner。
-    validate_campaign_request(task_dirs, args.max_concurrent)
+    # 1. 只有同一源码完成 smoke 才能打开并发。
+    all_tasks = [*discovery_dirs, *validation_dirs]
+    validate_campaign_request(all_tasks, 3)
     runs_root = args.runs_dir.resolve()
     gate = find_open_concurrency_gate(runs_root)
     source_root = args.source_root.resolve()
     before_source = source_tree_digest(source_root)
+    if gate["source_digest"] != before_source:
+        raise CampaignGateError("源码已变化，必须先用当前源码重新完成 smoke Gate")
     before_online = online_process_snapshot()
-    campaign_id = (
-        f"{BENCHMARK_PREFIX}campaign-"
-        + time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    scheduled, pending = plan_diagnostic_wave(discovery_dirs, validation_dirs)
+    campaign_id = f"{BENCHMARK_PREFIX}campaign-" + time.strftime(
+        "%Y%m%d-%H%M%S", time.gmtime()
     )
     campaign_dir = runs_root / "_campaigns" / campaign_id
     campaign_dir.mkdir(parents=True, exist_ok=False)
@@ -326,34 +330,44 @@ async def run_campaign(
         "schema": "akasic.harbor-campaign.v1",
         "state": "running",
         "campaign_id": campaign_id,
-        "max_concurrent": args.max_concurrent,
+        "max_concurrent": 3,
+        "scheduling_policy": "2_discovery_1_validation",
         "gate": gate,
         "source_digest_before": before_source,
-        "tasks": [str(path.resolve()) for path in task_dirs],
+        "scheduled": [
+            {"mode": item["mode"], "task": str(item["task"].resolve())}
+            for item in scheduled
+        ],
+        "pending": [
+            {"mode": item["mode"], "task": str(item["task"].resolve())}
+            for item in pending
+        ],
         "online_before": before_online,
     }
     atomic_json(manifest_path, initial)
 
-    # 2. semaphore 是唯一并发 owner；每个 task 仍创建独立 Trial/Docker project。
-    semaphore = asyncio.Semaphore(args.max_concurrent)
+    # 2. 本波天然最多三项；每项仍创建独立 Trial/Docker project。
+    async def guarded(item: dict[str, object]) -> dict[str, object]:
+        task_dir = item["task"]
+        mode = item["mode"]
+        if not isinstance(task_dir, Path) or not isinstance(mode, str):
+            raise TypeError("scheduler 只产生已验证的 Path/mode")
+        try:
+            return await run_trial(args, task_dir, run_kind=mode)
+        except Exception as error:
+            return {
+                "state": "controller_failed",
+                "mode": mode,
+                "task": str(task_dir.resolve()),
+                "error": {
+                    "type": type(error).__name__,
+                    "message": str(error),
+                },
+            }
 
-    async def guarded(task_dir: Path) -> dict[str, object]:
-        async with semaphore:
-            try:
-                return await run_trial(args, task_dir, run_kind="diagnostic")
-            except Exception as error:
-                return {
-                    "state": "controller_failed",
-                    "task": str(task_dir.resolve()),
-                    "error": {
-                        "type": type(error).__name__,
-                        "message": str(error),
-                    },
-                }
+    outcomes = await asyncio.gather(*(guarded(item) for item in scheduled))
 
-    outcomes = await asyncio.gather(*(guarded(path) for path in task_dirs))
-
-    # 3. campaign 完成只表示生命周期证据齐全；reward 单独统计，不把失败题伪装通过。
+    # 3. campaign 只记录生命周期，不计算或拼接 benchmark 分数。
     after_source = source_tree_digest(source_root)
     after_online = online_process_snapshot()
     online_report = validate_online_processes_unchanged(before_online, after_online)
@@ -362,12 +376,6 @@ async def run_campaign(
         and after_source == before_source
         and online_report["status"] == "passed"
     )
-    passed = sum(
-        1
-        for outcome in outcomes
-        if isinstance(outcome.get("reward"), dict)
-        and outcome["reward"].get("reward") == 1.0
-    )
     final = {
         **initial,
         "state": "completed" if lifecycle_complete else "failed",
@@ -375,11 +383,6 @@ async def run_campaign(
         "source_unchanged": after_source == before_source,
         "online": online_report,
         "outcomes": outcomes,
-        "score": {
-            "passed": passed,
-            "total": len(outcomes),
-            "pass_rate": passed / len(outcomes),
-        },
     }
     atomic_json(manifest_path, final)
     print(json.dumps(final, ensure_ascii=False, indent=2))
@@ -390,19 +393,24 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source-root", type=Path, required=True)
     parser.add_argument("--harbor-root", type=Path, required=True)
-    parser.add_argument("--task-dir", type=Path, action="append", required=True)
+    parser.add_argument("--task-dir", type=Path, action="append", default=[])
+    parser.add_argument(
+        "--validation-task-dir",
+        type=Path,
+        action="append",
+        default=[],
+    )
     parser.add_argument("--runs-dir", type=Path, required=True)
     parser.add_argument("--credential-profile", type=Path, required=True)
-    parser.add_argument("--max-concurrent", type=int, default=1)
     parser.add_argument(
         "--uv-binary",
         type=Path,
         default=Path(os.environ.get("AKASIC_BENCH_UV", "/home/huashen/.local/bin/uv")),
     )
     args = parser.parse_args()
-    if len(args.task_dir) == 1:
+    if len(args.task_dir) == 1 and not args.validation_task_dir:
         return asyncio.run(run_smoke(args, args.task_dir[0]))
-    return asyncio.run(run_campaign(args, args.task_dir))
+    return asyncio.run(run_campaign(args, args.task_dir, args.validation_task_dir))
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_harbor_v4flash_campaign.py
+++ b/tests/benchmark/test_harbor_v4flash_campaign.py
@@ -6,6 +6,7 @@ import pytest
 from benchmark.harbor_v4flash.campaign import (
     CampaignGateError,
     find_open_concurrency_gate,
+    plan_diagnostic_wave,
     task_slug,
     validate_campaign_request,
 )
@@ -62,3 +63,43 @@ def test_open_gate_fails_closed_without_smoke(tmp_path: Path) -> None:
 def test_task_slug_is_bounded_and_docker_safe(tmp_path: Path) -> None:
     task = tmp_path / ("UPPER_case.with spaces-" + "x" * 80)
     assert task_slug(task) == "upper-case-with-spaces-" + "x" * 25
+
+
+def test_diagnostic_wave_uses_two_discovery_and_one_validation(
+    tmp_path: Path,
+) -> None:
+    discovery = [tmp_path / f"d{index}" for index in range(4)]
+    validation = [tmp_path / f"v{index}" for index in range(2)]
+
+    scheduled, pending = plan_diagnostic_wave(discovery, validation)
+
+    assert [item["mode"] for item in scheduled] == [
+        "validation",
+        "discovery",
+        "discovery",
+    ]
+    assert [(item["mode"], item["task"].name) for item in pending] == [
+        ("discovery", "d2"),
+        ("discovery", "d3"),
+        ("validation", "v1"),
+    ]
+
+
+def test_diagnostic_wave_lends_empty_validation_slot_to_discovery(
+    tmp_path: Path,
+) -> None:
+    discovery = [tmp_path / f"d{index}" for index in range(4)]
+
+    scheduled, pending = plan_diagnostic_wave(discovery, [])
+
+    assert [item["task"].name for item in scheduled] == ["d0", "d1", "d2"]
+    assert [item["task"].name for item in pending] == ["d3"]
+
+
+def test_diagnostic_wave_never_runs_three_validations(tmp_path: Path) -> None:
+    validation = [tmp_path / f"v{index}" for index in range(3)]
+
+    scheduled, pending = plan_diagnostic_wave([], validation)
+
+    assert [item["task"].name for item in scheduled] == ["v0"]
+    assert [item["task"].name for item in pending] == ["v1", "v2"]


### PR DESCRIPTION
Stacked on #246.

## 结果

- 新增薄的单波调度器：最多 3 个独立 Harbor/Docker trial。
- 默认 `2 discovery + 1 validation`；无 validation 时第三个 slot 借给 discovery；validation 永远不会占满三个 slot。
- 每次命令只运行当前波，未调度任务写入 campaign manifest 的 `pending`，下一波由 Root 决定。
- source digest 必须与 smoke Gate 一致，否则 fail-fast。
- 删除旧 campaign 的聚合 `score/pass_rate`，不拼接不同 attempt 成绩。
- 不引入事件溯源、lease、reconcile 或持久状态机；继续复用独立 trial manifest、trace、外部 verifier 和 stop-retain 证据。

## 边界与验证

- 只影响 benchmark 调度入口；不修改线上 runtime、正式 workspace、dataset、verifier、timeout 或模型配置。
- 不提供删除容器/volume 接口，不自动运行完整 89 题 eval。
- 126 个 benchmark 与相关 runtime pytest 通过；Black/Python 3.13 target 和 diff check 通过。
- Public Gate 8 个场景通过：`docker/debug/reports/change-gate/20260730-141256-8a9b8783`。
- `sourceDigest`: `0ff722f3ce52bbe1cd13a1043d1192de1dfa47712c10cc7d8f83eab0ad0d87fb`
- `planDigest`: `f784524f352be66c5e81ad89e3fe554c69b9ff80784f2f16ff68d28637117fff`
- `private-contract-gate`: pending maintainer。
- 回滚：revert `08b5dca5`。