### PR TITLE
fix(plugins): allow safe candidate artifact retry

### DIFF
--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -348,7 +348,14 @@ def _activate_plugin_version(
 
         # 3. Artifact 只创建一次；一次原子写发布完整 stable/latest pair。
         if target_root.exists():
-            _validate_source_tree(target_root)
+            generated_runtime_roots = tuple(
+                target_root / Path(runtime.requirements).parent / ".venv"
+                for runtime in static_manifest.python
+            )
+            _validate_source_tree(
+                target_root,
+                generated_runtime_roots=generated_runtime_roots,
+            )
             existing_revision = _run_git(["rev-parse", "HEAD"], cwd=target_root)
             if existing_revision != source_revision:
                 raise RuntimeError(f"插件 artifact 身份冲突: {target_root}")
@@ -478,14 +485,23 @@ def _validate_path_segment(value: object, label: str) -> str:
     return value
 
 
-def _validate_source_tree(root: Path) -> None:
-    """校验 Git source 符号链接只指向 clone root 内的真实对象。"""
+def _validate_source_tree(
+    root: Path,
+    *,
+    generated_runtime_roots: tuple[Path, ...] = (),
+) -> None:
+    """校验 Git source 链接，并跳过 Core 已生成的 runtime 内容。"""
 
     root = root.resolve(strict=True)
     # 1. lstat 所有文件和目录项，但不让 os.walk 跟随 source 链接
     for current, directories, filenames in os.walk(root, followlinks=False):
         for name in [*directories, *filenames]:
             path = Path(current) / name
+            if any(
+                path != runtime_root and path.is_relative_to(runtime_root)
+                for runtime_root in generated_runtime_roots
+            ):
+                continue
             if not path.is_symlink():
                 continue
             try:

--- a/agent/plugins/mcp_generation_host.py
+++ b/agent/plugins/mcp_generation_host.py
@@ -1408,4 +1408,5 @@ def _task_error(task: asyncio.Task[Any], fallback: BaseException) -> BaseExcepti
 
 
 def _error_text(error: BaseException) -> str:
-    return f"{type(error).__name__}: {error}"
+    message = str(error).strip()
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -153,6 +154,64 @@ def test_install_git_plugin_prepares_declared_mcp_runtime(
         for _, cwd in calls
     )
     assert not (result.installed_path / "mcp" / "servers.json").exists()
+
+
+def test_retry_reuses_artifact_with_core_generated_python_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "feed-mcp"
+    (repo / "mcp").mkdir(parents=True)
+    (repo / "mcp" / "requirements.txt").write_text("", encoding="utf-8")
+    _write_v3_plugin(repo, name="feed", marker="v1")
+    (repo / "akashic.plugin.toml").write_text(
+        (repo / "akashic.plugin.toml").read_text(encoding="utf-8")
+        + '\n[[python]]\nrequirements = "mcp/requirements.txt"\n',
+        encoding="utf-8",
+    )
+    _commit(repo)
+
+    def fake_run(args: list[str], *, cwd: Path, label: str) -> None:
+        if label.endswith("venv"):
+            python_path = install_module._venv_python_path(cwd / ".venv")
+            python_path.parent.mkdir(parents=True, exist_ok=True)
+            python_path.symlink_to(sys.executable)
+
+    monkeypatch.setattr(install_module, "_run_command", fake_run)
+    home = tmp_path / "plugins-home"
+    workspace = tmp_path / "workspace"
+    _ = install_git_plugin(
+        workspace=workspace,
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+    )
+
+    plugin_path = repo / "plugin.py"
+    plugin_path.write_text(
+        plugin_path.read_text(encoding="utf-8").replace("v1", "v2"),
+        encoding="utf-8",
+    )
+    _commit(repo)
+    candidate = install_git_plugin(
+        workspace=workspace,
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+        stage_candidate=True,
+    )
+    _ = discard_latest_pointer(candidate.installed_path.parents[1])
+
+    retried = install_git_plugin(
+        workspace=workspace,
+        source=str(repo),
+        marketplace="lab",
+        plugins_home=home,
+        stage_candidate=True,
+    )
+
+    assert retried.installed_path == candidate.installed_path
+    assert retried.staged_candidate is True
 
 
 def test_plugin_enable_disable_and_uninstall_preserve_data(tmp_path: Path) -> None:

--- a/tests/test_plugin_mcp_generation_host.py
+++ b/tests/test_plugin_mcp_generation_host.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import agent.mcp.client as client_module
+import agent.plugins.mcp_generation_host as mcp_host_module
 from agent.plugin_composition import (
     MCP_SERVERS,
     CompositionRoot,
@@ -27,6 +28,10 @@ from agent.plugins.mcp_generation_host import (
     McpMaterializedCommand,
 )
 from utils.process_group import OwnedProcessGroup
+
+
+def test_incident_error_text_has_no_blank_timeout_message() -> None:
+    assert mcp_host_module._error_text(TimeoutError()) == "TimeoutError"
 
 
 def _free_port() -> int:


### PR DESCRIPTION
## 变更

- 重试同一已验证插件 artifact 时，仅跳过 manifest 声明下由 Core 生成的 `.venv` 后代
- 初次 Git clone 的越界 symlink 校验保持不变
- 空消息异常（例如 `TimeoutError()`）生成合法、非空的 MCP Incident 文本

## 可达路径

hua-home 上 Feed v3 candidate 首次准备后 runtime handshake 失败并留下 immutable artifact；再次安装 exact source 时，Core 把自己生成的 `.venv/bin/python -> /usr/bin/python3.14` 误判为插件 source 越界。原始超时同时被尾空格 Incident 校验覆盖。

## 验证

- `.venv/bin/pytest -q tests/test_plugin_install.py tests/test_plugin_mcp_generation_host.py tests/test_plugin_runtime_control.py tests/test_plugin_turn_rollout.py`：52 passed
- `pyright ...`：0 errors
- `python -m compileall ...`：passed
- `git diff --check`：passed
- 未运行 E1～E4；本 PR 是局部安装重试修复，线上行为将在 exact-head 部署后用 attached child 验证。