### PR TITLE
fix(proactive): 注入北京时间锚点，修复主动推送把 UTC 当成当地时间的口吻错误

### DIFF
--- a/plugins/wake_proactive/prompt.py
+++ b/plugins/wake_proactive/prompt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from agent.prompting import (
@@ -13,6 +14,19 @@ from plugins.wake_proactive.context import WakeContext, content_candidate_map
 
 PromptMode = Literal["content", "alert", "context"]
 ContentPhase = Literal["screen", "final"]
+
+_CST = timezone(timedelta(hours=8))
+
+
+def _now_cst_text() -> str:
+    """当前北京时间（UTC+8）字符串，作为给 LLM 的本地时间锚点。
+
+    数据源（Fitbit/Steam/Feed 等）注入的时间戳均为 UTC（+00:00），
+    若不做标注，LLM 会把 UTC 的 04:xx 直接当成凌晨，导致作息判断
+    和推送口吻出错。这里显式给出北京时间并提醒转换。
+    """
+    return datetime.now(timezone.utc).astimezone(_CST).strftime("%Y-%m-%d %H:%M:%S")
+
 
 _SYSTEM_PROMPT = (
     "你正在处理一次主动唤醒。运行时会明确给出 mode，并且只开放当前 mode 可用的工具。"
@@ -91,7 +105,13 @@ def build_messages(
     """用稳定前缀渲染 content、alert 或 context 主动唤醒输入。"""
 
     # 1. 渲染所有 mode 共用的用户上下文
+    now_cst = _now_cst_text()
     sections = [
+        (
+            f"【当前时间】{now_cst}（北京时间，UTC+8）。\n"
+            "数据源时间戳若带 +00:00 后缀则为 UTC，判断用户作息、内容新鲜度或"
+            "'此刻'时请先转换为北京时间；不要在消息里提及本提示。"
+        ),
         f"【固定 MEMORY.md】\n{memory_text}",
         f"【固定 PROACTIVE_CONTEXT.md】\n{proactive_context}",
         f"【截至当前时间的最近被动对话】\n{recent_passive_conversation}",

--- a/tests/wake_proactive/test_runtime.py
+++ b/tests/wake_proactive/test_runtime.py
@@ -703,6 +703,27 @@ def test_prompt_exposes_current_context_and_only_selected_mode(mode) -> None:
         assert "本轮单条事件" in messages[1]["content"]
 
 
+def test_prompt_anchors_utc_source_times_to_beijing_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "plugins.wake_proactive.prompt._now_cst_text",
+        lambda: "2026-08-22 12:34:56",
+    )
+
+    messages = build_messages(
+        ctx=WakeContext(content_events=[]),
+        memory_text="",
+        proactive_context="",
+        recent_passive_conversation="",
+        recent_proactive_messages="",
+    )
+
+    prompt = messages[1]["content"]
+    assert "【当前时间】2026-08-22 12:34:56（北京时间，UTC+8）" in prompt
+    assert "+00:00 后缀则为 UTC" in prompt
+
+
 def test_content_final_prompt_has_no_default_share_or_skip_tendency() -> None:
     messages = build_messages(
         ctx=WakeContext(content_events=[]),


### PR DESCRIPTION
## 问题

主动推送链路（wake-proactive）组装 LLM 上下文时，所有数据源时间戳（observed_at / fetched_at / expires_at 等）均为 UTC（+00:00），但 prompt 里没有给出当前时间的本地时区锚点。LLM 看到 04:xx 按字面理解为凌晨，导致**本地中午生成的推送写出凌晨快四点半了**这类与真实时间完全不符的口吻。

## 复现证据

- 08-19 12:23 CST，proactive tick 生成内容，LLM 请求快照中注入的时间戳全是 UTC（observed_at 04:23:17+00:00 等）
- 推送原文：凌晨快四点半了，你还醒着——实际是中午 12:23

## 修复

`build_messages()` 的 user 上下文开头注入【当前时间】块：

- 显式给出当前北京时间（UTC+8）作为锚点
- 提示数据源 +00:00 后缀为 UTC，判断用户作息/内容新鲜度时先转换
- 要求 LLM 不在消息里提及该提示

## 验证

- `pytest -q tests/wake_proactive/test_runtime.py`：34 passed，含固定时钟断言
- Change Gate exact head `729ead9b00493fd16a7abea0050727de00d415ef`：passed，24 个公开场景
  - report: `docker/debug/reports/change-gate/20260822-082633-d90bb6d1/gate.json`
  - source digest: `db7fb05a00a99c5ed33ebcb68013c3f064db5ad8e63a34c9764ba58a6419d3f2`
  - plan digest: `60a4bf33aab3e66bfb75d0d08e38b1d7d3fcdc8e7be4c2b144918170ae460769`

## 影响面

仅 wake-proactive 的 prompt 输入侧；对输出侧已有的 PROACTIVE_CONTEXT.md 统一北京时间规则形成输入侧配套。
