### PR TITLE
fix(turn): separate logical identity from attempts

### DIFF
--- a/agent/control/models.py
+++ b/agent/control/models.py
@@ -311,6 +311,16 @@ class TurnResult:
     items: list[TurnItem]
     usage: TurnUsage | None
     error: TurnError | None
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    @property
+    def interaction_id(self) -> str:
+        """返回当前 attempt 所属的逻辑 Turn 身份。"""
+
+        value = self.metadata.get("interactionId", self.id)
+        if not isinstance(value, str) or not value:
+            raise ValueError("turn result interactionId 必须是非空字符串")
+        return value
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "status", TurnStatus(self.status))
@@ -355,6 +365,7 @@ class TurnResult:
             items=list(record.items),
             usage=record.usage,
             error=record.error,
+            metadata=dict(record.metadata),
         )
 
 

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -757,6 +757,12 @@ class AgentLoop:
         key: str,
         client_message_id: str,
     ) -> None:
+        control_turn_id = running_turn_id.get()
+        if isinstance(msg, InboundMessage):
+            control_turn_id = str(
+                msg.metadata.get("control_turn_id") or control_turn_id
+            )
+
         # 1. 对外发布被动 turn 开始事件，具体副作用由 observer 决定。
         #    身份使用入站边界已解析的同一个 client_message_id，禁止再次解析。
         await self._event_bus.observe(
@@ -767,6 +773,7 @@ class AgentLoop:
                 content=_item_content(msg),
                 timestamp=msg.timestamp,
                 turn_id=running_turn_id.get(),
+                control_turn_id=control_turn_id,
                 client_message_id=client_message_id,
             )
         )

--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -3,9 +3,11 @@
 """
 
 import logging
+from dataclasses import replace
 from pathlib import Path
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
+from uuid import uuid4
 
 from agent.tools.base import Tool
 from bus.events import (
@@ -144,6 +146,8 @@ class MessagePushTool(Tool):
     ) -> DeliveryReceipt:
         """通过单一 adapter 提交完整消息，并保留 chat lane 顺序。"""
 
+        if commit_role != "passive" and message.control_turn_id is None:
+            message = replace(message, control_turn_id=f"turn:{uuid4().hex}")
         adapter = self._adapters.get(message.channel)
         if adapter is None:
             return DeliveryReceipt(

--- a/agent/turns/orchestrator.py
+++ b/agent/turns/orchestrator.py
@@ -46,6 +46,7 @@ class TurnOrchestrator:
         content = result.outbound.content
         media = list(result.outbound.media or [])
         delivery_id = uuid4().hex
+        control_turn_id = f"turn:{uuid4().hex}"
         receipt = None
         try:
             # 2. 先执行发送前 side_effects，再真正 dispatch 到 outbound。
@@ -57,6 +58,7 @@ class TurnOrchestrator:
                     content=content,
                     metadata={"delivery_id": delivery_id},
                     media=media,
+                    control_turn_id=control_turn_id,
                 )
             )
         except Exception as e:
@@ -73,6 +75,7 @@ class TurnOrchestrator:
                 media=list(receipt.canonical_media),
                 result=result,
                 delivery_id=delivery_id,
+                control_turn_id=control_turn_id,
             )
             await self._session.session_manager.append_messages(
                 session, session.messages[-1:]
@@ -103,6 +106,7 @@ class TurnOrchestrator:
         media: list[str],
         result: TurnResult,
         delivery_id: str,
+        control_turn_id: str,
     ) -> None:
         source_refs = []
         state_summary_tag = "none"
@@ -117,6 +121,7 @@ class TurnOrchestrator:
             media=media if media else None,
             proactive=True,
             delivery_id=delivery_id,
+            control_turn_id=control_turn_id,
             tools_used=["message_push"],
             evidence_item_ids=[str(item_id) for item_id in result.evidence],
             source_refs=source_refs,

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -449,7 +449,8 @@ class PassiveMessageWorker:
                 reply_to=cast(str | None, data.get("replyTo")),
                 media=list(cast(list[str], data.get("media", []))),
                 metadata=metadata,
-                control_turn_id=result.id,
+                control_turn_id=result.interaction_id,
+                execution_attempt_id=result.id,
                 session_message_id=cast(str | None, data.get("sessionMessageId")),
                 terminal_status=TurnTerminalStatus.COMPLETED,
             )
@@ -466,7 +467,8 @@ class PassiveMessageWorker:
                 channel=item.channel,
                 chat_id=item.chat_id,
                 content="本轮已中断。",
-                control_turn_id=result.id,
+                control_turn_id=result.interaction_id,
+                execution_attempt_id=result.id,
                 metadata=metadata,
                 terminal_status=terminal_status,
             )
@@ -476,7 +478,8 @@ class PassiveMessageWorker:
             channel=item.channel,
             chat_id=item.chat_id,
             content="处理消息时出错，请稍后再试。",
-            control_turn_id=result.id,
+            control_turn_id=result.interaction_id,
+            execution_attempt_id=result.id,
             metadata=metadata,
             terminal_status=terminal_status,
         )

--- a/bus/events.py
+++ b/bus/events.py
@@ -59,6 +59,11 @@ class ChannelMessage:
     metadata: dict[str, object] = field(default_factory=dict[str, object])
     session_message_id: str | None = None
     control_turn_id: str | None = None
+    execution_attempt_id: str | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     terminal_status: TurnTerminalStatus | None = None
 
 
@@ -118,6 +123,11 @@ class OutboundMessage:
     media: list[str] = field(default_factory=list[str])
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
     control_turn_id: str | None = field(default=None, repr=False, compare=False)
+    execution_attempt_id: str | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     session_message_id: str | None = field(default=None, repr=False, compare=False)
     terminal_status: TurnTerminalStatus | None = field(
         default=None,
@@ -149,6 +159,7 @@ def channel_message_from_outbound(
         metadata=dict(message.metadata),
         session_message_id=message.session_message_id,
         control_turn_id=message.control_turn_id,
+        execution_attempt_id=message.execution_attempt_id,
         terminal_status=message.terminal_status,
     )
 

--- a/bus/events_lifecycle.py
+++ b/bus/events_lifecycle.py
@@ -18,6 +18,7 @@ class TurnStarted:
     content: str
     timestamp: datetime
     turn_id: str = ""
+    control_turn_id: str = ""
     client_message_id: str = ""
 
 

--- a/docs/decisions/0034-turn-is-the-logical-work-unit.md
+++ b/docs/decisions/0034-turn-is-the-logical-work-unit.md
@@ -1,0 +1,31 @@
+# 0034 Turn 是逻辑工作单元
+
+- 状态：accepted
+- 日期：2026-08-13
+- 决策者：维护者
+- 关联：`CTX-003`、`SES-007`、`SES-008`、`MEM-011`、`OUT-001`、`OUT-004`、`SCH-003`
+
+## 背景
+
+控制存储把每次执行记录称为 turn，但被动会话允许一次逻辑交互跨越多个中断 attempt。此前 Mobile 实时终态使用最后一次 attempt ID，SessionDB 历史使用首个 interaction ID，严格 canonical 合并因此会把同一逻辑交互误判为身份变化。
+
+## 决策
+
+`Turn` 只表示用户可理解的逻辑工作单元，`Attempt` 表示 Turn 内部的一次执行。被动链路的 `U1 → interrupt → U2 → interrupt → U3 → A` 是一个 Turn、三个 Attempt；全部消息共享一个 `control_turn_id`，实时流的 `turn_id` 暂时继续标识可中断和可重放的 Attempt。
+
+proactive、每次 `message_push`、每次 schedule fire 和每个 spawn completion assistant 分别创建独立 Turn。它们的 assistant 明确送达后立即关闭，不等待用户回复；随后用户回复创建新的被动 Turn，只能用显式引用关联来源。
+
+```text
+被动： U1 ── Attempt 1 ── interrupt ─┐
+        U2 ── Attempt 2 ── interrupt ├── Turn L ── A final
+        U3 ── Attempt 3 ─────────────┘
+
+主动： source ── Turn P ── A delivered ── closed
+```
+
+## 结果
+
+- Mobile 协议事件同时携带执行 `turn_id` 与逻辑 `control_turn_id`，客户端严格校验两者各自的不变量。
+- 现有 `turns` 表仍保存 Attempt checkpoint，不迁移或删除既有记录。
+- 主动来源在发送边界分配逻辑 Turn，不取得目标 session 的推理 lane。
+- 旧客户端继续只读取 `turn_id`；新客户端使用 `control_turn_id` 完成 canonical 合并。

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -467,8 +467,8 @@ completed logical interaction 含多个 user message 时，Akasha 按显式 inte
 ### MEM-011 历史投影按不可拆分逻辑单元和 token tail 保留
 
 Session compaction、Markdown consolidation 的切点和 prompt history 必须使用同一个逻辑
-历史分组。显式 `control_turn_id` 的 `U1..Un+A_final` 是一个单元；已送达 proactive
-assistant 是一个独立单元。任何窗口、retained tail 或 consolidation cursor 不得落入
+历史分组。显式 `control_turn_id` 的 `U1..Un+A_final` 是一个单元；每条已送达 proactive、
+`message_push`、schedule fire 和 spawn completion assistant 各自是一个独立单元。任何窗口、retained tail 或 consolidation cursor 不得落入
 逻辑单元内部。runtime 不再使用 `memory_window` 计数；compaction 反向累积至少 20,000
 token，并允许因完整单元跨过阈值。单元展开后可以超过 token target，但重建 provider
 payload 必须满足当前模型硬输入边界。
@@ -568,7 +568,7 @@ Core；旧代恢复失败则停在 maintenance 并保留全部证据。软件回
 
 ### OUT-001 被动按 Turn 提交，主动按送达提交
 
-被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，本 turn 的全部有序 user message 与唯一 terminal assistant 共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应的用户 Turn，只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。
+被动消息以完整 Turn 为权威提交单位。推理和持久化成功后，本 turn 的全部有序 user message 与唯一 terminal assistant 共同进入会话历史；随后 dispatch 失败不得回滚已经提交的 Turn。主动消息没有对应 user message，但每条 proactive、`message_push`、schedule fire 和 spawn completion assistant 都拥有独立 Turn；assistant 明确送达即关闭该 Turn，不等待用户回复。只有 dispatch 明确成功后才进入会话历史、presence、dedupe 和 success 状态；未发送内容不得让 Agent 误认为自己已经说过。用户随后回复时创建新的被动 Turn，引用关系只能通过显式 `reply_to_turn_id` 表达，不能把主动 Turn 重新打开。
 
 同一条主动消息的实时事件与发送成功后的历史投影必须携带同一个稳定投递身份。客户端优先用该身份精确合并；内容与时间匹配只能兼容缺少稳定身份的旧消息。部分送达和结果不明必须有独立状态，不能冒充成功或完全失败。
 
@@ -584,7 +584,7 @@ Core；旧代恢复失败则停在 maintenance 并保留全部证据。软件回
 
 ### OUT-004 `message_push` 不取得目标 session 的执行所有权
 
-`message_push` 是调用 turn 发起的外部投递，不是目标 session 的 inbound turn。它不得等待目标 session lane；实际 adapter send 仍通过 ChatLane 的短提交 owner 串行。普通 scheduler/proactive 的 non-passive 投递继续等待同 chat 的被动回复优先完成；被动或程序化验证 turn 发起的 push 可以走 passive-send 路径，但不能与另一实际 send 重叠。push 正文不注入正在运行的父 Prompt，也不追加到目标 session history；调用参数和真实 delivery receipt 保存在调用 session 的工具 trace。pointer、异常或取消都不得伪装成已经发生的外部投递被回滚。
+`message_push` 是调用 turn 发起的外部投递，不是目标 session 的 inbound execution attempt；它在发送边界分配并关闭自己的 outbound Turn，不取得目标 session 的推理所有权。它不得等待目标 session lane；实际 adapter send 仍通过 ChatLane 的短提交 owner 串行。普通 scheduler/proactive 的 non-passive 投递继续等待同 chat 的被动回复优先完成；被动或程序化验证 turn 发起的 push 可以走 passive-send 路径，但不能与另一实际 send 重叠。push 正文不注入正在运行的父 Prompt；调用参数和真实 delivery receipt 保存在调用 session 的工具 trace。pointer、异常或取消都不得伪装成已经发生的外部投递被回滚。
 
 ### OUT-005 硬终止只关闭 Execution Attempt
 
@@ -710,7 +710,7 @@ add、cancel 和 reschedule 先构造 candidate，持久化成功后才替换内
 
 ### SCH-003 Soft 调度任务是无状态原子执行
 
-每次 soft job 只使用当前 prompt、系统能力和工具完成一次独立推理，不读取同一 job 的历史窗口，不把内部 user 或 assistant turn 写入会话历史，也不把内部 turn 事件发布到目标 channel。目标 channel 只负责调度时的 busy admission 与最终发送；推理成功且结果非空时只产生一次外部推送，失败或空结果不得伪装成已送达。
+每次 soft job 只使用当前 prompt、系统能力和工具完成一次独立推理，不读取同一 job 的历史窗口，不把内部 user 或 assistant attempt 写入会话历史，也不把内部 attempt 事件发布到目标 channel。每次 schedule fire 拥有一个独立 outbound Turn；目标 channel 只负责调度时的 busy admission 与最终发送，assistant 明确送达即关闭该 Turn。推理成功且结果非空时只产生一次外部推送，失败或空结果不得伪装成已送达。
 
 ### PRO-001 主动流程的空、跳过和失败可区分
 

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -9,11 +9,11 @@ import sqlite3
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Iterator, Mapping
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from time import monotonic
 from typing import TYPE_CHECKING, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from bus.events import (
     ChannelMessage,
@@ -718,6 +718,7 @@ class MobileRealtimeChannel:
             "content": message,
             "attachments": [],
             "metadata": {"source": "message_push"},
+            "control_turn_id": f"turn:{uuid4().hex}",
         }
         if delivery_id is not None:
             payload["delivery_id"] = delivery_id
@@ -736,6 +737,8 @@ class MobileRealtimeChannel:
         self._raise_delta_failure()
         if message.metadata.get("_channel_commit_role") == "passive":
             return await self._deliver_passive_message(message)
+        if message.control_turn_id is None:
+            message = replace(message, control_turn_id=f"turn:{uuid4().hex}")
         session_id = self._session_id(message.chat_id)
         if not self._runtime.storage.list_active_devices():
             return DeliveryReceipt(
@@ -754,6 +757,7 @@ class MobileRealtimeChannel:
                 "content": message.content,
                 "attachments": [],
                 "metadata": {"source": "message_push"},
+                "control_turn_id": message.control_turn_id,
             }
             if delivery_id is not None:
                 payload["delivery_id"] = delivery_id
@@ -851,6 +855,7 @@ class MobileRealtimeChannel:
             "content": message.content,
             "attachments": [attachment_descriptor(record) for record in records],
             "metadata": {"source": "message_push"},
+            "control_turn_id": message.control_turn_id,
         }
         if delivery_id is not None:
             payload["delivery_id"] = delivery_id
@@ -1761,6 +1766,7 @@ class MobileRealtimeChannel:
             payload={
                 "content": event.content,
                 "client_message_id": event.client_message_id,
+                "control_turn_id": event.control_turn_id or turn_id,
             },
         )
         # 3. 时间链：服务端接受 turn；duration 为 send.received → turn.started
@@ -2043,7 +2049,16 @@ class MobileRealtimeChannel:
 
         self._raise_delta_failure()
         session_id = self._session_id(message.chat_id)
-        turn_id = message.control_turn_id or self._current_turn_id(session_id)
+        raw_attempt_id = message.execution_attempt_id
+        if raw_attempt_id is not None and (
+            not isinstance(raw_attempt_id, str) or not raw_attempt_id
+        ):
+            raise RuntimeError("mobile final execution attempt id 无效")
+        turn_id = (
+            cast(str | None, raw_attempt_id)
+            or message.control_turn_id
+            or self._current_turn_id(session_id)
+        )
         key = (session_id, turn_id)
         message_id = message.session_message_id
         media = [attachment.source for attachment in message.attachments]
@@ -2065,6 +2080,7 @@ class MobileRealtimeChannel:
             payload: dict[str, object] = {
                 "status": message.terminal_status.value,
                 "message": message.content or "本轮已中断。",
+                "control_turn_id": message.control_turn_id,
             }
             if client_message_id is not None:
                 payload["client_message_id"] = client_message_id
@@ -2122,6 +2138,7 @@ class MobileRealtimeChannel:
             "thinking": message.thinking or "",
             "attachments": attachments,
             "metadata": metadata,
+            "control_turn_id": message.control_turn_id or turn_id,
         }
         user_message_id = source_metadata.get("persisted_user_message_id")
         # client_message_id 可单独存在（failed/中断终态）；persisted_user_message_id
@@ -2690,7 +2707,17 @@ class MobileRealtimeChannel:
     ) -> dict[str, object]:
         """构造 turn.interrupted 载荷；进程内已知 client_message_id 必须贯通。"""
 
-        payload: dict[str, object] = {"status": status, "message": message}
+        turn = self._require_ctx().session_manager.control_store.read_turn(turn_id)
+        control_turn_id: object = (
+            turn.metadata.get("interactionId", turn.id) if turn is not None else turn_id
+        )
+        if not isinstance(control_turn_id, str) or not control_turn_id:
+            raise RuntimeError("mobile interrupted logical turn id 无效")
+        payload: dict[str, object] = {
+            "status": status,
+            "message": message,
+            "control_turn_id": control_turn_id,
+        }
         if reason is not None:
             payload["reason"] = reason
         state = self._process_turns.get((session_id, turn_id))

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -313,6 +313,7 @@ async def test_recovered_mobile_handoff_without_turn_creates_one_turn_and_delive
     assert manager.control_store.list_inbound_handoffs() == []
     assert [msg.content for msg in delivered] == ["echo:hello"]
     assert delivered[0].control_turn_id == turns[0].id
+    assert delivered[0].execution_attempt_id == turns[0].id
     await _cancel_task(dispatch)
     await runtime.shutdown()
     manager.close()

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -205,6 +205,8 @@ async def test_runtime_replays_two_interrupted_attempts_into_one_interaction(
 
     assert captured_final is not None
     assert captured_final.metadata["interactionId"] == first.id
+    assert result.id == third.id
+    assert result.interaction_id == first.id
     assert captured_final.metadata["continuedFromTurnId"] == second.id
     assert captured_final.metadata["attemptOrdinal"] == 2
     assert captured_final.metadata["priorInputCount"] == 2

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1796,6 +1796,7 @@ async def test_typed_interrupted_outbound_publishes_one_durable_terminal(
     assert terminals[0]["payload"] == {
         "status": "interrupted",
         "message": "本轮已中断。",
+        "control_turn_id": turn_id,
         "client_message_id": "cmid-interrupted",
     }
     storage.close()
@@ -2029,6 +2030,7 @@ async def test_resume_reconciles_recovered_terminal_turn_for_mobile_device(
             "payload": {
                 "status": "cancelled",
                 "message": "服务端已确认本轮生成结束",
+                "control_turn_id": turn_id,
                 "reason": "resume_reconciliation",
             },
             "device_id": device_id,
@@ -2164,6 +2166,7 @@ async def test_channel_stop_publishes_terminal_before_clearing_active_turn(
         "payload": {
             "status": "interrupted",
             "message": "服务端正在维护，本轮生成已中断",
+            "control_turn_id": turn_id,
             "reason": "runtime_shutdown",
         },
     }
@@ -3928,14 +3931,16 @@ async def test_late_a_final_keeps_b_active_and_identity(
     channel._send_received_at[(session_id, "cmid-A")] = 10.0
     channel._send_received_at[(session_id, "cmid-B")] = 20.0
 
-    # 1. 迟到的 A final 通过 control_turn_id 归属 A，绝不 fallback 归 B。
+    # 1. 迟到的 A final 通过 execution attempt 归属 A；逻辑 Turn 独立投影。
+    logical_turn_a = "turn:logical-A"
     with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
         await channel._on_response(
             OutboundMessage(
                 channel="mobile",
                 chat_id=session_id.removeprefix("mobile:"),
                 content="A1A2终",
-                control_turn_id=turn_a,
+                control_turn_id=logical_turn_a,
+                execution_attempt_id=turn_a,
                 metadata={
                     "client_message_id": "cmid-A",
                     "persisted_user_message_id": "uid-A",
@@ -3946,6 +3951,7 @@ async def test_late_a_final_keeps_b_active_and_identity(
     assert final["event_type"] == "message.final"
     assert final["turn_id"] == turn_a
     final_payload = cast(dict[str, object], final["payload"])
+    assert final_payload["control_turn_id"] == logical_turn_a
     assert final_payload["client_message_id"] == "cmid-A"
     assert final_payload["user_message_id"] == "uid-A"
     final_records = [
@@ -4012,6 +4018,16 @@ async def test_interrupt_publish_paths_carry_known_client_message_id(
         )
     )
     active_turn = "turn-stop-active"
+    manager.control_store.create_turn(
+        TurnRecord(
+            id=active_turn,
+            thread_id=session_id,
+            status=TurnStatus.QUEUED,
+            input="A",
+            created_at=datetime.now(timezone.utc),
+            metadata={"interactionId": "turn-logical-stop"},
+        )
+    )
     await channel._on_turn_started(
         TurnStarted(
             session_key=session_id,
@@ -4041,12 +4057,23 @@ async def test_interrupt_publish_paths_carry_known_client_message_id(
     assert interrupted[-1]["payload"] == {
         "status": "interrupted",
         "message": "已停止",
+        "control_turn_id": "turn-logical-stop",
         "client_message_id": "cmid-stop",
     }
     assert session_id not in channel._active_turn_ids
 
     # 2. shutdown：另一活动 turn 的 interrupted 同样贯通已知 client_message_id
     shutdown_turn = "turn-shutdown"
+    manager.control_store.create_turn(
+        TurnRecord(
+            id=shutdown_turn,
+            thread_id=session_id,
+            status=TurnStatus.QUEUED,
+            input="B",
+            created_at=datetime.now(timezone.utc),
+            metadata={"interactionId": "turn-logical-shutdown"},
+        )
+    )
     await channel._on_turn_started(
         TurnStarted(
             session_key=session_id,
@@ -4066,6 +4093,7 @@ async def test_interrupt_publish_paths_carry_known_client_message_id(
         "status": "interrupted",
         "message": "服务端正在维护，本轮生成已中断",
         "reason": "runtime_shutdown",
+        "control_turn_id": "turn-logical-shutdown",
         "client_message_id": "cmid-shutdown",
     }
     manager.close()
@@ -4266,17 +4294,14 @@ async def test_proactive_sender_uses_mobile_event_path(tmp_path: Path) -> None:
     )
 
     assert receipt.status is DeliveryStatus.SUCCESS
-    assert runtime.events == [
-        {
-            "event_type": "message.proactive",
-            "session_id": f"mobile:{chat_id}",
-            "payload": {
-                "content": "该休息一下了",
-                "attachments": [],
-                "metadata": {"source": "message_push"},
-            },
-        }
-    ]
+    assert len(runtime.events) == 1
+    proactive = runtime.events[0]
+    assert proactive["event_type"] == "message.proactive"
+    assert proactive["session_id"] == f"mobile:{chat_id}"
+    assert proactive["payload"]["content"] == "该休息一下了"
+    assert proactive["payload"]["attachments"] == []
+    assert proactive["payload"]["metadata"] == {"source": "message_push"}
+    assert proactive["payload"]["control_turn_id"].startswith("turn:")
     await channel.stop()
     storage.close()
 
@@ -4314,7 +4339,9 @@ async def test_proactive_metadata_sender_forwards_delivery_id(tmp_path: Path) ->
     )
 
     assert receipt.status is DeliveryStatus.SUCCESS
-    assert runtime.events[-1]["payload"] == {
+    payload = runtime.events[-1]["payload"]
+    assert payload["control_turn_id"].startswith("turn:")
+    assert {key: value for key, value in payload.items() if key != "control_turn_id"} == {
         "content": "该休息一下了",
         "attachments": [],
         "metadata": {"source": "message_push"},
@@ -4499,8 +4526,8 @@ async def test_send_and_turn_started_bind_each_client_message_id_per_session(
         if event["event_type"] == "turn.started"
     ]
     assert started_payloads == [
-        {"content": "A", "client_message_id": first_id},
-        {"content": "B", "client_message_id": second_id},
+        {"content": "A", "client_message_id": first_id, "control_turn_id": "turn-A"},
+        {"content": "B", "client_message_id": second_id, "control_turn_id": "turn-B"},
     ]
     for item in bus.inbound:
         manager.release_admission(item.session_admission_id)
@@ -5032,6 +5059,7 @@ async def test_interrupted_terminal_publish_fail_once_is_retryable(
     assert interrupted[0]["payload"] == {
         "status": "interrupted",
         "message": "已停止",
+        "control_turn_id": turn_id,
         "client_message_id": "cmid-stop",
     }
     assert channel._process_turns == {}

--- a/tests/turns/test_orchestrator.py
+++ b/tests/turns/test_orchestrator.py
@@ -90,6 +90,8 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
             delivery_id = outbound.metadata["delivery_id"]
             assert isinstance(delivery_id, str)
             assert len(delivery_id) == 32
+            assert outbound.control_turn_id is not None
+            assert outbound.control_turn_id.startswith("turn:")
             dispatched_delivery_ids.append(delivery_id)
             return DeliveryReceipt(DeliveryStatus.SUCCESS)
 
@@ -128,6 +130,7 @@ async def test_orchestrator_proactive_reply_persists_dispatches_and_runs_success
     )
 
     assert sent is True
+    assert session.messages[-1]["control_turn_id"].startswith("turn:")
     assert session.messages[0]["proactive"] is True
     assert session.messages[0]["content"] == "hello"
     assert session.messages[0]["delivery_id"] == dispatched_delivery_ids[0]

--- a/tests/turns/test_outbound.py
+++ b/tests/turns/test_outbound.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from agent.turns.outbound import BusOutboundPort, OutboundDispatch, PushToolOutboundPort
-from bus.events import ChannelMessage, DeliveryStatus, OutboundMessage
+from agent.tools.message_push import MessagePushTool
+from bus.events import ChannelMessage, DeliveryReceipt, DeliveryStatus, OutboundMessage
 from bus.queue import MessageBus
 
 
@@ -102,3 +103,25 @@ async def test_push_tool_outbound_port_forwards_control_turn_id_verbatim() -> No
     assert message.session_message_id == "telegram:123:5"
     assert message.metadata == {"source": "passive"}
     assert message.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_message_push_assigns_one_independent_turn_per_dispatch() -> None:
+    delivered: list[ChannelMessage] = []
+    push = MessagePushTool()
+
+    async def deliver(message: ChannelMessage) -> DeliveryReceipt:
+        delivered.append(message)
+        return DeliveryReceipt(DeliveryStatus.SUCCESS)
+
+    _ = push.register_channel("mobile", deliver)
+    for content in ("one", "two"):
+        receipt = await push.dispatch(ChannelMessage("mobile", "chat", content))
+        assert receipt.status is DeliveryStatus.SUCCESS
+
+    turn_ids = [message.control_turn_id for message in delivered]
+    assert all(
+        turn_id is not None and turn_id.startswith("turn:")
+        for turn_id in turn_ids
+    )
+    assert len(set(turn_ids)) == 2


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Mobile realtime final 使用 execution attempt ID，而 SessionDB history 使用 logical interaction ID，continued attempt 会触发 Canonical control turn id mismatch。
- 用户可见结果：Turn 是逻辑工作单元；被动多 Attempt 保持一个 Turn；proactive、message_push、schedule fire、spawn completion assistant 各自独立 Turn，送达即关闭。
- 本 PR 不处理：不迁移或删除既有 SessionDB 消息，不放宽 Android 严格校验。

## Change intent

- change_type：fix
- semantic_delta：compatible
- capability_owner：mixed
- consumer_scope：Core control、Mobile realtime、proactive、message_push、scheduler、spawn
- runtime_patch：required
- runtime_patch_reason：逻辑 Turn 身份与 Attempt 生命周期均由服务端权威状态拥有，客户端无法推断。
- authoritative_state_owner：ConversationRuntime interaction metadata 与 SessionDB control_turn_id
- client_only_alternative：不可行，会把服务端 identity 漂移隐藏在客户端。
- 关联不变量：SES-007、SES-008、MEM-011、OUT-001、OUT-004、SCH-003
- protected_state：sessions.db/messages append-only
- 允许的副作用：新增协议字段与主动 outbound Turn ID
- 禁止的副作用：删除消息、放宽协议、改变 stop 的 Attempt owner

## 改动范围

- 主要文件：control models、passive worker、mobile realtime channel、message_push、proactive orchestrator
- 配置或迁移影响：无 schema migration
- 回滚方式：revert 本提交；既有数据未改写

## 验证

- targeted Core tests：171 passed
- mobile realtime tests：72 passed
- change gate：passed，report 20260813-095534-beea4dbc，planDigest 5f9706ab7a4006022d3f6764ff6b18be307a7d945bce0e0acc0cc303cc32c284
- Terra xhigh 只读 Review：No findings
- 未运行：按维护者明确授权跳过 E2E 与真机 Gate

## 工作手册

- projectneed 与 accepted decision 0034 已同步
- NOW 无对应未完成事项