### PR TITLE
refactor: 收敛双轨历史投影，删除 start_index 死路径

### DIFF
--- a/agent/core/runtime_support.py
+++ b/agent/core/runtime_support.py
@@ -159,12 +159,7 @@ class SessionLike(Protocol):
     metadata: dict[str, object]
     last_consolidated: int
 
-    def get_history(
-        self,
-        max_messages: int = 500,
-        *,
-        start_index: int | None = None,
-    ) -> list[dict[str, object]]: ...
+    def get_history(self, max_messages: int = 500) -> list[dict[str, object]]: ...
     def add_message(
         self,
         role: str,

--- a/session/manager.py
+++ b/session/manager.py
@@ -181,38 +181,6 @@ def _rebuild_user_content(
     return images + [{"type": "text", "text": combined_text}]
 
 
-def _align_to_user_boundary(
-    messages: list[dict[str, object]],
-) -> list[dict[str, object]]:
-    for i, m in enumerate(messages):
-        if m.get("role") == "user" or (
-            m.get("role") == "assistant" and m.get("proactive")
-        ):
-            return messages[i:]
-    return []
-
-
-def _rewind_to_explicit_turn_start(
-    messages: list[dict[str, object]],
-    start: int,
-) -> int:
-    """把历史窗口起点退回显式 control turn 的第一条消息。"""
-
-    if start < 0 or start >= len(messages):
-        return start
-    raw_turn_id = messages[start].get("control_turn_id")
-    if raw_turn_id is None:
-        return start
-    if not isinstance(raw_turn_id, str) or not raw_turn_id:
-        raise ValueError("session message control_turn_id 必须是非空字符串")
-    while start > 0:
-        previous_turn_id = messages[start - 1].get("control_turn_id")
-        if previous_turn_id != raw_turn_id:
-            break
-        start -= 1
-    return start
-
-
 def logical_history_unit_ranges(
     messages: list[dict[str, object]],
 ) -> list[tuple[int, int]]:
@@ -254,22 +222,6 @@ def logical_history_unit_ranges(
             index += 1
         ranges.append((start, index))
     return ranges
-
-
-def logical_history_unit_count(
-    messages: list[dict[str, object]],
-    *,
-    start_index: int = 0,
-) -> int:
-    """统计游标之后仍需投影的完整历史单元。"""
-
-    if start_index < 0 or start_index > len(messages):
-        raise ValueError("history unit start_index 超出消息范围")
-    return sum(
-        1
-        for start, end in logical_history_unit_ranges(messages)
-        if end > start_index and start < len(messages)
-    )
 
 
 def logical_history_tail_start(
@@ -403,46 +355,9 @@ class Session:
         self.updated_at = datetime.now(UTC)
         return msg
 
-    def get_history(
-        self,
-        max_messages: int = 500,
-        *,
-        start_index: int | None = None,
-    ) -> list[dict[str, object]]:
-        """按完整历史单元选择窗口并展开为 provider 消息。"""
-        if start_index is not None:
-            if max_messages <= 0:
-                return []
-            start = max(0, int(start_index))
-            if start >= len(self.messages):
-                return []
-            # 1. 新格式按显式 identity 保留完整 turn；legacy 再退到 user 边界。
-            explicit_start = _rewind_to_explicit_turn_start(self.messages, start)
-            if explicit_start != start or self.messages[start].get("control_turn_id"):
-                start = explicit_start
-            else:
-                while (
-                    start > 0
-                    and self.messages[start].get("role") != "user"
-                    and not (
-                        self.messages[start].get("role") == "assistant"
-                        and self.messages[start].get("proactive")
-                    )
-                ):
-                    start -= 1
-            # start=0 但仍非合法边界时，向后找第一个 user 或 proactive assistant。
-            messages = self.messages[start:]
-            if messages and not (
-                messages[0].get("role") == "user"
-                or (
-                    messages[0].get("role") == "assistant"
-                    and messages[0].get("proactive")
-                )
-            ):
-                messages = _align_to_user_boundary(messages)
-            if not messages:
-                return []
-        elif max_messages <= 0:
+    def get_history(self, max_messages: int = 500) -> list[dict[str, object]]:
+        """按完整历史单元选择尾部窗口并展开为 provider 消息。"""
+        if max_messages <= 0:
             messages = []
         else:
             start = logical_history_tail_start(self.messages, max_messages)

--- a/tests/test_agent_core_p2_reasoner.py
+++ b/tests/test_agent_core_p2_reasoner.py
@@ -390,7 +390,7 @@ def test_default_reasoner_replays_interrupted_attempt_before_current_input():
         key="mobile:one",
         created_at=timestamp,
         messages=[{"role": "user", "content": "old canonical"}],
-        get_history=lambda max_messages=40, *, start_index=None: [
+        get_history=lambda max_messages=40: [
             {"role": "user", "content": "old canonical"}
         ],
         last_consolidated=0,
@@ -527,7 +527,7 @@ def test_default_reasoner_disable_memory_writes_expands_to_memory_write_tools():
         key="telegram:123",
         created_at=datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
         messages=[],
-        get_history=lambda max_messages=40, *, start_index=None: [],
+        get_history=lambda max_messages=40: [],
         last_consolidated=0,
     )
     msg = SimpleNamespace(
@@ -849,7 +849,7 @@ def test_default_reasoner_observes_tool_lifecycle_events():
         key="telegram:123",
         created_at=datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
         messages=[],
-        get_history=lambda max_messages=40, *, start_index=None: [],
+        get_history=lambda max_messages=40: [],
         last_consolidated=0,
     )
     msg = SimpleNamespace(
@@ -1147,7 +1147,7 @@ def test_default_reasoner_run_turn_uses_context_render():
         key="cli:1",
         created_at=datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
         messages=[{"role": "assistant", "content": "old"}],
-        get_history=lambda max_messages=40, *, start_index=None: [
+        get_history=lambda max_messages=40: [
             {"role": "assistant", "content": "old"}
         ],
         last_consolidated=0,
@@ -1197,7 +1197,7 @@ def test_default_reasoner_run_turn_reports_llm_timeout():
         key="cli:1",
         created_at=datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
         messages=[],
-        get_history=lambda max_messages=40, *, start_index=None: [],
+        get_history=lambda max_messages=40: [],
         last_consolidated=0,
     )
     msg = SimpleNamespace(

--- a/tests/test_agent_core_p5_agent_core.py
+++ b/tests/test_agent_core_p5_agent_core.py
@@ -41,14 +41,7 @@ class _DummySession:
     def created_at(self) -> datetime:
         return self._created_at
 
-    def get_history(
-        self,
-        max_messages: int = 500,
-        *,
-        start_index: int | None = None,
-    ) -> list[dict]:
-        if start_index is not None:
-            return self.messages[start_index:][-max_messages:]
+    def get_history(self, max_messages: int = 500) -> list[dict]:
         return self.messages[-max_messages:]
 
     def add_message(

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -291,9 +291,7 @@ class _DummySession:
         self.metadata: dict[str, object] = {}
         self.last_consolidated = 0
 
-    def get_history(
-        self, max_messages: int = 500, *, start_index: int | None = None
-    ) -> list[dict[str, object]]:
+    def get_history(self, max_messages: int = 500) -> list[dict[str, object]]:
         return list(self.messages)
 
     def history_units(self, *, after_seq: int = -1) -> tuple[SimpleNamespace, ...]:

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -654,7 +654,7 @@ def test_session_get_history_skips_cached_llm_frame_by_default():
     )
     session.add_message("assistant", "world")
 
-    history = session.get_history(start_index=session.last_consolidated)
+    history = session.get_history(max_messages=1)
 
     assert history == [
         {"role": "user", "content": user_content},
@@ -705,23 +705,12 @@ def test_session_get_history_allows_proactive_assistant_boundary():
     session.add_message("user", "刚才那个")
     session.last_consolidated = 2
 
-    history = session.get_history(start_index=session.last_consolidated)
+    history = session.get_history(max_messages=2)
 
     assert history == [
         {"role": "assistant", "content": "[主动推送] 主动消息"},
         {"role": "user", "content": "刚才那个"},
     ]
-
-
-def test_session_get_history_rewinds_consolidated_index_to_user_boundary():
-    session = Session("cli:1")
-    session.add_message("user", "hello")
-    session.add_message("assistant", "world")
-    session.last_consolidated = 1
-
-    history = session.get_history(start_index=session.last_consolidated)
-
-    assert history[0] == {"role": "user", "content": "hello"}
 
 
 def test_session_get_history_never_splits_explicit_multi_input_turn():
@@ -750,7 +739,6 @@ def test_session_get_history_never_splits_explicit_multi_input_turn():
         {"role": "assistant", "content": "final"},
     ]
     assert session.get_history(max_messages=1) == expected
-    assert session.get_history(start_index=3) == expected
 
 
 def test_session_get_history_counts_logical_turn_and_proactive_as_units():
@@ -789,7 +777,7 @@ def test_session_get_history_keeps_full_consolidated_tail():
     for i in range(5):
         session.add_message("user", f"u{i}")
 
-    history = session.get_history(max_messages=2, start_index=0)
+    history = session.get_history(max_messages=500)
 
     assert history == [
         {"role": "user", "content": "u0"},
@@ -798,14 +786,6 @@ def test_session_get_history_keeps_full_consolidated_tail():
         {"role": "user", "content": "u3"},
         {"role": "user", "content": "u4"},
     ]
-
-
-def test_session_get_history_assistant_only_returns_empty():
-    session = Session("cli:1")
-    session.add_message("assistant", "a1")
-    session.add_message("assistant", "a2")
-
-    assert session.get_history(start_index=0) == []
 
 
 def test_session_get_history_skips_legacy_context_frame_by_default():
@@ -817,7 +797,7 @@ def test_session_get_history_skips_legacy_context_frame_by_default():
         llm_user_content="hello",
     )
 
-    history = session.get_history(start_index=0)
+    history = session.get_history(max_messages=500)
 
     assert history == [{"role": "user", "content": "hello"}]
 
@@ -881,7 +861,7 @@ def test_session_get_history_keeps_short_tool_results_after_consolidation_tail()
             }
         ]
 
-    history = session.get_history(start_index=session.last_consolidated)
+    history = session.get_history(max_messages=500)
     tool_contents = [m["content"] for m in history if m.get("role") == "tool"]
 
     assert tool_contents == ["result-0", "result-1", "result-2"]

--- a/tests/test_safety_retry_service.py
+++ b/tests/test_safety_retry_service.py
@@ -119,7 +119,7 @@ def _session():
         key="s:1",
         created_at=datetime(2026, 8, 8, tzinfo=timezone.utc),
         messages=history,
-        get_history=lambda max_messages=500, *, start_index=None: [
+        get_history=lambda max_messages=500: [
             dict(message) for message in history
         ],
         last_consolidated=3,


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`get_history` 与 `history_units` 双轨历史投影。前者携带 `start_index` 参数与三重边界修正（`_rewind_to_explicit_turn_start`、`_align_to_user_boundary`），该路径生产零调用（唯一调用方 `passive_turn.py:829` 无参），且其 rewind 语义已被「历史单元不可拆分」取代——`max_messages` 尾部窗口天然不切 turn。
- 用户可见结果：`semantic_delta: none`，双轨收敛为单一单元窗口投影。
- 本 PR 不处理：`logical_history_unit_ranges`/`_render_session_messages` 的共享已存在，未新增抽象。

## Change intent

- `change_type`：`refactor`；`semantic_delta`：`none`
- `capability_owner`：`core`（session 历史投影）
- `runtime_patch`：`none`
- `protected_state`：`max_messages` 尾部单元窗口语义、`logical_history_unit_ranges` 划分规则、渲染输出
- 允许的副作用：`get_history` 签名收窄、死代码删除、测试改写
- 禁止的副作用：窗口语义、渲染输出、持久化变化

## 改动范围

- `session/manager.py`：`get_history` 删除 `start_index` 参数与三重修正；删除 `_rewind_to_explicit_turn_start`、`_align_to_user_boundary`、死函数 `logical_history_unit_count`
- `agent/core/runtime_support.py`：SessionLike 协议同步
- `tests/test_logic_modules.py`：7 处 `start_index` 调用改写为等价 `max_messages` 单元窗口断言；2 个纯 rewind 语义测试删除（该语义无生产承载）
- 测试桩同步：`test_agent_core_p2_reasoner.py`、`test_agent_core_p5_agent_core.py`、`test_lifecycle_phases.py`、`test_safety_retry_service.py`
- 配置或迁移影响：无；回滚：revert `560febe9`

## 验证

- [x] targeted tests：223 passed（logic_modules 47、compaction runtime、session store、context compaction 契约、reasoner、lifecycle、safety、memory window）
- [x] pyright `--level error` 与基线逐条 diff 一致，零新增
- [x] `python docker/debug/gate.py run --base origin/main`：GATE PASSED
- planDigest：`85035573e9abb007ff13ed8e818c8103daac43728c86c02e26eb796501f46c3c`
- 未运行项：无

## 工作手册

- [x] 已核对 projectneed、决策、NOW；无长期语义变化，无需新增文档