### PR TITLE
fix(benchmark): persist credential references only

### DIFF
--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 import time
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 
@@ -16,8 +18,10 @@ from harbor.models.task.config import TaskConfig as HarborTaskConfig
 from harbor.models.trial.config import (
     AgentConfig,
     EnvironmentConfig,
-    TaskConfig as TrialTaskConfig,
     TrialConfig,
+)
+from harbor.models.trial.config import (
+    TaskConfig as TrialTaskConfig,
 )
 from harbor.trial.trial import Trial
 
@@ -85,6 +89,23 @@ def _credential_env(profile_path: Path) -> dict[str, str]:
         "DEEPSEEK_API_KEY": deepseek,
         "DASHSCOPE_API_KEY": dashscope,
     }
+
+
+@contextmanager
+def _credential_templates(profile_path: Path) -> Iterator[dict[str, str]]:
+    """Expose credentials to Harbor by name while restoring the host environment."""
+
+    values = _credential_env(profile_path)
+    previous = {name: os.environ.get(name) for name in values}
+    os.environ.update(values)
+    try:
+        yield {name: f"${{{name}}}" for name in values}
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def _task_agent_timeout_sec(task_dir: Path) -> float:
@@ -169,7 +190,7 @@ async def run_trial(
     project = compose_project_name(f"{trial_name}__env")
     before_source = source_tree_digest(source_root)
     before_online = online_process_snapshot()
-    credential_env = _credential_env(args.credential_profile.resolve())
+    credential_env = cast(dict[str, str], args.credential_templates)
     source_bundle = create_source_bundle(
         source_root,
         trial_dir / "inputs" / "source.bundle",
@@ -490,9 +511,13 @@ def main() -> int:
             "--runtime-volume 或 AKASIC_BENCH_RUNTIME_VOLUME 是必填项；"
             "harness 不会在 trial 内冷安装"
         )
-    if len(args.task_dir) == 1:
-        return asyncio.run(run_smoke(args, args.task_dir[0]))
-    return asyncio.run(run_campaign(args, args.task_dir))
+    with _credential_templates(
+        args.credential_profile.resolve()
+    ) as credential_templates:
+        args.credential_templates = credential_templates
+        if len(args.task_dir) == 1:
+            return asyncio.run(run_smoke(args, args.task_dir[0]))
+        return asyncio.run(run_campaign(args, args.task_dir))
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import tomllib
@@ -6,11 +7,11 @@ from pathlib import Path
 import pytest
 
 from benchmark.harbor_v4flash.controller import (
+    _credential_templates,
     _inspect_finished_project,
     _task_agent_timeout_sec,
 )
-from benchmark.harbor_v4flash.isolation import IsolationError
-from benchmark.harbor_v4flash.isolation import create_source_bundle
+from benchmark.harbor_v4flash.isolation import IsolationError, create_source_bundle
 
 
 def _git(root: Path, *args: str) -> str:
@@ -47,6 +48,36 @@ def test_task_agent_timeout_uses_harbor_task_budget(tmp_path: Path) -> None:
     )
 
     assert _task_agent_timeout_sec(task_dir) == 3600.0
+
+
+def test_credential_templates_persist_names_and_restore_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = tmp_path / "config.toml"
+    profile.write_text(
+        """
+[llm.main]
+api_key = "deepseek-sentinel"
+
+[memory.embedding]
+api_key = "dashscope-sentinel"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "previous")
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+
+    with _credential_templates(profile) as templates:
+        assert templates == {
+            "DEEPSEEK_API_KEY": "${DEEPSEEK_API_KEY}",
+            "DASHSCOPE_API_KEY": "${DASHSCOPE_API_KEY}",
+        }
+        assert os.environ["DEEPSEEK_API_KEY"] == "deepseek-sentinel"
+        assert os.environ["DASHSCOPE_API_KEY"] == "dashscope-sentinel"
+
+    assert os.environ["DEEPSEEK_API_KEY"] == "previous"
+    assert "DASHSCOPE_API_KEY" not in os.environ
 
 
 @pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])


### PR DESCRIPTION
## 问题与结果

- 解决的问题：benchmark controller 从 profile 读取真实 key 后直接放入 `AgentConfig.env`，Harbor 持久化 trial config 时会保留敏感值片段，且凭据校验发生在 trial 资源预留之后。
- 用户可见结果：controller 在创建任何 trial 资源前校验 profile；运行期间只向 Harbor 配置传 `${KEY}` 引用，结束后恢复原宿主环境。
- 本 PR 不处理：Harbor Docker transport 的 argv 泄漏；该问题由 Harbor owner 的独立 patch 处理。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：benchmark harness only
- `runtime_patch`：`none`
- `authoritative_state_owner`：benchmark trial config/manifest
- 关联不变量：持久化配置不得保存真实 credential 或其片段；credential profile 必须在资源预留前 fail-loud。
- 允许副作用：controller 进程生命周期内临时设置两项环境变量并在退出时恢复。
- 禁止副作用：不得改变线上进程、正式 workspace、模型或 task 行为。

## 验证

- Benchmark targeted suite：`34 passed`。
- 真实 `dna-insert` smoke 期间：宿主 `/proc/*/cmdline` 对两项真实 secret 命中 0；trial config 完整值命中 0、前四/后三片段命中 0，两个 `${KEY}` 引用均存在。
- Public Gate 8/8 passed：`docker/debug/reports/change-gate/20260730-194555-61e2988a`。
- `planDigest`：`8a541c79d0b0629a325203fb9fa182c59f0b47ae7141e2c4b19025348915b1df`
- `private-contract-gate`：`pending_maintainer`

## 回滚

- revert `2ffb12a4`。