### PR TITLE
fix(tools): expose searched tools within provider schema cap

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1937,6 +1937,11 @@ class DefaultReasoner(Reasoner):
                             internal_arguments["excluded_names"] = (
                                 visible_names | disabled
                             )
+                            max_schemas = _provider_max_tool_schemas(
+                                self._llm.provider
+                            )
+                            if max_schemas > 0:
+                                internal_arguments["max_unlocked"] = max_schemas - 1
                         if name == "message_push":
                             internal_arguments["_commit_role"] = "passive"
                         return await self._tools.execute(
@@ -2061,13 +2066,23 @@ class DefaultReasoner(Reasoner):
                                 always_on_order = self._tools.get_registered_order(
                                     self._tools.get_always_on_names() - disabled
                                 )
+                                max_schemas = _provider_max_tool_schemas(
+                                    self._llm.provider
+                                )
+                                retained = _project_tool_order(
+                                    [*always_on_order, *visible_order],
+                                    max(1, max_schemas - len(_newly_unlocked))
+                                    if max_schemas > 0
+                                    else 0,
+                                )
                                 visible_order = _project_tool_order(
                                     [
-                                        *always_on_order,
+                                        *retained,
                                         *_newly_unlocked,
+                                        *always_on_order,
                                         *visible_order,
                                     ],
-                                    _provider_max_tool_schemas(self._llm.provider),
+                                    max_schemas,
                                 )
                                 visible_names = set(visible_order)
                                 dropped = previous_visible - visible_names

--- a/agent/tools/tool_search.py
+++ b/agent/tools/tool_search.py
@@ -73,6 +73,7 @@ class ToolSearchTool(Tool):
         top_k: int = 5,
         allowed_risk: list[str] | None = None,
         excluded_names: set[str] | list[str] | tuple[str, ...] | None = None,
+        max_unlocked: int | None = None,
         **_: Any,
     ) -> str:
         excluded: set[str] = (
@@ -97,6 +98,7 @@ class ToolSearchTool(Tool):
                 query[7:],
                 allowed_risk=allowed_risk,
                 excluded_names=excluded,
+                max_unlocked=max_unlocked,
             )
 
         # ── 关键词搜索路径 ────────────────────────────────────────────────
@@ -117,22 +119,28 @@ class ToolSearchTool(Tool):
                 },
                 ensure_ascii=False,
             )
+        capacity_limited: list[str] = []
+        if max_unlocked is not None:
+            capacity_limited = [
+                item["name"]
+                for item in results[max_unlocked:]
+                if isinstance(item.get("name"), str) and item["name"]
+            ]
+            results = results[:max_unlocked]
         unlocked = [
             item["name"]
             for item in results
             if isinstance(item.get("name"), str) and item["name"]
         ]
         self._registry.grant_current_turn_search(unlocked)
+        result: dict[str, Any] = {
+            "matched": results,
+            "unlocked": unlocked,
+            "already_loaded": [],
+        }
+        self._append_next_action(result, unlocked, capacity_limited)
         return json.dumps(
-            {
-                "matched": results,
-                "unlocked": unlocked,
-                "already_loaded": [],
-                "next_action": (
-                    "unlocked 中的工具 schema 已加载。下一步直接调用需要的工具，"
-                    "不要再次 tool_search。"
-                ),
-            },
+            result,
             ensure_ascii=False,
             indent=2,
         )
@@ -143,6 +151,7 @@ class ToolSearchTool(Tool):
         *,
         allowed_risk: list[str] | None = None,
         excluded_names: set[str] | None = None,
+        max_unlocked: int | None = None,
     ) -> str:
         """处理 select:A,B,C 精确加载路径。
 
@@ -190,6 +199,10 @@ class ToolSearchTool(Tool):
                 else:
                     found.append(name)
 
+        capacity_limited: list[str] = []
+        if max_unlocked is not None:
+            capacity_limited = found[max_unlocked:]
+            found = found[:max_unlocked]
         matched = self._registry.get_schemas_as_doc_results(found)
         self._registry.grant_current_turn_search(found)
         result: dict[str, Any] = {
@@ -197,11 +210,7 @@ class ToolSearchTool(Tool):
             "unlocked": found,
             "already_loaded": already_loaded,
         }
-        if found:
-            result["next_action"] = (
-                "unlocked 中的工具 schema 已加载。下一步直接调用需要的工具，"
-                "不要再次 tool_search。"
-            )
+        self._append_next_action(result, found, capacity_limited)
 
         tip_parts: list[str] = []
         if already_loaded:
@@ -218,3 +227,23 @@ class ToolSearchTool(Tool):
             result["tip"] = "; ".join(tip_parts)
 
         return json.dumps(result, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def _append_next_action(
+        result: dict[str, Any],
+        unlocked: list[str],
+        capacity_limited: list[str],
+    ) -> None:
+        """记录真实装载结果与 provider 容量限制。"""
+
+        if unlocked:
+            result["next_action"] = (
+                "unlocked 中的工具 schema 已加载。下一步直接调用需要的工具，"
+                "不要再次 tool_search。"
+            )
+        if capacity_limited:
+            result["capacity_limited"] = capacity_limited
+            result["next_action"] = (
+                "unlocked 中的工具可直接调用；capacity_limited 中的工具尚未加载，"
+                "需要时请稍后单独 select。"
+            )

--- a/tests/test_loop_tool_visibility.py
+++ b/tests/test_loop_tool_visibility.py
@@ -20,7 +20,9 @@ from unittest.mock import MagicMock
 
 from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig, MemoryServices
+from agent.control.context import running_turn_id
 from bus.queue import MessageBus
+from core.error_context import current_session_key
 
 import pytest
 
@@ -378,6 +380,79 @@ class TestVisibilityGuard:
         assert final == "done"
         assert schemas_seen == [["tool_search", "recent_preload"]]
         assert "always_a" in reg.get_deferred_names(visible=set(schemas_seen[0]))["builtin"]
+
+    def test_search_unlock_replaces_overfull_always_on_tool(self, tmp_path):
+        reg = ToolRegistry()
+        reg.register(ToolSearchTool(reg), always_on=True, risk="read-only")
+        reg.register(_DummyTool("always_a"), always_on=True)
+        reg.register(_DummyTool("always_b"), always_on=True)
+        selected = _DummyTool("selected_tool")
+        overflow = _DummyTool("overflow_tool")
+        reg.register(selected, requires_turn_search=True)
+        reg.register(overflow, requires_turn_search=True)
+
+        schemas_seen: list[list[str]] = []
+
+        class _LimitedProvider(_FakeProvider):
+            max_tool_schemas = 2
+
+            async def chat(self, **kwargs: Any) -> LLMResponse:
+                schemas_seen.append(
+                    [tool["function"]["name"] for tool in kwargs.get("tools") or []]
+                )
+                return await super().chat(**kwargs)
+
+        provider = _LimitedProvider(
+            [
+                LLMResponse(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            "s1",
+                            "tool_search",
+                            {"query": "select:selected_tool,overflow_tool"},
+                        )
+                    ],
+                ),
+                LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall("t1", "selected_tool", {})],
+                ),
+                LLMResponse(content="done", tool_calls=[]),
+            ]
+        )
+        loop = _make_loop(tmp_path, provider, reg)
+
+        turn_token = running_turn_id.set("turn:search-cap")
+        session_token = current_session_key.set("programmatic:search-cap")
+        scope = reg.begin_turn_search_scope(
+            turn_id="turn:search-cap",
+            session_key="programmatic:search-cap",
+            attempt=0,
+        )
+        try:
+            final, tools_used, tool_chain, _, _ = asyncio.run(
+                loop._run_agent_loop([{"role": "user", "content": "use selected"}])
+            )
+            with pytest.raises(RuntimeError, match="必须在当前 turn"):
+                asyncio.run(reg.execute("overflow_tool", {}, raise_errors=True))
+        finally:
+            reg.end_turn_search_scope(scope)
+            current_session_key.reset(session_token)
+            running_turn_id.reset(turn_token)
+
+        assert final == "done"
+        assert schemas_seen == [
+            ["tool_search", "always_a"],
+            ["tool_search", "selected_tool"],
+            ["tool_search", "selected_tool"],
+        ]
+        assert tools_used == ["tool_search", "selected_tool"]
+        assert len(selected.calls) == 1
+        assert len(overflow.calls) == 0
+        search_result = json.loads(tool_chain[0]["calls"][0]["result"])
+        assert search_result["unlocked"] == ["selected_tool"]
+        assert search_result["capacity_limited"] == ["overflow_tool"]
 
 
 # ── LRU 测试 ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reserve provider schema capacity for tools unlocked by the current turn search
- retain existing always-on priority when capacity is available
- add a regression proving an unlocked tool replaces an overfull always-on entry and executes

## Verification
- `/mnt/data/coding/akasic-agent/.venv/bin/pytest -q tests/test_loop_tool_visibility.py tests/test_tool_search.py` (79 passed)
- `git diff --check`

## Scope
This keeps the provider schema cap and current-turn search authorization strict; it does not add a bypass or compatibility path.