### PR TITLE
fix(runtime): retain long plugin install executions

### DIFF
--- a/docker/host-runtime/systemd/akashic-host-bridge.service
+++ b/docker/host-runtime/systemd/akashic-host-bridge.service
@@ -11,7 +11,7 @@ EnvironmentFile=%h/.config/akashic-container/runtime.env
 Environment=AKASHIC_LOG_FORMAT=json
 Environment=AKASHIC_SERVICE_NAME=akashic-host-bridge
 ExecStartPre=/usr/bin/env ${AKASHIC_BRIDGE_PYTHON} ${AKASHIC_RUNTIME_CHECKOUT}/scripts/verify_host_runtime_deployment.py --host-only --release-manifest ${AKASHIC_RELEASE_MANIFEST} --runtime-checkout ${AKASHIC_RUNTIME_CHECKOUT} --mise ${AKASHIC_MISE} --bridge-python ${AKASHIC_BRIDGE_PYTHON} --expected-toolchain-digest ${AKASHIC_HOST_TOOLCHAIN_DIGEST}
-ExecStart=/usr/bin/env ${AKASHIC_MISE} exec -C ${AKASHIC_RUNTIME_CHECKOUT} -- /usr/bin/env PYTHONPATH=${AKASHIC_RUNTIME_CHECKOUT} ${AKASHIC_BRIDGE_PYTHON} -m agent.host_bridge.server --socket ${AKASHIC_HOST_BRIDGE_SOCKET} --token-file ${AKASHIC_HOST_BRIDGE_TOKEN_FILE} --lease-timeout 10 --artifact-root ${AKASHIC_HOST_ARTIFACT_ROOT} --release-commit ${AKASHIC_RUNTIME_COMMIT} --toolchain-digest ${AKASHIC_HOST_TOOLCHAIN_DIGEST} --runtime-checkout ${AKASHIC_RUNTIME_CHECKOUT} --bridge-python ${AKASHIC_BRIDGE_PYTHON}
+ExecStart=/usr/bin/env ${AKASHIC_MISE} exec -C ${AKASHIC_RUNTIME_CHECKOUT} -- /usr/bin/env PYTHONPATH=${AKASHIC_RUNTIME_CHECKOUT} ${AKASHIC_BRIDGE_PYTHON} -m agent.host_bridge.server --socket ${AKASHIC_HOST_BRIDGE_SOCKET} --token-file ${AKASHIC_HOST_BRIDGE_TOKEN_FILE} --lease-timeout 305 --artifact-root ${AKASHIC_HOST_ARTIFACT_ROOT} --release-commit ${AKASHIC_RUNTIME_COMMIT} --toolchain-digest ${AKASHIC_HOST_TOOLCHAIN_DIGEST} --runtime-checkout ${AKASHIC_RUNTIME_CHECKOUT} --bridge-python ${AKASHIC_BRIDGE_PYTHON}
 Restart=on-failure
 RestartSec=3s
 KillMode=control-group

--- a/tests/test_host_runtime_lifecycle.py
+++ b/tests/test_host_runtime_lifecycle.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
+
+from agent.tools.unified_exec import MAX_WRITE_STDIN_YIELD_TIME_MS
 
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEMD = ROOT / "docker" / "host-runtime" / "systemd"
@@ -31,6 +34,16 @@ def test_core_consumes_external_services_without_owning_them() -> None:
     assert not (ROOT / "docker/home-services").exists()
     assert not (SYSTEMD / "akashic-home-services.service").exists()
     assert not (SYSTEMD / "akashic-opencli-browser.service").exists()
+
+
+def test_host_bridge_lease_covers_longest_write_stdin_wait() -> None:
+    bridge_unit = (SYSTEMD / "akashic-host-bridge.service").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"--lease-timeout (\d+)", bridge_unit)
+
+    assert match is not None
+    assert int(match.group(1)) > MAX_WRITE_STDIN_YIELD_TIME_MS / 1_000 + 2
 
 
 def test_release_restart_does_not_control_external_services(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- align the Host Bridge lease with the public 300-second write_stdin wait
- prevent valid long plugin-install executions from being reaped during Core event-loop stalls
- retain boot fencing and execution hard-timeout cleanup

## Evidence
- production log: manager lease reaped 9 seconds after a running plugin-install yielded its execution_id
- candidate reached latest_ready only after the host execution had already been killed
- `pytest -q tests/test_host_runtime_lifecycle.py tests/test_host_bridge.py` -> 19 passed
- `git diff --check` -> passed

## Scope
No semantic-gate relaxation, plugin contract change, or workspace migration.