### PR TITLE
fix(security): persist mobile admission ownership

### DIFF
--- a/agent/plugins/mobile_ui.py
+++ b/agent/plugins/mobile_ui.py
@@ -15,6 +15,7 @@ from agent.plugins.snapshot import RuntimeSnapshot
 
 MOBILE_UI_QUERY_TIMEOUT_SECONDS = 20.0
 MOBILE_UI_QUERY_WORKERS = 8
+MOBILE_UI_QUERY_QUEUE_LIMIT = 16
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +52,8 @@ class PluginMobileUiProvider:
             thread_name_prefix="mobile-plugin-ui",
         )
         self._draining_queries: set[asyncio.Task[dict[str, object]]] = set()
+        self._admission_lock = asyncio.Lock()
+        self._admitted_queries = 0
 
     def catalog(self) -> dict[str, object]:
         """返回当前 generation 的轻量目录与内容摘要。"""
@@ -107,6 +110,7 @@ class PluginMobileUiProvider:
     ) -> dict[str, object]:
         """在线程池执行只读 handler，并在超时后继续持有快照到线程退出。"""
 
+        await self._reserve_query_slot()
         task = asyncio.create_task(
             self._run_query(
                 plugin_id,
@@ -117,6 +121,7 @@ class PluginMobileUiProvider:
                 turn_id=turn_id,
             )
         )
+        task.add_done_callback(self._query_done)
         try:
             async with asyncio.timeout(MOBILE_UI_QUERY_TIMEOUT_SECONDS):
                 return await asyncio.shield(task)
@@ -128,6 +133,25 @@ class PluginMobileUiProvider:
         except asyncio.CancelledError:
             self._drain_query(task)
             raise
+
+    async def _reserve_query_slot(self) -> None:
+        """在提交线程池前拒绝超过有界 worker+queue 容量的查询。"""
+
+        async with self._admission_lock:
+            limit = MOBILE_UI_QUERY_WORKERS + MOBILE_UI_QUERY_QUEUE_LIMIT
+            if self._admitted_queries >= limit:
+                raise MobileUiQueryOverloaded(
+                    "插件 mobile UI query 队列已满"
+                )
+            self._admitted_queries += 1
+
+    def _query_done(self, completed: asyncio.Task[dict[str, object]]) -> None:
+        self._admitted_queries -= 1
+        if self._admitted_queries < 0:
+            raise RuntimeError("插件 mobile UI query admission 计数失衡")
+        self._draining_queries.discard(completed)
+        if not completed.cancelled():
+            _ = completed.exception()
 
     async def _run_query(
         self,
@@ -177,13 +201,6 @@ class PluginMobileUiProvider:
 
     def _drain_query(self, task: asyncio.Task[dict[str, object]]) -> None:
         self._draining_queries.add(task)
-
-        def consume(completed: asyncio.Task[dict[str, object]]) -> None:
-            self._draining_queries.discard(completed)
-            if not completed.cancelled():
-                _ = completed.exception()
-
-        task.add_done_callback(consume)
 
     def _require_snapshot(self) -> RuntimeSnapshot:
         snapshot = self._manager.current_snapshot

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -385,6 +385,9 @@ class AppRuntime:
                     self.config.mobile_realtime,
                     self.workspace,
                 )
+                self.bus.bind_durable_inbound_store(
+                    self.session_manager.control_store
+                )
                 from infra.mobile_realtime.runtime_inspection import (
                     RuntimeInspectionService,
                 )

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -28,6 +28,7 @@ from bootstrap.tools import CoreRuntime, build_core_runtime
 from bootstrap.workspace_lock import WorkspaceInstanceLock
 from bootstrap.workspace_token import ensure_workspace_token
 from bus.event_bus import EventBus
+from bus.queue import MessageBus
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.service_host import PluginServiceHost
 from agent.plugins.watcher import PluginWatcher
@@ -83,6 +84,14 @@ def _clear_readiness(
             readiness.clear()
 
     return clear
+
+
+def _close_message_bus(bus: object | None) -> Callable[[], Awaitable[None]]:
+    """返回已初始化 MessageBus 的异步关闭动作。"""
+
+    if isinstance(bus, MessageBus):
+        return bus.aclose
+    return _noop_async
 
 
 def _raise_unexpected_task_errors(name: str, results: list[object]) -> None:
@@ -758,6 +767,7 @@ class AppRuntime:
                     "mobile_gateway_server.wait",
                     _wait_server_task(self.mobile_gateway_task),
                 ),
+                ("message_bus.aclose", _close_message_bus(self.bus)),
                 (
                     "mobile_gateway.close",
                     _close_mobile_gateway(self.mobile_gateway_runtime),

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -28,6 +28,8 @@ class PassiveMessageWorker:
     async def run(self) -> None:
         self._running = True
         try:
+            # 1. 仅重放有界 durable handoff 页，lane 准入由 MessageBus 统一持有。
+            await self._bus.recover_durable_inbounds()
             while self._running:
                 try:
                     item = await asyncio.wait_for(self._bus.consume_inbound(), timeout=1.0)
@@ -85,8 +87,16 @@ class PassiveMessageWorker:
     async def _run_message(self, item: InboundMessage) -> None:
         """执行一条渠道消息，并始终完成 MessageBus 入站确认。"""
 
+        # 1. canonical 用户消息证明该 handoff 已进入过 turn。
+        if self._is_recovered_mobile_duplicate(item):
+            await self._bus.complete_inbound(item)
+            return
+        if item.channel == "mobile" and item.session_admission_id is None:
+            _, item.session_admission_id = self._legacy_loop.session_manager.admit_existing(
+                item.session_key
+            )
         try:
-            # 1. 渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
+            # 2. 渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
             request = TurnRequest(
                 item.session_key,
                 item.content,
@@ -116,7 +126,7 @@ class PassiveMessageWorker:
                 break
             result = await handle.result()
 
-            # 2. channel adapter 在领域终态外层映射用户安全文案。
+            # 3. channel adapter 在领域终态外层映射用户安全文案。
             if result.status is TurnStatus.COMPLETED:
                 assistant = next(
                     entry for entry in reversed(result.items) if entry.kind.value == "assistantMessage"
@@ -150,6 +160,20 @@ class PassiveMessageWorker:
                     self._legacy_loop.session_manager.release_admission(
                         item.session_admission_id
                     )
+
+    def _is_recovered_mobile_duplicate(self, item: InboundMessage) -> bool:
+        """识别 canonical 用户消息已存在的移动 handoff，避免重复 turn。"""
+
+        if item.channel != "mobile" or item.handoff_id is None:
+            return False
+        client_message_id = item.metadata.get("client_message_id")
+        if not isinstance(client_message_id, str) or not client_message_id:
+            return False
+        message = self._legacy_loop.session_manager.control_store.get_message_by_client_id(
+            item.session_key,
+            client_message_id,
+        )
+        return message is not None
 
     def stop(self) -> None:
         self._running = False

--- a/bus/events.py
+++ b/bus/events.py
@@ -79,6 +79,7 @@ class InboundMessage:
     media: list[str] = field(default_factory=list[str])
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
     session_admission_id: str | None = field(default=None, repr=False, compare=False)
+    handoff_id: str | None = field(default=None, repr=False, compare=False)
 
     @property
     def session_key(self) -> str:

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -16,6 +16,8 @@ _T = TypeVar("_T")
 
 DEFAULT_MESSAGE_BUS_CAPACITY = 256
 DEFAULT_MESSAGE_BUS_BYTES = 4 * 1024 * 1024
+_INBOUND_CLEANUP_RETRY_INITIAL_DELAY = 0.1
+_INBOUND_CLEANUP_RETRY_MAX_DELAY = 5.0
 
 
 class MessageBusCapacityError(RuntimeError):
@@ -181,6 +183,15 @@ class _ChatLaneState:
         default_factory=lambda: set[int]()
     )
     sending: bool = False
+
+
+@dataclass
+class _InboundOwner:
+    """在 durable cleanup 确认前保持 accepted inbound item 的强引用。"""
+
+    item: InboundItem
+    item_bytes: int
+    cleanup_pending: bool = False
 
 
 class ChatLane:
@@ -374,7 +385,9 @@ class MessageBus:
         self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
         self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
         self._inbound_bytes = 0
-        self._inbound_accepted: dict[int, int] = {}
+        self._inbound_accepted: dict[int, _InboundOwner] = {}
+        self._inbound_cleanup_tasks: dict[int, asyncio.Task[None]] = {}
+        self._inbound_cleanup_error: BaseException | None = None
         self._recovery_claimed: set[str] = set()
         self._outbound_bytes = 0
         self._inbound_reserved_items = 0
@@ -402,6 +415,7 @@ class MessageBus:
     async def recover_durable_inbounds(self) -> None:
         """在有界 bus slot 内重放尚未完成的移动 handoff。"""
 
+        self._raise_inbound_cleanup_error()
         store = self._durable_inbound_store
         if store is None:
             return
@@ -432,6 +446,9 @@ class MessageBus:
                     error.reason,
                 )
                 break
+            except BaseException:
+                self._recovery_claimed.discard(handoff_id)
+                raise
 
     def has_pending_mobile_handoff(
         self,
@@ -462,6 +479,7 @@ class MessageBus:
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
+        self._raise_inbound_cleanup_error()
         await self._publish_inbound(msg, allow_existing_handoff=False)
 
     async def _publish_inbound(
@@ -528,7 +546,10 @@ class MessageBus:
             finally:
                 self._inbound_reserved_items -= 1
                 self._inbound_reserved_bytes -= item_bytes
-            self._inbound_accepted[id(msg)] = item_bytes
+            self._inbound_accepted[id(msg)] = _InboundOwner(
+                item=msg,
+                item_bytes=item_bytes,
+            )
             self._inbound_bytes += item_bytes
 
     async def consume_inbound(self) -> InboundItem:
@@ -536,36 +557,145 @@ class MessageBus:
         return await self._inbound.get()
 
     async def complete_inbound(self, msg: InboundItem) -> None:
+        self._raise_inbound_cleanup_error()
         item_bytes = _wire_size(msg)
         async with self._admission_lock:
-            accepted = self._inbound_accepted.get(id(msg))
-            if accepted is None:
+            owner = self._inbound_accepted.get(id(msg))
+            if owner is None or owner.item is not msg:
                 raise RuntimeError("inbound 未被接受或已完成")
-            if accepted != item_bytes:
+            if owner.item_bytes != item_bytes:
                 raise RuntimeError("inbound ownership bytes 不一致")
+            if owner.cleanup_pending:
+                raise RuntimeError("inbound cleanup 已在重试中")
         if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
             store = self._durable_inbound_store
             if store is None:
                 raise RuntimeError("mobile inbound durable handoff store 未绑定")
             try:
                 store.complete_inbound_handoff(msg.handoff_id)
-            except Exception as error:
+            except OSError as error:
                 logger.error(
                     "message_bus cleanup_degraded: retained inbound owner "
                     "handoff=%s error=%s",
                     msg.handoff_id,
                     error,
                 )
+                owner.cleanup_pending = True
+                self._schedule_inbound_cleanup_retry(id(msg))
                 raise
-        await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+            except Exception as error:
+                self._record_inbound_cleanup_fatal(error, id(msg))
+                raise
+        await self._finalize_inbound_owner(id(msg), owner)
+
+    def _raise_inbound_cleanup_error(self) -> None:
+        error = self._inbound_cleanup_error
+        if error is not None:
+            raise RuntimeError("message bus inbound cleanup owner failed") from error
+
+    def _record_inbound_cleanup_fatal(
+        self,
+        error: BaseException,
+        owner_key: int,
+    ) -> None:
+        if self._inbound_cleanup_error is None:
+            self._inbound_cleanup_error = error
+        logger.exception(
+            "message_bus event=runtime_fatal owner=message_bus.inbound_cleanup "
+            "owner_key=%s error=%s",
+            owner_key,
+            error,
+        )
+
+    def _schedule_inbound_cleanup_retry(self, owner_key: int) -> None:
+        """为 cleanup-only owner 启动唯一的退避重试 task。"""
+
+        existing = self._inbound_cleanup_tasks.get(owner_key)
+        if existing is not None and not existing.done():
+            raise RuntimeError(f"inbound cleanup retry 已存在: {owner_key}")
+        self._inbound_cleanup_tasks[owner_key] = asyncio.create_task(
+            self._retry_inbound_cleanup(owner_key),
+            name=f"message-bus-cleanup:{owner_key}",
+        )
+
+    async def _retry_inbound_cleanup(self, owner_key: int) -> None:
+        """只重试 durable handoff 删除，成功后释放原 accepted owner。"""
+
+        delay = _INBOUND_CLEANUP_RETRY_INITIAL_DELAY
+        attempt = 0
+        try:
+            while True:
+                await asyncio.sleep(delay)
+                owner = self._inbound_accepted.get(owner_key)
+                if owner is None:
+                    raise RuntimeError(f"inbound cleanup owner 丢失: {owner_key}")
+                if not owner.cleanup_pending:
+                    raise RuntimeError(f"inbound cleanup owner 状态非法: {owner_key}")
+                item = owner.item
+                if not isinstance(item, InboundMessage) or item.handoff_id is None:
+                    raise RuntimeError(f"cleanup owner 缺少 mobile handoff: {owner_key}")
+                store = self._durable_inbound_store
+                if store is None:
+                    raise RuntimeError("mobile inbound durable handoff store 未绑定")
+                try:
+                    store.complete_inbound_handoff(item.handoff_id)
+                except OSError as error:
+                    attempt += 1
+                    delay = min(_INBOUND_CLEANUP_RETRY_MAX_DELAY, delay * 2)
+                    logger.error(
+                        "message_bus cleanup_degraded: retry failed "
+                        "handoff=%s attempt=%s next_delay=%.3f error=%s",
+                        item.handoff_id,
+                        attempt,
+                        delay,
+                        error,
+                    )
+                    continue
+                try:
+                    await self._finalize_inbound_owner(owner_key, owner)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    self._record_inbound_cleanup_fatal(error, owner_key)
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            self._record_inbound_cleanup_fatal(error, owner_key)
+        finally:
+            current = self._inbound_cleanup_tasks.get(owner_key)
+            if current is asyncio.current_task():
+                self._inbound_cleanup_tasks.pop(owner_key, None)
+
+    async def _finalize_inbound_owner(
+        self,
+        owner_key: int,
+        owner: _InboundOwner,
+    ) -> None:
+        """确认 lane 完成后释放 accepted owner，并继续有限 durable pump。"""
+
+        item = owner.item
+        await self._chat_lane.mark_passive_done(item.channel, item.chat_id)
         async with self._admission_lock:
-            released = self._inbound_accepted.pop(id(msg), None)
-            if released != accepted:
+            current = self._inbound_accepted.pop(owner_key, None)
+            if current is not owner:
                 raise RuntimeError("inbound ownership changed during completion")
-            self._inbound_bytes -= released
-        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
-            self._recovery_claimed.discard(msg.handoff_id)
+            self._inbound_bytes -= owner.item_bytes
+        if isinstance(item, InboundMessage) and item.handoff_id is not None:
+            self._recovery_claimed.discard(item.handoff_id)
         await self.recover_durable_inbounds()
+
+    async def aclose(self) -> None:
+        """停止出站循环并收束所有 cleanup-only retry task。"""
+
+        self.stop()
+        tasks = tuple(self._inbound_cleanup_tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._inbound_cleanup_tasks.clear()
+        self._raise_inbound_cleanup_error()
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -3,7 +3,10 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import TypeVar
+from typing import Protocol, cast
+from uuid import uuid4
 
 from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
 
@@ -71,6 +74,99 @@ def _wire_size(item: object) -> int:
     else:
         raise TypeError(f"unsupported MessageBus item: {type(item).__name__}")
     return len(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode())
+
+
+class DurableInboundStore(Protocol):
+    """MessageBus 所需的最小移动 handoff 持久 owner 接口。"""
+
+    def reserve_inbound_handoff(
+        self,
+        *,
+        handoff_id: str,
+        dedupe_key: str | None,
+        channel: str,
+        sender: str,
+        chat_id: str,
+        session_key: str,
+        content: str,
+        timestamp: str,
+        media_json: str,
+        metadata_json: str,
+        created_at: str,
+    ) -> tuple[str, bool]: ...
+
+    def list_inbound_handoffs(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, str | None]]: ...
+
+    def has_inbound_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool: ...
+
+    def complete_inbound_handoff(self, handoff_id: str) -> None: ...
+
+
+def _mobile_dedupe_key(message: InboundMessage) -> str | None:
+    client_message_id = message.metadata.get("client_message_id")
+    if not isinstance(client_message_id, str) or not client_message_id:
+        return None
+    return f"{message.session_key}:{client_message_id}"
+
+
+def _serialize_handoff(message: InboundMessage) -> tuple[str, str]:
+    media_json = json.dumps(
+        message.media,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    metadata_json = json.dumps(
+        message.metadata,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    return media_json, metadata_json
+
+
+def _inbound_from_handoff(row: dict[str, str | None]) -> InboundMessage:
+    required = (
+        "handoff_id",
+        "channel",
+        "sender",
+        "chat_id",
+        "content",
+        "timestamp",
+        "media_json",
+        "metadata_json",
+    )
+    values = {key: row.get(key) for key in required}
+    if any(not isinstance(value, str) or not value for value in values.values()):
+        raise ValueError(f"inbound handoff schema invalid: {row!r}")
+    media = json.loads(cast(str, values["media_json"]))
+    metadata = json.loads(cast(str, values["metadata_json"]))
+    if not isinstance(media, list) or not all(isinstance(item, str) for item in media):
+        raise ValueError(f"inbound handoff media invalid: {values['handoff_id']}")
+    if not isinstance(metadata, dict):
+        raise ValueError(f"inbound handoff metadata invalid: {values['handoff_id']}")
+    timestamp = datetime.fromisoformat(cast(str, values["timestamp"]))
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError(f"inbound handoff timestamp missing timezone: {values['handoff_id']}")
+    return InboundMessage(
+        channel=cast(str, values["channel"]),
+        sender=cast(str, values["sender"]),
+        chat_id=cast(str, values["chat_id"]),
+        content=cast(str, values["content"]),
+        timestamp=timestamp,
+        media=cast(list[str], media),
+        metadata=cast(dict[str, object], metadata),
+        handoff_id=cast(str, values["handoff_id"]),
+    )
 
 
 @dataclass
@@ -278,6 +374,8 @@ class MessageBus:
         self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
         self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
         self._inbound_bytes = 0
+        self._inbound_accepted: dict[int, int] = {}
+        self._recovery_claimed: set[str] = set()
         self._outbound_bytes = 0
         self._inbound_reserved_items = 0
         self._outbound_reserved_items = 0
@@ -292,6 +390,65 @@ class MessageBus:
         self._delivery_observer: (
             Callable[[OutboundMessage, bool], Awaitable[None]] | None
         ) = None
+        self._durable_inbound_store: DurableInboundStore | None = None
+
+    def bind_durable_inbound_store(self, store: DurableInboundStore) -> None:
+        """在 channel 启动前绑定一次由 session 持有的 handoff store。"""
+
+        if self._durable_inbound_store is not None:
+            raise RuntimeError("durable inbound store 已绑定")
+        self._durable_inbound_store = store
+
+    async def recover_durable_inbounds(self) -> None:
+        """在有界 bus slot 内重放尚未完成的移动 handoff。"""
+
+        store = self._durable_inbound_store
+        if store is None:
+            return
+        # 1. 只读取有限页，避免启动时把整个 durable backlog 搬入内存。
+        available = self._inbound_capacity - len(self._inbound_accepted)
+        if available <= 0:
+            return
+        rows = store.list_inbound_handoffs(
+            limit=min(self._inbound_capacity, available + len(self._recovery_claimed))
+        )
+        for row in rows:
+            handoff_id = row.get("handoff_id")
+            if not isinstance(handoff_id, str) or handoff_id in self._recovery_claimed:
+                continue
+            if len(self._inbound_accepted) >= self._inbound_capacity:
+                break
+            item = _inbound_from_handoff(row)
+            self._recovery_claimed.add(handoff_id)
+            try:
+                await self._publish_inbound(item, allow_existing_handoff=True)
+            except MessageBusCapacityError as error:
+                self._recovery_claimed.discard(handoff_id)
+                if error.item_bytes > self._inbound_bytes_capacity:
+                    raise
+                logger.info(
+                    "durable inbound recovery waiting for bus capacity: handoff=%s reason=%s",
+                    handoff_id,
+                    error.reason,
+                )
+                break
+
+    def has_pending_mobile_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        """检查移动命令是否仍由 durable queue owner 持有。"""
+
+        store = self._durable_inbound_store
+        return bool(
+            store is not None
+            and store.has_inbound_handoff(
+                session_key=session_key,
+                client_message_id=client_message_id,
+            )
+        )
 
     def bind_outbound_delivery_observer(
         self,
@@ -305,16 +462,62 @@ class MessageBus:
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
+        await self._publish_inbound(msg, allow_existing_handoff=False)
+
+    async def _publish_inbound(
+        self,
+        msg: InboundItem,
+        *,
+        allow_existing_handoff: bool,
+    ) -> None:
+        """在容量、lane 和 durable handoff 三者一致后入队一条消息。"""
+
         item_bytes = _wire_size(msg)
         async with self._admission_lock:
-            if self._inbound.qsize() + self._inbound_reserved_items >= self._inbound_capacity:
+            if id(msg) in self._inbound_accepted:
+                raise RuntimeError("同一 inbound 对象被重复接受")
+            if len(self._inbound_accepted) + self._inbound_reserved_items >= self._inbound_capacity:
                 raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="queue full")
-            if self._inbound_bytes + self._inbound_reserved_bytes + item_bytes > self._inbound_bytes_capacity:
-                raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="byte budget full")
+            if (
+                self._inbound_bytes
+                + self._inbound_reserved_bytes
+                + item_bytes
+                > self._inbound_bytes_capacity
+            ):
+                raise MessageBusCapacityError(
+                    "inbound",
+                    item_bytes=item_bytes,
+                    reason="byte budget full",
+                )
             self._inbound_reserved_items += 1
             self._inbound_reserved_bytes += item_bytes
             marked = False
             try:
+                if isinstance(msg, InboundMessage) and msg.channel == "mobile":
+                    store = self._durable_inbound_store
+                    if store is None:
+                        raise RuntimeError("mobile inbound durable handoff store 未绑定")
+                    requested_handoff_id = msg.handoff_id
+                    media_json, metadata_json = _serialize_handoff(msg)
+                    handoff_id, created = store.reserve_inbound_handoff(
+                        handoff_id=msg.handoff_id or uuid4().hex,
+                        dedupe_key=_mobile_dedupe_key(msg),
+                        channel=msg.channel,
+                        sender=msg.sender,
+                        chat_id=msg.chat_id,
+                        session_key=msg.session_key,
+                        content=msg.content,
+                        timestamp=msg.timestamp.astimezone(timezone.utc).isoformat(),
+                        media_json=media_json,
+                        metadata_json=metadata_json,
+                        created_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                    msg.handoff_id = handoff_id
+                    if not created and not (
+                        allow_existing_handoff
+                        and requested_handoff_id == handoff_id
+                    ):
+                        return
                 await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
                 marked = True
                 self._inbound.put_nowait(msg)
@@ -325,17 +528,44 @@ class MessageBus:
             finally:
                 self._inbound_reserved_items -= 1
                 self._inbound_reserved_bytes -= item_bytes
+            self._inbound_accepted[id(msg)] = item_bytes
             self._inbound_bytes += item_bytes
 
     async def consume_inbound(self) -> InboundItem:
         """阻塞直到有消息可消费"""
-        msg = await self._inbound.get()
-        async with self._admission_lock:
-            self._inbound_bytes -= _wire_size(msg)
-        return msg
+        return await self._inbound.get()
 
     async def complete_inbound(self, msg: InboundItem) -> None:
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            accepted = self._inbound_accepted.get(id(msg))
+            if accepted is None:
+                raise RuntimeError("inbound 未被接受或已完成")
+            if accepted != item_bytes:
+                raise RuntimeError("inbound ownership bytes 不一致")
+        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
+            store = self._durable_inbound_store
+            if store is None:
+                raise RuntimeError("mobile inbound durable handoff store 未绑定")
+            try:
+                store.complete_inbound_handoff(msg.handoff_id)
+            except Exception as error:
+                logger.error(
+                    "message_bus cleanup_degraded: retained inbound owner "
+                    "handoff=%s error=%s",
+                    msg.handoff_id,
+                    error,
+                )
+                raise
         await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+        async with self._admission_lock:
+            released = self._inbound_accepted.pop(id(msg), None)
+            if released != accepted:
+                raise RuntimeError("inbound ownership changed during completion")
+            self._inbound_bytes -= released
+        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
+            self._recovery_claimed.discard(msg.handoff_id)
+        await self.recover_durable_inbounds()
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -1,14 +1,76 @@
 import asyncio
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TypeVar
 
-from bus.events import InboundItem, OutboundMessage
+from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
 
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+
+DEFAULT_MESSAGE_BUS_CAPACITY = 256
+DEFAULT_MESSAGE_BUS_BYTES = 4 * 1024 * 1024
+
+
+class MessageBusCapacityError(RuntimeError):
+    """表示消息在进入有界队列前被拒绝。"""
+
+    error_type = "resource-exhausted"
+    failure_type = "operation_rejected"
+    code = "resource-exhausted"
+    retryable = True
+
+    def __init__(self, direction: str, *, item_bytes: int, reason: str) -> None:
+        self.direction = direction
+        self.item_bytes = item_bytes
+        self.reason = reason
+        super().__init__(
+            f"resource-exhausted: {direction} message bus admission {reason} "
+            f"(item_bytes={item_bytes})"
+        )
+
+
+# Keep a descriptive alias for callers that use the transport terminology.
+MessageBusBusyError = MessageBusCapacityError
+
+
+def _wire_size(item: object) -> int:
+    """计算消息进入队列后占用的 UTF-8 JSON 字节数。"""
+
+    if isinstance(item, InboundMessage):
+        payload = {
+            "channel": item.channel,
+            "sender": item.sender,
+            "chat_id": item.chat_id,
+            "content": item.content,
+            "timestamp": item.timestamp.isoformat(),
+            "media": list(item.media),
+            "metadata": dict(item.metadata),
+        }
+    elif isinstance(item, SpawnCompletionItem):
+        payload = {
+            "channel": item.channel,
+            "chat_id": item.chat_id,
+            "event": repr(item.event),
+            "decision": repr(item.decision),
+            "timestamp": item.timestamp.isoformat(),
+        }
+    elif isinstance(item, OutboundMessage):
+        payload = {
+            "channel": item.channel,
+            "chat_id": item.chat_id,
+            "content": item.content,
+            "thinking": item.thinking,
+            "reply_to": item.reply_to,
+            "media": list(item.media),
+            "metadata": dict(item.metadata),
+        }
+    else:
+        raise TypeError(f"unsupported MessageBus item: {type(item).__name__}")
+    return len(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode())
 
 
 @dataclass
@@ -91,6 +153,18 @@ class ChatLane:
         try:
             async with state.condition:
                 state.passive_sends += 1
+                state.condition.notify_all()
+        finally:
+            self._release_state(key, state)
+
+    async def mark_passive_send_done(self, channel: str, chat_id: str) -> None:
+        """回滚尚未开始发送的出站 lane 计数。"""
+
+        key, state = self._acquire_state(channel, chat_id)
+        try:
+            async with state.condition:
+                if state.passive_sends > 0:
+                    state.passive_sends -= 1
                 state.condition.notify_all()
         finally:
             self._release_state(key, state)
@@ -180,9 +254,36 @@ class OutboundSubscription:
 class MessageBus:
     """agent 与各 channel 之间的异步消息总线"""
 
-    def __init__(self, chat_lane: ChatLane | None = None) -> None:
-        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue()
-        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+    def __init__(
+        self,
+        chat_lane: ChatLane | None = None,
+        *,
+        inbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
+        outbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
+        inbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
+        outbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
+    ) -> None:
+        for name, value in (
+            ("inbound_capacity", inbound_capacity),
+            ("outbound_capacity", outbound_capacity),
+            ("inbound_bytes", inbound_bytes),
+            ("outbound_bytes", outbound_bytes),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} 必须是正整数")
+        self._inbound_capacity = inbound_capacity
+        self._outbound_capacity = outbound_capacity
+        self._inbound_bytes_capacity = inbound_bytes
+        self._outbound_bytes_capacity = outbound_bytes
+        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
+        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
+        self._inbound_bytes = 0
+        self._outbound_bytes = 0
+        self._inbound_reserved_items = 0
+        self._outbound_reserved_items = 0
+        self._inbound_reserved_bytes = 0
+        self._outbound_reserved_bytes = 0
+        self._admission_lock = asyncio.Lock()
         self._subscribers: dict[
             str, list[Callable[[OutboundMessage], Awaitable[None]]]
         ] = {}
@@ -204,20 +305,61 @@ class MessageBus:
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
-        await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
-        await self._inbound.put(msg)
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            if self._inbound.qsize() + self._inbound_reserved_items >= self._inbound_capacity:
+                raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="queue full")
+            if self._inbound_bytes + self._inbound_reserved_bytes + item_bytes > self._inbound_bytes_capacity:
+                raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="byte budget full")
+            self._inbound_reserved_items += 1
+            self._inbound_reserved_bytes += item_bytes
+            marked = False
+            try:
+                await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
+                marked = True
+                self._inbound.put_nowait(msg)
+            except BaseException:
+                if marked:
+                    await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+                raise
+            finally:
+                self._inbound_reserved_items -= 1
+                self._inbound_reserved_bytes -= item_bytes
+            self._inbound_bytes += item_bytes
 
     async def consume_inbound(self) -> InboundItem:
         """阻塞直到有消息可消费"""
-        return await self._inbound.get()
+        msg = await self._inbound.get()
+        async with self._admission_lock:
+            self._inbound_bytes -= _wire_size(msg)
+        return msg
 
     async def complete_inbound(self, msg: InboundItem) -> None:
         await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""
-        await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
-        await self._outbound.put(msg)
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            if self._outbound.qsize() + self._outbound_reserved_items >= self._outbound_capacity:
+                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="queue full")
+            if self._outbound_bytes + self._outbound_reserved_bytes + item_bytes > self._outbound_bytes_capacity:
+                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="byte budget full")
+            self._outbound_reserved_items += 1
+            self._outbound_reserved_bytes += item_bytes
+            marked = False
+            try:
+                await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
+                marked = True
+                self._outbound.put_nowait(msg)
+            except BaseException:
+                if marked:
+                    await self._chat_lane.mark_passive_send_done(msg.channel, msg.chat_id)
+                raise
+            finally:
+                self._outbound_reserved_items -= 1
+                self._outbound_reserved_bytes -= item_bytes
+            self._outbound_bytes += item_bytes
 
     def subscribe_outbound(
         self,
@@ -252,6 +394,8 @@ class MessageBus:
         while self._running:
             try:
                 msg = await asyncio.wait_for(self._outbound.get(), timeout=1.0)
+                async with self._admission_lock:
+                    self._outbound_bytes -= _wire_size(msg)
                 delivered = await self._chat_lane.run_passive(
                     msg.channel,
                     msg.chat_id,
@@ -310,3 +454,35 @@ class MessageBus:
     @property
     def outbound_size(self) -> int:
         return self._outbound.qsize()
+
+    @property
+    def inbound_bytes(self) -> int:
+        return self._inbound_bytes
+
+    @property
+    def outbound_bytes(self) -> int:
+        return self._outbound_bytes
+
+    @property
+    def inbound_capacity(self) -> int:
+        return self._inbound_capacity
+
+    @property
+    def outbound_capacity(self) -> int:
+        return self._outbound_capacity
+
+    @property
+    def inbound_bytes_capacity(self) -> int:
+        return self._inbound_bytes_capacity
+
+    @property
+    def outbound_bytes_capacity(self) -> int:
+        return self._outbound_bytes_capacity
+
+    @property
+    def inbound_reserved_bytes(self) -> int:
+        return self._inbound_reserved_bytes
+
+    @property
+    def outbound_reserved_bytes(self) -> int:
+        return self._outbound_reserved_bytes

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -433,6 +433,17 @@ class MobileRealtimeChannel:
                         "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
                     },
                 )
+            if self._require_ctx().bus.has_pending_mobile_handoff(
+                session_key=session_id,
+                client_message_id=frame.payload.client_message_id,
+            ):
+                return CommandReply(
+                    type=f"{receipt.command_type}.error",
+                    payload={
+                        "code": "command_in_progress",
+                        "message": "该命令已进入持久化队列，请等待原命令 ID 的最终收据",
+                    },
+                )
             if (device_id, frame.id) in self._receipt_completion_failures:
                 self._receipt_completion_failures.discard((device_id, frame.id))
                 unknown = self._runtime.storage.mark_command_outcome_unknown(

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -69,6 +69,7 @@ from infra.mobile_realtime.storage import (
     AttachmentRecord,
     AttachmentStateError,
     CommandReceipt,
+    CommandReceiptCapacityError,
     MobileStorageError,
 )
 
@@ -171,6 +172,7 @@ class MobileRealtimeChannel:
         self._runtime = runtime
         self._ctx: ChannelContext | None = None
         self._processing_commands: set[tuple[str, str]] = set()
+        self._receipt_completion_failures: set[tuple[str, str]] = set()
         self._active_turn_ids: dict[str, str] = {}
         self._process_turns: dict[tuple[str, str], _ProcessTurnState] = {}
         self._delta_batches: dict[tuple[str, str], _DeltaBatch] = {}
@@ -263,6 +265,7 @@ class MobileRealtimeChannel:
         self._active_turn_ids.clear()
         self._process_turns.clear()
         self._processing_commands.clear()
+        self._receipt_completion_failures.clear()
 
     async def handle_command(
         self,
@@ -274,13 +277,19 @@ class MobileRealtimeChannel:
 
         # 1. 先持久化命令占用，避免重连重复触发 Agent turn
         self._raise_delta_failure()
-        receipt, created = self._runtime.storage.reserve_command(
-            device_id=device_id,
-            command_id=frame.id,
-            command_type=frame.type,
-            request_hash=_command_hash(frame),
-            created_at=_utc_now(),
-        )
+        try:
+            receipt, created = self._runtime.storage.reserve_command(
+                device_id=device_id,
+                command_id=frame.id,
+                command_type=frame.type,
+                request_hash=_command_hash(frame),
+                created_at=_utc_now(),
+            )
+        except CommandReceiptCapacityError as error:
+            raise MobileCommandError(
+                "mobile_command_receipt_capacity_reached",
+                str(error),
+            ) from error
         if not created:
             replay = self._recover_message_send_receipt(
                 device_id=device_id,
@@ -298,41 +307,47 @@ class MobileRealtimeChannel:
         command_key = (device_id, frame.id)
         self._processing_commands.add(command_key)
         try:
-            reply = await self._execute_command(device_id=device_id, frame=frame)
-        except (MobileCommandError, RuntimeInspectionError) as error:
-            reply = CommandReply(
-                type=f"{frame.type}.error",
-                payload={"code": error.code, "message": str(error)},
-                session_id=frame.session_id,
-                turn_id=frame.turn_id,
-            )
+            try:
+                reply = await self._execute_command(device_id=device_id, frame=frame)
+            except (MobileCommandError, RuntimeInspectionError) as error:
+                reply = CommandReply(
+                    type=f"{frame.type}.error",
+                    payload={"code": error.code, "message": str(error)},
+                    session_id=frame.session_id,
+                    turn_id=frame.turn_id,
+                )
 
-        # 3. 只有收据完成后才释放当前进程对未决副作用的所有权
-        _validate_reply_frame_size(frame, reply)
-        completed = self._runtime.storage.complete_command(
-            device_id=device_id,
-            command_id=frame.id,
-            reply_type=reply.type,
-            reply_payload_json=json.dumps(
-                reply.payload,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-                allow_nan=False,
-            ),
-            session_id=reply.session_id,
-            turn_id=reply.turn_id,
-            completed_at=_utc_now(),
-        )
-        self._processing_commands.discard(command_key)
-        stored = _reply_from_receipt(completed)
-        return CommandReply(
-            type=stored.type,
-            payload=stored.payload,
-            session_id=stored.session_id,
-            turn_id=stored.turn_id,
-            binary=reply.binary,
-        )
+            # 3. 只有收据完成后才释放当前进程对未决副作用的所有权
+            _validate_reply_frame_size(frame, reply)
+            try:
+                completed = self._runtime.storage.complete_command(
+                    device_id=device_id,
+                    command_id=frame.id,
+                    reply_type=reply.type,
+                    reply_payload_json=json.dumps(
+                        reply.payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                        allow_nan=False,
+                    ),
+                    session_id=reply.session_id,
+                    turn_id=reply.turn_id,
+                    completed_at=_utc_now(),
+                )
+            except Exception:
+                self._receipt_completion_failures.add(command_key)
+                raise
+            stored = _reply_from_receipt(completed)
+            return CommandReply(
+                type=stored.type,
+                payload=stored.payload,
+                session_id=stored.session_id,
+                turn_id=stored.turn_id,
+                binary=reply.binary,
+            )
+        finally:
+            self._processing_commands.discard(command_key)
 
     async def handle_plugin_ui_command(
         self,
@@ -383,11 +398,23 @@ class MobileRealtimeChannel:
         """从已持久化消息修复中断的 message.send 收据。"""
 
         # 1. 已完成或非消息命令继续复用稳定回复
-        if receipt.status == "completed":
+        if receipt.status in {"completed", "outcome_unknown"}:
             self._processing_commands.discard((device_id, frame.id))
             return _reply_from_receipt(receipt)
+        if (device_id, frame.id) in self._processing_commands:
+            return CommandReply(
+                type=f"{receipt.command_type}.error",
+                payload={
+                    "code": "command_in_progress",
+                    "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
+                },
+            )
         if not isinstance(frame, MessageSendCommand):
-            return _reply_from_receipt(receipt)
+            unknown = self._runtime.storage.mark_command_outcome_unknown(
+                device_id=device_id,
+                command_id=frame.id,
+            )
+            return _reply_from_receipt(unknown)
 
         # 2. 只有同一 client_message_id 已落库时，才能确认副作用已完成
         session_id = self._normalize_session_id(frame.session_id)
@@ -399,7 +426,20 @@ class MobileRealtimeChannel:
         )
         if message is None:
             if (device_id, frame.id) in self._processing_commands:
-                return _reply_from_receipt(receipt)
+                return CommandReply(
+                    type=f"{receipt.command_type}.error",
+                    payload={
+                        "code": "command_in_progress",
+                        "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
+                    },
+                )
+            if (device_id, frame.id) in self._receipt_completion_failures:
+                self._receipt_completion_failures.discard((device_id, frame.id))
+                unknown = self._runtime.storage.mark_command_outcome_unknown(
+                    device_id=device_id,
+                    command_id=frame.id,
+                )
+                return _reply_from_receipt(unknown)
             return self._complete_interrupted_message_send(
                 device_id=device_id,
                 frame=frame,
@@ -429,6 +469,7 @@ class MobileRealtimeChannel:
             turn_id=None,
             completed_at=_utc_now(),
         )
+        self._receipt_completion_failures.discard((device_id, frame.id))
         self._processing_commands.discard((device_id, frame.id))
         return _reply_from_receipt(completed)
 

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -1180,6 +1180,8 @@ class MobileGatewayRuntime:
                     }
                 )
             return
+        from infra.mobile_realtime.channel import MobileCommandError
+
         try:
             reply = await self.channel.handle_command(
                 device_id=device_id,
@@ -1193,6 +1195,18 @@ class MobileGatewayRuntime:
                     connection_epoch=connection_epoch,
                     reply_type=f"{frame.type}.error",
                     payload={"code": "command_id_conflict", "message": str(error)},
+                    session_id=frame.session_id,
+                    turn_id=frame.turn_id,
+                )
+            return
+        except MobileCommandError as error:
+            async with connection.send_lock:
+                await _send_reply(
+                    websocket,
+                    frame_id=frame.id,
+                    connection_epoch=connection_epoch,
+                    reply_type=f"{frame.type}.error",
+                    payload={"code": error.code, "message": str(error)},
                     session_id=frame.session_id,
                     turn_id=frame.turn_id,
                 )

--- a/infra/mobile_realtime/storage.py
+++ b/infra/mobile_realtime/storage.py
@@ -6,7 +6,7 @@ import sqlite3
 import stat
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Literal, cast
 
@@ -55,6 +55,10 @@ class SentCursorError(MobileStorageError):
 
 class CommandConflictError(MobileStorageError):
     """表示同一命令 ID 被用于不同请求。"""
+
+
+class CommandReceiptCapacityError(MobileStorageError):
+    """表示设备命令收据达到数量或字节高水位。"""
 
 
 class AttachmentStateError(MobileStorageError):
@@ -117,11 +121,34 @@ class CommandReceipt:
     command_id: str
     command_type: str
     request_hash: str
-    status: Literal["processing", "completed"]
+    status: Literal["processing", "completed", "outcome_unknown"]
     reply_type: str | None
     reply_payload_json: str | None
     session_id: str | None
     turn_id: str | None
+    created_at: datetime
+    completed_at: datetime | None
+
+
+_COMMAND_RECEIPT_RETENTION = timedelta(days=7)
+_COMMAND_RECEIPT_MAX_COUNT = 10_000
+_COMMAND_RECEIPT_MAX_BYTES = 64 * 1024 * 1024
+_RECEIPT_BYTES_SQL = " + ".join(
+    f"COALESCE(length(CAST({field} AS BLOB)), 0)"
+    for field in (
+        "device_id",
+        "command_id",
+        "command_type",
+        "request_hash",
+        "status",
+        "reply_type",
+        "reply_payload_json",
+        "session_id",
+        "turn_id",
+        "created_at",
+        "completed_at",
+    )
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1475,14 +1502,16 @@ class MobileRealtimeStorage:
         digest = _require_text(request_hash, "request_hash")
         timestamp = _serialize_datetime(created_at, "created_at")
 
-        # 2. 在写事务内复用相同请求，拒绝命令 ID 冲突
+        # 2. 在同一写事务内优先复用现有请求，随后清理并检查设备高水位
         with self._lock, self._db:
             _ = self._db.execute("BEGIN IMMEDIATE")
             _ = self._read_device_row(device_key)
+            self._cleanup_expired_command_receipts_locked(device_key, now=created_at)
             row = self._db.execute(
                 """
                 SELECT device_id, command_id, command_type, request_hash,
-                       status, reply_type, reply_payload_json, session_id, turn_id
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
                 FROM mobile_command_receipts
                 WHERE device_id = ? AND command_id = ?
                 """,
@@ -1498,6 +1527,27 @@ class MobileRealtimeStorage:
                         f"命令 ID 已绑定其他请求: {device_key}/{command_key}"
                     )
                 return receipt, False
+            count, size = self._command_receipt_usage_locked(device_key)
+            projected_size = _receipt_row_bytes(
+                device_id=device_key,
+                command_id=command_key,
+                command_type=command_name,
+                request_hash=digest,
+                status="processing",
+                reply_type=None,
+                reply_payload_json=None,
+                session_id=None,
+                turn_id=None,
+                created_at=timestamp,
+                completed_at=None,
+            )
+            if count >= _COMMAND_RECEIPT_MAX_COUNT or (
+                size + projected_size > _COMMAND_RECEIPT_MAX_BYTES
+            ):
+                raise CommandReceiptCapacityError(
+                    "mobile command receipt capacity reached: "
+                    f"device={device_key} count={count} bytes={size}"
+                )
             _ = self._db.execute(
                 """
                 INSERT INTO mobile_command_receipts(
@@ -1517,7 +1567,97 @@ class MobileRealtimeStorage:
             reply_payload_json=None,
             session_id=None,
             turn_id=None,
+            created_at=created_at,
+            completed_at=None,
         ), True
+
+    def cleanup_command_receipts(
+        self,
+        *,
+        device_id: str,
+        now: datetime,
+    ) -> int:
+        """删除已过保留期的 completed 收据并返回删除数量。"""
+
+        device_key = _require_text(device_id, "device_id")
+        _ = _serialize_datetime(now, "now")
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            _ = self._read_device_row(device_key)
+            return self._cleanup_expired_command_receipts_locked(
+                device_key,
+                now=now,
+            )
+
+    def mark_command_outcome_unknown(
+        self,
+        *,
+        device_id: str,
+        command_id: str,
+    ) -> CommandReceipt:
+        """把无法核对外部效果的 processing 收据持久化为 outcome_unknown。"""
+
+        device_key = _require_text(device_id, "device_id")
+        command_key = _require_text(command_id, "command_id")
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            updated = self._db.execute(
+                """
+                UPDATE mobile_command_receipts
+                SET status = 'outcome_unknown'
+                WHERE device_id = ? AND command_id = ? AND status = 'processing'
+                """,
+                (device_key, command_key),
+            )
+            if updated.rowcount != 1:
+                raise MobileStorageError(
+                    f"命令收据不处于 processing: {device_key}/{command_key}"
+                )
+            row = self._db.execute(
+                """
+                SELECT device_id, command_id, command_type, request_hash,
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
+                FROM mobile_command_receipts
+                WHERE device_id = ? AND command_id = ?
+                """,
+                (device_key, command_key),
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("已标记 outcome_unknown 的收据在同一事务中消失")
+        return _command_receipt_from_row(row)
+
+    def _cleanup_expired_command_receipts_locked(
+        self,
+        device_id: str,
+        *,
+        now: datetime,
+    ) -> int:
+        cutoff = now - _COMMAND_RECEIPT_RETENTION
+        cutoff_text = _serialize_datetime(cutoff, "cutoff")
+        deleted = self._db.execute(
+            """
+            DELETE FROM mobile_command_receipts
+            WHERE device_id = ? AND status = 'completed'
+              AND completed_at IS NOT NULL AND completed_at < ?
+            """,
+            (device_id, cutoff_text),
+        )
+        return deleted.rowcount
+
+    def _command_receipt_usage_locked(self, device_id: str) -> tuple[int, int]:
+        row = self._db.execute(
+            f"""
+            SELECT COUNT(*) AS count,
+                   COALESCE(SUM({_RECEIPT_BYTES_SQL}), 0) AS bytes
+            FROM mobile_command_receipts
+            WHERE device_id = ?
+            """,
+            (device_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("命令收据用量查询无结果")
+        return int(row["count"]), int(row["bytes"])
 
     def complete_command(
         self,
@@ -1542,6 +1682,61 @@ class MobileRealtimeStorage:
         # 2. 只允许 processing 收据推进为 completed
         with self._lock, self._db:
             _ = self._db.execute("BEGIN IMMEDIATE")
+            existing = self._db.execute(
+                """
+                SELECT device_id, command_id, command_type, request_hash,
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
+                FROM mobile_command_receipts
+                WHERE device_id = ? AND command_id = ?
+                """,
+                (device_key, command_key),
+            ).fetchone()
+            if existing is None:
+                raise MobileStorageError(
+                    f"命令收据不存在: {device_key}/{command_key}"
+                )
+            current = _command_receipt_from_row(existing)
+            if current.status != "processing":
+                raise MobileStorageError(
+                    f"命令收据不处于 processing: {device_key}/{command_key}"
+                )
+            self._cleanup_expired_command_receipts_locked(
+                device_key,
+                now=completed_at,
+            )
+            _count, size = self._command_receipt_usage_locked(device_key)
+            current_size = _receipt_row_bytes(
+                device_id=current.device_id,
+                command_id=current.command_id,
+                command_type=current.command_type,
+                request_hash=current.request_hash,
+                status=current.status,
+                reply_type=current.reply_type,
+                reply_payload_json=current.reply_payload_json,
+                session_id=current.session_id,
+                turn_id=current.turn_id,
+                created_at=_serialize_datetime(current.created_at, "created_at"),
+                completed_at=None,
+            )
+            projected_size = _receipt_row_bytes(
+                device_id=current.device_id,
+                command_id=current.command_id,
+                command_type=current.command_type,
+                request_hash=current.request_hash,
+                status="completed",
+                reply_type=reply_name,
+                reply_payload_json=payload,
+                session_id=session_id,
+                turn_id=turn_id,
+                created_at=_serialize_datetime(current.created_at, "created_at"),
+                completed_at=timestamp,
+            )
+            if size - current_size + projected_size > _COMMAND_RECEIPT_MAX_BYTES:
+                raise CommandReceiptCapacityError(
+                    "mobile command receipt byte capacity reached: "
+                    f"device={device_key} bytes={size}"
+                )
             updated = self._db.execute(
                 """
                 UPDATE mobile_command_receipts
@@ -1566,7 +1761,8 @@ class MobileRealtimeStorage:
             row = self._db.execute(
                 """
                 SELECT device_id, command_id, command_type, request_hash,
-                       status, reply_type, reply_payload_json, session_id, turn_id
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
                 FROM mobile_command_receipts
                 WHERE device_id = ? AND command_id = ?
                 """,
@@ -1663,7 +1859,9 @@ class MobileRealtimeStorage:
                 command_id TEXT NOT NULL,
                 command_type TEXT NOT NULL,
                 request_hash TEXT NOT NULL,
-                status TEXT NOT NULL CHECK(status IN ('processing', 'completed')),
+                status TEXT NOT NULL CHECK(
+                    status IN ('processing', 'completed', 'outcome_unknown')
+                ),
                 reply_type TEXT,
                 reply_payload_json TEXT,
                 session_id TEXT,
@@ -1672,7 +1870,8 @@ class MobileRealtimeStorage:
                 completed_at TEXT,
                 PRIMARY KEY(device_id, command_id),
                 CHECK(
-                    (status = 'processing' AND reply_type IS NULL
+                    ((status IN ('processing', 'outcome_unknown'))
+                     AND reply_type IS NULL
                      AND reply_payload_json IS NULL AND completed_at IS NULL)
                     OR
                     (status = 'completed' AND reply_type IS NOT NULL
@@ -1732,6 +1931,76 @@ class MobileRealtimeStorage:
             """
         )
         self._db.commit()
+        self._migrate_command_receipt_status()
+
+    def _migrate_command_receipt_status(self) -> None:
+        """把旧版 receipt CHECK 约束升级为可持久化 outcome_unknown。"""
+
+        row = self._db.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'mobile_command_receipts'"
+        ).fetchone()
+        if row is None or not isinstance(row[0], str):
+            raise RuntimeError("mobile_command_receipts schema 不存在")
+        if "outcome_unknown" in row[0]:
+            return
+        with self._lock:
+            try:
+                _ = self._db.execute("BEGIN IMMEDIATE")
+                _ = self._db.execute(
+                    "ALTER TABLE mobile_command_receipts "
+                    "RENAME TO mobile_command_receipts_legacy"
+                )
+                _ = self._db.execute(
+                    """
+                    CREATE TABLE mobile_command_receipts (
+                        device_id TEXT NOT NULL,
+                        command_id TEXT NOT NULL,
+                        command_type TEXT NOT NULL,
+                        request_hash TEXT NOT NULL,
+                        status TEXT NOT NULL CHECK(
+                            status IN ('processing', 'completed', 'outcome_unknown')
+                        ),
+                        reply_type TEXT,
+                        reply_payload_json TEXT,
+                        session_id TEXT,
+                        turn_id TEXT,
+                        created_at TEXT NOT NULL,
+                        completed_at TEXT,
+                        PRIMARY KEY(device_id, command_id),
+                        CHECK(
+                            ((status IN ('processing', 'outcome_unknown'))
+                             AND reply_type IS NULL
+                             AND reply_payload_json IS NULL
+                             AND completed_at IS NULL)
+                            OR
+                            (status = 'completed' AND reply_type IS NOT NULL
+                             AND reply_payload_json IS NOT NULL
+                             AND completed_at IS NOT NULL)
+                        ),
+                        FOREIGN KEY(device_id) REFERENCES mobile_devices(device_id)
+                            ON DELETE CASCADE
+                    )
+                    """
+                )
+                _ = self._db.execute(
+                    """
+                    INSERT INTO mobile_command_receipts(
+                        device_id, command_id, command_type, request_hash,
+                        status, reply_type, reply_payload_json, session_id, turn_id,
+                        created_at, completed_at
+                    )
+                    SELECT device_id, command_id, command_type, request_hash,
+                           status, reply_type, reply_payload_json, session_id, turn_id,
+                           created_at, completed_at
+                    FROM mobile_command_receipts_legacy
+                    """
+                )
+                _ = self._db.execute("DROP TABLE mobile_command_receipts_legacy")
+                self._db.commit()
+            except sqlite3.Error:
+                self._db.rollback()
+                raise
 
     def _insert_device(self, device: DeviceRecord) -> None:
         if device.revoked_at is not None:
@@ -1852,7 +2121,7 @@ def _device_from_row(row: sqlite3.Row) -> DeviceRecord:
 
 def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
     status = _row_text(row, "status")
-    if status not in {"processing", "completed"}:
+    if status not in {"processing", "completed", "outcome_unknown"}:
         raise ValueError(f"mobile_command_receipts.status 非法: {status}")
     optional: dict[str, str | None] = {}
     for field in ("reply_type", "reply_payload_json", "session_id", "turn_id"):
@@ -1860,11 +2129,11 @@ def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
         if value is not None and not isinstance(value, str):
             raise TypeError(f"mobile_command_receipts.{field} 必须为文本或 NULL")
         optional[field] = value
-    if status == "processing" and (
+    if status in {"processing", "outcome_unknown"} and (
         optional["reply_type"] is not None
         or optional["reply_payload_json"] is not None
     ):
-        raise ValueError("processing 命令收据包含回复")
+        raise ValueError(f"{status} 命令收据包含回复")
     if status == "completed" and (
         not optional["reply_type"] or not optional["reply_payload_json"]
     ):
@@ -1874,12 +2143,61 @@ def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
         command_id=_row_text(row, "command_id"),
         command_type=_row_text(row, "command_type"),
         request_hash=_row_text(row, "request_hash"),
-        status=cast(Literal["processing", "completed"], status),
+        status=cast(
+            Literal["processing", "completed", "outcome_unknown"],
+            status,
+        ),
         reply_type=optional["reply_type"],
         reply_payload_json=optional["reply_payload_json"],
         session_id=optional["session_id"],
         turn_id=optional["turn_id"],
+        created_at=_parse_datetime(_row_text(row, "created_at"), "created_at"),
+        completed_at=_optional_row_datetime(row, "completed_at"),
     )
+
+
+def _receipt_row_bytes(
+    *,
+    device_id: str,
+    command_id: str,
+    command_type: str,
+    request_hash: str,
+    status: str,
+    reply_type: str | None,
+    reply_payload_json: str | None,
+    session_id: str | None,
+    turn_id: str | None,
+    created_at: str,
+    completed_at: str | None,
+) -> int:
+    """按 SQLite 文本字段的 UTF-8 字节数计算单条收据占用。"""
+
+    return sum(
+        len(value.encode("utf-8"))
+        for value in (
+            device_id,
+            command_id,
+            command_type,
+            request_hash,
+            status,
+            reply_type,
+            reply_payload_json,
+            session_id,
+            turn_id,
+            created_at,
+            completed_at,
+        )
+        if value is not None
+    )
+
+
+def _optional_row_datetime(row: sqlite3.Row, field: str) -> datetime | None:
+    value = row[field]
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"SQLite 字段 {field} 必须为文本或 NULL")
+    return _parse_datetime(value, field)
 
 
 def _attachment_from_row(row: sqlite3.Row) -> AttachmentRecord:

--- a/session/store.py
+++ b/session/store.py
@@ -432,34 +432,87 @@ class SessionStore:
         )
         if not all(isinstance(value, str) and value for value in fields if value is not None):
             raise ValueError("inbound handoff fields must be non-empty strings")
+        identity = {
+            "dedupe_key": dedupe_key,
+            "channel": channel,
+            "sender": sender,
+            "chat_id": chat_id,
+            "session_key": session_key,
+            "content": content,
+            "timestamp": timestamp,
+            "media_json": media_json,
+            "metadata_json": metadata_json,
+        }
+        stable_identity = {
+            key: value for key, value in identity.items() if key != "timestamp"
+        }
+
+        def validate_existing(row: sqlite3.Row, *, include_timestamp: bool) -> None:
+            expected_identity = identity if include_timestamp else stable_identity
+            for column, expected in expected_identity.items():
+                if row[column] != expected:
+                    raise RuntimeError(
+                        "inbound handoff identity conflict: "
+                        f"handoff_id={handoff_id} field={column}"
+                    )
+
         with self._lock:
+            existing_by_id = self._conn.execute(
+                "SELECT * FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            ).fetchone()
             if dedupe_key is not None:
-                existing = self._conn.execute(
-                    "SELECT handoff_id FROM inbound_handoffs WHERE dedupe_key = ?",
+                existing_by_dedupe = self._conn.execute(
+                    "SELECT * FROM inbound_handoffs WHERE dedupe_key = ?",
                     (dedupe_key,),
                 ).fetchone()
-                if existing is not None:
-                    return str(existing["handoff_id"]), False
-            self._conn.execute(
+            else:
+                existing_by_dedupe = None
+            if (
+                existing_by_id is not None
+                and existing_by_dedupe is not None
+                and existing_by_id["handoff_id"] != existing_by_dedupe["handoff_id"]
+            ):
+                raise RuntimeError(
+                    "inbound handoff identity conflict: handoff_id and dedupe_key differ"
+                )
+            existing = existing_by_id or existing_by_dedupe
+            if existing is not None:
+                validate_existing(existing, include_timestamp=existing_by_id is not None)
+                return str(existing["handoff_id"]), False
+            cursor = self._conn.execute(
                 """
                 INSERT INTO inbound_handoffs(
                     handoff_id, dedupe_key, channel, sender, chat_id,
                     session_key, content, timestamp, media_json,
                     metadata_json, created_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(handoff_id) DO NOTHING
+                ON CONFLICT DO NOTHING
                 """,
                 fields,
             )
             row = self._conn.execute(
-                "SELECT handoff_id FROM inbound_handoffs WHERE handoff_id = ?",
+                "SELECT * FROM inbound_handoffs WHERE handoff_id = ?",
                 (handoff_id,),
             ).fetchone()
+            if row is None and dedupe_key is not None:
+                row = self._conn.execute(
+                    "SELECT * FROM inbound_handoffs WHERE dedupe_key = ?",
+                    (dedupe_key,),
+                ).fetchone()
             if row is None:
                 self._conn.rollback()
                 raise RuntimeError(f"inbound handoff disappeared: {handoff_id}")
-            self._conn.commit()
-            return str(row["handoff_id"]), True
+            try:
+                validate_existing(
+                    row,
+                    include_timestamp=row["handoff_id"] == handoff_id,
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
+            return str(row["handoff_id"]), cursor.rowcount == 1
 
     def list_inbound_handoffs(
         self,

--- a/session/store.py
+++ b/session/store.py
@@ -338,6 +338,25 @@ class SessionStore:
                 )
                 """)
             self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS inbound_handoffs (
+                    handoff_id  TEXT PRIMARY KEY,
+                    dedupe_key  TEXT UNIQUE,
+                    channel     TEXT NOT NULL,
+                    sender      TEXT NOT NULL,
+                    chat_id     TEXT NOT NULL,
+                    session_key TEXT NOT NULL,
+                    content     TEXT NOT NULL,
+                    timestamp   TEXT NOT NULL,
+                    media_json  TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    created_at  TEXT NOT NULL
+                )
+                """)
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_inbound_handoffs_session
+                ON inbound_handoffs(session_key, created_at)
+                """)
+            self._conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_session_admissions_session
                 ON session_admissions(session_key)
                 """)
@@ -379,6 +398,127 @@ class SessionStore:
                 """)
             self._ensure_next_seq_values()
             self._ensure_fts()
+            self._conn.commit()
+
+    def reserve_inbound_handoff(
+        self,
+        *,
+        handoff_id: str,
+        dedupe_key: str | None,
+        channel: str,
+        sender: str,
+        chat_id: str,
+        session_key: str,
+        content: str,
+        timestamp: str,
+        media_json: str,
+        metadata_json: str,
+        created_at: str,
+    ) -> tuple[str, bool]:
+        """Durably reserve one inbound message before exposing it to MessageBus."""
+
+        fields = (
+            handoff_id,
+            dedupe_key,
+            channel,
+            sender,
+            chat_id,
+            session_key,
+            content,
+            timestamp,
+            media_json,
+            metadata_json,
+            created_at,
+        )
+        if not all(isinstance(value, str) and value for value in fields if value is not None):
+            raise ValueError("inbound handoff fields must be non-empty strings")
+        with self._lock:
+            if dedupe_key is not None:
+                existing = self._conn.execute(
+                    "SELECT handoff_id FROM inbound_handoffs WHERE dedupe_key = ?",
+                    (dedupe_key,),
+                ).fetchone()
+                if existing is not None:
+                    return str(existing["handoff_id"]), False
+            self._conn.execute(
+                """
+                INSERT INTO inbound_handoffs(
+                    handoff_id, dedupe_key, channel, sender, chat_id,
+                    session_key, content, timestamp, media_json,
+                    metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(handoff_id) DO NOTHING
+                """,
+                fields,
+            )
+            row = self._conn.execute(
+                "SELECT handoff_id FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            ).fetchone()
+            if row is None:
+                self._conn.rollback()
+                raise RuntimeError(f"inbound handoff disappeared: {handoff_id}")
+            self._conn.commit()
+            return str(row["handoff_id"]), True
+
+    def list_inbound_handoffs(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, str | None]]:
+        """按 durable 到达顺序读取有限页的 pending inbound handoff。"""
+
+        if limit is not None and (
+            not isinstance(limit, int) or isinstance(limit, bool) or limit < 1
+        ):
+            raise ValueError("inbound handoff limit 必须是正整数")
+        limit_sql = "" if limit is None else " LIMIT ?"
+
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT handoff_id, dedupe_key, channel, sender, chat_id,
+                       session_key, content, timestamp, media_json,
+                       metadata_json, created_at
+                FROM inbound_handoffs
+                ORDER BY created_at ASC, handoff_id ASC
+                """ + limit_sql,
+                () if limit is None else (limit,),
+            ).fetchall()
+        return [
+            {key: cast(str | None, row[key]) for key in row.keys()}
+            for row in rows
+        ]
+
+    def has_inbound_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        """Check whether a client message still owns an uncompleted handoff."""
+
+        dedupe_key = f"{session_key}:{client_message_id}"
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM inbound_handoffs WHERE dedupe_key = ?",
+                (dedupe_key,),
+            ).fetchone()
+        return row is not None
+
+    def complete_inbound_handoff(self, handoff_id: str) -> None:
+        """Release a handoff only after its worker has finished processing."""
+
+        if not isinstance(handoff_id, str) or not handoff_id:
+            raise ValueError("handoff_id must be a non-empty string")
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise RuntimeError(f"inbound handoff not found: {handoff_id}")
             self._conn.commit()
 
     def _ensure_session_columns(self) -> None:

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -12,6 +12,7 @@ from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
 from bootstrap.passive_worker import PassiveMessageWorker
 from bus.events import InboundMessage, OutboundMessage
+from bus.queue import MessageBus
 from session.manager import SessionManager
 from session.store import SessionStore
 
@@ -25,6 +26,9 @@ class _Bus:
 
     async def consume_inbound(self) -> InboundMessage:
         return await self.inbound.get()
+
+    async def recover_durable_inbounds(self) -> None:
+        return None
 
     async def publish_outbound(self, message: OutboundMessage) -> None:
         self.outbound.append(message)
@@ -98,6 +102,39 @@ async def test_channel_adapter_releases_session_admission_after_completion(
     assert dashboard_store.delete_session(session_key, cascade=True)
     dashboard_store.close()
     await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_recovered_mobile_handoff_with_canonical_user_skips_new_turn(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:existing"
+    session = manager.get_or_create(session_key)
+    session.add_message("user", "hello", client_message_id="client:1")
+    manager.save(session)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(manager.control_store)
+    inbound = InboundMessage(
+        "mobile",
+        "device:1",
+        "existing",
+        "hello",
+        metadata={"session_key_override": session_key, "client_message_id": "client:1"},
+    )
+    await bus.publish_inbound(inbound)
+    recovered = await bus.consume_inbound()
+    worker = PassiveMessageWorker(
+        bus,
+        cast(Any, object()),
+        cast(Any, SimpleNamespace(session_manager=manager)),
+    )
+
+    await worker._run_message(recovered)
+
+    assert manager.control_store.list_turns(session_key) == []
+    assert manager.control_store.list_inbound_handoffs() == []
     manager.close()
 
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -87,12 +87,21 @@ class _Bus:
     def __init__(self) -> None:
         self.inbound: list[object] = []
         self.outbound: dict[str, object] = {}
+        self.pending_handoff = False
 
     async def publish_inbound(self, message: object) -> None:
         self.inbound.append(message)
 
     def subscribe_outbound(self, channel: str, callback: object) -> None:
         self.outbound[channel] = callback
+
+    def has_pending_mobile_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        return self.pending_handoff
 
 
 class _FailingBus(_Bus):
@@ -863,6 +872,69 @@ async def test_message_send_marks_prestart_processing_receipt_retryable(
     assert result == replayed
     assert result.type == "message.send.error"
     assert result.payload["code"] == "command_interrupted"
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_message_send_pending_handoff_stays_in_progress_until_user_reconciles(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"mobile:{uuid4()}"
+    frame = _message_frame(
+        frame_id="01ARZ3NDEKSTV4RRFFQ69G5FAY",
+        session_id=session_id,
+    )
+    _, created = storage.reserve_command(
+        device_id=device_id,
+        command_id=frame.id,
+        command_type=frame.type,
+        request_hash=channel_module._command_hash(frame),
+        created_at=datetime.now(timezone.utc),
+    )
+    assert created
+    bus = _Bus()
+    bus.pending_handoff = True
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=bus,
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+
+    pending = await channel.handle_command(device_id=device_id, frame=frame)
+    assert pending.type == "message.send.error"
+    assert pending.payload["code"] == "command_in_progress"
+    receipt = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts WHERE device_id = ? AND command_id = ?",
+        (device_id, frame.id),
+    ).fetchone()
+    assert receipt is not None and receipt[0] == "processing"
+
+    session = manager.get_or_create(session_id)
+    session.add_message("user", frame.payload.text, client_message_id=frame.id)
+    manager.save(session)
+    bus.pending_handoff = False
+    completed = await channel.handle_command(device_id=device_id, frame=frame)
+    assert completed.type == "message.send.ok"
+    receipt = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts WHERE device_id = ? AND command_id = ?",
+        (device_id, frame.id),
+    ).fetchone()
+    assert receipt is not None and receipt[0] == "completed"
+    manager.close()
     storage.close()
 
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -732,11 +732,48 @@ async def test_message_send_keeps_unknown_outcome_without_persisted_user(
     result = await channel.handle_command(device_id=device_id, frame=frame)
 
     assert result.type == "message.send.error"
-    assert result.payload["code"] == "command_outcome_unknown"
+    assert result.payload["code"] == "command_in_progress"
     assert bus.inbound == []
     release.set()
     completed = await original
     assert completed.type == "message.send.ok"
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_processing_non_message_keeps_active_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
+    frame = _generic_frame(
+        frame_id="01ARZ3NDEKTSV4RRFFQ69G5FB3",
+        command_type="ping",
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute_slowly(
+        *, device_id: str, frame: object
+    ) -> channel_module.CommandReply:
+        started.set()
+        await release.wait()
+        return channel_module.CommandReply(type="ping.ok", payload={})
+
+    monkeypatch.setattr(channel, "_execute_command", execute_slowly)
+    original = asyncio.create_task(
+        channel.handle_command(device_id=device_id, frame=frame)
+    )
+    await started.wait()
+    duplicate = await channel.handle_command(device_id=device_id, frame=frame)
+    assert duplicate.payload["code"] == "command_in_progress"
+    release.set()
+    assert (await original).type == "ping.ok"
+    replay = await channel.handle_command(device_id=device_id, frame=frame)
+    assert replay.type == "ping.ok"
     storage.close()
 
 

--- a/tests/mobile_realtime/test_storage.py
+++ b/tests/mobile_realtime/test_storage.py
@@ -9,10 +9,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+import infra.mobile_realtime.storage as storage_module
 
 from infra.mobile_realtime.storage import (
     AckOverflowError,
     AckRollbackError,
+    CommandConflictError,
+    CommandReceiptCapacityError,
     DeviceRecord,
     MobileRealtimeStorage,
     PairingExpiredError,
@@ -364,3 +367,124 @@ def test_corrupt_sqlite_event_payload_fails_at_row_boundary(
 
     with pytest.raises(TypeError, match="JSON object"):
         storage.read_durable_events("device-1", after_event_seq=0, limit=10)
+
+
+def test_command_receipt_replay_conflict_and_retention(
+    storage: MobileRealtimeStorage,
+) -> None:
+    storage.register_device(_device())
+    old = NOW - timedelta(days=8)
+    receipt, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    assert created and receipt.status == "processing"
+    completed = storage.complete_command(
+        device_id="device-1",
+        command_id="command-1",
+        reply_type="ping.ok",
+        reply_payload_json='{"ok":true}',
+        session_id=None,
+        turn_id=None,
+        completed_at=NOW,
+    )
+    replay, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW + timedelta(days=1),
+    )
+    assert not created and replay == completed
+    with pytest.raises(CommandConflictError):
+        storage.reserve_command(
+            device_id="device-1",
+            command_id="command-1",
+            command_type="ping",
+            request_hash="different",
+            created_at=NOW,
+        )
+
+    _, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-2",
+        command_type="ping",
+        request_hash="hash-2",
+        created_at=old,
+    )
+    assert created
+    storage.complete_command(
+        device_id="device-1",
+        command_id="command-2",
+        reply_type="ping.ok",
+        reply_payload_json='{"ok":true}',
+        session_id=None,
+        turn_id=None,
+        completed_at=old,
+    )
+    replacement, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-2",
+        command_type="ping",
+        request_hash="hash-2",
+        created_at=NOW,
+    )
+    assert created and replacement.status == "processing"
+
+
+def test_command_receipt_capacity_cleanup_and_insert_are_bounded(
+    storage: MobileRealtimeStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage.register_device(_device())
+    monkeypatch.setattr(storage_module, "_COMMAND_RECEIPT_MAX_COUNT", 1)
+    storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    with pytest.raises(CommandReceiptCapacityError):
+        storage.reserve_command(
+            device_id="device-1",
+            command_id="command-2",
+            command_type="ping",
+            request_hash="hash-2",
+            created_at=NOW,
+        )
+    assert storage.read_cursor("device-1").next_event_seq == 1
+
+
+def test_command_receipt_completion_rejects_byte_overflow_without_losing_processing(
+    storage: MobileRealtimeStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage.register_device(_device())
+    storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    monkeypatch.setattr(storage_module, "_COMMAND_RECEIPT_MAX_BYTES", 50)
+    with pytest.raises(CommandReceiptCapacityError):
+        storage.complete_command(
+            device_id="device-1",
+            command_id="command-1",
+            reply_type="ping.ok",
+            reply_payload_json='{"result":"' + ("x" * 128) + '"}',
+            session_id=None,
+            turn_id=None,
+            completed_at=NOW,
+        )
+    row = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts "
+        "WHERE device_id = ? AND command_id = ?",
+        ("device-1", "command-1"),
+    ).fetchone()
+    assert row["status"] == "processing"

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bus.events import InboundMessage, OutboundMessage
+from bus.queue import MessageBus, MessageBusCapacityError
+
+
+@pytest.mark.asyncio
+async def test_inbound_capacity_rejection_does_not_leave_chat_lane_pending() -> None:
+    bus = MessageBus(inbound_capacity=1, inbound_bytes=4096)
+    first = InboundMessage("cli", "user", "one", "first")
+    await bus.publish_inbound(first)
+
+    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
+        await bus.publish_inbound(InboundMessage("cli", "user", "two", "second"))
+
+    assert bus.inbound_size == 1
+    assert bus.chat_lane._states[("cli", "one")].passive_turns == 1
+    assert ("cli", "two") not in bus.chat_lane._states
+
+    consumed = await bus.consume_inbound()
+    await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes == 0
+    assert bus.chat_lane._states == {}
+
+
+@pytest.mark.asyncio
+async def test_outbound_capacity_rejection_rolls_back_chat_lane_send_count() -> None:
+    bus = MessageBus(outbound_capacity=1, outbound_bytes=4096)
+    await bus.publish_outbound(OutboundMessage("cli", "one", "first"))
+
+    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
+        await bus.publish_outbound(OutboundMessage("cli", "two", "second"))
+
+    state = bus.chat_lane._states[("cli", "one")]
+    assert state.passive_sends == 1
+    assert ("cli", "two") not in bus.chat_lane._states
+
+    bus._running = True
+    dispatch = asyncio.create_task(bus.dispatch_outbound())
+    await asyncio.sleep(0)
+    bus.stop()
+    dispatch.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await dispatch
+    assert bus.outbound_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_releases_reservation_before_chat_lane_wait() -> None:
+    bus = MessageBus(inbound_capacity=1)
+    blocked = asyncio.Event()
+
+    async def wait_for_admission(_channel: str, _chat_id: str) -> None:
+        await blocked.wait()
+
+    bus.chat_lane.mark_passive_pending = wait_for_admission  # type: ignore[method-assign]
+    publish = asyncio.create_task(
+        bus.publish_inbound(InboundMessage("cli", "user", "one", "first"))
+    )
+    await asyncio.sleep(0)
+    assert bus.inbound_reserved_bytes > 0
+    publish.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await publish
+    assert bus.inbound_reserved_bytes == 0
+    assert bus.inbound_size == 0

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import gc
+import logging
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from bus.events import InboundMessage, OutboundMessage
 from bus.queue import MessageBus, MessageBusCapacityError
+from session.manager import SessionManager
+from session.store import SessionStore
 
 
 @pytest.mark.asyncio
@@ -68,3 +75,177 @@ async def test_cancelled_admission_releases_reservation_before_chat_lane_wait() 
         await publish
     assert bus.inbound_reserved_bytes == 0
     assert bus.inbound_size == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retry_keeps_owner_after_worker_drops_item(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:cleanup"
+    manager.save(manager.get_or_create(session_key))
+    _, admission_id = manager.admit_existing(session_key)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "cleanup",
+        "hello",
+        metadata={"session_key_override": session_key, "client_message_id": "client-1"},
+        session_admission_id=admission_id,
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    assert consumed is item
+    item_ref = weakref.ref(item)
+    original_complete = store.complete_inbound_handoff
+    attempts = 0
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("temporary delete failure")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+
+    class _Runtime:
+        async def wait_thread_available(self, _session_key: str) -> None:
+            return None
+
+        async def start_turn(self, _request: object) -> object:
+            raise RuntimeError("worker stopped before turn submission")
+
+    from bootstrap.passive_worker import PassiveMessageWorker
+
+    worker = PassiveMessageWorker(
+        bus,
+        _Runtime(),  # type: ignore[arg-type]
+        SimpleNamespace(session_manager=manager),  # type: ignore[arg-type]
+    )
+    lane = asyncio.Queue()
+    lane.put_nowait(consumed)
+    worker._lane_queues[session_key] = lane
+    lane_task = asyncio.create_task(worker._run_lane(session_key, lane))
+    await lane_task
+    assert manager.control_store.list_turns(session_key) == []
+    owner_key = id(item)
+    assert owner_key in bus._inbound_accepted
+    del consumed
+    del item
+    gc.collect()
+    assert item_ref() is not None
+
+    async def cleanup_finished() -> None:
+        while store.list_inbound_handoffs():
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(cleanup_finished(), timeout=1)
+    await asyncio.sleep(0)
+    gc.collect()
+    assert attempts >= 2
+    assert bus.inbound_bytes == 0
+    assert bus._inbound_accepted == {}
+    assert bus._inbound_cleanup_tasks == {}
+    assert bus.chat_lane._states == {}
+    replacement = InboundMessage(
+        "mobile",
+        "device:1",
+        "cleanup",
+        "replacement",
+        metadata={"session_key_override": session_key, "client_message_id": "client-2"},
+        session_admission_id=admission_id,
+    )
+    await bus.publish_inbound(replacement)
+    assert bus._inbound_accepted[id(replacement)].item is replacement
+    await bus.complete_inbound(replacement)
+    await bus.aclose()
+    manager.close()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_cleanup_failure_is_bounded_and_shutdown_cancels_retry(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "persistent",
+        "hello",
+        metadata={"client_message_id": "client-persistent"},
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    attempts = 0
+
+    def always_fail(_handoff_id: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError("persistent delete failure")
+
+    store.complete_inbound_handoff = always_fail  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent delete failure"):
+        await bus.complete_inbound(consumed)
+    await asyncio.sleep(0.35)
+    assert 2 <= attempts <= 4
+    assert bus.inbound_bytes > 0
+    assert len(bus._inbound_accepted) == 1
+    assert len(bus._inbound_cleanup_tasks) == 1
+    await bus.aclose()
+    assert bus._inbound_cleanup_tasks == {}
+    assert store._conn.execute(
+        "SELECT 1 FROM inbound_handoffs WHERE handoff_id = ?",
+        (consumed.handoff_id,),
+    ).fetchone() is not None
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_finalize_failure_is_fatal_and_observable(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "fatal",
+        "hello",
+        metadata={"client_message_id": "client-fatal"},
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    original_complete = store.complete_inbound_handoff
+    failed = True
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal failed
+        if failed:
+            failed = False
+            raise OSError("temporary delete failure")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+
+    async def fatal_finalize(_owner_key: int, _owner: object) -> None:
+        raise RuntimeError("owner mismatch")
+
+    bus._finalize_inbound_owner = fatal_finalize  # type: ignore[method-assign]
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError, match="temporary delete failure"):
+            await bus.complete_inbound(consumed)
+        await asyncio.sleep(0.2)
+    assert bus._inbound_cleanup_error is not None
+    assert bus._inbound_cleanup_tasks == {}
+    assert "event=runtime_fatal" in caplog.text
+    assert "owner=message_bus.inbound_cleanup" in caplog.text
+    with pytest.raises(RuntimeError, match="cleanup owner failed"):
+        await bus.aclose()
+    store.close()

--- a/tests/test_plugin_mobile_ui.py
+++ b/tests/test_plugin_mobile_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import threading
 from types import MappingProxyType, SimpleNamespace
@@ -241,6 +242,54 @@ async def test_mobile_ui_timeout_keeps_snapshot_lease_until_worker_exits(
             break
         await asyncio.sleep(0.01)
     assert store.exited == 1
+
+
+@pytest.mark.asyncio
+async def test_mobile_ui_query_rejects_beyond_bounded_worker_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider()
+    blocker = threading.Event()
+    entered = threading.Event()
+    monkeypatch.setattr(mobile_ui_module, "MOBILE_UI_QUERY_WORKERS", 1)
+    monkeypatch.setattr(mobile_ui_module, "MOBILE_UI_QUERY_QUEUE_LIMIT", 0)
+    cast(Any, provider)._executor.shutdown(wait=True)
+    cast(Any, provider)._executor = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="mobile-plugin-ui-test",
+    )
+
+    def block(*args: object, **kwargs: object) -> dict[str, object]:
+        entered.set()
+        blocker.wait(timeout=1)
+        return {}
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_query = block
+    running = asyncio.create_task(
+        provider.query(
+            "sample@github",
+            "revision-1",
+            "health.snapshot",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+    )
+    assert await asyncio.to_thread(entered.wait, 1)
+    with pytest.raises(mobile_ui_module.MobileUiQueryOverloaded):
+        await provider.query(
+            "sample@github",
+            "revision-1",
+            "health.snapshot",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-2",
+        )
+    blocker.set()
+    assert await running == {}
+
 
 @pytest.mark.asyncio
 async def test_mobile_ui_rpc_failure_isolated_from_transport() -> None:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,4 +1,6 @@
 from datetime import UTC, datetime, timedelta
+import asyncio
+import logging
 import threading
 
 import pytest
@@ -14,6 +16,8 @@ from agent.control.models import (
 )
 from session.manager import SessionManager
 from session.store import SessionStore
+from bus.events import InboundMessage
+from bus.queue import MessageBus
 
 NOW = datetime(2026, 7, 14, 8, 0, tzinfo=UTC)
 
@@ -67,6 +71,155 @@ def test_turn_reopens_with_terminal_usage_and_items(tmp_path) -> None:
     assert record.usage == TurnUsage(input_tokens=12, output_tokens=3, coverage="exact")
     assert record.final_response == "完成"
     reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_inbound_handoff_survives_queue_restart_and_deduplicates(tmp_path) -> None:
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    message = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="你好",
+        metadata={"client_message_id": "client:1"},
+    )
+
+    await bus.publish_inbound(message)
+    assert len(store.list_inbound_handoffs()) == 1
+
+    restarted = MessageBus()
+    recovered_store = SessionStore(db_path)
+    restarted.bind_durable_inbound_store(recovered_store)
+    await restarted.recover_durable_inbounds()
+    recovered = await restarted.consume_inbound()
+    assert recovered.content == "你好"
+    assert recovered.handoff_id == message.handoff_id
+
+    duplicate = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="你好",
+        metadata={"client_message_id": "client:1"},
+    )
+    await bus.publish_inbound(duplicate)
+    assert bus.inbound_size == 1
+
+    await restarted.complete_inbound(recovered)
+    assert store.list_inbound_handoffs() == []
+    recovered_store.close()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_handoff_recovery_is_bounded_and_pumps_after_completion(tmp_path) -> None:
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path)
+    seed = MessageBus()
+    seed.bind_durable_inbound_store(store)
+    for index in range(3):
+        await seed.publish_inbound(
+            InboundMessage(
+                channel="mobile",
+                sender="device:1",
+                chat_id=f"mobile:session-{index}",
+                content=f"message-{index}",
+                metadata={"client_message_id": f"client:{index}"},
+            )
+        )
+
+    recovered_store = SessionStore(db_path)
+    restarted = MessageBus(inbound_capacity=1)
+    restarted.bind_durable_inbound_store(recovered_store)
+    await restarted.recover_durable_inbounds()
+    assert restarted.inbound_size == 1
+    assert len(recovered_store.list_inbound_handoffs()) == 3
+
+    for index in range(3):
+        item = await restarted.consume_inbound()
+        assert item.content == f"message-{index}"
+        await restarted.complete_inbound(item)
+        assert restarted.inbound_size == (1 if index < 2 else 0)
+    assert recovered_store.list_inbound_handoffs() == []
+    recovered_store.close()
+    store.close()
+
+
+def test_mobile_handoff_recovery_rejects_corrupt_json(tmp_path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    store._conn.execute(
+        """
+        INSERT INTO inbound_handoffs(
+            handoff_id, dedupe_key, channel, sender, chat_id, session_key,
+            content, timestamp, media_json, metadata_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "handoff-corrupt",
+            "mobile:session:client-corrupt",
+            "mobile",
+            "device:1",
+            "mobile:session",
+            "mobile:session",
+            "bad",
+            NOW.isoformat(),
+            "{}",
+            "[]",
+            NOW.isoformat(),
+        ),
+    )
+    store._conn.commit()
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    with pytest.raises(ValueError, match="inbound handoff media invalid"):
+        asyncio.run(bus.recover_durable_inbounds())
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    message = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="hello",
+        metadata={"client_message_id": "client:delete-retry"},
+    )
+    await bus.publish_inbound(message)
+    consumed = await bus.consume_inbound()
+    original_complete = store.complete_inbound_handoff
+    failed = True
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal failed
+        if failed:
+            failed = False
+            raise OSError("delete unavailable")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError, match="delete unavailable"):
+            await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes > 0
+    assert len(bus._inbound_accepted) == 1
+    assert len(store.list_inbound_handoffs()) == 1
+    assert "cleanup_degraded" in caplog.text
+
+    await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes == 0
+    assert bus._inbound_accepted == {}
+    assert store.list_inbound_handoffs() == []
+    store.close()
 
 
 def test_queued_turn_can_be_cancelled(tmp_path) -> None:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -179,6 +179,39 @@ def test_mobile_handoff_recovery_rejects_corrupt_json(tmp_path) -> None:
     store.close()
 
 
+def test_mobile_handoff_conflicting_reuse_fails_loud(tmp_path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    base = {
+        "handoff_id": "handoff-1",
+        "dedupe_key": "mobile:session:client-1",
+        "channel": "mobile",
+        "sender": "device:1",
+        "chat_id": "mobile:session",
+        "session_key": "mobile:session",
+        "content": "hello",
+        "timestamp": NOW.isoformat(),
+        "media_json": "[]",
+        "metadata_json": '{"client_message_id":"client-1"}',
+        "created_at": NOW.isoformat(),
+    }
+    assert store.reserve_inbound_handoff(**base) == ("handoff-1", True)
+    assert store.reserve_inbound_handoff(**base | {"handoff_id": "handoff-2"}) == (
+        "handoff-1",
+        False,
+    )
+    with pytest.raises(RuntimeError, match="identity conflict"):
+        store.reserve_inbound_handoff(**base | {"content": "tampered"})
+    with pytest.raises(RuntimeError, match="identity conflict"):
+        store.reserve_inbound_handoff(
+            **base
+            | {
+                "handoff_id": "handoff-2",
+                "content": "tampered",
+            }
+        )
+    store.close()
+
+
 @pytest.mark.asyncio
 async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
     tmp_path,
@@ -215,7 +248,11 @@ async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
     assert len(store.list_inbound_handoffs()) == 1
     assert "cleanup_degraded" in caplog.text
 
-    await bus.complete_inbound(consumed)
+    async def retry_finished() -> None:
+        while bus.inbound_bytes:
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(retry_finished(), timeout=1)
     assert bus.inbound_bytes == 0
     assert bus._inbound_accepted == {}
     assert store.list_inbound_handoffs() == []

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -475,9 +475,10 @@ async def test_message_push_default_call_waits_for_passive_lane():
         events.append(message)
 
     _register_text_channel(tool, "cli", text)
-    await bus.publish_inbound(
-        InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
+    inbound = InboundMessage(
+        channel="cli", sender="user", chat_id="1", content="hello"
     )
+    await bus.publish_inbound(inbound)
     push_task = asyncio.create_task(
         tool.execute(target_channel="cli", target_chat_id="1", message="inline")
     )
@@ -485,9 +486,7 @@ async def test_message_push_default_call_waits_for_passive_lane():
     await asyncio.sleep(0.01)
     assert not push_task.done()
 
-    await bus.complete_inbound(
-        InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
-    )
+    await bus.complete_inbound(inbound)
     result = await asyncio.wait_for(push_task, timeout=1)
 
     assert result == "消息已发送"

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -271,8 +271,8 @@ async def test_message_push_reports_partial_after_text_commit() -> None:
     _ = tool.register_channel("telegram", deliver=deliver)
 
     result = await tool.execute(
-        channel="telegram",
-        chat_id="1",
+        target_channel="telegram",
+        target_chat_id="1",
         message="正文",
         file="/tmp/report.pdf",
     )


### PR DESCRIPTION
## Summary

- bound accepted MessageBus bytes before enqueue and preserve cleanup ownership across retries
- persist mobile inbound handoff before worker execution so crashes do not lose accepted messages
- retain command receipts and bound plugin UI query leases without deleting authoritative history

## Failure semantics

- admission overflow fails before ownership transfer
- accepted inbound work remains durably recoverable after worker crash
- receipt capacity and query overload return explicit errors to the channel/agent
- cleanup failures retain the same inbound owner for retry instead of reporting false success

## Verification

- mobile/bus/session focused suite: 158 passed
- `python docker/debug/gate.py audit` — passed
- `git diff --check` — passed
- GitHubLuna read-only review found no P0/P1 issue in the channel/storage conflict resolutions

## Stack

- base: `codex/companion-security-wake-scheduler` (#294)
- next: execution admission, control replay, Dashboard fixtures, private runtime pin

## Rollback

Restore branch: `backup/companion-security-pr4-before-peer-contract-rebase`.
