### PR TITLE
test(mobile): make key tampering deterministic

### DIFF
--- a/tests/mobile_realtime/test_key_protection.py
+++ b/tests/mobile_realtime/test_key_protection.py
@@ -155,7 +155,9 @@ def test_tampered_blob_and_manifest_path_are_rejected(tmp_path: Path) -> None:
     manager = KeysetManager(root, keys)
     _ = manager.initialize(lan_hostname="akashic.local")
     blob = root / "keyset-v1" / "server-identity.key.enc"
-    blob.write_bytes(blob.read_bytes()[:-1] + b"x")
+    tampered_blob = bytearray(blob.read_bytes())
+    tampered_blob[-1] ^= 1
+    blob.write_bytes(tampered_blob)
 
     with pytest.raises(KeyProtectionError, match="blob hash 不匹配"):
         manager.load()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：篡改测试把密文末字节固定写成 `x`；原字节恰好为 `x` 时文件未改变，Gate 会随机失败。
- 用户可见结果：测试始终翻转末字节的一位，保证每次都产生真实篡改。
- 本 PR 不处理：密钥保护生产逻辑与 Agent 行为。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`not_applicable`
- `consumer_scope`：mobile realtime 测试与 change-impact Gate
- `runtime_patch`：`none`
- `runtime_patch_reason`：只修改测试输入
- `authoritative_state_owner`：不适用
- `client_only_alternative`：不适用
- 关联不变量：篡改测试必须保证输入字节实际变化
- `protected_state`：正式密钥、workspace、SessionDB
- 允许的副作用：测试临时目录内修改临时密文
- 禁止的副作用：修改生产密钥或运行时行为

## 改动范围

- 主要文件：`tests/mobile_realtime/test_key_protection.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用
- 回滚方式：revert `86c26c08`

## 验证

- [x] `tests/mobile_realtime/test_key_protection.py`：6 passed。
- [x] Python 类型检查或前端 typecheck/lint：无生产源码变更，不适用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，8 个公开场景通过且无残留资源。
- `sourceDigest`：`22eef6f8a41cf55c22bc0ebe4e3b87e41b988bd07469888080a16b68edea22de`
- `planDigest`：`dedd0fa2904071b718858aee9051e05a3b45903b48c470cf6a281fd349296abb`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：统一私有 companion 外部状态尚未实现，由维护者后续执行。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用。
- [x] 已完成事项已从 `NOW.md` 删除；本 PR 无对应事项，不适用。