### PR TITLE
test: remove benchmark iteration cap

### DIFF
--- a/benchmark/harbor_v4flash/config.toml
+++ b/benchmark/harbor_v4flash/config.toml
@@ -17,7 +17,7 @@ input_modalities = ["text"]
 [agent]
 system_prompt = "You are Akashic, a helpful AI assistant with access to tools. Always respond in the same language the user uses."
 max_tokens = 0
-max_iterations = 40
+max_iterations = 0
 dev_mode = true
 
 [agent.context]


### PR DESCRIPTION
## What changed

Set the isolated V4 Flash benchmark profile to `max_iterations = 0`, using the existing Akasic meaning of unlimited ReAct iterations. The outer 840/900 second driver and Harbor deadlines remain unchanged.

## Why

Two sealed diagnostic trials reached the benchmark-specific 40-iteration cap while still incomplete. This change tests whether that cap prevents otherwise recoverable work without changing the production default or online configuration.

## Semantic delta

This is an experiment configuration behavior change, not a semantics-neutral refactor and not an Agent fix. A benchmark turn may now continue past 40 model requests until it returns a final response, is interrupted, errors, or reaches the unchanged outer deadline. Production config, generated config defaults, task inputs, verifier logic, and the online workspace are unchanged.

## Real ablation

Frozen case: `build-cython-ext`, same model/effort/task/verifier and isolated Docker lifecycle.

- baseline `max_iterations=40`: 40 requests, verifier 9/11, reward 0; stopped with an incomplete-progress summary
- treatment `max_iterations=0`: 46 requests, verifier 10/11, reward 0; voluntarily returned a false completion claim while still missing `np.int` in `ccomplexity.pyx`

The treatment therefore proves the cap affected the trajectory, but it does not solve the underlying Agent failure. The remaining general signal is mismatch between search scope, edit scope, and completion evidence.

## Validation

- `.venv/bin/pytest -q tests/test_agent_core_p2_reasoner.py::test_default_reasoner_zero_max_iterations_is_unlimited tests/test_runtime_smoke.py::test_load_config_keeps_internal_max_iterations_default` — 2 passed
- smoke `regex-log`: reward 1, source/online isolation passed, container stopped-retained
- treatment `build-cython-ext`: lifecycle valid, source/online isolation passed, container stopped-retained
- public Gate passed: `docker/debug/reports/change-gate/20260730-151033-01d6f403`
- plan digest: `68551c80b11586902dfd0c806435a7f5078ff019e4e67b0ec42f38875bd5c981`
- private-contract-gate: `pending_maintainer`