### PR TITLE
fix: reserve retained benchmark networks

### DIFF
--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -30,12 +30,14 @@ from benchmark.harbor_v4flash.campaign import (
 )
 from benchmark.harbor_v4flash.isolation import (
     BENCHMARK_PREFIX,
+    IsolationError,
     artifact_digests,
     atomic_json,
     compose_project_name,
     create_source_bundle,
     inspect_compose_project,
     online_process_snapshot,
+    reserve_compose_network,
     source_tree_digest,
     validate_online_processes_unchanged,
 )
@@ -116,6 +118,20 @@ def _safe_trial_result(result: Any) -> dict[str, object]:
     }
 
 
+def _inspect_finished_project(
+    result: Any,
+    project_name: str,
+) -> tuple[list[dict[str, object]], str | None]:
+    """保留 Harbor 前置失败，同时让成功 trial 的容器缺失继续 fail-loud。"""
+
+    try:
+        return inspect_compose_project(project_name), None
+    except IsolationError as error:
+        if getattr(result, "exception_info", None) is None:
+            raise
+        return [], str(error)
+
+
 async def run_trial(
     args: argparse.Namespace,
     task_dir: Path,
@@ -136,6 +152,7 @@ async def run_trial(
     trial_name = f"{BENCHMARK_PREFIX}{run_kind}-{task_slug(task_dir)}-{timestamp}"
     trial_dir = runs_root / trial_name
     trial_dir.mkdir(parents=True, exist_ok=False)
+    project = compose_project_name(f"{trial_name}__env")
     before_source = source_tree_digest(source_root)
     before_online = online_process_snapshot()
     credential_env = _credential_env(args.credential_profile.resolve())
@@ -146,6 +163,19 @@ async def run_trial(
     uv_binary = args.uv_binary.resolve()
     if not uv_binary.is_file():
         raise FileNotFoundError(f"uv binary 不存在：{uv_binary}")
+    network = reserve_compose_network(project)
+    network_compose_path = trial_dir / "inputs" / "network-compose.json"
+    atomic_json(
+        network_compose_path,
+        {
+            "networks": {
+                "default": {
+                    "external": True,
+                    "name": network["name"],
+                }
+            }
+        },
+    )
 
     manifest_path = trial_dir / "campaign-manifest.json"
     initial_source: dict[str, object] = {
@@ -192,6 +222,10 @@ async def run_trial(
             "persisted_values": False,
         },
         "online_before": before_online,
+        "docker": {
+            "project": project,
+            "network": network,
+        },
     }
     atomic_json(manifest_path, initial_manifest)
 
@@ -225,6 +259,7 @@ async def run_trial(
         environment=EnvironmentConfig(
             type=EnvironmentType.DOCKER,
             delete=True,
+            extra_docker_compose=[network_compose_path],
             kwargs={"keep_containers": True},
         ),
     )
@@ -238,8 +273,7 @@ async def run_trial(
         before_online,
         after_online,
     )
-    project = compose_project_name(f"{trial_name}__env")
-    containers = inspect_compose_project(project)
+    containers, inspection_error = _inspect_finished_project(result, project)
     stopped = bool(containers) and all(
         not bool(container.get("running")) for container in containers
     )
@@ -276,9 +310,11 @@ async def run_trial(
         "online": online_report,
         "docker": {
             "project": project,
-            "retained": True,
+            "retained": bool(containers),
             "all_stopped": stopped,
             "containers": containers,
+            "inspection_error": inspection_error,
+            "network": network,
         },
         "result": _safe_trial_result(result),
         "artifacts": {

--- a/benchmark/harbor_v4flash/isolation.py
+++ b/benchmark/harbor_v4flash/isolation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -9,6 +10,8 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 BENCHMARK_PREFIX = "akasic-bench-v4flash-"
+BENCHMARK_NETWORK_POOL = ipaddress.IPv4Network("10.240.0.0/16")
+BENCHMARK_NETWORK_PREFIX = 28
 _IGNORED_TREE_PARTS = {
     ".git",
     ".mypy_cache",
@@ -133,6 +136,75 @@ def compose_project_name(session_id: str) -> str:
     if not re.match(r"^[a-z0-9]", value):
         value = "0" + value
     return re.sub(r"[^a-z0-9_-]", "-", value)
+
+
+def reserve_compose_network(
+    project_name: str,
+    *,
+    network_pool: ipaddress.IPv4Network = BENCHMARK_NETWORK_POOL,
+    network_prefix: int = BENCHMARK_NETWORK_PREFIX,
+) -> dict[str, str]:
+    """为 retained benchmark project 原子预留一个小型独立网络。"""
+
+    # 1. 只允许 benchmark owner 在合法 IPv4 池内分配子网。
+    if not project_name.startswith(BENCHMARK_PREFIX):
+        raise IsolationError(f"compose project 缺少 benchmark 前缀：{project_name}")
+    if network_prefix <= network_pool.prefixlen or network_prefix > 30:
+        raise IsolationError(
+            f"benchmark network prefix 无效：{network_pool} /{network_prefix}"
+        )
+
+    # 2. Docker 负责原子判定重叠；hash 只分散起点，冲突时顺序探测。
+    subnet_count = 1 << (network_prefix - network_pool.prefixlen)
+    subnet_size = 1 << (32 - network_prefix)
+    start = int.from_bytes(hashlib.sha256(project_name.encode()).digest()[:4]) % (
+        subnet_count
+    )
+    network_name = f"{project_name}_default"
+    for step in range(subnet_count):
+        index = (start + step) % subnet_count
+        candidate = ipaddress.IPv4Network(
+            (int(network_pool.network_address) + index * subnet_size, network_prefix)
+        )
+        result = subprocess.run(
+            [
+                "docker",
+                "network",
+                "create",
+                "--driver",
+                "bridge",
+                "--subnet",
+                str(candidate),
+                "--label",
+                f"com.docker.compose.project={project_name}",
+                "--label",
+                "com.docker.compose.network=default",
+                "--label",
+                "akasic.benchmark.managed=true",
+                network_name,
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode == 0:
+            network_id = result.stdout.strip()
+            if not network_id:
+                raise IsolationError("docker network create 成功但未返回 network id")
+            return {
+                "id": network_id,
+                "name": network_name,
+                "subnet": str(candidate),
+                "pool": str(network_pool),
+            }
+        error = "\n".join((result.stdout, result.stderr)).strip()
+        if "overlaps with other one on this address space" in error:
+            continue
+        raise IsolationError(
+            f"无法创建 benchmark network {network_name}：{error}"
+        )
+    raise IsolationError(f"benchmark network pool 已耗尽：{network_pool}")
 
 
 def inspect_compose_project(project_name: str) -> list[dict[str, object]]:

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from benchmark.harbor_v4flash.controller import _task_agent_timeout_sec
+from benchmark.harbor_v4flash.controller import (
+    _inspect_finished_project,
+    _task_agent_timeout_sec,
+)
+from benchmark.harbor_v4flash.isolation import IsolationError
 from benchmark.harbor_v4flash.isolation import create_source_bundle
 
 
@@ -59,6 +63,42 @@ def test_task_agent_timeout_rejects_invalid_budget(
 
     with pytest.raises(ValueError, match=r"\[agent\]\.timeout_sec"):
         _task_agent_timeout_sec(task_dir)
+
+
+def test_harbor_startup_failure_keeps_original_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = type("Result", (), {"exception_info": object()})()
+
+    def missing_project(project_name: str) -> list[dict[str, object]]:
+        raise IsolationError(f"未找到 compose project：{project_name}")
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.controller.inspect_compose_project",
+        missing_project,
+    )
+
+    containers, error = _inspect_finished_project(result, "akasic-bench-missing")
+
+    assert containers == []
+    assert error == "未找到 compose project：akasic-bench-missing"
+
+
+def test_success_without_compose_project_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = type("Result", (), {"exception_info": None})()
+
+    def missing_project(project_name: str) -> list[dict[str, object]]:
+        raise IsolationError(f"未找到 compose project：{project_name}")
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.controller.inspect_compose_project",
+        missing_project,
+    )
+
+    with pytest.raises(IsolationError, match="未找到 compose project"):
+        _inspect_finished_project(result, "akasic-bench-missing")
 
 
 def test_source_bundle_restores_history_and_keeps_worktree_overlay(

--- a/tests/benchmark/test_harbor_v4flash_isolation.py
+++ b/tests/benchmark/test_harbor_v4flash_isolation.py
@@ -1,3 +1,5 @@
+import ipaddress
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -6,6 +8,7 @@ from benchmark.harbor_v4flash.isolation import (
     IsolationError,
     artifact_digests,
     compose_project_name,
+    reserve_compose_network,
     sha256_file,
     validate_isolation,
 )
@@ -36,6 +39,44 @@ def test_compose_project_name_matches_harbor_normalization() -> None:
         compose_project_name("Akasic-Bench-V4Flash-Smoke.Name__env")
         == "akasic-bench-v4flash-smoke-name__env"
     )
+
+
+def test_reserve_compose_network_retries_overlapping_subnet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+    responses = iter(
+        [
+            subprocess.CompletedProcess(
+                [],
+                1,
+                stdout="",
+                stderr="Pool overlaps with other one on this address space",
+            ),
+            subprocess.CompletedProcess([], 0, stdout="network-id\n", stderr=""),
+        ]
+    )
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return next(responses)
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    network = reserve_compose_network(
+        "akasic-bench-v4flash-smoke__env",
+        network_pool=ipaddress.IPv4Network("10.240.0.0/29"),
+        network_prefix=30,
+    )
+
+    assert network["id"] == "network-id"
+    assert network["pool"] == "10.240.0.0/29"
+    assert commands[0][6] != commands[1][6]
+
+
+def test_reserve_compose_network_rejects_non_benchmark_owner() -> None:
+    with pytest.raises(IsolationError, match="benchmark 前缀"):
+        reserve_compose_network("production_default")
 
 
 def test_validate_isolation_accepts_only_trial_bind_mounts(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：stop-retain trial 的 Compose 网络按 Docker 默认 `/20` 地址池分配；14 个 benchmark 网络后默认池耗尽，下一题与公开 Gate 均无法创建网络。
- 用户可见结果：每个 benchmark project 从专用 `10.240.0.0/16` 原子预留独立 `/28`，足以保留完整 89 题；实际 Compose 复用该 external network，task 仍无主机端口。
- 附带修复：Harbor 在容器创建前已记录异常时，controller 不再用“compose project 不存在”覆盖原始 result；成功 trial 若容器缺失仍 fail-loud。
- 本 PR 不处理：生产网络、Docker daemon 配置、task/verifier、Agent 策略、runtime 冷安装缓存。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`not_applicable`
- `consumer_scope`：仅 `benchmark/harbor_v4flash` 实验 harness
- `runtime_patch`：`none`
- `runtime_patch_reason`：不修改线上 runtime 或 Docker daemon
- `authoritative_state_owner`：benchmark controller + Docker network labels
- `client_only_alternative`：不适用
- 关联不变量：每题网络独立；只允许 benchmark project 分配；前置失败保留 Harbor 原始证据；成功路径容器缺失仍失败
- `protected_state`：正式 workspace、线上容器/网络、task/verifier
- 允许的副作用：创建带 `akasic.benchmark.managed=true` 标签的独立 `/28` bridge network
- 禁止的副作用：修改 daemon 默认池、发布端口、复用生产网络、吞掉成功路径隔离错误

## 改动范围

- 主要文件：`benchmark/harbor_v4flash/isolation.py`、`benchmark/harbor_v4flash/controller.py` 及定向测试
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：trial manifest 的 docker evidence 增加 network identity 与 inspection_error；无持久化迁移
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source/task/Harbor digest 机制不变
- 回滚方式：revert `7f1cbd0b`

## 验证

- [x] 24 个 benchmark targeted tests 通过
- [x] `compileall`、`git diff --check` 通过
- [x] 真实 `regex-log` smoke：reward=1、19 项 artifact digest、missing=[]、source unchanged、online passed、container stopped-retained
- [x] 实际 network：`10.240.104.160/28`，owner labels 正确，无发布端口
- [x] Public Gate 8/8 passed：`docker/debug/reports/change-gate/20260730-162533-0cb71d94`
- `sourceDigest`：`67d0d37a405306e2d7f7c14cf907ca22c89c7d807318e2314037c618ee442eb1`
- `planDigest`：`480533bfc79faa9b69a1eb5f82c4f0dee590bc2010a944998907344917fa0704`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：private gate 需要维护者身份

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有生产长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有对应 NOW 事项。