### PR TITLE
fix(benchmark): continuously drain terminal events

### DIFF
--- a/benchmark/harbor_v4flash/runtime_driver.py
+++ b/benchmark/harbor_v4flash/runtime_driver.py
@@ -4,12 +4,18 @@ import argparse
 import asyncio
 import json
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from akashic_sdk import AsyncAkashic
 
 TERMINAL_STATUSES = {"completed", "failed", "interrupted", "cancelled"}
+
+
+@dataclass(slots=True)
+class _EventDrainState:
+    event_count: int = 0
 
 
 def _append_jsonl(path: Path, record: dict[str, object]) -> None:
@@ -36,6 +42,117 @@ async def _connect(endpoint: str, deadline_s: float) -> AsyncAkashic:
     raise TimeoutError(f"app-server readiness 超时：{last_error}")
 
 
+async def _drain_events(
+    handle: Any,
+    *,
+    trace_path: Path,
+    state: _EventDrainState,
+) -> dict[str, Any] | None:
+    """持续记录事件流，并返回其中唯一的 terminal turn。"""
+
+    # 1. 按 SDK 到达顺序持续消费并封存每一帧。
+    async for event in handle.events():
+        state.event_count += 1
+        _append_jsonl(
+            trace_path,
+            {
+                "kind": "sdk_event",
+                "timestamp": time.time(),
+                "event": event,
+            },
+        )
+
+        # 2. terminal 仍由协议事件唯一提交；普通流结束留给 turn/read 判定。
+        if event.get("method") == "turn/completed":
+            params = event.get("params")
+            if isinstance(params, dict) and isinstance(params.get("turn"), dict):
+                return params["turn"]
+    return None
+
+
+def _recovered_terminal(
+    persisted: dict[str, Any],
+    *,
+    trace_path: Path,
+    terminal_grace_s: float,
+    event_count: int,
+) -> tuple[dict[str, Any], str, int]:
+    _append_jsonl(
+        trace_path,
+        {
+            "kind": "driver",
+            "phase": "terminal_recovered",
+            "timestamp": time.time(),
+            "status": str(persisted.get("status") or ""),
+            "source": "turn/read",
+            "delivery_gap": True,
+            "grace_s": terminal_grace_s,
+        },
+    )
+    return persisted, "turn/read_recovery", event_count
+
+
+async def _wait_for_drain(
+    drain_task: asyncio.Task[dict[str, Any] | None],
+    timeout_s: float,
+) -> tuple[bool, dict[str, Any] | None]:
+    done, _ = await asyncio.wait({drain_task}, timeout=max(0.0, timeout_s))
+    if not done:
+        return False, None
+    return True, drain_task.result()
+
+
+async def _read_while_draining(
+    client: Any,
+    handle: Any,
+    *,
+    drain_task: asyncio.Task[dict[str, Any] | None],
+    deadline: float,
+    timeout_message: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """并发读取持久化投影，并让事件 drain 始终保持活跃。"""
+
+    # 1. 发出一次读取；drain 先结束时仍保留读取直到 deadline。
+    read_task = asyncio.create_task(client.turn_read(handle.thread_id, handle.id))
+    try:
+        while True:
+            if drain_task.done():
+                terminal = drain_task.result()
+                if terminal is not None:
+                    return terminal, None
+            waiters = {read_task}
+            if not drain_task.done():
+                waiters.add(drain_task)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(timeout_message)
+
+            # 2. 同时完成时先暴露异常；两者成功则以 terminal event 收束。
+            done, _ = await asyncio.wait(
+                waiters,
+                timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                raise TimeoutError(timeout_message)
+            terminal = None
+            if drain_task in done:
+                terminal = drain_task.result()
+            if read_task in done:
+                persisted = read_task.result()
+                if terminal is not None:
+                    return terminal, None
+                return None, persisted
+            if terminal is not None:
+                return terminal, None
+    finally:
+        if not read_task.done():
+            read_task.cancel()
+            _ = await asyncio.gather(read_task, return_exceptions=True)
+        elif not read_task.cancelled():
+            _ = read_task.exception()
+
+
 async def _observe_terminal(
     client: Any,
     handle: Any,
@@ -47,71 +164,71 @@ async def _observe_terminal(
 ) -> tuple[dict[str, Any], str, int]:
     """记录事件流，并在 terminal 通知丢失时用权威 turn/read 明示恢复。"""
 
-    # 1. 正常路径逐帧记录；空闲时才读取持久化投影，不干扰事件吞吐。
+    # 1. 独立 drain 在所有 turn/read 和 grace 等待期间持续消费事件。
     deadline = time.monotonic() + turn_timeout_s
+    timeout_message = f"turn 未在 {turn_timeout_s:.1f}s 内终止"
     terminal_seen_at: float | None = None
-    event_count = 0
-    stream = handle.events().__aiter__()
-    next_event: asyncio.Task[Any] | None = asyncio.create_task(stream.__anext__())
+    state = _EventDrainState()
+    drain_task = asyncio.create_task(
+        _drain_events(handle, trace_path=trace_path, state=state)
+    )
     try:
         while time.monotonic() < deadline:
-            if next_event is not None:
-                done, _ = await asyncio.wait(
-                    {next_event},
-                    timeout=min(poll_interval_s, max(0.0, deadline - time.monotonic())),
-                )
-                if done:
-                    try:
-                        event = next_event.result()
-                    except StopAsyncIteration:
-                        next_event = None
-                    else:
-                        event_count += 1
-                        _append_jsonl(
-                            trace_path,
-                            {
-                                "kind": "sdk_event",
-                                "timestamp": time.time(),
-                                "event": event,
-                            },
-                        )
-                        if event.get("method") == "turn/completed":
-                            params = event.get("params")
-                            if isinstance(params, dict) and isinstance(
-                                params.get("turn"),
-                                dict,
-                            ):
-                                return params["turn"], "event", event_count
-                        next_event = asyncio.create_task(stream.__anext__())
-                        continue
+            remaining = max(0.0, deadline - time.monotonic())
+            drain_done, terminal = await _wait_for_drain(
+                drain_task,
+                min(poll_interval_s, remaining),
+            )
+            if terminal is not None:
+                return terminal, "event", state.event_count
 
-            # 2. terminal 已持久化但通知在 grace 内仍未到达时，保留缺口证据并收束。
-            persisted = await client.turn_read(handle.thread_id, handle.id)
+            # 2. turn/read 与 drain 并发；响应排在通知 burst 后也不会阻塞消费。
+            terminal, persisted = await _read_while_draining(
+                client,
+                handle,
+                drain_task=drain_task,
+                deadline=deadline,
+                timeout_message=timeout_message,
+            )
+            if terminal is not None:
+                return terminal, "event", state.event_count
+            assert persisted is not None
+            if drain_task.done():
+                terminal = drain_task.result()
+                if terminal is not None:
+                    return terminal, "event", state.event_count
+            drain_done = drain_task.done()
             status = str(persisted.get("status") or "")
             if status in TERMINAL_STATUSES:
                 if terminal_seen_at is None:
                     terminal_seen_at = time.monotonic()
-                if next_event is None or time.monotonic() - terminal_seen_at >= terminal_grace_s:
-                    _append_jsonl(
-                        trace_path,
-                        {
-                            "kind": "driver",
-                            "phase": "terminal_recovered",
-                            "timestamp": time.time(),
-                            "status": status,
-                            "source": "turn/read",
-                            "delivery_gap": True,
-                            "grace_s": terminal_grace_s,
-                        },
+                grace_remaining = terminal_grace_s - (
+                    time.monotonic() - terminal_seen_at
+                )
+                if not drain_done and grace_remaining > 0:
+                    drain_done, terminal = await _wait_for_drain(
+                        drain_task,
+                        min(
+                            grace_remaining,
+                            deadline - time.monotonic(),
+                        ),
                     )
-                    return persisted, "turn/read_recovery", event_count
-            elif next_event is None:
+                    if terminal is not None:
+                        return terminal, "event", state.event_count
+                if drain_done or time.monotonic() - terminal_seen_at >= terminal_grace_s:
+                    return _recovered_terminal(
+                        persisted,
+                        trace_path=trace_path,
+                        terminal_grace_s=terminal_grace_s,
+                        event_count=state.event_count,
+                    )
+            elif drain_done:
                 raise RuntimeError("SDK 事件流结束但 turn/read 尚未终止")
-        raise TimeoutError(f"turn 未在 {turn_timeout_s:.1f}s 内终止")
+        raise TimeoutError(timeout_message)
     finally:
-        if next_event is not None and not next_event.done():
-            next_event.cancel()
-            _ = await asyncio.gather(next_event, return_exceptions=True)
+        if not drain_task.done():
+            drain_task.cancel()
+            _ = await asyncio.gather(drain_task, return_exceptions=True)
 
 
 async def run_turn(

--- a/tests/benchmark/test_harbor_v4flash_runtime_driver.py
+++ b/tests/benchmark/test_harbor_v4flash_runtime_driver.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from akashic_sdk import SlowConsumerError
 
 from benchmark.harbor_v4flash.runtime_driver import _observe_terminal
 
@@ -19,13 +20,126 @@ class _HandleWithoutTerminalEvent:
 
 class _PersistedTerminalClient:
     async def turn_read(self, thread_id: str, turn_id: str) -> dict[str, Any]:
-        assert thread_id == _HandleWithoutTerminalEvent.thread_id
-        assert turn_id == _HandleWithoutTerminalEvent.id
         return {
             "id": turn_id,
             "threadId": thread_id,
             "status": "completed",
         }
+
+
+class _DelayedPersistedTerminalClient(_PersistedTerminalClient):
+    async def turn_read(self, thread_id: str, turn_id: str) -> dict[str, Any]:
+        await asyncio.sleep(0.01)
+        return await super().turn_read(thread_id, turn_id)
+
+
+class _BurstHandle:
+    thread_id = "programmatic:burst"
+    id = "turn:burst"
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(512)
+
+    async def events(self):
+        yield {"method": "turn/started", "params": {"turnId": self.id}}
+        while True:
+            event = await self.queue.get()
+            yield event
+            if event.get("method") == "turn/completed":
+                return
+
+
+class _BurstBeforeReadResponseClient:
+    def __init__(self, handle: _BurstHandle) -> None:
+        self.handle = handle
+        self.terminal = {
+            "id": handle.id,
+            "threadId": handle.thread_id,
+            "status": "completed",
+        }
+
+    async def turn_read(self, thread_id: str, turn_id: str) -> dict[str, Any]:
+        assert thread_id == self.handle.thread_id
+        assert turn_id == self.handle.id
+        for index in range(600):
+            try:
+                self.handle.queue.put_nowait(
+                    {
+                        "method": "turn/output_delta",
+                        "params": {"turnId": turn_id, "delta": str(index)},
+                    }
+                )
+            except asyncio.QueueFull as error:
+                raise SlowConsumerError("turn notification queue overflow") from error
+            await asyncio.sleep(0)
+        self.handle.queue.put_nowait(
+            {
+                "method": "turn/completed",
+                "params": {"turnId": turn_id, "turn": self.terminal},
+            }
+        )
+        await asyncio.sleep(0)
+        return self.terminal
+
+
+class _TerminalThenReadErrorClient:
+    def __init__(self, handle: _BurstHandle) -> None:
+        self.handle = handle
+
+    async def turn_read(self, thread_id: str, turn_id: str) -> dict[str, Any]:
+        self.handle.queue.put_nowait(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "turnId": turn_id,
+                    "turn": {
+                        "id": turn_id,
+                        "threadId": thread_id,
+                        "status": "completed",
+                    },
+                },
+            }
+        )
+        await asyncio.sleep(0)
+        raise RuntimeError("turn read failed")
+
+
+class _EndedStreamHandle:
+    thread_id = "programmatic:ended"
+    id = "turn:ended"
+
+    async def events(self):
+        yield {"method": "turn/started", "params": {"turnId": self.id}}
+
+
+class _FailingStreamHandle:
+    thread_id = "programmatic:failed-stream"
+    id = "turn:failed-stream"
+
+    async def events(self):
+        yield {"method": "turn/started", "params": {"turnId": self.id}}
+        raise RuntimeError("event stream failed")
+
+
+class _CancellingHandle:
+    thread_id = "programmatic:cancel"
+    id = "turn:cancel"
+
+    def __init__(self) -> None:
+        self.closed = asyncio.Event()
+
+    async def events(self):
+        try:
+            yield {"method": "turn/started", "params": {"turnId": self.id}}
+            await asyncio.Event().wait()
+        finally:
+            self.closed.set()
+
+
+class _NeverReturningClient:
+    async def turn_read(self, thread_id: str, turn_id: str) -> dict[str, Any]:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
 
 
 @pytest.mark.asyncio
@@ -52,3 +166,98 @@ async def test_observer_recovers_persisted_terminal_after_delivery_gap(
     assert event_count == 1
     assert records[-1]["phase"] == "terminal_recovered"
     assert records[-1]["delivery_gap"] is True
+
+
+@pytest.mark.asyncio
+async def test_observer_continuously_drains_burst_while_turn_read_is_pending(
+    tmp_path: Path,
+) -> None:
+    trace = tmp_path / "trace.jsonl"
+    handle = _BurstHandle()
+
+    terminal, source, event_count = await _observe_terminal(
+        _BurstBeforeReadResponseClient(handle),
+        handle,
+        trace_path=trace,
+        turn_timeout_s=1,
+        poll_interval_s=0.001,
+    )
+
+    records = [
+        json.loads(line)
+        for line in trace.read_text(encoding="utf-8").splitlines()
+    ]
+    assert terminal["status"] == "completed"
+    assert source == "event"
+    assert event_count == 602
+    assert [record["event"]["method"] for record in records] == [
+        "turn/started",
+        *(["turn/output_delta"] * 600),
+        "turn/completed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_observer_recovers_terminal_after_event_stream_ends(
+    tmp_path: Path,
+) -> None:
+    trace = tmp_path / "trace.jsonl"
+
+    terminal, source, event_count = await _observe_terminal(
+        _DelayedPersistedTerminalClient(),
+        _EndedStreamHandle(),
+        trace_path=trace,
+        turn_timeout_s=1,
+        poll_interval_s=0.001,
+    )
+
+    assert terminal["status"] == "completed"
+    assert source == "turn/read_recovery"
+    assert event_count == 1
+
+
+@pytest.mark.asyncio
+async def test_observer_preserves_event_stream_error_priority(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="event stream failed"):
+        await _observe_terminal(
+            _PersistedTerminalClient(),
+            _FailingStreamHandle(),
+            trace_path=tmp_path / "trace.jsonl",
+            turn_timeout_s=1,
+            poll_interval_s=0.001,
+        )
+
+
+@pytest.mark.asyncio
+async def test_observer_preserves_turn_read_error_priority(tmp_path: Path) -> None:
+    handle = _BurstHandle()
+
+    with pytest.raises(RuntimeError, match="turn read failed"):
+        await _observe_terminal(
+            _TerminalThenReadErrorClient(handle),
+            handle,
+            trace_path=tmp_path / "trace.jsonl",
+            turn_timeout_s=1,
+            poll_interval_s=0.001,
+        )
+
+
+@pytest.mark.asyncio
+async def test_observer_cancellation_closes_event_drain(tmp_path: Path) -> None:
+    handle = _CancellingHandle()
+    observer = asyncio.create_task(
+        _observe_terminal(
+            _NeverReturningClient(),
+            handle,
+            trace_path=tmp_path / "trace.jsonl",
+            turn_timeout_s=10,
+            poll_interval_s=0.001,
+        )
+    )
+    await asyncio.sleep(0.01)
+
+    observer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await observer
+
+    assert handle.closed.is_set()


### PR DESCRIPTION
## 改了什么

把 benchmark runtime driver 的事件消费改成独立、持续运行的 drain task。`turn/read` 轮询和 terminal grace 等待期间，SDK event stream 仍会按序被消费和记录。

## 根因与影响

原实现每次只挂一个 `next_event`。空闲 0.5 秒后，主协程会同步等待 `turn/read`；如果终态 burst 在请求后到达，单个 task 只消费一帧，而 RPC response 排在整批通知之后，余下通知会填满 SDK 队列。`winning-avg-corewars` 两次真实运行分别在 727/959 个事件附近复现。

修复不扩大队列、不合并 delta、不修改协议、terminal、read-recovery 或 deadline 语义。

## 验证

- 旧实现消融：600 delta + started + terminal 在约第 514 帧稳定 `SlowConsumerError`
- 新实现：602 帧完整、顺序一致，并从 event terminal 收束
- 覆盖 stream 正常结束后 recovery、stream 异常优先和取消清理
- 57 个 benchmark tests 通过
- Pyright：0 errors
- Change Gate：passed，`20260731-020838-22767a1a`
- private-contract-gate：`pending_maintainer`

## 真实任务验证

`winning-avg-corewars` 在相同 512 队列下完整消费 1,259 个事件，`terminal_source=event`，没有 delivery recovery 或 `SlowConsumerError`；官方 verifier 正常执行并得到 CTRF 2/3、reward 0。reward 只反映 warrior 未达 stone/snake 阈值，不影响 transport 假设验收。

`semantic_delta: compatible`：把 driver 暂停消费导致的误失败恢复为正常完成，但不改变 event、sequence、terminal 或错误阈值。