### PR TITLE
fix(web): 暂停后终态帧不再携带 null duration_ms

### DIFF
--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -13,10 +13,12 @@ test("WebSocket boundary validates every frame family and observable trace lane"
   const answer = parseChatFrame({ type: "answer.delta", session_id: "one", turn_id: "turn", delta: "答" });
   const terminal = parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "答案", duration_ms: 42 });
   const terminalFromString = parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "答案", duration_ms: "42" });
+  const terminalNullDuration = parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "答案", duration_ms: null });
   assert.equal(traceKindForChatFrame(thinking), "thinking");
   assert.equal(traceKindForChatFrame(answer), "answer");
   assert.equal(traceKindForChatFrame(terminal), "terminal");
   assert.equal(terminalFromString.duration_ms, 42);
+  assert.equal(terminalNullDuration.duration_ms, null);
   assert.throws(() => parseChatFrame({ type: "answer.delta", session_id: "one" }), /缺少字符串字段: turn_id/u);
   assert.throws(() => parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "x", duration_ms: "42ms" }), /duration_ms 格式无效/u);
   assert.throws(() => parseChatFrame({ type: "future.frame" }), /未知消息类型/u);

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -67,7 +67,7 @@ export function parseChatFrame(value: unknown): ChatFrame {
       if (frame.media !== undefined && (!Array.isArray(frame.media) || frame.media.some((item) => typeof item !== "string"))) {
         throw new Error("message.final.media 格式无效");
       }
-      if (frame.duration_ms !== undefined) {
+      if (frame.duration_ms != null) {
         const durationMs = parseDurationMs(frame.duration_ms);
         if (durationMs === null) {
           console.debug(

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -286,8 +286,10 @@ class WebChatChannel:
             "thinking": message.thinking or "",
             "media": media,
             "metadata": metadata,
-            "duration_ms": metadata.get("turn_duration_ms"),
         }
+        duration_ms = metadata.get("turn_duration_ms")
+        if duration_ms is not None:
+            frame["duration_ms"] = duration_ms
 
         logger.debug(
             "[web_chat] deliver_message session=%s type=%s source=%s",

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -847,7 +847,6 @@ async def test_web_attach_refills_cached_terminal() -> None:
         "content": "answer",
         "thinking": "reasoning",
         "media": [],
-        "duration_ms": None,
         "metadata": {},
     }]
     assert "web:abc" not in channel._pending_terminal


### PR DESCRIPTION
## 问题与结果

- 解决的问题：点击「暂停」(turn.stop) 后，前端报 `message.final.duration_ms 格式无效`，终态帧解析失败、回复按钮卡在「中止回答」。
- 用户可见结果：暂停后消息正常收敛到终态，按钮恢复「发送消息」，不再报错。
- 本 PR 不处理：断线时终态帧补投的既有链路（已在 #449 处理）；暂停后中断路径本身仍不产生 `turn_duration_ms`，只是不再把 `null` 塞进帧。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`protocol`
- `consumer_scope`：Web Chat 前端与服务端 Web channel
- `runtime_patch`：`none`
- `runtime_patch_reason`：不适用
- `authoritative_state_owner`：`infra/channels/web_chat_channel.py` 构造的 `message.final` 帧
- `client_only_alternative`：前端已同时把 `duration_ms: null` 视为未提供，可独立容错
- 关联不变量：`message.final.duration_ms` 为可选 number，缺省时前端用 `startedAt` 兜底
- `protected_state`：正常完成路径的 `duration_ms`（int）照旧发送；消息正文只追加
- 允许的副作用：无数据库/进程/网络变化
- 禁止的副作用：不改变暂停的其它语义

## 改动范围

- 主要文件：
  - `infra/channels/web_chat_channel.py`
  - `frontend/chat/src/web-chat-transport.ts`
  - `tests/test_web_chat_channel.py`
  - `frontend/chat/src/web-chat-transport.test.mjs`
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无 schema 变化
- 协议 source、runtime、provider 与 scenario 的不可变 revision：无协议 revision 变化
- 回滚方式：revert 本 commit；服务端重启、前端 `npm run build:chat` 重建

## 验证

- [x] 相关 targeted tests 已通过（`tests/test_web_chat_channel.py` 23 passed；`web-chat-transport.test.mjs` 8 pass）。
- [x] 前端 typecheck/lint 已通过；Python ruff 未安装，未运行（已说明）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，GATE PASSED。
- `planDigest`：`99c5ead0361fa614c1a3cea6d21b0d01eed0301ae81f273552d255987c2aff44`
- 真实设备证据：不适用（纯协议契约修复）
- 未运行项与原因：ruff（环境未安装）

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。
