### PR TITLE
fix(akasha): pair snapshots by logical index state

### DIFF
--- a/plugins/akasha/application/rebuild.py
+++ b/plugins/akasha/application/rebuild.py
@@ -24,6 +24,7 @@ from ..domain.model import (
     SeedEvidence,
 )
 from ..infrastructure.loader import load_turns
+from ..infrastructure.sparse_index import sparse_index_state_sha256
 from ..infrastructure.persistence import (
     canonical_json,
     logical_state_sha256,
@@ -222,6 +223,7 @@ def deterministic_metadata(index_path: Path) -> dict[str, str]:
         "git_commit": _git_commit(),
         "numpy_version": np.__version__,
         "source_index_sha256": sha256_file(index_path),
+        "source_index_state_sha256": sparse_index_state_sha256(index_path),
         **_index_identity(index_path),
     }
 

--- a/plugins/akasha/application/runtime.py
+++ b/plugins/akasha/application/runtime.py
@@ -20,6 +20,7 @@ from ..infrastructure.loader import load_turn_suffix, load_turns
 from ..infrastructure.lease import WriterLease
 from ..infrastructure.persistence import (
     load_memory_state,
+    memory_has_source_index_state,
     memory_turn_count,
     sha256_file,
     write_memory_database,
@@ -29,6 +30,7 @@ from ..infrastructure.sparse_index import (
     BuildConfig,
     SparseIndexRebuildRequired,
     build_sparse_index,
+    sparse_index_state_sha256,
 )
 from ..infrastructure.sparse_index.encoding import tokenize
 from .cycle import CycleCommit, MemoryCycle, RetrievalTicket
@@ -243,19 +245,7 @@ class OnlineMemoryRuntime:
             # 2. Publish durable state before exposing the completed transaction.
             if self.cycle.context is None:
                 raise RuntimeError("committed memory state has no context")
-            write_memory_database(
-                self.memory_path,
-                turns=self.cycle.turns,
-                graph=self.cycle.graph,
-                events=self.cycle.events,
-                evidence=self.cycle.evidence,
-                captures=[],
-                context=self.cycle.context,
-                burst_members=self.cycle.burst_members,
-                config=self.config,
-                metadata=deterministic_metadata(self.index_path),
-                recalls=self.cycle.recalls,
-            )
+            self._write_cycle_snapshot(self.cycle)
         except Exception:
             self.cycle = self._restore_persisted_cycle()
             raise
@@ -265,6 +255,11 @@ class OnlineMemoryRuntime:
         """Restore a snapshot and causally catch up any indexed source turns."""
 
         # 1. Bring the derived sparse index to the sessions source boundary.
+        legacy_source_hash = (
+            sha256_file(self.index_path)
+            if self.index_path.exists() and self.memory_path.exists()
+            else None
+        )
         try:
             result = build_sparse_index(
                 self.sessions_path,
@@ -292,14 +287,23 @@ class OnlineMemoryRuntime:
 
         # 2. Restore the persisted prefix and replay only crash-window suffixes.
         try:
-            cycle, suffix = self._load_persisted_prefix(turns)
+            has_state_identity = memory_has_source_index_state(self.memory_path)
+            cycle, suffix = self._load_persisted_prefix(
+                turns,
+                legacy_source_hash=(
+                    None if has_state_identity else legacy_source_hash
+                ),
+            )
         except ValueError as exc:
             logger.warning(
                 "Akasha memory snapshot no longer matches source; rebuilding: %s",
                 exc,
             )
             return self._fresh_rebuild_from_source()
-        return self._catch_up(cycle, suffix)
+        cycle = self._catch_up(cycle, suffix)
+        if not has_state_identity and not suffix:
+            self._write_cycle_snapshot(cycle)
+        return cycle
 
     def _fresh_rebuild_from_source(self) -> MemoryCycle:
         """先生成完整候选，再按 index→memory 顺序发布可恢复派生状态。"""
@@ -364,6 +368,8 @@ class OnlineMemoryRuntime:
     def _load_persisted_prefix(
         self,
         turns: list[Turn],
+        *,
+        legacy_source_hash: str | None = None,
     ) -> tuple[MemoryCycle, list[Turn]]:
         """Restore the durable prefix and return its unprocessed source suffix."""
 
@@ -374,7 +380,12 @@ class OnlineMemoryRuntime:
             )
         prefix = turns[:persisted]
         exact_source_hash = (
-            sha256_file(self.index_path) if persisted == len(turns) else None
+            legacy_source_hash if persisted == len(turns) else None
+        )
+        exact_state_hash = (
+            sparse_index_state_sha256(self.index_path)
+            if persisted == len(turns) and legacy_source_hash is None
+            else None
         )
         (
             graph,
@@ -388,6 +399,7 @@ class OnlineMemoryRuntime:
             turns=prefix,
             config=self.config,
             source_index_sha256=exact_source_hash,
+            source_index_state_sha256=exact_state_hash,
         )
         cycle = MemoryCycle.restore(
             config=self.config,
@@ -406,6 +418,25 @@ class OnlineMemoryRuntime:
         )
         return cycle, turns[persisted:]
 
+    def _write_cycle_snapshot(self, cycle: MemoryCycle) -> None:
+        """Persist one complete cycle with the current sparse-index identity."""
+
+        if cycle.context is None:
+            raise RuntimeError("persisted memory state has no context")
+        write_memory_database(
+            self.memory_path,
+            turns=cycle.turns,
+            graph=cycle.graph,
+            events=cycle.events,
+            evidence=cycle.evidence,
+            captures=[],
+            context=cycle.context,
+            burst_members=cycle.burst_members,
+            config=self.config,
+            metadata=deterministic_metadata(self.index_path),
+            recalls=cycle.recalls,
+        )
+
     def _catch_up(
         self,
         cycle: MemoryCycle,
@@ -422,19 +453,7 @@ class OnlineMemoryRuntime:
             return cycle
         if cycle.context is None:
             raise RuntimeError("recovered memory state has no context")
-        write_memory_database(
-            self.memory_path,
-            turns=cycle.turns,
-            graph=cycle.graph,
-            events=cycle.events,
-            evidence=cycle.evidence,
-            captures=[],
-            context=cycle.context,
-            burst_members=cycle.burst_members,
-            config=self.config,
-            metadata=deterministic_metadata(self.index_path),
-            recalls=cycle.recalls,
-        )
+        self._write_cycle_snapshot(cycle)
         return cycle
 
 

--- a/plugins/akasha/infrastructure/persistence.py
+++ b/plugins/akasha/infrastructure/persistence.py
@@ -82,6 +82,7 @@ def load_memory_state(
     turns: list[Turn],
     config: MemoryConfig,
     source_index_sha256: str | None,
+    source_index_state_sha256: str | None = None,
 ) -> tuple[
     DynamicMemoryGraph,
     list[PlasticityResult],
@@ -105,6 +106,7 @@ def load_memory_state(
             turns,
             config,
             source_index_sha256,
+            source_index_state_sha256,
         )
 
         # 2. Restore graph arrays and learned clocks exactly.
@@ -601,6 +603,7 @@ def _validate_snapshot_identity(
     turns: list[Turn],
     config: MemoryConfig,
     source_index_sha256: str | None,
+    source_index_state_sha256: str | None,
 ) -> None:
     metadata = dict(
         connection.execute(
@@ -613,6 +616,8 @@ def _validate_snapshot_identity(
     }
     if source_index_sha256 is not None:
         expected["source_index_sha256"] = source_index_sha256
+    if source_index_state_sha256 is not None:
+        expected["source_index_state_sha256"] = source_index_state_sha256
     mismatches = {
         key: (metadata.get(key), value)
         for key, value in expected.items()
@@ -710,6 +715,22 @@ def memory_turn_count(memory_path: Path) -> int:
     if count <= 0:
         raise ValueError("memory snapshot turn_count must be positive")
     return count
+
+
+def memory_has_source_index_state(memory_path: Path) -> bool:
+    """Report whether a snapshot uses the logical sparse-index identity."""
+
+    connection = sqlite3.connect(
+        f"file:{memory_path}?mode=ro",
+        uri=True,
+    )
+    try:
+        row = connection.execute(
+            "SELECT 1 FROM metadata WHERE key='source_index_state_sha256'"
+        ).fetchone()
+    finally:
+        connection.close()
+    return row is not None
 
 
 def _load_graph(

--- a/plugins/akasha/infrastructure/sparse_index/__init__.py
+++ b/plugins/akasha/infrastructure/sparse_index/__init__.py
@@ -9,6 +9,7 @@ from .builder import (
     SparseIndexRebuildRequired,
     audit_source_embeddings,
     build_sparse_index,
+    sparse_index_state_sha256,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "SparseIndexRebuildRequired",
     "audit_source_embeddings",
     "build_sparse_index",
+    "sparse_index_state_sha256",
 ]

--- a/plugins/akasha/infrastructure/sparse_index/builder.py
+++ b/plugins/akasha/infrastructure/sparse_index/builder.py
@@ -7,7 +7,7 @@ import hashlib
 import math
 import sqlite3
 from collections import Counter, defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +30,24 @@ LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
 INTERRUPTED_ASSISTANT_MARKER = "[interrupted]"
 TurnPair = tuple[tuple[sqlite3.Row, ...], sqlite3.Row]
 
+_STATE_TABLES = (
+    "sparse_turns",
+    "sparse_features",
+    "turn_terms",
+    "lexical_corpora",
+    "lexical_stats",
+    "turn_dense",
+    "time_observations",
+    "time_stats",
+    "stream_state",
+)
+_DIAGNOSTIC_METADATA_KEYS = frozenset(
+    {
+        "turns_excluded_interrupted",
+        "turns_excluded_memory",
+    }
+)
+
 
 class AppendOnlyViolation(RuntimeError):
     """Report that an incremental source contains new historical turns."""
@@ -37,6 +55,62 @@ class AppendOnlyViolation(RuntimeError):
 
 class SparseIndexRebuildRequired(ValueError):
     """Report that a derived sparse index must be rebuilt from its source."""
+
+
+def sparse_index_state_sha256(path: Path) -> str:
+    """Hash graph-relevant index state independently of SQLite file layout."""
+
+    # 1. Hash all non-diagnostic metadata in stable key order.
+    connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        digest = hashlib.sha256()
+        metadata = connection.execute(
+            "SELECT key, value FROM metadata ORDER BY key"
+        )
+        for key, value in metadata:
+            if key in _DIAGNOSTIC_METADATA_KEYS:
+                continue
+            digest.update(_identity_json([key, value]))
+
+        # 2. Hash every logical index row in deterministic column order.
+        for table in _STATE_TABLES:
+            columns = [
+                row[1]
+                for row in connection.execute(
+                    f'PRAGMA table_info("{table}")'
+                )
+            ]
+            if not columns:
+                raise ValueError(f"sparse index state table is missing: {table}")
+            order = ", ".join(f'"{column}"' for column in columns)
+            digest.update(table.encode("utf-8") + b"\0")
+            for row in connection.execute(
+                f'SELECT * FROM "{table}" ORDER BY {order}'
+            ):
+                digest.update(_identity_json(row))
+        return digest.hexdigest()
+    finally:
+        connection.close()
+
+
+def _identity_json(values: Iterable[object]) -> bytes:
+    normalized = [
+        {"float": value.hex()}
+        if isinstance(value, float)
+        else {"bytes": value.hex()}
+        if isinstance(value, bytes)
+        else value
+        for value in values
+    ]
+    return (
+        json.dumps(
+            normalized,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -3344,6 +3344,84 @@ def test_online_runtime_reopens_unchanged_sidecars_without_rebuilding(
     assert hashlib.sha256(memory_path.read_bytes()).hexdigest() == memory_sha
 
 
+def test_online_runtime_ignores_excluded_turn_diagnostics_on_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """排除计数增长不得触发既有记忆图的全量重放。"""
+
+    # 1. 发布一个旧格式快照，随后只新增明确排除的 session。
+    sessions_path = tmp_path / "sessions.db"
+    index_path = tmp_path / "memory" / "akasha-v2-index.db"
+    memory_path = tmp_path / "memory" / "akasha.db"
+    _create_sessions(sessions_path)
+    started = datetime(2026, 8, 5, tzinfo=timezone.utc)
+    _append_turn(
+        sessions_path,
+        sequence=0,
+        user="alpha request",
+        assistant="beta reply",
+        started=started,
+        with_embeddings=True,
+    )
+    first = OnlineMemoryRuntime(
+        sessions_path=sessions_path,
+        index_path=index_path,
+        memory_path=memory_path,
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+        config=MemoryConfig(),
+    )
+    first.close()
+    with closing(sqlite3.connect(memory_path)) as connection, connection:
+        connection.execute(
+            "DELETE FROM metadata WHERE key='source_index_state_sha256'"
+        )
+    _append_turn(
+        sessions_path,
+        sequence=0,
+        user="programmatic request",
+        assistant="programmatic reply",
+        started=started + timedelta(minutes=1),
+        session_key="github:owner/repo:pr:1",
+        with_embeddings=True,
+        session_metadata={"skip_post_memory": True},
+    )
+
+    # 2. 重启只更新诊断计数，并把旧快照升级为逻辑索引身份。
+    def reject_rebuild(_runtime: OnlineMemoryRuntime) -> MemoryCycle:
+        raise AssertionError("excluded turns must not rebuild learned memory")
+
+    monkeypatch.setattr(
+        OnlineMemoryRuntime,
+        "_fresh_rebuild_from_source",
+        reject_rebuild,
+    )
+    reopened = OnlineMemoryRuntime(
+        sessions_path=sessions_path,
+        index_path=index_path,
+        memory_path=memory_path,
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+        config=MemoryConfig(),
+    )
+    try:
+        assert reopened.cycle.state_version == 1
+    finally:
+        reopened.close()
+
+    with closing(sqlite3.connect(index_path)) as connection:
+        excluded = connection.execute(
+            "SELECT value FROM metadata WHERE key='turns_excluded_memory'"
+        ).fetchone()
+    with closing(sqlite3.connect(memory_path)) as connection:
+        state_hash = connection.execute(
+            "SELECT value FROM metadata WHERE key='source_index_state_sha256'"
+        ).fetchone()
+    assert excluded == ("1",)
+    assert state_hash is not None
+
+
 def test_online_runtime_replays_an_appended_suffix_without_rebuilding(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -75,6 +75,7 @@ from plugins.akasha.infrastructure.sparse_index import (
     SparseIndexRebuildRequired,
     audit_source_embeddings,
     build_sparse_index,
+    sparse_index_state_sha256,
 )
 from plugins.akasha.infrastructure.sparse_index.schema import (
     INDEX_VERSION,
@@ -3266,11 +3267,17 @@ def test_online_runtime_rebuilds_pair_after_crash_between_sidecar_replaces(
     runtime.close()
     monkeypatch.setattr(os, "replace", real_replace)
     mixed_index_sha = hashlib.sha256(index_path.read_bytes()).hexdigest()
+    mixed_index_state_sha = sparse_index_state_sha256(index_path)
     with closing(sqlite3.connect(memory_path)) as connection:
         stale_memory_sha = connection.execute(
             "SELECT value FROM metadata WHERE key = 'source_index_sha256'"
         ).fetchone()
+        stale_memory_state_sha = connection.execute(
+            "SELECT value FROM metadata "
+            "WHERE key = 'source_index_state_sha256'"
+        ).fetchone()
     assert stale_memory_sha != (mixed_index_sha,)
+    assert stale_memory_state_sha != (mixed_index_state_sha,)
 
     # 3. The next boot detects the mixed pair and deterministically republishes it.
     recovered = OnlineMemoryRuntime(
@@ -3287,7 +3294,14 @@ def test_online_runtime_rebuilds_pair_after_crash_between_sidecar_replaces(
         recovered_memory_sha = connection.execute(
             "SELECT value FROM metadata WHERE key = 'source_index_sha256'"
         ).fetchone()
+        recovered_memory_state_sha = connection.execute(
+            "SELECT value FROM metadata "
+            "WHERE key = 'source_index_state_sha256'"
+        ).fetchone()
     assert recovered_memory_sha == (final_index_sha,)
+    assert recovered_memory_state_sha == (
+        sparse_index_state_sha256(index_path),
+    )
 
 
 def test_online_runtime_reopens_unchanged_sidecars_without_rebuilding(
@@ -3420,6 +3434,34 @@ def test_online_runtime_ignores_excluded_turn_diagnostics_on_restart(
         ).fetchone()
     assert excluded == ("1",)
     assert state_hash is not None
+
+    # 3. 已迁移快照再次遇到排除计数增长，仍只更新诊断元数据。
+    _append_turn(
+        sessions_path,
+        sequence=0,
+        user="scheduler request",
+        assistant="scheduler reply",
+        started=started + timedelta(minutes=2),
+        session_key="scheduler:job-1",
+        with_embeddings=True,
+    )
+    modern = OnlineMemoryRuntime(
+        sessions_path=sessions_path,
+        index_path=index_path,
+        memory_path=memory_path,
+        embedding_model="embedding-model",
+        embedding_dimension=2,
+        config=MemoryConfig(),
+    )
+    try:
+        assert modern.cycle.state_version == 1
+    finally:
+        modern.close()
+    with closing(sqlite3.connect(index_path)) as connection:
+        modern_excluded = connection.execute(
+            "SELECT value FROM metadata WHERE key='turns_excluded_memory'"
+        ).fetchone()
+    assert modern_excluded == ("2",)
 
 
 def test_online_runtime_replays_an_appended_suffix_without_rebuilding(


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Akasha 启动时把 SQLite 物理文件哈希当成索引身份；no-memory/programmatic Turn 只更新排除计数也会触发 5423 Turn 全量重建。
- 用户可见结果：只增加排除诊断计数时复用既有 MemoryCycle；旧快照首次启动只原子升级身份元数据，不重放历史 Turn。
- 本 PR 不处理：Akasha 算法、召回排序、SessionDB 或排除策略本身。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：Akasha sparse index 与 memory snapshot 配对恢复
- `runtime_patch`：`required`
- `runtime_patch_reason`：线上启动出现 854.703 秒误重建
- `authoritative_state_owner`：SessionDB；两个 SQLite sidecar 均为可重建派生状态
- `client_only_alternative`：`not_applicable`
- 关联不变量：index→memory 顺序发布；混合代 sidecar 必须 fail-loud 并重建
- `protected_state`：sessions.db/messages、既有 MemoryCycle 学习状态、plugin-data
- 允许的副作用：旧 memory snapshot 首次启动原子重写一次，新增逻辑索引身份 metadata
- 禁止的副作用：修改/删除 SessionDB 消息；忽略真实索引内容变化；静默接受混合代 sidecar

## 改动范围

- 主要文件：Akasha sparse-index identity、snapshot persistence/runtime 与回归测试
- 配置或迁移影响：无配置变化；旧 snapshot 在字节身份仍匹配启动前 index 时升级为逻辑身份
- 已知 schema lineage 与最终 schema identity：memory metadata 新增 `source_index_state_sha256`；SQLite schema 不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `e934bd2c`，candidate `45915fa4`
- 回滚方式：回退本 PR；部署前 recovery point 保留旧 sidecar 组合

## 验证

- [x] 相关 targeted tests 已通过：`tests/test_akasha_plugin.py` 55 passed。
- [x] Python 类型检查已通过：pyright 0 errors（既有 warnings）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行，24 scenarios passed，残留资源为空。
- `sourceDigest`：`146730b7d42f725a666f4082dd81616bbe74945b62daaa87f991e268568fe616`
- `planDigest`：`5575e1065ee7d81db891f17683941d5c7b5ac43a2724ce7370250255e5711cbb`
- 真实设备证据：不适用；这是服务端派生状态恢复修复。
- 未运行项与原因：未跑 E1～E4；其为部署准入，不是该局部修复合并阻断。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期产品语义变化。
- [x] MOB-001 不适用。
- [x] 当前没有对应 NOW 事项。