### PR TITLE
fix(plugins): restage trusted exact artifacts

### DIFF
--- a/agent/plugins/install.py
+++ b/agent/plugins/install.py
@@ -9,6 +9,7 @@ import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from uuid import uuid4
 
 from agent.plugins.artifacts import (
     ArtifactPointer,
@@ -16,6 +17,7 @@ from agent.plugins.artifacts import (
     pointer_state_path,
     read_pointers,
     relative_artifact_pointer,
+    resolve_pointer,
     write_pointers,
 )
 from agent.plugins.manifest import (
@@ -53,6 +55,7 @@ class _CacheActivation:
     previous_pointers: ArtifactPointers | None
     created_artifact: bool
     created_data_dir: bool
+    superseded_artifact: Path | None
 
     def rollback(self) -> None:
         """撤销已发布 cache，并恢复发布前的可运行版本。"""
@@ -64,13 +67,15 @@ class _CacheActivation:
         target_root = self.result.installed_path
         if self.created_artifact and (target_root.exists() or target_root.is_symlink()):
             _remove_path(target_root)
-
         # 3. 安装未提交时不留下本事务新建的正式 plugin-data 空目录。
         if self.created_data_dir:
             _remove_created_data_dir(self.result.data_path)
 
     def finalize(self) -> None:
-        """Immutable artifacts require no destructive post-commit cleanup."""
+        """提交完成后删除离线刷新所替代的旧 artifact。"""
+
+        if self.superseded_artifact is not None:
+            _remove_path(self.superseded_artifact)
 
 
 def aka_plugins_root() -> Path:
@@ -154,6 +159,7 @@ def install_git_plugin(
     sparse_paths: list[str] | None = None,
     plugins_home: Path | None = None,
     stage_candidate: bool = False,
+    refresh_existing_artifact: bool = False,
 ) -> PluginInstallResult:
     home = (plugins_home or aka_plugins_root()).resolve(strict=False)
     _ = _validate_path_segment(marketplace, "marketplace")
@@ -210,6 +216,7 @@ def install_git_plugin(
             workspace=workspace,
             source_revision=source_revision,
             stage_candidate=stage_candidate,
+            refresh_existing_artifact=refresh_existing_artifact,
         )
         plugin_id = f"{plugin_name}@{marketplace}"
         try:
@@ -300,6 +307,7 @@ def _activate_plugin_version(
     workspace: Path,
     source_revision: str,
     stage_candidate: bool,
+    refresh_existing_artifact: bool,
 ) -> _CacheActivation:
     """Prepare one immutable artifact and publish it as latest."""
 
@@ -330,7 +338,17 @@ def _activate_plugin_version(
     artifacts_root = plugin_base / ".artifacts"
     _ensure_directory(artifacts_root)
     artifact_id = f"{plugin_version}-{source_revision[:16]}"
-    target_root = artifacts_root / artifact_id
+    base_target_root = artifacts_root / artifact_id
+    superseded_artifact = (
+        resolve_pointer(plugin_base, stable)
+        if refresh_existing_artifact and stable.path is not None
+        else None
+    )
+    target_root = (
+        artifacts_root / f"{artifact_id}-restaged-{uuid4().hex[:16]}"
+        if refresh_existing_artifact and base_target_root.exists()
+        else base_target_root
+    )
     if target_root.is_symlink():
         raise ValueError(f"插件 artifact 目标不能是符号链接: {target_root}")
     if target_root.exists() and not target_root.is_dir():
@@ -346,7 +364,7 @@ def _activate_plugin_version(
         _ = shutil.copytree(clone_root, staging_root, dirs_exist_ok=True)
         _prepare_static_python_runtimes(staging_root, static_manifest)
 
-        # 3. Artifact 只创建一次；一次原子写发布完整 stable/latest pair。
+        # 3. 先落完整 artifact，再原子切换 stable/latest 指针对。
         if target_root.exists():
             generated_runtime_roots = tuple(
                 target_root / Path(runtime.requirements).parent / ".venv"
@@ -397,6 +415,7 @@ def _activate_plugin_version(
         previous_pointers=previous_pointers,
         created_artifact=created_artifact,
         created_data_dir=created_data_dir,
+        superseded_artifact=superseded_artifact,
     )
 
 

--- a/agent/plugins/trusted_install.py
+++ b/agent/plugins/trusted_install.py
@@ -104,6 +104,7 @@ def install_trusted_plugin_batch(
                 sparse_paths=list(source.sparse),
                 plugins_home=plugins_home,
                 stage_candidate=False,
+                refresh_existing_artifact=True,
             )
         except (OSError, RuntimeError, ValueError) as exc:
             completed = [str(item["pluginId"]) for item in installed]

--- a/tests/test_plugin_trusted_install.py
+++ b/tests/test_plugin_trusted_install.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 import main
+import agent.plugins.install as plugin_install_module
 from agent.supervisor import _SupervisorLock
 from agent.plugins.artifacts import read_pointers
 from agent.plugins.trusted_install import (
@@ -68,6 +70,117 @@ def test_trusted_batch_installs_exact_v3_plugins_as_stable(tmp_path: Path) -> No
         assert pointers is not None
         assert pointers.stable == pointers.latest
         assert str(item["sourceRevision"])[:16] in str(item["installedPath"])
+
+
+def test_trusted_batch_restages_an_existing_exact_artifact(
+    tmp_path: Path,
+) -> None:
+    repository = _create_plugin_repository(
+        tmp_path / "calendar",
+        "calendar",
+        python_runtime=True,
+    )
+    revision = _git_output(repository, "rev-parse", "HEAD")
+    batch_path = tmp_path / "trusted.json"
+    batch_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "plugins": [
+                    {
+                        "source": str(repository),
+                        "marketplace": "lab",
+                        "ref": revision,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    home = tmp_path / "plugins-home"
+    first = install_trusted_plugin_batch(
+        workspace=tmp_path / "workspace",
+        batch_path=batch_path,
+        plugins_home=home,
+    )
+    artifact = Path(first["plugins"][0]["installedPath"])  # type: ignore[index]
+    runtime = artifact / "mcp/.venv"
+    assert runtime.is_dir()
+    shutil.rmtree(runtime)
+
+    second = install_trusted_plugin_batch(
+        workspace=tmp_path / "workspace",
+        batch_path=batch_path,
+        plugins_home=home,
+    )
+
+    refreshed = Path(second["plugins"][0]["installedPath"])  # type: ignore[index]
+    assert refreshed != artifact
+    assert not artifact.exists()
+    assert (refreshed / "mcp/.venv/bin/python").is_file()
+
+
+def test_trusted_batch_keeps_old_artifact_when_pointer_commit_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _create_plugin_repository(
+        tmp_path / "calendar",
+        "calendar",
+        python_runtime=True,
+    )
+    revision = _git_output(repository, "rev-parse", "HEAD")
+    batch_path = tmp_path / "trusted.json"
+    batch_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "plugins": [
+                    {
+                        "source": str(repository),
+                        "marketplace": "lab",
+                        "ref": revision,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    home = tmp_path / "plugins-home"
+    first = install_trusted_plugin_batch(
+        workspace=tmp_path / "workspace",
+        batch_path=batch_path,
+        plugins_home=home,
+    )
+    artifact = Path(first["plugins"][0]["installedPath"])  # type: ignore[index]
+    plugin_base = home / "cache/lab/calendar"
+    previous_pointers = read_pointers(plugin_base)
+    real_write_pointers = plugin_install_module.write_pointers
+    calls = 0
+
+    def fail_first_pointer_commit(*args: object, **kwargs: object) -> Path:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("simulated pointer commit failure")
+        return real_write_pointers(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        plugin_install_module,
+        "write_pointers",
+        fail_first_pointer_commit,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated pointer commit failure"):
+        install_trusted_plugin_batch(
+            workspace=tmp_path / "workspace",
+            batch_path=batch_path,
+            plugins_home=home,
+        )
+
+    assert artifact.is_dir()
+    assert read_pointers(plugin_base) == previous_pointers
+    assert list((plugin_base / ".artifacts").iterdir()) == [artifact]
 
 
 @pytest.mark.parametrize(
@@ -356,18 +469,28 @@ def _create_plugin_repository(
     name: str,
     *,
     api_version: int = 3,
+    python_runtime: bool = False,
 ) -> Path:
     path.mkdir(parents=True)
     (path / "plugin.py").write_text(
         f"api_version = {api_version}\nname = {name!r}\nversion = '1.0.0'\n",
         encoding="utf-8",
     )
+    python_declaration = ""
+    if python_runtime:
+        (path / "mcp").mkdir()
+        (path / "mcp/requirements.txt").write_text("", encoding="utf-8")
+        python_declaration = (
+            "\n[[python]]\n"
+            "requirements = 'mcp/requirements.txt'\n"
+        )
     (path / "akashic.plugin.toml").write_text(
         "schema_version = 1\n"
         f"name = {name!r}\n"
         "version = '1.0.0'\n"
         f"api_version = {api_version}\n"
-        "entrypoint = 'plugin.py'\n",
+        "entrypoint = 'plugin.py'\n"
+        + python_declaration,
         encoding="utf-8",
     )
     for args in (


### PR DESCRIPTION
## Summary

- restage an existing exact artifact into a new immutable directory during physically offline trusted publication
- atomically switch stable/latest only after the new artifact and generated runtimes are complete
- retain the prior artifact through pointer and manifest commit; rollback restores old pointers

## Live finding

The first hua-home trusted batch reused an exact Calendar artifact created before Python runtime staging existed. Its code SHA matched, but `mcp/.venv/bin/python` was absent, so Core correctly refused startup. The batch must rebuild generated runtimes instead of treating source identity as runtime readiness.

## Verification

- `pytest -q tests/test_plugin_trusted_install.py tests/test_plugin_install.py` — 31 passed, including pointer commit failure oracle
- focused pyright — 0 errors, 1 existing warning
- Terra high rereview — original crash-window P1 closed; no P0/P1
- Change Gate exact head `b9d0789d383effc1cb87b8e8395032feca773ac3` — passed, 24 public scenarios
  - report: `docker/debug/reports/change-gate/20260822-091524-0c38ab11/gate.json`
  - source digest: `b6e231642b51a127bd5a5e7ea27a3246b562b2099bcef76e219d8c7461eab147`
  - plan digest: `6a9bb8b6b8fa84c180e46f4c6f9d0f8627053f023e252f3e1598600750813f3c`
