### PR TITLE
docs(plugins): mark v2 removal owners

### DIFF
--- a/agent/plugins/__init__.py
+++ b/agent/plugins/__init__.py
@@ -1,5 +1,6 @@
-# 插件兼容接口：外部插件从本模块导入下列对象。核心重构可以在内部适配，
-# 但迁移现有插件及其测试前，不要仅因核心调用减少而删除或改名。
+# V2_REMOVAL(plugin-public-api-v2)：外部 v2 插件从本模块导入下面的 class、decorator、job
+# 与领域 spec。最后一个 consumer 迁到 agent.plugin_composition 和 v3 contract 后删除这些
+# public exports；仍被 Core 使用的 generation/scope 类型先移入 Core-private 模块。
 from agent.plugins.base import Plugin
 from agent.plugins.config import PluginConfig
 from agent.plugins.context import PluginContext, PluginKVStore

--- a/agent/plugins/base.py
+++ b/agent/plugins/base.py
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
     from agent.plugins.generation import PluginReadinessContext
 
 
-# 插件生命周期接口：现有插件实现这些回调和贡献方法。prepare、activate、
-# retire、terminate 的调用时机及贡献方法的含义，在插件迁移前不得改变。
+# V2_REMOVAL(plugin-api-v2)：这是 v2 插件的完整公开类合同。全部 canonical consumer
+# 改成 api_version=3 namespace、full-fleet Gate 接管后，删除整个类；迁移期
+# 不得继续给它增加新的 lifecycle、job、channel、command 或 mobile 领域方法。
 class Plugin(ABC):
     api_version: int = 2
     name: str | None = None

--- a/agent/plugins/decorators.py
+++ b/agent/plugins/decorators.py
@@ -13,6 +13,9 @@ from agent.plugins.registry import (
     plugin_registry,
 )
 
+# V2_REMOVAL(plugin-decorators-v2)：这些全局 decorator metadata 只服务 v2 class 插件。
+# lifecycle/tool consumer 全部迁到 typed event、Service 与 v3 tool registration 后删除本模块，
+# 不保留转发到 CompositionRoot 的兼容 decorator。
 
 def _get_or_create_handler(
     func: Callable[..., Any],

--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -65,6 +65,9 @@ class GateResult:
 
 @dataclass(frozen=True)
 class PluginContributions:
+    # V2_REMOVAL(plugin-contributions-v2)：phase/MCP/process/proactive/job/channel/mobile 字段是
+    # Manager 对 v2 固定方法的冻结结果。对应首个真实 v3 capability 与 full-fleet Gate 建立后
+    # 逐族删除；manifest/Skill/Dashboard 等 v3 暂用字段须先迁入明确的 generation projection。
     manifest: dict[str, object]
     skill_roots: tuple[Path, ...] = ()
     drift_skill_roots: tuple[Path, ...] = ()

--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -573,6 +573,8 @@ def _load_plugin_entry(plugin_root: Path) -> type | ComposablePlugin:
         spec.loader.exec_module(module)
         if getattr(module, "api_version", None) == 3:
             return ComposablePlugin.from_module(module)
+        # V2_REMOVAL(plugin-install-v2)：full-fleet 只剩 v3 namespace 后删除 class registry
+        # fallback，unknown/legacy declaration 在这一边界直接 fail-loud。
         plugin_class = plugin_registry.get_class(module_name)
         if plugin_class is None:
             raise ValueError("plugin.py 未声明 Plugin 子类或 v3 apply 模块")

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -321,6 +321,9 @@ class PluginManager:
             return list(self.current_snapshot.tool_hooks)
         return list(self._tool_hooks)
 
+    # V2_REMOVAL(plugin-manager-projections)：channels/phase/proactive/jobs 是 v2 固定贡献的
+    # Manager 投影。每个族群迁入 stable Root capability/catalog 且 bootstrap consumer 改读新
+    # owner 后，删除下面的属性与 mutable fallback。
     @property
     def channels(self) -> list[Channel]:
         if self.current_snapshot is not None:
@@ -815,6 +818,8 @@ class PluginManager:
 
     @property
     def telegram_bot_commands(self) -> list[tuple[str, str]]:
+        # V2_REMOVAL(channel-command-catalog)：Observe/Setup Helper/Status Commands 迁到只发布
+        # stable generation 的 channel command catalog 后，连同 mobile 聚合和 bootstrap 传参删除。
         return self._declared_bot_commands("telegram_bot_commands")
 
     @property
@@ -4573,6 +4578,9 @@ class PluginManager:
                     instance.dashboard_module,
                 ),
             )
+        # V2_REMOVAL(plugin-contribution-collector-v2)：以下分支逐项调用 v2 class 领域方法。
+        # command/MCP/process/channel/proactive/mobile/phase 首个 v3 consumer 建立 capability 后
+        # 按迁移地图逐族删除；最后删除整个 legacy branch。
         cls = cast(type[Any], type(instance))
         _reject_legacy_mobile_ui_api(cls, plugin_id)
         sources: list[RegisteredProactiveSource] = []

--- a/agent/plugins/registry.py
+++ b/agent/plugins/registry.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable, Any
 
+# V2_REMOVAL(plugin-registry-v2)：_classes 与 decorator handler metadata 是 v2 全局注册面。
+# v3 loader 只读 namespace，listener/service 由 Root 持有；最后一个 v2 class/decorator/tool
+# consumer 迁走后删除 class discovery 与 metadata registry，只保留另有 owner 的实例查询前
+# 先迁移该 consumer。
 
 class HandlerType(Enum):
     GATE = auto()

--- a/agent/plugins/snapshot.py
+++ b/agent/plugins/snapshot.py
@@ -33,6 +33,9 @@ RuntimeSelector = Literal["stable", "latest"]
 class RuntimeSnapshot:
     snapshot_id: str
     generations: Mapping[str, PluginGeneration]
+    # V2_REMOVAL(snapshot-fixed-contributions)：这些 phase/job/proactive/channel/MCP/process 字段
+    # 是 v2 固定贡献目录。最后一个 consumer 迁到 stable Root capability/catalog 后删除，最终
+    # snapshot 只保留 generation、CompositionRoot/topology 与必要的派生 catalog identity。
     before_turn_modules: tuple[object, ...]
     before_reasoning_modules: tuple[object, ...]
     prompt_render_modules: tuple[object, ...]

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -461,6 +461,8 @@ class AppRuntime:
                     self.mobile_gateway_runtime.channel.bind_mobile_ui_provider(
                         plugin_ui_provider
                     )
+            # V2_REMOVAL(channel-capability-v2)：ChannelHost 改从 committed stable v3 channel
+            # capability 绑定后删除 Manager.channels 投影；candidate 不得经 bootstrap 提前发布。
             plugin_channels = list(plugin_manager.channels) if plugin_manager else []
             if self.mobile_gateway_runtime is not None:
                 plugin_channels.append(self.mobile_gateway_runtime.channel)
@@ -471,6 +473,8 @@ class AppRuntime:
                     channel_name=self.config.channels.chat.channel_name,
                 )
                 plugin_channels.append(self.web_chat_channel)
+            # V2_REMOVAL(channel-command-catalog)：channel host 改读 committed stable command
+            # catalog 后，删除两个 Manager command 列表和对应 start_channels 参数。
             self.channel_host = await start_channels(
                 self.config,
                 bus=self.bus,
@@ -491,6 +495,8 @@ class AppRuntime:
             if self.readiness is not None:
                 self.readiness.mark_stage("channels.ready")
             if plugin_manager is not None:
+                # V2_REMOVAL(channel-capability-v2)：stable v3 channel catalog 接管 generation
+                # binding、drain 与 endpoint swap 后，删除 PluginContributions.channels 回读。
                 channel_bindings = (
                     {
                         plugin_id: generation.contributions.channels
@@ -577,6 +583,9 @@ class AppRuntime:
                     self.chat_server.serve(),
                     name="chat_server",
                 )
+            # V2_REMOVAL(proactive-capability-v2)：全部 legacy proactive/job consumer 迁入 v3
+            # timer/turn-enqueue capability 或明确删除，并由 full-fleet Gate 覆盖后，删除
+            # proactive_* 固定参数投影。
             proactive_tasks, self.proactive_loop = build_proactive_runtime(
                 self.config,
                 self.workspace,
@@ -587,6 +596,8 @@ class AppRuntime:
                 presence=self.presence,
                 agent_loop=self.agent_loop,
                 event_bus=event_bus,
+                # V2_REMOVAL(tool-hooks)：全部 ToolHook consumer 与 Tool Gate 迁到 typed events
+                # 后，独立删除此参数；不以 proactive 族群迁移完成作为前置。
                 tool_hooks=list(plugin_manager.tool_hooks) if plugin_manager else None,
                 proactive_modules=(
                     list(plugin_manager.proactive_modules) if plugin_manager else None

--- a/bootstrap/channels.py
+++ b/bootstrap/channels.py
@@ -27,6 +27,8 @@ async def start_channels(
     interrupt_controller: InterruptController | None = None,
     plugin_channels: list[Channel] | None = None,
 ) -> ChannelHost:
+    # V2_REMOVAL(channel-command-catalog)：Telegram/mobile 改从 stable command catalog 投影后，
+    # 删除两个 list 参数；candidate catalog 不得经此启动路径提前发布。
     attachment_store = AttachmentStore(session_manager.workspace / "uploads")
 
     def _ctx_factory(channel: Channel) -> ChannelContext:

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -115,6 +115,8 @@ class CoreRuntime:
                 manifest_path = sync_manifest()
                 logger.info("插件清单已同步: %s", manifest_path)
             logger.info("插件加载完成: %d 个", self.plugin_manager.loaded_count)
+            # V2_REMOVAL(tool-hooks)：全部 ToolHook consumer 迁到 typed Tool events 后，删除
+            # passive loop 与 SpawnTool 的 hook 注入；子代理/proactive 转发点按同一删除批次处理。
             if self.plugin_manager.tool_hooks:
                 self.loop.add_tool_hooks(self.plugin_manager.tool_hooks)
                 spawn_tool = self.tools.get_tool("spawn")
@@ -149,6 +151,8 @@ class CoreRuntime:
         from agent.lifecycle.phases.prompt_render import default_prompt_render_modules
 
         # 2. 收集各阶段插件贡献。
+        # V2_REMOVAL(plugin-manager-projections)：inspect 改读 stable Root lifecycle topology 后，
+        # 删除 Manager.before_*/after_*/prompt_render_modules 的诊断投影。
         manager = self.plugin_manager
         before_turn_modules = manager.before_turn_modules if manager is not None else []
         before_reasoning_modules = (


### PR DESCRIPTION
## 问题与结果

- 解决的问题：v3 最终迁移地图已有删除批次，但部分 v2 public API、fixed projection 与 bootstrap consumer 在源码附近缺少可检索的删除前置。
- 用户可见结果：最终迁移者可用 `V2_REMOVAL(...)` 定位 class/decorator/registry/loader、PluginContributions、RuntimeSnapshot、Manager fixed projections、channel command/channel capability、proactive 与 ToolHook bootstrap consumer。
- 本 PR 不处理：不删除 v2，不建立新 capability，不改任何运行行为。

Relates to #394 and depends on #442.

## Change intent

- `change_type`：`docs`
- `semantic_delta`：`none`
- `capability_owner`：`core`
- `consumer_scope`：v2 plugin runtime maintainers 与后续 removal PR reviewer
- `runtime_patch`：`none`
- `runtime_patch_reason`：仅增加源码迁移注释。
- `authoritative_state_owner`：各 marker 指向的现有 Manager/bootstrap/Root owner 不变。
- `client_only_alternative`：不适用。
- 关联不变量：Issue #394、Decision 0036、#442 A～J 删除地图。
- `protected_state`：全部 runtime 行为、Plugin API v2、SessionDB、workspace、plugin-data、installed artifacts。
- 允许的副作用：11 个 Python 文件的注释。
- 禁止的副作用：AST、配置、schema、runtime、外部插件变化。

## 改动范围

- 主要文件：`agent/plugins/*` 与 `bootstrap/app.py`、`channels.py`、`tools.py` 的 owner 注释。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用。
- 不可变 revision：base #442 `5cee3f1c`；本 PR head `501dad1c`；相邻 marker patch-id `6e066c26`。
- 回滚方式：revert 本 PR；不涉及运行数据恢复。

## 验证

- [x] 11 个修改文件 base/current Python AST identity 完全相同。
- [x] 注释-only diff 经 diff check、compile/type evidence 核对，无运行语义变化。
- [x] 两次 stacked rebase 前后 marker patch-id 均为 `6e066c26`。
- [ ] 不重复运行 runtime Gate：comments-only stacked PR；base #441 exact-head Gate 已通过。
- `sourceDigest`：不适用。
- `planDigest`：不适用。
- 真实设备证据：不适用。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前删除接手点由 #442 维护，本 PR 只建立源码检索锚点。

## Review evidence

Terra xhigh 只读审查确认：channel、command、proactive、ToolHook 的删除前置互相独立；v3 仍使用的 generation/Skill/Dashboard/CompositionRoot 未被误标为可整类删除；exact rebase 无语义漂移；无 P0/P1。
