### PR TITLE
[mobile] 空会话列表使用默认标题

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -100,8 +100,8 @@
 |---|---|---|
 | 任何会修改仓库文件的任务 | 本索引 → [`WORKFLOW.md`](WORKFLOW.md) → 下方对应领域 | 当前分支、目标分支、完整 diff、验证报告 |
 | Prompt、人格、上下文窗口、历史裁切、重试 | `projectneed` 第 5～7、13 节 → [Veda 人格设计](design/veda-persona.md) → [0002](decisions/0002-context-reduction-is-a-nondestructive-projection.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `agent/persona.py`、`agent/core/prompt_block.py`、`agent/core/passive_turn.py`、`agent/prompting/`、`session/manager.py`、`session/store.py` |
-| 会话、消息、turn、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
-| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
+| 会话、消息、turn、同 Turn 输入、打断、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Codex 式同 Turn 输入需求](design/codex-style-same-turn-input-requirements.md) → [Codex 式同 Turn 输入设计](design/codex-style-same-turn-input.md) → [0025](decisions/0025-codex-style-same-turn-input.md) | `agent/control/runtime.py`、`agent/core/passive_turn.py`、`bootstrap/passive_worker.py`、`session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
+| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [Codex 式同 Turn 输入需求](design/codex-style-same-turn-input-requirements.md) → [Codex 式同 Turn 输入设计](design/codex-style-same-turn-input.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
 | 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [Linux Supervisor 安全自重启提议](design/linux-supervisor-safe-self-restart.md) → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
 | 插件安装、热重载、自验证、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、9～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [0024](decisions/0024-plugin-self-validation-uses-stable-and-latest.md) → [插件递归自验证运行时设计](design/recursive-plugin-self-validation.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/snapshot.py`、`agent/plugins/reload_journal.py`、`agent/plugins/skill_links.py`、`agent/control/runtime.py`、`agent/looping/core.py`、`agent/mcp/host.py` |
@@ -206,12 +206,15 @@ docs/
 │   ├── 0021-yoyo-workspace-ledger-defines-migration-origin.md
 │   ├── 0022-mobile-webui-uses-server-selected-generations.md
 │   ├── 0023-akashic-tokens-own-material-3-semantics.md
-│   └── 0024-plugin-self-validation-uses-stable-and-latest.md
+│   ├── 0024-plugin-self-validation-uses-stable-and-latest.md
+│   └── 0025-codex-style-same-turn-input.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── linux-supervisor-safe-self-restart.md
 │   ├── mobile-cross-repository-semantic-gate.md
 │   ├── mobile-long-message-delivery.md
+│   ├── codex-style-same-turn-input-requirements.md
+│   ├── codex-style-same-turn-input.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── query-local-react-compaction.md
 │   ├── server-published-mobile-webui.md

--- a/docs/decisions/0012-query-local-compaction-is-a-persisted-projection.md
+++ b/docs/decisions/0012-query-local-compaction-is-a-persisted-projection.md
@@ -57,6 +57,10 @@ core model runtime 拥有当前 query 的压缩计算。它只接收当前 promp
 - 当前 query 中途崩溃或取消时不单独提交 compaction；既有 Turn 状态继续说明该次执行未完成。
 - Session-wide 历史归档、自动删除、摘要展开工具和跨模型重新总结不属于本决定。
 
+## 2026-08-06 补充：中断 Attempt 仍属于当前 Query
+
+同一 logical interaction 经历 `U1/interrupt/U2/interrupt/U3` 时，前驱 attempt 的闭合工具组必须加入当前 QueryCompactor，不能作为永久不可压缩的 base prefix。current-query anchor 显式合并全部 U；interrupt marker 和最近闭合工具后缀保留在热视图。最终 `react_compaction.compacted_tool_groups` 相对于所有 attempt 聚合后的完整 `tool_chain` 计数，SessionDB 和 control checkpoint 仍保持既有只追加/状态机写入。
+
 ## 验收
 
 - 低于软水位时 provider payload 与基线等价，不产生 `react_compaction`。

--- a/docs/decisions/0025-codex-style-same-turn-input.md
+++ b/docs/decisions/0025-codex-style-same-turn-input.md
@@ -1,0 +1,59 @@
+# 0025 · 普通输入采用 Codex 式 Logical Interaction continuity
+
+- 状态：accepted
+- 日期：2026-08-06
+- 关联条款：SES-007～SES-008、MEM-010、RUN-008、OUT-005
+- supersedes：无
+- superseded by：无
+
+## 背景
+
+当前 runtime 需要在用户中断后保留尚未完成任务的连续性。用户确认的目标是：U1 启动 attempt，用户中断后再发送 U2/U3；每条新 U 创建新 attempt，但都属于同一个 logical interaction，直到唯一 A_final 才结束。
+
+Codex `2b5bdcf67547860f2e5c5a605009a70026796b2b` 的普通 user admission 会先尝试 active-turn steer；pending input 在下一次模型采样前 drain，检测到 pending input 时同一 user-visible turn 继续。显式 `turn/interrupt` 则独立终结 turn。
+
+## 决定
+
+普通输入不暴露 steer/follow-up 选择。core 在没有 active attempt 时创建；active 时 `turn/start` 明确返回 busy，唯一可用动作是精确中断。中断 terminal 后的下一条 U 沿 durable predecessor 创建新 attempt。最终回复候选必须先 seal input source，成功后才提交 completed interaction。
+
+Mobile 输入区在 active 时只显示 hard interrupt，草稿保留但不能发送；各 channel `/stop` 使用相同 hard interrupt。控制协议不再提供 `turn/steer`。Akasha 对 completed turn 聚合全部有序 U 和唯一 final A，不再用相邻角色推断新格式。
+
+## 2026-08-06 勘误
+
+维护者以真实 Mobile 场景重新确认后，以上 active-with-draft steer 交互不再成立。当前接受语义如下：
+
+- Mobile active 时无论是否存在草稿，尾部动作都只能是中止；草稿保留但不能发送。
+- hard interrupt 只终结当前 execution attempt，不终结 logical interaction。
+- 中止收束后发送的下一条 U 创建新 attempt，沿用同一 interaction identity，并重放此前全部 U 和已经闭合的工具调用/结果。
+- `U1 → stop → U2 → stop → U3 → A_final` 是一个 completed logical interaction、三个 execution attempts；只有 `A_final` 关闭 interaction。
+- SessionDB 最终只追加 `U1、U2、U3、A_final` 的 canonical transcript。Akasha 在线与离线都只从该 completed transcript 建立一个样本；attempt checkpoint 不进入学习。
+- `memory_window`、Markdown consolidation 和 recent turns 都把这四条消息视为一个逻辑历史单元；proactive assistant 单独占一个单元。
+- 前驱 attempt 的闭合工具组加入 query-local ReAct compaction；摘要输入显式包含 U1/U2/U3，最近工具后缀保留原文，权威工具证据不因压缩被改写。
+
+## 理由
+
+这个模型直接匹配 Mobile 操作：执行中只有中止，终止后发送就是补充尚未完成的任务。attempt identity 和 terminal fencing 避免迟到输入串到错误执行；闭合工具组压缩控制模型热上下文，同时让 durable ledger 保持可审计。
+
+## 影响
+
+- 正面影响：连环中止后补充要求仍保留同一 interaction、完整工具事实和同一最终回答；Mobile 没有 send/stop 模式选择。
+- 兼容性：`turn/start` active 行为、移除 `turn/steer`、completed transcript、history budget 和 Akasha projection 发生 breaking 变化。
+- 数据和迁移：不改旧正文；新消息在 extra 中携带显式 turn 归属。Akasha builder 对旧数据保留 legacy pair。
+- 失败与回滚：输入先写 turn checkpoint 再进入内存；代码可回滚，已追加 message 不删除。
+
+## 验收
+
+- [x] 两次中止产生三个 attempt ID，但沿用同一 interaction ID，只有一个 terminal A。
+- [x] SessionDB 和 Akasha 都把全部 U 归入同一 completed turn。
+- [x] `/stop` 仍只产生 interrupted terminal，不注入 user input。
+- [x] Mobile active 时只显示中止；草稿不能把动作切换回发送。
+- [x] 同一 interaction 的前驱工具组可进入 ReAct compaction，摘要锚定全部 U。
+- [x] memory window、Markdown consolidation 与 proactive 使用一致的逻辑历史单元。
+
+## 接受风险
+
+一个 logical interaction 可以包含很多 U 和工具结果，因此 SessionDB/control ledger 会按既有只追加和结果边界持续增长；`memory_window` 也不是 token 硬上限。当前接受这一风险：模型热上下文会合并全部 user query，并只压缩已闭合的旧工具组；若单个 query anchor 或最近不可拆工具后缀本身超过 provider 边界，则明确失败。本决定不引入 Maka 式通用 ArchiveRead 协议，也不自动删除权威证据。
+
+## 未决问题
+
+- 无。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,6 +30,7 @@
 | [0022](0022-mobile-webui-uses-server-selected-generations.md) | accepted | 移动 WebUI 使用服务端选择的不可变 generation | WEBUI-001～WEBUI-006、MOB-001～MOB-004、TST-006～TST-008 |
 | [0023](0023-akashic-tokens-own-material-3-semantics.md) | accepted | Akashic Token 拥有 Material 3 设计语义 | WEBUI-001～WEBUI-007 |
 | [0024](0024-plugin-self-validation-uses-stable-and-latest.md) | accepted | 插件自验证使用 stable/latest 与 session 级并发 | RUN-007、OUT-004、PLG-013、CTRL-003、TST-001～TST-006 |
+| [0025](0025-codex-style-same-turn-input.md) | accepted | 中断后的新 Attempt 续接同一 Logical Interaction | SES-007～SES-008、MEM-010～MEM-011、RUN-008、OUT-005 |
 
 ## 新增规则
 

--- a/docs/design/codex-style-same-turn-input-requirements.md
+++ b/docs/design/codex-style-same-turn-input-requirements.md
@@ -1,0 +1,82 @@
+# Codex 式同 Turn 输入需求合同
+
+- 状态：accepted / implemented
+- 日期：2026-08-06
+- 决策：[0025](../decisions/0025-codex-style-same-turn-input.md)
+- 设计：[Codex 式同 Turn 输入设计与任务合同](codex-style-same-turn-input.md)
+- 关联条款：CTX-003、SES-001～SES-002、SES-005、SES-007～SES-008、MEM-009～MEM-010、RUN-002～RUN-003、RUN-007～RUN-008、OUT-001、OUT-005
+
+## 1. 用户可见目标
+
+普通用户输入在 session 没有 active execution attempt 时创建新 attempt；若上一个 attempt 被中止且尚无最终 A，则自动续接同一个 logical interaction。用户不选择 `steer`、`follow-up` 或 `next prompt`。
+
+一次 logical interaction 可以按顺序经历 `U1 → stop → U2 → stop → U3 → A_final`。每次 stop 只结束 execution attempt；下一 attempt 必须看到此前 U 和所有已闭合工具事实。Mobile active 时尾部动作始终是中止，草稿保留但不能发送；中止收束后才恢复发送。Telegram、QQ 等 channel 的 `/stop` 使用相同语义。
+
+## 2. 需求
+
+### STI-001 普通输入自动选择 logical interaction
+
+同 session 没有 active attempt 时，普通 U 创建 attempt；最新 interaction 没有最终 A 时，新 attempt 沿用其 identity。active attempt 期间 Mobile 不接收普通发送。core 根据 durable terminal 状态选择 interaction，客户端不暴露模式选择器。
+
+### STI-002 同一 turn 支持多个 U
+
+一个 turn 的输入是有序非空集合，而不是单条 user message。每个 U 拥有稳定 item ID、ordinal、原始正文、附件引用和客户端身份；任何 consumer 不得用相邻角色推断 turn 归属。
+
+### STI-003 新 U 在 Attempt 边界生效
+
+新 U 只能在前一 attempt 已中止收束后进入下一 attempt。active attempt 上的普通 `turn/start` 必须返回 busy；控制协议不提供 `turn/steer`。已完成的工具调用和结果按既有证据保留规则继续持久化并进入下一 attempt；正在执行且没有 result 的工具以 interrupted 闭合，但不进入下一次模型 replay。
+
+### STI-004 最终 A 才结束 Logical Interaction
+
+interrupted、cancelled 或 failed attempt 都不关闭 logical interaction。只有一次 attempt 成功提交 terminal assistant 时，该回复才成为 `A_final`，interaction completed；此后的普通 U 才创建新的 interaction。
+
+### STI-005 控制面只提供精确中断
+
+active attempt 期间唯一改变执行状态的用户动作是携带精确 thread/turn identity 的 `turn/interrupt`。普通输入只走 `turn/start`：active 时明确 busy，terminal 后由 core 根据 durable predecessor 创建下一 attempt。adapter 不得提供 steer、follow-up 或 next-prompt 分支。
+
+### STI-006 Attempt checkpoint 可恢复和重放
+
+每个 attempt 的初始 U、工具 started/completed 和状态实时写入 `turns`。下一 attempt 从前驱链恢复全部 U，并把每个已完成 tool call/result 投影回模型历史；未闭合工具和 partial assistant delta 不重放。SessionDB `messages` 仍只在 interaction completed 时提交完整 transcript batch。
+
+### STI-007 Completed transcript 是多个 U 加一个最终 A
+
+completed turn 在一个 SessionDB 事务中按 ordinal 追加全部 U，随后追加唯一 `A_final`。每条消息携带相同 `control_turn_id`；user 携带 `turn_input_ordinal`，assistant 携带 terminal 标志和输入数量。历史窗口或 consolidation 起点若落在该 turn 中间，replay 必须退回 U1，允许实际投影量超过消息数预算。现有消息正文保持只追加。
+
+### STI-008 硬终止保持独立
+
+Mobile 中止动作和 `/stop` 只调用 `turn/interrupt`，把 active attempt 终结为 interrupted。它们不注入 user message、不伪装成 steer，也不自动启动下一 attempt。Mobile active 时无论草稿是否为空都只提供中止；草稿保留，中止收束后才允许发送。
+
+### STI-009 Akasha 使用显式多输入投影
+
+Akasha 对一个 completed logical interaction 建立一个学习样本：有序聚合全部 U，输出为 `A_final`。attempt checkpoint 不触发在线学习，也不进入离线 rebuild；在线与离线 builder 只从最终 transcript 的 `control_turn_id`、ordinal 和 terminal 标志重建。旧消息继续走明确的 legacy pair 兼容路径。
+
+### STI-010 失败和竞态不得丢输入或串 turn
+
+输入 admission、hard interrupt 和 turn completion 共用同一个 session/turn owner。active 时到达的普通 U 明确拒绝，不得塞回旧 attempt；客户端在 interrupt terminal 后重发，core 才创建下一 attempt。重复或过期控制请求不得影响当前 turn。
+
+### STI-011 历史预算按 Logical Interaction 计数
+
+`memory_window`、Markdown consolidation 的保留尾部、分页切点、积压阈值和 recent turns 都按不可拆分的逻辑历史单元计数。一个 completed `U1..Un+A_final` 是一个单元；一次已送达 proactive assistant 是一个独立单元。窗口和游标不得落入显式 `control_turn_id` 中间。
+
+### STI-012 连环中断的工具前缀可压缩但不可丢证据
+
+下一 attempt 初始 prompt 中的前驱工具调用/结果必须加入现有 query-local ReAct compaction，而不是成为永远不可压缩的固定前缀。压缩只淘汰已闭合工具组，显式把本 interaction 的全部 U 作为 current-query anchor，并保留最近原始工具后缀。压缩无合法切点、摘要无效或节省不足时 fail-loud；不得改写或删除权威 turn/message 证据。
+
+## 3. 验收序列
+
+1. U1 创建 interaction I1 / attempt E1，Agent 完成一个工具批次。
+2. 用户中止 E1；U2 创建 E2，模型看到 U1 和 E1 的完整工具调用/结果。
+3. 用户再次中止 E2；U3 创建 E3，模型看到 U1/U2 和 E1/E2 的完整已闭合工具事实。
+4. 只有 A_final 输出后 I1 completed；E1/E2/E3 各有独立 attempt ID。
+5. SessionDB 完成 transcript 为 `U1、U2、U3、A_final`，四条消息携带同一 interaction `control_turn_id`。
+6. Akasha 只建立一个 I1 节点，输入由 U1/U2/U3 确定性聚合，输出来自 A_final。
+7. 下一轮 U4 把 I1 当作一个历史单元；热窗口可见 I1 的全部 U、压缩摘要/最近工具后缀和 A_final，超出热窗口后由 Markdown consolidation 与 Akasha recall 提供派生语境，SessionDB 仍保留权威 transcript。
+
+## 4. 非目标
+
+- 不恢复模型隐藏思维或 provider 私有流状态。
+- 不在任意 token delta 中间注入 U。
+- 不让 `/stop` 自动变成继续任务的 user message。
+- 不修改或删除既有 message 正文。
+- 不在客户端复制 active-turn admission 规则。
+- 不在本功能中新增通用 tool-result archive/read 协议；单个 logical interaction 仍可能很大，这是已接受风险。

--- a/docs/design/codex-style-same-turn-input.md
+++ b/docs/design/codex-style-same-turn-input.md
@@ -1,0 +1,186 @@
+# Codex 式同 Turn 输入设计与任务合同
+
+- 状态：accepted / implemented
+- 日期：2026-08-06
+- 需求：[Codex 式同 Turn 输入需求合同](codex-style-same-turn-input-requirements.md)
+- 决策：[0025](../decisions/0025-codex-style-same-turn-input.md)
+- 参考版本：`codex@2b5bdcf67547860f2e5c5a605009a70026796b2b`
+
+## 1. 设计结论
+
+采用 Codex 的 durable history continuity，但把 user-visible turn 明确定义为 logical interaction：每条普通输入只在没有 active attempt 时创建 execution attempt；最新 interaction 尚无最终 A 时，新 attempt 自动续接。active 时只允许 interrupt，系统不提供 user steer。
+
+当前 `ConversationRuntime` 继续拥有 session lane、attempt identity、interrupt 和 terminal CAS，并用 `interactionId`、`attemptOrdinal`、`continuedFromTurnId` 连接 attempt。`DefaultReasoner` 把前驱 attempt 的有序 U 和已闭合工具调用/结果投影进下一次 prompt。`PassiveMessageWorker` 只负责 durable handoff 和最终 outbound；中止 attempt 不产生 outbound A。
+
+## 2. 状态与调用合同
+
+`ConversationRuntime.start_turn(request)` 只有两种结果：没有 active attempt 时创建新 execution attempt；存在 active attempt 时返回 `ThreadBusyError`，不写入任何 user item。`turn/steer` 不属于协议。
+
+Mobile active 时发送入口关闭，只能调用 `turn.stop`；中止终态完成后，下一条普通 U 调用 `turn/start` 创建新 attempt。其他 channel 的 `/stop` 使用相同路径。turn-local input source 只承担 final seal 和恢复既有有序输入，不再拥有运行中输入 ingress。
+
+## 3. Reasoner 行为
+
+新 attempt 启动时，runtime 沿 `continuedFromTurnId` 回溯同一 interaction，恢复全部 user item，并把此前每个已完成 tool item 投影为 assistant tool call + tool result。每个 attempt 的 partial assistant delta 和没有 result 的工具不进入 replay；当前 U 始终是最后一条 user message。
+
+provider 返回 tool call 时，先完成整个 tool batch并持久发布工具 item。provider 返回自然语言时原子 seal；成功后当前自然语言成为唯一 `A_final`。active 期间不存在 pending U。
+
+已经实时发送的中间 delta 属于 attempt 流展示，不拥有 interaction 完成语义；只有 terminal assistant item 和最终 transcript commit 才关闭 interaction。
+
+## 4. 持久化
+
+### `turns.items_json`
+
+- 正常增加：每个 attempt 创建时写当前 U；工具和最终 item 按现有 owner 写入。
+- 原位更新：仅 active turn 的 items append 和既有状态 CAS。
+- 逻辑失效：terminal 后 input source seal，旧 generation 不再写入。
+- 物理减少：只随用户显式删除 session cascade。
+- 恢复证据：attempt ID、interaction ID、前驱 ID、item ID、logical ordinal、status 和 tool item。
+
+### `messages`
+
+- 正常增加：completed interaction 一次 INSERT `U1..Un,A_final`。
+- 原位更新：本功能不允许。
+- 逻辑失效：不因 interrupt、Akasha 或 context projection 改变。
+- 物理减少：只按 SES-003 的显式撤销/删除。
+- 恢复证据：seq、message ID、共同 `control_turn_id`、input ordinal 和 terminal 标志。
+
+### runtime input source
+
+- 只投影从 durable predecessor 恢复的全部 U 和当前 attempt 的初始 U。
+- active attempt 不接收新 U；seal 后释放。它不是真源，不能覆盖 turns 或 messages。
+
+### Akasha sidecar
+
+- 在线事件只在最终 attempt 成功提交时携带全部有序 user message IDs 与 final assistant ID。
+- builder 对新格式按 `control_turn_id` 分组，对 legacy 数据保留严格相邻 pair。
+- 多 U 文本按 ordinal 连接；dense 使用所有非空 user message embedding 的确定性归一化均值。缺失任一必需 embedding 时保持现有 fail-loud audit。
+- interrupted/cancelled/failed attempt 只存在于 `turns`，不成为 Akasha 样本；Akasha 仍是可重建派生状态，不反向修改 SessionDB。
+
+### Session history replay
+
+- `max_messages` 表示逻辑历史单元数量，不再表示物理 message 数。一个显式 `U1..Un+A_final` 是一个单元；一次 proactive assistant 是一个单元。
+- consolidation 保留尾部、分页、积压阈值、recent turns 和 `start_index` 使用同一分组。窗口若落在显式 `control_turn_id` 中间，必须退回 U1；展开后的 provider message 数允许超过预算。
+- legacy 消息继续使用既有 user/proactive assistant 边界规则，不用相邻角色反推新格式 turn identity。
+
+### Attempt replay 和 query compaction
+
+前驱 attempt replay 在 prompt 中按顺序保留 `U、assistant tool-call、tool result、interrupt marker`。runtime 把每个已闭合 tool-call/result 识别为可压缩批次；两个以上闭合批次且达到 provider 软水位后，旧批次进入现有 `context_compact` 摘要，最近完整批次和当前未闭合后缀保持原文。
+
+摘要的 current-query anchor 不是最后一条 U，而是本 interaction 的全部 `U1..Un`。摘要无效、工具批次未闭合、切点与 `prior_tool_chain` 数量不一致、压缩后仍越过硬水位时都 fail-loud。`turns` checkpoint、最终 `messages.tool_chain` 和既有消息正文不因 provider 投影压缩而 UPDATE 或 DELETE。
+
+这一选择结合两类参考实践：`pi-mono@74caa2649f10ed71b4378ce69f5d9fbfd2466ca5` 保留 append-only session，并用 summary + recent suffix 构造 prompt，切点不会落在 tool result；`maka-agent@785b0c4f202c0263fb59150ae903195932233466` 以 source-bearing checkpoint、coverage/digest、head anchor 和可读取 archive 保住 ledger/replay 一致性。本实现采用共同原则“权威账本完整、模型视图有界、切点只在闭合因果边界”，但本 PR 不新增通用工具结果 archive。
+
+### Interaction 完成后的下一轮
+
+以 `U1 → stop → U2 → stop → U3 → A1` 为例，最终 SessionDB 有四条连续 message，共享一个 `control_turn_id`。下一轮 U4 读取历史时，I1 作为一个逻辑单元展开：模型看到 U1/U2/U3、I1 的 compact summary 与最近工具后缀、以及 A1，然后看到 U4。I1 超出热窗口后，Markdown consolidation 会把其用户 query 和确认事实写入派生记忆，Akasha 可按一个 completed node 召回；SessionDB 的四条权威消息仍保留。
+
+### Proactive
+
+已成功送达的 proactive assistant 没有 user turn，也不生成 Akasha 学习节点；它在 canonical history、memory window、Markdown recent turns 和 consolidation 边界中作为一个独立逻辑单元。用户随后回复 proactive 时，回复 metadata 继续保留引用，新的被动 interaction 仍按正常 U/A 规则学习。本 PR 不把 proactive assistant 伪造成 Akasha 的 U 或 A。
+
+## 5. Channel 和 UI
+
+- Mobile：active 时无论草稿是否为空都只显示中止，草稿保留但发送不可用；中止收束后恢复发送。中止继续调用 `turn.stop`。
+- Telegram、QQ、Web Chat：`/stop` 或现有 stop command 结束 active attempt；终态后的下一条普通消息自动续接未完成 interaction。
+- Programmatic control：`turn/start` 在 active 时返回 busy；只有 `turn/interrupt` 能改变 active attempt。
+
+## 6. 失败语义
+
+- turn item 写入失败：输入 admission 失败，不进入内存 queue。
+- active thread 收到普通 `turn/start`：返回 busy，不写 checkpoint，不 fallback 到新 turn。
+- source 已 seal：旧 attempt 不再接收输入；terminal 后下一次 `turn/start` 创建新 attempt。
+- tool batch 未闭合：不进入 attempt replay，也不能成为 compaction 切点。
+- completed transcript batch 写入失败：turn 不得声称正式提交，现有错误向 owner 暴露。
+- Akasha 失败：completed transcript 保持，sidecar degraded 并从固定输入重建。
+- hard interrupt：沿现有唯一 interrupt owner 结束 attempt，不提交 canonical assistant；下一条 U 由 runtime 根据 durable 前驱续接 interaction。
+- 单个 logical interaction 过大：先压缩旧闭合工具组；如果全部 U anchor 或最近不可拆后缀本身超过 provider 硬边界，明确失败。这是已接受风险，不能通过拆 U、删工具证据或伪造摘要规避。
+
+## 7. 验证
+
+- runtime：`U1/stop/U2/stop/U3/A` 的 interaction identity、attempt 前驱、logical ordinal、stale attempt 和 hard interrupt。
+- reasoner：前驱 U、十个工具调用/结果、abort marker 在当前 U 之前完整可见；未闭合工具不重放。
+- persistence：关闭重开 SQLite，核对 turn items、completed message batch、只追加 write set 和 seq。
+- replay：`max_messages` 或 consolidation index 落在 U2/U3/A 时仍从同一 turn 的 U1 开始投影。
+- compaction：两次中断留下的闭合工具组可以被压缩；摘要输入同时包含 U1/U2/U3，最近组保持原文，最终 persisted cut 不超过聚合后的完整 tool chain。
+- proactive：主动 assistant 独占一个历史单元，不进入 Akasha；相邻被动 interaction 保持独立。
+- channel：中止 attempt 不发送 assistant outbound；后续消息的新 attempt 最终只发送一次 A。
+- Mobile：验证 idle 显示 send，active 空草稿和 active 有草稿都显示 stop，stopping 显示 pending stop；active 时快捷键和 native send 同样被拒绝。
+- Akasha：`U1,U2,U3,A` 在线与离线得到一个相同 turn；legacy pair 不回归。
+- known-bad：邻接配对、seal 后仍接收、第二 inbound 重复发送 final A、工具批次中途注入。
+- known-bad：active `turn/start` 被隐式 steer、按物理 message 数裁掉 U1、consolidation 游标落在 multi-U turn 内、attempt replay 永远不可压缩。
+
+## 8. 实现任务合同
+
+```yaml
+change_type: feature
+semantic_delta: breaking
+capability_owner: mixed
+consumer_scope:
+  - conversation runtime
+  - passive channels and interrupt-only programmatic control
+  - shared Mobile WebUI
+  - SessionDB prompt replay
+  - Akasha online and offline builders
+runtime_patch: required
+runtime_patch_reason: "只有 core 拥有 active turn、provider/tool 安全边界、terminal seal 和 transcript commit；客户端实现会复制并猜测权威状态。"
+authoritative_state_owner: "ConversationRuntime owns admission and seal; SessionStore owns turn checkpoints and transcript; Akasha owns derived projection."
+client_only_alternative: "rejected"
+invariants:
+  - STI-001
+  - STI-003
+  - STI-004
+  - STI-007
+  - STI-009
+  - SES-002
+  - SES-005
+protected_state:
+  - existing message bodies and seq
+  - hard interrupt semantics
+  - external tool effects
+  - formal workspace data
+allowed_paths:
+  - agent/control/**
+  - agent/core/**
+  - agent/lifecycle/**
+  - bootstrap/passive_worker.py
+  - bootstrap/control_execution.py
+  - bus/**
+  - session/**
+  - infra/channels/**
+  - infra/mobile_realtime/**
+  - frontend/**/src/**
+  - plugins/akasha/**
+  - tests/**
+  - tests_scenarios/contracts/**
+  - docker/debug/**
+  - docs/**
+forbidden_paths:
+  - generated frontend bundles
+  - plugin cache
+  - formal Akashic workspace
+allowed_effects:
+  - isolated SQLite fixture writes
+  - isolated frontend build
+  - isolated Akasha rebuild
+forbidden_effects:
+  - update or delete existing messages
+  - publish, deploy or restart formal services
+  - replay indeterminate external effects
+validation:
+  - focused unit and semantic tests
+  - SQLite close/reopen write-set checks
+  - Akasha online/offline equivalence
+  - shared WebUI build
+  - isolated change-impact Gate
+rollback: "Restore /tmp/akasic-codex-turn-input-backup.aSq3Tx and revert code consumers; never delete newly appended messages."
+worktree_writer: "/mnt/data/coding/akasic-agent-worktrees/pi-style-interruption-design"
+handoff_head: ""
+external_revisions:
+  - "codex@2b5bdcf67547860f2e5c5a605009a70026796b2b"
+  - "pi-mono@74caa2649f10ed71b4378ce69f5d9fbfd2466ca5"
+  - "maka-agent@785b0c4f202c0263fb59150ae903195932233466"
+schema_lineages:
+  - "turns.items_json attempt user/tool checkpoints"
+  - "messages.extra control_turn_id/turn_input_ordinal/turn_terminal"
+  - "TurnCommitted persisted_user_message_ids"
+```

--- a/docs/design/query-local-react-compaction.md
+++ b/docs/design/query-local-react-compaction.md
@@ -114,7 +114,7 @@ SessionDB assistant.extra
 next query prompt replay
 ```
 
-`LLMProvider` 负责用 system prompt、消息、tool schema 和多模态块估算完整请求。`DefaultReasoner` 负责决定哪些已经闭合的当前 query 工具组进入摘要。`SessionManager` 只在完整 Turn 提交和后续重放时处理版本化字段。
+`LLMProvider` 负责用 system prompt、消息、tool schema 和多模态块估算完整请求。`DefaultReasoner` 负责决定哪些已经闭合的当前 query 工具组进入摘要；同一 logical interaction 的中断 attempt replay 也属于当前 query，而不是不可压缩的历史前缀。`SessionManager` 只在完整 Turn 提交和后续重放时处理版本化字段。
 
 ## 4. 触发、切点和重复压缩
 
@@ -130,7 +130,7 @@ hard_limit = floor(model.context_window * effective_context_percent)
 
 每次 provider 调用前，优先使用上一响应的准确 input usage 加新增消息估算；没有完整 usage、tool schema 变化或压缩重建前缀时，对完整请求重新估算。达到软水位后，只能选择已经完整闭合的工具组前缀。当前 user query、当前 iteration 新注入提示和最近工具后缀不进入切点。
 
-第一次压缩使用被淘汰的工具组生成摘要。再次压缩使用上一份摘要和新淘汰工具组生成新摘要，并替换旧 compact pair。摘要至少包含：
+第一次压缩使用被淘汰的工具组生成摘要。再次压缩使用上一份摘要和新淘汰工具组生成新摘要，并替换旧 compact pair。若 query 经历中断续接，current-query anchor 必须显式包含该 interaction 的全部有序 U，而不是只取最后一条 U。摘要至少包含：
 
 - Goal
 - Constraints
@@ -170,6 +170,10 @@ hard_limit = floor(model.context_window * effective_context_percent)
 
 Session 重载读取上一 assistant row 的 `react_compaction`，跳过已压缩 `tool_chain` 前缀，投影摘要、后缀和最终回复，再追加新 user query。
 
+### 中断后的下一 Attempt
+
+runtime 从 control predecessor 恢复 U 和已闭合工具组。replay 中每个 assistant tool-call 及其全部 result 是一个闭合批次；interrupt marker、下一条 U 和尚未闭合的尾部留在 pending suffix。达到软水位时，旧 replay 批次与本 attempt 后续产生的批次使用同一个 compactor，最终 `compacted_tool_groups` 相对于聚合后的完整 `tool_chain` 计数。
+
 ## 7. Edge case 和失败语义
 
 - 模型正在流式输出：不压缩，响应结束并形成完整工具批次后再判断。
@@ -182,6 +186,8 @@ Session 重载读取上一 assistant row 的 `react_compaction`，跳过已压�
 - compaction summary 请求不携带业务工具，也不复用主 ReAct cache namespace。
 - 被压缩前缀的 opaque `model_state` 不重放；压缩后的下一次真实响应建立新状态。
 - tool result 在 summary 输入中按字符上限序列化，完整证据仍在 runtime `tool_chain` 和既有有界持久化结果中。
+- attempt replay 与 prior tool chain 的闭合组数量不一致、tool call/result identity 不闭合或 replay 不在最终 prompt 中：内部合同损坏，立即失败，不猜测切点。
+- 一个 interaction 的全部 U anchor 使用有界序列化；极端超长 query 可能无法通过压缩进入 provider 硬窗口。这是接受风险，不能通过只保留最后一条 U 来伪装成功。
 - SessionDB 中字段损坏、版本未知、切点超过 `tool_chain` 长度：在反序列化边界 fail-loud。
 
 ## 8. 验证

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -315,6 +315,8 @@ D 类效果只能由拥有 prepared、committed、failed 和必要补偿语义�
 
 Prompt 历史不得从孤立 assistant 或 tool result 开始。assistant 工具调用和对应结果成对保留；合法 user 边界或明确的 proactive assistant 边界拥有窗口起点。长工具结果只允许在临时模型视图中截短。
 
+同一个 completed logical interaction 可以跨越一个或多个 execution attempt，包含一个或多个有序 user message、此前 attempt 的完整已闭合工具事实和唯一 terminal assistant。中止只关闭 attempt，不关闭 interaction。窗口与重放使用显式 `control_turn_id` 和 input ordinal 识别边界，不得把相邻 user/assistant 角色当作新格式的 turn 归属协议。
+
 已送达的 proactive assistant 消息进入 prompt history 时保留完整正文，不得施加 proactive 专属字符预算或改写成 preview。整体请求超限时，只能由通用 prompt history 退化按完整语义边界缩小窗口。
 
 ### CTX-004 派生上下文不得伪装成用户原话
@@ -341,7 +343,7 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 
 ### SES-001 回合持久化全有或全无
 
-同一批 session metadata、消息和序列分配必须在一个事务中提交。任一步失败时数据库不出现半批消息，内存对象也不得获得并不存在的稳定 ID。
+同一批 session metadata、消息和序列分配必须在一个事务中提交。completed 被动 turn 的批次可以包含多个有序 user message 和唯一 terminal assistant；任一步失败时数据库不出现半批消息，内存对象也不得获得并不存在的稳定 ID。
 
 ### SES-002 消息序列单调且不复用
 
@@ -362,6 +364,14 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 ### SES-006 附件随消息引用保留
 
 消息仍引用的附件属于会话数据，必须保持可读。附件清理只能从完整引用关系出发，先识别真正孤儿，再经过 dry-run、备份和名称明确的删除操作；在引用计数、cascade 和恢复协议落地前不得自动 GC。文件年龄、当前 prompt 是否使用、索引是否命中和代码重构都不能成为删除依据。
+
+### SES-007 普通输入续接未完成 Logical Interaction
+
+同一 session 没有 active execution attempt 时，普通 user input 创建 attempt；最新 logical interaction 尚未产生 terminal assistant 时，新 attempt 必须沿用同一 interaction identity，并看到此前全部有序 user input 和已经闭合的工具调用/结果。active attempt 期间普通 `turn/start` 明确返回 busy，Mobile 普通发送不可用；channel 消息先通过 `/stop` 或等价中止结束 attempt，再由下一条普通输入续接。控制协议不提供 steer/follow-up 输入模式。
+
+### SES-008 Completed Interaction 显式拥有全部输入和唯一最终回复
+
+一个 logical interaction 可以拥有多个 execution attempt 和多个有序 user input。每个 attempt 的输入、工具 started/completed 和中止终态先写入 `turns`；下一 attempt 从这些事实构造 prompt replay，不恢复隐藏思维，也不重放未闭合工具。只有最终 assistant 成功提交时 interaction 才 completed。completed transcript 在一个事务中按 ordinal 追加全部 user message 和唯一 terminal assistant，并携带共同 interaction identity；不得为中止 attempt 生成 Akasha 学习样本或用角色邻接推断归属。
 
 ## 8. 记忆系统
 
@@ -399,7 +409,15 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 
 ### MEM-009 Akasha 使用固定输入确定性重建
 
-`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有完成的 user/assistant turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
+`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有 completed turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
+
+### MEM-010 Akasha 对同 Interaction 多输入建立一个确定性样本
+
+completed logical interaction 含多个 user message 时，Akasha 按显式 interaction identity 和 input ordinal 聚合全部用户输入，并以唯一 terminal assistant 作为输出，只建立一个学习样本。中止 attempt 的 `turns` checkpoint 只服务执行恢复，不直接进入在线学习或离线 rebuild；只有最终 transcript batch 成为 Akasha 权威输入。每条非空 user message 和 assistant 使用各自已持久化 embedding；多输入 dense 使用固定版本的归一化聚合。在线提交和离线 builder 必须共用相同 source IDs、文本连接、向量聚合和 digest 规则。新格式不得按相邻角色配对；旧数据只能走名称明确的 legacy 兼容路径。
+
+### MEM-011 历史投影按不可拆分逻辑单元保留
+
+`memory_window`、Markdown consolidation 的保留尾部、积压阈值、分页切点和 recent turns 必须使用同一个逻辑历史分组。显式 `control_turn_id` 的 `U1..Un+A_final` 是一个单元；已送达 proactive assistant 是一个独立单元。任何窗口或 consolidation 游标不得落入逻辑单元内部。单元展开后允许超过配置的消息条数；配置值表示单元数量，不是 token 硬上限。
 
 ## 9. 运行时、并发和出站
 
@@ -433,9 +451,13 @@ Linux 上无子命令执行 `python main.py` 是正式服务入口，必须先�
 
 同一 `session_key` 同时只能有一个 active turn，channel、control 和 direct/programmatic 入口必须汇入同一个 session lane owner。不同 session 的 turn 可以并发；全局 active turn、请求字节和 runtime object 上限只负责有界准入，不得以跨 session 的整轮互斥实现。Turn 的 messages、文件读取状态、工具 trace、取消信号和 runtime snapshot 绑定属于 task-local 状态；共享 runtime service 只能保留有明确 owner、可并发使用或受短事务保护的状态。
 
+### RUN-008 Active Attempt 只接受中断并原子终结
+
+ConversationRuntime 的 session lane owner 在 active attempt 上拒绝所有普通输入，只接受精确 `turn/interrupt`。Reasoner 最终回复前仍在同一 owner 下封口；中断和完成都必须提交唯一 terminal 状态。下一条普通输入只能在 terminal 后创建新 attempt，并由 durable predecessor 恢复同一未完成 logical interaction；不得存在运行中 drain user input 的隐式或显式入口。
+
 ### OUT-001 被动按 Turn 提交，主动按送达提交
 
-被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，user 与 assistant 消息共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
+被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，本 turn 的全部有序 user message 与唯一 terminal assistant 共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
 
 同一条主动消息的实时事件与发送成功后的历史投影必须携带同一个稳定投递身份。客户端优先用该身份精确合并；内容与时间匹配只能兼容缺少稳定身份的旧消息。部分送达和结果不明必须有独立状态，不能冒充成功或完全失败。
 
@@ -452,6 +474,10 @@ Linux 上无子命令执行 `python main.py` 是正式服务入口，必须先�
 ### OUT-004 `message_push` 不取得目标 session 的执行所有权
 
 `message_push` 是调用 turn 发起的外部投递，不是目标 session 的 inbound turn。它不得等待目标 session lane；实际 adapter send 仍通过 ChatLane 的短提交 owner 串行。普通 scheduler/proactive 的 non-passive 投递继续等待同 chat 的被动回复优先完成；被动或程序化验证 turn 发起的 push 可以走 passive-send 路径，但不能与另一实际 send 重叠。push 正文不注入正在运行的父 Prompt，也不追加到目标 session history；调用参数和真实 delivery receipt 保存在调用 session 的工具 trace。pointer、异常或取消都不得伪装成已经发生的外部投递被回滚。
+
+### OUT-005 硬终止只关闭 Execution Attempt
+
+Mobile 中止按钮和 channel `/stop` 只调用带精确 attempt identity 的 hard interrupt，把 active attempt 终结为 interrupted；它们不创建 user message，也不自动启动下一 attempt。中止后到达的下一条普通输入按 SES-007 续接尚未完成的 logical interaction。Mobile active 时无论草稿是否为空都只显示中止，草稿保留但发送不可用；中止收束后才恢复发送。客户端不得让用户选择 steer、follow-up 或 next-prompt 模式。
 
 ## 10. 插件 generation 与 snapshot
 

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -1198,7 +1198,11 @@ class MobileRealtimeChannel:
             items.append(
                 {
                     "session_id": session_id,
-                    "title": first_content.splitlines()[0][:32] or "新对话",
+                    "title": (
+                        first_content.splitlines()[0][:32]
+                        if first_content
+                        else "新对话"
+                    ),
                     "updated_at": str(session["updated_at"]),
                     "message_count": total,
                 }

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1259,6 +1259,8 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     web_session = manager.get_or_create(f"web:{uuid4()}")
     web_session.add_message("user", "不要同步 Web 会话")
     manager.save(web_session)
+    empty_session_id = f"mobile:{uuid4()}"
+    manager.get_or_create(empty_session_id)
 
     listed = await channel.handle_command(
         device_id=device_id,
@@ -1278,14 +1280,15 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     )
 
     assert listed.type == "session.list.ok"
-    assert listed.payload["total"] == 1
+    assert listed.payload["total"] == 2
     session_event = runtime.events[-2]
     assert session_event["event_type"] == "session.list"
     session_payload = cast(dict[str, object], session_event["payload"])
     session_items = cast(list[dict[str, object]], session_payload["items"])
-    assert len(session_items) == 1
-    assert session_items[0]["session_id"] == session_id
-    assert session_items[0]["title"] == "恢复这段对话"
+    assert len(session_items) == 2
+    session_items_by_id = {str(item["session_id"]): item for item in session_items}
+    assert session_items_by_id[session_id]["title"] == "恢复这段对话"
+    assert session_items_by_id[empty_session_id]["title"] == "新对话"
     assert history.type == "history.get.ok"
     history_event = runtime.events[-1]
     history_payload = cast(dict[str, object], history_event["payload"])


### PR DESCRIPTION
## 问题与结果

- 解决的问题：移动端列出尚无消息的会话时，对空字符串调用 splitlines()[0] 会抛出 IndexError。
- 用户可见结果：空会话稳定显示“新对话”。
- 本 PR 不处理：中断续接语义；该功能从下一张 stacked PR 开始 review。

## Change intent

- change_type：fix
- semantic_delta：compatible
- capability_owner：mobile
- consumer_scope：移动端 session list
- runtime_patch：none
- runtime_patch_reason：不适用
- authoritative_state_owner：sessions.db 仍由 SessionStore 拥有；这里只读
- client_only_alternative：客户端无法修复服务端 list 响应失败
- 关联不变量：空会话合法；历史正文不因展示而改变
- protected_state：sessions.db/messages、正式 workspace
- 允许的副作用：仅修改源码、测试、分支和 PR
- 禁止的副作用：不得写正式 workspace 或删除消息

## 改动范围

- 主要文件：infra/mobile_realtime/channel.py、tests/mobile_realtime/test_channel.py
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：HEAD d1941201f55cfa83f0a686eec46760b00f0917e1
- 回滚方式：revert 本 PR commit

## 验证

- [x] 相关 targeted tests 已通过：46 passed
- [ ] Python 类型检查或前端 typecheck/lint 已通过；本 PR 不涉及类型模型
- [ ] python docker/debug/gate.py run --base origin/main 已运行；交由 PR CI 执行
- sourceDigest：等待 CI
- planDigest：等待 CI
- 真实设备证据：不适用；这是服务端空列表边界
- 未运行项与原因：未重复运行全量；栈顶累计源码已通过 2835 passed、2 skipped

## 工作手册

- [x] 已核对 projectneed.md、相关决策和 NOW.md
- [x] 本次没有长期语义变化
- [x] 已按 MOB-001 核对 mobile owner
- [x] 当前没有对应 NOW 事项