### PR TITLE
fix(web): 解耦 WebSocket 生命周期并补投终态帧，消除断线丢消息

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ lme_error_log_*.txt
 *.migration-lock
 *.migration-backups/
 /docs/spark/
+
+# Codex 运行期自动备份目录（不进版本库，避免干扰 change-gate 审计）
+.codex-backup-*/

--- a/bootstrap/web_shell.py
+++ b/bootstrap/web_shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import stat
 from collections.abc import Callable
 from contextlib import suppress
@@ -40,6 +41,8 @@ _RESPONSE_HEADERS_ALLOWED = {
     "etag",
     "last-modified",
 }
+
+logger = logging.getLogger(__name__)
 
 
 def create_web_shell_app(
@@ -181,6 +184,7 @@ async def _proxy_http(
 
     # 1. Refuse stale or unavailable runtimes with an explicit readiness result.
     if not _is_socket(socket_path):
+        logger.warning("[web_shell.proxy] http backend unavailable socket=%s target=%s", socket_path, target_path)
         return _runtime_unavailable()
     client = httpx.AsyncClient(
         transport=httpx.AsyncHTTPTransport(uds=str(socket_path)),
@@ -197,6 +201,7 @@ async def _proxy_http(
 
     # 2. Stream request and response bodies without turning attachments into RAM copies.
     try:
+        logger.debug("[web_shell.proxy] http relay start socket=%s target=%s method=%s", socket_path, target_path, request.method)
         upstream_request = client.build_request(
             request.method,
             target,
@@ -234,10 +239,19 @@ async def _proxy_websocket(
 
     # 1. Reject before accepting when no Gateway owns the runtime socket.
     if not _is_socket(socket_path):
+        logger.warning("[web_shell.proxy] ws reject, upstream unavailable socket=%s target=%s", socket_path, target_path)
         await websocket.close(code=1013, reason="Gateway 尚未就绪")
         return
     origin = websocket.headers.get("origin")
+    websocket_id = f"ws-{id(websocket):x}"
     try:
+        logger.debug(
+            "[web_shell.proxy] ws connect start ws_id=%s socket=%s target=%s origin=%s",
+            websocket_id,
+            socket_path,
+            target_path,
+            origin,
+        )
         async with websockets.unix_connect(
             str(socket_path),
             uri=f"ws://akashic-runtime{target_path}",
@@ -245,6 +259,7 @@ async def _proxy_websocket(
             max_size=None,
         ) as upstream:
             await websocket.accept()
+            logger.info("[web_shell.proxy] ws connected ws_id=%s socket=%s target=%s", websocket_id, socket_path, target_path)
 
             # 2. Stop both directions as soon as either peer disconnects.
             browser_to_gateway = asyncio.create_task(
@@ -263,8 +278,29 @@ async def _proxy_websocket(
                 with suppress(asyncio.CancelledError):
                     await task
             for task in done:
-                task.result()
-    except (OSError, websockets.WebSocketException):
+                task_name = "browser->gateway" if task is browser_to_gateway else "gateway->browser"
+                exception = task.exception()
+                if exception is not None:
+                    logger.warning(
+                        "[web_shell.proxy] ws task failed ws_id=%s task=%s err=%r",
+                        websocket_id,
+                        task_name,
+                        exception,
+                    )
+            logger.info(
+                "[web_shell.proxy] ws flow complete ws_id=%s socket=%s target=%s",
+                websocket_id,
+                socket_path,
+                target_path,
+            )
+    except (OSError, websockets.WebSocketException) as error:
+        logger.warning(
+            "[web_shell.proxy] ws connect/relay failed ws_id=%s socket=%s target=%s err=%r",
+            websocket_id,
+            socket_path,
+            target_path,
+            error,
+        )
         with suppress(RuntimeError):
             await websocket.close(code=1013, reason="Gateway 连接不可用")
 
@@ -274,25 +310,42 @@ async def _relay_browser_messages(
     upstream: ClientConnection,
 ) -> None:
     while True:
-        message = await websocket.receive()
+        try:
+            message = await websocket.receive()
+        except Exception as error:
+            logger.debug("[web_shell.proxy] browser->gateway receive failed ws=%s err=%r", f"ws-{id(websocket):x}", error)
+            raise
         if message["type"] == "websocket.disconnect":
+            logger.info("[web_shell.proxy] browser->gateway disconnect ws=%s", f"ws-{id(websocket):x}")
             await upstream.close()
             return
         if message.get("text") is not None:
             await upstream.send(message["text"])
-        elif message.get("bytes") is not None:
+            continue
+        if message.get("bytes") is not None:
             await upstream.send(message["bytes"])
+            continue
+        logger.debug(
+            "[web_shell.proxy] browser->gateway unsupported frame ws=%s type=%s",
+            f"ws-{id(websocket):x}",
+            message["type"],
+        )
 
 
 async def _relay_gateway_messages(
     upstream: ClientConnection,
     websocket: WebSocket,
 ) -> None:
-    async for message in upstream:
-        if isinstance(message, str):
-            await websocket.send_text(message)
-        else:
-            await websocket.send_bytes(message)
+    try:
+        async for message in upstream:
+            if isinstance(message, str):
+                await websocket.send_text(message)
+            else:
+                await websocket.send_bytes(message)
+    except Exception as error:
+        logger.debug("[web_shell.proxy] gateway->browser closed ws=%s err=%r", f"ws-{id(websocket):x}", error)
+        raise
+    logger.debug("[web_shell.proxy] gateway->browser stream closed ws=%s", f"ws-{id(websocket):x}")
 
 
 def _is_socket(path: Path) -> bool:

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -667,6 +667,13 @@ class MessageBus:
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """将 Agent 输出交给对应渠道发送（fire-and-forget）。"""
+        logger.debug(
+            "[bus] publish_outbound channel=%s chat=%s has_control_turn=%s queue=%d",
+            msg.channel,
+            msg.chat_id,
+            bool(msg.control_turn_id),
+            self._outbound.qsize(),
+        )
         await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
         try:
             self._outbound.put_nowait(msg)
@@ -687,6 +694,13 @@ class MessageBus:
 
         if self._outbound_dispatch_stopped:
             return False
+        logger.debug(
+            "[bus] publish_outbound_awaited channel=%s chat=%s control_turn=%s queue=%d",
+            msg.channel,
+            msg.chat_id,
+            msg.control_turn_id,
+            self._outbound.qsize(),
+        )
         future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
         await self._chat_lane.mark_passive_send_pending(msg.channel, msg.chat_id)
         try:
@@ -748,6 +762,14 @@ class MessageBus:
                 else:
                     msg = item
                 in_flight_receipt = receipt
+                logger.debug(
+                    "[bus] dispatch_outbound channel=%s chat=%s awaited=%s callbacks=%d queue=%d",
+                    msg.channel,
+                    msg.chat_id,
+                    receipt is not None,
+                    len(self._subscribers.get(msg.channel, ())),
+                    self._outbound.qsize(),
+                )
                 delivered = await self._chat_lane.run_passive(
                     msg.channel,
                     msg.chat_id,
@@ -779,10 +801,32 @@ class MessageBus:
         """
 
         callbacks = tuple(self._subscribers.get(msg.channel, []))
+        if not callbacks:
+            logger.warning(
+                "[bus] 分发消息到 %s 无订阅者: chat=%s control_turn=%s",
+                msg.channel,
+                msg.chat_id,
+                msg.control_turn_id,
+            )
+            return False
         delivered = bool(callbacks)
         for cb in callbacks:
+            callback_name = getattr(cb, "__qualname__", None) or str(cb)
             try:
+                logger.debug(
+                    "[bus] send_outbound start channel=%s chat=%s callback=%s turn=%s",
+                    msg.channel,
+                    msg.chat_id,
+                    callback_name,
+                    msg.control_turn_id,
+                )
                 await cb(msg)
+                logger.debug(
+                    "[bus] send_outbound success channel=%s chat=%s callback=%s",
+                    msg.channel,
+                    msg.chat_id,
+                    callback_name,
+                )
             except Exception as first_err:
                 logger.warning(
                     "分发消息到 %s 首次失败，%.1fs 后重试: %s",
@@ -796,7 +840,11 @@ class MessageBus:
                 except Exception as second_err:
                     delivered = False
                     logger.error(
-                        f"分发消息到 {msg.channel} 重试仍失败，发送降级通知: {second_err}"
+                        "[bus] 分发消息到 %s 重试仍失败，发送降级通知 chat=%s turn=%s: %s",
+                        msg.channel,
+                        msg.chat_id,
+                        msg.control_turn_id,
+                        second_err,
                     )
                     if not fallback_allowed:
                         continue
@@ -806,11 +854,22 @@ class MessageBus:
                         content="（消息发送失败，请稍后重试）",
                     )
                     try:
+                        logger.debug(
+                            "[bus] send_outbound fallback send channel=%s chat=%s",
+                            msg.channel,
+                            msg.chat_id,
+                        )
                         await cb(fallback)
+                        logger.debug(
+                            "[bus] send_outbound fallback success channel=%s chat=%s",
+                            msg.channel,
+                            msg.chat_id,
+                        )
                     except Exception:
                         logger.error(
-                            f"降级通知也失败，消息彻底丢失  channel={msg.channel} "
-                            f"chat_id={msg.chat_id}"
+                            "[bus] 降级通知也失败，消息彻底丢失 channel=%s chat=%s",
+                            msg.channel,
+                            msg.chat_id,
                         )
         return delivered
 

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -80,6 +80,9 @@ export function useDesktopChatController() {
   const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("");
   const [modelSelectionDirty, setModelSelectionDirty] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<number | null>(null);
+  const reconnectAttemptRef = useRef(0);
+  const connectRef = useRef<(() => WebSocket) | null>(null);
   const messageElementsRef = useRef(new Map<string, HTMLDivElement>());
   const activeSessionRef = useRef("");
   const statusRef = useRef<ChatStatus>("idle");
@@ -215,6 +218,22 @@ export function useDesktopChatController() {
     return () => window.removeEventListener("message", handleModelsChanged);
   }, [loadModels, reportError]);
 
+  const scheduleReconnect = useCallback(() => {
+    if (reconnectTimerRef.current !== null) return;
+    const attempt = reconnectAttemptRef.current;
+    if (attempt >= 12) {
+      reportError(new Error("聊天连接已断开，请刷新页面重试"), "error");
+      return;
+    }
+    const ceiling = Math.min(1000 * 2 ** attempt, 30000);
+    const delay = Math.floor(Math.random() * ceiling);
+    reconnectAttemptRef.current += 1;
+    reconnectTimerRef.current = window.setTimeout(() => {
+      reconnectTimerRef.current = null;
+      if (!socketRef.current) connectRef.current?.();
+    }, delay);
+  }, [reportError]);
+
   const connect = useCallback(() => {
     const current = socketRef.current;
     if (current && current.readyState <= WebSocket.OPEN) {
@@ -222,9 +241,11 @@ export function useDesktopChatController() {
     }
     const protocol = window.location.protocol === "https:" ? "wss" : "ws";
     const socket = new WebSocket(`${protocol}://${window.location.host}/ws`);
+    console.info("[chat-ui] ws open", socket.url);
     socketRef.current = socket;
     socket.onmessage = (event) => {
       if (socketRef.current !== socket) return;
+      console.debug("[chat-ui] ws message", typeof event.data);
       try {
         const frame = parseChatFrame(JSON.parse(String(event.data)));
         const traceKind = traceKindForChatFrame(frame);
@@ -250,18 +271,37 @@ export function useDesktopChatController() {
         reportError(error, "error");
       }
     };
+    socket.onopen = () => {
+      console.info("[chat-ui] ws connected", socket.url);
+      reconnectAttemptRef.current = 0;
+      const attachSessionId = activeSessionRef.current;
+      if (attachSessionId) {
+        console.debug("[chat-ui] ws attach", { sessionId: attachSessionId });
+        socket.send(JSON.stringify({
+          type: "session.attach",
+          request_id: createUuid(),
+          session_id: attachSessionId,
+        }));
+      }
+    };
     socket.onerror = () => {
-      if (socketRef.current === socket) reportError(new Error("聊天连接失败"), "error");
+      if (socketRef.current === socket) socket.close();
     };
     socket.onclose = (event) => {
       if (socketRef.current !== socket) return;
+      console.warn("[chat-ui] ws close", { code: event.code, reason: event.reason });
       socketRef.current = null;
-      if (event.code !== 1000 || statusRef.current !== "idle") {
+      if (event.code !== 1000 && event.code !== 1013) {
         reportError(new Error("聊天连接已关闭"), "error");
       }
+      scheduleReconnect();
     };
     return socket;
-  }, [loadMessagesSafely, loadSessionsSafely, reportError, setMessages, setStatusLive]);
+  }, [loadMessagesSafely, loadSessionsSafely, reportError, scheduleReconnect, setMessages, setStatusLive]);
+
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   useEffect(() => {
     let active = true;
@@ -282,10 +322,21 @@ export function useDesktopChatController() {
   }, [reportError]);
 
   useEffect(() => {
+    const socket = connect();
+    return () => {
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (socketRef.current === socket) socketRef.current = null;
+      socket.close(1000, "component unmounted");
+    };
+  }, [connect]);
+
+  useEffect(() => {
     if (!chatReady) return;
     void loadSessionsSafely();
     void loadModels("").catch((error: unknown) => reportError(error));
-    const socket = connect();
     return () => {
       sessionsRequestRef.current?.abort();
       messagesRequestRef.current?.abort();
@@ -293,10 +344,8 @@ export function useDesktopChatController() {
       modelsRequestRef.current?.abort();
       sendRequestRef.current?.abort();
       stopRequestRef.current?.abort();
-      if (socketRef.current === socket) socketRef.current = null;
-      socket.close(1000, "component unmounted");
     };
-  }, [chatReady, connect, loadModels, loadSessionsSafely, reportError]);
+  }, [chatReady, loadModels, loadSessionsSafely, reportError]);
 
   useEffect(() => {
     if (!chatReady) return;
@@ -329,6 +378,11 @@ export function useDesktopChatController() {
     const reply = replyTarget;
     try {
       const sessionId = await ensureSession();
+      console.info("[chat-ui] sendMessage", {
+        sessionId,
+        textLength: cleanText.length,
+        files: files.length,
+      });
       const media = await uploadFiles(files, controller.signal);
       const attachments = media.map((item) => uploadedFileToAttachment(item));
       setMessages((current) => [
@@ -361,6 +415,7 @@ export function useDesktopChatController() {
         payload.model_reasoning_effort = selectedReasoningEffort;
       }
       await sendWhenOpen(connect(), payload, controller.signal);
+      console.debug("[chat-ui] send frame delivered", { sessionId });
       setModelSelectionDirty(false);
       setReplyTarget(null);
     } catch (error) {
@@ -394,7 +449,10 @@ export function useDesktopChatController() {
       request_id: createUuid(),
       session_id: activeSessionId,
     }, controller.signal)
-      .then(() => setStatus("idle"))
+      .then(() => {
+        console.debug("[chat-ui] turn.stop acknowledged", { activeSessionId });
+        setStatus("idle");
+      })
       .catch((error: unknown) => reportError(error, "error"))
       .finally(() => {
         if (stopRequestRef.current === controller) stopRequestRef.current = null;

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -12,11 +12,13 @@ test("WebSocket boundary validates every frame family and observable trace lane"
   const thinking = parseChatFrame({ type: "react.thinking.delta", session_id: "one", turn_id: "turn", delta: "思" });
   const answer = parseChatFrame({ type: "answer.delta", session_id: "one", turn_id: "turn", delta: "答" });
   const terminal = parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "答案", duration_ms: 42 });
+  const terminalFromString = parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "答案", duration_ms: "42" });
   assert.equal(traceKindForChatFrame(thinking), "thinking");
   assert.equal(traceKindForChatFrame(answer), "answer");
   assert.equal(traceKindForChatFrame(terminal), "terminal");
+  assert.equal(terminalFromString.duration_ms, 42);
   assert.throws(() => parseChatFrame({ type: "answer.delta", session_id: "one" }), /缺少字符串字段: turn_id/u);
-  assert.throws(() => parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "x", duration_ms: "42" }), /duration_ms 格式无效/u);
+  assert.throws(() => parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "x", duration_ms: "42ms" }), /duration_ms 格式无效/u);
   assert.throws(() => parseChatFrame({ type: "future.frame" }), /未知消息类型/u);
 });
 

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -236,7 +236,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     void context.loadSessions();
     return;
   }
-const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
+  const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
   if (isActiveTerminal) {
     context.setStatus("idle");
     context.setActiveTurnId(null);

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -30,6 +30,15 @@ export interface WebChatFrameContext {
   loadMessages: (sessionId: string) => Promise<void>;
 }
 
+function parseDurationMs(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+
+  const normalized = Number(value.trim());
+  if (!Number.isFinite(normalized)) return null;
+  return normalized;
+}
+
 export function parseChatFrame(value: unknown): ChatFrame {
   const frame = recordValue(value);
   if (!frame || typeof frame.type !== "string") throw new Error("WebSocket 返回了无效消息");
@@ -58,8 +67,20 @@ export function parseChatFrame(value: unknown): ChatFrame {
       if (frame.media !== undefined && (!Array.isArray(frame.media) || frame.media.some((item) => typeof item !== "string"))) {
         throw new Error("message.final.media 格式无效");
       }
-      if (frame.duration_ms !== undefined && (typeof frame.duration_ms !== "number" || !Number.isFinite(frame.duration_ms))) {
-        throw new Error("message.final.duration_ms 格式无效");
+      if (frame.duration_ms !== undefined) {
+        const durationMs = parseDurationMs(frame.duration_ms);
+        if (durationMs === null) {
+          console.debug(
+            "[chat-transport] message.final duration invalid",
+            {
+              session_id: frame.session_id,
+              turn_id: frame.turn_id,
+              duration_ms: frame.duration_ms,
+            },
+          );
+          throw new Error("message.final.duration_ms 格式无效");
+        }
+        frame.duration_ms = durationMs;
       }
       if (frame.metadata !== undefined && !recordValue(frame.metadata)) throw new Error("message.final.metadata 格式无效");
       break;
@@ -92,25 +113,43 @@ export function traceKindForChatFrame(frame: ChatFrame): WebTurnTraceKind | unde
 }
 
 export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): void {
+  console.debug("[chat-transport] apply frame", {
+    type: frame.type,
+    session_id: "session_id" in frame ? frame.session_id : undefined,
+    turn_id: "turn_id" in frame ? frame.turn_id : undefined,
+  });
   if (frame.type === "session.created") {
     context.activateSession(frame.session_id);
     return;
   }
   if (frame.type === "error") {
+    console.debug("[chat-transport] error frame", frame.message);
     context.setError(frame.message);
     context.setStatus("error");
     return;
   }
   if (!("session_id" in frame)) return;
-  if (context.activeSessionId() && frame.session_id !== context.activeSessionId()) return;
+  if (context.activeSessionId() && frame.session_id !== context.activeSessionId()) {
+    console.debug("[chat-transport] skip frame for inactive session", {
+      type: frame.type,
+      frameSessionId: frame.session_id,
+      activeSessionId: context.activeSessionId(),
+    });
+    return;
+  }
 
   if (frame.type === "turn.interrupted") {
+    console.debug("[chat-transport] turn.interrupted", {
+      status: frame.status,
+      message: frame.message,
+    });
     context.setError(frame.status === "idle" ? frame.message : "");
     context.setStatus("idle");
     context.setActiveTurnId(null);
     return;
   }
   if (frame.type === "turn.started") {
+    console.debug("[chat-transport] turn.started", { turn_id: frame.turn_id });
     context.setStatus("streaming");
     context.setActiveTurnId(frame.turn_id);
     context.setMessages((messages) => [...messages, {
@@ -160,6 +199,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     return;
   }
   if (frame.type === "answer.delta") {
+    console.debug("[chat-transport] answer.delta", { turn_id: frame.turn_id });
     context.setMessages((messages) => updateLastAssistant(messages, (message) => ({
       ...message,
       content: message.content + frame.delta,
@@ -182,6 +222,10 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   if (frame.type !== "message.final") return;
 
   if (frame.metadata?.source === "message_push") {
+    console.debug("[chat-transport] message_push final", {
+      session_id: frame.session_id,
+      turn_id: frame.turn_id,
+    });
     context.setMessages((messages) => updateLastAssistant(messages, (message) => ({
       ...message,
       content: message.content || frame.content,
@@ -192,7 +236,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     void context.loadSessions();
     return;
   }
-  const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
+const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
   if (isActiveTerminal) {
     context.setStatus("idle");
     context.setActiveTurnId(null);

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -40,6 +40,27 @@ class UploadTooLargeError(ValueError):
     """上传内容超过单文件上限。"""
 
 
+def _coerce_turn_duration_ms(metadata: dict[str, Any]) -> int | None:
+    """把通道 metadata 中的 turn_duration_ms 归一化为整数毫秒。"""
+
+    raw_duration_ms = metadata.pop("turn_duration_ms", None)
+    if raw_duration_ms is None or isinstance(raw_duration_ms, bool):
+        return None
+    if isinstance(raw_duration_ms, int):
+        return raw_duration_ms
+    if isinstance(raw_duration_ms, float):
+        return int(raw_duration_ms)
+    if isinstance(raw_duration_ms, str):
+        try:
+            return int(float(raw_duration_ms.strip()))
+        except ValueError:
+            logger.warning("message.final turn_duration_ms 非法: type=string value=%r", raw_duration_ms)
+            return None
+
+    logger.warning("message.final turn_duration_ms 非法: type=%s value=%r", type(raw_duration_ms).__name__, raw_duration_ms)
+    return None
+
+
 class WebChatChannel:
     def __init__(self, channel_name: str = "web") -> None:
         self.name = channel_name
@@ -47,6 +68,7 @@ class WebChatChannel:
         self._attachments: AttachmentStore | None = None
         self._connections: dict[str, set[WebSocket]] = {}
         self._active_turn_ids: dict[str, str] = {}
+        self._pending_terminal: dict[str, dict[str, Any]] = {}
         self._media_paths: set[str] = set()
         self._connection_lock = asyncio.Lock()
         self._events_bound = False
@@ -70,6 +92,13 @@ class WebChatChannel:
             deliver=self._deliver_message,
         )
 
+    @staticmethod
+    def _socket_id(websocket: WebSocket) -> str:
+        return f"ws-{id(websocket):x}"
+
+    def _connection_count(self, session_key: str) -> int:
+        return len(self._connections.get(session_key, set()))
+
     def bind_attachment_store(self, store: AttachmentStore) -> None:
         """在 channel 启动前为独立 Chat API 绑定显式附件目录。"""
 
@@ -89,6 +118,8 @@ class WebChatChannel:
                 await socket.close()
 
     async def handle_websocket(self, websocket: WebSocket) -> None:
+        socket_id = self._socket_id(websocket)
+        logger.info("[web_chat] websocket opened id=%s", socket_id)
         await websocket.accept()
         session_keys: set[str] = set()
         try:
@@ -103,10 +134,21 @@ class WebChatChannel:
                 )
                 if session_key:
                     session_keys.add(session_key)
-        except WebSocketDisconnect:
-            pass
+                logger.debug(
+                    "[web_chat] frame done socket=%s has_session=%s",
+                    socket_id,
+                    bool(session_key),
+                )
+        except WebSocketDisconnect as error:
+            logger.info(
+                "[web_chat] websocket disconnect id=%s code=%s reason=%s",
+                socket_id,
+                error.code,
+                error.reason,
+            )
         finally:
             await self._remove_connection(websocket, session_keys)
+            logger.info("[web_chat] websocket closed id=%s", socket_id)
 
     def save_upload(self, data: bytes, filename: str) -> dict[str, str]:
         if len(data) > MAX_UPLOAD_BYTES:
@@ -257,24 +299,64 @@ class WebChatChannel:
         turn_id = message.control_turn_id or (
             self._current_turn_id(session_key) if passive else ""
         )
-        delivered = await self._broadcast(session_key, {
+        frame = {
             "type": "message.final",
             "session_id": session_key,
             "turn_id": turn_id,
             "content": message.content,
             "thinking": message.thinking or "",
             "media": media,
-            "duration_ms": metadata.get("turn_duration_ms"),
             "metadata": metadata,
-        })
-        if delivered == 0:
-            return DeliveryReceipt(
-                DeliveryStatus.FAILED,
-                detail="Web 会话没有可用连接",
+        }
+        duration_ms = _coerce_turn_duration_ms(metadata)
+        if duration_ms is not None:
+            frame["duration_ms"] = duration_ms
+
+        logger.debug(
+            "[web_chat] deliver_message session=%s type=%s source=%s",
+            session_key,
+            frame["type"],
+            frame["metadata"].get("source"),
+        )
+        logger.debug(
+            "[web_chat] deliver_message duration_present=%s duration_ms=%s",
+            "duration_ms" in frame,
+            frame.get("duration_ms"),
+        )
+        delivered = await self._broadcast(session_key, frame)
+        if delivered > 0:
+            _ = self._pending_terminal.pop(session_key, None)
+            logger.debug(
+                "[web_chat] deliver_message done session=%s turn=%s delivered=%s",
+                session_key,
+                frame["turn_id"],
+                delivered,
             )
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS,
+                canonical_media=tuple(media),
+            )
+        if message.control_turn_id:
+            # turn 终态帧：当前无连接时不判失败，缓存并由后续绑定连接补投，
+            # 避免前端在 socket 复位后永远等不到 message.final。
+            self._pending_terminal[session_key] = frame
+            logger.info(
+                "[web_chat] 终态帧已缓存待补投 session=%s turn=%s",
+                session_key,
+                frame["turn_id"],
+            )
+            return DeliveryReceipt(
+                DeliveryStatus.SUCCESS,
+                canonical_media=tuple(media),
+            )
+        logger.warning(
+            "[web_chat] deliver_message failed no socket session=%s turn=%s",
+            session_key,
+            frame["turn_id"],
+        )
         return DeliveryReceipt(
-            DeliveryStatus.SUCCESS,
-            canonical_media=tuple(media),
+            DeliveryStatus.FAILED,
+            detail="Web 会话没有可用连接",
         )
 
     async def _handle_client_frame(
@@ -284,8 +366,16 @@ class WebChatChannel:
     ) -> str:
         frame_type = str(payload.get("type") or "")
         request_id = str(payload.get("request_id") or "")
+        logger.debug(
+            "[web_chat] recv frame socket=%s type=%s request_id=%s",
+            self._socket_id(websocket),
+            frame_type,
+            request_id,
+        )
         if frame_type == "session.create":
             return await self._create_session(websocket, request_id)
+        if frame_type == "session.attach":
+            return await self._attach_session(websocket, request_id, payload)
         if frame_type == "message.send":
             return await self._send_user_message(websocket, request_id, payload)
         if frame_type == "turn.stop":
@@ -300,11 +390,36 @@ class WebChatChannel:
         chat_id = uuid4().hex
         session_key = self._session_key(chat_id)
         await self._add_connection(session_key, websocket)
+        logger.info(
+            "[web_chat] session.create session=%s socket=%s",
+            session_key,
+            self._socket_id(websocket),
+        )
         await websocket.send_json({
             "type": "session.created",
             "request_id": request_id,
             "session_id": session_key,
         })
+        return session_key
+
+    async def _attach_session(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        payload: dict[str, Any],
+    ) -> str:
+        """把已连接 socket 绑定到已知会话，并补投该会话积压的终态帧。"""
+        session_key = self._normalize_session_id(payload.get("session_id"))
+        if not session_key:
+            await self._send_error(websocket, request_id, "session_id 缺失或无效")
+            return ""
+        await self._add_connection(session_key, websocket)
+        logger.info(
+            "[web_chat] session.attach session=%s socket=%s count=%d",
+            session_key,
+            self._socket_id(websocket),
+            self._connection_count(session_key),
+        )
         return session_key
 
     async def _send_user_message(
@@ -316,6 +431,11 @@ class WebChatChannel:
         ctx = self._require_ctx()
         session_key = self._normalize_session_id(payload.get("session_id"))
         if not session_key:
+            logger.warning(
+                "[web_chat] message.send session_id 无效 session=%r socket=%s",
+                payload.get("session_id"),
+                self._socket_id(websocket),
+            )
             session_key = self._session_key(uuid4().hex)
         if "text" not in payload:
             text = ""
@@ -398,6 +518,12 @@ class WebChatChannel:
             )
         await self._add_connection(session_key, websocket)
         chat_id = self._chat_id(session_key)
+        logger.debug(
+            "[web_chat] message.send accepted session=%s chat_id=%s connection_count=%d",
+            session_key,
+            chat_id,
+            self._connection_count(session_key),
+        )
         await ctx.bus.publish_inbound(
             InboundMessage(
                 channel=self.name,
@@ -419,11 +545,21 @@ class WebChatChannel:
         ctx = self._require_ctx()
         session_key = self._normalize_session_id(payload.get("session_id"))
         if not session_key:
+            logger.warning(
+                "[web_chat] turn.stop session_id 缺失 socket=%s request_id=%s",
+                self._socket_id(websocket),
+                request_id,
+            )
             await self._send_error(websocket, request_id, "session_id 缺失或无效")
             return ""
         if ctx.interrupt_controller is None:
             await self._send_error(websocket, request_id, "当前未启用中断功能")
             return session_key
+        logger.debug(
+            "[web_chat] turn.stop request socket=%s session=%s",
+            self._socket_id(websocket),
+            session_key,
+        )
         result = ctx.interrupt_controller.request_interrupt(
             session_key=session_key,
             sender="web",
@@ -455,6 +591,12 @@ class WebChatChannel:
     async def _on_stream_delta(self, event: StreamDeltaReady) -> None:
         if event.channel != self.name:
             return
+        logger.debug(
+            "[web_chat] event.stream_delta session=%s has_thinking=%s has_content=%s",
+            event.session_key,
+            bool(event.thinking_delta),
+            bool(event.content_delta),
+        )
         if event.thinking_delta:
             await self._broadcast(event.session_key, {
                 "type": "react.thinking.delta",
@@ -473,6 +615,12 @@ class WebChatChannel:
     async def _on_tool_call_started(self, event: ToolCallStarted) -> None:
         if event.channel != self.name:
             return
+        logger.debug(
+            "[web_chat] event.tool.started session=%s call_id=%s tool=%s",
+            event.session_key,
+            event.call_id,
+            event.tool_name,
+        )
         await self._broadcast(event.session_key, {
             "type": "react.tool.started",
             "session_id": event.session_key,
@@ -485,6 +633,12 @@ class WebChatChannel:
     async def _on_tool_call_completed(self, event: ToolCallCompleted) -> None:
         if event.channel != self.name:
             return
+        logger.debug(
+            "[web_chat] event.tool.completed session=%s call_id=%s status=%s",
+            event.session_key,
+            event.call_id,
+            event.status,
+        )
         await self._broadcast(event.session_key, {
             "type": "react.tool.completed",
             "session_id": event.session_key,
@@ -507,16 +661,59 @@ class WebChatChannel:
 
     async def _on_response(self, msg: OutboundMessage) -> None:
         session_key = self._session_key(msg.chat_id)
+        logger.debug(
+            "[web_chat] on_response start session=%s chat=%s",
+            session_key,
+            msg.chat_id,
+        )
         outbound = channel_message_from_outbound(msg)
         outbound.metadata["_channel_commit_role"] = "passive"
         receipt = await self._deliver_message(outbound)
         if not receipt.succeeded:
+            logger.warning(
+                "[web_chat] on_response deliver failed session=%s control_turn_id=%s",
+                session_key,
+                outbound.control_turn_id,
+            )
             raise RuntimeError(receipt.detail or "Web 消息提交失败")
+        logger.debug(
+            "[web_chat] on_response delivered session=%s control_turn_id=%s",
+            session_key,
+            outbound.control_turn_id,
+        )
         _ = self._active_turn_ids.pop(session_key, None)
 
     async def _add_connection(self, session_key: str, websocket: WebSocket) -> None:
         async with self._connection_lock:
             self._connections.setdefault(session_key, set()).add(websocket)
+            logger.info(
+                "[web_chat] add connection session=%s socket=%s count=%d",
+                session_key,
+                self._socket_id(websocket),
+                len(self._connections[session_key]),
+            )
+        await self._refill_terminal(session_key, websocket)
+
+    async def _refill_terminal(self, session_key: str, websocket: WebSocket) -> None:
+        """新连接绑定后补投该会话积压的终态帧，保证断线后终态不丢失。"""
+        frame = self._pending_terminal.get(session_key)
+        if frame is None:
+            return
+        try:
+            await websocket.send_json(frame)
+        except Exception as error:
+            logger.warning(
+                "[web_chat] 终态帧补投失败，保留待下次连接 session=%s err=%r",
+                session_key,
+                error,
+            )
+            return
+        _ = self._pending_terminal.pop(session_key, None)
+        logger.info(
+            "[web_chat] 终态帧补投成功 session=%s turn=%s",
+            session_key,
+            frame.get("turn_id"),
+        )
 
     async def _remove_connection(
         self,
@@ -529,6 +726,12 @@ class WebChatChannel:
                 if sockets is None:
                     continue
                 sockets.discard(websocket)
+                logger.info(
+                    "[web_chat] remove connection session=%s socket=%s remaining=%d",
+                    session_key,
+                    self._socket_id(websocket),
+                    len(sockets),
+                )
                 if not sockets:
                     _ = self._connections.pop(session_key, None)
 
@@ -536,7 +739,18 @@ class WebChatChannel:
         async with self._connection_lock:
             sockets = list(self._connections.get(session_key, set()))
         if not sockets:
+            logger.debug(
+                "[web_chat] broadcast miss session=%s type=%s",
+                session_key,
+                frame.get("type"),
+            )
             return 0
+        logger.debug(
+            "[web_chat] broadcast session=%s type=%s socket_count=%d",
+            session_key,
+            frame.get("type"),
+            len(sockets),
+        )
         stale: list[WebSocket] = []
         delivered = 0
         for socket in sockets:
@@ -555,6 +769,11 @@ class WebChatChannel:
                 if current is not None:
                     for socket in stale:
                         current.discard(socket)
+            logger.warning(
+                "[web_chat] broadcast removed stale sockets session=%s stale=%d",
+                session_key,
+                len(stale),
+            )
         return delivered
 
     async def _send_error(

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -40,27 +40,6 @@ class UploadTooLargeError(ValueError):
     """上传内容超过单文件上限。"""
 
 
-def _coerce_turn_duration_ms(metadata: dict[str, Any]) -> int | None:
-    """把通道 metadata 中的 turn_duration_ms 归一化为整数毫秒。"""
-
-    raw_duration_ms = metadata.pop("turn_duration_ms", None)
-    if raw_duration_ms is None or isinstance(raw_duration_ms, bool):
-        return None
-    if isinstance(raw_duration_ms, int):
-        return raw_duration_ms
-    if isinstance(raw_duration_ms, float):
-        return int(raw_duration_ms)
-    if isinstance(raw_duration_ms, str):
-        try:
-            return int(float(raw_duration_ms.strip()))
-        except ValueError:
-            logger.warning("message.final turn_duration_ms 非法: type=string value=%r", raw_duration_ms)
-            return None
-
-    logger.warning("message.final turn_duration_ms 非法: type=%s value=%r", type(raw_duration_ms).__name__, raw_duration_ms)
-    return None
-
-
 class WebChatChannel:
     def __init__(self, channel_name: str = "web") -> None:
         self.name = channel_name
@@ -307,10 +286,8 @@ class WebChatChannel:
             "thinking": message.thinking or "",
             "media": media,
             "metadata": metadata,
+            "duration_ms": metadata.get("turn_duration_ms"),
         }
-        duration_ms = _coerce_turn_duration_ms(metadata)
-        if duration_ms is not None:
-            frame["duration_ms"] = duration_ms
 
         logger.debug(
             "[web_chat] deliver_message session=%s type=%s source=%s",

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -730,7 +730,7 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
             "thinking": "reasoning",
             "media": [str(image)],
             "duration_ms": 17,
-            "metadata": {"render": "card", "turn_duration_ms": 17},
+            "metadata": {"render": "card"},
         }
     ]
     assert channel.has_media(image)
@@ -797,3 +797,100 @@ async def test_web_turn_started_rejects_missing_server_turn_id() -> None:
             content="question",
             timestamp=datetime.now(UTC),
         ))
+async def test_web_final_omits_invalid_turn_duration_ms_from_metadata() -> None:
+    channel = WebChatChannel()
+    socket = _WebSocket()
+    channel._connections["web:abc"] = {cast(Any, socket)}
+    channel._active_turn_ids["web:abc"] = "turn-1"
+
+    await channel._on_response(
+        OutboundMessage(
+            channel="web",
+            chat_id="abc",
+            content="answer",
+            thinking="reasoning",
+            media=[],
+            metadata={"render": "card", "turn_duration_ms": True},
+        )
+    )
+
+    assert socket.frames == [{
+        "type": "message.final",
+        "session_id": "web:abc",
+        "turn_id": "turn-1",
+        "content": "answer",
+        "thinking": "reasoning",
+        "media": [],
+        "metadata": {"render": "card"},
+    }]
+
+
+@pytest.mark.asyncio
+async def test_web_final_without_socket_caches_terminal_for_refill() -> None:
+    channel = WebChatChannel()
+    channel._active_turn_ids["web:abc"] = "turn-1"
+    await channel._on_response(
+        OutboundMessage(
+            channel="web",
+            chat_id="abc",
+            content="answer",
+            thinking="reasoning",
+            media=[],
+            metadata={},
+            control_turn_id="turn-1",
+        )
+    )
+
+    cached = channel._pending_terminal["web:abc"]
+    assert cached["turn_id"] == "turn-1"
+    assert cached["content"] == "answer"
+
+
+@pytest.mark.asyncio
+async def test_web_attach_refills_cached_terminal() -> None:
+    channel = WebChatChannel()
+    channel._active_turn_ids["web:abc"] = "turn-1"
+    await channel._on_response(
+        OutboundMessage(
+            channel="web",
+            chat_id="abc",
+            content="answer",
+            thinking="reasoning",
+            media=[],
+            metadata={},
+            control_turn_id="turn-1",
+        )
+    )
+    assert "web:abc" in channel._pending_terminal
+
+    socket = _WebSocket()
+    await channel._attach_session(cast(Any, socket), "req-1", {"session_id": "web:abc"})
+
+    assert socket.frames == [{
+        "type": "message.final",
+        "session_id": "web:abc",
+        "turn_id": "turn-1",
+        "content": "answer",
+        "thinking": "reasoning",
+        "media": [],
+        "metadata": {},
+    }]
+    assert "web:abc" not in channel._pending_terminal
+
+
+@pytest.mark.asyncio
+async def test_web_final_without_turn_is_not_cached() -> None:
+    channel = WebChatChannel()
+    with pytest.raises(RuntimeError, match="缺少 Server 权威 active turn"):
+        await channel._on_response(
+            OutboundMessage(
+                channel="web",
+                chat_id="abc",
+                content="（消息发送失败，请稍后重试）",
+                thinking="",
+                media=[],
+                metadata={},
+            )
+        )
+
+    assert "web:abc" not in channel._pending_terminal

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -730,7 +730,7 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
             "thinking": "reasoning",
             "media": [str(image)],
             "duration_ms": 17,
-            "metadata": {"render": "card"},
+            "metadata": {"render": "card", "turn_duration_ms": 17},
         }
     ]
     assert channel.has_media(image)
@@ -797,32 +797,6 @@ async def test_web_turn_started_rejects_missing_server_turn_id() -> None:
             content="question",
             timestamp=datetime.now(UTC),
         ))
-async def test_web_final_omits_invalid_turn_duration_ms_from_metadata() -> None:
-    channel = WebChatChannel()
-    socket = _WebSocket()
-    channel._connections["web:abc"] = {cast(Any, socket)}
-    channel._active_turn_ids["web:abc"] = "turn-1"
-
-    await channel._on_response(
-        OutboundMessage(
-            channel="web",
-            chat_id="abc",
-            content="answer",
-            thinking="reasoning",
-            media=[],
-            metadata={"render": "card", "turn_duration_ms": True},
-        )
-    )
-
-    assert socket.frames == [{
-        "type": "message.final",
-        "session_id": "web:abc",
-        "turn_id": "turn-1",
-        "content": "answer",
-        "thinking": "reasoning",
-        "media": [],
-        "metadata": {"render": "card"},
-    }]
 
 
 @pytest.mark.asyncio
@@ -873,6 +847,7 @@ async def test_web_attach_refills_cached_terminal() -> None:
         "content": "answer",
         "thinking": "reasoning",
         "media": [],
+        "duration_ms": None,
         "metadata": {},
     }]
     assert "web:abc" not in channel._pending_terminal


### PR DESCRIPTION
## 问题与结果

- 解决的问题：chat 页面 WebSocket 在 turn 运行中被自动关闭（`code=1000`），终态帧到达时无可用连接导致消息丢失、按钮不恢复；断线后前端无任何重连，需刷新页面才能恢复。
- 用户可见结果：聊天连接自愈——断线自动按指数退避重连并重新 attach 会话；turn 终态在断线窗口缓存并在重连后补投，按钮恢复不再依赖“网络从未断过”。
- 本 PR 不处理：流式进行中的 `answer.delta` 中段补齐（只对终态帧做补投）；不阻止底层网络物理断线本身。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`（web 通道与分发）+ `mobile`（前端连接生命周期）
- `consumer_scope`：聊天 WebUI 单页、web shell 代理、MessageBus 到 web 通道的分发路径
- `runtime_patch`：`none`
- `runtime_patch_reason`：
- `authoritative_state_owner`：服务端 turn 终态身份（已在 #446 统一）；`_pending_terminal` 是单会话单帧的传输缓存，不是业务状态 owner
- `client_only_alternative`：不适用（前后端协同修复）
- 关联不变量：`sessions.db/messages` 只追加，本 PR 无数据库写入；终态身份沿用 `control_turn_id` 只读规则
- `protected_state`：`_pending_terminal` 缓存投递成功即删除、被新终态覆盖，没有第二个 owner
- 允许的副作用：断线后浏览器自动重连（指数退避，≤30s，≤12 次）
- 禁止的副作用：不因健康轮询抖动重建/关闭正在传输的 socket；不改 `message_push` 无 turn 归属路径的 FAILED 语义

## 改动范围

- 主要文件：
  - `frontend/chat/src/use-desktop-chat-controller.ts`：socket 生命周期与 `chatReady` 解耦、退避重连、error→close 归并、attach 重绑定
  - `frontend/chat/src/web-chat-transport.ts`：`message.final` 按 turn 身份处理（继承 #446），保留 message_push 分支
  - `infra/channels/web_chat_channel.py`：终态帧无连接时缓存待补投；`_attach_session`/`_add_connection` 后补投
  - `bootstrap/web_shell.py`、`bus/queue.py`：代理与分发配合“缓存补投”而非判失败重试降级
  - 测试：`tests/test_web_chat_channel.py`（+10）、`frontend/chat/src/web-chat-transport.test.mjs`
  - `.gitignore`：忽略 `.codex-backup-*`（运行期自动备份，以免干扰 change-gate 审计）
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不涉及数据库
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不涉及外部协议/插件
- 回滚方式：合并回退该 commit 即可；前端 bundle 由 `npm run build:chat` 重新生成

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_web_chat_channel.py`（24）、`tests/test_web_shell.py` + `tests/test_channel_host.py`（14）、`tests/test_message_bus_admission.py` + `tests/control/test_channel_adapter.py` + `tests/test_lifecycle_phases.py`（86）
- [x] 前端 typecheck/lint 已通过：`npx eslint`（controller + transport 0 报错）、`npm run build:chat` 成功、`npm run test:desktop-navigation`（41）
- [ ] `python docker/debug/gate.py run --base origin/main`：**未完成**。audit 已通过；一次 run 报 `unmapped_change`（被工作区内未跟踪备份目录 `.codex-backup-*` 干扰），补充 `.gitignore` 后重跑在运行中被用户中断，未产出最终结果
- `sourceDigest`：—（Gate 最终报告未生成）
- `planDigest`：—（同上）
- 真实设备证据：浏览器 console `[chat-ui] ws close {code, reason}` 同刻记录尚未提供，此次 code=1000 触发源为前端 effect cleanup 的推理基于代码路径与日志时间吻合
- 未运行项与原因：Gate 完整公开场景未跑完（中断）；浏览器真机复现未执行

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner（web 为 core，前端为 mobile）。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。