### PR TITLE
fix(benchmark): separate agent state from task workspace

### DIFF
--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -24,7 +24,8 @@ from benchmark.harbor_v4flash.runtime_volume import (
 
 _RUNTIME_ROOT = "/opt/akashic"
 _SOURCE_ROOT = f"{_RUNTIME_ROOT}/src"
-_WORKSPACE = "/app"
+_TASK_ROOT = "/app"
+_WORKSPACE = "/opt/akashic-workspace"
 _ENDPOINT = f"{_WORKSPACE}/akashic.sock"
 _AGENT_LOGS = "/logs/agent"
 
@@ -330,7 +331,7 @@ class AkashicHarborAgent(BaseAgent):
         instruction_path = self.logs_dir / "instruction.md"
         instruction_path.write_text(instruction, encoding="utf-8")
         gateway_command = (
-            f"mkdir -p {_WORKSPACE} && cd /app || exit $?; "
+            f"mkdir -p {_WORKSPACE} && cd {_TASK_ROOT} || exit $?; "
             f"env PATH={GIT_MOUNT_PATH}/bin:$PATH "
             f"PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src "
             "PYTHONDONTWRITEBYTECODE=1 "
@@ -351,7 +352,10 @@ class AkashicHarborAgent(BaseAgent):
         # 2. SDK driver 记录全部 turn 通知并核对持久化终态。
         driver_command = " ".join(
             [
-                f"cd /app && PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src",
+                (
+                    f"cd {_TASK_ROOT} && "
+                    f"PYTHONPATH={_SOURCE_ROOT}:{_SOURCE_ROOT}/sdk/python/src"
+                ),
                 "PYTHONDONTWRITEBYTECODE=1",
                 f"{RUNTIME_VENV_PATH}/bin/python",
                 f"{_SOURCE_ROOT}/benchmark/harbor_v4flash/runtime_driver.py",

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -10,6 +10,7 @@ from harbor.environments.base import ExecResult
 
 from benchmark.harbor_v4flash.agent import (
     _ENDPOINT,
+    _TASK_ROOT,
     _WORKSPACE,
     _run_driver_and_shutdown,
 )
@@ -59,9 +60,11 @@ def test_v4flash_high_uses_provider_output_limit() -> None:
     assert config["agent"]["max_iterations"] == 0
 
 
-def test_benchmark_workspace_matches_terminal_task_root() -> None:
-    assert _WORKSPACE == "/app"
-    assert _ENDPOINT == "/app/akashic.sock"
+def test_benchmark_workspace_is_separate_from_terminal_task_root() -> None:
+    assert _TASK_ROOT == "/app"
+    assert _WORKSPACE == "/opt/akashic-workspace"
+    assert _WORKSPACE != _TASK_ROOT
+    assert _ENDPOINT == "/opt/akashic-workspace/akashic.sock"
 
 
 def test_driver_success_keeps_command_order_and_logs(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题

Benchmark 过去把 Akasic durable workspace 与官方 task root 都设为 `/app`，会把 `sessions.db`、Akasha DB、plugin-data、socket 和 lock 写进题目目录，污染全树扫描与文件计数类 oracle。

## 改动

- task/process/tool cwd 继续保持 `/app`
- Akasic durable workspace 与 UDS 移到 `/opt/akashic-workspace`
- 不跨题复用状态，不修改 task、instruction、model、verifier 或工具能力

## 验证

- 累计 `tests/benchmark`: 49 passed
- adjacent public Gate: passed (`docker/debug/reports/change-gate/20260730-234531-3050b4f8`)
- source-bound smoke: `cancel-async-tasks`, reward 1, CTRF 6/6
- live probe: gateway cwd=`/app`; task root 无 Akasic DB/memory/plugin-data/socket/lock；durable files 位于 `/opt/akashic-workspace`
- source/online isolation passed; online PID 162463 unchanged
- private Gate: pending maintainer

Stacked on #260; keep draft during the 89-case diagnostic traversal.
