### PR TITLE
[codex] 修复 Akasha 主动 Turn 重放

### DIFF
--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -365,6 +365,12 @@ def _eligible_pairs(
         for turn_id in explicit_order:
             turn_messages = explicit[turn_id]
             users = [row for row in turn_messages if row["role"] == "user"]
+            if not users and all(
+                row["role"] == "assistant"
+                and _message_extra(row).get("proactive") is True
+                for row in turn_messages
+            ):
+                continue
             assistants = [
                 row
                 for row in turn_messages

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -2107,7 +2107,13 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
                 0,
                 "assistant",
                 "proactive",
-                json.dumps({"proactive": True, "delivery_id": "delivery-1"}),
+                json.dumps(
+                    {
+                        "proactive": True,
+                        "delivery_id": "delivery-1",
+                        "control_turn_id": "proactive-turn",
+                    }
+                ),
                 started.isoformat(),
             ),
         )
@@ -2153,6 +2159,47 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
     assert dense is not None and dense[0] == "u1"
     user_dense = struct.unpack("<2f", dense[1])
     assert user_dense == pytest.approx((2 / math.sqrt(5), 1 / math.sqrt(5)))
+
+
+def test_sparse_builder_rejects_orphan_message_push_turn(tmp_path: Path) -> None:
+    """不能把工具使用记录误当成合法的主动 Turn 身份。"""
+
+    # 1. 构造只有 message_push 执行证据、没有 proactive 身份的孤儿 Turn。
+    sessions = tmp_path / "sessions.db"
+    index = tmp_path / "index.db"
+    _create_sessions(sessions)
+    started = datetime(2026, 8, 6, tzinfo=timezone.utc)
+    with closing(sqlite3.connect(sessions)) as connection, connection:
+        connection.execute(
+            "INSERT INTO sessions VALUES ('test:one', ?, ?, 0, NULL)",
+            (started.isoformat(), started.isoformat()),
+        )
+        connection.execute(
+            "INSERT INTO messages VALUES (?, 'test:one', 0, ?, ?, NULL, ?, ?)",
+            (
+                "a1",
+                "assistant",
+                "orphan outbound",
+                json.dumps(
+                    {
+                        "control_turn_id": "orphan-turn",
+                        "tools_used": ["message_push"],
+                    }
+                ),
+                started.isoformat(),
+            ),
+        )
+
+    # 2. 普通孤儿 Turn 仍由 replay 边界明确拒绝。
+    with pytest.raises(ValueError, match="同 turn transcript 结构无效: orphan-turn"):
+        build_sparse_index(
+            sessions,
+            index,
+            BuildConfig(
+                embedding_model="embedding-model",
+                embedding_dimension=2,
+            ),
+        )
 
 
 def _seed_two_explicit_akasha_turns(workspace: Path) -> datetime:


### PR DESCRIPTION
## 改动

- Akasha sparse replay 排除带显式 `control_turn_id` 的 proactive assistant-only Turn。
- 保留其他显式 Turn 的严格结构校验，缺少 user 的普通 Turn 继续 fail-loud。
- 将现有 proactive 顺序回归改成生产真实的显式 Turn 形态。

## 根因

Proactive 消息现在拥有独立 Turn identity，但 Akasha replay 仍把所有显式 Turn 都当成 user → terminal assistant 对话。正式 workspace 在重启全量 replay 时因此拒绝合法的 proactive Turn，Core 无法启动。

## 验证

- `tests/test_akasha_plugin.py`: 41 passed
- 正式 `sessions.db` 只读 replay 到 `/tmp`：5320 turns，派生 SQLite `integrity_check = ok`
- `python docker/debug/gate.py run --base origin/main`: passed，report `20260814-010909-0a43faab`

## 状态边界

不修改 `sessions.db/messages` 或其他正式 workspace 权威事实；只修正 Akasha 派生索引的输入分类。
