### PR TITLE
refactor: attempt replay 格式收敛到单一 replay_format 模块

### DIFF
--- a/agent/control/replay_format.py
+++ b/agent/control/replay_format.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from agent.control.models import TurnItem, TurnItemKind, TurnRecord
+
+ATTEMPT_INTERRUPTED_MARKER = "[execution attempt interrupted]"
+
+METADATA_ATTEMPT_REPLAY = "_controlAttemptReplay"
+METADATA_PRIOR_TOOL_CHAIN = "_controlPriorToolChain"
+
+
+def replay_messages(
+    attempts: list[TurnRecord],
+    *,
+    tool_group_from_item: Callable[[TurnItem], dict[str, Any] | None],
+) -> list[dict[str, Any]]:
+    """把中断 attempt 的 items 投影为模型历史，仅供下一 attempt 使用。"""
+
+    messages: list[dict[str, Any]] = []
+    for attempt in attempts:
+        for item in attempt.items:
+            if item.kind is TurnItemKind.USER_MESSAGE:
+                content = item.data.get("content")
+                media = item.data.get("media", [])
+                if not isinstance(content, str):
+                    raise ValueError(f"turn user content 必须是字符串: {item.id}")
+                if not isinstance(media, list) or not all(
+                    isinstance(value, str) for value in media
+                ):
+                    raise ValueError(f"turn user media 必须是字符串数组: {item.id}")
+                if media:
+                    content = "\n".join(
+                        [
+                            content,
+                            "",
+                            "[附加媒体]",
+                            *(f"- {value}" for value in media),
+                        ]
+                    )
+                messages.append({"role": "user", "content": content})
+            elif item.kind is TurnItemKind.TOOL_CALL:
+                group = tool_group_from_item(item)
+                if group is None:
+                    continue
+                call = group["calls"][0]
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": group["text"],
+                        "tool_calls": [
+                            {
+                                "id": call["call_id"],
+                                "type": "function",
+                                "function": {
+                                    "name": call["name"],
+                                    "arguments": json.dumps(
+                                        call["arguments"], ensure_ascii=False
+                                    ),
+                                },
+                            }
+                        ],
+                    }
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call["call_id"],
+                        "content": call["result"],
+                    }
+                )
+        messages.append(
+            {
+                "role": "assistant",
+                "content": ATTEMPT_INTERRUPTED_MARKER,
+            }
+        )
+    return messages
+
+
+def split_replay_batches(
+    attempt_replay: list[dict[str, Any]],
+) -> tuple[list[list[dict[str, Any]]], list[dict[str, Any]]]:
+    """把 replay 拆成已闭合的工具批次和未触碰的尾部。"""
+
+    # 1. 每个 assistant tool call 之后必须有全部匹配结果。
+    batches: list[list[dict[str, Any]]] = []
+    batch_start = 0
+    cursor = 0
+    while cursor < len(attempt_replay):
+        message = attempt_replay[cursor]
+        raw_calls = message.get("tool_calls")
+        if message.get("role") != "assistant" or not isinstance(raw_calls, list):
+            cursor += 1
+            continue
+        call_ids = {
+            str(call.get("id"))
+            for call in raw_calls
+            if isinstance(call, dict) and isinstance(call.get("id"), str)
+        }
+        if not call_ids or len(call_ids) != len(raw_calls):
+            raise RuntimeError("control attempt replay tool call identity 无效")
+        result_ids: set[str] = set()
+        batch_end = cursor + 1
+        while batch_end < len(attempt_replay):
+            result = attempt_replay[batch_end]
+            if result.get("role") != "tool":
+                break
+            result_id = result.get("tool_call_id")
+            if not isinstance(result_id, str):
+                raise RuntimeError("control attempt replay tool result identity 无效")
+            result_ids.add(result_id)
+            batch_end += 1
+        if result_ids != call_ids:
+            # 不完整的尾部保持 pending，永不提升为 active。
+            if batches:
+                return batches, list(attempt_replay[batch_start:])
+            return [], list(attempt_replay)
+        batches.append(list(attempt_replay[batch_start:batch_end]))
+        batch_start = batch_end
+        cursor = batch_end
+
+    # 2. 中断标记和任何非工具后缀按顺序留在 pending。
+    return batches, list(attempt_replay[batch_start:])

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -20,6 +20,7 @@ from agent.control.errors import (
 from agent.control.events import TurnEvent
 from agent.control.ids import new_item_id, new_turn_id
 from agent.control.models import (
+    TurnRecord,
     TurnError,
     TurnItem,
     TurnItemKind,
@@ -27,6 +28,11 @@ from agent.control.models import (
     TurnRequest,
     TurnResult,
     TurnStatus,
+)
+from agent.control.replay_format import (
+    METADATA_ATTEMPT_REPLAY,
+    METADATA_PRIOR_TOOL_CHAIN,
+    replay_messages,
 )
 from agent.control.ports import (
     ControlExecutionResult,
@@ -225,7 +231,10 @@ class ConversationRuntime:
             turn_id = new_turn_id()
             previous_attempts = self._open_interaction_attempts(request.thread_id)
             prior_inputs = self._attempt_user_inputs(previous_attempts)
-            attempt_replay = self._attempt_replay_messages(previous_attempts)
+            attempt_replay = replay_messages(
+                previous_attempts,
+                tool_group_from_item=ConversationRuntime._tool_group_from_item,
+            )
             prior_tool_chain = self._attempt_tool_chain(previous_attempts)
             interaction_id = (
                 self._interaction_id(previous_attempts[-1])
@@ -441,73 +450,6 @@ class ConversationRuntime:
                     chain.append(group)
         return chain
 
-    @classmethod
-    def _attempt_replay_messages(
-        cls,
-        attempts: list[TurnRecord],
-    ) -> list[dict[str, Any]]:
-        """构造仅供下一 attempt 使用的模型历史，不写回 canonical messages。"""
-
-        messages: list[dict[str, Any]] = []
-        for attempt in attempts:
-            for item in attempt.items:
-                if item.kind is TurnItemKind.USER_MESSAGE:
-                    content = item.data.get("content")
-                    media = item.data.get("media", [])
-                    if not isinstance(content, str):
-                        raise ValueError(f"turn user content 必须是字符串: {item.id}")
-                    if not isinstance(media, list) or not all(
-                        isinstance(value, str) for value in media
-                    ):
-                        raise ValueError(f"turn user media 必须是字符串数组: {item.id}")
-                    if media:
-                        content = "\n".join(
-                            [
-                                content,
-                                "",
-                                "[附加媒体]",
-                                *(f"- {value}" for value in media),
-                            ]
-                        )
-                    messages.append({"role": "user", "content": content})
-                elif item.kind is TurnItemKind.TOOL_CALL:
-                    group = cls._tool_group_from_item(item)
-                    if group is None:
-                        continue
-                    call = group["calls"][0]
-                    messages.append(
-                        {
-                            "role": "assistant",
-                            "content": group["text"],
-                            "tool_calls": [
-                                {
-                                    "id": call["call_id"],
-                                    "type": "function",
-                                    "function": {
-                                        "name": call["name"],
-                                        "arguments": json.dumps(
-                                            call["arguments"], ensure_ascii=False
-                                        ),
-                                    },
-                                }
-                            ],
-                        }
-                    )
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call["call_id"],
-                            "content": call["result"],
-                        }
-                    )
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": "[execution attempt interrupted]",
-                }
-            )
-        return messages
-
     def _build_turn_user_input(
         self,
         request: TurnRequest,
@@ -674,8 +616,8 @@ class ConversationRuntime:
                     **request.metadata,
                     "turnId": turn_id,
                     "_controlTurnInputSource": self._turn_input_sources[turn_id],
-                    "_controlAttemptReplay": attempt_replay,
-                    "_controlPriorToolChain": prior_tool_chain,
+                    METADATA_ATTEMPT_REPLAY: attempt_replay,
+                    METADATA_PRIOR_TOOL_CHAIN: prior_tool_chain,
                 },
             )
             live_item_ids: set[str] = set()

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, cast
 import agent.core.passive_support as support
 from agent.control.context import running_turn_id
 from agent.control.ports import InputLock, TurnUserInput
+from agent.control.replay_format import split_replay_batches
 from agent.config_models import ContextCompactionConfig
 from agent.model_runtime.context_compaction import (
     ContextCompactionError,
@@ -1197,9 +1198,7 @@ class DefaultReasoner(Reasoner):
             replay_slice = initial_messages[replay_start:replay_end]
             if replay_slice != attempt_replay:
                 raise RuntimeError("control attempt replay 未出现在完整 prompt history")
-            replay_batches, replay_tail = _parse_attempt_replay(
-                attempt_replay,
-            )
+            replay_batches, replay_tail = split_replay_batches(attempt_replay)
         if len(replay_batches) != prior_tool_groups:
             raise RuntimeError(
                 "control attempt replay 与 prior tool chain 数量不一致: "
@@ -2748,51 +2747,6 @@ class DefaultReasoner(Reasoner):
 
 # ── 模块级辅助函数 ──────────────────────────────────────────────
 
-
-def _parse_attempt_replay(
-    attempt_replay: list[dict[str, Any]],
-) -> tuple[list[list[dict[str, Any]]], list[dict[str, Any]]]:
-    """Split replay into closed tool batches and an untouched trailing suffix."""
-
-    # 1. Each assistant tool call must be followed by every matching result.
-    batches: list[list[dict[str, Any]]] = []
-    batch_start = 0
-    cursor = 0
-    while cursor < len(attempt_replay):
-        message = attempt_replay[cursor]
-        raw_calls = message.get("tool_calls")
-        if message.get("role") != "assistant" or not isinstance(raw_calls, list):
-            cursor += 1
-            continue
-        call_ids = {
-            str(call.get("id"))
-            for call in raw_calls
-            if isinstance(call, dict) and isinstance(call.get("id"), str)
-        }
-        if not call_ids or len(call_ids) != len(raw_calls):
-            raise RuntimeError("control attempt replay tool call identity 无效")
-        result_ids: set[str] = set()
-        batch_end = cursor + 1
-        while batch_end < len(attempt_replay):
-            result = attempt_replay[batch_end]
-            if result.get("role") != "tool":
-                break
-            result_id = result.get("tool_call_id")
-            if not isinstance(result_id, str):
-                raise RuntimeError("control attempt replay tool result identity 无效")
-            result_ids.add(result_id)
-            batch_end += 1
-        if result_ids != call_ids:
-            # An incomplete tail remains pending and is never promoted to active.
-            if batches:
-                return batches, list(attempt_replay[batch_start:])
-            return [], list(attempt_replay)
-        batches.append(list(attempt_replay[batch_start:batch_end]))
-        batch_start = batch_end
-        cursor = batch_end
-
-    # 2. Keep interruption markers and any non-tool suffix in pending order.
-    return batches, list(attempt_replay[batch_start:])
 
 
 def extract_model_facing_turn(

--- a/bootstrap/control_execution.py
+++ b/bootstrap/control_execution.py
@@ -9,6 +9,7 @@ from agent.control.errors import ControlExecutionError
 from agent.control.ids import new_item_id
 from agent.control.models import TurnItem, TurnItemKind, TurnRequest, TurnUsage
 from agent.control.ports import ControlExecutionResult
+from agent.control.replay_format import METADATA_ATTEMPT_REPLAY, METADATA_PRIOR_TOOL_CHAIN
 from agent.looping.core import AgentLoop
 from agent.model_runtime.errors import (
     AuthenticationError,
@@ -120,10 +121,10 @@ async def execute_control_turn(
                 turn_id=turn_id,
                 interaction_id=interaction_id,
                 attempt_replay=_attempt_replay(
-                    request.metadata.get("_controlAttemptReplay")
+                    request.metadata.get(METADATA_ATTEMPT_REPLAY)
                 ),
                 prior_tool_chain=_prior_tool_chain(
-                    request.metadata.get("_controlPriorToolChain")
+                    request.metadata.get(METADATA_PRIOR_TOOL_CHAIN)
                 ),
                 prior_input_count=_prior_input_count(
                     request.metadata.get("priorInputCount")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：attempt replay 格式合同手写在两端——runtime 的正向投影 `_attempt_replay_messages` 与 passive_turn 的反向解析 `_parse_attempt_replay` 必须字节级一致，违反时只在运行期 `RuntimeError`；metadata 键名散落字符串字面量。
- 用户可见结果：`semantic_delta: none`，格式投影与解析收敛为单一 owner，键名定义一处。
- 本 PR 不处理：camelCase/snake_case 四层换名通道的键名风格统一（键值不变，仅引用常量化）；e2e 中断→重启→重放测试（解锁后可补）。

## Change intent

- `change_type`：`refactor`；`semantic_delta`：`none`
- `capability_owner`：`core`（control replay 格式）
- `runtime_patch`：`none`
- `protected_state`：replay 消息形状（role/工具调用/中断标记文本）、metadata 键值、错误消息
- 允许的副作用：新增 `replay_format.py`，两个投影函数迁入，两个调用点改引用常量
- 禁止的副作用：任何 wire 协议、持久化、消息格式变化

## 改动范围

- 新增 `agent/control/replay_format.py`：`replay_messages`（正向）/ `split_replay_batches`（反向）/ `ATTEMPT_INTERRUPTED_MARKER` / `METADATA_ATTEMPT_REPLAY` / `METADATA_PRIOR_TOOL_CHAIN`
- `agent/control/runtime.py`：删除 `_attempt_replay_messages`，调用 `replay_messages`；写入端用键常量
- `agent/core/passive_turn.py`：删除 `_parse_attempt_replay`，调用 `split_replay_batches`
- `bootstrap/control_execution.py`：读取端用键常量
- 配置或迁移影响：无；回滚：revert `fa7ad841`

## 验证

- [x] targeted tests：83 passed（conversation_runtime、d8 replay、reasoner、lifecycle）
- [x] pyright `--level error` 与基线逐条 diff 一致，零新增
- [x] `python docker/debug/gate.py run --base origin/main`：GATE PASSED
- planDigest：`7a38b8f117c955784edbd4cfab6334ae682a60a21036b83754868926cc44e713`
- 未运行项：无

## 工作手册

- [x] 已核对 projectneed、决策、NOW；无长期语义变化，无需新增文档