### PR TITLE
fix(security): bound execution and control replay

### DIFF
--- a/agent/background/subagent_manager.py
+++ b/agent/background/subagent_manager.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from agent.background.runtime import (
     AgentBackgroundJobRunner,
@@ -40,6 +40,67 @@ _RESULT_MAX_CHARS = 12_000
 _SYNC_RESULT_MAX_CHARS = 100_000
 _SPAWN_MAX_ITERATIONS = 50
 _SYNC_MAX_ITERATIONS = 10
+MAX_ACTIVE_SUBAGENTS = 3
+
+
+class SubagentCapacityError(RuntimeError):
+    """当前 subagent admission 已满，拒绝本次创建。"""
+
+    def __init__(self, *, active: int, maximum: int) -> None:
+        self.active = active
+        self.maximum = maximum
+        super().__init__(
+            "subagent capacity reached: "
+            f"active={active}, max={maximum}; current spawn rejected"
+        )
+
+
+@dataclass(frozen=True)
+class _SubagentAdmissionLease:
+    token: str
+    owner: str
+    admission: "_SubagentAdmission"
+
+    def release(self) -> None:
+        self.admission.release(self)
+
+
+class _SubagentAdmission:
+    """在同一事件循环内原子登记真实 subagent worker。"""
+
+    def __init__(self, maximum: int = MAX_ACTIVE_SUBAGENTS) -> None:
+        if maximum < 1:
+            raise ValueError("subagent admission maximum must be positive")
+        self._maximum = maximum
+        self._active: dict[str, _SubagentAdmissionLease] = {}
+
+    @property
+    def active_count(self) -> int:
+        return len(self._active)
+
+    def acquire(self, *, owner: str) -> _SubagentAdmissionLease:
+        """在无 await 的临界区登记 worker，容量满时只拒绝当前调用。"""
+
+        # 1. 事件循环内同步检查和登记，避免同步/后台路径竞态超卖。
+        active = len(self._active)
+        if active >= self._maximum:
+            raise SubagentCapacityError(active=active, maximum=self._maximum)
+
+        lease = _SubagentAdmissionLease(
+            token=uuid.uuid4().hex,
+            owner=owner,
+            admission=self,
+        )
+        self._active[lease.token] = lease
+        return lease
+
+    def release(self, lease: _SubagentAdmissionLease) -> None:
+        current = self._active.get(lease.token)
+        if current is not lease:
+            raise RuntimeError(
+                f"subagent admission lease 已释放或不属于 owner={lease.owner}"
+            )
+        del self._active[lease.token]
 
 
 @dataclass(frozen=True)
@@ -80,9 +141,11 @@ class SubagentManager:
         self._fetch_requester = fetch_requester
         self._multimodal = multimodal
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._sync_tasks: dict[str, asyncio.Task[tuple[str, str]]] = {}
         self._running_jobs: dict[str, RunningSubagentJob] = {}
         self._cancel_announced: set[str] = set()
         self._snapshot_release_tasks: set[asyncio.Task[None]] = set()
+        self._admission = _SubagentAdmission()
 
     def add_tool_hooks(self, hooks: list[ToolHook]) -> None:
         object.__setattr__(self._runtime, "tool_hooks", list(hooks))
@@ -105,9 +168,34 @@ class SubagentManager:
         profile: str = PROFILE_RESEARCH,
     ) -> str:
         """同步执行子任务，并将结果直接返回当前轮次。"""
+
         job_id = uuid.uuid4().hex[:8]
         display_label = (label or task[:30] or job_id).strip()
-        task_dir = self._job_task_dir(job_id)
+        lease = self._admission.acquire(owner=f"sync:{job_id}")
+        worker: asyncio.Task[tuple[str, str]] | None = None
+        callback_registered = False
+        try:
+            task_dir = self._job_task_dir(job_id)
+            worker = asyncio.create_task(
+                self._run_sync_subagent(
+                    task=task,
+                    task_dir=task_dir,
+                    profile=profile,
+                ),
+                name=f"spawn_sync:{job_id}",
+            )
+            self._sync_tasks[job_id] = worker
+            worker.add_done_callback(
+                lambda done: self._finish_sync_job(job_id, lease, done)
+            )
+            callback_registered = True
+        except BaseException:
+            if not callback_registered and worker is not None:
+                self._sync_tasks.pop(job_id, None)
+                worker.cancel()
+                _ = await asyncio.gather(worker, return_exceptions=True)
+            lease.release()
+            raise
 
         logger.info(
             "[spawn_sync] started job_id=%s label=%r profile=%s",
@@ -116,18 +204,28 @@ class SubagentManager:
             profile,
         )
 
-        subagent = self._build_subagent(
-            task_dir=task_dir,
-            profile=profile,
-            max_iterations=_SYNC_MAX_ITERATIONS,
-        )
         try:
-            result = await subagent.run(task)
-            exit_reason = getattr(subagent, "last_exit_reason", None) or "completed"
-        except Exception as e:
-            logger.exception("[spawn_sync] subagent failed job_id=%s err=%s", job_id, e)
-            result = f"执行出错：{e}"
-            exit_reason = "error"
+            assert worker is not None
+            result, exit_reason = await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            # 1. 取消真实 worker，并等待其 finally/cleanup 完成后再传播取消。
+            worker.cancel()
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                pass
+            except BaseException as exc:
+                logger.exception(
+                    "[spawn_sync] cancelled worker cleanup failed job_id=%s err=%s",
+                    job_id,
+                    exc,
+                )
+            # 2. done callback 只在 worker 真实结束后释放 admission。
+            logger.info(
+                "[spawn_sync] wait cancelled; worker cleanup confirmed job_id=%s",
+                job_id,
+            )
+            raise
 
         truncated = result
         if len(truncated) > _SYNC_RESULT_MAX_CHARS:
@@ -159,56 +257,91 @@ class SubagentManager:
         """创建后台 subagent 任务，并立即把控制权还给主 agent。"""
         job_id = uuid.uuid4().hex[:8]
         display_label = (label or task[:30] or job_id).strip()
-        task_dir = self._job_task_dir(job_id)
-        # 1. 先写追踪记录，确保后台任务创建失败时仍可定位
-        self._append_spawn_trace(
-            job_id=job_id,
-            payload={
-                "phase": "started",
-                "label": display_label,
-                "task_dir": str(task_dir),
-                "origin_channel": origin_channel,
-                "origin_chat_id": origin_chat_id,
-                "profile": profile,
-                "retry_count": retry_count,
-                "decision": _decision_payload(decision),
-            },
-        )
-        # 2. 租用当前快照后启动后台任务，隔离后续热重载
-        from agent.plugins.snapshot import lease_current_runtime_snapshot
-
-        snapshot_lease = lease_current_runtime_snapshot()
-        bg_task = asyncio.create_task(
-            self._run_subagent(
+        lease = self._admission.acquire(owner=f"background:{job_id}")
+        task_dir: Path | None = None
+        snapshot_lease: RuntimeSnapshotLease | None = None
+        bg_task: asyncio.Task[None] | None = None
+        callback_registered = False
+        try:
+            # 1. 先写追踪记录，确保后台任务创建失败时仍可定位
+            task_dir = self._job_task_dir(job_id)
+            self._append_spawn_trace(
                 job_id=job_id,
-                task=task,
+                payload={
+                    "phase": "started",
+                    "label": display_label,
+                    "task_dir": str(task_dir),
+                    "origin_channel": origin_channel,
+                    "origin_chat_id": origin_chat_id,
+                    "profile": profile,
+                    "retry_count": retry_count,
+                    "decision": _decision_payload(decision),
+                },
+            )
+            # 2. 租用当前快照后启动后台任务，隔离后续热重载
+            from agent.plugins.snapshot import lease_current_runtime_snapshot
+
+            snapshot_lease = lease_current_runtime_snapshot()
+            assert task_dir is not None
+            bg_task = asyncio.create_task(
+                self._run_subagent(
+                    job_id=job_id,
+                    task=task,
+                    label=display_label,
+                    task_dir=task_dir,
+                    origin_channel=origin_channel,
+                    origin_chat_id=origin_chat_id,
+                    decision=decision,
+                    profile=profile,
+                    retry_count=retry_count,
+                    snapshot_lease=snapshot_lease,
+                ),
+                name=f"spawn:{job_id}",
+            )
+            # 3. 登记任务后立即返回，完成回调负责释放 admission/快照
+            self._running_tasks[job_id] = bg_task
+            self._running_jobs[job_id] = RunningSubagentJob(
+                job_id=job_id,
                 label=display_label,
-                task_dir=task_dir,
+                task=task,
+                profile=profile,
                 origin_channel=origin_channel,
                 origin_chat_id=origin_chat_id,
-                decision=decision,
-                profile=profile,
+                task_dir=str(task_dir),
                 retry_count=retry_count,
-                snapshot_lease=snapshot_lease,
-            ),
-            name=f"spawn:{job_id}",
-        )
-        # 3. 登记任务后立即返回，完成回调负责释放快照
-        self._running_tasks[job_id] = bg_task
-        self._running_jobs[job_id] = RunningSubagentJob(
-            job_id=job_id,
-            label=display_label,
-            task=task,
-            profile=profile,
-            origin_channel=origin_channel,
-            origin_chat_id=origin_chat_id,
-            task_dir=str(task_dir),
-            retry_count=retry_count,
-            started_at=datetime.now(timezone.utc).isoformat(),
-        )
-        bg_task.add_done_callback(
-            lambda _: self._finish_background_job(job_id, snapshot_lease)
-        )
+                started_at=datetime.now(timezone.utc).isoformat(),
+            )
+            bg_task.add_done_callback(
+                lambda done: self._finish_background_job(
+                    job_id,
+                    snapshot_lease,
+                    lease,
+                    done,
+                )
+            )
+            callback_registered = True
+        except BaseException:
+            if not callback_registered and bg_task is not None:
+                self._forget_running_job(job_id)
+                bg_task.cancel()
+                _ = await asyncio.gather(bg_task, return_exceptions=True)
+            if (
+                not callback_registered
+                and snapshot_lease is not None
+                and snapshot_lease.active
+            ):
+                try:
+                    await snapshot_lease.release()
+                except BaseException as exc:
+                    logger.exception(
+                        "[spawn] cleanup_degraded snapshot release failed "
+                        "job_id=%s err=%s",
+                        job_id,
+                        exc,
+                    )
+            if not callback_registered:
+                lease.release()
+            raise
         logger.info(
             "[spawn] started job_id=%s label=%r profile=%s retry_count=%d origin=%s:%s reason=%s confidence=%s",
             job_id,
@@ -226,7 +359,7 @@ class SubagentManager:
         )
 
     def get_running_count(self) -> int:
-        return len(self._running_tasks)
+        return self._admission.active_count
 
     def list_running_jobs(self) -> list[dict[str, object]]:
         return [asdict(job) for job in self._running_jobs.values()]
@@ -248,6 +381,29 @@ class SubagentManager:
         self._running_tasks.pop(job_id, None)
         self._running_jobs.pop(job_id, None)
         self._cancel_announced.discard(job_id)
+
+    async def _run_sync_subagent(
+        self,
+        *,
+        task: str,
+        task_dir: Path,
+        profile: str,
+    ) -> tuple[str, str]:
+        """运行同步 worker，并把可观察错误转换成当前协议结果。"""
+
+        subagent = self._build_subagent(
+            task_dir=task_dir,
+            profile=profile,
+            max_iterations=_SYNC_MAX_ITERATIONS,
+        )
+        try:
+            result = await subagent.run(task)
+            exit_reason = getattr(subagent, "last_exit_reason", None) or "completed"
+        except Exception as exc:
+            logger.exception("[spawn_sync] subagent failed err=%s", exc)
+            result = f"执行出错：{exc}"
+            exit_reason = "error"
+        return result, exit_reason
 
     async def _run_subagent(
         self,
@@ -369,18 +525,48 @@ class SubagentManager:
         self,
         job_id: str,
         snapshot_lease: RuntimeSnapshotLease | None,
+        admission_lease: _SubagentAdmissionLease,
+        task: asyncio.Task[None],
     ) -> None:
         self._forget_running_job(job_id)
+        admission_lease.release()
+        _consume_task_exception(task)
         if snapshot_lease is not None and snapshot_lease.active:
-            task = asyncio.create_task(
+            release_task = asyncio.create_task(
                 snapshot_lease.release(),
                 name=f"spawn_snapshot_release:{job_id}",
             )
-            self._snapshot_release_tasks.add(task)
-            task.add_done_callback(self._snapshot_release_tasks.discard)
+            self._snapshot_release_tasks.add(release_task)
+            release_task.add_done_callback(
+                lambda done: self._finish_snapshot_release(job_id, done)
+            )
+
+    def _finish_sync_job(
+        self,
+        job_id: str,
+        admission_lease: _SubagentAdmissionLease,
+        task: asyncio.Task[tuple[str, str]],
+    ) -> None:
+        self._sync_tasks.pop(job_id, None)
+        admission_lease.release()
+        _consume_task_exception(task)
+
+    def _finish_snapshot_release(
+        self,
+        job_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        self._snapshot_release_tasks.discard(task)
+        _consume_task_exception(task)
+        if not task.cancelled() and task.exception() is not None:
+            logger.error(
+                "[spawn] cleanup_degraded snapshot release failed job_id=%s err=%s",
+                job_id,
+                task.exception(),
+            )
 
     async def shutdown(self) -> None:
-        tasks = list(self._running_tasks.values())
+        tasks = [*self._running_tasks.values(), *self._sync_tasks.values()]
         for task in tasks:
             _ = task.cancel()
         if tasks:
@@ -520,3 +706,11 @@ def _decision_payload(decision: SpawnDecision | None) -> dict[str, object] | Non
             "reason_code": decision.meta.reason_code,
         },
     }
+
+
+def _consume_task_exception(task: asyncio.Task[Any]) -> None:
+    """读取后台 task 的异常，避免取消等待后的未处理异常噪声。"""
+
+    if task.cancelled():
+        return
+    _ = task.exception()

--- a/agent/control/errors.py
+++ b/agent/control/errors.py
@@ -29,6 +29,15 @@ class RuntimeClosedError(ControlError):
     pass
 
 
+class ControlAdmissionError(ControlError):
+    """表示 queued/running turn 超出控制面准入容量。"""
+
+    error_type = "resource-exhausted"
+    failure_type = "operation_rejected"
+    code = "resource-exhausted"
+    retryable = True
+
+
 class ControlExecutionError(ControlError):
     def __init__(self, error_type: str, message: str, *, retryable: bool) -> None:
         super().__init__(message)

--- a/agent/control/protocol/router.py
+++ b/agent/control/protocol/router.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from pydantic import ValidationError
 
 from agent.control.errors import (
+    ControlAdmissionError,
     RuntimeClosedError,
     ThreadBusyError,
     ThreadNotFoundError,
@@ -99,6 +100,14 @@ class ConnectionRouter:
             await self._send(JsonRpcError(THREAD_NOT_FOUND, str(exc)).envelope(request_id))
         except ThreadBusyError as exc:
             await self._send(JsonRpcError(THREAD_BUSY, str(exc), {"retryable": True}).envelope(request_id))
+        except ControlAdmissionError as exc:
+            await self._send(
+                JsonRpcError(
+                    SERVER_OVERLOADED,
+                    str(exc),
+                    {"retryable": True, "failure": exc.failure_type},
+                ).envelope(request_id)
+            )
         except TurnNotFoundError as exc:
             await self._send(JsonRpcError(TURN_NOT_FOUND, str(exc)).envelope(request_id))
         except RuntimeClosedError as exc:

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import time
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import cast
 
 from agent.control.errors import (
+    ControlAdmissionError,
     ControlExecutionError,
     RuntimeClosedError,
     SlowConsumerError,
@@ -33,6 +37,26 @@ logger = logging.getLogger(__name__)
 _STREAM_END = object()
 StreamValue = TurnEvent | BaseException | object
 
+DEFAULT_CONTROL_MAX_ACTIVE_TURNS = 16
+DEFAULT_CONTROL_MAX_ACTIVE_BYTES = 32 * 1024 * 1024
+DEFAULT_CONTROL_MAX_RUNTIME_OBJECTS = 16
+DEFAULT_REPLAY_EVENTS_PER_TURN = 256
+DEFAULT_REPLAY_BYTES_PER_TURN = 4 * 1024 * 1024
+DEFAULT_REPLAY_BYTES_GLOBAL = 32 * 1024 * 1024
+DEFAULT_TERMINAL_REPLAY_TTL_SECONDS = 5 * 60
+
+
+def _encoded_turn_bytes(request: TurnRequest) -> int:
+    """计算控制面 turn 请求的 UTF-8 编码字节数。"""
+
+    return len(json.dumps(request.to_dict(), ensure_ascii=False, sort_keys=True, default=str).encode())
+
+
+def _encoded_event_bytes(event: TurnEvent) -> int:
+    """计算 replay event 的 UTF-8 编码字节数。"""
+
+    return len(json.dumps(event.to_notification(), ensure_ascii=False, sort_keys=True, default=str).encode())
+
 
 class TurnHandle:
     """持有一个 turn 的结果、事件流和精确中断入口。"""
@@ -48,8 +72,8 @@ class TurnHandle:
     async def result(self) -> TurnResult:
         return await self._runtime.wait_result(self.thread_id, self.id)
 
-    def events(self) -> AsyncIterator[TurnEvent]:
-        return self._runtime.subscribe(self.thread_id, self.id)
+    def events(self, *, after_event: int | None = None) -> AsyncIterator[TurnEvent]:
+        return self._runtime.subscribe(self.thread_id, self.id, after_event=after_event)
 
     async def interrupt(self) -> TurnRecord:
         return await self._runtime.interrupt_turn(self.thread_id, self.id)
@@ -65,17 +89,55 @@ class ConversationRuntime:
         *,
         subscriber_queue_size: int = 256,
         restart_coordinator: RestartCoordinator | None = None,
+        max_active_turns: int = DEFAULT_CONTROL_MAX_ACTIVE_TURNS,
+        max_active_bytes: int = DEFAULT_CONTROL_MAX_ACTIVE_BYTES,
+        max_live_runtime_objects: int = DEFAULT_CONTROL_MAX_RUNTIME_OBJECTS,
+        replay_events_per_turn: int = DEFAULT_REPLAY_EVENTS_PER_TURN,
+        replay_bytes_per_turn: int = DEFAULT_REPLAY_BYTES_PER_TURN,
+        replay_bytes_global: int = DEFAULT_REPLAY_BYTES_GLOBAL,
+        terminal_replay_ttl_seconds: float = DEFAULT_TERMINAL_REPLAY_TTL_SECONDS,
     ) -> None:
         if subscriber_queue_size < 2:
             raise ValueError("subscriber_queue_size 必须至少为 2")
+        for name, value in (
+            ("max_active_turns", max_active_turns),
+            ("max_active_bytes", max_active_bytes),
+            ("max_live_runtime_objects", max_live_runtime_objects),
+            ("replay_events_per_turn", replay_events_per_turn),
+            ("replay_bytes_per_turn", replay_bytes_per_turn),
+            ("replay_bytes_global", replay_bytes_global),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} 必须是正整数")
+        if terminal_replay_ttl_seconds <= 0:
+            raise ValueError("terminal_replay_ttl_seconds 必须为正数")
         self._store = store
         self._executor = executor
         self._subscriber_queue_size = subscriber_queue_size
         self._admission = asyncio.Lock()
+        self._control_admission_lock = asyncio.Lock()
+        self._max_active_turns = max_active_turns
+        self._max_active_bytes = max_active_bytes
+        self._max_live_runtime_objects = max_live_runtime_objects
+        self._active_turn_bytes: dict[str, int] = {}
+        self._active_admission_bytes = 0
+        self._live_runtime_objects = 0
+        self._replay_events_per_turn = replay_events_per_turn
+        self._replay_bytes_per_turn = replay_bytes_per_turn
+        self._replay_bytes_global = replay_bytes_global
+        self._terminal_replay_ttl_seconds = terminal_replay_ttl_seconds
         self._active_by_thread: dict[str, str] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._results: dict[str, asyncio.Future[TurnResult]] = {}
         self._history: dict[str, list[TurnEvent]] = {}
+        self._history_sequences: dict[str, list[int]] = {}
+        self._next_event_sequence: dict[str, int] = {}
+        self._history_truncated: set[str] = set()
+        self._replay_order: OrderedDict[tuple[str, int], tuple[TurnEvent, int]] = OrderedDict()
+        self._history_byte_totals: dict[str, int] = {}
+        self._replay_bytes = 0
+        self._terminal_replay_expiry: dict[str, float] = {}
+        self._replay_cleanup_degraded: dict[str, str] = {}
         self._subscribers: dict[str, set[asyncio.Queue[StreamValue]]] = {}
         self._interrupt_requested: set[str] = set()
         self._thread_idle: dict[str, asyncio.Event] = {}
@@ -87,38 +149,49 @@ class ConversationRuntime:
     async def start_turn(self, request: TurnRequest) -> TurnHandle:
         """持久化 queued turn 并立即返回可操作句柄。"""
 
-        # 1. 在唯一 owner 处拒绝同 thread 并发。
-        if self._closed or not self._accepting_turns:
-            raise RuntimeClosedError("conversation runtime is shutting down")
-        if request.thread_id in self._active_by_thread:
-            raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
+        # 1. 在唯一 owner 处检查 thread 与控制面容量；拒绝不写 SessionStore。
+        request_bytes = _encoded_turn_bytes(request)
+        async with self._control_admission_lock:
+            if self._closed or not self._accepting_turns:
+                raise RuntimeClosedError("conversation runtime is shutting down")
+            if request.thread_id in self._active_by_thread:
+                raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
+            admission_token = self._reserve_admission(request_bytes)
 
-        # 2. 先持久化 handle，再让后台任务推进状态。
-        turn_id = new_turn_id()
-        user_item = TurnItem(
-            TurnItemKind.USER_MESSAGE,
-            new_item_id(),
-            {"content": request.input},
-        )
-        record = self._store.create_turn(
-            TurnRecord(
-                id=turn_id,
-                thread_id=request.thread_id,
-                status=TurnStatus.QUEUED,
-                input=request.input,
-                metadata=dict(request.metadata),
-                items=[user_item],
-                usage=None,
-                error=None,
-                created_at=datetime.now(UTC),
+            # 2. 先持久化 queued handle；失败时只回滚本轮 admission token。
+            turn_id = new_turn_id()
+            user_item = TurnItem(
+                TurnItemKind.USER_MESSAGE,
+                new_item_id(),
+                {"content": request.input},
             )
-        )
-        self._active_by_thread[request.thread_id] = turn_id
-        self._thread_idle[request.thread_id] = asyncio.Event()
-        loop = asyncio.get_running_loop()
-        self._results[turn_id] = loop.create_future()
-        self._history[turn_id] = []
-        self._subscribers[turn_id] = set()
+            try:
+                record = self._store.create_turn(
+                    TurnRecord(
+                        id=turn_id,
+                        thread_id=request.thread_id,
+                        status=TurnStatus.QUEUED,
+                        input=request.input,
+                        metadata=dict(request.metadata),
+                        items=[user_item],
+                        usage=None,
+                        error=None,
+                        created_at=datetime.now(UTC),
+                    )
+                )
+            except BaseException:
+                self._release_admission(admission_token, request_bytes)
+                raise
+            self._commit_admission_token(admission_token, turn_id, request_bytes)
+            self._active_by_thread[request.thread_id] = turn_id
+            self._thread_idle[request.thread_id] = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            self._results[turn_id] = loop.create_future()
+            self._history[turn_id] = []
+            self._history_sequences[turn_id] = []
+            self._history_byte_totals[turn_id] = 0
+            self._next_event_sequence[turn_id] = 0
+            self._subscribers[turn_id] = set()
         self._publish(TurnEvent.create("turn/queued", request.thread_id, turn_id, turn=record.to_dict()))
         self._publish(
             TurnEvent.create(
@@ -139,6 +212,44 @@ class ConversationRuntime:
         task = asyncio.create_task(self._run(request, turn_id), name=f"conversation-turn:{turn_id}")
         self._tasks[turn_id] = task
         return TurnHandle(self, request.thread_id, turn_id)
+
+    def _reserve_admission(self, request_bytes: int) -> str:
+        """在控制准入锁内保留一个 queued/running turn 的容量 token。"""
+
+        active_turns = len(self._active_turn_bytes)
+        if (
+            active_turns >= self._max_active_turns
+            or self._active_admission_bytes + request_bytes > self._max_active_bytes
+            or self._live_runtime_objects >= self._max_live_runtime_objects
+        ):
+            raise ControlAdmissionError(
+                "resource-exhausted: control admission capacity busy "
+                f"(turns={active_turns}/{self._max_active_turns}, "
+                f"bytes={self._active_admission_bytes + request_bytes}/{self._max_active_bytes}, "
+                f"runtime_objects={self._live_runtime_objects + 1}/{self._max_live_runtime_objects})"
+            )
+        # The turn id is not available until after the persistent record is built.
+        token = f"__reserved__:{time.monotonic_ns()}:{active_turns}"
+        self._active_turn_bytes[token] = request_bytes
+        self._active_admission_bytes += request_bytes
+        self._live_runtime_objects += 1
+        return token
+
+    def _commit_admission_token(self, token: str, turn_id: str, request_bytes: int) -> None:
+        if token not in self._active_turn_bytes:
+            raise RuntimeError(f"control admission token missing for turn: {turn_id}")
+        if self._active_turn_bytes.pop(token) != request_bytes:
+            raise RuntimeError(f"control admission token bytes mismatch: {turn_id}")
+        self._active_turn_bytes[turn_id] = request_bytes
+
+    def _release_admission(self, turn_id: str, request_bytes: int) -> None:
+        stored = self._active_turn_bytes.pop(turn_id, None)
+        if stored is None:
+            return
+        if stored != request_bytes:
+            raise RuntimeError(f"control admission bytes mismatch: {turn_id}")
+        self._active_admission_bytes -= stored
+        self._live_runtime_objects -= 1
 
     async def _run(self, request: TurnRequest, turn_id: str) -> None:
         """在全局 admission 内执行 turn，并保证只写一个终态。"""
@@ -354,9 +465,22 @@ class ConversationRuntime:
                 idle.set()
             _ = self._tasks.pop(turn_id, None)
             self._interrupt_requested.discard(turn_id)
+            self._release_admission(turn_id, _encoded_turn_bytes(request))
 
     def _publish(self, event: TurnEvent) -> None:
-        self._history[event.turn_id].append(event)
+        self._gc_terminal_replay()
+        history = self._history[event.turn_id]
+        sequences = self._history_sequences[event.turn_id]
+        sequence = self._next_event_sequence[event.turn_id]
+        self._next_event_sequence[event.turn_id] = sequence + 1
+        event_bytes = _encoded_event_bytes(event)
+        history.append(event)
+        sequences.append(sequence)
+        self._replay_order[(event.turn_id, sequence)] = (event, event_bytes)
+        self._replay_bytes += event_bytes
+        self._history_byte_totals[event.turn_id] += event_bytes
+        self._trim_turn_replay(event.turn_id)
+        self._trim_global_replay()
         for queue in tuple(self._subscribers[event.turn_id]):
             try:
                 queue.put_nowait(event)
@@ -366,7 +490,115 @@ class ConversationRuntime:
                 queue.put_nowait(SlowConsumerError(f"turn event consumer too slow: {event.turn_id}"))
                 self._subscribers[event.turn_id].discard(queue)
 
+    def _trim_turn_replay(self, turn_id: str) -> None:
+        history = self._history[turn_id]
+        sequences = self._history_sequences[turn_id]
+        while history and (
+            len(history) > self._replay_events_per_turn
+            or self._history_bytes(turn_id) > self._replay_bytes_per_turn
+        ):
+            if not self._remove_oldest_replay_event(turn_id):
+                self._replay_cleanup_degraded[turn_id] = "turn replay eviction failed"
+                logger.error(
+                    "event=cleanup_degraded owner=control.replay_ring turn=%s "
+                    "reason=turn_eviction_failed",
+                    turn_id,
+                )
+                break
+            if len(history) != len(sequences):
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+        if len(history) < self._next_event_sequence[turn_id]:
+            self._history_truncated.add(turn_id)
+
+    def _trim_global_replay(self) -> None:
+        while self._replay_bytes > self._replay_bytes_global and self._replay_order:
+            (turn_id, sequence), (event, event_bytes) = self._replay_order.popitem(last=False)
+            if not self._remove_replay_event(
+                turn_id, sequence, event, event_bytes=event_bytes, global_removed=True
+            ):
+                self._replay_order[(turn_id, sequence)] = (event, event_bytes)
+                self._replay_order.move_to_end((turn_id, sequence), last=False)
+                self._replay_cleanup_degraded[turn_id] = "global replay eviction failed"
+                logger.error(
+                    "event=cleanup_degraded owner=control.replay_ring turn=%s "
+                    "reason=global_eviction_failed",
+                    turn_id,
+                )
+                break
+            self._history_truncated.add(turn_id)
+
+    def _history_bytes(self, turn_id: str) -> int:
+        return self._history_byte_totals[turn_id]
+
+    def _remove_oldest_replay_event(self, turn_id: str) -> bool:
+        history = self._history[turn_id]
+        sequences = self._history_sequences[turn_id]
+        if not history:
+            return False
+        return self._remove_replay_event(turn_id, sequences[0], history[0])
+
+    def _remove_replay_event(
+        self,
+        turn_id: str,
+        sequence: int,
+        event: TurnEvent,
+        *,
+        event_bytes: int | None = None,
+        global_removed: bool = False,
+    ) -> bool:
+        history = self._history.get(turn_id)
+        sequences = self._history_sequences.get(turn_id)
+        if history is None or sequences is None:
+            return False
+        for index, (item_sequence, item) in enumerate(zip(sequences, history)):
+            if item_sequence == sequence and item is event:
+                if not global_removed and (turn_id, sequence) not in self._replay_order:
+                    return False
+                history.pop(index)
+                sequences.pop(index)
+                if not global_removed:
+                    self._replay_order.pop((turn_id, sequence), None)
+                size = event_bytes
+                if size is None:
+                    entry = self._replay_order.get((turn_id, sequence))
+                    size = _encoded_event_bytes(event) if entry is None else entry[1]
+                self._replay_bytes -= size
+                self._history_byte_totals[turn_id] -= size
+                return True
+        return False
+
+    def _gc_terminal_replay(self) -> None:
+        now = time.monotonic()
+        for turn_id, expiry in tuple(self._terminal_replay_expiry.items()):
+            if expiry > now:
+                continue
+            history = self._history.get(turn_id)
+            if history is None:
+                self._terminal_replay_expiry.pop(turn_id, None)
+                continue
+            while history:
+                if not self._remove_oldest_replay_event(turn_id):
+                    self._replay_cleanup_degraded[turn_id] = "terminal replay expiry failed"
+                    logger.error(
+                        "event=cleanup_degraded owner=control.replay_ring turn=%s "
+                        "reason=terminal_expiry_failed",
+                        turn_id,
+                    )
+                    break
+            if not history:
+                self._history.pop(turn_id, None)
+                self._history_sequences.pop(turn_id, None)
+                self._history_byte_totals.pop(turn_id, None)
+                self._history_truncated.discard(turn_id)
+                self._next_event_sequence.pop(turn_id, None)
+                self._subscribers.pop(turn_id, None)
+                self._results.pop(turn_id, None)
+                self._terminal_replay_expiry.pop(turn_id, None)
+
     def _finish_streams(self, turn_id: str) -> None:
+        self._terminal_replay_expiry[turn_id] = (
+            time.monotonic() + self._terminal_replay_ttl_seconds
+        )
         for queue in tuple(self._subscribers[turn_id]):
             try:
                 queue.put_nowait(_STREAM_END)
@@ -381,15 +613,54 @@ class ConversationRuntime:
                 _ = queue.get_nowait()
             queue.put_nowait(error)
 
-    async def subscribe(self, thread_id: str, turn_id: str) -> AsyncIterator[TurnEvent]:
+    async def subscribe(
+        self,
+        thread_id: str,
+        turn_id: str,
+        *,
+        after_event: int | None = None,
+    ) -> AsyncIterator[TurnEvent]:
+        """订阅 live stream，并在 replay 被截断或过期时发出权威快照。"""
+
+        if after_event is not None and (
+            not isinstance(after_event, int) or isinstance(after_event, bool) or after_event < -1
+        ):
+            raise ValueError("after_event 必须是大于等于 -1 的整数")
+        self._gc_terminal_replay()
         record = self.read_turn(thread_id, turn_id)
-        queue: asyncio.Queue[StreamValue] = asyncio.Queue(self._subscriber_queue_size)
         history = self._history.get(turn_id)
-        if history is None:
-            if record.status.is_terminal:
-                return
+        sequences = self._history_sequences.get(turn_id, [])
+        replay_expired = record.status.is_terminal and history is None
+        if history is None and not replay_expired:
             raise TurnNotFoundError(f"turn 不在当前 runtime: {thread_id}/{turn_id}")
-        for event in history:
+
+        replay_events: list[TurnEvent] = [] if history is None else list(history)
+        replay_sequences = [] if history is None else list(sequences)
+        replay_truncated = False
+        if replay_expired:
+            replay_events = [self._replay_notice("replay/expired", record)]
+        elif record.status.is_terminal and self._terminal_replay_expired(turn_id):
+            replay_expired = True
+            replay_events = [self._replay_notice("replay/expired", record)]
+        else:
+            if after_event is not None:
+                replay_truncated = bool(
+                    replay_sequences and after_event < replay_sequences[0] - 1
+                )
+                replay_events = [
+                    event
+                    for sequence, event in zip(replay_sequences, replay_events)
+                    if sequence > after_event
+                ]
+            elif turn_id in self._history_truncated:
+                replay_truncated = True
+            if replay_truncated:
+                replay_events.insert(0, self._replay_notice("replay/truncated", record))
+
+        queue: asyncio.Queue[StreamValue] = asyncio.Queue(
+            max(self._subscriber_queue_size, len(replay_events) + 1)
+        )
+        for event in replay_events:
             queue.put_nowait(event)
         if record.status.is_terminal:
             queue.put_nowait(_STREAM_END)
@@ -406,11 +677,55 @@ class ConversationRuntime:
         finally:
             self._subscribers.get(turn_id, set()).discard(queue)
 
+    def _terminal_replay_expired(self, turn_id: str) -> bool:
+        expiry = self._terminal_replay_expiry.get(turn_id)
+        return expiry is not None and expiry <= time.monotonic()
+
+    @staticmethod
+    def _replay_notice(method: str, record: TurnRecord) -> TurnEvent:
+        status = "replay_truncated" if method.endswith("truncated") else "replay_expired"
+        return TurnEvent.create(
+            method,
+            record.thread_id,
+            record.id,
+            error=status,
+            replay_status=status,
+            snapshot=record.to_dict(),
+        )
+
     def read_turn(self, thread_id: str, turn_id: str) -> TurnRecord:
         record = self._store.read_turn(turn_id)
         if record is None or record.thread_id != thread_id:
             raise TurnNotFoundError(f"turn 不存在: {thread_id}/{turn_id}")
         return record
+
+    def admission_snapshot(self) -> dict[str, int]:
+        """返回 queued/running turn 的控制准入计数，不含历史 thread。"""
+
+        return {
+            "turns": len(self._active_turn_bytes),
+            "bytes": self._active_admission_bytes,
+            "runtime_objects": self._live_runtime_objects,
+            "max_turns": self._max_active_turns,
+            "max_bytes": self._max_active_bytes,
+            "max_runtime_objects": self._max_live_runtime_objects,
+        }
+
+    @property
+    def active_turn_count(self) -> int:
+        return len(self._active_turn_bytes)
+
+    @property
+    def active_admission_bytes(self) -> int:
+        return self._active_admission_bytes
+
+    @property
+    def live_runtime_objects(self) -> int:
+        return self._live_runtime_objects
+
+    @property
+    def replay_bytes(self) -> int:
+        return self._replay_bytes
 
     def is_thread_active(self, thread_id: str) -> bool:
         return thread_id in self._active_by_thread
@@ -497,6 +812,10 @@ class ConversationRuntime:
             if idle is not None:
                 idle.set()
             _ = self._tasks.pop(turn_id, None)
+            request_bytes = self._active_turn_bytes.get(turn_id)
+            if request_bytes is None:
+                raise RuntimeError(f"queued turn admission missing: {turn_id}")
+            self._release_admission(turn_id, request_bytes)
             return terminal
 
         # 2. in-progress task 自己在取消处理器中提交 interrupted。

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -137,7 +137,9 @@ class ConversationRuntime:
         self._history_byte_totals: dict[str, int] = {}
         self._replay_bytes = 0
         self._terminal_replay_expiry: dict[str, float] = {}
-        self._replay_cleanup_degraded: dict[str, str] = {}
+        self._replay_reaper_task: asyncio.Task[None] | None = None
+        self._replay_reaper_wakeup = asyncio.Event()
+        self._replay_reaper_error: BaseException | None = None
         self._subscribers: dict[str, set[asyncio.Queue[StreamValue]]] = {}
         self._interrupt_requested: set[str] = set()
         self._thread_idle: dict[str, asyncio.Event] = {}
@@ -152,6 +154,7 @@ class ConversationRuntime:
         # 1. 在唯一 owner 处检查 thread 与控制面容量；拒绝不写 SessionStore。
         request_bytes = _encoded_turn_bytes(request)
         async with self._control_admission_lock:
+            self._raise_replay_reaper_failure()
             if self._closed or not self._accepting_turns:
                 raise RuntimeClosedError("conversation runtime is shutting down")
             if request.thread_id in self._active_by_thread:
@@ -468,6 +471,7 @@ class ConversationRuntime:
             self._release_admission(turn_id, _encoded_turn_bytes(request))
 
     def _publish(self, event: TurnEvent) -> None:
+        self._raise_replay_reaper_failure()
         self._gc_terminal_replay()
         history = self._history[event.turn_id]
         sequences = self._history_sequences[event.turn_id]
@@ -497,14 +501,7 @@ class ConversationRuntime:
             len(history) > self._replay_events_per_turn
             or self._history_bytes(turn_id) > self._replay_bytes_per_turn
         ):
-            if not self._remove_oldest_replay_event(turn_id):
-                self._replay_cleanup_degraded[turn_id] = "turn replay eviction failed"
-                logger.error(
-                    "event=cleanup_degraded owner=control.replay_ring turn=%s "
-                    "reason=turn_eviction_failed",
-                    turn_id,
-                )
-                break
+            self._remove_oldest_replay_event(turn_id)
             if len(history) != len(sequences):
                 raise RuntimeError(f"control replay index corrupted: {turn_id}")
         if len(history) < self._next_event_sequence[turn_id]:
@@ -513,29 +510,20 @@ class ConversationRuntime:
     def _trim_global_replay(self) -> None:
         while self._replay_bytes > self._replay_bytes_global and self._replay_order:
             (turn_id, sequence), (event, event_bytes) = self._replay_order.popitem(last=False)
-            if not self._remove_replay_event(
+            self._remove_replay_event(
                 turn_id, sequence, event, event_bytes=event_bytes, global_removed=True
-            ):
-                self._replay_order[(turn_id, sequence)] = (event, event_bytes)
-                self._replay_order.move_to_end((turn_id, sequence), last=False)
-                self._replay_cleanup_degraded[turn_id] = "global replay eviction failed"
-                logger.error(
-                    "event=cleanup_degraded owner=control.replay_ring turn=%s "
-                    "reason=global_eviction_failed",
-                    turn_id,
-                )
-                break
+            )
             self._history_truncated.add(turn_id)
 
     def _history_bytes(self, turn_id: str) -> int:
         return self._history_byte_totals[turn_id]
 
-    def _remove_oldest_replay_event(self, turn_id: str) -> bool:
+    def _remove_oldest_replay_event(self, turn_id: str) -> None:
         history = self._history[turn_id]
         sequences = self._history_sequences[turn_id]
-        if not history:
-            return False
-        return self._remove_replay_event(turn_id, sequences[0], history[0])
+        if not history or len(history) != len(sequences):
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+        self._remove_replay_event(turn_id, sequences[0], history[0])
 
     def _remove_replay_event(
         self,
@@ -545,27 +533,60 @@ class ConversationRuntime:
         *,
         event_bytes: int | None = None,
         global_removed: bool = False,
-    ) -> bool:
+    ) -> None:
         history = self._history.get(turn_id)
         sequences = self._history_sequences.get(turn_id)
         if history is None or sequences is None:
-            return False
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+        if len(history) != len(sequences):
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+        if len(set(sequences)) != len(sequences):
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+
+        target_index: int | None = None
         for index, (item_sequence, item) in enumerate(zip(sequences, history)):
-            if item_sequence == sequence and item is event:
-                if not global_removed and (turn_id, sequence) not in self._replay_order:
-                    return False
-                history.pop(index)
-                sequences.pop(index)
-                if not global_removed:
-                    self._replay_order.pop((turn_id, sequence), None)
-                size = event_bytes
-                if size is None:
-                    entry = self._replay_order.get((turn_id, sequence))
-                    size = _encoded_event_bytes(event) if entry is None else entry[1]
-                self._replay_bytes -= size
-                self._history_byte_totals[turn_id] -= size
-                return True
-        return False
+            key = (turn_id, item_sequence)
+            entry = self._replay_order.get(key)
+            if global_removed and item_sequence == sequence:
+                if item is not event:
+                    raise RuntimeError(f"control replay index corrupted: {turn_id}")
+                if target_index is not None:
+                    raise RuntimeError(f"control replay index corrupted: {turn_id}")
+                target_index = index
+                continue
+            if entry is None or entry[0] is not item:
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+            if item_sequence == sequence:
+                if item is not event:
+                    raise RuntimeError(f"control replay index corrupted: {turn_id}")
+                target_index = index
+
+        if target_index is None:
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+        key = (turn_id, sequence)
+        entry = self._replay_order.get(key)
+        if global_removed:
+            if entry is not None:
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+            if event_bytes is None:
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+            size = event_bytes
+        else:
+            if entry is None or entry[0] is not event:
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+            if event_bytes is not None and entry[1] != event_bytes:
+                raise RuntimeError(f"control replay index corrupted: {turn_id}")
+            size = entry[1]
+        turn_total = self._history_byte_totals.get(turn_id)
+        if turn_total is None or size < 0 or turn_total < size or self._replay_bytes < size:
+            raise RuntimeError(f"control replay index corrupted: {turn_id}")
+
+        history.pop(target_index)
+        sequences.pop(target_index)
+        if not global_removed:
+            self._replay_order.pop(key)
+        self._replay_bytes -= size
+        self._history_byte_totals[turn_id] = turn_total - size
 
     def _gc_terminal_replay(self) -> None:
         now = time.monotonic()
@@ -577,14 +598,7 @@ class ConversationRuntime:
                 self._terminal_replay_expiry.pop(turn_id, None)
                 continue
             while history:
-                if not self._remove_oldest_replay_event(turn_id):
-                    self._replay_cleanup_degraded[turn_id] = "terminal replay expiry failed"
-                    logger.error(
-                        "event=cleanup_degraded owner=control.replay_ring turn=%s "
-                        "reason=terminal_expiry_failed",
-                        turn_id,
-                    )
-                    break
+                self._remove_oldest_replay_event(turn_id)
             if not history:
                 self._history.pop(turn_id, None)
                 self._history_sequences.pop(turn_id, None)
@@ -596,9 +610,12 @@ class ConversationRuntime:
                 self._terminal_replay_expiry.pop(turn_id, None)
 
     def _finish_streams(self, turn_id: str) -> None:
+        self._raise_replay_reaper_failure()
         self._terminal_replay_expiry[turn_id] = (
             time.monotonic() + self._terminal_replay_ttl_seconds
         )
+        self._ensure_replay_reaper()
+        self._replay_reaper_wakeup.set()
         for queue in tuple(self._subscribers[turn_id]):
             try:
                 queue.put_nowait(_STREAM_END)
@@ -626,6 +643,7 @@ class ConversationRuntime:
             not isinstance(after_event, int) or isinstance(after_event, bool) or after_event < -1
         ):
             raise ValueError("after_event 必须是大于等于 -1 的整数")
+        self._raise_replay_reaper_failure()
         self._gc_terminal_replay()
         record = self.read_turn(thread_id, turn_id)
         history = self._history.get(turn_id)
@@ -680,6 +698,64 @@ class ConversationRuntime:
     def _terminal_replay_expired(self, turn_id: str) -> bool:
         expiry = self._terminal_replay_expiry.get(turn_id)
         return expiry is not None and expiry <= time.monotonic()
+
+    def _raise_replay_reaper_failure(self) -> None:
+        if self._replay_reaper_error is not None:
+            raise RuntimeError("control replay reaper failed") from self._replay_reaper_error
+
+    def _ensure_replay_reaper(self) -> None:
+        self._raise_replay_reaper_failure()
+        if self._replay_reaper_task is None:
+            loop = asyncio.get_running_loop()
+            self._replay_reaper_task = loop.create_task(
+                self._replay_reaper(),
+                name="conversation-replay-reaper",
+            )
+            self._replay_reaper_task.add_done_callback(
+                self._observe_replay_reaper_task
+            )
+
+    def _observe_replay_reaper_task(self, task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None and self._replay_reaper_error is None:
+            self._replay_reaper_error = error
+
+    async def _replay_reaper(self) -> None:
+        """按最早 terminal expiry 回收 replay，并把内部损坏升级为 runtime fatal。"""
+
+        try:
+            while not self._closed:
+                # 1. 先清除旧唤醒，再读取当前最早 expiry，避免错过更早的新终态。
+                self._replay_reaper_wakeup.clear()
+                expiry = min(self._terminal_replay_expiry.values(), default=None)
+                if expiry is None:
+                    await self._replay_reaper_wakeup.wait()
+                    continue
+
+                delay = expiry - time.monotonic()
+                if delay > 0:
+                    try:
+                        await asyncio.wait_for(
+                            self._replay_reaper_wakeup.wait(), timeout=delay
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                    continue
+
+                # 2. 到期清理只触碰运行时 replay 投影；SessionStore 保持权威终态。
+                self._gc_terminal_replay()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            self._replay_reaper_error = exc
+            self._accepting_turns = False
+            logger.critical(
+                "event=runtime_fatal owner=control.replay_reaper reason=terminal_replay_cleanup_failed",
+                exc_info=True,
+            )
+            raise
 
     @staticmethod
     def _replay_notice(method: str, record: TurnRecord) -> TurnEvent:
@@ -847,10 +923,21 @@ class ConversationRuntime:
 
     async def shutdown(self) -> None:
         if self._closed:
+            self._raise_replay_reaper_failure()
             return
         self._closed = True
+        self._accepting_turns = False
         tasks = tuple(self._tasks.values())
         for task in tasks:
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        reaper = self._replay_reaper_task
+        if reaper is not None:
+            reaper.cancel()
+            result = await asyncio.gather(reaper, return_exceptions=True)
+            if result and isinstance(result[0], BaseException) and not isinstance(
+                result[0], asyncio.CancelledError
+            ):
+                self._replay_reaper_error = result[0]
+        self._raise_replay_reaper_failure()

--- a/agent/looping/handlers.py
+++ b/agent/looping/handlers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from agent.control.context import current_turn_id
 from agent.core.runtime_support import AgentLoopRunner, PromptRenderRunner, TurnRunResult
 from agent.lifecycle.types import PromptRenderInput, TurnPersistencePolicy
 from agent.looping.ports import SessionServices
@@ -71,10 +72,14 @@ async def process_spawn_completion_event(
     )
 
     # 2. 再调用主模型生成用户可见回复。
+    turn_id = current_turn_id.get()
+    if not turn_id:
+        raise RuntimeError("spawn completion tool context 缺少 runtime turn_id")
     tools.set_context(
         channel=item.channel,
         chat_id=item.chat_id,
         session_key=key,
+        turn_id=turn_id,
         current_timestamp=item.timestamp.isoformat(),
     )
     prompt_render = await prompt_render_fn(

--- a/agent/plugins/mobile_ui.py
+++ b/agent/plugins/mobile_ui.py
@@ -15,6 +15,7 @@ from agent.plugins.snapshot import RuntimeSnapshot
 
 MOBILE_UI_QUERY_TIMEOUT_SECONDS = 20.0
 MOBILE_UI_QUERY_WORKERS = 8
+MOBILE_UI_QUERY_QUEUE_LIMIT = 16
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +52,8 @@ class PluginMobileUiProvider:
             thread_name_prefix="mobile-plugin-ui",
         )
         self._draining_queries: set[asyncio.Task[dict[str, object]]] = set()
+        self._admission_lock = asyncio.Lock()
+        self._admitted_queries = 0
 
     def catalog(self) -> dict[str, object]:
         """返回当前 generation 的轻量目录与内容摘要。"""
@@ -107,6 +110,7 @@ class PluginMobileUiProvider:
     ) -> dict[str, object]:
         """在线程池执行只读 handler，并在超时后继续持有快照到线程退出。"""
 
+        await self._reserve_query_slot()
         task = asyncio.create_task(
             self._run_query(
                 plugin_id,
@@ -117,6 +121,7 @@ class PluginMobileUiProvider:
                 turn_id=turn_id,
             )
         )
+        task.add_done_callback(self._query_done)
         try:
             async with asyncio.timeout(MOBILE_UI_QUERY_TIMEOUT_SECONDS):
                 return await asyncio.shield(task)
@@ -128,6 +133,25 @@ class PluginMobileUiProvider:
         except asyncio.CancelledError:
             self._drain_query(task)
             raise
+
+    async def _reserve_query_slot(self) -> None:
+        """在提交线程池前拒绝超过有界 worker+queue 容量的查询。"""
+
+        async with self._admission_lock:
+            limit = MOBILE_UI_QUERY_WORKERS + MOBILE_UI_QUERY_QUEUE_LIMIT
+            if self._admitted_queries >= limit:
+                raise MobileUiQueryOverloaded(
+                    "插件 mobile UI query 队列已满"
+                )
+            self._admitted_queries += 1
+
+    def _query_done(self, completed: asyncio.Task[dict[str, object]]) -> None:
+        self._admitted_queries -= 1
+        if self._admitted_queries < 0:
+            raise RuntimeError("插件 mobile UI query admission 计数失衡")
+        self._draining_queries.discard(completed)
+        if not completed.cancelled():
+            _ = completed.exception()
 
     async def _run_query(
         self,
@@ -177,13 +201,6 @@ class PluginMobileUiProvider:
 
     def _drain_query(self, task: asyncio.Task[dict[str, object]]) -> None:
         self._draining_queries.add(task)
-
-        def consume(completed: asyncio.Task[dict[str, object]]) -> None:
-            self._draining_queries.discard(completed)
-            if not completed.cancelled():
-                _ = completed.exception()
-
-        task.add_done_callback(consume)
 
     def _require_snapshot(self) -> RuntimeSnapshot:
         snapshot = self._manager.current_snapshot

--- a/agent/tools/spawn.py
+++ b/agent/tools/spawn.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from agent.background.subagent_manager import SubagentManager
+from agent.background.subagent_manager import SubagentCapacityError, SubagentManager
 from agent.policies.delegation import DelegationPolicy
 from agent.tool_hooks.base import ToolHook
 from agent.tools.base import Tool
@@ -128,7 +128,8 @@ subagent 没有看过当前会话。像给刚进房间的同事写交接文档�
         **_: Any,
     ) -> str:
         retry_count = max(0, int(retry_count))
-        running_count = self._manager.get_running_count() if run_in_background else 0
+        # manager 的 admission 是最终原子 owner；两种执行模式都读取同一活动计数。
+        running_count = self._manager.get_running_count()
         decision = self._policy.decide(
             task=task, label=label, running_count=running_count
         )
@@ -152,21 +153,27 @@ subagent 没有看过当前会话。像给刚进房间的同事写交接文档�
             chat_id = str(ctx.origin_chat_id if ctx else "").strip()
             if not channel or not chat_id:
                 return "错误：当前会话上下文缺失，无法创建后台任务"
-            return await self._manager.spawn(
+            try:
+                return await self._manager.spawn(
+                    task=task,
+                    label=label,
+                    origin_channel=channel,
+                    origin_chat_id=chat_id,
+                    decision=decision,
+                    profile=profile,
+                    retry_count=retry_count,
+                )
+            except SubagentCapacityError as exc:
+                return f"错误：{exc}"
+
+        try:
+            return await self._manager.spawn_sync(
                 task=task,
                 label=label,
-                origin_channel=channel,
-                origin_chat_id=chat_id,
-                decision=decision,
                 profile=profile,
-                retry_count=retry_count,
             )
-
-        return await self._manager.spawn_sync(
-            task=task,
-            label=label,
-            profile=profile,
-        )
+        except SubagentCapacityError as exc:
+            return f"错误：{exc}"
 
 
 class SpawnManageTool(Tool):

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -28,6 +28,7 @@ from bootstrap.tools import CoreRuntime, build_core_runtime
 from bootstrap.workspace_lock import WorkspaceInstanceLock
 from bootstrap.workspace_token import ensure_workspace_token
 from bus.event_bus import EventBus
+from bus.queue import MessageBus
 from agent.plugins.jobs import PluginJobRuntime
 from agent.plugins.service_host import PluginServiceHost
 from agent.plugins.watcher import PluginWatcher
@@ -83,6 +84,14 @@ def _clear_readiness(
             readiness.clear()
 
     return clear
+
+
+def _close_message_bus(bus: object | None) -> Callable[[], Awaitable[None]]:
+    """返回已初始化 MessageBus 的异步关闭动作。"""
+
+    if isinstance(bus, MessageBus):
+        return bus.aclose
+    return _noop_async
 
 
 def _raise_unexpected_task_errors(name: str, results: list[object]) -> None:
@@ -759,6 +768,7 @@ class AppRuntime:
                     "mobile_gateway_server.wait",
                     _wait_server_task(self.mobile_gateway_task),
                 ),
+                ("message_bus.aclose", _close_message_bus(self.bus)),
                 (
                     "mobile_gateway.close",
                     _close_mobile_gateway(self.mobile_gateway_runtime),

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -386,6 +386,9 @@ class AppRuntime:
                     self.config.mobile_realtime,
                     self.workspace,
                 )
+                self.bus.bind_durable_inbound_store(
+                    self.session_manager.control_store
+                )
                 from infra.mobile_realtime.runtime_inspection import (
                     RuntimeInspectionService,
                 )

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -28,6 +28,8 @@ class PassiveMessageWorker:
     async def run(self) -> None:
         self._running = True
         try:
+            # 1. 仅重放有界 durable handoff 页，lane 准入由 MessageBus 统一持有。
+            await self._bus.recover_durable_inbounds()
             while self._running:
                 try:
                     item = await asyncio.wait_for(self._bus.consume_inbound(), timeout=1.0)
@@ -85,8 +87,16 @@ class PassiveMessageWorker:
     async def _run_message(self, item: InboundMessage) -> None:
         """执行一条渠道消息，并始终完成 MessageBus 入站确认。"""
 
+        # 1. canonical 用户消息证明该 handoff 已进入过 turn。
+        if self._is_recovered_mobile_duplicate(item):
+            await self._bus.complete_inbound(item)
+            return
+        if item.channel == "mobile" and item.session_admission_id is None:
+            _, item.session_admission_id = self._legacy_loop.session_manager.admit_existing(
+                item.session_key
+            )
         try:
-            # 1. 渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
+            # 2. 渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
             request = TurnRequest(
                 item.session_key,
                 item.content,
@@ -116,7 +126,7 @@ class PassiveMessageWorker:
                 break
             result = await handle.result()
 
-            # 2. channel adapter 在领域终态外层映射用户安全文案。
+            # 3. channel adapter 在领域终态外层映射用户安全文案。
             if result.status is TurnStatus.COMPLETED:
                 assistant = next(
                     entry for entry in reversed(result.items) if entry.kind.value == "assistantMessage"
@@ -150,6 +160,20 @@ class PassiveMessageWorker:
                     self._legacy_loop.session_manager.release_admission(
                         item.session_admission_id
                     )
+
+    def _is_recovered_mobile_duplicate(self, item: InboundMessage) -> bool:
+        """识别 canonical 用户消息已存在的移动 handoff，避免重复 turn。"""
+
+        if item.channel != "mobile" or item.handoff_id is None:
+            return False
+        client_message_id = item.metadata.get("client_message_id")
+        if not isinstance(client_message_id, str) or not client_message_id:
+            return False
+        message = self._legacy_loop.session_manager.control_store.get_message_by_client_id(
+            item.session_key,
+            client_message_id,
+        )
+        return message is not None
 
     def stop(self) -> None:
         self._running = False

--- a/bus/events.py
+++ b/bus/events.py
@@ -79,6 +79,7 @@ class InboundMessage:
     media: list[str] = field(default_factory=list[str])
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
     session_admission_id: str | None = field(default=None, repr=False, compare=False)
+    handoff_id: str | None = field(default=None, repr=False, compare=False)
 
     @property
     def session_key(self) -> str:

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -16,6 +16,8 @@ _T = TypeVar("_T")
 
 DEFAULT_MESSAGE_BUS_CAPACITY = 256
 DEFAULT_MESSAGE_BUS_BYTES = 4 * 1024 * 1024
+_INBOUND_CLEANUP_RETRY_INITIAL_DELAY = 0.1
+_INBOUND_CLEANUP_RETRY_MAX_DELAY = 5.0
 
 
 class MessageBusCapacityError(RuntimeError):
@@ -181,6 +183,15 @@ class _ChatLaneState:
         default_factory=lambda: set[int]()
     )
     sending: bool = False
+
+
+@dataclass
+class _InboundOwner:
+    """在 durable cleanup 确认前保持 accepted inbound item 的强引用。"""
+
+    item: InboundItem
+    item_bytes: int
+    cleanup_pending: bool = False
 
 
 class ChatLane:
@@ -374,7 +385,9 @@ class MessageBus:
         self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
         self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
         self._inbound_bytes = 0
-        self._inbound_accepted: dict[int, int] = {}
+        self._inbound_accepted: dict[int, _InboundOwner] = {}
+        self._inbound_cleanup_tasks: dict[int, asyncio.Task[None]] = {}
+        self._inbound_cleanup_error: BaseException | None = None
         self._recovery_claimed: set[str] = set()
         self._outbound_bytes = 0
         self._inbound_reserved_items = 0
@@ -402,6 +415,7 @@ class MessageBus:
     async def recover_durable_inbounds(self) -> None:
         """在有界 bus slot 内重放尚未完成的移动 handoff。"""
 
+        self._raise_inbound_cleanup_error()
         store = self._durable_inbound_store
         if store is None:
             return
@@ -432,6 +446,9 @@ class MessageBus:
                     error.reason,
                 )
                 break
+            except BaseException:
+                self._recovery_claimed.discard(handoff_id)
+                raise
 
     def has_pending_mobile_handoff(
         self,
@@ -462,6 +479,7 @@ class MessageBus:
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
+        self._raise_inbound_cleanup_error()
         await self._publish_inbound(msg, allow_existing_handoff=False)
 
     async def _publish_inbound(
@@ -528,7 +546,10 @@ class MessageBus:
             finally:
                 self._inbound_reserved_items -= 1
                 self._inbound_reserved_bytes -= item_bytes
-            self._inbound_accepted[id(msg)] = item_bytes
+            self._inbound_accepted[id(msg)] = _InboundOwner(
+                item=msg,
+                item_bytes=item_bytes,
+            )
             self._inbound_bytes += item_bytes
 
     async def consume_inbound(self) -> InboundItem:
@@ -536,36 +557,145 @@ class MessageBus:
         return await self._inbound.get()
 
     async def complete_inbound(self, msg: InboundItem) -> None:
+        self._raise_inbound_cleanup_error()
         item_bytes = _wire_size(msg)
         async with self._admission_lock:
-            accepted = self._inbound_accepted.get(id(msg))
-            if accepted is None:
+            owner = self._inbound_accepted.get(id(msg))
+            if owner is None or owner.item is not msg:
                 raise RuntimeError("inbound 未被接受或已完成")
-            if accepted != item_bytes:
+            if owner.item_bytes != item_bytes:
                 raise RuntimeError("inbound ownership bytes 不一致")
+            if owner.cleanup_pending:
+                raise RuntimeError("inbound cleanup 已在重试中")
         if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
             store = self._durable_inbound_store
             if store is None:
                 raise RuntimeError("mobile inbound durable handoff store 未绑定")
             try:
                 store.complete_inbound_handoff(msg.handoff_id)
-            except Exception as error:
+            except OSError as error:
                 logger.error(
                     "message_bus cleanup_degraded: retained inbound owner "
                     "handoff=%s error=%s",
                     msg.handoff_id,
                     error,
                 )
+                owner.cleanup_pending = True
+                self._schedule_inbound_cleanup_retry(id(msg))
                 raise
-        await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+            except Exception as error:
+                self._record_inbound_cleanup_fatal(error, id(msg))
+                raise
+        await self._finalize_inbound_owner(id(msg), owner)
+
+    def _raise_inbound_cleanup_error(self) -> None:
+        error = self._inbound_cleanup_error
+        if error is not None:
+            raise RuntimeError("message bus inbound cleanup owner failed") from error
+
+    def _record_inbound_cleanup_fatal(
+        self,
+        error: BaseException,
+        owner_key: int,
+    ) -> None:
+        if self._inbound_cleanup_error is None:
+            self._inbound_cleanup_error = error
+        logger.exception(
+            "message_bus event=runtime_fatal owner=message_bus.inbound_cleanup "
+            "owner_key=%s error=%s",
+            owner_key,
+            error,
+        )
+
+    def _schedule_inbound_cleanup_retry(self, owner_key: int) -> None:
+        """为 cleanup-only owner 启动唯一的退避重试 task。"""
+
+        existing = self._inbound_cleanup_tasks.get(owner_key)
+        if existing is not None and not existing.done():
+            raise RuntimeError(f"inbound cleanup retry 已存在: {owner_key}")
+        self._inbound_cleanup_tasks[owner_key] = asyncio.create_task(
+            self._retry_inbound_cleanup(owner_key),
+            name=f"message-bus-cleanup:{owner_key}",
+        )
+
+    async def _retry_inbound_cleanup(self, owner_key: int) -> None:
+        """只重试 durable handoff 删除，成功后释放原 accepted owner。"""
+
+        delay = _INBOUND_CLEANUP_RETRY_INITIAL_DELAY
+        attempt = 0
+        try:
+            while True:
+                await asyncio.sleep(delay)
+                owner = self._inbound_accepted.get(owner_key)
+                if owner is None:
+                    raise RuntimeError(f"inbound cleanup owner 丢失: {owner_key}")
+                if not owner.cleanup_pending:
+                    raise RuntimeError(f"inbound cleanup owner 状态非法: {owner_key}")
+                item = owner.item
+                if not isinstance(item, InboundMessage) or item.handoff_id is None:
+                    raise RuntimeError(f"cleanup owner 缺少 mobile handoff: {owner_key}")
+                store = self._durable_inbound_store
+                if store is None:
+                    raise RuntimeError("mobile inbound durable handoff store 未绑定")
+                try:
+                    store.complete_inbound_handoff(item.handoff_id)
+                except OSError as error:
+                    attempt += 1
+                    delay = min(_INBOUND_CLEANUP_RETRY_MAX_DELAY, delay * 2)
+                    logger.error(
+                        "message_bus cleanup_degraded: retry failed "
+                        "handoff=%s attempt=%s next_delay=%.3f error=%s",
+                        item.handoff_id,
+                        attempt,
+                        delay,
+                        error,
+                    )
+                    continue
+                try:
+                    await self._finalize_inbound_owner(owner_key, owner)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    self._record_inbound_cleanup_fatal(error, owner_key)
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            self._record_inbound_cleanup_fatal(error, owner_key)
+        finally:
+            current = self._inbound_cleanup_tasks.get(owner_key)
+            if current is asyncio.current_task():
+                self._inbound_cleanup_tasks.pop(owner_key, None)
+
+    async def _finalize_inbound_owner(
+        self,
+        owner_key: int,
+        owner: _InboundOwner,
+    ) -> None:
+        """确认 lane 完成后释放 accepted owner，并继续有限 durable pump。"""
+
+        item = owner.item
+        await self._chat_lane.mark_passive_done(item.channel, item.chat_id)
         async with self._admission_lock:
-            released = self._inbound_accepted.pop(id(msg), None)
-            if released != accepted:
+            current = self._inbound_accepted.pop(owner_key, None)
+            if current is not owner:
                 raise RuntimeError("inbound ownership changed during completion")
-            self._inbound_bytes -= released
-        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
-            self._recovery_claimed.discard(msg.handoff_id)
+            self._inbound_bytes -= owner.item_bytes
+        if isinstance(item, InboundMessage) and item.handoff_id is not None:
+            self._recovery_claimed.discard(item.handoff_id)
         await self.recover_durable_inbounds()
+
+    async def aclose(self) -> None:
+        """停止出站循环并收束所有 cleanup-only retry task。"""
+
+        self.stop()
+        tasks = tuple(self._inbound_cleanup_tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._inbound_cleanup_tasks.clear()
+        self._raise_inbound_cleanup_error()
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -1,14 +1,172 @@
 import asyncio
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import TypeVar
+from typing import Protocol, cast
+from uuid import uuid4
 
-from bus.events import InboundItem, OutboundMessage
+from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
 
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+
+DEFAULT_MESSAGE_BUS_CAPACITY = 256
+DEFAULT_MESSAGE_BUS_BYTES = 4 * 1024 * 1024
+
+
+class MessageBusCapacityError(RuntimeError):
+    """表示消息在进入有界队列前被拒绝。"""
+
+    error_type = "resource-exhausted"
+    failure_type = "operation_rejected"
+    code = "resource-exhausted"
+    retryable = True
+
+    def __init__(self, direction: str, *, item_bytes: int, reason: str) -> None:
+        self.direction = direction
+        self.item_bytes = item_bytes
+        self.reason = reason
+        super().__init__(
+            f"resource-exhausted: {direction} message bus admission {reason} "
+            f"(item_bytes={item_bytes})"
+        )
+
+
+# Keep a descriptive alias for callers that use the transport terminology.
+MessageBusBusyError = MessageBusCapacityError
+
+
+def _wire_size(item: object) -> int:
+    """计算消息进入队列后占用的 UTF-8 JSON 字节数。"""
+
+    if isinstance(item, InboundMessage):
+        payload = {
+            "channel": item.channel,
+            "sender": item.sender,
+            "chat_id": item.chat_id,
+            "content": item.content,
+            "timestamp": item.timestamp.isoformat(),
+            "media": list(item.media),
+            "metadata": dict(item.metadata),
+        }
+    elif isinstance(item, SpawnCompletionItem):
+        payload = {
+            "channel": item.channel,
+            "chat_id": item.chat_id,
+            "event": repr(item.event),
+            "decision": repr(item.decision),
+            "timestamp": item.timestamp.isoformat(),
+        }
+    elif isinstance(item, OutboundMessage):
+        payload = {
+            "channel": item.channel,
+            "chat_id": item.chat_id,
+            "content": item.content,
+            "thinking": item.thinking,
+            "reply_to": item.reply_to,
+            "media": list(item.media),
+            "metadata": dict(item.metadata),
+        }
+    else:
+        raise TypeError(f"unsupported MessageBus item: {type(item).__name__}")
+    return len(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode())
+
+
+class DurableInboundStore(Protocol):
+    """MessageBus 所需的最小移动 handoff 持久 owner 接口。"""
+
+    def reserve_inbound_handoff(
+        self,
+        *,
+        handoff_id: str,
+        dedupe_key: str | None,
+        channel: str,
+        sender: str,
+        chat_id: str,
+        session_key: str,
+        content: str,
+        timestamp: str,
+        media_json: str,
+        metadata_json: str,
+        created_at: str,
+    ) -> tuple[str, bool]: ...
+
+    def list_inbound_handoffs(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, str | None]]: ...
+
+    def has_inbound_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool: ...
+
+    def complete_inbound_handoff(self, handoff_id: str) -> None: ...
+
+
+def _mobile_dedupe_key(message: InboundMessage) -> str | None:
+    client_message_id = message.metadata.get("client_message_id")
+    if not isinstance(client_message_id, str) or not client_message_id:
+        return None
+    return f"{message.session_key}:{client_message_id}"
+
+
+def _serialize_handoff(message: InboundMessage) -> tuple[str, str]:
+    media_json = json.dumps(
+        message.media,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    metadata_json = json.dumps(
+        message.metadata,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    return media_json, metadata_json
+
+
+def _inbound_from_handoff(row: dict[str, str | None]) -> InboundMessage:
+    required = (
+        "handoff_id",
+        "channel",
+        "sender",
+        "chat_id",
+        "content",
+        "timestamp",
+        "media_json",
+        "metadata_json",
+    )
+    values = {key: row.get(key) for key in required}
+    if any(not isinstance(value, str) or not value for value in values.values()):
+        raise ValueError(f"inbound handoff schema invalid: {row!r}")
+    media = json.loads(cast(str, values["media_json"]))
+    metadata = json.loads(cast(str, values["metadata_json"]))
+    if not isinstance(media, list) or not all(isinstance(item, str) for item in media):
+        raise ValueError(f"inbound handoff media invalid: {values['handoff_id']}")
+    if not isinstance(metadata, dict):
+        raise ValueError(f"inbound handoff metadata invalid: {values['handoff_id']}")
+    timestamp = datetime.fromisoformat(cast(str, values["timestamp"]))
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError(f"inbound handoff timestamp missing timezone: {values['handoff_id']}")
+    return InboundMessage(
+        channel=cast(str, values["channel"]),
+        sender=cast(str, values["sender"]),
+        chat_id=cast(str, values["chat_id"]),
+        content=cast(str, values["content"]),
+        timestamp=timestamp,
+        media=cast(list[str], media),
+        metadata=cast(dict[str, object], metadata),
+        handoff_id=cast(str, values["handoff_id"]),
+    )
 
 
 @dataclass
@@ -91,6 +249,18 @@ class ChatLane:
         try:
             async with state.condition:
                 state.passive_sends += 1
+                state.condition.notify_all()
+        finally:
+            self._release_state(key, state)
+
+    async def mark_passive_send_done(self, channel: str, chat_id: str) -> None:
+        """回滚尚未开始发送的出站 lane 计数。"""
+
+        key, state = self._acquire_state(channel, chat_id)
+        try:
+            async with state.condition:
+                if state.passive_sends > 0:
+                    state.passive_sends -= 1
                 state.condition.notify_all()
         finally:
             self._release_state(key, state)
@@ -180,9 +350,38 @@ class OutboundSubscription:
 class MessageBus:
     """agent 与各 channel 之间的异步消息总线"""
 
-    def __init__(self, chat_lane: ChatLane | None = None) -> None:
-        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue()
-        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+    def __init__(
+        self,
+        chat_lane: ChatLane | None = None,
+        *,
+        inbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
+        outbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
+        inbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
+        outbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
+    ) -> None:
+        for name, value in (
+            ("inbound_capacity", inbound_capacity),
+            ("outbound_capacity", outbound_capacity),
+            ("inbound_bytes", inbound_bytes),
+            ("outbound_bytes", outbound_bytes),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} 必须是正整数")
+        self._inbound_capacity = inbound_capacity
+        self._outbound_capacity = outbound_capacity
+        self._inbound_bytes_capacity = inbound_bytes
+        self._outbound_bytes_capacity = outbound_bytes
+        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
+        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
+        self._inbound_bytes = 0
+        self._inbound_accepted: dict[int, int] = {}
+        self._recovery_claimed: set[str] = set()
+        self._outbound_bytes = 0
+        self._inbound_reserved_items = 0
+        self._outbound_reserved_items = 0
+        self._inbound_reserved_bytes = 0
+        self._outbound_reserved_bytes = 0
+        self._admission_lock = asyncio.Lock()
         self._subscribers: dict[
             str, list[Callable[[OutboundMessage], Awaitable[None]]]
         ] = {}
@@ -191,6 +390,65 @@ class MessageBus:
         self._delivery_observer: (
             Callable[[OutboundMessage, bool], Awaitable[None]] | None
         ) = None
+        self._durable_inbound_store: DurableInboundStore | None = None
+
+    def bind_durable_inbound_store(self, store: DurableInboundStore) -> None:
+        """在 channel 启动前绑定一次由 session 持有的 handoff store。"""
+
+        if self._durable_inbound_store is not None:
+            raise RuntimeError("durable inbound store 已绑定")
+        self._durable_inbound_store = store
+
+    async def recover_durable_inbounds(self) -> None:
+        """在有界 bus slot 内重放尚未完成的移动 handoff。"""
+
+        store = self._durable_inbound_store
+        if store is None:
+            return
+        # 1. 只读取有限页，避免启动时把整个 durable backlog 搬入内存。
+        available = self._inbound_capacity - len(self._inbound_accepted)
+        if available <= 0:
+            return
+        rows = store.list_inbound_handoffs(
+            limit=min(self._inbound_capacity, available + len(self._recovery_claimed))
+        )
+        for row in rows:
+            handoff_id = row.get("handoff_id")
+            if not isinstance(handoff_id, str) or handoff_id in self._recovery_claimed:
+                continue
+            if len(self._inbound_accepted) >= self._inbound_capacity:
+                break
+            item = _inbound_from_handoff(row)
+            self._recovery_claimed.add(handoff_id)
+            try:
+                await self._publish_inbound(item, allow_existing_handoff=True)
+            except MessageBusCapacityError as error:
+                self._recovery_claimed.discard(handoff_id)
+                if error.item_bytes > self._inbound_bytes_capacity:
+                    raise
+                logger.info(
+                    "durable inbound recovery waiting for bus capacity: handoff=%s reason=%s",
+                    handoff_id,
+                    error.reason,
+                )
+                break
+
+    def has_pending_mobile_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        """检查移动命令是否仍由 durable queue owner 持有。"""
+
+        store = self._durable_inbound_store
+        return bool(
+            store is not None
+            and store.has_inbound_handoff(
+                session_key=session_key,
+                client_message_id=client_message_id,
+            )
+        )
 
     def bind_outbound_delivery_observer(
         self,
@@ -204,20 +462,134 @@ class MessageBus:
 
     async def publish_inbound(self, msg: InboundItem) -> None:
         """将渠道输入交给 Agent 消费。"""
-        await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
-        await self._inbound.put(msg)
+        await self._publish_inbound(msg, allow_existing_handoff=False)
+
+    async def _publish_inbound(
+        self,
+        msg: InboundItem,
+        *,
+        allow_existing_handoff: bool,
+    ) -> None:
+        """在容量、lane 和 durable handoff 三者一致后入队一条消息。"""
+
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            if id(msg) in self._inbound_accepted:
+                raise RuntimeError("同一 inbound 对象被重复接受")
+            if len(self._inbound_accepted) + self._inbound_reserved_items >= self._inbound_capacity:
+                raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="queue full")
+            if (
+                self._inbound_bytes
+                + self._inbound_reserved_bytes
+                + item_bytes
+                > self._inbound_bytes_capacity
+            ):
+                raise MessageBusCapacityError(
+                    "inbound",
+                    item_bytes=item_bytes,
+                    reason="byte budget full",
+                )
+            self._inbound_reserved_items += 1
+            self._inbound_reserved_bytes += item_bytes
+            marked = False
+            try:
+                if isinstance(msg, InboundMessage) and msg.channel == "mobile":
+                    store = self._durable_inbound_store
+                    if store is None:
+                        raise RuntimeError("mobile inbound durable handoff store 未绑定")
+                    requested_handoff_id = msg.handoff_id
+                    media_json, metadata_json = _serialize_handoff(msg)
+                    handoff_id, created = store.reserve_inbound_handoff(
+                        handoff_id=msg.handoff_id or uuid4().hex,
+                        dedupe_key=_mobile_dedupe_key(msg),
+                        channel=msg.channel,
+                        sender=msg.sender,
+                        chat_id=msg.chat_id,
+                        session_key=msg.session_key,
+                        content=msg.content,
+                        timestamp=msg.timestamp.astimezone(timezone.utc).isoformat(),
+                        media_json=media_json,
+                        metadata_json=metadata_json,
+                        created_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                    msg.handoff_id = handoff_id
+                    if not created and not (
+                        allow_existing_handoff
+                        and requested_handoff_id == handoff_id
+                    ):
+                        return
+                await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
+                marked = True
+                self._inbound.put_nowait(msg)
+            except BaseException:
+                if marked:
+                    await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+                raise
+            finally:
+                self._inbound_reserved_items -= 1
+                self._inbound_reserved_bytes -= item_bytes
+            self._inbound_accepted[id(msg)] = item_bytes
+            self._inbound_bytes += item_bytes
 
     async def consume_inbound(self) -> InboundItem:
         """阻塞直到有消息可消费"""
         return await self._inbound.get()
 
     async def complete_inbound(self, msg: InboundItem) -> None:
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            accepted = self._inbound_accepted.get(id(msg))
+            if accepted is None:
+                raise RuntimeError("inbound 未被接受或已完成")
+            if accepted != item_bytes:
+                raise RuntimeError("inbound ownership bytes 不一致")
+        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
+            store = self._durable_inbound_store
+            if store is None:
+                raise RuntimeError("mobile inbound durable handoff store 未绑定")
+            try:
+                store.complete_inbound_handoff(msg.handoff_id)
+            except Exception as error:
+                logger.error(
+                    "message_bus cleanup_degraded: retained inbound owner "
+                    "handoff=%s error=%s",
+                    msg.handoff_id,
+                    error,
+                )
+                raise
         await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+        async with self._admission_lock:
+            released = self._inbound_accepted.pop(id(msg), None)
+            if released != accepted:
+                raise RuntimeError("inbound ownership changed during completion")
+            self._inbound_bytes -= released
+        if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
+            self._recovery_claimed.discard(msg.handoff_id)
+        await self.recover_durable_inbounds()
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""
-        await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
-        await self._outbound.put(msg)
+        item_bytes = _wire_size(msg)
+        async with self._admission_lock:
+            if self._outbound.qsize() + self._outbound_reserved_items >= self._outbound_capacity:
+                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="queue full")
+            if self._outbound_bytes + self._outbound_reserved_bytes + item_bytes > self._outbound_bytes_capacity:
+                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="byte budget full")
+            self._outbound_reserved_items += 1
+            self._outbound_reserved_bytes += item_bytes
+            marked = False
+            try:
+                await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
+                marked = True
+                self._outbound.put_nowait(msg)
+            except BaseException:
+                if marked:
+                    await self._chat_lane.mark_passive_send_done(msg.channel, msg.chat_id)
+                raise
+            finally:
+                self._outbound_reserved_items -= 1
+                self._outbound_reserved_bytes -= item_bytes
+            self._outbound_bytes += item_bytes
 
     def subscribe_outbound(
         self,
@@ -252,6 +624,8 @@ class MessageBus:
         while self._running:
             try:
                 msg = await asyncio.wait_for(self._outbound.get(), timeout=1.0)
+                async with self._admission_lock:
+                    self._outbound_bytes -= _wire_size(msg)
                 delivered = await self._chat_lane.run_passive(
                     msg.channel,
                     msg.chat_id,
@@ -310,3 +684,35 @@ class MessageBus:
     @property
     def outbound_size(self) -> int:
         return self._outbound.qsize()
+
+    @property
+    def inbound_bytes(self) -> int:
+        return self._inbound_bytes
+
+    @property
+    def outbound_bytes(self) -> int:
+        return self._outbound_bytes
+
+    @property
+    def inbound_capacity(self) -> int:
+        return self._inbound_capacity
+
+    @property
+    def outbound_capacity(self) -> int:
+        return self._outbound_capacity
+
+    @property
+    def inbound_bytes_capacity(self) -> int:
+        return self._inbound_bytes_capacity
+
+    @property
+    def outbound_bytes_capacity(self) -> int:
+        return self._outbound_bytes_capacity
+
+    @property
+    def inbound_reserved_bytes(self) -> int:
+        return self._inbound_reserved_bytes
+
+    @property
+    def outbound_reserved_bytes(self) -> int:
+        return self._outbound_reserved_bytes

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -8,74 +8,15 @@ from typing import TypeVar
 from typing import Protocol, cast
 from uuid import uuid4
 
-from bus.events import InboundItem, InboundMessage, OutboundMessage, SpawnCompletionItem
+from bus.events import InboundItem, InboundMessage, OutboundMessage
 
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
-DEFAULT_MESSAGE_BUS_CAPACITY = 256
-DEFAULT_MESSAGE_BUS_BYTES = 4 * 1024 * 1024
+_DURABLE_INBOUND_RECOVERY_PAGE_SIZE = 256
 _INBOUND_CLEANUP_RETRY_INITIAL_DELAY = 0.1
 _INBOUND_CLEANUP_RETRY_MAX_DELAY = 5.0
-
-
-class MessageBusCapacityError(RuntimeError):
-    """表示消息在进入有界队列前被拒绝。"""
-
-    error_type = "resource-exhausted"
-    failure_type = "operation_rejected"
-    code = "resource-exhausted"
-    retryable = True
-
-    def __init__(self, direction: str, *, item_bytes: int, reason: str) -> None:
-        self.direction = direction
-        self.item_bytes = item_bytes
-        self.reason = reason
-        super().__init__(
-            f"resource-exhausted: {direction} message bus admission {reason} "
-            f"(item_bytes={item_bytes})"
-        )
-
-
-# Keep a descriptive alias for callers that use the transport terminology.
-MessageBusBusyError = MessageBusCapacityError
-
-
-def _wire_size(item: object) -> int:
-    """计算消息进入队列后占用的 UTF-8 JSON 字节数。"""
-
-    if isinstance(item, InboundMessage):
-        payload = {
-            "channel": item.channel,
-            "sender": item.sender,
-            "chat_id": item.chat_id,
-            "content": item.content,
-            "timestamp": item.timestamp.isoformat(),
-            "media": list(item.media),
-            "metadata": dict(item.metadata),
-        }
-    elif isinstance(item, SpawnCompletionItem):
-        payload = {
-            "channel": item.channel,
-            "chat_id": item.chat_id,
-            "event": repr(item.event),
-            "decision": repr(item.decision),
-            "timestamp": item.timestamp.isoformat(),
-        }
-    elif isinstance(item, OutboundMessage):
-        payload = {
-            "channel": item.channel,
-            "chat_id": item.chat_id,
-            "content": item.content,
-            "thinking": item.thinking,
-            "reply_to": item.reply_to,
-            "media": list(item.media),
-            "metadata": dict(item.metadata),
-        }
-    else:
-        raise TypeError(f"unsupported MessageBus item: {type(item).__name__}")
-    return len(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode())
 
 
 class DurableInboundStore(Protocol):
@@ -187,10 +128,9 @@ class _ChatLaneState:
 
 @dataclass
 class _InboundOwner:
-    """在 durable cleanup 确认前保持 accepted inbound item 的强引用。"""
+    """在 durable cleanup 确认前保持 mobile handoff 的强引用。"""
 
     item: InboundItem
-    item_bytes: int
     cleanup_pending: bool = False
 
 
@@ -359,42 +299,16 @@ class OutboundSubscription:
 
 
 class MessageBus:
-    """agent 与各 channel 之间的异步消息总线"""
+    """在单用户 Companion 内传递消息，并持有 mobile handoff 的删除责任。"""
 
-    def __init__(
-        self,
-        chat_lane: ChatLane | None = None,
-        *,
-        inbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
-        outbound_capacity: int = DEFAULT_MESSAGE_BUS_CAPACITY,
-        inbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
-        outbound_bytes: int = DEFAULT_MESSAGE_BUS_BYTES,
-    ) -> None:
-        for name, value in (
-            ("inbound_capacity", inbound_capacity),
-            ("outbound_capacity", outbound_capacity),
-            ("inbound_bytes", inbound_bytes),
-            ("outbound_bytes", outbound_bytes),
-        ):
-            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
-                raise ValueError(f"{name} 必须是正整数")
-        self._inbound_capacity = inbound_capacity
-        self._outbound_capacity = outbound_capacity
-        self._inbound_bytes_capacity = inbound_bytes
-        self._outbound_bytes_capacity = outbound_bytes
-        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue(maxsize=inbound_capacity)
-        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=outbound_capacity)
-        self._inbound_bytes = 0
+    def __init__(self, chat_lane: ChatLane | None = None) -> None:
+        self._inbound: asyncio.Queue[InboundItem] = asyncio.Queue()
+        self._outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
         self._inbound_accepted: dict[int, _InboundOwner] = {}
         self._inbound_cleanup_tasks: dict[int, asyncio.Task[None]] = {}
         self._inbound_cleanup_error: BaseException | None = None
         self._recovery_claimed: set[str] = set()
-        self._outbound_bytes = 0
-        self._inbound_reserved_items = 0
-        self._outbound_reserved_items = 0
-        self._inbound_reserved_bytes = 0
-        self._outbound_reserved_bytes = 0
-        self._admission_lock = asyncio.Lock()
+        self._durable_handoff_lock = asyncio.Lock()
         self._subscribers: dict[
             str, list[Callable[[OutboundMessage], Awaitable[None]]]
         ] = {}
@@ -413,39 +327,22 @@ class MessageBus:
         self._durable_inbound_store = store
 
     async def recover_durable_inbounds(self) -> None:
-        """在有界 bus slot 内重放尚未完成的移动 handoff。"""
+        """分页重放尚未完成的移动 handoff，不以 bus 容量拒绝消息。"""
 
         self._raise_inbound_cleanup_error()
         store = self._durable_inbound_store
         if store is None:
             return
         # 1. 只读取有限页，避免启动时把整个 durable backlog 搬入内存。
-        available = self._inbound_capacity - len(self._inbound_accepted)
-        if available <= 0:
-            return
-        rows = store.list_inbound_handoffs(
-            limit=min(self._inbound_capacity, available + len(self._recovery_claimed))
-        )
+        rows = store.list_inbound_handoffs(limit=_DURABLE_INBOUND_RECOVERY_PAGE_SIZE)
         for row in rows:
             handoff_id = row.get("handoff_id")
             if not isinstance(handoff_id, str) or handoff_id in self._recovery_claimed:
                 continue
-            if len(self._inbound_accepted) >= self._inbound_capacity:
-                break
             item = _inbound_from_handoff(row)
             self._recovery_claimed.add(handoff_id)
             try:
                 await self._publish_inbound(item, allow_existing_handoff=True)
-            except MessageBusCapacityError as error:
-                self._recovery_claimed.discard(handoff_id)
-                if error.item_bytes > self._inbound_bytes_capacity:
-                    raise
-                logger.info(
-                    "durable inbound recovery waiting for bus capacity: handoff=%s reason=%s",
-                    handoff_id,
-                    error.reason,
-                )
-                break
             except BaseException:
                 self._recovery_claimed.discard(handoff_id)
                 raise
@@ -488,69 +385,50 @@ class MessageBus:
         *,
         allow_existing_handoff: bool,
     ) -> None:
-        """在容量、lane 和 durable handoff 三者一致后入队一条消息。"""
+        """将消息入队；mobile 先持久化并由本类负责删除确认。"""
 
-        item_bytes = _wire_size(msg)
-        async with self._admission_lock:
-            if id(msg) in self._inbound_accepted:
-                raise RuntimeError("同一 inbound 对象被重复接受")
-            if len(self._inbound_accepted) + self._inbound_reserved_items >= self._inbound_capacity:
-                raise MessageBusCapacityError("inbound", item_bytes=item_bytes, reason="queue full")
-            if (
-                self._inbound_bytes
-                + self._inbound_reserved_bytes
-                + item_bytes
-                > self._inbound_bytes_capacity
-            ):
-                raise MessageBusCapacityError(
-                    "inbound",
-                    item_bytes=item_bytes,
-                    reason="byte budget full",
-                )
-            self._inbound_reserved_items += 1
-            self._inbound_reserved_bytes += item_bytes
-            marked = False
+        if not isinstance(msg, InboundMessage) or msg.channel != "mobile":
+            await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
             try:
-                if isinstance(msg, InboundMessage) and msg.channel == "mobile":
-                    store = self._durable_inbound_store
-                    if store is None:
-                        raise RuntimeError("mobile inbound durable handoff store 未绑定")
-                    requested_handoff_id = msg.handoff_id
-                    media_json, metadata_json = _serialize_handoff(msg)
-                    handoff_id, created = store.reserve_inbound_handoff(
-                        handoff_id=msg.handoff_id or uuid4().hex,
-                        dedupe_key=_mobile_dedupe_key(msg),
-                        channel=msg.channel,
-                        sender=msg.sender,
-                        chat_id=msg.chat_id,
-                        session_key=msg.session_key,
-                        content=msg.content,
-                        timestamp=msg.timestamp.astimezone(timezone.utc).isoformat(),
-                        media_json=media_json,
-                        metadata_json=metadata_json,
-                        created_at=datetime.now(timezone.utc).isoformat(),
-                    )
-                    msg.handoff_id = handoff_id
-                    if not created and not (
-                        allow_existing_handoff
-                        and requested_handoff_id == handoff_id
-                    ):
-                        return
-                await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
-                marked = True
                 self._inbound.put_nowait(msg)
             except BaseException:
-                if marked:
-                    await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+                await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
                 raise
-            finally:
-                self._inbound_reserved_items -= 1
-                self._inbound_reserved_bytes -= item_bytes
-            self._inbound_accepted[id(msg)] = _InboundOwner(
-                item=msg,
-                item_bytes=item_bytes,
+            return
+
+        async with self._durable_handoff_lock:
+            if id(msg) in self._inbound_accepted:
+                raise RuntimeError("同一 mobile inbound 对象被重复接受")
+            store = self._durable_inbound_store
+            if store is None:
+                raise RuntimeError("mobile inbound durable handoff store 未绑定")
+            requested_handoff_id = msg.handoff_id
+            media_json, metadata_json = _serialize_handoff(msg)
+            handoff_id, created = store.reserve_inbound_handoff(
+                handoff_id=msg.handoff_id or uuid4().hex,
+                dedupe_key=_mobile_dedupe_key(msg),
+                channel=msg.channel,
+                sender=msg.sender,
+                chat_id=msg.chat_id,
+                session_key=msg.session_key,
+                content=msg.content,
+                timestamp=msg.timestamp.astimezone(timezone.utc).isoformat(),
+                media_json=media_json,
+                metadata_json=metadata_json,
+                created_at=datetime.now(timezone.utc).isoformat(),
             )
-            self._inbound_bytes += item_bytes
+            msg.handoff_id = handoff_id
+            if not created and not (
+                allow_existing_handoff and requested_handoff_id == handoff_id
+            ):
+                return
+            await self._chat_lane.mark_passive_pending(msg.channel, msg.chat_id)
+            try:
+                self._inbound.put_nowait(msg)
+            except BaseException:
+                await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+                raise
+            self._inbound_accepted[id(msg)] = _InboundOwner(item=msg)
 
     async def consume_inbound(self) -> InboundItem:
         """阻塞直到有消息可消费"""
@@ -558,15 +436,14 @@ class MessageBus:
 
     async def complete_inbound(self, msg: InboundItem) -> None:
         self._raise_inbound_cleanup_error()
-        item_bytes = _wire_size(msg)
-        async with self._admission_lock:
-            owner = self._inbound_accepted.get(id(msg))
-            if owner is None or owner.item is not msg:
-                raise RuntimeError("inbound 未被接受或已完成")
-            if owner.item_bytes != item_bytes:
-                raise RuntimeError("inbound ownership bytes 不一致")
-            if owner.cleanup_pending:
-                raise RuntimeError("inbound cleanup 已在重试中")
+        owner = self._inbound_accepted.get(id(msg))
+        if owner is None:
+            await self._chat_lane.mark_passive_done(msg.channel, msg.chat_id)
+            return
+        if owner.item is not msg:
+            raise RuntimeError("mobile inbound ownership changed")
+        if owner.cleanup_pending:
+            raise RuntimeError("inbound cleanup 已在重试中")
         if isinstance(msg, InboundMessage) and msg.handoff_id is not None:
             store = self._durable_inbound_store
             if store is None:
@@ -672,15 +549,14 @@ class MessageBus:
         owner_key: int,
         owner: _InboundOwner,
     ) -> None:
-        """确认 lane 完成后释放 accepted owner，并继续有限 durable pump。"""
+        """确认 lane 完成后释放 mobile handoff owner，并继续分页 pump。"""
 
         item = owner.item
         await self._chat_lane.mark_passive_done(item.channel, item.chat_id)
-        async with self._admission_lock:
+        async with self._durable_handoff_lock:
             current = self._inbound_accepted.pop(owner_key, None)
             if current is not owner:
                 raise RuntimeError("inbound ownership changed during completion")
-            self._inbound_bytes -= owner.item_bytes
         if isinstance(item, InboundMessage) and item.handoff_id is not None:
             self._recovery_claimed.discard(item.handoff_id)
         await self.recover_durable_inbounds()
@@ -699,27 +575,12 @@ class MessageBus:
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送。"""
-        item_bytes = _wire_size(msg)
-        async with self._admission_lock:
-            if self._outbound.qsize() + self._outbound_reserved_items >= self._outbound_capacity:
-                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="queue full")
-            if self._outbound_bytes + self._outbound_reserved_bytes + item_bytes > self._outbound_bytes_capacity:
-                raise MessageBusCapacityError("outbound", item_bytes=item_bytes, reason="byte budget full")
-            self._outbound_reserved_items += 1
-            self._outbound_reserved_bytes += item_bytes
-            marked = False
-            try:
-                await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
-                marked = True
-                self._outbound.put_nowait(msg)
-            except BaseException:
-                if marked:
-                    await self._chat_lane.mark_passive_send_done(msg.channel, msg.chat_id)
-                raise
-            finally:
-                self._outbound_reserved_items -= 1
-                self._outbound_reserved_bytes -= item_bytes
-            self._outbound_bytes += item_bytes
+        await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
+        try:
+            self._outbound.put_nowait(msg)
+        except BaseException:
+            await self._chat_lane.mark_passive_send_done(msg.channel, msg.chat_id)
+            raise
 
     def subscribe_outbound(
         self,
@@ -754,8 +615,6 @@ class MessageBus:
         while self._running:
             try:
                 msg = await asyncio.wait_for(self._outbound.get(), timeout=1.0)
-                async with self._admission_lock:
-                    self._outbound_bytes -= _wire_size(msg)
                 delivered = await self._chat_lane.run_passive(
                     msg.channel,
                     msg.chat_id,
@@ -814,35 +673,3 @@ class MessageBus:
     @property
     def outbound_size(self) -> int:
         return self._outbound.qsize()
-
-    @property
-    def inbound_bytes(self) -> int:
-        return self._inbound_bytes
-
-    @property
-    def outbound_bytes(self) -> int:
-        return self._outbound_bytes
-
-    @property
-    def inbound_capacity(self) -> int:
-        return self._inbound_capacity
-
-    @property
-    def outbound_capacity(self) -> int:
-        return self._outbound_capacity
-
-    @property
-    def inbound_bytes_capacity(self) -> int:
-        return self._inbound_bytes_capacity
-
-    @property
-    def outbound_bytes_capacity(self) -> int:
-        return self._outbound_bytes_capacity
-
-    @property
-    def inbound_reserved_bytes(self) -> int:
-        return self._inbound_reserved_bytes
-
-    @property
-    def outbound_reserved_bytes(self) -> int:
-        return self._outbound_reserved_bytes

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -433,6 +433,17 @@ class MobileRealtimeChannel:
                         "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
                     },
                 )
+            if self._require_ctx().bus.has_pending_mobile_handoff(
+                session_key=session_id,
+                client_message_id=frame.payload.client_message_id,
+            ):
+                return CommandReply(
+                    type=f"{receipt.command_type}.error",
+                    payload={
+                        "code": "command_in_progress",
+                        "message": "该命令已进入持久化队列，请等待原命令 ID 的最终收据",
+                    },
+                )
             if (device_id, frame.id) in self._receipt_completion_failures:
                 self._receipt_completion_failures.discard((device_id, frame.id))
                 unknown = self._runtime.storage.mark_command_outcome_unknown(

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -69,6 +69,7 @@ from infra.mobile_realtime.storage import (
     AttachmentRecord,
     AttachmentStateError,
     CommandReceipt,
+    CommandReceiptCapacityError,
     MobileStorageError,
 )
 
@@ -171,6 +172,7 @@ class MobileRealtimeChannel:
         self._runtime = runtime
         self._ctx: ChannelContext | None = None
         self._processing_commands: set[tuple[str, str]] = set()
+        self._receipt_completion_failures: set[tuple[str, str]] = set()
         self._active_turn_ids: dict[str, str] = {}
         self._process_turns: dict[tuple[str, str], _ProcessTurnState] = {}
         self._delta_batches: dict[tuple[str, str], _DeltaBatch] = {}
@@ -263,6 +265,7 @@ class MobileRealtimeChannel:
         self._active_turn_ids.clear()
         self._process_turns.clear()
         self._processing_commands.clear()
+        self._receipt_completion_failures.clear()
 
     async def handle_command(
         self,
@@ -274,13 +277,19 @@ class MobileRealtimeChannel:
 
         # 1. 先持久化命令占用，避免重连重复触发 Agent turn
         self._raise_delta_failure()
-        receipt, created = self._runtime.storage.reserve_command(
-            device_id=device_id,
-            command_id=frame.id,
-            command_type=frame.type,
-            request_hash=_command_hash(frame),
-            created_at=_utc_now(),
-        )
+        try:
+            receipt, created = self._runtime.storage.reserve_command(
+                device_id=device_id,
+                command_id=frame.id,
+                command_type=frame.type,
+                request_hash=_command_hash(frame),
+                created_at=_utc_now(),
+            )
+        except CommandReceiptCapacityError as error:
+            raise MobileCommandError(
+                "mobile_command_receipt_capacity_reached",
+                str(error),
+            ) from error
         if not created:
             replay = self._recover_message_send_receipt(
                 device_id=device_id,
@@ -298,41 +307,47 @@ class MobileRealtimeChannel:
         command_key = (device_id, frame.id)
         self._processing_commands.add(command_key)
         try:
-            reply = await self._execute_command(device_id=device_id, frame=frame)
-        except (MobileCommandError, RuntimeInspectionError) as error:
-            reply = CommandReply(
-                type=f"{frame.type}.error",
-                payload={"code": error.code, "message": str(error)},
-                session_id=frame.session_id,
-                turn_id=frame.turn_id,
-            )
+            try:
+                reply = await self._execute_command(device_id=device_id, frame=frame)
+            except (MobileCommandError, RuntimeInspectionError) as error:
+                reply = CommandReply(
+                    type=f"{frame.type}.error",
+                    payload={"code": error.code, "message": str(error)},
+                    session_id=frame.session_id,
+                    turn_id=frame.turn_id,
+                )
 
-        # 3. 只有收据完成后才释放当前进程对未决副作用的所有权
-        _validate_reply_frame_size(frame, reply)
-        completed = self._runtime.storage.complete_command(
-            device_id=device_id,
-            command_id=frame.id,
-            reply_type=reply.type,
-            reply_payload_json=json.dumps(
-                reply.payload,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-                allow_nan=False,
-            ),
-            session_id=reply.session_id,
-            turn_id=reply.turn_id,
-            completed_at=_utc_now(),
-        )
-        self._processing_commands.discard(command_key)
-        stored = _reply_from_receipt(completed)
-        return CommandReply(
-            type=stored.type,
-            payload=stored.payload,
-            session_id=stored.session_id,
-            turn_id=stored.turn_id,
-            binary=reply.binary,
-        )
+            # 3. 只有收据完成后才释放当前进程对未决副作用的所有权
+            _validate_reply_frame_size(frame, reply)
+            try:
+                completed = self._runtime.storage.complete_command(
+                    device_id=device_id,
+                    command_id=frame.id,
+                    reply_type=reply.type,
+                    reply_payload_json=json.dumps(
+                        reply.payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                        allow_nan=False,
+                    ),
+                    session_id=reply.session_id,
+                    turn_id=reply.turn_id,
+                    completed_at=_utc_now(),
+                )
+            except Exception:
+                self._receipt_completion_failures.add(command_key)
+                raise
+            stored = _reply_from_receipt(completed)
+            return CommandReply(
+                type=stored.type,
+                payload=stored.payload,
+                session_id=stored.session_id,
+                turn_id=stored.turn_id,
+                binary=reply.binary,
+            )
+        finally:
+            self._processing_commands.discard(command_key)
 
     async def handle_plugin_ui_command(
         self,
@@ -383,11 +398,23 @@ class MobileRealtimeChannel:
         """从已持久化消息修复中断的 message.send 收据。"""
 
         # 1. 已完成或非消息命令继续复用稳定回复
-        if receipt.status == "completed":
+        if receipt.status in {"completed", "outcome_unknown"}:
             self._processing_commands.discard((device_id, frame.id))
             return _reply_from_receipt(receipt)
+        if (device_id, frame.id) in self._processing_commands:
+            return CommandReply(
+                type=f"{receipt.command_type}.error",
+                payload={
+                    "code": "command_in_progress",
+                    "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
+                },
+            )
         if not isinstance(frame, MessageSendCommand):
-            return _reply_from_receipt(receipt)
+            unknown = self._runtime.storage.mark_command_outcome_unknown(
+                device_id=device_id,
+                command_id=frame.id,
+            )
+            return _reply_from_receipt(unknown)
 
         # 2. 只有同一 client_message_id 已落库时，才能确认副作用已完成
         session_id = self._normalize_session_id(frame.session_id)
@@ -399,7 +426,20 @@ class MobileRealtimeChannel:
         )
         if message is None:
             if (device_id, frame.id) in self._processing_commands:
-                return _reply_from_receipt(receipt)
+                return CommandReply(
+                    type=f"{receipt.command_type}.error",
+                    payload={
+                        "code": "command_in_progress",
+                        "message": "该命令仍在执行，请等待原命令 ID 的最终收据",
+                    },
+                )
+            if (device_id, frame.id) in self._receipt_completion_failures:
+                self._receipt_completion_failures.discard((device_id, frame.id))
+                unknown = self._runtime.storage.mark_command_outcome_unknown(
+                    device_id=device_id,
+                    command_id=frame.id,
+                )
+                return _reply_from_receipt(unknown)
             return self._complete_interrupted_message_send(
                 device_id=device_id,
                 frame=frame,
@@ -429,6 +469,7 @@ class MobileRealtimeChannel:
             turn_id=None,
             completed_at=_utc_now(),
         )
+        self._receipt_completion_failures.discard((device_id, frame.id))
         self._processing_commands.discard((device_id, frame.id))
         return _reply_from_receipt(completed)
 

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -1180,6 +1180,8 @@ class MobileGatewayRuntime:
                     }
                 )
             return
+        from infra.mobile_realtime.channel import MobileCommandError
+
         try:
             reply = await self.channel.handle_command(
                 device_id=device_id,
@@ -1193,6 +1195,18 @@ class MobileGatewayRuntime:
                     connection_epoch=connection_epoch,
                     reply_type=f"{frame.type}.error",
                     payload={"code": "command_id_conflict", "message": str(error)},
+                    session_id=frame.session_id,
+                    turn_id=frame.turn_id,
+                )
+            return
+        except MobileCommandError as error:
+            async with connection.send_lock:
+                await _send_reply(
+                    websocket,
+                    frame_id=frame.id,
+                    connection_epoch=connection_epoch,
+                    reply_type=f"{frame.type}.error",
+                    payload={"code": error.code, "message": str(error)},
                     session_id=frame.session_id,
                     turn_id=frame.turn_id,
                 )

--- a/infra/mobile_realtime/storage.py
+++ b/infra/mobile_realtime/storage.py
@@ -6,7 +6,7 @@ import sqlite3
 import stat
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Literal, cast
 
@@ -55,6 +55,10 @@ class SentCursorError(MobileStorageError):
 
 class CommandConflictError(MobileStorageError):
     """表示同一命令 ID 被用于不同请求。"""
+
+
+class CommandReceiptCapacityError(MobileStorageError):
+    """表示设备命令收据达到数量或字节高水位。"""
 
 
 class AttachmentStateError(MobileStorageError):
@@ -117,11 +121,34 @@ class CommandReceipt:
     command_id: str
     command_type: str
     request_hash: str
-    status: Literal["processing", "completed"]
+    status: Literal["processing", "completed", "outcome_unknown"]
     reply_type: str | None
     reply_payload_json: str | None
     session_id: str | None
     turn_id: str | None
+    created_at: datetime
+    completed_at: datetime | None
+
+
+_COMMAND_RECEIPT_RETENTION = timedelta(days=7)
+_COMMAND_RECEIPT_MAX_COUNT = 10_000
+_COMMAND_RECEIPT_MAX_BYTES = 64 * 1024 * 1024
+_RECEIPT_BYTES_SQL = " + ".join(
+    f"COALESCE(length(CAST({field} AS BLOB)), 0)"
+    for field in (
+        "device_id",
+        "command_id",
+        "command_type",
+        "request_hash",
+        "status",
+        "reply_type",
+        "reply_payload_json",
+        "session_id",
+        "turn_id",
+        "created_at",
+        "completed_at",
+    )
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1475,14 +1502,16 @@ class MobileRealtimeStorage:
         digest = _require_text(request_hash, "request_hash")
         timestamp = _serialize_datetime(created_at, "created_at")
 
-        # 2. 在写事务内复用相同请求，拒绝命令 ID 冲突
+        # 2. 在同一写事务内优先复用现有请求，随后清理并检查设备高水位
         with self._lock, self._db:
             _ = self._db.execute("BEGIN IMMEDIATE")
             _ = self._read_device_row(device_key)
+            self._cleanup_expired_command_receipts_locked(device_key, now=created_at)
             row = self._db.execute(
                 """
                 SELECT device_id, command_id, command_type, request_hash,
-                       status, reply_type, reply_payload_json, session_id, turn_id
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
                 FROM mobile_command_receipts
                 WHERE device_id = ? AND command_id = ?
                 """,
@@ -1498,6 +1527,27 @@ class MobileRealtimeStorage:
                         f"命令 ID 已绑定其他请求: {device_key}/{command_key}"
                     )
                 return receipt, False
+            count, size = self._command_receipt_usage_locked(device_key)
+            projected_size = _receipt_row_bytes(
+                device_id=device_key,
+                command_id=command_key,
+                command_type=command_name,
+                request_hash=digest,
+                status="processing",
+                reply_type=None,
+                reply_payload_json=None,
+                session_id=None,
+                turn_id=None,
+                created_at=timestamp,
+                completed_at=None,
+            )
+            if count >= _COMMAND_RECEIPT_MAX_COUNT or (
+                size + projected_size > _COMMAND_RECEIPT_MAX_BYTES
+            ):
+                raise CommandReceiptCapacityError(
+                    "mobile command receipt capacity reached: "
+                    f"device={device_key} count={count} bytes={size}"
+                )
             _ = self._db.execute(
                 """
                 INSERT INTO mobile_command_receipts(
@@ -1517,7 +1567,97 @@ class MobileRealtimeStorage:
             reply_payload_json=None,
             session_id=None,
             turn_id=None,
+            created_at=created_at,
+            completed_at=None,
         ), True
+
+    def cleanup_command_receipts(
+        self,
+        *,
+        device_id: str,
+        now: datetime,
+    ) -> int:
+        """删除已过保留期的 completed 收据并返回删除数量。"""
+
+        device_key = _require_text(device_id, "device_id")
+        _ = _serialize_datetime(now, "now")
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            _ = self._read_device_row(device_key)
+            return self._cleanup_expired_command_receipts_locked(
+                device_key,
+                now=now,
+            )
+
+    def mark_command_outcome_unknown(
+        self,
+        *,
+        device_id: str,
+        command_id: str,
+    ) -> CommandReceipt:
+        """把无法核对外部效果的 processing 收据持久化为 outcome_unknown。"""
+
+        device_key = _require_text(device_id, "device_id")
+        command_key = _require_text(command_id, "command_id")
+        with self._lock, self._db:
+            _ = self._db.execute("BEGIN IMMEDIATE")
+            updated = self._db.execute(
+                """
+                UPDATE mobile_command_receipts
+                SET status = 'outcome_unknown'
+                WHERE device_id = ? AND command_id = ? AND status = 'processing'
+                """,
+                (device_key, command_key),
+            )
+            if updated.rowcount != 1:
+                raise MobileStorageError(
+                    f"命令收据不处于 processing: {device_key}/{command_key}"
+                )
+            row = self._db.execute(
+                """
+                SELECT device_id, command_id, command_type, request_hash,
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
+                FROM mobile_command_receipts
+                WHERE device_id = ? AND command_id = ?
+                """,
+                (device_key, command_key),
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("已标记 outcome_unknown 的收据在同一事务中消失")
+        return _command_receipt_from_row(row)
+
+    def _cleanup_expired_command_receipts_locked(
+        self,
+        device_id: str,
+        *,
+        now: datetime,
+    ) -> int:
+        cutoff = now - _COMMAND_RECEIPT_RETENTION
+        cutoff_text = _serialize_datetime(cutoff, "cutoff")
+        deleted = self._db.execute(
+            """
+            DELETE FROM mobile_command_receipts
+            WHERE device_id = ? AND status = 'completed'
+              AND completed_at IS NOT NULL AND completed_at < ?
+            """,
+            (device_id, cutoff_text),
+        )
+        return deleted.rowcount
+
+    def _command_receipt_usage_locked(self, device_id: str) -> tuple[int, int]:
+        row = self._db.execute(
+            f"""
+            SELECT COUNT(*) AS count,
+                   COALESCE(SUM({_RECEIPT_BYTES_SQL}), 0) AS bytes
+            FROM mobile_command_receipts
+            WHERE device_id = ?
+            """,
+            (device_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("命令收据用量查询无结果")
+        return int(row["count"]), int(row["bytes"])
 
     def complete_command(
         self,
@@ -1542,6 +1682,61 @@ class MobileRealtimeStorage:
         # 2. 只允许 processing 收据推进为 completed
         with self._lock, self._db:
             _ = self._db.execute("BEGIN IMMEDIATE")
+            existing = self._db.execute(
+                """
+                SELECT device_id, command_id, command_type, request_hash,
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
+                FROM mobile_command_receipts
+                WHERE device_id = ? AND command_id = ?
+                """,
+                (device_key, command_key),
+            ).fetchone()
+            if existing is None:
+                raise MobileStorageError(
+                    f"命令收据不存在: {device_key}/{command_key}"
+                )
+            current = _command_receipt_from_row(existing)
+            if current.status != "processing":
+                raise MobileStorageError(
+                    f"命令收据不处于 processing: {device_key}/{command_key}"
+                )
+            self._cleanup_expired_command_receipts_locked(
+                device_key,
+                now=completed_at,
+            )
+            _count, size = self._command_receipt_usage_locked(device_key)
+            current_size = _receipt_row_bytes(
+                device_id=current.device_id,
+                command_id=current.command_id,
+                command_type=current.command_type,
+                request_hash=current.request_hash,
+                status=current.status,
+                reply_type=current.reply_type,
+                reply_payload_json=current.reply_payload_json,
+                session_id=current.session_id,
+                turn_id=current.turn_id,
+                created_at=_serialize_datetime(current.created_at, "created_at"),
+                completed_at=None,
+            )
+            projected_size = _receipt_row_bytes(
+                device_id=current.device_id,
+                command_id=current.command_id,
+                command_type=current.command_type,
+                request_hash=current.request_hash,
+                status="completed",
+                reply_type=reply_name,
+                reply_payload_json=payload,
+                session_id=session_id,
+                turn_id=turn_id,
+                created_at=_serialize_datetime(current.created_at, "created_at"),
+                completed_at=timestamp,
+            )
+            if size - current_size + projected_size > _COMMAND_RECEIPT_MAX_BYTES:
+                raise CommandReceiptCapacityError(
+                    "mobile command receipt byte capacity reached: "
+                    f"device={device_key} bytes={size}"
+                )
             updated = self._db.execute(
                 """
                 UPDATE mobile_command_receipts
@@ -1566,7 +1761,8 @@ class MobileRealtimeStorage:
             row = self._db.execute(
                 """
                 SELECT device_id, command_id, command_type, request_hash,
-                       status, reply_type, reply_payload_json, session_id, turn_id
+                       status, reply_type, reply_payload_json, session_id, turn_id,
+                       created_at, completed_at
                 FROM mobile_command_receipts
                 WHERE device_id = ? AND command_id = ?
                 """,
@@ -1663,7 +1859,9 @@ class MobileRealtimeStorage:
                 command_id TEXT NOT NULL,
                 command_type TEXT NOT NULL,
                 request_hash TEXT NOT NULL,
-                status TEXT NOT NULL CHECK(status IN ('processing', 'completed')),
+                status TEXT NOT NULL CHECK(
+                    status IN ('processing', 'completed', 'outcome_unknown')
+                ),
                 reply_type TEXT,
                 reply_payload_json TEXT,
                 session_id TEXT,
@@ -1672,7 +1870,8 @@ class MobileRealtimeStorage:
                 completed_at TEXT,
                 PRIMARY KEY(device_id, command_id),
                 CHECK(
-                    (status = 'processing' AND reply_type IS NULL
+                    ((status IN ('processing', 'outcome_unknown'))
+                     AND reply_type IS NULL
                      AND reply_payload_json IS NULL AND completed_at IS NULL)
                     OR
                     (status = 'completed' AND reply_type IS NOT NULL
@@ -1732,6 +1931,76 @@ class MobileRealtimeStorage:
             """
         )
         self._db.commit()
+        self._migrate_command_receipt_status()
+
+    def _migrate_command_receipt_status(self) -> None:
+        """把旧版 receipt CHECK 约束升级为可持久化 outcome_unknown。"""
+
+        row = self._db.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'mobile_command_receipts'"
+        ).fetchone()
+        if row is None or not isinstance(row[0], str):
+            raise RuntimeError("mobile_command_receipts schema 不存在")
+        if "outcome_unknown" in row[0]:
+            return
+        with self._lock:
+            try:
+                _ = self._db.execute("BEGIN IMMEDIATE")
+                _ = self._db.execute(
+                    "ALTER TABLE mobile_command_receipts "
+                    "RENAME TO mobile_command_receipts_legacy"
+                )
+                _ = self._db.execute(
+                    """
+                    CREATE TABLE mobile_command_receipts (
+                        device_id TEXT NOT NULL,
+                        command_id TEXT NOT NULL,
+                        command_type TEXT NOT NULL,
+                        request_hash TEXT NOT NULL,
+                        status TEXT NOT NULL CHECK(
+                            status IN ('processing', 'completed', 'outcome_unknown')
+                        ),
+                        reply_type TEXT,
+                        reply_payload_json TEXT,
+                        session_id TEXT,
+                        turn_id TEXT,
+                        created_at TEXT NOT NULL,
+                        completed_at TEXT,
+                        PRIMARY KEY(device_id, command_id),
+                        CHECK(
+                            ((status IN ('processing', 'outcome_unknown'))
+                             AND reply_type IS NULL
+                             AND reply_payload_json IS NULL
+                             AND completed_at IS NULL)
+                            OR
+                            (status = 'completed' AND reply_type IS NOT NULL
+                             AND reply_payload_json IS NOT NULL
+                             AND completed_at IS NOT NULL)
+                        ),
+                        FOREIGN KEY(device_id) REFERENCES mobile_devices(device_id)
+                            ON DELETE CASCADE
+                    )
+                    """
+                )
+                _ = self._db.execute(
+                    """
+                    INSERT INTO mobile_command_receipts(
+                        device_id, command_id, command_type, request_hash,
+                        status, reply_type, reply_payload_json, session_id, turn_id,
+                        created_at, completed_at
+                    )
+                    SELECT device_id, command_id, command_type, request_hash,
+                           status, reply_type, reply_payload_json, session_id, turn_id,
+                           created_at, completed_at
+                    FROM mobile_command_receipts_legacy
+                    """
+                )
+                _ = self._db.execute("DROP TABLE mobile_command_receipts_legacy")
+                self._db.commit()
+            except sqlite3.Error:
+                self._db.rollback()
+                raise
 
     def _insert_device(self, device: DeviceRecord) -> None:
         if device.revoked_at is not None:
@@ -1852,7 +2121,7 @@ def _device_from_row(row: sqlite3.Row) -> DeviceRecord:
 
 def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
     status = _row_text(row, "status")
-    if status not in {"processing", "completed"}:
+    if status not in {"processing", "completed", "outcome_unknown"}:
         raise ValueError(f"mobile_command_receipts.status 非法: {status}")
     optional: dict[str, str | None] = {}
     for field in ("reply_type", "reply_payload_json", "session_id", "turn_id"):
@@ -1860,11 +2129,11 @@ def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
         if value is not None and not isinstance(value, str):
             raise TypeError(f"mobile_command_receipts.{field} 必须为文本或 NULL")
         optional[field] = value
-    if status == "processing" and (
+    if status in {"processing", "outcome_unknown"} and (
         optional["reply_type"] is not None
         or optional["reply_payload_json"] is not None
     ):
-        raise ValueError("processing 命令收据包含回复")
+        raise ValueError(f"{status} 命令收据包含回复")
     if status == "completed" and (
         not optional["reply_type"] or not optional["reply_payload_json"]
     ):
@@ -1874,12 +2143,61 @@ def _command_receipt_from_row(row: sqlite3.Row) -> CommandReceipt:
         command_id=_row_text(row, "command_id"),
         command_type=_row_text(row, "command_type"),
         request_hash=_row_text(row, "request_hash"),
-        status=cast(Literal["processing", "completed"], status),
+        status=cast(
+            Literal["processing", "completed", "outcome_unknown"],
+            status,
+        ),
         reply_type=optional["reply_type"],
         reply_payload_json=optional["reply_payload_json"],
         session_id=optional["session_id"],
         turn_id=optional["turn_id"],
+        created_at=_parse_datetime(_row_text(row, "created_at"), "created_at"),
+        completed_at=_optional_row_datetime(row, "completed_at"),
     )
+
+
+def _receipt_row_bytes(
+    *,
+    device_id: str,
+    command_id: str,
+    command_type: str,
+    request_hash: str,
+    status: str,
+    reply_type: str | None,
+    reply_payload_json: str | None,
+    session_id: str | None,
+    turn_id: str | None,
+    created_at: str,
+    completed_at: str | None,
+) -> int:
+    """按 SQLite 文本字段的 UTF-8 字节数计算单条收据占用。"""
+
+    return sum(
+        len(value.encode("utf-8"))
+        for value in (
+            device_id,
+            command_id,
+            command_type,
+            request_hash,
+            status,
+            reply_type,
+            reply_payload_json,
+            session_id,
+            turn_id,
+            created_at,
+            completed_at,
+        )
+        if value is not None
+    )
+
+
+def _optional_row_datetime(row: sqlite3.Row, field: str) -> datetime | None:
+    value = row[field]
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"SQLite 字段 {field} 必须为文本或 NULL")
+    return _parse_datetime(value, field)
 
 
 def _attachment_from_row(row: sqlite3.Row) -> AttachmentRecord:

--- a/session/store.py
+++ b/session/store.py
@@ -432,34 +432,87 @@ class SessionStore:
         )
         if not all(isinstance(value, str) and value for value in fields if value is not None):
             raise ValueError("inbound handoff fields must be non-empty strings")
+        identity = {
+            "dedupe_key": dedupe_key,
+            "channel": channel,
+            "sender": sender,
+            "chat_id": chat_id,
+            "session_key": session_key,
+            "content": content,
+            "timestamp": timestamp,
+            "media_json": media_json,
+            "metadata_json": metadata_json,
+        }
+        stable_identity = {
+            key: value for key, value in identity.items() if key != "timestamp"
+        }
+
+        def validate_existing(row: sqlite3.Row, *, include_timestamp: bool) -> None:
+            expected_identity = identity if include_timestamp else stable_identity
+            for column, expected in expected_identity.items():
+                if row[column] != expected:
+                    raise RuntimeError(
+                        "inbound handoff identity conflict: "
+                        f"handoff_id={handoff_id} field={column}"
+                    )
+
         with self._lock:
+            existing_by_id = self._conn.execute(
+                "SELECT * FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            ).fetchone()
             if dedupe_key is not None:
-                existing = self._conn.execute(
-                    "SELECT handoff_id FROM inbound_handoffs WHERE dedupe_key = ?",
+                existing_by_dedupe = self._conn.execute(
+                    "SELECT * FROM inbound_handoffs WHERE dedupe_key = ?",
                     (dedupe_key,),
                 ).fetchone()
-                if existing is not None:
-                    return str(existing["handoff_id"]), False
-            self._conn.execute(
+            else:
+                existing_by_dedupe = None
+            if (
+                existing_by_id is not None
+                and existing_by_dedupe is not None
+                and existing_by_id["handoff_id"] != existing_by_dedupe["handoff_id"]
+            ):
+                raise RuntimeError(
+                    "inbound handoff identity conflict: handoff_id and dedupe_key differ"
+                )
+            existing = existing_by_id or existing_by_dedupe
+            if existing is not None:
+                validate_existing(existing, include_timestamp=existing_by_id is not None)
+                return str(existing["handoff_id"]), False
+            cursor = self._conn.execute(
                 """
                 INSERT INTO inbound_handoffs(
                     handoff_id, dedupe_key, channel, sender, chat_id,
                     session_key, content, timestamp, media_json,
                     metadata_json, created_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(handoff_id) DO NOTHING
+                ON CONFLICT DO NOTHING
                 """,
                 fields,
             )
             row = self._conn.execute(
-                "SELECT handoff_id FROM inbound_handoffs WHERE handoff_id = ?",
+                "SELECT * FROM inbound_handoffs WHERE handoff_id = ?",
                 (handoff_id,),
             ).fetchone()
+            if row is None and dedupe_key is not None:
+                row = self._conn.execute(
+                    "SELECT * FROM inbound_handoffs WHERE dedupe_key = ?",
+                    (dedupe_key,),
+                ).fetchone()
             if row is None:
                 self._conn.rollback()
                 raise RuntimeError(f"inbound handoff disappeared: {handoff_id}")
-            self._conn.commit()
-            return str(row["handoff_id"]), True
+            try:
+                validate_existing(
+                    row,
+                    include_timestamp=row["handoff_id"] == handoff_id,
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
+            return str(row["handoff_id"]), cursor.rowcount == 1
 
     def list_inbound_handoffs(
         self,

--- a/session/store.py
+++ b/session/store.py
@@ -338,6 +338,25 @@ class SessionStore:
                 )
                 """)
             self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS inbound_handoffs (
+                    handoff_id  TEXT PRIMARY KEY,
+                    dedupe_key  TEXT UNIQUE,
+                    channel     TEXT NOT NULL,
+                    sender      TEXT NOT NULL,
+                    chat_id     TEXT NOT NULL,
+                    session_key TEXT NOT NULL,
+                    content     TEXT NOT NULL,
+                    timestamp   TEXT NOT NULL,
+                    media_json  TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    created_at  TEXT NOT NULL
+                )
+                """)
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_inbound_handoffs_session
+                ON inbound_handoffs(session_key, created_at)
+                """)
+            self._conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_session_admissions_session
                 ON session_admissions(session_key)
                 """)
@@ -379,6 +398,127 @@ class SessionStore:
                 """)
             self._ensure_next_seq_values()
             self._ensure_fts()
+            self._conn.commit()
+
+    def reserve_inbound_handoff(
+        self,
+        *,
+        handoff_id: str,
+        dedupe_key: str | None,
+        channel: str,
+        sender: str,
+        chat_id: str,
+        session_key: str,
+        content: str,
+        timestamp: str,
+        media_json: str,
+        metadata_json: str,
+        created_at: str,
+    ) -> tuple[str, bool]:
+        """Durably reserve one inbound message before exposing it to MessageBus."""
+
+        fields = (
+            handoff_id,
+            dedupe_key,
+            channel,
+            sender,
+            chat_id,
+            session_key,
+            content,
+            timestamp,
+            media_json,
+            metadata_json,
+            created_at,
+        )
+        if not all(isinstance(value, str) and value for value in fields if value is not None):
+            raise ValueError("inbound handoff fields must be non-empty strings")
+        with self._lock:
+            if dedupe_key is not None:
+                existing = self._conn.execute(
+                    "SELECT handoff_id FROM inbound_handoffs WHERE dedupe_key = ?",
+                    (dedupe_key,),
+                ).fetchone()
+                if existing is not None:
+                    return str(existing["handoff_id"]), False
+            self._conn.execute(
+                """
+                INSERT INTO inbound_handoffs(
+                    handoff_id, dedupe_key, channel, sender, chat_id,
+                    session_key, content, timestamp, media_json,
+                    metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(handoff_id) DO NOTHING
+                """,
+                fields,
+            )
+            row = self._conn.execute(
+                "SELECT handoff_id FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            ).fetchone()
+            if row is None:
+                self._conn.rollback()
+                raise RuntimeError(f"inbound handoff disappeared: {handoff_id}")
+            self._conn.commit()
+            return str(row["handoff_id"]), True
+
+    def list_inbound_handoffs(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, str | None]]:
+        """按 durable 到达顺序读取有限页的 pending inbound handoff。"""
+
+        if limit is not None and (
+            not isinstance(limit, int) or isinstance(limit, bool) or limit < 1
+        ):
+            raise ValueError("inbound handoff limit 必须是正整数")
+        limit_sql = "" if limit is None else " LIMIT ?"
+
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT handoff_id, dedupe_key, channel, sender, chat_id,
+                       session_key, content, timestamp, media_json,
+                       metadata_json, created_at
+                FROM inbound_handoffs
+                ORDER BY created_at ASC, handoff_id ASC
+                """ + limit_sql,
+                () if limit is None else (limit,),
+            ).fetchall()
+        return [
+            {key: cast(str | None, row[key]) for key in row.keys()}
+            for row in rows
+        ]
+
+    def has_inbound_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        """Check whether a client message still owns an uncompleted handoff."""
+
+        dedupe_key = f"{session_key}:{client_message_id}"
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM inbound_handoffs WHERE dedupe_key = ?",
+                (dedupe_key,),
+            ).fetchone()
+        return row is not None
+
+    def complete_inbound_handoff(self, handoff_id: str) -> None:
+        """Release a handoff only after its worker has finished processing."""
+
+        if not isinstance(handoff_id, str) or not handoff_id:
+            raise ValueError("handoff_id must be a non-empty string")
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM inbound_handoffs WHERE handoff_id = ?",
+                (handoff_id,),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise RuntimeError(f"inbound handoff not found: {handoff_id}")
             self._conn.commit()
 
     def _ensure_session_columns(self) -> None:

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -12,6 +12,7 @@ from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
 from bootstrap.passive_worker import PassiveMessageWorker
 from bus.events import InboundMessage, OutboundMessage
+from bus.queue import MessageBus
 from session.manager import SessionManager
 from session.store import SessionStore
 
@@ -25,6 +26,9 @@ class _Bus:
 
     async def consume_inbound(self) -> InboundMessage:
         return await self.inbound.get()
+
+    async def recover_durable_inbounds(self) -> None:
+        return None
 
     async def publish_outbound(self, message: OutboundMessage) -> None:
         self.outbound.append(message)
@@ -98,6 +102,39 @@ async def test_channel_adapter_releases_session_admission_after_completion(
     assert dashboard_store.delete_session(session_key, cascade=True)
     dashboard_store.close()
     await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_recovered_mobile_handoff_with_canonical_user_skips_new_turn(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:existing"
+    session = manager.get_or_create(session_key)
+    session.add_message("user", "hello", client_message_id="client:1")
+    manager.save(session)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(manager.control_store)
+    inbound = InboundMessage(
+        "mobile",
+        "device:1",
+        "existing",
+        "hello",
+        metadata={"session_key_override": session_key, "client_message_id": "client:1"},
+    )
+    await bus.publish_inbound(inbound)
+    recovered = await bus.consume_inbound()
+    worker = PassiveMessageWorker(
+        bus,
+        cast(Any, object()),
+        cast(Any, SimpleNamespace(session_manager=manager)),
+    )
+
+    await worker._run_message(recovered)
+
+    assert manager.control_store.list_turns(session_key) == []
+    assert manager.control_store.list_inbound_handoffs() == []
     manager.close()
 
 

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -131,6 +131,7 @@ async def test_recovered_mobile_handoff_with_canonical_user_skips_new_turn(
         cast(Any, SimpleNamespace(session_manager=manager)),
     )
 
+    assert isinstance(recovered, InboundMessage)
     await worker._run_message(recovered)
 
     assert manager.control_store.list_turns(session_key) == []

--- a/tests/control/test_d8_control_admission_replay.py
+++ b/tests/control/test_d8_control_admission_replay.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.control.errors import ControlAdmissionError
+from agent.control.models import TurnRequest, TurnStatus
+from agent.control.ports import ControlExecutionResult
+from agent.control.runtime import ConversationRuntime
+from agent.control.protocol.errors import SERVER_OVERLOADED
+from agent.control.protocol.router import ConnectionRouter
+from agent.control.service import ControlService
+from session.store import SessionStore
+from session.manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_control_admission_rejects_only_current_start_and_releases_after_terminal(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(request: TurnRequest) -> str:
+        started.set()
+        await release.wait()
+        return request.input
+
+    runtime = ConversationRuntime(store, execute, max_active_turns=1)
+    first = await runtime.start_turn(TurnRequest("programmatic:one", "one"))
+    await started.wait()
+
+    with pytest.raises(ControlAdmissionError, match="resource-exhausted"):
+        await runtime.start_turn(TurnRequest("programmatic:two", "two"))
+    assert store.list_turns("programmatic:two", limit=10) == []
+    assert runtime.admission_snapshot()["turns"] == 1
+
+    release.set()
+    assert (await first.result()).status is TurnStatus.COMPLETED
+    assert runtime.admission_snapshot()["turns"] == 0
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_immediate_queued_interrupt_releases_control_admission(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(request: TurnRequest) -> str:
+        return request.input
+
+    runtime = ConversationRuntime(store, execute, max_active_turns=1)
+    handle = await runtime.start_turn(TurnRequest("programmatic:queued", "hello"))
+    record = await handle.interrupt()
+    assert record.status is TurnStatus.CANCELLED
+    assert runtime.admission_snapshot()["turns"] == 0
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_router_maps_control_capacity_to_existing_overloaded_error(
+    tmp_path: Path,
+) -> None:
+    sessions = SessionManager(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(request: TurnRequest) -> str:
+        started.set()
+        await release.wait()
+        return request.input
+
+    runtime = ConversationRuntime(sessions.control_store, execute, max_active_turns=1)
+    service = ControlService(runtime, sessions, tmp_path)
+    sent: list[dict[str, object]] = []
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    router = ConnectionRouter(service, send)
+    await router.handle_line(
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":'
+        b'{"protocolVersion":"1.0","clientInfo":{"name":"test","version":"1"}}}\n'
+    )
+    await router.handle_line(b'{"jsonrpc":"2.0","method":"initialized","params":{}}\n')
+    first_thread = service.start_thread({})["id"]
+    second_thread = service.start_thread({})["id"]
+    await router.handle_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "turn/start",
+                "params": {"threadId": first_thread, "input": "first", "metadata": {}},
+            }
+        ).encode()
+        + b"\n"
+    )
+    await started.wait()
+    await router.handle_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "turn/start",
+                "params": {"threadId": second_thread, "input": "second", "metadata": {}},
+            }
+        ).encode()
+        + b"\n"
+    )
+    response = next(item for item in sent if item.get("id") == 3)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == SERVER_OVERLOADED
+    assert "resource-exhausted" in error["message"]
+    assert error["data"] == {"retryable": True, "failure": "operation_rejected"}
+    assert sessions.control_store.list_turns(str(second_thread), limit=10) == []
+    release.set()
+    await router.close()
+    await runtime.shutdown()
+    sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_eviction_reports_snapshot_without_dropping_live_events(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    deltas = [f"d{index}" for index in range(8)]
+
+    async def execute(_request: TurnRequest) -> ControlExecutionResult:
+        return ControlExecutionResult("".join(deltas), deltas=deltas)
+
+    runtime = ConversationRuntime(
+        store,
+        execute,
+        replay_events_per_turn=4,
+        replay_bytes_per_turn=4096,
+        replay_bytes_global=4096,
+    )
+    handle = await runtime.start_turn(TurnRequest("programmatic:replay", "hello"))
+    live_events = [event async for event in handle.events()]
+    assert len([event for event in live_events if event.method == "item/assistantMessage/delta"]) == 8
+    assert live_events[-1].method == "turn/completed"
+
+    replay_events = [event async for event in handle.events()]
+    assert replay_events[0].method == "replay/truncated"
+    assert replay_events[0].data["replay_status"] == "replay_truncated"
+    assert replay_events[0].data["snapshot"]["status"] == "completed"
+    assert replay_events[-1].method == "turn/completed"
+    assert len(runtime._history[handle.id]) <= 4
+    assert store.read_turn(handle.id) is not None
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_global_replay_index_has_no_stale_nodes_after_multi_turn_eviction(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> ControlExecutionResult:
+        return ControlExecutionResult("x" * 64, deltas=["x" * 8] * 10)
+
+    runtime = ConversationRuntime(
+        store,
+        execute,
+        replay_events_per_turn=4,
+        replay_bytes_per_turn=4096,
+        replay_bytes_global=1024,
+    )
+    handles = []
+    for index in range(8):
+        handle = await runtime.start_turn(TurnRequest(f"programmatic:multi-{index}", "hello"))
+        handles.append(handle)
+        await handle.result()
+
+    retained_events = sum(len(history) for history in runtime._history.values())
+    assert len(runtime._replay_order) == retained_events
+    assert runtime.replay_bytes <= 1024
+    assert all(
+        key in runtime._replay_order
+        for turn_id, sequences in runtime._history_sequences.items()
+        for key in ((turn_id, sequence) for sequence in sequences)
+    )
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_replay_expiry_reads_authoritative_store_snapshot(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> str:
+        return "done"
+
+    runtime = ConversationRuntime(store, execute, terminal_replay_ttl_seconds=0.001)
+    handle = await runtime.start_turn(TurnRequest("programmatic:expired", "hello"))
+    assert (await handle.result()).status is TurnStatus.COMPLETED
+    await asyncio.sleep(0.01)
+
+    replay_events = [event async for event in handle.events()]
+    assert replay_events[0].method == "replay/expired"
+    assert replay_events[0].data["replay_status"] == "replay_expired"
+    assert replay_events[0].data["snapshot"]["status"] == "completed"
+    assert runtime._history.get(handle.id) is None
+    assert store.read_turn(handle.id) is not None
+    await runtime.shutdown()
+    store.close()

--- a/tests/control/test_d8_control_admission_replay.py
+++ b/tests/control/test_d8_control_admission_replay.py
@@ -213,3 +213,59 @@ async def test_terminal_replay_expiry_reads_authoritative_store_snapshot(tmp_pat
     assert store.read_turn(handle.id) is not None
     await runtime.shutdown()
     store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_replay_reaper_evicts_without_followup_activity(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> str:
+        return "done"
+
+    runtime = ConversationRuntime(store, execute, terminal_replay_ttl_seconds=0.01)
+    handle = await runtime.start_turn(TurnRequest("programmatic:reaper", "hello"))
+    assert (await handle.result()).status is TurnStatus.COMPLETED
+    reaper = runtime._replay_reaper_task
+    assert reaper is not None
+
+    for _ in range(100):
+        if handle.id not in runtime._history:
+            break
+        await asyncio.sleep(0.005)
+
+    assert handle.id not in runtime._history
+    assert handle.id not in runtime._results
+    assert handle.id not in runtime._subscribers
+    assert handle.id not in runtime._terminal_replay_expiry
+    assert store.read_turn(handle.id) is not None
+    await runtime.shutdown()
+    assert reaper.done()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_replay_reaper_surfaces_index_corruption(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> str:
+        return "done"
+
+    runtime = ConversationRuntime(store, execute, terminal_replay_ttl_seconds=0.01)
+    handle = await runtime.start_turn(TurnRequest("programmatic:corrupt-replay", "hello"))
+    assert (await handle.result()).status is TurnStatus.COMPLETED
+    reaper = runtime._replay_reaper_task
+    assert reaper is not None
+    runtime._history_sequences[handle.id].clear()
+
+    with caplog.at_level("CRITICAL", logger="agent.control.runtime"):
+        with pytest.raises(RuntimeError, match="control replay index corrupted"):
+            await asyncio.wait_for(asyncio.shield(reaper), timeout=1)
+    assert "event=runtime_fatal owner=control.replay_reaper" in caplog.text
+    assert runtime._replay_reaper_error is not None
+    with pytest.raises(RuntimeError, match="control replay reaper failed"):
+        await runtime.shutdown()
+    assert store.read_turn(handle.id) is not None
+    store.close()

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -87,12 +87,21 @@ class _Bus:
     def __init__(self) -> None:
         self.inbound: list[object] = []
         self.outbound: dict[str, object] = {}
+        self.pending_handoff = False
 
     async def publish_inbound(self, message: object) -> None:
         self.inbound.append(message)
 
     def subscribe_outbound(self, channel: str, callback: object) -> None:
         self.outbound[channel] = callback
+
+    def has_pending_mobile_handoff(
+        self,
+        *,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        return self.pending_handoff
 
 
 class _FailingBus(_Bus):
@@ -863,6 +872,69 @@ async def test_message_send_marks_prestart_processing_receipt_retryable(
     assert result == replayed
     assert result.type == "message.send.error"
     assert result.payload["code"] == "command_interrupted"
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_message_send_pending_handoff_stays_in_progress_until_user_reconciles(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"mobile:{uuid4()}"
+    frame = _message_frame(
+        frame_id="01ARZ3NDEKSTV4RRFFQ69G5FAY",
+        session_id=session_id,
+    )
+    _, created = storage.reserve_command(
+        device_id=device_id,
+        command_id=frame.id,
+        command_type=frame.type,
+        request_hash=channel_module._command_hash(frame),
+        created_at=datetime.now(timezone.utc),
+    )
+    assert created
+    bus = _Bus()
+    bus.pending_handoff = True
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=bus,
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+
+    pending = await channel.handle_command(device_id=device_id, frame=frame)
+    assert pending.type == "message.send.error"
+    assert pending.payload["code"] == "command_in_progress"
+    receipt = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts WHERE device_id = ? AND command_id = ?",
+        (device_id, frame.id),
+    ).fetchone()
+    assert receipt is not None and receipt[0] == "processing"
+
+    session = manager.get_or_create(session_id)
+    session.add_message("user", frame.payload.text, client_message_id=frame.id)
+    manager.save(session)
+    bus.pending_handoff = False
+    completed = await channel.handle_command(device_id=device_id, frame=frame)
+    assert completed.type == "message.send.ok"
+    receipt = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts WHERE device_id = ? AND command_id = ?",
+        (device_id, frame.id),
+    ).fetchone()
+    assert receipt is not None and receipt[0] == "completed"
+    manager.close()
     storage.close()
 
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -732,11 +732,48 @@ async def test_message_send_keeps_unknown_outcome_without_persisted_user(
     result = await channel.handle_command(device_id=device_id, frame=frame)
 
     assert result.type == "message.send.error"
-    assert result.payload["code"] == "command_outcome_unknown"
+    assert result.payload["code"] == "command_in_progress"
     assert bus.inbound == []
     release.set()
     completed = await original
     assert completed.type == "message.send.ok"
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_processing_non_message_keeps_active_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
+    frame = _generic_frame(
+        frame_id="01ARZ3NDEKTSV4RRFFQ69G5FB3",
+        command_type="ping",
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute_slowly(
+        *, device_id: str, frame: object
+    ) -> channel_module.CommandReply:
+        started.set()
+        await release.wait()
+        return channel_module.CommandReply(type="ping.ok", payload={})
+
+    monkeypatch.setattr(channel, "_execute_command", execute_slowly)
+    original = asyncio.create_task(
+        channel.handle_command(device_id=device_id, frame=frame)
+    )
+    await started.wait()
+    duplicate = await channel.handle_command(device_id=device_id, frame=frame)
+    assert duplicate.payload["code"] == "command_in_progress"
+    release.set()
+    assert (await original).type == "ping.ok"
+    replay = await channel.handle_command(device_id=device_id, frame=frame)
+    assert replay.type == "ping.ok"
     storage.close()
 
 

--- a/tests/mobile_realtime/test_storage.py
+++ b/tests/mobile_realtime/test_storage.py
@@ -9,10 +9,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+import infra.mobile_realtime.storage as storage_module
 
 from infra.mobile_realtime.storage import (
     AckOverflowError,
     AckRollbackError,
+    CommandConflictError,
+    CommandReceiptCapacityError,
     DeviceRecord,
     MobileRealtimeStorage,
     PairingExpiredError,
@@ -364,3 +367,124 @@ def test_corrupt_sqlite_event_payload_fails_at_row_boundary(
 
     with pytest.raises(TypeError, match="JSON object"):
         storage.read_durable_events("device-1", after_event_seq=0, limit=10)
+
+
+def test_command_receipt_replay_conflict_and_retention(
+    storage: MobileRealtimeStorage,
+) -> None:
+    storage.register_device(_device())
+    old = NOW - timedelta(days=8)
+    receipt, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    assert created and receipt.status == "processing"
+    completed = storage.complete_command(
+        device_id="device-1",
+        command_id="command-1",
+        reply_type="ping.ok",
+        reply_payload_json='{"ok":true}',
+        session_id=None,
+        turn_id=None,
+        completed_at=NOW,
+    )
+    replay, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW + timedelta(days=1),
+    )
+    assert not created and replay == completed
+    with pytest.raises(CommandConflictError):
+        storage.reserve_command(
+            device_id="device-1",
+            command_id="command-1",
+            command_type="ping",
+            request_hash="different",
+            created_at=NOW,
+        )
+
+    _, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-2",
+        command_type="ping",
+        request_hash="hash-2",
+        created_at=old,
+    )
+    assert created
+    storage.complete_command(
+        device_id="device-1",
+        command_id="command-2",
+        reply_type="ping.ok",
+        reply_payload_json='{"ok":true}',
+        session_id=None,
+        turn_id=None,
+        completed_at=old,
+    )
+    replacement, created = storage.reserve_command(
+        device_id="device-1",
+        command_id="command-2",
+        command_type="ping",
+        request_hash="hash-2",
+        created_at=NOW,
+    )
+    assert created and replacement.status == "processing"
+
+
+def test_command_receipt_capacity_cleanup_and_insert_are_bounded(
+    storage: MobileRealtimeStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage.register_device(_device())
+    monkeypatch.setattr(storage_module, "_COMMAND_RECEIPT_MAX_COUNT", 1)
+    storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    with pytest.raises(CommandReceiptCapacityError):
+        storage.reserve_command(
+            device_id="device-1",
+            command_id="command-2",
+            command_type="ping",
+            request_hash="hash-2",
+            created_at=NOW,
+        )
+    assert storage.read_cursor("device-1").next_event_seq == 1
+
+
+def test_command_receipt_completion_rejects_byte_overflow_without_losing_processing(
+    storage: MobileRealtimeStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage.register_device(_device())
+    storage.reserve_command(
+        device_id="device-1",
+        command_id="command-1",
+        command_type="ping",
+        request_hash="hash-1",
+        created_at=NOW,
+    )
+    monkeypatch.setattr(storage_module, "_COMMAND_RECEIPT_MAX_BYTES", 50)
+    with pytest.raises(CommandReceiptCapacityError):
+        storage.complete_command(
+            device_id="device-1",
+            command_id="command-1",
+            reply_type="ping.ok",
+            reply_payload_json='{"result":"' + ("x" * 128) + '"}',
+            session_id=None,
+            turn_id=None,
+            completed_at=NOW,
+        )
+    row = storage._db.execute(
+        "SELECT status FROM mobile_command_receipts "
+        "WHERE device_id = ? AND command_id = ?",
+        ("device-1", "command-1"),
+    ).fetchone()
+    assert row["status"] == "processing"

--- a/tests/test_agent_core_p6_runner.py
+++ b/tests/test_agent_core_p6_runner.py
@@ -12,6 +12,7 @@ from agent.lifecycle.types import TurnPersistencePolicy
 from agent.looping.ports import SessionServices
 from agent.tools.registry import ToolRegistry
 from agent.core.runner import CoreRunner, CoreRunnerDeps
+from agent.control.context import current_turn_id
 from bus.events import InboundMessage, OutboundMessage, SpawnCompletionItem
 from bus.internal_events import SpawnCompletionEvent
 
@@ -106,7 +107,11 @@ async def test_core_runner_handles_spawn_completion_via_direct_helper_deps():
         ),
     )
 
-    out = await runner.process(item, "scheduler:job-1", dispatch_outbound=False)
+    turn_token = current_turn_id.set("turn:spawn-completion")
+    try:
+        out = await runner.process(item, "scheduler:job-1", dispatch_outbound=False)
+    finally:
+        current_turn_id.reset(turn_token)
 
     assert out.content == "spawn done"
     session_svc.session_manager.get_or_create.assert_called_once_with("scheduler:job-1")
@@ -114,6 +119,7 @@ async def test_core_runner_handles_spawn_completion_via_direct_helper_deps():
         channel="telegram",
         chat_id="123",
         session_key="scheduler:job-1",
+        turn_id="turn:spawn-completion",
         current_timestamp=item.timestamp.isoformat(),
     )
     prompt_render_fn.assert_awaited_once()

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 import json
 import sqlite3
+import shutil
 import threading
 import tomllib
 from datetime import datetime
@@ -53,6 +54,33 @@ def _isolate_dashboard_plugin_home(monkeypatch: pytest.MonkeyPatch) -> None:
     """让 Dashboard 测试只观察各自声明的 HOME/manifest。"""
 
     monkeypatch.delenv("AKASHIC_PLUGIN_HOME", raising=False)
+
+
+def _use_writable_dashboard_plugins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plugin_ids: set[str],
+) -> None:
+    """复制指定插件源码，并为只读 Gate 合成最小测试面板产物。"""
+
+    discovered = _dashboard_plugin_dirs(Path.cwd())
+    missing = plugin_ids - discovered.keys()
+    assert not missing
+    writable: dict[str, Path] = {}
+    for plugin_id in sorted(plugin_ids):
+        target = tmp_path / "dashboard-plugins" / plugin_id
+        shutil.copytree(discovered[plugin_id], target)
+        for source in target.glob("dashboard_panel*.ts*"):
+            source.with_suffix(".js").write_text(
+                "export default {};\n",
+                encoding="utf-8",
+            )
+        writable[plugin_id] = target
+    monkeypatch.setattr(
+        dashboard_api,
+        "_dashboard_plugin_dirs",
+        lambda _project_root: dict(writable),
+    )
 
 
 class _DashboardMemoryAdmin:
@@ -900,6 +928,11 @@ def test_wake_package_owns_dashboard_visibility(tmp_path, monkeypatch) -> None:
         "bootstrap.dashboard_api.load_package_manifest",
         lambda: {"default-proactive": False, "wake-proactive": True},
     )
+    _use_writable_dashboard_plugins(
+        tmp_path,
+        monkeypatch,
+        {"wake-proactive"},
+    )
     with TestClient(create_dashboard_app(tmp_path)) as client:
         plugin_ids = {
             item["id"] for item in client.get("/api/dashboard/plugins").json()
@@ -1035,7 +1068,15 @@ def test_plugin_asset_paths_reject_cross_platform_traversal(tmp_path) -> None:
         assert client.get("/plugins/missing/dashboard_panel.js").status_code == 404
 
 
-def test_memory_engine_plugins_only_expose_active_engine_panels(tmp_path) -> None:
+def test_memory_engine_plugins_only_expose_active_engine_panels(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _use_writable_dashboard_plugins(
+        tmp_path,
+        monkeypatch,
+        {"default_memory"},
+    )
     with TestClient(create_dashboard_app(tmp_path)) as client:
         plugins = client.get("/api/dashboard/plugins").json()
         memory_plugins = {
@@ -1050,7 +1091,15 @@ def test_memory_engine_plugins_only_expose_active_engine_panels(tmp_path) -> Non
         assert client.get("/plugins/cross_memory/dashboard_panel_inspector.js").status_code == 404
 
 
-def test_akasha_only_exposes_read_only_inspector_panel(tmp_path) -> None:
+def test_akasha_only_exposes_read_only_inspector_panel(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _use_writable_dashboard_plugins(
+        tmp_path,
+        monkeypatch,
+        {"akasha"},
+    )
     with TestClient(
         create_dashboard_app(
             tmp_path,

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -48,6 +48,13 @@ class _TrackedTestClient(_RawTestClient):
 TestClient = _TrackedTestClient
 
 
+@pytest.fixture(autouse=True)
+def _isolate_dashboard_plugin_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """让 Dashboard 测试只观察各自声明的 HOME/manifest。"""
+
+    monkeypatch.delenv("AKASHIC_PLUGIN_HOME", raising=False)
+
+
 class _DashboardMemoryAdmin:
     def __init__(self, workspace) -> None:
         self._store = MemoryStore2(workspace / "memory" / "memory2.db")

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -9,72 +9,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from bus.events import InboundMessage, OutboundMessage
-from bus.queue import MessageBus, MessageBusCapacityError
+from bus.events import InboundMessage
+from bus.queue import MessageBus
 from session.manager import SessionManager
 from session.store import SessionStore
-
-
-@pytest.mark.asyncio
-async def test_inbound_capacity_rejection_does_not_leave_chat_lane_pending() -> None:
-    bus = MessageBus(inbound_capacity=1, inbound_bytes=4096)
-    first = InboundMessage("cli", "user", "one", "first")
-    await bus.publish_inbound(first)
-
-    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
-        await bus.publish_inbound(InboundMessage("cli", "user", "two", "second"))
-
-    assert bus.inbound_size == 1
-    assert bus.chat_lane._states[("cli", "one")].passive_turns == 1
-    assert ("cli", "two") not in bus.chat_lane._states
-
-    consumed = await bus.consume_inbound()
-    await bus.complete_inbound(consumed)
-    assert bus.inbound_bytes == 0
-    assert bus.chat_lane._states == {}
-
-
-@pytest.mark.asyncio
-async def test_outbound_capacity_rejection_rolls_back_chat_lane_send_count() -> None:
-    bus = MessageBus(outbound_capacity=1, outbound_bytes=4096)
-    await bus.publish_outbound(OutboundMessage("cli", "one", "first"))
-
-    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
-        await bus.publish_outbound(OutboundMessage("cli", "two", "second"))
-
-    state = bus.chat_lane._states[("cli", "one")]
-    assert state.passive_sends == 1
-    assert ("cli", "two") not in bus.chat_lane._states
-
-    bus._running = True
-    dispatch = asyncio.create_task(bus.dispatch_outbound())
-    await asyncio.sleep(0)
-    bus.stop()
-    dispatch.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await dispatch
-    assert bus.outbound_bytes == 0
-
-
-@pytest.mark.asyncio
-async def test_cancelled_admission_releases_reservation_before_chat_lane_wait() -> None:
-    bus = MessageBus(inbound_capacity=1)
-    blocked = asyncio.Event()
-
-    async def wait_for_admission(_channel: str, _chat_id: str) -> None:
-        await blocked.wait()
-
-    bus.chat_lane.mark_passive_pending = wait_for_admission  # type: ignore[method-assign]
-    publish = asyncio.create_task(
-        bus.publish_inbound(InboundMessage("cli", "user", "one", "first"))
-    )
-    await asyncio.sleep(0)
-    assert bus.inbound_reserved_bytes > 0
-    publish.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await publish
-    assert bus.inbound_reserved_bytes == 0
-    assert bus.inbound_size == 0
 
 
 @pytest.mark.asyncio
@@ -145,7 +83,6 @@ async def test_cleanup_retry_keeps_owner_after_worker_drops_item(tmp_path: Path)
     await asyncio.sleep(0)
     gc.collect()
     assert attempts >= 2
-    assert bus.inbound_bytes == 0
     assert bus._inbound_accepted == {}
     assert bus._inbound_cleanup_tasks == {}
     assert bus.chat_lane._states == {}
@@ -193,7 +130,6 @@ async def test_persistent_cleanup_failure_is_bounded_and_shutdown_cancels_retry(
         await bus.complete_inbound(consumed)
     await asyncio.sleep(0.35)
     assert 2 <= attempts <= 4
-    assert bus.inbound_bytes > 0
     assert len(bus._inbound_accepted) == 1
     assert len(bus._inbound_cleanup_tasks) == 1
     await bus.aclose()

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bus.events import InboundMessage, OutboundMessage
+from bus.queue import MessageBus, MessageBusCapacityError
+from session.manager import SessionManager
+from session.store import SessionStore
+
+
+@pytest.mark.asyncio
+async def test_inbound_capacity_rejection_does_not_leave_chat_lane_pending() -> None:
+    bus = MessageBus(inbound_capacity=1, inbound_bytes=4096)
+    first = InboundMessage("cli", "user", "one", "first")
+    await bus.publish_inbound(first)
+
+    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
+        await bus.publish_inbound(InboundMessage("cli", "user", "two", "second"))
+
+    assert bus.inbound_size == 1
+    assert bus.chat_lane._states[("cli", "one")].passive_turns == 1
+    assert ("cli", "two") not in bus.chat_lane._states
+
+    consumed = await bus.consume_inbound()
+    await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes == 0
+    assert bus.chat_lane._states == {}
+
+
+@pytest.mark.asyncio
+async def test_outbound_capacity_rejection_rolls_back_chat_lane_send_count() -> None:
+    bus = MessageBus(outbound_capacity=1, outbound_bytes=4096)
+    await bus.publish_outbound(OutboundMessage("cli", "one", "first"))
+
+    with pytest.raises(MessageBusCapacityError, match="resource-exhausted"):
+        await bus.publish_outbound(OutboundMessage("cli", "two", "second"))
+
+    state = bus.chat_lane._states[("cli", "one")]
+    assert state.passive_sends == 1
+    assert ("cli", "two") not in bus.chat_lane._states
+
+    bus._running = True
+    dispatch = asyncio.create_task(bus.dispatch_outbound())
+    await asyncio.sleep(0)
+    bus.stop()
+    dispatch.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await dispatch
+    assert bus.outbound_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_releases_reservation_before_chat_lane_wait() -> None:
+    bus = MessageBus(inbound_capacity=1)
+    blocked = asyncio.Event()
+
+    async def wait_for_admission(_channel: str, _chat_id: str) -> None:
+        await blocked.wait()
+
+    bus.chat_lane.mark_passive_pending = wait_for_admission  # type: ignore[method-assign]
+    publish = asyncio.create_task(
+        bus.publish_inbound(InboundMessage("cli", "user", "one", "first"))
+    )
+    await asyncio.sleep(0)
+    assert bus.inbound_reserved_bytes > 0
+    publish.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await publish
+    assert bus.inbound_reserved_bytes == 0
+    assert bus.inbound_size == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retry_keeps_owner_after_worker_drops_item(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:cleanup"
+    manager.save(manager.get_or_create(session_key))
+    _, admission_id = manager.admit_existing(session_key)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "cleanup",
+        "hello",
+        metadata={"session_key_override": session_key, "client_message_id": "client-1"},
+        session_admission_id=admission_id,
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    assert consumed is item
+    item_ref = weakref.ref(item)
+    original_complete = store.complete_inbound_handoff
+    attempts = 0
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("temporary delete failure")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+
+    class _Runtime:
+        async def wait_thread_available(self, _session_key: str) -> None:
+            return None
+
+        async def start_turn(self, _request: object) -> object:
+            raise RuntimeError("worker stopped before turn submission")
+
+    from bootstrap.passive_worker import PassiveMessageWorker
+
+    worker = PassiveMessageWorker(
+        bus,
+        _Runtime(),  # type: ignore[arg-type]
+        SimpleNamespace(session_manager=manager),  # type: ignore[arg-type]
+    )
+    lane = asyncio.Queue()
+    lane.put_nowait(consumed)
+    worker._lane_queues[session_key] = lane
+    lane_task = asyncio.create_task(worker._run_lane(session_key, lane))
+    await lane_task
+    assert manager.control_store.list_turns(session_key) == []
+    owner_key = id(item)
+    assert owner_key in bus._inbound_accepted
+    del consumed
+    del item
+    gc.collect()
+    assert item_ref() is not None
+
+    async def cleanup_finished() -> None:
+        while store.list_inbound_handoffs():
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(cleanup_finished(), timeout=1)
+    await asyncio.sleep(0)
+    gc.collect()
+    assert attempts >= 2
+    assert bus.inbound_bytes == 0
+    assert bus._inbound_accepted == {}
+    assert bus._inbound_cleanup_tasks == {}
+    assert bus.chat_lane._states == {}
+    replacement = InboundMessage(
+        "mobile",
+        "device:1",
+        "cleanup",
+        "replacement",
+        metadata={"session_key_override": session_key, "client_message_id": "client-2"},
+        session_admission_id=admission_id,
+    )
+    await bus.publish_inbound(replacement)
+    assert bus._inbound_accepted[id(replacement)].item is replacement
+    await bus.complete_inbound(replacement)
+    await bus.aclose()
+    manager.close()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_cleanup_failure_is_bounded_and_shutdown_cancels_retry(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "persistent",
+        "hello",
+        metadata={"client_message_id": "client-persistent"},
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    attempts = 0
+
+    def always_fail(_handoff_id: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError("persistent delete failure")
+
+    store.complete_inbound_handoff = always_fail  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="persistent delete failure"):
+        await bus.complete_inbound(consumed)
+    await asyncio.sleep(0.35)
+    assert 2 <= attempts <= 4
+    assert bus.inbound_bytes > 0
+    assert len(bus._inbound_accepted) == 1
+    assert len(bus._inbound_cleanup_tasks) == 1
+    await bus.aclose()
+    assert bus._inbound_cleanup_tasks == {}
+    assert store._conn.execute(
+        "SELECT 1 FROM inbound_handoffs WHERE handoff_id = ?",
+        (consumed.handoff_id,),
+    ).fetchone() is not None
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_finalize_failure_is_fatal_and_observable(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    item = InboundMessage(
+        "mobile",
+        "device:1",
+        "fatal",
+        "hello",
+        metadata={"client_message_id": "client-fatal"},
+    )
+    await bus.publish_inbound(item)
+    consumed = await bus.consume_inbound()
+    original_complete = store.complete_inbound_handoff
+    failed = True
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal failed
+        if failed:
+            failed = False
+            raise OSError("temporary delete failure")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+
+    async def fatal_finalize(_owner_key: int, _owner: object) -> None:
+        raise RuntimeError("owner mismatch")
+
+    bus._finalize_inbound_owner = fatal_finalize  # type: ignore[method-assign]
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError, match="temporary delete failure"):
+            await bus.complete_inbound(consumed)
+        await asyncio.sleep(0.2)
+    assert bus._inbound_cleanup_error is not None
+    assert bus._inbound_cleanup_tasks == {}
+    assert "event=runtime_fatal" in caplog.text
+    assert "owner=message_bus.inbound_cleanup" in caplog.text
+    with pytest.raises(RuntimeError, match="cleanup owner failed"):
+        await bus.aclose()
+    store.close()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -4437,20 +4437,30 @@ async def test_subagent_shutdown_releases_unstarted_snapshot_lease() -> None:
     manager = object.__new__(SubagentManager)
     manager._running_tasks = {}
     manager._running_jobs = {}
+    manager._sync_tasks = {}
     manager._cancel_announced = set()
     manager._snapshot_release_tasks = set()
+    released: list[bool] = []
+    admission_lease = SimpleNamespace(release=lambda: released.append(True))
+
     async def wait_forever() -> None:
         _ = await asyncio.Event().wait()
 
     task = asyncio.create_task(wait_forever())
     manager._running_tasks["job"] = task
     task.add_done_callback(
-        lambda _: manager._finish_background_job("job", snapshot_lease)
+        lambda done: manager._finish_background_job(
+            "job",
+            snapshot_lease,
+            cast(Any, admission_lease),
+            done,
+        )
     )
 
     await manager.shutdown()
 
     assert snapshot.lease_count == 0
+    assert released == [True]
     await store.close()
 
 

--- a/tests/test_plugin_mobile_ui.py
+++ b/tests/test_plugin_mobile_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import threading
 from types import MappingProxyType, SimpleNamespace
@@ -241,6 +242,54 @@ async def test_mobile_ui_timeout_keeps_snapshot_lease_until_worker_exits(
             break
         await asyncio.sleep(0.01)
     assert store.exited == 1
+
+
+@pytest.mark.asyncio
+async def test_mobile_ui_query_rejects_beyond_bounded_worker_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider()
+    blocker = threading.Event()
+    entered = threading.Event()
+    monkeypatch.setattr(mobile_ui_module, "MOBILE_UI_QUERY_WORKERS", 1)
+    monkeypatch.setattr(mobile_ui_module, "MOBILE_UI_QUERY_QUEUE_LIMIT", 0)
+    cast(Any, provider)._executor.shutdown(wait=True)
+    cast(Any, provider)._executor = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="mobile-plugin-ui-test",
+    )
+
+    def block(*args: object, **kwargs: object) -> dict[str, object]:
+        entered.set()
+        blocker.wait(timeout=1)
+        return {}
+
+    cast(Any, provider)._manager.current_snapshot.generations[
+        "sample@github"
+    ].instance.mobile_ui_query = block
+    running = asyncio.create_task(
+        provider.query(
+            "sample@github",
+            "revision-1",
+            "health.snapshot",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-1",
+        )
+    )
+    assert await asyncio.to_thread(entered.wait, 1)
+    with pytest.raises(mobile_ui_module.MobileUiQueryOverloaded):
+        await provider.query(
+            "sample@github",
+            "revision-1",
+            "health.snapshot",
+            {},
+            session_id="mobile:test",
+            turn_id="turn-2",
+        )
+    blocker.set()
+    assert await running == {}
+
 
 @pytest.mark.asyncio
 async def test_mobile_ui_rpc_failure_isolated_from_transport() -> None:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,4 +1,6 @@
 from datetime import UTC, datetime, timedelta
+import asyncio
+import logging
 import threading
 
 import pytest
@@ -14,6 +16,8 @@ from agent.control.models import (
 )
 from session.manager import SessionManager
 from session.store import SessionStore
+from bus.events import InboundMessage
+from bus.queue import MessageBus
 
 NOW = datetime(2026, 7, 14, 8, 0, tzinfo=UTC)
 
@@ -67,6 +71,155 @@ def test_turn_reopens_with_terminal_usage_and_items(tmp_path) -> None:
     assert record.usage == TurnUsage(input_tokens=12, output_tokens=3, coverage="exact")
     assert record.final_response == "完成"
     reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_inbound_handoff_survives_queue_restart_and_deduplicates(tmp_path) -> None:
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path)
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    message = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="你好",
+        metadata={"client_message_id": "client:1"},
+    )
+
+    await bus.publish_inbound(message)
+    assert len(store.list_inbound_handoffs()) == 1
+
+    restarted = MessageBus()
+    recovered_store = SessionStore(db_path)
+    restarted.bind_durable_inbound_store(recovered_store)
+    await restarted.recover_durable_inbounds()
+    recovered = await restarted.consume_inbound()
+    assert recovered.content == "你好"
+    assert recovered.handoff_id == message.handoff_id
+
+    duplicate = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="你好",
+        metadata={"client_message_id": "client:1"},
+    )
+    await bus.publish_inbound(duplicate)
+    assert bus.inbound_size == 1
+
+    await restarted.complete_inbound(recovered)
+    assert store.list_inbound_handoffs() == []
+    recovered_store.close()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_handoff_recovery_is_bounded_and_pumps_after_completion(tmp_path) -> None:
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path)
+    seed = MessageBus()
+    seed.bind_durable_inbound_store(store)
+    for index in range(3):
+        await seed.publish_inbound(
+            InboundMessage(
+                channel="mobile",
+                sender="device:1",
+                chat_id=f"mobile:session-{index}",
+                content=f"message-{index}",
+                metadata={"client_message_id": f"client:{index}"},
+            )
+        )
+
+    recovered_store = SessionStore(db_path)
+    restarted = MessageBus(inbound_capacity=1)
+    restarted.bind_durable_inbound_store(recovered_store)
+    await restarted.recover_durable_inbounds()
+    assert restarted.inbound_size == 1
+    assert len(recovered_store.list_inbound_handoffs()) == 3
+
+    for index in range(3):
+        item = await restarted.consume_inbound()
+        assert item.content == f"message-{index}"
+        await restarted.complete_inbound(item)
+        assert restarted.inbound_size == (1 if index < 2 else 0)
+    assert recovered_store.list_inbound_handoffs() == []
+    recovered_store.close()
+    store.close()
+
+
+def test_mobile_handoff_recovery_rejects_corrupt_json(tmp_path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    store._conn.execute(
+        """
+        INSERT INTO inbound_handoffs(
+            handoff_id, dedupe_key, channel, sender, chat_id, session_key,
+            content, timestamp, media_json, metadata_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "handoff-corrupt",
+            "mobile:session:client-corrupt",
+            "mobile",
+            "device:1",
+            "mobile:session",
+            "mobile:session",
+            "bad",
+            NOW.isoformat(),
+            "{}",
+            "[]",
+            NOW.isoformat(),
+        ),
+    )
+    store._conn.commit()
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    with pytest.raises(ValueError, match="inbound handoff media invalid"):
+        asyncio.run(bus.recover_durable_inbounds())
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    bus = MessageBus()
+    bus.bind_durable_inbound_store(store)
+    message = InboundMessage(
+        channel="mobile",
+        sender="device:1",
+        chat_id="mobile:session",
+        content="hello",
+        metadata={"client_message_id": "client:delete-retry"},
+    )
+    await bus.publish_inbound(message)
+    consumed = await bus.consume_inbound()
+    original_complete = store.complete_inbound_handoff
+    failed = True
+
+    def fail_once(handoff_id: str) -> None:
+        nonlocal failed
+        if failed:
+            failed = False
+            raise OSError("delete unavailable")
+        original_complete(handoff_id)
+
+    store.complete_inbound_handoff = fail_once  # type: ignore[method-assign]
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError, match="delete unavailable"):
+            await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes > 0
+    assert len(bus._inbound_accepted) == 1
+    assert len(store.list_inbound_handoffs()) == 1
+    assert "cleanup_degraded" in caplog.text
+
+    await bus.complete_inbound(consumed)
+    assert bus.inbound_bytes == 0
+    assert bus._inbound_accepted == {}
+    assert store.list_inbound_handoffs() == []
+    store.close()
 
 
 def test_queued_turn_can_be_cancelled(tmp_path) -> None:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -115,7 +115,7 @@ async def test_mobile_inbound_handoff_survives_queue_restart_and_deduplicates(tm
 
 
 @pytest.mark.asyncio
-async def test_mobile_handoff_recovery_is_bounded_and_pumps_after_completion(tmp_path) -> None:
+async def test_mobile_handoff_recovery_pages_durable_rows_and_completes_them(tmp_path) -> None:
     db_path = tmp_path / "sessions.db"
     store = SessionStore(db_path)
     seed = MessageBus()
@@ -132,17 +132,17 @@ async def test_mobile_handoff_recovery_is_bounded_and_pumps_after_completion(tmp
         )
 
     recovered_store = SessionStore(db_path)
-    restarted = MessageBus(inbound_capacity=1)
+    restarted = MessageBus()
     restarted.bind_durable_inbound_store(recovered_store)
     await restarted.recover_durable_inbounds()
-    assert restarted.inbound_size == 1
+    assert restarted.inbound_size == 3
     assert len(recovered_store.list_inbound_handoffs()) == 3
 
     for index in range(3):
         item = await restarted.consume_inbound()
         assert item.content == f"message-{index}"
         await restarted.complete_inbound(item)
-        assert restarted.inbound_size == (1 if index < 2 else 0)
+        assert restarted.inbound_size == 2 - index
     assert recovered_store.list_inbound_handoffs() == []
     recovered_store.close()
     store.close()
@@ -243,17 +243,15 @@ async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
     with caplog.at_level(logging.ERROR):
         with pytest.raises(OSError, match="delete unavailable"):
             await bus.complete_inbound(consumed)
-    assert bus.inbound_bytes > 0
     assert len(bus._inbound_accepted) == 1
     assert len(store.list_inbound_handoffs()) == 1
     assert "cleanup_degraded" in caplog.text
 
     async def retry_finished() -> None:
-        while bus.inbound_bytes:
+        while bus._inbound_accepted:
             await asyncio.sleep(0.02)
 
     await asyncio.wait_for(retry_finished(), timeout=1)
-    assert bus.inbound_bytes == 0
     assert bus._inbound_accepted == {}
     assert store.list_inbound_handoffs() == []
     store.close()

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -179,6 +179,39 @@ def test_mobile_handoff_recovery_rejects_corrupt_json(tmp_path) -> None:
     store.close()
 
 
+def test_mobile_handoff_conflicting_reuse_fails_loud(tmp_path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    base = {
+        "handoff_id": "handoff-1",
+        "dedupe_key": "mobile:session:client-1",
+        "channel": "mobile",
+        "sender": "device:1",
+        "chat_id": "mobile:session",
+        "session_key": "mobile:session",
+        "content": "hello",
+        "timestamp": NOW.isoformat(),
+        "media_json": "[]",
+        "metadata_json": '{"client_message_id":"client-1"}',
+        "created_at": NOW.isoformat(),
+    }
+    assert store.reserve_inbound_handoff(**base) == ("handoff-1", True)
+    assert store.reserve_inbound_handoff(**base | {"handoff_id": "handoff-2"}) == (
+        "handoff-1",
+        False,
+    )
+    with pytest.raises(RuntimeError, match="identity conflict"):
+        store.reserve_inbound_handoff(**base | {"content": "tampered"})
+    with pytest.raises(RuntimeError, match="identity conflict"):
+        store.reserve_inbound_handoff(
+            **base
+            | {
+                "handoff_id": "handoff-2",
+                "content": "tampered",
+            }
+        )
+    store.close()
+
+
 @pytest.mark.asyncio
 async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
     tmp_path,
@@ -215,7 +248,11 @@ async def test_mobile_handoff_delete_failure_retains_owner_until_retry(
     assert len(store.list_inbound_handoffs()) == 1
     assert "cleanup_degraded" in caplog.text
 
-    await bus.complete_inbound(consumed)
+    async def retry_finished() -> None:
+        while bus.inbound_bytes:
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(retry_finished(), timeout=1)
     assert bus.inbound_bytes == 0
     assert bus._inbound_accepted == {}
     assert store.list_inbound_handoffs() == []

--- a/tests/test_spawn_completion_flow.py
+++ b/tests/test_spawn_completion_flow.py
@@ -63,9 +63,12 @@ async def test_spawn_completion_updates_original_session_without_raw_result(tmp_
 
     response = await loop._process(item)
     updated = session_manager.get_or_create("telegram:123")
+    execution_context = tools.get_execution_context()
 
     assert response.channel == "telegram"
     assert response.chat_id == "123"
+    assert execution_context is not None
+    assert execution_context.turn_id.startswith("turn:")
     assert "整理" in response.content
     assert updated.messages[-1]["content"] == "我已经整理完后台结果，结论如下。"
     assert all(

--- a/tests/test_spawn_tool.py
+++ b/tests/test_spawn_tool.py
@@ -115,7 +115,7 @@ async def test_spawn_tool_blocks_when_concurrent_limit_reached():
 
 
 @pytest.mark.asyncio
-async def test_spawn_tool_sync_mode_ignores_background_concurrency_limit():
+async def test_spawn_tool_sync_mode_uses_shared_concurrency_limit():
     registry = ToolRegistry()
     manager = _make_manager()
     manager.get_running_count = Mock(return_value=3)
@@ -123,8 +123,8 @@ async def test_spawn_tool_sync_mode_ignores_background_concurrency_limit():
 
     result = await tool.execute(task="inline task")
 
-    assert result == "sync-result"
-    manager.spawn_sync.assert_awaited_once()
+    assert "任务被拦截" in result
+    manager.spawn_sync.assert_not_awaited()
     manager.spawn.assert_not_called()
 
 

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -286,6 +286,7 @@ async def test_cancelled_sync_wait_keeps_admission_until_worker_finishes(tmp_pat
             started.set()
             try:
                 await asyncio.Event().wait()
+                raise AssertionError("阻塞任务不应正常返回")
             except asyncio.CancelledError:
                 cleanup_started.set()
                 await release.wait()

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -3,7 +3,9 @@ from typing import Any, cast
 
 import pytest
 
+from agent.background.subagent_manager import SubagentCapacityError
 from agent.background.subagent_manager import SubagentManager
+from agent.background.subagent_manager import _SubagentAdmission
 from agent.policies.delegation import SpawnDecision, SpawnDecisionMeta
 from agent.provider import LLMResponse
 from bus.events import SpawnCompletionItem
@@ -198,3 +200,144 @@ async def test_spawn_sync_uses_shorter_iteration_budget(tmp_path):
     assert "退出原因: completed" in result
     assert observed["profile"] == "research"
     assert observed["max_iterations"] == 10
+
+
+@pytest.mark.asyncio
+async def test_sync_and_background_workers_share_atomic_capacity(tmp_path):
+    bus = MessageBus()
+    manager = SubagentManager(
+        provider=cast(Any, _Provider()),
+        workspace=tmp_path,
+        bus=bus,
+        model="m",
+        max_tokens=256,
+        fetch_requester=object(),  # type: ignore[arg-type]
+    )
+    sync_started = asyncio.Event()
+    sync_release = asyncio.Event()
+    background_started = asyncio.Event()
+    background_release = asyncio.Event()
+
+    class _BlockingSubAgent:
+        last_exit_reason = "completed"
+
+        async def run(self, task: str) -> str:
+            sync_started.set()
+            await sync_release.wait()
+            return task
+
+    async def _fake_background(**_kwargs: Any) -> None:
+        background_started.set()
+        await background_release.wait()
+
+    manager._build_subagent = (
+        lambda *, task_dir, profile="research", max_iterations=50: _BlockingSubAgent()
+    )  # type: ignore[assignment]
+    manager._run_subagent = _fake_background  # type: ignore[assignment]
+
+    sync_task = asyncio.create_task(
+        manager.spawn_sync(task="sync", label="sync")
+    )
+    await asyncio.wait_for(sync_started.wait(), timeout=0.2)
+    await manager.spawn(
+        task="background-1",
+        label="background-1",
+        origin_channel="telegram",
+        origin_chat_id="1",
+    )
+    await manager.spawn(
+        task="background-2",
+        label="background-2",
+        origin_channel="telegram",
+        origin_chat_id="1",
+    )
+    await asyncio.wait_for(background_started.wait(), timeout=0.2)
+    assert manager.get_running_count() == 3
+
+    with pytest.raises(SubagentCapacityError, match="active=3, max=3"):
+        await manager.spawn_sync(task="rejected", label="rejected")
+
+    background_release.set()
+    sync_release.set()
+    assert "退出原因: completed" in await sync_task
+    await asyncio.sleep(0)
+    assert manager.get_running_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_sync_wait_keeps_admission_until_worker_finishes(tmp_path):
+    bus = MessageBus()
+    manager = SubagentManager(
+        provider=cast(Any, _Provider()),
+        workspace=tmp_path,
+        bus=bus,
+        model="m",
+        max_tokens=256,
+        fetch_requester=object(),  # type: ignore[arg-type]
+    )
+    started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _BlockingSubAgent:
+        last_exit_reason = "completed"
+
+        async def run(self, _task: str) -> str:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cleanup_started.set()
+                await release.wait()
+                raise
+
+    manager._build_subagent = (
+        lambda *, task_dir, profile="research", max_iterations=50: _BlockingSubAgent()
+    )  # type: ignore[assignment]
+
+    caller = asyncio.create_task(manager.spawn_sync(task="long", label="long"))
+    await asyncio.wait_for(started.wait(), timeout=0.2)
+    caller.cancel()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.2)
+    assert manager.get_running_count() == 1
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert manager.get_running_count() == 0
+
+
+def test_subagent_admission_rejects_double_release() -> None:
+    admission = _SubagentAdmission()
+    lease = admission.acquire(owner="test")
+    lease.release()
+    with pytest.raises(RuntimeError, match="已释放"):
+        lease.release()
+
+
+@pytest.mark.asyncio
+async def test_background_setup_failure_releases_admission(tmp_path):
+    bus = MessageBus()
+    manager = SubagentManager(
+        provider=cast(Any, _Provider()),
+        workspace=tmp_path,
+        bus=bus,
+        model="m",
+        max_tokens=256,
+        fetch_requester=object(),  # type: ignore[arg-type]
+    )
+
+    def fail_task_dir(_job_id: str):
+        raise OSError("task directory unavailable")
+
+    manager._job_task_dir = fail_task_dir  # type: ignore[assignment]
+    with pytest.raises(OSError, match="task directory unavailable"):
+        await manager.spawn(
+            task="setup failure",
+            label="setup",
+            origin_channel="telegram",
+            origin_chat_id="1",
+        )
+    assert manager.get_running_count() == 0

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -475,9 +475,10 @@ async def test_message_push_default_call_waits_for_passive_lane():
         events.append(message)
 
     _register_text_channel(tool, "cli", text)
-    await bus.publish_inbound(
-        InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
+    inbound = InboundMessage(
+        channel="cli", sender="user", chat_id="1", content="hello"
     )
+    await bus.publish_inbound(inbound)
     push_task = asyncio.create_task(
         tool.execute(target_channel="cli", target_chat_id="1", message="inline")
     )
@@ -485,9 +486,7 @@ async def test_message_push_default_call_waits_for_passive_lane():
     await asyncio.sleep(0.01)
     assert not push_task.done()
 
-    await bus.complete_inbound(
-        InboundMessage(channel="cli", sender="user", chat_id="1", content="hello")
-    )
+    await bus.complete_inbound(inbound)
     result = await asyncio.wait_for(push_task, timeout=1)
 
     assert result == "消息已发送"

--- a/tests/test_unified_exec.py
+++ b/tests/test_unified_exec.py
@@ -440,6 +440,49 @@ async def test_failed_owner_cleanup_retains_execution_and_quarantines_new_spawn(
 
 
 @pytest.mark.asyncio
+async def test_failed_owner_cleanup_retains_complete_diagnostic_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = ShellProcessManager()
+    owner = "mobile:cleanup-log"
+    original_remove = manager._remove_execution
+    output_path: Path | None = None
+    try:
+        opened = await manager.exec_command(
+            command="printf retained-log; sleep 30",
+            argv=["/bin/sh", "-c", "printf retained-log; sleep 30"],
+            cwd=None,
+            env=dict(os.environ),
+            tty=False,
+            yield_time_ms=250,
+            max_output_tokens=10,
+            hard_timeout_s=60,
+            owner_session_key=owner,
+        )
+        assert opened.execution_id is not None
+        assert opened.output_path is not None
+        output_path = Path(opened.output_path)
+
+        async def deny_remove(*_args: object, **_kwargs: object) -> None:
+            raise PermissionError(errno.EPERM, os.strerror(errno.EPERM))
+
+        monkeypatch.setattr(manager, "_remove_execution", deny_remove)
+        report = await manager.terminate_owner(owner)
+
+        assert report.failed_execution_ids == (opened.execution_id,)
+        assert output_path.exists()
+        assert output_path.read_text(encoding="utf-8") == "retained-log"
+
+        monkeypatch.setattr(manager, "_remove_execution", original_remove)
+        retry = await manager.terminate_owner(owner)
+        assert retry.failed_execution_ids == ()
+        assert not output_path.exists()
+    finally:
+        monkeypatch.setattr(manager, "_remove_execution", original_remove)
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_stop_during_initial_wait_returns_terminal_state() -> None:
     manager = ShellProcessManager()
     shell = ShellTool(manager)


### PR DESCRIPTION
## Summary

- retain the shared bounded admission pool for foreground shell and subagent execution
- retain Mobile receipt, durable inbound handoff, cleanup retry, and crash recovery
- remove MessageBus-wide capacity admission: the bus preserves lane ordering but does not reject inbound/outbound messages through an independent global quota
- retain bounded control replay and terminal reaping
- isolate Dashboard plugin fixtures and pin the private Fitbit field-safety runtime

## Failure semantics

- shell/subagent capacity exhaustion remains explicit at its owning boundary; existing executions continue unchanged
- Mobile handoff persists before queueing and remains owned until durable deletion succeeds; cleanup failures are observable and retried
- control replay overflow/expiry is observable and does not silently discard live subscribers
- Dashboard field failures remain isolated so one invalid value does not suppress unrelated fields

## Verification

- `git diff --check`: passed
- focused local behavior checks: unbounded MessageBus plus Mobile durable-handoff completion: passed
- full local pytest was not run because this checkout lacks `apscheduler`
- this branch currently has no GitHub checks reported

## Stack

- base: #294 (`codex/companion-security-wake-scheduler`)
- next: #291 (final companion contract and cumulative semantic Gate)
- #295 is closed by product decision; its global MessageBus admission change is intentionally not included

## Private Gate

The public plan remains `pending_maintainer` until the maintainer runs the formal private consumer against the same `plan.json`. Local native tests, if available, are supporting evidence only.

## Rollback

Restore branch: `backup/companion-security-execution-replay-before-pr295-removal-20260802`.