### PR TITLE
fix(sdk): cooperatively yield while routing notifications

### DIFF
--- a/sdk/python/src/akashic_sdk/client.py
+++ b/sdk/python/src/akashic_sdk/client.py
@@ -135,6 +135,8 @@ class _WireClient:
                         self.notifications.put_nowait(message)
                     except asyncio.QueueFull as exc:
                         raise SlowConsumerError("global notification queue overflow") from exc
+                # 已缓冲的 readline 可连续同步返回，让活跃消费者有机会排空有界队列。
+                await asyncio.sleep(0)
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -11,7 +13,64 @@ from agent.control.service import ControlService
 from infra.control.socket import SocketAppServer
 from session.manager import SessionManager
 
-from akashic_sdk import Akashic, AsyncAkashic
+from akashic_sdk import Akashic, AsyncAkashic, SlowConsumerError, TurnHandle
+from akashic_sdk.client import _WireClient
+
+
+def _buffered_notification_reader(
+    count: int,
+    *,
+    turn_id: str | None = None,
+) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    for index in range(count):
+        params: dict[str, object] = {"index": index}
+        if turn_id is not None:
+            params["turnId"] = turn_id
+        payload: dict[str, object] = {
+            "jsonrpc": "2.0",
+            "method": "test/notification",
+            "params": params,
+        }
+        reader.feed_data(
+            (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+        )
+    reader.feed_eof()
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_sdk_reader_yields_to_active_turn_consumer() -> None:
+    reader = _buffered_notification_reader(600, turn_id="turn-1")
+    wire = _WireClient(reader, cast(asyncio.StreamWriter, object()))
+    handle = TurnHandle(wire, "thread-1", "turn-1")
+
+    notifications = handle.events()
+    received = [
+        await asyncio.wait_for(anext(notifications), timeout=1)
+        for _ in range(600)
+    ]
+    await wire.reader_task
+
+    assert [event["params"]["index"] for event in received] == list(range(600))
+
+
+@pytest.mark.asyncio
+async def test_sdk_reader_fails_loud_for_unconsumed_notification_queue() -> None:
+    reader = _buffered_notification_reader(513)
+    wire = _WireClient(reader, cast(asyncio.StreamWriter, object()))
+    client = AsyncAkashic(wire)
+
+    await wire.reader_task
+
+    notifications = client.notifications()
+    for _ in range(511):
+        _ = await anext(notifications)
+    with pytest.raises(
+        SlowConsumerError,
+        match="global notification queue overflow",
+    ):
+        _ = await anext(notifications)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 改了什么

SDK reader 每次成功路由 notification 后协作让出一次事件循环调度，同时保留 512 有界队列和 `SlowConsumerError`。

## 根因与影响

当 `StreamReader.readline()` 已有大量缓冲行时，它可以连续同步返回；reader 因而能在活跃消费者获得调度前填满队列，误报 slow consumer 并关闭整条 wire。该修复不扩容、不丢帧、不合并 delta，也不改变真实慢消费者的 fail-loud 合同。

Terminal-Bench 的真实 burst 还暴露了 benchmark driver 在 `turn/read` 等待期间停止持续消费的问题；那一层由后续 stacked PR 单独修复。

## 验证

- 旧实现：活跃消费者处理 600 条已缓冲通知时，第 513 条稳定误报
- 新实现：10 个 SDK 测试通过
- 反向故障注入：不消费 513 条时仍抛出同一 `SlowConsumerError`
- Pyright：0 errors
- Change Gate：passed，`20260731-011235-3b69e1a4`
- private-contract-gate：`not_required`

## 真实消融

- 只应用本 PR 时，`winning-avg-corewars` 的更大终态 burst 仍在 959 个事件后溢出，证明 SDK fairness 修复必要但不充分
- 叠加 #265 的持续 drain 后，同题完整记录 1,259 个事件并由正常 terminal event 收束

`semantic_delta: compatible`：把可达的误报 `SlowConsumerError` 恢复为成功，不改变 notification 内容、顺序、队列上限或真实慢消费者错误。