### PR TITLE
[codex] 移动流式批处理脱离固定 60Hz

### DIFF
--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -136,7 +136,7 @@ class _ProcessTurnState:
 
 
 _DELTA_FLUSH_BYTES = 4 * 1024
-_DELTA_FLUSH_INTERVAL_SECONDS = 1.0 / 60.0
+_DELTA_TRANSPORT_COALESCE_SECONDS = 0.008
 _MAX_DELTA_BATCHES = 256
 _MAX_DEVICE_CAPABILITIES = 128
 _MAX_DEVICE_CAPABILITY_LENGTH = 512
@@ -2442,7 +2442,7 @@ class MobileRealtimeChannel:
         block_id: str | None,
         ordinal: int | None,
     ) -> bool:
-        """把连续 delta 聚合成 16ms/4KiB 批；已收口返回 False 且不重建任何结构。"""
+        """把连续 delta 聚合成 8ms/4KiB 传输批；已收口返回 False 且不重建任何结构。"""
 
         flush_now = False
         async with self._delta_locked(session_id, turn_id) as lock:
@@ -2477,7 +2477,8 @@ class MobileRealtimeChannel:
         key = (session_id, turn_id)
         batch = self._delta_batches.get(key)
         if batch is None:
-            # 1. 有界批：新建批与 16ms 定时器，绝不越过 256 活跃 turn 上限。
+            # 1. 有界批：8ms 只限制传输合批延迟；可见 React 发布
+            #    由共享 WebUI rAF 驱动。
             if len(self._delta_batches) >= _MAX_DELTA_BATCHES:
                 raise RuntimeError("mobile delta batch 已达到 256 个活跃 turn 上限")
             timer = asyncio.create_task(
@@ -2538,7 +2539,7 @@ class MobileRealtimeChannel:
         return True
 
     async def _flush_after_interval(self, key: tuple[str, str]) -> None:
-        await asyncio.sleep(_DELTA_FLUSH_INTERVAL_SECONDS)
+        await asyncio.sleep(_DELTA_TRANSPORT_COALESCE_SECONDS)
         _ = await self._flush_deltas(*key)
 
     async def _flush_deltas(self, session_id: str, turn_id: str) -> bool:

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -2697,12 +2697,12 @@ async def test_delta_paths_reuse_existing_lock_without_allocating_lock() -> None
     ]
 
 
-def test_stream_delta_flush_cadence_targets_60hz() -> None:
-    assert channel_module._DELTA_FLUSH_INTERVAL_SECONDS == pytest.approx(1.0 / 60.0)
+def test_stream_delta_transport_window_is_independent_from_display_refresh() -> None:
+    assert channel_module._DELTA_TRANSPORT_COALESCE_SECONDS == pytest.approx(0.008)
 
 
 @pytest.mark.asyncio
-async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool_and_final(
+async def test_stream_deltas_batch_within_transport_window_and_flush_before_tool_and_final(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2759,13 +2759,13 @@ async def test_stream_deltas_batch_within_one_frame_window_and_flush_before_tool
                 thinking_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
-    # 首个 thinking delta 立即 flush 减少首字一帧等待；后续仍按 16ms 批处理
+        await asyncio.sleep(0)
+    # 首个 thinking delta 立即 flush；后续按短传输窗口合批，不绑定显示刷新率。
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",
     ]
-    await asyncio.sleep(channel_module._DELTA_FLUSH_INTERVAL_SECONDS + 0.01)
+    await asyncio.sleep(channel_module._DELTA_TRANSPORT_COALESCE_SECONDS + 0.01)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",
@@ -3177,7 +3177,7 @@ async def test_terminal_and_reconcile_flush_pending_delta_before_terminal_event(
                 thinking_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",
@@ -3202,7 +3202,7 @@ async def test_terminal_and_reconcile_flush_pending_delta_before_terminal_event(
     assert cast(dict[str, object], runtime.events[2]["payload"])["delta"] == "二"
     assert channel._delta_batches == {}
     assert channel._process_turns == {}
-    await asyncio.sleep(channel_module._DELTA_FLUSH_INTERVAL_SECONDS + 0.01)
+    await asyncio.sleep(channel_module._DELTA_TRANSPORT_COALESCE_SECONDS + 0.01)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "react.thinking.delta",
@@ -3320,7 +3320,7 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "answer.delta",
@@ -3404,7 +3404,7 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
         assert channel._delta_failure is None
 
     # 5. 定时器窗口过后仍无迟到发布
-    await asyncio.sleep(channel_module._DELTA_FLUSH_INTERVAL_SECONDS + 0.01)
+    await asyncio.sleep(channel_module._DELTA_TRANSPORT_COALESCE_SECONDS + 0.01)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "answer.delta",
@@ -3493,7 +3493,7 @@ async def test_terminal_and_late_delta_queued_on_same_lock_release_terminal_then
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "answer.delta",
@@ -3543,7 +3543,7 @@ async def test_terminal_and_late_delta_queued_on_same_lock_release_terminal_then
     assert channel._delta_failure is None
 
     # 3. 定时器窗口过后仍无迟到发布，也没有 timer 崩溃。
-    await asyncio.sleep(channel_module._DELTA_FLUSH_INTERVAL_SECONDS + 0.01)
+    await asyncio.sleep(channel_module._DELTA_TRANSPORT_COALESCE_SECONDS + 0.01)
     assert len(runtime.events) == 4
     await channel.stop()
     manager.close()
@@ -3612,7 +3612,7 @@ async def test_stream_delta_racing_terminal_commits_no_state_or_wire(
             content_delta="一",
         )
     )
-    await asyncio.sleep(0.005)
+    await asyncio.sleep(0)
     key = (session_id, turn_id)
     state_ref = channel._process_turns[key]
     lock = channel._delta_locks[key]
@@ -3740,7 +3740,7 @@ async def test_tool_events_racing_terminal_dropped_without_state_touch(
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "answer.delta",
@@ -3940,7 +3940,7 @@ async def test_racing_delta_dropped_so_final_suffix_covers_full_body(
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     key = (session_id, turn_id)
     state_ref = channel._process_turns[key]
     lock = channel._delta_locks[key]
@@ -4048,7 +4048,7 @@ async def test_late_a_final_keeps_b_active_and_identity(
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     await channel._on_turn_started(
         TurnStarted(
             session_key=session_id,
@@ -4822,7 +4822,7 @@ async def test_terminal_final_publish_fail_once_is_retryable_without_fake_succes
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     key = (session_id, turn_id)
     outbound = OutboundMessage(
         channel="mobile",
@@ -4933,7 +4933,7 @@ async def test_terminal_failure_after_batch_flush_retry_does_not_duplicate_delta
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     assert [event["event_type"] for event in runtime.events] == [
         "turn.started",
         "answer.delta",
@@ -5040,7 +5040,7 @@ async def test_late_delta_queued_during_terminal_failure_gap_accepted_then_retry
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     key = (session_id, turn_id)
     outbound = OutboundMessage(
         channel="mobile",
@@ -5224,7 +5224,7 @@ async def test_dual_terminal_race_only_lock_first_winner_publishes(
                 content_delta=delta,
             )
         )
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(0)
     key = (session_id, turn_id)
     lock = channel._delta_locks[key]
     await lock.acquire()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Mobile Core 把连续 delta 固定按 `1 / 60` 秒合批，在 Pixel 7 的 90Hz 显示链路上会形成不均匀的 11.1/22.2ms 可见节奏。
- 用户可见结果：Core 改用与显示刷新率无关的 8ms 传输微批上限；共享 WebUI 继续通过真实 `requestAnimationFrame` 在当前设备帧上只发布最新单行投影。
- 本 PR 不处理：不新增刷新率上报协议，不修改 Android Room/WebView bridge，不宣称已经取得候选 runtime 的 Pixel 流式性能数据。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Mobile realtime 的全部已配对设备；桌面 Web transport 不受影响。
- `runtime_patch`：`required`
- `runtime_patch_reason`：固定 60Hz 合批发生在 Core，客户端 rAF 无法恢复尚未投递的中间 target；Core 只保留 transport-neutral 的短合批延迟，不拥有设备刷新率。
- `authoritative_state_owner`：Core 继续拥有 durable event 顺序、ACK/replay 与 terminal；共享 WebUI 拥有可见 React 发布节奏。
- `client_only_alternative`：前端按 rAF 合并已经在主线实现，但单独使用它无法解除 Core 的 16.67ms 上游门控。
- 关联不变量：MOB-001、MOB-005、MOB-008、WEBUI-001～WEBUI-003、TST-006～TST-008。
- `protected_state`：SessionDB 正文、turn identity、event 顺序、durable inbox/ACK/replay、terminal barrier、协议 schema。
- 允许的副作用：持续高速小 delta 的传输发布上限由约 60/s 提高到约 125/s；同一 8ms 窗口和 4KiB 阈值内仍合批。
- 禁止的副作用：不增删或迁移权威数据，不改变协议字段、事件内容、顺序、终态和 Android 持久状态 owner。

## 改动范围

- 主要文件：`infra/mobile_realtime/channel.py`、`tests/mobile_realtime/test_channel.py`。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：无 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：候选 commit `2b485e80aa30f904c9d173667af4ee00ec28f9a1`；base `b10fcc0144d6f98bc05eb355af60707c8ebafbb0`。
- 回滚方式：revert 本提交即可恢复 16.67ms 合批；本次没有数据迁移或不可逆写入。

## 验证

- [x] 相关 targeted tests 已通过。
- [x] Python 类型检查或前端 typecheck/lint 已通过；不适用项已说明。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`7e6150b26d882ad4f4e8d519d9fe7efc3537d2b86df0ca7615f2b4f352a8b2f9`
- `planDigest`：`ab6df8dbde47f1392844af33059f10d52468b038f529420c528d1a7dd458a008`
- 真实设备证据：Pixel 7 `28151FDH200478`，当前 active mode 2 / `renderFrameRate=90.0`，系统 peak/min 均未限频；本 PR 未构建或安装候选 APK，正式 release WebView 未开放调试 socket，因此没有把 display mode 冒充候选 rAF/paint 结果。
- 未运行项与原因：仓库未配置 ruff；既有 `black --check tests/mobile_realtime/test_channel.py` 存在两处与本 diff 无关的 baseline 格式漂移。候选 Core 的 Pixel 流式 E2E 留待合入、发布真实 runtime 后验证。

Targeted evidence：

- `pytest tests/mobile_realtime/test_channel.py -q`：75 passed。
- 共享 WebUI `node --test`：54 passed。
- change-impact Gate：passed，包含 `mobile_realtime_contract` 282 passed、`mobile_webui_contract` 111 passed，以及所选全部公开场景。
- `python -m py_compile` 与 `git diff --check`：passed。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。
