### PR TITLE
fix(webui): 统一服务端 Turn 终态身份

### DIFF
--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -254,10 +254,13 @@ class WebChatChannel:
         passive = metadata.pop("_channel_commit_role", None) == "passive"
         if not passive:
             metadata.setdefault("source", "message_push")
+        turn_id = message.control_turn_id or (
+            self._current_turn_id(session_key) if passive else ""
+        )
         delivered = await self._broadcast(session_key, {
             "type": "message.final",
             "session_id": session_key,
-            "turn_id": message.control_turn_id or self._current_turn_id(session_key),
+            "turn_id": turn_id,
             "content": message.content,
             "thinking": message.thinking or "",
             "media": media,
@@ -438,7 +441,9 @@ class WebChatChannel:
     async def _on_turn_started(self, event: TurnStarted) -> None:
         if event.channel != self.name:
             return
-        turn_id = self._turn_id(event.session_key, event.timestamp.timestamp())
+        turn_id = event.control_turn_id or event.turn_id
+        if not turn_id:
+            raise RuntimeError("Web TurnStarted 缺少 Server 权威 turn_id")
         self._active_turn_ids[event.session_key] = turn_id
         await self._broadcast(event.session_key, {
             "type": "turn.started",
@@ -582,11 +587,13 @@ class WebChatChannel:
     def _chat_id(self, session_key: str) -> str:
         return session_key[len(self.name) + 1:]
 
-    def _turn_id(self, session_key: str, seed: float) -> str:
-        return f"{session_key}:{seed:.6f}"
-
     def _current_turn_id(self, session_key: str) -> str:
-        return self._active_turn_ids.get(session_key, session_key)
+        try:
+            return self._active_turn_ids[session_key]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"Web 会话 {session_key} 缺少 Server 权威 active turn"
+            ) from exc
 
     def _require_ctx(self) -> ChannelContext:
         if self._ctx is None:

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -501,7 +501,7 @@ class WebChatChannel:
         await self._broadcast(event.session_key, {
             "type": "turn.output.completed",
             "session_id": event.session_key,
-            "turn_id": event.turn_id or self._current_turn_id(event.session_key),
+            "turn_id": self._current_turn_id(event.session_key),
             "client_message_id": event.client_message_id,
         })
 

--- a/scripts/webui-performance/serve_isolated_runtime.py
+++ b/scripts/webui-performance/serve_isolated_runtime.py
@@ -18,6 +18,7 @@ from bus.events_lifecycle import (
     StreamDeltaReady,
     ToolCallCompleted,
     ToolCallStarted,
+    TurnOutputCompleted,
     TurnStarted,
 )
 from infra.channels.base import AttachmentStore
@@ -54,12 +55,15 @@ class DeterministicRuntimeBus:
         await self.sessions.append_messages(session, [user, assistant])
 
         # 2. Exercise the real lifecycle-to-WebSocket adapter, including rich blocks.
+        turn_id = f"turn:isolated:{message.chat_id}"
         await self.events.emit(TurnStarted(
             session_key=message.session_key,
             channel="web",
             chat_id=message.chat_id,
             content=message.content,
             timestamp=message.timestamp,
+            turn_id=turn_id,
+            control_turn_id=turn_id,
         ))
         await self.events.emit(StreamDeltaReady(
             session_key=message.session_key,
@@ -96,6 +100,12 @@ class DeterministicRuntimeBus:
                 content_delta=delta,
             ))
             await asyncio.sleep(0.001)
+        await self.events.emit(TurnOutputCompleted(
+            session_key=message.session_key,
+            channel="web",
+            chat_id=message.chat_id,
+            turn_id=turn_id,
+        ))
 
         # 3. Deliver the authoritative terminal frame through the registered channel callback.
         if self.outbound is None:
@@ -105,6 +115,7 @@ class DeterministicRuntimeBus:
             chat_id=message.chat_id,
             content=answer,
             thinking=assistant["reasoning_content"],
+            control_turn_id=turn_id,
         ))
 
 

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -763,7 +763,7 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
         session_key="web:abc",
         channel="web",
         chat_id="abc",
-        turn_id="turn:server-owner",
+        turn_id="attempt-1",
         client_message_id="client-1",
     ))
     await channel._on_response(OutboundMessage(

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -11,6 +12,7 @@ from starlette.websockets import WebSocketState
 
 from bootstrap.chat_api import create_chat_app
 from bus.events import OutboundMessage
+from bus.events_lifecycle import StreamDeltaReady, TurnOutputCompleted, TurnStarted
 from infra.channels.base import AttachmentStore
 from infra.channels.web_chat_channel import UploadTooLargeError, WebChatChannel
 from session.manager import Session
@@ -732,3 +734,66 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
         }
     ]
     assert channel.has_media(image)
+
+
+@pytest.mark.asyncio
+async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
+    channel = WebChatChannel()
+    socket = _WebSocket()
+    channel._connections["web:abc"] = {cast(Any, socket)}
+
+    await channel._on_turn_started(TurnStarted(
+        session_key="web:abc",
+        channel="web",
+        chat_id="abc",
+        content="question",
+        timestamp=datetime.now(UTC),
+        turn_id="attempt-1",
+        control_turn_id="turn:server-owner",
+        client_message_id="client-1",
+    ))
+    await channel._on_stream_delta(StreamDeltaReady(
+        session_key="web:abc",
+        channel="web",
+        chat_id="abc",
+        turn_id="attempt-1",
+        content_delta="answer",
+    ))
+    await channel._on_output_completed(TurnOutputCompleted(
+        session_key="web:abc",
+        channel="web",
+        chat_id="abc",
+        turn_id="turn:server-owner",
+        client_message_id="client-1",
+    ))
+    await channel._on_response(OutboundMessage(
+        channel="web",
+        chat_id="abc",
+        content="answer",
+        control_turn_id="turn:server-owner",
+    ))
+
+    assert [frame["type"] for frame in socket.frames] == [
+        "turn.started",
+        "answer.delta",
+        "turn.output.completed",
+        "message.final",
+    ]
+    assert {frame["turn_id"] for frame in socket.frames} == {
+        "turn:server-owner"
+    }
+    assert "web:abc" not in channel._active_turn_ids
+
+
+@pytest.mark.asyncio
+async def test_web_turn_started_rejects_missing_server_turn_id() -> None:
+    channel = WebChatChannel()
+
+    with pytest.raises(RuntimeError, match="缺少 Server 权威 turn_id"):
+        await channel._on_turn_started(TurnStarted(
+            session_key="web:abc",
+            channel="web",
+            chat_id="abc",
+            content="question",
+            timestamp=datetime.now(UTC),
+        ))


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Web adapter 在 `turn.started` 自造时间戳 Turn ID，后续 `message.final` 使用 Server Turn ID，导致 WebUI 严格终态匹配永远失败。
- 用户可见结果：WebUI 在 Server final 到达后恢复发送态，不再依赖刷新页面。
- 本 PR 不处理：Akasha 延迟、WebSocket 重连策略及移动端协议。

## Change intent

- `change_type`：fix
- `semantic_delta`：compatible
- `capability_owner`：core
- `consumer_scope`：desktop Web adapter / WebUI
- `runtime_patch`：required
- `runtime_patch_reason`：Web adapter 必须投影 Core 已发布的 logical control Turn ID，不能生成第二套身份。
- `authoritative_state_owner`：Core Turn lifecycle
- `client_only_alternative`：拒绝；放宽客户端终态匹配会隐藏 stale/foreign frame。
- 关联不变量：同一 logical Turn 的 started/delta/output.completed/final 使用同一 Server ID。
- `protected_state`：sessions.db/messages、Mobile 协议、terminal 时序语义。
- 允许的副作用：WebSocket frame 的 turn_id 统一为 Server logical control ID。
- 禁止的副作用：数据库写入、移动端协议变化、客户端猜测 Turn identity。

## 改动范围

- 主要文件：`infra/channels/web_chat_channel.py`、`tests/test_web_chat_channel.py`、隔离性能 fixture。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `e5fe6b48`，head `0fe74acc`。
- 回滚方式：回滚本 PR；部署侧可用 `akashic-release rollback --yes`。

## 验证

- [x] `pytest -q tests/test_web_chat_channel.py`：20 passed。
- [x] Web transport/status Node tests：9 passed。
- [x] Python `py_compile` 通过。
- [x] `python docker/debug/gate.py run --base origin/main`：23/23 passed。
- `sourceDigest`：`e4f05d0acd3822f6fdac70480952f85193ce2ab3af1101522ab6c2e08775b28a`
- `planDigest`：`b52b30312e40cd84aa45415bf960be4e5a5f5f3d431d917aa508c2de5a6a7ca8`
- 真实设备证据：不适用；服务端发布后执行 LAN WebUI / WebSocket 真实验收。
- Terra xhigh 只读 Review：初审发现并关闭 control ID 与 attempt ID 分叉 P1；最终复审 no findings。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次修复既有 owner，不引入长期新语义。
- [x] 已按 MOB-001 核对；Mobile 保持不变。
- [x] 当前没有对应 NOW 条目。