### PR TITLE
fix(provider): adapt tool schemas and catalog size for OpenCode Go

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1039,9 +1039,15 @@ class DefaultReasoner(Reasoner):
         if max_schemas <= 0 or len(normal_order) <= max_schemas:
             return set(normal_order), normal_order
 
-        # The newest preloaded tools are most likely relevant to the current session.
+        if len(always_on_order) > max_schemas:
+            raise RuntimeError(
+                "always_on 工具数量超过当前模型 endpoint 的 schema 上限："
+                f"{len(always_on_order)} > {max_schemas}"
+            )
+
+        # always_on 是运行时合同；预加载工具只能占用剩余槽位。
         projected = _project_tool_order(
-            ["tool_search", *reversed(preload_order), *always_on_order],
+            [*always_on_order, *reversed(preload_order)],
             max_schemas,
         )
         return set(projected), projected
@@ -2208,9 +2214,12 @@ class DefaultReasoner(Reasoner):
                             tools_unlocked.extend(_newly_unlocked)
                             if visible_order is not None:
                                 previous_visible = set(visible_order)
+                                always_on_order = self._tools.get_registered_order(
+                                    self._tools.get_always_on_names() - disabled
+                                )
                                 visible_order = _project_tool_order(
                                     [
-                                        "tool_search",
+                                        *always_on_order,
                                         *_newly_unlocked,
                                         *visible_order,
                                     ],
@@ -3150,8 +3159,10 @@ def build_turn_injection_prompt(
 def _provider_max_tool_schemas(provider: object) -> int:
     raw_limit = getattr(provider, "max_tool_schemas", 0)
     if isinstance(raw_limit, bool) or not isinstance(raw_limit, int):
-        return 0
-    return max(0, raw_limit)
+        raise TypeError("provider.max_tool_schemas 必须是整数")
+    if raw_limit < 0:
+        raise ValueError("provider.max_tool_schemas 不能为负数")
+    return raw_limit
 
 
 def _project_tool_order(candidates: list[str], limit: int) -> list[str]:

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1020,6 +1020,32 @@ class DefaultReasoner(Reasoner):
             self._build_prompt_render_phase(context) if context is not None else None
         )
 
+    def _initial_visible_tools(
+        self,
+        *,
+        preloaded_tools: set[str] | None,
+        preloaded_tool_order: list[str] | None,
+        disabled: set[str],
+    ) -> tuple[set[str], list[str]]:
+        always_on = self._tools.get_always_on_names() - disabled
+        always_on_order = self._tools.get_registered_order(always_on)
+        preload_order = [
+            name
+            for name in preloaded_tool_order or sorted(preloaded_tools or set())
+            if name not in disabled
+        ]
+        normal_order = list(dict.fromkeys([*always_on_order, *preload_order]))
+        max_schemas = _provider_max_tool_schemas(self._llm.provider)
+        if max_schemas <= 0 or len(normal_order) <= max_schemas:
+            return set(normal_order), normal_order
+
+        # The newest preloaded tools are most likely relevant to the current session.
+        projected = _project_tool_order(
+            ["tool_search", *reversed(preload_order), *always_on_order],
+            max_schemas,
+        )
+        return set(projected), projected
+
     def add_tool_hooks(self, hooks: list["ToolHook"]) -> None:
         self._tool_executor.add_hooks(hooks)
 
@@ -1401,7 +1427,12 @@ class DefaultReasoner(Reasoner):
             tools=self._tools,
             tool_search_enabled=self._tool_search_enabled,
             visible_names=(
-                (preloaded or set()) | disabled_tools
+                self._initial_visible_tools(
+                    preloaded_tools=preloaded,
+                    preloaded_tool_order=preloaded_order,
+                    disabled=disabled_tools,
+                )[0]
+                | disabled_tools
                 if self._tool_search_enabled
                 else None
             ),
@@ -1607,18 +1638,18 @@ class DefaultReasoner(Reasoner):
         before_step_phase, after_step_phase = self._runtime_step_phases()
         if self._tool_search_enabled:
             always_on = self._tools.get_always_on_names()
-            visible_names = (always_on | (preloaded_tools or set())) - disabled
-            visible_order = self._tools.get_registered_order(always_on - disabled)
-            seen_visible = set(visible_order)
-            for name in preloaded_tool_order or sorted(preloaded_tools or set()):
-                if name in visible_names and name not in seen_visible:
-                    visible_order.append(name)
-                    seen_visible.add(name)
+            visible_names, visible_order = self._initial_visible_tools(
+                preloaded_tools=preloaded_tools,
+                preloaded_tool_order=preloaded_tool_order,
+                disabled=disabled,
+            )
             logger.info(
-                "[tool_search] visible=%d 个工具 always_on=%d preloaded=%d need_search=%s",
+                "[tool_search] visible=%d 个工具 always_on=%d preloaded=%d "
+                "provider_limit=%s need_search=%s",
                 len(visible_names),
                 len(always_on),
                 len(preloaded_tools or set()),
+                _provider_max_tool_schemas(self._llm.provider) or "unlimited",
                 "yes" if len(visible_names) == len(always_on) else "maybe",
             )
 
@@ -1720,6 +1751,16 @@ class DefaultReasoner(Reasoner):
             elif schema_names is not None:
                 schema_names = [name for name in schema_names if name not in disabled]
             tool_schemas = self._tools.get_schemas(names=schema_names)
+            max_tool_schemas = _provider_max_tool_schemas(self._llm.provider)
+            if (
+                max_tool_schemas > 0
+                and len(tool_schemas) > max_tool_schemas
+                and not self._tool_search_enabled
+            ):
+                raise RuntimeError(
+                    "当前模型 endpoint 最多接受 "
+                    f"{max_tool_schemas} 个工具 schema；请开启 tool_search 后重试"
+                )
             call_result = await self._call_provider(
                 compaction_state,
                 messages,
@@ -2164,14 +2205,24 @@ class DefaultReasoner(Reasoner):
                             if name not in visible_names and name not in disabled
                         ]
                         if _newly_unlocked:
-                            visible_names.update(_newly_unlocked)
                             tools_unlocked.extend(_newly_unlocked)
                             if visible_order is not None:
-                                seen_visible = set(visible_order)
-                                for name in _newly_unlocked:
-                                    if name not in seen_visible:
-                                        visible_order.append(name)
-                                        seen_visible.add(name)
+                                previous_visible = set(visible_order)
+                                visible_order = _project_tool_order(
+                                    [
+                                        "tool_search",
+                                        *_newly_unlocked,
+                                        *visible_order,
+                                    ],
+                                    _provider_max_tool_schemas(self._llm.provider),
+                                )
+                                visible_names = set(visible_order)
+                                dropped = previous_visible - visible_names
+                                if dropped:
+                                    logger.info(
+                                        "[工具投影] 为新解锁工具释放 schema 槽位: %s",
+                                        sorted(dropped),
+                                    )
                             logger.info(
                                 "[工具解锁] tool_search 新解锁: %s",
                                 sorted(_newly_unlocked),
@@ -3094,6 +3145,23 @@ def build_turn_injection_prompt(
     if not tool_search_enabled:
         return ""
     return build_deferred_tools_hint(tools, visible=visible_names)
+
+
+def _provider_max_tool_schemas(provider: object) -> int:
+    raw_limit = getattr(provider, "max_tool_schemas", 0)
+    if isinstance(raw_limit, bool) or not isinstance(raw_limit, int):
+        return 0
+    return max(0, raw_limit)
+
+
+def _project_tool_order(candidates: list[str], limit: int) -> list[str]:
+    ordered = list(dict.fromkeys(name for name in candidates if name))
+    if "tool_search" in ordered:
+        ordered.remove("tool_search")
+        ordered.insert(0, "tool_search")
+    if limit <= 0:
+        return ordered
+    return ordered[:limit]
 
 
 def build_deferred_tools_hint(

--- a/agent/model_runtime/provider_profiles.py
+++ b/agent/model_runtime/provider_profiles.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
 
 OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1"
+OPENCODE_GO_MAX_TOOL_SCHEMAS = 16
 
 
 @dataclass(frozen=True)
@@ -11,6 +13,7 @@ class ProviderProfile:
     default_base_url: str
     messages_model_prefixes: tuple[str, ...]
     input_modalities: tuple[str, ...] = ("text",)
+    max_tool_schemas: int = 0
 
     def classify_model(self, model: str) -> str:
         """排除已知 Messages 家族，其余模型默认走 Chat Completions。"""
@@ -26,6 +29,9 @@ OPENCODE_GO_PROFILE = ProviderProfile(
     provider_id="opencode-go",
     default_base_url=OPENCODE_GO_BASE_URL,
     messages_model_prefixes=("minimax-", "qwen"),
+    # Verified compatibility ceiling for the OpenCode Go endpoint. Larger local
+    # catalogs remain available through tool_search instead of being discarded.
+    max_tool_schemas=OPENCODE_GO_MAX_TOOL_SCHEMAS,
 )
 
 _PROFILES = {
@@ -35,6 +41,37 @@ _PROFILES = {
 
 def get_provider_profile(provider: str) -> ProviderProfile | None:
     return _PROFILES.get(provider.strip().lower())
+
+
+def is_opencode_go_base_url(base_url: str) -> bool:
+    """Match the persisted wire endpoint, independent of the runtime display name."""
+
+    value = base_url.strip()
+    if not value:
+        return False
+    parsed = urlsplit(value)
+    normalized = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            "",
+            "",
+        )
+    )
+    return normalized == OPENCODE_GO_BASE_URL
+
+
+def get_runtime_provider_profile(
+    *,
+    provider: str,
+    base_url: str,
+) -> ProviderProfile | None:
+    """Resolve compatibility from the actual endpoint before the logical provider id."""
+
+    if is_opencode_go_base_url(base_url):
+        return OPENCODE_GO_PROFILE
+    return get_provider_profile(provider)
 
 
 def validate_profile_runtime(

--- a/agent/model_runtime/registry.py
+++ b/agent/model_runtime/registry.py
@@ -371,6 +371,19 @@ class RoleBoundProvider(LLMProvider):
 
         return self._resolved_runtime().max_output_tokens
 
+    @property
+    def max_tool_schemas(self) -> int:
+        """Resolve the tool cap from the selected runtime's actual wire endpoint."""
+
+        from agent.model_runtime.provider_profiles import get_runtime_provider_profile
+
+        runtime = self._resolved_runtime()
+        profile = get_runtime_provider_profile(
+            provider=runtime.provider,
+            base_url=runtime.base_url,
+        )
+        return profile.max_tool_schemas if profile is not None else 0
+
     def estimate_context_tokens(
         self,
         messages: list[dict],

--- a/agent/provider.py
+++ b/agent/provider.py
@@ -29,6 +29,10 @@ from agent.llm_json import load_json_object_loose
 from agent.model_runtime.auth.codex import CodexAuthDriver
 from agent.model_runtime.auth.store import CredentialStore
 from agent.model_runtime.errors import ContextWindowError
+from agent.model_runtime.provider_profiles import (
+    get_runtime_provider_profile,
+    is_opencode_go_base_url,
+)
 from agent.model_runtime.transports.responses import CodexResponsesTransport
 from agent.model_runtime.types import (
     LLMResponse,
@@ -112,6 +116,9 @@ class _StreamHttpTelemetry:
 
 
 class ProviderStrategy:
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return tools
+
     def normalize_messages(self, messages: list[dict]) -> list[dict]:
         return _strip_reasoning_content(_normalize_chat_messages(messages))
 
@@ -233,6 +240,9 @@ class DashScopeStrategy(ProviderStrategy):
 
 
 class OpenCodeGoStrategy(ProviderStrategy):
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return _normalize_opencode_go_tools(tools)
+
     def prepare_stream_request(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         stream_kwargs = {**kwargs, "stream": True}
         stream_options = dict(stream_kwargs.get("stream_options") or {})
@@ -250,6 +260,13 @@ class OpenCodeGoStrategy(ProviderStrategy):
             return super().extract_message(msg, raw)
         text = str(reasoning)
         return raw, text, {"reasoning_content": text}
+
+
+class OpenCodeGoDeepSeekStrategy(DeepSeekStrategy):
+    """DeepSeek model semantics over the OpenCode Go wire contract."""
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return _normalize_opencode_go_tools(tools)
 
 
 class OpenCodeGoGLMStrategy(OpenCodeGoStrategy):
@@ -427,7 +444,7 @@ class ChatCompletionsRuntime:
         if request.max_output_tokens > 0:
             kwargs["max_tokens"] = request.max_output_tokens
         if request.tools:
-            kwargs["tools"] = request.tools
+            kwargs["tools"] = strategy.normalize_tools(request.tools)
             kwargs["tool_choice"] = request.tool_choice
         merged_extra_body = dict(self._extra_body)
         merged_extra_body.update(request.extra_body)
@@ -1059,6 +1076,11 @@ class LLMProvider:
         self._runtime_id = runtime_id
         self._extra_body = dict(extra_body or {})
         self._context_window = int(context_window)
+        profile = get_runtime_provider_profile(
+            provider=provider_name,
+            base_url=base_url or "",
+        )
+        self._max_tool_schemas = profile.max_tool_schemas if profile is not None else 0
         self._force_disable_thinking = force_disable_thinking
         if self._context_window < 0:
             raise ValueError("context_window 不能小于 0")
@@ -1136,6 +1158,12 @@ class LLMProvider:
         """Return the stable runtime identity used by durable compaction receipts."""
 
         return self._runtime_id
+
+    @property
+    def max_tool_schemas(self) -> int:
+        """Maximum schemas accepted by the current wire endpoint; 0 means unlimited."""
+
+        return self._max_tool_schemas
 
     def estimate_context_tokens(
         self,
@@ -1502,10 +1530,12 @@ def _select_provider_strategy(
     base_url: str,
     model: str,
 ) -> ProviderStrategy:
-    if provider_name.strip().lower() == "opencode-go":
+    if provider_name.strip().lower() == "opencode-go" or is_opencode_go_base_url(
+        base_url
+    ):
         normalized_model = model.strip().lower()
         if normalized_model.startswith("deepseek-"):
-            return DeepSeekStrategy()
+            return OpenCodeGoDeepSeekStrategy()
         if normalized_model.startswith("glm-"):
             return OpenCodeGoGLMStrategy()
         if normalized_model.startswith("kimi-"):
@@ -1523,6 +1553,81 @@ def _select_provider_strategy(
     ):
         return DashScopeStrategy()
     return ProviderStrategy()
+
+
+_OPENCODE_GO_SCHEMA_KEYS = frozenset(
+    {
+        "type",
+        "description",
+        "properties",
+        "required",
+        "items",
+        "enum",
+    }
+)
+
+
+def _normalize_opencode_go_tools(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project JSON Schema to the subset accepted by OpenCode Go."""
+
+    normalized: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            normalized.append(dict(tool))
+            continue
+        projected_function = {
+            key: value
+            for key, value in function.items()
+            if key in {"name", "description"}
+        }
+        parameters = function.get("parameters")
+        if isinstance(parameters, dict):
+            projected_function["parameters"] = _normalize_opencode_go_schema(parameters)
+        projected = dict(tool)
+        projected["function"] = projected_function
+        normalized.append(projected)
+    return normalized
+
+
+def _normalize_opencode_go_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    projected: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key not in _OPENCODE_GO_SCHEMA_KEYS:
+            continue
+        if key == "properties" and isinstance(value, dict):
+            projected[key] = {
+                str(name): _normalize_opencode_go_schema(child)
+                for name, child in value.items()
+                if isinstance(child, dict)
+            }
+        elif key == "items" and isinstance(value, dict):
+            projected[key] = _normalize_opencode_go_schema(value)
+        elif key == "enum" and isinstance(value, list):
+            projected[key] = [item for item in value if item is not None]
+        elif key == "type" and isinstance(value, list):
+            non_null = [item for item in value if item != "null"]
+            if non_null:
+                projected[key] = non_null[0]
+        else:
+            projected[key] = value
+
+    # Collapse the common nullable-union form instead of dropping its useful shape.
+    if "type" not in projected:
+        raw_branches = schema.get("anyOf") or schema.get("oneOf")
+        if isinstance(raw_branches, list):
+            branches = [
+                branch
+                for branch in raw_branches
+                if isinstance(branch, dict) and branch.get("type") != "null"
+            ]
+            if len(branches) == 1:
+                branch = _normalize_opencode_go_schema(branches[0])
+                branch.update(projected)
+                projected = branch
+    return projected
 
 
 def _drop_thinking_keys(extra_body: dict[str, Any]) -> None:

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -552,15 +552,15 @@ class ToolRegistry:
     ) -> DeferredToolNames:
         """返回所有 deferred 工具名，按来源分组。
 
-        visible: 当前 turn 已可见工具名（always_on + preloaded），从结果中排除。
-        deferred = 全量注册工具 - always_on - meta_tools - visible
+        visible: 当前 turn 实际已投影给 provider 的工具名，从结果中排除。
+        deferred = 全量注册工具 - meta_tools - visible。provider 上限挤出的
+        always_on 工具也必须可发现，否则模型无法通过 tool_search 重新加载。
         格式: {"builtin": [...], "mcp": {"server_name": [...], ...}}
         """
         view = self._runtime_view()
         if view is not self:
             return view.get_deferred_names(visible)
-        always_on = self.get_always_on_names()
-        excluded = always_on | _META_TOOLS | (visible or set())
+        excluded = _META_TOOLS | (visible or set())
         builtin: list[str] = []
         mcp: dict[str, list[str]] = {}
 

--- a/tests/test_loop_tool_visibility.py
+++ b/tests/test_loop_tool_visibility.py
@@ -284,18 +284,20 @@ class TestVisibilityGuard:
         )
         assert "当前工具状态" not in second_call_text
 
-    def test_provider_tool_limit_keeps_search_and_prioritizes_new_unlock(
+    def test_provider_tool_limit_keeps_always_on_and_prioritizes_new_unlock(
         self, tmp_path
     ):
         reg = ToolRegistry()
         reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
-        for name in ("always_a", "always_b", "always_c"):
+        for name in ("always_a", "always_b"):
             reg.register(_DummyTool(name), always_on=True)
+        reg.register(_DummyTool("old_preload"))
+        reg.register(_DummyTool("selected_tool"))
 
         schemas_seen: list[list[str]] = []
 
         class _LimitedProvider(_FakeProvider):
-            max_tool_schemas = 3
+            max_tool_schemas = 4
 
             async def chat(self, **kwargs: Any) -> LLMResponse:
                 schemas_seen.append(
@@ -308,7 +310,9 @@ class TestVisibilityGuard:
                 LLMResponse(
                     content="",
                     tool_calls=[
-                        ToolCall("s1", "tool_search", {"query": "select:always_c"})
+                        ToolCall(
+                            "s1", "tool_search", {"query": "select:selected_tool"}
+                        )
                     ],
                 ),
                 LLMResponse(content="done", tool_calls=[]),
@@ -317,15 +321,44 @@ class TestVisibilityGuard:
         loop = _make_loop(tmp_path, provider, reg)
 
         final, _, _, _, _ = asyncio.run(
-            loop._run_agent_loop([{"role": "user", "content": "use always_c"}])
+            loop._run_agent_loop(
+                [{"role": "user", "content": "use selected"}],
+                preloaded_tools={"old_preload"},
+            )
         )
 
         assert final == "done"
-        assert schemas_seen[0] == ["tool_search", "always_a", "always_b"]
-        assert schemas_seen[1][0:2] == ["tool_search", "always_c"]
-        assert all(len(names) <= 3 for names in schemas_seen)
+        assert schemas_seen[0] == [
+            "tool_search",
+            "always_a",
+            "always_b",
+            "old_preload",
+        ]
+        assert schemas_seen[1] == [
+            "tool_search",
+            "always_a",
+            "always_b",
+            "selected_tool",
+        ]
+        assert all(len(names) <= 4 for names in schemas_seen)
         deferred = reg.get_deferred_names(visible=set(schemas_seen[0]))
-        assert "always_c" in deferred["builtin"]
+        assert "selected_tool" in deferred["builtin"]
+
+    def test_provider_tool_limit_rejects_overfull_always_on_catalog(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
+        reg.register(_DummyTool("always_a"), always_on=True)
+        reg.register(_DummyTool("always_b"), always_on=True)
+
+        class _LimitedProvider(_FakeProvider):
+            max_tool_schemas = 2
+
+        loop = _make_loop(tmp_path, _LimitedProvider([]), reg)
+
+        with pytest.raises(RuntimeError, match="always_on 工具数量超过"):
+            asyncio.run(
+                loop._run_agent_loop([{"role": "user", "content": "hello"}])
+            )
 
 
 # ── LRU 测试 ──────────────────────────────────────────────────────────────────

--- a/tests/test_loop_tool_visibility.py
+++ b/tests/test_loop_tool_visibility.py
@@ -284,6 +284,49 @@ class TestVisibilityGuard:
         )
         assert "当前工具状态" not in second_call_text
 
+    def test_provider_tool_limit_keeps_search_and_prioritizes_new_unlock(
+        self, tmp_path
+    ):
+        reg = ToolRegistry()
+        reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
+        for name in ("always_a", "always_b", "always_c"):
+            reg.register(_DummyTool(name), always_on=True)
+
+        schemas_seen: list[list[str]] = []
+
+        class _LimitedProvider(_FakeProvider):
+            max_tool_schemas = 3
+
+            async def chat(self, **kwargs: Any) -> LLMResponse:
+                schemas_seen.append(
+                    [tool["function"]["name"] for tool in kwargs.get("tools") or []]
+                )
+                return await super().chat(**kwargs)
+
+        provider = _LimitedProvider(
+            [
+                LLMResponse(
+                    content="",
+                    tool_calls=[
+                        ToolCall("s1", "tool_search", {"query": "select:always_c"})
+                    ],
+                ),
+                LLMResponse(content="done", tool_calls=[]),
+            ]
+        )
+        loop = _make_loop(tmp_path, provider, reg)
+
+        final, _, _, _, _ = asyncio.run(
+            loop._run_agent_loop([{"role": "user", "content": "use always_c"}])
+        )
+
+        assert final == "done"
+        assert schemas_seen[0] == ["tool_search", "always_a", "always_b"]
+        assert schemas_seen[1][0:2] == ["tool_search", "always_c"]
+        assert all(len(names) <= 3 for names in schemas_seen)
+        deferred = reg.get_deferred_names(visible=set(schemas_seen[0]))
+        assert "always_c" in deferred["builtin"]
+
 
 # ── LRU 测试 ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -25,6 +25,11 @@ from agent.model_runtime.errors import (
     RetryableTransportError,
     TransportError,
 )
+from agent.model_runtime.provider_profiles import (
+    OPENCODE_GO_PROFILE,
+    get_runtime_provider_profile,
+    is_opencode_go_base_url,
+)
 from agent.model_runtime.transports.responses import (
     CodexResponsesTransport,
     _parse_usage,
@@ -171,6 +176,23 @@ def test_opencode_go_profile_is_dynamic_and_rejects_wrong_wire() -> None:
             context_window=64_000,
             input_modalities=("text", "image"),
         )
+
+
+def test_opencode_go_profile_follows_actual_base_url() -> None:
+    assert is_opencode_go_base_url("https://OPENCODE.AI/zen/go/v1/") is True
+    disguised = get_runtime_provider_profile(
+        provider="deepseek",
+        base_url="https://opencode.ai/zen/go/v1",
+    )
+    assert disguised is OPENCODE_GO_PROFILE
+    assert disguised.max_tool_schemas == 16
+    assert (
+        get_runtime_provider_profile(
+            provider="deepseek",
+            base_url="https://api.deepseek.com/v1",
+        )
+        is None
+    )
 
 
 def test_opencode_go_reasoning_efforts_follow_verbose_catalog() -> None:

--- a/tests/test_more_support_modules.py
+++ b/tests/test_more_support_modules.py
@@ -691,6 +691,93 @@ async def test_opencode_go_stream_requests_usage_chunk(
 
 
 @pytest.mark.asyncio
+async def test_opencode_go_endpoint_normalizes_tool_schema_even_when_provider_is_deepseek(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _FakeClient([_Response()])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "lookup",
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "default": "all",
+                        "minLength": 1,
+                    },
+                    "limit": {
+                        "anyOf": [
+                            {"type": "integer", "minimum": 1, "maximum": 10},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        },
+    }
+    provider = LLMProvider(
+        api_key="k",
+        base_url="https://opencode.ai/zen/go/v1",
+        provider_name="deepseek",
+        max_retries=0,
+    )
+
+    await provider.chat([], [tool], "deepseek-v4-flash", 10)
+
+    assert provider.max_tool_schemas == 16
+    sent_function = fake.calls[0]["tools"][0]["function"]
+    assert "strict" not in sent_function
+    sent_schema = sent_function["parameters"]
+    assert sent_schema == {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer"},
+        },
+        "required": ["query"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_official_deepseek_endpoint_keeps_tool_schema_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _FakeClient([_Response()])
+    monkeypatch.setattr("agent.provider.AsyncOpenAI", lambda **_: fake)
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "minimum": 1, "default": 5}
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+    provider = LLMProvider(
+        api_key="k",
+        base_url="https://api.deepseek.com/v1",
+        provider_name="deepseek",
+        max_retries=0,
+    )
+
+    await provider.chat([], [tool], "deepseek-chat", 10)
+
+    assert provider.max_tool_schemas == 0
+    assert fake.calls[0]["tools"] == [tool]
+
+
+@pytest.mark.asyncio
 async def test_provider_chat_stream_propagates_sdk_read_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_safety_retry_service.py
+++ b/tests/test_safety_retry_service.py
@@ -160,6 +160,7 @@ def _make_reasoner(
             Any,
             SimpleNamespace(
                 get_always_on_names=lambda: {"always"},
+                get_registered_order=lambda names=None: sorted(names or ()),
                 get_deferred_names=lambda visible=None: {
                     "builtin": [],
                     "mcp": {},


### PR DESCRIPTION
## 问题

持久化 runtime 的逻辑 provider 名称可能是 `deepseek`，但实际请求 endpoint 是
OpenCode Go。此前兼容策略只依据 provider 名称选择，导致：

- OpenCode Go 收到不支持的 JSON Schema 关键字；
- 完整工具目录超过 endpoint 可接受的 schema 数量；
- 请求返回 `unsupported_tool_schema` 或 `tool_count_limit`。

重启不会改变持久化 runtime 的实际 base URL，因此无法解决该问题。

## 修改

### Endpoint 与 Schema 适配

- 优先根据实际 `base_url` 解析 runtime provider profile。
- 即使逻辑 provider 是 `deepseek`，OpenCode Go endpoint 仍使用对应 wire strategy。
- 将发送给 OpenCode Go 的工具 JSON Schema 投影到其支持的子集。
- 完整 schema 继续保留在本地，用于参数验证。
- 官方 DeepSeek endpoint 和其他 provider 保持原行为。

### 工具目录投影

- 在 provider profile 中集中声明 OpenCode Go 的兼容上限：
  `max_tool_schemas = 16`。
- 在构造发送 schema 前完成工具目录投影。
- 始终保留 `tool_search`。
- 优先保留最近 preload 和新解锁的工具。
- 被投影移出的工具继续保持 deferred/searchable，可通过 `tool_search` 重新加载。
- 未开启 `tool_search` 且工具数超过 endpoint 上限时返回明确错误。

## 设计边界

- 不修改 workspace registry 或用户配置。
- 不迁移现有 runtime。
- 不删除或禁用插件工具。
- provider 上限为 `0` 时表示不限制，其他 endpoint 不受影响。
- `16` 是 OpenCode Go endpoint 实测通过的保守兼容上限，并集中保存在 provider profile 中。

## 测试

```text
107 passed