### PR TITLE
[codex] 加速 Akasha 串行重放与在线轮次

### DIFF
--- a/plugins/akasha/application/cycle.py
+++ b/plugins/akasha/application/cycle.py
@@ -180,6 +180,7 @@ class MemoryCycle:
                     pool=pool,
                     query=turn,
                     context=decision.context,
+                    precomputed_fields=decision.fields,
                     evidence=evidence,
                     diffusion=diffusion,
                     historical_surprise=_historical_surprise(
@@ -271,7 +272,7 @@ class MemoryCycle:
         self.inhibited_nodes.difference_update(feedback.remember_nodes)
         inhibited = frozenset(self.inhibited_nodes)
         self.graph.apply_feedback_inhibition(inhibited)
-        learning_evidence = selected.evidence
+        learning_evidence = _learning_evidence(selected.evidence)
         learning_diffusion = selected.diffusion
 
         # 4. Learn retrieved activity, then reinforce only the addressed episode.
@@ -288,6 +289,16 @@ class MemoryCycle:
             feedback.remember_nodes,
             feedback.remember_boost,
         )
+        pool = self.feature_pool
+        if pool is not None:
+            if len(pool.turns) == self.state_version:
+                pool.append_turn(causal_turn)
+            else:
+                expected = pool.turns[self.state_version]
+                if expected.turn_id != causal_turn.turn_id:
+                    raise ValueError(
+                        "feature pool committed turn differs from causal turn"
+                    )
         self.turns.append(causal_turn)
 
         # 5. Advance only the committed turn's stream-local visible burst.
@@ -305,7 +316,13 @@ class MemoryCycle:
             members.append(causal_turn.node_id)
         else:
             members[:] = [causal_turn.node_id]
-        pool = self.feature_pool or BurstAwareFeaturePool(self.turns)
+        pool = self.feature_pool
+        if pool is None:
+            pool = BurstAwareFeaturePool(
+                self.turns,
+                appendable=True,
+            )
+            self.feature_pool = pool
         self.context = pool.build_context(
             tuple(
                 (node, 1.0)
@@ -335,6 +352,8 @@ class MemoryCycle:
     ) -> BurstAwareFeaturePool:
         if self.feature_pool is None:
             return BurstAwareFeaturePool([*self.turns, turn])
+        if len(self.feature_pool.turns) == self.state_version:
+            return self.feature_pool.query_view(turn)
         expected = self.feature_pool.turns[self.state_version]
         if expected.turn_id != turn.turn_id:
             raise ValueError("feature pool turn differs from causal query")
@@ -349,6 +368,15 @@ class MemoryCycle:
         if self.state_version == 0:
             return BurstDecision(
                 evidence=SeedEvidence((), {}, 0.5, 0.5, 1.0),
+                fields={
+                    name: np.empty(0, dtype=np.float64)
+                    for name in (
+                        "query_dense",
+                        "query_bm25",
+                        "context_dense",
+                        "context_bm25",
+                    )
+                },
                 base_continuation=0.5,
                 context_dependence=0.5,
                 context_mass=0.0,
@@ -383,6 +411,19 @@ def _feedback_state(turns: list[Turn]) -> set[int]:
         inhibited.update(turn.feedback.forget_nodes)
         inhibited.difference_update(turn.feedback.remember_nodes)
     return inhibited
+
+
+def _learning_evidence(evidence: SeedEvidence) -> SeedEvidence:
+    """Remove diagnostic-only support outside the committed seed."""
+
+    seed_nodes = frozenset(node for node, _ in evidence.seed)
+    return replace(
+        evidence,
+        channels={
+            name: members & seed_nodes
+            for name, members in evidence.channels.items()
+        },
+    )
 
 
 def _validate_feedback(feedback: TurnFeedback, event: int) -> None:

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from ..domain.features import BurstAwareFeaturePool
 from ..domain.model import MemoryConfig, Turn
-from ..infrastructure.loader import load_turns
+from ..infrastructure.loader import load_turn_suffix, load_turns
 from ..infrastructure.lease import WriterLease
 from ..infrastructure.persistence import (
     load_memory_state,
@@ -167,10 +167,14 @@ class OnlineMemoryRuntime:
                 embedding_dimension=self.embedding_dimension,
             ),
         )
-        turns = load_turns(self.index_path)
-        if len(turns) <= self.cycle.state_version:
+        suffix = tuple(
+            load_turn_suffix(
+                self.index_path,
+                self.cycle.state_version,
+            )
+        )
+        if not suffix:
             raise ValueError("TurnCommitted did not append a new sparse turn")
-        suffix = tuple(turns[self.cycle.state_version :])
         latest = suffix[-1]
         if (
             latest.user_message_id != user_message_id
@@ -273,7 +277,7 @@ class OnlineMemoryRuntime:
                 self.config,
                 turn_capacity=len(turns),
                 feature_pool=(
-                    BurstAwareFeaturePool(turns)
+                    BurstAwareFeaturePool(turns, appendable=True)
                     if turns
                     else None
                 ),
@@ -334,7 +338,6 @@ class OnlineMemoryRuntime:
         cycle, suffix = self._load_persisted_prefix(turns)
         if suffix:
             raise RuntimeError("fresh Akasha rebuild left an unpublished suffix")
-        cycle.feature_pool = None
         return cycle
 
     def _build_config(self) -> BuildConfig:
@@ -350,7 +353,6 @@ class OnlineMemoryRuntime:
             return MemoryCycle(self.config)
         turns = load_turns(self.index_path)
         cycle, _ = self._load_persisted_prefix(turns)
-        cycle.feature_pool = None
         return cycle
 
     def _load_persisted_prefix(
@@ -389,7 +391,7 @@ class OnlineMemoryRuntime:
             burst_members=burst_members,
         )
         cycle.feature_pool = (
-            BurstAwareFeaturePool(turns)
+            BurstAwareFeaturePool(turns, appendable=True)
             if turns
             else None
         )
@@ -407,7 +409,6 @@ class OnlineMemoryRuntime:
                 turn,
                 cycle.retrieve(turn),
             )
-        cycle.feature_pool = None
         if not turns:
             return cycle
         if cycle.context is None:

--- a/plugins/akasha/domain/diffusion.py
+++ b/plugins/akasha/domain/diffusion.py
@@ -27,11 +27,11 @@ class IndexedMaxHeap:
 
     def __init__(self, capacity: int, residual: np.ndarray) -> None:
         self.nodes: list[int] = []
-        self.position = np.full(capacity, -1, dtype=np.int32)
+        self.position = [-1] * capacity
         self.residual = residual
 
     def update(self, node_id: int) -> None:
-        position = int(self.position[node_id])
+        position = self.position[node_id]
         if position < 0:
             self.position[node_id] = len(self.nodes)
             self.nodes.append(node_id)
@@ -55,44 +55,61 @@ class IndexedMaxHeap:
         return sorted(self.nodes)
 
     def _sift_up(self, position: int) -> None:
-        node = self.nodes[position]
+        nodes = self.nodes
+        positions = self.position
+        residual = self.residual
+        node = nodes[position]
+        node_value = residual[node]
         while position:
             parent = (position - 1) // 2
-            parent_node = self.nodes[parent]
-            if not self._higher(node, parent_node):
+            parent_node = nodes[parent]
+            parent_value = residual[parent_node]
+            if not (
+                node_value > parent_value
+                or (node_value == parent_value and node < parent_node)
+            ):
                 break
-            self.nodes[position] = parent_node
-            self.position[parent_node] = position
+            nodes[position] = parent_node
+            positions[parent_node] = position
             position = parent
-        self.nodes[position] = node
-        self.position[node] = position
+        nodes[position] = node
+        positions[node] = position
 
     def _sift_down(self, position: int) -> None:
-        size = len(self.nodes)
-        node = self.nodes[position]
+        nodes = self.nodes
+        positions = self.position
+        residual = self.residual
+        size = len(nodes)
+        node = nodes[position]
+        node_value = residual[node]
         while True:
             left = position * 2 + 1
             if left >= size:
                 break
             right = left + 1
             child = left
-            if right < size and self._higher(self.nodes[right], self.nodes[left]):
-                child = right
-            child_node = self.nodes[child]
-            if not self._higher(child_node, node):
+            left_node = nodes[left]
+            child_node = left_node
+            child_value = residual[left_node]
+            if right < size:
+                right_node = nodes[right]
+                right_value = residual[right_node]
+                if right_value > child_value or (
+                    right_value == child_value and right_node < child_node
+                ):
+                    child = right
+                    child_node = right_node
+                    child_value = right_value
+            if not (
+                child_value > node_value
+                or (child_value == node_value and child_node < node)
+            ):
                 break
-            self.nodes[position] = child_node
-            self.position[child_node] = position
+            nodes[position] = child_node
+            positions[child_node] = position
             position = child
-        self.nodes[position] = node
-        self.position[node] = position
-
-    def _higher(self, left: int, right: int) -> bool:
-        left_value = self.residual[left]
-        right_value = self.residual[right]
-        return left_value > right_value or (
-            left_value == right_value and left < right
-        )
+        nodes[position] = node
+        positions[node] = position
 
 
 def residual_push(
@@ -130,6 +147,7 @@ def residual_push(
 
     # 2. Repeatedly settle the largest residual coordinate.
     pushes = 0
+    update_heap = heap.update
     while True:
         if residual_total <= tolerance:
             residual_total = math.fsum(
@@ -148,29 +166,25 @@ def residual_push(
         transitions, unspread = graph.transitions(node, event)
         for target, probability, edge_id in transitions:
             addition = propagated * probability
-            residual_total += _add_residual(
-                residual,
-                heap,
-                target,
-                addition,
-            )
-            _record_parent(
-                parent_node,
-                parent_edge,
-                parent_mass,
-                target,
-                node,
-                edge_id,
-                addition,
-            )
+            if addition != 0.0:
+                residual[target] += addition
+                update_heap(target)
+                residual_total += addition
+                if (
+                    parent_node is not None
+                    and parent_edge is not None
+                    and parent_mass is not None
+                    and addition > parent_mass[target]
+                ):
+                    parent_mass[target] = addition
+                    parent_node[target] = node
+                    parent_edge[target] = edge_id
         for target, probability in seed:
             addition = propagated * unspread * probability
-            residual_total += _add_residual(
-                residual,
-                heap,
-                target,
-                addition,
-            )
+            if addition != 0.0:
+                residual[target] += addition
+                update_heap(target)
+                residual_total += addition
         pushes += 1
         if pushes % 4096 == 0:
             residual_total = math.fsum(
@@ -186,33 +200,3 @@ def residual_push(
         parent_node=parent_node,
         parent_edge=parent_edge,
     )
-
-
-def _add_residual(
-    residual: np.ndarray,
-    heap: IndexedMaxHeap,
-    node_id: int,
-    addition: float,
-) -> float:
-    if addition == 0.0:
-        return 0.0
-    residual[node_id] += addition
-    heap.update(node_id)
-    return addition
-
-
-def _record_parent(
-    parent_node: np.ndarray | None,
-    parent_edge: np.ndarray | None,
-    parent_mass: np.ndarray | None,
-    target: int,
-    source: int,
-    edge_id: int,
-    addition: float,
-) -> None:
-    if parent_node is None or parent_edge is None or parent_mass is None:
-        return
-    if addition > parent_mass[target]:
-        parent_mass[target] = addition
-        parent_node[target] = source
-        parent_edge[target] = edge_id

--- a/plugins/akasha/domain/features.py
+++ b/plugins/akasha/domain/features.py
@@ -15,39 +15,73 @@ from .model import ContextState, SeedEvidence, Turn
 class FeaturePool:
     """Serve causal evidence from contiguous dense and inverted lexical arrays."""
 
-    def __init__(self, turns: list[Turn]) -> None:
+    def __init__(
+        self,
+        turns: list[Turn],
+        *,
+        appendable: bool = False,
+    ) -> None:
         if not turns:
             raise ValueError("memory rebuild requires at least one turn")
-        self.turns = turns
+        self.turns = list(turns)
+        self._query_turn: Turn | None = None
+        self._appendable = appendable
+        self._size = len(turns)
+        self._capacity = _next_capacity(self._size) if appendable else self._size
         dimension = _dense_dimension(turns)
-        self.user_dense, self.user_mask = _dense_matrix(
+        user_dense, user_mask = _dense_matrix(
             turns,
             "user_dense",
             dimension,
         )
-        self.assistant_dense, self.assistant_mask = _dense_matrix(
+        assistant_dense, assistant_mask = _dense_matrix(
             turns,
             "assistant_dense",
             dimension,
         )
-        self.turn_dense, self.turn_dense_mask = _turn_dense_matrix(
+        turn_dense, turn_dense_mask = _turn_dense_matrix(
             turns,
             dimension,
         )
-        self.normalized_terms = tuple(_normalized_turn_terms(turn) for turn in turns)
-        self.lengths = np.asarray(
+        self.user_dense = _reserve_rows(user_dense, self._capacity)
+        self.user_mask = _reserve_values(user_mask, self._capacity)
+        self.assistant_dense = _reserve_rows(
+            assistant_dense,
+            self._capacity,
+        )
+        self.assistant_mask = _reserve_values(
+            assistant_mask,
+            self._capacity,
+        )
+        self.turn_dense = _reserve_rows(turn_dense, self._capacity)
+        self.turn_dense_mask = _reserve_values(
+            turn_dense_mask,
+            self._capacity,
+        )
+        self.normalized_terms = [_normalized_turn_terms(turn) for turn in turns]
+        lengths = np.asarray(
             [_term_total(turn) for turn in turns],
             dtype=np.float64,
         )
-        self.prefix_lengths = np.concatenate(
-            (np.zeros(1, dtype=np.float64), np.cumsum(self.lengths))
+        self.lengths = _reserve_values(lengths, self._capacity)
+        prefix_lengths = np.concatenate(
+            (np.zeros(1, dtype=np.float64), np.cumsum(lengths))
         )
-        self.gaps = np.asarray(
+        self.prefix_lengths = _reserve_values(
+            prefix_lengths,
+            self._capacity + 1,
+        )
+        gaps = np.asarray(
             [
                 math.nan if turn.inter_gap_seconds is None else turn.inter_gap_seconds
                 for turn in turns
             ],
             dtype=np.float64,
+        )
+        self.gaps = _reserve_values(
+            gaps,
+            self._capacity,
+            fill=math.nan,
         )
         self.term_order, self.postings = _build_postings(turns)
 
@@ -170,8 +204,10 @@ class FeaturePool:
             selected = positions[:stop]
             tf = frequencies[:stop]
             idf = math.log1p((end - stop + 0.5) / (stop + 0.5))
-            saturation = tf * 2.2 / (
-                tf + 1.2 * (0.25 + 0.75 * self.lengths[selected] / average_length)
+            saturation = (
+                tf
+                * 2.2
+                / (tf + 1.2 * (0.25 + 0.75 * self.lengths[selected] / average_length))
             )
             scores[selected] += query_terms[term] * idf * saturation
         return scores
@@ -181,9 +217,7 @@ class FeaturePool:
             return 0.5
         observed = self.gaps[1:end]
         observed = observed[np.isfinite(observed)]
-        return (float(np.count_nonzero(observed >= gap)) + 0.5) / (
-            observed.size + 1.0
-        )
+        return (float(np.count_nonzero(observed >= gap)) + 0.5) / (observed.size + 1.0)
 
     def continuation_belief(
         self,
@@ -228,9 +262,7 @@ class FeaturePool:
                 continue
             tf = document_terms[term]
             idf = math.log1p((end - df + 0.5) / (df + 0.5))
-            saturation = tf * 2.2 / (
-                tf + 1.2 * (0.25 + 0.75 * length / average_length)
-            )
+            saturation = tf * 2.2 / (tf + 1.2 * (0.25 + 0.75 * length / average_length))
             parts.append(query_terms[term] * idf * saturation)
         return math.fsum(parts)
 
@@ -259,6 +291,7 @@ class BurstDecision:
     """Describe one causal boundary decision and its retrieval evidence."""
 
     evidence: SeedEvidence
+    fields: dict[str, np.ndarray]
     base_continuation: float
     context_dependence: float
     context_mass: float
@@ -270,9 +303,164 @@ class BurstDecision:
 class BurstAwareFeaturePool(FeaturePool):
     """Infer query evidence against one stream-local active burst."""
 
-    def __init__(self, turns: list[Turn]) -> None:
-        super().__init__(turns)
-        self.context_dependence = _causal_context_dependence(turns)
+    def __init__(
+        self,
+        turns: list[Turn],
+        *,
+        appendable: bool = False,
+    ) -> None:
+        super().__init__(turns, appendable=appendable)
+        dependence = _causal_context_dependence(turns)
+        self.context_dependence = _reserve_values(
+            dependence,
+            self._capacity,
+        )
+        self._ordered_supports = sorted(
+            _term_effective_support(turn.user_terms) for turn in turns
+        )
+
+    def query_view(self, turn: Turn) -> BurstAwareFeaturePool:
+        """Expose one ephemeral cue while sharing immutable history arrays."""
+
+        # 1. Share every strictly historical feature structure.
+        view = object.__new__(BurstAwareFeaturePool)
+        view.__dict__ = self.__dict__.copy()
+        view._query_turn = turn
+        view._appendable = False
+
+        # 2. Materialize only the cue's causal dependence scalar.
+        view._query_context_dependence = self._next_context_dependence(turn)
+        return view
+
+    def append_turn(self, turn: Turn) -> None:
+        """Append one committed turn without rebuilding historical features."""
+
+        if not self._appendable:
+            raise RuntimeError("feature pool is not appendable")
+        if turn.node_id != self._size:
+            raise ValueError("feature pool turn must append at its node ID")
+
+        # 1. Grow dense and causal arrays before exposing the new row.
+        self._ensure_capacity()
+        node_id = self._size
+        self._write_dense_row(node_id, turn)
+        self.normalized_terms.append(_normalized_turn_terms(turn))
+        length = float(_term_total(turn))
+        self.lengths[node_id] = length
+        self.prefix_lengths[node_id + 1] = self.prefix_lengths[node_id] + length
+        self.gaps[node_id] = (
+            math.nan if turn.inter_gap_seconds is None else turn.inter_gap_seconds
+        )
+
+        # 2. Extend only postings touched by this turn in stable term order.
+        for term, tf in _combined_terms(turn):
+            if term not in self.term_order:
+                self.term_order[term] = len(self.term_order)
+            posting = self.postings.get(term)
+            if posting is None:
+                self.postings[term] = (
+                    np.asarray([node_id], dtype=np.int32),
+                    np.asarray([float(tf)], dtype=np.float64),
+                )
+            else:
+                self.postings[term] = (
+                    np.append(posting[0], np.int32(node_id)),
+                    np.append(posting[1], float(tf)),
+                )
+
+        # 3. Commit the same order statistic used by full construction.
+        support = _term_effective_support(turn.user_terms)
+        self.context_dependence[node_id] = self._next_context_dependence(turn)
+        bisect.insort_right(self._ordered_supports, support)
+        self.turns.append(turn)
+        self._size += 1
+
+    def _next_context_dependence(self, turn: Turn) -> float:
+        support = _term_effective_support(turn.user_terms)
+        if not self._ordered_supports or support <= 0.0:
+            return 0.5
+        position = bisect.bisect_left(self._ordered_supports, support)
+        return (len(self._ordered_supports) - position + 0.5) / (
+            len(self._ordered_supports) + 1.0
+        )
+
+    def _ensure_capacity(self) -> None:
+        if self._size < self._capacity:
+            return
+        capacity = max(1, self._capacity * 2)
+        self.user_dense = _reserve_rows(self.user_dense, capacity)
+        self.user_mask = _reserve_values(self.user_mask, capacity)
+        self.assistant_dense = _reserve_rows(
+            self.assistant_dense,
+            capacity,
+        )
+        self.assistant_mask = _reserve_values(
+            self.assistant_mask,
+            capacity,
+        )
+        self.turn_dense = _reserve_rows(self.turn_dense, capacity)
+        self.turn_dense_mask = _reserve_values(
+            self.turn_dense_mask,
+            capacity,
+        )
+        self.lengths = _reserve_values(self.lengths, capacity)
+        self.prefix_lengths = _reserve_values(
+            self.prefix_lengths,
+            capacity + 1,
+        )
+        self.gaps = _reserve_values(
+            self.gaps,
+            capacity,
+            fill=math.nan,
+        )
+        self.context_dependence = _reserve_values(
+            self.context_dependence,
+            capacity,
+        )
+        self._capacity = capacity
+
+    def _write_dense_row(self, node_id: int, turn: Turn) -> None:
+        vectors = [
+            vector
+            for vector in (turn.user_dense, turn.assistant_dense)
+            if vector is not None
+        ]
+        dimension = self.user_dense.shape[1]
+        if dimension == 0 and vectors:
+            dimension = vectors[0].shape[0]
+            self.user_dense = np.zeros(
+                (self._capacity, dimension),
+                dtype=np.float32,
+            )
+            self.assistant_dense = np.zeros(
+                (self._capacity, dimension),
+                dtype=np.float32,
+            )
+            self.turn_dense = np.zeros(
+                (self._capacity, dimension),
+                dtype=np.float32,
+            )
+        for vector, matrix, mask in (
+            (turn.user_dense, self.user_dense, self.user_mask),
+            (
+                turn.assistant_dense,
+                self.assistant_dense,
+                self.assistant_mask,
+            ),
+        ):
+            if vector is not None:
+                if vector.shape != (dimension,):
+                    raise ValueError("dense vectors must share one dimension")
+                matrix[node_id] = vector
+                mask[node_id] = True
+        if vectors:
+            self.turn_dense[node_id] = _unit(
+                sum(
+                    vectors,
+                    start=np.zeros(dimension, dtype=np.float32),
+                )
+            )
+            self.turn_dense_mask[node_id] = True
 
     def infer_burst_seed(
         self,
@@ -284,7 +472,7 @@ class BurstAwareFeaturePool(FeaturePool):
         """Infer a causal burst boundary and mix cue with active context."""
 
         # 1. Score the current cue and the complete visible burst separately.
-        query = self.turns[index]
+        query = self._turn_at(index)
         query_terms = _normalize_pairs(query.user_terms)
         query_dense = self.dense_scores(query.user_dense, index)
         query_bm25 = self.bm25_scores(query_terms, index)
@@ -310,31 +498,19 @@ class BurstAwareFeaturePool(FeaturePool):
             query_dense,
             query_bm25,
         )
-        dependence = float(self.context_dependence[index])
+        dependence = self._context_dependence_at(index)
         continuation = _burst_continuation(
             base,
             time_prior,
             dependence,
         )
         continued = bool(visible_nodes) and continuation >= 0.5
-        active_context = (
-            candidate_context
-            if continued
-            else ContextState((), None, ())
-        )
+        active_context = candidate_context if continued else ContextState((), None, ())
 
         # 3. Fuse normalized cue and context sources without fixed weights.
-        context_mass = (
-            _combine_odds(continuation, dependence)
-            if continued
-            else 0.0
-        )
+        context_mass = _combine_odds(continuation, dependence) if continued else 0.0
         seed = _mix_sources(fields, context_mass)
-        seed_nodes = (
-            None
-            if capture_channels
-            else tuple(node for node, _ in seed)
-        )
+        seed_nodes = None if capture_channels else tuple(node for node, _ in seed)
         return BurstDecision(
             evidence=SeedEvidence(
                 seed=seed,
@@ -348,6 +524,7 @@ class BurstAwareFeaturePool(FeaturePool):
                     query_bm25,
                 ),
             ),
+            fields=fields,
             base_continuation=base,
             context_dependence=dependence,
             context_mass=context_mass,
@@ -355,6 +532,20 @@ class BurstAwareFeaturePool(FeaturePool):
             visible_nodes=visible_nodes if continued else (),
             context=active_context,
         )
+
+    def _turn_at(self, index: int) -> Turn:
+        if index < len(self.turns):
+            return self.turns[index]
+        if index == len(self.turns) and self._query_turn is not None:
+            return self._query_turn
+        raise IndexError(index)
+
+    def _context_dependence_at(self, index: int) -> float:
+        if index < self._size:
+            return float(self.context_dependence[index])
+        if index == self._size and self._query_turn is not None:
+            return self._query_context_dependence
+        raise IndexError(index)
 
 
 def effective_support(values: np.ndarray) -> float:
@@ -475,6 +666,37 @@ def _build_postings(
         for term in sorted(positions, key=term_order.__getitem__)
     }
     return term_order, postings
+
+
+def _next_capacity(size: int) -> int:
+    capacity = 1
+    while capacity <= size:
+        capacity *= 2
+    return capacity
+
+
+def _reserve_rows(matrix: np.ndarray, capacity: int) -> np.ndarray:
+    if matrix.shape[0] == capacity:
+        return matrix
+    reserved = np.zeros(
+        (capacity, matrix.shape[1]),
+        dtype=matrix.dtype,
+    )
+    reserved[: matrix.shape[0]] = matrix
+    return reserved
+
+
+def _reserve_values(
+    values: np.ndarray,
+    capacity: int,
+    *,
+    fill: float = 0.0,
+) -> np.ndarray:
+    if values.shape[0] == capacity:
+        return values
+    reserved = np.full(capacity, fill, dtype=values.dtype)
+    reserved[: values.shape[0]] = values
+    return reserved
 
 
 def _dense_matrix(

--- a/plugins/akasha/domain/readout.py
+++ b/plugins/akasha/domain/readout.py
@@ -39,6 +39,18 @@ class Basin:
 
 
 @dataclass(frozen=True)
+class _BasinStructure:
+    """Cache cue-independent members and normalized weights for one read."""
+
+    hub_id: int
+    members: tuple[int, ...]
+    weights: tuple[float, ...]
+    member_array: np.ndarray
+    normalized: np.ndarray
+    conductance: float
+
+
+@dataclass(frozen=True)
 class RecallItem:
     """Expose one completed historical turn with auditable sources."""
 
@@ -128,6 +140,7 @@ def read_pattern_completion(
     pool: FeaturePool,
     query: Turn,
     context: ContextState,
+    precomputed_fields: dict[str, np.ndarray] | None = None,
     evidence: SeedEvidence,
     diffusion: DiffusionResult,
     historical_surprise: np.ndarray,
@@ -139,24 +152,29 @@ def read_pattern_completion(
 ) -> PatternCompletion:
     """Read contextual and independent basin routes without mutating memory."""
 
-    # 1. Preserve the contextual V8 route as the non-destructive baseline.
+    # 1. Snapshot cue-independent basin structure once for both routes.
+    basin_structures = _active_basin_structures(graph, query.node_id)
+
+    # 2. Preserve the contextual V8 route as the non-destructive baseline.
     contextual = _exclude_recall_items(
         _read_contextual_route(
             graph=graph,
             pool=pool,
             query=query,
             context=context,
+            precomputed_fields=precomputed_fields,
             evidence=evidence,
             diffusion=diffusion,
             historical_surprise=historical_surprise,
             config=config,
             visible_nodes=visible_nodes,
             burst_continued=burst_continued,
+            basin_structures=basin_structures,
         ),
         inhibited_nodes,
     )
 
-    # 2. Inhibit query-only routing when the cue depends on its active context.
+    # 3. Inhibit query-only routing when the cue depends on its active context.
     address_mass = _independent_address_mass(context_dependence)
     if address_mass == 0.0:
         return contextual
@@ -165,15 +183,17 @@ def read_pattern_completion(
             graph=graph,
             pool=pool,
             query=query,
+            precomputed_fields=precomputed_fields,
             surprise=evidence.surprise,
             historical_surprise=historical_surprise,
             config=config,
             visible_nodes=visible_nodes,
+            basin_structures=basin_structures,
         ),
         inhibited_nodes,
     )
 
-    # 3. Let address-only completions compete without evicting baseline items.
+    # 4. Let address-only completions compete without evicting baseline items.
     return _competitive_route_union(
         contextual,
         address,
@@ -221,20 +241,27 @@ def _read_contextual_route(
     pool: FeaturePool,
     query: Turn,
     context: ContextState,
+    precomputed_fields: dict[str, np.ndarray] | None,
     evidence: SeedEvidence,
     diffusion: DiffusionResult,
     historical_surprise: np.ndarray,
     config: MemoryConfig,
     visible_nodes: tuple[int, ...],
     burst_continued: bool,
+    basin_structures: tuple[_BasinStructure, ...],
 ) -> PatternCompletion:
     """Settle the existing current-cue plus active-context route."""
 
-    fields = _evidence_fields(pool, query.node_id, context)
-    scores = (
-        fields["current"]
-        + evidence.continuation
-        * (fields["same_event"] - fields["current"])
+    fields = (
+        _reuse_evidence_fields(
+            precomputed_fields,
+            include_context=burst_continued,
+        )
+        if precomputed_fields is not None
+        else _evidence_fields(pool, query.node_id, context)
+    )
+    scores = fields["current"] + evidence.continuation * (
+        fields["same_event"] - fields["current"]
     )
     return _read_route(
         graph=graph,
@@ -248,6 +275,7 @@ def _read_contextual_route(
         config=config,
         visible_nodes=visible_nodes,
         burst_continued=burst_continued,
+        basin_structures=basin_structures,
     )
 
 
@@ -256,14 +284,27 @@ def _read_independent_route(
     graph: DynamicMemoryGraph,
     pool: FeaturePool,
     query: Turn,
+    precomputed_fields: dict[str, np.ndarray] | None,
     surprise: float,
     historical_surprise: np.ndarray,
     config: MemoryConfig,
     visible_nodes: tuple[int, ...],
+    basin_structures: tuple[_BasinStructure, ...],
 ) -> PatternCompletion:
     """Settle a query-only graph-address route without active context."""
 
-    fields = _evidence_fields(pool, query.node_id, ContextState((), None, ()))
+    fields = (
+        _reuse_evidence_fields(
+            precomputed_fields,
+            include_context=False,
+        )
+        if precomputed_fields is not None
+        else _evidence_fields(
+            pool,
+            query.node_id,
+            ContextState((), None, ()),
+        )
+    )
     seed = _sparsemax(fields["current"])
     diffusion = residual_push(
         graph,
@@ -285,6 +326,7 @@ def _read_independent_route(
         config=config,
         visible_nodes=visible_nodes,
         burst_continued=False,
+        basin_structures=basin_structures,
     )
 
 
@@ -301,11 +343,12 @@ def _read_route(
     config: MemoryConfig,
     visible_nodes: tuple[int, ...],
     burst_continued: bool,
+    basin_structures: tuple[_BasinStructure, ...],
 ) -> PatternCompletion:
     """Settle one independently normalized basin-routing hypothesis."""
 
     # 1. Select live engram heads from this route's evidence.
-    basins = _active_basins(graph, query.node_id, basin_scores)
+    basins = _score_active_basins(basin_structures, basin_scores)
     temperature = _surprise_temperature(
         surprise,
         historical_surprise,
@@ -747,14 +790,42 @@ def _evidence_fields(
     }
 
 
-def _active_basins(
+def _reuse_evidence_fields(
+    source: dict[str, np.ndarray],
+    *,
+    include_context: bool,
+) -> dict[str, np.ndarray]:
+    """Project already calibrated seed evidence onto one readout route."""
+
+    # 1. Reuse the exact current-cue arrays produced by burst inference.
+    current_dense = source["query_dense"]
+    current_bm25 = source["query_bm25"]
+    current = current_dense + current_bm25
+
+    # 2. Match the existing empty-context route with exact zero arrays.
+    if include_context:
+        context_dense = source["context_dense"]
+        context_bm25 = source["context_bm25"]
+    else:
+        context_dense = np.zeros_like(current_dense)
+        context_bm25 = np.zeros_like(current_bm25)
+    same_event = current + context_dense + context_bm25
+    return {
+        "current": current,
+        "same_event": same_event,
+        "current_dense": current_dense,
+        "current_bm25": current_bm25,
+        "context_dense": context_dense,
+        "context_bm25": context_bm25,
+    }
+
+def _active_basin_structures(
     graph: DynamicMemoryGraph,
     event: int,
-    scores: np.ndarray,
-) -> tuple[Basin, ...]:
-    """Match cues to raw engram structure before decayed transmission."""
+) -> tuple[_BasinStructure, ...]:
+    """Snapshot raw engram structure before route-specific scoring."""
 
-    basins: list[Basin] = []
+    structures: list[_BasinStructure] = []
     for hub in graph.hubs:
         members: list[int] = []
         weights: list[float] = []
@@ -769,21 +840,42 @@ def _active_basins(
         member_array = np.asarray(members, dtype=np.int32)
         total = math.fsum(weights)
         normalized = np.asarray(weights) / total
-        values = scores[member_array]
-        peak = float(np.max(values))
-        pooled = peak + math.log(
-            float(np.sum(normalized * np.exp(values - peak)))
-        )
-        pooled *= -math.expm1(-total)
-        basins.append(
-            Basin(
+        structures.append(
+            _BasinStructure(
                 hub.created_event,
-                pooled,
                 tuple(members),
                 tuple(weights),
+                member_array,
+                normalized,
+                -math.expm1(-total),
+            )
+        )
+    return tuple(structures)
+
+def _score_active_basins(
+    structures: tuple[_BasinStructure, ...],
+    scores: np.ndarray,
+) -> tuple[Basin, ...]:
+    """Score one immutable basin snapshot with route-specific evidence."""
+
+    basins: list[Basin] = []
+    for structure in structures:
+        values = scores[structure.member_array]
+        peak = float(np.max(values))
+        pooled = peak + math.log(
+            float(np.sum(structure.normalized * np.exp(values - peak)))
+        )
+        pooled *= structure.conductance
+        basins.append(
+            Basin(
+                structure.hub_id,
+                pooled,
+                structure.members,
+                structure.weights,
             )
         )
     return tuple(basins)
+
 
 
 def _pooled_heads(

--- a/plugins/akasha/infrastructure/loader.py
+++ b/plugins/akasha/infrastructure/loader.py
@@ -23,8 +23,7 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
     connection.row_factory = sqlite3.Row
     try:
         _validate_index(connection)
-        rows = connection.execute(
-            """
+        rows = connection.execute("""
             SELECT turn_id, session_key, user_seq,
                    user_message_id, assistant_message_id,
                    started_at, committed_at, user_text, assistant_text,
@@ -32,19 +31,59 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
                    remember_boost
             FROM sparse_turns
             ORDER BY started_at, session_key, user_seq, turn_id
-            """
-        ).fetchall()
+            """).fetchall()
         rows.sort(key=_turn_sort_key)
         if max_turns is not None:
             if max_turns <= 0:
                 raise ValueError("max_turns must be positive")
             rows = rows[:max_turns]
-        selected = {row["turn_id"] for row in rows}
+        selected = {str(row["turn_id"]) for row in rows}
         dense = _load_dense(connection, selected)
         terms = _load_terms(connection, selected)
     finally:
         connection.close()
     return _materialize_turns(rows, dense, terms)
+
+
+def load_turn_suffix(index_path: Path, start: int) -> list[Turn]:
+    """Load one causal suffix without scanning historical feature payloads."""
+
+    if start < 0:
+        raise ValueError("turn suffix start cannot be negative")
+    connection = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    try:
+        _validate_index(connection)
+        all_rows = connection.execute("""
+            SELECT turn_id, session_key, user_seq,
+                   user_message_id, assistant_message_id,
+                   started_at, committed_at, user_text, assistant_text,
+                   remember_targets_json, forget_targets_json,
+                   remember_boost
+            FROM sparse_turns
+            ORDER BY started_at, session_key, user_seq, turn_id
+            """).fetchall()
+        all_rows.sort(key=_turn_sort_key)
+        if start > len(all_rows):
+            raise ValueError("turn suffix starts beyond the causal index")
+        rows = all_rows[start:]
+        selected = {str(row["turn_id"]) for row in rows}
+        dense = _load_dense(connection, selected, selective=True)
+        terms = _load_terms(connection, selected, selective=True)
+    finally:
+        connection.close()
+    node_by_turn = {
+        str(row["turn_id"]): node_id for node_id, row in enumerate(all_rows)
+    }
+    previous = None if start == 0 else _as_utc(all_rows[start - 1]["started_at"])
+    return _materialize_turns(
+        rows,
+        dense,
+        terms,
+        node_offset=start,
+        node_by_turn=node_by_turn,
+        previous=previous,
+    )
 
 
 def _validate_index(connection: sqlite3.Connection) -> None:
@@ -73,14 +112,16 @@ def _validate_index(connection: sqlite3.Connection) -> None:
 def _load_dense(
     connection: sqlite3.Connection,
     selected: set[str],
+    *,
+    selective: bool = False,
 ) -> dict[tuple[str, str], np.ndarray]:
     dense: dict[tuple[str, str], np.ndarray] = {}
-    rows = connection.execute(
-        """
-        SELECT turn_id, field, embedding, dim
-        FROM turn_dense
-        ORDER BY turn_id, field
-        """
+    rows = _feature_rows(
+        connection,
+        table="turn_dense",
+        columns="turn_id, field, embedding, dim",
+        selected=selected,
+        selective=selective,
     )
     for row in rows:
         if row["turn_id"] not in selected:
@@ -95,37 +136,73 @@ def _load_dense(
 def _load_terms(
     connection: sqlite3.Connection,
     selected: set[str],
+    *,
+    selective: bool = False,
 ) -> dict[tuple[str, str], tuple[tuple[str, int], ...]]:
     grouped: dict[tuple[str, str], list[tuple[str, int]]] = defaultdict(list)
-    rows = connection.execute(
-        """
-        SELECT turn_id, field, term, tf
-        FROM turn_terms
-        ORDER BY turn_id, field, term
-        """
+    rows = _feature_rows(
+        connection,
+        table="turn_terms",
+        columns="turn_id, field, term, tf",
+        selected=selected,
+        selective=selective,
     )
     for row in rows:
         if row["turn_id"] in selected:
-            grouped[(row["turn_id"], row["field"])].append(
-                (row["term"], row["tf"])
-            )
+            grouped[(row["turn_id"], row["field"])].append((row["term"], row["tf"]))
     return {key: tuple(values) for key, values in grouped.items()}
+
+
+def _feature_rows(
+    connection: sqlite3.Connection,
+    *,
+    table: str,
+    columns: str,
+    selected: set[str],
+    selective: bool,
+):
+    """Read a small suffix by primary-key prefix or stream the full table."""
+
+    if selective and len(selected) <= 500:
+        if not selected:
+            return ()
+        placeholders = ", ".join("?" for _ in selected)
+        ordered = tuple(sorted(selected, key=lambda item: item.encode("utf-8")))
+        return connection.execute(
+            (
+                f"SELECT {columns} FROM {table} "
+                f"WHERE turn_id IN ({placeholders}) "
+                "ORDER BY turn_id, field, term"
+                if table == "turn_terms"
+                else f"SELECT {columns} FROM {table} "
+                f"WHERE turn_id IN ({placeholders}) "
+                "ORDER BY turn_id, field"
+            ),
+            ordered,
+        )
+    order = "turn_id, field, term" if table == "turn_terms" else "turn_id, field"
+    return connection.execute(f"SELECT {columns} FROM {table} ORDER BY {order}")
 
 
 def _materialize_turns(
     rows: list[sqlite3.Row],
     dense: dict[tuple[str, str], np.ndarray],
     terms: dict[tuple[str, str], tuple[tuple[str, int], ...]],
+    *,
+    node_offset: int = 0,
+    node_by_turn: dict[str, int] | None = None,
+    previous: datetime | None = None,
 ) -> list[Turn]:
     """Attach validated features and derive global causal gaps."""
 
     turns: list[Turn] = []
-    node_by_turn = {
-        str(row["turn_id"]): node_id
-        for node_id, row in enumerate(rows)
-    }
-    previous: datetime | None = None
-    for node_id, row in enumerate(rows):
+    if node_by_turn is None:
+        node_by_turn = {
+            str(row["turn_id"]): node_id + node_offset
+            for node_id, row in enumerate(rows)
+        }
+    for local_node_id, row in enumerate(rows):
+        node_id = local_node_id + node_offset
         started = _as_utc(row["started_at"])
         gap = None if previous is None else (started - previous).total_seconds()
         if gap is not None and gap < 0.0:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -8,11 +8,13 @@ import sqlite3
 import struct
 import threading
 from contextlib import closing
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import numpy as np
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -39,9 +41,12 @@ from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryScope
 from core.memory.plugin import MemoryPlugin as MemoryPluginProtocol
+from plugins.akasha.application.cycle import MemoryCycle
 from plugins.akasha.application.rebuild import rebuild_memory
 from plugins.akasha.config import AkashaConfig, render_akasha_config
 from plugins.akasha.dashboard import register as register_dashboard
+from plugins.akasha.domain.features import BurstAwareFeaturePool
+from plugins.akasha.domain.model import MemoryConfig
 from plugins.akasha.engine import (
     ActiveRecallSnapshot,
     AkashaFeedbackPersistModule,
@@ -50,6 +55,7 @@ from plugins.akasha.engine import (
     RetrievalRecords,
 )
 from plugins.akasha.inspector import AkashaInspectorReader
+from plugins.akasha.infrastructure.loader import load_turn_suffix, load_turns
 from plugins.akasha.infrastructure.persistence import (
     logical_state_sha256,
 )
@@ -481,6 +487,130 @@ def test_mobile_recall_card_projection_preserves_bounded_lanes() -> None:
 def test_active_mobile_recall_marks_temporary_absence_as_pending() -> None:
     assert _empty_mobile_recall()["pending"] is False
     assert _empty_mobile_recall(pending=True)["pending"] is True
+
+
+def test_suffix_loader_and_appendable_features_match_full_replay(
+    tmp_path: Path,
+) -> None:
+    """Keep the incremental online view identical to full replay features."""
+
+    # 1. Build one causal source with dense, lexical, and temporal evidence.
+    sessions = tmp_path / "sessions.db"
+    index = tmp_path / "index.db"
+    _create_sessions(sessions)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    for offset, (user, assistant) in enumerate(
+        (
+            ("alpha first", "first answer"),
+            ("beta second", "alpha bridge"),
+            ("alpha third", "final answer"),
+        )
+    ):
+        _append_turn(
+            sessions,
+            sequence=offset * 2,
+            user=user,
+            assistant=assistant,
+            started=started + timedelta(minutes=offset * 3),
+            with_embeddings=True,
+        )
+    build_sparse_index(
+        sessions,
+        index,
+        BuildConfig(
+            embedding_model="embedding-model",
+            embedding_dimension=2,
+        ),
+    )
+
+    # 2. A suffix retains global node IDs, gaps, feedback, and feature bytes.
+    full = load_turns(index)
+    suffix = load_turn_suffix(index, 1)
+    assert len(full) == 3
+    assert len(suffix) == 2
+    for expected, actual in zip(full[1:], suffix, strict=True):
+        assert actual.node_id == expected.node_id
+        assert actual.turn_id == expected.turn_id
+        assert actual.inter_gap_seconds == expected.inter_gap_seconds
+        assert actual.user_terms == expected.user_terms
+        assert actual.assistant_terms == expected.assistant_terms
+        assert actual.feedback == expected.feedback
+        assert actual.user_dense is not None
+        assert expected.user_dense is not None
+        assert actual.assistant_dense is not None
+        assert expected.assistant_dense is not None
+        assert np.array_equal(actual.user_dense, expected.user_dense)
+        assert np.array_equal(
+            actual.assistant_dense,
+            expected.assistant_dense,
+        )
+
+    # 3. The O(1) query view and incremental append preserve full-pool results.
+    online = BurstAwareFeaturePool(full[:2], appendable=True)
+    replay = BurstAwareFeaturePool(full)
+    context = online.build_context(((1, 1.0),))
+    view = online.query_view(full[2])
+    online_decision = view.infer_burst_seed(2, context, (1,), True)
+    replay_decision = replay.infer_burst_seed(2, context, (1,), True)
+    assert view.turns is online.turns
+    assert online_decision.evidence == replay_decision.evidence
+    assert online_decision.base_continuation == (replay_decision.base_continuation)
+    assert online_decision.context_dependence == (replay_decision.context_dependence)
+    assert online_decision.context_mass == replay_decision.context_mass
+    assert online_decision.continued == replay_decision.continued
+    for name in online_decision.fields:
+        assert np.array_equal(
+            online_decision.fields[name],
+            replay_decision.fields[name],
+        )
+    online.append_turn(full[2])
+    assert np.array_equal(online.turn_dense[:3], replay.turn_dense)
+    assert np.array_equal(online.lengths[:3], replay.lengths)
+    assert np.array_equal(
+        online.context_dependence[:3],
+        replay.context_dependence,
+    )
+
+    # 4. A history without vectors can accept the first later dense turn.
+    sparse_first = replace(
+        full[0],
+        user_dense=None,
+        assistant_dense=None,
+    )
+    dense_online = BurstAwareFeaturePool(
+        [sparse_first],
+        appendable=True,
+    )
+    dense_online.append_turn(full[1])
+    dense_replay = BurstAwareFeaturePool([sparse_first, full[1]])
+    assert np.array_equal(dense_online.user_dense[:2], dense_replay.user_dense)
+    assert np.array_equal(
+        dense_online.assistant_dense[:2],
+        dense_replay.assistant_dense,
+    )
+    assert np.array_equal(dense_online.turn_dense[:2], dense_replay.turn_dense)
+
+    # 5. Diagnostic path capture cannot change committed online/replay state.
+    online_cycle = MemoryCycle(
+        MemoryConfig(),
+        turn_capacity=len(full),
+        feature_pool=BurstAwareFeaturePool(full),
+    )
+    replay_cycle = MemoryCycle(
+        MemoryConfig(),
+        turn_capacity=len(full),
+        feature_pool=BurstAwareFeaturePool(full),
+    )
+    for turn in full:
+        online_cycle.commit(
+            turn,
+            online_cycle.retrieve(turn, capture_paths=True),
+        )
+        replay_cycle.commit(
+            turn,
+            replay_cycle.retrieve(turn, capture_paths=False),
+        )
+    assert online_cycle.evidence == replay_cycle.evidence
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha 的串行在线轮次与完整 replay 在相同语义下存在重复建池、重复特征计算、重复 basin 遍历、SQLite 过量载荷读取，以及扩散热循环中的 Python/NumPy 标量开销。
- 用户可见结果：不改为异步、不减少候选、不改变稳定排序或浮点累加顺序。5214 轮完整 replay 从 573.433s 降到 359.284s（-37.345%，1.596x）；在线 query 中位数从 0.9076s 降到 0.1058s（-88.34%，8.576x）；在线 stage + publish 从 3.5836s 降到 2.2611s（-36.905%，1.585x）。
- 本 PR 不处理：网络调用、异步状态机、近似检索、UI、schema/migration，以及 Akasha canonical upstream mirror 的既有版本漂移。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`plugin`
- `consumer_scope`：Akasha 在线查询、在线提交与完整 replay
- `runtime_patch`：`none`
- `runtime_patch_reason`：核心 runtime 与协议无需修改，优化位于 Akasha 插件内部
- `authoritative_state_owner`：`sessions.db` 仍由 Session 子系统拥有；Akasha 插件只读取它并维护自己的派生索引
- `client_only_alternative`：不适用
- 关联不变量：同一条串行 `MemoryCycle.retrieve -> commit` 路径；稳定堆顺序为 residual 降序、node id 升序；浮点累加顺序不变；在线与 replay 的持久语义一致
- `protected_state`：正式 SessionDB、既有消息、召回 ticket、Akasha 17 张非 metadata 语义表及其逐行结果
- 允许的副作用：合并后只改变 Akasha 派生计算的执行方式与性能
- 禁止的副作用：修改正式 workspace、改变 SessionDB、引入异步/并行语义、减少候选、调整阈值或排序、静默降级

## 改动范围

- 主要文件：
  - `plugins/akasha/domain/features.py`：保留可追加 FeaturePool，查询使用 O(1) 共享视图，提交增量追加一轮
  - `plugins/akasha/domain/readout.py`：复用 burst 阶段已有 dense/BM25 字段，basin 结构只快照一次
  - `plugins/akasha/domain/diffusion.py`：内联热循环操作并改用 Python int 位置表，保持比较与累加顺序
  - `plugins/akasha/infrastructure/loader.py`：保留全量轻量元数据，只加载 suffix 的 dense/lexical payload
  - `plugins/akasha/application/runtime.py`、`cycle.py`：在线与 replay 继续共用串行生命周期，并规范化不影响学习的诊断 evidence
  - `tests/test_akasha_plugin.py`：覆盖 suffix loader、O(1) view、增量 append、首个 dense turn 与 capture parity
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无 schema 变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：
  - base：`a3cc6eab0ba9049dddbc22fff274abc0da827515`
  - head：`5a4a668a77c74068faf902b4357073b368f5bf2a`
  - replay 输入快照 SHA256：`38d73e353022b850facd91bed6201c8e4e67c45b9691871abd78e8e72486e9a1`
  - benchmark 实现提交：`9e98e48915daa49e4354f33a3e64aa9f2ff0738f`；rebase 后六个生产优化文件与该提交逐字一致
- 回滚方式：revert 本 PR 的单一实现提交；rebase 前恢复点为本地 `backup/perf-akasha-exact-replay-pre-rebase-20260809`

## 验证

- [x] 相关 targeted tests 已通过。
  - 当前 HEAD：`tests/test_akasha_plugin.py`，26 passed
  - canonical engine 单元测试：22 passed
- [x] Python 类型检查或前端 typecheck/lint 已通过；不适用项已说明。
  - production Pyright：0 errors
  - tests Pyright：0 errors
  - `compileall`：通过
  - `git diff --check`：通过
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`fbb2b86ab66ff23e9b0cd76fd79d5b4c42fb24518fd7e8f3e4fb19796b727d8f`
- `planDigest`：`6d95abd69e8308d23304f896f791e788d2fad8df6f1f56382be635c77cb94e5e`
- Gate 报告：`docker/debug/reports/change-gate/20260809-130016-5a1a02f8`，passed
- 完整 replay A/B：
  - 5214 turns、31 sessions、5101 hubs、23395 relations 完全一致
  - logical hash：`e08168336267dfb9cfd9027a936709c53ad594357ecb0718aece7b7f088d8cc7`
  - 17 张非 metadata 表逐行一致，包括 5214 个 recall runs 与 73015 个 recall items
- 在线与 replay 一致性：
  - 5215 turns、32 sessions、5102 hubs、23399 relations 完全一致
  - logical hash：`aa5df5ed9b43f58e8515d7ac2290b7aa1dde5b555de080d71900f33f7ad2da8f`
  - 17 张非 metadata 表逐行一致，包括 5215 个 recall runs 与 73031 个 recall items
- 真实设备证据：不适用，本 PR 不修改客户端或设备路径
- 未运行项与原因：
  - 未重跑网络调用，性能合同明确排除网络
  - replay 峰值 RSS 为 464268 KiB -> 466392 KiB（+0.457%），本 PR 不宣称 replay 峰值内存改善
  - 初次在独立 worktree 直接运行 Pyright 时因找不到 `.venv` 而缺少依赖；显式使用主 checkout 的共享 venv 后两套配置均为 0 errors
  - pinned upstream mirror 检查存在基线已有漂移；本 PR 不伪造 `UPSTREAM.json`，合并前仍需单独完成 canonical upstream 对账

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项。