### PR TITLE
fix(plugins): bind candidate Root tool modules

### DIFF
--- a/agent/plugin_composition/context.py
+++ b/agent/plugin_composition/context.py
@@ -11,6 +11,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any, AsyncGenerator, Protocol, TypeVar, cast
 
 from agent.plugin_composition.effect import Effect, EffectSetup
@@ -90,6 +91,12 @@ class Context:
 
         reject_executor_context_access()
         return self._root.instance_token
+
+    def _plugin_module(self) -> ModuleType | None:
+        """Return the exact module mounted on this Fiber when one exists."""
+
+        reject_executor_context_access()
+        return self._fiber.plugin_module
 
     @property
     def runtime(self) -> PluginRuntime:
@@ -414,6 +421,7 @@ class Fiber:
         parent: Fiber | None,
         required_for_readiness: bool,
         runtime: PluginRuntime | None,
+        plugin_module: ModuleType | None,
         static_active: bool = True,
         is_root: bool = False,
     ) -> None:
@@ -426,6 +434,7 @@ class Fiber:
         self.parent = parent
         self.required_for_readiness = required_for_readiness
         self.runtime = runtime
+        self.plugin_module = plugin_module
         self.state = FiberState.ACTIVE if is_root else FiberState.PENDING
         self.context = Context(root, self)
         self.dependency_store: dict[ServiceKey[object], _Provider] = {}
@@ -689,6 +698,7 @@ class CompositionRoot:
             parent=None,
             required_for_readiness=True,
             runtime=None,
+            plugin_module=None,
             static_active=True,
             is_root=True,
         )
@@ -979,6 +989,11 @@ class CompositionRoot:
             parent=parent,
             required_for_readiness=required_for_readiness,
             runtime=runtime,
+            plugin_module=(
+                module
+                if isinstance((module := getattr(plugin, "module", None)), ModuleType)
+                else parent.plugin_module
+            ),
             static_active=static_active,
         )
         self._next_fiber_id += 1

--- a/agent/plugin_composition/runtime_services.py
+++ b/agent/plugin_composition/runtime_services.py
@@ -34,6 +34,12 @@ class MemoryTurnRuntime:
 
         return cls(None)
 
+    @property
+    def formal(self) -> bool:
+        """Return whether this service owns the selected formal Turn runtime."""
+
+        return self._runtime is not None
+
     def take_user_metadata(self, turn_id: str) -> MappingProxyType[str, object]:
         """消费一个正式 Turn 的插件 metadata，并断开可变对象引用。"""
 

--- a/agent/plugin_composition/tool_catalog.py
+++ b/agent/plugin_composition/tool_catalog.py
@@ -5,7 +5,7 @@ import json
 import re
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from types import MappingProxyType
+from types import MappingProxyType, ModuleType
 from typing import Literal, TypeAlias, cast
 
 from agent.plugin_composition.context import Context, FiberHandle, HealthHandle
@@ -60,12 +60,13 @@ class PluginToolDescriptor:
 
 @dataclass(frozen=True, slots=True)
 class PluginToolBinding:
-    """Bind one Tool descriptor to an exact generation and Fiber activation."""
+    """Bind one Tool and its exact Root-local module to a live Fiber."""
 
     generation_id: str
     plugin_id: str
     descriptor: PluginToolDescriptor
     definition: PluginToolDefinition
+    module: ModuleType | None
     owner_fiber: FiberHandle
     activation_token: object
     required_health: HealthHandle
@@ -126,6 +127,7 @@ class _Registration:
     generation_id: str
     definition: PluginToolDefinition
     descriptor: PluginToolDescriptor
+    module: ModuleType | None
     owner_fiber: FiberHandle
     activation_token: object
     required_health: HealthHandle | None = None
@@ -140,6 +142,7 @@ class _ToolDeclarations:
 
     async def register(self, ctx: Context, definition: PluginToolDefinition) -> None:
         normalized = _normalize_definition(definition)
+        module = ctx._plugin_module()  # pyright: ignore[reportPrivateUsage]
         owner_fiber = ctx.fiber
         activation_token = owner_fiber.activation_token
         if activation_token is None:
@@ -152,6 +155,7 @@ class _ToolDeclarations:
                 ctx.runtime.plugin_id,
                 ctx.generation_id,
                 normalized,
+                module,
                 owner_fiber,
                 activation_token,
             )
@@ -174,6 +178,7 @@ class _ToolDeclarations:
         plugin_id: str,
         generation_id: str,
         definition: PluginToolDefinition,
+        module: ModuleType | None,
         owner_fiber: FiberHandle,
         activation_token: object,
     ) -> tuple[_Registration, object]:
@@ -196,6 +201,7 @@ class _ToolDeclarations:
             generation_id=generation_id,
             definition=definition,
             descriptor=descriptor,
+            module=module,
             owner_fiber=owner_fiber,
             activation_token=activation_token,
         )
@@ -240,6 +246,7 @@ class _ToolDeclarations:
                 plugin_id=registration.plugin_id,
                 descriptor=registration.descriptor,
                 definition=registration.definition,
+                module=registration.module,
                 owner_fiber=registration.owner_fiber,
                 activation_token=registration.activation_token,
                 required_health=health,

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -6859,7 +6859,7 @@ def _build_v3_plugin_tool(
             "plugin Tool handler 不属于 exact generation: "
             f"{binding.plugin_id}:{binding.generation_id}"
         )
-    handler: object = generation.instance.module
+    handler: object = binding.module
     for segment in binding.descriptor.handler_export.replace(":", ".").split("."):
         handler = getattr(handler, segment, None)
         if handler is None:

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -210,6 +210,11 @@ def _persist_feedback(
 ) -> None:
     """Move selected-engine feedback into the current pending user row."""
 
+    # 1. Candidate turns preserve topology but have no formal pending user row.
+    if not runtime.formal:
+        return
+
+    # 2. Formal turns consume and merge the selected engine's metadata once.
     metadata = runtime.take_user_metadata(running_turn_id.get())
     duplicated = set(event.persist_user_metadata) & set(metadata)
     if duplicated:

--- a/tests/test_plugin_composition_tool_catalog.py
+++ b/tests/test_plugin_composition_tool_catalog.py
@@ -284,9 +284,10 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
         "name = 'github-watch'\n"
         "version = '1.0.0'\n"
         "inject = (TOOL_CATALOG,)\n"
+        "bound_data_dir = None\n"
         "async def inspect_repository(context, arguments):\n"
-        "    return context.turn_id + ':' + str(arguments['repository'])\n"
-        "async def apply(ctx, config):\n"
+        "    return context.turn_id + ':' + str(arguments['repository']) + ':' + str(bound_data_dir)\n"
+        "async def mount_tools(ctx):\n"
         "    await ctx.require(TOOL_CATALOG).register(ctx, PluginToolDefinition(\n"
         "        name='inspect_repository',\n"
         "        description='Inspect one repository.',\n"
@@ -298,7 +299,11 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
         "        },\n"
         "        handler_export='inspect_repository',\n"
         "        risk='read-only',\n"
-        "    ))\n",
+        "    ))\n"
+        "async def apply(ctx, config):\n"
+        "    global bound_data_dir\n"
+        "    bound_data_dir = ctx.data_root\n"
+        "    await ctx.mount(mount_tools, inject=(TOOL_CATALOG,))\n",
         encoding="utf-8",
     )
     registry = ToolRegistry(validate_semantic_schema=False)
@@ -332,7 +337,8 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
     finally:
         reset_runtime_snapshot(token)
         await lease.release()
-    assert result == "turn:test:akashic-agent"
+    assert result.startswith("turn:test:akashic-agent:")
+    assert "plugin-validation" not in result
 
     stable_binding = snapshot.plugin_tool_catalog["inspect_repository"]
     source = (plugin_dir / "plugin.py").read_text(encoding="utf-8")
@@ -348,24 +354,29 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
     assert candidate_catalog is not snapshot.plugin_tool_catalog
     assert candidate_catalog.identity == snapshot.plugin_tool_catalog.identity
 
-    publication = await manager.publish_prepared("github-watch")
-    assert publication["publication_state"] == "committed"
-    formal = manager.current_snapshot
-    assert formal is not None and formal.composition_root is not None
-    formal_catalog = formal.plugin_tool_catalog
-    assert formal_catalog is not None
-    assert formal_catalog is not candidate_catalog
-    assert formal_catalog.identity == candidate_catalog.identity
-    assert (
-        formal_catalog.root_instance_token
-        is formal.composition_root.instance_token
-    )
+    transaction = manager.snapshot_store.begin_publish(candidate.runtime_snapshot)
+    await manager.snapshot_store.commit_latest(transaction)
+    candidate_lease = manager.snapshot_store.lease(selector="latest")
+    candidate_token = bind_runtime_snapshot(candidate_lease)
+    candidate.runtime_snapshot.tool_registry.set_context(turn_id="turn:candidate")
+    try:
+        candidate_result = await candidate.runtime_snapshot.tool_registry.execute(
+            "inspect_repository",
+            {"repository": "akashic-agent"},
+            raise_errors=True,
+        )
+    finally:
+        reset_runtime_snapshot(candidate_token)
+        await candidate_lease.release()
+    assert "turn:candidate:akashic-agent:" in candidate_result
+    assert "plugin-validation" in candidate_result
+
+    await manager.snapshot_store.discard_latest(candidate.runtime_snapshot)
     assert not candidate_binding.is_live()
-    assert formal_catalog["inspect_repository"].is_live()
+    await manager.discard_prepared("github-watch")
 
     await manager.terminate_all()
     assert not stable_binding.is_live()
-    assert not formal_catalog["inspect_repository"].is_live()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_composition_tool_catalog.py
+++ b/tests/test_plugin_composition_tool_catalog.py
@@ -337,6 +337,7 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
     finally:
         reset_runtime_snapshot(token)
         await lease.release()
+    assert isinstance(result, str)
     assert result.startswith("turn:test:akashic-agent:")
     assert "plugin-validation" not in result
 
@@ -368,6 +369,7 @@ async def test_manager_compiles_and_executes_exact_v3_tool_binding(
     finally:
         reset_runtime_snapshot(candidate_token)
         await candidate_lease.release()
+    assert isinstance(candidate_result, str)
     assert "turn:candidate:akashic-agent:" in candidate_result
     assert "plugin-validation" in candidate_result
 

--- a/tests/test_plugin_memory_turn_runtime.py
+++ b/tests/test_plugin_memory_turn_runtime.py
@@ -68,6 +68,7 @@ def test_memory_turn_runtime_copies_metadata_and_reads_bounded_recall() -> None:
 def test_candidate_memory_turn_runtime_rejects_formal_state_access() -> None:
     runtime = MemoryTurnRuntime.candidate_validation()
 
+    assert not runtime.formal
     with pytest.raises(RuntimeError, match="candidate 验证期"):
         runtime.take_user_metadata("turn-1")
     with pytest.raises(RuntimeError, match="candidate 验证期"):
@@ -236,6 +237,31 @@ async def test_real_akasha_v3_rebuilds_formal_mobile_binding(
     assert candidate is not None and candidate.runtime_snapshot is not None
     assert manager.current_snapshot is stable
     assert sentinel.read_bytes() == b"formal-memory"
+
+    candidate_feedback = AfterReasoningCtx(
+        session_key="test:candidate",
+        channel="programmatic",
+        chat_id="candidate",
+        tools_used=(),
+        thinking=None,
+        response_metadata=ResponseMetadata(raw_text="candidate reply"),
+        streamed=False,
+        tool_chain=(),
+        context_retry={},
+        reply="candidate reply",
+    )
+    candidate_turn_token = running_turn_id.set("turn-candidate")
+    try:
+        result = await candidate.runtime_snapshot.composition_root.context.serial(
+            AFTER_REASONING_PREPROCESS_EVENT,
+            candidate_feedback,
+        )
+    finally:
+        running_turn_id.reset(candidate_turn_token)
+    assert result is None
+    assert candidate_feedback.persist_user_metadata == {}
+    assert engine.metadata_calls == 1
+
     candidate_registry = candidate.runtime_snapshot.mobile_ui_registry
     assert candidate_registry is not None
     with pytest.raises(RuntimeError, match="candidate 验证期"):


### PR DESCRIPTION
## 问题与结果

- 解决的问题：candidate Root 的 v3 Tool descriptor 会回到 generation 的另一份 module 解析 handler，导致 apply() 绑定的 Root-local 状态缺失；Akasha candidate after-reasoning 会误访问正式 Memory Turn runtime。
- 用户可见结果：attached candidate child 可以通过真实 ToolRegistry 调用候选插件只读工具，Akasha 在不写 Memory 的候选验证中保持相同拓扑且不再失败。
- 本 PR 不处理：插件版本晋升、E1～E4 部署验收和移动端改动。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：v3 plugin candidate Root、Tool catalog、Akasha candidate lifecycle
- `runtime_patch`：`required`
- `runtime_patch_reason`：candidate clone module 与 generation module 是不同的运行时实例，Core 必须把 exact Root module 绑定到 Tool binding。
- `authoritative_state_owner`：PluginManager / RuntimeSnapshot / CompositionRoot
- `client_only_alternative`：无；客户端无法修复服务端 candidate module 身份。
- 关联不变量：Tool handler 属于 exact Root、exact snapshot catalog 和 live Fiber；candidate 不访问正式 Memory Turn runtime。
- `protected_state`：stable plugin pointer、正式 Memory、session messages、外部 GitHub 状态。
- 允许的副作用：测试临时 workspace 与 Change Gate 临时报告。
- 禁止的副作用：晋升插件、写正式 Memory、修改生产 workspace、外部 GitHub write action。

## 改动范围

- 主要文件：`agent/plugin_composition/context.py`、`agent/plugin_composition/tool_catalog.py`、`agent/plugins/manager.py`、`agent/plugin_composition/runtime_services.py`、`plugins/akasha/plugin.py`
- 配置或迁移影响：无。
- 已知 schema lineage 与最终 schema identity：不适用；无持久化 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `1b9195fc2036a0c5bfad1ed3a5e8ee79a515f9b1`；head `565d613c`。
- 回滚方式：revert 本提交；备份分支 `backup/pre-candidate-runtime-fix-20260822`。

## 验证

- [x] 相关 targeted tests 已通过：134 passed。
- [x] Python 类型检查已通过：0 errors（仓库既有 warnings 保留）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`9d6cd00cb3cd5bd5e6e0fd371477765aa81daad47ad06ef37e51c84da5b49689`
- `planDigest`：`da23655b9ec947cabfc9fad2fcc6b44391d0602eca8fa824c15a3334b588a302`
- Gate：passed，临时报告 `docker/debug/reports/change-gate/20260822-052929-72496cad`
- 真实设备证据：不适用；本 PR 不改移动端协议或 UI。
- 未运行项与原因：未跑 E1～E4；它们属于部署准入，本次用真实 candidate probe 在部署后验证。

## 工作手册

- [x] 已核对 `projectneed.md`、决策 0024/0026、相关设计和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] MOB-001 不适用。
- [x] 当前没有需要从 `NOW.md` 删除的对应事项。

Terra high 最终只读复审：无 P0/P1/P2。
