### PR TITLE
[codex] render systemd service user home

### DIFF
--- a/scripts/akashic_release/systemd.py
+++ b/scripts/akashic_release/systemd.py
@@ -49,7 +49,11 @@ def install_units(
     """Install changed unit templates with a recoverable pre-write backup."""
 
     source_root = checkout / "docker" / "host-runtime" / "systemd"
-    service_user = pwd.getpwuid(os.getuid()).pw_name
+    service_account = pwd.getpwuid(os.getuid())
+    service_user = service_account.pw_name
+    service_home = Path(service_account.pw_dir)
+    if not service_home.is_absolute():
+        raise RuntimeError("service user home 必须为绝对路径")
     service_group = grp.getgrgid(os.getgid()).gr_name
     changed: list[tuple[str, bytes, Path]] = []
     for name in _UNITS:
@@ -57,7 +61,7 @@ def install_units(
         target = unit_root / name
         if not source.is_file():
             raise RuntimeError(f"release 缺少 systemd unit: {source}")
-        rendered = _render_unit(source, service_user, service_group)
+        rendered = _render_unit(source, service_user, service_group, service_home)
         if not target.exists() or target.read_bytes() != rendered:
             changed.append((name, rendered, target))
     if not changed:
@@ -89,12 +93,19 @@ def install_units(
     return True
 
 
-def _render_unit(source: Path, service_user: str, service_group: str) -> bytes:
+def _render_unit(
+    source: Path,
+    service_user: str,
+    service_group: str,
+    service_home: Path,
+) -> bytes:
     text = source.read_text(encoding="utf-8")
     if text.count("User=huashen") != 1 or text.count("Group=huashen") != 1:
         raise RuntimeError(f"systemd unit 用户模板结构无效: {source}")
-    rendered = text.replace("User=huashen", f"User={service_user}").replace(
-        "Group=huashen", f"Group={service_group}"
+    rendered = (
+        text.replace("User=huashen", f"User={service_user}")
+        .replace("Group=huashen", f"Group={service_group}")
+        .replace("%h", str(service_home))
     )
     if (
         rendered.count(f"User={service_user}") != 1

--- a/tests/test_akashic_release_installer.py
+++ b/tests/test_akashic_release_installer.py
@@ -391,7 +391,9 @@ def test_unit_install_backs_up_changed_file(
     monkeypatch.setattr(
         systemd_module.pwd,
         "getpwuid",
-        lambda _uid: SimpleNamespace(pw_name="operator"),
+        lambda _uid: SimpleNamespace(
+            pw_name="operator", pw_dir="/srv/operators/operator"
+        ),
     )
     monkeypatch.setattr(
         systemd_module.grp,
@@ -440,7 +442,7 @@ def test_unit_install_accepts_canonical_huashen_service_identity(
     monkeypatch.setattr(
         systemd_module.pwd,
         "getpwuid",
-        lambda _uid: SimpleNamespace(pw_name="huashen"),
+        lambda _uid: SimpleNamespace(pw_name="huashen", pw_dir="/home/huashen"),
     )
     monkeypatch.setattr(
         systemd_module.grp,
@@ -470,6 +472,11 @@ def test_unit_install_accepts_canonical_huashen_service_identity(
         rendered = (unit_root / name).read_text(encoding="utf-8")
         assert "User=huashen" in rendered
         assert "Group=huashen" in rendered
+        assert "%h" not in rendered
+        assert (
+            "EnvironmentFile=/home/huashen/.config/akashic-container/runtime.env"
+            in rendered
+        )
 
 
 def test_isolated_unit_root_requires_and_verifies_external_contract(


### PR DESCRIPTION
## 问题

System systemd 不会按 `User=` 把 unit 中的 `%h` 解析为该用户 home。真实 hua-home 首次启动外围 unit 已复现：EnvironmentFile 被解析到错误 home，服务在进入容器前以 `resources` 失败。Core/Bridge 模板仍使用同一写法。

## 修复

- installer 从 passwd 记录读取当前 service user 的绝对 home
- 安装 unit 时同时渲染 User、Group 和 `%h`
- 合同测试确认安装后的 Core/Bridge unit 不再保留 `%h`，并指向真实 runtime.env

## 验证

- `pytest -q tests/test_akashic_release_installer.py`：18 passed
- `pyright scripts/akashic_release/systemd.py tests/test_akashic_release_installer.py --level error`：0 errors
- 公开语义 Gate 正在最终 main 上复跑。