### PR TITLE
fix(mobile): preserve history cursor type

### DIFF
--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -2322,7 +2322,7 @@ def _fit_mobile_history_payload(
     if allow_content_refs:
         while len(items) > 1:
             items.pop()
-            payload["next_after_seq"] = int(items[-1]["seq"])
+            payload["next_after_seq"] = cast(int, items[-1]["seq"])
             payload["has_more"] = True
             if (
                 _mobile_tool_argument_encoded_size(payload)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`_fit_mobile_history_payload` 将已确立为整数的历史游标重新传给 `int()`，Pyright 因容器被宽化为 `dict[str, object]` 而拒绝该调用，导致 `check-and-test` 失败。
- 用户可见结果：恢复主分支 CI；移动端历史分页行为不变。
- 本 PR 不处理：benchmark 报告内容和运行结果。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`mobile`
- `consumer_scope`：移动端历史同步游标的静态类型检查
- `runtime_patch`：`none`
- `runtime_patch_reason`：无运行时语义变化
- `authoritative_state_owner`：`sessions.db/messages` 的既有历史存储 owner（未修改）
- `client_only_alternative`：不适用；失败发生在服务端 Python 类型检查
- 关联不变量：`_mobile_history_item` 输出的 `seq` 为 `int`
- `protected_state`：会话历史及分页游标语义
- 允许的副作用：无
- 禁止的副作用：不得改变历史内容、顺序、分页边界或持久状态

## 改动范围

- 主要文件：`infra/mobile_realtime/channel.py`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无 schema 变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：无协议变化
- 回滚方式：revert `48d63b05`

## 验证

- [x] 相关 targeted tests 已通过：`pytest -q tests/mobile_realtime/test_channel.py -k history`（6 passed）
- [x] Python 类型检查已通过：`pyright --level error --venvpath /mnt/data/coding/akasic-agent`（0 errors）
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过
- `sourceDigest`：`5e085fd99eacd2a77a1baaf701986eac7a06fa97ab0320f8232d07af25756ef9`
- `planDigest`：`ca8107ef65ad977a9f5e2886e525aefcf3714d160030f53bc0fa5dcc22b990ae`
- 真实设备证据：不适用；无运行时或客户端行为变化
- 未运行项与原因：无

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`；本修复不改变既有需求或决策。
- [x] 本次没有长期语义变化。
- [x] 已按 mobile capability owner 核对；无跨仓库或客户端改动。
- [x] 当前没有对应 `NOW.md` 事项。
