### PR TITLE
ci: install benchmark SDK explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -r requirements.txt
           .venv/bin/python -m pip install -r requirements-dev.txt
+          .venv/bin/python -m pip install -e sdk/python
 
       - name: Run pyright
         run: |


### PR DESCRIPTION
## 问题与结果

- 解决的问题：完整 CI 需要导入仓库内的 `akashic_sdk`，但通用开发依赖文件不能引用尚未复制进 change-impact Gate 镜像的本地 editable package。
- 用户可见结果：CI 在 checkout 后显式安装 `sdk/python`；Gate 的通用依赖安装保持可移植。
- 本 PR 不处理：benchmark harness 与 Agent 运行时实现；它们由后续独立实现 PR 承载。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`not_applicable`
- `consumer_scope`：GitHub Actions 的 check-and-test job
- `runtime_patch`：`none`
- `runtime_patch_reason`：不修改运行时
- `authoritative_state_owner`：repository CI policy
- `client_only_alternative`：不适用
- 关联不变量：CI 必须从 checkout 后的 canonical SDK source 安装测试依赖
- `protected_state`：正式 workspace、SessionDB、外部服务
- 允许的副作用：CI 虚拟环境安装本地 SDK
- 禁止的副作用：修改生产依赖、workspace 或运行时行为

## 改动范围

- 主要文件：`.github/workflows/ci.yml`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用
- 回滚方式：revert `4b0f5d1f`

## 验证

- [x] 相关 targeted tests 已通过（由 change-impact Gate 选择 8 个公开场景）。
- [x] Python 类型检查或前端 typecheck/lint 已通过；本 PR 无 Python/前端源码变更，不适用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`82ca6d5376ded1e14fa4cd6e302c43939f7a9fcb307a77dffa5fe5adab39caf3`
- `planDigest`：`a13ac0bc45ba6179f2626ef09c35b1f06d06d86f331077f1cf5b6c81b2e246aa`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：统一私有 companion 外部状态尚未实现，由维护者后续执行。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用。
- [x] 已完成事项已从 `NOW.md` 删除；本 PR 无对应事项，不适用。