### PR TITLE
[codex] 优化 Dashboard、聊天配对与消息回源

### DIFF
--- a/agent/tools/message_lookup.py
+++ b/agent/tools/message_lookup.py
@@ -19,6 +19,7 @@ class FetchMessagesTool(Tool):
         "这是 recall_memory / search_messages / 记忆注入三条路里唯一可以直接作为最终证据的工具。\n"
         "何时必须调用：回答依赖具体时间、原话、金额、配置值、是否发生过——只要结论需要事实支撑，就在回复前调用此工具。\n"
         "recall_memory 返回 evidence 时优先传 evidence；search_messages 返回 source_ref 时传 source_ref。\n"
+        "recall_memory 的 summary 若只是截断的原始消息或预览，传该条目的 evidence 读取完整原文，不要根据预览补写缺失内容。\n"
         "支持 context 参数扩展前后文，适合还原完整上下文片段。\n"
         "【引用协议（必须执行）】本工具调用后，最终回复正文末尾必须另起一行输出：\n"
         "  §cited:[memory_id1,memory_id2,...]§\n"
@@ -165,10 +166,15 @@ class SearchMessagesTool(Tool):
     name = "search_messages"
     description = (
         "对原始历史消息做 grep 式搜索，返回命中候选消息的预览和 source_ref。\n"
-        "适合查找某个词、句子、文件名、报错、命令、配置项曾出现在哪些消息里——它是文本定位工具。\n"
-        "不是记忆检索工具：不负责总结偏好、判断做没做过、回答历史事实。这些问题先用 recall_memory。\n"
+        "检索历史信息时，必须先尝试 recall_memory 获取相关记忆、关联情景和模式线索；"
+        "如果 recall_memory 返回相关条目，但 summary 是截断的原始消息或预览，先将该条目的 evidence "
+        "传给 fetch_messages 获取完整原文；不要把截断当作召回失败。\n"
+        "只有 recall_memory 已经尝试但未找到相关内容，或通过 fetch_messages 读取已召回原文后结果仍不足、"
+        "仍无法确定答案时，才使用本工具检索原始消息。\n"
+        "适合在上述回忆不足后，查找某个词、句子、文件名、报错、命令、配置项曾出现在哪些消息里——"
+        "它是文本定位工具，不负责记忆召回、偏好总结或历史事实判断。\n"
         "命中后若需确认上下文或以结果作为证据，必须继续 fetch_messages(source_ref)，预览不能直接作证。\n"
-        "recall_memory 返回的摘要读起来像[询问行为]而非[事件本身]时，可同步用此工具补一路 grep 交叉验证。"
+        "recall_memory 返回的摘要读起来像[询问行为]而非[事件本身]时，可用本工具补一路 grep 交叉验证。"
     )
     parameters = {
         "type": "object",

--- a/docker/debug/restart_probe.py
+++ b/docker/debug/restart_probe.py
@@ -966,7 +966,7 @@ def _failure_mode_checks(report_dir: Path) -> list[CheckResult]:
         )
     )
 
-    # 2. stale readiness 不能满足新 boot；startup 卡住后必须走 15 秒失败门。
+    # 2. stale readiness 不能满足新 boot；故障场景单独使用 15 秒失败门。
     stale_config, stale_workspace, _ = _isolated_config("stale-ready")
     stale_home = Path("/sandbox/stale-ready-home")
     stale_payload = {"bootId": "stale", "pid": 1, "state": "ready"}
@@ -983,7 +983,11 @@ def _failure_mode_checks(report_dir: Path) -> list[CheckResult]:
             "--workspace",
             str(stale_workspace),
         ],
-        env={**os.environ, "HOME": str(stale_home)},
+        env={
+            **os.environ,
+            "HOME": str(stale_home),
+            "AKASHIC_READINESS_TIMEOUT_S": "15",
+        },
         timeout=25,
     )
     stale_duration = time.monotonic() - stale_started

--- a/frontend/chat/src/mobile-pairing-dialog.tsx
+++ b/frontend/chat/src/mobile-pairing-dialog.tsx
@@ -175,10 +175,10 @@ export function MobilePairingDialog({ open, onOpenChange }: MobilePairingDialogP
           <motion.div
             key={state.stage}
             className="mobile-pairing-stage"
-            initial={{ opacity: 0, y: 10, filter: "blur(4px)" }}
-            animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-            exit={{ opacity: 0, y: -6, filter: "blur(4px)" }}
-            transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.16, ease: "easeOut" }}
           >
             {state.stage === "creating" ? <CreatingStage /> : null}
             {state.stage === "waiting" ? (

--- a/frontend/chat/src/settings-app.tsx
+++ b/frontend/chat/src/settings-app.tsx
@@ -268,7 +268,6 @@ export function SettingsApp() {
       <div className="settings-shell">
         <header className="settings-header">
           <div>
-            <span className="settings-kicker">AKASHIC SETTINGS</span>
             <h1>{state?.mode === "needs_setup" ? "连接你的模型" : "模型与认证"}</h1>
             <p>选择一个 Provider，验证后安全切换。已保存的密钥不会显示在页面中。</p>
           </div>

--- a/frontend/chat/src/settings.css
+++ b/frontend/chat/src/settings.css
@@ -19,16 +19,9 @@
   margin-bottom: 36px;
 }
 
-.settings-kicker {
-  color: oklch(0.72 0.09 146);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-}
-
 .settings-header h1,
 .settings-repair h1 {
-  margin: 8px 0 9px;
+  margin: 0 0 9px;
   font-size: clamp(30px, 4vw, 44px);
   font-weight: 660;
   letter-spacing: -0.035em;
@@ -110,25 +103,21 @@
   border-radius: 14px;
   padding: 28px;
   background: oklch(0.185 0.008 150);
-  box-shadow: 0 22px 60px oklch(0 0 0 / 0.23);
 }
 
 .panel-heading {
   display: flex;
   align-items: center;
-  gap: 13px;
+  gap: 10px;
   margin-bottom: 27px;
 }
 
 .panel-icon {
   display: grid;
-  width: 38px;
-  height: 38px;
+  width: 24px;
+  height: 24px;
   place-items: center;
-  border: 1px solid oklch(0.76 0.08 146 / 0.25);
-  border-radius: 9px;
   color: oklch(0.81 0.1 146);
-  background: oklch(0.23 0.025 150);
 }
 .panel-icon svg { width: 18px; }
 .panel-heading h2 { margin: 0; font-size: 19px; letter-spacing: -0.015em; }

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -102,8 +102,8 @@ input {
   border: 0;
   border-radius: 12px;
   padding: 6px 14px 6px 10px;
-  color: var(--pairing-on-primary-container);
-  background: var(--pairing-surface-container-low);
+  color: var(--pairing-on-surface);
+  background: transparent;
   font-size: 14px;
   font-weight: 650;
   cursor: pointer;
@@ -113,7 +113,7 @@ input {
 }
 
 .mobile-connect-trigger:hover {
-  color: var(--pairing-on-surface);
+  color: var(--pairing-on-primary-container);
   background: var(--pairing-surface-container-high);
 }
 
@@ -128,13 +128,11 @@ input {
 
 .mobile-connect-icon {
   display: grid;
-  width: 32px;
-  height: 32px;
+  width: 20px;
+  height: 20px;
   place-items: center;
   flex: 0 0 auto;
-  border-radius: 8px;
-  color: var(--pairing-on-primary-container);
-  background: var(--pairing-primary-container);
+  color: var(--pairing-primary);
 }
 
 .icon-button,
@@ -669,14 +667,12 @@ form.composer:focus-within [data-slot="input-group"] {
   max-height: min(880px, calc(100vh - 32px));
   gap: 0;
   overflow-y: auto;
-  border: 0;
-  border-radius: 28px;
+  border: 1px solid var(--pairing-outline);
+  border-radius: 18px;
   padding: 0;
   color: var(--pairing-on-surface);
   background: var(--pairing-surface);
-  box-shadow:
-    0 0 0 1px var(--pairing-outline),
-    0 24px 68px var(--pairing-shadow);
+  box-shadow: 0 12px 32px var(--pairing-shadow);
   transition-property: opacity, transform;
   transition-duration: 180ms;
   transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
@@ -687,7 +683,7 @@ form.composer:focus-within [data-slot="input-group"] {
   width: 44px;
   height: 44px;
   place-items: center;
-  border-radius: 50%;
+  border-radius: 8px;
   color: var(--pairing-on-surface-variant);
   transition-property: scale, opacity, background-color;
   transition-duration: 150ms;
@@ -705,8 +701,8 @@ form.composer:focus-within [data-slot="input-group"] {
 
 .mobile-pairing-header {
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr);
-  gap: 16px;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 12px;
   padding: 28px 76px 22px 28px;
   text-align: left;
 }
@@ -729,12 +725,10 @@ form.composer:focus-within [data-slot="input-group"] {
 
 .mobile-pairing-symbol {
   display: grid;
-  width: 48px;
-  height: 48px;
+  width: 28px;
+  height: 28px;
   place-items: center;
-  border-radius: 15px;
-  color: var(--pairing-on-primary-container);
-  background: var(--pairing-primary-container);
+  color: var(--pairing-primary);
 }
 
 .mobile-pairing-stage {
@@ -796,19 +790,17 @@ form.composer:focus-within [data-slot="input-group"] {
 }
 
 .mobile-pairing-qr-wrap {
-  padding: 14px;
-  border-radius: 24px;
+  padding: 10px;
+  border: 1px solid var(--pairing-outline-strong);
+  border-radius: 14px;
   background: var(--pairing-qr-surface);
-  box-shadow:
-    0 0 0 1px var(--pairing-outline-strong),
-    0 10px 30px var(--pairing-shadow-soft);
 }
 
 .mobile-pairing-qr {
   display: block;
   width: 100%;
   aspect-ratio: 1;
-  border-radius: 10px;
+  border-radius: 4px;
   outline: 1px solid var(--pairing-qr-outline);
   outline-offset: -1px;
 }
@@ -844,8 +836,8 @@ form.composer:focus-within [data-slot="input-group"] {
   background: var(--pairing-primary-container-high);
 }
 
-.mobile-pairing-step strong,
-.mobile-pairing-step span {
+.mobile-pairing-step > div > strong,
+.mobile-pairing-step > div > span {
   display: block;
 }
 
@@ -882,20 +874,18 @@ form.composer:focus-within [data-slot="input-group"] {
 .mobile-pairing-device-row {
   display: grid;
   min-width: min(100%, 360px);
-  grid-template-columns: 44px minmax(0, 1fr);
-  gap: 13px;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
   align-items: center;
   margin-bottom: 30px;
 }
 
 .mobile-pairing-device-icon {
   display: grid;
-  width: 44px;
-  height: 44px;
+  width: 24px;
+  height: 24px;
   place-items: center;
-  border-radius: 14px;
-  color: var(--pairing-on-primary-container);
-  background: var(--pairing-primary-container);
+  color: var(--pairing-primary);
 }
 
 .mobile-pairing-device-row span,
@@ -969,7 +959,7 @@ form.composer:focus-within [data-slot="input-group"] {
   justify-content: center;
   gap: 8px;
   border: 0;
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 0 20px;
   font-size: 14px;
   font-weight: 650;
@@ -1058,7 +1048,7 @@ form.composer:focus-within [data-slot="input-group"] {
   .mobile-pairing-dialog {
     width: min(calc(100vw - 20px), 760px);
     max-height: calc(100vh - 20px);
-    border-radius: 24px;
+    border-radius: 16px;
   }
 
   .mobile-pairing-header {

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { BookOpenText, Sparkles } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import "./styles.css";
 import { api, asPageResult, pageCount } from "./api";
 import {
@@ -39,6 +39,8 @@ const pluginPreset = document.createElement("link");
 pluginPreset.rel = "stylesheet";
 pluginPreset.href = "/assets/sdk/preset.css";
 document.head.appendChild(pluginPreset);
+
+const notificationIcon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAQAAABIkb+zAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAACYktHRAAAqo0jMgAAAAd0SU1FB+oHEQ4oCHiWdTwAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjYtMDctMTdUMTQ6Mzk6NTArMDA6MDA+rUxAAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDI2LTA3LTE3VDE0OjM5OjUwKzAwOjAwT/D0/AAAACh0RVh0ZGF0ZTp0aW1lc3RhbXAAMjAyNi0wNy0xN1QxNDo0MDowOCswMDowMLbEq2kAAAyzSURBVHja7Zt7tB1Vfcc/c+bcmxAeCeFCwiNgSIBcMUWQiIhUlihoK9RlAKE+qxZqDWqlXav0oVCr4ipLsa3KksJqsWorYC0ComBcPETKq4CQIEISwqOhJAQSQpJzZubTP2bP3DnnntclF7q6en+z1r3nzOzZ+/v97d/+7d/+7X1gSqZkSqZkSqZkSqYEAPOrLuLBXunzLhBr/m8DmzD8un/tNlWX5Xf+D0gF/hJXqbpN/YEYv4IErF5Ry1Xe7/peZCyepWrDzFRd7ZAYvXLAI2Pr1q2J7XRi68ZjT8a9HYvnq5qomqnbPUCsvRLQa9aNWyDv7CxnOsuZ7u5wC5V6lUbFeD6hpqYWkqlHiXH39us7Bh6AiBhJyYBZLOYwXsPBzGF3poUiEZtZxxM8wD3czxqS8FaKFjgSTuKrSMSYwWTEjLy8mo+C08MDPNtrfMZ+0vAev+TrSr1HuaN0rpu1on3VpvohcYfU3B184bEjT/M6t4dGU5s2TUzNKldqEu4XcpdnO7MyeK9QG21kXx4Cpc3H4pDL/HXZXGLWtwcyU5uh3HrPdRdr4pvHab8g8MFJJtCi+6WungD0Vklsqvo3Iv4wwG0vo2/vPYhfCvjc7vfxh8Gm0wnAHq/hk8XRLnVk6pJJI1CaDuLpblGbOwA+h/esI8F9Njs+3+p+veeBgaeI4O5iMuAivssMEuqDv99BMuBh1gNv7trkGp4IJbvIgMOj4q0jfsSJpEQ7NoeEStcCsLCjKjNq3AfEpK0BSDWyGAhEBf5u3MRraTK0g+AL2QLMZM82VLkk1LkRiKi10UsmSACAmITduJ3RSYSf6306MzroLGM6j3M1kJF1N6IBCJg3lALLGaXB8KTBz+UFNjETW0KIGjHf5E/YBGSM8loWMZeMmBdYySUTqD04TsQfOX6u3BFJ1J+KeJe2hXD6ERGHPMu721+cKPx82vrqJMM3xPvTxW9V3Ghmpn5AxLf4aLjbDFdDfWSiBIbED3T01JMhR7TV3lT/XMQzVW1U4qe81749MfixuNCG7tCk1Vma6rnibNerjaDhn4t4Rgm4vdfeNXHrv+Nl0n+qPmBNvKBy943iIpMOKkvVRx3UiZTm8xdOtvWPSaK+U9zXh7ze77jRW8rgbnybDfWcAcdwGfccZKYTjjUnQuBOI3GaiHu4QDyoY5SVqKsHzlGU9t850J08aarvEHHU1wev9/kS8JhkJqHkIJNv6Tzf4fiBNJmSqevdS/xTVb8u4sle6ipb54aG+rmB01zlovH+SSUw3hCb6rXi3m4LLS0pw/ZLyrYTE/UbIdc0Af2f4WSbTzbu2yXuIe7sc+aD9DO+z0s9UcSb1O0BwXljXnFwB3r7pOo/dXMLhWbQKh7uu1yhppWnp4mnhs8rPKHQ/qAGFIsnTip83e45lf7M1C3OFT/b1jvbfF69UjxB/bHvNRZrE4GfE7jayTOgTH3Baf6grDNR7xb3C6DbW3qnuJcHhhGxtzt1z6yOJ1ATF5g4ef4/Ve8Vj7HwLcWdnV3bQjPxWv/Vt1dSkYs8z8zfL3Ihgw7gz06i/vOa/k7EK8O3XDWj4pEu926/5NrQL0eKOM2jXOoXvTUQvrdXdruTA13hZIZviXqKiAeW8BP15jI1ibepL6q/JX6wDKRz+k31hIH2CoL9Hzup8DN1m/PEYfFcizgnUVd5pkucLf62qrdaFzeap8uKlFlT/feArS+Buvj1CRhQs2+ol6jLxzyJt1kdyqoPO0McdanTxU/ZHsrlPXag/XbMgv8fcs2APZCo3/Upew/3pvrhoJpYnOeLJfg0pHxvc34wpY+VkNvrOK9vKBEaeMuA8FN1jW/qkRgs/q93Zrm6qIc5pgoyUbf7E7/vio7w87YeyqfY/h7obx3MgJrquz3CThPeGKmGekGZEC7a+KitM29S+dS5N1PzxU7ci0Ak1tsiwV7wfxG6vJVuvjDfVOryBffK625JE/yl7RtKSc9sa1P9sjjUi0AcJvD+IUSupcPFi9oI5J8/7zfUxIal7Vp11LH46Tbd95ZUXdnTC4Vmvu0gBtQwX5Djdep2UzUr92A+KX7PfK93lfVC/xVTzfdlPlTWNags7kWgJu7tFvuHEA31prBqXtP2bLmLW9YSx4z573IU1KwZOSQe7bPm+8L9pal+qheBodCt/fSfqBvcU8T5bnGtt/grdatX+7YAcU83qvrxMfMpwUcliSFxT2+omF6/dq/qbUL4S/sN4PzpUSFnMcM54v6+yv3dJwAbFt+q6vmF9ksCtRCgHWixu4x4TqXm3i3/ukdaJTTbD35mHtcMBXAj3mLmVr9msf1UD+nCT1Tj+BL+XH+mpl7rSOiHmjjqzX1NN1MbvroXgX/o05V5A2cFkHk65OHy/uVj+vbLHi/GY8uQUD4OfZypt5djYkjEC+3nk1L19O4E8tg860PgD8pJqS5+Rt1q7oHCllzLnFu6vfB9mblvytxmnoOuh/AZT7PfSEjUL1Qxt+58vIF5LXn6dkmJuJGLqYc9kgR4DzBMscNyevgkMXFeqlJdBpxKviuRb1G9h2IDKAUOYhBZ1J3Ab9JzQw2AXcoyNWB/FpQYI+Cw8mlK2gY/ImMXDilbrQGHMoO0LNQ/ZRUB+3YncMQAr+/PTmREoc2dmdZCYJ+cQFRebTLctr8zg+mVb7MGIjC3O4FD6L3xGgGzGQGKeTU/o1KMUtgE9Dqe1O7EW3e/5jKIVCm3wd2ra0MFAZnOfhR2Dut4tuWdNUC3aFFgI0+3EH6c58KnLBDofzqrxchbCcxkzBw6U0iBQxkbqJu4I9zNK/5pFe/YFaQOLC/Lp+FbPqQzauwzEIHuUkktbeziTpvqN0vXF4tvUrXhNvW/3TW40Fo4elZc+VGzmniwqtvD8ZxwrNJowCgsU5/uTqDwtNf7tS4eOVV/WdFtbJFX1tS3iXEZ67RftRCBfris7aPlxBeLx9k/mMjUh6uYWx3XJnYjI+Y61vGHHTlGwCgHsooaGfnMcAE38342czGriMkQmM8oC5jDLFK28AwP8iBPku8AX8Y9/B41/pn/CPvPeb1Hh+cdNEvEBp7gMFLq/Ff3Hngo6P1oF3btzKZ6ZssCMa58qolH+EB5fmtMXvQuF1sclGp/syYut1sgkaq3emGYwy/rPojvCXee5RHWEHWc1CLgDKq+ICWmTp0aKTXgSA4lJiWpXCnTeB3HQChVp04ctA81Ml4VnnaSDLidx8O3+7sT+LeKYd1I51k5Bo7jN1o6OwdblN5O7qHqlSs/prO+BJSTqqJ4H8MkPXzQDTwTWv9FdwJX8TA1UgSuoJtLS4CPhcoqc25ENHaEZrwmY2A1kEXt83REQsxHuupf6mzhJ8wB6qzm3q4kxdPVhqNi1HVpk4+NQzol+ozEPXzOTnsxTzmjPatThtIf7xGHNtXviV9Q9Su9VmSx+I/qcRIyN42uVV5TXWtVANXF74x7s6Fe3J5XK4fvSNd5p3DsJ4a1Sp9Ffe6/7/TvzY+kPtTVLyTBiw+3UgiAFms4vD3mRfSg1sxmJUP0/R76T9Q7RLxW/Va/xFZNrPvWUPHJXSvOtbWknUIJ6Vw1tWEa/uaJlvbcUP72H9trGVPsDg/7lJlz7HUEsLLojoKBXK4dfHpR8XMuEoeLmbflZOP5LaX/rKy5Wqou/q5FJq+TNNSrRDxSPcneyV2LlNMYiboPdR0JibrF44PWq+FDvp+4xMt90Pu8zCXlvbES+Sr40xUTa+/fvIWN7iXi+/MzvO1uozeZWDzADfYazPpXpTXHFZCtR/HjCvQ4zOKz/BfHnz3Nyr/5wv+Eyqw/zmn0I5C/usANFUNKW9Lmuax0afmLgLiMPuv5ry8csl5GpwWRnTzbdeM0XvTF8xY56mUvEX6FwpC4wMdadFWc5bnNL/pkuPeYn/PwDr/caL+GfaNf8dnw1hYv8b4SeN7PZ/mz8LQKv8sWX9SbApCfF92Jf+JUYCvXcCr5bFwnZRGPcCxH8XpOYjrwND/ndn7F4zzNZiI2UWNXMmYxwnxezRs4hlnA09zIau7nauaxkjqSIXW28m6u5xlG2MB7+XGR/3jJq5yWzjvFleof+RrvLTv+0dLqZ7vUS8uj+IVprHND27h5wIs83umlTleo24MR3egBYV1wubvbllfqLH2phddrRKTAMuZzDvA7LONYpgF3ciwJUXmadoSFLGQ/9mVXZjObjCdpsJG1PMYa1rCBol8jmlzBKeH7HVwQgsl5jPCfoef7Qhygbyor2hzkEAkCB3Mc89mVC1lDDYlpORTctcUYyaiR8kkuoslabuAKlpMHc7nK60W+4uX/BdaUTMmUTMmUTMmU/D+W/wGZEHgnLlD3igAAAABJRU5ErkJggg==";
 
 // Creates a PluginDispatch bound to the given plugin + latest state getter.
 function makeDispatch(
@@ -147,54 +149,6 @@ function useLatestReader<T>(value: T): () => T {
   return useCallback(() => ref.current, []);
 }
 
-function MagicIndicator(props: { containerRef: React.RefObject<HTMLElement | null>; activeSelector: string }) {
-  const [style, setStyle] = useState<React.CSSProperties>({ opacity: 0 });
-
-  useEffect(() => {
-    let animationFrameId: number;
-
-    const update = () => {
-      animationFrameId = requestAnimationFrame(() => {
-        if (!props.containerRef.current) return;
-        const activeEl = props.containerRef.current.querySelector(props.activeSelector) as HTMLElement;
-        if (!activeEl) {
-          setStyle((prev) => ({ ...prev, opacity: 0 }));
-          return;
-        }
-
-        const top = activeEl.offsetTop;
-        const left = activeEl.offsetLeft;
-        const width = activeEl.offsetWidth;
-        const height = activeEl.offsetHeight;
-        const radius = window.getComputedStyle(activeEl).borderRadius;
-
-        setStyle({
-          opacity: 1,
-          transform: `translate(${left}px, ${top}px)`,
-          width: `${width}px`,
-          height: `${height}px`,
-          borderRadius: radius,
-        });
-      });
-    };
-
-    update();
-    const observer = new MutationObserver(update);
-    if (props.containerRef.current) {
-      observer.observe(props.containerRef.current, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
-    }
-    window.addEventListener("resize", update);
-
-    return () => {
-      cancelAnimationFrame(animationFrameId);
-      observer.disconnect();
-      window.removeEventListener("resize", update);
-    };
-  }, [props.activeSelector, props.containerRef]);
-
-  return <div className="magic-indicator" style={style} />;
-}
-
 function App(): React.ReactElement {
   const [viewMode, setViewMode] = useState<ViewMode>("sessions");
   const [plugins, setPlugins] = useState<PluginConfig[]>([]);
@@ -202,6 +156,10 @@ function App(): React.ReactElement {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [sessionSearch, setSessionSearch] = useState("");
   const [sessionChannel, setSessionChannel] = useState("");
+  const [expandedSessionGroups, setExpandedSessionGroups] = useState<Record<string, boolean>>({
+    scheduler: false,
+    programmatic: false,
+  });
   const [activeSessionKey, setActiveSessionKey] = useState<string | null>(null);
   const [activeSession, setActiveSession] = useState<SessionRow | null>(null);
   const [messages, setMessages] = useState<MessageRow[]>([]);
@@ -227,8 +185,6 @@ function App(): React.ReactElement {
   const [hiddenPlugins, setHiddenPlugins] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
 
-  const explorerBodyRef = useRef<HTMLDivElement>(null);
-  const tableBodyRef = useRef<HTMLDivElement>(null);
   const sessionsRequestRef = useRef<AbortController | null>(null);
   const messagesRequestRef = useRef<AbortController | null>(null);
   const proactiveRequestRef = useRef<AbortController | null>(null);
@@ -260,6 +216,18 @@ function App(): React.ReactElement {
   }, []);
 
   const channels = useMemo(() => Array.from(new Set(sessions.map((session) => session.key.split(":")[0]).filter(Boolean))), [sessions]);
+  const ordinarySessions = useMemo(
+    () => sessions.filter((session) => !isFoldedSession(session)),
+    [sessions],
+  );
+  const schedulerSessions = useMemo(
+    () => sessions.filter((session) => sessionChannelOf(session) === "scheduler"),
+    [sessions],
+  );
+  const programmaticSessions = useMemo(
+    () => sessions.filter((session) => sessionChannelOf(session) === "programmatic"),
+    [sessions],
+  );
 
   const reportError = useCallback((exc: unknown): void => {
     if (isAbortError(exc)) return;
@@ -452,6 +420,10 @@ function App(): React.ReactElement {
     setActiveSession(sessions.find((session) => session.key === key) ?? null);
     setActiveMessage(null);
     setMessagePage(1);
+    const channel = sessionChannelOf({ key });
+    if (channel === "scheduler" || channel === "programmatic") {
+      setExpandedSessionGroups((current) => ({ ...current, [channel]: true }));
+    }
     selectView("sessions");
   });
 
@@ -550,83 +522,46 @@ function App(): React.ReactElement {
 
   return (
     <div className="shell">
-      <header className="topbar">
+      <aside className="sessions-pane">
         <div className="brand">
-          <div className="brand-mark" aria-hidden="true">
-            <BookOpenText className="brand-mark-book" />
-            <Sparkles className="brand-mark-spark" />
-          </div>
+          <img className="brand-mark" src={notificationIcon} alt="" />
           <div>
-            <div className="brand-title">Akashic Dashboard</div>
-            <div className="brand-sub">Session / Memory Explorer</div>
+            <div className="brand-title">Akashic</div>
+            <div className="brand-sub">Dashboard</div>
           </div>
         </div>
-        <TopbarFilters
-          viewMode={viewMode}
-          messageSearch={messageSearch}
-          setMessageSearch={(value) => { setMessageSearch(value); setMessagePage(1); }}
-          messageRole={messageRole}
-          setMessageRole={(value) => { setMessageRole(value); setMessagePage(1); }}
-          activeSessionKey={activeSessionKey}
-          clearSession={() => { setActiveSessionKey(null); setActiveSession(null); setActiveMessage(null); setMessagePage(1); }}
-          proactiveSection={proactiveSection}
-          proactiveSessionFilter={proactiveSessionFilter}
-          clearProactiveSession={() => { setProactiveSessionFilter(""); setProactivePage(1); }}
-          currentPlugin={currentPlugin}
-          currentPluginState={currentPluginState}
-          onSetPluginState={currentPlugin ? (updater) => setPluginState((c) => ({ ...c, [currentPlugin.id]: updater(c[currentPlugin.id]) })) : undefined}
-          onError={reportError}
+        <ModuleSwitcher
+            viewMode={viewMode}
+            sessionsCount={sessions.length}
+            plugins={plugins.filter((plugin) => !hiddenPlugins[plugin.id])}
+            pluginState={pluginState}
+            onSelect={(next) => {
+              if (next === "sessions") {
+                setActiveSessionKey(null);
+                setActiveSession(null);
+                setActiveMessage(null);
+                setMessagePage(1);
+              }
+              selectView(next);
+            }}
         />
-        <div className="topbar-view">
-          <div className="view-chip"><span>{viewLabel(viewMode, currentPlugin)}</span></div>
-          {viewMode.startsWith("plugin:") && currentPlugin?.renderTopbarAction && currentPluginState && currentDispatch && (
-            <PluginTopbarAction
-              plugin={currentPlugin}
-              pluginId={currentPlugin.id}
-              state={currentPluginState}
-              onSetState={(updater) => setPluginState((c) => ({ ...c, [currentPlugin.id]: updater(c[currentPlugin.id]) }))}
-              onActivate={() => focusView(`plugin:${currentPlugin.id}`)}
-              onError={reportError}
-            />
-          )}
-        </div>
-      </header>
 
-      <main className={`workspace${isPluginWorkbench ? " plugin-workbench-mode" : ""}`}>
-        <aside className="sessions-pane">
-          {/* Section switcher: flat tabs, not accordions — the active section's
-              content is always shown in the body below (no expand-on-entry). */}
-          <div className="section-switcher">
-            <div className="pane-kicker">Explorer</div>
-            <button type="button" className={`section-tab ${viewMode === "sessions" ? "active" : ""}`} onClick={() => {
-              setActiveSessionKey(null);
-              setActiveSession(null);
-              setActiveMessage(null);
-              setMessagePage(1);
-              selectView("sessions");
-            }}>
-              <span className="section-tab-label">Sessions</span>
-              <span className="section-tab-count">{sessions.length}</span>
-            </button>
-            {plugins.filter((p) => !hiddenPlugins[p.id]).map((plugin) => (
-              <button key={plugin.id} type="button" className={`section-tab ${viewMode === `plugin:${plugin.id}` ? "active" : ""}`} onClick={() => selectView(`plugin:${plugin.id}`)}>
-                <span className="section-tab-label">{plugin.label}</span>
-                <span className="section-tab-count">{pluginState[plugin.id]?.total ?? 0}</span>
-              </button>
-            ))}
-          </div>
-
-          <div className="explorer-body" ref={explorerBodyRef} style={{ position: "relative" }}>
-            <MagicIndicator containerRef={explorerBodyRef} activeSelector=".active" />
+          <div className="explorer-body">
             {viewMode === "sessions" && (
               <>
-                <div className="filters-stack">
+                <div className="filters-stack session-filters">
                   <label className="search search-small">
                     <span>⌕</span>
-                    <input type="text" placeholder="过滤 session" value={sessionSearch} onChange={(event) => setSessionSearch(event.target.value.trim())} />
+                    <input type="text" placeholder="搜索会话" value={sessionSearch} onChange={(event) => setSessionSearch(event.target.value.trim())} />
                   </label>
-                  <select value={sessionChannel} onChange={(event) => setSessionChannel(event.target.value)}>
-                    <option value="">全部 channel</option>
+                  <select value={sessionChannel} onChange={(event) => {
+                    const channel = event.target.value;
+                    setSessionChannel(channel);
+                    if (channel === "scheduler" || channel === "programmatic") {
+                      setExpandedSessionGroups((current) => ({ ...current, [channel]: true }));
+                    }
+                  }}>
+                    <option value="">全部来源</option>
                     {channels.map((channel) => <option key={channel} value={channel}>{channel}</option>)}
                   </select>
                 </div>
@@ -638,24 +573,52 @@ function App(): React.ReactElement {
                     setMessagePage(1);
                     selectView("sessions");
                   }}>
-                    <span>全部消息</span><strong>{sessions.length}</strong>
+                    <span>全部会话</span><strong>{sessions.length}</strong>
                   </button>
-                  {sessions.map((session) => (
-                    <button key={session.key} className={`session-item ${activeSessionKey === session.key ? "active" : ""}`} type="button" onClick={() => {
+                  {ordinarySessions.map((session) => (
+                    <SessionNavItem
+                      key={session.key}
+                      session={session}
+                      active={activeSessionKey === session.key}
+                      onSelect={() => {
+                        setActiveSessionKey(session.key);
+                        setActiveSession(session);
+                        setActiveMessage(null);
+                        setMessagePage(1);
+                        selectView("sessions");
+                      }}
+                    />
+                  ))}
+                  <SessionGroup
+                    id="scheduler-sessions"
+                    label="定时任务"
+                    sessions={schedulerSessions}
+                    open={expandedSessionGroups.scheduler}
+                    activeSessionKey={activeSessionKey}
+                    onOpenChange={() => setExpandedSessionGroups((current) => ({ ...current, scheduler: !current.scheduler }))}
+                    onSelect={(session) => {
                       setActiveSessionKey(session.key);
                       setActiveSession(session);
                       setActiveMessage(null);
                       setMessagePage(1);
                       selectView("sessions");
-                    }}>
-                      <div className="nav-item-row">
-                        <span className="nav-type-dot memory-type-profile" />
-                        <span className="nav-item-name mono">{formatSessionKeyForTable(session.key)}</span>
-                        <span className="nav-item-count">{session.message_count}</span>
-                      </div>
-                      <div className="nav-item-desc">{relativeTime(session.updated_at)}</div>
-                    </button>
-                  ))}
+                    }}
+                  />
+                  <SessionGroup
+                    id="programmatic-sessions"
+                    label="程序会话"
+                    sessions={programmaticSessions}
+                    open={expandedSessionGroups.programmatic}
+                    activeSessionKey={activeSessionKey}
+                    onOpenChange={() => setExpandedSessionGroups((current) => ({ ...current, programmatic: !current.programmatic }))}
+                    onSelect={(session) => {
+                      setActiveSessionKey(session.key);
+                      setActiveSession(session);
+                      setActiveMessage(null);
+                      setMessagePage(1);
+                      selectView("sessions");
+                    }}
+                  />
                 </div>
               </>
             )}
@@ -686,8 +649,42 @@ function App(): React.ReactElement {
                 onError={reportError}
               />
             )}
-          </div>
-        </aside>
+        </div>
+      </aside>
+
+      <section className="content-shell">
+        <header className="content-toolbar">
+          <ContentFilters
+            viewMode={viewMode}
+            messageSearch={messageSearch}
+            setMessageSearch={(value) => { setMessageSearch(value); setMessagePage(1); }}
+            messageRole={messageRole}
+            setMessageRole={(value) => { setMessageRole(value); setMessagePage(1); }}
+            activeSessionKey={activeSessionKey}
+            clearSession={() => { setActiveSessionKey(null); setActiveSession(null); setActiveMessage(null); setMessagePage(1); }}
+            proactiveSection={proactiveSection}
+            proactiveSessionFilter={proactiveSessionFilter}
+            clearProactiveSession={() => { setProactiveSessionFilter(""); setProactivePage(1); }}
+            currentPlugin={currentPlugin}
+            currentPluginState={currentPluginState}
+            onSetPluginState={currentPlugin ? (updater) => setPluginState((c) => ({ ...c, [currentPlugin.id]: updater(c[currentPlugin.id]) })) : undefined}
+            onError={reportError}
+          />
+          {viewMode.startsWith("plugin:") && currentPlugin?.renderTopbarAction && currentPluginState && currentDispatch && (
+            <div className="content-toolbar-actions">
+              <PluginTopbarAction
+                plugin={currentPlugin}
+                pluginId={currentPlugin.id}
+                state={currentPluginState}
+                onSetState={(updater) => setPluginState((c) => ({ ...c, [currentPlugin.id]: updater(c[currentPlugin.id]) }))}
+                onActivate={() => focusView(`plugin:${currentPlugin.id}`)}
+                onError={reportError}
+              />
+            </div>
+          )}
+        </header>
+
+        <main className={`workspace${isPluginWorkbench ? " plugin-workbench-mode" : ""}`}>
 
         {isPluginWorkbench && currentPlugin && currentDispatch ? (
           <section className="plugin-workbench-pane">
@@ -724,8 +721,7 @@ function App(): React.ReactElement {
                 </div>
               )}
               <TableHead viewMode={viewMode} plugin={currentPlugin} pluginState={currentPluginState} messageSortBy={messageSortBy} messageSortOrder={messageSortOrder} proactiveSortBy={proactiveSortBy} proactiveSortOrder={proactiveSortOrder} onSort={sort} onPluginSort={currentDispatch ? (key) => currentDispatch.setSort(key) : undefined} />
-              <div className="table-body" ref={tableBodyRef} style={{ position: "relative" }}>
-                <MagicIndicator containerRef={tableBodyRef} activeSelector=".active" />
+              <div className="table-body">
                 <Rows
                   viewMode={viewMode}
                   messages={messages}
@@ -815,10 +811,204 @@ function App(): React.ReactElement {
             </aside>
           </>
         )}
-      </main>
+        </main>
+      </section>
       {error && <div className="modal-backdrop" onClick={() => setError(null)}><div className="modal"><div className="modal-title">请求失败</div><p>{error}</p><div className="modal-actions"><button className="primary" type="button" onClick={() => setError(null)}>关闭</button></div></div></div>}
     </div>
   );
+}
+
+function SessionGroup(props: {
+  id: string;
+  label: string;
+  sessions: SessionRow[];
+  open: boolean;
+  activeSessionKey: string | null;
+  onOpenChange(): void;
+  onSelect(session: SessionRow): void;
+}): React.ReactElement | null {
+  if (!props.sessions.length) return null;
+  return (
+    <div className={`nav-group session-group ${props.open ? "open" : ""}`}>
+      <button
+        className="nav-group-toggle"
+        type="button"
+        aria-expanded={props.open}
+        aria-controls={props.id}
+        onClick={props.onOpenChange}
+      >
+        <span className="nav-group-caret" aria-hidden="true">›</span>
+        <span className="nav-group-label">{props.label}</span>
+        <span className="nav-group-count">{props.sessions.length}</span>
+      </button>
+      <div
+        id={props.id}
+        className={`nav-group-body ${props.open ? "open" : ""}`}
+        hidden={!props.open}
+      >
+        <div className="nav-group-body-inner">
+          {props.sessions.map((session) => (
+            <SessionNavItem
+              key={session.key}
+              session={session}
+              active={props.activeSessionKey === session.key}
+              nested
+              onSelect={() => props.onSelect(session)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ModuleSwitcher(props: {
+  viewMode: ViewMode;
+  sessionsCount: number;
+  plugins: PluginConfig[];
+  pluginState: Record<string, PluginState>;
+  onSelect(next: ViewMode): void;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const currentPlugin = props.viewMode.startsWith("plugin:")
+    ? props.plugins.find((plugin) => `plugin:${plugin.id}` === props.viewMode) ?? null
+    : null;
+  const currentLabel = props.viewMode === "sessions" ? "Sessions" : currentPlugin?.label ?? "Explorer";
+  const currentCount = props.viewMode === "sessions"
+    ? props.sessionsCount
+    : currentPlugin ? props.pluginState[currentPlugin.id]?.total ?? 0 : 0;
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent): void => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const select = (next: ViewMode): void => {
+    props.onSelect(next);
+    setOpen(false);
+  };
+
+  return (
+    <div className="module-switcher" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        className="module-switcher-trigger"
+        type="button"
+        aria-expanded={open}
+        aria-controls="dashboard-module-options"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="module-switcher-label">{currentLabel}</span>
+        <span className="module-switcher-meta">
+          <span className="module-switcher-count">{currentCount}</span>
+          <ChevronDown className={open ? "open" : ""} size={16} aria-hidden="true" />
+        </span>
+      </button>
+      <div id="dashboard-module-options" className="module-switcher-options" hidden={!open}>
+        <button
+          className={`module-switcher-option ${props.viewMode === "sessions" ? "active" : ""}`}
+          type="button"
+          aria-current={props.viewMode === "sessions" ? "page" : undefined}
+          onClick={() => select("sessions")}
+        >
+          <span>Sessions</span>
+          <span>{props.sessionsCount}</span>
+        </button>
+        {props.plugins.map((plugin) => {
+          const mode = `plugin:${plugin.id}` as ViewMode;
+          return (
+            <button
+              key={plugin.id}
+              className={`module-switcher-option ${props.viewMode === mode ? "active" : ""}`}
+              type="button"
+              aria-current={props.viewMode === mode ? "page" : undefined}
+              onClick={() => select(mode)}
+            >
+              <span>{plugin.label}</span>
+              <span>{props.pluginState[plugin.id]?.total ?? 0}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SessionNavItem(props: {
+  session: SessionRow;
+  active: boolean;
+  nested?: boolean;
+  onSelect(): void;
+}): React.ReactElement {
+  const title = sessionNavTitle(props.session);
+  const channel = sessionChannelOf(props.session);
+  return (
+    <button
+      className={`session-item ${props.nested ? "nested" : ""} ${props.active ? "active" : ""}`}
+      type="button"
+      aria-current={props.active ? "page" : undefined}
+      title={`${title}\n${props.session.key}`}
+      onClick={props.onSelect}
+    >
+      <div className="nav-item-row">
+        <span className="nav-item-name">{title}</span>
+        <span className="nav-item-count" title={`${props.session.message_count} 条消息`}>
+          {props.session.message_count}
+        </span>
+      </div>
+      <div className="nav-item-desc">
+        <span>{sessionChannelLabel(channel)}</span>
+        <span aria-hidden="true">·</span>
+        <span>{relativeTime(props.session.updated_at)}</span>
+      </div>
+    </button>
+  );
+}
+
+function isFoldedSession(session: Pick<SessionRow, "key">): boolean {
+  const channel = sessionChannelOf(session);
+  return channel === "scheduler" || channel === "programmatic";
+}
+
+function sessionChannelOf(session: Pick<SessionRow, "key">): string {
+  return session.key.split(":", 1)[0] || "unknown";
+}
+
+function sessionNavTitle(session: SessionRow): string {
+  const firstMessage = stripMarkdown(session.first_message_content).trim();
+  return firstMessage || formatSessionKeyForTable(session.key);
+}
+
+function sessionChannelLabel(channel: string): string {
+  const labels: Record<string, string> = {
+    cli: "CLI",
+    cross_mem: "Cross Memory",
+    dashboard: "Dashboard",
+    feishu: "飞书",
+    mobile: "Mobile",
+    programmatic: "Programmatic",
+    qq: "QQ",
+    qqbot: "QQ Bot",
+    scheduler: "定时任务",
+    telegram: "Telegram",
+    web: "Web",
+  };
+  return labels[channel] || channel;
 }
 
 function PluginNavBody(props: {
@@ -896,7 +1086,7 @@ function PluginTopbarAction(props: {
   return <div ref={ref} />;
 }
 
-function TopbarFilters(props: {
+function ContentFilters(props: {
   viewMode: ViewMode;
   messageSearch: string;
   setMessageSearch(value: string): void;
@@ -913,7 +1103,7 @@ function TopbarFilters(props: {
   onError(error: unknown): void;
 }): React.ReactElement {
   return (
-    <div className="topbar-filters">
+    <div className="content-filters">
       {props.viewMode.startsWith("plugin:") ? (
           props.currentPlugin?.renderFilters && props.currentPluginState && props.onSetPluginState
             ? <PluginFilters
@@ -1171,12 +1361,6 @@ function proactiveSectionCount(section: string, overview: ProactiveOverview | nu
   if (section === "all") return overview.counts.tick_logs ?? 0;
   if (section === "drift" || section === "proactive") return overview.flow_counts[section] ?? 0;
   return overview.result_counts[section] ?? 0;
-}
-
-function viewLabel(viewMode: ViewMode, plugin: PluginConfig | null): string {
-  if (plugin) return plugin.viewLabel || plugin.label;
-  if (viewMode === "proactive") return "proactive";
-  return "messages";
 }
 
 createRoot(document.getElementById("root") as HTMLElement).render(<App />);

--- a/frontend/dashboard/src/styles.css
+++ b/frontend/dashboard/src/styles.css
@@ -215,48 +215,34 @@ body {
   /* ── Layout ── */
 
   .shell {
-    @apply flex h-screen flex-col overflow-hidden;
+    @apply flex h-screen overflow-hidden bg-bg;
   }
 
-  /* Raised chrome bar: hairline top highlight + soft drop to lift over content */
-  .topbar {
-    @apply flex h-[60px] flex-shrink-0 items-center gap-4 px-6 z-10;
-    margin: 12px 16px 0 16px;
-    border-radius: var(--radius-lg);
-    background-color: var(--color-surface);
-    border: 1px solid var(--color-border);
-    box-shadow: var(--shadow);
+  .content-shell {
+    @apply flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden;
   }
 
   .brand {
-    @apply flex w-64 flex-shrink-0 items-center gap-3;
+    @apply flex h-16 flex-shrink-0 items-center gap-3 border-b border-border px-4;
   }
 
   .brand-mark {
-    @apply relative grid h-10 w-10 place-items-center rounded-[14px] text-fg;
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04));
-    box-shadow: inset 0 0 0 1px var(--color-border-strong), 0 14px 34px rgba(0, 0, 0, 0.36);
-  }
-
-  .brand-mark-book {
-    @apply h-[27px] w-[27px];
-    stroke-width: 1.65;
-  }
-
-  .brand-mark-spark {
-    @apply absolute right-[5px] top-[5px] h-[11px] w-[11px] text-muted;
-    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.12));
+    @apply h-8 w-8 flex-shrink-0 object-contain;
   }
 
   .brand-title {
-    @apply text-[15px] font-bold tracking-tight text-fg;
+    @apply text-[14px] font-semibold leading-4 tracking-tight text-fg;
   }
 
   .brand-sub {
-    @apply text-xs text-muted;
+    @apply mt-0.5 text-[11.5px] leading-4 text-muted;
   }
 
-  .topbar-filters {
+  .content-toolbar {
+    @apply flex min-h-16 flex-shrink-0 items-center gap-3 border-b border-border bg-surface px-4;
+  }
+
+  .content-filters {
     @apply min-w-0 flex-1;
   }
 
@@ -264,7 +250,7 @@ body {
     @apply flex min-w-0 items-center gap-2;
   }
 
-  .topbar-view {
+  .content-toolbar-actions {
     @apply flex flex-shrink-0 items-center gap-2;
   }
 
@@ -370,13 +356,6 @@ body {
     @apply bg-accent-soft font-medium text-accent;
   }
 
-  /* ── View chip & session chip ── */
-
-  .view-chip {
-    @apply inline-flex items-center gap-1.5 rounded-sm border border-border bg-surface-2 px-3 py-1 font-mono text-[10.5px] font-medium uppercase tracking-[0.08em] text-muted;
-    box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.04);
-  }
-
   .active-session-chip {
     @apply flex min-w-0 max-w-[280px] items-center gap-1.5 rounded border border-border-strong bg-accent-soft px-3 py-1 text-xs;
   }
@@ -396,7 +375,7 @@ body {
   /* ── Workspace ── */
 
   .workspace {
-    @apply flex min-h-0 flex-1 overflow-hidden gap-4 p-4;
+    @apply flex min-h-0 flex-1 overflow-hidden gap-3 p-3;
   }
 
   /* ── Panes ── */
@@ -405,11 +384,9 @@ body {
      log surface is the darkest layer and sits recessed between them. */
   .sessions-pane {
     @apply flex min-h-0 flex-shrink-0 flex-col bg-surface-2 overflow-hidden;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    width: clamp(260px, 20vw, 320px);
+    border-right: 1px solid var(--color-border);
+    width: clamp(280px, 18vw, 320px);
     background: var(--color-surface-2);
-    box-shadow: var(--shadow);
   }
 
   .messages-pane {
@@ -481,10 +458,6 @@ body {
     @apply border-b border-border px-3 pb-2 pt-3;
   }
 
-  .pane-kicker {
-    @apply font-sans text-[11px] font-medium tracking-wide text-subtle;
-  }
-
   .pane-title {
     @apply mt-1 text-[15px] font-semibold tracking-tight text-fg;
   }
@@ -493,31 +466,75 @@ body {
     @apply grid gap-2 p-3;
   }
 
-  /* ── Section switcher (flat tabs) + always-on body ── */
+  /* ── Context switcher ── */
 
-  .section-switcher {
-    @apply flex flex-col gap-0.5 border-b border-border px-2 pb-2 pt-3;
+  .module-switcher {
+    @apply relative flex-shrink-0 border-b border-border p-2;
   }
 
-  .section-switcher .pane-kicker {
-    @apply px-2 pb-1.5;
+  .module-switcher-trigger {
+    @apply flex min-h-11 w-full cursor-pointer items-center justify-between gap-3 rounded-md border border-transparent bg-transparent px-2.5 text-left text-fg transition-colors;
   }
 
-  .section-tab {
-    @apply flex w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-transparent bg-transparent px-2.5 py-2 text-left text-[13px] font-semibold tracking-tight text-muted transition-colors;
+  .module-switcher-trigger:hover,
+  .module-switcher-trigger[aria-expanded="true"] {
+    @apply bg-surface-3;
   }
 
-  .section-tab:hover {
-    @apply bg-surface-2 text-fg;
+  .module-switcher-label {
+    @apply min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[14px] font-semibold tracking-tight;
   }
 
-  .section-tab.active {
-    @apply border-border-strong bg-accent-soft text-fg;
+  .module-switcher-meta {
+    @apply flex flex-shrink-0 items-center gap-2 text-muted;
   }
 
-  .section-tab-count {
-    @apply flex-shrink-0 rounded-sm bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] font-medium tabular-nums text-muted;
-    box-shadow: inset 0 1px 1px 0 rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  .module-switcher-count,
+  .module-switcher-option > span:last-child {
+    @apply text-[11.5px] font-medium tabular-nums text-subtle;
+  }
+
+  .module-switcher-trigger svg {
+    @apply transition-transform;
+    transition-duration: 150ms;
+  }
+
+  .module-switcher-trigger svg.open {
+    transform: rotate(180deg);
+  }
+
+  .module-switcher-options {
+    @apply absolute left-2 right-2 top-[calc(100%-4px)] z-30 max-h-[min(480px,65vh)] overflow-y-auto rounded-md border border-border bg-surface-2 p-1;
+    box-shadow: 0 8px 20px -12px rgba(0, 0, 0, 0.9), 0 1px 2px rgba(0, 0, 0, 0.45);
+  }
+
+  .module-switcher-option {
+    @apply flex min-h-10 w-full cursor-pointer items-center justify-between gap-3 rounded px-2.5 text-left text-[13px] font-medium text-muted transition-colors;
+  }
+
+  .module-switcher-option:hover {
+    @apply bg-surface-3 text-fg;
+  }
+
+  .module-switcher-option.active {
+    @apply bg-accent-soft text-fg;
+  }
+
+  .session-filters {
+    @apply flex gap-2 p-2;
+  }
+
+  .session-filters .search {
+    @apply min-w-0 flex-1;
+  }
+
+  .session-filters input,
+  .session-filters select {
+    @apply min-h-10;
+  }
+
+  .session-filters select {
+    @apply w-[108px] flex-shrink-0;
   }
 
   .explorer-body {
@@ -554,7 +571,7 @@ body {
   }
 
   .nav-group-toggle {
-    @apply mx-1.5 flex w-[calc(100%-12px)] cursor-pointer items-center gap-2 rounded border border-transparent bg-transparent px-2.5 py-2 text-fg transition-colors;
+    @apply mx-1.5 flex min-h-11 w-[calc(100%-12px)] cursor-pointer items-center gap-2 rounded border border-transparent bg-transparent px-2.5 py-2 text-fg transition-colors;
   }
 
   .nav-group-toggle:hover {
@@ -586,8 +603,7 @@ body {
   }
 
   .nav-group-count {
-    @apply rounded-sm bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] font-medium tabular-nums text-muted;
-    box-shadow: inset 0 1px 1px 0 rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    @apply text-[11.5px] font-medium tabular-nums text-subtle;
   }
 
   .nav-group-body {
@@ -603,13 +619,29 @@ body {
     @apply ml-2.5 min-h-0 overflow-hidden border-l border-border pl-2 pt-0.5;
   }
 
+  .session-group {
+    @apply mt-2 border-t border-border pt-2;
+  }
+
+  .session-group + .session-group {
+    @apply mt-0 border-t-0 pt-0;
+  }
+
+  .session-group .nav-group-toggle {
+    @apply rounded-md;
+  }
+
+  .session-group .nav-group-body-inner {
+    @apply ml-4 pl-1.5;
+  }
+
   /* ── Nav rows ── */
 
   .all-messages-row,
   .session-item,
   .memory-quick-item,
   .proactive-quick-item {
-    @apply relative mx-1 my-px w-[calc(100%-8px)] cursor-pointer rounded border border-transparent bg-transparent px-2 py-[7px] text-left text-fg transition-colors;
+    @apply relative mx-1 my-px min-h-11 w-[calc(100%-8px)] cursor-pointer rounded border border-transparent bg-transparent px-2 py-2 text-left text-fg transition-colors;
   }
 
   .all-messages-row::before,
@@ -632,8 +664,7 @@ body {
   .session-item.active,
   .memory-quick-item.active,
   .proactive-quick-item.active {
-    /* bg handled by magic indicator */
-    @apply border-border-strong text-fg;
+    @apply border-border-strong bg-accent-soft text-fg;
   }
 
   .all-messages-row {
@@ -645,7 +676,7 @@ body {
   }
 
   .all-messages-row strong {
-    @apply font-mono text-[10.5px] font-medium tabular-nums text-subtle;
+    @apply text-[11.5px] font-medium tabular-nums text-subtle;
   }
 
   .session-list,
@@ -658,12 +689,8 @@ body {
     @apply flex items-center gap-2;
   }
 
-  .nav-type-dot {
-    @apply h-1.5 w-1.5 flex-shrink-0 rounded-full;
-  }
-
   .nav-item-name {
-    @apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold;
+    @apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13.5px] font-semibold leading-5 tracking-[-0.01em];
   }
 
   .nav-item-name.mono {
@@ -671,11 +698,15 @@ body {
   }
 
   .nav-item-count {
-    @apply flex-shrink-0 font-mono text-[10.5px] tabular-nums text-subtle;
+    @apply flex-shrink-0 text-[11.5px] font-medium tabular-nums text-subtle;
   }
 
   .nav-item-desc {
-    @apply mt-1 flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] text-muted;
+    @apply mt-0.5 flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] leading-4 text-muted;
+  }
+
+  .session-item.nested {
+    @apply mx-0 w-full;
   }
 
   .session-actions {
@@ -875,8 +906,8 @@ body {
     border: 1px solid var(--color-border);
   }
 
-  /* Restrained selection: background handled by magic indicator */
   .table-row.active {
+    background: rgb(var(--color-accent-rgb) / 0.1);
     border: 1px solid rgb(var(--color-accent-rgb) / 0.2);
   }
 
@@ -1371,6 +1402,7 @@ body {
   /* ── Scrollbar ── */
 
   .detail-pane::-webkit-scrollbar,
+  .explorer-body::-webkit-scrollbar,
   .explorer-nav::-webkit-scrollbar,
   .table-body::-webkit-scrollbar,
   .modal::-webkit-scrollbar {
@@ -1379,6 +1411,7 @@ body {
   }
 
   .detail-pane::-webkit-scrollbar-track,
+  .explorer-body::-webkit-scrollbar-track,
   .explorer-nav::-webkit-scrollbar-track,
   .table-body::-webkit-scrollbar-track,
   .modal::-webkit-scrollbar-track {
@@ -1386,6 +1419,7 @@ body {
   }
 
   .detail-pane::-webkit-scrollbar-thumb,
+  .explorer-body::-webkit-scrollbar-thumb,
   .explorer-nav::-webkit-scrollbar-thumb,
   .table-body::-webkit-scrollbar-thumb,
   .modal::-webkit-scrollbar-thumb {
@@ -1394,6 +1428,7 @@ body {
   }
 
   .detail-pane::-webkit-scrollbar-thumb:hover,
+  .explorer-body::-webkit-scrollbar-thumb:hover,
   .explorer-nav::-webkit-scrollbar-thumb:hover,
   .table-body::-webkit-scrollbar-thumb:hover,
   .modal::-webkit-scrollbar-thumb:hover {
@@ -1402,6 +1437,7 @@ body {
 
   .detail-pane,
   .plugin-workbench-pane,
+  .explorer-body,
   .explorer-nav,
   .table-body,
   .modal {
@@ -1420,33 +1456,30 @@ body {
   }
 
   @media (max-width: 980px) {
+    .sessions-pane {
+      width: 240px;
+    }
+
     .workspace {
+      @apply gap-2 p-2;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .shell {
       @apply flex-col;
     }
 
     .sessions-pane {
       @apply w-full border-b border-r-0 border-border;
+      max-height: 42vh;
     }
 
-    .plugin-workbench-pane {
-      @apply min-h-0 w-full;
+    .content-toolbar {
+      @apply h-auto min-h-16 flex-wrap px-3 py-2;
     }
 
-    .detail-pane {
-      @apply block w-full border-l-0 border-t border-border;
-    }
-  }
-
-  @media (max-width: 760px) {
-    .topbar {
-      @apply h-auto flex-wrap items-start px-4 py-3;
-    }
-
-    .brand {
-      @apply w-auto;
-    }
-
-    .topbar-filters,
+    .content-filters,
     .filter-row,
     .search {
       @apply w-full;
@@ -1466,31 +1499,3 @@ body {
       grid-template-columns: 34px 72px minmax(140px, 1.25fr) 48px 52px 64px 76px 76px 70px 56px;
     }
   }
-
-/* ── Magic Indicator (Kitty style sliding cursor) ── */
-.magic-indicator {
-  position: absolute;
-  top: 0; 
-  left: 0;
-  border-radius: 4px;
-  background: rgba(var(--color-accent-rgb), 0.1);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-accent-rgb), 0.2);
-  pointer-events: none;
-  z-index: 0;
-  transition: transform 180ms ease-out,
-              width 180ms ease-out,
-              height 180ms ease-out,
-              opacity 120ms ease;
-}
-
-.magic-indicator::before {
-  content: "";
-  position: absolute;
-  bottom: 15%;
-  left: 0;
-  top: 15%;
-  width: 3px;
-  background: var(--color-accent);
-  border-radius: 0 3px 3px 0;
-  box-shadow: 0 0 12px -2px rgb(var(--color-accent-rgb) / 0.5);
-}

--- a/frontend/dashboard/src/types.ts
+++ b/frontend/dashboard/src/types.ts
@@ -17,6 +17,7 @@ export interface SessionRow {
   metadata: Record<string, unknown>;
   last_user_at: string | null;
   last_proactive_at: string | null;
+  first_message_content: string | null;
   message_count: number;
 }
 

--- a/tests/test_message_lookup_tool.py
+++ b/tests/test_message_lookup_tool.py
@@ -361,6 +361,28 @@ def test_message_lookup_tools_require_fetch_for_evidence():
     assert "§cited:[" in FetchMessagesTool.description
 
 
+def test_search_messages_description_requires_recall_memory_first():
+    description = SearchMessagesTool.description
+
+    assert "必须先尝试 recall_memory" in description
+    assert "recall_memory 已经尝试" in description
+    assert "截断的原始消息" in description
+    assert "evidence" in description
+    assert "fetch_messages 获取完整原文" in description
+    assert "不要把截断当作召回失败" in description
+    assert "仍无法确定答案时" in description
+    assert "akasha" not in description.lower()
+
+
+def test_fetch_messages_description_handles_truncated_recall_preview():
+    description = FetchMessagesTool.description
+
+    assert "截断的原始消息" in description
+    assert "evidence 读取完整原文" in description
+    assert "不要根据预览补写缺失内容" in description
+    assert "akasha" not in description.lower()
+
+
 def test_history_fact_guard_requires_fetch_after_search_preview():
     prompt = build_agent_behavior_rules_prompt(workspace=Path("."))
     assert "search_messages" in prompt

--- a/tests/test_restart_probe.py
+++ b/tests/test_restart_probe.py
@@ -159,4 +159,5 @@ def test_restart_probe_defaults_are_pr_gate_and_soak_compatible() -> None:
     assert '"supervisorHwmKiB": 64 * 1024' in source
     assert '"childRssKiB": 64 * 1024' in source
     assert '"childHwmKiB": 64 * 1024' in source
+    assert '"AKASHIC_READINESS_TIMEOUT_S": "15"' in source
     json.dumps({"status": "passed", "iterations": 3})


### PR DESCRIPTION
## 改动

- 将 Dashboard 重组为稳定的左右工作区：左侧品牌、模块与会话导航，右侧筛选、表格和详情。
- 折叠定时任务与 programmatic session，并使用首条消息生成更可读的会话标题。
- 清理 Dashboard 与移动端配对界面的多余装饰、阴影、徽章和无语义图标。
- 修复截断消息召回时优先选择并回源完整消息的行为。

## 原因与影响

原布局由全局顶栏、悬浮侧栏和内容卡片叠加组成，信息层级分散；移动端配对图标也存在越界。新布局统一为左侧导航和右侧内容工具栏，降低视觉噪声，同时保留会话筛选和详情能力。消息回源修复避免截断内容覆盖可用的完整记录。

## 验证

- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run build`
- `.venv/bin/python -m pytest -q tests/test_message_lookup_tool.py`（20 passed）
- `.venv/bin/python docker/debug/gate.py run --base origin/main`（GATE PASSED）
- private-contract-gate: required / pending maintainer