### PR TITLE
fix(release): 统一 Core readiness 等待预算

### DIFF
--- a/docs/design/linux-supervisor-safe-self-restart.md
+++ b/docs/design/linux-supervisor-safe-self-restart.md
@@ -111,6 +111,11 @@ run_supervisor()
 
 改造不能简单把 15 改成更大的拍脑袋数字。Gateway 应发送阶段事件，Supervisor 使用一个不可续期的总体硬 deadline，并在失败时报告最后阶段与耗时。默认值由改造前后的同机冷启动/热启动 profile 确定，而不是由阶段事件不断续命。
 
+发布验证不得另设更短的固定 deadline。Core 初始化、Docker health `start_period` 与
+release doctor 共同使用 `AKASHIC_READINESS_TIMEOUT_S`；doctor 只增加固定的 health
+probe 收敛余量。这样长 migration/replay 仍受同一个不可续期硬上限约束，不会被第二个
+owner 提前停止。
+
 ### 4.4 生命周期清理依赖 Supervisor 存活
 
 当前清理会按 `AKASHIC_BOOT_ID` 扫描 `/proc/*/environ`，对找到的进程组先 TERM、再 KILL，并验证目标消失。这能处理 Supervisor 存活时的 Gateway 异常，但 Supervisor 被 SIGKILL 后没有仍存活的清理 owner；MCP 或 managed service 可能继续占用端口。

--- a/scripts/akashic_release/doctor.py
+++ b/scripts/akashic_release/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import math
 import subprocess
 from pathlib import Path
 from typing import Callable, Mapping
@@ -11,6 +12,9 @@ from scripts.verify_host_runtime_deployment import verify_deployment_image
 from scripts.verify_host_runtime_deployment import verify_host_toolchain_deployment
 
 Run = Callable[..., subprocess.CompletedProcess[str]]
+
+_DEFAULT_READINESS_TIMEOUT_SECONDS = 120.0
+_HEALTH_PROBE_GRACE_SECONDS = 60.0
 
 
 def read_environment(path: Path) -> dict[str, str]:
@@ -56,7 +60,23 @@ def probe_bridge(
     )
 
 
-def verify_release(environment_file: Path, *, health_timeout_sec: float = 180) -> None:
+def release_health_timeout(environment: Mapping[str, str]) -> float:
+    """Derive the release health deadline from the Core readiness owner."""
+
+    raw_timeout = environment.get(
+        "AKASHIC_READINESS_TIMEOUT_S",
+        str(_DEFAULT_READINESS_TIMEOUT_SECONDS),
+    )
+    try:
+        readiness_timeout = float(raw_timeout)
+    except ValueError as error:
+        raise RuntimeError("AKASHIC_READINESS_TIMEOUT_S 必须是正数") from error
+    if not math.isfinite(readiness_timeout) or readiness_timeout <= 0:
+        raise RuntimeError("AKASHIC_READINESS_TIMEOUT_S 必须是正数")
+    return readiness_timeout + _HEALTH_PROBE_GRACE_SECONDS
+
+
+def verify_release(environment_file: Path) -> None:
     """Verify manifest, host identity, Bridge RPC, and Core health."""
 
     environment = read_environment(environment_file)
@@ -74,7 +94,10 @@ def verify_release(environment_file: Path, *, health_timeout_sec: float = 180) -
         environment["AKASHIC_HOST_TOOLCHAIN_DIGEST"],
     )
     probe_bridge(environment, environment_file=environment_file)
-    wait_for_core_health(environment["AKASHIC_CONTAINER_NAME"], health_timeout_sec)
+    wait_for_core_health(
+        environment["AKASHIC_CONTAINER_NAME"],
+        release_health_timeout(environment),
+    )
 
 
 async def _inspect_bridge(environment: Mapping[str, str]) -> dict[str, object]:

--- a/tests/test_akashic_release_installer.py
+++ b/tests/test_akashic_release_installer.py
@@ -15,6 +15,7 @@ from scripts.akashic_release.activate import activate_release, render_environmen
 from scripts.akashic_release.activate import release_environment
 from scripts.akashic_release.bridge import prepare_bridge_venv
 from scripts.akashic_release.doctor import probe_bridge, read_environment
+from scripts.akashic_release.doctor import release_health_timeout
 from scripts.akashic_release.manifest import read_json, release_lock, write_json
 from scripts.akashic_release.migrate import migration_plan
 from scripts.akashic_release.model import ReleasePaths
@@ -218,6 +219,17 @@ def test_bridge_probe_uses_generation_python_without_secret_arguments(
         )
     ]
     assert "must-not-enter-argv" not in " ".join(calls[0][0])
+
+
+def test_release_health_timeout_uses_core_readiness_owner() -> None:
+    assert release_health_timeout({}) == 180.0
+    assert release_health_timeout({"AKASHIC_READINESS_TIMEOUT_S": "1800"}) == 1860.0
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "infinity", "invalid"])
+def test_release_health_timeout_rejects_invalid_config(value: str) -> None:
+    with pytest.raises(RuntimeError, match="必须是正数"):
+        release_health_timeout({"AKASHIC_READINESS_TIMEOUT_S": value})
 
 
 def test_activation_failure_atomically_restores_previous_environment(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：release doctor 固定 180 秒等待 Core healthy，会把仍在合法 yoyo migration/replay、health 状态为 starting 的 Core 提前停止；回滚验证也会被同一错误窗口截断并进入 maintenance。
- 用户可见结果：发布验证与 Core 初始化、Docker health start_period 共用 AKASHIC_READINESS_TIMEOUT_S；长 migration 仍受单一不可续期硬上限约束，不再被第二套 180 秒 owner 提前终止。
- 本 PR 不处理：不延长正在运行的 deadline、不吞掉 unhealthy/inspect/配置错误、不改变 migration 或业务数据。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：hua-home release installer/doctor 与 rollback verification
- `runtime_patch`：`required`
- `runtime_patch_reason`：错误位于服务端发布生命周期 owner
- `authoritative_state_owner`：AKASHIC_READINESS_TIMEOUT_S 是 Core 启动 readiness 唯一预算 owner
- `client_only_alternative`：无
- 关联不变量：一个启动只有一个不可续期 readiness deadline；unhealthy 仍立即失败；配置非法 fail-fast
- `protected_state`：正式 workspace、migration ledger、消息与 sidecar
- 允许的副作用：release doctor 比原固定 180 秒等待更久，最长为 readiness 配置加 60 秒探针余量
- 禁止的副作用：自动续期、无限等待、忽略 unhealthy、修改业务数据

## 改动范围

- 主要文件：scripts/akashic_release/doctor.py、对应 installer tests、Supervisor 设计说明
- 配置或迁移影响：不新增配置；复用现有 AKASHIC_READINESS_TIMEOUT_S
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：source 16598178；Gate 20260817-025804-afe8e426
- 回滚方式：回退本提交，doctor 恢复固定 180 秒；不涉及持久数据恢复

## 验证

- [x] 相关 targeted tests 已通过：31 passed。
- [x] Python py_compile 已通过；本地环境未安装 ruff。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，23 scenarios passed。
- `sourceDigest`：`4be9f6d1369ca64cd9dc69d2ee7491030e4535cd173e79299d44faedc34ad108`
- `planDigest`：`fcfeda3f141f13f4ef78bf43baa60fc3500ce53439dc1c2a05be13633885d6b1`
- 真实设备证据：不适用；合并后在 hua-home 真实长 migration/replay 验证
- 未运行项与原因：本地 ruff 未安装

## 工作手册

- [x] 已核对相关设计与真实发布日志。
- [x] 长 migration 使用单一物理 deadline 的语义已由维护者确认。
- [x] 跨客户端能力 owner 不适用。
- [x] 当前没有对应 NOW 事项。
