### PR TITLE
test(gate): stage peer capability retirement

### DIFF
--- a/docker/debug/gate.py
+++ b/docker/debug/gate.py
@@ -57,6 +57,7 @@ class Group:
     priority: str
     requirements: tuple[str, ...]
     paths: tuple[str, ...]
+    deleted_paths: tuple[str, ...]
     depends_on: tuple[str, ...]
     scenarios: tuple[str, ...]
 
@@ -190,6 +191,11 @@ def _load_groups(data: dict[str, object]) -> dict[str, Group]:
             priority=cast(str, priority),
             requirements=_strings(item, "requirements", owner=f"groups.{group_id}"),
             paths=_strings(item, "paths", owner=f"groups.{group_id}"),
+            deleted_paths=_possibly_empty_strings(
+                item, "deleted_paths", owner=f"groups.{group_id}"
+            )
+            if "deleted_paths" in item
+            else (),
             depends_on=_optional_strings(
                 item, "depends_on", owner=f"groups.{group_id}"
             ),
@@ -362,7 +368,10 @@ def _groups_for_path(path: str, catalog: Catalog) -> set[str]:
     return {
         group.id
         for group in catalog.groups.values()
-        if any(_matches(path, pattern) for pattern in group.paths)
+        if any(
+            _matches(path, pattern)
+            for pattern in (*group.paths, *group.deleted_paths)
+        )
     }
 
 

--- a/tests/semantic/test_change_gate.py
+++ b/tests/semantic/test_change_gate.py
@@ -53,6 +53,18 @@ def test_unknown_executable_file_is_not_silently_accepted() -> None:
     assert gate._groups_for_path(mutant_path, catalog) == set()
 
 
+def test_deleted_path_contract_maps_live_and_removed_peer_files() -> None:
+    gate = _gate_module()
+    catalog = gate.load_catalog()
+
+    group = catalog.groups["companion_peer_removal"]
+
+    assert group.deleted_paths == ("agent/peer_agent/**",)
+    assert "companion_peer_removal" in gate._groups_for_path(
+        "agent/peer_agent/tool.py", catalog
+    )
+
+
 def test_change_classes_allow_single_class_and_reject_mixed_contract_changes() -> None:
     gate = _gate_module()
 

--- a/tests_scenarios/contracts/coverage-baseline.json
+++ b/tests_scenarios/contracts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "acceptedGaps": [],
   "base": "d627fa600781855770a5ede752f268982b68ebf9",
-  "catalogDigest": "9c2f0dc9c4bd4e62becbde6cd448e19038d18f61c92d19ad88ebcb027ab56fc5",
+  "catalogDigest": "214d8af95e0159e690c8e4422fc6a6a64a232aff4ee23e6a833a848dcfc9e6b1",
   "coveredP0": {
     "companion_peer_removal": [
       "contract_catalog"

--- a/tests_scenarios/contracts/coverage-baseline.json
+++ b/tests_scenarios/contracts/coverage-baseline.json
@@ -1,8 +1,11 @@
 {
   "acceptedGaps": [],
   "base": "d627fa600781855770a5ede752f268982b68ebf9",
-  "catalogDigest": "e554a27b0724a0d8aa3094d5689c7d006f90e471261c8d54343481217cce6225",
+  "catalogDigest": "9c2f0dc9c4bd4e62becbde6cd448e19038d18f61c92d19ad88ebcb027ab56fc5",
   "coveredP0": {
+    "companion_peer_removal": [
+      "contract_catalog"
+    ],
     "context_projection": [
       "context_history_nondestructive"
     ],

--- a/tests_scenarios/contracts/impact.toml
+++ b/tests_scenarios/contracts/impact.toml
@@ -192,7 +192,6 @@ paths = [
   "agent/core/**",
   "agent/llm_json.py",
   "agent/model_runtime/**",
-  "agent/peer_agent/**",
   "agent/persona.py",
   "agent/policies/**",
   "agent/provider.py",
@@ -257,6 +256,14 @@ priority = "p2"
 requirements = ["COM-001", "COM-004"]
 paths = ["frontend/**", "eslint.config.js"]
 depends_on = ["control"]
+scenarios = ["contract_catalog"]
+
+[groups.companion_peer_removal]
+priority = "p0"
+requirements = ["RUN-003", "ERR-001", "TST-001"]
+paths = ["agent/config.py"]
+deleted_paths = ["agent/peer_agent/**"]
+depends_on = ["runtime"]
 scenarios = ["contract_catalog"]
 
 [groups.sdk]


### PR DESCRIPTION
## Summary

- add a transitional `deleted_paths` owner to the public change-impact Gate
- keep live `agent/peer_agent/**` files mapped before removal and keep their deletion mapped afterward
- update the reviewed P0 coverage baseline without introducing downstream companion scenarios

## Why

Peer capability removal is a two-stage change. Removing the old runtime path rule first leaves live files unmapped; deleting production files first makes the old rule invalid. This contract layer establishes the deletion boundary before the pure production PR removes the capability.

## Verification

- `python docker/debug/gate.py audit` — passed
- `pytest -q tests/semantic/test_change_gate.py` — 12 passed
- `python docker/debug/gate.py run --base origin/main` — passed; report `20260801-204759-82ba1fca`
- `git diff --check origin/main..HEAD` — passed

## Stack

This is the first PR in the companion-security stack. PR #292 will be retargeted to this branch after publication.

## Private Gate

`required`; provider identity remains maintainer-private according to the public Gate contract.

## Rollback

Restore branch: `backup/companion-security-pr0-before-contract`.
