### PR TITLE
fix(plugins): classify stale programmatic sessions

### DIFF
--- a/agent/plugin_composition/background_jobs.py
+++ b/agent/plugin_composition/background_jobs.py
@@ -131,6 +131,10 @@ class ProgrammaticTurnReceipt:
 class ProgrammaticTurnPreAdmissionError(RuntimeError):
     """Report a failure proven to happen before Turn admission."""
 
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
+
 
 class ProgrammaticTurnUncertainError(RuntimeError):
     """Report a failure after Turn admission may already have happened."""

--- a/agent/plugins/generation_job_host.py
+++ b/agent/plugins/generation_job_host.py
@@ -698,7 +698,8 @@ class _ProgrammaticTurnPort:
             or metadata.get("job_name") != self._request.job.binding.name
         ):
             raise ProgrammaticTurnPreAdmissionError(
-                "programmatic Turn session provenance 不匹配"
+                "programmatic Turn session provenance 不匹配",
+                reason="session_provenance_mismatch",
             )
         plugin_metadata = {
             str(key): value

--- a/tests/test_plugin_generation_job_host.py
+++ b/tests/test_plugin_generation_job_host.py
@@ -993,8 +993,12 @@ async def test_programmatic_turn_port_rejects_reserved_metadata_and_foreign_sess
         with pytest.raises(ValueError, match="不能覆盖 Core 字段"):
             await ctx.turns.create_session(metadata={"plugin_id": "forged"})
         session_id = await ctx.turns.create_session(metadata={})
-        with pytest.raises(RuntimeError, match="provenance 不匹配"):
+        with pytest.raises(
+            ProgrammaticTurnPreAdmissionError,
+            match="provenance 不匹配",
+        ) as caught:
             await ctx.turns.submit("programmatic:foreign", "no")
+        assert caught.value.reason == "session_provenance_mismatch"
         handle = conversation.requests
         assert session_id.startswith("programmatic:")
         assert handle == []


### PR DESCRIPTION
## 问题

GitHub Watcher 复用 v2 时代的 programmatic Session 时，Core 能证明 provenance 不匹配，但异常只有文本，插件无法安全区分该永久错误与一般准入失败。

## 修改

- 为 `ProgrammaticTurnPreAdmissionError` 增加可选稳定 `reason`。
- provenance 不匹配时标记 `session_provenance_mismatch`。
- 不放宽 Core 的 Session owner 校验。

## 验证

- `72 passed`：generation job host、background jobs、job outcome ledger。
- pyright：0 errors（现有 warnings 保持）。

## 交付

该 PR 堆叠在 #458，配套 GitHub Watcher PR 会只在这个明确 reason 下丢弃旧 thread 并重建。