### PR TITLE
[codex] 添加模型交互预览与设计对账

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,14 @@ uv venv && uv pip install -r requirements.txt
 
 没有 uv？先 `pip install uv`。
 
-**1. 启动设置中心**
+**1. 启动 Akashic Web**
 
 ```bash
 uv run python main.py
 ```
 
-Supervisor 会始终提供本机设置中心：
-
-- 设置中心：<http://127.0.0.1:6321>
-- Web Chat：<http://127.0.0.1:6322>
+Supervisor 会始终提供唯一的本机 Web 入口：<http://127.0.0.1:2236>。访问后直接进入
+Chat；没有模型配置时，Chat 会保留完整界面并引导进入“模型与认证”。
 
 第一次运行不需要先创建 `config.toml`。打开设置中心，选择一种认证方式：
 
@@ -81,12 +79,13 @@ Supervisor 会始终提供本机设置中心：
 | Codex Auth | 复用本机 Codex 登录，未登录时按页面提示完成设备授权 |
 
 ```text
-打开 6321
+打开 2236 Chat
    │
+   ├── 点击“连接模型”
    ├── 选择 Provider 与认证
    ├── 读取或填写模型
    ├── 发送最小真实请求验证
-   └── 保存配置 → 启动 Gateway → 打开 6322 对话
+   └── 保存配置 → 同一页面自动恢复对话
 ```
 
 API Key 会直接写入本机 `config.toml`，文件权限为 `0600`；设置 API 和页面不会回显
@@ -149,8 +148,6 @@ allow_from = ["your_username"]
 
 [channels.chat]
 enabled = true
-host = "127.0.0.1"
-port = 6322
 channel_name = "web"
 ```
 
@@ -167,7 +164,7 @@ channel_name = "web"
 `--workspace PATH`；它的优先级高于 `AKASHIC_WORKSPACE` 和 `config.toml`。
 
 **个人推荐**：主模型使用 DeepSeek，轻量和视觉任务使用 Qwen。通信渠道推荐
-Telegram；只想先本机试用时，完成 6321 设置后直接打开 6322 即可。
+Telegram；只想先本机试用时，打开 2236 绑定模型后即可直接对话。
 
 **3. 运行与安全切换**
 
@@ -176,9 +173,9 @@ Telegram；只想先本机试用时，完成 6321 设置后直接打开 6322 即
 送达和私有提交证据全部完成后安全拉起下一代进程。需要让调试器直接附着未托管 gateway
 时，显式运行 `uv run python main.py gateway`；该模式不会注册自重启工具。
 
-在 6321 切换 Provider 时，Supervisor 会停止接收新 turn、等待已经接收的 turn 自然完成，
-再启动候选 Gateway。候选未通过 readiness 时会恢复配置并重新启动原 Gateway；设置中心在
-整个过程中保持可用。
+在 2236 的“模型与认证”切换 Provider、模型或默认角色时，Gateway 会原子发布新模型代际，不停止接收新
+turn，也不重启进程。已经开始的执行继续使用旧代，下一个真正开始的执行使用新代；候选
+配置或真实请求校验失败时保持原配置和当前代际。
 
 从终端或 supervisor 切换到 PyCharm 前，先优雅停止当前 workspace 的 runtime：
 
@@ -198,7 +195,7 @@ supervisor；需要直接调试 child 时把程序参数设为 `gateway`。也�
 
 ## 用 Android 手机接入
 
-Akashic Mobile 是一个通过独立实时网关连接 Akashic Agent 的 Android 客户端。远程接入推荐使用 Cloudflare Tunnel：Web Chat 和配对管理页继续留在本机 `127.0.0.1:6322`，Tunnel 只转发由 Akashic 设备认证保护的 `6323` 端口。
+Akashic Mobile 是一个通过独立实时网关连接 Akashic Agent 的 Android 客户端。远程接入推荐使用 Cloudflare Tunnel：Web Chat 和模型设置继续留在本机 `127.0.0.1:2236`，Tunnel 只转发由 Akashic 设备认证保护的 `6323` 端口。
 
 ```text
 1. 在 config.toml 启用 [mobile_realtime]
@@ -282,8 +279,8 @@ AKASHIC_WEBUI_SOURCE_COMMIT="$(git rev-parse HEAD)"
 
 | 想看什么 | 文档 |
 |---------|------|
-| 怎么首次配置或切换 Provider | 启动后访问 `http://127.0.0.1:6321`，支持 API Key、OpenCode Go 和 Codex Auth |
-| 怎么打开本机 Web Chatbox | 启动后访问 `http://127.0.0.1:6322`，配置见 `config.toml` 的 `[channels.chat]` |
+| 怎么首次配置或切换 Provider | 启动后访问 `http://127.0.0.1:2236/settings`，支持 API Key、OpenCode Go 和 Codex Auth |
+| 怎么打开本机 Web Chat | 启动后访问 `http://127.0.0.1:2236`；没有模型时页面会直接引导配置 |
 | 怎么用 Android 手机远程连接 | [移动端接入手册](./_handbook/mobile-access.md) |
 | 怎么让 agent 主动推送消息、怎么配数据源 | [_handbook/proactive-guide.md](./_handbook/proactive-guide.md) |
 | 怎么写后台任务让 agent 空闲时自动干活 | [_handbook/drift-guide.md](./_handbook/drift-guide.md) |
@@ -327,8 +324,8 @@ Agent 根据电量模型自适应调整轮询频率——你刚聊完时不烦�
 ```bash
 uv run python main.py exec --new --final-only "总结最近上下文"
 uv run python main.py app-server --stdio # 父进程托管 JSON-RPC app-server
-uv run python main.py dashboard # 打开 Dashboard（默认 :2236）
-# Web Chatbox 跟主进程一起启动，默认 http://127.0.0.1:6322
+uv run python main.py dashboard # 单独运行 Dashboard 调试入口
+# 正式 Supervisor 只提供 http://127.0.0.1:2236，根页面是统一壳层并默认选中 Chat
 uv run python main.py --help    # 查看全部子命令
 
 pytest tests/

--- a/_handbook/mobile-access.md
+++ b/_handbook/mobile-access.md
@@ -4,11 +4,11 @@ Akashic Mobile 是一个通过独立实时网关连接 Akashic Agent 的 Android
 
 ## 1. 接入结构
 
-Akashic Agent 同时提供两个端口。`6322` 承载本机 Web Chat 和配对管理页面；`6323` 承载手机使用的 WSS 实时协议与同源 HTTPS 插件查询。Cloudflare 只转发 `6323`。
+Akashic Agent 提供两个用途明确的端口。`2236` 是本机唯一 Web 入口，承载 Chat、设置、Dashboard 和配对管理页面；`6323` 承载手机使用的 WSS 实时协议与同源 HTTPS 插件查询。Cloudflare 只转发 `6323`。
 
 ```text
 ┌────────────┐  本机 HTTP   ┌────────────────────────┐
-│ 维护者浏览器 │ ──────────▶ │ Web Chat :6322         │
+│ 维护者浏览器 │ ──────────▶ │ Web Shell :2236        │
 └────────────┘              │ 生成二维码、批准设备      │
                             └───────────┬────────────┘
                                         │ 一次性配对状态
@@ -39,7 +39,7 @@ uv run python main.py
 ```
 
 ```text
-http://127.0.0.1:6322
+http://127.0.0.1:2236
 ```
 
 ## 3. 启用移动实时网关
@@ -55,8 +55,6 @@ cp --preserve=all --no-clobber config.toml config.toml.before-mobile
 ```toml
 [channels.chat]
 enabled = true
-host = "127.0.0.1"
-port = 6322
 channel_name = "web"
 
 [mobile_realtime]
@@ -75,7 +73,7 @@ master_key_namespace = "akasic/mobile-realtime"
 keyset_manifest = "data/mobile/keys/current.json"
 ```
 
-`public_url` 必须使用 `wss`，路径必须是 `/ws`，不能携带用户名、密码、query 或 fragment。`channels.chat.host` 必须保持 loopback；配置加载器会拒绝把配对管理页面暴露到局域网。
+`public_url` 必须使用 `wss`，路径必须是 `/ws`，不能携带用户名、密码、query 或 fragment。正式 Supervisor 的 Web Shell 固定使用 loopback `2236`，并提供统一 Dashboard 壳层与静态前端；Chat 与 Dashboard 的运行时 API 通过 Unix socket 接入，不再配置独立 HTTP 端口。
 
 优雅停止旧进程，再重新启动：
 
@@ -205,7 +203,7 @@ PY
 ## 6. 安装并配对手机
 
 1. 从 [Akashic Mobile Releases](https://github.com/kachofugetsu09/akashic-mobile/releases/latest) 下载 APK 并安装。
-2. 在电脑上打开 `http://127.0.0.1:6322`，点击“连接手机”。
+2. 在电脑上打开 `http://127.0.0.1:2236`，点击“连接手机”。
 3. 在 Android 客户端选择“扫描电脑”，扫描电脑页面上的二维码。
 4. 手机和电脑会显示六位确认码。逐位核对，数字一致后在电脑上选择“确认并连接”。
 5. 等待电脑显示“手机已连接”，再关闭配对窗口。
@@ -251,7 +249,7 @@ Cloudflare 对 `502`、Tunnel 状态和 WebSocket 的解释见官方的 [Tunnel 
 
 ## 8. 安全边界
 
-- 只把 `6323` 配到 Cloudflare；`6321` 设置中心和 `6322` Web Chat 留在 loopback。
+- 只把 `6323` 配到 Cloudflare；唯一 Web 入口 `2236` 留在 loopback。
 - Tunnel token 只放在权限为 `0600` 的文件或专用 secret store 中。怀疑泄露时在 Cloudflare Dashboard 轮换 token，并重启 connector。
 - `mobile_realtime.db`、`data/mobile/keys/` 和 Secret Service 中的 master key 共同维持服务端身份与已配对设备。备份和恢复必须成组处理。
 - 不要删除 `current.json`、加密 key blob 或移动数据库来处理启动错误。数据库有身份而 keyset 丢失时，runtime 会按设计拒绝启动。

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -43,7 +43,7 @@ Dashboard 插件的前端样式分为两层：主程序提供公共 preset，插
 
 ### 插件颜色主题契约
 
-Dashboard、桌面 Web、6321 设置页和 Android 移动 WebUI 使用同一个扁平 theme ID。默认值是 `light`，当前内置 `light`、`dark` 和实验性的 `warm-paper`；不提供“跟随系统”。主题目录随 WebUI 构建发布为 `akashic-theme-catalog.json`。
+Dashboard、`2236` Web Shell 内的 Chat/设置页和 Android 移动 WebUI 使用同一个扁平 theme ID。默认值是 `light`，当前内置 `light`、`dark` 和实验性的 `warm-paper`；不提供“跟随系统”。主题目录随 WebUI 构建发布为 `akashic-theme-catalog.json`。
 
 ```text
 ┌─ theme ID：light / dark / warm-paper / future-theme

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -104,6 +104,7 @@
 | Markdown 记忆、Memory2、Akasha | `projectneed` 第 6、8、11～13 节 → [0006](decisions/0006-akasha-v2-is-the-canonical-explicit-memory-engine.md) → [Akasha V2 在线与重放](design/akasha-v2-runtime-migration.md) → [Codex 式同 Turn 输入需求](design/codex-style-same-turn-input-requirements.md) → [Codex 式同 Turn 输入设计](design/codex-style-same-turn-input.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/memory.py`、`core/memory/markdown.py`、`memory2/store.py`、`plugins/default_memory/`、`plugins/akasha/` |
 | 主动流程、Wake、Drift、调度 | `projectneed` 第 6、9、12～13 节 → [持久化状态地图](design/persistence-state-map.md) → [Wake 最近主动消息上下文](design/wake-recent-delivery-context.md) | `bootstrap/proactive.py`、`proactive_v2/`、`plugins/default_proactive/`、`plugins/wake_proactive/`、`plugins/drift_flow/`、`agent/scheduler.py` |
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [Linux Supervisor 安全自重启提议](design/linux-supervisor-safe-self-restart.md) → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
+| Provider、模型角色、运行时切换、usage、首次配置 | `projectneed` RUN-005～RUN-012、ONB-001、CTX-001 → [0026](decisions/0026-runtime-models-use-generation-leases.md) → [0027](decisions/0027-model-credentials-live-with-workspace-connections.md) → [运行时模型注册表与 Onboarding](design/runtime-model-registry-and-onboarding.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/model_runtime/`、`bootstrap/providers.py`、`bootstrap/settings_api.py`、`bootstrap/app.py`、`main.py`、`agent/supervisor.py`、`frontend/chat/src`、Observe 隔离 Gate |
 | 插件安装、热重载、自验证、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、9～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [0024](decisions/0024-plugin-self-validation-uses-stable-and-latest.md) → [插件递归自验证运行时设计](design/recursive-plugin-self-validation.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/snapshot.py`、`agent/plugins/reload_journal.py`、`agent/plugins/skill_links.py`、`agent/control/runtime.py`、`agent/looping/core.py`、`agent/mcp/host.py` |
 | 移动端查看 Markdown、定时任务、插件、Skill、MCP | `projectneed` 第 6、10～13 节 → [移动端运行时检查](design/mobile-runtime-inspection.md) → [持久化状态地图](design/persistence-state-map.md) | `infra/mobile_realtime/runtime_inspection.py`、`infra/mobile_realtime/protocol.py`、`infra/mobile_realtime/channel.py` |
 | Workspace、配置、凭据、迁移、备份 | `projectneed` 第 6、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [0021](decisions/0021-yoyo-workspace-ledger-defines-migration-origin.md) → [Yoyo 迁移维护手册](design/git-migration-authoring.md) | `main.py`、`bootstrap/init_workspace.py`、`agent/config.py`、`agent/migrations/`、`migrations/yoyo/`、`agent/model_runtime/auth/store.py`、`scripts/rolling_backup.py` |
@@ -207,7 +208,9 @@ docs/
 │   ├── 0022-mobile-webui-uses-server-selected-generations.md
 │   ├── 0023-akashic-tokens-own-material-3-semantics.md
 │   ├── 0024-plugin-self-validation-uses-stable-and-latest.md
-│   └── 0025-codex-style-same-turn-input.md
+│   ├── 0025-codex-style-same-turn-input.md
+│   ├── 0026-runtime-models-use-generation-leases.md
+│   └── 0027-model-credentials-live-with-workspace-connections.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── linux-supervisor-safe-self-restart.md
@@ -217,6 +220,7 @@ docs/
 │   ├── codex-style-same-turn-input.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── query-local-react-compaction.md
+│   ├── runtime-model-registry-and-onboarding.md
 │   ├── server-published-mobile-webui.md
 │   ├── shared-chat-webui.md
 │   ├── unified-shell-execution.md

--- a/docs/decisions/0026-runtime-models-use-generation-leases.md
+++ b/docs/decisions/0026-runtime-models-use-generation-leases.md
@@ -1,0 +1,64 @@
+# 0026 · 运行时模型切换使用 execution generation lease
+
+- 状态：accepted
+- 日期：2026-08-06
+- 部分勘误：[0027](0027-model-credentials-live-with-workspace-connections.md) 将模型凭据从全局 JSON 迁入 workspace connection
+- 关联条款：RUN-009～RUN-012、ONB-001、CTX-001、PLG-003
+
+## 背景
+
+当前 Gateway 启动时从 `config.toml` 构造 main、fast、agent 和 vision provider，并把实例注入 Turn、主动流程、调度、记忆和插件。频繁变化的模型状态和端口、渠道等进程配置混在同一文件；设置服务修改模型后还会通过 Supervisor 让整个 Gateway 排空并重启。因此一次普通模型切换会阻止新 Turn，且首次没有配置时启动脚本可能在用户完成设置前结束 Supervisor。
+
+模型能力和 usage 还存在两个平行问题：设置要求用户手填上下文窗口、多模态和输出上限；插件与部分主动流程消费私有缓存字段，没有统一的 coverage 语义。
+
+## 决定
+
+workspace 新增 `model-registry.sqlite3`，以 connection、model 和 role binding 三层保存模型配置；`config.toml` 只保留进程、渠道、记忆和其他静态配置。根据 0027 的勘误，模型 CredentialStore 也以同一 workspace 数据库为 backend，connection 行拥有 credential payload。
+
+Core 的 `ModelRegistry` 在每个新执行单元开始时读取模型库最新 revision，把 `default`、`fast`、`agent` 和 `vision` 整组绑定编译为不可变 generation，再租用这一代。passive ReAct、proactive ReAct、schedule SOFT、Memory Optimizer、consolidation、plugin job 和回复后记忆任务各自是完整执行单元。执行期间出现新 revision 不改变当前租约；没有外层执行单元的单次模型调用在调用前读取最新 revision。旧代在 lease 归零后释放。模型凭据的最终 owner 由 0027 勘误为同一 workspace connection。
+
+Supervisor 继续拥有进程和 boot 代际，但不拥有模型 generation。新增连接时可以通过独立 reload 信号要求 Gateway 立即验证并发布；普通 role binding 修改由下一执行直接读取数据库 revision。两条路径都不触发 Gateway 退出、全局 quiesce 或 Guardian 换代。首次没有配置时 Supervisor 仍拥有 bootstrap 写入，合法配置产生后再启动第一代 Gateway。
+
+Supervisor 同时在整个生命周期内独占 `2236` Web Shell。根路径 `/` 直接提供统一 Dashboard 壳层并默认选中 Chat，不做 `/dashboard` 跳转；壳层内部 Chat 使用 `/chat`，模型与认证使用 `/settings`。Gateway 的 Chat/Dashboard API 只通过 workspace Unix socket 向 Web Shell 提供能力。`6321`、`6322` 不再监听，Web 页面不得用端口号承担路由或能力探测语义。这样 onboarding、Gateway reload 和异常退出都不会让用户入口消失。
+
+模型能力使用“显式覆盖 → provider 权威目录 → 固定版本 LiteLLM 本地注册表 → unknown”的字段级优先级。只读取 wheel 内置快照，不让设置与启动依赖公共网络。Unknown 不猜测。Usage 使用固定版本 `genai-prices` 的 provider extractor，再补充当前统一类型仍需要的窄字段映射；解析缺口显式降级 coverage。
+
+## 理由
+
+- 数据库 revision 加 execution lease 直接表达“库中始终是最新状态，当前执行用旧快照，下一执行用新快照”，不依赖消息发送方猜测是否需要重启。
+- Core 是 Turn、后台任务和插件共同模型语义的唯一交点；只在 Web 客户端切换会遗漏其他消费者。
+- LiteLLM 只拥有 provider/model 能力归一化；保留现有传输层，避免引入其 router 的重试、fallback 和路由语义。
+- 固定 wheel 的内置目录让正常启动不依赖公共网络，又能直接复用成熟 registry API。
+- Supervisor 只传递 reload admission 和回执，继续保持 RUN-004 的进程所有权。
+
+## 数据影响
+
+- `model-registry.sqlite3`：增加 connection、model、role binding 和单调 revision。设置事务原位更新当前绑定或增加来源/模型；删除必须是独立操作，且受外键和 session 引用检查约束。
+- `config.toml`：迁移前保留具名备份，迁移后删除动态模型表并写入 `registry = "workspace"` 标记；后续模型切换不得再改写该文件。
+- workspace 模型 CredentialStore：新 API Key 随 connection 增加或更新；迁移把旧 inline key 或被引用的旧 JSON credential 复制入数据库，并在成功校验后从 TOML 删除动态模型配置。
+- `sessions.metadata`：允许原位更新版本化 `model_selection`（model ref + reasoning effort）；清除只删除这一键，不影响消息正文。旧 `model_runtime_override` 只读兼容至下一次显式选择。
+- turn 元数据与 usage：随新 Turn 追加实际 runtime/generation 和规范化 usage；既有 Turn 不回填。
+- `sessions.db/messages`：保持只追加；模型切换、能力变化和上下文缩小都不得 UPDATE 或 DELETE。
+- 能力快照：解析结果随 runtime 配置持久化并标记 `litellm` 来源；依赖版本固定后才允许更新，不是用户输入真源。
+
+## 失败与回滚
+
+候选先完成边界校验和真实 provider probe，再用一个数据库事务提交模型行和 revision。Gateway 在新执行开始前完整构造 candidate generation；失败继续使用 current。若数据库已提交但调用方未收到回执，重试读取 revision 判断是否已经提交。进程崩溃后从模型库重建，不通过内存指针推断外部效果已回滚。
+
+源码回滚使用任务前 Git stash 恢复点或回退本分支提交。运行配置恢复使用对应 operation backup，并再次走同一数据库提交协议；不得直接修改内存 current 指针冒充持久配置已经恢复。
+
+## 验收
+
+- A Turn 运行中发布 B，A 的多次请求仍使用旧代，下一 Turn 使用 B。
+- 排队但未开始、主动 tick、plugin job 和记忆任务在开始时取得最新代。
+- 候选失败不改变配置摘要和 current generation。
+- 更小窗口只改变临时 Prompt 投影，不改变完整 session 历史。
+- 无配置的正式入口持续提供 onboarding，配置成功后启动 Gateway。
+- 只出现一个 `2236` TCP listener；无配置时 `/` 仍是 Chat，且不存在 `6321/6322` listener。
+- 使用固定 Observe 插件 revision 在一次性 workspace 观察真实 committed Turn、model binding 和 usage。
+
+## 未选择的方案
+
+- 每次切换重启 Gateway：会排空无关执行，不能表达 execution-local 冻结。
+- 由 Web 客户端比较上一轮模型后决定重启：遗漏后台消费者，并把 Core 权威语义交给单一客户端。
+- 采用完整 LiteLLM/Pydantic AI transport：会改变现有协议、重试和错误边界，超出本次目标；本决定只采用 LiteLLM 的本地元数据 registry。

--- a/docs/decisions/0027-model-credentials-live-with-workspace-connections.md
+++ b/docs/decisions/0027-model-credentials-live-with-workspace-connections.md
@@ -1,0 +1,66 @@
+# 0027 · 模型凭据随 workspace connection 保存
+
+- 状态：accepted
+- 日期：2026-08-07
+- 勘误：[0026](0026-runtime-models-use-generation-leases.md) 中“凭据继续由全局 CredentialStore 保存”的部分
+- 关联条款：RUN-009～RUN-012、ONB-001、WSP-001、BAK-001
+
+## 背景
+
+0026 已把 Provider connection、model 和 role 迁入 workspace 的
+`model-registry.sqlite3`，但 credential id 仍指向全局 `~/.akashic/auth.json`。
+这样一个可运行模型要同时恢复 workspace 数据库和 HOME 下的第二个 owner，首次设置事务也要跨
+SQLite 与 JSON 两个提交边界。用户确认当前是单人本地 Companion，接受用文件权限保护明文
+secret，希望先采用最小结构，不引入 keyring、加密层或 credential generation。
+
+## 决定
+
+1. Provider API Key、Codex access/refresh token 与账号路由字段直接作为 JSON payload 保存到对应
+   `model_connections` 行；`auth_kind` 标识 payload 类型。Base URL、Provider、模型与凭据由同一
+   workspace 数据库拥有。
+2. `model-registry.sqlite3`、可能出现的 WAL/SHM 和设置/迁移备份使用 `0600`。设置状态、日志、
+   API 响应和 Observe 不返回或复制 secret。
+3. API Key connection 与模型候选在一个 SQLite 事务提交。Codex 登录可以先建立没有模型的
+   connection，登录成功后原位写 token；选择模型后复用同一 connection。
+4. Codex token refresh 原位更新 credential payload，不增加模型 revision。Provider、Base URL、
+   模型、角色或显式 API Key 设置变化仍通过模型设置事务增加 revision，下一 execution generation
+   生效。
+5. 未发布的 `20260807_01_model_registry_database` 直接完成一次迁移：从 inline key 或旧 JSON
+   credential 复制被模型引用的凭据，验证数据库和新配置后才允许 Yoyo 落账。旧 JSON 不自动删除，
+   因为它可能仍被其他 workspace 或非模型配置引用；迁移后本 workspace 的模型运行不再读取它。
+6. 不新增加密、系统 keyring、credential 独立表、credential generation 或自动删除。删除来源与
+   secret 仍需以后名称明确的独立操作。
+
+```text
+┌──────────────────── workspace ────────────────────┐
+│ model-registry.sqlite3                            │
+│ connection(provider · base_url · auth_payload)   │
+│        └── model definitions ── role bindings    │
+└───────────────────────┬───────────────────────────┘
+                        ▼ execution start
+               immutable model generation
+```
+
+## 理由
+
+connection 本来就是 API Key 或登录订阅的产品身份。把 secret 留在同一行，使 onboarding 保存、
+workspace 恢复和运行时读取都只有一个权威 owner；现有 `CredentialStore` 调用形状可以保留为窄
+访问接口，不需要再造 secret 服务。`0600` 符合当前单人本地部署边界，也明确保留未来需要更强
+保护时的升级空间。
+
+## 影响与回滚
+
+- workspace 备份包含模型 secret，必须按 secret 处理，不能上传到普通诊断或提交到 Git。
+- 旧 `auth.json` 保留为迁移前恢复证据和非模型兼容状态，不再是已迁移模型的运行时 fallback。
+- 迁移或设置失败时用 SQLite backup API 恢复数据库 preimage，并恢复 `config.toml`；失败不得写
+  Yoyo 成功回执或部分发布模型 revision。
+- 源码回滚到 0026 实现时，可从迁移 operation backup 恢复旧配置与 JSON credential；不能只回退
+  SQLite schema 后继续启动。
+
+## 验收
+
+- 全新 onboarding 后只备份 workspace 模型数据库即可恢复已配置 Provider connection 和模型 secret。
+- API Key、Codex refresh token 不出现在设置 state、日志、Observe 或 `config.toml`。
+- 数据库、WAL/SHM 和备份均为 `0600`；权限过宽时 credential 读取 fail-loud。
+- 迁移首次执行、失败、修复后重试和重复启动保持幂等，失败前后的 config、数据库与旧 JSON 字节可核对。
+- Codex token refresh 与 API Key 模型请求都从 workspace 数据库读取，且现有 execution lease 语义不变。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -31,6 +31,8 @@
 | [0023](0023-akashic-tokens-own-material-3-semantics.md) | accepted | Akashic Token 拥有 Material 3 设计语义 | WEBUI-001～WEBUI-007 |
 | [0024](0024-plugin-self-validation-uses-stable-and-latest.md) | accepted | 插件自验证使用 stable/latest 与 session 级并发 | RUN-007、OUT-004、PLG-013、CTRL-003、TST-001～TST-006 |
 | [0025](0025-codex-style-same-turn-input.md) | accepted | 中断后的新 Attempt 续接同一 Logical Interaction | SES-007～SES-008、MEM-010～MEM-011、RUN-008、OUT-005 |
+| [0026](0026-runtime-models-use-generation-leases.md) | accepted | 运行时模型切换使用 execution generation lease | RUN-009～RUN-012、ONB-001、CTX-001、PLG-003 |
+| [0027](0027-model-credentials-live-with-workspace-connections.md) | accepted | 模型凭据随 workspace connection 保存 | RUN-009～RUN-012、ONB-001、WSP-001、BAK-001 |
 
 ## 新增规则
 

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -41,7 +41,7 @@ Akashic <workspace>
 
 切 Git 分支、删除代码 worktree 或做代码 refactor，不应改变 Akashic workspace。反过来，迁移或恢复 workspace 也不等于迁移源码和 Git 历史。后文出现裸词 `workspace` 时，都指这个运行数据根。
 
-workspace 仍不是完整运行环境的全部。显式主配置、全局凭据、全局插件安装清单、插件代码缓存和外部插件 canonical source 可以位于它之外；这些对象要通过 companion manifest 单独列出，不能靠猜测 HOME 路径补齐。
+workspace 仍不是完整运行环境的全部。模型 Provider credential 已随 connection 进入 workspace；显式主配置、旧或非模型全局凭据、全局插件安装清单、插件代码缓存和外部插件 canonical source 仍可以位于它之外。这些对象要通过 companion manifest 单独列出，不能靠猜测 HOME 路径补齐。
 
 ## 3. 用“增、改、减”阅读持久状态
 
@@ -93,6 +93,8 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 | `plugin-data/` | 已激活插件在自己的 opaque 目录增加数据 | 由插件 schema 和 owner 决定 | 普通卸载只删除代码和能力投影，保留数据；永久删除必须使用名称不同的用户操作、影响预览、备份和再次确认 |
 | `runtime/plugin-reloads.sqlite3` | 每次热重载增加 transaction 与阶段事件 | 同一 transaction 按状态机更新当前 phase、snapshot identity 和错误 | 当前没有自动 retention；恢复和事故审计仍依赖的记录不得自动删除 |
 | `migrations.sqlite3` | Yoyo 在 migration step 成功后记录唯一 migration ID | 已应用回执保持不变；新增迁移只追加新的成功回执 | runtime 没有删除或回滚回执权限；只随用户明确删除整个 workspace 而减少，恢复依赖 workspace 备份与 SQLite 完整性检查 |
+| `model-registry.sqlite3` | onboarding 或设置事务增加含 credential payload 的 connection、model 和 role binding，并增加单调 revision | connection 的 key/token、Base URL、模型字段和角色绑定可原位更新；Codex token refresh 不增加模型 revision，其余成功模型事务增加 revision，旧 execution generation 只在 lease 归零后失效 | 只有独立模型/来源删除操作可以减少；被 role 或 session 引用时必须拒绝，普通模型切换不得 cascade；数据库、WAL/SHM 与备份均按 secret 使用 `0600` |
+| `sessions.metadata.model_selection` | 会话首次固定 model ref/effort 时增加版本化对象 | 用户切换 model/effort 时仅更新该对象；旧字符串 override 在下一次显式选择时升级 | 用户选择“跟随默认”时只移除该 metadata 键；不得改写或减少 messages |
 | 插件贡献的 Skill/Drift skill | 插件 source 持有 skill 正文；安装把版本化副本发布到 cache，generation 从 `skill_roots` 建 catalog | workspace `skills/` 和 `drift/skills/` 软链接随 active generation 重建 | 禁用/卸载插件可以移除已安装副本、catalog 和软链接；外部 canonical source 不归 workspace 或卸载流程所有 |
 | 插件贡献的 MCP | 插件安装读取 `mcp_servers()` 并准备 runtime，generation readiness 通过后发布 MCP catalog | 插件升级或热重载按 generation 原子替换，旧代随 lease 排空 | 禁用/卸载插件移除 MCP catalog 和 runtime；plugin-data 不级联删除 |
 | `mcp/servers/*.toml` 与手工 skill 目录 | 当前代码仍允许绕过插件直接声明或放置能力 | watcher/loader 可以热加载这些兼容内容 | 目标架构不再扩展这条路径；应迁移成插件并删除第二套 owner，迁移完成前不得把兼容目录写成 canonical 产品资产 |
@@ -104,8 +106,8 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 
 | 对象 | 正常增加 | 允许的原位或逻辑变化 | 允许物理减少的条件 |
 |---|---|---|---|
-| 显式 `config.toml` | 用户增加 channel、model、plugin 和 runtime 配置 | 由配置管理动作修改当前值；它可能位于源码目录或任意 `--config` 路径 | 只能由明确配置管理动作删除；workspace 迁移不能假设它一定随目录存在 |
-| `~/.akashic/auth.json` | `CredentialStore.put/put_many` 增加 credential ID | token refresh 或重新登录原子替换同一 credential，并保留 `before-write` 备份 | 当前 store 没有通用删除 API；不能因 workspace、插件或模型配置变化自动删凭据 |
+| 显式 `config.toml` | 用户增加 channel、plugin、memory 和进程配置；模型迁移后只保留 workspace registry 标记 | 由配置管理动作修改静态当前值；它可能位于源码目录或任意 `--config` 路径 | 只能由明确配置管理动作删除；workspace 迁移不能假设它一定随目录存在 |
+| `~/.akashic/auth.json` | 旧安装、非模型配置或其他 workspace 可以增加 credential ID；0026 后本 workspace 的模型不再以它为 owner | 兼容 owner 可以继续更新自己的 credential；模型 Yoyo 只复制被当前 workspace 引用的值，不原位修改旧文件 | 当前 store 没有通用删除 API；模型迁移不得因当前 workspace 已复制就删除可能被其他消费者引用的 credential |
 | `~/.akashic-plugin/manifest.toml` | 安装时增加 plugin/package identity；运行时加载该插件后取得 Skill/MCP 声明 | enable/disable 更新 entry | 明确卸载时移除对应 entry；这只减少安装清单和能力，不删除 workspace 内 plugin-data |
 | `~/.akashic-plugin/cache/` | 插件安装在 staging 校验后发布插件代码、Skill 和 MCP runtime | 更新版本时原子替换并可回滚当前安装事务 | 明确卸载可以删除代码与能力 cache；它不是外部 canonical source，也不授权删除 plugin-data |
 | 外部插件 canonical source | 用户在独立源码仓库创建和提交 | 通过该仓库自己的 Git 工作流演进 | 只受该源码仓库的用户操作管理；Akashic workspace 备份、插件卸载和 cache 清理都不拥有它 |
@@ -165,12 +167,12 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 workspace 之外还有两组明确的全局状态：
 
 ```text
-~/.akashic/auth.json              凭据
+~/.akashic/auth.json              旧模型迁移输入与非模型兼容凭据
 ~/.akashic-plugin/manifest.toml   已安装/启用插件目录
 ~/.akashic-plugin/cache/          已安装插件代码缓存
 ```
 
-因此，“整个 workspace 已备份”目前不能推出“系统已完整备份”。显式 `config.toml`、全局凭据、全局插件清单和插件 canonical source 仍在 workspace 之外。
+因此，“整个 workspace 已备份”可以覆盖已迁移模型及其凭据，但仍不能推出“系统已完整备份”。显式 `config.toml`、旧或非模型全局凭据、全局插件清单和插件 canonical source 仍在 workspace 之外。
 
 ## 5. 状态根与选择规则
 
@@ -181,11 +183,11 @@ workspace 之外还有两组明确的全局状态：
 | `config.toml:[runtime].workspace` | CLI 和环境变量都为空时使用 | `main.py`、`agent.config` | 默认 workspace 选择 |
 | 显式 `--config` | 可把主配置放在任意路径 | `main.py`、setup | 运行配置根，不保证位于 workspace |
 | `AKASHIC_PLUGIN_HOME` | 未设置时回退 `~/.akashic-plugin` | `agent.plugins.manifest` | 全局插件安装根 |
-| `~/.akashic/auth.json` | `CredentialStore` 默认固定使用 | `agent.model_runtime.auth` | 全局凭据库 |
+| `~/.akashic/auth.json` | 旧配置或显式 JSON store 使用；已迁移模型不再回退读取 | `agent.model_runtime.auth` 兼容边界 | 迁移输入、恢复证据与非模型兼容凭据 |
 
-**F-001：** runtime 的大部分可写状态已经从显式 workspace 派生。全局凭据和插件安装状态是有意保留的例外，而不是 workspace 内的隐式目录。
+**F-001：** runtime 的大部分可写状态已经从显式 workspace 派生。模型 credential 属于 workspace connection；旧或非模型全局凭据与插件安装状态是有意保留的例外，而不是 workspace 内的隐式目录。
 
-**G-001：** 当前没有一个单独 manifest 同时声明主配置、workspace、全局凭据、插件清单和外部 plugin source 的完整恢复集合。
+**G-001：** 当前没有一个单独 manifest 同时声明主配置、workspace、旧或非模型全局凭据、插件清单和外部 plugin source 的完整恢复集合。
 
 ## 6. Workspace 当前文件结构
 
@@ -452,8 +454,10 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 
 ### 11.1 主配置和凭据
 
-- `config.toml` 通常位于仓库根并被 `.gitignore` 排除，也可通过 `--config` 指向其他位置。它包含 runtime、channel、memory、proactive 和模型设置，可能直接含 secret 或引用 auth ID。
-- `~/.akashic/auth.json` 由 `CredentialStore` 以 0600 权限、跨进程锁、fsync 和原子替换维护；覆盖前刷新 `auth.json.before-write.bak`。
+- `config.toml` 通常位于仓库根并被 `.gitignore` 排除，也可通过 `--config` 指向其他位置。模型迁移后它保存 runtime、channel、memory、proactive 等静态设置；动态 connection/model/role 由 workspace `model-registry.sqlite3` 保存。
+- `model-registry.sqlite3` 保存 Provider connection 的 Base URL 与 credential payload、模型能力快照、角色绑定和 revision。它及其备份属于 secret；普通模型选择只改该库，不改 `config.toml`；每个完整执行在入口读取 revision 并冻结整组角色。
+- `sessions.db/sessions.metadata.model_selection` 保存单个会话固定的 model ref 与 reasoning effort；它跨重启保留但不复制 Provider 凭据或能力，实际执行仍从开始时取得的 registry generation 解析。
+- `~/.akashic/auth.json` 继续由 JSON 兼容 owner 以 0600 权限维护。模型 Yoyo 从中复制当前 workspace 引用的 credential，但不删除旧值；迁移后模型设置、Codex refresh 和 runtime 请求只读写 workspace 模型库。
 
 两者都是恢复运行所需配置，但不能直接提交到 Git 或写入普通诊断文档。
 
@@ -504,7 +508,7 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 3. 当前快照 manifest 不记录 workspace 选择、应用 commit、schema/插件版本、主配置位置或全局状态位置。
 4. 没有一条仓库内工作流证明同一份快照能在隔离 workspace 恢复并通过应用级只读 smoke。
 5. SQLite 分别 backup 时，每个文件内部一致，但多个数据库与普通文件之间没有全局事务时点。
-6. 备份范围没有明确包含或排除 `.app-server-token`、diagnostic traces、全局凭据和全局插件 manifest。
+6. 备份范围没有明确包含或排除 `.app-server-token`、diagnostic traces、旧或非模型全局凭据和全局插件 manifest。
 7. `mcp/servers/*.toml` 与 workspace 手工 skill 目录仍绕过插件安装系统，形成第二套能力 owner；现存内容尚未迁移。
 8. 通用 rolling backup 尚不能把 WebUI publication DB 与它引用的 blobs 作为同一一致性 source；首版 publisher 必须至少导出可审阅 reachable manifest，并在发布正式资源前完成隔离恢复 smoke。
 
@@ -516,7 +520,7 @@ INT-001～INT-008 和 INT-011 已由花月哥哥确认，其中长期语义已�
 
 ### INT-001 Workspace 是主要运行工作区 — 已确认
 
-确认内容：显式 workspace 保存 Akashic 的主要运行文件，是会话、记忆、附件、调度、自主流程和 plugin-data 的主要备份/迁移单元。主配置、全局凭据、插件 manifest/cache 和外部 plugin source 是明确的 companion state。
+确认内容：显式 workspace 保存 Akashic 的主要运行文件，是会话、记忆、附件、调度、自主流程、模型 connection/credential 和 plugin-data 的主要备份/迁移单元。主配置、旧或非模型全局凭据、插件 manifest/cache 和外部 plugin source 是明确的 companion state。
 
 已提升条款：WSP-001、WSP-004。迁移工具以 workspace 为主体，同时生成 global companion manifest，不再散落猜路径。
 

--- a/docs/design/runtime-model-registry-and-onboarding.md
+++ b/docs/design/runtime-model-registry-and-onboarding.md
@@ -1,0 +1,213 @@
+# 运行时模型注册表与 Onboarding
+
+- 状态：implemented and verified；0026、0027、思考强度二级菜单与真实 Provider GUI 链路已对账
+- 日期：2026-08-06
+- 决策：[0026](../decisions/0026-runtime-models-use-generation-leases.md)、[0027](../decisions/0027-model-credentials-live-with-workspace-connections.md)
+- 需求：RUN-009～RUN-012、ONB-001、CTX-001
+
+## 1. 目标与当前差距
+
+用户可以配置多个 Provider connection，在每个 connection 下启用一个或多个模型，把模型绑定到 `default`、`fast`、`agent` 和 `vision`，并在 Gateway 运行期间修改。数据库始终保存最新 revision；已经开始的执行保持旧快照，下一执行读取新 revision。首次设置只要求登录 Codex、登录 OpenCode，或填写 Base URL、API Key 和 Model Name。
+
+实施前 `bootstrap/providers.py` 在启动时一次性构造 provider，`bootstrap/tools.py` 随后把实例注入所有消费者。`bootstrap/settings_api.py` 写配置后调用 Supervisor restart bridge；Supervisor 向 Gateway 发送 `SIGUSR2`，`main.py` 排空全局 Turn 后退出。因此原实现没有运行时模型 owner。
+
+## 2. 目标结构
+
+```text
+浏览器只访问 http://127.0.0.1:2236
+               │
+               ▼
+┌─────────────────────────────────────┐
+│ Supervisor Web Shell                │
+│ / Chat · /settings 模型配置         │
+│ 无配置/Gateway 重载或退出时仍存活   │
+└──────────────┬──────────────────────┘
+               │ workspace Unix socket
+               ▼
+┌────────────────────────────┐
+│ workspace model registry DB│
+│ connection/model/role/rev  │
+└──────────────┬─────────────┘
+               │ each execution start
+               ▼
+┌────────────────────────────┐
+│ Gateway ModelRegistry      │
+│ immutable leased generation│
+└────────┬───────────┬───────┘
+         │ lease      │ role proxy
+         ▼            ▼
+┌────────────────┐  ┌────────────────────┐
+│ExecutionBinding│  │default/fast/agent/ │
+│generation +    │  │vision provider view│
+│session override│  └────────────────────┘
+└───────┬────────┘
+        ▼
+ Turn / Proactive / Schedule / Plugin / Memory
+```
+
+`ModelRegistry` 是 generation、角色和 runtime lookup 的 Core owner。`RoleBoundProvider` 保持现有 `LLMProvider` 调用形状：属性读取和 `chat()` 都委托给当前 execution binding 中对应 runtime。没有 execution scope 的单次内部调用在调用开始时租用 current，并在返回后释放。
+
+## 3. 执行与模型解析
+
+执行开始时先读取模型库 revision，再创建不可变 `ExecutionBinding`：
+
+- `generation_id` 与配置摘要；
+- generation 内全部 role → runtime 映射；
+- 会话可选的显式 model ref 与 reasoning effort；
+- 每个 runtime 的 provider、model、credential 引用和能力快照。
+
+对话选择解析优先级为：本次 inbound 显式 model ref/effort、session metadata、generation 的 default。显式选择只替换 default/agent 主推理，不把 fast、vision 等内部角色偷偷改成同一模型；effort 也只覆盖这个显式模型。Plugin job、proactive tick 和 memory run 不读取某个 Web session 的选择，按自身角色解析。
+
+Turn、job 或 tick 内的所有 retry、工具 batch、summary 和 fallback 都继承 context-local binding。passive ReAct、proactive ReAct、schedule SOFT、Memory Optimizer、consolidation、plugin job 和 post-response memory job 都在各自入口建立 scope。没有外层 scope 的单次 LLM 调用在调用前读取最新 revision。数据库新 revision 只改变后续 scope；旧代进入 retiring，最后一个 lease 释放后移出 registry 引用并由 Python 回收。
+
+## 4. 设置提交和进程边界
+
+Supervisor 在启动任何 Gateway 之前先取得 `2236`，并在整个进程生命周期内持有该监听。它直接提供统一 Dashboard 静态壳层、Chat/设置静态页面与 settings transaction；Gateway 的 Chat/Dashboard API 只绑定 workspace 内的 owner-scoped Unix socket，由 Web Shell 同源转发。系统不再监听 `6321` 或 `6322`。
+
+无配置时 `/` 仍直接渲染统一 Dashboard 壳层并默认选中内嵌 Chat，地址栏不跳转。Chat 在读取 Web Shell readiness 后不连接 Gateway WebSocket，不读取会话，也不制造“连接失败”；空状态显示“连接模型”，发送区禁用。`/settings` 使用同一前端构建和同源设置 API。首次合法保存会在候选 `Config.load` 后初始化 VEDA、SessionDB 等缺失的 workspace 基线，再由 Supervisor 启动 Gateway；运行中修改模型不重复执行首次初始化。readiness 成功后原页面重新探测并解锁聊天。Gateway ready 后：
+
+1. 设置服务读取模型库 revision 并拒绝陈旧写入。
+2. 使用临时候选凭据执行真实 model probe。
+3. 创建 operation backup，用一个 SQLite 事务提交含 credential payload 的 connection、model、role 和新 revision；数据库与备份均按 secret 使用 `0600`。
+4. 新执行开始时读取新 revision、构造完整 candidate generation 并原子 publish。
+5. candidate 构建失败时保留 current，并让本次执行明确失败；修复后的下一执行再次读取数据库。
+6. 首次 onboarding 保存后，设置服务仍通知 Supervisor 启动第一代 Gateway；普通 role binding 修改不触发进程重启。
+
+`SIGUSR2` 和 restart commit 协议继续只用于正式 Gateway 换代。模型设置不得调用 quiesce、退出码或 Guardian cleanup。
+
+并发设置由设置 owner 串行，并使用 expected revision 拒绝 stale writer。调用方在响应丢失时重新读取 state；revision 已增加表示提交已经持久化，不能盲目重复写入凭据。
+
+## 5. 模型能力注册表
+
+固定 `litellm==1.95.0` 只作为本地能力 registry，不接管请求 transport、重试、fallback 或错误类型。设置进程从 wheel 内置 `model_cost` 读取 max input、output、vision/modalities、reasoning effort、tool call 和 parallel tool call；内部总上下文由 max input 与 max output 相加，避免把输入上限误当总预算。`LITELLM_LOCAL_MODEL_COST_MAP=True` 禁止运行时联网刷新。版本更新必须作为依赖变更评审，避免上游变化静默进入运行配置。
+
+LiteLLM 曾发生 `1.82.7`、`1.82.8` PyPI 供应链事故，因此这两个版本明确禁止。当前依赖精确固定到带 GitHub tag 的 `1.95.0`；升级 Gate 必须同时核对 release tag、wheel 版本、registry contract tests 和依赖安全报告，不能改成范围版本。
+
+字段级来源优先级：
+
+1. 用户打开高级设置后显式覆盖；
+2. Codex/OpenCode 或目标 provider 的权威目录；
+3. 固定版本 LiteLLM 本地注册表；
+4. unknown。
+
+通用 Base URL 先由 `genai-prices` 的 provider API 正则识别，随后用 LiteLLM 的 provider/model key 解析能力。无法确定 provider/model 时保持 unknown。Unknown runtime 的 `context_window=0`、`max_output_tokens=0`、文本输入基线只代表当前请求形状，不声明模型没有其他能力；UI 显示“能力未知”，Core 关闭主动压缩和硬预算，让 provider 错误保持原义。任意自建网关可隐藏或改名上游模型，不能仅凭 Base URL 保证识别；这种情况不得猜测。
+
+Custom API 的 transport provider 继续是 `openai` 兼容协议，注册表另存 `catalog_provider_id`。已知 Base URL 可把它解析成 `deepseek`、`openrouter` 等 usage/catalog 身份，但不得借此更换 wire transport 或重试策略。
+
+## 6. Usage 归一化
+
+Chat Completions 与 Responses transport 把完整 response payload 交给统一 extractor。固定 `genai-prices==0.0.71` 根据 provider id/API URL 和 `chat`/`responses` flavor 提取 input、cache read、cache write 和 output。Reasoning output 使用响应中的明确 provider detail 窄映射补齐。
+
+`ModelUsage` 增加 `cache_write_input_tokens`，并保留 request/covered request/coverage。聚合规则只对已知字段求和；任一请求未覆盖时总 coverage 至少为 partial。插件 `generate()` 返回正文与 usage 的结构化结果；`generate_text()` 作为兼容便捷方法调用它，不再丢弃 usage。旧 `cache_prompt_tokens/cache_hit_tokens` 只能由 normalized usage 派生，逐步移除私有 tool-call 字段。
+
+Extractor 找不到 provider、flavor 或字段时只捕获明确的 `LookupError`、`TypeError` 或 `ValueError`，记录 normalizer unavailable，再使用已声明的本地窄映射；仍无数据则返回 unavailable。解析失败不应让已经成功的模型回复变成失败，也不得生成假零。
+
+## 7. Onboarding 与 Chat UI
+
+设置页按具名 Provider connection 展示多套账号或 API Key，并提供 Codex、OpenCode、DeepSeek、OpenRouter 模板。API 连接先填写连接名称、Provider ID、Base URL 和 API Key，再通过 provider `/models`、Codex/OpenCode 权威目录发现 model；目录不可用时才手工填写 Model Name。模型识别后展示 effort 等能力，unknown 字段保持未知。
+
+Chat composer 上方只保留一个等宽向上展开胶囊，显示“model：来源”并按 Provider connection 分组滚动。模型列表底部固定一行“思考强度”；点击后在同一宽度和高度内切换到当前模型支持的 effort 二级列表，返回按钮恢复模型列表。选择模型或 effort 时面板保持展开，点击外部或 Escape 收起；不兼容的旧 effort 按“模型默认 → medium → 第一项”选择可用值。切换在发送下一条消息时随 inbound frame 提交；服务端校验后更新 `sessions.metadata.model_selection = {schema_version, model_ref, reasoning_effort}`。当前 active Turn 不受影响。重新打开 session 时从服务端读取选择；选择“跟随默认”删除该对象。旧 `model_runtime_override` 字符串继续只读兼容，并在下一次显式选择时转成新结构。
+
+Web 导航与路由固定为：
+
+```text
+2236 /（统一 Dashboard 壳层，默认选中 Chat，地址不跳转）
+├── /chat?embedded=1                 壳层内 Chat
+├── /chat?embedded=1&surface=runtime 壳层内知识与运行
+├── /settings?embedded=1             壳层内模型与认证
+└── /dashboard                       旧链接兼容，同样返回统一壳层
+```
+
+页面之间只使用同源路径。前端不拼接端口，不使用 iframe 端口探测；设置成功回到根路径 `/` 即可在统一壳层中对话。
+
+### 7.1 多凭据与来源身份
+
+Memoh 的可复用部分是 owner 模型，不是整页复制：一套登录或 API Key 对应一个具名 Provider 实例，模型以 `provider_id + model_id` 唯一。它的数据层允许相同 `client_type` 的多个实例，只要求实例名称不同；现有预设画廊会隐藏已经配置过的模板，因此“重复添加同一预设”在 UI 上仍不够直接。Akashic 采用前者并补齐入口：同一 Provider 可以继续添加主账号、备用账号或不同网关，不把多个 secret 塞进同一 runtime。
+
+设置 API 需要从当前“按 Provider 类型派生固定 runtime ID”升级成具名 runtime 的 create/update 操作。每项至少持有稳定 `runtime_id`、用户可读 `source_name`、transport/provider、credential 引用、Base URL、model name、默认 reasoning effort 与能力快照。列表和 Chat 都以 `model name：source name` 显示，身份和提交仍使用稳定 runtime ID，不能用显示文字做主键。
+
+API Key 是 write-only：读取状态只返回掩码和凭据状态，空值保存表示保留原 secret；替换 key 必须显式输入新值。Codex 和 OpenCode 使用同一来源实例外壳，但表单切换成登录动作，不伪装成 API Key 字段。新增来源成功后显示非阻塞 Toast；表单用带 backdrop blur 的模态层或侧栏，Portal 到 `document.body`，支持 Escape、焦点圈定和焦点恢复。
+
+### 7.2 五个等权交互候选
+
+这五版只用于选择交互方向，当前无推荐顺序：
+
+| 编号 | Chat 选模 | 设置页 | 主要取舍 |
+|---|---|---|---|
+| 01 悬浮坞 | 输入框上方胶囊，向上展开带搜索列表 | 来源卡片 + 居中表单 | 模型上下文最完整，占用纵向空间较多 |
+| 02 双段胶囊 | 模型与 reasoning effort 分段显示 | 行式清单 + 右侧表单 | 强度更直达，胶囊信息密度较高 |
+| 03 卡片叠层 | 候选按卡片逐层展开 | 来源索引 + 主从详情 | 来源关系明显，大量模型时需搜索辅助 |
+| 04 指令面板 | 搜索优先的 command menu | 可搜索清单 + 紧凑表单 | 键盘效率高，对首次用户提示要求更高 |
+| 05 等宽上展胶囊（用户选择） | 输入框上方唯一胶囊，固定下沿和左右边界，只增加高度向上展开；内部按供应商分组纵向滑动 | 单列来源 + 分步表单 | 只保留一个模型入口，来源与同名模型仍可区分 |
+
+独立预览入口为 `/chat?preview=model-experience`，只使用演示数据，不调用设置 API、不保存或发送凭据。五版都使用 brief spring 入场、选择反馈和 `prefers-reduced-motion`；高频切换不使用持续或循环动画。
+
+05 修订版删除 composer 内部的第二个模型胶囊。唯一胶囊固定在输入框上方：桌面高 44px、宽 320～420px；展开前后宽度完全一致，只把高度增加到约 420px，稳定显示 5～6 个模型行。移动端宽度与输入框一致，展开高度不超过约 `62vh`。展开层的下沿和左右边界保持同一锚点，滚动只发生在模型列表，使用 sticky Provider 标题和 overscroll containment；点击模型或 effort 后更新胶囊但保持展开，点击外部或 Escape 才关闭，当前 Turn 语义不变。
+
+Provider/模型 Logo 候选使用 MIT 的 `@lobehub/icons`，已覆盖 Codex、DeepSeek、OpenAI、OpenCode、OpenRouter 等。生产构建应固定 npm 版本并本地打包，不依赖 CDN；无法识别的来源回退到稳定首字母标识。Memoh 仓库与其内置图标整体是 AGPL-3.0，本任务不复制其 SVG。
+
+## 8. 持久状态
+
+| 对象 | 增加 | 原位更新 | 逻辑失效 | 物理减少 | 恢复证据 |
+|---|---|---|---|---|---|
+| model connection/model/role | 用户保存新来源或模型 | 修改来源、能力快照或角色绑定并增加 revision | 旧 revision 被新 revision supersede | 仅独立删除操作；外键和引用存在时拒绝 | operation backup + SQLite integrity check |
+| model connection credential | 新登录或新 API Key 随 connection 增加 | 同 auth id 原位刷新 token/key；Codex refresh 不增加模型 revision | 新 payload supersede 旧 payload | 只随以后独立来源删除；本任务不删除 | SQLite operation backup + auth probe + `0600` mode |
+| session model selection | 首次固定 model ref/effort | 切换 model 或 effort | 清除 selection 后跟随 default | 只删除 metadata 单键；消息不变 | sessions.db 完整消息快照 |
+| turn binding/usage | 新 Turn 提交时追加 | terminal metadata 按既有协议更新 | 后续 Turn 使用新代 | 不自动删除 | turn/message join + Observe DB |
+| messages | 新 Turn 原子 INSERT | 不允许 | 不适用 | 仅用户撤销/删除会话 | SQLite backup + full snapshot |
+| capability snapshot | 保存 runtime 时从固定 wheel 派生 | 用户换模型时更新 | 新 runtime generation supersede 旧快照 | 仅随独立 runtime 删除；本任务不自动删除 | config backup + dependency pin + registry test |
+| 首次 workspace 基线 | 首次合法模型配置后创建缺失的 VEDA、数据库与目录 | 本任务不覆盖既有基线 | 不适用 | 本任务不减少 | init summary + 文件/DB 完整性检查 |
+
+## 9. Edge cases
+
+- A 已开始、设置改成 B：A 的后续 tool loop 仍是 A，下一执行是 B。
+- 请求已进入队列但未取得 execution lease：开始时使用 B。
+- 同时修改 provider、key、model 和角色：作为一个 candidate generation 提交，不允许混合观察。
+- candidate probe 成功但 publish 前崩溃：模型库 revision 是真源；重启或下一执行重新读取，调用方通过 revision 确认结果。
+- candidate 构建失败：旧 current 继续服务，设置写入恢复 backup。
+- 新模型窗口更小：只重新计算临时 Prompt；历史消息不改写。
+- unknown/目录消失：已有显式覆盖继续；没有覆盖则保持 unknown，不沿用另一个模型的能力。
+- 流式响应没有 usage：正文成功，coverage unavailable。
+- 一次 Turn 多次请求且部分无 usage：request_count 全量，covered_request_count 只计已覆盖请求，总 coverage partial。
+- Session override 指向后来删除的 runtime：设置删除必须先拒绝仍被引用的 runtime；本任务不做 cascade。
+- 会话选择的 effort 不在模型支持集合：发送边界明确失败，不降级到默认 effort；fast/vision 等内部角色不继承会话 effort。
+- Codex token 刷新原位更新 workspace connection；OpenCode 本机登录只作为 onboarding 导入源。迁移后的模型请求只从 workspace 数据库读取，不把 token 内容写入 session、设置状态或 Observe。
+- 首次设置耗时超过启动脚本旧等待窗口：Supervisor 保持存活并明确输出设置 URL。
+- 无 `config.toml`：2236 返回 Chat 壳层和 `needs_setup`，不创建假 session、不连接不存在的 WebSocket。
+- config 已写但 Gateway 仍在启动：Chat 显示“正在启动”，保留设置入口并按有界间隔探测 readiness。
+- Gateway 换代或异常退出：2236 不掉线；现有页面显示“正在重新连接”，恢复后重新拉取 session/model state。
+- 遗留配置仍包含 `channels.chat.host/port`：加载可以兼容，但字段不再产生监听；新配置不再写入 6322。
+
+## 10. 实施与验证
+
+1. 引入 registry、execution scope、role proxy 和 generation reload 回执。
+2. 把 Turn、plugin job、proactive tick 和 memory run 接入 scope。
+3. 用固定 LiteLLM registry 加入能力解析和简化设置 API/UI。
+4. 加入 Chat runtime selector 与 session metadata。
+5. 用 `genai-prices` 统一 transport usage，并升级插件结果契约。
+6. 运行针对性单测、前端检查、静态检查和 Change Gate。
+7. 从 canonical Observe 仓库固定 revision 安装到一次性 plugin home，在一次性 workspace 产生真实 committed Turn；从 lifecycle event 核对 model binding，并从 Observe SQLite 核对稳定 message identity 和 usage。
+
+验证不得连接正式 workspace、正式插件 cache 或正式 2236。隔离容器只映射一个随机 host port 到容器内 2236，并断言容器内没有 6321/6322 listener。Observe 报告同时固定 Core tree、插件 requested ref/resolved commit、安装目录摘要、scenario profile 和报告摘要。
+
+### 10.1 隔离实测结果
+
+2026-08-07 使用随机端口 `22367`、一次性 workspace 和一次性 plugin home 验证；正式 workspace、正式插件 cache 和正式 `2236` 未写入。Observe 从 canonical 仓库固定到 commit `4d85b9dc64ef0d8d96c5a635586ca17dd94b59cd` 安装。
+
+- 一个已取得 generation 2 lease 的 ReAct 在两次 provider 请求之间把数据库 `agent` role 从 gate-a 更新为 gate-b；该 ReAct 的请求序列仍为 gate-a、gate-a，下一 ReAct 为 gate-b。
+- 第一 ReAct 的 terminal metadata 与 Observe SQLite 都记录 input 21、cache hit 7、output 5、request count 2；第二 ReAct记录 input 13、cache hit 6、output 4、request count 1，coverage 均为 exact。
+- 浏览器从所有来源中把会话固定到 gate-a 后实际发送成功；模型网关收到 gate-a。刷新 Chat、重新进入原会话后，服务端 `sessions.metadata.model_selection` 和胶囊都恢复 gate-a；新会话仍跟随当前 default gate-b。
+- 随机端口首次暴露 settings iframe 的 `frame-ancestors` 硬编码问题；CSP 已改为同源 `'self'`，保留 `5173` 本地开发壳层，随机端口 Dashboard 复验通过。
+- Change Gate 通过，报告目录为 `docker/debug/reports/change-gate/20260807-015529-0c00821a`。
+
+### 10.2 SQLite 凭据与真实 GUI 回归
+
+2026-08-07 另用全新容器、一次性 HOME/workspace 和随机 host 端口 `22368` 回归本轮 0027 与 UI；容器内仍只监听 `2236`，正式 workspace、正式插件 cache 和正式 `2236` 均未写入。API Key 取自维护者明确授权的源码配置，只经浏览器表单提交；Codex 复用现有登录凭据作为隔离测试夹具，模型发现、保存、选择和对话均从 GUI 完成。
+
+- 无 `config.toml` 时根路径直接显示统一 Chat 空状态和“连接模型”，不会先挂载未就绪的 Dashboard runtime iframe，也不再弹出 503 错误框。
+- GUI 保存一个 OpenCode Go connection 下的 `deepseek-v4-flash`、`deepseek-v4-pro`，以及 DeepSeek API 的 `deepseek-v4-flash`；容器没有 `opencode` CLI 时明确记录目录降级，并从固定 LiteLLM 本地注册表恢复三个模型支持的 `low/medium/high`，不猜测远端状态。
+- Codex GUI 目录发现 `gpt-5.6-luna` 及其 `low/medium/high/xhigh/max`，保存后 API state 只返回 `codexConfigured=true`，不返回 token。
+- 同一 Web session 依次从胶囊选择并完成四个真实 Turn：OpenCode Flash/high、OpenCode Pro/low、DeepSeek/medium、Codex Luna/high。胶囊 trigger 为 `412px`、展开层为 `418px`（3px shell inset），模型和 effort 选择后保持展开，Escape 收起并恢复焦点；重新打开该 session 后恢复 Luna/high。
+- SessionDB 四个 terminal Turn 均为 `coverage=exact`：input 分别为 `12452/12388/12814/11999`，cache hit 为 `4992/4992/4992/0`，output 为 `80/32/11/21`，reasoning output 为 `70/23/0/8`。DeepSeek 的独立 reasoning token 为 `0`，表示该响应没有返回可归一化的独立字段，不影响 `medium` effort 已随 inbound metadata 提交。
+- Observe 固定安装并晋升 commit `4d85b9dc64ef0d8d96c5a635586ca17dd94b59cd`；从该 stable snapshot 冷启动后记录同四个 session/turn，output、prompt 与 cache hit 和 SessionDB 完全一致。聚合为 `turn_count=4`、`tracked_turn_count=4`、`prompt_tokens=49653`、`hit_tokens=14976`。
+- `model-registry.sqlite3` 与 credential lock 均为 `0600`；三类 connection 的 secret 只在 SQLite JSON payload 中，隔离 `config.toml` 不含 API Key、token、Provider URL 或模型表。

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -211,7 +211,7 @@ candidate 在 10 秒健康提交前必须由 process-scope attempt lease 持有�
 
 ### WEBUI-007 Akashic Token 以 Material 3 系统角色表达产品语义
 
-6321 设置、桌面 Chat、共享 Mobile WebUI、Dashboard 和插件公开控件必须从同一个 Akashic Theme Catalog 读取颜色。Catalog 以 Material 3 的 primary、secondary、tertiary、error 与 tonal surface 角色表达通用界面语义，并由 Akashic 扩展 success、warning、trace 和 info 等领域角色；组件库的默认值、插件私有颜色和页面局部常量都不得成为第二主题真源。
+2236 的模型设置、桌面 Chat、共享 Mobile WebUI、Dashboard 和插件公开控件必须从同一个 Akashic Theme Catalog 读取颜色。Catalog 以 Material 3 的 primary、secondary、tertiary、error 与 tonal surface 角色表达通用界面语义，并由 Akashic 扩展 success、warning、trace 和 info 等领域角色；组件库的默认值、插件私有颜色和页面局部常量都不得成为第二主题真源。
 
 颜色必须表达动作、选择、状态或层级：primary 只突出当前主要动作，容器色表达选择和低强度强调，error、warning、success、trace 不能互相借色。布局优先使用留白和 tonal surface 建立层级，边框只表达结构或状态；卡片、胶囊和阴影不得作为所有内容的默认容器。引入 Material 组件不能改变 WEBUI-001～WEBUI-006 的源码、平台能力、状态 owner 与发布边界。
 
@@ -459,6 +459,34 @@ Linux 上无子命令执行 `python main.py` 是正式服务入口，必须先�
 
 ConversationRuntime 的 session lane owner 在 active attempt 上拒绝所有普通输入，只接受精确 `turn/interrupt`。Reasoner 最终回复前仍在同一 owner 下封口；中断和完成都必须提交唯一 terminal 状态。下一条普通输入只能在 terminal 后创建新 attempt，并由 durable predecessor 恢复同一未完成 logical interaction；不得存在运行中 drain user input 的隐式或显式入口。
 
+### RUN-009 每个执行单元冻结模型 generation
+
+Turn、proactive tick、schedule、plugin job、记忆优化和其他独立推理单元在真正开始执行时解析当前模型角色，并冻结同一份 provider、model、credential 与能力 generation。执行期间修改角色绑定或连接配置只服务后续执行；已经开始的执行及其工具循环、重试和上下文压缩继续使用旧 generation。排队但尚未开始的执行使用开始时最新 generation。旧 generation 只有在全部 execution lease 归零后才能释放。
+
+### RUN-010 默认模型和模型角色可在运行时修改
+
+`default`、`fast`、`agent` 和 `vision` 角色引用 named runtime。设置 owner 对候选连接和模型完成真实校验并原子持久化后，Gateway 原子发布新 generation，不停止 admission、不排空无关 turn，也不请求 Supervisor 重启。候选校验、配置提交或 generation 构建失败时继续服务旧 generation，并向设置调用方返回明确失败。
+
+角色绑定和 Provider/model 目录的权威当前值保存在 workspace 模型注册库，成功事务增加单调 revision。完整 passive ReAct、proactive ReAct、schedule SOFT、Memory Optimizer、consolidation、plugin job 和其他独立推理单元在入口读取最新 revision，并冻结整组角色直到执行结束；没有外层执行单元的单次调用在调用前读取最新 revision。普通模型设置不得通过改写 `config.toml` 或重启进程传播。
+
+Provider connection 的 Base URL、API Key、Codex access/refresh token 与账号路由字段由同一个 workspace 模型注册库拥有，数据库及其备份按 secret 使用 `0600`。设置状态、日志、Observe 和会话 metadata 只返回 credential 状态或引用，不得返回 secret。已迁移模型不得回退读取全局 HOME credential；旧 credential 文件只保留为迁移输入、恢复证据或非模型兼容状态。Codex token refresh 可以原位更新 credential payload，不改变当前模型 revision；来源、模型、角色和显式 key 设置变化仍按完整候选事务增加 revision。
+
+对话模型选择按“本次消息显式 model ref/effort → session selection → 当前 default”解析。Session selection 以版本化对象持久化后跨 Gateway 重启保留；清除后重新跟随动态 default。显式 effort 只属于显式选择的 default/agent 主推理，不传播给 fast、vision 等内部角色；不受支持的值明确失败。实际执行绑定写入 turn 诊断元数据，不得反向改写既有消息。旧字符串 override 只读兼容，并在下一次显式选择时升级。
+
+### RUN-011 模型能力来自带来源的注册表
+
+Codex、OpenCode 等 provider 权威目录优先提供模型能力；其余已知模型使用仓库固定版本的公共模型目录派生快照。显式高级覆盖只覆盖对应字段。每个能力字段保留来源，未知字段保持 unknown，不猜测多模态、上下文窗口或输出上限。上下文窗口 unknown 时关闭依赖确定窗口的主动压缩和本地硬预算，保留 provider 的明确错误；不得要求普通 onboarding 为已识别模型重复填写这些字段。
+
+### RUN-012 Provider usage 使用统一且带覆盖率的结果
+
+所有模型传输把 provider 响应映射为统一 usage：input、cache read、cache write、output、reasoning output、request count、covered request count 与 coverage。Provider 未返回、流式响应缺失或当前解析器不支持的字段保持 unknown，并标记 `partial` 或 `unavailable`；不得用零值伪装已统计。插件、主动流程、记忆和核心 Turn 消费同一结构化结果，兼容字段只能从该结果派生。
+
+### ONB-001 首次模型配置使用三个渐进入口
+
+首次启动只展示“登录 Codex”“登录或检测 OpenCode”“Base URL + API Key + Model Name”三个主要入口。已识别模型自动填充能力并隐藏高级覆盖；无法识别能力仍允许保存连接，但必须明确显示哪些能力 unknown。没有配置时 Supervisor 仍须在 `2236` 提供统一 Dashboard 壳层：访问根路径 `/` 时地址不跳转，壳层默认选中 Chat，发送区明确显示尚未连接模型并能原地进入模型设置。保存合法配置后同一入口恢复聊天，不要求用户改 URL、端口或重启浏览器。
+
+`2236` 是唯一 Web 监听和唯一用户可见入口。模型设置、Chat、知识与运行及 Dashboard 使用同源路径；不得再启动 `6321`、`6322`，也不得依据浏览器端口判断页面类型。Gateway 未启动、正在换代或异常退出时，Supervisor 拥有的 `2236` 壳层继续存活并显示真实状态；启动脚本不得因 Gateway 尚未 ready 而杀死仍在 onboarding 的 Supervisor。
+
 ### OUT-001 被动按 Turn 提交，主动按送达提交
 
 被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，本 turn 的全部有序 user message 与唯一 terminal assistant 共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
@@ -545,7 +573,7 @@ latest 默认只允许只读行为验证。共享 plugin-data 写入、不可撤
 
 ### WSP-001 Workspace 可写状态显式归属
 
-会话、记忆、附件、plugin-data、socket、运行日志和运行密钥都从显式 workspace 派生。全局插件缓存和 credential store 必须列入明确 global state 清单；运行时不得隐式回退 HOME。
+会话、记忆、附件、plugin-data、socket、运行日志、运行密钥和模型 connection credential 都从显式 workspace 派生。全局插件缓存、旧或非模型 credential store 必须列入明确 global state 清单；已迁移模型运行时不得隐式回退 HOME。
 
 ### WSP-002 数据路径不能通过片段或符号链接逃逸
 
@@ -557,7 +585,7 @@ plugin、marketplace、snapshot 等名称必须是安全单片段；resolved pat
 
 ### WSP-004 Workspace 是 Akashic 运行数据根
 
-`<workspace>` 表示由 `--workspace`、`AKASHIC_WORKSPACE` 或主配置选中的 Akashic 运行实例主要工作区。它承载会话、长期记忆、附件、调度、主动流程、plugin-data、能力投影、诊断和运行控制状态，不是源码仓库、Git checkout 或 Git worktree。插件代码、Skill/MCP 的 canonical source、全局插件清单和凭据可以位于 workspace 之外，必须作为明确 companion state 管理。Git worktree 只承载代码、测试和项目工作手册；任何代码 worktree 都不得把自己的目录当成正式运行数据根。
+`<workspace>` 表示由 `--workspace`、`AKASHIC_WORKSPACE` 或主配置选中的 Akashic 运行实例主要工作区。它承载会话、长期记忆、附件、调度、主动流程、模型 connection credential、plugin-data、能力投影、诊断和运行控制状态，不是源码仓库、Git checkout 或 Git worktree。插件代码、Skill/MCP 的 canonical source、全局插件清单以及旧或非模型凭据可以位于 workspace 之外，必须作为明确 companion state 管理。Git worktree 只承载代码、测试和项目工作手册；任何代码 worktree 都不得把自己的目录当成正式运行数据根。
 
 ### MIG-001 兼容迁移由 workspace Yoyo 账本一次性推进
 

--- a/frontend/chat/src/main.tsx
+++ b/frontend/chat/src/main.tsx
@@ -164,6 +164,9 @@ const LazyTraceMotionShowcase = lazy(() =>
 const LazyDrawerIslandShowcase = lazy(() =>
   import("./drawer-island-showcase").then(({ DrawerIslandShowcase }) => ({ default: DrawerIslandShowcase })),
 );
+const LazyModelExperienceShowcase = lazy(() =>
+  import("./model-experience-showcase").then(({ ModelExperienceShowcase }) => ({ default: ModelExperienceShowcase })),
+);
 const LazySettingsApp = lazy(() =>
   import("./settings-app").then(({ SettingsApp }) => ({ default: SettingsApp })),
 );
@@ -1489,6 +1492,7 @@ const isMobileShowcase = preview === "mobile";
 const isSharedChatShowcase = preview === "chat";
 const isTraceMotionShowcase = preview === "trace-motion";
 const isDrawerIslandShowcase = preview === "drawer-islands";
+const isModelExperienceShowcase = preview === "model-experience";
 const rootApp = window.location.pathname === "/settings" || window.location.pathname.startsWith("/settings/")
   ? <LazySettingsApp />
   : isMobileShowcase
@@ -1499,6 +1503,8 @@ const rootApp = window.location.pathname === "/settings" || window.location.path
         ? <LazyTraceMotionShowcase />
       : isDrawerIslandShowcase
         ? <LazyDrawerIslandShowcase />
+      : isModelExperienceShowcase
+        ? <LazyModelExperienceShowcase />
     : <App />;
 
 createRoot(document.getElementById("root")!).render(

--- a/frontend/chat/src/model-experience-showcase.css
+++ b/frontend/chat/src/model-experience-showcase.css
@@ -1,0 +1,2257 @@
+.model-experience-showcase {
+  --mx-primary: oklch(0.53 0.17 257);
+  --mx-primary-soft: oklch(0.93 0.04 257);
+  --mx-ink: oklch(0.25 0.025 260);
+  --mx-muted: oklch(0.52 0.025 260);
+  --mx-canvas: oklch(0.975 0.008 258);
+  --mx-surface: oklch(0.995 0.003 258);
+  --mx-surface-low: oklch(0.955 0.012 258);
+  --mx-border: oklch(0.87 0.018 258);
+  min-height: 100%;
+  overflow: auto;
+  padding: 34px clamp(18px, 4vw, 58px) 50px;
+  color: var(--mx-ink);
+  background:
+    radial-gradient(circle at 92% 4%, oklch(0.9 0.055 248 / 0.65), transparent 30%),
+    linear-gradient(145deg, var(--mx-canvas), oklch(0.96 0.015 275));
+  font-family: Inter, "Noto Sans SC", "PingFang SC", system-ui, sans-serif;
+}
+
+.model-experience-showcase button,
+.model-experience-showcase input,
+.model-experience-showcase select,
+.model-experience-showcase textarea {
+  font: inherit;
+}
+
+.model-experience-showcase button {
+  color: inherit;
+}
+
+.model-experience-showcase button:focus-visible,
+.model-experience-showcase input:focus-visible,
+.model-experience-showcase select:focus-visible,
+.model-experience-showcase textarea:focus-visible {
+  outline: 3px solid oklch(0.62 0.18 257 / 0.4);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.mx-showcase-header {
+  display: flex;
+  width: min(1440px, 100%);
+  align-items: end;
+  justify-content: space-between;
+  gap: 30px;
+  margin: 0 auto 24px;
+}
+
+.mx-overline {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--mx-primary);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.mx-showcase-header h1,
+.mx-settings__header h2,
+.mx-connection-form h2 {
+  margin: 0;
+  letter-spacing: -0.035em;
+}
+
+.mx-showcase-header h1 {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.06;
+}
+
+.mx-showcase-header p,
+.mx-settings__header p,
+.mx-connection-form header p {
+  margin: 10px 0 0;
+  color: var(--mx-muted);
+  line-height: 1.55;
+}
+
+.mx-surface-switch {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 4px;
+  border: 1px solid var(--mx-border);
+  border-radius: 16px;
+  padding: 4px;
+  background: oklch(1 0 0 / 0.7);
+  box-shadow: 0 12px 30px oklch(0.24 0.03 257 / 0.06);
+  backdrop-filter: blur(18px);
+}
+
+.mx-surface-switch button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 12px;
+  padding: 0 17px;
+  background: transparent;
+  cursor: pointer;
+  transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.mx-surface-switch button[aria-selected="true"] {
+  color: white;
+  background: var(--mx-primary);
+}
+
+.mx-surface-switch button:active {
+  transform: scale(0.96);
+}
+
+.mx-variant-tabs {
+  display: grid;
+  width: min(1440px, 100%);
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 9px;
+  margin: 0 auto 18px;
+}
+
+.mx-variant-tabs button {
+  display: grid;
+  min-height: 88px;
+  grid-template-columns: auto 1fr;
+  gap: 1px 9px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  padding: 13px 14px;
+  text-align: left;
+  background: oklch(1 0 0 / 0.48);
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.mx-variant-tabs button > span {
+  grid-row: 1 / 3;
+  color: var(--mx-primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.mx-variant-tabs strong {
+  font-size: 0.92rem;
+}
+
+.mx-variant-tabs small {
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.mx-variant-tabs button[aria-selected="true"] {
+  border-color: oklch(0.71 0.11 257);
+  background: var(--mx-surface);
+  box-shadow: 0 10px 30px oklch(0.24 0.03 257 / 0.08);
+  transform: translateY(-2px);
+}
+
+.mx-version-caption {
+  display: none;
+}
+
+.mx-chat,
+.mx-settings {
+  position: relative;
+  width: min(1440px, 100%);
+  min-height: 690px;
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--mx-border);
+  border-radius: 28px;
+  background: var(--mx-surface);
+  box-shadow: 0 26px 70px oklch(0.25 0.04 260 / 0.1);
+}
+
+.mx-chat__topline {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--mx-border);
+  padding: 0 24px;
+}
+
+.mx-chat__topline > span {
+  font-weight: 700;
+}
+
+.mx-chat__topline button {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  border-radius: 12px;
+  padding: 0 12px;
+  color: var(--mx-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.mx-chat__empty {
+  display: grid;
+  justify-items: center;
+  padding: 118px 20px 210px;
+  text-align: center;
+}
+
+.mx-akashic-mark {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border-radius: 17px;
+  color: white;
+  background: var(--mx-ink);
+  box-shadow: 0 12px 28px oklch(0.25 0.04 260 / 0.18);
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+.mx-chat__empty h2 {
+  margin: 18px 0 8px;
+  font-size: clamp(1.75rem, 3vw, 2.55rem);
+  letter-spacing: -0.035em;
+}
+
+.mx-chat__empty p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--mx-muted);
+}
+
+.mx-composer-wrap {
+  position: absolute;
+  z-index: 3;
+  inset: auto max(20px, calc((100% - 900px) / 2)) 35px;
+}
+
+.mx-composer {
+  position: relative;
+  border: 1px solid var(--mx-border);
+  border-radius: 25px;
+  padding: 16px 16px 12px;
+  background: oklch(0.955 0.014 258 / 0.94);
+  box-shadow: 0 18px 50px oklch(0.24 0.03 257 / 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.mx-composer textarea {
+  width: 100%;
+  min-height: 72px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  padding: 2px 4px;
+  color: var(--mx-ink);
+  background: transparent;
+  font-size: 1rem;
+}
+
+.mx-composer__bar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.mx-add,
+.mx-send,
+.mx-model-menu__head button,
+.mx-connection-form header button {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.mx-add:hover,
+.mx-model-menu__head button:hover,
+.mx-connection-form header button:hover {
+  background: oklch(0.91 0.02 258);
+}
+
+.mx-model-trigger {
+  display: flex;
+  min-width: 0;
+  min-height: 42px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid oklch(0.84 0.025 257);
+  border-radius: 999px;
+  padding: 3px 11px 3px 4px;
+  background: oklch(1 0 0 / 0.78);
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.mx-model-trigger:hover,
+.mx-model-trigger.is-open {
+  border-color: oklch(0.67 0.12 257);
+  background: white;
+  box-shadow: 0 8px 18px oklch(0.31 0.04 257 / 0.1);
+}
+
+.mx-model-trigger:active {
+  transform: scale(0.96);
+}
+
+.mx-model-trigger > svg {
+  flex: 0 0 auto;
+  color: var(--mx-muted);
+  transition: transform 180ms ease;
+}
+
+.mx-model-trigger.is-open > svg {
+  transform: rotate(180deg);
+}
+
+.mx-model-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.mx-model-label__copy {
+  display: grid;
+  min-width: 0;
+  text-align: left;
+}
+
+.mx-model-label__copy strong,
+.mx-model-label__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-model-label__copy strong {
+  font-size: 0.82rem;
+  font-style: normal;
+}
+
+.mx-model-label__copy strong i {
+  color: var(--mx-muted);
+  font-style: normal;
+  font-weight: 450;
+}
+
+.mx-model-label__copy small {
+  margin-top: 2px;
+  color: var(--mx-muted);
+  font-size: 0.71rem;
+}
+
+.mx-brand {
+  position: relative;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid oklch(0.88 0.02 258);
+  border-radius: 50%;
+  background: white;
+}
+
+.mx-brand img {
+  position: relative;
+  z-index: 1;
+  display: block;
+  object-fit: contain;
+}
+
+.mx-brand > span {
+  position: absolute;
+  color: var(--mx-ink);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.mx-brand img:not([src=""]) + span {
+  opacity: 0;
+}
+
+.mx-brand--codex {
+  background: oklch(0.25 0.025 260);
+}
+
+.mx-brand--opencode {
+  background: oklch(0.93 0.015 120);
+}
+
+.mx-send {
+  margin-left: auto;
+  color: white;
+  background: var(--mx-primary);
+}
+
+.mx-model-menu {
+  position: absolute;
+  z-index: 5;
+  inset: auto 0 calc(100% + 12px) 0;
+  max-height: 420px;
+  overflow: hidden;
+  border: 1px solid var(--mx-border);
+  border-radius: 23px;
+  background: oklch(0.99 0.006 258 / 0.96);
+  box-shadow: 0 24px 60px oklch(0.25 0.04 260 / 0.17);
+  backdrop-filter: blur(24px);
+  transform-origin: bottom center;
+}
+
+.mx-model-menu__head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  padding: 16px 16px 10px 18px;
+}
+
+.mx-model-menu__head > div {
+  display: grid;
+}
+
+.mx-model-menu__head strong {
+  font-size: 0.9rem;
+}
+
+.mx-model-menu__head span {
+  margin-top: 3px;
+  color: var(--mx-muted);
+  font-size: 0.75rem;
+}
+
+.mx-search,
+.mx-settings-search {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--mx-border);
+  border-radius: 14px;
+  padding: 0 12px;
+  background: var(--mx-surface-low);
+}
+
+.mx-search {
+  margin: 0 12px 8px;
+}
+
+.mx-search input,
+.mx-settings-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.mx-search kbd,
+.mx-settings-search kbd {
+  border: 1px solid var(--mx-border);
+  border-radius: 6px;
+  padding: 2px 6px;
+  color: var(--mx-muted);
+  background: white;
+  font-size: 0.68rem;
+}
+
+.mx-model-menu__options {
+  display: grid;
+  max-height: 300px;
+  gap: 3px;
+  overflow: auto;
+  padding: 4px 8px 10px;
+}
+
+.mx-model-option {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 0;
+  border-radius: 14px;
+  padding: 7px 10px;
+  background: transparent;
+  cursor: pointer;
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.mx-model-option:hover,
+.mx-model-option[aria-selected="true"] {
+  background: var(--mx-primary-soft);
+}
+
+.mx-model-option > .mx-model-label {
+  flex: 1;
+}
+
+.mx-model-option > svg {
+  flex: 0 0 auto;
+  color: var(--mx-primary);
+}
+
+.mx-chat--split .mx-model-menu {
+  inset-inline: auto 0;
+  width: min(580px, 100%);
+}
+
+.mx-trigger-effort {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-left: 1px solid var(--mx-border);
+  padding-left: 9px;
+  color: var(--mx-primary);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.mx-effort-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-top: 1px solid var(--mx-border);
+  padding: 10px 12px;
+}
+
+.mx-effort-row > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: auto;
+  color: var(--mx-muted);
+  font-size: 0.78rem;
+}
+
+.mx-effort-row button {
+  min-width: 40px;
+  min-height: 36px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.mx-effort-row button.is-active {
+  color: var(--mx-primary);
+  background: var(--mx-primary-soft);
+  font-weight: 700;
+}
+
+.mx-chat--deck .mx-model-menu {
+  inset-inline: 8%;
+  overflow: visible;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.mx-chat--deck .mx-model-menu__head,
+.mx-chat--deck .mx-search {
+  display: none;
+}
+
+.mx-chat--deck .mx-model-menu__options {
+  max-height: none;
+  overflow: visible;
+  padding: 0;
+}
+
+.mx-chat--deck .mx-model-option {
+  border: 1px solid var(--mx-border);
+  background: oklch(0.99 0.006 258 / 0.96);
+  box-shadow: 0 14px 32px oklch(0.25 0.04 260 / 0.1);
+  backdrop-filter: blur(20px);
+}
+
+.mx-chat--deck .mx-model-option:nth-child(2) { margin-inline: 14px; }
+.mx-chat--deck .mx-model-option:nth-child(3) { margin-inline: 28px; }
+.mx-chat--deck .mx-model-option:nth-child(4) { margin-inline: 42px; }
+
+.mx-chat--command .mx-model-menu {
+  inset-inline: 8%;
+  border-radius: 18px;
+}
+
+.mx-chat--command .mx-model-option {
+  border-radius: 9px;
+}
+
+.mx-rail-picker {
+  position: relative;
+  z-index: 8;
+  height: 48px;
+  margin-block-end: 10px;
+}
+
+.mx-rail-shell {
+  position: absolute;
+  inset: auto auto 0 0;
+  width: clamp(320px, 46%, 420px);
+  height: 48px;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  transform-origin: bottom left;
+  transition-property: height, border-color, border-radius, background-color, box-shadow;
+  transition-duration: 260ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.mx-rail-shell.is-open {
+  height: min(420px, calc(100vh - 280px));
+  border-color: var(--mx-border);
+  border-radius: 24px;
+  background: oklch(0.99 0.006 258 / 0.97);
+  box-shadow: 0 28px 72px oklch(0.22 0.04 260 / 0.2);
+  backdrop-filter: blur(24px);
+}
+
+.mx-rail-trigger {
+  position: absolute;
+  z-index: 3;
+  inset: auto auto 3px 3px;
+  display: flex;
+  width: min(414px, calc(100% - 6px));
+  min-width: 0;
+  height: 42px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid oklch(0.79 0.045 257);
+  border-radius: 999px;
+  padding: 3px 12px 3px 4px;
+  background: oklch(0.965 0.02 257 / 0.98);
+  box-shadow: 0 10px 24px oklch(0.28 0.04 257 / 0.11);
+  cursor: pointer;
+  transition-property: border-color, background-color, box-shadow;
+  transition-duration: 180ms;
+  transition-timing-function: ease-out;
+}
+
+.mx-rail-trigger:hover,
+.mx-rail-shell.is-open .mx-rail-trigger {
+  border-color: oklch(0.63 0.12 257);
+  background: var(--mx-primary-soft);
+}
+
+.mx-rail-trigger .mx-model-label {
+  min-width: 0;
+  flex: 1;
+}
+
+.mx-rail-trigger > svg {
+  flex: 0 0 auto;
+  color: var(--mx-primary);
+  transition: transform 180ms ease-out;
+}
+
+.mx-rail-shell.is-open .mx-rail-trigger > svg {
+  transform: rotate(180deg);
+}
+
+.mx-rail-panel {
+  position: absolute;
+  inset: 0 0 52px;
+  display: grid;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(10px);
+  transition-property: opacity, transform;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.mx-rail-shell.is-open .mx-rail-panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition-delay: 90ms;
+}
+
+.mx-rail-panel__head {
+  display: flex;
+  min-height: 66px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 13px 17px 10px;
+}
+
+.mx-rail-panel__head > div {
+  display: grid;
+  gap: 2px;
+}
+
+.mx-rail-panel__head span,
+.mx-rail-panel__head small {
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+}
+
+.mx-rail-panel__head strong {
+  font-size: 0.92rem;
+}
+
+.mx-rail-panel__head small {
+  flex: 0 0 auto;
+}
+
+.mx-rail-model-list {
+  position: relative;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-padding-block: 38px 12px;
+  scroll-snap-type: y proximity;
+  padding: 0 9px 12px;
+  scrollbar-color: oklch(0.72 0.03 257) transparent;
+  scrollbar-width: thin;
+}
+
+.mx-rail-source + .mx-rail-source {
+  margin-block-start: 14px;
+}
+
+.mx-rail-source__head {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 8px;
+  background: linear-gradient(oklch(0.99 0.006 258 / 0.98) 78%, oklch(0.99 0.006 258 / 0));
+}
+
+.mx-rail-source__head .mx-brand {
+  width: 27px !important;
+  height: 27px !important;
+}
+
+.mx-rail-source__head strong {
+  font-size: 0.76rem;
+}
+
+.mx-rail-source__head > span:last-child {
+  display: grid;
+  min-width: 22px;
+  height: 22px;
+  place-items: center;
+  margin-inline-start: auto;
+  border-radius: 999px;
+  color: var(--mx-muted);
+  background: var(--mx-surface-low);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.mx-rail-source__models {
+  display: grid;
+  gap: 4px;
+}
+
+.mx-rail-model {
+  display: grid;
+  min-height: 58px;
+  grid-template-columns: minmax(0, 1fr) auto 34px;
+  align-items: center;
+  gap: 11px;
+  scroll-snap-align: start;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  padding: 7px 8px 7px 12px;
+  text-align: start;
+  background: transparent;
+  cursor: pointer;
+  transition-property: border-color, background-color;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.mx-rail-model:hover,
+.mx-rail-model:focus-visible {
+  border-color: oklch(0.82 0.05 257);
+  background: oklch(0.96 0.023 257);
+}
+
+.mx-rail-model[aria-selected="true"] {
+  border-color: oklch(0.69 0.11 257);
+  background: var(--mx-primary-soft);
+}
+
+.mx-rail-model__copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.mx-rail-model__copy strong,
+.mx-rail-model__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-rail-model__copy strong {
+  font-size: 0.82rem;
+}
+
+.mx-rail-model__copy small {
+  color: var(--mx-muted);
+  font-size: 0.7rem;
+}
+
+.mx-rail-model__effort {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 0 8px;
+  color: var(--mx-muted);
+  background: var(--mx-surface-low);
+  font-size: 0.7rem;
+  font-weight: 650;
+}
+
+.mx-rail-model__state {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--mx-muted);
+}
+
+.mx-rail-model__state.is-selected {
+  color: white;
+  background: var(--mx-primary);
+}
+
+.mx-settings {
+  padding: clamp(24px, 4vw, 48px);
+}
+
+.mx-settings__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.mx-settings__header h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.mx-primary-button,
+.mx-text-button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 14px;
+  padding: 0 17px;
+  cursor: pointer;
+  transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
+}
+
+.mx-primary-button {
+  color: white;
+  background: var(--mx-primary);
+  box-shadow: 0 8px 18px oklch(0.45 0.17 257 / 0.2);
+}
+
+.mx-text-button {
+  color: var(--mx-muted);
+  background: transparent;
+}
+
+.mx-connection-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.mx-connection {
+  display: grid;
+  min-height: 76px;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--mx-border);
+  border-radius: 17px;
+  padding: 10px 13px;
+  text-align: left;
+  background: var(--mx-surface);
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.mx-connection:hover {
+  border-color: oklch(0.72 0.08 257);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px oklch(0.25 0.04 260 / 0.08);
+}
+
+.mx-connection__copy {
+  display: grid;
+  min-width: 0;
+}
+
+.mx-connection__copy strong,
+.mx-connection__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-connection__copy strong {
+  font-size: 0.88rem;
+}
+
+.mx-connection__copy small {
+  margin-top: 4px;
+  color: var(--mx-muted);
+  font-size: 0.73rem;
+}
+
+.mx-connection__models {
+  color: var(--mx-muted);
+  font-size: 0.75rem;
+}
+
+.mx-state {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.mx-state--ready {
+  color: oklch(0.42 0.12 153);
+  background: oklch(0.93 0.05 153);
+}
+
+.mx-state--standby {
+  color: oklch(0.48 0.12 75);
+  background: oklch(0.94 0.055 85);
+}
+
+.mx-settings--split .mx-connection-list,
+.mx-settings--command .mx-connection-list,
+.mx-settings--rail .mx-connection-list {
+  grid-template-columns: 1fr;
+}
+
+.mx-settings--split .mx-connection,
+.mx-settings--command .mx-connection,
+.mx-settings--rail .mx-connection {
+  border-inline: 0;
+  border-top: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.mx-settings-search {
+  width: min(620px, 100%);
+  margin-bottom: 22px;
+}
+
+.mx-settings--deck {
+  padding-left: 230px;
+}
+
+.mx-source-index {
+  position: absolute;
+  inset: 46px auto 46px 38px;
+  display: grid;
+  width: 160px;
+  align-content: start;
+  gap: 5px;
+  border-right: 1px solid var(--mx-border);
+  padding-right: 18px;
+}
+
+.mx-source-index > strong {
+  margin-bottom: 8px;
+  font-size: 0.78rem;
+}
+
+.mx-source-index button {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  border: 0;
+  border-radius: 10px;
+  padding: 0 10px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.mx-source-index button.is-active {
+  color: var(--mx-primary);
+  background: var(--mx-primary-soft);
+  font-weight: 700;
+}
+
+.mx-settings--deck .mx-connection-list {
+  grid-template-columns: 1fr;
+}
+
+.mx-settings--deck .mx-connection {
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+}
+
+.mx-role-bindings {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin-top: 26px;
+  border-top: 1px solid var(--mx-border);
+  padding: 18px 4px;
+}
+
+.mx-role-bindings > span {
+  display: grid;
+}
+
+.mx-role-bindings small {
+  margin-top: 4px;
+  color: var(--mx-muted);
+}
+
+.mx-role-bindings button {
+  min-height: 40px;
+  margin-left: auto;
+  border: 1px solid var(--mx-border);
+  border-radius: 12px;
+  padding: 0 14px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.mx-scrim {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 22px;
+  background: oklch(0.2 0.03 260 / 0.34);
+  backdrop-filter: blur(12px) saturate(0.8);
+}
+
+.mx-connection-form {
+  width: min(680px, 100%);
+  max-height: min(860px, calc(100vh - 44px));
+  overflow: auto;
+  border: 1px solid oklch(1 0 0 / 0.7);
+  border-radius: 26px;
+  padding: 26px;
+  background: oklch(0.99 0.006 258 / 0.97);
+  box-shadow: 0 30px 90px oklch(0.18 0.04 260 / 0.28);
+}
+
+.mx-connection-form--split {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(560px, 100%);
+  max-height: none;
+  border-radius: 26px 0 0 26px;
+}
+
+.mx-connection-form--deck {
+  border-radius: 18px;
+  box-shadow: 14px 14px 0 oklch(0.88 0.03 258 / 0.65), 0 30px 90px oklch(0.18 0.04 260 / 0.24);
+}
+
+.mx-connection-form--command {
+  width: min(760px, 100%);
+  border-radius: 18px;
+}
+
+.mx-connection-form--rail {
+  align-self: end;
+  width: min(920px, 100%);
+  border-radius: 28px 28px 0 0;
+}
+
+.mx-connection-form > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.mx-connection-form h2 {
+  font-size: 1.65rem;
+}
+
+.mx-source-choices {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 24px 0 20px;
+  border: 0;
+  padding: 0;
+}
+
+.mx-source-choices legend {
+  width: 100%;
+  margin-bottom: 8px;
+  color: var(--mx-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.mx-source-choices label {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--mx-border);
+  border-radius: 13px;
+  padding: 0 12px;
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+
+.mx-source-choices label.is-active {
+  border-color: oklch(0.67 0.13 257);
+  color: var(--mx-primary);
+  background: var(--mx-primary-soft);
+}
+
+.mx-source-choices label > input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mx-source-choices label > svg:last-child {
+  margin-left: auto;
+  opacity: 0;
+}
+
+.mx-source-choices label.is-active > svg:last-child {
+  opacity: 1;
+}
+
+.mx-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mx-form-grid > label {
+  position: relative;
+  display: grid;
+  gap: 7px;
+}
+
+.mx-form-grid > label > span {
+  color: var(--mx-muted);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.mx-form-grid input,
+.mx-form-grid select {
+  width: 100%;
+  min-height: 46px;
+  box-sizing: border-box;
+  border: 1px solid var(--mx-border);
+  border-radius: 12px;
+  padding: 0 12px;
+  color: var(--mx-ink);
+  background: white;
+}
+
+.mx-secret input {
+  padding-right: 46px;
+}
+
+.mx-secret button {
+  position: absolute;
+  inset: 28px 3px auto auto;
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 0;
+  border-radius: 10px;
+  color: var(--mx-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.mx-login-hint {
+  display: flex;
+  grid-column: span 2;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--mx-border);
+  border-radius: 14px;
+  padding: 13px;
+  background: var(--mx-primary-soft);
+}
+
+.mx-login-hint span {
+  display: grid;
+}
+
+.mx-login-hint small {
+  margin-top: 3px;
+  color: var(--mx-muted);
+}
+
+.mx-form-note {
+  margin: 16px 0 0;
+  border-left: 3px solid oklch(0.7 0.11 257);
+  padding-left: 11px;
+  color: var(--mx-muted);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.mx-connection-form footer {
+  display: flex;
+  justify-content: end;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.mx-steps {
+  display: flex;
+  gap: 8px;
+  margin: 20px 0 0;
+}
+
+.mx-steps span {
+  flex: 1;
+  border-bottom: 3px solid var(--mx-border);
+  padding: 0 0 8px;
+  color: var(--mx-muted);
+  font-size: 0.75rem;
+}
+
+.mx-steps span.is-active {
+  border-color: var(--mx-primary);
+  color: var(--mx-primary);
+  font-weight: 700;
+}
+
+.mx-toast-region {
+  position: fixed;
+  z-index: 120;
+  inset: auto 26px 24px auto;
+}
+
+.mx-toast {
+  display: flex;
+  min-width: min(340px, calc(100vw - 32px));
+  align-items: center;
+  gap: 12px;
+  border: 1px solid oklch(0.83 0.05 153);
+  border-radius: 16px;
+  padding: 13px 15px;
+  color: oklch(0.35 0.1 153);
+  background: oklch(0.98 0.025 153 / 0.97);
+  box-shadow: 0 18px 50px oklch(0.2 0.04 260 / 0.18);
+  backdrop-filter: blur(18px);
+}
+
+.mx-toast span {
+  display: grid;
+}
+
+.mx-toast small {
+  margin-top: 2px;
+  color: var(--mx-muted);
+}
+
+.mx-memoh-settings {
+  min-height: 760px;
+  overflow: auto;
+  padding: clamp(28px, 4vw, 52px);
+  background:
+    linear-gradient(180deg, oklch(0.985 0.006 258), oklch(0.968 0.01 258));
+}
+
+.mx-memoh-page-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.mx-memoh-page-header h2,
+.mx-memoh-identity h2,
+.mx-memoh-dialog h2 {
+  margin: 0;
+  letter-spacing: -0.035em;
+}
+
+.mx-memoh-page-header h2 {
+  font-size: clamp(1.9rem, 3vw, 2.7rem);
+}
+
+.mx-memoh-page-header p,
+.mx-memoh-gallery-section > header p,
+.mx-memoh-section > header p,
+.mx-memoh-dialog > header p {
+  margin: 7px 0 0;
+  color: var(--mx-muted);
+  line-height: 1.5;
+}
+
+.mx-memoh-search {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--mx-border);
+  border-radius: 13px;
+  padding: 0 12px;
+  color: var(--mx-muted);
+  background: oklch(1 0 0 / 0.84);
+  transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+}
+
+.mx-memoh-search:focus-within {
+  border-color: oklch(0.68 0.12 257);
+  background: white;
+  box-shadow: 0 0 0 3px oklch(0.68 0.12 257 / 0.12);
+}
+
+.mx-memoh-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--mx-ink);
+  background: transparent;
+}
+
+.mx-memoh-search--page {
+  width: min(540px, 100%);
+  margin-bottom: 34px;
+}
+
+.mx-memoh-gallery-section + .mx-memoh-gallery-section {
+  margin-top: 36px;
+}
+
+.mx-memoh-gallery-section > header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 13px;
+}
+
+.mx-memoh-gallery-section h3,
+.mx-memoh-section h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: -0.015em;
+}
+
+.mx-memoh-gallery-section > header p,
+.mx-memoh-section > header p {
+  font-size: 0.78rem;
+}
+
+.mx-memoh-gallery-section > header > span {
+  color: var(--mx-muted);
+  font-size: 0.76rem;
+}
+
+.mx-memoh-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.mx-memoh-provider-card {
+  display: grid;
+  min-height: 92px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  border: 1px solid var(--mx-border);
+  border-radius: 18px;
+  padding: 14px;
+  text-align: left;
+  background: oklch(0.995 0.003 258 / 0.9);
+  cursor: pointer;
+  box-shadow: 0 6px 18px oklch(0.25 0.035 260 / 0.035);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease, background-color 180ms ease;
+}
+
+.mx-memoh-provider-card:hover {
+  border-color: oklch(0.72 0.09 257);
+  background: white;
+  box-shadow: 0 13px 30px oklch(0.25 0.035 260 / 0.08);
+  transform: translateY(-2px);
+}
+
+.mx-memoh-provider-card__copy,
+.mx-memoh-provider-card__meta {
+  display: grid;
+  min-width: 0;
+}
+
+.mx-memoh-provider-card__copy strong,
+.mx-memoh-provider-card__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-memoh-provider-card__copy strong {
+  font-size: 0.9rem;
+}
+
+.mx-memoh-provider-card__copy small,
+.mx-memoh-provider-card__meta small {
+  margin-top: 5px;
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+}
+
+.mx-memoh-provider-card__meta {
+  justify-items: end;
+  gap: 7px;
+}
+
+.mx-memoh-provider-card__meta i {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: oklch(0.43 0.11 153);
+  font-size: 0.7rem;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.mx-memoh-provider-card__meta i > span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.62 0.15 153);
+}
+
+.mx-memoh-provider-card__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--mx-primary);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.mx-memoh-gallery-section--templates .mx-memoh-provider-card {
+  min-height: 82px;
+  border-style: dashed;
+  box-shadow: none;
+  background: transparent;
+}
+
+.mx-memoh-back,
+.mx-memoh-secondary-button,
+.mx-memoh-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  color: var(--mx-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.mx-memoh-back {
+  min-height: 42px;
+  gap: 8px;
+  margin: -10px 0 18px -10px;
+  border-radius: 12px;
+  padding: 0 10px;
+  font-weight: 650;
+}
+
+.mx-memoh-back:hover,
+.mx-memoh-icon-button:hover {
+  color: var(--mx-ink);
+  background: var(--mx-surface-low);
+}
+
+.mx-memoh-identity {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 18px;
+  border: 1px solid var(--mx-border);
+  border-radius: 20px;
+  padding: 17px 18px;
+  background: oklch(1 0 0 / 0.78);
+}
+
+.mx-memoh-identity > span:nth-child(2) {
+  min-width: 0;
+}
+
+.mx-memoh-identity > span:nth-child(2) > small {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--mx-muted);
+  font-size: 0.7rem;
+  font-weight: 650;
+}
+
+.mx-memoh-identity h2 {
+  overflow: hidden;
+  font-size: 1.25rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-memoh-icon-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+}
+
+.mx-memoh-delete:hover {
+  color: oklch(0.52 0.18 25);
+  background: oklch(0.95 0.04 25);
+}
+
+.mx-memoh-enabled {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.mx-memoh-enabled small {
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+}
+
+.mx-memoh-switch {
+  position: relative;
+  width: 44px;
+  height: 26px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  padding: 3px;
+  background: oklch(0.8 0.02 258);
+  cursor: pointer;
+  transition: background-color 180ms ease;
+}
+
+.mx-memoh-switch > span {
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 2px 5px oklch(0.25 0.03 260 / 0.22);
+  transform: translateX(0);
+  transition: transform 180ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.mx-memoh-switch[aria-checked="true"] {
+  background: var(--mx-primary);
+}
+
+.mx-memoh-switch[aria-checked="true"] > span {
+  transform: translateX(18px);
+}
+
+.mx-memoh-section {
+  border: 1px solid var(--mx-border);
+  border-radius: 20px;
+  padding: 21px;
+  background: oklch(1 0 0 / 0.78);
+}
+
+.mx-memoh-section + .mx-memoh-section {
+  margin-top: 14px;
+}
+
+.mx-memoh-section > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.mx-memoh-config-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mx-memoh-config-grid > label {
+  position: relative;
+  display: grid;
+  gap: 7px;
+}
+
+.mx-memoh-config-grid > label > span {
+  color: var(--mx-muted);
+  font-size: 0.74rem;
+  font-weight: 650;
+}
+
+.mx-memoh-config-grid input,
+.mx-memoh-config-grid select {
+  width: 100%;
+  min-height: 46px;
+  box-sizing: border-box;
+  border: 1px solid var(--mx-border);
+  border-radius: 12px;
+  padding: 0 12px;
+  color: var(--mx-ink);
+  background: white;
+}
+
+.mx-memoh-field-wide,
+.mx-memoh-account {
+  grid-column: 1 / -1;
+}
+
+.mx-memoh-account {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid oklch(0.84 0.05 257);
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: var(--mx-primary-soft);
+}
+
+.mx-memoh-account__icon {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 12px;
+  color: var(--mx-primary);
+  background: white;
+}
+
+.mx-memoh-account > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+}
+
+.mx-memoh-account small {
+  margin-top: 3px;
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+}
+
+.mx-memoh-account > button {
+  min-height: 40px;
+  margin-left: auto;
+  border: 1px solid oklch(0.75 0.08 257);
+  border-radius: 11px;
+  padding: 0 13px;
+  color: var(--mx-primary);
+  background: white;
+  cursor: pointer;
+}
+
+.mx-memoh-form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.mx-memoh-form-footer > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+}
+
+.mx-memoh-secondary-button {
+  min-height: 40px;
+  flex: 0 0 auto;
+  gap: 7px;
+  border: 1px solid var(--mx-border);
+  border-radius: 11px;
+  padding: 0 12px;
+  color: var(--mx-ink);
+  background: white;
+}
+
+.mx-memoh-secondary-button:hover {
+  border-color: oklch(0.72 0.09 257);
+  color: var(--mx-primary);
+}
+
+.mx-memoh-models .mx-memoh-search {
+  margin-bottom: 10px;
+}
+
+.mx-memoh-model-list {
+  border-top: 1px solid var(--mx-border);
+}
+
+.mx-memoh-model-row {
+  display: grid;
+  min-height: 68px;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--mx-border);
+}
+
+.mx-memoh-model-row__copy {
+  display: grid;
+  min-width: 0;
+}
+
+.mx-memoh-model-row__copy strong,
+.mx-memoh-model-row__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mx-memoh-model-row__copy strong {
+  font-size: 0.84rem;
+}
+
+.mx-memoh-model-row__copy small {
+  margin-top: 4px;
+  color: var(--mx-muted);
+  font-size: 0.7rem;
+}
+
+.mx-memoh-effort {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.mx-memoh-effort > span {
+  color: var(--mx-muted);
+  font-size: 0.7rem;
+}
+
+.mx-memoh-effort select {
+  min-height: 38px;
+  border: 1px solid var(--mx-border);
+  border-radius: 10px;
+  padding: 0 28px 0 9px;
+  background: white;
+}
+
+.mx-memoh-icon-button.is-testing svg,
+.is-spinning {
+  animation: mx-memoh-spin 800ms linear infinite;
+}
+
+@keyframes mx-memoh-spin {
+  to { transform: rotate(360deg); }
+}
+
+.mx-memoh-empty {
+  display: grid;
+  min-height: 150px;
+  place-items: center;
+  align-content: center;
+  gap: 8px;
+  border: 1px dashed var(--mx-border);
+  border-radius: 15px;
+  color: var(--mx-muted);
+  text-align: center;
+  background: var(--mx-surface-low);
+}
+
+.mx-memoh-empty strong {
+  color: var(--mx-ink);
+}
+
+.mx-memoh-empty span,
+.mx-memoh-capability-note {
+  font-size: 0.72rem;
+}
+
+.mx-memoh-capability-note {
+  margin: 13px 0 0;
+  color: var(--mx-muted);
+}
+
+.mx-memoh-dialog {
+  --mx-primary: oklch(0.53 0.17 257);
+  --mx-primary-soft: oklch(0.93 0.04 257);
+  --mx-ink: oklch(0.25 0.025 260);
+  --mx-muted: oklch(0.52 0.025 260);
+  --mx-surface-low: oklch(0.955 0.012 258);
+  --mx-border: oklch(0.87 0.018 258);
+  width: min(720px, 100%);
+  max-height: min(880px, calc(100vh - 44px));
+  overflow: auto;
+  border: 1px solid oklch(1 0 0 / 0.75);
+  border-radius: 24px;
+  padding: 25px;
+  color: var(--mx-ink);
+  background: oklch(0.99 0.006 258 / 0.98);
+  box-shadow: 0 30px 90px oklch(0.18 0.04 260 / 0.28);
+  font-family: Inter, "Noto Sans SC", "PingFang SC", system-ui, sans-serif;
+}
+
+.mx-memoh-dialog > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.mx-memoh-dialog h2 {
+  font-size: 1.6rem;
+}
+
+.mx-memoh-kind-picker {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 22px 0 18px;
+  border: 0;
+  padding: 0;
+}
+
+.mx-memoh-kind-picker legend {
+  width: 100%;
+  margin-bottom: 8px;
+  color: var(--mx-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.mx-memoh-kind-picker label {
+  position: relative;
+  display: grid;
+  min-height: 82px;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-content: center;
+  gap: 5px 8px;
+  border: 1px solid var(--mx-border);
+  border-radius: 14px;
+  padding: 10px;
+  cursor: pointer;
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.mx-memoh-kind-picker label.is-active {
+  border-color: oklch(0.66 0.14 257);
+  color: var(--mx-primary);
+  background: var(--mx-primary-soft);
+}
+
+.mx-memoh-kind-picker label > input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mx-memoh-kind-picker label > span {
+  display: grid;
+}
+
+.mx-memoh-kind-picker label small {
+  margin-top: 2px;
+  color: var(--mx-muted);
+  font-size: 0.65rem;
+  line-height: 1.3;
+}
+
+.mx-memoh-kind-picker label > svg:last-child {
+  position: absolute;
+  inset: 8px 8px auto auto;
+  opacity: 0;
+}
+
+.mx-memoh-kind-picker label.is-active > svg:last-child {
+  opacity: 1;
+}
+
+.mx-memoh-discovery {
+  display: flex !important;
+  min-height: 58px;
+  align-items: center;
+  gap: 10px !important;
+  border: 1px solid var(--mx-border);
+  border-radius: 13px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.mx-memoh-discovery > input {
+  width: 18px;
+  min-height: 18px;
+  accent-color: var(--mx-primary);
+}
+
+.mx-memoh-discovery > span {
+  display: grid;
+}
+
+.mx-memoh-discovery small {
+  margin-top: 2px;
+  color: var(--mx-muted);
+  font-weight: 400;
+}
+
+.mx-memoh-dialog footer {
+  display: flex;
+  justify-content: end;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.mx-toast-region {
+  --mx-muted: oklch(0.52 0.025 260);
+}
+
+.mx-prototype-note {
+  width: min(1440px, 100%);
+  margin: 14px auto 0;
+  color: var(--mx-muted);
+  font-size: 0.72rem;
+  text-align: right;
+}
+
+@media (max-width: 900px) {
+  .mx-showcase-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .mx-variant-tabs {
+    display: flex;
+    overflow-x: auto;
+    padding: 4px 2px 10px;
+  }
+
+  .mx-variant-tabs button {
+    min-width: 190px;
+  }
+
+  .mx-settings--deck {
+    padding-left: 36px;
+  }
+
+  .mx-source-index {
+    position: static;
+    width: auto;
+    grid-template-columns: repeat(3, 1fr);
+    margin-bottom: 20px;
+    border: 0;
+    padding: 0;
+  }
+
+  .mx-source-index > strong {
+    display: none;
+  }
+
+  .mx-memoh-kind-picker {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .model-experience-showcase {
+    padding: 22px 12px 40px;
+  }
+
+  .mx-showcase-header {
+    margin-bottom: 16px;
+  }
+
+  .mx-showcase-header h1 {
+    font-size: 2rem;
+  }
+
+  .mx-surface-switch {
+    width: 100%;
+  }
+
+  .mx-surface-switch button {
+    flex: 1;
+  }
+
+  .mx-chat,
+  .mx-settings {
+    min-height: 680px;
+    border-radius: 22px;
+  }
+
+  .mx-chat__empty {
+    padding-top: 96px;
+  }
+
+  .mx-composer-wrap {
+    inset-inline: 12px;
+    bottom: 16px;
+  }
+
+  .mx-model-trigger {
+    max-width: calc(100% - 102px);
+  }
+
+  .mx-rail-shell,
+  .mx-rail-shell.is-open {
+    width: 100%;
+  }
+
+  .mx-rail-shell.is-open {
+    height: min(62vh, 460px);
+    border-radius: 21px;
+  }
+
+  .mx-rail-trigger {
+    width: calc(100% - 6px);
+  }
+
+  .mx-rail-panel__head {
+    min-height: 60px;
+    padding-inline: 14px;
+  }
+
+  .mx-rail-panel__head small {
+    display: none;
+  }
+
+  .mx-rail-model {
+    min-height: 62px;
+    grid-template-columns: minmax(0, 1fr) auto 36px;
+  }
+
+  .mx-rail-model__effort {
+    padding-inline: 7px;
+  }
+
+  .mx-model-label__copy strong i,
+  .mx-model-label__copy strong {
+    font-size: 0.75rem;
+  }
+
+  .mx-chat--deck .mx-model-menu,
+  .mx-chat--command .mx-model-menu {
+    inset-inline: 0;
+  }
+
+  .mx-chat--deck .mx-model-option:nth-child(n) {
+    margin-inline: 0;
+  }
+
+  .mx-settings {
+    padding: 24px 18px;
+  }
+
+  .mx-settings__header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .mx-settings__header .mx-primary-button {
+    width: 100%;
+  }
+
+  .mx-connection-list {
+    grid-template-columns: 1fr;
+  }
+
+  .mx-connection {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .mx-connection__models {
+    display: none;
+  }
+
+  .mx-settings--deck .mx-connection {
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+  }
+
+  .mx-source-choices,
+  .mx-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mx-source-choices {
+    gap: 6px;
+  }
+
+  .mx-login-hint {
+    grid-column: auto;
+  }
+
+  .mx-connection-form {
+    max-height: calc(100vh - 24px);
+    border-radius: 22px;
+    padding: 20px;
+  }
+
+  .mx-connection-form--split {
+    inset: 12px;
+    width: auto;
+    max-height: calc(100vh - 24px);
+    border-radius: 22px;
+  }
+
+  .mx-connection-form--rail {
+    border-radius: 22px 22px 0 0;
+  }
+
+  .mx-toast-region {
+    inset: auto 16px 16px;
+  }
+
+  .mx-toast {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .mx-memoh-settings {
+    min-height: 760px;
+    padding: 24px 18px;
+  }
+
+  .mx-memoh-page-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .mx-memoh-page-header .mx-primary-button,
+  .mx-memoh-gallery {
+    width: 100%;
+  }
+
+  .mx-memoh-gallery {
+    grid-template-columns: 1fr;
+  }
+
+  .mx-memoh-identity {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .mx-memoh-delete {
+    display: none;
+  }
+
+  .mx-memoh-enabled {
+    grid-column: 2 / -1;
+    justify-content: space-between;
+  }
+
+  .mx-memoh-section {
+    padding: 17px;
+  }
+
+  .mx-memoh-section > header,
+  .mx-memoh-form-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .mx-memoh-config-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mx-memoh-field-wide,
+  .mx-memoh-account {
+    grid-column: auto;
+  }
+
+  .mx-memoh-account {
+    align-items: start;
+    flex-wrap: wrap;
+  }
+
+  .mx-memoh-account > button {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .mx-memoh-model-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    padding-block: 11px;
+  }
+
+  .mx-memoh-effort {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .mx-memoh-dialog {
+    max-height: calc(100vh - 24px);
+    border-radius: 22px;
+    padding: 20px;
+  }
+
+  .mx-memoh-kind-picker {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .model-experience-showcase *,
+  .model-experience-showcase *::before,
+  .model-experience-showcase *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}

--- a/frontend/chat/src/model-experience-showcase.tsx
+++ b/frontend/chat/src/model-experience-showcase.tsx
@@ -1,0 +1,987 @@
+import { motion } from "motion/react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  KeyRound,
+  Layers3,
+  LogIn,
+  Plus,
+  RefreshCw,
+  Search,
+  SendHorizontal,
+  Settings2,
+  ShieldCheck,
+  SlidersHorizontal,
+  Sparkles,
+  Trash2,
+  X,
+  Zap,
+} from "lucide-react";
+import { FormEvent, KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import codexIcon from "./assets/provider-icons/codex.svg";
+import deepseekIcon from "./assets/provider-icons/deepseek.svg";
+import opencodeIcon from "./assets/provider-icons/opencode.svg";
+import openrouterIcon from "./assets/provider-icons/openrouter.svg";
+import "./model-experience-showcase.css";
+
+type Surface = "chat" | "settings";
+type VariantId = "dock" | "split" | "deck" | "command" | "rail";
+type ModelOption = {
+  id: string;
+  name: string;
+  source: string;
+  icon: "deepseek" | "opencode" | "codex" | "openrouter";
+  effort: string;
+  detail: string;
+};
+
+const PROVIDER_ICONS: Record<ModelOption["icon"], string> = {
+  codex: codexIcon,
+  deepseek: deepseekIcon,
+  opencode: opencodeIcon,
+  openrouter: openrouterIcon,
+};
+
+const VARIANTS: Array<{ id: VariantId; number: string; name: string; note: string }> = [
+  { id: "dock", number: "01", name: "悬浮坞", note: "选择层锚定输入框，配置用居中表单" },
+  { id: "split", number: "02", name: "双段胶囊", note: "模型与推理强度并排，配置用侧滑表单" },
+  { id: "deck", number: "03", name: "卡片叠层", note: "候选像卡片展开，配置用主从详情" },
+  { id: "command", number: "04", name: "指令面板", note: "搜索优先，配置也采用快速查找" },
+  { id: "rail", number: "05", name: "等宽上展", note: "唯一胶囊等宽向上展开，全供应商分组滑动" },
+];
+
+const MODELS: ModelOption[] = [
+  {
+    id: "oc-v4-flash",
+    name: "deepseek-v4-flash",
+    source: "OpenCode Go",
+    icon: "opencode",
+    effort: "高",
+    detail: "主账号 · 128K",
+  },
+  {
+    id: "ds-chat",
+    name: "deepseek-chat",
+    source: "DeepSeek 官方",
+    icon: "deepseek",
+    effort: "中",
+    detail: "API Key · 64K",
+  },
+  {
+    id: "codex-main",
+    name: "gpt-5.2-codex",
+    source: "Codex 登录",
+    icon: "codex",
+    effort: "高",
+    detail: "OAuth · 400K",
+  },
+  {
+    id: "router-v4",
+    name: "deepseek-v4-flash",
+    source: "OpenRouter 备用",
+    icon: "openrouter",
+    effort: "低",
+    detail: "备用密钥 · 128K",
+  },
+];
+
+const RAIL_MODELS: ModelOption[] = [
+  ...MODELS,
+  { id: "oc-kimi", name: "kimi-k2.5", source: "OpenCode Go", icon: "opencode", effort: "高", detail: "主账号 · 256K" },
+  { id: "oc-glm", name: "glm-5", source: "OpenCode Go", icon: "opencode", effort: "中", detail: "主账号 · 200K" },
+  { id: "ds-reasoner", name: "deepseek-reasoner", source: "DeepSeek 官方", icon: "deepseek", effort: "高", detail: "API Key · 64K" },
+  { id: "codex-mini", name: "gpt-5.1-codex-mini", source: "Codex 登录", icon: "codex", effort: "中", detail: "OAuth · 400K" },
+  { id: "router-claude", name: "claude-sonnet-4.5", source: "OpenRouter 备用", icon: "openrouter", effort: "高", detail: "备用密钥 · 200K" },
+  { id: "router-gemini", name: "gemini-2.5-pro", source: "OpenRouter 备用", icon: "openrouter", effort: "中", detail: "备用密钥 · 1M" },
+];
+
+const RAIL_SOURCES = ["OpenCode Go", "DeepSeek 官方", "Codex 登录", "OpenRouter 备用"];
+
+const CONNECTIONS = [
+  { id: "codex", name: "Codex 登录", meta: "OAuth · 已连接", models: 6, icon: "codex", state: "就绪" },
+  { id: "opencode", name: "OpenCode Go 主账号", meta: "登录凭据 · 4 个模型", models: 4, icon: "opencode", state: "就绪" },
+  { id: "deepseek", name: "DeepSeek 官方", meta: "sk-••••••9Q · api.deepseek.com", models: 2, icon: "deepseek", state: "就绪" },
+  { id: "openrouter", name: "OpenRouter 备用", meta: "sk-or-••••K2 · 仅故障切换", models: 3, icon: "openrouter", state: "备用" },
+] as const;
+
+type MemohProviderKind = "api" | "codex" | "opencode" | "custom";
+type MemohModel = {
+  id: string;
+  name: string;
+  metadata: string;
+  enabled: boolean;
+  effort: string;
+};
+type MemohProvider = {
+  id: string;
+  name: string;
+  icon: string;
+  kind: MemohProviderKind;
+  clientType: string;
+  description: string;
+  status: "已连接" | "未配置";
+  baseUrl?: string;
+  secret?: string;
+  account?: string;
+  models: MemohModel[];
+};
+
+const MEMOH_PROVIDERS: MemohProvider[] = [
+  {
+    id: "deepseek-main",
+    name: "DeepSeek 官方",
+    icon: "deepseek",
+    kind: "api",
+    clientType: "OpenAI Compatible",
+    description: "官方 API · 独立计费",
+    status: "已连接",
+    baseUrl: "https://api.deepseek.com/v1",
+    secret: "已保存 · sk-••••••9Q",
+    models: [
+      { id: "deepseek-chat", name: "deepseek-chat", metadata: "64K · 工具调用", enabled: true, effort: "中" },
+      { id: "deepseek-reasoner", name: "deepseek-reasoner", metadata: "64K · 深度推理", enabled: true, effort: "高" },
+    ],
+  },
+  {
+    id: "codex-account",
+    name: "Codex 登录",
+    icon: "codex",
+    kind: "codex",
+    clientType: "Codex OAuth",
+    description: "huayue@example.com · 订阅账号",
+    status: "已连接",
+    account: "huayue@example.com",
+    models: [
+      { id: "gpt-5.2-codex", name: "gpt-5.2-codex", metadata: "400K · 视觉 · 工具", enabled: true, effort: "高" },
+      { id: "gpt-5.1-codex-mini", name: "gpt-5.1-codex-mini", metadata: "400K · 快速", enabled: true, effort: "中" },
+    ],
+  },
+  {
+    id: "opencode-main",
+    name: "OpenCode Go 主账号",
+    icon: "opencode",
+    kind: "opencode",
+    clientType: "OpenCode Login",
+    description: "登录凭据 · 自动同步模型",
+    status: "已连接",
+    account: "OpenCode Go · 主账号",
+    models: [
+      { id: "deepseek-v4-flash", name: "deepseek-v4-flash", metadata: "128K · 视觉 · 工具", enabled: true, effort: "高" },
+      { id: "kimi-k2.5", name: "kimi-k2.5", metadata: "256K · 视觉", enabled: true, effort: "高" },
+      { id: "glm-5", name: "glm-5", metadata: "200K · 工具调用", enabled: false, effort: "中" },
+    ],
+  },
+];
+
+const MEMOH_TEMPLATES: MemohProvider[] = [
+  {
+    id: "openrouter-template",
+    name: "OpenRouter",
+    icon: "openrouter",
+    kind: "api",
+    clientType: "OpenAI Compatible",
+    description: "一个密钥连接多个模型",
+    status: "未配置",
+    baseUrl: "https://openrouter.ai/api/v1",
+    models: [],
+  },
+  {
+    id: "deepseek-template",
+    name: "DeepSeek API",
+    icon: "deepseek",
+    kind: "api",
+    clientType: "OpenAI Compatible",
+    description: "预填官方 Base URL",
+    status: "未配置",
+    baseUrl: "https://api.deepseek.com/v1",
+    models: [],
+  },
+  {
+    id: "codex-template",
+    name: "Codex 订阅",
+    icon: "codex",
+    kind: "codex",
+    clientType: "Codex OAuth",
+    description: "浏览器登录，无需 API Key",
+    status: "未配置",
+    models: [],
+  },
+  {
+    id: "custom-template",
+    name: "自定义兼容接口",
+    icon: "custom",
+    kind: "custom",
+    clientType: "OpenAI Compatible",
+    description: "Base URL + API Key",
+    status: "未配置",
+    models: [],
+  },
+];
+
+function BrandIcon({ name, size = 20 }: { name: ModelOption["icon"] | string; size?: number }) {
+  const icon = PROVIDER_ICONS[name as ModelOption["icon"]];
+  return (
+    <span className={`mx-brand mx-brand--${name}`} style={{ width: size + 12, height: size + 12 }} aria-hidden="true">
+      {icon && <img src={icon} alt="" width={size} height={size} />}
+      <span>{name.slice(0, 1).toUpperCase()}</span>
+    </span>
+  );
+}
+
+function ModelLabel({ model, compact = false }: { model: ModelOption; compact?: boolean }) {
+  return (
+    <span className="mx-model-label">
+      <BrandIcon name={model.icon} size={compact ? 16 : 19} />
+      <span className="mx-model-label__copy">
+        <strong>{model.name}<i>：</i>{model.source}</strong>
+        {!compact && <small>{model.detail} · 推理 {model.effort}</small>}
+      </span>
+    </span>
+  );
+}
+
+function SelectionMenu({
+  variant,
+  selected,
+  onSelect,
+  onClose,
+}: {
+  variant: VariantId;
+  selected: ModelOption;
+  onSelect: (model: ModelOption) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const options = useMemo(
+    () => MODELS.filter((model) => `${model.name} ${model.source}`.toLowerCase().includes(query.toLowerCase())),
+    [query],
+  );
+  const showSearch = variant === "command" || variant === "dock";
+
+  return (
+    <motion.div
+      className={`mx-model-menu mx-model-menu--${variant}`}
+      role="listbox"
+      aria-label="选择本轮模型"
+      initial={{ opacity: 0, y: 12, scale: 0.96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+    >
+      <div className="mx-model-menu__head">
+        <div>
+          <strong>{variant === "command" ? "切换运行模型" : "本轮使用"}</strong>
+          <span>切换只影响下一轮发送</span>
+        </div>
+        <button type="button" aria-label="关闭模型选择" onClick={onClose}><X size={18} /></button>
+      </div>
+      {showSearch && (
+        <label className="mx-search">
+          <Search size={17} aria-hidden="true" />
+          <span className="sr-only">搜索模型或来源</span>
+          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索模型或来源" autoFocus />
+          {variant === "command" && <kbd>⌘ K</kbd>}
+        </label>
+      )}
+      <div className="mx-model-menu__options">
+        {options.map((model, index) => (
+          <motion.button
+            type="button"
+            role="option"
+            aria-selected={selected.id === model.id}
+            className="mx-model-option"
+            key={model.id}
+            onClick={() => onSelect(model)}
+            initial={{ opacity: 0, y: variant === "deck" ? 12 : 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: Math.min(index * 0.035, 0.12), duration: 0.2 }}
+            whileTap={{ scale: 0.96 }}
+          >
+            <ModelLabel model={model} />
+            {selected.id === model.id ? <Check size={18} /> : <ArrowRight size={17} />}
+          </motion.button>
+        ))}
+      </div>
+      {variant === "split" && (
+        <div className="mx-effort-row" aria-label="推理强度">
+          <span><Sparkles size={16} />推理强度</span>
+          {['低', '中', '高'].map((effort) => <button type="button" key={effort} className={effort === selected.effort ? "is-active" : ""}>{effort}</button>)}
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function RailModelPicker({
+  open,
+  selected,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean;
+  selected: ModelOption;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (model: ModelOption) => void;
+}) {
+  const selectedIndex = Math.max(0, RAIL_MODELS.findIndex((model) => model.id === selected.id));
+  const [activeIndex, setActiveIndex] = useState(selectedIndex);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setActiveIndex(selectedIndex);
+    window.setTimeout(() => optionRefs.current[selectedIndex]?.focus({ preventScroll: true }), 0);
+  }, [open, selectedIndex]);
+
+  function moveFocus(nextIndex: number) {
+    const normalized = (nextIndex + RAIL_MODELS.length) % RAIL_MODELS.length;
+    setActiveIndex(normalized);
+    const option = optionRefs.current[normalized];
+    const list = listRef.current;
+    option?.focus({ preventScroll: true });
+    if (!option || !list) return;
+    const optionRect = option.getBoundingClientRect();
+    const listRect = list.getBoundingClientRect();
+    if (optionRect.top < listRect.top + 38) list.scrollTop += optionRect.top - listRect.top - 38;
+    if (optionRect.bottom > listRect.bottom - 8) list.scrollTop += optionRect.bottom - listRect.bottom + 8;
+  }
+
+  function closePicker() {
+    onOpenChange(false);
+    triggerRef.current?.focus({ preventScroll: true });
+  }
+
+  function selectModel(model: ModelOption) {
+    onSelect(model);
+    triggerRef.current?.focus({ preventScroll: true });
+  }
+
+  function onListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePicker();
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      moveFocus(activeIndex + (event.key === "ArrowDown" ? 1 : -1));
+      return;
+    }
+    if ((event.key === "Enter" || event.key === " ") && document.activeElement === optionRefs.current[activeIndex]) {
+      event.preventDefault();
+      selectModel(RAIL_MODELS[activeIndex]);
+    }
+  }
+
+  return (
+    <div className="mx-rail-picker">
+      <div className={`mx-rail-shell ${open ? "is-open" : ""}`}>
+        <div className="mx-rail-panel" aria-hidden={!open}>
+          <header className="mx-rail-panel__head">
+            <div><span>所有供应商</span><strong>选择下一轮使用的模型</strong></div>
+            <small>{RAIL_MODELS.length} 个可用模型</small>
+          </header>
+          <div
+            id="mx-rail-model-list"
+            ref={listRef}
+            className="mx-rail-model-list"
+            role="listbox"
+            aria-label="所有供应商的模型"
+            onKeyDown={onListKeyDown}
+          >
+            {RAIL_SOURCES.map((source) => {
+              const sourceModels = RAIL_MODELS.filter((model) => model.source === source);
+              const sourceIcon = sourceModels[0]?.icon;
+              return (
+                <section className="mx-rail-source" aria-label={source} key={source}>
+                  <div className="mx-rail-source__head">
+                    {sourceIcon && <BrandIcon name={sourceIcon} size={15} />}
+                    <strong>{source}</strong>
+                    <span>{sourceModels.length}</span>
+                  </div>
+                  <div className="mx-rail-source__models">
+                    {sourceModels.map((model) => {
+                      const index = RAIL_MODELS.findIndex((candidate) => candidate.id === model.id);
+                      const isSelected = selected.id === model.id;
+                      return (
+                        <motion.button
+                          ref={(node) => { optionRefs.current[index] = node; }}
+                          type="button"
+                          role="option"
+                          aria-selected={isSelected}
+                          tabIndex={open && activeIndex === index ? 0 : -1}
+                          className="mx-rail-model"
+                          key={model.id}
+                          onFocus={() => setActiveIndex(index)}
+                          onClick={() => selectModel(model)}
+                          whileTap={{ scale: 0.96 }}
+                        >
+                          <span className="mx-rail-model__copy"><strong>{model.name}</strong><small>{model.detail}</small></span>
+                          <span className="mx-rail-model__effort"><Sparkles size={13} />{model.effort}</span>
+                          <span className={`mx-rail-model__state ${isSelected ? "is-selected" : ""}`} aria-hidden="true">
+                            {isSelected ? <Check size={17} /> : <ArrowRight size={16} />}
+                          </span>
+                        </motion.button>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+        <motion.button
+          ref={triggerRef}
+          type="button"
+          className="mx-rail-trigger"
+          aria-haspopup="listbox"
+          aria-controls="mx-rail-model-list"
+          aria-expanded={open}
+          onClick={() => onOpenChange(!open)}
+          whileTap={{ scale: 0.96 }}
+        >
+          <ModelLabel model={selected} compact />
+          <ChevronDown size={18} aria-hidden="true" />
+        </motion.button>
+      </div>
+    </div>
+  );
+}
+
+function ChatPrototype({ variant }: { variant: VariantId }) {
+  const [selected, setSelected] = useState(MODELS[0]);
+  const [open, setOpen] = useState(false);
+  const isSplit = variant === "split";
+
+  function choose(model: ModelOption) {
+    setSelected(model);
+    setOpen(false);
+  }
+
+  return (
+    <section className={`mx-chat mx-chat--${variant}`} aria-label={`${variant} 对话选模原型`}>
+      <div className="mx-chat__topline"><span>新对话</span><button type="button"><Settings2 size={18} />对话设置</button></div>
+      <div className="mx-chat__empty">
+        <span className="mx-akashic-mark">あ</span>
+        <h2>今天想一起完成什么？</h2>
+        <p>模型选择属于下一轮发送，不打断正在运行的这一轮。</p>
+      </div>
+      <div className="mx-composer-wrap">
+        {variant !== "rail" && open && <SelectionMenu variant={variant} selected={selected} onSelect={choose} onClose={() => setOpen(false)} />}
+        {variant === "rail" && <RailModelPicker open={open} selected={selected} onOpenChange={setOpen} onSelect={choose} />}
+        <div className="mx-composer">
+          <textarea aria-label="消息" placeholder="有问题，尽管问" />
+          <div className="mx-composer__bar">
+            <button type="button" className="mx-add" aria-label="添加附件"><Plus size={20} /></button>
+            {variant !== "rail" && (
+              <button
+                type="button"
+                className={`mx-model-trigger ${open ? "is-open" : ""}`}
+                aria-haspopup="listbox"
+                aria-expanded={open}
+                onClick={() => setOpen((value) => !value)}
+              >
+                <ModelLabel model={selected} compact />
+                {isSplit && <span className="mx-trigger-effort"><Sparkles size={14} />{selected.effort}</span>}
+                <ChevronDown size={17} />
+              </button>
+            )}
+            <motion.button type="button" className="mx-send" aria-label="发送" whileTap={{ scale: 0.96 }}>
+              <SendHorizontal size={20} />
+            </motion.button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ConnectionRow({ connection, variant }: { connection: (typeof CONNECTIONS)[number]; variant: VariantId }) {
+  return (
+    <button type="button" className="mx-connection">
+      <BrandIcon name={connection.icon} size={21} />
+      <span className="mx-connection__copy"><strong>{connection.name}</strong><small>{connection.meta}</small></span>
+      <span className="mx-connection__models">{connection.models} 模型</span>
+      <span className={`mx-state mx-state--${connection.state === "备用" ? "standby" : "ready"}`}>{connection.state}</span>
+      {variant === "deck" && <ArrowRight size={17} />}
+    </button>
+  );
+}
+
+function ConnectionForm({
+  variant,
+  onClose,
+  onSaved,
+}: {
+  variant: VariantId;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [showKey, setShowKey] = useState(false);
+  const [source, setSource] = useState("api");
+
+  useEffect(() => {
+    nameRef.current?.focus();
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+      if (event.key !== "Tab" || !panelRef.current) return;
+      const focusable = Array.from(panelRef.current.querySelectorAll<HTMLElement>("button, input, select"));
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    onSaved();
+  }
+
+  return (
+    <motion.div
+      className="mx-scrim"
+      role="presentation"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}
+    >
+      <motion.div
+        className={`mx-connection-form mx-connection-form--${variant}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mx-form-title"
+        ref={panelRef}
+        initial={{ opacity: 0, y: variant === "rail" ? 32 : 14, x: variant === "split" ? 32 : 0, scale: 0.97 }}
+        animate={{ opacity: 1, y: 0, x: 0, scale: 1 }}
+        transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+      >
+        <header>
+          <div><span className="mx-overline">新连接</span><h2 id="mx-form-title">接入一个模型来源</h2><p>一套登录或 API Key 是一个独立来源，可继续添加备用账号。</p></div>
+          <button type="button" aria-label="关闭表单" onClick={onClose}><X size={20} /></button>
+        </header>
+
+        {variant === "rail" && <div className="mx-steps" aria-label="配置步骤"><span className="is-active">1 来源</span><span>2 凭据</span><span>3 模型</span></div>}
+
+        <form onSubmit={submit}>
+          <fieldset className="mx-source-choices">
+            <legend>连接方式</legend>
+            {[
+              { id: "api", label: "API Key", icon: <KeyRound size={17} /> },
+              { id: "codex", label: "Codex 登录", icon: <LogIn size={17} /> },
+              { id: "opencode", label: "OpenCode", icon: <Layers3 size={17} /> },
+            ].map((item) => (
+              <label key={item.id} className={source === item.id ? "is-active" : ""}>
+                <input type="radio" name="source" value={item.id} checked={source === item.id} onChange={() => setSource(item.id)} />
+                {item.icon}<span>{item.label}</span><Check size={16} />
+              </label>
+            ))}
+          </fieldset>
+
+          <div className="mx-form-grid">
+            <label><span>来源名称</span><input ref={nameRef} required defaultValue={source === "api" ? "DeepSeek 官方" : ""} placeholder="例如：OpenCode Go 主账号" /></label>
+            {source === "api" ? (
+              <>
+                <label className="mx-secret"><span>API Key</span><input required type={showKey ? "text" : "password"} defaultValue="sk-demo-not-a-real-key" /><button type="button" aria-label={showKey ? "隐藏 API Key" : "显示 API Key"} onClick={() => setShowKey((value) => !value)}>{showKey ? <EyeOff size={18} /> : <Eye size={18} />}</button></label>
+                <label><span>Base URL</span><input required type="url" defaultValue="https://api.deepseek.com/v1" /></label>
+              </>
+            ) : (
+              <div className="mx-login-hint"><LogIn size={20} /><span><strong>保存后开始安全登录</strong><small>凭据由本机认证存储管理，不会显示完整 Token。</small></span></div>
+            )}
+            <label><span>模型名称</span><input required defaultValue={source === "api" ? "deepseek-chat" : ""} placeholder="例如：deepseek-v4-flash" /></label>
+            <label><span>默认思考强度</span><select defaultValue="high"><option value="low">低</option><option value="medium">中</option><option value="high">高</option><option value="xhigh">极高</option></select></label>
+          </div>
+          <p className="mx-form-note">上下文长度、多模态与可选强度由模型注册表识别；识别不到时再显示高级覆盖项。</p>
+          <footer><button type="button" className="mx-text-button" onClick={onClose}>取消</button><motion.button type="submit" className="mx-primary-button" whileTap={{ scale: 0.96 }}>保存并验证<ArrowRight size={17} /></motion.button></footer>
+        </form>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function MemohSwitch({ checked, label, onChange }: { checked: boolean; label: string; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      className="mx-memoh-switch"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={onChange}
+    >
+      <span />
+    </button>
+  );
+}
+
+function MemohProviderCard({
+  provider,
+  template = false,
+  onOpen,
+}: {
+  provider: MemohProvider;
+  template?: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <motion.button type="button" className="mx-memoh-provider-card" onClick={onOpen} whileTap={{ scale: 0.98 }}>
+      <BrandIcon name={provider.icon} size={23} />
+      <span className="mx-memoh-provider-card__copy">
+        <strong>{provider.name}</strong>
+        <small>{provider.description}</small>
+      </span>
+      {template ? (
+        <span className="mx-memoh-provider-card__action">配置 <ChevronRight size={16} /></span>
+      ) : (
+        <span className="mx-memoh-provider-card__meta">
+          <small>{provider.models.length} 个模型</small>
+          <i><span />已连接</i>
+        </span>
+      )}
+    </motion.button>
+  );
+}
+
+function MemohModelRow({ model }: { model: MemohModel }) {
+  const [enabled, setEnabled] = useState(model.enabled);
+  const [effort, setEffort] = useState(model.effort);
+  const [testing, setTesting] = useState(false);
+
+  function testModel() {
+    setTesting(true);
+    window.setTimeout(() => setTesting(false), 900);
+  }
+
+  return (
+    <div className="mx-memoh-model-row">
+      <span className="mx-memoh-model-row__copy"><strong>{model.name}</strong><small>{model.metadata}</small></span>
+      <label className="mx-memoh-effort">
+        <span>思考强度</span>
+        <select value={effort} onChange={(event) => setEffort(event.target.value)} aria-label={`${model.name} 默认思考强度`}>
+          <option>低</option><option>中</option><option>高</option><option>极高</option>
+        </select>
+      </label>
+      <button type="button" className={`mx-memoh-icon-button ${testing ? "is-testing" : ""}`} onClick={testModel} aria-label={`测试 ${model.name}`}>
+        {testing ? <RefreshCw size={17} /> : <Zap size={17} />}
+      </button>
+      <MemohSwitch checked={enabled} label={`${enabled ? "停用" : "启用"} ${model.name}`} onChange={() => setEnabled((value) => !value)} />
+    </div>
+  );
+}
+
+function MemohProviderDetail({
+  provider,
+  onBack,
+  onSaved,
+}: {
+  provider: MemohProvider;
+  onBack: () => void;
+  onSaved: (message: string) => void;
+}) {
+  const [enabled, setEnabled] = useState(provider.status === "已连接");
+  const [showKey, setShowKey] = useState(false);
+  const [query, setQuery] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const isLogin = provider.kind === "codex" || provider.kind === "opencode";
+  const isDraft = provider.status === "未配置";
+  const models = provider.models.filter((model) => model.name.toLowerCase().includes(query.toLowerCase()));
+
+  function saveProvider(event: FormEvent) {
+    event.preventDefault();
+    onSaved(isDraft ? "连接已创建，正在读取模型目录。" : "配置已保存，新的请求将使用本次设置。");
+  }
+
+  function refreshModels() {
+    setRefreshing(true);
+    window.setTimeout(() => {
+      setRefreshing(false);
+      onSaved("模型目录已同步；能力信息来自注册表。 ");
+    }, 900);
+  }
+
+  return (
+    <motion.div className="mx-memoh-detail" initial={{ opacity: 0, x: 18 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 0.24 }}>
+      <button type="button" className="mx-memoh-back" onClick={onBack}><ArrowLeft size={18} />全部连接</button>
+
+      <section className="mx-memoh-identity">
+        <BrandIcon name={provider.icon} size={28} />
+        <span><small>{isDraft ? "新建连接" : provider.clientType}</small><h2>{provider.name}</h2></span>
+        {!isDraft && <button type="button" className="mx-memoh-icon-button mx-memoh-delete" aria-label={`删除 ${provider.name}`}><Trash2 size={18} /></button>}
+        <span className="mx-memoh-enabled"><small>{enabled ? "已启用" : "已停用"}</small><MemohSwitch checked={enabled} label={`${enabled ? "停用" : "启用"}连接`} onChange={() => setEnabled((value) => !value)} /></span>
+      </section>
+
+      <form className="mx-memoh-section" onSubmit={saveProvider}>
+        <header><div><h3>连接配置</h3><p>{isLogin ? "账号授权由本机安全存储管理。" : "密钥保存后只显示模糊状态，不会重新回填明文。"}</p></div></header>
+        <div className="mx-memoh-config-grid">
+          <label><span>连接名称</span><input required defaultValue={provider.name} /></label>
+          {isLogin ? (
+            <div className="mx-memoh-account">
+              <span className="mx-memoh-account__icon"><ShieldCheck size={20} /></span>
+              <span><strong>{provider.account ?? "尚未登录"}</strong><small>{isDraft ? "登录后自动同步可用模型" : "授权有效 · 凭据不会显示在网页中"}</small></span>
+              <button type="button" onClick={() => onSaved(isDraft ? "已打开安全登录流程。" : "已准备重新授权。")}>{isDraft ? "开始登录" : "重新连接"}</button>
+            </div>
+          ) : (
+            <>
+              <label><span>兼容协议</span><select defaultValue={provider.clientType}><option>OpenAI Compatible</option><option>Anthropic</option><option>Google Generative AI</option></select></label>
+              <label className="mx-memoh-field-wide"><span>Base URL</span><input required type="url" defaultValue={provider.baseUrl} placeholder="https://api.example.com/v1" /></label>
+              <label className="mx-secret mx-memoh-field-wide"><span>API Key</span><input required type={showKey ? "text" : "password"} defaultValue={provider.secret} placeholder="sk-…" /><button type="button" aria-label={showKey ? "隐藏 API Key" : "显示 API Key"} onClick={() => setShowKey((value) => !value)}>{showKey ? <EyeOff size={18} /> : <Eye size={18} />}</button></label>
+            </>
+          )}
+        </div>
+        <div className="mx-memoh-form-footer">
+          <span><ShieldCheck size={16} />凭据仅保存在本机</span>
+          <motion.button type="submit" className="mx-primary-button" whileTap={{ scale: 0.96 }}>{isDraft && isLogin ? "继续登录" : isDraft ? "保存并检测" : "保存更改"}</motion.button>
+        </div>
+      </form>
+
+      <section className="mx-memoh-section mx-memoh-models">
+        <header>
+          <div><h3>模型目录</h3><p>从 Provider 拉取模型，再由注册表补全上下文、视觉和推理能力。</p></div>
+          <button type="button" className="mx-memoh-secondary-button" onClick={refreshModels}><RefreshCw size={16} className={refreshing ? "is-spinning" : ""} />{refreshing ? "同步中" : "刷新模型"}</button>
+        </header>
+        {provider.models.length > 0 ? (
+          <>
+            <label className="mx-memoh-search"><Search size={17} /><span className="sr-only">搜索此连接的模型</span><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索此连接的模型" /></label>
+            <div className="mx-memoh-model-list">{models.map((model) => <MemohModelRow key={model.id} model={model} />)}</div>
+          </>
+        ) : (
+          <div className="mx-memoh-empty"><RefreshCw size={21} /><strong>保存后自动发现模型</strong><span>如果服务不支持模型列表，再允许手动填写 model name。</span></div>
+        )}
+        <p className="mx-memoh-capability-note">识别失败时才显示“高级覆盖”，默认不要求填写上下文长度或是否多模态。</p>
+      </section>
+    </motion.div>
+  );
+}
+
+function MemohAddProviderDialog({ onClose, onSaved }: { onClose: () => void; onSaved: (message: string) => void }) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [kind, setKind] = useState<MemohProviderKind>("api");
+  const [showKey, setShowKey] = useState(false);
+  const [manualModel, setManualModel] = useState(false);
+  const isLogin = kind === "codex" || kind === "opencode";
+
+  useEffect(() => {
+    nameRef.current?.focus();
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+      if (event.key !== "Tab" || !panelRef.current) return;
+      const focusable = Array.from(panelRef.current.querySelectorAll<HTMLElement>("button, input, select"));
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    onSaved(isLogin ? "连接已保存，接下来完成安全登录。" : "连接已保存，API Key 已加密并开始发现模型。 ");
+  }
+
+  return (
+    <motion.div className="mx-scrim" role="presentation" initial={{ opacity: 0 }} animate={{ opacity: 1 }} onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>
+      <motion.div ref={panelRef} className="mx-memoh-dialog" role="dialog" aria-modal="true" aria-labelledby="mx-memoh-add-title" initial={{ opacity: 0, y: 18, scale: 0.98 }} animate={{ opacity: 1, y: 0, scale: 1 }} transition={{ type: "spring", duration: 0.3, bounce: 0 }}>
+        <header><div><span className="mx-overline">添加 Provider</span><h2 id="mx-memoh-add-title">新建模型连接</h2><p>先选择认证方式，只填写这一类连接真正需要的字段。</p></div><button type="button" className="mx-memoh-icon-button" onClick={onClose} aria-label="关闭"><X size={20} /></button></header>
+        <form onSubmit={submit}>
+          <fieldset className="mx-memoh-kind-picker">
+            <legend>认证方式</legend>
+            {[
+              { id: "api", label: "API Key", detail: "Base URL + 密钥", icon: <KeyRound size={18} /> },
+              { id: "codex", label: "Codex 登录", detail: "订阅账号授权", icon: <LogIn size={18} /> },
+              { id: "opencode", label: "OpenCode", detail: "账号登录", icon: <Layers3 size={18} /> },
+              { id: "custom", label: "自定义", detail: "选择兼容协议", icon: <Settings2 size={18} /> },
+            ].map((item) => (
+              <label key={item.id} className={kind === item.id ? "is-active" : ""}>
+                <input type="radio" name="memoh-kind" value={item.id} checked={kind === item.id} onChange={() => { setKind(item.id as MemohProviderKind); setManualModel(false); }} />
+                {item.icon}<span><strong>{item.label}</strong><small>{item.detail}</small></span><Check size={16} />
+              </label>
+            ))}
+          </fieldset>
+
+          <div className="mx-memoh-config-grid">
+            <label className="mx-memoh-field-wide"><span>连接名称</span><input ref={nameRef} required placeholder={kind === "codex" ? "Codex 订阅" : kind === "opencode" ? "OpenCode Go 主账号" : "例如：DeepSeek 官方"} /></label>
+            {isLogin ? (
+              <div className="mx-memoh-account mx-memoh-field-wide"><span className="mx-memoh-account__icon"><ShieldCheck size={20} /></span><span><strong>无需填写 API Key</strong><small>保存后打开官方授权；完成后自动同步模型。</small></span></div>
+            ) : (
+              <>
+                {kind === "custom" && <label><span>兼容协议</span><select defaultValue="OpenAI Compatible"><option>OpenAI Compatible</option><option>Anthropic</option><option>Google Generative AI</option></select></label>}
+                <label className={kind === "api" ? "mx-memoh-field-wide" : ""}><span>Base URL</span><input required type="url" placeholder="https://api.example.com/v1" /></label>
+                <label className="mx-secret mx-memoh-field-wide"><span>API Key</span><input required type={showKey ? "text" : "password"} placeholder="sk-…" /><button type="button" aria-label={showKey ? "隐藏 API Key" : "显示 API Key"} onClick={() => setShowKey((value) => !value)}>{showKey ? <EyeOff size={18} /> : <Eye size={18} />}</button></label>
+                <label className="mx-memoh-discovery mx-memoh-field-wide"><input type="checkbox" checked={manualModel} onChange={(event) => setManualModel(event.target.checked)} /><span><strong>服务不支持模型发现</strong><small>仅此时手动填写 model name。</small></span></label>
+                {manualModel && <><label><span>Model name</span><input required placeholder="deepseek-chat" /></label><label><span>默认思考强度</span><select defaultValue="high"><option value="low">低</option><option value="medium">中</option><option value="high">高</option><option value="xhigh">极高</option></select></label></>}
+              </>
+            )}
+          </div>
+          <p className="mx-form-note">上下文窗口、多模态和缓存统计字段由注册表及真实响应归一化，不进入首次配置表单。</p>
+          <footer><button type="button" className="mx-text-button" onClick={onClose}>取消</button><motion.button type="submit" className="mx-primary-button" whileTap={{ scale: 0.96 }}>{isLogin ? "保存并登录" : "保存并检测"}<ArrowRight size={17} /></motion.button></footer>
+        </form>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function MemohSettingsPrototype() {
+  const [selected, setSelected] = useState<MemohProvider | null>(null);
+  const [query, setQuery] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [toast, setToast] = useState("");
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+  const normalizedQuery = query.trim().toLowerCase();
+  const connected = MEMOH_PROVIDERS.filter((provider) => `${provider.name} ${provider.description}`.toLowerCase().includes(normalizedQuery));
+  const templates = MEMOH_TEMPLATES.filter((provider) => `${provider.name} ${provider.description}`.toLowerCase().includes(normalizedQuery));
+
+  function showToast(message: string) {
+    setDialogOpen(false);
+    setToast(message);
+    window.setTimeout(() => setToast(""), 2800);
+    window.setTimeout(() => addButtonRef.current?.focus(), 0);
+  }
+
+  if (selected) {
+    return (
+      <section className="mx-settings mx-settings--dock mx-memoh-settings" aria-label="Memoh 风格模型配置原型">
+        <MemohProviderDetail provider={selected} onBack={() => setSelected(null)} onSaved={showToast} />
+        {createPortal(<div className="mx-toast-region" aria-live="polite" aria-atomic="true">{toast && <motion.div className="mx-toast" role="status" initial={{ opacity: 0, y: 16, scale: 0.96 }} animate={{ opacity: 1, y: 0, scale: 1 }}><Check size={18} /><span><strong>操作成功</strong><small>{toast}</small></span></motion.div>}</div>, document.body)}
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-settings mx-settings--dock mx-memoh-settings" aria-label="Memoh 风格模型配置原型">
+      <header className="mx-memoh-page-header">
+        <div><span className="mx-overline">设置 · Provider</span><h2>模型连接</h2><p>像 Memoh 一样按 Provider 实例管理账号、密钥与模型目录。</p></div>
+        <motion.button ref={addButtonRef} type="button" className="mx-primary-button" onClick={() => setDialogOpen(true)} whileTap={{ scale: 0.96 }}><Plus size={18} />添加连接</motion.button>
+      </header>
+      <label className="mx-memoh-search mx-memoh-search--page"><Search size={18} /><span className="sr-only">搜索 Provider</span><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索连接或模板" /></label>
+
+      <section className="mx-memoh-gallery-section">
+        <header><div><h3>已连接</h3><p>每套凭据都是独立实例，同一供应商可以添加多个账号。</p></div><span>{connected.length} 个</span></header>
+        <div className="mx-memoh-gallery">{connected.map((provider) => <MemohProviderCard key={provider.id} provider={provider} onOpen={() => setSelected(provider)} />)}</div>
+      </section>
+      <section className="mx-memoh-gallery-section mx-memoh-gallery-section--templates">
+        <header><div><h3>添加 Provider</h3><p>选择模板后预填协议与 Base URL，再完成认证。</p></div></header>
+        <div className="mx-memoh-gallery">{templates.map((provider) => <MemohProviderCard key={provider.id} provider={provider} template onOpen={() => setSelected(provider)} />)}</div>
+      </section>
+
+      {createPortal(
+        <>
+          {dialogOpen && <MemohAddProviderDialog onClose={() => { setDialogOpen(false); window.setTimeout(() => addButtonRef.current?.focus(), 0); }} onSaved={showToast} />}
+          <div className="mx-toast-region" aria-live="polite" aria-atomic="true">{toast && <motion.div className="mx-toast" role="status" initial={{ opacity: 0, y: 16, scale: 0.96 }} animate={{ opacity: 1, y: 0, scale: 1 }}><Check size={18} /><span><strong>连接已保存</strong><small>{toast}</small></span></motion.div>}</div>
+        </>,
+        document.body,
+      )}
+    </section>
+  );
+}
+
+function GenericSettingsPrototype({ variant }: { variant: VariantId }) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [toast, setToast] = useState(false);
+  const title = variant === "command" ? "搜索与管理来源" : variant === "deck" ? "模型来源详情" : "模型与连接";
+
+  function saved() {
+    setFormOpen(false);
+    setToast(true);
+    window.setTimeout(() => setToast(false), 2600);
+  }
+
+  return (
+    <section className={`mx-settings mx-settings--${variant}`} aria-label={`${variant} 模型配置原型`}>
+      <header className="mx-settings__header">
+        <div><span className="mx-overline">设置 · 模型</span><h2>{title}</h2><p>每套凭据是一个具名来源；同一 Provider 可以添加多个账号。</p></div>
+        <motion.button type="button" className="mx-primary-button" onClick={() => setFormOpen(true)} whileTap={{ scale: 0.96 }}><Plus size={18} />添加来源</motion.button>
+      </header>
+      {variant === "command" && <label className="mx-settings-search"><Search size={18} /><span className="sr-only">搜索连接</span><input placeholder="搜索来源、模型或凭据类型" /><kbd>⌘ K</kbd></label>}
+      {variant === "deck" && <aside className="mx-source-index"><strong>来源</strong><button type="button" className="is-active">全部 <span>4</span></button><button type="button">登录 <span>2</span></button><button type="button">API Key <span>2</span></button></aside>}
+      <div className="mx-connection-list">
+        {CONNECTIONS.map((connection) => <ConnectionRow key={connection.id} connection={connection} variant={variant} />)}
+      </div>
+      {variant === "rail" && <div className="mx-role-bindings"><SlidersHorizontal size={19} /><span><strong>角色默认值</strong><small>默认 · gpt-5.2-codex；快速 · deepseek-v4-flash</small></span><button type="button">调整</button></div>}
+
+      {createPortal(
+        <>
+          {formOpen && <ConnectionForm variant={variant} onClose={() => setFormOpen(false)} onSaved={saved} />}
+          <div className="mx-toast-region" aria-live="polite" aria-atomic="true">
+            {toast && <motion.div className="mx-toast" role="status" initial={{ opacity: 0, y: 16, scale: 0.96 }} animate={{ opacity: 1, y: 0, scale: 1 }}><Check size={18} /><span><strong>来源已保存</strong><small>连接验证通过，模型信息已识别。</small></span></motion.div>}
+          </div>
+        </>,
+        document.body,
+      )}
+    </section>
+  );
+}
+
+function SettingsPrototype({ variant }: { variant: VariantId }) {
+  return variant === "dock" ? <MemohSettingsPrototype /> : <GenericSettingsPrototype variant={variant} />;
+}
+
+/** Present five equally weighted interaction directions for model setup and per-turn selection. */
+export function ModelExperienceShowcase() {
+  const [variant, setVariant] = useState<VariantId>("dock");
+  const [surface, setSurface] = useState<Surface>("chat");
+  const active = VARIANTS.find((item) => item.id === variant) ?? VARIANTS[0];
+
+  function onVariantKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const next = (index + (event.key === "ArrowRight" ? 1 : -1) + VARIANTS.length) % VARIANTS.length;
+    setVariant(VARIANTS[next].id);
+    document.getElementById(`mx-variant-${VARIANTS[next].id}`)?.focus();
+  }
+
+  return (
+    <main className="model-experience-showcase">
+      <header className="mx-showcase-header">
+        <div><span className="mx-overline">AKASHIC · INTERACTION STUDY</span><h1>模型体验，五个等权方向</h1><p>每版都覆盖多凭据配置、模糊表单、保存 Toast，以及聊天框上方的动态模型选择。</p></div>
+        <div className="mx-surface-switch" role="tablist" aria-label="预览页面">
+          <button type="button" role="tab" aria-selected={surface === "chat"} onClick={() => setSurface("chat")}>对话选模</button>
+          <button type="button" role="tab" aria-selected={surface === "settings"} onClick={() => setSurface("settings")}>模型配置</button>
+        </div>
+      </header>
+      <nav className="mx-variant-tabs" role="tablist" aria-label="五个等权设计版本">
+        {VARIANTS.map((item, index) => (
+          <button
+            id={`mx-variant-${item.id}`}
+            type="button"
+            role="tab"
+            aria-selected={variant === item.id}
+            key={item.id}
+            onClick={() => setVariant(item.id)}
+            onKeyDown={(event) => onVariantKeyDown(event, index)}
+          >
+            <span>{item.number}</span><strong>{item.name}</strong><small>{item.note}</small>
+          </button>
+        ))}
+      </nav>
+      <div className="mx-version-caption"><span>方案 {active.number} / 05</span><strong>{active.name}</strong><p>{active.note}</p></div>
+      <motion.div key={`${variant}-${surface}`} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.24 }}>
+        {surface === "chat" ? <ChatPrototype variant={variant} /> : <SettingsPrototype variant={variant} />}
+      </motion.div>
+      <p className="mx-prototype-note">交互原型 · 使用演示数据，不保存或发送任何凭据</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## 问题与结果

- 解决的问题：生产聊天交互与大型设计预览混在同一 PR 难以 review，且新 `main` 已占用 ADR 0025/RUN-008。
- 用户可见结果：单独保留五版模型交互预览，并对账最终持久化、onboarding、execution lease 和 GUI 验证文档。
- 本 PR 不处理：生产胶囊逻辑（在 #334）、设置 UI（在 #333）。

## Change intent

- `change_type`：`docs`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：模型交互预览与项目工作手册
- `runtime_patch`：`none`
- `authoritative_state_owner`：不新增运行状态；文档对账 #330–#334

## 改动范围

- 主要文件：`frontend/chat/src/model-experience-showcase.*`、`docs/design/runtime-model-registry-and-onboarding.md`、ADR 0026/0027。
- 对账调整：因最新 `main` 已新增 ADR 0025 和 RUN-008，本功能 ADR 顺延为 0026/0027，模型条款顺延为 RUN-009–RUN-012。
- 回滚方式：回退 `0c272d75`；原单体 PR 保留在 `backup/pr327-monolith-20260807`，改写前恢复点保留在 `backup/runtime-model-stack-pre-locked-runtime-fix-20260807`。

## 验证

- [x] 常规后端全量测试：2795 passed，2 skipped（独立 Harbor benchmark 工具链不在此 venv）。
- [x] TypeScript typecheck 和完整 ESLint 通过。
- [x] Dashboard/Chat production build 通过；#334 另在 clean worktree 独立构建通过。
- [x] `python docker/debug/gate.py run --base origin/main` 通过。
- [x] Arch Python 3.14 Docker 冷构建通过，LiteLLM/tokenizers 从官方 PyPI 成功安装。
- `sourceDigest`：`e711fffcdafbeb3dd1598ccc8c7b81a7b61dbdd1edbb9980015903bbaa118046`
- `planDigest`：`7d51876c56b609b8101d5a0936aefb7864a7849602c08668f039c84cd994c597`
- Gate 报告：`docker/debug/reports/change-gate/20260807-202541-b338a9c2`
- 真实 Provider GUI 证据：沿用本堆栈源自原 #327 的隔离容器验证；拆分后又重跑了最新 `main` 上的累计测试与 Gate。

## 工作手册

- [x] 已核对 `projectneed.md`、ADR、设计文档和持久化地图。
- [x] 长期语义变化已获得维护者确认。
- [x] 本 PR 是 6/6，adjacent diff 为 `stack/runtime-model-chat...feature/runtime-model-registry`。

## PR 堆栈

#330 → #331 → #332 → #333 → #334 → **#327**
