### PR TITLE
fix(plugins): allow semantic gate to authorize candidate switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Akashic 理想上的动作应该是：
 │  ├─ 识别 GitHub 插件仓库
 │  ├─ 执行 plugin-install
 │  ├─ 检查 manifest.toml 与 plugin.py
-│  └─ Runtime 自动发现并原子发布新快照
+│  └─ Runtime readiness 与语义检查通过后原子发布新快照
 └─ 不重启，下一次执行使用新代际
 ```
 
-安装、升级、启停、源码和 `config.local.toml` 修改都会自动热重载。正在执行的请求保持旧代际，新请求统一使用新代际；候选验证失败时继续保留旧版本。
+安装、升级、启停、源码和 `config.local.toml` 修改都会自动热重载。正在执行的请求保持旧代际，新请求统一使用新代际。安装候选的 readiness 与 `readiness_semantic_checks` 均通过即可切换；attached child 的真实工具证据是可选的增强验证，不是安装生效的必要条件。任一 gate 失败时继续保留旧版本。
 
 想看完整机制，直接看 [插件系统 Handbook](./_handbook/plugins-tutorial.md)。
 

--- a/_handbook/plugins-tutorial.md
+++ b/_handbook/plugins-tutorial.md
@@ -248,6 +248,11 @@ python main.py plugin-install \
 python main.py plugin-doctor --plugin demo@github
 ```
 
+`plugin-install` 会在隔离候选上完成 MCP readiness，并执行插件声明的
+`readiness_semantic_checks`。两者通过后，Core 会在当前 turn 正常结束时自动切换；不要求
+attached programmatic child 再次调用候选工具。child 工具轨迹仍可作为额外验证证据。
+readiness 或语义检查失败时，候选会被丢弃，原 stable 版本保持不变。
+
 运行中的 Runtime 会自动应用启停和卸载变化：
 
 ```bash

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -2029,6 +2029,27 @@ class PluginManager:
             "candidate_error": None if transaction is None else transaction.error,
         }
 
+    def candidate_semantic_gate_passed(
+        self,
+        plugin_id: str,
+        generation_id: str,
+    ) -> bool:
+        """Return whether a ready candidate passed MCP readiness and semantic checks."""
+
+        ready = self._ready_candidate
+        if ready is None or ready.plugin_id != plugin_id:
+            return False
+        candidate = ready.candidate
+        if candidate.generation_id != generation_id:
+            return False
+        required = {"mcp_readiness", "readiness_semantic_checks"}
+        checks = {
+            check.check_id: check.status
+            for check in candidate.gate_result.checks
+            if check.check_id in required
+        }
+        return all(checks.get(check_id) == "passed" for check_id in required)
+
     def candidate_child_evidence(
         self,
         plugin_id: str,

--- a/agent/plugins/turn_rollout.py
+++ b/agent/plugins/turn_rollout.py
@@ -30,6 +30,7 @@ class PendingPluginOperation:
     source_revision: str = ""
     reload_tx_id: str = ""
     validation_evidence: tuple[str, ...] = ()
+    semantic_gate_passed: bool = False
     sealed: bool = False
 
 
@@ -83,6 +84,10 @@ class TurnPluginRollout:
             if not generation_id or not reload_tx_id:
                 await self._manager.drop_candidate(plugin_id)
                 raise RuntimeError("插件候选缺少 generation 或 reload transaction 身份")
+            semantic_gate_passed = self._manager.candidate_semantic_gate_passed(
+                plugin_id,
+                generation_id,
+            )
             self._pending = PendingPluginOperation(
                 owner_turn_id=owner_turn_id,
                 plugin_id=plugin_id,
@@ -90,6 +95,7 @@ class TurnPluginRollout:
                 generation_id=generation_id,
                 source_revision=result.source_revision,
                 reload_tx_id=reload_tx_id,
+                semantic_gate_passed=semantic_gate_passed,
             )
             register_plugin_child_capability_minter(
                 owner_turn_id,
@@ -102,6 +108,7 @@ class TurnPluginRollout:
                         "event": "turn_operation_registered",
                         "owner_turn_id": owner_turn_id,
                         "operation": "install",
+                        "semantic_gate_passed": semantic_gate_passed,
                     },
                 )
             return result, status
@@ -342,10 +349,15 @@ class TurnPluginRollout:
         try:
             if status is not TurnStatus.COMPLETED:
                 await self._cancel(pending, f"parent turn {status.value}")
-            elif pending.kind == "install" and not pending.validation_evidence:
+            elif (
+                pending.kind == "install"
+                and not pending.validation_evidence
+                and not pending.semantic_gate_passed
+            ):
                 await self._cancel(
                     pending,
-                    "attached programmatic child 没有成功使用 candidate-owned Tool/Skill",
+                    "候选 readiness/语义 gate 未通过，且 attached programmatic child "
+                    "没有成功使用 candidate-owned Tool/Skill",
                 )
             elif pending.kind == "install":
                 await self._manager.switch_ready(pending.plugin_id)

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -985,9 +985,10 @@ class AppRuntime:
         publication = status["candidate_state"] if result.staged_candidate else "stable"
         message = (
             f"{plugin_id} 候选版本安装成功。当前 turn 仍使用原版本；"
-            "本 turn 启动的 attached programmatic 验证会自动使用新版本。"
-            "验证正确后请正常结束当前 turn，系统会在本轮结束后自动切换，"
-            "下一 turn 生效；如果结果或轨迹不正确，请先执行 plugin-revert。"
+            "候选 readiness 与语义检查已通过。"
+            "本 turn 启动的 attached programmatic 验证仍可作为额外证据。"
+            "请正常结束当前 turn，系统会在本轮结束后自动切换，下一 turn 生效；"
+            "如果结果或轨迹不正确，请先执行 plugin-revert。"
             if result.staged_candidate
             else f"{plugin_id} 已经是当前安装版本；没有创建候选，也不需要重启。"
         )

--- a/docs/design/plugin-install-uninstall-turn-boundary-rollout.md
+++ b/docs/design/plugin-install-uninstall-turn-boundary-rollout.md
@@ -18,9 +18,9 @@ plugin-revert     撤销当前 turn 最近一次尚未提交的 install/uninstal
 
 Agent 不再执行 `plugin-status`、`plugin-promote`、`plugin-discard` 或手工 restart。Core 保留 stable/latest、准备、验证绑定、提交、丢弃、排空、端点切换和恢复等内部机制，但不要求 Agent 理解或编排这些阶段。
 
-`plugin-install` 成功后，当前 turn 自己仍绑定原 stable；由该 turn 启动的 attached programmatic child 自动绑定刚安装的候选。Agent 根据真实 child 结果和工具轨迹决定：符合目标就正常结束 turn，不符合就先 `plugin-revert`，修改源码后继续递归。
+`plugin-install` 成功后，当前 turn 自己仍绑定原 stable。候选已由隔离 MCP catalog 完成 readiness 与 `readiness_semantic_checks`；由该 turn 启动的 attached programmatic child 仍可绑定候选并提供额外的真实工具轨迹。Agent 发现结果不符合目标时先 `plugin-revert`，修改源码后继续递归。
 
-当前 turn 正常结束且候选已完成 programmatic 验证时，Core 才在旧 lease 释放后自动切换。下一 turn 自动绑定新 stable。
+当前 turn 正常结束，且候选语义 gate 通过或已有有效 child evidence 时，Core 在旧 lease 释放后自动切换。下一 turn 自动绑定新 stable。
 
 ## 2. 当前事实与有意语义变化
 
@@ -67,19 +67,18 @@ managed service host  ChannelHost
 
 命令返回成功前，Core 必须完成 artifact 身份、manifest、依赖、Skill/MCP/tool catalog、managed service/Channel 声明、名称冲突、受保护 write set 和恢复源检查，并把 pending install 绑定到当前 turn。
 
-成功返回表示候选已经可以由当前 turn 的 programmatic child 验证，不表示正式 endpoint 已经切换：
+成功返回表示候选的 readiness 与语义检查已经通过，并且仍可由当前 turn 的 programmatic child 做增强验证；不表示正式 endpoint 已经切换：
 
 ```text
 Fitbit 候选版本安装成功。
 
 当前 turn 仍使用原版本。
-从现在开始，本 turn 启动的 programmatic 验证会自动使用新版本。
+候选 readiness 与语义检查已经通过。
+本 turn 启动的 programmatic 验证仍可自动使用新版本，作为额外验证。
 
-请执行 programmatic 验证：
-- 如果行为和工具轨迹正确，正常结束当前 turn；
-- 如果不正确，执行 plugin-revert，然后继续修改。
+如果发现候选行为不正确，请执行 plugin-revert，然后继续修改；否则正常结束当前 turn。
 
-验证通过并结束当前 turn 后，系统会自动重启 Fitbit 服务。
+结束当前 turn 后，系统会自动重启 Fitbit 服务。
 下一 turn 使用新版本。你不需要 promote、discard 或 restart。
 ```
 
@@ -99,7 +98,7 @@ Turn T 执行 install S1
 
 Core 记录 `owner_turn_id + candidate_generation_id + source_revision`。child 在创建时冻结候选身份；T 后续安装其他 revision 不得让已经运行的 child 半途换代。
 
-至少一个绑定当前候选的 attached child 必须正常完成，当前 turn 才能授权提交。child 失败、取消、超时、身份不一致或根本没有运行时，Core 在 turn 结束时取消 pending install，不发布候选。
+readiness 与 `readiness_semantic_checks` 均通过即可授权提交；有效的 attached child Tool/Skill evidence 是兼容的另一条授权依据，不再是必要条件。若语义 gate 未通过且没有有效 child evidence，Core 在 turn 结束时取消 pending install，不发布候选。
 
 Core 只核对 child 确实绑定候选、真实 terminal/tool trace 存在且没有越过 write-set 边界。Fitbit 领域结果与轨迹是否符合修改目标由 Agent 判断；不符合时 Agent 必须在结束 turn 前执行 `plugin-revert`。
 
@@ -158,12 +157,12 @@ programmatic child 验证候选           切换 endpoint 与 snapshot
 
 ```text
 install 前置检查成功
-AND 当前 candidate 完成真实 attached programmatic 验证
+AND 当前 candidate 的 readiness + 语义 gate 通过，或存在真实 attached child evidence
 AND 没有 revert
 AND parent turn 正常完成
 ```
 
-parent turn interrupted/failed、验证 child 非正常终结或候选身份变化时，Core 自动取消候选，旧 stable 不变。pending uninstall 只有在 parent turn 正常完成且没有 revert 时才执行。
+parent turn interrupted/failed、候选身份变化，或 readiness/语义 gate 失败且无有效 child evidence 时，Core 自动取消候选，旧 stable 不变。pending uninstall 只有在 parent turn 正常完成且没有 revert 时才执行。
 
 Core 不主动创建 turn、不主动发送用户消息，也不向 SessionDB 追加伪造对话。用户下一次主动发起 turn 时，runtime 从 journal 与当前 snapshot 派生最近一次相关操作的事实，供 Agent 自然语言回答，不要求 status 或轮询。
 
@@ -250,13 +249,13 @@ new Channel.start()
 
 ### Goal
 
-Agent 只用 `install/uninstall/revert` 管理插件；install 后的 programmatic child 自动验证当前候选，失败可在同一 turn revert 并继续递归，成功则由 Core 在 turn 后安全提交；uninstall 与 revert 保持代码、plugin-data 和错误语义明确。
+Agent 只用 `install/uninstall/revert` 管理插件；install 的 readiness 与语义检查在隔离候选上完成，programmatic child 可提供额外证据，失败可在同一 turn revert 并继续递归，成功则由 Core 在 turn 后安全提交；uninstall 与 revert 保持代码、plugin-data 和错误语义明确。
 
 ### Success criteria
 
 - [x] Agent 可见插件管理动作只有 install、uninstall、revert。
 - [x] 当前 turn 自己保持旧 snapshot；其 attached programmatic child 自动、精确绑定当前 candidate。
-- [x] 没有真实 programmatic 验证、child 非正常结束、parent 非正常结束或已经 revert 时，candidate 不得发布。
+- [x] readiness/语义 gate 未通过且没有有效 child evidence、parent 非正常结束或已经 revert 时，candidate 不得发布。
 - [x] revert 只撤销同一 turn 最近 pending install/uninstall，不能跨 turn 回滚。
 - [x] install/uninstall 返回说明已发生、未发生、后续动作和 Agent 下一步。
 - [x] 独占 service/Channel 不绕过 coexistence Gate，在隔离验证或 turn 后维护切换中处理。
@@ -283,7 +282,7 @@ client_only_alternative: "只改 Skill 无法关闭 Agent 手工 promote/discard
 invariants:
   - "父 turn 从 admission 到 terminal 始终绑定旧 snapshot。"
   - "attached programmatic child 按 owner turn 精确绑定候选。"
-  - "未验证、已 revert 或非正常终结的候选不得发布。"
+  - "readiness/语义 gate 与 child evidence 均未通过、已 revert 或 parent 非正常终结的候选不得发布。"
   - "独占 endpoint 先停 admission，再等待全部旧 lease 归零。"
   - "endpoint、snapshot、pointer 和 manifest 共同提交或恢复。"
   - "plugin-data、SessionDB/messages 和 memory 不因插件管理减少。"
@@ -360,11 +359,11 @@ schema_lineages:
 
 | 场景 | 必须观察到的结果 |
 |---|---|
-| install 后父 turn | 父继续使用 S0；返回明确要求 programmatic 验证 |
+| install 后父 turn | 父继续使用 S0；返回 readiness/语义 gate 结果，programmatic 验证可选 |
 | attached programmatic child | 自动绑定 S1，真实 tool/Skill/trace 来自同一 candidate identity |
 | programmatic 失败后 revert | S1不发布，S0始终不变；修复后可 install S2继续递归 |
-| 没有 programmatic 就结束 | pending install自动取消，下一 turn仍是 S0 |
-| 验证通过且正常结束 | turn 后排空 S0并提交 S1；下一 turn自动使用 S1 |
+| 没有 programmatic 就结束 | 语义 gate 通过则提交；否则因无 child evidence 取消并保持 S0 |
+| 语义 gate 或 child evidence 通过且正常结束 | turn 后排空 S0并提交 S1；下一 turn自动使用 S1 |
 | pending uninstall 后 revert | manifest、代码、能力和 plugin-data均保持原样 |
 | uninstall 正常提交 | turn 后停止 endpoint、移除能力和代码；plugin-data保留 |
 | 跨 turn revert | 明确失败，不改变当前 stable；需要修复后 install或明确 uninstall |

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -117,6 +117,87 @@ def _after_step_ctx(**overrides: object) -> AfterStepCtx:
     return AfterStepCtx(**defaults)
 
 
+@pytest.mark.parametrize(
+    ("checks", "expected"),
+    [
+        (
+            (
+                ("mcp_readiness", "passed"),
+                ("readiness_semantic_checks", "passed"),
+            ),
+            True,
+        ),
+        ((("mcp_readiness", "passed"),), False),
+        (
+            (
+                ("mcp_readiness", "passed"),
+                ("readiness_semantic_checks", "failed"),
+            ),
+            False,
+        ),
+    ],
+)
+def test_candidate_semantic_gate_requires_both_checks(
+    checks: tuple[tuple[str, str], ...],
+    expected: bool,
+) -> None:
+    manager = _make_manager([], event_bus=EventBus())
+    manager._ready_candidate = cast(
+        Any,
+        SimpleNamespace(
+            plugin_id="demo@github",
+            candidate=SimpleNamespace(
+                generation_id="gen-1",
+                gate_result=SimpleNamespace(
+                    checks=tuple(
+                        SimpleNamespace(check_id=check_id, status=status)
+                        for check_id, status in checks
+                    )
+                ),
+            ),
+        ),
+    )
+
+    assert (
+        manager.candidate_semantic_gate_passed("demo@github", "gen-1")
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("plugin_id", "generation_id"),
+    [
+        ("other@github", "gen-1"),
+        ("demo@github", "gen-2"),
+    ],
+)
+def test_candidate_semantic_gate_rejects_mismatched_candidate_identity(
+    plugin_id: str,
+    generation_id: str,
+) -> None:
+    manager = _make_manager([], event_bus=EventBus())
+    manager._ready_candidate = cast(
+        Any,
+        SimpleNamespace(
+            plugin_id="demo@github",
+            candidate=SimpleNamespace(
+                generation_id="gen-1",
+                gate_result=SimpleNamespace(
+                    checks=(
+                        SimpleNamespace(check_id="mcp_readiness", status="passed"),
+                        SimpleNamespace(
+                            check_id="readiness_semantic_checks",
+                            status="passed",
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    assert manager.candidate_semantic_gate_passed(plugin_id, generation_id) is False
+
+
 # ── 加载测试 ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_plugin_turn_rollout.py
+++ b/tests/test_plugin_turn_rollout.py
@@ -18,6 +18,7 @@ class _Manager:
         self.annotations: list[tuple[str, dict[str, object]]] = []
         self.installed = {"fitbit@github"}
         self.staged_candidate = True
+        self.semantic_gate_passed = False
 
     async def install_candidate(self, **_kwargs):
         return (
@@ -58,6 +59,11 @@ class _Manager:
             and item.data.get("name") == "candidate_probe"
             and item.data.get("status") == "success"
         )
+
+    def candidate_semantic_gate_passed(self, plugin_id, generation_id):
+        assert plugin_id == "fitbit@github"
+        assert generation_id == "gen-2"
+        return self.semantic_gate_passed
 
 
 async def _settle() -> None:
@@ -124,6 +130,35 @@ async def test_attached_child_freezes_candidate_and_parent_promotes_after_valida
     assert manager.promoted == ["fitbit@github"]
     assert manager.discarded == []
     assert uninstalled == []
+    assert "已经成功提交" in rollout.consume_fact()
+    assert rollout.consume_fact() == ""
+
+
+@pytest.mark.asyncio
+async def test_semantic_gate_allows_parent_to_promote_without_child_evidence(
+    tmp_path: Path,
+):
+    manager = _Manager()
+    manager.semantic_gate_passed = True
+
+    async def uninstall(_plugin_id: str) -> dict[str, object]:
+        return {}
+
+    rollout = TurnPluginRollout(
+        cast(Any, manager), workspace=tmp_path, uninstall=uninstall
+    )
+    await rollout.install(
+        "turn-parent",
+        source="repo",
+        marketplace="github",
+        ref_name="",
+        sparse_paths=[],
+    )
+    rollout.turn_terminal("turn-parent", TurnStatus.COMPLETED, {}, ())
+    await _settle()
+
+    assert manager.promoted == ["fitbit@github"]
+    assert manager.discarded == []
     assert "已经成功提交" in rollout.consume_fact()
     assert rollout.consume_fact() == ""
 


### PR DESCRIPTION
## 问题

插件候选已经通过 MCP readiness 和 `readiness_semantic_checks` 后，
turn rollout 仍强制要求 attached programmatic child 提供候选 Tool/Skill evidence。

当没有 child evidence 时，`_resolve_parent` 会取消候选，导致已经完成语义验证的插件无法切换。

## 修改

- 根据实际 ready candidate 的 `plugin_id` 和 `generation_id` 读取 gate 结果。
- 仅当以下两项检查均为 `passed` 时认定 semantic gate 通过：
  - `mcp_readiness`
  - `readiness_semantic_checks`
- 将 semantic gate 结果记录到 pending install operation。
- parent turn 正常结束时，满足以下任一条件即可执行 `switch_ready`：
  - semantic gate 已通过；
  - 存在有效的 attached child evidence。
- 更新 README、插件 Handbook 和 rollout 设计文档。
- 补充 gate 缺失、失败及候选身份不匹配测试。

## 保持不变的失败语义

- readiness 或 semantic check 失败，且没有 child evidence 时，候选仍会取消。
- parent turn 失败、中断或执行 revert 时，候选仍不会发布。
- attached child 验证仍可作为额外证据。
- 未修改 capability 分发、控制面协议或 subagent 注入。

## 测试

```text
221 passed, 2 deselected