### PR TITLE
[control 2/3] 在新 attempt 重放已完成工作

### DIFF
--- a/agent/context.py
+++ b/agent/context.py
@@ -159,6 +159,21 @@ class MessageEnvelopeBuilder:
             return text
         return images + [{"type": "text", "text": text}]
 
+    def build_user_content(
+        self,
+        text: str,
+        media: list[str] | None,
+        *,
+        message_timestamp: datetime | None = None,
+    ) -> str | list[dict[str, Any]]:
+        """构造可追加到同一模型上下文的用户消息内容。"""
+
+        return self._build_user_content(
+            text,
+            media,
+            message_timestamp=message_timestamp,
+        )
+
     def _build_text_with_media_refs(self, text: str, media: list[str]) -> str:
         refs: list[str] = []
         local_image_paths: list[str] = []
@@ -258,6 +273,7 @@ class ContextBuilder:
                 SkillsCatalogPromptBlock(render_fn=build_skills_catalog_prompt),
             ]
         )
+
         self._envelope_builder = MessageEnvelopeBuilder(
             policies={TelegramChannelPolicy.channel: TelegramChannelPolicy()},
             multimodal=multimodal,
@@ -270,6 +286,21 @@ class ContextBuilder:
         self._last_assembled_contexts: ContextVar[
             dict[str, dict[str, str]] | None
         ] = ContextVar("akashic_context_assembled_contexts", default=None)
+
+    def build_user_message_content(
+        self,
+        text: str,
+        media: list[str] | None,
+        *,
+        message_timestamp: datetime | None = None,
+    ) -> str | list[dict[str, Any]]:
+        """复用首条消息的媒体与时间 envelope 构造同 turn 输入。"""
+
+        return self._envelope_builder.build_user_content(
+            text,
+            media,
+            message_timestamp=message_timestamp,
+        )
 
     def set_media_capabilities(
         self,

--- a/agent/control/ports.py
+++ b/agent/control/ports.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Protocol
 
 from agent.control.models import TurnItem, TurnRequest, TurnUsage
 
@@ -16,3 +18,23 @@ class ControlExecutionResult:
 
 
 TurnExecutor = Callable[[TurnRequest], Awaitable[str | ControlExecutionResult]]
+
+
+@dataclass(frozen=True, slots=True)
+class TurnUserInput:
+    """保存同一 turn 内一条已经准入的用户输入。"""
+
+    item_id: str
+    ordinal: int
+    content: str
+    media: tuple[str, ...]
+    metadata: dict[str, object]
+    timestamp: datetime
+
+
+class TurnInputSource(Protocol):
+    """向 reasoner 提供已持久化的 interaction 输入并原子封口。"""
+
+    async def seal(self) -> None: ...
+
+    def consumed_inputs(self) -> tuple[TurnUserInput, ...]: ...

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -443,8 +443,22 @@ class ConversationRuntime:
             for item in attempt.items:
                 if item.kind is TurnItemKind.USER_MESSAGE:
                     content = item.data.get("content")
+                    media = item.data.get("media", [])
                     if not isinstance(content, str):
                         raise ValueError(f"turn user content 必须是字符串: {item.id}")
+                    if not isinstance(media, list) or not all(
+                        isinstance(value, str) for value in media
+                    ):
+                        raise ValueError(f"turn user media 必须是字符串数组: {item.id}")
+                    if media:
+                        content = "\n".join(
+                            [
+                                content,
+                                "",
+                                "[附加媒体]",
+                                *(f"- {value}" for value in media),
+                            ]
+                        )
                     messages.append({"role": "user", "content": content})
                 elif item.kind is TurnItemKind.TOOL_CALL:
                     group = cls._tool_group_from_item(item)

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -201,6 +201,12 @@ class ConversationRuntime:
         self._accepting_turns = True
         self._restart_owner_turn_id: str | None = None
         self._restart_coordinator = restart_coordinator
+        recovered = self._store.recover_in_progress_turns()
+        if recovered:
+            logger.warning(
+                "Recovered %d stale in-progress control turns as interrupted",
+                len(recovered),
+            )
 
     async def start_turn(self, request: TurnRequest) -> TurnHandle:
         """拒绝 active thread，否则恢复未完成 interaction 并创建新 attempt。"""

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -7,7 +7,7 @@ import time
 from collections import OrderedDict
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from agent.control.errors import (
     ControlAdmissionError,
@@ -28,7 +28,12 @@ from agent.control.models import (
     TurnResult,
     TurnStatus,
 )
-from agent.control.ports import ControlExecutionResult, TurnExecutor
+from agent.control.ports import (
+    ControlExecutionResult,
+    TurnExecutor,
+    TurnInputSource,
+    TurnUserInput,
+)
 from agent.restart import RestartCoordinator
 from session.store import SessionStore
 from agent.looping.interrupt import InterruptResult
@@ -44,24 +49,59 @@ DEFAULT_REPLAY_EVENTS_PER_TURN = 256
 DEFAULT_REPLAY_BYTES_PER_TURN = 4 * 1024 * 1024
 DEFAULT_REPLAY_BYTES_GLOBAL = 32 * 1024 * 1024
 DEFAULT_TERMINAL_REPLAY_TTL_SECONDS = 5 * 60
+_INTERACTION_ID = "interactionId"
+_ATTEMPT_ORDINAL = "attemptOrdinal"
+_CONTINUED_FROM_TURN_ID = "continuedFromTurnId"
+_PRIOR_INPUT_COUNT = "priorInputCount"
 
 
 def _encoded_turn_bytes(request: TurnRequest) -> int:
     """计算控制面 turn 请求的 UTF-8 编码字节数。"""
 
-    return len(json.dumps(request.to_dict(), ensure_ascii=False, sort_keys=True, default=str).encode())
+    return len(
+        json.dumps(
+            request.to_dict(), ensure_ascii=False, sort_keys=True, default=str
+        ).encode()
+    )
 
 
 def _encoded_event_bytes(event: TurnEvent) -> int:
     """计算 replay event 的 UTF-8 编码字节数。"""
 
-    return len(json.dumps(event.to_notification(), ensure_ascii=False, sort_keys=True, default=str).encode())
+    return len(
+        json.dumps(
+            event.to_notification(), ensure_ascii=False, sort_keys=True, default=str
+        ).encode()
+    )
+
+
+def _encoded_json_bytes(value: object) -> int:
+    return len(json.dumps(value, ensure_ascii=False, sort_keys=True).encode())
+
+
+def _merge_turn_items(base: list[TurnItem], updates: list[TurnItem]) -> list[TurnItem]:
+    """按 item identity 保留顺序并应用最新 checkpoint。"""
+
+    merged = list(base)
+    positions = {item.id: index for index, item in enumerate(merged)}
+    if len(positions) != len(merged):
+        raise RuntimeError("turn items 包含重复 identity")
+    for item in updates:
+        index = positions.get(item.id)
+        if index is None:
+            positions[item.id] = len(merged)
+            merged.append(item)
+        else:
+            merged[index] = item
+    return merged
 
 
 class TurnHandle:
     """持有一个 turn 的结果、事件流和精确中断入口。"""
 
-    def __init__(self, runtime: ConversationRuntime, thread_id: str, turn_id: str) -> None:
+    def __init__(
+        self, runtime: ConversationRuntime, thread_id: str, turn_id: str
+    ) -> None:
         self._runtime = runtime
         self.thread_id = thread_id
         self.id = turn_id
@@ -77,6 +117,20 @@ class TurnHandle:
 
     async def interrupt(self) -> TurnRecord:
         return await self._runtime.interrupt_turn(self.thread_id, self.id)
+
+
+class _RuntimeTurnInputSource(TurnInputSource):
+    """把 reasoner 的 final seal 交回 runtime 唯一 owner。"""
+
+    def __init__(self, runtime: ConversationRuntime, turn_id: str) -> None:
+        self._runtime = runtime
+        self._turn_id = turn_id
+
+    async def seal(self) -> None:
+        await self._runtime._seal_turn_input(self._turn_id)
+
+    def consumed_inputs(self) -> tuple[TurnUserInput, ...]:
+        return self._runtime._consumed_turn_inputs(self._turn_id)
 
 
 class ConversationRuntime:
@@ -126,13 +180,18 @@ class ConversationRuntime:
         self._replay_bytes_global = replay_bytes_global
         self._terminal_replay_ttl_seconds = terminal_replay_ttl_seconds
         self._active_by_thread: dict[str, str] = {}
+        self._consumed_inputs: dict[str, list[TurnUserInput]] = {}
+        self._sealed_turn_inputs: set[str] = set()
+        self._turn_input_sources: dict[str, _RuntimeTurnInputSource] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._results: dict[str, asyncio.Future[TurnResult]] = {}
         self._history: dict[str, list[TurnEvent]] = {}
         self._history_sequences: dict[str, list[int]] = {}
         self._next_event_sequence: dict[str, int] = {}
         self._history_truncated: set[str] = set()
-        self._replay_order: OrderedDict[tuple[str, int], tuple[TurnEvent, int]] = OrderedDict()
+        self._replay_order: OrderedDict[tuple[str, int], tuple[TurnEvent, int]] = (
+            OrderedDict()
+        )
         self._history_byte_totals: dict[str, int] = {}
         self._replay_bytes = 0
         self._terminal_replay_expiry: dict[str, float] = {}
@@ -148,33 +207,55 @@ class ConversationRuntime:
         self._restart_coordinator = restart_coordinator
 
     async def start_turn(self, request: TurnRequest) -> TurnHandle:
-        """持久化 queued turn 并立即返回可操作句柄。"""
+        """拒绝 active thread，否则恢复未完成 interaction 并创建新 attempt。"""
 
         # 1. 在唯一 owner 处检查 thread 与控制面容量；拒绝不写 SessionStore。
-        request_bytes = _encoded_turn_bytes(request)
         async with self._control_admission_lock:
             self._raise_replay_reaper_failure()
             if self._closed or not self._accepting_turns:
                 raise RuntimeClosedError("conversation runtime is shutting down")
             if request.thread_id in self._active_by_thread:
                 raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
+            turn_id = new_turn_id()
+            previous_attempts = self._open_interaction_attempts(request.thread_id)
+            prior_inputs = self._attempt_user_inputs(previous_attempts)
+            attempt_replay = self._attempt_replay_messages(previous_attempts)
+            prior_tool_chain = self._attempt_tool_chain(previous_attempts)
+            interaction_id = (
+                self._interaction_id(previous_attempts[-1])
+                if previous_attempts
+                else turn_id
+            )
+            metadata = {
+                **request.metadata,
+                _INTERACTION_ID: interaction_id,
+                _ATTEMPT_ORDINAL: len(previous_attempts),
+                _PRIOR_INPUT_COUNT: len(prior_inputs),
+            }
+            if previous_attempts:
+                metadata[_CONTINUED_FROM_TURN_ID] = previous_attempts[-1].id
+            effective_request = TurnRequest(request.thread_id, request.input, metadata)
+            request_bytes = (
+                _encoded_turn_bytes(effective_request)
+                + _encoded_json_bytes(attempt_replay)
+                + _encoded_json_bytes(prior_tool_chain)
+            )
             admission_token = self._reserve_admission(request_bytes)
 
             # 2. 先持久化 queued handle；失败时只回滚本轮 admission token。
-            turn_id = new_turn_id()
-            user_item = TurnItem(
-                TurnItemKind.USER_MESSAGE,
-                new_item_id(),
-                {"content": request.input},
-            )
             try:
+                initial_input = self._build_turn_user_input(
+                    effective_request,
+                    ordinal=len(prior_inputs),
+                )
+                user_item = self._user_input_item(initial_input)
                 record = self._store.create_turn(
                     TurnRecord(
                         id=turn_id,
                         thread_id=request.thread_id,
                         status=TurnStatus.QUEUED,
-                        input=request.input,
-                        metadata=dict(request.metadata),
+                        input=effective_request.input,
+                        metadata=dict(effective_request.metadata),
                         items=[user_item],
                         usage=None,
                         error=None,
@@ -182,11 +263,14 @@ class ConversationRuntime:
                     )
                 )
             except BaseException:
-                self._release_admission(admission_token, request_bytes)
+                self._release_admission(admission_token)
                 raise
             self._commit_admission_token(admission_token, turn_id, request_bytes)
             self._active_by_thread[request.thread_id] = turn_id
             self._thread_idle[request.thread_id] = asyncio.Event()
+            self._consumed_inputs[turn_id] = [*prior_inputs, initial_input]
+            source = _RuntimeTurnInputSource(self, turn_id)
+            self._turn_input_sources[turn_id] = source
             loop = asyncio.get_running_loop()
             self._results[turn_id] = loop.create_future()
             self._history[turn_id] = []
@@ -194,26 +278,288 @@ class ConversationRuntime:
             self._history_byte_totals[turn_id] = 0
             self._next_event_sequence[turn_id] = 0
             self._subscribers[turn_id] = set()
-        self._publish(TurnEvent.create("turn/queued", request.thread_id, turn_id, turn=record.to_dict()))
+            handle = TurnHandle(self, request.thread_id, turn_id)
         self._publish(
             TurnEvent.create(
-                "item/started",
-                request.thread_id,
-                turn_id,
-                item=user_item.to_dict(),
+                "turn/queued", request.thread_id, turn_id, turn=record.to_dict()
             )
         )
-        self._publish(
-            TurnEvent.create(
-                "item/completed",
-                request.thread_id,
+        self._publish_user_item(request.thread_id, turn_id, user_item)
+        task = asyncio.create_task(
+            self._run(
+                effective_request,
                 turn_id,
-                item=user_item.to_dict(),
-            )
+                attempt_replay=attempt_replay,
+                prior_tool_chain=prior_tool_chain,
+            ),
+            name=f"conversation-turn:{turn_id}",
         )
-        task = asyncio.create_task(self._run(request, turn_id), name=f"conversation-turn:{turn_id}")
         self._tasks[turn_id] = task
-        return TurnHandle(self, request.thread_id, turn_id)
+        return handle
+
+    def _open_interaction_attempts(self, thread_id: str) -> list[TurnRecord]:
+        """从最新未完成 attempt 沿显式前驱恢复 logical interaction。"""
+
+        # 1. completed 是唯一关闭 logical interaction 的终态。
+        latest_page = self._store.list_turns(thread_id, limit=1)
+        if not latest_page or latest_page[0].status is TurnStatus.COMPLETED:
+            return []
+
+        # 2. 新数据沿 continuedFromTurnId 精确回溯；旧数据作为单 attempt 兼容。
+        attempts = [latest_page[0]]
+        seen = {latest_page[0].id}
+        while previous_id := attempts[-1].metadata.get(_CONTINUED_FROM_TURN_ID):
+            if not isinstance(previous_id, str) or not previous_id:
+                raise ValueError("continuedFromTurnId 必须是非空字符串")
+            if previous_id in seen:
+                raise RuntimeError(f"control attempt 前驱成环: {previous_id}")
+            previous = self._store.read_turn(previous_id)
+            if previous is None or previous.thread_id != thread_id:
+                raise RuntimeError(
+                    f"control attempt 前驱不存在或 thread 漂移: {previous_id}"
+                )
+            if previous.status is TurnStatus.COMPLETED:
+                raise RuntimeError(
+                    f"completed turn 不得成为未完成 interaction 前驱: {previous_id}"
+                )
+            attempts.append(previous)
+            seen.add(previous_id)
+        attempts.reverse()
+        interaction_id = self._interaction_id(attempts[-1])
+        if any(self._interaction_id(item) != interaction_id for item in attempts):
+            raise RuntimeError(
+                f"control attempt interaction identity 漂移: {interaction_id}"
+            )
+        return attempts
+
+    @staticmethod
+    def _interaction_id(record: TurnRecord) -> str:
+        raw = record.metadata.get(_INTERACTION_ID, record.id)
+        if not isinstance(raw, str) or not raw:
+            raise ValueError("interactionId 必须是非空字符串")
+        return raw
+
+    @staticmethod
+    def _attempt_user_inputs(attempts: list[TurnRecord]) -> list[TurnUserInput]:
+        """按 logical ordinal 恢复此前 attempt 的所有用户输入。"""
+
+        inputs: list[TurnUserInput] = []
+        for attempt in attempts:
+            for item in attempt.items:
+                if item.kind is not TurnItemKind.USER_MESSAGE:
+                    continue
+                data = item.data
+                ordinal = data.get("ordinal")
+                content = data.get("content")
+                media = data.get("media", [])
+                metadata = data.get("metadata", {})
+                timestamp = data.get("timestamp")
+                if (
+                    not isinstance(ordinal, int)
+                    or isinstance(ordinal, bool)
+                    or ordinal != len(inputs)
+                ):
+                    raise ValueError(
+                        f"logical interaction user ordinal 不连续: {attempt.id}/{ordinal}"
+                    )
+                if not isinstance(content, str):
+                    raise ValueError(f"turn user content 必须是字符串: {item.id}")
+                if not isinstance(media, list) or not all(
+                    isinstance(value, str) for value in media
+                ):
+                    raise ValueError(f"turn user media 必须是字符串数组: {item.id}")
+                if not isinstance(metadata, dict) or not all(
+                    isinstance(key, str) for key in metadata
+                ):
+                    raise ValueError(
+                        f"turn user metadata 必须是字符串键对象: {item.id}"
+                    )
+                if not isinstance(timestamp, str):
+                    raise ValueError(f"turn user timestamp 必须是字符串: {item.id}")
+                parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    raise ValueError(f"turn user timestamp 必须包含时区: {item.id}")
+                inputs.append(
+                    TurnUserInput(
+                        item_id=item.id,
+                        ordinal=ordinal,
+                        content=content,
+                        media=tuple(media),
+                        metadata=dict(cast(dict[str, object], metadata)),
+                        timestamp=parsed.astimezone(UTC),
+                    )
+                )
+        return inputs
+
+    @staticmethod
+    def _tool_group_from_item(item: TurnItem) -> dict[str, Any] | None:
+        """把一个已闭合 tool item 转换为标准 replay group。"""
+
+        if item.kind is not TurnItemKind.TOOL_CALL:
+            return None
+        data = item.data
+        status = data.get("status")
+        result = data.get("resultPreview")
+        if status in {"in_progress", "interrupted", "cancelled"}:
+            return None
+        call_id = data.get("callId")
+        name = data.get("name")
+        arguments = data.get("arguments", {})
+        if not isinstance(call_id, str) or not call_id:
+            raise ValueError(f"completed tool callId 无效: {item.id}")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"completed tool name 无效: {item.id}")
+        if not isinstance(arguments, dict):
+            raise ValueError(f"completed tool arguments 无效: {item.id}")
+        if not isinstance(result, str):
+            raise ValueError(f"completed tool resultPreview 无效: {item.id}")
+        return {
+            "text": "",
+            "calls": [
+                {
+                    "call_id": call_id,
+                    "name": name,
+                    "status": status,
+                    "arguments": dict(arguments),
+                    "final_arguments": dict(arguments),
+                    "result": result,
+                }
+            ],
+        }
+
+    @staticmethod
+    def _attempt_tool_chain(attempts: list[TurnRecord]) -> list[dict[str, Any]]:
+        """把完成的工具 item 投影为正常 session replay 使用的 tool_chain。"""
+
+        chain: list[dict[str, Any]] = []
+        for attempt in attempts:
+            for item in attempt.items:
+                group = ConversationRuntime._tool_group_from_item(item)
+                if group is not None:
+                    chain.append(group)
+        return chain
+
+    @classmethod
+    def _attempt_replay_messages(
+        cls,
+        attempts: list[TurnRecord],
+    ) -> list[dict[str, Any]]:
+        """构造仅供下一 attempt 使用的模型历史，不写回 canonical messages。"""
+
+        messages: list[dict[str, Any]] = []
+        for attempt in attempts:
+            for item in attempt.items:
+                if item.kind is TurnItemKind.USER_MESSAGE:
+                    content = item.data.get("content")
+                    if not isinstance(content, str):
+                        raise ValueError(f"turn user content 必须是字符串: {item.id}")
+                    messages.append({"role": "user", "content": content})
+                elif item.kind is TurnItemKind.TOOL_CALL:
+                    group = cls._tool_group_from_item(item)
+                    if group is None:
+                        continue
+                    call = group["calls"][0]
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": group["text"],
+                            "tool_calls": [
+                                {
+                                    "id": call["call_id"],
+                                    "type": "function",
+                                    "function": {
+                                        "name": call["name"],
+                                        "arguments": json.dumps(
+                                            call["arguments"], ensure_ascii=False
+                                        ),
+                                    },
+                                }
+                            ],
+                        }
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call["call_id"],
+                            "content": call["result"],
+                        }
+                    )
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "[execution attempt interrupted]",
+                }
+            )
+        return messages
+
+    def _build_turn_user_input(
+        self,
+        request: TurnRequest,
+        *,
+        ordinal: int,
+    ) -> TurnUserInput:
+        raw_timestamp = request.metadata.get("inputTimestamp")
+        if isinstance(raw_timestamp, str):
+            timestamp = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+            if timestamp.tzinfo is None:
+                raise ValueError("control inputTimestamp 必须包含时区")
+            timestamp = timestamp.astimezone(UTC)
+        else:
+            timestamp = datetime.now(UTC)
+        media = request.metadata.get("media", [])
+        if not isinstance(media, list) or not all(
+            isinstance(item, str) for item in media
+        ):
+            raise ValueError("control metadata media 必须是字符串数组")
+        inbound_metadata = request.metadata.get("inboundMetadata", {})
+        if not isinstance(inbound_metadata, dict) or not all(
+            isinstance(key, str) for key in inbound_metadata
+        ):
+            raise ValueError("control inboundMetadata 必须是字符串键对象")
+        return TurnUserInput(
+            item_id=new_item_id(),
+            ordinal=ordinal,
+            content=request.input,
+            media=tuple(media),
+            metadata=dict(cast(dict[str, object], inbound_metadata)),
+            timestamp=timestamp,
+        )
+
+    @staticmethod
+    def _user_input_item(user_input: TurnUserInput) -> TurnItem:
+        return TurnItem(
+            TurnItemKind.USER_MESSAGE,
+            user_input.item_id,
+            {
+                "content": user_input.content,
+                "ordinal": user_input.ordinal,
+                "media": list(user_input.media),
+                "metadata": dict(user_input.metadata),
+                "timestamp": user_input.timestamp.isoformat(),
+            },
+        )
+
+    def _publish_user_item(self, thread_id: str, turn_id: str, item: TurnItem) -> None:
+        self._publish(
+            TurnEvent.create("item/started", thread_id, turn_id, item=item.to_dict())
+        )
+        self._publish(
+            TurnEvent.create("item/completed", thread_id, turn_id, item=item.to_dict())
+        )
+
+    async def _seal_turn_input(self, turn_id: str) -> None:
+        """在 admission lock 下原子封口，active attempt 不存在输入队列。"""
+
+        async with self._control_admission_lock:
+            if turn_id not in self._consumed_inputs:
+                raise RuntimeError(f"turn input source 已释放: {turn_id}")
+            self._sealed_turn_inputs.add(turn_id)
+
+    def _consumed_turn_inputs(self, turn_id: str) -> tuple[TurnUserInput, ...]:
+        consumed = self._consumed_inputs.get(turn_id)
+        if consumed is None:
+            raise RuntimeError(f"turn input source 已释放: {turn_id}")
+        return tuple(consumed)
 
     def _reserve_admission(self, request_bytes: int) -> str:
         """在控制准入锁内保留一个 queued/running turn 的容量 token。"""
@@ -237,23 +583,30 @@ class ConversationRuntime:
         self._live_runtime_objects += 1
         return token
 
-    def _commit_admission_token(self, token: str, turn_id: str, request_bytes: int) -> None:
+    def _commit_admission_token(
+        self, token: str, turn_id: str, request_bytes: int
+    ) -> None:
         if token not in self._active_turn_bytes:
             raise RuntimeError(f"control admission token missing for turn: {turn_id}")
         if self._active_turn_bytes.pop(token) != request_bytes:
             raise RuntimeError(f"control admission token bytes mismatch: {turn_id}")
         self._active_turn_bytes[turn_id] = request_bytes
 
-    def _release_admission(self, turn_id: str, request_bytes: int) -> None:
+    def _release_admission(self, turn_id: str) -> None:
         stored = self._active_turn_bytes.pop(turn_id, None)
         if stored is None:
             return
-        if stored != request_bytes:
-            raise RuntimeError(f"control admission bytes mismatch: {turn_id}")
         self._active_admission_bytes -= stored
         self._live_runtime_objects -= 1
 
-    async def _run(self, request: TurnRequest, turn_id: str) -> None:
+    async def _run(
+        self,
+        request: TurnRequest,
+        turn_id: str,
+        *,
+        attempt_replay: list[dict[str, Any]],
+        prior_tool_chain: list[dict[str, Any]],
+    ) -> None:
         """执行已按 thread 和容量准入的 turn，并保证只写一个终态。"""
 
         terminal: TurnRecord | None = None
@@ -291,13 +644,23 @@ class ConversationRuntime:
                 status=TurnStatus.IN_PROGRESS,
                 thread_id=request.thread_id,
             )
-            self._publish(TurnEvent.create("turn/started", request.thread_id, turn_id, turn=record.to_dict()))
+            self._publish(
+                TurnEvent.create(
+                    "turn/started", request.thread_id, turn_id, turn=record.to_dict()
+                )
+            )
 
             # 2. 核心执行不依赖 transport；成功结果进入正式 assistant item。
             execution_request = TurnRequest(
                 request.thread_id,
                 request.input,
-                {**request.metadata, "turnId": turn_id},
+                {
+                    **request.metadata,
+                    "turnId": turn_id,
+                    "_controlTurnInputSource": self._turn_input_sources[turn_id],
+                    "_controlAttemptReplay": attempt_replay,
+                    "_controlPriorToolChain": prior_tool_chain,
+                },
             )
             live_item_ids: set[str] = set()
 
@@ -308,11 +671,21 @@ class ConversationRuntime:
                         raise ValueError(f"item 重复 started: {item.id}")
                     observed_items[item.id] = item
                     open_item_ids[item.id] = None
+                    self._store.append_active_turn_item(
+                        turn_id,
+                        thread_id=request.thread_id,
+                        item=item,
+                    )
                 elif method == "item/completed":
                     if item.id not in open_item_ids:
                         raise ValueError(f"item 未 started 即 completed: {item.id}")
                     observed_items[item.id] = item
                     open_item_ids.pop(item.id)
+                    self._store.replace_active_turn_item(
+                        turn_id,
+                        thread_id=request.thread_id,
+                        item=item,
+                    )
                 else:
                     raise ValueError(f"未知 control item event: {method}")
                 self._publish(
@@ -326,6 +699,7 @@ class ConversationRuntime:
 
             execution_request.metadata["_controlItemEvent"] = publish_item
             execution = await self._executor(execution_request)
+            await self._turn_input_sources[turn_id].seal()
             if open_item_ids:
                 raise RuntimeError(
                     f"executor 返回时仍有未闭合 item: {sorted(open_item_ids)}"
@@ -386,7 +760,13 @@ class ConversationRuntime:
                     item=assistant_item.to_dict(),
                 )
             )
-            items = [*record.items, *execution.items, assistant_item]
+            current = self._store.read_turn(turn_id)
+            if current is None:
+                raise TurnNotFoundError(f"turn 不存在: {turn_id}")
+            items = _merge_turn_items(
+                current.items,
+                [*execution.items, assistant_item],
+            )
             terminal = self._store.transition_turn(
                 turn_id,
                 expected_status=TurnStatus.IN_PROGRESS,
@@ -407,7 +787,10 @@ class ConversationRuntime:
                     and turn_id in self._interrupt_requested
                     else TurnStatus.CANCELLED
                 )
-                items = [*current.items, *close_observed_items(status)]
+                items = _merge_turn_items(
+                    current.items,
+                    close_observed_items(status),
+                )
                 terminal = self._store.transition_turn(
                     turn_id,
                     expected_status=current.status,
@@ -416,13 +799,15 @@ class ConversationRuntime:
                     items=items,
                 )
         except Exception as exc:
-            logger.exception("conversation turn failed thread=%s turn=%s", request.thread_id, turn_id)
+            logger.exception(
+                "conversation turn failed thread=%s turn=%s", request.thread_id, turn_id
+            )
             current = self._store.read_turn(turn_id)
             if current is not None and current.status is TurnStatus.IN_PROGRESS:
-                items = [
-                    *current.items,
-                    *close_observed_items(TurnStatus.FAILED),
-                ]
+                items = _merge_turn_items(
+                    current.items,
+                    close_observed_items(TurnStatus.FAILED),
+                )
                 terminal = self._store.transition_turn(
                     turn_id,
                     expected_status=current.status,
@@ -450,7 +835,12 @@ class ConversationRuntime:
                         turn_id,
                         terminal.status.value,
                     )
-                event = TurnEvent.create("turn/completed", request.thread_id, turn_id, turn=terminal.to_dict())
+                event = TurnEvent.create(
+                    "turn/completed",
+                    request.thread_id,
+                    turn_id,
+                    turn=terminal.to_dict(),
+                )
                 self._publish(event)
                 if not future.done():
                     future.set_result(TurnResult.from_record(terminal))
@@ -466,7 +856,10 @@ class ConversationRuntime:
                 idle.set()
             _ = self._tasks.pop(turn_id, None)
             self._interrupt_requested.discard(turn_id)
-            self._release_admission(turn_id, _encoded_turn_bytes(request))
+            self._consumed_inputs.pop(turn_id, None)
+            self._sealed_turn_inputs.discard(turn_id)
+            self._turn_input_sources.pop(turn_id, None)
+            self._release_admission(turn_id)
 
     def _publish(self, event: TurnEvent) -> None:
         self._raise_replay_reaper_failure()
@@ -489,7 +882,9 @@ class ConversationRuntime:
             except asyncio.QueueFull:
                 while not queue.empty():
                     _ = queue.get_nowait()
-                queue.put_nowait(SlowConsumerError(f"turn event consumer too slow: {event.turn_id}"))
+                queue.put_nowait(
+                    SlowConsumerError(f"turn event consumer too slow: {event.turn_id}")
+                )
                 self._subscribers[event.turn_id].discard(queue)
 
     def _trim_turn_replay(self, turn_id: str) -> None:
@@ -507,7 +902,9 @@ class ConversationRuntime:
 
     def _trim_global_replay(self) -> None:
         while self._replay_bytes > self._replay_bytes_global and self._replay_order:
-            (turn_id, sequence), (event, event_bytes) = self._replay_order.popitem(last=False)
+            (turn_id, sequence), (event, event_bytes) = self._replay_order.popitem(
+                last=False
+            )
             self._remove_replay_event(
                 turn_id, sequence, event, event_bytes=event_bytes, global_removed=True
             )
@@ -576,7 +973,12 @@ class ConversationRuntime:
                 raise RuntimeError(f"control replay index corrupted: {turn_id}")
             size = entry[1]
         turn_total = self._history_byte_totals.get(turn_id)
-        if turn_total is None or size < 0 or turn_total < size or self._replay_bytes < size:
+        if (
+            turn_total is None
+            or size < 0
+            or turn_total < size
+            or self._replay_bytes < size
+        ):
             raise RuntimeError(f"control replay index corrupted: {turn_id}")
 
         history.pop(target_index)
@@ -620,7 +1022,9 @@ class ConversationRuntime:
             except asyncio.QueueFull:
                 while not queue.empty():
                     _ = queue.get_nowait()
-                queue.put_nowait(SlowConsumerError(f"turn event consumer too slow: {turn_id}"))
+                queue.put_nowait(
+                    SlowConsumerError(f"turn event consumer too slow: {turn_id}")
+                )
 
     def _fail_streams(self, turn_id: str, error: BaseException) -> None:
         for queue in tuple(self._subscribers[turn_id]):
@@ -638,7 +1042,9 @@ class ConversationRuntime:
         """订阅 live stream，并在 replay 被截断或过期时发出权威快照。"""
 
         if after_event is not None and (
-            not isinstance(after_event, int) or isinstance(after_event, bool) or after_event < -1
+            not isinstance(after_event, int)
+            or isinstance(after_event, bool)
+            or after_event < -1
         ):
             raise ValueError("after_event 必须是大于等于 -1 的整数")
         self._raise_replay_reaper_failure()
@@ -699,7 +1105,9 @@ class ConversationRuntime:
 
     def _raise_replay_reaper_failure(self) -> None:
         if self._replay_reaper_error is not None:
-            raise RuntimeError("control replay reaper failed") from self._replay_reaper_error
+            raise RuntimeError(
+                "control replay reaper failed"
+            ) from self._replay_reaper_error
 
     def _ensure_replay_reaper(self) -> None:
         self._raise_replay_reaper_failure()
@@ -709,9 +1117,7 @@ class ConversationRuntime:
                 self._replay_reaper(),
                 name="conversation-replay-reaper",
             )
-            self._replay_reaper_task.add_done_callback(
-                self._observe_replay_reaper_task
-            )
+            self._replay_reaper_task.add_done_callback(self._observe_replay_reaper_task)
 
     def _observe_replay_reaper_task(self, task: asyncio.Task[None]) -> None:
         if task.cancelled():
@@ -757,7 +1163,9 @@ class ConversationRuntime:
 
     @staticmethod
     def _replay_notice(method: str, record: TurnRecord) -> TurnEvent:
-        status = "replay_truncated" if method.endswith("truncated") else "replay_expired"
+        status = (
+            "replay_truncated" if method.endswith("truncated") else "replay_expired"
+        )
         return TurnEvent.create(
             method,
             record.thread_id,
@@ -817,7 +1225,9 @@ class ConversationRuntime:
         # 1. caller 必须是当前 runtime 唯一已经持久化的 turn。
         active_turns = set(self._tasks)
         if caller_turn_id not in active_turns:
-            raise RuntimeClosedError(f"restart caller turn 不在当前 runtime: {caller_turn_id}")
+            raise RuntimeClosedError(
+                f"restart caller turn 不在当前 runtime: {caller_turn_id}"
+            )
         others = active_turns - {caller_turn_id}
         if others:
             raise RuntimeClosedError(
@@ -836,9 +1246,7 @@ class ConversationRuntime:
         """只允许原 restart owner 在提交前恢复准入。"""
 
         if self._restart_owner_turn_id != caller_turn_id:
-            raise RuntimeError(
-                f"restart admission owner 不匹配: {caller_turn_id}"
-            )
+            raise RuntimeError(f"restart admission owner 不匹配: {caller_turn_id}")
         self._restart_owner_turn_id = None
         if not self._closed:
             self._accepting_turns = True
@@ -859,16 +1267,28 @@ class ConversationRuntime:
         return await asyncio.shield(future)
 
     async def interrupt_turn(self, thread_id: str, turn_id: str) -> TurnRecord:
-        record = self.read_turn(thread_id, turn_id)
-        if record.status.is_terminal:
-            return record
-        if self._active_by_thread.get(thread_id) != turn_id:
-            raise TurnNotFoundError(f"active turn 不匹配: {thread_id}/{turn_id}")
-        if record.status is TurnStatus.QUEUED:
-            # 1. 先让已启动 task 自行收束；启动前取消则由 owner 补交 cancelled。
+        # 1. 与普通输入 admission/final seal 共用栅栏，先封口再取消执行。
+        async with self._control_admission_lock:
+            record = self.read_turn(thread_id, turn_id)
+            if record.status.is_terminal:
+                return record
+            if self._active_by_thread.get(thread_id) != turn_id:
+                raise TurnNotFoundError(f"active turn 不匹配: {thread_id}/{turn_id}")
+            already_sealed = turn_id in self._sealed_turn_inputs
             task = self._tasks[turn_id]
-            task.cancel()
             future = self._results[turn_id]
+            if not already_sealed:
+                self._sealed_turn_inputs.add(turn_id)
+                if record.status is TurnStatus.IN_PROGRESS:
+                    self._interrupt_requested.add(turn_id)
+                task.cancel()
+
+        if already_sealed:
+            await asyncio.shield(future)
+            return self.read_turn(thread_id, turn_id)
+
+        if record.status is TurnStatus.QUEUED:
+            # 2. 先让已启动 task 自行收束；启动前取消则由 owner 补交 cancelled。
             _ = await asyncio.gather(task, return_exceptions=True)
             if future.done():
                 return self.read_turn(thread_id, turn_id)
@@ -878,7 +1298,11 @@ class ConversationRuntime:
                 status=TurnStatus.CANCELLED,
                 thread_id=thread_id,
             )
-            self._publish(TurnEvent.create("turn/completed", thread_id, turn_id, turn=terminal.to_dict()))
+            self._publish(
+                TurnEvent.create(
+                    "turn/completed", thread_id, turn_id, turn=terminal.to_dict()
+                )
+            )
             future.set_result(TurnResult.from_record(terminal))
             self._finish_streams(turn_id)
             _ = self._active_by_thread.pop(thread_id, None)
@@ -886,17 +1310,16 @@ class ConversationRuntime:
             if idle is not None:
                 idle.set()
             _ = self._tasks.pop(turn_id, None)
-            request_bytes = self._active_turn_bytes.get(turn_id)
-            if request_bytes is None:
+            if turn_id not in self._active_turn_bytes:
                 raise RuntimeError(f"queued turn admission missing: {turn_id}")
-            self._release_admission(turn_id, request_bytes)
+            self._consumed_inputs.pop(turn_id, None)
+            self._sealed_turn_inputs.discard(turn_id)
+            self._turn_input_sources.pop(turn_id, None)
+            self._release_admission(turn_id)
             return terminal
 
-        # 2. in-progress task 自己在取消处理器中提交 interrupted。
-        self._interrupt_requested.add(turn_id)
-        task = self._tasks[turn_id]
-        task.cancel()
-        await asyncio.shield(self._results[turn_id])
+        # 3. in-progress task 自己在取消处理器中提交 interrupted。
+        await asyncio.shield(future)
         return self.read_turn(thread_id, turn_id)
 
     def request_interrupt(
@@ -934,8 +1357,10 @@ class ConversationRuntime:
         if reaper is not None:
             reaper.cancel()
             result = await asyncio.gather(reaper, return_exceptions=True)
-            if result and isinstance(result[0], BaseException) and not isinstance(
-                result[0], asyncio.CancelledError
+            if (
+                result
+                and isinstance(result[0], BaseException)
+                and not isinstance(result[0], asyncio.CancelledError)
             ):
                 self._replay_reaper_error = result[0]
         self._raise_replay_reaper_failure()

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -75,10 +75,6 @@ def _encoded_event_bytes(event: TurnEvent) -> int:
     )
 
 
-def _encoded_json_bytes(value: object) -> int:
-    return len(json.dumps(value, ensure_ascii=False, sort_keys=True).encode())
-
-
 def _merge_turn_items(base: list[TurnItem], updates: list[TurnItem]) -> list[TurnItem]:
     """按 item identity 保留顺序并应用最新 checkpoint。"""
 
@@ -235,11 +231,7 @@ class ConversationRuntime:
             if previous_attempts:
                 metadata[_CONTINUED_FROM_TURN_ID] = previous_attempts[-1].id
             effective_request = TurnRequest(request.thread_id, request.input, metadata)
-            request_bytes = (
-                _encoded_turn_bytes(effective_request)
-                + _encoded_json_bytes(attempt_replay)
-                + _encoded_json_bytes(prior_tool_chain)
-            )
+            request_bytes = _encoded_turn_bytes(effective_request)
             admission_token = self._reserve_admission(request_bytes)
 
             # 2. 先持久化 queued handle；失败时只回滚本轮 admission token。

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -803,7 +803,9 @@ class ConversationRuntime:
                 "conversation turn failed thread=%s turn=%s", request.thread_id, turn_id
             )
             current = self._store.read_turn(turn_id)
-            if current is not None and current.status is TurnStatus.IN_PROGRESS:
+            if current is not None and current.status.is_terminal:
+                terminal = current
+            elif current is not None and current.status is TurnStatus.IN_PROGRESS:
                 items = _merge_turn_items(
                     current.items,
                     close_observed_items(TurnStatus.FAILED),

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, cast
 
 import agent.core.passive_support as support
 from agent.control.context import current_turn_id
+from agent.control.ports import TurnInputSource, TurnUserInput
 from agent.model_runtime.query_compaction import QueryCompactor
 from agent.core.runtime_support import ToolDiscoveryState
 from agent.core.types import (
@@ -55,7 +57,10 @@ from agent.lifecycle.phases.before_reasoning import (
     BeforeReasoningFrame,
     default_before_reasoning_modules,
 )
-from agent.lifecycle.phases.before_step import BeforeStepFrame, default_before_step_modules
+from agent.lifecycle.phases.before_step import (
+    BeforeStepFrame,
+    default_before_step_modules,
+)
 from agent.lifecycle.phases.before_turn import (
     BeforeTurnFrame,
     MemoryConsolidator,
@@ -97,7 +102,9 @@ from core.common.diagnostic_log import diagnostic_context, diagnostic_line
 logger = logging.getLogger(__name__)
 
 
-def _persistence_from_metadata(metadata: dict[str, Any] | None) -> TurnPersistencePolicy:
+def _persistence_from_metadata(
+    metadata: dict[str, Any] | None,
+) -> TurnPersistencePolicy:
     return TurnPersistencePolicy(
         persist_user=not bool((metadata or {}).get("omit_user_turn")),
         persist_assistant=not bool((metadata or {}).get("omit_assistant_turn")),
@@ -359,9 +366,11 @@ class PassiveTurnPipeline:
                 consolidator=self._memory_consolidator,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._before_turn_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._before_turn_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=BeforeTurnFrame,
@@ -379,9 +388,11 @@ class PassiveTurnPipeline:
                 self._context,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._before_reasoning_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._before_reasoning_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=BeforeReasoningFrame,
@@ -397,9 +408,11 @@ class PassiveTurnPipeline:
                 self._session,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._after_reasoning_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._after_reasoning_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=AfterReasoningFrame,
@@ -417,9 +430,11 @@ class PassiveTurnPipeline:
                 self._history_window,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._after_turn_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._after_turn_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=AfterTurnFrame,
@@ -429,7 +444,10 @@ class PassiveTurnPipeline:
         snapshot = get_current_runtime_snapshot()
         if snapshot is None:
             return self._phases
-        if self._snapshot_phases is None or self._snapshot_phases[0] != snapshot.snapshot_id:
+        if (
+            self._snapshot_phases is None
+            or self._snapshot_phases[0] != snapshot.snapshot_id
+        ):
             self._snapshot_phases = (
                 snapshot.snapshot_id,
                 _PassivePhaseBundle(
@@ -522,8 +540,10 @@ class PassiveTurnPipeline:
 
                 # Phase 2: BeforeReasoning 模块链（工具上下文、BeforeReasoning 事件、prompt warmup）。
                 with diagnostic_context(phase="before_reasoning"):
-                    before_reasoning = await self._runtime_phases().before_reasoning.run(
-                        BeforeReasoningInput(state=state, before_turn=before_turn)
+                    before_reasoning = (
+                        await self._runtime_phases().before_reasoning.run(
+                            BeforeReasoningInput(state=state, before_turn=before_turn)
+                        )
                     )
                 if before_reasoning.abort:
                     logger.info(
@@ -837,6 +857,7 @@ class DefaultContextStore(ContextStore):
             history_messages=history_messages,
         )
 
+
 class Reasoner(ABC):
 
     @abstractmethod
@@ -923,33 +944,41 @@ class DefaultReasoner(Reasoner):
         self._prompt_render_plugin_modules: list[object] = []
         self._before_step_plugin_modules: list[object] = []
         self._after_step_plugin_modules: list[object] = []
-        self._snapshot_step_phases: tuple[
-            str,
+        self._snapshot_step_phases: (
             tuple[
-                Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame],
-                Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame],
-            ],
-        ] | None = None
-        self._snapshot_prompt_render_phase: tuple[
-            str,
-            Phase[PromptRenderInput, PromptRenderResult, PromptRenderFrame],
-        ] | None = None
+                str,
+                tuple[
+                    Phase[BeforeStepInput, BeforeStepCtx, BeforeStepFrame],
+                    Phase[AfterStepCtx, AfterStepCtx, AfterStepFrame],
+                ],
+            ]
+            | None
+        ) = None
+        self._snapshot_prompt_render_phase: (
+            tuple[
+                str,
+                Phase[PromptRenderInput, PromptRenderResult, PromptRenderFrame],
+            ]
+            | None
+        ) = None
         self._tool_executor = ToolExecutor([])
-        self._stream_sink_factory: Callable[
-            [object], Callable[[dict[str, str] | str], Awaitable[None]] | None
-        ] | None = None
+        self._stream_sink_factory: (
+            Callable[[object], Callable[[dict[str, str] | str], Awaitable[None]] | None]
+            | None
+        ) = None
         bus = event_bus or EventBus()
         self._bus = bus
         self._before_step = self._build_before_step_phase()
         self._after_step = self._build_after_step_phase()
-        self._prompt_render: Phase[
-            PromptRenderInput,
-            PromptRenderResult,
-            PromptRenderFrame,
-        ] | None = (
-            self._build_prompt_render_phase(context)
-            if context is not None
-            else None
+        self._prompt_render: (
+            Phase[
+                PromptRenderInput,
+                PromptRenderResult,
+                PromptRenderFrame,
+            ]
+            | None
+        ) = (
+            self._build_prompt_render_phase(context) if context is not None else None
         )
 
     def add_tool_hooks(self, hooks: list["ToolHook"]) -> None:
@@ -989,9 +1018,11 @@ class DefaultReasoner(Reasoner):
                 self._bus,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._before_step_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._before_step_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=BeforeStepFrame,
@@ -1006,9 +1037,11 @@ class DefaultReasoner(Reasoner):
                 self._bus,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._after_step_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._after_step_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=AfterStepFrame,
@@ -1025,9 +1058,11 @@ class DefaultReasoner(Reasoner):
                 context,
                 plugin_modules=cast(
                     "list[Any]",
-                    self._prompt_render_plugin_modules
-                    if plugin_modules is None
-                    else plugin_modules,
+                    (
+                        self._prompt_render_plugin_modules
+                        if plugin_modules is None
+                        else plugin_modules
+                    ),
                 ),
             ),
             frame_factory=PromptRenderFrame,
@@ -1079,10 +1114,10 @@ class DefaultReasoner(Reasoner):
 
     def set_stream_sink_factory(
         self,
-        factory: Callable[
-            [object], Callable[[dict[str, str] | str], Awaitable[None]] | None
-        ]
-        | None,
+        factory: (
+            Callable[[object], Callable[[dict[str, str] | str], Awaitable[None]] | None]
+            | None
+        ),
     ) -> None:
         self._stream_sink_factory = factory
 
@@ -1110,11 +1145,36 @@ class DefaultReasoner(Reasoner):
             "selected_plan": None,
             "trimmed_sections": [],
         }
-        source_history = (
+        source_history = list(
             base_history
             if base_history is not None
             else get_history_since_consolidated(session, self._memory_window)
         )
+        metadata = getattr(msg, "metadata", None) or {}
+        raw_attempt_replay = metadata.get("_control_attempt_replay", [])
+        if not isinstance(raw_attempt_replay, list) or not all(
+            isinstance(item, dict) for item in raw_attempt_replay
+        ):
+            raise RuntimeError("control attempt replay 契约无效")
+        attempt_replay = [
+            dict(cast(dict[str, Any], item)) for item in raw_attempt_replay
+        ]
+        raw_prior_input_count = metadata.get("_control_prior_input_count", 0)
+        if (
+            not isinstance(raw_prior_input_count, int)
+            or isinstance(raw_prior_input_count, bool)
+            or raw_prior_input_count < 0
+        ):
+            raise RuntimeError("control prior input count 契约无效")
+        prior_input_count = raw_prior_input_count
+        raw_prior_tool_chain = metadata.get("_control_prior_tool_chain", [])
+        if not isinstance(raw_prior_tool_chain, list) or not all(
+            isinstance(item, dict) for item in raw_prior_tool_chain
+        ):
+            raise RuntimeError("control prior tool chain 契约无效")
+        prior_tool_chain = [
+            dict(cast(dict[str, Any], item)) for item in raw_prior_tool_chain
+        ]
         total_history = len(source_history)
         preloaded: set[str] | None = None
         preloaded_order: list[str] = []
@@ -1126,9 +1186,22 @@ class DefaultReasoner(Reasoner):
                 preloaded_order if preloaded_order else "[]",
             )
         stream_sink = (
-            self._stream_sink_factory(msg) if self._stream_sink_factory is not None else None
+            self._stream_sink_factory(msg)
+            if self._stream_sink_factory is not None
+            else None
         )
         disabled_tools = _disabled_tools_from_msg(msg)
+        raw_turn_input_source = (getattr(msg, "metadata", None) or {}).get(
+            "_control_turn_input_source"
+        )
+        turn_input_source: TurnInputSource | None = None
+        if raw_turn_input_source is not None:
+            if not all(
+                callable(getattr(raw_turn_input_source, name, None))
+                for name in ("seal", "consumed_inputs")
+            ):
+                raise RuntimeError("control turn input source 契约无效")
+            turn_input_source = cast(TurnInputSource, raw_turn_input_source)
         # session 级记忆排除：disable_memory_writes 展开为 memory 来源的写工具。
         if bool((getattr(msg, "metadata", None) or {}).get("disable_memory_writes")):
             disabled_tools |= self._tools.get_source_tool_names(
@@ -1151,6 +1224,7 @@ class DefaultReasoner(Reasoner):
                 source_history,
                 plan["history_window"],
             )
+            history_for_attempt.extend(attempt_replay)
             turn_injection_prompt = build_turn_injection_prompt(
                 tools=self._tools,
                 tool_search_enabled=self._tool_search_enabled,
@@ -1177,6 +1251,14 @@ class DefaultReasoner(Reasoner):
                 )
             )
             initial_messages = prompt_render.messages
+            if turn_input_source is not None:
+                consumed_inputs = turn_input_source.consumed_inputs()
+                if prior_input_count >= len(consumed_inputs):
+                    raise RuntimeError("control attempt 缺少当前用户输入")
+                self._append_turn_inputs(
+                    initial_messages,
+                    consumed_inputs[prior_input_count + 1 :],
+                )
             llm_user_content, llm_context_frame = extract_model_facing_turn(
                 initial_messages
             )
@@ -1198,12 +1280,25 @@ class DefaultReasoner(Reasoner):
                         tool_event_channel=msg.channel,
                         tool_event_chat_id=msg.chat_id,
                         disabled_tools=disabled_tools,
+                        turn_input_source=turn_input_source,
+                        initial_attempt_replay=attempt_replay,
+                        initial_prior_tool_groups=len(prior_tool_chain),
                     )
                 finally:
                     end_turn_search_scope(search_scope)
                 tools_used = list(result.metadata.get("tools_used") or [])
                 tools_unlocked = list(result.metadata.get("tools_unlocked") or [])
                 tool_chain = list(result.metadata.get("tool_chain") or [])
+                if prior_tool_chain:
+                    tool_chain = [*prior_tool_chain, *tool_chain]
+                    tools_used = [
+                        *[
+                            str(call["name"])
+                            for group in prior_tool_chain
+                            for call in cast(list[dict[str, object]], group["calls"])
+                        ],
+                        *tools_used,
+                    ]
                 media = list(result.metadata.get("media") or [])
                 if attempt > 0:
                     retry_trace["selected_plan"] = plan["name"]
@@ -1225,11 +1320,17 @@ class DefaultReasoner(Reasoner):
                 if attempt == 0:
                     retry_trace["selected_plan"] = plan["name"]
                     retry_trace["trimmed_sections"] = sorted(plan["disabled_sections"])
-                if isinstance(llm_user_content, (str, list)):
+                if prior_input_count == 0 and isinstance(llm_user_content, (str, list)):
                     retry_trace["llm_user_content"] = llm_user_content
-                if isinstance(llm_context_frame, str) and llm_context_frame.strip():
+                if (
+                    prior_input_count == 0
+                    and isinstance(llm_context_frame, str)
+                    and llm_context_frame.strip()
+                ):
                     retry_trace["llm_context_frame"] = llm_context_frame
-                retry_trace["react_stats"] = dict(result.metadata.get("react_stats") or {})
+                retry_trace["react_stats"] = dict(
+                    result.metadata.get("react_stats") or {}
+                )
                 raw_model_state = result.metadata.get("model_state")
                 raw_react_compaction = result.metadata.get("react_compaction")
                 if raw_react_compaction is not None and not isinstance(
@@ -1316,6 +1417,9 @@ class DefaultReasoner(Reasoner):
         tool_event_channel: str = "",
         tool_event_chat_id: str = "",
         disabled_tools: set[str] | None = None,
+        turn_input_source: TurnInputSource | None = None,
+        initial_attempt_replay: list[dict[str, Any]] | None = None,
+        initial_prior_tool_groups: int = 0,
     ) -> ReasonerResult:
         # 1. 初始化消息上下文、本轮工具轨迹。
         messages = list(initial_messages)
@@ -1335,12 +1439,24 @@ class DefaultReasoner(Reasoner):
         react_usages: list[ModelUsage] = []
         react_finish_reasons: list[str | None] = []
         disabled = set(disabled_tools or set())
+        compaction_base, completed_replay_batches, current_query = (
+            _query_compaction_seed(messages, initial_attempt_replay or [])
+        )
+        if len(completed_replay_batches) != initial_prior_tool_groups:
+            raise RuntimeError(
+                "control attempt replay 与 prior tool chain 数量不一致: "
+                f"replay={len(completed_replay_batches)} "
+                f"tool_chain={initial_prior_tool_groups}"
+            )
         compactor = QueryCompactor(
             provider=self._llm.provider,
             model=self._llm_config.model,
-            base_messages=messages,
+            base_messages=compaction_base,
             scope_id=current_turn_id.get() or tool_event_session_key,
+            completed_batches=completed_replay_batches,
+            current_query=current_query,
         )
+        pending_start_override: int | None = compactor.pending_start
         before_step_phase, after_step_phase = self._runtime_step_phases()
         if self._tool_search_enabled:
             always_on = self._tools.get_always_on_names()
@@ -1366,17 +1482,49 @@ class DefaultReasoner(Reasoner):
                 self._llm_config.max_iterations > 0
                 and iteration >= self._llm_config.max_iterations
             ):
-                break
-            batch_start = len(messages)
+                summary = await self._summarize_incomplete_progress(
+                    messages,
+                    reason="max_iterations",
+                    iteration=iteration,
+                    tools_used=tools_used,
+                )
+                result = self._build_result(
+                    reply=summary,
+                    tools_used=tools_used,
+                    tool_chain=tool_chain,
+                    react_compaction=compactor.persistence_payload(),
+                    media=outbound_media,
+                    visible_names=visible_names,
+                    thinking=None,
+                    streamed=False,
+                    react_input_samples=react_input_samples,
+                    cache_prompt_tokens=react_cache_prompt_tokens,
+                    cache_hit_tokens=react_cache_hit_tokens,
+                    cache_seen=react_cache_seen,
+                    tools_unlocked=tools_unlocked,
+                    model_usages=react_usages,
+                    finish_reasons=react_finish_reasons,
+                    mobile_attention=mobile_attention,
+                )
+                await self._seal_turn_input_source(turn_input_source)
+                return result
+            batch_start = (
+                pending_start_override
+                if pending_start_override is not None
+                else len(messages)
+            )
+            pending_start_override = None
             # 3. BeforeStep 模块链：token 估算、BeforeStep 事件、提示注入。
-            step_ctx = await before_step_phase.run(BeforeStepInput(
-                session_key=tool_event_session_key,
-                channel=tool_event_channel,
-                chat_id=tool_event_chat_id,
-                iteration=iteration,
-                messages=messages,
-                visible_names=visible_names,
-            ))
+            step_ctx = await before_step_phase.run(
+                BeforeStepInput(
+                    session_key=tool_event_session_key,
+                    channel=tool_event_channel,
+                    chat_id=tool_event_chat_id,
+                    iteration=iteration,
+                    messages=messages,
+                    visible_names=visible_names,
+                )
+            )
             if step_ctx.early_stop:
                 summary = await self._summarize_incomplete_progress(
                     messages,
@@ -1384,7 +1532,7 @@ class DefaultReasoner(Reasoner):
                     iteration=iteration + 1,
                     tools_used=tools_used,
                 )
-                return self._build_result(
+                result = self._build_result(
                     reply=step_ctx.early_stop_reply or summary,
                     tools_used=tools_used,
                     tool_chain=tool_chain,
@@ -1402,6 +1550,8 @@ class DefaultReasoner(Reasoner):
                     finish_reasons=react_finish_reasons,
                     mobile_attention=mobile_attention,
                 )
+                await self._seal_turn_input_source(turn_input_source)
+                return result
             # 4. 构造本轮工具 schema，并按完整 provider input 判断压缩水位。
             schema_names: list[str] | set[str] | None = (
                 list(visible_order) if visible_order is not None else None
@@ -1423,7 +1573,11 @@ class DefaultReasoner(Reasoner):
             logger.info(
                 "[LLM调用] 第%d轮，可见工具=%s input_tokens~=%d quality=%s compacted=%s",
                 iteration + 1,
-                f"{len(visible_names)}个" if visible_names is not None else "全部（tool_search未开启）",
+                (
+                    f"{len(visible_names)}个"
+                    if visible_names is not None
+                    else "全部（tool_search未开启）"
+                ),
                 prepared.estimated_tokens,
                 prepared.estimate_quality,
                 prepared.compacted,
@@ -1489,23 +1643,23 @@ class DefaultReasoner(Reasoner):
                 if isinstance(model_state, dict):
                     retry_assistant["model_state"] = model_state
                 messages.append(retry_assistant)
-                messages.append({
-                    "role": "user",
-                    "content": (
-                        "你刚才只输出了思考过程，没有给出正式回复或工具调用。"
-                        "请继续：需要操作时通过已提供的结构化工具调用，"
-                        "不要把工具调用协议写入文本；否则直接回复用户。"
-                    ),
-                })
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "你刚才只输出了思考过程，没有给出正式回复或工具调用。"
+                            "请继续：需要操作时通过已提供的结构化工具调用，"
+                            "不要把工具调用协议写入文本；否则直接回复用户。"
+                        ),
+                    }
+                )
                 retry_prepared = await compactor.prepare(
                     messages,
                     pending_start=batch_start,
                     tools=tool_schemas,
                 )
                 if retry_prepared.compacted:
-                    react_usages.append(
-                        retry_prepared.summary_usage or ModelUsage()
-                    )
+                    react_usages.append(retry_prepared.summary_usage or ModelUsage())
                 batch_start = retry_prepared.pending_start
                 request_message_count = len(messages)
                 try:
@@ -1632,7 +1786,10 @@ class DefaultReasoner(Reasoner):
                         )
                         continue
                     # 6.1 deferred 工具未解锁时，先回填 select: 引导错误。
-                    if visible_names is not None and tool_call.name not in visible_names:
+                    if (
+                        visible_names is not None
+                        and tool_call.name not in visible_names
+                    ):
                         exec_result = await self._tool_executor.preflight(
                             ToolExecutionRequest(
                                 call_id=tool_call.id,
@@ -1697,7 +1854,7 @@ class DefaultReasoner(Reasoner):
                                     "result": result,
                                 }
                             )
-                            for skipped in response.tool_calls[tool_batch_index + 1:]:
+                            for skipped in response.tool_calls[tool_batch_index + 1 :]:
                                 append_tool_result(
                                     messages,
                                     tool_call_id=skipped.id,
@@ -1705,14 +1862,16 @@ class DefaultReasoner(Reasoner):
                                     tool_name=skipped.name,
                                     execution_status="skipped",
                                 )
-                            tool_chain.append({"text": response.content, "calls": iter_calls})
+                            tool_chain.append(
+                                {"text": response.content, "calls": iter_calls}
+                            )
                             summary = await self._summarize_incomplete_progress(
                                 messages,
                                 reason="tool_call_loop",
                                 iteration=iteration + 1,
                                 tools_used=tools_used,
                             )
-                            return self._build_result(
+                            result = self._build_result(
                                 reply=summary,
                                 tools_used=tools_used,
                                 tool_chain=tool_chain,
@@ -1730,13 +1889,15 @@ class DefaultReasoner(Reasoner):
                                 finish_reasons=react_finish_reasons,
                                 mobile_attention=mobile_attention,
                             )
+                            await self._seal_turn_input_source(turn_input_source)
+                            return result
                         logger.warning(
                             "[工具未解锁] LLM 尝试调用 '%s'，但该工具 schema 不可见，引导模型先 tool_search",
                             tool_call.name,
                         )
                         result = (
                             f"工具 '{tool_call.name}' 当前未加载（schema 不可见）。"
-                            f"请先调用 tool_search(query=\"select:{tool_call.name}\") 加载，"
+                            f'请先调用 tool_search(query="select:{tool_call.name}") 加载，'
                             "然后再调用该工具。不要放弃当前任务。"
                         )
                         append_tool_result(
@@ -1774,7 +1935,9 @@ class DefaultReasoner(Reasoner):
                     ) -> Any:
                         internal_arguments: dict[str, Any] = {}
                         if name == "tool_search" and visible_names is not None:
-                            internal_arguments["excluded_names"] = visible_names | disabled
+                            internal_arguments["excluded_names"] = (
+                                visible_names | disabled
+                            )
                         if name == "message_push":
                             internal_arguments["_commit_role"] = "passive"
                         return await self._tools.execute(
@@ -1784,7 +1947,9 @@ class DefaultReasoner(Reasoner):
                         )
 
                     _args_preview = support.log_preview(tool_call.arguments, 120)
-                    logger.info("[工具执行→] %s  args=%s", tool_call.name, _args_preview)
+                    logger.info(
+                        "[工具执行→] %s  args=%s", tool_call.name, _args_preview
+                    )
                     await self._observe_tool_call_started(
                         session_key=tool_event_session_key,
                         channel=tool_event_channel,
@@ -1796,13 +1961,15 @@ class DefaultReasoner(Reasoner):
                     )
                     # 工具调用统一先过 ToolExecutor：
                     # pre_hook 可改参/拒绝，真实执行后再补 post_hook trace。
-                    await self._bus.fanout(BeforeToolCallCtx(
-                        session_key=tool_event_session_key,
-                        channel=tool_event_channel,
-                        chat_id=tool_event_chat_id,
-                        tool_name=tool_call.name,
-                        arguments=dict(tool_call.arguments),
-                    ))
+                    await self._bus.fanout(
+                        BeforeToolCallCtx(
+                            session_key=tool_event_session_key,
+                            channel=tool_event_channel,
+                            chat_id=tool_event_chat_id,
+                            tool_name=tool_call.name,
+                            arguments=dict(tool_call.arguments),
+                        )
+                    )
                     exec_result = await self._tool_executor.execute(
                         ToolExecutionRequest(
                             call_id=tool_call.id,
@@ -1821,15 +1988,17 @@ class DefaultReasoner(Reasoner):
                     if exec_result.status == "success":
                         tools_used.append(tool_call.name)
                     result = exec_result.output
-                    await self._bus.fanout(AfterToolResultCtx(
-                        session_key=tool_event_session_key,
-                        channel=tool_event_channel,
-                        chat_id=tool_event_chat_id,
-                        tool_name=tool_call.name,
-                        arguments=dict(exec_result.final_arguments),
-                        result=str(result),
-                        status=exec_result.status,
-                    ))
+                    await self._bus.fanout(
+                        AfterToolResultCtx(
+                            session_key=tool_event_session_key,
+                            channel=tool_event_channel,
+                            chat_id=tool_event_chat_id,
+                            tool_name=tool_call.name,
+                            arguments=dict(exec_result.final_arguments),
+                            result=str(result),
+                            status=exec_result.status,
+                        )
+                    )
                     normalized = normalize_tool_result(result)
                     if normalized.mobile_attention is not None:
                         if exec_result.status != "success":
@@ -1862,7 +2031,10 @@ class DefaultReasoner(Reasoner):
                         tool_name=tool_call.name,
                         execution_status=exec_result.status,
                     )
-                    if exec_result.status == "success" and tool_call.name == "message_push":
+                    if (
+                        exec_result.status == "success"
+                        and tool_call.name == "message_push"
+                    ):
                         _collect_current_web_push_media(
                             outbound_media,
                             exec_result.final_arguments,
@@ -1878,7 +2050,9 @@ class DefaultReasoner(Reasoner):
                     ):
                         _newly_unlocked = [
                             name
-                            for name in self._discovery.unlock_names_from_result(normalized.text)
+                            for name in self._discovery.unlock_names_from_result(
+                                normalized.text
+                            )
                             if name not in visible_names and name not in disabled
                         ]
                         if _newly_unlocked:
@@ -1890,7 +2064,10 @@ class DefaultReasoner(Reasoner):
                                     if name not in seen_visible:
                                         visible_order.append(name)
                                         seen_visible.add(name)
-                            logger.info("[工具解锁] tool_search 新解锁: %s", sorted(_newly_unlocked))
+                            logger.info(
+                                "[工具解锁] tool_search 新解锁: %s",
+                                sorted(_newly_unlocked),
+                            )
                         else:
                             logger.info("[工具解锁] tool_search 未解锁新工具")
                     # tool_chain 持久化的是“执行后的事实”：
@@ -1933,7 +2110,7 @@ class DefaultReasoner(Reasoner):
                             iteration + 1,
                             tool_call.name,
                         )
-                        for skipped in response.tool_calls[tool_batch_index + 1:]:
+                        for skipped in response.tool_calls[tool_batch_index + 1 :]:
                             append_tool_result(
                                 messages,
                                 tool_call_id=skipped.id,
@@ -1941,14 +2118,16 @@ class DefaultReasoner(Reasoner):
                                 tool_name=skipped.name,
                                 execution_status="skipped",
                             )
-                        tool_chain.append({"text": response.content, "calls": iter_calls})
+                        tool_chain.append(
+                            {"text": response.content, "calls": iter_calls}
+                        )
                         summary = await self._summarize_incomplete_progress(
                             messages,
                             reason="tool_call_loop",
                             iteration=iteration + 1,
                             tools_used=tools_used,
                         )
-                        return self._build_result(
+                        result = self._build_result(
                             reply=summary,
                             tools_used=tools_used,
                             tool_chain=tool_chain,
@@ -1966,6 +2145,8 @@ class DefaultReasoner(Reasoner):
                             finish_reasons=react_finish_reasons,
                             mobile_attention=mobile_attention,
                         )
+                        await self._seal_turn_input_source(turn_input_source)
+                        return result
 
                 # 7. 本轮工具执行完后，记录 tool_chain。
                 tool_chain_group = {"text": response.content, "calls": iter_calls}
@@ -1984,19 +2165,21 @@ class DefaultReasoner(Reasoner):
                     tool_schemas,
                 )
                 # 7a. AfterStep 模块链（工具分支）：通知观察者本轮工具执行完毕。
-                after_step = await after_step_phase.run(AfterStepCtx(
-                    session_key=tool_event_session_key,
-                    channel=tool_event_channel,
-                    chat_id=tool_event_chat_id,
-                    iteration=iteration,
-                    context_tokens_estimate=pressure_tokens,
-                    tools_called=tuple(tc.name for tc in response.tool_calls),
-                    partial_reply=response.content or "",
-                    tools_used_so_far=tuple(tools_used),
-                    tool_chain_partial=tuple(tool_chain),
-                    partial_thinking=response.thinking,
-                    has_more=True,
-                ))
+                after_step = await after_step_phase.run(
+                    AfterStepCtx(
+                        session_key=tool_event_session_key,
+                        channel=tool_event_channel,
+                        chat_id=tool_event_chat_id,
+                        iteration=iteration,
+                        context_tokens_estimate=pressure_tokens,
+                        tools_called=tuple(tc.name for tc in response.tool_calls),
+                        partial_reply=response.content or "",
+                        tools_used_so_far=tuple(tools_used),
+                        tool_chain_partial=tuple(tool_chain),
+                        partial_thinking=response.thinking,
+                        has_more=True,
+                    )
+                )
                 if after_step.early_stop:
                     reason = after_step.early_stop_reason or "after_step"
                     logger.warning(
@@ -2010,7 +2193,7 @@ class DefaultReasoner(Reasoner):
                         iteration=iteration + 1,
                         tools_used=tools_used,
                     )
-                    return self._build_result(
+                    result = self._build_result(
                         reply=summary,
                         tools_used=tools_used,
                         tool_chain=tool_chain,
@@ -2028,6 +2211,8 @@ class DefaultReasoner(Reasoner):
                         finish_reasons=react_finish_reasons,
                         mobile_attention=mobile_attention,
                     )
+                    await self._seal_turn_input_source(turn_input_source)
+                    return result
                 continue
 
             # 8. 没有 tool_calls 时，说明本轮得到最终回复。
@@ -2037,22 +2222,7 @@ class DefaultReasoner(Reasoner):
                 len(tools_used),
                 tools_used if tools_used else "无",
             )
-            messages.append({"role": "assistant", "content": response.content})
-            # 8b. AfterStep 模块链（最终回复分支）：通知观察者本轮推理结束。
-            _ = await after_step_phase.run(AfterStepCtx(
-                session_key=tool_event_session_key,
-                channel=tool_event_channel,
-                chat_id=tool_event_chat_id,
-                iteration=iteration,
-                context_tokens_estimate=support.estimate_messages_tokens(messages),
-                tools_called=(),
-                partial_reply=response.content or "",
-                tools_used_so_far=tuple(tools_used),
-                tool_chain_partial=tuple(tool_chain),
-                partial_thinking=response.thinking,
-                has_more=False,
-            ))
-            return self._build_result(
+            result = self._build_result(
                 reply=response.content or "模型未返回可用回复，请重试。",
                 tools_used=tools_used,
                 tool_chain=tool_chain,
@@ -2075,37 +2245,55 @@ class DefaultReasoner(Reasoner):
                     else None
                 ),
             )
+            await self._seal_turn_input_source(turn_input_source)
+            messages.append({"role": "assistant", "content": response.content})
+            # 8b. AfterStep 模块链（最终回复分支）：通知观察者本轮推理结束。
+            _ = await after_step_phase.run(
+                AfterStepCtx(
+                    session_key=tool_event_session_key,
+                    channel=tool_event_channel,
+                    chat_id=tool_event_chat_id,
+                    iteration=iteration,
+                    context_tokens_estimate=support.estimate_messages_tokens(messages),
+                    tools_called=(),
+                    partial_reply=response.content or "",
+                    tools_used_so_far=tuple(tools_used),
+                    tool_chain_partial=tuple(tool_chain),
+                    partial_thinking=response.thinking,
+                    has_more=False,
+                )
+            )
+            return result
 
-        # 9. 达到最大迭代次数后，生成不完整进展总结。
-        logger.warning(
-            "[迭代上限] 达到最大轮次%d，触发收尾总结，已调用工具: %s",
-            iteration,
-            tools_used if tools_used else "无",
-        )
-        summary = await self._summarize_incomplete_progress(
-            messages,
-            reason="max_iterations",
-            iteration=iteration,
-            tools_used=tools_used,
-        )
-        return self._build_result(
-            reply=summary,
-            tools_used=tools_used,
-            tool_chain=tool_chain,
-            react_compaction=compactor.persistence_payload(),
-            media=outbound_media,
-            visible_names=visible_names,
-            thinking=None,
-            streamed=False,
-            react_input_samples=react_input_samples,
-            cache_prompt_tokens=react_cache_prompt_tokens,
-            cache_hit_tokens=react_cache_hit_tokens,
-            cache_seen=react_cache_seen,
-            tools_unlocked=tools_unlocked,
-            model_usages=react_usages,
-            finish_reasons=react_finish_reasons,
-            mobile_attention=mobile_attention,
-        )
+    @staticmethod
+    async def _seal_turn_input_source(source: TurnInputSource | None) -> None:
+        """在提交最终候选前封口 active attempt。"""
+
+        if source is not None:
+            await source.seal()
+
+    def _append_turn_inputs(
+        self,
+        messages: list[dict[str, Any]],
+        inputs: tuple[TurnUserInput, ...],
+    ) -> None:
+        """使用首条消息相同的 envelope 追加有序用户输入。"""
+
+        if not inputs:
+            return
+        if self._context is None:
+            raise RuntimeError("logical interaction input requires ContextBuilder")
+        for item in inputs:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": self._context.build_user_message_content(
+                        item.content,
+                        list(item.media) if item.media else None,
+                        message_timestamp=item.timestamp,
+                    ),
+                }
+            )
 
     async def _observe_tool_call_started(
         self,
@@ -2252,7 +2440,9 @@ class DefaultReasoner(Reasoner):
             "iteration_count": len(react_input_samples),
             "turn_input_sum_tokens": sum(react_input_samples),
             "turn_input_peak_tokens": max(react_input_samples, default=0),
-            "final_call_input_tokens": react_input_samples[-1] if react_input_samples else 0,
+            "final_call_input_tokens": (
+                react_input_samples[-1] if react_input_samples else 0
+            ),
         }
         if cache_seen:
             react_stats["cache_prompt_tokens"] = cache_prompt_tokens
@@ -2284,9 +2474,7 @@ class DefaultReasoner(Reasoner):
             "tools_unlocked": list(tools_unlocked or []),
             "tool_chain": list(tool_chain),
             "react_compaction": (
-                dict(react_compaction)
-                if react_compaction is not None
-                else None
+                dict(react_compaction) if react_compaction is not None else None
             ),
             "media": list(media),
             "visible_names": set(visible_names) if visible_names is not None else None,
@@ -2380,6 +2568,77 @@ class DefaultReasoner(Reasoner):
 # ── 模块级辅助函数 ──────────────────────────────────────────────
 
 
+def _query_compaction_seed(
+    messages: list[dict[str, Any]],
+    attempt_replay: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]], str | None]:
+    """把中断重放拆成可压缩的闭合工具组，并锚定完整 logical query。"""
+
+    # 1. 从最终 prompt 中精确定位 runtime 注入的连续 replay 区间。
+    if not attempt_replay:
+        return list(messages), [], None
+    replay_size = len(attempt_replay)
+    candidates = [
+        index
+        for index in range(len(messages) - replay_size + 1)
+        if messages[index : index + replay_size] == attempt_replay
+    ]
+    if not candidates:
+        raise RuntimeError("control attempt replay 未出现在最终模型 prompt 中")
+    replay_start = candidates[-1]
+    replay_end = replay_start + replay_size
+
+    # 2. 每个 assistant tool-call 与其完整 tool result 闭合为一个原子批次。
+    batches: list[list[dict[str, Any]]] = []
+    batch_start = 0
+    cursor = 0
+    while cursor < replay_size:
+        message = attempt_replay[cursor]
+        raw_calls = message.get("tool_calls")
+        if message.get("role") != "assistant" or not isinstance(raw_calls, list):
+            cursor += 1
+            continue
+        call_ids = {
+            str(call.get("id"))
+            for call in raw_calls
+            if isinstance(call, dict) and isinstance(call.get("id"), str)
+        }
+        if not call_ids or len(call_ids) != len(raw_calls):
+            raise RuntimeError("control attempt replay tool call identity 无效")
+        result_ids: set[str] = set()
+        batch_end = cursor + 1
+        while batch_end < replay_size:
+            result = attempt_replay[batch_end]
+            if result.get("role") != "tool":
+                break
+            result_id = result.get("tool_call_id")
+            if not isinstance(result_id, str):
+                raise RuntimeError("control attempt replay tool result identity 无效")
+            result_ids.add(result_id)
+            batch_end += 1
+        if result_ids != call_ids:
+            raise RuntimeError("control attempt replay 包含未闭合的工具调用")
+        batches.append(list(attempt_replay[batch_start:batch_end]))
+        batch_start = batch_end
+        cursor = batch_end
+
+    # 3. 摘要显式携带本 interaction 的全部 U；末尾未闭合片段保持原文热可见。
+    interaction_inputs = [
+        message.get("content")
+        for message in [*attempt_replay, *messages[replay_end:]]
+        if message.get("role") == "user"
+        and not (
+            isinstance(message.get("content"), str)
+            and is_context_frame(cast(str, message["content"]))
+        )
+    ]
+    current_query = json.dumps(
+        {"logical_interaction_inputs": interaction_inputs},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return list(messages[:replay_start]), batches, current_query
+
 
 def get_history_since_consolidated(
     session: "SessionLike",
@@ -2397,9 +2656,7 @@ def extract_model_facing_turn(
     if not messages:
         return None, None
     user_content = (
-        messages[-1].get("content")
-        if messages[-1].get("role") == "user"
-        else None
+        messages[-1].get("content") if messages[-1].get("role") == "user" else None
     )
     if len(messages) < 2:
         return user_content, None
@@ -2460,7 +2717,7 @@ def build_deferred_tools_hint(
     total = len(builtin) + sum(len(v) for v in mcp.values())
     lines.append(
         f"\n共 {total} 个。加载方式：\n"
-        "- 已知工具名 → tool_search(query=\"select:工具名\")，支持逗号分隔多个\n"
-        "- 描述功能   → tool_search(query=\"关键词\") 搜索匹配"
+        '- 已知工具名 → tool_search(query="select:工具名")，支持逗号分隔多个\n'
+        '- 描述功能   → tool_search(query="关键词") 搜索匹配'
     )
     return "\n".join(lines) + "\n\n"

--- a/agent/lifecycle/phases/after_reasoning.py
+++ b/agent/lifecycle/phases/after_reasoning.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from agent.core.passive_support import update_session_runtime_metadata
+from agent.control.ports import TurnInputSource, TurnUserInput
 from agent.core.response_parser import parse_response
 from agent.lifecycle.phase import (
     PhaseFrame,
@@ -72,6 +73,11 @@ class _BuildAfterReasoningCtxModule:
         turn_result = input.turn_result
         inbound_metadata = dict(msg.metadata or {})
         inbound_metadata.pop("mobile_attention", None)
+        inbound_metadata.pop("_control_turn_input_source", None)
+        inbound_metadata.pop("_control_attempt_replay", None)
+        inbound_metadata.pop("_control_prior_tool_chain", None)
+        inbound_metadata.pop("_control_prior_input_count", None)
+        inbound_metadata.pop("_control_execution_turn_id", None)
         raw_reply = turn_result.reply
         if raw_reply is None:
             raw_reply = "I've completed processing but have no response to give."
@@ -147,26 +153,43 @@ class _PersistUserMessageModule:
         llm_context_frame = ctx.context_retry.get("llm_context_frame")
         if isinstance(llm_context_frame, str) and llm_context_frame.strip():
             user_kwargs["llm_context_frame"] = llm_context_frame
-        user_kwargs.update(_collect_persist_user_slots(frame.slots))
-        if (msg.metadata or {}).get("skip_post_memory") is True:
-            user_kwargs["skip_post_memory"] = True
-        client_message_id = msg.metadata.get("client_message_id")
-        if isinstance(client_message_id, str) and client_message_id:
-            user_kwargs["client_message_id"] = client_message_id
-        client_created_at = msg.metadata.get("client_created_at")
-        if isinstance(client_created_at, str) and client_created_at:
-            user_kwargs["timestamp"] = client_created_at
-        for field in ("reply_to_message_id", "reply_role", "reply_preview"):
-            value = msg.metadata.get(field)
-            if isinstance(value, str) and value:
-                user_kwargs[field] = value
-        display_content = msg.metadata.get("display_content")
-        frame.slots[_PERSISTED_USER_SLOT] = session.add_message(
-            "user",
-            display_content if isinstance(display_content, str) else msg.content,
-            media=msg.media if msg.media else None,
-            **user_kwargs,
-        )
+        shared_user_kwargs = _collect_persist_user_slots(frame.slots)
+        control_turn_id = str(msg.metadata.get("control_turn_id") or "")
+        persisted_users: list[dict[str, Any]] = []
+        for index, turn_input in enumerate(_turn_user_inputs(msg)):
+            input_kwargs = dict(user_kwargs) if index == 0 else {}
+            if index == 0:
+                input_kwargs.update(shared_user_kwargs)
+            input_kwargs["timestamp"] = turn_input.timestamp.isoformat()
+            input_kwargs["turn_input_ordinal"] = turn_input.ordinal
+            if control_turn_id:
+                input_kwargs["control_turn_id"] = control_turn_id
+            if turn_input.metadata.get("skip_post_memory") is True:
+                input_kwargs["skip_post_memory"] = True
+            for field in (
+                "client_message_id",
+                "client_created_at",
+                "reply_to_message_id",
+                "reply_role",
+                "reply_preview",
+            ):
+                value = turn_input.metadata.get(field)
+                if isinstance(value, str) and value:
+                    input_kwargs[
+                        "timestamp" if field == "client_created_at" else field
+                    ] = value
+            display_content = turn_input.metadata.get("display_content")
+            persisted_users.append(
+                session.add_message(
+                    "user",
+                    display_content
+                    if isinstance(display_content, str)
+                    else turn_input.content,
+                    media=list(turn_input.media) if turn_input.media else None,
+                    **input_kwargs,
+                )
+            )
+        frame.slots[_PERSISTED_USER_SLOT] = persisted_users
         return frame
 
 
@@ -197,7 +220,18 @@ class _PersistAssistantMessageModule:
                 frame.input.turn_result.react_compaction
             )
         assistant_kwargs.update(_collect_persist_assistant_slots(frame.slots))
-        if (frame.input.state.msg.metadata or {}).get("skip_post_memory") is True:
+        turn_inputs = _turn_user_inputs(frame.input.state.msg)
+        control_turn_id = str(
+            frame.input.state.msg.metadata.get("control_turn_id") or ""
+        )
+        if control_turn_id and frame.input.state.persistence.persist_user:
+            assistant_kwargs["control_turn_id"] = control_turn_id
+            assistant_kwargs["turn_terminal"] = True
+            assistant_kwargs["turn_input_count"] = len(turn_inputs)
+        if any(
+            turn_input.metadata.get("skip_post_memory") is True
+            for turn_input in turn_inputs
+        ):
             assistant_kwargs["skip_post_memory"] = True
         if frame.input.state.persistence.persist_assistant:
             media = list(ctx.media)
@@ -247,8 +281,8 @@ class _AppendMessagesModule:
         session = cast("Session", raw_session)
         messages: list[dict[str, Any]] = []
         if state.persistence.persist_user:
-            messages.append(
-                cast(dict[str, Any], frame.slots[_PERSISTED_USER_SLOT])
+            messages.extend(
+                cast(list[dict[str, Any]], frame.slots[_PERSISTED_USER_SLOT])
             )
         if state.persistence.persist_assistant:
             messages.append(
@@ -273,10 +307,22 @@ class _BuildOutboundMessageModule:
         metadata = dict(ctx.outbound_metadata)
         metadata.update(collect_prefixed_slots(frame.slots, _OUTBOUND_METADATA_PREFIX))
         if frame.input.state.persistence.persist_user:
-            persisted_user = cast(
-                dict[str, object],
+            persisted_users = cast(
+                list[dict[str, object]],
                 frame.slots[_PERSISTED_USER_SLOT],
             )
+            if not persisted_users:
+                raise RuntimeError("本轮 user 消息列表为空")
+            persisted_user = persisted_users[0]
+            persisted_user_ids = [
+                str(item["id"])
+                for item in persisted_users
+                if isinstance(item.get("id"), str) and item["id"]
+            ]
+            if len(persisted_user_ids) == len(persisted_users):
+                metadata["persisted_user_message_ids"] = persisted_user_ids
+            elif ctx.channel == "mobile":
+                raise RuntimeError("本轮 user 消息缺少稳定 ID")
             raw_user_message_id = persisted_user.get("id")
             raw_client_message_id = persisted_user.get("client_message_id")
             if isinstance(raw_user_message_id, str) and raw_user_message_id:
@@ -310,6 +356,29 @@ class _BuildOutboundMessageModule:
             session_message_id=session_message_id,
         )
         return frame
+
+
+def _turn_user_inputs(msg: object) -> tuple[TurnUserInput, ...]:
+    """读取 sealed control source；普通内部 turn 投影为单条输入。"""
+
+    metadata = getattr(msg, "metadata", None) or {}
+    raw_source = metadata.get("_control_turn_input_source")
+    if raw_source is not None:
+        source = cast(TurnInputSource, raw_source)
+        inputs = source.consumed_inputs()
+        if not inputs:
+            raise RuntimeError("sealed control turn 缺少用户输入")
+        return inputs
+    return (
+        TurnUserInput(
+            item_id="direct",
+            ordinal=0,
+            content=str(getattr(msg, "content")),
+            media=tuple(getattr(msg, "media", ()) or ()),
+            metadata=dict(metadata),
+            timestamp=getattr(msg, "timestamp"),
+        ),
+    )
 
 
 class _ReturnAfterReasoningResultModule:

--- a/agent/lifecycle/phases/after_turn.py
+++ b/agent/lifecycle/phases/after_turn.py
@@ -12,6 +12,7 @@ from agent.core.passive_support import (
     log_react_context_budget,
 )
 from agent.control.context import current_turn_id
+from agent.control.ports import TurnInputSource
 from agent.core.types import to_tool_call_groups
 from agent.lifecycle.phase import (
     PhaseFrame,
@@ -123,12 +124,36 @@ class _BuildTurnCommittedModule:
             else None
         )
         raw_user_message_id = snap.outbound.metadata.get("persisted_user_message_id")
+        raw_user_message_ids = snap.outbound.metadata.get(
+            "persisted_user_message_ids"
+        )
+        persisted_user_message_ids = (
+            tuple(cast(list[str], raw_user_message_ids))
+            if isinstance(raw_user_message_ids, list)
+            and all(isinstance(item, str) and item for item in raw_user_message_ids)
+            else ()
+        )
+        raw_source = msg.metadata.get("_control_turn_input_source")
+        input_messages = [msg.content]
+        skip_post_memory = (msg.metadata or {}).get("skip_post_memory") is True
+        if raw_source is not None:
+            inputs = cast(TurnInputSource, raw_source).consumed_inputs()
+            input_messages = [item.content for item in inputs]
+            skip_post_memory = any(
+                item.metadata.get("skip_post_memory") is True for item in inputs
+            )
+        aggregate_input = "\n\n".join(input_messages)
+        extra = dict(cast(dict[str, object], frame.slots[_EXTRA_SLOT]))
+        if skip_post_memory:
+            extra["skip_post_memory"] = True
         frame.slots[_TURN_COMMITTED_SLOT] = TurnCommitted(
             session_key=state.session_key,
             channel=msg.channel,
             chat_id=msg.chat_id,
-            input_message=msg.content,
-            persisted_user_message=msg.content if persistence.persist_user else None,
+            input_message=aggregate_input,
+            persisted_user_message=(
+                aggregate_input if persistence.persist_user else None
+            ),
             assistant_response=snap.ctx.reply,
             tools_used=list(snap.ctx.tools_used),
             turn_id=current_turn_id.get(),
@@ -137,6 +162,7 @@ class _BuildTurnCommittedModule:
                 if isinstance(raw_user_message_id, str) and raw_user_message_id
                 else None
             ),
+            persisted_user_message_ids=persisted_user_message_ids,
             assistant_message_id=snap.outbound.session_message_id,
             thinking=snap.ctx.thinking,
             raw_reply=snap.ctx.response_metadata.raw_text,
@@ -147,7 +173,7 @@ class _BuildTurnCommittedModule:
             timestamp=msg.timestamp,
             post_reply_budget=dict(cast(dict[str, int], frame.slots[_BUDGET_SLOT])),
             react_stats=dict(cast(dict[str, int], frame.slots[_REACT_STATS_SLOT])),
-            extra=dict(cast(dict[str, object], frame.slots[_EXTRA_SLOT])),
+            extra=extra,
             model_usage=(
                 dict(raw_model_usage) if isinstance(raw_model_usage, dict) else {}
             ),

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -16,6 +16,7 @@ from agent.lifecycle.phase import (
 )
 from agent.lifecycle.types import BeforeTurnCtx, TurnState
 from session.memory_policy import excludes_memory
+from session.manager import logical_history_unit_count
 
 if TYPE_CHECKING:
     from agent.core.passive_turn import ContextStore
@@ -60,7 +61,9 @@ class _AcquireSessionModule:
 
     async def run(self, frame: BeforeTurnFrame) -> BeforeTurnFrame:
         state = frame.input
-        require_existing = state.msg.metadata.pop("require_existing_session", False) is True
+        require_existing = (
+            state.msg.metadata.pop("require_existing_session", False) is True
+        )
         session = (
             self._session_manager.get_existing(state.session_key)
             if require_existing
@@ -145,7 +148,7 @@ class _MemoryContextGuardModule:
             getattr(session, "last_consolidated", 0),
             len(messages),
         )
-        pending = len(messages) - last
+        pending = logical_history_unit_count(messages, start_index=last)
         if pending < self._threshold:
             return frame
 

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -711,7 +711,11 @@ class AgentLoop:
         # 给本 turn task 打上 session 归属，供 observe 全局错误采集关联。
         session_token = current_session_key.set(key)
         inherited_turn_id = (
-            str(msg.metadata.get("control_turn_id") or "")
+            str(
+                msg.metadata.get("_control_execution_turn_id")
+                or msg.metadata.get("control_turn_id")
+                or ""
+            )
             if isinstance(msg, InboundMessage)
             else ""
         )
@@ -907,13 +911,27 @@ class AgentLoop:
         sender: str = "user",
         media: list[str] | None = None,
         metadata: dict[str, object] | None = None,
+        turn_input_source: object | None = None,
+        timestamp: datetime | None = None,
         turn_id: str = "",
+        interaction_id: str = "",
+        attempt_replay: list[dict[str, Any]] | None = None,
+        prior_tool_chain: list[dict[str, Any]] | None = None,
+        prior_input_count: int = 0,
         stateless: bool = False,
         runtime_selector: RuntimeSelector = "stable",
     ) -> OutboundMessage:
         """执行直接消息，并按需隔离会话历史与持久化。"""
 
         inbound_metadata = dict(metadata or {})
+        if turn_input_source is not None:
+            inbound_metadata["_control_turn_input_source"] = turn_input_source
+        if attempt_replay:
+            inbound_metadata["_control_attempt_replay"] = list(attempt_replay)
+        if prior_tool_chain:
+            inbound_metadata["_control_prior_tool_chain"] = list(prior_tool_chain)
+        if prior_input_count:
+            inbound_metadata["_control_prior_input_count"] = prior_input_count
         if stateless:
             inbound_metadata.update(
                 {
@@ -936,7 +954,8 @@ class AgentLoop:
         if disabled_tools:
             inbound_metadata["disabled_tools"] = list(disabled_tools)
         if turn_id:
-            inbound_metadata["control_turn_id"] = turn_id
+            inbound_metadata["control_turn_id"] = interaction_id or turn_id
+            inbound_metadata["_control_execution_turn_id"] = turn_id
         msg = InboundMessage(
             channel=channel,
             sender=sender,
@@ -944,6 +963,7 @@ class AgentLoop:
             content=content,
             media=list(media or []),
             metadata=inbound_metadata,
+            timestamp=timestamp or datetime.now().astimezone(),
         )
         response = await self._process_with_runtime_admission(
             msg,

--- a/agent/model_runtime/query_compaction.py
+++ b/agent/model_runtime/query_compaction.py
@@ -43,6 +43,7 @@ _SUMMARY_PROMPT = """更新当前长任务的上下文压缩摘要。
 
 保留文件路径、符号、命令、错误、数值和验证结果。若输入中存在仍在运行的 shell execution，必须保留 execution_id、命令和当前状态。省略重复探索、无用日志、tool_call_id 和其他协议细节。只输出摘要正文。"""
 
+
 class ContextCompactionError(RuntimeError):
     """当前 query 无法生成可继续执行的有界上下文。"""
 
@@ -250,14 +251,32 @@ class QueryCompactor:
         model: str,
         base_messages: list[dict],
         scope_id: str,
+        completed_batches: list[list[dict]] | None = None,
+        current_query: object | None = None,
     ) -> None:
         self._provider = provider
         self._model = model
         self._base_messages = [_copy_message(message) for message in base_messages]
         self._scope_id = scope_id
-        self._completed_batches: list[list[dict]] = []
+        self._completed_batches = [
+            [_copy_message(message) for message in batch]
+            for batch in completed_batches or []
+        ]
+        self._current_query = (
+            _bounded_text(current_query, _MESSAGE_SUMMARY_CHAR_LIMIT)
+            if current_query is not None
+            else _find_current_query(self._base_messages)
+        )
         self._compaction: ReactCompaction | None = None
         self._meter = _ContextTokenMeter()
+
+    @property
+    def pending_start(self) -> int:
+        """返回初始消息中尚未闭合为 tool batch 的起点。"""
+
+        return len(self._base_messages) + sum(
+            len(batch) for batch in self._completed_batches
+        )
 
     @property
     def compaction(self) -> ReactCompaction | None:
@@ -416,11 +435,10 @@ class QueryCompactor:
         """Generate one structured handoff from previous summary and evicted batches."""
 
         # 1. 序列化受控输入，避免单个工具结果占满 summary 请求。
-        current_query = _find_current_query(self._base_messages)
         sections = [
             _SUMMARY_PROMPT,
             "\n[Current user query]\n",
-            current_query,
+            self._current_query,
         ]
         if self._compaction is not None:
             sections.extend(
@@ -453,9 +471,7 @@ class QueryCompactor:
             if summary and not response.tool_calls:
                 return summary, aggregate_usage(usages) if usages else None
             if attempt < _SUMMARY_MAX_RETRIES:
-                await asyncio.sleep(
-                    _SUMMARY_RETRY_BASE_DELAY_SECONDS * (2**attempt)
-                )
+                await asyncio.sleep(_SUMMARY_RETRY_BASE_DELAY_SECONDS * (2**attempt))
 
         raise ContextCompactionError("context_compaction_summary_invalid")
 

--- a/bootstrap/control_execution.py
+++ b/bootstrap/control_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
+from datetime import datetime
 
 import openai
 
@@ -41,6 +42,7 @@ async def execute_control_turn(
     """执行正式被动 turn，并把工具与用量投影到控制面结果。"""
 
     turn_id = str(request.metadata["turnId"])
+    interaction_id = str(request.metadata.get("interactionId") or turn_id)
     completed_items: list[TurnItem] = []
     tool_item_ids: dict[str, str] = {}
     invalid_tool_events: list[str] = []
@@ -99,6 +101,12 @@ async def execute_control_turn(
     delta_subscription = event_bus.on(StreamDeltaReady, collect_delta)
     try:
         try:
+            inbound_metadata = _inbound_metadata(
+                request.metadata.get("inboundMetadata")
+            )
+            input_source = request.metadata.get("_controlTurnInputSource")
+            if input_source is None:
+                raise RuntimeError("control executor 缺少 turn input source")
             outbound = await loop.process_direct_message(
                 request.input,
                 session_key=request.thread_id,
@@ -106,8 +114,20 @@ async def execute_control_turn(
                 chat_id=str(request.metadata.get("chatId") or request.thread_id),
                 sender=str(request.metadata.get("sender") or "user"),
                 media=_media_values(request.metadata.get("media")),
-                metadata=_inbound_metadata(request.metadata.get("inboundMetadata")),
+                metadata=inbound_metadata,
+                turn_input_source=input_source,
+                timestamp=_input_timestamp(request.metadata.get("inputTimestamp")),
                 turn_id=turn_id,
+                interaction_id=interaction_id,
+                attempt_replay=_attempt_replay(
+                    request.metadata.get("_controlAttemptReplay")
+                ),
+                prior_tool_chain=_prior_tool_chain(
+                    request.metadata.get("_controlPriorToolChain")
+                ),
+                prior_input_count=_prior_input_count(
+                    request.metadata.get("priorInputCount")
+                ),
                 stream_events=True,
                 runtime_selector=cast(
                     RuntimeSelector,
@@ -188,8 +208,33 @@ def _tool_item(event: ToolCallCompleted, item_id: str) -> TurnItem:
             "arguments": dict(event.final_arguments),
             "status": event.status,
             "resultPreview": event.result_preview,
+            "iteration": event.iteration,
         },
     )
+
+
+def _attempt_replay(value: object) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise ValueError("control attempt replay 必须是对象数组")
+    return [dict(cast(dict[str, Any], item)) for item in value]
+
+
+def _prior_tool_chain(value: object) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise ValueError("control prior tool chain 必须是对象数组")
+    return [dict(cast(dict[str, Any], item)) for item in value]
+
+
+def _prior_input_count(value: object) -> int:
+    if value is None:
+        return 0
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("control prior input count 必须是非负整数")
+    return value
 
 
 def _media_values(value: object) -> list[str]:
@@ -208,6 +253,17 @@ def _inbound_metadata(value: object) -> dict[str, object]:
     if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
         raise ValueError("control inboundMetadata 必须是字符串键对象")
     return dict(cast(dict[str, object], value))
+
+
+def _input_timestamp(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("control inputTimestamp 必须是 RFC 3339 字符串")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("control inputTimestamp 必须包含时区")
+    return parsed
 
 
 def _turn_usage(value: dict[str, Any]) -> TurnUsage | None:

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from agent.control.errors import RuntimeClosedError, ThreadBusyError
 from agent.control.models import TurnRequest, TurnStatus
-from agent.control.runtime import ConversationRuntime
+from agent.control.runtime import ConversationRuntime, TurnHandle
 from agent.looping.core import AgentLoop
 from bus.events import InboundMessage, OutboundMessage
 from bus.queue import MessageBus
@@ -17,13 +17,16 @@ logger = logging.getLogger(__name__)
 class PassiveMessageWorker:
     """把渠道入站消息转换为 ConversationRuntime turn。"""
 
-    def __init__(self, bus: MessageBus, runtime: ConversationRuntime, legacy_loop: AgentLoop) -> None:
+    def __init__(
+        self, bus: MessageBus, runtime: ConversationRuntime, legacy_loop: AgentLoop
+    ) -> None:
         self._bus = bus
         self._runtime = runtime
         self._legacy_loop = legacy_loop
         self._running = False
         self._lane_queues: dict[str, asyncio.Queue[InboundMessage | object]] = {}
         self._lane_tasks: dict[str, asyncio.Task[None]] = {}
+        self._result_tasks: set[asyncio.Task[None]] = set()
 
     async def run(self) -> None:
         self._running = True
@@ -32,7 +35,9 @@ class PassiveMessageWorker:
             await self._bus.recover_durable_inbounds()
             while self._running:
                 try:
-                    item = await asyncio.wait_for(self._bus.consume_inbound(), timeout=1.0)
+                    item = await asyncio.wait_for(
+                        self._bus.consume_inbound(), timeout=1.0
+                    )
                 except asyncio.TimeoutError:
                     continue
                 self._enqueue(item)
@@ -47,6 +52,11 @@ class PassiveMessageWorker:
                 )
             self._lane_tasks.clear()
             self._lane_queues.clear()
+            for task in tuple(self._result_tasks):
+                task.cancel()
+            if self._result_tasks:
+                await asyncio.gather(*tuple(self._result_tasks), return_exceptions=True)
+            self._result_tasks.clear()
 
     def _enqueue(self, item: object) -> None:
         key = cast(Any, item).session_key
@@ -70,7 +80,7 @@ class PassiveMessageWorker:
             item = await queue.get()
             try:
                 if isinstance(item, InboundMessage):
-                    await self._run_message(item)
+                    await self._admit_message(item)
                 else:
                     await self._legacy_loop._run_inbound_turn(cast(Any, item))
             except asyncio.CancelledError:
@@ -85,16 +95,27 @@ class PassiveMessageWorker:
                 return
 
     async def _run_message(self, item: InboundMessage) -> None:
-        """执行一条渠道消息，并始终完成 MessageBus 入站确认。"""
+        """兼容直接调用：等待由本条消息新建的 turn 完成。"""
+
+        result_task = await self._admit_message(item)
+        if result_task is not None:
+            await result_task
+
+    async def _admit_message(
+        self,
+        item: InboundMessage,
+    ) -> asyncio.Task[None] | None:
+        """快速准入渠道消息，并把唯一终态发送职责交给新 turn owner。"""
 
         # 1. canonical 用户消息证明该 handoff 已进入过 turn。
         if self._is_recovered_mobile_duplicate(item):
             await self._bus.complete_inbound(item)
             return
         if item.channel == "mobile" and item.session_admission_id is None:
-            _, item.session_admission_id = self._legacy_loop.session_manager.admit_existing(
-                item.session_key
+            _, item.session_admission_id = (
+                self._legacy_loop.session_manager.admit_existing(item.session_key)
             )
+        transferred = False
         try:
             # 2. 渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
             request = TurnRequest(
@@ -105,14 +126,15 @@ class PassiveMessageWorker:
                     "chatId": item.chat_id,
                     "sender": item.sender,
                     "media": list(item.media),
+                    "inputTimestamp": item.timestamp.isoformat(),
                     "inboundMetadata": dict(item.metadata),
                 },
             )
             while True:
-                await self._runtime.wait_thread_available(item.session_key)
                 try:
                     handle = await self._runtime.start_turn(request)
                 except ThreadBusyError:
+                    await self._runtime.wait_thread_available(item.session_key)
                     continue
                 except RuntimeClosedError:
                     await self._bus.publish_outbound(
@@ -124,12 +146,28 @@ class PassiveMessageWorker:
                     )
                     return
                 break
-            result = await handle.result()
+            task = asyncio.create_task(
+                self._finish_message(item, handle),
+                name=f"passive-result:{handle.id}",
+            )
+            self._result_tasks.add(task)
+            task.add_done_callback(self._result_tasks.discard)
+            transferred = True
+            return task
+        finally:
+            if not transferred:
+                await self._complete_message(item)
 
-            # 3. channel adapter 在领域终态外层映射用户安全文案。
+    async def _finish_message(self, item: InboundMessage, handle: TurnHandle) -> None:
+        """等待新 turn 的唯一终态并发送一次 outbound。"""
+
+        try:
+            result = await handle.result()
             if result.status is TurnStatus.COMPLETED:
                 assistant = next(
-                    entry for entry in reversed(result.items) if entry.kind.value == "assistantMessage"
+                    entry
+                    for entry in reversed(result.items)
+                    if entry.kind.value == "assistantMessage"
                 )
                 data = assistant.data
                 outbound = OutboundMessage(
@@ -153,13 +191,18 @@ class PassiveMessageWorker:
                 return
             await self._bus.publish_outbound(outbound)
         finally:
-            try:
-                await self._bus.complete_inbound(item)
-            finally:
-                if item.session_admission_id is not None:
-                    self._legacy_loop.session_manager.release_admission(
-                        item.session_admission_id
-                    )
+            await self._complete_message(item)
+
+    async def _complete_message(self, item: InboundMessage) -> None:
+        """确认 durable inbound 并释放 mobile session admission。"""
+
+        try:
+            await self._bus.complete_inbound(item)
+        finally:
+            if item.session_admission_id is not None:
+                self._legacy_loop.session_manager.release_admission(
+                    item.session_admission_id
+                )
 
     def _is_recovered_mobile_duplicate(self, item: InboundMessage) -> bool:
         """识别 canonical 用户消息已存在的移动 handoff，避免重复 turn。"""
@@ -169,11 +212,19 @@ class PassiveMessageWorker:
         client_message_id = item.metadata.get("client_message_id")
         if not isinstance(client_message_id, str) or not client_message_id:
             return False
-        message = self._legacy_loop.session_manager.control_store.get_message_by_client_id(
-            item.session_key,
-            client_message_id,
+        message = (
+            self._legacy_loop.session_manager.control_store.get_message_by_client_id(
+                item.session_key,
+                client_message_id,
+            )
         )
-        return message is not None
+        return (
+            message is not None
+            or self._legacy_loop.session_manager.control_store.has_turn_user_input_by_client_id(
+                item.session_key,
+                client_message_id,
+            )
+        )
 
     def stop(self) -> None:
         self._running = False

--- a/bus/events_lifecycle.py
+++ b/bus/events_lifecycle.py
@@ -39,6 +39,7 @@ class TurnCommitted:
     tools_used: list[str]
     turn_id: str = ""
     persisted_user_message_id: str | None = None
+    persisted_user_message_ids: tuple[str, ...] = ()
     assistant_message_id: str | None = None
     thinking: str | None = None
     raw_reply: str | None = None

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -66,7 +66,7 @@ python docker/debug/programmatic_control_probe.py --gate soak
 
 当前基建实现 `smoke`、PR 必选的 `failure-matrix` 和 nightly/release `soak`。`smoke`
 覆盖 UDS/stdio、基本 turn，以及 streaming/tool/usage 的事件与 DB 一致性；
-`failure-matrix` 覆盖双连接隔离、同 thread 冲突、精确中断、断线恢复、慢客户端背压、
+`failure-matrix` 覆盖双连接隔离、同 thread active-start busy、精确中断、断线恢复、慢客户端背压、
 provider 分类、非法协议、Web channel parity、workspace lock、SIGTERM 和 crash/restart。
 `soak` 执行 10 次预热与 100 次混合 turn，包含 10 次 reconnect、interrupt 和 provider
 failure，并检查 RSS、fd、线程与 DB 非终态阈值。

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -267,8 +267,15 @@ def _turn_projection(turn: dict[str, Any]) -> dict[str, object]:
         if not isinstance(raw_item, dict):
             raise GateFailure(f"turn item 非对象：{raw_item!r}")
         data = raw_item.get("data")
-        if raw_item.get("type") == "assistantMessage" and isinstance(data, dict):
+        if isinstance(data, dict):
             data = dict(data)
+            data.pop("timestamp", None)
+            metadata = data.get("metadata")
+            if isinstance(metadata, dict):
+                stable_metadata = dict(metadata)
+                stable_metadata.pop("client_request_id", None)
+                data["metadata"] = stable_metadata
+        if raw_item.get("type") == "assistantMessage" and isinstance(data, dict):
             session_message_id = data.get("sessionMessageId")
             if isinstance(session_message_id, str):
                 data["sessionMessageId"] = "<session-message-id>"
@@ -287,6 +294,11 @@ def _turn_projection(turn: dict[str, Any]) -> dict[str, object]:
                     stable_metadata["persisted_user_message_id"] = (
                         "<persisted-user-message-id>"
                     )
+                persisted_ids = stable_metadata.get("persisted_user_message_ids")
+                if isinstance(persisted_ids, list):
+                    stable_metadata["persisted_user_message_ids"] = [
+                        "<persisted-user-message-id>" for _ in persisted_ids
+                    ]
                 data["metadata"] = stable_metadata
         items.append({"type": raw_item.get("type"), "data": data})
     error = turn.get("error")
@@ -385,6 +397,50 @@ def _wait_database_turn_status(
     raise GateFailure(
         f"等待 channel turn 状态超时：thread={thread_id} input={input_text!r} "
         f"expected={sorted(expected)} actual={last_status}"
+    )
+
+
+def _wait_database_turn_inputs(
+    database: Path,
+    thread_id: str,
+    input_text: str,
+    expected_count: int,
+    *,
+    timeout: float = SCENARIO_DEADLINE_S,
+) -> dict[str, object]:
+    """等待 active channel turn 持久化指定数量的有序 user item。"""
+
+    deadline = time.monotonic() + timeout
+    last_inputs: list[object] = []
+    while time.monotonic() < deadline:
+        with sqlite3.connect(database) as connection:
+            connection.row_factory = sqlite3.Row
+            row = connection.execute(
+                """
+                SELECT id, status, items_json
+                FROM turns
+                WHERE session_key = ? AND json_extract(input_json, '$.input') = ?
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                (thread_id, input_text),
+            ).fetchone()
+        if row is not None:
+            items = json.loads(row["items_json"])
+            last_inputs = [
+                item.get("data", {}).get("content")
+                for item in items
+                if isinstance(item, dict) and item.get("type") == "userMessage"
+            ]
+            if len(last_inputs) == expected_count:
+                return {
+                    "id": row["id"],
+                    "status": row["status"],
+                    "userInputs": last_inputs,
+                }
+        threading.Event().wait(0.02)
+    raise GateFailure(
+        f"等待 channel turn 输入超时：thread={thread_id} input={input_text!r} "
+        f"expected_count={expected_count} actual={last_inputs!r}"
     )
 
 
@@ -835,9 +891,9 @@ def _inside_memory_context(report_dir: Path) -> int:
         model_requests = _model_requests(
             _http_json("GET", f"{model_url}/control/requests")
         )
-        recent_context = Path(
-            "/sandbox/workspace/memory/RECENT_CONTEXT.md"
-        ).read_text(encoding="utf-8")
+        recent_context = Path("/sandbox/workspace/memory/RECENT_CONTEXT.md").read_text(
+            encoding="utf-8"
+        )
         passed = (
             isinstance(completed_operation, dict)
             and completed_operation.get("id") == operation.get("id")
@@ -911,9 +967,7 @@ def _inside_memory_context(report_dir: Path) -> int:
                 {
                     "terminal": retry_payload,
                     "messageCount": retry_message_count,
-                    "lastConsolidated": (
-                        None if retry_row is None else retry_row[0]
-                    ),
+                    "lastConsolidated": (None if retry_row is None else retry_row[0]),
                     "modelRequestCount": len(final_requests),
                 },
             )
@@ -1005,16 +1059,16 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             )
         )
 
-        # 2. 同 thread 的第二个 start 必须稳定返回 -32011。
+        # 2. 同 thread 的第二个 start 必须明确 busy，不能注入 owner turn。
         _create_barrier(
             model_url,
             "thread-conflict",
-            {"mode": "complete", "content": "conflict owner"},
+            {"mode": "complete", "content": "intermediate candidate"},
         )
         conflict_thread = _start_thread(first, "PC-06")
         conflict_turn = _start_turn(first, conflict_thread, "conflict owner")
         _wait_barrier(model_url, "thread-conflict")
-        conflict = first.request_raw(
+        rejected = first.request_raw(
             "turn/start",
             {
                 "threadId": conflict_thread,
@@ -1024,14 +1078,27 @@ def _inside_failure_matrix(report_dir: Path) -> int:
         )
         _release_barrier(model_url, "thread-conflict")
         conflict_terminal = first.wait_terminal(conflict_turn)
-        conflict_error = conflict.get("error")
+        rejected_error = rejected.get("error")
+        terminal_turn = _event_turn(conflict_terminal)
+        user_inputs = [
+            item.get("data", {}).get("content")
+            for item in terminal_turn.get("items", [])
+            if isinstance(item, dict) and item.get("type") == "userMessage"
+        ]
         checks.append(
             CheckResult(
                 "PC-06",
-                isinstance(conflict_error, dict)
-                and conflict_error.get("code") == -32011
-                and _terminal_status(conflict_terminal) == "completed",
-                {"error": conflict_error, "ownerTerminal": conflict_terminal},
+                isinstance(rejected_error, dict)
+                and rejected_error.get("code") == -32011
+                and rejected_error.get("data") == {"retryable": True}
+                and _terminal_status(conflict_terminal) == "completed"
+                and terminal_turn.get("finalResponse") == "intermediate candidate"
+                and user_inputs == ["conflict owner"],
+                {
+                    "rejected": rejected_error,
+                    "ownerTerminal": conflict_terminal,
+                    "userInputs": user_inputs,
+                },
             )
         )
 
@@ -1085,12 +1152,9 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             {"threadId": interrupt_thread, "turnId": interrupted_turn},
         )
         _ = first.request("server/status", {})
-        interrupted_events = _recorded_turn_notifications(
-            events_path, interrupted_turn
-        )
+        interrupted_events = _recorded_turn_notifications(events_path, interrupted_turn)
         interrupted_terminal_count = sum(
-            event.get("method") == "turn/completed"
-            for event in interrupted_events
+            event.get("method") == "turn/completed" for event in interrupted_events
         )
         _, shell_completed = _tool_lifecycle(interrupted_events, "shell")
         persisted_shell = next(
@@ -1206,9 +1270,7 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             {
                 "id": f"call_pc09_{index}",
                 "name": "tool_search",
-                "arguments": {
-                    "query": f"no-match-pc09-{index}-" + "x" * (32 * 1024)
-                },
+                "arguments": {"query": f"no-match-pc09-{index}-" + "x" * (32 * 1024)},
             }
             for index in range(80)
         ]
@@ -1481,22 +1543,36 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             lane_thread = str(
                 json.loads(lane_web.recv(timeout=SCENARIO_DEADLINE_S))["session_id"]
             )
+            _create_barrier(
+                model_url,
+                "pc16-strict-lane",
+                {"mode": "complete", "content": "order one final"},
+            )
             _http_json(
                 "PUT",
                 f"{model_url}/control/script",
                 [
-                    {"mode": "complete", "content": "ordered one"},
-                    {"mode": "complete", "content": "ordered two"},
-                    # 当前 provider 会执行首次请求和三次重试，失败 turn 必须全部耗尽。
-                    *[{"mode": "error", "status": 500} for _ in range(4)],
-                    {"mode": "complete", "content": "recovered"},
+                    {"mode": "complete", "content": "order two final"},
+                    {"mode": "complete", "content": "order three final"},
+                    {"mode": "complete", "content": "order four final"},
                 ],
             )
+            lane_web.send(
+                json.dumps(
+                    {
+                        "type": "message.send",
+                        "request_id": "pc16-order-1",
+                        "session_id": lane_thread,
+                        "text": "order one",
+                        "media": [],
+                    }
+                )
+            )
+            _wait_barrier(model_url, "pc16-strict-lane")
             for request_id, text in (
-                ("pc16-order-1", "order one"),
                 ("pc16-order-2", "order two"),
-                ("pc16-fail", "lane failure"),
-                ("pc16-recover", "lane recovery"),
+                ("pc16-order-3", "order three"),
+                ("pc16-order-4", "order four"),
             ):
                 lane_web.send(
                     json.dumps(
@@ -1509,19 +1585,70 @@ def _inside_failure_matrix(report_dir: Path) -> int:
                         }
                     )
                 )
-            lane_finals = [_receive_web_final(lane_web) for _ in range(4)]
-            lane_states = [
-                _wait_database_turn_status(
-                    database,
-                    lane_thread,
-                    text,
-                    {"completed", "failed"},
-                )
-                for text in ("order one", "order two", "lane failure", "lane recovery")
+            active_inputs = _wait_database_turn_inputs(
+                database, lane_thread, "order one", 1
+            )
+            _release_barrier(model_url, "pc16-strict-lane")
+            ordered_finals = [_receive_web_final(lane_web) for _ in range(4)]
+            ordered_turns = [
+                _wait_database_turn(database, lane_thread, f"order {name}")
+                for name in ("one", "two", "three", "four")
             ]
+
+            _http_json(
+                "PUT",
+                f"{model_url}/control/script",
+                [{"mode": "error", "status": 500} for _ in range(4)],
+            )
+            lane_web.send(
+                json.dumps(
+                    {
+                        "type": "message.send",
+                        "request_id": "pc16-fail",
+                        "session_id": lane_thread,
+                        "text": "lane failure",
+                        "media": [],
+                    }
+                )
+            )
+            failed_final = _receive_web_final(lane_web)
+            failed_state = _wait_database_turn_status(
+                database, lane_thread, "lane failure", {"failed"}
+            )
+
+            _http_json(
+                "PUT",
+                f"{model_url}/control/script",
+                {"mode": "complete", "content": "recovered"},
+            )
+            lane_web.send(
+                json.dumps(
+                    {
+                        "type": "message.send",
+                        "request_id": "pc16-recover",
+                        "session_id": lane_thread,
+                        "text": "lane recovery",
+                        "media": [],
+                    }
+                )
+            )
+            recovered_final = _receive_web_final(lane_web)
+            recovered_state = _wait_database_turn_status(
+                database, lane_thread, "lane recovery", {"completed"}
+            )
             lane_evidence["sameThread"] = {
-                "finals": [frame.get("content") for frame in lane_finals],
-                "statuses": [state["status"] for state in lane_states],
+                "activeInputs": active_inputs,
+                "orderedTurns": [_turn_projection(turn) for turn in ordered_turns],
+                "finals": [
+                    *[frame.get("content") for frame in ordered_finals],
+                    failed_final.get("content"),
+                    recovered_final.get("content"),
+                ],
+                "statuses": [
+                    *[turn["status"] for turn in ordered_turns],
+                    failed_state["status"],
+                    recovered_state["status"],
+                ],
             }
 
         different_threads = cast(dict[str, object], lane_evidence["differentThreads"])
@@ -1534,15 +1661,26 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             == "completed"
             and different_threads["slowFinal"] == "slow complete"
             and different_threads["fastFinal"] == "fast complete"
+            and cast(dict[str, object], same_thread["activeInputs"])["userInputs"]
+            == ["order one"]
             and same_thread["finals"]
             == [
-                "ordered one",
-                "ordered two",
+                "order one final",
+                "order two final",
+                "order three final",
+                "order four final",
                 "处理消息时出错，请稍后再试。",
                 "recovered",
             ]
             and same_thread["statuses"]
-            == ["completed", "completed", "failed", "completed"]
+            == [
+                "completed",
+                "completed",
+                "completed",
+                "completed",
+                "failed",
+                "completed",
+            ]
         )
         checks.append(
             CheckResult(
@@ -1927,6 +2065,7 @@ def _prepare_host_sandbox(sandbox: Path, source_root: Path) -> None:
 
     # 3. 配置只引用同一 sandbox 内的路径。
     _write_config(sandbox)
+
 
 def _install_control_failure_plugin(sandbox: Path) -> None:
     """安装只为 PC10 构造 started 后 gate failure 的隔离插件。"""

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -100,8 +100,8 @@
 |---|---|---|
 | 任何会修改仓库文件的任务 | 本索引 → [`WORKFLOW.md`](WORKFLOW.md) → 下方对应领域 | 当前分支、目标分支、完整 diff、验证报告 |
 | Prompt、人格、上下文窗口、历史裁切、重试 | `projectneed` 第 5～7、13 节 → [Veda 人格设计](design/veda-persona.md) → [0002](decisions/0002-context-reduction-is-a-nondestructive-projection.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `agent/persona.py`、`agent/core/prompt_block.py`、`agent/core/passive_turn.py`、`agent/prompting/`、`session/manager.py`、`session/store.py` |
-| 会话、消息、turn、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) | `session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
-| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
+| 会话、消息、turn、同 Turn 输入、打断、附件、删除或恢复 | `projectneed` 第 6～7、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Codex 式同 Turn 输入需求](design/codex-style-same-turn-input-requirements.md) → [Codex 式同 Turn 输入设计](design/codex-style-same-turn-input.md) → [0025](decisions/0025-codex-style-same-turn-input.md) | `agent/control/runtime.py`、`agent/core/passive_turn.py`、`bootstrap/passive_worker.py`、`session/`、`infra/channels/base.py`、`bootstrap/channels.py`、`bootstrap/chat_api.py` |
+| Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [Codex 式同 Turn 输入需求](design/codex-style-same-turn-input-requirements.md) → [Codex 式同 Turn 输入设计](design/codex-style-same-turn-input.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
 | 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [Linux Supervisor 安全自重启提议](design/linux-supervisor-safe-self-restart.md) → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
 | 插件安装、热重载、自验证、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、9～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [0024](decisions/0024-plugin-self-validation-uses-stable-and-latest.md) → [插件递归自验证运行时设计](design/recursive-plugin-self-validation.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/snapshot.py`、`agent/plugins/reload_journal.py`、`agent/plugins/skill_links.py`、`agent/control/runtime.py`、`agent/looping/core.py`、`agent/mcp/host.py` |
@@ -206,12 +206,15 @@ docs/
 │   ├── 0021-yoyo-workspace-ledger-defines-migration-origin.md
 │   ├── 0022-mobile-webui-uses-server-selected-generations.md
 │   ├── 0023-akashic-tokens-own-material-3-semantics.md
-│   └── 0024-plugin-self-validation-uses-stable-and-latest.md
+│   ├── 0024-plugin-self-validation-uses-stable-and-latest.md
+│   └── 0025-codex-style-same-turn-input.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── linux-supervisor-safe-self-restart.md
 │   ├── mobile-cross-repository-semantic-gate.md
 │   ├── mobile-long-message-delivery.md
+│   ├── codex-style-same-turn-input-requirements.md
+│   ├── codex-style-same-turn-input.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── query-local-react-compaction.md
 │   ├── server-published-mobile-webui.md

--- a/docs/decisions/0012-query-local-compaction-is-a-persisted-projection.md
+++ b/docs/decisions/0012-query-local-compaction-is-a-persisted-projection.md
@@ -57,6 +57,10 @@ core model runtime 拥有当前 query 的压缩计算。它只接收当前 promp
 - 当前 query 中途崩溃或取消时不单独提交 compaction；既有 Turn 状态继续说明该次执行未完成。
 - Session-wide 历史归档、自动删除、摘要展开工具和跨模型重新总结不属于本决定。
 
+## 2026-08-06 补充：中断 Attempt 仍属于当前 Query
+
+同一 logical interaction 经历 `U1/interrupt/U2/interrupt/U3` 时，前驱 attempt 的闭合工具组必须加入当前 QueryCompactor，不能作为永久不可压缩的 base prefix。current-query anchor 显式合并全部 U；interrupt marker 和最近闭合工具后缀保留在热视图。最终 `react_compaction.compacted_tool_groups` 相对于所有 attempt 聚合后的完整 `tool_chain` 计数，SessionDB 和 control checkpoint 仍保持既有只追加/状态机写入。
+
 ## 验收
 
 - 低于软水位时 provider payload 与基线等价，不产生 `react_compaction`。

--- a/docs/decisions/0025-codex-style-same-turn-input.md
+++ b/docs/decisions/0025-codex-style-same-turn-input.md
@@ -1,0 +1,59 @@
+# 0025 · 普通输入采用 Codex 式 Logical Interaction continuity
+
+- 状态：accepted
+- 日期：2026-08-06
+- 关联条款：SES-007～SES-008、MEM-010、RUN-008、OUT-005
+- supersedes：无
+- superseded by：无
+
+## 背景
+
+当前 runtime 需要在用户中断后保留尚未完成任务的连续性。用户确认的目标是：U1 启动 attempt，用户中断后再发送 U2/U3；每条新 U 创建新 attempt，但都属于同一个 logical interaction，直到唯一 A_final 才结束。
+
+Codex `2b5bdcf67547860f2e5c5a605009a70026796b2b` 的普通 user admission 会先尝试 active-turn steer；pending input 在下一次模型采样前 drain，检测到 pending input 时同一 user-visible turn 继续。显式 `turn/interrupt` 则独立终结 turn。
+
+## 决定
+
+普通输入不暴露 steer/follow-up 选择。core 在没有 active attempt 时创建；active 时 `turn/start` 明确返回 busy，唯一可用动作是精确中断。中断 terminal 后的下一条 U 沿 durable predecessor 创建新 attempt。最终回复候选必须先 seal input source，成功后才提交 completed interaction。
+
+Mobile 输入区在 active 时只显示 hard interrupt，草稿保留但不能发送；各 channel `/stop` 使用相同 hard interrupt。控制协议不再提供 `turn/steer`。Akasha 对 completed turn 聚合全部有序 U 和唯一 final A，不再用相邻角色推断新格式。
+
+## 2026-08-06 勘误
+
+维护者以真实 Mobile 场景重新确认后，以上 active-with-draft steer 交互不再成立。当前接受语义如下：
+
+- Mobile active 时无论是否存在草稿，尾部动作都只能是中止；草稿保留但不能发送。
+- hard interrupt 只终结当前 execution attempt，不终结 logical interaction。
+- 中止收束后发送的下一条 U 创建新 attempt，沿用同一 interaction identity，并重放此前全部 U 和已经闭合的工具调用/结果。
+- `U1 → stop → U2 → stop → U3 → A_final` 是一个 completed logical interaction、三个 execution attempts；只有 `A_final` 关闭 interaction。
+- SessionDB 最终只追加 `U1、U2、U3、A_final` 的 canonical transcript。Akasha 在线与离线都只从该 completed transcript 建立一个样本；attempt checkpoint 不进入学习。
+- `memory_window`、Markdown consolidation 和 recent turns 都把这四条消息视为一个逻辑历史单元；proactive assistant 单独占一个单元。
+- 前驱 attempt 的闭合工具组加入 query-local ReAct compaction；摘要输入显式包含 U1/U2/U3，最近工具后缀保留原文，权威工具证据不因压缩被改写。
+
+## 理由
+
+这个模型直接匹配 Mobile 操作：执行中只有中止，终止后发送就是补充尚未完成的任务。attempt identity 和 terminal fencing 避免迟到输入串到错误执行；闭合工具组压缩控制模型热上下文，同时让 durable ledger 保持可审计。
+
+## 影响
+
+- 正面影响：连环中止后补充要求仍保留同一 interaction、完整工具事实和同一最终回答；Mobile 没有 send/stop 模式选择。
+- 兼容性：`turn/start` active 行为、移除 `turn/steer`、completed transcript、history budget 和 Akasha projection 发生 breaking 变化。
+- 数据和迁移：不改旧正文；新消息在 extra 中携带显式 turn 归属。Akasha builder 对旧数据保留 legacy pair。
+- 失败与回滚：输入先写 turn checkpoint 再进入内存；代码可回滚，已追加 message 不删除。
+
+## 验收
+
+- [x] 两次中止产生三个 attempt ID，但沿用同一 interaction ID，只有一个 terminal A。
+- [x] SessionDB 和 Akasha 都把全部 U 归入同一 completed turn。
+- [x] `/stop` 仍只产生 interrupted terminal，不注入 user input。
+- [x] Mobile active 时只显示中止；草稿不能把动作切换回发送。
+- [x] 同一 interaction 的前驱工具组可进入 ReAct compaction，摘要锚定全部 U。
+- [x] memory window、Markdown consolidation 与 proactive 使用一致的逻辑历史单元。
+
+## 接受风险
+
+一个 logical interaction 可以包含很多 U 和工具结果，因此 SessionDB/control ledger 会按既有只追加和结果边界持续增长；`memory_window` 也不是 token 硬上限。当前接受这一风险：模型热上下文会合并全部 user query，并只压缩已闭合的旧工具组；若单个 query anchor 或最近不可拆工具后缀本身超过 provider 边界，则明确失败。本决定不引入 Maka 式通用 ArchiveRead 协议，也不自动删除权威证据。
+
+## 未决问题
+
+- 无。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,6 +30,7 @@
 | [0022](0022-mobile-webui-uses-server-selected-generations.md) | accepted | 移动 WebUI 使用服务端选择的不可变 generation | WEBUI-001～WEBUI-006、MOB-001～MOB-004、TST-006～TST-008 |
 | [0023](0023-akashic-tokens-own-material-3-semantics.md) | accepted | Akashic Token 拥有 Material 3 设计语义 | WEBUI-001～WEBUI-007 |
 | [0024](0024-plugin-self-validation-uses-stable-and-latest.md) | accepted | 插件自验证使用 stable/latest 与 session 级并发 | RUN-007、OUT-004、PLG-013、CTRL-003、TST-001～TST-006 |
+| [0025](0025-codex-style-same-turn-input.md) | accepted | 中断后的新 Attempt 续接同一 Logical Interaction | SES-007～SES-008、MEM-010～MEM-011、RUN-008、OUT-005 |
 
 ## 新增规则
 

--- a/docs/design/codex-style-same-turn-input-requirements.md
+++ b/docs/design/codex-style-same-turn-input-requirements.md
@@ -1,0 +1,82 @@
+# Codex 式同 Turn 输入需求合同
+
+- 状态：accepted / implemented
+- 日期：2026-08-06
+- 决策：[0025](../decisions/0025-codex-style-same-turn-input.md)
+- 设计：[Codex 式同 Turn 输入设计与任务合同](codex-style-same-turn-input.md)
+- 关联条款：CTX-003、SES-001～SES-002、SES-005、SES-007～SES-008、MEM-009～MEM-010、RUN-002～RUN-003、RUN-007～RUN-008、OUT-001、OUT-005
+
+## 1. 用户可见目标
+
+普通用户输入在 session 没有 active execution attempt 时创建新 attempt；若上一个 attempt 被中止且尚无最终 A，则自动续接同一个 logical interaction。用户不选择 `steer`、`follow-up` 或 `next prompt`。
+
+一次 logical interaction 可以按顺序经历 `U1 → stop → U2 → stop → U3 → A_final`。每次 stop 只结束 execution attempt；下一 attempt 必须看到此前 U 和所有已闭合工具事实。Mobile active 时尾部动作始终是中止，草稿保留但不能发送；中止收束后才恢复发送。Telegram、QQ 等 channel 的 `/stop` 使用相同语义。
+
+## 2. 需求
+
+### STI-001 普通输入自动选择 logical interaction
+
+同 session 没有 active attempt 时，普通 U 创建 attempt；最新 interaction 没有最终 A 时，新 attempt 沿用其 identity。active attempt 期间 Mobile 不接收普通发送。core 根据 durable terminal 状态选择 interaction，客户端不暴露模式选择器。
+
+### STI-002 同一 turn 支持多个 U
+
+一个 turn 的输入是有序非空集合，而不是单条 user message。每个 U 拥有稳定 item ID、ordinal、原始正文、附件引用和客户端身份；任何 consumer 不得用相邻角色推断 turn 归属。
+
+### STI-003 新 U 在 Attempt 边界生效
+
+新 U 只能在前一 attempt 已中止收束后进入下一 attempt。active attempt 上的普通 `turn/start` 必须返回 busy；控制协议不提供 `turn/steer`。已完成的工具调用和结果按既有证据保留规则继续持久化并进入下一 attempt；正在执行且没有 result 的工具以 interrupted 闭合，但不进入下一次模型 replay。
+
+### STI-004 最终 A 才结束 Logical Interaction
+
+interrupted、cancelled 或 failed attempt 都不关闭 logical interaction。只有一次 attempt 成功提交 terminal assistant 时，该回复才成为 `A_final`，interaction completed；此后的普通 U 才创建新的 interaction。
+
+### STI-005 控制面只提供精确中断
+
+active attempt 期间唯一改变执行状态的用户动作是携带精确 thread/turn identity 的 `turn/interrupt`。普通输入只走 `turn/start`：active 时明确 busy，terminal 后由 core 根据 durable predecessor 创建下一 attempt。adapter 不得提供 steer、follow-up 或 next-prompt 分支。
+
+### STI-006 Attempt checkpoint 可恢复和重放
+
+每个 attempt 的初始 U、工具 started/completed 和状态实时写入 `turns`。下一 attempt 从前驱链恢复全部 U，并把每个已完成 tool call/result 投影回模型历史；未闭合工具和 partial assistant delta 不重放。SessionDB `messages` 仍只在 interaction completed 时提交完整 transcript batch。
+
+### STI-007 Completed transcript 是多个 U 加一个最终 A
+
+completed turn 在一个 SessionDB 事务中按 ordinal 追加全部 U，随后追加唯一 `A_final`。每条消息携带相同 `control_turn_id`；user 携带 `turn_input_ordinal`，assistant 携带 terminal 标志和输入数量。历史窗口或 consolidation 起点若落在该 turn 中间，replay 必须退回 U1，允许实际投影量超过消息数预算。现有消息正文保持只追加。
+
+### STI-008 硬终止保持独立
+
+Mobile 中止动作和 `/stop` 只调用 `turn/interrupt`，把 active attempt 终结为 interrupted。它们不注入 user message、不伪装成 steer，也不自动启动下一 attempt。Mobile active 时无论草稿是否为空都只提供中止；草稿保留，中止收束后才允许发送。
+
+### STI-009 Akasha 使用显式多输入投影
+
+Akasha 对一个 completed logical interaction 建立一个学习样本：有序聚合全部 U，输出为 `A_final`。attempt checkpoint 不触发在线学习，也不进入离线 rebuild；在线与离线 builder 只从最终 transcript 的 `control_turn_id`、ordinal 和 terminal 标志重建。旧消息继续走明确的 legacy pair 兼容路径。
+
+### STI-010 失败和竞态不得丢输入或串 turn
+
+输入 admission、hard interrupt 和 turn completion 共用同一个 session/turn owner。active 时到达的普通 U 明确拒绝，不得塞回旧 attempt；客户端在 interrupt terminal 后重发，core 才创建下一 attempt。重复或过期控制请求不得影响当前 turn。
+
+### STI-011 历史预算按 Logical Interaction 计数
+
+`memory_window`、Markdown consolidation 的保留尾部、分页切点、积压阈值和 recent turns 都按不可拆分的逻辑历史单元计数。一个 completed `U1..Un+A_final` 是一个单元；一次已送达 proactive assistant 是一个独立单元。窗口和游标不得落入显式 `control_turn_id` 中间。
+
+### STI-012 连环中断的工具前缀可压缩但不可丢证据
+
+下一 attempt 初始 prompt 中的前驱工具调用/结果必须加入现有 query-local ReAct compaction，而不是成为永远不可压缩的固定前缀。压缩只淘汰已闭合工具组，显式把本 interaction 的全部 U 作为 current-query anchor，并保留最近原始工具后缀。压缩无合法切点、摘要无效或节省不足时 fail-loud；不得改写或删除权威 turn/message 证据。
+
+## 3. 验收序列
+
+1. U1 创建 interaction I1 / attempt E1，Agent 完成一个工具批次。
+2. 用户中止 E1；U2 创建 E2，模型看到 U1 和 E1 的完整工具调用/结果。
+3. 用户再次中止 E2；U3 创建 E3，模型看到 U1/U2 和 E1/E2 的完整已闭合工具事实。
+4. 只有 A_final 输出后 I1 completed；E1/E2/E3 各有独立 attempt ID。
+5. SessionDB 完成 transcript 为 `U1、U2、U3、A_final`，四条消息携带同一 interaction `control_turn_id`。
+6. Akasha 只建立一个 I1 节点，输入由 U1/U2/U3 确定性聚合，输出来自 A_final。
+7. 下一轮 U4 把 I1 当作一个历史单元；热窗口可见 I1 的全部 U、压缩摘要/最近工具后缀和 A_final，超出热窗口后由 Markdown consolidation 与 Akasha recall 提供派生语境，SessionDB 仍保留权威 transcript。
+
+## 4. 非目标
+
+- 不恢复模型隐藏思维或 provider 私有流状态。
+- 不在任意 token delta 中间注入 U。
+- 不让 `/stop` 自动变成继续任务的 user message。
+- 不修改或删除既有 message 正文。
+- 不在客户端复制 active-turn admission 规则。
+- 不在本功能中新增通用 tool-result archive/read 协议；单个 logical interaction 仍可能很大，这是已接受风险。

--- a/docs/design/codex-style-same-turn-input.md
+++ b/docs/design/codex-style-same-turn-input.md
@@ -1,0 +1,186 @@
+# Codex 式同 Turn 输入设计与任务合同
+
+- 状态：accepted / implemented
+- 日期：2026-08-06
+- 需求：[Codex 式同 Turn 输入需求合同](codex-style-same-turn-input-requirements.md)
+- 决策：[0025](../decisions/0025-codex-style-same-turn-input.md)
+- 参考版本：`codex@2b5bdcf67547860f2e5c5a605009a70026796b2b`
+
+## 1. 设计结论
+
+采用 Codex 的 durable history continuity，但把 user-visible turn 明确定义为 logical interaction：每条普通输入只在没有 active attempt 时创建 execution attempt；最新 interaction 尚无最终 A 时，新 attempt 自动续接。active 时只允许 interrupt，系统不提供 user steer。
+
+当前 `ConversationRuntime` 继续拥有 session lane、attempt identity、interrupt 和 terminal CAS，并用 `interactionId`、`attemptOrdinal`、`continuedFromTurnId` 连接 attempt。`DefaultReasoner` 把前驱 attempt 的有序 U 和已闭合工具调用/结果投影进下一次 prompt。`PassiveMessageWorker` 只负责 durable handoff 和最终 outbound；中止 attempt 不产生 outbound A。
+
+## 2. 状态与调用合同
+
+`ConversationRuntime.start_turn(request)` 只有两种结果：没有 active attempt 时创建新 execution attempt；存在 active attempt 时返回 `ThreadBusyError`，不写入任何 user item。`turn/steer` 不属于协议。
+
+Mobile active 时发送入口关闭，只能调用 `turn.stop`；中止终态完成后，下一条普通 U 调用 `turn/start` 创建新 attempt。其他 channel 的 `/stop` 使用相同路径。turn-local input source 只承担 final seal 和恢复既有有序输入，不再拥有运行中输入 ingress。
+
+## 3. Reasoner 行为
+
+新 attempt 启动时，runtime 沿 `continuedFromTurnId` 回溯同一 interaction，恢复全部 user item，并把此前每个已完成 tool item 投影为 assistant tool call + tool result。每个 attempt 的 partial assistant delta 和没有 result 的工具不进入 replay；当前 U 始终是最后一条 user message。
+
+provider 返回 tool call 时，先完成整个 tool batch并持久发布工具 item。provider 返回自然语言时原子 seal；成功后当前自然语言成为唯一 `A_final`。active 期间不存在 pending U。
+
+已经实时发送的中间 delta 属于 attempt 流展示，不拥有 interaction 完成语义；只有 terminal assistant item 和最终 transcript commit 才关闭 interaction。
+
+## 4. 持久化
+
+### `turns.items_json`
+
+- 正常增加：每个 attempt 创建时写当前 U；工具和最终 item 按现有 owner 写入。
+- 原位更新：仅 active turn 的 items append 和既有状态 CAS。
+- 逻辑失效：terminal 后 input source seal，旧 generation 不再写入。
+- 物理减少：只随用户显式删除 session cascade。
+- 恢复证据：attempt ID、interaction ID、前驱 ID、item ID、logical ordinal、status 和 tool item。
+
+### `messages`
+
+- 正常增加：completed interaction 一次 INSERT `U1..Un,A_final`。
+- 原位更新：本功能不允许。
+- 逻辑失效：不因 interrupt、Akasha 或 context projection 改变。
+- 物理减少：只按 SES-003 的显式撤销/删除。
+- 恢复证据：seq、message ID、共同 `control_turn_id`、input ordinal 和 terminal 标志。
+
+### runtime input source
+
+- 只投影从 durable predecessor 恢复的全部 U 和当前 attempt 的初始 U。
+- active attempt 不接收新 U；seal 后释放。它不是真源，不能覆盖 turns 或 messages。
+
+### Akasha sidecar
+
+- 在线事件只在最终 attempt 成功提交时携带全部有序 user message IDs 与 final assistant ID。
+- builder 对新格式按 `control_turn_id` 分组，对 legacy 数据保留严格相邻 pair。
+- 多 U 文本按 ordinal 连接；dense 使用所有非空 user message embedding 的确定性归一化均值。缺失任一必需 embedding 时保持现有 fail-loud audit。
+- interrupted/cancelled/failed attempt 只存在于 `turns`，不成为 Akasha 样本；Akasha 仍是可重建派生状态，不反向修改 SessionDB。
+
+### Session history replay
+
+- `max_messages` 表示逻辑历史单元数量，不再表示物理 message 数。一个显式 `U1..Un+A_final` 是一个单元；一次 proactive assistant 是一个单元。
+- consolidation 保留尾部、分页、积压阈值、recent turns 和 `start_index` 使用同一分组。窗口若落在显式 `control_turn_id` 中间，必须退回 U1；展开后的 provider message 数允许超过预算。
+- legacy 消息继续使用既有 user/proactive assistant 边界规则，不用相邻角色反推新格式 turn identity。
+
+### Attempt replay 和 query compaction
+
+前驱 attempt replay 在 prompt 中按顺序保留 `U、assistant tool-call、tool result、interrupt marker`。runtime 把每个已闭合 tool-call/result 识别为可压缩批次；两个以上闭合批次且达到 provider 软水位后，旧批次进入现有 `context_compact` 摘要，最近完整批次和当前未闭合后缀保持原文。
+
+摘要的 current-query anchor 不是最后一条 U，而是本 interaction 的全部 `U1..Un`。摘要无效、工具批次未闭合、切点与 `prior_tool_chain` 数量不一致、压缩后仍越过硬水位时都 fail-loud。`turns` checkpoint、最终 `messages.tool_chain` 和既有消息正文不因 provider 投影压缩而 UPDATE 或 DELETE。
+
+这一选择结合两类参考实践：`pi-mono@74caa2649f10ed71b4378ce69f5d9fbfd2466ca5` 保留 append-only session，并用 summary + recent suffix 构造 prompt，切点不会落在 tool result；`maka-agent@785b0c4f202c0263fb59150ae903195932233466` 以 source-bearing checkpoint、coverage/digest、head anchor 和可读取 archive 保住 ledger/replay 一致性。本实现采用共同原则“权威账本完整、模型视图有界、切点只在闭合因果边界”，但本 PR 不新增通用工具结果 archive。
+
+### Interaction 完成后的下一轮
+
+以 `U1 → stop → U2 → stop → U3 → A1` 为例，最终 SessionDB 有四条连续 message，共享一个 `control_turn_id`。下一轮 U4 读取历史时，I1 作为一个逻辑单元展开：模型看到 U1/U2/U3、I1 的 compact summary 与最近工具后缀、以及 A1，然后看到 U4。I1 超出热窗口后，Markdown consolidation 会把其用户 query 和确认事实写入派生记忆，Akasha 可按一个 completed node 召回；SessionDB 的四条权威消息仍保留。
+
+### Proactive
+
+已成功送达的 proactive assistant 没有 user turn，也不生成 Akasha 学习节点；它在 canonical history、memory window、Markdown recent turns 和 consolidation 边界中作为一个独立逻辑单元。用户随后回复 proactive 时，回复 metadata 继续保留引用，新的被动 interaction 仍按正常 U/A 规则学习。本 PR 不把 proactive assistant 伪造成 Akasha 的 U 或 A。
+
+## 5. Channel 和 UI
+
+- Mobile：active 时无论草稿是否为空都只显示中止，草稿保留但发送不可用；中止收束后恢复发送。中止继续调用 `turn.stop`。
+- Telegram、QQ、Web Chat：`/stop` 或现有 stop command 结束 active attempt；终态后的下一条普通消息自动续接未完成 interaction。
+- Programmatic control：`turn/start` 在 active 时返回 busy；只有 `turn/interrupt` 能改变 active attempt。
+
+## 6. 失败语义
+
+- turn item 写入失败：输入 admission 失败，不进入内存 queue。
+- active thread 收到普通 `turn/start`：返回 busy，不写 checkpoint，不 fallback 到新 turn。
+- source 已 seal：旧 attempt 不再接收输入；terminal 后下一次 `turn/start` 创建新 attempt。
+- tool batch 未闭合：不进入 attempt replay，也不能成为 compaction 切点。
+- completed transcript batch 写入失败：turn 不得声称正式提交，现有错误向 owner 暴露。
+- Akasha 失败：completed transcript 保持，sidecar degraded 并从固定输入重建。
+- hard interrupt：沿现有唯一 interrupt owner 结束 attempt，不提交 canonical assistant；下一条 U 由 runtime 根据 durable 前驱续接 interaction。
+- 单个 logical interaction 过大：先压缩旧闭合工具组；如果全部 U anchor 或最近不可拆后缀本身超过 provider 硬边界，明确失败。这是已接受风险，不能通过拆 U、删工具证据或伪造摘要规避。
+
+## 7. 验证
+
+- runtime：`U1/stop/U2/stop/U3/A` 的 interaction identity、attempt 前驱、logical ordinal、stale attempt 和 hard interrupt。
+- reasoner：前驱 U、十个工具调用/结果、abort marker 在当前 U 之前完整可见；未闭合工具不重放。
+- persistence：关闭重开 SQLite，核对 turn items、completed message batch、只追加 write set 和 seq。
+- replay：`max_messages` 或 consolidation index 落在 U2/U3/A 时仍从同一 turn 的 U1 开始投影。
+- compaction：两次中断留下的闭合工具组可以被压缩；摘要输入同时包含 U1/U2/U3，最近组保持原文，最终 persisted cut 不超过聚合后的完整 tool chain。
+- proactive：主动 assistant 独占一个历史单元，不进入 Akasha；相邻被动 interaction 保持独立。
+- channel：中止 attempt 不发送 assistant outbound；后续消息的新 attempt 最终只发送一次 A。
+- Mobile：验证 idle 显示 send，active 空草稿和 active 有草稿都显示 stop，stopping 显示 pending stop；active 时快捷键和 native send 同样被拒绝。
+- Akasha：`U1,U2,U3,A` 在线与离线得到一个相同 turn；legacy pair 不回归。
+- known-bad：邻接配对、seal 后仍接收、第二 inbound 重复发送 final A、工具批次中途注入。
+- known-bad：active `turn/start` 被隐式 steer、按物理 message 数裁掉 U1、consolidation 游标落在 multi-U turn 内、attempt replay 永远不可压缩。
+
+## 8. 实现任务合同
+
+```yaml
+change_type: feature
+semantic_delta: breaking
+capability_owner: mixed
+consumer_scope:
+  - conversation runtime
+  - passive channels and interrupt-only programmatic control
+  - shared Mobile WebUI
+  - SessionDB prompt replay
+  - Akasha online and offline builders
+runtime_patch: required
+runtime_patch_reason: "只有 core 拥有 active turn、provider/tool 安全边界、terminal seal 和 transcript commit；客户端实现会复制并猜测权威状态。"
+authoritative_state_owner: "ConversationRuntime owns admission and seal; SessionStore owns turn checkpoints and transcript; Akasha owns derived projection."
+client_only_alternative: "rejected"
+invariants:
+  - STI-001
+  - STI-003
+  - STI-004
+  - STI-007
+  - STI-009
+  - SES-002
+  - SES-005
+protected_state:
+  - existing message bodies and seq
+  - hard interrupt semantics
+  - external tool effects
+  - formal workspace data
+allowed_paths:
+  - agent/control/**
+  - agent/core/**
+  - agent/lifecycle/**
+  - bootstrap/passive_worker.py
+  - bootstrap/control_execution.py
+  - bus/**
+  - session/**
+  - infra/channels/**
+  - infra/mobile_realtime/**
+  - frontend/**/src/**
+  - plugins/akasha/**
+  - tests/**
+  - tests_scenarios/contracts/**
+  - docker/debug/**
+  - docs/**
+forbidden_paths:
+  - generated frontend bundles
+  - plugin cache
+  - formal Akashic workspace
+allowed_effects:
+  - isolated SQLite fixture writes
+  - isolated frontend build
+  - isolated Akasha rebuild
+forbidden_effects:
+  - update or delete existing messages
+  - publish, deploy or restart formal services
+  - replay indeterminate external effects
+validation:
+  - focused unit and semantic tests
+  - SQLite close/reopen write-set checks
+  - Akasha online/offline equivalence
+  - shared WebUI build
+  - isolated change-impact Gate
+rollback: "Restore /tmp/akasic-codex-turn-input-backup.aSq3Tx and revert code consumers; never delete newly appended messages."
+worktree_writer: "/mnt/data/coding/akasic-agent-worktrees/pi-style-interruption-design"
+handoff_head: ""
+external_revisions:
+  - "codex@2b5bdcf67547860f2e5c5a605009a70026796b2b"
+  - "pi-mono@74caa2649f10ed71b4378ce69f5d9fbfd2466ca5"
+  - "maka-agent@785b0c4f202c0263fb59150ae903195932233466"
+schema_lineages:
+  - "turns.items_json attempt user/tool checkpoints"
+  - "messages.extra control_turn_id/turn_input_ordinal/turn_terminal"
+  - "TurnCommitted persisted_user_message_ids"
+```

--- a/docs/design/query-local-react-compaction.md
+++ b/docs/design/query-local-react-compaction.md
@@ -114,7 +114,7 @@ SessionDB assistant.extra
 next query prompt replay
 ```
 
-`LLMProvider` 负责用 system prompt、消息、tool schema 和多模态块估算完整请求。`DefaultReasoner` 负责决定哪些已经闭合的当前 query 工具组进入摘要。`SessionManager` 只在完整 Turn 提交和后续重放时处理版本化字段。
+`LLMProvider` 负责用 system prompt、消息、tool schema 和多模态块估算完整请求。`DefaultReasoner` 负责决定哪些已经闭合的当前 query 工具组进入摘要；同一 logical interaction 的中断 attempt replay 也属于当前 query，而不是不可压缩的历史前缀。`SessionManager` 只在完整 Turn 提交和后续重放时处理版本化字段。
 
 ## 4. 触发、切点和重复压缩
 
@@ -130,7 +130,7 @@ hard_limit = floor(model.context_window * effective_context_percent)
 
 每次 provider 调用前，优先使用上一响应的准确 input usage 加新增消息估算；没有完整 usage、tool schema 变化或压缩重建前缀时，对完整请求重新估算。达到软水位后，只能选择已经完整闭合的工具组前缀。当前 user query、当前 iteration 新注入提示和最近工具后缀不进入切点。
 
-第一次压缩使用被淘汰的工具组生成摘要。再次压缩使用上一份摘要和新淘汰工具组生成新摘要，并替换旧 compact pair。摘要至少包含：
+第一次压缩使用被淘汰的工具组生成摘要。再次压缩使用上一份摘要和新淘汰工具组生成新摘要，并替换旧 compact pair。若 query 经历中断续接，current-query anchor 必须显式包含该 interaction 的全部有序 U，而不是只取最后一条 U。摘要至少包含：
 
 - Goal
 - Constraints
@@ -170,6 +170,10 @@ hard_limit = floor(model.context_window * effective_context_percent)
 
 Session 重载读取上一 assistant row 的 `react_compaction`，跳过已压缩 `tool_chain` 前缀，投影摘要、后缀和最终回复，再追加新 user query。
 
+### 中断后的下一 Attempt
+
+runtime 从 control predecessor 恢复 U 和已闭合工具组。replay 中每个 assistant tool-call 及其全部 result 是一个闭合批次；interrupt marker、下一条 U 和尚未闭合的尾部留在 pending suffix。达到软水位时，旧 replay 批次与本 attempt 后续产生的批次使用同一个 compactor，最终 `compacted_tool_groups` 相对于聚合后的完整 `tool_chain` 计数。
+
 ## 7. Edge case 和失败语义
 
 - 模型正在流式输出：不压缩，响应结束并形成完整工具批次后再判断。
@@ -182,6 +186,8 @@ Session 重载读取上一 assistant row 的 `react_compaction`，跳过已压�
 - compaction summary 请求不携带业务工具，也不复用主 ReAct cache namespace。
 - 被压缩前缀的 opaque `model_state` 不重放；压缩后的下一次真实响应建立新状态。
 - tool result 在 summary 输入中按字符上限序列化，完整证据仍在 runtime `tool_chain` 和既有有界持久化结果中。
+- attempt replay 与 prior tool chain 的闭合组数量不一致、tool call/result identity 不闭合或 replay 不在最终 prompt 中：内部合同损坏，立即失败，不猜测切点。
+- 一个 interaction 的全部 U anchor 使用有界序列化；极端超长 query 可能无法通过压缩进入 provider 硬窗口。这是接受风险，不能通过只保留最后一条 U 来伪装成功。
 - SessionDB 中字段损坏、版本未知、切点超过 `tool_chain` 长度：在反序列化边界 fail-loud。
 
 ## 8. 验证

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -315,6 +315,8 @@ D 类效果只能由拥有 prepared、committed、failed 和必要补偿语义�
 
 Prompt 历史不得从孤立 assistant 或 tool result 开始。assistant 工具调用和对应结果成对保留；合法 user 边界或明确的 proactive assistant 边界拥有窗口起点。长工具结果只允许在临时模型视图中截短。
 
+同一个 completed logical interaction 可以跨越一个或多个 execution attempt，包含一个或多个有序 user message、此前 attempt 的完整已闭合工具事实和唯一 terminal assistant。中止只关闭 attempt，不关闭 interaction。窗口与重放使用显式 `control_turn_id` 和 input ordinal 识别边界，不得把相邻 user/assistant 角色当作新格式的 turn 归属协议。
+
 已送达的 proactive assistant 消息进入 prompt history 时保留完整正文，不得施加 proactive 专属字符预算或改写成 preview。整体请求超限时，只能由通用 prompt history 退化按完整语义边界缩小窗口。
 
 ### CTX-004 派生上下文不得伪装成用户原话
@@ -341,7 +343,7 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 
 ### SES-001 回合持久化全有或全无
 
-同一批 session metadata、消息和序列分配必须在一个事务中提交。任一步失败时数据库不出现半批消息，内存对象也不得获得并不存在的稳定 ID。
+同一批 session metadata、消息和序列分配必须在一个事务中提交。completed 被动 turn 的批次可以包含多个有序 user message 和唯一 terminal assistant；任一步失败时数据库不出现半批消息，内存对象也不得获得并不存在的稳定 ID。
 
 ### SES-002 消息序列单调且不复用
 
@@ -362,6 +364,14 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 ### SES-006 附件随消息引用保留
 
 消息仍引用的附件属于会话数据，必须保持可读。附件清理只能从完整引用关系出发，先识别真正孤儿，再经过 dry-run、备份和名称明确的删除操作；在引用计数、cascade 和恢复协议落地前不得自动 GC。文件年龄、当前 prompt 是否使用、索引是否命中和代码重构都不能成为删除依据。
+
+### SES-007 普通输入续接未完成 Logical Interaction
+
+同一 session 没有 active execution attempt 时，普通 user input 创建 attempt；最新 logical interaction 尚未产生 terminal assistant 时，新 attempt 必须沿用同一 interaction identity，并看到此前全部有序 user input 和已经闭合的工具调用/结果。active attempt 期间普通 `turn/start` 明确返回 busy，Mobile 普通发送不可用；channel 消息先通过 `/stop` 或等价中止结束 attempt，再由下一条普通输入续接。控制协议不提供 steer/follow-up 输入模式。
+
+### SES-008 Completed Interaction 显式拥有全部输入和唯一最终回复
+
+一个 logical interaction 可以拥有多个 execution attempt 和多个有序 user input。每个 attempt 的输入、工具 started/completed 和中止终态先写入 `turns`；下一 attempt 从这些事实构造 prompt replay，不恢复隐藏思维，也不重放未闭合工具。只有最终 assistant 成功提交时 interaction 才 completed。completed transcript 在一个事务中按 ordinal 追加全部 user message 和唯一 terminal assistant，并携带共同 interaction identity；不得为中止 attempt 生成 Akasha 学习样本或用角色邻接推断归属。
 
 ## 8. 记忆系统
 
@@ -399,7 +409,15 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 
 ### MEM-009 Akasha 使用固定输入确定性重建
 
-`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有完成的 user/assistant turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
+`akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有 completed turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
+
+### MEM-010 Akasha 对同 Interaction 多输入建立一个确定性样本
+
+completed logical interaction 含多个 user message 时，Akasha 按显式 interaction identity 和 input ordinal 聚合全部用户输入，并以唯一 terminal assistant 作为输出，只建立一个学习样本。中止 attempt 的 `turns` checkpoint 只服务执行恢复，不直接进入在线学习或离线 rebuild；只有最终 transcript batch 成为 Akasha 权威输入。每条非空 user message 和 assistant 使用各自已持久化 embedding；多输入 dense 使用固定版本的归一化聚合。在线提交和离线 builder 必须共用相同 source IDs、文本连接、向量聚合和 digest 规则。新格式不得按相邻角色配对；旧数据只能走名称明确的 legacy 兼容路径。
+
+### MEM-011 历史投影按不可拆分逻辑单元保留
+
+`memory_window`、Markdown consolidation 的保留尾部、积压阈值、分页切点和 recent turns 必须使用同一个逻辑历史分组。显式 `control_turn_id` 的 `U1..Un+A_final` 是一个单元；已送达 proactive assistant 是一个独立单元。任何窗口或 consolidation 游标不得落入逻辑单元内部。单元展开后允许超过配置的消息条数；配置值表示单元数量，不是 token 硬上限。
 
 ## 9. 运行时、并发和出站
 
@@ -433,9 +451,13 @@ Linux 上无子命令执行 `python main.py` 是正式服务入口，必须先�
 
 同一 `session_key` 同时只能有一个 active turn，channel、control 和 direct/programmatic 入口必须汇入同一个 session lane owner。不同 session 的 turn 可以并发；全局 active turn、请求字节和 runtime object 上限只负责有界准入，不得以跨 session 的整轮互斥实现。Turn 的 messages、文件读取状态、工具 trace、取消信号和 runtime snapshot 绑定属于 task-local 状态；共享 runtime service 只能保留有明确 owner、可并发使用或受短事务保护的状态。
 
+### RUN-008 Active Attempt 只接受中断并原子终结
+
+ConversationRuntime 的 session lane owner 在 active attempt 上拒绝所有普通输入，只接受精确 `turn/interrupt`。Reasoner 最终回复前仍在同一 owner 下封口；中断和完成都必须提交唯一 terminal 状态。下一条普通输入只能在 terminal 后创建新 attempt，并由 durable predecessor 恢复同一未完成 logical interaction；不得存在运行中 drain user input 的隐式或显式入口。
+
 ### OUT-001 被动按 Turn 提交，主动按送达提交
 
-被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，user 与 assistant 消息共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
+被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，本 turn 的全部有序 user message 与唯一 terminal assistant 共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
 
 同一条主动消息的实时事件与发送成功后的历史投影必须携带同一个稳定投递身份。客户端优先用该身份精确合并；内容与时间匹配只能兼容缺少稳定身份的旧消息。部分送达和结果不明必须有独立状态，不能冒充成功或完全失败。
 
@@ -452,6 +474,10 @@ Linux 上无子命令执行 `python main.py` 是正式服务入口，必须先�
 ### OUT-004 `message_push` 不取得目标 session 的执行所有权
 
 `message_push` 是调用 turn 发起的外部投递，不是目标 session 的 inbound turn。它不得等待目标 session lane；实际 adapter send 仍通过 ChatLane 的短提交 owner 串行。普通 scheduler/proactive 的 non-passive 投递继续等待同 chat 的被动回复优先完成；被动或程序化验证 turn 发起的 push 可以走 passive-send 路径，但不能与另一实际 send 重叠。push 正文不注入正在运行的父 Prompt，也不追加到目标 session history；调用参数和真实 delivery receipt 保存在调用 session 的工具 trace。pointer、异常或取消都不得伪装成已经发生的外部投递被回滚。
+
+### OUT-005 硬终止只关闭 Execution Attempt
+
+Mobile 中止按钮和 channel `/stop` 只调用带精确 attempt identity 的 hard interrupt，把 active attempt 终结为 interrupted；它们不创建 user message，也不自动启动下一 attempt。中止后到达的下一条普通输入按 SES-007 续接尚未完成的 logical interaction。Mobile active 时无论草稿是否为空都只显示中止，草稿保留但发送不可用；中止收束后才恢复发送。客户端不得让用户选择 steer、follow-up 或 next-prompt 模式。
 
 ## 10. 插件 generation 与 snapshot
 

--- a/frontend/chat/src/mobile-message-state.test.mjs
+++ b/frontend/chat/src/mobile-message-state.test.mjs
@@ -13,6 +13,7 @@ import {
   formatMobileSelectionCopyText,
   isMobileImageViewerHistoryState,
   mergeMobileComposerDraft,
+  mobileComposerActionMode,
   mobileMessageCanReply,
   mobileSelectionActionAvailability,
   mobileComposerDraftMatches,
@@ -479,6 +480,13 @@ test("composer only submits explicit desktop shortcut outside IME composition", 
     metaKey: false,
     isComposing: true,
   }), false);
+});
+
+test("composer exposes only stop while an execution attempt is active", () => {
+  assert.equal(mobileComposerActionMode({ hasDraft: false, canStop: false, stopping: false }), "send");
+  assert.equal(mobileComposerActionMode({ hasDraft: false, canStop: true, stopping: false }), "stop");
+  assert.equal(mobileComposerActionMode({ hasDraft: true, canStop: true, stopping: false }), "stop");
+  assert.equal(mobileComposerActionMode({ hasDraft: true, canStop: true, stopping: true }), "stop");
 });
 
 test("composer grows from one line and scrolls only above six-line cap", () => {

--- a/frontend/chat/src/mobile-message-state.ts
+++ b/frontend/chat/src/mobile-message-state.ts
@@ -218,6 +218,8 @@ export interface MobileComposerTextareaMetrics {
   overflowY: "auto" | "hidden";
 }
 
+export type MobileComposerActionMode = "send" | "stop";
+
 export interface MobileReplyNavigationMessage {
   role: "user" | "assistant";
   createdAt: number;
@@ -259,6 +261,17 @@ export function flushMobileComposerBeforePairing(
 
 export function allMobileAttachmentsReady(attachments: readonly { state: string }[]) {
   return attachments.every((attachment) => attachment.state === "ready");
+}
+
+export function mobileComposerActionMode({
+  canStop,
+  stopping,
+}: {
+  hasDraft: boolean;
+  canStop: boolean;
+  stopping: boolean;
+}): MobileComposerActionMode {
+  return stopping || canStop ? "stop" : "send";
 }
 
 export function isMobileImageViewerHistoryState(state: unknown, attachmentId: string) {

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -85,6 +85,7 @@ import {
   flushMobileComposerBeforePairing,
   formatMobileSelectionCopyText,
   isMobileImageViewerHistoryState,
+  mobileComposerActionMode,
   mobileMessageCanReply,
   mobileMessageHasCopyContent,
   mergeMobileComposerDraft,
@@ -1699,7 +1700,7 @@ function MobileNativeApp() {
   const send = () => {
     const text = input.trim();
     const attachmentsReady = allMobileAttachmentsReady(snapshot.composer.attachments);
-    if (sendPending || !snapshot.composer.canSend || !attachmentsReady) return;
+    if (sendPending || !snapshot.composer.canSend || snapshot.composer.canStop || !attachmentsReady) return;
     if (!text && snapshot.composer.attachments.length === 0) return;
     const native = window.AkashicNative;
     const sessionId = snapshot.selectedSessionId;
@@ -2833,7 +2834,13 @@ function MobileComposer({
   const hasOwner = snapshot.selectedSessionId !== undefined;
   const hasDraft = snapshot.composer.attachments.length > 0;
   const attachmentsReady = allMobileAttachmentsReady(snapshot.composer.attachments);
-  const canSubmit = hasOwner && snapshot.composer.canSend && attachmentsReady && !sendPending && (!!input.trim() || hasDraft);
+  const hasMessageDraft = !!input.trim() || hasDraft;
+  const canSubmit = hasOwner && snapshot.composer.canSend && !snapshot.composer.canStop && attachmentsReady && !sendPending && hasMessageDraft;
+  const actionMode = mobileComposerActionMode({
+    hasDraft: hasMessageDraft,
+    canStop: snapshot.composer.canStop,
+    stopping,
+  });
   const zoneRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -2922,7 +2929,7 @@ function MobileComposer({
         <button className="mobile-icon-button" type="button" disabled={sendPending || !hasOwner} onClick={() => window.AkashicNative?.chooseAttachments()} aria-label="添加附件">
           <Paperclip size={22} />
         </button>
-        {snapshot.composer.canStop || stopping ? (
+        {actionMode === "stop" ? (
           <ComposerActionButton mode="stop" className={stopping ? "pending" : undefined} onClick={onStop} label={stopping ? "正在中止" : "中止回答"} disabled={stopping} />
         ) : (
           <ComposerActionButton mode="send" onClick={onSend} label={sendPending ? "正在保存消息" : "发送消息"} disabled={!canSubmit} />

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -1198,7 +1198,11 @@ class MobileRealtimeChannel:
             items.append(
                 {
                     "session_id": session_id,
-                    "title": first_content.splitlines()[0][:32] or "新对话",
+                    "title": (
+                        first_content.splitlines()[0][:32]
+                        if first_content
+                        else "新对话"
+                    ),
                     "updated_at": str(session["updated_at"]),
                     "message_count": total,
                 }

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -30,6 +30,9 @@ async with await AsyncAkashic.connect(endpoint) as client:
 `python main.py app-server --stdio` 并直接使用 JSON-RPC NDJSON 流；当前 Python facade 连接
 Unix socket 或 loopback TCP。
 
+`RemoteError.retryable` 直接反映服务端错误数据中的重试语义。当前 thread 已有 active turn
+时，新的 `turn()` 会得到 `retryable=True`；SDK 不自动重试，调用方应等待、停止当前 turn 或稍后重发。
+
 loopback TCP 连接需显式传入 workspace token：
 
 ```python

--- a/sdk/python/src/akashic_sdk/client.py
+++ b/sdk/python/src/akashic_sdk/client.py
@@ -15,6 +15,8 @@ class RemoteError(RuntimeError):
         super().__init__(message)
         self.code = code
         self.data = data
+        retryable = data.get("retryable") if isinstance(data, dict) else None
+        self.retryable = retryable is True
 
 
 class ConnectionClosedError(ConnectionError):

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -13,7 +13,13 @@ from agent.control.service import ControlService
 from infra.control.socket import SocketAppServer
 from session.manager import SessionManager
 
-from akashic_sdk import Akashic, AsyncAkashic, SlowConsumerError, TurnHandle
+from akashic_sdk import (
+    Akashic,
+    AsyncAkashic,
+    RemoteError,
+    SlowConsumerError,
+    TurnHandle,
+)
 from akashic_sdk.client import _WireClient
 
 
@@ -95,6 +101,40 @@ async def test_async_sdk_runs_against_real_socket_router(tmp_path: Path) -> None
                 "turn/completed",
             ]
             assert result["finalResponse"] == "sdk:hello"
+    finally:
+        await server.stop()
+        await runtime.shutdown()
+        sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sdk_exposes_active_turn_busy_as_retryable(tmp_path: Path) -> None:
+    sessions = SessionManager(tmp_path)
+    started = asyncio.Event()
+
+    async def execute(_request: TurnRequest) -> str:
+        started.set()
+        await asyncio.Event().wait()
+        return "unreachable"
+
+    runtime = ConversationRuntime(sessions.control_store, execute)
+    server = SocketAppServer(
+        tmp_path / "control-busy.sock",
+        ControlService(runtime, sessions, tmp_path),
+    )
+    await server.start()
+    try:
+        async with await AsyncAkashic.connect(str(server.endpoint)) as client:
+            thread = await client.thread_start()
+            first = await thread.turn("u1")
+            await started.wait()
+
+            with pytest.raises(RemoteError) as captured:
+                await thread.turn("u2")
+
+            assert captured.value.retryable is True
+            assert captured.value.data == {"retryable": True}
+            assert (await first.interrupt())["status"] == "interrupted"
     finally:
         await server.stop()
         await runtime.shutdown()

--- a/session/manager.py
+++ b/session/manager.py
@@ -125,17 +125,19 @@ def _build_proactive_history_messages(
     frame = cast(
         dict[str, object],
         build_context_frame_message(
-            build_context_frame_content([
-                PromptSectionRender(
-                    name="recent_proactive_message_meta",
-                    content=(
-                        "上一条 assistant 消息是系统主动推送。"
-                        "以下 metadata 仅用于理解用户后续指代，不是用户陈述。\n"
-                        + _truncate_text(meta, _PROACTIVE_META_HISTORY_CHAR_BUDGET)
-                    ),
-                    is_static=False,
-                )
-            ])
+            build_context_frame_content(
+                [
+                    PromptSectionRender(
+                        name="recent_proactive_message_meta",
+                        content=(
+                            "上一条 assistant 消息是系统主动推送。"
+                            "以下 metadata 仅用于理解用户后续指代，不是用户陈述。\n"
+                            + _truncate_text(meta, _PROACTIVE_META_HISTORY_CHAR_BUDGET)
+                        ),
+                        is_static=False,
+                    )
+                ]
+            )
         ),
     )
     messages.append(frame)
@@ -193,14 +195,106 @@ def _align_to_user_boundary(
     return []
 
 
+def _rewind_to_explicit_turn_start(
+    messages: list[dict[str, object]],
+    start: int,
+) -> int:
+    """把历史窗口起点退回显式 control turn 的第一条消息。"""
+
+    if start < 0 or start >= len(messages):
+        return start
+    raw_turn_id = messages[start].get("control_turn_id")
+    if raw_turn_id is None:
+        return start
+    if not isinstance(raw_turn_id, str) or not raw_turn_id:
+        raise ValueError("session message control_turn_id 必须是非空字符串")
+    while start > 0:
+        previous_turn_id = messages[start - 1].get("control_turn_id")
+        if previous_turn_id != raw_turn_id:
+            break
+        start -= 1
+    return start
+
+
+def logical_history_unit_ranges(
+    messages: list[dict[str, object]],
+) -> list[tuple[int, int]]:
+    """把 canonical messages 划分为不可拆分的历史单元。"""
+
+    # 1. 新格式按连续 control turn 聚合；proactive 永远是独立事件。
+    ranges: list[tuple[int, int]] = []
+    index = 0
+    while index < len(messages):
+        start = index
+        message = messages[index]
+        raw_turn_id = message.get("control_turn_id")
+        if raw_turn_id is not None:
+            if not isinstance(raw_turn_id, str) or not raw_turn_id:
+                raise ValueError("session message control_turn_id 必须是非空字符串")
+            index += 1
+            while (
+                index < len(messages)
+                and messages[index].get("control_turn_id") == raw_turn_id
+            ):
+                index += 1
+            ranges.append((start, index))
+            continue
+        if message.get("role") == "assistant" and message.get("proactive"):
+            ranges.append((start, start + 1))
+            index += 1
+            continue
+
+        # 2. legacy 数据沿既有 user/proactive 边界分组，不反推新 turn identity。
+        index += 1
+        while index < len(messages):
+            candidate = messages[index]
+            if candidate.get("control_turn_id") is not None:
+                break
+            if candidate.get("role") == "user" or (
+                candidate.get("role") == "assistant" and candidate.get("proactive")
+            ):
+                break
+            index += 1
+        ranges.append((start, index))
+    return ranges
+
+
+def logical_history_unit_count(
+    messages: list[dict[str, object]],
+    *,
+    start_index: int = 0,
+) -> int:
+    """统计游标之后仍需投影的完整历史单元。"""
+
+    if start_index < 0 or start_index > len(messages):
+        raise ValueError("history unit start_index 超出消息范围")
+    return sum(
+        1
+        for start, end in logical_history_unit_ranges(messages)
+        if end > start_index and start < len(messages)
+    )
+
+
+def logical_history_tail_start(
+    messages: list[dict[str, object]],
+    max_units: int,
+) -> int:
+    """返回最后 max_units 个完整历史单元的消息起点。"""
+
+    if max_units <= 0:
+        return len(messages)
+    ranges = logical_history_unit_ranges(messages)
+    if len(ranges) <= max_units:
+        return 0
+    return ranges[-max_units][0]
+
+
 @dataclass
 class Session:
     """单次对话中的 session。"""
 
     key: str
-    messages: list[dict[str, object]] = field(
-        default_factory=list[dict[str, object]]
-    )
+    messages: list[dict[str, object]] = field(default_factory=list[dict[str, object]])
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
@@ -229,23 +323,27 @@ class Session:
         *,
         start_index: int | None = None,
     ) -> list[dict[str, object]]:
-        """将 session 消息展开为 LLM 可直接使用的 OpenAI 格式消息列表。"""
+        """按完整历史单元选择窗口并展开为 provider 消息。"""
         if start_index is not None:
             if max_messages <= 0:
                 return []
             start = max(0, int(start_index))
             if start >= len(self.messages):
                 return []
-            # 向前回退到最近的 user 边界（保留完整 turn）
-            while (
-                start > 0
-                and self.messages[start].get("role") != "user"
-                and not (
-                    self.messages[start].get("role") == "assistant"
-                    and self.messages[start].get("proactive")
-                )
-            ):
-                start -= 1
+            # 1. 新格式按显式 identity 保留完整 turn；legacy 再退到 user 边界。
+            explicit_start = _rewind_to_explicit_turn_start(self.messages, start)
+            if explicit_start != start or self.messages[start].get("control_turn_id"):
+                start = explicit_start
+            else:
+                while (
+                    start > 0
+                    and self.messages[start].get("role") != "user"
+                    and not (
+                        self.messages[start].get("role") == "assistant"
+                        and self.messages[start].get("proactive")
+                    )
+                ):
+                    start -= 1
             # start=0 但仍非合法边界时，向后找第一个 user 或 proactive assistant。
             messages = self.messages[start:]
             if messages and not (
@@ -261,7 +359,8 @@ class Session:
         elif max_messages <= 0:
             messages = []
         else:
-            messages = self.messages[-max_messages:]
+            start = logical_history_tail_start(self.messages, max_messages)
+            messages = self.messages[start:]
         out: list[dict[str, object]] = []
         for m in messages:
             role = m["role"]
@@ -314,9 +413,7 @@ class Session:
                         message_id=message_id,
                     )
                 )
-                replay_tool_chain = tool_chain[
-                    compaction.compacted_tool_groups :
-                ]
+                replay_tool_chain = tool_chain[compaction.compacted_tool_groups :]
             for group in replay_tool_chain:
                 calls = cast(list[dict[str, object]], group["calls"])
                 if not calls:

--- a/session/store.py
+++ b/session/store.py
@@ -841,6 +841,111 @@ class SessionStore:
             ).fetchone()
         return self._row_to_turn(row) if row is not None else None
 
+    def append_active_turn_item(
+        self,
+        turn_id: str,
+        *,
+        thread_id: str,
+        item: TurnItem,
+    ) -> TurnRecord:
+        """原子追加 active turn item，并拒绝终态或 thread 漂移。"""
+
+        # 1. 在同一事务读取并校验当前 active turn。
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT id, session_key, status, input_json, items_json,
+                       usage_json, error_json, final_response,
+                       created_at, started_at, completed_at
+                FROM turns
+                WHERE id = ?
+                """,
+                (turn_id,),
+            ).fetchone()
+            if row is None or str(row["session_key"]) != thread_id:
+                raise TurnNotFoundError(f"turn 不属于 thread: {thread_id}/{turn_id}")
+            status = TurnStatus(str(row["status"]))
+            if status not in {TurnStatus.QUEUED, TurnStatus.IN_PROGRESS}:
+                raise TurnStateTransitionError(
+                    f"terminal turn 不得追加 item: {turn_id}/{status.value}"
+                )
+            items = _decode_turn_items(row["items_json"], turn_id)
+            if any(existing.id == item.id for existing in items):
+                raise ValueError(f"turn item id 重复: {turn_id}/{item.id}")
+
+            # 2. status CAS 保证 append 不会跨过并发 terminal transition。
+            items.append(item)
+            payload = json.dumps(
+                [entry.to_dict() for entry in items],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            cursor = self._conn.execute(
+                "UPDATE turns SET items_json = ? WHERE id = ? AND status = ?",
+                (payload, turn_id, status.value),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise TurnStateTransitionError(
+                    f"turn item append CAS 失败: {turn_id}/{status.value}"
+                )
+            self._conn.commit()
+
+        stored = self.read_turn(turn_id)
+        if stored is None:
+            raise RuntimeError(f"turn item 追加后无法读取: {turn_id}")
+        return stored
+
+    def replace_active_turn_item(
+        self,
+        turn_id: str,
+        *,
+        thread_id: str,
+        item: TurnItem,
+    ) -> TurnRecord:
+        """原子替换 active turn 中同 identity item 的最新 checkpoint。"""
+
+        # 1. 在同一事务定位 active turn 和既有 item identity。
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT session_key, status, items_json FROM turns WHERE id = ?",
+                (turn_id,),
+            ).fetchone()
+            if row is None or str(row["session_key"]) != thread_id:
+                raise TurnNotFoundError(f"turn 不属于 thread: {thread_id}/{turn_id}")
+            status = TurnStatus(str(row["status"]))
+            if status not in {TurnStatus.QUEUED, TurnStatus.IN_PROGRESS}:
+                raise TurnStateTransitionError(
+                    f"terminal turn 不得更新 item: {turn_id}/{status.value}"
+                )
+            items = _decode_turn_items(row["items_json"], turn_id)
+            matches = [index for index, existing in enumerate(items) if existing.id == item.id]
+            if len(matches) != 1:
+                raise ValueError(f"turn item identity 无法唯一解析: {turn_id}/{item.id}")
+
+            # 2. status CAS 保证 started/completed 更新不跨过终态。
+            items[matches[0]] = item
+            payload = json.dumps(
+                [entry.to_dict() for entry in items],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            cursor = self._conn.execute(
+                "UPDATE turns SET items_json = ? WHERE id = ? AND status = ?",
+                (payload, turn_id, status.value),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise TurnStateTransitionError(
+                    f"turn item update CAS 失败: {turn_id}/{status.value}"
+                )
+            self._conn.commit()
+
+        stored = self.read_turn(turn_id)
+        if stored is None:
+            raise RuntimeError(f"turn item 更新后无法读取: {turn_id}")
+        return stored
+
     def transition_turn(
         self,
         turn_id: str,
@@ -1823,6 +1928,31 @@ class SessionStore:
                 f"同一会话存在重复 client_message_id: {session_key} {client_message_id}"
             )
         return None if not rows else self._row_to_message(rows[0])
+
+    def has_turn_user_input_by_client_id(
+        self,
+        session_key: str,
+        client_message_id: str,
+    ) -> bool:
+        """判断移动入站是否已经进入任一 durable execution attempt。"""
+
+        # 1. turns.items_json 是中断前用户输入的权威落点；只匹配 user item。
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT 1
+                FROM turns AS turn_record, json_each(turn_record.items_json) AS item
+                WHERE turn_record.session_key = ?
+                  AND json_extract(item.value, '$.type') = 'userMessage'
+                  AND json_extract(
+                        item.value,
+                        '$.data.metadata.client_message_id'
+                      ) = ?
+                LIMIT 1
+                """,
+                (session_key, client_message_id),
+            ).fetchone()
+        return row is not None
 
     def get_message_by_delivery_id(
         self,

--- a/session/store.py
+++ b/session/store.py
@@ -1070,6 +1070,69 @@ class SessionStore:
             ).fetchall()
         return [self._row_to_turn(row) for row in rows]
 
+    def recover_in_progress_turns(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> list[TurnRecord]:
+        """把上一 runtime 遗留的执行中 turn 原子收敛为 interrupted。"""
+        timestamp = now or datetime.now(UTC)
+        if timestamp.tzinfo is None:
+            raise ValueError("turn recovery 时间必须包含时区")
+        timestamp = timestamp.astimezone(UTC)
+
+        # 1. 在一个事务内闭合遗留 item，并用 status CAS 提交终态。
+        recovered_ids: list[str] = []
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, items_json FROM turns WHERE status = ? ORDER BY created_at, id",
+                (TurnStatus.IN_PROGRESS.value,),
+            ).fetchall()
+            for row in rows:
+                turn_id = str(row["id"])
+                items = _decode_turn_items(row["items_json"], turn_id)
+                closed_items = [
+                    TurnItem(
+                        item.kind,
+                        item.id,
+                        {**item.data, "status": TurnStatus.INTERRUPTED.value},
+                    )
+                    if item.data.get("status") == TurnStatus.IN_PROGRESS.value
+                    else item
+                    for item in items
+                ]
+                cursor = self._conn.execute(
+                    """
+                    UPDATE turns
+                    SET status = ?, items_json = ?, completed_at = ?
+                    WHERE id = ? AND status = ?
+                    """,
+                    (
+                        TurnStatus.INTERRUPTED.value,
+                        json.dumps(
+                            [item.to_dict() for item in closed_items],
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                        ),
+                        timestamp.isoformat(),
+                        turn_id,
+                        TurnStatus.IN_PROGRESS.value,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    self._conn.rollback()
+                    raise TurnStateTransitionError(
+                        f"turn recovery CAS 失败: {turn_id}/in_progress"
+                    )
+                recovered_ids.append(turn_id)
+            self._conn.commit()
+
+        # 2. 从提交后的权威行恢复严格领域对象。
+        recovered = [self.read_turn(turn_id) for turn_id in recovered_ids]
+        if any(record is None for record in recovered):
+            raise RuntimeError("turn recovery 提交后无法重读")
+        return cast(list[TurnRecord], recovered)
+
     def delete_thread_turns(self, thread_id: str) -> int:
         with self._lock:
             cursor = self._conn.execute(

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -140,7 +140,61 @@ async def test_recovered_mobile_handoff_with_canonical_user_skips_new_turn(
 
 
 @pytest.mark.asyncio
-async def test_worker_executes_different_threads_without_blocking_consumer(tmp_path: Path) -> None:
+async def test_recovered_mobile_handoff_in_interrupted_attempt_is_not_reenqueued(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:interrupted"
+    reached = asyncio.Event()
+
+    async def execute(_request: TurnRequest) -> str:
+        reached.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    runtime = ConversationRuntime(manager.control_store, execute)
+    handle = await runtime.start_turn(
+        TurnRequest(
+            session_key,
+            "u1",
+            {
+                "inboundMetadata": {"client_message_id": "client:interrupted"},
+            },
+        )
+    )
+    await reached.wait()
+    assert (await handle.interrupt()).status is TurnStatus.INTERRUPTED
+
+    bus = _Bus()
+    worker = PassiveMessageWorker(
+        cast(Any, bus),
+        runtime,
+        cast(Any, SimpleNamespace(session_manager=manager)),
+    )
+    recovered = InboundMessage(
+        "mobile",
+        "device:1",
+        "interrupted",
+        "u1",
+        metadata={
+            "session_key_override": session_key,
+            "client_message_id": "client:interrupted",
+        },
+        handoff_id="handoff:interrupted",
+    )
+
+    await worker._run_message(recovered)
+
+    assert bus.completed == [recovered]
+    assert len(manager.control_store.list_turns(session_key)) == 1
+    await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_executes_different_threads_without_blocking_consumer(
+    tmp_path: Path,
+) -> None:
     store = SessionStore(tmp_path / "sessions.db")
     release = asyncio.Event()
     first_started = asyncio.Event()
@@ -178,34 +232,37 @@ async def test_worker_executes_different_threads_without_blocking_consumer(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_worker_serializes_same_thread_and_continues_after_failure(tmp_path: Path) -> None:
+async def test_worker_waits_for_terminal_before_admitting_next_message(
+    tmp_path: Path,
+) -> None:
     store = SessionStore(tmp_path / "sessions.db")
-    calls: list[str] = []
+    release = asyncio.Event()
+    first_started = asyncio.Event()
 
     async def execute(request: TurnRequest) -> str:
-        calls.append(request.input)
-        if request.input == "bad":
-            raise RuntimeError("broken turn")
+        if request.input == "u1":
+            first_started.set()
+            await release.wait()
         return request.input
 
     runtime = ConversationRuntime(store, execute)
     bus = _Bus()
     worker = PassiveMessageWorker(cast(Any, bus), runtime, cast(Any, object()))
     worker_task = asyncio.create_task(worker.run())
-    bus.inbound.put_nowait(InboundMessage("telegram", "user", "same", "bad"))
-    bus.inbound.put_nowait(InboundMessage("telegram", "user", "same", "good"))
+    bus.inbound.put_nowait(InboundMessage("telegram", "user", "same", "u1"))
+    bus.inbound.put_nowait(InboundMessage("telegram", "user", "same", "u2"))
+
+    await asyncio.wait_for(first_started.wait(), 1)
+    assert len(store.list_turns("telegram:same")) == 1
+    assert bus.completed == []
+    release.set()
     _ = await asyncio.wait_for(bus.completions.get(), 1)
     _ = await asyncio.wait_for(bus.completions.get(), 1)
 
-    assert calls == ["bad", "good"]
-    assert [message.content for message in bus.outbound] == [
-        "处理消息时出错，请稍后再试。",
-        "good",
-    ]
-    assert [turn.status for turn in reversed(store.list_turns("telegram:same"))] == [
-        TurnStatus.FAILED,
-        TurnStatus.COMPLETED,
-    ]
+    assert [message.content for message in bus.outbound] == ["u1", "u2"]
+    turns = store.list_turns("telegram:same")
+    assert len(turns) == 2
+    assert all(turn.status is TurnStatus.COMPLETED for turn in turns)
     worker.stop()
     await worker_task
     await runtime.shutdown()
@@ -213,7 +270,9 @@ async def test_worker_serializes_same_thread_and_continues_after_failure(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_channel_adapter_preserves_full_outbound_projection(tmp_path: Path) -> None:
+async def test_channel_adapter_preserves_full_outbound_projection(
+    tmp_path: Path,
+) -> None:
     store = SessionStore(tmp_path / "sessions.db")
 
     async def execute(_request: TurnRequest) -> ControlExecutionResult:

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -78,6 +79,70 @@ async def test_runtime_rejects_same_thread_input_and_interrupts_exact_turn(
     record = await first.interrupt()
     assert record.status is TurnStatus.INTERRUPTED
     _assert_single_terminal(runtime, first.id)
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_startup_interrupts_crash_stale_in_progress_turn(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    stale = store.create_turn(
+        TurnRecord(
+            id="turn:stale",
+            thread_id="programmatic:restart",
+            status=TurnStatus.QUEUED,
+            input="u1",
+            metadata={"interactionId": "turn:stale", "attemptOrdinal": 0},
+            items=[
+                TurnItem(
+                    TurnItemKind.USER_MESSAGE,
+                    "user:stale",
+                    {
+                        "content": "u1",
+                        "ordinal": 0,
+                        "media": [],
+                        "metadata": {},
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                ),
+                TurnItem(
+                    TurnItemKind.TOOL_CALL,
+                    "tool:stale",
+                    {
+                        "callId": "call:stale",
+                        "name": "lookup",
+                        "arguments": {},
+                        "status": "in_progress",
+                    },
+                )
+            ],
+            usage=None,
+            error=None,
+            created_at=datetime.now(UTC),
+        )
+    )
+    store.transition_turn(
+        stale.id,
+        expected_status=TurnStatus.QUEUED,
+        status=TurnStatus.IN_PROGRESS,
+        thread_id=stale.thread_id,
+    )
+
+    async def execute(_request: TurnRequest) -> str:
+        return "continued"
+
+    runtime = ConversationRuntime(store, execute)
+
+    recovered = store.read_turn(stale.id)
+    assert recovered is not None
+    assert recovered.status is TurnStatus.INTERRUPTED
+    assert recovered.items[1].data["status"] == "interrupted"
+    continued = await runtime.start_turn(
+        TurnRequest("programmatic:restart", "u2")
+    )
+    assert (await continued.result()).status is TurnStatus.COMPLETED
     await runtime.shutdown()
     store.close()
 

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -121,7 +121,13 @@ async def test_runtime_replays_two_interrupted_attempts_into_one_interaction(
         return "final"
 
     runtime = ConversationRuntime(store, execute)
-    first = await runtime.start_turn(TurnRequest("mobile:chain", "u1"))
+    first = await runtime.start_turn(
+        TurnRequest(
+            "mobile:chain",
+            "u1",
+            {"media": ["/workspace/uploads/reference.png"]},
+        )
+    )
     await reached[0].wait()
     assert (await first.interrupt()).status is TurnStatus.INTERRUPTED
 
@@ -142,7 +148,12 @@ async def test_runtime_replays_two_interrupted_attempts_into_one_interaction(
         message["content"]
         for message in captured_final.metadata["_controlAttemptReplay"]
         if message["role"] in {"user", "tool"}
-    ] == ["u1", "result-0", "u2", "result-1"]
+    ] == [
+        "u1\n\n[附加媒体]\n- /workspace/uploads/reference.png",
+        "result-0",
+        "u2",
+        "result-1",
+    ]
     assert [
         group["calls"][0]["result"]
         for group in captured_final.metadata["_controlPriorToolChain"]

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -479,6 +479,37 @@ async def test_exception_closes_and_persists_open_tool_item(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_late_executor_exception_reuses_existing_terminal_turn(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(request: TurnRequest) -> str:
+        turn_id = cast(str, request.metadata["turnId"])
+        store.transition_turn(
+            turn_id,
+            expected_status=TurnStatus.IN_PROGRESS,
+            status=TurnStatus.INTERRUPTED,
+            thread_id=request.thread_id,
+        )
+        raise RuntimeError("late executor event")
+
+    runtime = ConversationRuntime(store, execute)
+    handle = await runtime.start_turn(TurnRequest("programmatic:terminal-race", "hello"))
+
+    result = await handle.result()
+
+    assert result.status is TurnStatus.INTERRUPTED
+    stored = store.read_turn(handle.id)
+    assert stored is not None
+    assert stored.status is TurnStatus.INTERRUPTED
+    assert stored.error is None
+    _assert_single_terminal(runtime, handle.id)
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
 async def test_fatal_runtime_failure_is_delivered_to_subscriber_once(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -25,9 +25,7 @@ from session.store import SessionStore
 
 def _assert_single_terminal(runtime: ConversationRuntime, turn_id: str) -> None:
     terminal = [
-        event
-        for event in runtime._history[turn_id]
-        if event.method == "turn/completed"
+        event for event in runtime._history[turn_id] if event.method == "turn/completed"
     ]
     assert len(terminal) == 1
 
@@ -58,7 +56,9 @@ async def test_runtime_persists_events_and_terminal_result(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_runtime_rejects_same_thread_and_interrupts_exact_turn(tmp_path: Path) -> None:
+async def test_runtime_rejects_same_thread_input_and_interrupts_exact_turn(
+    tmp_path: Path,
+) -> None:
     store = SessionStore(tmp_path / "sessions.db")
     reached = asyncio.Event()
 
@@ -70,11 +70,145 @@ async def test_runtime_rejects_same_thread_and_interrupts_exact_turn(tmp_path: P
     runtime = ConversationRuntime(store, execute)
     first = await runtime.start_turn(TurnRequest("programmatic:test", "held"))
     await reached.wait()
-    with pytest.raises(ThreadBusyError):
-        _ = await runtime.start_turn(TurnRequest("programmatic:test", "conflict"))
+    with pytest.raises(ThreadBusyError, match="thread 已有 active turn"):
+        await runtime.start_turn(TurnRequest("programmatic:test", "follow-up"))
+    checkpoint = store.read_turn(first.id)
+    assert checkpoint is not None
+    assert [item.data["content"] for item in checkpoint.items] == ["held"]
     record = await first.interrupt()
     assert record.status is TurnStatus.INTERRUPTED
     _assert_single_terminal(runtime, first.id)
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_replays_two_interrupted_attempts_into_one_interaction(
+    tmp_path: Path,
+) -> None:
+    """U1/stop/U2/stop/U3 保留一个 interaction 和全部已完成工具事实。"""
+
+    store = SessionStore(tmp_path / "sessions.db")
+    reached = [asyncio.Event(), asyncio.Event()]
+    captured_final: TurnRequest | None = None
+    captured_inputs: list[str] = []
+
+    async def execute(request: TurnRequest) -> str:
+        nonlocal captured_final, captured_inputs
+        attempt = cast(int, request.metadata["attemptOrdinal"])
+        if attempt < 2:
+            emit = request.metadata["_controlItemEvent"]
+            assert callable(emit)
+            item = TurnItem(
+                TurnItemKind.TOOL_CALL,
+                f"tool-{attempt}",
+                {
+                    "callId": f"call-{attempt}",
+                    "name": "lookup",
+                    "arguments": {"attempt": attempt},
+                    "status": "success",
+                    "resultPreview": f"result-{attempt}",
+                },
+            )
+            emit("item/started", item)
+            emit("item/completed", item)
+            reached[attempt].set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+        captured_final = request
+        source = request.metadata["_controlTurnInputSource"]
+        captured_inputs = [item.content for item in source.consumed_inputs()]
+        return "final"
+
+    runtime = ConversationRuntime(store, execute)
+    first = await runtime.start_turn(TurnRequest("mobile:chain", "u1"))
+    await reached[0].wait()
+    assert (await first.interrupt()).status is TurnStatus.INTERRUPTED
+
+    second = await runtime.start_turn(TurnRequest("mobile:chain", "u2"))
+    await reached[1].wait()
+    assert (await second.interrupt()).status is TurnStatus.INTERRUPTED
+
+    third = await runtime.start_turn(TurnRequest("mobile:chain", "u3"))
+    result = await third.result()
+
+    assert captured_final is not None
+    assert captured_final.metadata["interactionId"] == first.id
+    assert captured_final.metadata["continuedFromTurnId"] == second.id
+    assert captured_final.metadata["attemptOrdinal"] == 2
+    assert captured_final.metadata["priorInputCount"] == 2
+    assert captured_inputs == ["u1", "u2", "u3"]
+    assert [
+        message["content"]
+        for message in captured_final.metadata["_controlAttemptReplay"]
+        if message["role"] in {"user", "tool"}
+    ] == ["u1", "result-0", "u2", "result-1"]
+    assert [
+        group["calls"][0]["result"]
+        for group in captured_final.metadata["_controlPriorToolChain"]
+    ] == ["result-0", "result-1"]
+    assert result.status is TurnStatus.COMPLETED
+    assert result.final_response == "final"
+    attempts = list(reversed(store.list_turns("mobile:chain")))
+    assert [attempt.status for attempt in attempts] == [
+        TurnStatus.INTERRUPTED,
+        TurnStatus.INTERRUPTED,
+        TurnStatus.COMPLETED,
+    ]
+    assert {attempt.metadata["interactionId"] for attempt in attempts} == {first.id}
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_seal_rejects_late_input_until_terminal(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    sealed = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(request: TurnRequest) -> str:
+        source = request.metadata["_controlTurnInputSource"]
+        await source.seal()
+        sealed.set()
+        await release.wait()
+        return "done"
+
+    runtime = ConversationRuntime(store, execute)
+    first = await runtime.start_turn(TurnRequest("programmatic:seal", "first"))
+    await sealed.wait()
+    with pytest.raises(ThreadBusyError, match="thread 已有 active turn"):
+        await runtime.start_turn(TurnRequest("programmatic:seal", "late"))
+    interrupt = asyncio.create_task(first.interrupt())
+    await asyncio.sleep(0)
+    assert not interrupt.done()
+    release.set()
+    assert (await interrupt).status is TurnStatus.COMPLETED
+    assert (await first.result()).status is TurnStatus.COMPLETED
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_initial_input_releases_admission_capacity(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> str:
+        return "unused"
+
+    runtime = ConversationRuntime(store, execute)
+    with pytest.raises(ValueError, match="必须包含时区"):
+        await runtime.start_turn(
+            TurnRequest(
+                "programmatic:invalid-input",
+                "hello",
+                {"inputTimestamp": "2026-08-06T12:00:00"},
+            )
+        )
+
+    assert runtime.admission_snapshot()["turns"] == 0
+    assert runtime.admission_snapshot()["bytes"] == 0
     await runtime.shutdown()
     store.close()
 
@@ -164,7 +298,9 @@ async def test_runtime_persists_structured_tool_items_and_usage(tmp_path: Path) 
         for event in events
         if event.method == "item/assistantMessage/delta"
     ] == ["ans", "wer"]
-    tool_events = [event for event in events if event.data.get("item") == tool_item.to_dict()]
+    tool_events = [
+        event for event in events if event.data.get("item") == tool_item.to_dict()
+    ]
     assert [event.method for event in tool_events] == ["item/started", "item/completed"]
     await runtime.shutdown()
     store.close()
@@ -195,9 +331,7 @@ async def test_runtime_replays_large_delta_stream_without_detaching_subscriber(
     result = await handle.result()
 
     delta_events = [
-        event
-        for event in events
-        if event.method == "item/assistantMessage/delta"
+        event for event in events if event.method == "item/assistantMessage/delta"
     ]
     assistant_item_id = cast(str, delta_events[0].data["itemId"])
     assistant_events = [
@@ -284,7 +418,9 @@ async def test_interrupt_closes_and_persists_open_tool_item(tmp_path: Path) -> N
         return await _executor_with_open_tool(request, started)
 
     runtime = ConversationRuntime(store, execute)
-    handle = await runtime.start_turn(TurnRequest("programmatic:interrupt-item", "hello"))
+    handle = await runtime.start_turn(
+        TurnRequest("programmatic:interrupt-item", "hello")
+    )
     await started.wait()
     result = await handle.interrupt()
     events = [event async for event in handle.events()]
@@ -298,7 +434,9 @@ async def test_interrupt_closes_and_persists_open_tool_item(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_shutdown_cancel_closes_and_persists_open_tool_item(tmp_path: Path) -> None:
+async def test_shutdown_cancel_closes_and_persists_open_tool_item(
+    tmp_path: Path,
+) -> None:
     store = SessionStore(tmp_path / "sessions.db")
     started = asyncio.Event()
 

--- a/tests/control/test_d8_control_admission_replay.py
+++ b/tests/control/test_d8_control_admission_replay.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from agent.control.errors import ControlAdmissionError
-from agent.control.models import TurnRequest, TurnStatus
+from agent.control.models import TurnItem, TurnItemKind, TurnRequest, TurnStatus
 from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
 from agent.control.protocol.errors import SERVER_OVERLOADED
@@ -58,6 +58,46 @@ async def test_immediate_queued_interrupt_releases_control_admission(tmp_path: P
     record = await handle.interrupt()
     assert record.status is TurnStatus.CANCELLED
     assert runtime.admission_snapshot()["turns"] == 0
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_continued_attempt_admission_counts_only_current_input(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    first_started = asyncio.Event()
+
+    async def execute(request: TurnRequest) -> str:
+        if request.metadata["attemptOrdinal"] == 0:
+            emit = request.metadata["_controlItemEvent"]
+            item = TurnItem(
+                TurnItemKind.TOOL_CALL,
+                "large-tool",
+                {
+                    "callId": "large-call",
+                    "name": "lookup",
+                    "arguments": {},
+                    "status": "success",
+                    "resultPreview": "x" * 8192,
+                },
+            )
+            emit("item/started", item)
+            emit("item/completed", item)
+            first_started.set()
+            await asyncio.Event().wait()
+        return "continued"
+
+    runtime = ConversationRuntime(store, execute, max_active_bytes=2048)
+    first = await runtime.start_turn(TurnRequest("programmatic:bounded", "u1"))
+    await first_started.wait()
+    assert (await first.interrupt()).status is TurnStatus.INTERRUPTED
+
+    second = await runtime.start_turn(TurnRequest("programmatic:bounded", "u2"))
+
+    assert (await second.result()).status is TurnStatus.COMPLETED
+    assert runtime.admission_snapshot()["bytes"] == 0
     await runtime.shutdown()
     store.close()
 

--- a/tests/control/test_protocol.py
+++ b/tests/control/test_protocol.py
@@ -33,7 +33,10 @@ async def test_router_requires_full_handshake_and_routes_turn(tmp_path: Path) ->
     await router.handle_line(
         b'{"jsonrpc":"2.0","id":1,"method":"server/status","params":{}}\n'
     )
-    assert sent[-1]["error"] == {"code": -32002, "message": "Client must complete initialize/initialized"}
+    assert sent[-1]["error"] == {
+        "code": -32002,
+        "message": "Client must complete initialize/initialized",
+    }
 
     await router.handle_line(
         b'{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"1.0","clientInfo":{"name":"test","version":"1"},"capabilities":{}}}\n'
@@ -44,8 +47,12 @@ async def test_router_requires_full_handshake_and_routes_turn(tmp_path: Path) ->
     capabilities = initialize_result["capabilities"]
     assert isinstance(capabilities, dict)
     assert capabilities["reasoningEvents"] is False
+    assert capabilities["turnInterrupt"] is True
+    assert capabilities["turnSteer"] is False
     await router.handle_line(b'{"jsonrpc":"2.0","method":"initialized","params":{}}\n')
-    await router.handle_line(b'{"jsonrpc":"2.0","id":3,"method":"thread/start","params":{"metadata":{}}}\n')
+    await router.handle_line(
+        b'{"jsonrpc":"2.0","id":3,"method":"thread/start","params":{"metadata":{}}}\n'
+    )
     response = next(item for item in sent if item.get("id") == 3)
     thread = response["result"]
     assert isinstance(thread, dict)
@@ -64,6 +71,68 @@ async def test_router_requires_full_handshake_and_routes_turn(tmp_path: Path) ->
     await asyncio.wait_for(_wait_terminal(sent), timeout=1)
     terminal = [item for item in sent if item.get("method") == "turn/completed"]
     assert len(terminal) == 1
+    await router.close()
+    await runtime.shutdown()
+    sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_turn_start_returns_busy_for_active_turn(
+    tmp_path: Path,
+) -> None:
+    sessions = SessionManager(tmp_path)
+    release = asyncio.Event()
+
+    async def execute(request: TurnRequest) -> str:
+        await release.wait()
+        return request.input
+
+    runtime = ConversationRuntime(sessions.control_store, execute)
+    service = ControlService(runtime, sessions, tmp_path)
+    sent: list[dict[str, object]] = []
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    router = ConnectionRouter(service, send)
+    await router.handle_line(
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1.0","clientInfo":{"name":"test","version":"1"},"capabilities":{}}}\n'
+    )
+    await router.handle_line(b'{"jsonrpc":"2.0","method":"initialized","params":{}}\n')
+    thread = service.start_thread({}, "stable")
+    thread_id = str(thread["id"])
+    for request_id, content, detached in (
+        (2, "u1", True),
+        (3, "u2", False),
+    ):
+        await router.handle_line(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "turn/start",
+                    "params": {
+                        "threadId": thread_id,
+                        "input": content,
+                        "metadata": {},
+                        "detached": detached,
+                    },
+                }
+            ).encode()
+        )
+    first = next(item for item in sent if item.get("id") == 2)
+    second = next(item for item in sent if item.get("id") == 3)
+    first_result = first["result"]
+    assert isinstance(first_result, dict)
+    second_error = second["error"]
+    assert isinstance(second_error, dict)
+    assert second_error["code"] == -32011
+    assert second_error["data"] == {"retryable": True}
+    assert "thread 已有 active turn" in str(second_error["message"])
+    release.set()
+    await asyncio.wait_for(_wait_terminal(sent), timeout=1)
+    await asyncio.sleep(0)
+    assert len([item for item in sent if item.get("method") == "turn/completed"]) == 1
     await router.close()
     await runtime.shutdown()
     sessions.close()
@@ -246,7 +315,9 @@ async def test_failed_token_does_not_advance_handshake_state(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_thread_consolidation_returns_operation_and_notification(tmp_path: Path) -> None:
+async def test_thread_consolidation_returns_operation_and_notification(
+    tmp_path: Path,
+) -> None:
     sessions = SessionManager(tmp_path)
     runtime = ConversationRuntime(sessions.control_store, _echo)
     consolidated: list[str] = []
@@ -278,7 +349,9 @@ async def test_thread_consolidation_returns_operation_and_notification(tmp_path:
     assert isinstance(operation, dict)
     assert operation["status"] == "in_progress"
     await asyncio.wait_for(_wait_method(sent, "operation/completed"), 1)
-    completed = next(item for item in sent if item.get("method") == "operation/completed")
+    completed = next(
+        item for item in sent if item.get("method") == "operation/completed"
+    )
     assert completed["params"] == {
         "operation": {
             "id": operation["id"],
@@ -350,7 +423,9 @@ async def test_plugin_uninstall_returns_before_old_turn_drain_completes(
 
     old_turn_released.set()
     await asyncio.wait_for(_wait_method(sent, "operation/completed"), timeout=1)
-    completed = next(item for item in sent if item.get("method") == "operation/completed")
+    completed = next(
+        item for item in sent if item.get("method") == "operation/completed"
+    )
     assert completed["params"] == {
         "operation": {
             "id": operation["id"],
@@ -495,9 +570,7 @@ async def test_thread_runtime_selector_is_strict_and_inherited_by_turn(
 
     thread = service.start_thread({"skip_post_memory": True}, "latest")
     thread_id = cast(str, thread["id"])
-    result = await (
-        await service.start_turn(thread_id, "verify", {}, None)
-    ).result()
+    result = await (await service.start_turn(thread_id, "verify", {}, None)).result()
 
     assert thread["metadata"] == {
         "skip_post_memory": True,
@@ -537,13 +610,13 @@ async def test_router_disconnect_interrupts_only_attached_turn(
     await router.handle_line(
         b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1.0","clientInfo":{"name":"test","version":"1"},"capabilities":{}}}\n'
     )
-    await router.handle_line(
-        b'{"jsonrpc":"2.0","method":"initialized","params":{}}\n'
-    )
+    await router.handle_line(b'{"jsonrpc":"2.0","method":"initialized","params":{}}\n')
     await router.handle_line(
         b'{"jsonrpc":"2.0","id":2,"method":"thread/start","params":{"metadata":{},"runtime":"latest"}}\n'
     )
-    thread = cast(dict[str, object], next(item for item in sent if item.get("id") == 2)["result"])
+    thread = cast(
+        dict[str, object], next(item for item in sent if item.get("id") == 2)["result"]
+    )
     thread_id = cast(str, thread["id"])
     await router.handle_line(
         (
@@ -552,7 +625,9 @@ async def test_router_disconnect_interrupts_only_attached_turn(
         ).encode()
     )
     await started.wait()
-    turn = cast(dict[str, object], next(item for item in sent if item.get("id") == 3)["result"])
+    turn = cast(
+        dict[str, object], next(item for item in sent if item.get("id") == 3)["result"]
+    )
     turn_id = cast(str, turn["id"])
 
     await router.close()
@@ -610,9 +685,7 @@ async def test_plugin_candidate_control_methods_use_runtime_owner(
         "publicationState": "latest_ready"
     }
     assert service.plugin_status() == {"candidateState": "latest_ready"}
-    assert await service.promote_plugin("feed@lab") == {
-        "publication_state": "promoted"
-    }
+    assert await service.promote_plugin("feed@lab") == {"publication_state": "promoted"}
     assert await service.discard_plugin("feed@lab") == {
         "publication_state": "discarded"
     }

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1259,6 +1259,8 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     web_session = manager.get_or_create(f"web:{uuid4()}")
     web_session.add_message("user", "不要同步 Web 会话")
     manager.save(web_session)
+    empty_session_id = f"mobile:{uuid4()}"
+    manager.get_or_create(empty_session_id)
 
     listed = await channel.handle_command(
         device_id=device_id,
@@ -1278,14 +1280,15 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     )
 
     assert listed.type == "session.list.ok"
-    assert listed.payload["total"] == 1
+    assert listed.payload["total"] == 2
     session_event = runtime.events[-2]
     assert session_event["event_type"] == "session.list"
     session_payload = cast(dict[str, object], session_event["payload"])
     session_items = cast(list[dict[str, object]], session_payload["items"])
-    assert len(session_items) == 1
-    assert session_items[0]["session_id"] == session_id
-    assert session_items[0]["title"] == "恢复这段对话"
+    assert len(session_items) == 2
+    session_items_by_id = {str(item["session_id"]): item for item in session_items}
+    assert session_items_by_id[session_id]["title"] == "恢复这段对话"
+    assert session_items_by_id[empty_session_id]["title"] == "新对话"
     assert history.type == "history.get.ok"
     history_event = runtime.events[-1]
     history_payload = cast(dict[str, object], history_event["payload"])

--- a/tests/test_agent_core_p2_reasoner.py
+++ b/tests/test_agent_core_p2_reasoner.py
@@ -1,10 +1,11 @@
 import asyncio
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
 
 from agent.core.passive_turn import DefaultReasoner, get_history_since_consolidated
+from agent.control.ports import TurnUserInput
 from agent.core.runtime_support import LLMServices, ToolDiscoveryState
 from agent.lifecycle.types import AfterStepCtx
 from agent.looping.ports import LLMConfig
@@ -141,7 +142,12 @@ def test_default_reasoner_runs_tool_loop_and_returns_reasoner_result():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -158,11 +164,123 @@ def test_default_reasoner_runs_tool_loop_and_returns_reasoner_result():
     react_stats = result.metadata["react_stats"]
     assert react_stats["iteration_count"] == 2
     assert react_stats["turn_input_sum_tokens"] >= react_stats["turn_input_peak_tokens"]
-    assert react_stats["final_call_input_tokens"] == react_stats["turn_input_peak_tokens"]
+    assert (
+        react_stats["final_call_input_tokens"] == react_stats["turn_input_peak_tokens"]
+    )
     assert react_stats["cache_prompt_tokens"] == 220
     assert react_stats["cache_hit_tokens"] == 100
     first_messages = provider.calls[0]["messages"]
-    assert not any("未加载工具目录" in str(m.get("content", "")) for m in first_messages)
+    assert not any(
+        "未加载工具目录" in str(m.get("content", "")) for m in first_messages
+    )
+
+
+def test_default_reasoner_replays_interrupted_attempt_before_current_input():
+    provider = _Provider([LLMResponse(content="final after u2", tool_calls=[])])
+    timestamp = datetime.now(UTC)
+    inputs = (
+        TurnUserInput("u1", 0, "first request", (), {}, timestamp),
+        TurnUserInput("u2", 1, "continue with node status", (), {}, timestamp),
+    )
+
+    class _Source:
+        async def seal(self) -> None:
+            return None
+
+        def consumed_inputs(self) -> tuple[TurnUserInput, ...]:
+            return inputs
+
+    replay = [
+        {"role": "user", "content": "first request"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "node=ready"},
+        {"role": "assistant", "content": "[execution attempt interrupted]"},
+    ]
+    prior_tool_chain = [
+        {
+            "text": "",
+            "calls": [
+                {
+                    "call_id": "call-1",
+                    "name": "lookup",
+                    "arguments": {},
+                    "result": "node=ready",
+                }
+            ],
+        }
+    ]
+    reasoner = DefaultReasoner(
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=ToolRegistry(),
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=False,
+        memory_window=1,
+        context=cast(
+            Any,
+            SimpleNamespace(
+                render=lambda request, **_: SimpleNamespace(
+                    messages=[
+                        *request.history,
+                        {"role": "user", "content": request.current_message},
+                    ],
+                ),
+            ),
+        ),
+    )
+    session = SimpleNamespace(
+        key="mobile:one",
+        messages=[{"role": "user", "content": "old canonical"}],
+        get_history=lambda max_messages=40, *, start_index=None: [
+            {"role": "user", "content": "old canonical"}
+        ],
+        last_consolidated=0,
+    )
+    msg = SimpleNamespace(
+        content="continue with node status",
+        media=[],
+        channel="mobile",
+        chat_id="one",
+        timestamp=timestamp,
+        metadata={
+            "_control_turn_input_source": _Source(),
+            "_control_attempt_replay": replay,
+            "_control_prior_tool_chain": prior_tool_chain,
+            "_control_prior_input_count": 1,
+        },
+    )
+
+    result = asyncio.run(reasoner.run_turn(msg=msg, session=cast(Any, session)))
+
+    assert provider.calls[0]["messages"][:-1] == [
+        {"role": "user", "content": "old canonical"},
+        *replay,
+        {"role": "user", "content": "continue with node status"},
+    ]
+    assert provider.calls[0]["messages"][-1] == {
+        "role": "assistant",
+        "content": "final after u2",
+    }
+    assert result.reply == "final after u2"
+    assert result.tool_chain == prior_tool_chain
+    assert result.tools_used == ["lookup"]
+    assert result.react_compaction is None
+    assert "llm_user_content" not in result.context_retry
 
 
 def test_default_reasoner_blocks_disabled_tool_even_if_model_calls_it():
@@ -179,7 +297,12 @@ def test_default_reasoner_blocks_disabled_tool_even_if_model_calls_it():
     tools = ToolRegistry()
     tools.register(push, always_on=True, risk="external-side-effect")
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -233,7 +356,12 @@ def test_default_reasoner_disable_memory_writes_expands_to_memory_write_tools():
     )
     tools.register(_DummyTool("read_file"), always_on=True, risk="read-only")
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -267,9 +395,7 @@ def test_default_reasoner_disable_memory_writes_expands_to_memory_write_tools():
 
     # 1. memory 来源的写工具被展开禁用，检索与普通工具保留。
     first_tools = cast(list[dict[str, Any]], provider.calls[0]["tools"])
-    first_tool_names = [
-        schema["function"]["name"] for schema in first_tools
-    ]
+    first_tool_names = [schema["function"]["name"] for schema in first_tools]
     assert "memorize" not in first_tool_names
     assert "recall_memory" in first_tool_names
     assert "read_file" in first_tool_names
@@ -369,7 +495,12 @@ def test_default_reasoner_tool_search_cannot_reunlock_disabled_tool():
     tools.register(ToolSearchTool(tools), always_on=True, risk="read-only")
     tools.register(push, always_on=True, risk="external-side-effect")
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -433,7 +564,9 @@ def test_default_reasoner_zero_max_iterations_is_unlimited():
 def test_default_reasoner_stops_on_context_pressure_after_tool_batch(monkeypatch):
     provider = _Provider(
         [
-            LLMResponse(content="", tool_calls=[ToolCall("c1", "inflate_probe", {"value": 1})]),
+            LLMResponse(
+                content="", tool_calls=[ToolCall("c1", "inflate_probe", {"value": 1})]
+            ),
             LLMResponse(content="阶段性回复", tool_calls=[]),
         ]
     )
@@ -473,10 +606,14 @@ def test_default_reasoner_stops_on_context_pressure_after_tool_batch(monkeypatch
     assert len(result.metadata["tool_chain"]) == 1
 
 
-def test_default_reasoner_context_pressure_policy_lives_in_after_step_plugin(monkeypatch):
+def test_default_reasoner_context_pressure_policy_lives_in_after_step_plugin(
+    monkeypatch,
+):
     provider = _Provider(
         [
-            LLMResponse(content="", tool_calls=[ToolCall("c1", "inflate_probe", {"value": 1})]),
+            LLMResponse(
+                content="", tool_calls=[ToolCall("c1", "inflate_probe", {"value": 1})]
+            ),
             LLMResponse(content="final", tool_calls=[]),
         ]
     )
@@ -531,17 +668,25 @@ def test_default_reasoner_observes_tool_lifecycle_events():
         lambda event: order.append("completed") or completed_events.append(event),
     )
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
         tool_search_enabled=False,
         memory_window=40,
-        context=cast(Any, SimpleNamespace(
+        context=cast(
+            Any,
+            SimpleNamespace(
                 render=lambda request, **_: SimpleNamespace(
-                messages=[{"role": "user", "content": request.current_message}],
+                    messages=[{"role": "user", "content": request.current_message}],
+                ),
             ),
-        )),
+        ),
         event_bus=event_bus,
     )
     session = SimpleNamespace(
@@ -581,7 +726,9 @@ def test_default_reasoner_observes_tool_lifecycle_events():
 def test_default_reasoner_observes_blocked_tool_lifecycle_events():
     provider = _Provider(
         [
-            LLMResponse(content="", tool_calls=[ToolCall("c1", "hidden_tool", {"x": 1})]),
+            LLMResponse(
+                content="", tool_calls=[ToolCall("c1", "hidden_tool", {"x": 1})]
+            ),
             LLMResponse(content="final", tool_calls=[]),
         ]
     )
@@ -602,7 +749,12 @@ def test_default_reasoner_observes_blocked_tool_lifecycle_events():
         lambda event: order.append("completed") or completed_events.append(event),
     )
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -648,7 +800,12 @@ def test_default_reasoner_unlocks_tool_search_visibility():
     hidden = _DummyTool("hidden_tool")
     tools.register(hidden)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -684,7 +841,12 @@ def test_default_reasoner_preflight_includes_deferred_tool_names():
         source_name="github",
     )
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -729,7 +891,12 @@ def test_default_reasoner_deferred_tool_direct_call_requires_select():
     tools.register(_DummyTool(), always_on=True)
     tools.register(_DummyTool("schedule"))
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -743,7 +910,9 @@ def test_default_reasoner_deferred_tool_direct_call_requires_select():
     assert result.reply == "final"
     tool_chain = list(result.metadata["tool_chain"])
     assert len(tool_chain) >= 1
-    schedule_call = next((c for c in tool_chain[0]["calls"] if c["name"] == "schedule"), None)
+    schedule_call = next(
+        (c for c in tool_chain[0]["calls"] if c["name"] == "schedule"), None
+    )
     assert schedule_call is not None
     assert "select:" in schedule_call["result"]
     assert "tool_search" in schedule_call["result"]
@@ -755,7 +924,12 @@ def test_default_reasoner_preloaded_tool_not_in_deferred_list():
     tools.register(_DummyTool(), always_on=True)
     tools.register(_DummyTool("schedule"))
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -771,7 +945,9 @@ def test_default_reasoner_preloaded_tool_not_in_deferred_list():
     )
 
     first_messages = provider.calls[0]["messages"]
-    assert not any("未加载工具目录" in str(m.get("content", "")) for m in first_messages)
+    assert not any(
+        "未加载工具目录" in str(m.get("content", "")) for m in first_messages
+    )
 
 
 def test_default_reasoner_run_turn_uses_context_render():
@@ -779,19 +955,31 @@ def test_default_reasoner_run_turn_uses_context_render():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
         tool_search_enabled=False,
         memory_window=40,
-        context=cast(Any, SimpleNamespace(
+        context=cast(
+            Any,
+            SimpleNamespace(
                 render=lambda request, **_: SimpleNamespace(
-                messages=[{"role": "user", "content": request.current_message}],
+                    messages=[{"role": "user", "content": request.current_message}],
+                ),
+                build_messages=lambda **_: (_ for _ in ()).throw(
+                    AssertionError("legacy build_messages should not be used")
+                ),
+                build_turn_injection_context=lambda **_: (_ for _ in ()).throw(
+                    AssertionError("legacy turn_injection should not be used")
+                ),
             ),
-            build_messages=lambda **_: (_ for _ in ()).throw(AssertionError("legacy build_messages should not be used")),
-            build_turn_injection_context=lambda **_: (_ for _ in ()).throw(AssertionError("legacy turn_injection should not be used")),
-        )),
+        ),
     )
 
     session = SimpleNamespace(
@@ -820,17 +1008,25 @@ def test_default_reasoner_run_turn_reports_llm_timeout():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
         tool_search_enabled=False,
         memory_window=40,
-        context=cast(Any, SimpleNamespace(
+        context=cast(
+            Any,
+            SimpleNamespace(
                 render=lambda request, **_: SimpleNamespace(
-                messages=[{"role": "user", "content": request.current_message}],
+                    messages=[{"role": "user", "content": request.current_message}],
+                ),
             ),
-        )),
+        ),
     )
     session = SimpleNamespace(
         key="cli:1",
@@ -872,7 +1068,12 @@ def test_empty_content_with_thinking_triggers_retry_and_succeeds():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -890,9 +1091,7 @@ def test_empty_content_with_thinking_triggers_retry_and_succeeds():
     ]
     retry_call = provider.calls[1]
     assert retry_call["disable_thinking"] is True
-    assert [
-        schema["function"]["name"] for schema in retry_call["tools"]
-    ] == ["dummy"]
+    assert [schema["function"]["name"] for schema in retry_call["tools"]] == ["dummy"]
     assert len(provider.calls) == 2
 
 
@@ -932,9 +1131,9 @@ def test_empty_content_with_thinking_retry_can_enter_tool_loop():
     assert tool.calls == [{}]
     assert len(provider.calls) == 3
     assert provider.calls[1]["disable_thinking"] is True
-    assert [
-        schema["function"]["name"] for schema in provider.calls[1]["tools"]
-    ] == ["dummy"]
+    assert [schema["function"]["name"] for schema in provider.calls[1]["tools"]] == [
+        "dummy"
+    ]
 
 
 def test_empty_content_with_thinking_retry_still_empty_falls_back():
@@ -947,7 +1146,12 @@ def test_empty_content_with_thinking_retry_still_empty_falls_back():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -971,7 +1175,12 @@ def test_empty_content_without_thinking_no_retry():
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),
@@ -1023,7 +1232,12 @@ def test_default_reasoner_reuses_snapshot_step_phases(monkeypatch):
     tools = ToolRegistry()
     tools.register(_DummyTool(), always_on=True)
     reasoner = DefaultReasoner(
-        llm=cast(Any, LLMServices(provider=cast(Any, provider), light_provider=cast(Any, provider))),
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
         llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
         tools=tools,
         discovery=ToolDiscoveryState(),

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -14,6 +14,7 @@ from agent.core.passive_support import build_context_hint_message
 from agent.core.passive_turn import ContextStore
 from agent.core.response_parser import ResponseMetadata
 from agent.core.runtime_support import TurnRunResult
+from agent.control.ports import TurnUserInput
 from agent.core.types import ContextBundle
 from agent.lifecycle.phase import Phase
 from agent.tools.registry import ToolRegistry
@@ -80,8 +81,7 @@ def open_observe_db(path: Path) -> sqlite3.Connection:
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS turns (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             ts TEXT NOT NULL,
@@ -108,8 +108,7 @@ def open_observe_db(path: Path) -> sqlite3.Connection:
             react_cache_prompt_tokens INTEGER,
             react_cache_hit_tokens INTEGER
         )
-        """
-    )
+        """)
     return conn
 
 
@@ -181,7 +180,9 @@ class _KVCachePluginModule:
         return frame
 
 
-def _format_memory_status_reply(messages: list[dict[str, object]], last_consolidated: int) -> str:
+def _format_memory_status_reply(
+    messages: list[dict[str, object]], last_consolidated: int
+) -> str:
     consolidated_user = _count_real_user_messages(messages[:last_consolidated])
     total_user = _count_real_user_messages(messages)
     pending_user = max(0, total_user - consolidated_user)
@@ -195,7 +196,9 @@ def _format_memory_status_reply(messages: list[dict[str, object]], last_consolid
     else:
         lines.append(f"上次整理到 {pending_user} 条用户消息之前。")
     if last_user_message:
-        lines.extend(["", "最后已整理的用户消息：", f"“{_preview_text(last_user_message)}”"])
+        lines.extend(
+            ["", "最后已整理的用户消息：", f"“{_preview_text(last_user_message)}”"]
+        )
     lines.extend(
         [
             "",
@@ -252,7 +255,11 @@ def _latest_real_user_content(messages: list[dict[str, object]]) -> str:
 
 def _is_real_user_message(item: dict[str, object]) -> bool:
     content = str(item.get("content", "")).strip()
-    return item.get("role") == "user" and bool(content) and "data-system-context-frame" not in content
+    return (
+        item.get("role") == "user"
+        and bool(content)
+        and "data-system-context-frame" not in content
+    )
 
 
 def _preview_text(text: str, limit: int = 80) -> str:
@@ -269,8 +276,11 @@ def _format_ts(ts: str) -> str:
 
 def _inbound() -> InboundMessage:
     return InboundMessage(
-        channel="telegram", sender="user", chat_id="123",
-        content="hello", timestamp=_now,
+        channel="telegram",
+        sender="user",
+        chat_id="123",
+        content="hello",
+        timestamp=_now,
     )
 
 
@@ -281,7 +291,9 @@ class _DummySession:
         self.metadata: dict[str, object] = {}
         self.last_consolidated = 0
 
-    def get_history(self, max_messages: int = 500, *, start_index: int | None = None) -> list[dict[str, object]]:
+    def get_history(
+        self, max_messages: int = 500, *, start_index: int | None = None
+    ) -> list[dict[str, object]]:
         return list(self.messages)
 
     def add_message(
@@ -346,7 +358,9 @@ async def test_before_turn_existing_admission_never_creates_deleted_session():
     session = _DummySession("mobile:deleted")
     get_existing = Mock(return_value=session)
     get_or_create = Mock(side_effect=AssertionError("不得重建已删除会话"))
-    session_mgr = SimpleNamespace(get_existing=get_existing, get_or_create=get_or_create)
+    session_mgr = SimpleNamespace(
+        get_existing=get_existing, get_or_create=get_or_create
+    )
     ctx_store = SimpleNamespace(prepare=AsyncMock(return_value=ContextBundle()))
     phase = Phase(
         default_before_turn_modules(
@@ -484,10 +498,7 @@ async def test_before_turn_memory_status_command_aborts_without_context_prepare(
 async def test_before_turn_memory_context_guard_blocks_unconsolidated_tail():
     bus = EventBus()
     session = _DummySession("telegram:123")
-    session.messages = [
-        {"role": "user", "content": f"u{i}"}
-        for i in range(30)
-    ]
+    session.messages = [{"role": "user", "content": f"u{i}"} for i in range(30)]
     session.last_consolidated = 0
     session_mgr = SimpleNamespace(get_or_create=lambda key: session)
     ctx_store = SimpleNamespace(prepare=AsyncMock())
@@ -524,13 +535,49 @@ async def test_before_turn_memory_context_guard_blocks_unconsolidated_tail():
 
 
 @pytest.mark.asyncio
-async def test_before_turn_memory_context_guard_consolidates_before_blocking():
+async def test_before_turn_memory_context_guard_counts_multi_input_turn_once():
     bus = EventBus()
     session = _DummySession("telegram:123")
     session.messages = [
-        {"role": "user", "content": f"u{i}"}
-        for i in range(30)
+        {
+            "role": "user" if index < 29 else "assistant",
+            "content": f"message-{index}",
+            "control_turn_id": "turn-one",
+        }
+        for index in range(30)
     ]
+    session.last_consolidated = 0
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(
+        prepare=AsyncMock(return_value=ContextBundle(history_messages=[]))
+    )
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+            keep_count=20,
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+
+    ctx = await phase.run(
+        TurnState(
+            msg=_inbound(),
+            session_key="telegram:123",
+            dispatch_outbound=True,
+        )
+    )
+
+    assert ctx.abort is False
+    ctx_store.prepare.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_before_turn_memory_context_guard_consolidates_before_blocking():
+    bus = EventBus()
+    session = _DummySession("telegram:123")
+    session.messages = [{"role": "user", "content": f"u{i}"} for i in range(30)]
     session.last_consolidated = 0
     session_mgr = SimpleNamespace(get_or_create=lambda key: session)
     ctx_store = SimpleNamespace(
@@ -577,10 +624,7 @@ async def test_before_turn_memory_context_guard_consolidates_before_blocking():
 async def test_before_turn_memory_context_guard_blocks_after_consolidation_failure():
     bus = EventBus()
     session = _DummySession("telegram:123")
-    session.messages = [
-        {"role": "user", "content": f"u{i}"}
-        for i in range(30)
-    ]
+    session.messages = [{"role": "user", "content": f"u{i}"} for i in range(30)]
     session.last_consolidated = 0
     session_mgr = SimpleNamespace(get_or_create=lambda key: session)
     ctx_store = SimpleNamespace(prepare=AsyncMock())
@@ -622,9 +666,7 @@ async def test_before_turn_memory_exclusion_overrides_explicit_turn_flag():
     bus = EventBus()
     session = _DummySession("telegram:123")
     session.metadata = {"skip_post_memory": True}
-    session.messages = [
-        {"role": "user", "content": f"u{i}"} for i in range(30)
-    ]
+    session.messages = [{"role": "user", "content": f"u{i}"} for i in range(30)]
     session.last_consolidated = 0
     session_mgr = SimpleNamespace(get_or_create=lambda key: session)
     ctx_store = SimpleNamespace(
@@ -658,9 +700,7 @@ async def test_before_turn_memory_exclusion_overrides_explicit_turn_flag():
 async def test_before_turn_injects_memory_exclusion_for_scheduler_session():
     bus = EventBus()
     session = _DummySession("scheduler:job")
-    session.messages = [
-        {"role": "user", "content": f"u{i}"} for i in range(30)
-    ]
+    session.messages = [{"role": "user", "content": f"u{i}"} for i in range(30)]
     session.last_consolidated = 0
     session_mgr = SimpleNamespace(get_or_create=lambda key: session)
     ctx_store = SimpleNamespace(
@@ -1016,9 +1056,13 @@ async def test_before_reasoning_setup_calls_tools_set_context():
     msg = _inbound()
 
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="block", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="block",
+        retrieval_trace_raw=None,
         history_messages=(),
         skill_names=["search"],
     )
@@ -1058,16 +1102,22 @@ async def test_before_reasoning_requires_session():
     msg = _inbound()
 
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
         history_messages=(),
     )
 
     state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
     # session is None
 
-    with pytest.raises(RuntimeError, match="BeforeReasoning requires TurnState.session"):
+    with pytest.raises(
+        RuntimeError, match="BeforeReasoning requires TurnState.session"
+    ):
         await phase.run(BeforeReasoningInput(state=state, before_turn=before_turn))
 
 
@@ -1097,9 +1147,13 @@ async def test_before_reasoning_finalize_calls_render():
     msg = _inbound()
 
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="block", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="block",
+        retrieval_trace_raw=None,
         history_messages=(),
         skill_names=["search"],
     )
@@ -1147,9 +1201,13 @@ async def test_before_reasoning_chain_can_add_extra_hints():
     msg = _inbound()
 
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
         history_messages=(),
         extra_hints=["hint from before turn"],
     )
@@ -1192,9 +1250,13 @@ async def test_before_reasoning_collects_export_slots():
     )
     msg = _inbound()
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
         history_messages=(),
     )
     state = TurnState(msg=msg, session_key="telegram:123", dispatch_outbound=True)
@@ -1239,9 +1301,13 @@ async def test_before_reasoning_chain_modify_skill_names_used_in_finalize_render
     msg = _inbound()
 
     before_turn = BeforeTurnCtx(
-        session_key="telegram:123", channel=msg.channel, chat_id=msg.chat_id,
-        content=msg.content, timestamp=msg.timestamp,
-        retrieved_memory_block="original_block", retrieval_trace_raw=None,
+        session_key="telegram:123",
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=msg.content,
+        timestamp=msg.timestamp,
+        retrieved_memory_block="original_block",
+        retrieval_trace_raw=None,
         history_messages=(),
         skill_names=["base_skill"],
     )
@@ -1676,7 +1742,9 @@ async def test_after_reasoning_persists_mobile_canonical_ids(tmp_path: Path):
         requires = ("after_reasoning.emit", "reasoning:ctx")
 
         async def run(self, frame: AfterReasoningFrame) -> AfterReasoningFrame:
-            frame.slots["outbound:metadata:client_message_id"] = "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+            frame.slots["outbound:metadata:client_message_id"] = (
+                "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+            )
             return frame
 
     manager = SessionManager(tmp_path / "workspace")
@@ -1711,8 +1779,83 @@ async def test_after_reasoning_persists_mobile_canonical_ids(tmp_path: Path):
 
     assert messages[0]["client_message_id"] == "01ARZ3NDEKTSV4RRFFQ69G5FAV"
     assert result.outbound.metadata["persisted_user_message_id"] == messages[0]["id"]
-    assert result.outbound.metadata["client_message_id"] == messages[0]["client_message_id"]
+    assert (
+        result.outbound.metadata["client_message_id"]
+        == messages[0]["client_message_id"]
+    )
     assert result.outbound.session_message_id == messages[1]["id"]
+    reloaded.close()
+
+
+@pytest.mark.asyncio
+async def test_after_reasoning_commits_all_same_turn_users_before_final_assistant(
+    tmp_path: Path,
+):
+    class _Source:
+        def consumed_inputs(self) -> tuple[TurnUserInput, ...]:
+            return (
+                TurnUserInput("i1", 0, "u1", (), {}, _now),
+                TurnUserInput(
+                    "i2",
+                    1,
+                    "u2",
+                    (),
+                    {"skip_post_memory": True},
+                    _now,
+                ),
+            )
+
+    manager = SessionManager(tmp_path / "workspace")
+    session = manager.get_or_create("telegram:same-turn")
+    msg = InboundMessage(
+        channel="telegram",
+        sender="user",
+        chat_id="same-turn",
+        content="u1",
+        metadata={
+            "control_turn_id": "turn-1",
+            "_control_turn_input_source": _Source(),
+        },
+    )
+    state = TurnState(msg=msg, session_key=session.key, dispatch_outbound=True)
+    state.session = session
+    phase = Phase(
+        default_after_reasoning_modules(
+            EventBus(),
+            cast(Any, SimpleNamespace(presence=None, session_manager=manager)),
+        ),
+        frame_factory=AfterReasoningFrame,
+    )
+
+    result = await phase.run(
+        AfterReasoningInput(
+            state=state,
+            turn_result=TurnRunResult(reply="final"),
+        )
+    )
+    manager.close()
+    reloaded = SessionManager(tmp_path / "workspace")
+    messages = reloaded.get_or_create(session.key).messages
+
+    assert [(item["role"], item["content"]) for item in messages] == [
+        ("user", "u1"),
+        ("user", "u2"),
+        ("assistant", "final"),
+    ]
+    assert [item["turn_input_ordinal"] for item in messages[:2]] == [0, 1]
+    assert [item["timestamp"] for item in messages[:2]] == [
+        _now.isoformat(),
+        _now.isoformat(),
+    ]
+    assert all(item["control_turn_id"] == "turn-1" for item in messages)
+    assert messages[2]["turn_terminal"] is True
+    assert messages[2]["turn_input_count"] == 2
+    assert messages[1]["skip_post_memory"] is True
+    assert messages[2]["skip_post_memory"] is True
+    assert result.outbound.metadata["persisted_user_message_ids"] == [
+        messages[0]["id"],
+        messages[1]["id"],
+    ]
     reloaded.close()
 
 
@@ -1835,8 +1978,14 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
                 channel=msg.channel,
                 chat_id=msg.chat_id,
                 content="reply",
-                metadata={"persisted_user_message_id": "telegram:123:0"},
-                session_message_id="telegram:123:1",
+                metadata={
+                    "persisted_user_message_id": "telegram:123:0",
+                    "persisted_user_message_ids": [
+                        "telegram:123:0",
+                        "telegram:123:1",
+                    ],
+                },
+                session_message_id="telegram:123:2",
             ),
             ctx=ctx,
         )
@@ -1844,5 +1993,9 @@ async def test_after_turn_collects_extra_and_telemetry_slots():
 
     assert committed_extra[0]["plugin_flag"] == "extra"
     assert committed_events[0].persisted_user_message_id == "telegram:123:0"
-    assert committed_events[0].assistant_message_id == "telegram:123:1"
+    assert committed_events[0].persisted_user_message_ids == (
+        "telegram:123:0",
+        "telegram:123:1",
+    )
+    assert committed_events[0].assistant_message_id == "telegram:123:2"
     assert after_turn_metadata == [{"plugin_flag": "telemetry"}]

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -30,8 +30,7 @@ from session.store import SessionStore
 
 
 def _seed_message_embeddings(store: SessionStore, message_ids: list[str]) -> None:
-    store._conn.execute(
-        """
+    store._conn.execute("""
         CREATE TABLE message_embeddings (
             message_id TEXT NOT NULL,
             content_hash TEXT NOT NULL,
@@ -42,8 +41,7 @@ def _seed_message_embeddings(store: SessionStore, message_ids: list[str]) -> Non
             updated_at TEXT NOT NULL,
             PRIMARY KEY (message_id, model)
         )
-        """
-    )
+        """)
     store._conn.executemany(
         """
         INSERT INTO message_embeddings
@@ -104,7 +102,9 @@ async def test_memory_optimizer_loop_and_memory_port_cover_paths(tmp_path: Path)
     memory.write_long_term.assert_called_once()
     memory.write_self.assert_called_once()
 
-    loop = MemoryOptimizerLoop(opt, interval_seconds=10, _now_fn=lambda: datetime(2025, 1, 1, 0, 0, 1))
+    loop = MemoryOptimizerLoop(
+        opt, interval_seconds=10, _now_fn=lambda: datetime(2025, 1, 1, 0, 0, 1)
+    )
     assert loop._seconds_until_next_tick() >= 1.0
     loop.stop()
 
@@ -216,16 +216,14 @@ async def test_session_batch_persistence_rolls_back_all_messages_on_failure(
     session = manager.get_or_create("telegram:atomic")
     session.add_message("user", "第一条")
     session.add_message("assistant", "第二条")
-    manager._store._conn.execute(
-        """
+    manager._store._conn.execute("""
         CREATE TRIGGER reject_assistant_message
         BEFORE INSERT ON messages
         WHEN NEW.role = 'assistant'
         BEGIN
             SELECT RAISE(ABORT, '测试写入失败');
         END
-        """
-    )
+        """)
     manager._store._conn.commit()
 
     with pytest.raises(sqlite3.IntegrityError, match="测试写入失败"):
@@ -255,11 +253,7 @@ async def test_session_persistence_truncates_each_large_tool_result(
 ) -> None:
     manager = SessionManager(tmp_path)
     session = manager.get_or_create("telegram:bounded-tool-result")
-    long_result = (
-        "head-"
-        + "x" * (_STORED_TOOL_RESULT_CHAR_BUDGET + 200)
-        + "-tail"
-    )
+    long_result = "head-" + "x" * (_STORED_TOOL_RESULT_CHAR_BUDGET + 200) + "-tail"
     session.add_message("assistant", "结论")
     session.messages[-1]["tool_chain"] = [
         {
@@ -534,7 +528,7 @@ def test_session_store_reraises_non_capability_fts_errors() -> None:
         ("extra", '{"media": null}', "message media"),
         ("extra", '{"source_refs": ["bad"]}', "message source_refs"),
         ("tool_chain", '[{"calls": null}]', "message tool_chain"),
-        ("tool_chain", '[null]', "message tool_chain"),
+        ("tool_chain", "[null]", "message tool_chain"),
         ("tool_chain", '[{"calls": [null]}]', "message tool_chain"),
     ],
 )
@@ -661,7 +655,7 @@ def test_session_get_history_skips_cached_llm_frame_by_default():
     session.add_message(
         "user",
         "hello",
-        llm_context_frame="<system-reminder data-system-context-frame=\"true\">\n\n## retrieved_memory\n旧记忆",
+        llm_context_frame='<system-reminder data-system-context-frame="true">\n\n## retrieved_memory\n旧记忆',
         llm_user_content=user_content,
     )
     session.add_message("assistant", "world")
@@ -734,6 +728,66 @@ def test_session_get_history_rewinds_consolidated_index_to_user_boundary():
     history = session.get_history(start_index=session.last_consolidated)
 
     assert history[0] == {"role": "user", "content": "hello"}
+
+
+def test_session_get_history_never_splits_explicit_multi_input_turn():
+    session = Session("cli:multi-input")
+    session.add_message("user", "old")
+    session.add_message("assistant", "old reply")
+    for ordinal, content in enumerate(("u1", "u2", "u3")):
+        session.add_message(
+            "user",
+            content,
+            control_turn_id="turn-1",
+            turn_input_ordinal=ordinal,
+        )
+    session.add_message(
+        "assistant",
+        "final",
+        control_turn_id="turn-1",
+        turn_terminal=True,
+        turn_input_count=3,
+    )
+
+    expected = [
+        {"role": "user", "content": "u1"},
+        {"role": "user", "content": "u2"},
+        {"role": "user", "content": "u3"},
+        {"role": "assistant", "content": "final"},
+    ]
+    assert session.get_history(max_messages=1) == expected
+    assert session.get_history(start_index=3) == expected
+
+
+def test_session_get_history_counts_logical_turn_and_proactive_as_units():
+    session = Session("cli:logical-window")
+    session.add_message("user", "old", control_turn_id="turn-old")
+    session.add_message("assistant", "old reply", control_turn_id="turn-old")
+    session.add_message("assistant", "主动提醒", proactive=True)
+    for ordinal, content in enumerate(("u1", "u2", "u3")):
+        session.add_message(
+            "user",
+            content,
+            control_turn_id="turn-current",
+            turn_input_ordinal=ordinal,
+        )
+    session.add_message(
+        "assistant",
+        "final",
+        control_turn_id="turn-current",
+        turn_terminal=True,
+        turn_input_count=3,
+    )
+
+    history = session.get_history(max_messages=2)
+
+    assert history[0] == {"role": "assistant", "content": "[主动推送] 主动提醒"}
+    assert history[1:] == [
+        {"role": "user", "content": "u1"},
+        {"role": "user", "content": "u2"},
+        {"role": "user", "content": "u3"},
+        {"role": "assistant", "content": "final"},
+    ]
 
 
 def test_session_get_history_keeps_full_consolidated_tail():

--- a/tests/test_query_compaction.py
+++ b/tests/test_query_compaction.py
@@ -422,9 +422,7 @@ def test_active_execution_history_rejects_unsuccessful_transport(
     append_tool_result(
         messages,
         tool_call_id="call-1",
-        content=json.dumps(
-            {"process_status": "running", "execution_id": 4201}
-        ),
+        content=json.dumps({"process_status": "running", "execution_id": 4201}),
         tool_name="shell",
         execution_status=transport_status,
     )
@@ -784,6 +782,41 @@ def test_reasoner_compacts_before_provider_without_tool_side_effects() -> None:
     assert result.metadata["react_stats"]["model_usage"]["request_count"] == 4
     assert result.metadata["react_stats"]["model_usage"]["input_tokens"] == 761
     assert result.metadata["react_stats"]["model_usage"]["output_tokens"] == 9
+
+
+def test_interrupted_attempt_tools_join_compaction_and_preserve_all_user_inputs() -> (
+    None
+):
+    provider = _LoopProvider()
+    reasoner, _ = _reasoner(provider)
+    replay = [
+        {"role": "user", "content": "u1: inspect config"},
+        *_batch(101),
+        {"role": "assistant", "content": "[execution attempt interrupted]"},
+        {"role": "user", "content": "u2: also inspect node status"},
+        *_batch(102),
+        {"role": "assistant", "content": "[execution attempt interrupted]"},
+    ]
+    messages = [
+        {"role": "user", "content": "old completed turn"},
+        *replay,
+        {"role": "user", "content": "u3: finish with both results"},
+    ]
+
+    result = asyncio.run(
+        reasoner.run(
+            messages,
+            initial_attempt_replay=replay,
+            initial_prior_tool_groups=2,
+        )
+    )
+
+    summary_prompt = provider.summary_calls[0]["messages"][0]["content"]
+    assert "u1: inspect config" in summary_prompt
+    assert "u2: also inspect node status" in summary_prompt
+    assert "u3: finish with both results" in summary_prompt
+    assert result.metadata["react_compaction"]["compacted_tool_groups"] >= 1
+    assert _contains_compaction_pair(provider.real_calls[0]["messages"])
 
 
 def test_reasoner_forces_one_compaction_after_provider_overflow() -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：U1 被中断后，U2/U3 的新 attempt 必须看到此前全部用户输入、已闭合 tool call/result 与 checkpoint，而不是从空上下文重新开始。
- 用户可见结果：只提供 interrupt；`U1 → interrupt → U2 → interrupt → U3 → A_final` 是一个 logical interaction、三个 execution attempts，只有最终 A 结束这一轮。
- 本 PR 不处理：完成 interaction 进入 Akasha、Markdown consolidation 和 memory window，由 #326 处理；interaction 撤销由 #328/#329 处理。

## Stack

- #323：语义合同
- #324：durable control primitives
- 当前 #325：runtime activation、attempt replay、strict mobile stop 与 query compaction
- #326：memory consumers
- #328/#329：完整 interaction 撤销与 Akasha 重建

## Review 修复

- P：turn 已由 stop 建立 terminal 后，迟到 executor 异常复用既有 terminal，不能覆盖 INTERRUPTED。
- R：continued attempt admission 只计算当前输入字节；前驱 replay/tool evidence 交由 reasoner compaction。
- G：replay 保留媒体路径文本引用，不读取、复制或丢弃附件。
- Q：启动时 CAS 收敛 crash-stale IN_PROGRESS turn 为 INTERRUPTED，并闭合 started tool item。
- SDK：Python `RemoteError.retryable` 透传 busy 可重试语义；不自动重试。
- 已接受但不改：G2 仍只保存有界 tool result preview；C3 索引优化不在本次高频接入路径。

## Change intent

- `change_type`：`feature` + review fixes
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：control runtime、mobile adapter、Reasoner、lifecycle、query compaction、Python SDK
- `runtime_patch`：`required`
- `runtime_patch_reason`：模型上下文、工具因果链、checkpoint CAS 与 active admission 只能由执行 owner 构造。
- `authoritative_state_owner`：SessionStore 保存 canonical ledger；provider prompt 是有界投影。
- `client_only_alternative`：客户端没有 tool result、checkpoint CAS 与 provider context 权限。
- 关联不变量：closed tool group 可重放；open tool 不伪造 result；压缩只切 closed causal boundary；最终只提交多个 U 与一个 A。
- `protected_state`：`sessions.db/messages` 正常路径只追加、工具证据、legacy history、附件文件。
- 允许的副作用：control turn 状态机与 attempt item 更新；最终 transcript batch append。
- 禁止的副作用：删除历史、把 partial assistant 当 terminal、把缺依赖或恢复失败伪装成成功。

## 改动范围

- 主要文件：`agent/control/runtime.py`、`agent/core/passive_turn.py`、`agent/lifecycle/phases/*`、`bootstrap/control_execution.py`、`session/manager.py`、`frontend/chat/src/mobile-*`、`sdk/python`。
- 配置或迁移影响：无 schema migration。
- 已知 schema lineage 与最终 schema identity：沿用 #324；messages 正常路径只追加。
- revision：base `feat/same-turn-control-ledger`，head `28398c71c039bb952f37365d8c34a83ca5bb1799`。
- 回滚方式：按栈逆序 revert #325；#324 primitives 不单独发布。

## 验证

- [x] P/R/G/Q 的 `tests/control/`、reasoner/replay/startup 定向测试通过。
- [x] SDK typed error 与真实 socket 端到端测试通过。
- [x] 栈顶 #329 的累计相关测试 207 passed，Pyright 0 errors，完整 public Gate 通过。
- [ ] GitHub `contract` check：先前 run 被取消且没有执行步骤，已对同一 head SHA 发起 rerun；以 rerun 最终状态为准。
- 真实设备证据：本 PR 的 strict stop mobile 累计树此前已发布 Preview 验证；本轮 review fixes 不改 mobile UI。
- 未运行项与原因：无新的正式 workspace 写入。

## 工作手册

- [x] 已核对 #323 合同、#324 durable owner 与 review 清单。
- [x] 长期语义变化已获确认。
- [x] runtime patch 无客户端等价替代。
- [x] 当前没有对应 NOW 事项。
