### PR TITLE
fix(benchmark): bind concurrency gate to source

### DIFF
--- a/benchmark/harbor_v4flash/campaign.py
+++ b/benchmark/harbor_v4flash/campaign.py
@@ -35,8 +35,12 @@ def validate_campaign_request(task_dirs: list[Path], max_concurrent: int) -> Non
         raise FileNotFoundError(f"task 目录不存在：{missing}")
 
 
-def find_open_concurrency_gate(runs_root: Path) -> dict[str, Any]:
-    """读取一个已完成 smoke 的并发授权证据。"""
+def find_open_concurrency_gate(
+    runs_root: Path,
+    *,
+    expected_source_digest: str,
+) -> dict[str, Any]:
+    """读取当前源码已完成 smoke 的并发授权证据。"""
 
     candidates: list[tuple[float, Path, dict[str, Any]]] = []
     for path in runs_root.glob("akasic-bench-v4flash-*/campaign-manifest.json"):
@@ -44,6 +48,7 @@ def find_open_concurrency_gate(runs_root: Path) -> dict[str, Any]:
         gate = payload.get("concurrency_gate")
         online = payload.get("online")
         docker = payload.get("docker")
+        source = payload.get("source")
         if (
             payload.get("state") == "completed"
             and isinstance(gate, dict)
@@ -53,10 +58,15 @@ def find_open_concurrency_gate(runs_root: Path) -> dict[str, Any]:
             and online.get("status") == "passed"
             and isinstance(docker, dict)
             and docker.get("all_stopped") is True
+            and isinstance(source, dict)
+            and source.get("digest_after") == expected_source_digest
         ):
             candidates.append((path.stat().st_mtime, path, payload))
     if not candidates:
-        raise CampaignGateError("未找到完成且隔离验证通过的 concurrency=3 smoke Gate")
+        raise CampaignGateError(
+            "未找到当前源码完成且隔离验证通过的 concurrency=3 smoke Gate："
+            f"{expected_source_digest}"
+        )
     _, path, payload = max(candidates, key=lambda item: item[0])
     return {
         "manifest": str(path),

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -389,9 +389,12 @@ async def run_campaign(
     # 1. 只有已完成 smoke 能打开并发，且整个 campaign 再次冻结源码和线上 owner。
     validate_campaign_request(task_dirs, args.max_concurrent)
     runs_root = args.runs_dir.resolve()
-    gate = find_open_concurrency_gate(runs_root)
     source_root = args.source_root.resolve()
     before_source = source_tree_digest(source_root)
+    gate = find_open_concurrency_gate(
+        runs_root,
+        expected_source_digest=before_source,
+    )
     before_online = online_process_snapshot()
     campaign_id = (
         f"{BENCHMARK_PREFIX}campaign-"

--- a/tests/benchmark/test_harbor_v4flash_campaign.py
+++ b/tests/benchmark/test_harbor_v4flash_campaign.py
@@ -48,7 +48,10 @@ def test_open_gate_requires_completed_stopped_isolated_smoke(
         encoding="utf-8",
     )
 
-    gate = find_open_concurrency_gate(tmp_path)
+    gate = find_open_concurrency_gate(
+        tmp_path,
+        expected_source_digest="sha256:source",
+    )
 
     assert gate["manifest"] == str(manifest)
     assert gate["source_digest"] == "sha256:source"
@@ -56,7 +59,34 @@ def test_open_gate_requires_completed_stopped_isolated_smoke(
 
 def test_open_gate_fails_closed_without_smoke(tmp_path: Path) -> None:
     with pytest.raises(CampaignGateError):
-        find_open_concurrency_gate(tmp_path)
+        find_open_concurrency_gate(
+            tmp_path,
+            expected_source_digest="sha256:source",
+        )
+
+
+def test_open_gate_rejects_smoke_from_different_source(tmp_path: Path) -> None:
+    trial = tmp_path / "akasic-bench-v4flash-smoke-stale"
+    trial.mkdir()
+    (trial / "campaign-manifest.json").write_text(
+        json.dumps(
+            {
+                "state": "completed",
+                "trial_name": "smoke-stale",
+                "source": {"digest_after": "sha256:old-source"},
+                "online": {"status": "passed"},
+                "docker": {"all_stopped": True},
+                "concurrency_gate": {"opened": True, "max_concurrent": 3},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CampaignGateError, match="sha256:new-source"):
+        find_open_concurrency_gate(
+            tmp_path,
+            expected_source_digest="sha256:new-source",
+        )
 
 
 def test_task_slug_is_bounded_and_docker_safe(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：之前任意历史 smoke manifest 都可能打开并发 Gate，即使随后 benchmark 源码已经变化。
- 用户可见结果：三并发 diagnostic campaign 现在只接受与当前源码 digest 完全一致的已完成 smoke；源码变化后必须重新 smoke。
- 本 PR 不处理：task reward、模型行为、磁盘容量和最终 89 题 eval。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：benchmark harness only
- `runtime_patch`：`none`
- `authoritative_state_owner`：benchmark trial manifests
- 关联不变量：并发授权必须绑定当前实验源码；旧 manifest 不能授权新源码。
- 允许的副作用：源码变化后 fail-loud，要求重新跑 smoke。
- 禁止的副作用：不得影响线上 runtime、workspace、task reward 或 Agent 行为。

## 改动范围

- `benchmark/harbor_v4flash/campaign.py`：Gate 查询要求 expected source digest。
- `benchmark/harbor_v4flash/controller.py`：campaign 启动前计算当前 digest 并传入 Gate 查询。
- `tests/benchmark/test_harbor_v4flash_campaign.py`：新增 stale-source Gate 拒绝回归。
- 回滚方式：revert `36022b3c`。

## 验证

- `PYTHONPATH=/mnt/data/coding/akasic-agent-worktrees/benchmark-gate-source-digest/sdk/python/src /mnt/data/coding/akasic-agent-worktrees/benchmark-deps/harbor-v0.16.1/.venv/bin/python -m pytest tests/benchmark -q` → `33 passed`。
- `/mnt/data/coding/akasic-agent/.venv/bin/python docker/debug/gate.py run --base origin/perf/benchmark-runtime-volume` → public Gate 8/8 passed；report `docker/debug/reports/change-gate/20260730-180334-9e157034`。
- `sourceDigest`：由 Gate report 冻结。
- `planDigest`：`7477c16a8ab6240760bc57208b0a6cea3c1a894e0cdf1d410d2ffd35d36a4680`
- `private-contract-gate`：`pending_maintainer`

## 工作手册

- 已按 `docs/INDEX.md`、`docs/WORKFLOW.md` 执行独立 worktree、targeted tests、公开 Gate 与 draft PR。
- 该修复只收紧 benchmark 并发授权，不改变 Agent 任务语义。