### PR TITLE
perf(benchmark): 复用 task image 与 Git 基础设施

### DIFF
--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -15,6 +15,7 @@ from benchmark.harbor_v4flash.isolation import (
     inspect_compose_project,
     validate_isolation,
 )
+from benchmark.harbor_v4flash.git_volume import GIT_BIN_PATH, GIT_MOUNT_PATH
 from benchmark.harbor_v4flash.result_projection import project_agent_context
 from benchmark.harbor_v4flash.runtime_volume import (
     RUNTIME_MOUNT_PATH,
@@ -56,6 +57,10 @@ class AkashicHarborAgent(BaseAgent):
         runtime_manifest_digest: str,
         runtime_lock_digest: str,
         runtime_python_version: str,
+        git_volume_name: str,
+        git_runtime_digest: str,
+        git_manifest_digest: str,
+        git_version: str,
         bootstrap_timeout_sec: int = 900,
         turn_timeout_sec: float,
         **kwargs,
@@ -74,6 +79,10 @@ class AkashicHarborAgent(BaseAgent):
         self._runtime_manifest_digest = runtime_manifest_digest
         self._runtime_lock_digest = runtime_lock_digest
         self._runtime_python_version = runtime_python_version
+        self._git_volume_name = git_volume_name
+        self._git_runtime_digest = git_runtime_digest
+        self._git_manifest_digest = git_manifest_digest
+        self._git_version = git_version
         self._bootstrap_timeout_sec = bootstrap_timeout_sec
         if turn_timeout_sec <= 0:
             raise ValueError("turn_timeout_sec 必须大于 0")
@@ -106,6 +115,29 @@ class AkashicHarborAgent(BaseAgent):
         )
         return f"{RUNTIME_VENV_PATH}/bin/python -c {shlex.quote(code)}"
 
+    def _git_check_command(self) -> str:
+        """生成只读取固定 Git manifest 并执行版本探针的校验命令。"""
+
+        expected = {
+            "volume_name": self._git_volume_name,
+            "runtime_digest": self._git_runtime_digest,
+            "manifest_digest": self._git_manifest_digest,
+            "git_version": self._git_version,
+        }
+        code = (
+            "import json,pathlib,subprocess;"
+            f"root=pathlib.Path({GIT_MOUNT_PATH!r});"
+            "manifest=json.loads((root/'manifest.json').read_text());"
+            f"expected=json.loads({json.dumps(json.dumps(expected))});"
+            "assert manifest['volume_name']==expected['volume_name'];"
+            "assert manifest['runtime_digest']==expected['runtime_digest'];"
+            "assert manifest['manifest_digest']==expected['manifest_digest'];"
+            f"version=subprocess.run([{GIT_BIN_PATH!r},'--version'],"
+            "check=True,text=True,stdout=subprocess.PIPE).stdout.strip();"
+            "assert version==expected['git_version']"
+        )
+        return f"{RUNTIME_VENV_PATH}/bin/python -c {shlex.quote(code)}"
+
     async def setup(self, environment: BaseEnvironment) -> None:
         """复制只读源码，验证共享 runtime，并证明容器隔离。"""
 
@@ -130,7 +162,8 @@ class AkashicHarborAgent(BaseAgent):
             allowed_bind_root=self._allowed_bind_root,
             forbidden_host_paths=self._forbidden_host_paths,
             allowed_volume_mounts=[
-                (self._runtime_volume_name, RUNTIME_MOUNT_PATH)
+                (self._runtime_volume_name, RUNTIME_MOUNT_PATH),
+                (self._git_volume_name, GIT_MOUNT_PATH),
             ],
         )
         checked_runtime = await environment.exec(
@@ -142,6 +175,15 @@ class AkashicHarborAgent(BaseAgent):
             checked_runtime.return_code,
             (checked_runtime.stdout or "") + (checked_runtime.stderr or ""),
         )
+        checked_git = await environment.exec(
+            command=self._git_check_command(),
+            user="root",
+        )
+        _require_success(
+            "校验 Akasic Git volume",
+            checked_git.return_code,
+            (checked_git.stdout or "") + (checked_git.stderr or ""),
+        )
         report["source_digest"] = self._source_digest
         report["runtime_volume"] = {
             "name": self._runtime_volume_name,
@@ -151,28 +193,27 @@ class AkashicHarborAgent(BaseAgent):
             "resolved_lock_digest": self._runtime_lock_digest,
             "python_version": self._runtime_python_version,
         }
+        report["git_volume"] = {
+            "name": self._git_volume_name,
+            "mount_path": GIT_MOUNT_PATH,
+            "runtime_digest": self._git_runtime_digest,
+            "manifest_digest": self._git_manifest_digest,
+            "git_version": self._git_version,
+        }
         atomic_json(self.logs_dir / "isolation.preflight.json", report)
 
-        # 3. 补齐 Git 基础设施，并恢复真实历史；Python 依赖不再逐 trial 安装。
+        # 3. 使用只读 Git 基础设施恢复真实历史，不在 trial 内联网安装。
         install_command = (
-            "if ! command -v git >/dev/null 2>&1; then "
-            "if command -v apk >/dev/null 2>&1; then "
-            "apk add --no-cache git ca-certificates; "
-            "elif command -v apt-get >/dev/null 2>&1; then "
-            "apt-get update && DEBIAN_FRONTEND=noninteractive "
-            "apt-get install -y --no-install-recommends git ca-certificates; "
-            "elif command -v yum >/dev/null 2>&1; then "
-            "yum install -y git ca-certificates; "
-            "else echo '任务镜像缺少 git 且无受支持的包管理器' >&2; exit 2; fi; fi && "
             f"rm -rf {_SOURCE_ROOT}/.git && "
-            f"git -C {_SOURCE_ROOT} init && "
-            f"git -C {_SOURCE_ROOT} fetch {_RUNTIME_ROOT}/source.bundle "
+            f"{GIT_BIN_PATH} -C {_SOURCE_ROOT} init && "
+            f"{GIT_BIN_PATH} -C {_SOURCE_ROOT} fetch {_RUNTIME_ROOT}/source.bundle "
             "'+refs/heads/*:refs/remotes/benchmark/*' "
             "'+refs/tags/*:refs/tags/*' && "
-            f"git -C {_SOURCE_ROOT} reset --mixed {shlex.quote(self._source_head)} && "
-            f"git -C {_SOURCE_ROOT} cat-file -e "
+            f"{GIT_BIN_PATH} -C {_SOURCE_ROOT} reset --mixed "
+            f"{shlex.quote(self._source_head)} && "
+            f"{GIT_BIN_PATH} -C {_SOURCE_ROOT} cat-file -e "
             "012e37c8b51df045353972bb551d8e868ab52455^{commit} && "
-            f"test \"$(git -C {_SOURCE_ROOT} rev-parse HEAD)\" = "
+            f"test \"$({GIT_BIN_PATH} -C {_SOURCE_ROOT} rev-parse HEAD)\" = "
             f"{shlex.quote(self._source_head)} && "
             f"chmod -R a-w {_SOURCE_ROOT}"
         )
@@ -200,7 +241,8 @@ class AkashicHarborAgent(BaseAgent):
         instruction_path.write_text(instruction, encoding="utf-8")
         gateway_command = (
             f"mkdir -p {_WORKSPACE} && cd /app || exit $?; "
-            f"env PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src "
+            f"env PATH={GIT_MOUNT_PATH}/bin:$PATH "
+            f"PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src "
             "PYTHONDONTWRITEBYTECODE=1 "
             f"{RUNTIME_VENV_PATH}/bin/python {_SOURCE_ROOT}/main.py gateway "
             f"--config {_SOURCE_ROOT}/benchmark/harbor_v4flash/config.toml "

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -46,6 +46,8 @@ from benchmark.harbor_v4flash.isolation import (
     source_tree_digest,
     validate_online_processes_unchanged,
 )
+from benchmark.harbor_v4flash.image_cache import prefetch_task_images
+from benchmark.harbor_v4flash.git_volume import inspect_git_volume
 from benchmark.harbor_v4flash.runtime_volume import (
     inspect_runtime_volume,
     runtime_compose_overlay,
@@ -171,6 +173,7 @@ async def run_trial(
     task_dir = task_dir.resolve()
     runs_root = args.runs_dir.resolve()
     task_agent_timeout_sec = _task_agent_timeout_sec(task_dir)
+    task_image = args.task_images[str(task_dir)]
     uv_binary = args.uv_binary.resolve()
     runtime_volume = inspect_runtime_volume(
         args.runtime_volume,
@@ -178,6 +181,10 @@ async def run_trial(
         uv_binary=uv_binary,
     )
     runtime_manifest = cast(dict[str, Any], runtime_volume["manifest"])
+    git_volume = inspect_git_volume(args.git_volume)
+    git_manifest = cast(dict[str, Any], git_volume["manifest"])
+    git_recipe = cast(dict[str, Any], git_manifest["recipe"])
+    git_packages = cast(dict[str, Any], git_recipe["packages"])
     runtime_recipe = cast(dict[str, Any], runtime_manifest["recipe"])
     runtime_lock = cast(dict[str, Any], runtime_recipe["resolved_lock"])
     runtime_python = cast(dict[str, Any], runtime_recipe["python"])
@@ -200,7 +207,11 @@ async def run_trial(
     runtime_compose_path = (
         trial_dir / "inputs" / "runtime-network-compose.json"
     )
-    compose_overlay = runtime_compose_overlay(args.runtime_volume)
+    compose_overlay = runtime_compose_overlay(
+        args.runtime_volume,
+        task_image_id=str(task_image["id"]),
+        git_volume_name=args.git_volume,
+    )
     compose_overlay["networks"] = {
         "default": {
             "external": True,
@@ -247,6 +258,7 @@ async def run_trial(
         },
         "source": initial_source,
         "runtime_cache": runtime_volume,
+        "git_cache": git_volume,
         "harbor": {
             "root": str(args.harbor_root.resolve()),
             "git_head": _git_output(args.harbor_root.resolve(), "rev-parse", "HEAD"),
@@ -261,6 +273,7 @@ async def run_trial(
         "docker": {
             "project": project,
             "network": network,
+            "task_image": task_image,
         },
     }
     atomic_json(manifest_path, initial_manifest)
@@ -292,6 +305,10 @@ async def run_trial(
                 "runtime_manifest_digest": runtime_manifest["manifest_digest"],
                 "runtime_lock_digest": runtime_lock["digest"],
                 "runtime_python_version": runtime_python["version"],
+                "git_volume_name": args.git_volume,
+                "git_runtime_digest": git_manifest["runtime_digest"],
+                "git_manifest_digest": git_manifest["manifest_digest"],
+                "git_version": git_packages["git_version"],
                 "bootstrap_timeout_sec": 900,
                 "turn_timeout_sec": task_agent_timeout_sec,
             },
@@ -491,6 +508,15 @@ async def run_campaign(
     return 0 if lifecycle_complete else 1
 
 
+async def _run_selected(args: argparse.Namespace) -> int:
+    """预拉取冻结 task images，再进入 smoke 或 campaign lifecycle。"""
+
+    args.task_images = await prefetch_task_images(args.task_dir)
+    if len(args.task_dir) == 1:
+        return await run_smoke(args, args.task_dir[0])
+    return await run_campaign(args, args.task_dir)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source-root", type=Path, required=True)
@@ -508,19 +534,26 @@ def main() -> int:
         "--runtime-volume",
         default=os.environ.get("AKASIC_BENCH_RUNTIME_VOLUME"),
     )
+    parser.add_argument(
+        "--git-volume",
+        default=os.environ.get("AKASIC_BENCH_GIT_VOLUME"),
+    )
     args = parser.parse_args()
     if not args.runtime_volume:
         parser.error(
             "--runtime-volume 或 AKASIC_BENCH_RUNTIME_VOLUME 是必填项；"
             "harness 不会在 trial 内冷安装"
         )
+    if not args.git_volume:
+        parser.error(
+            "--git-volume 或 AKASIC_BENCH_GIT_VOLUME 是必填项；"
+            "harness 不会在 trial 内安装 Git"
+        )
     with _credential_templates(
         args.credential_profile.resolve()
     ) as credential_templates:
         args.credential_templates = credential_templates
-        if len(args.task_dir) == 1:
-            return asyncio.run(run_smoke(args, args.task_dir[0]))
-        return asyncio.run(run_campaign(args, args.task_dir))
+        return asyncio.run(_run_selected(args))
 
 
 if __name__ == "__main__":

--- a/benchmark/harbor_v4flash/git_volume.py
+++ b/benchmark/harbor_v4flash/git_volume.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import uuid
+from typing import Any
+
+GIT_VOLUME_PREFIX = "akasic-bench-git-v1-"
+GIT_VOLUME_SCHEMA = "akasic.benchmark-git.v1"
+GIT_MOUNT_PATH = "/opt/akashic-git"
+GIT_BIN_PATH = f"{GIT_MOUNT_PATH}/bin/git"
+DEFAULT_GIT_BUILDER_IMAGE = "debian:bullseye-slim"
+GIT_TOP_LEVEL = ("bin", "manifest.json", "metadata.json", "root")
+_LABEL_PREFIX = "akasic.benchmark.git"
+_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class GitVolumeError(RuntimeError):
+    pass
+
+
+def _canonical_digest(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _run(
+    command: list[str],
+    *,
+    text: bool = True,
+) -> subprocess.CompletedProcess[Any]:
+    result = subprocess.run(
+        command,
+        check=False,
+        text=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stdout = result.stdout if isinstance(result.stdout, str) else ""
+        stderr = result.stderr if isinstance(result.stderr, str) else ""
+        output = "\n".join((stdout, stderr)).strip()
+        raise GitVolumeError(
+            f"命令失败，exit={result.returncode}：{' '.join(command[:4])}\n"
+            f"{output[-4000:]}"
+        )
+    return result
+
+
+def _builder_image_identity(reference: str) -> dict[str, object]:
+    """复用或拉取 Git builder，并固定到不可变 image ID。"""
+
+    inspected = subprocess.run(
+        ["docker", "image", "inspect", reference],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if inspected.returncode != 0:
+        _run(["docker", "pull", reference])
+    payload: object = json.loads(
+        _run(["docker", "image", "inspect", reference]).stdout
+    )
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise GitVolumeError("docker image inspect 必须返回一个 builder image")
+    raw = payload[0]
+    if not isinstance(raw, dict):
+        raise GitVolumeError("builder image inspect 元素必须是对象")
+    image: dict[str, Any] = raw
+    image_id = str(image.get("Id") or "")
+    platform = f"{image.get('Os')}/{image.get('Architecture')}"
+    if not image_id.startswith("sha256:"):
+        raise GitVolumeError("Git builder image 缺少不可变 ID")
+    if platform not in {"linux/amd64", "linux/arm64"}:
+        raise GitVolumeError(f"Git builder 平台不受支持：{platform}")
+    return {
+        "reference": reference,
+        "id": image_id,
+        "repo_digests": sorted(
+            str(value) for value in image.get("RepoDigests") or []
+        ),
+        "platform": platform,
+    }
+
+
+def create_git_manifest(
+    *,
+    builder_image: dict[str, object],
+    metadata: dict[str, object],
+    content_digest: str,
+) -> dict[str, object]:
+    """生成由 builder、包版本和实际内容共同决定的 Git manifest。"""
+
+    recipe = {
+        "id": "debian-portable-git-volume-v1",
+        "builder_image": builder_image,
+        "packages": metadata,
+        "content_digest": content_digest,
+    }
+    recipe_digest = _canonical_digest(recipe)
+    runtime_digest = _canonical_digest(
+        {
+            "schema": GIT_VOLUME_SCHEMA,
+            "recipe_digest": recipe_digest,
+        }
+    )
+    volume_name = GIT_VOLUME_PREFIX + runtime_digest.removeprefix("sha256:")[:24]
+    base = {
+        "schema": GIT_VOLUME_SCHEMA,
+        "volume_name": volume_name,
+        "runtime_digest": runtime_digest,
+        "recipe_digest": recipe_digest,
+        "recipe": recipe,
+        "contents": {
+            "mount_path": GIT_MOUNT_PATH,
+            "git_path": "bin/git",
+            "top_level": list(GIT_TOP_LEVEL),
+            "contains_source": False,
+            "contains_workspace": False,
+            "contains_task_data": False,
+            "contains_secrets": False,
+        },
+    }
+    return {**base, "manifest_digest": _canonical_digest(base)}
+
+
+def git_volume_labels(manifest: dict[str, object]) -> dict[str, str]:
+    recipe = manifest.get("recipe")
+    if not isinstance(recipe, dict):
+        raise GitVolumeError("Git manifest recipe 必须是对象")
+    builder = recipe.get("builder_image")
+    packages = recipe.get("packages")
+    if not isinstance(builder, dict) or not isinstance(packages, dict):
+        raise GitVolumeError("Git manifest builder/packages 必须是对象")
+    return {
+        f"{_LABEL_PREFIX}.managed": "true",
+        f"{_LABEL_PREFIX}.schema": str(manifest["schema"]),
+        f"{_LABEL_PREFIX}.volume_name": str(manifest["volume_name"]),
+        f"{_LABEL_PREFIX}.digest": str(manifest["runtime_digest"]),
+        f"{_LABEL_PREFIX}.manifest_digest": str(manifest["manifest_digest"]),
+        f"{_LABEL_PREFIX}.recipe_digest": str(manifest["recipe_digest"]),
+        f"{_LABEL_PREFIX}.content_digest": str(recipe["content_digest"]),
+        f"{_LABEL_PREFIX}.git_version": str(packages["git_version"]),
+        f"{_LABEL_PREFIX}.builder_image_id": str(builder["id"]),
+        f"{_LABEL_PREFIX}.platform": str(builder["platform"]),
+    }
+
+
+def _volume_file(
+    volume_name: str,
+    image_id: str,
+    relative_path: str,
+) -> bytes:
+    result = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--network",
+            "none",
+            "--mount",
+            f"type=volume,src={volume_name},dst={GIT_MOUNT_PATH},readonly",
+            "--entrypoint",
+            "/bin/cat",
+            image_id,
+            f"{GIT_MOUNT_PATH}/{relative_path}",
+        ],
+        text=False,
+    )
+    return bytes(result.stdout)
+
+
+def _volume_projection(
+    volume_name: str,
+    image_id: str,
+) -> tuple[list[str], str]:
+    script = (
+        f"top=$(find {GIT_MOUNT_PATH} -mindepth 1 -maxdepth 1 "
+        "-printf '%f\\n' | LC_ALL=C sort); "
+        f"digest=$(tar --sort=name --mtime=@0 --owner=0 --group=0 "
+        f"--numeric-owner -cf - -C {GIT_MOUNT_PATH} bin metadata.json root "
+        "| sha256sum | cut -d' ' -f1); "
+        "printf '%s\\n--DIGEST--\\nsha256:%s\\n' \"$top\" \"$digest\""
+    )
+    output = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--network",
+            "none",
+            "--mount",
+            f"type=volume,src={volume_name},dst={GIT_MOUNT_PATH},readonly",
+            "--entrypoint",
+            "/bin/sh",
+            image_id,
+            "-eu",
+            "-c",
+            script,
+        ]
+    ).stdout
+    top, digest = output.split("--DIGEST--\n", maxsplit=1)
+    return [line for line in top.splitlines() if line], digest.strip()
+
+
+def inspect_git_volume(volume_name: str) -> dict[str, object]:
+    """校验 Git volume 的 labels、manifest、内容摘要和可执行入口。"""
+
+    if not _VOLUME_NAME_PATTERN.fullmatch(volume_name):
+        raise GitVolumeError(f"Docker volume 名称不合法：{volume_name!r}")
+    payload: object = json.loads(
+        _run(["docker", "volume", "inspect", volume_name]).stdout
+    )
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise GitVolumeError("docker volume inspect 必须返回一个 volume")
+    raw = payload[0]
+    if not isinstance(raw, dict):
+        raise GitVolumeError("docker volume inspect 元素必须是对象")
+    volume: dict[str, Any] = raw
+    raw_labels = volume.get("Labels")
+    if not isinstance(raw_labels, dict):
+        raise GitVolumeError("Git volume 缺少 labels")
+    labels = {str(key): str(value) for key, value in raw_labels.items()}
+    image_id = labels.get(f"{_LABEL_PREFIX}.builder_image_id", "")
+    if not image_id.startswith("sha256:"):
+        raise GitVolumeError("Git volume 缺少 builder image ID label")
+    manifest: object = json.loads(
+        _volume_file(volume_name, image_id, "manifest.json")
+    )
+    if not isinstance(manifest, dict):
+        raise GitVolumeError("Git manifest 必须是对象")
+    without_digest = {
+        key: value for key, value in manifest.items() if key != "manifest_digest"
+    }
+    if manifest.get("manifest_digest") != _canonical_digest(without_digest):
+        raise GitVolumeError("Git manifest 摘要不匹配")
+    recipe = manifest.get("recipe")
+    if not isinstance(recipe, dict):
+        raise GitVolumeError("Git manifest recipe 必须是对象")
+    if manifest.get("recipe_digest") != _canonical_digest(recipe):
+        raise GitVolumeError("Git recipe 摘要不匹配")
+    expected_name = str(manifest.get("volume_name") or "")
+    if expected_name != volume_name:
+        raise GitVolumeError("Git volume 名称与 manifest 不匹配")
+    if labels != git_volume_labels(manifest):
+        raise GitVolumeError("Git volume labels 与 manifest 不匹配")
+    top_level, content_digest = _volume_projection(volume_name, image_id)
+    if top_level != list(GIT_TOP_LEVEL):
+        raise GitVolumeError("Git volume 含 allowlist 外内容")
+    if content_digest != recipe.get("content_digest"):
+        raise GitVolumeError("Git volume 内容摘要不匹配")
+    return {
+        "name": volume_name,
+        "driver": volume.get("Driver"),
+        "scope": volume.get("Scope"),
+        "created_at": volume.get("CreatedAt"),
+        "labels": labels,
+        "manifest": manifest,
+    }
+
+
+def _create_labeled_volume(
+    volume_name: str,
+    labels: dict[str, str],
+) -> None:
+    command = ["docker", "volume", "create"]
+    for key, value in sorted(labels.items()):
+        command.extend(["--label", f"{key}={value}"])
+    command.append(volume_name)
+    created = _run(command).stdout.strip()
+    if created != volume_name:
+        raise GitVolumeError(f"Docker 创建了非预期 volume：{created!r}")
+
+
+def _find_reusable_git_volume(
+    builder: dict[str, object],
+) -> dict[str, object] | None:
+    """复用同一 builder 已发布的有效 Git volume。"""
+
+    # 1. Docker labels 是本机 cache 索引，不访问 apt 或 registry。
+    image_id = str(builder["id"])
+    result = _run(
+        [
+            "docker",
+            "volume",
+            "ls",
+            "--filter",
+            f"label={_LABEL_PREFIX}.managed=true",
+            "--filter",
+            f"label={_LABEL_PREFIX}.builder_image_id={image_id}",
+            "--format",
+            "{{.Name}}",
+        ]
+    )
+    candidates = sorted(line for line in result.stdout.splitlines() if line)
+
+    # 2. 只复用通过完整内容校验的 volume；损坏 cache 必须显式暴露。
+    invalid: list[str] = []
+    for volume_name in candidates:
+        try:
+            return inspect_git_volume(volume_name)
+        except GitVolumeError:
+            invalid.append(volume_name)
+    if invalid:
+        names = ", ".join(invalid)
+        raise GitVolumeError(
+            f"发现损坏的 Git volume cache：{names}；"
+            "确认后删除，或使用 build --rebuild 重新发布"
+        )
+    return None
+
+
+def build_git_volume(
+    *,
+    builder_image_reference: str = DEFAULT_GIT_BUILDER_IMAGE,
+    reuse_existing: bool = True,
+) -> dict[str, object]:
+    """一次下载 Git/CA，发布跨 trial 只读复用的内容寻址 volume。"""
+
+    # 1. 命中已校验的本地 cache 时，不再启动 apt。
+    builder = _builder_image_identity(builder_image_reference)
+    if reuse_existing:
+        cached = _find_reusable_git_volume(builder)
+        if cached is not None:
+            return cached
+
+    # 2. staging 保留真实包版本和依赖内容，最终身份不依赖浮动 apt 元数据。
+    image_id = str(builder["id"])
+    staging = f"akasic-bench-git-staging-{uuid.uuid4().hex}"
+    _run(["docker", "volume", "create", staging])
+    build_script = f"""
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git ca-certificates
+mkdir -p {GIT_MOUNT_PATH}/bin {GIT_MOUNT_PATH}/root/usr/bin
+mkdir -p {GIT_MOUNT_PATH}/root/usr/lib {GIT_MOUNT_PATH}/root/usr/share
+mkdir -p {GIT_MOUNT_PATH}/root/etc/ssl/certs {GIT_MOUNT_PATH}/root/libdeps
+cp -a /usr/bin/git {GIT_MOUNT_PATH}/root/usr/bin/git
+cp -a /usr/lib/git-core {GIT_MOUNT_PATH}/root/usr/lib/git-core
+cp -a /usr/share/git-core {GIT_MOUNT_PATH}/root/usr/share/git-core
+cp -a /etc/ssl/certs/ca-certificates.crt {GIT_MOUNT_PATH}/root/etc/ssl/certs/
+for executable in /usr/bin/git $(find /usr/lib/git-core -type f -perm /111); do
+    ldd "$executable" 2>/dev/null || true
+done | awk '/=> \\/|^\\// {{ for (i=1; i<=NF; i++) if ($i ~ "^/") print $i }}' \
+    | LC_ALL=C sort -u | while read -r library; do
+        case "$(basename "$library")" in
+            libc.so.*|libpthread.so.*|libdl.so.*|librt.so.*|libm.so.*|libresolv.so.*|ld-linux-*) continue ;;
+        esac
+        cp -L "$library" "{GIT_MOUNT_PATH}/root/libdeps/$(basename "$library")"
+    done
+git_version=$(git --version)
+git_package=$(dpkg-query -W -f='${{Version}}' git)
+ca_package=$(dpkg-query -W -f='${{Version}}' ca-certificates)
+printf '{{"git_version":"%s","git_package":"%s","ca_certificates_package":"%s"}}\\n' \
+    "$git_version" "$git_package" "$ca_package" > {GIT_MOUNT_PATH}/metadata.json
+cat > {GIT_BIN_PATH} <<'EOF'
+#!/bin/sh
+root=/opt/akashic-git/root
+export GIT_EXEC_PATH="$root/usr/lib/git-core"
+export GIT_TEMPLATE_DIR="$root/usr/share/git-core/templates"
+export LD_LIBRARY_PATH="$root/libdeps"
+export SSL_CERT_FILE="$root/etc/ssl/certs/ca-certificates.crt"
+exec "$root/usr/bin/git" "$@"
+EOF
+chmod 0555 {GIT_BIN_PATH}
+chmod -R a-w {GIT_MOUNT_PATH}
+"""
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "bridge",
+                "--mount",
+                f"type=volume,src={staging},dst={GIT_MOUNT_PATH}",
+                "--entrypoint",
+                "/bin/sh",
+                image_id,
+                "-eu",
+                "-c",
+                build_script,
+            ]
+        )
+        metadata: object = json.loads(
+            _volume_file(staging, image_id, "metadata.json")
+        )
+        if not isinstance(metadata, dict):
+            raise GitVolumeError("Git metadata 必须是对象")
+        _, content_digest = _volume_projection(staging, image_id)
+        manifest = create_git_manifest(
+            builder_image=builder,
+            metadata=metadata,
+            content_digest=content_digest,
+        )
+        volume_name = str(manifest["volume_name"])
+        exists = subprocess.run(
+            ["docker", "volume", "inspect", volume_name],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode == 0
+        if not exists:
+            _create_labeled_volume(volume_name, git_volume_labels(manifest))
+            manifest_json = json.dumps(
+                manifest,
+                ensure_ascii=False,
+                indent=2,
+            )
+            copy_script = f"""
+cp -a /source/bin /target/bin
+cp -a /source/metadata.json /target/metadata.json
+cp -a /source/root /target/root
+printf '%s\\n' "$MANIFEST_JSON" > /target/manifest.json
+chmod -R a-w /target
+"""
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--read-only",
+                    "--network",
+                    "none",
+                    "--mount",
+                    f"type=volume,src={staging},dst=/source,readonly",
+                    "--mount",
+                    f"type=volume,src={volume_name},dst=/target",
+                    "--env",
+                    f"MANIFEST_JSON={manifest_json}",
+                    "--entrypoint",
+                    "/bin/sh",
+                    image_id,
+                    "-eu",
+                    "-c",
+                    copy_script,
+                ]
+            )
+        return inspect_git_volume(volume_name)
+    finally:
+        _run(["docker", "volume", "rm", staging])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["build", "inspect"])
+    parser.add_argument("--volume")
+    parser.add_argument("--builder-image", default=DEFAULT_GIT_BUILDER_IMAGE)
+    parser.add_argument("--rebuild", action="store_true")
+    args = parser.parse_args()
+    if args.command == "build":
+        report = build_git_volume(
+            builder_image_reference=args.builder_image,
+            reuse_existing=not args.rebuild,
+        )
+    else:
+        if not args.volume:
+            parser.error("--volume 是 inspect 的必填参数")
+        report = inspect_git_volume(args.volume)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/harbor_v4flash/image_cache.py
+++ b/benchmark/harbor_v4flash/image_cache.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from harbor.models.task.config import TaskConfig as HarborTaskConfig
+
+MAX_IMAGE_PULL_CONCURRENCY = 2
+IMAGE_PULL_ATTEMPTS = 3
+IMAGE_PULL_TIMEOUT_SEC = 1800
+
+
+class TaskImageError(RuntimeError):
+    pass
+
+
+def task_image_reference(task_dir: Path) -> str:
+    """读取 Harbor task 声明的预构建 Docker image。"""
+
+    config_path = task_dir.resolve() / "task.toml"
+    config = HarborTaskConfig.model_validate_toml(
+        config_path.read_text(encoding="utf-8")
+    )
+    reference = (config.environment.docker_image or "").strip()
+    if not reference:
+        raise TaskImageError(f"{config_path} 未声明 [environment].docker_image")
+    return reference
+
+
+def _inspect_image(reference: str) -> dict[str, object] | None:
+    result = subprocess.run(
+        ["docker", "image", "inspect", reference],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return None
+    payload: object = json.loads(result.stdout)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise TaskImageError("docker image inspect 必须返回一个 image")
+    raw = payload[0]
+    if not isinstance(raw, dict):
+        raise TaskImageError("docker image inspect 元素必须是对象")
+    image: dict[str, Any] = raw
+    image_id = str(image.get("Id") or "")
+    platform = f"{image.get('Os')}/{image.get('Architecture')}"
+    if not image_id.startswith("sha256:"):
+        raise TaskImageError(f"task image 缺少不可变 ID：{reference}")
+    if platform not in {"linux/amd64", "linux/arm64"}:
+        raise TaskImageError(f"task image 平台不受支持：{reference} {platform}")
+    size = image.get("Size")
+    if not isinstance(size, int) or size <= 0:
+        raise TaskImageError(f"task image 缺少有效 size：{reference}")
+    return {
+        "reference": reference,
+        "id": image_id,
+        "repo_digests": sorted(
+            str(value) for value in image.get("RepoDigests") or []
+        ),
+        "platform": platform,
+        "size_bytes": size,
+    }
+
+
+def _pull_image(reference: str) -> dict[str, object]:
+    """命中本地 image cache，或在模型运行前有限重试拉取一次。"""
+
+    # 1. 已冻结到本机的完整 image 直接复用，不再次访问 registry。
+    cached = _inspect_image(reference)
+    if cached is not None:
+        return {**cached, "cache_hit": True, "pull_attempts": 0}
+
+    # 2. 只重试尚未创建 trial 的幂等下载；最后一次错误保持原义。
+    last_output = ""
+    for attempt in range(1, IMAGE_PULL_ATTEMPTS + 1):
+        try:
+            result = subprocess.run(
+                ["docker", "pull", reference],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=IMAGE_PULL_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired as error:
+            last_output = f"docker pull 超过 {IMAGE_PULL_TIMEOUT_SEC}s"
+            if attempt == IMAGE_PULL_ATTEMPTS:
+                raise TaskImageError(
+                    f"task image 拉取超时：{reference}；{last_output}"
+                ) from error
+        else:
+            last_output = "\n".join((result.stdout, result.stderr)).strip()
+            if result.returncode == 0:
+                inspected = _inspect_image(reference)
+                if inspected is None:
+                    raise TaskImageError(
+                        f"docker pull 成功但 image 不可 inspect：{reference}"
+                    )
+                return {
+                    **inspected,
+                    "cache_hit": False,
+                    "pull_attempts": attempt,
+                }
+            if attempt == IMAGE_PULL_ATTEMPTS:
+                raise TaskImageError(
+                    f"task image 拉取失败：{reference}\n{last_output[-4000:]}"
+                )
+    raise AssertionError("image pull retry loop 没有终止")
+
+
+async def prefetch_task_images(
+    task_dirs: list[Path],
+) -> dict[str, dict[str, object]]:
+    """最多两路预拉取 task images，并按 task 路径返回不可变身份。"""
+
+    # 1. 相同 reference 只拉取一次，避免并发 trial 重复访问 registry。
+    task_references = {
+        str(task_dir.resolve()): task_image_reference(task_dir.resolve())
+        for task_dir in task_dirs
+    }
+    references = sorted(set(task_references.values()))
+
+    # 2. semaphore 独占 registry 并发，trial 不再同时承担 image 下载。
+    semaphore = asyncio.Semaphore(MAX_IMAGE_PULL_CONCURRENCY)
+
+    async def prefetch(reference: str) -> tuple[str, dict[str, object]]:
+        async with semaphore:
+            image = await asyncio.to_thread(_pull_image, reference)
+        return reference, image
+
+    # 3. 任一 image 失败则整个批次在创建 trial 前失败。
+    images = dict(await asyncio.gather(*(prefetch(ref) for ref in references)))
+    return {
+        task_path: images[reference]
+        for task_path, reference in task_references.items()
+    }

--- a/benchmark/harbor_v4flash/runtime_volume.py
+++ b/benchmark/harbor_v4flash/runtime_volume.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmark.harbor_v4flash.isolation import sha256_file
+from benchmark.harbor_v4flash.git_volume import GIT_MOUNT_PATH
 
 RUNTIME_VOLUME_PREFIX = "akasic-bench-runtime-v1-"
 RUNTIME_VOLUME_SCHEMA = "akasic.benchmark-runtime.v1"
@@ -447,30 +448,58 @@ def inspect_runtime_volume(
     }
 
 
-def runtime_compose_overlay(volume_name: str) -> dict[str, object]:
-    """生成 Harbor main service 的唯一共享 runtime 只读挂载。"""
+def runtime_compose_overlay(
+    volume_name: str,
+    *,
+    task_image_id: str | None = None,
+    git_volume_name: str | None = None,
+) -> dict[str, object]:
+    """生成 Harbor main service 的冻结 image 与 runtime 只读挂载。"""
 
     if not _VOLUME_NAME_PATTERN.fullmatch(volume_name):
         raise RuntimeVolumeError(f"Docker volume 名称不合法：{volume_name!r}")
+    if task_image_id is not None and not task_image_id.startswith("sha256:"):
+        raise RuntimeVolumeError(f"task image ID 不合法：{task_image_id!r}")
+    if git_volume_name is not None and not _VOLUME_NAME_PATTERN.fullmatch(
+        git_volume_name
+    ):
+        raise RuntimeVolumeError(f"Git volume 名称不合法：{git_volume_name!r}")
+    service_volumes: list[dict[str, object]] = [
+        {
+            "type": "volume",
+            "source": "akasic_runtime",
+            "target": RUNTIME_MOUNT_PATH,
+            "read_only": True,
+        }
+    ]
+    service: dict[str, object] = {"volumes": service_volumes}
+    if task_image_id is not None:
+        service["image"] = task_image_id
+        service["pull_policy"] = "never"
+    volumes: dict[str, object] = {
+        "akasic_runtime": {
+            "external": True,
+            "name": volume_name,
+        }
+    }
+    if git_volume_name is not None:
+        service_volumes.append(
+            {
+                "type": "volume",
+                "source": "akasic_git",
+                "target": GIT_MOUNT_PATH,
+                "read_only": True,
+            }
+        )
+        volumes["akasic_git"] = {
+            "external": True,
+            "name": git_volume_name,
+        }
     return {
         "services": {
-            "main": {
-                "volumes": [
-                    {
-                        "type": "volume",
-                        "source": "akasic_runtime",
-                        "target": RUNTIME_MOUNT_PATH,
-                        "read_only": True,
-                    }
-                ]
-            }
+            "main": service,
         },
-        "volumes": {
-            "akasic_runtime": {
-                "external": True,
-                "name": volume_name,
-            }
-        },
+        "volumes": volumes,
     }
 
 

--- a/tests/benchmark/test_harbor_v4flash_git_volume.py
+++ b/tests/benchmark/test_harbor_v4flash_git_volume.py
@@ -1,0 +1,89 @@
+import subprocess
+
+import pytest
+
+from benchmark.harbor_v4flash.git_volume import (
+    GIT_MOUNT_PATH,
+    GIT_TOP_LEVEL,
+    GitVolumeError,
+    _find_reusable_git_volume,
+    create_git_manifest,
+    git_volume_labels,
+)
+
+
+def test_git_manifest_freezes_builder_packages_and_content() -> None:
+    manifest = create_git_manifest(
+        builder_image={
+            "reference": "debian:bullseye-slim",
+            "id": "sha256:builder",
+            "repo_digests": ["debian@sha256:repo"],
+            "platform": "linux/amd64",
+        },
+        metadata={
+            "git_version": "git version 2.30.2",
+            "git_package": "1:2.30.2-1",
+            "ca_certificates_package": "20210119",
+        },
+        content_digest="sha256:content",
+    )
+
+    assert manifest["volume_name"].startswith("akasic-bench-git-v1-")
+    assert manifest["contents"] == {
+        "mount_path": GIT_MOUNT_PATH,
+        "git_path": "bin/git",
+        "top_level": list(GIT_TOP_LEVEL),
+        "contains_source": False,
+        "contains_workspace": False,
+        "contains_task_data": False,
+        "contains_secrets": False,
+    }
+    labels = git_volume_labels(manifest)
+    assert labels["akasic.benchmark.git.content_digest"] == "sha256:content"
+    assert labels["akasic.benchmark.git.git_version"] == "git version 2.30.2"
+
+
+def test_git_volume_cache_reuses_valid_local_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.git_volume._run",
+        lambda _: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="akasic-bench-git-v1-valid\n",
+            stderr="",
+        ),
+    )
+    expected = {"name": "akasic-bench-git-v1-valid"}
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.git_volume.inspect_git_volume",
+        lambda _: expected,
+    )
+
+    assert _find_reusable_git_volume({"id": "sha256:builder"}) == expected
+
+
+def test_git_volume_cache_exposes_corrupt_local_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.git_volume._run",
+        lambda _: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="akasic-bench-git-v1-corrupt\n",
+            stderr="",
+        ),
+    )
+
+    def reject(_: str) -> dict[str, object]:
+        raise GitVolumeError("corrupt")
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.git_volume.inspect_git_volume",
+        reject,
+    )
+
+    with pytest.raises(GitVolumeError, match="损坏"):
+        _find_reusable_git_volume({"id": "sha256:builder"})

--- a/tests/benchmark/test_harbor_v4flash_image_cache.py
+++ b/tests/benchmark/test_harbor_v4flash_image_cache.py
@@ -1,0 +1,152 @@
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+from benchmark.harbor_v4flash.image_cache import (
+    MAX_IMAGE_PULL_CONCURRENCY,
+    TaskImageError,
+    _pull_image,
+    prefetch_task_images,
+    task_image_reference,
+)
+
+
+def test_task_image_reference_requires_prebuilt_image(tmp_path: Path) -> None:
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "task.toml").write_text(
+        """
+schema_version = "1.1"
+[task]
+name = "test/task"
+[environment]
+docker_image = "example/task:fixed"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert task_image_reference(task) == "example/task:fixed"
+
+
+def test_task_image_reference_rejects_missing_image(tmp_path: Path) -> None:
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "task.toml").write_text(
+        """
+schema_version = "1.1"
+[task]
+name = "test/task"
+[environment]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TaskImageError, match="docker_image"):
+        task_image_reference(task)
+
+
+def test_pull_image_reuses_complete_local_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = {
+        "reference": "example/task:fixed",
+        "id": "sha256:image",
+        "repo_digests": ["example/task@sha256:repo"],
+        "platform": "linux/amd64",
+        "size_bytes": 123,
+    }
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.image_cache._inspect_image",
+        lambda _: identity,
+    )
+
+    assert _pull_image("example/task:fixed") == {
+        **identity,
+        "cache_hit": True,
+        "pull_attempts": 0,
+    }
+
+
+def test_prefetch_limits_registry_concurrency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active = 0
+    peak = 0
+    lock = threading.Lock()
+    release = threading.Event()
+    tasks = []
+    for index in range(4):
+        task = tmp_path / f"task-{index}"
+        task.mkdir()
+        (task / "task.toml").write_text(
+            f"""
+schema_version = "1.1"
+[task]
+name = "test/task-{index}"
+[environment]
+docker_image = "example/task-{index}:fixed"
+""".strip(),
+            encoding="utf-8",
+        )
+        tasks.append(task)
+
+    def pull(reference: str) -> dict[str, object]:
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+            if peak == MAX_IMAGE_PULL_CONCURRENCY:
+                release.set()
+        assert release.wait(timeout=5)
+        with lock:
+            active -= 1
+        return {"reference": reference, "id": "sha256:image"}
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.image_cache._pull_image",
+        pull,
+    )
+
+    result = asyncio.run(prefetch_task_images(tasks))
+
+    assert peak == MAX_IMAGE_PULL_CONCURRENCY
+    assert set(result) == {str(path.resolve()) for path in tasks}
+
+
+def test_prefetch_pulls_shared_reference_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks = []
+    for index in range(2):
+        task = tmp_path / f"task-{index}"
+        task.mkdir()
+        (task / "task.toml").write_text(
+            f"""
+schema_version = "1.1"
+[task]
+name = "test/task-{index}"
+[environment]
+docker_image = "example/shared:fixed"
+""".strip(),
+            encoding="utf-8",
+        )
+        tasks.append(task)
+    calls: list[str] = []
+
+    def pull(reference: str) -> dict[str, object]:
+        calls.append(reference)
+        return {"reference": reference, "id": "sha256:image"}
+
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.image_cache._pull_image",
+        pull,
+    )
+
+    result = asyncio.run(prefetch_task_images(tasks))
+
+    assert calls == ["example/shared:fixed"]
+    assert set(result) == {str(path.resolve()) for path in tasks}

--- a/tests/benchmark/test_harbor_v4flash_runtime_volume.py
+++ b/tests/benchmark/test_harbor_v4flash_runtime_volume.py
@@ -74,6 +74,28 @@ def test_runtime_manifest_and_compose_freeze_identity() -> None:
             }
         },
     }
+    assert runtime_compose_overlay(
+        volume_name,
+        task_image_id="sha256:task-image",
+        git_volume_name="akasic-bench-git-v1-example",
+    )["services"]["main"] == {
+        "image": "sha256:task-image",
+        "pull_policy": "never",
+        "volumes": [
+            {
+                "type": "volume",
+                "source": "akasic_runtime",
+                "target": RUNTIME_MOUNT_PATH,
+                "read_only": True,
+            },
+            {
+                "type": "volume",
+                "source": "akasic_git",
+                "target": "/opt/akashic-git",
+                "read_only": True,
+            }
+        ],
+    }
 
 
 def test_inspect_runtime_volume_verifies_manifest_lock_and_inputs(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：并发 trial 在启动阶段各自拉取 task image，并在容器内重复 `apt install git ca-certificates`，会放大 registry/apt 压力并造成环境启动超时。
- 用户可见结果：批次开始前最多两路预拉取唯一 task image，trial 固定使用本机不可变 image ID；Git/CA 由内容寻址的只读 Docker volume 复用，trial 内不再联网安装。
- 本 PR 不处理：不修改 Terminal-Bench task、verifier、oracle、instruction，也不调整模型或 Akashic agent 的任务策略。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`compatible`
- `capability_owner`：`not_applicable`
- `consumer_scope`：仅 `benchmark/harbor_v4flash` 诊断 harness
- `runtime_patch`：`none`
- `runtime_patch_reason`：不修改线上 runtime
- `authoritative_state_owner`：benchmark controller 与 Docker 本地 cache
- `client_only_alternative`：不适用
- 关联不变量：官方 task/verifier 不变；源码只读；线上 gateway/workspace 不变；共享 volume 只读；task image 固定到已校验 ID。
- `protected_state`：线上 workspace、线上 gateway、官方 dataset、trial 源码。
- 允许的副作用：预拉取官方 task image；创建带完整 manifest/labels 的 Git cache volume；创建并清理隔离 trial 容器和网络。
- 禁止的副作用：向正式 workspace 写入、修改官方 task/verifier、动态从 registry 替换已冻结 trial image。

## 改动范围

- 主要文件：`benchmark/harbor_v4flash/{image_cache,git_volume,runtime_volume,controller,agent}.py` 及对应测试。
- 配置或迁移影响：controller 新增必填 `--git-volume` / `AKASIC_BENCH_GIT_VOLUME`；无数据库或配置迁移。
- 已知 schema lineage 与最终 schema identity：不适用。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source `3ac8634db14f88dfa86bffb065778df5908ab589`；Git volume runtime digest `sha256:e4706df27562c97921ac2a6c1def7a3a67f5c178f628bbfc2e78521c372a4b80`。
- 回滚方式：revert `3ac8634d`；删除未被 trial 使用的 `akasic-bench-git-v1-e4706df27562c97921ac2a6c` volume。

## 验证

- [x] 35 个相关 benchmark targeted tests 通过。
- [x] 新增模块 Pyright：0 errors（仓库严格配置仍报告既有风格 warnings）。
- [x] 真实 Docker smoke：`cancel-async-tasks` reward 1.0；environment setup 0.89s，agent setup 1.54s；task image `cache_hit=true`、`pull_attempts=0`；两个共享 volume 均为只读；源码摘要、线上 PID 未变化。
- [x] Git volume 在 Debian 11/12/13 与 Ubuntu 24.04 官方 task 镜像中完成 `init + bundle fetch + rev-parse`。
- [x] 相邻 stacked base Gate 通过：`docker/debug/reports/change-gate/20260730-230948-607bbb55`。
- [ ] `origin/main` 累计 Gate 因前序 stacked PR 的受保护合同变化报 `protected_contract_mixed`，未将其伪装为本提交通过。
- `sourceDigest`：`279474d457a9a63ceb6008108b14b24679604f78e80f25816493aef2f723561b`
- `planDigest`：`38c760241b05fa1a2ac9c31acbf0b0b4fe562cba8a21dfc07aadaa4645fb264e`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用。
- 未运行项与原因：完整 89 题最终 eval 按实验设计暂不运行；当前只做逐 case 诊断。

## 工作手册

- [x] 已核对 `projectneed.md`、决策 0011、benchmark 设计和 `NOW.md`。
- [x] 本次不改变长期产品语义，只优化诊断 harness 的下载与 setup 路径。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 无本 PR 对应的已完成事项。