### PR TITLE
fix(akasha): 按终态提交时间重放 Turn

### DIFF
--- a/docs/design/akasha-v2-runtime-migration.md
+++ b/docs/design/akasha-v2-runtime-migration.md
@@ -122,7 +122,7 @@
 一个历史 turn 是稳定原子节点。它携带原始 message 指针、user/assistant dense、
 增量 BM25 词项、时间与 burst 统计。检索先形成非负 seed，再进入同一 `MemoryCycle`：
 
-用户消息可以在上一轮 assistant 回复尚未提交时到达。v9 索引把“本轮开始时间减去
+用户消息可以在上一轮 assistant 回复尚未提交时到达。v10 索引把“本轮开始时间减去
 上一轮提交时间”保留为有符号 `response_delta_seconds`：非负部分是空闲间隔，负值的
 绝对值是回复重叠，并分别编码 `time` 与 `time_overlap` 特征。只有同一 session 的
 turn 开始时间倒序或单轮持久化跨度为负才属于源数据契约破坏；合法重叠不得阻止启动。
@@ -147,9 +147,11 @@ dense / BM25 / burst / temporal evidence
 正向关系强于反向关系；同一连接预算内，反复共同激活的关系获得份额，未共同激活关系
 相对受抑制。遗忘按事件时间与重复激活共同决定，而不是只按数据库年龄单调删除。
 
-在线与 replay 均按 `(timestamp, session_key bytes, user_seq, turn_id bytes)` 建立全局
-因果顺序。所有 set/dict 到持久化输出前都有稳定排序；重放进程固定 BLAS 线程数，
-不同 `PYTHONHASHSEED` 不得改变 canonical logical state。
+在线与 replay 均按
+`(committed_at, session_key bytes, user_seq, turn_id bytes)` 建立全局因果顺序；
+`started_at` 只保留输入开始与轮内时序证据，不允许跨 attempt 恢复把已完成 Turn
+倒插到既有记忆之前。所有 set/dict 到持久化输出前都有稳定排序；重放进程固定
+BLAS 线程数，不同 `PYTHONHASHSEED` 不得改变 canonical logical state。
 
 ## 6. 重建合同
 

--- a/migrations/yoyo/20260817_01_akasha_sparse_index_v10.py
+++ b/migrations/yoyo/20260817_01_akasha_sparse_index_v10.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import cast
+from uuid import uuid4
+
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+
+__depends__ = {"20260805_01_akasha_sparse_index_v9"}
+__transactional__ = False
+
+_LEGACY_INDEX_VERSION = "9"
+
+
+def _uses_akasha(config_path: Path) -> bool:
+    if not config_path.is_file():
+        return False
+    payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    raw_memory = payload.get("memory", {})
+    if not isinstance(raw_memory, dict):
+        raise ValueError("memory 配置必须是 table")
+    memory = cast(dict[str, object], raw_memory)
+    return memory.get("enabled") is True and memory.get("engine") == "akasha"
+
+
+def rebuild_akasha_v10(_connection: object) -> None:
+    """按终态提交顺序重建并发布 Akasha v10 派生状态。"""
+
+    # 1. 非 Akasha installation 只记录迁移回执，不加载完整 runtime。
+    current = current_migration_context()
+    if not _uses_akasha(current.config_path):
+        return
+
+    # 2. 复用公共 owner 备份并确定性重建两份 sidecar。
+    from agent.migrations.akasha_sidecar import rebuild_akasha_sidecars
+
+    backup_dir = (
+        current.workspace
+        / "backups"
+        / "akasha-sparse-index-v10"
+        / uuid4().hex
+    )
+    _ = rebuild_akasha_sidecars(
+        config_path=current.config_path,
+        workspace=current.workspace,
+        backup_dir=backup_dir,
+        accepted_versions={_LEGACY_INDEX_VERSION},
+    )
+
+
+steps = [step(rebuild_akasha_v10)]

--- a/plugins/akasha/infrastructure/loader.py
+++ b/plugins/akasha/infrastructure/loader.py
@@ -30,7 +30,7 @@ def load_turns(index_path: Path, max_turns: int | None = None) -> list[Turn]:
                    remember_targets_json, forget_targets_json,
                    remember_boost
             FROM sparse_turns
-            ORDER BY started_at, session_key, user_seq, turn_id
+            ORDER BY committed_at, session_key, user_seq, turn_id
             """).fetchall()
         rows.sort(key=_turn_sort_key)
         if max_turns is not None:
@@ -61,7 +61,7 @@ def load_turn_suffix(index_path: Path, start: int) -> list[Turn]:
                    remember_targets_json, forget_targets_json,
                    remember_boost
             FROM sparse_turns
-            ORDER BY started_at, session_key, user_seq, turn_id
+            ORDER BY committed_at, session_key, user_seq, turn_id
             """).fetchall()
         all_rows.sort(key=_turn_sort_key)
         if start > len(all_rows):
@@ -75,7 +75,7 @@ def load_turn_suffix(index_path: Path, start: int) -> list[Turn]:
     node_by_turn = {
         str(row["turn_id"]): node_id for node_id, row in enumerate(all_rows)
     }
-    previous = None if start == 0 else _as_utc(all_rows[start - 1]["started_at"])
+    previous = None if start == 0 else _as_utc(all_rows[start - 1]["committed_at"])
     return _materialize_turns(
         rows,
         dense,
@@ -203,8 +203,8 @@ def _materialize_turns(
         }
     for local_node_id, row in enumerate(rows):
         node_id = local_node_id + node_offset
-        started = _as_utc(row["started_at"])
-        gap = None if previous is None else (started - previous).total_seconds()
+        committed = _as_utc(row["committed_at"])
+        gap = None if previous is None else (committed - previous).total_seconds()
         if gap is not None and gap < 0.0:
             raise ValueError("causal turn order produced a negative gap")
         turn_id = row["turn_id"]
@@ -246,7 +246,7 @@ def _materialize_turns(
                 ),
             )
         )
-        previous = started
+        previous = committed
     return turns
 
 
@@ -274,7 +274,7 @@ def _feedback_nodes(
 
 def _turn_sort_key(row: sqlite3.Row) -> tuple[datetime, bytes, int, bytes]:
     return (
-        _as_utc(row["started_at"]),
+        _as_utc(row["committed_at"]),
         row["session_key"].encode("utf-8"),
         row["user_seq"],
         row["turn_id"].encode("utf-8"),

--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -295,7 +295,7 @@ def _load_canonical_turns(
     # 3. Establish one deterministic global causal order.
     turns.sort(
         key=lambda turn: (
-            _parse_time(turn.started_at),
+            _parse_time(turn.committed_at),
             turn.session_key.encode("utf-8"),
             turn.user_seq,
             turn.turn_id.encode("utf-8"),
@@ -890,7 +890,7 @@ def _select_new_turns(
         return turns
     last_indexed = max(
         (
-            _parse_time(row["started_at"]),
+            _parse_time(row["committed_at"]),
             row["session_key"].encode("utf-8"),
             row["user_seq"],
             row["turn_id"].encode("utf-8"),
@@ -902,7 +902,7 @@ def _select_new_turns(
         turn.turn_id
         for turn in new_turns
         if (
-            _parse_time(turn.started_at),
+            _parse_time(turn.committed_at),
             turn.session_key.encode("utf-8"),
             turn.user_seq,
             turn.turn_id.encode("utf-8"),

--- a/plugins/akasha/infrastructure/sparse_index/schema.py
+++ b/plugins/akasha/infrastructure/sparse_index/schema.py
@@ -1,6 +1,6 @@
 """SQLite schema for the derived sparse turn index."""
 
-INDEX_VERSION = "9"
+INDEX_VERSION = "10"
 
 SCHEMA = """
 PRAGMA foreign_keys = ON;

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -2161,6 +2161,105 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
     assert user_dense == pytest.approx((2 / math.sqrt(5), 1 / math.sqrt(5)))
 
 
+def test_sparse_builder_appends_resumed_turn_by_terminal_commit_time(
+    tmp_path: Path,
+) -> None:
+    """跨天恢复的 Turn 按最终提交时间追加，不按首个输入时间倒插。"""
+
+    # 1. 先建立已有高水位，再补入一个更早开始但更晚完成的 interaction。
+    sessions = tmp_path / "sessions.db"
+    index = tmp_path / "index.db"
+    _create_sessions(sessions)
+    existing_started = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    _append_turn(
+        sessions,
+        sequence=0,
+        user="existing",
+        assistant="existing answer",
+        started=existing_started,
+        session_key="test:existing",
+        with_embeddings=True,
+    )
+    config = BuildConfig(
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+    )
+    build_sparse_index(sessions, index, config)
+
+    resumed_started = datetime(2026, 8, 12, tzinfo=timezone.utc)
+    resumed_at = datetime(2026, 8, 16, tzinfo=timezone.utc)
+    rows = (
+        (
+            "resume:u1",
+            0,
+            "user",
+            "old input",
+            {"control_turn_id": "turn:resume", "turn_input_ordinal": 0},
+            resumed_started,
+        ),
+        (
+            "resume:u2",
+            1,
+            "user",
+            "current input",
+            {"control_turn_id": "turn:resume", "turn_input_ordinal": 1},
+            resumed_at,
+        ),
+        (
+            "resume:a1",
+            2,
+            "assistant",
+            "final answer",
+            {
+                "control_turn_id": "turn:resume",
+                "turn_terminal": True,
+                "turn_input_count": 2,
+            },
+            resumed_at + timedelta(seconds=10),
+        ),
+    )
+    with closing(sqlite3.connect(sessions)) as connection, connection:
+        connection.execute(
+            "INSERT INTO sessions VALUES ('test:resume', ?, ?, 0, NULL)",
+            (resumed_started.isoformat(), resumed_at.isoformat()),
+        )
+        for message_id, seq, role, content, extra, timestamp in rows:
+            connection.execute(
+                "INSERT INTO messages VALUES (?, 'test:resume', ?, ?, ?, NULL, ?, ?)",
+                (
+                    message_id,
+                    seq,
+                    role,
+                    content,
+                    json.dumps(extra),
+                    timestamp.isoformat(),
+                ),
+            )
+            connection.execute(
+                "INSERT INTO message_embeddings VALUES (?, ?, 'embedding-model', ?, 2, ?, ?)",
+                (
+                    message_id,
+                    hashlib.sha256(content.encode()).hexdigest(),
+                    sqlite3.Binary(struct.pack("<2f", 1.0, 0.0)),
+                    timestamp.isoformat(),
+                    timestamp.isoformat(),
+                ),
+            )
+
+    # 2. 增量与 replay 都把恢复 Turn 放在最终提交位置。
+    result = build_sparse_index(sessions, index, config)
+    turns = load_turns(index)
+
+    assert result.indexed_turns == 1
+    assert [turn.turn_id for turn in turns] == [
+        "test:existing:0::test:existing:1",
+        "resume:u1::resume:a1",
+    ]
+    assert turns[1].started_at == resumed_started.isoformat()
+    assert turns[1].committed_at == (resumed_at + timedelta(seconds=10)).isoformat()
+    assert turns[1].inter_gap_seconds == pytest.approx(86400.0)
+
+
 def test_sparse_builder_rejects_orphan_message_push_turn(tmp_path: Path) -> None:
     """不能把工具使用记录误当成合法的主动 Turn 身份。"""
 
@@ -2926,7 +3025,7 @@ def test_rebuild_akasha_sidecars_backs_up_and_publishes_verified_pair(
     with closing(sqlite3.connect(index_path)) as connection:
         assert connection.execute(
             "SELECT value FROM metadata WHERE key = 'index_version'"
-        ).fetchone() == ("9",)
+        ).fetchone() == ("10",)
         assert connection.execute("SELECT COUNT(*) FROM sparse_turns").fetchone() == (
             1,
         )
@@ -2937,7 +3036,7 @@ def test_rebuild_akasha_sidecars_backs_up_and_publishes_verified_pair(
     manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
     assert rebuilt
     assert graph_path.is_file()
-    assert manifest["indexVersion"] == "9"
+    assert manifest["indexVersion"] == "10"
     assert manifest["candidateMemorySha256"]
     assert hashlib.sha256(sessions_path.read_bytes()).hexdigest() == source_sha
 

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -80,6 +80,7 @@ def test_init_records_yoyo_origin_in_workspace_ledger(tmp_path: Path) -> None:
         ("20260808_05_activate_session_compaction_cursor",),
         ("20260808_03_remove_compaction_trigger",),
         ("20260808_06_retire_legacy_context_state",),
+        ("20260817_01_akasha_sparse_index_v10",),
     ]
     assert not config_path.with_name("config.toml.migration-cursor").exists()
 

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -29,6 +29,7 @@ _MODEL_REGISTRY_ID = "20260807_01_model_registry_database"
 _EMBEDDING_REGISTRY_ID = "20260807_02_embedding_model_registry"
 _MODEL_CAPABILITIES_ID = "20260808_01_restore_migrated_reasoning_efforts"
 _OPENCODE_VARIANTS_ID = "20260808_02_correct_opencode_go_variants"
+_AKASHA_V10_ID = "20260817_01_akasha_sparse_index_v10"
 _CURRENT_IDS = (
     _ORIGIN_ID,
     _AKASHA_V9_ID,
@@ -43,6 +44,7 @@ _CURRENT_IDS = (
     _CURSOR_ID,
     _CONFIG_ID,
     _RETIRE_ID,
+    _AKASHA_V10_ID,
 )
 _CURRENT_LEDGER_IDS = tuple(sorted(_CURRENT_IDS))
 
@@ -667,6 +669,7 @@ api_key = "secret"
         _CURSOR_ID,
         _CONFIG_ID,
         _RETIRE_ID,
+        _AKASHA_V10_ID,
     )
     assert (
         CredentialStore.for_workspace(root / "workspace").api_key("model_deepseek_main")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：跨 attempt 恢复的 Turn 可能很早开始、很晚才终态提交；Akasha 以 started_at 维护增量高水位时会把该 Turn 判为历史倒插并抛出 AppendOnlyViolation。
- 用户可见结果：恢复完成的 Turn 按服务端终态提交时间进入 Akasha 因果流，移动端右脑召回不再因索引启动失败而空白。
- 本 PR 不处理：不改变消息正文、Turn 身份、WebUI 生命周期协议或轮内 started_at 时序证据。

## Change intent

- `change_type`：`fix` + `migration`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：Akasha sparse index、graph replay 和所有只读 recall 消费者
- `runtime_patch`：`required`
- `runtime_patch_reason`：排序与增量高水位位于服务端 Akasha 派生状态 owner
- `authoritative_state_owner`：sessions.db/messages 与服务端终态提交记录；Akasha sidecar 仅为可重建投影
- `client_only_alternative`：无；客户端无法修正服务端派生索引顺序
- 关联不变量：同一已完成 Turn 只投影一次；全局因果顺序单调；started_at 继续保留真实输入开始时间
- `protected_state`：sessions.db/messages 只追加正文、Turn 身份、原始时间戳
- 允许的副作用：备份 v9 sidecar，确定性重建并原子发布 v10 sidecar
- 禁止的副作用：UPDATE/DELETE 消息正文、修改正式 workspace 的权威会话事实、静默跳过重建错误

## 改动范围

- 主要文件：Akasha builder/loader/schema、v10 yoyo migration、回归测试和运行设计文档
- 配置或迁移影响：启用 Akasha 的 installation 启动时从 v9 全量 replay 到 v10；迁移为非事务型，sidecar 由共享 migration owner 备份并原子发布
- 已知 schema lineage 与最终 schema identity：v9 -> v10；SQLite 表结构不变，metadata.index_version=10，排序语义改为 committed_at
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source 5d28e9b4；不涉及客户端/provider 协议变化；Gate 报告 20260817-022900-c01ad1bd
- 回滚方式：回退本提交，并从 workspace/backups/akasha-sparse-index-v10/<run-id> 恢复成对 sidecar；sessions.db 不需要回滚

## 验证

- [x] 相关 targeted tests 已通过。
- [x] Python 静态编译与远端 pyright 已通过；仓库本地环境未安装 ruff，未以 fallback 掩盖。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`3c6dbf63e38e532f5b27d237fa5816d4976052a630ec80d657789d9ab9671377`
- `planDigest`：`9a39dd677c842531fb1d0d30c5e6784339427c535f9bfb9462147fe4f6ccfd12`
- 真实设备证据：不适用；本 PR 不修改移动端，合并后在 hua-home 真实 workspace replay 并验证公网 WebSocket 与召回投影
- 未运行项与原因：本地 ruff 未安装；targeted tests 67 passed，Gate 23 scenarios passed。首轮远端全量测试 3300 passed、1 个迁移账本预期失败；已补齐该精确预期并触发重跑。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 终态提交时间作为因果顺序已由维护者确认，并同步设计文档。
- [x] 已按 MOB-001 核对：权威 owner 在服务端 Akasha 派生索引，移动端仅消费结果。
- [x] 当前没有对应 NOW 事项，不适用。
