### PR TITLE
fix(plugins): expose formal session read mode

### DIFF
--- a/agent/plugin_composition/session_read.py
+++ b/agent/plugin_composition/session_read.py
@@ -44,6 +44,12 @@ class SessionReadService:
 
         return cls(None)
 
+    @property
+    def formal(self) -> bool:
+        """Return whether this service can read the formal Session owner."""
+
+        return self._lookup_existing is not None
+
     def read(self, session_key: str) -> SessionReadSnapshot | None:
         """返回一个既有 Session 快照，不创建持久状态。"""
 

--- a/tests/test_plugin_composition_session_read.py
+++ b/tests/test_plugin_composition_session_read.py
@@ -55,10 +55,14 @@ def test_session_read_missing_and_candidate_boundaries_fail_loud() -> None:
         calls.append(session_key)
         raise KeyError(session_key)
 
-    assert SessionReadService(missing).read("mobile:missing") is None
+    formal = SessionReadService(missing)
+    candidate = SessionReadService.candidate_validation()
+    assert formal.formal is True
+    assert candidate.formal is False
+    assert formal.read("mobile:missing") is None
     assert calls == ["mobile:missing"]
     with pytest.raises(RuntimeError, match="candidate 验证期禁止"):
-        SessionReadService.candidate_validation().read("mobile:existing")
+        candidate.read("mobile:existing")
 
     inconsistent = SimpleNamespace(messages=[], last_consolidated=2)
     active = SimpleNamespace(generation=1, consolidated_through_seq=3)


### PR DESCRIPTION
## 结论

为 `SessionReadService` 暴露只读 `formal` 不变量，使 v3 插件能在 apply 阶段明确区分正式 Root 与 candidate Root，而不读取私有字段或尝试正式 Session 访问。

## 现场触发

hua-home 上 github-watch 候选 child 已成功调用候选工具，但 `proactive_feedback` 在 candidate `AFTER_TURN_COMMITTED` 阶段尝试写正式反馈并抛错，导致完整 child Turn 失败。后续插件 PR 将使用此属性在 candidate Root 不注册正式持久化 listener/worker。

## 语义边界

- candidate `read()` 仍然 fail-loud；没有放宽正式 Session 访问。
- 正式 `SessionReadService` 行为不变。
- 本 PR 不修改 SessionDB、plugin-data 或 publication。

## 验证

- `17 passed`: Session Read、Turn Rollout、child lineage
- Pyright touched files: 0 errors
- Change Gate: passed，24 个公开场景
- 报告：`docker/debug/reports/change-gate/20260822-063748-4a76cff6`
