### PR TITLE
fix(plugins): align GitHub Watch candidate data boundary

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -6545,7 +6545,18 @@ def _copy_validation_data(
     # 2. Candidate data must never retain an edge back into formal storage.
     for directory, dirnames, filenames in os.walk(source_root, followlinks=False):
         root = Path(directory)
-        for name in (*dirnames, *filenames):
+        relative_dir = root.relative_to(source_root)
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if not _candidate_data_path_is_excluded(relative_dir / name, excluded)
+        ]
+        retained_files = [
+            name
+            for name in filenames
+            if not _candidate_data_path_is_excluded(relative_dir / name, excluded)
+        ]
+        for name in (*dirnames, *retained_files):
             path = root / name
             if path.is_symlink():
                 raise RuntimeError(
@@ -6558,11 +6569,7 @@ def _copy_validation_data(
         relative_dir = current.relative_to(source_root)
         ignored: list[str] = []
         for name in names:
-            relative = (relative_dir / name).as_posix()
-            if any(
-                relative == item or relative.startswith(item + "/")
-                for item in excluded
-            ):
+            if _candidate_data_path_is_excluded(relative_dir / name, excluded):
                 ignored.append(name)
         return ignored
 
@@ -6575,6 +6582,16 @@ def _copy_validation_data(
         for filename in filenames:
             inventory.append(root.joinpath(filename).relative_to(target).as_posix())
     return tuple(sorted(inventory))
+
+
+def _candidate_data_path_is_excluded(
+    relative_path: PurePosixPath,
+    excluded: tuple[str, ...],
+) -> bool:
+    relative = relative_path.as_posix()
+    return any(
+        relative == item or relative.startswith(item + "/") for item in excluded
+    )
 
 
 def _replace_snapshot_payload(

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -6585,7 +6585,7 @@ def _copy_validation_data(
 
 
 def _candidate_data_path_is_excluded(
-    relative_path: PurePosixPath,
+    relative_path: Path,
     excluded: tuple[str, ...],
 ) -> bool:
     relative = relative_path.as_posix()

--- a/docker/debug/plugin-v3-fleet.lock.json
+++ b/docker/debug/plugin-v3-fleet.lock.json
@@ -137,9 +137,9 @@
     {
       "id": "github_watch",
       "repository": "https://github.com/kachofugetsu09/github-watch.git",
-      "requested_ref": "1f8e843610a6f2802dd62ea2fad01e9ec7a8e308",
-      "resolved_sha": "1f8e843610a6f2802dd62ea2fad01e9ec7a8e308",
-      "change_source_pr_head": "1f8e843610a6f2802dd62ea2fad01e9ec7a8e308"
+      "requested_ref": "b9266ab3ca9932c074a6d91cf48ab69691bcf1ce",
+      "resolved_sha": "b9266ab3ca9932c074a6d91cf48ab69691bcf1ce",
+      "change_source_pr_head": "b9266ab3ca9932c074a6d91cf48ab69691bcf1ce"
     }
   ]
 }

--- a/tests/test_plugin_static_manifest.py
+++ b/tests/test_plugin_static_manifest.py
@@ -337,6 +337,27 @@ def test_candidate_data_copy_rejects_symlink_to_formal_storage(
     assert not target.exists()
 
 
+def test_candidate_data_copy_ignores_symlink_inside_excluded_cache(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "production-data"
+    target = tmp_path / "candidate-data"
+    cache = source / "checkouts" / "repository" / ".venv"
+    cache.mkdir(parents=True)
+    (cache / "lib").mkdir()
+    (cache / "lib64").symlink_to("lib", target_is_directory=True)
+    (source / "state.json").write_text("keep", encoding="utf-8")
+
+    inventory = manager_module._copy_validation_data(  # pyright: ignore[reportPrivateUsage]
+        source,
+        target,
+        ("checkouts",),
+    )
+
+    assert inventory == ("state.json",)
+    assert not (target / "checkouts").exists()
+
+
 def test_static_process_declaration_must_match_c13_root_registry(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- pin GitHub Watch to merged head `b9266ab3`
- exclude derived checkout/mirror caches from isolated candidate plugin-data
- retain durable ledger data and strict Core symlink rejection

## Verification
- GitHub Watch: 48 tests passed
- `plugin_v3_fleet_gate.py`: passed against the updated exact lock
- `git diff --check`

## Production finding
A Feed rollout correctly aborted because an older GitHub Watch stable generation exposed a virtualenv `lib64 -> lib` symlink inside derived checkout data. The plugin now classifies those cache roots as candidate-copy exclusions instead of weakening Core safety.