### PR TITLE
feat(compaction): add session ledger schema and dormant store

### DIFF
--- a/agent/migrations/session_db_backup.py
+++ b/agent/migrations/session_db_backup.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import cast
+from uuid import uuid4
+
+
+def _read_table_sql(connection: sqlite3.Connection, table: str) -> str:
+    """读取表定义，并拒绝缺失的 schema owner。"""
+
+    # 1. 从 SQLite 元数据读取规范 CREATE TABLE 定义。
+    table_row = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if table_row is None or not table_row[0]:
+        raise RuntimeError(f"{table} schema lineage 不兼容，表定义缺失")
+
+    # 2. 保留后续 schema 校验使用的原始文本。
+    return str(table_row[0])
+
+
+def _validate_table_columns(
+    connection: sqlite3.Connection,
+    table: str,
+    columns: tuple[tuple[str, str, int, int], ...],
+) -> None:
+    """校验 SQLite 列顺序、类型、非空属性和主键序号。"""
+
+    # 1. 读取 SQLite 按声明顺序返回的列元数据。
+    actual_columns = tuple(
+        (str(row[1]), str(row[2]).upper(), int(row[3]), int(row[5]))
+        for row in connection.execute(f"PRAGMA table_info({table})")
+    )
+
+    # 2. 将本迁移持有的 manifest 规范化为相同的比较形状。
+    expected_columns = tuple(
+        (name, column_type.upper(), not_null, pk_ordinal)
+        for name, column_type, not_null, pk_ordinal in columns
+    )
+    if actual_columns != expected_columns:
+        raise RuntimeError(f"{table} schema lineage 不兼容，列定义不匹配")
+
+
+def _validate_sql_fragments(
+    table: str,
+    table_sql: str,
+    fragments: tuple[str, ...],
+) -> None:
+    """校验表定义包含本迁移持有的全部 SQL 约束片段。"""
+
+    # 1. 规范化 SQL 空白和大小写，不改变片段语义。
+    normalized_sql = "".join(table_sql.upper().split())
+
+    # 2. 在首个缺失约束处失败，保留迁移诊断信息。
+    for fragment in fragments:
+        if "".join(fragment.upper().split()) not in normalized_sql:
+            raise RuntimeError(f"{table} schema lineage 不兼容，约束定义缺失")
+
+
+def _read_table_indexes(
+    connection: sqlite3.Connection,
+    table: str,
+) -> list[tuple[object, ...]]:
+    """读取一张表的 SQLite 索引元数据。"""
+
+    # 1. 让 SQLite 返回包含自动索引在内的完整列表。
+    return connection.execute(f"PRAGMA index_list({table})").fetchall()
+
+
+def _validate_named_indexes(
+    connection: sqlite3.Connection,
+    table: str,
+    index_rows: list[tuple[object, ...]],
+    named_indexes: dict[str, tuple[tuple[str, ...], int]],
+) -> None:
+    """校验显式命名索引的集合、唯一性和列顺序。"""
+
+    # 1. 从命名索引合同中排除 SQLite 自动生成的索引。
+    named_rows = {
+        str(row[1]): (int(cast(int, row[2])), str(row[3]))
+        for row in index_rows
+        if not str(row[1]).startswith("sqlite_autoindex_")
+    }
+    if set(named_rows) != set(named_indexes):
+        raise RuntimeError(f"{table} schema lineage 不兼容，索引集合不匹配")
+
+    # 2. 校验每个本迁移索引的唯一性、来源和列顺序。
+    for name, (expected_columns, expected_unique) in named_indexes.items():
+        unique, origin = named_rows[name]
+        if unique != expected_unique or origin != "c":
+            raise RuntimeError(f"{table} schema lineage 不兼容，索引定义不匹配: {name}")
+        actual_columns = tuple(
+            str(row[2])
+            for row in connection.execute(f"PRAGMA index_info({name!r})")
+        )
+        if actual_columns != expected_columns:
+            raise RuntimeError(f"{table} schema lineage 不兼容，索引列不匹配: {name}")
+
+
+def _validate_auto_indexes(
+    connection: sqlite3.Connection,
+    table: str,
+    index_rows: list[tuple[object, ...]],
+    auto_indexes: tuple[tuple[str, tuple[str, ...]], ...],
+) -> None:
+    """校验 SQLite 为主键和唯一约束生成的索引。"""
+
+    # 1. 收集 SQLite 自动索引的来源和列顺序。
+    actual_auto_indexes = []
+    for row in index_rows:
+        name = str(row[1])
+        if not name.startswith("sqlite_autoindex_"):
+            continue
+        actual_auto_indexes.append(
+            (
+                str(row[3]),
+                tuple(
+                    str(index_row[2])
+                    for index_row in connection.execute(f"PRAGMA index_info({name!r})")
+                ),
+            )
+        )
+
+    # 2. 比较生成的 schema identity，不依赖 SQLite 返回顺序。
+    if sorted(actual_auto_indexes) != sorted(auto_indexes):
+        raise RuntimeError(f"{table} schema lineage 不兼容，约束索引不匹配")
+
+
+def validate_table_schema(
+    connection: sqlite3.Connection,
+    *,
+    table: str,
+    columns: tuple[tuple[str, str, int, int], ...],
+    named_indexes: dict[str, tuple[tuple[str, ...], int]],
+    auto_indexes: tuple[tuple[str, tuple[str, ...]], ...],
+    sql_fragments: tuple[str, ...] = (),
+    validate_named_indexes: bool = True,
+) -> None:
+    """除非 SQLite 表符合本迁移的 schema identity，否则明确失败。"""
+
+    # 1. 校验表定义、列顺序和内联约束。
+    table_sql = _read_table_sql(connection, table)
+    _validate_table_columns(connection, table, columns)
+    _validate_sql_fragments(table, table_sql, sql_fragments)
+
+    # 2. 在本阶段负责创建显式索引时校验它们。
+    index_rows = _read_table_indexes(connection, table)
+    if validate_named_indexes:
+        _validate_named_indexes(connection, table, index_rows, named_indexes)
+
+    # 3. 始终校验 SQLite 为约束生成的自动索引。
+    _validate_auto_indexes(connection, table, index_rows, auto_indexes)
+
+
+def _integrity_check(path: Path) -> None:
+    """Verify a SQLite file before publishing it as recovery evidence."""
+
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute("PRAGMA integrity_check").fetchall()
+    finally:
+        connection.close()
+    if rows != [("ok",)]:
+        raise RuntimeError(f"SQLite integrity_check 失败: {path}: {rows[:3]}")
+
+
+def _fsync_directory(path: Path) -> None:
+    """Durably publish one renamed backup and its manifest."""
+
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def backup_sqlite_database(
+    source: Path,
+    backup_root: Path,
+    *,
+    migration: str,
+) -> Path:
+    """Create an online SQLite backup and manifest before a migration DDL write."""
+
+    # 1. Allocate a private, recoverable directory before touching the source DB.
+    backup_root.mkdir(parents=True, mode=0o700, exist_ok=False)
+    os.chmod(backup_root, 0o700)
+    backup = backup_root / source.name
+    candidate = backup.with_name(f".{backup.name}.{uuid4().hex}.tmp")
+    manifest_candidate: Path | None = None
+    try:
+        source_connection = sqlite3.connect(source)
+        try:
+            target_connection = sqlite3.connect(candidate)
+            try:
+                source_connection.backup(target_connection)
+                target_connection.commit()
+            finally:
+                target_connection.close()
+        finally:
+            source_connection.close()
+        candidate.chmod(0o600)
+        with candidate.open("rb") as stream:
+            os.fsync(stream.fileno())
+        _integrity_check(candidate)
+        candidate.replace(backup)
+        backup.chmod(0o600)
+
+        # 2. Persist machine-readable location, digest, and integrity evidence.
+        payload = {
+            "schema_version": 1,
+            "migration": migration,
+            "source": str(source),
+            "backup": backup.name,
+            "sha256": hashlib.sha256(backup.read_bytes()).hexdigest(),
+            "sqlite_integrity": "ok",
+        }
+        manifest = (
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        manifest_path = backup_root / "manifest.json"
+        manifest_candidate = manifest_path.with_name(
+            f".{manifest_path.name}.{uuid4().hex}.tmp"
+        )
+        manifest_candidate.write_bytes(manifest)
+        manifest_candidate.chmod(0o600)
+        with manifest_candidate.open("rb") as stream:
+            os.fsync(stream.fileno())
+        manifest_candidate.replace(manifest_path)
+        _fsync_directory(backup_root)
+    except BaseException:
+        candidate.unlink(missing_ok=True)
+        if manifest_candidate is not None:
+            manifest_candidate.unlink(missing_ok=True)
+        raise
+    return backup

--- a/migrations/yoyo/20260807_01_session_context_compaction_ledger.py
+++ b/migrations/yoyo/20260807_01_session_context_compaction_ledger.py
@@ -1,217 +1,204 @@
 from __future__ import annotations
 
-import os
-import shutil
 import sqlite3
-import tomllib
-from pathlib import Path
-from typing import Any
 from uuid import uuid4
 
-import tomlkit
 from yoyo import step
 
 from agent.migrations.context import current_migration_context
-
+from agent.migrations.session_db_backup import (
+    backup_sqlite_database,
+    validate_table_schema,
+)
 
 __depends__ = {"20260805_01_akasha_sparse_index_v9"}
 __transactional__ = False
 
 _MIGRATION_NAME = "session-context-compaction-ledger"
+_LEGACY_SCHEMA = {
+    "columns": (
+        ("session_key", "TEXT", 1, 1),
+        ("generation", "INTEGER", 1, 2),
+        ("parent_generation", "INTEGER", 1, 0),
+        ("created_at", "TEXT", 1, 0),
+        ("trigger", "TEXT", 1, 0),
+        ("summary_format_version", "INTEGER", 1, 0),
+        ("summary", "TEXT", 1, 0),
+        ("source_ref", "TEXT", 1, 0),
+        ("source_from_seq", "INTEGER", 1, 0),
+        ("consolidated_through_seq", "INTEGER", 1, 0),
+        ("source_message_ids_json", "TEXT", 1, 0),
+        ("retained_tail_json", "TEXT", 1, 0),
+        ("model_runtime_id", "TEXT", 1, 0),
+        ("model", "TEXT", 1, 0),
+        ("context_window", "INTEGER", 1, 0),
+        ("threshold_tokens", "INTEGER", 1, 0),
+        ("hard_input_tokens", "INTEGER", 1, 0),
+        ("keep_recent_tokens", "INTEGER", 1, 0),
+        ("tokens_before", "INTEGER", 1, 0),
+        ("tokens_after", "INTEGER", 1, 0),
+        ("summary_usage_json", "TEXT", 1, 0),
+        ("invalidated_at", "TEXT", 0, 0),
+        ("invalidated_reason", "TEXT", 0, 0),
+    ),
+    "named_indexes": {
+        "idx_session_compactions_active": (
+            ("session_key", "invalidated_at", "generation"),
+            0,
+        ),
+    },
+    "auto_indexes": (
+        ("pk", ("session_key", "generation")),
+        ("u", ("session_key", "source_ref")),
+    ),
+    "sql_fragments": (),
+}
+_FINAL_SCHEMA = {
+    "columns": (
+        ("session_key", "TEXT", 1, 1),
+        ("generation", "INTEGER", 1, 2),
+        ("parent_generation", "INTEGER", 1, 0),
+        ("created_at", "TEXT", 1, 0),
+        ("trigger", "TEXT", 1, 0),
+        ("summary_format_version", "INTEGER", 1, 0),
+        ("summary", "TEXT", 1, 0),
+        ("source_ref", "TEXT", 1, 0),
+        ("source_plan_digest", "TEXT", 1, 0),
+        ("source_from_seq", "INTEGER", 1, 0),
+        ("consolidated_through_seq", "INTEGER", 1, 0),
+        ("source_message_ids_json", "TEXT", 1, 0),
+        ("retained_tail_json", "TEXT", 1, 0),
+        ("model_runtime_id", "TEXT", 1, 0),
+        ("model", "TEXT", 1, 0),
+        ("context_window", "INTEGER", 1, 0),
+        ("threshold_tokens", "INTEGER", 1, 0),
+        ("hard_input_tokens", "INTEGER", 1, 0),
+        ("keep_recent_tokens", "INTEGER", 1, 0),
+        ("tokens_before", "INTEGER", 1, 0),
+        ("tokens_after", "INTEGER", 1, 0),
+        ("summary_usage_json", "TEXT", 1, 0),
+        ("invalidated_at", "TEXT", 0, 0),
+        ("invalidated_reason", "TEXT", 0, 0),
+    ),
+    "named_indexes": {
+        "idx_session_compactions_active": (
+            ("session_key", "invalidated_at", "generation"),
+            0,
+        ),
+    },
+    "auto_indexes": (
+        ("pk", ("session_key", "generation")),
+        ("u", ("session_key", "source_ref")),
+    ),
+    "sql_fragments": (
+        "CHECK (length(source_plan_digest) = 64 AND "
+        "source_plan_digest NOT GLOB '*[^0-9a-f]*')",
+    ),
+}
 
 
-def _integrity_check(path: Path) -> None:
-    connection = sqlite3.connect(path)
-    try:
-        rows = connection.execute("PRAGMA integrity_check").fetchall()
-    finally:
-        connection.close()
-    if rows != [("ok",)]:
-        raise RuntimeError(f"SQLite integrity_check 失败: {path}: {rows[:3]}")
+def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+    """Return whether SQLite owns the expected table name."""
 
-
-def _backup_sqlite(source: Path, target: Path) -> None:
-    """Create and verify a SQLite online backup."""
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    candidate = target.with_name(f".{target.name}.{uuid4().hex}.tmp")
-    try:
-        source_connection = sqlite3.connect(source)
-        target_connection = sqlite3.connect(candidate)
-        try:
-            source_connection.backup(target_connection)
-            target_connection.commit()
-        finally:
-            target_connection.close()
-            source_connection.close()
-        _integrity_check(candidate)
-        candidate.replace(target)
-    except BaseException:
-        candidate.unlink(missing_ok=True)
-        raise
-
-
-def _restore_file(path: Path, content: bytes | None, mode: int | None) -> None:
-    if content is None:
-        path.unlink(missing_ok=True)
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    candidate = path.with_name(f".{path.name}.{uuid4().hex}.restore")
-    candidate.write_bytes(content)
-    if mode is not None:
-        candidate.chmod(mode)
-    candidate.replace(path)
-
-
-def _write_config(path: Path, document: Any, mode: int) -> None:
-    rendered = tomlkit.dumps(document).encode("utf-8")
-    candidate = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
-    candidate.write_bytes(rendered)
-    candidate.chmod(mode)
-    with candidate.open("rb") as stream:
-        os.fsync(stream.fileno())
-    candidate.replace(path)
-
-
-def _migrate_config(path: Path) -> None:
-    """Move legacy window keys to agent.context.compaction."""
-
-    if not path.is_file():
-        return
-    raw = path.read_text(encoding="utf-8")
-    # Parse with stdlib first so malformed config remains a hard migration failure.
-    tomllib.loads(raw)
-    document = tomlkit.parse(raw)
-    agent = document.setdefault("agent", tomlkit.table())
-    if not isinstance(agent, dict):
-        raise ValueError("agent 配置必须是 TOML table")
-    context = agent.setdefault("context", tomlkit.table())
-    if not isinstance(context, dict):
-        raise ValueError("agent.context 配置必须是 TOML table")
-    compaction = context.setdefault("compaction", tomlkit.table())
-    if not isinstance(compaction, dict):
-        raise ValueError("agent.context.compaction 配置必须是 TOML table")
-    if "trigger_percent" not in compaction:
-        compaction["trigger_percent"] = 0.74
-    if "keep_recent_tokens" not in compaction:
-        compaction["keep_recent_tokens"] = 20_000
-
-    # Explicitly migrate removed keys; the runtime loader rejects them if they reappear.
-    context.pop("memory_window", None)
-    document.pop("memory_window", None)
-    llm = document.get("llm")
-    if isinstance(llm, dict):
-        runtimes = llm.get("runtimes")
-        if isinstance(runtimes, dict):
-            for runtime in runtimes.values():
-                if isinstance(runtime, dict):
-                    runtime.pop("effective_context_percent", None)
-                    runtime.pop("compaction_trigger_percent", None)
-    _write_config(path, document, path.stat().st_mode & 0o777)
+    return (
+        connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
 
 
 def _ensure_ledger_schema(connection: sqlite3.Connection) -> None:
-    connection.execute(
-        """
-        CREATE TABLE IF NOT EXISTS session_compactions (
-            session_key TEXT NOT NULL,
-            generation INTEGER NOT NULL,
-            parent_generation INTEGER NOT NULL DEFAULT 0,
-            created_at TEXT NOT NULL,
-            trigger TEXT NOT NULL,
-            summary_format_version INTEGER NOT NULL,
-            summary TEXT NOT NULL,
-            source_ref TEXT NOT NULL,
-            source_from_seq INTEGER NOT NULL,
-            consolidated_through_seq INTEGER NOT NULL,
-            source_message_ids_json TEXT NOT NULL,
-            retained_tail_json TEXT NOT NULL,
-            model_runtime_id TEXT NOT NULL,
-            model TEXT NOT NULL,
-            context_window INTEGER NOT NULL,
-            threshold_tokens INTEGER NOT NULL,
-            hard_input_tokens INTEGER NOT NULL,
-            keep_recent_tokens INTEGER NOT NULL,
-            tokens_before INTEGER NOT NULL,
-            tokens_after INTEGER NOT NULL,
-            summary_usage_json TEXT NOT NULL,
-            invalidated_at TEXT,
-            invalidated_reason TEXT,
-            PRIMARY KEY (session_key, generation),
-            UNIQUE (session_key, source_ref)
+    """Create or validate the additive compaction ledger without touching data."""
+
+    # 1. Create the first-generation ledger when the table is absent.
+    if not _table_exists(connection, "session_compactions"):
+        connection.execute("""
+            CREATE TABLE session_compactions (
+                session_key TEXT NOT NULL,
+                generation INTEGER NOT NULL,
+                parent_generation INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                trigger TEXT NOT NULL,
+                summary_format_version INTEGER NOT NULL,
+                summary TEXT NOT NULL,
+                source_ref TEXT NOT NULL,
+                source_from_seq INTEGER NOT NULL,
+                consolidated_through_seq INTEGER NOT NULL,
+                source_message_ids_json TEXT NOT NULL,
+                retained_tail_json TEXT NOT NULL,
+                model_runtime_id TEXT NOT NULL,
+                model TEXT NOT NULL,
+                context_window INTEGER NOT NULL,
+                threshold_tokens INTEGER NOT NULL,
+                hard_input_tokens INTEGER NOT NULL,
+                keep_recent_tokens INTEGER NOT NULL,
+                tokens_before INTEGER NOT NULL,
+                tokens_after INTEGER NOT NULL,
+                summary_usage_json TEXT NOT NULL,
+                invalidated_at TEXT,
+                invalidated_reason TEXT,
+                PRIMARY KEY (session_key, generation),
+                UNIQUE (session_key, source_ref)
+            )
+            """)
+
+    # 2. Accept only the known pre- and post-digest schema identities.
+    columns = {
+        str(row[1])
+        for row in connection.execute("PRAGMA table_info(session_compactions)")
+    }
+    schema = _FINAL_SCHEMA if "source_plan_digest" in columns else _LEGACY_SCHEMA
+    expected_columns = {column[0] for column in schema["columns"]}
+    missing = sorted(expected_columns - columns)
+    if missing:
+        raise RuntimeError(
+            "session_compactions schema lineage 不兼容，缺少列: " + ", ".join(missing)
         )
-        """
-    )
-    connection.execute(
-        """
+    connection.execute("""
         CREATE INDEX IF NOT EXISTS idx_session_compactions_active
         ON session_compactions(session_key, invalidated_at, generation)
-        """
+        """)
+    validate_table_schema(
+        connection,
+        table="session_compactions",
+        columns=schema["columns"],  # type: ignore[arg-type]
+        named_indexes=schema["named_indexes"],  # type: ignore[arg-type]
+        auto_indexes=schema["auto_indexes"],  # type: ignore[arg-type]
+        sql_fragments=schema["sql_fragments"],  # type: ignore[arg-type]
     )
-    connection.execute(
-        "UPDATE sessions SET last_consolidated = 0 "
-        "WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions')"
-    )
 
 
-def migrate_session_context_compaction_ledger(_connection: object) -> None:
-    """Back up installation state and publish the session compaction schema."""
+def add_session_compaction_ledger(_connection: object) -> None:
+    """Back up SessionDB and add the immutable compaction ledger schema."""
 
+    _ = _connection
     current = current_migration_context()
-    config = current.config_path
-    sessions = current.workspace / "sessions.db"
-    recent = current.workspace / "memory" / "RECENT_CONTEXT.md"
-    backup_root = (
-        current.workspace
-        / "backups"
-        / _MIGRATION_NAME
-        / uuid4().hex
+    sessions_db = current.workspace / "sessions.db"
+    if not sessions_db.exists():
+        return
+
+    # 1. Preserve a verified online backup before any DDL write.
+    backup_sqlite_database(
+        sessions_db,
+        current.workspace / "backups" / _MIGRATION_NAME / uuid4().hex,
+        migration=_MIGRATION_NAME,
     )
-    config_bytes = config.read_bytes() if config.exists() else None
-    config_mode = config.stat().st_mode & 0o777 if config.exists() else None
-    recent_bytes = recent.read_bytes() if recent.exists() else None
-    recent_mode = recent.stat().st_mode & 0o777 if recent.exists() else None
-    sessions_backup = backup_root / "sessions.db"
-    if sessions.exists():
-        _integrity_check(sessions)
-        _backup_sqlite(sessions, sessions_backup)
-    if config_bytes is not None:
-        backup_root.mkdir(parents=True, exist_ok=True)
-        (backup_root / config.name).write_bytes(config_bytes)
-        if config_mode is not None:
-            (backup_root / config.name).chmod(config_mode)
-    if recent_bytes is not None:
-        recent_backup = backup_root / "memory" / recent.name
-        recent_backup.parent.mkdir(parents=True, exist_ok=True)
-        recent_backup.write_bytes(recent_bytes)
-        if recent_mode is not None:
-            recent_backup.chmod(recent_mode)
 
+    # 2. Apply only additive DDL in a short transaction.
+    connection = sqlite3.connect(sessions_db)
     try:
-        # 1. Migrate config and SessionDB before touching the retired projection.
-        _migrate_config(config)
-        if sessions.exists():
-            connection = sqlite3.connect(sessions)
-            try:
-                _ensure_ledger_schema(connection)
-                connection.commit()
-            finally:
-                connection.close()
-            _integrity_check(sessions)
-
-        # 2. Keep a verified archive but remove the retired workspace projection.
-        if recent.exists():
-            recent.unlink()
-        if recent.exists() or recent.is_symlink():
-            raise RuntimeError(f"RECENT_CONTEXT.md 删除失败: {recent}")
-    except BaseException:
-        # 3. Restore every touched persistent object; Yoyo will not record success.
-        _restore_file(config, config_bytes, config_mode)
-        if sessions_backup.exists():
-            shutil.copy2(sessions_backup, sessions)
-            _integrity_check(sessions)
-        _restore_file(recent, recent_bytes, recent_mode)
-        raise
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            _ensure_ledger_schema(connection)
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        connection.commit()
+    finally:
+        connection.close()
 
 
-steps = [step(migrate_session_context_compaction_ledger)]
+steps = [step(add_session_compaction_ledger)]

--- a/migrations/yoyo/20260807_01_session_context_compaction_ledger.py
+++ b/migrations/yoyo/20260807_01_session_context_compaction_ledger.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import tomllib
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import tomlkit
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+
+__depends__ = {"20260805_01_akasha_sparse_index_v9"}
+__transactional__ = False
+
+_MIGRATION_NAME = "session-context-compaction-ledger"
+
+
+def _integrity_check(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute("PRAGMA integrity_check").fetchall()
+    finally:
+        connection.close()
+    if rows != [("ok",)]:
+        raise RuntimeError(f"SQLite integrity_check 失败: {path}: {rows[:3]}")
+
+
+def _backup_sqlite(source: Path, target: Path) -> None:
+    """Create and verify a SQLite online backup."""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    candidate = target.with_name(f".{target.name}.{uuid4().hex}.tmp")
+    try:
+        source_connection = sqlite3.connect(source)
+        target_connection = sqlite3.connect(candidate)
+        try:
+            source_connection.backup(target_connection)
+            target_connection.commit()
+        finally:
+            target_connection.close()
+            source_connection.close()
+        _integrity_check(candidate)
+        candidate.replace(target)
+    except BaseException:
+        candidate.unlink(missing_ok=True)
+        raise
+
+
+def _restore_file(path: Path, content: bytes | None, mode: int | None) -> None:
+    if content is None:
+        path.unlink(missing_ok=True)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    candidate = path.with_name(f".{path.name}.{uuid4().hex}.restore")
+    candidate.write_bytes(content)
+    if mode is not None:
+        candidate.chmod(mode)
+    candidate.replace(path)
+
+
+def _write_config(path: Path, document: Any, mode: int) -> None:
+    rendered = tomlkit.dumps(document).encode("utf-8")
+    candidate = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    candidate.write_bytes(rendered)
+    candidate.chmod(mode)
+    with candidate.open("rb") as stream:
+        os.fsync(stream.fileno())
+    candidate.replace(path)
+
+
+def _migrate_config(path: Path) -> None:
+    """Move legacy window keys to agent.context.compaction."""
+
+    if not path.is_file():
+        return
+    raw = path.read_text(encoding="utf-8")
+    # Parse with stdlib first so malformed config remains a hard migration failure.
+    tomllib.loads(raw)
+    document = tomlkit.parse(raw)
+    agent = document.setdefault("agent", tomlkit.table())
+    if not isinstance(agent, dict):
+        raise ValueError("agent 配置必须是 TOML table")
+    context = agent.setdefault("context", tomlkit.table())
+    if not isinstance(context, dict):
+        raise ValueError("agent.context 配置必须是 TOML table")
+    compaction = context.setdefault("compaction", tomlkit.table())
+    if not isinstance(compaction, dict):
+        raise ValueError("agent.context.compaction 配置必须是 TOML table")
+    if "trigger_percent" not in compaction:
+        compaction["trigger_percent"] = 0.74
+    if "keep_recent_tokens" not in compaction:
+        compaction["keep_recent_tokens"] = 20_000
+
+    # Explicitly migrate removed keys; the runtime loader rejects them if they reappear.
+    context.pop("memory_window", None)
+    document.pop("memory_window", None)
+    llm = document.get("llm")
+    if isinstance(llm, dict):
+        runtimes = llm.get("runtimes")
+        if isinstance(runtimes, dict):
+            for runtime in runtimes.values():
+                if isinstance(runtime, dict):
+                    runtime.pop("effective_context_percent", None)
+                    runtime.pop("compaction_trigger_percent", None)
+    _write_config(path, document, path.stat().st_mode & 0o777)
+
+
+def _ensure_ledger_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_compactions (
+            session_key TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            parent_generation INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            trigger TEXT NOT NULL,
+            summary_format_version INTEGER NOT NULL,
+            summary TEXT NOT NULL,
+            source_ref TEXT NOT NULL,
+            source_from_seq INTEGER NOT NULL,
+            consolidated_through_seq INTEGER NOT NULL,
+            source_message_ids_json TEXT NOT NULL,
+            retained_tail_json TEXT NOT NULL,
+            model_runtime_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            context_window INTEGER NOT NULL,
+            threshold_tokens INTEGER NOT NULL,
+            hard_input_tokens INTEGER NOT NULL,
+            keep_recent_tokens INTEGER NOT NULL,
+            tokens_before INTEGER NOT NULL,
+            tokens_after INTEGER NOT NULL,
+            summary_usage_json TEXT NOT NULL,
+            invalidated_at TEXT,
+            invalidated_reason TEXT,
+            PRIMARY KEY (session_key, generation),
+            UNIQUE (session_key, source_ref)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_session_compactions_active
+        ON session_compactions(session_key, invalidated_at, generation)
+        """
+    )
+    connection.execute(
+        "UPDATE sessions SET last_consolidated = 0 "
+        "WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions')"
+    )
+
+
+def migrate_session_context_compaction_ledger(_connection: object) -> None:
+    """Back up installation state and publish the session compaction schema."""
+
+    current = current_migration_context()
+    config = current.config_path
+    sessions = current.workspace / "sessions.db"
+    recent = current.workspace / "memory" / "RECENT_CONTEXT.md"
+    backup_root = (
+        current.workspace
+        / "backups"
+        / _MIGRATION_NAME
+        / uuid4().hex
+    )
+    config_bytes = config.read_bytes() if config.exists() else None
+    config_mode = config.stat().st_mode & 0o777 if config.exists() else None
+    recent_bytes = recent.read_bytes() if recent.exists() else None
+    recent_mode = recent.stat().st_mode & 0o777 if recent.exists() else None
+    sessions_backup = backup_root / "sessions.db"
+    if sessions.exists():
+        _integrity_check(sessions)
+        _backup_sqlite(sessions, sessions_backup)
+    if config_bytes is not None:
+        backup_root.mkdir(parents=True, exist_ok=True)
+        (backup_root / config.name).write_bytes(config_bytes)
+        if config_mode is not None:
+            (backup_root / config.name).chmod(config_mode)
+    if recent_bytes is not None:
+        recent_backup = backup_root / "memory" / recent.name
+        recent_backup.parent.mkdir(parents=True, exist_ok=True)
+        recent_backup.write_bytes(recent_bytes)
+        if recent_mode is not None:
+            recent_backup.chmod(recent_mode)
+
+    try:
+        # 1. Migrate config and SessionDB before touching the retired projection.
+        _migrate_config(config)
+        if sessions.exists():
+            connection = sqlite3.connect(sessions)
+            try:
+                _ensure_ledger_schema(connection)
+                connection.commit()
+            finally:
+                connection.close()
+            _integrity_check(sessions)
+
+        # 2. Keep a verified archive but remove the retired workspace projection.
+        if recent.exists():
+            recent.unlink()
+        if recent.exists() or recent.is_symlink():
+            raise RuntimeError(f"RECENT_CONTEXT.md 删除失败: {recent}")
+    except BaseException:
+        # 3. Restore every touched persistent object; Yoyo will not record success.
+        _restore_file(config, config_bytes, config_mode)
+        if sessions_backup.exists():
+            shutil.copy2(sessions_backup, sessions)
+            _integrity_check(sessions)
+        _restore_file(recent, recent_bytes, recent_mode)
+        raise
+
+
+steps = [step(migrate_session_context_compaction_ledger)]

--- a/migrations/yoyo/20260808_01_session_mutation_audits.py
+++ b/migrations/yoyo/20260808_01_session_mutation_audits.py
@@ -12,6 +12,7 @@ from agent.migrations.session_db_backup import (
 )
 
 __depends__ = {"20260807_01_session_context_compaction_ledger"}
+__transactional__ = False
 
 
 # This manifest is the migration contract shared by SessionStore and recovery readers.

--- a/migrations/yoyo/20260808_01_session_mutation_audits.py
+++ b/migrations/yoyo/20260808_01_session_mutation_audits.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sqlite3
+
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+__depends__ = {"20260807_01_session_context_compaction_ledger"}
+
+
+# This manifest is the migration contract shared by SessionStore and recovery readers.
+SCHEMA_MANIFEST: dict[str, dict[str, tuple[str, ...]]] = {
+    "session_delete_audits": {
+        "columns": (
+            "audit_id",
+            "targets_json",
+            "message_ids_json",
+            "compactions_json",
+            "action_source",
+            "cascade",
+            "backup_path",
+            "started_at",
+            "completed_at",
+            "result",
+            "deleted_count",
+            "error",
+        ),
+        "indexes": ("idx_session_delete_audits_time",),
+    },
+    "session_source_mutation_audits": {
+        "columns": (
+            "audit_id",
+            "operation",
+            "session_key",
+            "message_ids_json",
+            "action_source",
+            "backup_path",
+            "completed_at",
+        ),
+        "indexes": ("idx_source_mutation_audits_lookup",),
+    },
+}
+
+
+def _ensure_table(
+    connection: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    create_sql: str,
+    index_sql: str,
+) -> None:
+    existing = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if existing is None:
+        connection.execute(create_sql)
+    actual = {
+        str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")
+    }
+    missing = sorted(set(columns) - actual)
+    if missing:
+        raise RuntimeError(f"{table} schema lineage 不兼容，缺少列: {', '.join(missing)}")
+    connection.execute(index_sql)
+
+
+def add_session_mutation_audits(connection: object) -> None:
+    """Create and validate the append-only SessionDB audit tables."""
+
+    _ = connection
+    sessions_db = current_migration_context().workspace / "sessions.db"
+    if not sessions_db.exists():
+        return
+    sessions_connection = sqlite3.connect(sessions_db)
+    try:
+        _ensure_table(
+            sessions_connection,
+            "session_delete_audits",
+            SCHEMA_MANIFEST["session_delete_audits"]["columns"],
+            """
+            CREATE TABLE session_delete_audits (
+                audit_id TEXT PRIMARY KEY,
+                targets_json TEXT NOT NULL,
+                message_ids_json TEXT NOT NULL,
+                compactions_json TEXT NOT NULL,
+                action_source TEXT NOT NULL,
+                cascade INTEGER NOT NULL CHECK (cascade IN (0, 1)),
+                backup_path TEXT,
+                started_at TEXT NOT NULL,
+                completed_at TEXT NOT NULL,
+                result TEXT NOT NULL,
+                deleted_count INTEGER NOT NULL,
+                error TEXT
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_session_delete_audits_time
+            ON session_delete_audits(completed_at, audit_id)
+            """,
+        )
+        _ensure_table(
+            sessions_connection,
+            "session_source_mutation_audits",
+            SCHEMA_MANIFEST["session_source_mutation_audits"]["columns"],
+            """
+            CREATE TABLE session_source_mutation_audits (
+                audit_id TEXT PRIMARY KEY,
+                operation TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                message_ids_json TEXT NOT NULL,
+                action_source TEXT NOT NULL,
+                backup_path TEXT,
+                completed_at TEXT NOT NULL
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_source_mutation_audits_lookup
+            ON session_source_mutation_audits(session_key, completed_at, audit_id)
+            """,
+        )
+        sessions_connection.commit()
+    finally:
+        sessions_connection.close()
+
+
+steps = [step(add_session_mutation_audits)]

--- a/migrations/yoyo/20260808_01_session_mutation_audits.py
+++ b/migrations/yoyo/20260808_01_session_mutation_audits.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import sqlite3
+from uuid import uuid4
 
 from yoyo import step
 
 from agent.migrations.context import current_migration_context
+from agent.migrations.session_db_backup import (
+    backup_sqlite_database,
+    validate_table_schema,
+)
 
 __depends__ = {"20260807_01_session_context_compaction_ledger"}
 
@@ -42,6 +47,49 @@ SCHEMA_MANIFEST: dict[str, dict[str, tuple[str, ...]]] = {
     },
 }
 
+_TABLE_SCHEMAS = {
+    "session_delete_audits": {
+        "columns": (
+            ("audit_id", "TEXT", 0, 1),
+            ("targets_json", "TEXT", 1, 0),
+            ("message_ids_json", "TEXT", 1, 0),
+            ("compactions_json", "TEXT", 1, 0),
+            ("action_source", "TEXT", 1, 0),
+            ("cascade", "INTEGER", 1, 0),
+            ("backup_path", "TEXT", 0, 0),
+            ("started_at", "TEXT", 1, 0),
+            ("completed_at", "TEXT", 1, 0),
+            ("result", "TEXT", 1, 0),
+            ("deleted_count", "INTEGER", 1, 0),
+            ("error", "TEXT", 0, 0),
+        ),
+        "named_indexes": {
+            "idx_session_delete_audits_time": (("completed_at", "audit_id"), 0),
+        },
+        "auto_indexes": (("pk", ("audit_id",)),),
+        "sql_fragments": ("CHECK (cascade IN (0, 1))",),
+    },
+    "session_source_mutation_audits": {
+        "columns": (
+            ("audit_id", "TEXT", 0, 1),
+            ("operation", "TEXT", 1, 0),
+            ("session_key", "TEXT", 1, 0),
+            ("message_ids_json", "TEXT", 1, 0),
+            ("action_source", "TEXT", 1, 0),
+            ("backup_path", "TEXT", 0, 0),
+            ("completed_at", "TEXT", 1, 0),
+        ),
+        "named_indexes": {
+            "idx_source_mutation_audits_lookup": (
+                ("session_key", "completed_at", "audit_id"),
+                0,
+            ),
+        },
+        "auto_indexes": (("pk", ("audit_id",)),),
+        "sql_fragments": (),
+    },
+}
+
 
 def _ensure_table(
     connection: sqlite3.Connection,
@@ -50,75 +98,106 @@ def _ensure_table(
     create_sql: str,
     index_sql: str,
 ) -> None:
+    """创建一张审计表，并校验表与索引的 schema identity。"""
+
+    # 1. 只创建缺失的表；已有表必须通过 manifest 校验。
     existing = connection.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
         (table,),
     ).fetchone()
     if existing is None:
         connection.execute(create_sql)
-    actual = {
-        str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")
-    }
-    missing = sorted(set(columns) - actual)
-    if missing:
-        raise RuntimeError(f"{table} schema lineage 不兼容，缺少列: {', '.join(missing)}")
+
+    # 2. 添加命名索引前，先校验列和内联约束。
+    schema = _TABLE_SCHEMAS[table]
+    validate_table_schema(
+        connection,
+        table=table,
+        columns=schema["columns"],
+        named_indexes=schema["named_indexes"],
+        auto_indexes=schema["auto_indexes"],
+        sql_fragments=schema["sql_fragments"],
+        validate_named_indexes=False,
+    )
+
+    # 3. 创建并校验本迁移持有的查询索引。
     connection.execute(index_sql)
+    validate_table_schema(
+        connection,
+        table=table,
+        columns=schema["columns"],
+        named_indexes=schema["named_indexes"],
+        auto_indexes=schema["auto_indexes"],
+        sql_fragments=schema["sql_fragments"],
+    )
 
 
 def add_session_mutation_audits(connection: object) -> None:
     """Create and validate the append-only SessionDB audit tables."""
 
     _ = connection
-    sessions_db = current_migration_context().workspace / "sessions.db"
+    current = current_migration_context()
+    sessions_db = current.workspace / "sessions.db"
     if not sessions_db.exists():
         return
+    backup_sqlite_database(
+        sessions_db,
+        current.workspace / "backups" / "session-mutation-audits" / uuid4().hex,
+        migration="session-mutation-audits",
+    )
     sessions_connection = sqlite3.connect(sessions_db)
     try:
-        _ensure_table(
-            sessions_connection,
-            "session_delete_audits",
-            SCHEMA_MANIFEST["session_delete_audits"]["columns"],
-            """
-            CREATE TABLE session_delete_audits (
-                audit_id TEXT PRIMARY KEY,
-                targets_json TEXT NOT NULL,
-                message_ids_json TEXT NOT NULL,
-                compactions_json TEXT NOT NULL,
-                action_source TEXT NOT NULL,
-                cascade INTEGER NOT NULL CHECK (cascade IN (0, 1)),
-                backup_path TEXT,
-                started_at TEXT NOT NULL,
-                completed_at TEXT NOT NULL,
-                result TEXT NOT NULL,
-                deleted_count INTEGER NOT NULL,
-                error TEXT
+        sessions_connection.execute("BEGIN IMMEDIATE")
+        try:
+            _ensure_table(
+                sessions_connection,
+                "session_delete_audits",
+                SCHEMA_MANIFEST["session_delete_audits"]["columns"],
+                """
+                CREATE TABLE session_delete_audits (
+                    audit_id TEXT PRIMARY KEY,
+                    targets_json TEXT NOT NULL,
+                    message_ids_json TEXT NOT NULL,
+                    compactions_json TEXT NOT NULL,
+                    action_source TEXT NOT NULL,
+                    cascade INTEGER NOT NULL CHECK (cascade IN (0, 1)),
+                    backup_path TEXT,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT NOT NULL,
+                    result TEXT NOT NULL,
+                    deleted_count INTEGER NOT NULL,
+                    error TEXT
+                )
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_delete_audits_time
+                ON session_delete_audits(completed_at, audit_id)
+                """,
             )
-            """,
-            """
-            CREATE INDEX IF NOT EXISTS idx_session_delete_audits_time
-            ON session_delete_audits(completed_at, audit_id)
-            """,
-        )
-        _ensure_table(
-            sessions_connection,
-            "session_source_mutation_audits",
-            SCHEMA_MANIFEST["session_source_mutation_audits"]["columns"],
-            """
-            CREATE TABLE session_source_mutation_audits (
-                audit_id TEXT PRIMARY KEY,
-                operation TEXT NOT NULL,
-                session_key TEXT NOT NULL,
-                message_ids_json TEXT NOT NULL,
-                action_source TEXT NOT NULL,
-                backup_path TEXT,
-                completed_at TEXT NOT NULL
+            _ensure_table(
+                sessions_connection,
+                "session_source_mutation_audits",
+                SCHEMA_MANIFEST["session_source_mutation_audits"]["columns"],
+                """
+                CREATE TABLE session_source_mutation_audits (
+                    audit_id TEXT PRIMARY KEY,
+                    operation TEXT NOT NULL,
+                    session_key TEXT NOT NULL,
+                    message_ids_json TEXT NOT NULL,
+                    action_source TEXT NOT NULL,
+                    backup_path TEXT,
+                    completed_at TEXT NOT NULL
+                )
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_source_mutation_audits_lookup
+                ON session_source_mutation_audits(session_key, completed_at, audit_id)
+                """,
             )
-            """,
-            """
-            CREATE INDEX IF NOT EXISTS idx_source_mutation_audits_lookup
-            ON session_source_mutation_audits(session_key, completed_at, audit_id)
-            """,
-        )
+        except BaseException:
+            if sessions_connection.in_transaction:
+                sessions_connection.rollback()
+            raise
         sessions_connection.commit()
     finally:
         sessions_connection.close()

--- a/migrations/yoyo/20260808_02_session_compaction_prepares.py
+++ b/migrations/yoyo/20260808_02_session_compaction_prepares.py
@@ -13,6 +13,7 @@ from agent.migrations.session_db_backup import (
 
 
 __depends__ = {"20260808_01_session_mutation_audits"}
+__transactional__ = False
 
 
 # This manifest is the durable fence contract shared by SessionStore and recovery.

--- a/migrations/yoyo/20260808_02_session_compaction_prepares.py
+++ b/migrations/yoyo/20260808_02_session_compaction_prepares.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import sqlite3
+from uuid import uuid4
 
 from yoyo import step
 
 from agent.migrations.context import current_migration_context
+from agent.migrations.session_db_backup import (
+    backup_sqlite_database,
+    validate_table_schema,
+)
 
 
 __depends__ = {"20260808_01_session_mutation_audits"}
@@ -29,6 +34,29 @@ SCHEMA_MANIFEST: dict[str, dict[str, tuple[str, ...]]] = {
     },
 }
 
+_TABLE_SCHEMA = {
+    "columns": (
+        ("session_key", "TEXT", 1, 1),
+        ("session_created_at", "TEXT", 1, 0),
+        ("generation", "INTEGER", 1, 2),
+        ("parent_generation", "INTEGER", 1, 0),
+        ("source_ref", "TEXT", 1, 0),
+        ("source_from_seq", "INTEGER", 1, 0),
+        ("consolidated_through_seq", "INTEGER", 1, 0),
+        ("source_message_ids_json", "TEXT", 1, 0),
+        ("retained_tail_json", "TEXT", 1, 0),
+        ("prepared_at", "TEXT", 1, 0),
+    ),
+    "named_indexes": {
+        "idx_session_compaction_prepares_ref": (("session_key", "source_ref"), 0),
+    },
+    "auto_indexes": (
+        ("pk", ("session_key", "generation")),
+        ("u", ("session_key", "source_ref")),
+    ),
+    "sql_fragments": (),
+}
+
 
 def _ensure_table(
     connection: sqlite3.Connection,
@@ -37,57 +65,85 @@ def _ensure_table(
     create_sql: str,
     index_sql: str,
 ) -> None:
-    """Create or validate one durable prepare schema and its lookup index."""
+    """创建或校验一张 durable prepare 表及其查询索引。"""
 
+    # 1. 只创建缺失的表；已有表必须通过 manifest 校验。
     existing = connection.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
         (table,),
     ).fetchone()
     if existing is None:
         connection.execute(create_sql)
-    actual = {
-        str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")
-    }
-    missing = sorted(set(columns) - actual)
-    if missing:
-        raise RuntimeError(f"{table} schema lineage 不兼容，缺少列: {', '.join(missing)}")
+
+    # 2. 添加命名索引前，先校验列和内联约束。
+    validate_table_schema(
+        connection,
+        table=table,
+        columns=_TABLE_SCHEMA["columns"],
+        named_indexes=_TABLE_SCHEMA["named_indexes"],
+        auto_indexes=_TABLE_SCHEMA["auto_indexes"],
+        sql_fragments=_TABLE_SCHEMA["sql_fragments"],
+        validate_named_indexes=False,
+    )
+
+    # 3. 创建并校验本迁移持有的查询索引。
     connection.execute(index_sql)
+    validate_table_schema(
+        connection,
+        table=table,
+        columns=_TABLE_SCHEMA["columns"],
+        named_indexes=_TABLE_SCHEMA["named_indexes"],
+        auto_indexes=_TABLE_SCHEMA["auto_indexes"],
+        sql_fragments=_TABLE_SCHEMA["sql_fragments"],
+    )
 
 
 def add_session_compaction_prepares(connection: object) -> None:
     """Create and validate the durable receipt-before-ledger fence table."""
 
     _ = connection
-    sessions_db = current_migration_context().workspace / "sessions.db"
+    current = current_migration_context()
+    sessions_db = current.workspace / "sessions.db"
     if not sessions_db.exists():
         return
+    backup_sqlite_database(
+        sessions_db,
+        current.workspace / "backups" / "session-compaction-prepares" / uuid4().hex,
+        migration="session-compaction-prepares",
+    )
     sessions_connection = sqlite3.connect(sessions_db)
     try:
-        _ensure_table(
-            sessions_connection,
-            "session_compaction_prepares",
-            SCHEMA_MANIFEST["session_compaction_prepares"]["columns"],
-            """
-            CREATE TABLE session_compaction_prepares (
-                session_key TEXT NOT NULL,
-                session_created_at TEXT NOT NULL,
-                generation INTEGER NOT NULL,
-                parent_generation INTEGER NOT NULL,
-                source_ref TEXT NOT NULL,
-                source_from_seq INTEGER NOT NULL,
-                consolidated_through_seq INTEGER NOT NULL,
-                source_message_ids_json TEXT NOT NULL,
-                retained_tail_json TEXT NOT NULL,
-                prepared_at TEXT NOT NULL,
-                PRIMARY KEY (session_key, generation),
-                UNIQUE (session_key, source_ref)
+        sessions_connection.execute("BEGIN IMMEDIATE")
+        try:
+            _ensure_table(
+                sessions_connection,
+                "session_compaction_prepares",
+                SCHEMA_MANIFEST["session_compaction_prepares"]["columns"],
+                """
+                CREATE TABLE session_compaction_prepares (
+                    session_key TEXT NOT NULL,
+                    session_created_at TEXT NOT NULL,
+                    generation INTEGER NOT NULL,
+                    parent_generation INTEGER NOT NULL,
+                    source_ref TEXT NOT NULL,
+                    source_from_seq INTEGER NOT NULL,
+                    consolidated_through_seq INTEGER NOT NULL,
+                    source_message_ids_json TEXT NOT NULL,
+                    retained_tail_json TEXT NOT NULL,
+                    prepared_at TEXT NOT NULL,
+                    PRIMARY KEY (session_key, generation),
+                    UNIQUE (session_key, source_ref)
+                )
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_compaction_prepares_ref
+                ON session_compaction_prepares(session_key, source_ref)
+                """,
             )
-            """,
-            """
-            CREATE INDEX IF NOT EXISTS idx_session_compaction_prepares_ref
-            ON session_compaction_prepares(session_key, source_ref)
-            """,
-        )
+        except BaseException:
+            if sessions_connection.in_transaction:
+                sessions_connection.rollback()
+            raise
         sessions_connection.commit()
     finally:
         sessions_connection.close()

--- a/migrations/yoyo/20260808_02_session_compaction_prepares.py
+++ b/migrations/yoyo/20260808_02_session_compaction_prepares.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sqlite3
+
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+
+__depends__ = {"20260808_01_session_mutation_audits"}
+
+
+# This manifest is the durable fence contract shared by SessionStore and recovery.
+SCHEMA_MANIFEST: dict[str, dict[str, tuple[str, ...]]] = {
+    "session_compaction_prepares": {
+        "columns": (
+            "session_key",
+            "session_created_at",
+            "generation",
+            "parent_generation",
+            "source_ref",
+            "source_from_seq",
+            "consolidated_through_seq",
+            "source_message_ids_json",
+            "retained_tail_json",
+            "prepared_at",
+        ),
+        "indexes": ("idx_session_compaction_prepares_ref",),
+    },
+}
+
+
+def _ensure_table(
+    connection: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    create_sql: str,
+    index_sql: str,
+) -> None:
+    """Create or validate one durable prepare schema and its lookup index."""
+
+    existing = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if existing is None:
+        connection.execute(create_sql)
+    actual = {
+        str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")
+    }
+    missing = sorted(set(columns) - actual)
+    if missing:
+        raise RuntimeError(f"{table} schema lineage 不兼容，缺少列: {', '.join(missing)}")
+    connection.execute(index_sql)
+
+
+def add_session_compaction_prepares(connection: object) -> None:
+    """Create and validate the durable receipt-before-ledger fence table."""
+
+    _ = connection
+    sessions_db = current_migration_context().workspace / "sessions.db"
+    if not sessions_db.exists():
+        return
+    sessions_connection = sqlite3.connect(sessions_db)
+    try:
+        _ensure_table(
+            sessions_connection,
+            "session_compaction_prepares",
+            SCHEMA_MANIFEST["session_compaction_prepares"]["columns"],
+            """
+            CREATE TABLE session_compaction_prepares (
+                session_key TEXT NOT NULL,
+                session_created_at TEXT NOT NULL,
+                generation INTEGER NOT NULL,
+                parent_generation INTEGER NOT NULL,
+                source_ref TEXT NOT NULL,
+                source_from_seq INTEGER NOT NULL,
+                consolidated_through_seq INTEGER NOT NULL,
+                source_message_ids_json TEXT NOT NULL,
+                retained_tail_json TEXT NOT NULL,
+                prepared_at TEXT NOT NULL,
+                PRIMARY KEY (session_key, generation),
+                UNIQUE (session_key, source_ref)
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_session_compaction_prepares_ref
+            ON session_compaction_prepares(session_key, source_ref)
+            """,
+        )
+        sessions_connection.commit()
+    finally:
+        sessions_connection.close()
+
+
+steps = [step(add_session_compaction_prepares)]

--- a/migrations/yoyo/20260808_04_session_compaction_source_plan_digest.py
+++ b/migrations/yoyo/20260808_04_session_compaction_source_plan_digest.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from uuid import uuid4
+
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+from agent.migrations.session_db_backup import (
+    backup_sqlite_database,
+    validate_table_schema,
+)
+
+
+__depends__ = {"20260808_02_session_compaction_prepares"}
+
+_MIGRATION_NAME = "session-compaction-source-plan-digest"
+_SOURCE_PLAN_DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
+_SOURCE_PLAN_DIGEST_CHECK = (
+    "CHECK (length(source_plan_digest) = 64 AND "
+    "source_plan_digest NOT GLOB '*[^0-9a-f]*')"
+)
+
+
+# This manifest is the final SessionDB schema contract shared by Store and recovery.
+SCHEMA_MANIFEST: dict[str, dict[str, tuple[str, ...]]] = {
+    "session_compactions": {
+        "columns": (
+            "session_key",
+            "generation",
+            "parent_generation",
+            "created_at",
+            "trigger",
+            "summary_format_version",
+            "summary",
+            "source_ref",
+            "source_plan_digest",
+            "source_from_seq",
+            "consolidated_through_seq",
+            "source_message_ids_json",
+            "retained_tail_json",
+            "model_runtime_id",
+            "model",
+            "context_window",
+            "threshold_tokens",
+            "hard_input_tokens",
+            "keep_recent_tokens",
+            "tokens_before",
+            "tokens_after",
+            "summary_usage_json",
+            "invalidated_at",
+            "invalidated_reason",
+        ),
+        "indexes": ("idx_session_compactions_active",),
+    },
+}
+
+
+_LEGACY_TABLE_SCHEMA = {
+    "columns": (
+        ("session_key", "TEXT", 1, 1),
+        ("generation", "INTEGER", 1, 2),
+        ("parent_generation", "INTEGER", 1, 0),
+        ("created_at", "TEXT", 1, 0),
+        ("trigger", "TEXT", 1, 0),
+        ("summary_format_version", "INTEGER", 1, 0),
+        ("summary", "TEXT", 1, 0),
+        ("source_ref", "TEXT", 1, 0),
+        ("source_from_seq", "INTEGER", 1, 0),
+        ("consolidated_through_seq", "INTEGER", 1, 0),
+        ("source_message_ids_json", "TEXT", 1, 0),
+        ("retained_tail_json", "TEXT", 1, 0),
+        ("model_runtime_id", "TEXT", 1, 0),
+        ("model", "TEXT", 1, 0),
+        ("context_window", "INTEGER", 1, 0),
+        ("threshold_tokens", "INTEGER", 1, 0),
+        ("hard_input_tokens", "INTEGER", 1, 0),
+        ("keep_recent_tokens", "INTEGER", 1, 0),
+        ("tokens_before", "INTEGER", 1, 0),
+        ("tokens_after", "INTEGER", 1, 0),
+        ("summary_usage_json", "TEXT", 1, 0),
+        ("invalidated_at", "TEXT", 0, 0),
+        ("invalidated_reason", "TEXT", 0, 0),
+    ),
+    "named_indexes": {
+        "idx_session_compactions_active": (
+            ("session_key", "invalidated_at", "generation"),
+            0,
+        ),
+    },
+    "auto_indexes": (
+        ("pk", ("session_key", "generation")),
+        ("u", ("session_key", "source_ref")),
+    ),
+    "sql_fragments": (),
+}
+
+_FINAL_TABLE_SCHEMA = {
+    "columns": (
+        ("session_key", "TEXT", 1, 1),
+        ("generation", "INTEGER", 1, 2),
+        ("parent_generation", "INTEGER", 1, 0),
+        ("created_at", "TEXT", 1, 0),
+        ("trigger", "TEXT", 1, 0),
+        ("summary_format_version", "INTEGER", 1, 0),
+        ("summary", "TEXT", 1, 0),
+        ("source_ref", "TEXT", 1, 0),
+        ("source_plan_digest", "TEXT", 1, 0),
+        ("source_from_seq", "INTEGER", 1, 0),
+        ("consolidated_through_seq", "INTEGER", 1, 0),
+        ("source_message_ids_json", "TEXT", 1, 0),
+        ("retained_tail_json", "TEXT", 1, 0),
+        ("model_runtime_id", "TEXT", 1, 0),
+        ("model", "TEXT", 1, 0),
+        ("context_window", "INTEGER", 1, 0),
+        ("threshold_tokens", "INTEGER", 1, 0),
+        ("hard_input_tokens", "INTEGER", 1, 0),
+        ("keep_recent_tokens", "INTEGER", 1, 0),
+        ("tokens_before", "INTEGER", 1, 0),
+        ("tokens_after", "INTEGER", 1, 0),
+        ("summary_usage_json", "TEXT", 1, 0),
+        ("invalidated_at", "TEXT", 0, 0),
+        ("invalidated_reason", "TEXT", 0, 0),
+    ),
+    "named_indexes": {
+        "idx_session_compactions_active": (
+            ("session_key", "invalidated_at", "generation"),
+            0,
+        ),
+    },
+    "auto_indexes": (
+        ("pk", ("session_key", "generation")),
+        ("u", ("session_key", "source_ref")),
+    ),
+    "sql_fragments": (_SOURCE_PLAN_DIGEST_CHECK,),
+}
+
+
+def _create_final_table(connection: sqlite3.Connection) -> None:
+    """Create the final ledger table and its query index."""
+
+    connection.execute(
+        f"""
+        CREATE TABLE session_compactions (
+            session_key TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            parent_generation INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            trigger TEXT NOT NULL,
+            summary_format_version INTEGER NOT NULL,
+            summary TEXT NOT NULL,
+            source_ref TEXT NOT NULL,
+            source_plan_digest TEXT NOT NULL {_SOURCE_PLAN_DIGEST_CHECK},
+            source_from_seq INTEGER NOT NULL,
+            consolidated_through_seq INTEGER NOT NULL,
+            source_message_ids_json TEXT NOT NULL,
+            retained_tail_json TEXT NOT NULL,
+            model_runtime_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            context_window INTEGER NOT NULL,
+            threshold_tokens INTEGER NOT NULL,
+            hard_input_tokens INTEGER NOT NULL,
+            keep_recent_tokens INTEGER NOT NULL,
+            tokens_before INTEGER NOT NULL,
+            tokens_after INTEGER NOT NULL,
+            summary_usage_json TEXT NOT NULL,
+            invalidated_at TEXT,
+            invalidated_reason TEXT,
+            PRIMARY KEY (session_key, generation),
+            UNIQUE (session_key, source_ref)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX idx_session_compactions_active
+        ON session_compactions(session_key, invalidated_at, generation)
+        """
+    )
+
+
+def _validate_schema(
+    connection: sqlite3.Connection,
+    schema: dict[str, object],
+) -> None:
+    """Validate one ledger schema identity through the shared SQLite checker."""
+
+    validate_table_schema(
+        connection,
+        table="session_compactions",
+        columns=schema["columns"],  # type: ignore[arg-type]
+        named_indexes=schema["named_indexes"],  # type: ignore[arg-type]
+        auto_indexes=schema["auto_indexes"],  # type: ignore[arg-type]
+        sql_fragments=schema["sql_fragments"],  # type: ignore[arg-type]
+    )
+
+
+def _validate_digest_values(connection: sqlite3.Connection) -> None:
+    """Reject persisted rows whose source-plan identity is absent or malformed."""
+
+    rows = connection.execute(
+        "SELECT session_key, generation, source_plan_digest FROM session_compactions"
+    ).fetchall()
+    for row in rows:
+        digest = row[2]
+        if not isinstance(digest, str) or _SOURCE_PLAN_DIGEST_PATTERN.fullmatch(digest) is None:
+            raise RuntimeError(
+                "session_compactions source_plan_digest 非法: "
+                f"{row[0]}:{row[1]}"
+            )
+
+
+def _rebuild_empty_legacy_table(connection: sqlite3.Connection) -> None:
+    """Rebuild the zero-row pre-digest table without inventing source identities."""
+
+    legacy_name = "session_compactions__source_plan_digest_legacy"
+    existing = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (legacy_name,),
+    ).fetchone()
+    if existing is not None:
+        raise RuntimeError("session_compactions schema upgrade staging table 已存在")
+    row = connection.execute("SELECT COUNT(1) FROM session_compactions").fetchone()
+    if row is None or int(row[0]) != 0:
+        raise RuntimeError("session_compactions 缺少 source_plan_digest 且已有数据")
+
+    # 1. Keep the whole operation in the caller transaction; rollback restores the old table.
+    connection.execute("DROP INDEX IF EXISTS idx_session_compactions_active")
+    connection.execute(
+        "ALTER TABLE session_compactions RENAME TO " + legacy_name
+    )
+    try:
+        _create_final_table(connection)
+        _validate_schema(connection, _FINAL_TABLE_SCHEMA)
+        connection.execute("DROP TABLE " + legacy_name)
+    except BaseException:
+        raise
+
+
+def _ensure_source_plan_digest_schema(connection: sqlite3.Connection) -> None:
+    """Upgrade only a verifiable empty legacy ledger; reject ambiguous rows."""
+
+    table = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_compactions'"
+    ).fetchone()
+    if table is None:
+        raise RuntimeError("session_compactions schema lineage 不兼容，表定义缺失")
+    columns = {
+        str(row[1]) for row in connection.execute("PRAGMA table_info(session_compactions)")
+    }
+    if "source_plan_digest" not in columns:
+        count_row = connection.execute(
+            "SELECT COUNT(1) FROM session_compactions"
+        ).fetchone()
+        count = int(count_row[0]) if count_row is not None else 0
+        if count:
+            raise RuntimeError(
+                "session_compactions 缺少 source_plan_digest 且已有数据，拒绝猜测回填"
+            )
+        _validate_schema(connection, _LEGACY_TABLE_SCHEMA)
+        _rebuild_empty_legacy_table(connection)
+        return
+    _validate_schema(connection, _FINAL_TABLE_SCHEMA)
+    _validate_digest_values(connection)
+
+
+def add_source_plan_digest(_connection: object) -> None:
+    """Back up and publish the final source-plan digest ledger schema."""
+
+    _ = _connection
+    current = current_migration_context()
+    sessions_db = current.workspace / "sessions.db"
+    if not sessions_db.exists():
+        return
+    backup_sqlite_database(
+        sessions_db,
+        current.workspace / "backups" / _MIGRATION_NAME / uuid4().hex,
+        migration=_MIGRATION_NAME,
+    )
+    connection = sqlite3.connect(sessions_db)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            _ensure_source_plan_digest_schema(connection)
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        connection.commit()
+    finally:
+        connection.close()
+
+
+steps = [step(add_source_plan_digest)]

--- a/migrations/yoyo/20260808_04_session_compaction_source_plan_digest.py
+++ b/migrations/yoyo/20260808_04_session_compaction_source_plan_digest.py
@@ -14,6 +14,7 @@ from agent.migrations.session_db_backup import (
 
 
 __depends__ = {"20260808_02_session_compaction_prepares"}
+__transactional__ = False
 
 _MIGRATION_NAME = "session-compaction-source-plan-digest"
 _SOURCE_PLAN_DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
@@ -230,12 +231,9 @@ def _rebuild_empty_legacy_table(connection: sqlite3.Connection) -> None:
     connection.execute(
         "ALTER TABLE session_compactions RENAME TO " + legacy_name
     )
-    try:
-        _create_final_table(connection)
-        _validate_schema(connection, _FINAL_TABLE_SCHEMA)
-        connection.execute("DROP TABLE " + legacy_name)
-    except BaseException:
-        raise
+    _create_final_table(connection)
+    _validate_schema(connection, _FINAL_TABLE_SCHEMA)
+    connection.execute("DROP TABLE " + legacy_name)
 
 
 def _ensure_source_plan_digest_schema(connection: sqlite3.Connection) -> None:

--- a/session/store.py
+++ b/session/store.py
@@ -4013,7 +4013,7 @@ class SessionStore:
                     turn_rows,
                 )
 
-                # 2. Cursor 只由 ledger provenance 驱动；迁移负责清理 legacy 值。
+                # 2. 旧游标先保持删除语义；若已有 ledger 记录则由 provenance 覆盖。
                 meta = self._conn.execute(
                     "SELECT last_consolidated FROM sessions WHERE key = ?",
                     (session_key,),
@@ -4021,7 +4021,8 @@ class SessionStore:
                 if meta is None:
                     raise ValueError(f"interaction session 不存在: {session_key}")
                 old_cursor = int(meta["last_consolidated"])
-                new_cursor = old_cursor
+                group_start = positions[0]
+                new_cursor = group_start if old_cursor > group_start else old_cursor
 
                 # 2. active admission 与删除共用同一写事务，避免当前 turn 在删除后提交。
                 self._require_no_pending_compaction_prepare_locked([session_key])

--- a/session/store.py
+++ b/session/store.py
@@ -47,6 +47,39 @@ class InteractionDeletion:
     new_last_consolidated: int
     backup_path: str
 
+
+@dataclass(frozen=True)
+class SessionCompaction:
+    """A persisted, immutable model-context checkpoint for one session."""
+
+    session_key: str
+    generation: int
+    parent_generation: int
+    created_at: str
+    trigger: str
+    summary_format_version: int
+    summary: str
+    source_ref: str
+    source_from_seq: int
+    consolidated_through_seq: int
+    source_message_ids: tuple[str, ...]
+    retained_tail: tuple[dict[str, Any], ...]
+    model_runtime_id: str
+    model: str
+    context_window: int
+    threshold_tokens: int
+    hard_input_tokens: int
+    keep_recent_tokens: int
+    tokens_before: int
+    tokens_after: int
+    summary_usage: dict[str, Any]
+    invalidated_at: str | None = None
+    invalidated_reason: str | None = None
+
+    @property
+    def active(self) -> bool:
+        return self.invalidated_at is None
+
 _FTS_CAPABILITY_ERROR_MARKERS = (
     "no such module: fts5",
     "no such tokenizer: trigram",
@@ -456,6 +489,39 @@ class SessionStore:
                 )
                 """)
             self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS session_compactions (
+                    session_key TEXT NOT NULL,
+                    generation INTEGER NOT NULL,
+                    parent_generation INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    trigger TEXT NOT NULL,
+                    summary_format_version INTEGER NOT NULL,
+                    summary TEXT NOT NULL,
+                    source_ref TEXT NOT NULL,
+                    source_from_seq INTEGER NOT NULL,
+                    consolidated_through_seq INTEGER NOT NULL,
+                    source_message_ids_json TEXT NOT NULL,
+                    retained_tail_json TEXT NOT NULL,
+                    model_runtime_id TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    context_window INTEGER NOT NULL,
+                    threshold_tokens INTEGER NOT NULL,
+                    hard_input_tokens INTEGER NOT NULL,
+                    keep_recent_tokens INTEGER NOT NULL,
+                    tokens_before INTEGER NOT NULL,
+                    tokens_after INTEGER NOT NULL,
+                    summary_usage_json TEXT NOT NULL,
+                    invalidated_at TEXT,
+                    invalidated_reason TEXT,
+                    PRIMARY KEY (session_key, generation),
+                    UNIQUE (session_key, source_ref)
+                )
+                """)
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_session_compactions_active
+                ON session_compactions(session_key, invalidated_at, generation)
+                """)
+            self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS turns (
                     id             TEXT PRIMARY KEY,
                     session_key    TEXT NOT NULL,
@@ -824,6 +890,346 @@ class SessionStore:
                 (int(last_consolidated), now, key),
             )
             self._conn.commit()
+
+    @staticmethod
+    def _row_to_compaction(row: sqlite3.Row) -> SessionCompaction:
+        """Decode one ledger row at the SQLite boundary."""
+
+        source_ids = _decode_json_payload(
+            row["source_message_ids_json"],
+            fallback="[]",
+            field="compaction source_message_ids",
+            identifier=f"{row['session_key']}:{row['generation']}",
+        )
+        retained_tail = _decode_json_payload(
+            row["retained_tail_json"],
+            fallback="[]",
+            field="compaction retained_tail",
+            identifier=f"{row['session_key']}:{row['generation']}",
+        )
+        usage = _decode_json_payload(
+            row["summary_usage_json"],
+            fallback="{}",
+            field="compaction summary_usage",
+            identifier=f"{row['session_key']}:{row['generation']}",
+        )
+        if not isinstance(source_ids, list) or not all(
+            isinstance(item, str) and item for item in source_ids
+        ):
+            raise ValueError(
+                "compaction source_message_ids 必须是非空字符串数组: "
+                f"{row['session_key']}:{row['generation']}"
+            )
+        if not isinstance(retained_tail, list) or not all(
+            isinstance(item, dict) for item in retained_tail
+        ):
+            raise ValueError(
+                "compaction retained_tail 必须是对象数组: "
+                f"{row['session_key']}:{row['generation']}"
+            )
+        if not isinstance(usage, dict):
+            raise ValueError(
+                "compaction summary_usage 必须是 JSON object: "
+                f"{row['session_key']}:{row['generation']}"
+            )
+        return SessionCompaction(
+            session_key=str(row["session_key"]),
+            generation=int(row["generation"]),
+            parent_generation=int(row["parent_generation"]),
+            created_at=str(row["created_at"]),
+            trigger=str(row["trigger"]),
+            summary_format_version=int(row["summary_format_version"]),
+            summary=str(row["summary"]),
+            source_ref=str(row["source_ref"]),
+            source_from_seq=int(row["source_from_seq"]),
+            consolidated_through_seq=int(row["consolidated_through_seq"]),
+            source_message_ids=tuple(str(item) for item in source_ids),
+            retained_tail=tuple(cast(dict[str, Any], item) for item in retained_tail),
+            model_runtime_id=str(row["model_runtime_id"]),
+            model=str(row["model"]),
+            context_window=int(row["context_window"]),
+            threshold_tokens=int(row["threshold_tokens"]),
+            hard_input_tokens=int(row["hard_input_tokens"]),
+            keep_recent_tokens=int(row["keep_recent_tokens"]),
+            tokens_before=int(row["tokens_before"]),
+            tokens_after=int(row["tokens_after"]),
+            summary_usage=cast(dict[str, Any], usage),
+            invalidated_at=(
+                str(row["invalidated_at"])
+                if row["invalidated_at"] is not None
+                else None
+            ),
+            invalidated_reason=(
+                str(row["invalidated_reason"])
+                if row["invalidated_reason"] is not None
+                else None
+            ),
+        )
+
+    def persist_compaction(
+        self,
+        *,
+        session_key: str,
+        trigger: str,
+        summary: str,
+        source_ref: str,
+        source_from_seq: int,
+        consolidated_through_seq: int,
+        source_message_ids: list[str] | tuple[str, ...],
+        retained_tail: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+        model_runtime_id: str,
+        model: str,
+        context_window: int,
+        threshold_tokens: int,
+        hard_input_tokens: int,
+        keep_recent_tokens: int,
+        tokens_before: int,
+        tokens_after: int,
+        summary_usage: dict[str, Any],
+        parent_generation: int | None = None,
+        generation: int | None = None,
+        summary_format_version: int = 1,
+    ) -> SessionCompaction:
+        """Insert one immutable checkpoint and advance the session cursor atomically."""
+
+        # 1. Validate the boundary payload before acquiring the write transaction.
+        if not session_key.strip() or not source_ref.strip() or not summary.strip():
+            raise ValueError("compaction session_key/source_ref/summary 不能为空")
+        if not source_message_ids or any(
+            not isinstance(item, str) or not item.strip() for item in source_message_ids
+        ):
+            raise ValueError("compaction source_message_ids 必须是非空字符串数组")
+        if any(not isinstance(item, dict) for item in retained_tail):
+            raise ValueError("compaction retained_tail 必须是对象数组")
+        if not isinstance(summary_usage, dict):
+            raise ValueError("compaction summary_usage 必须是 JSON object")
+        encoded_ids = json.dumps(
+            list(source_message_ids), ensure_ascii=False, separators=(",", ":")
+        )
+        encoded_tail = json.dumps(
+            list(retained_tail), ensure_ascii=False, separators=(",", ":")
+        )
+        encoded_usage = json.dumps(
+            summary_usage, ensure_ascii=False, separators=(",", ":")
+        )
+        now = datetime.now().astimezone().isoformat()
+
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                session_row = self._conn.execute(
+                    "SELECT last_consolidated FROM sessions WHERE key = ?",
+                    (session_key,),
+                ).fetchone()
+                if session_row is None:
+                    raise KeyError(f"session 不存在: {session_key}")
+                current_cursor = int(session_row["last_consolidated"] or 0)
+                max_row = self._conn.execute(
+                    "SELECT COALESCE(MAX(generation), 0) AS generation "
+                    "FROM session_compactions WHERE session_key = ?",
+                    (session_key,),
+                ).fetchone()
+                max_generation = int(max_row["generation"] if max_row else 0)
+                if generation is None:
+                    generation = max_generation + 1
+                if int(generation) <= max_generation:
+                    raise ValueError(
+                        f"compaction generation 必须单调递增: {session_key}:{generation}"
+                    )
+                if parent_generation is None:
+                    parent_generation = current_cursor
+                if int(parent_generation) != current_cursor:
+                    raise ValueError(
+                        "compaction parent_generation 与当前 cursor 不一致: "
+                        f"session={session_key} cursor={current_cursor} parent={parent_generation}"
+                    )
+                existing = self._conn.execute(
+                    "SELECT * FROM session_compactions "
+                    "WHERE session_key = ? AND source_ref = ?",
+                    (session_key, source_ref),
+                ).fetchone()
+                if existing is not None:
+                    existing_value = self._row_to_compaction(existing)
+                    if (
+                        existing_value.trigger != str(trigger)
+                        or existing_value.parent_generation != int(parent_generation)
+                        or existing_value.summary_format_version != int(summary_format_version)
+                        or existing_value.summary != summary
+                        or existing_value.source_from_seq != int(source_from_seq)
+                        or existing_value.consolidated_through_seq
+                        != int(consolidated_through_seq)
+                        or existing_value.source_message_ids != tuple(source_message_ids)
+                        or existing_value.retained_tail != tuple(retained_tail)
+                        or existing_value.model_runtime_id != model_runtime_id
+                        or existing_value.model != model
+                        or existing_value.context_window != int(context_window)
+                        or existing_value.threshold_tokens != int(threshold_tokens)
+                        or existing_value.hard_input_tokens != int(hard_input_tokens)
+                        or existing_value.keep_recent_tokens != int(keep_recent_tokens)
+                        or existing_value.tokens_before != int(tokens_before)
+                        or existing_value.tokens_after != int(tokens_after)
+                        or existing_value.summary_usage != summary_usage
+                    ):
+                        raise ValueError(
+                            f"compaction source_ref 内容冲突: {session_key}:{source_ref}"
+                        )
+                    self._conn.rollback()
+                    return existing_value
+                self._conn.execute(
+                    """
+                    INSERT INTO session_compactions (
+                        session_key, generation, parent_generation, created_at,
+                        trigger, summary_format_version, summary, source_ref,
+                        source_from_seq, consolidated_through_seq,
+                        source_message_ids_json, retained_tail_json,
+                        model_runtime_id, model, context_window, threshold_tokens,
+                        hard_input_tokens, keep_recent_tokens, tokens_before,
+                        tokens_after, summary_usage_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_key,
+                        int(generation),
+                        int(parent_generation),
+                        now,
+                        str(trigger),
+                        int(summary_format_version),
+                        summary.strip(),
+                        source_ref.strip(),
+                        int(source_from_seq),
+                        int(consolidated_through_seq),
+                        encoded_ids,
+                        encoded_tail,
+                        model_runtime_id,
+                        model,
+                        int(context_window),
+                        int(threshold_tokens),
+                        int(hard_input_tokens),
+                        int(keep_recent_tokens),
+                        int(tokens_before),
+                        int(tokens_after),
+                        encoded_usage,
+                    ),
+                )
+                self._conn.execute(
+                    "UPDATE sessions SET last_consolidated = ?, updated_at = ? WHERE key = ?",
+                    (int(generation), now, session_key),
+                )
+                row = self._conn.execute(
+                    "SELECT * FROM session_compactions WHERE session_key = ? AND generation = ?",
+                    (session_key, int(generation)),
+                ).fetchone()
+                if row is None:
+                    raise RuntimeError("compaction checkpoint insert 后无法读取")
+                self._conn.commit()
+                return self._row_to_compaction(row)
+            except BaseException:
+                self._conn.rollback()
+                raise
+
+    def get_compaction(
+        self, session_key: str, generation: int
+    ) -> SessionCompaction | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM session_compactions WHERE session_key = ? AND generation = ?",
+                (session_key, int(generation)),
+            ).fetchone()
+        return self._row_to_compaction(row) if row is not None else None
+
+    def get_active_compaction(self, session_key: str) -> SessionCompaction | None:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT last_consolidated FROM sessions WHERE key = ?",
+                (session_key,),
+            ).fetchone()
+            if cursor is None or int(cursor["last_consolidated"] or 0) == 0:
+                return None
+            row = self._conn.execute(
+                "SELECT * FROM session_compactions WHERE session_key = ? AND generation = ?",
+                (session_key, int(cursor["last_consolidated"])),
+            ).fetchone()
+        if row is None:
+            raise ValueError(
+                "session last_consolidated 未指向 compaction generation: "
+                f"{session_key}:{cursor['last_consolidated']}"
+            )
+        value = self._row_to_compaction(row)
+        if not value.active:
+            raise ValueError(
+                "session last_consolidated 指向已失效 compaction generation: "
+                f"{session_key}:{value.generation}"
+            )
+        return value
+
+    def list_compactions(
+        self, session_key: str, *, include_invalidated: bool = True
+    ) -> list[SessionCompaction]:
+        where = "" if include_invalidated else " AND invalidated_at IS NULL"
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM session_compactions WHERE session_key = ?"
+                + where
+                + " ORDER BY generation",
+                (session_key,),
+            ).fetchall()
+        return [self._row_to_compaction(row) for row in rows]
+
+    def _invalidate_compactions_for_messages_locked(
+        self,
+        session_key: str,
+        message_ids: set[str],
+        *,
+        reason: str,
+    ) -> tuple[int, int]:
+        """Invalidate a checkpoint and descendants whose provenance was deleted."""
+
+        if not message_ids:
+            return 0, 0
+        rows = self._conn.execute(
+            "SELECT * FROM session_compactions WHERE session_key = ? ORDER BY generation",
+            (session_key,),
+        ).fetchall()
+        first_hit: int | None = None
+        for row in rows:
+            checkpoint = self._row_to_compaction(row)
+            if not checkpoint.active:
+                continue
+            retained_ids = {
+                str(item.get("id"))
+                for item in checkpoint.retained_tail
+                if item.get("id")
+            }
+            if message_ids.intersection(checkpoint.source_message_ids) or message_ids.intersection(
+                retained_ids
+            ):
+                first_hit = checkpoint.generation
+                break
+        if first_hit is None:
+            return 0, 0
+        invalidated_at = datetime.now().astimezone().isoformat()
+        self._conn.execute(
+            """
+            UPDATE session_compactions
+            SET invalidated_at = ?, invalidated_reason = ?
+            WHERE session_key = ? AND generation >= ? AND invalidated_at IS NULL
+            """,
+            (invalidated_at, reason, session_key, first_hit),
+        )
+        previous = self._conn.execute(
+            """
+            SELECT MAX(generation) AS generation
+            FROM session_compactions
+            WHERE session_key = ? AND generation < ? AND invalidated_at IS NULL
+            """,
+            (session_key, first_hit),
+        ).fetchone()
+        new_cursor = int(previous["generation"] or 0) if previous else 0
+        self._conn.execute(
+            "UPDATE sessions SET last_consolidated = ?, updated_at = ? WHERE key = ?",
+            (new_cursor, invalidated_at, session_key),
+        )
+        return first_hit, new_cursor
 
     def get_session_meta(self, key: str) -> dict[str, Any] | None:
         with self._lock:
@@ -1483,6 +1889,10 @@ class SessionStore:
                         "DELETE FROM turns WHERE session_key = ?",
                         (key,),
                     )
+                    self._conn.execute(
+                        "DELETE FROM session_compactions WHERE session_key = ?",
+                        (key,),
+                    )
                 cur = self._conn.execute(
                     "DELETE FROM sessions WHERE key = ?",
                     (key,),
@@ -1537,6 +1947,10 @@ class SessionStore:
                     )
                     self._conn.execute(
                         f"DELETE FROM turns WHERE session_key IN ({placeholders})",
+                        tuple(clean_keys),
+                    )
+                    self._conn.execute(
+                        f"DELETE FROM session_compactions WHERE session_key IN ({placeholders})",
                         tuple(clean_keys),
                     )
                 cur = self._conn.execute(
@@ -2318,7 +2732,7 @@ class SessionStore:
                     turn_rows,
                 )
 
-                # 2. 游标位于组内或组后时回退到组前边界。
+                # 2. 旧 cursor 仍作为 legacy fallback；新 ledger 由 provenance 决定回退。
                 meta = self._conn.execute(
                     "SELECT last_consolidated FROM sessions WHERE key = ?",
                     (session_key,),
@@ -2327,7 +2741,15 @@ class SessionStore:
                     raise ValueError(f"interaction session 不存在: {session_key}")
                 old_cursor = int(meta["last_consolidated"])
                 group_start = positions[0]
-                new_cursor = group_start if old_cursor > group_start else old_cursor
+                ledger_exists = self._conn.execute(
+                    "SELECT 1 FROM session_compactions WHERE session_key = ? LIMIT 1",
+                    (session_key,),
+                ).fetchone() is not None
+                # New installations store a generation here; legacy installations still
+                # use the old message-index fallback until the Yoyo migration runs.
+                new_cursor = old_cursor if ledger_exists else (
+                    group_start if old_cursor > group_start else old_cursor
+                )
 
                 # 3. 正文、逐消息 embedding 与游标在同一事务中提交。
                 message_ids = tuple(str(row["id"]) for row in turn_rows)
@@ -2337,6 +2759,15 @@ class SessionStore:
                     message_ids,
                 )
                 self._delete_message_embeddings_locked(list(message_ids))
+                _first_invalidated, ledger_cursor = (
+                    self._invalidate_compactions_for_messages_locked(
+                        session_key,
+                        set(message_ids),
+                        reason=f"interaction_deleted:{normalized_turn_id}",
+                    )
+                )
+                if _first_invalidated:
+                    new_cursor = ledger_cursor
                 self._conn.execute(
                     """
                     UPDATE sessions

--- a/session/store.py
+++ b/session/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import threading
 from dataclasses import dataclass
@@ -20,8 +21,9 @@ from agent.control.models import (
     parse_rfc3339,
 )
 from agent.model_runtime.query_compaction import parse_react_compaction
-
 logger = logging.getLogger(__name__)
+
+_SOURCE_PLAN_DIGEST_RE = re.compile(r"[0-9a-f]{64}")
 
 
 class InteractionDeleteRequiredError(ValueError):
@@ -35,6 +37,34 @@ class InteractionDeleteRequiredError(ValueError):
         self.control_turn_id = control_turn_id
 
 
+class SessionAdmissionConflictError(ValueError):
+    """拒绝在 session 仍被 active turn 持有时执行破坏性删除。"""
+
+    def __init__(self, session_key: str, *, audit_id: str | None = None) -> None:
+        super().__init__(f"session 正在处理消息，暂时不能删除: {session_key}")
+        self.session_key = session_key
+        self.audit_id = audit_id
+
+
+class SessionCompactionPrepareConflictError(ValueError):
+    """拒绝在 source plan 被 durable compaction prepare 锁定时修改消息。"""
+
+    def __init__(
+        self,
+        session_key: str,
+        source_ref: str,
+        *,
+        audit_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            "session 存在 pending compaction prepare，暂时不能修改消息: "
+            f"{session_key}:{source_ref}"
+        )
+        self.session_key = session_key
+        self.source_ref = source_ref
+        self.audit_id = audit_id
+
+
 @dataclass(frozen=True)
 class InteractionDeletion:
     """记录一次完整 interaction 撤销及其游标变化。"""
@@ -46,6 +76,54 @@ class InteractionDeletion:
     old_last_consolidated: int
     new_last_consolidated: int
     backup_path: str
+    audit_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionDeleteAudit:
+    """记录一次 session 删除命令及其可恢复证据。"""
+
+    audit_id: str
+    targets: tuple[str, ...]
+    message_ids: tuple[str, ...]
+    compactions: tuple[dict[str, Any], ...]
+    action_source: str
+    cascade: bool
+    backup_path: str | None
+    started_at: str
+    completed_at: str
+    result: str
+    deleted_count: int
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceMutationAudit:
+    """记录一次 canonical source 消息编辑或物理删除。"""
+
+    audit_id: str
+    operation: str
+    session_key: str
+    message_ids: tuple[str, ...]
+    action_source: str
+    backup_path: str | None
+    completed_at: str
+
+
+@dataclass(frozen=True)
+class CompactionPrepare:
+    """Durable fence protecting one receipt-before-ledger crash window."""
+
+    session_key: str
+    session_created_at: str
+    generation: int
+    parent_generation: int
+    source_ref: str
+    source_from_seq: int
+    consolidated_through_seq: int
+    source_message_ids: tuple[str, ...]
+    retained_tail: tuple[dict[str, Any], ...]
+    prepared_at: str
 
 
 @dataclass(frozen=True)
@@ -60,6 +138,7 @@ class SessionCompaction:
     summary_format_version: int
     summary: str
     source_ref: str
+    source_plan_digest: str
     source_from_seq: int
     consolidated_through_seq: int
     source_message_ids: tuple[str, ...]
@@ -79,6 +158,15 @@ class SessionCompaction:
     @property
     def active(self) -> bool:
         return self.invalidated_at is None
+
+
+@dataclass(frozen=True)
+class CompactionHead:
+    """Store-owned cursor and monotonic next generation for one session."""
+
+    session_key: str
+    parent_generation: int
+    next_generation: int
 
 _FTS_CAPABILITY_ERROR_MARKERS = (
     "no such module: fts5",
@@ -338,6 +426,25 @@ def _decode_required_turn_time(raw: object, field_name: str, turn_id: str) -> da
     return value
 
 
+def _validate_source_plan_digest(value: object) -> str:
+    """Validate the canonical SHA-256 source-plan identity at the write boundary."""
+
+    if not isinstance(value, str) or _SOURCE_PLAN_DIGEST_RE.fullmatch(value) is None:
+        raise ValueError("compaction source_plan_digest 必须是 64 位小写 SHA-256")
+    return value
+
+
+def _required_source_plan_digest(value: object, *, identifier: str) -> str:
+    """Decode one persisted source-plan digest without normalizing corrupted state."""
+
+    try:
+        return _validate_source_plan_digest(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"compaction source_plan_digest 无效: {identifier}"
+        ) from exc
+
+
 def _decode_message_tool_chain(
     raw: str | bytes | bytearray,
     message_id: str,
@@ -475,6 +582,79 @@ class SessionStore:
                 CREATE INDEX IF NOT EXISTS idx_session_admissions_session
                 ON session_admissions(session_key)
                 """)
+            # SessionStore owns this fresh runtime audit schema; it is not a
+            # user-data migration and is created before any management command.
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS session_delete_audits (
+                    audit_id      TEXT PRIMARY KEY,
+                    targets_json  TEXT NOT NULL,
+                    message_ids_json TEXT NOT NULL,
+                    compactions_json TEXT NOT NULL,
+                    action_source TEXT NOT NULL,
+                    cascade       INTEGER NOT NULL CHECK (cascade IN (0, 1)),
+                    backup_path   TEXT,
+                    started_at    TEXT NOT NULL,
+                    completed_at  TEXT NOT NULL,
+                    result        TEXT NOT NULL,
+                    deleted_count INTEGER NOT NULL,
+                    error         TEXT
+                )
+                """)
+            audit_columns = {
+                str(row["name"])
+                for row in self._conn.execute(
+                    "PRAGMA table_info(session_delete_audits)"
+                ).fetchall()
+            }
+            if "message_ids_json" not in audit_columns:
+                self._conn.execute(
+                    "ALTER TABLE session_delete_audits ADD COLUMN "
+                    "message_ids_json TEXT NOT NULL DEFAULT '[]'"
+                )
+            if "compactions_json" not in audit_columns:
+                self._conn.execute(
+                    "ALTER TABLE session_delete_audits ADD COLUMN "
+                    "compactions_json TEXT NOT NULL DEFAULT '[]'"
+                )
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_session_delete_audits_time
+                ON session_delete_audits(completed_at, audit_id)
+                """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS session_source_mutation_audits (
+                    audit_id      TEXT PRIMARY KEY,
+                    operation     TEXT NOT NULL,
+                    session_key   TEXT NOT NULL,
+                    message_ids_json TEXT NOT NULL,
+                    action_source TEXT NOT NULL,
+                    backup_path   TEXT,
+                    completed_at  TEXT NOT NULL
+                )
+                """)
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_source_mutation_audits_lookup
+                ON session_source_mutation_audits(session_key, completed_at, audit_id)
+                """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS session_compaction_prepares (
+                    session_key TEXT NOT NULL,
+                    session_created_at TEXT NOT NULL,
+                    generation INTEGER NOT NULL,
+                    parent_generation INTEGER NOT NULL,
+                    source_ref TEXT NOT NULL,
+                    source_from_seq INTEGER NOT NULL,
+                    consolidated_through_seq INTEGER NOT NULL,
+                    source_message_ids_json TEXT NOT NULL,
+                    retained_tail_json TEXT NOT NULL,
+                    prepared_at TEXT NOT NULL,
+                    PRIMARY KEY (session_key, generation),
+                    UNIQUE (session_key, source_ref)
+                )
+                """)
+            self._conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_session_compaction_prepares_ref
+                ON session_compaction_prepares(session_key, source_ref)
+                """)
             self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS messages (
                     id          TEXT PRIMARY KEY,
@@ -498,6 +678,11 @@ class SessionStore:
                     summary_format_version INTEGER NOT NULL,
                     summary TEXT NOT NULL,
                     source_ref TEXT NOT NULL,
+                    source_plan_digest TEXT NOT NULL
+                        CHECK (
+                            length(source_plan_digest) = 64
+                            AND source_plan_digest NOT GLOB '*[^0-9a-f]*'
+                        ),
                     source_from_seq INTEGER NOT NULL,
                     consolidated_through_seq INTEGER NOT NULL,
                     source_message_ids_json TEXT NOT NULL,
@@ -860,25 +1045,39 @@ class SessionStore:
         *,
         created_at: str,
         updated_at: str,
-        last_consolidated: int,
+        last_consolidated: int | None = None,
         metadata: dict[str, Any],
     ) -> None:
         payload = json.dumps(metadata or {}, ensure_ascii=False)
         with self._lock:
-            self._conn.execute(
-                """
-                INSERT INTO sessions (key, created_at, updated_at, last_consolidated, metadata)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(key) DO UPDATE SET
-                    updated_at = excluded.updated_at,
-                    last_consolidated = excluded.last_consolidated,
-                    metadata = excluded.metadata
-                """,
-                (key, created_at, updated_at, int(last_consolidated), payload),
-            )
+            if last_consolidated is None:
+                self._conn.execute(
+                    """
+                    INSERT INTO sessions (key, created_at, updated_at, last_consolidated, metadata)
+                    VALUES (?, ?, ?, 0, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        updated_at = excluded.updated_at,
+                        metadata = excluded.metadata
+                    """,
+                    (key, created_at, updated_at, payload),
+                )
+            else:
+                self._conn.execute(
+                    """
+                    INSERT INTO sessions (key, created_at, updated_at, last_consolidated, metadata)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        updated_at = excluded.updated_at,
+                        last_consolidated = excluded.last_consolidated,
+                        metadata = excluded.metadata
+                    """,
+                    (key, created_at, updated_at, int(last_consolidated), payload),
+                )
             self._conn.commit()
 
     def update_last_consolidated(self, key: str, last_consolidated: int) -> None:
+        """Update the legacy consolidation cursor for compatibility callers."""
+
         now = datetime.now().astimezone().isoformat()
         with self._lock:
             self._conn.execute(
@@ -890,6 +1089,393 @@ class SessionStore:
                 (int(last_consolidated), now, key),
             )
             self._conn.commit()
+
+    @staticmethod
+    def _row_to_compaction_prepare(row: sqlite3.Row) -> CompactionPrepare:
+        """Decode one durable compaction prepare fence at the SQLite boundary."""
+
+        # 1. Validate scalar identity before any normalization or JSON decoding.
+        scalar_strings = {
+            "session_key": row["session_key"],
+            "session_created_at": row["session_created_at"],
+            "source_ref": row["source_ref"],
+            "prepared_at": row["prepared_at"],
+        }
+        if any(not isinstance(value, str) for value in scalar_strings.values()):
+            raise ValueError("compaction prepare identity 字段类型无效")
+        scalar_ints = {
+            "generation": row["generation"],
+            "parent_generation": row["parent_generation"],
+            "source_from_seq": row["source_from_seq"],
+            "consolidated_through_seq": row["consolidated_through_seq"],
+        }
+        if any(
+            not isinstance(value, int) or isinstance(value, bool)
+            for value in scalar_ints.values()
+        ):
+            raise ValueError("compaction prepare numeric identity 字段无效")
+
+        # 2. JSON columns must remain text/blob; NULL must not enter fallback decoding.
+        raw_source_ids = row["source_message_ids_json"]
+        raw_retained_tail = row["retained_tail_json"]
+        json_types = (str, bytes, bytearray)
+        if not isinstance(raw_source_ids, json_types):
+            raise ValueError("compaction prepare source_message_ids_json 类型无效")
+        if not isinstance(raw_retained_tail, json_types):
+            raise ValueError("compaction prepare retained_tail_json 类型无效")
+
+        # 3. Decode JSON payloads at the SQLite trust boundary.
+        identifier = f"{scalar_strings['session_key']}:{scalar_ints['generation']}"
+        source_ids = _decode_json_payload(
+            raw_source_ids,
+            fallback="[]",
+            field="compaction prepare source_message_ids",
+            identifier=identifier,
+        )
+        retained_tail = _decode_json_payload(
+            raw_retained_tail,
+            fallback="[]",
+            field="compaction prepare retained_tail",
+            identifier=identifier,
+        )
+        if not isinstance(source_ids, list) or not all(
+            isinstance(item, str) and item for item in source_ids
+        ):
+            raise ValueError("compaction prepare source_message_ids 无效")
+        if not isinstance(retained_tail, list) or not all(
+            isinstance(item, dict) for item in retained_tail
+        ):
+            raise ValueError("compaction prepare retained_tail 无效")
+
+        # 4. Reuse the write-boundary contract for source ids/tail and validate timestamp.
+        SessionStore._validate_prepare_payload(
+            session_key=scalar_strings["session_key"],
+            session_created_at=scalar_strings["session_created_at"],
+            generation=scalar_ints["generation"],
+            parent_generation=scalar_ints["parent_generation"],
+            source_ref=scalar_strings["source_ref"],
+            source_from_seq=scalar_ints["source_from_seq"],
+            consolidated_through_seq=scalar_ints["consolidated_through_seq"],
+            source_message_ids=tuple(cast(str, item) for item in source_ids),
+            retained_tail=tuple(cast(dict[str, Any], item) for item in retained_tail),
+        )
+        try:
+            prepared_at = datetime.fromisoformat(scalar_strings["prepared_at"])
+        except ValueError as exc:
+            raise ValueError("compaction prepare prepared_at 无效") from exc
+        if prepared_at.tzinfo is None:
+            raise ValueError("compaction prepare prepared_at 必须包含时区")
+        return CompactionPrepare(
+            session_key=scalar_strings["session_key"],
+            session_created_at=scalar_strings["session_created_at"],
+            generation=scalar_ints["generation"],
+            parent_generation=scalar_ints["parent_generation"],
+            source_ref=scalar_strings["source_ref"],
+            source_from_seq=scalar_ints["source_from_seq"],
+            consolidated_through_seq=scalar_ints["consolidated_through_seq"],
+            source_message_ids=tuple(cast(str, item) for item in source_ids),
+            retained_tail=tuple(cast(dict[str, Any], item) for item in retained_tail),
+            prepared_at=scalar_strings["prepared_at"],
+        )
+
+    @staticmethod
+    def _same_compaction_prepare_identity(
+        left: CompactionPrepare,
+        right: CompactionPrepare,
+    ) -> bool:
+        """Compare replayable prepare identity while allowing a new attempt timestamp."""
+
+        return (
+            left.session_key == right.session_key
+            and left.session_created_at == right.session_created_at
+            and left.generation == right.generation
+            and left.parent_generation == right.parent_generation
+            and left.source_ref == right.source_ref
+            and left.source_from_seq == right.source_from_seq
+            and left.consolidated_through_seq == right.consolidated_through_seq
+            and left.source_message_ids == right.source_message_ids
+            and left.retained_tail == right.retained_tail
+        )
+
+    @staticmethod
+    def _validate_prepare_payload(
+        *,
+        session_key: str,
+        session_created_at: str,
+        generation: int,
+        parent_generation: int,
+        source_ref: str,
+        source_from_seq: int,
+        consolidated_through_seq: int,
+        source_message_ids: list[str] | tuple[str, ...],
+        retained_tail: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    ) -> None:
+        """Validate the durable prepare identity before acquiring the write lock."""
+
+        if not session_key.strip() or not session_created_at.strip() or not source_ref.strip():
+            raise ValueError("compaction prepare identity 不能为空")
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 1:
+            raise ValueError("compaction prepare generation 无效")
+        if (
+            not isinstance(parent_generation, int)
+            or isinstance(parent_generation, bool)
+            or parent_generation < 0
+        ):
+            raise ValueError("compaction prepare parent_generation 无效")
+        if (
+            not isinstance(source_from_seq, int)
+            or isinstance(source_from_seq, bool)
+            or not isinstance(consolidated_through_seq, int)
+            or isinstance(consolidated_through_seq, bool)
+            or source_from_seq < 0
+            or consolidated_through_seq < source_from_seq
+        ):
+            raise ValueError("compaction prepare source seq 边界无效")
+        if not source_message_ids or any(
+            not isinstance(item, str) or not item.strip() for item in source_message_ids
+        ):
+            raise ValueError("compaction prepare source_message_ids 无效")
+        if any(
+            not isinstance(item, dict)
+            or not isinstance(item.get("id"), str)
+            or not item["id"]
+            or not isinstance(item.get("seq"), int)
+            or isinstance(item.get("seq"), bool)
+            or not isinstance(item.get("message"), dict)
+            or not isinstance(item.get("unit_ref"), str)
+            or not item["unit_ref"]
+            for item in retained_tail
+        ):
+            raise ValueError("compaction prepare retained_tail 无效")
+
+    def _validate_compaction_prepare_locked(
+        self,
+        prepared: CompactionPrepare,
+    ) -> CompactionPrepare | None:
+        """Validate a pending fence against the current session head and source rows."""
+
+        # 1. incarnation、cursor 和 generation 必须仍然指向同一个 session head。
+        session_row = self._conn.execute(
+            "SELECT created_at, last_consolidated FROM sessions WHERE key = ?",
+            (prepared.session_key,),
+        ).fetchone()
+        if session_row is None:
+            raise KeyError(f"session 不存在: {prepared.session_key}")
+        if str(session_row["created_at"]) != prepared.session_created_at:
+            raise ValueError("compaction prepare session incarnation 冲突")
+        current_cursor = int(session_row["last_consolidated"] or 0)
+        if prepared.parent_generation != current_cursor:
+            raise ValueError("compaction prepare parent_generation 与 cursor 冲突")
+        max_row = self._conn.execute(
+            "SELECT COALESCE(MAX(generation), 0) AS generation "
+            "FROM session_compactions WHERE session_key = ?",
+            (prepared.session_key,),
+        ).fetchone()
+        max_generation = int(max_row["generation"] if max_row else 0)
+        if prepared.generation != max_generation + 1:
+            raise ValueError("compaction prepare generation 不匹配 ledger head")
+
+        # 2. source plan 必须仍由 canonical SessionDB rows 完整支撑。
+        self._validate_compaction_provenance_locked(
+            prepared.session_key,
+            source_message_ids=prepared.source_message_ids,
+            retained_tail=prepared.retained_tail,
+            source_from_seq=prepared.source_from_seq,
+            consolidated_through_seq=prepared.consolidated_through_seq,
+        )
+
+        # 3. 重试只允许复用完全相同的 prepare identity。
+        existing = self._conn.execute(
+            "SELECT * FROM session_compaction_prepares "
+            "WHERE session_key = ? AND generation = ?",
+            (prepared.session_key, prepared.generation),
+        ).fetchone()
+        if existing is None:
+            return None
+        existing_value = self._row_to_compaction_prepare(existing)
+        if not self._same_compaction_prepare_identity(existing_value, prepared):
+            raise ValueError("compaction prepare identity 冲突")
+        return existing_value
+
+    def _insert_compaction_prepare_locked(self, prepared: CompactionPrepare) -> None:
+        """Insert a validated pending fence while the SQLite write transaction is held."""
+
+        self._conn.execute(
+            "INSERT INTO session_compaction_prepares("
+            "session_key, session_created_at, generation, parent_generation, "
+            "source_ref, source_from_seq, consolidated_through_seq, "
+            "source_message_ids_json, retained_tail_json, prepared_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                prepared.session_key,
+                prepared.session_created_at,
+                prepared.generation,
+                prepared.parent_generation,
+                prepared.source_ref,
+                prepared.source_from_seq,
+                prepared.consolidated_through_seq,
+                json.dumps(list(prepared.source_message_ids), ensure_ascii=False),
+                json.dumps(list(prepared.retained_tail), ensure_ascii=False),
+                prepared.prepared_at,
+            ),
+        )
+
+    def prepare_compaction(
+        self,
+        *,
+        session_key: str,
+        session_created_at: str,
+        generation: int,
+        parent_generation: int,
+        source_ref: str,
+        source_from_seq: int,
+        consolidated_through_seq: int,
+        source_message_ids: list[str] | tuple[str, ...],
+        retained_tail: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    ) -> CompactionPrepare:
+        """Durably fence canonical sources before a cross-file receipt write."""
+
+        # 1. 校验外部 prepare identity，再复制可变 JSON 输入。
+        self._validate_prepare_payload(
+            session_key=session_key,
+            session_created_at=session_created_at,
+            generation=generation,
+            parent_generation=parent_generation,
+            source_ref=source_ref,
+            source_from_seq=source_from_seq,
+            consolidated_through_seq=consolidated_through_seq,
+            source_message_ids=source_message_ids,
+            retained_tail=retained_tail,
+        )
+        prepared = CompactionPrepare(
+            session_key=session_key.strip(),
+            session_created_at=session_created_at.strip(),
+            generation=generation,
+            parent_generation=parent_generation,
+            source_ref=source_ref.strip(),
+            source_from_seq=source_from_seq,
+            consolidated_through_seq=consolidated_through_seq,
+            source_message_ids=tuple(source_message_ids),
+            retained_tail=tuple(dict(item) for item in retained_tail),
+            prepared_at=datetime.now().astimezone().isoformat(),
+        )
+        # 2. 以 immutable value 进入 SQLite 事务，避免调用方后续修改 source plan。
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                existing = self._validate_compaction_prepare_locked(prepared)
+                if existing is not None:
+                    self._conn.rollback()
+                    return existing
+                # 3. 只有通过同一事务校验的 prepare 才能进入 durable fence。
+                self._insert_compaction_prepare_locked(prepared)
+                self._conn.commit()
+                return prepared
+            except BaseException:
+                self._conn.rollback()
+                raise
+
+    def get_compaction_prepare(
+        self,
+        session_key: str,
+        *,
+        source_ref: str | None = None,
+        generation: int | None = None,
+    ) -> CompactionPrepare | None:
+        """Read one pending prepare fence by its incarnation-scoped identity."""
+
+        if (source_ref is None) == (generation is None):
+            raise ValueError("compaction prepare 必须按 source_ref 或 generation 查询")
+        with self._lock:
+            if source_ref is not None:
+                row = self._conn.execute(
+                    "SELECT * FROM session_compaction_prepares "
+                    "WHERE session_key = ? AND source_ref = ?",
+                    (session_key, source_ref),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    "SELECT * FROM session_compaction_prepares "
+                    "WHERE session_key = ? AND generation = ?",
+                    (session_key, generation),
+                ).fetchone()
+        return self._row_to_compaction_prepare(row) if row is not None else None
+
+    def _clear_orphan_compaction_prepare(self, prepare: CompactionPrepare) -> bool:
+        """Release one pre-effect orphan fence after proving its identity."""
+
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                # 1. Re-read the full row so a stale recovery handle cannot clear a new fence.
+                row = self._conn.execute(
+                    "SELECT * FROM session_compaction_prepares "
+                    "WHERE session_key = ? AND generation = ?",
+                    (prepare.session_key, prepare.generation),
+                ).fetchone()
+                if row is None:
+                    self._conn.rollback()
+                    return False
+                if self._row_to_compaction_prepare(row) != prepare:
+                    raise ValueError("compaction prepare identity 冲突")
+                # 2. Only the runtime's no-receipt pre-effect path may remove this row.
+                self._conn.execute(
+                    "DELETE FROM session_compaction_prepares "
+                    "WHERE session_key = ? AND generation = ?",
+                    (prepare.session_key, prepare.generation),
+                )
+                self._conn.commit()
+                return True
+            except BaseException:
+                self._conn.rollback()
+                raise
+
+    def _assert_compaction_prepare_locked(
+        self,
+        prepare: CompactionPrepare,
+    ) -> None:
+        """Prove the pending fence still owns the checkpoint write set."""
+
+        row = self._conn.execute(
+            "SELECT * FROM session_compaction_prepares "
+            "WHERE session_key = ? AND generation = ?",
+            (prepare.session_key, prepare.generation),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("compaction prepare 在 checkpoint 提交前丢失")
+        existing = self._row_to_compaction_prepare(row)
+        if not self._same_compaction_prepare_identity(existing, prepare):
+            raise ValueError("compaction prepare identity 冲突")
+
+    def _delete_compaction_prepare_locked(self, prepare: CompactionPrepare) -> None:
+        """Delete the verified fence inside the checkpoint transaction."""
+
+        self._assert_compaction_prepare_locked(prepare)
+        self._conn.execute(
+            "DELETE FROM session_compaction_prepares "
+            "WHERE session_key = ? AND generation = ?",
+            (prepare.session_key, prepare.generation),
+        )
+
+    def _require_no_pending_compaction_prepare_locked(
+        self,
+        session_keys: list[str],
+    ) -> None:
+        """Reject destructive mutation while any targeted session has a pending fence."""
+
+        if not session_keys:
+            return
+        placeholders = ",".join("?" for _ in session_keys)
+        row = self._conn.execute(
+            "SELECT session_key, source_ref FROM session_compaction_prepares "
+            f"WHERE session_key IN ({placeholders}) LIMIT 1",
+            tuple(session_keys),
+        ).fetchone()
+        if row is not None:
+            raise SessionCompactionPrepareConflictError(
+                str(row["session_key"]),
+                str(row["source_ref"]),
+            )
 
     @staticmethod
     def _row_to_compaction(row: sqlite3.Row) -> SessionCompaction:
@@ -921,10 +1507,17 @@ class SessionStore:
                 f"{row['session_key']}:{row['generation']}"
             )
         if not isinstance(retained_tail, list) or not all(
-            isinstance(item, dict) for item in retained_tail
+            isinstance(item, dict)
+            and isinstance(item.get("id"), str)
+            and bool(item["id"])
+            and isinstance(item.get("seq"), int)
+            and isinstance(item.get("message"), dict)
+            and isinstance(item.get("unit_ref"), str)
+            and bool(item["unit_ref"])
+            for item in retained_tail
         ):
             raise ValueError(
-                "compaction retained_tail 必须是对象数组: "
+                "compaction retained_tail 必须是带 id/seq/unit_ref/message 的对象数组: "
                 f"{row['session_key']}:{row['generation']}"
             )
         if not isinstance(usage, dict):
@@ -941,6 +1534,10 @@ class SessionStore:
             summary_format_version=int(row["summary_format_version"]),
             summary=str(row["summary"]),
             source_ref=str(row["source_ref"]),
+            source_plan_digest=_required_source_plan_digest(
+                row["source_plan_digest"],
+                identifier=f"{row['session_key']}:{row['generation']}",
+            ),
             source_from_seq=int(row["source_from_seq"]),
             consolidated_through_seq=int(row["consolidated_through_seq"]),
             source_message_ids=tuple(str(item) for item in source_ids),
@@ -973,6 +1570,7 @@ class SessionStore:
         trigger: str,
         summary: str,
         source_ref: str,
+        source_plan_digest: str,
         source_from_seq: int,
         consolidated_through_seq: int,
         source_message_ids: list[str] | tuple[str, ...],
@@ -989,18 +1587,40 @@ class SessionStore:
         parent_generation: int | None = None,
         generation: int | None = None,
         summary_format_version: int = 1,
+        prepare: CompactionPrepare | None = None,
     ) -> SessionCompaction:
         """Insert one immutable checkpoint and advance the session cursor atomically."""
 
         # 1. Validate the boundary payload before acquiring the write transaction.
         if not session_key.strip() or not source_ref.strip() or not summary.strip():
             raise ValueError("compaction session_key/source_ref/summary 不能为空")
+        source_plan_digest = _validate_source_plan_digest(source_plan_digest)
         if not source_message_ids or any(
             not isinstance(item, str) or not item.strip() for item in source_message_ids
         ):
             raise ValueError("compaction source_message_ids 必须是非空字符串数组")
-        if any(not isinstance(item, dict) for item in retained_tail):
-            raise ValueError("compaction retained_tail 必须是对象数组")
+        if (
+            not isinstance(source_from_seq, int)
+            or isinstance(source_from_seq, bool)
+            or not isinstance(consolidated_through_seq, int)
+            or isinstance(consolidated_through_seq, bool)
+            or source_from_seq < 0
+            or consolidated_through_seq < source_from_seq
+        ):
+            raise ValueError("compaction source seq 边界无效")
+        if any(
+            not isinstance(item, dict)
+            or not isinstance(item.get("id"), str)
+            or not item["id"]
+            or not isinstance(item.get("seq"), int)
+            or not isinstance(item.get("message"), dict)
+            or not isinstance(item.get("unit_ref"), str)
+            or not item["unit_ref"]
+            for item in retained_tail
+        ):
+            raise ValueError(
+                "compaction retained_tail 必须是带 id/seq/unit_ref/message 的对象数组"
+            )
         if not isinstance(summary_usage, dict):
             raise ValueError("compaction summary_usage 必须是 JSON object")
         encoded_ids = json.dumps(
@@ -1012,18 +1632,89 @@ class SessionStore:
         encoded_usage = json.dumps(
             summary_usage, ensure_ascii=False, separators=(",", ":")
         )
+        if prepare is not None:
+            if (
+                prepare.session_key != session_key
+                or prepare.source_ref != source_ref
+                or prepare.source_from_seq != source_from_seq
+                or prepare.consolidated_through_seq != consolidated_through_seq
+                or prepare.source_message_ids != tuple(source_message_ids)
+                or prepare.retained_tail != tuple(retained_tail)
+                or (generation is not None and prepare.generation != generation)
+                or (
+                    parent_generation is not None
+                    and prepare.parent_generation != parent_generation
+                )
+            ):
+                raise ValueError("compaction checkpoint 与 prepare identity 冲突")
         now = datetime.now().astimezone().isoformat()
 
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 session_row = self._conn.execute(
-                    "SELECT last_consolidated FROM sessions WHERE key = ?",
+                    "SELECT created_at, last_consolidated FROM sessions WHERE key = ?",
                     (session_key,),
                 ).fetchone()
                 if session_row is None:
                     raise KeyError(f"session 不存在: {session_key}")
+                if prepare is not None:
+                    if str(session_row["created_at"]) != prepare.session_created_at:
+                        raise ValueError("compaction checkpoint session incarnation 冲突")
+                    self._assert_compaction_prepare_locked(prepare)
+                else:
+                    self._require_no_pending_compaction_prepare_locked([session_key])
                 current_cursor = int(session_row["last_consolidated"] or 0)
+                self._validate_compaction_provenance_locked(
+                    session_key,
+                    source_message_ids=source_message_ids,
+                    retained_tail=retained_tail,
+                    source_from_seq=source_from_seq,
+                    consolidated_through_seq=consolidated_through_seq,
+                )
+                existing = self._conn.execute(
+                    "SELECT * FROM session_compactions "
+                    "WHERE session_key = ? AND source_ref = ?",
+                    (session_key, source_ref),
+                ).fetchone()
+                if existing is not None:
+                    existing_value = self._row_to_compaction(existing)
+                    expected_parent = (
+                        existing_value.parent_generation
+                        if parent_generation is None
+                        else int(parent_generation)
+                    )
+                    if (
+                        (generation is not None and int(generation) != existing_value.generation)
+                        or existing_value.trigger != str(trigger)
+                        or existing_value.parent_generation != expected_parent
+                        or existing_value.summary_format_version != int(summary_format_version)
+                        or existing_value.summary != summary
+                        or existing_value.source_plan_digest != source_plan_digest
+                        or existing_value.source_from_seq != int(source_from_seq)
+                        or existing_value.consolidated_through_seq
+                        != int(consolidated_through_seq)
+                        or existing_value.source_message_ids != tuple(source_message_ids)
+                        or existing_value.retained_tail != tuple(retained_tail)
+                        or existing_value.model_runtime_id != model_runtime_id
+                        or existing_value.model != model
+                        or existing_value.context_window != int(context_window)
+                        or existing_value.threshold_tokens != int(threshold_tokens)
+                        or existing_value.hard_input_tokens != int(hard_input_tokens)
+                        or existing_value.keep_recent_tokens != int(keep_recent_tokens)
+                        or existing_value.tokens_before != int(tokens_before)
+                        or existing_value.tokens_after != int(tokens_after)
+                        or existing_value.summary_usage != summary_usage
+                    ):
+                        raise ValueError(
+                            f"compaction source_ref 内容冲突: {session_key}:{source_ref}"
+                        )
+                    if prepare is not None:
+                        self._delete_compaction_prepare_locked(prepare)
+                        self._conn.commit()
+                    else:
+                        self._conn.rollback()
+                    return existing_value
                 max_row = self._conn.execute(
                     "SELECT COALESCE(MAX(generation), 0) AS generation "
                     "FROM session_compactions WHERE session_key = ?",
@@ -1043,49 +1734,18 @@ class SessionStore:
                         "compaction parent_generation 与当前 cursor 不一致: "
                         f"session={session_key} cursor={current_cursor} parent={parent_generation}"
                     )
-                existing = self._conn.execute(
-                    "SELECT * FROM session_compactions "
-                    "WHERE session_key = ? AND source_ref = ?",
-                    (session_key, source_ref),
-                ).fetchone()
-                if existing is not None:
-                    existing_value = self._row_to_compaction(existing)
-                    if (
-                        existing_value.trigger != str(trigger)
-                        or existing_value.parent_generation != int(parent_generation)
-                        or existing_value.summary_format_version != int(summary_format_version)
-                        or existing_value.summary != summary
-                        or existing_value.source_from_seq != int(source_from_seq)
-                        or existing_value.consolidated_through_seq
-                        != int(consolidated_through_seq)
-                        or existing_value.source_message_ids != tuple(source_message_ids)
-                        or existing_value.retained_tail != tuple(retained_tail)
-                        or existing_value.model_runtime_id != model_runtime_id
-                        or existing_value.model != model
-                        or existing_value.context_window != int(context_window)
-                        or existing_value.threshold_tokens != int(threshold_tokens)
-                        or existing_value.hard_input_tokens != int(hard_input_tokens)
-                        or existing_value.keep_recent_tokens != int(keep_recent_tokens)
-                        or existing_value.tokens_before != int(tokens_before)
-                        or existing_value.tokens_after != int(tokens_after)
-                        or existing_value.summary_usage != summary_usage
-                    ):
-                        raise ValueError(
-                            f"compaction source_ref 内容冲突: {session_key}:{source_ref}"
-                        )
-                    self._conn.rollback()
-                    return existing_value
                 self._conn.execute(
                     """
                     INSERT INTO session_compactions (
                         session_key, generation, parent_generation, created_at,
                         trigger, summary_format_version, summary, source_ref,
+                        source_plan_digest,
                         source_from_seq, consolidated_through_seq,
                         source_message_ids_json, retained_tail_json,
                         model_runtime_id, model, context_window, threshold_tokens,
                         hard_input_tokens, keep_recent_tokens, tokens_before,
                         tokens_after, summary_usage_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         session_key,
@@ -1096,6 +1756,7 @@ class SessionStore:
                         int(summary_format_version),
                         summary.strip(),
                         source_ref.strip(),
+                        source_plan_digest,
                         int(source_from_seq),
                         int(consolidated_through_seq),
                         encoded_ids,
@@ -1115,6 +1776,8 @@ class SessionStore:
                     "UPDATE sessions SET last_consolidated = ?, updated_at = ? WHERE key = ?",
                     (int(generation), now, session_key),
                 )
+                if prepare is not None:
+                    self._delete_compaction_prepare_locked(prepare)
                 row = self._conn.execute(
                     "SELECT * FROM session_compactions WHERE session_key = ? AND generation = ?",
                     (session_key, int(generation)),
@@ -1126,6 +1789,70 @@ class SessionStore:
             except BaseException:
                 self._conn.rollback()
                 raise
+
+    def _validate_compaction_provenance_locked(
+        self,
+        session_key: str,
+        *,
+        source_message_ids: list[str] | tuple[str, ...],
+        retained_tail: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+        source_from_seq: int,
+        consolidated_through_seq: int,
+    ) -> None:
+        """Validate source ids/seqs while the compaction transaction owns the Store lock."""
+
+        ids = {str(item) for item in source_message_ids}
+        ids.update(str(item["id"]) for item in retained_tail)
+        if not ids:
+            raise ValueError("compaction provenance 不能为空")
+        placeholders = ",".join("?" for _ in ids)
+        rows = self._conn.execute(
+            f"SELECT id, seq FROM messages WHERE session_key = ? AND id IN ({placeholders})",
+            (session_key, *sorted(ids)),
+        ).fetchall()
+        by_id = {str(row["id"]): int(row["seq"]) for row in rows}
+        missing = sorted(ids - by_id.keys())
+        if missing:
+            raise ValueError(
+                "compaction provenance 引用不存在的 canonical message: "
+                + ",".join(missing)
+            )
+        for item in retained_tail:
+            message_id = str(item["id"])
+            if by_id[message_id] != int(item["seq"]):
+                raise ValueError(
+                    "compaction retained_tail seq 与 canonical message 不一致: "
+                    f"{message_id}:{item['seq']}!={by_id[message_id]}"
+                )
+        source_seqs = [by_id[str(message_id)] for message_id in source_message_ids]
+        if min(source_seqs) != int(source_from_seq) or max(source_seqs) != int(
+            consolidated_through_seq
+        ):
+            raise ValueError(
+                "compaction source seq 边界与 canonical message 不一致: "
+                f"{source_from_seq}-{consolidated_through_seq}!="
+                f"{min(source_seqs)}-{max(source_seqs)}"
+            )
+
+    def validate_compaction_provenance(
+        self,
+        session_key: str,
+        *,
+        source_message_ids: list[str] | tuple[str, ...],
+        retained_tail: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+        source_from_seq: int,
+        consolidated_through_seq: int,
+    ) -> None:
+        """Fail early on missing provenance; persist_compaction repeats it atomically."""
+
+        with self._lock:
+            self._validate_compaction_provenance_locked(
+                session_key,
+                source_message_ids=source_message_ids,
+                retained_tail=retained_tail,
+                source_from_seq=source_from_seq,
+                consolidated_through_seq=consolidated_through_seq,
+            )
 
     def get_compaction(
         self, session_key: str, generation: int
@@ -1161,6 +1888,45 @@ class SessionStore:
                 f"{session_key}:{value.generation}"
             )
         return value
+
+    def get_compaction_head(self, session_key: str) -> CompactionHead:
+        """Read the current cursor and never-reused next generation atomically."""
+
+        with self._lock:
+            session_row = self._conn.execute(
+                "SELECT last_consolidated FROM sessions WHERE key = ?",
+                (session_key,),
+            ).fetchone()
+            if session_row is None:
+                raise KeyError(f"session 不存在: {session_key}")
+            cursor = int(session_row["last_consolidated"] or 0)
+            max_row = self._conn.execute(
+                "SELECT COALESCE(MAX(generation), 0) AS generation "
+                "FROM session_compactions WHERE session_key = ?",
+                (session_key,),
+            ).fetchone()
+            max_generation = int(max_row["generation"] if max_row else 0)
+            if cursor < 0 or cursor > max_generation:
+                raise ValueError(
+                    "session compaction cursor 超出 ledger head: "
+                    f"{session_key}:{cursor}>{max_generation}"
+                )
+            if cursor:
+                row = self._conn.execute(
+                    "SELECT invalidated_at FROM session_compactions "
+                    "WHERE session_key = ? AND generation = ?",
+                    (session_key, cursor),
+                ).fetchone()
+                if row is None or row["invalidated_at"] is not None:
+                    raise ValueError(
+                        "session compaction cursor 未指向有效 generation: "
+                        f"{session_key}:{cursor}"
+                    )
+        return CompactionHead(
+            session_key=session_key,
+            parent_generation=cursor,
+            next_generation=max_generation + 1,
+        )
 
     def list_compactions(
         self, session_key: str, *, include_invalidated: bool = True
@@ -1248,6 +2014,61 @@ class SessionStore:
             "last_user_at": row["last_user_at"],
             "last_proactive_at": row["last_proactive_at"],
         }
+
+    def delete_session_messages_and_update_cursor(
+        self,
+        session_key: str,
+        *,
+        ids: list[str],
+        last_consolidated: int,
+    ) -> int:
+        """Delete selected legacy messages and advance the compatibility cursor."""
+
+        clean_ids = [
+            str(message_id).strip() for message_id in ids if str(message_id).strip()
+        ]
+        if not clean_ids:
+            return 0
+        placeholders = ",".join("?" for _ in clean_ids)
+        now = datetime.now().astimezone().isoformat()
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                seq_rows = self._conn.execute(
+                    f"""
+                    SELECT id, seq
+                    FROM messages
+                    WHERE session_key = ? AND id IN ({placeholders})
+                    """,
+                    tuple([session_key, *clean_ids]),
+                ).fetchall()
+                next_seq = (
+                    max(int(row["seq"]) for row in seq_rows) + 1 if seq_rows else 0
+                )
+                deleted_ids = [str(row["id"]) for row in seq_rows]
+                cur = self._conn.execute(
+                    f"""
+                    DELETE FROM messages
+                    WHERE session_key = ? AND id IN ({placeholders})
+                    """,
+                    tuple([session_key, *clean_ids]),
+                )
+                self._delete_message_embeddings_locked(deleted_ids)
+                self._conn.execute(
+                    """
+                    UPDATE sessions
+                    SET last_consolidated = ?,
+                        updated_at = ?,
+                        next_seq = CASE WHEN next_seq < ? THEN ? ELSE next_seq END
+                    WHERE key = ?
+                    """,
+                    (int(last_consolidated), now, next_seq, next_seq, session_key),
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
+        return int(cur.rowcount or 0)
 
     def create_turn(self, record: TurnRecord) -> TurnRecord:
         """持久化一个 queued turn 并返回数据库中的正式记录。"""
@@ -1851,117 +2672,522 @@ class SessionStore:
             return None
         return self.get_session_meta(key)
 
-    def delete_session(self, key: str, *, cascade: bool = False) -> bool:
+    @staticmethod
+    def _normalize_delete_targets(keys: list[str]) -> tuple[str, ...]:
+        targets: list[str] = []
+        for raw_key in keys:
+            key = str(raw_key).strip()
+            if key and key not in targets:
+                targets.append(key)
+        return tuple(targets)
+
+    @staticmethod
+    def _normalize_action_source(action_source: str) -> str:
+        if not isinstance(action_source, str) or not action_source.strip():
+            raise ValueError("action_source 必须是非空字符串")
+        return action_source.strip()
+
+    @staticmethod
+    def _delete_audit_value(
+        *,
+        audit_id: str,
+        targets: tuple[str, ...],
+        message_ids: tuple[str, ...],
+        compactions: tuple[dict[str, Any], ...],
+        action_source: str,
+        cascade: bool,
+        backup_path: Path | None,
+        started_at: str,
+        result: str,
+        deleted_count: int,
+        error: str | None = None,
+    ) -> SessionDeleteAudit:
+        return SessionDeleteAudit(
+            audit_id=audit_id,
+            targets=targets,
+            message_ids=message_ids,
+            compactions=compactions,
+            action_source=action_source,
+            cascade=cascade,
+            backup_path=str(backup_path) if backup_path is not None else None,
+            started_at=started_at,
+            completed_at=datetime.now().astimezone().isoformat(),
+            result=result,
+            deleted_count=deleted_count,
+            error=error,
+        )
+
+    def _insert_delete_audit_locked(self, audit: SessionDeleteAudit) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO session_delete_audits(
+                audit_id, targets_json, message_ids_json, compactions_json,
+                action_source, cascade, backup_path, started_at, completed_at,
+                result, deleted_count, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                audit.audit_id,
+                json.dumps(list(audit.targets), ensure_ascii=False),
+                json.dumps(list(audit.message_ids), ensure_ascii=False),
+                json.dumps(list(audit.compactions), ensure_ascii=False),
+                audit.action_source,
+                int(audit.cascade),
+                audit.backup_path,
+                audit.started_at,
+                audit.completed_at,
+                audit.result,
+                audit.deleted_count,
+                audit.error,
+            ),
+        )
+
+    def _persist_delete_audit(self, audit: SessionDeleteAudit) -> None:
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
-                self._require_sessions_not_admitted_locked([key])
-                if not cascade:
-                    row = self._conn.execute(
-                        """
-                        SELECT
-                            (SELECT COUNT(1) FROM messages WHERE session_key = ?) +
-                            (SELECT COUNT(1) FROM turns WHERE session_key = ?) AS c
-                        """,
-                        (key, key),
-                    ).fetchone()
-                    count = int((row["c"] if row else 0) or 0)
-                    if count > 0:
-                        raise ValueError(
-                            "session 下仍有 messages 或 turns，需使用 cascade 删除"
-                        )
-                else:
-                    if self._has_message_embeddings_locked():
-                        self._conn.execute(
-                            """
-                            DELETE FROM message_embeddings
-                            WHERE message_id IN (
-                                SELECT id FROM messages WHERE session_key = ?
-                            )
-                            """,
-                            (key,),
-                        )
-                    self._conn.execute(
-                        "DELETE FROM messages WHERE session_key = ?",
-                        (key,),
-                    )
-                    self._conn.execute(
-                        "DELETE FROM turns WHERE session_key = ?",
-                        (key,),
-                    )
-                    self._conn.execute(
-                        "DELETE FROM session_compactions WHERE session_key = ?",
-                        (key,),
-                    )
-                cur = self._conn.execute(
-                    "DELETE FROM sessions WHERE key = ?",
-                    (key,),
-                )
+                self._insert_delete_audit_locked(audit)
                 self._conn.commit()
             except BaseException:
                 self._conn.rollback()
                 raise
-        return cur.rowcount > 0
 
-    def delete_sessions_batch(self, keys: list[str], *, cascade: bool = False) -> int:
-        clean_keys = [str(key).strip() for key in keys if str(key).strip()]
-        if not clean_keys:
-            return 0
-        placeholders = ",".join("?" for _ in clean_keys)
+    def _row_to_delete_audit(self, row: sqlite3.Row) -> SessionDeleteAudit:
+        targets = _decode_json_payload(
+            row["targets_json"],
+            fallback="[]",
+            field="session delete audit targets",
+            identifier=str(row["audit_id"]),
+        )
+        if not isinstance(targets, list) or not all(
+            isinstance(target, str) and target for target in targets
+        ):
+            raise ValueError(f"session delete audit targets 无效: {row['audit_id']}")
+        message_ids = _decode_json_payload(
+            row["message_ids_json"],
+            fallback="[]",
+            field="session delete audit message ids",
+            identifier=str(row["audit_id"]),
+        )
+        if not isinstance(message_ids, list) or not all(
+            isinstance(message_id, str) and message_id for message_id in message_ids
+        ):
+            raise ValueError(
+                f"session delete audit message ids 无效: {row['audit_id']}"
+            )
+        compactions = _decode_json_payload(
+            row["compactions_json"],
+            fallback="[]",
+            field="session delete audit compactions",
+            identifier=str(row["audit_id"]),
+        )
+        if not isinstance(compactions, list) or not all(
+            isinstance(item, dict)
+            and isinstance(item.get("session_key"), str)
+            and isinstance(item.get("generation"), int)
+            and isinstance(item.get("parent_generation"), int)
+            and isinstance(item.get("source_ref"), str)
+            and isinstance(item.get("source_message_ids"), list)
+            for item in compactions
+        ):
+            raise ValueError(
+                f"session delete audit compactions 无效: {row['audit_id']}"
+            )
+        return SessionDeleteAudit(
+            audit_id=str(row["audit_id"]),
+            targets=tuple(cast(str, target) for target in targets),
+            message_ids=tuple(cast(str, message_id) for message_id in message_ids),
+            compactions=tuple(cast(dict[str, Any], item) for item in compactions),
+            action_source=str(row["action_source"]),
+            cascade=bool(int(row["cascade"])),
+            backup_path=(
+                str(row["backup_path"]) if row["backup_path"] is not None else None
+            ),
+            started_at=str(row["started_at"]),
+            completed_at=str(row["completed_at"]),
+            result=str(row["result"]),
+            deleted_count=int(row["deleted_count"]),
+            error=str(row["error"]) if row["error"] is not None else None,
+        )
+
+    def get_session_delete_audit(self, audit_id: str) -> SessionDeleteAudit | None:
         with self._lock:
-            self._conn.execute("BEGIN IMMEDIATE")
-            try:
-                self._require_sessions_not_admitted_locked(clean_keys)
-                if not cascade:
-                    row = self._conn.execute(
-                        f"""
-                        SELECT
-                            (SELECT COUNT(1) FROM messages
-                             WHERE session_key IN ({placeholders})) +
-                            (SELECT COUNT(1) FROM turns
-                             WHERE session_key IN ({placeholders})) AS c
-                        """,
-                        tuple([*clean_keys, *clean_keys]),
-                    ).fetchone()
-                    count = int((row["c"] if row else 0) or 0)
-                    if count > 0:
-                        raise ValueError(
-                            "选中的 session 中仍有 messages 或 turns，需使用 cascade 删除"
+            row = self._conn.execute(
+                "SELECT * FROM session_delete_audits WHERE audit_id = ?",
+                (audit_id,),
+            ).fetchone()
+        return None if row is None else self._row_to_delete_audit(row)
+
+    def list_session_delete_audits(self, *, limit: int = 100) -> list[SessionDeleteAudit]:
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            raise ValueError("session delete audit limit 必须是正整数")
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM session_delete_audits
+                ORDER BY completed_at DESC, audit_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [self._row_to_delete_audit(row) for row in rows]
+
+    @staticmethod
+    def _normalize_source_ids(
+        source_ids: list[str] | tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if isinstance(source_ids, (str, bytes)):
+            raise ValueError("source_ids 必须是字符串数组")
+        normalized = tuple(dict.fromkeys(str(item).strip() for item in source_ids))
+        if not normalized or any(not item for item in normalized):
+            raise ValueError("source_ids 必须包含非空字符串")
+        return normalized
+
+    def _record_source_mutation_locked(
+        self,
+        *,
+        operation: str,
+        session_key: str,
+        message_ids: tuple[str, ...],
+        action_source: str,
+        backup_path: Path | None,
+    ) -> SourceMutationAudit:
+        audit = SourceMutationAudit(
+            audit_id=uuid4().hex,
+            operation=operation,
+            session_key=session_key,
+            message_ids=message_ids,
+            action_source=action_source,
+            backup_path=str(backup_path) if backup_path is not None else None,
+            completed_at=datetime.now().astimezone().isoformat(),
+        )
+        self._conn.execute(
+            """
+            INSERT INTO session_source_mutation_audits(
+                audit_id, operation, session_key, message_ids_json, action_source,
+                backup_path, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                audit.audit_id,
+                audit.operation,
+                audit.session_key,
+                json.dumps(list(audit.message_ids), ensure_ascii=False),
+                audit.action_source,
+                audit.backup_path,
+                audit.completed_at,
+            ),
+        )
+        return audit
+
+    def _row_to_source_mutation_audit(
+        self,
+        row: sqlite3.Row,
+    ) -> SourceMutationAudit:
+        message_ids = _decode_json_payload(
+            row["message_ids_json"],
+            fallback="[]",
+            field="source mutation audit message ids",
+            identifier=str(row["audit_id"]),
+        )
+        if not isinstance(message_ids, list) or not all(
+            isinstance(item, str) and item for item in message_ids
+        ):
+            raise ValueError(f"source mutation audit message ids 无效: {row['audit_id']}")
+        return SourceMutationAudit(
+            audit_id=str(row["audit_id"]),
+            operation=str(row["operation"]),
+            session_key=str(row["session_key"]),
+            message_ids=tuple(cast(str, item) for item in message_ids),
+            action_source=str(row["action_source"]),
+            backup_path=(
+                str(row["backup_path"]) if row["backup_path"] is not None else None
+            ),
+            completed_at=str(row["completed_at"]),
+        )
+
+    def find_authorized_source_mutations(
+        self,
+        *,
+        session_key: str,
+        source_ids: list[str] | tuple[str, ...],
+        prepared_at: str,
+    ) -> list[SourceMutationAudit]:
+        """Return committed mutation audits intersecting the prepared source plan."""
+
+        if not isinstance(session_key, str) or not session_key.strip():
+            raise ValueError("session_key 必须是非空字符串")
+        if not isinstance(prepared_at, str) or not prepared_at.strip():
+            raise ValueError("prepared_at 必须是非空字符串")
+        requested = set(self._normalize_source_ids(source_ids))
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT *
+                FROM session_source_mutation_audits
+                WHERE session_key = ?
+                  AND completed_at >= ?
+                ORDER BY completed_at, audit_id
+                """,
+                (session_key.strip(), prepared_at.strip()),
+            ).fetchall()
+        audits = [self._row_to_source_mutation_audit(row) for row in rows]
+        return [audit for audit in audits if requested.intersection(audit.message_ids)]
+
+    def _snapshot_delete_lineage_locked(
+        self,
+        targets: tuple[str, ...],
+    ) -> tuple[tuple[str, ...], tuple[dict[str, Any], ...]]:
+        """Capture canonical message IDs and compaction lineage before deletion."""
+
+        placeholders = ",".join("?" for _ in targets)
+        message_rows = self._conn.execute(
+            f"""
+            SELECT id
+            FROM messages
+            WHERE session_key IN ({placeholders})
+            ORDER BY session_key, seq
+            """,
+            targets,
+        ).fetchall()
+        compaction_rows = self._conn.execute(
+            f"""
+            SELECT *
+            FROM session_compactions
+            WHERE session_key IN ({placeholders})
+            ORDER BY session_key, generation
+            """,
+            targets,
+        ).fetchall()
+        compactions: list[dict[str, Any]] = []
+        for row in compaction_rows:
+            checkpoint = self._row_to_compaction(row)
+            compactions.append(
+                {
+                    "session_key": checkpoint.session_key,
+                    "generation": checkpoint.generation,
+                    "parent_generation": checkpoint.parent_generation,
+                    "source_ref": checkpoint.source_ref,
+                    "source_message_ids": list(checkpoint.source_message_ids),
+                }
+            )
+        return (
+            tuple(str(row["id"]) for row in message_rows),
+            tuple(compactions),
+        )
+
+    def _delete_sessions_with_audit(
+        self,
+        targets: tuple[str, ...],
+        *,
+        cascade: bool,
+        action_source: str,
+    ) -> SessionDeleteAudit:
+        action_source = self._normalize_action_source(action_source)
+        audit_id = uuid4().hex
+        started_at = datetime.now().astimezone().isoformat()
+        backup_path: Path | None = None
+        message_ids: tuple[str, ...] = ()
+        compactions: tuple[dict[str, Any], ...] = ()
+        try:
+            with self._lock:
+                self._conn.execute("BEGIN IMMEDIATE")
+                try:
+                    if not targets:
+                        audit = self._delete_audit_value(
+                            audit_id=audit_id,
+                            targets=targets,
+                            message_ids=message_ids,
+                            compactions=compactions,
+                            action_source=action_source,
+                            cascade=cascade,
+                            backup_path=None,
+                            started_at=started_at,
+                            result="not_found",
+                            deleted_count=0,
                         )
-                else:
-                    if self._has_message_embeddings_locked():
+                        self._insert_delete_audit_locked(audit)
+                        self._conn.commit()
+                        return audit
+
+                    # 1. 读取待删除 lineage，并在同一写事务中确认 admission。
+                    placeholders = ",".join("?" for _ in targets)
+                    existing_rows = self._conn.execute(
+                        f"SELECT key FROM sessions WHERE key IN ({placeholders})",
+                        targets,
+                    ).fetchall()
+                    if not existing_rows:
+                        audit = self._delete_audit_value(
+                            audit_id=audit_id,
+                            targets=targets,
+                            message_ids=message_ids,
+                            compactions=compactions,
+                            action_source=action_source,
+                            cascade=cascade,
+                            backup_path=None,
+                            started_at=started_at,
+                            result="not_found",
+                            deleted_count=0,
+                        )
+                        self._insert_delete_audit_locked(audit)
+                        self._conn.commit()
+                        return audit
+
+                    message_ids, compactions = self._snapshot_delete_lineage_locked(
+                        targets
+                    )
+                    self._require_sessions_not_admitted_locked(list(targets))
+                    self._require_no_pending_compaction_prepare_locked(list(targets))
+
+                    if not cascade:
+                        row = self._conn.execute(
+                            f"""
+                            SELECT
+                                (SELECT COUNT(1) FROM messages
+                                 WHERE session_key IN ({placeholders})) +
+                                (SELECT COUNT(1) FROM turns
+                                 WHERE session_key IN ({placeholders})) +
+                                (SELECT COUNT(1) FROM session_compactions
+                                 WHERE session_key IN ({placeholders})) +
+                                (SELECT COUNT(1) FROM session_compaction_prepares
+                                 WHERE session_key IN ({placeholders})) AS c
+                            """,
+                            tuple([*targets, *targets, *targets, *targets]),
+                        ).fetchone()
+                        count = int((row["c"] if row else 0) or 0)
+                        if count > 0:
+                            raise ValueError(
+                                "选中的 session 仍有 messages 或 turns（也可能包含 compactions 或 pending prepare），"
+                                "需使用 cascade 删除"
+                            )
+
+                    # 2. 在任何物理减少前创建并校验不可覆盖的完整快照。
+                    backup_path = self._backup_before_session_delete_locked()
+                    if cascade and self._has_message_embeddings_locked():
                         self._conn.execute(
                             f"""
                             DELETE FROM message_embeddings
                             WHERE message_id IN (
-                                SELECT id
-                                FROM messages
+                                SELECT id FROM messages
                                 WHERE session_key IN ({placeholders})
                             )
                             """,
-                            tuple(clean_keys),
+                            targets,
                         )
-                    self._conn.execute(
-                        f"DELETE FROM messages WHERE session_key IN ({placeholders})",
-                        tuple(clean_keys),
+                    if cascade:
+                        self._conn.execute(
+                            f"DELETE FROM messages WHERE session_key IN ({placeholders})",
+                            targets,
+                        )
+                        self._conn.execute(
+                            f"DELETE FROM turns WHERE session_key IN ({placeholders})",
+                            targets,
+                        )
+                        self._conn.execute(
+                            f"DELETE FROM session_compactions WHERE session_key IN ({placeholders})",
+                            targets,
+                        )
+                        self._conn.execute(
+                            f"DELETE FROM session_compaction_prepares "
+                            f"WHERE session_key IN ({placeholders})",
+                            targets,
+                        )
+                    cur = self._conn.execute(
+                        f"DELETE FROM sessions WHERE key IN ({placeholders})",
+                        targets,
                     )
-                    self._conn.execute(
-                        f"DELETE FROM turns WHERE session_key IN ({placeholders})",
-                        tuple(clean_keys),
+                    audit = self._delete_audit_value(
+                        audit_id=audit_id,
+                        targets=targets,
+                        message_ids=message_ids,
+                        compactions=compactions,
+                        action_source=action_source,
+                        cascade=cascade,
+                        backup_path=backup_path,
+                        started_at=started_at,
+                        result="committed",
+                        deleted_count=int(cur.rowcount or 0),
                     )
-                    self._conn.execute(
-                        f"DELETE FROM session_compactions WHERE session_key IN ({placeholders})",
-                        tuple(clean_keys),
-                    )
-                cur = self._conn.execute(
-                    f"DELETE FROM sessions WHERE key IN ({placeholders})",
-                    tuple(clean_keys),
-                )
-                self._conn.commit()
-            except BaseException:
-                self._conn.rollback()
-                raise
-        return int(cur.rowcount or 0)
+                    self._insert_delete_audit_locked(audit)
+                    self._conn.commit()
+                    return audit
+                except BaseException:
+                    self._conn.rollback()
+                    raise
+        except BaseException as exc:
+            failed = self._delete_audit_value(
+                audit_id=audit_id,
+                targets=targets,
+                message_ids=message_ids,
+                compactions=compactions,
+                action_source=action_source,
+                cascade=cascade,
+                backup_path=backup_path,
+                started_at=started_at,
+                result="rejected" if isinstance(exc, ValueError) else "failed",
+                deleted_count=0,
+                error=str(exc),
+            )
+            self._persist_delete_audit(failed)
+            setattr(exc, "audit_id", audit_id)
+            if isinstance(
+                exc,
+                (SessionAdmissionConflictError, SessionCompactionPrepareConflictError),
+            ):
+                exc.audit_id = audit_id
+            raise
+
+    def delete_session_with_audit(
+        self,
+        key: str,
+        *,
+        cascade: bool = False,
+        action_source: str = "session.store.delete_session",
+    ) -> SessionDeleteAudit:
+        return self._delete_sessions_with_audit(
+            self._normalize_delete_targets([key]),
+            cascade=cascade,
+            action_source=action_source,
+        )
+
+    def delete_session(
+        self,
+        key: str,
+        *,
+        cascade: bool = False,
+        action_source: str = "session.store.delete_session",
+    ) -> bool:
+        return self.delete_session_with_audit(
+            key,
+            cascade=cascade,
+            action_source=action_source,
+        ).result == "committed"
+
+    def delete_sessions_batch_with_audit(
+        self,
+        keys: list[str],
+        *,
+        cascade: bool = False,
+        action_source: str = "session.store.delete_sessions_batch",
+    ) -> SessionDeleteAudit:
+        return self._delete_sessions_with_audit(
+            self._normalize_delete_targets(keys),
+            cascade=cascade,
+            action_source=action_source,
+        )
+
+    def delete_sessions_batch(
+        self,
+        keys: list[str],
+        *,
+        cascade: bool = False,
+        action_source: str = "session.store.delete_sessions_batch",
+    ) -> int:
+        return self.delete_sessions_batch_with_audit(
+            keys,
+            cascade=cascade,
+            action_source=action_source,
+        ).deleted_count
 
     def acquire_session_admission(self, key: str, admission_id: str) -> bool:
         """仅在会话仍存在时创建处理租约，并阻止并发删除。"""
@@ -2023,9 +3249,7 @@ class SessionStore:
             tuple(keys),
         ).fetchone()
         if row is not None:
-            raise ValueError(
-                f"session 正在处理消息，暂时不能删除: {row['session_key']}"
-            )
+            raise SessionAdmissionConflictError(str(row["session_key"]))
 
     def update_presence(
         self,
@@ -2552,6 +3776,7 @@ class SessionStore:
         tool_chain: Any | None = None,
         extra: dict[str, Any] | None = None,
         ts: str | None = None,
+        action_source: str = "session.store.message_edit",
     ) -> dict[str, Any] | None:
         set_parts: list[str] = []
         params: list[Any] = []
@@ -2572,120 +3797,176 @@ class SessionStore:
             params.append(ts)
         if not set_parts:
             return self.get_message(message_id)
-
+        normalized_source = self._normalize_action_source(action_source)
         with self._lock:
-            row = self._conn.execute(
-                "SELECT session_key, content FROM messages WHERE id = ?",
-                (message_id,),
-            ).fetchone()
-            if row is None:
-                return None
-            session_key = str(row["session_key"])
-            params.append(message_id)
-            cur = self._conn.execute(
-                f"UPDATE messages SET {', '.join(set_parts)} WHERE id = ?",
-                tuple(params),
-            )
-            if content is not None and content != str(row["content"] or ""):
-                self._delete_message_embeddings_locked([message_id])
-            self._conn.execute(
-                "UPDATE sessions SET updated_at = ? WHERE key = ?",
-                (datetime.now().astimezone().isoformat(), session_key),
-            )
-            self._conn.commit()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT session_key, role, content FROM messages WHERE id = ?",
+                    (message_id,),
+                ).fetchone()
+                if row is None:
+                    self._conn.rollback()
+                    return None
+                session_key = str(row["session_key"])
+                self._require_no_pending_compaction_prepare_locked([session_key])
+                self._require_sessions_not_admitted_locked([session_key])
+                params.append(message_id)
+                cur = self._conn.execute(
+                    f"UPDATE messages SET {', '.join(set_parts)} WHERE id = ?",
+                    tuple(params),
+                )
+                if content is not None and content != str(row["content"] or ""):
+                    self._delete_message_embeddings_locked([message_id])
+                self._conn.execute(
+                    "UPDATE sessions SET updated_at = ? WHERE key = ?",
+                    (datetime.now().astimezone().isoformat(), session_key),
+                )
+                self._record_source_mutation_locked(
+                    operation="message_edit",
+                    session_key=session_key,
+                    message_ids=(message_id,),
+                    action_source=normalized_source,
+                    backup_path=None,
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
         if cur.rowcount <= 0:
             return None
         return self.get_message(message_id)
 
-    def delete_message(self, message_id: str) -> bool:
+    def delete_message(
+        self,
+        message_id: str,
+        *,
+        action_source: str = "session.store.message_delete",
+    ) -> bool:
+        normalized_source = self._normalize_action_source(action_source)
         with self._lock:
-            row = self._conn.execute(
-                "SELECT session_key, extra FROM messages WHERE id = ?",
-                (message_id,),
-            ).fetchone()
-            if row is None:
-                return False
-            control_turn_id = _message_control_turn_id(row["extra"], message_id)
-            if control_turn_id is not None:
-                raise InteractionDeleteRequiredError(message_id, control_turn_id)
-            session_key = str(row["session_key"])
-            cur = self._conn.execute(
-                "DELETE FROM messages WHERE id = ?",
-                (message_id,),
-            )
-            self._delete_message_embeddings_locked([message_id])
-            self._conn.execute(
-                "UPDATE sessions SET updated_at = ? WHERE key = ?",
-                (datetime.now().astimezone().isoformat(), session_key),
-            )
-            self._conn.commit()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT session_key, extra FROM messages WHERE id = ?",
+                    (message_id,),
+                ).fetchone()
+                if row is None:
+                    self._conn.rollback()
+                    return False
+                session_key = str(row["session_key"])
+                self._require_no_pending_compaction_prepare_locked([session_key])
+                control_turn_id = _message_control_turn_id(row["extra"], message_id)
+                if control_turn_id is not None:
+                    raise InteractionDeleteRequiredError(message_id, control_turn_id)
+                self._require_sessions_not_admitted_locked([session_key])
+                backup_path = self._backup_before_delete_locked("message-deletions")
+                cur = self._conn.execute(
+                    "DELETE FROM messages WHERE id = ?",
+                    (message_id,),
+                )
+                self._delete_message_embeddings_locked([message_id])
+                self._conn.execute(
+                    "UPDATE sessions SET updated_at = ? WHERE key = ?",
+                    (datetime.now().astimezone().isoformat(), session_key),
+                )
+                self._record_source_mutation_locked(
+                    operation="message_delete",
+                    session_key=session_key,
+                    message_ids=(message_id,),
+                    action_source=normalized_source,
+                    backup_path=backup_path,
+                )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
         return cur.rowcount > 0
 
-    def delete_messages_batch(self, ids: list[str]) -> int:
+    def delete_messages_batch(
+        self,
+        ids: list[str],
+        *,
+        action_source: str = "session.store.message_batch_delete",
+    ) -> int:
         clean_ids = [
             str(message_id).strip() for message_id in ids if str(message_id).strip()
         ]
         if not clean_ids:
             return 0
+        normalized_source = self._normalize_action_source(action_source)
         placeholders = ",".join("?" for _ in clean_ids)
         now = datetime.now().astimezone().isoformat()
         with self._lock:
-            explicit_rows = self._conn.execute(
-                f"SELECT id, extra FROM messages WHERE id IN ({placeholders})",
-                tuple(clean_ids),
-            ).fetchall()
-            for row in explicit_rows:
-                message_id = str(row["id"])
-                control_turn_id = _message_control_turn_id(
-                    row["extra"],
-                    message_id,
-                )
-                if control_turn_id is not None:
-                    raise InteractionDeleteRequiredError(
-                        message_id,
-                        control_turn_id,
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                explicit_rows = self._conn.execute(
+                    f"""
+                    SELECT id, session_key, extra
+                    FROM messages
+                    WHERE id IN ({placeholders})
+                    ORDER BY session_key, seq
+                    """,
+                    tuple(clean_ids),
+                ).fetchall()
+                grouped: dict[str, list[str]] = {}
+                for row in explicit_rows:
+                    grouped.setdefault(str(row["session_key"]), []).append(
+                        str(row["id"])
                     )
-            rows = self._conn.execute(
-                f"SELECT DISTINCT session_key FROM messages WHERE id IN ({placeholders})",
-                tuple(clean_ids),
-            ).fetchall()
-            cur = self._conn.execute(
-                f"DELETE FROM messages WHERE id IN ({placeholders})",
-                tuple(clean_ids),
-            )
-            self._delete_message_embeddings_locked(clean_ids)
-            for row in rows:
-                self._conn.execute(
-                    "UPDATE sessions SET updated_at = ? WHERE key = ?",
-                    (now, str(row["session_key"])),
+                if not grouped:
+                    self._conn.rollback()
+                    return 0
+                self._require_no_pending_compaction_prepare_locked(list(grouped))
+                for row in explicit_rows:
+                    message_id = str(row["id"])
+                    control_turn_id = _message_control_turn_id(row["extra"], message_id)
+                    if control_turn_id is not None:
+                        raise InteractionDeleteRequiredError(
+                            message_id,
+                            control_turn_id,
+                        )
+                self._require_sessions_not_admitted_locked(list(grouped))
+                backup_path = self._backup_before_delete_locked("message-deletions")
+                cur = self._conn.execute(
+                    f"DELETE FROM messages WHERE id IN ({placeholders})",
+                    tuple(clean_ids),
                 )
-            self._conn.commit()
+                self._delete_message_embeddings_locked(clean_ids)
+                for session_key in grouped:
+                    self._conn.execute(
+                        "UPDATE sessions SET updated_at = ? WHERE key = ?",
+                        (now, session_key),
+                    )
+                for session_key in grouped:
+                    self._record_source_mutation_locked(
+                        operation="message_batch_delete",
+                        session_key=session_key,
+                        message_ids=tuple(grouped[session_key]),
+                        action_source=normalized_source,
+                        backup_path=backup_path,
+                    )
+                self._conn.commit()
+            except BaseException:
+                self._conn.rollback()
+                raise
         return int(cur.rowcount or 0)
 
     def delete_interaction(
         self,
         control_turn_id: str,
+        *,
+        action_source: str = "session.store.interaction_delete",
     ) -> InteractionDeletion | None:
         """校验并原子撤销一个显式 interaction 及其派生 embedding。"""
 
         if not isinstance(control_turn_id, str) or not control_turn_id.strip():
             raise ValueError("control_turn_id 必须是非空字符串")
         normalized_turn_id = control_turn_id.strip()
+        normalized_source = self._normalize_action_source(action_source)
         now = datetime.now().astimezone().isoformat()
 
         with self._lock:
-            exists = self._conn.execute(
-                """
-                SELECT 1
-                FROM messages
-                WHERE json_extract(COALESCE(extra, '{}'), '$.control_turn_id') = ?
-                LIMIT 1
-                """,
-                (normalized_turn_id,),
-            ).fetchone()
-            if exists is None:
-                return None
-            backup_path = self._backup_before_interaction_delete_locked()
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 # 1. 解析完整 transcript，并拒绝跨 session 或非连续结构。
@@ -2732,7 +4013,7 @@ class SessionStore:
                     turn_rows,
                 )
 
-                # 2. 旧 cursor 仍作为 legacy fallback；新 ledger 由 provenance 决定回退。
+                # 2. Cursor 只由 ledger provenance 驱动；迁移负责清理 legacy 值。
                 meta = self._conn.execute(
                     "SELECT last_consolidated FROM sessions WHERE key = ?",
                     (session_key,),
@@ -2740,19 +4021,15 @@ class SessionStore:
                 if meta is None:
                     raise ValueError(f"interaction session 不存在: {session_key}")
                 old_cursor = int(meta["last_consolidated"])
-                group_start = positions[0]
-                ledger_exists = self._conn.execute(
-                    "SELECT 1 FROM session_compactions WHERE session_key = ? LIMIT 1",
-                    (session_key,),
-                ).fetchone() is not None
-                # New installations store a generation here; legacy installations still
-                # use the old message-index fallback until the Yoyo migration runs.
-                new_cursor = old_cursor if ledger_exists else (
-                    group_start if old_cursor > group_start else old_cursor
-                )
+                new_cursor = old_cursor
+
+                # 2. active admission 与删除共用同一写事务，避免当前 turn 在删除后提交。
+                self._require_no_pending_compaction_prepare_locked([session_key])
+                self._require_sessions_not_admitted_locked([session_key])
+                message_ids = tuple(str(row["id"]) for row in turn_rows)
+                backup_path = self._backup_before_interaction_delete_locked()
 
                 # 3. 正文、逐消息 embedding 与游标在同一事务中提交。
-                message_ids = tuple(str(row["id"]) for row in turn_rows)
                 placeholders = ",".join("?" for _ in message_ids)
                 self._conn.execute(
                     f"DELETE FROM messages WHERE id IN ({placeholders})",
@@ -2776,8 +4053,15 @@ class SessionStore:
                     """,
                     (new_cursor, now, session_key),
                 )
+                audit = self._record_source_mutation_locked(
+                    operation="interaction_delete",
+                    session_key=session_key,
+                    message_ids=message_ids,
+                    action_source=normalized_source,
+                    backup_path=backup_path,
+                )
                 self._conn.commit()
-            except Exception:
+            except BaseException:
                 self._conn.rollback()
                 raise
 
@@ -2789,6 +4073,7 @@ class SessionStore:
             old_last_consolidated=old_cursor,
             new_last_consolidated=new_cursor,
             backup_path=str(backup_path),
+            audit_id=audit.audit_id,
         )
         logger.info(
             "interaction deleted control_turn_id=%s session_key=%s messages=%d "
@@ -2803,83 +4088,46 @@ class SessionStore:
         return deletion
 
     def _backup_before_interaction_delete_locked(self) -> Path:
-        """创建并验证删除前的完整 SessionDB SQLite 快照。"""
+        """创建 interaction 删除前的完整 SessionDB SQLite 快照。"""
 
-        backup_root = Path(self.db_path).parent / "backups" / "interaction-deletions"
+        return self._backup_before_delete_locked("interaction-deletions")
+
+    def _backup_before_session_delete_locked(self) -> Path:
+        """创建 session 删除前的完整 SessionDB SQLite 快照。"""
+
+        return self._backup_before_delete_locked("session-deletions")
+
+    def _backup_before_delete_locked(self, category: str) -> Path:
+        """在事务尚未写入时创建并验证不可覆盖的 SQLite 快照。"""
+
+        backup_root = Path(self.db_path).parent / "backups" / category
         backup_root.mkdir(parents=True, exist_ok=True)
         backup_id = uuid4().hex
         backup_path = backup_root / f"sessions-{backup_id}.db"
         candidate_path = backup_root / f".sessions-{backup_id}.db.tmp"
         candidate_path.touch(mode=0o600, exist_ok=False)
         try:
-            target = sqlite3.connect(candidate_path)
+            # 当前连接已进入 BEGIN IMMEDIATE；同一连接作为备份源会让 SQLite
+            # backup API 永久等待，因此在事务尚未写入时通过独立连接读取快照。
+            source = sqlite3.connect(self.db_path)
             try:
-                self._conn.backup(target)
-                rows = target.execute("PRAGMA integrity_check").fetchall()
-                if rows != [("ok",)]:
-                    raise RuntimeError(
-                        f"interaction 删除备份 integrity_check 失败: {rows[:3]}"
-                    )
+                target = sqlite3.connect(candidate_path)
+                try:
+                    source.backup(target)
+                    rows = target.execute("PRAGMA integrity_check").fetchall()
+                    if rows != [("ok",)]:
+                        raise RuntimeError(
+                            f"{category} 删除备份 integrity_check 失败: {rows[:3]}"
+                        )
+                finally:
+                    target.close()
             finally:
-                target.close()
+                source.close()
             _ = candidate_path.replace(backup_path)
         except (OSError, RuntimeError, sqlite3.Error):
             candidate_path.unlink(missing_ok=True)
             raise
         return backup_path
-
-    def delete_session_messages_and_update_cursor(
-        self,
-        session_key: str,
-        *,
-        ids: list[str],
-        last_consolidated: int,
-    ) -> int:
-        clean_ids = [
-            str(message_id).strip() for message_id in ids if str(message_id).strip()
-        ]
-        if not clean_ids:
-            return 0
-        placeholders = ",".join("?" for _ in clean_ids)
-        now = datetime.now().astimezone().isoformat()
-        with self._lock:
-            self._conn.execute("BEGIN IMMEDIATE")
-            try:
-                seq_rows = self._conn.execute(
-                    f"""
-                    SELECT id, seq
-                    FROM messages
-                    WHERE session_key = ? AND id IN ({placeholders})
-                    """,
-                    tuple([session_key, *clean_ids]),
-                ).fetchall()
-                next_seq = (
-                    max(int(row["seq"]) for row in seq_rows) + 1 if seq_rows else 0
-                )
-                deleted_ids = [str(row["id"]) for row in seq_rows]
-                cur = self._conn.execute(
-                    f"""
-                    DELETE FROM messages
-                    WHERE session_key = ? AND id IN ({placeholders})
-                    """,
-                    tuple([session_key, *clean_ids]),
-                )
-                self._delete_message_embeddings_locked(deleted_ids)
-                self._conn.execute(
-                    """
-                    UPDATE sessions
-                    SET last_consolidated = ?,
-                        updated_at = ?,
-                        next_seq = CASE WHEN next_seq < ? THEN ? ELSE next_seq END
-                    WHERE key = ?
-                    """,
-                    (int(last_consolidated), now, next_seq, next_seq, session_key),
-                )
-                self._conn.commit()
-            except Exception:
-                self._conn.rollback()
-                raise
-        return int(cur.rowcount or 0)
 
     def fetch_by_ids_with_context(
         self, ids: list[str], context: int

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -70,9 +70,13 @@ def test_init_records_yoyo_origin_in_workspace_ledger(tmp_path: Path) -> None:
         ("20260802_01_yoyo_origin",),
         ("20260805_01_akasha_sparse_index_v9",),
         ("20260807_01_model_registry_database",),
+        ("20260807_01_session_context_compaction_ledger",),
         ("20260807_02_embedding_model_registry",),
         ("20260808_01_restore_migrated_reasoning_efforts",),
+        ("20260808_01_session_mutation_audits",),
         ("20260808_02_correct_opencode_go_variants",),
+        ("20260808_02_session_compaction_prepares",),
+        ("20260808_04_session_compaction_source_plan_digest",),
     ]
     assert not config_path.with_name("config.toml.migration-cursor").exists()
 

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 import shutil
 import sqlite3
 import tomllib
@@ -17,6 +18,10 @@ from bootstrap.workspace_lock import WorkspaceInstanceLock
 _PROJECT_ROOT = Path(__file__).parents[1]
 _ORIGIN_ID = "20260802_01_yoyo_origin"
 _AKASHA_V9_ID = "20260805_01_akasha_sparse_index_v9"
+_COMPACTION_ID = "20260807_01_session_context_compaction_ledger"
+_AUDIT_ID = "20260808_01_session_mutation_audits"
+_PREPARE_ID = "20260808_02_session_compaction_prepares"
+_DIGEST_ID = "20260808_04_session_compaction_source_plan_digest"
 _MODEL_REGISTRY_ID = "20260807_01_model_registry_database"
 _EMBEDDING_REGISTRY_ID = "20260807_02_embedding_model_registry"
 _MODEL_CAPABILITIES_ID = "20260808_01_restore_migrated_reasoning_efforts"
@@ -25,9 +30,13 @@ _CURRENT_IDS = (
     _ORIGIN_ID,
     _AKASHA_V9_ID,
     _MODEL_REGISTRY_ID,
+    _COMPACTION_ID,
     _EMBEDDING_REGISTRY_ID,
     _MODEL_CAPABILITIES_ID,
+    _AUDIT_ID,
     _OPENCODE_VARIANTS_ID,
+    _PREPARE_ID,
+    _DIGEST_ID,
 )
 
 
@@ -37,6 +46,17 @@ def _runner(root: Path, *, repo_root: Path = _PROJECT_ROOT) -> MigrationRunner:
         config_path=root / "config.toml",
         workspace=root / "workspace",
     )
+
+
+def _catalog(root: Path, migration_ids: tuple[str, ...]) -> Path:
+    catalog = root / "migrations" / "yoyo"
+    catalog.mkdir(parents=True)
+    for migration_id in migration_ids:
+        shutil.copy2(
+            _PROJECT_ROOT / "migrations/yoyo" / f"{migration_id}.py",
+            catalog / f"{migration_id}.py",
+        )
+    return root
 
 
 def _applied_ids(ledger: Path) -> list[str]:
@@ -50,6 +70,23 @@ def _applied_ids(ledger: Path) -> list[str]:
     return [str(row[0]) for row in rows]
 
 
+def _create_sessions(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE sessions ("
+            "key TEXT PRIMARY KEY, last_consolidated INTEGER NOT NULL)"
+        )
+        connection.execute(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, body TEXT NOT NULL)"
+        )
+        connection.execute("INSERT INTO sessions VALUES ('chat', 4)")
+        connection.execute("INSERT INTO messages VALUES ('m1', 'session-bytes')")
+        connection.commit()
+    finally:
+        connection.close()
+
+
 def test_origin_removes_legacy_state_without_touching_business_data(
     tmp_path: Path,
 ) -> None:
@@ -59,7 +96,7 @@ def test_origin_removes_legacy_state_without_touching_business_data(
     config = root / "config.toml"
     config.write_bytes(b"current = true\n")
     sessions = workspace / "sessions.db"
-    sessions.write_bytes(b"session-bytes")
+    _create_sessions(sessions)
     memory = workspace / "memory/MEMORY.md"
     memory.parent.mkdir()
     memory.write_bytes(b"memory-bytes")
@@ -79,10 +116,41 @@ def test_origin_removes_legacy_state_without_touching_business_data(
     assert not cursor.exists()
     assert not lock.exists()
     assert not backups.exists()
-    assert config.read_bytes() == b"current = true\n"
-    assert sessions.read_bytes() == b"session-bytes"
+    config_data = tomllib.loads(config.read_text(encoding="utf-8"))
+    assert config_data == {"current": True}
+    migrated = sqlite3.connect(sessions)
+    try:
+        assert migrated.execute(
+            "SELECT last_consolidated FROM sessions WHERE key = 'chat'"
+        ).fetchone() == (4,)
+        assert migrated.execute("SELECT body FROM messages").fetchall() == [
+            ("session-bytes",)
+        ]
+        assert {
+            row[0]
+            for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        } >= {
+            "session_delete_audits",
+            "session_source_mutation_audits",
+        }
+    finally:
+        migrated.close()
     assert memory.read_bytes() == b"memory-bytes"
     assert _applied_ids(workspace / "migrations.sqlite3") == list(_CURRENT_IDS)
+
+    migration_backups = sorted(
+        (workspace / "backups/session-context-compaction-ledger").iterdir()
+    )
+    assert len(migration_backups) == 1
+    manifest = json.loads((migration_backups[0] / "manifest.json").read_text())
+    assert manifest["sqlite_integrity"] == "ok"
+    archived = sqlite3.connect(migration_backups[0] / "sessions.db")
+    try:
+        assert archived.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        archived.close()
 
 
 def test_origin_is_a_noop_when_legacy_state_is_absent(tmp_path: Path) -> None:
@@ -245,9 +313,13 @@ system_prompt = "test"
     sessions = workspace / "sessions.db"
     sessions.write_bytes(b"protected-session-bytes")
 
-    outcome = _runner(root).run()
+    model_repo = _catalog(
+        tmp_path / "model-registry-repo",
+        (_ORIGIN_ID, _MODEL_REGISTRY_ID),
+    )
+    outcome = _runner(root, repo_root=model_repo).run()
 
-    assert outcome.migrations == _CURRENT_IDS
+    assert outcome.migrations == (_ORIGIN_ID, _MODEL_REGISTRY_ID)
     assert sessions.read_bytes() == b"protected-session-bytes"
     assert "runtimes" not in config.read_text(encoding="utf-8")
     snapshot = ModelRegistryStore.for_workspace(workspace).read_snapshot()
@@ -289,22 +361,24 @@ input_modalities = ["text"]
     sessions.write_bytes(b"protected-session-bytes")
 
     # 1. 重现已经被上一条迁移写入通用 LiteLLM effort 的 workspace
-    legacy_repo = tmp_path / "legacy-repo"
-    legacy_catalog = legacy_repo / "migrations/yoyo"
-    legacy_catalog.mkdir(parents=True)
-    for migration_id in (
+    legacy_repo = _catalog(
+        tmp_path / "legacy-repo",
+        (
+            _ORIGIN_ID,
+            _AKASHA_V9_ID,
+            _MODEL_REGISTRY_ID,
+            _EMBEDDING_REGISTRY_ID,
+            _MODEL_CAPABILITIES_ID,
+        ),
+    )
+    first = _runner(root, repo_root=legacy_repo).run()
+    assert first.migrations == (
         _ORIGIN_ID,
         _AKASHA_V9_ID,
         _MODEL_REGISTRY_ID,
         _EMBEDDING_REGISTRY_ID,
         _MODEL_CAPABILITIES_ID,
-    ):
-        shutil.copy2(
-            _PROJECT_ROOT / "migrations/yoyo" / f"{migration_id}.py",
-            legacy_catalog / f"{migration_id}.py",
-        )
-    first = _runner(root, repo_root=legacy_repo).run()
-    assert first.migrations == _CURRENT_IDS[:-1]
+    )
     store = ModelRegistryStore.for_workspace(root / "workspace")
     before = store.read_snapshot()
     assert before is not None
@@ -316,7 +390,18 @@ input_modalities = ["text"]
     config_after_first_migration = config.read_bytes()
 
     # 2. 只应用勘误并证明身份、凭据、角色与业务状态保持不变
-    corrected = _runner(root).run()
+    corrected_repo = _catalog(
+        tmp_path / "corrected-repo",
+        (
+            _ORIGIN_ID,
+            _AKASHA_V9_ID,
+            _MODEL_REGISTRY_ID,
+            _EMBEDDING_REGISTRY_ID,
+            _MODEL_CAPABILITIES_ID,
+            _OPENCODE_VARIANTS_ID,
+        ),
+    )
+    corrected = _runner(root, repo_root=corrected_repo).run()
     assert corrected.migrations == (_OPENCODE_VARIANTS_ID,)
     after = store.read_snapshot()
     assert after is not None
@@ -498,9 +583,13 @@ api_key = "secret"
 
     assert outcome.migrations == (
         _MODEL_REGISTRY_ID,
+        _COMPACTION_ID,
         _EMBEDDING_REGISTRY_ID,
         _MODEL_CAPABILITIES_ID,
+        _AUDIT_ID,
         _OPENCODE_VARIANTS_ID,
+        _PREPARE_ID,
+        _DIGEST_ID,
     )
     assert (
         CredentialStore.for_workspace(root / "workspace").api_key("model_deepseek_main")

--- a/tests/test_session_compaction_prepare_migration.py
+++ b/tests/test_session_compaction_prepare_migration.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from agent.migrations.runner import MigrationRunner
+
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+_PREPARE_ID = "20260808_02_session_compaction_prepares"
+
+
+def _create_sessions(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE sessions ("
+            "key TEXT PRIMARY KEY, last_consolidated INTEGER NOT NULL)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _runner(root: Path) -> MigrationRunner:
+    return MigrationRunner(
+        repo_root=_PROJECT_ROOT,
+        config_path=root / "config.toml",
+        workspace=root / "workspace",
+    )
+
+
+def test_prepare_migration_publishes_exact_schema_and_indexes(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    _create_sessions(workspace / "sessions.db")
+
+    outcome = _runner(root).run()
+
+    assert outcome.migrations[-1] == _PREPARE_ID
+    connection = sqlite3.connect(workspace / "sessions.db")
+    try:
+        columns = {
+            row[1]
+            for row in connection.execute(
+                "PRAGMA table_info(session_compaction_prepares)"
+            )
+        }
+        assert columns == {
+            "session_key",
+            "session_created_at",
+            "generation",
+            "parent_generation",
+            "source_ref",
+            "source_from_seq",
+            "consolidated_through_seq",
+            "source_message_ids_json",
+            "retained_tail_json",
+            "prepared_at",
+        }
+        indexes = {
+            row[1]
+            for row in connection.execute(
+                "SELECT type, name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+        assert "idx_session_compaction_prepares_ref" in indexes
+        assert {
+            row[1]
+            for row in connection.execute(
+                "PRAGMA index_list(session_compaction_prepares)"
+            )
+        } >= {
+            "idx_session_compaction_prepares_ref",
+        }
+    finally:
+        connection.close()
+
+
+def test_prepare_migration_rejects_incompatible_existing_table(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute(
+            "CREATE TABLE session_compaction_prepares (session_key TEXT PRIMARY KEY)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    runner = _runner(root)
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        runner.run()
+
+    if runner.ledger_path.exists():
+        ledger = sqlite3.connect(runner.ledger_path)
+        try:
+            applied = {
+                row[0]
+                for row in ledger.execute(
+                    "SELECT migration_id FROM _yoyo_migration"
+                )
+            }
+        finally:
+            ledger.close()
+        assert _PREPARE_ID not in applied

--- a/tests/test_session_compaction_prepare_migration.py
+++ b/tests/test_session_compaction_prepare_migration.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import sqlite3
+import stat
 from pathlib import Path
 
 import pytest
@@ -24,6 +26,23 @@ def _create_sessions(path: Path) -> None:
         connection.close()
 
 
+_PREPARE_TABLE_WITHOUT_UNIQUE = """
+CREATE TABLE session_compaction_prepares (
+    session_key TEXT NOT NULL,
+    session_created_at TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    parent_generation INTEGER NOT NULL,
+    source_ref TEXT NOT NULL,
+    source_from_seq INTEGER NOT NULL,
+    consolidated_through_seq INTEGER NOT NULL,
+    source_message_ids_json TEXT NOT NULL,
+    retained_tail_json TEXT NOT NULL,
+    prepared_at TEXT NOT NULL,
+    PRIMARY KEY (session_key, generation)
+)
+"""
+
+
 def _runner(root: Path) -> MigrationRunner:
     return MigrationRunner(
         repo_root=_PROJECT_ROOT,
@@ -40,7 +59,7 @@ def test_prepare_migration_publishes_exact_schema_and_indexes(tmp_path: Path) ->
 
     outcome = _runner(root).run()
 
-    assert outcome.migrations[-1] == _PREPARE_ID
+    assert _PREPARE_ID in outcome.migrations
     connection = sqlite3.connect(workspace / "sessions.db")
     try:
         columns = {
@@ -78,6 +97,19 @@ def test_prepare_migration_publishes_exact_schema_and_indexes(tmp_path: Path) ->
         }
     finally:
         connection.close()
+    backups = sorted(
+        (workspace / "backups/session-compaction-prepares").iterdir()
+    )
+    assert len(backups) == 1
+    manifest = json.loads((backups[0] / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["sqlite_integrity"] == "ok"
+    assert stat.S_IMODE((backups[0] / "sessions.db").stat().st_mode) == 0o600
+    assert stat.S_IMODE((backups[0] / "manifest.json").stat().st_mode) == 0o600
+    archived = sqlite3.connect(backups[0] / "sessions.db")
+    try:
+        assert archived.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        archived.close()
 
 
 def test_prepare_migration_rejects_incompatible_existing_table(tmp_path: Path) -> None:
@@ -99,6 +131,38 @@ def test_prepare_migration_rejects_incompatible_existing_table(tmp_path: Path) -
     with pytest.raises(RuntimeError, match="schema lineage"):
         runner.run()
 
+    if runner.ledger_path.exists():
+        ledger = sqlite3.connect(runner.ledger_path)
+        try:
+            applied = {
+                row[0]
+                for row in ledger.execute(
+                    "SELECT migration_id FROM _yoyo_migration"
+                )
+            }
+        finally:
+            ledger.close()
+        assert _PREPARE_ID not in applied
+
+
+def test_prepare_migration_rejects_missing_source_ref_unique_constraint(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute(_PREPARE_TABLE_WITHOUT_UNIQUE)
+        connection.commit()
+    finally:
+        connection.close()
+
+    runner = _runner(root)
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        runner.run()
     if runner.ledger_path.exists():
         ledger = sqlite3.connect(runner.ledger_path)
         try:

--- a/tests/test_session_compaction_source_plan_digest.py
+++ b/tests/test_session_compaction_source_plan_digest.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+from typing import Any, TypedDict
+
+from session.store import SessionStore
+
+
+class _CompactionKwargs(TypedDict):
+    session_key: str
+    trigger: str
+    summary: str
+    source_ref: str
+    source_plan_digest: str
+    source_from_seq: int
+    consolidated_through_seq: int
+    source_message_ids: list[str]
+    retained_tail: list[dict[str, Any]]
+    model_runtime_id: str
+    model: str
+    context_window: int
+    threshold_tokens: int
+    hard_input_tokens: int
+    keep_recent_tokens: int
+    tokens_before: int
+    tokens_after: int
+    summary_usage: dict[str, Any]
+    generation: int
+    parent_generation: int
+
+
+def _persist_kwargs(session_key: str, digest: str) -> _CompactionKwargs:
+    return {
+        "session_key": session_key,
+        "trigger": "soft_limit",
+        "summary": "summary",
+        "source_ref": "source:1",
+        "source_plan_digest": digest,
+        "source_from_seq": 0,
+        "consolidated_through_seq": 0,
+        "source_message_ids": ["session:digest:0"],
+        "retained_tail": [
+            {
+                "id": "session:digest:0",
+                "seq": 0,
+                "unit_ref": "unit:1",
+                "message": {"role": "user", "content": "source"},
+            }
+        ],
+        "model_runtime_id": "runtime",
+        "model": "model",
+        "context_window": 100,
+        "threshold_tokens": 74,
+        "hard_input_tokens": 90,
+        "keep_recent_tokens": 20,
+        "tokens_before": 80,
+        "tokens_after": 40,
+        "summary_usage": {},
+        "generation": 1,
+        "parent_generation": 0,
+    }
+
+
+def _store(tmp_path) -> SessionStore:
+    store = SessionStore(tmp_path / "sessions.db")
+    store.create_session(key="session:digest")
+    store.insert_message(
+        "session:digest",
+        role="user",
+        content="source",
+        ts="2026-08-08T00:00:00+00:00",
+        seq=0,
+    )
+    return store
+
+
+def test_store_persists_and_reloads_canonical_digest(tmp_path) -> None:
+    store = _store(tmp_path)
+    try:
+        digest = "a" * 64
+        row = store.persist_compaction(**_persist_kwargs("session:digest", digest))
+        assert row.source_plan_digest == digest
+        reopened = SessionStore(tmp_path / "sessions.db")
+        try:
+            loaded = reopened.get_compaction("session:digest", 1)
+            assert loaded is not None
+            assert loaded.source_plan_digest == digest
+        finally:
+            reopened.close()
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("digest", ("a" * 63, "g" * 64, ""))
+def test_store_rejects_noncanonical_digest_at_write_boundary(tmp_path, digest: str) -> None:
+    store = _store(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="source_plan_digest"):
+            store.persist_compaction(**_persist_kwargs("session:digest", digest))
+        assert store.list_compactions("session:digest") == []
+        assert store.get_compaction_head("session:digest").parent_generation == 0
+    finally:
+        store.close()

--- a/tests/test_session_compaction_source_plan_digest_migration.py
+++ b/tests/test_session_compaction_source_plan_digest_migration.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import yoyo
+
+from agent.migrations.context import bind_migration_context
+
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+_MIGRATION_PATH = (
+    _PROJECT_ROOT
+    / "migrations"
+    / "yoyo"
+    / "20260808_04_session_compaction_source_plan_digest.py"
+)
+
+
+def _load_migration():
+    """Load the real migration callback without wrapping it in a Yoyo step."""
+
+    spec = importlib.util.spec_from_file_location(
+        "session_compaction_source_plan_digest_migration_under_test",
+        _MIGRATION_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"无法加载迁移: {_MIGRATION_PATH}")
+    original_step = yoyo.step
+    yoyo.step = lambda callback: callback  # type: ignore[assignment]
+    try:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        yoyo.step = original_step
+    return module
+
+
+def _create_legacy_db(path: Path, *, with_row: bool) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE sessions ("
+            "key TEXT PRIMARY KEY, last_consolidated INTEGER NOT NULL)"
+        )
+        connection.execute(
+            """
+            CREATE TABLE session_compactions (
+                session_key TEXT NOT NULL,
+                generation INTEGER NOT NULL,
+                parent_generation INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                trigger TEXT NOT NULL,
+                summary_format_version INTEGER NOT NULL,
+                summary TEXT NOT NULL,
+                source_ref TEXT NOT NULL,
+                source_from_seq INTEGER NOT NULL,
+                consolidated_through_seq INTEGER NOT NULL,
+                source_message_ids_json TEXT NOT NULL,
+                retained_tail_json TEXT NOT NULL,
+                model_runtime_id TEXT NOT NULL,
+                model TEXT NOT NULL,
+                context_window INTEGER NOT NULL,
+                threshold_tokens INTEGER NOT NULL,
+                hard_input_tokens INTEGER NOT NULL,
+                keep_recent_tokens INTEGER NOT NULL,
+                tokens_before INTEGER NOT NULL,
+                tokens_after INTEGER NOT NULL,
+                summary_usage_json TEXT NOT NULL,
+                invalidated_at TEXT,
+                invalidated_reason TEXT,
+                PRIMARY KEY (session_key, generation),
+                UNIQUE (session_key, source_ref)
+            )
+            """
+        )
+        connection.execute(
+            "CREATE INDEX idx_session_compactions_active ON "
+            "session_compactions(session_key, invalidated_at, generation)"
+        )
+        if with_row:
+            connection.execute(
+                """
+                INSERT INTO session_compactions (
+                    session_key, generation, parent_generation, created_at,
+                    trigger, summary_format_version, summary, source_ref,
+                    source_from_seq, consolidated_through_seq,
+                    source_message_ids_json, retained_tail_json,
+                    model_runtime_id, model, context_window, threshold_tokens,
+                    hard_input_tokens, keep_recent_tokens, tokens_before,
+                    tokens_after, summary_usage_json
+                ) VALUES (
+                    'session', 1, 0, '2026-08-08T00:00:00+00:00',
+                    'soft_limit', 1, 'summary', 'source:1',
+                    0, 0, '["m0"]', '[]', 'runtime', 'model', 100,
+                    74, 90, 20, 80, 40, '{}'
+                )
+                """
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _run(module, workspace: Path) -> None:
+    config = workspace.parent / "config.toml"
+    config.write_text("", encoding="utf-8")
+    with bind_migration_context(config_path=config, workspace=workspace):
+        module.add_source_plan_digest(None)
+
+
+def _backup_root(workspace: Path) -> Path:
+    roots = sorted((workspace / "backups/session-compaction-source-plan-digest").iterdir())
+    assert len(roots) == 1
+    return roots[0]
+
+
+def test_empty_legacy_ledger_is_rebuilt_to_final_digest_schema(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sessions = workspace / "sessions.db"
+    _create_legacy_db(sessions, with_row=False)
+
+    _run(module, workspace)
+
+    connection = sqlite3.connect(sessions)
+    try:
+        columns = [
+            row[1] for row in connection.execute("PRAGMA table_info(session_compactions)")
+        ]
+        assert "source_plan_digest" in columns
+        assert connection.execute(
+            "SELECT COUNT(1) FROM session_compactions"
+        ).fetchone() == (0,)
+        table_sql = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='session_compactions'"
+        ).fetchone()[0]
+        assert "source_plan_digest TEXT NOT NULL" in table_sql
+        assert "length(source_plan_digest) = 64" in table_sql
+        assert {
+            row[1] for row in connection.execute("PRAGMA index_list(session_compactions)")
+        } >= {"idx_session_compactions_active"}
+        assert connection.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        connection.close()
+
+    manifest = json.loads((_backup_root(workspace) / "manifest.json").read_text())
+    assert manifest["sqlite_integrity"] == "ok"
+
+
+def test_legacy_rows_without_digest_fail_loud_and_preserve_backup(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sessions = workspace / "sessions.db"
+    _create_legacy_db(sessions, with_row=True)
+    before = sqlite3.connect(sessions)
+    try:
+        before_row = before.execute(
+            "SELECT source_ref, summary FROM session_compactions"
+        ).fetchall()
+    finally:
+        before.close()
+
+    with pytest.raises(RuntimeError, match="缺少 source_plan_digest 且已有数据"):
+        _run(module, workspace)
+
+    connection = sqlite3.connect(sessions)
+    try:
+        assert connection.execute(
+            "SELECT source_ref, summary FROM session_compactions"
+        ).fetchall() == before_row
+        assert "source_plan_digest" not in {
+            row[1] for row in connection.execute("PRAGMA table_info(session_compactions)")
+        }
+        assert connection.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        connection.close()
+
+    backup_root = _backup_root(workspace)
+    manifest = json.loads((backup_root / "manifest.json").read_text())
+    assert manifest["sqlite_integrity"] == "ok"
+    archived = sqlite3.connect(backup_root / manifest["backup"])
+    try:
+        assert archived.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+        assert archived.execute(
+            "SELECT source_ref, summary FROM session_compactions"
+        ).fetchall() == before_row
+    finally:
+        archived.close()
+
+
+def test_existing_final_schema_rejects_invalid_digest_rows(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sessions = workspace / "sessions.db"
+    _create_legacy_db(sessions, with_row=False)
+    _run(module, workspace)
+
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute("PRAGMA ignore_check_constraints = ON")
+        connection.execute(
+            """
+            INSERT INTO session_compactions (
+                session_key, generation, parent_generation, created_at,
+                trigger, summary_format_version, summary, source_ref,
+                source_plan_digest, source_from_seq, consolidated_through_seq,
+                source_message_ids_json, retained_tail_json,
+                model_runtime_id, model, context_window, threshold_tokens,
+                hard_input_tokens, keep_recent_tokens, tokens_before,
+                tokens_after, summary_usage_json
+            ) VALUES (
+                'session', 1, 0, '2026-08-08T00:00:00+00:00',
+                'soft_limit', 1, 'summary', 'source:1', '', 0, 0,
+                '["m0"]', '[]', 'runtime', 'model', 100, 74, 90, 20,
+                80, 40, '{}'
+            )
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    connection = sqlite3.connect(sessions)
+    try:
+        with pytest.raises(RuntimeError, match="source_plan_digest 非法"):
+            module._validate_digest_values(connection)
+    finally:
+        connection.close()

--- a/tests/test_session_context_compaction_migration.py
+++ b/tests/test_session_context_compaction_migration.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import yoyo
+
+from agent.migrations.context import bind_migration_context
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+_MIGRATION_PATH = (
+    _PROJECT_ROOT
+    / "migrations"
+    / "yoyo"
+    / "20260807_01_session_context_compaction_ledger.py"
+)
+
+
+def _load_migration():
+    """Load the additive migration callback without wrapping it in Yoyo."""
+
+    spec = importlib.util.spec_from_file_location(
+        "session_context_compaction_migration_under_test",
+        _MIGRATION_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"无法加载迁移: {_MIGRATION_PATH}")
+    original_step = yoyo.step
+    yoyo.step = lambda callback: callback  # type: ignore[assignment]
+    try:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        yoyo.step = original_step
+    return module
+
+
+def _create_sessions(path: Path, *, cursor: object = 9) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE sessions ("
+            "key TEXT PRIMARY KEY, last_consolidated INTEGER NOT NULL)"
+        )
+        connection.execute(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, body TEXT NOT NULL)"
+        )
+        connection.execute("INSERT INTO sessions VALUES ('chat', ?)", (cursor,))
+        connection.execute("INSERT INTO messages VALUES ('m1', 'preserve me')")
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _run(module, config: Path, workspace: Path) -> None:
+    with bind_migration_context(config_path=config, workspace=workspace):
+        module.add_session_compaction_ledger(None)
+
+
+def _latest_backup(workspace: Path) -> Path:
+    roots = sorted((workspace / "backups/session-context-compaction-ledger").iterdir())
+    assert len(roots) == 1
+    return roots[0]
+
+
+def test_additive_ledger_preserves_config_recent_cursor_and_messages(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    (workspace / "memory").mkdir(parents=True)
+    config = tmp_path / "config.toml"
+    original_config = b"memory_window = 12\n[llm]\neffective_context_percent = 0.9\n"
+    config.write_bytes(original_config)
+    recent = workspace / "memory/RECENT_CONTEXT.md"
+    original_recent = b"recent projection\n"
+    recent.write_bytes(original_recent)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+
+    _run(module, config, workspace)
+
+    assert config.read_bytes() == original_config
+    assert recent.read_bytes() == original_recent
+    connection = sqlite3.connect(sessions)
+    try:
+        assert connection.execute(
+            "SELECT last_consolidated FROM sessions WHERE key = 'chat'"
+        ).fetchone() == (9,)
+        assert connection.execute("SELECT body FROM messages").fetchall() == [
+            ("preserve me",)
+        ]
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'session_compactions'"
+        ).fetchone() == ("session_compactions",)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM session_compactions"
+        ).fetchone() == (0,)
+    finally:
+        connection.close()
+
+    backup = _latest_backup(workspace)
+    manifest = json.loads((backup / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["sqlite_integrity"] == "ok"
+    archived = sqlite3.connect(backup / manifest["backup"])
+    try:
+        assert archived.execute(
+            "SELECT last_consolidated FROM sessions"
+        ).fetchone() == (9,)
+        assert archived.execute("SELECT body FROM messages").fetchall() == [
+            ("preserve me",)
+        ]
+        assert archived.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        archived.close()
+
+
+def test_existing_ledger_is_only_validated_and_not_rewritten(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_text("current = true\n", encoding="utf-8")
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions, cursor=3)
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute("""
+            CREATE TABLE session_compactions (
+                session_key TEXT NOT NULL,
+                generation INTEGER NOT NULL,
+                parent_generation INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                trigger TEXT NOT NULL,
+                summary_format_version INTEGER NOT NULL,
+                summary TEXT NOT NULL,
+                source_ref TEXT NOT NULL,
+                source_from_seq INTEGER NOT NULL,
+                consolidated_through_seq INTEGER NOT NULL,
+                source_message_ids_json TEXT NOT NULL,
+                retained_tail_json TEXT NOT NULL,
+                model_runtime_id TEXT NOT NULL,
+                model TEXT NOT NULL,
+                context_window INTEGER NOT NULL,
+                threshold_tokens INTEGER NOT NULL,
+                hard_input_tokens INTEGER NOT NULL,
+                keep_recent_tokens INTEGER NOT NULL,
+                tokens_before INTEGER NOT NULL,
+                tokens_after INTEGER NOT NULL,
+                summary_usage_json TEXT NOT NULL,
+                invalidated_at TEXT,
+                invalidated_reason TEXT,
+                PRIMARY KEY (session_key, generation),
+                UNIQUE (session_key, source_ref)
+            )
+            """)
+        connection.execute(
+            "INSERT INTO session_compactions "
+            "(session_key, generation, created_at, trigger, summary_format_version, "
+            "summary, source_ref, source_from_seq, consolidated_through_seq, "
+            "source_message_ids_json, retained_tail_json, model_runtime_id, model, "
+            "context_window, threshold_tokens, hard_input_tokens, keep_recent_tokens, "
+            "tokens_before, tokens_after, summary_usage_json) "
+            "VALUES ('chat', 1, 'now', 'manual', 1, 'summary', 'ref', 0, 0, '[]', '[]', "
+            "'runtime', 'model', 1, 1, 1, 1, 1, 1, '{}')"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    _run(module, config, workspace)
+
+    connection = sqlite3.connect(sessions)
+    try:
+        assert connection.execute(
+            "SELECT last_consolidated FROM sessions"
+        ).fetchone() == (3,)
+        assert connection.execute(
+            "SELECT source_ref, summary FROM session_compactions"
+        ).fetchall() == [("ref", "summary")]
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index' "
+            "AND name = 'idx_session_compactions_active'"
+        ).fetchone() == ("idx_session_compactions_active",)
+    finally:
+        connection.close()
+
+
+def test_invalid_existing_ledger_fails_before_partial_publish(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_text("current = true\n", encoding="utf-8")
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute(
+            "CREATE TABLE session_compactions (session_key TEXT NOT NULL)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(RuntimeError, match="缺少列"):
+        _run(module, config, workspace)
+
+    connection = sqlite3.connect(sessions)
+    try:
+        assert connection.execute(
+            "PRAGMA table_info(session_compactions)"
+        ).fetchall() == [(0, "session_key", "TEXT", 1, None, 0)]
+        assert connection.execute(
+            "SELECT last_consolidated FROM sessions"
+        ).fetchone() == (9,)
+    finally:
+        connection.close()

--- a/tests/test_session_mutation_audit_migration.py
+++ b/tests/test_session_mutation_audit_migration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from agent.migrations.runner import MigrationRunner
+
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+
+
+def _create_sessions(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE sessions ("
+            "key TEXT PRIMARY KEY, last_consolidated INTEGER NOT NULL)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_audit_migration_publishes_manifest_schema_and_indexes(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    _create_sessions(workspace / "sessions.db")
+
+    outcome = MigrationRunner(
+        repo_root=_PROJECT_ROOT,
+        config_path=root / "config.toml",
+        workspace=workspace,
+    ).run()
+
+    assert outcome.migrations[-1] == "20260808_01_session_mutation_audits"
+    connection = sqlite3.connect(workspace / "sessions.db")
+    try:
+        expected = {
+            "session_delete_audits": {
+                "audit_id",
+                "targets_json",
+                "message_ids_json",
+                "compactions_json",
+                "action_source",
+                "cascade",
+                "backup_path",
+                "started_at",
+                "completed_at",
+                "result",
+                "deleted_count",
+                "error",
+            },
+            "session_source_mutation_audits": {
+                "audit_id",
+                "operation",
+                "session_key",
+                "message_ids_json",
+                "action_source",
+                "backup_path",
+                "completed_at",
+            },
+        }
+        for table, columns in expected.items():
+            actual = {
+                row[1]
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            }
+            assert actual == columns
+        indexes = {
+            row[1]
+            for row in connection.execute(
+                "SELECT type, name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+        assert {
+            "idx_session_delete_audits_time",
+            "idx_source_mutation_audits_lookup",
+        } <= indexes
+    finally:
+        connection.close()
+
+
+def test_audit_migration_rejects_incompatible_existing_table(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    connection = sqlite3.connect(sessions)
+    try:
+        connection.execute(
+            "CREATE TABLE session_source_mutation_audits (audit_id TEXT PRIMARY KEY)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    runner = MigrationRunner(
+        repo_root=_PROJECT_ROOT,
+        config_path=root / "config.toml",
+        workspace=workspace,
+    )
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        runner.run()
+    if runner.ledger_path.exists():
+        ledger = sqlite3.connect(runner.ledger_path)
+        try:
+            applied = {
+                row[0]
+                for row in ledger.execute(
+                    "SELECT migration_id FROM _yoyo_migration"
+                )
+            }
+        finally:
+            ledger.close()
+        assert "20260808_01_session_mutation_audits" not in applied

--- a/tests/test_session_mutation_audit_migration.py
+++ b/tests/test_session_mutation_audit_migration.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
 import sqlite3
+import stat
 from pathlib import Path
 
 import pytest
 
+import agent.migrations.session_db_backup as session_db_backup
 from agent.migrations.runner import MigrationRunner
 
 
@@ -23,6 +26,35 @@ def _create_sessions(path: Path) -> None:
         connection.close()
 
 
+_DELETE_AUDIT_TABLE = """
+CREATE TABLE session_delete_audits (
+    audit_id TEXT,
+    targets_json TEXT NOT NULL,
+    message_ids_json TEXT NOT NULL,
+    compactions_json TEXT NOT NULL,
+    action_source TEXT NOT NULL,
+    cascade INTEGER NOT NULL CHECK (cascade IN (0, 1)),
+    backup_path TEXT,
+    started_at TEXT NOT NULL,
+    completed_at TEXT NOT NULL,
+    result TEXT NOT NULL,
+    deleted_count INTEGER NOT NULL,
+    error TEXT
+)
+"""
+
+
+def _create_table(path: Path, sql: str, index_sql: str | None = None) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(sql)
+        if index_sql is not None:
+            connection.execute(index_sql)
+        connection.commit()
+    finally:
+        connection.close()
+
+
 def test_audit_migration_publishes_manifest_schema_and_indexes(tmp_path: Path) -> None:
     root = tmp_path / "state"
     workspace = root / "workspace"
@@ -35,7 +67,7 @@ def test_audit_migration_publishes_manifest_schema_and_indexes(tmp_path: Path) -
         workspace=workspace,
     ).run()
 
-    assert outcome.migrations[-1] == "20260808_01_session_mutation_audits"
+    assert "20260808_01_session_mutation_audits" in outcome.migrations
     connection = sqlite3.connect(workspace / "sessions.db")
     try:
         expected = {
@@ -81,6 +113,19 @@ def test_audit_migration_publishes_manifest_schema_and_indexes(tmp_path: Path) -
         } <= indexes
     finally:
         connection.close()
+    backups = sorted(
+        (workspace / "backups/session-mutation-audits").iterdir()
+    )
+    assert len(backups) == 1
+    manifest = json.loads((backups[0] / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["sqlite_integrity"] == "ok"
+    assert stat.S_IMODE((backups[0] / "sessions.db").stat().st_mode) == 0o600
+    assert stat.S_IMODE((backups[0] / "manifest.json").stat().st_mode) == 0o600
+    archived = sqlite3.connect(backups[0] / "sessions.db")
+    try:
+        assert archived.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        archived.close()
 
 
 def test_audit_migration_rejects_incompatible_existing_table(tmp_path: Path) -> None:
@@ -105,6 +150,16 @@ def test_audit_migration_rejects_incompatible_existing_table(tmp_path: Path) -> 
     )
     with pytest.raises(RuntimeError, match="schema lineage"):
         runner.run()
+    restored = sqlite3.connect(sessions)
+    try:
+        assert restored.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'session_delete_audits'"
+        ).fetchone() is None
+    finally:
+        restored.close()
+    backups = sorted((workspace / "backups/session-mutation-audits").iterdir())
+    assert len(backups) == 1
     if runner.ledger_path.exists():
         ledger = sqlite3.connect(runner.ledger_path)
         try:
@@ -117,3 +172,91 @@ def test_audit_migration_rejects_incompatible_existing_table(tmp_path: Path) -> 
         finally:
             ledger.close()
         assert "20260808_01_session_mutation_audits" not in applied
+
+
+def test_audit_migration_rejects_wrong_primary_key(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    _create_table(sessions, _DELETE_AUDIT_TABLE)
+
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        MigrationRunner(
+            repo_root=_PROJECT_ROOT,
+            config_path=root / "config.toml",
+            workspace=workspace,
+        ).run()
+
+
+def test_audit_migration_rejects_wrong_named_index(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    _create_table(
+        sessions,
+        _DELETE_AUDIT_TABLE.replace("audit_id TEXT,", "audit_id TEXT PRIMARY KEY,"),
+        "CREATE INDEX idx_session_delete_audits_time "
+        "ON session_delete_audits(audit_id, completed_at)",
+    )
+
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        MigrationRunner(
+            repo_root=_PROJECT_ROOT,
+            config_path=root / "config.toml",
+            workspace=workspace,
+        ).run()
+
+
+def test_audit_migration_rejects_unknown_extra_index(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    sessions = workspace / "sessions.db"
+    _create_sessions(sessions)
+    _create_table(
+        sessions,
+        _DELETE_AUDIT_TABLE.replace("audit_id TEXT,", "audit_id TEXT PRIMARY KEY,"),
+        "CREATE INDEX extra_delete_audit_index "
+        "ON session_delete_audits(audit_id)",
+    )
+
+    with pytest.raises(RuntimeError, match="schema lineage"):
+        MigrationRunner(
+            repo_root=_PROJECT_ROOT,
+            config_path=root / "config.toml",
+            workspace=workspace,
+        ).run()
+
+
+def test_sqlite_backup_failure_keeps_published_evidence_and_cleans_temps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "sessions.db"
+    connection = sqlite3.connect(source)
+    try:
+        connection.execute("CREATE TABLE sessions (key TEXT PRIMARY KEY)")
+        connection.commit()
+    finally:
+        connection.close()
+    backup_root = tmp_path / "backups"
+
+    def fail_after_publish(_path: Path) -> None:
+        raise RuntimeError("forced directory fsync failure")
+
+    monkeypatch.setattr(session_db_backup, "_fsync_directory", fail_after_publish)
+    with pytest.raises(RuntimeError, match="forced directory fsync failure"):
+        session_db_backup.backup_sqlite_database(
+            source,
+            backup_root,
+            migration="test-backup",
+        )
+
+    assert (backup_root / "sessions.db").is_file()
+    assert (backup_root / "manifest.json").is_file()
+    assert not list(backup_root.glob("*.tmp"))
+    assert not list(backup_root.glob(".*.tmp"))


### PR DESCRIPTION
## 问题与结果

- 解决的问题：为每个 session 增加可恢复的 compaction generation、source provenance、prepare fence 与 mutation audit 持久化底座。
- 用户可见结果：本层没有运行时行为变化；SessionDB 获得后续 runtime 可使用的 immutable ledger 与受约束 Store API。
- 本 PR 不处理：provider-call Gate、Markdown consolidation、cursor 激活、旧配置/API/RECENT_CONTEXT 退役。

## Change intent

- `change_type`：`migration`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：`session/store.py`、SessionDB Yoyo migrations 与对应测试。
- `runtime_patch`：`none`
- `runtime_patch_reason`：新增 Store API 在本层未接入生产 provider path。
- `authoritative_state_owner`：SessionStore/`sessions.db` 与 Yoyo migration runner。
- `client_only_alternative`：无；客户端不能拥有 SessionDB schema。
- 关联不变量：messages/tool evidence 正常路径只追加；generation 单调；source_ref 唯一；prepare 阻断 source mutation；迁移不调用 LLM。
- `protected_state`：既有 sessions/messages/turns、legacy cursor、config、RECENT_CONTEXT 与 migration history。
- 允许的副作用：verified SQLite backup；additive ledger/audit/prepare/digest DDL。
- 禁止的副作用：推进 cursor、修改 config/RECENT_CONTEXT、写 Markdown/receipt、调用 provider、删除旧 API。

## 改动范围

- 主要文件：`session/store.py`、`agent/migrations/session_db_backup.py`、`migrations/yoyo/20260807_01_*`、`20260808_01_*`、`20260808_02_*`、`20260808_04_*` 及直接测试。
- 配置或迁移影响：L01 → U01 → P02 → D04；全部为 SessionDB additive migration。D04 对非空且缺 digest 的未知中间 schema fail-loud，不猜测回填。
- 已知 schema lineage 与最终 schema identity：legacy ledger 先建立；D04 增加 non-empty lowercase SHA-256 `source_plan_digest`；prepare 以 `(session_key,generation)` 为主键并对 `(session_key,source_ref)` 唯一。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：本层不改协议/provider；HEAD `958e2599`。
- 回滚方式：代码回到 `origin/main@167bb051`；持久状态使用 migration 生成的 verified SQLite backup，代码回滚不删除新增表或既有正文。

## 验证

- [x] 相关 targeted tests 已通过：45 passed，覆盖 L01/U01/P02/D04 与 SessionStore。
- [x] Python 类型检查或前端 typecheck/lint 已通过；production/tests/Python SDK 三套 Pyright 均为 0 errors。
- [x] 本 PR 的完整远端 CI 已通过：change-impact-gate、contract、mobile-plugin-contract-gate、locked-runtime、check-and-test、docker-control-gate、runtime-extension-gate。
- [ ] 本层未单独执行本地累计 `python docker/debug/gate.py run --base origin/main`。
- `sourceDigest`：本层未单独记录；不借用最终累计层证据。
- `planDigest`：本层未单独记录；不借用最终累计层证据。
- 真实设备证据：不适用；没有客户端或设备改动。
- 未运行项与原因：本层本地累计 Public Gate 未单独运行；最终累计 Gate 由 stack 3/3 记录。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；本层不涉及跨仓库/客户端。
- [x] 已完成事项已从 `NOW.md` 删除；本层只是 stack 1/3，最终对账留在 stack 3/3。

> Stack 1/3：本 PR → runtime cutover → legacy retirement。仓库使用 squash merge；合并本层后需要按新 main restack 后续两层。