### PR TITLE
[codex] 修复 v3 MCP 工具在频道重绑后消失

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -2604,10 +2604,7 @@ class PluginManager:
             _validate_static_manifest_runtime(snapshot, generations)
             snapshot.skill_catalog_generation_id = catalog_id
             snapshot.plugin_skill_index = catalog.normal_plugins
-            snapshot.tool_registry = self._compile_snapshot_tools(
-                generations,
-                snapshot.plugin_tool_catalog,
-            )
+            self._refresh_composition_runtime_tools(snapshot)
             return snapshot, catalog_id
         except BaseException:
             self._skill_host.close(catalog_id)

--- a/tests/test_plugin_composition_mcp_slots.py
+++ b/tests/test_plugin_composition_mcp_slots.py
@@ -17,6 +17,16 @@ from agent.plugin_composition import (
     McpServerDefinition,
     PluginRuntime,
 )
+from agent.plugin_composition.channels import (
+    ChannelCapability,
+    ChannelFactoryContext,
+    ChannelReady,
+    CoreChannelDefinition,
+    DeliveryStatus,
+    ProviderDeliveryReceipt,
+    ProviderDeliveryRequest,
+    StopReceipt,
+)
 from agent.plugin_composition.mcp_slots import (
     PluginMcpServers,
     _freeze_plugin_mcp_servers,
@@ -298,6 +308,38 @@ def _manager(
     )
 
 
+class _CoreChannelAdapter:
+    def __init__(self, binding_token: str) -> None:
+        self._binding_token = binding_token
+
+    async def start(self) -> ChannelReady:
+        return ChannelReady(self._binding_token)
+
+    async def deliver(
+        self,
+        request: ProviderDeliveryRequest,
+    ) -> ProviderDeliveryReceipt:
+        return ProviderDeliveryReceipt(request.delivery_id, DeliveryStatus.DELIVERED)
+
+    async def stop(self) -> StopReceipt:
+        return StopReceipt(self._binding_token, resources_closed=True)
+
+
+def _core_channel_definition() -> CoreChannelDefinition:
+    def factory(context: ChannelFactoryContext) -> _CoreChannelAdapter:
+        return _CoreChannelAdapter(context.binding_token)
+
+    return CoreChannelDefinition(
+        name="web",
+        capabilities=frozenset({ChannelCapability.OUTBOUND}),
+        factory=factory,
+        inbound_identity=None,
+        source_revision="core-native-v3",
+        config_revision="core-native-v3",
+        generation_id="core-native-v3",
+    )
+
+
 def _port_live(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         return probe.connect_ex(("127.0.0.1", port)) == 0
@@ -502,6 +544,34 @@ async def test_static_manifest_is_admission_source_and_reconciles_mcp_root(
     assert candidate.static_manifest is not None
     await manager.discard_prepared("calendar")
     await manager.terminate_all()
+    assert not _port_live(18000)
+
+
+@pytest.mark.asyncio
+async def test_core_channel_rebind_preserves_live_mcp_tools(tmp_path: Path) -> None:
+    _ = _write_static_manager_plugin(tmp_path, "1")
+    manager = _manager(
+        tmp_path,
+        tool_registry=ToolRegistry(follow_runtime_snapshot=False),
+    )
+
+    try:
+        await manager.load_all()
+        await manager.bind_core_channel_definitions((_core_channel_definition(),))
+
+        snapshot = manager.current_snapshot
+        assert snapshot is not None and snapshot.tool_registry is not None
+        tool = snapshot.tool_registry.get_tool("mcp_calendar__get_events")
+        assert tool is not None
+        assert await tool.execute() == "|".join(
+            (
+                "formal",
+                "18000",
+                str(tmp_path / "workspace/plugin-data/calendar-builtin"),
+            )
+        )
+    finally:
+        await manager.terminate_all()
     assert not _port_live(18000)
 
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：pure-v3 Core 在 stable 插件批次启动并挂载 MCP facade 后，会因 `bind_core_channel_definitions()` 再次编译 topology snapshot，并用静态工具表覆盖 live MCP routes，导致 Calendar、Feed、Fitbit、Steam 的主对话工具目录全部变为 0。
- 用户可见结果：频道目录重绑后仍保留 exact live generation 的 MCP 工具，`mcp_fitbit__fitbit_health_snapshot` 等工具可被主对话发现和调用。
- 本 PR 不处理：Calendar provider 返回 `None`、Telegram/LLM/GitHub 外部网络重试、Feed 历史 cleanup timeout、控制字符出站失败，以及 `plugin-doctor` 的静态 MCP 计数缺口。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：所有通过 pure-v3 MCP generation host 暴露工具的插件和所有 Core channel。
- `runtime_patch`：`required`
- `runtime_patch_reason`：ToolRegistry 与 committed snapshot 由 Core 拥有；插件和客户端无法在频道重绑后恢复 exact generation MCP facade。
- `authoritative_state_owner`：Core committed RuntimeSnapshot / PluginManager。
- `client_only_alternative`：不适用；客户端无法重建服务端 tool route。
- 关联不变量：一个 committed snapshot 的 ToolRegistry 必须同时包含静态/plugin tools 与该 snapshot 中 exact live v3 MCP facade。
- `protected_state`：SessionDB、plugin-data、reload journal、插件 artifact/pointer、MCP/process lifecycle、channel admission。
- 允许的副作用：topology snapshot 编译时重新投影当前 live MCP tool wrappers。
- 禁止的副作用：启动额外进程、调用 MCP、修改 workspace/数据库、改变插件或频道生命周期。

## 改动范围

- 主要文件：`agent/plugins/manager.py`、`tests/test_plugin_composition_mcp_slots.py`。
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `2387e92fcfebfa27d0e5fb6be6323a6ea0a68da7`，candidate `8169ce3002db4ac6403228a215b448eac0316531`。
- 回滚方式：将 hua-home release 回滚到 `2387e92f`，或 revert 本提交。

## 验证

- [x] 相关 targeted tests 已通过：MCP slots、PluginManager、Hot Reload、Core channel adapter，共 `102 passed`。
- [x] Python 类型检查或前端 typecheck/lint 已通过；Change Gate 的锁定容器环境执行相关检查，另有 `compileall` 与 `git diff --check` 通过。
- [x] `python docker/debug/gate.py run --base 2387e92fcfebfa27d0e5fb6be6323a6ea0a68da7` 已运行并 passed。
- `sourceDigest`：`e53edbb1f0ead7a3bbce51746e20f1329eae6a1c8c8ed9ff9657343720cb55d9`
- `planDigest`：`0ce0160506634edef53821084d6201a1119c38fc08c6a0a3881d81da7c54a055`
- 真实设备证据：不适用；服务端部署后另做公网 Mobile challenge 与 runtime capability/tool 调用验证。
- 未运行项与原因：未执行 Android/ADB E2E；本 PR 不修改移动协议或客户端。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化；恢复已批准 pure-v3 MCP committed snapshot 语义。
- [x] MOB-001 不适用；能力 owner 是 Core ToolRegistry。
- [x] 当前 `NOW.md` 没有对应事项。