### PR TITLE
feat(mobile-webui): add server-selected OTA publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ __pycache__/
 
 # Node.js
 node_modules/
-package-lock.json
 /dist/
 frontend/dashboard/static/
 

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -19,6 +19,8 @@ RUN printf '%s\n' \
         ca-certificates \
         curl \
         git \
+        nodejs \
+        npm \
         python \
         python-pip \
         util-linux \

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,7 +114,7 @@
 | Shell、长任务、PTY、进程续接或轮询 | `projectneed` SH-001、RUN-002～RUN-003、ERR-001 → [0014](decisions/0014-shell-uses-unified-execution.md) → [Unified Shell Execution 设计](design/unified-shell-execution.md) | `agent/tools/shell.py`、`agent/tools/unified_exec.py`、`agent/tools/meta/register.py`、`agent/background/subagent_profiles.py`、`bootstrap/tools.py` |
 | 移动端、客户端协议、跨仓库 runtime patch 或 stacked PR 评审 | `projectneed` MOB-001～MOB-007、GOV-001～GOV-005、TST-001～TST-008 → [0003](decisions/0003-core-capability-ownership-is-semantic.md) → [0004](decisions/0004-cross-repository-evidence-is-an-immutable-combination.md) → [0007](decisions/0007-mobile-plugin-control-and-data-planes-are-explicit.md) → [0009](decisions/0009-akasha-mobile-recall-preserves-semantic-lanes.md) → [0019](decisions/0019-mobile-long-messages-use-bounded-events.md) → [0020](decisions/0020-mobile-history-content-uses-authenticated-http-ranges.md) → [Mobile 长消息投递](design/mobile-long-message-delivery.md) → [移动端与跨仓库 Gate](design/mobile-cross-repository-semantic-gate.md) → [`templates/review-contract.md`](templates/review-contract.md) | 每层 `base..head`、最终累计 diff、所有 schema lineage、协议 source、runtime/provider/scenario identity 和设备隔离证据 |
 | 新增或修改项目文档 | 本索引 → [`writing-rules.md`](writing-rules.md) → 目标文档的权威上游 | 所有相对链接、重复规则、过时入口和 Git diff |
-| Dashboard、Chat UI | `projectneed` 公共合同、WEBUI-001～WEBUI-003 → [0018](decisions/0018-chat-webui-has-one-source-and-two-adapters.md) → [共享对话 WebUI](design/shared-chat-webui.md) → [服务端发布的移动 WebUI OTA](design/server-published-mobile-webui.md) → `NOW.md` 对应事项 | `frontend/**/src`、真实构建和渲染结果 |
+| Dashboard、Chat UI | `projectneed` 公共合同、WEBUI-001～WEBUI-006 → [0018](decisions/0018-chat-webui-has-one-source-and-two-adapters.md) → [0022](decisions/0022-mobile-webui-uses-server-selected-generations.md) → [共享对话 WebUI](design/shared-chat-webui.md) → [服务端发布的移动 WebUI OTA](design/server-published-mobile-webui.md) → `NOW.md` 对应事项 | `frontend/**/src`、真实构建和渲染结果 |
 
 任务同时命中两行以上、会修改持久数据或会产生外部不可逆效果时，读取 `projectneed.md` 全文。执行阶段可以收窄材料，评审阶段必须展开所有相关 diff、状态变化和证据。
 
@@ -203,7 +203,8 @@ docs/
 │   ├── 0018-chat-webui-has-one-source-and-two-adapters.md
 │   ├── 0019-mobile-long-messages-use-bounded-events.md
 │   ├── 0020-mobile-history-content-uses-authenticated-http-ranges.md
-│   └── 0021-yoyo-workspace-ledger-defines-migration-origin.md
+│   ├── 0021-yoyo-workspace-ledger-defines-migration-origin.md
+│   └── 0022-mobile-webui-uses-server-selected-generations.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── linux-supervisor-safe-self-restart.md

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,7 +114,7 @@
 | Shell、长任务、PTY、进程续接或轮询 | `projectneed` SH-001、RUN-002～RUN-003、ERR-001 → [0014](decisions/0014-shell-uses-unified-execution.md) → [Unified Shell Execution 设计](design/unified-shell-execution.md) | `agent/tools/shell.py`、`agent/tools/unified_exec.py`、`agent/tools/meta/register.py`、`agent/background/subagent_profiles.py`、`bootstrap/tools.py` |
 | 移动端、客户端协议、跨仓库 runtime patch 或 stacked PR 评审 | `projectneed` MOB-001～MOB-007、GOV-001～GOV-005、TST-001～TST-008 → [0003](decisions/0003-core-capability-ownership-is-semantic.md) → [0004](decisions/0004-cross-repository-evidence-is-an-immutable-combination.md) → [0007](decisions/0007-mobile-plugin-control-and-data-planes-are-explicit.md) → [0009](decisions/0009-akasha-mobile-recall-preserves-semantic-lanes.md) → [0019](decisions/0019-mobile-long-messages-use-bounded-events.md) → [0020](decisions/0020-mobile-history-content-uses-authenticated-http-ranges.md) → [Mobile 长消息投递](design/mobile-long-message-delivery.md) → [移动端与跨仓库 Gate](design/mobile-cross-repository-semantic-gate.md) → [`templates/review-contract.md`](templates/review-contract.md) | 每层 `base..head`、最终累计 diff、所有 schema lineage、协议 source、runtime/provider/scenario identity 和设备隔离证据 |
 | 新增或修改项目文档 | 本索引 → [`writing-rules.md`](writing-rules.md) → 目标文档的权威上游 | 所有相对链接、重复规则、过时入口和 Git diff |
-| Dashboard、Chat UI | `projectneed` 公共合同、WEBUI-001～WEBUI-003 → [0018](decisions/0018-chat-webui-has-one-source-and-two-adapters.md) → [共享对话 WebUI](design/shared-chat-webui.md) → `NOW.md` 对应事项 | `frontend/**/src`、真实构建和渲染结果 |
+| Dashboard、Chat UI | `projectneed` 公共合同、WEBUI-001～WEBUI-003 → [0018](decisions/0018-chat-webui-has-one-source-and-two-adapters.md) → [共享对话 WebUI](design/shared-chat-webui.md) → [服务端发布的移动 WebUI OTA](design/server-published-mobile-webui.md) → `NOW.md` 对应事项 | `frontend/**/src`、真实构建和渲染结果 |
 
 任务同时命中两行以上、会修改持久数据或会产生外部不可逆效果时，读取 `projectneed.md` 全文。执行阶段可以收窄材料，评审阶段必须展开所有相关 diff、状态变化和证据。
 
@@ -211,6 +211,7 @@ docs/
 │   ├── mobile-long-message-delivery.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── query-local-react-compaction.md
+│   ├── server-published-mobile-webui.md
 │   ├── shared-chat-webui.md
 │   ├── unified-shell-execution.md
 │   ├── veda-persona.md

--- a/docs/decisions/0018-chat-webui-has-one-source-and-two-adapters.md
+++ b/docs/decisions/0018-chat-webui-has-one-source-and-two-adapters.md
@@ -3,6 +3,7 @@
 - 状态：accepted
 - 日期：2026-08-01
 - 关联条款：WEBUI-001～WEBUI-003、MOB-001、GOV-001～GOV-005、TST-007～TST-008
+- 部分勘误：[0022](0022-mobile-webui-uses-server-selected-generations.md) 将固定 ZIP 收窄为 embedded baseline，并增加服务端选择的不可变 generation
 
 ## 背景
 
@@ -13,7 +14,7 @@
 1. `akasic-agent/frontend/chat` 是对话 WebUI 的唯一源码真源，同时构建桌面浏览器入口和 Android WebView 入口。
 2. 共用消息、Markdown、流式呈现和主题 token 只实现一次；桌面扫码配对与 Android 原生桥通过两个显式入口组合。
 3. Android 的 Room、outbox、附件、通知、Keystore、配对扫描和生命周期继续由 `akashic-mobile` 原生层拥有。共享 WebUI 只消费经过校验的 snapshot、patch 和命令接口。
-4. `akashic-mobile` 不通过本机路径、submodule 或浮动分支读取源码。它保存一个由干净源码 commit 构建的静态 ZIP，并在 Gradle 解包前验证 SHA-256；ZIP 内 manifest 固定 repository、commit、tree 和资产摘要。
+4. `akashic-mobile` 不通过本机路径、submodule 或浮动分支读取源码。它保存一个由干净源码 commit 构建的静态 ZIP 作为 embedded baseline，并在 Gradle 解包前验证 SHA-256；ZIP 内 manifest 固定 repository、commit、tree 和资产摘要。已配对运行时还可按 [0022](0022-mobile-webui-uses-server-selected-generations.md) 消费服务端选择的不可变 generation。
 5. Web 默认改用移动端现有浅蓝色主题；正文流式呈现由共用 `MessageResponse` 的 `isAnimating` 状态驱动。`prefers-reduced-motion` 继续关闭非必要动画。
 
 ## 理由
@@ -22,7 +23,7 @@
 
 ## 影响
 
-- WebUI 改动只在 `akasic-agent` 编写和测试，再生成新产物并更新移动仓库的固定 ZIP 与摘要。
+- WebUI 改动只在 `akasic-agent` 编写和测试；baseline 变化更新移动仓库的固定 ZIP 与摘要，兼容的运行时 UI 变化也可按 0022 发布服务端 generation。
 - Android 原生接口变化仍需先更新移动端桥合同，并通过固定组合验证；本决策不授权修改核心协议或持久状态。
 - 移动仓库删除 `frontend/chat` 源码和 Node 构建链，CI 改为校验固定 WebUI 产物并构建 Android。
 

--- a/docs/decisions/0022-mobile-webui-uses-server-selected-generations.md
+++ b/docs/decisions/0022-mobile-webui-uses-server-selected-generations.md
@@ -1,0 +1,54 @@
+# 0022 · 移动 WebUI 使用服务端选择的不可变 generation
+
+- 状态：accepted
+- 日期：2026-08-03
+- 关联条款：WEBUI-001～WEBUI-006、MOB-001～MOB-004、GOV-005、TST-006～TST-008
+- amends：[0018](0018-chat-webui-has-one-source-and-two-adapters.md)
+- 设计：[服务端发布的移动 WebUI OTA](../design/server-published-mobile-webui.md)
+
+## 背景
+
+决策 0018 把 `frontend/chat` 固定为唯一源码真源，并要求 Android 把由干净提交生成的 ZIP 放进 APK。这个基线保证离线构建和可复现性，但任何颜色、布局、抽屉 island 或既有桥交互变化都要重新发布 APK，无法满足服务端明确发布界面后让已配对设备收敛的产品目标。
+
+直接让 WebView 打开远程页面会把网络可用性、服务端瞬时状态和页面执行混成同一个启动条件，也会把凭据、任意导航和不完整资源带进 Web 容器。客户端维护一条包含检查、下载、等待页面状态和激活的总状态机，则会让每个网络与生命周期 edge case 增加新的全局跳转。
+
+## 决定
+
+1. APK 内固定 ZIP 继续作为 embedded baseline，而不是移动 WebUI 的唯一交付来源。Android 无网络、未配对、目标不兼容、资源损坏或候选激活失败时始终能使用 baseline。
+2. Core 发布者拥有 WebUI generation、manifest、按内容摘要寻址的资源、Stable/Preview 指针和发布 journal。候选资源完整写入并校验后，单一发布事务才改变当前 `ReleaseView`；Runtime 只读已提交状态，不在请求路径构建 WebUI，也不因启动、重启或 watcher 自动发布。
+3. Stable 从指定提交和完整构建上下文确定性生成。Preview 可以固化未提交输入及其 provenance；它只有在提交后重建出相同 generation 时才能提升 Stable。清除 Preview、提升和回滚都是显式指针操作，不修改 generation 内容。
+4. 已配对客户端通过中立协议读取当前 `ReleaseView`，再经同一服务端身份和短期认证读取 manifest 与静态资源。客户端按 `server identity + generation + manifest digest` 识别目标，不按发布序号、时间或 semver 判断新旧；通知只提示重新解析，不直接授予目标。
+5. Android 与未来的 iOS 只保留四个事实：`desired`、`ready(desired)`、`serving` 和 `fallback`；行为收敛为 `Resolve`、`Ensure` 和 `Present`。下载与激活由不同 owner 协调，`Present` 只在 UI session 边界使用本地完整验证的资源。
+6. 每个服务端拥有独立的客户端 CAS、generation、marker 和 rejected target。embedded baseline 不参与 OTA GC；清理或重置只能减少可证明未引用的派生 UI 资源，不能触碰业务状态、配对身份或其他服务端缓存。
+7. WebUI 只表达产品界面并调用版本化 capability。新增原生能力或不兼容 bridge/snapshot 时仍发布移动二进制；现有 GitHub APK updater 与安装权限保持独立，本决定不提前改造成 Google Play 发行模式。
+8. `Resolve/Ensure` 只返回 `Ready`、`RetryAfter`、`WaitFor(trigger)` 或 `RejectTarget`。同 Target 的 `WaitFor(space)` 和永久 reject 都不因前台、重连或重复 hint 自动下载；必须等 Target/兼容指纹变化或名称明确的用户动作。candidate 由 process-scope attempt lease 持有，健康提交前的 Activity 重建不得将它提升为 serving。
+
+## 理由
+
+这个选择保留 0018 的单一源码真源、离线 baseline 和原生状态 owner，同时把“服务端当前选择什么”“本地是否完整拥有”“下一 UI session 展示什么”分给三个明确动作。不可变 generation 和内容摘要复用减少下载量，却不在 serving 目录原位打补丁；显式指针让 Preview、提升和回滚可审计，也避免客户端推测服务端发布历史。
+
+具体采用的成熟不变量及官方来源记录在关联设计的“成熟实践与采用理由”中。外部实践只说明为什么选择 embedded baseline、兼容分组、内容摘要和 session-boundary activation，不覆盖本仓库的数据 owner 与安全合同。
+
+## 状态与减少协议
+
+| 对象 | 正常增加 | 允许原位变化或逻辑失效 | 允许物理减少 | 恢复证据 |
+|---|---|---|---|---|
+| Core generation 与资源 | 显式 build/import 提交完整不可变对象 | 不原位更新；指针变化只令旧对象不再可达 | 显式 GC 只能删除当前 Stable/Preview 和发布事务均不可达的对象 | 当前 `ReleaseView`、manifest 摘要、资源摘要与发布 journal |
+| Stable/Preview 与 journal | 显式 publish/clear/promote/rollback 原子提交；journal 追加 | 指针可以原子替换，Preview 可以显式清空；journal 不改写 | 指针行不以删除资源代替更新；journal retention 另立合同 | 旧或新完整 `ReleaseView`，不能出现半提交选择 |
+| 客户端 WebUI 缓存 | `Ensure` 写临时对象，完整校验后提交 verified generation | desired/serving/fallback/attempt marker 按 owner 事务变化 | 安全 GC 或用户明确重置单个服务端 UI 缓存；必须跳过 pinned 对象 | embedded baseline、最近健康 fallback、verified marker 与逐文件摘要 |
+| 消息、草稿、outbox、附件、配对与插件状态 | 继续按各自 owner 合同变化 | 本决定不授权任何更新或逻辑失效 | 本决定不授权任何删除 | 各自数据库、文件和 owner 的既有恢复证据 |
+
+## 影响
+
+- Core 增加平台中立发布仓、显式发布命令、已认证发布发现和静态资源数据面；这是 `runtime_patch: required`，因为当前选择、跨设备收敛和回滚属于服务端权威语义。只在客户端实现会复制每台设备的发布真相，不能形成同一服务端的 Stable/Preview。
+- Android 增加按服务端隔离的派生缓存、兼容选择、激活与回退；Room、outbox、附件、通知、Keystore 和系统能力继续由现有原生 owner 管理。
+- 0018 第 4 项的固定 ZIP 变为 embedded baseline 与离线构建证据；“每次 WebUI 更新都同步移动仓库 ZIP”不再是已配对设备获得 UI-only 更新的唯一方式。
+- 协议 source、客户端 snapshot、实际 Core runtime、场景目录、Android commit、APK digest 和真机 run 继续按 0004 固定为不可变验收组合。
+
+## 验收
+
+- Core 显式发布 Preview 或 Stable 后，已配对 Android 在不安装新 APK 的情况下下载并在下一 UI session 使用对应 generation；未发布、离线或失败时继续使用本地 serving 或 baseline。
+- 构建、发布、下载、摘要、进程、WebView renderer 和健康握手的失败注入均不产生混合 generation，不让未健康页面取得写动作，也不破坏回退链。
+- 同一地址上的不同服务端身份、不同设备、多个服务端缓存和迟到回调不能串改 desired、serving 或资源。
+- 更新、回滚、GC 和重置前后的消息、草稿、outbox、附件、阅读位置、配对和插件状态逐项保持其 owner 合同。
+- 两仓库 targeted tests、固定协议组合、隔离 Docker Gate 和 run-specific 真机 Gate 均绑定当前源码与真实执行数量；旧报告、`OK (0 tests)` 或只看返回值不能通过。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -27,6 +27,7 @@
 | [0019](0019-mobile-long-messages-use-bounded-events.md) | accepted | Mobile 长消息使用有界正文事件和紧凑终态 | MOB-001、MOB-003、MOB-005、MOB-007、SES-001 |
 | [0020](0020-mobile-history-content-uses-authenticated-http-ranges.md) | accepted | Mobile 历史长正文使用认证 HTTP Range 恢复 | MOB-001、MOB-003、MOB-006、MOB-007、SES-001、TST-005、TST-008 |
 | [0021](0021-yoyo-workspace-ledger-defines-migration-origin.md) | accepted | Yoyo workspace 账本定义迁移原点 | MIG-001、MIG-002、WSP-003、BAK-001 |
+| [0022](0022-mobile-webui-uses-server-selected-generations.md) | accepted | 移动 WebUI 使用服务端选择的不可变 generation | WEBUI-001～WEBUI-006、MOB-001～MOB-004、TST-006～TST-008 |
 
 ## 新增规则
 

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -122,6 +122,20 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 
 上述状态的容量拒绝、quarantine 和 cleanup 失败只影响当前 operation/item/unit。权威 schema 损坏、owner 无法建立或提交结果不可判定时，按 `ERR-001` 与 `SEC-010` fail-loud；不得写入空成功或静默丢弃。
 
+### 3.6 移动 WebUI 发布与客户端缓存
+
+[0022](../decisions/0022-mobile-webui-uses-server-selected-generations.md) 把服务端当前 `ReleaseView` 和其可达 generation 定义为 deployment 权威状态，把设备上的 verified generation 定义为按服务端隔离的派生 UI 缓存。两者都不得借用 SessionDB、Mobile Realtime DB 或 plugin-data 的删除和恢复协议。
+
+| 对象 | 正常增加 | 允许的原位更新/逻辑终态 | 物理减少条件 | owner 与恢复证据 |
+|---|---|---|---|---|
+| `<workspace>/mobile-webui/publication.sqlite3` | 显式 build/import 增加 immutable generation/file 引用；每次 publish/clear/promote/rollback/restore 追加 journal；rollback pin 显式增加 | 单 writer 事务原子替换 Stable/Preview 指针并递增审计 sequence；generation、manifest 和 journal 既有内容不改写 | 指针不以 DELETE 代替更新；journal retention 未另立合同前不得自动减少；只有显式 unpin/GC 可减少 rollback eligibility，用户删除整个 workspace 属于其既有范围 | Core WebUI publisher；SQLite integrity、当前 `ReleaseView`、selection digest、journal、pin 与 source provenance |
+| `<workspace>/mobile-webui/blobs/` | 候选校验后以 SHA-256 创建不可变文件；相同内容复用 | 只改变 generation、指针和 pin 的可达性，不原位改 blob | 显式 publication GC 在写锁内重新读取引用，只删除 Stable/Preview、每 channel 最近 4 个选择、显式 pin、候选和进行中备份 source set 均不可达的对象 | Core WebUI publisher；manifest/file digest、blob bytes、引用扫描与 GC report |
+| `<workspace>/mobile-webui/staging/` | build/import 为当前候选创建临时对象 | 成功提交后变为 immutable CAS 引用；崩溃遗留保持未提交 | 启动恢复或显式 GC 只能删除能证明未被 publication DB 引用的 staging | Core WebUI publisher；候选 marker、publication transaction 与 orphan report |
+| 用户指定的 WebUI backup artifact | `backup` 在临时目录写 SQLite online snapshot、自包含 CAS、source manifest 与 artifact digest，完整校验后原子发布；已存在目标不覆盖 | 已发布 artifact 内容不可原位更新；它独立保留快照时的 lineage、ReleaseView、journal 和全部声明资源 | publisher 不自动删除；只有名称明确、目标精确的 backup retention/delete 操作可减少，且不能把删除备份当成 live GC | Core WebUI backup/restore owner；artifact manifest/digest、SQLite `integrity_check`、server/epoch/selection/journal 与全部 reachable member hash |
+| 移动端 app-private WebUI store | `Ensure` 在单 server staging 写入 manifest/blob，完整校验后增加 verified generation | desired/serving/fallback/attempt/reject marker 按 `Resolve/Ensure/Present` owner 更新；`WaitFor(space)` 是 coordinator 持有的进程内协调事实，不写业务 Room 表 | 安全 GC 只删除未 pinned 对象，或用户明确“重置此服务端 UI 缓存”；必须先取消并等待该 server owner，物理文件删除成功后才能删 metadata/reference，且不得删除其他 server 或业务状态 | Android/future iOS native store；embedded baseline、per-server manifest/hash、verified/attempt marker、删除失败后仍在的 owner、业务 write-set 对比 |
+
+发布仓的 `release_epoch` 是 store 初始化时生成并持久化的 lineage UUID；从备份恢复到历史 `ReleaseView` 后保持备份中的 lineage 与当前选择。客户端不使用 epoch、sequence 或时间排序，因此恢复不会要求伪造更大的版本号。正式备份必须在同一 source snapshot 中列出 `publication.sqlite3`、当时所有数据库声明的 generation/blob、rollback pin 和 artifact digest；只复制数据库或只复制目录都不能证明可恢复。backup source set 在快照完成前 pin，避免与 live GC 竞态；恢复先在隔离目录验证 SQLite `integrity_check`、server identity、epoch、ReleaseView/selection、journal 连续性及每个 manifest/member digest，再原子替换 live publication root，替换前另建可恢复备份，替换后重复全部校验。
+
 ## 4. 再看上层所有权
 
 ```text
@@ -179,6 +193,10 @@ workspace 之外还有两组明确的全局状态：
 <workspace>/
 ├── sessions.db
 ├── migrations.sqlite3                 Yoyo 迁移成功回执
+├── mobile-webui/
+│   ├── publication.sqlite3             WebUI generation、ReleaseView 与 journal
+│   ├── blobs/sha256/<prefix>/<digest>  不可变静态资源
+│   └── staging/                         未提交候选；可证明 orphan 后才清理
 ├── sessions/                         目前只创建目录，未找到生产写入者
 ├── schedules.json
 ├── PROACTIVE_CONTEXT.md
@@ -468,6 +486,7 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 5. SQLite 分别 backup 时，每个文件内部一致，但多个数据库与普通文件之间没有全局事务时点。
 6. 备份范围没有明确包含或排除 `.app-server-token`、diagnostic traces、全局凭据和全局插件 manifest。
 7. `mcp/servers/*.toml` 与 workspace 手工 skill 目录仍绕过插件安装系统，形成第二套能力 owner；现存内容尚未迁移。
+8. 通用 rolling backup 尚不能把 WebUI publication DB 与它引用的 blobs 作为同一一致性 source；首版 publisher 必须至少导出可审阅 reachable manifest，并在发布正式资源前完成隔离恢复 smoke。
 
 这些缺口正是 `BAK-001` 和 `NOW.md` 中恢复演练事项尚未完成的部分。
 

--- a/docs/design/server-published-mobile-webui.md
+++ b/docs/design/server-published-mobile-webui.md
@@ -1,0 +1,616 @@
+# 服务端发布的移动 WebUI OTA 设计
+
+- 状态：proposed；产品边界、三步协调模型和 edge case 语义已经确认，持久化落点、线协议字段、资源上限和实施合同仍待确认
+- 日期：2026-08-03
+- 关联决策：[0018](../decisions/0018-chat-webui-has-one-source-and-two-adapters.md)
+- 关联条款：WEBUI-001～WEBUI-003、MOB-001、STA-001～STA-003、CAP-001～CAP-002、ERR-001、TST-006～TST-008
+- 涉及仓库：`akasic-agent`、`akashic-mobile`
+
+## 1. 文档边界
+
+本文固化已经确认的产品边界、发布模型、Android 三步协调模型、回滚语义和 edge case。它不是实现批准，也不把尚未修改的现行合同描述成已经支持 OTA。
+
+本文使用三种标记：
+
+- **F（fact）**：当前代码或现行合同已经能证明的事实。
+- **C（confirmed）**：维护者在本轮设计中已经确认的目标语义。
+- **U（unknown）**：仍会影响持久状态、协议兼容或实施范围的待确认项。
+
+在新决策被接受、相关需求条款完成勘误、两仓库实现和 Gate 通过前，当前 APK 内固定 ZIP 仍是唯一已实现路径。
+
+## 2. 用户意图与成功边界
+
+**C：** 产品界面由同一份 WebUI 表达。顶部栏、抽屉、抽屉中的 island、会话列表、消息、输入区、插件面板和产品设置都属于 WebUI。调整样式、布局或只使用已有桥能力的交互时，服务端发布新 WebUI 即可，不要求重新发布 APK。
+
+**C：** Kotlin 和未来的 Swift 只拥有平台可信能力、设备状态和 Web 容器，不重复实现产品界面。新增原生系统能力、桥协议或不兼容快照字段时，仍需要发布 Android/iOS 二进制。
+
+**C：** 移动端不直接打开远程网页。它从已配对服务端发现发布版本，下载并验证不可变资源，写入每个服务端独立的本地缓存，再从本地可信 origin 加载。
+
+**C：** Android 先实现。协议、manifest 和状态语义保持平台中立，未来供 Swift/WKWebView 使用；本轮不创建 iOS 项目。
+
+**C：** Google Play 适配不属于本轮范围。当前 GitHub APK 检查、下载、安装入口和权限保持原状；未来真的准备提交 Google Play 时再单独设计发行边界，本设计不提前删除或隐藏现有能力。
+
+用户能观察到的最终边界是：
+
+| 变化 | 是否只发布 WebUI | 是否发布移动二进制 |
+|---|---:|---:|
+| 调整颜色、间距、动效、抽屉布局 | 是 | 否 |
+| 在抽屉增加只使用现有数据和动作的 island | 是 | 否 |
+| 调整消息、输入区、插件面板的组合方式 | 是 | 否 |
+| 使用 manifest 已兼容的桥字段或 capability | 是 | 否 |
+| 新增相机、通知、文件选择、系统分享等原生能力 | 否 | 是 |
+| 改变 bridge/snapshot 协议且旧客户端不能兼容 | 否 | 是 |
+| 修改 Kotlin/Swift 生命周期、数据库、网络或安全逻辑 | 否 | 是 |
+
+## 3. 当前事实与合同冲突
+
+- **F：** `frontend/chat` 是桌面和移动 WebUI 的唯一源码真源；`mobile-native.tsx` 是移动入口。
+- **F：** `scripts/package-mobile-web.sh` 当前只接受整个 Git tree 干净的源码，生成完整 ZIP、SHA-256 和 schema v1 manifest。
+- **F：** Android 当前把固定 ZIP 作为 Gradle 输入，构建时校验并解包进 APK。
+- **F：** Android 通过 `WebViewAssetLoader` 从 `https://appassets.androidplatform.net` 加载 APK 资产并阻止外部资源请求。Native→Web 使用指定 origin 的 `postWebMessage`；Web→Native 当前仍通过 `addJavascriptInterface`，在服务端下发 JS 前需要收窄。
+- **F：** Room、outbox、附件传输、通知、Keystore、配对、系统 Activity result 和生命周期由 Android 原生层拥有。
+- **F：** Core 已有配对后的 WSS 与同源认证 HTTPS 传输模式，可以作为发布发现与资源下载的现有信任基础。
+- **F：** [0018](../decisions/0018-chat-webui-has-one-source-and-two-adapters.md) 和移动仓库的现行合同要求固定 ZIP、干净 commit、构建期解包且无网络 fallback。
+
+因此，服务端发布 OTA 不是对现有实现的自然解释，而是对“移动产物怎样交付”这一部分合同的有意改变。它不改变 WEBUI-001～WEBUI-003 的单一源码真源和状态 owner；后续接受设计时必须用新决策明确勘误 0018，并同步修改移动仓库对应合同。
+
+### 3.1 成熟实践与采用理由
+
+本设计不引入 Expo、Ionic 或 OCI 依赖，只采用它们已经验证的发布不变量：远程选择与本地运行分离、资源不可变、下载与激活分离、原生兼容性先于 WebUI 选择、失败时始终存在内嵌回退。
+
+| 成熟实践 | 官方行为 | 本设计采用的抽象 |
+|---|---|---|
+| [Expo Updates](https://docs.expo.dev/versions/latest/sdk/updates/) | 默认启动时检查并下载，下一次启动才应用；binary 中保留 embedded update | `Ensure` 可以后台运行，`Present` 只在 UI session 边界运行；APK baseline 永久可用 |
+| [Expo runtime versions](https://docs.expo.dev/eas-update/runtime-versions/) | 远程更新必须匹配原生 runtime compatibility | `Target` 在下载前检查 native、bridge、snapshot 和平台兼容范围 |
+| [Expo error recovery](https://docs.expo.dev/eas-update/error-recovery/) | 首次内容出现前失败可以回退；已经运行后的回退不能假装撤销持久副作用 | candidate 健康前不开放有副作用 bridge；回退只切换 UI，不回滚原生业务事实 |
+| [Ionic Appflow background strategy](https://ionic.io/docs/appflow/deploy/setup/capacitor-sdk) | 推荐后台下载、下次启动应用；需要前台重载时只阻止少量 critical workflow | 页面 modal、手势和选区不进入原生状态机，只保留一个 `canReplaceUi` 原生判定 |
+| [Ionic differential updates](https://ionic.io/docs/appflow/deploy/differentials) | manifest 为每个文件保存 hash，只下载变化文件 | `Ensure(Target)` 按 content hash 复用 blobs，不在 serving 目录原位打补丁 |
+| [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) | blob 由 digest 标识，manifest 引用 blobs，可变 tag 选择不可变内容 | generation 是不可变内容；Stable/Preview 只组成当前 `ReleaseView` |
+| [Android WebViewAssetLoader](https://developer.android.com/develop/ui/views/layout/webapps/load-local-content) | 应用内资源从 HTTPS 语义的本地 origin 加载 | 下载和校验由原生完成，WebView 只看本地 generation |
+| [Android WebView termination handling](https://developer.android.com/develop/ui/views/layout/webapps/handle-termination) | renderer 退出后不得复用旧 WebView；重复崩溃不能无限重载同一页面 | 单次重建 serving，重复失败回 fallback并 `RejectTarget` |
+| [Android WorkManager unique work](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/manage-work) | unique work 避免同一目标重复排队，并定义替换策略 | 每个 server 只有一个 `Ensure` owner；新 `Target` 取代旧工作 |
+
+这些实践共同指向一个更小的心智模型：客户端不维护“正在检查、等待激活、重新下载”等平行状态机，而是持续回答三个问题：服务端当前想要什么、本地是否已经完整拥有它、下一次 UI session 应展示什么。
+
+## 4. 能力和状态所有权
+
+```text
+┌────────────────────── akasic-agent / Core ──────────────────────┐
+│ WebUI 源码与构建          发布者               Runtime           │
+│ 产品界面、主题、组件  →  manifest + blobs  →  只读发现与下载接口 │
+└───────────────┬───────────────────────┬─────────────────────────┘
+                │ WSS 发布描述           │ 同身份 HTTPS 资源
+                ▼                       ▼
+┌──────────────────── Android / future iOS ───────────────────────┐
+│ 配对与认证 → desired/ready → serving/fallback → 本地 origin       │
+│ Room/outbox/附件/通知/系统能力/生命周期/激活协调器由原生层拥有    │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │ versioned snapshot/patch/actions
+                               ▼
+                     ┌──────────────────────┐
+                     │ WebView 产品界面     │
+                     │ 无凭据、无任意网络、 │
+                     │ 无文件路径与发布权限 │
+                     └──────────────────────┘
+```
+
+| 对象或能力 | 权威 owner | WebUI 权限 |
+|---|---|---|
+| 主题、排版、导航、抽屉、island、消息和输入区视觉 | `frontend/chat` | 创建和渲染 |
+| WebUI generation、manifest、Stable/Preview 指针 | Core 发布者 | 无 |
+| 会话和消息真源 | Core SessionDB | 只读取原生层给出的投影 |
+| 移动会话投影、阅读位置、草稿、outbox | 移动原生存储 | 展示并发出受约束动作 |
+| 配对身份、TLS、token、下载 ticket | 移动原生层与 Core | 不可读取 |
+| 附件上传下载、系统文件选择、相机、通知、分享 | 移动原生层 | 只调用 capability 白名单 |
+| 插件运行状态和真实外部效果 | Core/插件 runtime | 只查询投影并提交显式动作 |
+| WebUI 下载、校验、激活、回滚、GC | 移动原生层 | 只能参与 reload handshake |
+| APK/未来 IPA 的构建、签名、安装和商店发布 | 平台发行链 | 无 |
+
+WebUI 只能接收：
+
+1. 版本化完整 snapshot 与有序 patch。
+2. 业务动作 bridge，例如发送、重试、切换会话和插件查询。
+3. 原生 capability 白名单及其明确成功、失败或取消结果。
+4. reload 前的通用 durable ack 和 reload 后的 ready/healthy 握手。
+
+WebUI 不得获得设备凭据、任意文件路径、任意 SQL、任意网络、发布指针写入、资源缓存写入、APK 安装或绕过原生校验的能力。
+
+## 5. 目标发布结构
+
+### 5.1 每个服务端独立发布
+
+**C：** 已配对服务端是 WebUI 的信任根和版本 owner。每个 `server_id` 拥有独立 Stable、Preview、generation 集合、客户端缓存、激活状态和 rejected TargetKey 集合。服务端 A 的资源、指针或失败不得影响服务端 B。
+
+```text
+WebUI source inputs
+       │
+       ▼
+┌───────────────┐   验证成功   ┌──────────────────────────────┐
+│ 离线构建候选  ├─────────────→│ 不可变 generation            │
+└───────────────┘              │ manifest + CAS blobs/archive │
+                               └──────────────┬───────────────┘
+                                              │ 原子提交
+                         ┌────────────────────┴──────────────────┐
+                         ▼                                       ▼
+                  Stable pointer                         Preview pointer
+                         │                                       │
+                         └───────── current ReleaseView ─────────┘
+                                              │
+                           WSS descriptor + HTTPS content
+                                              │
+                                              ▼
+                               per-server native local cache
+```
+
+构建、校验和资源写入发生在候选区。只有全部成功后，单一发布者才原子提交 Stable/Preview 指针组成的 `ReleaseView`。Runtime 只读取已提交发布，不在请求路径运行 Node/Vite，也不拥有发布写权限。
+
+`ReleaseView` 是“服务端现在选择什么”的完整快照，至少包含 server identity、Stable target、可选 Preview target 和每个 target 的 manifest digest。规范化选择内容计算 `selection_digest`；审计 journal 可以记录每次发布事件，但客户端不按 journal 序号、发布时间或 semver 推断新旧。
+
+这一点有意采用 OCI mutable tag 的语义：客户端每次只解析当前指针。显式回滚可以重新得到一个历史上出现过的 `selection_digest`，这是相同 desired state，不需要伪造一个“更大版本号”。每个 server 的 `Resolve` 单飞串行，迟到响应用本地 resolve token 丢弃，因此服务端备份恢复也不需要客户端理解 release lineage。
+
+### 5.2 三层来源
+
+| 来源 | 用途 | 生命周期 |
+|---|---|---|
+| Embedded baseline | APK 永久安全底座、首次启动和最终回退 | 永不被 OTA 覆盖或 GC |
+| Stable | 服务端默认生产 WebUI | 由显式发布命令原子推进或回滚 |
+| Preview | 服务端级试验 WebUI | 由显式发布、清除或提升操作改变 |
+
+**C：** Preview 对该服务端配对的全部设备生效，不是单设备选择。Preview 效果不好时，发布者可以清除 Preview 或把指针回退到旧 generation；客户端下一次成功 Resolve 后收敛到当前 ReleaseView。
+
+**C：** 保存源码、构建成功、文件 watcher 或重启 Core 都不得自动发布。Stable 和 Preview 都必须由名称明确的发布命令提交。Watcher 只能发送“有新发布可检查”的提示。
+
+### 5.3 Preview 与 Stable 可复现性
+
+- Preview 允许使用有未提交 WebUI 输入的源码，但构建前必须固化 base commit、patch/tree digest、完整 build context、产物 digest、`reproducible=false` 和 dirty provenance。
+- Stable 只从指定 commit 的隔离 source snapshot、固定 lockfile/config/toolchain 构建，并且只接受 `reproducible=true` 的 generation。
+- 当前开发 checkout 的后端、测试、文档甚至 WebUI dirty 都不影响从指定 commit 发布 Stable；它们不会进入隔离 source snapshot。
+- dirty WebUI 输入不能通过忽略标记或伪造 commit 进入 Stable。
+- 同一 generation ID 对应不同内容时 fail-loud；完全相同内容重复发布可以成为 no-op，但不能伪造新的资源内容。
+- `reproducible=true` 的 Preview 可以原样提升 Stable。dirty Preview 必须先提交其真实输入，并从隔离 snapshot 重建出完全相同 generation；若产物不同，先发布新的 Preview 重新验证，不能把未复现的 dirty artifact 提升 Stable。
+
+### 5.4 Manifest 语义
+
+generation manifest 至少表达以下语义；最终字段名和编码在协议设计中确认：
+
+- `manifest_schema`
+- `generation_id`
+- source repository、commit/base、WebUI 输入 digest 和 dirty provenance
+- bundle/render digest 与构建工具身份
+- bridge protocol 与 snapshot protocol 范围
+- minimum native build、platform 和可选 WebView 约束
+- entrypoint
+- 每个文件的相对路径、content hash 和 size
+- archive hash、总解包 size 和文件数量
+- `reproducible`
+- builder/publisher identity 和可复现构建信息
+
+channel、Stable/Preview、发布时间、发布事件和当前选择不进入 generation manifest；它们属于 `ReleaseView` 或发布 journal。这样同一 Preview generation 才能原样提升 Stable。
+
+`generation_id` 由经过规范化的 manifest 内容和资源内容决定，不由可变 channel、服务器路径或客户端时间决定。`TargetKey = server_identity + generation_id + manifest_digest`；generation 自身不可变。
+
+## 6. 增量同步与缓存
+
+**C：** 增量的含义是 `Ensure(Target)` 按 content hash 复用 blobs，不是在 serving 目录原位覆盖文件，也不是把补丁执行权限交给 WebView。
+
+1. 客户端先获取并验证 manifest。
+2. 客户端按 `server_id + content_hash` 检查已有 blobs。
+3. 冷缓存或缺失比例较大时下载完整 archive；少量缺失时只下载缺失 blobs。
+4. 校验每个 blob、完整文件树和 bundle digest。
+5. 从不可变 blobs 物化 verified generation，使 `ready(Target)=true`。
+6. serving generation 在 Present 健康提交前保持不变。
+
+客户端不得跨 `server_id` 共享 CAS，即使 hash 相同。这样可以防止服务端身份撤销、保留策略和故障归属被全局去重混淆。
+
+所有可用网络默认允许后台下载，不按 Wi-Fi/蜂窝做产品级禁用；下载必须受单文件、文件数、总压缩量、总解包量、压缩比、时间、并发和磁盘余量的硬限制。具体数值仍是 U。
+
+## 7. Android 组件边界
+
+目标 Android 原生层包含以下职责，名称表达职责而不是预先锁定类结构：
+
+| 组件 | 职责 |
+|---|---|
+| `ReleaseResolver` | 串行读取当前 `ReleaseView`，得到唯一 compatible `desired Target`；hint 只令它重新解析 |
+| `ArtifactEnsurer` | 每 server 单 owner，把 desired target 变成完整、已验证的本地 artifact；统一重试、等待和拒绝语义 |
+| `UiSessionController` | 在 UI session 边界选择 serving、执行短暂 activation marker、健康提交和回退 |
+| `LocalWebUiStore` | 保存 per-server blobs、verified generation、serving/fallback marker，并提供本地 asset handler 与安全 GC |
+
+这些组件不得修改 SessionDB、Room 消息、outbox、草稿、附件、配对密钥或插件真源。WebUI 更新失败只改变派生资源、发布选择和诊断状态。
+
+## 8. 客户端三步协调模型
+
+客户端不实现一条把 `CHECKING`、`DOWNLOADING`、`WAITING_SAFE_POINT`、`ACTIVATING` 串起来的全局状态机。检查网络和替换 WebView 是两个独立 owner；把它们硬连成状态机会让每个新 edge case 都增加跳转。
+
+客户端只持久化或推导四个事实：
+
+| 事实 | 含义 |
+|---|---|
+| `desired` | 最近一次成功、已认证 `Resolve` 得到的 compatible Target；没有则为 baseline |
+| `ready(desired)` | `LocalWebUiStore` 能否证明 desired 的 manifest、blobs 和物化目录完整且匹配 |
+| `serving` | 当前 UI session 实际加载的 generation 或 embedded baseline |
+| `fallback` | 最近一次健康 serving；不可用时为 embedded baseline |
+
+所有行为只有三个幂等动作：
+
+```text
+authenticated trigger
+        │
+        ▼
+┌────────────────┐       desired Target
+│ Resolve(server)├─────────────────────────┐
+└────────────────┘                         ▼
+                                    ┌────────────────┐
+                                    │ Ensure(Target) │  网络、hash、CAS、磁盘
+                                    └───────┬────────┘
+                                            │ ready
+                                            ▼
+UI session boundary ───────────────→┌────────────────┐
+                                    │ Present(Target)│  只读本地资源，不等网络
+                                    └───────┬────────┘
+                                            ▼
+                                          serving
+```
+
+`Resolve` 回答“服务端当前想要什么”；`Ensure` 回答“本地是否完整拥有它”；`Present` 回答“这次 UI session 展示什么”。下载失败不改变 serving，激活等待不占用下载 worker，WebView 页面状态也不影响后台下载。
+
+维护者判断行为时只使用下面五条规则：
+
+| 问题 | 唯一规则 |
+|---|---|
+| 什么时候检查 | 配对成功、重连、进入前台、hint、手动检查时 `Resolve`；同 server 请求合并 |
+| 什么时候下载 | 当前 desired 不是 baseline，且 `ready(desired)=false` 时 `Ensure` |
+| 什么时候等待 | 只有 `RetryAfter` 的计时、`WaitFor` 的明确事件，或 ready 后等待 UI session 边界 |
+| 什么时候重新下载 | 当前 desired 改变，或 ready/partial 的完整性证据失效；只补缺失或损坏 blob |
+| 什么时候替换页面 | `ready(desired)=true`、desired 与 serving 不同、到达 UI session 边界且 `canReplaceUi=true` |
+
+### 8.1 Resolve：什么时候检查
+
+以下事件令每 server 的 resolver 重新读取当前 `ReleaseView`：
+
+- 配对认证完成。
+- 已认证连接重新建立。
+- 应用进入前台。
+- 收到 release hint。
+- 用户手动检查。
+
+同一 server 同时只有一个 resolve 请求。请求期间到达的多个 hint 合并为一个 dirty bit；当前请求结束后最多再查一次。hint 不携带可直接下载或激活的 target。客户端用本地 resolve token 忽略旧请求结果，不比较远端 publication sequence、时间或 semver。
+
+选择规则固定为：compatible Preview、compatible Stable、当前 serving、embedded baseline。Preview 和 Stable 都只是 `ReleaseView` 中的指针；服务端回滚后，下一次成功 Resolve 直接得到旧 generation 作为新 desired。
+
+### 8.2 Ensure：什么时候下载、等待和重新下载
+
+`Ensure(Target)` 是每 server 唯一、latest-wins 的后台工作。只有同时满足以下条件才访问网络：
+
+1. target 来自当前已认证 `ReleaseView`。
+2. target 与 native、bridge、snapshot 和平台兼容。
+3. 本地还不能证明该 target 已 ready。
+
+它先取得 descriptor 锚定的 manifest digest，再只下载缺失 blobs。进程重启、应用进入前台、Runtime 重启或重复 hint 都不会令已验证 target 重下。
+
+Resolve/Ensure 对外只产生四种协调结果，不新增全局状态：
+
+| 结果 | 典型条件 | 下一步 |
+|---|---|---|
+| `Ready` | target 已完整验证，或本次补齐后验证成功 | 等待 `Present`；不再访问网络 |
+| `RetryAfter` | 离线、超时、连接中断、临时 5xx | 保持 serving；有界退避，reconnect 或手动检查可提前触发 |
+| `WaitFor(trigger)` | 未认证、空间不足、native 不兼容、系统限制后台工作 | 不轮询；只等明确的 auth、space、binary upgrade、OS 或新 ReleaseView 事件 |
+| `RejectTarget` | manifest/path 非法、当前发布 404、重复 hash 冲突、超硬限制 | 同一 TargetKey 不再自动尝试；只接受新 target 或用户显式重试 |
+
+重新下载只发生在以下情况：
+
+- 当前 desired 改变，新的 `Ensure` 替换旧任务；已验证、同 server 的 blobs 继续复用。
+- partial 有相同 strong ETag/content digest 和 Range 证据时续传；否则只重下该 blob。
+- 本地已存 blob 自检损坏时删除该 blob 并补一次；连续从服务端取得错误内容则 `RejectTarget`。
+- ticket 401 时重新认证获取一次绑定 ticket；仍失败转 `WaitFor(auth)`，不匿名重试。
+- 用户执行“重置此服务端 UI 缓存”后显式手动重试，或服务端提交了不同 TargetKey。
+
+新 desired 出现时，旧下载可以安全取消，也可以完成当前不可分割写入；无论哪种方式，只有当前 desired 可以进入 `Present`。临时文件、旧 target 和已验证共享 blobs 的清理由 store 引用关系决定，不由 worker 猜测。
+
+### 8.3 Present：什么时候替换 WebView
+
+`Present` 永远不等待网络。它只在本地已经 `ready(desired)` 时考虑切换，并且只在 UI session 边界运行：
+
+- 冷启动创建第一个 WebView 前。
+- 应用从不可见回到前台、准备重新开放 UI 动作前。
+- 切换到另一个 server 的 UI session。
+- 用户点击“立即应用已下载更新”。
+
+Activity 因旋转或系统重建但仍属于同一 UI session 时，继续加载原 serving，不借机切换版本。应用持续停留前台时不强制打断；界面只显示“已下载，将在下次进入应用时使用”，用户可以显式立即应用。
+
+原生层只暴露一个 `canReplaceUi` 判定，不理解页面里的 modal、选区、抽屉、手势或各类 island：
+
+1. 当前没有等待系统回调的文件选择、保存、权限或设置页请求。
+2. incoming share 已复制到原生持久区。
+3. 原生层可以生成一份完整、身份明确的 snapshot。
+4. 没有另一次 activation、server switch、reset 或 revoke 持有 owner。
+
+streaming、stop、outbox、上传和下载本身不阻止替换，只要它们由原生 owner 持久化并能进入 snapshot。重要草稿和 island 输入必须使用通用 durable draft/capability；只存在于 DOM 的临时展开、选择和未提交表单不升级成原生状态。
+
+### 8.4 短 activation transaction
+
+满足边界后，唯一 `UiSessionController` 执行以下短事务：
+
+1. 重新读取当前 desired、ready 证据、server identity 和 `canReplaceUi`。
+2. 关闭旧页面的普通 action admission；fence 后请求明确返回 `ui_reloading`。
+3. 写入 `attempting TargetKey`、fallback、activation nonce 和当前 native/WebView compatibility fingerprint。
+4. 销毁旧 WebView，从 generation-specific 本地 URL 创建 candidate WebView。
+5. candidate 先以只读 bridge 完成 exact origin、nonce、generation 和协议握手。
+6. 原生发送完整 snapshot；页面完成 root render 和首次 visual acknowledgment。
+7. 原子提交 serving、清除 attempting，再开放有副作用的业务动作。
+
+candidate 自己的 `reportHealthy` 只是证据之一，不能单独提交 serving。关键资源错误、协议身份不符、snapshot apply 失败、首次 visual acknowledgment 超时或 renderer termination 都使事务失败。
+
+### 8.5 恢复、回滚和 rejected target
+
+- activation 失败：立即加载 fallback；fallback 不可用时加载 embedded baseline。
+- 启动发现 `attempting`：说明上次 activation 未提交。直接使用 fallback，并把精确 TargetKey 标为不再自动激活；诊断记为 `activation_incomplete`，不虚构为 renderer crash。用户可显式重试，新 TargetKey 也可重新尝试。
+- serving 单次 renderer termination：销毁旧 WebView并有界重建同一 serving；窗口内重复发生则回到 fallback/baseline，并拒绝该环境下的 TargetKey。
+- 普通服务端回滚：Resolve 得到旧 generation，Ensure 复用本地 blobs，下一次 UI session 边界 Present。
+- emergency revoke：这是唯一可以绕过普通 session 边界的路径。先关闭 bridge admission，再回到已验证 fallback 或 baseline；原生持久状态不回滚。
+- “样式不好看”不是健康失败。发布者显式清除 Preview 或把 Stable/Preview 指针改回旧 generation；客户端只协调 desired state。
+
+## 9. 清理与重置
+
+**C：** embedded baseline 永久保留。客户端只 pin 当前 serving、fallback、ready desired 和 attempting 所引用的 generation 及其 blobs。Stable/Preview 是服务端选择，不自动让客户端永久保留两个 channel 的全部历史。
+
+正常稳定状态通常只有 serving 与 fallback 两代；desired 正在下载或激活时短暂增加一代。最终实现同时设置每 server generation 数和总字节硬上限，具体数值在真实 bundle 测量后确认。达到上限时先删未引用对象；若 pinned 集合本身超过预算则 `WaitFor(space)`，不得破坏回退链。
+
+客户端提供两个名称明确的动作：
+
+| 动作 | 允许改变 | 不得改变 |
+|---|---|---|
+| 清理未使用 UI 资源 | 删除各服务端未被 serving/fallback/ready desired/attempting 引用的派生 blobs、archive 和 orphan staging | pinned generation、baseline、业务数据和凭据 |
+| 重置此服务端 UI 缓存 | 取消并等待该 server 的 Ensure/Present owner 退出，回到 baseline，删除其派生 UI 缓存，并将当前 TargetKey 置为需手动重试 | 配对身份、Room、outbox、草稿、附件、SessionDB、插件数据和其他服务端缓存 |
+
+不提供任意本地版本选择器。正常版本选择由服务端当前 `ReleaseView` 决定；客户端只保留恢复所需 generation。重置后不会在下一个周期立即偷偷重下同一 TargetKey；用户手动重试或服务端 target 改变后才重新 Ensure。低磁盘时先运行安全 GC，空间仍不足则保留当前 UI、停止下载并明确报告，不删除 pinned 资源制造“成功”。
+
+持久对象的最低语义如下；具体目录和 schema 是 U：
+
+| 对象 | 正常增加 | 允许更新或逻辑失效 | 物理减少条件与 owner | 恢复证据 |
+|---|---|---|---|---|
+| 服务端 immutable generation | 成功构建并验证后新增 | 被新指针 supersede，不改内容 | 无指针/租约引用且满足保留协议时由发布 GC 删除 | manifest、blob hash、发布日志 |
+| 服务端 CAS blob/archive | 以 content hash 新增 | 只改变引用可达性 | 无 generation/候选引用时由发布 GC 删除 | hash、size、引用扫描 |
+| Stable/Preview pointer 与 `ReleaseView` | 发布事务创建 | 单 writer 原子替换当前选择；Preview 可显式清除 | 不直接删除所指内容；旧 generation 按 GC 协议处理 | 当前 ReleaseView、selection digest、发布 journal |
+| 客户端 generation/blob cache | Ensure 验证后新增 | serving/fallback/desired/rejected 改变引用状态 | 仅上述清理、重置或安全 orphan recovery | hash、manifest、per-server reference set |
+| `attempting` marker | Present 关闭旧 bridge 后写入 | 成功清除；未提交恢复为 rejected-for-auto TargetKey | 只能由完成或启动恢复事务清除 | fallback、nonce、TargetKey、启动恢复报告 |
+| embedded baseline | 随 APK 安装 | APK 升级替换整个应用版本 | OTA 和 UI GC 永远无权删除 | APK 签名和内嵌资源 hash |
+
+## 10. 信任和网络边界
+
+**C：** 不新增独立 WebUI 签名密钥。信任链来自现有配对服务端身份：
+
+```text
+paired server identity
+        │ authenticated WSS
+        ▼
+release descriptor ── short-lived bound ticket ──→ same server HTTPS
+        │                                         manifest / blobs
+        └──────────────── hashes + limits ────────────────────┘
+```
+
+- descriptor 必须来自已认证 WSS，并绑定 `server_id`、设备、`selection_digest`、Stable/Preview TargetKey 和 manifest digest。
+- 下载 ticket 短时有效、一次或有界使用，绑定资源和配对 epoch；401 只能重新获取 ticket，不能降级匿名下载。
+- HTTPS 不跟随任意 host redirect；最终 TLS/服务端身份必须与配对身份一致。
+- 设备 revoke 后停止新发现和下载，关闭该服务端 bridge admission，并按明确产品动作决定是否保留已验证缓存；不得继续把旧 ticket 当授权。
+- WebView 继续只加载原生提供的本地可信 origin，generation 进入 URL path；entry HTML 使用 `no-store`，content-hash asset 可以 immutable。CSP 不开放任意网络，外部链接交给系统浏览器。
+- WebView navigation、subresource 和 service worker 不得绕过 asset handler 访问发布服务器或第三方。
+- Web→Native bridge 使用 exact-origin、main-frame 的单一版本化消息 envelope；Android 优先使用带 `allowedOriginRules` 的 [WebViewCompat.addWebMessageListener](https://developer.android.com/reference/androidx/webkit/WebViewCompat#addWebMessageListener)。candidate 健康前不开放有副作用 capability。Android 官方把加载不可信内容的 JavaScript interface 列为高风险边界，见 [WebView native bridge security](https://developer.android.com/privacy-and-security/risks/insecure-webview-native-bridges)。
+- archive 必须拒绝绝对路径、`..`、重复规范化路径、symlink、特殊文件、zip bomb、超限文件数和超限解包体积。
+- manifest、文件 hash、archive hash 或 content length 不一致时 fail-loud，不使用“尽量能打开”的部分版本。
+
+## 11. Edge case 合同矩阵
+
+每个 case 必须归入发布事务、`Resolve`、`Ensure`、`Present` 或 Store 中的一个 owner。新增 case 只能选择已有结果 `Ready / RetryAfter / WaitFor / RejectTarget` 或 Present 的 commit/fallback，不得为单个异常再造一条全局状态。
+
+### 11.1 构建与发布
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| PUB-001 | 当前 Git worktree 有无关后端、测试或文档 dirty | Stable 从指定 commit 的隔离 source snapshot 构建；当前 checkout dirty 不参与判断 |
+| PUB-002 | WebUI 构建输入含未提交变化 | 只允许 Preview；固化 base commit、patch/tree digest、产物和 `reproducible=false` |
+| PUB-003 | 构建、manifest、磁盘或校验失败 | 不创建可见 generation，不改变 ReleaseView |
+| PUB-004 | 资源写入后、ReleaseView 提交前崩溃 | 当前选择不变；候选成为可证明未引用的 orphan |
+| PUB-005 | ReleaseView 提交过程中崩溃 | 恢复后只能读到完整旧选择或完整新选择 |
+| PUB-006 | 并发 Stable/Preview 发布 | 单 writer 或 compare-and-swap；后到者基于当前 ReleaseView 重验 |
+| PUB-007 | 同一 generation ID 对应不同内容 | fail-loud，不覆盖任何旧内容 |
+| PUB-008 | 相同内容重复 Preview | 允许 no-op；复用同一 generation/blobs |
+| PUB-009 | Preview 提升 Stable | 只允许 `reproducible=true` 或已从提交输入重建出相同 generation 的 Preview；指针改变与 Preview 清除一次事务提交 |
+| PUB-010 | watcher、保存源码或 Runtime 重启 | 不自动发布；最多在已提交后发 hint |
+| PUB-011 | Stable 回滚到旧 generation | 改变当前指针；若完整选择与历史相同，允许得到相同 selection digest |
+| PUB-012 | Stable 回滚时 Preview 仍存在 | 明确提示 Preview 仍优先，不暗中清除 |
+| PUB-013 | 发布者在事务提交前发出 hint | hint 必须由 commit 后 outbox/回调产生；过早 hint 不得暴露候选 |
+| PUB-014 | 发布 GC 与指针提交并发 | ReleaseView 可达对象在同一引用/租约协议下 pin；不得提交指向缺失 blob 的选择 |
+| PUB-015 | commit 相同但 lockfile、构建配置、toolchain 或环境不同 | WebUI build context fingerprint 不同；Stable 可复现证据必须覆盖全部真实输入 |
+| PUB-016 | 发布仓从备份恢复到旧选择 | 恢复后的当前 ReleaseView 是 desired truth；审计 journal 记录恢复，但客户端不比较历史序号拒绝它 |
+
+### 11.2 发现、认证和身份
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| AUTH-001 | 未配对 | 只用 baseline，不请求远程 descriptor |
+| AUTH-002 | WSS 未认证或会话失效 | 不接受 ReleaseView，继续 serving/baseline；`WaitFor(auth)` |
+| AUTH-003 | 收到 release hint | 经认证重新查询，不直接信任 hint 内容 |
+| AUTH-004 | 旧 Resolve 在本地目标已改变后返回 | resolve token 不匹配即丢弃；同一 server 不并发提交两个结果 |
+| AUTH-005 | ticket 过期 | 重新鉴权获取 ticket；不匿名重试 |
+| AUTH-006 | ticket 设备、资源或 pairing epoch 不匹配 | 拒绝并报告认证失败 |
+| AUTH-007 | 设备被 revoke | 立即关闭 bridge admission并回 baseline；停止 Resolve/Ensure，保留业务数据和已验证缓存直到明确清理 |
+| AUTH-008 | HTTP redirect 到其他 host | 拒绝，不携带 ticket 跳转 |
+| AUTH-009 | TLS identity 改变 | 停止更新并要求重新配对，不静默接受 |
+| AUTH-010 | server identity 变化但地址相同 | 视为新服务端；旧缓存不能继承 |
+| AUTH-011 | 地址改变但固定 server identity 相同 | 只有经过配对 profile 的显式重绑定/验证才沿用缓存；redirect 不能完成重绑定 |
+| AUTH-012 | 相同 selection digest 或 TargetKey 返回不同规范化内容 | fail-loud，拒绝整个 ReleaseView/Target |
+
+### 11.3 网络与传输
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| NET-001 | Wi-Fi、蜂窝或受限但可用网络 | 均可自动下载，仍受统一硬限制 |
+| NET-002 | 下载中断 | 只对有明确 range/identity 的资源有界续传，否则从该 blob 重下 |
+| NET-003 | 长时间离线 | 保持 serving；最后一次已认证 desired 仍可使用本地 ready artifact，重连后重新 Resolve |
+| NET-004 | 401 | 更新一次绑定 ticket；仍失败转 `WaitFor(auth)` |
+| NET-005 | 当前 Target 的 manifest/blob 404 | `RejectTarget` 并报告发布仓损坏，不解释为“没有更新” |
+| NET-006 | 412、strong ETag 或内容身份变化 | 丢弃该 blob partial并重新 Resolve，不拼接不同内容 |
+| NET-007 | Content-Length、实际字节或 hash 超限/不符 | 删除临时对象并 fail-loud |
+| NET-008 | archive 路径逃逸、symlink、特殊文件或压缩炸弹 | 在物化前拒绝整个候选 |
+| NET-009 | Ensure A 期间 Resolve 得到 Target B | B 替换唯一 worker；A 不可 Present，已验证 blobs 可复用 |
+| NET-010 | 临时错误连续发生 | `RetryAfter` 有界退避并可观察，不阻塞 serving |
+| NET-011 | 应用或设备重启 | 先读取 verified marker/hash；完整 target 不因重启重新下载 |
+| NET-012 | 本地单个 blob 自检损坏 | 只删除并补齐该 blob；从服务端连续得到错误内容后 `RejectTarget` |
+| NET-013 | 设备离线后服务端已清除 Preview | 设备无法猜测远端变化，继续使用最后已认证 desired；重连 Resolve 后收敛，不按本地时间伪造清除 |
+| NET-014 | 客户端或服务端 wall clock 回拨/跳变 | 时间只用于展示、TTL 或退避，不用于判断 ReleaseView 新旧 |
+
+### 11.4 存储、GC 和人工清理
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| STO-001 | 下载前空间不足 | 先安全 GC；仍不足则停止候选下载并报告 |
+| STO-002 | GC 遇到 serving/fallback/ready desired/attempting 引用 | 跳过，不以低空间为由删除 |
+| STO-003 | 多进程或多个更新任务竞争缓存 | per-server store lock 保证单 writer |
+| STO-004 | 发现 `.partial`、orphan staging 或无提交 marker | 只清理能证明未引用的对象 |
+| STO-005 | serving 资源损坏 | 回到 verified fallback/baseline，并对当前 desired 重新 Ensure |
+| STO-006 | 清理未使用 UI 资源 | 只删未引用派生资源，不改变版本指针和业务状态 |
+| STO-007 | 重置此服务端 UI 缓存 | 取消并等待 owner，回 baseline，只删其派生 UI 缓存；同 TargetKey 等手动重试 |
+| STO-008 | 两个 server 有相同 content hash | 仍保存为身份隔离的缓存，不跨 server 引用 |
+| STO-009 | GC 或重置中途进程死亡 | 通过引用扫描和事务 marker 恢复，不留下 serving 指向空目录 |
+| STO-010 | embedded baseline | 永不参与 OTA GC |
+| STO-011 | pinned 集合自身超过 generation/byte cap | 保留回退链并 `WaitFor(space)`；不谎报清理成功 |
+| STO-012 | OS 清除 cache 目录 | serving/fallback 放 app-private durable files；丢失的 partial/未引用 cache 可重建 |
+| STO-013 | app data 被恢复到另一设备但 Keystore/配对身份不可用 | 不执行旧远程 UI；回 baseline并等待重新配对，业务数据按其独立恢复合同处理 |
+| STO-014 | reset/clear 与 Ensure/Present 并发 | 同一 store/coordinator owner 先取消并等完成，再删除；不得边读边删 |
+
+### 11.5 生命周期与进程恢复
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| LIFE-001 | 应用在后台 | Ensure 可以继续；不创建或替换 WebView |
+| LIFE-002 | 冷启动存在 ready compatible desired | Present 只读本地资源，不等待网络；失败立即 fallback |
+| LIFE-003 | Activity 重建或旋转 | 同一 UI session 继续 serving；application-scope owner 不借机切 desired |
+| LIFE-004 | Ensure 时进程死亡 | 下次从可信 marker恢复或重验，不把 partial 当 ready |
+| LIFE-005 | 启动发现 `attempting` | 视为 activation 未提交，使用 fallback，并禁止同 TargetKey 自动重试；不虚构 crash 原因 |
+| LIFE-006 | APK 升级 | 重新检查全部 cached generation 与新 native/bridge 兼容性 |
+| LIFE-007 | APK 降级 | 不加载要求更高 native build 的缓存；baseline 必须可用 |
+| LIFE-008 | WebView provider/version 变化 | compatibility fingerprint 与 rejected key 重新评估，不能永久继承旧判断 |
+| LIFE-009 | 应用长时间停留前台 | 不强制中断；显示 ready 状态，下一 UI session 或用户立即应用 |
+| LIFE-010 | 从文件选择、权限或设置页返回前台 | 先完成原生 continuation；该次 resume 暂不 Present |
+| LIFE-011 | WebView provider 缺失、禁用或无法创建 | 显示原生恢复页并提示系统修复；不能假称 baseline 已成功渲染 |
+| LIFE-012 | APK 升级时旧 `attempting` 尚在 | 新 binary 先用自己的 baseline，废止旧 attempt，再按新兼容性重新 Resolve/Ensure |
+| LIFE-013 | serving 健康提交后应用被 force-stop 或 OS kill | serving marker 已提交，下一次可继续使用；不当作 candidate 失败 |
+
+### 11.6 用户行为与页面状态
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| UX-001 | 正在输入或 IME composition | 自动 Present 不在前台交互中途发生；草稿继续通过通用原生 owner 持久化 |
+| UX-002 | durable draft/阅读锚点写入尚未得到原生 ack | `canReplaceUi=false`；不为每种页面表单增加独立 blocker |
+| UX-003 | stream、stop 或 resync | stream/stop 不阻止；只有原生暂时无法生成完整 snapshot 时 `canReplaceUi=false` |
+| UX-004 | 文件选择、保存、权限或设置 Activity result | 等待原生 continuation 完成 |
+| UX-005 | incoming share 仍依赖临时 URI | 等待复制进原生持久区 |
+| UX-006 | 页面拥有 pending plugin query | 销毁时显式 cancel并返回；迟到结果由 nonce 拒绝，不等待查询完成 |
+| UX-007 | modal、文本选择、拖动或手势进行中 | 原生不感知；自动 Present 只在 UI session 边界发生 |
+| UX-008 | drawer、surface、滚动锚点 | 需要恢复的内容进入通用 snapshot/durable state；否则允许回默认状态，不保持 DOM |
+| UX-009 | island 中有未提交表单 | 重要输入使用通用 durable draft/capability；纯 DOM 临时表单不升级为 native owner |
+| UX-010 | 已持久 outbox、上传或下载仍进行 | 不阻塞；新页面从原生 snapshot 恢复 |
+| UX-011 | 用户动作恰好跨 fence | fence 前正常提交；fence 后明确 `ui_reloading`，不得重复 |
+| UX-012 | 用户切换服务端 | 创建新 UI session；分别按新 server 的 desired/ready/serving 选择 |
+| UX-013 | 用户点击“立即应用” | 执行一次通用 durable ack/提醒；`canReplaceUi=false` 时明确等待原因，不绕过原生 owner |
+| UX-014 | 更新 ready 后用户一直不离开前台 | 不强制 reload；显示一次非阻塞状态，避免反复提示 |
+
+### 11.7 WebView、bridge 和健康检查
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| WEB-001 | 页面声明错误 generation/bridge/snapshot | 健康检查失败并回滚 |
+| WEB-002 | 旧 WebView 的迟到 callback | nonce/generation 不匹配，忽略并记录 |
+| WEB-003 | WebUI 调用客户端不支持 capability | 返回明确 unsupported；不得假成功 |
+| WEB-004 | 页面尝试外部网络或任意 navigation | 原生阻止；外链按白名单交系统浏览器 |
+| WEB-005 | entrypoint 或关键资源加载失败 | 回滚，不渲染半版本 |
+| WEB-006 | 初始化 JS、bridge、root render 或 snapshot apply 失败 | 回滚并 `RejectTarget` |
+| WEB-007 | candidate 在健康窗口 renderer crash | 回滚并 `RejectTarget` |
+| WEB-008 | serving 页面单次运行期 crash | 有界重建同版本 |
+| WEB-009 | serving 页面窗口内重复 crash | 回滚 fallback/baseline 并 `RejectTarget` |
+| WEB-010 | UI 只是主观不好看但技术健康 | 客户端不自作回滚；由服务端发布者清除/回滚 Preview 或 Stable |
+| WEB-011 | 通用 durable ack 超时或返回不完整 | 取消本次 Present，serving 继续；不枚举页面内部组件 |
+| WEB-012 | reportHealthy 来自错误 nonce 或 snapshot | 拒绝，不清除 attempting |
+| WEB-013 | iframe 或错误 origin 调用 native bridge | exact-origin、main-frame listener 拒绝；不使用向所有 frame 暴露的大接口 |
+| WEB-014 | Service Worker 或 browser cache 返回旧 generation 资源 | Service Worker 不得联网；generation-specific URL、HTML no-store、hash asset immutable |
+| WEB-015 | 路径大小写、Unicode normalization 冲突或 MIME 与扩展不符 | manifest 规范化阶段拒绝整个 target |
+| WEB-016 | action 在 reload 前后重复、capability 已废弃 | 版本化 envelope + request ID；幂等与终态由原生 owner 决定 |
+| WEB-017 | 页面自报 healthy 但尚未产生可见首帧 | 原生 visual acknowledgment 未到，不提交 serving、不开放写动作 |
+
+### 11.8 连续发布、多设备和多服务端
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| CON-001 | 下载 A 时发布 B | latest desired wins；A 不激活 |
+| CON-002 | A ready、尚未 Present 时 Resolve 得到 B | A 不再是 desired；Ensure B，下一边界不能激活 A |
+| CON-003 | 合格 Preview 提升 Stable 并清除 Preview | 一次发布事务；设备最终指向同一已验证 generation |
+| CON-004 | Stable 回滚但 Preview 未清除 | Preview 设备继续 Preview，并向操作者明确提示 |
+| CON-005 | 某一设备 `RejectTarget` | 只影响该设备与 compatibility fingerprint，不自动全局回滚服务端 |
+| CON-006 | 部分设备长期离线 | 上线后只 Resolve 当前 ReleaseView，不逐个重放发布事件 |
+| CON-007 | emergency target 本地缺失 | 直接 baseline；后台再取合法 fallback target |
+| CON-008 | server A 失败、server B 正常 | 缓存、指针、rejected TargetKey 和通知完全隔离 |
+| CON-009 | 从备份恢复发布仓 | 已认证 Resolve 直接接受恢复后的当前 ReleaseView；不比较客户端历史序号或时间 |
+| CON-010 | 短时间收到大量 hint | 合并为 dirty bit；单飞 Resolve 结束后最多补查一次 |
+| CON-011 | 旧 Resolve/Ensure callback 晚于 server switch | owner token 不匹配即忽略；不能改变新 UI session |
+| CON-012 | 同一应用同时维护多个 server UI 缓存 | 每 server 独立 Resolve/Ensure/Store；全局容量只触发安全 GC，不串改 desired |
+
+### 11.9 兼容性与二进制发行
+
+| ID | 场景 | 必须结果 |
+|---|---|---|
+| BIN-001 | Android 纯 UI/CSS/已有桥交互 | 服务端 WebUI 发布，不发 APK |
+| BIN-002 | 新原生 capability 或不兼容 bridge | 设置 minimum native build 并发布二进制 |
+| BIN-003 | 无兼容 generation | 保持 serving/baseline，并明确提示升级应用 |
+| BIN-004 | 当前 GitHub APK 发行 | updater、下载、安装入口和权限保持原状；与 WebUI OTA 使用独立 owner |
+| BIN-005 | 未来准备提交 Google Play | 另开设计和政策审查；本轮不提前删除 GitHub updater。Google 对 WebView JavaScript 与 APK/原生代码自更新的边界见 [Device and Network Abuse](https://support.google.com/googleplay/android-developer/answer/16559646?hl=en) |
+| BIN-006 | 未来 iOS | 复用中立 manifest/Resolve/Ensure/Present；哪些 WebUI 变化可 OTA 需按 [App Review Guidelines 2.5.2](https://developer.apple.com/app-store/review/guidelines/) 单独确认 |
+| BIN-007 | 服务端下发 dex/JAR/.so 或原生可执行内容 | 永久拒绝；WebUI OTA 只接受声明的静态 Web 资源类型 |
+| BIN-008 | APK 升级带来新 baseline，但服务端仍选择旧 generation | 按 compatibility 和当前 ReleaseView 选择，不以 build 时间判断；无兼容 target 时使用新 baseline |
+
+## 12. 用户可见行为
+
+- 正常 Resolve、Ensure 和等待下一 UI session 默认安静进行，不弹阻塞对话框。
+- 激活成功可以使用轻量非阻塞提示；频繁 Preview 更新不应持续打扰。
+- 回滚、资源损坏、磁盘不足、需要升级原生应用、配对身份变化和 emergency revoke 必须明确可见。
+- 手动检查只展示从四个事实推导出的结果：已是当前版本、正在补齐、已下载等待下一次进入、`WaitFor` 的明确原因或 `RejectTarget` 的明确错误。
+- “立即应用”只在 ready 时出现；`canReplaceUi=false` 时显示原生 continuation/snapshot 等粗粒度原因，不展示内部状态名。
+- “清理未使用 UI 资源”和“重置此服务端 UI 缓存”必须明确不会删除聊天、草稿、附件或配对；执行结果报告释放空间和当前来源。
+
+## 13. 分阶段实施方向
+
+以下只是设计顺序，不是当前实施授权：
+
+1. 接受本设计后，新增决策记录并勘误 0018 与移动仓库固定 ZIP/no-network 合同。
+2. 确认服务端发布仓的持久化根、备份/恢复、增改减和发布事务。
+3. 固化平台中立 generation manifest、ReleaseView、WSS descriptor、HTTPS ticket/content 和 bridge envelope。
+4. 实现 Core 隔离构建、不可变 generation、CAS、Stable/Preview 发布和只读 Runtime 接口。
+5. Android 分别实现 `ReleaseResolver`、`ArtifactEnsurer`、`UiSessionController` 与 `LocalWebUiStore`，不再实现平行的下载/等待/激活总状态机。
+6. 运行 Core/Android targeted tests、change-impact Gate、跨仓库固定组合和真机故障注入。
+7. 当前 GitHub APK updater 保持原状；未来真的准备 Google Play 或 iOS 时分别建立新合同，不作为首版 OTA 前置工作。
+
+## 14. 验收边界
+
+设计落地至少需要证明：
+
+- 纯 UI 改动从 Core 发布后，已配对 Android 无需 APK 更新即可在下一 UI session 或用户显式立即应用时使用。
+- WebView 始终加载经过认证发现、完整校验并从本地可信 origin 提供的不可变资源。
+- 任意构建、发布、下载、校验、激活、renderer crash 或进程死亡故障都保留 serving/fallback/baseline 中至少一个可启动版本。
+- 所有传输失败都能唯一归入 `RetryAfter`、`WaitFor(trigger)` 或 `RejectTarget`；不会因为新 edge case 增加全局更新状态。
+- 连续发布最终只 Present 最近一次成功 Resolve 的 desired Target；不会在 serving 目录混合两个 generation。
+- 草稿、阅读位置、outbox、附件、消息、配对和插件真实状态在更新、回滚、GC 和重置前后符合各自 owner 合同。
+- Preview dirty provenance 可审计，Stable 能从声明的 WebUI 输入重建相同产物。
+- 所有安全上限、archive 攻击、ticket 失效、身份变化和恶意 navigation 都有独立失败测试。
+- 多服务端、多设备、冷启动、后台、Activity result、IME、streaming、连续崩溃、备份恢复、旧 callback 和低磁盘场景有明确 oracle，且分别绑定 Resolve/Ensure/Present/Store owner。
+- Android 真机证据与 Core CI、跨仓库组合证据分层报告，不用模拟成功替代设备行为。
+
+## 15. 待继续商讨
+
+以下内容尚未批准，不能从本文推断实现：
+
+1. 服务端发布仓位于 Akashic `<workspace>`、独立 deployment state root，还是由配置显式选择；Stable/Preview、generation、CAS 和 publication journal 是否进入正式备份。
+2. 各持久对象的具体目录、schema、锁、事务、retention 数值、备份恢复和跨版本迁移。
+3. generation manifest、ReleaseView、selection digest 与 WSS/HTTPS 的精确字段名、命令、事件、错误码、endpoint 和 ticket 生命周期。
+4. 文件数、大小、压缩比、并发、超时、重试、健康窗口、崩溃窗口和 rejected TargetKey 重试窗口的具体常量。
+5. bridge snapshot/patch/capability 的精确兼容矩阵、single-envelope 迁移和通用 durable ack；不再为页面各类临时状态设计专用 flush 字段。
+6. 两仓库 PR 切分、任务合同、Gate 选择、真机矩阵和正式发布操作手册。
+7. Google Play 与 iOS 的未来发行资格和具体改动；当前 GitHub APK updater 不变，该项不阻塞首版 OTA。

--- a/docs/design/server-published-mobile-webui.md
+++ b/docs/design/server-published-mobile-webui.md
@@ -1,22 +1,22 @@
 # 服务端发布的移动 WebUI OTA 设计
 
-- 状态：proposed；产品边界、三步协调模型和 edge case 语义已经确认，持久化落点、线协议字段、资源上限和实施合同仍待确认
+- 状态：accepted；产品边界、三步协调模型、持久化、线协议、资源上限和 edge case 合同已经确认，实施与验收状态以两仓库当前代码和 Gate 报告为准
 - 日期：2026-08-03
-- 关联决策：[0018](../decisions/0018-chat-webui-has-one-source-and-two-adapters.md)
-- 关联条款：WEBUI-001～WEBUI-003、MOB-001、STA-001～STA-003、CAP-001～CAP-002、ERR-001、TST-006～TST-008
+- 关联决策：[0018](../decisions/0018-chat-webui-has-one-source-and-two-adapters.md)、[0022](../decisions/0022-mobile-webui-uses-server-selected-generations.md)
+- 关联条款：WEBUI-001～WEBUI-006、MOB-001、STA-001～STA-003、CAP-001～CAP-002、ERR-001、TST-006～TST-008
 - 涉及仓库：`akasic-agent`、`akashic-mobile`
 
 ## 1. 文档边界
 
-本文固化已经确认的产品边界、发布模型、Android 三步协调模型、回滚语义和 edge case。它不是实现批准，也不把尚未修改的现行合同描述成已经支持 OTA。
+本文是已经确认的产品边界、发布模型、Android 三步协调模型、回滚语义、线协议和 edge case 实施合同。它不把尚未通过当前源码验证的行为描述成已经交付；实际支持范围仍由两仓库实现、固定协议组合、隔离 Gate 和真机报告共同证明。
 
 本文使用三种标记：
 
 - **F（fact）**：当前代码或现行合同已经能证明的事实。
 - **C（confirmed）**：维护者在本轮设计中已经确认的目标语义。
-- **U（unknown）**：仍会影响持久状态、协议兼容或实施范围的待确认项。
+- **I（implementation evidence）**：必须由当前代码、schema、测试或运行报告证明的实施事实。
 
-在新决策被接受、相关需求条款完成勘误、两仓库实现和 Gate 通过前，当前 APK 内固定 ZIP 仍是唯一已实现路径。
+决策 0022 与 WEBUI-004～WEBUI-006 已接受本合同。是否已经交付必须以 Core provider 实现、Android consumer 锁定、两仓库 Gate 和本轮真机报告的组合证据为准；文档批准或单仓库绿灯都不能单独证明 OTA 已经运行。
 
 ## 2. 用户意图与成功边界
 
@@ -42,17 +42,17 @@
 | 改变 bridge/snapshot 协议且旧客户端不能兼容 | 否 | 是 |
 | 修改 Kotlin/Swift 生命周期、数据库、网络或安全逻辑 | 否 | 是 |
 
-## 3. 当前事实与合同冲突
+## 3. 实施前基线与当前证据
 
-- **F：** `frontend/chat` 是桌面和移动 WebUI 的唯一源码真源；`mobile-native.tsx` 是移动入口。
-- **F：** `scripts/package-mobile-web.sh` 当前只接受整个 Git tree 干净的源码，生成完整 ZIP、SHA-256 和 schema v1 manifest。
-- **F：** Android 当前把固定 ZIP 作为 Gradle 输入，构建时校验并解包进 APK。
-- **F：** Android 通过 `WebViewAssetLoader` 从 `https://appassets.androidplatform.net` 加载 APK 资产并阻止外部资源请求。Native→Web 使用指定 origin 的 `postWebMessage`；Web→Native 当前仍通过 `addJavascriptInterface`，在服务端下发 JS 前需要收窄。
+- **F（实施前基线）：** `frontend/chat` 是桌面和移动 WebUI 的唯一源码真源；`mobile-native.tsx` 是移动入口。
+- **F（实施前基线）：** `scripts/package-mobile-web.sh` 只接受整个 Git tree 干净的源码，生成完整 ZIP、SHA-256 和 schema v1 manifest；Android 把该 ZIP 作为 Gradle 输入，构建时校验并解包进 APK。这条 schema v1 路径在首个 OTA APK 中仍作为 embedded baseline，不导入 schema v2 OTA 缓存。
+- **F（实施前基线）：** Android 通过 `WebViewAssetLoader` 从 `https://appassets.androidplatform.net` 加载 APK 资产并阻止外部资源请求。Native→Web 使用指定 origin 的 `postWebMessage`；Web→Native 当时使用 `addJavascriptInterface`，因而服务端下发 JS 的 candidate 路径必须收窄 bridge admission。
 - **F：** Room、outbox、附件传输、通知、Keystore、配对、系统 Activity result 和生命周期由 Android 原生层拥有。
 - **F：** Core 已有配对后的 WSS 与同源认证 HTTPS 传输模式，可以作为发布发现与资源下载的现有信任基础。
-- **F：** [0018](../decisions/0018-chat-webui-has-one-source-and-two-adapters.md) 和移动仓库的现行合同要求固定 ZIP、干净 commit、构建期解包且无网络 fallback。
+- **I（Core provider）：** `infra/mobile_webui/` 拥有 canonical manifest、发布仓、ticket 和 HTTP 数据面；`scripts/publish-mobile-webui.py` 拥有 build/import/promote/rollback/GC 命令；`infra/mobile_realtime/` 只读已提交的 `ReleaseView`。`scripts/generate_mobile_realtime_schema.py`、`schema/mobile-realtime-v1.json` 与 `tests/mobile_webui/` 共同构成 provider 的机器可读证据。
+- **I（跨仓库 consumer）：** Android 只能消费 Mobile 仓库锁定到 Core merge commit/tree/schema SHA-256 的快照。OTA 的当前实际支持范围必须继续从该锁、Android 源码、migration test、隔离 runtime 和真机报告读取，不由本文档代为宣布。
 
-因此，服务端发布 OTA 不是对现有实现的自然解释，而是对“移动产物怎样交付”这一部分合同的有意改变。它不改变 WEBUI-001～WEBUI-003 的单一源码真源和状态 owner；后续接受设计时必须用新决策明确勘误 0018，并同步修改移动仓库对应合同。
+因此，服务端发布 OTA 是对“移动产物怎样交付”的有意改变，不是把旧固定 ZIP 路径改名。决策 0022 勘误 0018 的交付边界，但不改变 WEBUI-001～WEBUI-003 的单一源码真源和状态 owner；移动仓库必须以自己的决策和锁定证据同步接受。
 
 ### 3.1 成熟实践与采用理由
 
@@ -60,15 +60,17 @@
 
 | 成熟实践 | 官方行为 | 本设计采用的抽象 |
 |---|---|---|
-| [Expo Updates](https://docs.expo.dev/versions/latest/sdk/updates/) | 默认启动时检查并下载，下一次启动才应用；binary 中保留 embedded update | `Ensure` 可以后台运行，`Present` 只在 UI session 边界运行；APK baseline 永久可用 |
+| [Expo 下载与应用策略](https://docs.expo.dev/eas-update/download-updates/) | 默认冷启动异步检查而不阻塞首屏，下载完成后在后续启动应用；官方明确不建议为“永远最新”长期阻塞启动 | `Ensure` 可以后台运行，`Present` 只在 UI session 边界运行；慢网或离线不阻塞 APK baseline |
 | [Expo runtime versions](https://docs.expo.dev/eas-update/runtime-versions/) | 远程更新必须匹配原生 runtime compatibility | `Target` 在下载前检查 native、bridge、snapshot 和平台兼容范围 |
 | [Expo error recovery](https://docs.expo.dev/eas-update/error-recovery/) | 首次内容出现前失败可以回退；已经运行后的回退不能假装撤销持久副作用 | candidate 健康前不开放有副作用 bridge；回退只切换 UI，不回滚原生业务事实 |
-| [Ionic Appflow background strategy](https://ionic.io/docs/appflow/deploy/setup/capacitor-sdk) | 推荐后台下载、下次启动应用；需要前台重载时只阻止少量 critical workflow | 页面 modal、手势和选区不进入原生状态机，只保留一个 `canReplaceUi` 原生判定 |
+| [Ionic Appflow Live Updates](https://ionic.io/docs/appflow/deploy/deploy-live-update) | background 方式先下载，关闭再打开应用时采用；auto 方式才在启动时立即切换 | 页面 modal、手势和选区不进入原生状态机，只保留一个 `canReplaceUi` 原生判定 |
 | [Ionic differential updates](https://ionic.io/docs/appflow/deploy/differentials) | manifest 为每个文件保存 hash，只下载变化文件 | `Ensure(Target)` 按 content hash 复用 blobs，不在 serving 目录原位打补丁 |
 | [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) | blob 由 digest 标识，manifest 引用 blobs，可变 tag 选择不可变内容 | generation 是不可变内容；Stable/Preview 只组成当前 `ReleaseView` |
-| [Android WebViewAssetLoader](https://developer.android.com/develop/ui/views/layout/webapps/load-local-content) | 应用内资源从 HTTPS 语义的本地 origin 加载 | 下载和校验由原生完成，WebView 只看本地 generation |
+| [Android WebViewAssetLoader](https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader) | 应用私有资源以 HTTPS 语义的本地 origin 加载，保留 same-origin 隔离；官方同时建议关闭不需要的 file/content access | 下载和校验由原生完成，WebView 只看本地 generation |
 | [Android WebView termination handling](https://developer.android.com/develop/ui/views/layout/webapps/handle-termination) | renderer 退出后不得复用旧 WebView；重复崩溃不能无限重载同一页面 | 单次重建 serving，重复失败回 fallback并 `RejectTarget` |
 | [Android WorkManager unique work](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/manage-work) | unique work 避免同一目标重复排队，并定义替换策略 | 每个 server 只有一个 `Ensure` owner；新 `Target` 取代旧工作 |
+| [RFC 9530 Digest Fields](https://www.ietf.org/rfc/rfc9530.html) | `Content-Digest` 校验本次消息内容，`Repr-Digest` 校验完整选定表示；Range 响应中二者可以不同 | 206 校验本次 range bytes，同时用 representation digest 和强 ETag 锚定完整 blob |
+| [SLSA Build Provenance v1.2](https://slsa.dev/spec/v1.2/build-provenance) | 构建溯源区分外部参数、内部环境、已解析依赖、builder 和最终 subject；完整输入才支持验证与重建 | manifest 固定源码、lock、脚本、toolchain 与有效构建环境摘要；`reproducible=true` 不由“Git 干净”单独推出 |
 
 这些实践共同指向一个更小的心智模型：客户端不维护“正在检查、等待激活、重新下载”等平行状态机，而是持续回答三个问题：服务端当前想要什么、本地是否已经完整拥有它、下一次 UI session 应展示什么。
 
@@ -127,7 +129,7 @@ WebUI source inputs
        ▼
 ┌───────────────┐   验证成功   ┌──────────────────────────────┐
 │ 离线构建候选  ├─────────────→│ 不可变 generation            │
-└───────────────┘              │ manifest + CAS blobs/archive │
+└───────────────┘              │ manifest + per-file CAS blobs│
                                └──────────────┬───────────────┘
                                               │ 原子提交
                          ┌────────────────────┴──────────────────┐
@@ -144,7 +146,7 @@ WebUI source inputs
 
 构建、校验和资源写入发生在候选区。只有全部成功后，单一发布者才原子提交 Stable/Preview 指针组成的 `ReleaseView`。Runtime 只读取已提交发布，不在请求路径运行 Node/Vite，也不拥有发布写权限。
 
-`ReleaseView` 是“服务端现在选择什么”的完整快照，至少包含 server identity、Stable target、可选 Preview target 和每个 target 的 manifest digest。规范化选择内容计算 `selection_digest`；审计 journal 可以记录每次发布事件，但客户端不按 journal 序号、发布时间或 semver 推断新旧。
+`ReleaseView` 是“服务端现在选择什么”的完整快照，至少包含 server identity、nullable Stable/Preview target 和每个 target 的 manifest digest。两根指针都为 `null` 是合法且唯一的“当前没有远端发布”，此时成功 Resolve 得到的 desired 必须是 embedded baseline；旧 serving 只能维持当前尚未结束的 UI session，不能反向成为远端 desired。规范化选择内容计算 `selection_digest`；审计 journal 可以记录每次发布事件，但客户端不按 journal 序号、发布时间或 semver 推断新旧。
 
 这一点有意采用 OCI mutable tag 的语义：客户端每次只解析当前指针。显式回滚可以重新得到一个历史上出现过的 `selection_digest`，这是相同 desired state，不需要伪造一个“更大版本号”。每个 server 的 `Resolve` 单飞串行，迟到响应用本地 resolve token 丢弃，因此服务端备份恢复也不需要客户端理解 release lineage。
 
@@ -156,7 +158,7 @@ WebUI source inputs
 | Stable | 服务端默认生产 WebUI | 由显式发布命令原子推进或回滚 |
 | Preview | 服务端级试验 WebUI | 由显式发布、清除或提升操作改变 |
 
-**C：** Preview 对该服务端配对的全部设备生效，不是单设备选择。Preview 效果不好时，发布者可以清除 Preview 或把指针回退到旧 generation；客户端下一次成功 Resolve 后收敛到当前 ReleaseView。
+**C：** Preview 对该服务端配对的全部设备生效，不是单设备选择。Preview 效果不好时，发布者可以清除 Preview 或把指针回退到仍被 rollback pin 保留的旧 generation；客户端下一次成功 Resolve 后收敛到当前 ReleaseView。首版发布仓保留当前 Stable/Preview、每个 channel 最近 4 个成功选择和显式 pin 的 generation；journal 本身不隐式 pin 资源。目标已被 GC 时，回滚命令必须以 `rollback_unavailable` fail-loud，保持指针不变；操作者只能先从自包含备份恢复/导入并重新校验，不能创建悬空指针。
 
 **C：** 保存源码、构建成功、文件 watcher 或重启 Core 都不得自动发布。Stable 和 Preview 都必须由名称明确的发布命令提交。Watcher 只能发送“有新发布可检查”的提示。
 
@@ -164,30 +166,41 @@ WebUI source inputs
 
 - Preview 允许使用有未提交 WebUI 输入的源码，但构建前必须固化 base commit、patch/tree digest、完整 build context、产物 digest、`reproducible=false` 和 dirty provenance。
 - Stable 只从指定 commit 的隔离 source snapshot、固定 lockfile/config/toolchain 构建，并且只接受 `reproducible=true` 的 generation。
+- `build_context_digest` 必须按实际交给构建进程的环境计算：包含 OS/architecture、解析后的 Node/npm 可执行身份、锁文件、构建脚本，以及能影响 Node/npm/Vite 的有效配置；输出临时路径等经审查不影响产物的调度元数据应规范化排除。该划分采用 SLSA 对 external/internal parameters 与 resolved dependencies 的区分，但首版只是本地可审计 provenance，不宣称达到某个 SLSA level。
 - 当前开发 checkout 的后端、测试、文档甚至 WebUI dirty 都不影响从指定 commit 发布 Stable；它们不会进入隔离 source snapshot。
 - dirty WebUI 输入不能通过忽略标记或伪造 commit 进入 Stable。
 - 同一 generation ID 对应不同内容时 fail-loud；完全相同内容重复发布可以成为 no-op，但不能伪造新的资源内容。
-- `reproducible=true` 的 Preview 可以原样提升 Stable。dirty Preview 必须先提交其真实输入，并从隔离 snapshot 重建出完全相同 generation；若产物不同，先发布新的 Preview 重新验证，不能把未复现的 dirty artifact 提升 Stable。
+- `reproducible=true` 的 Preview 可以原样提升 Stable。dirty Preview 提交真实输入后必须从隔离 snapshot 重建为新的 reproducible generation，再发布为 Preview 验证；逐文件摘要相同的 blobs 可以复用，但 provenance 改变会产生新的 generation，未复现的 dirty target 不能直接提升 Stable。
 
 ### 5.4 Manifest 语义
 
-generation manifest 至少表达以下语义；最终字段名和编码在协议设计中确认：
+schema 2 manifest 使用 UTF-8 canonical JSON：对象键排序、无无意义空白、禁止重复键、未知字段和非标准数值。字段固定如下：
 
-- `manifest_schema`
-- `generation_id`
-- source repository、commit/base、WebUI 输入 digest 和 dirty provenance
-- bundle/render digest 与构建工具身份
-- bridge protocol 与 snapshot protocol 范围
-- minimum native build、platform 和可选 WebView 约束
-- entrypoint
-- 每个文件的相对路径、content hash 和 size
-- archive hash、总解包 size 和文件数量
-- `reproducible`
-- builder/publisher identity 和可复现构建信息
+| 字段 | 语义 |
+|---|---|
+| `schema_version` | 固定为 `2` |
+| `generation_id` | 完整 manifest 排除本字段后的 canonical SHA-256 |
+| `entrypoint` | 本地 UI session 入口；首版为 `mobile.html` |
+| `files[]` | 严格对象 `{path, sha256, size_bytes, mime}`；path 总 UTF-8 长度 1..512 bytes、每段 1..128 bytes、每段只允许 ASCII `[A-Za-z0-9._-]+`，并按 UTF-8 bytes 排序 |
+| `bridge_protocol_min/max` | Web→Native bridge 兼容闭区间 |
+| `snapshot_protocol_min/max` | Native→Web snapshot 兼容闭区间 |
+| `minimum_native_build` | 能运行该 generation 的最小原生 build code |
+| `platforms` | 有序去重的平台集合；首版包含 `android` |
+| `source_repository/commit/tree` | 构建来源的固定 repository、commit 与 Git tree |
+| `input_digest` | 影响移动入口构建的全部源码输入清单摘要 |
+| `build_context_digest` | 实际构建环境、有效配置、锁文件、构建脚本和 builder identity 的规范摘要；不得明文保存环境秘密 |
+| `dirty_provenance` | `null`，或严格对象 `{base_commit, tracked_patch_digest, untracked_tree_digest}` |
+| `reproducible` | Stable 与可提升 Preview 必须为 `true` |
+| `builder_identity` | 严格对象 `{node_version, npm_version, package_lock_digest, build_script_digest}` |
+| `unpacked_size_bytes/file_count` | 必须分别等于 `files` 的总字节数和项数 |
 
 channel、Stable/Preview、发布时间、发布事件和当前选择不进入 generation manifest；它们属于 `ReleaseView` 或发布 journal。这样同一 Preview generation 才能原样提升 Stable。
 
-`generation_id` 由经过规范化的 manifest 内容和资源内容决定，不由可变 channel、服务器路径或客户端时间决定。`TargetKey = server_identity + generation_id + manifest_digest`；generation 自身不可变。
+`manifest_digest` 是包含 `generation_id` 的完整 canonical manifest SHA-256。`generation_id` 与 `manifest_digest` 都不包含可变 channel、服务器路径、发布时间或客户端时间。`TargetKey` 是严格对象 `{server_id, generation_id, manifest_digest}` 的 canonical SHA-256；它不进入 manifest，因此同一不可变 generation 可以由不同服务端独立发布。
+
+本协议中的 canonical JSON 固定为：RFC 8259 object、UTF-8 无 BOM、键按 Unicode code point 升序、无键外空白、字符串不转义非 ASCII 且只转义 JSON 必需字符、布尔/null 使用小写字面量、整数使用无前导零十进制；禁止重复键、未知键、NaN 与 Infinity。`server_id` 使用现有配对身份在已认证协议中携带的原始 ASCII identifier bytes，区分大小写，禁止 trim、大小写转换或 Unicode 归一化。`TargetKey` 的字段集合和顺序语义精确为上述三个 non-null string；`selection_digest` 的字段集合精确为 `{server_id, stable_target_key, preview_target_key}`，后两项即使为空也必须编码为 JSON `null`。Core 与 Kotlin 必须对同一 golden vectors 产生逐字节相同的 canonical bytes 与 SHA-256。
+
+MIME 不由平台库猜测，而由两端共享的固定小写 suffix map 决定：`.html/.htm → text/html`，`.css → text/css`，`.js/.mjs/.cjs → text/javascript`，`.json → application/json`，`.wasm → application/wasm`，`.woff/.woff2/.ttf/.otf → font/*`，常见图片、音视频和 `.txt` 使用 manifest 列出的对应类型；未列出的后缀固定为 `application/octet-stream`。`.dex/.jar/.so/.apk/.aab` 无论声明什么 MIME 都拒绝。Core publisher、Core domain validator、机器 schema 的可达枚举和 Android parser 必须消费同一份含 JS/CSS/unknown 文件的 golden fixture；任一端使用系统 MIME 推断都视为合同漂移。
 
 ## 6. 增量同步与缓存
 
@@ -195,14 +208,14 @@ channel、Stable/Preview、发布时间、发布事件和当前选择不进入 g
 
 1. 客户端先获取并验证 manifest。
 2. 客户端按 `server_id + content_hash` 检查已有 blobs。
-3. 冷缓存或缺失比例较大时下载完整 archive；少量缺失时只下载缺失 blobs。
+3. 无论冷缓存还是增量更新都只下载本服务端缺失的 blobs；首版不再并行维护 archive 与 blob 两套选择策略。
 4. 校验每个 blob、完整文件树和 bundle digest。
 5. 从不可变 blobs 物化 verified generation，使 `ready(Target)=true`。
 6. serving generation 在 Present 健康提交前保持不变。
 
 客户端不得跨 `server_id` 共享 CAS，即使 hash 相同。这样可以防止服务端身份撤销、保留策略和故障归属被全局去重混淆。
 
-所有可用网络默认允许后台下载，不按 Wi-Fi/蜂窝做产品级禁用；下载必须受单文件、文件数、总压缩量、总解包量、压缩比、时间、并发和磁盘余量的硬限制。具体数值仍是 U。
+所有可用网络默认允许后台下载，不按 Wi-Fi/蜂窝做产品级禁用。首版固定 manifest 不超过 1 MiB、单 generation 不超过 2,048 个文件、单文件不超过 8 MiB、文件总量不超过 64 MiB、单次 Range response 不超过 8 MiB；下载还必须检查 Content-Length、实际字节、磁盘余量、超时和单 server 并发 owner。因为数据面不传 archive，OTA 路径没有压缩比或解包状态。
 
 ## 7. Android 组件边界
 
@@ -275,7 +288,7 @@ UI session boundary ───────────────→┌───
 
 同一 server 同时只有一个 resolve 请求。请求期间到达的多个 hint 合并为一个 dirty bit；当前请求结束后最多再查一次。hint 不携带可直接下载或激活的 target。客户端用本地 resolve token 忽略旧请求结果，不比较远端 publication sequence、时间或 semver。
 
-选择规则固定为：compatible Preview、compatible Stable、当前 serving、embedded baseline。Preview 和 Stable 都只是 `ReleaseView` 中的指针；服务端回滚后，下一次成功 Resolve 直接得到旧 generation 作为新 desired。
+选择规则固定为：compatible Preview、compatible Stable、embedded baseline。Preview 和 Stable 都只是 `ReleaseView` 中的指针；服务端回滚后，下一次成功 Resolve 直接得到旧 generation 作为新 desired。当前 serving 只在尚未完成新的 Resolve、临时认证/网络失败或当前 UI session 尚未到替换边界时继续显示；它不参与一次成功 Resolve 的 desired 选择。两根指针为 `null` 或均不兼容时，desired 明确变为 baseline，并在下一 UI session 收敛。
 
 ### 8.2 Ensure：什么时候下载、等待和重新下载
 
@@ -333,8 +346,8 @@ streaming、stop、outbox、上传和下载本身不阻止替换，只要它们�
 1. 重新读取当前 desired、ready 证据、server identity 和 `canReplaceUi`。
 2. 关闭旧页面的普通 action admission；fence 后请求明确返回 `ui_reloading`。
 3. 写入 `attempting TargetKey`、fallback、activation nonce 和当前 native/WebView compatibility fingerprint。
-4. 销毁旧 WebView，从 generation-specific 本地 URL 创建 candidate WebView。
-5. candidate 先以只读 bridge 完成 exact origin、nonce、generation 和协议握手。
+4. 销毁旧 WebView，以不可变 `PresentationLease(server, generation, manifest, nonce)` 从 `/mobile-webui/<server-hash>/<generation>/<entrypoint>` 创建 candidate WebView；handler 只服务该 lease，不能读取别的 generation，也不能对缺失文件回退 embedded asset。
+5. candidate 先通过 `WebMessageListener` 的只读 bridge 完成 exact origin、main frame、nonce、generation 和协议握手；远端 generation 不暴露 `addJavascriptInterface`。
 6. 原生发送完整 snapshot；页面完成 root render 和首次 visual acknowledgment。
 7. 原子提交 serving、清除 attempting，再开放有副作用的业务动作。
 
@@ -353,23 +366,23 @@ candidate 自己的 `reportHealthy` 只是证据之一，不能单独提交 serv
 
 **C：** embedded baseline 永久保留。客户端只 pin 当前 serving、fallback、ready desired 和 attempting 所引用的 generation 及其 blobs。Stable/Preview 是服务端选择，不自动让客户端永久保留两个 channel 的全部历史。
 
-正常稳定状态通常只有 serving 与 fallback 两代；desired 正在下载或激活时短暂增加一代。最终实现同时设置每 server generation 数和总字节硬上限，具体数值在真实 bundle 测量后确认。达到上限时先删未引用对象；若 pinned 集合本身超过预算则 `WaitFor(space)`，不得破坏回退链。
+正常稳定状态通常只有 serving 与 fallback 两代；desired 正在下载或激活时短暂增加一代。GC 以每 server 最多 4 个 verified generation、256 MiB 和应用全局 512 MiB 为目标预算；pinned 对象不因预算被删除。若 pinned 集合已经超过预算则 `WaitFor(space)`，不得破坏回退链或伪造清理成功。
 
 客户端提供两个名称明确的动作：
 
 | 动作 | 允许改变 | 不得改变 |
 |---|---|---|
-| 清理未使用 UI 资源 | 删除各服务端未被 serving/fallback/ready desired/attempting 引用的派生 blobs、archive 和 orphan staging | pinned generation、baseline、业务数据和凭据 |
+| 清理未使用 UI 资源 | 删除各服务端未被 serving/fallback/ready desired/attempting 引用的派生 blobs、manifest 和 orphan staging | pinned generation、baseline、业务数据和凭据 |
 | 重置此服务端 UI 缓存 | 取消并等待该 server 的 Ensure/Present owner 退出，回到 baseline，删除其派生 UI 缓存，并将当前 TargetKey 置为需手动重试 | 配对身份、Room、outbox、草稿、附件、SessionDB、插件数据和其他服务端缓存 |
 
 不提供任意本地版本选择器。正常版本选择由服务端当前 `ReleaseView` 决定；客户端只保留恢复所需 generation。重置后不会在下一个周期立即偷偷重下同一 TargetKey；用户手动重试或服务端 target 改变后才重新 Ensure。低磁盘时先运行安全 GC，空间仍不足则保留当前 UI、停止下载并明确报告，不删除 pinned 资源制造“成功”。
 
-持久对象的最低语义如下；具体目录和 schema 是 U：
+Core 发布仓固定在 `<workspace>/mobile-webui/`，包含 `publication.sqlite3`、`blobs/sha256/<prefix>/<digest>` 和 `staging/`；不得写入 `sessions.db`、`mobile_realtime.db` 或 plugin-data。客户端固定使用 app-private `filesDir/mobile-web-ui/<server identity>/` 保存 blobs、manifest 和 staging，并用 Room 的 WebUI 专属表保存四事实与引用；不得借迁移或 reset 触碰既有业务表。持久对象的最低语义如下：
 
 | 对象 | 正常增加 | 允许更新或逻辑失效 | 物理减少条件与 owner | 恢复证据 |
 |---|---|---|---|---|
 | 服务端 immutable generation | 成功构建并验证后新增 | 被新指针 supersede，不改内容 | 无指针/租约引用且满足保留协议时由发布 GC 删除 | manifest、blob hash、发布日志 |
-| 服务端 CAS blob/archive | 以 content hash 新增 | 只改变引用可达性 | 无 generation/候选引用时由发布 GC 删除 | hash、size、引用扫描 |
+| 服务端 CAS blob | 以 content hash 新增 | 只改变引用可达性 | 无 generation/候选引用时由发布 GC 删除 | hash、size、引用扫描 |
 | Stable/Preview pointer 与 `ReleaseView` | 发布事务创建 | 单 writer 原子替换当前选择；Preview 可显式清除 | 不直接删除所指内容；旧 generation 按 GC 协议处理 | 当前 ReleaseView、selection digest、发布 journal |
 | 客户端 generation/blob cache | Ensure 验证后新增 | serving/fallback/desired/rejected 改变引用状态 | 仅上述清理、重置或安全 orphan recovery | hash、manifest、per-server reference set |
 | `attempting` marker | Present 关闭旧 bridge 后写入 | 成功清除；未提交恢复为 rejected-for-auto TargetKey | 只能由完成或启动恢复事务清除 | fallback、nonce、TargetKey、启动恢复报告 |
@@ -383,20 +396,22 @@ candidate 自己的 `reportHealthy` 只是证据之一，不能单独提交 serv
 paired server identity
         │ authenticated WSS
         ▼
-release descriptor ── short-lived bound ticket ──→ same server HTTPS
+ReleaseView ── target-scoped short-lived ticket ──→ same server HTTPS
         │                                         manifest / blobs
         └──────────────── hashes + limits ────────────────────┘
 ```
 
-- descriptor 必须来自已认证 WSS，并绑定 `server_id`、设备、`selection_digest`、Stable/Preview TargetKey 和 manifest digest。
-- 下载 ticket 短时有效、一次或有界使用，绑定资源和配对 epoch；401 只能重新获取 ticket，不能降级匿名下载。
+- 客户端用 capability `mobile-webui-ota-v1` 声明支持。已认证 WSS command `mobile.webui.release.get` 返回完整当前 `ReleaseView`；control `mobile.webui.release.changed` 只带 `server_id` 与 `selection_digest`，仅触发重新 Resolve，不携带可执行 target。
+- `ReleaseView` 严格包含 `server_id`、持久 store lineage `release_epoch`、仅供审计的 `sequence`、`selection_digest`、nullable `stable` 与 `preview`。每个 Target 严格包含 `target_key`、`generation_id`、`manifest_digest`、`manifest_size_bytes`、bridge/snapshot 兼容范围、`minimum_native_build` 和 `platforms`。`selection_digest` 使用 5.4 节固定的精确对象和 canonical bytes；nullable 键仍存在。Core schema 必须同时归档 canonical golden vectors，Android Runtime Contract 必须逐字节复算。
+- 已认证 WSS command `mobile.webui.content.prepare` 只接受当前 TargetKey，严格返回 `{target_key, manifest_digest, ticket, expires_at}`；ticket 固定 300 秒有效并绑定 `server_id`、device、connection epoch、release epoch、TargetKey 与 manifest identity。HTTPS 每次执行重新检查设备撤销和 epoch，并验证请求 digest 属于该 target。
+- HTTPS 路径固定为 `/mobile/webui/v1/manifest/{manifest_digest}` 与 `/mobile/webui/v1/blob/{blob_digest}`。manifest 使用 `no-store`；带 Bearer 授权的 blob 使用 `private, immutable`、strong ETag 和有界 Range，禁止 shared cache 绕过 ticket 复核。按照 [RFC 9530](https://www.ietf.org/rfc/rfc9530.html)，`Content-Digest` 校验本次响应 bytes，`Repr-Digest` 校验完整 representation；206 时二者通常不同，客户端同时校验二者且显式请求 identity encoding。CAS 只拥有摘要、bytes 与 size；`Content-Type` 必须从当前 target 的 `generation_files` 成员读取，不能由同 digest 首次写入时的 MIME 决定。因为资源 URL 不含 path，同一 target 内一个 digest 只能对应一种 MIME；不同 target 可以对相同 bytes 声明不同合法 MIME。401 只能重新 prepare一次，不能降级匿名下载；3xx 不转发 Authorization。
 - HTTPS 不跟随任意 host redirect；最终 TLS/服务端身份必须与配对身份一致。
 - 设备 revoke 后停止新发现和下载，关闭该服务端 bridge admission，并按明确产品动作决定是否保留已验证缓存；不得继续把旧 ticket 当授权。
-- WebView 继续只加载原生提供的本地可信 origin，generation 进入 URL path；entry HTML 使用 `no-store`，content-hash asset 可以 immutable。CSP 不开放任意网络，外部链接交给系统浏览器。
+- WebView 继续只加载原生提供的本地可信 origin，server 与 generation 进入 URL path；entry HTML 使用 `no-store`，content-hash asset 可以 immutable。entry CSP 固定拒绝 `connect-src`、`frame-src`、`object-src` 与 `worker-src`，外部链接交给系统浏览器。
 - WebView navigation、subresource 和 service worker 不得绕过 asset handler 访问发布服务器或第三方。
 - Web→Native bridge 使用 exact-origin、main-frame 的单一版本化消息 envelope；Android 优先使用带 `allowedOriginRules` 的 [WebViewCompat.addWebMessageListener](https://developer.android.com/reference/androidx/webkit/WebViewCompat#addWebMessageListener)。candidate 健康前不开放有副作用 capability。Android 官方把加载不可信内容的 JavaScript interface 列为高风险边界，见 [WebView native bridge security](https://developer.android.com/privacy-and-security/risks/insecure-webview-native-bridges)。
-- archive 必须拒绝绝对路径、`..`、重复规范化路径、symlink、特殊文件、zip bomb、超限文件数和超限解包体积。
-- manifest、文件 hash、archive hash 或 content length 不一致时 fail-loud，不使用“尽量能打开”的部分版本。
+- 发布者扫描输入目录时必须拒绝绝对路径、`..`、反斜杠、空段、ASCII 大小写冲突、超长路径、`%`/`?`/`#`、非 ASCII 段、symlink 和特殊文件；客户端对 manifest 重复执行同一规范化与 MIME 白名单。首版收窄为 URL/storage 都无歧义的 ASCII path，不把 Unicode case-fold 或 percent-decoding 差异留给跨平台实现。首版 OTA 不接收 archive，因此不把 ZIP 解压权限交给数据面。
+- manifest、文件 hash 或 content length 不一致时 fail-loud，不使用“尽量能打开”的部分版本。
 
 ## 11. Edge case 合同矩阵
 
@@ -422,6 +437,9 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | PUB-014 | 发布 GC 与指针提交并发 | ReleaseView 可达对象在同一引用/租约协议下 pin；不得提交指向缺失 blob 的选择 |
 | PUB-015 | commit 相同但 lockfile、构建配置、toolchain 或环境不同 | WebUI build context fingerprint 不同；Stable 可复现证据必须覆盖全部真实输入 |
 | PUB-016 | 发布仓从备份恢复到旧选择 | 恢复后的当前 ReleaseView 是 desired truth；审计 journal 记录恢复，但客户端不比较历史序号拒绝它 |
+| PUB-017 | 回滚目标仍在 rollback pin/备份 | 在线 pin 可直接原子切指针；只在备份中时必须先隔离恢复/导入并完整复验 |
+| PUB-018 | 回滚目标已 GC 且无可验证备份 | `rollback_unavailable`，不改变 ReleaseView、不发成功 hint、不伪造 generation |
+| PUB-019 | Stable/Preview 都清空 | ReleaseView 保留两个 null 键；客户端成功 Resolve 后 desired=baseline |
 
 ### 11.2 发现、认证和身份
 
@@ -439,6 +457,9 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | AUTH-010 | server identity 变化但地址相同 | 视为新服务端；旧缓存不能继承 |
 | AUTH-011 | 地址改变但固定 server identity 相同 | 只有经过配对 profile 的显式重绑定/验证才沿用缓存；redirect 不能完成重绑定 |
 | AUTH-012 | 相同 selection digest 或 TargetKey 返回不同规范化内容 | fail-loud，拒绝整个 ReleaseView/Target |
+| AUTH-013 | 收到 `release.changed` EVENT、durable replay 或未认证 CONTROL | 全部拒绝；hint 只允许已认证 CONTROL，且 envelope 的 positive connection epoch 必须与当前连接一致 |
+| AUTH-014 | hint 缺少 `server_id`/`selection_digest`、多余键或 digest 不是 64 位小写十六进制 | 严格拒绝 payload；合法 digest 仍只是 dirty hint，不能作为 Target |
+| AUTH-015 | `ReleaseView` 省略 nullable `stable` 或 `preview` 键 | 严格拒绝；显式 `null` 才表示该 channel 无选择，不得把缺键默认成 null |
 
 ### 11.3 网络与传输
 
@@ -451,13 +472,17 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | NET-005 | 当前 Target 的 manifest/blob 404 | `RejectTarget` 并报告发布仓损坏，不解释为“没有更新” |
 | NET-006 | 412、strong ETag 或内容身份变化 | 丢弃该 blob partial并重新 Resolve，不拼接不同内容 |
 | NET-007 | Content-Length、实际字节或 hash 超限/不符 | 删除临时对象并 fail-loud |
-| NET-008 | archive 路径逃逸、symlink、特殊文件或压缩炸弹 | 在物化前拒绝整个候选 |
+| NET-008 | manifest 路径逃逸、超长/非 ASCII/percent 歧义、大小写冲突，或发布输入含 symlink/特殊文件 | 在任何 serving/verified marker 前拒绝整个候选；首版不接收 archive |
 | NET-009 | Ensure A 期间 Resolve 得到 Target B | B 替换唯一 worker；A 不可 Present，已验证 blobs 可复用 |
 | NET-010 | 临时错误连续发生 | `RetryAfter` 有界退避并可观察，不阻塞 serving |
 | NET-011 | 应用或设备重启 | 先读取 verified marker/hash；完整 target 不因重启重新下载 |
 | NET-012 | 本地单个 blob 自检损坏 | 只删除并补齐该 blob；从服务端连续得到错误内容后 `RejectTarget` |
 | NET-013 | 设备离线后服务端已清除 Preview | 设备无法猜测远端变化，继续使用最后已认证 desired；重连 Resolve 后收敛，不按本地时间伪造清除 |
 | NET-014 | 客户端或服务端 wall clock 回拨/跳变 | 时间只用于展示、TTL 或退避，不用于判断 ReleaseView 新旧 |
+| NET-015 | `409 target_changed` | 终止旧 target owner 并重新 Resolve；旧响应不能更新 desired/ready/serving |
+| NET-016 | `416 invalid_range` | 校验并丢弃不成立的 partial，再从零请求该 blob；有界重试仍失败则按损坏证据拒绝 |
+| NET-017 | `500 release_store_corrupt` 或临时 5xx | 保留当前健康 serving；发布仓损坏需显式报告，临时 5xx 进入 `RetryAfter`，都不能从 realtime owner 裸抛退出 |
+| NET-018 | 一个 manifest 的多个 path 复用同一 blob digest | size 与 MIME 都必须相同，否则拒绝整个 Target；缺失空间只按唯一 digest 计算，不重复扩大下载预算 |
 
 ### 11.4 存储、GC 和人工清理
 
@@ -477,6 +502,9 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | STO-012 | OS 清除 cache 目录 | serving/fallback 放 app-private durable files；丢失的 partial/未引用 cache 可重建 |
 | STO-013 | app data 被恢复到另一设备但 Keystore/配对身份不可用 | 不执行旧远程 UI；回 baseline并等待重新配对，业务数据按其独立恢复合同处理 |
 | STO-014 | reset/clear 与 Ensure/Present 并发 | 同一 store/coordinator owner 先取消并等完成，再删除；不得边读边删 |
+| STO-015 | GC 删文件失败 | 保留 DAO/reference owner 并 fail-loud，不报告已释放空间；只有物理删除成功后才能删 metadata |
+| STO-016 | 同 Target 已因空间不足进入 `WaitFor(space)` | 前台、重连或普通 hint 可 Resolve 当前选择，但不得对同 Target 再 prepare/manifest/download；只有 Target 变化、显式清理、用户明确重试、reset 或 revoke 才解除该等待事实 |
+| STO-017 | manifest/blob 本地验证、删除或 Room 写入失败 | WebUI coordinator 保留 serving/lease owner 并转换为可观察错误或有界重试；派生 UI 缓存故障不得冒充 realtime 协议错误而断开消息连接 |
 
 ### 11.5 生命周期与进程恢复
 
@@ -495,6 +523,8 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | LIFE-011 | WebView provider 缺失、禁用或无法创建 | 显示原生恢复页并提示系统修复；不能假称 baseline 已成功渲染 |
 | LIFE-012 | APK 升级时旧 `attempting` 尚在 | 新 binary 先用自己的 baseline，废止旧 attempt，再按新兼容性重新 Resolve/Ensure |
 | LIFE-013 | serving 健康提交后应用被 force-stop 或 OS kill | serving marker 已提交，下一次可继续使用；不当作 candidate 失败 |
+| LIFE-014 | 同一 Activity 从 server A 切换到 B | 在 B 首帧前同步建立新 UI session；不能继承 A 的 `sessionStarted` 而跳过 B 的 Present 边界 |
+| LIFE-015 | candidate 健康窗口中 Activity 旋转/配置重建 | application/process-scope attempt lease 仍是唯一 owner；新 WebView 继续以 candidate 身份和 `admission=false` 运行，不得把未提交 generation 读成 serving |
 
 ### 11.6 用户行为与页面状态
 
@@ -536,6 +566,8 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | WEB-015 | 路径大小写、Unicode normalization 冲突或 MIME 与扩展不符 | manifest 规范化阶段拒绝整个 target |
 | WEB-016 | action 在 reload 前后重复、capability 已废弃 | 版本化 envelope + request ID；幂等与终态由原生 owner 决定 |
 | WEB-017 | 页面自报 healthy 但尚未产生可见首帧 | 原生 visual acknowledgment 未到，不提交 serving、不开放写动作 |
+| WEB-018 | 两个 generation 复用同一 bytes digest 但声明不同合法 MIME | CAS 复用 bytes；每次响应按当前 target 的 MIME 返回，不能继承首次写入 MIME；同一 target 内 digest 对应多个 MIME 时拒绝 manifest |
+| WEB-019 | candidate 在健康提交前尝试打开外链 | 拦截且不调用系统 Activity；只有同一 lease 健康提交并开放 admission 后，才可按已有外链策略交给系统浏览器 |
 
 ### 11.8 连续发布、多设备和多服务端
 
@@ -553,6 +585,9 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | CON-010 | 短时间收到大量 hint | 合并为 dirty bit；单飞 Resolve 结束后最多补查一次 |
 | CON-011 | 旧 Resolve/Ensure callback 晚于 server switch | owner token 不匹配即忽略；不能改变新 UI session |
 | CON-012 | 同一应用同时维护多个 server UI 缓存 | 每 server 独立 Resolve/Ensure/Store；全局容量只触发安全 GC，不串改 desired |
+| CON-013 | 成功 Resolve 得到两个 null 指针 | 当前 UI session 可继续旧 serving；下一 session 使用 baseline，旧 serving 不成为 desired |
+| CON-014 | 用户对当前 rejected Target 执行显式“重新检查/重试” | 只清除当前 ReleaseView 中精确 TargetKey + compatibility fingerprint 的 reject 并 Resolve；不清空其他 target，不改 GitHub APK 更新器 |
+| CON-015 | candidate B 健康窗口中 Resolve 得到 Target C | 立即废止 B 的 attempt lease 并恢复已提交 serving/baseline；B 不再渲染或提交，其已验证 blobs 可由 Store 复用，唯一 Ensure owner 转向 C |
 
 ### 11.9 兼容性与二进制发行
 
@@ -566,6 +601,8 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 | BIN-006 | 未来 iOS | 复用中立 manifest/Resolve/Ensure/Present；哪些 WebUI 变化可 OTA 需按 [App Review Guidelines 2.5.2](https://developer.apple.com/app-store/review/guidelines/) 单独确认 |
 | BIN-007 | 服务端下发 dex/JAR/.so 或原生可执行内容 | 永久拒绝；WebUI OTA 只接受声明的静态 Web 资源类型 |
 | BIN-008 | APK 升级带来新 baseline，但服务端仍选择旧 generation | 按 compatibility 和当前 ReleaseView 选择，不以 build 时间判断；无兼容 target 时使用新 baseline |
+| BIN-009 | 首个 OTA APK 同时含 baseline schema 1 与远端 manifest schema 2 | 两者由不同 owner 解析：Gradle/embedded loader 继续验证 schema 1 ZIP，OTA parser 只接受 schema 2；baseline 不写入 OTA Room/CAS |
+| BIN-010 | 强制保留数据降级到旧 APK | 不属于支持的恢复路径；不得 destructive migrate v13 业务库。旧 binary 不解析 OTA store，恢复应安装兼容的新 binary；embedded baseline 不能证明 Room downgrade 安全 |
 
 ## 12. 用户可见行为
 
@@ -576,17 +613,19 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 - “立即应用”只在 ready 时出现；`canReplaceUi=false` 时显示原生 continuation/snapshot 等粗粒度原因，不展示内部状态名。
 - “清理未使用 UI 资源”和“重置此服务端 UI 缓存”必须明确不会删除聊天、草稿、附件或配对；执行结果报告释放空间和当前来源。
 
-## 13. 分阶段实施方向
+## 13. 实施与交付顺序
 
-以下只是设计顺序，不是当前实施授权：
+维护者已经批准按以下顺序实施和交付：
 
-1. 接受本设计后，新增决策记录并勘误 0018 与移动仓库固定 ZIP/no-network 合同。
-2. 确认服务端发布仓的持久化根、备份/恢复、增改减和发布事务。
-3. 固化平台中立 generation manifest、ReleaseView、WSS descriptor、HTTPS ticket/content 和 bridge envelope。
-4. 实现 Core 隔离构建、不可变 generation、CAS、Stable/Preview 发布和只读 Runtime 接口。
-5. Android 分别实现 `ReleaseResolver`、`ArtifactEnsurer`、`UiSessionController` 与 `LocalWebUiStore`，不再实现平行的下载/等待/激活总状态机。
-6. 运行 Core/Android targeted tests、change-impact Gate、跨仓库固定组合和真机故障注入。
-7. 当前 GitHub APK updater 保持原状；未来真的准备 Google Play 或 iOS 时分别建立新合同，不作为首版 OTA 前置工作。
+1. 决策 0022 与 WEBUI-004～WEBUI-006 勘误固定 ZIP/no-network 合同，并把本文精确 wire 生成 Core schema 真源。
+2. Core 实现隔离构建、不可变 generation、CAS、Stable/Preview 发布、备份清单和只读 Runtime 接口；先合并 Core PR 并固定 merge commit/tree/schema digest。
+3. Android 实现 `ReleaseResolver`、`ArtifactEnsurer`、`UiSessionController` 与 `LocalWebUiStore`，把协议 snapshot 和 Runtime Contract 固定到已合并 Core commit，不实现平行的下载/等待/激活总状态机。
+4. 两仓库分别运行 targeted tests、静态检查和 change-impact Gate，再运行无网络、只读源码、tmpfs workspace 的固定跨仓库组合。
+5. 只从干净移动端 commit 构建 run-specific app/test package，连接一次性 Core workspace 与 Gateway，在真机分阶段验证发布、增量下载、进程恢复、回滚、缓存重置和业务 write set；正式 app package、正式 Gateway 与正式 workspace 保持逐项不变。
+6. Core 与 Android PR checks、主审累计 diff 和真机 cleanup 都通过后合并 Android PR，从 merge commit 构建并验证签名 APK，发布下一个 GitHub patch release。
+7. Release 资产和摘要复读成功后更新两个本地 `main`，最后按 Supervisor/Guardian 合同安全重启正式 Core，并独立核对新 boot、readiness、listener 与受保护数据。
+
+当前 GitHub APK updater 保持原状；未来真的准备 Google Play 或 iOS 时分别建立新合同，不作为首版 OTA 前置工作。
 
 ## 14. 验收边界
 
@@ -599,18 +638,25 @@ release descriptor ── short-lived bound ticket ──→ same server HTTPS
 - 连续发布最终只 Present 最近一次成功 Resolve 的 desired Target；不会在 serving 目录混合两个 generation。
 - 草稿、阅读位置、outbox、附件、消息、配对和插件真实状态在更新、回滚、GC 和重置前后符合各自 owner 合同。
 - Preview dirty provenance 可审计，Stable 能从声明的 WebUI 输入重建相同产物。
-- 所有安全上限、archive 攻击、ticket 失效、身份变化和恶意 navigation 都有独立失败测试。
+- 所有安全上限、输入目录路径攻击、ticket 失效、身份变化和恶意 navigation 都有独立失败测试。
 - 多服务端、多设备、冷启动、后台、Activity result、IME、streaming、连续崩溃、备份恢复、旧 callback 和低磁盘场景有明确 oracle，且分别绑定 Resolve/Ensure/Present/Store owner。
 - Android 真机证据与 Core CI、跨仓库组合证据分层报告，不用模拟成功替代设备行为。
 
-## 15. 待继续商讨
+## 15. 首版固定实施参数
 
-以下内容尚未批准，不能从本文推断实现：
+| 范围 | 固定选择 |
+|---|---|
+| 原生兼容 | 首个 OTA Android binary 使用 native build 45；bridge protocol `1`、snapshot protocol `7` |
+| ticket | ECDSA target-scoped bearer，TTL 300 秒；同一 target 内只能读取 manifest 与清单成员；每次 HTTP 执行复核 device revoke 与 connection epoch |
+| HTTP 失败 | 无发布返回 nullable Stable/Preview；非法 ticket=`401 invalid_ticket`，选择已变=`409 target_changed`，目标成员不存在=`404 resource_not_found`，Range 无效=`416 invalid_range`，发布仓引用损坏=`500 release_store_corrupt` |
+| 资源边界 | manifest 1 MiB、2,048 files、single blob 8 MiB、generation 64 MiB、single Range response 8 MiB；无 archive 数据面 |
+| 健康提交 | candidate 必须在 10 秒内完成 exact-origin/nonce/generation/bridge/snapshot 握手、完整 snapshot、root render 和 visual acknowledgment；JS 自报 healthy 单独无效 |
+| renderer 恢复 | serving 单次 termination 重建同 generation；5 分钟内第二次 termination 回 fallback/baseline 并拒绝当前 compatibility fingerprint 下的 TargetKey |
+| 自动重试 | 同 TargetKey 的 `RejectTarget` 不自动重试；只在 TargetKey、native/WebView compatibility fingerprint 改变或用户明确重试时解除。临时错误使用有界退避，reconnect 和手动检查可以提前触发 |
+| 客户端保留 | 每 server 4 个 verified generation/256 MiB、全局 512 MiB 为 GC 目标；pinned 集合可以临时超出并转 `WaitFor(space)`，不能删除 pinned 资源 |
+| 发布保留与恢复 | `release_epoch` 是 publication store 初始化时生成并持久化的 lineage UUID；`sequence` 只追加审计。当前 Stable/Preview、每 channel 最近 4 个选择、显式 pin 与进行中的 backup source set 不可 GC；客户端不比较 epoch/sequence 判断新旧 |
+| Bridge | Web→Native 只接受本地 exact origin、main frame 的版本化单 envelope；candidate 通过 visual health 前只开放只读握手和 snapshot，不开放发送、文件、系统或插件副作用 |
 
-1. 服务端发布仓位于 Akashic `<workspace>`、独立 deployment state root，还是由配置显式选择；Stable/Preview、generation、CAS 和 publication journal 是否进入正式备份。
-2. 各持久对象的具体目录、schema、锁、事务、retention 数值、备份恢复和跨版本迁移。
-3. generation manifest、ReleaseView、selection digest 与 WSS/HTTPS 的精确字段名、命令、事件、错误码、endpoint 和 ticket 生命周期。
-4. 文件数、大小、压缩比、并发、超时、重试、健康窗口、崩溃窗口和 rejected TargetKey 重试窗口的具体常量。
-5. bridge snapshot/patch/capability 的精确兼容矩阵、single-envelope 迁移和通用 durable ack；不再为页面各类临时状态设计专用 flush 字段。
-6. 两仓库 PR 切分、任务合同、Gate 选择、真机矩阵和正式发布操作手册。
-7. Google Play 与 iOS 的未来发行资格和具体改动；当前 GitHub APK updater 不变，该项不阻塞首版 OTA。
+OTA 交付的唯一机器可读真源由 Core merge commit 中的 schema 生成器、`schema/mobile-realtime-v1.json` 和 canonical golden vectors 共同保存。Android 只能消费固定 repository/merge commit/tree/path/SHA-256 的 snapshot，并记录实际 provider runtime；只有锁定到已合并 Core 身份的 consumer 通过跨仓库组合 Gate 和本轮设备验收时，才能声称该组合已交付。文档表格用于评审语义，若字段、canonical bytes 或错误码与机器 schema 不一致则实现和 Gate 必须 fail-loud，不能选择更宽松的一方。
+
+Google Play 与 iOS 的未来发行资格和具体改动仍不属于首版；当前 GitHub APK updater 不变，该项不阻塞 WebUI OTA。

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -185,6 +185,28 @@ SessionDB 继续保存完整 assistant 正文和完整内部轨迹。实时投�
 
 两端默认使用同一套移动端浅蓝主题和同一套流式正文呈现。视觉与组件复用不得把 SessionDB、Room、outbox、设备密钥、通知、配对或插件运行状态迁入 WebUI；这些状态继续由 `MOB-001` 与移动仓库合同指定的 owner 管理。
 
+### WEBUI-004 移动 WebUI 只发布不可变 generation
+
+Core 发布者从固定 WebUI 输入生成不可变 manifest 和按内容摘要寻址的静态资源。只有名称明确的 Stable、Preview、清除和回滚命令可以原子改变当前 `ReleaseView`；保存源码、构建成功、文件 watcher 和 Runtime 重启都不得自动发布。Preview 对同一服务端配对的设备共同生效；Stable 必须能从声明的提交、锁文件、构建配置和工具链重建相同 generation，未提交的 Preview 只有在提交后重建出相同 generation 时才能提升。
+
+客户端把每次已认证 `Resolve` 返回的当前 `ReleaseView` 当作服务端选择，不按发布序号、时间、语义版本或本地历史推断新旧。发布恢复或显式回滚可以重新选择过去的 generation；迟到的客户端回调只能用本地 owner token 拒绝，不能覆盖较新的解析结果。
+
+### WEBUI-005 移动端只运行本地完整验证的 WebUI
+
+Android 和未来的 iOS 客户端不得直接打开远程页面。已配对客户端从当前服务端身份下解析发布选择，通过同一认证边界补齐 manifest 与静态资源，校验兼容范围、路径、类型、大小和摘要后，才从本地可信 origin 创建新的 UI session。每个服务端的缓存和失败记录相互隔离；相同摘要不得跨服务端共享资源。
+
+APK 或 IPA 必须保留 embedded baseline，远程发现、下载、校验、激活、renderer 故障或进程恢复失败时仍能回到最近健康的本地 generation 或 baseline。客户端只协调 `Resolve`、`Ensure` 和 `Present` 三个幂等动作，不建立把网络检查、下载、等待页面状态和 WebView 替换串成一条全局更新状态机。
+
+`Resolve/Ensure` 只能得到 `Ready`、`RetryAfter`、`WaitFor(trigger)` 或 `RejectTarget`。同一 Target 进入 `WaitFor(space)` 后，前台、重连和普通 hint 可以重新 Resolve 当前选择，但不得重复 prepare、manifest 或 blob 下载；只有 Target 变化、显式清理、用户明确重试、reset 或 revoke 解除该等待事实。同 Target 的永久 reject 也只能由 Target/兼容指纹变化或针对当前 Target 的显式用户重试解除。
+
+### WEBUI-006 WebUI OTA 不取得原生与业务状态所有权
+
+纯样式、布局、组件组合和只使用既有 bridge capability 的交互通过服务端 WebUI 发布交付，不要求发布移动二进制。新增或改变原生 capability、bridge/snapshot 兼容边界、平台生命周期、数据库、网络或安全逻辑时必须发布对应平台二进制，并用 manifest 的兼容范围阻止旧客户端加载。
+
+移动原生层继续拥有配对、认证、下载、摘要校验、缓存、激活、回退、GC、系统能力和业务动作 admission；WebUI 不得读取凭据、任意文件路径、任意网络或发布权限。更新、回滚、清理未使用 UI 资源和重置单个服务端 UI 缓存只能改变派生 WebUI 资源和诊断状态，不得删除或改写消息、草稿、outbox、阅读位置、附件、配对密钥或插件事实。GitHub APK 更新检查、下载、安装确认和权限继续使用独立 owner，不因 WebUI OTA 自动改变。
+
+candidate 在 10 秒健康提交前必须由 process-scope attempt lease 持有，Activity 旋转、配置重建或 server switch 不得把它误当成已提交 serving。在该边界前不开放写动作或外链 Activity；GC 只有在物理文件删除成功后才能删除对应 metadata/reference owner，删除失败必须 fail-loud 并保留引用。
+
 ## 5. Agent 任务合同
 
 本节参考 [OpenAI · Prompting guidance for GPT-5.6](https://developers.openai.com/api/docs/guides/prompt-guidance-gpt-5p6)，并按本项目的数据与权限边界收窄。外部指南提供设计依据，不会自动覆盖本文件条款；指南更新需要评审后再修改 PRM 条款。

--- a/frontend/chat/mobile.html
+++ b/frontend/chat/mobile.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline' blob:; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'none'; connect-src 'none'"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline' blob:; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; frame-src 'none'; worker-src 'none'; base-uri 'none'; connect-src 'none'"
     />
     <meta name="color-scheme" content="light" />
     <title>Akashic Mobile</title>

--- a/frontend/chat/src/mobile-bridge.test.mjs
+++ b/frontend/chat/src/mobile-bridge.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { installMobileBridge } from "./mobile-bridge.ts";
+
+const EXPECTED_METHODS = [
+  "requestSnapshot", "selectSession", "removeUnavailableSession", "createSession",
+  "restartPairing", "reloadFromServer", "exportDiagnostics", "openSettings",
+  "chooseAttachments", "removeAttachment", "retryAttachment", "continueMeteredTransfer",
+  "retryFailedMessage", "saveReadingPosition", "markSessionReadThrough", "navigationTargetHandled",
+  "retryDownloadedAttachment", "touchDownloadedAttachment", "openDownloadedAttachment",
+  "shareDownloadedAttachment", "saveDownloadedAttachment", "setWebHistoryActive", "dismissError",
+  "shareText", "saveComposerDraft", "commitSharedText", "rejectSharedText", "sendMessage",
+  "copyText", "performActionHaptic", "sendCommand", "refreshRuntimeInspection",
+  "openRuntimeDocument", "openRuntimeMcp", "openRuntimeJob", "clearRuntimeInspectionDetail",
+  "stopTurn", "queryPluginUi", "cancelPluginUiOwner", "reportHealthy",
+];
+
+function installFor(url) {
+  const messages = [];
+  globalThis.window = {
+    location: { href: url },
+    AkashicNativeTransport: { postMessage: (message) => messages.push(JSON.parse(message)) },
+  };
+  installMobileBridge();
+  return { bridge: window.AkashicNative, messages };
+}
+
+test("embedded and remote WebUI install one generation-bound native surface", () => {
+  const remote = installFor("https://mobile.invalid/mobile.html?generation_id=remote-gen&nonce=remote-nonce");
+  const embedded = installFor("file:///android_asset/mobile.html?generation_id=embedded&nonce=baseline");
+  assert.deepEqual(Object.keys(remote.bridge).sort(), [...EXPECTED_METHODS].sort());
+  assert.deepEqual(Object.keys(embedded.bridge).sort(), [...EXPECTED_METHODS].sort());
+
+  assert.throws(() => remote.bridge.selectSession(), /expects 1 args/);
+  remote.bridge.requestSnapshot();
+  embedded.bridge.reportHealthy();
+  assert.deepEqual(remote.messages[0], {
+    v: 1,
+    generation_id: "remote-gen",
+    nonce: "remote-nonce",
+    method: "requestSnapshot",
+    args: [],
+  });
+  assert.deepEqual(embedded.messages[0], {
+    v: 1,
+    generation_id: "embedded",
+    nonce: "baseline",
+    method: "reportHealthy",
+    args: [],
+  });
+  delete globalThis.window;
+});

--- a/frontend/chat/src/mobile-bridge.ts
+++ b/frontend/chat/src/mobile-bridge.ts
@@ -1,0 +1,59 @@
+type NativeTransport = {
+  postMessage(message: string): void;
+};
+
+type NativeBridgeMethod = (...args: unknown[]) => void;
+
+const METHODS = [
+  "requestSnapshot", "selectSession", "removeUnavailableSession", "createSession",
+  "restartPairing", "reloadFromServer", "exportDiagnostics", "openSettings",
+  "chooseAttachments", "removeAttachment", "retryAttachment", "continueMeteredTransfer",
+  "retryFailedMessage", "saveReadingPosition", "markSessionReadThrough", "navigationTargetHandled",
+  "retryDownloadedAttachment", "touchDownloadedAttachment", "openDownloadedAttachment",
+  "shareDownloadedAttachment", "saveDownloadedAttachment", "setWebHistoryActive", "dismissError",
+  "shareText", "saveComposerDraft", "commitSharedText", "rejectSharedText", "sendMessage",
+  "copyText", "performActionHaptic", "sendCommand", "refreshRuntimeInspection",
+  "openRuntimeDocument", "openRuntimeMcp", "openRuntimeJob", "clearRuntimeInspectionDetail",
+  "stopTurn", "queryPluginUi", "cancelPluginUiOwner", "reportHealthy",
+] as const;
+
+const METHOD_ARITY: Record<(typeof METHODS)[number], number> = {
+  requestSnapshot: 0, selectSession: 1, removeUnavailableSession: 1, createSession: 0,
+  restartPairing: 0, reloadFromServer: 0, exportDiagnostics: 0, openSettings: 0,
+  chooseAttachments: 0, removeAttachment: 1, retryAttachment: 1, continueMeteredTransfer: 0,
+  retryFailedMessage: 1, saveReadingPosition: 3, markSessionReadThrough: 2, navigationTargetHandled: 1,
+  retryDownloadedAttachment: 1, touchDownloadedAttachment: 1, openDownloadedAttachment: 1,
+  shareDownloadedAttachment: 1, saveDownloadedAttachment: 1, setWebHistoryActive: 1, dismissError: 0,
+  shareText: 2, saveComposerDraft: 4, commitSharedText: 4, rejectSharedText: 2, sendMessage: 6,
+  copyText: 1, performActionHaptic: 0, sendCommand: 1, refreshRuntimeInspection: 0,
+  openRuntimeDocument: 1, openRuntimeMcp: 2, openRuntimeJob: 1, clearRuntimeInspectionDetail: 0,
+  stopTurn: 0, queryPluginUi: 10, cancelPluginUiOwner: 1, reportHealthy: 0,
+};
+
+export function installMobileBridge(): void {
+  const transport = window.AkashicNativeTransport as NativeTransport | undefined;
+  if (!transport || typeof transport.postMessage !== "function") return;
+  const url = new URL(window.location.href);
+  const generationId = url.searchParams.get("generation_id");
+  const nonce = url.searchParams.get("nonce");
+  if (!generationId || !nonce) {
+    console.error("[mobile] native transport missing generation-specific URL identity");
+    return;
+  }
+  const bridge: Record<string, NativeBridgeMethod> = {};
+  for (const method of METHODS) {
+    bridge[method] = (...args: unknown[]) => {
+      if (args.length !== METHOD_ARITY[method]) {
+        throw new TypeError(`[mobile] ${method} expects ${METHOD_ARITY[method]} args`);
+      }
+      transport.postMessage(JSON.stringify({
+        v: 1,
+        generation_id: generationId,
+        nonce,
+        method,
+        args,
+      }));
+    };
+  }
+  window.AkashicNative = bridge as unknown as Window["AkashicNative"];
+}

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -1,4 +1,5 @@
 import "./mobile-polyfills";
+import { installMobileBridge } from "./mobile-bridge";
 
 import React, {
   lazy,
@@ -319,7 +320,7 @@ interface MobileRuntimeDetail {
 }
 
 interface NativeBridge {
-  reportReady(): void;
+  reportHealthy(): void;
   requestSnapshot(): void;
   selectSession(sessionId: string): void;
   removeUnavailableSession(sessionId: string): void;
@@ -891,6 +892,9 @@ function parseMobilePluginResult(value: unknown) {
 
 declare global {
   interface Window {
+    AkashicNativeTransport?: {
+      postMessage(message: string): void;
+    };
     AkashicNative?: NativeBridge;
     AkashicMobile?: {
       receiveSnapshot(snapshot: unknown): void;
@@ -1352,7 +1356,6 @@ function MobileNativeApp() {
       }
     };
     window.addEventListener("message", receiveNativeMessage);
-    window.AkashicNative?.reportReady();
     requestSnapshot();
     return () => {
       if (requestTimer !== null) window.clearTimeout(requestTimer);
@@ -1363,6 +1366,14 @@ function MobileNativeApp() {
       delete window.AkashicMobile;
     };
   }, [applySharedText, clearAcceptedComposerDraft, flushComposerDraft, streamStore]);
+
+  useEffect(() => {
+    if (!snapshot) return;
+    const frame = window.requestAnimationFrame(() => {
+      window.AkashicNative?.reportHealthy();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [snapshot]);
 
   useEffect(() => {
     if (snapshot?.composer.isStopping || !snapshot?.composer.canStop || snapshot?.connection.error) {
@@ -4179,6 +4190,7 @@ function syncMobileViewportHeight() {
 
 syncMobileViewportHeight();
 window.addEventListener("resize", syncMobileViewportHeight);
+installMobileBridge();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Mobile Web root 不存在");

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -1793,7 +1793,15 @@ class MobileGatewayRuntime:
             if target is None or target.manifest_digest != manifest_digest:
                 raise MobileWebUiHttpError("resource_not_found", "manifest 不属于当前 target", status_code=404)
             body = canonical_manifest_bytes(self.publication.get_manifest(manifest_digest))
-            if self.publication.get_release_light().selection_digest != verified.selection_digest:
+            current = self.publication.get_release_light()
+            current_target = current.target(verified.target_key)
+            if (
+                current.release_epoch != verified.release_epoch
+                or current.selection_digest != verified.selection_digest
+                or current_target is None
+                or current_target.generation_id != verified.generation_id
+                or current_target.manifest_digest != verified.manifest_digest
+            ):
                 raise MobileWebUiHttpError("target_changed", "manifest 读取期间 release 已变化", status_code=409)
             return body, verified
         except WebUiTicketError as error:

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -1101,6 +1101,61 @@ class MobileGatewayRuntime:
                 force_close=False,
             )
 
+    async def revoke_device(
+        self,
+        device_id: str,
+        *,
+        revoked_at: datetime | None = None,
+    ) -> DeviceRecord:
+        """持久化设备撤销，并通知当前连接后以 4403 关闭。"""
+
+        # 1. 先提交权威撤销状态，任何后续投递失败都不能回滚它
+        revoked = self.storage.revoke_device(device_id, revoked_at=revoked_at or _utc_now())
+        async with self._delivery_lock:
+            connection = self._connections.pop(device_id, None)
+        if connection is None:
+            return revoked
+
+        # 2. 使用已摘除的连接发送一次非 durable 撤销控制帧
+        frame = parse_frame(
+            json.dumps(
+                {
+                    "v": 1,
+                    "kind": "control",
+                    "type": "device.revoked",
+                    "connection_epoch": connection.connection_epoch,
+                    "payload": {
+                        "device_id": revoked.device_id,
+                        "revoked_at": revoked.revoked_at.isoformat() if revoked.revoked_at is not None else None,
+                    },
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
+        try:
+            async with asyncio.timeout(_CONNECTION_CONTROL_SEND_TIMEOUT_SECONDS):
+                _ = await connection.send_lock.acquire()
+            try:
+                async with asyncio.timeout(_CONNECTION_CONTROL_SEND_TIMEOUT_SECONDS):
+                    await connection.websocket.send_text(frame_to_json(frame))
+            finally:
+                connection.send_lock.release()
+        except (WebSocketDisconnect, RuntimeError, OSError, TimeoutError) as error:
+            logger.warning("mobile 撤销控制帧投递失败: device=%s error=%s", device_id, error)
+        finally:
+            # 3. 无论控制帧是否送达，都强制关闭旧连接并保留已提交撤销
+            await self._close_connection(
+                device_id,
+                connection,
+                code=_CLOSE_REVOKED,
+                reason="设备已撤销",
+                force=True,
+            )
+        return revoked
+
     async def publish_webui_release_changed(self) -> None:
         """在 publication commit 后向具备 OTA 能力的在线设备发送 hint。"""
 
@@ -1776,6 +1831,16 @@ class MobileGatewayRuntime:
             content = blob.path.read_bytes()
             if len(content) != blob.size_bytes or hashlib.sha256(content).hexdigest() != blob_digest:
                 raise RuntimeError("CAS blob 内容与 publication metadata 不一致")
+            current = self.publication.get_release_light()
+            current_target = current.target(verified.target_key)
+            if (
+                current.release_epoch != verified.release_epoch
+                or current.selection_digest != verified.selection_digest
+                or current_target is None
+                or current_target.generation_id != verified.generation_id
+                or current_target.manifest_digest != verified.manifest_digest
+            ):
+                raise MobileWebUiHttpError("target_changed", "blob 读取期间 release 已变化", status_code=409)
             if range_header is not None and if_range is not None and if_range != f'"{blob_digest}"':
                 raise MobileWebUiHttpError("range_precondition_failed", "If-Range 与 blob 摘要不匹配", status_code=412)
             try:
@@ -2101,7 +2166,7 @@ def create_mobile_gateway_app(runtime: MobileGatewayRuntime) -> FastAPI:
         status = 206 if request.headers.get("range") is not None else 200
         headers = {
             "Accept-Ranges": "bytes",
-            "Cache-Control": "public, max-age=31536000, immutable, no-transform",
+            "Cache-Control": "private, max-age=31536000, immutable, no-transform",
             "Content-Encoding": "identity",
             "Content-Length": str(len(content)),
             "ETag": f'"{blob_digest}"',

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -13,7 +13,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, Callable, NoReturn, cast
 
 import uvicorn
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
@@ -98,7 +98,7 @@ from infra.mobile_webui.http import (
     parse_single_range,
 )
 from infra.mobile_webui.manifest import ManifestError, canonical_manifest_bytes
-from infra.mobile_webui.protocol import ErrorReplyWire, PrepareReplyWire, ReleaseViewWire
+from infra.mobile_webui.protocol import ErrorCode, ErrorReplyWire, PrepareReplyWire, ReleaseViewWire
 from infra.mobile_webui.store import (
     MobileWebUiStore,
     ReleaseSelectionChangedError,
@@ -153,7 +153,9 @@ class MobileMessageContentHttpError(RuntimeError):
 
 
 class MobileWebUiHttpError(RuntimeError):
-    def __init__(self, code: str, message: str, *, status_code: int) -> None:
+    code: ErrorCode
+
+    def __init__(self, code: ErrorCode, message: str, *, status_code: int) -> None:
         super().__init__(message)
         self.code = code
         self.status_code = status_code
@@ -1163,7 +1165,7 @@ class MobileGatewayRuntime:
             raise RuntimeError("WebUI publication store 未绑定")
         release = self.publication.get_release()
         self._publication_selection_digest = release.selection_digest
-        payload = {
+        payload: dict[str, object] = {
             "server_id": release.server_id,
             "selection_digest": release.selection_digest,
         }
@@ -1859,7 +1861,8 @@ class MobileGatewayRuntime:
                 start, end = 0, len(content) - 1
             else:
                 start, end = selected
-            return content[start : end + 1], start, end, len(content), blob.mime, verified
+            mime = cast(str, blob.mime)
+            return content[start : end + 1], start, end, len(content), mime, verified
         except WebUiTicketError as error:
             _raise_webui_ticket_http_error(error)
         except MobileWebUiHttpError:
@@ -2678,7 +2681,7 @@ def _release_view_json(release: ReleaseView) -> dict[str, object]:
     }
 
 
-def _raise_webui_ticket_http_error(error: WebUiTicketError) -> None:
+def _raise_webui_ticket_http_error(error: WebUiTicketError) -> NoReturn:
     status = {
         "invalid_ticket": 401,
         "target_changed": 409,
@@ -2686,7 +2689,7 @@ def _raise_webui_ticket_http_error(error: WebUiTicketError) -> None:
     }.get(error.code)
     if status is None:
         raise MobileWebUiHttpError("invalid_ticket", str(error), status_code=401) from error
-    raise MobileWebUiHttpError(error.code, str(error), status_code=status) from error
+    raise MobileWebUiHttpError(cast(ErrorCode, error.code), str(error), status_code=status) from error
 
 
 def _resolve_workspace_path(workspace: Path, configured: Path) -> Path:

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -6,7 +6,9 @@ import hashlib
 import json
 import logging
 import secrets
+import sqlite3
 import time
+from contextlib import asynccontextmanager
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -68,6 +70,8 @@ from infra.mobile_realtime.protocol import (
     AuthAcceptedPayload,
     GenericCommand,
     GenericControl,
+    MobileWebUiContentPrepareCommand,
+    MobileWebUiReleaseGetCommand,
     MessageSendCommand,
     MobileFrame,
     ProtocolDecodeError,
@@ -87,6 +91,21 @@ from infra.mobile_realtime.storage import (
     UnknownDeviceError,
     AttachmentRecord,
 )
+from infra.mobile_webui.http import (
+    VerifiedWebUiTicket,
+    WebUiTicketError,
+    WebUiTicketIssuer,
+    parse_single_range,
+)
+from infra.mobile_webui.manifest import ManifestError, canonical_manifest_bytes
+from infra.mobile_webui.protocol import ErrorReplyWire, PrepareReplyWire, ReleaseViewWire
+from infra.mobile_webui.store import (
+    MobileWebUiStore,
+    ReleaseSelectionChangedError,
+    ReleaseView,
+    TargetResourceNotFoundError,
+    UnknownReleaseError,
+)
 
 if TYPE_CHECKING:
     from infra.mobile_realtime.channel import MobileRealtimeChannel
@@ -95,6 +114,8 @@ _CLOSE_PROTOCOL = 4400
 _CLOSE_UNAUTHENTICATED = 4401
 _PLUGIN_UI_HTTP_PATH = "/mobile/plugin-ui/v1/query"
 _MESSAGE_CONTENT_HTTP_PATH = "/mobile/message-content/v1"
+_MOBILE_WEBUI_MANIFEST_PATH = "/mobile/webui/v1/manifest"
+_MOBILE_WEBUI_BLOB_PATH = "/mobile/webui/v1/blob"
 _MAX_MESSAGE_CONTENT_RANGE_BYTES = 256 * 1024
 _MAX_PLUGIN_UI_HTTP_REQUEST_BYTES = 72 * 1024
 _CLOSE_REVOKED = 4403
@@ -131,6 +152,13 @@ class MobileMessageContentHttpError(RuntimeError):
         self.status_code = status_code
 
 
+class MobileWebUiHttpError(RuntimeError):
+    def __init__(self, code: str, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
 @dataclass(frozen=True, slots=True)
 class PairingApproval:
     pairing_id: str
@@ -145,6 +173,7 @@ class ActiveMobileConnection:
     pending_events: deque[DurableInboxEvent]
     ready: bool
     delivery_task: asyncio.Task[None] | None
+    capabilities: tuple[str, ...] = ()
     plugin_ui_tasks: set[asyncio.Task[None]] = field(default_factory=_plugin_ui_task_set)
     sent_condition: asyncio.Condition = field(default_factory=asyncio.Condition)
     reply_barrier: int | None = None
@@ -224,6 +253,7 @@ class MobileGatewayRuntime:
         inbox: DurableInboxManager,
         approvals: PairingApprovalRegistry,
         keyset: LoadedKeyset,
+        publication: MobileWebUiStore | None = None,
     ) -> None:
         self.config = config
         self.storage = storage
@@ -232,12 +262,27 @@ class MobileGatewayRuntime:
         self.inbox = inbox
         self.approvals = approvals
         self.keyset = keyset
+        self.publication = publication
         self.admin = MobilePairingAdmin(pairing, approvals)
         self.plugin_ui_http_tickets = PluginUiHttpTicketIssuer(keyset, storage)
         self.message_content_tickets = MessageContentTicketIssuer(keyset, storage)
+        self.webui_http_tickets = (
+            WebUiTicketIssuer(
+                keyset,
+                storage,
+                publication,
+                connection_checker=self._is_current_webui_connection,
+            )
+            if publication is not None
+            else None
+        )
         self._channel: MobileRealtimeChannel | None = None
         self._connections: dict[str, ActiveMobileConnection] = {}
         self._delivery_lock = asyncio.Lock()
+        self._publication_monitor_task: asyncio.Task[None] | None = None
+        self._publication_selection_digest = (
+            publication.get_release_light().selection_digest if publication is not None else None
+        )
 
     @property
     def channel(self) -> MobileRealtimeChannel:
@@ -253,6 +298,7 @@ class MobileGatewayRuntime:
     async def handle_websocket(self, websocket: WebSocket) -> None:
         """执行 challenge、配对或设备认证，再进入已认证协议循环。"""
 
+        self.start()
         await websocket.accept()
         connection_id = secrets.token_hex(16)
         challenge = self.authenticator.create_challenge(connection_id)
@@ -308,6 +354,7 @@ class MobileGatewayRuntime:
                 websocket,
                 device_id=device.device_id,
                 connection_epoch=device.connection_epoch,
+                capabilities=device.capabilities,
             )
         except WebSocketDisconnect:
             return
@@ -387,6 +434,7 @@ class MobileGatewayRuntime:
         *,
         device_id: str,
         connection_epoch: int,
+        capabilities: tuple[str, ...] = (),
     ) -> None:
         """只处理 epoch 匹配的 resume、ACK 和基础 command。"""
 
@@ -428,6 +476,8 @@ class MobileGatewayRuntime:
                         ResumeControl,
                         AckFrame,
                         GenericCommand,
+                        MobileWebUiReleaseGetCommand,
+                        MobileWebUiContentPrepareCommand,
                         MessageSendCommand,
                         AttachmentBeginCommand,
                         AttachmentFinishCommand,
@@ -461,6 +511,7 @@ class MobileGatewayRuntime:
                         device_id=device_id,
                         connection_epoch=connection_epoch,
                         last_ack=frame.payload.last_ack,
+                        capabilities=capabilities,
                     )
                     resumed = True
                     continue
@@ -493,6 +544,8 @@ class MobileGatewayRuntime:
                     frame,
                     (
                         GenericCommand,
+                        MobileWebUiReleaseGetCommand,
+                        MobileWebUiContentPrepareCommand,
                         MessageSendCommand,
                         AttachmentBeginCommand,
                         AttachmentFinishCommand,
@@ -505,6 +558,43 @@ class MobileGatewayRuntime:
                         connection_epoch=connection_epoch,
                     ):
                         return
+                    connection = self._connections.get(device_id)
+                    if connection is None:
+                        return
+                    if isinstance(
+                        frame,
+                        (MobileWebUiReleaseGetCommand, MobileWebUiContentPrepareCommand),
+                    ) and "mobile-webui-ota-v1" not in connection.capabilities:
+                        async with connection.send_lock:
+                            await _send_reply(
+                                websocket,
+                                frame_id=frame.id,
+                                connection_epoch=connection_epoch,
+                                reply_type=f"{frame.type}.error",
+                                payload=ErrorReplyWire(
+                                    code="capability_required",
+                                    message="设备未声明 mobile-webui-ota-v1",
+                                ).model_dump(mode="json"),
+                                session_id=frame.session_id,
+                                turn_id=frame.turn_id,
+                            )
+                        continue
+                    if isinstance(frame, MobileWebUiReleaseGetCommand):
+                        await self._handle_webui_release_get(
+                            websocket,
+                            frame,
+                            connection_epoch,
+                            device_id,
+                        )
+                        continue
+                    if isinstance(frame, MobileWebUiContentPrepareCommand):
+                        await self._handle_webui_content_prepare(
+                            websocket,
+                            frame,
+                            connection_epoch,
+                            device_id,
+                        )
+                        continue
                     if (
                         isinstance(frame, GenericCommand)
                         and frame.type == "message.content.prepare"
@@ -612,6 +702,7 @@ class MobileGatewayRuntime:
         device_id: str,
         connection_epoch: int,
         last_ack: int,
+        capabilities: tuple[str, ...] = (),
     ) -> None:
         """先占住设备投递槽，再在锁外重放并切换为实时投递。"""
 
@@ -629,6 +720,7 @@ class MobileGatewayRuntime:
                 pending_events=deque(),
                 ready=False,
                 delivery_task=None,
+                capabilities=capabilities,
             )
             self._connections[device_id] = connection
 
@@ -1009,6 +1101,73 @@ class MobileGatewayRuntime:
                 force_close=False,
             )
 
+    async def publish_webui_release_changed(self) -> None:
+        """在 publication commit 后向具备 OTA 能力的在线设备发送 hint。"""
+
+        if self.publication is None:
+            raise RuntimeError("WebUI publication store 未绑定")
+        release = self.publication.get_release()
+        self._publication_selection_digest = release.selection_digest
+        payload = {
+            "server_id": release.server_id,
+            "selection_digest": release.selection_digest,
+        }
+        async with self._delivery_lock:
+            targets = tuple(
+                (device_id, connection.connection_epoch)
+                for device_id, connection in self._connections.items()
+                if connection.ready and "mobile-webui-ota-v1" in connection.capabilities
+            )
+        for device_id, connection_epoch in targets:
+            await self.publish_connection_control(
+                control_type="mobile.webui.release.changed",
+                payload=payload,
+                device_id=device_id,
+                connection_epoch=connection_epoch,
+            )
+
+    def start(self) -> None:
+        """Start the non-durable publication watcher on the active event loop."""
+
+        if self.publication is None or self._publication_monitor_task is not None:
+            return
+        self._publication_monitor_task = asyncio.create_task(self._watch_publication())
+
+    async def stop(self) -> None:
+        """Stop the publication watcher without changing durable publication state."""
+
+        task = self._publication_monitor_task
+        self._publication_monitor_task = None
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def _watch_publication(self) -> None:
+        """Poll committed selection identity and emit capability-filtered hints."""
+
+        while True:
+            await asyncio.sleep(0.5)
+            if self.publication is None:
+                return
+            try:
+                selection_digest = self.publication.get_release_light().selection_digest
+                if selection_digest == self._publication_selection_digest:
+                    continue
+                await self.publish_webui_release_changed()
+            except asyncio.CancelledError:
+                raise
+            except (ManifestError, RuntimeError, UnknownReleaseError, sqlite3.Error):
+                logger.exception("mobile WebUI publication hint watcher failed")
+
+    def _is_current_webui_connection(self, device_id: str, connection_epoch: int) -> bool:
+        connection = self._connections.get(device_id)
+        return bool(
+            connection is not None
+            and connection.ready
+            and connection.connection_epoch == connection_epoch
+            and "mobile-webui-ota-v1" in connection.capabilities
+        )
+
     async def _evict_failed_control_connection(
         self,
         *,
@@ -1178,6 +1337,94 @@ class MobileGatewayRuntime:
             event_id=event_id,
             envelope_json=stored,
         )
+
+    async def _handle_webui_release_get(
+        self,
+        websocket: WebSocket,
+        frame: MobileWebUiReleaseGetCommand,
+        connection_epoch: int,
+        device_id: str,
+    ) -> None:
+        """返回单一 ReleaseView；无发布时保留 nullable stable/preview。"""
+
+        connection = self._connections.get(device_id)
+        if connection is None or connection.websocket is not websocket:
+            return
+        try:
+            if self.publication is None:
+                raise RuntimeError("WebUI publication store 未绑定")
+            release = self.publication.get_release()
+            payload = ReleaseViewWire.model_validate(_release_view_json(release), strict=True).model_dump(mode="json", exclude_none=False)
+            reply_type = "mobile.webui.release.get.ok"
+        except (ManifestError, RuntimeError, sqlite3.Error, ValidationError) as error:
+            logger.exception("读取 WebUI ReleaseView 失败")
+            reply_type = "mobile.webui.release.get.error"
+            payload = ErrorReplyWire(
+                code="release_store_corrupt",
+                message=str(error)[:512],
+            ).model_dump(mode="json")
+        async with connection.send_lock:
+            await _send_reply(
+                websocket,
+                frame_id=frame.id,
+                connection_epoch=connection_epoch,
+                reply_type=reply_type,
+                payload=payload,
+                session_id=frame.session_id,
+                turn_id=frame.turn_id,
+            )
+
+    async def _handle_webui_content_prepare(
+        self,
+        websocket: WebSocket,
+        frame: MobileWebUiContentPrepareCommand,
+        connection_epoch: int,
+        device_id: str,
+    ) -> None:
+        """为当前 target 签发一个可访问 manifest 与全部成员 blob 的票据。"""
+
+        connection = self._connections.get(device_id)
+        if connection is None or connection.websocket is not websocket:
+            return
+        reply_type = "mobile.webui.content.prepare.ok"
+        try:
+            if self.publication is None or self.webui_http_tickets is None:
+                raise RuntimeError("WebUI publication store 未绑定")
+            release = self.publication.get_release()
+            target_key = frame.payload.target_key
+            target = release.target(target_key)
+            if target is None:
+                raise MobileWebUiHttpError("target_not_found", "target 不属于当前 stable/preview", status_code=404)
+            grant = self.webui_http_tickets.issue(
+                device_id=device_id,
+                connection_epoch=connection_epoch,
+                release=release,
+                target_key=target_key,
+            )
+            raw_payload: dict[str, object] = {
+                "target_key": target.target_key,
+                "manifest_digest": target.manifest_digest,
+                "ticket": grant.ticket,
+                "expires_at": grant.expires_at.astimezone(timezone.utc).isoformat(),
+            }
+            payload = PrepareReplyWire.model_validate(raw_payload, strict=True).model_dump(mode="json")
+        except MobileWebUiHttpError as error:
+            reply_type = "mobile.webui.content.prepare.error"
+            payload = ErrorReplyWire(code=error.code, message=str(error)[:512]).model_dump(mode="json")
+        except (ManifestError, RuntimeError, sqlite3.Error, ValidationError) as error:
+            logger.exception("签发 WebUI content ticket 失败")
+            reply_type = "mobile.webui.content.prepare.error"
+            payload = ErrorReplyWire(code="release_store_corrupt", message=str(error)[:512]).model_dump(mode="json")
+        async with connection.send_lock:
+            await _send_reply(
+                websocket,
+                frame_id=frame.id,
+                connection_epoch=connection_epoch,
+                reply_type=reply_type,
+                payload=payload,
+                session_id=frame.session_id,
+                turn_id=frame.turn_id,
+            )
 
     async def _handle_command(
         self,
@@ -1470,6 +1717,89 @@ class MobileGatewayRuntime:
         start, end = _parse_message_content_range(range_header, len(content))
         return content[start : end + 1], start, end, len(content), verified.sha256
 
+    def read_webui_manifest_http(
+        self,
+        *,
+        ticket: str,
+        manifest_digest: str,
+    ) -> tuple[bytes, VerifiedWebUiTicket]:
+        """校验 target-scoped ticket 并返回当前 immutable manifest。"""
+
+        if self.publication is None or self.webui_http_tickets is None:
+            raise MobileWebUiHttpError("release_store_corrupt", "WebUI publication store 未绑定", status_code=500)
+        try:
+            verified = self.webui_http_tickets.verify(
+                ticket,
+                resource_kind="manifest",
+                resource_digest=manifest_digest,
+            )
+            release = self.publication.get_release()
+            target = release.target(verified.target_key)
+            if target is None or target.manifest_digest != manifest_digest:
+                raise MobileWebUiHttpError("resource_not_found", "manifest 不属于当前 target", status_code=404)
+            body = canonical_manifest_bytes(self.publication.get_manifest(manifest_digest))
+            if self.publication.get_release_light().selection_digest != verified.selection_digest:
+                raise MobileWebUiHttpError("target_changed", "manifest 读取期间 release 已变化", status_code=409)
+            return body, verified
+        except WebUiTicketError as error:
+            _raise_webui_ticket_http_error(error)
+        except MobileWebUiHttpError:
+            raise
+        except UnknownReleaseError as error:
+            raise MobileWebUiHttpError("release_store_corrupt", str(error), status_code=500) from error
+        except (ManifestError, RuntimeError, sqlite3.Error) as error:
+            raise MobileWebUiHttpError("release_store_corrupt", str(error), status_code=500) from error
+
+    def read_webui_blob_http(
+        self,
+        *,
+        ticket: str,
+        blob_digest: str,
+        range_header: str | None,
+        if_range: str | None,
+    ) -> tuple[bytes, int, int, int, str, VerifiedWebUiTicket]:
+        """校验 target 成员关系并返回一个完整或单段有界 blob range。"""
+
+        if self.publication is None or self.webui_http_tickets is None:
+            raise MobileWebUiHttpError("release_store_corrupt", "WebUI publication store 未绑定", status_code=500)
+        try:
+            verified = self.webui_http_tickets.verify(
+                ticket,
+                resource_kind="blob",
+                resource_digest=blob_digest,
+            )
+            blob = self.publication.verify_target_resource(
+                target_key=verified.target_key,
+                selection_digest=verified.selection_digest,
+                resource_digest=blob_digest,
+            )
+            content = blob.path.read_bytes()
+            if len(content) != blob.size_bytes or hashlib.sha256(content).hexdigest() != blob_digest:
+                raise RuntimeError("CAS blob 内容与 publication metadata 不一致")
+            if range_header is not None and if_range is not None and if_range != f'"{blob_digest}"':
+                raise MobileWebUiHttpError("range_precondition_failed", "If-Range 与 blob 摘要不匹配", status_code=412)
+            try:
+                selected = parse_single_range(range_header, len(content))
+            except WebUiTicketError as error:
+                raise MobileWebUiHttpError("invalid_range", str(error), status_code=416) from error
+            if selected is None:
+                start, end = 0, len(content) - 1
+            else:
+                start, end = selected
+            return content[start : end + 1], start, end, len(content), blob.mime, verified
+        except WebUiTicketError as error:
+            _raise_webui_ticket_http_error(error)
+        except MobileWebUiHttpError:
+            raise
+        except ReleaseSelectionChangedError as error:
+            raise MobileWebUiHttpError("target_changed", str(error), status_code=409) from error
+        except TargetResourceNotFoundError as error:
+            raise MobileWebUiHttpError("resource_not_found", str(error), status_code=404) from error
+        except UnknownReleaseError as error:
+            raise MobileWebUiHttpError("resource_not_found", str(error), status_code=404) from error
+        except (ManifestError, RuntimeError, sqlite3.Error) as error:
+            raise MobileWebUiHttpError("release_store_corrupt", str(error), status_code=500) from error
+
     async def handle_plugin_ui_http_query(
         self,
         *,
@@ -1540,6 +1870,20 @@ class MobileGatewayRuntime:
                 _ = await connection.sent_condition.wait()
 
     def close(self) -> None:
+        task = self._publication_monitor_task
+        self._publication_monitor_task = None
+        if task is not None:
+            task.cancel()
+            loop = task.get_loop()
+            if not loop.is_closed() and not loop.is_running():
+                loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+            elif loop.is_running():
+                async def drain_cancelled_task() -> None:
+                    await asyncio.gather(task, return_exceptions=True)
+
+                _ = asyncio.create_task(drain_cancelled_task())
+        if self.publication is not None:
+            self.publication.close()
         self.storage.close()
 
 
@@ -1561,6 +1905,7 @@ def build_mobile_gateway_runtime(
     )
     keysets = KeysetManager(current_path.parent, keys)
     storage = MobileRealtimeStorage(database_path)
+    publication: MobileWebUiStore | None = None
     try:
         identity = storage.read_server_identity()
         if current_path.exists():
@@ -1579,6 +1924,10 @@ def build_mobile_gateway_runtime(
                 keyset_manifest_path=str(config.key_encryption.keyset_manifest),
                 public_key_fingerprint=keyset.server_fingerprint,
             )
+        )
+        publication = MobileWebUiStore(
+            workspace / "mobile-webui",
+            server_id=keyset.manifest.server_id,
         )
         loop = asyncio.get_running_loop()
         approvals = PairingApprovalRegistry(loop)
@@ -1601,18 +1950,29 @@ def build_mobile_gateway_runtime(
             ),
             approvals=approvals,
             keyset=keyset,
+            publication=publication,
         )
         from infra.mobile_realtime.channel import MobileRealtimeChannel
 
         runtime.bind_channel(MobileRealtimeChannel(runtime))
         return runtime, keyset
     except BaseException:
+        if publication is not None:
+            publication.close()
         storage.close()
         raise
 
 
 def create_mobile_gateway_app(runtime: MobileGatewayRuntime) -> FastAPI:
-    app = FastAPI(title="Akasic Mobile Realtime Gateway", docs_url=None, redoc_url=None)
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        runtime.start()
+        try:
+            yield
+        finally:
+            await runtime.stop()
+
+    app = FastAPI(title="Akasic Mobile Realtime Gateway", docs_url=None, redoc_url=None, lifespan=lifespan)
     app.add_middleware(GZipMiddleware, minimum_size=1024)
 
     @app.websocket("/ws")
@@ -1700,6 +2060,58 @@ def create_mobile_gateway_app(runtime: MobileGatewayRuntime) -> FastAPI:
                 "X-Content-Type-Options": "nosniff",
             },
         )
+
+    @app.get(f"{_MOBILE_WEBUI_MANIFEST_PATH}/{{manifest_digest}}")
+    async def mobile_webui_manifest(request: Request, manifest_digest: str) -> Response:
+        """返回 target ticket 授权的 canonical manifest。"""
+
+        try:
+            body, _verified = runtime.read_webui_manifest_http(
+                ticket=_webui_http_bearer(request),
+                manifest_digest=manifest_digest,
+            )
+        except MobileWebUiHttpError as error:
+            return _mobile_webui_http_error_response(error)
+        return Response(
+            content=body,
+            media_type="application/json",
+            headers={
+                "Cache-Control": "no-store, no-transform",
+                "Content-Encoding": "identity",
+                "Content-Digest": f"sha-256=:{base64.b64encode(hashlib.sha256(body).digest()).decode('ascii')}:",
+                "ETag": f'"{manifest_digest}"',
+                "Repr-Digest": f"sha-256=:{base64.b64encode(bytes.fromhex(manifest_digest)).decode('ascii')}:",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+
+    @app.get(f"{_MOBILE_WEBUI_BLOB_PATH}/{{blob_digest}}")
+    async def mobile_webui_blob(request: Request, blob_digest: str) -> Response:
+        """返回 target 成员 blob，支持单段 8 MiB Range。"""
+
+        try:
+            content, start, end, total, mime, _verified = runtime.read_webui_blob_http(
+                ticket=_webui_http_bearer(request),
+                blob_digest=blob_digest,
+                range_header=request.headers.get("range"),
+                if_range=request.headers.get("if-range"),
+            )
+        except MobileWebUiHttpError as error:
+            return _mobile_webui_http_error_response(error)
+        status = 206 if request.headers.get("range") is not None else 200
+        headers = {
+            "Accept-Ranges": "bytes",
+            "Cache-Control": "public, max-age=31536000, immutable, no-transform",
+            "Content-Encoding": "identity",
+            "Content-Length": str(len(content)),
+            "ETag": f'"{blob_digest}"',
+            "Content-Digest": f"sha-256=:{base64.b64encode(hashlib.sha256(content).digest()).decode('ascii')}:",
+            "Repr-Digest": f"sha-256=:{base64.b64encode(bytes.fromhex(blob_digest)).decode('ascii')}:",
+            "X-Content-Type-Options": "nosniff",
+        }
+        if status == 206:
+            headers["Content-Range"] = f"bytes {start}-{end}/{total}"
+        return Response(content=content, status_code=status, media_type=mime, headers=headers)
 
     return app
 
@@ -2000,6 +2412,16 @@ def _message_content_http_bearer(request: Request) -> str:
     return ticket
 
 
+def _webui_http_bearer(request: Request) -> str:
+    authorization = request.headers.get("authorization")
+    if authorization is None or not authorization.startswith("Bearer "):
+        raise MobileWebUiHttpError("invalid_ticket", "WebUI 请求缺少 Bearer ticket", status_code=401)
+    ticket = authorization.removeprefix("Bearer ")
+    if not 1 <= len(ticket) <= 4096 or any(character.isspace() for character in ticket):
+        raise MobileWebUiHttpError("invalid_ticket", "WebUI Bearer ticket 无效", status_code=401)
+    return ticket
+
+
 def _parse_message_content_range(value: str | None, total: int) -> tuple[int, int]:
     """解析一个显式 bytes range，并强制单次响应保持有界。"""
 
@@ -2048,6 +2470,16 @@ def _message_content_error_response(
     response = JSONResponse(
         {"error": {"code": code, "message": message}},
         status_code=status_code,
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
+
+
+def _mobile_webui_http_error_response(error: MobileWebUiHttpError) -> JSONResponse:
+    response = JSONResponse(
+        {"error": ErrorReplyWire(code=error.code, message=str(error)[:512]).model_dump(mode="json")},
+        status_code=error.status_code,
     )
     response.headers["Cache-Control"] = "no-store"
     response.headers["X-Content-Type-Options"] = "nosniff"
@@ -2160,6 +2592,28 @@ def _device_json(device: DeviceRecord) -> dict[str, object]:
         "created_at": device.created_at.isoformat(),
         "capabilities": list(device.capabilities),
     }
+
+
+def _release_view_json(release: ReleaseView) -> dict[str, object]:
+    return {
+        "server_id": release.server_id,
+        "release_epoch": release.release_epoch,
+        "sequence": release.sequence,
+        "selection_digest": release.selection_digest,
+        "stable": release.stable.as_json() if release.stable is not None else None,
+        "preview": release.preview.as_json() if release.preview is not None else None,
+    }
+
+
+def _raise_webui_ticket_http_error(error: WebUiTicketError) -> None:
+    status = {
+        "invalid_ticket": 401,
+        "target_changed": 409,
+        "resource_not_found": 404,
+    }.get(error.code)
+    if status is None:
+        raise MobileWebUiHttpError("invalid_ticket", str(error), status_code=401) from error
+    raise MobileWebUiHttpError(error.code, str(error), status_code=status) from error
 
 
 def _resolve_workspace_path(workspace: Path, configured: Path) -> Path:

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -44,6 +44,8 @@ COMMAND_TYPES = frozenset(
         "plugin.ui.query",
         "plugin.ui.query.prepare",
         "plugin.ui.cancel",
+        "mobile.webui.release.get",
+        "mobile.webui.content.prepare",
         "device.update",
         "ping",
     }
@@ -78,6 +80,7 @@ CONTROL_TYPES = frozenset(
         "auth.accepted",
         "resume",
         "plugin.ui.changed",
+        "mobile.webui.release.changed",
         "pair.claim",
         "pair.pending",
         "pair.accepted",
@@ -121,6 +124,10 @@ FrameId: TypeAlias = Annotated[
 ConnectionEpoch: TypeAlias = Annotated[int, Field(ge=1)]
 EventSequence: TypeAlias = Annotated[int, Field(ge=1)]
 NonEmptyId: TypeAlias = Annotated[str, Field(min_length=1, max_length=512)]
+ServerId: TypeAlias = Annotated[
+    str,
+    Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"),
+]
 JsonObject: TypeAlias = dict[str, JsonValue]
 
 
@@ -273,6 +280,27 @@ class CommandEnvelope(ProtocolModel):
         return self
 
 
+class MobileWebUiReleaseGetPayload(ProtocolModel):
+    """ReleaseView 查询不接受客户端排序或版本选择参数。"""
+
+
+class MobileWebUiContentPreparePayload(ProtocolModel):
+    target_key: Annotated[
+        str,
+        Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"),
+    ]
+
+
+class MobileWebUiReleaseGetCommand(CommandEnvelope):
+    type: Literal["mobile.webui.release.get"]
+    payload: MobileWebUiReleaseGetPayload
+
+
+class MobileWebUiContentPrepareCommand(CommandEnvelope):
+    type: Literal["mobile.webui.content.prepare"]
+    payload: MobileWebUiContentPreparePayload
+
+
 class MessageSendCommand(ProtocolModel):
     v: Literal[1]
     kind: Literal["command"]
@@ -354,6 +382,8 @@ ClientCommand: TypeAlias = (
     | AttachmentBeginCommand
     | AttachmentFinishCommand
     | AttachmentDownloadCommand
+    | MobileWebUiReleaseGetCommand
+    | MobileWebUiContentPrepareCommand
     | GenericCommand
 )
 CommandFrame: TypeAlias = Annotated[
@@ -516,6 +546,19 @@ class PluginUiChangedControl(AuthenticatedControlEnvelope):
     type: Literal["plugin.ui.changed"]
 
 
+class MobileWebUiReleaseChangedPayload(ProtocolModel):
+    server_id: ServerId
+    selection_digest: Annotated[
+        str,
+        Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"),
+    ]
+
+
+class MobileWebUiReleaseChangedControl(AuthenticatedControlEnvelope):
+    type: Literal["mobile.webui.release.changed"]
+    payload: MobileWebUiReleaseChangedPayload
+
+
 class GenericControl(ControlEnvelope):
     type: Literal[
         "server.challenge",
@@ -528,7 +571,11 @@ class GenericControl(ControlEnvelope):
 
 
 ControlFrame: TypeAlias = Annotated[
-    AuthAcceptedControl | ResumeControl | PluginUiChangedControl | GenericControl,
+    AuthAcceptedControl
+    | ResumeControl
+    | PluginUiChangedControl
+    | MobileWebUiReleaseChangedControl
+    | GenericControl,
     Field(discriminator="type"),
 ]
 

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -84,6 +84,7 @@ CONTROL_TYPES = frozenset(
         "pair.claim",
         "pair.pending",
         "pair.accepted",
+        "device.revoked",
         "protocol.error",
     }
 )
@@ -566,6 +567,7 @@ class GenericControl(ControlEnvelope):
         "pair.claim",
         "pair.pending",
         "pair.accepted",
+        "device.revoked",
         "protocol.error",
     ]
 

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -70,7 +70,6 @@ EVENT_TYPES = frozenset(
         "connection.degraded",
         "sync.completed",
         "sync.reset_required",
-        "device.revoked",
     }
 )
 CONTROL_TYPES = frozenset(
@@ -477,7 +476,6 @@ class GenericEvent(EventEnvelope):
         "connection.degraded",
         "sync.completed",
         "sync.reset_required",
-        "device.revoked",
     ]
 
 

--- a/infra/mobile_webui/__init__.py
+++ b/infra/mobile_webui/__init__.py
@@ -1,0 +1,31 @@
+"""Server-owned WebUI release publication and immutable content storage."""
+
+from infra.mobile_webui.manifest import (
+    ManifestError,
+    WebUiFile,
+    WebUiManifest,
+    WebUiTarget,
+    canonical_manifest_bytes,
+    manifest_digest,
+    manifest_from_directory,
+)
+from infra.mobile_webui.store import (
+    MobileWebUiStore,
+    ReleaseConflictError,
+    ReleaseView,
+    StoredBlob,
+)
+
+__all__ = [
+    "ManifestError",
+    "MobileWebUiStore",
+    "ReleaseConflictError",
+    "ReleaseView",
+    "StoredBlob",
+    "WebUiFile",
+    "WebUiManifest",
+    "WebUiTarget",
+    "canonical_manifest_bytes",
+    "manifest_digest",
+    "manifest_from_directory",
+]

--- a/infra/mobile_webui/http.py
+++ b/infra/mobile_webui/http.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from infra.mobile_realtime.key_protection import LoadedKeyset
+from infra.mobile_realtime.storage import MobileRealtimeStorage
+from infra.mobile_webui.store import (
+    MobileWebUiStore,
+    ReleaseSelectionChangedError,
+    ReleaseView,
+    TargetResourceNotFoundError,
+)
+
+AUDIENCE = "mobile-webui-v1"
+DEFAULT_TTL = timedelta(seconds=300)
+MAX_RANGE_BYTES = 8 * 1024 * 1024
+
+
+class WebUiTicketError(ValueError):
+    """表示 WebUI HTTP ticket 不可接受。"""
+
+    def __init__(self, message: str, *, code: str = "invalid_ticket") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class WebUiHttpGrant:
+    ticket: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedWebUiTicket:
+    device_id: str
+    connection_epoch: int
+    target_key: str
+    generation_id: str
+    release_epoch: str
+    manifest_digest: str
+    selection_digest: str
+
+
+class WebUiTicketIssuer:
+    """签发并在每个 HTTP 请求重新核对设备、代际和发布选择。"""
+
+    def __init__(
+        self,
+        keyset: LoadedKeyset,
+        storage: MobileRealtimeStorage,
+        publication: MobileWebUiStore,
+        *,
+        ttl: timedelta = DEFAULT_TTL,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        connection_checker: Callable[[str, int], bool] | None = None,
+    ) -> None:
+        if ttl <= timedelta(0) or ttl > DEFAULT_TTL:
+            raise ValueError("WebUI ticket ttl 必须在 0..300 秒内")
+        self._keyset = keyset
+        self._storage = storage
+        self._publication = publication
+        self._ttl = ttl
+        self._clock = clock
+        self._connection_checker = connection_checker
+
+    def issue(
+        self,
+        *,
+        device_id: str,
+        connection_epoch: int,
+        release: ReleaseView,
+        target_key: str,
+    ) -> WebUiHttpGrant:
+        target = release.target(target_key)
+        if target is None:
+            raise WebUiTicketError("target 不属于当前 ReleaseView", code="target_changed")
+        now = self._now()
+        expires_at = now + self._ttl
+        claims = {
+            "aud": AUDIENCE,
+            "connection_epoch": connection_epoch,
+            "device_id": device_id,
+            "exp": _unix_seconds(expires_at),
+            "iat": _unix_seconds(now),
+            "manifest_digest": target.manifest_digest,
+            "generation_id": target.generation_id,
+            "release_epoch": release.release_epoch,
+            "selection_digest": release.selection_digest,
+            "server_id": self._keyset.manifest.server_id,
+            "target_key": target.target_key,
+            "v": 1,
+        }
+        payload = _canonical_json(claims)
+        signature = self._keyset.identity_private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+        return WebUiHttpGrant(
+            ticket=f"{_b64url(payload)}.{_b64url(signature)}",
+            expires_at=expires_at,
+        )
+
+    def verify(
+        self,
+        ticket: str,
+        *,
+        resource_kind: str,
+        resource_digest: str,
+    ) -> VerifiedWebUiTicket:
+        """验签后校验当前连接、发布 epoch 和 target 成员关系。"""
+
+        # 1. 验证签名、claims 结构和时钟窗口
+        parts = ticket.split(".")
+        if len(parts) != 2:
+            raise WebUiTicketError("WebUI ticket 格式无效")
+        payload = _decode_b64url(parts[0])
+        signature = _decode_b64url(parts[1])
+        try:
+            self._keyset.identity_private_key.public_key().verify(signature, payload, ec.ECDSA(hashes.SHA256()))
+        except InvalidSignature as error:
+            raise WebUiTicketError("WebUI ticket 签名无效") from error
+        claims = _decode_claims(payload)
+        expected = {
+            "aud", "connection_epoch", "device_id", "exp", "iat",
+            "generation_id", "manifest_digest", "release_epoch", "selection_digest", "server_id", "target_key", "v",
+        }
+        if set(claims) != expected or claims["v"] != 1 or claims["aud"] != AUDIENCE:
+            raise WebUiTicketError("WebUI ticket claims 无效")
+        if claims["server_id"] != self._keyset.manifest.server_id:
+            raise WebUiTicketError("WebUI ticket 不属于当前服务端")
+        device_id = _require_text(claims["device_id"], "device_id")
+        connection_epoch = _require_positive_int(claims["connection_epoch"], "connection_epoch")
+        target_key = _require_text(claims["target_key"], "target_key")
+        release_epoch = _require_text(claims["release_epoch"], "release_epoch")
+        manifest_digest = _require_digest(claims["manifest_digest"], "manifest_digest")
+        generation_id = _require_digest(claims["generation_id"], "generation_id")
+        selection_digest = _require_digest(claims["selection_digest"], "selection_digest")
+        issued_at = _require_nonnegative_int(claims["iat"], "iat")
+        expires_at = _require_nonnegative_int(claims["exp"], "exp")
+        now = _unix_seconds(self._now())
+        if expires_at <= now or issued_at > now or expires_at - issued_at > int(self._ttl.total_seconds()) + 1:
+            raise WebUiTicketError("WebUI ticket 已过期或 TTL 无效")
+
+        # 2. 每个请求重读设备状态与当前连接代际
+        device = self._storage.read_device(device_id)
+        if device is None or device.revoked_at is not None:
+            raise WebUiTicketError("设备不存在或已撤销")
+        if self._connection_checker is not None and not self._connection_checker(device_id, connection_epoch):
+            raise WebUiTicketError("WebUI ticket connection_epoch 已失效")
+
+        # 3. 发布指针和请求 digest 都必须属于 ticket 绑定的 target
+        release = self._publication.get_release_light()
+        target = release.target(target_key)
+        if release.release_epoch != release_epoch or release.selection_digest != selection_digest or target is None or target.manifest_digest != manifest_digest or target.generation_id != generation_id:
+            raise WebUiTicketError("WebUI ticket 对应的 release 已变化", code="target_changed")
+        if resource_kind == "manifest":
+            if resource_digest != manifest_digest:
+                raise WebUiTicketError("manifest digest 与 target 不匹配", code="resource_not_found")
+        elif resource_kind == "blob":
+            try:
+                _ = self._publication.verify_target_resource(
+                    target_key=target_key,
+                    selection_digest=selection_digest,
+                    resource_digest=resource_digest,
+                )
+            except TargetResourceNotFoundError as error:
+                raise WebUiTicketError("blob 不属于当前 target", code="resource_not_found") from error
+            except ReleaseSelectionChangedError as error:
+                raise WebUiTicketError("release selection 已变化", code="target_changed") from error
+        else:
+            raise WebUiTicketError("未知 WebUI resource kind")
+        return VerifiedWebUiTicket(
+            device_id=device_id,
+            connection_epoch=connection_epoch,
+            target_key=target_key,
+            generation_id=generation_id,
+            release_epoch=release_epoch,
+            manifest_digest=manifest_digest,
+            selection_digest=selection_digest,
+        )
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if value.tzinfo is None:
+            raise ValueError("WebUI ticket clock 必须带 timezone")
+        return value.astimezone(timezone.utc)
+
+
+def parse_single_range(header: str | None, total: int) -> tuple[int, int] | None:
+    """解析一个有界 bytes Range；多段和不满足范围的请求明确失败。"""
+
+    if header is None:
+        return None
+    if not header.startswith("bytes=") or "," in header:
+        raise WebUiTicketError("Range 只支持单个 bytes range")
+    value = header[6:].strip()
+    if "-" not in value or total <= 0:
+        raise WebUiTicketError("Range 无法满足")
+    start_text, end_text = value.split("-", 1)
+    try:
+        if not start_text:
+            suffix = int(end_text)
+            if suffix <= 0:
+                raise ValueError
+            start = max(0, total - suffix)
+            end = total - 1
+        else:
+            start = int(start_text)
+            end = int(end_text) if end_text else total - 1
+            if start < 0 or end < start or start >= total:
+                raise ValueError
+            end = min(end, total - 1)
+    except (TypeError, ValueError) as error:
+        raise WebUiTicketError("Range 无法满足") from error
+    if end - start + 1 > MAX_RANGE_BYTES:
+        raise WebUiTicketError("Range 超过 8 MiB 上限")
+    return start, end
+
+
+def _canonical_json(value: dict[str, object]) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _decode_claims(payload: bytes) -> dict[str, object]:
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise WebUiTicketError("WebUI ticket claims 不是 JSON") from error
+    if not isinstance(value, dict):
+        raise WebUiTicketError("WebUI ticket claims 必须是 object")
+    return value
+
+
+def _b64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _decode_b64url(value: str) -> bytes:
+    try:
+        if not value or any(char not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_" for char in value):
+            raise ValueError
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except (ValueError, binascii.Error) as error:
+        raise WebUiTicketError("WebUI ticket base64 无效") from error
+
+
+def _require_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512 or any(char.isspace() for char in value):
+        raise WebUiTicketError(f"{label} 无效")
+    return value
+
+
+def _require_positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise WebUiTicketError(f"{label} 无效")
+    return value
+
+
+def _require_nonnegative_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise WebUiTicketError(f"{label} 无效")
+    return value
+
+
+def _require_digest(value: object, label: str) -> str:
+    if not isinstance(value, str) or len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise WebUiTicketError(f"{label} 无效")
+    return value
+
+
+def _unix_seconds(value: datetime) -> int:
+    return int(value.astimezone(timezone.utc).timestamp())
+
+
+__all__ = [
+    "AUDIENCE",
+    "MAX_RANGE_BYTES",
+    "VerifiedWebUiTicket",
+    "WebUiHttpGrant",
+    "WebUiTicketError",
+    "WebUiTicketIssuer",
+    "parse_single_range",
+]

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -534,9 +534,12 @@ def _require_bool(value: object, label: str) -> bool:
 
 
 def _require_string_map(value: dict[object, object], label: str) -> dict[str, str]:
-    if any(not isinstance(key, str) or not isinstance(item, str) for key, item in value.items()):
-        raise ManifestError(f"{label} 必须是 string map")
-    return dict(value)
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise ManifestError(f"{label} 必须是 string map")
+        result[key] = item
+    return result
 
 
 def _validate_dirty_provenance(value: Mapping[str, object] | None) -> None:

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Mapping
+
+MAX_MANIFEST_BYTES = 1 * 1024 * 1024
+MAX_FILES = 2048
+MAX_FILE_BYTES = 8 * 1024 * 1024
+MAX_UNPACKED_BYTES = 64 * 1024 * 1024
+MANIFEST_SCHEMA_VERSION = 2
+
+_MIME_ALLOWLIST = frozenset(
+    {
+        "application/font-woff",
+        "application/font-woff2",
+        "application/javascript",
+        "application/json",
+        "application/octet-stream",
+        "application/wasm",
+        "font/otf",
+        "font/ttf",
+        "font/woff",
+        "font/woff2",
+        "image/avif",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/svg+xml",
+        "image/webp",
+        "text/css",
+        "text/html",
+        "text/javascript",
+        "text/plain",
+        "video/mp4",
+        "audio/mpeg",
+        "audio/ogg",
+        "audio/wav",
+    }
+)
+_FORBIDDEN_SUFFIXES = frozenset({".dex", ".jar", ".so", ".apk", ".aab"})
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_SERVER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_PLATFORM_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_MIME_BY_SUFFIX = {
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".cjs": "text/javascript",
+    ".json": "application/json",
+    ".wasm": "application/wasm",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+    ".avif": "image/avif",
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".mp3": "audio/mpeg",
+    ".ogg": "audio/ogg",
+    ".wav": "audio/wav",
+    ".txt": "text/plain",
+}
+
+
+class ManifestError(ValueError):
+    """表示 WebUI manifest 或文件集合违反发布合同。"""
+
+
+@dataclass(frozen=True, slots=True)
+class WebUiFile:
+    path: str
+    sha256: str
+    size_bytes: int
+    mime: str
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+            "mime": self.mime,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WebUiTarget:
+    target_key: str
+    generation_id: str
+    manifest_digest: str
+    manifest_size_bytes: int
+    bridge_protocol_min: int
+    bridge_protocol_max: int
+    snapshot_protocol_min: int
+    snapshot_protocol_max: int
+    minimum_native_build: int
+    platforms: tuple[str, ...]
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "target_key": self.target_key,
+            "generation_id": self.generation_id,
+            "manifest_digest": self.manifest_digest,
+            "manifest_size_bytes": self.manifest_size_bytes,
+            "bridge_protocol_min": self.bridge_protocol_min,
+            "bridge_protocol_max": self.bridge_protocol_max,
+            "snapshot_protocol_min": self.snapshot_protocol_min,
+            "snapshot_protocol_max": self.snapshot_protocol_max,
+            "minimum_native_build": self.minimum_native_build,
+            "platforms": list(self.platforms),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WebUiManifest:
+    generation_id: str
+    entrypoint: str
+    files: tuple[WebUiFile, ...]
+    bridge_protocol_min: int
+    bridge_protocol_max: int
+    snapshot_protocol_min: int
+    snapshot_protocol_max: int
+    minimum_native_build: int
+    platforms: tuple[str, ...]
+    source_repository: str
+    source_commit: str
+    source_tree: str
+    input_digest: str
+    build_context_digest: str
+    dirty_provenance: Mapping[str, object] | None
+    reproducible: bool
+    builder_identity: Mapping[str, str]
+    unpacked_size_bytes: int
+    file_count: int
+
+    def as_json_without_digest(self) -> dict[str, object]:
+        """Return the complete canonical manifest payload."""
+
+        value: dict[str, object] = {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "generation_id": self.generation_id,
+            "entrypoint": self.entrypoint,
+            "files": [item.as_json() for item in self.files],
+            "bridge_protocol_min": self.bridge_protocol_min,
+            "bridge_protocol_max": self.bridge_protocol_max,
+            "snapshot_protocol_min": self.snapshot_protocol_min,
+            "snapshot_protocol_max": self.snapshot_protocol_max,
+            "minimum_native_build": self.minimum_native_build,
+            "platforms": list(self.platforms),
+            "source_repository": self.source_repository,
+            "source_commit": self.source_commit,
+            "source_tree": self.source_tree,
+            "input_digest": self.input_digest,
+            "build_context_digest": self.build_context_digest,
+            "dirty_provenance": self.dirty_provenance,
+            "reproducible": self.reproducible,
+            "builder_identity": self.builder_identity,
+            "unpacked_size_bytes": self.unpacked_size_bytes,
+            "file_count": self.file_count,
+        }
+        return value
+
+    def as_json(self) -> dict[str, object]:
+        return self.as_json_without_digest()
+
+    def target(self, server_id: str, digest: str | None = None) -> WebUiTarget:
+        if _SERVER_ID_RE.fullmatch(server_id) is None:
+            raise ManifestError("server_id 无效")
+        body = canonical_manifest_bytes(self)
+        actual_digest = hashlib.sha256(body).hexdigest()
+        if digest is not None and digest != actual_digest:
+            raise ManifestError("manifest digest 与 canonical 内容不一致")
+        return WebUiTarget(
+            target_key=derive_target_key(server_id, self.generation_id, actual_digest),
+            generation_id=self.generation_id,
+            manifest_digest=actual_digest,
+            manifest_size_bytes=len(body),
+            bridge_protocol_min=self.bridge_protocol_min,
+            bridge_protocol_max=self.bridge_protocol_max,
+            snapshot_protocol_min=self.snapshot_protocol_min,
+            snapshot_protocol_max=self.snapshot_protocol_max,
+            minimum_native_build=self.minimum_native_build,
+            platforms=self.platforms,
+        )
+
+
+def manifest_from_json(payload: object) -> WebUiManifest:
+    """把数据库或 HTTP 读出的 manifest object 严格恢复为领域值。"""
+
+    if not isinstance(payload, dict):
+        raise ManifestError("manifest 顶层必须是 object")
+    required = {
+        "schema_version", "generation_id", "entrypoint", "files",
+        "bridge_protocol_min", "bridge_protocol_max", "snapshot_protocol_min",
+        "snapshot_protocol_max", "minimum_native_build", "platforms",
+        "source_repository", "source_commit", "source_tree", "input_digest",
+        "build_context_digest", "dirty_provenance", "reproducible",
+        "builder_identity", "unpacked_size_bytes", "file_count",
+    }
+    if set(payload) != required:
+        raise ManifestError("manifest 字段集合无效")
+    raw_files = payload["files"]
+    raw_platforms = payload["platforms"]
+    if not isinstance(raw_files, list) or not isinstance(raw_platforms, list):
+        raise ManifestError("manifest files/platforms 类型无效")
+    files: list[WebUiFile] = []
+    for raw in raw_files:
+        if not isinstance(raw, dict) or set(raw) != {"path", "sha256", "size_bytes", "mime"}:
+            raise ManifestError("manifest file 项字段无效")
+        files.append(
+            WebUiFile(
+                path=_require_string(raw["path"], "file.path"),
+                sha256=_require_string(raw["sha256"], "file.sha256"),
+                size_bytes=_require_int(raw["size_bytes"], "file.size_bytes"),
+                mime=_require_string(raw["mime"], "file.mime"),
+            )
+        )
+    dirty = payload["dirty_provenance"]
+    if dirty is not None and not isinstance(dirty, dict):
+        raise ManifestError("dirty_provenance 必须是 object 或 null")
+    builder = payload["builder_identity"]
+    if not isinstance(builder, dict):
+        raise ManifestError("builder_identity 必须是 object")
+    manifest = WebUiManifest(
+        generation_id=_require_string(payload["generation_id"], "generation_id"),
+        entrypoint=_require_string(payload["entrypoint"], "entrypoint"),
+        files=tuple(files),
+        bridge_protocol_min=_require_int(payload["bridge_protocol_min"], "bridge_protocol_min"),
+        bridge_protocol_max=_require_int(payload["bridge_protocol_max"], "bridge_protocol_max"),
+        snapshot_protocol_min=_require_int(payload["snapshot_protocol_min"], "snapshot_protocol_min"),
+        snapshot_protocol_max=_require_int(payload["snapshot_protocol_max"], "snapshot_protocol_max"),
+        minimum_native_build=_require_int(payload["minimum_native_build"], "minimum_native_build"),
+        platforms=tuple(_require_string(item, "platform") for item in raw_platforms),
+        source_repository=_require_string(payload["source_repository"], "source_repository"),
+        source_commit=_require_string(payload["source_commit"], "source_commit"),
+        source_tree=_require_string(payload["source_tree"], "source_tree"),
+        input_digest=_require_string(payload["input_digest"], "input_digest"),
+        build_context_digest=_require_string(payload["build_context_digest"], "build_context_digest"),
+        dirty_provenance=dirty,
+        reproducible=_require_bool(payload["reproducible"], "reproducible"),
+        builder_identity=_require_string_map(builder, "builder_identity"),
+        unpacked_size_bytes=_require_int(payload["unpacked_size_bytes"], "unpacked_size_bytes"),
+        file_count=_require_int(payload["file_count"], "file_count"),
+    )
+    if payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
+        raise ManifestError("manifest schema_version 不受支持")
+    validate_manifest(manifest)
+    return manifest
+
+
+def canonical_manifest_bytes(manifest: WebUiManifest) -> bytes:
+    """编码完整 manifest，manifest_digest 是此结果的 sha256。"""
+
+    validate_manifest(manifest)
+    encoded = json.dumps(
+        manifest.as_json_without_digest(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    if len(encoded) > MAX_MANIFEST_BYTES:
+        raise ManifestError("manifest 超过 1 MiB 上限")
+    return encoded
+
+
+def canonical_generation_identity_bytes(manifest: WebUiManifest) -> bytes:
+    """编码决定 generation_id 的 manifest 内容（不含 generation_id）。"""
+
+    body = manifest.as_json_without_digest().copy()
+    _ = body.pop("generation_id")
+    return json.dumps(
+        body,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def generation_id_for_manifest(manifest: WebUiManifest) -> str:
+    return hashlib.sha256(canonical_generation_identity_bytes(manifest)).hexdigest()
+
+
+def derive_target_key(server_id: str, generation_id: str, digest: str) -> str:
+    body = json.dumps(
+        {"server_id": server_id, "generation_id": generation_id, "manifest_digest": digest},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def manifest_digest(manifest: WebUiManifest) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def validate_manifest(manifest: WebUiManifest) -> None:
+    """在发布和 HTTP 读取边界统一校验 manifest 不变量。"""
+
+    if not _valid_digest(manifest.generation_id):
+        raise ManifestError("generation_id 必须是 64 位小写 sha256")
+    if generation_id_for_manifest(manifest) != manifest.generation_id:
+        raise ManifestError("generation_id 必须由 manifest 内容确定性派生")
+    if manifest.entrypoint != "mobile.html":
+        raise ManifestError("entrypoint 必须是 mobile.html")
+    if manifest.entrypoint not in {item.path for item in manifest.files}:
+        raise ManifestError("entrypoint 不在文件清单中")
+    for minimum, maximum, label in (
+        (manifest.bridge_protocol_min, manifest.bridge_protocol_max, "bridge_protocol"),
+        (manifest.snapshot_protocol_min, manifest.snapshot_protocol_max, "snapshot_protocol"),
+    ):
+        if not isinstance(minimum, int) or isinstance(minimum, bool) or not isinstance(maximum, int) or isinstance(maximum, bool) or minimum < 1 or minimum > maximum:
+            raise ManifestError(f"{label} 兼容窗口无效")
+    if not isinstance(manifest.minimum_native_build, int) or isinstance(manifest.minimum_native_build, bool) or manifest.minimum_native_build < 1:
+        raise ManifestError("minimum_native_build 必须为正整数")
+    _validate_dirty_provenance(manifest.dirty_provenance)
+    if manifest.reproducible != (manifest.dirty_provenance is None):
+        raise ManifestError("reproducible 必须与 dirty_provenance 一致")
+    _validate_builder_identity(manifest.builder_identity)
+    for value, label in (
+        (manifest.source_repository, "source_repository"),
+        (manifest.source_commit, "source_commit"),
+        (manifest.source_tree, "source_tree"),
+        (manifest.input_digest, "input_digest"),
+        (manifest.build_context_digest, "build_context_digest"),
+    ):
+        _require_nonempty_token(value, label)
+    _require_git_object(manifest.source_commit, "source_commit")
+    _require_git_object(manifest.source_tree, "source_tree")
+    for value, label in (
+        (manifest.input_digest, "input_digest"),
+        (manifest.build_context_digest, "build_context_digest"),
+    ):
+        if not _valid_digest(value):
+            raise ManifestError(f"{label} 必须是 sha256")
+    _validate_platforms(manifest.platforms)
+
+    if not manifest.files or len(manifest.files) > MAX_FILES:
+        raise ManifestError("files 数量超出范围")
+    if tuple(item.path for item in manifest.files) != tuple(
+        sorted((item.path for item in manifest.files), key=lambda value: value.encode("utf-8"))
+    ):
+        raise ManifestError("files 必须按 NFC UTF-8 path 顺序排列")
+    if manifest.file_count != len(manifest.files):
+        raise ManifestError("file_count 与 files 不一致")
+    seen: set[str] = set()
+    seen_folded: set[str] = set()
+    digest_mimes: dict[str, str] = {}
+    total = 0
+    for item in manifest.files:
+        normalized = _normalise_path(item.path)
+        if normalized != item.path:
+            raise ManifestError(f"文件路径必须使用 NFC POSIX 形式: {item.path}")
+        folded = normalized.lower()
+        if normalized in seen or folded in seen_folded:
+            raise ManifestError(f"文件路径冲突: {item.path}")
+        seen.add(normalized)
+        seen_folded.add(folded)
+        if not _valid_digest(item.sha256):
+            raise ManifestError(f"文件 sha256 无效: {item.path}")
+        if not isinstance(item.size_bytes, int) or isinstance(item.size_bytes, bool) or not 0 <= item.size_bytes <= MAX_FILE_BYTES:
+            raise ManifestError(f"文件大小超出上限: {item.path}")
+        if item.mime not in _MIME_ALLOWLIST:
+            raise ManifestError(f"MIME 不在 allowlist: {item.path}")
+        expected_mime = _MIME_BY_SUFFIX.get(Path(item.path).suffix.lower(), "application/octet-stream")
+        if item.mime != expected_mime:
+            raise ManifestError(f"MIME 与固定后缀映射不一致: {item.path}")
+        previous_mime = digest_mimes.setdefault(item.sha256, item.mime)
+        if previous_mime != item.mime:
+            raise ManifestError("同一 generation 内 digest 不得映射多个 MIME")
+        if Path(item.path).suffix.lower() in _FORBIDDEN_SUFFIXES:
+            raise ManifestError(f"文件类型禁止进入 WebUI: {item.path}")
+        total += item.size_bytes
+    if manifest.unpacked_size_bytes != total:
+        raise ManifestError("unpacked_size_bytes 与 files 不一致")
+    if total > MAX_UNPACKED_BYTES:
+        raise ManifestError("manifest unpacked 总大小超过 64 MiB")
+
+
+def manifest_from_directory(
+    root: Path,
+    *,
+    entrypoint: str = "mobile.html",
+    bridge_protocol_min: int = 1,
+    bridge_protocol_max: int = 1,
+    snapshot_protocol_min: int = 7,
+    snapshot_protocol_max: int = 7,
+    minimum_native_build: int = 45,
+    platforms: tuple[str, ...] = ("android",),
+    source_repository: str,
+    source_commit: str,
+    source_tree: str,
+    input_digest: str,
+    build_context_digest: str,
+    dirty_provenance: Mapping[str, object] | None,
+    reproducible: bool,
+    builder_identity: Mapping[str, str],
+) -> tuple[WebUiManifest, dict[str, bytes]]:
+    """从已构建目录读取普通文件并生成确定性 manifest 与内容。"""
+
+    if not root.is_dir():
+        raise ManifestError(f"WebUI build 目录不存在: {root}")
+    files: list[WebUiFile] = []
+    contents: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix().encode("utf-8")):
+        if path.is_symlink():
+            raise ManifestError(f"WebUI build 不允许 symlink: {path}")
+        if path.is_dir():
+            continue
+        try:
+            mode = path.stat().st_mode
+        except OSError as error:
+            raise ManifestError(f"WebUI build 文件无法读取: {path}") from error
+        if not stat.S_ISREG(mode):
+            raise ManifestError(f"WebUI build 只允许普通文件: {path}")
+        relative = path.relative_to(root).as_posix()
+        data = path.read_bytes()
+        digest = hashlib.sha256(data).hexdigest()
+        mime = _MIME_BY_SUFFIX.get(Path(relative).suffix.lower(), "application/octet-stream")
+        files.append(WebUiFile(relative, digest, len(data), mime))
+        contents[relative] = data
+    draft = WebUiManifest(
+        generation_id="0" * 64,
+        entrypoint=entrypoint,
+        files=tuple(files),
+        bridge_protocol_min=bridge_protocol_min,
+        bridge_protocol_max=bridge_protocol_max,
+        snapshot_protocol_min=snapshot_protocol_min,
+        snapshot_protocol_max=snapshot_protocol_max,
+        minimum_native_build=minimum_native_build,
+        platforms=platforms,
+        source_repository=source_repository,
+        source_commit=source_commit,
+        source_tree=source_tree,
+        input_digest=input_digest,
+        build_context_digest=build_context_digest,
+        dirty_provenance=dirty_provenance,
+        reproducible=reproducible,
+        builder_identity=builder_identity,
+        unpacked_size_bytes=sum(item.size_bytes for item in files),
+        file_count=len(files),
+    )
+    manifest = WebUiManifest(
+        generation_id=generation_id_for_manifest(draft),
+        entrypoint=draft.entrypoint,
+        files=draft.files,
+        bridge_protocol_min=draft.bridge_protocol_min,
+        bridge_protocol_max=draft.bridge_protocol_max,
+        snapshot_protocol_min=draft.snapshot_protocol_min,
+        snapshot_protocol_max=draft.snapshot_protocol_max,
+        minimum_native_build=draft.minimum_native_build,
+        platforms=draft.platforms,
+        source_repository=draft.source_repository,
+        source_commit=draft.source_commit,
+        source_tree=draft.source_tree,
+        input_digest=draft.input_digest,
+        build_context_digest=draft.build_context_digest,
+        dirty_provenance=draft.dirty_provenance,
+        reproducible=draft.reproducible,
+        builder_identity=draft.builder_identity,
+        unpacked_size_bytes=draft.unpacked_size_bytes,
+        file_count=draft.file_count,
+    )
+    validate_manifest(manifest)
+    return manifest, contents
+
+
+def _normalise_path(value: str) -> str:
+    if not value or "\\" in value:
+        raise ManifestError(f"文件路径无效: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ManifestError(f"文件路径必须是安全相对路径: {value!r}")
+    if "/".join(path.parts) != value:
+        raise ManifestError(f"文件路径包含非规范分隔符: {value!r}")
+    if not 1 <= len(value.encode("utf-8")) <= 512:
+        raise ManifestError("文件路径 UTF-8 长度必须在 1..512 bytes")
+    for segment in path.parts:
+        if not 1 <= len(segment.encode("utf-8")) <= 128 or _PATH_SEGMENT_RE.fullmatch(segment) is None:
+            raise ManifestError(f"文件路径 segment 只能使用 ASCII [A-Za-z0-9._-]: {value!r}")
+    normalized = unicodedata.normalize("NFC", value)
+    if normalized != value or normalized.startswith("/"):
+        raise ManifestError(f"文件路径不是 NFC 相对形式: {value!r}")
+    return normalized
+
+
+def _require_nonempty_token(value: str, label: str) -> None:
+    if not isinstance(value, str) or not value or len(value) > 2048 or any(char.isspace() for char in value):
+        raise ManifestError(f"{label} 无效")
+
+
+def _valid_digest(value: str) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _validate_platforms(platforms: tuple[str, ...]) -> None:
+    if not platforms or len(platforms) > 64 or len(set(platforms)) != len(platforms):
+        raise ManifestError("platforms 必须为非空无重复列表")
+    if tuple(platforms) != tuple(sorted(platforms, key=lambda value: value.encode("utf-8"))):
+        raise ManifestError("platforms 必须按规范顺序排列")
+    for value in platforms:
+        if not isinstance(value, str) or _PLATFORM_RE.fullmatch(value) is None:
+            raise ManifestError("platform 必须是 ASCII token")
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise ManifestError(f"{label} 必须是字符串")
+    return value
+
+
+def _require_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ManifestError(f"{label} 必须是整数")
+    return value
+
+
+def _require_bool(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ManifestError(f"{label} 必须是 bool")
+    return value
+
+
+def _require_string_map(value: dict[object, object], label: str) -> dict[str, str]:
+    if any(not isinstance(key, str) or not isinstance(item, str) for key, item in value.items()):
+        raise ManifestError(f"{label} 必须是 string map")
+    return dict(value)
+
+
+def _validate_dirty_provenance(value: Mapping[str, object] | None) -> None:
+    if value is None:
+        return
+    if set(value) != {"base_commit", "tracked_patch_digest", "untracked_tree_digest"}:
+        raise ManifestError("dirty_provenance 字段集合无效")
+    for key, item in value.items():
+        if not isinstance(item, str) or not item:
+            raise ManifestError(f"dirty_provenance.{key} 无效")
+        if key != "base_commit" and not _valid_digest(item):
+            raise ManifestError(f"dirty_provenance.{key} 必须是 sha256")
+        if key == "base_commit":
+            _require_git_object(item, "dirty_provenance.base_commit")
+
+
+def _validate_builder_identity(value: Mapping[str, str]) -> None:
+    if set(value) != {"node_version", "npm_version", "package_lock_digest", "build_script_digest"}:
+        raise ManifestError("builder_identity 字段集合无效")
+    for key, item in value.items():
+        if not isinstance(item, str) or not item or len(item) > 64 or any(char.isspace() for char in item):
+            raise ManifestError(f"builder_identity.{key} 无效")
+    for key in ("package_lock_digest", "build_script_digest"):
+        if not _valid_digest(value[key]):
+            raise ManifestError(f"builder_identity.{key} 必须是 sha256")
+
+
+def _require_git_object(value: str, label: str) -> None:
+    if len(value) != 40 or any(char not in "0123456789abcdef" for char in value):
+        raise ManifestError(f"{label} 必须是 git commit/tree 摘要")
+
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "MAX_FILE_BYTES",
+    "MAX_FILES",
+    "MAX_MANIFEST_BYTES",
+    "MAX_UNPACKED_BYTES",
+    "ManifestError",
+    "WebUiFile",
+    "WebUiManifest",
+    "WebUiTarget",
+    "canonical_generation_identity_bytes",
+    "canonical_manifest_bytes",
+    "derive_target_key",
+    "generation_id_for_manifest",
+    "manifest_digest",
+    "manifest_from_directory",
+    "manifest_from_json",
+    "validate_manifest",
+]

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -17,9 +17,6 @@ MANIFEST_SCHEMA_VERSION = 2
 
 _MIME_ALLOWLIST = frozenset(
     {
-        "application/font-woff",
-        "application/font-woff2",
-        "application/javascript",
         "application/json",
         "application/octet-stream",
         "application/wasm",

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -357,7 +357,7 @@ def validate_manifest(manifest: WebUiManifest) -> None:
         raise ManifestError("file_count 与 files 不一致")
     seen: set[str] = set()
     seen_folded: set[str] = set()
-    digest_mimes: dict[str, str] = {}
+    digest_metadata: dict[str, tuple[int, str]] = {}
     total = 0
     for item in manifest.files:
         normalized = _normalise_path(item.path)
@@ -377,9 +377,10 @@ def validate_manifest(manifest: WebUiManifest) -> None:
         expected_mime = _MIME_BY_SUFFIX.get(Path(item.path).suffix.lower(), "application/octet-stream")
         if item.mime != expected_mime:
             raise ManifestError(f"MIME 与固定后缀映射不一致: {item.path}")
-        previous_mime = digest_mimes.setdefault(item.sha256, item.mime)
-        if previous_mime != item.mime:
-            raise ManifestError("同一 generation 内 digest 不得映射多个 MIME")
+        metadata = (item.size_bytes, item.mime)
+        previous_metadata = digest_metadata.setdefault(item.sha256, metadata)
+        if previous_metadata != metadata:
+            raise ManifestError("同一 generation 内 digest 不得映射多个 size/mime")
         if Path(item.path).suffix.lower() in _FORBIDDEN_SUFFIXES:
             raise ManifestError(f"文件类型禁止进入 WebUI: {item.path}")
         total += item.size_bytes

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -52,6 +52,7 @@ _MIME_BY_SUFFIX = {
     ".mjs": "text/javascript",
     ".cjs": "text/javascript",
     ".json": "application/json",
+    ".map": "application/json",
     ".wasm": "application/wasm",
     ".woff": "font/woff",
     ".woff2": "font/woff2",

--- a/infra/mobile_webui/protocol.py
+++ b/infra/mobile_webui/protocol.py
@@ -114,11 +114,12 @@ class WebUiManifestWire(WireModel):
         folded = [item.path.lower() for item in self.files]
         if len(set(folded)) != len(folded):
             raise ValueError("files 存在大小写折叠冲突")
-        digest_mimes: dict[str, MimeType] = {}
+        digest_metadata: dict[str, tuple[int, MimeType]] = {}
         for item in self.files:
-            previous_mime = digest_mimes.setdefault(item.sha256, item.mime)
-            if previous_mime != item.mime:
-                raise ValueError("同一 generation 内 digest 不得映射多个 MIME")
+            metadata = (item.size_bytes, item.mime)
+            previous_metadata = digest_metadata.setdefault(item.sha256, metadata)
+            if previous_metadata != metadata:
+                raise ValueError("同一 generation 内 digest 不得映射多个 size/mime")
         total = sum(item.size_bytes for item in self.files)
         if total != self.unpacked_size_bytes or total > 64 * 1024 * 1024:
             raise ValueError("unpacked_size_bytes 与 files 不一致")

--- a/infra/mobile_webui/protocol.py
+++ b/infra/mobile_webui/protocol.py
@@ -12,9 +12,6 @@ ServerId = Annotated[str, Field(min_length=1, max_length=128, pattern=r"^[A-Za-z
 PlatformToken = Annotated[str, Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9._-]{1,64}$")]
 Token = Annotated[str, Field(min_length=1, max_length=2048, pattern=r"^\S+$")]
 MimeType = Literal[
-    "application/font-woff",
-    "application/font-woff2",
-    "application/javascript",
     "application/json",
     "application/octet-stream",
     "application/wasm",

--- a/infra/mobile_webui/protocol.py
+++ b/infra/mobile_webui/protocol.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+Digest = Annotated[str, Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")]
+GitSha1 = Annotated[str, Field(min_length=40, max_length=40, pattern=r"^[0-9a-f]{40}$")]
+ServerId = Annotated[str, Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")]
+PlatformToken = Annotated[str, Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9._-]{1,64}$")]
+Token = Annotated[str, Field(min_length=1, max_length=2048, pattern=r"^\S+$")]
+MimeType = Literal[
+    "application/font-woff",
+    "application/font-woff2",
+    "application/javascript",
+    "application/json",
+    "application/octet-stream",
+    "application/wasm",
+    "font/otf",
+    "font/ttf",
+    "font/woff",
+    "font/woff2",
+    "image/avif",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/svg+xml",
+    "image/webp",
+    "text/css",
+    "text/html",
+    "text/javascript",
+    "text/plain",
+    "video/mp4",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wav",
+]
+ErrorCode = Literal[
+    "capability_required",
+    "invalid_range",
+    "invalid_ticket",
+    "range_precondition_failed",
+    "release_store_corrupt",
+    "resource_not_found",
+    "rollback_unavailable",
+    "target_changed",
+    "target_not_found",
+]
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class DirtyProvenanceWire(WireModel):
+    base_commit: GitSha1
+    tracked_patch_digest: Digest
+    untracked_tree_digest: Digest
+
+
+class BuilderIdentityWire(WireModel):
+    node_version: Token = Field(max_length=64)
+    npm_version: Token = Field(max_length=64)
+    package_lock_digest: Digest
+    build_script_digest: Digest
+
+
+class WebUiFileWire(WireModel):
+    path: str = Field(min_length=1, max_length=512, pattern=r"^[A-Za-z0-9._-]{1,128}(?:/[A-Za-z0-9._-]{1,128})*$")
+    sha256: Digest
+    size_bytes: int = Field(ge=0, le=8 * 1024 * 1024)
+    mime: MimeType
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        if unicodedata.normalize("NFC", value) != value or any(segment in {".", ".."} for segment in value.split("/")):
+            raise ValueError("path 必须是 NFC 安全相对路径")
+        if value.rsplit("/", 1)[-1].lower().endswith((".dex", ".jar", ".so", ".apk", ".aab")):
+            raise ValueError("path 后缀不允许进入 WebUI")
+        return value
+
+
+class WebUiManifestWire(WireModel):
+    schema_version: Literal[2]
+    generation_id: Digest
+    entrypoint: Literal["mobile.html"]
+    files: list[WebUiFileWire] = Field(min_length=1, max_length=2048)
+    bridge_protocol_min: int = Field(ge=1)
+    bridge_protocol_max: int = Field(ge=1)
+    snapshot_protocol_min: int = Field(ge=1)
+    snapshot_protocol_max: int = Field(ge=1)
+    minimum_native_build: int = Field(ge=1)
+    platforms: list[PlatformToken] = Field(min_length=1, max_length=64)
+    source_repository: Token = Field(max_length=2048)
+    source_commit: GitSha1
+    source_tree: GitSha1
+    input_digest: Digest
+    build_context_digest: Digest
+    dirty_provenance: DirtyProvenanceWire | None
+    reproducible: bool
+    builder_identity: BuilderIdentityWire
+    unpacked_size_bytes: int = Field(ge=0, le=64 * 1024 * 1024)
+    file_count: int = Field(ge=1, le=2048)
+
+    @model_validator(mode="after")
+    def validate_manifest_contract(self) -> WebUiManifestWire:
+        _validate_protocol_window(self.bridge_protocol_min, self.bridge_protocol_max, "bridge_protocol")
+        _validate_protocol_window(self.snapshot_protocol_min, self.snapshot_protocol_max, "snapshot_protocol")
+        _validate_sorted_tokens(self.platforms, "platforms")
+        if self.file_count != len(self.files):
+            raise ValueError("file_count 与 files 不一致")
+        if tuple(item.path for item in self.files) != tuple(sorted((item.path for item in self.files), key=lambda value: value.encode("utf-8"))):
+            raise ValueError("files 必须按 UTF-8 path 顺序排列")
+        folded = [item.path.lower() for item in self.files]
+        if len(set(folded)) != len(folded):
+            raise ValueError("files 存在大小写折叠冲突")
+        digest_mimes: dict[str, MimeType] = {}
+        for item in self.files:
+            previous_mime = digest_mimes.setdefault(item.sha256, item.mime)
+            if previous_mime != item.mime:
+                raise ValueError("同一 generation 内 digest 不得映射多个 MIME")
+        total = sum(item.size_bytes for item in self.files)
+        if total != self.unpacked_size_bytes or total > 64 * 1024 * 1024:
+            raise ValueError("unpacked_size_bytes 与 files 不一致")
+        if self.reproducible != (self.dirty_provenance is None):
+            raise ValueError("reproducible 必须与 dirty_provenance 一致")
+        return self
+
+
+class WebUiTargetWire(WireModel):
+    target_key: Digest
+    generation_id: Digest
+    manifest_digest: Digest
+    manifest_size_bytes: int = Field(ge=1, le=1024 * 1024)
+    bridge_protocol_min: int = Field(ge=1)
+    bridge_protocol_max: int = Field(ge=1)
+    snapshot_protocol_min: int = Field(ge=1)
+    snapshot_protocol_max: int = Field(ge=1)
+    minimum_native_build: int = Field(ge=1)
+    platforms: list[PlatformToken] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def validate_target_contract(self) -> WebUiTargetWire:
+        _validate_protocol_window(self.bridge_protocol_min, self.bridge_protocol_max, "bridge_protocol")
+        _validate_protocol_window(self.snapshot_protocol_min, self.snapshot_protocol_max, "snapshot_protocol")
+        _validate_sorted_tokens(self.platforms, "platforms")
+        return self
+
+
+class ReleaseViewWire(WireModel):
+    server_id: ServerId
+    release_epoch: str = Field(
+        min_length=36,
+        max_length=36,
+        pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    )
+    sequence: int = Field(ge=0)
+    selection_digest: Digest
+    stable: WebUiTargetWire | None
+    preview: WebUiTargetWire | None
+
+    @model_validator(mode="after")
+    def validate_release_epoch(self) -> ReleaseViewWire:
+        try:
+            parsed = UUID(self.release_epoch)
+        except ValueError as error:
+            raise ValueError("release_epoch 必须是 UUID4") from error
+        if parsed.version != 4 or str(parsed) != self.release_epoch:
+            raise ValueError("release_epoch 必须是规范小写 UUID4")
+        return self
+
+
+class PrepareReplyWire(WireModel):
+    target_key: Digest
+    manifest_digest: Digest
+    ticket: str = Field(min_length=1, max_length=4096)
+    expires_at: str = Field(min_length=1, max_length=64)
+
+
+class ErrorReplyWire(WireModel):
+    code: ErrorCode
+    message: str = Field(min_length=1, max_length=512)
+
+
+class HttpErrorBodyWire(WireModel):
+    error: ErrorReplyWire
+
+
+def _validate_protocol_window(minimum: int, maximum: int, label: str) -> None:
+    if minimum > maximum:
+        raise ValueError(f"{label} 兼容窗口无效")
+
+
+def _validate_sorted_tokens(values: list[str], label: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{label} 不得重复")
+    if tuple(values) != tuple(sorted(values, key=lambda value: value.encode("utf-8"))):
+        raise ValueError(f"{label} 必须按 UTF-8 顺序排列")
+
+
+__all__ = [
+    "BuilderIdentityWire",
+    "DirtyProvenanceWire",
+    "ErrorReplyWire",
+    "HttpErrorBodyWire",
+    "PrepareReplyWire",
+    "ReleaseViewWire",
+    "WebUiFileWire",
+    "WebUiManifestWire",
+    "WebUiTargetWire",
+]

--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -93,6 +93,7 @@ class MobileWebUiStore:
         self.trash_root = root / "trash"
         self.lock_path = root / "publication.lock"
         self.server_id = server_id
+        self._recover_restore_marker(root)
         self.root.mkdir(parents=True, exist_ok=True)
         self.blob_root.mkdir(parents=True, exist_ok=True)
         self.staging_root.mkdir(parents=True, exist_ok=True)
@@ -111,6 +112,7 @@ class MobileWebUiStore:
             self._init_schema()
             self._ensure_server_id()
             self._ensure_lineage_epoch()
+            self._recover_blob_temps()
             self._recover_trash()
         except BaseException:
             self._db.close()
@@ -340,7 +342,7 @@ class MobileWebUiStore:
         row = self._db.execute("SELECT manifest_json, manifest_digest FROM webui_generations WHERE manifest_digest = ?", (digest,)).fetchone()
         if row is None:
             raise UnknownReleaseError(digest)
-        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        manifest = manifest_from_json(_strict_json_loads(bytes(row["manifest_json"])))
         if manifest_digest(manifest) != digest:
             raise RuntimeError("manifest digest 损坏")
         return manifest
@@ -524,11 +526,17 @@ class MobileWebUiStore:
         """验证 backup 后原子替换 target，并为旧 store 留下可恢复副本。"""
 
         MobileWebUiStore.verify_backup(destination, server_id=server_id)
+        MobileWebUiStore._recover_restore_marker(target_root)
         target_root.parent.mkdir(parents=True, exist_ok=True)
+        if target_root.is_symlink() or (target_root.exists() and not target_root.is_dir()):
+            raise RuntimeError("WebUI restore target 必须是普通目录")
         temporary = Path(tempfile.mkdtemp(prefix=f".{target_root.name}.", dir=target_root.parent))
         old_root: Path | None = None
+        restore_marker: Path | None = None
         try:
             shutil.copytree(destination, temporary, dirs_exist_ok=True)
+            MobileWebUiStore._append_restore_journal(temporary, server_id=server_id)
+            MobileWebUiStore._refresh_backup_descriptor(temporary)
             MobileWebUiStore.verify_backup(temporary, server_id=server_id)
             if target_root.exists():
                 backup_path = pre_restore_backup or target_root.with_name(f"{target_root.name}.pre-restore-{uuid4()}")
@@ -541,6 +549,7 @@ class MobileWebUiStore:
                 finally:
                     existing.close()
                 old_root = target_root.with_name(f"{target_root.name}.recovery-{uuid4()}")
+                restore_marker = MobileWebUiStore._write_restore_marker(target_root, old_root)
                 os.replace(target_root, old_root)
             try:
                 os.replace(temporary, target_root)
@@ -548,8 +557,12 @@ class MobileWebUiStore:
                 if old_root is not None and not target_root.exists():
                     os.replace(old_root, target_root)
                 raise
+            if restore_marker is not None:
+                MobileWebUiStore._clear_restore_marker(restore_marker)
             return target_root
         except BaseException:
+            if restore_marker is not None and target_root.exists():
+                MobileWebUiStore._clear_restore_marker(restore_marker)
             shutil.rmtree(temporary, ignore_errors=True)
             raise
 
@@ -592,7 +605,10 @@ class MobileWebUiStore:
             if not isinstance(descriptor_ids, list) or set(descriptor_ids) != generation_ids or len(descriptor_ids) != len(generation_ids):
                 raise RuntimeError("WebUI backup generation source set 不完整")
             for row in generations:
-                manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+                try:
+                    manifest = manifest_from_json(_strict_json_loads(bytes(row["manifest_json"])))
+                except ManifestError as error:
+                    raise RuntimeError(f"WebUI backup manifest JSON 损坏: {row['generation_id']}") from error
                 digest = str(row["manifest_digest"])
                 if manifest_digest(manifest) != digest:
                     raise RuntimeError(f"WebUI backup manifest 损坏: {row['generation_id']}")
@@ -626,9 +642,11 @@ class MobileWebUiStore:
                 journal_max = db.execute("SELECT MAX(sequence) AS value FROM webui_publication_journal").fetchone()["value"]
                 if journal_max is None or int(journal_max) != int(state["sequence"]):
                     raise RuntimeError("WebUI backup journal 与 release sequence 不一致")
-            elif db.execute("SELECT 1 FROM webui_publication_journal LIMIT 1").fetchone() is not None:
-                raise RuntimeError("WebUI backup 无 release state 但存在 journal")
-            journal_rows = db.execute("SELECT sequence, generation_id, release_epoch FROM webui_publication_journal ORDER BY sequence").fetchall()
+            journal_rows = db.execute("SELECT sequence, generation_id, operation, release_epoch, stable, preview FROM webui_publication_journal ORDER BY sequence").fetchall()
+            if state is None:
+                for row in journal_rows:
+                    if str(row["operation"]) != "restore" or row["generation_id"] is not None or int(row["stable"]) != 0 or int(row["preview"]) != 0:
+                        raise RuntimeError("WebUI backup 无 release state 时仅允许空指针 restore journal")
             for expected_sequence, row in enumerate(journal_rows, start=1):
                 if int(row["sequence"]) != expected_sequence or str(row["release_epoch"]) != str(lineage["value"]):
                     raise RuntimeError("WebUI backup journal sequence/epoch 不连续")
@@ -674,7 +692,7 @@ class MobileWebUiStore:
         row = self._db.execute("SELECT manifest_json, manifest_digest, target_key FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
         if row is None:
             raise RuntimeError("release pointer 引用了不存在的 generation")
-        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        manifest = manifest_from_json(_strict_json_loads(bytes(row["manifest_json"])))
         target = manifest.target(self.server_id, str(row["manifest_digest"]))
         if str(row["target_key"]) != target.target_key:
             raise RuntimeError("generation target_key 损坏")
@@ -686,7 +704,7 @@ class MobileWebUiStore:
         row = self._db.execute("SELECT manifest_json, manifest_digest FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
         if row is None:
             raise RuntimeError("release pointer 引用了不存在的 generation")
-        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        manifest = manifest_from_json(_strict_json_loads(bytes(row["manifest_json"])))
         digest = str(row["manifest_digest"])
         if manifest_digest(manifest) != digest:
             raise RuntimeError("generation manifest digest 损坏")
@@ -829,6 +847,151 @@ class MobileWebUiStore:
         _require_canonical_uuid4(value, "WebUI release lineage epoch")
         return value
 
+    @staticmethod
+    def _restore_marker_path(root: Path) -> Path:
+        return root.resolve().with_name(f".{root.resolve().name}.restore-pending.json")
+
+    @staticmethod
+    def _recover_restore_marker(root: Path) -> None:
+        """Recover a store swap interrupted between old-root rename and new-root install."""
+
+        target_root = root.resolve()
+        marker = MobileWebUiStore._restore_marker_path(target_root)
+        if not marker.exists() and not marker.is_symlink():
+            return
+        if marker.is_symlink() or not marker.is_file():
+            raise RuntimeError("WebUI restore marker 不是普通文件")
+        try:
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError("WebUI restore marker 损坏") from error
+        if not isinstance(payload, dict) or set(payload) != {"target_root", "recovery_root"}:
+            raise RuntimeError("WebUI restore marker 字段不符合合同")
+        if payload["target_root"] != str(target_root) or not isinstance(payload["recovery_root"], str):
+            raise RuntimeError("WebUI restore marker 路径不符合合同")
+        recovery_root = Path(payload["recovery_root"]).resolve()
+        if recovery_root == target_root or not recovery_root.name.startswith(f"{target_root.name}.recovery-"):
+            raise RuntimeError("WebUI restore marker recovery 路径不符合合同")
+        if target_root.is_symlink():
+            raise RuntimeError("WebUI restore marker target 不能是符号链接")
+        if target_root.exists():
+            MobileWebUiStore._clear_restore_marker(marker)
+            return
+        if recovery_root.is_symlink() or not recovery_root.is_dir():
+            raise RuntimeError("WebUI restore marker 缺少可恢复旧 store")
+        target_root.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(recovery_root, target_root)
+        MobileWebUiStore._fsync_directory(target_root.parent)
+        MobileWebUiStore._clear_restore_marker(marker)
+
+    @staticmethod
+    def _write_restore_marker(target_root: Path, recovery_root: Path) -> Path:
+        target_root = target_root.resolve()
+        recovery_root = recovery_root.resolve()
+        marker = MobileWebUiStore._restore_marker_path(target_root)
+        temporary = marker.with_name(f".{marker.name}.{uuid4().hex}.tmp")
+        payload = json.dumps(
+            {"target_root": str(target_root), "recovery_root": str(recovery_root)},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.write(b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, marker)
+        MobileWebUiStore._fsync_directory(marker.parent)
+        return marker
+
+    @staticmethod
+    def _clear_restore_marker(marker: Path) -> None:
+        if marker.exists() or marker.is_symlink():
+            marker.unlink()
+            MobileWebUiStore._fsync_directory(marker.parent)
+
+    @staticmethod
+    def _append_restore_journal(root: Path, *, server_id: str) -> None:
+        """Append a restore audit event while preserving the restored pointer state."""
+
+        db_path = root / "publication.sqlite3"
+        db = sqlite3.connect(db_path, isolation_level=None)
+        db.row_factory = sqlite3.Row
+        try:
+            db.execute("PRAGMA foreign_keys = ON")
+            db.execute("PRAGMA journal_mode = WAL")
+            db.execute("PRAGMA synchronous = FULL")
+            meta = db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
+            if meta is None or str(meta["value"]) != server_id:
+                raise RuntimeError("restore backup server_id 不匹配")
+            lineage = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+            if lineage is None:
+                raise RuntimeError("restore backup 缺少 release_epoch")
+            release_epoch = str(lineage["value"])
+            _require_canonical_uuid4(release_epoch, "restore backup release_epoch")
+            db.execute("BEGIN IMMEDIATE")
+            try:
+                state = db.execute("SELECT stable_generation_id, preview_generation_id, sequence FROM webui_release_state WHERE singleton = 1").fetchone()
+                if state is None:
+                    latest = db.execute("SELECT MAX(sequence) AS value FROM webui_publication_journal").fetchone()["value"]
+                    sequence = int(latest or 0) + 1
+                    generation_id = None
+                    stable = 0
+                    preview = 0
+                else:
+                    sequence = int(state["sequence"]) + 1
+                    generation_id = state["stable_generation_id"] or state["preview_generation_id"]
+                    stable = int(state["stable_generation_id"] is not None)
+                    preview = int(state["preview_generation_id"] is not None)
+                    db.execute("UPDATE webui_release_state SET sequence = ?, updated_at = ? WHERE singleton = 1", (sequence, _now()))
+                db.execute(
+                    "INSERT INTO webui_publication_journal(sequence, generation_id, operation, release_epoch, stable, preview, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (sequence, generation_id, "restore", release_epoch, stable, preview, "restore-mobile-webui", _now()),
+                )
+                db.execute("COMMIT")
+            except BaseException:
+                db.execute("ROLLBACK")
+                raise
+            checkpoint = db.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            if checkpoint is not None and int(checkpoint[0]) != 0:
+                raise RuntimeError("restore backup WAL checkpoint 失败")
+        finally:
+            db.close()
+
+    @staticmethod
+    def _refresh_backup_descriptor(root: Path) -> None:
+        descriptor_path = root / "backup.json"
+        try:
+            descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError("restore backup descriptor 损坏") from error
+        if not isinstance(descriptor, dict) or set(descriptor) != {"backup_id", "server_id", "generation_ids", "sha256", "created_at"}:
+            raise RuntimeError("restore backup descriptor 字段不符合合同")
+        descriptor["sha256"] = _tree_digest(root)
+        descriptor_path.write_text(json.dumps(descriptor, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+        with descriptor_path.open("rb") as handle:
+            os.fsync(handle.fileno())
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        directory_fd = os.open(path, os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _recover_blob_temps(self) -> None:
+        """Remove only temp names emitted by this store's digest-addressed CAS writer."""
+
+        with self._exclusive():
+            for path in self.blob_root.glob("[0-9a-f][0-9a-f]/*"):
+                match = re.fullmatch(r"\.([0-9a-f]{64})\.\d+\.tmp", path.name)
+                if match is None or path.parent.name != match.group(1)[:2]:
+                    continue
+                if path.is_file() or path.is_symlink():
+                    path.unlink()
+
     def _recover_trash(self) -> None:
         """启动时恢复未完成 GC 的 CAS 临时 rename，并清除无引用 trash。"""
 
@@ -870,6 +1033,33 @@ class MobileWebUiStore:
 
 def _valid_digest(value: str) -> bool:
     return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _strict_json_loads(payload: bytes) -> object:
+    """Parse persisted manifest JSON without duplicate fields or non-standard numbers."""
+
+    def reject_constant(value: str) -> object:
+        raise ManifestError(f"manifest JSON 不允许常量: {value}")
+
+    def reject_duplicate_fields(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ManifestError(f"manifest JSON 存在重复字段: {key}")
+            result[key] = value
+        return result
+
+    try:
+        text = payload.decode("utf-8")
+        return json.loads(
+            text,
+            object_pairs_hook=reject_duplicate_fields,
+            parse_constant=reject_constant,
+        )
+    except ManifestError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ManifestError("manifest JSON 无效") from error
 
 
 def _require_canonical_uuid4(value: str, label: str) -> None:

--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -1,0 +1,913 @@
+from __future__ import annotations
+
+import hashlib
+import fcntl
+import json
+import os
+import re
+import shutil
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+from uuid import UUID
+
+from infra.mobile_webui.manifest import (
+    ManifestError,
+    WebUiManifest,
+    WebUiTarget,
+    canonical_manifest_bytes,
+    derive_target_key,
+    manifest_digest,
+    manifest_from_json,
+    validate_manifest,
+)
+
+
+class ReleaseConflictError(RuntimeError):
+    """表示不可变 generation/blob 已经存在但内容不一致。"""
+
+
+class UnknownReleaseError(KeyError):
+    """表示 target 或 generation 不存在。"""
+
+
+class RollbackUnavailableError(UnknownReleaseError):
+    """表示目标既未显式 pin，也不在最近 channel 选择窗口内。"""
+
+    code = "rollback_unavailable"
+
+
+class ReleaseSelectionChangedError(UnknownReleaseError):
+    """表示请求期间 ReleaseView selection 已经变化。"""
+
+
+class TargetResourceNotFoundError(UnknownReleaseError):
+    """表示 digest 不是当前 target 的成员。"""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredBlob:
+    digest: str
+    size_bytes: int
+    path: Path
+    # MIME 只有在 verify_target_resource 返回时才有值；CAS 自身不拥有 MIME 语义。
+    mime: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseView:
+    server_id: str
+    release_epoch: str
+    sequence: int
+    selection_digest: str
+    stable: WebUiTarget | None
+    preview: WebUiTarget | None
+
+    def target(self, target_key: str) -> WebUiTarget | None:
+        for target in (self.stable, self.preview):
+            if target is not None and target.target_key == target_key:
+                return target
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class GarbageCollectionReport:
+    removed_generations: tuple[str, ...]
+    removed_blobs: tuple[str, ...]
+
+
+class MobileWebUiStore:
+    """维护 WebUI immutable CAS、单一发布视图和 append-only 审计日志。"""
+
+    def __init__(self, root: Path, *, server_id: str) -> None:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", server_id) is None:
+            raise ValueError("mobile WebUI server_id 无效")
+        self.root = root
+        self.db_path = root / "publication.sqlite3"
+        self.blob_root = root / "blobs" / "sha256"
+        self.staging_root = root / "staging"
+        self.trash_root = root / "trash"
+        self.lock_path = root / "publication.lock"
+        self.server_id = server_id
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.blob_root.mkdir(parents=True, exist_ok=True)
+        self.staging_root.mkdir(parents=True, exist_ok=True)
+        self.trash_root.mkdir(parents=True, exist_ok=True)
+        self._lock_file = self.lock_path.open("a+")
+        try:
+            self._db = sqlite3.connect(self.db_path, isolation_level=None)
+        except BaseException:
+            self._lock_file.close()
+            raise
+        try:
+            self._db.row_factory = sqlite3.Row
+            self._db.execute("PRAGMA foreign_keys = ON")
+            self._db.execute("PRAGMA journal_mode = WAL")
+            self._db.execute("PRAGMA synchronous = FULL")
+            self._init_schema()
+            self._ensure_server_id()
+            self._ensure_lineage_epoch()
+            self._recover_trash()
+        except BaseException:
+            self._db.close()
+            self._lock_file.close()
+            raise
+
+    def close(self) -> None:
+        self._db.close()
+        self._lock_file.close()
+
+    @contextmanager
+    def _exclusive(self):
+        fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_UN)
+
+    def publish(
+        self,
+        manifest: WebUiManifest,
+        contents: dict[str, bytes],
+        *,
+        stable: bool = False,
+        preview: bool = True,
+        actor: str = "publish-mobile-webui",
+    ) -> ReleaseView:
+        """在跨进程独占锁内完成 CAS 与原子 pointer 提交。"""
+
+        with self._exclusive():
+            return self._publish_locked(manifest, contents, stable=stable, preview=preview, actor=actor)
+
+    def _publish_locked(
+        self,
+        manifest: WebUiManifest,
+        contents: dict[str, bytes],
+        *,
+        stable: bool,
+        preview: bool,
+        actor: str,
+    ) -> ReleaseView:
+        """完成 CAS 后原子插入 generation、替换单一 ReleaseView 并写 journal。"""
+
+        # 1. 校验 manifest、稳定发布资格和每个文件的真实摘要
+        validate_manifest(manifest)
+        if stable and (not manifest.reproducible or manifest.dirty_provenance is not None):
+            raise ManifestError("Stable 发布要求 reproducible=true 且 dirty_provenance=null")
+        if not stable and not preview:
+            raise ValueError("publish 至少要更新 stable 或 preview")
+        digest = manifest_digest(manifest)
+        if set(contents) != {item.path for item in manifest.files}:
+            raise ManifestError("发布内容与 manifest 文件集合不一致")
+        manifest_bytes = canonical_manifest_bytes(manifest)
+        self._write_blob(digest, manifest_bytes)
+        for item in manifest.files:
+            data = contents[item.path]
+            if len(data) != item.size_bytes or hashlib.sha256(data).hexdigest() != item.sha256:
+                raise ManifestError(f"发布内容摘要不匹配: {item.path}")
+            self._write_blob(item.sha256, data)
+
+        # 2. 单写者事务只更新 generation 与两个 nullable pointer
+        generation_id = manifest.generation_id
+        now = _now()
+        self._db.execute("BEGIN IMMEDIATE")
+        deleted_blobs: set[str] = set()
+        moved_blobs: dict[str, Path] = {}
+        try:
+            existing = self._db.execute(
+                "SELECT manifest_digest, manifest_json FROM webui_generations WHERE generation_id = ?",
+                (generation_id,),
+            ).fetchone()
+            if existing is not None:
+                if existing["manifest_digest"] != digest or bytes(existing["manifest_json"]) != manifest_bytes:
+                    raise ReleaseConflictError("generation_id 已存在但内容不同")
+            else:
+                target_key = derive_target_key(self.server_id, generation_id, digest)
+                self._db.execute(
+                    "INSERT INTO webui_generations(generation_id, target_key, manifest_digest, manifest_json, created_at, source_repository, source_commit, source_tree) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (generation_id, target_key, digest, manifest_bytes, now, manifest.source_repository, manifest.source_commit, manifest.source_tree),
+                )
+                for item in manifest.files:
+                    self._db.execute(
+                        "INSERT INTO webui_generation_files(generation_id, path, digest, size_bytes, mime) VALUES (?, ?, ?, ?, ?)",
+                        (generation_id, item.path, item.sha256, item.size_bytes, item.mime),
+                    )
+                self._ensure_blob_row(digest, len(manifest_bytes), now)
+                for item in manifest.files:
+                    self._ensure_blob_row(item.sha256, item.size_bytes, now)
+            state = self._db.execute("SELECT stable_generation_id, preview_generation_id, sequence FROM webui_release_state WHERE singleton = 1").fetchone()
+            stable_id = state["stable_generation_id"] if state is not None else None
+            preview_id = state["preview_generation_id"] if state is not None else None
+            previous_stable_id = stable_id
+            previous_preview_id = preview_id
+            if stable:
+                stable_id = generation_id
+            if preview:
+                preview_id = generation_id
+            sequence = int(state["sequence"]) + 1 if state is not None else 1
+            selection_digest = self._selection_digest(stable_id, preview_id)
+            release_epoch = self._lineage_epoch()
+            self._db.execute(
+                """
+                INSERT INTO webui_release_state(singleton, release_epoch, sequence, stable_generation_id, preview_generation_id, selection_digest, updated_at)
+                VALUES (1, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(singleton) DO UPDATE SET release_epoch=excluded.release_epoch, sequence=excluded.sequence,
+                    stable_generation_id=excluded.stable_generation_id, preview_generation_id=excluded.preview_generation_id,
+                    selection_digest=excluded.selection_digest, updated_at=excluded.updated_at
+                """,
+                (release_epoch, sequence, stable_id, preview_id, selection_digest, now),
+            )
+            self._db.execute(
+                "INSERT INTO webui_publication_journal(sequence, generation_id, operation, release_epoch, stable, preview, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (sequence, generation_id, "publish", release_epoch, int(stable), int(preview), actor, now),
+            )
+            if stable_id != previous_stable_id:
+                self._record_channel_selection_locked("stable", stable_id)
+            if preview_id != previous_preview_id:
+                self._record_channel_selection_locked("preview", preview_id)
+            self._db.execute("COMMIT")
+        except BaseException:
+            self._db.execute("ROLLBACK")
+            raise
+        return self.get_release()
+
+    def promote_preview(self, *, actor: str = "promote-mobile-webui-preview") -> ReleaseView:
+        """把当前 Preview 原子提升为 Stable 并清除 Preview 指针。"""
+
+        with self._exclusive():
+            return self._update_pointers(stable_from_preview=True, clear_preview=True, actor=actor)
+
+    def clear_preview(self, *, actor: str = "clear-mobile-webui-preview") -> ReleaseView:
+        with self._exclusive():
+            return self._update_pointers(clear_preview=True, actor=actor)
+
+    def pin_target(self, target_key: str, *, reason: str = "rollback") -> None:
+        """固定一个 generation，避免显式 GC 删除可回滚目标。"""
+
+        with self._exclusive():
+            row = self._db.execute("SELECT generation_id FROM webui_generations WHERE target_key = ?", (target_key,)).fetchone()
+            if row is None:
+                raise UnknownReleaseError(target_key)
+            self._db.execute(
+                "INSERT INTO webui_pins(target_key, generation_id, reason, created_at) VALUES (?, ?, ?, ?) ON CONFLICT(target_key) DO UPDATE SET generation_id=excluded.generation_id, reason=excluded.reason",
+                (target_key, row["generation_id"], reason, _now()),
+            )
+
+    def unpin_target(self, target_key: str) -> None:
+        with self._exclusive():
+            self._db.execute("DELETE FROM webui_pins WHERE target_key = ?", (target_key,))
+
+    def rollback(self, target_key: str, *, actor: str = "rollback-mobile-webui") -> ReleaseView:
+        """把已 pin 或最近 channel 选择窗口内的 immutable generation 设置为 Stable。"""
+
+        with self._exclusive():
+            return self._rollback_locked(target_key, actor=actor)
+
+    def _rollback_locked(self, target_key: str, *, actor: str) -> ReleaseView:
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            target = self._db.execute(
+                """
+                SELECT generation_id FROM webui_pins WHERE target_key = ?
+                UNION
+                SELECT generation_id FROM webui_channel_selections
+                WHERE channel IN ('stable', 'preview') AND target_key = ?
+                ORDER BY generation_id LIMIT 1
+                """,
+                (target_key, target_key),
+            ).fetchone()
+            if target is None:
+                raise RollbackUnavailableError("rollback target 不在 pin 或最近 stable/preview selection 窗口")
+            generation_id = str(target["generation_id"])
+            manifest = self._manifest_for_generation(generation_id)
+            state = self._db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
+            if state is None:
+                raise UnknownReleaseError("尚未发布任何 WebUI generation")
+            sequence = int(state["sequence"]) + 1
+            preview_id = state["preview_generation_id"]
+            selection = self._selection_digest(generation_id, preview_id)
+            now = _now()
+            self._db.execute("UPDATE webui_release_state SET sequence = ?, stable_generation_id = ?, selection_digest = ?, updated_at = ? WHERE singleton = 1", (sequence, generation_id, selection, now))
+            self._db.execute("INSERT INTO webui_publication_journal(sequence, generation_id, operation, release_epoch, stable, preview, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (sequence, generation_id, "rollback", state["release_epoch"], 1, int(preview_id is not None), actor, now))
+            if state["stable_generation_id"] != generation_id:
+                self._record_channel_selection_locked("stable", generation_id)
+            self._db.execute("COMMIT")
+        except BaseException:
+            self._db.execute("ROLLBACK")
+            raise
+        return self.get_release()
+
+    def record_channel_selection(self, channel: str, target_key: str) -> None:
+        """记录一次成功 Resolve 选择，并保留每个 channel 最近四个 target。"""
+
+        if channel not in {"stable", "preview"}:
+            raise ValueError("channel 必须为 stable 或 preview")
+        with self._exclusive():
+            target = self.get_target(target_key)
+            if target is None:
+                raise UnknownReleaseError(target_key)
+            self._record_channel_selection_locked(channel, target.generation_id)
+
+    def get_release(self, *, verify_integrity: bool = True) -> ReleaseView:
+        state = self._db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
+        if state is None:
+            return ReleaseView(self.server_id, self._lineage_epoch(), 0, self._selection_digest(None, None), None, None)
+        lineage_epoch = self._lineage_epoch()
+        state_epoch = str(state["release_epoch"])
+        _require_canonical_uuid4(state_epoch, "release state release_epoch")
+        if state_epoch != lineage_epoch:
+            raise RuntimeError("release state release_epoch 与 lineage 不一致")
+        stable = self._target_for_generation(state["stable_generation_id"], verify_integrity=verify_integrity)
+        preview = self._target_for_generation(state["preview_generation_id"], verify_integrity=verify_integrity)
+        expected = self._selection_digest(state["stable_generation_id"], state["preview_generation_id"])
+        if expected != state["selection_digest"]:
+            raise RuntimeError("release selection_digest 损坏")
+        return ReleaseView(self.server_id, str(state["release_epoch"]), int(state["sequence"]), str(state["selection_digest"]), stable, preview)
+
+    def get_release_light(self) -> ReleaseView:
+        """重读 pointer/manifest identity，不扫描全部成员 blob；HTTP ticket 每请求使用。"""
+
+        return self.get_release(verify_integrity=False)
+
+    def get_target(self, target_key: str) -> WebUiTarget | None:
+        return self.get_release().target(target_key)
+
+    def get_manifest(self, digest: str) -> WebUiManifest:
+        row = self._db.execute("SELECT manifest_json, manifest_digest FROM webui_generations WHERE manifest_digest = ?", (digest,)).fetchone()
+        if row is None:
+            raise UnknownReleaseError(digest)
+        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        if manifest_digest(manifest) != digest:
+            raise RuntimeError("manifest digest 损坏")
+        return manifest
+
+    def read_blob(self, digest: str) -> StoredBlob:
+        if not _valid_digest(digest):
+            raise ValueError("blob digest 无效")
+        row = self._db.execute("SELECT digest, size_bytes FROM webui_blobs WHERE digest = ?", (digest,)).fetchone()
+        if row is None:
+            raise UnknownReleaseError(digest)
+        path = self.blob_path(digest)
+        if not path.is_file():
+            raise RuntimeError(f"CAS blob 缺失: {digest}")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+            raise RuntimeError(f"CAS blob 摘要损坏: {digest}")
+        return StoredBlob(digest, int(row["size_bytes"]), path)
+
+    def verify_target_resource(self, *, target_key: str, selection_digest: str, resource_digest: str) -> StoredBlob:
+        release = self.get_release_light()
+        if release.selection_digest != selection_digest:
+            raise ReleaseSelectionChangedError("release selection 已变化")
+        target = release.target(target_key)
+        if target is None:
+            raise TargetResourceNotFoundError("target 不属于当前 stable/preview")
+        row = self._db.execute(
+            "SELECT digest, size_bytes, mime FROM webui_generation_files WHERE generation_id = ? AND digest = ? ORDER BY path LIMIT 1",
+            (target.generation_id, resource_digest),
+        ).fetchone()
+        if row is None:
+            raise TargetResourceNotFoundError("resource 不属于当前 target")
+        try:
+            blob = self.read_blob(resource_digest)
+        except UnknownReleaseError as error:
+            raise RuntimeError("target 成员引用的 CAS metadata 缺失") from error
+        if blob.size_bytes != int(row["size_bytes"]):
+            raise RuntimeError("target 成员 size 与 CAS metadata 不一致")
+        return StoredBlob(blob.digest, blob.size_bytes, blob.path, str(row["mime"]))
+
+    def gc(self, *, keep_unreachable: int = 0) -> GarbageCollectionReport:
+        """在跨进程独占锁内清理不可达历史。"""
+
+        with self._exclusive():
+            return self._gc_locked(keep_unreachable=keep_unreachable)
+
+    def _gc_locked(self, *, keep_unreachable: int = 0) -> GarbageCollectionReport:
+        """显式清理不可达历史，Stable/Preview 指针永不被本操作删除。"""
+
+        if keep_unreachable < 0:
+            raise ValueError("keep_unreachable 不能为负数")
+        self._db.execute("BEGIN IMMEDIATE")
+        deleted_blobs: set[str] = set()
+        moved_blobs: dict[str, Path] = {}
+        try:
+            state = self._db.execute("SELECT stable_generation_id, preview_generation_id FROM webui_release_state WHERE singleton = 1").fetchone()
+            protected = set()
+            if state is not None:
+                protected = {str(value) for value in (state["stable_generation_id"], state["preview_generation_id"]) if value is not None}
+            protected.update(str(row["generation_id"]) for row in self._db.execute("SELECT generation_id FROM webui_pins").fetchall())
+            protected.update(str(row["generation_id"]) for row in self._db.execute("SELECT generation_id FROM webui_channel_selections").fetchall())
+            protected.update(str(row["generation_id"]) for row in self._db.execute("SELECT generation_id FROM webui_backup_sets").fetchall())
+            rows = self._db.execute("SELECT generation_id FROM webui_generations ORDER BY created_at DESC, generation_id DESC").fetchall()
+            candidates = [str(row["generation_id"]) for row in rows if str(row["generation_id"]) not in protected]
+            remove_generations = candidates[keep_unreachable:]
+            remove_blobs: set[str] = set()
+            for generation_id in remove_generations:
+                files = self._db.execute("SELECT digest FROM webui_generation_files WHERE generation_id = ?", (generation_id,)).fetchall()
+                remove_blobs.update(str(row["digest"]) for row in files)
+                row = self._db.execute("SELECT manifest_digest FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
+                if row is not None:
+                    remove_blobs.add(str(row["manifest_digest"]))
+                self._db.execute("DELETE FROM webui_generations WHERE generation_id = ?", (generation_id,))
+            for digest in tuple(remove_blobs):
+                ref = self._db.execute("SELECT 1 FROM webui_generations WHERE manifest_digest = ? OR generation_id IN (SELECT generation_id FROM webui_generation_files WHERE digest = ?) LIMIT 1", (digest, digest)).fetchone()
+                if ref is None:
+                    source = self.blob_path(digest)
+                    if source.is_file():
+                        trash_path = self.trash_root / digest
+                        if trash_path.exists():
+                            trash_path.unlink()
+                        os.replace(source, trash_path)
+                        moved_blobs[digest] = trash_path
+                    self._db.execute("DELETE FROM webui_blobs WHERE digest = ?", (digest,))
+                    deleted_blobs.add(digest)
+            self._db.execute("COMMIT")
+        except BaseException:
+            self._db.execute("ROLLBACK")
+            for digest, trash_path in moved_blobs.items():
+                target = self.blob_path(digest)
+                if trash_path.exists() and not target.exists():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(trash_path, target)
+            raise
+        for digest in tuple(deleted_blobs):
+            trash_path = moved_blobs.get(digest)
+            if trash_path is not None and trash_path.exists():
+                trash_path.unlink()
+        known = {str(row["digest"]) for row in self._db.execute("SELECT digest FROM webui_blobs").fetchall()}
+        for path in self.blob_root.rglob("*"):
+            if not path.is_file() or path.name.startswith("."):
+                continue
+            if _valid_digest(path.name) and path.name not in known:
+                path.unlink()
+                deleted_blobs.add(path.name)
+        return GarbageCollectionReport(tuple(remove_generations), tuple(sorted(deleted_blobs)))
+
+    def backup_to(self, destination: Path) -> Path:
+        """在跨进程独占锁内发布 SQLite、CAS 和校验清单。"""
+
+        with self._exclusive():
+            return self._backup_locked(destination)
+
+    def _backup_locked(self, destination: Path) -> Path:
+        """在独立目录发布 SQLite、CAS 和校验清单，供恢复 smoke 使用。"""
+
+        destination = destination.resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent))
+        backup_id = str(uuid4())
+        try:
+            generations = tuple(str(row["generation_id"]) for row in self._db.execute("SELECT generation_id FROM webui_generations").fetchall())
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                now = _now()
+                for generation_id in generations:
+                    self._db.execute("INSERT INTO webui_backup_sets(backup_id, generation_id, destination, created_at) VALUES (?, ?, ?, ?)", (backup_id, generation_id, str(destination), now))
+                self._db.execute("COMMIT")
+            except BaseException:
+                self._db.execute("ROLLBACK")
+                raise
+            backup_db = temporary / "publication.sqlite3"
+            target = sqlite3.connect(backup_db)
+            try:
+                self._db.backup(target)
+            finally:
+                target.close()
+            snapshot = sqlite3.connect(backup_db)
+            snapshot.row_factory = sqlite3.Row
+            try:
+                blob_rows = snapshot.execute("SELECT digest FROM webui_blobs").fetchall()
+            finally:
+                snapshot.close()
+            for row in blob_rows:
+                digest = str(row["digest"])
+                source = self.blob_path(digest)
+                if not source.is_file():
+                    raise RuntimeError(f"backup 时 CAS blob 缺失: {digest}")
+                target_path = temporary / "blobs" / "sha256" / digest[:2] / digest
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target_path)
+            descriptor = {"backup_id": backup_id, "server_id": self.server_id, "generation_ids": generations, "sha256": _tree_digest(temporary), "created_at": _now()}
+            (temporary / "backup.json").write_text(json.dumps(descriptor, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+            if destination.exists():
+                raise FileExistsError(destination)
+            os.replace(temporary, destination)
+            return destination
+        except BaseException:
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                self._db.execute("DELETE FROM webui_backup_sets WHERE backup_id = ?", (backup_id,))
+                self._db.execute("COMMIT")
+            except BaseException:
+                self._db.execute("ROLLBACK")
+                raise
+            shutil.rmtree(temporary, ignore_errors=True)
+            raise
+
+    def release_backup(self, backup_id: str) -> None:
+        """显式释放 backup source set，之后 GC 才可回收其历史 generation。"""
+
+        with self._exclusive():
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                self._db.execute("DELETE FROM webui_backup_sets WHERE backup_id = ?", (backup_id,))
+                self._db.execute("COMMIT")
+            except BaseException:
+                self._db.execute("ROLLBACK")
+                raise
+
+    @staticmethod
+    def restore_backup(destination: Path, target_root: Path, *, server_id: str, pre_restore_backup: Path | None = None) -> Path:
+        """验证 backup 后原子替换 target，并为旧 store 留下可恢复副本。"""
+
+        MobileWebUiStore.verify_backup(destination, server_id=server_id)
+        target_root.parent.mkdir(parents=True, exist_ok=True)
+        temporary = Path(tempfile.mkdtemp(prefix=f".{target_root.name}.", dir=target_root.parent))
+        old_root: Path | None = None
+        try:
+            shutil.copytree(destination, temporary, dirs_exist_ok=True)
+            MobileWebUiStore.verify_backup(temporary, server_id=server_id)
+            if target_root.exists():
+                backup_path = pre_restore_backup or target_root.with_name(f"{target_root.name}.pre-restore-{uuid4()}")
+                if backup_path.exists():
+                    raise FileExistsError(backup_path)
+                existing = MobileWebUiStore(target_root, server_id=server_id)
+                try:
+                    existing.backup_to(backup_path)
+                    MobileWebUiStore.verify_backup(backup_path, server_id=server_id)
+                finally:
+                    existing.close()
+                old_root = target_root.with_name(f"{target_root.name}.recovery-{uuid4()}")
+                os.replace(target_root, old_root)
+            try:
+                os.replace(temporary, target_root)
+            except BaseException:
+                if old_root is not None and not target_root.exists():
+                    os.replace(old_root, target_root)
+                raise
+            return target_root
+        except BaseException:
+            shutil.rmtree(temporary, ignore_errors=True)
+            raise
+
+    @staticmethod
+    def verify_backup(destination: Path, *, server_id: str) -> None:
+        """在不连接正式 store 的前提下校验备份 SQLite、manifest 和全部 CAS。"""
+
+        db_path = destination / "publication.sqlite3"
+        if not db_path.is_file():
+            raise RuntimeError("WebUI backup 缺少 publication.sqlite3")
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+        try:
+            integrity = db.execute("PRAGMA integrity_check").fetchone()
+            if integrity is None or integrity[0] != "ok":
+                raise RuntimeError("WebUI backup SQLite integrity_check 失败")
+            descriptor_path = destination / "backup.json"
+            if not descriptor_path.is_file():
+                raise RuntimeError("WebUI backup 缺少 backup.json")
+            descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+            if descriptor.get("server_id") != server_id or descriptor.get("sha256") != _tree_digest(destination):
+                raise RuntimeError("WebUI backup descriptor 校验失败")
+            meta = db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
+            if meta is None or str(meta["value"]) != server_id:
+                raise RuntimeError("WebUI backup server_id 不匹配")
+            lineage = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+            if lineage is None:
+                raise RuntimeError("WebUI backup 缺少 release_epoch")
+            lineage_epoch = str(lineage["value"])
+            _require_canonical_uuid4(lineage_epoch, "WebUI backup release_epoch")
+            rows = db.execute("SELECT digest, size_bytes FROM webui_blobs").fetchall()
+            for row in rows:
+                digest = str(row["digest"])
+                path = destination / "blobs" / "sha256" / digest[:2] / digest
+                if not path.is_file() or len(path.read_bytes()) != int(row["size_bytes"]) or hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+                    raise RuntimeError(f"WebUI backup CAS 损坏: {digest}")
+            generations = db.execute("SELECT generation_id, target_key, manifest_digest, manifest_json FROM webui_generations").fetchall()
+            generation_ids = {str(row["generation_id"]) for row in generations}
+            descriptor_ids = descriptor.get("generation_ids")
+            if not isinstance(descriptor_ids, list) or set(descriptor_ids) != generation_ids or len(descriptor_ids) != len(generation_ids):
+                raise RuntimeError("WebUI backup generation source set 不完整")
+            for row in generations:
+                manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+                digest = str(row["manifest_digest"])
+                if manifest_digest(manifest) != digest:
+                    raise RuntimeError(f"WebUI backup manifest 损坏: {row['generation_id']}")
+                expected_target_key = derive_target_key(server_id, str(row["generation_id"]), digest)
+                if str(row["target_key"]) != expected_target_key:
+                    raise RuntimeError(f"WebUI backup target_key 损坏: {row['generation_id']}")
+                member_rows = db.execute("SELECT path, digest, size_bytes, mime FROM webui_generation_files WHERE generation_id = ?", (row["generation_id"],)).fetchall()
+                expected = {item.path: (item.sha256, item.size_bytes, item.mime) for item in manifest.files}
+                actual = {str(item["path"]): (str(item["digest"]), int(item["size_bytes"]), str(item["mime"])) for item in member_rows}
+                if actual != expected:
+                    raise RuntimeError(f"WebUI backup generation files 损坏: {row['generation_id']}")
+            state = db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
+            if state is not None:
+                if str(state["release_epoch"]) != str(lineage["value"]):
+                    raise RuntimeError("WebUI backup release epoch lineage 不一致")
+                stable_id = state["stable_generation_id"]
+                preview_id = state["preview_generation_id"]
+                for pointer in (stable_id, preview_id):
+                    if pointer is not None and str(pointer) not in generation_ids:
+                        raise RuntimeError("WebUI backup release pointer 不可达")
+                stable_key = next((str(row["target_key"]) for row in generations if row["generation_id"] == stable_id), None)
+                preview_key = next((str(row["target_key"]) for row in generations if row["generation_id"] == preview_id), None)
+                selection_body = json.dumps(
+                    {"server_id": server_id, "stable_target_key": stable_key, "preview_target_key": preview_key},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode("utf-8")
+                if str(state["selection_digest"]) != hashlib.sha256(selection_body).hexdigest():
+                    raise RuntimeError("WebUI backup selection_digest 损坏")
+                journal_max = db.execute("SELECT MAX(sequence) AS value FROM webui_publication_journal").fetchone()["value"]
+                if journal_max is None or int(journal_max) != int(state["sequence"]):
+                    raise RuntimeError("WebUI backup journal 与 release sequence 不一致")
+            elif db.execute("SELECT 1 FROM webui_publication_journal LIMIT 1").fetchone() is not None:
+                raise RuntimeError("WebUI backup 无 release state 但存在 journal")
+            journal_rows = db.execute("SELECT sequence, generation_id, release_epoch FROM webui_publication_journal ORDER BY sequence").fetchall()
+            for expected_sequence, row in enumerate(journal_rows, start=1):
+                if int(row["sequence"]) != expected_sequence or str(row["release_epoch"]) != str(lineage["value"]):
+                    raise RuntimeError("WebUI backup journal sequence/epoch 不连续")
+        finally:
+            db.close()
+
+    def _update_pointers(self, *, stable_from_preview: bool = False, clear_preview: bool = False, actor: str) -> ReleaseView:
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            state = self._db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
+            if state is None:
+                raise UnknownReleaseError("尚未发布任何 WebUI generation")
+            stable_id = state["preview_generation_id"] if stable_from_preview else state["stable_generation_id"]
+            preview_id = None if clear_preview else state["preview_generation_id"]
+            previous_stable_id = state["stable_generation_id"]
+            previous_preview_id = state["preview_generation_id"]
+            if stable_from_preview:
+                if state["preview_generation_id"] is None:
+                    raise UnknownReleaseError("没有可提升的 Preview")
+                manifest = self._manifest_for_generation(state["preview_generation_id"])
+                if not manifest.reproducible or manifest.dirty_provenance is not None:
+                    raise ManifestError("Preview 必须 reproducible 且无 dirty provenance 才能 promotion")
+            sequence = int(state["sequence"]) + 1
+            selection = self._selection_digest(stable_id, preview_id)
+            now = _now()
+            self._db.execute("UPDATE webui_release_state SET sequence = ?, stable_generation_id = ?, preview_generation_id = ?, selection_digest = ?, updated_at = ? WHERE singleton = 1", (sequence, stable_id, preview_id, selection, now))
+            generation_id = stable_id or preview_id
+            operation = "promote_preview" if stable_from_preview else "clear_preview"
+            self._db.execute("INSERT INTO webui_publication_journal(sequence, generation_id, operation, release_epoch, stable, preview, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (sequence, generation_id, operation, state["release_epoch"], int(stable_from_preview), int(not clear_preview), actor, now))
+            if stable_id != previous_stable_id:
+                self._record_channel_selection_locked("stable", stable_id)
+            if preview_id != previous_preview_id:
+                self._record_channel_selection_locked("preview", preview_id)
+            self._db.execute("COMMIT")
+        except BaseException:
+            self._db.execute("ROLLBACK")
+            raise
+        return self.get_release()
+
+    def _target_for_generation(self, generation_id: str | None, *, verify_integrity: bool = True) -> WebUiTarget | None:
+        if generation_id is None:
+            return None
+        row = self._db.execute("SELECT manifest_json, manifest_digest, target_key FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("release pointer 引用了不存在的 generation")
+        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        target = manifest.target(self.server_id, str(row["manifest_digest"]))
+        if str(row["target_key"]) != target.target_key:
+            raise RuntimeError("generation target_key 损坏")
+        if verify_integrity:
+            self._verify_generation_complete(generation_id, manifest, str(row["manifest_digest"]))
+        return target
+
+    def _manifest_for_generation(self, generation_id: str) -> WebUiManifest:
+        row = self._db.execute("SELECT manifest_json, manifest_digest FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("release pointer 引用了不存在的 generation")
+        manifest = manifest_from_json(json.loads(bytes(row["manifest_json"])))
+        digest = str(row["manifest_digest"])
+        if manifest_digest(manifest) != digest:
+            raise RuntimeError("generation manifest digest 损坏")
+        self._verify_generation_complete(generation_id, manifest, digest)
+        return manifest
+
+    def _verify_generation_complete(self, generation_id: str, manifest: WebUiManifest, digest: str) -> None:
+        manifest_blob = self.read_blob(digest)
+        if manifest_blob.path.read_bytes() != canonical_manifest_bytes(manifest):
+            raise RuntimeError("generation manifest CAS 不完整")
+        rows = self._db.execute("SELECT path, digest, size_bytes, mime FROM webui_generation_files WHERE generation_id = ?", (generation_id,)).fetchall()
+        expected = {item.path: (item.sha256, item.size_bytes, item.mime) for item in manifest.files}
+        actual = {str(row["path"]): (str(row["digest"]), int(row["size_bytes"]), str(row["mime"])) for row in rows}
+        if actual != expected:
+            raise RuntimeError("generation file metadata 不完整")
+        for file_digest, size_bytes, _mime in actual.values():
+            blob = self.read_blob(file_digest)
+            if blob.size_bytes != size_bytes:
+                raise RuntimeError("generation member size 与 CAS metadata 不一致")
+
+    def _selection_digest(self, stable_id: str | None, preview_id: str | None) -> str:
+        stable_key = self._target_key_for_generation(stable_id)
+        preview_key = self._target_key_for_generation(preview_id)
+        body = json.dumps({"server_id": self.server_id, "stable_target_key": stable_key, "preview_target_key": preview_key}, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(body).hexdigest()
+
+    def _ensure_blob_row(self, digest: str, size_bytes: int, created_at: str) -> None:
+        """Ensure CAS owns only digest/size; MIME remains generation-file metadata."""
+
+        row = self._db.execute("SELECT size_bytes FROM webui_blobs WHERE digest = ?", (digest,)).fetchone()
+        if row is not None:
+            if int(row["size_bytes"]) != size_bytes:
+                raise ReleaseConflictError(f"CAS digest 已存在但 size 不一致: {digest}")
+            return
+        # Keep the legacy column for on-disk compatibility; never use it for HTTP semantics.
+        self._db.execute(
+            "INSERT INTO webui_blobs(digest, size_bytes, mime, created_at) VALUES (?, ?, ?, ?)",
+            (digest, size_bytes, "application/octet-stream", created_at),
+        )
+
+    def _target_key_for_generation(self, generation_id: str | None) -> str | None:
+        if generation_id is None:
+            return None
+        row = self._db.execute("SELECT target_key FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("release pointer 引用的 generation 不存在")
+        return str(row["target_key"])
+
+    def _record_channel_selection_locked(self, channel: str, generation_id: str | None) -> None:
+        if generation_id is None:
+            return
+        row = self._db.execute("SELECT target_key FROM webui_generations WHERE generation_id = ?", (generation_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("selection pointer generation 不存在")
+        existing = self._db.execute(
+            "SELECT selection_id FROM webui_channel_selections WHERE channel = ? AND target_key = ? LIMIT 1",
+            (channel, row["target_key"]),
+        ).fetchone()
+        if existing is not None:
+            self._db.execute("DELETE FROM webui_channel_selections WHERE selection_id = ?", (existing["selection_id"],))
+        self._db.execute(
+            "INSERT INTO webui_channel_selections(channel, target_key, generation_id, selected_at) VALUES (?, ?, ?, ?)",
+            (channel, row["target_key"], generation_id, _now()),
+        )
+        rows = self._db.execute("SELECT selection_id FROM webui_channel_selections WHERE channel = ? ORDER BY selection_id DESC", (channel,)).fetchall()
+        for old in rows[4:]:
+            self._db.execute("DELETE FROM webui_channel_selections WHERE selection_id = ?", (old["selection_id"],))
+
+    def _init_schema(self) -> None:
+        self._db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS webui_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS webui_generations (
+                generation_id TEXT PRIMARY KEY, target_key TEXT NOT NULL UNIQUE,
+                manifest_digest TEXT NOT NULL UNIQUE, manifest_json BLOB NOT NULL,
+                created_at TEXT NOT NULL, source_repository TEXT NOT NULL,
+                source_commit TEXT NOT NULL, source_tree TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS webui_generation_files (
+                generation_id TEXT NOT NULL REFERENCES webui_generations(generation_id) ON DELETE CASCADE,
+                path TEXT NOT NULL, digest TEXT NOT NULL, size_bytes INTEGER NOT NULL,
+                mime TEXT NOT NULL, PRIMARY KEY(generation_id, path)
+            );
+            CREATE INDEX IF NOT EXISTS webui_generation_files_digest ON webui_generation_files(digest);
+            CREATE TABLE IF NOT EXISTS webui_blobs (
+                digest TEXT PRIMARY KEY, size_bytes INTEGER NOT NULL, mime TEXT NOT NULL, created_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS webui_release_state (
+                singleton INTEGER PRIMARY KEY CHECK(singleton = 1), release_epoch TEXT NOT NULL,
+                sequence INTEGER NOT NULL, stable_generation_id TEXT REFERENCES webui_generations(generation_id),
+                preview_generation_id TEXT REFERENCES webui_generations(generation_id), selection_digest TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS webui_pins (
+                target_key TEXT PRIMARY KEY,
+                generation_id TEXT NOT NULL REFERENCES webui_generations(generation_id),
+                reason TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS webui_channel_selections (
+                selection_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel TEXT NOT NULL,
+                target_key TEXT NOT NULL,
+                generation_id TEXT NOT NULL REFERENCES webui_generations(generation_id),
+                selected_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS webui_backup_sets (
+                backup_id TEXT NOT NULL,
+                generation_id TEXT NOT NULL REFERENCES webui_generations(generation_id),
+                destination TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY(backup_id, generation_id)
+            );
+            CREATE TABLE IF NOT EXISTS webui_publication_journal (
+                sequence INTEGER PRIMARY KEY, generation_id TEXT, operation TEXT NOT NULL, release_epoch TEXT NOT NULL,
+                stable INTEGER NOT NULL, preview INTEGER NOT NULL, actor TEXT NOT NULL, created_at TEXT NOT NULL
+            );
+            """
+        )
+
+    def _ensure_server_id(self) -> None:
+        row = self._db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
+        if row is None:
+            self._db.execute("INSERT INTO webui_meta(key, value) VALUES ('server_id', ?)", (self.server_id,))
+        elif str(row["value"]) != self.server_id:
+            raise ValueError("mobile WebUI publication store server_id 不匹配")
+
+    def _ensure_lineage_epoch(self) -> None:
+        row = self._db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+        if row is None:
+            self._db.execute("INSERT INTO webui_meta(key, value) VALUES ('release_epoch', ?)", (str(uuid4()),))
+            return
+        _require_canonical_uuid4(str(row["value"]), "WebUI release lineage epoch")
+
+    def _lineage_epoch(self) -> str:
+        row = self._db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+        if row is None:
+            raise RuntimeError("WebUI release lineage epoch 缺失")
+        value = str(row["value"])
+        _require_canonical_uuid4(value, "WebUI release lineage epoch")
+        return value
+
+    def _recover_trash(self) -> None:
+        """启动时恢复未完成 GC 的 CAS 临时 rename，并清除无引用 trash。"""
+
+        with self._exclusive():
+            for path in tuple(item for item in self.trash_root.rglob("*") if item.is_file()):
+                digest = path.name
+                row = self._db.execute("SELECT 1 FROM webui_blobs WHERE digest = ?", (digest,)).fetchone()
+                target = self.blob_path(digest)
+                if row is not None and not target.exists():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(path, target)
+                elif path.exists():
+                    path.unlink()
+
+    def _write_blob(self, digest: str, data: bytes) -> None:
+        if hashlib.sha256(data).hexdigest() != digest:
+            raise ManifestError("CAS blob digest 不匹配")
+        path = self.blob_path(digest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            if not path.is_file() or path.read_bytes() != data:
+                raise ReleaseConflictError(f"CAS digest 已存在但内容不同: {digest}")
+            return
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        with temporary.open("xb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def blob_path(self, digest: str) -> Path:
+        return self.blob_root / digest[:2] / digest
+
+
+def _valid_digest(value: str) -> bool:
+    return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _require_canonical_uuid4(value: str, label: str) -> None:
+    """Require the persisted release lineage value to be canonical UUID4."""
+
+    try:
+        parsed = UUID(value)
+    except (AttributeError, ValueError, TypeError) as error:
+        raise RuntimeError(f"{label} 必须是规范 UUID4") from error
+    if parsed.version != 4 or str(parsed) != value:
+        raise RuntimeError(f"{label} 必须是规范小写 UUID4")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    ignored = {"backup.json", "publication.sqlite3-wal", "publication.sqlite3-shm"}
+    for path in sorted(item for item in root.rglob("*") if item.is_file() and item.name not in ignored):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        data = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return digest.hexdigest()
+
+
+__all__ = [
+    "GarbageCollectionReport",
+    "MobileWebUiStore",
+    "ReleaseConflictError",
+    "ReleaseSelectionChangedError",
+    "ReleaseView",
+    "RollbackUnavailableError",
+    "StoredBlob",
+    "TargetResourceNotFoundError",
+    "UnknownReleaseError",
+]

--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -113,6 +113,7 @@ class MobileWebUiStore:
             self._ensure_server_id()
             self._ensure_lineage_epoch()
             self._recover_blob_temps()
+            self._recover_backup_pending()
             self._recover_trash()
         except BaseException:
             self._db.close()
@@ -457,11 +458,20 @@ class MobileWebUiStore:
     def _backup_locked(self, destination: Path) -> Path:
         """在独立目录发布 SQLite、CAS 和校验清单，供恢复 smoke 使用。"""
 
-        destination = destination.resolve()
+        destination = _absolute_path(destination)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent))
+        if destination.is_symlink():
+            raise RuntimeError("WebUI backup destination 不能是符号链接")
+        if destination.exists():
+            raise FileExistsError(destination)
         backup_id = str(uuid4())
+        temporary = destination.parent / f".{destination.name}.{backup_id}.tmp"
+        if temporary.exists() or temporary.is_symlink():
+            raise FileExistsError(temporary)
+        marker = self._write_backup_pending_marker(backup_id, destination, temporary)
+        published = False
         try:
+            temporary.mkdir()
             generations = tuple(str(row["generation_id"]) for row in self._db.execute("SELECT generation_id FROM webui_generations").fetchall())
             self._db.execute("BEGIN IMMEDIATE")
             try:
@@ -493,12 +503,22 @@ class MobileWebUiStore:
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source, target_path)
             descriptor = {"backup_id": backup_id, "server_id": self.server_id, "generation_ids": generations, "sha256": _tree_digest(temporary), "created_at": _now()}
-            (temporary / "backup.json").write_text(json.dumps(descriptor, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
-            if destination.exists():
+            descriptor_path = temporary / "backup.json"
+            with descriptor_path.open("w", encoding="utf-8") as handle:
+                handle.write(json.dumps(descriptor, ensure_ascii=False, sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._fsync_tree(temporary)
+            if destination.is_symlink() or destination.exists():
                 raise FileExistsError(destination)
             os.replace(temporary, destination)
+            published = True
+            self._fsync_directory(destination.parent)
+            self._clear_backup_pending_marker(marker)
             return destination
         except BaseException:
+            if published:
+                raise
             self._db.execute("BEGIN IMMEDIATE")
             try:
                 self._db.execute("DELETE FROM webui_backup_sets WHERE backup_id = ?", (backup_id,))
@@ -507,6 +527,7 @@ class MobileWebUiStore:
                 self._db.execute("ROLLBACK")
                 raise
             shutil.rmtree(temporary, ignore_errors=True)
+            self._clear_backup_pending_marker(marker)
             raise
 
     def release_backup(self, backup_id: str) -> None:
@@ -526,6 +547,7 @@ class MobileWebUiStore:
         """验证 backup 后原子替换 target，并为旧 store 留下可恢复副本。"""
 
         MobileWebUiStore.verify_backup(destination, server_id=server_id)
+        target_root = _absolute_path(target_root)
         MobileWebUiStore._recover_restore_marker(target_root)
         target_root.parent.mkdir(parents=True, exist_ok=True)
         if target_root.is_symlink() or (target_root.exists() and not target_root.is_dir()):
@@ -551,11 +573,14 @@ class MobileWebUiStore:
                 old_root = target_root.with_name(f"{target_root.name}.recovery-{uuid4()}")
                 restore_marker = MobileWebUiStore._write_restore_marker(target_root, old_root)
                 os.replace(target_root, old_root)
+                MobileWebUiStore._fsync_directory(target_root.parent)
             try:
                 os.replace(temporary, target_root)
+                MobileWebUiStore._fsync_directory(target_root.parent)
             except BaseException:
                 if old_root is not None and not target_root.exists():
                     os.replace(old_root, target_root)
+                    MobileWebUiStore._fsync_directory(target_root.parent)
                 raise
             if restore_marker is not None:
                 MobileWebUiStore._clear_restore_marker(restore_marker)
@@ -570,6 +595,9 @@ class MobileWebUiStore:
     def verify_backup(destination: Path, *, server_id: str) -> None:
         """在不连接正式 store 的前提下校验备份 SQLite、manifest 和全部 CAS。"""
 
+        destination = _absolute_path(destination)
+        if destination.is_symlink() or not destination.is_dir():
+            raise RuntimeError("WebUI backup destination 必须是普通目录")
         db_path = destination / "publication.sqlite3"
         if not db_path.is_file():
             raise RuntimeError("WebUI backup 缺少 publication.sqlite3")
@@ -582,7 +610,9 @@ class MobileWebUiStore:
             descriptor_path = destination / "backup.json"
             if not descriptor_path.is_file():
                 raise RuntimeError("WebUI backup 缺少 backup.json")
-            descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+            descriptor = _strict_json_loads(descriptor_path.read_bytes())
+            if not isinstance(descriptor, dict):
+                raise RuntimeError("WebUI backup descriptor 字段不符合合同")
             if descriptor.get("server_id") != server_id or descriptor.get("sha256") != _tree_digest(destination):
                 raise RuntimeError("WebUI backup descriptor 校验失败")
             meta = db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
@@ -849,13 +879,14 @@ class MobileWebUiStore:
 
     @staticmethod
     def _restore_marker_path(root: Path) -> Path:
-        return root.resolve().with_name(f".{root.resolve().name}.restore-pending.json")
+        root = _absolute_path(root)
+        return root.with_name(f".{root.name}.restore-pending.json")
 
     @staticmethod
     def _recover_restore_marker(root: Path) -> None:
         """Recover a store swap interrupted between old-root rename and new-root install."""
 
-        target_root = root.resolve()
+        target_root = _absolute_path(root)
         marker = MobileWebUiStore._restore_marker_path(target_root)
         if not marker.exists() and not marker.is_symlink():
             return
@@ -869,12 +900,14 @@ class MobileWebUiStore:
             raise RuntimeError("WebUI restore marker 字段不符合合同")
         if payload["target_root"] != str(target_root) or not isinstance(payload["recovery_root"], str):
             raise RuntimeError("WebUI restore marker 路径不符合合同")
-        recovery_root = Path(payload["recovery_root"]).resolve()
+        recovery_root = _absolute_path(Path(payload["recovery_root"]))
         if recovery_root == target_root or not recovery_root.name.startswith(f"{target_root.name}.recovery-"):
             raise RuntimeError("WebUI restore marker recovery 路径不符合合同")
         if target_root.is_symlink():
             raise RuntimeError("WebUI restore marker target 不能是符号链接")
         if target_root.exists():
+            if not target_root.is_dir():
+                raise RuntimeError("WebUI restore marker target 必须是普通目录")
             MobileWebUiStore._clear_restore_marker(marker)
             return
         if recovery_root.is_symlink() or not recovery_root.is_dir():
@@ -886,8 +919,8 @@ class MobileWebUiStore:
 
     @staticmethod
     def _write_restore_marker(target_root: Path, recovery_root: Path) -> Path:
-        target_root = target_root.resolve()
-        recovery_root = recovery_root.resolve()
+        target_root = _absolute_path(target_root)
+        recovery_root = _absolute_path(recovery_root)
         marker = MobileWebUiStore._restore_marker_path(target_root)
         temporary = marker.with_name(f".{marker.name}.{uuid4().hex}.tmp")
         payload = json.dumps(
@@ -981,6 +1014,134 @@ class MobileWebUiStore:
         finally:
             os.close(directory_fd)
 
+    @staticmethod
+    def _fsync_tree(root: Path) -> None:
+        """Durably flush a completed backup tree before its atomic rename."""
+
+        # 1. Flush file contents before making the directory entry durable.
+        for path in sorted(item for item in root.rglob("*") if item.is_file()):
+            with path.open("rb") as handle:
+                os.fsync(handle.fileno())
+        # 2. Flush each directory from the leaves back to the backup root.
+        directories = sorted((item for item in root.rglob("*") if item.is_dir()), key=lambda item: len(item.parts), reverse=True)
+        for path in (*directories, root):
+            MobileWebUiStore._fsync_directory(path)
+
+    def _write_backup_pending_marker(self, backup_id: str, destination: Path, temporary: Path) -> Path:
+        """Persist the owner record that makes a pre-rename backup recoverable."""
+
+        marker = self.staging_root / f".backup-{backup_id}.pending.json"
+        marker_temporary = marker.with_name(f"{marker.name}.{os.getpid()}.tmp")
+        payload = {
+            "backup_id": backup_id,
+            "destination": str(destination),
+            "server_id": self.server_id,
+            "temporary": str(temporary),
+        }
+        with marker_temporary.open("xb") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+            handle.write(b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(marker_temporary, marker)
+        self._fsync_directory(marker.parent)
+        return marker
+
+    @staticmethod
+    def _clear_backup_pending_marker(marker: Path) -> None:
+        if marker.is_symlink() or (marker.exists() and not marker.is_file()):
+            raise RuntimeError("WebUI backup pending marker 不是普通文件")
+        if marker.exists():
+            marker.unlink()
+            MobileWebUiStore._fsync_directory(marker.parent)
+
+    @staticmethod
+    def _remove_pending_temporary(temporary: Path) -> None:
+        if temporary.is_symlink():
+            raise RuntimeError("WebUI backup pending temporary 不能是符号链接")
+        if temporary.is_dir():
+            shutil.rmtree(temporary)
+        elif temporary.exists():
+            temporary.unlink()
+
+    def _recover_backup_pending(self) -> None:
+        """Recover only store-owned backup registrations with no valid destination."""
+
+        with self._exclusive():
+            for marker_temporary in self.staging_root.iterdir():
+                if re.fullmatch(r"\.backup-[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.pending\.json\.\d+\.tmp", marker_temporary.name):
+                    if marker_temporary.is_symlink():
+                        raise RuntimeError("WebUI backup pending marker temporary 不能是符号链接")
+                    if marker_temporary.is_file():
+                        marker_temporary.unlink()
+            self._fsync_directory(self.staging_root)
+            for marker in sorted(self.staging_root.glob(".backup-*.pending.json")):
+                if marker.is_symlink() or not marker.is_file():
+                    raise RuntimeError("WebUI backup pending marker 不是普通文件")
+                backup_id, destination, temporary = self._read_backup_pending_marker(marker)
+                rows = self._db.execute(
+                    "SELECT DISTINCT destination FROM webui_backup_sets WHERE backup_id = ?",
+                    (backup_id,),
+                ).fetchall()
+                destinations = {str(row["destination"]) for row in rows}
+                if destinations and destinations != {str(destination)}:
+                    raise RuntimeError("WebUI backup pending registration destination 不一致")
+                published = self._is_valid_published_backup(destination, backup_id)
+                if rows and not published:
+                    self._db.execute("BEGIN IMMEDIATE")
+                    try:
+                        self._db.execute("DELETE FROM webui_backup_sets WHERE backup_id = ?", (backup_id,))
+                        self._db.execute("COMMIT")
+                    except BaseException:
+                        self._db.execute("ROLLBACK")
+                        raise
+                self._remove_pending_temporary(temporary)
+                self._clear_backup_pending_marker(marker)
+
+    def _read_backup_pending_marker(self, marker: Path) -> tuple[str, Path, Path]:
+        """Validate a pending marker and derive its only permitted temporary path."""
+
+        try:
+            payload = _strict_json_loads(marker.read_bytes())
+        except (OSError, ManifestError) as error:
+            raise RuntimeError("WebUI backup pending marker 损坏") from error
+        if not isinstance(payload, dict) or set(payload) != {"backup_id", "destination", "server_id", "temporary"}:
+            raise RuntimeError("WebUI backup pending marker 字段不符合合同")
+        backup_id = payload["backup_id"]
+        destination_raw = payload["destination"]
+        temporary_raw = payload["temporary"]
+        if not isinstance(backup_id, str) or not isinstance(destination_raw, str) or not isinstance(temporary_raw, str):
+            raise RuntimeError("WebUI backup pending marker 类型不符合合同")
+        _require_canonical_uuid4(backup_id, "WebUI backup pending backup_id")
+        if marker.name != f".backup-{backup_id}.pending.json":
+            raise RuntimeError("WebUI backup pending marker 文件名不符合合同")
+        if payload["server_id"] != self.server_id:
+            raise RuntimeError("WebUI backup pending marker server_id 不匹配")
+        destination = _absolute_path(Path(destination_raw))
+        if destination_raw != str(destination):
+            raise RuntimeError("WebUI backup pending destination 必须是规范绝对路径")
+        temporary = destination.parent / f".{destination.name}.{backup_id}.tmp"
+        if temporary_raw != str(temporary):
+            raise RuntimeError("WebUI backup pending temporary 路径不符合合同")
+        return backup_id, destination, temporary
+
+    def _is_valid_published_backup(self, destination: Path, backup_id: str) -> bool:
+        """Return whether destination is a complete backup for this pending owner."""
+
+        if destination.is_symlink() or not destination.is_dir():
+            return False
+        descriptor_path = destination / "backup.json"
+        if descriptor_path.is_symlink() or not descriptor_path.is_file():
+            return False
+        try:
+            descriptor = _strict_json_loads(descriptor_path.read_bytes())
+            if not isinstance(descriptor, dict) or descriptor.get("backup_id") != backup_id:
+                return False
+            MobileWebUiStore.verify_backup(destination, server_id=self.server_id)
+        except (OSError, ManifestError, RuntimeError, sqlite3.Error, UnicodeError, ValueError, TypeError):
+            return False
+        return True
+
     def _recover_blob_temps(self) -> None:
         """Remove only temp names emitted by this store's digest-addressed CAS writer."""
 
@@ -1033,6 +1194,12 @@ class MobileWebUiStore:
 
 def _valid_digest(value: str) -> bool:
     return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _absolute_path(path: Path) -> Path:
+    """Make a lexical absolute path without following the destination symlink."""
+
+    return Path(os.path.abspath(os.fspath(path)))
 
 
 def _strict_json_loads(payload: bytes) -> object:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,9245 @@
+{
+  "name": "akashic-agent-frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "akashic-agent-frontend",
+      "dependencies": {
+        "@ai-sdk/react": "^4.0.16",
+        "@radix-ui/react-collapsible": "^1.1.15",
+        "@radix-ui/react-dialog": "^1.1.18",
+        "@radix-ui/react-dropdown-menu": "^2.1.19",
+        "@radix-ui/react-hover-card": "^1.1.18",
+        "@radix-ui/react-scroll-area": "^1.2.2",
+        "@radix-ui/react-select": "^2.3.2",
+        "@radix-ui/react-separator": "^1.1.11",
+        "@radix-ui/react-slot": "^1.3.0",
+        "@radix-ui/react-tooltip": "^1.2.11",
+        "@radix-ui/react-use-controllable-state": "^1.2.3",
+        "@streamdown/cjk": "^1.0.3",
+        "@streamdown/code": "^1.1.1",
+        "@streamdown/math": "^1.0.2",
+        "@streamdown/mermaid": "^1.0.2",
+        "@tanstack/react-virtual": "^3.14.9",
+        "ai": "^7.0.15",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
+        "core-js": "3.49.0",
+        "lucide-react": "^1.23.0",
+        "micromark": "^4.0.2",
+        "micromark-extension-gfm": "^3.0.0",
+        "motion": "^12.42.2",
+        "nanoid": "^5.1.16",
+        "qrcode": "^1.5.4",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "recharts": "^3.8.1",
+        "shiki": "3.23.0",
+        "streamdown": "^2.5.0",
+        "tailwind-merge": "^2.6.0",
+        "type-fest": "^5.8.0",
+        "use-stick-to-bottom": "^1.1.6"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/node": "22.20.1",
+        "@types/qrcode": "^1.5.6",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.3.4",
+        "ai-elements": "^1.9.0",
+        "autoprefixer": "^10.4.20",
+        "esbuild": "^0.25.0",
+        "eslint": "^10.2.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
+        "globals": "^17.5.0",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "typescript": "5.8.3",
+        "typescript-eslint": "^8.59.1",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.37.tgz",
+      "integrity": "sha512-YBCTsSlX0ETVsjo0ihfBOeJ3p3y1wXKXDzF9Ygp9dscUY06dzOGmyWJSGsKg+khKVArzBWUW4UCSAKms20ZDmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.22.tgz",
+      "integrity": "sha512-j3jPwKFTffZCJzYGpN69yKu/y646uu2gWoEwh1jgVyYVpzfu6ErFU+YAd/+xTPxsUTx8FEIEUHTlEsDuOe+ytQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.18.tgz",
+      "integrity": "sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.51.tgz",
+      "integrity": "sha512-CZtoWfeY66gkvKldYXrDZobMe9cASkMAXqfgu32FVv0FyMHwWvqQdePwYPVIW7xHLC+ULnSaUKbz+0uUykF5kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.22",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "ai": "7.0.48",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
+      "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
+      "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+      "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@streamdown/cjk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@streamdown/cjk/-/cjk-1.0.3.tgz",
+      "integrity": "sha512-WRg8HR/gHbBoTgsMd91OKFUClIoDcEFVofJvluvEAyjx3KpU0aGgD9tGDqHkHj14ShoMSkX0IYetWGegTcwIJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "remark-cjk-friendly": "^2.0.1",
+        "remark-cjk-friendly-gfm-strikethrough": "^2.0.1",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/code": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@streamdown/code/-/code-1.1.1.tgz",
+      "integrity": "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "shiki": "^3.19.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/math": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@streamdown/math/-/math-1.0.2.tgz",
+      "integrity": "sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "katex": "^0.16.27",
+        "rehype-katex": "^7.0.1",
+        "remark-math": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/mermaid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@streamdown/mermaid/-/mermaid-1.0.2.tgz",
+      "integrity": "sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mermaid": "^11.12.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.48.tgz",
+      "integrity": "sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.37",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai-elements": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ai-elements/-/ai-elements-1.9.0.tgz",
+      "integrity": "sha512-lIBC48Y5ZWd9tKFDx6V6LoLl7RlKs9L/tAQA3J4N5SFDqqJglM+PX7kocAiuS/w0KeRFUXzXVsSgJNLGp3BwNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "elements": "index.js"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
+      "integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.43.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown-cjk-friendly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly/-/mdast-util-to-markdown-cjk-friendly-1.0.0.tgz",
+      "integrity": "sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough/-/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough-1.0.0.tgz",
+      "integrity": "sha512-1ePVfB4P/vz3xSsm6H3D32r6VYGErxclnuLLFK02/2ReF+UdEKm7caulK6Vm0LBIp5gPRtB2Z1OYDznCkX3k2w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-2.0.1.tgz",
+      "integrity": "sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-2.0.1.tgz",
+      "integrity": "sha512-wVC0zwjJNqQeX+bb07YTPu/CvSAyCTafyYb7sMhX1r62/Lw5M/df3JyYaANyp8g15c1ypJRFSsookTqA1IDsUg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "get-east-asian-width": "^1.4.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-3.0.1.tgz",
+      "integrity": "sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/motion": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+      "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.43.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-harden": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/rehype-harden/-/rehype-harden-1.1.8.tgz",
+      "integrity": "sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-cjk-friendly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-2.3.1.tgz",
+      "integrity": "sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly": "1.0.0",
+        "micromark-extension-cjk-friendly": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/remark-cjk-friendly-gfm-strikethrough": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-2.3.1.tgz",
+      "integrity": "sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": "1.0.0",
+        "micromark-extension-cjk-friendly-gfm-strikethrough": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remend": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz",
+      "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/streamdown": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/streamdown/-/streamdown-2.5.0.tgz",
+      "integrity": "sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "hast-util-to-jsx-runtime": "^2.3.6",
+        "html-url-attributes": "^3.0.1",
+        "marked": "^17.0.1",
+        "mermaid": "^11.12.2",
+        "rehype-harden": "^1.1.8",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remend": "1.3.0",
+        "tailwind-merge": "^3.4.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/streamdown/node_modules/marked": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/streamdown/node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-stick-to-bottom": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.6.tgz",
+      "integrity": "sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/samdenty"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -75,7 +75,6 @@
     "attachment.progress",
     "attachment.ready",
     "connection.degraded",
-    "device.revoked",
     "history.page",
     "message.final",
     "message.proactive",
@@ -840,8 +839,7 @@
               "attachment.ready",
               "connection.degraded",
               "sync.completed",
-              "sync.reset_required",
-              "device.revoked"
+              "sync.reset_required"
             ],
             "title": "Type",
             "type": "string"
@@ -1842,7 +1840,6 @@
               "attachment.progress": "#/$defs/GenericEvent",
               "attachment.ready": "#/$defs/GenericEvent",
               "connection.degraded": "#/$defs/GenericEvent",
-              "device.revoked": "#/$defs/GenericEvent",
               "history.page": "#/$defs/GenericEvent",
               "message.final": "#/$defs/GenericEvent",
               "message.proactive": "#/$defs/GenericEvent",
@@ -1946,7 +1943,6 @@
             "attachment.progress": "#/$defs/GenericEvent",
             "attachment.ready": "#/$defs/GenericEvent",
             "connection.degraded": "#/$defs/GenericEvent",
-            "device.revoked": "#/$defs/GenericEvent",
             "history.page": "#/$defs/GenericEvent",
             "message.final": "#/$defs/GenericEvent",
             "message.proactive": "#/$defs/GenericEvent",

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -38,6 +38,8 @@
     "history.get",
     "message.content.prepare",
     "message.send",
+    "mobile.webui.content.prepare",
+    "mobile.webui.release.get",
     "ping",
     "plugin.ui.asset.get",
     "plugin.ui.cancel",
@@ -58,6 +60,7 @@
   "controlTypes": [
     "auth.accepted",
     "device.proof",
+    "mobile.webui.release.changed",
     "pair.accepted",
     "pair.claim",
     "pair.pending",
@@ -1065,6 +1068,253 @@
         "title": "MessageSendPayload",
         "type": "object"
       },
+      "MobileWebUiContentPrepareCommand": {
+        "additionalProperties": false,
+        "properties": {
+          "connection_epoch": {
+            "minimum": 1,
+            "title": "Connection Epoch",
+            "type": "integer"
+          },
+          "id": {
+            "maxLength": 36,
+            "minLength": 26,
+            "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "const": "command",
+            "title": "Kind",
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/MobileWebUiContentPreparePayload"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Session Id"
+          },
+          "turn_id": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Turn Id"
+          },
+          "type": {
+            "const": "mobile.webui.content.prepare",
+            "title": "Type",
+            "type": "string"
+          },
+          "v": {
+            "const": 1,
+            "title": "V",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "v",
+          "kind",
+          "type",
+          "id",
+          "connection_epoch",
+          "payload"
+        ],
+        "title": "MobileWebUiContentPrepareCommand",
+        "type": "object"
+      },
+      "MobileWebUiContentPreparePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "target_key": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Target Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_key"
+        ],
+        "title": "MobileWebUiContentPreparePayload",
+        "type": "object"
+      },
+      "MobileWebUiReleaseChangedControl": {
+        "additionalProperties": false,
+        "properties": {
+          "connection_epoch": {
+            "minimum": 1,
+            "title": "Connection Epoch",
+            "type": "integer"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "maxLength": 36,
+                "minLength": 26,
+                "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Id"
+          },
+          "kind": {
+            "const": "control",
+            "title": "Kind",
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/MobileWebUiReleaseChangedPayload"
+          },
+          "type": {
+            "const": "mobile.webui.release.changed",
+            "title": "Type",
+            "type": "string"
+          },
+          "v": {
+            "const": 1,
+            "title": "V",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "v",
+          "kind",
+          "type",
+          "connection_epoch",
+          "payload"
+        ],
+        "title": "MobileWebUiReleaseChangedControl",
+        "type": "object"
+      },
+      "MobileWebUiReleaseChangedPayload": {
+        "additionalProperties": false,
+        "properties": {
+          "selection_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Selection Digest",
+            "type": "string"
+          },
+          "server_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Server Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server_id",
+          "selection_digest"
+        ],
+        "title": "MobileWebUiReleaseChangedPayload",
+        "type": "object"
+      },
+      "MobileWebUiReleaseGetCommand": {
+        "additionalProperties": false,
+        "properties": {
+          "connection_epoch": {
+            "minimum": 1,
+            "title": "Connection Epoch",
+            "type": "integer"
+          },
+          "id": {
+            "maxLength": 36,
+            "minLength": 26,
+            "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "const": "command",
+            "title": "Kind",
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/$defs/MobileWebUiReleaseGetPayload"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Session Id"
+          },
+          "turn_id": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Turn Id"
+          },
+          "type": {
+            "const": "mobile.webui.release.get",
+            "title": "Type",
+            "type": "string"
+          },
+          "v": {
+            "const": 1,
+            "title": "V",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "v",
+          "kind",
+          "type",
+          "id",
+          "connection_epoch",
+          "payload"
+        ],
+        "title": "MobileWebUiReleaseGetCommand",
+        "type": "object"
+      },
+      "MobileWebUiReleaseGetPayload": {
+        "additionalProperties": false,
+        "description": "ReleaseView 查询不接受客户端排序或版本选择参数。",
+        "properties": {},
+        "title": "MobileWebUiReleaseGetPayload",
+        "type": "object"
+      },
       "PluginUiChangedControl": {
         "additionalProperties": false,
         "properties": {
@@ -1503,6 +1753,8 @@
               "history.get": "#/$defs/GenericCommand",
               "message.content.prepare": "#/$defs/GenericCommand",
               "message.send": "#/$defs/MessageSendCommand",
+              "mobile.webui.content.prepare": "#/$defs/MobileWebUiContentPrepareCommand",
+              "mobile.webui.release.get": "#/$defs/MobileWebUiReleaseGetCommand",
               "ping": "#/$defs/GenericCommand",
               "plugin.ui.asset.get": "#/$defs/GenericCommand",
               "plugin.ui.cancel": "#/$defs/GenericCommand",
@@ -1536,6 +1788,12 @@
               "$ref": "#/$defs/AttachmentDownloadCommand"
             },
             {
+              "$ref": "#/$defs/MobileWebUiReleaseGetCommand"
+            },
+            {
+              "$ref": "#/$defs/MobileWebUiContentPrepareCommand"
+            },
+            {
               "$ref": "#/$defs/GenericCommand"
             }
           ]
@@ -1545,6 +1803,7 @@
             "mapping": {
               "auth.accepted": "#/$defs/AuthAcceptedControl",
               "device.proof": "#/$defs/GenericControl",
+              "mobile.webui.release.changed": "#/$defs/MobileWebUiReleaseChangedControl",
               "pair.accepted": "#/$defs/GenericControl",
               "pair.claim": "#/$defs/GenericControl",
               "pair.pending": "#/$defs/GenericControl",
@@ -1564,6 +1823,9 @@
             },
             {
               "$ref": "#/$defs/PluginUiChangedControl"
+            },
+            {
+              "$ref": "#/$defs/MobileWebUiReleaseChangedControl"
             },
             {
               "$ref": "#/$defs/GenericControl"
@@ -1626,6 +1888,8 @@
             "history.get": "#/$defs/GenericCommand",
             "message.content.prepare": "#/$defs/GenericCommand",
             "message.send": "#/$defs/MessageSendCommand",
+            "mobile.webui.content.prepare": "#/$defs/MobileWebUiContentPrepareCommand",
+            "mobile.webui.release.get": "#/$defs/MobileWebUiReleaseGetCommand",
             "ping": "#/$defs/GenericCommand",
             "plugin.ui.asset.get": "#/$defs/GenericCommand",
             "plugin.ui.cancel": "#/$defs/GenericCommand",
@@ -1657,6 +1921,12 @@
           },
           {
             "$ref": "#/$defs/AttachmentDownloadCommand"
+          },
+          {
+            "$ref": "#/$defs/MobileWebUiReleaseGetCommand"
+          },
+          {
+            "$ref": "#/$defs/MobileWebUiContentPrepareCommand"
           },
           {
             "$ref": "#/$defs/GenericCommand"
@@ -1714,6 +1984,7 @@
           "mapping": {
             "auth.accepted": "#/$defs/AuthAcceptedControl",
             "device.proof": "#/$defs/GenericControl",
+            "mobile.webui.release.changed": "#/$defs/MobileWebUiReleaseChangedControl",
             "pair.accepted": "#/$defs/GenericControl",
             "pair.claim": "#/$defs/GenericControl",
             "pair.pending": "#/$defs/GenericControl",
@@ -1735,6 +2006,9 @@
             "$ref": "#/$defs/PluginUiChangedControl"
           },
           {
+            "$ref": "#/$defs/MobileWebUiReleaseChangedControl"
+          },
+          {
             "$ref": "#/$defs/GenericControl"
           }
         ]
@@ -1743,6 +2017,912 @@
   },
   "maxAttachmentChunkBytes": 131072,
   "maxJsonFrameBytes": 262144,
+  "mobileWebUi": {
+    "capability": "mobile-webui-ota-v1",
+    "commandTypes": [
+      "mobile.webui.release.get",
+      "mobile.webui.content.prepare"
+    ],
+    "contentPrepareReply": {
+      "fields": [
+        "target_key",
+        "manifest_digest",
+        "ticket",
+        "expires_at"
+      ],
+      "paths": {
+        "blob": "/mobile/webui/v1/blob/{blob_digest}",
+        "manifest": "/mobile/webui/v1/manifest/{manifest_digest}"
+      },
+      "type": "mobile.webui.content.prepare.ok"
+    },
+    "controlType": "mobile.webui.release.changed",
+    "http": {
+      "blob": "/mobile/webui/v1/blob/{blob_digest}",
+      "blobCacheControl": "immutable",
+      "manifest": "/mobile/webui/v1/manifest/{manifest_digest}",
+      "manifestCacheControl": "no-store",
+      "range": "one bytes range, response <= 8388608 bytes",
+      "statuses": {
+        "invalid_range": 416,
+        "invalid_ticket": 401,
+        "range_precondition_failed": 412,
+        "release_store_corrupt": 500,
+        "resource_not_found": 404,
+        "target_changed": 409
+      }
+    },
+    "manifest": {
+      "canonical": "UTF-8 JSON, sorted object keys, no insignificant whitespace, NFC paths, files/platforms UTF-8 order; duplicate/unknown fields rejected",
+      "fields": [
+        "schema_version",
+        "generation_id",
+        "entrypoint",
+        "files",
+        "bridge_protocol_min",
+        "bridge_protocol_max",
+        "snapshot_protocol_min",
+        "snapshot_protocol_max",
+        "minimum_native_build",
+        "platforms",
+        "source_repository",
+        "source_commit",
+        "source_tree",
+        "input_digest",
+        "build_context_digest",
+        "dirty_provenance",
+        "reproducible",
+        "builder_identity",
+        "unpacked_size_bytes",
+        "file_count"
+      ],
+      "generationId": "sha256(canonical complete manifest with generation_id omitted)",
+      "limits": {
+        "fileBytes": 8388608,
+        "files": 2048,
+        "manifestBytes": 1048576,
+        "unpackedBytes": 67108864
+      },
+      "manifestDigest": "sha256(canonical complete manifest)",
+      "provenance": {
+        "builder_identity": "{node_version,npm_version,package_lock_digest,build_script_digest}",
+        "dirty_provenance": "null or {base_commit,tracked_patch_digest,untracked_tree_digest}",
+        "stable": "reproducible=true and dirty_provenance=null"
+      },
+      "schemaVersion": 2
+    },
+    "releaseView": {
+      "fields": [
+        "server_id",
+        "release_epoch",
+        "sequence",
+        "selection_digest",
+        "stable",
+        "preview"
+      ],
+      "noPublication": "stable=null and preview=null is the desired baseline",
+      "preview": "Target|null",
+      "selectionDigest": "sha256(canonical UTF-8 JSON {server_id,stable_target_key,preview_target_key}; null keys are present)",
+      "sequenceSemantics": "audit-only; clients never order or choose by sequence/time/semver",
+      "stable": "Target|null"
+    },
+    "schemas": {
+      "BuilderIdentity": {
+        "additionalProperties": false,
+        "properties": {
+          "build_script_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Build Script Digest",
+            "type": "string"
+          },
+          "node_version": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "pattern": "^\\S+$",
+            "title": "Node Version",
+            "type": "string"
+          },
+          "npm_version": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "pattern": "^\\S+$",
+            "title": "Npm Version",
+            "type": "string"
+          },
+          "package_lock_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Package Lock Digest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "node_version",
+          "npm_version",
+          "package_lock_digest",
+          "build_script_digest"
+        ],
+        "title": "BuilderIdentityWire",
+        "type": "object"
+      },
+      "DirtyProvenance": {
+        "additionalProperties": false,
+        "properties": {
+          "base_commit": {
+            "maxLength": 40,
+            "minLength": 40,
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Base Commit",
+            "type": "string"
+          },
+          "tracked_patch_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Tracked Patch Digest",
+            "type": "string"
+          },
+          "untracked_tree_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Untracked Tree Digest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base_commit",
+          "tracked_patch_digest",
+          "untracked_tree_digest"
+        ],
+        "title": "DirtyProvenanceWire",
+        "type": "object"
+      },
+      "ErrorReply": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "enum": [
+              "capability_required",
+              "invalid_range",
+              "invalid_ticket",
+              "range_precondition_failed",
+              "release_store_corrupt",
+              "resource_not_found",
+              "rollback_unavailable",
+              "target_changed",
+              "target_not_found"
+            ],
+            "title": "Code",
+            "type": "string"
+          },
+          "message": {
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "ErrorReplyWire",
+        "type": "object"
+      },
+      "HttpErrorBody": {
+        "$defs": {
+          "ErrorReplyWire": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "enum": [
+                  "capability_required",
+                  "invalid_range",
+                  "invalid_ticket",
+                  "range_precondition_failed",
+                  "release_store_corrupt",
+                  "resource_not_found",
+                  "rollback_unavailable",
+                  "target_changed",
+                  "target_not_found"
+                ],
+                "title": "Code",
+                "type": "string"
+              },
+              "message": {
+                "maxLength": 512,
+                "minLength": 1,
+                "title": "Message",
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "title": "ErrorReplyWire",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "$ref": "#/$defs/ErrorReplyWire"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "HttpErrorBodyWire",
+        "type": "object"
+      },
+      "Manifest": {
+        "$defs": {
+          "BuilderIdentityWire": {
+            "additionalProperties": false,
+            "properties": {
+              "build_script_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Build Script Digest",
+                "type": "string"
+              },
+              "node_version": {
+                "maxLength": 2048,
+                "minLength": 1,
+                "pattern": "^\\S+$",
+                "title": "Node Version",
+                "type": "string"
+              },
+              "npm_version": {
+                "maxLength": 2048,
+                "minLength": 1,
+                "pattern": "^\\S+$",
+                "title": "Npm Version",
+                "type": "string"
+              },
+              "package_lock_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Package Lock Digest",
+                "type": "string"
+              }
+            },
+            "required": [
+              "node_version",
+              "npm_version",
+              "package_lock_digest",
+              "build_script_digest"
+            ],
+            "title": "BuilderIdentityWire",
+            "type": "object"
+          },
+          "DirtyProvenanceWire": {
+            "additionalProperties": false,
+            "properties": {
+              "base_commit": {
+                "maxLength": 40,
+                "minLength": 40,
+                "pattern": "^[0-9a-f]{40}$",
+                "title": "Base Commit",
+                "type": "string"
+              },
+              "tracked_patch_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Tracked Patch Digest",
+                "type": "string"
+              },
+              "untracked_tree_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Untracked Tree Digest",
+                "type": "string"
+              }
+            },
+            "required": [
+              "base_commit",
+              "tracked_patch_digest",
+              "untracked_tree_digest"
+            ],
+            "title": "DirtyProvenanceWire",
+            "type": "object"
+          },
+          "WebUiFileWire": {
+            "additionalProperties": false,
+            "properties": {
+              "mime": {
+                "enum": [
+                  "application/font-woff",
+                  "application/font-woff2",
+                  "application/javascript",
+                  "application/json",
+                  "application/octet-stream",
+                  "application/wasm",
+                  "font/otf",
+                  "font/ttf",
+                  "font/woff",
+                  "font/woff2",
+                  "image/avif",
+                  "image/gif",
+                  "image/jpeg",
+                  "image/png",
+                  "image/svg+xml",
+                  "image/webp",
+                  "text/css",
+                  "text/html",
+                  "text/javascript",
+                  "text/plain",
+                  "video/mp4",
+                  "audio/mpeg",
+                  "audio/ogg",
+                  "audio/wav"
+                ],
+                "title": "Mime",
+                "type": "string"
+              },
+              "path": {
+                "maxLength": 512,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9._-]{1,128}(?:/[A-Za-z0-9._-]{1,128})*$",
+                "title": "Path",
+                "type": "string"
+              },
+              "sha256": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Sha256",
+                "type": "string"
+              },
+              "size_bytes": {
+                "maximum": 8388608,
+                "minimum": 0,
+                "title": "Size Bytes",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "path",
+              "sha256",
+              "size_bytes",
+              "mime"
+            ],
+            "title": "WebUiFileWire",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "bridge_protocol_max": {
+            "minimum": 1,
+            "title": "Bridge Protocol Max",
+            "type": "integer"
+          },
+          "bridge_protocol_min": {
+            "minimum": 1,
+            "title": "Bridge Protocol Min",
+            "type": "integer"
+          },
+          "build_context_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Build Context Digest",
+            "type": "string"
+          },
+          "builder_identity": {
+            "$ref": "#/$defs/BuilderIdentityWire"
+          },
+          "dirty_provenance": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/DirtyProvenanceWire"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "entrypoint": {
+            "const": "mobile.html",
+            "title": "Entrypoint",
+            "type": "string"
+          },
+          "file_count": {
+            "maximum": 2048,
+            "minimum": 1,
+            "title": "File Count",
+            "type": "integer"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/$defs/WebUiFileWire"
+            },
+            "maxItems": 2048,
+            "minItems": 1,
+            "title": "Files",
+            "type": "array"
+          },
+          "generation_id": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Generation Id",
+            "type": "string"
+          },
+          "input_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Input Digest",
+            "type": "string"
+          },
+          "minimum_native_build": {
+            "minimum": 1,
+            "title": "Minimum Native Build",
+            "type": "integer"
+          },
+          "platforms": {
+            "items": {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._-]{1,64}$",
+              "type": "string"
+            },
+            "maxItems": 64,
+            "minItems": 1,
+            "title": "Platforms",
+            "type": "array"
+          },
+          "reproducible": {
+            "title": "Reproducible",
+            "type": "boolean"
+          },
+          "schema_version": {
+            "const": 2,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "snapshot_protocol_max": {
+            "minimum": 1,
+            "title": "Snapshot Protocol Max",
+            "type": "integer"
+          },
+          "snapshot_protocol_min": {
+            "minimum": 1,
+            "title": "Snapshot Protocol Min",
+            "type": "integer"
+          },
+          "source_commit": {
+            "maxLength": 40,
+            "minLength": 40,
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Source Commit",
+            "type": "string"
+          },
+          "source_repository": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "pattern": "^\\S+$",
+            "title": "Source Repository",
+            "type": "string"
+          },
+          "source_tree": {
+            "maxLength": 40,
+            "minLength": 40,
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Source Tree",
+            "type": "string"
+          },
+          "unpacked_size_bytes": {
+            "maximum": 67108864,
+            "minimum": 0,
+            "title": "Unpacked Size Bytes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "schema_version",
+          "generation_id",
+          "entrypoint",
+          "files",
+          "bridge_protocol_min",
+          "bridge_protocol_max",
+          "snapshot_protocol_min",
+          "snapshot_protocol_max",
+          "minimum_native_build",
+          "platforms",
+          "source_repository",
+          "source_commit",
+          "source_tree",
+          "input_digest",
+          "build_context_digest",
+          "dirty_provenance",
+          "reproducible",
+          "builder_identity",
+          "unpacked_size_bytes",
+          "file_count"
+        ],
+        "title": "WebUiManifestWire",
+        "type": "object"
+      },
+      "ManifestFile": {
+        "additionalProperties": false,
+        "properties": {
+          "mime": {
+            "enum": [
+              "application/font-woff",
+              "application/font-woff2",
+              "application/javascript",
+              "application/json",
+              "application/octet-stream",
+              "application/wasm",
+              "font/otf",
+              "font/ttf",
+              "font/woff",
+              "font/woff2",
+              "image/avif",
+              "image/gif",
+              "image/jpeg",
+              "image/png",
+              "image/svg+xml",
+              "image/webp",
+              "text/css",
+              "text/html",
+              "text/javascript",
+              "text/plain",
+              "video/mp4",
+              "audio/mpeg",
+              "audio/ogg",
+              "audio/wav"
+            ],
+            "title": "Mime",
+            "type": "string"
+          },
+          "path": {
+            "maxLength": 512,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._-]{1,128}(?:/[A-Za-z0-9._-]{1,128})*$",
+            "title": "Path",
+            "type": "string"
+          },
+          "sha256": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          },
+          "size_bytes": {
+            "maximum": 8388608,
+            "minimum": 0,
+            "title": "Size Bytes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "path",
+          "sha256",
+          "size_bytes",
+          "mime"
+        ],
+        "title": "WebUiFileWire",
+        "type": "object"
+      },
+      "PrepareReply": {
+        "additionalProperties": false,
+        "properties": {
+          "expires_at": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Expires At",
+            "type": "string"
+          },
+          "manifest_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Manifest Digest",
+            "type": "string"
+          },
+          "target_key": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Target Key",
+            "type": "string"
+          },
+          "ticket": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Ticket",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_key",
+          "manifest_digest",
+          "ticket",
+          "expires_at"
+        ],
+        "title": "PrepareReplyWire",
+        "type": "object"
+      },
+      "ReleaseView": {
+        "$defs": {
+          "WebUiTargetWire": {
+            "additionalProperties": false,
+            "properties": {
+              "bridge_protocol_max": {
+                "minimum": 1,
+                "title": "Bridge Protocol Max",
+                "type": "integer"
+              },
+              "bridge_protocol_min": {
+                "minimum": 1,
+                "title": "Bridge Protocol Min",
+                "type": "integer"
+              },
+              "generation_id": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Generation Id",
+                "type": "string"
+              },
+              "manifest_digest": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Manifest Digest",
+                "type": "string"
+              },
+              "manifest_size_bytes": {
+                "maximum": 1048576,
+                "minimum": 1,
+                "title": "Manifest Size Bytes",
+                "type": "integer"
+              },
+              "minimum_native_build": {
+                "minimum": 1,
+                "title": "Minimum Native Build",
+                "type": "integer"
+              },
+              "platforms": {
+                "items": {
+                  "maxLength": 64,
+                  "minLength": 1,
+                  "pattern": "^[A-Za-z0-9._-]{1,64}$",
+                  "type": "string"
+                },
+                "maxItems": 64,
+                "minItems": 1,
+                "title": "Platforms",
+                "type": "array"
+              },
+              "snapshot_protocol_max": {
+                "minimum": 1,
+                "title": "Snapshot Protocol Max",
+                "type": "integer"
+              },
+              "snapshot_protocol_min": {
+                "minimum": 1,
+                "title": "Snapshot Protocol Min",
+                "type": "integer"
+              },
+              "target_key": {
+                "maxLength": 64,
+                "minLength": 64,
+                "pattern": "^[0-9a-f]{64}$",
+                "title": "Target Key",
+                "type": "string"
+              }
+            },
+            "required": [
+              "target_key",
+              "generation_id",
+              "manifest_digest",
+              "manifest_size_bytes",
+              "bridge_protocol_min",
+              "bridge_protocol_max",
+              "snapshot_protocol_min",
+              "snapshot_protocol_max",
+              "minimum_native_build",
+              "platforms"
+            ],
+            "title": "WebUiTargetWire",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "preview": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/WebUiTargetWire"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "release_epoch": {
+            "maxLength": 36,
+            "minLength": 36,
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            "title": "Release Epoch",
+            "type": "string"
+          },
+          "selection_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Selection Digest",
+            "type": "string"
+          },
+          "sequence": {
+            "minimum": 0,
+            "title": "Sequence",
+            "type": "integer"
+          },
+          "server_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Server Id",
+            "type": "string"
+          },
+          "stable": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/WebUiTargetWire"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "server_id",
+          "release_epoch",
+          "sequence",
+          "selection_digest",
+          "stable",
+          "preview"
+        ],
+        "title": "ReleaseViewWire",
+        "type": "object"
+      },
+      "Target": {
+        "additionalProperties": false,
+        "properties": {
+          "bridge_protocol_max": {
+            "minimum": 1,
+            "title": "Bridge Protocol Max",
+            "type": "integer"
+          },
+          "bridge_protocol_min": {
+            "minimum": 1,
+            "title": "Bridge Protocol Min",
+            "type": "integer"
+          },
+          "generation_id": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Generation Id",
+            "type": "string"
+          },
+          "manifest_digest": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Manifest Digest",
+            "type": "string"
+          },
+          "manifest_size_bytes": {
+            "maximum": 1048576,
+            "minimum": 1,
+            "title": "Manifest Size Bytes",
+            "type": "integer"
+          },
+          "minimum_native_build": {
+            "minimum": 1,
+            "title": "Minimum Native Build",
+            "type": "integer"
+          },
+          "platforms": {
+            "items": {
+              "maxLength": 64,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9._-]{1,64}$",
+              "type": "string"
+            },
+            "maxItems": 64,
+            "minItems": 1,
+            "title": "Platforms",
+            "type": "array"
+          },
+          "snapshot_protocol_max": {
+            "minimum": 1,
+            "title": "Snapshot Protocol Max",
+            "type": "integer"
+          },
+          "snapshot_protocol_min": {
+            "minimum": 1,
+            "title": "Snapshot Protocol Min",
+            "type": "integer"
+          },
+          "target_key": {
+            "maxLength": 64,
+            "minLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Target Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_key",
+          "generation_id",
+          "manifest_digest",
+          "manifest_size_bytes",
+          "bridge_protocol_min",
+          "bridge_protocol_max",
+          "snapshot_protocol_min",
+          "snapshot_protocol_max",
+          "minimum_native_build",
+          "platforms"
+        ],
+        "title": "WebUiTargetWire",
+        "type": "object"
+      }
+    },
+    "target": {
+      "fields": [
+        "target_key",
+        "generation_id",
+        "manifest_digest",
+        "manifest_size_bytes",
+        "bridge_protocol_min",
+        "bridge_protocol_max",
+        "snapshot_protocol_min",
+        "snapshot_protocol_max",
+        "minimum_native_build",
+        "platforms"
+      ],
+      "targetKey": "sha256(canonical UTF-8 JSON {server_id,generation_id,manifest_digest})"
+    },
+    "ticket": {
+      "audience": "mobile-webui-v1",
+      "claims": [
+        "aud",
+        "v",
+        "server_id",
+        "device_id",
+        "connection_epoch",
+        "target_key",
+        "generation_id",
+        "manifest_digest",
+        "selection_digest",
+        "release_epoch",
+        "iat",
+        "exp"
+      ],
+      "recheck": "signature, server/device/revoke, connection_epoch, release_epoch, selection_digest and target membership on every HTTP request",
+      "scope": "one target manifest plus all blobs listed by that target manifest",
+      "ttlSeconds": 300
+    }
+  },
   "preAuthControlTypes": [
     "device.proof",
     "pair.accepted",

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -60,6 +60,7 @@
   "controlTypes": [
     "auth.accepted",
     "device.proof",
+    "device.revoked",
     "mobile.webui.release.changed",
     "pair.accepted",
     "pair.claim",
@@ -742,6 +743,7 @@
               "pair.claim",
               "pair.pending",
               "pair.accepted",
+              "device.revoked",
               "protocol.error"
             ],
             "title": "Type",
@@ -1803,6 +1805,7 @@
             "mapping": {
               "auth.accepted": "#/$defs/AuthAcceptedControl",
               "device.proof": "#/$defs/GenericControl",
+              "device.revoked": "#/$defs/GenericControl",
               "mobile.webui.release.changed": "#/$defs/MobileWebUiReleaseChangedControl",
               "pair.accepted": "#/$defs/GenericControl",
               "pair.claim": "#/$defs/GenericControl",
@@ -1984,6 +1987,7 @@
           "mapping": {
             "auth.accepted": "#/$defs/AuthAcceptedControl",
             "device.proof": "#/$defs/GenericControl",
+            "device.revoked": "#/$defs/GenericControl",
             "mobile.webui.release.changed": "#/$defs/MobileWebUiReleaseChangedControl",
             "pair.accepted": "#/$defs/GenericControl",
             "pair.claim": "#/$defs/GenericControl",
@@ -2341,9 +2345,6 @@
             "properties": {
               "mime": {
                 "enum": [
-                  "application/font-woff",
-                  "application/font-woff2",
-                  "application/javascript",
                   "application/json",
                   "application/octet-stream",
                   "application/wasm",
@@ -2560,9 +2561,6 @@
         "properties": {
           "mime": {
             "enum": [
-              "application/font-woff",
-              "application/font-woff2",
-              "application/javascript",
               "application/json",
               "application/octet-stream",
               "application/wasm",

--- a/scripts/generate_mobile_realtime_schema.py
+++ b/scripts/generate_mobile_realtime_schema.py
@@ -19,6 +19,18 @@ from infra.mobile_realtime.protocol import (
     PROTOCOL_VERSION,
 )
 from infra.mobile_realtime.attachments import MAX_ATTACHMENT_CHUNK_BYTES
+from infra.mobile_webui.protocol import (
+    BuilderIdentityWire,
+    DirtyProvenanceWire,
+    ErrorReplyWire,
+    HttpErrorBodyWire,
+    PrepareReplyWire,
+    ReleaseViewWire,
+    WebUiFileWire,
+    WebUiManifestWire,
+    WebUiTargetWire,
+)
+from pydantic import TypeAdapter
 
 
 OUTPUT = ROOT / "schema" / "mobile-realtime-v1.json"
@@ -60,6 +72,102 @@ def build_schema() -> dict[str, object]:
         "eventTypes": sorted(EVENT_TYPES),
         "controlTypes": sorted(CONTROL_TYPES),
         "preAuthControlTypes": sorted(PRE_AUTH_CONTROL_TYPES),
+        "mobileWebUi": {
+            "capability": "mobile-webui-ota-v1",
+            "commandTypes": [
+                "mobile.webui.release.get",
+                "mobile.webui.content.prepare",
+            ],
+            "controlType": "mobile.webui.release.changed",
+            "contentPrepareReply": {
+                "type": "mobile.webui.content.prepare.ok",
+                "fields": ["target_key", "manifest_digest", "ticket", "expires_at"],
+                "paths": {
+                    "manifest": "/mobile/webui/v1/manifest/{manifest_digest}",
+                    "blob": "/mobile/webui/v1/blob/{blob_digest}",
+                },
+            },
+            "schemas": {
+                "ReleaseView": TypeAdapter(ReleaseViewWire).json_schema(),
+                "Target": TypeAdapter(WebUiTargetWire).json_schema(),
+                "Manifest": TypeAdapter(WebUiManifestWire).json_schema(),
+                "ManifestFile": TypeAdapter(WebUiFileWire).json_schema(),
+                "DirtyProvenance": TypeAdapter(DirtyProvenanceWire).json_schema(),
+                "BuilderIdentity": TypeAdapter(BuilderIdentityWire).json_schema(),
+                "PrepareReply": TypeAdapter(PrepareReplyWire).json_schema(),
+                "ErrorReply": TypeAdapter(ErrorReplyWire).json_schema(),
+                "HttpErrorBody": TypeAdapter(HttpErrorBodyWire).json_schema(),
+            },
+            "releaseView": {
+                "fields": [
+                    "server_id", "release_epoch", "sequence", "selection_digest",
+                    "stable", "preview",
+                ],
+                "stable": "Target|null",
+                "preview": "Target|null",
+                "selectionDigest": "sha256(canonical UTF-8 JSON {server_id,stable_target_key,preview_target_key}; null keys are present)",
+                "sequenceSemantics": "audit-only; clients never order or choose by sequence/time/semver",
+                "noPublication": "stable=null and preview=null is the desired baseline",
+            },
+            "target": {
+                "fields": [
+                    "target_key", "generation_id", "manifest_digest", "manifest_size_bytes",
+                    "bridge_protocol_min", "bridge_protocol_max", "snapshot_protocol_min",
+                    "snapshot_protocol_max", "minimum_native_build", "platforms",
+                ],
+                "targetKey": "sha256(canonical UTF-8 JSON {server_id,generation_id,manifest_digest})",
+            },
+            "manifest": {
+                "schemaVersion": 2,
+                "fields": [
+                    "schema_version", "generation_id", "entrypoint", "files",
+                    "bridge_protocol_min", "bridge_protocol_max", "snapshot_protocol_min",
+                    "snapshot_protocol_max", "minimum_native_build", "platforms",
+                    "source_repository", "source_commit", "source_tree", "input_digest",
+                    "build_context_digest", "dirty_provenance", "reproducible",
+                    "builder_identity", "unpacked_size_bytes", "file_count",
+                ],
+                "generationId": "sha256(canonical complete manifest with generation_id omitted)",
+                "manifestDigest": "sha256(canonical complete manifest)",
+                "canonical": "UTF-8 JSON, sorted object keys, no insignificant whitespace, NFC paths, files/platforms UTF-8 order; duplicate/unknown fields rejected",
+                "limits": {
+                    "manifestBytes": 1048576,
+                    "files": 2048,
+                    "fileBytes": 8388608,
+                    "unpackedBytes": 67108864,
+                },
+                "provenance": {
+                    "dirty_provenance": "null or {base_commit,tracked_patch_digest,untracked_tree_digest}",
+                    "builder_identity": "{node_version,npm_version,package_lock_digest,build_script_digest}",
+                    "stable": "reproducible=true and dirty_provenance=null",
+                },
+            },
+            "ticket": {
+                "audience": "mobile-webui-v1",
+                "ttlSeconds": 300,
+                "claims": [
+                    "aud", "v", "server_id", "device_id", "connection_epoch", "target_key",
+                    "generation_id", "manifest_digest", "selection_digest", "release_epoch", "iat", "exp",
+                ],
+                "scope": "one target manifest plus all blobs listed by that target manifest",
+                "recheck": "signature, server/device/revoke, connection_epoch, release_epoch, selection_digest and target membership on every HTTP request",
+            },
+            "http": {
+                "manifest": "/mobile/webui/v1/manifest/{manifest_digest}",
+                "blob": "/mobile/webui/v1/blob/{blob_digest}",
+                "manifestCacheControl": "no-store",
+                "blobCacheControl": "immutable",
+                "range": "one bytes range, response <= 8388608 bytes",
+                "statuses": {
+                    "invalid_ticket": 401,
+                    "target_changed": 409,
+                    "resource_not_found": 404,
+                    "invalid_range": 416,
+                    "range_precondition_failed": 412,
+                    "release_store_corrupt": 500,
+                },
+            },
+        },
         "frame": FRAME_ADAPTER.json_schema(),
     }
 

--- a/scripts/publish-mobile-webui.py
+++ b/scripts/publish-mobile-webui.py
@@ -49,22 +49,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.action == "publish":
             build_dir = args.build_dir
             temporary: Path | None = None
-            if build_dir is None:
-                temporary = Path(tempfile.mkdtemp(prefix="mobile-webui-build-", dir=workspace if workspace is not None else None))
-                build_dir = _build(
-                    source_repository,
-                    temporary,
-                    allow_dirty=args.allow_dirty,
-                    source_commit=args.source_commit,
-                    stable=args.stable,
-                )
+            temporary_sidecar: Path | None = None
             try:
+                if build_dir is None:
+                    temporary = Path(tempfile.mkdtemp(prefix="mobile-webui-build-", dir=workspace if workspace is not None else None))
+                    temporary_sidecar = temporary.with_name(temporary.name + ".provenance.json")
+                    build_dir = _build(
+                        source_repository,
+                        temporary,
+                        allow_dirty=args.allow_dirty,
+                        source_commit=args.source_commit,
+                        stable=args.stable,
+                    )
                 manifest, contents = _manifest(source_repository, build_dir, allow_dirty=args.allow_dirty)
                 release = store.publish(manifest, contents, stable=args.stable, preview=not args.stable, actor=args.actor)
                 print(json.dumps(_release_json(release), ensure_ascii=False, sort_keys=True))
             finally:
-                if temporary is not None:
-                    shutil.rmtree(temporary, ignore_errors=True)
+                try:
+                    if temporary_sidecar is not None:
+                        _remove_owned_temporary_file(temporary_sidecar)
+                finally:
+                    if temporary is not None:
+                        shutil.rmtree(temporary, ignore_errors=True)
             return 0
         if args.action == "promote-preview":
             print(json.dumps(_release_json(store.promote_preview(actor=args.actor)), ensure_ascii=False, sort_keys=True))
@@ -171,20 +177,9 @@ def _build(
             output_dir=output,
         )
         if lock_available:
-            subprocess.run(
-                ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
-                cwd=build_workspace,
-                env=environment,
-                check=True,
-            )
+            _run_build(build_workspace, environment=environment, lock_available=True)
         else:
-            subprocess.run(
-                ["npm", "install", "--package-lock=false", "--ignore-scripts", "--no-audit", "--no-fund"],
-                cwd=build_workspace,
-                env=environment,
-                check=True,
-            )
-        subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=environment, check=True)
+            _run_build(build_workspace, environment=environment, lock_available=False)
         after = _capture_provenance(
             build_workspace,
             environment=environment,
@@ -240,9 +235,13 @@ def _manifest(workspace: Path, build_dir: Path, *, allow_dirty: bool):
         raise RuntimeError("无 package-lock 的构建不能作为 Stable/reproducible manifest")
     if dirty is None:
         expected_provenance = {key: sidecar[key] for key in _build_provenance_keys()}
-        with _build_source(workspace, commit, dirty=False) as snapshot:
-            if _capture_provenance(snapshot, environment=environment, output_dir=build_dir) != expected_provenance:
-                raise RuntimeError("clean build provenance 未通过 commit snapshot 重算")
+        _verify_clean_reproducibility(
+            workspace,
+            commit,
+            build_dir,
+            expected_provenance=expected_provenance,
+            expected_artifact_digest=str(sidecar["artifact_digest"]),
+        )
     return manifest_from_directory(
         build_dir,
         source_repository=sidecar["source_repository"],
@@ -259,6 +258,75 @@ def _manifest(workspace: Path, build_dir: Path, *, allow_dirty: bool):
 def _require_clean_source(workspace: Path, *, allow_dirty: bool) -> None:
     if _webui_dirty(workspace) and not allow_dirty:
         raise RuntimeError("WebUI/build inputs require clean source；Preview 可用 --allow-dirty")
+
+
+def _remove_owned_temporary_file(path: Path) -> None:
+    """Remove only the exact provenance sidecar owned by an internal build."""
+
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise RuntimeError(f"内部 build sidecar 不是普通文件: {path}")
+    if path.exists():
+        path.unlink()
+
+
+def _run_build(
+    build_workspace: Path,
+    *,
+    environment: Mapping[str, str],
+    lock_available: bool,
+) -> None:
+    """Install the pinned dependency graph and emit one isolated WebUI artifact tree."""
+
+    # 1. Recreate dependencies from the declared lock policy.
+    if lock_available:
+        subprocess.run(
+            ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
+            cwd=build_workspace,
+            env=dict(environment),
+            check=True,
+        )
+    else:
+        subprocess.run(
+            ["npm", "install", "--package-lock=false", "--ignore-scripts", "--no-audit", "--no-fund"],
+            cwd=build_workspace,
+            env=dict(environment),
+            check=True,
+        )
+    # 2. Build only into the caller-owned output directory.
+    subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=dict(environment), check=True)
+
+
+def _verify_clean_reproducibility(
+    workspace: Path,
+    commit: str,
+    build_dir: Path,
+    *,
+    expected_provenance: Mapping[str, object],
+    expected_artifact_digest: str,
+) -> None:
+    """Rebuild clean input in a fresh worktree and reject any artifact drift."""
+
+    if not _commit_has_file(workspace, commit, "package-lock.json"):
+        raise RuntimeError("clean reproducible build 要求指定 commit 自带 package-lock.json")
+    candidate = Path(tempfile.mkdtemp(prefix="mobile-webui-repro-", dir=build_dir.parent))
+    try:
+        with _build_source(workspace, commit, dirty=False) as snapshot:
+            environment = _build_environment(candidate)
+            before = _capture_provenance(snapshot, environment=environment, output_dir=candidate)
+            if before != dict(expected_provenance):
+                raise RuntimeError("clean build provenance 未通过 commit snapshot 重算")
+            _run_build(snapshot, environment=environment, lock_available=True)
+            after = _capture_provenance(snapshot, environment=environment, output_dir=candidate)
+            if before != after:
+                raise RuntimeError("可复现校验期间 source/input/build_context 发生变化")
+        actual_artifact_digest = _artifact_digest(candidate)
+        if actual_artifact_digest != expected_artifact_digest:
+            raise RuntimeError(
+                "clean build artifact 不可复现: "
+                f"expected={expected_artifact_digest} actual={actual_artifact_digest}"
+            )
+    finally:
+        shutil.rmtree(candidate, ignore_errors=True)
 
 
 def _webui_dirty(workspace: Path) -> bool:

--- a/scripts/publish-mobile-webui.py
+++ b/scripts/publish-mobile-webui.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -14,7 +15,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -163,9 +164,12 @@ def _build(
         raise FileExistsError(f"build output 非空: {output}")
     output.mkdir(parents=True, exist_ok=True)
     with _build_source(workspace, commit, dirty=dirty) as build_workspace:
-        before = _capture_provenance(build_workspace)
-        environment = os.environ.copy()
-        environment["AKASHIC_MOBILE_WEB_OUT_DIR"] = str(output)
+        environment = _build_environment(output)
+        before = _capture_provenance(
+            build_workspace,
+            environment=environment,
+            output_dir=output,
+        )
         if lock_available:
             subprocess.run(
                 ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
@@ -181,7 +185,11 @@ def _build(
                 check=True,
             )
         subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=environment, check=True)
-        after = _capture_provenance(build_workspace)
+        after = _capture_provenance(
+            build_workspace,
+            environment=environment,
+            output_dir=output,
+        )
         if before != after:
             raise RuntimeError("构建期间 source/input/build_context 发生变化")
     sidecar = output.with_name(output.name + ".provenance.json")
@@ -212,18 +220,28 @@ def _manifest(workspace: Path, build_dir: Path, *, allow_dirty: bool):
         raise RuntimeError("build-dir provenance 的 source tree 不存在或不匹配")
     current_head = _git(workspace, "rev-parse", "HEAD")
     dirty = sidecar["dirty_provenance"]
+    environment = _build_environment(build_dir)
     if dirty is not None:
-        if current_head != commit or _capture_provenance(workspace)["input_digest"] != sidecar["input_digest"] or _dirty_provenance(workspace) != dirty:
+        current_provenance = _capture_provenance(workspace, environment=environment, output_dir=build_dir)
+        if (
+            current_head != commit
+            or current_provenance["input_digest"] != sidecar["input_digest"]
+            or current_provenance["build_context_digest"] != sidecar["build_context_digest"]
+            or _dirty_provenance(workspace) != dirty
+        ):
             raise RuntimeError("dirty build provenance 与当前 source 不匹配")
-    elif current_head == commit and _capture_provenance(workspace) != {key: sidecar[key] for key in _build_provenance_keys()}:
-        raise RuntimeError("build-dir provenance 与当前 clean source 不匹配")
+    elif current_head == commit:
+        expected_provenance = {key: sidecar[key] for key in _build_provenance_keys()}
+        if _capture_provenance(workspace, environment=environment, output_dir=build_dir) != expected_provenance:
+            raise RuntimeError("build-dir provenance 与当前 clean source 不匹配")
     if dirty is not None and not allow_dirty:
         raise RuntimeError("publish 默认拒绝 dirty source；Preview 请显式 --allow-dirty")
     if dirty is None and sidecar["builder_identity"]["package_lock_digest"] == _no_lock_digest():
         raise RuntimeError("无 package-lock 的构建不能作为 Stable/reproducible manifest")
     if dirty is None:
+        expected_provenance = {key: sidecar[key] for key in _build_provenance_keys()}
         with _build_source(workspace, commit, dirty=False) as snapshot:
-            if _capture_provenance(snapshot) != {key: sidecar[key] for key in _build_provenance_keys()}:
+            if _capture_provenance(snapshot, environment=environment, output_dir=build_dir) != expected_provenance:
                 raise RuntimeError("clean build provenance 未通过 commit snapshot 重算")
     return manifest_from_directory(
         build_dir,
@@ -300,20 +318,51 @@ def _commit_has_file(workspace: Path, commit: str, path: str) -> bool:
     return result.returncode == 0
 
 
-def _capture_provenance(workspace: Path) -> dict[str, object]:
+def _capture_provenance(
+    workspace: Path,
+    *,
+    environment: Mapping[str, str] | None = None,
+    output_dir: Path | None = None,
+) -> dict[str, object]:
     """Capture all source/build identity inputs before and after a build."""
 
+    effective_environment = dict(os.environ if environment is None else environment)
     package_lock = workspace / "package-lock.json"
     package_lock_digest = _sha256(package_lock.read_bytes()) if package_lock.is_file() else _no_lock_digest()
     build_script = workspace / "scripts" / "package-mobile-web.sh"
     script_digest = _sha256(build_script.read_bytes())
-    node_version = _run_version("node", "--version")
-    npm_version = _run_version("npm", "--version")
+    node_identity = _executable_identity("node", effective_environment)
+    npm_identity = _executable_identity("npm", effective_environment)
+    node_version = _run_version(node_identity["path"], "--version", environment=effective_environment, cwd=workspace)
+    npm_version = _run_version(npm_identity["path"], "--version", environment=effective_environment, cwd=workspace)
+    npm_config = _npm_config_snapshot(
+        npm_identity["path"],
+        workspace,
+        environment=effective_environment,
+        output_dir=output_dir,
+    )
     context = {
-        "node": node_version,
-        "npm": npm_version,
+        "os": {
+            "name": os.name,
+            "platform": sys.platform,
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "executables": {
+            "node": node_identity,
+            "npm": npm_identity,
+        },
+        "environment": _effective_build_environment(
+            effective_environment,
+            workspace=workspace,
+            output_dir=output_dir,
+        ),
+        "npm_config": npm_config,
         "package_lock": package_lock_digest,
         "script": script_digest,
+        "node_version": node_version,
+        "npm_version": npm_version,
     }
     return {
         "source_repository": _repository_url(workspace),
@@ -457,8 +506,151 @@ def _git(workspace: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _run_version(command: str, flag: str) -> str:
-    return subprocess.run([command, flag], check=True, capture_output=True, text=True).stdout.strip()
+def _run_version(
+    command: str,
+    flag: str,
+    *,
+    environment: Mapping[str, str],
+    cwd: Path,
+) -> str:
+    return subprocess.run(
+        [command, flag],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=dict(environment),
+        cwd=cwd,
+    ).stdout.strip()
+
+
+def _executable_identity(command: str, environment: Mapping[str, str]) -> dict[str, object]:
+    path = shutil.which(command, path=environment.get("PATH"))
+    if path is None:
+        raise RuntimeError(f"构建工具不可解析: {command}")
+    resolved = Path(path).resolve()
+    data = _read_regular_input(resolved)
+    return {
+        "path": str(resolved),
+        "sha256": _sha256(data),
+        "size_bytes": len(data),
+    }
+
+
+_BUILD_ENV_EXACT = frozenset(
+    {
+        "ALL_PROXY",
+        "CI",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LOGNAME",
+        "NO_PROXY",
+        "PATH",
+        "PWD",
+        "SOURCE_DATE_EPOCH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "TZ",
+        "USER",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+_BUILD_ENV_PREFIXES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "VITE_",
+    "NODE_",
+    "NPM_CONFIG_",
+    "npm_config_",
+)
+
+
+def _effective_build_environment(
+    environment: Mapping[str, str],
+    *,
+    workspace: Path,
+    output_dir: Path | None,
+) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for key in sorted(environment, key=lambda value: value.encode("utf-8")):
+        value = environment[key]
+        if key == "AKASHIC_MOBILE_WEB_OUT_DIR":
+            value = "<OUTPUT_DIR>"
+        value = _normalise_context_paths(value, workspace=workspace, output_dir=output_dir)
+        values[key] = value
+    return values
+
+
+def _normalise_context_paths(
+    value: Any,
+    *,
+    workspace: Path,
+    output_dir: Path | None,
+) -> Any:
+    if isinstance(value, str):
+        text = value
+        if output_dir is not None:
+            text = text.replace(str(output_dir.resolve()), "<OUTPUT_DIR>")
+        text = text.replace(str(workspace.resolve()), "<SOURCE_WORKSPACE>")
+        return text
+    if isinstance(value, list):
+        return [_normalise_context_paths(item, workspace=workspace, output_dir=output_dir) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _normalise_context_paths(item, workspace=workspace, output_dir=output_dir)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _npm_config_snapshot(
+    npm_path: str,
+    workspace: Path,
+    *,
+    environment: Mapping[str, str],
+    output_dir: Path | None = None,
+) -> dict[str, object]:
+    result = subprocess.run(
+        [npm_path, "config", "list", "--json"],
+        cwd=workspace,
+        env=dict(environment),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("npm config list --json 未返回 JSON") from error
+    if not isinstance(parsed, dict):
+        raise RuntimeError("npm config list --json 顶层必须是 object")
+    normalised = _normalise_context_paths(parsed, workspace=workspace, output_dir=output_dir)
+    if not isinstance(normalised, dict):
+        raise AssertionError("npm config snapshot normalise 类型改变")
+    return normalised
+
+
+def _build_environment(output_dir: Path) -> dict[str, str]:
+    """Return the controlled environment shared by build and provenance revalidation."""
+
+    inherited = os.environ
+    environment = {
+        key: value
+        for key, value in inherited.items()
+        if key in _BUILD_ENV_EXACT or any(key.startswith(prefix) for prefix in _BUILD_ENV_PREFIXES)
+    }
+    if "PATH" not in environment:
+        raise RuntimeError("构建环境缺少 PATH")
+    environment["AKASHIC_MOBILE_WEB_OUT_DIR"] = str(output_dir.resolve())
+    return environment
 
 
 def _sha256(data: bytes) -> str:

--- a/scripts/publish-mobile-webui.py
+++ b/scripts/publish-mobile-webui.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Build, publish and inspect the server-owned mobile WebUI release store."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from infra.mobile_webui.manifest import manifest_from_directory
+from infra.mobile_webui.store import MobileWebUiStore
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    source_repository = args.source_repository.resolve()
+    workspace = args.workspace.resolve() if args.workspace is not None else None
+    if args.action == "build":
+        output = _build(source_repository, args.output, allow_dirty=args.allow_dirty, source_commit=args.source_commit, stable=False)
+        print(output)
+        return 0
+    if args.action == "restore":
+        if not args.server_id:
+            parser.error("restore 需要 --server-id")
+        if args.destination is None or args.restore_root is None:
+            parser.error("restore 需要 --destination 和 --restore-root")
+        restored = MobileWebUiStore.restore_backup(args.destination, args.restore_root, server_id=args.server_id)
+        print(restored)
+        return 0
+    if not args.server_id:
+        parser.error("publish/inspect/promote/clear-preview/gc/backup 需要 --server-id")
+    if workspace is None and args.store_root is None:
+        parser.error("有状态操作必须显式提供 --workspace 或 --store-root")
+    store = MobileWebUiStore(args.store_root or workspace / "mobile-webui", server_id=args.server_id)
+    try:
+        if args.action == "publish":
+            build_dir = args.build_dir
+            temporary: Path | None = None
+            if build_dir is None:
+                temporary = Path(tempfile.mkdtemp(prefix="mobile-webui-build-", dir=workspace if workspace is not None else None))
+                build_dir = _build(
+                    source_repository,
+                    temporary,
+                    allow_dirty=args.allow_dirty,
+                    source_commit=args.source_commit,
+                    stable=args.stable,
+                )
+            try:
+                manifest, contents = _manifest(source_repository, build_dir, allow_dirty=args.allow_dirty)
+                release = store.publish(manifest, contents, stable=args.stable, preview=not args.stable, actor=args.actor)
+                print(json.dumps(_release_json(release), ensure_ascii=False, sort_keys=True))
+            finally:
+                if temporary is not None:
+                    shutil.rmtree(temporary, ignore_errors=True)
+            return 0
+        if args.action == "promote-preview":
+            print(json.dumps(_release_json(store.promote_preview(actor=args.actor)), ensure_ascii=False, sort_keys=True))
+            return 0
+        if args.action == "rollback":
+            if not args.target_key:
+                parser.error("rollback 需要 --target-key")
+            print(json.dumps(_release_json(store.rollback(args.target_key, actor=args.actor)), ensure_ascii=False, sort_keys=True))
+            return 0
+        if args.action == "pin":
+            if not args.target_key:
+                parser.error("pin 需要 --target-key")
+            store.pin_target(args.target_key, reason=args.reason)
+            return 0
+        if args.action == "unpin":
+            if not args.target_key:
+                parser.error("unpin 需要 --target-key")
+            store.unpin_target(args.target_key)
+            return 0
+        if args.action == "clear-preview":
+            print(json.dumps(_release_json(store.clear_preview(actor=args.actor)), ensure_ascii=False, sort_keys=True))
+            return 0
+        if args.action == "inspect":
+            print(json.dumps(_release_json(store.get_release()), ensure_ascii=False, sort_keys=True))
+            return 0
+        if args.action == "gc":
+            report = store.gc(keep_unreachable=args.keep_unreachable)
+            print(json.dumps({"removed_generations": report.removed_generations, "removed_blobs": report.removed_blobs}, ensure_ascii=False, sort_keys=True))
+            return 0
+        if args.action == "backup":
+            if args.destination is None:
+                parser.error("backup 需要 --destination")
+            destination = store.backup_to(args.destination)
+            MobileWebUiStore.verify_backup(destination, server_id=args.server_id)
+            print(destination)
+            return 0
+        if args.action == "release-backup":
+            if not args.backup_id:
+                parser.error("release-backup 需要 --backup-id")
+            store.release_backup(args.backup_id)
+            return 0
+        raise AssertionError(f"unsupported action: {args.action}")
+    finally:
+        store.close()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("build", "publish", "inspect", "promote-preview", "clear-preview", "rollback", "pin", "unpin", "gc", "backup", "release-backup", "restore"))
+    parser.add_argument("--source-repository", type=Path, default=Path.cwd())
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--store-root", type=Path)
+    parser.add_argument("--server-id")
+    parser.add_argument("--build-dir", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--destination", type=Path)
+    parser.add_argument("--allow-dirty", action="store_true")
+    parser.add_argument("--source-commit", help="用于构建/发布的 40 位 commit；Stable 默认使用 HEAD")
+    parser.add_argument("--stable", action="store_true")
+    parser.add_argument("--keep-unreachable", type=int, default=0)
+    parser.add_argument("--target-key")
+    parser.add_argument("--reason", default="rollback")
+    parser.add_argument("--backup-id")
+    parser.add_argument("--restore-root", type=Path)
+    parser.add_argument("--actor", default="publish-mobile-webui")
+    return parser
+
+
+def _build(
+    workspace: Path,
+    output: Path | None,
+    *,
+    allow_dirty: bool,
+    source_commit: str | None,
+    stable: bool,
+) -> Path:
+    workspace = workspace.resolve()
+    if stable and allow_dirty:
+        raise RuntimeError("Stable 不允许 --allow-dirty")
+    commit = _resolve_commit(workspace, source_commit)
+    current_head = _git(workspace, "rev-parse", "HEAD")
+    if commit == current_head:
+        _require_clean_source(workspace, allow_dirty=allow_dirty)
+    dirty = commit == current_head and _webui_dirty(workspace)
+    if stable and dirty:
+        raise RuntimeError("Stable 构建输入存在 dirty provenance")
+    lock_available = _commit_has_file(workspace, commit, "package-lock.json")
+    if stable and not lock_available:
+        raise RuntimeError("Stable 要求指定 commit 自带 package-lock.json")
+    if not lock_available and not dirty:
+        raise RuntimeError("无 package-lock 的 clean 构建只能拒绝；请使用带 dirty provenance 的 Preview")
+    workspace.parent.mkdir(parents=True, exist_ok=True)
+    if output is None:
+        output = Path(tempfile.mkdtemp(prefix="mobile-webui-build-"))
+    output = output.resolve()
+    if output.exists() and any(output.iterdir()):
+        raise FileExistsError(f"build output 非空: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    with _build_source(workspace, commit, dirty=dirty) as build_workspace:
+        before = _capture_provenance(build_workspace)
+        environment = os.environ.copy()
+        environment["AKASHIC_MOBILE_WEB_OUT_DIR"] = str(output)
+        if lock_available:
+            subprocess.run(
+                ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
+                cwd=build_workspace,
+                env=environment,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                ["npm", "install", "--package-lock=false", "--ignore-scripts", "--no-audit", "--no-fund"],
+                cwd=build_workspace,
+                env=environment,
+                check=True,
+            )
+        subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=environment, check=True)
+        after = _capture_provenance(build_workspace)
+        if before != after:
+            raise RuntimeError("构建期间 source/input/build_context 发生变化")
+    sidecar = output.with_name(output.name + ".provenance.json")
+    sidecar.write_text(
+        json.dumps(
+            {
+                **before,
+                "artifact_digest": _artifact_digest(output),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+def _manifest(workspace: Path, build_dir: Path, *, allow_dirty: bool):
+    sidecar_path = build_dir.with_name(build_dir.name + ".provenance.json")
+    if not sidecar_path.is_file():
+        raise RuntimeError("外部 build-dir 必须带受控 build provenance sidecar")
+    sidecar = _load_sidecar(sidecar_path)
+    commit = sidecar["source_commit"]
+    tree = sidecar["source_tree"]
+    if sidecar["artifact_digest"] != _artifact_digest(build_dir):
+        raise RuntimeError("build-dir provenance 与 artifact 不匹配")
+    if _git(workspace, "rev-parse", f"{commit}^{{tree}}") != tree:
+        raise RuntimeError("build-dir provenance 的 source tree 不存在或不匹配")
+    current_head = _git(workspace, "rev-parse", "HEAD")
+    dirty = sidecar["dirty_provenance"]
+    if dirty is not None:
+        if current_head != commit or _capture_provenance(workspace)["input_digest"] != sidecar["input_digest"] or _dirty_provenance(workspace) != dirty:
+            raise RuntimeError("dirty build provenance 与当前 source 不匹配")
+    elif current_head == commit and _capture_provenance(workspace) != {key: sidecar[key] for key in _build_provenance_keys()}:
+        raise RuntimeError("build-dir provenance 与当前 clean source 不匹配")
+    if dirty is not None and not allow_dirty:
+        raise RuntimeError("publish 默认拒绝 dirty source；Preview 请显式 --allow-dirty")
+    if dirty is None and sidecar["builder_identity"]["package_lock_digest"] == _no_lock_digest():
+        raise RuntimeError("无 package-lock 的构建不能作为 Stable/reproducible manifest")
+    if dirty is None:
+        with _build_source(workspace, commit, dirty=False) as snapshot:
+            if _capture_provenance(snapshot) != {key: sidecar[key] for key in _build_provenance_keys()}:
+                raise RuntimeError("clean build provenance 未通过 commit snapshot 重算")
+    return manifest_from_directory(
+        build_dir,
+        source_repository=sidecar["source_repository"],
+        source_commit=commit,
+        source_tree=tree,
+        input_digest=sidecar["input_digest"],
+        build_context_digest=sidecar["build_context_digest"],
+        dirty_provenance=dirty,
+        reproducible=dirty is None,
+        builder_identity=sidecar["builder_identity"],
+    )
+
+
+def _require_clean_source(workspace: Path, *, allow_dirty: bool) -> None:
+    if _webui_dirty(workspace) and not allow_dirty:
+        raise RuntimeError("WebUI/build inputs require clean source；Preview 可用 --allow-dirty")
+
+
+def _webui_dirty(workspace: Path) -> bool:
+    return bool(_git(workspace, "status", "--porcelain", "--untracked-files=all", "--", *(_webui_paths())))
+
+
+def _dirty_provenance(workspace: Path) -> dict[str, str]:
+    tracked = subprocess.run(["git", "diff", "--binary", "HEAD", "--", *(_webui_paths())], cwd=workspace, check=True, capture_output=True).stdout
+    untracked_digest = hashlib.sha256()
+    for path in _git(workspace, "ls-files", "--others", "--exclude-standard", "--", *(_webui_paths())).splitlines():
+        absolute = workspace / path
+        _hash_record(untracked_digest, path.encode("utf-8"), _read_regular_input(absolute))
+    return {
+        "base_commit": _git(workspace, "rev-parse", "HEAD"),
+        "tracked_patch_digest": hashlib.sha256(tracked).hexdigest(),
+        "untracked_tree_digest": untracked_digest.hexdigest(),
+    }
+
+
+@contextmanager
+def _build_source(workspace: Path, commit: str, *, dirty: bool):
+    """Yield an immutable git worktree for clean builds or the explicit dirty preview source."""
+
+    temporary = Path(tempfile.mkdtemp(prefix="mobile-webui-source-", dir=workspace.parent))
+    shutil.rmtree(temporary)
+    added = False
+    try:
+        subprocess.run(["git", "worktree", "add", "--detach", str(temporary), commit], cwd=workspace, check=True)
+        added = True
+        if dirty:
+            _overlay_webui_inputs(workspace, temporary)
+        yield temporary
+    finally:
+        if added:
+            subprocess.run(["git", "worktree", "remove", "--force", str(temporary)], cwd=workspace, check=False)
+        shutil.rmtree(temporary, ignore_errors=True)
+
+
+def _resolve_commit(workspace: Path, requested: str | None) -> str:
+    commit = requested or _git(workspace, "rev-parse", "HEAD")
+    if len(commit) != 40 or any(char not in "0123456789abcdef" for char in commit):
+        raise RuntimeError("source-commit 必须是 40 位小写 commit SHA-1")
+    resolved = _git(workspace, "rev-parse", "--verify", f"{commit}^{{commit}}")
+    if resolved != commit:
+        raise RuntimeError("source-commit 不是可解析的 commit")
+    return commit
+
+
+def _commit_has_file(workspace: Path, commit: str, path: str) -> bool:
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}:{path}"],
+        cwd=workspace,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def _capture_provenance(workspace: Path) -> dict[str, object]:
+    """Capture all source/build identity inputs before and after a build."""
+
+    package_lock = workspace / "package-lock.json"
+    package_lock_digest = _sha256(package_lock.read_bytes()) if package_lock.is_file() else _no_lock_digest()
+    build_script = workspace / "scripts" / "package-mobile-web.sh"
+    script_digest = _sha256(build_script.read_bytes())
+    node_version = _run_version("node", "--version")
+    npm_version = _run_version("npm", "--version")
+    context = {
+        "node": node_version,
+        "npm": npm_version,
+        "package_lock": package_lock_digest,
+        "script": script_digest,
+    }
+    return {
+        "source_repository": _repository_url(workspace),
+        "source_commit": _git(workspace, "rev-parse", "HEAD"),
+        "source_tree": _git(workspace, "rev-parse", "HEAD^{tree}"),
+        "input_digest": _input_digest(workspace),
+        "build_context_digest": _sha256(json.dumps(context, sort_keys=True, separators=(",", ":")).encode()),
+        "dirty_provenance": _dirty_provenance(workspace) if _webui_dirty(workspace) else None,
+        "builder_identity": {
+            "node_version": node_version,
+            "npm_version": npm_version,
+            "package_lock_digest": package_lock_digest,
+            "build_script_digest": script_digest,
+        },
+    }
+
+
+def _input_digest(workspace: Path) -> str:
+    paths = _git(workspace, "ls-files", "--cached", "--others", "--exclude-standard", "--", *_webui_paths()).splitlines()
+    digest = hashlib.sha256()
+    for relative in sorted(set(paths), key=lambda value: value.encode("utf-8")):
+        path = workspace / relative
+        if path.exists():
+            _hash_record(digest, relative.encode("utf-8"), _read_regular_input(path))
+        else:
+            _hash_record(digest, relative.encode("utf-8"), b"<missing>")
+    return digest.hexdigest()
+
+
+def _repository_url(workspace: Path) -> str:
+    remote = _git(workspace, "config", "--get", "remote.origin.url")
+    if remote.startswith("git@github.com:"):
+        remote = "https://github.com/" + remote.removeprefix("git@github.com:")
+    remote = remote.removesuffix(".git")
+    if not remote or any(char.isspace() for char in remote):
+        raise RuntimeError("source repository remote.origin.url 无效")
+    return remote
+
+
+def _load_sidecar(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    required = {
+        "artifact_digest", "build_context_digest", "builder_identity", "dirty_provenance",
+        "input_digest", "source_commit", "source_repository", "source_tree",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise RuntimeError("build provenance sidecar 字段集合无效")
+    for key in ("artifact_digest", "build_context_digest", "input_digest"):
+        if not isinstance(value[key], str) or len(value[key]) != 64 or any(char not in "0123456789abcdef" for char in value[key]):
+            raise RuntimeError(f"build provenance {key} 无效")
+    for key in ("source_commit", "source_tree"):
+        if not isinstance(value[key], str) or len(value[key]) != 40 or any(char not in "0123456789abcdef" for char in value[key]):
+            raise RuntimeError(f"build provenance {key} 无效")
+    if not isinstance(value["source_repository"], str) or not value["source_repository"] or any(char.isspace() for char in value["source_repository"]):
+        raise RuntimeError("build provenance source_repository 无效")
+    builder = value["builder_identity"]
+    if not isinstance(builder, dict) or set(builder) != {"node_version", "npm_version", "package_lock_digest", "build_script_digest"}:
+        raise RuntimeError("build provenance builder_identity 无效")
+    dirty = value["dirty_provenance"]
+    if dirty is not None and (not isinstance(dirty, dict) or set(dirty) != {"base_commit", "tracked_patch_digest", "untracked_tree_digest"}):
+        raise RuntimeError("build provenance dirty_provenance 无效")
+    return value
+
+
+def _no_lock_digest() -> str:
+    return _sha256(b"NO_PACKAGE_LOCK\n")
+
+
+def _read_regular_input(path: Path) -> bytes:
+    if path.is_symlink():
+        raise RuntimeError(f"WebUI 输入不允许 symlink: {path}")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise RuntimeError(f"WebUI 输入无法读取: {path}") from error
+    if not stat.S_ISREG(mode):
+        raise RuntimeError(f"WebUI 输入只允许普通文件: {path}")
+    return path.read_bytes()
+
+
+def _overlay_webui_inputs(source: Path, snapshot: Path) -> None:
+    """Overlay the exact dirty WebUI input set onto a clean commit worktree."""
+
+    tracked = _git(source, "ls-files", "--cached", "--", *_webui_paths()).splitlines()
+    untracked = _git(source, "ls-files", "--others", "--exclude-standard", "--", *_webui_paths()).splitlines()
+    for relative in (*tracked, *untracked):
+        source_path = source / relative
+        target_path = snapshot / relative
+        if source_path.exists() or source_path.is_symlink():
+            data = _read_regular_input(source_path)
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            if target_path.is_dir() and not target_path.is_symlink():
+                shutil.rmtree(target_path)
+            target_path.write_bytes(data)
+        elif relative in tracked:
+            if target_path.exists() or target_path.is_symlink():
+                target_path.unlink()
+
+
+def _hash_record(digest: hashlib._Hash, path: bytes, data: bytes) -> None:
+    digest.update(len(path).to_bytes(8, "big"))
+    digest.update(path)
+    digest.update(len(data).to_bytes(8, "big"))
+    digest.update(data)
+
+
+def _build_provenance_keys() -> tuple[str, ...]:
+    return (
+        "build_context_digest",
+        "builder_identity",
+        "dirty_provenance",
+        "input_digest",
+        "source_commit",
+        "source_repository",
+        "source_tree",
+    )
+
+
+def _webui_paths() -> tuple[str, ...]:
+    return (
+        "frontend/chat",
+        "scripts/package-mobile-web.sh",
+        "package.json",
+        "package-lock.json",
+    )
+
+
+def _release_json(release):
+    return {
+        "server_id": release.server_id,
+        "release_epoch": release.release_epoch,
+        "sequence": release.sequence,
+        "selection_digest": release.selection_digest,
+        "stable": release.stable.as_json() if release.stable is not None else None,
+        "preview": release.preview.as_json() if release.preview is not None else None,
+    }
+
+
+def _git(workspace: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=workspace, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _run_version(command: str, flag: str) -> str:
+    return subprocess.run([command, flag], check=True, capture_output=True, text=True).stdout.strip()
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _artifact_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted((item for item in root.rglob("*") if item.is_file()), key=lambda item: item.relative_to(root).as_posix().encode("utf-8")):
+        _hash_record(digest, path.relative_to(root).as_posix().encode("utf-8"), path.read_bytes())
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mobile_realtime/test_mobile_realtime_protocol.py
+++ b/tests/mobile_realtime/test_mobile_realtime_protocol.py
@@ -10,6 +10,8 @@ from pydantic import ValidationError
 from infra.mobile_realtime.protocol import (
     AttachmentDownloadCommand,
     AuthAcceptedControl,
+    CONTROL_TYPES,
+    EVENT_TYPES,
     GenericControl,
     MessageSendCommand,
     PRE_AUTH_CONTROL_TYPES,
@@ -360,6 +362,22 @@ def test_pair_claim_is_valid_before_authentication() -> None:
 def test_control_rejects_unknown_type() -> None:
     with pytest.raises(ValidationError):
         parse_frame('{"v":1,"kind":"control","type":"auth.skipped","payload":{}}')
+
+
+def test_device_revoked_is_control_only() -> None:
+    assert "device.revoked" in CONTROL_TYPES
+    assert "device.revoked" not in EVENT_TYPES
+    control = parse_frame(
+        '{"v":1,"kind":"control","type":"device.revoked",'
+        '"connection_epoch":7,"payload":{"device_id":"device-1"}}'
+    )
+    assert isinstance(control, GenericControl)
+    with pytest.raises(ValidationError):
+        parse_frame(
+            '{"v":1,"kind":"event","type":"device.revoked",'
+            '"id":"01ARZ3NDEKTSV4RRFFQ69G5FAV","connection_epoch":7,'
+            '"event_seq":1,"payload":{"device_id":"device-1"}}'
+        )
 
 
 def test_plugin_ui_changed_is_authenticated_connection_control() -> None:

--- a/tests/mobile_webui/fixtures/manifest-v2.json
+++ b/tests/mobile_webui/fixtures/manifest-v2.json
@@ -1,0 +1,39 @@
+{
+  "manifest": {
+    "bridge_protocol_max": 1,
+    "bridge_protocol_min": 1,
+    "build_context_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "builder_identity": {
+      "build_script_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "node_version": "v22.23.1",
+      "npm_version": "10.9.0",
+      "package_lock_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    "dirty_provenance": null,
+    "entrypoint": "mobile.html",
+    "file_count": 1,
+    "files": [
+      {
+        "mime": "text/html",
+        "path": "mobile.html",
+        "sha256": "79179d7a9ab0e61354b2924a8db81f0cece3165461b7021010156cd79d363aac",
+        "size_bytes": 12
+      }
+    ],
+    "generation_id": "2b75e991d7134f8e60df02677336ef7f2c4bfaec89685393d1416fdabeec72e9",
+    "input_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "minimum_native_build": 45,
+    "platforms": ["android"],
+    "reproducible": true,
+    "schema_version": 2,
+    "snapshot_protocol_max": 7,
+    "snapshot_protocol_min": 7,
+    "source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "source_repository": "https://github.com/example/repo",
+    "source_tree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "unpacked_size_bytes": 12
+  },
+  "manifest_digest": "b4c9c2e698f110b385e576c190fae17c6217f64e824d18e5909f27c53a0df9fa",
+  "selection_digest": "f39766d597b64e8eaada0eefba9d4713a4f6aaa9802c81c665f788394ac76025",
+  "target_key": "5737f08516b5075c1edc2427a135c0e77c887b9be4ed454708904ad32381a126"
+}

--- a/tests/mobile_webui/test_gateway_http.py
+++ b/tests/mobile_webui/test_gateway_http.py
@@ -6,6 +6,7 @@ from collections import deque
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 from cryptography.hazmat.primitives.asymmetric import ec
 import httpx
@@ -224,6 +225,37 @@ async def test_blob_http_rechecks_selection_after_body_read(tmp_path: Path, monk
             )
         assert error.value.code == "target_changed"
         assert reads >= 2
+    finally:
+        await runtime.stop()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_manifest_http_rechecks_release_epoch_after_body_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, store, _storage, ticket, manifest_digest = _runtime(tmp_path)
+    runtime.start()
+    try:
+        original_get_manifest = store.get_manifest
+        switched = False
+
+        def hooked_get_manifest(digest: str):
+            nonlocal switched
+            manifest = original_get_manifest(digest)
+            if not switched:
+                switched = True
+                next_epoch = str(uuid4())
+                store._db.execute("UPDATE webui_meta SET value = ? WHERE key = 'release_epoch'", (next_epoch,))
+                store._db.execute(
+                    "UPDATE webui_release_state SET release_epoch = ? WHERE singleton = 1",
+                    (next_epoch,),
+                )
+            return manifest
+
+        monkeypatch.setattr(store, "get_manifest", hooked_get_manifest)
+        with pytest.raises(MobileWebUiHttpError, match="release 已变化") as error:
+            runtime.read_webui_manifest_http(ticket=ticket, manifest_digest=manifest_digest)
+        assert error.value.code == "target_changed"
+        assert switched
     finally:
         await runtime.stop()
         store.close()

--- a/tests/mobile_webui/test_gateway_http.py
+++ b/tests/mobile_webui/test_gateway_http.py
@@ -6,9 +6,11 @@ from collections import deque
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 from uuid import uuid4
 
 from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import WebSocket
 import httpx
 import pytest
 
@@ -39,6 +41,10 @@ _SOURCE = {
         "build_script_digest": "f" * 64,
     },
 }
+
+
+def _websocket_stub() -> WebSocket:
+    return cast(WebSocket, object())
 
 
 class _FakeKeyset:
@@ -84,7 +90,7 @@ def _runtime(tmp_path: Path) -> tuple[MobileGatewayRuntime, MobileWebUiStore, _F
         publication=store,
     )
     runtime._connections[device.device_id] = ActiveMobileConnection(
-        object(),
+        _websocket_stub(),
         7,
         asyncio.Lock(),
         deque(),
@@ -143,7 +149,7 @@ async def test_webui_http_headers_ranges_and_ticket_lifecycle(tmp_path: Path) ->
             assert not_member.json()["error"]["code"] == "resource_not_found"
 
             runtime._connections["device-1"] = ActiveMobileConnection(
-                object(),
+                _websocket_stub(),
                 8,
                 asyncio.Lock(),
                 deque(),
@@ -156,7 +162,7 @@ async def test_webui_http_headers_ranges_and_ticket_lifecycle(tmp_path: Path) ->
             assert stale_epoch.json()["error"]["code"] == "invalid_ticket"
 
             runtime._connections["device-1"] = ActiveMobileConnection(
-                object(),
+                _websocket_stub(),
                 7,
                 asyncio.Lock(),
                 deque(),

--- a/tests/mobile_webui/test_gateway_http.py
+++ b/tests/mobile_webui/test_gateway_http.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections import deque
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric import ec
+import httpx
+import pytest
+
+from agent.config_models import MobileRealtimeConfig
+from infra.mobile_realtime.gateway import (
+    ActiveMobileConnection,
+    MobileGatewayRuntime,
+    MobileWebUiHttpError,
+    create_mobile_gateway_app,
+)
+from infra.mobile_realtime.storage import DeviceRecord
+from infra.mobile_webui.manifest import manifest_from_directory
+from infra.mobile_webui.store import MobileWebUiStore
+
+
+_SOURCE = {
+    "source_repository": "https://github.com/example/repo",
+    "source_commit": "a" * 40,
+    "source_tree": "b" * 40,
+    "input_digest": "c" * 64,
+    "build_context_digest": "d" * 64,
+    "dirty_provenance": None,
+    "reproducible": True,
+    "builder_identity": {
+        "node_version": "v22.23.1",
+        "npm_version": "10.9.0",
+        "package_lock_digest": "e" * 64,
+        "build_script_digest": "f" * 64,
+    },
+}
+
+
+class _FakeKeyset:
+    class Manifest:
+        server_id = "server-1"
+
+    manifest = Manifest()
+    identity_private_key = ec.generate_private_key(ec.SECP256R1())
+
+
+class _FakeStorage:
+    def __init__(self, device: DeviceRecord) -> None:
+        self.device = device
+
+    def read_device(self, device_id: str) -> DeviceRecord | None:
+        return self.device if device_id == self.device.device_id else None
+
+
+def _runtime(tmp_path: Path) -> tuple[MobileGatewayRuntime, MobileWebUiStore, _FakeStorage, str, str]:
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "mobile.html").write_bytes(b"<html>mobile</html>")
+    manifest, contents = manifest_from_directory(build, **_SOURCE)
+    store = MobileWebUiStore(tmp_path / "publication", server_id="server-1")
+    release = store.publish(manifest, contents, stable=True, preview=False)
+    device = DeviceRecord(
+        "device-1",
+        "pub",
+        "Pixel",
+        datetime.now(timezone.utc),
+        None,
+        ("mobile-webui-ota-v1",),
+    )
+    storage = _FakeStorage(device)
+    runtime = MobileGatewayRuntime(
+        config=MobileRealtimeConfig(),
+        storage=storage,  # type: ignore[arg-type]
+        pairing=object(),  # type: ignore[arg-type]
+        authenticator=object(),  # type: ignore[arg-type]
+        inbox=object(),  # type: ignore[arg-type]
+        approvals=object(),  # type: ignore[arg-type]
+        keyset=_FakeKeyset(),  # type: ignore[arg-type]
+        publication=store,
+    )
+    runtime._connections[device.device_id] = ActiveMobileConnection(
+        object(),
+        7,
+        asyncio.Lock(),
+        deque(),
+        True,
+        None,
+        device.capabilities,
+    )
+    assert release.stable is not None
+    grant = runtime.webui_http_tickets.issue(
+        device_id=device.device_id,
+        connection_epoch=7,
+        release=release,
+        target_key=release.stable.target_key,
+    )
+    return runtime, store, storage, grant.ticket, release.stable.manifest_digest
+
+
+@pytest.mark.asyncio
+async def test_webui_http_headers_ranges_and_ticket_lifecycle(tmp_path: Path) -> None:
+    runtime, store, storage, ticket, manifest_digest = _runtime(tmp_path)
+    app = create_mobile_gateway_app(runtime)
+    headers = {"Authorization": f"Bearer {ticket}"}
+    runtime.start()
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            manifest_response = await client.get(f"/mobile/webui/v1/manifest/{manifest_digest}", headers=headers)
+            assert manifest_response.status_code == 200
+            assert manifest_response.headers["cache-control"] == "no-store, no-transform"
+            assert manifest_response.headers["etag"] == f'"{manifest_digest}"'
+            assert manifest_response.headers["content-digest"].startswith("sha-256=:")
+            assert manifest_response.headers["repr-digest"] == f"sha-256=:{base64.b64encode(bytes.fromhex(manifest_digest)).decode()}:"
+
+            manifest = manifest_response.json()
+            blob_digest = manifest["files"][0]["sha256"]
+            blob_response = await client.get(f"/mobile/webui/v1/blob/{blob_digest}", headers=headers)
+            assert blob_response.status_code == 200
+            assert blob_response.headers["cache-control"] == "private, max-age=31536000, immutable, no-transform"
+            assert blob_response.headers["etag"] == f'"{blob_digest}"'
+            assert "content-range" not in blob_response.headers
+            ranged = await client.get(
+                f"/mobile/webui/v1/blob/{blob_digest}",
+                headers={**headers, "Range": "bytes=0-3", "If-Range": f'"{blob_digest}"'},
+            )
+            assert ranged.status_code == 206
+            assert ranged.headers["content-range"] == f"bytes 0-3/{len(blob_response.content)}"
+            assert ranged.headers["repr-digest"] == f"sha-256=:{base64.b64encode(bytes.fromhex(blob_digest)).decode()}:"
+            invalid_range = await client.get(
+                f"/mobile/webui/v1/blob/{blob_digest}",
+                headers={**headers, "Range": "bytes=999-1000"},
+            )
+            assert invalid_range.status_code == 416
+            assert invalid_range.json()["error"]["code"] == "invalid_range"
+            not_member = await client.get(f"/mobile/webui/v1/blob/{'0' * 64}", headers=headers)
+            assert not_member.status_code == 404
+            assert not_member.json()["error"]["code"] == "resource_not_found"
+
+            runtime._connections["device-1"] = ActiveMobileConnection(
+                object(),
+                8,
+                asyncio.Lock(),
+                deque(),
+                True,
+                None,
+                ("mobile-webui-ota-v1",),
+            )
+            stale_epoch = await client.get(f"/mobile/webui/v1/manifest/{manifest_digest}", headers=headers)
+            assert stale_epoch.status_code == 401
+            assert stale_epoch.json()["error"]["code"] == "invalid_ticket"
+
+            runtime._connections["device-1"] = ActiveMobileConnection(
+                object(),
+                7,
+                asyncio.Lock(),
+                deque(),
+                True,
+                None,
+                ("mobile-webui-ota-v1",),
+            )
+            fresh_release = store.get_release()
+            assert fresh_release.stable is not None
+            fresh_grant = runtime.webui_http_tickets.issue(
+                device_id="device-1",
+                connection_epoch=7,
+                release=fresh_release,
+                target_key=fresh_release.stable.target_key,
+            )
+            second_build = tmp_path / "second-build"
+            second_build.mkdir()
+            (second_build / "mobile.html").write_bytes(b"<html>new</html>")
+            second_manifest, second_contents = manifest_from_directory(second_build, **_SOURCE)
+            store.publish(second_manifest, second_contents, preview=True)
+            changed = await client.get(
+                f"/mobile/webui/v1/manifest/{manifest_digest}",
+                headers={"Authorization": f"Bearer {fresh_grant.ticket}"},
+            )
+            assert changed.status_code == 409
+            assert changed.json()["error"]["code"] == "target_changed"
+            storage.device = replace(storage.device, revoked_at=datetime.now(timezone.utc))
+            revoked = await client.get(f"/mobile/webui/v1/manifest/{manifest_digest}", headers=headers)
+            assert revoked.status_code == 401
+            assert revoked.json()["error"]["code"] == "invalid_ticket"
+    finally:
+        await runtime.stop()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_blob_http_rechecks_selection_after_body_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, store, _storage, ticket, manifest_digest = _runtime(tmp_path)
+    runtime.start()
+    try:
+        manifest = store.get_manifest(manifest_digest)
+        blob_digest = manifest.files[0].sha256
+        second_build = tmp_path / "race-build"
+        second_build.mkdir()
+        (second_build / "mobile.html").write_bytes(b"<html>race</html>")
+        second_manifest, second_contents = manifest_from_directory(second_build, **_SOURCE)
+        original_read_bytes = Path.read_bytes
+        reads = 0
+
+        def hooked_read_bytes(path: Path) -> bytes:
+            nonlocal reads
+            data = original_read_bytes(path)
+            if path == store.blob_path(blob_digest):
+                reads += 1
+                if reads == 2:
+                    store.publish(second_manifest, second_contents, preview=True)
+            return data
+
+        monkeypatch.setattr(Path, "read_bytes", hooked_read_bytes)
+        with pytest.raises(MobileWebUiHttpError, match="release 已变化") as error:
+            runtime.read_webui_blob_http(
+                ticket=ticket,
+                blob_digest=blob_digest,
+                range_header=None,
+                if_range=None,
+            )
+        assert error.value.code == "target_changed"
+        assert reads >= 2
+    finally:
+        await runtime.stop()
+        store.close()

--- a/tests/mobile_webui/test_gateway_runtime.py
+++ b/tests/mobile_webui/test_gateway_runtime.py
@@ -5,14 +5,16 @@ from collections import deque
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
+from fastapi import WebSocket
 import pytest
 from pydantic import ValidationError
 
 from infra.mobile_realtime.gateway import ActiveMobileConnection, MobileGatewayRuntime
 from infra.mobile_realtime.storage import DeviceRecord
 from infra.mobile_realtime.protocol import parse_frame
-from infra.mobile_webui.manifest import manifest_from_directory
+from infra.mobile_webui.manifest import WebUiManifest, manifest_from_directory
 from infra.mobile_webui.store import MobileWebUiStore
 
 
@@ -33,12 +35,16 @@ _SOURCE = {
 }
 
 
-def _manifest(root: Path, text: bytes) -> tuple[object, dict[str, bytes]]:
+def _manifest(root: Path, text: bytes) -> tuple[WebUiManifest, dict[str, bytes]]:
     root.mkdir(parents=True, exist_ok=True)
     path = root / "mobile.html"
     path.write_bytes(text)
     manifest, contents = manifest_from_directory(root, **_SOURCE)
     return manifest, contents
+
+
+def _websocket_stub(value: object) -> WebSocket:
+    return cast(WebSocket, value)
 
 
 def _watcher_runtime(store: MobileWebUiStore) -> MobileGatewayRuntime:
@@ -68,9 +74,9 @@ async def test_publication_watcher_deduplicates_and_filters_capability(tmp_path:
 
         runtime.publish_connection_control = send_control
         runtime._connections = {
-            "enabled": ActiveMobileConnection(object(), 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",)),
-            "disabled": ActiveMobileConnection(object(), 8, asyncio.Lock(), deque(), True, None, ("other",)),
-            "not-ready": ActiveMobileConnection(object(), 9, asyncio.Lock(), deque(), False, None, ("mobile-webui-ota-v1",)),
+            "enabled": ActiveMobileConnection(_websocket_stub(object()), 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",)),
+            "disabled": ActiveMobileConnection(_websocket_stub(object()), 8, asyncio.Lock(), deque(), True, None, ("other",)),
+            "not-ready": ActiveMobileConnection(_websocket_stub(object()), 9, asyncio.Lock(), deque(), False, None, ("mobile-webui-ota-v1",)),
         }
         runtime.start()
         runtime.start()
@@ -121,8 +127,8 @@ async def test_control_delivery_rejects_replaced_epoch_and_evicts_failed_socket(
                 self.closed = True
 
         old_socket = Socket()
-        old = ActiveMobileConnection(old_socket, 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
-        replacement = ActiveMobileConnection(Socket(), 8, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        old = ActiveMobileConnection(_websocket_stub(old_socket), 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        replacement = ActiveMobileConnection(_websocket_stub(Socket()), 8, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
         runtime._connections = {"device": old}
         runtime._connections["device"] = replacement
         await runtime.publish_connection_control(
@@ -134,7 +140,7 @@ async def test_control_delivery_rejects_replaced_epoch_and_evicts_failed_socket(
         assert old_socket.sent == []
 
         failing_socket = Socket(fail=True)
-        failing = ActiveMobileConnection(failing_socket, 9, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        failing = ActiveMobileConnection(_websocket_stub(failing_socket), 9, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
         runtime._connections["device"] = failing
         await runtime.publish_connection_control(
             control_type="mobile.webui.release.changed",
@@ -184,7 +190,7 @@ async def test_revoke_device_commits_offline_and_notifies_active_connection() ->
     runtime._delivery_lock = asyncio.Lock()
     socket = Socket()
     runtime._connections = {
-        device.device_id: ActiveMobileConnection(socket, 7, asyncio.Lock(), deque(), True, None, ())
+        device.device_id: ActiveMobileConnection(_websocket_stub(socket), 7, asyncio.Lock(), deque(), True, None, ())
     }
     revoked = await runtime.revoke_device(device.device_id)
     assert revoked.revoked_at is not None
@@ -201,7 +207,7 @@ async def test_revoke_device_commits_offline_and_notifies_active_connection() ->
 
     failing_socket = Socket(fail=True)
     runtime._connections[device.device_id] = ActiveMobileConnection(
-        failing_socket,
+        _websocket_stub(failing_socket),
         8,
         asyncio.Lock(),
         deque(),

--- a/tests/mobile_webui/test_gateway_runtime.py
+++ b/tests/mobile_webui/test_gateway_runtime.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from infra.mobile_realtime.gateway import ActiveMobileConnection, MobileGatewayRuntime
+from infra.mobile_realtime.storage import DeviceRecord
+from infra.mobile_realtime.protocol import parse_frame
+from infra.mobile_webui.manifest import manifest_from_directory
+from infra.mobile_webui.store import MobileWebUiStore
+
+
+_SOURCE = {
+    "source_repository": "https://github.com/example/repo",
+    "source_commit": "a" * 40,
+    "source_tree": "b" * 40,
+    "input_digest": "c" * 64,
+    "build_context_digest": "d" * 64,
+    "dirty_provenance": None,
+    "reproducible": True,
+    "builder_identity": {
+        "node_version": "v22.23.1",
+        "npm_version": "10.9.0",
+        "package_lock_digest": "e" * 64,
+        "build_script_digest": "f" * 64,
+    },
+}
+
+
+def _manifest(root: Path, text: bytes) -> tuple[object, dict[str, bytes]]:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "mobile.html"
+    path.write_bytes(text)
+    manifest, contents = manifest_from_directory(root, **_SOURCE)
+    return manifest, contents
+
+
+def _watcher_runtime(store: MobileWebUiStore) -> MobileGatewayRuntime:
+    runtime = object.__new__(MobileGatewayRuntime)
+    runtime.publication = store
+    runtime._publication_monitor_task = None
+    runtime._publication_selection_digest = store.get_release_light().selection_digest
+    runtime._connections = {}
+    runtime._delivery_lock = asyncio.Lock()
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_publication_watcher_deduplicates_and_filters_capability(tmp_path: Path) -> None:
+    first, first_contents = _manifest(tmp_path / "first", b"first")
+    second, second_contents = _manifest(tmp_path / "second", b"second")
+    third, third_contents = _manifest(tmp_path / "third", b"third")
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    runtime = None
+    try:
+        store.publish(first, first_contents, stable=True, preview=False)
+        runtime = _watcher_runtime(store)
+        sent: list[tuple[str, str, str, int]] = []
+
+        async def send_control(*, control_type: str, payload: dict[str, object], device_id: str, connection_epoch: int) -> None:
+            sent.append((control_type, str(payload["selection_digest"]), device_id, connection_epoch))
+
+        runtime.publish_connection_control = send_control
+        runtime._connections = {
+            "enabled": ActiveMobileConnection(object(), 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",)),
+            "disabled": ActiveMobileConnection(object(), 8, asyncio.Lock(), deque(), True, None, ("other",)),
+            "not-ready": ActiveMobileConnection(object(), 9, asyncio.Lock(), deque(), False, None, ("mobile-webui-ota-v1",)),
+        }
+        runtime.start()
+        runtime.start()
+        await asyncio.sleep(0.05)
+        assert sent == []
+
+        second_release = store.publish(second, second_contents, preview=True)
+        await asyncio.sleep(0.65)
+        assert sent == [("mobile.webui.release.changed", second_release.selection_digest, "enabled", 7)]
+        await asyncio.sleep(0.6)
+        assert len(sent) == 1
+
+        store.publish(second, second_contents, preview=True)
+        await asyncio.sleep(0.6)
+        assert len(sent) == 1
+
+        third_release = store.publish(third, third_contents, preview=True)
+        await asyncio.sleep(0.6)
+        assert sent[-1] == ("mobile.webui.release.changed", third_release.selection_digest, "enabled", 7)
+        assert len(sent) == 2
+    finally:
+        if runtime is not None:
+            await runtime.stop()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_control_delivery_rejects_replaced_epoch_and_evicts_failed_socket(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build", b"content")
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    runtime = None
+    try:
+        store.publish(manifest, contents, stable=True, preview=False)
+        runtime = _watcher_runtime(store)
+
+        class Socket:
+            def __init__(self, *, fail: bool = False) -> None:
+                self.fail = fail
+                self.sent: list[str] = []
+                self.closed = False
+
+            async def send_text(self, value: str) -> None:
+                if self.fail:
+                    raise RuntimeError("closed")
+                self.sent.append(value)
+
+            async def close(self, **_kwargs: object) -> None:
+                self.closed = True
+
+        old_socket = Socket()
+        old = ActiveMobileConnection(old_socket, 7, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        replacement = ActiveMobileConnection(Socket(), 8, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        runtime._connections = {"device": old}
+        runtime._connections["device"] = replacement
+        await runtime.publish_connection_control(
+            control_type="mobile.webui.release.changed",
+            payload={"server_id": "server-1", "selection_digest": "a" * 64},
+            device_id="device",
+            connection_epoch=7,
+        )
+        assert old_socket.sent == []
+
+        failing_socket = Socket(fail=True)
+        failing = ActiveMobileConnection(failing_socket, 9, asyncio.Lock(), deque(), True, None, ("mobile-webui-ota-v1",))
+        runtime._connections["device"] = failing
+        await runtime.publish_connection_control(
+            control_type="mobile.webui.release.changed",
+            payload={"server_id": "server-1", "selection_digest": "b" * 64},
+            device_id="device",
+            connection_epoch=9,
+        )
+        await asyncio.sleep(0)
+        assert "device" not in runtime._connections
+        assert failing_socket.closed
+    finally:
+        if runtime is not None:
+            await runtime.stop()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_revoke_device_commits_offline_and_notifies_active_connection() -> None:
+    device = DeviceRecord("device", "pub", "Pixel", datetime.now(timezone.utc), None, ())
+
+    class Storage:
+        def __init__(self) -> None:
+            self.device = device
+
+        def revoke_device(self, device_id: str, *, revoked_at: datetime) -> DeviceRecord:
+            assert device_id == self.device.device_id
+            if self.device.revoked_at is None:
+                self.device = replace(self.device, revoked_at=revoked_at)
+            return self.device
+
+    class Socket:
+        def __init__(self, *, fail: bool = False) -> None:
+            self.fail = fail
+            self.sent: list[str] = []
+            self.closed: list[dict[str, object]] = []
+
+        async def send_text(self, value: str) -> None:
+            if self.fail:
+                raise RuntimeError("closed")
+            self.sent.append(value)
+
+        async def close(self, **kwargs: object) -> None:
+            self.closed.append(kwargs)
+
+    runtime = object.__new__(MobileGatewayRuntime)
+    runtime.storage = Storage()
+    runtime._delivery_lock = asyncio.Lock()
+    socket = Socket()
+    runtime._connections = {
+        device.device_id: ActiveMobileConnection(socket, 7, asyncio.Lock(), deque(), True, None, ())
+    }
+    revoked = await runtime.revoke_device(device.device_id)
+    assert revoked.revoked_at is not None
+    assert runtime.storage.device.revoked_at == revoked.revoked_at
+    assert device.device_id not in runtime._connections
+    assert socket.closed == [{"code": 4403, "reason": "设备已撤销"}]
+    frame = parse_frame(socket.sent[0])
+    assert frame.kind == "control"
+    assert frame.type == "device.revoked"
+    assert frame.connection_epoch == 7
+
+    offline = await runtime.revoke_device("device")
+    assert offline.revoked_at == revoked.revoked_at
+
+    failing_socket = Socket(fail=True)
+    runtime._connections[device.device_id] = ActiveMobileConnection(
+        failing_socket,
+        8,
+        asyncio.Lock(),
+        deque(),
+        True,
+        None,
+        (),
+    )
+    failed = await runtime.revoke_device(device.device_id)
+    assert failed.revoked_at == revoked.revoked_at
+    assert device.device_id not in runtime._connections
+    assert failing_socket.closed == [{"code": 4403, "reason": "设备已撤销"}]

--- a/tests/mobile_webui/test_gateway_runtime.py
+++ b/tests/mobile_webui/test_gateway_runtime.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from infra.mobile_realtime.gateway import ActiveMobileConnection, MobileGatewayRuntime
 from infra.mobile_realtime.storage import DeviceRecord
@@ -212,3 +213,19 @@ async def test_revoke_device_commits_offline_and_notifies_active_connection() ->
     assert failed.revoked_at == revoked.revoked_at
     assert device.device_id not in runtime._connections
     assert failing_socket.closed == [{"code": 4403, "reason": "设备已撤销"}]
+
+
+def test_device_revoked_cannot_enter_durable_event_enqueue() -> None:
+    runtime = object.__new__(MobileGatewayRuntime)
+
+    class Inbox:
+        def enqueue(self, **_kwargs: object) -> None:
+            raise AssertionError("invalid durable event must fail before inbox write")
+
+    runtime.inbox = Inbox()
+    with pytest.raises(ValidationError):
+        runtime._enqueue_event(
+            device_id="device",
+            event_type="device.revoked",
+            payload={"device_id": "device"},
+        )

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import os
+import signal
 import sqlite3
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -54,6 +56,38 @@ def _manifest(root: Path, text: bytes = b"<html>ok</html>\n"):
     root.mkdir(parents=True, exist_ok=True)
     (root / "mobile.html").write_bytes(text)
     return manifest_from_directory(root, **_SOURCE)
+
+
+def _kill_backup_before_rename(root: str, destination: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    absolute_destination = os.path.abspath(destination)
+
+    def kill_before_rename(source: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:
+        if os.path.abspath(os.fspath(target)) == absolute_destination:
+            os.kill(os.getpid(), signal.SIGKILL)
+        original_replace(source, target)
+
+    store_module.os.replace = kill_before_rename
+    store = MobileWebUiStore(Path(root), server_id="server-1")
+    store.backup_to(Path(destination))
+
+
+def _kill_backup_after_rename(root: str, destination: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    absolute_destination = os.path.abspath(destination)
+
+    def kill_after_rename(source: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:
+        original_replace(source, target)
+        if os.path.abspath(os.fspath(target)) == absolute_destination:
+            os.kill(os.getpid(), signal.SIGKILL)
+
+    store_module.os.replace = kill_after_rename
+    store = MobileWebUiStore(Path(root), server_id="server-1")
+    store.backup_to(Path(destination))
 
 
 def test_golden_manifest_and_derived_ids() -> None:
@@ -152,7 +186,7 @@ def test_manifest_directory_covers_wire_reachable_script_and_binary_mimes(tmp_pa
     assert by_path == {
         "app.js": "text/javascript",
         "asset.bin": "application/octet-stream",
-        "bundle.map": "application/octet-stream",
+        "bundle.map": "application/json",
         "mobile.html": "text/html",
         "module.mjs": "text/javascript",
         "style.css": "text/css",
@@ -208,6 +242,85 @@ def test_store_preview_promotion_rollback_gc_and_backup(tmp_path: Path) -> None:
         backup = store.backup_to(tmp_path / "backup")
         MobileWebUiStore.verify_backup(backup, server_id="server-1")
         assert first.generation_id not in store.gc().removed_generations
+    finally:
+        store.close()
+
+
+def test_backup_pending_kill_restart_reclaims_registration_and_gc_can_collect(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.publish(manifest, contents, stable=True, preview=False)
+    store.close()
+    destination = tmp_path / "backup-before-rename"
+    context = multiprocessing.get_context("fork")
+    child = context.Process(target=_kill_backup_before_rename, args=(str(root), str(destination)))
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    assert list((root / "staging").glob(".backup-*.pending.json"))
+    assert list(destination.parent.glob(f".{destination.name}.*.tmp"))
+
+    reopened = MobileWebUiStore(root, server_id="server-1")
+    try:
+        assert reopened._db.execute("SELECT COUNT(*) FROM webui_backup_sets").fetchone()[0] == 0
+        assert not list((root / "staging").glob(".backup-*.pending.json"))
+        assert not list(destination.parent.glob(f".{destination.name}.*.tmp"))
+        generations = [manifest]
+        for index in range(5):
+            next_manifest, next_contents = _manifest(
+                tmp_path / f"build-{index}",
+                f"<html>{index}</html>\n".encode(),
+            )
+            generations.append(next_manifest)
+            reopened.publish(next_manifest, next_contents, stable=True, preview=False)
+        report = reopened.gc()
+        assert generations[0].generation_id in report.removed_generations
+    finally:
+        reopened.close()
+
+
+def test_backup_pending_restart_preserves_published_destination(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.publish(manifest, contents, stable=True, preview=False)
+    store.close()
+    destination = tmp_path / "backup-after-rename"
+    context = multiprocessing.get_context("fork")
+    child = context.Process(target=_kill_backup_after_rename, args=(str(root), str(destination)))
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    assert destination.is_dir()
+    assert list((root / "staging").glob(".backup-*.pending.json"))
+
+    reopened = MobileWebUiStore(root, server_id="server-1")
+    try:
+        MobileWebUiStore.verify_backup(destination, server_id="server-1")
+        backup_id = json.loads((destination / "backup.json").read_text(encoding="utf-8"))["backup_id"]
+        assert reopened._db.execute(
+            "SELECT COUNT(*) FROM webui_backup_sets WHERE backup_id = ?", (backup_id,)
+        ).fetchone()[0] == 1
+        assert not list((root / "staging").glob(".backup-*.pending.json"))
+        reopened.release_backup(backup_id)
+    finally:
+        reopened.close()
+
+
+def test_backup_rejects_destination_symlink_without_writing_target(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.publish(manifest, contents, stable=True, preview=False)
+    target = tmp_path / "symlink-target"
+    destination = tmp_path / "symlink-destination"
+    destination.symlink_to(target, target_is_directory=True)
+    try:
+        with pytest.raises(RuntimeError, match="符号链接"):
+            store.backup_to(destination)
+        assert not target.exists()
+        assert store._db.execute("SELECT COUNT(*) FROM webui_backup_sets").fetchone()[0] == 0
     finally:
         store.close()
 
@@ -310,6 +423,18 @@ def test_restore_empty_backup_keeps_no_state_and_records_restore(tmp_path: Path)
         assert tuple(event) == (1, None, "restore", 0, 0)
     finally:
         restored.close()
+
+
+def test_restore_rejects_target_symlink_without_following_target(tmp_path: Path) -> None:
+    source = MobileWebUiStore(tmp_path / "source", server_id="server-1")
+    backup = source.backup_to(tmp_path / "backup")
+    source.close()
+    actual_target = tmp_path / "actual-target"
+    target = tmp_path / "target-link"
+    target.symlink_to(actual_target, target_is_directory=True)
+    with pytest.raises(RuntimeError, match="普通目录"):
+        MobileWebUiStore.restore_backup(backup, target, server_id="server-1")
+    assert not actual_target.exists()
 
 
 def test_restore_marker_recovers_old_root_after_swap_gap(tmp_path: Path) -> None:

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from infra.mobile_realtime.protocol import (
+    MobileWebUiContentPrepareCommand,
+    MobileWebUiReleaseChangedControl,
+    parse_frame,
+)
+from infra.mobile_webui.protocol import PrepareReplyWire, ReleaseViewWire
+from infra.mobile_realtime.storage import DeviceRecord
+from infra.mobile_webui.http import WebUiTicketIssuer, WebUiTicketError, parse_single_range
+from infra.mobile_webui.manifest import (
+    ManifestError,
+    WebUiManifest,
+    WebUiFile,
+    canonical_manifest_bytes,
+    derive_target_key,
+    generation_id_for_manifest,
+    manifest_digest,
+    manifest_from_directory,
+    manifest_from_json,
+    validate_manifest,
+)
+from infra.mobile_webui.store import MobileWebUiStore, UnknownReleaseError
+
+
+_SOURCE = {
+    "source_repository": "https://github.com/example/repo",
+    "source_commit": "a" * 40,
+    "source_tree": "b" * 40,
+    "input_digest": "c" * 64,
+    "build_context_digest": "d" * 64,
+    "dirty_provenance": None,
+    "reproducible": True,
+    "builder_identity": {
+        "node_version": "v22.23.1",
+        "npm_version": "10.9.0",
+        "package_lock_digest": "e" * 64,
+        "build_script_digest": "f" * 64,
+    },
+}
+
+
+def _manifest(root: Path, text: bytes = b"<html>ok</html>\n"):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "mobile.html").write_bytes(text)
+    return manifest_from_directory(root, **_SOURCE)
+
+
+def test_golden_manifest_and_derived_ids() -> None:
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "manifest-v2.json").read_text()
+    )
+    manifest = manifest_from_json(fixture["manifest"])
+    assert manifest_digest(manifest) == fixture["manifest_digest"]
+    assert generation_id_for_manifest(manifest) == manifest.generation_id
+    assert derive_target_key("server-1", manifest.generation_id, fixture["manifest_digest"]) == fixture["target_key"]
+    assert canonical_manifest_bytes(manifest).decode() == json.dumps(
+        fixture["manifest"], ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    mismatched = json.loads(json.dumps(fixture["manifest"]))
+    mismatched["files"][0]["mime"] = "application/octet-stream"
+    with pytest.raises(ManifestError):
+        manifest_from_json(mismatched)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("../escape", "/absolute", "a\\b", "a/./b", "a/../b", "a b"),
+)
+def test_manifest_rejects_unsafe_or_noncanonical_paths(tmp_path: Path, name: str) -> None:
+    digest = "0" * 64
+    files = (WebUiFile(name, digest, 0, "text/html"),)
+    draft = WebUiManifest(
+        generation_id="0" * 64,
+        entrypoint=name,
+        files=files,
+        bridge_protocol_min=1,
+        bridge_protocol_max=1,
+        snapshot_protocol_min=7,
+        snapshot_protocol_max=7,
+        minimum_native_build=45,
+        platforms=("android",),
+        **_SOURCE,
+        unpacked_size_bytes=0,
+        file_count=1,
+    )
+    with pytest.raises(ManifestError):
+        manifest_from_json({**draft.as_json(), "generation_id": draft.generation_id})
+
+
+def test_manifest_rejects_ambiguous_digest_mime() -> None:
+    digest = "1" * 64
+    draft = WebUiManifest(
+        generation_id="0" * 64,
+        entrypoint="mobile.html",
+        files=(
+            WebUiFile("mobile.html", digest, 1, "text/html"),
+            WebUiFile("script.js", digest, 1, "text/javascript"),
+        ),
+        bridge_protocol_min=1,
+        bridge_protocol_max=1,
+        snapshot_protocol_min=7,
+        snapshot_protocol_max=7,
+        minimum_native_build=45,
+        platforms=("android",),
+        **_SOURCE,
+        unpacked_size_bytes=2,
+        file_count=2,
+    )
+    with pytest.raises(ManifestError):
+        validate_manifest(replace(draft, generation_id=generation_id_for_manifest(draft)))
+
+
+def test_manifest_directory_uses_fixed_mime_mapping(tmp_path: Path) -> None:
+    root = tmp_path / "mime"
+    root.mkdir()
+    (root / "mobile.html").write_bytes(b"<html/>")
+    (root / "bundle.js").write_bytes(b"same")
+    (root / "asset.unknown").write_bytes(b"different")
+    manifest, _ = manifest_from_directory(root, **_SOURCE)
+    by_path = {item.path: item.mime for item in manifest.files}
+    assert by_path["bundle.js"] == "text/javascript"
+    assert by_path["asset.unknown"] == "application/octet-stream"
+
+
+def test_manifest_directory_rejects_symlink_and_special_file(tmp_path: Path) -> None:
+    root = tmp_path / "special"
+    root.mkdir()
+    (root / "mobile.html").write_bytes(b"<html/>")
+    os.symlink(root / "mobile.html", root / "link.html")
+    with pytest.raises(ManifestError):
+        manifest_from_directory(root, **_SOURCE)
+    (root / "link.html").unlink()
+    fifo = root / "pipe"
+    os.mkfifo(fifo)
+    with pytest.raises(ManifestError):
+        manifest_from_directory(root, **_SOURCE)
+
+
+def test_store_preview_promotion_rollback_gc_and_backup(tmp_path: Path) -> None:
+    first, first_contents = _manifest(tmp_path / "first")
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    try:
+        first_release = store.publish(first, first_contents, stable=True, preview=False)
+        store.pin_target(first_release.stable.target_key)  # type: ignore[union-attr]
+        second, second_contents = _manifest(tmp_path / "second", b"<html>new</html>\n")
+        preview = store.publish(second, second_contents, preview=True)
+        assert preview.stable is not None and preview.preview is not None
+        rolled_with_preview = store.rollback(first_release.stable.target_key)  # type: ignore[union-attr]
+        assert rolled_with_preview.stable is not None and rolled_with_preview.stable.generation_id == first.generation_id
+        assert rolled_with_preview.preview is not None and rolled_with_preview.preview.generation_id == second.generation_id
+        promoted = store.promote_preview()
+        assert promoted.stable is not None and promoted.stable.generation_id == second.generation_id
+        rolled = store.rollback(first_release.stable.target_key)  # type: ignore[union-attr]
+        assert rolled.stable is not None and rolled.stable.generation_id == first.generation_id
+        cleared = store.clear_preview()
+        assert cleared.stable is not None and cleared.preview is None
+        backup = store.backup_to(tmp_path / "backup")
+        MobileWebUiStore.verify_backup(backup, server_id="server-1")
+        assert first.generation_id not in store.gc().removed_generations
+    finally:
+        store.close()
+
+
+def test_store_rejects_corrupt_release_epoch_on_open(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.close()
+    connection = sqlite3.connect(root / "publication.sqlite3")
+    try:
+        connection.execute(
+            "UPDATE webui_meta SET value = ? WHERE key = 'release_epoch'",
+            ("not-a-uuid",),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    with pytest.raises(RuntimeError, match="规范 UUID4"):
+        MobileWebUiStore(root, server_id="server-1")
+
+
+def test_channel_history_is_distinct_per_pointer_and_bounds_gc(tmp_path: Path) -> None:
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    try:
+        stable_releases = []
+        for index in range(6):
+            manifest, contents = _manifest(tmp_path / f"stable-{index}", f"<html>stable-{index}</html>\n".encode())
+            stable_releases.append(store.publish(manifest, contents, stable=True, preview=False))
+        preview_releases = []
+        for index in range(6):
+            manifest, contents = _manifest(tmp_path / f"preview-{index}", f"<html>preview-{index}</html>\n".encode())
+            preview_releases.append(store.publish(manifest, contents, preview=True))
+        before = store._db.execute(
+            "SELECT channel, COUNT(*) AS count FROM webui_channel_selections GROUP BY channel"
+        ).fetchall()
+        assert {row["channel"]: row["count"] for row in before} == {"preview": 4, "stable": 4}
+        store.publish(manifest, contents, preview=True)  # no-op pointer does not add history
+        store.clear_preview()
+        after = store._db.execute(
+            "SELECT channel, COUNT(*) AS count FROM webui_channel_selections GROUP BY channel"
+        ).fetchall()
+        assert {row["channel"]: row["count"] for row in after} == {"preview": 4, "stable": 4}
+        assert store.rollback(preview_releases[-1].preview.target_key).preview is None  # type: ignore[union-attr]
+        report = store.gc()
+        assert stable_releases[0].stable.generation_id in report.removed_generations  # type: ignore[union-attr]
+    finally:
+        store.close()
+
+
+def test_ticket_scope_and_range(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    release = store.publish(manifest, contents, stable=True, preview=False)
+
+    class FakeKeyset:
+        class Manifest:
+            server_id = "server-1"
+
+        manifest = Manifest()
+        identity_private_key = ec.generate_private_key(ec.SECP256R1())
+
+    device = DeviceRecord("device-1", "pub", "test", datetime.now(timezone.utc), None, ("mobile-webui-ota-v1",))
+
+    class FakeStorage:
+        def read_device(self, device_id: str):
+            return device if device_id == device.device_id else None
+
+    issuer = WebUiTicketIssuer(FakeKeyset(), FakeStorage(), store, connection_checker=lambda _id, epoch: epoch == 7)
+    assert release.stable is not None
+    grant = issuer.issue(device_id=device.device_id, connection_epoch=7, release=release, target_key=release.stable.target_key)
+    verified = issuer.verify(grant.ticket, resource_kind="manifest", resource_digest=release.stable.manifest_digest)
+    assert verified.target_key == release.stable.target_key
+    with pytest.raises(WebUiTicketError):
+        issuer.verify(grant.ticket, resource_kind="blob", resource_digest="0" * 64)
+    assert parse_single_range("bytes=0-3", 10) == (0, 3)
+    assert parse_single_range("bytes=-3", 10) == (7, 9)
+    with pytest.raises(WebUiTicketError):
+        parse_single_range("bytes=0-1,3-4", 10)
+    store.close()
+
+
+def test_webui_commands_and_hint_are_strict() -> None:
+    frame_id = "01J00000000000000000000000"
+    command = parse_frame(json.dumps({"v": 1, "kind": "command", "type": "mobile.webui.content.prepare", "id": frame_id, "connection_epoch": 7, "payload": {"target_key": "a" * 64}}))
+    assert isinstance(command, MobileWebUiContentPrepareCommand)
+    control = parse_frame(json.dumps({"v": 1, "kind": "control", "type": "mobile.webui.release.changed", "connection_epoch": 7, "payload": {"server_id": "server-1", "selection_digest": "b" * 64}}))
+    assert isinstance(control, MobileWebUiReleaseChangedControl)
+    reply = PrepareReplyWire(
+        target_key="a" * 64,
+        manifest_digest="b" * 64,
+        ticket="ticket",
+        expires_at="2026-08-03T00:00:00Z",
+    )
+    assert set(reply.model_dump()) == {"target_key", "manifest_digest", "ticket", "expires_at"}
+    with pytest.raises(ValueError):
+        PrepareReplyWire.model_validate({**reply.model_dump(), "generation_id": "c" * 64}, strict=True)
+    with pytest.raises(ValueError):
+        ReleaseViewWire.model_validate(
+            {
+                "server_id": "server-1",
+                "release_epoch": "00000000-0000-1000-8000-000000000000",
+                "sequence": 0,
+                "selection_digest": "b" * 64,
+                "stable": None,
+                "preview": None,
+            },
+            strict=True,
+        )

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -133,6 +133,46 @@ def test_manifest_directory_uses_fixed_mime_mapping(tmp_path: Path) -> None:
     assert by_path["asset.unknown"] == "application/octet-stream"
 
 
+def test_manifest_directory_covers_wire_reachable_script_and_binary_mimes(tmp_path: Path) -> None:
+    root = tmp_path / "mime-golden"
+    root.mkdir()
+    contents = {
+        "mobile.html": b"<html/>",
+        "app.js": b"console.log(1);",
+        "module.mjs": b"export {};",
+        "worker.cjs": b"module.exports = {};",
+        "style.css": b"body{}",
+        "bundle.map": b"{}",
+        "asset.bin": b"\x00\x01",
+    }
+    for path, data in contents.items():
+        (root / path).write_bytes(data)
+    manifest, _ = manifest_from_directory(root, **_SOURCE)
+    by_path = {item.path: item.mime for item in manifest.files}
+    assert by_path == {
+        "app.js": "text/javascript",
+        "asset.bin": "application/octet-stream",
+        "bundle.map": "application/octet-stream",
+        "mobile.html": "text/html",
+        "module.mjs": "text/javascript",
+        "style.css": "text/css",
+        "worker.cjs": "text/javascript",
+    }
+    from infra.mobile_webui.protocol import WebUiManifestWire, WebUiFileWire
+
+    WebUiManifestWire.model_validate(manifest.as_json(), strict=True)
+    with pytest.raises(ValueError):
+        WebUiFileWire.model_validate(
+            {
+                "path": "bad.js",
+                "sha256": "0" * 64,
+                "size_bytes": 0,
+                "mime": "application/javascript",
+            },
+            strict=True,
+        )
+
+
 def test_manifest_directory_rejects_symlink_and_special_file(tmp_path: Path) -> None:
     root = tmp_path / "special"
     root.mkdir()
@@ -187,6 +227,118 @@ def test_store_rejects_corrupt_release_epoch_on_open(tmp_path: Path) -> None:
         connection.close()
     with pytest.raises(RuntimeError, match="规范 UUID4"):
         MobileWebUiStore(root, server_id="server-1")
+
+
+def test_store_rejects_duplicate_and_nonstandard_manifest_json(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.publish(manifest, contents, stable=True, preview=False)
+    raw = canonical_manifest_bytes(manifest)
+    duplicate = raw[:-1] + b',"generation_id":"' + manifest.generation_id.encode() + b'"}'
+    store._db.execute("UPDATE webui_generations SET manifest_json = ? WHERE generation_id = ?", (duplicate, manifest.generation_id))
+    with pytest.raises(ManifestError, match="重复字段"):
+        store.get_manifest(manifest_digest(manifest))
+    store._db.execute(
+        "UPDATE webui_generations SET manifest_json = ? WHERE generation_id = ?",
+        (raw.replace(str(manifest.unpacked_size_bytes).encode(), b"NaN", 1), manifest.generation_id),
+    )
+    with pytest.raises(ManifestError, match="不允许常量"):
+        store.get_manifest(manifest_digest(manifest))
+    store.close()
+
+
+def test_store_recovers_only_its_blob_temp_residue(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    digest = "a" * 64
+    blob_dir = root / "blobs" / "sha256" / digest[:2]
+    blob_dir.mkdir(parents=True, exist_ok=True)
+    stale = blob_dir / f".{digest}.123.tmp"
+    unrelated = blob_dir / ".not-a-store-temp.tmp"
+    stale.write_bytes(b"partial")
+    unrelated.write_bytes(b"keep")
+    store.close()
+    reopened = MobileWebUiStore(root, server_id="server-1")
+    reopened.close()
+    assert not stale.exists()
+    assert unrelated.read_bytes() == b"keep"
+
+
+def test_restore_appends_audit_event_and_preserves_source_backup(tmp_path: Path) -> None:
+    manifest, contents = _manifest(tmp_path / "build")
+    source = MobileWebUiStore(tmp_path / "source", server_id="server-1")
+    source.publish(manifest, contents, stable=True, preview=False)
+    backup = source.backup_to(tmp_path / "backup")
+    source_descriptor = (backup / "backup.json").read_bytes()
+    source.close()
+    target = MobileWebUiStore(tmp_path / "target", server_id="server-1")
+    target.close()
+    MobileWebUiStore.restore_backup(
+        backup,
+        tmp_path / "target",
+        server_id="server-1",
+        pre_restore_backup=tmp_path / "pre-restore",
+    )
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+    assert (backup / "backup.json").read_bytes() == source_descriptor
+    MobileWebUiStore.verify_backup(tmp_path / "target", server_id="server-1")
+    restored = MobileWebUiStore(tmp_path / "target", server_id="server-1")
+    try:
+        assert restored.get_release().sequence == 2
+        event = restored._db.execute(
+            "SELECT sequence, generation_id, operation, stable, preview, actor FROM webui_publication_journal ORDER BY sequence DESC LIMIT 1"
+        ).fetchone()
+        assert tuple(event) == (2, manifest.generation_id, "restore", 1, 0, "restore-mobile-webui")
+    finally:
+        restored.close()
+    MobileWebUiStore.verify_backup(tmp_path / "pre-restore", server_id="server-1")
+
+
+def test_restore_empty_backup_keeps_no_state_and_records_restore(tmp_path: Path) -> None:
+    source = MobileWebUiStore(tmp_path / "empty", server_id="server-1")
+    backup = source.backup_to(tmp_path / "empty-backup")
+    source.close()
+    MobileWebUiStore.restore_backup(backup, tmp_path / "restored-empty", server_id="server-1")
+    MobileWebUiStore.verify_backup(tmp_path / "restored-empty", server_id="server-1")
+    restored = MobileWebUiStore(tmp_path / "restored-empty", server_id="server-1")
+    try:
+        assert restored.get_release().stable is None
+        event = restored._db.execute(
+            "SELECT sequence, generation_id, operation, stable, preview FROM webui_publication_journal"
+        ).fetchone()
+        assert tuple(event) == (1, None, "restore", 0, 0)
+    finally:
+        restored.close()
+
+
+def test_restore_marker_recovers_old_root_after_swap_gap(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.close()
+    recovery = tmp_path / "store.recovery-test"
+    os.replace(root, recovery)
+    marker = MobileWebUiStore._write_restore_marker(root, recovery)
+    assert marker.exists()
+    recovered = MobileWebUiStore(root, server_id="server-1")
+    recovered.close()
+    assert root.is_dir()
+    assert not recovery.exists()
+    assert not marker.exists()
+
+
+def test_restore_marker_keeps_new_root_when_swap_completed(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = MobileWebUiStore(root, server_id="server-1")
+    store.close()
+    recovery = tmp_path / "store.recovery-new"
+    recovery.mkdir()
+    marker = MobileWebUiStore._write_restore_marker(root, recovery)
+    reopened = MobileWebUiStore(root, server_id="server-1")
+    reopened.close()
+    assert root.is_dir()
+    assert recovery.is_dir()
+    assert not marker.exists()
 
 
 def test_channel_history_is_distinct_per_pointer_and_bounds_gc(tmp_path: Path) -> None:

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -8,17 +8,19 @@ import sqlite3
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 
+from infra.mobile_realtime.key_protection import LoadedKeyset
 from infra.mobile_realtime.protocol import (
     MobileWebUiContentPrepareCommand,
     MobileWebUiReleaseChangedControl,
     parse_frame,
 )
 from infra.mobile_webui.protocol import PrepareReplyWire, ReleaseViewWire
-from infra.mobile_realtime.storage import DeviceRecord
+from infra.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
 from infra.mobile_webui.http import WebUiTicketIssuer, WebUiTicketError, parse_single_range
 from infra.mobile_webui.manifest import (
     ManifestError,
@@ -155,6 +157,29 @@ def test_manifest_rejects_ambiguous_digest_mime() -> None:
         validate_manifest(replace(draft, generation_id=generation_id_for_manifest(draft)))
 
 
+def test_manifest_rejects_ambiguous_digest_size() -> None:
+    digest = "2" * 64
+    draft = WebUiManifest(
+        generation_id="0" * 64,
+        entrypoint="mobile.html",
+        files=(
+            WebUiFile("mobile.html", digest, 1, "text/html"),
+            WebUiFile("screen.htm", digest, 2, "text/html"),
+        ),
+        bridge_protocol_min=1,
+        bridge_protocol_max=1,
+        snapshot_protocol_min=7,
+        snapshot_protocol_max=7,
+        minimum_native_build=45,
+        platforms=("android",),
+        **_SOURCE,
+        unpacked_size_bytes=3,
+        file_count=2,
+    )
+    with pytest.raises(ManifestError, match="size/mime"):
+        validate_manifest(replace(draft, generation_id=generation_id_for_manifest(draft)))
+
+
 def test_manifest_directory_uses_fixed_mime_mapping(tmp_path: Path) -> None:
     root = tmp_path / "mime"
     root.mkdir()
@@ -205,6 +230,24 @@ def test_manifest_directory_covers_wire_reachable_script_and_binary_mimes(tmp_pa
             },
             strict=True,
         )
+
+
+def test_wire_manifest_rejects_ambiguous_digest_size(tmp_path: Path) -> None:
+    root = tmp_path / "wire-size-conflict"
+    root.mkdir()
+    (root / "mobile.html").write_bytes(b"<html/>")
+    manifest, _ = manifest_from_directory(root, **_SOURCE)
+    payload = manifest.as_json()
+    payload["files"] = [
+        {"path": "a.html", "sha256": "0" * 64, "size_bytes": 1, "mime": "text/html"},
+        {"path": "mobile.html", "sha256": "0" * 64, "size_bytes": 2, "mime": "text/html"},
+    ]
+    payload["file_count"] = 2
+    payload["unpacked_size_bytes"] = 3
+    from infra.mobile_webui.protocol import WebUiManifestWire
+
+    with pytest.raises(ValueError, match="size/mime"):
+        WebUiManifestWire.model_validate(payload, strict=True)
 
 
 def test_manifest_directory_rejects_symlink_and_special_file(tmp_path: Path) -> None:
@@ -509,10 +552,15 @@ def test_ticket_scope_and_range(tmp_path: Path) -> None:
     device = DeviceRecord("device-1", "pub", "test", datetime.now(timezone.utc), None, ("mobile-webui-ota-v1",))
 
     class FakeStorage:
-        def read_device(self, device_id: str):
+        def read_device(self, device_id: str) -> DeviceRecord | None:
             return device if device_id == device.device_id else None
 
-    issuer = WebUiTicketIssuer(FakeKeyset(), FakeStorage(), store, connection_checker=lambda _id, epoch: epoch == 7)
+    issuer = WebUiTicketIssuer(
+        cast(LoadedKeyset, FakeKeyset()),
+        cast(MobileRealtimeStorage, FakeStorage()),
+        store,
+        connection_checker=lambda _id, epoch: epoch == 7,
+    )
     assert release.stable is not None
     grant = issuer.issue(device_id=device.device_id, connection_epoch=7, release=release, target_key=release.stable.target_key)
     verified = issuer.verify(grant.ticket, resource_kind="manifest", resource_digest=release.stable.manifest_digest)

--- a/tests/mobile_webui/test_publisher.py
+++ b/tests/mobile_webui/test_publisher.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
+from infra.mobile_webui.store import MobileWebUiStore
 
 
 _PUBLISHER_PATH = Path(__file__).parents[2] / "scripts" / "publish-mobile-webui.py"
@@ -24,7 +26,23 @@ def _repo(tmp_path: Path, *, lock: bool = True) -> Path:
     (repo / "frontend/chat").mkdir(parents=True)
     (repo / "scripts").mkdir()
     (repo / "frontend/chat/mobile.html").write_text("base", encoding="utf-8")
-    (repo / "package.json").write_text('{"name":"test"}\n', encoding="utf-8")
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "test",
+                "scripts": {
+                    "build:mobile-web": (
+                        "node -e \"const fs=require('fs');"
+                        "fs.mkdirSync(process.env.AKASHIC_MOBILE_WEB_OUT_DIR,{recursive:true});"
+                        "fs.copyFileSync('frontend/chat/mobile.html',"
+                        "process.env.AKASHIC_MOBILE_WEB_OUT_DIR+'/mobile.html')\""
+                    )
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     (repo / "scripts/package-mobile-web.sh").write_text("#!/bin/sh\n", encoding="utf-8")
     if lock:
         (repo / "package-lock.json").write_text(
@@ -77,9 +95,10 @@ def test_dirty_overlay_rejects_symlink_and_preserves_tracked_deletion(tmp_path: 
 
 def test_clean_sidecar_rejects_source_race(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
-    before = _PUBLISHER._capture_provenance(repo)
     output = tmp_path / "output"
     output.mkdir()
+    environment = _PUBLISHER._build_environment(output)
+    before = _PUBLISHER._capture_provenance(repo, environment=environment, output_dir=output)
     (output / "mobile.html").write_text("base", encoding="utf-8")
     (tmp_path / "output.provenance.json").write_text(
         json.dumps({**before, "artifact_digest": _PUBLISHER._artifact_digest(output)}),
@@ -89,3 +108,65 @@ def test_clean_sidecar_rejects_source_race(tmp_path: Path) -> None:
     (repo / "frontend/chat/mobile.html").write_text("changed", encoding="utf-8")
     with pytest.raises(RuntimeError, match="source"):
         _PUBLISHER._manifest(repo, output, allow_dirty=False)
+
+
+def test_build_context_tracks_effective_env_and_normalizes_output_dir(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    environment = os.environ.copy()
+    environment["VITE_PUBLIC_THEME"] = "dark"
+    environment["VITE_PRIVATE_TOKEN"] = "do-not-write-this-value"
+    first = _PUBLISHER._capture_provenance(
+        repo,
+        environment={**environment, "AKASHIC_MOBILE_WEB_OUT_DIR": "/tmp/mobile-web-a"},
+        output_dir=Path("/tmp/mobile-web-a"),
+    )
+    second = _PUBLISHER._capture_provenance(
+        repo,
+        environment={**environment, "AKASHIC_MOBILE_WEB_OUT_DIR": "/tmp/mobile-web-b"},
+        output_dir=Path("/tmp/mobile-web-b"),
+    )
+    assert first["build_context_digest"] == second["build_context_digest"]
+    assert "do-not-write-this-value" not in repr(first)
+
+    changed = _PUBLISHER._capture_provenance(
+        repo,
+        environment={
+            **environment,
+            "VITE_PUBLIC_THEME": "light",
+            "AKASHIC_MOBILE_WEB_OUT_DIR": "/tmp/mobile-web-b",
+        },
+        output_dir=Path("/tmp/mobile-web-b"),
+    )
+    assert changed["build_context_digest"] != second["build_context_digest"]
+
+
+def test_build_environment_is_controlled_and_clean_publish_revalidates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setenv("UNTRACKED_BUILD_INPUT", "ignored")
+    output = tmp_path / "build-output"
+    built = _PUBLISHER._build(repo, output, allow_dirty=False, source_commit=None, stable=True)
+    assert "UNTRACKED_BUILD_INPUT" not in _PUBLISHER._build_environment(output)
+    manifest, contents = _PUBLISHER._manifest(repo, built, allow_dirty=False)
+    store = MobileWebUiStore(tmp_path / "store", server_id="server-1")
+    try:
+        release = store.publish(manifest, contents, stable=True, preview=False)
+        assert release.stable is not None
+        assert release.stable.generation_id == manifest.generation_id
+    finally:
+        store.close()
+
+    monkeypatch.setenv("VITE_PUBLIC_THEME", "light")
+    changed_environment = _PUBLISHER._build_environment(output)
+    original_environment = dict(changed_environment)
+    original_environment.pop("VITE_PUBLIC_THEME", None)
+    first = _PUBLISHER._capture_provenance(
+        repo,
+        environment=original_environment,
+        output_dir=output,
+    )
+    second = _PUBLISHER._capture_provenance(
+        repo,
+        environment=changed_environment,
+        output_dir=output,
+    )
+    assert first["build_context_digest"] != second["build_context_digest"]

--- a/tests/mobile_webui/test_publisher.py
+++ b/tests/mobile_webui/test_publisher.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_PUBLISHER_PATH = Path(__file__).parents[2] / "scripts" / "publish-mobile-webui.py"
+_SPEC = importlib.util.spec_from_file_location("publish_mobile_webui", _PUBLISHER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_PUBLISHER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PUBLISHER)
+
+
+def _run(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _repo(tmp_path: Path, *, lock: bool = True) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "frontend/chat").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    (repo / "frontend/chat/mobile.html").write_text("base", encoding="utf-8")
+    (repo / "package.json").write_text('{"name":"test"}\n', encoding="utf-8")
+    (repo / "scripts/package-mobile-web.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    if lock:
+        (repo / "package-lock.json").write_text(
+            '{"name":"test","lockfileVersion":3,"packages":{"":{"name":"test"}}}\n',
+            encoding="utf-8",
+        )
+    _run(repo, "init", "-q")
+    _run(repo, "config", "user.email", "test@example.invalid")
+    _run(repo, "config", "user.name", "Test")
+    _run(repo, "add", ".")
+    _run(repo, "commit", "-qm", "initial")
+    _run(repo, "remote", "add", "origin", "https://github.com/example/test.git")
+    return repo
+
+
+def test_stable_without_commit_lock_fails_before_build(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, lock=False)
+    with pytest.raises(RuntimeError, match="package-lock"):
+        _PUBLISHER._build(repo, None, allow_dirty=False, source_commit=None, stable=True)
+
+
+def test_dirty_preview_overlay_is_frozen_with_untracked_inputs(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "frontend/chat/mobile.html").write_text("dirty", encoding="utf-8")
+    (repo / "frontend/chat/extra.js").write_text("extra", encoding="utf-8")
+    (repo / ".gitignore").write_text("frontend/chat/ignored.js\n", encoding="utf-8")
+    _run(repo, "add", ".gitignore")
+    _run(repo, "commit", "-qm", "ignore rule")
+    (repo / "frontend/chat/ignored.js").write_text("ignored", encoding="utf-8")
+    commit = _PUBLISHER._git(repo, "rev-parse", "HEAD")
+    with _PUBLISHER._build_source(repo, commit, dirty=True) as snapshot:
+        assert (snapshot / "frontend/chat/mobile.html").read_text(encoding="utf-8") == "dirty"
+        assert (snapshot / "frontend/chat/extra.js").read_text(encoding="utf-8") == "extra"
+        assert not (snapshot / "frontend/chat/ignored.js").exists()
+        (repo / "frontend/chat/mobile.html").write_text("changed-after-freeze", encoding="utf-8")
+        assert (snapshot / "frontend/chat/mobile.html").read_text(encoding="utf-8") == "dirty"
+
+
+def test_dirty_overlay_rejects_symlink_and_preserves_tracked_deletion(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "frontend/chat/mobile.html").unlink()
+    commit = _PUBLISHER._git(repo, "rev-parse", "HEAD")
+    with _PUBLISHER._build_source(repo, commit, dirty=True) as snapshot:
+        assert not (snapshot / "frontend/chat/mobile.html").exists()
+    (repo / "frontend/chat/link.js").symlink_to(repo / "package.json")
+    with pytest.raises(RuntimeError, match="symlink"):
+        with _PUBLISHER._build_source(repo, commit, dirty=True):
+            pass
+
+
+def test_clean_sidecar_rejects_source_race(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    before = _PUBLISHER._capture_provenance(repo)
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "mobile.html").write_text("base", encoding="utf-8")
+    (tmp_path / "output.provenance.json").write_text(
+        json.dumps({**before, "artifact_digest": _PUBLISHER._artifact_digest(output)}),
+        encoding="utf-8",
+    )
+    _ = _PUBLISHER._manifest(repo, output, allow_dirty=False)
+    (repo / "frontend/chat/mobile.html").write_text("changed", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="source"):
+        _PUBLISHER._manifest(repo, output, allow_dirty=False)

--- a/tests/mobile_webui/test_publisher.py
+++ b/tests/mobile_webui/test_publisher.py
@@ -170,3 +170,64 @@ def test_build_environment_is_controlled_and_clean_publish_revalidates(tmp_path:
         output_dir=output,
     )
     assert first["build_context_digest"] != second["build_context_digest"]
+
+
+def test_clean_publish_rejects_nondeterministic_artifact_rebuild(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    package = json.loads((repo / "package.json").read_text(encoding="utf-8"))
+    package["scripts"]["build:mobile-web"] = (
+        "node -e \"const fs=require('fs');"
+        "fs.mkdirSync(process.env.AKASHIC_MOBILE_WEB_OUT_DIR,{recursive:true});"
+        "fs.writeFileSync(process.env.AKASHIC_MOBILE_WEB_OUT_DIR+'/mobile.html',String(Math.random()))\""
+    )
+    (repo / "package.json").write_text(json.dumps(package) + "\n", encoding="utf-8")
+    _run(repo, "add", "package.json")
+    _run(repo, "commit", "-qm", "nondeterministic build")
+    output = tmp_path / "nondeterministic-output"
+    built = _PUBLISHER._build(repo, output, allow_dirty=False, source_commit=None, stable=True)
+    with pytest.raises(RuntimeError, match="artifact 不可复现"):
+        _PUBLISHER._manifest(repo, built, allow_dirty=False)
+
+
+def test_internal_publish_cleans_build_sidecar_on_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    workspace = tmp_path / "runtime-workspace"
+    assert _PUBLISHER.main(
+        [
+            "publish",
+            "--source-repository",
+            str(repo),
+            "--workspace",
+            str(workspace),
+            "--server-id",
+            "server-1",
+            "--stable",
+        ]
+    ) == 0
+    _ = capsys.readouterr()
+    assert not list(workspace.glob("mobile-webui-build-*.provenance.json"))
+
+
+def test_internal_publish_cleans_build_sidecar_on_build_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _repo(tmp_path)
+    workspace = tmp_path / "runtime-workspace"
+
+    def fail_build(source: Path, output: Path, **_kwargs: object) -> Path:
+        output.mkdir(parents=True, exist_ok=True)
+        output.with_name(output.name + ".provenance.json").write_text("owned", encoding="utf-8")
+        raise RuntimeError("synthetic build failure")
+
+    monkeypatch.setattr(_PUBLISHER, "_build", fail_build)
+    with pytest.raises(RuntimeError, match="synthetic build failure"):
+        _PUBLISHER.main(
+            [
+                "publish",
+                "--source-repository",
+                str(repo),
+                "--workspace",
+                str(workspace),
+                "--server-id",
+                "server-1",
+            ]
+        )
+    assert not list(workspace.glob("mobile-webui-build-*.provenance.json"))

--- a/tests_scenarios/contracts/coverage-baseline.json
+++ b/tests_scenarios/contracts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "acceptedGaps": [],
   "base": "d627fa600781855770a5ede752f268982b68ebf9",
-  "catalogDigest": "a2a598b26f89ba4dca06a0b7545182ff742231eb0c3c7c022ea7458df9a35466",
+  "catalogDigest": "4bad9bf2f6284b6d27d8d9b73ba469c795151b1e7e428a66274a1cdce6e14cca",
   "purpose": "approved_contract_mapping",
   "coveredP0": {
     "companion_control": [

--- a/tests_scenarios/contracts/impact.toml
+++ b/tests_scenarios/contracts/impact.toml
@@ -77,6 +77,41 @@ paths = [
 depends_on = ["channel", "plugin", "session_persistence"]
 scenarios = ["mobile_realtime_contract"]
 
+[groups.mobile_webui]
+priority = "p1"
+requirements = [
+  "WEBUI-001",
+  "WEBUI-002",
+  "WEBUI-003",
+  "WEBUI-004",
+  "WEBUI-005",
+  "WEBUI-006",
+  "MOB-001",
+  "CAP-001",
+  "CAP-002",
+  "ERR-001",
+  "TST-001",
+  "TST-002",
+  "TST-005",
+  "TST-006",
+  "TST-007",
+  "TST-008",
+]
+paths = [
+  "frontend/chat/**",
+  "infra/mobile_realtime/gateway.py",
+  "infra/mobile_realtime/protocol.py",
+  "infra/mobile_webui/**",
+  "package-lock.json",
+  "schema/mobile-realtime-v1.json",
+  "scripts/generate_mobile_realtime_schema.py",
+  "scripts/publish-mobile-webui.py",
+  "tests/mobile_realtime/test_mobile_realtime_protocol.py",
+  "tests/mobile_webui/**",
+]
+depends_on = ["mobile_realtime"]
+scenarios = ["mobile_webui_contract"]
+
 [groups.mcp]
 priority = "p0"
 requirements = ["PLG-004", "PLG-008", "PLG-009", "TST-001", "TST-003"]
@@ -349,6 +384,7 @@ paths = [
   "pyproject.toml",
   "pyrightconfig*.json",
   "requirements*.txt",
+  "package-lock.json",
   "private_runtime",
   "scripts/**",
   "skills/**",

--- a/tests_scenarios/contracts/scenarios.toml
+++ b/tests_scenarios/contracts/scenarios.toml
@@ -148,6 +148,50 @@ command = [
 observes = ["protocol_frames", "session_identity", "durable_delivery", "resume_cursor", "attachment_finality", "plugin_ui_snapshot"]
 mutants = ["unicode_utf16_command_length"]
 
+[scenarios.mobile_webui_contract]
+requirements = [
+  "WEBUI-001",
+  "WEBUI-002",
+  "WEBUI-003",
+  "WEBUI-004",
+  "WEBUI-005",
+  "WEBUI-006",
+  "MOB-001",
+  "CAP-001",
+  "CAP-002",
+  "ERR-001",
+  "TST-001",
+  "TST-002",
+  "TST-005",
+  "TST-006",
+  "TST-007",
+  "TST-008",
+]
+groups = ["mobile_webui"]
+environment = "public_clean_workspace"
+timeout_seconds = 180
+command = [
+  "python",
+  "-m",
+  "pytest",
+  "-q",
+  "tests/mobile_webui",
+  "tests/mobile_realtime/test_mobile_realtime_protocol.py",
+]
+observes = [
+  "release_view",
+  "generation_manifest",
+  "blob_cas_integrity",
+  "target_scoped_ticket",
+  "range_digest_headers",
+  "publication_write_set",
+  "publication_recovery",
+  "publication_gc_reachability",
+  "build_provenance_reproducibility",
+  "failure_semantics",
+]
+mutants = []
+
 [scenarios.mcp_call_finality]
 requirements = ["PLG-004", "PLG-008", "TST-001", "TST-003"]
 groups = ["mcp"]

--- a/tests_scenarios/contracts/state-contracts.toml
+++ b/tests_scenarios/contracts/state-contracts.toml
@@ -75,6 +75,49 @@ physical_reduction_owner = "mobile.receipt_store"
 recovery_evidence = ["receipt_retention", "external_effect_reconciliation", "receipt_write_set"]
 failure_semantics = ["operation_rejected", "unit_failed", "cleanup_degraded", "runtime_fatal"]
 
+[states.mobile_webui_publication]
+priority = "p1"
+requirements = [
+  "WEBUI-004",
+  "WEBUI-005",
+  "WEBUI-006",
+  "MOB-001",
+  "CAP-001",
+  "CAP-002",
+  "ERR-001",
+  "TST-001",
+  "TST-002",
+  "TST-005",
+  "TST-006",
+  "TST-007",
+  "TST-008",
+]
+owner = "mobile_webui.publication_store"
+normal_change = "append_state_machine"
+destructive_owner = "protocol_owner"
+writers = ["mobile_webui"]
+consumers = ["mobile_webui", "mobile_realtime"]
+protected_tables = [
+  "webui_meta",
+  "webui_generations",
+  "webui_generation_files",
+  "webui_blobs",
+  "webui_release_state",
+  "webui_pins",
+  "webui_channel_selections",
+  "webui_backup_sets",
+  "webui_publication_journal",
+]
+oracles = ["mobile_webui_contract"]
+retention = "immutable generations and CAS blobs remain until no ReleaseView, pin, backup, channel-history or active candidate reference is reachable; publication journal is append-only"
+physical_reduction_owner = "mobile_webui.publication_store"
+recovery_evidence = [
+  "publication_write_set",
+  "publication_recovery",
+  "publication_gc_reachability",
+]
+failure_semantics = ["operation_rejected", "unit_failed", "cleanup_degraded", "runtime_fatal"]
+
 [states.mcp_reservoir]
 priority = "p0"
 requirements = ["SEC-004", "PRO-002", "TST-001", "TST-002", "TST-003"]


### PR DESCRIPTION
## 问题与结果

- 解决的问题：移动端的共享 WebUI 只能随 APK 发布，纯样式、布局和既有 bridge 交互调整也必须重新发包。
- 用户可见结果：Core 可显式发布不可变 Stable/Preview generation，已配对移动端只解析服务端当前选择，下载本地完整验证资源，并在新 UI session 激活；无发布、离线或失败仍由 APK embedded baseline 托底。
- 本 PR 不处理：Android 消费端实现与 APK 发行（后续独立 PR）；GitHub APK updater 与 Google Play 发行策略保持原状。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Android 当前消费，未来 iOS 可消费同一发布合同；旧移动端无 capability 时不收到 hint
- `runtime_patch`：`required`
- `runtime_patch_reason`：需要新 runtime 加载 `mobile-webui-ota-v1`、发布仓、WSS resolve/prepare 与 HTTPS manifest/blob 路由
- `authoritative_state_owner`：`infra.mobile_webui.MobileWebUiStore`，固定于 `<workspace>/mobile-webui/`
- `client_only_alternative`：客户端只能继续使用 embedded baseline，无法达成服务端 UI-only 发布与回滚
- 关联不变量：`WEBUI-001`～`WEBUI-006`、`MOB-001`、`CAP-001`、`CAP-002`、`ERR-001`、`TST-001`、`TST-002`、`TST-005`～`TST-008`
- `protected_state`：`sessions.db/messages`、实时回执、plugin-data、附件、调度、配对与正式 workspace 其他状态
- 允许的副作用：只有名称明确的 publish/promote/rollback/clear/pin/GC/backup/restore 可改变独立 WebUI 发布仓；selection 变化可向具备 capability 的已认证连接发非持久 hint
- 禁止的副作用：保存源码、普通构建、watcher 或 runtime 重启不自动发布；不写 `sessions.db`、`mobile_realtime.db`、plugin-data，不向无 capability 设备发 hint

## 改动范围

- 主要文件：`infra/mobile_webui/**`、`infra/mobile_realtime/{gateway,protocol}.py`、`frontend/chat/**`、`scripts/publish-mobile-webui.py`、`schema/mobile-realtime-v1.json`、`tests/mobile_webui/**`、决策/设计/持久化手册与 Change Gate catalog
- 配置或迁移影响：新增独立 `<workspace>/mobile-webui/publication.sqlite3` 与按 SHA-256 寻址 blobs；不迁移、不改写既有业务数据库
- 已知 schema lineage 与最终 schema identity：新建 Core publication schema；generation manifest 固定 schema 2；mobile realtime schema 由 generator 生成并通过 `--check`
- 协议 source、runtime、provider 与 scenario 的不可变 revision：Core head `05a4ca43396687799fc31bc5b97b66da4694a383`；base `3dd2d8351c6f5e7ae4241a46734a8c94eee2285b`；发布协议与 provider 同此 PR head；`mobile_webui_contract` 由 Change Gate catalog 固定
- 回滚方式：先把 Stable/Preview 显式 clear/rollback 到已知 generation 或 baseline，再 revert 本 PR；发布仓 backup/restore 保留可审计恢复点

## 验证

- [x] 相关 targeted tests 已通过：`249 passed` (`tests/mobile_webui tests/mobile_realtime`)；隔离 Gate 中 `mobile_webui_contract` `91 passed`
- [x] `npm run lint`、`npm run typecheck`、`npm run build` 通过；`python scripts/generate_mobile_realtime_schema.py --check` 通过
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：22 checks 全绿，残留 containers/networks/volumes 均为空，报告 `docker/debug/reports/change-gate/20260803-073814-5904ad57`
- `sourceDigest`：`13c3da00e6f39f5b3f6c51907ff7a28280e643f1ab992a2d144454bbe9a1ec40`
- `planDigest`：`68ff963a2340400ab7379bc20fc5ba52343ab8d2cb3b270f06c8b21882967fe0`
- 真实设备证据：不适用于 Core provider PR；跨仓库 Android 消费 PR 将使用隔离 application ID/workspace 与固定 Core revision 进行真机 Gate
- 未运行项与原因：本 PR 未对正式 workspace 执行发布或设备配对，以避免生产数据写入；这些将在隔离 runtime 完成

## 工作手册

- [x] 已核对 `projectneed.md`、决策 0018/0022、持久化地图和 `NOW.md`。
- [x] 长期语义变化已由维护者确认，并写入 accepted 决策 0022。
- [x] 跨仓库能力 owner 已核对：Core 拥有发布选择/资源与协议真源，Android 拥有下载/校验/缓存/激活/回退。
- [x] `NOW.md` 无本任务对应已完成条目，不适用。

