### PR TITLE
fix(memory): replay appended turns on restart

### DIFF
--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -373,6 +373,9 @@ class OnlineMemoryRuntime:
                 "memory snapshot contains more turns than sessions source"
             )
         prefix = turns[:persisted]
+        exact_source_hash = (
+            sha256_file(self.index_path) if persisted == len(turns) else None
+        )
         (
             graph,
             events,
@@ -384,7 +387,7 @@ class OnlineMemoryRuntime:
             self.memory_path,
             turns=prefix,
             config=self.config,
-            source_index_sha256=sha256_file(self.index_path),
+            source_index_sha256=exact_source_hash,
         )
         cycle = MemoryCycle.restore(
             config=self.config,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -3344,6 +3344,70 @@ def test_online_runtime_reopens_unchanged_sidecars_without_rebuilding(
     assert hashlib.sha256(memory_path.read_bytes()).hexdigest() == memory_sha
 
 
+def test_online_runtime_replays_an_appended_suffix_without_rebuilding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """进程离线期间新增的 Turn 必须增量追平而不是重建完整图。"""
+
+    # 1. 先持久化一个与稀疏索引完全对齐的记忆快照。
+    sessions_path = tmp_path / "sessions.db"
+    index_path = tmp_path / "memory" / "akasha-v2-index.db"
+    memory_path = tmp_path / "memory" / "akasha.db"
+    _create_sessions(sessions_path)
+    _append_turn(
+        sessions_path,
+        sequence=0,
+        user="alpha request",
+        assistant="beta reply",
+        started=datetime(2026, 8, 5, tzinfo=timezone.utc),
+        with_embeddings=True,
+    )
+    first = OnlineMemoryRuntime(
+        sessions_path=sessions_path,
+        index_path=index_path,
+        memory_path=memory_path,
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+        config=MemoryConfig(),
+    )
+    first.close()
+
+    # 2. 模拟 Core 停机窗口新增一个合法 append-only Turn。
+    _append_turn(
+        sessions_path,
+        sequence=2,
+        user="gamma request",
+        assistant="delta reply",
+        started=datetime(2026, 8, 5, 0, 1, tzinfo=timezone.utc),
+        with_embeddings=True,
+    )
+
+    def reject_rebuild(_runtime: OnlineMemoryRuntime) -> MemoryCycle:
+        raise AssertionError("append-only suffix must not rebuild")
+
+    monkeypatch.setattr(
+        OnlineMemoryRuntime,
+        "_fresh_rebuild_from_source",
+        reject_rebuild,
+    )
+
+    # 3. 重启只回放新增后缀，并发布新的完整配对快照。
+    reopened = OnlineMemoryRuntime(
+        sessions_path=sessions_path,
+        index_path=index_path,
+        memory_path=memory_path,
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+        config=MemoryConfig(),
+    )
+    try:
+        assert reopened.cycle.state_version == 2
+        assert len(reopened.cycle.turns) == 2
+    finally:
+        reopened.close()
+
+
 @pytest.mark.parametrize(
     ("context_mass", "query", "context", "expected_node"),
     (


### PR DESCRIPTION
## 变更
- 只在记忆快照与稀疏索引长度完全相等时校验整个索引文件哈希
- 稀疏索引有合法 append-only 后缀时，复用已验证前缀并增量回放
- 保留无后缀时的 index/memory 配对哈希校验

## 验证
- `54 passed`：`tests/test_akasha_plugin.py`
- Pyright：0 errors（5 个既有 unused-result warnings）
- `git diff --check` 通过

## 发布边界
Draft PR，叠在 #459 上；试运行阶段不合并。