### PR TITLE
[codex] 修复旧 toolset wiring 启动迁移

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -95,7 +95,7 @@ keyset_manifest = "data/mobile/keys/current.json"
 
 # 可选：控制加载哪些工具集（默认值适合大多数场景）
 # [agent.wiring]
-# toolsets = ["meta_common", "spawn", "schedule"]
+# toolsets = ["meta_common"]
 
 # =============================================================================
 # 必填：至少配置一个频道（Telegram 或 QQ 选其一）

--- a/migrations/yoyo/20260823_01_retire_legacy_toolset_wiring.py
+++ b/migrations/yoyo/20260823_01_retire_legacy_toolset_wiring.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tomllib
+from pathlib import Path
+from uuid import uuid4
+
+import tomlkit
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+__depends__ = {"20260817_01_akasha_sparse_index_v10"}
+__transactional__ = False
+
+_MIGRATION_NAME = "retire-legacy-toolset-wiring"
+_LEGACY_TOOLSETS = ("meta_common", "spawn", "schedule")
+_CURRENT_TOOLSETS = ("meta_common",)
+
+
+class _ConfigSnapshot:
+    """Capture bytes, permissions, and link identity before rewriting config."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        content: bytes,
+        kind: str,
+        mode: int,
+        resolved_target: Path,
+        symlink_target: str | None,
+    ) -> None:
+        self.path = path
+        self.content = content
+        self.kind = kind
+        self.mode = mode
+        self.resolved_target = resolved_target
+        self.symlink_target = symlink_target
+
+
+def _snapshot_config(path: Path) -> _ConfigSnapshot | None:
+    """Read one regular config file without losing a symbolic-link boundary."""
+
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise RuntimeError(f"无法读取配置迁移源元数据: {path}") from exc
+
+    if stat.S_ISLNK(metadata.st_mode):
+        target = os.readlink(path)
+        resolved = path.resolve(strict=False)
+        if not path.is_file() or not resolved.is_file():
+            raise RuntimeError(f"配置迁移源软链接不是可读文件: {path}")
+        return _ConfigSnapshot(
+            path=path,
+            content=path.read_bytes(),
+            kind="symlink",
+            mode=stat.S_IMODE(resolved.stat().st_mode),
+            resolved_target=resolved,
+            symlink_target=target,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"配置迁移源必须是普通文件或软链接: {path}")
+    return _ConfigSnapshot(
+        path=path,
+        content=path.read_bytes(),
+        kind="file",
+        mode=stat.S_IMODE(metadata.st_mode),
+        resolved_target=path,
+        symlink_target=None,
+    )
+
+
+def _sha256(payload: bytes) -> str:
+    """Return the digest used to prove a recoverable config snapshot."""
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist an already-replaced file entry in its parent directory."""
+
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_atomic(path: Path, payload: bytes, mode: int) -> None:
+    """Write one fsynced file through a same-directory atomic replacement."""
+
+    candidate = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        candidate.write_bytes(payload)
+        candidate.chmod(mode)
+        with candidate.open("rb") as stream:
+            os.fsync(stream.fileno())
+        candidate.replace(path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        candidate.unlink(missing_ok=True)
+        raise
+
+
+def _render_config(raw: bytes) -> bytes | None:
+    """Replace only the exact retired default toolset sequence."""
+
+    text = raw.decode("utf-8")
+    # 1. Parse before mutation so malformed config remains a startup error.
+    tomllib.loads(text)
+    document = tomlkit.parse(text)
+    agent = document.get("agent")
+    if not isinstance(agent, dict):
+        return None
+    wiring = agent.get("wiring")
+    if not isinstance(wiring, dict):
+        return None
+    toolsets = wiring.get("toolsets")
+    if not isinstance(toolsets, list) or tuple(toolsets) != _LEGACY_TOOLSETS:
+        return None
+
+    # 2. Preserve every other user-owned field and remove only retired entries.
+    wiring["toolsets"] = list(_CURRENT_TOOLSETS)
+    rendered = tomlkit.dumps(document).encode("utf-8")
+    parsed = tomllib.loads(rendered.decode("utf-8"))
+    final_agent = parsed.get("agent")
+    final_wiring = final_agent.get("wiring") if isinstance(final_agent, dict) else None
+    if (
+        not isinstance(final_wiring, dict)
+        or tuple(final_wiring.get("toolsets", ())) != _CURRENT_TOOLSETS
+    ):
+        raise RuntimeError("配置迁移后 agent.wiring.toolsets 不等于当前默认值")
+    return rendered
+
+
+def _write_backup(snapshot: _ConfigSnapshot, root: Path) -> Path:
+    """Store a verified 0600 source copy and manifest before publication."""
+
+    root.mkdir(parents=True, mode=0o700, exist_ok=False)
+    os.chmod(root, 0o700)
+    backup = root / "config.toml.before"
+    _write_atomic(backup, snapshot.content, 0o600)
+    digest = _sha256(snapshot.content)
+    if _sha256(backup.read_bytes()) != digest:
+        raise RuntimeError(f"配置迁移备份校验失败: {snapshot.path}")
+    manifest = {
+        "schema_version": 1,
+        "migration": _MIGRATION_NAME,
+        "source": {
+            "path": str(snapshot.path),
+            "kind": snapshot.kind,
+            "resolved_target": str(snapshot.resolved_target),
+            "symlink_target": snapshot.symlink_target,
+            "mode": snapshot.mode,
+            "backup": backup.name,
+            "sha256": digest,
+        },
+    }
+    rendered = (
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    _write_atomic(root / "manifest.json", rendered, 0o600)
+    if json.loads((root / "manifest.json").read_text(encoding="utf-8")) != manifest:
+        raise RuntimeError(f"配置迁移备份 manifest 校验失败: {root}")
+    return backup
+
+
+def _publish_config(snapshot: _ConfigSnapshot, rendered: bytes) -> None:
+    """Publish config bytes while preserving an existing symbolic link."""
+
+    _write_atomic(snapshot.resolved_target, rendered, snapshot.mode)
+    if snapshot.kind == "symlink" and (
+        not snapshot.path.is_symlink()
+        or os.readlink(snapshot.path) != snapshot.symlink_target
+    ):
+        raise RuntimeError(f"配置软链接身份发生变化: {snapshot.path}")
+    if snapshot.path.read_bytes() != rendered:
+        raise RuntimeError(f"配置迁移发布校验失败: {snapshot.path}")
+
+
+def _restore_config(snapshot: _ConfigSnapshot, backup: Path) -> None:
+    """Restore the exact pre-migration bytes after a failed publication."""
+
+    payload = backup.read_bytes()
+    if _sha256(payload) != _sha256(snapshot.content):
+        raise RuntimeError(f"配置迁移恢复备份摘要不匹配: {snapshot.path}")
+    _write_atomic(snapshot.resolved_target, payload, snapshot.mode)
+    if snapshot.kind == "symlink" and (
+        not snapshot.path.is_symlink()
+        or os.readlink(snapshot.path) != snapshot.symlink_target
+    ):
+        raise RuntimeError(f"配置软链接恢复身份不匹配: {snapshot.path}")
+    if snapshot.path.read_bytes() != snapshot.content:
+        raise RuntimeError(f"配置迁移恢复校验失败: {snapshot.path}")
+
+
+def retire_legacy_toolset_wiring(_connection: object) -> None:
+    """Migrate the exact pre-plugin toolset default without touching custom config."""
+
+    _ = _connection
+    current = current_migration_context()
+    snapshot = _snapshot_config(current.config_path)
+    if snapshot is None:
+        return
+    rendered = _render_config(snapshot.content)
+    if rendered is None:
+        return
+
+    # 1. Persist a recoverable source snapshot before the only external write.
+    backup_root = current.workspace / "backups" / _MIGRATION_NAME / uuid4().hex
+    backup = _write_backup(snapshot, backup_root)
+
+    # 2. Publish the narrow replacement and restore it if verification fails.
+    try:
+        _publish_config(snapshot, rendered)
+    except BaseException as migration_error:
+        try:
+            _restore_config(snapshot, backup)
+        except BaseException as restore_error:
+            raise RuntimeError(
+                f"toolset wiring migration failed and restore failed: {migration_error}"
+            ) from restore_error
+        raise
+
+
+steps = [step(retire_legacy_toolset_wiring)]

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -81,6 +81,7 @@ def test_init_records_yoyo_origin_in_workspace_ledger(tmp_path: Path) -> None:
         ("20260808_03_remove_compaction_trigger",),
         ("20260808_06_retire_legacy_context_state",),
         ("20260817_01_akasha_sparse_index_v10",),
+        ("20260823_01_retire_legacy_toolset_wiring",),
     ]
     assert not config_path.with_name("config.toml.migration-cursor").exists()
 

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 import json
+import hashlib
 import shutil
 import sqlite3
+import stat
 import tomllib
 from pathlib import Path
 
@@ -30,6 +32,7 @@ _EMBEDDING_REGISTRY_ID = "20260807_02_embedding_model_registry"
 _MODEL_CAPABILITIES_ID = "20260808_01_restore_migrated_reasoning_efforts"
 _OPENCODE_VARIANTS_ID = "20260808_02_correct_opencode_go_variants"
 _AKASHA_V10_ID = "20260817_01_akasha_sparse_index_v10"
+_TOOLSET_WIRING_ID = "20260823_01_retire_legacy_toolset_wiring"
 _CURRENT_IDS = (
     _ORIGIN_ID,
     _AKASHA_V9_ID,
@@ -45,6 +48,7 @@ _CURRENT_IDS = (
     _CONFIG_ID,
     _RETIRE_ID,
     _AKASHA_V10_ID,
+    _TOOLSET_WIRING_ID,
 )
 _CURRENT_LEDGER_IDS = tuple(sorted(_CURRENT_IDS))
 
@@ -304,6 +308,102 @@ def test_staged_catalog_upgrade_preserves_legacy_inputs_until_final_cutover(
         "keep_recent_tokens": 20_000,
     }
     assert not recent.exists()
+
+
+def test_toolset_wiring_migration_retires_only_the_exact_legacy_default(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    root.mkdir()
+    config = root / "config.toml"
+    config.write_text(
+        "# Preserve user formatting and unrelated values.\n"
+        "[agent.wiring]\n"
+        'toolsets = ["meta_common", "spawn", "schedule"]\n'
+        "\n"
+        "[custom]\n"
+        'value = "protected"\n',
+        encoding="utf-8",
+    )
+    config.chmod(0o640)
+
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
+    assert _runner(root, repo_root=legacy_repo).run().migrations == _CURRENT_IDS[:-1]
+    before = config.read_bytes()
+
+    outcome = _runner(root).run()
+
+    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    migrated = tomllib.loads(config.read_text(encoding="utf-8"))
+    assert migrated["agent"]["wiring"]["toolsets"] == ["meta_common"]
+    assert migrated["custom"] == {"value": "protected"}
+    assert stat.S_IMODE(config.stat().st_mode) == 0o640
+    backups = sorted(
+        (root / "workspace/backups/retire-legacy-toolset-wiring").iterdir()
+    )
+    assert len(backups) == 1
+    manifest = json.loads((backups[0] / "manifest.json").read_text(encoding="utf-8"))
+    backup = backups[0] / manifest["source"]["backup"]
+    assert backup.read_bytes() == before
+    assert manifest["source"]["sha256"] == hashlib.sha256(before).hexdigest()
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    assert stat.S_IMODE((backups[0] / "manifest.json").stat().st_mode) == 0o600
+
+    assert _runner(root).run().state == "current"
+    assert len(list(backups[0].parent.iterdir())) == 1
+
+
+@pytest.mark.parametrize(
+    "toolsets",
+    (["meta_common"], ["meta_common", "spawn"], ["schedule"]),
+)
+def test_toolset_wiring_migration_leaves_nonlegacy_values_untouched(
+    tmp_path: Path,
+    toolsets: list[str],
+) -> None:
+    root = tmp_path / "state"
+    root.mkdir()
+    config = root / "config.toml"
+    config.write_text(
+        toml.dumps({"agent": {"wiring": {"toolsets": toolsets}}}),
+        encoding="utf-8",
+    )
+
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
+    _ = _runner(root, repo_root=legacy_repo).run()
+    before = config.read_bytes()
+
+    outcome = _runner(root).run()
+
+    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    assert config.read_bytes() == before
+    assert not (root / "workspace/backups/retire-legacy-toolset-wiring").exists()
+
+
+def test_toolset_wiring_migration_preserves_config_symlink_identity(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    root.mkdir()
+    source = root / "config-source.toml"
+    source.write_text(
+        "[agent.wiring]\n" 'toolsets = ["meta_common", "spawn", "schedule"]\n',
+        encoding="utf-8",
+    )
+    config = root / "config.toml"
+    config.symlink_to(source.name)
+
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
+    _ = _runner(root, repo_root=legacy_repo).run()
+
+    outcome = _runner(root).run()
+
+    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    assert config.is_symlink()
+    assert os.readlink(config) == source.name
+    assert tomllib.loads(source.read_text(encoding="utf-8"))["agent"]["wiring"][
+        "toolsets"
+    ] == ["meta_common"]
 
 
 def test_new_branch_migration_is_applied_even_after_sibling_ran(
@@ -670,6 +770,7 @@ api_key = "secret"
         _CONFIG_ID,
         _RETIRE_ID,
         _AKASHA_V10_ID,
+        _TOOLSET_WIRING_ID,
     )
     assert (
         CredentialStore.for_workspace(root / "workspace").api_key("model_deepseek_main")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：旧版 `[agent.wiring].toolsets = ["meta_common", "spawn", "schedule"]` 会在 #478 后导致正式启动配置校验失败。
- 用户可见结果：仅命中该精确旧值的升级实例会在 Yoyo 阶段原子迁移为 `["meta_common"]`；所有其他显式工具集保持字节不变。
- 本 PR 不处理：proactive_v2、Wake 旧接线、default proactive 或任何 runtime 行为改造。

## Change intent

- `change_type`：`migration`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：已有旧版持久化配置的启动路径
- `runtime_patch`：`none`
- `runtime_patch_reason`：Yoyo 在运行时构建前完成配置修复。
- `authoritative_state_owner`：配置文件；迁移记录由 workspace Yoyo ledger 管理。
- `client_only_alternative`：不适用。
- `concept_gate`：`not_applicable`
- `concept_gate_reason`：不新增概念或执行模型，只淘汰一项精确遗留配置。
- 关联不变量：非精确旧值不得被迁移改写；备份与发布验证失败必须 loud。
- `protected_state`：自定义 toolsets、配置权限和 symlink 身份、Yoyo ledger。
- 允许的副作用：命中旧值时在 workspace 建立私有备份并原子改写配置。
- 禁止的副作用：不改写任何其他配置，也不触及 workspace 的业务状态。

## 改动范围

- 主要文件：`migrations/yoyo/20260823_01_retire_legacy_toolset_wiring.py`、迁移/初始化测试、`config.example.toml`。
- 配置或迁移影响：精确旧数组迁移为当前唯一有效数组；缺失或自定义数组不变。
- 已知 schema lineage 与最终 schema identity：`20260817_01_akasha_sparse_index_v10` -> `20260823_01_retire_legacy_toolset_wiring`。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不适用。
- 回滚方式：revert 本提交；每次命中改写前的原始配置保存在 `workspace/backups/retire-legacy-toolset-wiring/<uuid>/`。

## 验证

- [x] 相关 targeted tests 已通过：`29 passed`。
- [x] Python 类型检查已通过：basedpyright `0 errors`（现有依赖类型告警 46 条）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：`d1721f705c4121fa25eaa0572160f586433e35f59cdadf542bb5c7969e2552b8`
- `planDigest`：`df5f3eee795bdfb2ea4bd8ffebb74e4f89ca1e32a983f8c1d96cdaca804f403f`
- 真实设备证据（设备/API、debug application ID、源码/APK 身份；不适用时说明）：不适用；本 PR 不包含客户端或运行时发布。
- 未运行项与原因：无。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`no`
- 独立 reviewer / model / reasoning：Codex 本地 review；Gate 全量选定场景通过。
- 审查 head：`5f5bad662cc8af22bf50abe3c83cccd8c21352f0`
- 新增概念及其唯一 owner；没有时写 `none`：`none`
- 无关设计轴的变化传播；没有时写 `none`：`none`
- 最短正常/失败/热更新链路：启动 -> Yoyo 读取 TOML -> 仅精确命中时备份、原子发布、校验；发布校验失败则从备份恢复并失败退出。
- legacy/source-specific 残留扫描：仅保留此专用 Yoyo；示例初始化值同步为当前默认。
- must-fix 及处置证据：命中条件、非命中不变、权限、symlink 与备份恢复均有 targeted tests。
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用：无跨仓库或客户端改动。
- [x] 已完成事项已从 `NOW.md` 删除；不适用：当前没有对应事项。