### PR TITLE
fix: exclude benchmark manifest from artifact digests

### DIFF
--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -28,12 +28,12 @@ from benchmark.harbor_v4flash.campaign import (
 )
 from benchmark.harbor_v4flash.isolation import (
     BENCHMARK_PREFIX,
+    artifact_digests,
     atomic_json,
     compose_project_name,
     create_source_bundle,
     inspect_compose_project,
     online_process_snapshot,
-    sha256_file,
     source_tree_digest,
     validate_online_processes_unchanged,
 )
@@ -76,16 +76,6 @@ def _credential_env(profile_path: Path) -> dict[str, str]:
         "DEEPSEEK_API_KEY": deepseek,
         "DASHSCOPE_API_KEY": dashscope,
     }
-
-
-def _artifact_digests(root: Path) -> dict[str, str]:
-    values: dict[str, str] = {}
-    if not root.exists():
-        return values
-    for path in sorted(root.rglob("*")):
-        if path.is_file():
-            values[path.relative_to(root).as_posix()] = sha256_file(path)
-    return values
 
 
 def _safe_trial_result(result: Any) -> dict[str, object]:
@@ -262,7 +252,10 @@ async def run_trial(
         "result": _safe_trial_result(result),
         "artifacts": {
             "missing": missing_artifacts,
-            "digests": _artifact_digests(trial_dir),
+            "digests": artifact_digests(
+                trial_dir,
+                exclude={manifest_path},
+            ),
         },
         "concurrency_gate": {
             "max_concurrent": 3 if trial_completed else 1,

--- a/benchmark/harbor_v4flash/isolation.py
+++ b/benchmark/harbor_v4flash/isolation.py
@@ -36,6 +36,23 @@ def sha256_file(path: Path) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
+def artifact_digests(
+    root: Path,
+    *,
+    exclude: set[Path] | None = None,
+) -> dict[str, str]:
+    """散列证据目录中的普通文件，并显式排除自引用 manifest。"""
+
+    excluded = {path.resolve() for path in (exclude or set())}
+    values: dict[str, str] = {}
+    if not root.exists():
+        return values
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.resolve() not in excluded:
+            values[path.relative_to(root).as_posix()] = sha256_file(path)
+    return values
+
+
 def create_source_bundle(
     source_root: Path,
     bundle_path: Path,

--- a/tests/benchmark/test_harbor_v4flash_isolation.py
+++ b/tests/benchmark/test_harbor_v4flash_isolation.py
@@ -4,7 +4,9 @@ import pytest
 
 from benchmark.harbor_v4flash.isolation import (
     IsolationError,
+    artifact_digests,
     compose_project_name,
+    sha256_file,
     validate_isolation,
 )
 
@@ -76,3 +78,18 @@ def test_validate_isolation_rejects_host_escape(
             allowed_bind_root=allowed,
             forbidden_host_paths=[Path("/home/huashen/.akashic/workspace")],
         )
+
+
+def test_artifact_digests_excludes_self_referential_manifest(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "campaign-manifest.json"
+    trace = tmp_path / "agent" / "trace.jsonl"
+    trace.parent.mkdir()
+    manifest.write_text('{"state":"prepared"}\n', encoding="utf-8")
+    trace.write_text('{"event":"completed"}\n', encoding="utf-8")
+
+    digests = artifact_digests(tmp_path, exclude={manifest})
+
+    assert "campaign-manifest.json" not in digests
+    assert digests == {"agent/trace.jsonl": sha256_file(trace)}


### PR DESCRIPTION
Stacked on #246.

## 问题与修复

首批当前-source smoke + 3 个独立 diagnostic run 全部稳定复现：`campaign-manifest.json` 在写最终 manifest 前先被加入 `artifacts.digests`，随后 manifest 本身被覆盖，因此记录的自身 SHA-256 永远与最终文件不一致。其他 artifact digest 均可验证。

本 PR 将 artifact 散列收敛到 `isolation.artifact_digests()`，并显式排除自引用 manifest；trace、turn result、verifier、result、source bundle 等仍逐文件散列。不增加状态机或迁移，不改变 Agent/task/verifier/模型/timeout/权限语义，也没有任何 case 特化。

## 验证

- 新增回归测试：manifest 被排除，其他 artifact digest 等于真实 SHA-256。
- 124 个 benchmark 与相关 runtime pytest 通过。
- 定向 8 个 benchmark 测试、py_compile 与 diff check 通过。
- Public Gate：`docker/debug/reports/change-gate/20260730-144321-8b4c7045`。
- 真实独立 Docker validation：`akasic-bench-v4flash-smoke-regex-log-20260730-064531-898385` 完整结束，容器 stop-retain、preflight/online/source Gate 通过；最终 manifest 不再列出自身，剩余 18 个 artifact digest 全部与磁盘 SHA-256 一致，0 mismatch。
- `sourceDigest`: `8ff06c504bfa0457807ac03ca8cc4b1d16a6e002657aef380ad1327960e19c4e`
- `planDigest`: `1d067f8ca6e1422181ba28018cc80607b84ef8503d7a3d77e20c06f0274d45a5`
- private gate pending maintainer。
- 回滚：revert `5c6a7f5f`。