### PR TITLE
[codex] add durable scoped Turn recovery

### DIFF
--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -70,13 +70,21 @@ _ATTEMPT_ORDINAL = "attemptOrdinal"
 _CONTINUED_FROM_TURN_ID = "continuedFromTurnId"
 _PRIOR_INPUT_COUNT = "priorInputCount"
 _INTERACTION_REJECTED = "interactionRejected"
+_FRESH_INTERACTION = "freshInteraction"
+_SUPERSEDES_INTERACTION_ID = "supersedesInteractionId"
 
 
 def _validate_turn_request_metadata(request: TurnRequest) -> None:
     """拒绝调用方伪造由 Control Runtime 独占的 turn metadata。"""
 
-    if _INTERACTION_REJECTED in request.metadata:
-        raise ValueError("turn metadata 的 interactionRejected 为 Runtime 保留字段")
+    reserved = (
+        _INTERACTION_REJECTED,
+        _FRESH_INTERACTION,
+        _SUPERSEDES_INTERACTION_ID,
+    )
+    forged = next((field for field in reserved if field in request.metadata), None)
+    if forged is not None:
+        raise ValueError(f"turn metadata 的 {forged} 为 Runtime 保留字段")
 
 
 def _encoded_turn_bytes(request: TurnRequest) -> int:
@@ -292,6 +300,7 @@ class ConversationRuntime:
         channel_binding_lease: ChannelBindingLease | None = None,
         live_media: tuple[str, ...] = (),
         execution_scope: TurnExecutionScope | None = None,
+        fresh_interaction: bool = False,
     ) -> TurnHandle:
         """拒绝 active thread，并仅把本次进程可用的 media 交给 executor。"""
 
@@ -304,7 +313,8 @@ class ConversationRuntime:
             if request.thread_id in self._active_by_thread:
                 raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
             turn_id = new_turn_id()
-            previous_attempts = self._open_interaction_attempts(request.thread_id)
+            recoverable_attempts = self._open_interaction_attempts(request.thread_id)
+            previous_attempts = [] if fresh_interaction else recoverable_attempts
             prior_inputs = self._attempt_user_inputs(previous_attempts)
             attempt_replay = replay_messages(
                 previous_attempts,
@@ -317,6 +327,20 @@ class ConversationRuntime:
                 previous_attempts=previous_attempts,
                 prior_inputs=prior_inputs,
             )
+            if fresh_interaction:
+                metadata: dict[str, Any] = {
+                    **effective_request.metadata,
+                    _FRESH_INTERACTION: True,
+                }
+                if recoverable_attempts:
+                    metadata[_SUPERSEDES_INTERACTION_ID] = self._interaction_id(
+                        recoverable_attempts[-1]
+                    )
+                effective_request = TurnRequest(
+                    effective_request.thread_id,
+                    effective_request.input,
+                    metadata,
+                )
             request_bytes = _encoded_turn_bytes(effective_request)
             admission_token = self._reserve_admission(request_bytes)
 
@@ -567,6 +591,16 @@ class ConversationRuntime:
         #    中断仍允许下一 attempt 沿显式前驱续接。
         latest_page = self._store.list_turns(thread_id, limit=1)
         if not latest_page or latest_page[0].status is TurnStatus.COMPLETED:
+            return []
+        fresh = latest_page[0].metadata.get(_FRESH_INTERACTION)
+        if fresh is not None and not isinstance(fresh, bool):
+            raise ValueError("freshInteraction 必须是布尔值")
+        superseded = latest_page[0].metadata.get(_SUPERSEDES_INTERACTION_ID)
+        if superseded is not None and (
+            not isinstance(superseded, str) or not superseded
+        ):
+            raise ValueError("supersedesInteractionId 必须是非空字符串")
+        if fresh is True:
             return []
         rejected = latest_page[0].metadata.get(_INTERACTION_REJECTED)
         if rejected is not None and not isinstance(rejected, bool):

--- a/agent/control/scoped_turn.py
+++ b/agent/control/scoped_turn.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Protocol, cast
 
-from agent.control.models import TurnRecord, TurnRequest, TurnResult
+from agent.control.models import TurnRecord, TurnRequest, TurnResult, TurnStatus
 from agent.control.turn_scope import TurnExecutionScope
 
 
@@ -40,6 +40,32 @@ class TurnAcceptedReceipt:
 
     session_id: str
     turn_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableTurnView:
+    """Expose immutable durable Turn state without the SessionStore write surface."""
+
+    session_id: str
+    turn_id: str
+    status: TurnStatus
+    final_response: str | None
+    error_type: str | None
+    error_message: str | None
+    error_retryable: bool | None
+
+    @classmethod
+    def from_record(cls, record: TurnRecord) -> DurableTurnView:
+        error = record.error
+        return cls(
+            session_id=record.thread_id,
+            turn_id=record.id,
+            status=record.status,
+            final_response=record.final_response,
+            error_type=error.type if error is not None else None,
+            error_message=error.message if error is not None else None,
+            error_retryable=error.retryable if error is not None else None,
+        )
 
 
 class ScopedTurnHandle:
@@ -118,7 +144,7 @@ class ScopedTurnPort:
             kwargs: dict[str, object] = {"runtime_snapshot_lease": lease}
             if self._execution_scope is not None:
                 kwargs["execution_scope"] = self._execution_scope
-            pending = start_turn(request, **kwargs)
+            pending = start_turn(request, fresh_interaction=True, **kwargs)
             if not inspect.isawaitable(pending):
                 raise TypeError("scoped Turn runtime start_turn 必须返回 awaitable")
             handle = await cast(Awaitable[RuntimeTurnHandle], pending)

--- a/agent/lifecycle/phases/before_turn.py
+++ b/agent/lifecycle/phases/before_turn.py
@@ -114,6 +114,11 @@ class _BuildBeforeTurnCtxModule:
             return frame
         state = frame.input
         bundle = cast(ContextBundle, frame.slots[_CONTEXT_BUNDLE_SLOT])
+        # Control admission 已拥有该内部字段的类型和 durable identity 不变量。
+        raw_turn_id = cast(
+            str | None,
+            state.msg.metadata.get("_control_execution_turn_id"),
+        )
         frame.slots[_CTX_SLOT] = BeforeTurnCtx(
             session_key=state.session_key,
             channel=state.msg.context_channel,
@@ -124,6 +129,7 @@ class _BuildBeforeTurnCtxModule:
             retrieved_memory_block=bundle.retrieved_memory_block,
             retrieval_trace_raw=bundle.retrieval_trace_raw,
             history_messages=tuple(bundle.history_messages),
+            turn_id=raw_turn_id,
         )
         return frame
 

--- a/agent/lifecycle/types.py
+++ b/agent/lifecycle/types.py
@@ -55,6 +55,7 @@ class BeforeTurnCtx:
     retrieved_memory_block: str
     retrieval_trace_raw: object | None
     history_messages: tuple[Any, ...]
+    turn_id: str | None = field(default=None, kw_only=True)
     # 可写
     skill_names: list[str] = field(default_factory=_empty_str_list)
     abort: bool = False

--- a/agent/plugin_composition/scoped_turns.py
+++ b/agent/plugin_composition/scoped_turns.py
@@ -4,8 +4,14 @@ import inspect
 import secrets
 from collections.abc import Awaitable, Callable, Mapping
 
-from agent.control.models import TurnRequest
-from agent.control.scoped_turn import ScopedTurnHandle, ScopedTurnPort, TurnScopeLease
+from agent.control.models import TurnRecord, TurnRequest
+from agent.control.scoped_turn import (
+    DurableTurnView,
+    ScopedTurnHandle,
+    ScopedTurnPort,
+    TurnAcceptedReceipt,
+    TurnScopeLease,
+)
 from agent.control.turn_scope import TurnExecutionScope
 from agent.plugin_composition.model import ServiceKey
 
@@ -119,6 +125,18 @@ class PluginScopedTurns:
         finally:
             if acquired_here:
                 await owner.release()
+
+    def read(self, accepted: TurnAcceptedReceipt) -> DurableTurnView:
+        """Read one accepted durable Turn through the Core runtime owner."""
+
+        runtime, _ = self._require_formal()
+        read_turn = getattr(runtime, "read_turn", None)
+        if not callable(read_turn):
+            raise RuntimeError("scoped Turn runtime 缺少 read_turn")
+        record = read_turn(accepted.session_id, accepted.turn_id)
+        if not isinstance(record, TurnRecord):
+            raise TypeError("scoped Turn runtime read_turn 必须返回 TurnRecord")
+        return DurableTurnView.from_record(record)
 
     def _require_formal(self) -> tuple[object, Callable[..., object]]:
         if self._runtime is None or self._session_creator is None:

--- a/tests/control/test_scoped_turn.py
+++ b/tests/control/test_scoped_turn.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from agent.control.models import TurnRequest, TurnStatus
+from agent.control.errors import ThreadBusyError, TurnNotFoundError
+from agent.control.models import TurnError, TurnRecord, TurnRequest, TurnStatus
 from agent.control.runtime import ConversationRuntime
-from agent.control.scoped_turn import ScopedTurnPort
+from agent.control.scoped_turn import ScopedTurnPort, TurnAcceptedReceipt
 from agent.control.turn_scope import TurnExecutionScope
 from agent.plugin_composition.scoped_turns import PluginScopedTurns
 from session.store import SessionStore
@@ -32,6 +35,16 @@ class _Scope:
         if self._active:
             self._active = False
             self._counter[0] -= 1
+
+
+def _queued_turn(turn_id: str, session_id: str) -> TurnRecord:
+    return TurnRecord(
+        id=turn_id,
+        thread_id=session_id,
+        status=TurnStatus.QUEUED,
+        input=turn_id,
+        created_at=datetime.now(UTC),
+    )
 
 
 @pytest.mark.asyncio
@@ -146,5 +159,207 @@ async def test_plugin_background_turn_acquires_and_releases_exact_scope(
     assert result.status is TurnStatus.COMPLETED
     assert result.final_response == "reply:wake"
     assert leases == [0]
+    await runtime.shutdown()
+    store.close()
+
+
+def test_plugin_scoped_turns_reads_immutable_durable_statuses(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+
+    async def execute(_request: TurnRequest) -> str:
+        return "unused"
+
+    runtime = ConversationRuntime(store, execute)
+    service = PluginScopedTurns(runtime, store.create_session)
+    session_id = "programmatic:read"
+    expected = {
+        "queued": TurnStatus.QUEUED,
+        "active": TurnStatus.IN_PROGRESS,
+        "completed": TurnStatus.COMPLETED,
+        "failed": TurnStatus.FAILED,
+        "cancelled": TurnStatus.CANCELLED,
+        "interrupted": TurnStatus.INTERRUPTED,
+    }
+    for suffix, status in expected.items():
+        turn_id = f"turn:{suffix}"
+        store.create_turn(_queued_turn(turn_id, session_id))
+        if status is TurnStatus.QUEUED:
+            continue
+        if status is TurnStatus.CANCELLED:
+            store.transition_turn(
+                turn_id,
+                expected_status=TurnStatus.QUEUED,
+                status=status,
+            )
+            continue
+        store.transition_turn(
+            turn_id,
+            expected_status=TurnStatus.QUEUED,
+            status=TurnStatus.IN_PROGRESS,
+        )
+        if status is TurnStatus.IN_PROGRESS:
+            continue
+        store.transition_turn(
+            turn_id,
+            expected_status=TurnStatus.IN_PROGRESS,
+            status=status,
+            error=(
+                TurnError("fixture", "failed", True)
+                if status is TurnStatus.FAILED
+                else None
+            ),
+            final_response="done" if status is TurnStatus.COMPLETED else None,
+        )
+
+    for suffix, status in expected.items():
+        view = service.read(TurnAcceptedReceipt(session_id, f"turn:{suffix}"))
+        assert view.status is status
+        with pytest.raises(FrozenInstanceError):
+            view.status = TurnStatus.CANCELLED  # type: ignore[misc]
+
+    with pytest.raises(TurnNotFoundError):
+        service.read(TurnAcceptedReceipt(session_id, "turn:missing"))
+    with pytest.raises(RuntimeError, match="candidate 验证期"):
+        PluginScopedTurns.candidate_validation().read(
+            TurnAcceptedReceipt(session_id, "turn:queued")
+        )
+    store.close()
+
+
+def test_scoped_read_observes_restart_recovery_terminals(tmp_path: Path) -> None:
+    path = tmp_path / "sessions.db"
+    store = SessionStore(path)
+    session_id = "programmatic:restart"
+    store.create_turn(_queued_turn("turn:queued-restart", session_id))
+    store.create_turn(_queued_turn("turn:active-restart", session_id))
+    store.transition_turn(
+        "turn:active-restart",
+        expected_status=TurnStatus.QUEUED,
+        status=TurnStatus.IN_PROGRESS,
+    )
+    store.close()
+
+    reopened = SessionStore(path)
+
+    async def execute(_request: TurnRequest) -> str:
+        return "unused"
+
+    runtime = ConversationRuntime(reopened, execute)
+    service = PluginScopedTurns(runtime, reopened.create_session)
+    assert service.read(
+        TurnAcceptedReceipt(session_id, "turn:queued-restart")
+    ).status is TurnStatus.CANCELLED
+    assert service.read(
+        TurnAcceptedReceipt(session_id, "turn:active-restart")
+    ).status is TurnStatus.INTERRUPTED
+    reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_scoped_fresh_turn_supersedes_failed_interaction_across_restart(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    session_id = "programmatic:fresh"
+
+    async def fail(_request: TurnRequest) -> str:
+        raise RuntimeError("first failed")
+
+    runtime = ConversationRuntime(store, fail)
+    first = await runtime.start_turn(TurnRequest(session_id, "old"))
+    assert (await first.result()).status is TurnStatus.FAILED
+    first_record = runtime.read_turn(session_id, first.id)
+    await runtime.shutdown()
+
+    observed_fresh: list[TurnRequest] = []
+
+    async def fail_fresh(request: TurnRequest) -> str:
+        observed_fresh.append(request)
+        raise RuntimeError("fresh failed")
+
+    runtime = ConversationRuntime(store, fail_fresh)
+    owner = _Scope([0])
+    fresh = await ScopedTurnPort(runtime, owner).start(
+        TurnRequest(session_id, "new")
+    )
+    assert (await fresh.result()).status is TurnStatus.FAILED
+    fresh_record = runtime.read_turn(session_id, fresh.id)
+    assert fresh_record.metadata["interactionId"] == fresh.id
+    assert fresh_record.metadata["attemptOrdinal"] == 0
+    assert fresh_record.metadata["supersedesInteractionId"] == first_record.id
+    assert "continuedFromTurnId" not in fresh_record.metadata
+    assert observed_fresh[0].metadata["priorInputCount"] == 0
+    await owner.release()
+    await runtime.shutdown()
+
+    observed_after_restart: list[TurnRequest] = []
+
+    async def complete(request: TurnRequest) -> str:
+        observed_after_restart.append(request)
+        return "ok"
+
+    runtime = ConversationRuntime(store, complete)
+    next_turn = await runtime.start_turn(TurnRequest(session_id, "after"))
+    assert (await next_turn.result()).status is TurnStatus.COMPLETED
+    assert observed_after_restart[0].metadata["attemptOrdinal"] == 0
+    assert observed_after_restart[0].metadata["priorInputCount"] == 0
+    assert "continuedFromTurnId" not in observed_after_restart[0].metadata
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_passive_failed_attempt_still_continues_normally(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    session_id = "channel:passive"
+    calls = 0
+    observed: list[TurnRequest] = []
+
+    async def execute(request: TurnRequest) -> str:
+        nonlocal calls
+        calls += 1
+        observed.append(request)
+        if calls == 1:
+            raise RuntimeError("retry")
+        return "ok"
+
+    runtime = ConversationRuntime(store, execute)
+    first = await runtime.start_turn(TurnRequest(session_id, "one"))
+    assert (await first.result()).status is TurnStatus.FAILED
+    second = await runtime.start_turn(TurnRequest(session_id, "two"))
+    assert (await second.result()).status is TurnStatus.COMPLETED
+
+    assert observed[1].metadata["interactionId"] == first.id
+    assert observed[1].metadata["attemptOrdinal"] == 1
+    assert observed[1].metadata["continuedFromTurnId"] == first.id
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_fixed_session_accepts_at_most_one_concurrent_scoped_turn(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(_request: TurnRequest) -> str:
+        started.set()
+        await release.wait()
+        return "ok"
+
+    runtime = ConversationRuntime(store, execute)
+    owner = _Scope([0])
+    port = ScopedTurnPort(runtime, owner)
+    first = await port.start(TurnRequest("programmatic:fixed", "first"))
+    await started.wait()
+    with pytest.raises(ThreadBusyError):
+        await port.start(TurnRequest("programmatic:fixed", "second"))
+    assert len(store.list_turns("programmatic:fixed")) == 1
+
+    release.set()
+    assert (await first.result()).status is TurnStatus.COMPLETED
+    await owner.release()
     await runtime.shutdown()
     store.close()

--- a/tests/test_lifecycle_phase.py
+++ b/tests/test_lifecycle_phase.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from datetime import datetime
 from unittest.mock import AsyncMock
@@ -214,6 +215,29 @@ def _before_turn_ctx(**kwargs: object) -> BeforeTurnCtx:
         session_key="k", channel="c", chat_id="ch", content="hello",
         timestamp=_now, retrieved_memory_block="", retrieval_trace_raw=None,
         history_messages=(),
+    )
+
+
+def test_before_turn_ctx_preserves_positional_plugin_constructor_abi() -> None:
+    skills = ["existing-skill"]
+    ctx = BeforeTurnCtx(
+        "k",
+        "c",
+        "ch",
+        "hello",
+        _now,
+        "",
+        None,
+        (),
+        skills,
+        turn_id="turn:durable",
+    )
+
+    assert ctx.skill_names is skills
+    assert ctx.turn_id == "turn:durable"
+    assert (
+        inspect.signature(BeforeTurnCtx).parameters["turn_id"].kind
+        is inspect.Parameter.KEYWORD_ONLY
     )
 
 

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -810,6 +810,49 @@ async def test_before_turn_accepts_plugin_modules():
 
 
 @pytest.mark.asyncio
+async def test_before_turn_projects_durable_execution_turn_id():
+    bus = EventBus()
+    session = _DummySession("programmatic:ctx")
+    session_mgr = SimpleNamespace(get_or_create=lambda key: session)
+    ctx_store = SimpleNamespace(
+        prepare=AsyncMock(
+            return_value=ContextBundle(
+                skill_mentions=[],
+                retrieved_memory_block="",
+                retrieval_trace_raw=None,
+                history_messages=[],
+            )
+        )
+    )
+    phase = Phase(
+        default_before_turn_modules(
+            bus,
+            cast(SessionManager, session_mgr),
+            cast(ContextStore, ctx_store),
+        ),
+        frame_factory=BeforeTurnFrame,
+    )
+    msg = InboundMessage(
+        channel="programmatic",
+        sender="owner",
+        chat_id="ctx",
+        content="hello",
+        timestamp=_now,
+        metadata={"_control_execution_turn_id": "turn:durable"},
+    )
+
+    ctx = await phase.run(
+        TurnState(
+            msg=msg,
+            session_key="programmatic:ctx",
+            dispatch_outbound=False,
+        )
+    )
+
+    assert ctx.turn_id == "turn:durable"
+
+
+@pytest.mark.asyncio
 async def test_before_turn_kvcache_command(tmp_path):
     bus = EventBus()
     session = _DummySession("telegram:123")

--- a/tests/test_plugin_generation_job_host.py
+++ b/tests/test_plugin_generation_job_host.py
@@ -317,7 +317,9 @@ class _ProgrammaticConversationRuntime:
         request: Any,
         *,
         runtime_snapshot_lease: RuntimeSnapshotLease,
+        fresh_interaction: bool,
     ) -> _ProgrammaticTurnHandle:
+        assert fresh_interaction is True
         handle = _ProgrammaticTurnHandle(f"turn:{len(self.requests) + 1}")
         self.requests.append((request, runtime_snapshot_lease, handle))
         return handle
@@ -1198,7 +1200,10 @@ async def test_pre_admission_reset_failure_releases_child_lease(
     monkeypatch,
 ) -> None:
     class RejectingConversation(_ProgrammaticConversationRuntime):
-        async def start_turn(self, request, *, runtime_snapshot_lease):
+        async def start_turn(
+            self, request, *, runtime_snapshot_lease, fresh_interaction
+        ):
+            assert fresh_interaction is True
             raise RuntimeError("rejected before Turn persistence")
 
     conversation = RejectingConversation()
@@ -1336,12 +1341,16 @@ async def test_programmatic_turn_repeated_cancel_finishes_admission_and_receipt(
     release = asyncio.Event()
 
     class BlockingConversation(_ProgrammaticConversationRuntime):
-        async def start_turn(self, request, *, runtime_snapshot_lease):
+        async def start_turn(
+            self, request, *, runtime_snapshot_lease, fresh_interaction
+        ):
+            assert fresh_interaction is True
             started.set()
             await release.wait()
             return await super().start_turn(
                 request,
                 runtime_snapshot_lease=runtime_snapshot_lease,
+                fresh_interaction=fresh_interaction,
             )
 
     conversation = BlockingConversation()
@@ -1399,7 +1408,10 @@ async def test_cancelled_pre_admission_failure_does_not_retry_handler(tmp_path) 
     class RejectingConversation(_ProgrammaticConversationRuntime):
         calls = 0
 
-        async def start_turn(self, request, *, runtime_snapshot_lease):
+        async def start_turn(
+            self, request, *, runtime_snapshot_lease, fresh_interaction
+        ):
+            assert fresh_interaction is True
             self.calls += 1
             started.set()
             await release.wait()


### PR DESCRIPTION
## 问题与结果

- 解决的问题：普通 v3 插件在 scoped Turn 接受后，before lifecycle 看不到 Turn identity，且进程重启后不能按 accepted receipt 读取 durable terminal；程序化新工作还会误续接旧失败 interaction。
- 用户可见结果：Scoped Turn 现在能说明“我是谁、后来怎样、这次是不是独立新工作”，供后续 Content/Wake 恢复使用。
- 本 PR 不处理：不实现 Content/Wake/Drift，不改 delivery，不删除旧 proactive island。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：Scheduler、Subagent、Background Jobs 与后续普通 programmatic Turn plugins
- `runtime_patch`：`required`
- `runtime_patch_reason`：SessionDB 已有 durable Turn 事实，但 scoped plugin 只有活进程 handle；新 proposal 需要 source-neutral independent interaction boundary
- `authoritative_state_owner`：ConversationRuntime / SessionStore 的现有 Turn 聚合
- `client_only_alternative`：`not_applicable`
- `concept_gate`：`required`
- `concept_gate_reason`：扩展 Turn lifecycle/recovery public plugin seam
- 关联不变量：Session messages 只追加；一个 thread 最多一个 active Turn；普通 passive failure continuation 不变
- `protected_state`：既有 Turn/schema、passive continuation、exact Root lease、candidate isolation
- 允许的副作用：Turn metadata append-only edge、scoped lifecycle read
- 禁止的副作用：SessionStore write surface 暴露给插件、Wake/Content/source 特判、新 manager/service

## 改动范围

- 主要文件：`agent/control/runtime.py`、`agent/control/scoped_turn.py`、`agent/plugin_composition/scoped_turns.py`、`agent/lifecycle/**` 与定向测试
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：无 schema 变化；supersession edge 保存于既有 Turn metadata
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `59583f96f37e53603130ddff005aa89d95003c6d`；head `6b5f12f9b3b946c6c68343607b93cf74a9745c17`
- 回滚方式：revert 本 commit；PR-A 与正式 runtime/workspace 不变

## 验证

- [x] 相关 targeted tests 已通过：128 passed
- [x] Python 类型检查已通过：Pyright 0 errors（46 existing warnings）
- [x] `python docker/debug/gate.py run --base 59583f96` 已运行并通过全部选中场景
- `sourceDigest`：`b5c982f58c93006bad710572e25956b52f072b6b13f9b3e2f0f542ac784d1217`
- `planDigest`：`cd90c43dc4c40169e8fbb040a39a7e5ea1a335b89fca2a4d19144810f4b18b00`
- 真实设备证据：不适用
- 未运行项与原因：真 provider E2E 后置到 PR-G

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：Terra / gpt-5.6-terra / xhigh
- 审查 head：`6b5f12f9b3b946c6c68343607b93cf74a9745c17`
- 新增概念及其唯一 owner：`DurableTurnView` 是既有 Turn 的 immutable read projection；fresh/supersession 仍由 Core Turn owner 持久化
- 无关设计轴的变化传播：`none`
- 最短正常/失败/热更新链路：accept receipt→before sees turn_id→live result 或 restart read；fresh scoped Turn 是 single-attempt，切入时 append supersession edge；old Root lease 仍由 handle terminal release
- legacy/source-specific 残留扫描：Core diff 无 Wake/Content/Drift/source 名称
- must-fix 及处置证据：`turn_id` 使用 keyword-only field，保持 lifecycle positional ABI；candidate read fail-loud
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前阶段进度保存在 stacked task contract，不写 `NOW.md`。
