### PR TITLE
fix(webui): render fenced code blocks in desktop history

### DIFF
--- a/frontend/chat/src/desktop-conversation.test.mjs
+++ b/frontend/chat/src/desktop-conversation.test.mjs
@@ -32,8 +32,13 @@ test("desktop rich content upgrades near the viewport without hiding fallback te
   assert.match(conversation, /new IntersectionObserver/);
   assert.match(conversation, /rootMargin: "800px 0px"/);
   assert.match(messageView, /<StaticMessageResponse onError=\{onError\}>\{content\}<\/StaticMessageResponse>/);
-  assert.match(messageView, /features\.math \|\| features\.mermaid/);
+  assert.match(messageView, /features\.math \|\| features\.mermaid \|\| features\.code/);
   assert.match(conversation, /enhancementSuspended=\{status !== "idle"\}/);
+});
+
+test("desktop static code fallback remains visually contained", () => {
+  assert.match(styles, /\.static-code-block\s*\{[\s\S]*?border:[^;]+;[\s\S]*?overflow-x:\s*auto;/);
+  assert.match(styles, /\.static-code-block\s*\{[\s\S]*?background:[^;]+;/);
 });
 
 test("desktop reply availability uses one history index", () => {

--- a/frontend/chat/src/message-rendering-policy.test.mjs
+++ b/frontend/chat/src/message-rendering-policy.test.mjs
@@ -24,6 +24,25 @@ test("rich Markdown engines are selected independently", () => {
     detectMessageRenderingFeatures("```mermaid\ngraph TD\nA-->B\n```"),
     { code: false, math: false, mermaid: true },
   );
+  assert.deepEqual(
+    detectMessageRenderingFeatures("~~~python\nprint('tilde fence')\n~~~"),
+    { code: true, math: false, mermaid: false },
+  );
+  assert.deepEqual(
+    detectMessageRenderingFeatures("~~~~mermaid\ngraph TD\nA-->B\n~~~~"),
+    { code: false, math: false, mermaid: true },
+  );
   assert.equal(messageNeedsMarkdown("**重点** 和 [链接](https://example.com)"), true);
   assert.equal(messageNeedsMarkdown("- 第一项\n- 第二项"), true);
+});
+
+test("fenced code detection respects marker type and fence length", () => {
+  assert.deepEqual(
+    detectMessageRenderingFeatures("````mermaid\n~~~\n```\n````"),
+    { code: false, math: false, mermaid: true },
+  );
+  assert.deepEqual(
+    detectMessageRenderingFeatures("    ```ts\n    const value = 1\n    ```"),
+    { code: false, math: false, mermaid: false },
+  );
 });

--- a/frontend/chat/src/message-rendering-policy.ts
+++ b/frontend/chat/src/message-rendering-policy.ts
@@ -4,7 +4,7 @@ export interface MessageRenderingFeatures {
   mermaid: boolean;
 }
 
-const fencedCodePattern = /^\s*```+\s*([^\s`]*)/gm;
+const fencedCodePattern = /^\s{0,3}(`{3,}|~{3,})([^\n]*)$/gm;
 const blockMathPattern = /(^|\n)\s*\$\$[\s\S]*?\$\$\s*(?=\n|$)/m;
 const inlineMathPattern = /(^|[^\\$])\$[^\s$](?:[^$\n]*?[^\s$])?\$(?!\$)/m;
 const markdownSyntaxPattern = /(^|\n)\s{0,3}(?:#{1,6}\s|>|[-+*]\s|\d+[.)]\s|```|~~~|(?:-{3,}|_{3,}|\*{3,})\s*$)|!?(?:\[[^\]]+\]\([^\n)]+\))|`[^`\n]+`|\*\*|__|~~|https?:\/\/|<\/?[a-z][^>]*>/im;
@@ -13,14 +13,21 @@ const markdownSyntaxPattern = /(^|\n)\s{0,3}(?:#{1,6}\s|>|[-+*]\s|\d+[.)]\s|```|
 export function detectMessageRenderingFeatures(markdown: string): MessageRenderingFeatures {
   let code = false;
   let mermaid = false;
-  let insideFence = false;
+  let openFence: { marker: string; length: number } | undefined;
   for (const match of markdown.matchAll(fencedCodePattern)) {
-    if (insideFence) {
-      insideFence = false;
+    const fence = match[1];
+    const marker = fence[0];
+    const info = match[2].trim();
+    if (openFence) {
+      if (marker === openFence.marker && fence.length >= openFence.length && info === "") {
+        openFence = undefined;
+      }
       continue;
     }
-    insideFence = true;
-    if (match[1]?.toLowerCase() === "mermaid") mermaid = true;
+    if (marker === "`" && info.includes("`")) continue;
+    openFence = { marker, length: fence.length };
+    const language = info.split(/\s+/, 1)[0]?.toLowerCase();
+    if (language === "mermaid") mermaid = true;
     else code = true;
   }
   return {

--- a/frontend/chat/src/message-view.tsx
+++ b/frontend/chat/src/message-view.tsx
@@ -67,7 +67,7 @@ const MessageBody = memo(function MessageBody({
   }
   if (deferRichContent) {
     const features = detectMessageRenderingFeatures(content);
-    if (features.math || features.mermaid) {
+    if (features.math || features.mermaid || features.code) {
       return (
         <Suspense fallback={<p className="plain-message-response">{content}</p>}>
           <LazyMessageResponse isAnimating={false}>{content}</LazyMessageResponse>

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -180,6 +180,15 @@ input {
 
 .static-code-block {
   position: relative;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-block: 1em;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 8px;
+  padding: 48px 16px 16px;
+  overflow-x: auto;
+  color: var(--md-sys-color-on-surface);
+  background: var(--md-sys-color-surface-container-low);
 }
 
 .static-code-copy {


### PR DESCRIPTION
## 问题与结果

- 解决的问题：桌面端历史消息启用 `deferRichContent` 后，代码 fence 未进入完整 Markdown 渲染路径，只显示为样式不完整的静态 `<pre>`。
- 用户可见结果：历史消息中的代码恢复语言标签、复制操作和代码高亮；静态 fallback 也具备边框、背景及代码块内部横向滚动。
- 本 PR 不处理：流式渲染策略、移动端原生能力、WebUI 发布流程。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：桌面 Chat 历史消息；共享 Markdown fence 特性检测
- `runtime_patch`：`none`
- `runtime_patch_reason`：纯前端渲染修复
- `authoritative_state_owner`：`not_applicable`
- `client_only_alternative`：仅补静态 CSS 无法恢复语言标签、Shiki 高亮及完整 CodeBlock 行为
- 关联不变量：`WEBUI-001`、`WEBUI-003`
- `protected_state`：无
- 允许的副作用：视口附近的 settled 代码消息按需加载代码渲染插件
- 禁止的副作用：不得改变消息状态、SessionDB、移动桥协议或 WebUI generation

## 改动范围

- 主要文件：
  - `frontend/chat/src/message-view.tsx`
  - `frontend/chat/src/message-rendering-policy.ts`
  - `frontend/chat/src/styles.css`
  - 对应渲染策略与桌面历史回归测试
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不适用
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用
- 回滚方式：revert `a58b7d1d` 与 `6ef0b260`

## 验证

- [x] 相关 targeted tests 已通过。
- [x] 前端 typecheck/lint 已通过。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`70b5439e2e5a665426f5d15318838e72bc0981cb0bdebb0007f929750471f354`
- `planDigest`：`bae6ca4f9b7b53caaffe6c12c25f526b1ff10df1acc3d42944ebf3810bcccca3`
- 真实设备证据：不适用，本次不改变原生能力或移动协议。
- Docker Node 22：
  - `npm ci` 通过
  - `npm run typecheck` 通过
  - `npm run lint`：0 errors，60 个非本次文件 warning
  - `npm run test:mobile-web-state`：127/127 通过
  - `npm run build:chat` 通过
- 浏览器验证：桌面页面无页面级横向溢出，完整代码块与静态 fallback 样式均生效。
- 未运行项与原因：本机为 ARM64；官方 Arch Linux Gate 镜像在 amd64 模拟下因 `pacman` seccomp sandbox 不兼容而在 image build 阶段中止，`checks` 为空且无残留 Docker 资源，需由原生 amd64 CI 完成公开场景。

## 工作手册

- [x] 已核对 `projectneed.md`、相关 WebUI 决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 不改变跨仓库或客户端能力 owner。
- [x] `NOW.md` 中没有对应待办事项。