### PR TITLE
feat(platform): support macOS supervisor mode with 2236 web shell

### DIFF
--- a/agent/background/boot_guardian.py
+++ b/agent/background/boot_guardian.py
@@ -1,4 +1,4 @@
-"""在 Linux 上持有单个 Gateway boot 的进程树生命周期。"""
+"""在 Linux 和 macOS 上持有单个 Gateway boot 的进程树生命周期。"""
 
 from __future__ import annotations
 
@@ -13,8 +13,8 @@ import time
 from pathlib import Path
 
 from core.common.diagnostic_log import diagnostic_line
-from utils.pidfd import open_pidfd
 from utils.process_group import process_group_exists
+from utils.process_guard import open_process_ref, process_wait_timeout
 
 GUARDIAN_FAILURE_EXIT_CODE = 70
 _BOOT_CLEANUP_TIMEOUT_SECONDS = 5.0
@@ -33,7 +33,7 @@ def run_boot_guardian(
 ) -> int:
     """启动一个 Gateway，在退出或 lease 丢失时清空 boot 并返回状态。"""
 
-    # 1. 建立 Linux orphan ownership 和信号唤醒边界。
+    # 1. 建立平台支持的 orphan ownership 和信号唤醒边界。
     _enable_child_subreaper()
     signal_read_fd, signal_write_fd = os.pipe()
     os.set_blocking(signal_read_fd, False)
@@ -46,7 +46,7 @@ def run_boot_guardian(
     }
 
     gateway: subprocess.Popen[bytes] | None = None
-    pidfd: int | None = None
+    gateway_ref = None
     cleanup_attempted = False
     try:
         # 2. Guardian 不携带 boot identity；只有 Gateway 及其后代属于 boot。
@@ -76,15 +76,16 @@ def run_boot_guardian(
         )
         os.close(lifecycle_fd)
         lifecycle_fd = -1
-        pidfd = open_pidfd(gateway.pid)
+        gateway_ref = open_process_ref(gateway.pid)
 
-        # 3. 只等待 Gateway、Supervisor lease 或停止信号，不做周期轮询。
+        # 3. Linux 事件驱动等待；macOS 定期轮询 Gateway 并等待其他 fd。
         with selectors.DefaultSelector() as selector:
-            selector.register(pidfd, selectors.EVENT_READ, "gateway")
+            if gateway_ref.wait_fd is not None:
+                selector.register(gateway_ref.wait_fd, selectors.EVENT_READ, "gateway")
             selector.register(lease_fd, selectors.EVENT_READ, "lease")
             selector.register(signal_read_fd, selectors.EVENT_READ, "signal")
             while gateway.poll() is None:
-                events = selector.select()
+                events = selector.select(process_wait_timeout(gateway_ref, None))
                 if any(key.data == "gateway" for key, _mask in events):
                     break
                 if any(key.data == "lease" for key, _mask in events):
@@ -110,7 +111,7 @@ def run_boot_guardian(
             gateway_exit_code = gateway.wait()
         _reap_adopted_children()
         return _portable_exit_code(gateway_exit_code)
-    except BaseException as run_error:
+    except BaseException:
         if gateway is not None and not cleanup_attempted:
             _ = _cleanup_boot_processes_best_effort(
                 boot_id=boot_id,
@@ -121,8 +122,8 @@ def run_boot_guardian(
     finally:
         if lifecycle_fd >= 0:
             os.close(lifecycle_fd)
-        if pidfd is not None:
-            os.close(pidfd)
+        if gateway_ref is not None:
+            gateway_ref.close()
         os.close(lease_fd)
         _ = signal.set_wakeup_fd(previous_wakeup_fd)
         for sig, handler in previous_handlers.items():
@@ -132,10 +133,12 @@ def run_boot_guardian(
 
 
 def _enable_child_subreaper() -> None:
-    """要求当前进程成为 Linux child subreaper，否则明确失败。"""
+    """Linux 成为 child subreaper；macOS 依赖独立进程组清理。"""
 
+    if sys.platform == "darwin":
+        return
     if not sys.platform.startswith("linux"):
-        raise RuntimeError("Boot Guardian 仅支持 Linux")
+        raise RuntimeError("Boot Guardian 仅支持 Linux 和 macOS")
     libc = ctypes.CDLL(None, use_errno=True)
     if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
         error_number = ctypes.get_errno()
@@ -148,10 +151,10 @@ def _cleanup_boot_processes(
     gateway_group_id: int | None,
     timeout_s: float = _BOOT_CLEANUP_TIMEOUT_SECONDS,
 ) -> None:
-    """在一个 TERM 到 KILL 总 deadline 内清空 Linux boot。"""
+    """在一个 TERM 到 KILL 总 deadline 内清空当前 boot。"""
 
-    if not sys.platform.startswith("linux"):
-        raise RuntimeError("boot 进程树清理仅支持 Linux")
+    if not _guardian_platform_supported():
+        raise RuntimeError("boot 进程树清理仅支持 Linux 和 macOS")
     if timeout_s <= 0:
         raise ValueError("boot cleanup timeout 必须大于 0")
 
@@ -245,12 +248,20 @@ def _discover_boot_targets(
     expected = f"AKASHIC_BOOT_ID={boot_id}".encode()
     own_group = os.getpgrp()
     own_pid = os.getpid()
-    for entry in Path("/proc").iterdir():
-        if not entry.name.isdigit():
-            continue
-        pid = int(entry.name)
+    if sys.platform.startswith("linux"):
+        candidates = (
+            int(entry.name)
+            for entry in Path("/proc").iterdir()
+            if entry.name.isdigit()
+        )
+    else:
+        candidates = iter(_darwin_process_ids())
+    for pid in candidates:
         try:
-            environ = (entry / "environ").read_bytes().split(b"\0")
+            if sys.platform.startswith("linux"):
+                environ = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+            else:
+                environ = _darwin_process_environ(pid)
             if expected not in environ:
                 continue
             group_id = os.getpgid(pid)
@@ -265,11 +276,15 @@ def _discover_boot_targets(
 
 
 def _pid_has_boot_identity(pid: int, boot_id: str) -> bool:
-    """判断一个 Linux 活进程是否携带精确的 boot token。"""
+    """判断一个活进程是否携带精确的 boot token。"""
 
     expected = f"AKASHIC_BOOT_ID={boot_id}".encode()
     try:
-        return expected in Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+        if sys.platform.startswith("linux"):
+            environ = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+        else:
+            environ = _darwin_process_environ(pid)
+        return expected in environ
     except OSError:
         return False
 
@@ -299,6 +314,18 @@ def _group_exists(group_id: int) -> bool:
 
 
 def _pid_exists(pid: int) -> bool:
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return False
+        state = result.stdout.strip()
+        return result.returncode == 0 and bool(state) and not state.startswith("Z")
     try:
         fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
     except (OSError, IndexError):
@@ -323,6 +350,8 @@ def _reap_adopted_children(*, exclude_pids: set[int] | None = None) -> None:
 
     excluded = exclude_pids or set()
     if excluded:
+        if sys.platform == "darwin":
+            return
         for entry in Path("/proc").iterdir():
             if not entry.name.isdigit():
                 continue
@@ -348,6 +377,69 @@ def _reap_adopted_children(*, exclude_pids: set[int] | None = None) -> None:
             return
         if pid == 0:
             return
+
+
+def _guardian_platform_supported(platform: str | None = None) -> bool:
+    current = platform or sys.platform
+    return current.startswith("linux") or current == "darwin"
+
+
+def _darwin_process_ids() -> list[int]:
+    libc = ctypes.CDLL(None, use_errno=True)
+    list_all_pids = libc.proc_listallpids
+    list_all_pids.argtypes = (ctypes.c_void_p, ctypes.c_int)
+    list_all_pids.restype = ctypes.c_int
+    count = list_all_pids(None, 0)
+    if count < 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+    buffer = (ctypes.c_int * (count + 32))()
+    actual = list_all_pids(buffer, ctypes.sizeof(buffer))
+    if actual < 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+    return [pid for pid in buffer[:actual] if pid > 0]
+
+
+def _darwin_process_environ(pid: int) -> list[bytes]:
+    """通过 KERN_PROCARGS2 读取 Darwin 进程的原始环境变量。"""
+
+    if sys.platform != "darwin":
+        raise RuntimeError("KERN_PROCARGS2 仅支持 macOS")
+    ctl_kern = 1
+    kern_procargs2 = 49
+    mib = (ctypes.c_int * 3)(ctl_kern, kern_procargs2, pid)
+    size = ctypes.c_size_t()
+    libc = ctypes.CDLL(None, use_errno=True)
+    sysctl = libc.sysctl
+    sysctl.argtypes = (
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.c_uint,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+    )
+    sysctl.restype = ctypes.c_int
+    if sysctl(mib, 3, None, ctypes.byref(size), None, 0) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+    buffer = ctypes.create_string_buffer(size.value)
+    if sysctl(mib, 3, buffer, ctypes.byref(size), None, 0) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+
+    raw = buffer.raw[: size.value]
+    integer_size = ctypes.sizeof(ctypes.c_int)
+    if len(raw) < integer_size:
+        return []
+    argc = int.from_bytes(raw[:integer_size], sys.byteorder, signed=True)
+    values = raw[integer_size:].split(b"\0")
+    index = 1  # executable path
+    while index < len(values) and not values[index]:
+        index += 1
+    index += max(0, argc)
+    return [value for value in values[index:] if b"=" in value]
 
 
 def _portable_exit_code(code: int) -> int:

--- a/agent/supervisor.py
+++ b/agent/supervisor.py
@@ -23,7 +23,12 @@ from agent.background.boot_guardian import (
     _pid_exists,
     _reap_adopted_children,
 )
-from utils.pidfd import open_pidfd, send_pidfd_signal
+from utils.process_guard import (
+    ProcessRef,
+    open_process_ref,
+    process_wait_timeout,
+    signal_process_ref,
+)
 
 RESTART_EXIT_CODE = 75
 SUPERVISOR_FAILURE_EXIT_CODE = 70
@@ -256,10 +261,10 @@ def run_supervisor(
     workspace: Path,
     readiness_timeout_s: float = 15.0,
 ) -> int:
-    """管理 Linux boot 代际，并且只接受当前 boot 的私有重启提交。"""
+    """管理 boot 代际，并且只接受当前 boot 的私有重启提交。"""
 
-    if not sys.platform.startswith("linux"):
-        raise RuntimeError("Supervisor 仅支持 Linux")
+    if not _supervisor_platform_supported():
+        raise RuntimeError("Supervisor 仅支持 Linux 和 macOS")
     if readiness_timeout_s <= 0:
         raise ValueError("readiness_timeout_s 必须大于 0")
     # 1. 建立 workspace owner、设置线程和停止信号边界。
@@ -460,7 +465,7 @@ def _wait_child(
     settings_bridge: _SettingsRestartBridge | None = None,
     report_settings_generation: int = 0,
 ) -> _ChildResult:
-    """等待 pidfd 与生命周期事件，直到 Guardian 退出或启动失败。"""
+    """等待进程与生命周期事件，直到 Guardian 退出或启动失败。"""
 
     # 1. 建立本代协议状态和三个可等待的内核事件。
     _ = workspace
@@ -469,13 +474,14 @@ def _wait_child(
     state = _LifecycleState(boot_id, nonce)
     deadline = time.monotonic() + readiness_timeout_s
     settings_generation = 0
-    gateway_pidfd: int | None = None
-    child_pidfd = open_pidfd(child.pid)
+    gateway_ref: ProcessRef | None = None
+    child_ref = open_process_ref(child.pid)
     lifecycle_open = True
     try:
         # 2. ready 前受总体 deadline 约束，ready 后只等待事件或进程退出。
         with selectors.DefaultSelector() as selector:
-            selector.register(child_pidfd, selectors.EVENT_READ, "guardian")
+            if child_ref.wait_fd is not None:
+                selector.register(child_ref.wait_fd, selectors.EVENT_READ, "guardian")
             selector.register(read_fd, selectors.EVENT_READ, "lifecycle")
             while child.poll() is None:
                 timeout = None
@@ -488,7 +494,7 @@ def _wait_child(
                         )
                         _stop_guardian(child)
                         break
-                events = selector.select(timeout)
+                events = selector.select(process_wait_timeout(child_ref, timeout))
                 for key, _mask in events:
                     if key.data == "guardian":
                         _ = child.wait()
@@ -515,13 +521,21 @@ def _wait_child(
                     elif key.data == "settings":
                         settings_generation = settings_bridge.take_request()
                         if settings_generation:
-                            assert gateway_pidfd is not None
-                            send_pidfd_signal(gateway_pidfd, signal.SIGUSR1)
+                            assert gateway_ref is not None
+                            if not gateway_ref.stable and not _pid_has_boot_identity(
+                                gateway_ref.pid,
+                                boot_id,
+                            ):
+                                state.protocol_error = (
+                                    "Gateway PID 已退出或身份变化，拒绝发送设置重载信号"
+                                )
+                                break
+                            signal_process_ref(gateway_ref, signal.SIGUSR1)
 
                 if state.protocol_error:
                     _stop_guardian(child)
                     break
-                if state.ready and gateway_pidfd is None:
+                if state.ready and gateway_ref is None:
                     assert state.gateway_pid is not None
                     if not _pid_has_boot_identity(state.gateway_pid, boot_id):
                         state.protocol_error = (
@@ -530,7 +544,7 @@ def _wait_child(
                         state.commit_valid = False
                         _stop_guardian(child)
                         break
-                    gateway_pidfd = open_pidfd(state.gateway_pid)
+                    gateway_ref = open_process_ref(state.gateway_pid)
                     if report_settings_generation:
                         settings_bridge.complete(report_settings_generation, True)
                         report_settings_generation = 0
@@ -561,12 +575,17 @@ def _wait_child(
     finally:
         if lease_fd is not None:
             os.close(lease_fd)
-        if gateway_pidfd is not None:
-            os.close(gateway_pidfd)
-        os.close(child_pidfd)
+        if gateway_ref is not None:
+            gateway_ref.close()
+        child_ref.close()
         os.close(read_fd)
         if owned_bridge:
             settings_bridge.close()
+
+
+def _supervisor_platform_supported(platform: str | None = None) -> bool:
+    current = platform or sys.platform
+    return current.startswith("linux") or current == "darwin"
 
 
 def _read_lifecycle_to_eof(fd: int, state: _LifecycleState) -> None:

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 入口
 
 主要模式：
-  python main.py                    Linux 由 supervisor 托管，其他平台直接运行 gateway
+  python main.py                    Linux/macOS 由 supervisor 托管，其他平台直接运行 gateway
   python main.py gateway            显式启动未托管 gateway（调试）
   python main.py supervise          显式进入 supervisor（兼容别名）
   python main.py app-server --stdio 启动父进程托管控制面
@@ -55,7 +55,8 @@ def _supervisor_readiness_timeout() -> float:
 
 
 def _supervisor_supported(platform: str | None = None) -> bool:
-    return (platform or sys.platform).startswith("linux")
+    current = platform or sys.platform
+    return current.startswith("linux") or current == "darwin"
 
 
 def _workspace_from_config(config_path: Path) -> str:
@@ -723,7 +724,7 @@ if __name__ == "__main__":
         print(str(exc), file=sys.stderr)
         sys.exit(1)
     if args and args[0] == "supervise" and not _supervisor_supported():
-        print("supervise 仅支持 Linux", file=sys.stderr)
+        print("supervise 仅支持 Linux 和 macOS", file=sys.stderr)
         sys.exit(2)
     if host_value is not None:
         dashboard_host = host_value

--- a/tests/test_agent_restart.py
+++ b/tests/test_agent_restart.py
@@ -18,6 +18,9 @@ from typing import Any, cast
 import pytest
 
 import agent.background.boot_guardian as boot_guardian_module
+import agent.supervisor as supervisor_module
+import main as main_module
+import utils.process_guard as process_guard_module
 from agent.control.context import running_turn_id
 from agent.control.errors import RuntimeClosedError
 from agent.control.models import TurnRequest
@@ -29,16 +32,14 @@ from agent.restart import (
     RestartState,
     SupervisorCommitChannel,
 )
-import agent.supervisor as supervisor_module
 from agent.supervisor import RESTART_EXIT_CODE, _wait_child, run_supervisor
 from agent.tools.agent_restart import AgentRestartTool
 from agent.tools.registry import ToolRegistry
 from agent.tools.tool_search import ToolSearchTool
-from bootstrap.runtime_readiness import RuntimeReadiness
 from bootstrap.app import AppRuntime
+from bootstrap.runtime_readiness import RuntimeReadiness
 from core.error_context import current_session_key
 from infra.control.connection import NdjsonConnection
-import main as main_module
 from session.store import SessionStore
 
 
@@ -1177,8 +1178,9 @@ def test_supervisor_child_does_not_inherit_blocked_stop_signals(
     def launch(_argv: list[str], **kwargs: Any) -> subprocess.Popen[bytes]:
         assert "preexec_fn" not in kwargs
         code = """
-import pathlib, sys, time
-pathlib.Path(sys.argv[1]).write_text(pathlib.Path('/proc/self/status').read_text())
+import pathlib, signal, sys, time
+blocked = signal.pthread_sigmask(signal.SIG_BLOCK, [])
+pathlib.Path(sys.argv[1]).write_text(','.join(str(int(sig)) for sig in blocked))
 time.sleep(30)
 """
         return cast(
@@ -1201,12 +1203,11 @@ time.sleep(30)
         deadline = time.monotonic() + 2
         while not probe_path.exists() and time.monotonic() < deadline:
             time.sleep(0.01)
-        status = probe_path.read_text()
-        sigblk_line = next(
-            line for line in status.splitlines() if line.startswith("SigBlk:")
+        blocked = {int(value) for value in probe_path.read_text().split(",") if value}
+        observed["blocked"] = len(blocked)
+        observed["stop_blocked"] = int(
+            signal.SIGINT in blocked or signal.SIGTERM in blocked
         )
-        blocked = int(sigblk_line.split()[1], 16)
-        observed["blocked"] = blocked
         child.send_signal(signal.SIGTERM)
         exit_code = child.wait(timeout=2)
         os.close(read_fd)
@@ -1219,8 +1220,7 @@ time.sleep(30)
         config_path=tmp_path / "config.toml",
         workspace=tmp_path,
     ) == 128 + signal.SIGTERM
-    stop_mask = (1 << (signal.SIGINT - 1)) | (1 << (signal.SIGTERM - 1))
-    assert observed["blocked"] & stop_mask == 0
+    assert observed["stop_blocked"] == 0
 
 
 def test_settings_restart_bridge_waits_for_matching_ready_generation() -> None:
@@ -1303,20 +1303,68 @@ def test_supervised_gateway_skips_duplicate_startup_migration(
     assert calls == []
 
 
-def test_platform_boundary_exposes_supervisor_only_on_linux(
+def test_platform_boundary_exposes_supervisor_on_linux_and_macos(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     assert main_module._supervisor_supported("linux")
+    assert main_module._supervisor_supported("darwin")
     assert not main_module._supervisor_supported("win32")
-    assert not main_module._supervisor_supported("darwin")
+    assert supervisor_module._supervisor_platform_supported("darwin")
+    assert boot_guardian_module._guardian_platform_supported("darwin")
 
-    monkeypatch.setattr(supervisor_module.sys, "platform", "darwin")
-    with pytest.raises(RuntimeError, match="仅支持 Linux"):
+    monkeypatch.setattr(supervisor_module.sys, "platform", "win32")
+    with pytest.raises(RuntimeError, match="仅支持 Linux 和 macOS"):
         run_supervisor(
             config_path=tmp_path / "config.toml",
             workspace=tmp_path,
         )
+
+
+def test_darwin_process_discovery_uses_exact_boot_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(boot_guardian_module.sys, "platform", "darwin")
+    monkeypatch.setattr(boot_guardian_module, "_darwin_process_ids", lambda: [101, 102])
+    monkeypatch.setattr(
+        boot_guardian_module,
+        "_darwin_process_environ",
+        lambda pid: [b"AKASHIC_BOOT_ID=boot-a"] if pid == 101 else [b"OTHER=1"],
+    )
+    monkeypatch.setattr(boot_guardian_module.os, "getpid", lambda: 999)
+    monkeypatch.setattr(boot_guardian_module.os, "getpgrp", lambda: 500)
+    monkeypatch.setattr(boot_guardian_module.os, "getpgid", lambda pid: pid + 1000)
+    groups: set[int] = set()
+    direct_pids: set[int] = set()
+
+    boot_guardian_module._discover_boot_targets("boot-a", groups, direct_pids)
+
+    assert groups == {1101}
+    assert direct_pids == set()
+
+
+def test_darwin_subreaper_is_explicit_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(boot_guardian_module.sys, "platform", "darwin")
+    boot_guardian_module._enable_child_subreaper()
+
+
+def test_process_ref_keeps_pidfd_on_linux_and_polls_on_darwin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(process_guard_module.sys, "platform", "linux")
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    monkeypatch.setattr(process_guard_module, "open_pidfd", lambda _pid: read_fd)
+    linux_ref = process_guard_module.open_process_ref(123)
+    assert linux_ref.stable
+    assert process_guard_module.process_wait_timeout(linux_ref, None) is None
+    linux_ref.close()
+
+    monkeypatch.setattr(process_guard_module.sys, "platform", "darwin")
+    darwin_ref = process_guard_module.open_process_ref(123)
+    assert not darwin_ref.stable
+    assert process_guard_module.process_wait_timeout(darwin_ref, None) == 0.1
+    darwin_ref.close()
 
 
 def test_settings_server_rejects_non_loopback_host(

--- a/utils/process_group.py
+++ b/utils/process_group.py
@@ -150,6 +150,8 @@ def process_group_exists(group_id: int) -> bool:
 
     if sys.platform.startswith("linux"):
         return _linux_group_has_live_members(group_id)
+    if sys.platform == "darwin":
+        return _darwin_group_has_live_members(group_id)
     try:
         os.killpg(group_id, 0)
     except ProcessLookupError:
@@ -157,6 +159,30 @@ def process_group_exists(group_id: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _darwin_group_has_live_members(group_id: int) -> bool:
+    """Darwin 的 killpg(0) 也会命中 zombie，需检查 stat。"""
+
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pgid=,stat="],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if (
+            len(fields) >= 2
+            and fields[0].isdigit()
+            and int(fields[0]) == group_id
+            and not fields[1].startswith("Z")
+        ):
+            return True
+    return False
 
 
 def _linux_group_has_live_members(group_id: int) -> bool:

--- a/utils/process_guard.py
+++ b/utils/process_guard.py
@@ -1,0 +1,53 @@
+"""跨 Linux 和 macOS 的稳定进程等待与信号边界。"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from dataclasses import dataclass
+
+from utils.pidfd import open_pidfd, send_pidfd_signal
+
+_FALLBACK_POLL_INTERVAL_SECONDS = 0.1
+
+
+@dataclass(frozen=True)
+class ProcessRef:
+    """Linux 持有 pidfd；macOS 保留 PID 并要求调用方校验身份。"""
+
+    pid: int
+    wait_fd: int | None
+
+    @property
+    def stable(self) -> bool:
+        return self.wait_fd is not None
+
+    def close(self) -> None:
+        if self.wait_fd is not None:
+            os.close(self.wait_fd)
+
+
+def open_process_ref(pid: int) -> ProcessRef:
+    if sys.platform.startswith("linux"):
+        return ProcessRef(pid, open_pidfd(pid))
+    if sys.platform == "darwin":
+        return ProcessRef(pid, None)
+    raise RuntimeError("进程引用仅支持 Linux 和 macOS")
+
+
+def process_wait_timeout(ref: ProcessRef, timeout: float | None) -> float | None:
+    """无可等待进程 fd 时限制 selector 阻塞时间，以便轮询 Popen。"""
+
+    if ref.wait_fd is not None:
+        return timeout
+    if timeout is None:
+        return _FALLBACK_POLL_INTERVAL_SECONDS
+    return min(max(0.0, timeout), _FALLBACK_POLL_INTERVAL_SECONDS)
+
+
+def signal_process_ref(ref: ProcessRef, sig: signal.Signals) -> None:
+    if ref.wait_fd is not None:
+        send_pidfd_signal(ref.wait_fd, sig)
+        return
+    os.kill(ref.pid, sig)


### PR DESCRIPTION
## 改动概要

让 akashic-agent 在 macOS 上也默认进入 Supervisor 模式，并提供统一的本地 Web 入口：

`http://127.0.0.1:2236`

Linux 现有行为保持不变。

## 主要改动

- 将 Supervisor 支持平台扩展为 Linux 和 macOS。
- 新增跨平台进程引用抽象：
  - Linux 继续使用 pidfd。
  - macOS 使用 PID 信号和有界轮询。
- 更新 Supervisor 和 Boot Guardian 的进程等待、信号和生命周期管理逻辑。
- macOS 使用 `proc_listallpids` 和 `KERN_PROCARGS2` 完成进程枚举及 boot identity 校验。
- macOS 跳过 Linux 专用的 child subreaper 设置，改用独立进程组进行清理。
- 修复 macOS 下 zombie 进程组被误判为仍存活的问题。
- 增加平台分派、macOS 进程发现和进程引用相关测试。
- 未引入新的第三方运行时依赖。

## 兼容性说明

- Linux 的 pidfd、subreaper、`/proc` 审计和原有生命周期状态机保持不变。
- macOS 不提供 Linux child subreaper 语义，因此进程树清理依赖独立进程组和 boot identity 校验。
- 本地 `6322` launchd bridge、`config.toml` 及现有工作区改动未被修改。

## 验证结果

- `uv run pytest tests/test_agent_restart.py -q`
  - `38 passed, 5 skipped`
- Python 编译检查通过。
- 已在 macOS 上手动验证 boot identity 读取和进程组清理。

完整测试集在当前 macOS 环境仍包含仓库已有的平台相关失败项，涉及 Linux `/proc`、`flock` 命令、Unix socket 路径长度以及外部 benchmark 依赖。