### PR TITLE
fix(benchmark): always stop runtime after driver exit

### DIFF
--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -5,7 +5,7 @@ import shlex
 from pathlib import Path
 
 from harbor.agents.base import BaseAgent
-from harbor.environments.base import BaseEnvironment
+from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
 
 from benchmark.harbor_v4flash import HARNESS_VERSION
@@ -32,6 +32,96 @@ _AGENT_LOGS = "/logs/agent"
 def _require_success(label: str, return_code: int, output: str) -> None:
     if return_code != 0:
         raise RuntimeError(f"{label} 失败，exit={return_code}\n{output[-4000:]}")
+
+
+def _write_driver_evidence(
+    logs_dir: Path,
+    completed: ExecResult | None,
+    error: BaseException | None,
+) -> None:
+    (logs_dir / "driver.stdout.log").write_text(
+        "" if completed is None else completed.stdout or "",
+        encoding="utf-8",
+    )
+    (logs_dir / "driver.stderr.log").write_text(
+        "" if completed is None else completed.stderr or "",
+        encoding="utf-8",
+    )
+    if error is not None:
+        (logs_dir / "driver.exception.log").write_text(
+            f"{type(error).__name__}: {error}\n",
+            encoding="utf-8",
+        )
+
+
+def _write_shutdown_evidence(
+    logs_dir: Path,
+    completed: ExecResult | None,
+    error: BaseException | None,
+) -> None:
+    if completed is not None:
+        output = (completed.stdout or "") + (completed.stderr or "")
+        if completed.return_code != 0:
+            output = f"exit={completed.return_code}\n{output}"
+    else:
+        assert error is not None
+        output = f"{type(error).__name__}: {error}\n"
+    (logs_dir / "runtime.shutdown.log").write_text(output, encoding="utf-8")
+
+
+async def _run_driver_and_shutdown(
+    environment: BaseEnvironment,
+    *,
+    driver_command: str,
+    driver_timeout_sec: float,
+    shutdown_command: str,
+    logs_dir: Path,
+) -> ExecResult:
+    """运行 driver 并始终尝试关闭 gateway，同时保留主失败。"""
+
+    # 1. 捕获 driver 的成功结果或原始异常，不提前跳过 cleanup。
+    driver_result: ExecResult | None = None
+    driver_error: BaseException | None = None
+    try:
+        driver_result = await environment.exec(
+            command=driver_command,
+            timeout_sec=driver_timeout_sec,  # pyright: ignore[reportArgumentType]
+        )
+        _require_success(
+            "执行 SDK turn",
+            driver_result.return_code,
+            (driver_result.stdout or "") + (driver_result.stderr or ""),
+        )
+    except BaseException as error:
+        driver_error = error
+
+    # 2. driver 成功、失败、超时或取消后都尝试关闭 gateway。
+    shutdown_result: ExecResult | None = None
+    shutdown_error: BaseException | None = None
+    try:
+        shutdown_result = await environment.exec(
+            command=shutdown_command,
+            timeout_sec=70,
+        )
+        _require_success(
+            "收束 Akasic gateway",
+            shutdown_result.return_code,
+            (shutdown_result.stdout or "") + (shutdown_result.stderr or ""),
+        )
+    except BaseException as error:
+        shutdown_error = error
+
+    # 3. 先写全两个阶段的证据，再按主失败优先级传播。
+    _write_driver_evidence(logs_dir, driver_result, driver_error)
+    _write_shutdown_evidence(logs_dir, shutdown_result, shutdown_error)
+    if driver_error is not None:
+        if shutdown_error is not None:
+            driver_error.add_note(f"gateway cleanup also failed: {shutdown_error}")
+        raise driver_error
+    if shutdown_error is not None:
+        raise shutdown_error
+    assert driver_result is not None
+    return driver_result
 
 
 class AkashicHarborAgent(BaseAgent):
@@ -277,12 +367,11 @@ class AkashicHarborAgent(BaseAgent):
                 str(self._turn_timeout_sec),
             ]
         )
-        completed = await environment.exec(
-            command=driver_command,
-            timeout_sec=self._turn_timeout_sec + 5,
-        )
-        shutdown = await environment.exec(
-            command=(
+        _ = await _run_driver_and_shutdown(
+            environment,
+            driver_command=driver_command,
+            driver_timeout_sec=self._turn_timeout_sec + 5,
+            shutdown_command=(
                 f"pid=$(cat {_AGENT_LOGS}/runtime.pid) && "
                 "if ! kill -0 \"$pid\" 2>/dev/null; then exit 0; fi; "
                 "kill -TERM \"$pid\" && "
@@ -292,29 +381,7 @@ class AkashicHarborAgent(BaseAgent):
                 "done; "
                 "exit 1"
             ),
-            timeout_sec=70,
-        )
-        (self.logs_dir / "driver.stdout.log").write_text(
-            completed.stdout or "",
-            encoding="utf-8",
-        )
-        (self.logs_dir / "driver.stderr.log").write_text(
-            completed.stderr or "",
-            encoding="utf-8",
-        )
-        (self.logs_dir / "runtime.shutdown.log").write_text(
-            (shutdown.stdout or "") + (shutdown.stderr or ""),
-            encoding="utf-8",
-        )
-        _require_success(
-            "收束 Akasic gateway",
-            shutdown.return_code,
-            (shutdown.stdout or "") + (shutdown.stderr or ""),
-        )
-        _require_success(
-            "执行 SDK turn",
-            completed.return_code,
-            (completed.stdout or "") + (completed.stderr or ""),
+            logs_dir=self.logs_dir,
         )
 
         # 3. 把可机读终态投影到 Harbor AgentContext。

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import subprocess
@@ -5,14 +6,32 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from harbor.environments.base import ExecResult
 
-from benchmark.harbor_v4flash.agent import _ENDPOINT, _WORKSPACE
+from benchmark.harbor_v4flash.agent import (
+    _ENDPOINT,
+    _WORKSPACE,
+    _run_driver_and_shutdown,
+)
 from benchmark.harbor_v4flash.controller import (
     _credential_templates,
     _inspect_finished_project,
     _task_agent_timeout_sec,
 )
 from benchmark.harbor_v4flash.isolation import IsolationError, create_source_bundle
+
+
+class _ScriptedEnvironment:
+    def __init__(self, *outcomes: ExecResult | BaseException) -> None:
+        self._outcomes = list(outcomes)
+        self.commands: list[str] = []
+
+    async def exec(self, *, command: str, timeout_sec: float) -> ExecResult:
+        self.commands.append(command)
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
 
 
 def _git(root: Path, *args: str) -> str:
@@ -43,6 +62,118 @@ def test_v4flash_high_uses_provider_output_limit() -> None:
 def test_benchmark_workspace_matches_terminal_task_root() -> None:
     assert _WORKSPACE == "/app"
     assert _ENDPOINT == "/app/akashic.sock"
+
+
+def test_driver_success_keeps_command_order_and_logs(tmp_path: Path) -> None:
+    environment = _ScriptedEnvironment(
+        ExecResult(return_code=0, stdout="driver complete\n"),
+        ExecResult(return_code=0, stdout="shutdown complete\n"),
+    )
+    result = asyncio.run(
+        _run_driver_and_shutdown(
+            environment,  # type: ignore[arg-type]
+            driver_command="driver",
+            driver_timeout_sec=5,
+            shutdown_command="shutdown",
+            logs_dir=tmp_path,
+        )
+    )
+
+    assert result.stdout == "driver complete\n"
+    assert environment.commands == ["driver", "shutdown"]
+    assert (
+        tmp_path / "driver.stdout.log"
+    ).read_text(encoding="utf-8") == "driver complete\n"
+    assert (
+        tmp_path / "runtime.shutdown.log"
+    ).read_text(encoding="utf-8") == "shutdown complete\n"
+    assert not (tmp_path / "driver.exception.log").exists()
+
+
+def test_driver_timeout_still_shuts_down_gateway_and_persists_evidence(
+    tmp_path: Path,
+) -> None:
+    environment = _ScriptedEnvironment(
+        TimeoutError("driver exceeded deadline"),
+        ExecResult(return_code=0, stdout="gateway stopped\n"),
+    )
+
+    with pytest.raises(TimeoutError, match="driver exceeded deadline"):
+        asyncio.run(
+            _run_driver_and_shutdown(
+                environment,  # type: ignore[arg-type]
+                driver_command="driver",
+                driver_timeout_sec=5,
+                shutdown_command="shutdown",
+                logs_dir=tmp_path,
+            )
+        )
+
+    assert environment.commands == ["driver", "shutdown"]
+    assert (tmp_path / "driver.stdout.log").read_text(encoding="utf-8") == ""
+    assert (tmp_path / "driver.stderr.log").read_text(encoding="utf-8") == ""
+    assert (
+        tmp_path / "driver.exception.log"
+    ).read_text(encoding="utf-8") == "TimeoutError: driver exceeded deadline\n"
+    assert (
+        tmp_path / "runtime.shutdown.log"
+    ).read_text(encoding="utf-8") == "gateway stopped\n"
+
+
+def test_driver_cancellation_still_shuts_down_gateway(
+    tmp_path: Path,
+) -> None:
+    environment = _ScriptedEnvironment(
+        asyncio.CancelledError("trial cancelled"),
+        ExecResult(return_code=0),
+    )
+
+    with pytest.raises(asyncio.CancelledError, match="trial cancelled"):
+        asyncio.run(
+            _run_driver_and_shutdown(
+                environment,  # type: ignore[arg-type]
+                driver_command="driver",
+                driver_timeout_sec=5,
+                shutdown_command="shutdown",
+                logs_dir=tmp_path,
+            )
+        )
+
+    assert environment.commands == ["driver", "shutdown"]
+    assert (
+        tmp_path / "driver.exception.log"
+    ).read_text(encoding="utf-8") == "CancelledError: trial cancelled\n"
+    assert (tmp_path / "runtime.shutdown.log").read_text(encoding="utf-8") == ""
+
+
+def test_driver_failure_remains_primary_when_shutdown_also_fails(
+    tmp_path: Path,
+) -> None:
+    environment = _ScriptedEnvironment(
+        ExecResult(return_code=1, stdout="driver failed\n"),
+        ExecResult(return_code=2),
+    )
+
+    with pytest.raises(RuntimeError, match="执行 SDK turn") as caught:
+        asyncio.run(
+            _run_driver_and_shutdown(
+                environment,  # type: ignore[arg-type]
+                driver_command="driver",
+                driver_timeout_sec=5,
+                shutdown_command="shutdown",
+                logs_dir=tmp_path,
+            )
+        )
+
+    assert any(
+        "gateway cleanup also failed" in note for note in caught.value.__notes__
+    )
+    assert (
+        tmp_path / "driver.exception.log"
+    ).read_text(encoding="utf-8").startswith("RuntimeError: 执行 SDK turn")
+    assert (
+        tmp_path / "runtime.shutdown.log"
+    ).read_text(encoding="utf-8") == "exit=2\n"
 
 
 def test_task_agent_timeout_uses_harbor_task_budget(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题

Akashic benchmark driver 超时、取消或非零退出时，旧路径会在 shutdown 前抛出，留下 gateway，并缺少完整 driver/cleanup 证据。

## 改动

- driver 所有终态都尝试 shutdown
- 分别记录 driver stdout/stderr/exception 与 runtime shutdown
- driver 与 cleanup 同时失败时保留 driver 为主异常
- 不修改 task、instruction、model、verifier 或成功路径行为

## 验证

- `tests/benchmark`: 49 passed
- pyright: 0 errors
- public change-impact Gate: passed (`docker/debug/reports/change-gate/20260730-233518-34db2a0a`)
- private Gate: pending maintainer

Stacked on #259; keep draft during the 89-case diagnostic traversal.
