### PR TITLE
[codex] decouple shell cleanup from turn finality

### DIFF
--- a/agent/background/boot_guardian.py
+++ b/agent/background/boot_guardian.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 from utils.pidfd import open_pidfd
+from utils.process_group import process_group_exists
 
 GUARDIAN_FAILURE_EXIT_CODE = 70
 _BOOT_CLEANUP_TIMEOUT_SECONDS = 5.0
@@ -38,8 +39,9 @@ def run_boot_guardian(
     os.set_blocking(signal_write_fd, False)
     previous_wakeup_fd = signal.set_wakeup_fd(signal_write_fd)
     stop_signals = (signal.SIGINT, signal.SIGTERM)
+    handled_signals = (*stop_signals, signal.SIGCHLD)
     previous_handlers = {
-        sig: signal.signal(sig, lambda _signum, _frame: None) for sig in stop_signals
+        sig: signal.signal(sig, lambda _signum, _frame: None) for sig in handled_signals
     }
 
     gateway: subprocess.Popen[bytes] | None = None
@@ -89,8 +91,11 @@ def run_boot_guardian(
                         break
                     raise RuntimeError("Supervisor lease 收到未知数据")
                 if any(key.data == "signal" for key, _mask in events):
-                    _drain_fd(signal_read_fd)
-                    break
+                    received = _drain_signal_fd(signal_read_fd)
+                    if signal.SIGCHLD in received:
+                        _reap_adopted_children(exclude_pids={gateway.pid})
+                    if received.intersection(stop_signals):
+                        break
 
         # 4. 无论退出来源如何，都在返回前证明当前 boot 已清空。
         gateway_exit_code = gateway.poll()
@@ -262,7 +267,7 @@ def _signal_targets(
 
 
 def _group_exists(group_id: int) -> bool:
-    return _linux_group_has_live_members(group_id)
+    return process_group_exists(group_id)
 
 
 def _pid_exists(pid: int) -> bool:
@@ -273,29 +278,41 @@ def _pid_exists(pid: int) -> bool:
     return fields[0] != "Z"
 
 
-def _linux_group_has_live_members(group_id: int) -> bool:
-    for entry in Path("/proc").iterdir():
-        if not entry.name.isdigit():
-            continue
-        try:
-            fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
-        except (OSError, IndexError):
-            continue
-        if len(fields) >= 3 and int(fields[2]) == group_id and fields[0] != "Z":
-            return True
-    return False
-
-
-def _drain_fd(fd: int) -> None:
+def _drain_signal_fd(fd: int) -> set[int]:
+    received: set[int] = set()
     while True:
         try:
-            if not os.read(fd, 4096):
-                return
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                return received
+            received.update(chunk)
         except BlockingIOError:
-            return
+            return received
 
 
-def _reap_adopted_children() -> None:
+def _reap_adopted_children(*, exclude_pids: set[int] | None = None) -> None:
+    """收割 adopted zombie；运行期间保留由 Popen 持有的直接 child。"""
+
+    excluded = exclude_pids or set()
+    if excluded:
+        for entry in Path("/proc").iterdir():
+            if not entry.name.isdigit():
+                continue
+            pid = int(entry.name)
+            if pid in excluded:
+                continue
+            try:
+                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+            except (OSError, IndexError):
+                continue
+            if len(fields) < 2 or fields[0] != "Z" or int(fields[1]) != os.getpid():
+                continue
+            try:
+                os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                continue
+        return
+
     while True:
         try:
             pid, _status = os.waitpid(-1, os.WNOHANG)

--- a/agent/background/boot_guardian.py
+++ b/agent/background/boot_guardian.py
@@ -12,6 +12,7 @@ import sys
 import time
 from pathlib import Path
 
+from core.common.diagnostic_log import diagnostic_line
 from utils.pidfd import open_pidfd
 from utils.process_group import process_group_exists
 
@@ -100,9 +101,10 @@ def run_boot_guardian(
         # 4. 无论退出来源如何，都在返回前证明当前 boot 已清空。
         gateway_exit_code = gateway.poll()
         cleanup_attempted = True
-        _cleanup_boot_processes(
+        _ = _cleanup_boot_processes_best_effort(
             boot_id=boot_id,
             gateway_group_id=gateway.pid,
+            owner="guardian",
         )
         if gateway_exit_code is None:
             gateway_exit_code = gateway.wait()
@@ -110,16 +112,11 @@ def run_boot_guardian(
         return _portable_exit_code(gateway_exit_code)
     except BaseException as run_error:
         if gateway is not None and not cleanup_attempted:
-            try:
-                _cleanup_boot_processes(
-                    boot_id=boot_id,
-                    gateway_group_id=gateway.pid,
-                )
-            except BaseException as cleanup_error:
-                raise BaseExceptionGroup(
-                    "Boot Guardian 执行与 boot 清理均失败",
-                    [run_error, cleanup_error],
-                ) from run_error
+            _ = _cleanup_boot_processes_best_effort(
+                boot_id=boot_id,
+                gateway_group_id=gateway.pid,
+                owner="guardian",
+            )
         raise
     finally:
         if lifecycle_fd >= 0:
@@ -187,6 +184,37 @@ def _cleanup_boot_processes(
     raise RuntimeError(
         f"boot {boot_id} 进程清理失败: groups={alive_groups}, pids={alive_pids}"
     )
+
+
+def _cleanup_boot_processes_best_effort(
+    *,
+    boot_id: str,
+    gateway_group_id: int | None,
+    owner: str,
+) -> bool:
+    """尽力清理 boot；权限或残留失败只输出结构化诊断。"""
+
+    try:
+        _cleanup_boot_processes(
+            boot_id=boot_id,
+            gateway_group_id=gateway_group_id,
+        )
+    except (OSError, RuntimeError) as exc:
+        print(
+            diagnostic_line(
+                "BootCleanup",
+                event="cleanup_degraded",
+                flow="runtime",
+                phase="boot_cleanup",
+                action="continue",
+                reason="boot_cleanup_unconfirmed",
+                error_type=type(exc).__name__,
+                note=f"owner={owner} boot_id={boot_id} error={exc}",
+            ),
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def _wait_boot_targets(

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from core.error_context import current_session_key
+from core.common.diagnostic_log import diagnostic_line
 from agent.control.context import current_turn_id
 from agent.control.ids import new_turn_id
 from agent.context import ContextBuilder
@@ -54,6 +55,7 @@ from bus.queue import MessageBus
 from proactive_v2.presence import PresenceStore
 from agent.provider import LLMProvider
 from agent.tools.shell import ShellTool
+from agent.tools.unified_exec import ExecutionCleanupReport
 from agent.tools.registry import ToolRegistry
 from session.manager import SessionManager
 
@@ -674,7 +676,6 @@ class AgentLoop:
             else ""
         )
         turn_token = current_turn_id.set(inherited_turn_id or new_turn_id())
-        primary_error: BaseException | None = None
         try:
             # 1. 先处理可能存在的续跑态，并发布 turn started。
             msg, resumed_from_interrupt = await self._resume_interrupted_message(msg, key)
@@ -699,29 +700,71 @@ class AgentLoop:
                 # 3. 无论核心处理结果如何，都释放 busy 状态。
                 if self._processing_state:
                     self._processing_state.exit(busy_key)
-        except BaseException as exc:
-            primary_error = exc
-            raise
         finally:
             # 4. 当前 query 结束即回收其 shell，再恢复调用方上下文。
             try:
-                try:
-                    await self._terminate_shell_owner(key)
-                except BaseException:
-                    if primary_error is None:
-                        raise
-                    logger.exception("shell owner cleanup 失败，保留原始 turn 异常")
+                await self._cleanup_shell_owner(key)
             finally:
                 current_session_key.reset(session_token)
                 current_turn_id.reset(turn_token)
 
-    async def _terminate_shell_owner(self, owner_session_key: str) -> None:
+    async def _cleanup_shell_owner(self, owner_session_key: str) -> None:
+        """回收 turn 的 Shell，并把失败隔离为 execution 诊断。"""
+
+        # 1. 未预期的 cleanup 异常只进入日志，不拥有 turn 终态。
+        try:
+            report = await self._terminate_shell_owner(owner_session_key)
+        except Exception as exc:
+            logger.exception(
+                diagnostic_line(
+                    "AgentLoop.shell_cleanup",
+                    event="cleanup_degraded",
+                    flow="passive",
+                    phase="cleanup",
+                    session=owner_session_key,
+                    turn=current_turn_id.get(),
+                    action="retain_turn_finality",
+                    reason="cleanup_exception",
+                    error_type=type(exc).__name__,
+                    note=str(exc),
+                )
+            )
+            return
+
+        # 2. manager 的已知失败保留 execution ownership 和完整明细。
+        if report is not None and report.failures:
+            failures = ";".join(
+                f"{failure.execution_id}:{failure.error_type}:{failure.message}"
+                for failure in report.failures
+            )
+            logger.error(
+                diagnostic_line(
+                    "AgentLoop.shell_cleanup",
+                    event="cleanup_degraded",
+                    flow="passive",
+                    phase="cleanup",
+                    session=owner_session_key,
+                    turn=current_turn_id.get(),
+                    action="retain_turn_finality",
+                    reason="execution_cleanup_unconfirmed",
+                    counts=(
+                        f"attempted:{len(report.attempted_execution_ids)},"
+                        f"failed:{len(report.failures)}"
+                    ),
+                    note=failures,
+                )
+            )
+
+    async def _terminate_shell_owner(
+        self,
+        owner_session_key: str,
+    ) -> ExecutionCleanupReport | None:
         shell = self.tools.get_tool("shell")
         if shell is None:
-            return
+            return None
         if not isinstance(shell, ShellTool):
             raise TypeError("注册名 shell 必须由 ShellTool 拥有生命周期")
-        await shell.terminate_owner(owner_session_key)
+        return await shell.terminate_owner(owner_session_key)
 
     async def _process_with_runtime_admission(
         self,

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 from agent.background.boot_guardian import (
     _cleanup_boot_processes,
+    _cleanup_boot_processes_best_effort,
     _enable_child_subreaper,
     _pid_has_boot_identity,
     _pid_exists,
@@ -356,9 +357,10 @@ def run_supervisor(
                 os.close(lifecycle_read_fd)
                 os.close(lease_write_fd)
                 _stop_guardian(guardian)
-                _cleanup_boot_processes(
+                _ = _cleanup_boot_processes_best_effort(
                     boot_id=boot_id,
                     gateway_group_id=None,
+                    owner="supervisor",
                 )
                 _reap_adopted_children()
                 guardian = None
@@ -375,33 +377,23 @@ def run_supervisor(
                     settings_bridge=settings_bridge,
                     report_settings_generation=report_settings_generation,
                 )
-            except BaseException as wait_error:
+            except BaseException:
                 _stop_guardian(guardian)
-                try:
-                    _cleanup_boot_processes(
-                        boot_id=boot_id,
-                        gateway_group_id=None,
-                    )
-                    _reap_adopted_children()
-                except BaseException as cleanup_error:
-                    raise BaseExceptionGroup(
-                        "Supervisor 等待 Guardian 与 boot 清理均失败",
-                        [wait_error, cleanup_error],
-                    ) from wait_error
+                _ = _cleanup_boot_processes_best_effort(
+                    boot_id=boot_id,
+                    gateway_group_id=None,
+                    owner="supervisor",
+                )
+                _reap_adopted_children()
                 raise
 
             # 3. Guardian 完成后再做一次 boot-scoped 空集验证和兜底清理。
-            try:
-                _cleanup_boot_processes(
-                    boot_id=boot_id,
-                    gateway_group_id=None,
-                )
-                _reap_adopted_children()
-            except RuntimeError as error:
-                print(str(error), file=sys.stderr)
-                if result.settings_generation:
-                    settings_bridge.complete(result.settings_generation, False)
-                return SUPERVISOR_FAILURE_EXIT_CODE
+            _ = _cleanup_boot_processes_best_effort(
+                boot_id=boot_id,
+                gateway_group_id=None,
+                owner="supervisor",
+            )
+            _reap_adopted_children()
             guardian = None
             if report_settings_generation:
                 report_settings_generation = 0

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -13,9 +13,11 @@ from agent.tools.shell_command import resolve_shell
 from agent.tools.unified_exec import DEFAULT_HARD_TIMEOUT_S
 from agent.tools.unified_exec import DEFAULT_INITIAL_YIELD_TIME_MS
 from agent.tools.unified_exec import DEFAULT_MAX_OUTPUT_TOKENS
+from agent.tools.unified_exec import ExecutionCleanupReport
 from agent.tools.unified_exec import MAX_HARD_TIMEOUT_S
 from agent.tools.unified_exec import ShellProcessManager
 from agent.tools.unified_exec import format_execution_result
+from core.common.diagnostic_log import diagnostic_line
 from core.error_context import current_session_key
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,31 @@ _UNIFIED_EXEC_ENV = {
     "GIT_PAGER": "cat",
     "GH_PAGER": "cat",
 }
+
+
+def _cleanup_diagnostic(
+    action: str,
+    owner_session_key: str,
+    report: ExecutionCleanupReport,
+) -> str:
+    failures = ";".join(
+        f"{failure.execution_id}:{failure.error_type}:{failure.message}"
+        for failure in report.failures
+    )
+    return diagnostic_line(
+        "ShellCleanup",
+        event="cleanup_degraded",
+        flow="runtime",
+        phase="cleanup",
+        session=owner_session_key,
+        action=action,
+        reason="execution_cleanup_unconfirmed",
+        counts=(
+            f"attempted:{len(report.attempted_execution_ids)},"
+            f"failed:{len(report.failures)}"
+        ),
+        note=failures,
+    )
 
 
 class ShellTool(Tool):
@@ -214,11 +241,17 @@ class ShellTool(Tool):
         )
         return format_execution_result(result, command=command)
 
-    async def shutdown(self) -> None:
-        await self.manager.shutdown()
+    async def shutdown(self) -> ExecutionCleanupReport:
+        report = await self.manager.shutdown()
+        if report.failures:
+            logger.error(_cleanup_diagnostic("shutdown", "-", report))
+        return report
 
-    async def terminate_owner(self, owner_session_key: str) -> None:
-        await self.manager.terminate_owner(owner_session_key)
+    async def terminate_owner(
+        self,
+        owner_session_key: str,
+    ) -> ExecutionCleanupReport:
+        return await self.manager.terminate_owner(owner_session_key)
 
 
 class ShellWriteStdinTool(Tool):

--- a/agent/tools/unified_exec.py
+++ b/agent/tools/unified_exec.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO
 
+from utils.process_group import process_group_exists
+
 MIN_YIELD_TIME_MS = 250
 MIN_EMPTY_YIELD_TIME_MS = 5_000
 MAX_YIELD_TIME_MS = 30_000
@@ -778,6 +780,12 @@ def _kill_remaining_process_group(process: asyncio.subprocess.Process) -> None:
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
         pass
+    except PermissionError:
+        # Linux killpg 会因组内只剩其他 UID 的 zombie 返回 EPERM；zombie 已不再执行，
+        # 由 subreaper wait 回收，不能把已完成命令误判为仍有活进程。
+        if not process_group_exists(process.pid):
+            return
+        raise
 
 
 async def _read_fd(fd: int, size: int) -> bytes:

--- a/agent/tools/unified_exec.py
+++ b/agent/tools/unified_exec.py
@@ -133,6 +133,24 @@ class ExecutionResult:
     finish_reason: str
 
 
+@dataclass(frozen=True)
+class ExecutionCleanupFailure:
+    execution_id: int
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ExecutionCleanupReport:
+    attempted_execution_ids: tuple[int, ...]
+    cleaned_execution_ids: tuple[int, ...]
+    failures: tuple[ExecutionCleanupFailure, ...]
+
+    @property
+    def failed_execution_ids(self) -> tuple[int, ...]:
+        return tuple(failure.execution_id for failure in self.failures)
+
+
 @dataclass
 class _Execution:
     execution_id: int
@@ -173,6 +191,7 @@ class ShellProcessManager:
             MIN_EMPTY_YIELD_TIME_MS,
         )
         self._executions: dict[int, _Execution] = {}
+        self._quarantined_owners: dict[str, ExecutionCleanupReport] = {}
         self._lock = asyncio.Lock()
         self._spawn_lock = asyncio.Lock()
         self._rng = random.SystemRandom()
@@ -194,6 +213,7 @@ class ShellProcessManager:
 
         # 1. 串行容量回收和 spawn，保证新进程在开始等待前已注册。
         async with self._spawn_lock:
+            await self._ensure_owner_admitted(owner_session_key)
             await self._prune_if_needed()
             execution_id = await self._allocate_execution_id()
             execution = await self._spawn(
@@ -306,23 +326,37 @@ class ShellProcessManager:
         await self._remove_execution(execution, delete_log=True)
         return True
 
-    async def terminate_owner(self, owner_session_key: str) -> None:
-        """回收某个对话 owner 创建的全部执行。"""
+    async def terminate_owner(
+        self,
+        owner_session_key: str,
+    ) -> ExecutionCleanupReport:
+        """回收 owner 执行，并隔离 cleanup 未确认的 owner。"""
 
-        async with self._lock:
-            executions = [
-                execution
-                for execution in self._executions.values()
-                if execution.owner_session_key == owner_session_key
-            ]
-        await self._terminate_many(executions)
+        # 1. 与 spawn 串行，避免 cleanup 与同 owner 新进程交错。
+        async with self._spawn_lock:
+            async with self._lock:
+                executions = [
+                    execution
+                    for execution in self._executions.values()
+                    if execution.owner_session_key == owner_session_key
+                ]
+            report = await self._terminate_many(executions)
 
-    async def shutdown(self) -> None:
-        """确认终止 manager 持有的全部执行。"""
+            # 2. cleanup 成功解除隔离；失败保留 execution 与失败证据。
+            async with self._lock:
+                if report.failures:
+                    self._quarantined_owners[owner_session_key] = report
+                else:
+                    _ = self._quarantined_owners.pop(owner_session_key, None)
+            return report
 
-        async with self._lock:
-            executions = list(self._executions.values())
-        await self._terminate_many(executions)
+    async def shutdown(self) -> ExecutionCleanupReport:
+        """尽力终止全部执行，并返回未清理明细。"""
+
+        async with self._spawn_lock:
+            async with self._lock:
+                executions = list(self._executions.values())
+            return await self._terminate_many(executions)
 
     async def active_execution_ids(self) -> list[int]:
         async with self._lock:
@@ -606,18 +640,47 @@ class ShellProcessManager:
             execution.failure_message = f"shell 硬超时终止失败: {exc}"
             execution.output_event.set()
 
-    async def _terminate_many(self, executions: list[_Execution]) -> None:
-        failures: list[str] = []
+    async def _terminate_many(
+        self,
+        executions: list[_Execution],
+    ) -> ExecutionCleanupReport:
+        """逐个清理 execution，并保留每个失败的 ownership。"""
+
+        cleaned: list[int] = []
+        failures: list[ExecutionCleanupFailure] = []
         for execution in executions:
             try:
                 if execution.process.returncode is None:
                     execution.finish_reason = "shutdown"
                     await self._terminate_confirmed(execution)
                 await self._remove_execution(execution, delete_log=True)
+                cleaned.append(execution.execution_id)
             except Exception as exc:
-                failures.append(f"{execution.execution_id}: {exc}")
-        if failures:
-            raise RuntimeError("shell execution 回收失败: " + "; ".join(failures))
+                failures.append(
+                    ExecutionCleanupFailure(
+                        execution_id=execution.execution_id,
+                        error_type=type(exc).__name__,
+                        message=str(exc),
+                    )
+                )
+        return ExecutionCleanupReport(
+            attempted_execution_ids=tuple(
+                execution.execution_id for execution in executions
+            ),
+            cleaned_execution_ids=tuple(cleaned),
+            failures=tuple(failures),
+        )
+
+    async def _ensure_owner_admitted(self, owner_session_key: str) -> None:
+        async with self._lock:
+            report = self._quarantined_owners.get(owner_session_key)
+        if report is None:
+            return
+        failed = ",".join(str(value) for value in report.failed_execution_ids)
+        raise RuntimeError(
+            f"owner={owner_session_key} 的 shell cleanup 未确认；"
+            f"failed_execution_ids={failed}，拒绝创建新 execution"
+        )
 
     async def _terminate_confirmed(self, execution: _Execution) -> None:
         if execution.process.returncode is None:

--- a/docker/debug/entrypoint.sh
+++ b/docker/debug/entrypoint.sh
@@ -115,6 +115,10 @@ case "$cmd" in
             --port "$DASHBOARD_PORT" \
             "$@"
         ;;
+    gate-root-shell-cleanup)
+        exec python -m pytest -q \
+            tests/test_unified_exec.py::test_real_cross_uid_live_process_group_returns_eperm
+        ;;
     *)
         exec_as_host "$cmd" "$@"
         ;;

--- a/utils/process_group.py
+++ b/utils/process_group.py
@@ -137,7 +137,7 @@ def _signal_posix_group(group_id: int, sig: signal.Signals) -> None:
 async def _wait_posix_group_exit(group_id: int, timeout_s: float) -> bool:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout_s
-    while _posix_group_exists(group_id):
+    while process_group_exists(group_id):
         remaining = deadline - loop.time()
         if remaining <= 0:
             return False
@@ -145,7 +145,9 @@ async def _wait_posix_group_exit(group_id: int, timeout_s: float) -> bool:
     return True
 
 
-def _posix_group_exists(group_id: int) -> bool:
+def process_group_exists(group_id: int) -> bool:
+    """只在进程组仍有活成员时返回 True。"""
+
     if sys.platform.startswith("linux"):
         return _linux_group_has_live_members(group_id)
     try:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：回复已提交后，Shell cleanup 的 EPERM 会从 AgentLoop finally 外溢，导致控制面把成功 turn 改成 failed；Guardian 也没有在 Gateway 运行期间持续 waitpid adopted zombie。
- 用户可见结果：已提交回复不再被 cleanup 反杀；zombie 静默回收；活残留写结构化日志、保留 execution ownership，并只隔离当前 runtime 内同 owner 的后续 Shell；合法重启继续。
- 本 PR 不处理：不持久化跨 runtime quarantine，不引入 cgroup，不改变普通 Shell 命令失败对 Agent 的可见性。
- 前置合同：#283

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：AgentLoop、Unified Exec、Linux Boot Guardian、Supervisor、移动端 turn 终态消费者
- `runtime_patch`：`required`
- `runtime_patch_reason`：失败位于 core execution lifecycle 与 turn finality 交界，客户端无法安全修复
- `authoritative_state_owner`：Turn Pipeline 独占回复与 turn 终态；ShellProcessManager/Guardian 独占 execution cleanup
- `client_only_alternative`：无；客户端重试可能重复已经发生的外部副作用
- 关联不变量：SH-002、RUN-003、RUN-004、OUT-001、ERR-001
- `protected_state`：已提交消息、TurnCommitted、其他 owner 的 Shell admission、合法 restart commit
- 允许的副作用：结构化 cleanup 日志、runtime-local 同 owner Shell quarantine、Guardian waitpid
- 禁止的副作用：cleanup 修改 turn、阻断合法 restart、删除未确认 execution、写正式 workspace

## 改动范围

- 主要文件：`agent/tools/unified_exec.py`、`agent/looping/core.py`、`agent/background/boot_guardian.py`、`agent/supervisor.py`、`docker/debug/entrypoint.sh`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：HEAD `9c6294cded2be441806c17c4df09b8712c292cbb`
- 回滚方式：revert 本 PR；本地恢复点 `backup/shell-finality-pre-change-20260801`

## 验证

- [x] 定向 lifecycle suite：97 passed, 1 skipped；root-only case 在 Gate 中独立强制执行
- [x] 目标 Pyright：0 errors
- [x] `python docker/debug/gate.py run --base origin/main`：11 个公开场景通过，资源清理为空
- `sourceDigest`：`11999bbc9b9fa9bcb7810082e471c84d2d96f87b744b0142d2bc32165a72aa84`
- `planDigest`：`6111449114c3f0d37a4cace03b20c39af3e2fcba0b920f7f24f97488868a3b4e`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：不适用；客户端协议未变化
- 未运行项与原因：维护者私有 Gate 当前不可用

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`
- [x] 长期语义已由维护者确认并在 #283 合入
- [x] 能力 owner 为 core；移动端仅消费最终 turn
- [x] 当前没有对应 NOW 未完成事项