### PR TITLE
fix(plugins): recover watcher synchronization failures

### DIFF
--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -73,9 +73,9 @@ class PluginWatcher:
                         results = await self._manager.reconcile_changed()
                     except Exception:
                         logger.exception("插件热重载失败")
-                        if confirming:
-                            self._forced = True
-                            continue
+                        # 保留旧 revision；成功 reconcile 前不能丢掉下一次重试或发布通知。
+                        self._forced = True
+                        continue
                     else:
                         # 安装器原子替换目录时，单次 discover 可能只看到短暂缺口。
                         # 禁用结果先确认一次，只向移动端发布稳定后的最终目录。
@@ -88,8 +88,8 @@ class PluginWatcher:
                             self._forced = True
                         elif confirming:
                             self._confirmation_pending = False
-                    revision = current_revision
-                    self._notification_pending = self._after_reconcile is not None
+                        revision = current_revision
+                        self._notification_pending = self._after_reconcile is not None
                 if needs_confirmation:
                     continue
                 if self._notification_pending:

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -8,6 +8,8 @@ from agent.plugins.manager import PluginManager
 
 logger = logging.getLogger(__name__)
 
+_MAX_RECONCILE_ATTEMPTS = 3
+
 
 class PluginWatcher:
     def __init__(
@@ -24,6 +26,7 @@ class PluginWatcher:
         self._after_reconcile = after_reconcile
         self._wake = asyncio.Event()
         self._forced = False
+        self._manual_wake_pending = False
         self._confirmation_pending = False
         self._notification_pending = False
         self._running = True
@@ -34,6 +37,9 @@ class PluginWatcher:
         """轮询插件文件状态，并在变化后执行一次热重载。"""
 
         revision = self._baseline_revision
+        failed_revision: str | None = None
+        failed_attempts = 0
+        blocked_revision: str | None = None
         self._run_started = True
         try:
             # 1. 启动前已停止时，不再触碰 manager
@@ -52,29 +58,52 @@ class PluginWatcher:
                 if not self._running:
                     break
                 forced = self._forced
+                manual_wake = self._manual_wake_pending
                 self._forced = False
+                self._manual_wake_pending = False
                 # 3. 读取最新状态；单次文件竞争交给下一轮恢复
                 try:
                     current_revision = await asyncio.to_thread(
                         self._manager.watch_revision
                     )
                 except OSError:
-                    self._forced = self._forced or forced
+                    self._forced = self._forced or forced or manual_wake
+                    self._manual_wake_pending = self._manual_wake_pending or manual_wake
                     logger.exception("插件热重载状态扫描失败")
                     continue
+                if manual_wake:
+                    failed_revision = None
+                    failed_attempts = 0
+                    blocked_revision = None
+                elif failed_revision is not None and current_revision != failed_revision:
+                    failed_revision = None
+                    failed_attempts = 0
+                    blocked_revision = None
                 changed = forced or current_revision != revision
+                if blocked_revision == current_revision and not manual_wake:
+                    changed = False
                 if not changed and not self._notification_pending:
                     continue
                 # 4. 插件版本只协调一次，通知失败仅重试通知
                 confirming = self._confirmation_pending
                 needs_confirmation = False
                 if changed:
+                    if failed_revision != current_revision:
+                        failed_revision = current_revision
+                        failed_attempts = 0
+                        blocked_revision = None
+                    failed_attempts += 1
                     try:
                         results = await self._manager.reconcile_changed()
                     except Exception:
                         logger.exception("插件热重载失败")
-                        # 保留旧 revision；成功 reconcile 前不能丢掉下一次重试或发布通知。
-                        self._forced = True
+                        if failed_attempts >= _MAX_RECONCILE_ATTEMPTS:
+                            blocked_revision = current_revision
+                            if self._confirmation_pending:
+                                self._notification_pending = False
+                        else:
+                            # 保留旧 revision；下一轮按轮询间隔自动重试。
+                            self._forced = True
                         continue
                     else:
                         # 安装器原子替换目录时，单次 discover 可能只看到短暂缺口。
@@ -90,6 +119,9 @@ class PluginWatcher:
                             self._confirmation_pending = False
                         revision = current_revision
                         self._notification_pending = self._after_reconcile is not None
+                        failed_revision = None
+                        failed_attempts = 0
+                        blocked_revision = None
                 if needs_confirmation:
                     continue
                 if self._notification_pending:
@@ -105,6 +137,7 @@ class PluginWatcher:
 
     def wake(self) -> None:
         self._forced = True
+        self._manual_wake_pending = True
         self._wake.set()
 
     def stop(self) -> None:

--- a/agent/plugins/watcher.py
+++ b/agent/plugins/watcher.py
@@ -84,7 +84,7 @@ class PluginWatcher:
                     changed = False
                 if not changed and not self._notification_pending:
                     continue
-                # 4. 插件版本只协调一次，通知失败仅重试通知
+                # 4. 同 revision 失败有界重试；通知失败只重试通知，不重复 reconcile
                 confirming = self._confirmation_pending
                 needs_confirmation = False
                 if changed:

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -465,7 +465,7 @@ candidate 在所有 invariant 通过前不接受公开请求。commit 临界区�
 
 ### PLG-007 Watcher 单轮失败不终止生命周期
 
-一次 scan 或 reconcile 失败只影响当前 revision，旧插件继续服务。相同失败 revision 不得无限重试；后续变化或显式 wake 可以恢复。stop 必须可等待。
+一次 scan 或 reconcile 失败只影响当前 revision，旧插件继续服务。相同失败 revision 只允许有界自动重试，不得无限重试；达到上限后由后续变化或显式 wake 恢复。只有 reconcile 成功才能推进已确认 revision 并发布 catalog changed 等后置通知，失败状态不得要求消费者通过清缓存恢复。stop 必须可等待。
 
 ### PLG-008 动态协议和冲突 fail-loud
 

--- a/infra/mobile_realtime/message_content_http.py
+++ b/infra/mobile_realtime/message_content_http.py
@@ -212,13 +212,16 @@ def _decode_b64url(value: str) -> bytes:
         raise MessageContentTicketError("message content ticket 段不能为空")
     padding = "=" * (-len(value) % 4)
     try:
-        return base64.b64decode(
+        decoded = base64.b64decode(
             value + padding,
             altchars=b"-_",
             validate=True,
         )
     except (binascii.Error, ValueError) as error:
         raise MessageContentTicketError("message content ticket Base64URL 无效") from error
+    if _b64url(decoded) != value:
+        raise MessageContentTicketError("message content ticket Base64URL 无效")
+    return decoded
 
 
 def _b64url(value: bytes) -> str:

--- a/tests/mobile_realtime/test_message_content_http.py
+++ b/tests/mobile_realtime/test_message_content_http.py
@@ -24,6 +24,8 @@ from infra.mobile_realtime.message_content_http import (
 from infra.mobile_realtime.storage import MobileRealtimeStorage
 from session.store import SessionStore
 
+_BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
 
 class _Storage:
     def read_device(self, device_id: str) -> object | None:
@@ -78,8 +80,38 @@ def test_ticket_rejects_tampering() -> None:
         sha256="b" * 64,
     )
 
+    payload, signature = grant.ticket.split(".")
+    tampered_first = "B" if signature[0] == "A" else "A"
     with pytest.raises(MessageContentTicketError, match="签名无效"):
-        issuer.verify(f"{grant.ticket[:-1]}A")
+        issuer.verify(f"{payload}.{tampered_first}{signature[1:]}")
+
+
+def _padding_bit_alias(value: str) -> str:
+    remainder = len(value) % 4
+    assert remainder in (2, 3)
+    padding_mask = 0b1111 if remainder == 2 else 0b11
+    tail_index = _BASE64URL_ALPHABET.index(value[-1])
+    assert tail_index & padding_mask == 0
+    alias_index = tail_index | 1
+    assert alias_index != tail_index
+    return value[:-1] + _BASE64URL_ALPHABET[alias_index]
+
+
+def test_ticket_rejects_noncanonical_payload_padding_bits() -> None:
+    now = datetime(2026, 8, 2, tzinfo=timezone.utc)
+    issuer = _issuer(now)
+    grant = issuer.issue(
+        device_id="device-1",
+        connection_epoch=7,
+        session_id="mobile:test",
+        message_id="mobile:test:3",
+        byte_length=1,
+        sha256="b" * 64,
+    )
+    payload, signature = grant.ticket.split(".")
+
+    with pytest.raises(MessageContentTicketError, match="Base64URL 无效"):
+        issuer.verify(f"{_padding_bit_alias(payload)}.{signature}")
 
 
 def test_range_is_single_bounded_and_clamped() -> None:

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -3016,6 +3016,51 @@ async def test_plugin_watcher_does_not_reconcile_after_recovered_scan_error() ->
 
 
 @pytest.mark.asyncio
+async def test_plugin_watcher_recovers_on_third_reconcile_attempt() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.revision = "broken"
+            self.failures_remaining = 2
+            self.calls = 0
+            self.recovered = asyncio.Event()
+
+        def watch_revision(self) -> str:
+            return self.revision
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            self.calls += 1
+            if self.failures_remaining:
+                self.failures_remaining -= 1
+                raise RuntimeError("transient callback failure")
+            self.recovered.set()
+            return []
+
+    manager = Manager()
+    notification_calls = 0
+    notified = asyncio.Event()
+
+    async def notify() -> None:
+        nonlocal notification_calls
+        notification_calls += 1
+        notified.set()
+
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+        after_reconcile=notify,
+    )
+    task = asyncio.create_task(watcher.run())
+    await asyncio.wait_for(manager.recovered.wait(), timeout=1)
+    await asyncio.wait_for(notified.wait(), timeout=1)
+
+    watcher.stop()
+    await task
+    assert manager.calls == 3
+    assert notification_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
     class Manager:
         def __init__(self) -> None:
@@ -3052,17 +3097,75 @@ async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
     task = asyncio.create_task(watcher.run())
     await asyncio.sleep(0)
     await asyncio.wait_for(manager.failed.wait(), timeout=1)
+    for _ in range(100):
+        if manager.calls >= 3:
+            break
+        await asyncio.sleep(0.01)
     await asyncio.sleep(0.03)
-    assert manager.calls >= 2
+    assert manager.calls == 3
     assert reconciled == 0
     assert not task.done()
 
     manager.allow_reconcile = True
+    manager.revision = "fixed"
     await asyncio.wait_for(manager.recovered.wait(), timeout=1)
     watcher.stop()
     await task
-    assert manager.calls >= 2
+    assert manager.calls == 4
     assert reconciled == 1
+
+
+@pytest.mark.asyncio
+async def test_plugin_watcher_wake_retries_blocked_revision() -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.revision = "broken"
+            self.allow_reconcile = False
+            self.calls = 0
+            self.recovered = asyncio.Event()
+
+        def watch_revision(self) -> str:
+            return self.revision
+
+        async def reconcile_changed(self) -> list[dict[str, object]]:
+            self.calls += 1
+            if not self.allow_reconcile:
+                raise RuntimeError("persistent callback failure")
+            self.recovered.set()
+            return []
+
+    manager = Manager()
+    notification_calls = 0
+    notified = asyncio.Event()
+
+    async def notify() -> None:
+        nonlocal notification_calls
+        notification_calls += 1
+        notified.set()
+
+    watcher = PluginWatcher(
+        cast(PluginManager, manager),
+        baseline_revision="stable",
+        interval_seconds=0.01,
+        after_reconcile=notify,
+    )
+    task = asyncio.create_task(watcher.run())
+    for _ in range(100):
+        if manager.calls >= 3:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.03)
+    assert manager.calls == 3
+    assert notification_calls == 0
+
+    manager.allow_reconcile = True
+    watcher.wake()
+    await asyncio.wait_for(manager.recovered.wait(), timeout=1)
+    await asyncio.wait_for(notified.wait(), timeout=1)
+    watcher.stop()
+    await task
+    assert manager.calls == 4
+    assert notification_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -3019,7 +3019,8 @@ async def test_plugin_watcher_does_not_reconcile_after_recovered_scan_error() ->
 async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
     class Manager:
         def __init__(self) -> None:
-            self.revision = "stable"
+            self.revision = "broken"
+            self.allow_reconcile = False
             self.failed = asyncio.Event()
             self.recovered = asyncio.Event()
             self.calls = 0
@@ -3029,7 +3030,7 @@ async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
 
         async def reconcile_changed(self) -> list[dict[str, object]]:
             self.calls += 1
-            if self.revision == "broken":
+            if not self.allow_reconcile:
                 self.failed.set()
                 raise RuntimeError("callback failed")
             self.recovered.set()
@@ -3050,19 +3051,18 @@ async def test_plugin_watcher_recovers_after_reconcile_failure() -> None:
     )
     task = asyncio.create_task(watcher.run())
     await asyncio.sleep(0)
-    manager.revision = "broken"
     await asyncio.wait_for(manager.failed.wait(), timeout=1)
     await asyncio.sleep(0.03)
-    assert manager.calls == 1
-    assert reconciled == 1
+    assert manager.calls >= 2
+    assert reconciled == 0
     assert not task.done()
 
-    manager.revision = "fixed"
+    manager.allow_reconcile = True
     await asyncio.wait_for(manager.recovered.wait(), timeout=1)
     watcher.stop()
     await task
-    assert manager.calls == 2
-    assert reconciled == 2
+    assert manager.calls >= 2
+    assert reconciled == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：插件目录瞬时 scan/reconcile 失败后，watcher 会把失败 revision 当成已处理，移动端 catalog 可能长期停留在旧状态；CI 同时揭示 message-content ticket 接受非 canonical Base64URL alias。
- 用户可见结果：同一 revision 最多自动尝试 3 次；达到上限后保留旧插件继续服务，并可由新 revision 或显式 `wake()` 恢复。只有 reconcile 成功才推进已确认 revision 和发布后置通知；票据入口拒绝 padding-bit alias。
- 本 PR 不处理：Android WebView bridge、配对 UI 与 APK 发布；这些在移动端 PR 独立交付。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：插件 watcher、移动端 plugin catalog 消费者
- `runtime_patch`：`required`
- `runtime_patch_reason`：失败 revision 的确认与重试属于核心插件 generation owner，客户端清缓存无法修复服务端内存状态。
- `authoritative_state_owner`：`PluginWatcher` + `PluginManager`
- `client_only_alternative`：无；客户端只能重新订阅，不能安全推进核心 generation。
- 关联不变量：PLG-007；旧 generation 在失败时继续服务；失败不发布成功通知；相同 revision 不无限重试。
- `protected_state`：正式 workspace、plugin-data、插件 cache 与既有 generation。
- 允许的副作用：内存中同 revision 有界重试计数、成功后的 catalog changed 通知。
- 禁止的副作用：删除 plugin-data、要求客户端清缓存、失败时推进 revision、无限重试。

## 改动范围

- 主要文件：`agent/plugins/watcher.py`、`infra/mobile_realtime/message_content_http.py`、对应测试与 `docs/projectneed.md`
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：无数据库 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `b5d2f11d3fe883a2818da321ef8a6e076f1e5d77`；head `08b631894d9b3bd6477cded6d4c7e7b0c82a06b6`。
- 回滚方式：revert 本 PR 四个 commit；正式数据无需恢复。

## 验证

- [x] 相关 targeted tests 已通过：watcher + message-content ticket 127 passed；插件 publication 组合 136 passed。
- [x] Python 静态检查已通过：`py_compile agent/plugins/watcher.py`、`git diff --check`。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行两次。
- `sourceDigest`：`b8784eca83c097009046c9919a19661ade0bb9733bfdef4665b12c043f0bd8db`
- `planDigest`：`2d088a37ab4daa49375af239ca06cf5c1ed858a573fefd1b18a43f2753b16342`
- 真实设备证据：Pixel 7 隔离 Gateway 与移动端 head `56b7a2d1f7452867ffe4f44327b02f9e8fb141ba` 完成发送/重启与插件 HTTPS Gate；正式 package/data 未变化。
- 未运行项与原因：本地完整 Gate 总状态为 failed。第二次运行中 `plugin_generation_contract` 等 21 个场景通过，唯一失败是无关 `companion_dashboard_value_contract` 的 Docker 冷启动总耗时超过固定 60s；相同 Docker 测试在延长诊断窗口后 31/31 passed（54.66s pytest），未修改 Gate 超时或 oracle，交由远端 required check 独立裁决。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已按已批准的 bounded retry 合同更新 PLG-007。
- [x] 已按 MOB-001 核对 owner：重试状态属于 core，不下放给客户端。
- [x] 当前没有需从 `NOW.md` 删除的对应事项。
