### PR TITLE
[memory 3/3] 按完整逻辑交互处理 Akasha 与压缩

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -63,6 +63,8 @@ dev_mode = false
 
 [agent.context]
 # 默认按主模型有效上下文自动推导；取消注释可显式覆盖。
+# 升级注意：memory_window 现在按完整逻辑历史单元计数，不再按消息行计数。
+# legacy U+A、multi-U+A_final 和已送达 proactive assistant 各计一个单元。
 # memory_window = 84
 
 [agent.tools]

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -19,6 +19,11 @@ from agent.provider import LLMProvider
 from bus.events_lifecycle import TurnCommitted
 from core.memory.events import ConsolidationCommitted
 from infra.persistence.json_store import atomic_write_text
+from session.manager import (
+    logical_history_tail_start,
+    logical_history_unit_count,
+    logical_history_unit_ranges,
+)
 from session.memory_policy import excludes_memory
 
 if TYPE_CHECKING:
@@ -78,6 +83,7 @@ class MemoryProfileApi(Protocol):
     def get_memory_context(self) -> str: ...
 
     def has_long_term_memory(self) -> bool: ...
+
 
 _ALLOWED_PENDING_TAGS = frozenset(
     {
@@ -183,19 +189,31 @@ def _select_consolidation_window(
     if total_messages - session.last_consolidated <= 0:
         return None
 
+    # 1. 游标只能停在完整逻辑单元之后；新写入不再制造半 turn 游标。
+    unit_ranges = logical_history_unit_ranges(session.messages)
+    boundaries = {0, *(end for _, end in unit_ranges)}
+    if session.last_consolidated not in boundaries:
+        raise ValueError(
+            "last_consolidated 落在逻辑历史单元内部: " f"{session.last_consolidated}"
+        )
+
     if force:
         consolidate_up_to = total_messages
     else:
-        if total_messages <= keep_count:
+        if len(unit_ranges) <= keep_count:
             return None
-        consolidate_up_to = total_messages - keep_count
+        consolidate_up_to = unit_ranges[-keep_count][0]
     old_messages = session.messages[session.last_consolidated : consolidate_up_to]
     if not old_messages:
         return None
+    new_unit_count = logical_history_unit_count(
+        session.messages,
+        start_index=session.last_consolidated,
+    ) - (0 if force else keep_count)
     if (
         not force
         and not continuing
-        and len(old_messages) < max(1, int(consolidation_min_new_messages))
+        and new_unit_count < max(1, int(consolidation_min_new_messages))
     ):
         return None
     return _ConsolidationWindow(
@@ -239,12 +257,6 @@ def _format_conversation_for_consolidation(old_messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _starts_semantic_turn(message: dict) -> bool:
-    return message.get("role") == "user" or (
-        message.get("role") == "assistant" and bool(message.get("proactive"))
-    )
-
-
 def _limit_consolidation_window(
     window: _ConsolidationWindow,
     *,
@@ -252,12 +264,11 @@ def _limit_consolidation_window(
 ) -> _ConsolidationWindow:
     """按完整语义回合限制单页正文，并返回稳定的绝对游标。"""
 
-    # 1. 先把窗口分成不会拆开 user/assistant/tool 因果链的语义组。
-    groups: list[list[dict]] = []
-    for message in window.old_messages:
-        if _starts_semantic_turn(message) or not groups:
-            groups.append([])
-        groups[-1].append(message)
+    # 1. 与 prompt history 共用同一分组，显式多 U turn 与 proactive 都保持原子。
+    groups = [
+        window.old_messages[start:end]
+        for start, end in logical_history_unit_ranges(window.old_messages)
+    ]
 
     # 2. 再按实际送给模型的文本长度装页；单个超长回合保持完整并 fail-loud。
     selected: list[dict] = []
@@ -275,9 +286,7 @@ def _limit_consolidation_window(
         old_messages=selected,
         keep_count=window.keep_count,
         consolidate_up_to=(
-            window.consolidate_up_to
-            - len(window.old_messages)
-            + len(selected)
+            window.consolidate_up_to - len(window.old_messages) + len(selected)
         ),
     )
 
@@ -328,7 +337,9 @@ def _normalize_history_entries(
         candidates.extend(raw_entries)
     elif raw_entries is not None:
         if not isinstance(raw_entries, str | dict):
-            raise _ConsolidationPayloadError("history_entries must be an array or object")
+            raise _ConsolidationPayloadError(
+                "history_entries must be an array or object"
+            )
         candidates.append(raw_entries)
     if fallback_entry is not None and not isinstance(raw_entries, list):
         candidates.append(fallback_entry)
@@ -357,7 +368,8 @@ def _normalize_history_entries(
 
 
 def _recent_turn_count(keep_count: int) -> int:
-    return max(1, keep_count // 2)
+    """把旧的消息预览预算换算为不切分的逻辑历史单元数。"""
+    return max(1, keep_count // 4)
 
 
 def _message_time(message: dict) -> str:
@@ -433,9 +445,7 @@ def _render_recent_context(
 ) -> str:
     compression = {} if compression is None else compression
     ongoing_threads = [
-        item.strip()
-        for item in compression.get("ongoing_threads", [])
-        if item.strip()
+        item.strip() for item in compression.get("ongoing_threads", []) if item.strip()
     ]
     sections = [
         ("最近持续关注", compression.get("active_topics", [])),
@@ -443,7 +453,12 @@ def _render_recent_context(
         ("最近待延续话题", compression.get("follow_ups", [])),
         ("最近避免事项", compression.get("avoidances", [])),
     ]
-    lines = ["# Recent Context", "", "## Compression", f"until: {compression_until or 'none'}"]
+    lines = [
+        "# Recent Context",
+        "",
+        "## Compression",
+        f"until: {compression_until or 'none'}",
+    ]
     rendered_any = False
     for title, items in sections:
         cleaned = [item.strip() for item in items if item.strip()]
@@ -459,7 +474,9 @@ def _render_recent_context(
             lines.append(f"- {item}")
     else:
         lines.append("- none")
-    lines.extend(["", "## Recent Turns", "<!-- a-preview = assistant reply preview only -->"])
+    lines.extend(
+        ["", "## Recent Turns", "<!-- a-preview = assistant reply preview only -->"]
+    )
     if recent_turns.strip():
         lines.append(recent_turns.strip())
     else:
@@ -484,9 +501,7 @@ class _MarkdownConsolidationWorker:
         self._provider = provider
         self._model = model
         self._recent_context_provider = recent_context_provider or provider
-        self._recent_context_model = (
-            str(recent_context_model or "").strip() or model
-        )
+        self._recent_context_model = str(recent_context_model or "").strip() or model
         self._keep_count = keep_count
         self._consolidation_input_budget = consolidation_input_budget
         self._provider_system_prompt = provider_system_prompt
@@ -717,17 +732,15 @@ ongoing_threads 严格限制：
     ) -> str | _ConsolidationFailure:
         """读取会话窗口并生成近期语境快照。"""
         # 1. 复用调用方已读取的 recent context，保证两个模型步骤看到同一版本。
-        tail = list(session.messages[-self._keep_count :]) if self._keep_count > 0 else []
-        recent_count = min(len(tail), _recent_turn_count(self._keep_count))
         session_messages = list(session.messages)
+        recent_count = _recent_turn_count(self._keep_count)
+        recent_start = logical_history_tail_start(session_messages, recent_count)
+        recent_turns = session_messages[recent_start:]
         if archive_all:
-            compact_source = (
-                session_messages[:-recent_count] if recent_count > 0 else session_messages
-            )
+            compact_source = session_messages[:recent_start]
         else:
             compact_source = list(window.old_messages) if window is not None else []
         compression_until = _message_time(compact_source[-1]) if compact_source else ""
-        recent_turns = tail[-recent_count:] if recent_count > 0 else []
         rendered_recent_turns = _format_recent_context_messages(recent_turns)
         recent_turns_for_prompt = _format_conversation_for_recent_context(recent_turns)
         conversation = _format_conversation_for_recent_context(compact_source)
@@ -793,7 +806,11 @@ ongoing_threads 严格限制：
                 or (
                     match.group(1).strip()
                     if old_recent_context.strip()
-                    and (match := re.search(r"^until:\s*(.+)$", old_recent_context, flags=re.M))
+                    and (
+                        match := re.search(
+                            r"^until:\s*(.+)$", old_recent_context, flags=re.M
+                        )
+                    )
                     else ""
                 )
             ),
@@ -804,9 +821,9 @@ ongoing_threads 严格限制：
         """刷新 RECENT_CONTEXT.md 的 recent turns 区块。"""
         # 1. 读取当前会话尾部并渲染稳定的 recent turns 格式。
         profile = self._profile_maint if profile_maint is None else profile_maint
-        tail = list(session.messages[-self._keep_count :]) if self._keep_count > 0 else []
-        recent_count = min(len(tail), _recent_turn_count(self._keep_count))
-        recent_turns = tail[-recent_count:] if recent_count > 0 else []
+        recent_count = _recent_turn_count(self._keep_count)
+        start = logical_history_tail_start(session.messages, recent_count)
+        recent_turns = list(session.messages[start:])
         rendered_recent_turns = _format_recent_context_messages(recent_turns)
         # 2. 保留压缩内容，只替换 recent turns。
         existing_text = await asyncio.to_thread(profile.read_recent_context)
@@ -840,14 +857,16 @@ ongoing_threads 严格限制：
             )
         else:
             if window is None:
-                ready_count = (
-                    len(session.messages) - self._keep_count - session.last_consolidated
+                pending_units = logical_history_unit_count(
+                    session.messages,
+                    start_index=session.last_consolidated,
                 )
-                if len(session.messages) <= self._keep_count:
+                ready_count = pending_units - self._keep_count
+                if pending_units <= self._keep_count:
                     logger.debug(
-                        "Session %s: No consolidation needed (messages=%d, keep=%d)",
+                        "Session %s: No consolidation needed (units=%d, keep=%d)",
                         session.key,
-                        len(session.messages),
+                        pending_units,
                         self._keep_count,
                     )
                 else:
@@ -1000,9 +1019,7 @@ history_entries.emotional_weight 规则：
         # 3. 普通 consolidation 按实际模型预算切成完整语义页。
         if self._consolidation_input_budget is not None and not archive_all:
             fixed_chars = (
-                len(self._provider_system_prompt)
-                + len(prompt)
-                - len(conversation)
+                len(self._provider_system_prompt) + len(prompt) - len(conversation)
             )
             available_tokens = self._consolidation_input_budget - max(
                 1, fixed_chars // 3
@@ -1105,8 +1122,6 @@ history_entries.emotional_weight 规则：
             scope_chat_id=scope_chat_id,
             archive_all=archive_all,
         )
-
-
 
 
 class MarkdownMemoryStore(MemoryStore):
@@ -1263,7 +1278,9 @@ class MarkdownMemoryMaintenance:
                 name=f"markdown-memory-maintenance:{session_key}",
             )
             self._maintenance_tasks[session_key] = next_task
-            next_task.add_done_callback(lambda t: self._on_maintenance_done(t, session_key))
+            next_task.add_done_callback(
+                lambda t: self._on_maintenance_done(t, session_key)
+            )
         else:
             _ = self._maintenance_queues.pop(session_key, None)
         if task.cancelled():
@@ -1271,7 +1288,11 @@ class MarkdownMemoryMaintenance:
             return
         exc = task.exception()
         if exc is not None:
-            logger.warning("markdown memory maintenance failed: session=%s err=%s", session_key, exc)
+            logger.warning(
+                "markdown memory maintenance failed: session=%s err=%s",
+                session_key,
+                exc,
+            )
 
     def _should_consolidate_session(self, session: object) -> bool:
         return (
@@ -1304,7 +1325,9 @@ class MarkdownMemoryMaintenance:
         async with lock:
             return await self._consolidate_unlocked(request)
 
-    async def _consolidate_unlocked(self, request: ConsolidateRequest) -> ConsolidateResult:
+    async def _consolidate_unlocked(
+        self, request: ConsolidateRequest
+    ) -> ConsolidateResult:
         """逐页压缩 backlog，并在每页提交后保存绝对游标。"""
 
         # 1. 每页重新读取 RECENT_CONTEXT，让下一页基于上一页的滚动摘要继续压缩。

--- a/core/memory/markdown.py
+++ b/core/memory/markdown.py
@@ -169,6 +169,26 @@ class _ConsolidationFailure:
     elapsed_ms: int = 0
 
 
+def _resolve_consolidation_cursor(
+    messages: list[dict],
+    last_consolidated: int,
+    *,
+    force: bool,
+) -> tuple[list[tuple[int, int]], int]:
+    """校验 consolidation 游标，并在显式 force 时返回最近合法边界。"""
+    unit_ranges = logical_history_unit_ranges(messages)
+    boundaries = {0, *(end for _, end in unit_ranges)}
+    if last_consolidated in boundaries:
+        return unit_ranges, last_consolidated
+    if not force:
+        raise ValueError(
+            "last_consolidated 落在逻辑历史单元内部: " f"{last_consolidated}"
+        )
+    return unit_ranges, max(
+        boundary for boundary in boundaries if boundary <= last_consolidated
+    )
+
+
 def _select_consolidation_window(
     session,
     *,
@@ -186,16 +206,15 @@ def _select_consolidation_window(
             consolidate_up_to=total_messages,
         )
 
-    if total_messages - session.last_consolidated <= 0:
-        return None
-
     # 1. 游标只能停在完整逻辑单元之后；新写入不再制造半 turn 游标。
-    unit_ranges = logical_history_unit_ranges(session.messages)
-    boundaries = {0, *(end for _, end in unit_ranges)}
-    if session.last_consolidated not in boundaries:
-        raise ValueError(
-            "last_consolidated 落在逻辑历史单元内部: " f"{session.last_consolidated}"
-        )
+    unit_ranges, consolidation_start = _resolve_consolidation_cursor(
+        session.messages,
+        session.last_consolidated,
+        force=force,
+    )
+
+    if total_messages - consolidation_start <= 0:
+        return None
 
     if force:
         consolidate_up_to = total_messages
@@ -203,12 +222,12 @@ def _select_consolidation_window(
         if len(unit_ranges) <= keep_count:
             return None
         consolidate_up_to = unit_ranges[-keep_count][0]
-    old_messages = session.messages[session.last_consolidated : consolidate_up_to]
+    old_messages = session.messages[consolidation_start:consolidate_up_to]
     if not old_messages:
         return None
     new_unit_count = logical_history_unit_count(
         session.messages,
-        start_index=session.last_consolidated,
+        start_index=consolidation_start,
     ) - (0 if force else keep_count)
     if (
         not force
@@ -1330,7 +1349,31 @@ class MarkdownMemoryMaintenance:
     ) -> ConsolidateResult:
         """逐页压缩 backlog，并在每页提交后保存绝对游标。"""
 
-        # 1. 每页重新读取 RECENT_CONTEXT，让下一页基于上一页的滚动摘要继续压缩。
+        # 1. 显式 force 先把失配游标持久回退到最近的完整逻辑单元边界。
+        cursor_repair: dict[str, int] = {}
+        if request.force and not request.archive_all:
+            previous_cursor = request.session.last_consolidated
+            _, recovered_cursor = _resolve_consolidation_cursor(
+                request.session.messages,
+                previous_cursor,
+                force=True,
+            )
+            if recovered_cursor != previous_cursor:
+                request.session.last_consolidated = recovered_cursor
+                cursor_repair = {
+                    "cursor_rewound_from": previous_cursor,
+                    "cursor_rewound_to": recovered_cursor,
+                }
+                logger.warning(
+                    "Force consolidation rewound invalid cursor: session=%s from=%d to=%d",
+                    request.session.key,
+                    previous_cursor,
+                    recovered_cursor,
+                )
+                if self._save_session is not None:
+                    await self._save_session(request.session)
+
+        # 2. 每页重新读取 RECENT_CONTEXT，让下一页基于上一页的滚动摘要继续压缩。
         consolidated_count = 0
         source_refs: list[str] = []
         while True:
@@ -1344,7 +1387,9 @@ class MarkdownMemoryMaintenance:
             )
             if draft is None:
                 if consolidated_count == 0:
-                    return ConsolidateResult(trace={"mode": "skipped"})
+                    return ConsolidateResult(
+                        trace={"mode": "skipped", **cursor_repair}
+                    )
                 break
             if isinstance(draft, _ConsolidationFailure):
                 failure_trace: dict[str, object] = {
@@ -1355,12 +1400,13 @@ class MarkdownMemoryMaintenance:
                 }
                 if source_refs:
                     failure_trace["completed_pages"] = len(source_refs)
+                failure_trace.update(cursor_repair)
                 return ConsolidateResult(
                     consolidated_count=consolidated_count,
                     trace=failure_trace,
                 )
 
-            # 2. 提交一页后立即保存游标；失败重启只会重做未提交页。
+            # 3. 提交一页后立即保存游标；失败重启只会重做未提交页。
             await self._commit_markdown_draft(request.session, draft)
             consolidated_count += len(draft.window.old_messages)
             source_refs.append(draft.source_ref)
@@ -1380,6 +1426,7 @@ class MarkdownMemoryMaintenance:
                 "source_ref": source_refs[-1],
                 "source_refs": source_refs,
                 "pages": len(source_refs),
+                **cursor_repair,
             },
         )
 

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -839,7 +839,7 @@ def _inside_memory_context(report_dir: Path) -> int:
     checks: list[CheckResult] = []
     client: JsonRpcSocketClient | None = None
     try:
-        # 1. 为每个 event/recent-context 步骤提供同一份双兼容 JSON。
+        # 1. 为两个逻辑历史分页提供同一份双兼容 JSON。
         _wait_http_ready(f"{model_url}/readyz", READINESS_DEADLINE_S)
         _wait_socket(endpoint, READINESS_DEADLINE_S)
         response = json.dumps(
@@ -857,7 +857,7 @@ def _inside_memory_context(report_dir: Path) -> int:
         _http_json(
             "PUT",
             f"{model_url}/control/script",
-            [{"mode": "complete", "content": response} for _ in range(4)],
+            [{"mode": "complete", "content": response} for _ in range(2)],
         )
 
         # 2. 通过正式 control protocol 启动手动整理并等待 operation 终态。
@@ -899,9 +899,9 @@ def _inside_memory_context(report_dir: Path) -> int:
             and completed_operation.get("id") == operation.get("id")
             and completed_operation.get("status") == "completed"
             and completed_operation.get("result") == {"consolidated": True}
-            and row == (20,)
+            and row == (16,)
             and message_count == 24
-            and len(model_requests) == 4
+            and len(model_requests) == 2
             and "until:" in recent_context
         )
         checks.append(
@@ -963,7 +963,7 @@ def _inside_memory_context(report_dir: Path) -> int:
                 and retry_payload.get("finalResponse") == "retry survived"
                 and retry_row == (4,)
                 and retry_message_count == 8
-                and len(final_requests) == 6,
+                and len(final_requests) == 4,
                 {
                     "terminal": retry_payload,
                     "messageCount": retry_message_count,

--- a/docs/design/codex-style-same-turn-input-requirements.md
+++ b/docs/design/codex-style-same-turn-input-requirements.md
@@ -58,6 +58,8 @@ Akasha 对一个 completed logical interaction 建立一个学习样本：有序
 
 `memory_window`、Markdown consolidation 的保留尾部、分页切点、积压阈值和 recent turns 都按不可拆分的逻辑历史单元计数。一个 completed `U1..Un+A_final` 是一个单元；一次已送达 proactive assistant 是一个独立单元。窗口和游标不得落入显式 `control_turn_id` 中间。
 
+升级既有配置时必须注意：`memory_window`、由它派生的 `keep_count` 和 `consolidation_min_new_messages` 已从“消息行数”改为“逻辑历史单元数”。因此相同数值会保留更大的 legacy 消息尾部，并使 consolidation 更晚触发；本变更不自动换算或改写用户配置。
+
 ### STI-012 连环中断的工具前缀可压缩但不可丢证据
 
 下一 attempt 初始 prompt 中的前驱工具调用/结果必须加入现有 query-local ReAct compaction，而不是成为永远不可压缩的固定前缀。压缩只淘汰已闭合工具组，显式把本 interaction 的全部 U 作为 current-query anchor，并保留最近原始工具后缀。压缩无合法切点、摘要无效或节省不足时 fail-loud；不得改写或删除权威 turn/message 证据。

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -806,7 +806,12 @@ class AkashaMemoryEngine:
             with self._lock:
                 self._pending.pop(event.session_key, None)
             return
-        user_id = event.persisted_user_message_id
+        user_ids = event.persisted_user_message_ids or (
+            (event.persisted_user_message_id,)
+            if event.persisted_user_message_id
+            else ()
+        )
+        user_id = user_ids[0] if user_ids else None
         assistant_id = event.assistant_message_id
         if not user_id or not assistant_id:
             raise ValueError(
@@ -817,17 +822,18 @@ class AkashaMemoryEngine:
         messages = _load_messages(
             self._sessions_path,
             event.session_key,
-            user_id,
+            user_ids,
             assistant_id,
         )
         with self._lock:
             pending = self._pending.get(event.session_key)
         if (
-            pending is not None
+            len(user_ids) == 1
+            and pending is not None
             and pending.query_text == cast(str, messages[0]["content"])
         ):
             assistant_vector = await self._embedder.embed(
-                cast(str, messages[1]["content"])
+                cast(str, messages[-1]["content"])
             )
             vectors = [
                 pending.query_dense.tolist(),
@@ -1019,7 +1025,7 @@ class AkashaMemoryEngine:
 def _load_messages(
     sessions_path: Path,
     session_key: str,
-    user_id: str,
+    user_ids: tuple[str, ...],
     assistant_id: str,
 ) -> list[dict[str, object]]:
     connection = sqlite3.connect(
@@ -1028,24 +1034,26 @@ def _load_messages(
     )
     connection.row_factory = sqlite3.Row
     try:
+        message_ids = (*user_ids, assistant_id)
+        placeholders = ",".join("?" for _ in message_ids)
         rows = connection.execute(
-            """
+            f"""
             SELECT id, session_key, seq, role, content, ts
             FROM messages
-            WHERE id IN (?, ?)
+            WHERE id IN ({placeholders})
             ORDER BY seq
             """,
-            (user_id, assistant_id),
+            message_ids,
         ).fetchall()
     finally:
         connection.close()
-    if len(rows) != 2:
+    if len(rows) != len(user_ids) + 1:
         raise ValueError("TurnCommitted messages do not exist")
     if (
-        rows[0]["id"] != user_id
-        or rows[0]["role"] != "user"
-        or rows[1]["id"] != assistant_id
-        or rows[1]["role"] != "assistant"
+        tuple(str(row["id"]) for row in rows[:-1]) != user_ids
+        or any(row["role"] != "user" for row in rows[:-1])
+        or rows[-1]["id"] != assistant_id
+        or rows[-1]["role"] != "assistant"
         or any(row["session_key"] != session_key for row in rows)
     ):
         raise ValueError("TurnCommitted message identity mismatch")

--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -7,9 +7,11 @@ import hashlib
 import math
 import sqlite3
 from collections import Counter, defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -22,6 +24,7 @@ from .schema import INDEX_VERSION, SCHEMA
 
 LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
 INTERRUPTED_ASSISTANT_MARKER = "[interrupted]"
+TurnPair = tuple[tuple[sqlite3.Row, ...], sqlite3.Row]
 
 
 class AppendOnlyViolation(RuntimeError):
@@ -277,13 +280,16 @@ def _load_canonical_turns(
 
     # 2. Preserve incomplete dense turns for lexical and temporal evidence.
     turns = [
-        _make_turn(user, assistant, embeddings)
-        for user, assistant in pairs
+        _make_turn(users, assistant, embeddings)
+        for users, assistant in pairs
     ]
     missing_embeddings = sum(
-        user["id"] not in embeddings
+        any(
+            _message_text(user).strip() and user["id"] not in embeddings
+            for user in users
+        )
         or assistant["id"] not in embeddings
-        for user, assistant in pairs
+        for users, assistant in pairs
     )
 
     # 3. Establish one deterministic global causal order.
@@ -332,8 +338,8 @@ def _source_messages(
 
 def _eligible_pairs(
     messages: list[sqlite3.Row],
-) -> tuple[list[tuple[sqlite3.Row, sqlite3.Row]], int, int]:
-    """Pair committed user/assistant messages and exclude explicit skips."""
+) -> tuple[list[TurnPair], int, int]:
+    """按显式 turn 元数据重建新格式，并保留严格 legacy 相邻配对。"""
 
     grouped: dict[str, list[sqlite3.Row]] = defaultdict(list)
     for message in messages:
@@ -342,10 +348,76 @@ def _eligible_pairs(
     excluded_interrupted = 0
     excluded_memory = 0
     for session_messages in grouped.values():
+        explicit: dict[str, list[sqlite3.Row]] = {}
+        explicit_order: list[str] = []
+        for message in session_messages:
+            turn_id = _message_extra(message).get("control_turn_id")
+            if turn_id is None:
+                continue
+            if not isinstance(turn_id, str) or not turn_id:
+                raise ValueError(f"control_turn_id 必须是非空字符串: {message['id']}")
+            if turn_id not in explicit:
+                explicit[turn_id] = []
+                explicit_order.append(turn_id)
+            explicit[turn_id].append(message)
+
+        # 1. 新格式只信任显式 ID、ordinal 和 terminal 标志。
+        for turn_id in explicit_order:
+            turn_messages = explicit[turn_id]
+            users = [row for row in turn_messages if row["role"] == "user"]
+            assistants = [
+                row
+                for row in turn_messages
+                if row["role"] == "assistant"
+                and _message_extra(row).get("turn_terminal") is True
+            ]
+            ordinals = [_message_extra(row).get("turn_input_ordinal") for row in users]
+            if (
+                not users
+                or len(assistants) != 1
+                or any(
+                    not isinstance(value, int) or isinstance(value, bool)
+                    for value in ordinals
+                )
+            ):
+                raise ValueError(f"同 turn transcript 结构无效: {turn_id}")
+            typed_ordinals = cast(list[int], ordinals)
+            if sorted(typed_ordinals) != list(range(len(users))):
+                raise ValueError(f"同 turn input ordinal 不连续: {turn_id}")
+            users.sort(
+                key=lambda row: cast(
+                    int,
+                    _message_extra(row)["turn_input_ordinal"],
+                )
+            )
+            assistant = assistants[0]
+            if _message_extra(assistant).get("turn_input_count") != len(users):
+                raise ValueError(f"同 turn input count 不匹配: {turn_id}")
+            if any(int(user["seq"]) >= int(assistant["seq"]) for user in users):
+                raise ValueError(f"同 turn assistant 顺序无效: {turn_id}")
+            first = users[0]
+            if _excluded_session(str(first["session_key"]), first):
+                excluded_memory += 1
+                continue
+            if _interrupted_pair(first, assistant):
+                excluded_interrupted += 1
+                continue
+            if any(_skip_post_memory(row) for row in (*users, assistant)):
+                continue
+            if not any(_message_text(row) for row in (*users, assistant)):
+                continue
+            pairs.append((tuple(users), assistant))
+
+        # 2. 无显式 turn metadata 的旧消息继续使用严格相邻配对。
         for user, assistant in zip(
             session_messages,
             session_messages[1:],
         ):
+            if (
+                _message_extra(user).get("control_turn_id") is not None
+                or _message_extra(assistant).get("control_turn_id") is not None
+            ):
+                continue
             if user["role"] != "user" or assistant["role"] != "assistant":
                 continue
             if _excluded_session(str(user["session_key"]), user):
@@ -358,7 +430,7 @@ def _eligible_pairs(
                 continue
             if not _message_text(user) and not _message_text(assistant):
                 continue
-            pairs.append((user, assistant))
+            pairs.append(((user,), assistant))
     return pairs, excluded_interrupted, excluded_memory
 
 
@@ -411,7 +483,7 @@ def _interrupted_pair(
 
 def _audit_rows(
     connection: sqlite3.Connection,
-    pairs: list[tuple[sqlite3.Row, sqlite3.Row]],
+    pairs: list[TurnPair],
     config: BuildConfig,
     excluded_interrupted: int,
     excluded_memory: int,
@@ -448,7 +520,7 @@ def _audit_rows(
 
 
 def _embedding_issues(
-    pairs: list[tuple[sqlite3.Row, sqlite3.Row]],
+    pairs: list[TurnPair],
     embeddings: dict[str, sqlite3.Row],
     expected_dimension: int | None,
 ) -> tuple[list[EmbeddingIssue], set[int], int]:
@@ -457,7 +529,7 @@ def _embedding_issues(
     issues = []
     dimensions: set[int] = set()
     required = 0
-    for message in (item for pair in pairs for item in pair):
+    for message in _pair_messages(pairs):
         content = _message_text(message)
         if not content.strip():
             continue
@@ -499,6 +571,14 @@ def _embedding_issues(
     return issues, dimensions, required
 
 
+def _pair_messages(pairs: list[TurnPair]) -> Iterator[sqlite3.Row]:
+    """按 transcript 顺序展开全部用户消息和最终助手消息。"""
+
+    for users, assistant in pairs:
+        yield from users
+        yield assistant
+
+
 def _embedding_issue(
     message: sqlite3.Row,
     row: sqlite3.Row | None,
@@ -529,13 +609,13 @@ def _embedding_issue(
 
 
 def _dimension_mismatches(
-    pairs: list[tuple[sqlite3.Row, sqlite3.Row]],
+    pairs: list[TurnPair],
     embeddings: dict[str, sqlite3.Row],
     expected_dimension: int,
     invalid_ids: set[str],
 ) -> list[EmbeddingIssue]:
     issues = []
-    for message in (item for pair in pairs for item in pair):
+    for message in _pair_messages(pairs):
         if not _message_text(message).strip():
             continue
         message_id = str(message["id"])
@@ -557,10 +637,11 @@ def _dimension_mismatches(
 
 
 def _make_turn(
-    user: sqlite3.Row,
+    users: tuple[sqlite3.Row, ...],
     assistant: sqlite3.Row,
     embeddings: dict[str, np.ndarray],
 ) -> CanonicalTurn:
+    user = users[0]
     turn_id = f"{user['id']}::{assistant['id']}"
     remember_targets, remember_boost = _feedback_marker(
         user,
@@ -576,6 +657,22 @@ def _make_turn(
         carrier_turn_id=turn_id,
         target_required=True,
     )
+    user_vectors = [
+        embeddings[str(row["id"])]
+        for row in users
+        if _message_text(row).strip() and str(row["id"]) in embeddings
+    ]
+    required_user_vectors = sum(bool(_message_text(row).strip()) for row in users)
+    user_embedding = embeddings.get(str(user["id"])) if len(users) == 1 else None
+    if (
+        len(users) > 1
+        and user_vectors
+        and len(user_vectors) == required_user_vectors
+    ):
+        mean = np.mean(np.stack(user_vectors), axis=0)
+        norm = float(np.linalg.norm(mean))
+        if norm > 0.0:
+            user_embedding = mean / norm
     return CanonicalTurn(
         turn_id=turn_id,
         session_key=user["session_key"],
@@ -584,9 +681,9 @@ def _make_turn(
         assistant_message_id=assistant["id"],
         started_at=user["ts"],
         committed_at=assistant["ts"],
-        user_text=user["content"] or "",
+        user_text="\n\n".join(_message_text(row) for row in users),
         assistant_text=assistant["content"] or "",
-        user_embedding=embeddings.get(user["id"]),
+        user_embedding=user_embedding,
         assistant_embedding=embeddings.get(assistant["id"]),
         remember_target_turn_ids=remember_targets,
         forget_target_turn_ids=forget_targets,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import math
 import sqlite3
+import struct
 import threading
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -874,6 +875,128 @@ def test_embedding_preflight_excludes_legacy_interrupted_turn(
     assert audit.eligible_turns == 0
     assert audit.excluded_interrupted_turns == 1
     assert audit.issues == ()
+
+
+def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions.db"
+    index = tmp_path / "index.db"
+    _create_sessions(sessions)
+    started = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    rows = [
+        ("u1", 0, "user", "alpha", {"control_turn_id": "t1", "turn_input_ordinal": 0}),
+        ("u2", 1, "user", "beta", {"control_turn_id": "t1", "turn_input_ordinal": 1}),
+        ("u3", 2, "user", "gamma", {"control_turn_id": "t1", "turn_input_ordinal": 2}),
+        ("a1", 3, "assistant", "final", {"control_turn_id": "t1", "turn_terminal": True, "turn_input_count": 3}),
+    ]
+    vectors = {
+        "u1": [1.0, 0.0],
+        "u2": [0.0, 1.0],
+        "u3": [1.0, 0.0],
+        "a1": [0.0, 1.0],
+    }
+    with closing(sqlite3.connect(sessions)) as connection, connection:
+        connection.execute(
+            "INSERT INTO sessions VALUES ('test:one', ?, ?, 0, NULL)",
+            (started.isoformat(), started.isoformat()),
+        )
+        for message_id, seq, role, content, extra in rows:
+            connection.execute(
+                "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, ?, ?)",
+                (
+                    message_id,
+                    seq,
+                    role,
+                    content,
+                    json.dumps(extra),
+                    (started + timedelta(seconds=seq)).isoformat(),
+                ),
+            )
+            connection.execute(
+                "INSERT INTO message_embeddings VALUES (?, ?, 'embedding-model', ?, 2, ?, ?)",
+                (
+                    message_id,
+                    hashlib.sha256(content.encode()).hexdigest(),
+                    sqlite3.Binary(
+                        struct.pack("<2f", *vectors[message_id])
+                    ),
+                    started.isoformat(),
+                    started.isoformat(),
+                ),
+            )
+
+    result = build_sparse_index(
+        sessions,
+        index,
+        BuildConfig(embedding_model="embedding-model", embedding_dimension=2),
+    )
+    with closing(sqlite3.connect(index)) as connection:
+        turn = connection.execute(
+            "SELECT user_message_id, assistant_message_id, user_text FROM sparse_turns"
+        ).fetchone()
+        dense = connection.execute(
+            "SELECT source_id, embedding FROM turn_dense WHERE field = 'user'"
+        ).fetchone()
+
+    assert result.indexed_turns == 1
+    assert turn == ("u1", "a1", "alpha\n\nbeta\n\ngamma")
+    assert dense is not None and dense[0] == "u1"
+    user_dense = struct.unpack("<2f", dense[1])
+    assert user_dense == pytest.approx((2 / math.sqrt(5), 1 / math.sqrt(5)))
+
+
+def test_sparse_builder_preserves_single_user_embedding_bytes(
+    tmp_path: Path,
+) -> None:
+    """Keep legacy turn digests stable when multi-user projection is enabled."""
+
+    # 1. Persist a legacy pair whose stored vector is deliberately not normalized.
+    sessions = tmp_path / "sessions.db"
+    index = tmp_path / "index.db"
+    _create_sessions(sessions)
+    started = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    with closing(sqlite3.connect(sessions)) as connection, connection:
+        connection.execute(
+            "INSERT INTO sessions VALUES ('test:one', ?, ?, 0, NULL)",
+            (started.isoformat(), started.isoformat()),
+        )
+        for message_id, seq, role, content, vector in (
+            ("u1", 0, "user", "legacy", (3.0, 4.0)),
+            ("a1", 1, "assistant", "final", (0.0, 1.0)),
+        ):
+            connection.execute(
+                "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, NULL, ?)",
+                (
+                    message_id,
+                    seq,
+                    role,
+                    content,
+                    (started + timedelta(seconds=seq)).isoformat(),
+                ),
+            )
+            connection.execute(
+                "INSERT INTO message_embeddings VALUES (?, ?, 'embedding-model', ?, 2, ?, ?)",
+                (
+                    message_id,
+                    hashlib.sha256(content.encode()).hexdigest(),
+                    sqlite3.Binary(struct.pack("<2f", *vector)),
+                    started.isoformat(),
+                    started.isoformat(),
+                ),
+            )
+
+    # 2. The incremental source digest must continue to see the original bytes.
+    build_sparse_index(
+        sessions,
+        index,
+        BuildConfig(embedding_model="embedding-model", embedding_dimension=2),
+    )
+    with closing(sqlite3.connect(index)) as connection:
+        dense = connection.execute(
+            "SELECT embedding FROM turn_dense WHERE field = 'user'"
+        ).fetchone()
+
+    assert dense is not None
+    assert dense[0] == struct.pack("<2f", 3.0, 4.0)
 
 
 def _engine(workspace: Path) -> AkashaMemoryEngine:

--- a/tests/test_consolidation_service.py
+++ b/tests/test_consolidation_service.py
@@ -334,7 +334,7 @@ def test_consolidation_recent_context_compresses_archived_window_not_kept_gap():
         profile_maint=cast(Any, memory),
         provider=cast(Any, provider),
         model="m",
-        keep_count=4,
+        keep_count=2,
     )
     session = SimpleNamespace(
         key="cli:1",
@@ -352,6 +352,11 @@ def test_consolidation_recent_context_compresses_archived_window_not_kept_gap():
             {"role": "user", "content": "第十一条", "timestamp": "2026-03-15T10:10:00"},
             {"role": "assistant", "content": "第十二条", "timestamp": "2026-03-15T10:11:00"},
             {"role": "user", "content": "第十三条", "timestamp": "2026-03-15T10:12:00"},
+            {"role": "assistant", "content": "第十四条", "timestamp": "2026-03-15T10:13:00"},
+            {"role": "user", "content": "第十五条", "timestamp": "2026-03-15T10:14:00"},
+            {"role": "assistant", "content": "第十六条", "timestamp": "2026-03-15T10:15:00"},
+            {"role": "user", "content": "第十七条", "timestamp": "2026-03-15T10:16:00"},
+            {"role": "assistant", "content": "第十八条", "timestamp": "2026-03-15T10:17:00"},
         ],
         last_consolidated=4,
         _channel="cli",
@@ -360,11 +365,12 @@ def test_consolidation_recent_context_compresses_archived_window_not_kept_gap():
 
     draft = _prepare(service, session)
 
-    assert "【较早窗口（本次待压缩）】\nUSER: 第五条\nASSISTANT: 第六条\nUSER: 第七条\nASSISTANT: 第八条\nUSER: 第九条" in captured_prompt["text"]
+    assert "【较早窗口（本次待压缩）】\nUSER: 第五条\nASSISTANT: 第六条\nUSER: 第七条\nASSISTANT: 第八条\nUSER: 第九条\nASSISTANT: 第十条" in captured_prompt["text"]
     assert draft is not None
     written = draft.recent_context_text
-    assert "until: 2026-03-15T10:08:00" in written
-    assert "[user] 第十三条" in written
+    assert "until: 2026-03-15T10:13:00" in written
+    assert "[user] 第十七条" in written
+    assert "[a-preview] 第十八条" in written
 
 
 def test_replace_recent_turns_block_preserves_existing_compression():
@@ -457,10 +463,10 @@ def test_consolidation_archive_all_compresses_full_history_before_recent_turns()
     assert "USER: 第一条" in prompt_before_recent
     assert "ASSISTANT: 第十条" in prompt_before_recent
     assert "USER: 第十一条" in prompt_before_recent
-    assert "ASSISTANT: 第十二条" not in prompt_before_recent
+    assert "ASSISTANT: 第十二条" in prompt_before_recent
     assert draft is not None
     written = draft.recent_context_text
-    assert "until: 2026-03-15T10:10:00" in written
+    assert "until: 2026-03-15T10:11:00" in written
     assert "[user] 第十三条" in written
 
 
@@ -501,7 +507,7 @@ def test_consolidation_recent_context_invalid_json_fails_consolidation():
         profile_maint=cast(Any, memory),
         provider=cast(Any, provider),
         model="m",
-        keep_count=4,
+        keep_count=2,
     )
     session = SimpleNamespace(
         key="cli:1",
@@ -525,7 +531,7 @@ def test_consolidation_recent_context_invalid_json_fails_consolidation():
         _chat_id="1",
     )
 
-    draft = _prepare(service, session)
+    draft = _prepare(service, session, force=True)
 
     assert draft is not None
     assert draft.step == "recent_context"
@@ -556,7 +562,7 @@ def test_consolidation_recent_context_exception_fails_consolidation():
         profile_maint=cast(Any, memory),
         provider=cast(Any, provider),
         model="m",
-        keep_count=4,
+        keep_count=2,
     )
     session = SimpleNamespace(
         key="cli:1",
@@ -580,7 +586,7 @@ def test_consolidation_recent_context_exception_fails_consolidation():
         _chat_id="1",
     )
 
-    draft = _prepare(service, session)
+    draft = _prepare(service, session, force=True)
 
     assert draft is not None
     assert draft.step == "recent_context"

--- a/tests/test_loop_consolidation_json.py
+++ b/tests/test_loop_consolidation_json.py
@@ -43,7 +43,7 @@ def test_select_consolidation_window_uses_half_window_tail_keep():
     session = SimpleNamespace(
         key="cli:1",
         last_consolidated=2,
-        messages=[{"content": str(i)} for i in range(10)],
+        messages=[{"role": "user", "content": str(i)} for i in range(10)],
     )
 
     window = _select_consolidation_window(
@@ -57,6 +57,28 @@ def test_select_consolidation_window_uses_half_window_tail_keep():
     assert window.keep_count == 3
     assert window.consolidate_up_to == 7
     assert [m["content"] for m in window.old_messages] == ["2", "3", "4", "5", "6"]
+
+
+def test_select_consolidation_window_never_splits_explicit_multi_input_turn():
+    messages = [
+        {"role": "user", "content": "old", "control_turn_id": "old"},
+        {"role": "assistant", "content": "done", "control_turn_id": "old"},
+        {"role": "user", "content": "u1", "control_turn_id": "current"},
+        {"role": "user", "content": "u2", "control_turn_id": "current"},
+        {"role": "assistant", "content": "final", "control_turn_id": "current"},
+    ]
+    session = SimpleNamespace(key="cli:1", last_consolidated=0, messages=messages)
+
+    window = _select_consolidation_window(
+        session,
+        keep_count=1,
+        consolidation_min_new_messages=1,
+        archive_all=False,
+    )
+
+    assert window is not None
+    assert window.old_messages == messages[:2]
+    assert window.consolidate_up_to == 2
 
 
 def test_build_consolidation_source_ref_returns_message_id_list_json():
@@ -116,8 +138,18 @@ def test_format_conversation_for_consolidation_skips_proactive_assistant_message
 def test_consolidation_formatters_skip_context_frame_messages():
     frame = '<system-reminder data-system-context-frame="true">\n内部上下文'
     messages = [
-        {"id": "1", "role": "user", "content": frame, "timestamp": "2026-03-09T10:00:00"},
-        {"id": "2", "role": "user", "content": "真实用户内容", "timestamp": "2026-03-09T10:01:00"},
+        {
+            "id": "1",
+            "role": "user",
+            "content": frame,
+            "timestamp": "2026-03-09T10:00:00",
+        },
+        {
+            "id": "2",
+            "role": "user",
+            "content": "真实用户内容",
+            "timestamp": "2026-03-09T10:01:00",
+        },
     ]
 
     window = SimpleNamespace(old_messages=messages)

--- a/tests/test_loop_consolidation_json.py
+++ b/tests/test_loop_consolidation_json.py
@@ -81,6 +81,37 @@ def test_select_consolidation_window_never_splits_explicit_multi_input_turn():
     assert window.consolidate_up_to == 2
 
 
+def test_force_consolidation_rewinds_invalid_cursor_to_recent_boundary():
+    messages = [
+        {"role": "user", "content": "u1", "control_turn_id": "first"},
+        {"role": "user", "content": "u2", "control_turn_id": "first"},
+        {"role": "assistant", "content": "a1", "control_turn_id": "first"},
+        {"role": "user", "content": "u3", "control_turn_id": "second"},
+        {"role": "assistant", "content": "a2", "control_turn_id": "second"},
+    ]
+    session = SimpleNamespace(key="cli:1", last_consolidated=4, messages=messages)
+
+    with pytest.raises(ValueError, match="逻辑历史单元内部"):
+        _select_consolidation_window(
+            session,
+            keep_count=1,
+            consolidation_min_new_messages=1,
+            archive_all=False,
+        )
+
+    window = _select_consolidation_window(
+        session,
+        keep_count=1,
+        consolidation_min_new_messages=1,
+        archive_all=False,
+        force=True,
+    )
+
+    assert window is not None
+    assert window.old_messages == messages[3:]
+    assert window.consolidate_up_to == 5
+
+
 def test_build_consolidation_source_ref_returns_message_id_list_json():
     window = SimpleNamespace(
         old_messages=[

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -715,6 +715,53 @@ async def test_markdown_consolidation_failure_trace_does_not_advance_cursor(
     assert session.last_consolidated == 0
 
 
+async def test_force_consolidation_persists_cursor_rewind_without_new_messages(
+    tmp_path: Path,
+):
+    session = SimpleNamespace(
+        key="cli:rewind",
+        messages=[
+            {
+                "role": "user",
+                "content": "remaining user",
+                "control_turn_id": "turn-1",
+            },
+            {
+                "role": "assistant",
+                "content": "remaining assistant",
+                "control_turn_id": "turn-1",
+            },
+        ],
+        last_consolidated=3,
+    )
+    maintenance = MarkdownMemoryMaintenance(
+        store=MarkdownMemoryStore(tmp_path),
+        provider=cast(Any, SimpleNamespace()),
+        model="lm",
+        keep_count=2,
+    )
+    save_session = AsyncMock()
+    maintenance.bind_lifecycle(
+        MemoryLifecycleBindRequest(
+            get_session=lambda _key: session,
+            save_session=save_session,
+        )
+    )
+
+    result = await maintenance.consolidate(
+        ConsolidateRequest(session=session, force=True)
+    )
+
+    assert result.consolidated_count == 0
+    assert result.trace == {
+        "mode": "skipped",
+        "cursor_rewound_from": 3,
+        "cursor_rewound_to": 2,
+    }
+    assert session.last_consolidated == 2
+    save_session.assert_awaited_once_with(session)
+
+
 async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cursor(
     tmp_path: Path,
 ):

--- a/tests/test_memory_engine_contract.py
+++ b/tests/test_memory_engine_contract.py
@@ -251,7 +251,10 @@ async def test_default_engine_keeps_history_injected_ids():
                 }
             ]
         ),
-        build_injection_block=lambda items: ("## 【相关历史】\n- 用户昨天提过 FitBit", ["e1"]),
+        build_injection_block=lambda items: (
+            "## 【相关历史】\n- 用户昨天提过 FitBit",
+            ["e1"],
+        ),
     )
     engine = _make_default_engine(retriever=cast(Any, retriever))
 
@@ -259,7 +262,9 @@ async def test_default_engine_keeps_history_injected_ids():
         MemoryQuery(
             text="Fitbit 型号",
             intent="context",
-            scope=MemoryScope(session_key="telegram:1", channel="telegram", chat_id="1"),
+            scope=MemoryScope(
+                session_key="telegram:1", channel="telegram", chat_id="1"
+            ),
             filters=MemoryQueryFilters(
                 kinds=("event",),
                 hints={"require_scope_match": True},
@@ -378,8 +383,7 @@ async def test_default_memory_engine_rolls_back_partial_event_wiring():
 
     assert event_bus.handler_count() == 0
     assert not any(
-        isinstance(closeable, EventSubscription)
-        for closeable in engine.closeables
+        isinstance(closeable, EventSubscription) for closeable in engine.closeables
     )
     assert engine._event_wired is False
 
@@ -632,7 +636,9 @@ async def test_default_memory_engine_logs_lifecycle_consolidation_failure(caplog
     await event_bus.aclose()
 
 
-async def test_markdown_consolidation_advances_window_when_consumer_fails(tmp_path: Path):
+async def test_markdown_consolidation_advances_window_when_consumer_fails(
+    tmp_path: Path,
+):
     event_bus = EventBus()
 
     async def _fail_consolidation(_event):
@@ -675,7 +681,9 @@ async def test_markdown_consolidation_advances_window_when_consumer_fails(tmp_pa
     await event_bus.aclose()
 
 
-async def test_markdown_consolidation_failure_trace_does_not_advance_cursor(tmp_path: Path):
+async def test_markdown_consolidation_failure_trace_does_not_advance_cursor(
+    tmp_path: Path,
+):
     session = SimpleNamespace(
         key="cli:1",
         messages=[{"role": "user", "content": f"u{i}"} for i in range(8)],
@@ -712,8 +720,7 @@ async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cu
 ):
     async def _chat(**kwargs):
         text = "\n".join(
-            str(message.get("content") or "")
-            for message in kwargs["messages"]
+            str(message.get("content") or "") for message in kwargs["messages"]
         )
         if "近期语境压缩代理" in text:
             return SimpleNamespace(
@@ -722,9 +729,7 @@ async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cu
                     '"follow_ups":[],"avoidances":[],"ongoing_threads":[]}'
                 )
             )
-        return SimpleNamespace(
-            content='{"history_entries":[],"pending_items":[]}'
-        )
+        return SimpleNamespace(content='{"history_entries":[],"pending_items":[]}')
 
     session = SimpleNamespace(
         key="cli:paged",
@@ -735,7 +740,7 @@ async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cu
                 "content": f"message-{index}",
                 "timestamp": f"2026-07-27T00:{index:02d}:00+00:00",
             }
-            for index in range(8)
+            for index in range(14)
         ],
         last_consolidated=0,
     )
@@ -758,11 +763,11 @@ async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cu
         ConsolidateRequest(session=session, drain_backlog=True)
     )
 
-    assert result.consolidated_count == 6
+    assert result.consolidated_count == 10
     assert result.trace["mode"] == "markdown"
-    assert result.trace["pages"] == 3
-    assert session.last_consolidated == 6
-    assert save_session.await_count == 3
+    assert result.trace["pages"] == 5
+    assert session.last_consolidated == 10
+    assert save_session.await_count == 5
     assert [
         json.loads(source_ref)
         for source_ref in cast(list[str], result.trace["source_refs"])
@@ -770,6 +775,8 @@ async def test_markdown_consolidation_drains_budgeted_pages_and_persists_each_cu
         ["cli:paged:0", "cli:paged:1"],
         ["cli:paged:2", "cli:paged:3"],
         ["cli:paged:4", "cli:paged:5"],
+        ["cli:paged:6", "cli:paged:7"],
+        ["cli:paged:8", "cli:paged:9"],
     ]
 
 
@@ -781,8 +788,7 @@ async def test_markdown_consolidation_preserves_committed_pages_after_later_fail
     async def _chat(**kwargs):
         nonlocal event_extract_calls
         text = "\n".join(
-            str(message.get("content") or "")
-            for message in kwargs["messages"]
+            str(message.get("content") or "") for message in kwargs["messages"]
         )
         if "近期语境压缩代理" in text:
             return SimpleNamespace(
@@ -794,9 +800,7 @@ async def test_markdown_consolidation_preserves_committed_pages_after_later_fail
         event_extract_calls += 1
         if event_extract_calls == 2:
             raise RuntimeError("page two failed")
-        return SimpleNamespace(
-            content='{"history_entries":[],"pending_items":[]}'
-        )
+        return SimpleNamespace(content='{"history_entries":[],"pending_items":[]}')
 
     session = SimpleNamespace(
         key="cli:paged-failure",
@@ -807,7 +811,7 @@ async def test_markdown_consolidation_preserves_committed_pages_after_later_fail
                 "content": f"message-{index}",
                 "timestamp": f"2026-07-27T00:{index:02d}:00+00:00",
             }
-            for index in range(8)
+            for index in range(14)
         ],
         last_consolidated=0,
     )
@@ -859,6 +863,30 @@ def test_consolidation_page_never_splits_a_single_semantic_turn():
 
     assert page.old_messages == messages[:2]
     assert page.consolidate_up_to == 2
+
+
+def test_consolidation_page_never_splits_explicit_multi_input_turn():
+    from core.memory.markdown import (
+        _ConsolidationWindow,
+        _limit_consolidation_window,
+    )
+
+    messages = [
+        {"role": "user", "content": "u1" * 500, "control_turn_id": "turn-1"},
+        {"role": "user", "content": "u2" * 500, "control_turn_id": "turn-1"},
+        {"role": "assistant", "content": "final", "control_turn_id": "turn-1"},
+        {"role": "assistant", "content": "主动提醒", "proactive": True},
+    ]
+    window = _ConsolidationWindow(
+        old_messages=messages,
+        keep_count=0,
+        consolidate_up_to=4,
+    )
+
+    page = _limit_consolidation_window(window, max_conversation_chars=1)
+
+    assert page.old_messages == messages[:3]
+    assert page.consolidate_up_to == 3
 
 
 async def test_default_memory_engine_serializes_lifecycle_maintenance():
@@ -1307,4 +1335,6 @@ def test_build_memory_runtime_exposes_default_memory_engine(
     assert runtime.engine is not None
     assert runtime.engine.describe().name == "default"
     assert runtime.embedding_api is runtime.engine.embedding_api
-    assert MemoryCapability.SEMANTICS_RICH_MEMORY in runtime.engine.describe().capabilities
+    assert (
+        MemoryCapability.SEMANTICS_RICH_MEMORY in runtime.engine.describe().capabilities
+    )


### PR DESCRIPTION
## 问题与结果

- 解决的问题：完成后的 U1/U2/U3/A 必须作为一个逻辑单元进入 Akasha、recent history、Markdown consolidation、memory window 与 compaction，不能再次按消息行拆散。
- 用户可见结果：下一轮 history 展开全部 U 与最终 A；Akasha 只建立一个 completed turn 节点；窗口、分页、replay 和 consolidation cursor 不拆 interaction。
- 本 PR 不处理：脏数据迁移；维护者已明确不处理。interaction 撤销由 #328/#329 处理；U5 joined-text turn embedding store 另开独立 PR。

## Stack

- #323：语义合同
- #324：durable control primitives
- #325：runtime 与 attempt replay
- 当前 #326：Akasha、memory window、consolidation 与 replay consumers
- #328：interaction 原子撤销
- #329：Akasha source deletion 协调与重建

## Review 修复

- U1：普通 consolidation 对非法 cursor 继续 fail-loud；显式 `force` 回退到不超过旧 cursor 的最近合法逻辑单元边界，持久化修复并留下 trace。`archive_all` 的全量边界也可自然修复。
- U2：`config.example.toml` 与需求文档明确 `memory_window`、`keep_count`、`min_new_messages` 从消息数变为逻辑单元数，升级不自动换算旧值。
- U3：维护者确认显式 multi-U interaction 只能整组撤销，已拆到 #328/#329。
- U5：维护者确认采用 Akasha 自管 turn embedding store，排在 U3 之后单独 review，不混入本 PR。

## Change intent

- `change_type`：`feature` + review fixes
- `semantic_delta`：`compatible`（配置计数单位变化已显式记录升级语义）
- `capability_owner`：`mixed`
- `consumer_scope`：Akasha plugin、Markdown memory、logical history/replay consumers
- `runtime_patch`：`required`
- `runtime_patch_reason`：完成 interaction identity 来自 core，Akasha 与 Markdown 只消费已提交事实；客户端不能决定 consolidation cursor 或 canonical turn。
- `authoritative_state_owner`：`sessions.db/messages` 是 truth；Akasha sidecar 与 recent context 是派生投影。
- 关联不变量：多个 U 与唯一 terminal A 原子消费；legacy adjacent UA 保持；proactive assistant 独立成单元；cursor 不落在逻辑单元内部。
- `protected_state`：既有 messages、legacy Akasha digest、正式 workspace。
- 允许的副作用：force 时只更新 consolidation cursor 与既有派生写入。
- 禁止的副作用：清洗脏数据、DELETE/UPDATE 历史正文、静默修复非 force cursor。

## 改动范围

- 主要文件：`core/memory/markdown.py`、`plugins/akasha/engine.py`、`plugins/akasha/infrastructure/sparse_index/builder.py`、history/replay consumers、配置升级说明。
- 配置或迁移影响：无 schema migration；窗口配置按 logical unit 解释，不自动改值。
- 已知 schema lineage 与最终 schema identity：同时接受显式 `control_turn_id` transcript 与严格 legacy adjacent UA；派生 sparse index 可重建。
- revision：base #325 head `28398c71`，当前 head `1aec2ea929ab0757b32d6a6f9a6bbfd3e07c0cdd`。
- 回滚方式：按栈逆序 revert U2 `1aec2ea9`、U1 `1b573ccc` 及本层 feature commits。

## 验证

- [x] U1 force/非-force/cursor boundary 定向测试通过。
- [x] Akasha online/offline、memory engine contract 与 logical history consumer 测试通过。
- [x] GitHub `contract` 与 `locked-runtime` checks 在当前 head SHA 均通过。
- [x] 栈顶 #329 累计相关测试 207 passed、全仓 Pyright 0 errors、完整 public Gate 通过。
- 真实设备证据：本 PR 不新增 mobile UI；交互主链的累计 Preview 证据由前层保留。
- 未运行项与原因：未迁移或重写正式 workspace，符合“不处理脏数据”的维护者决定。

## 工作手册

- [x] 已核对 `projectneed.md`、0025 决策、persistence state map 与 review 清单。
- [x] 长期语义变化已获确认。
- [x] 已核对 Akasha plugin 与 core owner 边界。
- [x] 当前没有对应 NOW 事项。
