### PR TITLE
fix(benchmark): capture cgroup resource-limit evidence

### DIFF
--- a/benchmark/harbor_v4flash/__init__.py
+++ b/benchmark/harbor_v4flash/__init__.py
@@ -1,3 +1,3 @@
 """用 Harbor 驱动 V4 Flash harness 实验。"""
 
-HARNESS_VERSION = "0.1.0"
+HARNESS_VERSION = "0.1.1"

--- a/benchmark/harbor_v4flash/agent.py
+++ b/benchmark/harbor_v4flash/agent.py
@@ -17,6 +17,12 @@ from benchmark.harbor_v4flash.isolation import (
 )
 from benchmark.harbor_v4flash.git_volume import GIT_BIN_PATH, GIT_MOUNT_PATH
 from benchmark.harbor_v4flash.result_projection import project_agent_context
+from benchmark.harbor_v4flash.resource_evidence import (
+    RESOURCE_EVIDENCE_FILENAME,
+    parse_resource_probe_output,
+    resource_probe_command,
+    resource_probe_failure,
+)
 from benchmark.harbor_v4flash.runtime_volume import (
     RUNTIME_MOUNT_PATH,
     RUNTIME_VENV_PATH,
@@ -70,6 +76,76 @@ def _write_shutdown_evidence(
     (logs_dir / "runtime.shutdown.log").write_text(output, encoding="utf-8")
 
 
+async def _capture_resource_evidence(
+    environment: BaseEnvironment,
+    logs_dir: Path,
+) -> tuple[BaseException | None, BaseException | None]:
+    """采集并持久化容器资源证据，分别返回采集与写入失败。"""
+
+    # 1. 容器仍运行时读取固定 cgroup 白名单。
+    resource_error: BaseException | None = None
+    try:
+        result = await environment.exec(
+            command=resource_probe_command(),
+            timeout_sec=10,
+        )
+        _require_success(
+            "采集容器资源证据",
+            result.return_code,
+            (result.stdout or "") + (result.stderr or ""),
+        )
+        evidence = parse_resource_probe_output(result.stdout or "")
+    except BaseException as error:
+        resource_error = error
+        evidence = resource_probe_failure(error)
+
+    # 2. 即使采集失败也写明确未知证据；写入失败单独返回。
+    try:
+        atomic_json(logs_dir / RESOURCE_EVIDENCE_FILENAME, evidence)
+    except BaseException as error:
+        return resource_error, error
+    return resource_error, None
+
+
+def _raise_lifecycle_errors(
+    *,
+    driver_error: BaseException | None,
+    resource_error: BaseException | None,
+    resource_write_error: BaseException | None,
+    shutdown_error: BaseException | None,
+) -> None:
+    """按 driver、资源采集、证据写入、shutdown 顺序传播主失败。"""
+
+    if driver_error is not None:
+        if resource_error is not None:
+            driver_error.add_note(
+                f"resource evidence collection also failed: {resource_error}"
+            )
+        if resource_write_error is not None:
+            driver_error.add_note(
+                f"resource evidence persistence also failed: {resource_write_error}"
+            )
+        if shutdown_error is not None:
+            driver_error.add_note(f"gateway cleanup also failed: {shutdown_error}")
+        raise driver_error
+    if resource_error is not None:
+        if resource_write_error is not None:
+            resource_error.add_note(
+                f"resource evidence persistence also failed: {resource_write_error}"
+            )
+        if shutdown_error is not None:
+            resource_error.add_note(f"gateway cleanup also failed: {shutdown_error}")
+        raise resource_error
+    if resource_write_error is not None:
+        if shutdown_error is not None:
+            resource_write_error.add_note(
+                f"gateway cleanup also failed: {shutdown_error}"
+            )
+        raise resource_write_error
+    if shutdown_error is not None:
+        raise shutdown_error
+
+
 async def _run_driver_and_shutdown(
     environment: BaseEnvironment,
     *,
@@ -78,7 +154,7 @@ async def _run_driver_and_shutdown(
     shutdown_command: str,
     logs_dir: Path,
 ) -> ExecResult:
-    """运行 driver 并始终尝试关闭 gateway，同时保留主失败。"""
+    """运行 driver、采集资源证据并关闭 gateway，同时保留主失败。"""
 
     # 1. 捕获 driver 的成功结果或原始异常，不提前跳过 cleanup。
     driver_result: ExecResult | None = None
@@ -96,7 +172,13 @@ async def _run_driver_and_shutdown(
     except BaseException as error:
         driver_error = error
 
-    # 2. driver 成功、失败、超时或取消后都尝试关闭 gateway。
+    # 2. driver 任意终态都先读取固定 cgroup 白名单，再停止容器内进程。
+    resource_error, resource_write_error = await _capture_resource_evidence(
+        environment,
+        logs_dir,
+    )
+
+    # 3. 资源采集成功或失败后都尝试关闭 gateway。
     shutdown_result: ExecResult | None = None
     shutdown_error: BaseException | None = None
     try:
@@ -112,15 +194,15 @@ async def _run_driver_and_shutdown(
     except BaseException as error:
         shutdown_error = error
 
-    # 3. 先写全两个阶段的证据，再按主失败优先级传播。
+    # 4. 先写全生命周期证据，再按 driver→资源→shutdown 的优先级传播。
     _write_driver_evidence(logs_dir, driver_result, driver_error)
     _write_shutdown_evidence(logs_dir, shutdown_result, shutdown_error)
-    if driver_error is not None:
-        if shutdown_error is not None:
-            driver_error.add_note(f"gateway cleanup also failed: {shutdown_error}")
-        raise driver_error
-    if shutdown_error is not None:
-        raise shutdown_error
+    _raise_lifecycle_errors(
+        driver_error=driver_error,
+        resource_error=resource_error,
+        resource_write_error=resource_write_error,
+        shutdown_error=shutdown_error,
+    )
     assert driver_result is not None
     return driver_result
 
@@ -342,12 +424,24 @@ class AkashicHarborAgent(BaseAgent):
             f"2>{_AGENT_LOGS}/runtime.stderr.log & "
             f"echo $! > {_AGENT_LOGS}/runtime.pid"
         )
-        started = await environment.exec(command=gateway_command)
-        _require_success(
-            "启动 Akasic gateway",
-            started.return_code,
-            (started.stdout or "") + (started.stderr or ""),
-        )
+        try:
+            started = await environment.exec(command=gateway_command)
+            _require_success(
+                "启动 Akasic gateway",
+                started.return_code,
+                (started.stdout or "") + (started.stderr or ""),
+            )
+        except BaseException as startup_error:
+            resource_error, resource_write_error = (
+                await _capture_resource_evidence(environment, self.logs_dir)
+            )
+            _raise_lifecycle_errors(
+                driver_error=startup_error,
+                resource_error=resource_error,
+                resource_write_error=resource_write_error,
+                shutdown_error=None,
+            )
+            raise AssertionError("unreachable")
 
         # 2. SDK driver 记录全部 turn 通知并核对持久化终态。
         driver_command = " ".join(

--- a/benchmark/harbor_v4flash/controller.py
+++ b/benchmark/harbor_v4flash/controller.py
@@ -48,6 +48,10 @@ from benchmark.harbor_v4flash.isolation import (
 )
 from benchmark.harbor_v4flash.image_cache import prefetch_task_images
 from benchmark.harbor_v4flash.git_volume import inspect_git_volume
+from benchmark.harbor_v4flash.resource_evidence import (
+    RESOURCE_EVIDENCE_FILENAME,
+    load_resource_evidence,
+)
 from benchmark.harbor_v4flash.runtime_volume import (
     inspect_runtime_volume,
     runtime_compose_overlay,
@@ -321,7 +325,12 @@ async def run_trial(
         ),
     )
     trial = await Trial.create(config)
-    result = await trial.run()
+    cancellation: asyncio.CancelledError | None = None
+    try:
+        result = await trial.run()
+    except asyncio.CancelledError as error:
+        cancellation = error
+        result = trial.result
 
     # 3. 只有完整 trace、外部 verifier、停止容器和线上 owner 不变才算 trial 完成。
     after_source = source_tree_digest(source_root)
@@ -337,10 +346,13 @@ async def run_trial(
     agent_dir = trial_dir / "agent"
     trace_path = agent_dir / "trace.jsonl"
     turn_result_path = agent_dir / "turn-result.json"
+    resource_evidence_path = agent_dir / RESOURCE_EVIDENCE_FILENAME
+    resource_evidence = load_resource_evidence(resource_evidence_path)
     required_artifacts = [
         agent_dir / "isolation.preflight.json",
         trace_path,
         turn_result_path,
+        resource_evidence_path,
         trial_dir / "verifier" / "reward.txt",
         trial_dir / "result.json",
     ]
@@ -351,6 +363,7 @@ async def run_trial(
     ]
     trial_completed = (
         not missing_artifacts
+        and resource_evidence["status"] == "collected"
         and stopped
         and after_source == before_source
         and online_report["status"] == "passed"
@@ -374,6 +387,10 @@ async def run_trial(
             "network": network,
         },
         "result": _safe_trial_result(result),
+        "resource_evidence": {
+            "artifact": str(resource_evidence_path.relative_to(trial_dir)),
+            **resource_evidence,
+        },
         "artifacts": {
             "missing": missing_artifacts,
             "digests": artifact_digests(
@@ -397,13 +414,14 @@ async def run_trial(
                 "manifest": str(manifest_path),
                 "trace": str(trace_path),
                 "containers_stopped": stopped,
+                "resource_classification": resource_evidence["classification"],
                 "concurrency_gate": final_manifest["concurrency_gate"],
             },
             ensure_ascii=False,
             indent=2,
         )
     )
-    return {
+    outcome = {
         "state": final_manifest["state"],
         "trial_name": trial_name,
         "trial_dir": str(trial_dir),
@@ -412,8 +430,12 @@ async def run_trial(
         "task": initial_manifest["task"],
         "reward": final_manifest["result"]["rewards"],
         "containers_stopped": stopped,
+        "resource_classification": resource_evidence["classification"],
         "concurrency_gate": final_manifest["concurrency_gate"],
     }
+    if cancellation is not None:
+        raise cancellation
+    return outcome
 
 
 async def run_smoke(args: argparse.Namespace, task_dir: Path) -> int:

--- a/benchmark/harbor_v4flash/isolation.py
+++ b/benchmark/harbor_v4flash/isolation.py
@@ -266,6 +266,9 @@ def inspect_compose_project(project_name: str) -> list[dict[str, object]]:
                 "image_id": item.get("Image"),
                 "status": item.get("State", {}).get("Status"),
                 "running": bool(item.get("State", {}).get("Running")),
+                "exit_code": item.get("State", {}).get("ExitCode"),
+                "oom_killed": bool(item.get("State", {}).get("OOMKilled")),
+                "memory_limit_bytes": item.get("HostConfig", {}).get("Memory"),
                 "mounts": mounts,
                 "ports": item.get("HostConfig", {}).get("PortBindings") or {},
                 "project": item.get("Config", {})

--- a/benchmark/harbor_v4flash/resource_evidence.py
+++ b/benchmark/harbor_v4flash/resource_evidence.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+RESOURCE_EVIDENCE_FILENAME = "container-resource.json"
+RESOURCE_EVIDENCE_SCHEMA = "akasic.container-resource.v1"
+
+_CGROUP_ROOT = "/sys/fs/cgroup"
+_REQUIRED_FILES = ("memory.max", "memory.current", "memory.events")
+_OPTIONAL_FILES = ("memory.peak", "memory.events.local")
+_SECTION_HEADER = "@@"
+_EVENT_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def resource_probe_command() -> str:
+    """生成只读取 cgroup v2 内存证据白名单的固定命令。"""
+
+    # 1. required 文件缺失时非零退出，不能把未知环境伪装成无 OOM。
+    required_checks = " ".join(
+        f'test -r "{_CGROUP_ROOT}/{name}";' for name in _REQUIRED_FILES
+    )
+
+    # 2. 输出固定分节格式；不读取进程、环境变量、挂载或宿主日志。
+    names = " ".join((*_REQUIRED_FILES, *_OPTIONAL_FILES))
+    script = (
+        "set -eu; "
+        f"{required_checks} "
+        'printf "cgroup_version=2\\n"; '
+        f"for name in {names}; do "
+        f'path="{_CGROUP_ROOT}/$name"; '
+        'if test -r "$path"; then '
+        f'printf "{_SECTION_HEADER}%s\\n" "$name"; '
+        'cat "$path"; '
+        "fi; "
+        "done"
+    )
+    return f"sh -c {shlex.quote(script)}"
+
+
+def parse_resource_probe_output(output: str) -> dict[str, object]:
+    """校验固定探针输出并投影为脱敏数值证据。"""
+
+    # 1. 分节必须完整且唯一，required 文件不能缺失。
+    lines = output.splitlines()
+    if not lines or lines[0] != "cgroup_version=2":
+        raise ValueError("resource probe 缺少 cgroup v2 标识")
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines[1:]:
+        if line.startswith(_SECTION_HEADER):
+            current = line.removeprefix(_SECTION_HEADER)
+            if current in sections:
+                raise ValueError(f"resource probe 分节重复：{current}")
+            if current not in {*_REQUIRED_FILES, *_OPTIONAL_FILES}:
+                raise ValueError(f"resource probe 分节不在白名单：{current}")
+            sections[current] = []
+            continue
+        if current is None:
+            raise ValueError("resource probe 在首个分节前包含数据")
+        sections[current].append(line)
+    required: set[str] = set(_REQUIRED_FILES)
+    missing = sorted(required - set(sections))
+    if missing:
+        raise ValueError(f"resource probe 缺少 required 分节：{missing}")
+
+    # 2. 标量和事件都只接受内核数值格式。
+    limit_raw = _parse_scalar(sections["memory.max"], allow_max=True)
+    current_bytes = int(_parse_scalar(sections["memory.current"]))
+    peak_bytes = (
+        int(_parse_scalar(sections["memory.peak"]))
+        if "memory.peak" in sections
+        else None
+    )
+    events = _parse_events(sections["memory.events"])
+    local_events = (
+        _parse_events(sections["memory.events.local"])
+        if "memory.events.local" in sections
+        else None
+    )
+    oom_events = (
+        events.get("oom", 0)
+        + events.get("oom_kill", 0)
+        + events.get("oom_group_kill", 0)
+    )
+
+    return {
+        "schema": RESOURCE_EVIDENCE_SCHEMA,
+        "status": "collected",
+        "classification": "resource_limit" if oom_events > 0 else "none",
+        "cgroup": {
+            "version": 2,
+            "memory": {
+                "limit_bytes": None if limit_raw == "max" else int(limit_raw),
+                "limit_raw": limit_raw,
+                "current_bytes": current_bytes,
+                "peak_bytes": peak_bytes,
+                "events": events,
+                "local_events": local_events,
+            },
+        },
+    }
+
+
+def resource_probe_failure(error: BaseException) -> dict[str, object]:
+    """把探针失败保存成显式未知状态，不伪装为无资源事件。"""
+
+    return {
+        "schema": RESOURCE_EVIDENCE_SCHEMA,
+        "status": "collection_failed",
+        "classification": "unknown",
+        "error": {
+            "type": type(error).__name__,
+            "message": str(error)[-2000:],
+        },
+    }
+
+
+def load_resource_evidence(path: Path) -> dict[str, object]:
+    """从 trial artifact 加载并校验资源证据的最小 envelope。"""
+
+    if not path.is_file():
+        return {
+            "schema": RESOURCE_EVIDENCE_SCHEMA,
+            "status": "unavailable",
+            "classification": "unknown",
+            "error": {
+                "type": "MissingArtifact",
+                "message": f"缺少 {RESOURCE_EVIDENCE_FILENAME}",
+            },
+        }
+    try:
+        payload: object = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("resource evidence 必须是对象")
+        evidence = cast(dict[str, Any], payload)
+        if evidence.get("schema") != RESOURCE_EVIDENCE_SCHEMA:
+            raise ValueError("resource evidence schema 不匹配")
+        if evidence.get("status") not in {"collected", "collection_failed"}:
+            raise ValueError("resource evidence status 无效")
+        if evidence.get("classification") not in {
+            "none",
+            "resource_limit",
+            "unknown",
+        }:
+            raise ValueError("resource evidence classification 无效")
+        return evidence
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        return resource_probe_failure(error)
+
+
+def _parse_scalar(lines: list[str], *, allow_max: bool = False) -> str:
+    if len(lines) != 1:
+        raise ValueError("resource probe 标量分节必须只有一行")
+    value = lines[0]
+    if allow_max and value == "max":
+        return value
+    if not value.isdecimal():
+        raise ValueError(f"resource probe 标量不是非负整数：{value!r}")
+    return value
+
+
+def _parse_events(lines: list[str]) -> dict[str, int]:
+    values: dict[str, int] = {}
+    for line in lines:
+        parts = line.split()
+        if (
+            len(parts) != 2
+            or not _EVENT_NAME.fullmatch(parts[0])
+            or not parts[1].isdecimal()
+        ):
+            raise ValueError(f"resource probe event 格式无效：{line!r}")
+        name, raw_value = parts
+        if name in values:
+            raise ValueError(f"resource probe event 重复：{name}")
+        values[name] = int(raw_value)
+    return values

--- a/tests/benchmark/test_harbor_v4flash_controller.py
+++ b/tests/benchmark/test_harbor_v4flash_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import shutil
 import subprocess
@@ -20,6 +21,10 @@ from benchmark.harbor_v4flash.controller import (
     _task_agent_timeout_sec,
 )
 from benchmark.harbor_v4flash.isolation import IsolationError, create_source_bundle
+from benchmark.harbor_v4flash.resource_evidence import (
+    RESOURCE_EVIDENCE_FILENAME,
+    resource_probe_command,
+)
 
 
 class _ScriptedEnvironment:
@@ -46,6 +51,21 @@ def _git(root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def _resource_result(*, oom_kill: int = 0) -> ExecResult:
+    return ExecResult(
+        return_code=0,
+        stdout=(
+            "cgroup_version=2\n"
+            "@@memory.max\n4294967296\n"
+            "@@memory.current\n268435456\n"
+            "@@memory.events\n"
+            f"low 0\nhigh 0\nmax 1\noom {oom_kill}\n"
+            f"oom_kill {oom_kill}\noom_group_kill 0\n"
+            "@@memory.peak\n4294967296\n"
+        ),
+    )
+
+
 def test_v4flash_high_uses_provider_output_limit() -> None:
     config_path = (
         Path(__file__).parents[2]
@@ -70,6 +90,7 @@ def test_benchmark_workspace_is_separate_from_terminal_task_root() -> None:
 def test_driver_success_keeps_command_order_and_logs(tmp_path: Path) -> None:
     environment = _ScriptedEnvironment(
         ExecResult(return_code=0, stdout="driver complete\n"),
+        _resource_result(),
         ExecResult(return_code=0, stdout="shutdown complete\n"),
     )
     result = asyncio.run(
@@ -83,13 +104,19 @@ def test_driver_success_keeps_command_order_and_logs(tmp_path: Path) -> None:
     )
 
     assert result.stdout == "driver complete\n"
-    assert environment.commands == ["driver", "shutdown"]
+    assert environment.commands == ["driver", resource_probe_command(), "shutdown"]
+    assert (tmp_path / "driver.stdout.log").read_text(
+        encoding="utf-8"
+    ) == "driver complete\n"
+    assert (tmp_path / "runtime.shutdown.log").read_text(
+        encoding="utf-8"
+    ) == "shutdown complete\n"
     assert (
-        tmp_path / "driver.stdout.log"
-    ).read_text(encoding="utf-8") == "driver complete\n"
-    assert (
-        tmp_path / "runtime.shutdown.log"
-    ).read_text(encoding="utf-8") == "shutdown complete\n"
+        json.loads((tmp_path / RESOURCE_EVIDENCE_FILENAME).read_text(encoding="utf-8"))[
+            "classification"
+        ]
+        == "none"
+    )
     assert not (tmp_path / "driver.exception.log").exists()
 
 
@@ -98,6 +125,7 @@ def test_driver_timeout_still_shuts_down_gateway_and_persists_evidence(
 ) -> None:
     environment = _ScriptedEnvironment(
         TimeoutError("driver exceeded deadline"),
+        _resource_result(oom_kill=1),
         ExecResult(return_code=0, stdout="gateway stopped\n"),
     )
 
@@ -112,15 +140,21 @@ def test_driver_timeout_still_shuts_down_gateway_and_persists_evidence(
             )
         )
 
-    assert environment.commands == ["driver", "shutdown"]
+    assert environment.commands == ["driver", resource_probe_command(), "shutdown"]
     assert (tmp_path / "driver.stdout.log").read_text(encoding="utf-8") == ""
     assert (tmp_path / "driver.stderr.log").read_text(encoding="utf-8") == ""
+    assert (tmp_path / "driver.exception.log").read_text(
+        encoding="utf-8"
+    ) == "TimeoutError: driver exceeded deadline\n"
+    assert (tmp_path / "runtime.shutdown.log").read_text(
+        encoding="utf-8"
+    ) == "gateway stopped\n"
     assert (
-        tmp_path / "driver.exception.log"
-    ).read_text(encoding="utf-8") == "TimeoutError: driver exceeded deadline\n"
-    assert (
-        tmp_path / "runtime.shutdown.log"
-    ).read_text(encoding="utf-8") == "gateway stopped\n"
+        json.loads((tmp_path / RESOURCE_EVIDENCE_FILENAME).read_text(encoding="utf-8"))[
+            "classification"
+        ]
+        == "resource_limit"
+    )
 
 
 def test_driver_cancellation_still_shuts_down_gateway(
@@ -128,6 +162,7 @@ def test_driver_cancellation_still_shuts_down_gateway(
 ) -> None:
     environment = _ScriptedEnvironment(
         asyncio.CancelledError("trial cancelled"),
+        _resource_result(),
         ExecResult(return_code=0),
     )
 
@@ -142,10 +177,10 @@ def test_driver_cancellation_still_shuts_down_gateway(
             )
         )
 
-    assert environment.commands == ["driver", "shutdown"]
-    assert (
-        tmp_path / "driver.exception.log"
-    ).read_text(encoding="utf-8") == "CancelledError: trial cancelled\n"
+    assert environment.commands == ["driver", resource_probe_command(), "shutdown"]
+    assert (tmp_path / "driver.exception.log").read_text(
+        encoding="utf-8"
+    ) == "CancelledError: trial cancelled\n"
     assert (tmp_path / "runtime.shutdown.log").read_text(encoding="utf-8") == ""
 
 
@@ -154,6 +189,7 @@ def test_driver_failure_remains_primary_when_shutdown_also_fails(
 ) -> None:
     environment = _ScriptedEnvironment(
         ExecResult(return_code=1, stdout="driver failed\n"),
+        RuntimeError("cgroup probe failed"),
         ExecResult(return_code=2),
     )
 
@@ -168,15 +204,53 @@ def test_driver_failure_remains_primary_when_shutdown_also_fails(
             )
         )
 
+    assert any("gateway cleanup also failed" in note for note in caught.value.__notes__)
     assert any(
-        "gateway cleanup also failed" in note for note in caught.value.__notes__
+        "resource evidence collection also failed" in note
+        for note in caught.value.__notes__
     )
     assert (
-        tmp_path / "driver.exception.log"
-    ).read_text(encoding="utf-8").startswith("RuntimeError: 执行 SDK turn")
-    assert (
-        tmp_path / "runtime.shutdown.log"
-    ).read_text(encoding="utf-8") == "exit=2\n"
+        (tmp_path / "driver.exception.log")
+        .read_text(encoding="utf-8")
+        .startswith("RuntimeError: 执行 SDK turn")
+    )
+    assert (tmp_path / "runtime.shutdown.log").read_text(encoding="utf-8") == "exit=2\n"
+    resource = json.loads(
+        (tmp_path / RESOURCE_EVIDENCE_FILENAME).read_text(encoding="utf-8")
+    )
+    assert resource["status"] == "collection_failed"
+    assert resource["classification"] == "unknown"
+
+
+def test_resource_probe_failure_fails_loud_after_successful_driver(
+    tmp_path: Path,
+) -> None:
+    environment = _ScriptedEnvironment(
+        ExecResult(return_code=0, stdout="driver complete\n"),
+        ExecResult(return_code=23, stderr="required cgroup file missing\n"),
+        ExecResult(return_code=0, stdout="gateway stopped\n"),
+    )
+
+    with pytest.raises(RuntimeError, match="采集容器资源证据"):
+        asyncio.run(
+            _run_driver_and_shutdown(
+                environment,  # type: ignore[arg-type]
+                driver_command="driver",
+                driver_timeout_sec=5,
+                shutdown_command="shutdown",
+                logs_dir=tmp_path,
+            )
+        )
+
+    assert environment.commands == ["driver", resource_probe_command(), "shutdown"]
+    resource = json.loads(
+        (tmp_path / RESOURCE_EVIDENCE_FILENAME).read_text(encoding="utf-8")
+    )
+    assert resource["status"] == "collection_failed"
+    assert resource["classification"] == "unknown"
+    assert (tmp_path / "runtime.shutdown.log").read_text(
+        encoding="utf-8"
+    ) == "gateway stopped\n"
 
 
 def test_task_agent_timeout_uses_harbor_task_budget(tmp_path: Path) -> None:

--- a/tests/benchmark/test_harbor_v4flash_isolation.py
+++ b/tests/benchmark/test_harbor_v4flash_isolation.py
@@ -118,7 +118,12 @@ def test_inspect_compose_project_records_immutable_image_id(
                                     )
                                 },
                             },
-                            "State": {"Status": "running", "Running": True},
+                            "State": {
+                                "Status": "exited",
+                                "Running": False,
+                                "ExitCode": 137,
+                                "OOMKilled": False,
+                            },
                             "Mounts": [
                                 {
                                     "Type": "volume",
@@ -131,7 +136,10 @@ def test_inspect_compose_project_records_immutable_image_id(
                                     "RW": False,
                                 }
                             ],
-                            "HostConfig": {"PortBindings": {}},
+                            "HostConfig": {
+                                "PortBindings": {},
+                                "Memory": 4294967296,
+                            },
                         }
                     ]
                 ),
@@ -147,6 +155,9 @@ def test_inspect_compose_project_records_immutable_image_id(
 
     assert containers[0]["image"] == "task:tag"
     assert containers[0]["image_id"] == "sha256:image-id"
+    assert containers[0]["exit_code"] == 137
+    assert containers[0]["oom_killed"] is False
+    assert containers[0]["memory_limit_bytes"] == 4294967296
     assert containers[0]["mounts"][0]["name"] == (
         "akasic-bench-runtime-v1-fixed"
     )

--- a/tests/benchmark/test_harbor_v4flash_resource_evidence.py
+++ b/tests/benchmark/test_harbor_v4flash_resource_evidence.py
@@ -1,0 +1,136 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmark.harbor_v4flash.resource_evidence import (
+    RESOURCE_EVIDENCE_FILENAME,
+    load_resource_evidence,
+    parse_resource_probe_output,
+    resource_probe_command,
+)
+
+
+def test_resource_probe_command_reads_only_fixed_cgroup_memory_files() -> None:
+    command = resource_probe_command()
+
+    assert "/sys/fs/cgroup/memory.max" in command
+    assert "/sys/fs/cgroup/memory.current" in command
+    assert "/sys/fs/cgroup/memory.events" in command
+    assert "/proc/" not in command
+    assert "journalctl" not in command
+    assert "docker" not in command
+
+
+def test_resource_probe_classifies_cgroup_oom_kill_as_resource_limit() -> None:
+    evidence = parse_resource_probe_output("""
+cgroup_version=2
+@@memory.max
+4294967296
+@@memory.current
+1073741824
+@@memory.events
+low 0
+high 0
+max 532
+oom 3
+oom_kill 1
+oom_group_kill 0
+@@memory.peak
+4294967296
+@@memory.events.local
+low 0
+high 0
+max 532
+oom 3
+oom_kill 1
+oom_group_kill 0
+""".lstrip())
+
+    assert evidence["status"] == "collected"
+    assert evidence["classification"] == "resource_limit"
+    memory = evidence["cgroup"]["memory"]  # type: ignore[index]
+    assert memory["limit_bytes"] == 4294967296
+    assert memory["current_bytes"] == 1073741824
+    assert memory["peak_bytes"] == 4294967296
+    assert memory["events"]["oom_kill"] == 1
+
+
+def test_resource_probe_classifies_oom_without_kill_as_resource_limit() -> None:
+    evidence = parse_resource_probe_output("""
+cgroup_version=2
+@@memory.max
+max
+@@memory.current
+2048
+@@memory.events
+low 0
+high 0
+max 1
+oom 1
+oom_kill 0
+oom_group_kill 0
+""".lstrip())
+
+    assert evidence["classification"] == "resource_limit"
+    assert evidence["cgroup"]["memory"]["limit_bytes"] is None  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "cgroup_version=1\n",
+        "cgroup_version=2\n@@memory.max\n4096\n",
+        (
+            "cgroup_version=2\n@@memory.max\n4096\n"
+            "@@memory.current\ninvalid\n@@memory.events\noom_kill 1\n"
+        ),
+        (
+            "cgroup_version=2\n@@memory.max\n4096\n"
+            "@@memory.current\n1024\n@@memory.events\nnot-valid\n"
+        ),
+    ],
+)
+def test_resource_probe_rejects_incomplete_or_malformed_evidence(
+    output: str,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_resource_probe_output(output)
+
+
+def test_missing_or_corrupt_resource_artifact_is_explicit(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / RESOURCE_EVIDENCE_FILENAME
+
+    missing = load_resource_evidence(path)
+    assert missing["status"] == "unavailable"
+    assert missing["classification"] == "unknown"
+
+    path.write_text("{not-json", encoding="utf-8")
+    corrupt = load_resource_evidence(path)
+    assert corrupt["status"] == "collection_failed"
+    assert corrupt["classification"] == "unknown"
+
+
+def test_load_resource_evidence_preserves_valid_failure_artifact(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / RESOURCE_EVIDENCE_FILENAME
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "akasic.container-resource.v1",
+                "status": "collection_failed",
+                "classification": "unknown",
+                "error": {"type": "RuntimeError", "message": "probe failed"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = load_resource_evidence(path)
+
+    assert evidence["status"] == "collection_failed"
+    assert evidence["error"]["type"] == "RuntimeError"  # type: ignore[index]


### PR DESCRIPTION
## 问题

`sam-cell-seg` 的任务进程在官方 4 GiB cgroup 限额下被内核 OOM kill，但原驱动只留下连接断开，无法区分资源上限与 Agent/协议失败。

## 改动

- 在容器关闭前读取固定白名单中的 cgroup memory 指标
- 将证据写入 `agent/container-resource.json` 并登记到 manifest
- `oom`/`oom_kill`/`oom_group_kill` 非零时分类为 `resource_limit`
- 成功、失败、超时与取消路径均保留证据；驱动原始错误仍为主错误

这不提高内存上限，也不改变任务、verifier、Agent prompt 或评分语义。

## 验证

- 63 个 benchmark 测试通过
- pyright 通过
- 合同 Gate 通过：`20260731-014045-7e5280b1`
- private-contract-gate：`pending_maintainer`
- 64 MiB 真实 cgroup OOM 探针正确分类为 `resource_limit`

## 真实任务验证

`sam-cell-seg` 的稳定源重跑保持官方 4 GiB 限额，Agent 由正常 terminal event 收束；采集结果为 `classification=none`、peak `429051904` bytes、所有 OOM 计数为 0。官方 verifier 9/9、reward 1，source unchanged 与 online invariant 均通过。该运行同时验证资源证据在成功路径不会误报；旧 OOM 的分类能力由真实 64 MiB cgroup 故障注入覆盖。

`semantic_delta: compatible`：新增持久资源 artifact、失败分类和探针完整性要求，不改变任务或评分语义。