### PR TITLE
[codex] 引入插件组合内核与验证回执

### DIFF
--- a/agent/plugin_composition/__init__.py
+++ b/agent/plugin_composition/__init__.py
@@ -1,0 +1,36 @@
+from agent.plugin_composition.context import CompositionRoot, Context, Fiber, Plugin
+from agent.plugin_composition.access import (
+    CompositionAudit,
+    ExternalEffectGate,
+    PluginDataAccess,
+    ScopedPluginData,
+)
+from agent.plugin_composition.effect import Effect
+from agent.plugin_composition.model import (
+    CompositionError,
+    CompositionReceipt,
+    ExternalEffectObservation,
+    FiberState,
+    FiberView,
+    ServiceKey,
+    WriteObservation,
+)
+
+__all__ = [
+    "CompositionError",
+    "CompositionReceipt",
+    "CompositionRoot",
+    "CompositionAudit",
+    "Context",
+    "Effect",
+    "ExternalEffectGate",
+    "ExternalEffectObservation",
+    "Fiber",
+    "FiberState",
+    "FiberView",
+    "Plugin",
+    "PluginDataAccess",
+    "ScopedPluginData",
+    "ServiceKey",
+    "WriteObservation",
+]

--- a/agent/plugin_composition/access.py
+++ b/agent/plugin_composition/access.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent.plugin_composition.model import (
+    ExternalEffectObservation,
+    WriteObservation,
+)
+
+
+class CompositionAudit:
+    """Record effects observed at Core-owned capability boundaries."""
+
+    def __init__(self) -> None:
+        self._writes: list[WriteObservation] = []
+        self._external_effects: list[ExternalEffectObservation] = []
+
+    @property
+    def writes(self) -> tuple[WriteObservation, ...]:
+        return tuple(self._writes)
+
+    @property
+    def external_effects(self) -> tuple[ExternalEffectObservation, ...]:
+        return tuple(self._external_effects)
+
+    def record_write(
+        self,
+        *,
+        plugin_id: str,
+        operation: str,
+        relative_path: str,
+        content: bytes,
+    ) -> None:
+        self._writes.append(
+            WriteObservation(
+                plugin_id=plugin_id,
+                operation=operation,
+                relative_path=relative_path,
+                sha256=hashlib.sha256(content).hexdigest(),
+            )
+        )
+
+    def record_external(self, *, kind: str, target: str, outcome: str) -> None:
+        self._external_effects.append(
+            ExternalEffectObservation(kind=kind, target=target, outcome=outcome)
+        )
+
+
+class ExternalEffectGate:
+    """Deny external effects by default and expose every attempt to Core."""
+
+    def __init__(self, audit: CompositionAudit) -> None:
+        self._audit = audit
+
+    def authorize(self, *, kind: str, target: str) -> None:
+        self._audit.record_external(kind=kind, target=target, outcome="denied")
+        raise PermissionError(f"候选插件禁止外部效果: {kind}:{target}")
+
+
+class PluginDataAccess:
+    """Allocate opaque plugin roots beneath one explicit workspace."""
+
+    def __init__(self, workspace: Path, audit: CompositionAudit) -> None:
+        self.workspace = workspace.resolve(strict=True)
+        self._audit = audit
+        self._root = self.workspace / "plugin-data"
+        directory_fd = _open_directory_chain(self.workspace, ("plugin-data",))
+        os.close(directory_fd)
+
+    def for_plugin(self, plugin_id: str) -> ScopedPluginData:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", plugin_id) is None:
+            raise ValueError(f"插件 ID 不是安全路径段: {plugin_id!r}")
+        root = self._root / plugin_id
+        directory_fd = _open_directory_chain(
+            self.workspace,
+            ("plugin-data", plugin_id),
+        )
+        os.close(directory_fd)
+        return ScopedPluginData(plugin_id, self.workspace, root, self._audit)
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedPluginData:
+    plugin_id: str
+    workspace: Path
+    root: Path
+    _audit: CompositionAudit
+
+    def read_text(self, relative_path: str) -> str:
+        parts = self._relative_parts(relative_path)
+        parent_fd = self._open_parent(parts[:-1])
+        try:
+            file_fd = os.open(
+                parts[-1],
+                os.O_RDONLY | os.O_NOFOLLOW,
+                dir_fd=parent_fd,
+            )
+            with os.fdopen(file_fd, "r", encoding="utf-8") as stream:
+                return stream.read()
+        finally:
+            os.close(parent_fd)
+
+    def write_text(self, relative_path: str, content: str) -> Path:
+        """Atomically write plugin-owned text through the scoped boundary."""
+
+        parts = self._relative_parts(relative_path)
+        parent_fd = self._open_parent(parts[:-1])
+        try:
+            operation = _atomic_write_at(parent_fd, parts[-1], content)
+        finally:
+            os.close(parent_fd)
+        self._audit.record_write(
+            plugin_id=self.plugin_id,
+            operation=operation,
+            relative_path=relative_path,
+            content=content.encode("utf-8"),
+        )
+        return self.root.joinpath(*parts)
+
+    def _relative_parts(self, relative_path: str) -> tuple[str, ...]:
+        relative = Path(relative_path)
+        if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+            raise ValueError(f"插件数据相对路径无效: {relative_path!r}")
+        return relative.parts
+
+    def _open_parent(self, relative_parts: tuple[str, ...]) -> int:
+        return _open_directory_chain(
+            self.workspace,
+            ("plugin-data", self.plugin_id, *relative_parts),
+        )
+
+
+def _open_directory_chain(workspace: Path, parts: tuple[str, ...]) -> int:
+    """Open or create a directory chain without following scoped symlinks."""
+
+    directory_fd = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for part in parts:
+            try:
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+            except FileNotFoundError:
+                os.mkdir(part, dir_fd=directory_fd)
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+            os.close(directory_fd)
+            directory_fd = next_fd
+        return directory_fd
+    except BaseException:
+        os.close(directory_fd)
+        raise
+
+
+def _atomic_write_at(directory_fd: int, name: str, content: str) -> str:
+    """Atomically replace one file relative to a bound directory descriptor."""
+
+    try:
+        target = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        target = None
+    if target is not None and stat.S_ISLNK(target.st_mode):
+        raise ValueError(f"插件数据目标不能是符号链接: {name}")
+
+    temporary = f".{name}.{secrets.token_hex(16)}.tmp"
+    file_fd = os.open(
+        temporary,
+        os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW,
+        0o666,
+        dir_fd=directory_fd,
+    )
+    try:
+        if target is not None:
+            os.fchmod(file_fd, stat.S_IMODE(target.st_mode))
+        with os.fdopen(file_fd, "w", encoding="utf-8", newline="") as stream:
+            file_fd = -1
+            _ = stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(
+            temporary,
+            name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        os.fsync(directory_fd)
+    except BaseException:
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        if file_fd != -1:
+            os.close(file_fd)
+    return "replace" if target is not None else "create"

--- a/agent/plugin_composition/context.py
+++ b/agent/plugin_composition/context.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+# pyright: reportPrivateUsage=false
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncGenerator, Protocol, TypeVar, cast
+
+from agent.plugin_composition.effect import Effect, EffectSetup
+from agent.plugin_composition.access import CompositionAudit
+from agent.plugin_composition.model import (
+    CompositionError,
+    CompositionReceipt,
+    FiberState,
+    FiberView,
+    ServiceKey,
+)
+
+T = TypeVar("T")
+PluginApply = Callable[["Context"], object]
+FiberObserver = Callable[["Fiber"], object]
+
+
+class Plugin(Protocol):
+    def apply(self, ctx: Context) -> object: ...
+
+
+@dataclass(slots=True)
+class _Provider:
+    key: ServiceKey[object]
+    value: object
+    owner: Fiber
+    revision: int
+
+
+class Context:
+    """Expose composition operations bound to one owning Fiber."""
+
+    def __init__(self, root: CompositionRoot, fiber: Fiber) -> None:
+        self._root = root
+        self._fiber = fiber
+
+    @property
+    def fiber(self) -> Fiber:
+        return self._fiber
+
+    @property
+    def generation_id(self) -> str:
+        return self._root.generation_id
+
+    async def mount(
+        self,
+        plugin: Plugin | PluginApply,
+        *,
+        name: str | None = None,
+        inject: Iterable[ServiceKey[object]] | None = None,
+        required_for_readiness: bool = True,
+    ) -> Fiber:
+        return await self._root._mount(
+            parent=self._fiber,
+            plugin=plugin,
+            name=name,
+            inject=inject,
+            required_for_readiness=required_for_readiness,
+        )
+
+    async def inject(
+        self,
+        dependencies: Iterable[ServiceKey[object]],
+        apply: PluginApply,
+        *,
+        name: str | None = None,
+    ) -> Fiber:
+        """Mount an optional child that activates only while deps exist."""
+
+        return await self.mount(
+            apply,
+            name=name or getattr(apply, "__name__", "inject"),
+            inject=dependencies,
+            required_for_readiness=False,
+        )
+
+    async def provide(self, key: ServiceKey[T], value: T) -> Effect:
+        async def setup() -> Callable[[], Awaitable[None]]:
+            self._root._register_provider(
+                cast(ServiceKey[object], key),
+                value,
+                self._fiber,
+            )
+
+            async def cleanup() -> None:
+                await self._root._remove_provider(
+                    cast(ServiceKey[object], key),
+                    self._fiber,
+                )
+
+            return cleanup
+
+        return await self.effect(setup, label=f"service:{key.name}")
+
+    def get(self, key: ServiceKey[T]) -> T | None:
+        provider = self._fiber.dependency_store.get(cast(ServiceKey[object], key))
+        if provider is None:
+            provider = self._root._active_provider(cast(ServiceKey[object], key))
+        return cast(T | None, None if provider is None else provider.value)
+
+    def require(self, key: ServiceKey[T]) -> T:
+        value = self.get(key)
+        if value is None:
+            raise CompositionError(
+                "INACTIVE_SERVICE",
+                f"当前 Fiber 无法取得 Service: {key.name}",
+            )
+        return value
+
+    async def effect(self, setup: EffectSetup, *, label: str = "effect") -> Effect:
+        return await self._fiber.add_effect(setup, label=label)
+
+
+class Fiber:
+    """Activate one plugin against a stable dependency epoch."""
+
+    def __init__(
+        self,
+        *,
+        root: CompositionRoot,
+        fiber_id: int,
+        name: str,
+        apply: PluginApply,
+        dependencies: tuple[ServiceKey[object], ...],
+        parent: Fiber | None,
+        required_for_readiness: bool,
+        is_root: bool = False,
+    ) -> None:
+        self.root = root
+        self.fiber_id = fiber_id
+        self.name = name
+        self.apply = apply
+        self.dependencies = dependencies
+        self.parent = parent
+        self.required_for_readiness = required_for_readiness
+        self.state = FiberState.ACTIVE if is_root else FiberState.PENDING
+        self.context = Context(root, self)
+        self.dependency_store: dict[ServiceKey[object], _Provider] = {}
+        self.effects: list[Effect] = []
+        self.children: list[Fiber] = []
+        self.error: BaseException | None = None
+        self._epoch: tuple[tuple[str, int], ...] | None = () if is_root else None
+        self._transition = asyncio.Lock()
+        self._transition_owner: asyncio.Task[object] | None = None
+        self._dispose_requested = False
+        self._dispose_task: asyncio.Task[None] | None = None
+        self._restart_task: asyncio.Task[None] | None = None
+        self._is_root = is_root
+
+    @property
+    def missing_services(self) -> tuple[str, ...]:
+        return tuple(
+            key.name
+            for key in self.dependencies
+            if self.root._active_provider(key) is None
+        )
+
+    async def add_effect(self, setup: EffectSetup, *, label: str) -> Effect:
+        """Register ownership before setup and expose only live Fiber states."""
+
+        if self.state in {FiberState.UNLOADING, FiberState.DISPOSED}:
+            raise CompositionError(
+                "INACTIVE_EFFECT",
+                f"{self.name} 在 {self.state.value} 状态不能注册 Effect",
+            )
+        effect = Effect(label=label, remove_from_owner=self._remove_effect)
+        self.effects.append(effect)
+        return await effect.start(setup)
+
+    async def reconcile(self) -> None:
+        """Move to the state implied by the newest dependency epoch."""
+
+        async with self._locked_transition():
+            if self._dispose_requested or self._is_root:
+                return
+            providers = self.root._dependency_snapshot(self.dependencies)
+            target_epoch = self.root._provider_epoch(providers)
+            if providers is None:
+                if self.state in {FiberState.ACTIVE, FiberState.FAILED}:
+                    await self._unload(next_state=FiberState.PENDING)
+                return
+            assert target_epoch is not None
+            if self.state == FiberState.ACTIVE and self._epoch == target_epoch:
+                return
+            if self.state in {FiberState.ACTIVE, FiberState.FAILED}:
+                await self._unload(next_state=FiberState.PENDING)
+            await self._load(providers, target_epoch)
+
+    async def restart(self) -> None:
+        self._reject_direct_reentrant_wait("restart")
+        if self._restart_task is None or self._restart_task.done():
+            self._restart_task = asyncio.create_task(
+                self._restart(),
+                name=f"plugin-fiber-restart:{self.name}",
+            )
+        await _await_critical(self._restart_task)
+
+    async def _restart(self) -> None:
+        async with self._locked_transition():
+            if self._dispose_requested or self._is_root:
+                return
+            if self.state in {FiberState.ACTIVE, FiberState.FAILED}:
+                await self._unload(next_state=FiberState.PENDING)
+        await self.reconcile()
+
+    async def dispose(self) -> None:
+        """Permanently unload this Fiber and join all child/effect cleanup."""
+
+        self._reject_direct_reentrant_wait("dispose")
+        if self._dispose_task is None:
+            self._dispose_task = asyncio.create_task(
+                self._dispose(),
+                name=f"plugin-fiber-dispose:{self.name}",
+            )
+        await _await_critical(self._dispose_task)
+
+    async def _dispose(self) -> None:
+        async with self._locked_transition():
+            if self.state == FiberState.DISPOSED:
+                return
+            self._dispose_requested = True
+            unload_error: BaseException | None = None
+            try:
+                if self.state != FiberState.UNLOADING:
+                    await self._unload(next_state=FiberState.DISPOSED)
+            except BaseException as error:
+                unload_error = error
+            finally:
+                self.state = FiberState.DISPOSED
+                self.root._remove_fiber(self)
+                if self.parent is not None and self in self.parent.children:
+                    self.parent.children.remove(self)
+        await self.root._notify_disposed(self)
+        if unload_error is not None:
+            raise unload_error
+
+    async def _load(
+        self,
+        providers: dict[ServiceKey[object], _Provider],
+        epoch: tuple[tuple[str, int], ...],
+    ) -> None:
+        # 1. Freeze the dependency values for this activation.
+        self.state = FiberState.LOADING
+        self.dependency_store = providers
+        self.error = None
+        await self.root._notify_status(self)
+        await asyncio.sleep(0)
+        if (
+            self._dispose_requested
+            or self.root._provider_epoch_if_active(self.dependencies) != epoch
+        ):
+            await self._unload(next_state=FiberState.PENDING)
+            return
+
+        # 2. Apply the plugin and publish its services only after success.
+        try:
+            result = self.apply(self.context)
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            cleanup_task = asyncio.create_task(
+                self._unload(next_state=FiberState.PENDING),
+                name=f"plugin-fiber-cancel-cleanup:{self.name}",
+            )
+            await _await_critical(cleanup_task)
+            raise
+        except Exception as error:
+            self.error = error
+            self.root._record_error(self, error)
+            await self._unload(next_state=FiberState.FAILED)
+            return
+        if (
+            self._dispose_requested
+            or self.root._provider_epoch_if_active(self.dependencies) != epoch
+        ):
+            await self._unload(next_state=FiberState.PENDING)
+            return
+        self._epoch = epoch
+        self.state = FiberState.ACTIVE
+        await self.root._notify_status(self)
+        await self.root._owner_became_active(self)
+
+    async def _unload(self, *, next_state: FiberState) -> None:
+        # 1. Make owned services unavailable before dependents clean up.
+        self.state = FiberState.UNLOADING
+        await self.root._notify_status(self)
+        errors: list[BaseException] = []
+        try:
+            await self.root._owner_became_inactive(self)
+        except BaseException as error:
+            errors.append(error)
+
+        # 2. Children and effects are fully drained in reverse ownership order.
+        for child in reversed(tuple(self.children)):
+            try:
+                await child.dispose()
+            except BaseException as error:
+                errors.append(error)
+        for effect in reversed(tuple(self.effects)):
+            try:
+                await effect.aclose()
+            except BaseException as error:
+                errors.append(error)
+        self.dependency_store = {}
+        self._epoch = None
+        self.state = next_state
+        await self.root._notify_status(self)
+        if errors:
+            raise BaseExceptionGroup(f"Fiber 卸载失败: {self.name}", errors)
+
+    @asynccontextmanager
+    async def _locked_transition(self) -> AsyncGenerator[None]:
+        """Own one lifecycle transition and expose direct self-waits."""
+
+        async with self._transition:
+            owner = asyncio.current_task()
+            self._transition_owner = cast(asyncio.Task[object] | None, owner)
+            try:
+                yield
+            finally:
+                self._transition_owner = None
+
+    def _reject_direct_reentrant_wait(self, operation: str) -> None:
+        current = asyncio.current_task()
+        if current is not None and current is self._transition_owner:
+            raise CompositionError(
+                "REENTRANT_LIFECYCLE_WAIT",
+                f"{self.name} 不能在自身生命周期过渡中直接等待 {operation}；"
+                "请用 asyncio.create_task 调度",
+            )
+
+    def _remove_effect(self, effect: Effect) -> None:
+        if effect in self.effects:
+            self.effects.remove(effect)
+
+
+class CompositionRoot:
+    """Own one generation topology and derive its validation receipt."""
+
+    def __init__(
+        self,
+        generation_id: str,
+        *,
+        audit: CompositionAudit | None = None,
+    ) -> None:
+        if not generation_id:
+            raise ValueError("generation_id 不能为空")
+        self.generation_id = generation_id
+        self._next_fiber_id = 1
+        self._next_provider_revision = 1
+        self._fibers: dict[int, Fiber] = {}
+        self._providers: dict[ServiceKey[object], _Provider] = {}
+        self._mount_observers: list[FiberObserver] = []
+        self._status_observers: list[FiberObserver] = []
+        self._dispose_observers: list[FiberObserver] = []
+        self._errors: list[str] = []
+        self._audit = audit or CompositionAudit()
+        self._dispose_task: asyncio.Task[None] | None = None
+        self.root_fiber = Fiber(
+            root=self,
+            fiber_id=0,
+            name="root",
+            apply=lambda _: None,
+            dependencies=(),
+            parent=None,
+            required_for_readiness=True,
+            is_root=True,
+        )
+        self.context = self.root_fiber.context
+
+    def on_mount(self, observer: FiberObserver) -> Callable[[], None]:
+        return self._add_observer(self._mount_observers, observer)
+
+    def on_status(self, observer: FiberObserver) -> Callable[[], None]:
+        return self._add_observer(self._status_observers, observer)
+
+    def on_dispose(self, observer: FiberObserver) -> Callable[[], None]:
+        return self._add_observer(self._dispose_observers, observer)
+
+    async def mount(
+        self,
+        plugin: Plugin | PluginApply,
+        *,
+        name: str | None = None,
+        inject: Iterable[ServiceKey[object]] | None = None,
+    ) -> Fiber:
+        return await self.context.mount(plugin, name=name, inject=inject)
+
+    async def dispose(self) -> None:
+        if self._dispose_task is None:
+            self._dispose_task = asyncio.create_task(
+                self._dispose(),
+                name=f"plugin-composition-dispose:{self.generation_id}",
+            )
+        await _await_critical(self._dispose_task)
+
+    async def _dispose(self) -> None:
+        self.root_fiber.state = FiberState.UNLOADING
+        errors: list[BaseException] = []
+        for child in reversed(tuple(self.root_fiber.children)):
+            try:
+                await child.dispose()
+            except BaseException as error:
+                errors.append(error)
+        for effect in reversed(tuple(self.root_fiber.effects)):
+            try:
+                await effect.aclose()
+            except BaseException as error:
+                errors.append(error)
+        self.root_fiber.state = FiberState.DISPOSED
+        if errors:
+            raise BaseExceptionGroup("Root Context 清理失败", errors)
+
+    def receipt(self) -> CompositionReceipt:
+        fibers = tuple(self._fiber_view(fiber) for fiber in self._fibers.values())
+        external_effects = self._audit.external_effects
+        required_pending = tuple(
+            view.name
+            for view in fibers
+            if view.required_for_readiness and view.state != FiberState.ACTIVE
+        )
+        optional_pending = tuple(
+            view.name
+            for view in fibers
+            if not view.required_for_readiness and view.state != FiberState.ACTIVE
+        )
+        effects = tuple(
+            f"{fiber.name}:{effect.label}"
+            for fiber in (self.root_fiber, *self._fibers.values())
+            for effect in fiber.effects
+        )
+        return CompositionReceipt(
+            generation_id=self.generation_id,
+            ready=(
+                self.root_fiber.state == FiberState.ACTIVE
+                and not required_pending
+                and not self._errors
+                and not external_effects
+            ),
+            fibers=fibers,
+            services=tuple(sorted(key.name for key in self._providers)),
+            effects=effects,
+            required_pending=required_pending,
+            optional_pending=optional_pending,
+            errors=tuple(self._errors),
+            writes=self._audit.writes,
+            external_effects=external_effects,
+        )
+
+    def topology_identity(self) -> str:
+        """Return the logical topology identity, excluding transient Fiber ids."""
+
+        receipt = self.receipt()
+        fibers = ",".join(
+            sorted(
+                f"{fiber.name}:{fiber.state.value}:"
+                f"{'required' if fiber.required_for_readiness else 'optional'}"
+                for fiber in receipt.fibers
+            )
+        )
+        return (
+            f"{receipt.generation_id}:{','.join(receipt.services)}:{fibers}:"
+            f"{','.join(sorted(receipt.effects))}"
+        )
+
+    def validation_identity(self) -> str:
+        """Bind the Core-observed topology and audit receipt at validation close."""
+
+        receipt = self.receipt()
+        writes = ",".join(
+            f"{item.plugin_id}:{item.operation}:{item.relative_path}:{item.sha256}"
+            for item in receipt.writes
+        )
+        external = ",".join(
+            f"{item.kind}:{item.target}:{item.outcome}"
+            for item in receipt.external_effects
+        )
+        return "|".join(
+            (
+                self.topology_identity(),
+                f"required:{','.join(receipt.required_pending)}",
+                f"optional:{','.join(receipt.optional_pending)}",
+                f"errors:{','.join(receipt.errors)}",
+                f"writes:{writes}",
+                f"external:{external}",
+            )
+        )
+
+    async def _mount(
+        self,
+        *,
+        parent: Fiber,
+        plugin: Plugin | PluginApply,
+        name: str | None,
+        inject: Iterable[ServiceKey[object]] | None,
+        required_for_readiness: bool,
+    ) -> Fiber:
+        """Publish only after parent ownership exists, then reconcile."""
+
+        # 1. Resolve the narrow apply(ctx) contract.
+        apply, resolved_name, dependencies = self._resolve_plugin(
+            plugin,
+            name=name,
+            inject=inject,
+        )
+        if parent.state in {FiberState.UNLOADING, FiberState.DISPOSED}:
+            raise CompositionError(
+                "INACTIVE_PLUGIN_OWNER",
+                f"{parent.name} 不能挂载子插件",
+            )
+        if any(fiber.name == resolved_name for fiber in self._fibers.values()):
+            raise CompositionError(
+                "DUPLICATE_PLUGIN",
+                f"同一拓扑不能重复挂载插件: {resolved_name}",
+            )
+
+        # 2. Parent ownership is visible before publication observers run.
+        fiber = Fiber(
+            root=self,
+            fiber_id=self._next_fiber_id,
+            name=resolved_name,
+            apply=apply,
+            dependencies=dependencies,
+            parent=parent,
+            required_for_readiness=required_for_readiness,
+        )
+        self._next_fiber_id += 1
+        parent.children.append(fiber)
+        self._fibers[fiber.fiber_id] = fiber
+        try:
+            await self._notify_mount(fiber)
+        except BaseException:
+            await fiber.dispose()
+            raise
+        if parent.state in {FiberState.UNLOADING, FiberState.DISPOSED}:
+            await fiber.dispose()
+            return fiber
+        try:
+            await fiber.reconcile()
+        except BaseException:
+            await fiber.dispose()
+            raise
+        return fiber
+
+    def _resolve_plugin(
+        self,
+        plugin: Plugin | PluginApply,
+        *,
+        name: str | None,
+        inject: Iterable[ServiceKey[object]] | None,
+    ) -> tuple[PluginApply, str, tuple[ServiceKey[object], ...]]:
+        if callable(plugin) and not hasattr(plugin, "apply"):
+            apply = cast(PluginApply, plugin)
+        else:
+            candidate = getattr(plugin, "apply", None)
+            if not callable(candidate):
+                raise TypeError("插件必须是 callable 或提供 apply(ctx)")
+            apply = cast(PluginApply, candidate)
+        resolved_name = name or str(getattr(plugin, "name", "")).strip()
+        resolved_name = resolved_name or getattr(apply, "__name__", "plugin")
+        raw_dependencies = inject
+        if raw_dependencies is None:
+            raw_dependencies = getattr(plugin, "inject", ())
+        dependencies = tuple(cast(Iterable[ServiceKey[object]], raw_dependencies))
+        if len(set(dependencies)) != len(dependencies):
+            raise ValueError(f"插件依赖重复: {resolved_name}")
+        return apply, resolved_name, dependencies
+
+    def _register_provider(
+        self,
+        key: ServiceKey[object],
+        value: object,
+        owner: Fiber,
+    ) -> None:
+        existing = self._providers.get(key)
+        if existing is not None:
+            raise CompositionError(
+                "DUPLICATE_SERVICE",
+                f"Service {key.name} 已由 {existing.owner.name} 提供",
+            )
+        self._providers[key] = _Provider(
+            key=key,
+            value=value,
+            owner=owner,
+            revision=self._next_provider_revision,
+        )
+        self._next_provider_revision += 1
+
+    async def _remove_provider(
+        self,
+        key: ServiceKey[object],
+        owner: Fiber,
+    ) -> None:
+        provider = self._providers.get(key)
+        if provider is None:
+            return
+        if provider.owner is not owner:
+            raise CompositionError(
+                "SERVICE_OWNER_MISMATCH",
+                f"{owner.name} 不能移除 {provider.owner.name} 的 Service {key.name}",
+            )
+        del self._providers[key]
+        await self._reconcile_dependents((key,), exclude=owner)
+
+    def _active_provider(self, key: ServiceKey[object]) -> _Provider | None:
+        provider = self._providers.get(key)
+        if provider is None or provider.owner.state != FiberState.ACTIVE:
+            return None
+        return provider
+
+    def _dependency_snapshot(
+        self,
+        dependencies: tuple[ServiceKey[object], ...],
+    ) -> dict[ServiceKey[object], _Provider] | None:
+        providers: dict[ServiceKey[object], _Provider] = {}
+        for key in dependencies:
+            provider = self._active_provider(key)
+            if provider is None:
+                return None
+            providers[key] = provider
+        return providers
+
+    @staticmethod
+    def _provider_epoch(
+        providers: Mapping[ServiceKey[object], _Provider] | None,
+    ) -> tuple[tuple[str, int], ...] | None:
+        if providers is None:
+            return None
+        return tuple(
+            sorted((key.name, provider.revision) for key, provider in providers.items())
+        )
+
+    def _provider_epoch_if_active(
+        self,
+        dependencies: tuple[ServiceKey[object], ...],
+    ) -> tuple[tuple[str, int], ...] | None:
+        return self._provider_epoch(self._dependency_snapshot(dependencies))
+
+    async def _owner_became_active(self, owner: Fiber) -> None:
+        keys = tuple(
+            key for key, provider in self._providers.items() if provider.owner is owner
+        )
+        await self._reconcile_dependents(keys, exclude=owner)
+
+    async def _owner_became_inactive(self, owner: Fiber) -> None:
+        keys = tuple(
+            key for key, provider in self._providers.items() if provider.owner is owner
+        )
+        await self._reconcile_dependents(keys, exclude=owner)
+
+    async def _reconcile_dependents(
+        self,
+        keys: tuple[ServiceKey[object], ...],
+        *,
+        exclude: Fiber,
+    ) -> None:
+        if not keys:
+            return
+        affected = [
+            fiber
+            for fiber in tuple(self._fibers.values())
+            if fiber is not exclude
+            and fiber.state != FiberState.DISPOSED
+            and any(key in fiber.dependencies for key in keys)
+        ]
+        if affected:
+            results = await asyncio.gather(
+                *(fiber.reconcile() for fiber in affected),
+                return_exceptions=True,
+            )
+            errors = [result for result in results if isinstance(result, BaseException)]
+            if errors:
+                raise BaseExceptionGroup("依赖 Fiber 协调失败", errors)
+
+    async def _notify_mount(self, fiber: Fiber) -> None:
+        for observer in tuple(self._mount_observers):
+            result = observer(fiber)
+            if inspect.isawaitable(result):
+                await result
+
+    async def _notify_status(self, fiber: Fiber) -> None:
+        await self._notify_contained(self._status_observers, fiber)
+
+    async def _notify_disposed(self, fiber: Fiber) -> None:
+        await self._notify_contained(self._dispose_observers, fiber)
+
+    async def _notify_contained(
+        self,
+        observers: list[FiberObserver],
+        fiber: Fiber,
+    ) -> None:
+        for observer in tuple(observers):
+            try:
+                result = observer(fiber)
+                if inspect.isawaitable(result):
+                    await result
+            except asyncio.CancelledError as error:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                self._record_error(fiber, error)
+            except Exception as error:
+                self._record_error(fiber, error)
+
+    def _record_error(self, fiber: Fiber, error: BaseException) -> None:
+        self._errors.append(f"{fiber.name}:{type(error).__name__}:{error}")
+
+    def _remove_fiber(self, fiber: Fiber) -> None:
+        _ = self._fibers.pop(fiber.fiber_id, None)
+
+    def _fiber_view(self, fiber: Fiber) -> FiberView:
+        return FiberView(
+            fiber_id=fiber.fiber_id,
+            name=fiber.name,
+            state=fiber.state,
+            required_for_readiness=fiber.required_for_readiness,
+            missing_services=fiber.missing_services,
+            error=(
+                None
+                if fiber.error is None
+                else f"{type(fiber.error).__name__}: {fiber.error}"
+            ),
+        )
+
+    @staticmethod
+    def _add_observer(
+        observers: list[FiberObserver],
+        observer: FiberObserver,
+    ) -> Callable[[], None]:
+        observers.append(observer)
+
+        def remove() -> None:
+            if observer in observers:
+                observers.remove(observer)
+
+        return remove
+
+
+async def _await_critical(task: asyncio.Task[None]) -> None:
+    """Finish lifecycle cleanup before propagating caller cancellation."""
+
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise

--- a/agent/plugin_composition/effect.py
+++ b/agent/plugin_composition/effect.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
+from typing import cast
+
+from agent.plugin_composition.model import CompositionError
+
+Cleanup = Callable[[], object]
+EffectSetup = Callable[[], object]
+
+
+class Effect:
+    """Own setup output and make concurrent disposal join one cleanup."""
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        remove_from_owner: Callable[[Effect], None],
+    ) -> None:
+        self.label = label
+        self._remove_from_owner = remove_from_owner
+        self._cleanups: list[Cleanup] = []
+        self._ready = asyncio.Event()
+        self._setup_task: asyncio.Task[object] | None = None
+        self._close_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    async def start(self, setup: EffectSetup) -> Effect:
+        """Run setup after ownership is visible and roll it back on failure."""
+
+        # 1. Capture setup ownership before user code can re-enter disposal.
+        self._setup_task = asyncio.current_task()
+        try:
+            result = setup()
+            await self._collect_result(result)
+        except BaseException as setup_error:
+            cleanup_errors = await self._run_cleanups()
+            self._closed = True
+            self._remove_from_owner(self)
+            if cleanup_errors:
+                raise BaseExceptionGroup(
+                    "effect setup 与 rollback 同时失败",
+                    [setup_error, *cleanup_errors],
+                )
+            raise
+        finally:
+            self._ready.set()
+
+        # 2. A reentrant disposer may already be waiting for setup to settle.
+        if self._close_task is not None:
+            try:
+                await asyncio.shield(self._close_task)
+            except asyncio.CancelledError:
+                await self._close_task
+                raise
+        return self
+
+    async def aclose(self) -> None:
+        """Dispose once; concurrent callers await the same cleanup task."""
+
+        if self._closed:
+            return
+        current = asyncio.current_task()
+        if current is self._setup_task and not self._ready.is_set():
+            raise CompositionError(
+                "REENTRANT_EFFECT_WAIT",
+                "effect setup 不能同步等待其 owner 完成卸载",
+            )
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(
+                self._close(),
+                name=f"plugin-effect-close:{self.label}",
+            )
+        try:
+            await asyncio.shield(self._close_task)
+        except asyncio.CancelledError:
+            await self._close_task
+            raise
+
+    async def _close(self) -> None:
+        # 1. Setup may still be producing cleanup functions.
+        _ = await self._ready.wait()
+        if self._closed:
+            return
+
+        # 2. All collected cleanup is attempted in reverse order.
+        errors = await self._run_cleanups()
+        self._closed = True
+        self._remove_from_owner(self)
+        if errors:
+            raise BaseExceptionGroup(f"effect cleanup 失败: {self.label}", errors)
+
+    async def _collect_result(self, result: object) -> None:
+        if inspect.isawaitable(result):
+            await self._collect_result(await result)
+            return
+        if result is None:
+            return
+        if callable(result):
+            self._cleanups.append(result)
+            return
+        if isinstance(result, AsyncIterable):
+            async for item in cast(AsyncIterable[object], result):
+                await self._collect_result(item)
+            return
+        if isinstance(result, Iterable) and not isinstance(
+            result,
+            (str, bytes, bytearray, dict),
+        ):
+            for item in cast(Iterable[object], result):
+                await self._collect_result(item)
+            return
+        result_type = type(cast(object, result)).__name__
+        raise TypeError(f"effect setup 返回了不支持的类型: {result_type}")
+
+    async def _run_cleanups(self) -> list[BaseException]:
+        errors: list[BaseException] = []
+        while self._cleanups:
+            cleanup = self._cleanups.pop()
+            try:
+                result = cleanup()
+                if isinstance(result, Awaitable):
+                    await result
+            except BaseException as error:
+                errors.append(error)
+        return errors

--- a/agent/plugin_composition/model.py
+++ b/agent/plugin_composition/model.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+
+class CompositionError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class FiberState(str, Enum):
+    PENDING = "pending"
+    LOADING = "loading"
+    ACTIVE = "active"
+    FAILED = "failed"
+    UNLOADING = "unloading"
+    DISPOSED = "disposed"
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceKey(Generic[T]):
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.name or self.name.strip() != self.name:
+            raise ValueError("ServiceKey.name 必须是非空且无首尾空白的字符串")
+
+
+@dataclass(frozen=True, slots=True)
+class FiberView:
+    fiber_id: int
+    name: str
+    state: FiberState
+    required_for_readiness: bool
+    missing_services: tuple[str, ...]
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class WriteObservation:
+    plugin_id: str
+    operation: str
+    relative_path: str
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalEffectObservation:
+    kind: str
+    target: str
+    outcome: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionReceipt:
+    generation_id: str
+    ready: bool
+    fibers: tuple[FiberView, ...]
+    services: tuple[str, ...]
+    effects: tuple[str, ...]
+    required_pending: tuple[str, ...]
+    optional_pending: tuple[str, ...]
+    errors: tuple[str, ...]
+    writes: tuple[WriteObservation, ...]
+    external_effects: tuple[ExternalEffectObservation, ...]

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1248,6 +1248,15 @@ class PluginManager:
             _ = self._draining_generations.pop(generation.plugin_id, None)
 
     async def _on_snapshot_drained(self, snapshot: RuntimeSnapshot) -> None:
+        composition_root = snapshot.composition_root
+        if (
+            composition_root is not None
+            and not self._snapshot_store.composition_is_referenced_elsewhere(
+                composition_root,
+                excluding_snapshot_id=snapshot.snapshot_id,
+            )
+        ):
+            await composition_root.dispose()
         catalog_id = self._snapshot_skill_catalogs.pop(snapshot.snapshot_id, None)
         if catalog_id is not None:
             self._skill_host.close(catalog_id)
@@ -1740,6 +1749,8 @@ class PluginManager:
                     if self._ready_candidate is ready:
                         await self._drop_ready(plugin_id)
                     raise
+
+            self._snapshot_store.seal_candidate_validation(ready.snapshot)
 
             # 2. 先切可回滚的 Skill 投影，再提交持久 pointer；整个回调不跨 await。
             skill_links_switched = False

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -16,6 +16,7 @@ from agent.plugins.specs import RegisteredProactiveSource, proactive_source_key
 from agent.tools.registry import ToolRegistry
 from agent.tool_hooks import ToolHook
 from agent.skills import SkillIndex
+from agent.plugin_composition import CompositionRoot
 from bus.event_bus import Handler
 from infra.channels.contract import Channel
 
@@ -59,6 +60,9 @@ class RuntimeSnapshot:
     event_handlers: Mapping[type[object], tuple[Handler[object], ...]] = field(
         default_factory=lambda: MappingProxyType({})
     )
+    composition_root: CompositionRoot | None = None
+    composition_topology_identity: str | None = None
+    composition_validation_identity: str | None = None
     state: SnapshotState = "compiled"
     lease_count: int = 0
     accepting_leases: bool = True
@@ -118,6 +122,7 @@ class RuntimeSnapshotCompiler:
         catalog_generation: PluginGeneration | None = None,
         snapshot_revision: str = "",
         workspace_mcp_generation: WorkspaceMcpGeneration | None = None,
+        composition_root: CompositionRoot | None = None,
     ) -> RuntimeSnapshot:
         ordered = [generations[key] for key in sorted(generations)]
         if any(generation.plugin_id != key for key, generation in generations.items()):
@@ -197,6 +202,18 @@ class RuntimeSnapshotCompiler:
             else ""
         )
         identity += f"|snapshot:{snapshot_revision}"
+        composition_identity: str | None = None
+        if composition_root is not None:
+            receipt = composition_root.receipt()
+            if not receipt.ready:
+                raise RuntimeError(
+                    "RuntimeSnapshot 插件组合拓扑未就绪: "
+                    f"required_pending={receipt.required_pending}, "
+                    f"errors={receipt.errors}, "
+                    f"external_effects={receipt.external_effects}"
+                )
+            composition_identity = composition_root.topology_identity()
+            identity += f"|composition:{composition_identity}"
         snapshot_id = hashlib.sha256(identity.encode()).hexdigest()[:16]
         return RuntimeSnapshot(
             snapshot_id=snapshot_id,
@@ -229,6 +246,8 @@ class RuntimeSnapshotCompiler:
             after_step_modules=phases["after_step_modules"],
             after_reasoning_modules=phases["after_reasoning_modules"],
             after_turn_modules=phases["after_turn_modules"],
+            composition_root=composition_root,
+            composition_topology_identity=composition_identity,
         )
 
     @staticmethod
@@ -446,9 +465,26 @@ class RuntimeSnapshotStore:
             for snapshot in self._snapshots.values()
         )
 
+    def composition_is_referenced_elsewhere(
+        self,
+        root: CompositionRoot,
+        *,
+        excluding_snapshot_id: str,
+    ) -> bool:
+        return any(
+            snapshot.snapshot_id != excluding_snapshot_id
+            and (
+                snapshot.state in {"validating", "committed"}
+                or snapshot.lease_count > 0
+            )
+            and snapshot.composition_root is root
+            for snapshot in self._snapshots.values()
+        )
+
     def install(self, snapshot: RuntimeSnapshot) -> None:
         if self._current is not None or self._pending is not None:
             raise RuntimeError("RuntimeSnapshotStore 已安装初始快照")
+        self._validate_composition(snapshot)
         self._adopt(snapshot)
         snapshot.state = "committed"
         self._current = snapshot
@@ -467,6 +503,7 @@ class RuntimeSnapshotStore:
             raise RuntimeError("已有 RuntimeSnapshot 候选等待 promote/discard")
         if candidate.snapshot_id in self._snapshots:
             raise RuntimeError(f"RuntimeSnapshot 已存在: {candidate.snapshot_id}")
+        self._validate_composition(candidate)
         self._adopt(candidate)
         transaction = SnapshotTransaction(previous=self._current, candidate=candidate)
         candidate.state = "validating"
@@ -483,6 +520,7 @@ class RuntimeSnapshotStore:
         after_open: Callable[[], None] | None = None,
     ) -> None:
         self._require_pending(transaction)
+        self._validate_composition(transaction.candidate)
         if before_open is not None:
             before_open()
         transaction.candidate.state = "committed"
@@ -509,6 +547,7 @@ class RuntimeSnapshotStore:
 
         # 1. Open only the explicitly selected candidate.
         self._require_pending(transaction)
+        self._validate_composition(transaction.candidate)
         if before_open is not None:
             before_open()
         transaction.candidate.state = "committed"
@@ -534,6 +573,7 @@ class RuntimeSnapshotStore:
             raise RuntimeError("没有等待 promote 的 RuntimeSnapshot 候选")
         if candidate.accepting_leases:
             raise RuntimeError("promote 前必须先暂停 candidate lease admission")
+        self._validate_composition(candidate, require_validation=True)
         if before_open is not None:
             before_open()
         previous = self._current
@@ -635,6 +675,20 @@ class RuntimeSnapshotStore:
             raise RuntimeError("等待 promote 的 RuntimeSnapshot 候选不一致")
         candidate.accepting_leases = False
         return candidate
+
+    def seal_candidate_validation(self, expected: RuntimeSnapshot) -> None:
+        """Seal the Core-observed receipt after validation leases have drained."""
+
+        candidate = self.unpromoted_candidate
+        if candidate is None or candidate is not expected:
+            raise RuntimeError("等待封存验证回执的 RuntimeSnapshot 候选不一致")
+        if candidate.accepting_leases or candidate.lease_count:
+            raise RuntimeError("封存验证回执前必须暂停并排空 candidate lease")
+        self._validate_composition(candidate)
+        root = candidate.composition_root
+        candidate.composition_validation_identity = (
+            None if root is None else root.validation_identity()
+        )
 
     async def wait_for_no_leases(self, snapshot: RuntimeSnapshot) -> None:
         async with self._condition:
@@ -841,6 +895,35 @@ class RuntimeSnapshotStore:
 
     def _adopt(self, snapshot: RuntimeSnapshot) -> None:
         snapshot.claim(self._token)
+
+    @staticmethod
+    def _validate_composition(
+        snapshot: RuntimeSnapshot,
+        *,
+        require_validation: bool = False,
+    ) -> None:
+        root = snapshot.composition_root
+        if root is None:
+            if snapshot.composition_topology_identity is not None:
+                raise RuntimeError(
+                    "RuntimeSnapshot composition identity 缺少 Root Context"
+                )
+            return
+        receipt = root.receipt()
+        if not receipt.ready:
+            raise RuntimeError(
+                "RuntimeSnapshot 插件组合拓扑未就绪: "
+                f"required_pending={receipt.required_pending}, "
+                f"errors={receipt.errors}, "
+                f"external_effects={receipt.external_effects}"
+            )
+        if root.topology_identity() != snapshot.composition_topology_identity:
+            raise RuntimeError("RuntimeSnapshot 插件组合拓扑在编译后发生变化")
+        if require_validation:
+            if snapshot.composition_validation_identity is None:
+                raise RuntimeError("RuntimeSnapshot 插件组合候选缺少 Core 验证回执")
+            if root.validation_identity() != snapshot.composition_validation_identity:
+                raise RuntimeError("RuntimeSnapshot 插件组合验证回执在封存后发生变化")
 
     def _selected(self, selector: RuntimeSelector) -> RuntimeSnapshot | None:
         if selector == "stable":

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -106,7 +106,7 @@
 | 正式启动、Supervisor、自重启、停止信号 | `projectneed` RUN-001～RUN-004 → [Linux Supervisor 安全自重启提议](design/linux-supervisor-safe-self-restart.md) → [`docker/debug/README.md`](../docker/debug/README.md) | `main.py`、`agent/supervisor.py`、`agent/restart.py`、`agent/tools/agent_restart.py`、`scripts/stop-runtime.sh`、restart Gate 报告 |
 | 容器、云主机运行适配、Host Bridge、hua-home迁移 | `projectneed` RUN-013～RUN-015、WSP-005、SH-001～SH-003 → [0032](decisions/0032-host-bridge-preserves-host-equivalent-execution.md) → [容器与 Linux 主机运行适配设计](design/akashic-container-cloud-runtime-adaptation.md) → [Core 与 Host Bridge 安装设计](design/akashic-core-bridge-installer.md) → [非迁移实验合同](design/akashic-container-host-bridge-experiment-contract.md) → [Unified Shell Execution 设计](design/unified-shell-execution.md) → [持久化状态地图](design/persistence-state-map.md) | exact-commit 安装、执行后端、runtime identity、插件安装链、Supervisor 与隔离实验；正式迁移前先运行 plan-only 清单并取得独立批准 |
 | Provider、模型角色、运行时切换、usage、首次配置 | `projectneed` RUN-005～RUN-012、ONB-001、CTX-001 → [0027](decisions/0027-runtime-models-use-generation-leases.md) → [0028](decisions/0028-model-credentials-live-with-workspace-connections.md) → [运行时模型注册表与 Onboarding](design/runtime-model-registry-and-onboarding.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/model_runtime/`、`bootstrap/providers.py`、`bootstrap/settings_api.py`、`bootstrap/app.py`、`main.py`、`agent/supervisor.py`、`frontend/chat/src`、Observe 隔离 Gate |
-| 插件安装、热重载、自验证、Cordis 迁移、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、9～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [0024](decisions/0024-plugin-self-validation-uses-stable-and-latest.md) → [0026](decisions/0026-plugin-rollout-is-owned-by-the-parent-turn.md) → [插件 install/uninstall/revert turn 边界发布合同](design/plugin-install-uninstall-turn-boundary-rollout.md) → [插件递归自验证运行时设计](design/recursive-plugin-self-validation.md) → [Cordis 插件迁移能力等价验收](design/cordis-plugin-capability-parity.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/snapshot.py`、`agent/plugins/reload_journal.py`、`agent/plugins/turn_rollout.py`、`agent/plugins/skill_links.py`、`agent/control/runtime.py`、`agent/looping/core.py`、`agent/mcp/host.py` |
+| 插件安装、热重载、自验证、Cordis 迁移、plugin-data、Skill、Drift skill、MCP | `projectneed` 第 6、9～13 节 → [0008](decisions/0008-plugin-runtime-publishes-only-committed-snapshots.md) → [0024](decisions/0024-plugin-self-validation-uses-stable-and-latest.md) → [0026](decisions/0026-plugin-rollout-is-owned-by-the-parent-turn.md) → [0036](decisions/0036-plugin-composition-keeps-promotion-owner.md) → [插件 install/uninstall/revert turn 边界发布合同](design/plugin-install-uninstall-turn-boundary-rollout.md) → [插件递归自验证运行时设计](design/recursive-plugin-self-validation.md) → [Cordis 插件迁移能力等价验收](design/cordis-plugin-capability-parity.md) → [插件组合内核第一阶段任务合同](design/plugin-composition-kernel-task-contract.md) → [持久化状态地图](design/persistence-state-map.md) | `agent/plugins/base.py`、`agent/plugins/install.py`、`agent/plugins/manager.py`、`agent/plugins/snapshot.py`、`agent/plugins/reload_journal.py`、`agent/plugins/turn_rollout.py`、`agent/plugins/skill_links.py`、`agent/control/runtime.py`、`agent/looping/core.py`、`agent/mcp/host.py` |
 | 移动端查看 Markdown、定时任务、插件、Skill、MCP | `projectneed` 第 6、10～13 节 → [移动端运行时检查](design/mobile-runtime-inspection.md) → [持久化状态地图](design/persistence-state-map.md) | `infra/mobile_realtime/runtime_inspection.py`、`infra/mobile_realtime/protocol.py`、`infra/mobile_realtime/channel.py` |
 | Workspace、配置、凭据、迁移、备份 | `projectneed` 第 6、11～13 节 → [持久化状态地图](design/persistence-state-map.md) → [0021](decisions/0021-yoyo-workspace-ledger-defines-migration-origin.md) → [Yoyo 迁移维护手册](design/git-migration-authoring.md) | `main.py`、`bootstrap/init_workspace.py`、`agent/config.py`、`agent/migrations/`、`migrations/yoyo/`、`agent/model_runtime/auth/store.py`、`scripts/rolling_backup.py` |
 | 高风险 refactor、语义不变重构、CI oracle | `projectneed` 第 4～6、13、15 节 → [综合重构账本](refactor/clean-code-ledger.md) → [上下文事故设计](design/project-workbook-and-semantic-safety.md) → 相关决策 | 改动前后的完整 diff、semantic tests、write set、故障注入 |
@@ -218,7 +218,8 @@ docs/
 │   ├── 0032-host-bridge-preserves-host-equivalent-execution.md
 │   ├── 0033-local-agent-instructions-are-not-project-documents.md
 │   ├── 0034-turn-is-the-logical-work-unit.md
-│   └── 0035-mobile-protocol-delivery-is-phased.md
+│   ├── 0035-mobile-protocol-delivery-is-phased.md
+│   └── 0036-plugin-composition-keeps-promotion-owner.md
 ├── design/
 │   ├── akasha-v2-runtime-migration.md
 │   ├── akashic-future-roadmap-issue-drafts.md
@@ -231,6 +232,7 @@ docs/
 │   ├── codex-style-same-turn-input-requirements.md
 │   ├── codex-style-same-turn-input.md
 │   ├── cordis-plugin-capability-parity.md
+│   ├── plugin-composition-kernel-task-contract.md
 │   ├── project-workbook-and-semantic-safety.md
 │   ├── query-local-react-compaction.md
 │   ├── runtime-model-registry-and-onboarding.md

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -13,6 +13,10 @@
 - 在独立 Fitbit canonical source 变更中让 monitor 与 MCP 读取同一个 `validation_port_env`，再以一次性 workspace 验收真实隔离 listener、child tool trace、正式切换和旧 listener 恢复；不得在 Core 中添加 Fitbit 特判。
 - 补充 turn-boundary rollout 的进程崩溃注入矩阵，覆盖 terminal 封口后、候选服务停止后、正式 endpoint 切换后和 pointer 提交前；恢复失败必须保持 degraded 可见，不能只恢复 pointer。
 
+## P0 · 插件组合内核
+
+- 第一阶段已按[0036](decisions/0036-plugin-composition-keeps-promotion-owner.md)和[任务合同](design/plugin-composition-kernel-task-contract.md)完成。下一步按差分回放选择 Citation/Meme 或 GitHub Watch 迁移试点；不得在证据出现前改写现有插件或删除 legacy host。
+
 ## P0 · 独立语义验收
 
 - 将 CTX-001 当前的 trace、完整状态快照和 fixture `DELETE` pilot 升级为 SQLite authorizer 与一次性候选真实 retry seam mutant；导入失败、fixture 失败或超时不得计为 mutant kill。

--- a/docs/decisions/0036-plugin-composition-keeps-promotion-owner.md
+++ b/docs/decisions/0036-plugin-composition-keeps-promotion-owner.md
@@ -1,0 +1,59 @@
+# 0036 · 插件组合内核保留现有晋升 owner
+
+- 状态：accepted / implemented phase 1
+- 日期：2026-08-14
+- 关联条款：PLG-001～PLG-013、WSP-001～WSP-005、ERR-001、TST-001～TST-007
+- supersedes：无
+- superseded by：无
+
+## 背景
+
+当前 `PluginManager` 同时理解插件加载、固定 lifecycle、七组 ReAct phase、Job、Channel、MCP、UI、Skill 和主动流程。它把各领域的贡献枚举成一个封闭总表，插件新增能力必须先修改 Core。DeepSeek Harness 使用的 Cordis 则把插件组合收敛为 Context、Service、Inject、Fiber、Effect 和 Scope，领域能力由普通 Service 自己定义。
+
+Akashic 已经拥有 Cordis 不提供的候选隔离、stable/latest、父 Turn 授权、generation lease、自验证和回滚日志。替换组合机制不应丢弃这些发布语义，也不应把 TypeScript Loader、HMR 或 Schemastery 再复制成第二个 owner。
+
+## 决定
+
+Akashic 新插件采用 Python 实现的最小组合内核：Root Context 持有一代完整拓扑，Service 表达能力，Inject 表达必需或可选依赖，Fiber 管理依赖波动下的状态，Effect 在所属 Root/Fiber scope 内逆序回收资源。插件公开入口是 `apply(ctx)`；Job、Channel、Prompt、输出处理、UI、MCP、存储和外部效果都是领域 Service，不进入组合内核的固定枚举。第一阶段不另造一个只转发 Fiber 所有权的 `Scope` 类；Cordis 的独立 service isolation scope 留到真实迁移插件提出需求时再实现。
+
+现有 publication plane 保持唯一 owner：安装 artifact、候选隔离、generation identity、行为验证回执、stable/latest、父 Turn 终点授权、snapshot lease、晋升、丢弃和恢复日志继续由 Core 管理。候选发布单位是完整 Root Context 拓扑，不是单个回调或单个 Service。
+
+现有插件在迁移完成前继续由一个 legacy host 承载。新内核不得为每个旧插件增加适配器，也不得改变旧 lifecycle、phase/slot 顺序、错误传播、plugin-data 或外部效果。每个领域迁移完成后删除对应旧分支，最终删除 legacy host。
+
+第一阶段只实现组合内核、候选回执和无外部效果的实验插件，并在带 run identity 的隔离 workspace 验证。它不接管正式 manifest、正式 plugin-data、真实渠道或远程 API。
+
+```text
+┌──────────────── publication plane / Core ────────────────┐
+│ artifact → candidate topology → behavior receipt → stable │
+│ generation identity / lease / journal / rollback          │
+└──────────────────────────┬─────────────────────────────────┘
+                           │ 发布一个完整 Root Context
+                           ▼
+┌──────────────── composition plane ────────────────────────┐
+│ Context ─ Service ─ Inject ─ Fiber ─ Effect                │
+└──────────────────────────┬─────────────────────────────────┘
+                           │ 普通领域 Service
+                           ▼
+ Prompt / Output / Tool / Job / Channel / UI / MCP / Storage
+```
+
+## 理由
+
+这保留了 Akashic 能验证自身修改的优势，同时消除 Core 对插件领域形状的先验知识。选择性转译 Cordis 的组合语义，比完整移植 Loader、Include、HMR、Schemastery 和 CosmoKit 更少产生重复 owner；Python 边界继续使用项目现有类型与 Pydantic，不宣称与 TypeScript 配置系统完全等价。
+
+## 影响
+
+- 正面影响：新领域能力不再要求扩展 `PluginManager` 固定字段；依赖出现和消失可以局部激活或回收 Fiber；资源由注册它的插件拥有清理。
+- 兼容性：旧插件默认行为不变；新插件只走显式的新入口。迁移必须逐插件证明行为等价。
+- 数据和迁移：第一阶段只写隔离 workspace 的实验回执；Core 只分配 plugin-data 根和权限，插件拥有其 schema、迁移、保留与删除协议。
+- 失败与回滚：组合失败拒绝候选，stable 不变；恢复点是实施前 Git bundle 和旧 stable generation。Effect 清理不能冒充文件、数据库或外部调用已回滚。
+
+## 验收
+
+- [x] Cordis 生命周期关键行为在 Python 内核测试中通过，包括依赖波动、重入卸载、epoch 防陈旧激活和逆序清理。
+- [x] 实验插件在隔离 workspace 中完成候选装载、自验证、晋升、依赖撤除和资源归零，且正式 workspace 与插件清单零写入。
+- [x] 旧插件回归保持通过，现有 publication plane 的 stable/latest 与 parent-Turn owner 不变。
+
+## 未决问题
+
+- Citation/Meme、GitHub Watch 和其他现有插件的迁移顺序由各自差分回放结果决定，不在第一阶段预先承诺。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -41,6 +41,7 @@
 | [0033](0033-local-agent-instructions-are-not-project-documents.md) | accepted | 本地 Agent 指令不属于版本化项目文档 | WBK-001～WBK-006、COM-001～COM-004 |
 | [0034](0034-turn-is-the-logical-work-unit.md) | accepted | Turn 是逻辑工作单元 | CTX-003、SES-007、SES-008、MEM-011、OUT-001、OUT-004、SCH-003 |
 | [0035](0035-mobile-protocol-delivery-is-phased.md) | accepted | 移动协议交付按变更性质分阶段 | MOB-008、MOB-006、TST-007、GOV-002 |
+| [0036](0036-plugin-composition-keeps-promotion-owner.md) | accepted | 插件组合内核保留现有晋升 owner | PLG-001～PLG-013、WSP-001～WSP-005、ERR-001、TST-001～TST-007 |
 
 ## 新增规则
 

--- a/docs/design/cordis-plugin-capability-parity.md
+++ b/docs/design/cordis-plugin-capability-parity.md
@@ -1,6 +1,6 @@
 # Cordis 插件迁移能力等价验收设计
 
-- 状态：proposed / local review
+- 状态：accepted / phase 1 implemented
 - 核对日期：2026-08-14
 - 文档基线：`akashic-agent@d1b1295b8490ffe899f27476bf97ae7b261ef76e`
 - 当前运行基线：`akashic-agent@07068e2bfb2dac0173298ed0c60a7f5c466ad745`
@@ -15,13 +15,21 @@ Akashic 可以采用 Cordis 的 service、typed event、effect、fiber 和配置
 
 本设计保留现有插件发布语义：候选隔离、父 Turn 授权、stable/latest 内部双快照、generation lease、领域 oracle、自动提交或丢弃。Cordis 负责挂载、依赖等待和可逆注册，不取得插件代码晋升、持久数据恢复或外部效果回滚的所有权。
 
-本设计只定义迁移前的能力基线与验收方法，不批准以下动作：
+本设计同时作为迁移前的能力基线与验收方法。维护者已批准第一阶段组合内核和实验插件，边界见[0036](../decisions/0036-plugin-composition-keeps-promotion-owner.md)与[任务合同](plugin-composition-kernel-task-contract.md)。第一阶段不批准以下动作：
 
 - 不修改当前正式 runtime、workspace、plugin-data 或插件 manifest。
 - 不把当前安装缓存当成可编辑源码。
-- 不批准将任一现有插件迁移到 Cordis。
+- 不批准将任一现有插件迁移到新内核；先只运行全新的实验插件。
 - 不批准修复当前 Wake ACK 故障或改变缺失依赖的错误语义。
 - 不批准向真实渠道、GitHub、浏览器账号或外部 API 发送测试效果。
+
+### 1.1 实施收敛：选择组合语义，不复制整套工具链
+
+第一阶段转译 Cordis 的 Context、Service、Inject、Fiber 与 Effect，并让 Root/Fiber 直接拥有 scope 生命周期；它吸收 DeepSeek Harness 对重入卸载、owner 先登记、UNLOADING 禁止新 Effect、child 先归属后发布、epoch 防陈旧激活和 observer 隔离的加固。它不移植独立 service isolation scope、Loader、Include、HMR、Timer、Logger、Schemastery 或 CosmoKit：Akashic 已有 artifact、安装、generation、热重载和晋升 owner；Timer 与 Logger 可以像 Job 一样成为普通 Service；配置继续使用 Python 类型和现有 Pydantic 边界。
+
+实现后的 publication seam 在候选 lease 排空后由 Core 封存拓扑、写集和外部效果回执；晋升前再次复核。Service 实例本身仍可承载运行时可变状态，不能为了消除 TOCTOU 而把 Cordis 的动态服务错误冻结成序列化值。任何被 `ExternalEffectGate` 拒绝的尝试即使被插件捕获，也会令候选不再 ready。
+
+因此本文后续出现的“Cordis 候选”表示采用上述组合语义的 Python 候选拓扑，不表示逐包、逐 API 或 TypeScript ABI 完整兼容。能力等价仍以可观察行为为准。
 
 ## 2. 本设计与现有自验证设计的关系
 

--- a/docs/design/plugin-composition-kernel-task-contract.md
+++ b/docs/design/plugin-composition-kernel-task-contract.md
@@ -1,0 +1,113 @@
+# 插件组合内核第一阶段任务合同
+
+## Role
+
+- 负责范围：Python 组合内核、Core 候选接入点、行为回执、实验插件和隔离 workspace 验证。
+- 当前阶段：complete
+
+## Goal
+
+新增一条可真实运行的新插件路径：插件只实现 `apply(ctx)` 并通过 Service 组合能力，Core 仍以完整 generation snapshot 完成候选验证和晋升；现有插件行为不变。
+
+## Success criteria
+
+- [x] Root Context 能挂载插件、提供 Service、等待必需依赖、响应可选依赖、逆序清理 Effect，并在依赖恢复后只激活最新 epoch。
+- [x] 候选回执由 Core 观察生成，至少列出未满足依赖、Fiber 状态、已注册 Effect、写入和外部效果；插件不能自行声称通过。
+- [x] 新实验插件在隔离 workspace 完成 candidate → validate → promote，随后撤除 provider 时 consumer 回到 pending，最终全部资源归零。
+- [x] 正式 workspace、正式 plugin home、SessionDB、memory、渠道和外部 API 零写入；旧插件测试保持通过。
+- [x] 相关验证已运行，未运行项和原因已说明。
+
+## Evidence
+
+- 必须先读取：`docs/INDEX.md`、`docs/WORKFLOW.md`、`docs/projectneed.md` 插件与 workspace 条款、决策 0008/0026/0036、递归自验证设计、Cordis 能力等价设计、持久化状态地图。
+- 已核对事实：当前 `PluginManager` 和 `PluginContributions` 枚举所有领域贡献；现有 `PluginScope` 能逆序清理但不拥有响应式 Service 依赖；DeepSeek Harness 的 Cordis 关键语义集中在 Context、Service、Inject、Fiber、Effect 和 Scope。
+- 未确认事实：现有真实插件迁移顺序；缺失 legacy phase dependency 的最终产品语义；真实外部写型插件的验证端点。
+- 关键假设：第一阶段使用全新、无外部效果的实验插件，不需要改变现有插件 manifest 格式或正式安装链。
+
+## Change intent
+
+```yaml
+change_type: refactor
+semantic_delta: compatible
+capability_owner: mixed
+consumer_scope:
+  - new-style experimental plugins
+  - plugin generation publisher
+runtime_patch: required
+runtime_patch_reason: "Core 必须为新式插件提供 generation 级 Root Context 和不可伪造的候选回执；只在插件侧实现会复制 publication owner。"
+authoritative_state_owner: "Core owns generation publication; each plugin owns its domain data beneath the Core-assigned root."
+client_only_alternative: ""
+invariants:
+  - stable 只接受通过行为验证的完整拓扑
+  - 一个请求从 admission 到结束只看同一 snapshot
+  - Effect 逆序清理且失败全部保留
+  - 缺失必需依赖和冲突在候选发布前 fail-loud
+protected_state:
+  - existing plugin lifecycle and contribution order
+  - formal workspace and plugin-data
+  - sessions, memory, channels, external APIs
+  - stable/latest parent-Turn promotion semantics
+allowed_paths:
+  - agent/plugin_composition/**
+  - agent/plugins/generation.py
+  - agent/plugins/snapshot.py
+  - agent/plugins/manager.py
+  - tests/**plugin_composition**
+  - tests/fixtures/plugins/composition/**
+  - examples/plugin_composition/**
+  - scripts/plugin_composition_experiment.py
+  - tests_scenarios/contracts/impact.toml
+  - tests_scenarios/contracts/coverage-baseline.json
+  - docs/INDEX.md
+  - docs/NOW.md
+  - docs/decisions/README.md
+  - docs/decisions/0036-plugin-composition-keeps-promotion-owner.md
+  - docs/design/cordis-plugin-capability-parity.md
+  - docs/design/plugin-composition-kernel-task-contract.md
+forbidden_paths:
+  - frontend/**
+  - migrations/**
+  - external plugin canonical sources
+allowed_effects:
+  - create and remove one run-identified isolated workspace
+  - write experiment receipts beneath that isolated workspace
+forbidden_effects:
+  - modify formal workspace, plugin home, manifest, cache or plugin-data
+  - send channel messages or call real external APIs
+  - install, promote or unload formal plugins
+validation:
+  - focused composition unit and lifecycle tests
+  - existing plugin snapshot and rollout regression tests
+  - isolated workspace experiment with before/after write-set evidence
+rollback: "/mnt/data/coding/akasic-agent/.backups/20260814-pre-plugin-composition-kernel-f2e8dd02.bundle"
+worktree_writer: "/mnt/data/coding/akasic-agent-worktrees/plugin-composition-kernel"
+handoff_head: "f2e8dd023b0cab188726f2bfe51d5190f03c6cce"
+external_revisions:
+  - "deepseek-harness@47f943859bef60e4160492346772ded9b24f765a"
+schema_lineages: []
+```
+
+## Autonomy
+
+- 可自主执行：主 Agent 串行修改上述代码和文档、运行无外部效果测试、创建带 run identity 的隔离 workspace；只有边界独立且确实缩短总耗时的只读审查或验证才并行委托。
+- 执行前需确认：写正式 workspace/plugin-data、改变现有插件行为、调用真实外部 API、安装或推广正式插件、修改数据库 schema。
+
+## Output
+
+- 交付文件或字段：组合内核、Core 接入点、候选回执、实验插件、实验脚本、回归测试和文档对账。
+- 必须附带的证据：base/head、测试命令和结果、实验 workspace identity、写集、Fiber/Effect 终态、正式状态零写入说明。
+
+## Stop rules
+
+- 满足全部成功标准后停止第一阶段。
+- 若新入口必须改变旧插件语义、正式持久状态或外部效果才能成立，停止并报告新的审批边界。
+- 若 Cordis 关键生命周期语义无法在 Python 中以确定性测试表达，保留 stable 路径并报告阻塞，不用静默降级获得通过。
+
+## Final evidence
+
+- 源码基线：`f2e8dd023b0cab188726f2bfe51d5190f03c6cce`；实施 worktree：`/mnt/data/coding/akasic-agent-worktrees/plugin-composition-kernel`。
+- 聚焦组合测试：`32 passed`；旧插件、hot-reload、snapshot、control lineage 与 mobile plugin scheduler 回归：`378 passed`。
+- 新增代码、实验和测试的 Basedpyright：`0 errors, 0 warnings`；相关 `compileall` 与 `git diff --check` 通过。
+- 隔离运行：`run_id=2a271aeb-48cf-494b-ae6c-2c95415d9b3d`，workspace 为 `/tmp/akashic-plugin-composition-final.SSJoyp/workspace`，晋升 snapshot 为 `f65425e0540e6e0f`；最终 Fiber、Service、Effect 全为空，外部效果为空。
+- `strace -f -e trace=%file` 记录 5704 行文件系统调用，没有命中正式 workspace 或 plugin home 的写型 syscall；两棵正式状态树的前后元数据指纹分别保持 `a28ed15820e42579964008811ea3803d78adddd3153157a586a66d8a080cffa9` 与 `75b19c7f6d421fca3e20a732f975e416f545f14924df71d10eeadf03722e02db`。
+- 未进入正式 manifest/install 链，未迁移 Citation、Meme、GitHub Watch 或其他现有插件；这些属于下一阶段差分回放试点。

--- a/examples/plugin_composition/__init__.py
+++ b/examples/plugin_composition/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable plugins used by the isolated composition experiment."""

--- a/examples/plugin_composition/probe.py
+++ b/examples/plugin_composition/probe.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from agent.plugin_composition import Context, PluginDataAccess, ServiceKey
+
+PLUGIN_DATA = ServiceKey[PluginDataAccess]("core.plugin-data")
+PROBE_SIGNAL = ServiceKey["ProbeSignal"]("probe.signal")
+PROBE_FORMATTER = ServiceKey[Callable[[str], str]]("probe.formatter")
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeSignal:
+    value: str
+
+
+@dataclass(slots=True)
+class ProbeTrace:
+    events: list[str] = field(default_factory=list)
+
+
+class ProbeProvider:
+    name = "probe-provider"
+    inject = (PLUGIN_DATA,)
+
+    def __init__(self, value: str, trace: ProbeTrace) -> None:
+        self.value = value
+        self.trace = trace
+
+    async def apply(self, ctx: Context) -> None:
+        """Persist plugin-owned state and provide the probe signal."""
+
+        # 1. The plugin owns its JSON shape; Core owns only the scoped writer.
+        data = ctx.require(PLUGIN_DATA).for_plugin(self.name)
+        _ = data.write_text(
+            "state.json",
+            json.dumps(
+                {"generation": ctx.generation_id, "value": self.value},
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            + "\n",
+        )
+
+        # 2. Service and cleanup are both owned by this Fiber.
+        self.trace.events.append(f"provider:load:{self.value}")
+        _ = await ctx.provide(PROBE_SIGNAL, ProbeSignal(self.value))
+        _ = await ctx.effect(
+            lambda: lambda: self.trace.events.append(f"provider:cleanup:{self.value}"),
+            label="probe-provider-trace",
+        )
+
+
+class ProbeConsumer:
+    name = "probe-consumer"
+    inject = (PROBE_SIGNAL,)
+
+    def __init__(self, trace: ProbeTrace) -> None:
+        self.trace = trace
+
+    async def apply(self, ctx: Context) -> None:
+        """Consume the required signal and mount one optional enhancement."""
+
+        signal = ctx.require(PROBE_SIGNAL)
+        self.trace.events.append(f"consumer:load:{signal.value}")
+
+        async def apply_formatter(inner: Context) -> None:
+            formatter = inner.require(PROBE_FORMATTER)
+            self.trace.events.append(f"consumer:formatted:{formatter(signal.value)}")
+            _ = await inner.effect(
+                lambda: lambda: self.trace.events.append(
+                    f"consumer:formatter-cleanup:{signal.value}"
+                ),
+                label="probe-formatter-consumer",
+            )
+
+        _ = await ctx.inject(
+            (PROBE_FORMATTER,),
+            apply_formatter,
+            name="probe-formatter-consumer",
+        )
+        _ = await ctx.effect(
+            lambda: lambda: self.trace.events.append(
+                f"consumer:cleanup:{signal.value}"
+            ),
+            label="probe-consumer-trace",
+        )
+
+
+class ProbeFormatterProvider:
+    name = "probe-formatter-provider"
+    inject = ()
+
+    async def apply(self, ctx: Context) -> None:
+        _ = await ctx.provide(PROBE_FORMATTER, str.upper)

--- a/scripts/plugin_composition_experiment.py
+++ b/scripts/plugin_composition_experiment.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Run the new plugin composition path in one explicit isolated workspace."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import uuid
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, cast
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+if str(SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SOURCE_ROOT))
+
+from agent.plugin_composition import (  # noqa: E402
+    CompositionAudit,
+    CompositionRoot,
+    ExternalEffectGate,
+    PluginDataAccess,
+    ServiceKey,
+)
+from agent.plugins.snapshot import (  # noqa: E402
+    RuntimeSnapshot,
+    RuntimeSnapshotCompiler,
+    RuntimeSnapshotStore,
+)
+from examples.plugin_composition.probe import (  # noqa: E402
+    PLUGIN_DATA,
+    PROBE_SIGNAL,
+    ProbeConsumer,
+    ProbeFormatterProvider,
+    ProbeProvider,
+    ProbeTrace,
+)
+from infra.persistence.json_store import atomic_write_text  # noqa: E402
+
+EXTERNAL_EFFECTS = ServiceKey[ExternalEffectGate]("core.external-effects")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="在全新隔离 workspace 中运行插件组合、验证和晋升实验"
+    )
+    _ = parser.add_argument(
+        "--workspace",
+        type=Path,
+        required=True,
+        help="必须尚不存在；脚本创建后保留全部实验证据",
+    )
+    return parser.parse_args()
+
+
+def _create_workspace(requested: Path) -> Path:
+    """Create only the explicitly named, previously absent workspace."""
+
+    workspace = requested.expanduser().resolve(strict=False)
+    source_root = SOURCE_ROOT.resolve(strict=True)
+    if workspace == source_root or source_root in workspace.parents:
+        raise ValueError("实验 workspace 不能位于源码 worktree 内")
+    for protected in _protected_roots():
+        if workspace == protected or protected in workspace.parents:
+            raise ValueError(f"实验 workspace 不能位于正式状态根内: {protected}")
+    if workspace.exists():
+        raise FileExistsError(f"实验 workspace 必须尚不存在: {workspace}")
+    if not workspace.parent.is_dir():
+        raise FileNotFoundError(f"实验 workspace 父目录不存在: {workspace.parent}")
+    workspace.mkdir()
+    return workspace
+
+
+def _protected_roots() -> tuple[Path, ...]:
+    """Resolve formal workspace and plugin-home roots without importing runtime."""
+
+    configured_workspace = os.environ.get(
+        "AKASHIC_WORKSPACE",
+        "~/.akashic/workspace",
+    )
+    configured_plugin_home = os.environ.get(
+        "AKASHIC_PLUGIN_HOME",
+        "~/.akashic-plugin",
+    )
+    roots = {
+        Path(configured_workspace).expanduser().resolve(strict=False),
+        Path(configured_plugin_home).expanduser().resolve(strict=False),
+    }
+    return tuple(sorted(roots, key=str))
+
+
+async def _drain_snapshot(snapshot: RuntimeSnapshot) -> None:
+    root = snapshot.composition_root
+    if root is not None:
+        await root.dispose()
+
+
+async def _run(workspace: Path) -> dict[str, object]:
+    """Build, validate, promote, lease, and drain one candidate topology."""
+
+    # 1. Core establishes the run identity and protected access points.
+    run_id = str(uuid.uuid4())
+    runtime_dir = workspace / "runtime"
+    runtime_dir.mkdir()
+    marker = {
+        "kind": "plugin-composition-experiment",
+        "run_id": run_id,
+        "workspace": str(workspace),
+    }
+    atomic_write_text(
+        runtime_dir / "plugin-composition-experiment.json",
+        json.dumps(marker, ensure_ascii=False, indent=2) + "\n",
+        domain="plugin_composition_experiment",
+    )
+    audit = CompositionAudit()
+    root = CompositionRoot(f"experiment:{run_id}", audit=audit)
+    _ = await root.context.provide(PLUGIN_DATA, PluginDataAccess(workspace, audit))
+    _ = await root.context.provide(
+        EXTERNAL_EFFECTS,
+        ExternalEffectGate(audit),
+    )
+
+    # 2. New plugins prove required waiting and optional nested injection.
+    trace = ProbeTrace()
+    consumer = await root.mount(ProbeConsumer(trace))
+    pending_receipt = root.receipt()
+    provider = await root.mount(ProbeProvider("first", trace))
+    optional_receipt = root.receipt()
+    _ = await root.mount(ProbeFormatterProvider())
+    ready_receipt = root.receipt()
+
+    # 3. Publish the complete topology as latest and validate through a lease.
+    compiler = RuntimeSnapshotCompiler()
+    stable = compiler.compile({}, snapshot_revision=f"stable:{run_id}")
+    candidate = compiler.compile(
+        {},
+        snapshot_revision=f"candidate:{run_id}",
+        composition_root=root,
+    )
+    store = RuntimeSnapshotStore(_drain_snapshot)
+    store.install(stable)
+    transaction = store.begin_publish(candidate)
+    await store.commit_latest(transaction)
+    lease = store.lease(selector="latest")
+    leased_root = lease.snapshot.composition_root
+    if leased_root is None:
+        raise RuntimeError("latest snapshot 缺少 composition root")
+    signal = leased_root.context.require(PROBE_SIGNAL)
+    await lease.release()
+
+    # 4. Exercise dependency loss/recovery on the isolated candidate itself.
+    await provider.dispose()
+    removed_receipt = root.receipt()
+    _ = await root.mount(ProbeProvider("second", trace))
+    restored_receipt = root.receipt()
+    restored_snapshot = compiler.compile(
+        {},
+        snapshot_revision=f"candidate:{run_id}",
+        composition_root=root,
+    )
+    _validate_behavior(
+        consumer_state=consumer.state.value,
+        pending_receipt=pending_receipt,
+        optional_receipt=optional_receipt,
+        ready_receipt=ready_receipt,
+        removed_receipt=removed_receipt,
+        restored_receipt=restored_receipt,
+        external_effect_count=len(audit.external_effects),
+        original_snapshot_id=candidate.snapshot_id,
+        restored_snapshot_id=restored_snapshot.snapshot_id,
+    )
+
+    # 5. Promote the exact validated object, lease stable, then drain it.
+    _ = store.pause_candidate_admission(candidate)
+    await store.wait_for_no_leases(candidate)
+    store.seal_candidate_validation(candidate)
+    _ = await store.promote_latest()
+    await store.retry_drains()
+    stable_lease = store.lease(selector="stable")
+    promoted_snapshot_id = stable_lease.snapshot.snapshot_id
+    await stable_lease.release()
+    promoted_receipt = root.receipt()
+    await store.close()
+    disposed_receipt = root.receipt()
+
+    return {
+        "run_id": run_id,
+        "workspace": str(workspace),
+        "stable_snapshot_id": promoted_snapshot_id,
+        "observed_signal": signal.value,
+        "trace": trace.events,
+        "receipts": {
+            "pending": pending_receipt,
+            "optional": optional_receipt,
+            "ready": ready_receipt,
+            "removed": removed_receipt,
+            "restored": restored_receipt,
+            "promoted": promoted_receipt,
+            "disposed": disposed_receipt,
+        },
+        "workspace_files_before_result": _workspace_files(workspace),
+    }
+
+
+def _validate_behavior(**evidence: object) -> None:
+    """Apply Core-owned oracles; plugins do not submit their own verdict."""
+
+    expected: dict[str, object] = {
+        "consumer_state": "active",
+        "external_effect_count": 0,
+    }
+    for field, value in expected.items():
+        if evidence[field] != value:
+            raise RuntimeError(f"实验行为不符合 oracle: {field}={evidence[field]!r}")
+    for field in ("pending_receipt", "removed_receipt"):
+        receipt = evidence[field]
+        if getattr(receipt, "ready") is not False:
+            raise RuntimeError(f"实验未观察到 required pending: {field}")
+    for field in ("ready_receipt", "restored_receipt"):
+        receipt = evidence[field]
+        if getattr(receipt, "ready") is not True:
+            raise RuntimeError(f"实验拓扑未恢复 ready: {field}")
+    optional = evidence["optional_receipt"]
+    if getattr(optional, "optional_pending") != ("probe-formatter-consumer",):
+        raise RuntimeError("实验未观察到 optional child pending")
+    if evidence["original_snapshot_id"] != evidence["restored_snapshot_id"]:
+        raise RuntimeError("逻辑等价恢复后 snapshot identity 发生漂移")
+
+
+def _workspace_files(workspace: Path) -> list[dict[str, str]]:
+    files: list[dict[str, str]] = []
+    for path in sorted(item for item in workspace.rglob("*") if item.is_file()):
+        content = path.read_bytes()
+        files.append(
+            {
+                "path": str(path.relative_to(workspace)),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        )
+    return files
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(cast(Any, value))
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"无法序列化实验字段: {type(value).__name__}")
+
+
+async def _main() -> int:
+    args = _parse_args()
+    workspace = _create_workspace(args.workspace)
+    result = await _run(workspace)
+    result_path = workspace / "runtime" / "plugin-composition-result.json"
+    atomic_write_text(
+        result_path,
+        json.dumps(
+            result,
+            ensure_ascii=False,
+            indent=2,
+            default=_json_default,
+        )
+        + "\n",
+        domain="plugin_composition_experiment",
+    )
+    print(result_path)
+    return 0
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_plugin_composition_experiment.py
+++ b/tests/test_plugin_composition_experiment.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_experiment_runs_full_candidate_promotion_in_isolated_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/plugin_composition_experiment.py",
+            "--workspace",
+            str(workspace),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    result_path = Path(result.stdout.strip())
+    evidence = json.loads(result_path.read_text(encoding="utf-8"))
+    assert evidence["workspace"] == str(workspace)
+    assert evidence["observed_signal"] == "first"
+    assert evidence["receipts"]["pending"]["ready"] is False
+    assert evidence["receipts"]["ready"]["ready"] is True
+    assert evidence["receipts"]["removed"]["ready"] is False
+    assert evidence["receipts"]["restored"]["ready"] is True
+    assert evidence["receipts"]["promoted"]["ready"] is True
+    assert evidence["receipts"]["disposed"]["ready"] is False
+    assert evidence["receipts"]["restored"]["external_effects"] == []
+    assert [
+        item["operation"] for item in evidence["receipts"]["restored"]["writes"]
+    ] == ["create", "replace"]
+
+
+def test_experiment_refuses_an_existing_workspace(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/plugin_composition_experiment.py",
+            "--workspace",
+            str(tmp_path),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "实验 workspace 必须尚不存在" in result.stderr
+
+
+def test_experiment_refuses_child_of_formal_workspace(tmp_path: Path) -> None:
+    formal_workspace = tmp_path / "formal"
+    formal_workspace.mkdir()
+    environment = dict(os.environ)
+    environment["AKASHIC_WORKSPACE"] = str(formal_workspace)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/plugin_composition_experiment.py",
+            "--workspace",
+            str(formal_workspace / "candidate"),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "不能位于正式状态根内" in result.stderr

--- a/tests/test_plugin_composition_kernel.py
+++ b/tests/test_plugin_composition_kernel.py
@@ -1,0 +1,721 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import asdict
+
+import pytest
+
+from agent.plugin_composition import (
+    CompositionAudit,
+    CompositionError,
+    CompositionRoot,
+    ExternalEffectGate,
+    FiberState,
+    PluginDataAccess,
+    ServiceKey,
+)
+from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
+from agent.plugins.manager import PluginManager
+
+GREETING = ServiceKey[str]("greeting")
+FORMATTER = ServiceKey[Callable[[str], str]]("formatter")
+
+
+class GreetingProvider:
+    name = "greeting-provider"
+    inject = ()
+
+    def __init__(self, value: str = "hello") -> None:
+        self.value = value
+
+    async def apply(self, ctx) -> None:
+        await ctx.provide(GREETING, self.value)
+
+
+@pytest.mark.asyncio
+async def test_required_dependency_follows_provider_lifecycle() -> None:
+    events: list[str] = []
+
+    class Consumer:
+        name = "consumer"
+        inject = (GREETING,)
+
+        async def apply(self, ctx) -> None:
+            events.append(f"load:{ctx.require(GREETING)}")
+            await ctx.effect(
+                lambda: lambda: events.append("unload"),
+                label="consumer",
+            )
+
+    root = CompositionRoot("required-lifecycle")
+    consumer = await root.mount(Consumer())
+    assert consumer.state == FiberState.PENDING
+    assert root.receipt().required_pending == ("consumer",)
+
+    first_provider = await root.mount(GreetingProvider("first"))
+    assert consumer.state == FiberState.ACTIVE
+    assert events == ["load:first"]
+    assert root.receipt().ready is True
+
+    await first_provider.dispose()
+    assert consumer.state == FiberState.PENDING
+    assert events == ["load:first", "unload"]
+
+    await root.mount(GreetingProvider("second"))
+    assert consumer.state == FiberState.ACTIVE
+    assert events == ["load:first", "unload", "load:second"]
+
+
+@pytest.mark.asyncio
+async def test_nested_inject_is_optional_for_candidate_readiness() -> None:
+    events: list[str] = []
+
+    class Parent:
+        name = "parent"
+        inject = ()
+
+        async def apply(self, ctx) -> None:
+            async def use_formatter(inner) -> None:
+                formatter = inner.require(FORMATTER)
+                events.append(formatter("ready"))
+
+            await ctx.inject((FORMATTER,), use_formatter, name="optional-formatter")
+
+    root = CompositionRoot("optional-inject")
+    parent = await root.mount(Parent())
+    receipt = root.receipt()
+    assert parent.state == FiberState.ACTIVE
+    assert receipt.ready is True
+    assert receipt.optional_pending == ("optional-formatter",)
+
+    class FormatterProvider:
+        name = "formatter-provider"
+        inject = ()
+
+        async def apply(self, ctx) -> None:
+            await ctx.provide(FORMATTER, lambda value: value.upper())
+
+    await root.mount(FormatterProvider())
+    assert events == ["READY"]
+    assert root.receipt().optional_pending == ()
+
+
+@pytest.mark.asyncio
+async def test_effect_cleanup_is_lifo_and_public_dispose_is_single_shot() -> None:
+    events: list[str] = []
+    root = CompositionRoot("effect-lifo")
+
+    async def apply(ctx) -> None:
+        effect = await ctx.effect(
+            lambda: (
+                lambda: events.append("first"),
+                lambda: events.append("second"),
+            ),
+            label="pair",
+        )
+        await effect.aclose()
+        await effect.aclose()
+
+    fiber = await root.mount(apply, name="effect-owner")
+    assert fiber.state == FiberState.ACTIVE
+    assert events == ["second", "first"]
+    assert fiber.effects == []
+
+
+@pytest.mark.asyncio
+async def test_effect_setup_failure_rolls_back_collected_cleanup() -> None:
+    cleanups: list[str] = []
+    root = CompositionRoot("effect-rollback")
+
+    def broken_setup():
+        yield lambda: cleanups.append("rolled-back")
+        raise RuntimeError("setup failed")
+
+    async def apply(ctx) -> None:
+        await ctx.effect(broken_setup, label="broken")
+
+    fiber = await root.mount(apply, name="broken-plugin")
+    assert fiber.state == FiberState.FAILED
+    assert cleanups == ["rolled-back"]
+    assert fiber.effects == []
+    assert root.receipt().ready is False
+
+
+@pytest.mark.asyncio
+async def test_reentrant_dispose_awaits_setup_and_async_cleanup() -> None:
+    setup_gate = asyncio.Event()
+    cleanup_gate = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    dispose_created = asyncio.Event()
+    dispose_task: asyncio.Task[None] | None = None
+    root = CompositionRoot("reentrant-dispose")
+
+    async def apply(ctx) -> None:
+        async def setup():
+            nonlocal dispose_task
+            dispose_task = asyncio.create_task(ctx.fiber.dispose())
+            dispose_created.set()
+            await setup_gate.wait()
+
+            async def cleanup() -> None:
+                cleanup_started.set()
+                await cleanup_gate.wait()
+
+            return cleanup
+
+        await ctx.effect(setup, label="reentrant")
+
+    mount_task = asyncio.create_task(root.mount(apply, name="owner"))
+    await dispose_created.wait()
+    assert dispose_task is not None
+    assert dispose_task.done() is False
+    setup_gate.set()
+    await cleanup_started.wait()
+    assert dispose_task.done() is False
+    cleanup_gate.set()
+    await dispose_task
+    fiber = await mount_task
+    assert fiber.state == FiberState.DISPOSED
+    assert fiber.effects == []
+
+
+@pytest.mark.asyncio
+async def test_reentrant_restart_awaits_setup_cleanup_and_reloads() -> None:
+    setup_gate = asyncio.Event()
+    cleanup_gate = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    restart_created = asyncio.Event()
+    restart_task: asyncio.Task[None] | None = None
+    apply_calls = 0
+    root = CompositionRoot("reentrant-restart")
+
+    async def apply(ctx) -> None:
+        nonlocal apply_calls, restart_task
+        apply_calls += 1
+        if apply_calls != 1:
+            return
+
+        async def setup():
+            nonlocal restart_task
+            restart_task = asyncio.create_task(ctx.fiber.restart())
+            restart_created.set()
+            await setup_gate.wait()
+
+            async def cleanup() -> None:
+                cleanup_started.set()
+                await cleanup_gate.wait()
+
+            return cleanup
+
+        _ = await ctx.effect(setup, label="reentrant")
+
+    mount_task = asyncio.create_task(root.mount(apply, name="owner"))
+    await restart_created.wait()
+    assert restart_task is not None
+    setup_gate.set()
+    await cleanup_started.wait()
+    assert restart_task.done() is False
+    cleanup_gate.set()
+    await restart_task
+    fiber = await mount_task
+    assert fiber.state == FiberState.ACTIVE
+    assert fiber.effects == []
+    assert apply_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_direct_reentrant_lifecycle_wait_fails_loud_instead_of_deadlock() -> None:
+    observed: list[str] = []
+    root = CompositionRoot("direct-reentrant-wait")
+
+    async def apply(ctx) -> None:
+        for operation in (ctx.fiber.dispose, ctx.fiber.restart):
+            with pytest.raises(CompositionError) as caught:
+                await operation()
+            observed.append(caught.value.code)
+
+    fiber = await asyncio.wait_for(root.mount(apply, name="owner"), timeout=0.5)
+    assert observed == [
+        "REENTRANT_LIFECYCLE_WAIT",
+        "REENTRANT_LIFECYCLE_WAIT",
+    ]
+    assert fiber.state == FiberState.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_unloading_rejects_new_effect_registration() -> None:
+    errors: list[CompositionError] = []
+    root = CompositionRoot("inactive-effect")
+
+    async def apply(ctx) -> None:
+        async def cleanup() -> None:
+            try:
+                await ctx.effect(lambda: None, label="too-late")
+            except CompositionError as error:
+                errors.append(error)
+
+        await ctx.effect(lambda: cleanup, label="owner")
+
+    fiber = await root.mount(apply, name="plugin")
+    await fiber.restart()
+    assert [error.code for error in errors] == ["INACTIVE_EFFECT"]
+    assert fiber.state == FiberState.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_does_not_truncate_disposal() -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_gate = asyncio.Event()
+    cleanup_finished = False
+    root = CompositionRoot("cancel-safe-cleanup")
+
+    async def apply(ctx) -> None:
+        async def cleanup() -> None:
+            nonlocal cleanup_finished
+            cleanup_started.set()
+            await cleanup_gate.wait()
+            cleanup_finished = True
+
+        await ctx.effect(lambda: cleanup, label="slow-cleanup")
+
+    fiber = await root.mount(apply, name="owner")
+    caller = asyncio.create_task(fiber.dispose())
+    await cleanup_started.wait()
+    caller.cancel()
+    await asyncio.sleep(0)
+    assert caller.done() is False
+    cleanup_gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    assert cleanup_finished is True
+    assert fiber.state == FiberState.DISPOSED
+    assert root.receipt().effects == ()
+
+
+@pytest.mark.asyncio
+async def test_mount_cancellation_rolls_back_published_fiber() -> None:
+    apply_started = asyncio.Event()
+    cleanup_finished = False
+    root = CompositionRoot("cancelled-mount")
+
+    async def apply(ctx) -> None:
+        nonlocal cleanup_finished
+        await ctx.effect(
+            lambda: lambda: _mark_cleanup(),
+            label="mount-cleanup",
+        )
+        apply_started.set()
+        await asyncio.Event().wait()
+
+    def _mark_cleanup() -> None:
+        nonlocal cleanup_finished
+        cleanup_finished = True
+
+    mount_task = asyncio.create_task(root.mount(apply, name="cancelled"))
+    await apply_started.wait()
+    mount_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await mount_task
+    assert cleanup_finished is True
+    assert root.receipt().fibers == ()
+    assert root.root_fiber.children == []
+
+
+@pytest.mark.asyncio
+async def test_stale_dependency_epoch_never_becomes_active() -> None:
+    apply_started = asyncio.Event()
+    apply_gate = asyncio.Event()
+    events: list[str] = []
+    root = CompositionRoot("stale-epoch")
+    provider = await root.mount(GreetingProvider())
+
+    async def consume(ctx) -> None:
+        events.append(f"start:{ctx.require(GREETING)}")
+        apply_started.set()
+        await apply_gate.wait()
+        await ctx.effect(lambda: lambda: events.append("cleanup"), label="owned")
+
+    mount_task = asyncio.create_task(
+        root.mount(consume, name="slow-consumer", inject=(GREETING,))
+    )
+    await apply_started.wait()
+    remove_task = asyncio.create_task(provider.dispose())
+    apply_gate.set()
+    consumer = await mount_task
+    await remove_task
+    assert consumer.state == FiberState.PENDING
+    assert events == ["start:hello", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_mount_observer_failure_rolls_back_parent_ownership() -> None:
+    root = CompositionRoot("publication-rollback")
+
+    def fail_publication(fiber) -> None:
+        if fiber.name == "broken-publication":
+            raise RuntimeError("publication failed")
+
+    root.on_mount(fail_publication)
+    with pytest.raises(RuntimeError, match="publication failed"):
+        await root.mount(lambda _: None, name="broken-publication")
+    assert root.root_fiber.children == []
+    assert root.receipt().fibers == ()
+
+
+@pytest.mark.asyncio
+async def test_parent_disposal_during_publication_drains_pending_child() -> None:
+    root = CompositionRoot("parent-child-quiescence")
+    owner_context = None
+    cleanup_started = asyncio.Event()
+    cleanup_gate = asyncio.Event()
+    child_apply_calls = 0
+    parent_dispose_task: asyncio.Task[None] | None = None
+
+    async def owner_apply(ctx) -> None:
+        nonlocal owner_context
+        owner_context = ctx
+
+    owner = await root.mount(owner_apply, name="owner")
+
+    async def observe_child(fiber) -> None:
+        nonlocal parent_dispose_task
+        if fiber.name != "child":
+            return
+
+        async def cleanup() -> None:
+            cleanup_started.set()
+            await cleanup_gate.wait()
+
+        _ = await fiber.context.effect(lambda: cleanup, label="pending-child")
+        parent_dispose_task = asyncio.create_task(owner.dispose())
+        await cleanup_started.wait()
+
+    root.on_mount(observe_child)
+
+    async def child_apply(_) -> None:
+        nonlocal child_apply_calls
+        child_apply_calls += 1
+
+    assert owner_context is not None
+    child_mount = asyncio.create_task(owner_context.mount(child_apply, name="child"))
+    await cleanup_started.wait()
+    assert child_apply_calls == 0
+    assert parent_dispose_task is not None
+    assert parent_dispose_task.done() is False
+    cleanup_gate.set()
+    child = await child_mount
+    await parent_dispose_task
+    assert child.state == FiberState.DISPOSED
+    assert owner.state == FiberState.DISPOSED
+
+
+@pytest.mark.asyncio
+async def test_dispose_observer_failure_is_contained_and_peers_run() -> None:
+    observed: list[str] = []
+    root = CompositionRoot("observer-containment")
+
+    def broken(fiber) -> None:
+        if fiber.name == "child":
+            raise RuntimeError("broken observer")
+
+    root.on_dispose(broken)
+    root.on_dispose(lambda fiber: observed.append(fiber.name))
+    child = await root.mount(lambda _: None, name="child")
+    await child.dispose()
+    assert observed == ["child"]
+    assert any("broken observer" in error for error in root.receipt().errors)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_provider_fails_without_replacing_first_owner() -> None:
+    root = CompositionRoot("duplicate-service")
+    first = await root.mount(GreetingProvider("first"))
+    duplicate = await root.mount(
+        GreetingProvider("second"),
+        name="second-provider",
+    )
+    assert first.state == FiberState.ACTIVE
+    assert duplicate.state == FiberState.FAILED
+    assert root.context.require(GREETING) == "first"
+    assert root.receipt().services == ("greeting",)
+
+
+@pytest.mark.asyncio
+async def test_root_disposal_drains_children_effects_and_services() -> None:
+    root = CompositionRoot("root-dispose")
+    await root.mount(GreetingProvider())
+    await root.dispose()
+    receipt = root.receipt()
+    assert receipt.fibers == ()
+    assert receipt.services == ()
+    assert receipt.effects == ()
+    assert receipt.ready is False
+
+
+@pytest.mark.asyncio
+async def test_root_disposal_rejects_mount_during_slow_cleanup() -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_gate = asyncio.Event()
+    root = CompositionRoot("root-dispose-mount-race")
+
+    async def cleanup() -> None:
+        cleanup_started.set()
+        await cleanup_gate.wait()
+
+    _ = await root.context.effect(lambda: cleanup, label="slow-root-cleanup")
+    dispose_task = asyncio.create_task(root.dispose())
+    await cleanup_started.wait()
+    with pytest.raises(CompositionError) as caught:
+        await root.mount(lambda _: None, name="too-late")
+    assert caught.value.code == "INACTIVE_PLUGIN_OWNER"
+    cleanup_gate.set()
+    await dispose_task
+    assert root.receipt().fibers == ()
+
+
+@pytest.mark.asyncio
+async def test_provider_cleanup_survives_all_dependent_cleanup_failures() -> None:
+    cleaned: list[str] = []
+    root = CompositionRoot("dependent-cleanup-failure")
+    provider = await root.mount(GreetingProvider())
+
+    async def consume(ctx) -> None:
+        name = ctx.fiber.name
+
+        def fail_cleanup() -> None:
+            cleaned.append(name)
+            raise RuntimeError(f"cleanup failed: {name}")
+
+        _ = await ctx.effect(lambda: fail_cleanup, label=f"cleanup:{name}")
+
+    _ = await root.mount(consume, name="consumer-a", inject=(GREETING,))
+    _ = await root.mount(consume, name="consumer-b", inject=(GREETING,))
+    with pytest.raises(BaseExceptionGroup, match="Fiber 卸载失败"):
+        await provider.dispose()
+
+    assert sorted(cleaned) == ["consumer-a", "consumer-b"]
+    assert provider.state == FiberState.DISPOSED
+    assert root.context.get(GREETING) is None
+    replacement = await root.mount(GreetingProvider(), name="replacement-provider")
+    assert replacement.state == FiberState.ACTIVE
+    assert root.context.require(GREETING) == "hello"
+
+
+@pytest.mark.asyncio
+async def test_observer_cancelled_error_is_contained_when_owner_not_cancelled() -> None:
+    observed: list[str] = []
+    root = CompositionRoot("observer-cancelled-error")
+
+    async def cancelled(_fiber) -> None:
+        raise asyncio.CancelledError("observer cancelled itself")
+
+    root.on_dispose(cancelled)
+    root.on_dispose(lambda fiber: observed.append(fiber.name))
+    child = await root.mount(lambda _: None, name="child")
+    await child.dispose()
+    assert observed == ["child"]
+    assert any("CancelledError" in error for error in root.receipt().errors)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_compiler_rejects_unready_required_topology() -> None:
+    root = CompositionRoot("candidate-unready")
+    await root.mount(
+        lambda _: None,
+        name="missing-consumer",
+        inject=(GREETING,),
+    )
+    with pytest.raises(RuntimeError, match="required_pending"):
+        RuntimeSnapshotCompiler().compile({}, composition_root=root)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_store_publishes_complete_composition_root() -> None:
+    drained: list[str] = []
+
+    async def dispose_snapshot(snapshot) -> None:
+        if snapshot.composition_root is not None:
+            drained.append(snapshot.composition_root.generation_id)
+            await snapshot.composition_root.dispose()
+
+    compiler = RuntimeSnapshotCompiler()
+    stable = compiler.compile({}, snapshot_revision="stable")
+    root = CompositionRoot("candidate-ready")
+    await root.mount(GreetingProvider())
+    candidate = compiler.compile(
+        {},
+        snapshot_revision="candidate",
+        composition_root=root,
+    )
+    store = RuntimeSnapshotStore(dispose_snapshot)
+    store.install(stable)
+    transaction = store.begin_publish(candidate)
+    await store.commit_latest(transaction)
+
+    lease = store.lease(selector="latest")
+    assert lease.snapshot.composition_root is root
+    assert lease.snapshot.composition_root.context.require(GREETING) == "hello"
+    await lease.release()
+
+    store.pause_candidate_admission(candidate)
+    store.seal_candidate_validation(candidate)
+    await store.promote_latest()
+    await store.retry_drains()
+    assert store.stable is candidate
+    assert drained == []
+    await store.close()
+    assert drained == ["candidate-ready"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_store_rejects_topology_drift_after_compile() -> None:
+    root = CompositionRoot("candidate-drift")
+    provider = await root.mount(GreetingProvider())
+    await root.mount(
+        lambda _: None,
+        name="consumer",
+        inject=(GREETING,),
+    )
+    candidate = RuntimeSnapshotCompiler().compile({}, composition_root=root)
+    await provider.dispose()
+
+    store = RuntimeSnapshotStore()
+    store.install(RuntimeSnapshotCompiler().compile({}))
+    with pytest.raises(RuntimeError, match="组合拓扑未就绪"):
+        store.begin_publish(candidate)
+
+
+@pytest.mark.asyncio
+async def test_promotion_rechecks_candidate_topology_after_behavior_probe() -> None:
+    root = CompositionRoot("candidate-promotion-recheck")
+    provider = await root.mount(GreetingProvider())
+    await root.mount(
+        lambda _: None,
+        name="consumer",
+        inject=(GREETING,),
+    )
+    compiler = RuntimeSnapshotCompiler()
+    candidate = compiler.compile({}, composition_root=root)
+    store = RuntimeSnapshotStore()
+    store.install(compiler.compile({}))
+    transaction = store.begin_publish(candidate)
+    await store.commit_latest(transaction)
+
+    await provider.dispose()
+    store.pause_candidate_admission(candidate)
+    with pytest.raises(RuntimeError, match="组合拓扑未就绪"):
+        await store.promote_latest()
+
+    _ = await root.mount(GreetingProvider())
+    store.seal_candidate_validation(candidate)
+    _ = await store.promote_latest()
+    assert store.stable is candidate
+    await store.close()
+    await root.dispose()
+
+
+@pytest.mark.asyncio
+async def test_plugin_manager_drains_snapshot_composition_root() -> None:
+    cleaned: list[str] = []
+    root = CompositionRoot("manager-drain")
+
+    async def apply(ctx) -> None:
+        await ctx.effect(
+            lambda: lambda: cleaned.append("cleaned"),
+            label="owned",
+        )
+
+    await root.mount(apply, name="plugin")
+    snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
+    manager = object.__new__(PluginManager)
+    manager._snapshot_store = RuntimeSnapshotStore()
+    manager._snapshot_skill_catalogs = {}
+    manager._finish_drained_reload = lambda _: None
+
+    await manager._on_snapshot_drained(snapshot)
+    assert cleaned == ["cleaned"]
+    assert root.receipt().ready is False
+
+
+def test_core_plugin_data_access_records_scoped_writes(tmp_path) -> None:
+    audit = CompositionAudit()
+    access = PluginDataAccess(tmp_path, audit)
+    data = access.for_plugin("probe")
+    target = data.write_text("state/value.json", '{"value": 1}\n')
+    assert target.relative_to(tmp_path).as_posix() == (
+        "plugin-data/probe/state/value.json"
+    )
+    assert data.read_text("state/value.json") == '{"value": 1}\n'
+    assert [
+        (write.plugin_id, write.operation, write.relative_path)
+        for write in audit.writes
+    ] == [("probe", "create", "state/value.json")]
+    with pytest.raises(ValueError, match="相对路径无效"):
+        data.write_text("../escape", "blocked")
+
+
+def test_core_plugin_data_access_never_follows_scoped_symlinks(tmp_path) -> None:
+    audit = CompositionAudit()
+    data = PluginDataAccess(tmp_path, audit).for_plugin("probe")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (data.root / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        data.write_text("escape/value.json", "blocked")
+    assert list(outside.iterdir()) == []
+
+
+def test_external_effect_gate_records_denial() -> None:
+    audit = CompositionAudit()
+    gate = ExternalEffectGate(audit)
+    with pytest.raises(PermissionError, match="禁止外部效果"):
+        gate.authorize(kind="http", target="https://example.invalid")
+    assert [asdict(effect) for effect in audit.external_effects] == [
+        {
+            "kind": "http",
+            "target": "https://example.invalid",
+            "outcome": "denied",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_external_effect_attempt_rejects_candidate_even_when_caught() -> None:
+    audit = CompositionAudit()
+    root = CompositionRoot("external-effect-gate", audit=audit)
+    gate = ExternalEffectGate(audit)
+
+    async def apply(_) -> None:
+        with pytest.raises(PermissionError):
+            gate.authorize(kind="http", target="https://example.invalid")
+
+    _ = await root.mount(apply, name="caught-denial")
+    assert root.receipt().ready is False
+    with pytest.raises(RuntimeError, match="拓扑未就绪"):
+        RuntimeSnapshotCompiler().compile({}, composition_root=root)
+
+
+@pytest.mark.asyncio
+async def test_promotion_requires_sealed_receipt_and_rejects_later_write(
+    tmp_path,
+) -> None:
+    audit = CompositionAudit()
+    root = CompositionRoot("sealed-validation", audit=audit)
+    data = PluginDataAccess(tmp_path, audit).for_plugin("probe")
+    data.write_text("state.json", "first")
+    _ = await root.mount(GreetingProvider())
+    compiler = RuntimeSnapshotCompiler()
+    candidate = compiler.compile({}, composition_root=root)
+    store = RuntimeSnapshotStore()
+    store.install(compiler.compile({}))
+    await store.commit_latest(store.begin_publish(candidate))
+    store.pause_candidate_admission(candidate)
+
+    with pytest.raises(RuntimeError, match="缺少 Core 验证回执"):
+        await store.promote_latest()
+    store.seal_candidate_validation(candidate)
+    data.write_text("state.json", "second")
+    with pytest.raises(RuntimeError, match="封存后发生变化"):
+        await store.promote_latest()

--- a/tests_scenarios/contracts/coverage-baseline.json
+++ b/tests_scenarios/contracts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "acceptedGaps": [],
   "base": "683b4791b0c25e3e899d65fe7c028514240414b3",
-  "catalogDigest": "98d030091096d2040917947f5c98a8febf8c73a96653098779f0e2cb4853040c",
+  "catalogDigest": "0576d9ca3e48960cd75d4b5e2949b9c0f111ac8c43797e480eca788bea88d8b3",
   "purpose": "approved_contract_mapping",
   "coveredP0": {
     "companion_control": [

--- a/tests_scenarios/contracts/impact.toml
+++ b/tests_scenarios/contracts/impact.toml
@@ -131,9 +131,12 @@ scenarios = ["mcp_call_finality", "mcp_process_lifecycle"]
 priority = "p0"
 requirements = ["PLG-001", "PLG-004", "PLG-009"]
 paths = [
+  "agent/plugin_composition/**",
   "agent/plugins/**",
+  "examples/plugin_composition/**",
   "plugin_packages/**",
   "plugins/**",
+  "scripts/plugin_composition_experiment.py",
   "bootstrap/tools.py",
   "bootstrap/wiring.py",
   "tests/fixtures/plugins/**",


### PR DESCRIPTION
## 变更

- 将 Cordis 的 Context、Service、Inject、Fiber 与 Effect 语义转译为 Python 组合内核。
- 由 Core 为完整候选拓扑生成不可伪造的 readiness、写集与外部效果回执。
- 把组合 Root 接入现有 RuntimeSnapshot lease、stable/latest 和 parent Turn 晋升边界。
- 增加无外部效果实验插件及隔离 workspace 的 candidate → validate → promote → dispose 验证。

## 边界

这是 #394 的 Phase 1，实现依赖 Draft PR #395 的能力等价设计。本 PR 不迁移现有插件，不修改正式 manifest、plugin-data、SessionDB、Memory、渠道或外部 API，也不替换现有 legacy host。

## 验证

- 聚焦组合测试：32 passed。
- 旧插件、hot-reload、snapshot、control lineage 与 mobile scheduler 回归：378 passed。
- 新增代码与测试 Basedpyright：0 errors / 0 warnings。
- compileall、git diff --check 通过。
- 隔离实验最终 Fiber、Service、Effect 全部归零；正式 workspace 与 plugin home 前后指纹一致。

Closes no issue; contributes to #394.