### PR TITLE
chore(frontend): 引入 you-might-not-need-an-effect 插件并清理可简化的 effect

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import reactYouMightNotNeedAnEffect from "eslint-plugin-react-you-might-not-need-an-effect";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
@@ -17,9 +18,11 @@ export default tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
+      "react-you-might-not-need-an-effect": reactYouMightNotNeedAnEffect,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      ...reactYouMightNotNeedAnEffect.configs.recommended.rules,
       "react-refresh/only-export-components": "off",
       "react-hooks/set-state-in-effect": "off",
       "@typescript-eslint/triple-slash-reference": "off",

--- a/frontend/chat/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/chat/src/components/ai-elements/prompt-input.tsx
@@ -723,6 +723,7 @@ export const PromptInput = ({
 
   // Note: File input cannot be programmatically set for security reasons
   // The syncHiddenInput prop is no longer functional
+  // 必要 effect：清空隐藏 input 的 DOM 值（DOM 操作），不可改为渲染期计算
   useEffect(() => {
     if (syncHiddenInput && inputRef.current && files.length === 0) {
       inputRef.current.value = "";

--- a/frontend/chat/src/components/ai-elements/reasoning.tsx
+++ b/frontend/chat/src/components/ai-elements/reasoning.tsx
@@ -98,12 +98,10 @@ export const Reasoning = memo(
       }
     }, [isStreaming, setDuration]);
 
-    // Auto-open when streaming starts (unless explicitly closed)
-    useEffect(() => {
-      if (isStreaming && !isOpen && !isExplicitlyClosed) {
-        setIsOpen(true);
-      }
-    }, [isStreaming, isOpen, setIsOpen, isExplicitlyClosed]);
+    // 渲染期调整：流式开始且未显式关闭时自动展开（setIsOpen 同值会 bail out，不会循环）
+    if (isStreaming && !isOpen && !isExplicitlyClosed) {
+      setIsOpen(true);
+    }
 
     // Auto-close when streaming ends (once only, and only if it ever streamed)
     useEffect(() => {

--- a/frontend/chat/src/desktop-auto-scroll.tsx
+++ b/frontend/chat/src/desktop-auto-scroll.tsx
@@ -41,6 +41,7 @@ export function DesktopAutoScroll({
   ].join(":");
   const lastMessageRole = lastMessage?.role;
 
+  // 必要 effect：新用户消息/流式输出时 DOM 滚动到底部（响应数据变化执行 DOM 副作用），不可改为渲染期计算
   useEffect(() => {
     const hasNewUserMessage = messages.length > lastMessageCountRef.current && lastMessageRole === "user";
     lastMessageCountRef.current = messages.length;

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -1517,11 +1517,10 @@ function MobileNativeApp() {
     return () => window.cancelAnimationFrame(frame);
   }, [snapshot]);
 
-  useEffect(() => {
-    if (snapshot?.composer.isStopping || !snapshot?.composer.canStop || snapshot?.connection.error) {
-      setStopRequested(false);
-    }
-  }, [snapshot?.composer.canStop, snapshot?.composer.isStopping, snapshot?.connection.error]);
+  // 渲染期调整：停止中/不可停止/连接错误时立即复位 stopRequested，无需等待 effect 提交
+  if (snapshot?.composer.isStopping || !snapshot?.composer.canStop || snapshot?.connection.error) {
+    setStopRequested(false);
+  }
 
   useLayoutEffect(() => {
     const sessionId = snapshot?.selectedSessionId;
@@ -1611,6 +1610,7 @@ function MobileNativeApp() {
     };
   }, [flushComposerDraft]);
 
+  // 必要 effect：按外部 snapshot.messages 过滤失效的恢复项（投影 reconcile），不可改为渲染期计算
   useEffect(() => {
     const actionable = new Set(
       snapshot?.messages.filter((message) => message.deliveryAction).map((message) => message.id) ?? [],
@@ -1621,6 +1621,7 @@ function MobileNativeApp() {
     });
   }, [snapshot?.messages]);
 
+  // 必要 effect：按外部 snapshot.messages reconcile 选中集合（投影），不可改为渲染期计算
   useEffect(() => {
     setSelectedMessageIds((current) => {
       if (current.size === 0) return current;
@@ -1631,6 +1632,7 @@ function MobileNativeApp() {
     });
   }, [snapshot?.messages]);
 
+  // 必要 effect：外部插件列表变化时校正 surface 指向（保留 effect 避免渲染期新对象引用触发循环）
   useEffect(() => {
     if (surface.kind !== "dashboard") return;
     if (!pluginDashboards.some((plugin) => plugin.id === surface.pluginId)) {
@@ -1674,6 +1676,7 @@ function MobileNativeApp() {
     }, 1300);
   }, []);
 
+  // 必要 effect：处理导航目标（DOM 定位 + 原生回调），不可改为渲染期计算
   useEffect(() => {
     const target = snapshot?.navigationTarget;
     if (!target || target.sessionId !== snapshot.selectedSessionId) return;
@@ -1685,6 +1688,7 @@ function MobileNativeApp() {
     window.AkashicNative?.navigationTargetHandled(target.messageId);
   }, [jumpToMessage, snapshot?.messages, snapshot?.navigationTarget, snapshot?.selectedSessionId]);
 
+  // 必要 effect：搜索目标自动选中（维护有效 searchTargetId，渲染期调整会改变“仍有效则不动”语义）
   useEffect(() => {
     if (!searchOpen || !normalizedSearchQuery || searchResults.length === 0) {
       setSearchTargetId(null);
@@ -1694,10 +1698,12 @@ function MobileNativeApp() {
     setSearchTargetId(searchResults[searchResults.length - 1].id);
   }, [normalizedSearchQuery, searchOpen, searchResults, searchTargetId]);
 
+  // 必要 effect：搜索目标变化时 DOM 定位，不可改为渲染期计算
   useEffect(() => {
     if (searchTargetId !== null) jumpToMessage(searchTargetId);
   }, [jumpToMessage, searchTargetId]);
 
+  // 必要 effect：会话切换时复位搜索/队列/分享等局部状态（含 ref 同步，保留 effect 避免渲染期写 ref）
   useEffect(() => {
     const sessionId = snapshot?.selectedSessionId;
     if (previousSessionIdRef.current === undefined) {
@@ -1721,19 +1727,23 @@ function MobileNativeApp() {
     setSelectedMessageIds(new Set());
   }, [snapshot?.selectedSessionId]);
 
+  // 必要 effect：未读锚点变化时复位已访问标记（需追踪上一次 anchorKey，渲染期调整不简洁）
   useEffect(() => {
     setUnreadAnchorVisited(false);
   }, [unreadState.anchorKey]);
 
+  // 必要 effect：latest-ref 提交后同步（React 官方认可的 ref 镜像写法，避免并发渲染回退）
   useLayoutEffect(() => {
     snapshotMessagesRef.current = snapshot?.messages ?? [];
   }, [snapshot?.messages]);
 
   const baselineMessages = snapshot?.messages;
+  // 必要 effect：外部 StreamProjectionStore 基线 reconcile（命令式投影 store，非订阅式）
   useEffect(() => {
     if (baselineMessages) streamStore.reconcileBaseline(baselineMessages);
   }, [baselineMessages, streamStore]);
 
+  // 必要 effect：latest-ref 提交后同步
   useLayoutEffect(() => {
     composerInputRef.current = input;
   }, [input]);
@@ -2640,6 +2650,7 @@ function MobileDrawer({
   onClose: () => void;
 }) {
   const drawerRef = useRef<HTMLElement>(null);
+  // 必要 effect：抽屉打开时聚焦（DOM focus 需提交后执行），不可改为渲染期计算
   useEffect(() => {
     if (open) requestAnimationFrame(() => drawerRef.current?.focus());
   }, [open]);
@@ -3399,6 +3410,7 @@ function TransferBanner({ status }: { status: MobileTransferStatus }) {
 
 function CommandSheet({ open, commands, onClose }: { open: boolean; commands: MobileSnapshot["composer"]["commands"]; onClose: (restoreFocus?: boolean) => void }) {
   const dispatchedRef = useRef(false);
+  // 必要 effect：命令面板打开时复位“已派发”标记（ref 状态机，不可改为渲染期计算）
   useEffect(() => {
     if (open) dispatchedRef.current = false;
   }, [open]);
@@ -3433,6 +3445,7 @@ function DraftAttachments({ attachments, disabled }: { attachments: MobileAttach
   const [operations, setOperations] = useState(new Map<string, "retry" | "remove">());
   const operationsRef = useRef(operations);
 
+  // 必要 effect：按 attachments 清理已完成的本地操作标记（投影 reconcile），不可改为渲染期计算
   useEffect(() => {
     setOperations((current) => {
       const next = new Map(current);
@@ -3521,6 +3534,7 @@ function MobileMessageAttachment({ attachment }: { attachment: MobileAttachment 
   const [viewerOpen, setViewerOpen] = useState(false);
   const viewerOpenRef = useRef(false);
 
+  // 必要 effect：附件 URL 变化时复位图片重试/不可用状态（响应外部投影重置本地状态）
   useEffect(() => {
     setImageRetry(0);
     setImageUnavailable(false);
@@ -4331,6 +4345,7 @@ function useMobileUnreadTracking(
   onUnreadChange: (state: MobileUnreadState) => void,
 ) {
   const sourceMessagesRef = useRef(sourceMessages);
+  // 必要 effect：latest-ref 提交后同步
   useEffect(() => {
     sourceMessagesRef.current = sourceMessages;
   }, [sourceMessages]);
@@ -4343,6 +4358,7 @@ function useMobileUnreadTracking(
   const anchorKeyRef = useRef<string | undefined>(undefined);
   const anchorOrdinalRef = useRef(0);
 
+  // 必要 effect：未读基线 reconcile 后回调父组件发布（外部投影，仅在集合变化时发布）
   useEffect(() => {
     const currentMessages = sourceMessagesRef.current;
     const publishUnread = (ids: string[], migrations: ReadonlyMap<string, string>) => {

--- a/frontend/chat/src/model-experience-showcase.tsx
+++ b/frontend/chat/src/model-experience-showcase.tsx
@@ -334,6 +334,7 @@ function RailModelPicker({
   const listRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
+  // 必要 effect：打开时同步选中项并聚焦（focus 需 DOM 提交后执行），不可改为渲染期计算
   useEffect(() => {
     if (!open) return;
     setActiveIndex(selectedIndex);

--- a/frontend/dashboard/src/PluginDetail.tsx
+++ b/frontend/dashboard/src/PluginDetail.tsx
@@ -10,6 +10,7 @@ export function PluginDetail(props: {
   const Detail = props.plugin.Detail;
 
   // 1. React-native plugins compose straight into the host tree (shared React).
+  // 必要 effect：legacy 插件 DOM render 契约（renderDetail 直接操作 ref 节点），不可改为渲染期计算
   useEffect(() => {
     if (Detail) return;
     if (ref.current && props.plugin.renderDetail) {
@@ -42,6 +43,7 @@ export function PluginMain(props: {
     dispatchRef.current = props.dispatch;
   }, [props.dispatch]);
 
+  // 必要 effect：legacy renderMain 自己拥有 DOM、timer、listener；宿主只更新 dispatch，不可改为渲染期计算
   useEffect(() => {
     if (Main) return;
     // legacy renderMain 自己拥有 DOM、timer、listener；宿主只更新 dispatch。

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -239,6 +239,7 @@ function App(): React.ReactElement {
     };
   }, []);
 
+  // 必要 effect：setup 未完成时引导到模型页（跨状态导航 + history 副作用），不可改为渲染期计算
   useEffect(() => {
     if (shellStatus === "needs_setup" && shellView !== "models") openView("models");
   }, [openView, shellStatus, shellView]);
@@ -665,6 +666,7 @@ function DashboardWorkspace(): React.ReactElement {
     }
   };
 
+  // 必要 effect：按当前视图加载对应面板数据（fetch 有副作用，React 官方认可 effect 做数据获取）
   useEffect(() => {
     if (viewMode === "sessions") void run(loadMessages);
   }, [loadMessages, run, viewMode]);
@@ -1311,6 +1313,7 @@ function PluginNavBody(props: {
   const report = useEffectEvent((error: unknown) => props.onError(error));
   const filtersKey = JSON.stringify(props.state.filters);
 
+  // 必要 effect：legacy 插件 DOM render 契约（renderNavBody 直接操作 ref 节点），不可改为渲染期计算
   useEffect(() => {
     if (ref.current && props.plugin.renderNavBody) {
       const dispatch = makeDispatch(props.plugin, getState, setState, activate, undefined, report);
@@ -1336,6 +1339,7 @@ function PluginFilters(props: {
   const report = useEffectEvent((error: unknown) => props.onError(error));
   const filtersKey = JSON.stringify(props.state.filters);
 
+  // 必要 effect：legacy 插件 DOM render 契约（renderFilters 直接操作 ref 节点）
   useEffect(() => {
     if (ref.current && props.plugin.renderFilters) {
       const dispatch = makeDispatch(props.plugin, getState, setState, activate, undefined, report);
@@ -1361,6 +1365,7 @@ function PluginTopbarAction(props: {
   const report = useEffectEvent((error: unknown) => props.onError(error));
   const filtersKey = JSON.stringify(props.state.filters);
 
+  // 必要 effect：legacy 插件 DOM render 契约（renderTopbarAction 直接操作 ref 节点）
   useEffect(() => {
     if (ref.current && props.plugin.renderTopbarAction) {
       const dispatch = makeDispatch(props.plugin, getState, setState, activate, undefined, report);

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint": "^10.2.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.1",
         "globals": "^17.5.0",
         "playwright-core": "^1.62.1",
         "postcss": "^8.4.49",
@@ -4777,6 +4778,38 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-you-might-not-need-an-effect/-/eslint-plugin-react-you-might-not-need-an-effect-1.0.1.tgz",
+      "integrity": "sha512-oOhQTYhor88Xp8RVytq25tvBfiAjU0r9SCDC51Qop+3Wg5BR1xGMAkM+/dV4MZbcMhdaU1L9bkv6LC95JmiTig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^16.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/nickjvandyke"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.1",
     "globals": "^17.5.0",
     "playwright-core": "^1.62.1",
     "postcss": "^8.4.49",


### PR DESCRIPTION
## 问题与结果

- 解决的问题：前端缺少「不必要的 effect」检测；个别 effect 可用渲染期计算替代，多数必要 effect 缺少「为何必须用 effect」的说明。
- 用户可见结果：无行为变化；lint 新增 `react-you-might-not-need-an-effect` 规则（recommended，warn 级）。
- 本 PR 不处理：不重构移动端外部投影、数据获取、DOM 操作、legacy 插件 DOM 契约等必要 effect。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`none`
- `capability_owner`：`not_applicable`
- `consumer_scope`：frontend（dashboard + chat + ai-elements 展示层）
- `runtime_patch`：`none`
- `runtime_patch_reason`：无
- `authoritative_state_owner`：`not_applicable`（纯前端展示层，无持久状态）
- `client_only_alternative`：`not_applicable`
- 关联不变量：无
- `protected_state`：无
- 允许的副作用：`package.json` / `package-lock.json` 新增 1 个 devDependency
- 禁止的副作用：无

## 改动范围

- 主要文件：`eslint.config.js`、`package.json`、`frontend/chat` 与 `frontend/dashboard` 共 8 个 tsx 文件
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：无变化
- 回滚方式：`git revert 79b61189`

## 验证

- [x] 相关 targeted tests 已通过：`test:mobile-web-state`（125 pass）、`test:desktop-navigation`（41 pass）
- [x] 前端 typecheck / lint 已通过：`tsc --noEmit` 通过；lint 0 error、60 warning（全部为已标注的必要 effect 误报）
- [ ] `python docker/debug/gate.py run --base origin/main`：纯前端展示层改动，未本地运行，交由 CI `change-impact-gate` 验证
- 未运行项与原因：`gate.py`（不涉及 core 语义、协议或持久化）

## 工作手册

无需更新（不改变持久语义、产品意图或 owner）。
