### PR TITLE
fix(mobile): reconcile interrupted turns after restart

### DIFF
--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -830,10 +830,6 @@ class AppRuntime:
                 ),
                 ("message_bus.aclose", _close_message_bus(self.bus)),
                 (
-                    "mobile_gateway.close",
-                    _close_mobile_gateway(self.mobile_gateway_runtime),
-                ),
-                (
                     "plugin_watcher.stop",
                     _stop_plugin_watcher(
                         self.plugin_watcher,
@@ -879,6 +875,10 @@ class AppRuntime:
                 (
                     "channels.stop",
                     self.channel_host.stop_all if self.channel_host else _noop_async,
+                ),
+                (
+                    "mobile_gateway.close",
+                    _close_mobile_gateway(self.mobile_gateway_runtime),
                 ),
                 (
                     "plugin_services.stop",

--- a/docker/host-runtime/systemd/akashic-core.service
+++ b/docker/host-runtime/systemd/akashic-core.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Akashic Core container
-Requires=akashic-host-bridge.service akashic-home-services.service
+Requires=akashic-host-bridge.service
 Requires=docker.service
+Wants=akashic-home-services.service
 After=docker.service akashic-host-bridge.service akashic-home-services.service
-PartOf=akashic-host-bridge.service akashic-home-services.service
+PartOf=akashic-host-bridge.service
 StartLimitIntervalSec=120
 StartLimitBurst=3
 

--- a/docs/design/akashic-core-bridge-installer.md
+++ b/docs/design/akashic-core-bridge-installer.md
@@ -89,6 +89,11 @@ scripts/install-akashic.sh
 systemd unit 是稳定入口，通常只在模板摘要变化时更新。固定 EnvironmentFile 由安装器通过同目录临时
 文件、fsync 和原子替换切换 generation；secret 不进入 release manifest 或日志。
 
+Core 对 HostBridge 使用 `Requires`、`After` 与 `PartOf`，因为二者属于同一 release 和执行边界。外围
+`akashic-home-services.service` 只使用 `Wants` 与 `After`：启动 Core 时尝试拉起外围容器并等待其启动
+顺序，但外围服务的维护停止或重启不得传播为 Core 停机。外围端点不可用继续由各插件的运行时健康和
+显式错误语义暴露，不能通过 systemd 生命周期耦合中断正在生成的 turn。
+
 ## 4. HostBridge 并发与生命周期
 
 当前 `_manager_operation` 在整个 RPC 期间持有 `operation_lock`。一个 Core 只有一个 Shell manager，

--- a/docs/design/codex-style-same-turn-input.md
+++ b/docs/design/codex-style-same-turn-input.md
@@ -84,6 +84,9 @@ interaction 仍按正常 U/A 规则学习。本设计不把 proactive assistant 
 ## 5. Channel 和 UI
 
 - Mobile：active 时无论草稿是否为空都只显示中止，草稿保留但发送不可用；中止收束后恢复发送。中止继续调用 `turn.stop`。
+- Mobile resume：客户端上报本地 `active_turns`，Core 必须在冻结 durable replay 窗口前读取 SessionDB 权威 turn。`interrupted`、`cancelled`、`failed` 补发定向 `turn.interrupted`；`completed` 继续由 `message.final` 或 history 恢复，不能伪装成中断。
+- Mobile stop：同一 turn 已在 SessionDB 终态时，`turn.stop` 幂等返回 `already_terminal`。只有 `terminal_status` 为 `interrupted`、`cancelled` 或 `failed` 时，Android 才把精确匹配的本地 streaming 消息和运行中 block 在同一 Room 事务内收敛，并删除对应 stop 意图。`completed` 必须由携带 `control_turn_id` 的 canonical `message.final` 或 history 迁移，不能伪装成中断；`turn_not_active`、`stale_turn`、未知 turn 或会话不匹配保留未确认投影并明确失败。
+- Mobile shutdown：计划停止 channel 时先 flush delta 并持久发布未完成 turn 的 `turn.interrupted`，再清理进程内 active map。异常退出遗漏的终态由下一次 resume 对账修复。
 - Telegram、QQ、Web Chat：`/stop` 或现有 stop command 结束 active attempt；终态后的下一条普通消息自动续接未完成 interaction。
 - Programmatic control：`turn/start` 在 active 时返回 busy；只有 `turn/interrupt` 能改变 active attempt。
 
@@ -108,6 +111,7 @@ interaction 仍按正常 U/A 规则学习。本设计不把 proactive assistant 
 - proactive：主动 assistant 独占一个历史单元，不进入 Akasha；相邻被动 interaction 保持独立。
 - channel：中止 attempt 不发送 assistant outbound；后续消息的新 attempt 最终只发送一次 A。
 - Mobile：验证 idle 显示 send，active 空草稿和 active 有草稿都显示 stop，stopping 显示 pending stop；active 时快捷键和 native send 同样被拒绝。
+- Mobile recovery：验证维护重启后 SessionDB 已终态但 durable inbox 缺失终态时，resume 在 `sync.completed` 前补发关闭信号；非 completed 的 `already_terminal` 能清掉精确匹配的 Room streaming 投影和 stop 意图；completed history 按 `control_turn_id` 迁移 canonical identity；`turn_not_active`、`stale_turn` 和普通协议错误不能误清理。
 - Akasha：`U1,U2,U3,A` 在线与离线得到一个相同 turn；legacy pair 不回归。
 - known-bad：邻接配对、seal 后仍接收、第二 inbound 重复发送 final A、工具批次中途注入。
 - known-bad：active `turn/start` 被隐式 steer、按物理 message 数裁掉 U1、consolidation 游标落在 multi-U turn 内、attempt replay 永远不可压缩。

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -36,6 +36,7 @@ from agent.plugins.mobile_ui import (
     MobileUiRpcInvalidRequest,
     MobileUiStaleRevision,
 )
+from agent.control.models import TurnStatus
 from agent.model_runtime.session_selection import read_session_model_selection
 from infra.mobile_realtime.runtime_inspection import (
     RuntimeInspectionError,
@@ -281,6 +282,31 @@ class MobileRealtimeChannel:
         )
 
     async def stop(self) -> None:
+        """先发布活动 turn 的终态，再释放移动渠道运行态。"""
+
+        # 1. 计划停机必须把已向手机公开的活动 turn 收敛为终态
+        store = self._require_ctx().session_manager.control_store
+        for session_id, turn_id in tuple(self._active_turn_ids.items()):
+            turn = store.read_turn(turn_id)
+            if turn is not None and turn.status is TurnStatus.COMPLETED:
+                continue
+            await self._flush_deltas(session_id, turn_id)
+            await self._runtime.publish_event(
+                event_type="turn.interrupted",
+                session_id=session_id,
+                turn_id=turn_id,
+                payload={
+                    "status": (
+                        turn.status.value
+                        if turn is not None and turn.status.is_terminal
+                        else TurnStatus.INTERRUPTED.value
+                    ),
+                    "message": "服务端正在维护，本轮生成已中断",
+                    "reason": "runtime_shutdown",
+                },
+            )
+
+        # 2. 终态已持久化后再取消批处理并清理进程内状态
         for batch in self._delta_batches.values():
             _ = batch.timer.cancel()
         if self._delta_batches:
@@ -297,6 +323,42 @@ class MobileRealtimeChannel:
         self._process_turns.clear()
         self._processing_commands.clear()
         self._receipt_completion_failures.clear()
+
+    async def reconcile_active_turns(
+        self,
+        *,
+        device_id: str,
+        active_turns: tuple[str, ...],
+    ) -> None:
+        """把客户端残留的活动 turn 与 SessionDB 权威终态对账。"""
+
+        # 1. 只接受属于移动会话且已被手机声明过的权威 turn
+        if not active_turns:
+            return
+        store = self._require_ctx().session_manager.control_store
+        for turn_id in active_turns:
+            turn = store.read_turn(turn_id)
+            if (
+                turn is None
+                or not turn.thread_id.startswith("mobile:")
+                or not self._runtime.storage.has_session_claim(turn.thread_id)
+            ):
+                continue
+
+            # 2. completed 由 durable message.final/history 恢复，其余终态补发关闭信号
+            if not turn.status.is_terminal or turn.status is TurnStatus.COMPLETED:
+                continue
+            await self._runtime.publish_event(
+                event_type="turn.interrupted",
+                session_id=turn.thread_id,
+                turn_id=turn.id,
+                payload={
+                    "status": turn.status.value,
+                    "message": "服务端已确认本轮生成结束",
+                    "reason": "resume_reconciliation",
+                },
+                device_id=device_id,
+            )
 
     async def handle_command(
         self,
@@ -1518,6 +1580,34 @@ class MobileRealtimeChannel:
         turn_id = frame.turn_id
         if turn_id is None:
             raise MobileCommandError("turn_id_required", "停止生成必须携带 turn_id")
+        turn = self._require_ctx().session_manager.control_store.read_turn(turn_id)
+        if turn is not None and turn.thread_id == session_id and turn.status.is_terminal:
+            if turn.status is not TurnStatus.COMPLETED:
+                await self._runtime.publish_event(
+                    event_type="turn.interrupted",
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    payload={
+                        "status": turn.status.value,
+                        "message": "服务端已确认本轮生成结束",
+                        "reason": "stop_reconciliation",
+                    },
+                    device_id=device_id,
+                )
+            if self._active_turn_ids.get(session_id) == turn_id:
+                _ = self._active_turn_ids.pop(session_id)
+                _ = self._process_turns.pop((session_id, turn_id), None)
+                _ = self._delta_locks.pop((session_id, turn_id), None)
+            return CommandReply(
+                type="turn.stop.ok",
+                session_id=session_id,
+                turn_id=turn_id,
+                payload={
+                    "status": "already_terminal",
+                    "terminal_status": turn.status.value,
+                    "message": "目标 turn 已经结束",
+                },
+            )
         active_turn_id = self._active_turn_ids.get(session_id)
         if active_turn_id is None:
             raise MobileCommandError("turn_not_active", "当前会话没有正在生成的内容")
@@ -2268,6 +2358,9 @@ def _mobile_history_item(item: Mapping[str, object]) -> dict[str, object]:
     client_message_id = item.get("client_message_id")
     if isinstance(client_message_id, str) and client_message_id:
         result["client_message_id"] = client_message_id
+    control_turn_id = item.get("control_turn_id")
+    if result["role"] == "assistant" and isinstance(control_turn_id, str) and control_turn_id:
+        mobile_extra["control_turn_id"] = control_turn_id
     for field in ("reply_to_message_id", "reply_role", "reply_preview"):
         value = item.get(field)
         if isinstance(value, str) and value:

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -514,6 +514,7 @@ class MobileGatewayRuntime:
                         device_id=device_id,
                         connection_epoch=connection_epoch,
                         last_ack=frame.payload.last_ack,
+                        active_turns=tuple(frame.payload.active_turns),
                         capabilities=capabilities,
                     )
                     resumed = True
@@ -705,11 +706,18 @@ class MobileGatewayRuntime:
         device_id: str,
         connection_epoch: int,
         last_ack: int,
+        active_turns: tuple[str, ...] = (),
         capabilities: tuple[str, ...] = (),
     ) -> None:
         """先占住设备投递槽，再在锁外重放并切换为实时投递。"""
 
-        # 1. 在短临界区内冻结重放窗口，并让并发新事件进入新连接队列
+        # 1. 冻结窗口前补齐 SessionDB 已终态、但旧 runtime 未发布的事件
+        await self.channel.reconcile_active_turns(
+            device_id=device_id,
+            active_turns=active_turns,
+        )
+
+        # 2. 在短临界区内冻结重放窗口，并让并发新事件进入新连接队列
         async with self._delivery_lock:
             replay_after, replay_through, terminal = self._prepare_resume(
                 device_id=device_id,
@@ -727,7 +735,7 @@ class MobileGatewayRuntime:
             )
             self._connections[device_id] = connection
 
-        # 2. 旧连接关闭和新连接重放都不占用全局投递锁
+        # 3. 旧连接关闭和新连接重放都不占用全局投递锁
         if previous is not None and previous.websocket is not websocket:
             await self._cancel_plugin_ui_connection(device_id, previous)
             async with previous.sent_condition:
@@ -756,7 +764,7 @@ class MobileGatewayRuntime:
                     if self._connections.get(device_id) is connection:
                         _ = self._connections.pop(device_id)
 
-        # 3. 原子切换 ready；重放期间积累的事件由同一设备任务顺序发送
+        # 4. 原子切换 ready；重放期间积累的事件由同一设备任务顺序发送
         async with self._delivery_lock:
             if self._connections.get(device_id) is not connection:
                 return

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -13,6 +13,7 @@ import infra.mobile_realtime.channel as channel_module
 import infra.mobile_realtime.gateway as gateway_module
 
 from agent.config_models import MobileRealtimeConfig
+from agent.control.models import TurnRecord, TurnStatus
 from infra.mobile_realtime.runtime_inspection import RuntimeInspectionService
 from bus.events import (
     AttachmentKind,
@@ -1333,6 +1334,7 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     session.add_message(
         "user",
         "恢复这段对话",
+        control_turn_id="turn-history",
         llm_context_frame="private context",
         client_message_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
         reply_to_message_id=f"{session_id}:0",
@@ -1342,6 +1344,7 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     session.add_message(
         "assistant",
         "历史回答",
+        control_turn_id="turn-history",
         media=[str(media_path)],
         reasoning_content="历史思考",
         tool_chain=[
@@ -1408,7 +1411,10 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     assert history_items[0]["reply_role"] == "assistant"
     assert history_items[0]["reply_preview"] == "更早的回答"
     assert "llm_context_frame" not in history_items[0]
-    assert history_items[1]["extra"] == {"reasoning_content": "历史思考"}
+    assert history_items[1]["extra"] == {
+        "reasoning_content": "历史思考",
+        "control_turn_id": "turn-history",
+    }
     tool_chain = cast(list[dict[str, object]], history_items[1]["tool_chain"])
     calls = cast(list[dict[str, object]], tool_chain[0]["calls"])
     assert calls[0]["description"] == "读取状态"
@@ -1783,6 +1789,207 @@ async def test_turn_stop_idle_result_still_closes_stale_mobile_turn(
     assert runtime.events[-1]["event_type"] == "turn.interrupted"
     assert session_id not in channel._active_turn_ids
     await channel.stop()
+    manager.close()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_reconciles_recovered_terminal_turn_for_mobile_device(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"mobile:{uuid4()}"
+    turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAY"
+    storage.claim_session(
+        device_id=device_id,
+        session_id=session_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    manager.save(manager.get_or_create(session_id))
+    manager.control_store.create_turn(
+        TurnRecord(
+            id=turn_id,
+            thread_id=session_id,
+            status=TurnStatus.QUEUED,
+            input="维护前的提问",
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    manager.control_store.transition_turn(
+        turn_id,
+        expected_status=TurnStatus.QUEUED,
+        status=TurnStatus.CANCELLED,
+    )
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=_Bus(),
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+
+    await channel.reconcile_active_turns(
+        device_id=device_id,
+        active_turns=(turn_id,),
+    )
+
+    assert runtime.events == [
+        {
+            "event_type": "turn.interrupted",
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "payload": {
+                "status": "cancelled",
+                "message": "服务端已确认本轮生成结束",
+                "reason": "resume_reconciliation",
+            },
+            "device_id": device_id,
+        }
+    ]
+    await channel.stop()
+    manager.close()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent_after_authoritative_terminal_turn(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"mobile:{uuid4()}"
+    turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAY"
+    storage.claim_session(
+        device_id=device_id,
+        session_id=session_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    manager.save(manager.get_or_create(session_id))
+    manager.control_store.create_turn(
+        TurnRecord(
+            id=turn_id,
+            thread_id=session_id,
+            status=TurnStatus.QUEUED,
+            input="维护前的提问",
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    manager.control_store.transition_turn(
+        turn_id,
+        expected_status=TurnStatus.QUEUED,
+        status=TurnStatus.IN_PROGRESS,
+    )
+    manager.control_store.transition_turn(
+        turn_id,
+        expected_status=TurnStatus.IN_PROGRESS,
+        status=TurnStatus.INTERRUPTED,
+    )
+    channel._active_turn_ids[session_id] = turn_id
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=_Bus(),
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+
+    reply = await channel.handle_command(
+        device_id=device_id,
+        frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+            command_type="turn.stop",
+            session_id=session_id,
+            turn_id=turn_id,
+        ),
+    )
+
+    assert reply.type == "turn.stop.ok"
+    assert reply.payload == {
+        "status": "already_terminal",
+        "terminal_status": "interrupted",
+        "message": "目标 turn 已经结束",
+    }
+    assert session_id not in channel._active_turn_ids
+    assert runtime.events[-1]["event_type"] == "turn.interrupted"
+
+    next_turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    channel._active_turn_ids[session_id] = next_turn_id
+    replay = await channel.handle_command(
+        device_id=device_id,
+        frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FB0",
+            command_type="turn.stop",
+            session_id=session_id,
+            turn_id=turn_id,
+        ),
+    )
+    assert replay.type == "turn.stop.ok"
+    assert channel._active_turn_ids[session_id] == next_turn_id
+
+    channel._active_turn_ids.clear()
+    await channel.stop()
+    manager.close()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_stop_publishes_terminal_before_clearing_active_turn(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"mobile:{uuid4()}"
+    turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAY"
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=_Bus(),
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+    channel._active_turn_ids[session_id] = turn_id
+
+    await channel.stop()
+
+    assert runtime.events[-1] == {
+        "event_type": "turn.interrupted",
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "payload": {
+            "status": "interrupted",
+            "message": "服务端正在维护，本轮生成已中断",
+            "reason": "runtime_shutdown",
+        },
+    }
     manager.close()
     storage.close()
 
@@ -2179,6 +2386,19 @@ async def test_turn_stop_rejects_missing_or_stale_turn_identity(tmp_path: Path) 
     )
     assert stale.type == "turn.stop.error"
     assert stale.payload["code"] == "stale_turn"
+
+    channel._active_turn_ids.clear()
+    unknown = await channel.handle_command(
+        device_id=device_id,
+        frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAP",
+            command_type="turn.stop",
+            session_id=session_id,
+            turn_id="01ARZ3NDEKTSV4RRFFQ69G5FAN",
+        ),
+    )
+    assert unknown.type == "turn.stop.error"
+    assert unknown.payload["code"] == "turn_not_active"
 
     await channel.stop()
     manager.close()

--- a/tests/mobile_realtime/test_gateway.py
+++ b/tests/mobile_realtime/test_gateway.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -327,6 +328,18 @@ def test_authenticated_gateway_requires_resume_and_acks_durable_sync(
             capabilities=("stream-v1",),
         )
     )
+    stale_turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAQ"
+
+    async def reconcile(*, device_id: str, active_turns: tuple[str, ...]) -> None:
+        assert active_turns == (stale_turn_id,)
+        await runtime.publish_event(
+            device_id=device_id,
+            event_type="turn.interrupted",
+            turn_id=stale_turn_id,
+            payload={"status": "cancelled"},
+        )
+
+    runtime.channel.reconcile_active_turns = AsyncMock(side_effect=reconcile)
     client = TestClient(create_mobile_gateway_app(runtime))
 
     with client.websocket_connect("/ws") as websocket:
@@ -349,19 +362,23 @@ def test_authenticated_gateway_requires_resume_and_acks_durable_sync(
                 "kind": "control",
                 "type": "resume",
                 "connection_epoch": epoch,
-                "payload": {"last_ack": 0, "active_turns": []},
+                "payload": {"last_ack": 0, "active_turns": [stale_turn_id]},
             }
         )
+        terminal = websocket.receive_json()
+        assert terminal["type"] == "turn.interrupted"
+        assert terminal["turn_id"] == stale_turn_id
+        assert terminal["event_seq"] == 1
         synced = websocket.receive_json()
         assert synced["type"] == "sync.completed"
-        assert synced["event_seq"] == 1
+        assert synced["event_seq"] == 2
         websocket.send_json(
             {
                 "v": 1,
                 "kind": "ack",
                 "type": "event.ack",
                 "connection_epoch": epoch,
-                "payload": {"through_event_seq": 1},
+                "payload": {"through_event_seq": 2},
             }
         )
         websocket.send_json(
@@ -378,7 +395,7 @@ def test_authenticated_gateway_requires_resume_and_acks_durable_sync(
         assert reply["type"] == "ping.ok"
 
     cursor = runtime.storage.read_cursor(device_id)
-    assert cursor.acknowledged_event_seq == 1
+    assert cursor.acknowledged_event_seq == 2
     assert (
         runtime.storage.read_durable_events(
             device_id,

--- a/tests/test_host_runtime_lifecycle.py
+++ b/tests/test_host_runtime_lifecycle.py
@@ -13,17 +13,17 @@ def test_core_consumes_external_services_without_owning_them() -> None:
         encoding="utf-8"
     )
 
-    assert (
-        "Requires=akashic-host-bridge.service akashic-home-services.service"
-        in core_unit
-    )
+    assert "Requires=akashic-host-bridge.service" in core_unit
+    assert "Wants=akashic-home-services.service" in core_unit
     assert (
         "After=docker.service akashic-host-bridge.service akashic-home-services.service"
         in core_unit
     )
     assert (
-        "PartOf=akashic-host-bridge.service akashic-home-services.service" in core_unit
+        "PartOf=akashic-host-bridge.service" in core_unit
     )
+    assert "Requires=akashic-home-services.service" not in core_unit
+    assert "PartOf=akashic-home-services.service" not in core_unit
     assert "home-services.env" not in core_unit
     assert "verify-running-home-services" not in core_unit
     assert "compose.external-services.yaml" in core_unit

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -583,6 +583,38 @@ async def test_run_cleanup_steps_continues_after_cancellation():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_stops_mobile_channel_before_closing_gateway_storage(tmp_path):
+    events: list[str] = []
+
+    class Gateway:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+            events.append("gateway.close")
+
+    gateway = Gateway()
+
+    class ConversationRuntime:
+        async def shutdown(self) -> None:
+            events.append("conversation.shutdown")
+
+    class ChannelHost:
+        async def stop_all(self) -> None:
+            assert gateway.closed is False
+            events.append("channels.stop")
+
+    runtime = bootstrap_app.AppRuntime(cast(Any, object()), tmp_path)
+    runtime.mobile_gateway_runtime = gateway
+    runtime.conversation_runtime = cast(Any, ConversationRuntime())
+    runtime.channel_host = cast(Any, ChannelHost())
+
+    await runtime.shutdown()
+
+    assert events == ["conversation.shutdown", "channels.stop", "gateway.close"]
+
+
+@pytest.mark.asyncio
 async def test_app_runtime_run_stops_primary_tasks_after_server_failure(tmp_path):
     runtime = bootstrap_app.AppRuntime(cast(Any, object()), tmp_path)
     runtime.dashboard_server = _FakeDashboardServer()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：维护重启会让移动端遗留 streaming turn，停止按钮随后收到 turn_not_active；Core 还错误耦合 home-services 生命周期。
- 用户可见结果：resume 在 sync.completed 前对账终态，stop 幂等；计划 shutdown 先持久化终态；重启配套服务不再重启 Core。
- 本 PR 不处理：Android 展示与 Room 收敛逻辑，见配套 akashic-mobile PR。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Mobile Realtime Android client
- `runtime_patch`：`required`
- `runtime_patch_reason`：SessionDB 权威终态、durable inbox 与 systemd lifecycle 均由 Core 拥有
- `authoritative_state_owner`：SessionDB turn status + MobileRealtimeStorage durable inbox
- `client_only_alternative`：无法可靠区分 completed、cancelled 与未知 turn，也无法修复 shutdown 写入顺序
- 关联不变量：终态不可伪装；durable terminal 先于 sync.completed；旧 turn 不清新 turn
- `protected_state`：sessions.db 追加历史、mobile durable inbox
- 允许的副作用：追加定向 turn.interrupted；安装器更新 Core unit
- 禁止的副作用：删除/改写历史消息；重启 home-services 时传播停止 Core

## 改动范围

- 主要文件：`infra/mobile_realtime/channel.py`、`infra/mobile_realtime/gateway.py`、`bootstrap/app.py`、Core systemd unit 与回归测试
- 配置或迁移影响：无 schema migration；systemd home-services 从 Requires/PartOf 改为 Wants/After
- 已知 schema lineage 与最终 schema identity：mobile-realtime-v1 schema 不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：Core `b7f62dd85fdcccdf46a7a7ecd45d96aa9955be5a` tree `147b0b755624613d9ac1e5ade0d29a3cf4a917f2`
- 回滚方式：`akashic-release rollback` 回到安装器创建的上一 generation

## 验证

- [x] 相关 targeted tests 已通过：133 passed。
- [x] Python 类型检查或前端 typecheck/lint 已通过；本次无前端改动。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，23 个公开场景通过。
- `sourceDigest`：`0d8bdc5d33a70b44a17ea6dae6dced1b7874d0d76b007874b6b5e073d003edfb`
- `planDigest`：`a9aef98be48b4b60254709f408aeb0dbe4cecc75da1d0e6e2db95650ef456344`
- 真实设备证据：按用户要求未执行手机 E2E；hua-home 已部署精确 commit，doctor healthy，并实测重启 home-services 后 Core start identity 不变。
- 未运行项与原因：全仓 benchmark 收集依赖缺少 akashic_sdk；不属于本变更 Gate。设备 crash/restart 闭环按用户要求未运行。

## 工作手册

- [x] 已核对 projectneed、相关决策和 NOW。
- [x] 长期语义变化已由本次彻底修复请求确认。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner。
- [x] 当前没有对应 NOW 事项。