### PR TITLE
fix(runtime): align healthcheck readiness window

### DIFF
--- a/docker/host-runtime/compose.experiment.yaml
+++ b/docker/host-runtime/compose.experiment.yaml
@@ -61,7 +61,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: "${AKASHIC_READINESS_TIMEOUT_S:-120}s"
     stop_grace_period: 60s
     logging:
       driver: local

--- a/tests/test_akashic_release_installer.py
+++ b/tests/test_akashic_release_installer.py
@@ -369,6 +369,7 @@ def test_release_environment_preserves_web_bind_and_loopback_mobile_port(
     )
     assert '127.0.0.1:${AKASHIC_PUBLISHED_MOBILE_PORT:-6323}:6323' in compose
     assert 'TZ: "${TZ:-Asia/Shanghai}"' in compose
+    assert 'start_period: "${AKASHIC_READINESS_TIMEOUT_S:-120}s"' in compose
 
 
 def test_activation_rejects_unadopted_legacy_skill_before_stopping(


### PR DESCRIPTION
## Summary
- align Docker healthcheck start period with the Core readiness budget
- keep cold plugin startup from being marked unhealthy before readiness can complete
- cover the Compose readiness contract in the release installer test

## Incident evidence
- hua-home candidate `a978dd4` reached Web readiness but Docker marked it unhealthy while cold plugin loading was still in progress
- the installer rolled back automatically to `88cd9b7`

## Verification
- `/mnt/data/coding/akasic-agent/.venv/bin/python -m pytest -q tests/test_akashic_release_installer.py` (20 passed)
- `git diff --check`