### PR TITLE
fix: respect benchmark task timeouts

### DIFF
--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -50,6 +50,7 @@ class AkashicHarborAgent(BaseAgent):
         forbidden_host_paths: list[str],
         source_digest: str,
         install_timeout_sec: int = 900,
+        turn_timeout_sec: float,
         **kwargs,
     ) -> None:
         super().__init__(logs_dir=logs_dir, model_name=model_name, **kwargs)
@@ -63,6 +64,9 @@ class AkashicHarborAgent(BaseAgent):
         ]
         self._source_digest = source_digest
         self._install_timeout_sec = install_timeout_sec
+        if turn_timeout_sec <= 0:
+            raise ValueError("turn_timeout_sec 必须大于 0")
+        self._turn_timeout_sec = turn_timeout_sec
 
     def version(self) -> str:
         return HARNESS_VERSION
@@ -177,11 +181,13 @@ class AkashicHarborAgent(BaseAgent):
                 f"{_AGENT_LOGS}/trace.jsonl",
                 "--result",
                 f"{_AGENT_LOGS}/turn-result.json",
+                "--turn-timeout",
+                str(self._turn_timeout_sec),
             ]
         )
         completed = await environment.exec(
             command=driver_command,
-            timeout_sec=900,
+            timeout_sec=self._turn_timeout_sec + 5,
         )
         shutdown = await environment.exec(
             command=(

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import os
 import subprocess
 import time
@@ -11,10 +12,11 @@ from pathlib import Path
 from typing import Any
 
 from harbor.models.environment_type import EnvironmentType
+from harbor.models.task.config import TaskConfig as HarborTaskConfig
 from harbor.models.trial.config import (
     AgentConfig,
     EnvironmentConfig,
-    TaskConfig,
+    TaskConfig as TrialTaskConfig,
     TrialConfig,
 )
 from harbor.trial.trial import Trial
@@ -43,6 +45,7 @@ DEFAULT_FORBIDDEN_PATHS = (
     Path("/home/huashen/.akashic/workspace"),
     Path("/home/huashen/.akashic-plugin/cache"),
 )
+HARNESS_CLEANUP_RESERVE_SEC = 120.0
 
 
 def _git_output(root: Path, *args: str) -> str:
@@ -78,6 +81,22 @@ def _credential_env(profile_path: Path) -> dict[str, str]:
     }
 
 
+def _task_agent_timeout_sec(task_dir: Path) -> float:
+    """读取并校验 Harbor task 声明的 agent 执行预算。"""
+
+    # 1. 复用 Harbor 的 task schema 解析权威配置。
+    config_path = task_dir / "task.toml"
+    config = HarborTaskConfig.model_validate_toml(
+        config_path.read_text(encoding="utf-8")
+    )
+
+    # 2. 本 harness 要求显式、有限且为正的 task 预算。
+    timeout_sec = config.agent.timeout_sec
+    if timeout_sec is None or not math.isfinite(timeout_sec) or timeout_sec <= 0:
+        raise ValueError(f"{config_path} 缺少有效的 [agent].timeout_sec")
+    return timeout_sec
+
+
 def _safe_trial_result(result: Any) -> dict[str, object]:
     verifier = getattr(result, "verifier_result", None)
     rewards = getattr(verifier, "rewards", None) if verifier is not None else None
@@ -109,6 +128,7 @@ async def run_trial(
     source_root = args.source_root.resolve()
     task_dir = task_dir.resolve()
     runs_root = args.runs_dir.resolve()
+    task_agent_timeout_sec = _task_agent_timeout_sec(task_dir)
     timestamp = (
         time.strftime("%Y%m%d-%H%M%S", time.gmtime())
         + f"-{time.time_ns() % 1_000_000:06d}"
@@ -152,6 +172,14 @@ async def run_trial(
             "max_output_tokens": None,
             "max_output_policy": "provider_default",
         },
+        "timeouts": {
+            "task_agent_sec": task_agent_timeout_sec,
+            "turn_sec": task_agent_timeout_sec,
+            "harness_cleanup_reserve_sec": HARNESS_CLEANUP_RESERVE_SEC,
+            "harbor_agent_sec": (
+                task_agent_timeout_sec + HARNESS_CLEANUP_RESERVE_SEC
+            ),
+        },
         "source": initial_source,
         "harbor": {
             "root": str(args.harbor_root.resolve()),
@@ -169,14 +197,16 @@ async def run_trial(
 
     # 2. Harbor 负责启动环境、执行 agent、外部 verifier 和停止但保留容器。
     config = TrialConfig(
-        task=TaskConfig(path=task_dir),
+        task=TrialTaskConfig(path=task_dir),
         trial_name=trial_name,
         trials_dir=runs_root,
         agent=AgentConfig(
             import_path=AkashicHarborAgent.import_path(),
             model_name="deepseek/deepseek-v4-flash",
             override_setup_timeout_sec=900,
-            override_timeout_sec=900,
+            override_timeout_sec=(
+                task_agent_timeout_sec + HARNESS_CLEANUP_RESERVE_SEC
+            ),
             env=credential_env,
             kwargs={
                 "source_root": str(source_root),
@@ -189,6 +219,7 @@ async def run_trial(
                 ],
                 "source_digest": before_source,
                 "install_timeout_sec": 900,
+                "turn_timeout_sec": task_agent_timeout_sec,
             },
         ),
         environment=EnvironmentConfig(

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -3,6 +3,9 @@ import subprocess
 import tomllib
 from pathlib import Path
 
+import pytest
+
+from benchmark.harbor_v4flash.controller import _task_agent_timeout_sec
 from benchmark.harbor_v4flash.isolation import create_source_bundle
 
 
@@ -28,6 +31,34 @@ def test_v4flash_high_uses_provider_output_limit() -> None:
 
     assert config["llm"]["runtimes"]["main"]["max_output_tokens"] == 0
     assert config["agent"]["max_tokens"] == 0
+    assert config["agent"]["max_iterations"] == 0
+
+
+def test_task_agent_timeout_uses_harbor_task_budget(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text(
+        "[agent]\ntimeout_sec = 3600.0\n",
+        encoding="utf-8",
+    )
+
+    assert _task_agent_timeout_sec(task_dir) == 3600.0
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_task_agent_timeout_rejects_invalid_budget(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    task_dir = tmp_path / value
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text(
+        f"[agent]\ntimeout_sec = {value}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"\[agent\]\.timeout_sec"):
+        _task_agent_timeout_sec(task_dir)
 
 
 def test_source_bundle_restores_history_and_keeps_worktree_overlay(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：benchmark controller 将所有任务硬截断为 900 秒；例如 `caffe-cifar-10` 在 task.toml 明确声明 3600 秒，因此有效任务会被 harness 提前终止。
- 用户可见结果：每个 trial 复用 Harbor task schema 的 `[agent].timeout_sec`；Agent turn 使用该预算，Harbor 外层仅增加 120 秒用于 shutdown 与证据封存。
- 本 PR 不处理：Agent 策略、模型能力、Terminal-Bench task/verifier、生产默认配置、Docker 地址池耗尽。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`not_applicable`
- `consumer_scope`：仅 `benchmark/harbor_v4flash` 实验 harness
- `runtime_patch`：`none`
- `runtime_patch_reason`：不修改线上 runtime
- `authoritative_state_owner`：Harbor task.toml
- `client_only_alternative`：不适用
- 关联不变量：harness 不得覆盖 benchmark 官方执行预算；清理时间不得挤占模型 turn
- `protected_state`：正式 workspace、线上进程、task/verifier
- 允许的副作用：独立 benchmark trial 可按 task 声明运行更久
- 禁止的副作用：修改生产 Agent 默认、task/verifier 或线上 workspace

## 改动范围

- 主要文件：`benchmark/harbor_v4flash/controller.py`、`benchmark/harbor_v4flash/agent.py`、`tests/benchmark/test_harbor_v4flash_controller.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：manifest 增加显式 timeout 证据，不涉及持久化 schema
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source commit 与 Harbor/task digest 继续写入 trial manifest
- 回滚方式：revert `fb3d3cd6`

## 验证

- [x] 相关 targeted tests 已通过：20 passed
- [x] `compileall` 与 git diff check 已通过
- [ ] `python docker/debug/gate.py run --base origin/experiment/unlimited-benchmark-iterations` 已运行但因本机 Docker 默认地址池耗尽，8 个公开场景均未启动；报告 `docker/debug/reports/change-gate/20260730-154307-b42c16d8`
- `sourceDigest`：`8607ab09030d89603a7e0389afa03cb8217240b97d9a523c5aba41d662373c1b`
- `planDigest`：`2bbad7b3c08ec38e1ac2837b607b68e691ecce768f6babc217982aa04587a1ca`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；真实 Harbor smoke `regex-log` reward=1，manifest 记录 task=900、turn=900、Harbor=1020，容器 stopped-retained，线上 owner 与源码摘要不变
- 未运行项与原因：private gate 需要维护者身份；公开 Gate 被保留 trial 占满 Docker 默认地址池阻塞

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有生产长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有对应 NOW 事项。