### PR TITLE
fix(benchmark): make shared runtime ABI portable

### DIFF
--- a/benchmark/harbor_v4flash/runtime_volume.py
+++ b/benchmark/harbor_v4flash/runtime_volume.py
@@ -18,13 +18,17 @@ RUNTIME_VOLUME_SCHEMA = "akasic.benchmark-runtime.v1"
 RUNTIME_MOUNT_PATH = "/opt/akashic-runtime"
 RUNTIME_VENV_PATH = f"{RUNTIME_MOUNT_PATH}/venv"
 DEFAULT_PYTHON_VERSION = "3.13.7"
-DEFAULT_BUILDER_IMAGE = "debian:bookworm-slim"
+DEFAULT_BUILDER_IMAGE = "debian:bullseye-slim"
+MAX_BUILDER_GLIBC_VERSION = (2, 31)
 RUNTIME_TOP_LEVEL = ("manifest.json", "python", "resolved.lock", "venv")
 RUNTIME_BUILD_RECIPE = {
-    "id": "uv-managed-python-relocatable-venv-v1",
+    "id": "uv-managed-python-relocatable-venv-v2",
     "python_install": "uv-python-install-no-cache",
     "venv": "uv-venv-relocatable",
-    "dependency_install": "uv-pip-sync-require-hashes-strict-no-cache",
+    "dependency_install": (
+        "uv-pip-sync-manylinux-2.28-require-hashes-strict-no-cache"
+    ),
+    "builder_glibc_max": "2.31",
     "builder_root": "read-only",
     "builder_cache": "ephemeral-tmpfs",
 }
@@ -81,9 +85,16 @@ def _docker_platform() -> str:
 
 def _resolver_platform(platform: str) -> str:
     return {
-        "linux/amd64": "x86_64-unknown-linux-gnu",
-        "linux/arm64": "aarch64-unknown-linux-gnu",
+        "linux/amd64": "x86_64-manylinux_2_28",
+        "linux/arm64": "aarch64-manylinux_2_28",
     }[platform]
+
+
+def _glibc_version(raw: str) -> tuple[int, int]:
+    match = re.fullmatch(r"glibc ([0-9]+)\.([0-9]+)", raw)
+    if match is None:
+        raise RuntimeVolumeError(f"无法识别 builder glibc 版本：{raw!r}")
+    return int(match.group(1)), int(match.group(2))
 
 
 def _uv_identity(uv_binary: Path) -> dict[str, str]:
@@ -157,7 +168,7 @@ def _resolve_lock(
 
 
 def _builder_image_identity(reference: str) -> dict[str, object]:
-    """拉取 builder tag，并把后续写入固定到不可变 image ID。"""
+    """冻结 builder image，并记录决定原生依赖兼容性的 glibc。"""
 
     # 1. 显式 builder 命令才允许拉取镜像。
     _run(["docker", "pull", reference])
@@ -175,11 +186,27 @@ def _builder_image_identity(reference: str) -> dict[str, object]:
     image_platform = f"{image.get('Os')}/{image.get('Architecture')}"
     if not image_id.startswith("sha256:"):
         raise RuntimeVolumeError("builder image 缺少不可变 image ID")
+    glibc = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--network",
+            "none",
+            "--entrypoint",
+            "/usr/bin/getconf",
+            image_id,
+            "GNU_LIBC_VERSION",
+        ]
+    ).stdout.strip()
+    _glibc_version(glibc)
     return {
         "reference": reference,
         "id": image_id,
         "repo_digests": sorted(str(value) for value in image.get("RepoDigests") or []),
         "platform": image_platform,
+        "libc": glibc,
     }
 
 
@@ -267,6 +294,9 @@ def runtime_volume_labels(manifest: dict[str, object]) -> dict[str, str]:
         for value in (requirements, uv, python, platform, lock, builder)
     ):
         raise RuntimeVolumeError("runtime manifest recipe 字段必须是对象")
+    builder_glibc = builder.get("libc")
+    if not isinstance(builder_glibc, str):
+        raise RuntimeVolumeError("runtime manifest builder glibc 缺失")
     return {
         f"{_LABEL_PREFIX}.managed": "true",
         f"{_LABEL_PREFIX}.schema": str(manifest["schema"]),
@@ -281,6 +311,7 @@ def runtime_volume_labels(manifest: dict[str, object]) -> dict[str, str]:
         f"{_LABEL_PREFIX}.platform": str(platform["docker"]),
         f"{_LABEL_PREFIX}.resolved_lock_digest": str(lock["digest"]),
         f"{_LABEL_PREFIX}.builder_image_id": str(builder["id"]),
+        f"{_LABEL_PREFIX}.builder_glibc": builder_glibc,
     }
 
 
@@ -437,6 +468,12 @@ def inspect_runtime_volume(
         "resolver": _resolver_platform(platform),
     }:
         raise RuntimeVolumeError("runtime volume 平台不匹配")
+    builder = recipe.get("builder_image")
+    if not isinstance(builder, dict):
+        raise RuntimeVolumeError("runtime volume builder image 缺失")
+    builder_glibc = _glibc_version(str(builder.get("libc") or ""))
+    if builder_glibc > MAX_BUILDER_GLIBC_VERSION:
+        raise RuntimeVolumeError("runtime volume builder glibc 高于兼容上限 2.31")
 
     return {
         "name": volume_name,
@@ -530,6 +567,11 @@ def build_runtime_volume(
             "builder image 平台不匹配："
             f"{builder_image['platform']} != {platform}"
         )
+    if (
+        _glibc_version(str(builder_image["libc"]))
+        > MAX_BUILDER_GLIBC_VERSION
+    ):
+        raise RuntimeVolumeError("builder glibc 高于兼容上限 2.31")
     with tempfile.TemporaryDirectory(prefix="akasic-runtime-volume-") as raw_temp:
         temp_root = Path(raw_temp)
         lock_path = temp_root / "resolved.lock"
@@ -593,7 +635,8 @@ def build_runtime_volume(
             f"/tools/uv venv --relocatable --python \"$1\" "
             f"{RUNTIME_VENV_PATH}\n"
             f"/tools/uv pip sync --python {RUNTIME_VENV_PATH}/bin/python "
-            "/inputs/resolved.lock --require-hashes --strict --no-cache\n"
+            "/inputs/resolved.lock --python-platform \"$RESOLVER_PLATFORM\" "
+            "--require-hashes --strict --no-cache\n"
             f"cp /inputs/resolved.lock {RUNTIME_MOUNT_PATH}/resolved.lock\n"
             f"cp /inputs/manifest.json {RUNTIME_MOUNT_PATH}/manifest.json\n"
             f"test \"$({RUNTIME_VENV_PATH}/bin/python -c "
@@ -638,6 +681,8 @@ def build_runtime_volume(
                     "UV_CACHE_DIR=/tmp/uv-cache",
                     "--env",
                     f"PYTHON_VERSION={python_version}",
+                    "--env",
+                    f"RESOLVER_PLATFORM={resolver_platform}",
                     "--entrypoint",
                     "/bin/sh",
                     str(builder_image["id"]),

--- a/tests/benchmark/test_harbor_v4flash_runtime_volume.py
+++ b/tests/benchmark/test_harbor_v4flash_runtime_volume.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import pytest
 
 from benchmark.harbor_v4flash.runtime_volume import (
+    DEFAULT_BUILDER_IMAGE,
     DEFAULT_PYTHON_VERSION,
     RUNTIME_MOUNT_PATH,
     RUNTIME_TOP_LEVEL,
     RuntimeVolumeError,
+    _resolver_platform,
     build_runtime_volume,
     create_runtime_manifest,
     inspect_runtime_volume,
@@ -32,12 +34,13 @@ def _manifest() -> tuple[dict[str, object], bytes]:
         },
         python_version=DEFAULT_PYTHON_VERSION,
         platform="linux/amd64",
-        resolver_platform="x86_64-unknown-linux-gnu",
+        resolver_platform="x86_64-manylinux_2_28",
         builder_image={
-            "reference": "debian:bookworm-slim",
+            "reference": "debian:bullseye-slim",
             "id": "sha256:builder",
             "repo_digests": ["debian@sha256:repo"],
             "platform": "linux/amd64",
+            "libc": "glibc 2.31",
         },
         resolved_lock_digest=(
             f"sha256:{hashlib.sha256(lock_bytes).hexdigest()}"
@@ -54,6 +57,9 @@ def test_runtime_manifest_and_compose_freeze_identity() -> None:
     assert runtime_volume_labels(manifest)[
         "akasic.benchmark.runtime.resolved_lock_digest"
     ] == manifest["recipe"]["resolved_lock"]["digest"]
+    assert runtime_volume_labels(manifest)[
+        "akasic.benchmark.runtime.builder_glibc"
+    ] == "glibc 2.31"
     assert runtime_compose_overlay(volume_name) == {
         "services": {
             "main": {
@@ -96,6 +102,14 @@ def test_runtime_manifest_and_compose_freeze_identity() -> None:
             }
         ],
     }
+
+
+def test_runtime_labels_reject_manifest_without_builder_glibc() -> None:
+    manifest, _ = _manifest()
+    del manifest["recipe"]["builder_image"]["libc"]
+
+    with pytest.raises(RuntimeVolumeError, match="builder glibc 缺失"):
+        runtime_volume_labels(manifest)
 
 
 def test_inspect_runtime_volume_verifies_manifest_lock_and_inputs(
@@ -187,5 +201,47 @@ def test_builder_rejects_non_frozen_python_before_docker(
             source_root=tmp_path,
             uv_binary=tmp_path / "uv",
             python_version="3.13.8",
+            builder_image_reference="debian:bookworm-slim",
+        )
+
+
+def test_runtime_resolver_uses_explicit_manylinux_baseline() -> None:
+    assert DEFAULT_BUILDER_IMAGE == "debian:bullseye-slim"
+    assert _resolver_platform("linux/amd64") == "x86_64-manylinux_2_28"
+    assert _resolver_platform("linux/arm64") == "aarch64-manylinux_2_28"
+
+
+def test_builder_rejects_glibc_newer_than_official_task_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._docker_platform",
+        lambda: "linux/amd64",
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._requirements_identity",
+        lambda _: {"digest": "sha256:requirements"},
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._uv_identity",
+        lambda _: {"version": "uv test", "digest": "sha256:uv"},
+    )
+    monkeypatch.setattr(
+        "benchmark.harbor_v4flash.runtime_volume._builder_image_identity",
+        lambda _: {
+            "reference": "debian:bookworm-slim",
+            "id": "sha256:builder",
+            "repo_digests": [],
+            "platform": "linux/amd64",
+            "libc": "glibc 2.36",
+        },
+    )
+
+    with pytest.raises(RuntimeVolumeError, match="glibc 高于兼容上限"):
+        build_runtime_volume(
+            source_root=tmp_path,
+            uv_binary=tmp_path / "uv",
+            python_version=DEFAULT_PYTHON_VERSION,
             builder_image_reference="debian:bookworm-slim",
         )


### PR DESCRIPTION
## 问题

旧 runtime volume 在 Debian bookworm/glibc 2.36 上构建，uv 选择的 `cryptography` wheel 要求 GLIBC 2.33/2.34。Terminal-Bench 的两个 QEMU 官方镜像是 bullseye/glibc 2.31，gateway 在 Agent 启动前即导入失败。

## 改动

- 默认 builder 改为 bullseye，并把实测 glibc 纳入内容身份
- builder glibc 高于 2.31 时 fail-loud
- resolver/sync 固定 `manylinux_2_28`
- recipe 升为 v2，旧不兼容 volume 明确拒绝
- 不向 task 增加依赖或工具，不改变 Agent/task/verifier 语义

## 验证

- 89 个官方 task image 均确认 linux/amd64；glibc floor 为 2.31
- 新 volume `akasic-bench-runtime-v1-32707cb2ec8aa57f47b31905`
- 307 个 native `.so` 的最高 GLIBC 要求为 2.28
- 在 glibc 2.31/2.36/2.39/2.41 的五个官方镜像中，主要原生依赖全部 import 成功
- 累计 93 tests passed
- adjacent public Gate passed (`docker/debug/reports/change-gate/20260731-003628-ab5343a0`)
- private Gate pending maintainer

Stacked on #262. QEMU source-bound rerun will follow after current isolated trials release slots.
