### PR TITLE
fix(installer): pin Bridge venv to mise Python

### DIFF
--- a/scripts/akashic_release/bridge.py
+++ b/scripts/akashic_release/bridge.py
@@ -42,8 +42,24 @@ def prepare_bridge_venv(
             cwd=checkout,
             check=True,
         )
+        python_executable = run(
+            [str(mise), "which", "python"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
         run(
-            [str(mise), "exec", "--", "uv", "venv", str(target)],
+            [
+                str(mise),
+                "exec",
+                "--",
+                "uv",
+                "venv",
+                "--python",
+                python_executable,
+                str(target),
+            ],
             cwd=checkout,
             check=True,
         )

--- a/tests/test_akashic_release_installer.py
+++ b/tests/test_akashic_release_installer.py
@@ -151,6 +151,12 @@ def test_bridge_venv_uses_hashed_requirements_from_domestic_index(
         arguments: list[str], **_kwargs: object
     ) -> subprocess.CompletedProcess[str]:
         calls.append(arguments)
+        if arguments[-2:] == ["which", "python"]:
+            return subprocess.CompletedProcess(
+                arguments,
+                0,
+                stdout="/mise/python/3.14.6/bin/python\n",
+            )
         if "venv" in arguments:
             (target / "bin").mkdir(parents=True)
             (target / "bin/python").write_text("", encoding="utf-8")
@@ -169,6 +175,10 @@ def test_bridge_venv_uses_hashed_requirements_from_domestic_index(
         "https://pypi.tuna.tsinghua.edu.cn/simple"
     )
     assert "--require-hashes" in install
+    create = calls[-2]
+    assert create[create.index("--python") + 1] == (
+        "/mise/python/3.14.6/bin/python"
+    )
 
 
 def test_bridge_probe_uses_generation_python_without_secret_arguments(


### PR DESCRIPTION
## Summary
- resolve the exact Python selected by the checkout mise contract
- pass that interpreter explicitly to `uv venv`
- cover the interpreter selection in installer tests

## Verification
- `/mnt/data/coding/akasic-agent/.venv/bin/pytest -q tests/test_akashic_release_installer.py tests/test_verify_host_runtime_deployment.py` (24 passed)
- `uvx ruff check --select E,F scripts/akashic_release/bridge.py`
- `git diff --check`

## Runtime evidence
On hua-home, the prior unpinned command selected CPython 3.12.13 while `mise which python` selected 3.14.6, causing the canonical host-toolchain verifier to reject the release before activation.