### PR TITLE
fix(mobile-webui): make restore recovery crash-safe

### DIFF
--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -93,7 +93,7 @@ class MobileWebUiStore:
         self.trash_root = root / "trash"
         self.lock_path = root / "publication.lock"
         self.server_id = server_id
-        self._recover_restore_marker(root)
+        self._recover_restore_marker(root, server_id=server_id)
         self.root.mkdir(parents=True, exist_ok=True)
         self.blob_root.mkdir(parents=True, exist_ok=True)
         self.staging_root.mkdir(parents=True, exist_ok=True)
@@ -548,7 +548,7 @@ class MobileWebUiStore:
 
         MobileWebUiStore.verify_backup(destination, server_id=server_id)
         target_root = _absolute_path(target_root)
-        MobileWebUiStore._recover_restore_marker(target_root)
+        MobileWebUiStore._recover_restore_marker(target_root, server_id=server_id)
         target_root.parent.mkdir(parents=True, exist_ok=True)
         if target_root.is_symlink() or (target_root.exists() and not target_root.is_dir()):
             raise RuntimeError("WebUI restore target 必须是普通目录")
@@ -560,7 +560,12 @@ class MobileWebUiStore:
             MobileWebUiStore._append_restore_journal(temporary, server_id=server_id)
             MobileWebUiStore._refresh_backup_descriptor(temporary)
             MobileWebUiStore.verify_backup(temporary, server_id=server_id)
-            if target_root.exists():
+            # 1. 先把候选树的内容和目录项完整落盘，再写 marker 或移动旧 root。
+            MobileWebUiStore._fsync_tree(temporary)
+            expected_tree_digest = _tree_digest(temporary)
+            had_target = target_root.exists()
+            recovery_root = target_root.with_name(f"{target_root.name}.recovery-{uuid4()}")
+            if had_target:
                 backup_path = pre_restore_backup or target_root.with_name(f"{target_root.name}.pre-restore-{uuid4()}")
                 if backup_path.exists():
                     raise FileExistsError(backup_path)
@@ -570,8 +575,16 @@ class MobileWebUiStore:
                     MobileWebUiStore.verify_backup(backup_path, server_id=server_id)
                 finally:
                     existing.close()
-                old_root = target_root.with_name(f"{target_root.name}.recovery-{uuid4()}")
-                restore_marker = MobileWebUiStore._write_restore_marker(target_root, old_root)
+                old_root = recovery_root
+            restore_marker = MobileWebUiStore._write_restore_marker(
+                target_root,
+                recovery_root,
+                temporary_root=temporary,
+                server_id=server_id,
+                expected_tree_digest=expected_tree_digest,
+                had_target=had_target,
+            )
+            if old_root is not None:
                 os.replace(target_root, old_root)
                 MobileWebUiStore._fsync_directory(target_root.parent)
             try:
@@ -583,12 +596,14 @@ class MobileWebUiStore:
                     MobileWebUiStore._fsync_directory(target_root.parent)
                 raise
             if restore_marker is not None:
+                if old_root is not None:
+                    MobileWebUiStore._remove_restore_recovery(old_root)
                 MobileWebUiStore._clear_restore_marker(restore_marker)
             return target_root
         except BaseException:
-            if restore_marker is not None and target_root.exists():
-                MobileWebUiStore._clear_restore_marker(restore_marker)
-            shutil.rmtree(temporary, ignore_errors=True)
+            # Marker 存在时把候选树和旧 root 交给启动恢复；不能提前清掉唯一证据。
+            if restore_marker is None:
+                shutil.rmtree(temporary, ignore_errors=True)
             raise
 
     @staticmethod
@@ -883,8 +898,8 @@ class MobileWebUiStore:
         return root.with_name(f".{root.name}.restore-pending.json")
 
     @staticmethod
-    def _recover_restore_marker(root: Path) -> None:
-        """Recover a store swap interrupted between old-root rename and new-root install."""
+    def _recover_restore_marker(root: Path, *, server_id: str | None = None) -> None:
+        """Recover an interrupted store swap without accepting an unverified new root."""
 
         target_root = _absolute_path(root)
         marker = MobileWebUiStore._restore_marker_path(target_root)
@@ -893,38 +908,181 @@ class MobileWebUiStore:
         if marker.is_symlink() or not marker.is_file():
             raise RuntimeError("WebUI restore marker 不是普通文件")
         try:
-            payload = json.loads(marker.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            payload = _strict_json_loads(marker.read_bytes())
+        except (OSError, ManifestError) as error:
             raise RuntimeError("WebUI restore marker 损坏") from error
-        if not isinstance(payload, dict) or set(payload) != {"target_root", "recovery_root"}:
+        expected_fields = {
+            "expected_tree_digest",
+            "had_target",
+            "recovery_root",
+            "server_id",
+            "target_root",
+            "temporary_root",
+        }
+        if not isinstance(payload, dict) or set(payload) != expected_fields:
             raise RuntimeError("WebUI restore marker 字段不符合合同")
-        if payload["target_root"] != str(target_root) or not isinstance(payload["recovery_root"], str):
-            raise RuntimeError("WebUI restore marker 路径不符合合同")
-        recovery_root = _absolute_path(Path(payload["recovery_root"]))
-        if recovery_root == target_root or not recovery_root.name.startswith(f"{target_root.name}.recovery-"):
+        if payload["target_root"] != str(target_root):
+            raise RuntimeError("WebUI restore marker target 路径不符合合同")
+        marker_server_id = payload["server_id"]
+        expected_tree_digest = payload["expected_tree_digest"]
+        had_target = payload["had_target"]
+        if (
+            not isinstance(marker_server_id, str)
+            or (server_id is not None and marker_server_id != server_id)
+            or not isinstance(expected_tree_digest, str)
+            or not _valid_digest(expected_tree_digest)
+            or not isinstance(had_target, bool)
+        ):
+            raise RuntimeError("WebUI restore marker identity 不符合合同")
+        recovery_root = _absolute_path(_require_marker_path(payload["recovery_root"], "recovery_root"))
+        temporary_root = _absolute_path(_require_marker_path(payload["temporary_root"], "temporary_root"))
+        if (
+            recovery_root == target_root
+            or recovery_root.parent != target_root.parent
+            or not recovery_root.name.startswith(f"{target_root.name}.recovery-")
+        ):
             raise RuntimeError("WebUI restore marker recovery 路径不符合合同")
+        if (
+            temporary_root == target_root
+            or temporary_root == recovery_root
+            or temporary_root.parent != target_root.parent
+            or not temporary_root.name.startswith(f".{target_root.name}.")
+        ):
+            raise RuntimeError("WebUI restore marker temporary 路径不符合合同")
         if target_root.is_symlink():
             raise RuntimeError("WebUI restore marker target 不能是符号链接")
-        if target_root.exists():
-            if not target_root.is_dir():
-                raise RuntimeError("WebUI restore marker target 必须是普通目录")
+        if recovery_root.is_symlink():
+            raise RuntimeError("WebUI restore marker recovery 不能是符号链接")
+        if temporary_root.is_symlink():
+            raise RuntimeError("WebUI restore marker temporary 不能是符号链接")
+        target_exists = target_root.exists()
+        recovery_exists = recovery_root.exists()
+        if target_exists and not target_root.is_dir():
+            raise RuntimeError("WebUI restore marker target 必须是普通目录")
+        if recovery_exists and not recovery_root.is_dir():
+            raise RuntimeError("WebUI restore marker recovery 必须是普通目录")
+
+        # 1. 两个 root 同时存在时，先完整验证新候选再清理 marker。
+        if target_exists and recovery_exists:
+            if not had_target:
+                raise RuntimeError("WebUI restore marker 无旧 target 却同时存在 recovery")
+            try:
+                MobileWebUiStore._verify_restored_root(
+                    target_root,
+                    server_id=marker_server_id,
+                    expected_tree_digest=expected_tree_digest,
+                )
+            except (ManifestError, OSError, RuntimeError, sqlite3.Error, TypeError, ValueError) as error:
+                failed_root = target_root.with_name(f"{target_root.name}.restore-failed-{uuid4().hex}")
+                if failed_root.exists() or failed_root.is_symlink():
+                    raise FileExistsError(failed_root) from error
+                os.replace(target_root, failed_root)
+                MobileWebUiStore._fsync_directory(target_root.parent)
+                os.replace(recovery_root, target_root)
+                MobileWebUiStore._fsync_directory(target_root.parent)
+                MobileWebUiStore._remove_restore_temporary(temporary_root)
+                MobileWebUiStore._clear_restore_marker(marker)
+                return
+            MobileWebUiStore._remove_restore_recovery(recovery_root)
+            MobileWebUiStore._remove_restore_temporary(temporary_root)
             MobileWebUiStore._clear_restore_marker(marker)
             return
-        if recovery_root.is_symlink() or not recovery_root.is_dir():
-            raise RuntimeError("WebUI restore marker 缺少可恢复旧 store")
-        target_root.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(recovery_root, target_root)
-        MobileWebUiStore._fsync_directory(target_root.parent)
-        MobileWebUiStore._clear_restore_marker(marker)
+
+        # 2. 只有 target 时，按 marker 区分旧 root 与无旧 root 的新候选。
+        if target_exists:
+            if not had_target:
+                MobileWebUiStore._verify_restored_root(
+                    target_root,
+                    server_id=marker_server_id,
+                    expected_tree_digest=expected_tree_digest,
+                )
+            MobileWebUiStore._remove_restore_temporary(temporary_root)
+            MobileWebUiStore._clear_restore_marker(marker)
+            return
+
+        # 3. 无旧 root 时，先验证 marker 绑定的完整 temporary，再完成安装。
+        if not had_target and not recovery_exists:
+            MobileWebUiStore._verify_restored_root(
+                temporary_root,
+                server_id=marker_server_id,
+                expected_tree_digest=expected_tree_digest,
+            )
+            target_root.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(temporary_root, target_root)
+            MobileWebUiStore._fsync_directory(target_root.parent)
+            MobileWebUiStore._clear_restore_marker(marker)
+            return
+
+        # 4. rename gap 没有 target，先恢复 marker 所有的旧 root。
+        if recovery_exists:
+            if not had_target:
+                raise RuntimeError("WebUI restore marker 无旧 target 却存在 recovery")
+            target_root.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(recovery_root, target_root)
+            MobileWebUiStore._fsync_directory(target_root.parent)
+            MobileWebUiStore._remove_restore_temporary(temporary_root)
+            MobileWebUiStore._clear_restore_marker(marker)
+            return
+        raise RuntimeError("WebUI restore marker 同时缺少 target 和 recovery")
 
     @staticmethod
-    def _write_restore_marker(target_root: Path, recovery_root: Path) -> Path:
+    def _verify_restored_root(root: Path, *, server_id: str, expected_tree_digest: str) -> None:
+        """Verify the newly installed backup tree and its marker-bound identity."""
+
+        MobileWebUiStore.verify_backup(root, server_id=server_id)
+        if _tree_digest(root) != expected_tree_digest:
+            raise RuntimeError("WebUI restore target 与 marker 绑定摘要不一致")
+
+    @staticmethod
+    def _remove_restore_temporary(root: Path) -> None:
+        """Remove only the temporary tree named by a durable restore marker."""
+
+        if root.is_symlink():
+            raise RuntimeError("WebUI restore temporary 不能是符号链接")
+        if root.is_dir():
+            shutil.rmtree(root)
+            MobileWebUiStore._fsync_directory(root.parent)
+        elif root.exists():
+            raise RuntimeError("WebUI restore temporary 必须是目录")
+
+    @staticmethod
+    def _remove_restore_recovery(root: Path) -> None:
+        """Durably remove the old root after the new restore is verified."""
+
+        if root.is_symlink():
+            raise RuntimeError("WebUI restore recovery 不能是符号链接")
+        if root.is_dir():
+            shutil.rmtree(root)
+            MobileWebUiStore._fsync_directory(root.parent)
+        elif root.exists():
+            raise RuntimeError("WebUI restore recovery 必须是目录")
+
+    @staticmethod
+    def _write_restore_marker(
+        target_root: Path,
+        recovery_root: Path,
+        *,
+        temporary_root: Path,
+        server_id: str,
+        expected_tree_digest: str,
+        had_target: bool,
+    ) -> Path:
         target_root = _absolute_path(target_root)
         recovery_root = _absolute_path(recovery_root)
+        temporary_root = _absolute_path(temporary_root)
+        if not _valid_digest(expected_tree_digest):
+            raise ValueError("WebUI restore marker expected_tree_digest 无效")
         marker = MobileWebUiStore._restore_marker_path(target_root)
         temporary = marker.with_name(f".{marker.name}.{uuid4().hex}.tmp")
         payload = json.dumps(
-            {"target_root": str(target_root), "recovery_root": str(recovery_root)},
+            {
+                "expected_tree_digest": expected_tree_digest,
+                "had_target": had_target,
+                "recovery_root": str(recovery_root),
+                "server_id": server_id,
+                "target_root": str(target_root),
+                "temporary_root": str(temporary_root),
+            },
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
@@ -1200,6 +1358,17 @@ def _absolute_path(path: Path) -> Path:
     """Make a lexical absolute path without following the destination symlink."""
 
     return Path(os.path.abspath(os.fspath(path)))
+
+
+def _require_marker_path(value: object, label: str) -> Path:
+    """Validate a restore marker path before any filesystem operation."""
+
+    if not isinstance(value, str):
+        raise RuntimeError(f"WebUI restore marker {label} 路径类型无效")
+    path = _absolute_path(Path(value))
+    if value != str(path):
+        raise RuntimeError(f"WebUI restore marker {label} 必须是规范绝对路径")
+    return path
 
 
 def _strict_json_loads(payload: bytes) -> object:

--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -601,7 +601,7 @@ class MobileWebUiStore:
                 MobileWebUiStore._clear_restore_marker(restore_marker)
             return target_root
         except BaseException:
-            # Marker 存在时把候选树和旧 root 交给启动恢复；不能提前清掉唯一证据。
+            # 恢复标记存在时，把候选树和旧 root 交给启动恢复；不能提前清掉唯一证据。
             if restore_marker is None:
                 shutil.rmtree(temporary, ignore_errors=True)
             raise
@@ -899,7 +899,7 @@ class MobileWebUiStore:
 
     @staticmethod
     def _recover_restore_marker(root: Path, *, server_id: str | None = None) -> None:
-        """Recover an interrupted store swap without accepting an unverified new root."""
+        """恢复被中断的 store 切换，不接受未经验证的新 root。"""
 
         target_root = _absolute_path(root)
         marker = MobileWebUiStore._restore_marker_path(target_root)
@@ -1027,7 +1027,7 @@ class MobileWebUiStore:
 
     @staticmethod
     def _verify_restored_root(root: Path, *, server_id: str, expected_tree_digest: str) -> None:
-        """Verify the newly installed backup tree and its marker-bound identity."""
+        """校验新安装的备份树及恢复标记绑定的身份。"""
 
         MobileWebUiStore.verify_backup(root, server_id=server_id)
         if _tree_digest(root) != expected_tree_digest:
@@ -1035,7 +1035,7 @@ class MobileWebUiStore:
 
     @staticmethod
     def _remove_restore_temporary(root: Path) -> None:
-        """Remove only the temporary tree named by a durable restore marker."""
+        """只删除持久恢复标记指定的 temporary 目录。"""
 
         if root.is_symlink():
             raise RuntimeError("WebUI restore temporary 不能是符号链接")
@@ -1047,7 +1047,7 @@ class MobileWebUiStore:
 
     @staticmethod
     def _remove_restore_recovery(root: Path) -> None:
-        """Durably remove the old root after the new restore is verified."""
+        """新 root 验证通过后，持久删除旧 root。"""
 
         if root.is_symlink():
             raise RuntimeError("WebUI restore recovery 不能是符号链接")
@@ -1361,7 +1361,7 @@ def _absolute_path(path: Path) -> Path:
 
 
 def _require_marker_path(value: object, label: str) -> Path:
-    """Validate a restore marker path before any filesystem operation."""
+    """在访问文件系统前校验恢复标记路径。"""
 
     if not isinstance(value, str):
         raise RuntimeError(f"WebUI restore marker {label} 路径类型无效")

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -8,7 +8,7 @@ import sqlite3
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -93,7 +93,7 @@ def _kill_backup_after_rename(root: str, destination: str) -> None:
 
 
 def _restore_fixture(root: Path) -> tuple[Path, Path, Path, WebUiManifest, WebUiManifest]:
-    """Create a verified source backup and a distinct old target store."""
+    """创建已验证的 source backup 和独立旧 target store。"""
 
     source_manifest, source_contents = _manifest(root / "source-build", b"<html>new</html>\n")
     source = MobileWebUiStore(root / "source", server_id="server-1")
@@ -535,6 +535,7 @@ def test_restore_appends_audit_event_and_preserves_source_backup(tmp_path: Path)
         server_id="server-1",
         pre_restore_backup=tmp_path / "pre-restore",
     )
+    assert not list(tmp_path.glob("target.recovery-*"))
     MobileWebUiStore.verify_backup(backup, server_id="server-1")
     assert (backup / "backup.json").read_bytes() == source_descriptor
     MobileWebUiStore.verify_backup(tmp_path / "target", server_id="server-1")
@@ -837,6 +838,95 @@ def test_restore_parent_fsync_failure_keeps_marker_for_valid_new_recovery(
         recovered.close()
     assert not marker.exists()
     assert not recovery_roots[0].exists()
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_recovery_delete_failure_keeps_marker_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infra.mobile_webui import store as store_module
+
+    backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
+    original_rmtree = store_module.shutil.rmtree
+    state = {"failed": False}
+
+    def rmtree(path: str | os.PathLike[str], *args: Any, **kwargs: Any) -> None:
+        if Path(path).name.startswith("target.recovery-") and not state["failed"]:
+            state["failed"] = True
+            raise OSError("injected recovery delete failure")
+        original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(store_module.shutil, "rmtree", rmtree)
+    with pytest.raises(OSError, match="recovery delete"):
+        MobileWebUiStore.restore_backup(
+            backup,
+            target,
+            server_id="server-1",
+            pre_restore_backup=pre_restore,
+        )
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    recovery_roots = list(tmp_path.glob("target.recovery-*"))
+    assert len(recovery_roots) == 1
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not recovery_roots[0].exists()
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_recovery_delete_fsync_failure_keeps_marker_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infra.mobile_webui import store as store_module
+
+    backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
+    original_rmtree = store_module.shutil.rmtree
+    original_fsync_directory = store_module.MobileWebUiStore._fsync_directory
+    state = {"recovery_deleted": False, "failed": False}
+
+    def rmtree(path: str | os.PathLike[str], *args: Any, **kwargs: Any) -> None:
+        original_rmtree(path, *args, **kwargs)
+        if Path(path).name.startswith("target.recovery-"):
+            state["recovery_deleted"] = True
+
+    def fsync_directory(path: Path) -> None:
+        if state["recovery_deleted"] and not state["failed"]:
+            state["failed"] = True
+            raise OSError("injected recovery parent fsync failure")
+        original_fsync_directory(path)
+
+    monkeypatch.setattr(store_module.shutil, "rmtree", rmtree)
+    monkeypatch.setattr(store_module.MobileWebUiStore, "_fsync_directory", staticmethod(fsync_directory))
+    with pytest.raises(OSError, match="recovery parent fsync"):
+        MobileWebUiStore.restore_backup(
+            backup,
+            target,
+            server_id="server-1",
+            pre_restore_backup=pre_restore,
+        )
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    assert not list(tmp_path.glob("target.recovery-*"))
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
     MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
     MobileWebUiStore.verify_backup(backup, server_id="server-1")
 

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -92,6 +92,105 @@ def _kill_backup_after_rename(root: str, destination: str) -> None:
     store.backup_to(Path(destination))
 
 
+def _restore_fixture(root: Path) -> tuple[Path, Path, Path, WebUiManifest, WebUiManifest]:
+    """Create a verified source backup and a distinct old target store."""
+
+    source_manifest, source_contents = _manifest(root / "source-build", b"<html>new</html>\n")
+    source = MobileWebUiStore(root / "source", server_id="server-1")
+    source.publish(source_manifest, source_contents, stable=True, preview=False)
+    source_backup = source.backup_to(root / "source-backup")
+    source.close()
+
+    old_manifest, old_contents = _manifest(root / "old-build", b"<html>old</html>\n")
+    target = MobileWebUiStore(root / "target", server_id="server-1")
+    target.publish(old_manifest, old_contents, stable=True, preview=False)
+    target.close()
+    return source_backup, root / "target", root / "pre-restore", source_manifest, old_manifest
+
+
+def _restore_target_name(target: str) -> str:
+    return Path(target).name
+
+
+def _kill_restore_before_old_rename(backup: str, target: str, pre_restore: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    target_name = _restore_target_name(target)
+
+    def kill_before_old_rename(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        if Path(destination).name.startswith(f"{target_name}.recovery-"):
+            os.kill(os.getpid(), signal.SIGKILL)
+        original_replace(source, destination)
+
+    store_module.os.replace = kill_before_old_rename
+    store_module.MobileWebUiStore.restore_backup(
+        Path(backup),
+        Path(target),
+        server_id="server-1",
+        pre_restore_backup=Path(pre_restore),
+    )
+
+
+def _kill_restore_after_old_rename(backup: str, target: str, pre_restore: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    target_name = _restore_target_name(target)
+
+    def kill_after_old_rename(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        original_replace(source, destination)
+        if Path(destination).name.startswith(f"{target_name}.recovery-"):
+            os.kill(os.getpid(), signal.SIGKILL)
+
+    store_module.os.replace = kill_after_old_rename
+    store_module.MobileWebUiStore.restore_backup(
+        Path(backup),
+        Path(target),
+        server_id="server-1",
+        pre_restore_backup=Path(pre_restore),
+    )
+
+
+def _kill_restore_after_new_install(backup: str, target: str, pre_restore: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    absolute_target = os.path.abspath(target)
+
+    def kill_after_new_install(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        original_replace(source, destination)
+        if os.path.abspath(os.fspath(destination)) == absolute_target:
+            os.kill(os.getpid(), signal.SIGKILL)
+
+    store_module.os.replace = kill_after_new_install
+    store_module.MobileWebUiStore.restore_backup(
+        Path(backup),
+        Path(target),
+        server_id="server-1",
+        pre_restore_backup=Path(pre_restore),
+    )
+
+
+def _kill_restore_before_new_install_without_old(backup: str, target: str) -> None:
+    from infra.mobile_webui import store as store_module
+
+    original_replace = store_module.os.replace
+    marker_path = os.path.abspath(store_module.MobileWebUiStore._restore_marker_path(Path(target)))
+
+    def kill_after_marker_install(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        original_replace(source, destination)
+        if os.path.abspath(os.fspath(destination)) == marker_path:
+            os.kill(os.getpid(), signal.SIGKILL)
+
+    store_module.os.replace = kill_after_marker_install
+    store_module.MobileWebUiStore.restore_backup(
+        Path(backup),
+        Path(target),
+        server_id="server-1",
+    )
+
+
 def test_golden_manifest_and_derived_ids() -> None:
     fixture = json.loads(
         (Path(__file__).parent / "fixtures" / "manifest-v2.json").read_text()
@@ -486,7 +585,14 @@ def test_restore_marker_recovers_old_root_after_swap_gap(tmp_path: Path) -> None
     store.close()
     recovery = tmp_path / "store.recovery-test"
     os.replace(root, recovery)
-    marker = MobileWebUiStore._write_restore_marker(root, recovery)
+    marker = MobileWebUiStore._write_restore_marker(
+        root,
+        recovery,
+        temporary_root=tmp_path / ".store.candidate",
+        server_id="server-1",
+        expected_tree_digest="a" * 64,
+        had_target=True,
+    )
     assert marker.exists()
     recovered = MobileWebUiStore(root, server_id="server-1")
     recovered.close()
@@ -495,18 +601,284 @@ def test_restore_marker_recovers_old_root_after_swap_gap(tmp_path: Path) -> None
     assert not marker.exists()
 
 
-def test_restore_marker_keeps_new_root_when_swap_completed(tmp_path: Path) -> None:
+def test_restore_marker_rejects_unverified_new_root_and_recovers_old_root(tmp_path: Path) -> None:
     root = tmp_path / "store"
     store = MobileWebUiStore(root, server_id="server-1")
     store.close()
     recovery = tmp_path / "store.recovery-new"
     recovery.mkdir()
-    marker = MobileWebUiStore._write_restore_marker(root, recovery)
+    marker = MobileWebUiStore._write_restore_marker(
+        root,
+        recovery,
+        temporary_root=tmp_path / ".store.candidate",
+        server_id="server-1",
+        expected_tree_digest="a" * 64,
+        had_target=True,
+    )
     reopened = MobileWebUiStore(root, server_id="server-1")
     reopened.close()
     assert root.is_dir()
-    assert recovery.is_dir()
+    assert not recovery.exists()
+    assert list(tmp_path.glob("store.restore-failed-*"))
     assert not marker.exists()
+
+
+def test_restore_recovery_pre_swap_crash_keeps_old_root_and_cleans_candidate(tmp_path: Path) -> None:
+    backup, target, pre_restore, _source_manifest, old_manifest = _restore_fixture(tmp_path)
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_before_old_rename,
+        args=(str(backup), str(target), str(pre_restore)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    assert list(tmp_path.glob(".target.*"))
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == old_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not list(tmp_path.glob(".target.*"))
+
+
+def test_restore_recovery_rename_gap_restores_old_root(tmp_path: Path) -> None:
+    backup, target, pre_restore, _source_manifest, old_manifest = _restore_fixture(tmp_path)
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_after_old_rename,
+        args=(str(backup), str(target), str(pre_restore)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert not target.exists()
+    assert list(tmp_path.glob("target.recovery-*"))
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == old_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not list(tmp_path.glob("target.recovery-*"))
+    assert not list(tmp_path.glob(".target.*"))
+
+
+def test_restore_recovery_new_target_valid_deletes_recovery_after_validation(tmp_path: Path) -> None:
+    backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_after_new_install,
+        args=(str(backup), str(target), str(pre_restore)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    recovery_roots = list(tmp_path.glob("target.recovery-*"))
+    assert len(recovery_roots) == 1
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not recovery_roots[0].exists()
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_recovery_new_target_without_old_root_verifies_before_marker_clear(tmp_path: Path) -> None:
+    source_manifest, source_contents = _manifest(tmp_path / "source-build", b"<html>new-only</html>\n")
+    source = MobileWebUiStore(tmp_path / "source", server_id="server-1")
+    source.publish(source_manifest, source_contents, stable=True, preview=False)
+    backup = source.backup_to(tmp_path / "source-backup")
+    source.close()
+    target = tmp_path / "new-target"
+    pre_restore = tmp_path / "unused-pre-restore"
+
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_after_new_install,
+        args=(str(backup), str(target), str(pre_restore)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    assert not list(tmp_path.glob("new-target.recovery-*"))
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_recovery_pre_install_crash_finishes_complete_temporary(tmp_path: Path) -> None:
+    source_manifest, source_contents = _manifest(tmp_path / "source-build", b"<html>new-pre-install</html>\n")
+    source = MobileWebUiStore(tmp_path / "source", server_id="server-1")
+    source.publish(source_manifest, source_contents, stable=True, preview=False)
+    backup = source.backup_to(tmp_path / "source-backup")
+    source.close()
+    target = tmp_path / "new-target"
+
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_before_new_install_without_old,
+        args=(str(backup), str(target)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert not target.exists()
+    assert not list(tmp_path.glob("new-target.recovery-*"))
+    temporary_roots = [path for path in tmp_path.glob(".new-target.*") if path.is_dir()]
+    assert len(temporary_roots) == 1
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not temporary_roots[0].exists()
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_recovery_new_target_corrupt_restores_old_and_keeps_failed_evidence(tmp_path: Path) -> None:
+    backup, target, pre_restore, _source_manifest, old_manifest = _restore_fixture(tmp_path)
+    context = multiprocessing.get_context("fork")
+    child = context.Process(
+        target=_kill_restore_after_new_install,
+        args=(str(backup), str(target), str(pre_restore)),
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == -signal.SIGKILL
+    (target / "publication.sqlite3").unlink()
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == old_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not MobileWebUiStore._restore_marker_path(target).exists()
+    assert len(list(tmp_path.glob("target.restore-failed-*"))) == 1
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_parent_fsync_failure_keeps_marker_for_valid_new_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infra.mobile_webui import store as store_module
+
+    backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
+    original_replace = store_module.os.replace
+    original_fsync_directory = store_module.MobileWebUiStore._fsync_directory
+    state = {"new_installed": False, "failed": False}
+    absolute_target = os.path.abspath(target)
+
+    def replace(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        original_replace(source, destination)
+        if os.path.abspath(os.fspath(destination)) == absolute_target:
+            state["new_installed"] = True
+
+    def fsync_directory(path: Path) -> None:
+        if state["new_installed"] and not state["failed"]:
+            state["failed"] = True
+            raise OSError("injected restore parent fsync failure")
+        original_fsync_directory(path)
+
+    monkeypatch.setattr(store_module.os, "replace", replace)
+    monkeypatch.setattr(store_module.MobileWebUiStore, "_fsync_directory", staticmethod(fsync_directory))
+    with pytest.raises(OSError, match="parent fsync"):
+        MobileWebUiStore.restore_backup(
+            backup,
+            target,
+            server_id="server-1",
+            pre_restore_backup=pre_restore,
+        )
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    recovery_roots = list(tmp_path.glob("target.recovery-*"))
+    assert len(recovery_roots) == 1
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    assert not recovery_roots[0].exists()
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
+
+
+def test_restore_marker_cleanup_failure_keeps_marker_and_recovers_on_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infra.mobile_webui import store as store_module
+
+    backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
+    original_clear = store_module.MobileWebUiStore._clear_restore_marker
+    state = {"failed": False}
+
+    def clear_marker(marker: Path) -> None:
+        if not state["failed"]:
+            state["failed"] = True
+            raise OSError("injected restore marker cleanup failure")
+        original_clear(marker)
+
+    monkeypatch.setattr(store_module.MobileWebUiStore, "_clear_restore_marker", staticmethod(clear_marker))
+    with pytest.raises(OSError, match="marker cleanup"):
+        MobileWebUiStore.restore_backup(
+            backup,
+            target,
+            server_id="server-1",
+            pre_restore_backup=pre_restore,
+        )
+    marker = MobileWebUiStore._restore_marker_path(target)
+    assert marker.is_file()
+    assert target.is_dir()
+    assert not list(tmp_path.glob("target.recovery-*"))
+
+    recovered = MobileWebUiStore(target, server_id="server-1")
+    try:
+        assert recovered.get_release().stable is not None
+        assert recovered.get_release().stable.generation_id == source_manifest.generation_id
+    finally:
+        recovered.close()
+    assert not marker.exists()
+    MobileWebUiStore.verify_backup(pre_restore, server_id="server-1")
+    MobileWebUiStore.verify_backup(backup, server_id="server-1")
 
 
 def test_channel_history_is_distinct_per_pointer_and_bounds_gc(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Mobile WebUI restore 在进程崩溃或 recovery 清理持久化失败时，可能提前清除唯一 marker、接受未验证 target，或留下没有恢复 owner 的旧 root。
- 用户可见结果：备份恢复在每个 rename/delete/fsync 窗口都保留可重放证据；新 root 只有通过 server identity、backup 与完整树摘要校验后才被接受。
- 本 PR 不处理：不改变 WebUI 发布、Stable/Preview 选择、Android consumer 或正式 workspace 内容。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Mobile WebUI 发布仓维护者与 Core runtime
- `runtime_patch`：`required`
- `runtime_patch_reason`：运行中的 Core 必须重启后才会加载新的 restore recovery 实现
- `authoritative_state_owner`：`MobileWebUiStore` restore marker、target、temporary、recovery 与 pre-restore backup
- `client_only_alternative`：无；Android 无权修复服务端发布仓恢复事务
- 关联不变量：候选树先完整 fsync；marker 绑定 server/路径/树摘要；恢复证据在清理持久完成前不得丢失
- `protected_state`：正式 workspace、SessionsDB、移动业务库、现有发布指针与 pre-restore backup
- 允许的副作用：在显式 restore 的目标父目录创建 marker、temporary、recovery/quarantine 和审计记录
- 禁止的副作用：接受未验证 root、跟随符号链接、删除 pre-restore backup、写会话或插件业务状态

## 改动范围

- 主要文件：`infra/mobile_webui/store.py`、`tests/mobile_webui/test_publication.py`
- 配置或迁移影响：无配置/schema 迁移；只加固 restore 文件事务与启动恢复
- 已知 schema lineage 与最终 schema identity：发布仓 SQLite schema 不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：线协议与 `schema/mobile-realtime-v1.json` 不变；本 PR 只修服务端持久化 owner
- 回滚方式：revert `8e502025`；如需整体撤销同时 revert `7c1f83a3`

## 崩溃矩阵

| 状态 | 恢复 owner / 结果 |
| --- | --- |
| `had_target=false`，marker + 完整 temporary | 验证 temporary，rename 到 target、fsync parent、清 marker |
| marker + 旧 target，尚无 recovery | 保留旧 target，删除 temporary 后清 marker |
| marker + recovery，无 target | recovery rename 回 target 并 fsync，再清理 temporary/marker |
| 新 target + recovery 均存在且新 target 有效 | 先验证新 target，再持久删除 recovery/temporary，最后清 marker |
| 新 target 损坏 | 隔离损坏 root，恢复 recovery；failed root 保留为证据 |
| recovery 删除或 parent fsync 失败 | marker 与仍存在的 owner 保留；下次启动重试，不能假报完成 |
| marker 清理失败 | marker 保留；启动重新验证并幂等清理 |

## 验证

- [x] 相关 targeted tests 已通过：`tests/mobile_webui/test_publication.py` 38 passed；`tests/mobile_webui` + realtime protocol 101 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过：生产与测试定向 Pyright 均 0 errors；前端不适用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：PASSED，`docker/debug/reports/change-gate/20260803-082654-54437431`。
- `sourceDigest`：`2e723200c6561277482cb0bb76225e6b8eb4388cbb317d481560d4331ffc2dd9`
- `planDigest`：`8b0c069b43ab48bf5245c3966e08781d9aa58fa2c98b7bd99065307273bdbdde`
- 真实设备证据：不适用；该 PR 是 Core 发布仓 restore 文件事务，Android 真机不拥有此路径。
- 未运行项与原因：无与本 PR 直接相关的未运行项；完整 Core runtime 重启在合并后按正式流程执行。

## 工作手册

- [x] 已核对 `projectneed.md`、决策 0022、WebUI OTA 设计和 `NOW.md`。
- [x] 长期产品语义已由既有 accepted 合同确认；本次只修 crash durability。
- [x] 已按 MOB-001 核对：restore owner 在 Core，Android 只消费已提交 ReleaseView。
- [x] 当前没有需从 `NOW.md` 删除的独立事项。
