### PR TITLE
refactor(mobile): 删除死协议面 turn.snapshot

### DIFF
--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -68,7 +68,6 @@ EVENT_TYPES = frozenset(
         "react.tool.completed",
         "answer.delta",
         "turn.output.completed",
-        "turn.snapshot",
         "message.final",
         "turn.interrupted",
         "message.proactive",
@@ -237,20 +236,6 @@ class AttachmentFinishPayload(ProtocolModel):
 class AttachmentDownloadPayload(ProtocolModel):
     attachment_id: FrameId
     offset: int = Field(ge=0)
-
-
-class TurnSnapshotPayload(ProtocolModel):
-    turn_id: NonEmptyId
-    status: Literal["queued", "running", "completed", "interrupted", "failed"]
-    blocks: list[JsonObject]
-    content_so_far: str
-    last_source_event_id: FrameId | None
-
-    @model_validator(mode="after")
-    def validate_last_source_event_id(self) -> TurnSnapshotPayload:
-        if self.last_source_event_id is not None:
-            _validate_frame_id(self.last_source_event_id, "last_source_event_id")
-        return self
 
 
 class DeltaPayload(ProtocolModel):
@@ -457,25 +442,6 @@ class AnswerDeltaEvent(EventEnvelope):
     payload: DeltaPayload
 
 
-class TurnSnapshotEvent(ProtocolModel):
-    v: Literal[1]
-    kind: Literal["event"]
-    type: Literal["turn.snapshot"]
-    id: FrameId
-    connection_epoch: ConnectionEpoch
-    event_seq: EventSequence
-    session_id: NonEmptyId | None = None
-    turn_id: NonEmptyId
-    payload: TurnSnapshotPayload
-
-    @model_validator(mode="after")
-    def validate_event(self) -> TurnSnapshotEvent:
-        _validate_frame_id(self.id, "id")
-        if self.turn_id != self.payload.turn_id:
-            raise ValueError("turn.snapshot envelope 与 payload 的 turn_id 必须一致")
-        return self
-
-
 class GenericEvent(EventEnvelope):
     type: Literal[
         "session.list",
@@ -498,7 +464,7 @@ class GenericEvent(EventEnvelope):
 
 
 EventFrame: TypeAlias = Annotated[
-    ThinkingDeltaEvent | AnswerDeltaEvent | TurnSnapshotEvent | GenericEvent,
+    ThinkingDeltaEvent | AnswerDeltaEvent | GenericEvent,
     Field(discriminator="type"),
 ]
 

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -89,7 +89,6 @@
     "sync.reset_required",
     "turn.interrupted",
     "turn.output.completed",
-    "turn.snapshot",
     "turn.started"
   ],
   "frame": {
@@ -1650,137 +1649,6 @@
         ],
         "title": "ThinkingDeltaEvent",
         "type": "object"
-      },
-      "TurnSnapshotEvent": {
-        "additionalProperties": false,
-        "properties": {
-          "connection_epoch": {
-            "minimum": 1,
-            "title": "Connection Epoch",
-            "type": "integer"
-          },
-          "event_seq": {
-            "minimum": 1,
-            "title": "Event Seq",
-            "type": "integer"
-          },
-          "id": {
-            "maxLength": 36,
-            "minLength": 26,
-            "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
-            "title": "Id",
-            "type": "string"
-          },
-          "kind": {
-            "const": "event",
-            "title": "Kind",
-            "type": "string"
-          },
-          "payload": {
-            "$ref": "#/$defs/TurnSnapshotPayload"
-          },
-          "session_id": {
-            "anyOf": [
-              {
-                "maxLength": 512,
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Session Id"
-          },
-          "turn_id": {
-            "maxLength": 512,
-            "minLength": 1,
-            "title": "Turn Id",
-            "type": "string"
-          },
-          "type": {
-            "const": "turn.snapshot",
-            "title": "Type",
-            "type": "string"
-          },
-          "v": {
-            "const": 1,
-            "title": "V",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "v",
-          "kind",
-          "type",
-          "id",
-          "connection_epoch",
-          "event_seq",
-          "turn_id",
-          "payload"
-        ],
-        "title": "TurnSnapshotEvent",
-        "type": "object"
-      },
-      "TurnSnapshotPayload": {
-        "additionalProperties": false,
-        "properties": {
-          "blocks": {
-            "items": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "type": "object"
-            },
-            "title": "Blocks",
-            "type": "array"
-          },
-          "content_so_far": {
-            "title": "Content So Far",
-            "type": "string"
-          },
-          "last_source_event_id": {
-            "anyOf": [
-              {
-                "maxLength": 36,
-                "minLength": 26,
-                "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Source Event Id"
-          },
-          "status": {
-            "enum": [
-              "queued",
-              "running",
-              "completed",
-              "interrupted",
-              "failed"
-            ],
-            "title": "Status",
-            "type": "string"
-          },
-          "turn_id": {
-            "maxLength": 512,
-            "minLength": 1,
-            "title": "Turn Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "turn_id",
-          "status",
-          "blocks",
-          "content_so_far",
-          "last_source_event_id"
-        ],
-        "title": "TurnSnapshotPayload",
-        "type": "object"
       }
     },
     "discriminator": {
@@ -1898,7 +1766,6 @@
               "sync.reset_required": "#/$defs/GenericEvent",
               "turn.interrupted": "#/$defs/GenericEvent",
               "turn.output.completed": "#/$defs/GenericEvent",
-              "turn.snapshot": "#/$defs/TurnSnapshotEvent",
               "turn.started": "#/$defs/GenericEvent"
             },
             "propertyName": "type"
@@ -1909,9 +1776,6 @@
             },
             {
               "$ref": "#/$defs/AnswerDeltaEvent"
-            },
-            {
-              "$ref": "#/$defs/TurnSnapshotEvent"
             },
             {
               "$ref": "#/$defs/GenericEvent"
@@ -2003,7 +1867,6 @@
             "sync.reset_required": "#/$defs/GenericEvent",
             "turn.interrupted": "#/$defs/GenericEvent",
             "turn.output.completed": "#/$defs/GenericEvent",
-            "turn.snapshot": "#/$defs/TurnSnapshotEvent",
             "turn.started": "#/$defs/GenericEvent"
           },
           "propertyName": "type"
@@ -2014,9 +1877,6 @@
           },
           {
             "$ref": "#/$defs/AnswerDeltaEvent"
-          },
-          {
-            "$ref": "#/$defs/TurnSnapshotEvent"
           },
           {
             "$ref": "#/$defs/GenericEvent"

--- a/tests/mobile_realtime/fixtures/frames-v1.json
+++ b/tests/mobile_realtime/fixtures/frames-v1.json
@@ -21,7 +21,9 @@
     "id": "01J00000000000000000000000",
     "connection_epoch": 7,
     "session_id": "mobile:demo",
-    "payload": {"accepted": true}
+    "payload": {
+      "accepted": true
+    }
   },
   {
     "v": 1,
@@ -42,37 +44,30 @@
     "kind": "ack",
     "type": "event.ack",
     "connection_epoch": 7,
-    "payload": {"through_event_seq": 1842}
+    "payload": {
+      "through_event_seq": 1842
+    }
   },
   {
     "v": 1,
     "kind": "control",
     "type": "auth.accepted",
     "connection_epoch": 7,
-    "payload": {"connection_epoch": 7, "device_id": "device-1"}
+    "payload": {
+      "connection_epoch": 7,
+      "device_id": "device-1"
+    }
   },
   {
     "v": 1,
     "kind": "control",
     "type": "resume",
     "connection_epoch": 7,
-    "payload": {"last_ack": 1842, "active_turns": ["turn-1"]}
-  },
-  {
-    "v": 1,
-    "kind": "event",
-    "type": "turn.snapshot",
-    "id": "01J00000000000000000000003",
-    "connection_epoch": 7,
-    "event_seq": 1843,
-    "session_id": "mobile:demo",
-    "turn_id": "turn-1",
     "payload": {
-      "turn_id": "turn-1",
-      "status": "running",
-      "blocks": [{"kind": "answer", "ordinal": 0, "content": "正在回答"}],
-      "content_so_far": "正在回答",
-      "last_source_event_id": "01J00000000000000000000002"
+      "last_ack": 1842,
+      "active_turns": [
+        "turn-1"
+      ]
     }
   }
 ]

--- a/tests/mobile_realtime/test_mobile_realtime_protocol.py
+++ b/tests/mobile_realtime/test_mobile_realtime_protocol.py
@@ -18,7 +18,6 @@ from infra.mobile_realtime.protocol import (
     ProtocolDecodeError,
     ReplyFrame,
     ThinkingDeltaEvent,
-    TurnSnapshotEvent,
     frame_to_json,
     parse_frame,
 )
@@ -34,7 +33,6 @@ def test_golden_frames_round_trip() -> None:
     assert isinstance(parsed[0], MessageSendCommand)
     assert isinstance(parsed[1], ReplyFrame)
     assert isinstance(parsed[4], AuthAcceptedControl)
-    assert isinstance(parsed[6], TurnSnapshotEvent)
     assert [json.loads(frame_to_json(frame)) for frame in parsed] == frames
 
 


### PR DESCRIPTION
## 改动

删除死协议面 `turn.snapshot`：协议层声明但生产链路从未发布、移动端无消费者。已 rebase 到 `main@8b1a7cf7`，解决与 #390 的冲突并保留 `turn.output.completed` 事件与 `TURN_OUTPUT_COMPLETED_CAPABILITY` 能力门槛。

- `protocol.py` 删除 `TurnSnapshotPayload`、`TurnSnapshotEvent`、EVENT_TYPES 条目与 union
- 重新生成 schema：`turn.snapshot` 0 处引用，`turn.output.completed` 4 处引用
- golden fixture 与 round-trip 测试同步收敛

## 验证

- targeted：`python -m pytest tests/mobile_realtime/ tests/control/test_channel_adapter.py -q` = **286 passed**
- 当前 head 远端 `check-and-test`：**3296 passed / 2 skipped**
- 其余 required checks 全绿

## 移动端配套

按 0035 breaking removal 围栏：kachofugetsu09/akashic-mobile#73 已从 mobile `main@ee4594da` 重建，保留 #64 的 `turn.output.completed` capability/消费链，只移除 `turn.snapshot`，并固定到本 PR head `9c3eb428`。#73 固定组合 Gate 通过后合并本 PR；随后 #73 前进最终 pin 再合并。
