### PR TITLE
fix(control): cooperatively replay buffered deltas

### DIFF
--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -264,6 +264,8 @@ class ConversationRuntime:
                             sequence=sequence,
                         )
                     )
+                    # 2a. 让订阅者消费事后回放，避免突发填满有界队列。
+                    await asyncio.sleep(0)
                 self._publish(
                     TurnEvent.create(
                         "item/completed",

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -143,6 +143,61 @@ async def test_runtime_persists_structured_tool_items_and_usage(tmp_path: Path) 
     store.close()
 
 
+@pytest.mark.asyncio
+async def test_runtime_replays_large_delta_stream_without_detaching_subscriber(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    deltas = [f"chunk-{sequence}" for sequence in range(300)]
+    response = "".join(deltas)
+
+    async def execute(_request: TurnRequest) -> ControlExecutionResult:
+        return ControlExecutionResult(response=response, deltas=deltas)
+
+    runtime = ConversationRuntime(store, execute)
+    handle = await runtime.start_turn(
+        TurnRequest("programmatic:large-delta-stream", "hello")
+    )
+    events: list[TurnEvent] = []
+    async for event in handle.events():
+        if event.method == "turn/completed":
+            persisted = store.read_turn(handle.id)
+            assert persisted is not None
+            assert persisted.status is TurnStatus.COMPLETED
+        events.append(event)
+    result = await handle.result()
+
+    delta_events = [
+        event
+        for event in events
+        if event.method == "item/assistantMessage/delta"
+    ]
+    assistant_item_id = cast(str, delta_events[0].data["itemId"])
+    assistant_events = [
+        event
+        for event in events
+        if event.data.get("itemId") == assistant_item_id
+        or (
+            isinstance(event.data.get("item"), dict)
+            and event.data["item"].get("id") == assistant_item_id
+        )
+    ]
+    assert [event.data["delta"] for event in delta_events] == deltas
+    assert [event.data["sequence"] for event in delta_events] == list(range(300))
+    assert [event.method for event in assistant_events] == [
+        "item/started",
+        *(["item/assistantMessage/delta"] * 300),
+        "item/completed",
+    ]
+    assert events[-1].method == "turn/completed"
+    assert result.status is TurnStatus.COMPLETED
+    assert result.final_response == response
+    assert [event.method for event in events].count("turn/completed") == 1
+    _assert_single_terminal(runtime, handle.id)
+    await runtime.shutdown()
+    store.close()
+
+
 async def _executor_with_open_tool(
     request: TurnRequest,
     started: asyncio.Event,


### PR DESCRIPTION
## 问题

Control execution 先缓存全部 assistant deltas，完成后在一个无 `await` 的循环中同步重放。超过有界 subscriber queue（256）时，即使消费者足够快，producer 也会在事件循环获得调度前触发 `SlowConsumerError`，丢失 assistant completion 与 terminal；wave-08 的 7/7 长回复都走了 read recovery。

## 改动

- 每个已存在的 delta publish 后 cooperative yield
- 不改 queue 上限、事件内容/顺序/数量、chunk 边界、provider 时序、持久化或 terminal 语义

## 验证

- 新回归在旧实现上稳定触发 `SlowConsumerError`
- 新实现完整交付 300 deltas、sequence 0..299、唯一 terminal，且 terminal 前 durable status 已 completed
- `tests/control`: 31 passed
- `tests/test_programmatic_control_probe.py`: 10 passed
- pyright: 0 errors
- adjacent public Gate: passed (`docker/debug/reports/change-gate/20260731-000726-8f39bbcf`)
- private Gate: pending maintainer

Stacked on #261. Source-bound benchmark smoke will be appended after the current isolated trials drain.
