### PR TITLE
[codex] 为完整执行冻结模型代际

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -2461,6 +2461,7 @@ class DefaultReasoner(Reasoner):
         usage = aggregate_usage(model_usages or [])
         react_stats["model_usage"] = {
             "input_tokens": usage.input_tokens,
+            "cache_write_input_tokens": usage.cache_write_input_tokens,
             "cached_input_tokens": usage.cached_input_tokens,
             "output_tokens": usage.output_tokens,
             "reasoning_output_tokens": usage.reasoning_output_tokens,

--- a/agent/lifecycle/phases/after_turn.py
+++ b/agent/lifecycle/phases/after_turn.py
@@ -21,6 +21,7 @@ from agent.lifecycle.phase import (
     topo_sort_modules,
 )
 from agent.lifecycle.types import AfterTurnCtx, TurnPersistencePolicy, TurnSnapshot
+from agent.model_runtime.registry import current_model_binding
 from agent.turns.outbound import OutboundDispatch, OutboundPort
 from bus.event_bus import EventBus
 from bus.events import OutboundMessage
@@ -88,11 +89,15 @@ class _BuildTurnWorkModule:
             history_window=hw,
         )
         frame.slots[_REACT_STATS_SLOT] = extract_react_stats(snap.ctx.context_retry)
-        frame.slots[_EXTRA_SLOT] = (
+        extra: dict[str, object] = (
             {"skip_post_memory": True}
             if (msg.metadata or {}).get("skip_post_memory")
             else {}
         )
+        binding = current_model_binding()
+        if binding is not None:
+            extra["model_binding"] = binding.describe("agent")
+        frame.slots[_EXTRA_SLOT] = extra
         frame.slots[_TOOL_CHAIN_SLOT] = list(snap.ctx.tool_chain)
         frame.slots[_PERSISTENCE_SLOT] = state.persistence
         return frame
@@ -177,8 +182,20 @@ class _BuildTurnCommittedModule:
             model_usage=(
                 dict(raw_model_usage) if isinstance(raw_model_usage, dict) else {}
             ),
+            model_binding=_model_binding_from_extra(frame.slots[_EXTRA_SLOT]),
         )
         return frame
+
+
+def _model_binding_from_extra(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError("after_turn extra 不是 dict")
+    raw = value.get("model_binding")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise TypeError("after_turn model_binding 不是 dict")
+    return {str(key): item for key, item in raw.items()}
 
 
 class _CollectAfterTurnExtraSlotsModule:

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -32,6 +32,12 @@ from agent.looping.ports import (
     SessionServices,
 )
 from agent.looping.session_lane import SessionLaneRegistry
+from agent.model_runtime.registry import RoleBoundProvider, model_execution_scope
+from agent.model_runtime.session_selection import (
+    SessionModelSelection,
+    read_session_model_selection,
+    write_session_model_selection,
+)
 from agent.retrieval.default_pipeline import DefaultMemoryRetrievalPipeline
 from agent.retrieval.protocol import MemoryRetrievalPipeline
 from agent.turns.outbound import BusOutboundPort
@@ -708,51 +714,103 @@ class AgentLoop:
     ) -> OutboundMessage:
         key = session_key or msg.session_key
         busy_key = busy_session_key or key
-        # 给本 turn task 打上 session 归属，供 observe 全局错误采集关联。
-        session_token = current_session_key.set(key)
-        inherited_turn_id = (
-            str(
-                msg.metadata.get("_control_execution_turn_id")
-                or msg.metadata.get("control_turn_id")
-                or ""
-            )
-            if isinstance(msg, InboundMessage)
-            else ""
-        )
-        turn_token = current_turn_id.set(inherited_turn_id or new_turn_id())
-        try:
-            # 1. 先处理可能存在的续跑态，并发布 turn started。
-            msg, resumed_from_interrupt = await self._resume_interrupted_message(
-                msg, key
-            )
-            await self._observe_turn_started(msg, key)
-            content = _item_content(msg)
-            preview = content[:60] + "..." if len(content) > 60 else content
-            logger.info(f"Processing message from {msg.channel}: {preview}")
+        model_selection = await self._resolve_model_selection(msg, key)
+        async with model_execution_scope(
+            self._llm_services.provider,
+            model_selection.model_ref or None,
+            model_selection.reasoning_effort,
+        ) as model_binding:
+            if model_binding is not None and isinstance(msg, InboundMessage):
+                msg.metadata["model_binding"] = model_binding.describe("agent")
 
-            # 2. 再进入 busy 状态并执行核心处理。
-            if self._processing_state:
-                self._processing_state.enter(busy_key)
-            try:
-                outbound = await self._core_runner.process(
-                    msg,
-                    key,
-                    dispatch_outbound=dispatch_outbound,
+            # 给本 turn task 打上 session 归属，供 observe 全局错误采集关联。
+            session_token = current_session_key.set(key)
+            inherited_turn_id = (
+                str(
+                    msg.metadata.get("_control_execution_turn_id")
+                    or msg.metadata.get("control_turn_id")
+                    or ""
                 )
-                if resumed_from_interrupt:
-                    self._interrupt_states.pop(key, None)
-                return outbound
-            finally:
-                # 3. 无论核心处理结果如何，都释放 busy 状态。
-                if self._processing_state:
-                    self._processing_state.exit(busy_key)
-        finally:
-            # 4. 当前 query 结束即回收其 shell，再恢复调用方上下文。
+                if isinstance(msg, InboundMessage)
+                else ""
+            )
+            turn_token = current_turn_id.set(inherited_turn_id or new_turn_id())
             try:
-                await self._cleanup_shell_owner(key)
+                # 1. 先处理可能存在的续跑态，并发布 turn started。
+                msg, resumed_from_interrupt = await self._resume_interrupted_message(
+                    msg, key
+                )
+                await self._observe_turn_started(msg, key)
+                content = _item_content(msg)
+                preview = content[:60] + "..." if len(content) > 60 else content
+                logger.info(f"Processing message from {msg.channel}: {preview}")
+
+                # 2. 再进入 busy 状态并执行核心处理。
+                if self._processing_state:
+                    self._processing_state.enter(busy_key)
+                try:
+                    outbound = await self._core_runner.process(
+                        msg,
+                        key,
+                        dispatch_outbound=dispatch_outbound,
+                    )
+                    if resumed_from_interrupt:
+                        self._interrupt_states.pop(key, None)
+                    return outbound
+                finally:
+                    # 3. 无论核心处理结果如何，都释放 busy 状态。
+                    if self._processing_state:
+                        self._processing_state.exit(busy_key)
             finally:
-                current_session_key.reset(session_token)
-                current_turn_id.reset(turn_token)
+                # 4. 当前 query 结束即回收其 shell，再恢复调用方上下文。
+                try:
+                    await self._cleanup_shell_owner(key)
+                finally:
+                    current_session_key.reset(session_token)
+                    current_turn_id.reset(turn_token)
+
+    async def _resolve_model_selection(
+        self,
+        msg: InboundItem,
+        session_key: str,
+    ) -> SessionModelSelection:
+        """Validate, persist, and resolve one conversation's model selection."""
+
+        if not isinstance(msg, InboundMessage):
+            return SessionModelSelection()
+        provider = self._llm_services.provider
+        if not isinstance(provider, RoleBoundProvider):
+            return SessionModelSelection()
+        registry = provider.registry
+        await registry.refresh()
+        session = self.session_manager.get_or_create(session_key)
+
+        # 1. A client-supplied field is an explicit session-setting operation.
+        if "model_runtime_id" in msg.metadata:
+            raw_runtime_id = msg.metadata["model_runtime_id"]
+            if not isinstance(raw_runtime_id, str):
+                raise TypeError("model_runtime_id 必须是字符串")
+            runtime_id = raw_runtime_id.strip()
+            raw_effort = msg.metadata.get("model_reasoning_effort", "")
+            if not isinstance(raw_effort, str):
+                raise TypeError("model_reasoning_effort 必须是字符串")
+            effort = raw_effort.strip()
+            if runtime_id:
+                if not registry.has_runtime(runtime_id):
+                    raise ValueError(f"模型 runtime 不存在: {runtime_id}")
+            write_session_model_selection(
+                session.metadata,
+                SessionModelSelection(runtime_id, effort),
+            )
+            self.session_manager.save(session)
+
+        # 2. Existing metadata is authoritative when this message follows it.
+        selection = read_session_model_selection(session.metadata)
+        if selection.model_ref and not registry.has_runtime(selection.model_ref):
+            raise ValueError(
+                f"session 引用不存在的模型 runtime: {selection.model_ref}"
+            )
+        return selection
 
     async def _cleanup_shell_owner(self, owner_session_key: str) -> None:
         """回收 turn 的 Shell，并把失败隔离为 execution 诊断。"""
@@ -1033,6 +1091,24 @@ class AgentLoop:
         archive_all: bool = False,
         force: bool = False,
         drain_backlog: bool = True,
+    ) -> bool:
+        """Run one consolidation against a frozen model revision."""
+
+        async with model_execution_scope(self._llm_services.provider):
+            return await self._trigger_memory_consolidation_bound(
+                session_key,
+                archive_all=archive_all,
+                force=force,
+                drain_backlog=drain_backlog,
+            )
+
+    async def _trigger_memory_consolidation_bound(
+        self,
+        session_key: str,
+        *,
+        archive_all: bool,
+        force: bool,
+        drain_backlog: bool,
     ) -> bool:
         from core.memory.markdown import ConsolidateRequest
 

--- a/agent/model_runtime/session_selection.py
+++ b/agent/model_runtime/session_selection.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import MutableMapping
+
+
+SESSION_MODEL_SELECTION_KEY = "model_selection"
+LEGACY_MODEL_OVERRIDE_KEY = "model_runtime_override"
+
+
+@dataclass(frozen=True)
+class SessionModelSelection:
+    """Describe the model choice persisted for one conversation."""
+
+    model_ref: str = ""
+    reasoning_effort: str = ""
+
+
+def read_session_model_selection(
+    metadata: MutableMapping[str, object],
+) -> SessionModelSelection:
+    """Read the structured selection while accepting the legacy string field."""
+
+    raw = metadata.get(SESSION_MODEL_SELECTION_KEY)
+    if raw is not None:
+        if not isinstance(raw, dict):
+            raise ValueError("session model_selection 必须是对象")
+        if raw.get("schema_version") != 1:
+            raise ValueError("session model_selection schema_version 无效")
+        model_ref = raw.get("model_ref", "")
+        effort = raw.get("reasoning_effort", "")
+        if not isinstance(model_ref, str) or not model_ref.strip():
+            raise ValueError("session model_selection.model_ref 必须是非空字符串")
+        if not isinstance(effort, str):
+            raise ValueError("session model_selection.reasoning_effort 必须是字符串")
+        return SessionModelSelection(model_ref.strip(), effort.strip())
+
+    legacy = metadata.get(LEGACY_MODEL_OVERRIDE_KEY)
+    if legacy is None:
+        return SessionModelSelection()
+    if not isinstance(legacy, str) or not legacy.strip():
+        raise ValueError("session model_runtime_override 必须是非空字符串")
+    return SessionModelSelection(legacy.strip(), "")
+
+
+def write_session_model_selection(
+    metadata: MutableMapping[str, object],
+    selection: SessionModelSelection,
+) -> None:
+    """Persist one explicit selection, or follow the global default when empty."""
+
+    metadata.pop(LEGACY_MODEL_OVERRIDE_KEY, None)
+    if not selection.model_ref:
+        if selection.reasoning_effort:
+            raise ValueError("默认模型不能单独覆盖推理强度")
+        metadata.pop(SESSION_MODEL_SELECTION_KEY, None)
+        return
+    metadata[SESSION_MODEL_SELECTION_KEY] = {
+        "schema_version": 1,
+        "model_ref": selection.model_ref,
+        "reasoning_effort": selection.reasoning_effort,
+    }
+
+
+__all__ = [
+    "SessionModelSelection",
+    "read_session_model_selection",
+    "write_session_model_selection",
+]

--- a/agent/plugins/jobs.py
+++ b/agent/plugins/jobs.py
@@ -9,6 +9,11 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol
 
 from bus.event_bus import EventSubscription
+from agent.model_runtime.registry import (
+    RoleBoundProvider,
+    current_model_binding,
+    model_execution_scope,
+)
 
 if TYPE_CHECKING:
     from agent.plugins.snapshot import RuntimeSnapshotLease, RuntimeSnapshotStore
@@ -17,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 class PluginLlmService(Protocol):
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int | None = None,
+    ) -> "PluginLlmResult": ...
+
     async def generate_text(
         self,
         *,
@@ -25,6 +39,13 @@ class PluginLlmService(Protocol):
         model: str | None = None,
         max_tokens: int | None = None,
     ) -> str: ...
+
+
+@dataclass(frozen=True)
+class PluginLlmResult:
+    text: str
+    model_usage: dict[str, object]
+    model_binding: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -102,17 +123,81 @@ class ProviderPluginLlmService:
         model: str | None = None,
         max_tokens: int | None = None,
     ) -> str:
+        result = await self.generate(
+            prompt=prompt,
+            system=system,
+            model=model,
+            max_tokens=max_tokens,
+        )
+        return result.text
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        system: str = "",
+        model: str | None = None,
+        max_tokens: int | None = None,
+    ) -> PluginLlmResult:
+        """返回插件可消费的文本、规范化 usage 与实际模型绑定。"""
+
+        async with model_execution_scope(self._provider):
+            return await self._generate_bound(
+                prompt=prompt,
+                system=system,
+                model=model,
+                max_tokens=max_tokens,
+            )
+
+    async def _generate_bound(
+        self,
+        *,
+        prompt: str,
+        system: str,
+        model: str | None,
+        max_tokens: int | None,
+    ) -> PluginLlmResult:
+        """Execute one plugin request inside its frozen model generation."""
+
+        # 1. 保持一次调用的消息语义和既有模型参数。
         messages: list[dict[str, str]] = []
         if system:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
-        resp = await self._provider.chat(
+        request_provider = self._provider
+        request_model = model or self._model
+        request_max_tokens = self._max_tokens if max_tokens is None else max_tokens
+        if isinstance(self._provider, RoleBoundProvider):
+            runtime, request_provider, _binding = self._provider.registry.resolve(
+                self._provider.role
+            )
+            request_model = model or runtime.model
+            if max_tokens is None and self._max_tokens == 0:
+                request_max_tokens = runtime.max_output_tokens
+        resp = await request_provider.chat(
             messages=messages,
             tools=[],
-            model=model or self._model,
-            max_tokens=self._max_tokens if max_tokens is None else max_tokens,
+            model=request_model,
+            max_tokens=request_max_tokens,
         )
-        return str(resp.content or "").strip()
+        usage = resp.usage
+        binding = current_model_binding()
+        return PluginLlmResult(
+            text=str(resp.content or "").strip(),
+            model_usage=(
+                {
+                    "input_tokens": usage.input_tokens,
+                    "cache_write_input_tokens": usage.cache_write_input_tokens,
+                    "cached_input_tokens": usage.cached_input_tokens,
+                    "output_tokens": usage.output_tokens,
+                    "reasoning_output_tokens": usage.reasoning_output_tokens,
+                    "coverage": usage.coverage.value,
+                }
+                if usage is not None
+                else {"coverage": "unavailable"}
+            ),
+            model_binding=binding.describe() if binding is not None else {},
+        )
 
 
 class PluginJobRuntime:
@@ -121,11 +206,13 @@ class PluginJobRuntime:
         *,
         event_bus: Any,
         llm: PluginLlmService,
+        model_provider: object | None = None,
         jobs: list[RegisteredPluginJob] | None = None,
         snapshot_store: RuntimeSnapshotStore | None = None,
     ) -> None:
         self._event_bus = event_bus
         self._llm = llm
+        self._model_provider = model_provider
         self._jobs = {plugin_job_key(job): job for job in jobs or []}
         self._snapshot_store = snapshot_store
         self._queue: asyncio.Queue[_JobRequest | None] = asyncio.Queue()
@@ -329,7 +416,8 @@ class PluginJobRuntime:
             triggered_at=datetime.now(timezone.utc),
         )
         try:
-            await self._invoke(request, ctx)
+            async with model_execution_scope(self._model_provider):
+                await self._invoke(request, ctx)
         except Exception:
             logger.exception(
                 "插件后台任务失败: plugin=%s job=%s reason=%s",

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -502,6 +502,7 @@ class AppRuntime:
                     self.plugin_job_runtime = PluginJobRuntime(
                         event_bus=event_bus,
                         llm=llm,
+                        model_provider=self.provider,
                         snapshot_store=plugin_manager.snapshot_store,
                     )
                     self.tasks.append(self.plugin_job_runtime.run())
@@ -629,6 +630,22 @@ class AppRuntime:
             except (asyncio.CancelledError, Exception) as rollback_error:
                 raise startup_error from rollback_error
             raise
+
+    async def reload_model_config(self, config_path: str | Path) -> dict[str, object]:
+        """Load and atomically publish a new model generation."""
+
+        # 1. Parse the complete candidate at the configuration boundary.
+        candidate = Config.load(config_path, workspace=self.workspace)
+        if self.core is None or self.core.model_registry is None:
+            raise RuntimeError("ModelRegistry 尚未启动")
+
+        # 2. Publish only after every provider in the candidate was constructed.
+        generation = await self.core.model_registry.reload(candidate)
+        self.config = candidate
+        return {
+            "generationId": generation.generation_id,
+            "configDigest": generation.config_digest,
+        }
 
     async def run(self) -> None:
         run_error: BaseException | None = None

--- a/bootstrap/proactive.py
+++ b/bootstrap/proactive.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from agent.config_models import Config
 from agent.looping.core import AgentLoop
 from agent.provider import LLMProvider
+from agent.model_runtime.registry import RoleBoundProvider
 from agent.tool_hooks import ToolHook
 from agent.plugins.specs import RegisteredProactiveSource
 from agent.tools.message_push import MessagePushTool
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
 
 
 def _build_proactive_provider(config: Config, provider: LLMProvider) -> LLMProvider:
+    if isinstance(provider, RoleBoundProvider):
+        return provider.registry.provider(
+            provider.role,
+            force_disable_thinking=True,
+        )
     api_key = str(getattr(config, "api_key", "") or "").strip()
     system_prompt = str(getattr(config, "system_prompt", "") or "")
     base_url = getattr(config, "base_url", None)
@@ -79,7 +85,7 @@ def build_proactive_runtime(
         push_tool=push_tool,
         config=proactive_cfg,
         model=config.model,
-        max_tokens=config.max_tokens,
+        max_tokens=0,
         state_store=proactive_state,
         state_store_owned=True,
         memory_store=memory_store,

--- a/bootstrap/providers.py
+++ b/bootstrap/providers.py
@@ -1,17 +1,71 @@
 from __future__ import annotations
 
 from agent.config_models import Config
+from agent.model_runtime.auth.store import CredentialStore
 from agent.model_runtime.fallback import ResilientLightProvider
+from agent.model_runtime.registry import (
+    ModelGeneration,
+    ModelRegistry,
+    model_config_digest,
+)
 from infra.providers.llm_provider import LLMProvider
 
 _MAIN_NETWORK_READ_TIMEOUT_S = 120.0
 _LIGHT_NETWORK_READ_TIMEOUT_S = 60.0
 
 
+def build_model_registry(config: Config) -> ModelRegistry:
+    """Build the runtime model registry from the validated configuration."""
+
+    return ModelRegistry(config, _build_model_generation)
+
+
+def _build_model_generation(config: Config, generation_id: int) -> ModelGeneration:
+    """Construct every configured runtime before publishing one generation."""
+
+    # 1. Reuse the established role builders and their fallback semantics.
+    default_provider, fast_provider, agent_provider = build_providers(config)
+    credential_store = CredentialStore.for_workspace(config.workspace_path)
+    runtime_providers: dict[str, LLMProvider] = {config.runtime_id: default_provider}
+    for runtime_id, runtime in config.model_runtimes.items():
+        if runtime_id in runtime_providers:
+            continue
+        runtime_providers[runtime_id] = LLMProvider.from_runtime(
+            runtime,
+            system_prompt=config.system_prompt,
+            credential_store=credential_store,
+            read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
+            payload_snapshot_enabled=config.dev_mode,
+        )
+
+    # 2. Role-specific wrappers are part of the immutable generation.
+    role_runtime_ids = {
+        "default": config.runtime_id,
+        "fast": config.fast_runtime_id or config.runtime_id,
+        "agent": config.agent_runtime_id or config.runtime_id,
+        "vision": config.vl_runtime_id or config.runtime_id,
+    }
+    role_providers: dict[str, object] = {"default": default_provider}
+    role_providers["fast"] = fast_provider or default_provider
+    role_providers["agent"] = agent_provider or default_provider
+    vision_provider = build_vl_provider(config)
+    role_providers["vision"] = vision_provider or default_provider
+    return ModelGeneration(
+        generation_id=generation_id,
+        config_digest=model_config_digest(config),
+        runtimes=dict(config.model_runtimes),
+        providers=runtime_providers,
+        role_runtime_ids=role_runtime_ids,
+        role_providers=role_providers,
+        registry_revision=config.model_registry_revision,
+    )
+
+
 def build_providers(
     config: Config,
 ) -> tuple[LLMProvider, LLMProvider | None, LLMProvider | None]:
     payload_snapshot_enabled = config.dev_mode
+    credential_store = CredentialStore.for_workspace(config.workspace_path)
     main_extra = _sanitize_extra_body(
         base_url=config.base_url,
         extra_body=config.extra_body,
@@ -21,6 +75,7 @@ def build_providers(
         LLMProvider.from_runtime(
             main_runtime,
             system_prompt=config.system_prompt,
+            credential_store=credential_store,
             extra_body=main_extra,
             read_timeout_s=_MAIN_NETWORK_READ_TIMEOUT_S,
             payload_snapshot_enabled=payload_snapshot_enabled,
@@ -144,6 +199,7 @@ def _build_named_role_provider(
     return LLMProvider.from_runtime(
         runtime,
         system_prompt=system_prompt,
+        credential_store=CredentialStore.for_workspace(config.workspace_path),
         read_timeout_s=read_timeout_s,
         force_disable_thinking=force_disable_thinking,
         payload_snapshot_enabled=config.dev_mode,

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -30,11 +30,13 @@ from agent.looping.ports import (
 )
 from agent.mcp.watcher import WorkspaceMcpWatcher
 from agent.provider import LLMProvider
+from agent.model_runtime.registry import ModelRegistry
 from agent.retrieval.default_pipeline import DefaultMemoryRetrievalPipeline
 from agent.scheduler import SchedulerService
 from agent.tools.base import ToolExecutionContext, get_current_tool_context
 from agent.tools.message_push import MessagePushTool
 from agent.tools.registry import ToolRegistry
+from agent.tools.spawn import SpawnTool
 from bootstrap.toolsets.meta import build_readonly_tools
 from bootstrap.toolsets.protocol import ToolsetDeps
 from bootstrap.toolsets.schedule import build_scheduler
@@ -46,7 +48,7 @@ from bootstrap.wiring import (
 )
 from agent.lifecycle.facade import TurnLifecycle
 from agent.plugins.jobs import ProviderPluginLlmService
-from bootstrap.providers import build_providers, build_vl_provider
+from bootstrap.providers import build_model_registry, build_providers, build_vl_provider
 from bootstrap.cleanup import run_cleanup_steps
 from bus.event_bus import EventBus
 from bus.processing import ProcessingState
@@ -79,6 +81,7 @@ class CoreRuntime:
     workspace_mcp_watcher_task: asyncio.Task[None] | None
     memory_runtime: MemoryRuntime
     presence: PresenceStore
+    model_registry: ModelRegistry | None = None
     agent_provider: LLMProvider | None = None
     plugin_manager: "PluginManager | None" = None
     workspace: Path | None = None
@@ -117,7 +120,9 @@ class CoreRuntime:
             if self.plugin_manager.tool_hooks:
                 self.loop.add_tool_hooks(self.plugin_manager.tool_hooks)
                 spawn_tool = self.tools.get_tool("spawn")
-                if spawn_tool is not None and hasattr(spawn_tool, "add_tool_hooks"):
+                if spawn_tool is not None:
+                    if not isinstance(spawn_tool, SpawnTool):
+                        raise TypeError("spawn 工具未建立 SpawnTool 内部不变量")
                     spawn_tool.add_tool_hooks(self.plugin_manager.tool_hooks)
 
         # 3. 首次启动全部成功后才启动容错热重载 watcher
@@ -488,10 +493,13 @@ def build_core_runtime(
     # 1. 创建总线、provider 和由 CoreRuntime.stop 负责关闭的 session owner。
     bus = MessageBus()
     event_bus = EventBus()
-    provider, light_provider, agent_provider = build_providers(config)
-    vl_provider = build_vl_provider(config)
+    model_registry = build_model_registry(config)
+    provider = model_registry.provider("default")
+    light_provider = model_registry.provider("fast")
+    agent_provider = model_registry.provider("agent")
+    vl_provider = model_registry.provider("vision") if config.vl_model else None
     # 2. agent_provider 供 AgentLoop 使用，provider 供 consolidation 事件提取使用。
-    loop_provider = agent_provider or provider
+    loop_provider = agent_provider
     loop_model = config.agent_model or config.model
     session_manager = SessionManager(workspace)
     if clear_stale_session_admissions:
@@ -534,7 +542,7 @@ def build_core_runtime(
                 model=loop_model,
                 light_model=config.light_model,
                 max_iterations=config.max_iterations,
-                max_tokens=config.max_tokens,
+                max_tokens=0,
                 tool_search_enabled=config.tool_search_enabled,
                 multimodal=config.multimodal,
                 vl_available=config.vl_model != "",
@@ -563,7 +571,7 @@ def build_core_runtime(
         llm=ProviderPluginLlmService(
             provider=provider,
             model=config.model,
-            max_tokens=config.max_tokens,
+            max_tokens=0,
         ),
         installed_cache_root=plugins_root() / "cache",
     )
@@ -623,6 +631,7 @@ def build_core_runtime(
         workspace_mcp_watcher_task=None,
         memory_runtime=memory_runtime,
         presence=presence,
+        model_registry=model_registry,
         plugin_manager=plugin_manager,
     )
 

--- a/bootstrap/toolsets/meta.py
+++ b/bootstrap/toolsets/meta.py
@@ -119,7 +119,7 @@ class SpawnToolsetProvider(ToolsetProvider):
             workspace=deps.workspace,
             bus=bus,
             model=config.model,
-            max_tokens=config.max_tokens,
+            max_tokens=0,
             fetch_requester=http_resources.external_default,
             multimodal=config.multimodal,
         )

--- a/bus/events_lifecycle.py
+++ b/bus/events_lifecycle.py
@@ -54,6 +54,7 @@ class TurnCommitted:
     react_stats: dict[str, int] = field(default_factory=dict[str, int])
     extra: dict[str, Any] = field(default_factory=dict[str, Any])
     model_usage: dict[str, Any] = field(default_factory=dict[str, Any])
+    model_binding: dict[str, Any] = field(default_factory=dict[str, Any])
 
 
 @dataclass(frozen=True)

--- a/memory2/post_response_worker.py
+++ b/memory2/post_response_worker.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import json_repair
 
 from agent.provider import LLMProvider
+from agent.model_runtime.registry import model_execution_scope
 from core.memory.events import MemoryWritten, TurnIngested
 from memory2.memorizer import Memorizer
 from memory2.retriever import Retriever
@@ -79,6 +80,30 @@ class PostResponseMemoryWorker:
         chat_id: str = "",
     ) -> None:
         """在独立转次上下文中识别并废弃失效记忆。"""
+
+        async with model_execution_scope(self._provider):
+            await self._run_bound(
+                user_msg=user_msg,
+                agent_response=agent_response,
+                tool_chain=tool_chain,
+                source_ref=source_ref,
+                session_key=session_key,
+                channel=channel,
+                chat_id=chat_id,
+            )
+
+    async def _run_bound(
+        self,
+        *,
+        user_msg: str,
+        agent_response: str,
+        tool_chain: list[dict],
+        source_ref: str,
+        session_key: str,
+        channel: str,
+        chat_id: str,
+    ) -> None:
+        """Process one post-response memory job inside its model snapshot."""
 
         # 1. 初始化本轮异步提炼的上下文和 token 预算。
         context = _RunContext(

--- a/proactive_v2/loop.py
+++ b/proactive_v2/loop.py
@@ -23,6 +23,7 @@ from core.error_context import current_session_key
 from agent.looping.ports import SessionServices
 from agent.core.proactive_kernel import ProactiveKernel
 from agent.provider import LLMProvider
+from agent.model_runtime.registry import model_execution_scope
 from agent.plugins.specs import RegisteredProactiveSource
 from agent.tool_hooks import ToolHook
 from agent.tools.message_push import MessagePushTool
@@ -462,20 +463,21 @@ class ProactiveLoop:
 
     async def _tick(self) -> float | None:
         """执行一次 proactive v2 tick。"""
-        if self._runtime_snapshot_store is None:
-            async with self._reload_lock:
-                return await self._tick_bound()
-        lease = await self._runtime_snapshot_store.acquire()
-        from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
-
-        async with lease:
-            token = bind_runtime_snapshot(lease)
-            try:
+        async with model_execution_scope(self._provider):
+            if self._runtime_snapshot_store is None:
                 async with self._reload_lock:
-                    await self._switch_snapshot(lease.snapshot)
                     return await self._tick_bound()
-            finally:
-                reset_runtime_snapshot(token)
+            lease = await self._runtime_snapshot_store.acquire()
+            from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+
+            async with lease:
+                token = bind_runtime_snapshot(lease)
+                try:
+                    async with self._reload_lock:
+                        await self._switch_snapshot(lease.snapshot)
+                        return await self._tick_bound()
+                finally:
+                    reset_runtime_snapshot(token)
 
     async def quiesce_for_reload(self) -> None:
         async with self._reload_lock:

--- a/proactive_v2/memory_optimizer.py
+++ b/proactive_v2/memory_optimizer.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from agent.memory import DEFAULT_SELF_MD
 from agent.provider import LLMProvider
+from agent.model_runtime.registry import model_execution_scope
 
 logger = logging.getLogger(__name__)
 
@@ -295,7 +296,8 @@ class MemoryOptimizer:
         if self._lock.locked():
             raise MemoryOptimizerBusy("memory optimizer 正在运行")
         async with self._lock:
-            await self._optimize()
+            async with model_execution_scope(self._provider):
+                await self._optimize()
 
     async def _optimize(self) -> None:
         """提交 pending 记忆合并，并随后更新自我认知。"""

--- a/tests/control/test_control_execution.py
+++ b/tests/control/test_control_execution.py
@@ -40,6 +40,7 @@ async def test_committed_control_turn_survives_shell_cleanup_error(
     loop._interrupt_states = {}
     loop._session_lanes = SessionLaneRegistry()
     loop._runtime_snapshot_store = None
+    loop._llm_services = SimpleNamespace(provider=object())
     loop._resume_interrupted_message = AsyncMock(
         side_effect=lambda message, _key: (message, False)
     )

--- a/tests/proactive_v2/test_integration.py
+++ b/tests/proactive_v2/test_integration.py
@@ -32,6 +32,7 @@ class SnapshotMcpTool(Tool):
 def make_loop() -> ProactiveLoop:
     loop = object.__new__(ProactiveLoop)
     loop._cfg = ProactiveConfig()
+    loop._provider = object()
     loop._state_store_owned = False
     loop._state_closed = False
     loop._sense = SimpleNamespace(target_session_key=lambda: "telegram:1")

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -960,6 +960,7 @@ async def test_proactive_loop_wrapper_methods_cover_paths(tmp_path: Path):
     loop._state_store_owned = False
     loop._state_closed = False
     loop._runtime_snapshot_store = None
+    loop._provider = object()
     loop._stopped = asyncio.Event()
     loop._wake = asyncio.Event()
     loop._reload_lock = asyncio.Lock()

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -2267,6 +2267,7 @@ async def test_proactive_quiesce_does_not_deadlock_with_paused_tick(
     await manager.load_all()
     loop = object.__new__(ProactiveLoop)
     loop._runtime_snapshot_store = manager.snapshot_store
+    loop._provider = object()
     loop._reload_lock = asyncio.Lock()
     stopped = asyncio.Event()
 
@@ -5363,6 +5364,7 @@ async def test_proactive_tick_keeps_one_snapshot_generation(tmp_path: Path) -> N
 
     loop = object.__new__(ProactiveLoop)
     loop._runtime_snapshot_store = manager.snapshot_store
+    loop._provider = object()
     loop._reload_lock = asyncio.Lock()
     loop._sense = SimpleNamespace(target_session_key=lambda: "cli:tick")
     loop._proactive_kernel = SimpleNamespace(run_tick=run_tick)

--- a/tests/test_plugin_jobs.py
+++ b/tests/test_plugin_jobs.py
@@ -5,13 +5,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from agent.config_models import Config, ModelRuntimeConfig
+from agent.model_runtime.registry import ModelGeneration, ModelRegistry, model_config_digest
 from agent.plugins.jobs import ProviderPluginLlmService
 
 
 @pytest.mark.asyncio
 async def test_plugin_job_distinguishes_default_and_explicit_zero_limit() -> None:
     provider = AsyncMock()
-    provider.chat.return_value = SimpleNamespace(content="done")
+    provider.chat.return_value = SimpleNamespace(content="done", usage=None)
     service = ProviderPluginLlmService(
         provider,
         model="main",
@@ -23,3 +25,55 @@ async def test_plugin_job_distinguishes_default_and_explicit_zero_limit() -> Non
 
     assert await service.generate_text(prompt="provider", max_tokens=0) == "done"
     assert provider.chat.await_args.kwargs["max_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_llm_reports_binding_and_preserves_explicit_model() -> None:
+    runtime = ModelRuntimeConfig(
+        runtime_id="a",
+        provider="openai",
+        model="model-a",
+        max_output_tokens=777,
+    )
+    config = Config(
+        provider="openai",
+        model=runtime.model,
+        api_key="test",
+        system_prompt="test",
+        runtime_id="a",
+        model_runtimes={"a": runtime},
+    )
+    concrete = AsyncMock()
+    concrete.chat.return_value = SimpleNamespace(content="done", usage=None)
+
+    def build(candidate: Config, generation_id: int) -> ModelGeneration:
+        return ModelGeneration(
+            generation_id=generation_id,
+            config_digest=model_config_digest(candidate),
+            runtimes=candidate.model_runtimes,
+            providers={"a": concrete},
+            role_runtime_ids={
+                "default": "a",
+                "fast": "a",
+                "agent": "a",
+                "vision": "a",
+            },
+        )
+
+    service = ProviderPluginLlmService(
+        ModelRegistry(config, build).provider("default"),
+        model="stale-startup-model",
+        max_tokens=0,
+    )
+    result = await service.generate(prompt="dynamic")
+    assert concrete.chat.await_args.kwargs["model"] == "model-a"
+    assert concrete.chat.await_args.kwargs["max_tokens"] == 777
+    assert result.model_binding["runtime_id"] == "a"
+
+    await service.generate(
+        prompt="override",
+        model="provider-model-alias",
+        max_tokens=128,
+    )
+    assert concrete.chat.await_args.kwargs["model"] == "provider-model-alias"
+    assert concrete.chat.await_args.kwargs["max_tokens"] == 128

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1908,6 +1908,7 @@ async def test_add_tool_hooks_propagates_to_tool_executor():
 
 @pytest.mark.asyncio
 async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
+    from agent.tools.spawn import SpawnTool
     from bootstrap.tools import CoreRuntime
 
     startup_order: list[str] = []
@@ -1987,7 +1988,7 @@ async def test_core_runtime_start_wires_plugin_tool_hooks_to_loop_and_spawn():
         ) -> None:
             self.received_after_turn = list(modules)
 
-    class FakeSpawnTool:
+    class FakeSpawnTool(SpawnTool):
         def __init__(self) -> None:
             self.received_hooks: list[ToolHook] | None = None
 

--- a/tests/test_proactive_facade_phase4.py
+++ b/tests/test_proactive_facade_phase4.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from bootstrap.proactive import _build_proactive_provider, build_proactive_runtime
+from agent.config_models import Config, ModelRuntimeConfig
+from agent.model_runtime.registry import ModelGeneration, ModelRegistry, model_config_digest
 from plugins.default_proactive.runtime import (
     ProactiveFlowDeps,
     ProactiveFlowRuntime,
@@ -85,6 +87,36 @@ def test_build_proactive_provider_strips_enable_thinking():
     assert proactive_provider is not provider
     assert proactive_provider._extra_body == {"foo": "bar"}
     assert proactive_provider._force_disable_thinking is True
+
+
+def test_build_proactive_provider_keeps_registry_binding():
+    runtime = ModelRuntimeConfig(
+        runtime_id="main",
+        provider="openai",
+        model="model-a",
+    )
+    cfg = Config(
+        provider="openai",
+        model=runtime.model,
+        api_key="k",
+        system_prompt="sys",
+        model_runtimes={"main": runtime},
+    )
+
+    def build(candidate: Config, generation_id: int) -> ModelGeneration:
+        return ModelGeneration(
+            generation_id=generation_id,
+            config_digest=model_config_digest(candidate),
+            runtimes=candidate.model_runtimes,
+            providers={"main": object()},
+            role_runtime_ids={role: "main" for role in ("default", "fast", "agent", "vision")},
+        )
+
+    provider = ModelRegistry(cfg, build).provider("default")
+    proactive_provider = _build_proactive_provider(cfg, provider)
+
+    assert proactive_provider.registry is provider.registry
+    assert proactive_provider.force_disable_thinking is True
 
 
 def test_agent_tick_prompt_keeps_self_block_with_facade():

--- a/tests/test_session_model_selection.py
+++ b/tests/test_session_model_selection.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from agent.model_runtime.session_selection import (
+    SessionModelSelection,
+    read_session_model_selection,
+    write_session_model_selection,
+)
+
+
+def test_structured_selection_round_trips_model_and_effort() -> None:
+    metadata: dict[str, object] = {}
+    write_session_model_selection(
+        metadata,
+        SessionModelSelection("deepseek-main", "high"),
+    )
+
+    assert read_session_model_selection(metadata) == SessionModelSelection(
+        "deepseek-main",
+        "high",
+    )
+
+
+def test_legacy_override_remains_readable_until_next_explicit_change() -> None:
+    metadata: dict[str, object] = {"model_runtime_override": "legacy-main"}
+    assert read_session_model_selection(metadata) == SessionModelSelection(
+        "legacy-main",
+        "",
+    )
+
+    write_session_model_selection(metadata, SessionModelSelection("next", "low"))
+    assert "model_runtime_override" not in metadata
+    assert read_session_model_selection(metadata) == SessionModelSelection(
+        "next",
+        "low",
+    )
+
+
+def test_follow_default_removes_pinned_selection() -> None:
+    metadata: dict[str, object] = {}
+    write_session_model_selection(metadata, SessionModelSelection("pinned", "high"))
+
+    write_session_model_selection(metadata, SessionModelSelection())
+
+    assert metadata == {}
+
+
+def test_effort_without_explicit_model_is_rejected() -> None:
+    with pytest.raises(ValueError, match="默认模型不能单独覆盖推理强度"):
+        write_session_model_selection({}, SessionModelSelection("", "high"))


### PR DESCRIPTION
## 问题与结果

- 解决的问题：运行时切换模型不能破坏已开始 turn/passive/proactive 的一致性。
- 用户可见结果：完整执行单元冻结旧 generation，下一执行使用最新 role binding。
- 本 PR 不处理：Web 设置、迁移和 UI。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：passive/proactive/schedule/plugin job/memory optimizer
- `runtime_patch`：`none`
- `authoritative_state_owner`：ModelRegistry revision + execution lease

## 改动范围

- 主要文件：`agent/looping/core.py`、`agent/model_runtime/session_selection.py`、`bootstrap/providers.py`、各后台模型消费者。
- 回滚方式：回退 `718fa54f`。

## 验证

- [x] 173 项 execution/session/plugin/proactive targeted tests 通过。
- [x] 六层累计 549 项改动测试通过。
- [ ] 单层 Change Gate 未单独运行；累计 Gate 已通过。

## 工作手册

- [x] 已核对执行快照、session 串行和 fail-loud 边界。
- [x] 本 PR 是 2/6，adjacent diff 为 `stack/runtime-model-core...stack/runtime-model-execution`。

## PR 堆栈

#330 → **#331** → #332 → #333 → #334 → #327
