### PR TITLE
fix(provider): 轮转 LLM 请求快照

### DIFF
--- a/agent/provider.py
+++ b/agent/provider.py
@@ -6,6 +6,7 @@ LLM Provider — OpenAI 兼容格式
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import hashlib
 import itertools
 import json
@@ -46,6 +47,8 @@ _LLM_PAYLOAD_SNAPSHOT_ENABLED = False
 _LAST_PAYLOAD_PATH = Path(tempfile.gettempdir()) / "akashic-last-llm-payload.json"
 _PAYLOAD_SNAPSHOT_DIR = Path(tempfile.gettempdir()) / "akashic-llm-payloads"
 _PAYLOAD_SNAPSHOT_SEQ = itertools.count(1)
+_PAYLOAD_SNAPSHOT_MAX_FILES = 16
+_PAYLOAD_SNAPSHOT_MAX_BYTES = 64 * 1024 * 1024
 StreamDelta = dict[str, str]
 
 # 安全审查错误码（各厂商）
@@ -918,21 +921,80 @@ def _save_llm_payload_snapshot(
     *,
     enabled: bool | None = None,
 ) -> Path | None:
+    """保存完整请求快照，并在写入前回收最旧快照。"""
+
     if not (_LLM_PAYLOAD_SNAPSHOT_ENABLED if enabled is None else enabled):
         return None
     try:
-        payload = json.dumps(kwargs, ensure_ascii=False, indent=2, default=str)
+        # 1. 序列化后先为新快照腾出空间，避免把共享 /tmp 写满。
+        payload = json.dumps(
+            kwargs,
+            ensure_ascii=False,
+            indent=2,
+            default=str,
+        ).encode("utf-8")
+        if len(payload) > _PAYLOAD_SNAPSHOT_MAX_BYTES:
+            logger.warning(
+                "[LLM请求快照] 跳过超限快照 bytes=%d max_bytes=%d",
+                len(payload),
+                _PAYLOAD_SNAPSHOT_MAX_BYTES,
+            )
+            return None
         _PAYLOAD_SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-        seq = next(_PAYLOAD_SNAPSHOT_SEQ)
-        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
-        path = _PAYLOAD_SNAPSHOT_DIR / f"{ts}-{os.getpid()}-{seq:06d}.json"
-        path.write_text(payload, encoding="utf-8")
-        _LAST_PAYLOAD_PATH.write_text(payload, encoding="utf-8")
+        lock_path = _PAYLOAD_SNAPSHOT_DIR / ".rotation.lock"
+        with lock_path.open("a+b") as lock_file:
+            lock_path.chmod(0o600)
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+            # 2. 回收崩溃残留和旧快照，再原子发布完整新快照。
+            for stale_path in _PAYLOAD_SNAPSHOT_DIR.glob(".*.tmp"):
+                stale_path.unlink()
+            for stale_link in _LAST_PAYLOAD_PATH.parent.glob(
+                f".{_LAST_PAYLOAD_PATH.name}.*.tmp"
+            ):
+                stale_link.unlink()
+            _LAST_PAYLOAD_PATH.unlink(missing_ok=True)
+            _prune_llm_payload_snapshots(required_bytes=len(payload))
+            seq = next(_PAYLOAD_SNAPSHOT_SEQ)
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+            path = _PAYLOAD_SNAPSHOT_DIR / f"{ts}-{os.getpid()}-{seq:06d}.json"
+            pending_path = path.with_name(f".{path.name}.tmp")
+            pending_path.write_bytes(payload)
+            pending_path.chmod(0o600)
+            os.replace(pending_path, path)
+
+            # 3. last 与最新快照共享 inode，保留入口但不重复占空间。
+            latest_link = _LAST_PAYLOAD_PATH.with_name(
+                f".{_LAST_PAYLOAD_PATH.name}.{os.getpid()}-{seq:06d}.tmp"
+            )
+            os.link(path, latest_link)
+            os.replace(latest_link, _LAST_PAYLOAD_PATH)
         logger.info("[LLM请求快照] saved=%s", path)
         return path
     except Exception as exc:
         logger.warning("[LLM请求快照] 保存失败: %s", exc)
         return None
+
+
+def _prune_llm_payload_snapshots(*, required_bytes: int) -> None:
+    """删除最旧快照，为下一份快照保留数量和字节预算。"""
+
+    snapshots = sorted(
+        (
+            entry
+            for entry in _PAYLOAD_SNAPSHOT_DIR.glob("*.json")
+            if entry.is_file()
+        ),
+        key=lambda entry: (entry.stat().st_mtime_ns, entry.name),
+    )
+    retained_bytes = sum(entry.stat().st_size for entry in snapshots)
+    while snapshots and (
+        len(snapshots) >= _PAYLOAD_SNAPSHOT_MAX_FILES
+        or retained_bytes + required_bytes > _PAYLOAD_SNAPSHOT_MAX_BYTES
+    ):
+        oldest = snapshots.pop(0)
+        retained_bytes -= oldest.stat().st_size
+        oldest.unlink()
 
 
 def _extract_cache_usage(usage: Any) -> tuple[int | None, int | None]:

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -489,10 +489,10 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 | `memory/spawn_trace.jsonl` | subagent manager | spawn 决策与完成 trace |
 | `memory/proactive_*_trace.jsonl` | proactive loop | 配置和频率决策 trace |
 | `subagent-runs/<job-id>/` | background subagent | 隔离的子任务报告和脚本产物 |
-| `/tmp/akashic-llm-payloads/` | provider，可配置启用 | 完整 LLM 请求快照 |
+| `/tmp/akashic-llm-payloads/` | provider，可配置启用 | 完整 LLM 请求快照；跨进程互斥写入，按最旧优先轮转，最多保留 16 份且合计不超过 64 MiB；单份超过 64 MiB 时明确报警并拒绝落盘 |
 | `/tmp/akashic-exec-*.log` | shell execution manager | 完整命令输出诊断日志；无截断终态、显式 stop、容量回收或 runtime shutdown 时删除，工具结果发生省略时保留并返回路径；不进入 SessionDB，也没有跨 runtime 恢复语义 |
 
-这些文件可能包含用户原文、工具参数、检索记忆、路径或模型 payload。它们对事故取证有价值，但当前代码没有统一 retention、脱敏、容量或备份策略。
+这些文件可能包含用户原文、工具参数、检索记忆、路径或模型 payload。它们对事故取证有价值；LLM 请求快照已由 provider 执行数量和容量轮转，`/tmp/akashic-last-llm-payload.json` 与最新快照共享 inode，不重复占用空间。其他诊断文件仍没有统一 retention、脱敏、容量或备份策略。
 
 **G-005：** 诊断证据的最低保留期、隐私边界和容量上限尚未形成项目级合同。确认前不能把它们提升为永久记忆，也不能在事故调查中默认它们一定存在。
 

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -7,6 +7,7 @@ import json
 import runpy
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -450,6 +451,112 @@ async def test_provider_payload_snapshot_can_enable_per_instance(
     assert len(files) == 1
     payload = json.loads(files[0].read_text(encoding="utf-8"))
     assert payload["messages"][0]["content"] == "dev"
+
+
+def test_provider_payload_snapshot_rotates_by_count_and_reuses_latest_inode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    snapshot_dir = tmp_path / "payloads"
+    last_payload = tmp_path / "last.json"
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_DIR", snapshot_dir)
+    monkeypatch.setattr(provider_module, "_LAST_PAYLOAD_PATH", last_payload)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_FILES", 3)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_BYTES", 1024 * 1024)
+
+    for index in range(5):
+        provider_module._save_llm_payload_snapshot(
+            {"request": index},
+            enabled=True,
+        )
+
+    files = sorted(snapshot_dir.glob("*.json"))
+    assert len(files) == 3
+    assert [json.loads(item.read_text())["request"] for item in files] == [2, 3, 4]
+    assert json.loads(last_payload.read_text())["request"] == 4
+    assert last_payload.stat().st_ino == files[-1].stat().st_ino
+
+
+def test_provider_payload_snapshot_rotates_by_total_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    snapshot_dir = tmp_path / "payloads"
+    last_payload = tmp_path / "last.json"
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_DIR", snapshot_dir)
+    monkeypatch.setattr(provider_module, "_LAST_PAYLOAD_PATH", last_payload)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_FILES", 16)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_BYTES", 700)
+
+    for index in range(4):
+        provider_module._save_llm_payload_snapshot(
+            {"request": index, "content": "x" * 300},
+            enabled=True,
+        )
+
+    files = sorted(snapshot_dir.glob("*.json"))
+    assert len(files) == 2
+    assert sum(item.stat().st_size for item in files) <= 700
+    assert [json.loads(item.read_text())["request"] for item in files] == [2, 3]
+
+
+def test_provider_payload_snapshot_rejects_oversize_without_losing_latest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    snapshot_dir = tmp_path / "payloads"
+    last_payload = tmp_path / "last.json"
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_DIR", snapshot_dir)
+    monkeypatch.setattr(provider_module, "_LAST_PAYLOAD_PATH", last_payload)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_BYTES", 256)
+
+    saved = provider_module._save_llm_payload_snapshot({"request": 1}, enabled=True)
+    rejected = provider_module._save_llm_payload_snapshot(
+        {"content": "x" * 300},
+        enabled=True,
+    )
+
+    assert saved is not None
+    assert rejected is None
+    assert json.loads(last_payload.read_text())["request"] == 1
+    assert "跳过超限快照" in caplog.text
+
+
+def test_provider_payload_snapshot_serializes_rotation_and_cleans_stale_temp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    snapshot_dir = tmp_path / "payloads"
+    snapshot_dir.mkdir()
+    stale_temp = snapshot_dir / ".interrupted.json.tmp"
+    stale_temp.write_text("partial")
+    last_payload = tmp_path / "last.json"
+    stale_link = tmp_path / ".last.json.123-000001.tmp"
+    stale_link.write_text("stale")
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_DIR", snapshot_dir)
+    monkeypatch.setattr(provider_module, "_LAST_PAYLOAD_PATH", last_payload)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_FILES", 4)
+    monkeypatch.setattr(provider_module, "_PAYLOAD_SNAPSHOT_MAX_BYTES", 1024 * 1024)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        saved = list(
+            executor.map(
+                lambda index: provider_module._save_llm_payload_snapshot(
+                    {"request": index},
+                    enabled=True,
+                ),
+                range(12),
+            )
+        )
+
+    files = sorted(snapshot_dir.glob("*.json"))
+    assert all(item is not None for item in saved)
+    assert len(files) == 4
+    assert not stale_temp.exists()
+    assert not stale_link.exists()
+    assert last_payload.stat().st_ino in {item.stat().st_ino for item in files}
+    assert all(item.stat().st_mode & 0o777 == 0o600 for item in files)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：开发模式下完整 LLM 请求快照无限累积，长期运行会占满容器 `/tmp`，并阻断共享临时空间的 SQLite 查询。
- 用户可见结果：保留完整 payload，同时自动保留最近 16 份且总量不超过 64 MiB；`last` 入口不再复制占盘。
- 本 PR 不处理：Grafana 仪表盘展示和其他诊断文件的统一 retention。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：启用 `agent.dev_mode` 的 Chat Completions runtime
- `runtime_patch`：`required`
- `runtime_patch_reason`：轮转必须由实际写入 payload 的 provider 执行，宿主机 tmpfiles 无法管理容器私有 tmpfs。
- `authoritative_state_owner`：`agent.provider`
- `client_only_alternative`：不适用
- 关联不变量：快照保持完整；最近一份继续可从 `/tmp/akashic-last-llm-payload.json` 读取。
- `protected_state`：SessionDB、workspace、模型请求与响应语义。
- 允许的副作用：新快照写入前删除超过数量或容量预算的最旧临时快照。
- 禁止的副作用：修改请求 payload、删除最新快照、写入正式 workspace。

## 改动范围

- 主要文件：`agent/provider.py`、`tests/test_more_support_modules.py`、`docs/design/persistence-state-map.md`
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source `7064231f`；无协议变化。
- 回滚方式：revert 本 PR；事故现场另有部署前压缩备份。

## 验证

- [x] 相关 targeted tests 已通过。
- [x] Python 类型检查或前端 typecheck/lint 已通过；不适用项已说明。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`ad859b878a79f529af2d17872d0bafa83dfdd666f3e643144788b5a4432d150b`
- `planDigest`：`b5d7533f7754a4dffe2402071d4a615c59f321831346c3a2d5e328d26969f219`
- 真实设备证据：不适用。
- 未运行项与原因：仓库无可用 ruff；完整 provider 测试文件 36 项通过，公开 change gate 通过。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。
