### PR TITLE
ci: 锁定外部渠道 host 合同

### DIFF
--- a/.github/workflows/plugin-api-v2.yml
+++ b/.github/workflows/plugin-api-v2.yml
@@ -41,6 +41,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - name: Install host channel contract dependencies
+        run: python -m pip install -r requirements.txt pytest pytest-asyncio
       - name: Verify locked external plugins in Docker Debug
         run: python docker/debug/plugin_api_v2_gate.py --require-clean-core
       - name: Upload Plugin API v2 evidence

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -260,6 +260,8 @@ GitHub HTTPS 地址获取这些对象，不读取宿主插件 cache、正式 wor
 │  ├─ 拒绝 API v1 / initialize
 │  ├─ prepare 不得取得 data_dir 或启动 task
 │  └─ lifecycle task 必须归 generation scope
+├─ Host 渠道合同
+│  └─ 固定 Feishu / QQBot 在当前 Core 上执行启动与完整消息投递测试
 └─ Docker Debug
    ├─ atomic-reload   失败保旧、成功原子切换、WAL 完成
    ├─ all-plugins     19 个可运行插件逐个热重载和禁用

--- a/docker/debug/plugin-api-v2.lock.json
+++ b/docker/debug/plugin-api-v2.lock.json
@@ -44,7 +44,7 @@
     {
       "id": "feishu",
       "repository": "https://github.com/akashic-plugins/feishu",
-      "commit": "b33bf07c4d791201e2fbcb8c889fd095e382ce7b"
+      "commit": "071278d518aea0ac80bcc76d9346e5bb02d93df1"
     },
     {
       "id": "fitbit-mcp",
@@ -79,7 +79,7 @@
     {
       "id": "qqbot",
       "repository": "https://github.com/akashic-plugins/qqbot",
-      "commit": "97234e9fac0007356300d1411c8432060efb883c"
+      "commit": "d9d105515db9e63f3639968fd488904f230be95b"
     },
     {
       "id": "setup_helper",

--- a/docker/debug/plugin_api_v2_gate.py
+++ b/docker/debug/plugin_api_v2_gate.py
@@ -22,6 +22,7 @@ DEFAULT_REPORT = (
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 REPOSITORY_PATTERN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 RUNTIME_PHASES = ("atomic-reload", "all-plugins", "fitbit")
+HOST_CHANNEL_CONTRACT_PLUGIN_IDS = ("feishu", "qqbot")
 EXPECTED_PLUGIN_IDS = {
     "calendar-mcp",
     "citation",
@@ -103,6 +104,14 @@ def main() -> int:
             report["static_contract"] = static_report
             if static_report["returncode"] != 0:
                 raise RuntimeError("Plugin API v2 静态合同失败")
+
+            host_channel_report = _run_host_channel_contract(
+                plugin_root=plugin_root,
+                report_dir=report_path.parent,
+            )
+            report["host_channel_contract"] = host_channel_report
+            if host_channel_report["returncode"] != 0:
+                raise RuntimeError("外部渠道 Host 合同失败")
 
             phase_reports = cast(dict[str, object], report["runtime_phases"])
             for phase in RUNTIME_PHASES:
@@ -285,6 +294,54 @@ def _run_runtime_phase(
         "returncode": result.returncode,
         "report": output_path.name,
         "sha256": hashlib.sha256(result.stdout.encode()).hexdigest(),
+    }
+
+
+def _run_host_channel_contract(
+    *,
+    plugin_root: Path,
+    report_dir: Path,
+) -> dict[str, object]:
+    """用当前 Core 接口运行锁定渠道仓库的启动与投递合同测试。"""
+
+    # 1. 每个仓库独立运行，避免同名测试模块互相污染
+    env = os.environ.copy()
+    env["AKASHIC_AGENT_ROOT"] = str(ROOT)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    outputs: list[str] = []
+    returncode = 0
+    for plugin_id in HOST_CHANNEL_CONTRACT_PLUGIN_IDS:
+        plugin_path = plugin_root / plugin_id
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "-p",
+                "no:cacheprovider",
+                "tests",
+            ],
+            cwd=plugin_path,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        outputs.append(f"===== {plugin_id} =====\n{result.stdout}")
+        if result.returncode != 0:
+            returncode = result.returncode
+
+    # 2. 保存可审计的固定组合结果
+    output = "\n".join(outputs)
+    output_path = report_dir / "host-channel-contract.log"
+    output_path.write_text(output, encoding="utf-8")
+    return {
+        "returncode": returncode,
+        "plugins": list(HOST_CHANNEL_CONTRACT_PLUGIN_IDS),
+        "report": output_path.name,
+        "sha256": hashlib.sha256(output.encode()).hexdigest(),
     }
 
 

--- a/tests/test_plugin_api_v2_gate.py
+++ b/tests/test_plugin_api_v2_gate.py
@@ -46,3 +46,15 @@ def test_release_lock_rejects_floating_reference(tmp_path: Path) -> None:
 
 def test_runtime_gate_uses_business_named_phases() -> None:
     assert gate.RUNTIME_PHASES == ("atomic-reload", "all-plugins", "fitbit")
+
+
+def test_host_channel_contract_covers_official_external_channels() -> None:
+    assert gate.HOST_CHANNEL_CONTRACT_PLUGIN_IDS == ("feishu", "qqbot")
+
+
+def test_release_lock_uses_host_contract_compatible_channel_commits() -> None:
+    release = gate._load_lock(gate.DEFAULT_LOCK)
+    commits = {plugin.id: plugin.commit for plugin in release.plugins}
+
+    assert commits["feishu"] == "071278d518aea0ac80bcc76d9346e5bb02d93df1"
+    assert commits["qqbot"] == "d9d105515db9e63f3639968fd488904f230be95b"


### PR DESCRIPTION
## 问题

Core 的 `MessagePushTool.register_channel` 合同变化后，现有 Plugin API v2 Gate 只在无渠道配置下加载外部插件，没有执行 Feishu/QQBot 的 `channel.start()`，因此旧 `text/stream_text/file/image` 参数未被 CI 捕获。

## 改动

- 将 Feishu、QQBot 发布锁更新到已通过 host 合同的合并提交
- 在固定插件组合检出后，用当前 Core 运行两个渠道仓库自带的启动与投递合同测试
- 将结果和哈希写入现有 Gate evidence
- CI 安装固定 host 测试所需依赖

## 验证

- `pytest -q -W error tests/test_plugin_api_v2_gate.py`: 6 passed
- Feishu/QQBot host channel contract against current Core: passed
- `pyright --level error docker/debug/plugin_api_v2_gate.py tests/test_plugin_api_v2_gate.py`: 0 errors
- workflow YAML parse and `git diff --check`: passed