### PR TITLE
refactor: 收敛 WebUI release epoch 命名，删除误导的 get_release_light

### DIFF
--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -283,7 +283,7 @@ class MobileGatewayRuntime:
         self._delivery_lock = asyncio.Lock()
         self._publication_monitor_task: asyncio.Task[None] | None = None
         self._publication_selection_digest = (
-            publication.get_release_light().selection_digest if publication is not None else None
+            publication.get_release(verify_integrity=False).selection_digest if publication is not None else None
         )
 
     @property
@@ -1207,7 +1207,7 @@ class MobileGatewayRuntime:
             if self.publication is None:
                 return
             try:
-                selection_digest = self.publication.get_release_light().selection_digest
+                selection_digest = self.publication.get_release(verify_integrity=False).selection_digest
                 if selection_digest == self._publication_selection_digest:
                     continue
                 await self.publish_webui_release_changed()
@@ -1795,7 +1795,7 @@ class MobileGatewayRuntime:
             if target is None or target.manifest_digest != manifest_digest:
                 raise MobileWebUiHttpError("resource_not_found", "manifest 不属于当前 target", status_code=404)
             body = canonical_manifest_bytes(self.publication.get_manifest(manifest_digest))
-            current = self.publication.get_release_light()
+            current = self.publication.get_release(verify_integrity=False)
             current_target = current.target(verified.target_key)
             if (
                 current.release_epoch != verified.release_epoch
@@ -1841,7 +1841,7 @@ class MobileGatewayRuntime:
             content = blob.path.read_bytes()
             if len(content) != blob.size_bytes or hashlib.sha256(content).hexdigest() != blob_digest:
                 raise RuntimeError("CAS blob 内容与 publication metadata 不一致")
-            current = self.publication.get_release_light()
+            current = self.publication.get_release(verify_integrity=False)
             current_target = current.target(verified.target_key)
             if (
                 current.release_epoch != verified.release_epoch

--- a/infra/mobile_webui/store.py
+++ b/infra/mobile_webui/store.py
@@ -111,7 +111,7 @@ class MobileWebUiStore:
             self._db.execute("PRAGMA synchronous = FULL")
             self._init_schema()
             self._ensure_server_id()
-            self._ensure_lineage_epoch()
+            self._ensure_release_epoch()
             self._recover_blob_temps()
             self._recover_backup_pending()
             self._recover_trash()
@@ -213,7 +213,7 @@ class MobileWebUiStore:
                 preview_id = generation_id
             sequence = int(state["sequence"]) + 1 if state is not None else 1
             selection_digest = self._selection_digest(stable_id, preview_id)
-            release_epoch = self._lineage_epoch()
+            release_epoch = self._release_epoch()
             self._db.execute(
                 """
                 INSERT INTO webui_release_state(singleton, release_epoch, sequence, stable_generation_id, preview_generation_id, selection_digest, updated_at)
@@ -318,23 +318,18 @@ class MobileWebUiStore:
     def get_release(self, *, verify_integrity: bool = True) -> ReleaseView:
         state = self._db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
         if state is None:
-            return ReleaseView(self.server_id, self._lineage_epoch(), 0, self._selection_digest(None, None), None, None)
-        lineage_epoch = self._lineage_epoch()
+            return ReleaseView(self.server_id, self._release_epoch(), 0, self._selection_digest(None, None), None, None)
+        release_epoch_now = self._release_epoch()
         state_epoch = str(state["release_epoch"])
         _require_canonical_uuid4(state_epoch, "release state release_epoch")
-        if state_epoch != lineage_epoch:
-            raise RuntimeError("release state release_epoch 与 lineage 不一致")
+        if state_epoch != release_epoch_now:
+            raise RuntimeError("release state release_epoch 与当前 release_epoch 不一致")
         stable = self._target_for_generation(state["stable_generation_id"], verify_integrity=verify_integrity)
         preview = self._target_for_generation(state["preview_generation_id"], verify_integrity=verify_integrity)
         expected = self._selection_digest(state["stable_generation_id"], state["preview_generation_id"])
         if expected != state["selection_digest"]:
             raise RuntimeError("release selection_digest 损坏")
         return ReleaseView(self.server_id, str(state["release_epoch"]), int(state["sequence"]), str(state["selection_digest"]), stable, preview)
-
-    def get_release_light(self) -> ReleaseView:
-        """重读 pointer/manifest identity，不扫描全部成员 blob；HTTP ticket 每请求使用。"""
-
-        return self.get_release(verify_integrity=False)
 
     def has_stable_publication_for_source(self, source_commit: str) -> bool:
         """判断一个 Core commit 是否曾成功成为 Stable，显式 rollback 不抹除该事实。"""
@@ -380,7 +375,7 @@ class MobileWebUiStore:
         return StoredBlob(digest, int(row["size_bytes"]), path)
 
     def verify_target_resource(self, *, target_key: str, selection_digest: str, resource_digest: str) -> StoredBlob:
-        release = self.get_release_light()
+        release = self.get_release(verify_integrity=False)
         if release.selection_digest != selection_digest:
             raise ReleaseSelectionChangedError("release selection 已变化")
         target = release.target(target_key)
@@ -651,11 +646,11 @@ class MobileWebUiStore:
             meta = db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
             if meta is None or str(meta["value"]) != server_id:
                 raise RuntimeError("WebUI backup server_id 不匹配")
-            lineage = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
-            if lineage is None:
+            release_row = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+            if release_row is None:
                 raise RuntimeError("WebUI backup 缺少 release_epoch")
-            lineage_epoch = str(lineage["value"])
-            _require_canonical_uuid4(lineage_epoch, "WebUI backup release_epoch")
+            release_epoch = str(release_row["value"])
+            _require_canonical_uuid4(release_epoch, "WebUI backup release_epoch")
             rows = db.execute("SELECT digest, size_bytes FROM webui_blobs").fetchall()
             for row in rows:
                 digest = str(row["digest"])
@@ -685,8 +680,8 @@ class MobileWebUiStore:
                     raise RuntimeError(f"WebUI backup generation files 损坏: {row['generation_id']}")
             state = db.execute("SELECT * FROM webui_release_state WHERE singleton = 1").fetchone()
             if state is not None:
-                if str(state["release_epoch"]) != str(lineage["value"]):
-                    raise RuntimeError("WebUI backup release epoch lineage 不一致")
+                if str(state["release_epoch"]) != str(release_row["value"]):
+                    raise RuntimeError("WebUI backup release epoch 与当前 release_epoch 不一致")
                 stable_id = state["stable_generation_id"]
                 preview_id = state["preview_generation_id"]
                 for pointer in (stable_id, preview_id):
@@ -711,7 +706,7 @@ class MobileWebUiStore:
                     if str(row["operation"]) != "restore" or row["generation_id"] is not None or int(row["stable"]) != 0 or int(row["preview"]) != 0:
                         raise RuntimeError("WebUI backup 无 release state 时仅允许空指针 restore journal")
             for expected_sequence, row in enumerate(journal_rows, start=1):
-                if int(row["sequence"]) != expected_sequence or str(row["release_epoch"]) != str(lineage["value"]):
+                if int(row["sequence"]) != expected_sequence or str(row["release_epoch"]) != str(release_row["value"]):
                     raise RuntimeError("WebUI backup journal sequence/epoch 不连续")
         finally:
             db.close()
@@ -895,19 +890,19 @@ class MobileWebUiStore:
         elif str(row["value"]) != self.server_id:
             raise ValueError("mobile WebUI publication store server_id 不匹配")
 
-    def _ensure_lineage_epoch(self) -> None:
+    def _ensure_release_epoch(self) -> None:
         row = self._db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
         if row is None:
             self._db.execute("INSERT INTO webui_meta(key, value) VALUES ('release_epoch', ?)", (str(uuid4()),))
             return
-        _require_canonical_uuid4(str(row["value"]), "WebUI release lineage epoch")
+        _require_canonical_uuid4(str(row["value"]), "WebUI release_epoch")
 
-    def _lineage_epoch(self) -> str:
+    def _release_epoch(self) -> str:
         row = self._db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
         if row is None:
-            raise RuntimeError("WebUI release lineage epoch 缺失")
+            raise RuntimeError("WebUI release_epoch 缺失")
         value = str(row["value"])
-        _require_canonical_uuid4(value, "WebUI release lineage epoch")
+        _require_canonical_uuid4(value, "WebUI release_epoch")
         return value
 
     @staticmethod
@@ -1134,10 +1129,10 @@ class MobileWebUiStore:
             meta = db.execute("SELECT value FROM webui_meta WHERE key = 'server_id'").fetchone()
             if meta is None or str(meta["value"]) != server_id:
                 raise RuntimeError("restore backup server_id 不匹配")
-            lineage = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
-            if lineage is None:
+            release_row = db.execute("SELECT value FROM webui_meta WHERE key = 'release_epoch'").fetchone()
+            if release_row is None:
                 raise RuntimeError("restore backup 缺少 release_epoch")
-            release_epoch = str(lineage["value"])
+            release_epoch = str(release_row["value"])
             _require_canonical_uuid4(release_epoch, "restore backup release_epoch")
             db.execute("BEGIN IMMEDIATE")
             try:
@@ -1417,7 +1412,7 @@ def _strict_json_loads(payload: bytes) -> object:
 
 
 def _require_canonical_uuid4(value: str, label: str) -> None:
-    """Require the persisted release lineage value to be canonical UUID4."""
+    """要求持久化的 release_epoch 值符合 UUID4 格式。"""
 
     try:
         parsed = UUID(value)

--- a/session/compaction_runtime.py
+++ b/session/compaction_runtime.py
@@ -73,7 +73,7 @@ class SessionCompactionPort(Protocol):
 
 
 class SessionCompactionRuntime:
-    """Own session projection plus Markdown/SQLite compaction commit saga."""
+    """拥有会话投影与 Markdown/SQLite 两阶段压缩提交。"""
 
     def __init__(
         self,

--- a/tests/mobile_webui/test_auto_publish.py
+++ b/tests/mobile_webui/test_auto_publish.py
@@ -87,7 +87,7 @@ def test_applied_main_is_a_noop(tmp_path: Path) -> None:
     )
     store._db.execute(
         "INSERT INTO webui_publication_journal(sequence, generation_id, operation, release_epoch, stable, preview, actor, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (1, "a" * 64, "publish", store._lineage_epoch(), 1, 0, "test", "2026-08-08T00:00:00Z"),
+        (1, "a" * 64, "publish", store._release_epoch(), 1, 0, "test", "2026-08-08T00:00:00Z"),
     )
     store.close()
 

--- a/tests/mobile_webui/test_gateway_runtime.py
+++ b/tests/mobile_webui/test_gateway_runtime.py
@@ -51,7 +51,7 @@ def _watcher_runtime(store: MobileWebUiStore) -> MobileGatewayRuntime:
     runtime = object.__new__(MobileGatewayRuntime)
     runtime.publication = store
     runtime._publication_monitor_task = None
-    runtime._publication_selection_digest = store.get_release_light().selection_digest
+    runtime._publication_selection_digest = store.get_release(verify_integrity=False).selection_digest
     runtime._connections = {}
     runtime._delivery_lock = asyncio.Lock()
     return runtime


### PR DESCRIPTION
## 问题与结果

- 解决的问题：WebUI 发布仓里同一概念两个名字（DB key `release_epoch` vs 方法 `_lineage_epoch`）；`get_release_light` 名字暗示性能优化，实际只是关闭完整性校验。
- 用户可见结果：`semantic_delta: none`，纯命名收敛与死方法删除。
- 本 PR 不处理：`sparse`（协议参数）、`canonical`（文档/协议合同词）、`_fact`（磁盘持久化文件名）、`logical_history_unit_count` 死函数（与后续历史投影收敛同文件，留给那个 PR）。

## Change intent

- `change_type`：`refactor`；`semantic_delta`：`none`
- `capability_owner`：`core`（mobile_webui 发布仓内部）
- `runtime_patch`：`none`
- `protected_state`：DB key `release_epoch`、wire 协议、`plugin-rollout-fact.json` 路径
- 允许的副作用：store.py 方法名与局部变量、错误消息文案、两个测试文件的引用
- 禁止的副作用：任何持久化值、协议键、文件路径变化

## 改动范围

- `infra/mobile_webui/store.py`：`_lineage_epoch`→`_release_epoch`、`_ensure_lineage_epoch`→`_ensure_release_epoch`；删除 `get_release_light`（调用点 `get_release(verify_integrity=False)`）；备份路径局部变量与错误消息去 lineage
- `infra/mobile_webui/http.py`、`infra/mobile_realtime/gateway.py`：`get_release_light()` 调用点替换
- `session/compaction_runtime.py`：docstring 去虚构 saga 概念
- `tests/mobile_webui/`：引用同步
- 配置或迁移影响：无；schema lineage：无变化；回滚：revert `e1dfd09e`

## 验证

- [x] targeted tests：95 passed（tests/mobile_webui/ 全部 + session compaction）
- [x] pyright `--level error` 与基线逐条 diff 一致，零新增
- [x] `python docker/debug/gate.py run --base origin/main`：GATE PASSED
- planDigest：`5d719c2874130a314e68450086eca27161a244efbba7633a5f4ec1639bb53147`
- 未运行项：无

## 工作手册

- [x] 已核对 projectneed、决策、NOW；无长期语义变化，无需新增文档