### PR TITLE
refactor: 三份签名授权票据收敛到共享 signed_ticket 模块

### DIFF
--- a/infra/mobile_realtime/message_content_http.py
+++ b/infra/mobile_realtime/message_content_http.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
-import base64
-import binascii
-import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
-
 from infra.mobile_realtime.key_protection import LoadedKeyset
+from infra.mobile_realtime.signed_ticket import (
+    b64url,
+    decode_b64url,
+    require_exact_keys,
+    require_nonnegative_int,
+    require_positive_int,
+    require_text,
+    sign,
+    unix_seconds,
+    verify_signature,
+)
 from infra.mobile_realtime.storage import MobileRealtimeStorage
 
 _AUDIENCE = "mobile-message-content"
@@ -75,21 +79,21 @@ class MessageContentTicketIssuer:
             "byte_length": byte_length,
             "connection_epoch": connection_epoch,
             "device_id": device_id,
-            "exp": _unix_seconds(expires_at),
-            "iat": _unix_seconds(now),
+            "exp": unix_seconds(expires_at),
+            "iat": unix_seconds(now),
             "message_id": message_id,
             "server_id": self._keyset.manifest.server_id,
             "session_id": session_id,
             "sha256": sha256,
             "v": 1,
         }
-        payload = _canonical_json(claims)
-        signature = self._keyset.identity_private_key.sign(
-            payload,
-            ec.ECDSA(hashes.SHA256()),
-        )
         return MessageContentGrant(
-            ticket=f"{_b64url(payload)}.{_b64url(signature)}",
+            ticket=sign(
+                self._keyset,
+                claims,
+                label="message content ticket",
+                error_factory=MessageContentTicketError,
+            ),
             expires_at=expires_at,
         )
 
@@ -97,21 +101,13 @@ class MessageContentTicketIssuer:
         """验签、校验不可变正文身份并重新读取设备撤销状态。"""
 
         # 1. 在 HTTP 边界一次性校验结构、签名和 claims
-        parts = ticket.split(".")
-        if len(parts) != 2:
-            raise MessageContentTicketError("message content ticket 格式无效")
-        payload = _decode_b64url(parts[0])
-        signature = _decode_b64url(parts[1])
-        try:
-            self._keyset.identity_private_key.public_key().verify(
-                signature,
-                payload,
-                ec.ECDSA(hashes.SHA256()),
-            )
-        except InvalidSignature as error:
-            raise MessageContentTicketError("message content ticket 签名无效") from error
-        claims = _decode_claims(payload)
-        _require_exact_keys(
+        claims = verify_signature(
+            ticket,
+            self._keyset,
+            label="message content ticket",
+            error_factory=MessageContentTicketError,
+        )
+        require_exact_keys(
             claims,
             {
                 "aud",
@@ -126,22 +122,21 @@ class MessageContentTicketIssuer:
                 "sha256",
                 "v",
             },
+            label="message content ticket",
+            error_factory=MessageContentTicketError,
         )
         if claims["v"] != 1 or claims["aud"] != _AUDIENCE:
             raise MessageContentTicketError("message content ticket 版本或用途无效")
         if claims["server_id"] != self._keyset.manifest.server_id:
             raise MessageContentTicketError("message content ticket 不属于当前服务端")
-        device_id = _require_text(claims["device_id"], "device_id", 512)
-        connection_epoch = _require_positive_int(
-            claims["connection_epoch"],
-            "connection_epoch",
-        )
-        issued_at = _require_nonnegative_int(claims["iat"], "iat")
-        expires_at = _require_nonnegative_int(claims["exp"], "exp")
-        now_seconds = _unix_seconds(self._now())
+        device_id = require_text(claims["device_id"], "device_id", 512, label="message content ticket", error_factory=MessageContentTicketError)
+        connection_epoch = require_positive_int(claims["connection_epoch"], "connection_epoch", label="message content ticket", error_factory=MessageContentTicketError)
+        issued_at = require_nonnegative_int(claims["iat"], "iat", label="message content ticket", error_factory=MessageContentTicketError)
+        expires_at = require_nonnegative_int(claims["exp"], "exp", label="message content ticket", error_factory=MessageContentTicketError)
+        now_seconds = unix_seconds(self._now())
         if expires_at <= now_seconds or issued_at > now_seconds:
             raise MessageContentTicketError("message content ticket 已过期或尚未生效")
-        sha256 = _require_text(claims["sha256"], "sha256", 64).lower()
+        sha256 = require_text(claims["sha256"], "sha256", 64, label="message content ticket", error_factory=MessageContentTicketError).lower()
         if len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256):
             raise MessageContentTicketError("message content ticket sha256 无效")
 
@@ -152,9 +147,9 @@ class MessageContentTicketIssuer:
         return VerifiedMessageContentTicket(
             device_id=device_id,
             connection_epoch=connection_epoch,
-            session_id=_require_text(claims["session_id"], "session_id", 512),
-            message_id=_require_text(claims["message_id"], "message_id", 512),
-            byte_length=_require_nonnegative_int(claims["byte_length"], "byte_length"),
+            session_id=require_text(claims["session_id"], "session_id", 512, label="message content ticket", error_factory=MessageContentTicketError),
+            message_id=require_text(claims["message_id"], "message_id", 512, label="message content ticket", error_factory=MessageContentTicketError),
+            byte_length=require_nonnegative_int(claims["byte_length"], "byte_length", label="message content ticket", error_factory=MessageContentTicketError),
             sha256=sha256,
         )
 
@@ -167,93 +162,6 @@ class MessageContentTicketIssuer:
 
 def format_message_content_expiry(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _canonical_json(value: object) -> bytes:
-    try:
-        return json.dumps(
-            value,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    except (TypeError, ValueError) as error:
-        raise MessageContentTicketError("message content ticket 无法规范化") from error
-
-
-def _decode_claims(payload: bytes) -> dict[str, object]:
-    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
-        result: dict[str, object] = {}
-        for key, value in pairs:
-            if key in result:
-                raise MessageContentTicketError(f"message content ticket 字段重复: {key}")
-            result[key] = value
-        return result
-
-    def reject_constant(value: str) -> None:
-        raise MessageContentTicketError(f"message content ticket 包含非标准常量: {value}")
-
-    try:
-        claims = json.loads(
-            payload,
-            object_pairs_hook=unique_object,
-            parse_constant=reject_constant,
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise MessageContentTicketError("message content ticket claims 无效") from error
-    if not isinstance(claims, dict):
-        raise MessageContentTicketError("message content ticket claims 必须是对象")
-    return claims
-
-
-def _decode_b64url(value: str) -> bytes:
-    if not value:
-        raise MessageContentTicketError("message content ticket 段不能为空")
-    padding = "=" * (-len(value) % 4)
-    try:
-        decoded = base64.b64decode(
-            value + padding,
-            altchars=b"-_",
-            validate=True,
-        )
-    except (binascii.Error, ValueError) as error:
-        raise MessageContentTicketError("message content ticket Base64URL 无效") from error
-    if _b64url(decoded) != value:
-        raise MessageContentTicketError("message content ticket Base64URL 无效")
-    return decoded
-
-
-def _b64url(value: bytes) -> str:
-    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
-
-
-def _unix_seconds(value: datetime) -> int:
-    return int(value.timestamp())
-
-
-def _require_exact_keys(raw: dict[str, object], expected: set[str]) -> None:
-    if set(raw) != expected:
-        raise MessageContentTicketError("message content ticket claims 字段无效")
-
-
-def _require_text(value: object, field: str, max_length: int) -> str:
-    if not isinstance(value, str) or not 1 <= len(value) <= max_length:
-        raise MessageContentTicketError(f"message content ticket {field} 无效")
-    return value
-
-
-def _require_nonnegative_int(value: object, field: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-        raise MessageContentTicketError(f"message content ticket {field} 无效")
-    return value
-
-
-def _require_positive_int(value: object, field: str) -> int:
-    parsed = _require_nonnegative_int(value, field)
-    if parsed == 0:
-        raise MessageContentTicketError(f"message content ticket {field} 无效")
-    return parsed
 
 
 __all__ = [

--- a/infra/mobile_realtime/plugin_ui_http.py
+++ b/infra/mobile_realtime/plugin_ui_http.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
-import base64
-import binascii
 import hashlib
-import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
-
 from infra.mobile_realtime.key_protection import LoadedKeyset
+from infra.mobile_realtime.signed_ticket import (
+    canonical_json,
+    require_exact_keys,
+    require_nonnegative_int,
+    require_positive_int,
+    require_text,
+    sign,
+    unix_seconds,
+    verify_signature,
+)
 from infra.mobile_realtime.storage import MobileRealtimeStorage
 
 _AUDIENCE = "mobile-plugin-ui-query"
@@ -68,19 +71,19 @@ class PluginUiHttpTicketIssuer:
             "aud": _AUDIENCE,
             "connection_epoch": connection_epoch,
             "device_id": device_id,
-            "exp": _unix_seconds(expires_at),
-            "iat": _unix_seconds(now),
+            "exp": unix_seconds(expires_at),
+            "iat": unix_seconds(now),
             "request_sha256": plugin_ui_http_request_sha256(request_body),
             "server_id": self._keyset.manifest.server_id,
             "v": 1,
         }
-        payload = _canonical_json(claims)
-        signature = self._keyset.identity_private_key.sign(
-            payload,
-            ec.ECDSA(hashes.SHA256()),
-        )
         return PluginUiHttpGrant(
-            ticket=f"{_b64url(payload)}.{_b64url(signature)}",
+            ticket=sign(
+                self._keyset,
+                claims,
+                label="plugin UI HTTP ticket",
+                error_factory=PluginUiHttpTicketError,
+            ),
             expires_at=expires_at,
         )
 
@@ -93,21 +96,13 @@ class PluginUiHttpTicketIssuer:
         """验签、核对请求摘要与设备撤销状态，并返回已认证身份。"""
 
         # 1. token 结构、签名和 claims 都在 HTTP 信任边界一次性校验
-        parts = ticket.split(".")
-        if len(parts) != 2:
-            raise PluginUiHttpTicketError("plugin UI HTTP ticket 格式无效")
-        payload = _decode_b64url(parts[0])
-        signature = _decode_b64url(parts[1])
-        try:
-            self._keyset.identity_private_key.public_key().verify(
-                signature,
-                payload,
-                ec.ECDSA(hashes.SHA256()),
-            )
-        except InvalidSignature as error:
-            raise PluginUiHttpTicketError("plugin UI HTTP ticket 签名无效") from error
-        claims = _decode_claims(payload)
-        _require_exact_keys(
+        claims = verify_signature(
+            ticket,
+            self._keyset,
+            label="plugin UI HTTP ticket",
+            error_factory=PluginUiHttpTicketError,
+        )
+        require_exact_keys(
             claims,
             {
                 "aud",
@@ -119,19 +114,18 @@ class PluginUiHttpTicketIssuer:
                 "server_id",
                 "v",
             },
+            label="plugin UI HTTP ticket",
+            error_factory=PluginUiHttpTicketError,
         )
         if claims["v"] != 1 or claims["aud"] != _AUDIENCE:
             raise PluginUiHttpTicketError("plugin UI HTTP ticket 版本或用途无效")
         if claims["server_id"] != self._keyset.manifest.server_id:
             raise PluginUiHttpTicketError("plugin UI HTTP ticket 不属于当前服务端")
-        device_id = _require_text(claims["device_id"], "device_id", 512)
-        connection_epoch = _require_positive_int(
-            claims["connection_epoch"],
-            "connection_epoch",
-        )
-        issued_at = _require_nonnegative_int(claims["iat"], "iat")
-        expires_at = _require_nonnegative_int(claims["exp"], "exp")
-        now_seconds = _unix_seconds(self._now())
+        device_id = require_text(claims["device_id"], "device_id", 512, label="plugin UI HTTP ticket", error_factory=PluginUiHttpTicketError)
+        connection_epoch = require_positive_int(claims["connection_epoch"], "connection_epoch", label="plugin UI HTTP ticket", error_factory=PluginUiHttpTicketError)
+        issued_at = require_nonnegative_int(claims["iat"], "iat", label="plugin UI HTTP ticket", error_factory=PluginUiHttpTicketError)
+        expires_at = require_nonnegative_int(claims["exp"], "exp", label="plugin UI HTTP ticket", error_factory=PluginUiHttpTicketError)
+        now_seconds = unix_seconds(self._now())
         if expires_at <= now_seconds or issued_at > now_seconds:
             raise PluginUiHttpTicketError("plugin UI HTTP ticket 已过期或尚未生效")
         expected_digest = plugin_ui_http_request_sha256(request_body)
@@ -155,99 +149,17 @@ class PluginUiHttpTicketIssuer:
 
 
 def plugin_ui_http_request_sha256(request_body: dict[str, object]) -> str:
-    return hashlib.sha256(_canonical_json(request_body)).hexdigest()
+    return hashlib.sha256(
+        canonical_json(
+            request_body,
+            label="plugin UI HTTP 请求",
+            error_factory=PluginUiHttpTicketError,
+        )
+    ).hexdigest()
 
 
 def format_plugin_ui_http_expiry(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _canonical_json(value: object) -> bytes:
-    try:
-        return json.dumps(
-            value,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    except (TypeError, ValueError) as error:
-        raise PluginUiHttpTicketError("plugin UI HTTP 请求无法规范化") from error
-
-
-def _decode_claims(payload: bytes) -> dict[str, object]:
-    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
-        result: dict[str, object] = {}
-        for key, value in pairs:
-            if key in result:
-                raise PluginUiHttpTicketError(
-                    f"plugin UI HTTP ticket claims 字段重复: {key}"
-                )
-            result[key] = value
-        return result
-
-    def reject_constant(value: str) -> None:
-        raise PluginUiHttpTicketError(
-            f"plugin UI HTTP ticket claims 包含非标准常量: {value}"
-        )
-
-    try:
-        claims = json.loads(
-            payload,
-            object_pairs_hook=unique_object,
-            parse_constant=reject_constant,
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise PluginUiHttpTicketError("plugin UI HTTP ticket claims 无效") from error
-    if not isinstance(claims, dict):
-        raise PluginUiHttpTicketError("plugin UI HTTP ticket claims 必须是对象")
-    return claims
-
-
-def _decode_b64url(value: str) -> bytes:
-    if not value:
-        raise PluginUiHttpTicketError("plugin UI HTTP ticket 段不能为空")
-    padding = "=" * (-len(value) % 4)
-    try:
-        return base64.b64decode(
-            value + padding,
-            altchars=b"-_",
-            validate=True,
-        )
-    except (binascii.Error, ValueError) as error:
-        raise PluginUiHttpTicketError("plugin UI HTTP ticket Base64URL 无效") from error
-
-
-def _b64url(value: bytes) -> str:
-    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
-
-
-def _unix_seconds(value: datetime) -> int:
-    return int(value.timestamp())
-
-
-def _require_exact_keys(raw: dict[str, object], expected: set[str]) -> None:
-    if set(raw) != expected:
-        raise PluginUiHttpTicketError("plugin UI HTTP ticket claims 字段无效")
-
-
-def _require_text(value: object, field: str, max_length: int) -> str:
-    if not isinstance(value, str) or not 1 <= len(value) <= max_length:
-        raise PluginUiHttpTicketError(f"plugin UI HTTP ticket {field} 无效")
-    return value
-
-
-def _require_nonnegative_int(value: object, field: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-        raise PluginUiHttpTicketError(f"plugin UI HTTP ticket {field} 无效")
-    return value
-
-
-def _require_positive_int(value: object, field: str) -> int:
-    parsed = _require_nonnegative_int(value, field)
-    if parsed == 0:
-        raise PluginUiHttpTicketError(f"plugin UI HTTP ticket {field} 无效")
-    return parsed
 
 
 __all__ = [

--- a/infra/mobile_realtime/signed_ticket.py
+++ b/infra/mobile_realtime/signed_ticket.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Callable
+from datetime import datetime
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from infra.mobile_realtime.key_protection import LoadedKeyset
+
+ErrorFactory = Callable[[str], ValueError]
+
+
+class SignedTicketError(ValueError):
+    """表示签名授权票据不可接受。"""
+
+
+def canonical_json(
+    value: object,
+    *,
+    label: str,
+    error_factory: ErrorFactory = SignedTicketError,
+    ensure_ascii: bool = True,
+) -> bytes:
+    """把 claims 序列化为定序字节，供签名与摘要使用。"""
+
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=ensure_ascii,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise error_factory(f"{label} 无法规范化") from error
+
+
+def b64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def decode_b64url(value: str, *, label: str, error_factory: ErrorFactory = SignedTicketError) -> bytes:
+    if not value:
+        raise error_factory(f"{label} 段不能为空")
+    padding = "=" * (-len(value) % 4)
+    try:
+        decoded = base64.b64decode(
+            value + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+    except (binascii.Error, ValueError) as error:
+        raise error_factory(f"{label} Base64URL 无效") from error
+    if b64url(decoded) != value:
+        raise error_factory(f"{label} Base64URL 无效")
+    return decoded
+
+
+def decode_claims(payload: bytes, *, label: str, error_factory: ErrorFactory = SignedTicketError) -> dict[str, object]:
+    """严格解码 claims：拒绝重复字段与非标准常量。"""
+
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise error_factory(f"{label} 字段重复: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> None:
+        raise error_factory(f"{label} 包含非标准常量: {value}")
+
+    try:
+        claims = json.loads(
+            payload,
+            object_pairs_hook=unique_object,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise error_factory(f"{label} claims 无效") from error
+    if not isinstance(claims, dict):
+        raise error_factory(f"{label} claims 必须是对象")
+    return claims
+
+
+def unix_seconds(value: datetime) -> int:
+    return int(value.timestamp())
+
+
+def sign(
+    keyset: LoadedKeyset,
+    claims: dict[str, object],
+    *,
+    label: str,
+    error_factory: ErrorFactory = SignedTicketError,
+    ensure_ascii: bool = True,
+) -> str:
+    """规范化 claims、签名并拼装为 `payload.signature` 票据。"""
+
+    payload = canonical_json(claims, label=label, error_factory=error_factory, ensure_ascii=ensure_ascii)
+    signature = keyset.identity_private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+    return f"{b64url(payload)}.{b64url(signature)}"
+
+
+def verify_signature(
+    ticket: str,
+    keyset: LoadedKeyset,
+    *,
+    label: str,
+    error_factory: ErrorFactory = SignedTicketError,
+) -> dict[str, object]:
+    """拆分、验签并严格解码票据 claims。"""
+
+    parts = ticket.split(".")
+    if len(parts) != 2:
+        raise error_factory(f"{label} 格式无效")
+    payload = decode_b64url(parts[0], label=label, error_factory=error_factory)
+    signature = decode_b64url(parts[1], label=label, error_factory=error_factory)
+    try:
+        keyset.identity_private_key.public_key().verify(signature, payload, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature as error:
+        raise error_factory(f"{label} 签名无效") from error
+    return decode_claims(payload, label=label, error_factory=error_factory)
+
+
+def require_exact_keys(
+    raw: dict[str, object],
+    expected: set[str],
+    *,
+    label: str,
+    error_factory: ErrorFactory = SignedTicketError,
+) -> None:
+    if set(raw) != expected:
+        raise error_factory(f"{label} claims 字段无效")
+
+
+def require_text(
+    value: object,
+    field: str,
+    max_length: int,
+    *,
+    label: str,
+    error_factory: ErrorFactory = SignedTicketError,
+    reject_whitespace: bool = False,
+) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= max_length:
+        raise error_factory(f"{label} {field} 无效")
+    if reject_whitespace and any(char.isspace() for char in value):
+        raise error_factory(f"{label} {field} 无效")
+    return value
+
+
+def require_nonnegative_int(value: object, field: str, *, label: str, error_factory: ErrorFactory = SignedTicketError) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise error_factory(f"{label} {field} 无效")
+    return value
+
+
+def require_positive_int(value: object, field: str, *, label: str, error_factory: ErrorFactory = SignedTicketError) -> int:
+    parsed = require_nonnegative_int(value, field, label=label, error_factory=error_factory)
+    if parsed == 0:
+        raise error_factory(f"{label} {field} 无效")
+    return parsed
+
+
+def require_digest(value: object, field: str, *, label: str, error_factory: ErrorFactory = SignedTicketError) -> str:
+    if not isinstance(value, str) or len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise error_factory(f"{label} {field} 无效")
+    return value

--- a/infra/mobile_webui/http.py
+++ b/infra/mobile_webui/http.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-import base64
-import binascii
-import hashlib
-import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
-
 from infra.mobile_realtime.key_protection import LoadedKeyset
+from infra.mobile_realtime.signed_ticket import (
+    require_digest,
+    require_nonnegative_int,
+    require_positive_int,
+    require_text,
+    sign,
+    unix_seconds,
+    verify_signature,
+)
 from infra.mobile_realtime.storage import MobileRealtimeStorage
 from infra.mobile_webui.store import (
     MobileWebUiStore,
@@ -90,8 +91,8 @@ class WebUiTicketIssuer:
             "aud": AUDIENCE,
             "connection_epoch": connection_epoch,
             "device_id": device_id,
-            "exp": _unix_seconds(expires_at),
-            "iat": _unix_seconds(now),
+            "exp": unix_seconds(expires_at),
+            "iat": unix_seconds(now),
             "manifest_digest": target.manifest_digest,
             "generation_id": target.generation_id,
             "release_epoch": release.release_epoch,
@@ -100,10 +101,14 @@ class WebUiTicketIssuer:
             "target_key": target.target_key,
             "v": 1,
         }
-        payload = _canonical_json(claims)
-        signature = self._keyset.identity_private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
         return WebUiHttpGrant(
-            ticket=f"{_b64url(payload)}.{_b64url(signature)}",
+            ticket=sign(
+                self._keyset,
+                claims,
+                label="WebUI ticket",
+                error_factory=WebUiTicketError,
+                ensure_ascii=False,
+            ),
             expires_at=expires_at,
         )
 
@@ -117,16 +122,12 @@ class WebUiTicketIssuer:
         """验签后校验当前连接、发布 epoch 和 target 成员关系。"""
 
         # 1. 验证签名、claims 结构和时钟窗口
-        parts = ticket.split(".")
-        if len(parts) != 2:
-            raise WebUiTicketError("WebUI ticket 格式无效")
-        payload = _decode_b64url(parts[0])
-        signature = _decode_b64url(parts[1])
-        try:
-            self._keyset.identity_private_key.public_key().verify(signature, payload, ec.ECDSA(hashes.SHA256()))
-        except InvalidSignature as error:
-            raise WebUiTicketError("WebUI ticket 签名无效") from error
-        claims = _decode_claims(payload)
+        claims = verify_signature(
+            ticket,
+            self._keyset,
+            label="WebUI ticket",
+            error_factory=WebUiTicketError,
+        )
         expected = {
             "aud", "connection_epoch", "device_id", "exp", "iat",
             "generation_id", "manifest_digest", "release_epoch", "selection_digest", "server_id", "target_key", "v",
@@ -135,16 +136,16 @@ class WebUiTicketIssuer:
             raise WebUiTicketError("WebUI ticket claims 无效")
         if claims["server_id"] != self._keyset.manifest.server_id:
             raise WebUiTicketError("WebUI ticket 不属于当前服务端")
-        device_id = _require_text(claims["device_id"], "device_id")
-        connection_epoch = _require_positive_int(claims["connection_epoch"], "connection_epoch")
-        target_key = _require_text(claims["target_key"], "target_key")
-        release_epoch = _require_text(claims["release_epoch"], "release_epoch")
-        manifest_digest = _require_digest(claims["manifest_digest"], "manifest_digest")
-        generation_id = _require_digest(claims["generation_id"], "generation_id")
-        selection_digest = _require_digest(claims["selection_digest"], "selection_digest")
-        issued_at = _require_nonnegative_int(claims["iat"], "iat")
-        expires_at = _require_nonnegative_int(claims["exp"], "exp")
-        now = _unix_seconds(self._now())
+        device_id = require_text(claims["device_id"], "device_id", 512, label="WebUI ticket", error_factory=WebUiTicketError, reject_whitespace=True)
+        connection_epoch = require_positive_int(claims["connection_epoch"], "connection_epoch", label="WebUI ticket", error_factory=WebUiTicketError)
+        target_key = require_text(claims["target_key"], "target_key", 512, label="WebUI ticket", error_factory=WebUiTicketError, reject_whitespace=True)
+        release_epoch = require_text(claims["release_epoch"], "release_epoch", 512, label="WebUI ticket", error_factory=WebUiTicketError, reject_whitespace=True)
+        manifest_digest = require_digest(claims["manifest_digest"], "manifest_digest", label="WebUI ticket", error_factory=WebUiTicketError)
+        generation_id = require_digest(claims["generation_id"], "generation_id", label="WebUI ticket", error_factory=WebUiTicketError)
+        selection_digest = require_digest(claims["selection_digest"], "selection_digest", label="WebUI ticket", error_factory=WebUiTicketError)
+        issued_at = require_nonnegative_int(claims["iat"], "iat", label="WebUI ticket", error_factory=WebUiTicketError)
+        expires_at = require_nonnegative_int(claims["exp"], "exp", label="WebUI ticket", error_factory=WebUiTicketError)
+        now = unix_seconds(self._now())
         if expires_at <= now or issued_at > now or expires_at - issued_at > int(self._ttl.total_seconds()) + 1:
             raise WebUiTicketError("WebUI ticket 已过期或 TTL 无效")
 
@@ -156,7 +157,7 @@ class WebUiTicketIssuer:
             raise WebUiTicketError("WebUI ticket connection_epoch 已失效")
 
         # 3. 发布指针和请求 digest 都必须属于 ticket 绑定的 target
-        release = self._publication.get_release_light()
+        release = self._publication.get_release(verify_integrity=False)
         target = release.target(target_key)
         if release.release_epoch != release_epoch or release.selection_digest != selection_digest or target is None or target.manifest_digest != manifest_digest or target.generation_id != generation_id:
             raise WebUiTicketError("WebUI ticket 对应的 release 已变化", code="target_changed")
@@ -222,61 +223,6 @@ def parse_single_range(header: str | None, total: int) -> tuple[int, int] | None
     if end - start + 1 > MAX_RANGE_BYTES:
         raise WebUiTicketError("Range 超过 8 MiB 上限")
     return start, end
-
-
-def _canonical_json(value: dict[str, object]) -> bytes:
-    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
-def _decode_claims(payload: bytes) -> dict[str, object]:
-    try:
-        value = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise WebUiTicketError("WebUI ticket claims 不是 JSON") from error
-    if not isinstance(value, dict):
-        raise WebUiTicketError("WebUI ticket claims 必须是 object")
-    return value
-
-
-def _b64url(value: bytes) -> str:
-    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
-
-
-def _decode_b64url(value: str) -> bytes:
-    try:
-        if not value or any(char not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_" for char in value):
-            raise ValueError
-        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
-    except (ValueError, binascii.Error) as error:
-        raise WebUiTicketError("WebUI ticket base64 无效") from error
-
-
-def _require_text(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value or len(value) > 512 or any(char.isspace() for char in value):
-        raise WebUiTicketError(f"{label} 无效")
-    return value
-
-
-def _require_positive_int(value: object, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        raise WebUiTicketError(f"{label} 无效")
-    return value
-
-
-def _require_nonnegative_int(value: object, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise WebUiTicketError(f"{label} 无效")
-    return value
-
-
-def _require_digest(value: object, label: str) -> str:
-    if not isinstance(value, str) or len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
-        raise WebUiTicketError(f"{label} 无效")
-    return value
-
-
-def _unix_seconds(value: datetime) -> int:
-    return int(value.astimezone(timezone.utc).timestamp())
 
 
 __all__ = [


### PR DESCRIPTION
## 问题与结果

- 解决的问题：同一「短期签名授权 + 有界 range 下载」概念在 `message_content_http.py` / `plugin_ui_http.py` / `mobile_webui/http.py` 三处实现，约 60% 代码同构（规范化 JSON、Base64URL 编解码、claims 解码、ECDSA 签名/验签、字段校验 helper 各复制一份）。
- 用户可见结果：`semantic_delta: none`，三份 helper 收敛为一份共享模块，公开接口、错误类型与错误消息不变。
- 本 PR 不处理：两套 range 解析（可选 vs 强制）语义差异需先定合同；`gateway.py` 的 release 当前性三份重复检查（涉及每请求读盘行为，留待单独 PR）。

## Change intent

- `change_type`：`refactor`；`semantic_delta`：`none`
- `capability_owner`：`core`（移动端 HTTP 票据）
- `runtime_patch`：`none`
- `protected_state`：三个域的错误类与消息文本、wire claims 字段、票据格式（`payload.signature`）、TTL 语义
- 允许的副作用：内部 helper 收敛、`signed_ticket.py` 新增
- 禁止的副作用：票据格式、claims 键、错误消息、TTL 范围变化

## 改动范围

- 新增 `infra/mobile_realtime/signed_ticket.py`：`canonical_json` / `b64url` / `decode_b64url` / `decode_claims` / `sign` / `verify_signature` / `require_*`，错误类与 label 按域传入；`ensure_ascii` 与空白符拒绝语义参数化以保留 webui 行为
- `infra/mobile_realtime/message_content_http.py`、`plugin_ui_http.py`、`infra/mobile_webui/http.py`：删除各自复制 helper，改用共享原语；域业务校验（aud/v/server_id、设备撤销重读、request sha256、release 指针核对）保留在域内
- 配置或迁移影响：无；回滚：revert `89a2f3dc`

## 验证

- [x] targeted tests：274 passed（tests/mobile_realtime/ + tests/mobile_webui/ 全部）
- [x] pyright `--level error` 与基线逐条 diff 一致，零新增
- [x] `python docker/debug/gate.py run --base origin/main`：GATE PASSED
- planDigest：`d7c84a37049d0566fdfed1b404c123add049311ce658857be0d6a34f599e161e`
- 未运行项：无

## 工作手册

- [x] 已核对 projectneed、决策、NOW；无长期语义变化，无需新增文档