### PR TITLE
[codex] add terminal mobile pairing

### DIFF
--- a/docs/design/akashic-core-bridge-installer.md
+++ b/docs/design/akashic-core-bridge-installer.md
@@ -180,8 +180,13 @@ error（若有）和人工命令；不能因第二个异常覆盖第一次失败
 akashic-release install [--commit SHA] [--yes]
 akashic-release doctor
 akashic-release rollback [--yes]
+akashic-release pair-mobile
 akashic-release migrate --snapshot-manifest PATH
 ```
+
+`pair-mobile` 只访问当前 release 的 loopback WebChat 管理入口，在 SSH 终端用锁定的 `qrcode`
+依赖直接绘制一次性二维码，等待已验签手机 claim，并要求 operator 输入相同的六位确认码后才批准。
+默认 pairing offer 有效期为 8 分钟；延长操作窗口不改变 secret 哈希存储、一次性消费、设备签名或人工确认。
 
 当前首版的 `migrate` 只校验预演 snapshot manifest 并输出 `plan_only` 阶段清单，明确返回
 `automaticDataWrites=false`。它不停止旧端、不复制正式 state、不切换 ingress；这些动作仍需维护者在

--- a/infra/mobile_realtime/pairing.py
+++ b/infra/mobile_realtime/pairing.py
@@ -28,7 +28,7 @@ from infra.mobile_realtime.storage import (
 
 _PAIRING_SECRET_BYTES = 32
 _PAIRING_SECRET_DOMAIN = b"akasic-mobile-pairing-secret-v1\x00"
-_PAIRING_TTL = timedelta(seconds=120)
+_PAIRING_TTL = timedelta(minutes=8)
 _MAX_ENDPOINTS = 16
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ protobuf>=6.33.0,<7
 pydantic>=2.12.0
 python-json-logger>=4.1.0,<5
 python-telegram-bot>=22.7
+qrcode>=8.2
 PyYAML>=6.0.0
 requests>=2.32.0
 rich>=14.0.0

--- a/scripts/akashic_release/cli.py
+++ b/scripts/akashic_release/cli.py
@@ -123,6 +123,12 @@ def rollback(args: argparse.Namespace) -> dict[str, object]:
     return {"status": status, "commit": previous}
 
 
+def pair_mobile(args: argparse.Namespace) -> dict[str, object]:
+    from scripts.akashic_release.mobile_pair import pair_mobile as run_pairing
+
+    return run_pairing(args.runtime_env)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="akashic-release")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -154,6 +160,10 @@ def _parser() -> argparse.ArgumentParser:
     rollback_parser.add_argument("--mise", type=Path, default=_DEFAULT_MISE)
     rollback_parser.add_argument("--yes", action="store_true")
     rollback_parser.set_defaults(handler=rollback)
+
+    pair_parser = subparsers.add_parser("pair-mobile")
+    pair_parser.add_argument("--runtime-env", type=Path, default=_DEFAULT_ENV)
+    pair_parser.set_defaults(handler=pair_mobile)
 
     migrate_parser = subparsers.add_parser("migrate")
     migrate_parser.add_argument("--snapshot-manifest", type=Path, required=True)

--- a/scripts/akashic_release/mobile_pair.py
+++ b/scripts/akashic_release/mobile_pair.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TextIO, cast
+
+import qrcode
+
+from scripts.akashic_release.doctor import read_environment
+
+RequestJson = Callable[[str, str, Mapping[str, object] | None], dict[str, object]]
+
+
+def pair_mobile(
+    environment_file: Path,
+    *,
+    input_fn: Callable[[str], str] = input,
+    output: TextIO = sys.stdout,
+    request_json: RequestJson | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> dict[str, object]:
+    """Create, render, confirm, and consume one mobile pairing offer."""
+
+    # 1. 只访问当前 release 的 loopback WebChat 管理入口
+    environment = read_environment(environment_file)
+    base_url = _loopback_base_url(environment)
+    request = request_json or _request_json
+    offer = request("POST", f"{base_url}/api/chat/mobile-pairing", None)
+    pairing_id = _text(offer, "pairing_id")
+    expires_at = _timestamp(offer, "expires_at")
+
+    # 2. 使用锁定依赖生成终端二维码，不打印 secret 原文
+    _print_qr(offer, output)
+    print(f"二维码有效期至 {expires_at.isoformat()}（约 8 分钟）。", file=output)
+    print("请用 Akashic Android 扫码，随后核对 6 位确认码。", file=output)
+
+    # 3. 等待已验签设备 claim，并要求 operator 输入相同确认码
+    claim = _wait_for_claim(
+        request=request,
+        base_url=base_url,
+        pairing_id=pairing_id,
+        expires_at=expires_at,
+        sleep=sleep,
+        now=now,
+    )
+    confirmation_code = _text(claim, "confirmation_code")
+    device_name = _text(claim, "device_name")
+    print(f"等待连接的设备：{device_name}", file=output)
+    print(f"服务端确认码：{confirmation_code}", file=output)
+    entered = input_fn("确认手机显示相同数字后，输入这 6 位确认码：").strip()
+    if entered != confirmation_code:
+        raise RuntimeError("确认码未匹配，未批准设备")
+
+    # 4. 由既有 pairing owner 原子消费 secret 并登记设备
+    device = request(
+        "POST",
+        f"{base_url}/api/chat/mobile-pairing/{pairing_id}/approve",
+        {"confirmation_code": confirmation_code},
+    )
+    return {
+        "status": "paired",
+        "deviceId": _text(device, "device_id"),
+        "displayName": _text(device, "display_name"),
+    }
+
+
+def _loopback_base_url(environment: Mapping[str, str]) -> str:
+    raw_port = environment.get("AKASHIC_PUBLISHED_WEB_PORT", "2236")
+    try:
+        port = int(raw_port)
+    except ValueError as error:
+        raise RuntimeError("AKASHIC_PUBLISHED_WEB_PORT 必须为端口整数") from error
+    if not 1 <= port <= 65535:
+        raise RuntimeError("AKASHIC_PUBLISHED_WEB_PORT 超出有效范围")
+    return f"http://127.0.0.1:{port}"
+
+
+def _request_json(
+    method: str,
+    url: str,
+    payload: Mapping[str, object] | None,
+) -> dict[str, object]:
+    """Call the loopback pairing API and require one JSON object response."""
+
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {} if body is None else {"Content-Type": "application/json"}
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            value = json.load(response)
+    except (urllib.error.HTTPError, urllib.error.URLError) as error:
+        raise RuntimeError(f"手机配对 API 调用失败: {method} {url}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError("手机配对 API 必须返回 JSON object")
+    return cast(dict[str, object], value)
+
+
+def _print_qr(offer: Mapping[str, object], output: TextIO) -> None:
+    encoded = json.dumps(offer, ensure_ascii=False, separators=(",", ":"))
+    qr_module = cast(Any, qrcode)
+    qr = qr_module.QRCode(
+        error_correction=qr_module.constants.ERROR_CORRECT_M,
+        border=2,
+    )
+    qr.add_data(encoded)
+    qr.make(fit=True)
+    qr.print_ascii(out=output, tty=False, invert=True)
+
+
+def _wait_for_claim(
+    *,
+    request: RequestJson,
+    base_url: str,
+    pairing_id: str,
+    expires_at: datetime,
+    sleep: Callable[[float], None],
+    now: Callable[[], datetime],
+) -> dict[str, object]:
+    """Poll until a verified device claim arrives or the offer expires."""
+
+    path = f"{base_url}/api/chat/mobile-pairing/{pairing_id}"
+    while now() < expires_at:
+        status = request("GET", path, None)
+        state = _text(status, "status")
+        if state == "waiting_for_desktop_confirmation":
+            return status
+        if state != "waiting_for_phone":
+            raise RuntimeError(f"未知配对状态: {state}")
+        sleep(1.25)
+    raise RuntimeError("二维码已过期，未批准设备")
+
+
+def _text(value: Mapping[str, object], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise RuntimeError(f"手机配对响应缺少 {key}")
+    return item
+
+
+def _timestamp(value: Mapping[str, object], key: str) -> datetime:
+    raw = _text(value, key)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise RuntimeError(f"手机配对响应的 {key} 非法") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RuntimeError(f"手机配对响应的 {key} 必须含时区")
+    return parsed

--- a/tests/mobile_realtime/test_pairing_auth.py
+++ b/tests/mobile_realtime/test_pairing_auth.py
@@ -108,6 +108,23 @@ def _services(
     return storage, service, keyset
 
 
+def test_default_pairing_offer_lasts_eight_minutes(tmp_path: Path) -> None:
+    storage, _service, keyset = _services(tmp_path)
+    now = datetime(2026, 8, 11, 2, 30, tzinfo=timezone.utc)
+    service = PairingService(
+        storage,
+        keyset,
+        lan_endpoints=("wss://akashic.local:6323/ws",),
+        tunnel_endpoints=("wss://mobile.huashen258.cc/ws",),
+        clock=lambda: now,
+    )
+
+    offer = service.create_offer()
+
+    assert offer.expires_at == now + timedelta(minutes=8)
+    storage.close()
+
+
 def test_pairing_requires_signed_claim_and_desktop_confirmation(tmp_path: Path) -> None:
     storage, service, _ = _services(tmp_path)
     device_key = ec.generate_private_key(ec.SECP256R1())

--- a/tests/test_mobile_pair_cli.py
+++ b/tests/test_mobile_pair_cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from scripts.akashic_release.mobile_pair import pair_mobile
+
+
+def _offer(now: datetime) -> dict[str, object]:
+    return {
+        "protocol_version": 1,
+        "server_id": "server-1",
+        "server_application_key_fingerprint": "fingerprint",
+        "server_application_public_key": "public-key",
+        "lan_endpoints": ["wss://akashic.local:6323/ws"],
+        "tunnel_endpoints": ["wss://mobile.huashen258.cc/ws"],
+        "tls_spki_pins": ["pin"],
+        "pairing_id": "pairing-1",
+        "one_time_secret": "secret-must-only-exist-inside-qr",
+        "expires_at": (now + timedelta(minutes=8)).isoformat(),
+    }
+
+
+def test_terminal_pairing_renders_qr_and_requires_matching_code(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 11, 2, 30, tzinfo=timezone.utc)
+    environment = tmp_path / "runtime.env"
+    environment.write_text("AKASHIC_PUBLISHED_WEB_PORT=2236\n", encoding="utf-8")
+    calls: list[tuple[str, str, object]] = []
+    statuses = iter(
+        [
+            {"pairing_id": "pairing-1", "status": "waiting_for_phone"},
+            {
+                "pairing_id": "pairing-1",
+                "status": "waiting_for_desktop_confirmation",
+                "device_name": "Pixel 9",
+                "confirmation_code": "482913",
+                "capabilities": ["stream-v1"],
+            },
+        ]
+    )
+
+    def request(method: str, url: str, payload: object) -> dict[str, object]:
+        calls.append((method, url, payload))
+        if url.endswith("/api/chat/mobile-pairing"):
+            return _offer(now)
+        if method == "GET":
+            return next(statuses)
+        return {"device_id": "device-1", "display_name": "Pixel 9"}
+
+    output = StringIO()
+    result = pair_mobile(
+        environment,
+        input_fn=lambda _prompt: "482913",
+        output=output,
+        request_json=request,
+        sleep=lambda _seconds: None,
+        now=lambda: now,
+    )
+
+    assert result == {
+        "status": "paired",
+        "deviceId": "device-1",
+        "displayName": "Pixel 9",
+    }
+    assert "约 8 分钟" in output.getvalue()
+    assert "服务端确认码：482913" in output.getvalue()
+    assert "secret-must-only-exist-inside-qr" not in output.getvalue()
+    assert all("127.0.0.1:2236" in url for _method, url, _payload in calls)
+    assert calls[-1][2] == {"confirmation_code": "482913"}
+
+
+def test_terminal_pairing_rejects_mismatched_confirmation_without_approval(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 11, 2, 30, tzinfo=timezone.utc)
+    environment = tmp_path / "runtime.env"
+    environment.write_text("AKASHIC_PUBLISHED_WEB_PORT=2236\n", encoding="utf-8")
+    calls: list[str] = []
+
+    def request(method: str, url: str, _payload: object) -> dict[str, object]:
+        calls.append(method)
+        if url.endswith("/api/chat/mobile-pairing"):
+            return _offer(now)
+        return {
+            "pairing_id": "pairing-1",
+            "status": "waiting_for_desktop_confirmation",
+            "device_name": "Unknown phone",
+            "confirmation_code": "482913",
+        }
+
+    with pytest.raises(RuntimeError, match="未批准"):
+        pair_mobile(
+            environment,
+            input_fn=lambda _prompt: "000000",
+            output=StringIO(),
+            request_json=request,
+            sleep=lambda _seconds: None,
+            now=lambda: now,
+        )
+
+    assert calls == ["POST", "GET"]

--- a/tests/test_mobile_pair_cli.py
+++ b/tests/test_mobile_pair_cli.py
@@ -31,18 +31,17 @@ def test_terminal_pairing_renders_qr_and_requires_matching_code(
     environment = tmp_path / "runtime.env"
     environment.write_text("AKASHIC_PUBLISHED_WEB_PORT=2236\n", encoding="utf-8")
     calls: list[tuple[str, str, object]] = []
-    statuses = iter(
-        [
-            {"pairing_id": "pairing-1", "status": "waiting_for_phone"},
-            {
-                "pairing_id": "pairing-1",
-                "status": "waiting_for_desktop_confirmation",
-                "device_name": "Pixel 9",
-                "confirmation_code": "482913",
-                "capabilities": ["stream-v1"],
-            },
-        ]
-    )
+    status_values: list[dict[str, object]] = [
+        {"pairing_id": "pairing-1", "status": "waiting_for_phone"},
+        {
+            "pairing_id": "pairing-1",
+            "status": "waiting_for_desktop_confirmation",
+            "device_name": "Pixel 9",
+            "confirmation_code": "482913",
+            "capabilities": ["stream-v1"],
+        },
+    ]
+    statuses = iter(status_values)
 
     def request(method: str, url: str, payload: object) -> dict[str, object]:
         calls.append((method, url, payload))


### PR DESCRIPTION
## 改动

- 新增 `akashic-release pair-mobile`，通过当前 release 的 loopback WebChat API 创建、轮询并批准配对
- 使用锁定的 `qrcode` 依赖在 SSH 终端直接绘制可扫描二维码
- 将默认配对 offer 有效期从 120 秒调整为 8 分钟
- 保留一次性 secret、手机签名 claim、六位码人工确认和原子消费语义

## 影响

迁移到无桌面的 hua-home 后，operator 无需 WebChat 桌面即可在 SSH 中完成 Android 配对。二维码正文不会作为文本写入终端日志，API 只访问 loopback。

## 验证

- `pytest -q tests/mobile_realtime tests/test_mobile_pair_cli.py tests/test_akashic_release_installer.py`：234 passed
- `pyright scripts/akashic_release/mobile_pair.py`：0 errors, 0 warnings
- `python docker/debug/gate.py run --base origin/main`：GATE PASSED