### PR TITLE
fix(channels): 透传失败终态错误

### DIFF
--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -965,10 +965,15 @@ class PassiveMessageWorker:
             )
         if result.status is not TurnStatus.FAILED:
             raise ValueError(f"不支持的 terminal 状态: {result.status.value}")
+        content = (
+            result.error.message
+            if result.error is not None
+            else "处理消息时出错，请稍后再试。"
+        )
         return OutboundMessage(
             channel=item.channel,
             chat_id=item.chat_id,
-            content="处理消息时出错，请稍后再试。",
+            content=content,
             control_turn_id=result.interaction_id,
             execution_attempt_id=result.id,
             metadata=metadata,

--- a/docker/debug/programmatic_control_probe.py
+++ b/docker/debug/programmatic_control_probe.py
@@ -402,7 +402,7 @@ def _wait_database_turn_status(
             connection.row_factory = sqlite3.Row
             row = connection.execute(
                 """
-                SELECT id, status, final_response
+                SELECT id, status, final_response, error_json
                 FROM turns
                 WHERE session_key = ? AND json_extract(input_json, '$.input') = ?
                 ORDER BY created_at DESC LIMIT 1
@@ -416,6 +416,11 @@ def _wait_database_turn_status(
                     "id": row["id"],
                     "status": last_status,
                     "finalResponse": row["final_response"],
+                    "error": (
+                        json.loads(row["error_json"])
+                        if row["error_json"]
+                        else None
+                    ),
                 }
         threading.Event().wait(0.02)
     raise GateFailure(
@@ -1833,6 +1838,12 @@ def _inside_failure_matrix(report_dir: Path) -> int:
             failed_state = _wait_database_turn_status(
                 database, lane_thread, "lane failure", {"failed"}
             )
+            failed_error = failed_state.get("error")
+            if (
+                not isinstance(failed_error, dict)
+                or not isinstance(failed_error.get("message"), str)
+            ):
+                raise GateFailure(f"failed turn 缺少 error.message：{failed_state!r}")
 
             _http_json(
                 "PUT",
@@ -1867,6 +1878,7 @@ def _inside_failure_matrix(report_dir: Path) -> int:
                     failed_state["status"],
                     recovered_state["status"],
                 ],
+                "failedError": failed_error["message"],
             }
 
         different_threads = cast(dict[str, object], lane_evidence["differentThreads"])
@@ -1887,7 +1899,7 @@ def _inside_failure_matrix(report_dir: Path) -> int:
                 "order two final",
                 "order three final",
                 "order four final",
-                "处理消息时出错，请稍后再试。",
+                same_thread["failedError"],
                 "recovered",
             ]
             and same_thread["statuses"]

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -21,7 +21,44 @@ test("WebSocket boundary validates every frame family and observable trace lane"
   assert.equal(terminalNullDuration.duration_ms, null);
   assert.throws(() => parseChatFrame({ type: "answer.delta", session_id: "one" }), /缺少字符串字段: turn_id/u);
   assert.throws(() => parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "x", duration_ms: "42ms" }), /duration_ms 格式无效/u);
+  assert.throws(() => parseChatFrame({ type: "message.final", session_id: "one", turn_id: "turn", content: "x", terminal_status: "unknown" }), /terminal_status 格式无效/u);
   assert.throws(() => parseChatFrame({ type: "future.frame" }), /未知消息类型/u);
+});
+
+test("failed terminal exposes provider error and reconciles durable messages", () => {
+  let messages = [];
+  let status = "idle";
+  let activeTurnId = null;
+  let error = "";
+  const loadedMessages = [];
+  const context = {
+    activeSessionId: () => "session",
+    activateSession: () => {},
+    setError: (next) => { error = next; },
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => activeTurnId,
+    setActiveTurnId: (next) => { activeTurnId = next; },
+    loadSessions: async () => {},
+    loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
+  };
+
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", content: "" }), context);
+  applyChatFrame(parseChatFrame({
+    type: "message.final",
+    session_id: "session",
+    turn_id: "turn",
+    content: "Error code: 429 - weekly usage limit reached",
+    terminal_status: "failed",
+  }), context);
+
+  assert.equal(status, "error");
+  assert.equal(activeTurnId, null);
+  assert.equal(error, "Error code: 429 - weekly usage limit reached");
+  assert.equal(messages[0].content, "Error code: 429 - weekly usage limit reached");
+  assert.equal(messages[0].streaming, false);
+  assert.deepEqual(loadedMessages, ["session"]);
 });
 
 test("frame controller preserves thinking, tool, answer, and terminal lifecycle", () => {

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -24,7 +24,7 @@ export type ChatFrame =
     session_message_id?: string;
     control_turn_id?: string;
     execution_attempt_id?: string;
-    terminal_status?: string;
+    terminal_status?: "completed" | "failed" | "interrupted" | "cancelled";
   }
   | { type: "turn.output.completed"; session_id: string; turn_id: string; client_message_id?: string }
   | { type: "turn.interrupted"; request_id: string; session_id: string; status: string; message: string }
@@ -97,6 +97,12 @@ export function parseChatFrame(value: unknown): ChatFrame {
         frame.duration_ms = durationMs;
       }
       if (frame.metadata !== undefined && !recordValue(frame.metadata)) throw new Error("message.final.metadata 格式无效");
+      if (
+        frame.terminal_status !== undefined
+        && !["completed", "failed", "interrupted", "cancelled"].includes(frame.terminal_status as string)
+      ) {
+        throw new Error("message.final.terminal_status 格式无效");
+      }
       break;
     case "turn.output.completed":
       requireStrings(frame, ["session_id", "turn_id"]);
@@ -278,9 +284,15 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     return;
   }
   const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
+  const isRecoveredTerminal = context.getActiveTurnId() === null;
+  const failed = frame.terminal_status === "failed";
   if (isActiveTerminal) {
-    context.setStatus("idle");
+    context.setStatus(failed ? "error" : "idle");
     context.setActiveTurnId(null);
+  }
+  if (failed && (isActiveTerminal || isRecoveredTerminal)) {
+    context.setError(frame.content);
+    context.setStatus("error");
   }
   context.setMessages((messages) => updateAssistantById(messages, frame.turn_id, (message) => ({
     ...message,

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, cast
 
 import pytest
 
+from agent.control.errors import ControlExecutionError
 from agent.control.models import TurnRequest, TurnStatus
 from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
@@ -1082,7 +1083,7 @@ async def test_failed_outbound_carries_authoritative_turn_id_across_threads(
     turns_b = manager.control_store.list_turns(session_b, limit=10)
     assert len(turns_a) == 1 and turns_a[0].status is TurnStatus.FAILED
     assert len(turns_b) == 1 and turns_b[0].status is TurnStatus.COMPLETED
-    failed = next(msg for msg in delivered if msg.content.startswith("处理消息时出错"))
+    failed = next(msg for msg in delivered if msg.content == "model crash")
     echoed = next(msg for msg in delivered if msg.content == "echo:b")
 
     # 1. FAILED 与 COMPLETED 都显式携带各自权威 turn id，A/B 不漂移。
@@ -1090,6 +1091,41 @@ async def test_failed_outbound_carries_authoritative_turn_id_across_threads(
     assert echoed.control_turn_id == turns_b[0].id
     assert turns_a[0].id != turns_b[0].id
     await _cancel_task(worker_task)
+    await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_body_reaches_channel_terminal(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "mobile:provider-failure"
+    manager.save(manager.get_or_create(session_key))
+    provider_error = "Error code: 429 - weekly usage limit reached"
+
+    async def execute(_request: TurnRequest) -> str:
+        raise ControlExecutionError(
+            "provider_rate_limited",
+            provider_error,
+            retryable=True,
+        )
+
+    runtime = ConversationRuntime(manager.control_store, execute)
+    bus, worker = _real_worker(manager, runtime)
+    delivered: list[OutboundMessage] = []
+
+    async def on_outbound(message: OutboundMessage) -> None:
+        delivered.append(message)
+
+    _bind_channel_delivery(worker, on_outbound)
+    await bus.publish_inbound(
+        _mobile_item("provider-failure", "hello", "client:provider-failure")
+    )
+    consumed = await _consume_message(bus)
+    await worker._run_message(consumed)
+
+    assert len(delivered) == 1
+    assert delivered[0].content == provider_error
+    assert delivered[0].terminal_status is TurnTerminalStatus.FAILED
     await runtime.shutdown()
     manager.close()
 
@@ -1250,10 +1286,8 @@ async def test_restart_recovery_redelivers_terminals_and_creates_missing_turn_on
     contents = [msg.content for msg in delivered2]
     assert "echo:done" in contents
     assert "echo:noturn" in contents
-    assert any(content.startswith("处理消息时出错") for content in contents)
-    redelivered_failed = next(
-        msg for msg in delivered2 if msg.content.startswith("处理消息时出错")
-    )
+    assert "boom" in contents
+    redelivered_failed = next(msg for msg in delivered2 if msg.content == "boom")
     assert redelivered_failed.control_turn_id == failed.id
     echoed_done = next(msg for msg in delivered2 if msg.content == "echo:done")
     assert echoed_done.control_turn_id == done.id
@@ -1299,7 +1333,7 @@ async def test_failed_outbound_carries_verified_client_message_id(
         session_key, "client:fcmid"
     )
     assert turn is not None and turn.status is TurnStatus.FAILED
-    failed = next(msg for msg in delivered if msg.content.startswith("处理消息时出错"))
+    failed = next(msg for msg in delivered if msg.content == "boom")
     assert failed.metadata["client_message_id"] == "client:fcmid"
     assert failed.control_turn_id == turn.id
     assert manager.control_store.list_inbound_handoffs() == []
@@ -1350,7 +1384,7 @@ async def test_restart_redelivery_failed_carries_verified_client_message_id(
         session_key, "client:rdfail"
     )
     assert turn is not None and turn.status is TurnStatus.FAILED
-    failed = next(msg for msg in delivered2 if msg.content.startswith("处理消息时出错"))
+    failed = next(msg for msg in delivered2 if msg.content == "boom")
     assert failed.metadata["client_message_id"] == "client:rdfail"
     assert failed.control_turn_id == turn.id
     assert manager2.control_store.list_inbound_handoffs() == []


### PR DESCRIPTION
## 变更

- failed Turn 终态直接投影权威 `TurnError.message`，不再统一覆盖为通用文案
- WebUI 识别 `message.final.terminal_status=failed`，保留错误状态和原始正文
- 失败后仍从持久历史对账，避免用户消息看似消失
- 未携带 `TurnError` 的异常终态继续使用通用兜底

## 验证

- `pytest -q tests/control/test_channel_adapter.py`：28 passed
- `node --test frontend/chat/src/web-chat-transport.test.mjs`：9 passed
- `npm run typecheck`：通过
- `npx eslint frontend/chat/src/web-chat-transport.ts`：通过
- `npm run build:chat`：通过
- Change Gate：通过，报告 `docker/debug/reports/change-gate/20260822-145541-fcddd7d5`

## 边界

本 PR 不修改 provider 重试、持久化 schema、会话数据或部署配置，也不包含生成 bundle。
