### PR TITLE
fix(plugins): discard cancelled install candidates

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -2093,6 +2093,14 @@ class PluginManager:
             )
             plugin_id = f"{result.plugin_name}@{result.marketplace}"
             status = self.candidate_status()
+            if install_cancelled or reconcile_cancelled:
+                if (
+                    result.staged_candidate
+                    and status["candidate_plugin_id"] == plugin_id
+                    and status["candidate_state"] == "latest_ready"
+                ):
+                    _ = await self._drop_ready(plugin_id)
+                raise asyncio.CancelledError
             if result.staged_candidate and (
                 status["candidate_plugin_id"] != plugin_id
                 or status["candidate_state"] != "latest_ready"
@@ -2107,8 +2115,6 @@ class PluginManager:
                     f"tx={status['candidate_reload_tx_id']} "
                     f"error={status['candidate_error']}"
                 )
-            if install_cancelled or reconcile_cancelled:
-                raise asyncio.CancelledError
             return result, status
 
     def annotate_reload(self, tx_id: str, details: dict[str, object]) -> None:

--- a/tests/test_plugin_runtime_control.py
+++ b/tests/test_plugin_runtime_control.py
@@ -400,7 +400,13 @@ async def test_runtime_install_and_watcher_share_candidate_owner(
     assert not (manager.installed_plugins_home / "cache" / "lab" / "beta").exists()
     assert not isinstance(watcher, BaseException)
     assert manager.candidate_status()["candidate_plugin_id"] == "alpha@lab"
-    await manager.drop_candidate("alpha@lab")
+    await manager.switch_ready("alpha@lab")
+    alpha_entrypoint = sources["alpha"] / "plugin.py"
+    alpha_entrypoint.write_text(
+        alpha_entrypoint.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    _commit(sources["alpha"])
 
     entered = threading.Event()
     release = threading.Event()
@@ -413,7 +419,7 @@ async def test_runtime_install_and_watcher_share_candidate_owner(
 
     monkeypatch.setattr("agent.plugins.manager.install_git_plugin", blocking_install)
     cancelled_install = asyncio.create_task(
-        app._install_plugin(str(sources["beta"]), "lab", "", [])
+        app._install_plugin(str(sources["alpha"]), "lab", "", [])
     )
     assert await asyncio.to_thread(entered.wait, 5)
     cancelled_install.cancel()
@@ -424,9 +430,13 @@ async def test_runtime_install_and_watcher_share_candidate_owner(
     with pytest.raises(asyncio.CancelledError):
         await cancelled_install
     _ = await waiting_watcher
-    assert manager.candidate_status()["candidate_plugin_id"] == "beta@lab"
-    assert manager.candidate_status()["candidate_state"] == "latest_ready"
-    await manager.drop_candidate("beta@lab")
+    cancelled_status = manager.candidate_status()
+    assert cancelled_status["candidate_plugin_id"] == "alpha@lab"
+    assert cancelled_status["candidate_state"] == "aborted"
+    assert (
+        cancelled_status["latest_snapshot_id"]
+        == cancelled_status["stable_snapshot_id"]
+    )
     await manager.terminate_all()
     await bus.aclose()
 


### PR DESCRIPTION
## 变更
- install/reconcile 已进入不可取消临界区后收到取消时，完成候选构建但立即恢复 stable 并 discard latest
- 不再留下阻塞下一次安装的 orphan `latest_ready` 候选
- 保留 append-only artifact 与 reload journal 作为审计证据

## 真实触发
GitHub Watcher 安装 shell 在长时间 candidate Gate 中被 owner Turn 中断；旧实现完成临界区后抛出 CancelledError，却留下无人拥有的 latest_ready。

## 验证
- plugin runtime control + turn rollout：14 passed
- Pyright：0 errors（37 个既有 warnings）
- `git diff --check` 通过

## 发布边界
Draft PR，叠在 #460 上；试运行阶段不合并。