### PR TITLE
fix(mobile): keep logical turn identity stable across replay

### DIFF
--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -124,6 +124,7 @@ class _ProcessTurnState:
     thinking_block: tuple[str, int] | None
     tool_blocks: dict[str, tuple[str, int, float]]
     answer_segments: list[str]
+    control_turn_id: str = ""
     first_thinking_received: bool = False
     first_answer_received: bool = False
     first_thinking_published: bool = False
@@ -1754,6 +1755,7 @@ class MobileRealtimeChannel:
             thinking_block=None,
             tool_blocks={},
             answer_segments=[],
+            control_turn_id=event.control_turn_id or turn_id,
             client_message_id=event.client_message_id,
         )
         self._turn_started_at[process_key] = monotonic()
@@ -1990,6 +1992,7 @@ class MobileRealtimeChannel:
                     "ordinal": ordinal,
                     "tool_name": event.tool_name,
                     "arguments": _mobile_tool_arguments(event.arguments),
+                    "control_turn_id": state.control_turn_id,
                 },
             )
 
@@ -2031,6 +2034,7 @@ class MobileRealtimeChannel:
                     ),
                     "result_preview": event.result_preview,
                     "duration_ms": max(0, round((monotonic() - started_at) * 1_000)),
+                    "control_turn_id": state.control_turn_id,
                 },
             )
 
@@ -2176,6 +2180,7 @@ class MobileRealtimeChannel:
                 turn_id,
                 message_content=message.content,
                 emitted_content=emitted_content,
+                control_turn_id=cast(str, final_payload["control_turn_id"]),
             )
             final_payload["content"] = final_content
             started_at = self._turn_started_at.get(key)
@@ -2474,7 +2479,11 @@ class MobileRealtimeChannel:
         published_any = False
         while batch.segments:
             event_type, delta, block_id, ordinal = batch.segments[0]
-            payload: dict[str, object] = {"delta": delta}
+            state = self._require_process_state(session_id, turn_id)
+            payload: dict[str, object] = {
+                "delta": delta,
+                "control_turn_id": state.control_turn_id,
+            }
             if block_id is not None:
                 if ordinal is None:
                     raise AssertionError("thinking delta block 缺少 ordinal")
@@ -2505,6 +2514,7 @@ class MobileRealtimeChannel:
         *,
         message_content: str,
         emitted_content: str,
+        control_turn_id: str,
     ) -> tuple[str, str]:
         """锁内把 final 缺失正文入批并记账；返回 (suffix, final_content)。"""
 
@@ -2530,6 +2540,7 @@ class MobileRealtimeChannel:
                 thinking_block=None,
                 tool_blocks={},
                 answer_segments=[],
+                control_turn_id=control_turn_id,
                 client_message_id="",
             )
             self._process_turns[key] = state

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -251,6 +251,7 @@ class DeltaPayload(ProtocolModel):
     delta: str = Field(min_length=1, max_length=65_536)
     block_id: NonEmptyId | None = None
     ordinal: int | None = Field(default=None, ge=0)
+    control_turn_id: NonEmptyId | None = None
 
     @model_validator(mode="after")
     def validate_process_block(self) -> DeltaPayload:

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -569,6 +569,20 @@
             "default": null,
             "title": "Block Id"
           },
+          "control_turn_id": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Control Turn Id"
+          },
           "delta": {
             "maxLength": 65536,
             "minLength": 1,

--- a/tests/mobile_realtime/fixtures/frames-v1.json
+++ b/tests/mobile_realtime/fixtures/frames-v1.json
@@ -32,7 +32,10 @@
     "event_seq": 1842,
     "session_id": "mobile:demo",
     "turn_id": "turn-1",
-    "payload": {"delta": "正在回答"}
+    "payload": {
+      "delta": "正在回答",
+      "control_turn_id": "turn:logical-1"
+    }
   },
   {
     "v": 1,

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -2592,6 +2592,13 @@ async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None
     key = ("mobile:test", "turn-1")
     existing_lock = asyncio.Lock()
     channel._delta_locks[key] = existing_lock
+    channel._process_turns[key] = channel_module._ProcessTurnState(
+        next_ordinal=0,
+        thinking_block=None,
+        tool_blocks={},
+        answer_segments=[],
+        control_turn_id="turn:logical-1",
+    )
 
     real_lock = channel_module.asyncio.Lock
     allocations = 0
@@ -2618,7 +2625,10 @@ async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None
             "event_type": "answer.delta",
             "session_id": key[0],
             "turn_id": key[1],
-            "payload": {"delta": "x" * 4096},
+            "payload": {
+                "delta": "x" * 4096,
+                "control_turn_id": "turn:logical-1",
+            },
         }
     ]
 
@@ -2662,6 +2672,7 @@ async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool
         created_at=datetime.now(timezone.utc),
     )
     turn_id = uuid4().hex
+    logical_turn_id = f"turn:{uuid4().hex}"
     await channel._on_turn_started(
         TurnStarted(
             session_key=session_id,
@@ -2670,6 +2681,7 @@ async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool
             content="帮我检查",
             timestamp=datetime.now(timezone.utc),
             turn_id=turn_id,
+            control_turn_id=logical_turn_id,
         )
     )
 
@@ -2765,7 +2777,8 @@ async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool
             content="完成",
             thinking="思考中",
             metadata={"mobile_attention": "confirmation"},
-            control_turn_id=turn_id,
+            control_turn_id=logical_turn_id,
+            execution_attempt_id=turn_id,
         )
     )
 
@@ -2783,6 +2796,11 @@ async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool
     tool_completed = cast(dict[str, object], runtime.events[5]["payload"])
     second_thinking = cast(dict[str, object], runtime.events[6]["payload"])
     final_metadata = cast(dict[str, object], runtime.events[7]["payload"])["metadata"]
+    assert all(
+        cast(dict[str, object], event["payload"])["control_turn_id"]
+        == logical_turn_id
+        for event in runtime.events
+    )
     assert tool_started["block_id"] == tool_completed["block_id"]
     assert tool_started["ordinal"] == tool_completed["ordinal"] == 1
     assert second_thinking["ordinal"] == 2

--- a/tests/mobile_realtime/test_mobile_realtime_protocol.py
+++ b/tests/mobile_realtime/test_mobile_realtime_protocol.py
@@ -324,10 +324,12 @@ def test_delta_process_block_fields_must_appear_together() -> None:
         "delta": "思考中",
         "block_id": "thinking:turn-1:0",
         "ordinal": 0,
+        "control_turn_id": "turn:logical-1",
     }
     parsed = parse_frame(json.dumps(frame))
     assert isinstance(parsed, ThinkingDeltaEvent)
     assert parsed.payload.block_id == "thinking:turn-1:0"
+    assert parsed.payload.control_turn_id == "turn:logical-1"
 
     frame["payload"].pop("ordinal")
     with pytest.raises(ValidationError, match="必须同时出现"):


### PR DESCRIPTION
## 问题与结果

- 解决的问题：continued attempt 的 turn.started 使用逻辑 control_turn_id，但 delta 只带执行 turn_id，Android durable replay 因身份变化停止 ACK。
- 用户可见结果：所有 turn-scoped delta/tool 事件都携带服务端权威 control_turn_id；旧 durable 事件由客户端兼容。
- 本 PR 不处理：不清理 inbox/cursor，不迁移 SessionDB，不改变 Turn/Attempt 语义。

## Change intent

- change_type：fix
- semantic_delta：none（落实 decision 0034 已声明合同）
- capability_owner：protocol / core
- consumer_scope：Mobile v1 realtime consumers
- runtime_patch：required
- runtime_patch_reason：逻辑身份由 Core 生命周期产生，客户端不能从 attempt 推导。
- authoritative_state_owner：Core _ProcessTurnState / TurnStarted
- client_only_alternative：仅兼容旧 backlog，无法保证新事件自描述。
- 关联不变量：同一 execution attempt 的所有事件共享同一 control_turn_id。
- protected_state：sessions.db/messages、durable inbox、device cursor、正式 workspace。
- 允许的副作用：未来 durable delta/tool payload 增加 control_turn_id。
- 禁止的副作用：删除消息、跳 ACK、重置设备或修改正式 workspace。

## 改动范围

- 主要文件：infra/mobile_realtime/channel.py、protocol.py、schema 与回归测试。
- 配置或迁移影响：无数据库迁移；v1 payload 兼容性增加字段。
- 已知 schema lineage 与最终 schema identity：mobile-realtime-v1 checked-in schema 由当前模型重新生成。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：7097bb49；Gate report 20260813-194355-e0ab68e1。
- 回滚方式：revert 7097bb49；不涉及持久状态回滚。

## 验证

- [x] 相关 targeted tests 已通过：120 passed。
- [x] Python 类型检查已通过：0 errors，2 个既有 optional warnings。
- [x] python docker/debug/gate.py run --base origin/main 已运行并通过。
- sourceDigest：bf858ee7410ea5bf9a22d4cb1fcc04b3128009718ca6408a76b3e06bafac229f
- planDigest：1614ce3f42719e13d7dce273f65ce683f7d97f8024d7b180292b911cc66b7f10
- 真实设备证据：由配套 Android PR 提供。
- 未运行项与原因：无 Core 设备测试。

## 工作手册

- [x] 已核对 projectneed、decision 0034、相关设计和 NOW。
- [x] 本次没有长期语义变化。
- [x] 已按 MOB-001 核对：Core 拥有协议身份，Android 只投影。
- [x] 当前没有对应 NOW 完成项。