### PR TITLE
fix(plugins): 修正 doctor 的 v3 MCP 声明报告

### DIFF
--- a/agent/plugins/doctor.py
+++ b/agent/plugins/doctor.py
@@ -284,8 +284,14 @@ def _check_capabilities(
                 f"misdirected={misdirected} stale={stale}",
             )
         )
-    servers = _declared_mcp_servers(declaration)
-    checks.append(_check("mcp", "ok", f"servers={len(servers)}"))
+    servers = _declared_mcp_servers(plugin_root)
+    checks.append(
+        _check(
+            "mcp",
+            "ok",
+            f"declared_servers={len(servers)} names={list(servers)}",
+        )
+    )
     return checks
 
 
@@ -306,12 +312,12 @@ def _check_candidate_declaration(
                 f"roots={len(roots)} missing={missing}",
             )
         )
-    servers = _declared_mcp_servers(declaration)
+    servers = _declared_mcp_servers(plugin_root)
     checks.append(
         _check(
             "candidate_mcp",
             "ok",
-            f"servers={len(servers)}",
+            f"declared_servers={len(servers)} names={list(servers)}",
         )
     )
     return checks
@@ -326,10 +332,14 @@ def _declared_skill_roots(
 
 
 def _declared_mcp_servers(
-    declaration: ComposablePlugin,
-) -> tuple[()]:
-    del declaration
-    return ()
+    plugin_root: Path,
+) -> tuple[str, ...]:
+    """Return import-free MCP names declared by the artifact."""
+
+    manifest = _load_optional_static_manifest(plugin_root)
+    if manifest is None:
+        return ()
+    return tuple(server.name for server in manifest.mcp_servers)
 
 
 def _check_empty_projection(

--- a/tests/test_plugin_doctor.py
+++ b/tests/test_plugin_doctor.py
@@ -43,13 +43,25 @@ def _write_static_manifest(
     *,
     name: str,
     entrypoint: str = "plugin.py",
+    mcp_names: tuple[str, ...] = (),
 ) -> None:
+    mcp_manifest = ""
+    for mcp_name in mcp_names:
+        runner = plugin_root / "mcp" / f"{mcp_name}.py"
+        runner.parent.mkdir(parents=True, exist_ok=True)
+        runner.write_text("", encoding="utf-8")
+        mcp_manifest += (
+            "\n[[mcp]]\n"
+            f"name = {mcp_name!r}\n"
+            f"command = ['mcp/{mcp_name}.py']\n"
+        )
     (plugin_root / "akashic.plugin.toml").write_text(
         "schema_version = 1\n"
         f"name = {name!r}\n"
         "version = '1.0.0'\n"
         "api_version = 3\n"
-        f"entrypoint = {entrypoint!r}\n",
+        f"entrypoint = {entrypoint!r}\n"
+        f"{mcp_manifest}",
         encoding="utf-8",
     )
 
@@ -112,7 +124,11 @@ def test_plugin_doctor_reads_v3_namespace_declaration(tmp_path: Path) -> None:
         "def apply(ctx, config): pass\n",
         encoding="utf-8",
     )
-    _write_static_manifest(plugin_root, name="v3_demo")
+    _write_static_manifest(
+        plugin_root,
+        name="v3_demo",
+        mcp_names=("fitbit", "steam"),
+    )
     _ = write_pointers(
         plugin_base,
         stable=ArtifactPointer(".artifacts/1.0.0-aaaa"),
@@ -129,7 +145,9 @@ def test_plugin_doctor_reads_v3_namespace_declaration(tmp_path: Path) -> None:
 
     assert report["status"] == "healthy"
     assert _check(report, "skills")["detail"].startswith("roots=0")
-    assert _check(report, "mcp")["detail"] == "servers=0"
+    assert _check(report, "mcp")["detail"] == (
+        "declared_servers=2 names=['fitbit', 'steam']"
+    )
 
 
 def test_plugin_doctor_uses_static_custom_entrypoint(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：`plugin-doctor` 无条件丢弃 pure-v3 MCP 声明，所有插件均误报 `servers=0`。
- 用户可见结果：doctor 从已校验的 immutable artifact manifest 报告 `declared_servers=N names=[...]`，明确这是静态声明而非运行健康。
- 本 PR 不处理：不连接运行中 Core，不把静态声明冒充 MCP 进程、工具调用或外部 API 健康；不部署 hua-home。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：plugin-doctor CLI 与其文本/JSON 消费者
- `runtime_patch`：`none`
- `runtime_patch_reason`：离线 doctor 只读已安装 artifact 的权威静态 manifest；运行态健康由 RuntimeSnapshot 和真实工具调用拥有。
- `authoritative_state_owner`：`akashic.plugin.toml` 拥有 artifact MCP 静态声明；Core RuntimeSnapshot 拥有当前 generation 运行态。
- `client_only_alternative`：不适用。
- 关联不变量：external v3 artifact 必须存在并通过静态 manifest 校验；builtin 无 manifest 时声明数为 0。
- `protected_state`：正式 workspace、插件 pointer、运行 generation、消息与记忆。
- 允许的副作用：doctor 只读输出变化。
- 禁止的副作用：不执行 plugin apply、不启动 MCP、不访问外部 API、不修改 workspace/pointer/runtime。

## 改动范围

- 主要文件：`agent/plugins/doctor.py`、`tests/test_plugin_doctor.py`
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：无 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `48815bbb1d998a2033a055d4fb25be158f2e6e54`；candidate `a6f75451`；Gate report `20260821-165011-4092457b`。
- 回滚方式：revert `a6f75451`，或从备份 `/mnt/data/coding/backups/akasic-plugin-doctor-v3-20260821-1647/` 恢复两文件。

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_plugin_doctor.py` 11 passed；manifest/install/runtime/composition MCP 相关 100 passed。
- [x] Python 类型检查已通过：Pyright 0 errors/0 warnings；Ruff 未提供于当前 requirements，命令不可用。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：25 个公开场景 passed。
- `sourceDigest`：`75e63fe537421d48da4cfd5e216e75573919a75ed44c473f60a368e73dffa0ef`
- `planDigest`：`1a222d77ea93b77baa3732c5f137eee0711fb5a2e051a54aae5a893b3afd3787`
- 真实设备证据：不适用；本 PR 不改移动端或协议。
- 未运行项与原因：未运行私有 Gate；无此局部 doctor 输出修复所需的私有凭据场景。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 跨仓库或客户端能力 owner 不适用。
- [x] 当前没有对应 `NOW.md` 事项。