### PR TITLE
perf(benchmark): reuse immutable runtime volume

### DIFF
--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -16,10 +16,13 @@ from benchmark.harbor_v4flash.isolation import (
     validate_isolation,
 )
 from benchmark.harbor_v4flash.result_projection import project_agent_context
+from benchmark.harbor_v4flash.runtime_volume import (
+    RUNTIME_MOUNT_PATH,
+    RUNTIME_VENV_PATH,
+)
 
 _RUNTIME_ROOT = "/opt/akashic"
 _SOURCE_ROOT = f"{_RUNTIME_ROOT}/src"
-_VENV = f"{_RUNTIME_ROOT}/venv"
 _WORKSPACE = "/tmp/akashic-workspace"
 _ENDPOINT = f"{_WORKSPACE}/akashic.sock"
 _AGENT_LOGS = "/logs/agent"
@@ -45,11 +48,15 @@ class AkashicHarborAgent(BaseAgent):
         source_root: str,
         source_bundle: str,
         source_head: str,
-        uv_binary: str,
         allowed_bind_root: str,
         forbidden_host_paths: list[str],
         source_digest: str,
-        install_timeout_sec: int = 900,
+        runtime_volume_name: str,
+        runtime_digest: str,
+        runtime_manifest_digest: str,
+        runtime_lock_digest: str,
+        runtime_python_version: str,
+        bootstrap_timeout_sec: int = 900,
         turn_timeout_sec: float,
         **kwargs,
     ) -> None:
@@ -57,13 +64,17 @@ class AkashicHarborAgent(BaseAgent):
         self._source_root = Path(source_root).resolve()
         self._source_bundle = Path(source_bundle).resolve()
         self._source_head = source_head
-        self._uv_binary = Path(uv_binary).resolve()
         self._allowed_bind_root = Path(allowed_bind_root).resolve()
         self._forbidden_host_paths = [
             Path(path).resolve() for path in forbidden_host_paths
         ]
         self._source_digest = source_digest
-        self._install_timeout_sec = install_timeout_sec
+        self._runtime_volume_name = runtime_volume_name
+        self._runtime_digest = runtime_digest
+        self._runtime_manifest_digest = runtime_manifest_digest
+        self._runtime_lock_digest = runtime_lock_digest
+        self._runtime_python_version = runtime_python_version
+        self._bootstrap_timeout_sec = bootstrap_timeout_sec
         if turn_timeout_sec <= 0:
             raise ValueError("turn_timeout_sec 必须大于 0")
         self._turn_timeout_sec = turn_timeout_sec
@@ -71,10 +82,34 @@ class AkashicHarborAgent(BaseAgent):
     def version(self) -> str:
         return HARNESS_VERSION
 
-    async def setup(self, environment: BaseEnvironment) -> None:
-        """复制只读 harness，安装独立 Python runtime，并证明容器隔离。"""
+    def _runtime_check_command(self) -> str:
+        """生成只读取固定 runtime manifest 和 lock 的容器内校验命令。"""
 
-        # 1. 只向当前 Harbor task 容器复制源码与 uv，不建立主机源码挂载。
+        expected = {
+            "volume_name": self._runtime_volume_name,
+            "runtime_digest": self._runtime_digest,
+            "manifest_digest": self._runtime_manifest_digest,
+            "lock_digest": self._runtime_lock_digest,
+            "python_version": self._runtime_python_version,
+        }
+        code = (
+            "import hashlib,json,platform,pathlib;"
+            f"root=pathlib.Path({RUNTIME_MOUNT_PATH!r});"
+            "manifest=json.loads((root/'manifest.json').read_text());"
+            f"expected=json.loads({json.dumps(json.dumps(expected))});"
+            "assert manifest['volume_name']==expected['volume_name'];"
+            "assert manifest['runtime_digest']==expected['runtime_digest'];"
+            "assert manifest['manifest_digest']==expected['manifest_digest'];"
+            "lock=hashlib.sha256((root/'resolved.lock').read_bytes()).hexdigest();"
+            "assert 'sha256:'+lock==expected['lock_digest'];"
+            "assert platform.python_version()==expected['python_version']"
+        )
+        return f"{RUNTIME_VENV_PATH}/bin/python -c {shlex.quote(code)}"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """复制只读源码，验证共享 runtime，并证明容器隔离。"""
+
+        # 1. 只向当前 Harbor task 容器复制源码，不建立主机源码挂载。
         prepare = await environment.exec(
             command=f"mkdir -p {_SOURCE_ROOT} {_AGENT_LOGS}",
             user="root",
@@ -85,9 +120,40 @@ class AkashicHarborAgent(BaseAgent):
             self._source_bundle,
             f"{_RUNTIME_ROOT}/source.bundle",
         )
-        await environment.upload_file(self._uv_binary, f"{_RUNTIME_ROOT}/uv")
 
-        # 2. 补齐官方 agent setup 所需基础设施，并恢复真实 Git 历史。
+        # 2. 模型和网络安装前，拒绝错误或可写的共享 volume。
+        project = compose_project_name(environment.session_id)
+        containers = inspect_compose_project(project)
+        report = validate_isolation(
+            containers,
+            project_name=project,
+            allowed_bind_root=self._allowed_bind_root,
+            forbidden_host_paths=self._forbidden_host_paths,
+            allowed_volume_mounts=[
+                (self._runtime_volume_name, RUNTIME_MOUNT_PATH)
+            ],
+        )
+        checked_runtime = await environment.exec(
+            command=self._runtime_check_command(),
+            user="root",
+        )
+        _require_success(
+            "校验 Akasic runtime volume",
+            checked_runtime.return_code,
+            (checked_runtime.stdout or "") + (checked_runtime.stderr or ""),
+        )
+        report["source_digest"] = self._source_digest
+        report["runtime_volume"] = {
+            "name": self._runtime_volume_name,
+            "mount_path": RUNTIME_MOUNT_PATH,
+            "runtime_digest": self._runtime_digest,
+            "manifest_digest": self._runtime_manifest_digest,
+            "resolved_lock_digest": self._runtime_lock_digest,
+            "python_version": self._runtime_python_version,
+        }
+        atomic_json(self.logs_dir / "isolation.preflight.json", report)
+
+        # 3. 补齐 Git 基础设施，并恢复真实历史；Python 依赖不再逐 trial 安装。
         install_command = (
             "if ! command -v git >/dev/null 2>&1; then "
             "if command -v apk >/dev/null 2>&1; then "
@@ -108,34 +174,18 @@ class AkashicHarborAgent(BaseAgent):
             "012e37c8b51df045353972bb551d8e868ab52455^{commit} && "
             f"test \"$(git -C {_SOURCE_ROOT} rev-parse HEAD)\" = "
             f"{shlex.quote(self._source_head)} && "
-            f"chmod 755 {_RUNTIME_ROOT}/uv && "
-            f"{_RUNTIME_ROOT}/uv venv --python 3.13 {_VENV} && "
-            f"{_RUNTIME_ROOT}/uv pip install --python {_VENV}/bin/python "
-            f"-r {_SOURCE_ROOT}/requirements.txt tzdata && "
             f"chmod -R a-w {_SOURCE_ROOT}"
         )
         installed = await environment.exec(
             command=install_command,
-            timeout_sec=self._install_timeout_sec,
+            timeout_sec=self._bootstrap_timeout_sec,
             user="root",
         )
         _require_success(
-            "安装 Akasic runtime",
+            "准备 Akasic source checkout",
             installed.return_code,
             (installed.stdout or "") + (installed.stderr or ""),
         )
-
-        # 3. 模型调用前，从宿主 Docker 控制面拒绝任何线上路径或端口泄漏。
-        project = compose_project_name(environment.session_id)
-        containers = inspect_compose_project(project)
-        report = validate_isolation(
-            containers,
-            project_name=project,
-            allowed_bind_root=self._allowed_bind_root,
-            forbidden_host_paths=self._forbidden_host_paths,
-        )
-        report["source_digest"] = self._source_digest
-        atomic_json(self.logs_dir / "isolation.preflight.json", report)
 
     async def run(
         self,
@@ -152,7 +202,7 @@ class AkashicHarborAgent(BaseAgent):
             f"mkdir -p {_WORKSPACE} && cd /app || exit $?; "
             f"env PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src "
             "PYTHONDONTWRITEBYTECODE=1 "
-            f"{_VENV}/bin/python {_SOURCE_ROOT}/main.py gateway "
+            f"{RUNTIME_VENV_PATH}/bin/python {_SOURCE_ROOT}/main.py gateway "
             f"--config {_SOURCE_ROOT}/benchmark/harbor_v4flash/config.toml "
             f"--workspace {_WORKSPACE} "
             f">{_AGENT_LOGS}/runtime.stdout.log "
@@ -171,7 +221,7 @@ class AkashicHarborAgent(BaseAgent):
             [
                 f"cd /app && PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src",
                 "PYTHONDONTWRITEBYTECODE=1",
-                f"{_VENV}/bin/python",
+                f"{RUNTIME_VENV_PATH}/bin/python",
                 f"{_SOURCE_ROOT}/benchmark/harbor_v4flash/runtime_driver.py",
                 "--endpoint",
                 shlex.quote(_ENDPOINT),

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -9,7 +9,7 @@ import subprocess
 import time
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from harbor.models.environment_type import EnvironmentType
 from harbor.models.task.config import TaskConfig as HarborTaskConfig
@@ -40,6 +40,10 @@ from benchmark.harbor_v4flash.isolation import (
     reserve_compose_network,
     source_tree_digest,
     validate_online_processes_unchanged,
+)
+from benchmark.harbor_v4flash.runtime_volume import (
+    inspect_runtime_volume,
+    runtime_compose_overlay,
 )
 
 DEFAULT_FORBIDDEN_PATHS = (
@@ -145,6 +149,16 @@ async def run_trial(
     task_dir = task_dir.resolve()
     runs_root = args.runs_dir.resolve()
     task_agent_timeout_sec = _task_agent_timeout_sec(task_dir)
+    uv_binary = args.uv_binary.resolve()
+    runtime_volume = inspect_runtime_volume(
+        args.runtime_volume,
+        source_root=source_root,
+        uv_binary=uv_binary,
+    )
+    runtime_manifest = cast(dict[str, Any], runtime_volume["manifest"])
+    runtime_recipe = cast(dict[str, Any], runtime_manifest["recipe"])
+    runtime_lock = cast(dict[str, Any], runtime_recipe["resolved_lock"])
+    runtime_python = cast(dict[str, Any], runtime_recipe["python"])
     timestamp = (
         time.strftime("%Y%m%d-%H%M%S", time.gmtime())
         + f"-{time.time_ns() % 1_000_000:06d}"
@@ -160,21 +174,20 @@ async def run_trial(
         source_root,
         trial_dir / "inputs" / "source.bundle",
     )
-    uv_binary = args.uv_binary.resolve()
-    if not uv_binary.is_file():
-        raise FileNotFoundError(f"uv binary 不存在：{uv_binary}")
     network = reserve_compose_network(project)
-    network_compose_path = trial_dir / "inputs" / "network-compose.json"
+    runtime_compose_path = (
+        trial_dir / "inputs" / "runtime-network-compose.json"
+    )
+    compose_overlay = runtime_compose_overlay(args.runtime_volume)
+    compose_overlay["networks"] = {
+        "default": {
+            "external": True,
+            "name": network["name"],
+        }
+    }
     atomic_json(
-        network_compose_path,
-        {
-            "networks": {
-                "default": {
-                    "external": True,
-                    "name": network["name"],
-                }
-            }
-        },
+        runtime_compose_path,
+        compose_overlay,
     )
 
     manifest_path = trial_dir / "campaign-manifest.json"
@@ -211,6 +224,7 @@ async def run_trial(
             ),
         },
         "source": initial_source,
+        "runtime_cache": runtime_volume,
         "harbor": {
             "root": str(args.harbor_root.resolve()),
             "git_head": _git_output(args.harbor_root.resolve(), "rev-parse", "HEAD"),
@@ -246,20 +260,24 @@ async def run_trial(
                 "source_root": str(source_root),
                 "source_bundle": source_bundle["path"],
                 "source_head": source_bundle["head"],
-                "uv_binary": str(uv_binary),
                 "allowed_bind_root": str(trial_dir),
                 "forbidden_host_paths": [
                     str(path) for path in DEFAULT_FORBIDDEN_PATHS
                 ],
                 "source_digest": before_source,
-                "install_timeout_sec": 900,
+                "runtime_volume_name": args.runtime_volume,
+                "runtime_digest": runtime_manifest["runtime_digest"],
+                "runtime_manifest_digest": runtime_manifest["manifest_digest"],
+                "runtime_lock_digest": runtime_lock["digest"],
+                "runtime_python_version": runtime_python["version"],
+                "bootstrap_timeout_sec": 900,
                 "turn_timeout_sec": task_agent_timeout_sec,
             },
         ),
         environment=EnvironmentConfig(
             type=EnvironmentType.DOCKER,
             delete=True,
-            extra_docker_compose=[network_compose_path],
+            extra_docker_compose=[runtime_compose_path],
             kwargs={"keep_containers": True},
         ),
     )
@@ -459,7 +477,16 @@ def main() -> int:
         type=Path,
         default=Path(os.environ.get("AKASIC_BENCH_UV", "/home/huashen/.local/bin/uv")),
     )
+    parser.add_argument(
+        "--runtime-volume",
+        default=os.environ.get("AKASIC_BENCH_RUNTIME_VOLUME"),
+    )
     args = parser.parse_args()
+    if not args.runtime_volume:
+        parser.error(
+            "--runtime-volume 或 AKASIC_BENCH_RUNTIME_VOLUME 是必填项；"
+            "harness 不会在 trial 内冷安装"
+        )
     if len(args.task_dir) == 1:
         return asyncio.run(run_smoke(args, args.task_dir[0]))
     return asyncio.run(run_campaign(args, args.task_dir))

--- a/benchmark/harbor_v4flash/isolation.py
+++ b/benchmark/harbor_v4flash/isolation.py
@@ -262,6 +262,7 @@ def inspect_compose_project(project_name: str) -> list[dict[str, object]]:
                 "id": item.get("Id"),
                 "name": str(item.get("Name") or "").lstrip("/"),
                 "image": item.get("Config", {}).get("Image"),
+                "image_id": item.get("Image"),
                 "status": item.get("State", {}).get("Status"),
                 "running": bool(item.get("State", {}).get("Running")),
                 "mounts": mounts,
@@ -280,8 +281,9 @@ def validate_isolation(
     project_name: str,
     allowed_bind_root: Path,
     forbidden_host_paths: list[Path],
+    allowed_volume_mounts: list[tuple[str, str]],
 ) -> dict[str, object]:
-    """拒绝主机路径泄漏、Docker 控制面和端口发布。"""
+    """拒绝非 trial bind、非 allowlist volume、Docker 控制面和端口。"""
 
     # 1. 所有容器必须属于唯一 benchmark project。
     if not project_name.startswith(BENCHMARK_PREFIX):
@@ -290,9 +292,14 @@ def validate_isolation(
         raise IsolationError("compose project 没有容器")
     allowed_root = allowed_bind_root.resolve()
     forbidden = [path.resolve() for path in forbidden_host_paths]
+    allowed_volumes = set(allowed_volume_mounts)
+    if len(allowed_volumes) != len(allowed_volume_mounts):
+        raise IsolationError("volume allowlist 含重复项")
 
-    # 2. bind mount 只能来自本 trial 证据目录，且禁止 Docker socket。
+    # 2. bind 只能来自本 trial；named volume 必须精确匹配且只读。
     checked_mounts = 0
+    checked_volume_mounts = 0
+    seen_volumes: set[tuple[str, str]] = set()
     for container in containers:
         if container.get("project") != project_name:
             raise IsolationError(f"容器 project 标签不一致：{container!r}")
@@ -303,8 +310,31 @@ def validate_isolation(
         if not isinstance(raw_mounts, list):
             raise IsolationError("容器投影 mounts 必须是数组")
         for raw_mount in raw_mounts:
-            if not isinstance(raw_mount, dict) or raw_mount.get("type") != "bind":
+            if not isinstance(raw_mount, dict):
+                raise IsolationError("容器投影 mount 必须是对象")
+            mount_type = raw_mount.get("type")
+            if mount_type == "volume":
+                checked_mount = (
+                    str(raw_mount.get("source") or ""),
+                    str(raw_mount.get("destination") or ""),
+                )
+                if bool(raw_mount.get("rw")):
+                    raise IsolationError(
+                        f"benchmark runtime volume 必须只读：{checked_mount!r}"
+                    )
+                if checked_mount not in allowed_volumes:
+                    raise IsolationError(
+                        f"volume mount 不在 allowlist：{checked_mount!r}"
+                    )
+                if checked_mount in seen_volumes:
+                    raise IsolationError(
+                        f"volume mount 重复：{checked_mount!r}"
+                    )
+                seen_volumes.add(checked_mount)
+                checked_volume_mounts += 1
                 continue
+            if mount_type != "bind":
+                raise IsolationError(f"benchmark 禁止 mount 类型：{mount_type!r}")
             checked_mounts += 1
             source = Path(str(raw_mount.get("source") or "")).resolve()
             destination = str(raw_mount.get("destination") or "")
@@ -317,12 +347,20 @@ def validate_isolation(
             for path in forbidden:
                 if source == path or path in source.parents or source in path.parents:
                     raise IsolationError(f"bind mount 触及受保护路径：{source}")
+    if seen_volumes != allowed_volumes:
+        missing = sorted(allowed_volumes - seen_volumes)
+        raise IsolationError(f"缺少 allowlist volume mount：{missing!r}")
 
     return {
         "status": "passed",
         "project": project_name,
         "container_count": len(containers),
         "checked_bind_mounts": checked_mounts,
+        "checked_volume_mounts": checked_volume_mounts,
+        "allowed_volume_mounts": [
+            {"source": source, "destination": destination, "rw": False}
+            for source, destination in sorted(allowed_volumes)
+        ],
         "containers": containers,
     }
 

--- a/benchmark/harbor_v4flash/isolation.py
+++ b/benchmark/harbor_v4flash/isolation.py
@@ -252,6 +252,7 @@ def inspect_compose_project(project_name: str) -> list[dict[str, object]]:
             mounts.append(
                 {
                     "type": mount.get("Type"),
+                    "name": mount.get("Name"),
                     "source": mount.get("Source"),
                     "destination": mount.get("Destination"),
                     "rw": bool(mount.get("RW")),
@@ -315,7 +316,7 @@ def validate_isolation(
             mount_type = raw_mount.get("type")
             if mount_type == "volume":
                 checked_mount = (
-                    str(raw_mount.get("source") or ""),
+                    str(raw_mount.get("name") or ""),
                     str(raw_mount.get("destination") or ""),
                 )
                 if bool(raw_mount.get("rw")):

--- a/benchmark/harbor_v4flash/runtime_volume.py
+++ b/benchmark/harbor_v4flash/runtime_volume.py
@@ -1,0 +1,668 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from benchmark.harbor_v4flash.isolation import sha256_file
+
+RUNTIME_VOLUME_PREFIX = "akasic-bench-runtime-v1-"
+RUNTIME_VOLUME_SCHEMA = "akasic.benchmark-runtime.v1"
+RUNTIME_MOUNT_PATH = "/opt/akashic-runtime"
+RUNTIME_VENV_PATH = f"{RUNTIME_MOUNT_PATH}/venv"
+DEFAULT_PYTHON_VERSION = "3.13.7"
+DEFAULT_BUILDER_IMAGE = "debian:bookworm-slim"
+RUNTIME_TOP_LEVEL = ("manifest.json", "python", "resolved.lock", "venv")
+RUNTIME_BUILD_RECIPE = {
+    "id": "uv-managed-python-relocatable-venv-v1",
+    "python_install": "uv-python-install-no-cache",
+    "venv": "uv-venv-relocatable",
+    "dependency_install": "uv-pip-sync-require-hashes-strict-no-cache",
+    "builder_root": "read-only",
+    "builder_cache": "ephemeral-tmpfs",
+}
+_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_LABEL_PREFIX = "akasic.benchmark.runtime"
+
+
+class RuntimeVolumeError(RuntimeError):
+    pass
+
+
+def _canonical_digest(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _run(
+    command: list[str],
+    *,
+    text: bool = True,
+) -> subprocess.CompletedProcess[Any]:
+    result = subprocess.run(
+        command,
+        check=False,
+        text=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stdout = result.stdout if isinstance(result.stdout, str) else ""
+        stderr = result.stderr if isinstance(result.stderr, str) else ""
+        output = "\n".join((stdout, stderr)).strip()
+        raise RuntimeVolumeError(
+            f"命令失败，exit={result.returncode}：{' '.join(command[:4])}\n"
+            f"{output[-4000:]}"
+        )
+    return result
+
+
+def _docker_platform() -> str:
+    result = _run(
+        ["docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"]
+    )
+    platform = result.stdout.strip()
+    if platform not in {"linux/amd64", "linux/arm64"}:
+        raise RuntimeVolumeError(f"runtime volume 不支持 Docker 平台：{platform}")
+    return platform
+
+
+def _resolver_platform(platform: str) -> str:
+    return {
+        "linux/amd64": "x86_64-unknown-linux-gnu",
+        "linux/arm64": "aarch64-unknown-linux-gnu",
+    }[platform]
+
+
+def _uv_identity(uv_binary: Path) -> dict[str, str]:
+    uv_binary = uv_binary.resolve()
+    if not uv_binary.is_file():
+        raise FileNotFoundError(f"uv binary 不存在：{uv_binary}")
+    version = _run([str(uv_binary), "--version"]).stdout.strip()
+    if not version.startswith("uv "):
+        raise RuntimeVolumeError(f"无法识别 uv 版本：{version!r}")
+    return {
+        "version": version,
+        "digest": sha256_file(uv_binary),
+    }
+
+
+def _requirements_identity(source_root: Path) -> dict[str, object]:
+    requirements_path = source_root.resolve() / "requirements.txt"
+    if not requirements_path.is_file():
+        raise FileNotFoundError(f"requirements.txt 不存在：{requirements_path}")
+    base_digest = sha256_file(requirements_path)
+    extras = ["tzdata"]
+    return {
+        "source": "requirements.txt",
+        "source_digest": base_digest,
+        "extras": extras,
+        "digest": _canonical_digest(
+            {
+                "source_digest": base_digest,
+                "extras": extras,
+            }
+        ),
+    }
+
+
+def _resolve_lock(
+    *,
+    source_root: Path,
+    uv_binary: Path,
+    python_version: str,
+    resolver_platform: str,
+    output_path: Path,
+) -> None:
+    """把声明依赖解析为稳定、带 distribution hash 的 runtime lock。"""
+
+    # 1. 额外依赖独立输入，避免改写项目 requirements.txt。
+    extras_path = output_path.with_name("runtime-extras.in")
+    extras_path.write_text("tzdata\n", encoding="utf-8")
+
+    # 2. 不使用持久 uv cache，输出不含临时路径或生成命令。
+    _run(
+        [
+            str(uv_binary.resolve()),
+            "pip",
+            "compile",
+            str(source_root.resolve() / "requirements.txt"),
+            str(extras_path),
+            "--python-version",
+            python_version,
+            "--python-platform",
+            resolver_platform,
+            "--generate-hashes",
+            "--no-annotate",
+            "--no-header",
+            "--no-cache",
+            "--output-file",
+            str(output_path),
+        ]
+    )
+    if not output_path.is_file() or not output_path.read_bytes():
+        raise RuntimeVolumeError("uv 没有生成 resolved.lock")
+
+
+def _builder_image_identity(reference: str) -> dict[str, object]:
+    """拉取 builder tag，并把后续写入固定到不可变 image ID。"""
+
+    # 1. 显式 builder 命令才允许拉取镜像。
+    _run(["docker", "pull", reference])
+
+    # 2. Docker image ID 和平台进入 recipe，tag 漂移会生成新 volume。
+    inspected = _run(["docker", "image", "inspect", reference]).stdout
+    payload: object = json.loads(inspected)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise RuntimeVolumeError("docker image inspect 必须返回一个 builder image")
+    raw = payload[0]
+    if not isinstance(raw, dict):
+        raise RuntimeVolumeError("builder image inspect 元素必须是对象")
+    image: dict[str, Any] = raw
+    image_id = str(image.get("Id") or "")
+    image_platform = f"{image.get('Os')}/{image.get('Architecture')}"
+    if not image_id.startswith("sha256:"):
+        raise RuntimeVolumeError("builder image 缺少不可变 image ID")
+    return {
+        "reference": reference,
+        "id": image_id,
+        "repo_digests": sorted(str(value) for value in image.get("RepoDigests") or []),
+        "platform": image_platform,
+    }
+
+
+def create_runtime_manifest(
+    *,
+    requirements: dict[str, object],
+    uv: dict[str, str],
+    python_version: str,
+    platform: str,
+    resolver_platform: str,
+    builder_image: dict[str, object],
+    resolved_lock_digest: str,
+) -> dict[str, object]:
+    """生成决定 volume 名称和 labels 的确定性 runtime manifest。"""
+
+    # 1. recipe 只包含可复算身份，不包含时间、主机路径或 secret。
+    recipe = {
+        "build": RUNTIME_BUILD_RECIPE,
+        "requirements": requirements,
+        "uv": uv,
+        "python": {
+            "implementation": "cpython",
+            "version": python_version,
+        },
+        "platform": {
+            "docker": platform,
+            "resolver": resolver_platform,
+        },
+        "builder_image": builder_image,
+        "resolved_lock": {
+            "path": "resolved.lock",
+            "digest": resolved_lock_digest,
+            "format": "requirements.txt-with-hashes",
+        },
+    }
+    recipe_digest = _canonical_digest(recipe)
+    runtime_digest = _canonical_digest(
+        {
+            "schema": RUNTIME_VOLUME_SCHEMA,
+            "recipe_digest": recipe_digest,
+        }
+    )
+    volume_name = (
+        RUNTIME_VOLUME_PREFIX
+        + runtime_digest.removeprefix("sha256:")[:24]
+    )
+
+    # 2. manifest 自身另有摘要，trial 可同时校验 recipe 与文件内容。
+    base = {
+        "schema": RUNTIME_VOLUME_SCHEMA,
+        "volume_name": volume_name,
+        "runtime_digest": runtime_digest,
+        "recipe_digest": recipe_digest,
+        "recipe": recipe,
+        "contents": {
+            "mount_path": RUNTIME_MOUNT_PATH,
+            "venv_path": "venv",
+            "top_level": list(RUNTIME_TOP_LEVEL),
+            "contains_source": False,
+            "contains_home": False,
+            "contains_workspace": False,
+            "contains_task_data": False,
+            "contains_secrets": False,
+            "contains_uv_cache": False,
+        },
+    }
+    return {
+        **base,
+        "manifest_digest": _canonical_digest(base),
+    }
+
+
+def runtime_volume_labels(manifest: dict[str, object]) -> dict[str, str]:
+    recipe = manifest["recipe"]
+    if not isinstance(recipe, dict):
+        raise RuntimeVolumeError("runtime manifest recipe 必须是对象")
+    requirements = recipe["requirements"]
+    uv = recipe["uv"]
+    python = recipe["python"]
+    platform = recipe["platform"]
+    lock = recipe["resolved_lock"]
+    builder = recipe["builder_image"]
+    if not all(
+        isinstance(value, dict)
+        for value in (requirements, uv, python, platform, lock, builder)
+    ):
+        raise RuntimeVolumeError("runtime manifest recipe 字段必须是对象")
+    return {
+        f"{_LABEL_PREFIX}.managed": "true",
+        f"{_LABEL_PREFIX}.schema": str(manifest["schema"]),
+        f"{_LABEL_PREFIX}.volume_name": str(manifest["volume_name"]),
+        f"{_LABEL_PREFIX}.digest": str(manifest["runtime_digest"]),
+        f"{_LABEL_PREFIX}.manifest_digest": str(manifest["manifest_digest"]),
+        f"{_LABEL_PREFIX}.recipe_digest": str(manifest["recipe_digest"]),
+        f"{_LABEL_PREFIX}.requirements_digest": str(requirements["digest"]),
+        f"{_LABEL_PREFIX}.uv_digest": str(uv["digest"]),
+        f"{_LABEL_PREFIX}.uv_version": str(uv["version"]),
+        f"{_LABEL_PREFIX}.python": str(python["version"]),
+        f"{_LABEL_PREFIX}.platform": str(platform["docker"]),
+        f"{_LABEL_PREFIX}.resolved_lock_digest": str(lock["digest"]),
+        f"{_LABEL_PREFIX}.builder_image_id": str(builder["id"]),
+    }
+
+
+def _inspect_volume(volume_name: str) -> dict[str, object]:
+    if not _VOLUME_NAME_PATTERN.fullmatch(volume_name):
+        raise RuntimeVolumeError(f"Docker volume 名称不合法：{volume_name!r}")
+    result = _run(["docker", "volume", "inspect", volume_name]).stdout
+    payload: object = json.loads(result)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise RuntimeVolumeError("docker volume inspect 必须返回一个 volume")
+    raw = payload[0]
+    if not isinstance(raw, dict):
+        raise RuntimeVolumeError("docker volume inspect 元素必须是对象")
+    return raw
+
+
+def _read_volume_file(
+    *,
+    volume_name: str,
+    image_id: str,
+    relative_path: str,
+) -> bytes:
+    result = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--network",
+            "none",
+            "--mount",
+            (
+                f"type=volume,src={volume_name},"
+                f"dst={RUNTIME_MOUNT_PATH},readonly"
+            ),
+            "--entrypoint",
+            "/bin/cat",
+            image_id,
+            f"{RUNTIME_MOUNT_PATH}/{relative_path}",
+        ],
+        text=False,
+    )
+    return bytes(result.stdout)
+
+
+def _volume_top_level(volume_name: str, image_id: str) -> list[str]:
+    result = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--network",
+            "none",
+            "--mount",
+            (
+                f"type=volume,src={volume_name},"
+                f"dst={RUNTIME_MOUNT_PATH},readonly"
+            ),
+            "--entrypoint",
+            "/bin/sh",
+            image_id,
+            "-c",
+            (
+                f"find {RUNTIME_MOUNT_PATH} -mindepth 1 -maxdepth 1 "
+                "-printf '%f\\n' | LC_ALL=C sort"
+            ),
+        ]
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def inspect_runtime_volume(
+    volume_name: str,
+    *,
+    source_root: Path,
+    uv_binary: Path,
+) -> dict[str, object]:
+    """校验 cache identity、只读内容清单和当前 benchmark 输入。"""
+
+    # 1. Docker labels 决定用哪个不可变 builder image 只读检查 volume。
+    volume = _inspect_volume(volume_name)
+    raw_labels = volume.get("Labels")
+    if not isinstance(raw_labels, dict):
+        raise RuntimeVolumeError("runtime volume 缺少 labels")
+    labels = {str(key): str(value) for key, value in raw_labels.items()}
+    image_id = labels.get(f"{_LABEL_PREFIX}.builder_image_id", "")
+    if not image_id.startswith("sha256:"):
+        raise RuntimeVolumeError("runtime volume 缺少 builder image ID label")
+    manifest_bytes = _read_volume_file(
+        volume_name=volume_name,
+        image_id=image_id,
+        relative_path="manifest.json",
+    )
+    raw_manifest: object = json.loads(manifest_bytes)
+    if not isinstance(raw_manifest, dict):
+        raise RuntimeVolumeError("runtime manifest 必须是对象")
+    manifest: dict[str, object] = raw_manifest
+
+    # 2. 复算 manifest、recipe、lock 和完整目录 allowlist。
+    if manifest.get("schema") != RUNTIME_VOLUME_SCHEMA:
+        raise RuntimeVolumeError("runtime manifest schema 不匹配")
+    without_digest = {
+        key: value for key, value in manifest.items() if key != "manifest_digest"
+    }
+    if manifest.get("manifest_digest") != _canonical_digest(without_digest):
+        raise RuntimeVolumeError("runtime manifest 摘要不匹配")
+    recipe = manifest.get("recipe")
+    if not isinstance(recipe, dict):
+        raise RuntimeVolumeError("runtime manifest recipe 必须是对象")
+    if manifest.get("recipe_digest") != _canonical_digest(recipe):
+        raise RuntimeVolumeError("runtime recipe 摘要不匹配")
+    runtime_digest = _canonical_digest(
+        {
+            "schema": RUNTIME_VOLUME_SCHEMA,
+            "recipe_digest": manifest["recipe_digest"],
+        }
+    )
+    if manifest.get("runtime_digest") != runtime_digest:
+        raise RuntimeVolumeError("runtime digest 不匹配")
+    expected_name = (
+        RUNTIME_VOLUME_PREFIX + runtime_digest.removeprefix("sha256:")[:24]
+    )
+    if manifest.get("volume_name") != volume_name or volume_name != expected_name:
+        raise RuntimeVolumeError("runtime volume 名称与 digest 不匹配")
+    if labels != runtime_volume_labels(manifest):
+        raise RuntimeVolumeError("runtime volume labels 与 manifest 不匹配")
+    lock_bytes = _read_volume_file(
+        volume_name=volume_name,
+        image_id=image_id,
+        relative_path="resolved.lock",
+    )
+    lock_digest = f"sha256:{hashlib.sha256(lock_bytes).hexdigest()}"
+    resolved_lock = recipe.get("resolved_lock")
+    if not isinstance(resolved_lock, dict) or resolved_lock.get("digest") != lock_digest:
+        raise RuntimeVolumeError("runtime resolved.lock 摘要不匹配")
+    if _volume_top_level(volume_name, image_id) != list(RUNTIME_TOP_LEVEL):
+        raise RuntimeVolumeError("runtime volume 含 allowlist 外内容")
+
+    # 3. 当前源码依赖、uv、Python 与 Docker 平台必须命中同一 recipe。
+    platform = _docker_platform()
+    if recipe.get("requirements") != _requirements_identity(source_root):
+        raise RuntimeVolumeError("runtime volume requirements 与当前源码不匹配")
+    if recipe.get("build") != RUNTIME_BUILD_RECIPE:
+        raise RuntimeVolumeError("runtime volume builder recipe 不匹配")
+    if recipe.get("uv") != _uv_identity(uv_binary):
+        raise RuntimeVolumeError("runtime volume uv 与当前 builder 输入不匹配")
+    python = recipe.get("python")
+    if not isinstance(python, dict) or python.get("version") != DEFAULT_PYTHON_VERSION:
+        raise RuntimeVolumeError("runtime volume Python 版本不匹配")
+    recipe_platform = recipe.get("platform")
+    if not isinstance(recipe_platform, dict) or recipe_platform != {
+        "docker": platform,
+        "resolver": _resolver_platform(platform),
+    }:
+        raise RuntimeVolumeError("runtime volume 平台不匹配")
+
+    return {
+        "name": volume_name,
+        "driver": volume.get("Driver"),
+        "scope": volume.get("Scope"),
+        "created_at": volume.get("CreatedAt"),
+        "labels": labels,
+        "manifest": manifest,
+    }
+
+
+def runtime_compose_overlay(volume_name: str) -> dict[str, object]:
+    """生成 Harbor main service 的唯一共享 runtime 只读挂载。"""
+
+    if not _VOLUME_NAME_PATTERN.fullmatch(volume_name):
+        raise RuntimeVolumeError(f"Docker volume 名称不合法：{volume_name!r}")
+    return {
+        "services": {
+            "main": {
+                "volumes": [
+                    {
+                        "type": "volume",
+                        "source": "akasic_runtime",
+                        "target": RUNTIME_MOUNT_PATH,
+                        "read_only": True,
+                    }
+                ]
+            }
+        },
+        "volumes": {
+            "akasic_runtime": {
+                "external": True,
+                "name": volume_name,
+            }
+        },
+    }
+
+
+def build_runtime_volume(
+    *,
+    source_root: Path,
+    uv_binary: Path,
+    python_version: str,
+    builder_image_reference: str,
+) -> dict[str, object]:
+    """显式解析依赖，并由唯一 builder 创建不可变 runtime volume。"""
+
+    # 1. 冻结所有 recipe 输入，解析不依赖宿主 uv cache 的 lock。
+    if python_version != DEFAULT_PYTHON_VERSION:
+        raise RuntimeVolumeError(
+            "benchmark runtime Python 已冻结为 "
+            f"{DEFAULT_PYTHON_VERSION}，不接受 {python_version}"
+        )
+    source_root = source_root.resolve()
+    uv_binary = uv_binary.resolve()
+    platform = _docker_platform()
+    resolver_platform = _resolver_platform(platform)
+    requirements = _requirements_identity(source_root)
+    uv = _uv_identity(uv_binary)
+    builder_image = _builder_image_identity(builder_image_reference)
+    if builder_image["platform"] != platform:
+        raise RuntimeVolumeError(
+            "builder image 平台不匹配："
+            f"{builder_image['platform']} != {platform}"
+        )
+    with tempfile.TemporaryDirectory(prefix="akasic-runtime-volume-") as raw_temp:
+        temp_root = Path(raw_temp)
+        lock_path = temp_root / "resolved.lock"
+        _resolve_lock(
+            source_root=source_root,
+            uv_binary=uv_binary,
+            python_version=python_version,
+            resolver_platform=resolver_platform,
+            output_path=lock_path,
+        )
+        manifest = create_runtime_manifest(
+            requirements=requirements,
+            uv=uv,
+            python_version=python_version,
+            platform=platform,
+            resolver_platform=resolver_platform,
+            builder_image=builder_image,
+            resolved_lock_digest=sha256_file(lock_path),
+        )
+        volume_name = str(manifest["volume_name"])
+        manifest_path = temp_root / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        # 2. 已存在 cache 只能校验复用；不覆盖身份相同但内容损坏的 volume。
+        exists = subprocess.run(
+            ["docker", "volume", "inspect", volume_name],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode == 0
+        if exists:
+            return inspect_runtime_volume(
+                volume_name,
+                source_root=source_root,
+                uv_binary=uv_binary,
+            )
+
+        create_command = ["docker", "volume", "create"]
+        for key, value in sorted(runtime_volume_labels(manifest).items()):
+            create_command.extend(["--label", f"{key}={value}"])
+        create_command.append(volume_name)
+        created = _run(create_command).stdout.strip()
+        if created != volume_name:
+            raise RuntimeVolumeError(
+                f"Docker 创建了非预期 volume：{created!r}"
+            )
+
+        # 3. builder 的根文件系统和临时 cache 均为一次性，只有目标 volume 可写。
+        builder_script = (
+            f"test -z \"$(find {RUNTIME_MOUNT_PATH} -mindepth 1 "
+            "-maxdepth 1 -print -quit)\"\n"
+            f"mkdir -p {RUNTIME_MOUNT_PATH}/python\n"
+            f"/tools/uv python install \"$PYTHON_VERSION\" "
+            f"--install-dir {RUNTIME_MOUNT_PATH}/python --no-cache --no-bin\n"
+            f"set -- {RUNTIME_MOUNT_PATH}/python/"
+            "cpython-${PYTHON_VERSION}-*/bin/python3.13\n"
+            "test \"$#\" -eq 1 && test -x \"$1\"\n"
+            f"/tools/uv venv --relocatable --python \"$1\" "
+            f"{RUNTIME_VENV_PATH}\n"
+            f"/tools/uv pip sync --python {RUNTIME_VENV_PATH}/bin/python "
+            "/inputs/resolved.lock --require-hashes --strict --no-cache\n"
+            f"cp /inputs/resolved.lock {RUNTIME_MOUNT_PATH}/resolved.lock\n"
+            f"cp /inputs/manifest.json {RUNTIME_MOUNT_PATH}/manifest.json\n"
+            f"test \"$({RUNTIME_VENV_PATH}/bin/python -c "
+            "'import platform; print(platform.python_version())')\" "
+            "= \"$PYTHON_VERSION\"\n"
+            f"chmod -R a-w {RUNTIME_MOUNT_PATH}\n"
+        )
+        try:
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--read-only",
+                    "--network",
+                    "bridge",
+                    "--tmpfs",
+                    "/tmp:rw,exec,nosuid,nodev,size=8589934592",
+                    "--mount",
+                    (
+                        f"type=volume,src={volume_name},"
+                        f"dst={RUNTIME_MOUNT_PATH}"
+                    ),
+                    "--mount",
+                    (
+                        f"type=bind,src={uv_binary},"
+                        "dst=/tools/uv,readonly"
+                    ),
+                    "--mount",
+                    (
+                        f"type=bind,src={lock_path},"
+                        "dst=/inputs/resolved.lock,readonly"
+                    ),
+                    "--mount",
+                    (
+                        f"type=bind,src={manifest_path},"
+                        "dst=/inputs/manifest.json,readonly"
+                    ),
+                    "--env",
+                    "HOME=/tmp/home",
+                    "--env",
+                    "UV_CACHE_DIR=/tmp/uv-cache",
+                    "--env",
+                    f"PYTHON_VERSION={python_version}",
+                    "--entrypoint",
+                    "/bin/sh",
+                    str(builder_image["id"]),
+                    "-eu",
+                    "-c",
+                    builder_script,
+                ]
+            )
+        except Exception as error:
+            raise RuntimeVolumeError(
+                f"runtime volume 构建失败，保留现场 {volume_name}；"
+                "修复根因后需显式删除该 volume 再重建"
+            ) from error
+
+    return inspect_runtime_volume(
+        volume_name,
+        source_root=source_root,
+        uv_binary=uv_binary,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["build", "inspect"])
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument(
+        "--uv-binary",
+        type=Path,
+        default=Path(
+            os.environ.get("AKASIC_BENCH_UV", "/home/huashen/.local/bin/uv")
+        ),
+    )
+    parser.add_argument("--volume")
+    parser.add_argument("--builder-image", default=DEFAULT_BUILDER_IMAGE)
+    args = parser.parse_args()
+
+    if args.command == "build":
+        report = build_runtime_volume(
+            source_root=args.source_root,
+            uv_binary=args.uv_binary,
+            python_version=DEFAULT_PYTHON_VERSION,
+            builder_image_reference=args.builder_image,
+        )
+    else:
+        if not args.volume:
+            parser.error("--volume 是 inspect 的必填参数")
+        report = inspect_runtime_volume(
+            args.volume,
+            source_root=args.source_root,
+            uv_binary=args.uv_binary,
+        )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_harbor_v4flash_isolation.py
+++ b/tests/benchmark/test_harbor_v4flash_isolation.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import subprocess
 from pathlib import Path
 
@@ -8,13 +9,21 @@ from benchmark.harbor_v4flash.isolation import (
     IsolationError,
     artifact_digests,
     compose_project_name,
+    inspect_compose_project,
     reserve_compose_network,
     sha256_file,
     validate_isolation,
 )
+from benchmark.harbor_v4flash.runtime_volume import RUNTIME_MOUNT_PATH
 
 
-def _container(*, source: str, ports: dict[str, object] | None = None) -> dict[str, object]:
+def _container(
+    *,
+    source: str,
+    ports: dict[str, object] | None = None,
+    volume_source: str = "akasic-bench-runtime-v1-fixed",
+    volume_rw: bool = False,
+) -> dict[str, object]:
     return {
         "id": "container",
         "name": "trial-client-1",
@@ -28,7 +37,13 @@ def _container(*, source: str, ports: dict[str, object] | None = None) -> dict[s
                 "source": source,
                 "destination": "/logs/agent",
                 "rw": True,
-            }
+            },
+            {
+                "type": "volume",
+                "source": volume_source,
+                "destination": RUNTIME_MOUNT_PATH,
+                "rw": volume_rw,
+            },
         ],
         "ports": ports or {},
     }
@@ -79,6 +94,49 @@ def test_reserve_compose_network_rejects_non_benchmark_owner() -> None:
         reserve_compose_network("production_default")
 
 
+def test_inspect_compose_project_records_immutable_image_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="container-id\n", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "Id": "container-id",
+                            "Name": "/trial-main-1",
+                            "Image": "sha256:image-id",
+                            "Config": {
+                                "Image": "task:tag",
+                                "Labels": {
+                                    "com.docker.compose.project": (
+                                        "akasic-bench-v4flash-smoke__env"
+                                    )
+                                },
+                            },
+                            "State": {"Status": "running", "Running": True},
+                            "Mounts": [],
+                            "HostConfig": {"PortBindings": {}},
+                        }
+                    ]
+                ),
+                stderr="",
+            ),
+        ]
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *_, **__: next(responses))
+
+    containers = inspect_compose_project(
+        "akasic-bench-v4flash-smoke__env"
+    )
+
+    assert containers[0]["image"] == "task:tag"
+    assert containers[0]["image_id"] == "sha256:image-id"
+
+
 def test_validate_isolation_accepts_only_trial_bind_mounts(tmp_path: Path) -> None:
     trial = tmp_path / "trial"
     logs = trial / "agent"
@@ -90,10 +148,14 @@ def test_validate_isolation_accepts_only_trial_bind_mounts(tmp_path: Path) -> No
         project_name=project,
         allowed_bind_root=trial,
         forbidden_host_paths=[tmp_path / "online"],
+        allowed_volume_mounts=[
+            ("akasic-bench-runtime-v1-fixed", RUNTIME_MOUNT_PATH)
+        ],
     )
 
     assert report["status"] == "passed"
     assert report["checked_bind_mounts"] == 1
+    assert report["checked_volume_mounts"] == 1
 
 
 @pytest.mark.parametrize(
@@ -118,6 +180,57 @@ def test_validate_isolation_rejects_host_escape(
             project_name=project,
             allowed_bind_root=allowed,
             forbidden_host_paths=[Path("/home/huashen/.akashic/workspace")],
+            allowed_volume_mounts=[
+                ("akasic-bench-runtime-v1-fixed", RUNTIME_MOUNT_PATH)
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    ("volume_source", "volume_rw"),
+    [
+        ("other-volume", False),
+        ("akasic-bench-runtime-v1-fixed", True),
+    ],
+)
+def test_validate_isolation_rejects_unapproved_or_writable_volume(
+    volume_source: str,
+    volume_rw: bool,
+) -> None:
+    project = "akasic-bench-v4flash-smoke__env"
+
+    with pytest.raises(IsolationError):
+        validate_isolation(
+            [
+                _container(
+                    source="/tmp/allowed/agent",
+                    volume_source=volume_source,
+                    volume_rw=volume_rw,
+                )
+            ],
+            project_name=project,
+            allowed_bind_root=Path("/tmp/allowed"),
+            forbidden_host_paths=[],
+            allowed_volume_mounts=[
+                ("akasic-bench-runtime-v1-fixed", RUNTIME_MOUNT_PATH)
+            ],
+        )
+
+
+def test_validate_isolation_rejects_missing_runtime_volume() -> None:
+    project = "akasic-bench-v4flash-smoke__env"
+    container = _container(source="/tmp/allowed/agent")
+    container["mounts"] = container["mounts"][:1]
+
+    with pytest.raises(IsolationError, match="缺少 allowlist volume"):
+        validate_isolation(
+            [container],
+            project_name=project,
+            allowed_bind_root=Path("/tmp/allowed"),
+            forbidden_host_paths=[],
+            allowed_volume_mounts=[
+                ("akasic-bench-runtime-v1-fixed", RUNTIME_MOUNT_PATH)
+            ],
         )
 
 

--- a/tests/benchmark/test_harbor_v4flash_isolation.py
+++ b/tests/benchmark/test_harbor_v4flash_isolation.py
@@ -21,7 +21,7 @@ def _container(
     *,
     source: str,
     ports: dict[str, object] | None = None,
-    volume_source: str = "akasic-bench-runtime-v1-fixed",
+    volume_name: str = "akasic-bench-runtime-v1-fixed",
     volume_rw: bool = False,
 ) -> dict[str, object]:
     return {
@@ -40,7 +40,8 @@ def _container(
             },
             {
                 "type": "volume",
-                "source": volume_source,
+                "name": volume_name,
+                "source": f"/var/lib/docker/volumes/{volume_name}/_data",
                 "destination": RUNTIME_MOUNT_PATH,
                 "rw": volume_rw,
             },
@@ -118,7 +119,18 @@ def test_inspect_compose_project_records_immutable_image_id(
                                 },
                             },
                             "State": {"Status": "running", "Running": True},
-                            "Mounts": [],
+                            "Mounts": [
+                                {
+                                    "Type": "volume",
+                                    "Name": "akasic-bench-runtime-v1-fixed",
+                                    "Source": (
+                                        "/var/lib/docker/volumes/"
+                                        "akasic-bench-runtime-v1-fixed/_data"
+                                    ),
+                                    "Destination": RUNTIME_MOUNT_PATH,
+                                    "RW": False,
+                                }
+                            ],
                             "HostConfig": {"PortBindings": {}},
                         }
                     ]
@@ -135,6 +147,9 @@ def test_inspect_compose_project_records_immutable_image_id(
 
     assert containers[0]["image"] == "task:tag"
     assert containers[0]["image_id"] == "sha256:image-id"
+    assert containers[0]["mounts"][0]["name"] == (
+        "akasic-bench-runtime-v1-fixed"
+    )
 
 
 def test_validate_isolation_accepts_only_trial_bind_mounts(tmp_path: Path) -> None:
@@ -187,14 +202,14 @@ def test_validate_isolation_rejects_host_escape(
 
 
 @pytest.mark.parametrize(
-    ("volume_source", "volume_rw"),
+    ("volume_name", "volume_rw"),
     [
         ("other-volume", False),
         ("akasic-bench-runtime-v1-fixed", True),
     ],
 )
 def test_validate_isolation_rejects_unapproved_or_writable_volume(
-    volume_source: str,
+    volume_name: str,
     volume_rw: bool,
 ) -> None:
     project = "akasic-bench-v4flash-smoke__env"
@@ -204,7 +219,7 @@ def test_validate_isolation_rejects_unapproved_or_writable_volume(
             [
                 _container(
                     source="/tmp/allowed/agent",
-                    volume_source=volume_source,
+                    volume_name=volume_name,
                     volume_rw=volume_rw,
                 )
             ],

--- a/tests/benchmark/test_harbor_v4flash_runtime_volume.py
+++ b/tests/benchmark/test_harbor_v4flash_runtime_volume.py
@@ -1,0 +1,169 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmark.harbor_v4flash.runtime_volume import (
+    DEFAULT_PYTHON_VERSION,
+    RUNTIME_MOUNT_PATH,
+    RUNTIME_TOP_LEVEL,
+    RuntimeVolumeError,
+    build_runtime_volume,
+    create_runtime_manifest,
+    inspect_runtime_volume,
+    runtime_compose_overlay,
+    runtime_volume_labels,
+)
+
+
+def _manifest() -> tuple[dict[str, object], bytes]:
+    lock_bytes = b"example==1.0 --hash=sha256:abc\n"
+    manifest = create_runtime_manifest(
+        requirements={
+            "source": "requirements.txt",
+            "source_digest": "sha256:requirements-source",
+            "extras": ["tzdata"],
+            "digest": "sha256:requirements",
+        },
+        uv={
+            "version": "uv 0.8.23",
+            "digest": "sha256:uv",
+        },
+        python_version=DEFAULT_PYTHON_VERSION,
+        platform="linux/amd64",
+        resolver_platform="x86_64-unknown-linux-gnu",
+        builder_image={
+            "reference": "debian:bookworm-slim",
+            "id": "sha256:builder",
+            "repo_digests": ["debian@sha256:repo"],
+            "platform": "linux/amd64",
+        },
+        resolved_lock_digest=(
+            f"sha256:{hashlib.sha256(lock_bytes).hexdigest()}"
+        ),
+    )
+    return manifest, lock_bytes
+
+
+def test_runtime_manifest_and_compose_freeze_identity() -> None:
+    manifest, _ = _manifest()
+    volume_name = str(manifest["volume_name"])
+
+    assert volume_name.startswith("akasic-bench-runtime-v1-")
+    assert runtime_volume_labels(manifest)[
+        "akasic.benchmark.runtime.resolved_lock_digest"
+    ] == manifest["recipe"]["resolved_lock"]["digest"]
+    assert runtime_compose_overlay(volume_name) == {
+        "services": {
+            "main": {
+                "volumes": [
+                    {
+                        "type": "volume",
+                        "source": "akasic_runtime",
+                        "target": RUNTIME_MOUNT_PATH,
+                        "read_only": True,
+                    }
+                ]
+            }
+        },
+        "volumes": {
+            "akasic_runtime": {
+                "external": True,
+                "name": volume_name,
+            }
+        },
+    }
+
+
+def test_inspect_runtime_volume_verifies_manifest_lock_and_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest, lock_bytes = _manifest()
+    volume_name = str(manifest["volume_name"])
+    labels = runtime_volume_labels(manifest)
+    requirements = manifest["recipe"]["requirements"]
+    uv = manifest["recipe"]["uv"]
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._inspect_volume",
+        lambda _: {
+            "Driver": "local",
+            "Scope": "local",
+            "CreatedAt": "fixed",
+            "Labels": labels,
+        },
+    )
+
+    def read_file(**kwargs: str) -> bytes:
+        if kwargs["relative_path"] == "manifest.json":
+            return json.dumps(manifest).encode()
+        return lock_bytes
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._read_volume_file",
+        read_file,
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._volume_top_level",
+        lambda *_: list(RUNTIME_TOP_LEVEL),
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._docker_platform",
+        lambda: "linux/amd64",
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._requirements_identity",
+        lambda _: requirements,
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._uv_identity",
+        lambda _: uv,
+    )
+
+    report = inspect_runtime_volume(
+        volume_name,
+        source_root=tmp_path,
+        uv_binary=tmp_path / "uv",
+    )
+
+    assert report["name"] == volume_name
+    assert report["manifest"] == manifest
+
+
+def test_inspect_runtime_volume_rejects_label_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest()
+    volume_name = str(manifest["volume_name"])
+    labels = runtime_volume_labels(manifest)
+    labels["akasic.benchmark.runtime.uv_version"] = "uv changed"
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._inspect_volume",
+        lambda _: {"Labels": labels},
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._read_volume_file",
+        lambda **_: json.dumps(manifest).encode(),
+    )
+
+    with pytest.raises(RuntimeVolumeError, match="labels"):
+        inspect_runtime_volume(
+            volume_name,
+            source_root=tmp_path,
+            uv_binary=tmp_path / "uv",
+        )
+
+
+def test_builder_rejects_non_frozen_python_before_docker(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RuntimeVolumeError, match="已冻结"):
+        build_runtime_volume(
+            source_root=tmp_path,
+            uv_binary=tmp_path / "uv",
+            python_version="3.13.8",
+            builder_image_reference="debian:bookworm-slim",
+        )


### PR DESCRIPTION
## 问题与结果

- 解决的问题：每个独立 Harbor task 都重新下载 Python、创建 venv、解析并安装 Akasic 依赖；Caffe 诊断题仅 runtime setup 就约 391 秒。
- 用户可见结果：显式构建一次按依赖身份命名的 Docker volume，后续 trial 只读复用 Python 3.13.7、relocatable venv 和 hash-locked dependencies；cache miss 或身份不一致直接失败，不在 trial 内回退冷安装。
- 本 PR 不处理：不共享 task data、HOME、workspace、trace、源码、secret 或 uv cache；不缓存 CIFAR/Caffe 下载；镜像缺 Git 时仍按 task image 的包管理器安装 Git；不运行 89 题最终 eval。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`not_applicable`（benchmark harness）
- `consumer_scope`：`benchmark/harbor_v4flash` 手工诊断 trial
- `runtime_patch`：`none`
- `runtime_patch_reason`：不修改线上 runtime；仅改变 benchmark task 的依赖交付方式
- `authoritative_state_owner`：显式 builder 是 runtime volume 唯一写入 owner；trial 只读
- `client_only_alternative`：不适用
- 关联不变量：每题容器/workspace/trace 独立；共享物只包含不可变解释器与第三方依赖；线上 workspace/process 不受影响
- `protected_state`：正式源码 checkout、`/home/huashen/.akashic/workspace`、plugin cache、task 初态和 verifier
- 允许的副作用：显式 builder 创建带 labels 的 Docker named volume；trial 挂载该 volume 为 `RW=false`
- 禁止的副作用：trial 写共享 volume、共享任务数据、读取线上路径、静默冷安装、删除 retained trial/container

## 改动范围

- 主要文件：`benchmark/harbor_v4flash/runtime_volume.py`、`agent.py`、`controller.py`、`isolation.py` 及定向测试
- 配置或迁移影响：无；trial 新增必填 `--runtime-volume` 或 `AKASIC_BENCH_RUNTIME_VOLUME`
- 已知 schema lineage 与最终 schema identity：`akasic.benchmark-runtime.v1`
- 不可变 revision：base `7f1cbd0bf82d31a8291582de0b80c1bdba1f3685`；head `1348be43bcc126c713efd32edf3fedaa9ece8402`；runtime volume `akasic-bench-runtime-v1-79ea7f8bd2cbcb92b44062c0`
- 回滚方式：revert `1348be43` 和 `ce5cb231`；现有 volume 不会影响未显式引用它的 trial

## 验证

- [x] `PYTHONPATH=.:sdk/python/src ...pytest`：32 passed
- [x] `compileall` 与 `git diff --check` 通过
- [x] 真实 builder 成功；同一只读 volume 在 regex-log 与 caffe-cifar-10 task image 中导入 `cryptography/numpy/scipy/sklearn/sqlite_vec` 成功
- [x] 完整 regex-log Harbor smoke 完成：reward 1，total 179.233s，agent setup 34.577s，source unchanged，online passed，container stopped-retained，19 artifacts，missing=[]
- [x] 首次 smoke 暴露 Docker `Mounts[].Source` 是宿主 mountpoint、真实名字在 `Mounts[].Name`；已用第二提交修复并用第二次完整 smoke 验证
- [x] `python docker/debug/gate.py run --base origin/fix/benchmark-retained-network-pool`：8/8 公开场景通过，residual resources 为空
- `sourceDigest`：`21b7953a8cdf40ccaa8e08f7d8c14991faf79045dd3a0a7c0df1c207f549048c`
- `planDigest`：`e1805380c650edb7605d707e9d2969075c7c2765422d9ea00fb8f4727fdedf1b`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：未跑 89 题；当前只实测 linux/amd64 的两个 glibc task image；私有 Gate 需维护者环境

## 工作手册

- [x] 已核对 `docs/INDEX.md`、`docs/WORKFLOW.md`、persistence state map、相关 benchmark design 和 `NOW.md`
- [x] 本次只改变诊断 harness 的依赖交付；不改变 task/verifier 或线上 Agent 语义
- [x] 跨仓库或客户端改动不适用
- [x] `NOW.md` 当前没有对应事项
