### PR TITLE
feat(settings): 支持按模型目录设置思考强度

### DIFF
--- a/agent/model_runtime/catalog/opencode_go.py
+++ b/agent/model_runtime/catalog/opencode_go.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 
 import httpx
@@ -15,6 +16,22 @@ from agent.model_runtime.provider_profiles import (
 @dataclass(frozen=True)
 class OpenCodeGoModel:
     slug: str
+    supported_reasoning_efforts: tuple[str, ...] = ()
+
+
+_GLM_EFFORT_ID = re.compile(r"^glm-5(?:\.(\d+)|-(\d+)|p(\d+))$")
+
+
+def _reasoning_efforts_for(model_id: str) -> tuple[str, ...]:
+    """OpenCode Go 目录不发布推理强度，按 opencode 客户端规则为 GLM-5.2+ 推算档位。"""
+    match = _GLM_EFFORT_ID.match(model_id.strip().lower())
+    if match:
+        minor = next(
+            int(value) for value in match.groups() if value is not None
+        )
+        if minor >= 2:
+            return ("high", "xhigh")
+    return ()
 
 
 class OpenCodeGoModelCatalog:
@@ -62,5 +79,12 @@ class OpenCodeGoModelCatalog:
             if not isinstance(model_id, str) or not model_id.strip():
                 raise TransportError("OpenCode Go 模型目录包含无效模型项")
             if OPENCODE_GO_PROFILE.classify_model(model_id) == "chat_completions":
-                models.append(OpenCodeGoModel(slug=model_id))
+                models.append(
+                    OpenCodeGoModel(
+                        slug=model_id,
+                        supported_reasoning_efforts=_reasoning_efforts_for(
+                            model_id
+                        ),
+                    )
+                )
         return models

--- a/agent/model_runtime/catalog/opencode_go.py
+++ b/agent/model_runtime/catalog/opencode_go.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import dataclass
 
 import httpx
@@ -19,19 +18,23 @@ class OpenCodeGoModel:
     supported_reasoning_efforts: tuple[str, ...] = ()
 
 
-_GLM_EFFORT_ID = re.compile(r"^glm-5(?:\.(\d+)|-(\d+)|p(\d+))$")
+_WIDELY_SUPPORTED_EFFORTS = ("low", "medium", "high")
+_GLM52_IDS = ("glm-5.2", "glm-5-2", "glm-5p2")
 
 
 def _reasoning_efforts_for(model_id: str) -> tuple[str, ...]:
-    """OpenCode Go 目录不发布推理强度，按 opencode 客户端规则为 GLM-5.2+ 推算档位。"""
-    match = _GLM_EFFORT_ID.match(model_id.strip().lower())
-    if match:
-        minor = next(
-            int(value) for value in match.groups() if value is not None
-        )
-        if minor >= 2:
-            return ("high", "xhigh")
-    return ()
+    """OpenCode Go 目录不发布推理强度；按 opencode 客户端对 OpenAI 兼容通道的规则推算。"""
+    normalized = model_id.strip().lower()
+    if normalized.startswith("deepseek-v4"):
+        return (*_WIDELY_SUPPORTED_EFFORTS, "max")
+    if any(marker in normalized for marker in _GLM52_IDS):
+        return ("high", "max")
+    # 排除列表：deepseek 旧版、kimi、minimax、qwen、glm(<5.2) 等无思考强度档位。
+    if normalized.startswith(
+        ("deepseek-", "kimi-", "minimax-", "qwen", "glm-")
+    ):
+        return ()
+    return _WIDELY_SUPPORTED_EFFORTS
 
 
 class OpenCodeGoModelCatalog:

--- a/bootstrap/settings_api.py
+++ b/bootstrap/settings_api.py
@@ -137,6 +137,12 @@ def create_settings_app(
                             "contextWindow": entry.capabilities.context_window,
                             "maxOutputTokens": entry.capabilities.max_output_tokens,
                             "inputModalities": list(entry.capabilities.input_modalities),
+                            "supportedReasoningEfforts": list(
+                                entry.capabilities.supported_reasoning_efforts
+                            ),
+                            "defaultReasoningEffort": (
+                                entry.capabilities.default_reasoning_effort
+                            ),
                         }
                         for entry in entries
                     ]
@@ -152,7 +158,17 @@ def create_settings_app(
                     key,
                     base_url=payload.base_url or "https://opencode.ai/zen/go/v1",
                 ).list_models()
-                return {"models": [{"id": entry.slug} for entry in entries]}
+                return {
+                    "models": [
+                        {
+                            "id": entry.slug,
+                            "supportedReasoningEfforts": list(
+                                entry.supported_reasoning_efforts
+                            ),
+                        }
+                        for entry in entries
+                    ]
+                }
             return {"models": []}
         except (AuthenticationError, TransportError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -361,6 +377,7 @@ def _runtime_summary(
         "contextWindow": context_window,
         "maxOutputTokens": max_output_tokens,
         "inputModalities": input_modalities,
+        "reasoningEffort": str(raw.get("reasoning_effort") or ""),
         "credential": {
             "id": auth,
             "configured": bool(auth and auth in credential_meta) or bool(inline),

--- a/frontend/chat/src/settings-app.tsx
+++ b/frontend/chat/src/settings-app.tsx
@@ -22,6 +22,7 @@ interface RuntimeSummary {
   contextWindow: number;
   maxOutputTokens: number;
   inputModalities: string[];
+  reasoningEffort: string;
   credential: { configured: boolean; source: string };
 }
 
@@ -40,6 +41,8 @@ interface ModelOption {
   contextWindow?: number;
   maxOutputTokens?: number;
   inputModalities?: string[];
+  supportedReasoningEfforts?: string[];
+  defaultReasoningEffort?: string;
 }
 
 interface CodexLoginState {
@@ -93,6 +96,7 @@ export function SettingsApp() {
   const [model, setModel] = useState("");
   const [contextWindow, setContextWindow] = useState("128000");
   const [maxOutputTokens, setMaxOutputTokens] = useState("0");
+  const [reasoningEffort, setReasoningEffort] = useState("");
   const [models, setModels] = useState<ModelOption[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -127,6 +131,9 @@ export function SettingsApp() {
     [kind, state],
   );
 
+  const selectedModel = models.find((item) => item.id === model);
+  const effortOptions = selectedModel?.supportedReasoningEfforts ?? [];
+
   function selectRuntime(runtime: RuntimeSummary) {
     setKind(runtimeKind(runtime));
     setProvider(runtime.provider);
@@ -134,6 +141,7 @@ export function SettingsApp() {
     setModel(runtime.model);
     setContextWindow(String(runtime.contextWindow || 128000));
     setMaxOutputTokens(String(runtime.maxOutputTokens ?? 0));
+    setReasoningEffort(runtime.reasoningEffort || "");
     setApiKey("");
     setModels([]);
   }
@@ -155,17 +163,20 @@ export function SettingsApp() {
       setModel("");
       setContextWindow("128000");
       setMaxOutputTokens("0");
+      setReasoningEffort("");
     } else if (next === "codex") {
       setProvider("codex");
       setBaseUrl("");
       setModel("");
       setContextWindow("128000");
       setMaxOutputTokens("0");
+      setReasoningEffort("");
     } else {
       setProvider("openai");
       setBaseUrl("https://api.openai.com/v1");
       setModel("");
       setMaxOutputTokens("0");
+      setReasoningEffort("");
     }
   }
 
@@ -194,6 +205,9 @@ export function SettingsApp() {
   function applyModel(option: ModelOption) {
     setModel(option.id);
     if (option.contextWindow) setContextWindow(String(option.contextWindow));
+    if (!reasoningEffort && option.defaultReasoningEffort) {
+      setReasoningEffort(option.defaultReasoningEffort);
+    }
   }
 
   async function save() {
@@ -212,6 +226,7 @@ export function SettingsApp() {
           base_url: baseUrl,
           context_window: Number(contextWindow),
           max_output_tokens: Number(maxOutputTokens),
+          reasoning_effort: reasoningEffort,
           input_modalities: ["text"],
         }),
       });
@@ -370,6 +385,20 @@ export function SettingsApp() {
                 </Button>
               )}
             </div>
+
+            <Field label="思考强度" hint={effortOptions.length ? "按模型支持的档位选择" : "填写模型支持的推理强度，留空使用 Provider 默认"}>
+              {effortOptions.length ? (
+                <Select value={reasoningEffort || "__default"} onValueChange={(value) => setReasoningEffort(value === "__default" ? "" : value)}>
+                  <SelectTrigger><SelectValue placeholder="选择思考强度" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default">不设置（Provider 默认）</SelectItem>
+                    {effortOptions.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input value={reasoningEffort} onChange={(event) => setReasoningEffort(event.target.value)} placeholder="如 low / medium / high" />
+              )}
+            </Field>
 
             <div className="field-grid two-columns">
               <Field label="上下文窗口"><Input inputMode="numeric" value={contextWindow} onChange={(event) => setContextWindow(event.target.value)} /></Field>

--- a/plugins/akasha/infrastructure/sparse_index/encoding.py
+++ b/plugins/akasha/infrastructure/sparse_index/encoding.py
@@ -17,6 +17,9 @@ with warnings.catch_warnings():
         message="pkg_resources is deprecated as an API.*",
         category=UserWarning,
     )
+    # jieba 0.42.1 在 Python 3.12 下产生 invalid escape sequence SyntaxWarning，
+    # 测试与 Gate 的 -W error 下必须显式忽略，否则导入即失败。
+    warnings.filterwarnings("ignore", category=SyntaxWarning)
     import jieba
 
 from .model import SparseFeature

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -14,7 +14,10 @@ from agent.config_models import ModelRuntimeConfig
 from agent.model_runtime.auth.codex import CODEX_CLIENT_VERSION, CodexAuthDriver
 from agent.model_runtime.auth.store import Credential, CredentialStore
 from agent.model_runtime.catalog.codex import CodexModelCatalog
-from agent.model_runtime.catalog.opencode_go import OpenCodeGoModelCatalog
+from agent.model_runtime.catalog.opencode_go import (
+    OpenCodeGoModelCatalog,
+    _reasoning_efforts_for,
+)
 from agent.model_runtime.context_policy import (
     build_runtime_context_budget,
     recommended_context_settings,
@@ -143,6 +146,18 @@ def test_opencode_go_profile_is_dynamic_and_rejects_wrong_wire() -> None:
         )
 
 
+def test_opencode_go_reasoning_efforts_follow_client_rules() -> None:
+    assert _reasoning_efforts_for("glm-5.2") == ("high", "xhigh")
+    assert _reasoning_efforts_for("glm-5.99") == ("high", "xhigh")
+    assert _reasoning_efforts_for("glm-5p2") == ("high", "xhigh")
+    assert _reasoning_efforts_for("glm-5-2") == ("high", "xhigh")
+    assert _reasoning_efforts_for("glm-5.1") == ()
+    assert _reasoning_efforts_for("glm-5") == ()
+    assert _reasoning_efforts_for("kimi-k3") == ()
+    assert _reasoning_efforts_for("deepseek-v4-pro") == ()
+    assert _reasoning_efforts_for("future-model-1") == ()
+
+
 @pytest.mark.asyncio
 async def test_opencode_go_catalog_uses_http_boundary_and_filters_protocols() -> None:
     requests: list[tuple[str, str | None]] = []
@@ -185,11 +200,15 @@ async def test_opencode_go_catalog_uses_http_boundary_and_filters_protocols() ->
         server.server_close()
         thread.join()
 
+    by_slug = {model.slug: model for model in models}
     assert [model.slug for model in models] == [
         "glm-5.99",
         "kimi-k3",
         "future-model-1",
     ]
+    assert by_slug["glm-5.99"].supported_reasoning_efforts == ("high", "xhigh")
+    assert by_slug["kimi-k3"].supported_reasoning_efforts == ()
+    assert by_slug["future-model-1"].supported_reasoning_efforts == ()
     assert requests == [("/v1/models", "Bearer secret")]
 
 

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -147,15 +147,35 @@ def test_opencode_go_profile_is_dynamic_and_rejects_wrong_wire() -> None:
 
 
 def test_opencode_go_reasoning_efforts_follow_client_rules() -> None:
-    assert _reasoning_efforts_for("glm-5.2") == ("high", "xhigh")
-    assert _reasoning_efforts_for("glm-5.99") == ("high", "xhigh")
-    assert _reasoning_efforts_for("glm-5p2") == ("high", "xhigh")
-    assert _reasoning_efforts_for("glm-5-2") == ("high", "xhigh")
+    assert _reasoning_efforts_for("deepseek-v4-pro") == (
+        "low",
+        "medium",
+        "high",
+        "max",
+    )
+    assert _reasoning_efforts_for("deepseek-v4-flash") == (
+        "low",
+        "medium",
+        "high",
+        "max",
+    )
+    assert _reasoning_efforts_for("glm-5.2") == ("high", "max")
+    assert _reasoning_efforts_for("glm-5p2") == ("high", "max")
+    assert _reasoning_efforts_for("glm-5-2") == ("high", "max")
+    assert _reasoning_efforts_for("glm-5.99") == ()
     assert _reasoning_efforts_for("glm-5.1") == ()
     assert _reasoning_efforts_for("glm-5") == ()
     assert _reasoning_efforts_for("kimi-k3") == ()
-    assert _reasoning_efforts_for("deepseek-v4-pro") == ()
-    assert _reasoning_efforts_for("future-model-1") == ()
+    assert _reasoning_efforts_for("minimax-m3") == ()
+    assert _reasoning_efforts_for("qwen3.7-plus") == ()
+    assert _reasoning_efforts_for("deepseek-chat") == ()
+    assert _reasoning_efforts_for("mimo-v2.5-pro") == (
+        "low",
+        "medium",
+        "high",
+    )
+    assert _reasoning_efforts_for("grok-4.5") == ("low", "medium", "high")
+    assert _reasoning_efforts_for("future-model-1") == ("low", "medium", "high")
 
 
 @pytest.mark.asyncio
@@ -206,9 +226,13 @@ async def test_opencode_go_catalog_uses_http_boundary_and_filters_protocols() ->
         "kimi-k3",
         "future-model-1",
     ]
-    assert by_slug["glm-5.99"].supported_reasoning_efforts == ("high", "xhigh")
+    assert by_slug["glm-5.99"].supported_reasoning_efforts == ()
     assert by_slug["kimi-k3"].supported_reasoning_efforts == ()
-    assert by_slug["future-model-1"].supported_reasoning_efforts == ()
+    assert by_slug["future-model-1"].supported_reasoning_efforts == (
+        "low",
+        "medium",
+        "high",
+    )
     assert requests == [("/v1/models", "Bearer secret")]
 
 

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -165,6 +165,144 @@ def test_apply_writes_inline_key_and_preserves_other_config(
     ).exists()
 
 
+def test_state_reports_reasoning_effort(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        _config().replace(
+            "input_modalities = [\"text\"]",
+            "input_modalities = [\"text\"]\nreasoning_effort = \"high\"",
+        ),
+        encoding="utf-8",
+    )
+    app = create_settings_app(
+        config_path,
+        tmp_path / "workspace",
+        credential_store=CredentialStore(tmp_path / "auth" / "auth.json"),
+    )
+
+    response = TestClient(app).get("/api/settings/state")
+
+    assert response.status_code == 200
+    assert response.json()["runtimes"][0]["reasoningEffort"] == "high"
+
+
+def test_apply_writes_reasoning_effort(tmp_path: Path, monkeypatch) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_config(), encoding="utf-8")
+
+    async def validate(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr("bootstrap.settings_api._validate_live_candidate", validate)
+    app = create_settings_app(
+        config_path,
+        tmp_path / "workspace",
+        credential_store=CredentialStore(tmp_path / "auth" / "auth.json"),
+    )
+    response = TestClient(app).post(
+        "/api/settings/apply",
+        headers={"Origin": "http://testserver", "X-Akasic-CSRF": "1"},
+        json={
+            "provider": "opencode-go",
+            "model": "glm-5",
+            "api_key": "new-secret",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "context_window": 128000,
+            "max_output_tokens": 0,
+            "reasoning_effort": "high",
+            "input_modalities": ["text"],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["llm"]["runtimes"]["opencode_go_main"]["reasoning_effort"] == "high"
+
+
+def test_codex_models_expose_reasoning_effort_capabilities(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_config(), encoding="utf-8")
+
+    class FakeModel:
+        slug = "o4-mini"
+        capabilities = type(
+            "Caps",
+            (),
+            {
+                "context_window": 200000,
+                "max_output_tokens": 100000,
+                "input_modalities": ("text",),
+                "supported_reasoning_efforts": ("minimal", "low", "medium", "high"),
+                "default_reasoning_effort": "medium",
+            },
+        )()
+
+    class FakeCatalog:
+        def __init__(self, auth) -> None:
+            pass
+
+        async def list_models(self):
+            return [FakeModel()]
+
+    monkeypatch.setattr("bootstrap.settings_api.CodexModelCatalog", FakeCatalog)
+    app = create_settings_app(
+        config_path,
+        tmp_path / "workspace",
+        credential_store=CredentialStore(tmp_path / "auth" / "auth.json"),
+    )
+    response = TestClient(app).post(
+        "/api/settings/models",
+        headers={"Origin": "http://testserver", "X-Akasic-CSRF": "1"},
+        json={"provider": "codex"},
+    )
+
+    assert response.status_code == 200, response.text
+    model = response.json()["models"][0]
+    assert model["supportedReasoningEfforts"] == ["minimal", "low", "medium", "high"]
+    assert model["defaultReasoningEffort"] == "medium"
+
+
+def test_opencode_go_models_expose_reasoning_efforts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_config(), encoding="utf-8")
+
+    class FakeModel:
+        def __init__(self, slug: str, efforts: tuple[str, ...]) -> None:
+            self.slug = slug
+            self.supported_reasoning_efforts = efforts
+
+    class FakeCatalog:
+        def __init__(self, api_key: str, *, base_url: str) -> None:
+            pass
+
+        async def list_models(self):
+            return [
+                FakeModel("glm-5.99", ("high", "xhigh")),
+                FakeModel("kimi-k3", ()),
+            ]
+
+    monkeypatch.setattr("bootstrap.settings_api.OpenCodeGoModelCatalog", FakeCatalog)
+    app = create_settings_app(
+        config_path,
+        tmp_path / "workspace",
+        credential_store=CredentialStore(tmp_path / "auth" / "auth.json"),
+    )
+    response = TestClient(app).post(
+        "/api/settings/models",
+        headers={"Origin": "http://testserver", "X-Akasic-CSRF": "1"},
+        json={"provider": "opencode-go", "api_key": "secret"},
+    )
+
+    assert response.status_code == 200, response.text
+    models = {item["id"]: item for item in response.json()["models"]}
+    assert models["glm-5.99"]["supportedReasoningEfforts"] == ["high", "xhigh"]
+    assert models["kimi-k3"]["supportedReasoningEfforts"] == []
+
+
 def test_mutation_rejects_cross_origin(tmp_path: Path) -> None:
     app = create_settings_app(
         tmp_path / "config.toml",

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -281,7 +281,7 @@ def test_opencode_go_models_expose_reasoning_efforts(
 
         async def list_models(self):
             return [
-                FakeModel("glm-5.99", ("high", "xhigh")),
+                FakeModel("deepseek-v4-pro", ("low", "medium", "high", "max")),
                 FakeModel("kimi-k3", ()),
             ]
 
@@ -299,7 +299,12 @@ def test_opencode_go_models_expose_reasoning_efforts(
 
     assert response.status_code == 200, response.text
     models = {item["id"]: item for item in response.json()["models"]}
-    assert models["glm-5.99"]["supportedReasoningEfforts"] == ["high", "xhigh"]
+    assert models["deepseek-v4-pro"]["supportedReasoningEfforts"] == [
+        "low",
+        "medium",
+        "high",
+        "max",
+    ]
     assert models["kimi-k3"]["supportedReasoningEfforts"] == []
 
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：设置页无法便捷配置模型思考强度；不同 Provider/模型的推理强度能力各不相同，此前网页上没有入口。
- 用户可见结果：设置页新增"思考强度"控件——Codex 与 OpenCode Go 按模型目录/客户端规则给出档位下拉，通用 API Key 支持自由填写；保存后写入 `llm.runtimes.<id>.reasoning_effort` 并随真实请求生效。
- 本 PR 不处理：`enable_thinking` 开关（已有 CLI 路径）；运行时按会话切换思考强度。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：设置页（前端 src）与设置 API（`bootstrap/settings_api.py`）
- `runtime_patch`：`none`
- `runtime_patch_reason`：
- `authoritative_state_owner`：`config.toml`（写入路径复用既有 `patch_main_model_config`）
- `client_only_alternative`：不适用
- 关联不变量：`reasoning_effort` 仅在非空时写入 TOML；凭据不通过设置 API 响应返回
- `protected_state`：`config.toml` 其余字段、凭据存储、`sessions.db` 等运行时数据
- 允许的副作用：设置 API state/models 响应新增只读字段；apply 请求新增 `reasoning_effort`
- 禁止的副作用：不触碰正式 workspace 与凭据明文

## 改动范围

- 主要文件：
  - `frontend/chat/src/settings-app.tsx`：思考强度控件（目录能力 → 下拉；否则自由填写）
  - `bootstrap/settings_api.py`：codex/opencode-go models 端点透出 `supportedReasoningEfforts`（codex 含 `defaultReasoningEffort`）；state 返回 `reasoningEffort`
  - `agent/model_runtime/catalog/opencode_go.py`：OpenCode Go 目录不发布推理强度（已实测 `/models` 仅含 id），按 opencode 客户端 openai-compatible 规则推算档位
  - `plugins/akasha/infrastructure/sparse_index/encoding.py`：忽略 jieba 0.42.1 在 Python 3.12 下的 SyntaxWarning（main 既有问题，`-W error` 下导入即失败）
  - 测试：`tests/test_model_runtime.py`、`tests/test_settings_api.py`
- 配置或迁移影响：无迁移；新增可选 `reasoning_effort` 写入，空值不写入
- 已知 schema lineage 与最终 schema identity：不涉及
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不涉及
- 回滚方式：`config.toml.<operationId>.bak`（设置 API 既有备份）；PR 提交可整体 revert

## 验证

- [x] 相关 targeted tests 已通过（`tests/test_settings_api.py` 10 个、`tests/test_model_runtime.py` 等 80 个）。
- [x] Python 类型检查已通过：pyright 项目与 tests 配置 0 errors；前端 settings-app 在独立 TypeScript 环境 typecheck 0 errors。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：20 个公开场景全部 passed，无残留资源。
- `sourceDigest`：见 `docker/debug/reports/change-gate/20260802-144825-90bc1c94/gate.json`
- `planDigest`：`0b640040b34372bcad56c55dae9673b0a9dad6462488a55af06cd2dfa93e689e`
- 真实设备证据：OpenCode Go 真实目录端到端验证（本机登录 key，`/models` 实测 + catalog 推算结果符合 opencode 客户端规则：deepseek-v4 → low/medium/high/max，glm-5.2 → high/max，kimi/minimax/qwen/glm 旧版无档位）
- 未运行项与原因：手机端/真实设备 UI 渲染未验证（无设备环境）；CI 的 `runtime-extension-gate` 已在本机等效跑过 workspace-mcp 与 restart soak，均 passed。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。
