### PR TITLE
refactor: turn 所有权释放收敛为单一 _release_turn_ownership

### DIFF
--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -557,6 +557,28 @@ class ConversationRuntime:
         self._active_admission_bytes -= stored
         self._live_runtime_objects -= 1
 
+    def _release_turn_ownership(
+        self,
+        thread_id: str,
+        turn_id: str,
+        *,
+        require_admission: bool = False,
+    ) -> None:
+        """释放 turn 在 runtime 的全部所有权状态；中断与正常收束共用。"""
+
+        _ = self._active_by_thread.pop(thread_id, None)
+        idle = self._thread_idle.pop(thread_id, None)
+        if idle is not None:
+            idle.set()
+        _ = self._tasks.pop(turn_id, None)
+        if require_admission and turn_id not in self._active_turn_bytes:
+            raise RuntimeError(f"queued turn admission missing: {turn_id}")
+        self._interrupt_requested.discard(turn_id)
+        self._consumed_inputs.pop(turn_id, None)
+        self._locked_turn_inputs.discard(turn_id)
+        self._turn_input_sources.pop(turn_id, None)
+        self._release_admission(turn_id)
+
     async def _run(
         self,
         request: TurnRequest,
@@ -810,16 +832,7 @@ class ConversationRuntime:
                 if not future.done():
                     future.set_exception(error)
                 self._fail_streams(turn_id, error)
-            _ = self._active_by_thread.pop(request.thread_id, None)
-            idle = self._thread_idle.pop(request.thread_id, None)
-            if idle is not None:
-                idle.set()
-            _ = self._tasks.pop(turn_id, None)
-            self._interrupt_requested.discard(turn_id)
-            self._consumed_inputs.pop(turn_id, None)
-            self._locked_turn_inputs.discard(turn_id)
-            self._turn_input_sources.pop(turn_id, None)
-            self._release_admission(turn_id)
+            self._release_turn_ownership(request.thread_id, turn_id)
             if terminal is not None and self._turn_terminal is not None:
                 self._turn_terminal(
                     turn_id,
@@ -1271,17 +1284,7 @@ class ConversationRuntime:
             )
             future.set_result(TurnResult.from_record(terminal))
             self._finish_streams(turn_id)
-            _ = self._active_by_thread.pop(thread_id, None)
-            idle = self._thread_idle.pop(thread_id, None)
-            if idle is not None:
-                idle.set()
-            _ = self._tasks.pop(turn_id, None)
-            if turn_id not in self._active_turn_bytes:
-                raise RuntimeError(f"queued turn admission missing: {turn_id}")
-            self._consumed_inputs.pop(turn_id, None)
-            self._locked_turn_inputs.discard(turn_id)
-            self._turn_input_sources.pop(turn_id, None)
-            self._release_admission(turn_id)
+            self._release_turn_ownership(thread_id, turn_id, require_admission=True)
             return terminal
 
         # 3. in-progress task 自己在取消处理器中提交 interrupted。


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`ConversationRuntime` 里两套几乎逐行重复的 turn 所有权清理序列——`_run` 的 finally 与 `interrupt_turn` 的 QUEUED 分支各自维护 `_active_by_thread`/`_thread_idle`/`_tasks`/`_consumed_inputs`/`_sealed_turn_inputs`/`_turn_input_sources`/admission 的清理，无法证明两个入口收敛到同一终态。
- 用户可见结果：`semantic_delta: none`，两套序列合并为单一 `_release_turn_ownership`。
- 本 PR 不处理：InputLock/seal 义务的 6 个散点收敛（seal 时机影响中断语义，不是纯重构，单独评估）。

## Change intent

- `change_type`：`refactor`；`semantic_delta`：`none`
- `capability_owner`：`core`（control turn 生命周期）
- `runtime_patch`：`none`
- `protected_state`：清理顺序与 QUEUED 路径的 `_active_turn_bytes` 防御检查
- 允许的副作用：`agent/control/runtime.py` 一个方法合并
- 禁止的副作用：终态选择、事件发布、admission 语义变化

## 改动范围

- `agent/control/runtime.py`：新增 `_release_turn_ownership(thread_id, turn_id, *, require_admission=False)`；`_run` finally 与 `interrupt_turn` QUEUED 分支改为调用它
- 配置或迁移影响：无；回滚：revert `eae132f0`

## 验证

- [x] targeted tests：64 passed（tests/control/ 全部）
- [x] pyright `--level error` 与基线逐条 diff 一致，零新增
- [x] `python docker/debug/gate.py run --base origin/main`：GATE PASSED
- planDigest：`03c92534f4c334ad5f90b92da61768ef6af81be7a9e505cb7f88cf240bf06d7b`
- 未运行项：无

## 工作手册

- [x] 已核对 projectneed、决策、NOW；无长期语义变化，无需新增文档