### PR TITLE
fix(security): bound wake reservoir and schedules

### DIFF
--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -35,6 +35,18 @@ from infra.persistence.json_store import atomic_save_json
 
 logger = logging.getLogger(__name__)
 _SCHEDULER_EXECUTION_CHANNEL = "scheduler"
+SCHEDULE_MAX_ACTIVE_JOBS = 10
+
+
+class ScheduleCapacityError(RuntimeError):
+    """表示新增任务会超过 workspace 全局活动任务上限。"""
+
+    code = "schedule_capacity_reached"
+
+    def __init__(self, *, active_jobs: int, max_active_jobs: int) -> None:
+        self.active_jobs = active_jobs
+        self.max_active_jobs = max_active_jobs
+        super().__init__(self.code)
 
 
 # ── LatencyTracker ───────────────────────────────────────────────
@@ -428,6 +440,7 @@ class SchedulerService:
     """
 
     GRACE_SECONDS = 300  # 5分钟内的 misfire 仍执行
+    MAX_ACTIVE_JOBS = SCHEDULE_MAX_ACTIVE_JOBS
 
     def __init__(
         self,
@@ -488,6 +501,17 @@ class SchedulerService:
             job.fire_at = job.fire_at.replace(tzinfo=timezone.utc)
         candidate = dict(self._jobs)
         candidate[job.id] = job
+        active_jobs = sum(
+            1 for current_job in self._jobs.values() if current_job.enabled
+        )
+        candidate_active_jobs = sum(
+            1 for candidate_job in candidate.values() if candidate_job.enabled
+        )
+        if candidate_active_jobs > self.MAX_ACTIVE_JOBS:
+            raise ScheduleCapacityError(
+                active_jobs=active_jobs,
+                max_active_jobs=self.MAX_ACTIVE_JOBS,
+            )
         self._commit_jobs(candidate)
         logger.info(
             f"Job added: {job.id[:8]} tier={job.tier} trigger={job.trigger} "

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -458,6 +458,7 @@ class SchedulerService:
         self.tracker = tracker or LatencyTracker()
         self._now = _now_fn or (lambda: datetime.now(timezone.utc))
         self._jobs: dict[str, ScheduledJob] = {}
+        self._persisted_jobs: dict[str, ScheduledJob] | None = None
         self._in_flight: set[str] = set()
         self._tasks: set[asyncio.Task[None]] = set()
         self._background_error: BaseException | None = None
@@ -499,10 +500,11 @@ class SchedulerService:
         # 确保 fire_at 带有 UTC 时区
         if job.fire_at.tzinfo is None:
             job.fire_at = job.fire_at.replace(tzinfo=timezone.utc)
-        candidate = dict(self._jobs)
+        current = self._current_persisted_jobs()
+        candidate = dict(current)
         candidate[job.id] = job
         active_jobs = sum(
-            1 for current_job in self._jobs.values() if current_job.enabled
+            1 for current_job in current.values() if current_job.enabled
         )
         candidate_active_jobs = sum(
             1 for candidate_job in candidate.values() if candidate_job.enabled
@@ -519,17 +521,17 @@ class SchedulerService:
         )
 
     def cancel_job(self, job_id: str) -> bool:
-        if job_id not in self._jobs:
+        candidate = self._current_persisted_jobs()
+        if job_id not in candidate:
             return False
-        candidate = dict(self._jobs)
         del candidate[job_id]
         self._commit_jobs(candidate)
         return True
 
     def cancel_job_by_name(self, name: str) -> list[str]:
-        cancelled = [jid for jid, j in self._jobs.items() if j.name == name]
+        candidate = self._current_persisted_jobs()
+        cancelled = [jid for jid, j in candidate.items() if j.name == name]
         if cancelled:
-            candidate = dict(self._jobs)
             for jid in cancelled:
                 del candidate[jid]
             self._commit_jobs(candidate)
@@ -537,6 +539,16 @@ class SchedulerService:
 
     def list_jobs(self) -> list[ScheduledJob]:
         return list(self._jobs.values())
+
+    def match_job_ids(self, id_or_prefix: str) -> list[str]:
+        """按完整 ID 或前缀匹配持久集合中的任务。"""
+
+        jobs = self._current_persisted_jobs()
+        return [
+            job_id
+            for job_id in jobs
+            if job_id == id_or_prefix or job_id.startswith(id_or_prefix)
+        ]
 
     def load_and_recover(self) -> None:
         """启动时加载持久化 jobs，处理 misfire。"""
@@ -582,6 +594,7 @@ class SchedulerService:
 
         if persistence_changed:
             self.store.save(persisted)
+        self._persisted_jobs = persisted
         self._jobs = recovered
         logger.info(f"SchedulerService recovered {count_loaded} jobs")
 
@@ -631,7 +644,17 @@ class SchedulerService:
         """先持久化候选状态，再提交内存中的任务映射。"""
 
         self.store.save(jobs)
-        self._jobs = jobs
+        self._persisted_jobs = dict(jobs)
+        self._jobs = {
+            job_id: job for job_id, job in jobs.items() if job.enabled
+        }
+
+    def _current_persisted_jobs(self) -> dict[str, ScheduledJob]:
+        """返回包含禁用记录的持久集合，尚未建立 owner 时回退运行集合。"""
+
+        if self._persisted_jobs is not None:
+            return dict(self._persisted_jobs)
+        return dict(self._jobs)
 
     async def _execute_and_reschedule(self, job: ScheduledJob) -> None:
         execution_succeeded = False
@@ -646,7 +669,7 @@ class SchedulerService:
             logger.error(f"Job {job.id[:8]} execution failed: {e}", exc_info=True)
         finally:
             self._in_flight.discard(job.id)
-            candidate = self._jobs
+            candidate = self._current_persisted_jobs()
             committed_job: ScheduledJob | None = None
             current_job = self._jobs.get(job.id)
             if not execution_cancelled and job.trigger == "every":
@@ -661,15 +684,12 @@ class SchedulerService:
                         fire_at=self._advance_every(job, reschedule_after),
                         run_count=job.run_count + (1 if execution_succeeded else 0),
                     )
-                    candidate = dict(self._jobs)
                     candidate[job.id] = committed_job
             elif not execution_cancelled and job.trigger != "every":
                 if current_job is job:
-                    candidate = dict(self._jobs)
                     _ = candidate.pop(job.id)
 
-            self.store.save(candidate)
-            self._jobs = candidate
+            self._commit_jobs(candidate)
             if committed_job is not None:
                 job.fire_at = committed_job.fire_at
                 job.run_count = committed_job.run_count

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -582,9 +582,10 @@ class SchedulerService:
                     persisted[job.id] = job
                     count_loaded += 1
                 else:
+                    persisted[job.id] = replace(job, enabled=False)
                     logger.info(
                         f"Job {job.id[:8]} ({job.name or 'unnamed'}) expired "
-                        f"{age:.0f}s ago, beyond grace period — discarded"
+                        f"{age:.0f}s ago, beyond grace period — retained disabled"
                     )
                     persistence_changed = True
             else:
@@ -687,7 +688,11 @@ class SchedulerService:
                     candidate[job.id] = committed_job
             elif not execution_cancelled and job.trigger != "every":
                 if current_job is job:
-                    _ = candidate.pop(job.id)
+                    candidate[job.id] = replace(
+                        job,
+                        enabled=False,
+                        run_count=job.run_count + (1 if execution_succeeded else 0),
+                    )
 
             self._commit_jobs(candidate)
             if committed_job is not None:

--- a/agent/tools/schedule.py
+++ b/agent/tools/schedule.py
@@ -273,10 +273,7 @@ class CancelScheduleTool(Tool):
             return "错误：id 或 name 至少提供一个"
 
         if job_id:
-            all_ids = list(self._service._jobs.keys())
-            matches = [
-                jid for jid in all_ids if jid == job_id or jid.startswith(job_id)
-            ]
+            matches = self._service.match_job_ids(job_id)
             if not matches:
                 return f"未找到 ID 为 {job_id!r} 的任务"
             for jid in matches:

--- a/agent/tools/schedule.py
+++ b/agent/tools/schedule.py
@@ -9,6 +9,7 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from agent.scheduler import (
+    ScheduleCapacityError,
     ScheduledJob,
     SchedulerService,
     compute_fire_at,
@@ -172,7 +173,14 @@ class ScheduleTool(Tool):
             name=name,
             timezone=tz,
         )
-        self._service.add_job(job)
+        try:
+            self._service.add_job(job)
+        except ScheduleCapacityError as exc:
+            return (
+                f"{exc.code}：当前已有 {exc.active_jobs} 个活动定时任务，"
+                f"默认上限为 {exc.max_active_jobs} 个。"
+                "请询问用户要移除哪个不再需要的任务后再添加。"
+            )
 
         # 5. 优先按请求时区展示，格式异常时保留已注册任务并回退 ISO 时间
         try:

--- a/plugins/wake_proactive/hazard.py
+++ b/plugins/wake_proactive/hazard.py
@@ -47,6 +47,7 @@ def advance_hazard(
     new_item_ids: set[str],
     random_draw: float,
     last_wake_at: datetime | None,
+    pool_mass: float | None = None,
 ) -> HazardResult:
     """用新事件推动全池概率抽签，并返回可审计的触发结果。"""
 
@@ -85,7 +86,8 @@ def advance_hazard(
         )
 
     # 2. 新事件提供 kick，旧池只放大本次抽签
-    evidence = sum(value for _, value in contributions)
+    material_mass = sum(value for _, value in contributions)
+    evidence = max(material_mass, max(0.0, float(pool_mass or 0.0)))
     refractory = (
         1.0
         - math.exp(

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -87,6 +87,7 @@ class WakeRunState:
     new_content_count: int = 0
     new_content_ids: set[str] | None = None
     unread_content_mass: float = 0.0
+    unread_content_count: int = 0
 
 
 @dataclass(slots=True)
@@ -174,7 +175,10 @@ class WakeRuntime:
         if state.alerts:
             return
         await self._cache_event_embeddings()
-        state.contents = self._state.unread("content")
+        state.contents = self._state.unread(
+            "content", limit=_MAX_TITLES_PER_WAKE
+        )
+        state.unread_content_count = self._state.unread_count("content")
         self._apply_semantic_interest(state.contents, state.ctx.now_utc)
 
     async def _fetch_source_channels(self) -> dict[str, list[dict[str, Any]]]:
@@ -302,6 +306,7 @@ class WakeRuntime:
                 for event in state.contents
                 if str(event["id"]) not in expired_ids
             ]
+            state.unread_content_count = self._state.unread_count("content")
         new_content_ids = (state.new_content_ids or set()) - expired_ids
         should_evaluate_content = bool(state.contents and new_content_ids)
         if should_evaluate_content:
@@ -334,7 +339,7 @@ class WakeRuntime:
                     now=state.ctx.now_utc,
                 )
                 state.ctx.content_backlog_count = (
-                    len(state.contents) - len(state.ctx.content_events)
+                    state.unread_content_count - len(state.ctx.content_events)
                 )
                 self._record_content_observation(state.ctx, result)
                 await self._run_content_tools(state.ctx)

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -218,6 +218,22 @@ class WakeRuntime:
                 reason=item.reason,
                 payload=item.payload,
             )
+        for source_id, dropped_count in getattr(
+            channels, "quarantine_overflow", {}
+        ).items():
+            self._state.record_quarantine(
+                source_id=source_id,
+                item_id="quarantine-overflow",
+                reason=(
+                    "坏 MCP item 超过单 source quarantine detail cap; "
+                    f"dropped={dropped_count}"
+                ),
+                payload={
+                    "overflow": True,
+                    "dropped_count": dropped_count,
+                    "detail_cap": mcp_sources.MAX_QUARANTINE_ITEMS_PER_SOURCE,
+                },
+            )
         state.context_results = self._state.ingest_context(
             channels["context"], state.ctx.now_utc
         )

--- a/plugins/wake_proactive/runtime.py
+++ b/plugins/wake_proactive/runtime.py
@@ -48,10 +48,9 @@ from session.embedding_store import MessageEmbeddingStore
 
 
 logger = logging.getLogger(__name__)
-_MAX_TITLES_PER_WAKE = 120
+_MAX_TITLES_PER_WAKE = 100
 _SEMANTIC_CALIBRATION_POWER = 4
 _CONTENT_MIN_RESIDENCE = timedelta(hours=24)
-_CONTENT_MAX_AGE = timedelta(days=14)
 _RECENT_PROACTIVE_WINDOW = timedelta(days=7)
 _RECENT_PROACTIVE_LIMIT = 30
 _RECENT_PROACTIVE_CHAR_BUDGET = 8_000
@@ -87,6 +86,7 @@ class WakeRunState:
     new_alert_count: int = 0
     new_content_count: int = 0
     new_content_ids: set[str] | None = None
+    unread_content_mass: float = 0.0
 
 
 @dataclass(slots=True)
@@ -207,10 +207,13 @@ class WakeRuntime:
         )
         state.new_content_ids = set(new_content_ids)
         state.new_content_count = len(new_content_ids)
-        self._state.queue_acknowledgements(
-            _group_acknowledgements(channels["content"]),
-            state.ctx.now_utc,
-        )
+        for item in getattr(channels, "quarantined", []):
+            self._state.record_quarantine(
+                source_id=item.source_id,
+                item_id=item.item_id,
+                reason=item.reason,
+                payload=item.payload,
+            )
         state.context_results = self._state.ingest_context(
             channels["context"], state.ctx.now_utc
         )
@@ -230,7 +233,12 @@ class WakeRuntime:
             else False
         )
         state.alerts = self._state.unread("alert")
-        state.contents = self._state.unread("content")
+        state.contents = self._state.unread(
+            "content", limit=_MAX_TITLES_PER_WAKE
+        )
+        state.unread_content_mass = self._state.unread_aggregate_mass(
+            "content", now=state.ctx.now_utc
+        )
 
     def _log_source_summary(
         self,
@@ -263,21 +271,37 @@ class WakeRuntime:
             await self._decide_event(state, "context", state.context_event)
             state.next_interval_seconds = self._tick_interval_seconds
             return True
-        expired_ids: set[str] = set()
-        if state.contents:
-            ranked = rank_events(state.contents, now=state.ctx.now_utc)
-            expired_ids = {
-                str(event["id"])
-                for event in ranked
-                if _content_expired(event, state.ctx.now_utc)
+        expiry_rows = self._state.expiry_candidates(
+            "content",
+            before=state.ctx.now_utc - _CONTENT_MIN_RESIDENCE,
+        )
+        expiry_events = [
+            {
+                "id": str(row["item_id"]),
+                "_reservoir_original_source_id": row["original_source_id"],
+                "_reservoir_ack_source_id": row["ack_source_id"],
+                "_reservoir_source_event_id": row["source_event_id"],
+                "published_at": row["published_at"],
+                "first_seen_at": row["first_seen_at"],
+                "preprocess_score": row["preprocess_score"],
             }
-            if expired_ids:
-                self._state.expire(sorted(expired_ids), state.ctx.now_utc)
-                state.contents = [
-                    event
-                    for event in state.contents
-                    if str(event["id"]) not in expired_ids
-                ]
+            for row in expiry_rows
+        ]
+        expired_ids = {
+            str(event["id"])
+            for event in rank_events(expiry_events, now=state.ctx.now_utc)
+            if _content_expired(event, state.ctx.now_utc)
+        }
+        if expired_ids:
+            self._state.queue_expiration(
+                sorted(expired_ids), state.ctx.now_utc
+            )
+            await self._flush_pending_acknowledgements()
+            state.contents = [
+                event
+                for event in state.contents
+                if str(event["id"]) not in expired_ids
+            ]
         new_content_ids = (state.new_content_ids or set()) - expired_ids
         should_evaluate_content = bool(state.contents and new_content_ids)
         if should_evaluate_content:
@@ -294,6 +318,7 @@ class WakeRuntime:
                     state.ctx.now_utc,
                 ),
                 last_wake_at=last_wake_at,
+                pool_mass=state.unread_content_mass,
             )
             state.hazard_result = result
             state.base_score = result.rate
@@ -1010,10 +1035,18 @@ class WakeRuntime:
         events: list[dict[str, Any]],
         now: datetime,
     ) -> None:
-        self._state.consume(
-            [str(event["id"]) for event in events],
-            now,
+        grouped: dict[str, list[str]] = {}
+        for event in events:
+            source_id = str(event.get("_reservoir_ack_source_id") or "")
+            source_event_id = str(event.get("_reservoir_source_event_id") or "")
+            if source_id and source_event_id:
+                grouped.setdefault(source_id, []).append(source_event_id)
+        self._state.consume_and_queue_ack(
+            item_ids=[str(event["id"]) for event in events],
+            acknowledgements=grouped,
+            now=now,
         )
+        await self._flush_pending_acknowledgements()
 
     async def _flush_pending_acknowledgements(self) -> None:
         grouped = self._state.pending_acknowledgements()
@@ -1123,12 +1156,7 @@ def _parse_optional_time(value: object) -> datetime | None:
 def _content_expired(event: dict[str, Any], now: datetime) -> bool:
     """只在内容超龄或度过驻留期后跌破衰减线时淘汰。"""
 
-    # 1. 发布时间可靠时直接淘汰绝对陈旧内容
-    published_at = _parse_optional_time(event.get("published_at"))
-    if published_at is not None and now - published_at >= _CONTENT_MAX_AGE:
-        return True
-
-    # 2. 新内容先获得一次跟随后续事件进入判别的机会
+    # 1. 新内容先获得一次跟随后续事件进入判别的机会
     first_seen_at = _parse_optional_time(event.get("first_seen_at"))
     if first_seen_at is None:
         raise ValueError("wake content missing first_seen_at")

--- a/plugins/wake_proactive/state.py
+++ b/plugins/wake_proactive/state.py
@@ -4,7 +4,7 @@ import json
 import hashlib
 import math
 import sqlite3
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -16,6 +16,14 @@ from plugins.wake_proactive.context_drive import (
     evaluate_context,
 )
 from plugins.wake_proactive.hazard import HazardResult
+
+
+MAX_FUTURE_TIMESTAMP_SKEW = timedelta(hours=24)
+QUARANTINE_PAYLOAD_BYTES = 4096
+QUARANTINE_GLOBAL_CAP = 1000
+QUARANTINE_PER_SOURCE_CAP = 100
+TOMBSTONE_RETENTION = timedelta(days=30)
+TOMBSTONE_GLOBAL_CAP = 10_000
 
 
 class WakeStateStore:
@@ -73,7 +81,32 @@ class WakeStateStore:
             )
             """
         )
+        _ = self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reservoir_quarantine (
+                identity TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                occurrences INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+        _ = self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reservoir_tombstones (
+                identity TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                source_event_id TEXT NOT NULL,
+                acknowledged_at TEXT NOT NULL
+            )
+            """
+        )
         self._migrate_reservoir_sources()
+        self._migrate_reservoir_timestamps()
         _ = self._conn.execute(
             "UPDATE reservoir_events SET status = 'unread' WHERE status = 'suppressed'"
         )
@@ -84,6 +117,30 @@ class WakeStateStore:
             ON reservoir_events(
                 kind, status, original_source_id, published_at DESC, first_seen_at DESC
             )
+            """
+        )
+        _ = self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reservoir_expiry
+            ON reservoir_events(kind, status, first_seen_at)
+            """
+        )
+        _ = self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reservoir_aggregate
+            ON reservoir_events(kind, status, published_at, preprocess_score)
+            """
+        )
+        _ = self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_quarantine_source_time
+            ON reservoir_quarantine(source_id, last_seen_at DESC)
+            """
+        )
+        _ = self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_tombstone_time
+            ON reservoir_tombstones(acknowledged_at)
             """
         )
         _ = self._conn.execute(
@@ -167,21 +224,11 @@ class WakeStateStore:
             )
             """
         )
-        _ = self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS reservoir_quarantine (
-                identity TEXT PRIMARY KEY,
-                source_id TEXT NOT NULL,
-                item_id TEXT NOT NULL,
-                reason TEXT NOT NULL,
-                payload_json TEXT NOT NULL,
-                first_seen_at TEXT NOT NULL,
-                last_seen_at TEXT NOT NULL,
-                occurrences INTEGER NOT NULL DEFAULT 1
-            )
-            """
-        )
-        self._migrate_pending_acknowledgements()
+        try:
+            self._migrate_pending_acknowledgements()
+        except Exception:
+            self._conn.close()
+            raise
         self._conn.commit()
 
     def _migrate_drift_timer(self) -> None:
@@ -237,11 +284,78 @@ class WakeStateStore:
                 (str(row["source_id"]), original_source_id, str(row["item_id"])),
             )
 
+    def _migrate_reservoir_timestamps(self) -> None:
+        now = datetime.now(UTC)
+        rows = self._conn.execute(
+            """
+            SELECT item_id, ack_source_id, source_event_id,
+                   published_at, first_seen_at, payload_json, status
+            FROM reservoir_events
+            """
+        ).fetchall()
+        for row in rows:
+            invalid_reason: str | None = None
+            for field in ("published_at", "first_seen_at"):
+                value = str(row[field] or "")
+                if not value:
+                    if field == "first_seen_at":
+                        invalid_reason = f"{field} 缺失"
+                        break
+                    continue
+                try:
+                    parsed = datetime.fromisoformat(value)
+                except ValueError:
+                    invalid_reason = f"{field} 不是 ISO timestamp"
+                    break
+                if parsed.tzinfo is None or parsed.utcoffset() is None:
+                    invalid_reason = f"{field} 为 naive timestamp"
+                    break
+                if parsed > now + MAX_FUTURE_TIMESTAMP_SKEW:
+                    invalid_reason = f"{field} 超过 future skew"
+                    break
+            if invalid_reason is None:
+                continue
+            self.record_quarantine(
+                source_id=str(row["ack_source_id"] or "unknown"),
+                item_id=str(row["item_id"]),
+                reason=f"legacy reservoir: {invalid_reason}",
+                payload=str(row["payload_json"]),
+                commit=False,
+            )
+            _ = self._conn.execute(
+                "UPDATE reservoir_events SET status = 'quarantined' WHERE item_id = ?",
+                (str(row["item_id"]),),
+            )
+
     def _migrate_pending_acknowledgements(self) -> None:
         info = list(self._conn.execute("PRAGMA table_info(pending_acknowledgements)"))
         columns = {str(row[1]) for row in info}
         primary_key = tuple(str(row[1]) for row in info if int(row[5]) > 0)
         if primary_key == ("source_id", "source_event_id"):
+            legacy_rows = list(
+                self._conn.execute(
+                    "SELECT source_id, source_event_id, queued_at FROM pending_acknowledgements"
+                )
+            )
+            resolved_rows: list[tuple[str, str, str, str]] = []
+            for row in legacy_rows:
+                matches = list(
+                    self._conn.execute(
+                        """
+                        SELECT item_id FROM reservoir_events
+                        WHERE ack_source_id = ? AND source_event_id = ?
+                        """,
+                        (str(row[0]), str(row[1])),
+                    )
+                )
+                if len(matches) != 1:
+                    raise RuntimeError(
+                        "pending acknowledgement migration cannot resolve "
+                        f"{row[0]}:{row[1]} to one reservoir item (matches={len(matches)})"
+                    )
+                resolved_rows.append(
+                    (str(row[0]), str(row[1]), str(matches[0][0]), str(row[2]))
+                )
             _ = self._conn.execute(
                 """
                 CREATE TABLE pending_acknowledgements_v2 (
@@ -254,20 +368,15 @@ class WakeStateStore:
                 )
                 """
             )
-            _ = self._conn.execute(
-                """
-                INSERT INTO pending_acknowledgements_v2(
-                    source_id, source_event_id, item_id, action, queued_at
+            for source_id, event_id, item_id, queued_at in resolved_rows:
+                _ = self._conn.execute(
+                    """
+                    INSERT INTO pending_acknowledgements_v2(
+                        source_id, source_event_id, item_id, action, queued_at
+                    ) VALUES (?, ?, ?, 'consume', ?)
+                    """,
+                    (source_id, event_id, item_id, queued_at),
                 )
-                SELECT source_id, source_event_id,
-                       coalesce((SELECT item_id FROM reservoir_events
-                                 WHERE ack_source_id = pending_acknowledgements.source_id
-                                   AND source_event_id = pending_acknowledgements.source_event_id
-                                 LIMIT 1), ''),
-                       'consume', queued_at
-                FROM pending_acknowledgements
-                """
-            )
             _ = self._conn.execute("DROP TABLE pending_acknowledgements")
             _ = self._conn.execute(
                 "ALTER TABLE pending_acknowledgements_v2 RENAME TO pending_acknowledgements"
@@ -400,6 +509,8 @@ class WakeStateStore:
         """持久化事件，并返回本轮首次进入池子的项目 ID。"""
 
         # 1. 在信任边界规范化来源标识
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("wake reservoir ingest requires timezone-aware now")
         inserted_ids: list[str] = []
         for event in events:
             event_kind = str(event.get("kind") or kind).strip()
@@ -436,18 +547,19 @@ class WakeStateStore:
                 )
                 continue
             item_id = f"{ack_source_id}:{source_event_id}"
+            tombstone = self._conn.execute(
+                "SELECT 1 FROM reservoir_tombstones WHERE identity = ?",
+                (item_id,),
+            ).fetchone()
+            if tombstone is not None:
+                continue
             payload = dict(event)
             payload["id"] = item_id
             payload["item_id"] = item_id
             published_at = str(
                 event.get("published_at") or event.get("triggered_at") or ""
             )
-            first_seen_at = str(
-                event.get("first_seen_at")
-                or event.get("published_at")
-                or event.get("triggered_at")
-                or now.isoformat()
-            )
+            first_seen_at = now.isoformat()
             score_value = event.get("preprocess_score")
             if score_value is None:
                 score_value = event.get("rank_score", 0.0)
@@ -492,16 +604,20 @@ class WakeStateStore:
                         commit=False,
                     )
                     break
+                if parsed > now + MAX_FUTURE_TIMESTAMP_SKEW:
+                    self.record_quarantine(
+                        source_id=ack_source_id,
+                        item_id=item_id,
+                        reason=f"{field} 超过 future skew",
+                        payload=event,
+                        commit=False,
+                    )
+                    break
             else:
                 published_at = str(
                     event.get("published_at") or event.get("triggered_at") or ""
                 )
-                first_seen_at = str(
-                    event.get("first_seen_at")
-                    or event.get("published_at")
-                    or event.get("triggered_at")
-                    or now.isoformat()
-                )
+                first_seen_at = now.isoformat()
                 existing = self._conn.execute(
                     "SELECT 1 FROM reservoir_events WHERE item_id = ?",
                     (item_id,),
@@ -568,6 +684,13 @@ class WakeStateStore:
                 payload["_event_embedding"] = json.loads(row["embedding_json"])
             result.append(payload)
         return result
+
+    def unread_count(self, kind: str) -> int:
+        row = self._conn.execute(
+            "SELECT count(*) AS count FROM reservoir_events WHERE kind = ? AND status = 'unread'",
+            (kind,),
+        ).fetchone()
+        return int(row["count"] if row is not None else 0)
 
     def unread_aggregate_mass(
         self,
@@ -640,6 +763,19 @@ class WakeStateStore:
 
         identity = f"{source_id}:{item_id}"
         now = datetime.now().astimezone().isoformat()
+        payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+        if len(payload_json.encode("utf-8")) > QUARANTINE_PAYLOAD_BYTES:
+            preview_budget = max(0, QUARANTINE_PAYLOAD_BYTES - 96)
+            preview = payload_json.encode("utf-8")[:preview_budget].decode(
+                "utf-8", errors="ignore"
+            )
+            payload_json = json.dumps(
+                {
+                    "truncated": True,
+                    "preview": preview,
+                },
+                ensure_ascii=False,
+            )
         _ = self._conn.execute(
             """
             INSERT INTO reservoir_quarantine(
@@ -657,10 +793,33 @@ class WakeStateStore:
                 source_id,
                 item_id,
                 reason,
-                json.dumps(payload, ensure_ascii=False, default=str),
+                payload_json,
                 now,
                 now,
             ),
+        )
+        _ = self._conn.execute(
+            """
+            DELETE FROM reservoir_quarantine
+            WHERE source_id = ? AND identity NOT IN (
+                SELECT identity FROM reservoir_quarantine
+                WHERE source_id = ?
+                ORDER BY last_seen_at DESC
+                LIMIT ?
+            )
+            """,
+            (source_id, source_id, QUARANTINE_PER_SOURCE_CAP),
+        )
+        _ = self._conn.execute(
+            """
+            DELETE FROM reservoir_quarantine
+            WHERE identity NOT IN (
+                SELECT identity FROM reservoir_quarantine
+                ORDER BY last_seen_at DESC
+                LIMIT ?
+            )
+            """,
+            (QUARANTINE_GLOBAL_CAP,),
         )
         if commit:
             self._conn.commit()
@@ -713,15 +872,21 @@ class WakeStateStore:
     ) -> None:
         for source_id, event_ids in acknowledgements.items():
             for event_id in event_ids:
-                _ = self._conn.execute(
+                item = self._conn.execute(
                     """
-                    INSERT INTO pending_acknowledgements(
-                        source_id, source_event_id, item_id, action, queued_at
-                    ) VALUES (?, ?, coalesce((SELECT item_id FROM reservoir_events
-                        WHERE ack_source_id = ? AND source_event_id = ? LIMIT 1), ''), 'consume', ?)
-                    ON CONFLICT DO NOTHING
+                    SELECT item_id FROM reservoir_events
+                    WHERE ack_source_id = ? AND source_event_id = ?
                     """,
-                    (source_id, event_id, source_id, event_id, now.isoformat()),
+                    (source_id, event_id),
+                ).fetchone()
+                if item is None:
+                    continue
+                self._queue_pending_ack(
+                    source_id=source_id,
+                    event_id=event_id,
+                    item_id=str(item[0]) if item is not None else "",
+                    action="consume",
+                    queued_at=now,
                 )
         self._conn.commit()
 
@@ -738,23 +903,67 @@ class WakeStateStore:
                 f"""
                 UPDATE reservoir_events
                 SET status = 'consumed', consumed_at = ?
-                WHERE item_id IN ({placeholders})
+                WHERE item_id IN ({placeholders}) AND status != 'pending_expiry'
                 """,
                 (now.isoformat(), *item_ids),
             )
         for source_id, event_ids in acknowledgements.items():
             for event_id in event_ids:
-                _ = self._conn.execute(
+                item = self._conn.execute(
                     """
-                    INSERT INTO pending_acknowledgements(
-                        source_id, source_event_id, item_id, action, queued_at
-                    ) VALUES (?, ?, coalesce((SELECT item_id FROM reservoir_events
-                        WHERE ack_source_id = ? AND source_event_id = ? LIMIT 1), ''), 'consume', ?)
-                    ON CONFLICT DO NOTHING
+                    SELECT item_id FROM reservoir_events
+                    WHERE ack_source_id = ? AND source_event_id = ?
                     """,
-                    (source_id, event_id, source_id, event_id, now.isoformat()),
+                    (source_id, event_id),
+                ).fetchone()
+                if item is None:
+                    continue
+                self._queue_pending_ack(
+                    source_id=source_id,
+                    event_id=event_id,
+                    item_id=str(item[0]) if item is not None else "",
+                    action="consume",
+                    queued_at=now,
                 )
         self._conn.commit()
+
+    def _queue_pending_ack(
+        self,
+        *,
+        source_id: str,
+        event_id: str,
+        item_id: str,
+        action: str,
+        queued_at: datetime,
+    ) -> None:
+        existing = self._conn.execute(
+            """
+            SELECT action FROM pending_acknowledgements
+            WHERE source_id = ? AND source_event_id = ? AND item_id = ?
+            """,
+            (source_id, event_id, item_id),
+        ).fetchone()
+        if existing is not None:
+            if str(existing[0]) == "expire" or action == "consume":
+                return
+            _ = self._conn.execute(
+                """
+                UPDATE pending_acknowledgements
+                SET action = 'expire', queued_at = ?
+                WHERE source_id = ? AND source_event_id = ? AND item_id = ?
+                """,
+                (queued_at.isoformat(), source_id, event_id, item_id),
+            )
+            return
+        _ = self._conn.execute(
+            """
+            INSERT INTO pending_acknowledgements(
+                source_id, source_event_id, item_id, action, queued_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT DO NOTHING
+            """,
+            (source_id, event_id, item_id, action, queued_at.isoformat()),
+        )
 
     def queue_expiration(self, item_ids: list[str], now: datetime) -> None:
         """登记低分事件的 expire ack，ack 成功前保留 payload。"""
@@ -767,7 +976,8 @@ class WakeStateStore:
             f"""
             SELECT item_id, ack_source_id, source_event_id
             FROM reservoir_events
-            WHERE item_id IN ({placeholders}) AND status = 'unread'
+            WHERE item_id IN ({placeholders})
+              AND status IN ('unread', 'consumed', 'pending_expiry')
             """,
             tuple(unique_ids),
         ).fetchall()
@@ -777,23 +987,16 @@ class WakeStateStore:
             _ = self._conn.execute(
                 """
                 UPDATE reservoir_events SET status = 'pending_expiry'
-                WHERE item_id = ? AND status = 'unread'
+                WHERE item_id = ? AND status IN ('unread', 'consumed', 'pending_expiry')
                 """,
                 (str(row["item_id"]),),
             )
-            _ = self._conn.execute(
-                """
-                INSERT INTO pending_acknowledgements(
-                    source_id, source_event_id, item_id, action, queued_at
-                ) VALUES (?, ?, ?, 'expire', ?)
-                ON CONFLICT DO NOTHING
-                """,
-                (
-                    str(row["ack_source_id"]),
-                    str(row["source_event_id"]),
-                    str(row["item_id"]),
-                    now.isoformat(),
-                ),
+            self._queue_pending_ack(
+                source_id=str(row["ack_source_id"]),
+                event_id=str(row["source_event_id"]),
+                item_id=str(row["item_id"]),
+                action="expire",
+                queued_at=now,
             )
         self._conn.commit()
 
@@ -840,10 +1043,32 @@ class WakeStateStore:
         try:
             for row in rows:
                 if str(row["action"]) == "expire" and str(row["item_id"]):
+                    item_id = str(row["item_id"])
+                    tombstone_row = self._conn.execute(
+                        "SELECT ack_source_id, source_event_id FROM reservoir_events WHERE item_id = ?",
+                        (item_id,),
+                    ).fetchone()
+                    if tombstone_row is None:
+                        continue
+                    _ = self._conn.execute(
+                        """
+                        INSERT INTO reservoir_tombstones(
+                            identity, source_id, source_event_id, acknowledged_at
+                        ) VALUES (?, ?, ?, ?)
+                        ON CONFLICT(identity) DO UPDATE SET
+                            acknowledged_at=excluded.acknowledged_at
+                        """,
+                        (
+                            item_id,
+                            str(tombstone_row["ack_source_id"]),
+                            str(tombstone_row["source_event_id"]),
+                            datetime.now(UTC).isoformat(),
+                        ),
+                    )
                     _ = self._conn.execute(
                         "DELETE FROM reservoir_events "
                         "WHERE item_id = ? AND status = 'pending_expiry'",
-                        (str(row["item_id"]),),
+                        (item_id,),
                     )
             _ = self._conn.execute(
                 f"""
@@ -851,6 +1076,22 @@ class WakeStateStore:
                 WHERE source_id = ? AND source_event_id IN ({placeholders})
                 """,
                 (source_id, *event_ids),
+            )
+            cutoff = (datetime.now(UTC) - TOMBSTONE_RETENTION).isoformat()
+            _ = self._conn.execute(
+                "DELETE FROM reservoir_tombstones WHERE acknowledged_at < ?",
+                (cutoff,),
+            )
+            _ = self._conn.execute(
+                """
+                DELETE FROM reservoir_tombstones
+                WHERE identity NOT IN (
+                    SELECT identity FROM reservoir_tombstones
+                    ORDER BY acknowledged_at DESC
+                    LIMIT ?
+                )
+                """,
+                (TOMBSTONE_GLOBAL_CAP,),
             )
             self._conn.commit()
         except Exception:

--- a/plugins/wake_proactive/state.py
+++ b/plugins/wake_proactive/state.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import math
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -80,7 +82,7 @@ class WakeStateStore:
             """
             CREATE INDEX idx_reservoir_unread
             ON reservoir_events(
-                kind, status, original_source_id, published_at DESC
+                kind, status, original_source_id, published_at DESC, first_seen_at DESC
             )
             """
         )
@@ -158,11 +160,28 @@ class WakeStateStore:
             CREATE TABLE IF NOT EXISTS pending_acknowledgements (
                 source_id TEXT NOT NULL,
                 source_event_id TEXT NOT NULL,
+                item_id TEXT NOT NULL DEFAULT '',
+                action TEXT NOT NULL DEFAULT 'consume',
                 queued_at TEXT NOT NULL,
-                PRIMARY KEY(source_id, source_event_id)
+                PRIMARY KEY(source_id, source_event_id, item_id)
             )
             """
         )
+        _ = self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reservoir_quarantine (
+                identity TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                occurrences INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+        self._migrate_pending_acknowledgements()
         self._conn.commit()
 
     def _migrate_drift_timer(self) -> None:
@@ -216,6 +235,52 @@ class WakeStateStore:
                 WHERE item_id = ?
                 """,
                 (str(row["source_id"]), original_source_id, str(row["item_id"])),
+            )
+
+    def _migrate_pending_acknowledgements(self) -> None:
+        info = list(self._conn.execute("PRAGMA table_info(pending_acknowledgements)"))
+        columns = {str(row[1]) for row in info}
+        primary_key = tuple(str(row[1]) for row in info if int(row[5]) > 0)
+        if primary_key == ("source_id", "source_event_id"):
+            _ = self._conn.execute(
+                """
+                CREATE TABLE pending_acknowledgements_v2 (
+                    source_id TEXT NOT NULL,
+                    source_event_id TEXT NOT NULL,
+                    item_id TEXT NOT NULL DEFAULT '',
+                    action TEXT NOT NULL DEFAULT 'consume',
+                    queued_at TEXT NOT NULL,
+                    PRIMARY KEY(source_id, source_event_id, item_id)
+                )
+                """
+            )
+            _ = self._conn.execute(
+                """
+                INSERT INTO pending_acknowledgements_v2(
+                    source_id, source_event_id, item_id, action, queued_at
+                )
+                SELECT source_id, source_event_id,
+                       coalesce((SELECT item_id FROM reservoir_events
+                                 WHERE ack_source_id = pending_acknowledgements.source_id
+                                   AND source_event_id = pending_acknowledgements.source_event_id
+                                 LIMIT 1), ''),
+                       'consume', queued_at
+                FROM pending_acknowledgements
+                """
+            )
+            _ = self._conn.execute("DROP TABLE pending_acknowledgements")
+            _ = self._conn.execute(
+                "ALTER TABLE pending_acknowledgements_v2 RENAME TO pending_acknowledgements"
+            )
+            return
+        if "item_id" not in columns:
+            _ = self._conn.execute(
+                "ALTER TABLE pending_acknowledgements ADD COLUMN item_id TEXT NOT NULL DEFAULT ''"
+            )
+        if "action" not in columns:
+            _ = self._conn.execute(
+                "ALTER TABLE pending_acknowledgements "
+                "ADD COLUMN action TEXT NOT NULL DEFAULT 'consume'"
             )
 
     def save(self, ctx: WakeContext) -> None:
@@ -337,6 +402,20 @@ class WakeStateStore:
         # 1. 在信任边界规范化来源标识
         inserted_ids: list[str] = []
         for event in events:
+            event_kind = str(event.get("kind") or kind).strip()
+            if event_kind != kind:
+                self.record_quarantine(
+                    source_id=str(event.get("ack_server") or event.get("_source") or "unknown"),
+                    item_id=str(
+                        event.get("event_id")
+                        or event.get("id")
+                        or _stable_quarantine_id(kind, event)
+                    ),
+                    reason=f"kind 与目标 channel 不匹配: {event_kind} != {kind}",
+                    payload=event,
+                    commit=False,
+                )
+                continue
             ack_source_id = str(
                 event.get("ack_server") or event.get("_source") or ""
             ).strip()
@@ -348,6 +427,13 @@ class WakeStateStore:
             ).strip()
             source_event_id = str(event.get("event_id") or event.get("id") or "").strip()
             if not ack_source_id or not original_source_id or not source_event_id:
+                self.record_quarantine(
+                    source_id=ack_source_id or original_source_id or "unknown",
+                    item_id=source_event_id or _stable_quarantine_id(kind, event),
+                    reason="缺少 source/event identity",
+                    payload=event,
+                    commit=False,
+                )
                 continue
             item_id = f"{ack_source_id}:{source_event_id}"
             payload = dict(event)
@@ -356,56 +442,116 @@ class WakeStateStore:
             published_at = str(
                 event.get("published_at") or event.get("triggered_at") or ""
             )
-            first_seen_at = str(event.get("first_seen_at") or now.isoformat())
-            score = float(event.get("preprocess_score") or event.get("rank_score") or 0.0)
-            status = "unread"
-            existing = self._conn.execute(
-                "SELECT 1 FROM reservoir_events WHERE item_id = ?",
-                (item_id,),
-            ).fetchone()
-            _ = self._conn.execute(
-                """
-                INSERT INTO reservoir_events(
-                    item_id, kind, source_id, original_source_id, ack_source_id,
-                    source_event_id, published_at, first_seen_at,
-                    preprocess_score, payload_json, status
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(item_id) DO UPDATE SET
-                    original_source_id=excluded.original_source_id,
-                    ack_source_id=excluded.ack_source_id,
-                    published_at=excluded.published_at,
-                    preprocess_score=excluded.preprocess_score,
-                    payload_json=excluded.payload_json,
-                    status=reservoir_events.status
-                """,
-                (
-                    item_id,
-                    kind,
-                    ack_source_id,
-                    original_source_id,
-                    ack_source_id,
-                    source_event_id,
-                    published_at,
-                    first_seen_at,
-                    score,
-                    json.dumps(payload, ensure_ascii=False),
-                    status,
-                ),
+            first_seen_at = str(
+                event.get("first_seen_at")
+                or event.get("published_at")
+                or event.get("triggered_at")
+                or now.isoformat()
             )
-            if existing is None:
-                inserted_ids.append(item_id)
+            score_value = event.get("preprocess_score")
+            if score_value is None:
+                score_value = event.get("rank_score", 0.0)
+            try:
+                score = float(score_value)
+            except (TypeError, ValueError):
+                self.record_quarantine(
+                    source_id=ack_source_id,
+                    item_id=item_id,
+                    reason="score 非数字",
+                    payload=event,
+                    commit=False,
+                )
+                continue
+            if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+                self.record_quarantine(
+                    source_id=ack_source_id,
+                    item_id=item_id,
+                    reason="score 超出 [0,1] 或非 finite",
+                    payload=event,
+                    commit=False,
+                )
+                continue
+            for field in ("published_at", "triggered_at", "first_seen_at"):
+                value = event.get(field)
+                if value in (None, ""):
+                    continue
+                try:
+                    parsed = (
+                        value
+                        if isinstance(value, datetime)
+                        else datetime.fromisoformat(str(value))
+                    )
+                except (TypeError, ValueError):
+                    parsed = None
+                if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+                    self.record_quarantine(
+                        source_id=ack_source_id,
+                        item_id=item_id,
+                        reason=f"{field} 必须是带 timezone 的 ISO timestamp",
+                        payload=event,
+                        commit=False,
+                    )
+                    break
+            else:
+                published_at = str(
+                    event.get("published_at") or event.get("triggered_at") or ""
+                )
+                first_seen_at = str(
+                    event.get("first_seen_at")
+                    or event.get("published_at")
+                    or event.get("triggered_at")
+                    or now.isoformat()
+                )
+                existing = self._conn.execute(
+                    "SELECT 1 FROM reservoir_events WHERE item_id = ?",
+                    (item_id,),
+                ).fetchone()
+                _ = self._conn.execute(
+                    """
+                    INSERT INTO reservoir_events(
+                        item_id, kind, source_id, original_source_id, ack_source_id,
+                        source_event_id, published_at, first_seen_at,
+                        preprocess_score, payload_json, status
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(item_id) DO UPDATE SET
+                        original_source_id=excluded.original_source_id,
+                        ack_source_id=excluded.ack_source_id,
+                        published_at=excluded.published_at,
+                        preprocess_score=excluded.preprocess_score,
+                        payload_json=excluded.payload_json,
+                        status=reservoir_events.status
+                    """,
+                    (
+                        item_id,
+                        kind,
+                        ack_source_id,
+                        original_source_id,
+                        ack_source_id,
+                        source_event_id,
+                        published_at,
+                        first_seen_at,
+                        score,
+                        json.dumps(payload, ensure_ascii=False),
+                        "unread",
+                    ),
+                )
+                if existing is None:
+                    inserted_ids.append(item_id)
+                continue
         self._conn.commit()
         return inserted_ids
 
-    def unread(self, kind: str) -> list[dict[str, Any]]:
-        rows = self._conn.execute(
-            """
+    def unread(self, kind: str, *, limit: int | None = None) -> list[dict[str, Any]]:
+        query = """
             SELECT * FROM reservoir_events
             WHERE kind = ? AND status = 'unread'
             ORDER BY original_source_id ASC, published_at DESC, first_seen_at DESC
-            """,
-            (kind,),
-        ).fetchall()
+        """
+        params: tuple[Any, ...] = (kind,)
+        if limit is not None:
+            query += " LIMIT ?"
+            params += (max(0, int(limit)),)
+        rows = self._conn.execute(query, params).fetchall()
         result: list[dict[str, Any]] = []
         for row in rows:
             payload = json.loads(row["payload_json"])
@@ -422,6 +568,109 @@ class WakeStateStore:
                 payload["_event_embedding"] = json.loads(row["embedding_json"])
             result.append(payload)
         return result
+
+    def unread_aggregate_mass(
+        self,
+        kind: str,
+        *,
+        now: datetime | None = None,
+    ) -> float:
+        """用 SQL 计算带时间衰减的旧池总分，不把 payload 载入内存。"""
+
+        if now is None:
+            row = self._conn.execute(
+                """
+                SELECT coalesce(sum(preprocess_score), 0.0) AS mass
+                FROM reservoir_events
+                WHERE kind = ? AND status IN ('unread', 'pending_expiry')
+                """,
+                (kind,),
+            ).fetchone()
+        else:
+            row = self._conn.execute(
+                """
+                SELECT coalesce(sum(
+                    -ln(max(1e-9, 1.0 - preprocess_score))
+                    * exp(
+                        -0.6931471805599453
+                        * max(0.0, julianday(?) - julianday(
+                            coalesce(nullif(published_at, ''), first_seen_at)
+                        )) * 24.0 / 36.0
+                    )
+                ), 0.0) AS mass
+                FROM reservoir_events
+                WHERE kind = ? AND status IN ('unread', 'pending_expiry')
+                """,
+                (now.isoformat(), kind),
+            ).fetchone()
+        return float(row["mass"] if row is not None else 0.0)
+
+    def expiry_candidates(
+        self,
+        kind: str,
+        *,
+        before: datetime,
+        limit: int = 256,
+    ) -> list[dict[str, Any]]:
+        """只读取达到最小驻留期的元数据，供衰减清理而非素材窗口。"""
+
+        rows = self._conn.execute(
+            """
+            SELECT item_id, original_source_id, ack_source_id, source_event_id,
+                   published_at, first_seen_at, preprocess_score
+            FROM reservoir_events
+            WHERE kind = ? AND status = 'unread' AND first_seen_at <= ?
+            ORDER BY first_seen_at ASC
+            LIMIT ?
+            """,
+            (kind, before.isoformat(), max(0, int(limit))),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def record_quarantine(
+        self,
+        *,
+        source_id: str,
+        item_id: str,
+        reason: str,
+        payload: object,
+        commit: bool = True,
+    ) -> None:
+        """按 source/item identity upsert 隔离诊断，避免 raw 无限追加。"""
+
+        identity = f"{source_id}:{item_id}"
+        now = datetime.now().astimezone().isoformat()
+        _ = self._conn.execute(
+            """
+            INSERT INTO reservoir_quarantine(
+                identity, source_id, item_id, reason, payload_json,
+                first_seen_at, last_seen_at, occurrences
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+            ON CONFLICT(identity) DO UPDATE SET
+                reason=excluded.reason,
+                payload_json=excluded.payload_json,
+                last_seen_at=excluded.last_seen_at,
+                occurrences=reservoir_quarantine.occurrences + 1
+            """,
+            (
+                identity,
+                source_id,
+                item_id,
+                reason,
+                json.dumps(payload, ensure_ascii=False, default=str),
+                now,
+                now,
+            ),
+        )
+        if commit:
+            self._conn.commit()
+
+    def quarantined(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM reservoir_quarantine ORDER BY last_seen_at DESC LIMIT ?",
+            (max(0, int(limit)),),
+        ).fetchall()
+        return [dict(row) for row in rows]
 
     def consume(self, item_ids: list[str], now: datetime) -> None:
         if not item_ids:
@@ -467,11 +716,12 @@ class WakeStateStore:
                 _ = self._conn.execute(
                     """
                     INSERT INTO pending_acknowledgements(
-                        source_id, source_event_id, queued_at
-                    ) VALUES (?, ?, ?)
-                    ON CONFLICT(source_id, source_event_id) DO NOTHING
+                        source_id, source_event_id, item_id, action, queued_at
+                    ) VALUES (?, ?, coalesce((SELECT item_id FROM reservoir_events
+                        WHERE ack_source_id = ? AND source_event_id = ? LIMIT 1), ''), 'consume', ?)
+                    ON CONFLICT DO NOTHING
                     """,
-                    (source_id, event_id, now.isoformat()),
+                    (source_id, event_id, source_id, event_id, now.isoformat()),
                 )
         self._conn.commit()
 
@@ -497,12 +747,54 @@ class WakeStateStore:
                 _ = self._conn.execute(
                     """
                     INSERT INTO pending_acknowledgements(
-                        source_id, source_event_id, queued_at
-                    ) VALUES (?, ?, ?)
-                    ON CONFLICT(source_id, source_event_id) DO NOTHING
+                        source_id, source_event_id, item_id, action, queued_at
+                    ) VALUES (?, ?, coalesce((SELECT item_id FROM reservoir_events
+                        WHERE ack_source_id = ? AND source_event_id = ? LIMIT 1), ''), 'consume', ?)
+                    ON CONFLICT DO NOTHING
                     """,
-                    (source_id, event_id, now.isoformat()),
+                    (source_id, event_id, source_id, event_id, now.isoformat()),
                 )
+        self._conn.commit()
+
+    def queue_expiration(self, item_ids: list[str], now: datetime) -> None:
+        """登记低分事件的 expire ack，ack 成功前保留 payload。"""
+
+        unique_ids = list(dict.fromkeys(item_ids))
+        if not unique_ids:
+            return
+        placeholders = ",".join("?" for _ in unique_ids)
+        rows = self._conn.execute(
+            f"""
+            SELECT item_id, ack_source_id, source_event_id
+            FROM reservoir_events
+            WHERE item_id IN ({placeholders}) AND status = 'unread'
+            """,
+            tuple(unique_ids),
+        ).fetchall()
+        for row in rows:
+            if not str(row["ack_source_id"] or ""):
+                continue
+            _ = self._conn.execute(
+                """
+                UPDATE reservoir_events SET status = 'pending_expiry'
+                WHERE item_id = ? AND status = 'unread'
+                """,
+                (str(row["item_id"]),),
+            )
+            _ = self._conn.execute(
+                """
+                INSERT INTO pending_acknowledgements(
+                    source_id, source_event_id, item_id, action, queued_at
+                ) VALUES (?, ?, ?, 'expire', ?)
+                ON CONFLICT DO NOTHING
+                """,
+                (
+                    str(row["ack_source_id"]),
+                    str(row["source_event_id"]),
+                    str(row["item_id"]),
+                    now.isoformat(),
+                ),
+            )
         self._conn.commit()
 
     def pending_acknowledgements(self) -> dict[str, list[str]]:
@@ -520,6 +812,16 @@ class WakeStateStore:
             )
         return grouped
 
+    def pending_acknowledgement_batches(self) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT source_id, source_event_id, item_id, action
+            FROM pending_acknowledgements
+            ORDER BY queued_at, source_id, source_event_id, item_id
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     def mark_acknowledged(
         self,
         source_id: str,
@@ -528,14 +830,32 @@ class WakeStateStore:
         if not event_ids:
             return
         placeholders = ",".join("?" for _ in event_ids)
-        _ = self._conn.execute(
+        rows = self._conn.execute(
             f"""
-            DELETE FROM pending_acknowledgements
+            SELECT item_id, action FROM pending_acknowledgements
             WHERE source_id = ? AND source_event_id IN ({placeholders})
             """,
             (source_id, *event_ids),
-        )
-        self._conn.commit()
+        ).fetchall()
+        try:
+            for row in rows:
+                if str(row["action"]) == "expire" and str(row["item_id"]):
+                    _ = self._conn.execute(
+                        "DELETE FROM reservoir_events "
+                        "WHERE item_id = ? AND status = 'pending_expiry'",
+                        (str(row["item_id"]),),
+                    )
+            _ = self._conn.execute(
+                f"""
+                DELETE FROM pending_acknowledgements
+                WHERE source_id = ? AND source_event_id IN ({placeholders})
+                """,
+                (source_id, *event_ids),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
 
     def unembedded(self, limit: int = 64) -> list[dict[str, str]]:
         rows = self._conn.execute(
@@ -898,6 +1218,12 @@ def _parse_optional_time(value: object) -> datetime | None:
     if value is None or not str(value).strip():
         return None
     return datetime.fromisoformat(str(value))
+
+
+def _stable_quarantine_id(kind: str, payload: object) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:24]
+    return f"{kind}:{digest}"
 
 
 def _decode_context_row(row: sqlite3.Row) -> NormalizedContext:

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -33,6 +33,8 @@ class SourceChannels(dict[str, list[dict[str, Any]]]):
     def __init__(self) -> None:
         super().__init__({"alert": [], "content": [], "context": []})
         self.quarantined: list[QuarantinedItem] = []
+        self.quarantine_overflow: dict[str, int] = {}
+        self.quarantine_overflow_count = 0
 
 
 class McpGateway(Protocol):
@@ -109,6 +111,11 @@ async def fetch_sources_async(
         channels.quarantined.extend(
             getattr(result, "quarantined", [])
         )
+        overflow_count = int(getattr(result, "quarantine_overflow_count", 0))
+        if overflow_count:
+            channels.quarantine_overflow[key] = (
+                channels.quarantine_overflow.get(key, 0) + overflow_count
+            )
     if failures and succeeded == 0:
         raise RuntimeError(f"所有 proactive sources 拉取失败: {failures}")
     return channels
@@ -147,6 +154,8 @@ async def fetch_source_strict_async(
                 result.quarantined.append(
                     QuarantinedItem(key, item_id, str(exc), raw)
                 )
+            else:
+                result.quarantine_overflow_count += 1
             logger.warning(
                 "[proactive.source] item quarantined source=%s item=%s reason=%s",
                 key,

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -11,6 +14,25 @@ from agent.tools.base import ToolResult
 from agent.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantinedItem:
+    """保留单条 MCP 输入的可查询诊断，而不阻断同批合法记录。"""
+
+    source_id: str
+    item_id: str
+    reason: str
+    payload: object
+
+
+class SourceChannels(dict[str, list[dict[str, Any]]]):
+    """三类 source 结果及同批被隔离的单条输入。"""
+
+    def __init__(self) -> None:
+        super().__init__({"alert": [], "content": [], "context": []})
+        self.quarantined: list[QuarantinedItem] = []
+
 
 class McpGateway(Protocol):
     async def call(
@@ -63,14 +85,15 @@ async def fetch_sources_async(
     sources: list[RegisteredProactiveSource],
 ) -> dict[str, list[dict[str, Any]]]:
     results = await asyncio.gather(
-        *(fetch_source_strict_async(pool, source) for source in sources),
+        *(
+            fetch_source_strict_async(
+                pool, source, quarantine_invalid=True
+            )
+            for source in sources
+        ),
         return_exceptions=True,
     )
-    channels: dict[str, list[dict[str, Any]]] = {
-        "alert": [],
-        "content": [],
-        "context": [],
-    }
+    channels = SourceChannels()
     succeeded = 0
     failures: list[str] = []
     for source, result in zip(sources, results):
@@ -82,6 +105,9 @@ async def fetch_sources_async(
         succeeded += 1
         for channel, items in result.items():
             channels[channel].extend(items)
+        channels.quarantined.extend(
+            getattr(result, "quarantined", [])
+        )
     if failures and succeeded == 0:
         raise RuntimeError(f"所有 proactive sources 拉取失败: {failures}")
     return channels
@@ -90,16 +116,14 @@ async def fetch_sources_async(
 async def fetch_source_strict_async(
     pool: McpGateway,
     source: RegisteredProactiveSource,
+    *,
+    quarantine_invalid: bool = False,
 ) -> dict[str, list[dict[str, Any]]]:
     """拉取并严格校验单个 source，保留原始失败。"""
 
     spec = source.spec
     key = source_key(source)
-    result: dict[str, list[dict[str, Any]]] = {
-        "alert": [],
-        "content": [],
-        "context": [],
-    }
+    result = SourceChannels()
     if spec.fetch_page_size > 0:
         data = await _fetch_pages(pool, source)
     else:
@@ -111,27 +135,84 @@ async def fetch_source_strict_async(
         return result
     if not isinstance(data, list):
         raise RuntimeError(f"source 返回值必须是 list 或 context dict: {key}")
-    for raw in data:
-        if not isinstance(raw, dict):
-            raise RuntimeError(
-                f"source item 必须是 object: {key} ({type(raw).__name__})"
+    for index, raw in enumerate(data):
+        item_id = _item_identity(raw, index)
+        try:
+            item = _validate_item(raw, spec.channels, key)
+        except ValueError as exc:
+            if not quarantine_invalid:
+                raise RuntimeError(str(exc)) from exc
+            result.quarantined.append(
+                QuarantinedItem(key, item_id, str(exc), raw)
             )
-        kind = str(raw.get("kind") or "").strip()
-        if not kind and len(spec.channels) == 1:
-            kind = spec.channels[0]
+            logger.warning(
+                "[proactive.source] item quarantined source=%s item=%s reason=%s",
+                key,
+                item_id,
+                exc,
+            )
+            continue
+        kind = str(item.get("kind") or "")
         if kind not in spec.channels:
             continue
-        if kind in {"alert", "content"} and not str(
-            raw.get("event_id") or raw.get("id") or ""
-        ).strip():
-            raise RuntimeError(f"source item 缺少 event_id/id: {key}")
-        item = dict(raw)
         if kind == "context":
             item.setdefault("_source", key)
         else:
             item.setdefault("ack_server", key)
         result[kind].append(item)
     return result
+
+
+def _item_identity(raw: object, index: int) -> str:
+    if isinstance(raw, dict):
+        value = raw.get("event_id") or raw.get("id")
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return f"index:{index}"
+
+
+def _validate_item(
+    raw: object,
+    declared_channels: tuple[str, ...],
+    source_id: str,
+) -> dict[str, Any]:
+    """在 MCP 信任边界验证一条记录，失败只返回该条 quarantine。"""
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"source item 必须是 object ({type(raw).__name__})")
+    item = dict(raw)
+    kind = str(item.get("kind") or "").strip()
+    if not kind and len(declared_channels) == 1:
+        kind = declared_channels[0]
+    if kind not in declared_channels:
+        raise ValueError(f"kind 未声明或为空: {source_id}")
+    if kind in {"alert", "content"}:
+        if not str(item.get("event_id") or item.get("id") or "").strip():
+            raise ValueError(f"source item 缺少 event_id/id: {source_id}")
+        score_value = item.get("preprocess_score")
+        if score_value is None:
+            score_value = item.get("rank_score", 0.0)
+        try:
+            score = float(score_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"score 非数字: {source_id}") from exc
+        if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+            raise ValueError(f"score 超出 [0,1] 或非 finite: {source_id}")
+        item["preprocess_score"] = score
+    for field in ("published_at", "triggered_at", "first_seen_at"):
+        if field not in item or item[field] in (None, ""):
+            continue
+        try:
+            parsed = item[field]
+            if isinstance(parsed, datetime):
+                value = parsed
+            else:
+                value = datetime.fromisoformat(str(parsed))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field} 不是 ISO timestamp: {source_id}") from exc
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError(f"{field} 必须带 timezone: {source_id}")
+    return item
 
 
 async def _fetch_pages(

--- a/proactive_v2/mcp_sources.py
+++ b/proactive_v2/mcp_sources.py
@@ -14,6 +14,7 @@ from agent.tools.base import ToolResult
 from agent.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+MAX_QUARANTINE_ITEMS_PER_SOURCE = 256
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,9 +143,10 @@ async def fetch_source_strict_async(
         except ValueError as exc:
             if not quarantine_invalid:
                 raise RuntimeError(str(exc)) from exc
-            result.quarantined.append(
-                QuarantinedItem(key, item_id, str(exc), raw)
-            )
+            if len(result.quarantined) < MAX_QUARANTINE_ITEMS_PER_SOURCE:
+                result.quarantined.append(
+                    QuarantinedItem(key, item_id, str(exc), raw)
+                )
             logger.warning(
                 "[proactive.source] item quarantined source=%s item=%s reason=%s",
                 key,
@@ -186,6 +188,7 @@ def _validate_item(
         kind = declared_channels[0]
     if kind not in declared_channels:
         raise ValueError(f"kind 未声明或为空: {source_id}")
+    item["kind"] = kind
     if kind in {"alert", "content"}:
         if not str(item.get("event_id") or item.get("id") or "").strip():
             raise ValueError(f"source item 缺少 event_id/id: {source_id}")
@@ -248,8 +251,12 @@ async def acknowledge_async(
     feedback: str | None = None,
 ) -> None:
     source = next((item for item in sources if source_key(item) == source_id), None)
-    if source is None or not source.spec.ack_tool or not event_ids:
+    if not event_ids:
         return
+    if source is None:
+        raise RuntimeError(f"MCP ack source 不存在: {source_id}")
+    if not source.spec.ack_tool:
+        raise RuntimeError(f"MCP source 未声明 ack tool: {source_id}")
     args: dict[str, Any] = {"event_ids": event_ids}
     if feedback is not None:
         args["feedback"] = feedback

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -240,6 +240,39 @@ async def test_single_channel_infers_kind_and_writes_it_back() -> None:
 
 
 @pytest.mark.asyncio
+async def test_quarantine_overflow_is_counted_without_retaining_raw_items() -> None:
+    pool = FakePool(
+        {
+            ("feed", "events"): [
+                {
+                    "kind": "content",
+                    "event_id": f"bad-{index}",
+                    "preprocess_score": float("nan"),
+                }
+                for index in range(300)
+            ]
+            + [
+                {
+                    "kind": "content",
+                    "event_id": "good-after-overflow",
+                    "preprocess_score": 0.4,
+                }
+            ]
+        }
+    )
+    result = await mcp_sources.fetch_sources_async(
+        cast(Any, pool),
+        [source("feed", "content", ("content",), "feed", "events")],
+    )
+
+    assert len(result.quarantined) == mcp_sources.MAX_QUARANTINE_ITEMS_PER_SOURCE
+    assert result.quarantine_overflow == {"feed:content": 44}
+    assert [item["event_id"] for item in result["content"]] == [
+        "good-after-overflow"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ack_without_declared_tool_is_not_local_success() -> None:
     pool = FakePool({("feed", "events"): []})
     no_ack = source("feed", "content", ("content",), "feed", "events")

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -188,6 +188,37 @@ async def test_fetch_source_rejects_corrupt_event_items(
 
 
 @pytest.mark.asyncio
+async def test_fetch_quarantines_one_bad_item_and_keeps_valid_batch_item() -> None:
+    pool = FakePool(
+        {
+            ("feed", "events"): [
+                {
+                    "kind": "content",
+                    "event_id": "good",
+                    "preprocess_score": 0.4,
+                    "published_at": "2026-07-12T00:00:00+00:00",
+                },
+                {
+                    "kind": "content",
+                    "event_id": "bad",
+                    "preprocess_score": float("nan"),
+                    "published_at": "2026-07-12T00:00:00+00:00",
+                },
+            ]
+        }
+    )
+    result = await mcp_sources.fetch_sources_async(
+        cast(Any, pool),
+        [source("feed", "content", ("content",), "feed", "events")],
+    )
+
+    assert [item["event_id"] for item in result["content"]] == ["good"]
+    assert [(item.item_id, item.source_id) for item in result.quarantined] == [
+        ("bad", "feed:content")
+    ]
+
+
+@pytest.mark.asyncio
 async def test_fetch_isolates_single_source_failure() -> None:
     pool = FakePool(
         {("ok", "events"): [{"kind": "content", "event_id": "1"}], ("bad", "events"): []},

--- a/tests/test_mcp_sources_async.py
+++ b/tests/test_mcp_sources_async.py
@@ -219,6 +219,38 @@ async def test_fetch_quarantines_one_bad_item_and_keeps_valid_batch_item() -> No
 
 
 @pytest.mark.asyncio
+async def test_single_channel_infers_kind_and_writes_it_back() -> None:
+    pool = FakePool(
+        {
+            ("feed", "events"): [
+                {
+                    "event_id": "missing-kind",
+                    "preprocess_score": 0.2,
+                    "published_at": "2026-07-12T00:00:00+00:00",
+                }
+            ]
+        }
+    )
+    result = await mcp_sources.fetch_sources_async(
+        cast(Any, pool),
+        [source("feed", "content", ("content",), "feed", "events")],
+    )
+
+    assert result["content"][0]["kind"] == "content"
+
+
+@pytest.mark.asyncio
+async def test_ack_without_declared_tool_is_not_local_success() -> None:
+    pool = FakePool({("feed", "events"): []})
+    no_ack = source("feed", "content", ("content",), "feed", "events")
+
+    with pytest.raises(RuntimeError, match="未声明 ack tool"):
+        await mcp_sources.acknowledge_async(
+            cast(Any, pool), [no_ack], "feed:content", ["event-1"]
+        )
+
+
+@pytest.mark.asyncio
 async def test_fetch_isolates_single_source_failure() -> None:
     pool = FakePool(
         {("ok", "events"): [{"kind": "content", "event_id": "1"}], ("bad", "events"): []},

--- a/tests/test_schedule_tool.py
+++ b/tests/test_schedule_tool.py
@@ -144,6 +144,28 @@ async def test_instant_after_registers_job(tmp_path, mock_push, mock_loop):
     assert job.message == "喝水了"
 
 
+async def test_capacity_error_is_converted_for_agent(tmp_path, mock_push, mock_loop):
+    svc = make_svc(tmp_path, mock_push, mock_loop)
+    for index in range(SchedulerService.MAX_ACTIVE_JOBS):
+        svc.add_job(make_job(name=f"job-{index}"))
+    tool = ScheduleTool(svc, default_tz="UTC")
+
+    result = await tool.execute(
+        tier="instant",
+        trigger="after",
+        when="5m",
+        channel="telegram",
+        chat_id="123",
+        message="overflow",
+        request_time=_NOW.isoformat(),
+    )
+
+    assert "schedule_capacity_reached" in result
+    assert "已有 10 个活动定时任务" in result
+    assert "移除哪个不再需要的任务" in result
+    assert len(svc.list_jobs()) == SchedulerService.MAX_ACTIVE_JOBS
+
+
 async def test_after_request_time_used_for_fire_at(tmp_path, mock_push, mock_loop):
     svc = make_svc(tmp_path, mock_push, mock_loop)
     tool = ScheduleTool(svc, default_tz="UTC")

--- a/tests/test_schedule_tool.py
+++ b/tests/test_schedule_tool.py
@@ -315,6 +315,37 @@ async def test_cancel_by_id(tmp_path, mock_push, mock_loop):
     assert job.id not in svc._jobs
 
 
+async def test_cancel_disabled_by_id_prefix_after_recovery(
+    tmp_path, mock_push, mock_loop
+):
+    svc = make_svc(tmp_path, mock_push, mock_loop)
+    disabled_target = make_job(name="disabled-target")
+    disabled_target.id = "target-123456"
+    disabled_target.enabled = False
+    disabled_other = make_job(name="disabled-other")
+    disabled_other.id = "other-456789"
+    disabled_other.enabled = False
+    active = make_job(name="active")
+    active.id = "active-job-789"
+    svc.store.save(
+        {
+            disabled_target.id: disabled_target,
+            disabled_other.id: disabled_other,
+            active.id: active,
+        }
+    )
+    svc.load_and_recover()
+
+    result = await CancelScheduleTool(svc).execute(id="target-1")
+
+    assert "已取消 1 个任务" in result
+    assert set(svc._jobs) == {active.id}
+    assert {job.id for job in svc.store.load()} == {
+        disabled_other.id,
+        active.id,
+    }
+
+
 async def test_cancel_by_name(tmp_path, mock_push, mock_loop):
     svc = make_svc(tmp_path, mock_push, mock_loop)
     job = make_job(name="daily-report")

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -177,10 +177,12 @@ async def test_instant_not_fired_before_fire_at(
     mock_push.execute.assert_not_called()
 
 
-# ── One-shot jobs removed after firing ───────────────────────────
+# ── One-shot jobs retained as disabled after firing ──────────────
 
 
-async def test_at_job_removed_after_fire(tmp_path, mock_push, mock_loop, fixed_now):
+async def test_at_job_retained_disabled_after_fire(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
     svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
     job = make_job(
         trigger="at", tier="instant", fire_at=fixed_now - timedelta(seconds=1)
@@ -191,9 +193,17 @@ async def test_at_job_removed_after_fire(tmp_path, mock_push, mock_loop, fixed_n
     await drain_tasks()
 
     assert job.id not in svc._jobs
+    assert svc.list_jobs() == []
+    persisted = svc.store.load()
+    assert len(persisted) == 1
+    assert persisted[0].id == job.id
+    assert persisted[0].enabled is False
+    assert persisted[0].run_count == 1
 
 
-async def test_after_job_removed_after_fire(tmp_path, mock_push, mock_loop, fixed_now):
+async def test_after_job_retained_disabled_after_fire(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
     svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
     job = make_job(
         trigger="after", tier="instant", fire_at=fixed_now - timedelta(seconds=1)
@@ -204,6 +214,27 @@ async def test_after_job_removed_after_fire(tmp_path, mock_push, mock_loop, fixe
     await drain_tasks()
 
     assert job.id not in svc._jobs
+    assert svc.store.load()[0].enabled is False
+    assert svc.store.load()[0].run_count == 1
+
+
+async def test_failed_one_shot_is_retained_disabled_without_run_count_increment(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    mock_push.execute.side_effect = RuntimeError("push failed")
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    job = make_job(
+        trigger="after", tier="instant", fire_at=fixed_now - timedelta(seconds=1)
+    )
+    svc._jobs[job.id] = job
+
+    await svc._tick()
+    await drain_tasks()
+
+    assert svc._jobs == {}
+    persisted = svc.store.load()
+    assert persisted[0].enabled is False
+    assert persisted[0].run_count == 0
 
 
 # ── Every: rescheduling ───────────────────────────────────────────
@@ -636,8 +667,10 @@ def test_misfire_within_grace_loaded(tmp_path, mock_push, mock_loop, fixed_now):
     assert job.id in svc._jobs
 
 
-def test_misfire_beyond_grace_discarded(tmp_path, mock_push, mock_loop, fixed_now):
-    """Jobs missed beyond 5min grace are discarded on startup."""
+def test_misfire_beyond_grace_retained_disabled_after_restart(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    """Jobs missed beyond 5min grace remain as disabled terminal records."""
     svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
     job = make_job(
         trigger="at",
@@ -648,6 +681,55 @@ def test_misfire_beyond_grace_discarded(tmp_path, mock_push, mock_loop, fixed_no
     svc.load_and_recover()
 
     assert job.id not in svc._jobs
+    assert svc.list_jobs() == []
+    assert svc.match_job_ids(job.id[:8]) == [job.id]
+    persisted = svc.store.load()
+    assert len(persisted) == 1
+    assert persisted[0].enabled is False
+
+    restarted = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    restarted.load_and_recover()
+    assert restarted._jobs == {}
+    assert restarted.match_job_ids(job.id) == [job.id]
+    assert restarted.store.load()[0].enabled is False
+
+
+async def test_terminal_disabled_job_does_not_consume_capacity(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    terminal = make_job(
+        trigger="at", tier="instant", fire_at=fixed_now - timedelta(seconds=1)
+    )
+    svc._jobs[terminal.id] = terminal
+
+    await svc._tick()
+    await drain_tasks()
+
+    assert svc._jobs == {}
+    assert svc.store.load()[0].enabled is False
+    for index in range(SchedulerService.MAX_ACTIVE_JOBS):
+        svc.add_job(make_job(name=f"active-{index}"))
+    with pytest.raises(ScheduleCapacityError):
+        svc.add_job(make_job(name="overflow"))
+    assert terminal.id in svc.match_job_ids(terminal.id)
+
+
+async def test_terminal_disabled_job_is_removed_only_by_explicit_cancel(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    terminal = make_job(
+        trigger="at", tier="instant", fire_at=fixed_now - timedelta(seconds=1)
+    )
+    svc._jobs[terminal.id] = terminal
+
+    await svc._tick()
+    await drain_tasks()
+    assert svc.store.load()[0].enabled is False
+
+    assert svc.cancel_job(terminal.id) is True
+    assert svc.store.load() == []
 
 
 def test_every_misfire_advances_to_future(tmp_path, mock_push, mock_loop, fixed_now):

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import replace
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -308,9 +309,104 @@ def test_disabled_job_does_not_consume_capacity(
     disabled.enabled = False
     svc.add_job(disabled)
 
-    assert len(svc._jobs) == SchedulerService.MAX_ACTIVE_JOBS + 1
+    assert len(svc._jobs) == SchedulerService.MAX_ACTIVE_JOBS
+    assert {job.id for job in svc.store.load()} == {
+        *svc._jobs,
+        disabled.id,
+    }
     with pytest.raises(ScheduleCapacityError):
         svc.add_job(make_job(name="overflow"))
+
+
+def test_legacy_disabled_job_survives_add(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    disabled = make_job(
+        name="legacy-disabled",
+        fire_at=fixed_now + timedelta(hours=1),
+    )
+    disabled.enabled = False
+    svc.store.save({disabled.id: disabled})
+
+    svc.load_and_recover()
+    active = make_job(
+        name="new-active",
+        fire_at=fixed_now + timedelta(hours=2),
+    )
+    svc.add_job(active)
+
+    assert set(svc._jobs) == {active.id}
+    assert {job.id for job in svc.store.load()} == {disabled.id, active.id}
+    assert svc.store.load()[0].enabled is False
+
+
+def test_cancel_other_keeps_disabled_job(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    disabled = make_job(
+        name="disabled-other",
+        fire_at=fixed_now + timedelta(hours=1),
+    )
+    disabled.enabled = False
+    target = make_job(
+        name="cancel-target",
+        fire_at=fixed_now + timedelta(hours=2),
+    )
+    svc.store.save({disabled.id: disabled, target.id: target})
+    svc.load_and_recover()
+
+    assert svc.cancel_job(target.id) is True
+
+    persisted = svc.store.load()
+    assert [job.id for job in persisted] == [disabled.id]
+    assert persisted[0].enabled is False
+
+
+def test_empty_persisted_set_does_not_revive_stale_active_job(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    stale = make_job(name="stale")
+    svc._jobs[stale.id] = stale
+    svc._commit_jobs({})
+
+    fresh = make_job(name="fresh")
+    svc.add_job(fresh)
+
+    assert set(svc._jobs) == {fresh.id}
+    assert [job.id for job in svc.store.load()] == [fresh.id]
+
+
+def test_replace_and_cancel_disabled_job(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    disabled = make_job(
+        name="replace-me",
+        fire_at=fixed_now + timedelta(hours=1),
+    )
+    disabled.enabled = False
+    svc.store.save({disabled.id: disabled})
+    svc.load_and_recover()
+
+    replacement = make_job(
+        name="replacement",
+        fire_at=fixed_now + timedelta(hours=2),
+    )
+    replacement.id = disabled.id
+    svc.add_job(replacement)
+    assert set(svc._jobs) == {disabled.id}
+    assert svc.store.load()[0].enabled is True
+
+    replacement_disabled = replace(replacement, enabled=False)
+    svc.add_job(replacement_disabled)
+    assert disabled.id not in svc._jobs
+    assert svc.store.load()[0].enabled is False
+
+    assert svc.cancel_job(disabled.id) is True
+    assert svc.store.load() == []
 
 
 def test_cancel_job_keeps_memory_state_when_persistence_fails(

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-from agent.scheduler import LatencyTracker, SchedulerService, ScheduledJob
+from agent.scheduler import (
+    LatencyTracker,
+    ScheduleCapacityError,
+    SchedulerService,
+    ScheduledJob,
+)
 from tests.conftest import drain_tasks, make_job
 
 # ── Helpers ──────────────────────────────────────────────────────
@@ -252,6 +257,60 @@ def test_add_job_does_not_publish_memory_state_when_persistence_fails(
         svc.add_job(job)
 
     assert svc.list_jobs() == []
+
+
+def test_add_job_rejects_eleventh_active_job_without_write(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    for index in range(SchedulerService.MAX_ACTIVE_JOBS):
+        svc.add_job(make_job(name=f"job-{index}"))
+    before = svc.store.path.read_bytes()
+    svc.store.save = MagicMock(wraps=svc.store.save)
+
+    with pytest.raises(ScheduleCapacityError) as exc_info:
+        svc.add_job(make_job(name="overflow"))
+
+    assert exc_info.value.code == "schedule_capacity_reached"
+    assert exc_info.value.active_jobs == SchedulerService.MAX_ACTIVE_JOBS
+    assert len(svc.list_jobs()) == SchedulerService.MAX_ACTIVE_JOBS
+    assert svc.store.save.call_count == 0
+    assert svc.store.path.read_bytes() == before
+
+
+def test_add_job_replacement_does_not_consume_capacity(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    jobs = [
+        make_job(name=f"job-{index}")
+        for index in range(SchedulerService.MAX_ACTIVE_JOBS)
+    ]
+    for job in jobs:
+        svc.add_job(job)
+
+    replacement = make_job(name="replacement")
+    replacement.id = jobs[0].id
+    svc.add_job(replacement)
+
+    assert len(svc.list_jobs()) == SchedulerService.MAX_ACTIVE_JOBS
+    assert svc._jobs[replacement.id] is replacement
+
+
+def test_disabled_job_does_not_consume_capacity(
+    tmp_path, mock_push, mock_loop, fixed_now
+):
+    svc = make_service(tmp_path, mock_push, mock_loop, fixed_now)
+    for index in range(SchedulerService.MAX_ACTIVE_JOBS):
+        svc.add_job(make_job(name=f"job-{index}"))
+
+    disabled = make_job(name="disabled")
+    disabled.enabled = False
+    svc.add_job(disabled)
+
+    assert len(svc._jobs) == SchedulerService.MAX_ACTIVE_JOBS + 1
+    with pytest.raises(ScheduleCapacityError):
+        svc.add_job(make_job(name="overflow"))
 
 
 def test_cancel_job_keeps_memory_state_when_persistence_fails(

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -342,7 +342,7 @@ async def test_content_vertical_slice_filters_investigates_and_shares(
     assert "scratchpad" not in final_messages[-1]["content"]
     assert "share_content" in final_messages[-1]["content"]
     assert "skip_content" in final_messages[-1]["content"]
-    assert gateway.acks == [{"event_ids": ["new", "old"]}]
+    assert gateway.acks == [{"event_ids": ["new"]}]
     assert [event["id"] for event in runtime._state.unread("content")] == [ids[1]]
 
 
@@ -401,10 +401,10 @@ async def test_content_skip_keeps_full_unread_window_when_title_page_is_capped(
     await runtime.decide(state)
 
     observation = runtime._state.observations("content")[0]
-    assert len(json.loads(observation["candidates_json"])) == 120
-    assert state.ctx.content_backlog_count == 1
+    assert len(json.loads(observation["candidates_json"])) == 100
+    assert state.ctx.content_backlog_count == 21
     assert len(runtime._state.unread("content")) == 121
-    assert len(gateway.acks[0]["event_ids"]) == 121
+    assert gateway.acks == []
 
 
 @pytest.mark.asyncio
@@ -443,6 +443,51 @@ async def test_decayed_content_is_acknowledged_without_wake(tmp_path, request):
     assert runtime._state.unread("content") == []
     assert runtime._state.observations("content") == []
     assert gateway.acks == [{"event_ids": ["stale"]}]
+
+
+@pytest.mark.asyncio
+async def test_decayed_content_keeps_payload_until_ack_retry_succeeds(tmp_path, request):
+    now = datetime(2026, 7, 12, tzinfo=UTC)
+    gateway = FlakyAckGateway(
+        [
+            {
+                "kind": "content",
+                "event_id": "stale-retry",
+                "title": "需要重试 ack 的旧内容",
+                "published_at": (now - timedelta(days=30)).isoformat(),
+                "preprocess_score": 0.9,
+            }
+        ]
+    )
+    scope = _scope(
+        tmp_path,
+        gateway,
+        SimpleNamespace(chat=AsyncMock()),
+        FakeOrchestrator(),
+        _source("content"),
+    )
+    scope.memory.embedding_api = None
+    store = WakeStateStore(tmp_path / "wake.db")
+    runtime = WakeRuntime(scope, state_store=store, clock=FixedClock(now))
+    request.addfinalizer(runtime.close)
+
+    first = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(first)
+    await runtime.decide(first)
+    assert store.pending_acknowledgement_batches()[0]["action"] == "expire"
+    assert store._conn.execute(
+        "SELECT 1 FROM reservoir_events WHERE item_id = ?",
+        ("feed_plugin:main:stale-retry",),
+    ).fetchone() is not None
+
+    gateway.events = []
+    second = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(second)
+    assert store.pending_acknowledgements() == {}
+    assert store._conn.execute(
+        "SELECT 1 FROM reservoir_events WHERE item_id = ?",
+        ("feed_plugin:main:stale-retry",),
+    ).fetchone() is None
 
 
 @pytest.mark.asyncio

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -449,6 +449,47 @@ async def test_ingest_after_embedding_keeps_material_window_bounded(tmp_path, re
 
 
 @pytest.mark.asyncio
+async def test_runtime_persists_quarantine_overflow_diagnostic(tmp_path, request):
+    events = [
+        {
+            "kind": "content",
+            "event_id": f"bad-{index}",
+            "preprocess_score": float("nan"),
+        }
+        for index in range(300)
+    ]
+    gateway = FakeGateway(events)
+    scope = _scope(
+        tmp_path,
+        gateway,
+        SimpleNamespace(chat=AsyncMock()),
+        FakeOrchestrator(),
+        _source("content"),
+    )
+    scope.memory.embedding_api = None
+    store = WakeStateStore(tmp_path / "wake.db")
+    runtime = WakeRuntime(
+        scope,
+        state_store=store,
+        clock=FixedClock(datetime(2026, 7, 12, tzinfo=UTC)),
+    )
+    request.addfinalizer(runtime.close)
+
+    await runtime.ingest(runtime.begin(new_proactive_frame("telegram:1")))
+
+    rows = store.quarantined(limit=1000)
+    # Per-source persistence remains capped at 100 rows; the synthetic
+    # overflow record must remain queryable within that cap.
+    assert len(rows) == 100
+    overflow = next(row for row in rows if row["item_id"] == "quarantine-overflow")
+    assert json.loads(overflow["payload_json"]) == {
+        "overflow": True,
+        "dropped_count": 44,
+        "detail_cap": 256,
+    }
+
+
+@pytest.mark.asyncio
 async def test_decayed_content_is_acknowledged_without_wake(tmp_path, request):
     now = datetime(2026, 7, 12, tzinfo=UTC)
     gateway = FakeGateway(

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -408,6 +408,47 @@ async def test_content_skip_keeps_full_unread_window_when_title_page_is_capped(
 
 
 @pytest.mark.asyncio
+async def test_ingest_after_embedding_keeps_material_window_bounded(tmp_path, request):
+    now = datetime(2026, 7, 12, tzinfo=UTC)
+    events = [
+        {
+            "kind": "content",
+            "event_id": f"bounded-{index}",
+            "title": f"标题 {index}",
+            "published_at": now.isoformat(),
+            "preprocess_score": 0.5,
+        }
+        for index in range(121)
+    ]
+    gateway = FakeGateway(events)
+    scope = _scope(
+        tmp_path,
+        gateway,
+        SimpleNamespace(chat=AsyncMock()),
+        FakeOrchestrator(),
+        _source("content"),
+    )
+    runtime = WakeRuntime(
+        scope,
+        state_store=WakeStateStore(tmp_path / "wake.db"),
+        clock=FixedClock(now),
+    )
+    request.addfinalizer(runtime.close)
+    statements: list[str] = []
+    runtime._state._conn.set_trace_callback(statements.append)
+    state = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(state)
+    runtime._state._conn.set_trace_callback(None)
+
+    assert len(state.contents) == 100
+    assert any(
+        "FROM reservoir_events" in statement
+        and "LIMIT 100" in statement
+        for statement in statements
+    )
+
+
+@pytest.mark.asyncio
 async def test_decayed_content_is_acknowledged_without_wake(tmp_path, request):
     now = datetime(2026, 7, 12, tzinfo=UTC)
     gateway = FakeGateway(
@@ -429,10 +470,11 @@ async def test_decayed_content_is_acknowledged_without_wake(tmp_path, request):
         _source("content"),
     )
     scope.memory.embedding_api = None
+    clock = FixedClock(now)
     runtime = WakeRuntime(
         scope,
         state_store=WakeStateStore(tmp_path / "wake.db"),
-        clock=FixedClock(now),
+        clock=clock,
     )
     request.addfinalizer(runtime.close)
     state = runtime.begin(new_proactive_frame("telegram:1"))
@@ -440,8 +482,15 @@ async def test_decayed_content_is_acknowledged_without_wake(tmp_path, request):
     await runtime.ingest(state)
     await runtime.decide(state)
 
-    assert runtime._state.unread("content") == []
+    assert len(runtime._state.unread("content")) == 1
     assert runtime._state.observations("content") == []
+    assert gateway.acks == []
+
+    clock.advance(timedelta(days=2))
+    retry = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(retry)
+    await runtime.decide(retry)
+    assert runtime._state.unread("content") == []
     assert gateway.acks == [{"event_ids": ["stale"]}]
 
 
@@ -468,12 +517,18 @@ async def test_decayed_content_keeps_payload_until_ack_retry_succeeds(tmp_path, 
     )
     scope.memory.embedding_api = None
     store = WakeStateStore(tmp_path / "wake.db")
-    runtime = WakeRuntime(scope, state_store=store, clock=FixedClock(now))
+    clock = FixedClock(now)
+    runtime = WakeRuntime(scope, state_store=store, clock=clock)
     request.addfinalizer(runtime.close)
 
     first = runtime.begin(new_proactive_frame("telegram:1"))
     await runtime.ingest(first)
     await runtime.decide(first)
+    assert store.pending_acknowledgements() == {}
+    clock.advance(timedelta(days=2))
+    second = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(second)
+    await runtime.decide(second)
     assert store.pending_acknowledgement_batches()[0]["action"] == "expire"
     assert store._conn.execute(
         "SELECT 1 FROM reservoir_events WHERE item_id = ?",
@@ -481,8 +536,9 @@ async def test_decayed_content_keeps_payload_until_ack_retry_succeeds(tmp_path, 
     ).fetchone() is not None
 
     gateway.events = []
-    second = runtime.begin(new_proactive_frame("telegram:1"))
-    await runtime.ingest(second)
+    gateway.events = []
+    third = runtime.begin(new_proactive_frame("telegram:1"))
+    await runtime.ingest(third)
     assert store.pending_acknowledgements() == {}
     assert store._conn.execute(
         "SELECT 1 FROM reservoir_events WHERE item_id = ?",

--- a/tests/wake_proactive/test_state.py
+++ b/tests/wake_proactive/test_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -88,3 +88,68 @@ def test_context_row_corruption_fails_loud(
 
     with pytest.raises(error_type):
         store.list_contexts()
+
+
+def test_reservoir_quarantine_is_identity_upsert_and_score_validation(store: WakeStateStore) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0, tzinfo=UTC)
+    store.ingest(
+        "content",
+        [
+            {
+                "ack_server": "feed",
+                "source_id": "source",
+                "event_id": "bad",
+                "preprocess_score": float("nan"),
+                "published_at": now.isoformat(),
+            }
+        ],
+        now,
+    )
+    store.ingest(
+        "content",
+        [
+            {
+                "ack_server": "feed",
+                "source_id": "source",
+                "event_id": "bad",
+                "preprocess_score": float("inf"),
+                "published_at": now.isoformat(),
+            }
+        ],
+        now,
+    )
+
+    items = store.quarantined()
+    assert len(items) == 1
+    assert items[0]["identity"] == "feed:feed:bad"
+    assert items[0]["occurrences"] == 2
+
+
+def test_expiry_ack_deletes_payload_only_after_successful_ack(store: WakeStateStore) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0, tzinfo=UTC)
+    store.ingest(
+        "content",
+        [
+            {
+                "ack_server": "feed",
+                "source_id": "source",
+                "event_id": "expire-me",
+                "preprocess_score": 0.1,
+                "published_at": now.isoformat(),
+            }
+        ],
+        now,
+    )
+    store.queue_expiration(["feed:expire-me"], now)
+    assert store.pending_acknowledgement_batches()[0]["action"] == "expire"
+    assert store.unread("content") == []
+    assert store._conn.execute(
+        "SELECT payload_json FROM reservoir_events WHERE item_id = ?",
+        ("feed:expire-me",),
+    ).fetchone() is not None
+
+    store.mark_acknowledged("feed", ["expire-me"])
+    assert store._conn.execute(
+        "SELECT 1 FROM reservoir_events WHERE item_id = ?",
+        ("feed:expire-me",),
+    ).fetchone() is None

--- a/tests/wake_proactive/test_state.py
+++ b/tests/wake_proactive/test_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -153,3 +154,112 @@ def test_expiry_ack_deletes_payload_only_after_successful_ack(store: WakeStateSt
         "SELECT 1 FROM reservoir_events WHERE item_id = ?",
         ("feed:expire-me",),
     ).fetchone() is None
+
+
+def test_future_timestamp_is_quarantined_and_first_seen_uses_local_receive_time(
+    store: WakeStateStore,
+) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0, tzinfo=UTC)
+    inserted = store.ingest(
+        "content",
+        [
+            {
+                "ack_server": "feed",
+                "source_id": "source",
+                "event_id": "old-published",
+                "preprocess_score": 0.5,
+                "published_at": (now - timedelta(days=10)).isoformat(),
+            },
+            {
+                "ack_server": "feed",
+                "source_id": "source",
+                "event_id": "future-published",
+                "preprocess_score": 0.5,
+                "published_at": (now + timedelta(days=2)).isoformat(),
+            },
+        ],
+        now,
+    )
+
+    assert inserted == 1
+    event = store.unread("content")[0]
+    assert event["id"] == "feed:old-published"
+    assert event["first_seen_at"] == now.isoformat()
+    assert store.quarantined()[0]["item_id"] == "feed:future-published"
+
+
+def test_quarantine_caps_payload_and_source_rows(store: WakeStateStore) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0, tzinfo=UTC)
+    events = [
+        {
+            "ack_server": "feed",
+            "source_id": "source",
+            "event_id": f"bad-{index}",
+            "preprocess_score": float("nan"),
+            "payload": "x" * 10_000,
+        }
+        for index in range(120)
+    ]
+    store.ingest("content", events, now)
+
+    rows = store.quarantined(limit=1000)
+    assert len(rows) == 100
+    assert all(len(str(row["payload_json"]).encode("utf-8")) <= 4096 for row in rows)
+
+
+def test_expire_upgrades_pending_consume_and_tombstone_blocks_reingest(
+    store: WakeStateStore,
+) -> None:
+    now = datetime(2026, 7, 23, 3, 0, 0, tzinfo=UTC)
+    event = {
+        "ack_server": "feed",
+        "source_id": "source",
+        "event_id": "same-event",
+        "preprocess_score": 0.1,
+        "published_at": now.isoformat(),
+    }
+    assert store.ingest("content", [event], now) == 1
+    store.consume_and_queue_ack(
+        item_ids=["feed:same-event"],
+        acknowledgements={"feed": ["same-event"]},
+        now=now,
+    )
+    store.queue_expiration(["feed:same-event"], now)
+    assert store.pending_acknowledgement_batches() == [
+        {
+            "source_id": "feed",
+            "source_event_id": "same-event",
+            "item_id": "feed:same-event",
+            "action": "expire",
+        }
+    ]
+    store.mark_acknowledged("feed", ["same-event"])
+    assert store.pending_acknowledgements() == {}
+    assert store.ingest("content", [event], now) == 0
+    assert store._conn.execute(
+        "SELECT 1 FROM reservoir_tombstones WHERE identity = ?",
+        ("feed:same-event",),
+    ).fetchone() is not None
+
+
+def test_legacy_pending_ack_without_unique_reservoir_lineage_fails_loud(tmp_path) -> None:
+    path = tmp_path / "legacy-pending.db"
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE pending_acknowledgements(
+            source_id TEXT NOT NULL,
+            source_event_id TEXT NOT NULL,
+            queued_at TEXT NOT NULL,
+            PRIMARY KEY(source_id, source_event_id)
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO pending_acknowledgements VALUES ('feed', 'missing', '2026-07-23T03:00:00+00:00')"
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(RuntimeError, match="cannot resolve"):
+        WakeStateStore(path)


### PR DESCRIPTION
## Summary

- quarantine malformed MCP wake records without aborting the whole batch
- bound the decaying wake reservoir and expose overflow diagnostics
- cap active schedules at 10 while retaining disabled and terminal one-shot history

## User-visible cases

- the 11th active schedule is rejected with an explicit capacity error so the agent can ask which unused job to remove
- disabled jobs do not consume active capacity and remain available for later re-enable
- expired one-shot jobs remain as terminal history instead of being silently deleted
- low-score wake evidence contributes to future wake-up until it crosses the cleanup floor, but is not injected as prompt material

## Verification

- focused wake/scheduler suite: 121 passed
- `python docker/debug/gate.py audit` — passed on the cumulative stack
- `git diff --check` — passed

## Stack

- base: `codex/companion-security-implementation` (#292)
- next: mobile admission and durable receipts

## Rollback

Restore branch: `backup/companion-security-pr3-before-peer-contract-rebase`.
