### PR TITLE
[interaction delete 1/2] 原子撤销完整 transcript

### DIFF
--- a/bootstrap/dashboard_api.py
+++ b/bootstrap/dashboard_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 import inspect
 from pathlib import Path, PureWindowsPath
@@ -13,7 +14,7 @@ import threading
 import os
 import shutil
 from types import ModuleType
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 import subprocess
 
@@ -34,7 +35,11 @@ from bootstrap.cleanup import run_cleanup_steps
 from agent.memory import MemoryStore
 from proactive_v2.memory_optimizer import MemoryOptimizerBusy
 from core.memory.engine import MemoryAdminApi
-from session.store import SessionStore
+from session.store import (
+    InteractionDeletion,
+    InteractionDeleteRequiredError,
+    SessionStore,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +172,25 @@ class ManualMemoryOptimizer(Protocol):
     def is_running(self) -> bool: ...
 
     async def optimize(self) -> None: ...
+
+
+@runtime_checkable
+class InteractionDeletionMemoryAdmin(Protocol):
+    async def delete_interaction_source(
+        self,
+        control_turn_id: str,
+        delete_source: Callable[[], InteractionDeletion | None],
+    ) -> InteractionDeletion | None: ...
+
+
+def _interaction_delete_detail(
+    exc: InteractionDeleteRequiredError,
+) -> dict[str, str]:
+    return {
+        "code": "interaction_delete_required",
+        "message_id": exc.message_id,
+        "control_turn_id": exc.control_turn_id,
+    }
 
 
 class ProactiveDashboardReader:
@@ -1112,15 +1136,64 @@ def create_dashboard_app(
 
     @app.delete("/api/dashboard/messages/{message_id:path}")
     def delete_message(message_id: str) -> dict[str, Any]:
-        deleted = store.delete_message(message_id)
+        try:
+            deleted = store.delete_message(message_id)
+        except InteractionDeleteRequiredError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=_interaction_delete_detail(exc),
+            ) from exc
         if not deleted:
             raise HTTPException(status_code=404, detail="message 不存在")
         return {"deleted": True, "id": message_id}
 
     @app.post("/api/dashboard/messages/batch-delete")
     def delete_messages_batch(payload: MessageBatchDeletePayload) -> dict[str, Any]:
-        deleted_count = store.delete_messages_batch(payload.ids)
+        try:
+            deleted_count = store.delete_messages_batch(payload.ids)
+        except InteractionDeleteRequiredError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=_interaction_delete_detail(exc),
+            ) from exc
         return {"deleted_count": deleted_count}
+
+    @app.delete("/api/dashboard/interactions/{control_turn_id:path}")
+    async def delete_interaction(control_turn_id: str) -> dict[str, Any]:
+        """撤销完整 transcript，并让启用的派生记忆同步收敛。"""
+
+        # 1. Akasha 必须先声明同步能力，避免删源后继续服务陈旧图。
+        reconciler = (
+            memory_admin
+            if isinstance(memory_admin, InteractionDeletionMemoryAdmin)
+            else None
+        )
+        if memory_admin.describe().name == "akasha" and reconciler is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Akasha interaction 删除同步能力不可用",
+            )
+
+        # 2. Akasha 先封住读写再执行窄删除回调；其他引擎只改 SessionDB。
+        deletion = (
+            await reconciler.delete_interaction_source(
+                control_turn_id,
+                lambda: store.delete_interaction(control_turn_id),
+            )
+            if reconciler is not None
+            else store.delete_interaction(control_turn_id)
+        )
+        if deletion is None:
+            raise HTTPException(status_code=404, detail="interaction 不存在")
+        return {
+            "deleted": True,
+            "control_turn_id": deletion.control_turn_id,
+            "session_key": deletion.session_key,
+            "message_ids": list(deletion.message_ids),
+            "old_last_consolidated": deletion.old_last_consolidated,
+            "new_last_consolidated": deletion.new_last_consolidated,
+            "backup_path": deletion.backup_path,
+        }
 
     @app.get("/api/dashboard/memories")
     def list_memories(

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -58,11 +58,12 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 
 | 对象 | 正常增加 | 允许的原位或逻辑变化 | 允许物理减少的条件 |
 |---|---|---|---|
-| `sessions.db/messages` | 每次持久化一批新消息时 INSERT；同一 session 的 `seq` 单调增加且不复用 | 正常收发不改旧正文；当前代码存在显式 `update_message`，但它是否属于获授权产品语义仍待确认 | 只有用户主动撤销消息或删除会话/线程，管理命令才能 DELETE，并声明目标、cascade、备份和审计 |
+| `sessions.db/messages` | 每次持久化一批新消息时 INSERT；同一 session 的 `seq` 单调增加且不复用 | 正常收发不改旧正文；当前代码存在显式 `update_message`，但它是否属于获授权产品语义仍待确认 | 只有用户主动撤销消息或删除会话/线程，管理命令才能 DELETE；带 `control_turn_id` 的显式 interaction 只能整组原子撤销，并声明目标、cascade、备份和审计 |
 | `sessions.db/sessions` | 新 session INSERT；已有 session 的新消息仍追加到 `messages` | 允许更新名称、时间、高水位、consolidation 游标和主动流程时间等 session metadata | 只有用户主动删除 session/thread 时，由 session 管理边界级联删除 |
 | `sessions.db/turns` | 新 turn 先 INSERT 为 queued | 按状态机更新 items、usage、error、final response 和终态；这是同一 turn 的进展，不是改写对话正文 | 当前只有显式 thread/session 删除路径可以减少；是否另设 retention 仍待确认 |
 | FTS 与 `message_embeddings` | 由新消息触发建索引或计算向量 | FTS 可以从正文重建；embedding 迁移属于独立流程。Akasha 确定性重建必须复用 sessions 中已存向量 | 用户撤销/删除原始消息时同步减少，或由独立索引维护流程重建；上下文裁切无权删除 |
 | `uploads/` | 每个新附件写入新的 UUID 文件 | 当前没有生产代码原位改写附件；消息引用决定附件仍然有效 | 消息仍引用时必须保留；当前没有引用计数、级联删除或 GC 协议，因此不得按年龄、当前 prompt 是否使用或代码清理自动删除 |
+| `backups/interaction-deletions/sessions-<uuid>.db` | 每次 interaction 撤销前通过 SQLite online backup 创建完整 SessionDB 快照，并以 `integrity_check` 验证 | 已发布快照不可原位更新；路径随删除响应与审计日志返回 | 当前没有自动 retention；只有名称明确、目标精确的备份管理操作可以删除，不能由普通清理或下一次撤销覆盖 |
 
 这里所说的“`sessions.db` 默认 append-only”，精确含义是：**数据库中的完整对话正文 `messages` 在正常运行中只追加，只有用户主动撤销消息或删除会话才允许减少。** SQLite 文件整体并非字面只追加，因为 `sessions` 元数据、`turns` 状态和派生索引都有受约束的 UPDATE/重建路径。当前 dashboard 已暴露旧消息编辑接口；是否保留这项 UPDATE 例外，是需要维护者明确回答的实现与意图差异。
 
@@ -268,6 +269,8 @@ workspace 之外还有两组明确的全局状态：
 | `message_embedding_migrations` | `MessageEmbeddingStore` | embedding 迁移 | 已导入 source 的幂等记录 |
 
 **F-002：** `plugins.akasha.engine` 明确把 `sessions.db/messages` 标为 truth。正常会话持久化路径只 INSERT 新消息；现有 update/delete/session cascade 方法属于用户数据管理边界，不能由上下文裁切、重构、检索或保留期猜测调用。
+
+**F-002A：** 含 `control_turn_id` 的 transcript 是一个不可拆分的用户数据管理单元。单消息和 generic batch 删除入口必须返回 `interaction_delete_required` 及 `control_turn_id`，由客户端显式转调 interaction 撤销；撤销前创建并验证不可覆盖的完整 SessionDB 快照，再在一个 SessionDB 事务中删除整组 U+A 与对应 `message_embeddings`。若 `last_consolidated` 位于该组内或组后，回退到组前消息边界；响应与日志报告旧/新游标及备份路径，其他消息、`seq` 高水位和附件保持不变。
 
 **F-003：** FTS 在缺失或旧 tokenizer 时会从 `messages` rebuild。独立的 embedding 迁移可以显式生成新模型向量，但这不属于 Akasha 重建；Akasha 只能读取 sessions 中与目标模型匹配的已存向量，缺失或错配必须失败。`message_embeddings` 与完整历史一起受 `CTX-001` 保护，不能在 prompt 裁切中顺带删除。
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -353,6 +353,8 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 
 删除 session、messages 或随之级联的派生索引，必须来自用户主动发起的撤销或删除操作，并经过名称明确的管理命令。命令必须携带用户动作来源、精确目标、cascade 语义、备份和审计证据。裁切、压缩、检索、展示、重放、保留期猜测和普通 refactor 不得调用这些接口。
 
+带显式 interaction identity 的 completed transcript 是不可拆分的删除单元。单消息或 generic batch 入口不得删除其中一部分，必须返回 interaction identity 供客户端向用户确认后转调整组原子撤销；整组撤销先创建可验证恢复快照，再同步删除逐消息 embedding、把位于该组内或组后的 consolidation 游标回退到组前边界。启用的派生记忆必须先声明删除同步能力，否则管理入口拒绝修改权威消息。
+
 ### SES-004 损坏数据在存储边界失败
 
 存储层遇到持久化 JSON、列类型、tool chain、metadata、embedding BLOB 或维度损坏，必须带 session/message 上下文抛错。不得返回空列表、空对象或 cache miss。

--- a/frontend/dashboard/src/api.test.mjs
+++ b/frontend/dashboard/src/api.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ApiError,
+  api,
+  interactionDeleteRequirement,
+} from "./api.ts";
+
+test("api preserves structured interaction delete requirements", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    detail: {
+      code: "interaction_delete_required",
+      message_id: "u2",
+      control_turn_id: "interaction-1",
+    },
+  }), {
+    status: 409,
+    headers: { "Content-Type": "application/json" },
+  });
+
+  try {
+    await assert.rejects(
+      api("/api/dashboard/messages/batch-delete"),
+      (error) => {
+        assert.ok(error instanceof ApiError);
+        assert.equal(error.status, 409);
+        assert.deepEqual(interactionDeleteRequirement(error), {
+          code: "interaction_delete_required",
+          message_id: "u2",
+          control_turn_id: "interaction-1",
+        });
+        return true;
+      },
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("interaction delete requirement rejects unrelated failures", () => {
+  assert.equal(
+    interactionDeleteRequirement(new ApiError(500, "boom", "boom")),
+    null,
+  );
+});

--- a/frontend/dashboard/src/api.ts
+++ b/frontend/dashboard/src/api.ts
@@ -1,5 +1,23 @@
 import type { PageResult } from "./types";
 
+export interface InteractionDeleteRequirement {
+  code: "interaction_delete_required";
+  message_id: string;
+  control_turn_id: string;
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail: unknown;
+
+  constructor(status: number, detail: unknown, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
 export async function api<T = unknown>(url: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(url, {
     headers: {
@@ -9,13 +27,34 @@ export async function api<T = unknown>(url: string, options: RequestInit = {}): 
     ...options,
   });
   if (!response.ok) {
-    const payload = await response.json().catch(() => ({})) as { detail?: string };
-    throw new Error(payload.detail || `请求失败: ${response.status}`);
+    const payload = await response.json().catch(() => ({})) as { detail?: unknown };
+    const detail = payload.detail;
+    const message = typeof detail === "string"
+      ? detail
+      : typeof detail === "object" && detail !== null && typeof (detail as { message?: unknown }).message === "string"
+        ? String((detail as { message: string }).message)
+        : `请求失败: ${response.status}`;
+    throw new ApiError(response.status, detail, message);
   }
   if (response.status === 204) {
     return null as T;
   }
   return response.json() as Promise<T>;
+}
+
+export function interactionDeleteRequirement(error: unknown): InteractionDeleteRequirement | null {
+  if (!(error instanceof ApiError) || error.status !== 409) return null;
+  const detail = error.detail;
+  if (typeof detail !== "object" || detail === null || Array.isArray(detail)) return null;
+  const candidate = detail as Partial<InteractionDeleteRequirement>;
+  if (
+    candidate.code !== "interaction_delete_required"
+    || typeof candidate.message_id !== "string"
+    || !candidate.message_id
+    || typeof candidate.control_turn_id !== "string"
+    || !candidate.control_turn_id
+  ) return null;
+  return candidate as InteractionDeleteRequirement;
 }
 
 export function pageCount(total: number, pageSize: number): number {

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -4,7 +4,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import "@material/web/progress/linear-progress.js";
 import { BookOpenText, Bot, ChevronDown, ChevronLeft, ChevronRight, Gauge, SlidersHorizontal, X } from "lucide-react";
 import "./styles.css";
-import { api, asPageResult, pageCount } from "./api";
+import { api, asPageResult, interactionDeleteRequirement, pageCount } from "./api";
 import {
   encodePath,
   formatSessionKeyForTable,
@@ -342,6 +342,34 @@ function DashboardWorkspace(): React.ReactElement {
       reportError(exc);
     }
   }, [reportError]);
+
+  const deleteSelectedMessages = useCallback(async (ids: string[]): Promise<boolean> => {
+    const pending = new Set(ids);
+    while (pending.size > 0) {
+      try {
+        await api("/api/dashboard/messages/batch-delete", {
+          method: "POST",
+          body: JSON.stringify({ ids: [...pending] }),
+        });
+        return true;
+      } catch (exc) {
+        const requirement = interactionDeleteRequirement(exc);
+        if (!requirement) throw exc;
+        if (!window.confirm("所选消息属于一次完整交互。继续会撤销这一轮的全部用户输入和最终回复，是否继续？")) {
+          return false;
+        }
+        const deletion = await api<{ message_ids: string[] }>(
+          `/api/dashboard/interactions/${encodePath(requirement.control_turn_id)}`,
+          { method: "DELETE" },
+        );
+        for (const messageId of deletion.message_ids) pending.delete(messageId);
+        if (pending.has(requirement.message_id)) {
+          throw new Error("整轮撤销响应未包含触发删除的消息", { cause: exc });
+        }
+      }
+    }
+    return true;
+  }, []);
 
   const loadSessions = useCallback(async () => {
     sessionsRequestRef.current?.abort();
@@ -810,7 +838,7 @@ function DashboardWorkspace(): React.ReactElement {
                         })}>{action.label}</button>
                       ))
                     : <Btn size="sm" variant="danger" onClick={() => void run(async () => {
-                        await api("/api/dashboard/messages/batch-delete", { method: "POST", body: JSON.stringify({ ids: [...selectedMessageIds] }) });
+                        if (!await deleteSelectedMessages([...selectedMessageIds])) return;
                         setSelectedMessageIds(new Set());
                         await refreshCurrentView();
                       })}>批量删除</Btn>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "package:mobile-web": "bash scripts/package-mobile-web.sh",
     "test:shared-chat-showcase": "node --test frontend/chat/src/shared-chat-showcase.test.mjs frontend/chat/src/trace-motion-showcase.test.mjs frontend/chat/src/drawer-island-showcase.test.mjs",
     "test:theme": "node --test frontend/theme/src/theme-catalog.test.mjs",
+    "test:dashboard-api": "node --experimental-strip-types --test frontend/dashboard/src/api.test.mjs",
     "test:mobile-web-state": "node --experimental-strip-types --test frontend/chat/src/message-rendering-policy.test.mjs frontend/chat/src/mobile-message-state.test.mjs frontend/chat/src/mobile-stream-projection.test.mjs frontend/chat/src/mobile-plugin-layout.test.mjs frontend/chat/src/mobile-plugin-query-queue.test.mjs frontend/chat/src/mobile-plugin-result-cache.test.mjs frontend/chat/src/mobile-surface-history.test.mjs",
     "typecheck": "tsc --noEmit"
   },

--- a/session/store.py
+++ b/session/store.py
@@ -4,9 +4,11 @@ import json
 import logging
 import sqlite3
 import threading
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
+from uuid import uuid4
 
 from agent.control.errors import TurnNotFoundError, TurnStateTransitionError
 from agent.control.models import (
@@ -20,6 +22,30 @@ from agent.control.models import (
 from agent.model_runtime.query_compaction import parse_react_compaction
 
 logger = logging.getLogger(__name__)
+
+
+class InteractionDeleteRequiredError(ValueError):
+    """要求调用方按完整 interaction 执行原子撤销。"""
+
+    def __init__(self, message_id: str, control_turn_id: str) -> None:
+        super().__init__(
+            f"message {message_id} 属于 interaction {control_turn_id}，必须整组撤销"
+        )
+        self.message_id = message_id
+        self.control_turn_id = control_turn_id
+
+
+@dataclass(frozen=True)
+class InteractionDeletion:
+    """记录一次完整 interaction 撤销及其游标变化。"""
+
+    control_turn_id: str
+    session_key: str
+    message_ids: tuple[str, ...]
+    first_user_message_id: str
+    old_last_consolidated: int
+    new_last_consolidated: int
+    backup_path: str
 
 _FTS_CAPABILITY_ERROR_MARKERS = (
     "no such module: fts5",
@@ -124,6 +150,62 @@ def _decode_message_extra(
             source=message_id,
         )
     return extra_dict
+
+
+def _message_control_turn_id(
+    raw: str | bytes | bytearray | None,
+    message_id: str,
+) -> str | None:
+    extra = _decode_message_extra(raw, message_id)
+    value = extra.get("control_turn_id")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"message control_turn_id 必须是非空字符串: {message_id}")
+    return value
+
+
+def _validate_deletable_interaction(
+    control_turn_id: str,
+    rows: list[sqlite3.Row],
+) -> str:
+    """校验显式 transcript 完整性并返回首条 user message ID。"""
+
+    # 1. 每一行都必须属于目标 interaction，且只能有一个 terminal assistant。
+    decoded = [
+        (row, _decode_message_extra(row["extra"], str(row["id"])))
+        for row in rows
+    ]
+    if any(extra.get("control_turn_id") != control_turn_id for _, extra in decoded):
+        raise ValueError(f"interaction transcript 身份不一致: {control_turn_id}")
+    users = [(row, extra) for row, extra in decoded if row["role"] == "user"]
+    terminals = [
+        (row, extra)
+        for row, extra in decoded
+        if row["role"] == "assistant" and extra.get("turn_terminal") is True
+    ]
+    if not users or len(terminals) != 1 or len(decoded) != len(users) + 1:
+        raise ValueError(f"interaction transcript 结构无效: {control_turn_id}")
+
+    # 2. ordinal、input count 和 assistant 顺序必须保持完整提交合同。
+    raw_ordinals = [extra.get("turn_input_ordinal") for _, extra in users]
+    if any(
+        not isinstance(value, int) or isinstance(value, bool)
+        for value in raw_ordinals
+    ):
+        raise ValueError(f"interaction input ordinal 不连续: {control_turn_id}")
+    ordinals = cast(list[int], raw_ordinals)
+    if sorted(ordinals) != list(range(len(users))):
+        raise ValueError(f"interaction input ordinal 不连续: {control_turn_id}")
+    assistant, assistant_extra = terminals[0]
+    if assistant_extra.get("turn_input_count") != len(users):
+        raise ValueError(f"interaction input count 不匹配: {control_turn_id}")
+    if any(int(row["seq"]) >= int(assistant["seq"]) for row, _ in users):
+        raise ValueError(f"interaction assistant 顺序无效: {control_turn_id}")
+    first_user = next(
+        row for row, extra in users if extra["turn_input_ordinal"] == 0
+    )
+    return str(first_user["id"])
 
 
 def _validate_model_state(value: object, message_id: str) -> None:
@@ -2104,11 +2186,14 @@ class SessionStore:
     def delete_message(self, message_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
-                "SELECT session_key FROM messages WHERE id = ?",
+                "SELECT session_key, extra FROM messages WHERE id = ?",
                 (message_id,),
             ).fetchone()
             if row is None:
                 return False
+            control_turn_id = _message_control_turn_id(row["extra"], message_id)
+            if control_turn_id is not None:
+                raise InteractionDeleteRequiredError(message_id, control_turn_id)
             session_key = str(row["session_key"])
             cur = self._conn.execute(
                 "DELETE FROM messages WHERE id = ?",
@@ -2131,6 +2216,21 @@ class SessionStore:
         placeholders = ",".join("?" for _ in clean_ids)
         now = datetime.now().astimezone().isoformat()
         with self._lock:
+            explicit_rows = self._conn.execute(
+                f"SELECT id, extra FROM messages WHERE id IN ({placeholders})",
+                tuple(clean_ids),
+            ).fetchall()
+            for row in explicit_rows:
+                message_id = str(row["id"])
+                control_turn_id = _message_control_turn_id(
+                    row["extra"],
+                    message_id,
+                )
+                if control_turn_id is not None:
+                    raise InteractionDeleteRequiredError(
+                        message_id,
+                        control_turn_id,
+                    )
             rows = self._conn.execute(
                 f"SELECT DISTINCT session_key FROM messages WHERE id IN ({placeholders})",
                 tuple(clean_ids),
@@ -2147,6 +2247,155 @@ class SessionStore:
                 )
             self._conn.commit()
         return int(cur.rowcount or 0)
+
+    def delete_interaction(
+        self,
+        control_turn_id: str,
+    ) -> InteractionDeletion | None:
+        """校验并原子撤销一个显式 interaction 及其派生 embedding。"""
+
+        if not isinstance(control_turn_id, str) or not control_turn_id.strip():
+            raise ValueError("control_turn_id 必须是非空字符串")
+        normalized_turn_id = control_turn_id.strip()
+        now = datetime.now().astimezone().isoformat()
+
+        with self._lock:
+            exists = self._conn.execute(
+                """
+                SELECT 1
+                FROM messages
+                WHERE json_extract(COALESCE(extra, '{}'), '$.control_turn_id') = ?
+                LIMIT 1
+                """,
+                (normalized_turn_id,),
+            ).fetchone()
+            if exists is None:
+                return None
+            backup_path = self._backup_before_interaction_delete_locked()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                # 1. 解析完整 transcript，并拒绝跨 session 或非连续结构。
+                rows = self._conn.execute(
+                    """
+                    SELECT id, session_key, seq, role, extra
+                    FROM messages
+                    WHERE json_extract(COALESCE(extra, '{}'), '$.control_turn_id') = ?
+                    ORDER BY session_key, seq
+                    """,
+                    (normalized_turn_id,),
+                ).fetchall()
+                if not rows:
+                    self._conn.rollback()
+                    return None
+                session_keys = {str(row["session_key"]) for row in rows}
+                if len(session_keys) != 1:
+                    raise ValueError(
+                        f"interaction 跨越多个 session: {normalized_turn_id}"
+                    )
+                session_key = next(iter(session_keys))
+                session_rows = self._conn.execute(
+                    """
+                    SELECT id, seq, role, extra
+                    FROM messages
+                    WHERE session_key = ?
+                    ORDER BY seq
+                    """,
+                    (session_key,),
+                ).fetchall()
+                positions = [
+                    index
+                    for index, row in enumerate(session_rows)
+                    if _message_control_turn_id(row["extra"], str(row["id"]))
+                    == normalized_turn_id
+                ]
+                if positions != list(range(positions[0], positions[-1] + 1)):
+                    raise ValueError(
+                        f"interaction transcript 不连续: {normalized_turn_id}"
+                    )
+                turn_rows = [session_rows[index] for index in positions]
+                first_user_message_id = _validate_deletable_interaction(
+                    normalized_turn_id,
+                    turn_rows,
+                )
+
+                # 2. 游标位于组内或组后时回退到组前边界。
+                meta = self._conn.execute(
+                    "SELECT last_consolidated FROM sessions WHERE key = ?",
+                    (session_key,),
+                ).fetchone()
+                if meta is None:
+                    raise ValueError(f"interaction session 不存在: {session_key}")
+                old_cursor = int(meta["last_consolidated"])
+                group_start = positions[0]
+                new_cursor = group_start if old_cursor > group_start else old_cursor
+
+                # 3. 正文、逐消息 embedding 与游标在同一事务中提交。
+                message_ids = tuple(str(row["id"]) for row in turn_rows)
+                placeholders = ",".join("?" for _ in message_ids)
+                self._conn.execute(
+                    f"DELETE FROM messages WHERE id IN ({placeholders})",
+                    message_ids,
+                )
+                self._delete_message_embeddings_locked(list(message_ids))
+                self._conn.execute(
+                    """
+                    UPDATE sessions
+                    SET last_consolidated = ?, updated_at = ?
+                    WHERE key = ?
+                    """,
+                    (new_cursor, now, session_key),
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+
+        deletion = InteractionDeletion(
+            control_turn_id=normalized_turn_id,
+            session_key=session_key,
+            message_ids=message_ids,
+            first_user_message_id=first_user_message_id,
+            old_last_consolidated=old_cursor,
+            new_last_consolidated=new_cursor,
+            backup_path=str(backup_path),
+        )
+        logger.info(
+            "interaction deleted control_turn_id=%s session_key=%s messages=%d "
+            "last_consolidated=%d->%d backup_path=%s",
+            deletion.control_turn_id,
+            deletion.session_key,
+            len(deletion.message_ids),
+            deletion.old_last_consolidated,
+            deletion.new_last_consolidated,
+            deletion.backup_path,
+        )
+        return deletion
+
+    def _backup_before_interaction_delete_locked(self) -> Path:
+        """创建并验证删除前的完整 SessionDB SQLite 快照。"""
+
+        backup_root = Path(self.db_path).parent / "backups" / "interaction-deletions"
+        backup_root.mkdir(parents=True, exist_ok=True)
+        backup_id = uuid4().hex
+        backup_path = backup_root / f"sessions-{backup_id}.db"
+        candidate_path = backup_root / f".sessions-{backup_id}.db.tmp"
+        candidate_path.touch(mode=0o600, exist_ok=False)
+        try:
+            target = sqlite3.connect(candidate_path)
+            try:
+                self._conn.backup(target)
+                rows = target.execute("PRAGMA integrity_check").fetchall()
+                if rows != [("ok",)]:
+                    raise RuntimeError(
+                        f"interaction 删除备份 integrity_check 失败: {rows[:3]}"
+                    )
+            finally:
+                target.close()
+            _ = candidate_path.replace(backup_path)
+        except (OSError, RuntimeError, sqlite3.Error):
+            candidate_path.unlink(missing_ok=True)
+            raise
+        return backup_path
 
     def delete_session_messages_and_update_cursor(
         self,

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -133,6 +133,87 @@ def create_dashboard_app(tmp_path, **kwargs):
     return _create_dashboard_app(tmp_path, **kwargs)
 
 
+def _seed_explicit_interaction(
+    workspace: Path,
+    *,
+    last_consolidated: int,
+) -> tuple[str, list[str]]:
+    store = SessionStore(workspace / "sessions.db")
+    timestamp = "2026-08-07T10:00:00+08:00"
+    rows = store.persist_session(
+        "mobile:review",
+        created_at=timestamp,
+        updated_at=timestamp,
+        last_consolidated=last_consolidated,
+        metadata={},
+        messages=[
+            {
+                "role": "user",
+                "content": "legacy",
+                "timestamp": timestamp,
+                "extra": {},
+            },
+            {
+                "role": "assistant",
+                "content": "old",
+                "timestamp": timestamp,
+                "extra": {},
+            },
+            {
+                "role": "user",
+                "content": "u1",
+                "timestamp": timestamp,
+                "extra": {
+                    "control_turn_id": "turn-review",
+                    "turn_input_ordinal": 0,
+                },
+            },
+            {
+                "role": "user",
+                "content": "u2",
+                "timestamp": timestamp,
+                "extra": {
+                    "control_turn_id": "turn-review",
+                    "turn_input_ordinal": 1,
+                },
+            },
+            {
+                "role": "user",
+                "content": "u3",
+                "timestamp": timestamp,
+                "extra": {
+                    "control_turn_id": "turn-review",
+                    "turn_input_ordinal": 2,
+                },
+            },
+            {
+                "role": "assistant",
+                "content": "final",
+                "timestamp": timestamp,
+                "extra": {
+                    "control_turn_id": "turn-review",
+                    "turn_terminal": True,
+                    "turn_input_count": 3,
+                },
+            },
+            {
+                "role": "user",
+                "content": "later",
+                "timestamp": timestamp,
+                "extra": {},
+            },
+            {
+                "role": "assistant",
+                "content": "later-a",
+                "timestamp": timestamp,
+                "extra": {},
+            },
+        ],
+    )
+    store.close()
+    return "turn-review", [str(row["id"]) for row in rows[2:6]]
+
+
 @pytest.mark.asyncio
 async def test_dashboard_lifespan_swallows_its_own_compile_cancellation(
     tmp_path, monkeypatch
@@ -659,6 +740,99 @@ def test_list_update_and_batch_delete_messages(tmp_path) -> None:
         )
         assert remain_resp.status_code == 200
         assert remain_resp.json()["total"] == 1
+
+
+def test_explicit_interaction_rejects_generic_message_deletes(tmp_path) -> None:
+    turn_id, message_ids = _seed_explicit_interaction(
+        tmp_path,
+        last_consolidated=6,
+    )
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        single = client.delete(f"/api/dashboard/messages/{message_ids[1]}")
+        batch = client.post(
+            "/api/dashboard/messages/batch-delete",
+            json={"ids": message_ids},
+        )
+
+    assert single.status_code == 409
+    assert single.json()["detail"] == {
+        "code": "interaction_delete_required",
+        "message_id": message_ids[1],
+        "control_turn_id": turn_id,
+    }
+    assert batch.status_code == 409
+    assert batch.json()["detail"]["control_turn_id"] == turn_id
+    store = SessionStore(tmp_path / "sessions.db")
+    assert all(store.get_message(message_id) is not None for message_id in message_ids)
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("old_cursor", "expected_cursor"),
+    ((0, 0), (4, 2), (8, 2)),
+)
+def test_delete_interaction_is_atomic_and_repairs_cursor(
+    tmp_path,
+    old_cursor: int,
+    expected_cursor: int,
+) -> None:
+    turn_id, message_ids = _seed_explicit_interaction(
+        tmp_path,
+        last_consolidated=old_cursor,
+    )
+    embedding_store = MessageEmbeddingStore(tmp_path / "sessions.db")
+    message_store = SessionStore(tmp_path / "sessions.db")
+    for message_id in message_ids:
+        message = message_store.get_message(message_id)
+        assert message is not None
+        embedding_store.upsert(
+            message_id=message_id,
+            content=str(message["content"]),
+            model="m",
+            embedding=[1.0, 0.0],
+        )
+    message_store.close()
+    embedding_store.close()
+
+    with TestClient(create_dashboard_app(tmp_path)) as client:
+        response = client.delete(f"/api/dashboard/interactions/{turn_id}")
+
+    assert response.status_code == 200
+    assert response.json()["message_ids"] == message_ids
+    assert response.json()["old_last_consolidated"] == old_cursor
+    assert response.json()["new_last_consolidated"] == expected_cursor
+    backup_path = Path(response.json()["backup_path"])
+    assert backup_path.is_file()
+    assert backup_path.stat().st_mode & 0o777 == 0o600
+    assert list(backup_path.parent.glob(".sessions-*.db.tmp")) == []
+    store = SessionStore(tmp_path / "sessions.db")
+    assert [item["content"] for item in store.fetch_session_messages("mobile:review")] == [
+        "legacy",
+        "old",
+        "later",
+        "later-a",
+    ]
+    meta = store.get_session_meta("mobile:review")
+    assert meta is not None
+    assert meta["last_consolidated"] == expected_cursor
+    with closing(sqlite3.connect(tmp_path / "sessions.db")) as database:
+        assert database.execute(
+            "SELECT COUNT(*) FROM message_embeddings WHERE message_id IN (?, ?, ?, ?)",
+            tuple(message_ids),
+        ).fetchone()[0] == 0
+    store.close()
+
+    restored_path = tmp_path / "restored" / "sessions.db"
+    restored_path.parent.mkdir()
+    shutil.copy2(backup_path, restored_path)
+    restored = SessionStore(restored_path)
+    assert [
+        restored.get_message(message_id) is not None for message_id in message_ids
+    ] == [True, True, True, True]
+    restored_meta = restored.get_session_meta("mobile:review")
+    assert restored_meta is not None
+    assert restored_meta["last_consolidated"] == old_cursor
+    restored.close()
 
 
 def test_list_memory_items_with_filters(tmp_path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：显式 multi-U interaction 仍可被旧的单消息或 generic batch 删除入口拆开，导致 ordinal、history unit、consolidation cursor 与 Akasha source 失去结构完整性。
- 用户可见结果：旧入口对显式 interaction 返回结构化 409（含 `control_turn_id`）；Dashboard 明确提示会撤销整轮 U+A，用户确认后才调用 interaction 级删除。整组删除前创建并验证不可覆盖的 SessionDB 快照，再在一个事务中删除 U+A、逐消息 embedding 并修复 consolidation cursor。
- 本 PR 不处理：Akasha sidecar 的在线重建与 crash-window 收敛，由下一张 stacked PR `fix/akasha-interaction-delete-rebuild` 实现。Akasha 已启用但尚无协调能力时，本 PR 明确返回 503，且不会先删除权威消息。U5 turn embedding store 不在本 PR。

## Stack

- Base：#326（完整 logical interaction 的 memory consumers）
- 当前：#328（SessionDB、Dashboard API 与客户端确认）
- 下一张：#329（Akasha 协调、generation fence 与 sidecar 重建）
- 合并顺序：#326 → #328 → #329；U5 在本栈 review 完成后另开 PR。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`breaking`（仅消息删除管理 API；正常消息收发不变）
- `capability_owner`：`mixed`
- `consumer_scope`：SessionStore、Dashboard API、Dashboard Web 客户端、MemoryAdmin 协调协议
- `runtime_patch`：`required`
- `runtime_patch_reason`：interaction 分组、embedding cascade 与 consolidation cursor 都由服务端权威状态决定；客户端无法安全猜测或复制。
- `authoritative_state_owner`：`session.store.SessionStore`
- `client_only_alternative`：无；客户端只负责展示 409 并取得用户整轮撤销确认。
- 关联不变量：显式 transcript ordinal 连续、唯一 terminal assistant、`turn_input_count` 匹配、interaction 物理连续；消息 `seq` 高水位不复用。
- `protected_state`：其他消息正文与顺序、其他 session、附件、turn ledger、正式 workspace 之外的状态。
- 允许的副作用：用户确认后创建 0600 SQLite 恢复快照；原子删除目标 interaction 与对应 message embeddings；必要时把 `last_consolidated` 回退到组前边界。
- 禁止的副作用：generic 删除拆组、自动删除附件、重写其他消息、Akasha 不可协调时先删 source、自动清理恢复快照。

## 改动范围

- 主要文件：`session/store.py`、`bootstrap/dashboard_api.py`、`frontend/dashboard/src/api.ts`、`frontend/dashboard/src/main.tsx`、对应测试与持久化合同。
- 配置或迁移影响：无配置变更、无 schema migration；新增运行时目录 `backups/interaction-deletions/`，当前无自动 retention。
- 已知 schema lineage 与最终 schema identity：`sessions.db` schema identity 不变；只使用既有 `messages`、`sessions`、`message_embeddings`。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `1aec2ea9`，head `a73f00e8`；stack base PR #326。
- 回滚方式：revert `a73f00e8`；已执行的删除可从响应/日志给出的完整 SQLite 快照隔离恢复。

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_session_store.py tests/test_dashboard_api.py`，60 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过：targeted Pyright 0 errors；Dashboard ESLint、`test:dashboard-api` 2 passed、TypeScript typecheck 通过。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过：`20260807-022216-5f88a689`。
- [ ] 远端 CI：GitHub Actions 当前 `major_outage`；PR 已 ready 并重新打开，但尚未生成 workflow run，恢复后需核对。
- `sourceDigest`：`777d9d9627753e24c1a87707cbbc6d72e53f0a5bf626e46ef5ba0575def04f6c`
- `planDigest`：`3964d316b84ce8ca2da3dce9c52b20bd27a20f32f0bc6f09f83a2e6b67555619`
- 真实设备证据：不适用；本 PR 是 Dashboard 数据管理接口与响应式 Web 客户端，不修改 mobile chat runtime。
- 未运行项与原因：仅远端 CI 因 GitHub Actions 官方故障未运行；本地对应 Gate、类型与测试均已完成。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已由维护者确认：显式 multi-U interaction 只能整组撤销。
- [x] 客户端只消费服务端结构化 409 与 interaction 删除协议，不复制持久化能力 owner。
- [x] `NOW.md` 当前无对应进行中事项，不适用。
