### PR TITLE
fix(shell): preserve explicit background timeouts

### DIFF
--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -10,6 +10,7 @@ Shell 工具（Bash 命令执行）
 后台任务（run_in_background=True）：
 - 立即返回 background_task_id，不阻塞前台
 - 输出持续写入临时日志文件
+- 显式硬超时最长 4 小时；未显式传入时不设置硬超时
 - 配合 ShellTaskOutputTool / ShellTaskStopTool 管理
 """
 
@@ -284,7 +285,7 @@ class ShellTool(Tool):
             "- 前台阻塞总超时默认 60 秒，普通命令最大 600 秒\n"
             "- 命令超过 15 秒未完成时默认自动转为后台任务，返回 background_task_id；后台会沿用当前 timeout 作为硬截止时间\n"
             "- 只有用户明确说“阻塞”时，才设置 auto_promote=false；未显式传 timeout 时会默认阻塞 21600 秒\n"
-            "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台模式只有显式传 timeout 时才会按 timeout 自动终止\n"
+            "- 服务进程或已知长时间运行的命令，直接用 run_in_background=true 后台启动，跳过 15 秒等待；后台显式硬超时最长 14400 秒，未显式传入时不设置硬超时\n"
             "- 收到 background_task_id 后，由你负责用 task_output 主动查看进展和结果；不会有系统自动回传\n"
             "- task_output 是轮询接口：block=true 单次最多等 30s 就返回快照（不会等到任务结束），长任务靠多次轮询推进\n"
             "- 如果决定放弃后台任务并准备最终回复，必须先调用 task_stop 终止它\n"
@@ -312,7 +313,7 @@ class ShellTool(Tool):
                     "description": (
                         f"前台阻塞或显式硬超时秒数，默认 {_DEFAULT_TIMEOUT}。"
                         f"普通命令最大 {_MAX_TIMEOUT}；auto_promote=false 时最大 {_BLOCKING_TIMEOUT}。"
-                        "自动转后台后只有显式传入才生效。"
+                        f"run_in_background=true 时最大 {_BG_TTL_S}，且只有显式传入才生效。"
                     ),
                     "minimum": 1,
                     "maximum": _BLOCKING_TIMEOUT,
@@ -346,11 +347,19 @@ class ShellTool(Tool):
         timeout_specified = "timeout" in kwargs and kwargs.get("timeout") is not None
         run_in_background: bool = bool(kwargs.get("run_in_background", False))
         auto_promote: bool = bool(kwargs.get("auto_promote", True))
-        max_timeout = (
-            _BLOCKING_TIMEOUT
-            if not run_in_background and not auto_promote
-            else _MAX_TIMEOUT
-        )
+        requested_timeout = int(kwargs["timeout"]) if timeout_specified else None
+        if run_in_background and requested_timeout is not None:
+            if requested_timeout < 1 or requested_timeout > _BG_TTL_S:
+                return _err(
+                    f"后台显式 timeout 必须在 1 到 {_BG_TTL_S} 秒之间，"
+                    f"收到 {requested_timeout}"
+                )
+        if run_in_background:
+            max_timeout = _BG_TTL_S
+        elif not auto_promote:
+            max_timeout = _BLOCKING_TIMEOUT
+        else:
+            max_timeout = _MAX_TIMEOUT
         default_timeout = (
             _BLOCKING_TIMEOUT
             if not run_in_background and not auto_promote and not timeout_specified

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -514,6 +514,7 @@ async def test_shell_run_in_background_preserves_explicit_long_timeout(monkeypat
     assert result["timeout_s"] == 3600
     assert task.timeout_s == 3600
     assert task.timeout_handle is not None
+    assert task.pump_task is not None
     task.timeout_handle.cancel()
     await asyncio.gather(task.pump_task, return_exceptions=True)
 

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -487,6 +487,72 @@ async def test_shell_run_in_background_returns_task_id(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_shell_run_in_background_preserves_explicit_long_timeout(monkeypatch):
+    """后台长任务应保留显式 3600 秒硬超时，不再静默压缩为 600 秒。"""
+    import agent.tools.shell as shell_mod
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        return _FakeProc(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(
+            command="sleep 3600",
+            description="后台长任务",
+            timeout=3600,
+            run_in_background=True,
+        )
+    )
+
+    task_id = result["background_task_id"]
+    task = shell_mod._BG_REGISTRY.pop(task_id)
+    assert result["timeout_s"] == 3600
+    assert task.timeout_s == 3600
+    assert task.timeout_handle is not None
+    task.timeout_handle.cancel()
+    await asyncio.gather(task.pump_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_shell_run_in_background_rejects_timeout_beyond_ttl(monkeypatch):
+    """后台显式硬超时超过任务 TTL 时应失败并且不启动进程。"""
+    import agent.tools.shell as shell_mod
+
+    launched = False
+
+    async def _fake_create_subprocess_shell(command, **kwargs):
+        nonlocal launched
+        launched = True
+        return _FakeProc(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        "agent.tools.shell.asyncio.create_subprocess_shell",
+        _fake_create_subprocess_shell,
+    )
+
+    tool = ShellTool()
+    result = json.loads(
+        await tool.execute(
+            command="sleep 99999",
+            description="超长后台任务",
+            timeout=shell_mod._BG_TTL_S + 1,
+            run_in_background=True,
+        )
+    )
+
+    assert result["error"] == (
+        f"后台显式 timeout 必须在 1 到 {shell_mod._BG_TTL_S} 秒之间，"
+        f"收到 {shell_mod._BG_TTL_S + 1}"
+    )
+    assert launched is False
+
+
+@pytest.mark.asyncio
 async def test_task_output_returns_log_content(monkeypatch, tmp_path):
     """task_output 能读取后台任务已写入的日志内容。"""
     import agent.tools.shell as shell_mod


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`run_in_background=true` 时显式 `timeout=3600` 会被普通前台上限静默压成 600 秒，长编译/服务任务会提前终止。
- 用户可见结果：直接后台任务保留显式硬超时，允许 1–14400 秒；超过后台 TTL 时明确失败，不启动进程；未显式传 timeout 时仍不设置硬超时。
- 本 PR 不处理：不改变前台 600 秒上限、显式阻塞 21600 秒上限、自动转后台语义或任务清理协议。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：调用内置 shell 工具的普通会话与程序化会话
- `runtime_patch`：`required`
- `runtime_patch_reason`：超时裁决与进程生命周期由 core shell 工具拥有，客户端无法可靠补偿被静默压缩的硬截止时间。
- `authoritative_state_owner`：ShellTool 的后台任务注册表与进程 owner
- `client_only_alternative`：客户端轮询不能延长 core 已设定的进程硬超时
- 关联不变量：显式后台 timeout 必须原样生效且不超过任务 TTL；非法范围不得启动进程；未显式 timeout 不得凭空增加硬截止
- `protected_state`：正式 workspace、SessionDB、线上进程
- 允许的副作用：在调用者显式要求时为后台进程设置最长 14400 秒的 timer
- 禁止的副作用：静默 clamp、超范围仍启动、改变前台或自动转后台上限

## 改动范围

- 主要文件：`agent/tools/shell.py`、`tests/test_shell_tool.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：shell tool schema 结构不变，描述与运行时范围一致
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用
- 回滚方式：revert 本 PR 的 squash commit；备份分支 `backup/shell-background-timeout-pre-test-type-20260731`

## 验证

- [x] `tests/test_shell_tool.py`：`37 passed`。
- [x] 完整 tests pyright：`0 errors`。
- [x] `python docker/debug/gate.py run --base origin/main`：8 个公开场景通过且无残留资源。
- `sourceDigest`：`f9d6b386608ffa9bc4451ea1ea7d4ab125c625809889059de1e04a8fc253c24e`
- `planDigest`：`3ea3548d78875c1621a67560abf9a37a29c8cd74c2e716537f5caa9c0f62c2ce`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用
- 未运行项与原因：统一私有 companion 外部状态尚未实现，由维护者后续执行。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认；这是 #253 已提出的兼容能力扩展，本 PR 仅移植到最新 main。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用。
- [x] 已完成事项已从 `NOW.md` 删除；本 PR 无对应事项，不适用。

Supersedes #253.