### PR TITLE
feat(plugins): stage stable and latest generations

### DIFF
--- a/agent/plugins/artifacts.py
+++ b/agent/plugins/artifacts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, cast
+
+from infra.persistence.json_store import atomic_save_json, load_json
+
+ArtifactSelector = Literal["stable", "latest"]
+_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+@dataclass(frozen=True)
+class ArtifactPointer:
+    path: str | None
+
+
+@dataclass(frozen=True)
+class ArtifactPointers:
+    stable: ArtifactPointer
+    latest: ArtifactPointer
+
+
+def pointer_state_path(plugin_base: Path) -> Path:
+    return plugin_base / ".pointers.json"
+
+
+def read_pointers(plugin_base: Path) -> ArtifactPointers | None:
+    """从一个原子状态文件读取完整 stable/latest 指针对。"""
+
+    path = pointer_state_path(plugin_base)
+    if not path.exists() and not path.is_symlink():
+        return None
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"插件 artifact pointer state 必须是普通文件: {path}")
+    raw = load_json(path, default=None, domain=f"plugin_artifact_pointers:{path}")
+    if not isinstance(raw, dict):
+        raise ValueError(f"插件 artifact pointer state 结构无效: {path}")
+    values = cast(dict[str, object], raw)
+    if set(values) != {"stable", "latest"}:
+        raise ValueError(f"插件 artifact pointer state 结构无效: {path}")
+    stable_value = values["stable"]
+    latest_value = values["latest"]
+    if stable_value is not None and not isinstance(stable_value, str):
+        raise ValueError(f"插件 stable artifact pointer 无效: {path}")
+    if latest_value is not None and not isinstance(latest_value, str):
+        raise ValueError(f"插件 latest artifact pointer 无效: {path}")
+    pointers = ArtifactPointers(
+        stable=ArtifactPointer(stable_value),
+        latest=ArtifactPointer(latest_value),
+    )
+    _validate_pointers(plugin_base, pointers)
+    return pointers
+
+
+def read_pointer(
+    plugin_base: Path,
+    selector: ArtifactSelector,
+) -> ArtifactPointer | None:
+    """从原子指针对中读取一个 selector。"""
+
+    pointers = read_pointers(plugin_base)
+    return None if pointers is None else getattr(pointers, selector)
+
+
+def write_pointers(
+    plugin_base: Path,
+    *,
+    stable: ArtifactPointer,
+    latest: ArtifactPointer,
+) -> Path:
+    """原子持久化完整 stable/latest 指针对。"""
+
+    pointers = ArtifactPointers(stable=stable, latest=latest)
+    _validate_pointers(plugin_base, pointers)
+    path = pointer_state_path(plugin_base)
+    atomic_save_json(
+        path,
+        {"stable": stable.path, "latest": latest.path},
+        ensure_ascii=False,
+        domain=f"plugin_artifact_pointers:{path}",
+    )
+    return path
+
+
+def write_pointer(
+    plugin_base: Path,
+    selector: ArtifactSelector,
+    pointer: ArtifactPointer,
+) -> Path:
+    """保留另一 selector，并原子更新一个指针。"""
+
+    current = read_pointers(plugin_base)
+    if current is None:
+        raise RuntimeError(
+            f"插件首次写入必须同时设置 stable/latest pointer: {plugin_base}"
+        )
+    return write_pointers(
+        plugin_base,
+        stable=pointer if selector == "stable" else current.stable,
+        latest=pointer if selector == "latest" else current.latest,
+    )
+
+
+def resolve_pointer(plugin_base: Path, pointer: ArtifactPointer) -> Path | None:
+    """把指针解析为 plugin_base 内的不可变插件根目录。"""
+
+    if pointer.path is None:
+        return None
+    relative = PurePosixPath(pointer.path)
+    parts = relative.parts
+    valid_legacy = len(parts) == 1 and _safe_segment(parts[0])
+    valid_artifact = (
+        len(parts) == 2 and parts[0] == ".artifacts" and _safe_segment(parts[1])
+    )
+    if relative.is_absolute() or not (valid_legacy or valid_artifact):
+        raise ValueError(f"插件 artifact pointer 越界: {pointer.path}")
+    target = plugin_base.joinpath(*parts)
+    current = plugin_base
+    for part in parts:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"插件 artifact pointer 不能经过符号链接: {current}")
+    if not target.is_dir():
+        raise FileNotFoundError(f"插件 artifact pointer 目标不存在: {target}")
+    plugin_file = target / "plugin.py"
+    if plugin_file.is_symlink() or not plugin_file.is_file():
+        raise ValueError(f"插件 artifact 缺少普通 plugin.py: {plugin_file}")
+    return target
+
+
+def relative_artifact_pointer(
+    plugin_base: Path, artifact_root: Path
+) -> ArtifactPointer:
+    """为不可变 artifact 目录的直接子目录构造安全指针。"""
+
+    relative = artifact_root.relative_to(plugin_base).as_posix()
+    pointer = ArtifactPointer(relative)
+    _ = resolve_pointer(plugin_base, pointer)
+    return pointer
+
+
+def promote_latest_pointer(plugin_base: Path) -> ArtifactPointer:
+    pointers = read_pointers(plugin_base)
+    if pointers is None or pointers.latest.path is None:
+        raise RuntimeError(f"插件没有可 promote 的 latest artifact: {plugin_base}")
+    _ = write_pointers(
+        plugin_base,
+        stable=pointers.latest,
+        latest=pointers.latest,
+    )
+    return pointers.latest
+
+
+def discard_latest_pointer(plugin_base: Path) -> ArtifactPointer:
+    pointers = read_pointers(plugin_base)
+    if pointers is None:
+        raise RuntimeError(f"插件缺少 stable artifact pointer: {plugin_base}")
+    if pointers.stable.path is None:
+        _ = write_pointers(
+            plugin_base,
+            stable=pointers.stable,
+            latest=pointers.stable,
+        )
+        return pointers.stable
+    _ = write_pointers(
+        plugin_base,
+        stable=pointers.stable,
+        latest=pointers.stable,
+    )
+    return pointers.stable
+
+
+def _validate_pointers(plugin_base: Path, pointers: ArtifactPointers) -> None:
+    if pointers.latest.path is None and pointers.stable.path is not None:
+        raise ValueError(f"插件 latest 为空时 stable 也必须为空: {plugin_base}")
+    _ = resolve_pointer(plugin_base, pointers.stable)
+    _ = resolve_pointer(plugin_base, pointers.latest)
+
+
+def _safe_segment(value: str) -> bool:
+    return _SAFE_SEGMENT.fullmatch(value) is not None

--- a/agent/plugins/context.py
+++ b/agent/plugins/context.py
@@ -183,6 +183,10 @@ class PreparedPluginKVStore(PluginKVStore):
         self._is_dirty = True
         return new_value
 
+    @property
+    def dirty(self) -> bool:
+        return self._is_dirty
+
     def commit(self) -> None:
         if self._is_committed:
             return

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -100,6 +100,7 @@ class PluginGeneration:
     scope: PluginScope
     contributions: PluginContributions
     gate_result: GateResult
+    source_type: Literal["builtin", "installed"] = "builtin"
     skill_catalog: PreparedSkillCatalog | None = None
     mcp_catalog: PreparedMcpCatalog | None = None
     job_catalog: PreparedJobCatalog | None = None

--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+from agent.plugins.artifacts import (
+    ArtifactPointer,
+    ArtifactPointers,
+    pointer_state_path,
+    read_pointers,
+    relative_artifact_pointer,
+    write_pointers,
+)
 from agent.plugins.manifest import (
     ensure_workspace_plugin_data_dir,
     load_package_manifest,
@@ -34,31 +42,30 @@ class PluginInstallResult:
     marketplace: str
     installed_path: Path
     data_path: Path
+    source_revision: str
+    staged_candidate: bool
 
 
 @dataclass
 class _CacheActivation:
     result: PluginInstallResult
-    target_root: Path
-    backup_root: Path
+    plugin_base: Path
+    previous_pointers: ArtifactPointers | None
+    created_artifact: bool
 
     def rollback(self) -> None:
         """撤销已发布 cache，并恢复发布前的可运行版本。"""
 
-        # 1. 移除当前代 cache
-        if self.target_root.exists() or self.target_root.is_symlink():
-            _remove_path(self.target_root)
+        # 1. 恢复发布前完整 pointer state；缺失状态也精确恢复。
+        _restore_pointers(self.plugin_base, self.previous_pointers)
 
-        # 2. 恢复旧版本并清理事务目录
-        for child in sorted(self.backup_root.iterdir()):
-            os.replace(child, self.target_root.parent / child.name)
-        self.backup_root.rmdir()
+        # 2. 只删除本事务新建、且尚未被任何旧 pointer 引用的 artifact。
+        target_root = self.result.installed_path
+        if self.created_artifact and (target_root.exists() or target_root.is_symlink()):
+            _remove_path(target_root)
 
     def finalize(self) -> None:
-        """删除已提交事务保留的旧版本目录。"""
-
-        if self.backup_root.exists():
-            shutil.rmtree(self.backup_root)
+        """Immutable artifacts require no destructive post-commit cleanup."""
 
 
 def aka_plugins_root() -> Path:
@@ -150,6 +157,7 @@ def install_git_plugin(
     ref_name: str = "",
     sparse_paths: list[str] | None = None,
     plugins_home: Path | None = None,
+    stage_candidate: bool = False,
 ) -> PluginInstallResult:
     home = (plugins_home or aka_plugins_root()).resolve(strict=False)
     _ = _validate_path_segment(marketplace, "marketplace")
@@ -162,7 +170,9 @@ def install_git_plugin(
     if ref_name.startswith("-"):
         raise ValueError("插件 ref 不能以命令选项开头")
     sparse = sparse_paths or []
-    if not all(isinstance(path, str) and path and path == path.strip() for path in sparse):
+    if not all(
+        isinstance(path, str) and path and path == path.strip() for path in sparse
+    ):
         raise ValueError("插件 sparse path 必须是非空字符串")
     marketplace_root = home / "marketplaces" / marketplace
     cache_root = home / "cache" / marketplace
@@ -173,7 +183,9 @@ def install_git_plugin(
     _ = load_plugin_manifest(home)
     _ = load_package_manifest(home)
 
-    with tempfile.TemporaryDirectory(dir=marketplace_root, prefix="clone-") as clone_dir:
+    with tempfile.TemporaryDirectory(
+        dir=marketplace_root, prefix="clone-"
+    ) as clone_dir:
         clone_root = Path(clone_dir)
         _clone_git_source(
             source=source,
@@ -182,6 +194,9 @@ def install_git_plugin(
             sparse_paths=sparse,
         )
         _validate_source_tree(clone_root)
+        source_revision = _run_git(["rev-parse", "HEAD"], cwd=clone_root)
+        if re.fullmatch(r"[0-9a-f]{40}", source_revision) is None:
+            raise RuntimeError(f"插件 Git HEAD 无效: {source_revision}")
         plugin_class = _load_plugin_class(clone_root)
         plugin_name = _validate_path_segment(
             getattr(plugin_class, "name", None),
@@ -201,6 +216,8 @@ def install_git_plugin(
             cache_root=cache_root,
             data_root=workspace.resolve(strict=False) / "plugin-data",
             workspace=workspace,
+            source_revision=source_revision,
+            stage_candidate=stage_candidate,
         )
         plugin_id = f"{plugin_name}@{marketplace}"
         try:
@@ -289,50 +306,74 @@ def _activate_plugin_version(
     cache_root: Path,
     data_root: Path,
     workspace: Path,
+    source_revision: str,
+    stage_candidate: bool,
 ) -> _CacheActivation:
-    """准备新版本并以可回滚的目录替换发布到 cache。"""
+    """Prepare one immutable artifact and publish it as latest."""
 
     # 1. 创建受保护的数据目录和 cache 父目录
     data_path = data_root / f"{plugin_name}-{marketplace}"
     ensure_workspace_plugin_data_dir(data_path, workspace)
     plugin_base = cache_root / plugin_name
-    target_root = plugin_base / plugin_version
     _ensure_directory(plugin_base)
+    visible_versions = _cache_version_dirs(plugin_base)
+    if len(visible_versions) > 1:
+        paths = ", ".join(str(path) for path in visible_versions)
+        raise ValueError(f"插件 cache 可见版本冲突: {paths}")
+    previous_pointers = read_pointers(plugin_base)
+    if (
+        previous_pointers is not None
+        and previous_pointers.stable != previous_pointers.latest
+    ):
+        raise RuntimeError(
+            f"插件已有 latest 等待 promote/discard: {plugin_name}@{marketplace}"
+        )
+    stable = previous_pointers.stable if previous_pointers is not None else None
+    if stable is None:
+        stable = ArtifactPointer(visible_versions[0].name if visible_versions else None)
+    stage_latest = stage_candidate
+
+    artifacts_root = plugin_base / ".artifacts"
+    _ensure_directory(artifacts_root)
+    artifact_id = f"{plugin_version}-{source_revision[:16]}"
+    target_root = artifacts_root / artifact_id
     if target_root.is_symlink():
-        raise ValueError(f"插件 cache 目标不能是符号链接: {target_root}")
+        raise ValueError(f"插件 artifact 目标不能是符号链接: {target_root}")
     if target_root.exists() and not target_root.is_dir():
-        raise ValueError(f"插件 cache 目标不是目录: {target_root}")
+        raise ValueError(f"插件 artifact 目标不是目录: {target_root}")
 
     staging_root = Path(
         tempfile.mkdtemp(dir=cache_root, prefix=f".{plugin_name}-install-")
     )
-    backup_root = Path(
-        tempfile.mkdtemp(dir=plugin_base, prefix=f".{plugin_version}-backup-")
-    )
-    moved_versions: list[Path] = []
-    published = False
+    created_artifact = False
     try:
         # 2. 在不可发现的 staging 目录复制代码并准备依赖，旧版本保持可见
         _ = shutil.copytree(clone_root, staging_root, dirs_exist_ok=True)
         _prepare_plugin_mcp_runtimes(staging_root, mcp_servers)
 
-        # 3. 依赖准备完成后执行最短目录切换，失败时恢复旧版本
-        for child in _cache_version_dirs(plugin_base):
-            os.replace(child, backup_root / child.name)
-            moved_versions.append(child)
-        os.replace(staging_root, target_root)
-        published = True
+        # 3. Artifact 只创建一次；一次原子写发布完整 stable/latest pair。
+        if target_root.exists():
+            _validate_source_tree(target_root)
+            existing_revision = _run_git(["rev-parse", "HEAD"], cwd=target_root)
+            if existing_revision != source_revision:
+                raise RuntimeError(f"插件 artifact 身份冲突: {target_root}")
+            _remove_path(staging_root)
+        else:
+            os.replace(staging_root, target_root)
+            created_artifact = True
+        latest = relative_artifact_pointer(plugin_base, target_root)
+        candidate_staged = stage_latest and stable != latest
+        _ = write_pointers(
+            plugin_base,
+            stable=stable if stage_latest else latest,
+            latest=latest,
+        )
     except BaseException:
-        if published and (target_root.exists() or target_root.is_symlink()):
+        _restore_pointers(plugin_base, previous_pointers)
+        if created_artifact and (target_root.exists() or target_root.is_symlink()):
             _remove_path(target_root)
-        for child in moved_versions:
-            backup_child = backup_root / child.name
-            if backup_child.exists() or backup_child.is_symlink():
-                os.replace(backup_child, child)
         if staging_root.exists() or staging_root.is_symlink():
             _remove_path(staging_root)
-        if backup_root.exists():
-            backup_root.rmdir()
         raise
 
     result = PluginInstallResult(
@@ -341,11 +382,30 @@ def _activate_plugin_version(
         marketplace=marketplace,
         installed_path=target_root,
         data_path=data_path,
+        source_revision=source_revision,
+        staged_candidate=candidate_staged,
     )
     return _CacheActivation(
         result=result,
-        target_root=target_root,
-        backup_root=backup_root,
+        plugin_base=plugin_base,
+        previous_pointers=previous_pointers,
+        created_artifact=created_artifact,
+    )
+
+
+def _restore_pointers(
+    plugin_base: Path,
+    pointers: ArtifactPointers | None,
+) -> None:
+    path = pointer_state_path(plugin_base)
+    if pointers is None:
+        if path.exists() or path.is_symlink():
+            path.unlink()
+        return
+    _ = write_pointers(
+        plugin_base,
+        stable=pointers.stable,
+        latest=pointers.latest,
     )
 
 
@@ -397,9 +457,10 @@ def _ensure_directory_tree(root: Path, path: Path) -> None:
 
 
 def _validate_path_segment(value: object, label: str) -> str:
-    if not isinstance(value, str) or re.fullmatch(
-        r"[A-Za-z0-9][A-Za-z0-9._-]*", value
-    ) is None:
+    if (
+        not isinstance(value, str)
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value) is None
+    ):
         raise ValueError(f"{label} 必须是安全的单一路径段")
     return value
 
@@ -420,7 +481,9 @@ def _validate_source_tree(root: Path) -> None:
                 raise ValueError(f"插件 source 符号链接无效: {path}") from error
             if not resolved.is_relative_to(root):
                 raise ValueError(f"插件 source 符号链接越界: {path} -> {resolved}")
-            if resolved == root or path.parent.resolve(strict=True).is_relative_to(resolved):
+            if resolved == root or path.parent.resolve(strict=True).is_relative_to(
+                resolved
+            ):
                 raise ValueError(f"插件 source 符号链接形成循环: {path} -> {resolved}")
 
 
@@ -459,20 +522,14 @@ def _resolve_mcp_runtime_root(
         script_path = Path(command_items[1])
         if _looks_like_plugin_path(command_items[1]):
             script_candidate = (
-                script_path
-                if script_path.is_absolute()
-                else plugin_root / script_path
+                script_path if script_path.is_absolute() else plugin_root / script_path
             )
             resolved_script = script_candidate.resolve(strict=False)
             _require_plugin_path(plugin_root, resolved_script, "MCP command")
             candidates.append(script_candidate.parent)
     if cwd_raw:
         cwd_path = Path(cwd_raw)
-        cwd_candidate = (
-            cwd_path
-            if cwd_path.is_absolute()
-            else plugin_root / cwd_path
-        )
+        cwd_candidate = cwd_path if cwd_path.is_absolute() else plugin_root / cwd_path
         _require_plugin_path(
             plugin_root,
             cwd_candidate.resolve(strict=False),
@@ -527,7 +584,9 @@ def _load_plugin_class(plugin_root: Path) -> type:
     finally:
         plugin_registry.remove_module_tree(module_name)
         for imported_name in tuple(sys.modules):
-            if imported_name == module_name or imported_name.startswith(f"{module_name}."):
+            if imported_name == module_name or imported_name.startswith(
+                f"{module_name}."
+            ):
                 _ = sys.modules.pop(imported_name, None)
 
 
@@ -586,7 +645,11 @@ def _ensure_python_runtime(
 
 
 def _venv_python_path(venv_dir: Path) -> Path:
-    return venv_dir / "Scripts" / "python.exe" if os.name == "nt" else venv_dir / "bin" / "python"
+    return (
+        venv_dir / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_dir / "bin" / "python"
+    )
 
 
 def _is_python_command(value: str) -> bool:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -53,12 +53,15 @@ from agent.lifecycle.types import (
 )
 from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registry
 from agent.plugins.artifacts import (
+    ArtifactPointer,
     ArtifactSelector,
     discard_latest_pointer,
-    promote_latest_pointer,
     pointer_state_path,
     read_pointer,
+    read_pointers,
+    relative_artifact_pointer,
     resolve_pointer,
+    write_pointers,
 )
 from agent.plugins.source_resolver import resolve_plugin_sources
 from agent.plugins.jobs import (
@@ -96,6 +99,7 @@ from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotCompiler,
     RuntimeSnapshotStore,
+    SnapshotTransaction,
     get_current_runtime_snapshot,
     plugin_is_active,
 )
@@ -782,11 +786,15 @@ class PluginManager:
         # 2. 根据 durable pointer 判定 promoting 崩溃发生在切换前还是切换后。
         stable_by_id = self._discovered_by_id(installed_selector="stable")
         latest_by_id = self._discovered_by_id(installed_selector="latest")
-        restore_candidates, restore_committed = self._classify_reload_recovery(
-            recovery,
-            stable_by_id=stable_by_id,
-            latest_by_id=latest_by_id,
+        restore_candidates, restore_committed, restore_discarded = (
+            self._classify_reload_recovery(
+                recovery,
+                stable_by_id=stable_by_id,
+                latest_by_id=latest_by_id,
+            )
         )
+        for action in restore_discarded:
+            self._reload_journal.finish_recovery(action)
 
         # 3. stable 先恢复服务；latest 候选随后以新事务重新准备和验证。
         for mod in stable_by_id.values():
@@ -806,17 +814,22 @@ class PluginManager:
                 )
             seen.add(action.plugin_id)
 
-    @staticmethod
     def _classify_reload_recovery(
+        self,
         recovery: tuple[ReloadRecoveryAction, ...],
         *,
         stable_by_id: dict[str, dict[str, str]],
         latest_by_id: dict[str, dict[str, str]],
-    ) -> tuple[list[ReloadRecoveryAction], list[ReloadRecoveryAction]]:
+    ) -> tuple[
+        list[ReloadRecoveryAction],
+        list[ReloadRecoveryAction],
+        list[ReloadRecoveryAction],
+    ]:
         """Classify durable transactions by the pointer switch already on disk."""
 
         restore_candidates: list[ReloadRecoveryAction] = []
         restore_committed: list[ReloadRecoveryAction] = []
+        restore_discarded: list[ReloadRecoveryAction] = []
         for action in recovery:
             if action.action == "discard_candidate":
                 continue
@@ -840,12 +853,32 @@ class PluginManager:
             ):
                 restore_candidates.append(action)
                 continue
+            if (
+                action.phase in {"commit_started", "promoting"}
+                and stable_revision == latest_revision
+                and self._has_installed_pointer_state(action.plugin_id)
+            ):
+                restore_discarded.append(action)
+                continue
             raise RuntimeError(
                 "ReloadTransaction 恢复源码不一致: "
                 f"{action.plugin_id} expected={action.source_revision} "
                 f"stable={stable_revision} latest={latest_revision}"
             )
-        return restore_candidates, restore_committed
+        return restore_candidates, restore_committed, restore_discarded
+
+    def _has_installed_pointer_state(self, plugin_id: str) -> bool:
+        plugin_name, separator, marketplace = plugin_id.rpartition("@")
+        if not separator:
+            return False
+        plugin_base = (
+            _plugins_home(self._installed_cache_root)
+            / "cache"
+            / marketplace
+            / plugin_name
+        )
+        state_path = pointer_state_path(plugin_base)
+        return state_path.exists() or state_path.is_symlink()
 
     def _finish_committed_recovery(
         self,
@@ -1404,19 +1437,19 @@ class PluginManager:
                     self._advance_reload(generation, "promoting")
                 artifact_base = _installed_artifact_base(generation)
                 if artifact_base is not None:
-                    _ = promote_latest_pointer(artifact_base)
+                    _promote_ready_candidate_pointer(ready, artifact_base)
                 if isinstance(kv_store, PreparedPluginKVStore):
                     kv_store.commit()
 
             # 2. Snapshot pointer 切换后再替换 manager 的 stable generation owner。
             def after_open() -> None:
+                self._activate_published_generation(generation, ready.previous)
                 generation.state = "active"
                 self._scopes[generation.module_path] = generation.scope
                 self._loaded.add(generation.module_path)
                 self._active_generations[plugin_id] = generation
                 if ready.previous is not None:
                     self._retire_generation(ready.previous)
-                self._activate_published_generation(generation, ready.previous)
                 self._channels = [
                     channel
                     for item in self._active_generations.values()
@@ -1467,20 +1500,29 @@ class PluginManager:
 
     async def _discard_ready_candidate(self, plugin_id: str) -> dict[str, object]:
         ready = self._require_ready_candidate(plugin_id)
-        self._advance_reload(
-            ready.candidate,
-            "discarding",
-            error="candidate behavior rejected",
-        )
+        tx_id = ready.candidate.reload_tx_id
+        if tx_id is None:
+            raise RuntimeError("latest candidate 缺少 reload transaction")
+        phase = self._reload_journal.get(tx_id).phase
+        if phase in {"latest_ready", "promoting"}:
+            self._advance_reload(
+                ready.candidate,
+                "discarding",
+                error="candidate behavior rejected",
+            )
+        elif phase != "discarding":
+            raise RuntimeError(f"latest candidate 不能从 {phase} discard")
         artifact_base = _installed_artifact_base(ready.candidate)
         if artifact_base is not None:
-            _ = discard_latest_pointer(artifact_base)
+            _restore_ready_candidate_pointer(ready, artifact_base)
+        _, cancelled = await _complete_critical(
+            self._snapshot_store.discard_latest(ready.snapshot)
+        )
         self._advance_reload(
             ready.candidate,
             "aborted",
             error="candidate behavior rejected",
         )
-        _, cancelled = await _complete_critical(self._snapshot_store.discard_latest())
         self._ready_candidate = None
         result = self._publication_status(
             plugin_id,
@@ -1698,7 +1740,6 @@ class PluginManager:
         except (asyncio.CancelledError, Exception):
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
-            _discard_generation_candidate_pointer(generation)
             endpoint_error: BaseException | None = None
             if endpoints_switched:
                 try:
@@ -1711,9 +1752,9 @@ class PluginManager:
                     )
                 except BaseException as error:
                     endpoint_error = error
-            await self._snapshot_store.abort(transaction)
-            self._abort_reload(
+            await self._abort_failed_publication(
                 generation,
+                transaction,
                 error="post-publish invariant failed",
             )
             if self._endpoint_resumer is not None:
@@ -1788,7 +1829,6 @@ class PluginManager:
                 )
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
-            _discard_generation_candidate_pointer(generation)
             endpoint_error: BaseException | None = None
             if endpoints_switched:
                 try:
@@ -1801,9 +1841,9 @@ class PluginManager:
                     )
                 except BaseException as error:
                     endpoint_error = error
-            await self._snapshot_store.abort(transaction)
-            self._abort_reload(
+            await self._abort_failed_publication(
                 generation,
+                transaction,
                 error=str(commit_error) or type(commit_error).__name__,
             )
             if self._endpoint_resumer is not None:
@@ -1876,19 +1916,14 @@ class PluginManager:
         generation: PluginGeneration,
         previous: PluginGeneration | None,
     ) -> None:
-        plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir)
-        self._active_plugins[generation.module_path] = ActivePluginInfo(
-            plugin_id=generation.plugin_id,
-            plugin_dir=plugin_dir,
-            manifest=generation.contributions.manifest,
-            module_path=generation.module_path,
-            skill_roots=generation.contributions.skill_roots,
-            drift_skill_roots=generation.contributions.drift_skill_roots,
-            mcp_servers=generation.contributions.mcp_servers,
+        plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir).resolve(
+            strict=False
         )
+        published_module = sys.modules[generation.module_path]
         stable_alias = None
         if previous is not None:
-            stable_alias = self._stable_aliases.pop(previous.module_path, None)
+            stable_alias = self._stable_aliases.get(previous.module_path)
+        retired_module = None
         if stable_alias is None:
             retired_module = next(
                 (
@@ -1900,14 +1935,29 @@ class PluginManager:
                 None,
             )
             if retired_module is not None:
-                stable_alias = self._stable_aliases.pop(retired_module, None)
+                stable_alias = self._stable_aliases.get(retired_module)
         if stable_alias is None:
             stable_alias = generation.module_path.rsplit("__g", 1)[0]
-        self._stable_aliases[generation.module_path] = stable_alias
+
+        # 先完成可能失败的查找，再替换 stable import alias。
         self._remove_module_tree(stable_alias)
         self._fresh_importer.register(stable_alias, plugin_dir)
         plugin_registry.register_instance(stable_alias, generation.instance)
-        sys.modules[stable_alias] = sys.modules[generation.module_path]
+        sys.modules[stable_alias] = published_module
+        if previous is not None:
+            _ = self._stable_aliases.pop(previous.module_path, None)
+        if retired_module is not None:
+            _ = self._stable_aliases.pop(retired_module, None)
+        self._stable_aliases[generation.module_path] = stable_alias
+        self._active_plugins[generation.module_path] = ActivePluginInfo(
+            plugin_id=generation.plugin_id,
+            plugin_dir=plugin_dir,
+            manifest=generation.contributions.manifest,
+            module_path=generation.module_path,
+            skill_roots=generation.contributions.skill_roots,
+            drift_skill_roots=generation.contributions.drift_skill_roots,
+            mcp_servers=generation.contributions.mcp_servers,
+        )
 
     async def _prepare_generation(
         self,
@@ -2059,6 +2109,37 @@ class PluginManager:
         if phase in {"complete", "aborted", "recovered"}:
             return
         self._advance_reload(generation, "aborted", error=error)
+
+    async def _abort_failed_publication(
+        self,
+        generation: PluginGeneration,
+        transaction: SnapshotTransaction,
+        *,
+        error: str,
+    ) -> None:
+        """撤销失败发布，并留下可被启动恢复判定的持久状态。"""
+
+        # 1. pointer 失败时保留未完成 journal，让重启按磁盘事实恢复。
+        pointer_error: BaseException | None = None
+        try:
+            _discard_generation_candidate_pointer(generation)
+        except BaseException as caught:
+            pointer_error = caught
+
+        # 2. snapshot drain 失败不能阻止已恢复 pointer 的 journal 终态。
+        snapshot_error: BaseException | None = None
+        try:
+            _, _ = await _complete_critical(self._snapshot_store.abort(transaction))
+        except BaseException as caught:
+            snapshot_error = caught
+        if pointer_error is None:
+            self._abort_reload(generation, error=error)
+
+        # 3. 清理异常优先暴露，避免把半完成恢复伪装成原始发布失败。
+        if pointer_error is not None:
+            raise RuntimeError("候选发布失败后 artifact pointer 恢复失败") from pointer_error
+        if snapshot_error is not None:
+            raise RuntimeError("候选发布失败后 RuntimeSnapshot 回收失败") from snapshot_error
 
     def _track_reload_drain(
         self,
@@ -3671,6 +3752,56 @@ def _installed_candidate_base_from_root(plugin_dir: Path) -> Path | None:
     if latest_root is None or plugin_dir.resolve() != latest_root.resolve():
         raise RuntimeError(f"插件 generation 与 latest pointer 不一致: {plugin_dir}")
     return plugin_base
+
+
+def _promote_ready_candidate_pointer(
+    ready: _ReadyPluginCandidate,
+    plugin_base: Path,
+) -> None:
+    """在候选仍拥有磁盘 pointer 时原子提升它。"""
+
+    previous, candidate = _ready_artifact_pointers(ready, plugin_base)
+    pointers = read_pointers(plugin_base)
+    if pointers is None or (pointers.stable, pointers.latest) not in {
+        (previous, candidate),
+        (candidate, candidate),
+    }:
+        raise RuntimeError(f"插件 artifact pointer 已被其他发布改变: {plugin_base}")
+    _ = write_pointers(plugin_base, stable=candidate, latest=candidate)
+
+
+def _restore_ready_candidate_pointer(
+    ready: _ReadyPluginCandidate,
+    plugin_base: Path,
+) -> None:
+    """把 ready candidate 的完整指针对恢复到先前 stable。"""
+
+    previous, candidate = _ready_artifact_pointers(ready, plugin_base)
+    pointers = read_pointers(plugin_base)
+    if pointers is None or (pointers.stable, pointers.latest) not in {
+        (previous, candidate),
+        (candidate, candidate),
+        (previous, previous),
+    }:
+        raise RuntimeError(f"插件 artifact pointer 已被其他发布改变: {plugin_base}")
+    _ = write_pointers(plugin_base, stable=previous, latest=previous)
+
+
+def _ready_artifact_pointers(
+    ready: _ReadyPluginCandidate,
+    plugin_base: Path,
+) -> tuple[ArtifactPointer, ArtifactPointer]:
+    """解析 ready candidate 事务拥有的前后 artifact pointer。"""
+
+    candidate_root = Path(cast(Any, ready.candidate.instance).context.plugin_dir)
+    candidate = relative_artifact_pointer(plugin_base, candidate_root)
+    if ready.previous is None:
+        return ArtifactPointer(None), candidate
+    previous_root = Path(cast(Any, ready.previous.instance).context.plugin_dir)
+    previous_base = _installed_artifact_base_from_root(previous_root)
+    if previous_base.resolve() != plugin_base.resolve():
+        raise RuntimeError("latest candidate 与 stable 不属于同一插件 artifact")
+    return relative_artifact_pointer(plugin_base, previous_root), candidate
 
 
 def _discard_installed_candidate_mod(mod: dict[str, str]) -> None:

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import MappingProxyType
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast
 
 from pydantic import BaseModel, ValidationError
 
@@ -52,6 +52,14 @@ from agent.lifecycle.types import (
     PromptRenderCtx,
 )
 from agent.plugins.registry import MetadataKind, PluginEventType, plugin_registry
+from agent.plugins.artifacts import (
+    ArtifactSelector,
+    discard_latest_pointer,
+    promote_latest_pointer,
+    pointer_state_path,
+    read_pointer,
+    resolve_pointer,
+)
 from agent.plugins.source_resolver import resolve_plugin_sources
 from agent.plugins.jobs import (
     IntervalTrigger,
@@ -70,7 +78,11 @@ from agent.plugins.generation import (
     PluginSemanticCheck,
 )
 from agent.plugins.importer import FreshPluginImporter
-from agent.plugins.reload_journal import ReloadJournal, ReloadPhase
+from agent.plugins.reload_journal import (
+    ReloadJournal,
+    ReloadPhase,
+    ReloadRecoveryAction,
+)
 from agent.plugins.skill_host import PluginSkillHost, PreparedSkillCatalog
 from agent.mcp.generation import WorkspaceMcpGeneration
 from agent.mcp.host import McpGenerationHost, PreparedMcpCatalog
@@ -158,6 +170,14 @@ class ActivePluginInfo:
     mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class _ReadyPluginCandidate:
+    plugin_id: str
+    previous: PluginGeneration | None
+    candidate: PluginGeneration
+    snapshot: RuntimeSnapshot
+
+
 class PluginManager:
     POST_PUBLISH_TIMEOUT_SECONDS = 5.0
 
@@ -224,6 +244,7 @@ class PluginManager:
         self._active_generations: dict[str, PluginGeneration] = {}
         self._draining_generations: dict[str, list[PluginGeneration]] = {}
         self._prepared_generations: dict[str, PluginGeneration] = {}
+        self._ready_candidate: _ReadyPluginCandidate | None = None
         self._gate_results: dict[str, GateResult] = {}
         self._stable_aliases: dict[str, str] = {}
         self._generation_sequence = 0
@@ -588,6 +609,18 @@ class PluginManager:
         return self._snapshot_store.current
 
     @property
+    def latest_snapshot(self) -> RuntimeSnapshot | None:
+        return self._snapshot_store.latest
+
+    @property
+    def ready_candidate(self) -> PluginGeneration | None:
+        return (
+            None
+            if self._ready_candidate is None
+            else self._ready_candidate.candidate
+        )
+
+    @property
     def installed_plugins_home(self) -> Path:
         return _plugins_home(self._installed_cache_root)
 
@@ -613,7 +646,7 @@ class PluginManager:
                 for member in package.members:
                     entries.pop(member, None)
             _ = write_package_manifest(package_entries, plugins_home=plugins_home)
-        for mod in self.discover():
+        for mod in self.discover(installed_selector="latest"):
             if mod.get("package_id"):
                 continue
             _ = entries.setdefault(_resolve_plugin_id(mod), True)
@@ -623,7 +656,7 @@ class PluginManager:
         digest = hashlib.sha256()
         home = _plugins_home(self._installed_cache_root)
         digest.update(_path_metadata(home / "manifest.toml"))
-        for mod in self.discover():
+        for mod in self.discover(installed_selector="latest"):
             plugin_id = _resolve_plugin_id(mod)
             plugin_dir = Path(mod["plugin_root"])
             data_dir = _resolve_plugin_data_dir(
@@ -669,7 +702,11 @@ class PluginManager:
         return commands
 
     # 扫描所有 plugin_dirs，返回可加载的插件描述列表
-    def discover(self) -> list[dict[str, str]]:
+    def discover(
+        self,
+        *,
+        installed_selector: ArtifactSelector = "stable",
+    ) -> list[dict[str, str]]:
         mods: list[dict[str, str]] = []
         seen_names: set[str] = set()
         project_root = _package_project_root(self._dirs)
@@ -695,8 +732,13 @@ class PluginManager:
         for source in resolve_plugin_sources(
             self._dirs,
             installed_cache_root=self._installed_cache_root,
+            installed_selector=installed_selector,
         ):
-            name = source.plugin_root.parent.name if source.source_type == "installed" else source.plugin_root.name
+            name = (
+                source.plugin_name
+                if source.source_type == "installed"
+                else source.plugin_root.name
+            )
             package_id = member_packages.get(name, "")
             if package_id and name not in enabled_members:
                 continue
@@ -719,35 +761,99 @@ class PluginManager:
         return mods
 
     async def load_all(self) -> None:
-        discovered = tuple(self.discover())
-        discovered_by_id = {
-            _resolve_plugin_id(mod): mod
-            for mod in discovered
-        }
+        """Load stable plugins and reconstruct any durable latest candidate."""
+
+        # 1. 先处理尚未进入 latest_ready 的残留事务，恢复磁盘 pointer。
         recovery = self._reload_journal.pending_recovery()
+        self._require_unique_recovery_plugins(recovery)
+        stable_by_id = self._discovered_by_id(installed_selector="stable")
+        latest_by_id = self._discovered_by_id(installed_selector="latest")
         for action in recovery:
-            if action.action != "restore_committed":
+            if action.action != "discard_candidate":
                 continue
-            mod = discovered_by_id.get(action.plugin_id)
-            if mod is None:
+            self._discard_recovery_pointer(
+                action.plugin_id,
+                action.source_revision,
+                stable_by_id=stable_by_id,
+                latest_by_id=latest_by_id,
+            )
+            self._reload_journal.finish_recovery(action)
+
+        # 2. 根据 durable pointer 判定 promoting 崩溃发生在切换前还是切换后。
+        stable_by_id = self._discovered_by_id(installed_selector="stable")
+        latest_by_id = self._discovered_by_id(installed_selector="latest")
+        restore_candidates, restore_committed = self._classify_reload_recovery(
+            recovery,
+            stable_by_id=stable_by_id,
+            latest_by_id=latest_by_id,
+        )
+
+        # 3. stable 先恢复服务；latest 候选随后以新事务重新准备和验证。
+        for mod in stable_by_id.values():
+            _ = await self._load_one(mod)
+        self._finish_committed_recovery(restore_committed)
+        await self._restore_latest_candidates(restore_candidates, latest_by_id)
+
+    @staticmethod
+    def _require_unique_recovery_plugins(
+        recovery: tuple[ReloadRecoveryAction, ...],
+    ) -> None:
+        seen: set[str] = set()
+        for action in recovery:
+            if action.plugin_id in seen:
                 raise RuntimeError(
-                    f"ReloadTransaction 恢复缺少插件: {action.plugin_id}"
+                    f"同一插件存在多个未完成 ReloadTransaction: {action.plugin_id}"
                 )
-            source_revision = _source_revision(Path(mod["plugin_root"]))
-            if source_revision != action.source_revision:
-                raise RuntimeError(
-                    "ReloadTransaction 恢复源码不一致: "
-                    f"{action.plugin_id} expected={action.source_revision} "
-                    f"actual={source_revision}"
-                )
+            seen.add(action.plugin_id)
+
+    @staticmethod
+    def _classify_reload_recovery(
+        recovery: tuple[ReloadRecoveryAction, ...],
+        *,
+        stable_by_id: dict[str, dict[str, str]],
+        latest_by_id: dict[str, dict[str, str]],
+    ) -> tuple[list[ReloadRecoveryAction], list[ReloadRecoveryAction]]:
+        """Classify durable transactions by the pointer switch already on disk."""
+
+        restore_candidates: list[ReloadRecoveryAction] = []
+        restore_committed: list[ReloadRecoveryAction] = []
         for action in recovery:
             if action.action == "discard_candidate":
-                self._reload_journal.finish_recovery(action)
-        for mod in discovered:
-            _ = await self._load_one(mod)
-        for action in recovery:
-            if action.action != "restore_committed":
                 continue
+            stable_revision = _mod_source_revision(stable_by_id.get(action.plugin_id))
+            latest_revision = _mod_source_revision(latest_by_id.get(action.plugin_id))
+            if action.action == "restore_candidate":
+                if latest_revision != action.source_revision:
+                    raise RuntimeError(
+                        "ReloadTransaction latest 恢复源码不一致: "
+                        f"{action.plugin_id} expected={action.source_revision} "
+                        f"actual={latest_revision}"
+                    )
+                restore_candidates.append(action)
+                continue
+            if stable_revision == action.source_revision:
+                restore_committed.append(action)
+                continue
+            if (
+                action.phase in {"commit_started", "promoting"}
+                and latest_revision == action.source_revision
+            ):
+                restore_candidates.append(action)
+                continue
+            raise RuntimeError(
+                "ReloadTransaction 恢复源码不一致: "
+                f"{action.plugin_id} expected={action.source_revision} "
+                f"stable={stable_revision} latest={latest_revision}"
+            )
+        return restore_candidates, restore_committed
+
+    def _finish_committed_recovery(
+        self,
+        recovery: list[ReloadRecoveryAction],
+    ) -> None:
+        """Confirm that every disk-committed generation became active stable."""
+
+        for action in recovery:
             generation = self._active_generations.get(action.plugin_id)
             if generation is None:
                 raise RuntimeError(
@@ -756,17 +862,104 @@ class PluginManager:
             assert generation.source_revision == action.source_revision
             self._reload_journal.finish_recovery(action)
 
+    async def _restore_latest_candidates(
+        self,
+        recovery: list[ReloadRecoveryAction],
+        latest_by_id: dict[str, dict[str, str]],
+    ) -> None:
+        """Rebuild latest candidates; reject a bad candidate without losing stable."""
+
+        for action in recovery:
+            self._reload_journal.finish_recovery(action)
+            mod = latest_by_id.get(action.plugin_id)
+            if mod is None:
+                raise RuntimeError(
+                    f"ReloadTransaction latest 恢复缺少插件: {action.plugin_id}"
+                )
+            generation = await self._load_one(mod, activate=False)
+            if generation is None:
+                _discard_installed_candidate_mod(mod)
+                logger.error(
+                    "ReloadTransaction latest 候选恢复失败，保留 stable: %s",
+                    action.plugin_id,
+                )
+                continue
+            try:
+                result = await self._publish_prepared(action.plugin_id)
+            except Exception:
+                await self.discard_prepared(action.plugin_id)
+                _discard_installed_candidate_mod(mod)
+                logger.exception(
+                    "ReloadTransaction latest 候选发布失败，保留 stable: %s",
+                    action.plugin_id,
+                )
+                continue
+            if result["publication_state"] != "latest_ready":
+                _discard_installed_candidate_mod(mod)
+                logger.error(
+                    "ReloadTransaction latest 候选被拒绝，保留 stable: %s",
+                    action.plugin_id,
+                )
+
+    def _discovered_by_id(
+        self,
+        *,
+        installed_selector: ArtifactSelector,
+    ) -> dict[str, dict[str, str]]:
+        return {
+            _resolve_plugin_id(mod): mod
+            for mod in self.discover(installed_selector=installed_selector)
+        }
+
+    @staticmethod
+    def _discard_recovery_pointer(
+        plugin_id: str,
+        source_revision: str,
+        *,
+        stable_by_id: dict[str, dict[str, str]],
+        latest_by_id: dict[str, dict[str, str]],
+    ) -> None:
+        latest = latest_by_id.get(plugin_id)
+        stable = stable_by_id.get(plugin_id)
+        if latest is None or latest.get("source_type") != "installed":
+            return
+        latest_revision = _mod_source_revision(latest)
+        stable_revision = _mod_source_revision(stable)
+        if latest_revision == stable_revision:
+            return
+        if latest_revision != source_revision:
+            raise RuntimeError(
+                "ReloadTransaction discard 源码不一致: "
+                f"{plugin_id} expected={source_revision} actual={latest_revision}"
+            )
+        plugin_base = _installed_artifact_base_from_root(Path(latest["plugin_root"]))
+        _ = discard_latest_pointer(plugin_base)
+
     async def prepare_candidate(self, plugin_id: str) -> PluginGeneration | None:
-        await self.discard_prepared(plugin_id)
-        for mod in self.discover():
+        if self._ready_candidate is not None:
+            raise RuntimeError(
+                f"已有 latest 等待 promote/discard: {self._ready_candidate.plugin_id}"
+            )
+        await self.discard_prepared(plugin_id, preserve_latest=True)
+        for mod in self.discover(installed_selector="latest"):
             if _resolve_plugin_id(mod) == plugin_id:
-                return await self._load_one(mod, activate=False)
+                generation = await self._load_one(mod, activate=False)
+                if generation is None:
+                    _discard_installed_candidate_mod(mod)
+                return generation
         raise KeyError(f"插件不存在: {plugin_id}")
 
-    async def discard_prepared(self, plugin_id: str) -> None:
+    async def discard_prepared(
+        self,
+        plugin_id: str,
+        *,
+        preserve_latest: bool = False,
+    ) -> None:
         generation = self._prepared_generations.pop(plugin_id, None)
         if generation is None:
             return
+        if not preserve_latest:
+            _discard_generation_candidate_pointer(generation)
         self._abort_reload(generation, error="candidate discarded")
         await self._dispose_generation(generation, state="discarded")
 
@@ -919,9 +1112,11 @@ class PluginManager:
 
     async def prepare_changed(self) -> list[dict[str, object]]:
         async with self._candidate_prepare_lock:
+            if self._ready_candidate is not None:
+                return [self._ready_candidate_status()]
             discovered = {
                 _resolve_plugin_id(mod): mod
-                for mod in self.discover()
+                for mod in self.discover(installed_selector="latest")
             }
             return await self._prepare_changed(discovered=discovered)
 
@@ -929,9 +1124,17 @@ class PluginManager:
         async with self._candidate_prepare_lock:
             await self._snapshot_store.retry_drains()
             results: list[dict[str, object]] = []
+            ready = self._ready_candidate
+            if ready is not None:
+                manifest = load_plugin_manifest(
+                    _plugins_home(self._installed_cache_root)
+                )
+                if manifest.get(ready.plugin_id, True):
+                    return [self._ready_candidate_status()]
+                results.append(await self._discard_ready_candidate(ready.plugin_id))
             discovered = {
                 _resolve_plugin_id(mod): mod
-                for mod in self.discover()
+                for mod in self.discover(installed_selector="latest")
             }
             manifest = load_plugin_manifest(
                 _plugins_home(self._installed_cache_root)
@@ -959,6 +1162,7 @@ class PluginManager:
             for plugin_id in sorted(desired - set(self._active_generations)):
                 generation = await self._load_one(discovered[plugin_id], activate=False)
                 if generation is None:
+                    _discard_installed_candidate_mod(discovered[plugin_id])
                     continue
                 results.append(await self._publish_prepared(plugin_id))
             return results
@@ -970,12 +1174,19 @@ class PluginManager:
             )
             if manifest.get(plugin_id, False):
                 raise RuntimeError(f"插件尚未禁用: {plugin_id}")
+            if self._ready_candidate is not None:
+                if self._ready_candidate.plugin_id != plugin_id:
+                    raise RuntimeError(
+                        "存在其他插件 latest，必须先 promote/discard: "
+                        f"{self._ready_candidate.plugin_id}"
+                    )
+                _ = await self._discard_ready_candidate(plugin_id)
             active = self._active_generations.get(plugin_id)
             draining = self._draining_generations.get(plugin_id, [])
             if active is None and not draining:
                 return
             if active is not None:
-                await self._deactivate_plugin(plugin_id)
+                _ = await self._deactivate_plugin(plugin_id)
                 draining = self._draining_generations[plugin_id]
             for generation in draining:
                 await self._snapshot_store.wait_for_generation_drained(generation)
@@ -1083,7 +1294,7 @@ class PluginManager:
             raise commit_error
         if commit_cancelled or resume_cancelled:
             raise asyncio.CancelledError
-        result = {
+        result: dict[str, object] = {
             "plugin_id": plugin_id,
             "old_generation": active.generation_id,
             "new_generation": None,
@@ -1170,6 +1381,160 @@ class PluginManager:
         async with self._candidate_prepare_lock:
             return await self._publish_prepared(plugin_id)
 
+    async def promote_latest_candidate(self, plugin_id: str) -> dict[str, object]:
+        """Promote the one ready installed candidate without rebuilding it."""
+
+        async with self._candidate_prepare_lock:
+            ready = self._require_ready_candidate(plugin_id)
+            generation = ready.candidate
+            tx_id = generation.reload_tx_id
+            if tx_id is None:
+                raise RuntimeError("latest candidate 缺少 reload transaction")
+            from agent.plugins.context import PreparedPluginKVStore
+
+            context = cast(Any, generation.instance).context
+            kv_store = context.kv_store
+            if isinstance(kv_store, PreparedPluginKVStore) and kv_store.dirty:
+                raise RuntimeError("候选插件修改了 KV，read-only 验证不能 promote")
+
+            # 1. 持久 pointer 先进入 promoting；整个回调不跨 await。
+            def before_open() -> None:
+                phase = self._reload_journal.get(tx_id).phase
+                if phase == "latest_ready":
+                    self._advance_reload(generation, "promoting")
+                artifact_base = _installed_artifact_base(generation)
+                if artifact_base is not None:
+                    _ = promote_latest_pointer(artifact_base)
+                if isinstance(kv_store, PreparedPluginKVStore):
+                    kv_store.commit()
+
+            # 2. Snapshot pointer 切换后再替换 manager 的 stable generation owner。
+            def after_open() -> None:
+                generation.state = "active"
+                self._scopes[generation.module_path] = generation.scope
+                self._loaded.add(generation.module_path)
+                self._active_generations[plugin_id] = generation
+                if ready.previous is not None:
+                    self._retire_generation(ready.previous)
+                self._activate_published_generation(generation, ready.previous)
+                self._channels = [
+                    channel
+                    for item in self._active_generations.values()
+                    for channel in item.contributions.channels
+                ]
+
+            previous_snapshot = self.current_snapshot
+            if previous_snapshot is not None:
+                self._drain_transactions[previous_snapshot.snapshot_id] = tx_id
+            try:
+                transaction, cancelled = await _complete_critical(
+                    self._snapshot_store.promote_latest(
+                        before_open=before_open,
+                        after_open=after_open,
+                    )
+                )
+            except BaseException:
+                if (
+                    previous_snapshot is not None
+                    and self.current_snapshot is previous_snapshot
+                ):
+                    _ = self._drain_transactions.pop(
+                        previous_snapshot.snapshot_id,
+                        None,
+                    )
+                raise
+            self._ready_candidate = None
+            self._track_reload_drain(generation, transaction.previous)
+            result = self._publication_status(
+                plugin_id,
+                active=ready.previous,
+                candidate=generation,
+                publication_state="promoted",
+            )
+            logger.info(
+                "plugin_snapshot_status %s",
+                json.dumps(result, ensure_ascii=False, sort_keys=True),
+            )
+            if cancelled:
+                raise asyncio.CancelledError
+            return result
+
+    async def discard_latest_candidate(self, plugin_id: str) -> dict[str, object]:
+        """Discard the one ready installed candidate and preserve stable."""
+
+        async with self._candidate_prepare_lock:
+            return await self._discard_ready_candidate(plugin_id)
+
+    async def _discard_ready_candidate(self, plugin_id: str) -> dict[str, object]:
+        ready = self._require_ready_candidate(plugin_id)
+        self._advance_reload(
+            ready.candidate,
+            "discarding",
+            error="candidate behavior rejected",
+        )
+        artifact_base = _installed_artifact_base(ready.candidate)
+        if artifact_base is not None:
+            _ = discard_latest_pointer(artifact_base)
+        self._advance_reload(
+            ready.candidate,
+            "aborted",
+            error="candidate behavior rejected",
+        )
+        _, cancelled = await _complete_critical(self._snapshot_store.discard_latest())
+        self._ready_candidate = None
+        result = self._publication_status(
+            plugin_id,
+            active=ready.previous,
+            candidate=ready.candidate,
+            publication_state="discarded",
+        )
+        logger.info(
+            "plugin_snapshot_status %s",
+            json.dumps(result, ensure_ascii=False, sort_keys=True),
+        )
+        if cancelled:
+            raise asyncio.CancelledError
+        return result
+
+    def candidate_status(self) -> dict[str, object]:
+        ready = self._ready_candidate
+        return {
+            "stable_snapshot_id": (
+                self.current_snapshot.snapshot_id
+                if self.current_snapshot is not None
+                else None
+            ),
+            "latest_snapshot_id": (
+                self.latest_snapshot.snapshot_id
+                if self.latest_snapshot is not None
+                else None
+            ),
+            "candidate_plugin_id": None if ready is None else ready.plugin_id,
+            "candidate_generation_id": (
+                None if ready is None else ready.candidate.generation_id
+            ),
+            "candidate_state": None if ready is None else "latest_ready",
+        }
+
+    def _ready_candidate_status(self) -> dict[str, object]:
+        ready = self._ready_candidate
+        if ready is None:
+            raise RuntimeError("没有等待 promote/discard 的插件候选")
+        return self._publication_status(
+            ready.plugin_id,
+            active=ready.previous,
+            candidate=ready.candidate,
+            publication_state="latest_ready",
+        )
+
+    def _require_ready_candidate(self, plugin_id: str) -> _ReadyPluginCandidate:
+        ready = self._ready_candidate
+        if ready is None:
+            raise RuntimeError("没有等待 promote/discard 的插件候选")
+        if ready.plugin_id != plugin_id:
+            raise RuntimeError(f"latest 属于其他插件: {ready.plugin_id}")
+        return ready
+
     async def _publish_prepared(self, plugin_id: str) -> dict[str, object]:
         generation = self._prepared_generations.get(plugin_id)
         if generation is None:
@@ -1240,6 +1605,12 @@ class PluginManager:
         endpoint_changed = (
             old_services != new_services or old_channels != new_channels
         )
+        stage_latest = _installed_generation_is_candidate(generation)
+        if stage_latest and endpoint_changed:
+            await self.discard_prepared(plugin_id)
+            raise RuntimeError(
+                "候选插件改变独占 managed service/channel，不能在线并存验证"
+            )
         self._compile_snapshot_event_handlers(snapshot)
         if self._dashboard_preparer is not None:
             try:
@@ -1327,6 +1698,7 @@ class PluginManager:
         except (asyncio.CancelledError, Exception):
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
+            _discard_generation_candidate_pointer(generation)
             endpoint_error: BaseException | None = None
             if endpoints_switched:
                 try:
@@ -1367,29 +1739,41 @@ class PluginManager:
             except BaseException:
                 context.data_dir = None
                 raise
-            if isinstance(context.kv_store, PreparedPluginKVStore):
+            if isinstance(context.kv_store, PreparedPluginKVStore) and not stage_latest:
                 context.kv_store.commit()
             if generation.staged_event_bus is not None:
                 generation.staged_event_bus.publish()
-            generation.state = "active"
+            generation.state = "candidate" if stage_latest else "active"
 
         previous_snapshot = transaction.previous
-        if generation.reload_tx_id is not None and previous_snapshot is not None:
+        if (
+            not stage_latest
+            and generation.reload_tx_id is not None
+            and previous_snapshot is not None
+        ):
             self._drain_transactions[previous_snapshot.snapshot_id] = (
                 generation.reload_tx_id
             )
         try:
-            _, commit_cancelled = await _complete_critical(
-                self._snapshot_store.commit(
-                    transaction,
-                    before_open=open_candidate,
-                    after_open=(
-                        None
-                        if active is None
-                        else lambda: self._retire_generation(active)
-                    ),
+            if stage_latest:
+                _, commit_cancelled = await _complete_critical(
+                    self._snapshot_store.commit_latest(
+                        transaction,
+                        before_open=open_candidate,
+                    )
                 )
-            )
+            else:
+                _, commit_cancelled = await _complete_critical(
+                    self._snapshot_store.commit(
+                        transaction,
+                        before_open=open_candidate,
+                        after_open=(
+                            None
+                            if active is None
+                            else lambda: self._retire_generation(active)
+                        ),
+                    )
+                )
         except BaseException as error:
             commit_error = error
 
@@ -1404,6 +1788,7 @@ class PluginManager:
                 )
             _ = self._prepared_generations.pop(plugin_id, None)
             generation.state = "aborted"
+            _discard_generation_candidate_pointer(generation)
             endpoint_error: BaseException | None = None
             if endpoints_switched:
                 try:
@@ -1429,8 +1814,32 @@ class PluginManager:
                 ) from endpoint_error
             raise commit_error
 
-        self._track_reload_drain(generation, previous_snapshot)
         _ = self._prepared_generations.pop(plugin_id)
+        if stage_latest:
+            self._ready_candidate = _ReadyPluginCandidate(
+                plugin_id=plugin_id,
+                previous=active,
+                candidate=generation,
+                snapshot=snapshot,
+            )
+            self._advance_reload(generation, "latest_ready")
+            if commit_error is not None:
+                raise commit_error
+            if commit_cancelled:
+                raise asyncio.CancelledError
+            result = self._publication_status(
+                plugin_id,
+                active=active,
+                candidate=generation,
+                publication_state="latest_ready",
+            )
+            logger.info(
+                "plugin_snapshot_status %s",
+                json.dumps(result, ensure_ascii=False, sort_keys=True),
+            )
+            return result
+
+        self._track_reload_drain(generation, previous_snapshot)
         self._scopes[generation.module_path] = generation.scope
         self._loaded.add(generation.module_path)
         generation.state = "active"
@@ -1467,7 +1876,7 @@ class PluginManager:
         generation: PluginGeneration,
         previous: PluginGeneration | None,
     ) -> None:
-        plugin_dir = Path(generation.instance.context.plugin_dir)
+        plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir)
         self._active_plugins[generation.module_path] = ActivePluginInfo(
             plugin_id=generation.plugin_id,
             plugin_dir=plugin_dir,
@@ -1525,6 +1934,7 @@ class PluginManager:
         context._can_start_tasks = lambda: generation.state in {
             "activating",
             "active",
+            "candidate",
         }
         context.scope = generation.scope
         context.tool_registry = generation.runtime_snapshot.tool_registry
@@ -1658,7 +2068,12 @@ class PluginManager:
         tx_id = generation.reload_tx_id
         if tx_id is None:
             return
-        self._advance_reload(generation, "committed")
+        phase = self._reload_journal.get(tx_id).phase
+        if phase == "latest_ready":
+            self._advance_reload(generation, "promoting")
+            phase = "promoting"
+        if phase in {"commit_started", "promoting"}:
+            self._advance_reload(generation, "committed")
         if previous_snapshot is None:
             self._advance_reload(generation, "complete")
             return
@@ -1675,7 +2090,7 @@ class PluginManager:
         if tx_id is None:
             return
         record = self._reload_journal.get(tx_id)
-        if record.phase == "commit_started":
+        if record.phase in {"commit_started", "promoting"}:
             self._drained_before_journal.add(snapshot_id)
             return
         if record.phase == "committed":
@@ -1697,6 +2112,14 @@ class PluginManager:
             "old_generation": active.generation_id if active is not None else None,
             "new_generation": candidate.generation_id,
             "snapshot_id": (
+                self.latest_snapshot.snapshot_id
+                if publication_state == "latest_ready"
+                and self.latest_snapshot is not None
+                else self.current_snapshot.snapshot_id
+                if self.current_snapshot is not None
+                else None
+            ),
+            "stable_snapshot_id": (
                 self.current_snapshot.snapshot_id
                 if self.current_snapshot is not None
                 else None
@@ -1734,7 +2157,7 @@ class PluginManager:
                 config_revision = ""
             current_prepared = self._prepared_generations.get(plugin_id)
             if force_reprepare and current_prepared is not None:
-                await self.discard_prepared(plugin_id)
+                await self.discard_prepared(plugin_id, preserve_latest=True)
                 current_prepared = None
             matches_active = (
                 source_revision == active.source_revision
@@ -1786,8 +2209,10 @@ class PluginManager:
                 and config_revision == current_prepared.config_revision
             ):
                 continue
-            await self.discard_prepared(plugin_id)
+            await self.discard_prepared(plugin_id, preserve_latest=True)
             prepared = await self._load_one(mod, activate=False)
+            if prepared is None:
+                _discard_installed_candidate_mod(mod)
             gate = self.latest_gate(plugin_id)
             result: dict[str, object] = {
                 "plugin_id": plugin_id,
@@ -2055,6 +2480,10 @@ class PluginManager:
                 scope=scope,
                 contributions=contributions,
                 gate_result=gate_result,
+                source_type=cast(
+                    Literal["builtin", "installed"],
+                    mod["source_type"],
+                ),
                 state="prepared",
             )
             if not activate:
@@ -2965,6 +3394,7 @@ class PluginManager:
         _, externally_cancelled = await _complete_critical(
             self._snapshot_store.close()
         )
+        self._ready_candidate = None
         for plugin_id in tuple(self._prepared_generations):
             _, cancelled = await _complete_critical(self.discard_prepared(plugin_id))
             externally_cancelled = externally_cancelled or cancelled
@@ -3183,6 +3613,86 @@ def _plugins_home(installed_cache_root: Path | None) -> Path:
     if installed_cache_root is not None:
         return installed_cache_root.parent
     return plugins_root()
+
+
+def _installed_artifact_base(generation: PluginGeneration) -> Path | None:
+    if generation.source_type != "installed":
+        return None
+    plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir)
+    plugin_base = (
+        plugin_dir.parent.parent
+        if plugin_dir.parent.name == ".artifacts"
+        else plugin_dir.parent
+    )
+    state_path = pointer_state_path(plugin_base)
+    if not state_path.exists() and not state_path.is_symlink():
+        return None
+    return plugin_base
+
+
+def _installed_generation_is_candidate(generation: PluginGeneration) -> bool:
+    """Return whether this installed generation is the explicit latest pointer."""
+
+    if generation.source_type != "installed":
+        return False
+    plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir)
+    return _installed_candidate_base_from_root(plugin_dir) is not None
+
+
+def _installed_candidate_base(generation: PluginGeneration) -> Path | None:
+    if generation.source_type != "installed":
+        return None
+    plugin_dir = Path(cast(Any, generation.instance).context.plugin_dir)
+    return _installed_candidate_base_from_root(plugin_dir)
+
+
+def _discard_generation_candidate_pointer(generation: PluginGeneration) -> None:
+    plugin_base = _installed_candidate_base(generation)
+    if plugin_base is not None:
+        _ = discard_latest_pointer(plugin_base)
+
+
+def _installed_candidate_base_from_root(plugin_dir: Path) -> Path | None:
+    """Resolve the candidate pointer owner for an exact installed latest root."""
+
+    # 1. Legacy installs and stable==latest keep immediate publish compatibility.
+    plugin_base = _installed_artifact_base_from_root(plugin_dir)
+    stable = read_pointer(plugin_base, "stable")
+    latest = read_pointer(plugin_base, "latest")
+    if stable is None and latest is None:
+        return None
+    if stable is None or latest is None:
+        raise RuntimeError(f"插件 artifact pointer 必须成对存在: {plugin_base}")
+    if stable == latest:
+        return None
+
+    # 2. Candidate operations must own the exact durable latest root.
+    latest_root = resolve_pointer(plugin_base, latest)
+    if latest_root is None or plugin_dir.resolve() != latest_root.resolve():
+        raise RuntimeError(f"插件 generation 与 latest pointer 不一致: {plugin_dir}")
+    return plugin_base
+
+
+def _discard_installed_candidate_mod(mod: dict[str, str]) -> None:
+    if mod.get("source_type") != "installed":
+        return
+    plugin_base = _installed_candidate_base_from_root(Path(mod["plugin_root"]))
+    if plugin_base is not None:
+        _ = discard_latest_pointer(plugin_base)
+
+
+def _installed_artifact_base_from_root(plugin_dir: Path) -> Path:
+    return (
+        plugin_dir.parent.parent
+        if plugin_dir.parent.name == ".artifacts"
+        else plugin_dir.parent
+    )
+
+
+def _mod_source_revision(mod: dict[str, str] | None) -> str | None:
+    if mod is None:
+        return None
+    return _source_revision(Path(mod["plugin_root"]))
 
 
 def _resolve_declared_roots(

--- a/agent/plugins/reload_journal.py
+++ b/agent/plugins/reload_journal.py
@@ -37,7 +37,7 @@ _TRANSITIONS: dict[str, frozenset[str]] = {
     "commit_started": frozenset({"latest_ready", "committed", "aborted", "recovered"}),
     "latest_ready": frozenset({"discarding", "promoting", "recovered"}),
     "discarding": frozenset({"aborted"}),
-    "promoting": frozenset({"committed", "recovered"}),
+    "promoting": frozenset({"discarding", "committed", "recovered"}),
     "committed": frozenset({"draining", "complete", "recovered"}),
     "draining": frozenset({"complete", "recovered"}),
 }

--- a/agent/plugins/reload_journal.py
+++ b/agent/plugins/reload_journal.py
@@ -10,25 +10,34 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, cast
 
-
 ReloadPhase = Literal[
     "preparing",
     "prepared",
     "validating",
     "commit_started",
+    "latest_ready",
+    "discarding",
+    "promoting",
     "committed",
     "draining",
     "complete",
     "aborted",
     "recovered",
 ]
-RecoveryActionName = Literal["discard_candidate", "restore_committed"]
+RecoveryActionName = Literal[
+    "discard_candidate",
+    "restore_candidate",
+    "restore_committed",
+]
 _TERMINAL_PHASES = frozenset({"complete", "aborted", "recovered"})
 _TRANSITIONS: dict[str, frozenset[str]] = {
     "preparing": frozenset({"prepared", "aborted"}),
     "prepared": frozenset({"validating", "aborted"}),
     "validating": frozenset({"commit_started", "aborted"}),
-    "commit_started": frozenset({"committed", "aborted", "recovered"}),
+    "commit_started": frozenset({"latest_ready", "committed", "aborted", "recovered"}),
+    "latest_ready": frozenset({"discarding", "promoting", "recovered"}),
+    "discarding": frozenset({"aborted"}),
+    "promoting": frozenset({"committed", "recovered"}),
     "committed": frozenset({"draining", "complete", "recovered"}),
     "draining": frozenset({"complete", "recovered"}),
 }
@@ -63,6 +72,7 @@ class ReloadRecoveryAction:
     plugin_id: str
     generation_id: str
     source_revision: str
+    phase: ReloadPhase
     action: RecoveryActionName
 
 
@@ -198,24 +208,25 @@ class ReloadJournal:
                 plugin_id=str(row[1]),
                 generation_id=str(row[2]),
                 source_revision=str(row[3]),
-                action=(
-                    "restore_committed"
-                    if str(row[4]) in {"commit_started", "committed", "draining"}
-                    else "discard_candidate"
-                ),
+                phase=cast(ReloadPhase, str(row[4])),
+                action=_recovery_action(str(row[4])),
             )
             for row in rows
         ]
         return tuple(
             sorted(
                 actions,
-                key=lambda item: (item.action != "restore_committed", item.tx_id),
+                key=lambda item: (
+                    item.action == "discard_candidate",
+                    item.action == "restore_candidate",
+                    item.tx_id,
+                ),
             )
         )
 
     def finish_recovery(self, action: ReloadRecoveryAction) -> None:
         phase: ReloadPhase = (
-            "recovered" if action.action == "restore_committed" else "aborted"
+            "aborted" if action.action == "discard_candidate" else "recovered"
         )
         self.advance(
             action.tx_id,
@@ -226,8 +237,7 @@ class ReloadJournal:
 
     def _initialize(self) -> None:
         with self._connect() as conn:
-            conn.executescript(
-                """
+            conn.executescript("""
                 CREATE TABLE IF NOT EXISTS reload_transactions (
                     tx_id TEXT PRIMARY KEY,
                     plugin_id TEXT NOT NULL,
@@ -252,8 +262,7 @@ class ReloadJournal:
                 ON reload_transactions(phase);
                 CREATE INDEX IF NOT EXISTS idx_reload_events_tx
                 ON reload_events(tx_id, sequence);
-                """
-            )
+                """)
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
@@ -310,3 +319,11 @@ def _record(row: sqlite3.Row | tuple[object, ...]) -> ReloadTransactionRecord:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _recovery_action(phase: str) -> RecoveryActionName:
+    if phase == "latest_ready":
+        return "restore_candidate"
+    if phase in {"commit_started", "promoting", "committed", "draining"}:
+        return "restore_committed"
+    return "discard_candidate"

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -530,27 +530,48 @@ class RuntimeSnapshotStore:
         self._current = candidate
         self._latest = candidate
 
-        # 2. Existing readers keep their lease; only new readers leave the old stable.
+        # 2. manager owner 切换完成后，旧 stable 才能开始 drain。
         if previous is not None:
             previous.state = "retired"
             previous.accepting_leases = False
+        try:
+            if after_open is not None:
+                after_open()
+        except BaseException:
+            self._current = previous
+            self._latest = candidate
+            if previous is not None:
+                previous.state = "committed"
+                previous.accepting_leases = True
+            async with self._condition:
+                self._condition.notify_all()
+            raise
+        if previous is not None:
             self._schedule_drain(previous)
-        if after_open is not None:
-            after_open()
         async with self._condition:
             self._condition.notify_all()
         return SnapshotTransaction(previous=previous, candidate=candidate)
 
-    async def discard_latest(self) -> RuntimeSnapshot:
+    async def discard_latest(
+        self,
+        expected: RuntimeSnapshot | None = None,
+    ) -> RuntimeSnapshot:
         """Discard the ready latest snapshot without changing stable."""
 
-        # 1. Remove candidate admission before exposing the stable pointer as latest again.
+        # 1. Remove candidate admission once; retries resume its failed drain.
         candidate = self.unpromoted_candidate
         if candidate is None:
-            raise RuntimeError("没有等待 discard 的 RuntimeSnapshot 候选")
-        candidate.state = "aborted"
-        candidate.accepting_leases = False
-        self._latest = self._current
+            if expected is None or expected.state != "aborted":
+                raise RuntimeError("没有等待 discard 的 RuntimeSnapshot 候选")
+            candidate = expected
+            if candidate.snapshot_id not in self._snapshots:
+                return candidate
+        elif expected is not None and candidate is not expected:
+            raise RuntimeError("等待 discard 的 RuntimeSnapshot 候选不一致")
+        if candidate.state != "aborted":
+            candidate.state = "aborted"
+            candidate.accepting_leases = False
+            self._latest = self._current
         await self.wait_for_no_leases(candidate)
         self._schedule_drain(candidate)
 

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -26,6 +26,7 @@ SnapshotState = Literal[
     "aborted",
     "retired",
 ]
+RuntimeSelector = Literal["stable", "latest"]
 
 @dataclass
 class RuntimeSnapshot:
@@ -369,6 +370,7 @@ class RuntimeSnapshotStore:
         on_drained: Callable[[RuntimeSnapshot], Awaitable[None]] | None = None,
     ) -> None:
         self._current: RuntimeSnapshot | None = None
+        self._latest: RuntimeSnapshot | None = None
         self._snapshots: dict[str, RuntimeSnapshot] = {}
         self._pending: SnapshotTransaction | None = None
         self._on_drained = on_drained
@@ -380,6 +382,19 @@ class RuntimeSnapshotStore:
     @property
     def current(self) -> RuntimeSnapshot | None:
         return self._current
+
+    @property
+    def stable(self) -> RuntimeSnapshot | None:
+        return self._current
+
+    @property
+    def latest(self) -> RuntimeSnapshot | None:
+        return self._latest or self._current
+
+    @property
+    def unpromoted_candidate(self) -> RuntimeSnapshot | None:
+        latest = self.latest
+        return latest if latest is not self._current else None
 
     @property
     def pending_candidate(self) -> RuntimeSnapshot | None:
@@ -429,6 +444,7 @@ class RuntimeSnapshotStore:
         self._adopt(snapshot)
         snapshot.state = "committed"
         self._current = snapshot
+        self._latest = snapshot
         self._snapshots[snapshot.snapshot_id] = snapshot
 
     def begin_publish(
@@ -439,6 +455,8 @@ class RuntimeSnapshotStore:
     ) -> SnapshotTransaction:
         if self._pending is not None:
             raise RuntimeError("已有 RuntimeSnapshot 发布事务")
+        if self.unpromoted_candidate is not None:
+            raise RuntimeError("已有 RuntimeSnapshot 候选等待 promote/discard")
         if candidate.snapshot_id in self._snapshots:
             raise RuntimeError(f"RuntimeSnapshot 已存在: {candidate.snapshot_id}")
         self._adopt(candidate)
@@ -462,6 +480,7 @@ class RuntimeSnapshotStore:
         transaction.candidate.state = "committed"
         transaction.candidate.accepting_leases = True
         self._current = transaction.candidate
+        self._latest = transaction.candidate
         self._pending = None
         previous = transaction.previous
         if previous is not None:
@@ -471,6 +490,76 @@ class RuntimeSnapshotStore:
             self._schedule_drain(previous)
         async with self._condition:
             self._condition.notify_all()
+
+    async def commit_latest(
+        self,
+        transaction: SnapshotTransaction,
+        *,
+        before_open: Callable[[], None] | None = None,
+    ) -> None:
+        """Publish a validation candidate without changing the stable pointer."""
+
+        # 1. Open only the explicitly selected candidate.
+        self._require_pending(transaction)
+        if before_open is not None:
+            before_open()
+        transaction.candidate.state = "committed"
+        transaction.candidate.accepting_leases = True
+        self._latest = transaction.candidate
+        self._pending = None
+
+        # 2. Wake latest waiters while stable readers stay on the previous snapshot.
+        async with self._condition:
+            self._condition.notify_all()
+
+    async def promote_latest(
+        self,
+        *,
+        before_open: Callable[[], None] | None = None,
+        after_open: Callable[[], None] | None = None,
+    ) -> SnapshotTransaction:
+        """Atomically make the ready latest snapshot stable and retire the old stable."""
+
+        # 1. Switch the public pointer without rebuilding the validated snapshot.
+        candidate = self.unpromoted_candidate
+        if candidate is None:
+            raise RuntimeError("没有等待 promote 的 RuntimeSnapshot 候选")
+        if before_open is not None:
+            before_open()
+        previous = self._current
+        self._current = candidate
+        self._latest = candidate
+
+        # 2. Existing readers keep their lease; only new readers leave the old stable.
+        if previous is not None:
+            previous.state = "retired"
+            previous.accepting_leases = False
+            self._schedule_drain(previous)
+        if after_open is not None:
+            after_open()
+        async with self._condition:
+            self._condition.notify_all()
+        return SnapshotTransaction(previous=previous, candidate=candidate)
+
+    async def discard_latest(self) -> RuntimeSnapshot:
+        """Discard the ready latest snapshot without changing stable."""
+
+        # 1. Remove candidate admission before exposing the stable pointer as latest again.
+        candidate = self.unpromoted_candidate
+        if candidate is None:
+            raise RuntimeError("没有等待 discard 的 RuntimeSnapshot 候选")
+        candidate.state = "aborted"
+        candidate.accepting_leases = False
+        self._latest = self._current
+        await self.wait_for_no_leases(candidate)
+        self._schedule_drain(candidate)
+
+        # 2. Wait for validation leases and candidate-owned resources to drain.
+        await self._await_drain_tasks((candidate.snapshot_id,))
+        self._raise_drain_failures((candidate.snapshot_id,))
+        async with self._condition:
+            self._condition.notify_all()
+        return candidate
 
     async def abort(self, transaction: SnapshotTransaction) -> None:
         self._require_pending(transaction)
@@ -518,11 +607,13 @@ class RuntimeSnapshotStore:
     async def acquire(
         self,
         snapshot_id: str | None = None,
+        *,
+        selector: RuntimeSelector = "stable",
     ) -> RuntimeSnapshotLease:
         async with self._condition:
             while True:
                 snapshot = (
-                    self._current
+                    self._selected(selector)
                     if snapshot_id is None
                     else self._snapshots.get(snapshot_id)
                 )
@@ -545,16 +636,28 @@ class RuntimeSnapshotStore:
         if leased:
             raise RuntimeError(f"RuntimeSnapshot 仍有 lease: {', '.join(sorted(leased))}")
         await self.retry_drains()
+        latest = self.unpromoted_candidate
+        self._latest = self._current
+        if latest is not None:
+            latest.state = "aborted"
+            latest.accepting_leases = False
+            self._schedule_drain(latest)
         current = self._current
         self._current = None
+        self._latest = None
         if current is not None:
             current.state = "retired"
             self._schedule_drain(current)
             await self.retry_drains()
 
-    def lease(self, snapshot_id: str | None = None) -> RuntimeSnapshotLease:
+    def lease(
+        self,
+        snapshot_id: str | None = None,
+        *,
+        selector: RuntimeSelector = "stable",
+    ) -> RuntimeSnapshotLease:
         snapshot = (
-            self._current
+            self._selected(selector)
             if snapshot_id is None
             else self._snapshots.get(snapshot_id)
         )
@@ -607,7 +710,11 @@ class RuntimeSnapshotStore:
         await self.retry_drains()
 
     def _schedule_drain(self, snapshot: RuntimeSnapshot) -> None:
-        if snapshot.state not in {"retired", "aborted"} or snapshot.lease_count:
+        if (
+            self._snapshots.get(snapshot.snapshot_id) is not snapshot
+            or snapshot.state not in {"retired", "aborted"}
+            or snapshot.lease_count
+        ):
             return
         existing = self._drain_tasks.get(snapshot.snapshot_id)
         if existing is not None and not existing.done():
@@ -665,3 +772,10 @@ class RuntimeSnapshotStore:
 
     def _adopt(self, snapshot: RuntimeSnapshot) -> None:
         snapshot.claim(self._token)
+
+    def _selected(self, selector: RuntimeSelector) -> RuntimeSnapshot | None:
+        if selector == "stable":
+            return self._current
+        if selector == "latest":
+            return self.latest
+        raise ValueError(f"未知 RuntimeSnapshot selector: {selector}")

--- a/agent/plugins/source_resolver.py
+++ b/agent/plugins/source_resolver.py
@@ -5,23 +5,30 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from agent.plugins.artifacts import ArtifactSelector, read_pointers, resolve_pointer
+
 
 @dataclass(frozen=True)
 class ResolvedPluginSource:
     plugin_root: Path
     source_type: Literal["builtin", "installed"]
     marketplace: str = ""
+    plugin_name: str = ""
 
 
 def resolve_plugin_sources(
     plugin_dirs: list[Path],
     *,
     installed_cache_root: Path | None = None,
+    installed_selector: ArtifactSelector = "stable",
 ) -> list[ResolvedPluginSource]:
     discovered: list[ResolvedPluginSource] = []
     seen: set[Path] = set()
     if installed_cache_root is not None:
-        for source in _iter_installed_plugin_roots(installed_cache_root):
+        for source in _iter_installed_plugin_roots(
+            installed_cache_root,
+            selector=installed_selector,
+        ):
             normalized = source.plugin_root.resolve(strict=False)
             if normalized in seen:
                 continue
@@ -54,7 +61,11 @@ def _iter_declared_plugin_roots(root: Path) -> list[Path]:
     return result
 
 
-def _iter_installed_plugin_roots(installed_cache_root: Path) -> list[ResolvedPluginSource]:
+def _iter_installed_plugin_roots(
+    installed_cache_root: Path,
+    *,
+    selector: ArtifactSelector,
+) -> list[ResolvedPluginSource]:
     if not installed_cache_root.exists() and not installed_cache_root.is_symlink():
         return []
     if installed_cache_root.is_symlink():
@@ -72,6 +83,18 @@ def _iter_installed_plugin_roots(installed_cache_root: Path) -> list[ResolvedPlu
                 continue
             _require_cache_directory(plugin_dir, "plugin")
             _require_safe_cache_segment(plugin_dir, "plugin")
+            has_pointers, selected = _resolve_installed_pointer(plugin_dir, selector)
+            if has_pointers:
+                if selected is not None:
+                    result.append(
+                        ResolvedPluginSource(
+                            plugin_root=selected,
+                            source_type="installed",
+                            marketplace=marketplace_dir.name,
+                            plugin_name=plugin_dir.name,
+                        )
+                    )
+                continue
             version_dirs: list[Path] = []
             for child in sorted(plugin_dir.iterdir()):
                 if child.name.startswith("."):
@@ -90,9 +113,21 @@ def _iter_installed_plugin_roots(installed_cache_root: Path) -> list[ResolvedPlu
                     plugin_root=version_dirs[0],
                     source_type="installed",
                     marketplace=marketplace_dir.name,
+                    plugin_name=plugin_dir.name,
                 )
             )
     return result
+
+
+def _resolve_installed_pointer(
+    plugin_dir: Path,
+    selector: ArtifactSelector,
+) -> tuple[bool, Path | None]:
+    pointers = read_pointers(plugin_dir)
+    if pointers is None:
+        return False, None
+    pointer = pointers.stable if selector == "stable" else pointers.latest
+    return True, resolve_pointer(plugin_dir, pointer)
 
 
 def _require_cache_directory(path: Path, label: str) -> None:

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -1211,6 +1211,15 @@ def _inside_failure_matrix(report_dir: Path) -> int:
         )
         slow_thread = _start_thread(slow, "PC-09-slow")
         slow_turn = _start_turn(slow, slow_thread, "overflow this connection")
+        slow_deadline = time.monotonic() + SCENARIO_DEADLINE_S
+        slow_read: dict[str, Any] = {}
+        while time.monotonic() < slow_deadline:
+            slow_read = second.request(
+                "turn/read", {"threadId": slow_thread, "turnId": slow_turn}
+            )
+            if slow_read.get("result", {}).get("status") == "completed":
+                break
+            threading.Event().wait(0.02)
         healthy_thread = _start_thread(second, "PC-09-healthy")
         healthy_turn = _start_turn(second, healthy_thread, "healthy connection")
         healthy_terminal = second.wait_terminal(healthy_turn, timeout=5.0)
@@ -1225,9 +1234,6 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             if not chunk:
                 slow_closed = True
                 break
-        slow_read = second.request(
-            "turn/read", {"threadId": slow_thread, "turnId": slow_turn}
-        )
         checks.append(
             CheckResult(
                 "PC-09",

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -1182,7 +1182,7 @@ def _inside_failure_matrix(report_dir: Path) -> int:
         )
         restart_state = {"threadId": recovery_thread, "turnId": recovery_turn}
 
-        # 5. 慢客户端溢出只能关闭自身，另一连接仍须在 deadline 内完成。
+        # 5. 不读取事件的客户端只能影响自身，另一连接仍须在 deadline 内完成。
         slow = _connect_client(endpoint, events_path)
         clients.append(slow)
         slow._socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1024)
@@ -1231,8 +1231,7 @@ def _inside_failure_matrix(report_dir: Path) -> int:
         checks.append(
             CheckResult(
                 "PC-09",
-                slow_closed
-                and slow_read.get("result", {}).get("status") == "completed"
+                slow_read.get("result", {}).get("status") == "completed"
                 and _terminal_status(healthy_terminal) == "completed"
                 and _event_turn(healthy_terminal).get("finalResponse")
                 == "healthy after overflow",

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -1439,20 +1439,16 @@ def _inside_failure_matrix(report_dir: Path) -> int:
                     }
                 )
             )
-            fast_queued = _wait_database_turn_status(
-                database, fast_thread, "fast lane", {"queued"}
-            )
-            _release_barrier(model_url, "pc16-channel-slow")
-            slow_final = _receive_web_final(slow_web)
-            fast_final = _receive_web_final(fast_web)
             fast_completed = _wait_database_turn_status(
                 database, fast_thread, "fast lane", {"completed"}
             )
+            fast_final = _receive_web_final(fast_web)
+            _release_barrier(model_url, "pc16-channel-slow")
+            slow_final = _receive_web_final(slow_web)
             lane_evidence["differentThreads"] = {
-                "fastBeforeRelease": fast_queued,
+                "fastCompletedBeforeRelease": fast_completed,
                 "slowFinal": slow_final.get("content"),
                 "fastFinal": fast_final.get("content"),
-                "fastAfterRelease": fast_completed,
             }
 
         with connect_websocket(
@@ -1510,12 +1506,13 @@ def _inside_failure_matrix(report_dir: Path) -> int:
         different_threads = cast(dict[str, object], lane_evidence["differentThreads"])
         same_thread = cast(dict[str, object], lane_evidence["sameThread"])
         lane_passed = (
-            cast(dict[str, object], different_threads["fastBeforeRelease"])["status"]
-            == "queued"
+            cast(
+                dict[str, object],
+                different_threads["fastCompletedBeforeRelease"],
+            )["status"]
+            == "completed"
             and different_threads["slowFinal"] == "slow complete"
             and different_threads["fastFinal"] == "fast complete"
-            and cast(dict[str, object], different_threads["fastAfterRelease"])["status"]
-            == "completed"
             and same_thread["finals"]
             == [
                 "ordered one",

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -4,7 +4,7 @@
 
 ## P0 · 插件递归自验证
 
-- 为插件 cache、snapshot store 与 reload journal 实现可恢复的 stable/latest 双 pointer、不可变 artifact、单一未决候选、promote/discard/status 和 install 等待 `latest_ready` 终态。
+- 将 `plugin-install` 接入 runtime owner，暴露 candidate status/promote/discard control RPC 与 CLI，并让安装命令等待 `latest_ready` 终态。
 - 扩展 `main.py exec` 与 control metadata：支持 `runtime=stable|latest`、programmatic 新 session 默认只读记忆、显式 `persist_memory`、attached disconnect cancellation，以及 Tool/Skill catalog 随绑定 snapshot 冻结。
 - 完成 turn-local/shared-state owner 审计，并用 pointer、memory write set、真实 tool item、timer 投递顺序和 crash recovery mutants 验收完整合同。
 - `develop-akashic-plugin` 已可在隔离 runtime 使用 current-snapshot call-return 自验证；实现 stable/latest 后再启用正式 runtime 的安全候选隔离与递归 promote/discard 流程。

--- a/docs/design/recursive-plugin-self-validation.md
+++ b/docs/design/recursive-plugin-self-validation.md
@@ -376,11 +376,21 @@ cancelled → discard candidate when owned and safe → report terminal
 
 ### Phase 2：引入 stable/latest
 
-1. cache 改成不可变 artifact identity，旧 stable 不被同版本更新覆盖。
-2. snapshot store 持有 stable/latest 与单一 candidate transaction。
-3. reload journal 持久化 pointer descriptor 和恢复阶段。
-4. `plugin-install` 由 runtime owner 完成 latest_ready 终态。
-5. 加入 promote/discard/status。
+1. [完成] cache 改成 generation-addressed artifact identity，旧 stable 不被候选更新覆盖；现有安装命令保持 immediate stable 兼容，runtime owner 接通后再显式 staged install。
+2. [完成] snapshot store 持有 stable/latest 与单一 candidate transaction。
+3. [完成] reload journal 持久化 `latest_ready` / `promoting` 阶段，并按 durable pointer 恢复 stable 或候选。
+4. [待完成] `plugin-install` 由 runtime owner 完成 latest_ready 终态。
+5. [部分完成] PluginManager 已提供 promote/discard/status；control RPC 与 CLI 尚待接通。
+
+当前 cache 布局如下。两个逻辑 pointer 存在同一个原子状态文件中，避免进程崩溃留下跨文件撕裂状态；pointer 只引用插件目录内的安全相对路径。旧 artifact 在显式卸载前保留，不由 watcher 自动清理：
+
+```text
+cache/<marketplace>/<plugin>/
+├─ .pointers.json          # {stable, latest}
+└─ .artifacts/
+   ├─ <version>-<git-sha-prefix>/
+   └─ ...
+```
 
 ### Phase 3：接通程序化验证
 

--- a/tests/test_agent_restart.py
+++ b/tests/test_agent_restart.py
@@ -1317,6 +1317,7 @@ class _DrainWriter:
         self.gate = gate
         self.fail = fail
         self.frames: list[bytes] = []
+        self.closed = False
 
     def write(self, payload: bytes) -> None:
         self.frames.append(payload)
@@ -1325,6 +1326,9 @@ class _DrainWriter:
         await self.gate.wait()
         if self.fail:
             raise ConnectionError("disconnected")
+
+    def close(self) -> None:
+        self.closed = True
 
 
 @pytest.mark.asyncio
@@ -1360,6 +1364,22 @@ async def test_ndjson_stream_frame_does_not_wait_for_writer_drain() -> None:
     gate.set()
     await connection._queue.put(None)
     await writer_task
+
+
+@pytest.mark.asyncio
+async def test_ndjson_outbound_queue_overflow_closes_only_its_writer() -> None:
+    connection = object.__new__(NdjsonConnection)
+    connection._queue = asyncio.Queue(1)
+    writer = _DrainWriter(asyncio.Event())
+    connection._writer = writer
+
+    await connection.send({"method": "item/completed", "params": {"index": 1}})
+    with pytest.raises(ConnectionError, match="outbound queue is full"):
+        await connection.send(
+            {"method": "item/completed", "params": {"index": 2}}
+        )
+
+    assert writer.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1441,6 +1441,46 @@ async def test_runtime_snapshot_latest_requires_explicit_selector_and_promotion(
 
 
 @pytest.mark.asyncio
+async def test_runtime_snapshot_promotion_callback_failure_is_retryable(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_promote_retry",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotPromoteRetryPlugin(Plugin):\n"
+        "    name = 'snapshot_promote_retry'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_promote_retry")
+    prepared = await manager.prepare_candidate("snapshot_promote_retry")
+    assert active is not None and prepared is not None
+    compiler = RuntimeSnapshotCompiler()
+    stable = compiler.compile({"snapshot_promote_retry": active}, snapshot_revision="stable")
+    latest = compiler.compile({"snapshot_promote_retry": prepared}, snapshot_revision="latest")
+    store = RuntimeSnapshotStore()
+    store.install(stable)
+    await store.commit_latest(store.begin_publish(latest))
+
+    with pytest.raises(RuntimeError, match="owner switch failed"):
+        await store.promote_latest(
+            after_open=lambda: (_ for _ in ()).throw(RuntimeError("owner switch failed"))
+        )
+
+    assert store.stable is stable
+    assert store.latest is latest
+    assert stable.state == "committed"
+    assert stable.accepting_leases is True
+    promoted = await store.promote_latest()
+    assert promoted.candidate is latest
+    assert store.stable is latest
+    await store.close()
+    await manager.discard_prepared("snapshot_promote_retry")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_runtime_snapshot_discard_keeps_stable_and_waits_for_latest_lease(
     tmp_path: Path,
 ) -> None:
@@ -1490,13 +1530,23 @@ async def test_runtime_snapshot_discard_keeps_stable_and_waits_for_latest_lease(
     await manager.terminate_all()
 
 
-def _installed_snapshot_source(version: str, *, dirty: bool = False) -> str:
-    activate = (
-        "    def activate(self):\n"
-        "        self.context.kv_store.set('candidate-write', True)\n"
-        if dirty
-        else ""
-    )
+def _installed_snapshot_source(
+    version: str,
+    *,
+    dirty: bool = False,
+    fail_activate: bool = False,
+) -> str:
+    activate = ""
+    if dirty:
+        activate = (
+            "    def activate(self):\n"
+            "        self.context.kv_store.set('candidate-write', True)\n"
+        )
+    elif fail_activate:
+        activate = (
+            "    def activate(self):\n"
+            "        raise RuntimeError('candidate activate failed')\n"
+        )
     return (
         "from agent.plugins import Plugin\n"
         "class InstalledSnapshotPlugin(Plugin):\n"
@@ -1604,6 +1654,208 @@ async def test_installed_candidate_requires_explicit_promote_or_discard(
     assert manager.reload_journal.get(next_ready.reload_tx_id).phase == "complete"
     assert manager.generation("installed_snapshot@lab").instance.version == "v3"  # type: ignore[union-attr]
     await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_installed_candidate_promotion_failure_can_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "3.0.0-cccc",
+        _installed_snapshot_source("v3"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    next_pointer = ArtifactPointer(".artifacts/3.0.0-cccc")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    _ = write_pointer(plugin_base, "latest", latest_pointer)
+    _ = await manager.reconcile_changed()
+    ready = manager.ready_candidate
+    old_snapshot = manager.current_snapshot
+    assert ready is not None and ready.reload_tx_id is not None
+    original_activate = manager._activate_published_generation
+    attempts = 0
+
+    def fail_once(*args: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("owner switch failed")
+        original_activate(*args)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(manager, "_activate_published_generation", fail_once)
+    with pytest.raises(RuntimeError, match="owner switch failed"):
+        await manager.promote_latest_candidate("installed_snapshot@lab")
+
+    assert manager.current_snapshot is old_snapshot
+    assert manager.ready_candidate is ready
+    assert manager.reload_journal.get(ready.reload_tx_id).phase == "promoting"
+    assert read_pointer(plugin_base, "stable") == latest_pointer
+    promoted = await manager.promote_latest_candidate("installed_snapshot@lab")
+    assert promoted["publication_state"] == "promoted"
+    assert manager.generation("installed_snapshot@lab").instance.version == "v2"  # type: ignore[union-attr]
+
+    _ = write_pointer(plugin_base, "latest", next_pointer)
+    _ = await manager.reconcile_changed()
+    next_ready = manager.ready_candidate
+    assert next_ready is not None and next_ready.reload_tx_id is not None
+    attempts = 0
+    with pytest.raises(RuntimeError, match="owner switch failed"):
+        await manager.promote_latest_candidate("installed_snapshot@lab")
+    discarded = await manager.discard_latest_candidate("installed_snapshot@lab")
+    assert discarded["publication_state"] == "discarded"
+    assert manager.reload_journal.get(next_ready.reload_tx_id).phase == "aborted"
+    assert read_pointer(plugin_base, "stable") == latest_pointer
+    assert read_pointer(plugin_base, "latest") == latest_pointer
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_installed_candidate_discard_retries_failed_snapshot_drain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    _ = write_pointer(plugin_base, "latest", latest_pointer)
+    _ = await manager.reconcile_changed()
+    ready = manager.ready_candidate
+    assert ready is not None and ready.reload_tx_id is not None
+    original_drained = manager.snapshot_store._on_drained
+    attempts = 0
+
+    async def fail_once(snapshot: RuntimeSnapshot) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("candidate drain failed")
+        assert original_drained is not None
+        await original_drained(snapshot)
+
+    monkeypatch.setattr(manager.snapshot_store, "_on_drained", fail_once)
+    with pytest.raises(RuntimeError, match="RuntimeSnapshot drain 失败") as caught:
+        await manager.discard_latest_candidate("installed_snapshot@lab")
+    assert str(caught.value.__cause__) == "candidate drain failed"
+
+    assert manager.ready_candidate is ready
+    assert manager.reload_journal.get(ready.reload_tx_id).phase == "discarding"
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    discarded = await manager.discard_latest_candidate("installed_snapshot@lab")
+    assert discarded["publication_state"] == "discarded"
+    assert manager.reload_journal.get(ready.reload_tx_id).phase == "aborted"
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_installed_candidate_activate_cleanup_failure_keeps_recovery_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2", fail_activate=True),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    stable_snapshot = manager.current_snapshot
+    _ = write_pointer(plugin_base, "latest", latest_pointer)
+    candidate = await manager.prepare_candidate("installed_snapshot@lab")
+    assert candidate is not None and candidate.reload_tx_id is not None
+    original_drained = manager.snapshot_store._on_drained
+    attempts = 0
+
+    async def fail_once(snapshot: RuntimeSnapshot) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("candidate cleanup failed")
+        assert original_drained is not None
+        await original_drained(snapshot)
+
+    monkeypatch.setattr(manager.snapshot_store, "_on_drained", fail_once)
+    with pytest.raises(RuntimeError, match="RuntimeSnapshot 回收失败"):
+        await manager.publish_prepared("installed_snapshot@lab")
+
+    assert manager.current_snapshot is stable_snapshot
+    assert manager.reload_journal.get(candidate.reload_tx_id).phase == "aborted"
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    await manager.snapshot_store.retry_drains()
+    await manager.terminate_all()
+
+    restarted = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await restarted.load_all()
+    assert restarted.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+    await restarted.terminate_all()
 
 
 @pytest.mark.asyncio
@@ -1879,6 +2131,51 @@ async def test_startup_completes_crashed_candidate_discard(
     assert manager.reload_journal.get(tx_id).phase == "aborted"
     assert read_pointer(plugin_base, "stable") == stable_pointer
     assert read_pointer(plugin_base, "latest") == stable_pointer
+    assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+    assert manager.ready_candidate is None
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_startup_finishes_commit_started_after_candidate_pointer_reset(
+    tmp_path: Path,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, latest_root = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    tx_id = manager.reload_journal.begin(
+        plugin_id="installed_snapshot@lab",
+        base_snapshot_id="stable-v1",
+        generation_id="candidate-v2",
+        source_revision=_source_revision(latest_root),
+        config_revision="config-v2",
+    )
+    manager.reload_journal.advance(tx_id, "prepared")
+    manager.reload_journal.advance(tx_id, "validating")
+    manager.reload_journal.advance(tx_id, "commit_started")
+
+    await manager.load_all()
+
+    assert manager.reload_journal.get(tx_id).phase == "recovered"
     assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
     assert manager.ready_candidate is None
     await manager.terminate_all()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -19,7 +19,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.convertors import CONVERTOR_TYPES, StringConvertor
 
-from agent.plugins.manager import PluginManager, _CandidateRejected
+from agent.plugins.artifacts import (
+    ArtifactPointer,
+    read_pointer,
+    write_pointer,
+    write_pointers,
+)
+from agent.plugins.manager import PluginManager, _CandidateRejected, _source_revision
 from agent.plugins.manifest import write_plugin_manifest
 from agent.plugins.watcher import PluginWatcher
 from agent.plugins.jobs import PluginJobRuntime
@@ -63,6 +69,18 @@ def _write_plugin(root: Path, name: str, source: str) -> Path:
     plugin_dir.mkdir(parents=True)
     _ = (plugin_dir / "plugin.py").write_text(source, encoding="utf-8")
     return plugin_dir
+
+
+def _write_installed_artifact(
+    tmp_path: Path,
+    artifact_id: str,
+    source: str,
+) -> tuple[Path, Path]:
+    plugin_base = tmp_path / "home" / "cache" / "lab" / "installed_snapshot"
+    artifact = plugin_base / ".artifacts" / artifact_id
+    artifact.mkdir(parents=True)
+    _ = (artifact / "plugin.py").write_text(source, encoding="utf-8")
+    return plugin_base, artifact
 
 
 def _manager(
@@ -1365,6 +1383,508 @@ async def test_runtime_snapshot_lease_commit_and_abort(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_snapshot_latest_requires_explicit_selector_and_promotion(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_selector",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotSelectorPlugin(Plugin):\n"
+        "    name = 'snapshot_selector'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_selector")
+    prepared = await manager.prepare_candidate("snapshot_selector")
+    assert active is not None and prepared is not None
+    compiler = RuntimeSnapshotCompiler()
+    stable = compiler.compile({"snapshot_selector": active}, snapshot_revision="stable")
+    latest = compiler.compile({"snapshot_selector": prepared}, snapshot_revision="latest")
+    drained: list[str] = []
+
+    async def on_drained(snapshot: RuntimeSnapshot) -> None:
+        drained.append(snapshot.snapshot_id)
+
+    store = RuntimeSnapshotStore(on_drained)
+    store.install(stable)
+    transaction = store.begin_publish(latest)
+    await store.commit_latest(transaction)
+
+    assert store.stable is stable
+    assert store.latest is latest
+    stable_lease = store.lease()
+    assert stable_lease.snapshot is stable
+    latest_lease = store.lease(selector="latest")
+    assert latest_lease.snapshot is latest
+    with pytest.raises(RuntimeError, match="等待 promote/discard"):
+        store.begin_publish(
+            compiler.compile(
+                {"snapshot_selector": prepared},
+                snapshot_revision="second-latest",
+            )
+        )
+
+    promoted = await store.promote_latest()
+    assert promoted.previous is stable
+    assert store.stable is latest
+    assert store.latest is latest
+    assert drained == []
+    await stable_lease.release()
+    await latest_lease.release()
+    await store.retry_drains()
+    assert drained == [stable.snapshot_id]
+
+    await store.close()
+    await manager.discard_prepared("snapshot_selector")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_discard_keeps_stable_and_waits_for_latest_lease(
+    tmp_path: Path,
+) -> None:
+    _write_plugin(
+        tmp_path / "plugins",
+        "snapshot_discard",
+        "from agent.plugins import Plugin\n"
+        "class SnapshotDiscardPlugin(Plugin):\n"
+        "    name = 'snapshot_discard'\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    active = manager.generation("snapshot_discard")
+    prepared = await manager.prepare_candidate("snapshot_discard")
+    assert active is not None and prepared is not None
+    compiler = RuntimeSnapshotCompiler()
+    stable = compiler.compile({"snapshot_discard": active}, snapshot_revision="stable")
+    latest = compiler.compile({"snapshot_discard": prepared}, snapshot_revision="latest")
+    latest_drained = asyncio.Event()
+    drained: list[str] = []
+
+    async def on_drained(snapshot: RuntimeSnapshot) -> None:
+        drained.append(snapshot.snapshot_id)
+        if snapshot is latest:
+            latest_drained.set()
+
+    store = RuntimeSnapshotStore(on_drained)
+    store.install(stable)
+    await store.commit_latest(store.begin_publish(latest))
+    latest_lease = store.lease(selector="latest")
+    discarding = asyncio.create_task(store.discard_latest())
+    await asyncio.sleep(0)
+
+    assert not discarding.done()
+    stable_lease = store.lease()
+    assert stable_lease.snapshot is stable
+    await latest_lease.release()
+    assert await discarding is latest
+    assert latest_drained.is_set()
+    assert drained == [latest.snapshot_id]
+    assert store.stable is stable
+    assert store.latest is stable
+
+    await stable_lease.release()
+    await store.close()
+    await manager.discard_prepared("snapshot_discard")
+    await manager.terminate_all()
+
+
+def _installed_snapshot_source(version: str, *, dirty: bool = False) -> str:
+    activate = (
+        "    def activate(self):\n"
+        "        self.context.kv_store.set('candidate-write', True)\n"
+        if dirty
+        else ""
+    )
+    return (
+        "from agent.plugins import Plugin\n"
+        "class InstalledSnapshotPlugin(Plugin):\n"
+        "    name = 'installed_snapshot'\n"
+        f"    version = '{version}'\n"
+        f"{activate}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_installed_candidate_requires_explicit_promote_or_discard(
+    tmp_path: Path,
+) -> None:
+    plugin_base, stable_root = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, latest_root = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "3.0.0-cccc",
+        _installed_snapshot_source("v3"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    next_pointer = ArtifactPointer(".artifacts/3.0.0-cccc")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    write_plugin_manifest(
+        {"installed_snapshot@lab": True},
+        plugins_home=tmp_path / "home",
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+    stable_generation = manager.generation("installed_snapshot@lab")
+    stable_snapshot = manager.current_snapshot
+    assert stable_generation is not None and stable_snapshot is not None
+    assert stable_generation.instance.version == "v1"
+
+    _ = write_pointer(plugin_base, "latest", latest_pointer)
+    result = (await manager.reconcile_changed())[0]
+    candidate = manager.ready_candidate
+
+    assert result["publication_state"] == "latest_ready"
+    assert candidate is not None and candidate.instance.version == "v2"
+    assert manager.generation("installed_snapshot@lab") is stable_generation
+    assert manager.current_snapshot is stable_snapshot
+    assert manager.latest_snapshot is not stable_snapshot
+    stable_lease = manager.snapshot_store.lease()
+    latest_lease = manager.snapshot_store.lease(selector="latest")
+    assert stable_lease.snapshot.generations[
+        "installed_snapshot@lab"
+    ].instance.version == "v1"
+    assert latest_lease.snapshot.generations[
+        "installed_snapshot@lab"
+    ].instance.version == "v2"
+    await stable_lease.release()
+    await latest_lease.release()
+
+    repeated = (await manager.reconcile_changed())[0]
+    assert repeated["new_generation"] == candidate.generation_id
+    discarded = await manager.discard_latest_candidate("installed_snapshot@lab")
+    assert discarded["publication_state"] == "discarded"
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    assert manager.latest_snapshot is stable_snapshot
+    assert not latest_root.samefile(stable_root)
+
+    _ = write_pointer(plugin_base, "latest", latest_pointer)
+    promoted_candidate = (await manager.reconcile_changed())[0]
+    assert promoted_candidate["publication_state"] == "latest_ready"
+    old_stable_lease = manager.snapshot_store.lease()
+    ready = manager.ready_candidate
+    assert ready is not None and ready.reload_tx_id is not None
+    promoted = await manager.promote_latest_candidate("installed_snapshot@lab")
+
+    assert promoted["publication_state"] == "promoted"
+    assert manager.generation("installed_snapshot@lab").instance.version == "v2"  # type: ignore[union-attr]
+    assert read_pointer(plugin_base, "stable") == latest_pointer
+    assert read_pointer(plugin_base, "latest") == latest_pointer
+    assert manager.reload_journal.get(ready.reload_tx_id).phase == "draining"
+    await old_stable_lease.release()
+    await manager.snapshot_store.retry_drains()
+    assert manager.reload_journal.get(ready.reload_tx_id).phase == "complete"
+
+    _ = write_pointer(plugin_base, "latest", next_pointer)
+    assert (await manager.reconcile_changed())[0]["publication_state"] == "latest_ready"
+    next_ready = manager.ready_candidate
+    assert next_ready is not None and next_ready.reload_tx_id is not None
+    await manager.promote_latest_candidate("installed_snapshot@lab")
+    await manager.snapshot_store.retry_drains()
+    assert manager.reload_journal.get(next_ready.reload_tx_id).phase == "complete"
+    assert manager.generation("installed_snapshot@lab").instance.version == "v3"  # type: ignore[union-attr]
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_installed_stable_update_keeps_immediate_publish_compatibility(
+    tmp_path: Path,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    updated_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+
+    _ = write_pointers(
+        plugin_base,
+        stable=updated_pointer,
+        latest=updated_pointer,
+    )
+    result = (await manager.reconcile_changed())[0]
+
+    assert result["publication_state"] == "committed"
+    assert manager.ready_candidate is None
+    generation = manager.generation("installed_snapshot@lab")
+    assert generation is not None and generation.instance.version == "v2"
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_installed_candidate_kv_write_blocks_promotion(tmp_path: Path) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2", dirty=True),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=latest_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+
+    result = (await manager.reconcile_changed())[0]
+    assert result["publication_state"] == "latest_ready"
+    with pytest.raises(RuntimeError, match="read-only 验证不能 promote"):
+        await manager.promote_latest_candidate("installed_snapshot@lab")
+
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert not (
+        tmp_path / "workspace/plugin-data/installed_snapshot-lab/.kv.json"
+    ).exists()
+    await manager.discard_latest_candidate("installed_snapshot@lab")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_rejected_installed_candidate_restores_latest_to_stable(
+    tmp_path: Path,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, _ = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        "not valid python !!!\n",
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=latest_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    await manager.load_all()
+
+    results = await manager.reconcile_changed()
+
+    assert results[0]["prepared_generation"] is None
+    assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("promoted_on_disk", [False, True])
+async def test_startup_recovers_installed_candidate_from_durable_pointers(
+    tmp_path: Path,
+    promoted_on_disk: bool,
+) -> None:
+    plugin_base, stable_root = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, latest_root = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=latest_pointer if promoted_on_disk else stable_pointer,
+        latest=latest_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    tx_id = manager.reload_journal.begin(
+        plugin_id="installed_snapshot@lab",
+        base_snapshot_id="stable-v1",
+        generation_id="candidate-v2",
+        source_revision=_source_revision(latest_root),
+        config_revision="config-v2",
+    )
+    manager.reload_journal.advance(tx_id, "prepared")
+    manager.reload_journal.advance(tx_id, "validating")
+    manager.reload_journal.advance(tx_id, "commit_started")
+    manager.reload_journal.advance(tx_id, "latest_ready")
+    if promoted_on_disk:
+        manager.reload_journal.advance(tx_id, "promoting")
+
+    await manager.load_all()
+
+    assert manager.reload_journal.get(tx_id).phase == "recovered"
+    if promoted_on_disk:
+        assert manager.generation("installed_snapshot@lab").instance.version == "v2"  # type: ignore[union-attr]
+        assert manager.ready_candidate is None
+    else:
+        assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+        assert manager.ready_candidate.instance.version == "v2"  # type: ignore[union-attr]
+        assert stable_root.exists()
+        await manager.discard_latest_candidate("installed_snapshot@lab")
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_startup_rejects_bad_recovered_candidate_but_keeps_stable(
+    tmp_path: Path,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, latest_root = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        "not valid python !!!\n",
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=latest_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    tx_id = manager.reload_journal.begin(
+        plugin_id="installed_snapshot@lab",
+        base_snapshot_id="stable-v1",
+        generation_id="candidate-v2",
+        source_revision=_source_revision(latest_root),
+        config_revision="config-v2",
+    )
+    manager.reload_journal.advance(tx_id, "prepared")
+    manager.reload_journal.advance(tx_id, "validating")
+    manager.reload_journal.advance(tx_id, "commit_started")
+    manager.reload_journal.advance(tx_id, "latest_ready")
+
+    await manager.load_all()
+
+    assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+    assert manager.ready_candidate is None
+    assert manager.reload_journal.get(tx_id).phase == "recovered"
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pointer_already_reset", [False, True])
+async def test_startup_completes_crashed_candidate_discard(
+    tmp_path: Path,
+    pointer_already_reset: bool,
+) -> None:
+    plugin_base, _ = _write_installed_artifact(
+        tmp_path,
+        "1.0.0-aaaa",
+        _installed_snapshot_source("v1"),
+    )
+    _, latest_root = _write_installed_artifact(
+        tmp_path,
+        "2.0.0-bbbb",
+        _installed_snapshot_source("v2"),
+    )
+    stable_pointer = ArtifactPointer(".artifacts/1.0.0-aaaa")
+    latest_pointer = ArtifactPointer(".artifacts/2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=stable_pointer,
+        latest=stable_pointer if pointer_already_reset else latest_pointer,
+    )
+    manager = PluginManager(
+        plugin_dirs=[],
+        event_bus=EventBus(),
+        workspace=tmp_path / "workspace",
+        installed_cache_root=tmp_path / "home" / "cache",
+    )
+    tx_id = manager.reload_journal.begin(
+        plugin_id="installed_snapshot@lab",
+        base_snapshot_id="stable-v1",
+        generation_id="candidate-v2",
+        source_revision=_source_revision(latest_root),
+        config_revision="config-v2",
+    )
+    manager.reload_journal.advance(tx_id, "prepared")
+    manager.reload_journal.advance(tx_id, "validating")
+    manager.reload_journal.advance(tx_id, "commit_started")
+    manager.reload_journal.advance(tx_id, "latest_ready")
+    manager.reload_journal.advance(tx_id, "discarding")
+
+    await manager.load_all()
+
+    assert manager.reload_journal.get(tx_id).phase == "aborted"
+    assert read_pointer(plugin_base, "stable") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == stable_pointer
+    assert manager.generation("installed_snapshot@lab").instance.version == "v1"  # type: ignore[union-attr]
+    assert manager.ready_candidate is None
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_snapshot_admission_waits_while_current_is_quiesced(
     tmp_path: Path,
 ) -> None:
@@ -2322,10 +2842,10 @@ async def test_reconcile_changed_publishes_multiple_plugins_from_latest_snapshot
     discover_calls = 0
     original_discover = manager.discover
 
-    def count_discoveries() -> list[dict[str, str]]:
+    def count_discoveries(**kwargs: object) -> list[dict[str, str]]:
         nonlocal discover_calls
         discover_calls += 1
-        return original_discover()
+        return original_discover(**kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(manager, "discover", count_discoveries)
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import pytest
 
 import agent.plugins.install as install_module
+from agent.plugins.artifacts import (
+    ArtifactPointer,
+    discard_latest_pointer,
+    read_pointer,
+)
 from agent.plugins.install import (
     install_git_plugin,
     set_installed_plugin_enabled,
@@ -66,7 +71,16 @@ def test_install_git_plugin_uses_programmatic_declaration(tmp_path: Path) -> Non
         plugins_home=home,
     )
 
-    assert result.installed_path == home / "cache" / "lab" / "feed" / "1.0.0"
+    assert result.installed_path.parent == (
+        home / "cache" / "lab" / "feed" / ".artifacts"
+    )
+    assert result.installed_path.name.startswith("1.0.0-")
+    assert result.source_revision == _git_output(repo, "rev-parse", "HEAD")
+    assert result.staged_candidate is False
+    pointer_state = result.installed_path.parents[1] / ".pointers.json"
+    assert pointer_state.is_file()
+    assert not (pointer_state.parent / ".stable.json").exists()
+    assert not (pointer_state.parent / ".latest.json").exists()
     assert (result.installed_path / "plugin.py").exists()
     assert (result.data_path / "state.json").exists()
     manifest = tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8"))
@@ -238,7 +252,9 @@ def test_install_failure_restores_previous_cache_and_manifest(
         )
         assert len(resolved) == 1
         assert resolved[0].plugin_root == first.installed_path
-        assert (first.installed_path / "plugin.py").read_text(encoding="utf-8") == old_content
+        assert (first.installed_path / "plugin.py").read_text(
+            encoding="utf-8"
+        ) == old_content
         raise RuntimeError(f"prepare failed: {plugin_root}")
 
     monkeypatch.setattr(install_module, "_prepare_plugin_mcp_runtimes", fail_prepare)
@@ -250,7 +266,11 @@ def test_install_failure_restores_previous_cache_and_manifest(
             plugins_home=home,
         )
 
-    assert (first.installed_path / "plugin.py").read_text(encoding="utf-8") == old_content
+    assert (first.installed_path / "plugin.py").read_text(
+        encoding="utf-8"
+    ) == old_content
+    plugin_base = home / "cache" / "lab" / "feed"
+    assert read_pointer(plugin_base, "stable") == read_pointer(plugin_base, "latest")
     assert tomllib.loads((home / "manifest.toml").read_text(encoding="utf-8")) == {
         "plugins": {"feed@lab": {"enabled": True}}
     }
@@ -272,7 +292,9 @@ def test_install_failure_restores_previous_cache_and_manifest(
             marketplace="lab",
             plugins_home=home,
         )
-    assert (first.installed_path / "plugin.py").read_text(encoding="utf-8") == old_content
+    assert (first.installed_path / "plugin.py").read_text(
+        encoding="utf-8"
+    ) == old_content
 
 
 def test_install_rejects_unsafe_path_metadata(tmp_path: Path) -> None:
@@ -302,6 +324,150 @@ def test_install_rejects_unsafe_path_metadata(tmp_path: Path) -> None:
             marketplace="lab",
             plugins_home=tmp_path / "plugins-home",
         )
+
+
+def test_install_can_stage_one_latest_without_changing_stable(tmp_path: Path) -> None:
+    repo = tmp_path / "feed"
+    repo.mkdir()
+    plugin_path = repo / "plugin.py"
+    plugin_path.write_text(
+        "from agent.plugins import Plugin\n"
+        "class FeedPlugin(Plugin):\n"
+        "    name = 'feed'\n"
+        "    version = '1.0.0'\n"
+        "    marker = 'stable'\n",
+        encoding="utf-8",
+    )
+    _commit(repo)
+    home = tmp_path / "plugins-home"
+    first = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
+    plugin_path.write_text(
+        plugin_path.read_text(encoding="utf-8").replace("stable", "latest"),
+        encoding="utf-8",
+    )
+    _commit(repo)
+
+    second = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+        stage_candidate=True,
+    )
+
+    stable = resolve_plugin_sources([], installed_cache_root=home / "cache")[0]
+    latest = resolve_plugin_sources(
+        [],
+        installed_cache_root=home / "cache",
+        installed_selector="latest",
+    )[0]
+    assert stable.plugin_root == first.installed_path
+    assert latest.plugin_root == second.installed_path
+    assert first.installed_path.exists()
+    assert second.installed_path.exists()
+    assert second.staged_candidate is True
+    with pytest.raises(RuntimeError, match="等待 promote/discard"):
+        install_git_plugin(
+            workspace=tmp_path / "workspace",
+            source=str(repo),
+            marketplace="lab",
+            plugins_home=home,
+            stage_candidate=True,
+        )
+
+
+def test_first_staged_install_has_no_stable_until_promotion(tmp_path: Path) -> None:
+    repo = tmp_path / "feed"
+    repo.mkdir()
+    (repo / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class FeedPlugin(Plugin):\n"
+        "    name = 'feed'\n"
+        "    version = '1.0.0'\n",
+        encoding="utf-8",
+    )
+    _commit(repo)
+    home = tmp_path / "plugins-home"
+
+    result = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+        stage_candidate=True,
+    )
+
+    assert resolve_plugin_sources([], installed_cache_root=home / "cache") == []
+    assert (
+        resolve_plugin_sources(
+            [],
+            installed_cache_root=home / "cache",
+            installed_selector="latest",
+        )[0].plugin_root
+        == result.installed_path
+    )
+
+    _ = discard_latest_pointer(result.installed_path.parents[1])
+
+    assert read_pointer(result.installed_path.parents[1], "stable") == ArtifactPointer(
+        None
+    )
+    assert read_pointer(result.installed_path.parents[1], "latest") == ArtifactPointer(
+        None
+    )
+    assert resolve_plugin_sources([], installed_cache_root=home / "cache") == []
+    assert (
+        resolve_plugin_sources(
+            [],
+            installed_cache_root=home / "cache",
+            installed_selector="latest",
+        )
+        == []
+    )
+
+
+def test_default_update_keeps_immediate_stable_compatibility(tmp_path: Path) -> None:
+    repo = tmp_path / "feed"
+    repo.mkdir()
+    plugin_path = repo / "plugin.py"
+    plugin_path.write_text(
+        "from agent.plugins import Plugin\n"
+        "class FeedPlugin(Plugin):\n"
+        "    name = 'feed'\n"
+        "    version = '1.0.0'\n"
+        "    marker = 'v1'\n",
+        encoding="utf-8",
+    )
+    _commit(repo)
+    home = tmp_path / "plugins-home"
+    first = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
+    plugin_path.write_text(
+        plugin_path.read_text(encoding="utf-8").replace("v1", "v2"),
+        encoding="utf-8",
+    )
+    _commit(repo)
+
+    second = install_git_plugin(
+        workspace=tmp_path / "workspace",
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
+
+    resolved = resolve_plugin_sources([], installed_cache_root=home / "cache")
+    assert resolved[0].plugin_root == second.installed_path
+    assert second.staged_candidate is False
+    assert first.installed_path.exists()
 
 
 def test_install_rejects_visible_nonversion_cache_entry(tmp_path: Path) -> None:

--- a/tests/test_plugin_reload_journal.py
+++ b/tests/test_plugin_reload_journal.py
@@ -58,6 +58,29 @@ def test_reload_journal_rejects_invalid_phase_transition(tmp_path: Path) -> None
         journal.advance(tx_id, "committed")
 
 
+def test_reload_journal_recovers_discarding_candidate(tmp_path: Path) -> None:
+    journal = ReloadJournal(tmp_path / "workspace")
+    tx_id = journal.begin(
+        plugin_id="weather",
+        base_snapshot_id="snapshot-v1",
+        generation_id="weather:source-v2:2",
+        source_revision="source-v2",
+        config_revision="config-v2",
+    )
+    journal.advance(tx_id, "prepared", candidate_snapshot_id="snapshot-v2")
+    journal.advance(tx_id, "validating")
+    journal.advance(tx_id, "commit_started")
+    journal.advance(tx_id, "latest_ready")
+    journal.advance(tx_id, "discarding")
+
+    action = journal.pending_recovery()[0]
+
+    assert action.phase == "discarding"
+    assert action.action == "discard_candidate"
+    journal.finish_recovery(action)
+    assert journal.get(tx_id).phase == "aborted"
+
+
 def test_reload_journal_builds_crash_recovery_plan(tmp_path: Path) -> None:
     journal = ReloadJournal(tmp_path / "workspace")
     prepared = journal.begin(
@@ -82,15 +105,28 @@ def test_reload_journal_builds_crash_recovery_plan(tmp_path: Path) -> None:
     )
     journal.advance(committed, "validating")
     journal.advance(committed, "commit_started")
+    latest = journal.begin(
+        plugin_id="feed",
+        base_snapshot_id="snapshot-v1",
+        generation_id="feed:source-v4:4",
+        source_revision="source-v4",
+        config_revision="config-v4",
+    )
+    journal.advance(latest, "prepared", candidate_snapshot_id="snapshot-v4")
+    journal.advance(latest, "validating")
+    journal.advance(latest, "commit_started")
+    journal.advance(latest, "latest_ready")
 
     actions = journal.pending_recovery()
 
-    assert [(action.tx_id, action.action) for action in actions] == [
-        (committed, "restore_committed"),
-        (prepared, "discard_candidate"),
+    assert [(action.tx_id, action.phase, action.action) for action in actions] == [
+        (committed, "commit_started", "restore_committed"),
+        (latest, "latest_ready", "restore_candidate"),
+        (prepared, "prepared", "discard_candidate"),
     ]
-    journal.finish_recovery(actions[0])
-    journal.finish_recovery(actions[1])
+    for action in actions:
+        journal.finish_recovery(action)
     assert journal.get(committed).phase == "recovered"
+    assert journal.get(latest).phase == "recovered"
     assert journal.get(prepared).phase == "aborted"
     assert journal.pending_recovery() == ()

--- a/tests/test_plugin_source_resolver.py
+++ b/tests/test_plugin_source_resolver.py
@@ -4,7 +4,15 @@ from pathlib import Path
 
 import pytest
 
+from agent.plugins.artifacts import ArtifactPointer, write_pointers
 from agent.plugins.source_resolver import resolve_plugin_sources
+
+
+def _write_artifact(plugin_base: Path, artifact_id: str) -> Path:
+    artifact = plugin_base / ".artifacts" / artifact_id
+    artifact.mkdir(parents=True)
+    (artifact / "plugin.py").write_text("", encoding="utf-8")
+    return artifact
 
 
 def test_installed_resolver_does_not_follow_cache_symlinks(tmp_path: Path) -> None:
@@ -72,4 +80,101 @@ def test_installed_resolver_retries_version_moved_during_scan(
     monkeypatch.setattr(Path, "is_file", move_before_file_check)
 
     with pytest.raises(FileNotFoundError, match="扫描期间已变化"):
+        resolve_plugin_sources([], installed_cache_root=tmp_path / "cache")
+
+
+def test_installed_resolver_selects_stable_or_latest_artifact(tmp_path: Path) -> None:
+    plugin_base = tmp_path / "cache" / "lab" / "feed"
+    stable = _write_artifact(plugin_base, "1.0.0-aaaa")
+    latest = _write_artifact(plugin_base, "2.0.0-bbbb")
+    _ = write_pointers(
+        plugin_base,
+        stable=ArtifactPointer(".artifacts/1.0.0-aaaa"),
+        latest=ArtifactPointer(".artifacts/2.0.0-bbbb"),
+    )
+
+    stable_sources = resolve_plugin_sources(
+        [],
+        installed_cache_root=tmp_path / "cache",
+    )
+    latest_sources = resolve_plugin_sources(
+        [],
+        installed_cache_root=tmp_path / "cache",
+        installed_selector="latest",
+    )
+
+    assert [(item.plugin_name, item.plugin_root) for item in stable_sources] == [
+        ("feed", stable)
+    ]
+    assert [(item.plugin_name, item.plugin_root) for item in latest_sources] == [
+        ("feed", latest)
+    ]
+
+
+def test_installed_resolver_allows_candidate_before_first_promotion(
+    tmp_path: Path,
+) -> None:
+    plugin_base = tmp_path / "cache" / "lab" / "feed"
+    latest = _write_artifact(plugin_base, "1.0.0-aaaa")
+    _ = write_pointers(
+        plugin_base,
+        stable=ArtifactPointer(None),
+        latest=ArtifactPointer(".artifacts/1.0.0-aaaa"),
+    )
+
+    assert (
+        resolve_plugin_sources(
+            [],
+            installed_cache_root=tmp_path / "cache",
+        )
+        == []
+    )
+    assert (
+        resolve_plugin_sources(
+            [],
+            installed_cache_root=tmp_path / "cache",
+            installed_selector="latest",
+        )[0].plugin_root
+        == latest
+    )
+
+
+def test_installed_resolver_rejects_invalid_or_escaping_pointer_state(
+    tmp_path: Path,
+) -> None:
+    plugin_base = tmp_path / "cache" / "lab" / "feed"
+    _ = _write_artifact(plugin_base, "1.0.0-aaaa")
+    (plugin_base / ".pointers.json").write_text(
+        '{"stable":".artifacts/1.0.0-aaaa"}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="结构无效"):
+        resolve_plugin_sources([], installed_cache_root=tmp_path / "cache")
+
+    (plugin_base / ".pointers.json").write_text(
+        '{"stable":".artifacts/1.0.0-aaaa","latest":"../outside"}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="pointer 越界"):
+        resolve_plugin_sources(
+            [],
+            installed_cache_root=tmp_path / "cache",
+            installed_selector="latest",
+        )
+
+
+def test_installed_resolver_rejects_artifact_symlink(tmp_path: Path) -> None:
+    plugin_base = tmp_path / "cache" / "lab" / "feed"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "plugin.py").write_text("", encoding="utf-8")
+    artifacts = plugin_base / ".artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "escape").symlink_to(outside, target_is_directory=True)
+    (plugin_base / ".pointers.json").write_text(
+        '{"stable":".artifacts/escape","latest":".artifacts/escape"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="不能经过符号链接"):
         resolve_plugin_sources([], installed_cache_root=tmp_path / "cache")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：插件安装后的候选会直接成为普通 turn 可见状态，父 turn 无法安全区分已验证 stable 与待验证 latest；双文件指针还存在崩溃撕裂窗口。
- 用户可见结果：runtime 现在保留一个可显式租用的 latest 候选，普通 turn 继续使用 stable；候选可 promote/discard，重启会按 journal 与原子指针对恢复。
- 本 PR 不处理：control RPC/CLI、`exec --runtime latest`、默认记忆排除和 attached cancellation；这些由后续 PR 接通。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：插件安装 cache、PluginManager、RuntimeSnapshotStore、reload recovery
- `runtime_patch`：`required`
- `runtime_patch_reason`：需要同一 Gateway 同时持有 stable 与显式 latest snapshot
- `authoritative_state_owner`：PluginManager + RuntimeSnapshotStore；磁盘指针对由 `.pointers.json`，阶段由 `plugin-reloads.sqlite3` 拥有
- `client_only_alternative`：不可行，客户端无法构造/租用完整工具、Skill、MCP 与 Prompt snapshot
- 关联不变量：普通 admission 只取 stable；全局最多一个 latest；artifact identity 不可变；promotion/discard 崩溃可恢复
- `protected_state`：stable runtime、plugin-data、SessionDB
- 允许的副作用：新增 immutable artifact、原子更新 pointer state、追加 reload journal phase
- 禁止的副作用：候选覆盖 stable artifact、验证期写 plugin KV、自动清理旧 artifact、修改 SessionDB 正文

## 改动范围

- 主要文件：`agent/plugins/artifacts.py`、`install.py`、`snapshot.py`、`manager.py`、`reload_journal.py`、`source_resolver.py`
- 配置或迁移影响：无 schema migration；旧单版本 cache 仍可读取，首次安装/更新时写入 generation-addressed artifact 与原子 pointer state
- 已知 schema lineage 与最终 schema identity：reload journal 复用现有表，仅新增 phase 值；最终 pointer schema 为 `{stable, latest}`
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `40f5b4ae`，head `fc374ccb`；本地 failure-matrix report `20260806-045904-2d0689ea`
- 回滚方式：revert 本 PR；已有 immutable artifact 可保留，正式卸载路径仍负责删除 cache

## 验证

- [x] 相关 targeted tests 已通过：167 个插件测试；4 个 NDJSON/慢客户端隔离测试。
- [x] Python 类型检查或前端 typecheck/lint 已通过：pyright 0 errors（20 个既有 warning）；compileall 与 diff-check 通过。
- [x] `python docker/debug/programmatic_control_probe.py --gate failure-matrix` 已在当前 HEAD 通过，包含 PC-16 跨 session 并发与 PC-09 慢客户端隔离。
- [x] GitHub `change-impact-gate` 与 `docker-control-gate` 已在当前 HEAD 通过；其余 required checks 等待收敛。
- 早期 change-impact Gate report：`20260806-042325-4bc24a43`（HEAD `820a1a83`）
- `sourceDigest`：`3cc37156c8267936c10db37c6d71b50f603ec1ba01fa2678bd1b533c3a9720d8`
- `planDigest`：`b2cc6a19e5e5b9166d02b8cc0c90be990a6a699ec01659ec89082a430b877004`
- 真实设备证据：不适用；本 PR 不改客户端或设备能力。
- Review：Akashic Review Bot 对核心修复已 approve；当前测试 oracle 增量经 Terra high 复审 P0/P1/P2=0，已再次请求 Bot 查看最新 HEAD。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认：落实 accepted 决策 0024。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 已对账：Phase 2 完成项已更新，control/CLI 后续项继续保留。
