### PR TITLE
[codex] 建立模型注册表与统一能力

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -96,12 +96,31 @@ def load_config(
     path: str | Path = "config.toml",
     *,
     workspace: str | Path,
+    credential_store: object | None = None,
 ) -> Config:
     workspace_path = Path(workspace)
-    data = _load_config_data(path)
+    config_path = Path(path)
+    data = _load_config_data(config_path)
     _reject_removed_peer_configuration(data)
+    resolved_credential_store = (
+        credential_store
+        if isinstance(credential_store, CredentialStore)
+        else None
+    )
 
-    llm = _as_dict(data.get("llm"), field="llm")
+    from agent.model_runtime.store import ModelRegistryStore
+
+    model_snapshot = ModelRegistryStore.for_workspace(workspace_path).read_snapshot()
+    model_credential_store = (
+        CredentialStore.for_workspace(workspace_path)
+        if model_snapshot is not None
+        else resolved_credential_store
+    )
+    llm = (
+        model_snapshot.as_config_llm()
+        if model_snapshot is not None
+        else _as_dict(data.get("llm"), field="llm")
+    )
     agent_cfg = _as_dict(data.get("agent"), field="agent")
     legacy_max_output_tokens = agent_cfg.get(
         "max_tokens",
@@ -110,6 +129,7 @@ def load_config(
     runtime_id, llm_main, model_runtimes = _load_llm_runtimes(
         llm,
         workspace_path,
+        credential_store=model_credential_store,
         legacy_main_max_output_tokens=legacy_max_output_tokens,
     )
     fast_runtime_id, llm_fast = _load_role_runtime(llm, "fast", runtime_id)
@@ -134,7 +154,11 @@ def load_config(
             "mobile_realtime 启用时，本机配对入口 channels.chat 必须监听 loopback"
         )
     proactive = _load_proactive_config(data)
-    memory = _load_memory_config(data, workspace_path)
+    memory = _load_memory_config(
+        data,
+        workspace_path,
+        credential_store=resolved_credential_store,
+    )
     wiring = _load_wiring_config(data)
 
     return Config(
@@ -147,6 +171,7 @@ def load_config(
                 auth_id=str(llm_main.get("auth") or ""),
                 inline_value=str(llm_main.get("api_key") or ""),
                 workspace=workspace_path,
+                credential_store=model_credential_store,
             )
         ),
         system_prompt=str(
@@ -184,6 +209,7 @@ def load_config(
             auth_id=str(llm_fast.get("auth") or ""),
             inline_value=str(llm_fast.get("api_key") or ""),
             workspace=workspace_path,
+            credential_store=model_credential_store,
         ),
         light_base_url=str(
             llm_fast.get("base_url") or ""
@@ -193,6 +219,7 @@ def load_config(
             auth_id=str(llm_agent.get("auth") or ""),
             inline_value=str(llm_agent.get("api_key") or ""),
             workspace=workspace_path,
+            credential_store=model_credential_store,
         ),
         agent_base_url=str(
             llm_agent.get("base_url") or ""
@@ -222,6 +249,7 @@ def load_config(
             auth_id=str(llm_vl.get("auth") or ""),
             inline_value=str(llm_vl.get("api_key") or ""),
             workspace=workspace_path,
+            credential_store=model_credential_store,
         ),
         vl_base_url=str(llm_vl.get("base_url") or ""),
         wiring=wiring,
@@ -253,6 +281,9 @@ def load_config(
         fast_runtime_id=fast_runtime_id,
         agent_runtime_id=agent_runtime_id,
         vl_runtime_id=vl_runtime_id,
+        model_registry_revision=(model_snapshot.revision if model_snapshot else 0),
+        config_path=config_path.expanduser().resolve(),
+        workspace_path=workspace_path.expanduser().resolve(),
     )
 
 
@@ -447,7 +478,12 @@ def _load_proactive_config(data: dict) -> ProactiveConfig:
     return proactive
 
 
-def _load_memory_config(data: dict, workspace: Path) -> MemoryConfig:
+def _load_memory_config(
+    data: dict,
+    workspace: Path,
+    *,
+    credential_store: CredentialStore | None = None,
+) -> MemoryConfig:
     memory = _as_dict(data.get("memory"), field="memory")
     embedding = _as_dict(memory.get("embedding"), field="memory.embedding")
     raw_output_dimensionality = embedding.get("output_dimensionality")
@@ -467,6 +503,7 @@ def _load_memory_config(data: dict, workspace: Path) -> MemoryConfig:
                 auth_id=str(embedding.get("auth") or ""),
                 inline_value=str(embedding.get("api_key", "")),
                 workspace=workspace,
+                credential_store=credential_store,
             ),
             base_url=str(embedding.get("base_url", "")),
             output_dimensionality=output_dimensionality,
@@ -544,6 +581,7 @@ def _load_llm_runtimes(
     llm: dict,
     workspace: Path,
     *,
+    credential_store: CredentialStore | None = None,
     legacy_main_max_output_tokens: object | None = None,
 ) -> tuple[str, dict, dict[str, ModelRuntimeConfig]]:
     """在配置边界解析 named runtimes，并拒绝未迁移的旧结构。"""
@@ -560,6 +598,13 @@ def _load_llm_runtimes(
         modalities = item.get("input_modalities", ["text"])
         if not isinstance(modalities, list) or not all(isinstance(v, str) for v in modalities):
             raise ValueError(f"llm.runtimes.{runtime_id}.input_modalities 必须是字符串数组")
+        supported_efforts = item.get("supported_reasoning_efforts", [])
+        if not isinstance(supported_efforts, list) or not all(
+            isinstance(value, str) and value.strip() for value in supported_efforts
+        ):
+            raise ValueError(
+                f"llm.runtimes.{runtime_id}.supported_reasoning_efforts 必须是非空字符串数组"
+            )
         provider = str(item.get("provider") or "").lower()
         auth_id = str(item.get("auth") or "")
         configured_max_output_tokens = item.get("max_output_tokens")
@@ -574,6 +619,9 @@ def _load_llm_runtimes(
             runtime_id=runtime_id,
             provider=provider,
             model=str(item.get("model") or ""),
+            source_id=str(item.get("source_id") or ""),
+            source_name=str(item.get("source_name") or provider),
+            catalog_provider_id=str(item.get("catalog_provider_id") or "").strip(),
             auth=auth_id,
             api_key=(
                 ""
@@ -582,16 +630,42 @@ def _load_llm_runtimes(
                     auth_id=auth_id,
                     inline_value=str(item.get("api_key") or ""),
                     workspace=workspace,
+                    credential_store=credential_store,
                 )
             ),
             base_url=_model_base_url(provider, item.get("base_url")),
             reasoning_effort=str(item.get("reasoning_effort") or ""),
+            supported_reasoning_efforts=tuple(supported_efforts),
             context_window=int(item.get("context_window") or 0),
             max_output_tokens=_as_output_token_limit(
                 configured_max_output_tokens,
                 field=f"llm.runtimes.{runtime_id}.max_output_tokens",
             ),
             input_modalities=tuple(modalities),
+            capability_source=str(
+                item.get(
+                    "capability_source",
+                    "explicit" if item.get("context_window") else "unknown",
+                )
+            ),
+            context_window_source=str(
+                item.get(
+                    "context_window_source",
+                    item.get("capability_source", "explicit" if item.get("context_window") else "unknown"),
+                )
+            ),
+            max_output_tokens_source=str(
+                item.get(
+                    "max_output_tokens_source",
+                    item.get("capability_source", "explicit" if item.get("max_output_tokens") else "unknown"),
+                )
+            ),
+            input_modalities_source=str(
+                item.get(
+                    "input_modalities_source",
+                    item.get("capability_source", "explicit" if item.get("input_modalities") else "unknown"),
+                )
+            ),
             effective_context_percent=float(item.get("effective_context_percent", 0.9)),
             compaction_trigger_percent=float(
                 item.get("compaction_trigger_percent", 0.74)
@@ -669,9 +743,15 @@ def _resolve(value: str, workspace: Path) -> str:
     return resolved
 
 
-def _load_api_key(*, auth_id: str, inline_value: str, workspace: Path) -> str:
+def _load_api_key(
+    *,
+    auth_id: str,
+    inline_value: str,
+    workspace: Path,
+    credential_store: CredentialStore | None = None,
+) -> str:
     if auth_id:
-        return CredentialStore().api_key(auth_id)
+        return (credential_store or CredentialStore()).api_key(auth_id)
     return _resolve(inline_value, workspace)
 
 

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -114,14 +114,22 @@ class ModelRuntimeConfig:
     runtime_id: str
     provider: str
     model: str
+    source_id: str = ""
+    source_name: str = ""
+    catalog_provider_id: str = ""
     auth: str = ""
     api_key: str = ""
     base_url: str = ""
     reasoning_effort: str = ""
+    supported_reasoning_efforts: tuple[str, ...] = ()
     context_window: int = 0
     # 0 表示不向 provider 发送输出上限，由模型服务自身边界负责。
     max_output_tokens: int = 0
     input_modalities: tuple[str, ...] = ("text",)
+    capability_source: str = "unknown"
+    context_window_source: str = "unknown"
+    max_output_tokens_source: str = "unknown"
+    input_modalities_source: str = "unknown"
     effective_context_percent: float = 0.9
     compaction_trigger_percent: float = 0.74
     use_responses_lite: bool = False
@@ -135,14 +143,24 @@ class ModelRuntimeConfig:
             raise ValueError(f"runtime {self.runtime_id} 必须配置 provider 和 model")
         if self.provider == "codex" and not self.auth:
             raise ValueError(f"Codex runtime {self.runtime_id} 必须配置 auth")
-        if self.context_window <= 0:
-            raise ValueError(f"runtime {self.runtime_id} 的 context_window 必须大于 0")
+        if self.context_window < 0:
+            raise ValueError(f"runtime {self.runtime_id} 的 context_window 不能小于 0")
         if self.max_output_tokens < 0:
             raise ValueError(
                 f"runtime {self.runtime_id} 的 max_output_tokens 不能小于 0"
             )
         if "text" not in self.input_modalities:
             raise ValueError(f"runtime {self.runtime_id} 的 input_modalities 必须包含 text")
+        allowed_sources = {"explicit", "provider_catalog", "litellm", "unknown"}
+        for field_name, source in (
+            ("context_window_source", self.context_window_source),
+            ("max_output_tokens_source", self.max_output_tokens_source),
+            ("input_modalities_source", self.input_modalities_source),
+        ):
+            if source not in allowed_sources:
+                raise ValueError(f"runtime {self.runtime_id} 的 {field_name} 无效")
+        if self.capability_source not in allowed_sources | {"mixed"}:
+            raise ValueError(f"runtime {self.runtime_id} 的 capability_source 无效")
         validate_profile_runtime(
             provider=self.provider,
             model=self.model,
@@ -157,7 +175,7 @@ class ModelRuntimeConfig:
                 f"runtime {self.runtime_id} 的 compaction_trigger_percent "
                 "必须在 (0, effective_context_percent) 内"
             )
-        if self.max_output_tokens > 0 and self.max_output_tokens >= int(
+        if self.context_window > 0 and self.max_output_tokens > 0 and self.max_output_tokens >= int(
             self.context_window * self.effective_context_percent
         ):
             raise ValueError(
@@ -211,6 +229,9 @@ class Config:
     fast_runtime_id: str = ""
     agent_runtime_id: str = ""
     vl_runtime_id: str = ""
+    model_registry_revision: int = 0
+    config_path: Path = Path("config.toml")
+    workspace_path: Path = Path(".")
 
     @classmethod
     def load(
@@ -218,10 +239,15 @@ class Config:
         path: str | Path = "config.toml",
         *,
         workspace: str | Path,
+        credential_store: object | None = None,
     ) -> Config:
         from importlib import import_module
 
-        return import_module("agent.config").load_config(path, workspace=workspace)
+        return import_module("agent.config").load_config(
+            path,
+            workspace=workspace,
+            credential_store=credential_store,
+        )
 
 
 __all__ = [

--- a/agent/model_runtime/auth/store.py
+++ b/agent/model_runtime/auth/store.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import tempfile
 import shutil
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterator
@@ -25,13 +26,23 @@ class Credential:
 
 
 class CredentialStore:
-    """安全地读取和原子更新用户凭据。"""
+    """Read credentials from the selected JSON or workspace SQLite owner."""
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or Path.home() / ".akashic" / "auth.json"
-        self.lock_path = self.path.with_suffix(".lock")
+        self.lock_path = self.path.with_name(f"{self.path.name}.credentials.lock")
+
+    @classmethod
+    def for_workspace(cls, workspace: Path) -> CredentialStore:
+        return cls(workspace / "model-registry.sqlite3")
+
+    @property
+    def is_database(self) -> bool:
+        return self.path.name == "model-registry.sqlite3"
 
     def get(self, credential_id: str) -> Credential:
+        if self.is_database:
+            return self._get_database_credential(credential_id)
         data = self._read_document()
         raw = data["credentials"].get(credential_id)
         if not isinstance(raw, dict):
@@ -53,6 +64,9 @@ class CredentialStore:
     def put_many(self, credentials: dict[str, Credential]) -> None:
         """在一次锁和原子替换中保存一组凭据。"""
         with self.locked():
+            if self.is_database:
+                self._write_database_credentials(credentials)
+                return
             data = self._read_document()
             for credential_id, credential in credentials.items():
                 data["credentials"][credential_id] = asdict(credential)
@@ -60,6 +74,8 @@ class CredentialStore:
 
     def metadata(self) -> dict[str, dict[str, str]]:
         """返回不含 token 的凭据状态，供本机设置边界展示。"""
+        if self.is_database:
+            return self._database_metadata()
         data = self._read_document()
         result: dict[str, dict[str, str]] = {}
         for credential_id, raw in data["credentials"].items():
@@ -73,6 +89,9 @@ class CredentialStore:
 
     def replace_locked(self, credential_id: str, credential: Credential) -> None:
         """调用方持有 store 锁时替换一条凭据。"""
+        if self.is_database:
+            self._write_database_credentials({credential_id: credential})
+            return
         data = self._read_document()
         data["credentials"][credential_id] = asdict(credential)
         self._write_document(data)
@@ -80,9 +99,11 @@ class CredentialStore:
     @contextmanager
     def locked(self) -> Iterator[None]:
         """持有跨进程独占锁，供刷新网络请求和持久化共同使用。"""
-        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        os.chmod(self.path.parent, 0o700)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.is_database:
+            os.chmod(self.path.parent, 0o700)
         lock_file = self.lock_path.open("a+", encoding="utf-8")
+        os.chmod(self.lock_path, 0o600)
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         try:
             yield
@@ -90,7 +111,151 @@ class CredentialStore:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
             lock_file.close()
 
+    def provision_connection(
+        self,
+        credential_id: str,
+        *,
+        name: str,
+        provider: str,
+        base_url: str,
+    ) -> None:
+        """Create the provider connection needed by a pre-model login flow."""
+
+        if not self.is_database:
+            return
+        from agent.model_runtime.store import ModelRegistryStore
+
+        model_store = ModelRegistryStore(self.path)
+        model_store.initialize()
+        with closing(sqlite3.connect(self.path)) as connection:
+            connection.execute(
+                """
+                INSERT INTO model_connections(
+                    id, name, provider, catalog_provider_id, auth_id, base_url
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name,
+                    provider = excluded.provider,
+                    catalog_provider_id = excluded.catalog_provider_id,
+                    auth_id = excluded.auth_id,
+                    base_url = excluded.base_url,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    credential_id,
+                    name,
+                    provider,
+                    provider,
+                    credential_id,
+                    base_url,
+                ),
+            )
+            connection.commit()
+        self._secure_database_files()
+
+    @staticmethod
+    def encode(credential: Credential) -> tuple[str, str]:
+        return (
+            credential.driver,
+            json.dumps(asdict(credential), ensure_ascii=False, separators=(",", ":")),
+        )
+
+    @staticmethod
+    def decode(
+        credential_id: str,
+        auth_kind: str,
+        auth_payload: str,
+    ) -> Credential:
+        try:
+            raw = json.loads(auth_payload)
+            credential = Credential(**raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthenticationError(f"凭据结构无效: {credential_id}") from exc
+        if credential.driver != auth_kind:
+            raise AuthenticationError(f"凭据类型不一致: {credential_id}")
+        return credential
+
+    def _get_database_credential(self, credential_id: str) -> Credential:
+        if not self.path.is_file():
+            raise AuthenticationError(f"凭据不存在: {credential_id}")
+        self._validate_database_permissions()
+        with closing(sqlite3.connect(self.path)) as connection:
+            rows = connection.execute(
+                """
+                SELECT auth_kind, auth_payload
+                FROM model_connections
+                WHERE auth_id = ? AND auth_kind != '' AND auth_payload != ''
+                """,
+                (credential_id,),
+            ).fetchall()
+        if not rows:
+            raise AuthenticationError(f"凭据不存在: {credential_id}")
+        credentials = {
+            self.decode(credential_id, str(kind), str(payload))
+            for kind, payload in rows
+        }
+        if len(credentials) != 1:
+            raise AuthenticationError(f"凭据存在冲突: {credential_id}")
+        return credentials.pop()
+
+    def _write_database_credentials(
+        self,
+        credentials: dict[str, Credential],
+    ) -> None:
+        if not self.path.is_file():
+            raise AuthenticationError("模型注册库尚未初始化")
+        self._validate_database_permissions()
+        with closing(sqlite3.connect(self.path)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            for credential_id, credential in credentials.items():
+                auth_kind, auth_payload = self.encode(credential)
+                cursor = connection.execute(
+                    """
+                    UPDATE model_connections
+                    SET auth_kind = ?, auth_payload = ?, updated_at = CURRENT_TIMESTAMP
+                    WHERE auth_id = ?
+                    """,
+                    (auth_kind, auth_payload, credential_id),
+                )
+                if cursor.rowcount == 0:
+                    raise AuthenticationError(
+                        f"凭据没有对应的 Provider connection: {credential_id}"
+                    )
+            connection.commit()
+        self._secure_database_files()
+
+    def _database_metadata(self) -> dict[str, dict[str, str]]:
+        if not self.path.is_file():
+            return {}
+        self._validate_database_permissions()
+        with closing(sqlite3.connect(self.path)) as connection:
+            rows = connection.execute(
+                """
+                SELECT auth_id, auth_kind, auth_payload
+                FROM model_connections
+                WHERE auth_id != '' AND auth_kind != '' AND auth_payload != ''
+                ORDER BY auth_id
+                """
+            ).fetchall()
+        result: dict[str, dict[str, str]] = {}
+        for credential_id, auth_kind, auth_payload in rows:
+            credential = self.decode(
+                str(credential_id),
+                str(auth_kind),
+                str(auth_payload),
+            )
+            metadata = {
+                "driver": credential.driver,
+                "updated_at": credential.updated_at,
+            }
+            previous = result.setdefault(str(credential_id), metadata)
+            if previous != metadata:
+                raise AuthenticationError(f"凭据元数据存在冲突: {credential_id}")
+        return result
+
     def _read_document(self) -> dict:
+        if self.is_database:
+            raise RuntimeError("SQLite CredentialStore 不能读取 JSON document")
         if not self.path.exists():
             return {"version": 1, "credentials": {}}
         self._validate_permissions()
@@ -131,3 +296,17 @@ class CredentialStore:
             raise AuthenticationError("auth.json 父目录权限过宽，必须为 0700")
         if file_mode & 0o077:
             raise AuthenticationError("auth.json 权限过宽，必须为 0600")
+
+    def _validate_database_permissions(self) -> None:
+        file_mode = self.path.stat().st_mode & 0o777
+        if file_mode & 0o077:
+            raise AuthenticationError("model-registry.sqlite3 权限过宽，必须为 0600")
+
+    def _secure_database_files(self) -> None:
+        for path in (
+            self.path,
+            self.path.with_name(f"{self.path.name}-wal"),
+            self.path.with_name(f"{self.path.name}-shm"),
+        ):
+            if path.exists():
+                os.chmod(path, 0o600)

--- a/agent/model_runtime/catalog/litellm_registry.py
+++ b/agent/model_runtime/catalog/litellm_registry.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, cast
+
+# LiteLLM 默认允许在线刷新价格表；模型设置必须只读取随固定 wheel 发布的快照。
+os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+import litellm
+from genai_prices.data_snapshot import get_snapshot
+
+
+@dataclass(frozen=True)
+class CatalogCapabilities:
+    context_window: int
+    max_output_tokens: int
+    input_modalities: tuple[str, ...]
+    reasoning: bool
+    tool_call: bool
+    input_modalities_known: bool = True
+    supported_reasoning_efforts: tuple[str, ...] = ()
+    supports_parallel_tool_calls: bool = True
+    source: str = "litellm"
+
+
+_PROVIDER_ALIASES = {
+    "dashscope": "dashscope",
+    "opencode_go": "opencode-go",
+    "xai": "x-ai",
+}
+
+_LITELLM_PROVIDER_ALIASES = {
+    "x-ai": "xai",
+    "z-ai": "zai",
+}
+
+_EFFORT_FLAGS = (
+    ("none", "supports_none_reasoning_effort"),
+    ("minimal", "supports_minimal_reasoning_effort"),
+    ("xhigh", "supports_xhigh_reasoning_effort"),
+    ("max", "supports_max_reasoning_effort"),
+)
+
+
+def resolve_catalog_capabilities(
+    provider: str,
+    model: str,
+    *,
+    base_url: str = "",
+) -> CatalogCapabilities | None:
+    """从固定 LiteLLM wheel 的注册表解析模型能力。"""
+
+    provider_id = resolve_catalog_provider_id(
+        provider,
+        model=model,
+        base_url=base_url,
+    )
+    raw = _model_entry(provider_id, model)
+    if raw is None:
+        return None
+    modalities, modalities_known = _input_modalities(raw)
+    reasoning = raw.get("supports_reasoning") is True
+    max_input_tokens = _positive_int(raw.get("max_input_tokens"))
+    max_output_tokens = _positive_int(
+        raw.get("max_output_tokens") or raw.get("max_tokens")
+    )
+    return CatalogCapabilities(
+        context_window=(
+            max_input_tokens + max_output_tokens
+            if max_input_tokens and max_output_tokens
+            else max_input_tokens
+        ),
+        max_output_tokens=max_output_tokens,
+        input_modalities=modalities,
+        input_modalities_known=modalities_known,
+        reasoning=reasoning,
+        tool_call=raw.get("supports_function_calling") is True,
+        supported_reasoning_efforts=_reasoning_efforts(raw) if reasoning else (),
+        supports_parallel_tool_calls=(
+            raw.get("supports_parallel_function_calling") is not False
+        ),
+    )
+
+
+def resolve_catalog_provider_id(
+    provider: str,
+    *,
+    model: str = "",
+    base_url: str = "",
+) -> str:
+    """用成熟注册表识别 provider 身份，不改变实际 wire transport。"""
+
+    # 1. genai-prices 的 provider API 正则优先识别官方入口。
+    if base_url:
+        try:
+            matched_provider = get_snapshot().find_provider(None, None, base_url)
+        except LookupError:
+            pass
+        else:
+            match = re.match(matched_provider.api_pattern, base_url)
+            suffix = base_url[match.end() :] if match is not None else "invalid"
+            if not suffix or suffix.startswith(("/", "?", "#")):
+                detected = matched_provider.id
+                if detected is not None:
+                    return _PROVIDER_ALIASES.get(detected, detected)
+
+    # 2. 明确 provider 或带 provider 前缀的模型使用 LiteLLM 注册表核对。
+    raw_provider = provider.strip().lower()
+    normalized = _PROVIDER_ALIASES.get(raw_provider, raw_provider)
+    if normalized in _known_provider_ids():
+        return normalized
+    if "/" in model:
+        prefix = model.split("/", 1)[0].lower()
+        if prefix in _known_provider_ids():
+            return prefix
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _known_provider_ids() -> frozenset[str]:
+    providers = {
+        str(raw.get("litellm_provider") or "").lower()
+        for raw in _registry().values()
+    }
+    providers.discard("")
+    providers.update(_PROVIDER_ALIASES.values())
+    return frozenset(providers)
+
+
+def _model_entry(provider: str, model: str) -> dict[str, Any] | None:
+    """优先匹配 provider 专属型号，再使用 LiteLLM 的 canonical 型号。"""
+
+    normalized_model = model.strip()
+    if not normalized_model:
+        return None
+    litellm_provider = _LITELLM_PROVIDER_ALIASES.get(provider, provider)
+    candidates: list[str] = []
+    if litellm_provider and not normalized_model.startswith(f"{litellm_provider}/"):
+        candidates.append(f"{litellm_provider}/{normalized_model}")
+    candidates.append(normalized_model)
+    for candidate in candidates:
+        raw = _registry().get(candidate)
+        if raw is not None:
+            return raw
+    return None
+
+
+def _input_modalities(raw: dict[str, Any]) -> tuple[tuple[str, ...], bool]:
+    declared = raw.get("supported_modalities")
+    if isinstance(declared, list):
+        declared_items = cast(list[object], declared)
+        if not all(isinstance(item, str) for item in declared_items):
+            return ("text",), False
+        declared_strings = cast(list[str], declared_items)
+        modalities = tuple(dict.fromkeys(item.lower() for item in declared_strings))
+        return (
+            ("text",) + tuple(item for item in modalities if item != "text"),
+            True,
+        )
+    vision = raw.get("supports_vision")
+    if isinstance(vision, bool):
+        return (("text", "image") if vision else ("text",), True)
+    return ("text",), False
+
+
+def _reasoning_efforts(raw: dict[str, Any]) -> tuple[str, ...]:
+    """按 LiteLLM 的 effort flags 生成 Memoh 同序的选项。"""
+
+    efforts = [
+        name
+        for name, flag in _EFFORT_FLAGS[:2]
+        if raw.get(flag) is True
+    ]
+    if raw.get("supports_low_reasoning_effort") is not False:
+        efforts.append("low")
+    efforts.extend(("medium", "high"))
+    efforts.extend(
+        name
+        for name, flag in _EFFORT_FLAGS[2:]
+        if raw.get(flag) is True
+    )
+    return tuple(efforts)
+
+
+def _positive_int(value: object) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+@lru_cache(maxsize=1)
+def _registry() -> dict[str, dict[str, Any]]:
+    return cast(dict[str, dict[str, Any]], litellm.model_cost)

--- a/agent/model_runtime/catalog/opencode_go.py
+++ b/agent/model_runtime/catalog/opencode_go.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from typing import cast
 
 import httpx
 
 from agent.model_runtime.errors import AuthenticationError, TransportError
+from agent.model_runtime.catalog.litellm_registry import resolve_catalog_capabilities
 from agent.model_runtime.provider_profiles import (
     OPENCODE_GO_BASE_URL,
     OPENCODE_GO_PROFILE,
@@ -152,9 +154,16 @@ class OpenCodeGoModelCatalog:
         model_items = cast(list[object], raw_models)
 
         # 3. `/models` 决定当前账号可用模型，OpenCode 决定各模型真实 variant。
-        reasoning_efforts = await _load_opencode_go_reasoning_efforts(
-            self.opencode_executable
-        )
+        try:
+            reasoning_efforts = await _load_opencode_go_reasoning_efforts(
+                self.opencode_executable
+            )
+        except TransportError as exc:
+            logging.getLogger(__name__).warning(
+                "OpenCode variant 目录不可用，思考强度改用本地模型注册表: %s",
+                exc,
+            )
+            reasoning_efforts = {}
         models: list[OpenCodeGoModel] = []
         for raw in model_items:
             if not isinstance(raw, dict):
@@ -167,9 +176,27 @@ class OpenCodeGoModelCatalog:
                 models.append(
                     OpenCodeGoModel(
                         slug=model_id,
-                        supported_reasoning_efforts=reasoning_efforts.get(
-                            model_id, ()
+                        supported_reasoning_efforts=(
+                            reasoning_efforts[model_id]
+                            if model_id in reasoning_efforts
+                            else _registry_reasoning_efforts(
+                                model_id,
+                                base_url=self.base_url,
+                            )
                         ),
                     )
                 )
         return models
+
+
+def _registry_reasoning_efforts(
+    model_id: str,
+    *,
+    base_url: str,
+) -> tuple[str, ...]:
+    capabilities = resolve_catalog_capabilities(
+        "opencode-go",
+        model_id,
+        base_url=base_url,
+    )
+    return capabilities.supported_reasoning_efforts if capabilities else ()

--- a/agent/model_runtime/registry.py
+++ b/agent/model_runtime/registry.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping
+
+from agent.config_models import Config, ModelRuntimeConfig
+from agent.model_runtime.store import ModelRegistryStore
+from agent.provider import LLMProvider
+
+
+@dataclass
+class ModelGeneration:
+    """Hold one immutable runtime/provider publication and its active leases."""
+
+    generation_id: int
+    config_digest: str
+    runtimes: Mapping[str, ModelRuntimeConfig]
+    providers: Mapping[str, Any]
+    role_runtime_ids: Mapping[str, str]
+    registry_revision: int = 0
+    role_providers: Mapping[str, Any] = field(default_factory=dict)
+    lease_count: int = 0
+    retired: bool = False
+
+    def resolve(
+        self,
+        role: str,
+        explicit_runtime_id: str | None,
+    ) -> tuple[str, ModelRuntimeConfig, Any]:
+        runtime_id = (
+            explicit_runtime_id
+            if explicit_runtime_id and role in {"default", "agent"}
+            else self.role_runtime_ids[role]
+        )
+        runtime = self.runtimes[runtime_id]
+        provider = self.role_providers.get(role) or self.providers[runtime_id]
+        if explicit_runtime_id and role in {"default", "agent"}:
+            provider = self.providers[runtime_id]
+        return runtime_id, runtime, provider
+
+
+@dataclass(frozen=True)
+class ModelExecutionBinding:
+    registry: ModelRegistry
+    generation: ModelGeneration
+    explicit_runtime_id: str | None
+    explicit_reasoning_effort: str = ""
+
+    def describe(self, role: str = "agent") -> dict[str, object]:
+        runtime_id, runtime, _provider = self.generation.resolve(
+            role,
+            self.explicit_runtime_id,
+        )
+        return {
+            "generation_id": self.generation.generation_id,
+            "config_digest": self.generation.config_digest,
+            "role": role,
+            "runtime_id": runtime_id,
+            "provider": runtime.provider,
+            "model": runtime.model,
+            "reasoning_effort": self.reasoning_effort_for(role, runtime),
+        }
+
+    def reasoning_effort_for(
+        self,
+        role: str,
+        runtime: ModelRuntimeConfig,
+    ) -> str:
+        """Resolve session effort only for the explicitly selected chat model."""
+
+        if self.explicit_runtime_id and role in {"default", "agent"}:
+            return self.explicit_reasoning_effort or runtime.reasoning_effort
+        return runtime.reasoning_effort
+
+
+_CURRENT_BINDING: ContextVar[ModelExecutionBinding | None] = ContextVar(
+    "model_execution_binding",
+    default=None,
+)
+
+
+GenerationBuilder = Callable[[Config, int], ModelGeneration]
+
+
+class ModelRegistry:
+    """Build, publish, and lease immutable model generations."""
+
+    def __init__(self, config: Config, builder: GenerationBuilder) -> None:
+        self._builder = builder
+        self._lock = asyncio.Lock()
+        self._reload_lock = asyncio.Lock()
+        self._next_generation_id = 1
+        self._current = builder(config, self._next_generation_id)
+        self._retired: dict[int, ModelGeneration] = {}
+        self._config_path = config.config_path
+        self._workspace_path = config.workspace_path
+        self._store = ModelRegistryStore.for_workspace(self._workspace_path)
+
+    @property
+    def current(self) -> ModelGeneration:
+        return self._current
+
+    def provider(
+        self,
+        role: str,
+        *,
+        force_disable_thinking: bool = False,
+    ) -> RoleBoundProvider:
+        if role not in self._current.role_runtime_ids:
+            raise KeyError(f"未知模型角色: {role}")
+        return RoleBoundProvider(
+            self,
+            role,
+            force_disable_thinking=force_disable_thinking,
+        )
+
+    def has_runtime(self, runtime_id: str) -> bool:
+        return runtime_id in self._current.runtimes and not runtime_id.startswith(
+            "__role_"
+        )
+
+    def list_runtimes(self) -> list[dict[str, object]]:
+        generation = self._current
+        roles_by_runtime: dict[str, list[str]] = {}
+        for role, runtime_id in generation.role_runtime_ids.items():
+            roles_by_runtime.setdefault(runtime_id, []).append(role)
+        return [
+            {
+                "id": runtime.runtime_id,
+                "provider": runtime.provider,
+                "catalogProvider": runtime.catalog_provider_id or runtime.provider,
+                "model": runtime.model,
+                "reasoningEffort": runtime.reasoning_effort,
+                "supportedReasoningEfforts": list(
+                    runtime.supported_reasoning_efforts
+                ),
+                "sourceId": runtime.source_id,
+                "sourceName": runtime.source_name or runtime.provider,
+                "contextWindow": runtime.context_window,
+                "maxOutputTokens": runtime.max_output_tokens,
+                "inputModalities": list(runtime.input_modalities),
+                "capabilitySource": runtime.capability_source,
+                "capabilitySources": {
+                    "contextWindow": runtime.context_window_source,
+                    "maxOutputTokens": runtime.max_output_tokens_source,
+                    "inputModalities": runtime.input_modalities_source,
+                },
+                "roles": sorted(roles_by_runtime.get(runtime.runtime_id, [])),
+            }
+            for runtime in generation.runtimes.values()
+            if not runtime.runtime_id.startswith("__role_")
+        ]
+
+    async def reload(self, config: Config) -> ModelGeneration:
+        """Build a complete candidate, then atomically publish it."""
+
+        # 1. Serialize reloads so every published generation has a unique id.
+        async with self._reload_lock:
+            generation_id = self._next_generation_id + 1
+            candidate = self._builder(config, generation_id)
+
+            # 2. A short critical section publishes one complete generation.
+            async with self._lock:
+                previous = self._current
+                self._current = candidate
+                self._next_generation_id = generation_id
+                previous.retired = True
+                if previous.lease_count:
+                    self._retired[previous.generation_id] = previous
+        return candidate
+
+    async def _refresh_from_store_if_changed(self) -> None:
+        """Publish the latest committed database revision before a new scope."""
+
+        # 1. The revision check is cheap and never mutates the current generation.
+        revision = self._store.revision()
+        if revision == 0 or revision == self._current.registry_revision:
+            return
+
+        # 2. Serialize candidate construction and recheck after waiting for peers.
+        async with self._reload_lock:
+            revision = self._store.revision()
+            if revision == self._current.registry_revision:
+                return
+            config = Config.load(
+                self._config_path,
+                workspace=self._workspace_path,
+            )
+            generation_id = self._next_generation_id + 1
+            candidate = self._builder(config, generation_id)
+
+            # 3. Publish one complete generation; active leases retain the old one.
+            async with self._lock:
+                previous = self._current
+                self._current = candidate
+                self._next_generation_id = generation_id
+                previous.retired = True
+                if previous.lease_count:
+                    self._retired[previous.generation_id] = previous
+
+    async def refresh(self) -> ModelGeneration:
+        """Refresh from canonical storage and return the visible generation."""
+
+        await self._refresh_from_store_if_changed()
+        return self._current
+
+    @asynccontextmanager
+    async def execution_scope(
+        self,
+        explicit_runtime_id: str | None = None,
+        explicit_reasoning_effort: str = "",
+    ) -> AsyncIterator[ModelExecutionBinding]:
+        """Freeze one generation for a complete execution unit."""
+
+        existing = _CURRENT_BINDING.get()
+        if existing is not None:
+            if existing.registry is not self:
+                raise RuntimeError("同一执行不能绑定两个 ModelRegistry")
+            if (
+                explicit_runtime_id is not None
+                and explicit_runtime_id != existing.explicit_runtime_id
+            ):
+                raise RuntimeError("嵌套执行的显式模型绑定冲突")
+            if (
+                explicit_reasoning_effort
+                and explicit_reasoning_effort != existing.explicit_reasoning_effort
+            ):
+                raise RuntimeError("嵌套执行的推理强度绑定冲突")
+            yield existing
+            return
+
+        # 1. A new execution observes the latest committed database revision.
+        await self._refresh_from_store_if_changed()
+
+        # 2. Snapshot and validate before publishing the context-local binding.
+        generation = self._current
+        if explicit_runtime_id and explicit_runtime_id not in generation.runtimes:
+            raise ValueError(f"模型 runtime 不存在: {explicit_runtime_id}")
+        if explicit_reasoning_effort and not explicit_runtime_id:
+            raise ValueError("显式推理强度必须绑定显式模型 runtime")
+        if explicit_reasoning_effort and explicit_runtime_id:
+            runtime = generation.runtimes[explicit_runtime_id]
+            supported = runtime.supported_reasoning_efforts
+            if supported and explicit_reasoning_effort not in supported:
+                raise ValueError(
+                    f"模型 {runtime.model} 不支持推理强度: {explicit_reasoning_effort}"
+                )
+        generation.lease_count += 1
+        binding = ModelExecutionBinding(
+            self,
+            generation,
+            explicit_runtime_id,
+            explicit_reasoning_effort,
+        )
+        token = _CURRENT_BINDING.set(binding)
+        try:
+            yield binding
+        finally:
+            # 3. Release only this scope's lease; retired generations drain naturally.
+            _CURRENT_BINDING.reset(token)
+            generation.lease_count -= 1
+            if generation.lease_count < 0:
+                raise RuntimeError("模型 generation lease 计数为负")
+            if generation.retired and generation.lease_count == 0:
+                self._retired.pop(generation.generation_id, None)
+
+    def resolve(
+        self,
+        role: str,
+    ) -> tuple[ModelRuntimeConfig, Any, ModelExecutionBinding | None]:
+        binding = _CURRENT_BINDING.get()
+        if binding is not None and binding.registry is self:
+            _runtime_id, runtime, provider = binding.generation.resolve(
+                role,
+                binding.explicit_runtime_id,
+            )
+            return runtime, provider, binding
+        _runtime_id, runtime, provider = self._current.resolve(role, None)
+        return runtime, provider, None
+
+
+class RoleBoundProvider(LLMProvider):
+    """Preserve the LLMProvider surface while resolving through a registry role."""
+
+    def __init__(
+        self,
+        registry: ModelRegistry,
+        role: str,
+        *,
+        force_disable_thinking: bool = False,
+    ) -> None:
+        self.registry = registry
+        self.role = role
+        self.force_disable_thinking = force_disable_thinking
+
+    async def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        model: str,
+        max_tokens: int,
+        tool_choice: str | dict = "auto",
+        extra_body: dict | None = None,
+        disable_thinking: bool = False,
+        on_content_delta: Callable[[Any], Awaitable[None]] | None = None,
+        cache_namespace: str = "",
+    ) -> Any:
+        async with self.registry.execution_scope():
+            runtime, provider, binding = self.registry.resolve(self.role)
+            request_extra = dict(extra_body or {})
+            if binding is not None:
+                effort = binding.reasoning_effort_for(self.role, runtime)
+                if effort and not self.force_disable_thinking and not disable_thinking:
+                    request_extra["reasoning_effort"] = effort
+            return await provider.chat(
+                messages=messages,
+                tools=tools,
+                model=runtime.model,
+                max_tokens=(
+                    runtime.max_output_tokens if max_tokens == 0 else max_tokens
+                ),
+                tool_choice=tool_choice,
+                extra_body=request_extra,
+                disable_thinking=self.force_disable_thinking or disable_thinking,
+                on_content_delta=on_content_delta,
+                cache_namespace=cache_namespace,
+            )
+
+    @property
+    def context_window(self) -> int:
+        runtime, _provider, _binding = self.registry.resolve(self.role)
+        return runtime.context_window
+
+    @property
+    def compaction_trigger_tokens(self) -> int:
+        runtime, _provider, _binding = self.registry.resolve(self.role)
+        return int(runtime.context_window * runtime.compaction_trigger_percent)
+
+    @property
+    def hard_input_tokens(self) -> int:
+        runtime, _provider, _binding = self.registry.resolve(self.role)
+        return int(runtime.context_window * runtime.effective_context_percent)
+
+    def estimate_context_tokens(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+    ) -> int:
+        _runtime, provider, _binding = self.registry.resolve(self.role)
+        return int(provider.estimate_context_tokens(messages, tools))
+
+    def estimate_appended_message_tokens(self, messages: list[dict]) -> int:
+        _runtime, provider, _binding = self.registry.resolve(self.role)
+        return int(provider.estimate_appended_message_tokens(messages))
+
+    def __getattr__(self, name: str) -> Any:
+        _runtime, provider, _binding = self.registry.resolve(self.role)
+        try:
+            return getattr(provider, name)
+        except AttributeError:
+            primary = getattr(provider, "primary", None)
+            if primary is None:
+                raise
+            return getattr(primary, name)
+
+
+@asynccontextmanager
+async def model_execution_scope(
+    provider: object,
+    explicit_runtime_id: str | None = None,
+    explicit_reasoning_effort: str = "",
+) -> AsyncIterator[ModelExecutionBinding | None]:
+    """Lease a model generation when the provider is registry-backed."""
+
+    if not isinstance(provider, RoleBoundProvider):
+        yield None
+        return
+    async with provider.registry.execution_scope(
+        explicit_runtime_id,
+        explicit_reasoning_effort,
+    ) as binding:
+        yield binding
+
+
+def current_model_binding() -> ModelExecutionBinding | None:
+    return _CURRENT_BINDING.get()
+
+
+def model_config_digest(config: Config) -> str:
+    """Return a secret-free digest of runtime and role semantics."""
+
+    payload = {
+        "runtimes": {
+            runtime_id: {
+                "provider": runtime.provider,
+                "model": runtime.model,
+                "source_id": runtime.source_id,
+                "source_name": runtime.source_name,
+                "catalog_provider_id": runtime.catalog_provider_id,
+                "auth": runtime.auth,
+                "base_url": runtime.base_url,
+                "reasoning_effort": runtime.reasoning_effort,
+                "supported_reasoning_efforts": list(
+                    runtime.supported_reasoning_efforts
+                ),
+                "context_window": runtime.context_window,
+                "max_output_tokens": runtime.max_output_tokens,
+                "input_modalities": list(runtime.input_modalities),
+                "capability_source": runtime.capability_source,
+                "context_window_source": runtime.context_window_source,
+                "max_output_tokens_source": runtime.max_output_tokens_source,
+                "input_modalities_source": runtime.input_modalities_source,
+            }
+            for runtime_id, runtime in sorted(config.model_runtimes.items())
+        },
+        "roles": {
+            "default": config.runtime_id,
+            "fast": config.fast_runtime_id or config.runtime_id,
+            "agent": config.agent_runtime_id or config.runtime_id,
+            "vision": config.vl_runtime_id or config.runtime_id,
+        },
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/agent/model_runtime/store.py
+++ b/agent/model_runtime/store.py
@@ -1,0 +1,658 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from contextlib import closing, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Mapping
+
+from agent.model_runtime.auth.store import Credential, CredentialStore
+
+
+MODEL_REGISTRY_FILENAME = "model-registry.sqlite3"
+MODEL_ROLES = ("default", "fast", "agent", "vision")
+
+
+@dataclass(frozen=True)
+class StoredModelRuntime:
+    runtime_id: str
+    source_id: str
+    source_name: str
+    provider: str
+    catalog_provider_id: str
+    auth_id: str
+    base_url: str
+    model: str
+    reasoning_effort: str
+    supported_reasoning_efforts: tuple[str, ...]
+    context_window: int
+    max_output_tokens: int
+    input_modalities: tuple[str, ...]
+    capability_source: str
+    context_window_source: str
+    max_output_tokens_source: str
+    input_modalities_source: str
+    effective_context_percent: float
+    compaction_trigger_percent: float
+    use_responses_lite: bool
+    supports_parallel_tool_calls: bool
+    reasoning_summary: str
+
+    def as_config_table(self, *, effort: str = "") -> dict[str, object]:
+        """Render one normalized row into the existing config loader shape."""
+
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "source_id": self.source_id,
+            "source_name": self.source_name,
+            "catalog_provider_id": self.catalog_provider_id,
+            "auth": self.auth_id,
+            "base_url": self.base_url,
+            "reasoning_effort": effort or self.reasoning_effort,
+            "supported_reasoning_efforts": list(self.supported_reasoning_efforts),
+            "context_window": self.context_window,
+            "max_output_tokens": self.max_output_tokens,
+            "input_modalities": list(self.input_modalities),
+            "capability_source": self.capability_source,
+            "context_window_source": self.context_window_source,
+            "max_output_tokens_source": self.max_output_tokens_source,
+            "input_modalities_source": self.input_modalities_source,
+            "effective_context_percent": self.effective_context_percent,
+            "compaction_trigger_percent": self.compaction_trigger_percent,
+            "use_responses_lite": self.use_responses_lite,
+            "supports_parallel_tool_calls": self.supports_parallel_tool_calls,
+            "reasoning_summary": self.reasoning_summary,
+        }
+
+
+@dataclass(frozen=True)
+class ModelRoleBinding:
+    role: str
+    runtime_id: str
+    reasoning_effort: str
+
+
+@dataclass(frozen=True)
+class ModelRegistrySnapshot:
+    revision: int
+    runtimes: Mapping[str, StoredModelRuntime]
+    roles: Mapping[str, ModelRoleBinding]
+
+    def as_config_llm(self) -> dict[str, object]:
+        """Expose one database revision through the legacy config parser boundary."""
+
+        # 1. Every runtime keeps its own default effort for explicit chat selection.
+        runtime_tables = {
+            runtime_id: runtime.as_config_table()
+            for runtime_id, runtime in self.runtimes.items()
+        }
+
+        # 2. Existing consumers use role aliases; role-specific effort is compiled
+        # into a private runtime clone only when it differs from the model default.
+        aliases: dict[str, str] = {}
+        for role in MODEL_ROLES:
+            binding = self.roles.get(role)
+            if binding is None:
+                if role == "default":
+                    raise ValueError("模型注册库缺少 default 角色")
+                aliases[role] = aliases["default"]
+                continue
+            runtime = self.runtimes.get(binding.runtime_id)
+            if runtime is None:
+                raise ValueError(
+                    f"模型角色 {role} 引用了不存在的模型: {binding.runtime_id}"
+                )
+            alias = binding.runtime_id
+            if binding.reasoning_effort and (
+                binding.reasoning_effort != runtime.reasoning_effort
+            ):
+                alias = f"__role_{role}"
+                runtime_tables[alias] = runtime.as_config_table(
+                    effort=binding.reasoning_effort
+                )
+            aliases[role] = alias
+
+        return {
+            "main": aliases["default"],
+            "fast": aliases["fast"],
+            "agent": aliases["agent"],
+            "vl": aliases["vision"],
+            "runtimes": runtime_tables,
+        }
+
+
+class ModelRegistryStore:
+    """Read and transactionally update workspace-owned model configuration."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @classmethod
+    def for_workspace(cls, workspace: Path) -> ModelRegistryStore:
+        return cls(workspace / MODEL_REGISTRY_FILENAME)
+
+    def exists(self) -> bool:
+        return self.path.is_file()
+
+    def initialize(self) -> None:
+        """Create the normalized schema without inventing any model rows."""
+
+        # 1. Schema creation belongs to migration/onboarding owners.
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._create_database_file()
+        with self._connect() as connection:
+            connection.executescript(_SCHEMA)
+            connection.execute(
+                "INSERT OR IGNORE INTO model_registry_meta(singleton, revision) VALUES (1, 0)"
+            )
+            connection.commit()
+
+    def backup_to(self, target: Path) -> None:
+        """Publish a verified SQLite backup with private permissions."""
+
+        if not self.path.is_file():
+            raise FileNotFoundError(self.path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            raise FileExistsError(target)
+        target.touch(mode=0o600, exist_ok=False)
+        with self._connect(read_only=True) as source:
+            with closing(sqlite3.connect(target)) as destination:
+                source.backup(destination)
+        os.chmod(target, 0o600)
+        ModelRegistryStore(target).integrity_check()
+
+    def restore_from(self, source: Path) -> None:
+        """Restore a verified backup into the canonical database path."""
+
+        ModelRegistryStore(source).integrity_check()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._create_database_file()
+        with closing(sqlite3.connect(source)) as backup:
+            with closing(sqlite3.connect(self.path)) as destination:
+                backup.backup(destination)
+        self._secure_database_files()
+
+    def revision(self) -> int:
+        """Return the current committed model revision."""
+
+        if not self.exists():
+            return 0
+        with self._connect(read_only=True) as connection:
+            row = connection.execute(
+                "SELECT revision FROM model_registry_meta WHERE singleton = 1"
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("模型注册库缺少 revision 元数据")
+        return int(row[0])
+
+    def integrity_check(self) -> None:
+        """Fail loudly unless SQLite and every declared foreign key are valid."""
+
+        with self._connect(read_only=True) as connection:
+            result = connection.execute("PRAGMA integrity_check").fetchone()
+            if result is None or str(result[0]) != "ok":
+                raise RuntimeError(f"模型注册库完整性检查失败: {result}")
+            foreign_keys = connection.execute("PRAGMA foreign_key_check").fetchall()
+        if foreign_keys:
+            raise RuntimeError(f"模型注册库外键检查失败: {foreign_keys}")
+
+    def read_snapshot(self) -> ModelRegistrySnapshot | None:
+        """Read one consistent revision; an empty registry means onboarding."""
+
+        if not self.exists():
+            return None
+        with self._connect(read_only=True) as connection:
+            connection.execute("BEGIN")
+            revision_row = connection.execute(
+                "SELECT revision FROM model_registry_meta WHERE singleton = 1"
+            ).fetchone()
+            if revision_row is None:
+                raise RuntimeError("模型注册库缺少 revision 元数据")
+            model_rows = connection.execute(_SELECT_MODELS).fetchall()
+            role_rows = connection.execute(
+                "SELECT role, model_id, reasoning_effort FROM model_role_bindings"
+            ).fetchall()
+        if not model_rows:
+            return None
+        runtimes = {
+            str(row[0]): _stored_runtime_from_row(row)
+            for row in model_rows
+        }
+        roles = {
+            str(row[0]): ModelRoleBinding(
+                role=str(row[0]),
+                runtime_id=str(row[1]),
+                reasoning_effort=str(row[2] or ""),
+            )
+            for row in role_rows
+        }
+        if "default" not in roles:
+            raise RuntimeError("模型注册库缺少 default 角色")
+        return ModelRegistrySnapshot(
+            revision=int(revision_row[0]),
+            runtimes=runtimes,
+            roles=roles,
+        )
+
+    def replace_from_llm_config(
+        self,
+        llm: Mapping[str, object],
+        *,
+        source_names: Mapping[str, str] | None = None,
+        credentials: Mapping[str, Credential] | None = None,
+    ) -> int:
+        """Import validated named runtimes as one new database revision."""
+
+        runtimes = llm.get("runtimes")
+        if not isinstance(runtimes, Mapping) or not runtimes:
+            raise ValueError("llm.runtimes 必须是非空 table")
+        main = llm.get("main")
+        if not isinstance(main, str) or main not in runtimes:
+            raise ValueError("llm.main 必须引用已配置 runtime")
+
+        # 1. Normalize every runtime and connection before opening the write txn.
+        normalized = [
+            _normalize_runtime(runtime_id, raw, source_names or {})
+            for runtime_id, raw in runtimes.items()
+        ]
+        sources: dict[str, tuple[object, ...]] = {}
+        for source, _model in normalized:
+            source_id = str(source[0])
+            previous = sources.setdefault(source_id, source)
+            if previous != source:
+                raise ValueError(
+                    f"同一 source_id 的连接字段不一致: {source_id}"
+                )
+        roles = {
+            "default": main,
+            "fast": _role_ref(llm, "fast", main, runtimes),
+            "agent": _role_ref(llm, "agent", main, runtimes),
+            "vision": _role_ref(llm, "vl", main, runtimes),
+        }
+
+        # 2. Replace the imported projection atomically and bump one revision.
+        self.initialize()
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            existing_credentials: dict[str, tuple[str, str]] = {}
+            for auth_id, auth_kind, auth_payload in connection.execute(
+                """
+                SELECT auth_id, auth_kind, auth_payload
+                FROM model_connections
+                WHERE auth_id != '' AND auth_kind != '' AND auth_payload != ''
+                """
+            ).fetchall():
+                credential_id = str(auth_id)
+                encoded = (str(auth_kind), str(auth_payload))
+                previous = existing_credentials.setdefault(credential_id, encoded)
+                if previous != encoded:
+                    raise ValueError(f"模型凭据存在冲突: {credential_id}")
+            supplied_credentials = {
+                credential_id: CredentialStore.encode(credential)
+                for credential_id, credential in (credentials or {}).items()
+            }
+            connection.execute("DELETE FROM model_role_bindings")
+            connection.execute("DELETE FROM model_definitions")
+            inserted_sources: set[str] = set()
+            for source, model in normalized:
+                source_id = str(source[0])
+                if source_id not in inserted_sources:
+                    auth_id = str(source[4])
+                    auth_kind, auth_payload = supplied_credentials.get(
+                        auth_id,
+                        existing_credentials.get(auth_id, ("", "")),
+                    )
+                    connection.execute(
+                        _INSERT_CONNECTION,
+                        (*source, auth_kind, auth_payload),
+                    )
+                    inserted_sources.add(source_id)
+                connection.execute(_INSERT_MODEL, model)
+            for role, runtime_id in roles.items():
+                connection.execute(
+                    "INSERT INTO model_role_bindings(role, model_id, reasoning_effort) VALUES (?, ?, '')",
+                    (role, runtime_id),
+                )
+            connection.execute(
+                "UPDATE model_registry_meta SET revision = revision + 1 WHERE singleton = 1"
+            )
+            revision = int(
+                connection.execute(
+                    "SELECT revision FROM model_registry_meta WHERE singleton = 1"
+                ).fetchone()[0]
+            )
+            connection.commit()
+        return revision
+
+    def set_role(
+        self,
+        role: str,
+        runtime_id: str,
+        *,
+        reasoning_effort: str = "",
+        expected_revision: int | None = None,
+    ) -> int:
+        """Commit one role binding with optimistic concurrency."""
+
+        if role not in MODEL_ROLES:
+            raise ValueError(f"未知模型角色: {role}")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            current = int(
+                connection.execute(
+                    "SELECT revision FROM model_registry_meta WHERE singleton = 1"
+                ).fetchone()[0]
+            )
+            if expected_revision is not None and current != expected_revision:
+                raise RuntimeError("模型设置已经变化，请刷新后重试")
+            model = connection.execute(
+                "SELECT enabled FROM model_definitions WHERE id = ?",
+                (runtime_id,),
+            ).fetchone()
+            if model is None or not bool(model[0]):
+                raise ValueError(f"模型不存在或未启用: {runtime_id}")
+            connection.execute(
+                """
+                INSERT INTO model_role_bindings(role, model_id, reasoning_effort)
+                VALUES (?, ?, ?)
+                ON CONFLICT(role) DO UPDATE SET
+                    model_id = excluded.model_id,
+                    reasoning_effort = excluded.reasoning_effort,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (role, runtime_id, reasoning_effort.strip()),
+            )
+            connection.execute(
+                "UPDATE model_registry_meta SET revision = revision + 1 WHERE singleton = 1"
+            )
+            revision = current + 1
+            connection.commit()
+        return revision
+
+    @contextmanager
+    def _connect(
+        self,
+        *,
+        read_only: bool = False,
+    ) -> Iterator[sqlite3.Connection]:
+        if read_only:
+            uri = f"file:{self.path.as_posix()}?mode=ro"
+            connection = sqlite3.connect(uri, uri=True)
+        else:
+            connection = sqlite3.connect(self.path)
+        try:
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.row_factory = sqlite3.Row
+            yield connection
+        finally:
+            connection.close()
+            if not read_only:
+                self._secure_database_files()
+
+    def _create_database_file(self) -> None:
+        if self.path.exists():
+            os.chmod(self.path, 0o600)
+            return
+        descriptor = os.open(
+            self.path,
+            os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            0o600,
+        )
+        os.close(descriptor)
+
+    def _secure_database_files(self) -> None:
+        for path in (
+            self.path,
+            self.path.with_name(f"{self.path.name}-wal"),
+            self.path.with_name(f"{self.path.name}-shm"),
+        ):
+            if path.exists():
+                os.chmod(path, 0o600)
+
+
+def _normalize_runtime(
+    runtime_id: object,
+    raw: object,
+    source_names: Mapping[str, str],
+) -> tuple[tuple[object, ...], tuple[object, ...]]:
+    if not isinstance(runtime_id, str) or not runtime_id.strip():
+        raise ValueError("runtime id 必须是非空字符串")
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"llm.runtimes.{runtime_id} 必须是 table")
+    provider = str(raw.get("provider") or "").strip().lower()
+    model = str(raw.get("model") or "").strip()
+    if not provider or not model:
+        raise ValueError(f"runtime {runtime_id} 必须配置 provider 和 model")
+    modalities = raw.get("input_modalities", ["text"])
+    if not isinstance(modalities, list) or not all(
+        isinstance(value, str) for value in modalities
+    ):
+        raise ValueError(f"runtime {runtime_id} 的 input_modalities 无效")
+    efforts = raw.get("supported_reasoning_efforts", [])
+    if not isinstance(efforts, list) or not all(
+        isinstance(value, str) and value.strip() for value in efforts
+    ):
+        raise ValueError(
+            f"runtime {runtime_id} 的 supported_reasoning_efforts 无效"
+        )
+    source_id = str(raw.get("source_id") or f"source:{runtime_id}")
+    source_name = source_names.get(runtime_id) or str(raw.get("source_name") or provider)
+    source = (
+        source_id,
+        source_name,
+        provider,
+        str(raw.get("catalog_provider_id") or provider),
+        str(raw.get("auth") or ""),
+        str(raw.get("base_url") or ""),
+    )
+    model_row = (
+        runtime_id,
+        source_id,
+        model,
+        str(raw.get("reasoning_effort") or ""),
+        json.dumps(efforts, ensure_ascii=False, separators=(",", ":")),
+        int(raw.get("context_window") or 0),
+        int(raw.get("max_output_tokens") or 0),
+        json.dumps(modalities, ensure_ascii=False, separators=(",", ":")),
+        str(raw.get("capability_source") or "unknown"),
+        str(raw.get("context_window_source") or raw.get("capability_source") or "unknown"),
+        str(raw.get("max_output_tokens_source") or raw.get("capability_source") or "unknown"),
+        str(raw.get("input_modalities_source") or raw.get("capability_source") or "unknown"),
+        float(raw.get("effective_context_percent", 0.9)),
+        float(raw.get("compaction_trigger_percent", 0.74)),
+        int(bool(raw.get("use_responses_lite", False))),
+        int(bool(raw.get("supports_parallel_tool_calls", True))),
+        str(raw.get("reasoning_summary") or "none"),
+    )
+    return source, model_row
+
+
+def _role_ref(
+    llm: Mapping[str, object],
+    role: str,
+    fallback: str,
+    runtimes: Mapping[object, object],
+) -> str:
+    value = llm.get(role, fallback)
+    if not isinstance(value, str) or value not in runtimes:
+        raise ValueError(f"llm.{role} 必须引用已配置 runtime")
+    return value
+
+
+def _stored_runtime_from_row(row: sqlite3.Row) -> StoredModelRuntime:
+    raw_efforts = json.loads(str(row[9]))
+    if not isinstance(raw_efforts, list) or not all(
+        isinstance(item, str) and item.strip() for item in raw_efforts
+    ):
+        raise RuntimeError(f"模型 {row[0]} 的 supported_reasoning_efforts 已损坏")
+    raw_modalities = json.loads(str(row[11]))
+    if not isinstance(raw_modalities, list) or not all(
+        isinstance(item, str) for item in raw_modalities
+    ):
+        raise RuntimeError(f"模型 {row[0]} 的 input_modalities 已损坏")
+    return StoredModelRuntime(
+        runtime_id=str(row[0]),
+        source_id=str(row[1]),
+        source_name=str(row[2]),
+        provider=str(row[3]),
+        catalog_provider_id=str(row[4]),
+        auth_id=str(row[5]),
+        base_url=str(row[6]),
+        model=str(row[7]),
+        reasoning_effort=str(row[8]),
+        supported_reasoning_efforts=tuple(raw_efforts),
+        context_window=int(row[10]),
+        input_modalities=tuple(raw_modalities),
+        max_output_tokens=int(row[12]),
+        capability_source=str(row[13]),
+        context_window_source=str(row[14]),
+        max_output_tokens_source=str(row[15]),
+        input_modalities_source=str(row[16]),
+        effective_context_percent=float(row[17]),
+        compaction_trigger_percent=float(row[18]),
+        use_responses_lite=bool(row[19]),
+        supports_parallel_tool_calls=bool(row[20]),
+        reasoning_summary=str(row[21]),
+    )
+
+
+_SELECT_MODELS = """
+SELECT
+    m.id,
+    c.id,
+    c.name,
+    c.provider,
+    c.catalog_provider_id,
+    c.auth_id,
+    c.base_url,
+    m.model,
+    m.reasoning_effort,
+    m.supported_reasoning_efforts,
+    m.context_window,
+    m.input_modalities,
+    m.max_output_tokens,
+    m.capability_source,
+    m.context_window_source,
+    m.max_output_tokens_source,
+    m.input_modalities_source,
+    m.effective_context_percent,
+    m.compaction_trigger_percent,
+    m.use_responses_lite,
+    m.supports_parallel_tool_calls,
+    m.reasoning_summary
+FROM model_definitions AS m
+JOIN model_connections AS c ON c.id = m.connection_id
+WHERE m.enabled = 1 AND c.enabled = 1
+ORDER BY m.created_at, m.id
+"""
+
+_INSERT_CONNECTION = """
+INSERT INTO model_connections(
+    id, name, provider, catalog_provider_id, auth_id, base_url,
+    auth_kind, auth_payload
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    provider = excluded.provider,
+    catalog_provider_id = excluded.catalog_provider_id,
+    auth_id = excluded.auth_id,
+    base_url = excluded.base_url,
+    auth_kind = CASE
+        WHEN excluded.auth_payload != '' THEN excluded.auth_kind
+        ELSE model_connections.auth_kind
+    END,
+    auth_payload = CASE
+        WHEN excluded.auth_payload != '' THEN excluded.auth_payload
+        ELSE model_connections.auth_payload
+    END,
+    enabled = 1,
+    updated_at = CURRENT_TIMESTAMP
+"""
+
+_INSERT_MODEL = """
+INSERT INTO model_definitions(
+    id,
+    connection_id,
+    model,
+    reasoning_effort,
+    supported_reasoning_efforts,
+    context_window,
+    max_output_tokens,
+    input_modalities,
+    capability_source,
+    context_window_source,
+    max_output_tokens_source,
+    input_modalities_source,
+    effective_context_percent,
+    compaction_trigger_percent,
+    use_responses_lite,
+    supports_parallel_tool_calls,
+    reasoning_summary
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS model_registry_meta (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision INTEGER NOT NULL CHECK (revision >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS model_connections (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    catalog_provider_id TEXT NOT NULL DEFAULT '',
+    auth_id TEXT NOT NULL DEFAULT '',
+    base_url TEXT NOT NULL DEFAULT '',
+    auth_kind TEXT NOT NULL DEFAULT '',
+    auth_payload TEXT NOT NULL DEFAULT '',
+    enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS model_definitions (
+    id TEXT PRIMARY KEY,
+    connection_id TEXT NOT NULL REFERENCES model_connections(id) ON DELETE RESTRICT,
+    model TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    reasoning_effort TEXT NOT NULL DEFAULT '',
+    supported_reasoning_efforts TEXT NOT NULL DEFAULT '[]',
+    context_window INTEGER NOT NULL DEFAULT 0 CHECK (context_window >= 0),
+    max_output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (max_output_tokens >= 0),
+    input_modalities TEXT NOT NULL DEFAULT '["text"]',
+    capability_source TEXT NOT NULL DEFAULT 'unknown',
+    context_window_source TEXT NOT NULL DEFAULT 'unknown',
+    max_output_tokens_source TEXT NOT NULL DEFAULT 'unknown',
+    input_modalities_source TEXT NOT NULL DEFAULT 'unknown',
+    effective_context_percent REAL NOT NULL DEFAULT 0.9,
+    compaction_trigger_percent REAL NOT NULL DEFAULT 0.74,
+    use_responses_lite INTEGER NOT NULL DEFAULT 0 CHECK (use_responses_lite IN (0, 1)),
+    supports_parallel_tool_calls INTEGER NOT NULL DEFAULT 1 CHECK (supports_parallel_tool_calls IN (0, 1)),
+    reasoning_summary TEXT NOT NULL DEFAULT 'none',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(connection_id, model)
+);
+
+CREATE TABLE IF NOT EXISTS model_role_bindings (
+    role TEXT PRIMARY KEY CHECK (role IN ('default', 'fast', 'agent', 'vision')),
+    model_id TEXT NOT NULL REFERENCES model_definitions(id) ON DELETE RESTRICT,
+    reasoning_effort TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+__all__ = [
+    "MODEL_REGISTRY_FILENAME",
+    "MODEL_ROLES",
+    "ModelRegistrySnapshot",
+    "ModelRegistryStore",
+    "ModelRoleBinding",
+    "StoredModelRuntime",
+]

--- a/agent/model_runtime/transports/responses.py
+++ b/agent/model_runtime/transports/responses.py
@@ -29,6 +29,7 @@ from agent.model_runtime.types import (
     ToolCall,
     UsageCoverage,
 )
+from agent.model_runtime.usage import normalize_provider_usage
 
 
 class CodexResponsesTransport:
@@ -473,8 +474,11 @@ def _parse_usage(raw: Any) -> ModelUsage | None:
     output_tokens = _field(raw, "output_tokens")
     input_details = _field(raw, "input_tokens_details")
     output_details = _field(raw, "output_tokens_details")
-    return ModelUsage(
+    fallback = ModelUsage(
         input_tokens=int(input_tokens) if input_tokens is not None else None,
+        cache_write_input_tokens=_optional_int(
+            _field(input_details, "cache_write_tokens")
+        ),
         cached_input_tokens=_optional_int(_field(input_details, "cached_tokens")),
         output_tokens=int(output_tokens) if output_tokens is not None else None,
         reasoning_output_tokens=_optional_int(_field(output_details, "reasoning_tokens")),
@@ -485,6 +489,57 @@ def _parse_usage(raw: Any) -> ModelUsage | None:
             else UsageCoverage.PARTIAL
             if input_tokens is not None or output_tokens is not None
             else UsageCoverage.UNAVAILABLE
+        ),
+    )
+    normalized = normalize_provider_usage(
+        {"usage": _dump(raw)},
+        provider_id="openai",
+        provider_api_url="",
+        api_flavor="responses",
+        reasoning_output_tokens=fallback.reasoning_output_tokens,
+    )
+    if normalized is None:
+        return fallback
+    return ModelUsage(
+        input_tokens=(
+            normalized.input_tokens
+            if normalized.input_tokens is not None
+            else fallback.input_tokens
+        ),
+        cache_write_input_tokens=(
+            normalized.cache_write_input_tokens
+            if normalized.cache_write_input_tokens is not None
+            else fallback.cache_write_input_tokens
+        ),
+        cached_input_tokens=(
+            normalized.cached_input_tokens
+            if normalized.cached_input_tokens is not None
+            else fallback.cached_input_tokens
+        ),
+        output_tokens=(
+            normalized.output_tokens
+            if normalized.output_tokens is not None
+            else fallback.output_tokens
+        ),
+        reasoning_output_tokens=(
+            normalized.reasoning_output_tokens
+            if normalized.reasoning_output_tokens is not None
+            else fallback.reasoning_output_tokens
+        ),
+        request_count=max(normalized.request_count, fallback.request_count),
+        covered_request_count=max(
+            normalized.covered_request_count, fallback.covered_request_count
+        ),
+        coverage=(
+            UsageCoverage.EXACT
+            if (
+                (normalized.input_tokens is not None or fallback.input_tokens is not None)
+                and (
+                    normalized.output_tokens is not None
+                    or fallback.output_tokens is not None
+                )
+            )
+            else normalized.coverage
         ),
     )
 

--- a/agent/model_runtime/types.py
+++ b/agent/model_runtime/types.py
@@ -14,6 +14,7 @@ class UsageCoverage(StrEnum):
 @dataclass(frozen=True)
 class ModelUsage:
     input_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
     cached_input_tokens: int | None = None
     output_tokens: int | None = None
     reasoning_output_tokens: int | None = None

--- a/agent/model_runtime/usage.py
+++ b/agent/model_runtime/usage.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import logging
+from typing import Any
+
+from genai_prices import extract_usage
+
 from .types import ModelUsage, UsageCoverage
+
+logger = logging.getLogger(__name__)
 
 
 def aggregate_usage(items: list[ModelUsage]) -> ModelUsage:
@@ -17,13 +24,14 @@ def aggregate_usage(items: list[ModelUsage]) -> ModelUsage:
     covered = sum(item.covered_request_count for item in items)
     coverage = (
         UsageCoverage.UNAVAILABLE
-        if covered == 0
+        if all(item.coverage is UsageCoverage.UNAVAILABLE for item in items)
         else UsageCoverage.EXACT
         if covered == request_count and all(item.coverage is UsageCoverage.EXACT for item in items)
         else UsageCoverage.PARTIAL
     )
     return ModelUsage(
         input_tokens=total("input_tokens"),
+        cache_write_input_tokens=total("cache_write_input_tokens"),
         cached_input_tokens=total("cached_input_tokens"),
         output_tokens=total("output_tokens"),
         reasoning_output_tokens=total("reasoning_output_tokens"),
@@ -31,3 +39,57 @@ def aggregate_usage(items: list[ModelUsage]) -> ModelUsage:
         covered_request_count=covered,
         coverage=coverage,
     )
+
+
+def normalize_provider_usage(
+    response_data: Any,
+    *,
+    provider_id: str,
+    provider_api_url: str,
+    api_flavor: str,
+    reasoning_output_tokens: int | None = None,
+) -> ModelUsage | None:
+    """用 genai-prices 归一化 provider usage，并显式保留覆盖度。"""
+
+    # 1. 优先使用 provider 标识；兼容网关名称未知时再按 API URL 识别。
+    attempts: list[dict[str, str]] = []
+    if provider_id:
+        attempts.append({"provider_id": provider_id})
+    if provider_api_url:
+        attempts.append({"provider_api_url": provider_api_url})
+    for identity in attempts:
+        try:
+            extracted = extract_usage(
+                response_data,
+                api_flavor=api_flavor,
+                **identity,
+            )
+        except (LookupError, TypeError, ValueError):
+            continue
+        usage = extracted.usage
+        known = [usage.input_tokens, usage.output_tokens]
+        covered = int(all(value is not None for value in known))
+        coverage = (
+            UsageCoverage.EXACT
+            if covered
+            else UsageCoverage.PARTIAL
+            if any(value is not None for value in known)
+            else UsageCoverage.UNAVAILABLE
+        )
+        return ModelUsage(
+            input_tokens=usage.input_tokens,
+            cache_write_input_tokens=usage.cache_write_tokens,
+            cached_input_tokens=usage.cache_read_tokens,
+            output_tokens=usage.output_tokens,
+            reasoning_output_tokens=reasoning_output_tokens,
+            covered_request_count=covered,
+            coverage=coverage,
+        )
+
+    # 2. 未知兼容网关交还既有 wire parser；不把未知伪装为 0。
+    logger.info(
+        "usage normalizer unavailable provider=%s api_flavor=%s",
+        provider_id or "-",
+        api_flavor,
+    )
+    return None

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -36,6 +36,7 @@ from agent.model_runtime.types import (
     ToolCall,
     UsageCoverage,
 )
+from agent.model_runtime.usage import normalize_provider_usage
 
 if TYPE_CHECKING:
     from agent.config_models import ModelRuntimeConfig
@@ -313,6 +314,7 @@ class ChatCompletionsRuntime:
         read_timeout_s: float = 90.0,
         max_retries: int = 3,
         provider_name: str = "",
+        usage_provider_name: str = "",
         force_disable_thinking: bool = False,
         payload_snapshot_enabled: bool | None = None,
     ) -> None:
@@ -331,6 +333,7 @@ class ChatCompletionsRuntime:
         )
         self._base_url = normalized_base_url or ""
         self._provider_name = provider_name
+        self._usage_provider_name = usage_provider_name or provider_name
         self._extra_body = extra_body or {}
         self._max_retries = max(0, int(max_retries))
         self._force_disable_thinking = force_disable_thinking
@@ -399,7 +402,11 @@ class ChatCompletionsRuntime:
         cache_prompt_tokens, cache_hit_tokens = _extract_cache_usage(
             getattr(resp, "usage", None)
         )
-        usage = _extract_model_usage(getattr(resp, "usage", None))
+        usage = _normalize_chat_usage(
+            resp,
+            provider_id=self._usage_provider_name,
+            provider_api_url=self._base_url,
+        )
         if tool_calls:
             provider_fields = strategy.provider_fields_for_tool_call(
                 provider_fields,
@@ -493,7 +500,11 @@ class ChatCompletionsRuntime:
                 if prompt_tokens is not None:
                     cache_prompt_tokens = prompt_tokens
                     cache_hit_tokens = hit_tokens
-                    usage = _extract_model_usage(raw_usage)
+                    usage = _normalize_chat_usage(
+                        {"model": kwargs.get("model"), "usage": _dump_value(raw_usage)},
+                        provider_id=self._usage_provider_name,
+                        provider_api_url=self._base_url,
+                    )
                 choices = getattr(chunk, "choices", None) or []
                 if not choices:
                     continue
@@ -669,6 +680,7 @@ class LLMProvider:
         runtime: ModelRuntimeConfig,
         *,
         system_prompt: str,
+        credential_store: CredentialStore | None = None,
         extra_body: dict[str, object] | None = None,
         read_timeout_s: float = 90.0,
         force_disable_thinking: bool = False,
@@ -685,7 +697,9 @@ class LLMProvider:
             extra_body=body,
             read_timeout_s=read_timeout_s,
             provider_name=runtime.provider,
+            usage_provider_name=runtime.catalog_provider_id or runtime.provider,
             auth_id=runtime.auth,
+            credential_store=credential_store,
             runtime_id=runtime.runtime_id,
             context_window=runtime.context_window,
             effective_context_percent=runtime.effective_context_percent,
@@ -706,7 +720,9 @@ class LLMProvider:
         read_timeout_s: float = 90.0,
         max_retries: int = 3,
         provider_name: str = "",
+        usage_provider_name: str = "",
         auth_id: str = "",
+        credential_store: CredentialStore | None = None,
         runtime_id: str = "main",
         context_window: int = 0,
         effective_context_percent: float = 0.9,
@@ -734,7 +750,7 @@ class LLMProvider:
             )
         self._backend: ModelBackend
         if provider_name.lower() == "codex":
-            auth = CodexAuthDriver(CredentialStore(), auth_id)
+            auth = CodexAuthDriver(credential_store or CredentialStore(), auth_id)
             self._backend = CodexResponsesTransport(
                 auth,
                 runtime_id=runtime_id,
@@ -752,6 +768,7 @@ class LLMProvider:
                 read_timeout_s=read_timeout_s,
                 max_retries=max_retries,
                 provider_name=provider_name,
+                usage_provider_name=usage_provider_name,
                 force_disable_thinking=force_disable_thinking,
                 payload_snapshot_enabled=payload_snapshot_enabled,
             )
@@ -973,11 +990,15 @@ def _extract_model_usage(usage: Any) -> ModelUsage | None:
     prompt_details = _get_field(usage, "prompt_tokens_details")
     completion_details = _get_field(usage, "completion_tokens_details")
     cached_tokens = _coerce_int(_get_field(prompt_details, "cached_tokens"))
+    cache_write_tokens = _coerce_int(
+        _get_field(prompt_details, "cache_write_tokens")
+    )
     if cached_tokens is None:
         _, cached_tokens = _extract_cache_usage(usage)
     reasoning_tokens = _coerce_int(_get_field(completion_details, "reasoning_tokens"))
     return ModelUsage(
         input_tokens=prompt_tokens,
+        cache_write_input_tokens=cache_write_tokens,
         cached_input_tokens=cached_tokens,
         output_tokens=completion_tokens,
         reasoning_output_tokens=reasoning_tokens,
@@ -990,6 +1011,83 @@ def _extract_model_usage(usage: Any) -> ModelUsage | None:
             else UsageCoverage.UNAVAILABLE
         ),
     )
+
+
+def _normalize_chat_usage(
+    response: Any,
+    *,
+    provider_id: str,
+    provider_api_url: str,
+) -> ModelUsage | None:
+    """优先用成熟 extractor 归一化，未知兼容格式沿用 wire parser。"""
+
+    data = _dump_value(response)
+    raw_usage = _get_field(response, "usage")
+    if isinstance(response, dict):
+        raw_usage = response.get("usage")
+    completion_details = _get_field(raw_usage, "completion_tokens_details")
+    reasoning_tokens = _coerce_int(_get_field(completion_details, "reasoning_tokens"))
+    fallback = _extract_model_usage(raw_usage)
+    normalized = normalize_provider_usage(
+        data,
+        provider_id=provider_id,
+        provider_api_url=provider_api_url,
+        api_flavor="chat",
+        reasoning_output_tokens=reasoning_tokens,
+    )
+    if normalized is None:
+        return fallback
+    if fallback is None:
+        return normalized
+    input_tokens = (
+        normalized.input_tokens
+        if normalized.input_tokens is not None
+        else fallback.input_tokens
+    )
+    output_tokens = (
+        normalized.output_tokens
+        if normalized.output_tokens is not None
+        else fallback.output_tokens
+    )
+    covered = int(input_tokens is not None and output_tokens is not None)
+    coverage = (
+        UsageCoverage.EXACT
+        if covered
+        else UsageCoverage.PARTIAL
+        if input_tokens is not None or output_tokens is not None
+        else UsageCoverage.UNAVAILABLE
+    )
+    return ModelUsage(
+        input_tokens=input_tokens,
+        cache_write_input_tokens=(
+            normalized.cache_write_input_tokens
+            if normalized.cache_write_input_tokens is not None
+            else fallback.cache_write_input_tokens
+        ),
+        cached_input_tokens=(
+            normalized.cached_input_tokens
+            if normalized.cached_input_tokens is not None
+            else fallback.cached_input_tokens
+        ),
+        output_tokens=output_tokens,
+        reasoning_output_tokens=(
+            normalized.reasoning_output_tokens
+            if normalized.reasoning_output_tokens is not None
+            else fallback.reasoning_output_tokens
+        ),
+        request_count=max(normalized.request_count, fallback.request_count),
+        covered_request_count=covered,
+        coverage=coverage,
+    )
+
+
+def _dump_value(value: Any) -> Any:
+    if isinstance(value, dict) or value is None:
+        return value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    return value
 
 
 def _iter_tool_call_deltas(delta: Any) -> list[dict[str, str | int]]:

--- a/bootstrap/memory.py
+++ b/bootstrap/memory.py
@@ -204,6 +204,8 @@ def _consolidation_input_budget(config: Config) -> int | None:
     budgets = []
     for runtime_id in sorted(runtime_ids):
         runtime = config.model_runtimes[runtime_id]
+        if runtime.context_window <= 0:
+            return None
         budgets.append(
             build_runtime_context_budget(
                 runtime.context_window,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,14 @@ duckduckgo_search>=8.0.0
 fake-useragent>=2.0.0
 fastapi>=0.134.0
 ftfy>=6.3.1
+genai-prices==0.0.71
 html2text>=2025.4.0
 httpx[socks]>=0.28.0
 httpcore>=1.0,<2
 json_repair>=0.58.0
 jieba>=0.42.1
 lark-oapi>=1.6.8
+litellm==1.95.0
 lxml>=6.0.0
 markdown-it-py>=4.0.0
 mdit-py-plugins>=0.5.0

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from agent.config_models import Config, ModelRuntimeConfig
+from agent.model_runtime.registry import (
+    ModelGeneration,
+    ModelRegistry,
+    current_model_binding,
+    model_config_digest,
+)
+from agent.model_runtime.catalog.litellm_registry import resolve_catalog_capabilities
+from agent.model_runtime.catalog.litellm_registry import resolve_catalog_provider_id
+from agent.model_runtime.types import LLMResponse
+from agent.model_runtime.usage import normalize_provider_usage
+from agent.provider import _normalize_chat_usage
+
+
+class _Provider:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[str] = []
+        self.last_kwargs: dict[str, object] = {}
+
+    async def chat(self, **kwargs: object) -> LLMResponse:
+        self.last_kwargs = dict(kwargs)
+        self.calls.append(str(kwargs["model"]))
+        return LLMResponse(content=self.name)
+
+
+def _config(default: str = "a", fast: str = "fast-a") -> Config:
+    runtimes = {
+        runtime_id: ModelRuntimeConfig(
+            runtime_id=runtime_id,
+            provider="openai",
+            model=f"model-{runtime_id}",
+            max_output_tokens=4096 if runtime_id == "a" else 8192,
+        )
+        for runtime_id in ("a", "b", "fast-a", "fast-b")
+    }
+    return Config(
+        provider="openai",
+        model=runtimes[default].model,
+        api_key="test",
+        system_prompt="test",
+        runtime_id=default,
+        model_runtimes=runtimes,
+        fast_runtime_id=fast,
+    )
+
+
+def _builder(config: Config, generation_id: int) -> ModelGeneration:
+    providers = {
+        runtime_id: _Provider(f"generation-{generation_id}:{runtime_id}")
+        for runtime_id in config.model_runtimes
+    }
+    return ModelGeneration(
+        generation_id=generation_id,
+        config_digest=model_config_digest(config),
+        runtimes=dict(config.model_runtimes),
+        providers=providers,
+        role_runtime_ids={
+            "default": config.runtime_id,
+            "fast": config.fast_runtime_id or config.runtime_id,
+            "agent": config.agent_runtime_id or config.runtime_id,
+            "vision": config.vl_runtime_id or config.runtime_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_running_execution_keeps_generation_and_next_execution_uses_reload() -> None:
+    registry = ModelRegistry(_config(), _builder)
+    provider = registry.provider("default")
+
+    async with registry.execution_scope() as binding:
+        assert binding.describe()["runtime_id"] == "a"
+        first = await provider.chat([], [], "ignored", 0)
+        await registry.reload(_config(default="b", fast="fast-b"))
+        second = await provider.chat([], [], "ignored", 0)
+
+    third = await provider.chat([], [], "ignored", 0)
+    assert [first.content, second.content, third.content] == [
+        "generation-1:a",
+        "generation-1:a",
+        "generation-2:b",
+    ]
+    assert registry.current.generation_id == 2
+
+
+@pytest.mark.asyncio
+async def test_role_provider_resolves_dynamic_default_limit_and_local_override() -> None:
+    registry = ModelRegistry(_config(), _builder)
+    provider = registry.provider("default", force_disable_thinking=True)
+
+    await provider.chat([], [], "ignored", 0)
+    first_concrete = registry.current.providers["a"]
+    assert first_concrete.calls == ["model-a"]
+    assert first_concrete.last_kwargs["max_tokens"] == 4096
+    assert first_concrete.last_kwargs["disable_thinking"] is True
+
+    await registry.reload(_config(default="b"))
+    await provider.chat([], [], "ignored", 0)
+    second_concrete = registry.current.providers["b"]
+    assert second_concrete.last_kwargs["max_tokens"] == 8192
+
+    await provider.chat([], [], "ignored", 512)
+    assert second_concrete.last_kwargs["max_tokens"] == 512
+
+
+@pytest.mark.asyncio
+async def test_execution_not_started_at_reload_uses_new_generation() -> None:
+    registry = ModelRegistry(_config(), _builder)
+    provider = registry.provider("fast")
+    release = asyncio.Event()
+
+    async def queued() -> str | None:
+        await release.wait()
+        response = await provider.chat([], [], "ignored", 0)
+        return response.content
+
+    task = asyncio.create_task(queued())
+    await registry.reload(_config(default="b", fast="fast-b"))
+    release.set()
+    assert await task == "generation-2:fast-b"
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_runtime_survives_default_reload() -> None:
+    registry = ModelRegistry(_config(), _builder)
+    provider = registry.provider("agent")
+
+    async with registry.execution_scope("b") as binding:
+        assert current_model_binding() is binding
+        await registry.reload(_config(default="b"))
+        response = await provider.chat([], [], "ignored", 0)
+        assert response.content == "generation-1:b"
+    assert current_model_binding() is None
+
+    response = await provider.chat([], [], "ignored", 0)
+    assert response.content == "generation-2:b"
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_effort_is_scoped_to_selected_chat_model() -> None:
+    config = _config()
+    runtimes = dict(config.model_runtimes)
+    runtimes["b"] = replace(
+        runtimes["b"],
+        reasoning_effort="medium",
+        supported_reasoning_efforts=("low", "medium", "high"),
+    )
+    registry = ModelRegistry(replace(config, model_runtimes=runtimes), _builder)
+    agent = registry.provider("agent")
+    fast = registry.provider("fast")
+
+    async with registry.execution_scope("b", "high"):
+        await agent.chat([], [], "ignored", 0)
+        await fast.chat([], [], "ignored", 0)
+
+    assert registry.current.providers["b"].last_kwargs["extra_body"] == {
+        "reasoning_effort": "high"
+    }
+    assert registry.current.providers["fast-a"].last_kwargs["extra_body"] == {}
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_effort_rejects_unsupported_value() -> None:
+    config = _config()
+    runtimes = dict(config.model_runtimes)
+    runtimes["b"] = replace(
+        runtimes["b"],
+        supported_reasoning_efforts=("low", "high"),
+    )
+    registry = ModelRegistry(replace(config, model_runtimes=runtimes), _builder)
+
+    with pytest.raises(ValueError, match="不支持推理强度"):
+        async with registry.execution_scope("b", "medium"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_invalid_candidate_does_not_replace_current_generation() -> None:
+    def builder(config: Config, generation_id: int) -> ModelGeneration:
+        if config.system_prompt == "broken":
+            raise ValueError("candidate failed")
+        return _builder(config, generation_id)
+
+    registry = ModelRegistry(_config(), builder)
+    with pytest.raises(ValueError, match="candidate failed"):
+        await registry.reload(replace(_config(default="b"), system_prompt="broken"))
+    assert registry.current.generation_id == 1
+    assert registry.current.role_runtime_ids["default"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_nested_scope_reuses_binding_and_rejects_conflict() -> None:
+    registry = ModelRegistry(_config(), _builder)
+    async with registry.execution_scope("a") as outer:
+        async with registry.execution_scope() as inner:
+            assert inner is outer
+        with pytest.raises(RuntimeError, match="显式模型绑定冲突"):
+            async with registry.execution_scope("b"):
+                pass
+
+    with pytest.raises(ValueError, match="模型 runtime 不存在"):
+        async with registry.execution_scope("missing"):
+            pass
+
+
+def test_litellm_registry_resolves_caps_and_keeps_unknown_explicit() -> None:
+    known = resolve_catalog_capabilities("openai", "gpt-5.2-pro")
+    assert known is not None
+    assert known.context_window == 400_000
+    assert known.max_output_tokens == 128_000
+    assert known.input_modalities == ("text", "image")
+    assert known.input_modalities_known is True
+    assert known.supported_reasoning_efforts == (
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    )
+    assert known.source == "litellm"
+    assert resolve_catalog_capabilities("unknown", "future-model") is None
+    assert (
+        resolve_catalog_provider_id(
+            "openai",
+            model="deepseek-chat",
+            base_url="https://api.deepseek.com/v1",
+        )
+        == "deepseek"
+    )
+    assert (
+        resolve_catalog_provider_id(
+            "unknown",
+            model="future-model",
+            base_url="https://api.deepseek.com.evil.invalid/v1",
+        )
+        == ""
+    )
+
+
+def test_genai_prices_normalizes_cache_read_and_write_fields() -> None:
+    usage = normalize_provider_usage(
+        {
+            "model": "openai/gpt-4.1",
+            "usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 30,
+                "prompt_tokens_details": {
+                    "cached_tokens": 80,
+                    "cache_write_tokens": 12,
+                },
+            },
+        },
+        provider_id="openrouter",
+        provider_api_url="https://openrouter.ai/api/v1",
+        api_flavor="chat",
+    )
+    assert usage is not None
+    assert usage.input_tokens == 120
+    assert usage.cache_write_input_tokens == 12
+    assert usage.cached_input_tokens == 80
+    assert usage.output_tokens == 30
+    assert usage.coverage.value == "exact"
+
+
+def test_genai_prices_unknown_provider_does_not_fake_usage() -> None:
+    usage = normalize_provider_usage(
+        {"usage": {"prompt_tokens": 2, "completion_tokens": 1}},
+        provider_id="private-gateway",
+        provider_api_url="https://llm.internal.invalid/v1",
+        api_flavor="chat",
+    )
+    assert usage is None
+
+
+def test_usage_normalizer_preserves_deepseek_cache_hit_extension() -> None:
+    usage = _normalize_chat_usage(
+        {
+            "model": "deepseek-chat",
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "prompt_cache_hit_tokens": 70,
+                "prompt_cache_miss_tokens": 30,
+            },
+        },
+        provider_id="deepseek",
+        provider_api_url="https://api.deepseek.com/v1",
+    )
+    assert usage is not None
+    assert usage.input_tokens == 100
+    assert usage.cached_input_tokens == 70
+    assert usage.output_tokens == 20
+    assert usage.coverage.value == "exact"
+
+
+def test_usage_aggregate_preserves_partial_requests() -> None:
+    from agent.model_runtime.types import ModelUsage, UsageCoverage
+    from agent.model_runtime.usage import aggregate_usage
+
+    usage = aggregate_usage(
+        [
+            ModelUsage(
+                input_tokens=10,
+                coverage=UsageCoverage.PARTIAL,
+                request_count=1,
+            )
+        ]
+    )
+    assert usage.input_tokens == 10
+    assert usage.covered_request_count == 0
+    assert usage.coverage is UsageCoverage.PARTIAL

--- a/tests/test_model_registry_store.py
+++ b/tests/test_model_registry_store.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.config_models import Config
+from agent.model_runtime.errors import AuthenticationError
+from agent.model_runtime.auth.store import Credential, CredentialStore
+from agent.model_runtime.registry import ModelGeneration, ModelRegistry
+from agent.model_runtime.store import ModelRegistryStore
+
+
+_CONFIG = """
+[runtime]
+workspace = "unused"
+
+[llm]
+main = "legacy"
+
+[llm.runtimes.legacy]
+provider = "openai"
+model = "legacy-model"
+input_modalities = ["text"]
+
+[agent]
+system_prompt = "test"
+"""
+
+
+def _llm_rows() -> dict[str, object]:
+    return {
+        "main": "model-a",
+        "fast": "model-b",
+        "agent": "model-a",
+        "vl": "model-b",
+        "runtimes": {
+            "model-a": {
+                "provider": "openai",
+                "model": "alpha",
+                "base_url": "https://one.example/v1",
+                "reasoning_effort": "medium",
+                "supported_reasoning_efforts": ["low", "medium", "high"],
+                "context_window": 128_000,
+                "max_output_tokens": 8_192,
+                "input_modalities": ["text", "image"],
+                "capability_source": "litellm",
+            },
+            "model-b": {
+                "provider": "openai",
+                "model": "beta",
+                "base_url": "https://two.example/v1",
+                "input_modalities": ["text"],
+            },
+        },
+    }
+
+
+def test_model_store_imports_connections_models_and_roles(tmp_path: Path) -> None:
+    store = ModelRegistryStore.for_workspace(tmp_path)
+
+    revision = store.replace_from_llm_config(
+        _llm_rows(),
+        source_names={"model-a": "主账号", "model-b": "备用账号"},
+    )
+    snapshot = store.read_snapshot()
+
+    assert revision == 1
+    assert snapshot is not None
+    assert snapshot.revision == 1
+    assert snapshot.runtimes["model-a"].source_name == "主账号"
+    assert snapshot.runtimes["model-a"].input_modalities == ("text", "image")
+    assert snapshot.runtimes["model-a"].supported_reasoning_efforts == (
+        "low",
+        "medium",
+        "high",
+    )
+    assert snapshot.roles["fast"].runtime_id == "model-b"
+    assert snapshot.as_config_llm()["main"] == "model-a"
+
+
+def test_role_update_is_revisioned_and_rejects_stale_writer(tmp_path: Path) -> None:
+    store = ModelRegistryStore.for_workspace(tmp_path)
+    _ = store.replace_from_llm_config(_llm_rows())
+
+    revision = store.set_role(
+        "default",
+        "model-b",
+        reasoning_effort="high",
+        expected_revision=1,
+    )
+
+    assert revision == 2
+    snapshot = store.read_snapshot()
+    assert snapshot is not None
+    assert snapshot.roles["default"].runtime_id == "model-b"
+    assert snapshot.roles["default"].reasoning_effort == "high"
+    with pytest.raises(RuntimeError, match="已经变化"):
+        store.set_role("default", "model-a", expected_revision=1)
+
+
+def test_config_load_prefers_workspace_model_database(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_CONFIG, encoding="utf-8")
+    store = ModelRegistryStore.for_workspace(tmp_path)
+    _ = store.replace_from_llm_config(_llm_rows())
+
+    config = Config.load(config_path, workspace=tmp_path)
+
+    assert config.model == "alpha"
+    assert config.runtime_id == "model-a"
+    assert config.fast_runtime_id == "model-b"
+    assert config.model_registry_revision == 1
+
+
+def test_model_credentials_live_in_private_workspace_database(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_CONFIG, encoding="utf-8")
+    llm = _llm_rows()
+    runtimes = llm["runtimes"]
+    assert isinstance(runtimes, dict)
+    runtimes["model-a"]["auth"] = "primary"  # type: ignore[index]
+    store = ModelRegistryStore.for_workspace(tmp_path)
+
+    store.replace_from_llm_config(
+        llm,
+        credentials={
+            "primary": Credential(driver="api_key", access_token="secret")
+        },
+    )
+
+    credentials = CredentialStore.for_workspace(tmp_path)
+    assert credentials.api_key("primary") == "secret"
+    assert Config.load(config_path, workspace=tmp_path).api_key == "secret"
+    assert os.stat(store.path).st_mode & 0o777 == 0o600
+    assert not (tmp_path / "auth.json").exists()
+
+
+def test_workspace_credential_store_rejects_broad_database_permissions(
+    tmp_path: Path,
+) -> None:
+    store = ModelRegistryStore.for_workspace(tmp_path)
+    store.replace_from_llm_config(
+        _llm_rows(),
+        credentials={
+            "unused": Credential(driver="api_key", access_token="secret")
+        },
+    )
+    os.chmod(store.path, 0o644)
+
+    with pytest.raises(AuthenticationError, match="权限过宽"):
+        CredentialStore.for_workspace(tmp_path).metadata()
+
+
+@pytest.mark.asyncio
+async def test_new_execution_reads_latest_role_while_active_scope_keeps_snapshot(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(_CONFIG, encoding="utf-8")
+    store = ModelRegistryStore.for_workspace(tmp_path)
+    _ = store.replace_from_llm_config(_llm_rows())
+
+    def build(config: Config, generation_id: int) -> ModelGeneration:
+        return ModelGeneration(
+            generation_id=generation_id,
+            config_digest=str(config.model_registry_revision),
+            runtimes=dict(config.model_runtimes),
+            providers={runtime_id: object() for runtime_id in config.model_runtimes},
+            role_runtime_ids={
+                "default": config.runtime_id,
+                "fast": config.fast_runtime_id,
+                "agent": config.agent_runtime_id,
+                "vision": config.vl_runtime_id,
+            },
+            registry_revision=config.model_registry_revision,
+        )
+
+    registry = ModelRegistry(Config.load(config_path, workspace=tmp_path), build)
+    async with registry.execution_scope() as active:
+        assert active.describe("default")["model"] == "alpha"
+        _ = store.set_role("default", "model-b", expected_revision=1)
+        assert active.describe("default")["model"] == "alpha"
+
+    async with registry.execution_scope() as next_execution:
+        assert next_execution.describe("default")["model"] == "beta"
+        assert next_execution.generation.registry_revision == 2

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -6,6 +6,8 @@ import os
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -37,6 +39,7 @@ from agent.model_runtime.transports.responses import (
 from agent.model_runtime.types import ModelRequest, ModelUsage, UsageCoverage
 from agent.model_runtime.usage import aggregate_usage
 from bootstrap.setup_wizard import WizardAnswers, _persist_answer_credentials, _render_config
+from bootstrap.memory import _consolidation_input_budget
 from session.store import _decode_message_extra
 
 
@@ -111,6 +114,23 @@ def test_context_budget_and_runtime_config_share_the_same_boundary() -> None:
             effective_context_percent=0.8,
             max_output_tokens=8_000,
         )
+
+
+def test_unknown_runtime_context_disables_consolidation_budget() -> None:
+    config = SimpleNamespace(
+        runtime_id="main",
+        fast_runtime_id="",
+        context_window=0,
+        effective_context_percent=0.9,
+        model_runtimes={
+            "main": SimpleNamespace(
+                context_window=0,
+                effective_context_percent=0.9,
+            )
+        },
+    )
+
+    assert _consolidation_input_budget(cast(Any, config)) is None
 
 
 def test_opencode_go_profile_is_dynamic_and_rejects_wrong_wire() -> None:
@@ -236,6 +256,43 @@ async def test_opencode_go_catalog_uses_http_boundary_and_opencode_variants(
         "high",
     )
     assert requests == [("/v1/models", "Bearer secret")]
+
+
+@pytest.mark.asyncio
+async def test_opencode_go_catalog_uses_local_registry_when_cli_is_unavailable(
+    monkeypatch,
+) -> None:
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"id": "deepseek-v4-flash"}]}
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return Response()
+
+    async def unavailable(_executable: str):
+        raise TransportError("无法执行 OpenCode 模型探测")
+
+    monkeypatch.setattr(
+        "agent.model_runtime.catalog.opencode_go.httpx.AsyncClient",
+        lambda **_kwargs: Client(),
+    )
+    monkeypatch.setattr(
+        "agent.model_runtime.catalog.opencode_go._load_opencode_go_reasoning_efforts",
+        unavailable,
+    )
+
+    models = await OpenCodeGoModelCatalog("secret").list_models()
+
+    assert models[0].supported_reasoning_efforts == ("low", "medium", "high")
 
 
 def test_credential_store_is_atomic_private_and_fail_loud(tmp_path: Path) -> None:
@@ -716,7 +773,10 @@ def test_usage_keeps_partial_coverage_unknown() -> None:
     ])
     parsed = _parse_usage({
         "input_tokens": 100,
-        "input_tokens_details": {"cached_tokens": 70},
+        "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 70,
+        },
         "output_tokens": 20,
         "output_tokens_details": {"reasoning_tokens": 8},
     })
@@ -724,4 +784,8 @@ def test_usage_keeps_partial_coverage_unknown() -> None:
     assert usage.coverage is UsageCoverage.PARTIAL
     assert (usage.input_tokens, usage.output_tokens) == (100, 20)
     assert parsed is not None
-    assert (parsed.cached_input_tokens, parsed.reasoning_output_tokens) == (70, 8)
+    assert (
+        parsed.cache_write_input_tokens,
+        parsed.cached_input_tokens,
+        parsed.reasoning_output_tokens,
+    ) == (0, 70, 8)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：模型配置、能力和 usage 没有统一权威 owner。
- 用户可见结果：建立 workspace SQLite 模型注册表，统一 Codex、OpenCode Go 和 API provider 的能力与 usage 表达。
- 本 PR 不处理：执行期租约、Web 入口、设置 UI 和聊天胶囊。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：模型 transport、provider 能力、usage 和 workspace registry
- `runtime_patch`：`none`
- `authoritative_state_owner`：`workspace/model-registry.sqlite3`
- 禁止的副作用：不修改正式 workspace，不伪造 unknown usage 为 0

## 改动范围

- 主要文件：`agent/model_runtime/**`、`agent/provider.py`、`agent/config*.py`
- 配置或迁移影响：只建立 core schema/API；Yoyo 迁移在第 3 层。
- 回滚方式：回退 `b1520f61`。

## 验证

- [x] 62 项 registry/store/runtime/config targeted tests 通过。
- [x] `git diff --check` 通过。
- [ ] 单层 Change Gate 未单独运行；六层累计 Gate 已通过。

## 工作手册

- [x] 已核对 `projectneed.md`、持久化地图和相关实现。
- [x] 长期语义变化已获得维护者确认。
- [x] 本 PR 是 1/6，adjacent diff 为 `main...stack/runtime-model-core`。

## PR 堆栈

**#330** → #331 → #332 → #333 → #334 → #327
