### PR TITLE
fix(plugins): 修复 snapshot 入站与主动 Dashboard 换代

### DIFF
--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -26,6 +26,7 @@ from agent.plugin_composition import DashboardContext
 from agent.plugin_composition.model import resolve_declared_workspace_root
 from agent.plugins.composable import ComposablePlugin
 from agent.plugins.generation import PluginGeneration
+from agent.plugins.private_proactive import PrivateFamily
 from agent.plugins.scope import PluginScope
 from agent.plugins.snapshot import (
     RuntimeSnapshot,
@@ -169,7 +170,121 @@ class PluginDashboardHost:
                 _require_routes_available(binding, occupied)
             bindings.append(binding)
             occupied.extend(binding.routes)
+        private_binding = self._prepare_private_proactive_dashboard(
+            snapshot,
+            occupied=occupied,
+        )
+        if private_binding is not None:
+            bindings.append(private_binding)
         snapshot.dashboard_bindings = tuple(bindings)
+
+    def _prepare_private_proactive_dashboard(
+        self,
+        snapshot: RuntimeSnapshot,
+        *,
+        occupied: list[APIRoute],
+    ) -> DashboardBinding | None:
+        """把 exact Default/Wake reader 投影到当前 snapshot。"""
+
+        # 1. 从私有 catalog 确定唯一 family 与 exact primary generation。
+        catalog = snapshot.private_proactive_catalog
+        if catalog is None:
+            return None
+        available_families: tuple[PrivateFamily, ...] = ("default", "wake")
+        families: list[PrivateFamily] = []
+        for family in available_families:
+            if catalog.family(family):
+                families.append(family)
+        if len(families) != 1:
+            raise RuntimeError("private proactive Dashboard family 必须唯一")
+        family = families[0]
+        primary = catalog.family(family)[0]
+        generation = snapshot.generations.get(primary.member)
+        if generation is None or generation.generation_id != primary.generation_id:
+            raise RuntimeError("private proactive Dashboard generation 不匹配")
+        root = snapshot.composition_root
+        if root is None:
+            raise RuntimeError("private proactive Dashboard 缺少 composition Root")
+        runtime = root.plugin_runtime(primary.member)
+        workspace = runtime.workspace.resolve(strict=False)
+        validation = runtime.data_dir.resolve(strict=False) != (
+            generation.data_dir.resolve(strict=False)
+        )
+        if validation:
+            workspace.mkdir(parents=True, exist_ok=True)
+
+        # 2. 复用 generation scope，使 reader 与 snapshot 一起 drain/close。
+        binding_key = (f"private-dashboard:{generation.generation_id}", workspace)
+        binding = self._bindings.get(binding_key)
+        if binding is not None:
+            _require_routes_available(binding, occupied)
+            return binding
+        scope = generation.scope
+        if validation:
+            scope = PluginScope(
+                f"{generation.plugin_id}:private-dashboard-validation"
+            )
+            generation.scope.defer(
+                "private_validation_dashboard",
+                lambda scope=scope: _close_dashboard_scope(scope),
+            )
+        binding = self._build_private_proactive_binding(
+            family,
+            generation=generation,
+            workspace=workspace,
+            scope=scope,
+            validation=validation,
+            occupied=occupied,
+        )
+        self._bindings[binding_key] = binding
+
+        def remove_binding() -> None:
+            _ = self._bindings.pop(binding_key, None)
+
+        scope.defer("private_dashboard", remove_binding)
+        return binding
+
+    def _build_private_proactive_binding(
+        self,
+        family: PrivateFamily,
+        *,
+        generation: PluginGeneration,
+        workspace: Path,
+        scope: PluginScope,
+        validation: bool,
+        occupied: list[APIRoute],
+    ) -> DashboardBinding:
+        """注册一个 Core-private proactive Dashboard binding。"""
+
+        # 1. 调用 family 固定的 Core reader，不解析外部 module/callable。
+        app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+        if family == "wake":
+            from plugins.wake_proactive.dashboard import register_private_dashboard
+        else:
+            from plugins.default_proactive.dashboard import register_private_dashboard
+        registered = register_private_dashboard(app, workspace)
+        for index, closeable in enumerate(_dashboard_closeables(registered)):
+            scope.defer(
+                f"private_dashboard_closeable:{index}",
+                getattr(closeable, "close"),
+            )
+        if app.router.on_startup or app.router.on_shutdown:
+            raise RuntimeError("private proactive dashboard 不支持 startup/shutdown hook")
+
+        # 2. 沿用 Dashboard host 的路由冲突与 snapshot dispatch 合同。
+        routes = _plugin_routes(app.routes)
+        binding = DashboardBinding(
+            plugin_id=f"{family}-proactive",
+            app=app,
+            routes=routes,
+            runtime_workspace=workspace,
+            runtime_data_root=generation.data_dir.resolve(strict=False),
+            validation=validation,
+            module_name=f"core.private_proactive.dashboard.{family}",
+            _scope=scope,
+        )
+        _require_routes_available(binding, occupied)
+        return binding
 
     async def release_validation(self, snapshot: RuntimeSnapshot) -> None:
         """Close candidate-only dashboard resources before formal rebuild."""

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -663,7 +663,7 @@ class PluginManager:
 
         previous_identity = self._channel_catalog_identity(previous)
         candidate_identity = self._channel_catalog_identity(candidate)
-        changed = previous_identity != candidate_identity
+        changed = self._channel_binding_changed(previous, candidate)
         old_runtime = self._active_channel_generation
         if changed and previous_identity is not None:
             if (
@@ -685,6 +685,23 @@ class PluginManager:
                 self._channel_provider_factories(candidate) if changed else {}
             ),
             changed=changed,
+        )
+
+    def _channel_binding_changed(
+        self,
+        previous: RuntimeSnapshot | None,
+        candidate: RuntimeSnapshot,
+    ) -> bool:
+        """判断 exact Channel binding 是否必须随候选 snapshot 换代。"""
+
+        previous_identity = self._channel_catalog_identity(previous)
+        candidate_identity = self._channel_catalog_identity(candidate)
+        return previous_identity != candidate_identity or (
+            candidate_identity is not None
+            and (
+                previous is None
+                or previous.snapshot_id != candidate.snapshot_id
+            )
         )
 
     async def _close_channel_publication(
@@ -2358,9 +2375,9 @@ class PluginManager:
 
         # 1. Snapshots without external participants retain the one-step path.
         endpoints_changed = old_commands != new_commands
-        channel_catalog_changed = (
-            self._channel_catalog_identity(transaction.previous)
-            != self._channel_catalog_identity(transaction.candidate)
+        channel_binding_changed = self._channel_binding_changed(
+            transaction.previous,
+            transaction.candidate,
         )
         previous_activity_identity = self._activity_catalog_identity(
             transaction.previous
@@ -2381,7 +2398,7 @@ class PluginManager:
         )
         if (
             not endpoints_changed
-            and not channel_catalog_changed
+            and not channel_binding_changed
             and not activity_catalog_changed
             and not force_provisional
             and not provisional_started

--- a/docs/decisions/0037-plugin-runtime-is-pure-v3.md
+++ b/docs/decisions/0037-plugin-runtime-is-pure-v3.md
@@ -24,9 +24,9 @@ Core 拥有 artifact、candidate、stable/latest、lease、journal、晋升与�
 2. 每个领域只保留一个 Core owner。Tool、Channel、Command、MCP、managed process、
    Job、UI、Skill、Dashboard 和被动链路均从 committed Root snapshot 读取。最后一个
    v2 consumer 迁走后立即删除对应 legacy owner，不保留 deprecated alias 或空壳。
-3. `default_proactive` 与 `wake_proactive` 可以继续使用 Core-private proactive bridge，直到维护者
-   另行批准迁移。这是一个指定的内建岛，不是外部插件可依赖的兼容 API；
-   外部同名插件不能获得该 bridge。
+3. `default_proactive` 与 `wake_proactive` 可以继续使用 Core-private proactive bridge 及其只读
+   Dashboard reader，直到维护者另行批准迁移。这是一个指定的内建岛，不是外部插件可依赖的
+   兼容 API；外部同名插件不能获得该 bridge 或 reader。
 4. Computer Use Linux 与 Context Pressure 退出已跟踪 fleet。卸载只移除安装清单与
    能力 cache；既有 `plugin-data` 默认保留，不因代码收敛而物理删除。
 5. 代码合并与 hua-home 正式替换分开。只有同一 clean head 上的 static fleet、Mobile、
@@ -45,7 +45,7 @@ Core 拥有 artifact、candidate、stable/latest、lease、journal、晋升与�
 │ typed capability host │ Tool / Channel / Command / MCP / Job / UI / Skill
 └──────────────────────┘
 
-Default/Wake private proactive bridge ──── Core-only、非公开 ABI
+Default/Wake private proactive bridge + Dashboard reader ──── Core-only、非公开 ABI
 ```
 
 ## 理由

--- a/docs/design/plugin-v3-private-proactive-island-task-contract.md
+++ b/docs/design/plugin-v3-private-proactive-island-task-contract.md
@@ -68,6 +68,10 @@ package/member、symlink 和从 external wrapper re-export 上表 callable 全�
 - proactive/wake/drift DB、`PROACTIVE_CONTEXT.md`、`proactive_pending.md` 的既有 owner 与恢复语义；
 - Core proactive kernel 的 tick、presence/busy、turn enqueue、delivery、ack 与 drain owner。
 
+Default/Wake Dashboard 的只读 reader 同属这个私有岛：Dashboard host 把对应内建 family 的路由绑定到 exact
+`RuntimeSnapshot.private_proactive_catalog`，每次请求随 snapshot lease 分派，reader 实现位于 exact Core source root。
+package manifest 只声明面板资源，不提供可执行 backend，也不形成 external plugin 可调用的 Dashboard ABI。
+
 目录名 `proactive_v2` 在第一轮可以保留为私有领域实现标识；它不再代表 public Plugin API。若后续重命名，只能做
 机械 import migration 并单独证明 state/schema/behavior 不变。
 
@@ -134,8 +138,8 @@ install、doctor、manifest/cache discovery 与 runtime admission 都抛明确�
 - stable：fixed clock 下 Default 与 Wake 各跑 normal/empty/skip/failure/cancel/restart，旧 state/schema 行为等价；
 - reload：old in-flight 完成，新 binding 才接新 tick；start failure 恢复旧 exact admission/pointer，或清空 kernel/lease
   并保持 fail-closed，cleanup failure 可查询/retry；
-- host：snapshot private catalog identity、family/order、C15 source projection、exact lease 与 ProactiveLoop adapter 全部
-  可观察；删除旧 lists 后 Default/Wake normal path 仍执行；
+- host：snapshot private catalog identity、family/order、C15 source projection、exact lease、ProactiveLoop adapter 与
+  Dashboard family 路由换代全部可观察；删除旧 lists 后 Default/Wake normal path 仍执行；
 - deletion：C20 的两个私有岛 E3 只证明六个 in-tree module，不授权删除公共 v2 owner。只有其他 external proactive/job
   consumer 全部迁移、最终 full-fleet E3/J 通过且 production/cache/canonical-source zero-consumer scan 为空后，才能证明
   除 private allowlist/host 和保留领域包外，`Plugin`/Manager/Snapshot/bootstrap 无 public v2 proactive/job consumer；

--- a/plugins/default_proactive/dashboard.py
+++ b/plugins/default_proactive/dashboard.py
@@ -9,11 +9,12 @@ from bootstrap.dashboard_api import ProactiveDashboardReader
 from proactive_v2.state import ProactiveStateStore
 
 
-def register(
+def register_private_dashboard(
     app: FastAPI,
-    plugin_dir: Path,
     workspace: Path,
 ) -> ProactiveDashboardReader:
+    """为 exact Default 私有岛注册只读 Dashboard。"""
+
     ProactiveStateStore(workspace / "proactive.db").close()
     reader = ProactiveDashboardReader(workspace / "proactive.db")
 
@@ -23,29 +24,57 @@ def register(
 
     @app.get("/api/dashboard/proactive/deliveries")
     def deliveries(
-        session_key: str = "", sent_from: str = "", sent_to: str = "",
-        page: int = 1, page_size: int = 50,
+        session_key: str = "",
+        sent_from: str = "",
+        sent_to: str = "",
+        page: int = 1,
+        page_size: int = 50,
     ) -> dict[str, Any]:
         items, total = reader.list_deliveries(
-            session_key=session_key, sent_from=sent_from, sent_to=sent_to,
-            page=page, page_size=page_size,
+            session_key=session_key,
+            sent_from=sent_from,
+            sent_to=sent_to,
+            page=page,
+            page_size=page_size,
         )
-        return {"items": items, "total": total, "page": max(1, page), "page_size": max(1, min(page_size, 200))}
+        return {
+            "items": items,
+            "total": total,
+            "page": max(1, page),
+            "page_size": max(1, min(page_size, 200)),
+        }
 
     @app.get("/api/dashboard/proactive/tick_logs")
     def tick_logs(
-        session_key: str = "", terminal_action: str = "", gate_exit: str = "",
+        session_key: str = "",
+        terminal_action: str = "",
+        gate_exit: str = "",
         flow: str = Query(default="", pattern="^(|drift|proactive)$"),
-        started_from: str = "", started_to: str = "", page: int = 1,
-        page_size: int = 50, sort_by: str = "started_at", sort_order: str = "desc",
+        started_from: str = "",
+        started_to: str = "",
+        page: int = 1,
+        page_size: int = 50,
+        sort_by: str = "started_at",
+        sort_order: str = "desc",
     ) -> dict[str, Any]:
         items, total = reader.list_tick_logs(
-            session_key=session_key, terminal_action=terminal_action,
-            gate_exit=gate_exit, flow=flow, started_from=started_from,
-            started_to=started_to, page=page, page_size=page_size,
-            sort_by=sort_by, sort_order=sort_order,
+            session_key=session_key,
+            terminal_action=terminal_action,
+            gate_exit=gate_exit,
+            flow=flow,
+            started_from=started_from,
+            started_to=started_to,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
-        return {"items": items, "total": total, "page": max(1, page), "page_size": max(1, min(page_size, 200))}
+        return {
+            "items": items,
+            "total": total,
+            "page": max(1, page),
+            "page_size": max(1, min(page_size, 200)),
+        }
 
     @app.get("/api/dashboard/proactive/tick_logs/{tick_id}")
     def tick_log(tick_id: str) -> dict[str, Any]:

--- a/plugins/wake_proactive/dashboard.py
+++ b/plugins/wake_proactive/dashboard.py
@@ -73,10 +73,12 @@ class WakeDashboardReader:
             "SELECT * FROM hazard_state ORDER BY updated_at DESC LIMIT 1"
         ).fetchone()
         unread = self._db().execute(
-            "SELECT count(*) FROM reservoir_events WHERE kind = 'content' AND status = 'unread'"
+            "SELECT count(*) FROM reservoir_events "
+            "WHERE kind = 'content' AND status = 'unread'"
         ).fetchone()
         latest_run = self._db().execute(
-            "SELECT terminal_action, now_utc FROM wake_runs ORDER BY now_utc DESC LIMIT 1"
+            "SELECT terminal_action, now_utc FROM wake_runs "
+            "ORDER BY now_utc DESC LIMIT 1"
         ).fetchone()
         if monitor is not None:
             result = dict(monitor)
@@ -116,14 +118,22 @@ class WakeDashboardReader:
     @staticmethod
     def _decode(item: dict[str, Any]) -> dict[str, Any]:
         for key in (
-            "scratchpad_json", "investigations_json", "cited_ids_json",
-            "display_event_map_json", "source_refs_json",
+            "scratchpad_json",
+            "investigations_json",
+            "cited_ids_json",
+            "display_event_map_json",
+            "source_refs_json",
         ):
             item[key.removesuffix("_json")] = json.loads(item.pop(key) or "null")
         return item
 
 
-def register(app: FastAPI, plugin_dir: Path, workspace: Path) -> WakeDashboardReader:
+def register_private_dashboard(
+    app: FastAPI,
+    workspace: Path,
+) -> WakeDashboardReader:
+    """为 exact Wake 私有岛注册只读 Dashboard。"""
+
     WakeStateStore(workspace / "wake_proactive.db").close()
     reader = WakeDashboardReader(workspace / "wake_proactive.db")
 

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -12,12 +12,23 @@ import threading
 import tomllib
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Literal, cast
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient as _RawTestClient
 
 import bootstrap.dashboard_api as dashboard_api
 from agent.plugins.artifacts import ArtifactPointer, write_pointers
+from agent.plugins.dashboard_host import (
+    PluginDashboardHost,
+    SnapshotDashboardMiddleware,
+)
+from agent.plugins.generation_activity_host import ActivityHost
+from agent.plugins.generation_private_proactive_host import PrivateProactiveHost
+from agent.plugins.manager import PluginManager
+from bus.event_bus import EventBus
 from bootstrap.dashboard_api import (
     _dashboard_plugin_dirs,
     create_dashboard_app as _create_dashboard_app,
@@ -1327,6 +1338,126 @@ def test_wake_package_owns_dashboard_visibility(tmp_path, monkeypatch) -> None:
         assert client.get("/api/dashboard/proactive/overview").status_code == 404
         assert client.get("/api/dashboard/wake-proactive/runs").status_code == 404
         assert client.get("/api/dashboard/wake-proactive/meter").status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("family", "members", "endpoint"),
+    (
+        (
+            "default",
+            ("default_proactive", "proactive_flow", "drift_flow"),
+            "/api/dashboard/proactive/overview",
+        ),
+        (
+            "wake",
+            ("wake_proactive", "wake_proactive_flow", "wake_drift_flow"),
+            "/api/dashboard/wake-proactive/runs?page=1&page_size=1",
+        ),
+    ),
+)
+async def test_real_private_proactive_snapshot_serves_dashboard_api(
+    tmp_path: Path,
+    family: Literal["default", "wake"],
+    members: tuple[str, ...],
+    endpoint: str,
+) -> None:
+    """真实 committed 私有 catalog 通过 Dashboard HTTP 边界读取领域数据库。"""
+
+    plugins_root = Path(__file__).parents[1] / "plugins"
+    manager = PluginManager(
+        plugin_dirs=[plugins_root / member for member in members],
+        event_bus=EventBus(),
+        workspace=tmp_path,
+        installed_cache_root=tmp_path / "plugin-home" / "cache",
+    )
+    manager.bind_activity_host(ActivityHost((PrivateProactiveHost(family),)))
+    await manager.load_all()
+    try:
+        app = create_dashboard_app(tmp_path, plugin_manager=manager)
+        with TestClient(app) as client:
+            response = client.get(endpoint)
+            assert response.status_code == 200
+            assert isinstance(response.json(), dict)
+    finally:
+        await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_private_proactive_dashboard_follows_exact_snapshot_switch(
+    tmp_path: Path,
+) -> None:
+    """Default/Wake 路由必须随请求 lease 的 exact snapshot 切换。"""
+
+    # 1. 分别构造两个真实 committed 私有 catalog。
+    plugins_root = Path(__file__).parents[1] / "plugins"
+
+    async def load_family(
+        family: Literal["default", "wake"],
+        members: tuple[str, ...],
+    ) -> PluginManager:
+        manager = PluginManager(
+            plugin_dirs=[plugins_root / member for member in members],
+            event_bus=EventBus(),
+            workspace=tmp_path / family,
+            installed_cache_root=tmp_path / f"plugin-home-{family}" / "cache",
+        )
+        manager.bind_activity_host(ActivityHost((PrivateProactiveHost(family),)))
+        await manager.load_all()
+        return manager
+
+    default_manager = await load_family(
+        "default",
+        ("default_proactive", "proactive_flow", "drift_flow"),
+    )
+    wake_manager = await load_family(
+        "wake",
+        ("wake_proactive", "wake_proactive_flow", "wake_drift_flow"),
+    )
+    default_snapshot = default_manager.current_snapshot
+    wake_snapshot = wake_manager.current_snapshot
+    assert default_snapshot is not None and wake_snapshot is not None
+
+    # 2. 同一 Dashboard host 为两个 snapshot 建立各自 binding。
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    host = PluginDashboardHost(core_routes=tuple(app.routes))
+    host.prepare_initial_snapshot(default_snapshot)
+    host.prepare_snapshot(wake_snapshot)
+
+    class Lease:
+        def __init__(self, snapshot: object) -> None:
+            self.snapshot = snapshot
+            self.active = True
+
+        async def __aenter__(self) -> object:
+            return self.snapshot
+
+        async def __aexit__(self, *_exc_info: object) -> None:
+            self.active = False
+
+    class SwitchingStore:
+        def __init__(self) -> None:
+            self.current = default_snapshot
+
+        async def acquire(self) -> object:
+            return Lease(self.current)
+
+    store = SwitchingStore()
+    app.add_middleware(
+        SnapshotDashboardMiddleware,
+        snapshot_store=cast(Any, store),
+    )
+
+    try:
+        with TestClient(app) as client:
+            assert client.get("/api/dashboard/proactive/overview").status_code == 200
+            assert client.get("/api/dashboard/wake-proactive/runs").status_code == 404
+            store.current = wake_snapshot
+            assert client.get("/api/dashboard/proactive/overview").status_code == 404
+            assert client.get("/api/dashboard/wake-proactive/runs").status_code == 200
+    finally:
+        await default_manager.terminate_all()
+        await wake_manager.terminate_all()
 
 
 def test_dashboard_lists_installed_plugin_panels(tmp_path, monkeypatch) -> None:

--- a/tests/test_plugin_composition_loader.py
+++ b/tests/test_plugin_composition_loader.py
@@ -436,6 +436,70 @@ async def test_v3_channel_registry_redacts_candidate_credentials_before_import(
 
 
 @pytest.mark.asyncio
+async def test_unrelated_snapshot_publication_rebinds_exact_channel_runtime(
+    tmp_path: Path,
+) -> None:
+    """非 Channel 插件晋升后，入站 runtime 必须绑定新的 exact snapshot。"""
+
+    # 1. 启动一个 Channel 与一个不贡献 Channel 的普通插件
+    channel_dir = _write_plugin(
+        tmp_path / "plugins",
+        "channel_probe",
+        _channel_plugin_source("1.0.0"),
+    )
+    (channel_dir / "akashic.plugin.toml").write_text(
+        _channel_static_manifest("1.0.0"),
+        encoding="utf-8",
+    )
+    data_dir = tmp_path / "workspace" / "plugin-data" / "channel_probe-builtin"
+    data_dir.mkdir(parents=True)
+    (data_dir / "config.local.toml").write_text(
+        "app_id = 'app-1'\napp_secret = 'secret'\n",
+        encoding="utf-8",
+    )
+    plain_dir = _write_plugin(
+        tmp_path / "plugins",
+        "plain_probe",
+        "api_version = 3\n"
+        "name = 'plain_probe'\n"
+        "version = '1.0.0'\n"
+        "async def apply(ctx, config): pass\n",
+    )
+    manager = _manager(tmp_path)
+    await manager.load_all()
+    previous = manager.current_snapshot
+    previous_runtime = manager.active_channel_generation
+    assert previous is not None and previous_runtime is not None
+
+    # 2. 只晋升普通插件，Channel catalog identity 保持不变
+    (plain_dir / "plugin.py").write_text(
+        "api_version = 3\n"
+        "name = 'plain_probe'\n"
+        "version = '2.0.0'\n"
+        "async def apply(ctx, config): pass\n",
+        encoding="utf-8",
+    )
+    assert await manager.prepare_candidate("plain_probe") is not None
+    result = await manager.publish_prepared("plain_probe")
+    current = manager.current_snapshot
+    current_runtime = manager.active_channel_generation
+
+    # 3. 新入站只能租用新 snapshot，旧 binding 已完成排空
+    assert result["publication_state"] == "committed"
+    assert current is not None and current is not previous
+    assert current.channel_registry_identity == previous.channel_registry_identity
+    assert current_runtime is not None and current_runtime is not previous_runtime
+    assert current_runtime.snapshot_id == current.snapshot_id
+    assert current_runtime.channel("feishu").admission_open
+    lease = manager.snapshot_store.lease(current_runtime.snapshot_id)
+    await lease.release()
+    with pytest.raises(RuntimeError, match="RuntimeSnapshot 不可(用|租用)"):
+        manager.snapshot_store.lease(previous_runtime.snapshot_id)
+
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_v3_channel_manager_binds_core_attachment_ports(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -1532,6 +1532,85 @@ async def test_web_v3_ingress_persists_unprefixed_identity_for_exact_session(
 
 
 @pytest.mark.asyncio
+async def test_web_ingress_survives_unrelated_plugin_snapshot_promotion(
+    tmp_path: Path,
+) -> None:
+    """普通插件晋升后，Web 入站继续通过新 stable snapshot。"""
+
+    # 1. 先发布普通插件，再接入 Core Web Channel
+    plugin_dir = tmp_path / "plugins" / "plain_probe"
+    plugin_dir.mkdir(parents=True)
+    plugin_source = (
+        "api_version = 3\n"
+        "name = 'plain_probe'\n"
+        "version = {version!r}\n"
+        "async def apply(ctx, config): pass\n"
+    )
+    (plugin_dir / "plugin.py").write_text(
+        plugin_source.format(version="1.0.0"),
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    session_manager = SessionManager(workspace)
+    manager = PluginManager(
+        plugin_dirs=[tmp_path / "plugins"],
+        event_bus=EventBus(),
+        workspace=workspace,
+        session_manager=session_manager,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    bus = MessageBus()
+    channel = WebChatChannel()
+    await channel.start(cast(Any, SimpleNamespace(
+        bus=bus,
+        session_manager=session_manager,
+        event_bus=EventBus(),
+        push_tool=_PushTool(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
+        interrupt_controller=None,
+    )))
+    manager.channel_generation_host.bind_inbound_publisher(
+        bus.publish_channel_inbound
+    )
+    await manager.bind_core_channel_definitions(
+        (build_core_channel_definition(channel),)
+    )
+    previous_runtime = manager.active_channel_generation
+    assert previous_runtime is not None
+
+    try:
+        # 2. 只晋升普通插件，Core Web Channel 声明保持完全相同
+        (plugin_dir / "plugin.py").write_text(
+            plugin_source.format(version="2.0.0"),
+            encoding="utf-8",
+        )
+        assert await manager.prepare_candidate("plain_probe") is not None
+        await manager.publish_prepared("plain_probe")
+        current_runtime = manager.active_channel_generation
+        assert current_runtime is not None
+        assert current_runtime is not previous_runtime
+        assert current_runtime.snapshot_id == manager.current_snapshot.snapshot_id
+
+        # 3. 真实 Web 发送必须进入 MessageBus，不得因旧 snapshot 断开
+        socket = _WebSocket()
+        await channel._send_user_message(
+            cast(Any, socket),
+            "request-after-promotion",
+            {"session_id": "web:after-promotion", "text": "hello", "media": []},
+        )
+        envelope = await bus.consume_inbound()
+        assert isinstance(envelope, InboundEnvelope)
+        assert envelope.snapshot_id == current_runtime.snapshot_id
+        assert envelope.message.content == "hello"
+        await bus.release_channel_inbound(envelope, InboundOwner.LANE)
+    finally:
+        await manager.terminate_all()
+        await bus.aclose()
+        session_manager.close()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("request_id", "session_id", "expected_request_id", "expected_error"),
     [


### PR DESCRIPTION
## 问题与结果

- 解决的问题：无关插件晋升后 Mobile/Web Channel 仍绑定已退役 snapshot，入站 lease 抛出 `RuntimeSnapshot 不可用`；pure-v3 下 Default/Wake 面板仍存在，但对应后端未进入 committed Dashboard publication，Wake API 返回 404。
- 用户可见结果：插件晋升后 Mobile/Web 发送继续进入新 stable snapshot；Default/Wake Dashboard 路由随每次 HTTP request 的 exact snapshot lease 切换，主动历史恢复可见。
- 本 PR 不处理：客户端缓存、重新配对、生产部署；Terra High 提出的非阻断 P2（为 candidate Dashboard 临时目录追加独立故障注入 oracle）。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Mobile/Web Channel ingress；Default/Wake private proactive Dashboard
- `runtime_patch`：`required`
- `runtime_patch_reason`：故障位于服务端 snapshot publication 与 Dashboard binding 生命周期，两个客户端共享同一根因。
- `authoritative_state_owner`：`RuntimeSnapshotStore`、`PluginManager` publication、`PluginDashboardHost`
- `client_only_alternative`：无；客户端重试只会重复命中已退役 snapshot，无法恢复缺失路由。
- 关联不变量：新 admission 只能 lease 当前 exact snapshot；Dashboard backend 只能由 committed private catalog 暴露；旧 binding 在 lease drain 后关闭。
- `protected_state`：sessions/messages、proactive/wake SQLite 正文、plugin-data、正式 workspace
- 允许的副作用：Dashboard reader 对所选 family 的既有 SQLite 做初始化兼容检查与只读查询；测试只写临时 workspace。
- 禁止的副作用：不更新/删除历史消息，不迁移正式 DB，不恢复 public v2 Dashboard ABI，不调用外部服务。

## 改动范围

- 主要文件：`agent/plugins/manager.py`、`agent/plugins/dashboard_host.py`、`plugins/default_proactive/dashboard.py`、`plugins/wake_proactive/dashboard.py` 及对应测试/合同。
- 配置或迁移影响：无配置变化，无数据迁移。
- 已知 schema lineage 与最终 schema identity：沿用现有 `proactive.db` / `wake_proactive.db` schema；最终 identity 不变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：head `11a3a4ae727f5031f2e0d0da22c876eac57e3aad`，base `aec8260ad38f67bdb699fa37beaa96941c8d3a79`；无 provider 调用。
- 回滚方式：revert 单提交 `11a3a4ae`；恢复点分支 `backup/pre-channel-snapshot-dashboard-fix-20260822`。

## 验证

- [x] 相关 targeted tests 已通过：Dashboard/PluginManager/Channel/Web/Mobile/isolated E2E 合并运行 `361 passed in 141.68s`。
- [x] Python 类型检查或前端 typecheck/lint 已通过：修改文件及测试 Pyright 均 `0 errors`；compileall 与 `git diff --check` 通过。前端未改动。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：25 个公开场景全部 passed，残留资源为空。
- `sourceDigest`：`3cc5188c9bd40471aa268cc3976ccd0b6917c0e24d2c1f628f6496fd8aed811f`
- `planDigest`：`70d224fcc72024d7ace9fbf8adc42fd348011a22df32c657f15c3a3f0a84ea9a`
- 真实设备证据：未运行；本次是服务端共享根因，本机真实 HTTP/MessageBus/Mobile protocol 与 isolated E2E 已覆盖，PR 不执行生产部署。
- 未运行项与原因：未运行 Pixel 真机、hua-home 部署及 E1-E4；按合同它们属于部署准入，不是本次局部修复 PR 的代码合并证据。

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，并更新 0037 与 private proactive island 合同。
- [x] 跨仓库或客户端改动已核对能力 owner：无需客户端 patch，改动归 Core。
- [x] 当前没有对应已完成 NOW 事项，不适用。

## 独立复审

Terra High 两轮只读复审：第一轮发现 startup 固定 Dashboard family 的 P1；修正为 request exact snapshot lease dispatch 并补 Default `200→404` / Wake `404→200` oracle 后，第二轮结论为 0 P0、0 P1，建议合并。