### PR TITLE
fix(shell): preserve explicit background timeouts

### DIFF
--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -10,6 +10,7 @@ Shell 工具（Bash 命令执行）
 后台任务（run_in_background=True）：
 - 立即返回 background_task_id，不阻塞前台
 - 输出持续写入临时日志文件
+- 显式硬超时最长 4 小时；未显式传入时不设置硬超时
 - 配合 ShellTaskOutputTool / ShellTaskStopTool 管理
 """
 
@@ -284,7 +285,7 @@ class ShellTool(Tool):
             "- 前台阻塞总超时默认 60 秒，普通命令最大 600 秒\n"
             "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；后台会沿用当前 timeout 作为硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false；未显式传 timeout 时会默认阻塞 21600 秒\n"
-            "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
+            "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台显式硬超时最长 14400 秒，未显式传入时不设置硬超时\n"
             "- 收到 background_task_id 后，由你负责用 task_output 主动查看进展和结果；不会有系统自动回传\n"
             "- task_output 是轮询接口：block=true 单次最多等 30s 就返回快照（不会等到任务结束），长任务靠多次轮询推进\n"
             "- 如果决定放弃后台任务并准备最终回复，必须先调用 task_stop 终止它\n"
@@ -312,7 +313,7 @@ class ShellTool(Tool):
                     "description": (
                         f"前台阻塞或显式硬超时秒数，默认 {_DEFAULT_TIMEOUT}。"
                         f"普通命令最大 {_MAX_TIMEOUT}；auto_promote=false 时最大 {_BLOCKING_TIMEOUT}。"
-                        "自动转后台后只有显式传入才生效。"
+                        f"run_in_background=true 时最大 {_BG_TTL_S}，且只有显式传入才生效。"
                     ),
                     "minimum": 1,
                     "maximum": _BLOCKING_TIMEOUT,
@@ -346,11 +347,19 @@ class ShellTool(Tool):
         timeout_specified = "timeout" in kwargs and kwargs.get("timeout") is not None
         run_in_background: bool = bool(kwargs.get("run_in_background", False))
         auto_promote: bool = bool(kwargs.get("auto_promote", True))
-        max_timeout = (
-            _BLOCKING_TIMEOUT
-            if not run_in_background and not auto_promote
-            else _MAX_TIMEOUT
-        )
+        requested_timeout = int(kwargs["timeout"]) if timeout_specified else None
+        if run_in_background and requested_timeout is not None:
+            if requested_timeout < 1 or requested_timeout > _BG_TTL_S:
+                return _err(
+                    f"后台显式 timeout 必须在 1 到 {_BG_TTL_S} 秒之间，"
+                    f"收到 {requested_timeout}"
+                )
+        if run_in_background:
+            max_timeout = _BG_TTL_S
+        elif not auto_promote:
+            max_timeout = _BLOCKING_TIMEOUT
+        else:
+            max_timeout = _MAX_TIMEOUT
         default_timeout = (
             _BLOCKING_TIMEOUT
             if not run_in_background and not auto_promote and not timeout_specified

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -458,6 +458,72 @@ async def test_shell_run_in_background_returns_task_id(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_shell_run_in_background_preserves_explicit_long_timeout(monkeypatch):
+    """后台长任务应保留显式 3600 秒硬超时，不再静默压缩为 600 秒。"""
+    import agent.tools.shell as shell_mod
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        return _FakeProc(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(
+            command="sleep 3600",
+            description="后台长任务",
+            timeout=3600,
+            run_in_background=True,
+        )
+    )
+
+    task_id = result["background_task_id"]
+    task = shell_mod._BG_REGISTRY.pop(task_id)
+    assert result["timeout_s"] == 3600
+    assert task.timeout_s == 3600
+    assert task.timeout_handle is not None
+    task.timeout_handle.cancel()
+    await asyncio.gather(task.pump_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_shell_run_in_background_rejects_timeout_beyond_ttl(monkeypatch):
+    """后台显式硬超时超过任务 TTL 时应失败并且不启动进程。"""
+    import agent.tools.shell as shell_mod
+
+    launched = False
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        nonlocal launched
+        launched = True
+        return _FakeProc(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(
+            command="sleep 99999",
+            description="超长后台任务",
+            timeout=shell_mod._BG_TTL_S + 1,
+            run_in_background=True,
+        )
+    )
+
+    assert result["error"] == (
+        f"后台显式 timeout 必须在 1 到 {shell_mod._BG_TTL_S} 秒之间，"
+        f"收到 {shell_mod._BG_TTL_S + 1}"
+    )
+    assert launched is False
+
+
+@pytest.mark.asyncio
 async def test_task_output_returns_log_content(monkeypatch, tmp_path):
     """task_output 能读取后台任务已写入的日志内容。"""
     import agent.tools.shell as shell_mod


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`run_in_background=true, timeout=3600` 被 shell 工具静默压缩为 600 秒，导致已知长时间编译、下载或训练任务提前终止。
- 用户可见结果：后台显式硬超时现在按请求保留到 14400 秒；超过后台生命周期上限的请求会明确失败且不会启动进程。
- 本 PR 不处理：不修改普通前台 600 秒上限、不修改 `task_output` 30 秒轮询窗口、不引入 turn deadline 状态机，也不处理 Agent 删除 partial download 后重试的决策问题。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：内建 shell 工具的后台任务调用方
- `runtime_patch`：`none`
- `runtime_patch_reason`：不适用
- `authoritative_state_owner`：shell 后台任务 registry
- `client_only_alternative`：不适用；缺陷位于 core tool contract
- 关联不变量：SH-001，后台任务生命周期有硬上限、状态查询和显式 stop
- `protected_state`：session、workspace、Akasha、任务文件、外部服务均不变
- 允许的副作用：后台进程可按调用方明确请求运行超过 600 秒、最长 14400 秒
- 禁止的副作用：不得扩大 4 小时后台 TTL；不得静默夹断超上限 timeout；不得改变前台与自动转后台现有语义

## 改动范围

- 主要文件：`agent/tools/shell.py`、`tests/test_shell_tool.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `7f1cbd0bf82d31a8291582de0b80c1bdba1f3685`，head `e395bd9c686355b75a8ef95f4c98ea0acd04eefd`
- 回滚方式：revert `e395bd9c`

## 验证

- [x] 相关 targeted tests 已通过：项目既有 venv 运行 `pytest -q tests/test_shell_tool.py`，`36 passed in 1.51s`
- [x] Python 编译与 `git diff --check` 已通过
- [x] `python docker/debug/gate.py run --base origin/fix/benchmark-retained-network-pool` 已运行；8/8 公开场景通过，残留容器/网络/volume 均为空
- `sourceDigest`：`ef59dcba815e57b4e87cd60606d6b079818d04c2613ee2ad4a776133ac485e20`
- `planDigest`：`de17b0a2bfa12226cd715db23878adfc37f7088840008a71dc4b8195a352e094`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：私有 Gate 需要维护者环境

## 工作手册

- [x] 已核对 `docs/projectneed.md` 的 SH-001、相关决策和 `NOW.md`
- [x] 本次为兼容性修复；没有需要单独确认的长期破坏性语义
- [x] 跨仓库或客户端改动不适用
- [x] `NOW.md` 当前没有对应事项