### PR TITLE
fix(provider): project overfull always-on catalogs

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -983,10 +983,11 @@ class DefaultReasoner(Reasoner):
             return set(normal_order), normal_order
 
         if len(always_on_order) > max_schemas:
-            raise RuntimeError(
-                "always_on 工具数量超过当前模型 endpoint 的 schema 上限："
-                f"{len(always_on_order)} > {max_schemas}"
+            projected = _project_tool_order(
+                [*reversed(preload_order), *always_on_order],
+                max_schemas,
             )
+            return set(projected), projected
 
         # always_on 是运行时合同；预加载工具只能占用剩余槽位。
         projected = _project_tool_order(

--- a/tests/test_loop_tool_visibility.py
+++ b/tests/test_loop_tool_visibility.py
@@ -344,21 +344,40 @@ class TestVisibilityGuard:
         deferred = reg.get_deferred_names(visible=set(schemas_seen[0]))
         assert "selected_tool" in deferred["builtin"]
 
-    def test_provider_tool_limit_rejects_overfull_always_on_catalog(self, tmp_path):
+    def test_provider_tool_limit_projects_overfull_always_on_catalog(self, tmp_path):
         reg = ToolRegistry()
         reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
         reg.register(_DummyTool("always_a"), always_on=True)
         reg.register(_DummyTool("always_b"), always_on=True)
+        reg.register(_DummyTool("recent_preload"))
+
+        schemas_seen: list[list[str]] = []
 
         class _LimitedProvider(_FakeProvider):
             max_tool_schemas = 2
 
-        loop = _make_loop(tmp_path, _LimitedProvider([]), reg)
+            async def chat(self, **kwargs: Any) -> LLMResponse:
+                schemas_seen.append(
+                    [tool["function"]["name"] for tool in kwargs.get("tools") or []]
+                )
+                return await super().chat(**kwargs)
 
-        with pytest.raises(RuntimeError, match="always_on 工具数量超过"):
-            asyncio.run(
-                loop._run_agent_loop([{"role": "user", "content": "hello"}])
+        loop = _make_loop(
+            tmp_path,
+            _LimitedProvider([LLMResponse(content="done", tool_calls=[])]),
+            reg,
+        )
+
+        final, _, _, _, _ = asyncio.run(
+            loop._run_agent_loop(
+                [{"role": "user", "content": "hello"}],
+                preloaded_tools={"recent_preload"},
             )
+        )
+
+        assert final == "done"
+        assert schemas_seen == [["tool_search", "recent_preload"]]
+        assert "always_a" in reg.get_deferred_names(visible=set(schemas_seen[0]))["builtin"]
 
 
 # ── LRU 测试 ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 问题与结果

- 解决的问题：OpenCode Go 物理上限为 16 个 tool schema，线上 committed catalog 有 23 个 always_on，导致任何 turn 在 provider 调用前失败。
- 用户可见结果：受限 endpoint 能启动 turn；tool_search 与最近预加载工具优先保留，投影外工具仍可搜索加载。
- 本 PR 不处理：不改插件注册、不删工具、不改变无上限 endpoint。

## Change intent

- change_type：fix
- semantic_delta：compatible
- capability_owner：provider
- consumer_scope：配置 max_tool_schemas 的 provider profile
- runtime_patch：required
- runtime_patch_reason：当前 hua-home 的 OpenCode Go turn 全部被 23 > 16 阻断
- authoritative_state_owner：provider profile 拥有 wire schema 上限；ToolRegistry 继续拥有完整目录
- client_only_alternative：无，失败发生在 Core provider 边界
- 关联不变量：发送 schema 数不超过 endpoint 上限；tool_search 始终保留；完整工具继续 deferred/searchable
- protected_state：workspace、插件 generation、SessionDB 与记忆
- 允许的副作用：只改变受限 endpoint 的初始 tool schema 投影
- 禁止的副作用：删除/禁用工具、修改注册表、修改插件状态

## 改动范围

- 主要文件：agent/core/passive_turn.py、tests/test_loop_tool_visibility.py
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：本地完整 schema 不变，仅 provider wire projection
- 协议 source、runtime、provider 与 scenario 的不可变 revision：复现 Core 95f5fdb0、OpenCode Go max_tool_schemas=16、always_on=23
- 回滚方式：revert 2a10149b，或回到 backup/pre-opencode-always-on-projection-20260822

## 验证

- [x] 相关 targeted tests 已通过。
- [x] Python 类型检查或前端 typecheck/lint 已通过；pyright 0 errors。
- [ ] python docker/debug/gate.py run --base origin/main 已运行。
- sourceDigest：不适用
- planDigest：不适用
- 真实设备证据：hua-home 无记忆 programmatic turn 在旧 head 明确复现 23 > 16；合并部署后复测
- 未运行项与原因：未跑 E1-E4；与本次 provider 边界修复无关。相关回归 112 passed。

## 工作手册

- [x] 已核对 projectneed.md、相关决策和 NOW.md。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用，无客户端改动。
- [x] 已完成事项已从 NOW.md 删除；不适用，当前无对应事项。