### PR TITLE
fix(installer): enable runtime units

### DIFF
--- a/docs/design/akashic-core-bridge-installer.md
+++ b/docs/design/akashic-core-bridge-installer.md
@@ -172,8 +172,9 @@ fail-loud，不覆盖目录。staging 失败只清理本轮 manifest 明确拥�
   → 写 completed activation receipt
 ```
 
-unit 内容未变化时不重写、不执行无意义的 daemon-reload。模板变化时由普通用户执行 installer，仅在
-安装 system unit、daemon-reload 和 unit 控制的窄步骤调用 sudo；服务进程继续使用声明的非 root 用户。
+unit 内容未变化时不重写、不执行无意义的 daemon-reload；每次安装仍显式核对并启用 Core 与 Bridge，
+保证首次安装和同代重装都能在宿主重启后恢复。模板变化时由普通用户执行 installer，仅在安装 system
+unit、daemon-reload、enable 和 unit 控制的窄步骤调用 sudo；服务进程继续使用声明的非 root 用户。
 指定非默认 `--unit-root` 时进入离线验证路径：外围 unit 必须存在于该隔离目录并通过
 `systemd-analyze verify`，Core/Bridge unit 只原子写入该目录，不调用 sudo 或 reload 正式 systemd。
 首次激活从系统 Python 发起时，UDS/gRPC probe 仍以候选 generation 的 Bridge Python 子进程运行；

--- a/scripts/akashic_release/systemd.py
+++ b/scripts/akashic_release/systemd.py
@@ -65,6 +65,8 @@ def install_units(
         if not target.exists() or target.read_bytes() != rendered:
             changed.append((name, rendered, target))
     if not changed:
+        if unit_root == _SYSTEM_UNIT_ROOT:
+            run(["sudo", "systemctl", "enable", *_UNITS], check=True)
         return False
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -90,6 +92,7 @@ def install_units(
             staged.unlink()
     if unit_root == _SYSTEM_UNIT_ROOT:
         run(["sudo", "systemctl", "daemon-reload"], check=True)
+        run(["sudo", "systemctl", "enable", *_UNITS], check=True)
     return True
 
 

--- a/tests/test_akashic_release_installer.py
+++ b/tests/test_akashic_release_installer.py
@@ -510,6 +510,55 @@ def test_unit_install_accepts_canonical_huashen_service_identity(
         )
 
 
+def test_unit_install_enables_unchanged_system_units(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        systemd_module.pwd,
+        "getpwuid",
+        lambda _uid: SimpleNamespace(pw_name="huashen", pw_dir="/home/huashen"),
+    )
+    monkeypatch.setattr(
+        systemd_module.grp,
+        "getgrgid",
+        lambda _gid: SimpleNamespace(gr_name="huashen"),
+    )
+    checkout = Path(__file__).resolve().parents[1]
+    unit_root = tmp_path / "units"
+    unit_root.mkdir()
+    monkeypatch.setattr(systemd_module, "_SYSTEM_UNIT_ROOT", unit_root)
+    for name in ("akashic-host-bridge.service", "akashic-core.service"):
+        source = checkout / "docker/host-runtime/systemd" / name
+        rendered = systemd_module._render_unit(
+            source, "huashen", "huashen", Path("/home/huashen")
+        )
+        (unit_root / name).write_bytes(rendered)
+    calls: list[list[str]] = []
+
+    def run(
+        arguments: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(arguments)
+        return subprocess.CompletedProcess(arguments, 0)
+
+    assert not install_units(
+        checkout=checkout,
+        backup_root=tmp_path / "backups",
+        run=run,
+        unit_root=unit_root,
+    )
+    assert calls == [
+        [
+            "sudo",
+            "systemctl",
+            "enable",
+            "akashic-host-bridge.service",
+            "akashic-core.service",
+        ]
+    ]
+
+
 def test_isolated_unit_root_requires_and_verifies_external_contract(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：首次安装只启动 Core/Bridge，却未 enable，宿主重启后不会自动恢复。
- 用户可见结果：首次安装和同代重装都会显式 enable 两个 unit；未变化的 unit 不重写、不 daemon-reload。
- 本 PR 不处理：服务运行策略、数据迁移、外围容器生命周期。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Core + HostBridge installer
- `runtime_patch`：`none`
- `runtime_patch_reason`：不适用
- `authoritative_state_owner`：systemd
- `client_only_alternative`：不适用
- 关联不变量：RUN-015，systemd 持有正式进程生命周期
- `protected_state`：workspace、release generation、runtime.env、外围服务
- 允许的副作用：`systemctl enable` Core/Bridge
- 禁止的副作用：启动额外服务、修改数据或重写未变化 unit

## 改动范围

- 主要文件：`scripts/akashic_release/systemd.py`、installer tests、安装设计
- 配置或迁移影响：无 schema 或数据迁移
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：本 PR HEAD + Gate report
- 回滚方式：revert 本 PR；已生成的 enable symlink 可用 `systemctl disable` 撤销

## 验证

- [x] 相关 targeted tests 已通过：20 passed。
- [x] Python 类型检查或前端 typecheck/lint：本次无新增类型边界；公开 Gate 包含对应检查。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`007c98f1ee6cc7e91bd35360c6c9b6be66a290f2ea97dc080f216ccef8e3fa76`
- `planDigest`：`5e6908ce4136f2115a3123d3fc8761150b0cc099948782ae4c409f8ac031f451`
- 真实设备证据：不适用
- 未运行项与原因：无真实宿主重启；目标机已发现并复现 disabled 状态，合并后会在目标机执行 enable 与重启恢复验收。

## 工作手册

- [x] 已核对 `projectneed.md`、相关设计和 `NOW.md`。
- [x] 本次没有未经确认的长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 无对应事项。
