### PR TITLE
[codex] 支持渠道完整消息和移动附件推送

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -33,7 +33,13 @@ from agent.tools.base import normalize_tool_result
 from agent.tools.registry import begin_turn_search_scope, end_turn_search_scope
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from bus.event_bus import EventBus
-from bus.events import InboundMessage, OutboundMessage, TurnDisposition
+from bus.events import (
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+    TurnDisposition,
+)
 from bus.events_lifecycle import (
     ToolCallCompleted,
     ToolCallStarted,
@@ -161,8 +167,11 @@ def _disabled_tools_from_msg(msg: object) -> set[str]:
 
 
 class _NoopOutboundPort:
-    async def dispatch(self, outbound: OutboundDispatch) -> bool:
-        return False
+    async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
+        return DeliveryReceipt(
+            DeliveryStatus.FAILED,
+            detail="未配置出站投递端口",
+        )
 
 
 @dataclass

--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -3,10 +3,18 @@
 """
 
 import logging
+from pathlib import Path
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from agent.tools.base import Tool
+from bus.events import (
+    AttachmentKind,
+    ChannelAttachment,
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+)
 from bus.queue import ChatLane
 
 logger = logging.getLogger(__name__)
@@ -61,53 +69,32 @@ class MessagePushTool(Tool):
     }
 
     def __init__(self, chat_lane: ChatLane | None = None) -> None:
-        # channel -> {type: sender_fn}
-        self._senders: dict[str, dict[str, Callable[..., Awaitable[None]]]] = {}
+        self._adapters: dict[
+            str, Callable[[ChannelMessage], Awaitable[DeliveryReceipt]]
+        ] = {}
         self._registration_tokens: dict[str, object] = {}
         self._chat_lane = chat_lane
 
     def register_channel(
         self,
         channel: str,
-        text: Callable[[str, str], Awaitable[None]] | None = None,
-        stream_text: Callable[[str, str], Awaitable[None]] | None = None,
-        text_with_metadata: (
-            Callable[[str, str, dict[str, object]], Awaitable[None]] | None
-        ) = None,
-        file: Callable[[str, str, str | None], Awaitable[None]] | None = None,
-        image: Callable[[str, str], Awaitable[None]] | None = None,
+        deliver: Callable[[ChannelMessage], Awaitable[DeliveryReceipt]],
     ) -> ChannelRegistration:
-        """注册渠道的各类 sender。
-        - text(chat_id, message)
-        - stream_text(chat_id, message)
-        - file(chat_id, file_path, name=None)
-        - image(chat_id, image_path_or_url)
-        """
-        if channel in self._senders:
+        """注册完整逻辑消息的唯一渠道 adapter。"""
+
+        if channel in self._adapters:
             raise RuntimeError(f"message_push 渠道名称重复: {channel}")
-        self._senders[channel] = {}
+        self._adapters[channel] = deliver
         token = object()
         self._registration_tokens[channel] = token
-        if text:
-            self._senders[channel]["text"] = text
-        if stream_text:
-            self._senders[channel]["stream_text"] = stream_text
-        if text_with_metadata:
-            self._senders[channel]["text_with_metadata"] = text_with_metadata
-        if file:
-            self._senders[channel]["file"] = file
-        if image:
-            self._senders[channel]["image"] = image
-        logger.debug(
-            f"message_push: 注册渠道 {channel!r}  支持: {list(self._senders[channel])}"
-        )
+        logger.debug("message_push: 注册渠道 %r", channel)
         return ChannelRegistration(self, channel, token)
 
     def unregister_channel(self, channel: str, token: object) -> None:
         if self._registration_tokens.get(channel) is not token:
             return
         _ = self._registration_tokens.pop(channel, None)
-        _ = self._senders.pop(channel, None)
+        _ = self._adapters.pop(channel, None)
 
     async def execute(self, **kwargs: Any) -> str:
         channel: str = kwargs["channel"]
@@ -126,77 +113,57 @@ class MessagePushTool(Tool):
 
         if not message and not file and not image:
             return "错误：message、file、image 至少提供一个"
-
-        senders = self._senders.get(channel)
-        if senders is None:
-            return f"渠道 {channel!r} 未注册，可用渠道：{list(self._senders) or ['（无）']}"
-
-        async def _send() -> str:
-            return await self._send_now(
+        attachments: list[ChannelAttachment] = []
+        if file:
+            attachments.append(
+                ChannelAttachment(AttachmentKind.FILE, file, Path(file).name)
+            )
+        if image:
+            attachments.append(ChannelAttachment(AttachmentKind.IMAGE, image))
+        receipt = await self.dispatch(
+            ChannelMessage(
                 channel=channel,
                 chat_id=chat_id,
-                message=message,
-                file=file,
-                image=image,
-                senders=senders,
-                outbound_metadata=outbound_metadata,
+                content=message or "",
+                attachments=tuple(attachments),
+                metadata=outbound_metadata,
+            ),
+            commit_role=commit_role,
+        )
+        if receipt.status is DeliveryStatus.SUCCESS:
+            return "消息已发送"
+        if receipt.status is DeliveryStatus.PARTIAL:
+            return f"消息部分送达：{receipt.detail or '渠道未提交全部内容'}"
+        return f"发送失败：{receipt.detail or '渠道未提交消息'}"
+
+    async def dispatch(
+        self,
+        message: ChannelMessage,
+        *,
+        commit_role: str = "",
+    ) -> DeliveryReceipt:
+        """通过单一 adapter 提交完整消息，并保留 chat lane 顺序。"""
+
+        adapter = self._adapters.get(message.channel)
+        if adapter is None:
+            return DeliveryReceipt(
+                DeliveryStatus.FAILED,
+                detail=(
+                    f"渠道 {message.channel!r} 未注册，可用渠道："
+                    f"{list(self._adapters) or ['（无）']}"
+                ),
             )
 
+        async def _deliver() -> DeliveryReceipt:
+            receipt = await adapter(message)
+            if not isinstance(receipt, DeliveryReceipt):
+                raise TypeError("message_push channel adapter 必须返回 DeliveryReceipt")
+            return receipt
+
         if self._chat_lane is not None and commit_role != "passive":
-            return await self._chat_lane.run_non_passive(channel, chat_id, _send)
-        return await _send()
-
-    async def _send_now(
-        self,
-        *,
-        channel: str,
-        chat_id: str,
-        message: str | None,
-        file: str | None,
-        image: str | None,
-        senders: dict[str, Callable[..., Awaitable[None]]],
-        outbound_metadata: dict[str, object],
-    ) -> str:
-
-        results: list[str] = []
-        try:
-            if message and "text" in senders:
-                if outbound_metadata and "text_with_metadata" in senders:
-                    await senders["text_with_metadata"](
-                        chat_id,
-                        message,
-                        dict(outbound_metadata),
-                    )
-                else:
-                    sender_name = "stream_text" if "stream_text" in senders else "text"
-                    await senders[sender_name](chat_id, message)
-                preview = message[:60] + "..." if len(message) > 60 else message
-                logger.info(f"[message_push] {channel}:{chat_id} ← text: {preview!r}")
-                results.append("文本已发送")
-
-            if file:
-                if "file" not in senders:
-                    results.append(f"渠道 {channel!r} 不支持发送文件")
-                else:
-                    import os
-
-                    name = os.path.basename(file)
-                    await senders["file"](chat_id, file, name)
-                    logger.info(f"[message_push] {channel}:{chat_id} ← file: {file!r}")
-                    results.append(f"文件 {name!r} 已发送")
-
-            if image:
-                if "image" not in senders:
-                    results.append(f"渠道 {channel!r} 不支持发送图片")
-                else:
-                    await senders["image"](chat_id, image)
-                    logger.info(
-                        f"[message_push] {channel}:{chat_id} ← image: {image!r}"
-                    )
-                    results.append("图片已发送")
-
-        except Exception as e:
-            logger.error(f"[message_push] 发送失败 {channel}:{chat_id}: {e}")
-            return f"发送失败：{e}"
-
-        return "；".join(results) if results else f"渠道 {channel!r} 没有可用的 sender"
+            return await self._chat_lane.run_non_passive(
+                message.channel,
+                message.chat_id,
+                _deliver,
+            )
+        return await _deliver()

--- a/agent/turns/orchestrator.py
+++ b/agent/turns/orchestrator.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from agent.turns.result import TurnResult, TurnSideEffect
+from bus.events import DeliveryStatus
 
 if TYPE_CHECKING:
     from agent.core.runtime_support import SessionLike
@@ -45,11 +46,11 @@ class TurnOrchestrator:
         content = result.outbound.content
         media = list(result.outbound.media or [])
         delivery_id = uuid4().hex
-        sent = False
+        receipt = None
         try:
             # 2. 先执行发送前 side_effects，再真正 dispatch 到 outbound。
             await self._run_effects(result.side_effects)
-            sent = await self._outbound.dispatch(
+            receipt = await self._outbound.dispatch(
                 OutboundDispatch(
                     channel=channel,
                     chat_id=chat_id,
@@ -62,12 +63,14 @@ class TurnOrchestrator:
             logger.exception("proactive outbound dispatch failed: %s", e)
 
         # 3. 只有用户真正收到后，才把 proactive 消息写入可见会话历史。
+        sent = receipt is not None and receipt.status is DeliveryStatus.SUCCESS
         if sent:
+            assert receipt is not None
             session = self._session.session_manager.get_or_create(session_key)
             self._persist_proactive_session(
                 session=session,
                 content=content,
-                media=media,
+                media=list(receipt.canonical_media),
                 result=result,
                 delivery_id=delivery_id,
             )

--- a/agent/turns/outbound.py
+++ b/agent/turns/outbound.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from bus.events import OutboundMessage
+from bus.events import (
+    AttachmentKind,
+    ChannelAttachment,
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+    OutboundMessage,
+)
 from bus.queue import MessageBus
 
 
@@ -19,14 +26,14 @@ class OutboundDispatch:
 
 
 class OutboundPort(Protocol):
-    async def dispatch(self, outbound: OutboundDispatch) -> bool: ...
+    async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt: ...
 
 
 class BusOutboundPort:
     def __init__(self, bus: MessageBus) -> None:
         self._bus = bus
 
-    async def dispatch(self, outbound: OutboundDispatch) -> bool:
+    async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
         await self._bus.publish_outbound(
             OutboundMessage(
                 channel=outbound.channel,
@@ -38,31 +45,35 @@ class BusOutboundPort:
                 session_message_id=outbound.session_message_id,
             )
         )
-        return True
+        return DeliveryReceipt(
+            DeliveryStatus.SUCCESS,
+            canonical_media=tuple(outbound.media),
+        )
 
 
 class PushToolOutboundPort:
     def __init__(self, push_tool: Any) -> None:
         self._push = push_tool
 
-    async def dispatch(self, outbound: OutboundDispatch) -> bool:
+    async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
         message = outbound.content.strip()
         channel = outbound.channel.strip()
         chat_id = outbound.chat_id.strip()
         media = [item.strip() for item in outbound.media if item.strip()]
         if (not message and not media) or not channel or not chat_id:
-            return False
-        result = await self._push.execute(
-            channel=channel,
-            chat_id=chat_id,
-            message=message,
-            image=media[0] if media else None,
-            _outbound_metadata=dict(outbound.metadata),
-        )
-        for image in media[1:]:
-            result = await self._push.execute(
+            return DeliveryReceipt(
+                DeliveryStatus.FAILED,
+                detail="出站消息缺少渠道、会话或内容",
+            )
+        return await self._push.dispatch(
+            ChannelMessage(
                 channel=channel,
                 chat_id=chat_id,
-                image=image,
+                content=message,
+                attachments=tuple(
+                    ChannelAttachment(AttachmentKind.IMAGE, item) for item in media
+                ),
+                metadata=dict(outbound.metadata),
+                session_message_id=outbound.session_message_id,
             )
-        return "已发送" in str(result)
+        )

--- a/bus/events.py
+++ b/bus/events.py
@@ -16,6 +16,55 @@ class TurnDisposition(StrEnum):
     SHORT_CIRCUITED = "short_circuited"
 
 
+class DeliveryStatus(StrEnum):
+    """表示一次完整逻辑消息的渠道提交终态。"""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+class AttachmentKind(StrEnum):
+    FILE = "file"
+    IMAGE = "image"
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelAttachment:
+    """渠道边界中带明确类型的单个附件。"""
+
+    kind: AttachmentKind
+    source: str
+    filename: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelMessage:
+    """提交给渠道 adapter 的完整逻辑消息。"""
+
+    channel: str
+    chat_id: str
+    content: str
+    attachments: tuple[ChannelAttachment, ...] = ()
+    thinking: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict[str, object])
+    session_message_id: str | None = None
+    control_turn_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryReceipt:
+    """记录渠道对完整逻辑消息的结构化提交结果。"""
+
+    status: DeliveryStatus
+    canonical_media: tuple[str, ...] = ()
+    detail: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status is DeliveryStatus.SUCCESS
+
+
 @dataclass
 class InboundMessage:
     """从 channel 传入的消息"""
@@ -65,6 +114,27 @@ class OutboundMessage:
         default=None,
         repr=False,
         compare=False,
+    )
+
+
+def channel_message_from_outbound(
+    message: OutboundMessage,
+    *,
+    media_kind: AttachmentKind = AttachmentKind.IMAGE,
+) -> ChannelMessage:
+    """把已提交 Turn 的字符串媒体投影转换为渠道边界类型。"""
+
+    return ChannelMessage(
+        channel=message.channel,
+        chat_id=message.chat_id,
+        content=message.content,
+        attachments=tuple(
+            ChannelAttachment(media_kind, source) for source in message.media
+        ),
+        thinking=message.thinking,
+        metadata=dict(message.metadata),
+        session_message_id=message.session_message_id,
+        control_turn_id=message.control_turn_id,
     )
 
 

--- a/docker/debug/plugins/replay_debug/plugin.py
+++ b/docker/debug/plugins/replay_debug/plugin.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import Any
 
 from agent.plugins import McpServerSpec, Plugin, ProactiveSourceSpec
+from bus.events import ChannelMessage, DeliveryReceipt
 from core.clock import clock_from_env
+from infra.channels.delivery import deliver_message_parts
 from infra.channels.contract import ChannelContext
 
 
@@ -29,9 +31,7 @@ class CaptureChannel:
         self._outbox_path.parent.mkdir(parents=True, exist_ok=True)
         self._registration = ctx.push_tool.register_channel(
             self.name,
-            text=self._send_text,
-            file=self._send_file,
-            image=self._send_image,
+            deliver=self._deliver,
         )
 
     async def stop(self) -> None:
@@ -41,6 +41,14 @@ class CaptureChannel:
 
     async def _send_text(self, chat_id: str, message: str) -> None:
         self._append({"type": "text", "chat_id": chat_id, "message": message})
+
+    async def _deliver(self, message: ChannelMessage) -> DeliveryReceipt:
+        return await deliver_message_parts(
+            message,
+            send_text=self._send_text,
+            send_file=self._send_file,
+            send_image=self._send_image,
+        )
 
     async def _send_file(
         self,

--- a/docker/debug/proactive_sandbox.py
+++ b/docker/debug/proactive_sandbox.py
@@ -23,6 +23,7 @@ from agent.tools.message_push import MessagePushTool
 from agent.tools.registry import ToolRegistry
 from agent.tools.web_fetch import WebFetchTool
 from bus.event_bus import EventBus
+from bus.events import ChannelMessage, DeliveryReceipt, DeliveryStatus
 from bootstrap.proactive import _build_proactive_provider
 from bootstrap.providers import build_providers
 from proactive_v2.config import ProactiveConfig
@@ -438,7 +439,11 @@ async def tick(
     async def send_text(chat_id: str, message: str) -> None:
         sent.append({"chat_id": chat_id, "message": message})
 
-    push.register_channel("sandbox", text=send_text)
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        await send_text(message.chat_id, message.content)
+        return DeliveryReceipt(DeliveryStatus.SUCCESS)
+
+    push.register_channel("sandbox", deliver=deliver)
     await plugins.load_all()
     runtime_sources = plugins.proactive_sources
     if isinstance(provider, SandboxProvider):

--- a/docker/debug/runtime_race_probe.py
+++ b/docker/debug/runtime_race_probe.py
@@ -34,7 +34,13 @@ from agent.tools.message_push import MessagePushTool
 from agent.tools.registry import ToolRegistry
 from agent.turns.outbound import BusOutboundPort, OutboundDispatch, PushToolOutboundPort
 from bootstrap.tools import build_core_runtime
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+)
 from bus.event_bus import EventBus
 from bus.processing import ProcessingState
 from bus.queue import MessageBus
@@ -275,7 +281,11 @@ class RaceHarness:
         async def _text(chat_id: str, message: str) -> None:
             await self._send_text_for(channel, chat_id, message)
 
-        push_tool.register_channel(channel, text=_text)
+        async def _deliver(message: ChannelMessage) -> DeliveryReceipt:
+            await _text(message.chat_id, message.content)
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
+
+        push_tool.register_channel(channel, deliver=_deliver)
         bus.subscribe_outbound(channel, self._send_outbound)
 
     async def start(self) -> None:

--- a/infra/channels/delivery.py
+++ b/infra/channels/delivery.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from bus.events import (
+    AttachmentKind,
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def deliver_message_parts(
+    message: ChannelMessage,
+    *,
+    send_text: Callable[[str, str], Awaitable[None]],
+    send_file: Callable[[str, str, str | None], Awaitable[None]],
+    send_image: Callable[[str, str], Awaitable[None]],
+) -> DeliveryReceipt:
+    """按平台原生能力发送完整消息，并准确报告部分提交。"""
+
+    committed = 0
+    try:
+        # 1. 先提交正文，再按已验证类型提交每个附件
+        if message.content:
+            await send_text(message.chat_id, message.content)
+            committed += 1
+        for attachment in message.attachments:
+            if attachment.kind is AttachmentKind.FILE:
+                await send_file(
+                    message.chat_id,
+                    attachment.source,
+                    attachment.filename,
+                )
+            elif attachment.kind is AttachmentKind.IMAGE:
+                await send_image(message.chat_id, attachment.source)
+            else:
+                raise ValueError(f"未知渠道附件类型: {attachment.kind}")
+            committed += 1
+    except Exception as error:
+        # 2. 渠道边界把平台异常转换为可判定的提交终态
+        status = DeliveryStatus.PARTIAL if committed else DeliveryStatus.FAILED
+        logger.warning(
+            "渠道消息提交失败: channel=%s chat=%s committed=%s error=%s",
+            message.channel,
+            message.chat_id,
+            committed,
+            error,
+        )
+        return DeliveryReceipt(status, detail=str(error))
+
+    return DeliveryReceipt(
+        DeliveryStatus.SUCCESS,
+        canonical_media=tuple(item.source for item in message.attachments),
+    )

--- a/infra/channels/qq_channel.py
+++ b/infra/channels/qq_channel.py
@@ -28,7 +28,13 @@ from typing import Any, cast
 from agent.config_models import QQGroupConfig
 from agent.looping.interrupt import InterruptController
 from bus.event_bus import EventBus
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    InboundMessage,
+    OutboundMessage,
+    channel_message_from_outbound,
+)
 from bus.events_lifecycle import (
     ToolCallCompleted,
     ToolCallStarted,
@@ -37,6 +43,7 @@ from bus.events_lifecycle import (
 from bus.queue import MessageBus
 from infra.channels.base import AttachmentStore, SessionIdentityIndex
 from infra.channels.contract import ChannelContext
+from infra.channels.delivery import deliver_message_parts
 from infra.channels.group_filter import (
     DefaultGroupFilter,
     GroupMessageFilter,
@@ -376,9 +383,7 @@ class QQChannel:
             self._interrupt_controller = ctx.interrupt_controller
             ctx.push_tool.register_channel(
                 self.name,
-                text=self.send,
-                file=self.send_file,
-                image=self.send_image,
+                deliver=self._deliver_message,
             )
         self._main_loop = asyncio.get_running_loop()
         self._identity_index.rebuild()
@@ -609,26 +614,10 @@ class QQChannel:
                 await self._send_private_trace(msg.chat_id, session_key, msg)
             except Exception as e:
                 logger.warning(f"[qq] 私聊 tracing 合并转发失败  chat_id={msg.chat_id}  错误: {e}")
-        if msg.content.strip():
-            try:
-                if msg.chat_id.startswith(_GROUP_PREFIX):
-                    group_id = msg.chat_id[len(_GROUP_PREFIX) :]
-                    logger.info(f"[qq] 群聊回复  group_id={group_id}  内容: {preview!r}")
-                    await self._run_on_bot_loop(
-                        api.send_group_text(int(group_id), msg.content)
-                    )
-                else:
-                    logger.info(f"[qq] 私聊回复  user_id={msg.chat_id}  内容: {preview!r}")
-                    await self._run_on_bot_loop(
-                        api.send_private_text(int(msg.chat_id), msg.content)
-                    )
-            except Exception as e:
-                logger.error(f"[qq] 发送失败  chat_id={msg.chat_id}  错误: {e}")
-        for image in (msg.media or []):
-            try:
-                await self.send_image(msg.chat_id, image)
-            except Exception as e:
-                logger.error(f"[qq] meme 图片发送失败  chat_id={msg.chat_id}  path={image}  err={e}")
+        logger.info("[qq] 发送回复  chat_id=%s 内容=%r", msg.chat_id, preview)
+        receipt = await self._deliver_message(channel_message_from_outbound(msg))
+        if not receipt.succeeded:
+            raise RuntimeError(receipt.detail or "QQ 消息提交失败")
         self._trace_states.pop(session_key, None)
 
     async def _send_private_trace(
@@ -744,6 +733,16 @@ class QQChannel:
             await self._run_on_bot_loop(api.send_group_image(int(group_id), uri))
         else:
             await self._run_on_bot_loop(api.send_private_image(int(chat_id), uri))
+
+    async def _deliver_message(self, message: ChannelMessage) -> DeliveryReceipt:
+        """以 QQ 原生调用提交完整消息并报告部分送达。"""
+
+        return await deliver_message_parts(
+            message,
+            send_text=self.send,
+            send_file=self.send_file,
+            send_image=self.send_image,
+        )
 
     def _require_main_loop(self) -> asyncio.AbstractEventLoop:
         if self._main_loop is None:

--- a/infra/channels/telegram_channel.py
+++ b/infra/channels/telegram_channel.py
@@ -25,7 +25,13 @@ from telegram.ext import (
 )
 
 from bus.event_bus import EventBus
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    InboundMessage,
+    OutboundMessage,
+    channel_message_from_outbound,
+)
 from bus.events_lifecycle import (
     StreamDeltaReady,
     ToolCallCompleted,
@@ -36,6 +42,7 @@ from bus.queue import MessageBus
 from agent.looping.interrupt import InterruptController
 from infra.channels.base import AttachmentStore, MessageDeduper, SessionIdentityIndex
 from infra.channels.contract import ChannelContext
+from infra.channels.delivery import deliver_message_parts
 from infra.channels.reply_context import build_reply_inbound_text
 from infra.channels.telegram_utils import (
     TelegramOutboundLimiter,
@@ -172,10 +179,7 @@ class TelegramChannel:
             self._interrupt_controller = ctx.interrupt_controller
             ctx.push_tool.register_channel(
                 self.name,
-                text=self.send,
-                stream_text=self.send_stream,
-                file=self.send_file,
-                image=self.send_image,
+                deliver=self._deliver_message,
             )
         self._bind_runtime()
         self._rebuild_user_map()
@@ -742,6 +746,27 @@ class TelegramChannel:
                 action=lambda: self._send_photo_file(cid, image),
             )
 
+    async def _deliver_message(self, message: ChannelMessage) -> DeliveryReceipt:
+        """以 Telegram 原生调用提交完整消息并报告部分送达。"""
+
+        async def send_text(chat_id: str, content: str) -> None:
+            if bool(message.metadata.get("streamed_reply")):
+                stream = self._active_streams.pop(str(chat_id), None)
+                if stream is not None:
+                    await stream.finalize(content)
+                    return
+            if message.metadata.get("_channel_commit_role") == "passive":
+                await self.send(chat_id, content)
+            else:
+                await self.send_stream(chat_id, content)
+
+        return await deliver_message_parts(
+            message,
+            send_text=send_text,
+            send_file=self.send_file,
+            send_image=self.send_image,
+        )
+
     async def _send_document_file(
         self,
         chat_id: int,
@@ -779,26 +804,9 @@ class TelegramChannel:
                     self._telegram_outbound_limiter,
                 )
             await self._send_final_tool_snapshot(session_key, msg.chat_id)
-        streamed_reply = bool((msg.metadata or {}).get("streamed_reply"))
-        if msg.content.strip():
-            if streamed_reply:
-                stream = self._active_streams.pop(str(msg.chat_id), None)
-                if stream is not None:
-                    await stream.finalize(msg.content)
-                else:
-                    await send_markdown(
-                        self._app.bot,
-                        msg.chat_id,
-                        msg.content,
-                        self._telegram_outbound_limiter,
-                    )
-            else:
-                await send_markdown(
-                    self._app.bot,
-                    msg.chat_id,
-                    msg.content,
-                    self._telegram_outbound_limiter,
-                )
+        outbound = channel_message_from_outbound(msg)
+        outbound.metadata["_channel_commit_role"] = "passive"
+        receipt = await self._deliver_message(outbound)
         if final_thinking and not had_live:
             await send_thinking_block(
                 self._app.bot,
@@ -812,11 +820,8 @@ class TelegramChannel:
         _ = self._live_last_lengths.pop(session_key, None)
         _ = self._tool_lines.pop(session_key, None)
         _ = self._active_streams.pop(str(msg.chat_id), None)
-        for image in (msg.media or []):
-            try:
-                await self.send_image(str(msg.chat_id), image)
-            except Exception as e:
-                logger.warning(f"[telegram] meme 图片发送失败  chat_id={msg.chat_id}  path={image}  err={e}")
+        if not receipt.succeeded:
+            raise RuntimeError(receipt.detail or "Telegram 消息提交失败")
 
     async def _safe_send_typing(
         self, context: ContextTypes.DEFAULT_TYPE, chat_id: int

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -10,7 +10,14 @@ from uuid import uuid4
 from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+    channel_message_from_outbound,
+)
 from bus.events_lifecycle import (
     StreamDeltaReady,
     ToolCallCompleted,
@@ -49,10 +56,7 @@ class WebChatChannel:
             self._events_bound = True
         ctx.push_tool.register_channel(
             self.name,
-            text=self.send,
-            stream_text=self.send_stream,
-            file=self.send_file,
-            image=self.send_image,
+            deliver=self._deliver_message,
         )
 
     def bind_attachment_store(self, store: AttachmentStore) -> None:
@@ -173,6 +177,36 @@ class WebChatChannel:
             "media": [image],
             "metadata": {"source": "message_push", "kind": "image"},
         })
+
+    async def _deliver_message(self, message: ChannelMessage) -> DeliveryReceipt:
+        """把完整渠道消息映射为一个 Web final frame。"""
+
+        session_key = self._session_key(message.chat_id)
+        media = [attachment.source for attachment in message.attachments]
+        self.remember_media(media)
+        metadata = dict(message.metadata)
+        passive = metadata.pop("_channel_commit_role", None) == "passive"
+        if not passive:
+            metadata.setdefault("source", "message_push")
+        delivered = await self._broadcast(session_key, {
+            "type": "message.final",
+            "session_id": session_key,
+            "turn_id": message.control_turn_id or self._current_turn_id(session_key),
+            "content": message.content,
+            "thinking": message.thinking or "",
+            "media": media,
+            "duration_ms": metadata.get("turn_duration_ms"),
+            "metadata": metadata,
+        })
+        if delivered == 0:
+            return DeliveryReceipt(
+                DeliveryStatus.FAILED,
+                detail="Web 会话没有可用连接",
+            )
+        return DeliveryReceipt(
+            DeliveryStatus.SUCCESS,
+            canonical_media=tuple(media),
+        )
 
     async def _handle_client_frame(
         self,
@@ -335,19 +369,11 @@ class WebChatChannel:
 
     async def _on_response(self, msg: OutboundMessage) -> None:
         session_key = self._session_key(msg.chat_id)
-        media = list(msg.media or [])
-        metadata = dict(msg.metadata or {})
-        self.remember_media(media)
-        await self._broadcast(session_key, {
-            "type": "message.final",
-            "session_id": session_key,
-            "turn_id": self._current_turn_id(session_key),
-            "content": msg.content,
-            "thinking": msg.thinking or "",
-            "media": media,
-            "duration_ms": metadata.get("turn_duration_ms"),
-            "metadata": metadata,
-        })
+        outbound = channel_message_from_outbound(msg)
+        outbound.metadata["_channel_commit_role"] = "passive"
+        receipt = await self._deliver_message(outbound)
+        if not receipt.succeeded:
+            raise RuntimeError(receipt.detail or "Web 消息提交失败")
         _ = self._active_turn_ids.pop(session_key, None)
 
     async def _add_connection(self, session_key: str, websocket: WebSocket) -> None:
@@ -368,18 +394,20 @@ class WebChatChannel:
                 if not sockets:
                     _ = self._connections.pop(session_key, None)
 
-    async def _broadcast(self, session_key: str, frame: dict[str, Any]) -> None:
+    async def _broadcast(self, session_key: str, frame: dict[str, Any]) -> int:
         async with self._connection_lock:
             sockets = list(self._connections.get(session_key, set()))
         if not sockets:
-            return
+            return 0
         stale: list[WebSocket] = []
+        delivered = 0
         for socket in sockets:
             if socket.application_state != WebSocketState.CONNECTED:
                 stale.append(socket)
                 continue
             try:
                 await socket.send_json(frame)
+                delivered += 1
             except Exception as e:
                 logger.warning("[web_chat] 发送 WebSocket frame 失败: %s", e)
                 stale.append(socket)
@@ -389,6 +417,7 @@ class WebChatChannel:
                 if current is not None:
                     for socket in stale:
                         current.discard(socket)
+        return delivered
 
     async def _send_error(
         self,

--- a/infra/mobile_realtime/attachments.py
+++ b/infra/mobile_realtime/attachments.py
@@ -268,6 +268,29 @@ class AttachmentTransferService:
     ) -> tuple[AttachmentRecord, ...]:
         """先完整快照一批媒体，再以单个事务注册全部附件。"""
 
+        candidates = self.snapshot_outbound_batch(
+            session_id=session_id,
+            local_media_paths=local_media_paths,
+            metadata_overrides=metadata_overrides,
+        )
+        try:
+            return self._storage.create_or_read_outbound_attachments(
+                candidates,
+                message_id=message_id,
+            )
+        except BaseException:
+            self.cleanup_outbound_candidates(candidates)
+            raise
+
+    def snapshot_outbound_batch(
+        self,
+        *,
+        session_id: str,
+        local_media_paths: tuple[str | Path, ...] | list[str | Path],
+        metadata_overrides: tuple[tuple[str, str] | None, ...] | None = None,
+    ) -> tuple[AttachmentRecord, ...]:
+        """完整快照并校验一批尚未提交的 outbound 候选。"""
+
         sources = tuple(Path(value) for value in local_media_paths)
         if not 1 <= len(sources) <= 10:
             raise AttachmentRequestError("单条消息附件数量必须在 1..10")
@@ -293,14 +316,18 @@ class AttachmentTransferService:
                         f"{self._max_attachment_bytes} 字节"
                     )
 
-            # 2. 存储层在一个 SQLite 事务内完成整批创建或复用
-            return self._storage.create_or_read_outbound_attachments(
-                tuple(candidates),
-                message_id=message_id,
-            )
+            return tuple(candidates)
         except BaseException:
             _remove_paths([Path(record.local_path) for record in candidates])
             raise
+
+    def cleanup_outbound_candidates(
+        self,
+        candidates: tuple[AttachmentRecord, ...],
+    ) -> None:
+        """删除未提交候选；调用方必须保证事务尚未成功。"""
+
+        _remove_paths([Path(record.local_path) for record in candidates])
 
     def read_message_outbound(
         self,

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import re
+import sqlite3
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -13,7 +14,14 @@ from time import monotonic
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+    channel_message_from_outbound,
+)
 from bus.events_lifecycle import (
     StreamDeltaReady,
     ToolCallCompleted,
@@ -57,7 +65,12 @@ from infra.mobile_realtime.remote_media import (
     RemoteMediaSnapshot,
     snapshot_remote_media,
 )
-from infra.mobile_realtime.storage import AttachmentStateError, CommandReceipt
+from infra.mobile_realtime.storage import (
+    AttachmentRecord,
+    AttachmentStateError,
+    CommandReceipt,
+    MobileStorageError,
+)
 
 if TYPE_CHECKING:
     from agent.plugins.mobile_ui import MobileUiProvider
@@ -231,9 +244,7 @@ class MobileRealtimeChannel:
         _ = ctx.event_bus.on(ToolCallCompleted, self._on_tool_call_completed)
         _ = ctx.push_tool.register_channel(
             self.name,
-            text=self.send,
-            stream_text=self.send_stream,
-            text_with_metadata=self.send_with_metadata,
+            deliver=self._deliver_message,
         )
 
     async def stop(self) -> None:
@@ -496,6 +507,124 @@ class MobileRealtimeChannel:
 
     async def send_stream(self, chat_id: str, message: str) -> None:
         await self.send(chat_id, message)
+
+    async def _deliver_message(self, message: ChannelMessage) -> DeliveryReceipt:
+        """把完整主动消息原子提交为一个 Mobile durable event。"""
+
+        self._raise_delta_failure()
+        if message.metadata.get("_channel_commit_role") == "passive":
+            return await self._deliver_passive_message(message)
+        session_id = self._session_id(message.chat_id)
+        if not self._runtime.storage.list_active_devices():
+            return DeliveryReceipt(
+                DeliveryStatus.FAILED,
+                detail="Mobile 没有可接收消息的已配对设备",
+            )
+        delivery_id = message.metadata.get("delivery_id")
+        if delivery_id is not None and (
+            not isinstance(delivery_id, str)
+            or not delivery_id
+            or len(delivery_id) > 128
+        ):
+            raise ValueError("mobile proactive delivery_id 无效")
+        if not message.attachments:
+            payload: dict[str, object] = {
+                "content": message.content,
+                "attachments": [],
+                "metadata": {"source": "message_push"},
+            }
+            if delivery_id is not None:
+                payload["delivery_id"] = delivery_id
+            await self._runtime.publish_event(
+                event_type="message.proactive",
+                session_id=session_id,
+                payload=payload,
+            )
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
+
+        snapshots: list[RemoteMediaSnapshot] = []
+        candidates: tuple[AttachmentRecord, ...] = ()
+        try:
+            # 1. 所有源先成为受限本地快照，尚不写数据库
+            paths: list[str] = []
+            overrides: list[tuple[str, str] | None] = []
+            for attachment in message.attachments:
+                if attachment.source.startswith(("http://", "https://")):
+                    snapshot = await snapshot_remote_media(
+                        attachment.source,
+                        self._require_ctx().attachment_store,
+                        max_bytes=(
+                            self._runtime.config.max_attachment_mb * 1024 * 1024
+                        ),
+                    )
+                    snapshots.append(snapshot)
+                    paths.append(str(snapshot.path))
+                    overrides.append((snapshot.filename, snapshot.content_type))
+                else:
+                    paths.append(attachment.source)
+                    overrides.append(None)
+            candidates = await asyncio.to_thread(
+                self._require_attachments().snapshot_outbound_batch,
+                session_id=session_id,
+                local_media_paths=tuple(paths),
+                metadata_overrides=tuple(overrides),
+            )
+
+            # 2. 附件记录与所有设备 inbox 行在同一事务提交
+            resolved = await self._runtime.publish_event_with_outbound_attachments(
+                candidates=candidates,
+                session_id=session_id,
+                payload_builder=lambda records: self._proactive_attachment_payload(
+                    message,
+                    records,
+                    delivery_id=cast(str | None, delivery_id),
+                ),
+            )
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS,
+                canonical_media=tuple(record.local_path for record in resolved),
+            )
+        except (
+            AttachmentRequestError,
+            AttachmentStateError,
+            MobileStorageError,
+            RemoteMediaError,
+            OSError,
+            sqlite3.Error,
+        ) as error:
+            if candidates:
+                self._require_attachments().cleanup_outbound_candidates(candidates)
+            logger.warning(
+                "mobile proactive 附件提交失败: session=%s error=%s",
+                session_id,
+                error,
+            )
+            return DeliveryReceipt(DeliveryStatus.FAILED, detail=str(error))
+        except BaseException:
+            if candidates:
+                self._require_attachments().cleanup_outbound_candidates(candidates)
+            raise
+        finally:
+            for snapshot in snapshots:
+                snapshot.path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _proactive_attachment_payload(
+        message: ChannelMessage,
+        records: tuple[AttachmentRecord, ...],
+        *,
+        delivery_id: str | None,
+    ) -> dict[str, object]:
+        """用事务内解析出的 canonical 附件构造主动事件。"""
+
+        payload: dict[str, object] = {
+            "content": message.content,
+            "attachments": [attachment_descriptor(record) for record in records],
+            "metadata": {"source": "message_push"},
+        }
+        if delivery_id is not None:
+            payload["delivery_id"] = delivery_id
+        return payload
 
     async def _execute_command(
         self,
@@ -1290,18 +1419,32 @@ class MobileRealtimeChannel:
         )
 
     async def _on_response(self, message: OutboundMessage) -> None:
+        outbound = channel_message_from_outbound(message)
+        outbound.metadata["_channel_commit_role"] = "passive"
+        receipt = await self._deliver_message(outbound)
+        if not receipt.succeeded:
+            raise RuntimeError(receipt.detail or "Mobile 被动消息提交失败")
+
+    async def _deliver_passive_message(
+        self,
+        message: ChannelMessage,
+    ) -> DeliveryReceipt:
+        """提交已持久化 Turn 的 Mobile final 投影。"""
+
         self._raise_delta_failure()
         session_id = self._session_id(message.chat_id)
         turn_id = message.control_turn_id or self._current_turn_id(session_id)
         await self._flush_deltas(session_id, turn_id)
         message_id = message.session_message_id
-        if message.media and message_id is None:
+        media = [attachment.source for attachment in message.attachments]
+        if media and message_id is None:
             raise RuntimeError("出站媒体缺少已持久化的 assistant 消息")
         metadata = dict(message.metadata)
+        _ = metadata.pop("_channel_commit_role", None)
         try:
             attachments = await self._outbound_descriptors(
                 session_id,
-                list(message.media),
+                media,
                 message_id=message_id,
             )
         except (
@@ -1346,6 +1489,10 @@ class MobileRealtimeChannel:
         )
         _ = self._active_turn_ids.pop(session_id, None)
         _ = self._process_turns.pop((session_id, turn_id), None)
+        return DeliveryReceipt(
+            DeliveryStatus.SUCCESS,
+            canonical_media=tuple(media),
+        )
 
     async def _mobile_history_item(
         self,

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -9,7 +9,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Callable, cast
 
 import uvicorn
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
@@ -78,6 +78,7 @@ from infra.mobile_realtime.storage import (
     PairingStateError,
     ServerIdentityReference,
     UnknownDeviceError,
+    AttachmentRecord,
 )
 
 if TYPE_CHECKING:
@@ -849,6 +850,72 @@ class MobileGatewayRuntime:
                     continue
                 connection.pending_events.append(event)
                 self._schedule_delivery_locked(target_device_id, connection)
+
+    async def publish_event_with_outbound_attachments(
+        self,
+        *,
+        candidates: tuple[AttachmentRecord, ...],
+        payload_builder: Callable[[tuple[AttachmentRecord, ...]], dict[str, object]],
+        session_id: str,
+    ) -> tuple[AttachmentRecord, ...]:
+        """原子提交附件和 proactive durable event，再排队在线投递。"""
+
+        event_id = _new_ulid()
+        # 1. delivery lock 内用一个 SQLite 事务提交附件与全部 inbox 行
+        async with self._delivery_lock:
+            target_device_ids = tuple(
+                device.device_id for device in self.storage.list_active_devices()
+            )
+            resolved, events = self.storage.commit_outbound_event(
+                candidates,
+                device_ids=target_device_ids,
+                event_id=event_id,
+                envelope_builder=lambda records: _encode_stored_event(
+                    event_id=event_id,
+                    event_type="message.proactive",
+                    payload=payload_builder(records),
+                    session_id=session_id,
+                    turn_id=None,
+                ),
+                created_at=datetime.now(timezone.utc),
+            )
+
+            # 2. 数据库提交已是送达事实；在线队列只优化即时可见性
+            self._queue_committed_events_locked(events)
+        return resolved
+
+    def _queue_committed_events_locked(
+        self,
+        events: tuple[DurableInboxEvent, ...],
+    ) -> None:
+        """尽力排队已提交事件；失败时保留 durable resume 恢复路径。"""
+
+        try:
+            for event in events:
+                connection = self._connections.get(event.device_id)
+                if connection is None:
+                    continue
+                if len(connection.pending_events) >= _MAX_PENDING_CONNECTION_EVENTS:
+                    _ = self._connections.pop(event.device_id)
+                    _ = asyncio.create_task(
+                        self._close_connection(
+                            event.device_id,
+                            connection,
+                            code=_CLOSE_SLOW_CONSUMER,
+                            reason="设备实时投递队列已满，请重新连接恢复",
+                        )
+                    )
+                    logger.warning(
+                        "mobile 设备投递队列已满，转为下次 resume: device=%s",
+                        event.device_id,
+                    )
+                    continue
+                connection.pending_events.append(event)
+                self._schedule_delivery_locked(event.device_id, connection)
+        except Exception:
+            logger.exception(
+                "mobile durable event 已提交，在线排队失败；等待设备 resume"
+            )
 
     async def publish_connection_control(
         self,

--- a/infra/mobile_realtime/storage.py
+++ b/infra/mobile_realtime/storage.py
@@ -8,7 +8,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal, cast
+from typing import Callable, Literal, cast
 
 
 PairingStatus = Literal["pending", "confirmed", "consumed", "expired"]
@@ -977,6 +977,107 @@ class MobileRealtimeStorage:
                         (_require_text(message_id, "message_id"), ordinal, record.attachment_id),
                     )
         return tuple(result)
+
+    def commit_outbound_event(
+        self,
+        records: tuple[AttachmentRecord, ...],
+        *,
+        device_ids: tuple[str, ...],
+        event_id: str,
+        envelope_builder: Callable[[tuple[AttachmentRecord, ...]], str],
+        created_at: datetime,
+    ) -> tuple[tuple[AttachmentRecord, ...], tuple[DurableInboxEvent, ...]]:
+        """原子提交 outbound 附件与同一事件的全部设备 inbox 行。"""
+
+        if not records:
+            raise ValueError("outbound event 附件批次不能为空")
+        for record in records:
+            self._validate_outbound_candidate(record)
+        device_keys = tuple(
+            _require_text(device_id, "device_id") for device_id in device_ids
+        )
+        if len(set(device_keys)) != len(device_keys):
+            raise ValueError("durable event 广播设备不能重复")
+        event_key = _require_text(event_id, "event_id")
+        timestamp = _serialize_datetime(created_at, "created_at")
+
+        # 1. 同一写锁内解析附件身份并构造引用 canonical 记录的 envelope
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            resolved: list[AttachmentRecord] = []
+            by_identity: dict[tuple[str, str, str, str, int], AttachmentRecord] = {}
+            for candidate in records:
+                identity = (
+                    candidate.session_id,
+                    candidate.filename,
+                    candidate.content_type,
+                    candidate.sha256,
+                    candidate.size_bytes,
+                )
+                record = by_identity.get(identity)
+                if record is None:
+                    record = self._read_outbound_for_candidate(candidate)
+                    if record is None:
+                        self._insert_outbound_attachment(candidate)
+                        record = candidate
+                    by_identity[identity] = record
+                if record.local_path != candidate.local_path:
+                    Path(candidate.local_path).unlink()
+                resolved.append(record)
+            resolved_records = tuple(resolved)
+            envelope = _require_text(
+                envelope_builder(resolved_records),
+                "envelope_json",
+            )
+
+            # 2. 在附件事务内为全部目标设备分配序号并写入 inbox
+            allocated: list[tuple[str, int]] = []
+            for device_key in device_keys:
+                row = self._db.execute(
+                    "SELECT next_event_seq FROM mobile_device_cursors WHERE device_id = ?",
+                    (device_key,),
+                ).fetchone()
+                if row is None:
+                    raise UnknownDeviceError(
+                        f"设备不存在或缺少 cursor: {device_key}"
+                    )
+                event_seq = _row_positive_int(row, "next_event_seq")
+                allocated.append((device_key, event_seq))
+                _ = self._db.execute(
+                    """
+                    INSERT INTO mobile_device_inbox(
+                        device_id, event_seq, event_id, priority,
+                        envelope_json, created_at
+                    ) VALUES(?, ?, ?, 'P0', ?, ?)
+                    """,
+                    (device_key, event_seq, event_key, envelope, timestamp),
+                )
+                updated = self._db.execute(
+                    """
+                    UPDATE mobile_device_cursors
+                    SET next_event_seq = ?
+                    WHERE device_id = ? AND next_event_seq = ?
+                    """,
+                    (event_seq + 1, device_key, event_seq),
+                )
+                if updated.rowcount != 1:
+                    raise RuntimeError(
+                        f"设备 event_seq 分配发生并发冲突: {device_key}"
+                    )
+
+        created = _parse_datetime(timestamp, "created_at")
+        events = tuple(
+            DurableInboxEvent(
+                device_id=device_key,
+                event_seq=event_seq,
+                event_id=event_key,
+                priority="P0",
+                envelope_json=envelope,
+                created_at=created,
+            )
+            for device_key, event_seq in allocated
+        )
+        return resolved_records, events
 
     def read_message_outbound_attachments(
         self,

--- a/tests/mobile_realtime/test_attachments.py
+++ b/tests/mobile_realtime/test_attachments.py
@@ -23,10 +23,43 @@ from infra.mobile_realtime.storage import (
     AttachmentStateError,
     DeviceRecord,
     MobileRealtimeStorage,
+    UnknownDeviceError,
 )
 
 
 ATTACHMENT_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+
+def test_outbound_attachment_and_all_device_inbox_rows_roll_back_together(
+    storage: MobileRealtimeStorage,
+    tmp_path: Path,
+) -> None:
+    service = AttachmentTransferService(
+        storage,
+        AttachmentStore(tmp_path / "attachments"),
+        max_attachment_bytes=1024,
+    )
+    source = tmp_path / "report.pdf"
+    source.write_bytes(b"report")
+    candidates = service.snapshot_outbound_batch(
+        session_id="mobile:session-1",
+        local_media_paths=(source,),
+    )
+
+    with pytest.raises(UnknownDeviceError, match="missing-device"):
+        storage.commit_outbound_event(
+            candidates,
+            device_ids=("device-1", "missing-device"),
+            event_id="event-atomic",
+            envelope_builder=lambda _records: '{"kind":"event"}',
+            created_at=datetime.now(timezone.utc),
+        )
+
+    assert storage.read_attachment(candidates[0].attachment_id) is None
+    assert storage.count_durable_events("device-1") == 0
+    assert Path(candidates[0].local_path).exists()
+    service.cleanup_outbound_candidates(candidates)
+    assert not Path(candidates[0].local_path).exists()
 
 
 @pytest.fixture

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -14,7 +14,13 @@ import infra.mobile_realtime.gateway as gateway_module
 
 from agent.config_models import MobileRealtimeConfig
 from infra.mobile_realtime.runtime_inspection import RuntimeInspectionService
-from bus.events import OutboundMessage
+from bus.events import (
+    AttachmentKind,
+    ChannelAttachment,
+    ChannelMessage,
+    DeliveryStatus,
+    OutboundMessage,
+)
 from bus.events_lifecycle import (
     StreamDeltaReady,
     ToolCallCompleted,
@@ -30,7 +36,11 @@ from infra.mobile_realtime.protocol import (
     parse_frame,
 )
 from infra.mobile_realtime.remote_media import RemoteMediaError, RemoteMediaSnapshot
-from infra.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
+from infra.mobile_realtime.storage import (
+    AttachmentRecord,
+    DeviceRecord,
+    MobileRealtimeStorage,
+)
 from session.manager import SessionManager
 
 
@@ -45,6 +55,32 @@ class _Runtime:
 
     async def publish_connection_control(self, **control: object) -> None:
         self.events.append(dict(control))
+
+    async def publish_event_with_outbound_attachments(
+        self,
+        *,
+        candidates: tuple[AttachmentRecord, ...],
+        payload_builder: Any,
+        session_id: str,
+    ) -> tuple[AttachmentRecord, ...]:
+        event_id = gateway_module._new_ulid()
+        resolved, events = self.storage.commit_outbound_event(
+            candidates,
+            device_ids=tuple(
+                device.device_id for device in self.storage.list_active_devices()
+            ),
+            event_id=event_id,
+            envelope_builder=lambda records: gateway_module._encode_stored_event(
+                event_id=event_id,
+                event_type="message.proactive",
+                payload=payload_builder(records),
+                session_id=session_id,
+                turn_id=None,
+            ),
+            created_at=datetime.now(timezone.utc),
+        )
+        self.events.append({"durable": events})
+        return resolved
 
 
 class _Bus:
@@ -1489,6 +1525,7 @@ async def test_command_list_uses_active_channel_catalog_without_stop(
     }
     await channel.stop()
     storage.close()
+    storage.close()
 
 
 @pytest.mark.asyncio
@@ -2058,10 +2095,17 @@ async def test_proactive_sender_uses_mobile_event_path(tmp_path: Path) -> None:
         session_id=f"mobile:{chat_id}",
         created_at=datetime.now(timezone.utc),
     )
-    sender = cast(Any, push.registered["mobile"]["text"])
+    deliver = cast(Any, push.registered["mobile"]["deliver"])
 
-    await sender(chat_id, "该休息一下了")
+    receipt = await deliver(
+        ChannelMessage(
+            channel="mobile",
+            chat_id=chat_id,
+            content="该休息一下了",
+        )
+    )
 
+    assert receipt.status is DeliveryStatus.SUCCESS
     assert runtime.events == [
         {
             "event_type": "message.proactive",
@@ -2080,6 +2124,7 @@ async def test_proactive_sender_uses_mobile_event_path(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_proactive_metadata_sender_forwards_delivery_id(tmp_path: Path) -> None:
     storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    _register_device(storage, uuid4().hex)
     runtime = _Runtime(storage)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     push = _PushTool()
@@ -2097,10 +2142,18 @@ async def test_proactive_metadata_sender_forwards_delivery_id(tmp_path: Path) ->
         )
     )
     chat_id = str(uuid4())
-    sender = cast(Any, push.registered["mobile"]["text_with_metadata"])
+    deliver = cast(Any, push.registered["mobile"]["deliver"])
 
-    await sender(chat_id, "该休息一下了", {"delivery_id": "delivery-1"})
+    receipt = await deliver(
+        ChannelMessage(
+            channel="mobile",
+            chat_id=chat_id,
+            content="该休息一下了",
+            metadata={"delivery_id": "delivery-1"},
+        )
+    )
 
+    assert receipt.status is DeliveryStatus.SUCCESS
     assert runtime.events[-1]["payload"] == {
         "content": "该休息一下了",
         "attachments": [],
@@ -2108,4 +2161,80 @@ async def test_proactive_metadata_sender_forwards_delivery_id(tmp_path: Path) ->
         "delivery_id": "delivery-1",
     }
     await channel.stop()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_proactive_attachment_commits_one_replayable_logical_message(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_ids = (uuid4().hex, uuid4().hex)
+    for device_id in device_ids:
+        _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    push = _PushTool()
+    upload_store = AttachmentStore(tmp_path / "uploads")
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=_Bus(),
+                session_manager=SessionManager(tmp_path / "workspace"),
+                event_bus=_EventBus(),
+                push_tool=push,
+                interrupt_controller=None,
+                attachment_store=upload_store,
+            ),
+        )
+    )
+    source = tmp_path / "photo.png"
+    source.write_bytes(b"png-payload")
+    chat_id = str(uuid4())
+    deliver = cast(Any, push.registered["mobile"]["deliver"])
+
+    receipt = await deliver(
+        ChannelMessage(
+            channel="mobile",
+            chat_id=chat_id,
+            content="看图",
+            attachments=(
+                ChannelAttachment(AttachmentKind.IMAGE, str(source)),
+            ),
+            metadata={"delivery_id": "delivery-with-image"},
+        )
+    )
+
+    assert receipt.status is DeliveryStatus.SUCCESS
+    assert len(receipt.canonical_media) == 1
+    assert receipt.canonical_media[0] != str(source)
+    assert Path(receipt.canonical_media[0]).read_bytes() == b"png-payload"
+    envelopes = []
+    for device_id in device_ids:
+        replay = storage.read_durable_events(
+            device_id,
+            after_event_seq=0,
+            limit=10,
+        )
+        assert len(replay) == 1
+        envelopes.append(json.loads(replay[0].envelope_json))
+    assert envelopes[0] == envelopes[1]
+    assert envelopes[0]["type"] == "message.proactive"
+    assert envelopes[0]["payload"]["content"] == "看图"
+    assert envelopes[0]["payload"]["delivery_id"] == "delivery-with-image"
+    assert len(envelopes[0]["payload"]["attachments"]) == 1
+
+    await channel.stop()
+    storage.close()
+
+    reopened = MobileRealtimeStorage(tmp_path / "mobile.db")
+    assert len(
+        reopened.read_durable_events(
+            device_ids[0],
+            after_event_seq=0,
+            limit=10,
+        )
+    ) == 1
+    reopened.close()
     storage.close()

--- a/tests/mobile_realtime/test_gateway.py
+++ b/tests/mobile_realtime/test_gateway.py
@@ -33,7 +33,9 @@ from bus.events_lifecycle import (
 from infra.channels.base import AttachmentStore
 from infra.mobile_realtime.attachments import (
     AttachmentChunk,
+    AttachmentTransferService,
     MAX_ATTACHMENT_CHUNK_BYTES,
+    attachment_descriptor,
     decode_attachment_chunk,
     encode_attachment_chunk,
 )
@@ -52,6 +54,67 @@ from infra.mobile_realtime.plugin_ui_http import (
 from infra.mobile_realtime.protocol import AttachmentDownloadCommand, parse_frame
 from infra.mobile_realtime.storage import DeviceRecord
 from session.manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_gateway_atomically_publishes_proactive_attachment(
+    tmp_path: Path,
+) -> None:
+    runtime, _keyset = build_mobile_gateway_runtime(
+        _config(),
+        tmp_path,
+        master_keys=_EphemeralMasterKeys(),
+    )
+    device_id = uuid4().hex
+    runtime.storage.register_device(
+        DeviceRecord(
+            device_id=device_id,
+            public_key="test-public-key",
+            display_name="Pixel",
+            created_at=datetime.now(timezone.utc),
+            revoked_at=None,
+            capabilities=("attachments",),
+        )
+    )
+    source = tmp_path / "report.pdf"
+    source.write_bytes(b"report")
+    service = AttachmentTransferService(
+        runtime.storage,
+        AttachmentStore(tmp_path / "uploads"),
+        max_attachment_bytes=1024,
+    )
+    candidates = service.snapshot_outbound_batch(
+        session_id="mobile:session-1",
+        local_media_paths=(source,),
+    )
+    try:
+        resolved = await runtime.publish_event_with_outbound_attachments(
+            candidates=candidates,
+            session_id="mobile:session-1",
+            payload_builder=lambda records: {
+                "content": "报告",
+                "attachments": [
+                    attachment_descriptor(record) for record in records
+                ],
+                "metadata": {"source": "message_push"},
+                "delivery_id": "delivery-1",
+            },
+        )
+
+        replay = runtime.storage.read_durable_events(
+            device_id,
+            after_event_seq=0,
+            limit=10,
+        )
+        assert len(resolved) == 1
+        assert runtime.storage.read_attachment(resolved[0].attachment_id) == resolved[0]
+        assert len(replay) == 1
+        envelope = json.loads(replay[0].envelope_json)
+        assert envelope["payload"]["attachments"][0]["attachment_id"] == (
+            resolved[0].attachment_id
+        )
+    finally:
+        runtime.close()
 
 
 class _ControlledWebSocket:

--- a/tests/proactive_v2/conftest.py
+++ b/tests/proactive_v2/conftest.py
@@ -17,6 +17,7 @@ from plugins.proactive_flow.tools import ToolDeps
 from agent.looping.ports import SessionServices
 from agent.turns.orchestrator import TurnOrchestrator, TurnOrchestratorDeps
 from agent.turns.outbound import OutboundDispatch
+from bus.events import DeliveryReceipt, DeliveryStatus
 
 
 # ── FakeStateStore ────────────────────────────────────────────────────────
@@ -267,8 +268,11 @@ def make_proactive_pipeline(
         presence=cast(Any, SimpleNamespace(record_proactive_sent=lambda _key: None)),
     )
     class _Outbound:
-        async def dispatch(self, outbound: OutboundDispatch) -> bool:
-            return await sender.send(outbound.content)
+        async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
+            sent = await sender.send(outbound.content)
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS if sent else DeliveryStatus.FAILED
+            )
 
     orchestrator = TurnOrchestrator(
         TurnOrchestratorDeps(

--- a/tests/proactive_v2/test_drift.py
+++ b/tests/proactive_v2/test_drift.py
@@ -24,6 +24,7 @@ from agent.tools.unified_exec import ShellProcessManager, UnknownExecutionError
 from agent.looping.ports import SessionServices
 from agent.turns.orchestrator import TurnOrchestrator, TurnOrchestratorDeps
 from agent.turns.outbound import OutboundDispatch
+from bus.events import DeliveryReceipt, DeliveryStatus
 from plugins.default_proactive.context import AgentTickContext
 from plugins.drift_flow.runtime import DriftTurnPipeline, DriftTurnPipelineDeps
 from plugins.drift_flow.state import DriftStateStore
@@ -1625,8 +1626,11 @@ async def test_agent_tick_drift_emits_delivery_result(
     )
 
     class _Outbound:
-        async def dispatch(self, outbound: OutboundDispatch) -> bool:
-            return await sender(outbound.content)
+        async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
+            sent = await sender(outbound.content)
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS if sent else DeliveryStatus.FAILED
+            )
 
     orchestrator = TurnOrchestrator(
         TurnOrchestratorDeps(

--- a/tests/test_agent_core_p5_agent_core.py
+++ b/tests/test_agent_core_p5_agent_core.py
@@ -8,16 +8,22 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from agent.context import ContextBuilder
-from agent.core.passive_turn import ContextStore, Reasoner
+from agent.core.passive_turn import ContextStore, Reasoner, _NoopOutboundPort
 from agent.core.runtime_support import SessionLike, TurnRunResult
 from agent.core.passive_support import predict_current_user_source_ref
 from agent.core.passive_turn import AgentCore, AgentCoreDeps
 from agent.core.types import ContextBundle
 from agent.looping.ports import SessionServices
 from agent.tools.registry import ToolRegistry
-from agent.turns.outbound import OutboundPort
+from agent.turns.outbound import OutboundDispatch, OutboundPort
 from bus.event_bus import EventBus
-from bus.events import InboundMessage, OutboundMessage, TurnDisposition
+from bus.events import (
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+    TurnDisposition,
+)
 from agent.lifecycle.types import BeforeReasoningCtx, BeforeTurnCtx
 from session.manager import SessionManager
 
@@ -51,6 +57,18 @@ class _DummySession:
         message = {"role": role, "content": content, **kwargs}
         self.messages.append(message)
         return message
+
+
+@pytest.mark.asyncio
+async def test_noop_outbound_port_returns_failed_receipt() -> None:
+    receipt = await _NoopOutboundPort().dispatch(
+        OutboundDispatch(channel="mobile", chat_id="device", content="hello")
+    )
+
+    assert receipt == DeliveryReceipt(
+        DeliveryStatus.FAILED,
+        detail="未配置出站投递端口",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_channel_host.py
+++ b/tests/test_channel_host.py
@@ -9,6 +9,7 @@ from agent.tools.message_push import MessagePushTool
 from bootstrap.channel_host import ChannelHost
 from bootstrap.app import AppRuntime
 from bus.event_bus import EventBus
+from bus.events import ChannelMessage, DeliveryReceipt, DeliveryStatus
 from bus.queue import MessageBus
 
 
@@ -77,12 +78,12 @@ class _RegisteredChannel:
         async def on_outbound(_message: object) -> None:
             return None
 
-        async def send_text(_chat_id: str, _message: str) -> None:
-            return None
+        async def deliver(_message: ChannelMessage) -> DeliveryReceipt:
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
         ctx.event_bus.on(_Event, lambda event: event)
         ctx.bus.subscribe_outbound(self.name, on_outbound)
-        ctx.push_tool.register_channel(self.name, text=send_text)
+        ctx.push_tool.register_channel(self.name, deliver=deliver)
         if self._fail_start:
             raise RuntimeError("registered start failed")
 
@@ -277,7 +278,7 @@ async def test_channel_host_revokes_shared_registrations_on_stop():
         channel="registered",
         chat_id="1",
         message="hello",
-    ) == "文本已发送"
+    ) == "消息已发送"
 
     await host.stop_all()
 
@@ -326,7 +327,7 @@ async def test_channel_host_restores_shared_registrations_after_failed_swap():
         channel="registered",
         chat_id="1",
         message="hello",
-    ) == "文本已发送"
+    ) == "消息已发送"
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -18,7 +18,12 @@ from agent.core.types import ContextBundle
 from agent.lifecycle.phase import Phase
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+)
 from bus.events_lifecycle import TurnCommitted
 from agent.lifecycle.types import (
     AfterReasoningCtx,
@@ -142,8 +147,8 @@ class _MemoryStatusPluginModule:
 
 
 class _DummyOutbound:
-    async def dispatch(self, outbound: OutboundDispatch) -> bool:
-        return True
+    async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
+        return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
 
 class _KVCachePluginModule:

--- a/tests/test_replay_debug.py
+++ b/tests/test_replay_debug.py
@@ -54,7 +54,7 @@ async def test_capture_channel_records_replay_time(tmp_path, monkeypatch) -> Non
     result = await push.execute(channel="replay", chat_id="user", message="hello")
     await channel.stop()
 
-    assert result == "文本已发送"
+    assert result == "消息已发送"
     report = status(layout)
     assert report["outbox_messages"] == 1
     assert report["latest_outbound"]["message"] == "hello"

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -8,6 +8,8 @@ from typing import cast, Any
 
 import pytest
 
+from bus.events import ChannelMessage, DeliveryReceipt, DeliveryStatus
+
 import main
 from bootstrap import app as bootstrap_app
 from bootstrap import init_workspace as workspace_init
@@ -935,11 +937,11 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
             starts.append("telegram")
             ctx.push_tool.register_channel(
                 self.name,
-                text=self.send,
-                stream_text=self.send_stream,
-                file=self.send_file,
-                image=self.send_image,
+                deliver=self.deliver,
             )
+
+        async def deliver(self, _message: ChannelMessage) -> DeliveryReceipt:
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
         async def stop(self) -> None:
             starts.append("telegram.stop")
@@ -966,10 +968,11 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
             starts.append("qq")
             ctx.push_tool.register_channel(
                 self.name,
-                text=self.send,
-                file=self.send_file,
-                image=self.send_image,
+                deliver=self.deliver,
             )
+
+        async def deliver(self, _message: ChannelMessage) -> DeliveryReceipt:
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
         async def stop(self) -> None:
             starts.append("qq.stop")
@@ -990,7 +993,10 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
             starts.append("plugin")
             attachment_roots.append(ctx.attachment_store.root)
             mobile_catalogs.append(ctx.mobile_bot_commands)
-            ctx.push_tool.register_channel(self.name, text=self.send)
+            ctx.push_tool.register_channel(self.name, deliver=self.deliver)
+
+        async def deliver(self, _message: ChannelMessage) -> DeliveryReceipt:
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
         async def stop(self) -> None:
             starts.append("plugin.stop")
@@ -1042,9 +1048,9 @@ async def test_start_channels_wires_telegram_qq_and_plugin(
         telegram, qq, plugin = host.channels
         assert starts == ["telegram", "qq", "plugin"]
         assert registrations == [
-            ("telegram", ["file", "image", "stream_text", "text"]),
-            ("qq", ["file", "image", "text"]),
-            ("plugin", ["text"]),
+            ("telegram", ["deliver"]),
+            ("qq", ["deliver"]),
+            ("plugin", ["deliver"]),
         ]
         assert telegram.kwargs["event_bus"] is event_bus
         assert telegram.kwargs["interrupt_controller"] is controller

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -21,15 +21,48 @@ from agent.tools.memorize import MemorizeTool
 from agent.tools.message_push import MessagePushTool
 from agent.tools.registry import ToolMeta, ToolRegistry
 from agent.tools.web_search import WebSearchTool
-from bus.events import InboundMessage, OutboundMessage
+from bus.events import (
+    ChannelMessage,
+    DeliveryReceipt,
+    DeliveryStatus,
+    InboundMessage,
+    OutboundMessage,
+)
 from bus.queue import ChatLane, MessageBus
 from core.common import timekit
+from infra.channels.delivery import deliver_message_parts
 from infra.persistence.json_store import atomic_save_json, load_json, save_json
 from memory2.memorizer import Memorizer
 from memory2.store import MemoryStore2
 from plugins.default_memory.engine import DefaultMemoryEngine
 from prompts.agent import build_agent_behavior_rules_prompt
 from prompts.completion import VERIFIABLE_COMPLETION_RULES
+
+
+def _register_text_channel(
+    tool: MessagePushTool,
+    channel: str,
+    sender: Any,
+) -> None:
+    async def unsupported_file(
+        _chat_id: str,
+        _path: str,
+        _name: str | None,
+    ) -> None:
+        raise AssertionError("text-only 测试不应发送文件")
+
+    async def unsupported_image(_chat_id: str, _path: str) -> None:
+        raise AssertionError("text-only 测试不应发送图片")
+
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        return await deliver_message_parts(
+            message,
+            send_text=sender,
+            send_file=unsupported_file,
+            send_image=unsupported_image,
+        )
+
+    _ = tool.register_channel(channel, deliver=deliver)
 
 
 def test_inbound_message_default_timestamp_is_aware_utc() -> None:
@@ -126,13 +159,15 @@ async def test_message_push_tool_covers_success_failure_and_fallbacks():
     async def image(chat_id: str, path: str) -> None:
         sent["image"].append((chat_id, path))
 
-    tool.register_channel(
-        "telegram",
-        text=text,
-        stream_text=stream_text,
-        file=file,
-        image=image,
-    )
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        return await deliver_message_parts(
+            message,
+            send_text=stream_text,
+            send_file=file,
+            send_image=image,
+        )
+
+    _ = tool.register_channel("telegram", deliver=deliver)
     result = await tool.execute(
         channel="telegram",
         chat_id=123,
@@ -141,9 +176,7 @@ async def test_message_push_tool_covers_success_failure_and_fallbacks():
         image="https://img",
     )
 
-    assert "文本已发送" in result
-    assert "文件 'demo.txt' 已发送" in result
-    assert "图片已发送" in result
+    assert result == "消息已发送"
     assert sent["text"] == []
     assert sent["stream_text"] == [("123", "hello")]
     assert sent["file"] == [("123", "/tmp/demo.txt", "demo.txt")]
@@ -154,40 +187,47 @@ async def test_message_push_tool_covers_success_failure_and_fallbacks():
     )
     assert "未注册" in await tool.execute(channel="qq", chat_id=1, message="x")
 
-    tool.register_channel("limited", text=text)
+    async def unsupported_file(
+        _chat_id: str,
+        _path: str,
+        _name: str | None,
+    ) -> None:
+        raise RuntimeError("渠道 'limited' 不支持发送文件")
+
+    async def unsupported_image(_chat_id: str, _path: str) -> None:
+        raise RuntimeError("渠道 'limited' 不支持发送图片")
+
+    async def limited_deliver(message: ChannelMessage) -> DeliveryReceipt:
+        return await deliver_message_parts(
+            message,
+            send_text=text,
+            send_file=unsupported_file,
+            send_image=unsupported_image,
+        )
+
+    _ = tool.register_channel("limited", deliver=limited_deliver)
     limited = await tool.execute(
         channel="limited", chat_id=1, file="/tmp/a.txt", image="/tmp/a.png"
     )
     assert "不支持发送文件" in limited
-    assert "不支持发送图片" in limited
 
     async def broken(chat_id: str, message: str) -> None:
         raise RuntimeError("send failed")
 
-    tool.register_channel("broken", text=broken)
+    _register_text_channel(tool, "broken", broken)
     assert "发送失败" in await tool.execute(channel="broken", chat_id=1, message="x")
 
 
 @pytest.mark.asyncio
 async def test_message_push_routes_internal_metadata_only_to_capable_sender():
     tool = MessagePushTool()
-    calls: list[tuple[str, str, dict[str, object]]] = []
+    calls: list[ChannelMessage] = []
 
-    async def text(_chat_id: str, _message: str) -> None:
-        raise AssertionError("metadata-capable sender should own this dispatch")
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        calls.append(message)
+        return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
-    async def text_with_metadata(
-        chat_id: str,
-        message: str,
-        metadata: dict[str, object],
-    ) -> None:
-        calls.append((chat_id, message, metadata))
-
-    tool.register_channel(
-        "mobile",
-        text=text,
-        text_with_metadata=text_with_metadata,
-    )
+    _ = tool.register_channel("mobile", deliver=deliver)
 
     result = await tool.execute(
         channel="mobile",
@@ -196,8 +236,49 @@ async def test_message_push_routes_internal_metadata_only_to_capable_sender():
         _outbound_metadata={"delivery_id": "delivery-1"},
     )
 
-    assert result == "文本已发送"
-    assert calls == [("123", "hello", {"delivery_id": "delivery-1"})]
+    assert result == "消息已发送"
+    assert calls[0].chat_id == "123"
+    assert calls[0].content == "hello"
+    assert calls[0].metadata == {"delivery_id": "delivery-1"}
+
+
+@pytest.mark.asyncio
+async def test_message_push_reports_partial_after_text_commit() -> None:
+    tool = MessagePushTool()
+    committed: list[str] = []
+
+    async def text(_chat_id: str, message: str) -> None:
+        committed.append(message)
+
+    async def file(
+        _chat_id: str,
+        _path: str,
+        _name: str | None,
+    ) -> None:
+        raise OSError("attachment unavailable")
+
+    async def image(_chat_id: str, _path: str) -> None:
+        raise AssertionError("测试消息没有图片")
+
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        return await deliver_message_parts(
+            message,
+            send_text=text,
+            send_file=file,
+            send_image=image,
+        )
+
+    _ = tool.register_channel("telegram", deliver=deliver)
+
+    result = await tool.execute(
+        channel="telegram",
+        chat_id="1",
+        message="正文",
+        file="/tmp/report.pdf",
+    )
+
+    assert result == "消息部分送达：attachment unavailable"
+    assert committed == ["正文"]
 
 
 @pytest.mark.asyncio
@@ -216,7 +297,7 @@ async def test_message_push_non_passive_waits_for_passive_reply():
         events.append(f"non_passive:{message}")
 
     bus.subscribe_outbound("cli", on_outbound)
-    tool.register_channel("cli", text=text)
+    _register_text_channel(tool, "cli", text)
     dispatch_task = asyncio.create_task(bus.dispatch_outbound())
     try:
         inbound = InboundMessage(
@@ -245,7 +326,7 @@ async def test_message_push_non_passive_waits_for_passive_reply():
 
         result = await asyncio.wait_for(push_task, timeout=1)
 
-        assert "文本已发送" in result
+        assert result == "消息已发送"
         assert events == [
             "passive:start:reply",
             "passive:end:reply",
@@ -267,7 +348,7 @@ async def test_message_push_non_passive_resumes_after_silent_passive_turn():
     async def text(chat_id: str, message: str) -> None:
         events.append(message)
 
-    tool.register_channel("cli", text=text)
+    _register_text_channel(tool, "cli", text)
     inbound = InboundMessage(
         channel="cli",
         sender="user",
@@ -289,7 +370,7 @@ async def test_message_push_non_passive_resumes_after_silent_passive_turn():
     await bus.complete_inbound(inbound)
     result = await asyncio.wait_for(push_task, timeout=1)
 
-    assert "文本已发送" in result
+    assert result == "消息已发送"
     assert events == ["scheduler"]
 
 
@@ -306,7 +387,7 @@ async def test_message_push_non_passive_same_chat_keeps_fifo_order():
             await release_first.wait()
         events.append(f"end:{message}")
 
-    tool.register_channel("cli", text=text)
+    _register_text_channel(tool, "cli", text)
     first = asyncio.create_task(
         tool.execute(
             channel="cli",
@@ -393,7 +474,7 @@ async def test_message_push_default_call_waits_for_passive_lane():
     async def text(chat_id: str, message: str) -> None:
         events.append(message)
 
-    tool.register_channel("cli", text=text)
+    _register_text_channel(tool, "cli", text)
     await bus.publish_inbound(
         InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
     )
@@ -409,7 +490,7 @@ async def test_message_push_default_call_waits_for_passive_lane():
     )
     result = await asyncio.wait_for(push_task, timeout=1)
 
-    assert "文本已发送" in result
+    assert result == "消息已发送"
     assert events == ["inline"]
 
 
@@ -422,7 +503,7 @@ async def test_message_push_passive_role_does_not_wait_for_passive_lane():
     async def text(chat_id: str, message: str) -> None:
         events.append(message)
 
-    tool.register_channel("cli", text=text)
+    _register_text_channel(tool, "cli", text)
     await bus.publish_inbound(
         InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
     )
@@ -437,7 +518,7 @@ async def test_message_push_passive_role_does_not_wait_for_passive_lane():
         timeout=1,
     )
 
-    assert "文本已发送" in result
+    assert result == "消息已发送"
     assert events == ["inline"]
 
 

--- a/tests/turns/test_orchestrator.py
+++ b/tests/turns/test_orchestrator.py
@@ -10,6 +10,7 @@ from agent.looping.ports import SessionServices
 from agent.turns.orchestrator import TurnOrchestrator, TurnOrchestratorDeps
 from agent.turns.outbound import OutboundDispatch, PushToolOutboundPort
 from agent.turns.result import TurnOutbound, TurnResult, TurnTrace
+from bus.events import DeliveryReceipt, DeliveryStatus
 
 
 class _DummySession:
@@ -39,9 +40,9 @@ async def test_orchestrator_skip_runs_side_effects_without_dispatch():
             order.append("side_effect")
 
     class _Outbound:
-        async def dispatch(self, outbound: OutboundDispatch) -> bool:
+        async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
             order.append("dispatch")
-            return True
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
     orchestrator = TurnOrchestrator(
         TurnOrchestratorDeps(
@@ -83,14 +84,14 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
             order.append(self._name)
 
     class _Outbound:
-        async def dispatch(self, outbound: OutboundDispatch) -> bool:
+        async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
             order.append("dispatch")
             assert outbound.content == "hello"
             delivery_id = outbound.metadata["delivery_id"]
             assert isinstance(delivery_id, str)
             assert len(delivery_id) == 32
             dispatched_delivery_ids.append(delivery_id)
-            return True
+            return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
     presence = SimpleNamespace(record_proactive_sent=lambda _key: order.append("presence"))
     session_manager = SimpleNamespace(
@@ -140,7 +141,9 @@ async def test_orchestrator_failed_dispatch_does_not_persist_proactive_message()
         get_or_create=lambda _key: session,
         append_messages=AsyncMock(return_value=None),
     )
-    outbound = SimpleNamespace(dispatch=AsyncMock(return_value=False))
+    outbound = SimpleNamespace(
+        dispatch=AsyncMock(return_value=DeliveryReceipt(DeliveryStatus.FAILED))
+    )
     orchestrator = TurnOrchestrator(
         TurnOrchestratorDeps(
             session=SessionServices(
@@ -167,9 +170,53 @@ async def test_orchestrator_failed_dispatch_does_not_persist_proactive_message()
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_partial_dispatch_does_not_persist_proactive_message():
+    session = _DummySession("telegram:123")
+    session_manager = SimpleNamespace(
+        get_or_create=lambda _key: session,
+        append_messages=AsyncMock(return_value=None),
+    )
+    outbound = SimpleNamespace(
+        dispatch=AsyncMock(
+            return_value=DeliveryReceipt(
+                DeliveryStatus.PARTIAL,
+                detail="attachment unavailable",
+            )
+        )
+    )
+    orchestrator = TurnOrchestrator(
+        TurnOrchestratorDeps(
+            session=SessionServices(
+                session_manager=cast(Any, session_manager),
+                presence=None,
+            ),
+            outbound=cast(Any, outbound),
+        )
+    )
+
+    sent = await orchestrator.handle_proactive_turn(
+        result=TurnResult(
+            decision="reply",
+            outbound=TurnOutbound(
+                session_key="telegram:123",
+                content="正文",
+                media=["/tmp/report.pdf"],
+            ),
+        ),
+        session_key="telegram:123",
+        channel="telegram",
+        chat_id="123",
+    )
+
+    assert sent is False
+    assert session.messages == []
+    session_manager.append_messages.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_push_outbound_port_propagates_unexpected_tool_error():
     push_tool = SimpleNamespace(
-        execute=AsyncMock(side_effect=RuntimeError("channel disconnected"))
+        dispatch=AsyncMock(side_effect=RuntimeError("channel disconnected"))
     )
     port = PushToolOutboundPort(push_tool)
 
@@ -185,7 +232,11 @@ async def test_push_outbound_port_propagates_unexpected_tool_error():
 
 @pytest.mark.asyncio
 async def test_push_outbound_port_forwards_internal_metadata():
-    push_tool = SimpleNamespace(execute=AsyncMock(return_value="文本已发送"))
+    push_tool = SimpleNamespace(
+        dispatch=AsyncMock(
+            return_value=DeliveryReceipt(DeliveryStatus.SUCCESS)
+        )
+    )
     port = PushToolOutboundPort(push_tool)
 
     sent = await port.dispatch(
@@ -197,14 +248,12 @@ async def test_push_outbound_port_forwards_internal_metadata():
         )
     )
 
-    assert sent is True
-    push_tool.execute.assert_awaited_once_with(
-        channel="mobile",
-        chat_id="123",
-        message="hello",
-        image=None,
-        _outbound_metadata={"delivery_id": "delivery-1"},
-    )
+    assert sent.status is DeliveryStatus.SUCCESS
+    pushed = push_tool.dispatch.await_args.args[0]
+    assert pushed.channel == "mobile"
+    assert pushed.chat_id == "123"
+    assert pushed.content == "hello"
+    assert pushed.metadata == {"delivery_id": "delivery-1"}
 
 
 @pytest.mark.asyncio
@@ -263,9 +312,12 @@ async def test_orchestrator_proactive_reply_dispatches_media():
     dispatched: list[OutboundDispatch] = []
 
     class _Outbound:
-        async def dispatch(self, outbound: OutboundDispatch) -> bool:
+        async def dispatch(self, outbound: OutboundDispatch) -> DeliveryReceipt:
             dispatched.append(outbound)
-            return True
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS,
+                canonical_media=("/stable/meme.png",),
+            )
 
     session_manager = SimpleNamespace(
         get_or_create=lambda _key: session,
@@ -294,4 +346,4 @@ async def test_orchestrator_proactive_reply_dispatches_media():
 
     assert sent is True
     assert dispatched[0].media == ["/tmp/meme.png"]
-    assert session.messages[0]["media"] == ["/tmp/meme.png"]
+    assert session.messages[0]["media"] == ["/stable/meme.png"]

--- a/tests/turns/test_outbound.py
+++ b/tests/turns/test_outbound.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from agent.turns.outbound import BusOutboundPort, OutboundDispatch
-from bus.events import OutboundMessage
+from bus.events import DeliveryStatus, OutboundMessage
 from bus.queue import MessageBus
 
 
@@ -24,7 +24,7 @@ async def test_bus_outbound_port_publishes_typed_message() -> None:
     )
     message = await bus._outbound.get()
 
-    assert sent is True
+    assert sent.status is DeliveryStatus.SUCCESS
     assert message == OutboundMessage(
         channel="telegram",
         chat_id="123",


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`message_push` 按正文与媒体拆分发送、依赖字符串判断成功，Mobile 主动附件缺少单次原子提交与统一回执。
- 用户可见结果：Telegram、QQ、Web、Mobile 都按完整逻辑消息投递；Mobile 正文与附件以单个 durable event 进入所有目标设备，失败或部分成功不会误写主动历史。
- 本 PR 不处理：Android 客户端改造、附件自动 GC、协议新增字段；现有 Mobile 描述符、下载、缓存、预览和分享链路已满足合同。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：渠道 adapter、主动投递、Mobile realtime、SessionDB 历史投影
- `runtime_patch`：`required`
- `runtime_patch_reason`：Core 消息 DTO、渠道注册与 Mobile 投递路径发生变化，需要进程重启加载
- `authoritative_state_owner`：Core outbound delivery contract；Mobile storage 拥有 durable inbox 与附件记录
- `client_only_alternative`：客户端无法修复 Core 的拆分提交、部分送达和历史误提交
- 关联不变量：OUT-001～OUT-003、RUN-001～RUN-003、MOB-001、MOB-005、SES-005～SES-006
- `protected_state`：SessionDB messages、Mobile attachment records、durable inbox
- 允许的副作用：成功投递时追加消息历史；Mobile 在单个 SQLite 事务中追加附件记录与目标设备 inbox
- 禁止的副作用：失败或部分送达时追加主动历史；临时展示或候选附件反向改写权威事实；修改正式 workspace

## 改动范围

- 主要文件：`bus/events.py`、`agent/tools/message_push.py`、`agent/turns/outbound.py`、`infra/channels/delivery.py`、`infra/mobile_realtime/{attachments,channel,gateway,storage}.py`
- 配置或迁移影响：无配置项、无数据库迁移；复用现有表与 wire event 结构
- 已知 schema lineage 与最终 schema identity：新增 Core 内部 typed DTO/receipt；Mobile wire 保持现有 `message` event 与 attachment descriptors
- 协议 source、runtime、provider 与 scenario 的不可变 revision：合同 `7c4bd214b658a42e583c9f465676c585094aed04`，实现 `1b0d1ef4dc10f5ae1830d909511dd7f1d376ba68`
- 回滚方式：revert 本 PR 的 squash commit；回滚点 `backup/mobile-message-push-implementation-pre-contract-merge-20260801`

## 验证

- [x] 相关 targeted tests 已通过：`282 passed`。
- [x] Python 类型检查已通过：相关变更文件 Pyright `0 errors`；前端不适用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`5e07b5b79ee95efaf10707d113a39a081e4ee87302759de78460559caea03aae`
- `planDigest`：`0e25c58d54e8ae3e9e56326afd2e6772650e4a6d169708a527cfe20416dc040c`
- `private-contract-gate`：`pending_maintainer`
- 真实设备证据：未改 Android 或 wire schema；本 PR 以 Core/Mobile gateway 的原子事务、重启重放和多设备测试为边界证据。
- 未运行项与原因：私有 Gate 需要维护者私有 provider identity；未做生产设备升级或服务重启。

## 工作手册

- [x] 已核对 `projectneed.md`、决策 0016、相关设计和 `NOW.md`。
- [x] 长期语义变化已在 Babel 设计流程中获得维护者确认，并由 #286 先行合入合同。
- [x] 已按 MOB-001 核对能力 owner；权威投递语义属于 Core，客户端保持现有协议。
- [x] 当前没有对应 `NOW.md` 事项。
