### PR TITLE
fix(mobile): recover continued turn terminal

### DIFF
--- a/agent/lifecycle/phases/after_reasoning.py
+++ b/agent/lifecycle/phases/after_reasoning.py
@@ -365,7 +365,7 @@ class _BuildOutboundMessageModule:
             )
             if not persisted_users:
                 raise RuntimeError("本轮 user 消息列表为空")
-            persisted_user = persisted_users[0]
+            persisted_user = persisted_users[-1]
             persisted_user_ids = [
                 str(item["id"])
                 for item in persisted_users

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -420,8 +420,8 @@ class PassiveMessageWorker:
         """把权威 turn 终态投影为出站消息；正常与恢复分支共用同一投影。
 
         completed/failed/recovered 一律从已验证 userMessage item 贯通
-        client_message_id 到 outbound metadata；缺失（mobile）或多值冲突
-        fail-fast，completed 已有 metadata 与已验证值冲突也 fail-fast。
+        client_message_id 到 outbound metadata；缺失（mobile）或 userMessage
+        多值冲突 fail-fast。assistant metadata 只是冗余投影，不拥有该身份。
         """
 
         verified_cmid = self._verified_client_message_id(result)
@@ -434,13 +434,6 @@ class PassiveMessageWorker:
             data = assistant.data
             metadata = dict(cast(dict[str, Any], data.get("metadata", {})))
             if verified_cmid:
-                existing = metadata.get("client_message_id")
-                if existing is not None and existing != verified_cmid:
-                    raise RuntimeError(
-                        f"outbound client_message_id 与已验证 userMessage 冲突: "
-                        f"turn={result.id} existing={existing!r} "
-                        f"verified={verified_cmid!r}"
-                    )
                 metadata["client_message_id"] = verified_cmid
             elif item.channel == "mobile" and item.handoff_id is not None:
                 # durable handoff 链必须在 channel/gateway 贯通身份，缺失即 fail-fast。

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -330,7 +330,10 @@ async def test_recovered_mobile_handoff_with_completed_turn_redelivers_and_acks(
     async def execute(_request: TurnRequest) -> ControlExecutionResult:
         return ControlExecutionResult(
             "persisted-answer",
-            assistant_data={"sessionMessageId": "mobile:terminal:5"},
+            assistant_data={
+                "sessionMessageId": "mobile:terminal:5",
+                "metadata": {"client_message_id": "client:previous-attempt"},
+            },
         )
 
     runtime = ConversationRuntime(manager.control_store, execute)
@@ -363,6 +366,7 @@ async def test_recovered_mobile_handoff_with_completed_turn_redelivers_and_acks(
     assert len(turns) == 1
     assert [msg.content for msg in delivered] == ["persisted-answer"]
     assert delivered[0].control_turn_id == turns[0].id
+    assert delivered[0].metadata["client_message_id"] == "client:t"
     assert delivered[0].session_message_id == "mobile:terminal:5"
     assert manager.control_store.list_inbound_handoffs() == []
     recovery_records = [

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -1662,13 +1662,23 @@ async def test_after_reasoning_commits_all_same_turn_users_before_final_assistan
     class _Source:
         def used_inputs(self) -> tuple[TurnUserInput, ...]:
             return (
-                TurnUserInput("i1", 0, "u1", (), {}, _now),
+                TurnUserInput(
+                    "i1",
+                    0,
+                    "u1",
+                    (),
+                    {"client_message_id": "client:previous-attempt"},
+                    _now,
+                ),
                 TurnUserInput(
                     "i2",
                     1,
                     "u2",
                     (),
-                    {"skip_post_memory": True},
+                    {
+                        "client_message_id": "client:current-attempt",
+                        "skip_post_memory": True,
+                    },
                     _now,
                 ),
             )
@@ -1736,6 +1746,11 @@ async def test_after_reasoning_commits_all_same_turn_users_before_final_assistan
         messages[1]["id"],
         messages[2]["id"],
     ]
+    assert result.outbound.metadata["persisted_user_message_id"] == messages[2]["id"]
+    assert (
+        result.outbound.metadata["client_message_id"]
+        == "client:current-attempt"
+    )
     deletion = reloaded.control_store.delete_interaction("turn-1")
     assert deletion is not None
     assert deletion.message_ids == tuple(item["id"] for item in messages[1:])


### PR DESCRIPTION
## 改动

- 多输入 Interaction 的单值消息关联改为当前 attempt 的最后一条用户输入。
- Mobile terminal 始终以 turn 中已验证的 userMessage `client_message_id` 为权威身份，覆盖 assistant 的旧冗余投影。
- 保留 userMessage 缺失或多值冲突的 fail-fast 校验。

## 根因与影响

中断后的续接 attempt 会同时持有旧输入和当前输入。AfterReasoning 误用第一条输入生成 assistant metadata；随后 durable terminal recovery 发现旧 ID 与当前 turn 的已验证 ID 不同而拒绝投递，导致服务端 turn 已 completed、移动端按钮仍停留在“正在终止本轮处理”。

修复后，未来 attempt 不再产生旧关联；已经卡住的 durable handoff 也能使用当前 turn 的权威 userMessage 身份重投终态，不需要修改 SessionDB。

## 验证

- `74 passed`：`tests/control/test_channel_adapter.py`、`tests/test_lifecycle_phases.py`
- Pyright：0 errors（既有 12 warnings）
- Change Gate：passed，报告 `20260813-002442-55f5baf2`

## 回滚

回滚 commit `ff978c7e`；本改动不包含 schema、迁移或数据改写。
