### PR TITLE
[codex] 在聊天中选择模型与思考强度

### DIFF
--- a/frontend/chat/src/main.tsx
+++ b/frontend/chat/src/main.tsx
@@ -9,6 +9,7 @@ import {
   Palette,
   Plus,
   Puzzle,
+  SlidersHorizontal,
   Smartphone,
 } from "lucide-react";
 import { cycleTheme, initializeTheme, setTheme, startCrossPortThemeSync, useTheme } from "../../theme/src/theme-runtime";
@@ -48,6 +49,7 @@ import { ComposerActionButton } from "./composer-action";
 import { akashicBrandIcon } from "./akashic-brand";
 import { ComposerReply, MessageReplyReference, SharedMessageActions } from "./message-actions";
 import { MobilePairingDialog } from "./mobile-pairing-dialog";
+import { ModelCapsulePicker, type ChatModelRuntime } from "./model-capsule-picker";
 import { loadWebPluginCatalog, MobilePluginSlot } from "./mobile-plugin-runtime";
 import { RuntimeDashboard } from "./runtime-dashboard";
 import "./styles.css";
@@ -78,8 +80,19 @@ interface MessageRow {
   reply_preview?: unknown;
 }
 
-interface ChatNavigation {
-  dashboard_port: number;
+interface ChatModelState {
+  generationId: number;
+  defaultRuntime: string;
+  sessionOverride: string;
+  sessionSelection: { modelRef: string; reasoningEffort: string };
+  runtimes: ChatModelRuntime[];
+}
+
+interface WebShellState {
+  status: "needs_setup" | "starting" | "ready";
+  configured: boolean;
+  chatReady: boolean;
+  settingsPath: string;
 }
 
 export interface ThinkingBlock {
@@ -244,13 +257,60 @@ function uploadedFileResponse(payload: unknown): UploadedFile {
   return body as unknown as UploadedFile;
 }
 
-function chatNavigation(payload: unknown): ChatNavigation {
+function webShellState(payload: unknown): WebShellState {
   const body = recordValue(payload);
-  const port = body?.dashboard_port;
-  if (!Number.isInteger(port) || Number(port) < 1 || Number(port) > 65535) {
-    throw new Error("/api/chat/navigation 返回了无效端口");
+  if (!body
+    || (body.status !== "needs_setup" && body.status !== "starting" && body.status !== "ready")
+    || typeof body.configured !== "boolean"
+    || typeof body.chatReady !== "boolean"
+    || typeof body.settingsPath !== "string") {
+    throw new Error("/api/shell/state 返回了无效状态");
   }
-  return { dashboard_port: Number(port) };
+  return body as unknown as WebShellState;
+}
+
+function chatModelState(payload: unknown): ChatModelState {
+  const body = recordValue(payload);
+  if (!body || !Number.isInteger(body.generationId)
+    || typeof body.defaultRuntime !== "string"
+    || typeof body.sessionOverride !== "string"
+    || !recordValue(body.sessionSelection)
+    || !Array.isArray(body.runtimes)) {
+    throw new Error("/api/chat/models 返回了无效模型注册表");
+  }
+  const runtimes = body.runtimes.map((value) => {
+    const item = recordValue(value);
+    if (!item || typeof item.id !== "string" || typeof item.provider !== "string"
+      || typeof item.model !== "string" || typeof item.sourceId !== "string"
+      || typeof item.sourceName !== "string" || typeof item.reasoningEffort !== "string"
+      || !Array.isArray(item.supportedReasoningEfforts)
+      || !item.supportedReasoningEfforts.every((effort) => typeof effort === "string")
+      || !Array.isArray(item.roles)
+      || !item.roles.every((role) => typeof role === "string")) {
+      throw new Error("/api/chat/models 返回了无效 runtime");
+    }
+    return {
+      id: item.id,
+      provider: item.provider,
+      model: item.model,
+      sourceId: item.sourceId,
+      sourceName: item.sourceName,
+      reasoningEffort: item.reasoningEffort,
+      supportedReasoningEfforts: item.supportedReasoningEfforts as string[],
+      roles: item.roles as string[],
+    };
+  });
+  const selection = recordValue(body.sessionSelection);
+  if (!selection || typeof selection.modelRef !== "string" || typeof selection.reasoningEffort !== "string") {
+    throw new Error("/api/chat/models 返回了无效会话模型选择");
+  }
+  return {
+    generationId: Number(body.generationId),
+    defaultRuntime: body.defaultRuntime,
+    sessionOverride: body.sessionOverride,
+    sessionSelection: { modelRef: selection.modelRef, reasoningEffort: selection.reasoningEffort },
+    runtimes,
+  };
 }
 
 function App() {
@@ -265,9 +325,13 @@ function App() {
   const [status, setStatus] = useState<ChatStatus>("idle");
   const [error, setError] = useState("");
   const [mobilePairingOpen, setMobilePairingOpen] = useState(false);
-  const [dashboardPort, setDashboardPort] = useState<number | null>(null);
+  const [shellState, setShellState] = useState<WebShellState | null>(null);
   const [replyTarget, setReplyTarget] = useState<ChatMessage | null>(null);
   const [copiedMessageId, setCopiedMessageId] = useState("");
+  const [modelState, setModelState] = useState<ChatModelState | null>(null);
+  const [selectedRuntimeId, setSelectedRuntimeId] = useState("");
+  const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
+  const [modelSelectionDirty, setModelSelectionDirty] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
   const messageElementsRef = useRef(new Map<string, HTMLDivElement>());
   const activeSessionRef = useRef("");
@@ -275,6 +339,7 @@ function App() {
   const sessionsRequestRef = useRef<AbortController | null>(null);
   const messagesRequestRef = useRef<AbortController | null>(null);
   const sendRequestRef = useRef<AbortController | null>(null);
+  const chatReady = shellState?.chatReady === true;
 
   useEffect(() => {
     activeSessionRef.current = activeSessionId;
@@ -320,6 +385,15 @@ function App() {
   const loadSessionsSafely = useCallback(() => loadSessions().catch((error: unknown) => reportError(error)), [loadSessions, reportError]);
   const loadMessagesSafely = useCallback((sessionId: string) => loadMessages(sessionId).catch((error: unknown) => reportError(error)), [loadMessages, reportError]);
 
+  const loadModels = useCallback(async (sessionId: string) => {
+    const query = sessionId ? `?session_key=${encodeURIComponent(sessionId)}` : "";
+    const next = chatModelState(await fetchChatJson<unknown>(`/api/chat/models${query}`));
+    setModelState(next);
+    setSelectedRuntimeId(next.sessionOverride);
+    setSelectedReasoningEffort(next.sessionSelection.reasoningEffort);
+    setModelSelectionDirty(false);
+  }, []);
+
   const connect = useCallback(() => {
     const current = socketRef.current;
     if (current && current.readyState <= WebSocket.OPEN) {
@@ -359,10 +433,27 @@ function App() {
   }, [loadMessagesSafely, loadSessionsSafely, reportError]);
 
   useEffect(() => {
+    let active = true;
+    const refresh = async () => {
+      try {
+        const next = webShellState(await fetchChatJson<unknown>("/api/shell/state"));
+        if (active) setShellState(next);
+      } catch (stateError) {
+        if (active) reportError(stateError);
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 1200);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [reportError]);
+
+  useEffect(() => {
+    if (!chatReady) return;
     void loadSessionsSafely();
-    void fetchChatJson<unknown>("/api/chat/navigation")
-      .then((payload) => setDashboardPort(chatNavigation(payload).dashboard_port))
-      .catch((error: unknown) => reportError(error));
+    void loadModels("").catch((error: unknown) => reportError(error));
     const socket = connect();
     return () => {
       sessionsRequestRef.current?.abort();
@@ -371,15 +462,16 @@ function App() {
       if (socketRef.current === socket) socketRef.current = null;
       socket.close(1000, "component unmounted");
     };
-  }, [connect, loadSessionsSafely, reportError]);
+  }, [chatReady, connect, loadModels, loadSessionsSafely, reportError]);
 
   useEffect(() => {
+    if (!chatReady) return;
     const controller = new AbortController();
     void loadWebPluginCatalog(controller.signal).catch((error: unknown) => {
       if (!isAbortError(error)) reportError(error);
     });
     return () => controller.abort();
-  }, [reportError]);
+  }, [chatReady, reportError]);
 
   const ensureSession = useCallback(async () => {
     if (activeSessionRef.current) return activeSessionRef.current;
@@ -429,7 +521,12 @@ function App() {
         media: media.map((item) => item.upload_path),
       };
       if (reply) payload.reply_to_message_id = reply.id;
+      if (modelSelectionDirty) {
+        payload.model_runtime_id = selectedRuntimeId;
+        payload.model_reasoning_effort = selectedReasoningEffort;
+      }
       await sendWhenOpen(connect(), payload, controller.signal);
+      setModelSelectionDirty(false);
       setReplyTarget(null);
     } catch (error) {
       if (isAbortError(error)) throw error;
@@ -440,7 +537,7 @@ function App() {
     } finally {
       if (sendRequestRef.current === controller) sendRequestRef.current = null;
     }
-  }, [connect, ensureSession, replyTarget, reportError]);
+  }, [connect, ensureSession, modelSelectionDirty, replyTarget, reportError, selectedReasoningEffort, selectedRuntimeId]);
 
   const stopTurn = useCallback(() => {
     if (!activeSessionId) return;
@@ -461,11 +558,13 @@ function App() {
     setMessages([]);
     setReplyTarget(null);
     setStatus("idle");
-  }, []);
+    setSelectedRuntimeId("");
+    setSelectedReasoningEffort("");
+    setModelSelectionDirty(false);
+    void loadModels("").catch((error: unknown) => reportError(error));
+  }, [loadModels, reportError]);
 
-  const dashboardHref = dashboardPort === null
-    ? undefined
-    : `${window.location.protocol}//${window.location.hostname}:${dashboardPort}`;
+  const dashboardHref = chatReady ? "/" : undefined;
 
   return (
     <main className={`chat-shell ${isEmbeddedRuntime ? "embedded-runtime" : ""}`}>
@@ -482,6 +581,13 @@ function App() {
           destinationHeading={isEmbeddedShell ? undefined : "工作空间"}
           sessionHeading="最近会话"
           destinations={isEmbeddedShell ? [] : [
+            {
+              id: "models",
+              icon: <SlidersHorizontal size={20} />,
+              label: "模型与认证",
+              description: "Provider · API Key · 推理强度",
+              href: "/settings",
+            },
             {
               id: "runtime",
               icon: <BookOpenText size={20} />,
@@ -515,7 +621,11 @@ function App() {
               activeSessionRef.current = session.key;
               setActiveSessionId(session.key);
               setReplyTarget(null);
+              setModelState(null);
+              setSelectedRuntimeId("");
+              setModelSelectionDirty(false);
               void loadMessagesSafely(session.key);
+              void loadModels(session.key).catch((error: unknown) => reportError(error));
             },
           }))}
           sessionAfterContent={surface === "chat" && activeSessionId ? (
@@ -558,7 +668,25 @@ function App() {
           <ConversationContent className={messages.length ? "conversation-content" : "conversation-content empty"}>
             {messages.length === 0 ? (
               <ConversationEmptyState className="home-state">
-                <h1>今天有什么计划?</h1>
+                {shellState?.status === "needs_setup" ? (
+                  <div className="model-connection-state">
+                    <span>首次使用</span>
+                    <h1>先连接一个模型</h1>
+                    <p>绑定 Codex、OpenCode 或自己的 API Key 后，就可以在这里直接对话。</p>
+                    <a href="/settings">连接模型</a>
+                  </div>
+                ) : shellState?.status === "starting" ? (
+                  <div className="model-connection-state">
+                    <span>正在启动</span>
+                    <h1>模型已保存，Akashic 正在准备对话</h1>
+                    <p>这个页面会自动恢复，不需要切换端口或刷新浏览器。</p>
+                    <a href="/settings">查看模型设置</a>
+                  </div>
+                ) : shellState === null ? (
+                  <h1>正在连接 Akashic…</h1>
+                ) : (
+                  <h1>今天有什么计划?</h1>
+                )}
               </ConversationEmptyState>
             ) : (
               <MessageRendererErrorBoundary>
@@ -639,6 +767,18 @@ function App() {
         </Conversation>
 
         <div className={`composer-wrap ${messages.length === 0 ? "home" : ""}`}>
+            {modelState && <ModelCapsulePicker
+              defaultRuntime={modelState.defaultRuntime}
+              runtimes={modelState.runtimes}
+              selectedRuntimeId={selectedRuntimeId}
+              selectedEffort={selectedReasoningEffort}
+              disabled={status !== "idle"}
+              onChange={(runtimeId, effort) => {
+                setSelectedRuntimeId(runtimeId);
+                setSelectedReasoningEffort(effort);
+                setModelSelectionDirty(true);
+              }}
+            />}
             <PromptInput
               className="composer"
               multiple
@@ -656,7 +796,8 @@ function App() {
                 <PromptInputTextarea
                   value={input}
                   onChange={(event) => setInput(event.target.value)}
-                placeholder="有问题，尽管问"
+                  disabled={!chatReady}
+                  placeholder={chatReady ? "有问题，尽管问" : "连接模型后即可开始对话"}
               />
             </PromptInputBody>
             <PromptInputFooter>
@@ -671,7 +812,7 @@ function App() {
                 </PromptInputActionMenu>
               </PromptInputTools>
               <PromptInputTools>
-                <ComposerSubmit input={input} status={status} onStop={stopTurn} />
+                <ComposerSubmit input={input} status={status} onStop={stopTurn} disabled={!chatReady} />
               </PromptInputTools>
             </PromptInputFooter>
           </PromptInput>
@@ -762,10 +903,12 @@ function ComposerSubmit({
   input,
   status,
   onStop,
+  disabled = false,
 }: {
   input: string;
   status: ChatStatus;
   onStop: () => void;
+  disabled?: boolean;
 }) {
   const attachments = usePromptInputAttachments();
   const isGenerating = status === "submitted" || status === "streaming";
@@ -775,7 +918,7 @@ function ComposerSubmit({
       label={isGenerating ? "中止回答" : "发送消息"}
       type={isGenerating ? "button" : "submit"}
       onClick={isGenerating ? onStop : undefined}
-      disabled={status === "idle" && !input.trim() && attachments.files.length === 0}
+      disabled={disabled || (status === "idle" && !input.trim() && attachments.files.length === 0)}
     />
   );
 }
@@ -1332,7 +1475,7 @@ initializeTheme();
 startCrossPortThemeSync();
 if (isEmbeddedShell) {
   const parentOrigins = new Set([
-    `${window.location.protocol}//${window.location.hostname}:2236`,
+    window.location.origin,
     `${window.location.protocol}//${window.location.hostname}:5173`,
   ]);
   window.addEventListener("message", (event: MessageEvent<unknown>) => {
@@ -1346,7 +1489,7 @@ const isMobileShowcase = preview === "mobile";
 const isSharedChatShowcase = preview === "chat";
 const isTraceMotionShowcase = preview === "trace-motion";
 const isDrawerIslandShowcase = preview === "drawer-islands";
-const rootApp = window.location.port === "6321"
+const rootApp = window.location.pathname === "/settings" || window.location.pathname.startsWith("/settings/")
   ? <LazySettingsApp />
   : isMobileShowcase
     ? <LazyMobileShowcase />

--- a/frontend/chat/src/model-capsule-picker.tsx
+++ b/frontend/chat/src/model-capsule-picker.tsx
@@ -1,0 +1,254 @@
+import { Check, ChevronDown, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import codexIcon from "./assets/provider-icons/codex.svg";
+import deepseekIcon from "./assets/provider-icons/deepseek.svg";
+import opencodeIcon from "./assets/provider-icons/opencode.svg";
+import openrouterIcon from "./assets/provider-icons/openrouter.svg";
+
+export interface ChatModelRuntime {
+  id: string;
+  provider: string;
+  model: string;
+  sourceId: string;
+  sourceName: string;
+  reasoningEffort: string;
+  supportedReasoningEfforts: string[];
+  roles: string[];
+}
+
+interface ModelCapsulePickerProps {
+  defaultRuntime: string;
+  runtimes: ChatModelRuntime[];
+  selectedRuntimeId: string;
+  selectedEffort: string;
+  disabled: boolean;
+  onChange: (runtimeId: string, effort: string) => void;
+}
+
+const PROVIDER_ICONS: Record<string, string> = {
+  codex: codexIcon,
+  deepseek: deepseekIcon,
+  "opencode-go": opencodeIcon,
+  opencode: opencodeIcon,
+  openrouter: openrouterIcon,
+};
+
+const EFFORT_LABELS: Record<string, string> = {
+  none: "关闭",
+  minimal: "极低",
+  low: "低",
+  medium: "中",
+  high: "高",
+  xhigh: "极高",
+  max: "最大",
+};
+
+function compatibleEffort(runtime: ChatModelRuntime | undefined, current: string): string {
+  if (!runtime) return "";
+  const supported = runtime.supportedReasoningEfforts;
+  if (current && supported.includes(current)) return current;
+  if (runtime.reasoningEffort && supported.includes(runtime.reasoningEffort)) {
+    return runtime.reasoningEffort;
+  }
+  if (supported.includes("medium")) return "medium";
+  return supported[0] || "";
+}
+
+function sourceIcon(runtime: ChatModelRuntime): string {
+  const provider = runtime.provider.toLowerCase();
+  const source = `${runtime.sourceName} ${runtime.sourceId}`.toLowerCase();
+  if (provider.includes("codex") || source.includes("codex")) return codexIcon;
+  if (provider.includes("opencode") || source.includes("opencode")) return opencodeIcon;
+  if (provider.includes("deepseek") || source.includes("deepseek")) return deepseekIcon;
+  if (provider.includes("openrouter") || source.includes("openrouter")) return openrouterIcon;
+  return PROVIDER_ICONS[provider] || "";
+}
+
+function ModelMark({ runtime }: { runtime: ChatModelRuntime }) {
+  const icon = sourceIcon(runtime);
+  return (
+    <span className="model-capsule__mark" aria-hidden="true">
+      {icon ? <img src={icon} alt="" /> : <span>{runtime.sourceName.slice(0, 1).toUpperCase()}</span>}
+    </span>
+  );
+}
+
+export function ModelCapsulePicker({
+  defaultRuntime,
+  runtimes,
+  selectedRuntimeId,
+  selectedEffort,
+  disabled,
+  onChange,
+}: ModelCapsulePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<"models" | "efforts">("models");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const defaultOptionRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const effortRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const effortTriggerRef = useRef<HTMLButtonElement>(null);
+  const defaultModel = runtimes.find((runtime) => runtime.id === defaultRuntime) || runtimes[0];
+  const explicitModel = runtimes.find((runtime) => runtime.id === selectedRuntimeId);
+  const visibleModel = explicitModel || defaultModel;
+  const supportedEfforts = visibleModel?.supportedReasoningEfforts;
+  const groups = useMemo(() => {
+    const grouped = new Map<string, ChatModelRuntime[]>();
+    for (const runtime of runtimes) {
+      const source = runtime.sourceName || runtime.provider;
+      grouped.set(source, [...(grouped.get(source) || []), runtime]);
+    }
+    return [...grouped.entries()];
+  }, [runtimes]);
+  const visibleEffort = compatibleEffort(visibleModel || defaultModel, selectedEffort);
+
+  useEffect(() => {
+    if (!open) return;
+    const selectedIndex = Math.max(0, runtimes.findIndex((item) => item.id === visibleModel?.id));
+    window.setTimeout(() => {
+      if (view === "efforts") {
+        const effortIndex = Math.max(0, supportedEfforts?.indexOf(visibleEffort) ?? 0);
+        effortRefs.current[effortIndex]?.focus({ preventScroll: true });
+      } else {
+        (selectedRuntimeId ? optionRefs.current[selectedIndex] : defaultOptionRef.current)?.focus({ preventScroll: true });
+      }
+    }, 0);
+    function closeOnPointer(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) closePicker(false);
+    }
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      closePicker(true);
+    }
+    document.addEventListener("pointerdown", closeOnPointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open, runtimes, selectedRuntimeId, supportedEfforts, view, visibleEffort, visibleModel?.id]);
+
+  if (!visibleModel || !defaultModel) return null;
+
+  function closePicker(restoreFocus: boolean) {
+    setOpen(false);
+    setView("models");
+    if (restoreFocus) triggerRef.current?.focus({ preventScroll: true });
+  }
+
+  function choose(runtime: ChatModelRuntime) {
+    onChange(runtime.id, compatibleEffort(runtime, selectedEffort));
+  }
+
+  function showEfforts() {
+    setView("efforts");
+  }
+
+  function showModels() {
+    setView("models");
+    window.setTimeout(() => effortTriggerRef.current?.focus({ preventScroll: true }), 0);
+  }
+
+  return (
+    <div ref={rootRef} className={`model-capsule ${open ? "is-open" : ""}`}>
+      <div className="model-capsule__shell">
+        <div id="model-capsule-panel" className="model-capsule__panel" aria-hidden={!open} aria-label={view === "models" ? "选择模型" : "选择思考强度"}>
+          <header className="model-capsule__header">
+            {view === "efforts" ? (
+              <button type="button" className="model-capsule__back" onClick={showModels}>
+                <ChevronLeft size={17} aria-hidden="true" />
+                <span><small>返回模型</small><strong>思考强度</strong></span>
+              </button>
+            ) : (
+              <div><span>所有供应商</span><strong>选择下一轮使用的模型</strong></div>
+            )}
+            <small>{view === "models" ? `${runtimes.length} 个可用模型` : visibleModel.model}</small>
+          </header>
+          {view === "models" ? <div className="model-capsule__model-view">
+            <div className="model-capsule__list" aria-label="所有供应商的模型">
+            <section className="model-capsule__source">
+              <div className="model-capsule__source-title"><strong>会话策略</strong></div>
+              <button ref={defaultOptionRef} type="button" aria-pressed={!selectedRuntimeId} className="model-capsule__option" onClick={() => onChange("", "")}>
+                <ModelMark runtime={defaultModel} />
+                <span className="model-capsule__copy"><strong>跟随默认模型</strong><small>{defaultModel.model}：{defaultModel.sourceName}</small></span>
+                {!selectedRuntimeId && <Check size={17} aria-hidden="true" />}
+              </button>
+            </section>
+            {groups.map(([source, models]) => (
+              <section className="model-capsule__source" aria-label={source} key={source}>
+                <div className="model-capsule__source-title"><strong>{source}</strong><span>{models.length}</span></div>
+                {models.map((runtime) => {
+                  const index = runtimes.findIndex((item) => item.id === runtime.id);
+                  const active = runtime.id === selectedRuntimeId;
+                  return (
+                    <div className={`model-capsule__option-wrap ${active ? "is-selected" : ""}`} key={runtime.id}>
+                      <button
+                        ref={(node) => { optionRefs.current[index] = node; }}
+                        type="button"
+                        aria-pressed={active}
+                        className="model-capsule__option"
+                        onClick={() => choose(runtime)}
+                      >
+                        <ModelMark runtime={runtime} />
+                        <span className="model-capsule__copy"><strong>{runtime.model}：{runtime.sourceName}</strong><small>{runtime.provider}</small></span>
+                        {active && <Check size={17} aria-hidden="true" />}
+                      </button>
+                    </div>
+                  );
+                })}
+              </section>
+            ))}
+            </div>
+            {visibleModel.supportedReasoningEfforts.length > 0 && (
+              <button ref={effortTriggerRef} type="button" className="model-capsule__effort-entry" onClick={showEfforts}>
+                <Sparkles size={17} aria-hidden="true" />
+                <span><small>思考强度</small><strong>{EFFORT_LABELS[visibleEffort] || visibleEffort}</strong></span>
+                <ChevronRight size={17} aria-hidden="true" />
+              </button>
+            )}
+          </div> : (
+            <div className="model-capsule__effort-list" aria-label={`${visibleModel.model} 支持的思考强度`}>
+              <div className="model-capsule__effort-model">
+                <ModelMark runtime={visibleModel} />
+                <span className="model-capsule__copy"><strong>{visibleModel.model}：{visibleModel.sourceName}</strong><small>仅影响下一轮及之后的此会话</small></span>
+              </div>
+              {visibleModel.supportedReasoningEfforts.map((effort, index) => (
+                <button
+                  ref={(node) => { effortRefs.current[index] = node; }}
+                  type="button"
+                  key={effort}
+                  aria-pressed={visibleEffort === effort}
+                  className={`model-capsule__effort-option ${visibleEffort === effort ? "is-selected" : ""}`}
+                  onClick={() => onChange(visibleModel.id, effort)}
+                >
+                  <span><strong>{EFFORT_LABELS[effort] || effort}</strong><small>{effort}</small></span>
+                  {visibleEffort === effort && <Check size={17} aria-hidden="true" />}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          ref={triggerRef}
+          type="button"
+          className="model-capsule__trigger"
+          aria-controls="model-capsule-panel"
+          aria-expanded={open}
+          disabled={disabled}
+          onClick={() => {
+            if (open) closePicker(false);
+            else setOpen(true);
+          }}
+        >
+          <ModelMark runtime={visibleModel} />
+          <span className="model-capsule__trigger-copy">
+            <strong>{visibleModel.model}：{visibleModel.sourceName}</strong>
+            <small>{explicitModel ? (visibleEffort ? `思考 ${EFFORT_LABELS[visibleEffort] || visibleEffort}` : "固定到此会话") : "跟随默认模型"}</small>
+          </span>
+          <ChevronDown size={18} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -333,6 +333,43 @@ input {
   line-height: 1.2;
 }
 
+.model-connection-state {
+  display: grid;
+  max-width: 520px;
+  justify-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.model-connection-state > span {
+  color: var(--md-sys-color-primary);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.model-connection-state h1 {
+  margin: 0;
+}
+
+.model-connection-state p {
+  max-width: 460px;
+  margin: 0;
+  color: var(--ak-color-text-secondary);
+  line-height: 1.7;
+}
+
+.model-connection-state a {
+  min-height: 42px;
+  border-radius: 999px;
+  padding: 10px 20px;
+  color: var(--md-sys-color-on-primary);
+  background: var(--md-sys-color-primary);
+  font-weight: 650;
+  text-decoration: none;
+}
+
 .role-divider {
   width: min(100%, 820px);
   height: 0;
@@ -911,4 +948,326 @@ form.composer:focus-within [data-slot="input-group"] {
   .mobile-pairing-footer {
     padding-inline: 20px;
   }
+}
+.model-capsule {
+  position: relative;
+  z-index: 12;
+  width: clamp(19rem, 48%, 26.25rem);
+  height: 3rem;
+  margin-block-end: 0.625rem;
+}
+
+.model-capsule__shell {
+  position: absolute;
+  inset: auto auto 0 0;
+  width: 100%;
+  height: 3rem;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  transform-origin: bottom left;
+  transition-property: height, border-color, border-radius, background-color, box-shadow;
+  transition-duration: 260ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.model-capsule.is-open .model-capsule__shell {
+  height: min(27rem, calc(100vh - 17.5rem));
+  border-color: var(--ak-color-border-subtle);
+  border-radius: 1.5rem;
+  background: color-mix(in oklch, var(--ak-color-bg-surface) 95%, transparent);
+  box-shadow: 0 1.75rem 4.5rem oklch(0.22 0.04 260 / 0.2);
+  backdrop-filter: blur(1.5rem);
+}
+
+.model-capsule__trigger {
+  position: absolute;
+  z-index: 3;
+  inset: auto 0.1875rem 0.1875rem;
+  display: flex;
+  width: calc(100% - 0.375rem);
+  min-width: 0;
+  height: 2.625rem;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid color-mix(in oklch, var(--ak-color-action-primary) 30%, var(--ak-color-border-subtle));
+  border-radius: 999px;
+  padding: 0.1875rem 0.75rem 0.1875rem 0.25rem;
+  color: var(--ak-color-text-primary);
+  background: color-mix(in oklch, var(--ak-color-action-container) 55%, var(--ak-color-bg-surface));
+  box-shadow: 0 0.625rem 1.5rem oklch(0.28 0.04 257 / 0.1);
+  cursor: pointer;
+  transition-property: border-color, background-color, box-shadow, scale;
+  transition-duration: 180ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.model-capsule__trigger:hover,
+.model-capsule.is-open .model-capsule__trigger {
+  border-color: var(--ak-color-action-primary);
+  background: var(--ak-color-action-container);
+}
+
+.model-capsule__trigger:active { scale: 0.96; }
+.model-capsule__trigger:disabled { cursor: default; opacity: 0.62; }
+.model-capsule__trigger:focus-visible,
+.model-capsule__option:focus-visible,
+.model-capsule__back:focus-visible,
+.model-capsule__effort-entry:focus-visible,
+.model-capsule__effort-option:focus-visible {
+  outline: 2px solid var(--ak-color-action-primary);
+  outline-offset: 2px;
+}
+
+.model-capsule__trigger > svg {
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+  color: var(--ak-color-action-primary);
+  transition: transform 180ms ease-out;
+}
+
+.model-capsule.is-open .model-capsule__trigger > svg { transform: rotate(180deg); }
+
+.model-capsule__mark {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 50%;
+  background: var(--ak-color-bg-canvas);
+  box-shadow: inset 0 0 0 1px oklch(0 0 0 / 0.1);
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.model-capsule__mark img { width: 1.15rem; height: 1.15rem; object-fit: contain; }
+.model-capsule__trigger-copy,
+.model-capsule__copy { display: grid; min-width: 0; text-align: start; }
+.model-capsule__trigger-copy { gap: 0.05rem; }
+.model-capsule__trigger-copy strong,
+.model-capsule__trigger-copy small,
+.model-capsule__copy strong,
+.model-capsule__copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.model-capsule__trigger-copy strong { font-size: 0.77rem; }
+.model-capsule__trigger-copy small,
+.model-capsule__copy small { color: var(--ak-color-text-secondary); font-size: 0.68rem; }
+
+.model-capsule__panel {
+  position: absolute;
+  inset: 0 0 3.25rem;
+  display: grid;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.625rem);
+  transition-property: opacity, transform;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.model-capsule.is-open .model-capsule__panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition-delay: 90ms;
+}
+
+.model-capsule__header {
+  display: flex;
+  min-height: 4.15rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1rem 0.625rem;
+}
+.model-capsule__header > div { display: grid; gap: 0.12rem; }
+.model-capsule__header span,
+.model-capsule__header small { color: var(--ak-color-text-secondary); font-size: 0.7rem; }
+.model-capsule__header strong { font-size: 0.9rem; }
+
+.model-capsule__back {
+  display: flex;
+  min-width: 0;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.45rem;
+  border: 0;
+  border-radius: 0.85rem;
+  padding: 0.25rem 0.4rem 0.25rem 0.2rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+.model-capsule__back > span { display: grid; gap: 0.08rem; text-align: start; }
+.model-capsule__back:hover { background: var(--ak-color-bg-surface-high); }
+.model-capsule__back:active { scale: 0.96; }
+
+.model-capsule__model-view {
+  display: grid;
+  min-height: 0;
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.model-capsule__list {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 0.55rem 0.75rem;
+  scrollbar-color: var(--ak-color-border-strong) transparent;
+  scrollbar-width: thin;
+}
+.model-capsule__source + .model-capsule__source { margin-block-start: 0.9rem; }
+.model-capsule__source-title {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  display: flex;
+  min-height: 2.2rem;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0.55rem;
+  background: linear-gradient(var(--ak-color-bg-surface) 76%, transparent);
+}
+.model-capsule__source-title strong { font-size: 0.72rem; }
+.model-capsule__source-title span {
+  display: grid;
+  min-width: 1.35rem;
+  min-height: 1.35rem;
+  place-items: center;
+  margin-inline-start: auto;
+  border-radius: 999px;
+  color: var(--ak-color-text-secondary);
+  background: var(--ak-color-bg-surface-low);
+  font-size: 0.65rem;
+}
+.model-capsule__option-wrap { border: 1px solid transparent; border-radius: 0.9rem; }
+.model-capsule__option-wrap.is-selected {
+  border-color: color-mix(in oklch, var(--ak-color-action-primary) 46%, transparent);
+  background: var(--ak-color-action-container);
+}
+.model-capsule__option {
+  display: grid;
+  width: 100%;
+  min-height: 3.45rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0.85rem;
+  padding: 0.4rem 0.55rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  transition-property: border-color, background-color, scale;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+.model-capsule__option:hover { background: var(--ak-color-bg-surface-high); }
+.model-capsule__option:active { scale: 0.96; }
+.model-capsule__copy { gap: 0.18rem; }
+.model-capsule__copy strong { font-size: 0.78rem; }
+.model-capsule__option > svg { color: var(--ak-color-action-primary); }
+
+.model-capsule__effort-entry {
+  display: grid;
+  min-height: 3.75rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0.35rem 0.55rem 0.55rem;
+  border: 1px solid var(--ak-color-border-subtle);
+  border-radius: 1rem;
+  padding: 0.45rem 0.7rem;
+  color: inherit;
+  background: var(--ak-color-bg-surface-low);
+  cursor: pointer;
+  box-shadow: 0 0.4rem 1rem oklch(0.28 0.04 257 / 0.07);
+  transition-property: border-color, background-color, scale;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+.model-capsule__effort-entry:hover {
+  border-color: color-mix(in oklch, var(--ak-color-action-primary) 48%, var(--ak-color-border-subtle));
+  background: var(--ak-color-bg-surface-high);
+}
+.model-capsule__effort-entry:active { scale: 0.96; }
+.model-capsule__effort-entry > svg:first-child { color: var(--ak-color-action-primary); }
+.model-capsule__effort-entry > svg:last-child { color: var(--ak-color-text-secondary); }
+.model-capsule__effort-entry > span { display: grid; min-width: 0; gap: 0.1rem; text-align: start; }
+.model-capsule__effort-entry small {
+  color: var(--ak-color-text-secondary);
+  font-size: 0.68rem;
+}
+.model-capsule__effort-entry strong { font-size: 0.78rem; }
+
+.model-capsule__effort-list {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 0.55rem 0.75rem;
+  scrollbar-color: var(--ak-color-border-strong) transparent;
+  scrollbar-width: thin;
+}
+.model-capsule__effort-model {
+  display: grid;
+  min-height: 4rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  margin-block-end: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 1rem;
+  background: var(--ak-color-bg-surface-low);
+}
+.model-capsule__effort-option {
+  display: grid;
+  width: 100%;
+  min-height: 3.35rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0.9rem;
+  padding: 0.45rem 0.7rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  transition-property: border-color, background-color, scale;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+.model-capsule__effort-option > span { display: grid; gap: 0.12rem; text-align: start; }
+.model-capsule__effort-option strong { font-size: 0.78rem; }
+.model-capsule__effort-option small { color: var(--ak-color-text-secondary); font-size: 0.68rem; }
+.model-capsule__effort-option:hover { background: var(--ak-color-bg-surface-high); }
+.model-capsule__effort-option:active { scale: 0.96; }
+.model-capsule__effort-option.is-selected {
+  border-color: color-mix(in oklch, var(--ak-color-action-primary) 46%, transparent);
+  color: var(--ak-color-on-action-container);
+  background: var(--ak-color-action-container);
+}
+.model-capsule__effort-option > svg { color: var(--ak-color-action-primary); }
+
+@media (max-width: 820px) {
+  .model-capsule { width: min(100%, 26.25rem); }
+  .model-capsule.is-open .model-capsule__shell { height: min(25rem, calc(100vh - 15rem)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .model-capsule__shell,
+  .model-capsule__panel,
+  .model-capsule__trigger,
+  .model-capsule__trigger > svg,
+  .model-capsule__option,
+  .model-capsule__back,
+  .model-capsule__effort-entry,
+  .model-capsule__effort-option { transition-duration: 0.01ms; }
 }


### PR DESCRIPTION
## 问题与结果

- 解决的问题：聊天时模型与 reasoning effort 无法以轻量方式选择。
- 用户可见结果：输入框上方提供水平向上展开的模型胶囊，按 provider 区分模型，二级选择当前模型支持的思考强度。
- 本 PR 不处理：五版交互预览和设计文档。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Chat session selection
- `runtime_patch`：`none`
- `authoritative_state_owner`：服务端 session model_selection；胶囊只提交显式选择

## 改动范围

- 主要文件：`frontend/chat/src/model-capsule-picker.tsx`、`main.tsx`、`styles.css`。
- 回滚方式：回退 `7106fec2`。

## 验证

- [x] 在独立 clean worktree 完成 TypeScript typecheck、ESLint 和 Chat production build。
- [x] 六层累计 549 项改动测试通过。
- [ ] 单层 Change Gate 未单独运行；累计 Gate 已通过。

## 工作手册

- [x] 不支持的 effort 不在前端选项中伪造，服务端仍保留边界校验。
- [x] 本 PR 是 5/6，adjacent diff 为 `stack/runtime-model-settings-ui...stack/runtime-model-chat`。

## PR 堆栈

#330 → #331 → #332 → #333 → **#334** → #327
