### PR TITLE
fix(webui): 恢复壳层嵌入 Chat 的手机配对入口

### DIFF
--- a/frontend/chat/src/main.tsx
+++ b/frontend/chat/src/main.tsx
@@ -708,21 +708,15 @@ function App() {
           sessionAfterContent={surface === "chat" && activeSessionId ? (
             <MobilePluginSlot name="drawer.panel" sessionId={activeSessionId} />
           ) : undefined}
-          actions={isEmbeddedShell ? [
-            {
-              id: "new-chat",
-              icon: <MessageSquarePlus size={18} />,
-              label: "新聊天",
-              primary: true,
-              onActivate: startNewChat,
-            },
-          ] : [
-            {
-              id: "theme",
-              icon: <Palette size={18} />,
-              label: `主题 · ${theme.label}`,
-              onActivate: cycleTheme,
-            },
+          actions={[
+            ...(isEmbeddedShell ? [] : [
+              {
+                id: "theme",
+                icon: <Palette size={18} />,
+                label: `主题 · ${theme.label}`,
+                onActivate: cycleTheme,
+              },
+            ]),
             {
               id: "connect-mobile",
               icon: <Smartphone size={18} />,


### PR DESCRIPTION
## 问题与结果

- 解决的问题：统一 Dashboard 壳层（2236 根路径）把 Chat 以 `embedded=1` 嵌入 iframe 时，侧栏 actions 只有「新聊天」，手机配对入口「连接手机」被隐藏，Web UI 上无法发起配对。
- 用户可见结果：壳层嵌入的 Chat 侧栏恢复「连接手机」按钮（位于「新聊天」之前），点击后打开二维码配对对话框；直接访问 `/chat` 的行为不变。
- 本 PR 不处理：配对协议、配对对话框、后端 API 与网关代理均未改动；也不涉及移动客户端。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`（配对入口是 Chat WebUI 的 UI 能力，配对协议 owner 不变）
- `consumer_scope`：桌面浏览器 WebUI（Dashboard 壳层嵌入视图与独立 `/chat`）
- `runtime_patch`：`none`
- `runtime_patch_reason`：不适用
- `authoritative_state_owner`：配对权威状态仍在 `infra/mobile_realtime/pairing.py` 与移动网关，本 PR 不触碰
- `client_only_alternative`：入口在 Chat 前端渲染，无客户端协议变化
- 关联不变量：WEBUI 语义不变；embedded/standalone 两个入口的 actions 顺序与语义保持一致
- `protected_state`：`sessions.db`、`akasha.db`、`proactive.db`、移动网关设备存储均不改变
- 允许的副作用：无持久化副作用；构建产物按既有 `static/chat` 流程发布
- 禁止的副作用：不新增 API、不改配对协议、不改网关端口与壳层路由

## 改动范围

- 主要文件：`frontend/chat/src/main.tsx`（+9 −15，合并 embedded 与 standalone 两分支的 actions 数组）
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：无变化
- 回滚方式：revert 本提交并重新构建 `static/chat`；或仅撤销该段合并 diff 后重新构建

## 验证

- [x] 相关 targeted tests 已通过：Playwright 真实渲染验证——embedded 模式 actions 为 `['连接手机', '新聊天']`，点击「连接手机」打开「连接 Android 手机」对话框；standalone 模式 actions 为 `['主题 · 浅色', '连接手机', '新聊天']`，行为不变。
- [x] Python 类型检查或前端 typecheck/lint 已通过：`tsc --noEmit` 通过、`npm run lint` 通过、`npm run build:chat` 成功。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`de697f57a4ce64358ae96107003c5a09bd4c120fcb269f132146cab36bde3ac9`
- `planDigest`：`2bb44760d5eca0a108a49dd035c73333601493d8aaa3feba6311c85d874c798b`
- 真实设备证据：不适用（纯 WebUI 入口修复，无移动客户端或设备协议变化）
- 未运行项与原因：无

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`：本次为纯前端可见性修复，无长期语义变化。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用（无协议变化）。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。
