### PR TITLE
fix(gate): forbid npm network fallback

### DIFF
--- a/docker/debug/docker-compose.change-gate.yml
+++ b/docker/debug/docker-compose.change-gate.yml
@@ -14,6 +14,7 @@ services:
       AKASHIC_GATE_INVENTORY: /sandbox/source-inventory.json
       AKASHIC_PLUGIN_HOME: /sandbox/plugin-home
       HOME: /sandbox/home
+      npm_config_offline: "true"
       PYTEST_ADDOPTS: "-p no:cacheprovider"
       PYTHONUNBUFFERED: "1"
     volumes:

--- a/tests/semantic/test_change_gate.py
+++ b/tests/semantic/test_change_gate.py
@@ -10,6 +10,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -444,3 +445,11 @@ def test_gate_build_and_scenario_have_independent_timeouts(
     assert "--build" not in scenario_command
     assert scenario_command[-4:-1] == ["--no-deps", "change-gate", "python"]
     assert scenario_timeout == scenario.timeout_seconds
+
+
+def test_change_gate_forbids_npm_network_fallback() -> None:
+    compose_path = ROOT / "docker" / "debug" / "docker-compose.change-gate.yml"
+    compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    environment = compose["services"]["change-gate"]["environment"]
+
+    assert environment["npm_config_offline"] == "true"


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Change Gate 的 Dashboard 场景会在容器内触发 npm 网络 fallback；网络等待占满 60 秒场景预算，导致与候选实现无关的超时。
- 用户可见结果：Change Gate 运行容器中的 npm 只使用本地缓存，缺包时立即失败，不再静默访问网络。
- 本 PR 不处理：不修改镜像构建、独立 mobile plugin Gate 或生产 runtime 的联网策略。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`not_applicable`
- `consumer_scope`：本仓库 Change Gate
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅测试容器环境
- `authoritative_state_owner`：不适用
- `client_only_alternative`：不适用
- 关联不变量：Gate 可复现、网络无关、失败必须 fail-loud
- `protected_state`：无
- 允许的副作用：Change Gate 容器读取本地 npm cache
- 禁止的副作用：Change Gate 场景访问 npm registry

## 改动范围

- 主要文件：`docker/debug/docker-compose.change-gate.yml`、`tests/semantic/test_change_gate.py`
- 配置或迁移影响：仅给 `change-gate` 服务设置 `npm_config_offline=true`
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：HEAD `c32a51d2968215277a1ccfb07b8534db112fcf20`
- 回滚方式：revert 本提交

## 验证

- [x] 相关 targeted tests 已通过：`21 passed`
- [x] Python 类型检查或前端 typecheck/lint 已通过；不适用：仅 Compose 配置与结构化 pytest oracle
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，`gate_result=passed`
- `sourceDigest`：`e929f6a45f4cb5d496351ac044ecabc17de4f0cc94e073b90b28b4534db6b64c`
- `planDigest`：`f7210b1131e3be580e4106062cc9dfc9fc57027a3bc63887cb0f9be8ee7d863c`
- 真实设备证据：不适用
- 未运行项与原因：无额外设备/前端构建需求

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`；本 PR 无对应长期语义事项
- [x] 本次没有长期产品语义变化
- [x] 跨仓库或客户端改动不适用
- [x] 当前没有需要从 `NOW.md` 删除的对应事项