### PR TITLE
[interaction delete 2/2] 重建 Akasha 派生状态

### DIFF
--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -326,7 +326,7 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 
 **F-007B：** 当前 `build_akasha_db.py` 在备份和目标数据库写入前审计全部合法对话 embedding。缺失、内容 hash 不匹配、模型/维度不匹配、非有限或零向量会写出确定性缺口报告并 fail-loud；scheduler、显式 `skip_post_memory` 和双方都为空的纯媒体 turn 不属于学习输入。
 
-**F-007C：** Akasha 启用时，interaction 撤销由 Akasha owner 先封住在线 query/commit，再调用只允许删除目标 interaction 的 SessionStore 回调，递增 source generation、清除所有基于旧图节点生成的 pending ticket，并从剩余 canonical source 生成完整 sidecar 候选。候选按 index→memory 发布；两文件之间的崩溃窗口在下次启动通过 source/index 或 index/memory 身份失配触发确定性重建。删除已提交但重建失败时，运行时保持 fail-loud，不得继续提供旧 turn 节点；重建前已读取消息、但重建后才取得 commit gate 的迟到 `TurnCommitted` 必须因 generation 失配而失效，不能重新写回 embedding。
+**F-007C：** Akasha 启用时，interaction 撤销由 Akasha owner 先以 source-event gate 排空已开始的 `TurnCommitted` embedding + staging，再封住在线 query/commit，调用只允许删除目标 interaction 的 SessionStore 回调，递增 source generation、清除所有基于旧图节点生成的 pending ticket，并从剩余 canonical source 生成完整 sidecar 候选。候选按 index→memory 发布；两文件之间的崩溃窗口在下次启动通过 source/index 或 index/memory 身份失配触发确定性重建。删除已提交但重建失败时，运行时保持 fail-loud，不得继续提供旧 turn 节点；等待删除期间才开始的 source event 必须因 generation 失配而失效，不能重新写回 embedding。
 
 ## 9. 主动流程、Wake、Drift 与调度
 

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -78,7 +78,7 @@ workspace 仍不是完整运行环境的全部。显式主配置、全局凭据�
 | `consolidation_writes.db` | 为新的 `source_ref + kind` INSERT 幂等记录 | 保存已提交 payload 和提交状态 | 当前没有通用自动清理合同；在定义重放窗口和恢复证据前不得减少 |
 | `memory2.db/memory_items` | consolidation 或显式 memorize INSERT 新记忆 | reinforcement 更新强度/元数据；supersede 保留旧条目并改变状态，属于逻辑减少 | 只有用户明确 forget/管理操作可以 hard delete；向量索引可随 canonical 条目重建 |
 | `memory2.db/memory_replacements` | 每次 supersede 追加替换关系与前后条目 | 保留勘误和 undo 证据 | 当前没有普通运行删除协议 |
-| `akasha.db` 与 `akasha-v2-index.db` | 固定算法读取 `sessions.db/messages` 和已有 `message_embeddings`，增加图、激活和查询记录 | 可以用同一组输入确定性重建；只读 Inspector 从既有表派生视图，不新增状态；重建不调用 LLM，也不重新解释历史 | 只能由显式 sidecar rebuild/maintenance 流程在备份后替换；embedding 缺失或模型不匹配时完整重建必须失败，不能跳过后声称成功 |
+| `akasha.db` 与 `akasha-v2-index.db` | 固定算法读取 `sessions.db/messages` 和已有 `message_embeddings`，增加图、激活和查询记录 | 可以用同一组输入确定性重建；用户整组撤销 interaction 后由 Akasha owner 串行全量替换；只读 Inspector 从既有表派生视图，不新增状态；重建不调用 LLM，也不重新解释历史 | 只能由显式 sidecar rebuild/maintenance 或 interaction 撤销协调流程替换；embedding 缺失或模型不匹配时完整重建必须失败，不能跳过后声称成功 |
 
 ### 3.3 自主运行、扩展与控制状态
 
@@ -325,6 +325,8 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 **F-007A：** 同一份 messages、匹配的 message embeddings、算法和配置必须得到可复现的图。算法与配置要作为重建输入固定；改变它们属于显式图迁移，不是同输入重建。
 
 **F-007B：** 当前 `build_akasha_db.py` 在备份和目标数据库写入前审计全部合法对话 embedding。缺失、内容 hash 不匹配、模型/维度不匹配、非有限或零向量会写出确定性缺口报告并 fail-loud；scheduler、显式 `skip_post_memory` 和双方都为空的纯媒体 turn 不属于学习输入。
+
+**F-007C：** Akasha 启用时，interaction 撤销由 Akasha owner 先封住在线 query/commit，再调用只允许删除目标 interaction 的 SessionStore 回调，递增 source generation、清除所有基于旧图节点生成的 pending ticket，并从剩余 canonical source 生成完整 sidecar 候选。候选按 index→memory 发布；两文件之间的崩溃窗口在下次启动通过 source/index 或 index/memory 身份失配触发确定性重建。删除已提交但重建失败时，运行时保持 fail-loud，不得继续提供旧 turn 节点；重建前已读取消息、但重建后才取得 commit gate 的迟到 `TurnCommitted` 必须因 generation 失配而失效，不能重新写回 embedding。
 
 ## 9. 主动流程、Wake、Drift 与调度
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -413,7 +413,7 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 
 `akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有 completed turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
 
-用户按 SES-003 撤销 completed interaction 后，Akasha 必须从剩余固定输入重建 sidecar；source 删除、pending 清理和派生发布由同一管理协调流程串行化。两份 sidecar 之间的发布崩溃窗口必须在重启时通过身份失配确定性收敛；当前进程若未能重建，则 memory query 和管理读取保持 fail-loud。
+用户按 SES-003 撤销 completed interaction 后，Akasha 必须从剩余固定输入重建 sidecar；source event 的 embedding + staging、source 删除、pending 清理和派生发布由同一管理协调流程串行化，不能在新 completed turn 已落库但 embedding 尚未持久化时开始 rebuild。两份 sidecar 之间的发布崩溃窗口必须在重启时通过身份失配确定性收敛；当前进程若未能重建，则 memory query 和管理读取保持 fail-loud。
 
 ### MEM-010 Akasha 对同 Interaction 多输入建立一个确定性样本
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -353,7 +353,7 @@ skills、长期记忆、检索结果和 recent context 必须带来源和信任�
 
 删除 session、messages 或随之级联的派生索引，必须来自用户主动发起的撤销或删除操作，并经过名称明确的管理命令。命令必须携带用户动作来源、精确目标、cascade 语义、备份和审计证据。裁切、压缩、检索、展示、重放、保留期猜测和普通 refactor 不得调用这些接口。
 
-带显式 interaction identity 的 completed transcript 是不可拆分的删除单元。单消息或 generic batch 入口不得删除其中一部分，必须返回 interaction identity 供客户端向用户确认后转调整组原子撤销；整组撤销先创建可验证恢复快照，再同步删除逐消息 embedding、把位于该组内或组后的 consolidation 游标回退到组前边界。启用的派生记忆必须先声明删除同步能力，否则管理入口拒绝修改权威消息。
+带显式 interaction identity 的 completed transcript 是不可拆分的删除单元。单消息或 generic batch 入口不得删除其中一部分，必须返回 interaction identity 供客户端向用户确认后转调整组原子撤销；整组撤销先创建可验证恢复快照，再同步删除逐消息 embedding、把位于该组内或组后的 consolidation 游标回退到组前边界，并由启用的派生记忆 owner 清除对应节点和所有基于旧图生成的 pending 引用。派生重建失败时不得继续提供撤销前的陈旧结果，删除期间已开始的迟到提交也不得重新写回被撤销 embedding。
 
 ### SES-004 损坏数据在存储边界失败
 
@@ -412,6 +412,8 @@ session、channel、chat、source_ref 和预算在每次 post-response run 创�
 ### MEM-009 Akasha 使用固定输入确定性重建
 
 `akasha.db` 和 graph snapshot 是派生 sidecar。完整重建只读取 `sessions.db/messages`、对应的 `message_embeddings`、固定算法和固定配置，不引入 LLM 重新解释历史，也不重新生成已经存在的 embedding。只有 completed turn 属于学习样本；被中断、失败或明确标为 `skip_post_memory` 的 turn 保留在原始会话中，但不要求 embedding，也不进入显式记忆图。同一组输入必须得到可复现的图；合法学习样本缺少或模型不匹配的 embedding 必须使完整重建失败并报告缺口，不能静默跳过后仍声称成功。
+
+用户按 SES-003 撤销 completed interaction 后，Akasha 必须从剩余固定输入重建 sidecar；source 删除、pending 清理和派生发布由同一管理协调流程串行化。两份 sidecar 之间的发布崩溃窗口必须在重启时通过身份失配确定性收敛；当前进程若未能重建，则 memory query 和管理读取保持 fail-loud。
 
 ### MEM-010 Akasha 对同 Interaction 多输入建立一个确定性样本
 

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import math
+import os
+import tempfile
 import threading
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -20,10 +23,16 @@ from ..infrastructure.persistence import (
     memory_turn_count,
     write_memory_database,
 )
-from ..infrastructure.sparse_index import BuildConfig, build_sparse_index
+from ..infrastructure.sparse_index import (
+    AppendOnlyViolation,
+    BuildConfig,
+    build_sparse_index,
+)
 from ..infrastructure.sparse_index.encoding import tokenize
 from .cycle import CycleCommit, MemoryCycle, RetrievalTicket
-from .rebuild import deterministic_metadata
+from .rebuild import deterministic_metadata, rebuild_memory
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -70,6 +79,12 @@ class OnlineMemoryRuntime:
 
     def close(self) -> None:
         self._writer_lease.close()
+
+    def rebuild_from_source(self) -> None:
+        """从 canonical sessions source 全量替换派生索引与图快照。"""
+
+        with self._state_lock:
+            self.cycle = self._fresh_rebuild_from_source()
 
     def query_turn(
         self,
@@ -240,14 +255,18 @@ class OnlineMemoryRuntime:
         """Restore a snapshot and causally catch up any indexed source turns."""
 
         # 1. Bring the derived sparse index to the sessions source boundary.
-        result = build_sparse_index(
-            self.sessions_path,
-            self.index_path,
-            BuildConfig(
-                embedding_model=self.embedding_model,
-                embedding_dimension=self.embedding_dimension,
-            ),
-        )
+        try:
+            result = build_sparse_index(
+                self.sessions_path,
+                self.index_path,
+                self._build_config(),
+            )
+        except AppendOnlyViolation as exc:
+            logger.warning(
+                "Akasha sparse source changed; rebuilding derived state: %s",
+                exc,
+            )
+            return self._fresh_rebuild_from_source()
         turns = load_turns(self.index_path) if result.discovered_turns else []
         if not self.memory_path.exists():
             cycle = MemoryCycle(
@@ -262,8 +281,67 @@ class OnlineMemoryRuntime:
             return self._catch_up(cycle, turns)
 
         # 2. Restore the persisted prefix and replay only crash-window suffixes.
-        cycle, suffix = self._load_persisted_prefix(turns)
+        try:
+            cycle, suffix = self._load_persisted_prefix(turns)
+        except ValueError as exc:
+            logger.warning(
+                "Akasha memory snapshot no longer matches source; rebuilding: %s",
+                exc,
+            )
+            return self._fresh_rebuild_from_source()
         return self._catch_up(cycle, suffix)
+
+    def _fresh_rebuild_from_source(self) -> MemoryCycle:
+        """先生成完整候选，再按 index→memory 顺序发布可恢复派生状态。"""
+
+        # 1. 在目标文件同一文件系统生成并验证完整候选。
+        self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        self.memory_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="akasha-index-rebuild-",
+            dir=self.index_path.parent,
+        ) as index_dir, tempfile.TemporaryDirectory(
+            prefix="akasha-memory-rebuild-",
+            dir=self.memory_path.parent,
+        ) as memory_dir:
+            candidate_index = Path(index_dir) / self.index_path.name
+            candidate_memory = Path(memory_dir) / self.memory_path.name
+            result = build_sparse_index(
+                self.sessions_path,
+                candidate_index,
+                self._build_config(),
+            )
+            if result.discovered_turns:
+                rebuild_memory(
+                    candidate_index,
+                    candidate_memory,
+                    config=self.config,
+                    target_sequences=(),
+                    target_session="",
+                )
+
+            # 2. 先发布 index；其后的崩溃窗口会在重启时重建不匹配 memory。
+            os.replace(candidate_index, self.index_path)
+            if result.discovered_turns:
+                os.replace(candidate_memory, self.memory_path)
+            elif self.memory_path.exists():
+                self.memory_path.unlink()
+
+        # 3. 从刚发布的确定性状态恢复唯一在线 cycle。
+        turns = load_turns(self.index_path) if result.discovered_turns else []
+        if not turns:
+            return MemoryCycle(self.config)
+        cycle, suffix = self._load_persisted_prefix(turns)
+        if suffix:
+            raise RuntimeError("fresh Akasha rebuild left an unpublished suffix")
+        cycle.feature_pool = None
+        return cycle
+
+    def _build_config(self) -> BuildConfig:
+        return BuildConfig(
+            embedding_model=self.embedding_model,
+            embedding_dimension=self.embedding_dimension,
+        )
 
     def _restore_persisted_cycle(self) -> MemoryCycle:
         """Reload exactly the durable prefix after an in-memory write failure."""

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import sqlite3
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +37,7 @@ from core.memory.engine import (
 )
 from memory2.embedder import Embedder
 from session.embedding_store import MessageEmbeddingStore
+from session.store import InteractionDeletion
 
 from .application.cycle import RetrievalTicket
 from .application.runtime import OnlineMemoryRuntime, StagedOnlineCommit
@@ -278,6 +280,8 @@ class AkashaMemoryEngine:
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
+        self._source_generation = 0
+        self._source_invalidated_error: RuntimeError | None = None
         self._staged_feedback: dict[
             str,
             dict[Literal["remember", "forget"], AkashaFeedbackMarker],
@@ -335,6 +339,7 @@ class AkashaMemoryEngine:
         async with self._commit_gate:
             await self._wait_for_publication()
             with self._lock:
+                self._require_valid_source()
                 cue, ticket = self._runtime.query_turn(
                     text=text,
                     dense=dense,
@@ -673,6 +678,7 @@ class AkashaMemoryEngine:
         *,
         limit: int = 200,
     ) -> list[dict[str, object]]:
+        self._require_valid_source()
         selected = [
             turn
             for turn in self._runtime.cycle.turns
@@ -700,6 +706,7 @@ class AkashaMemoryEngine:
         sort_by: str = "created_at",
         sort_order: str = "desc",
     ) -> tuple[list[dict[str, object]], int]:
+        self._require_valid_source()
         del memory_type, status, scope_channel, scope_chat_id
         del has_embedding, sort_by
         rows = [
@@ -732,6 +739,7 @@ class AkashaMemoryEngine:
         *,
         include_embedding: bool = False,
     ) -> dict[str, object] | None:
+        self._require_valid_source()
         _ = include_embedding
         for turn in self._runtime.cycle.turns:
             if turn.turn_id == item_id:
@@ -773,6 +781,7 @@ class AkashaMemoryEngine:
         score_threshold: float = 0.0,
         include_superseded: bool = False,
     ) -> list[dict[str, object]]:
+        self._require_valid_source()
         del memory_type, include_superseded
         turns = self._runtime.cycle.turns
         query = next(
@@ -827,6 +836,7 @@ class AkashaMemoryEngine:
         )
         with self._lock:
             pending = self._pending.get(event.session_key)
+            source_generation = self._source_generation
         if (
             len(user_ids) == 1
             and pending is not None
@@ -843,28 +853,100 @@ class AkashaMemoryEngine:
             vectors = await self._embedder.embed_batch(
                 [cast(str, message["content"]) for message in messages]
             )
-        _upsert_embeddings(
-            self._embedding_store,
-            self._embedding_model,
-            messages,
-            vectors,
-        )
-
         # 3. Serialize durable staging behind the prior graph publication.
         async with self._commit_gate:
             await self._wait_for_publication()
             with self._lock:
+                if source_generation != self._source_generation:
+                    return
+                self._require_valid_source()
+                _upsert_embeddings(
+                    self._embedding_store,
+                    self._embedding_model,
+                    messages,
+                    vectors,
+                )
+                selected_ticket = None
                 if self._pending.get(event.session_key) is pending:
                     self._pending.pop(event.session_key, None)
+                    selected_ticket = None if pending is None else pending.ticket
                 staged = self._runtime.stage_from_source(
                     user_message_id=user_id,
                     assistant_message_id=assistant_id,
-                    ticket=None if pending is None else pending.ticket,
+                    ticket=selected_ticket,
                 )
             self._publish_task = asyncio.create_task(
                 asyncio.to_thread(self._publish_staged, staged),
                 name="akasha-publish-staged",
             )
+
+    async def delete_interaction_source(
+        self,
+        control_turn_id: str,
+        delete_source: Callable[[], InteractionDeletion | None],
+    ) -> InteractionDeletion | None:
+        """封住在线读写，执行窄 source 删除并重建派生状态。"""
+
+        # 1. 与在线 commit 串行，整个 source mutation 窗口不开放旧图。
+        async with self._commit_gate:
+            await self._wait_for_publication()
+            return await asyncio.to_thread(
+                self._delete_source_and_rebuild,
+                control_turn_id,
+                delete_source,
+            )
+
+    def _delete_source_and_rebuild(
+        self,
+        control_turn_id: str,
+        delete_source: Callable[[], InteractionDeletion | None],
+    ) -> InteractionDeletion | None:
+        """在工作线程内完成 source transaction 与确定性派生发布。"""
+
+        # 1. 先使所有非 gate 管理读也 fail-loud，再调用唯一授权的删除动作。
+        with self._lock:
+            self._source_invalidated_error = RuntimeError(
+                "Akasha source mutation is in progress"
+            )
+        try:
+            deletion = delete_source()
+        except Exception:
+            with self._lock:
+                self._source_invalidated_error = None
+            raise
+        if deletion is None:
+            with self._lock:
+                self._source_invalidated_error = None
+            return None
+        if deletion.control_turn_id != control_turn_id:
+            with self._lock:
+                self._source_invalidated_error = RuntimeError(
+                    "Akasha source deletion returned a different interaction"
+                )
+            raise RuntimeError("interaction deletion identity mismatch")
+
+        # 2. 递增 source 代际，并清除所有基于旧图节点生成的 pending ticket。
+        with self._lock:
+            self._source_generation += 1
+            if self._pending:
+                self._pending.clear()
+                self._pending_changed.notify_all()
+
+        # 3. 以 canonical source 全量替换 turn 派生状态。
+        try:
+            self._runtime.rebuild_from_source()
+        except Exception as exc:
+            with self._lock:
+                self._source_invalidated_error = RuntimeError(
+                    "Akasha derived state is stale after interaction deletion"
+                )
+            raise RuntimeError(
+                "Akasha failed to reconcile interaction deletion: "
+                f"{deletion.control_turn_id}"
+            ) from exc
+        with self._lock:
+            self._source_invalidated_error = None
+        return deletion
 
     async def aclose(self) -> None:
         """Drain a staged graph publication before closing owned resources."""
@@ -886,6 +968,10 @@ class AkashaMemoryEngine:
 
         with self._lock:
             self._runtime.publish_staged(staged)
+
+    def _require_valid_source(self) -> None:
+        if self._source_invalidated_error is not None:
+            raise self._source_invalidated_error
 
     def _records(
         self,

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -277,6 +277,7 @@ class AkashaMemoryEngine:
         # 2. Keep one global graph writer and one pending query per session.
         self._lock = threading.RLock()
         self._pending_changed = threading.Condition(self._lock)
+        self._source_event_gate = asyncio.Lock()
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
@@ -805,6 +806,21 @@ class AkashaMemoryEngine:
         )[:top_k]
 
     async def _on_turn_committed(self, event: TurnCommitted) -> None:
+        """Serialize source-event embedding and staging with source deletion."""
+
+        with self._lock:
+            source_generation = self._source_generation
+            source_was_invalid = self._source_invalidated_error is not None
+        async with self._source_event_gate:
+            with self._lock:
+                if (
+                    source_was_invalid
+                    or source_generation != self._source_generation
+                ):
+                    return
+            await self._commit_source_event(event)
+
+    async def _commit_source_event(self, event: TurnCommitted) -> None:
         """Stage one committed turn and publish its graph asynchronously."""
 
         # 1. Respect the host's explicit exclusion and validate stable IDs.
@@ -836,7 +852,6 @@ class AkashaMemoryEngine:
         )
         with self._lock:
             pending = self._pending.get(event.session_key)
-            source_generation = self._source_generation
         if (
             len(user_ids) == 1
             and pending is not None
@@ -857,8 +872,6 @@ class AkashaMemoryEngine:
         async with self._commit_gate:
             await self._wait_for_publication()
             with self._lock:
-                if source_generation != self._source_generation:
-                    return
                 self._require_valid_source()
                 _upsert_embeddings(
                     self._embedding_store,
@@ -888,13 +901,14 @@ class AkashaMemoryEngine:
         """封住在线读写，执行窄 source 删除并重建派生状态。"""
 
         # 1. 与在线 commit 串行，整个 source mutation 窗口不开放旧图。
-        async with self._commit_gate:
-            await self._wait_for_publication()
-            return await asyncio.to_thread(
-                self._delete_source_and_rebuild,
-                control_turn_id,
-                delete_source,
-            )
+        async with self._source_event_gate:
+            async with self._commit_gate:
+                await self._wait_for_publication()
+                return await asyncio.to_thread(
+                    self._delete_source_and_rebuild,
+                    control_turn_id,
+                    delete_source,
+                )
 
     def _delete_source_and_rebuild(
         self,

--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -863,6 +863,13 @@ def _select_new_turns(
 ) -> list[CanonicalTurn]:
     """Accept only unchanged existing turns followed by causal append-only work."""
 
+    source_turn_ids = {turn.turn_id for turn in turns}
+    removed = sorted(set(existing) - source_turn_ids)
+    if removed:
+        raise AppendOnlyViolation(
+            "source removed indexed turns; rebuild is required, "
+            f"first={removed[0]}"
+        )
     for turn in turns:
         row = existing.get(turn.turn_id)
         if row is None:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -46,6 +46,8 @@ from plugins.akasha.engine import (
     ActiveRecallSnapshot,
     AkashaFeedbackPersistModule,
     AkashaMemoryEngine,
+    PendingRetrieval,
+    RetrievalRecords,
 )
 from plugins.akasha.inspector import AkashaInspectorReader
 from plugins.akasha.infrastructure.persistence import (
@@ -62,6 +64,7 @@ from plugins.akasha.plugin import (
     _empty_mobile_recall,
     _mobile_recall_lane,
 )
+from session.store import InteractionDeletion, SessionStore
 
 
 class _Embedder:
@@ -942,6 +945,250 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
     assert dense is not None and dense[0] == "u1"
     user_dense = struct.unpack("<2f", dense[1])
     assert user_dense == pytest.approx((2 / math.sqrt(5), 1 / math.sqrt(5)))
+
+
+def _seed_two_explicit_akasha_turns(workspace: Path) -> datetime:
+    """Persist two canonical explicit turns with frozen embeddings."""
+
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    started = datetime(2026, 8, 7, tzinfo=timezone.utc)
+    rows = [
+        (
+            "u1",
+            0,
+            "user",
+            "alpha",
+            {"control_turn_id": "t1", "turn_input_ordinal": 0},
+        ),
+        (
+            "u2",
+            1,
+            "user",
+            "continue",
+            {"control_turn_id": "t1", "turn_input_ordinal": 1},
+        ),
+        (
+            "a1",
+            2,
+            "assistant",
+            "first",
+            {
+                "control_turn_id": "t1",
+                "turn_terminal": True,
+                "turn_input_count": 2,
+            },
+        ),
+        (
+            "u3",
+            3,
+            "user",
+            "beta",
+            {"control_turn_id": "t2", "turn_input_ordinal": 0},
+        ),
+        (
+            "a2",
+            4,
+            "assistant",
+            "second",
+            {
+                "control_turn_id": "t2",
+                "turn_terminal": True,
+                "turn_input_count": 1,
+            },
+        ),
+    ]
+    with closing(sqlite3.connect(sessions)) as connection, connection:
+        connection.execute(
+            "INSERT INTO sessions VALUES ('test:one', ?, ?, 5, NULL)",
+            (started.isoformat(), started.isoformat()),
+        )
+        for message_id, seq, role, content, extra in rows:
+            connection.execute(
+                "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, ?, ?)",
+                (
+                    message_id,
+                    seq,
+                    role,
+                    content,
+                    json.dumps(extra),
+                    (started + timedelta(seconds=seq)).isoformat(),
+                ),
+            )
+            vector = (1.0, 0.0) if role == "user" else (0.0, 1.0)
+            connection.execute(
+                "INSERT INTO message_embeddings VALUES (?, ?, 'embedding-model', ?, 2, ?, ?)",
+                (
+                    message_id,
+                    hashlib.sha256(content.encode()).hexdigest(),
+                    sqlite3.Binary(struct.pack("<2f", *vector)),
+                    started.isoformat(),
+                    started.isoformat(),
+                ),
+            )
+    return started
+
+
+@pytest.mark.asyncio
+async def test_interaction_deletion_rebuilds_akasha_and_clears_pending(
+    tmp_path: Path,
+) -> None:
+    started = _seed_two_explicit_akasha_turns(tmp_path)
+    sessions = tmp_path / "sessions.db"
+
+    engine = _engine(tmp_path)
+    first_turn = engine._runtime.cycle.turns[0]  # noqa: SLF001
+    assert first_turn.user_dense is not None
+    _, ticket = engine._runtime.query_turn(  # noqa: SLF001
+        text=first_turn.user_text,
+        dense=first_turn.user_dense,
+        session_key="test:one",
+        timestamp=started + timedelta(seconds=10),
+    )
+    engine._pending["test:one"] = PendingRetrieval(  # noqa: SLF001
+        ticket=ticket,
+        query_timestamp=started,
+        query_text=first_turn.user_text,
+        query_dense=first_turn.user_dense.copy(),
+        turn_id="attempt-3",
+        records=RetrievalRecords(dense=(), completion=()),
+    )
+    engine._pending["test:other"] = engine._pending["test:one"]  # noqa: SLF001
+    store = SessionStore(sessions)
+    deletion = await engine.delete_interaction_source(
+        "t1",
+        lambda: store.delete_interaction("t1"),
+    )
+    assert deletion is not None
+
+    assert "test:one" not in engine._pending  # noqa: SLF001
+    assert "test:other" not in engine._pending  # noqa: SLF001
+    assert [turn.turn_id for turn in engine._runtime.cycle.turns] == [  # noqa: SLF001
+        "u3::a2"
+    ]
+    with closing(
+        sqlite3.connect(tmp_path / "memory" / "akasha-v2-index.db")
+    ) as connection:
+        assert connection.execute(
+            "SELECT turn_id FROM sparse_turns ORDER BY turn_id"
+        ).fetchall() == [("u3::a2",)]
+    with closing(
+        sqlite3.connect(tmp_path / "memory" / "akasha.db")
+    ) as connection:
+        assert connection.execute(
+            "SELECT turn_id FROM turn_nodes ORDER BY turn_id"
+        ).fetchall() == [("u3::a2",)]
+    store.close()
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_late_commit_after_interaction_deletion_does_not_restore_embeddings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _seed_two_explicit_akasha_turns(tmp_path)
+    engine = _engine(tmp_path)
+    embed_started = asyncio.Event()
+    release_embed = asyncio.Event()
+
+    async def blocked_embed_batch(texts: list[str]) -> list[list[float]]:
+        embed_started.set()
+        await release_embed.wait()
+        return [
+            [1.0, 0.0] if "alpha" in text else [0.0, 1.0]
+            for text in texts
+        ]
+
+    monkeypatch.setattr(engine._embedder, "embed_batch", blocked_embed_batch)  # noqa: SLF001
+    event = TurnCommitted(
+        session_key="test:one",
+        channel="test",
+        chat_id="one",
+        input_message="alpha\n\ncontinue",
+        persisted_user_message="alpha\n\ncontinue",
+        assistant_response="first",
+        tools_used=[],
+        persisted_user_message_id="u1",
+        persisted_user_message_ids=("u1", "u2"),
+        assistant_message_id="a1",
+        timestamp=started,
+    )
+    commit_task = asyncio.create_task(engine._on_turn_committed(event))  # noqa: SLF001
+    await embed_started.wait()
+
+    store = SessionStore(tmp_path / "sessions.db")
+    deletion = await engine.delete_interaction_source(
+        "t1",
+        lambda: store.delete_interaction("t1"),
+    )
+    assert deletion is not None
+    release_embed.set()
+    await commit_task
+
+    with closing(sqlite3.connect(tmp_path / "sessions.db")) as connection:
+        assert connection.execute(
+            "SELECT message_id FROM message_embeddings WHERE message_id IN ('u1', 'u2', 'a1')"
+        ).fetchall() == []
+    store.close()
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
+
+
+def test_restart_repairs_sidecars_after_source_interaction_was_deleted(
+    tmp_path: Path,
+) -> None:
+    _seed_two_explicit_akasha_turns(tmp_path)
+    original = _engine(tmp_path)
+    original._runtime.close()  # noqa: SLF001
+    original._embedding_store.close()  # noqa: SLF001
+    store = SessionStore(tmp_path / "sessions.db")
+    deletion = store.delete_interaction("t1")
+    assert deletion is not None
+    store.close()
+
+    restarted = _engine(tmp_path)
+
+    assert [turn.turn_id for turn in restarted._runtime.cycle.turns] == [  # noqa: SLF001
+        "u3::a2"
+    ]
+    restarted._runtime.close()  # noqa: SLF001
+    restarted._embedding_store.close()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_failed_interaction_rebuild_keeps_akasha_fail_loud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_sessions(tmp_path / "sessions.db")
+    engine = _engine(tmp_path)
+
+    def fail_rebuild() -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(
+        engine._runtime,  # noqa: SLF001
+        "rebuild_from_source",
+        fail_rebuild,
+    )
+    deletion = InteractionDeletion(
+        control_turn_id="t1",
+        session_key="test:one",
+        message_ids=("u1", "a1"),
+        first_user_message_id="u1",
+        old_last_consolidated=2,
+        new_last_consolidated=0,
+        backup_path=str(tmp_path / "backup.db"),
+    )
+
+    with pytest.raises(RuntimeError, match="failed to reconcile"):
+        await engine.delete_interaction_source("t1", lambda: deletion)
+    with pytest.raises(RuntimeError, match="derived state is stale"):
+        engine.list_items_for_dashboard()
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
 
 
 def test_sparse_builder_preserves_single_user_embedding_bytes(

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1084,12 +1084,38 @@ async def test_interaction_deletion_rebuilds_akasha_and_clears_pending(
 
 
 @pytest.mark.asyncio
-async def test_late_commit_after_interaction_deletion_does_not_restore_embeddings(
+async def test_interaction_deletion_waits_for_in_flight_source_embedding(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     started = _seed_two_explicit_akasha_turns(tmp_path)
+    with closing(sqlite3.connect(tmp_path / "sessions.db")) as connection, connection:
+        connection.execute("DELETE FROM message_embeddings WHERE message_id IN ('u3', 'a2')")
+        connection.execute("DELETE FROM messages WHERE id IN ('u3', 'a2')")
     engine = _engine(tmp_path)
+    with closing(sqlite3.connect(tmp_path / "sessions.db")) as connection, connection:
+        connection.execute(
+            "INSERT INTO messages VALUES ('u3', 'test:one', 3, 'user', 'beta', NULL, ?, ?)",
+            (
+                json.dumps(
+                    {"control_turn_id": "t2", "turn_input_ordinal": 0}
+                ),
+                (started + timedelta(seconds=3)).isoformat(),
+            ),
+        )
+        connection.execute(
+            "INSERT INTO messages VALUES ('a2', 'test:one', 4, 'assistant', 'second', NULL, ?, ?)",
+            (
+                json.dumps(
+                    {
+                        "control_turn_id": "t2",
+                        "turn_terminal": True,
+                        "turn_input_count": 1,
+                    }
+                ),
+                (started + timedelta(seconds=4)).isoformat(),
+            ),
+        )
     embed_started = asyncio.Event()
     release_embed = asyncio.Event()
 
@@ -1106,31 +1132,42 @@ async def test_late_commit_after_interaction_deletion_does_not_restore_embedding
         session_key="test:one",
         channel="test",
         chat_id="one",
-        input_message="alpha\n\ncontinue",
-        persisted_user_message="alpha\n\ncontinue",
-        assistant_response="first",
+        input_message="beta",
+        persisted_user_message="beta",
+        assistant_response="second",
         tools_used=[],
-        persisted_user_message_id="u1",
-        persisted_user_message_ids=("u1", "u2"),
-        assistant_message_id="a1",
+        persisted_user_message_id="u3",
+        persisted_user_message_ids=("u3",),
+        assistant_message_id="a2",
         timestamp=started,
     )
     commit_task = asyncio.create_task(engine._on_turn_committed(event))  # noqa: SLF001
     await embed_started.wait()
 
     store = SessionStore(tmp_path / "sessions.db")
-    deletion = await engine.delete_interaction_source(
-        "t1",
-        lambda: store.delete_interaction("t1"),
+    deletion_task = asyncio.create_task(
+        engine.delete_interaction_source(
+            "t1",
+            lambda: store.delete_interaction("t1"),
+        )
     )
-    assert deletion is not None
+    await asyncio.sleep(0)
+    assert not deletion_task.done()
     release_embed.set()
     await commit_task
+    deletion = await deletion_task
+    assert deletion is not None
 
     with closing(sqlite3.connect(tmp_path / "sessions.db")) as connection:
         assert connection.execute(
             "SELECT message_id FROM message_embeddings WHERE message_id IN ('u1', 'u2', 'a1')"
         ).fetchall() == []
+        assert connection.execute(
+            "SELECT message_id FROM message_embeddings WHERE message_id IN ('u3', 'a2') ORDER BY message_id"
+        ).fetchall() == [("a2",), ("u3",)]
+    assert [turn.turn_id for turn in engine._runtime.cycle.turns] == [  # noqa: SLF001
+        "u3::a2"
+    ]
     store.close()
     engine._runtime.close()  # noqa: SLF001
     engine._embedding_store.close()  # noqa: SLF001


### PR DESCRIPTION
## 问题与结果

- 解决的问题：SessionDB interaction 删除后，Akasha 的 append-only sparse index、memory graph、pending retrieval ticket 与迟到 `TurnCommitted` 仍可能保留或重新写回已撤销事实。
- 用户可见结果：Akasha owner 先用 source-event gate 排空已开始的 embedding + staging，再封住 query/commit；删除 source 后递增 generation、清空所有旧图 ticket，并从剩余 canonical source 确定性重建两份 sidecar。重建失败后查询与管理读取 fail-loud；进程在 index/memory 发布窗口崩溃时，重启会检测 identity mismatch 并自愈。
- 本 PR 不处理：SessionDB 原子删除、409 和 Dashboard 确认在前置 stacked PR；U5 joined-text turn embedding store 仍为后续独立 PR。

## Stack

- #326：完整 logical interaction 的 memory consumers
- #328：SessionDB、Dashboard API 与客户端确认
- 当前 #329：Akasha 协调、generation fence 与 sidecar 重建
- 合并顺序：#326 → #328 → #329；U5 不混入本栈。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：Akasha online runtime、sparse builder、MemoryAdmin interaction 协调入口
- `runtime_patch`：`required`
- `runtime_patch_reason`：只有 Akasha owner 能串行化 live graph、pending ticket、publication task 与确定性 sidecar rebuild；客户端无法安全实现。
- `authoritative_state_owner`：SessionDB 仍是 truth；Akasha 只拥有可重建 sidecar 与在线 cycle。
- `client_only_alternative`：无。
- 关联不变量：Akasha 完整重建只读 sessions messages、既有 embeddings、固定配置与固定算法；不调用 LLM、不重新解释或补算 embedding。
- `protected_state`：SessionDB 剩余消息与 embeddings、其他正式 workspace 文件、外部效果、未关联附件。
- 允许的副作用：interaction 删除协调期间清空所有基于旧图节点的 pending ticket；以完整候选原子替换 Akasha index/memory sidecar。
- 禁止的副作用：陈旧图继续服务、迟到提交回写被撤销 embedding、残缺 rebuild 被报告成功、修改 canonical messages。

## 改动范围

- 主要文件：`plugins/akasha/application/runtime.py`、`plugins/akasha/engine.py`、`plugins/akasha/infrastructure/sparse_index/builder.py`、对应测试与记忆合同。
- 配置或迁移影响：无配置、无 schema migration；sidecar 可由固定输入重建。
- 已知 schema lineage 与最终 schema identity：SessionDB 与两份 Akasha SQLite schema identity 均不变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `a73f00e8`，head `ffabe8b9`（`b17f4e5f` + source-event race fix）；依赖前置 interaction-delete PR。
- 回滚方式：revert `ffabe8b9`、`b17f4e5f`；若 source 已删除，使用前置 PR 返回的 SessionDB 快照恢复，再按既有 rebuild 流程生成 sidecar。

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_akasha_plugin.py tests/test_memory_engine_contract.py`，60 passed；累计相关测试 207 passed。
- [x] Python 类型检查已通过：targeted 与全仓 Pyright 0 errors；前端检查在前置 PR 通过。
- [x] 竞态测试覆盖 completed turn 已落库但 embedding 尚在 provider 阶段时，删除必须等待并保留非目标 turn embedding。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过：`20260807-024515-3fe04d9a`。
- [ ] 远端 CI：GitHub Actions 当前 `major_outage`；PR 已 ready 并重新打开，但尚未生成 workflow run，恢复后需核对。
- `sourceDigest`：`2f290b541ef7bbd4567be36901c4b4b060456b8c67cc8ca17eaf628a7254fcce`
- `planDigest`：`0e90f4ad9e14298aed129b0a336fc63ba0fb38d19462d2019fa28451847aa331`
- 真实设备证据：不适用；本 PR 不修改 mobile UI 或传输协议。
- 未运行项与原因：仅远端 CI 因 GitHub Actions 官方故障未运行；本地对应 Gate、类型与测试均已完成。

## 工作手册

- [x] 已核对 `projectneed.md`、persistence state map、相关决策和 `NOW.md`。
- [x] 长期语义变化已由维护者确认；generation fence 是为满足已确认的整组撤销与 fail-loud 合同。
- [x] Akasha owner 持有 runtime patch；客户端只调用前置服务端协议。
- [x] `NOW.md` 当前无对应进行中事项，不适用。
