### PR TITLE
[codex] 阻止 v3 Mobile handoff 重建已完成 Turn

### DIFF
--- a/agent/plugin_composition/channels.py
+++ b/agent/plugin_composition/channels.py
@@ -157,7 +157,7 @@ class ChannelInboundMessage:
         _text(self.channel, "channel")
         _text(self.sender, "sender")
         _text(self.chat_id, "chat_id")
-        _string(self.content, "content")
+        _content_string(self.content, "content")
         if not isinstance(self.timestamp, datetime):
             raise TypeError("timestamp 必须是 datetime")
         if self.timestamp.tzinfo is None or self.timestamp.utcoffset() is None:
@@ -430,7 +430,7 @@ class OutboundEnvelope:
             "recipient",
         ):
             _text(getattr(self, field_name), field_name)
-        _string(self.body, "body")
+        _content_string(self.body, "body")
         if isinstance(self.attempt_sequence, bool) or not isinstance(
             self.attempt_sequence, int
         ) or self.attempt_sequence < 1:
@@ -447,8 +447,9 @@ class OutboundEnvelope:
         )
         if not isinstance(self.commit_role, ChannelCommitRole):
             raise TypeError("commit_role 必须是 ChannelCommitRole")
+        if self.thinking is not None:
+            _content_string(self.thinking, "thinking")
         for field_name in (
-            "thinking",
             "reply_to",
             "session_message_id",
             "control_turn_id",
@@ -513,8 +514,8 @@ class ControlResponseBodies:
     idle: str
 
     def __post_init__(self) -> None:
-        _string(self.interrupted, "interrupted")
-        _string(self.idle, "idle")
+        _content_string(self.interrupted, "interrupted")
+        _content_string(self.idle, "idle")
 
 
 class ChannelControlPort(Protocol):
@@ -554,8 +555,8 @@ class StreamDeltaPresentation:
     def __post_init__(self) -> None:
         _text(self.turn_id, "turn_id")
         _positive_sequence(self.sequence)
-        _string(self.text_delta, "text_delta")
-        _string(self.reasoning_delta, "reasoning_delta")
+        _content_string(self.text_delta, "text_delta")
+        _content_string(self.reasoning_delta, "reasoning_delta")
 
 
 @dataclass(frozen=True, slots=True)
@@ -719,7 +720,7 @@ class PushToolRequest:
     def __post_init__(self) -> None:
         _text(self.channel, "channel")
         _text(self.recipient, "recipient")
-        _string(self.body, "body")
+        _content_string(self.body, "body")
         object.__setattr__(self, "metadata", _freeze_json_mapping(self.metadata))
         object.__setattr__(
             self,
@@ -894,8 +895,7 @@ class ProviderDeliveryRequest:
         _text(self.binding_token, "binding_token")
         _text(self.delivery_id, "delivery_id")
         _text(self.recipient, "recipient")
-        if not isinstance(self.body, str):
-            raise TypeError("body 必须是 str")
+        _content_string(self.body, "body")
         object.__setattr__(
             self,
             "attachments",
@@ -905,8 +905,9 @@ class ProviderDeliveryRequest:
         object.__setattr__(self, "metadata", metadata)
         if not isinstance(self.commit_role, ChannelCommitRole):
             raise TypeError("commit_role 必须是 ChannelCommitRole")
+        if self.thinking is not None:
+            _content_string(self.thinking, "thinking")
         for field_name in (
-            "thinking",
             "reply_to",
             "session_message_id",
             "control_turn_id",
@@ -1800,6 +1801,14 @@ def _string(value: object, field_name: str) -> str:
     if not isinstance(value, str):
         raise TypeError(f"{field_name} 必须是 str")
     if any(ord(char) < 32 for char in value):
+        raise ValueError(f"{field_name} 不能包含控制字符")
+    return value
+
+
+def _content_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} 必须是 str")
+    if any(ord(char) < 32 and char not in "\t\n\r" for char in value):
         raise ValueError(f"{field_name} 不能包含控制字符")
     return value
 

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -254,6 +254,30 @@ class PassiveMessageWorker:
                 session_admission_id = self._bus.mobile_session_admission_id(
                     envelope
                 )
+                store = self._legacy_loop.session_manager.control_store
+                matched = store.find_turn_by_client_message_id(
+                    envelope.session_key,
+                    envelope.message_id,
+                )
+                if matched is not None:
+                    if not matched.status.is_terminal:
+                        raise RuntimeError(
+                            f"mobile turn 非终态未恢复: "
+                            f"{matched.id}/{matched.status.value}"
+                        )
+                    task = asyncio.create_task(
+                        self._settle_channel_envelope(
+                            envelope,
+                            TurnResult.from_record(matched),
+                            (),
+                            session_admission_id,
+                        ),
+                        name=f"channel-passive-recovery:{matched.id}",
+                    )
+                    self._result_tasks.add(task)
+                    task.add_done_callback(self._result_tasks.discard)
+                    transferred = True
+                    return task
             else:
                 _, session_admission_id = (
                     self._legacy_loop.session_manager.admit_existing(
@@ -370,9 +394,25 @@ class PassiveMessageWorker:
     ) -> None:
         """Await the turn and settle one exact non-retryable provider delivery."""
 
+        result = await handle.result()
+        await self._settle_channel_envelope(
+            envelope,
+            result,
+            attachment_leases,
+            session_admission_id,
+        )
+
+    async def _settle_channel_envelope(
+        self,
+        envelope: InboundEnvelope,
+        result: TurnResult,
+        attachment_leases: tuple[_ModelAttachmentLease, ...],
+        session_admission_id: str,
+    ) -> None:
+        """Deliver one authoritative terminal and settle its exact inbound owner."""
+
         terminal_durable = envelope.channel != "mobile"
         try:
-            result = await handle.result()
             legacy_view = InboundMessage(
                 channel=envelope.channel,
                 sender=envelope.sender,

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -2066,7 +2066,17 @@ class MobileRealtimeChannel:
         """发布全部移动会话索引，供手机按需分页拉取缺失历史。"""
 
         # 1. 所有已认证手机共享 mobile 渠道的完整会话空间
-        _expect_keys(frame.payload, set())
+        _expect_keys(frame.payload, {"history_snapshot_version"})
+        history_snapshot_version = frame.payload.get("history_snapshot_version")
+        if history_snapshot_version is not None and (
+            not isinstance(history_snapshot_version, int)
+            or isinstance(history_snapshot_version, bool)
+            or history_snapshot_version != 1
+        ):
+            raise MobileCommandError(
+                "invalid_payload",
+                "history_snapshot_version 仅支持 1",
+            )
         ctx = self._require_ctx()
         session_rows = {
             item["key"]: item for item in ctx.session_manager.list_sessions()
@@ -2085,7 +2095,7 @@ class MobileRealtimeChannel:
                 raise RuntimeError(
                     f"已绑定移动会话在 session store 中不存在: {session_id}"
                 )
-            messages, total = (
+            messages, dashboard_total = (
                 ctx.session_manager.control_store.list_messages_for_dashboard(
                     session_key=session_id,
                     page=1,
@@ -2095,18 +2105,23 @@ class MobileRealtimeChannel:
                 )
             )
             first_content = str(messages[0]["content"]).strip() if messages else ""
-            items.append(
-                {
-                    "session_id": session_id,
-                    "title": (
-                        first_content.splitlines()[0][:32]
-                        if first_content
-                        else "新对话"
-                    ),
-                    "updated_at": str(session["updated_at"]),
-                    "message_count": total,
-                }
-            )
+            item: dict[str, object] = {
+                "session_id": session_id,
+                "title": (
+                    first_content.splitlines()[0][:32]
+                    if first_content
+                    else "新对话"
+                ),
+                "updated_at": str(session["updated_at"]),
+                "message_count": dashboard_total,
+            }
+            if history_snapshot_version == 1:
+                snapshot_total, snapshot_max_seq = (
+                    ctx.session_manager.control_store.mobile_history_snapshot(session_id)
+                )
+                item["message_count"] = snapshot_total
+                item["snapshot_max_seq"] = snapshot_max_seq
+            items.append(item)
 
         # 3. 索引也走 durable event，断线后仍会重放
         _ = await self._runtime.publish_event(

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -2594,6 +2594,7 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
     session_items_by_id = {str(item["session_id"]): item for item in session_items}
     assert session_items_by_id[session_id]["title"] == "恢复这段对话"
     assert session_items_by_id[empty_session_id]["title"] == "新对话"
+    assert "snapshot_max_seq" not in session_items_by_id[session_id]
     assert history.type == "history.get.ok"
     history_event = runtime.events[-1]
     history_payload = cast(dict[str, object], history_event["payload"])
@@ -2608,6 +2609,33 @@ async def test_session_list_and_history_sync_publish_all_mobile_sessions(
         "reasoning_content": "历史思考",
         "control_turn_id": "turn-history",
     }
+
+    versioned = await channel.handle_command(
+        device_id=device_id,
+        frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+            command_type="session.list",
+            payload={"history_snapshot_version": 1},
+        ),
+    )
+    assert versioned.type == "session.list.ok"
+    versioned_items = cast(
+        list[dict[str, object]],
+        cast(dict[str, object], runtime.events[-1]["payload"])["items"],
+    )
+    versioned_by_id = {str(item["session_id"]): item for item in versioned_items}
+    assert versioned_by_id[session_id]["snapshot_max_seq"] == 1
+    assert versioned_by_id[empty_session_id]["snapshot_max_seq"] == -1
+    invalid_version = await channel.handle_command(
+        device_id=device_id,
+        frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FB0",
+            command_type="session.list",
+            payload={"history_snapshot_version": 2},
+        ),
+    )
+    assert invalid_version.type == "session.list.error"
+    assert invalid_version.payload["code"] == "invalid_payload"
     tool_chain = cast(list[dict[str, object]], history_items[1]["tool_chain"])
     calls = cast(list[dict[str, object]], tool_chain[0]["calls"])
     assert calls[0]["description"] == "读取状态"

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -1386,6 +1386,125 @@ async def test_v3_channel_worker_preserves_exact_binding_through_terminal_delive
 
 
 @pytest.mark.asyncio
+async def test_v3_mobile_recovery_redelivers_existing_turn_without_duplicate(
+    tmp_path: Path,
+) -> None:
+    manager1 = SessionManager(tmp_path)
+    session_key = "mobile:chat-1"
+    client_message_id = "client-recovered-1"
+    manager1.save(manager1.get_or_create(session_key))
+    executed: list[TurnRequest] = []
+
+    async def execute(request: TurnRequest) -> str:
+        executed.append(request)
+        return f"echo:\n{request.input}"
+
+    runtime1 = ConversationRuntime(manager1.control_store, execute)
+    original = await runtime1.start_turn(
+        TurnRequest(
+            session_key,
+            "hello",
+            {"inboundMetadata": {"client_message_id": client_message_id}},
+        )
+    )
+    original_result = await original.result()
+
+    bus1 = MessageBus()
+    bus1.bind_durable_inbound_store(manager1.control_store)
+    bus1.bind_mobile_session_admission_owner(manager1)
+    envelope1, lease1 = _v3_inbound(
+        channel="mobile",
+        message_id=client_message_id,
+        metadata={
+            "session_key_override": session_key,
+            "client_message_id": client_message_id,
+            "mobile_v3_handoff": True,
+            "mobile_handoff_id": "handoff-recovered-1",
+        },
+    )
+    await bus1.publish_channel_inbound(envelope1)
+    await bus1.aclose()
+    assert lease1.closed == 1
+    assert len(manager1.control_store.list_inbound_handoffs()) == 1
+    await runtime1.shutdown()
+    manager1.close()
+
+    manager2 = SessionManager(tmp_path)
+    manager2.clear_stale_admissions()
+    runtime2 = ConversationRuntime(manager2.control_store, execute)
+    bus2 = MessageBus()
+    bus2.bind_durable_inbound_store(manager2.control_store)
+    bus2.bind_mobile_session_admission_owner(manager2)
+    delivered: list[OutboundEnvelope] = []
+    recovered_leases: list[_InboundLease] = []
+    recovered_event = asyncio.Event()
+
+    async def dispatch(
+        envelope: OutboundEnvelope,
+        _binding: object,
+    ) -> ChannelDeliveryReceipt:
+        delivered.append(envelope)
+        return ChannelDeliveryReceipt(
+            envelope.delivery_id,
+            DeliveryStatus.DELIVERED,
+        )
+
+    async def recover(raw: RawInbound) -> bool:
+        lease = _InboundLease(channel="mobile")
+        recovered_leases.append(lease)
+        envelope = InboundEnvelope(
+            message_id=raw.message_id,
+            snapshot_id=lease.snapshot_id,
+            generation_id=lease.generation_id,
+            binding_token=lease.binding_token,
+            message=raw.message,
+            lease=lease,
+        )
+        await bus2.publish_channel_inbound(envelope)
+        recovered_event.set()
+        return True
+
+    bus2.bind_mobile_channel_inbound_recoverer(recover)
+    bus2.bind_channel_outbound_dispatcher(dispatch)
+    from bootstrap.passive_worker import PassiveMessageWorker
+
+    worker = PassiveMessageWorker(
+        bus2,
+        runtime2,
+        cast(Any, SimpleNamespace(session_manager=manager2)),
+    )
+    worker_task = asyncio.create_task(worker.run())
+    dispatch_task = asyncio.create_task(bus2.dispatch_outbound())
+    await asyncio.wait_for(recovered_event.wait(), timeout=2)
+    await asyncio.wait_for(recovered_leases[0].closed_event.wait(), timeout=2)
+
+    turns = manager2.control_store.list_turns(session_key, limit=10)
+    assert len(executed) == 1
+    assert len(turns) == 1
+    assert turns[0].id == original_result.id
+    assert len(delivered) == 1
+    assert delivered[0].control_turn_id == original_result.id
+    assert delivered[0].body == "echo:\nhello"
+    assert manager2.control_store.list_inbound_handoffs() == []
+    for _ in range(100):
+        admission = manager2.control_store._conn.execute(
+            "SELECT 1 FROM session_admissions WHERE session_key = ?",
+            (session_key,),
+        ).fetchone()
+        if admission is None:
+            break
+        await asyncio.sleep(0)
+    assert admission is None
+
+    worker.stop()
+    bus2.stop()
+    await worker_task
+    await dispatch_task
+    await runtime2.shutdown()
+    manager2.close()
+
+
+@pytest.mark.asyncio
 async def test_v3_channel_worker_holds_session_admission_until_terminal(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_plugin_composition_channels.py
+++ b/tests/test_plugin_composition_channels.py
@@ -680,6 +680,40 @@ def test_c14c_metadata_is_recursively_frozen_and_rejects_unsafe_values() -> None
         )
 
 
+def test_channel_text_accepts_layout_controls_and_rejects_nul() -> None:
+    body = "line one\nline two\tvalue\r\n"
+    message = ChannelInboundMessage(
+        channel="feishu",
+        sender="sender",
+        chat_id="chat",
+        content=body,
+        timestamp=datetime.now(timezone.utc),
+        metadata={},
+    )
+    outbound = OutboundEnvelope(
+        logical_delivery_id="delivery",
+        delivery_id="delivery",
+        attempt_sequence=1,
+        snapshot_id="snapshot",
+        generation_id="generation",
+        binding_token="binding",
+        channel="feishu",
+        recipient="chat",
+        body=body,
+        metadata={},
+    )
+
+    assert message.content == body
+    assert outbound.body == body
+    with pytest.raises(ValueError, match="控制字符"):
+        _ = PushToolRequest(
+            channel="feishu",
+            recipient="chat",
+            body="unsafe\x00body",
+            metadata={},
+        )
+
+
 def test_raw_inbound_and_outbound_receipts_enforce_identity_contract() -> None:
     envelope = _inbound_envelope()
     raw = RawInbound(message_id="provider-message", message=envelope.message)


### PR DESCRIPTION
## 问题与结果

- 解决的问题：pure-v3 Mobile 的 durable handoff 在终态正文包含换行时被通用字符串校验拒绝，handoff 因而保留；服务重启恢复时，v3 InboundEnvelope 路径没有复用既有 Turn 幂等栅栏，会为同一 client_message_id 新建第二个 Turn。
- 用户可见结果：标准多行终态可以正常 durable delivery；重启恢复已存在 terminal Turn 的 handoff 时只重投权威终态，不再执行 Provider 或创建重叠 Turn。
- 本 PR 不处理：不删除线上已有重复 Turn，不修改 Android 展示，不调整容量策略，不合并或部署生产。
- Stack：基于 draft PR #456 的 head 8169ce3002db4ac6403228a215b448eac0316531。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：pure-v3 Mobile inbound recovery；Channel 任意文本正文校验
- `runtime_patch`：`required`
- `runtime_patch_reason`：重复 Turn 由 Core 的 handoff → Turn admission 边界产生，客户端无法阻止服务重启后的 durable replay。
- `authoritative_state_owner`：SessionStore 的唯一 `session_key + client_message_id` Turn；MessageBus 的 durable inbound handoff。
- `client_only_alternative`：客户端可隐藏重复 UI，但无法阻止 Provider 再执行和第二个 Turn 持久化，因此不可接受。
- 关联不变量：同一 Mobile client_message_id 在一个 Session 中只对应一个权威 Turn；终态 durable delivery 成功后才物理删除 handoff。
- `protected_state`：sessions/messages append-only；既有 turns、mobile inbox、attachments 与 plugin data 不改写。
- 允许的副作用：成功重投终态后删除对应 inbound_handoffs 行并释放 exact lease/session admission。
- 禁止的副作用：不重跑已 terminal Turn；不静默选择重复 Turn；不放宽身份字段控制字符校验。

## 改动范围

- 主要文件：`bootstrap/passive_worker.py`、`agent/plugin_composition/channels.py` 及两份针对性测试。
- 配置或迁移影响：无配置、无 schema migration。
- 已知 schema lineage 与最终 schema identity：不变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `8169ce3002db4ac6403228a215b448eac0316531`；head `ccd63b2d`。
- 回滚方式：回退本 PR 单一提交 `ccd63b2d`；源码备份位于 `/mnt/data/coding/akasic-agent-backups/mobile-v3-turn-dedupe-20260821-OE6tR3/`。

## 验证

- [x] 相关 targeted tests 已通过：130 passed。
- [x] Python 类型检查已通过：Pyright 0 errors（117 个基线 warning）；compileall 通过。
- [ ] `python docker/debug/gate.py run --base origin/main` 未运行。
- `sourceDigest`：不适用。
- `planDigest`：不适用。
- 真实设备证据：未运行；用户明确不要求 E2E，本 PR 仅做 Core 回归与只读复审。
- 未运行项与原因：未跑 E2E/完整 Gate，避免扩大此次最小修复范围。
- Terra high 只读复审：最终无阻塞 finding；真实两进程同库 recovery 回归覆盖 `recover_durable_inbounds → recoverer → exact envelope → worker`。

## 工作手册

- [x] 已核对相关工作手册、持久化边界和真实生产日志。
- [x] 本次没有 breaking 或长期产品语义变化。
- [x] 已按 MOB-001 核对：权威修复属于 Core，Android 仅隐藏重复不能替代。
- [x] 当前没有对应 NOW 事项，文档无需修改。
