### PR TITLE
fix(restart-probe): handle process exit race during identity reads

### DIFF
--- a/docker/debug/restart_probe.py
+++ b/docker/debug/restart_probe.py
@@ -223,7 +223,7 @@ def _process_identity(pid: int) -> dict[str, int]:
 def _identity_alive(identity: dict[str, int]) -> bool:
     try:
         stat = Path(f"/proc/{identity['pid']}/stat").read_text(encoding="utf-8")
-    except FileNotFoundError:
+    except (FileNotFoundError, ProcessLookupError):
         return False
     fields = stat[stat.rfind(")") + 2 :].split()
     return fields[0] != "Z" and {

--- a/tests/test_restart_probe.py
+++ b/tests/test_restart_probe.py
@@ -97,6 +97,29 @@ def test_process_identity_rejects_reused_pid_counterexample() -> None:
     )
 
 
+def test_process_identity_treats_proc_lookup_race_as_exited(monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = {"pid": 123456, "starttime": 1}
+
+    def read_text(_path: Path, **_kwargs: object) -> str:
+        raise ProcessLookupError("process exited during /proc read")
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    assert not _identity_alive(identity)
+
+
+def test_process_identity_propagates_unexpected_proc_read_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = {"pid": 123456, "starttime": 1}
+
+    def read_text(_path: Path, **_kwargs: object) -> str:
+        raise PermissionError("unexpected /proc read failure")
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    with pytest.raises(PermissionError, match="unexpected /proc read failure"):
+        _identity_alive(identity)
+
+
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="依赖 Linux zombie 状态")
 def test_process_identity_treats_zombie_as_exited() -> None:
     pid = os.fork()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`restart_probe` 在旧进程正常退出的 `/proc/<pid>/stat` 竞态中可能收到 `ProcessLookupError`，把已退出误报成 Gate 崩溃。
- 用户可见结果：重启与 MCP soak Gate 能把该竞态判为 identity 已退出，不再产生与产品代码无关的随机红灯。
- 本 PR 不处理：不改变 Supervisor、MCP、正式 runtime 或 Mobile WebUI 产品语义。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`not_applicable`
- `consumer_scope`：仅 Core CI/restart probe 维护者
- `runtime_patch`：`none`
- `runtime_patch_reason`：只修改验收探针，不修改运行时代码
- `authoritative_state_owner`：Linux `/proc` 进程 identity（PID + starttime）
- `client_only_alternative`：不适用
- 关联不变量：正常退出后的 identity 必须判为不存活；非退出类读取错误继续 fail-loud
- `protected_state`：正式 workspace、正式进程、仓库源码、Docker 残留资源
- 允许的副作用：隔离 Gate 创建并清理自己的容器、网络和临时 workspace
- 禁止的副作用：写正式 workspace、切换正式进程、吞掉权限或未知 I/O 错误

## 改动范围

- 主要文件：`docker/debug/restart_probe.py`、`tests/test_restart_probe.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用；本 PR 不改协议或场景目录
- 回滚方式：revert `a51802ca`

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_restart_probe.py`，12 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过：生产与测试定向 Pyright 均 0 errors；前端不适用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：PASSED，`docker/debug/reports/change-gate/20260803-084109-7da95926`。
- `sourceDigest`：`6d2d8e997e60e32430faf0a34a27c0befa27d67e5ed0088ac226afcadc29c308`
- `planDigest`：`9bdde2e581fd348070015d7dfd829de826afb364739ae6ab7449aa60bc50bb2b`
- 真实设备证据：不适用；Host restart/MCP soak 20 轮通过，报告 `docker/debug/reports/restart/20260803-084124-dde67f3e`，全部 return code 为 0，仓库未变且无容器、网络、volume 残留。
- 未运行项与原因：无与本改动相关的未运行项。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`；本修复不改变其长期语义。
- [x] 本次没有长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有需从 `NOW.md` 删除的对应事项。
