### PR TITLE
fix(mobile-webui): bind clean build provenance to source workspace

### DIFF
--- a/scripts/publish-mobile-webui.py
+++ b/scripts/publish-mobile-webui.py
@@ -260,6 +260,14 @@ def _require_clean_source(workspace: Path, *, allow_dirty: bool) -> None:
         raise RuntimeError("WebUI/build inputs require clean source；Preview 可用 --allow-dirty")
 
 
+def _source_environment(workspace: Path, environment: Mapping[str, str]) -> dict[str, str]:
+    """Bind source-sensitive commands to the workspace they inspect or build."""
+
+    bound = dict(environment)
+    bound["PWD"] = str(workspace.resolve())
+    return bound
+
+
 def _remove_owned_temporary_file(path: Path) -> None:
     """Remove only the exact provenance sidecar owned by an internal build."""
 
@@ -277,23 +285,24 @@ def _run_build(
 ) -> None:
     """Install the pinned dependency graph and emit one isolated WebUI artifact tree."""
 
+    source_environment = _source_environment(build_workspace, environment)
     # 1. Recreate dependencies from the declared lock policy.
     if lock_available:
         subprocess.run(
             ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
             cwd=build_workspace,
-            env=dict(environment),
+            env=source_environment,
             check=True,
         )
     else:
         subprocess.run(
             ["npm", "install", "--package-lock=false", "--ignore-scripts", "--no-audit", "--no-fund"],
             cwd=build_workspace,
-            env=dict(environment),
+            env=source_environment,
             check=True,
         )
     # 2. Build only into the caller-owned output directory.
-    subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=dict(environment), check=True)
+    subprocess.run(["npm", "run", "build:mobile-web"], cwd=build_workspace, env=source_environment, check=True)
 
 
 def _verify_clean_reproducibility(
@@ -394,7 +403,10 @@ def _capture_provenance(
 ) -> dict[str, object]:
     """Capture all source/build identity inputs before and after a build."""
 
-    effective_environment = dict(os.environ if environment is None else environment)
+    effective_environment = _source_environment(
+        workspace,
+        os.environ if environment is None else environment,
+    )
     package_lock = workspace / "package-lock.json"
     package_lock_digest = _sha256(package_lock.read_bytes()) if package_lock.is_file() else _no_lock_digest()
     build_script = workspace / "scripts" / "package-mobile-web.sh"

--- a/tests/mobile_webui/test_publisher.py
+++ b/tests/mobile_webui/test_publisher.py
@@ -140,6 +140,43 @@ def test_build_context_tracks_effective_env_and_normalizes_output_dir(tmp_path: 
     assert changed["build_context_digest"] != second["build_context_digest"]
 
 
+def test_source_bound_provenance_ignores_inherited_pwd(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    environment = os.environ.copy()
+    first = _PUBLISHER._capture_provenance(
+        repo,
+        environment={**environment, "PWD": str(tmp_path / "inherited-a")},
+        output_dir=tmp_path / "output",
+    )
+    second = _PUBLISHER._capture_provenance(
+        repo,
+        environment={**environment, "PWD": str(tmp_path / "inherited-b")},
+        output_dir=tmp_path / "output",
+    )
+    assert first["build_context_digest"] == second["build_context_digest"]
+
+
+def test_run_build_binds_pwd_to_build_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _repo(tmp_path)
+    calls: list[tuple[list[str], Path, dict[str, str]]] = []
+
+    def fake_run(
+        command: list[str], *, cwd: Path, env: dict[str, str], check: bool
+    ) -> None:
+        assert check is True
+        calls.append((command, cwd, env))
+
+    monkeypatch.setattr(_PUBLISHER.subprocess, "run", fake_run)
+    _PUBLISHER._run_build(
+        repo,
+        environment={"PATH": os.environ["PATH"], "PWD": str(tmp_path / "inherited")},
+        lock_available=True,
+    )
+    assert len(calls) == 2
+    assert all(cwd == repo for _, cwd, _ in calls)
+    assert all(env["PWD"] == str(repo.resolve()) for _, _, env in calls)
+
+
 def test_build_environment_is_controlled_and_clean_publish_revalidates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _repo(tmp_path)
     monkeypatch.setenv("UNTRACKED_BUILD_INPUT", "ignored")
@@ -189,9 +226,15 @@ def test_clean_publish_rejects_nondeterministic_artifact_rebuild(tmp_path: Path)
         _PUBLISHER._manifest(repo, built, allow_dirty=False)
 
 
-def test_internal_publish_cleans_build_sidecar_on_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_internal_publish_cleans_build_sidecar_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     repo = _repo(tmp_path)
     workspace = tmp_path / "runtime-workspace"
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("PWD", str(repo))
     assert _PUBLISHER.main(
         [
             "publish",


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Core Stable 发布从 source repo root 启动时，clean detached build 继承了调用方 `PWD`；provenance 归一化以 detached workspace 为基准，随后与 manifest 的 source-bound provenance 不一致。
- 用户可见结果：稳定发布的 clean build 与 provenance 都使用实际 source workspace 的绝对 `PWD`，source repo root 启动不再被错误的 build-dir provenance mismatch 拒绝。
- 本 PR 不处理：不删除 clean-build Gate，不放宽 dirty/allow-dirty 约束，不改变正式 workspace 的持久化协议。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Core Mobile WebUI stable publisher 的 clean build/provenance 路径
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅修复发布脚本和测试，不修改运行时服务
- `authoritative_state_owner`：发布脚本；测试使用一次性临时 git/workspace
- `client_only_alternative`：不适用
- 关联不变量：构建命令、npm config、版本探测和 provenance 必须绑定同一 source workspace
- `protected_state`：正式 Akashic workspace、sessions.db/messages、移动端协议和持久化状态不变
- 允许的副作用：一次性 clean build 临时 worktree/output，以及构建 provenance 计算
- 禁止的副作用：放宽稳定发布校验、覆盖正式 workspace、修改数据库或迁移

## 改动范围

- 主要文件：`scripts/publish-mobile-webui.py`、`tests/mobile_webui/test_publisher.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用；无 schema 变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用；无协议变化
- 回滚方式：revert commit `7c6ee789`

## 验证

- [x] `tests/mobile_webui/test_publisher.py`：11 passed。
- [x] `tests/mobile_webui`：56 passed。
- [x] 生产 Python pyright：0 errors（共享环境通过 `--venvpath /mnt/data/coding/akasic-agent` 指向当前已安装依赖）。
- [x] `git diff --check`：通过。
- [x] `python docker/debug/gate.py run --base origin/main`：通过。
- `sourceDigest`：`d40c76a8f631b50824babb51e2058ced759081a50dc3c58616085c9e6480a82b`
- `planDigest`：`1c9eacb53f0550be08a01d3f809e09116d5c9dea66e711e2630f7c45dc956b52`
- 真实设备证据：不适用；本 PR 仅修复 server-side publisher provenance。
- 未运行项与原因：完整仓库 pytest 未单独重复运行；测试 pyright 仍受本地缺失的既有 `harbor`/`akashic_sdk` benchmark imports 阻塞，未修改测试配置或隐藏该环境问题。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 不涉及跨仓库或客户端实现；MOB-001 不适用。
- [x] 没有对应 `NOW.md` 完成事项。
