### PR TITLE
feat(content): add durable v3 inbox composition

### DIFF
--- a/plugins/content/__init__.py
+++ b/plugins/content/__init__.py
@@ -1,0 +1,1 @@
+"""Durable Content inbox plugin."""

--- a/plugins/content/akashic.plugin.toml
+++ b/plugins/content/akashic.plugin.toml
@@ -1,0 +1,6 @@
+schema_version = 1
+name = "content"
+version = "3.0.0"
+api_version = 3
+entrypoint = "plugin.py"
+candidate_data_mode = "shared_read"

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -36,6 +36,8 @@ class ContentSourceServices(Protocol):
 class ContentWakeServices(Protocol):
     def snapshot(self, now: datetime) -> Mapping[str, object]: ...
 
+    def selected(self, limit: int = 100) -> tuple[Mapping[str, object], ...]: ...
+
     def selection(
         self, accepted_turn: Mapping[str, object]
     ) -> Mapping[str, object] | None: ...
@@ -99,6 +101,9 @@ class _WakeServices:
 
     def snapshot(self, now: datetime) -> Mapping[str, object]:
         return self._store.snapshot(now)
+
+    def selected(self, limit: int = 100) -> tuple[Mapping[str, object], ...]:
+        return self._store.selected(limit)
 
     def selection(
         self, accepted_turn: Mapping[str, object]

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -36,6 +36,10 @@ class ContentSourceServices(Protocol):
 class ContentWakeServices(Protocol):
     def snapshot(self, now: datetime) -> Mapping[str, object]: ...
 
+    def selection(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None: ...
+
     def select(
         self,
         item_ref: Mapping[str, object],
@@ -95,6 +99,11 @@ class _WakeServices:
 
     def snapshot(self, now: datetime) -> Mapping[str, object]:
         return self._store.snapshot(now)
+
+    def selection(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None:
+        return self._store.selection(accepted_turn)
 
     def select(
         self,

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -142,7 +142,10 @@ async def apply(ctx: Context, config: object) -> None:
     """Publish two narrow views over one generation-scoped Content store."""
 
     _ = config
-    store = ContentStore(ctx.data_root / "content.sqlite3")
+    store = ContentStore(
+        ctx.data_root / "content.sqlite3",
+        data_access=ctx.data_access,
+    )
     store.initialize()
     _ = await ctx.provide(CONTENT_SOURCE, _SourceServices(store))
     _ = await ctx.provide(CONTENT_WAKE, _WakeServices(store))

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Protocol
+
+from agent.plugin_composition import Context, ServiceKey
+from plugins.content.store import ContentStore
+
+api_version = 3
+name = "content"
+version = "3.0.0"
+desc = "Durable source-neutral Content inbox"
+author = "Akashic Core"
+inject = ()
+skill_roots = ()
+drift_skill_roots = ()
+workspace_roots = ()
+workspace_files = ()
+
+
+class BoundContentSource(Protocol):
+    def submit(
+        self, batch_id: str, items: Sequence[Mapping[str, object]]
+    ) -> Mapping[str, object]: ...
+
+    def unsettled(self, limit: int = 100) -> tuple[Mapping[str, object], ...]: ...
+
+    def ack(self, settlement_ref: str) -> Mapping[str, object]: ...
+
+
+class ContentSourceServices(Protocol):
+    def bind(self, source_id: str) -> BoundContentSource: ...
+
+
+class ContentWakeServices(Protocol):
+    def snapshot(self, now: datetime) -> Mapping[str, object]: ...
+
+    def select(
+        self,
+        item_ref: Mapping[str, object],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> Mapping[str, object]: ...
+
+    def transition(
+        self,
+        selection_token: str,
+        action: str,
+        *,
+        not_before: datetime | None = None,
+    ) -> Mapping[str, object]: ...
+
+
+CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
+CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+
+
+class _BoundSource:
+    def __init__(self, store: ContentStore, source_id: str) -> None:
+        self._store = store
+        self._source_id = source_id
+
+    def submit(
+        self, batch_id: str, items: Sequence[Mapping[str, object]]
+    ) -> Mapping[str, object]:
+        return self._store.submit(self._source_id, batch_id, items)
+
+    def unsettled(self, limit: int = 100) -> tuple[Mapping[str, object], ...]:
+        return self._store.unsettled(self._source_id, limit)
+
+    def ack(self, settlement_ref: str) -> Mapping[str, object]:
+        return self._store.ack(self._source_id, settlement_ref)
+
+
+class _SourceServices:
+    def __init__(self, store: ContentStore) -> None:
+        self._store = store
+        self._bound: dict[str, _BoundSource] = {}
+
+    def bind(self, source_id: str) -> BoundContentSource:
+        if not source_id or source_id.strip() != source_id:
+            raise ValueError("Content source_id 必须非空且无首尾空白")
+        if source_id in self._bound:
+            raise RuntimeError(f"Content source_id 已有 owner: {source_id}")
+        bound = _BoundSource(self._store, source_id)
+        self._bound[source_id] = bound
+        return bound
+
+
+class _WakeServices:
+    def __init__(self, store: ContentStore) -> None:
+        self._store = store
+
+    def snapshot(self, now: datetime) -> Mapping[str, object]:
+        return self._store.snapshot(now)
+
+    def select(
+        self,
+        item_ref: Mapping[str, object],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> Mapping[str, object]:
+        return self._store.select(item_ref, snapshot_seq, accepted_turn, now)
+
+    def transition(
+        self,
+        selection_token: str,
+        action: str,
+        *,
+        not_before: datetime | None = None,
+    ) -> Mapping[str, object]:
+        allowed = {
+            "ready_for_delivery",
+            "defer",
+            "await_change",
+            "invalidated",
+            "abandoned",
+            "expired",
+        }
+        if action not in allowed:
+            raise ValueError(f"Content Wake capability 不拥有 transition: {action}")
+        return self._store.transition(
+            selection_token,
+            action,
+            not_before=not_before,
+        )
+
+
+async def apply(ctx: Context, config: object) -> None:
+    """Publish two narrow views over one generation-scoped Content store."""
+
+    _ = config
+    store = ContentStore(ctx.data_root / "content.sqlite3")
+    store.initialize()
+    _ = await ctx.provide(CONTENT_SOURCE, _SourceServices(store))
+    _ = await ctx.provide(CONTENT_WAKE, _WakeServices(store))

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import Protocol
 
-from agent.plugin_composition import Context, ServiceKey
+from agent.plugin_composition import Context, EmitEventKey, ServiceKey
 from plugins.content.store import ContentStore
 
 api_version = 3
@@ -61,17 +61,26 @@ class ContentWakeServices(Protocol):
 
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
 CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+CONTENT_CHANGED = EmitEventKey[None]("content.changed")
 
 
 class _BoundSource:
-    def __init__(self, store: ContentStore, source_id: str) -> None:
+    def __init__(
+        self,
+        store: ContentStore,
+        source_id: str,
+        changed: Callable[[], None],
+    ) -> None:
         self._store = store
         self._source_id = source_id
+        self._changed = changed
 
     def submit(
         self, batch_id: str, items: Sequence[Mapping[str, object]]
     ) -> Mapping[str, object]:
-        return self._store.submit(self._source_id, batch_id, items)
+        receipt = self._store.submit(self._source_id, batch_id, items)
+        self._changed()
+        return receipt
 
     def unsettled(self, limit: int = 100) -> tuple[Mapping[str, object], ...]:
         return self._store.unsettled(self._source_id, limit)
@@ -81,8 +90,9 @@ class _BoundSource:
 
 
 class _SourceServices:
-    def __init__(self, store: ContentStore) -> None:
+    def __init__(self, store: ContentStore, changed: Callable[[], None]) -> None:
         self._store = store
+        self._changed = changed
         self._bound: dict[str, _BoundSource] = {}
 
     def bind(self, source_id: str) -> BoundContentSource:
@@ -90,7 +100,7 @@ class _SourceServices:
             raise ValueError("Content source_id 必须非空且无首尾空白")
         if source_id in self._bound:
             raise RuntimeError(f"Content source_id 已有 owner: {source_id}")
-        bound = _BoundSource(self._store, source_id)
+        bound = _BoundSource(self._store, source_id, self._changed)
         self._bound[source_id] = bound
         return bound
 
@@ -152,5 +162,8 @@ async def apply(ctx: Context, config: object) -> None:
         data_access=ctx.data_access,
     )
     store.initialize()
-    _ = await ctx.provide(CONTENT_SOURCE, _SourceServices(store))
+    _ = await ctx.provide(
+        CONTENT_SOURCE,
+        _SourceServices(store, lambda: ctx.emit(CONTENT_CHANGED, None)),
+    )
     _ = await ctx.provide(CONTENT_WAKE, _WakeServices(store))

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -59,6 +59,9 @@ _TABLE_SQL = {
 _INDEX_SQL = (
     "CREATE INDEX items_wake_idx ON items(status, not_before, snapshot_seq)",
     "CREATE INDEX items_source_ack_idx ON items(source_id, status, snapshot_seq)",
+    "CREATE UNIQUE INDEX items_selected_turn_idx "
+    "ON items(selected_session_id, selected_turn_id) "
+    "WHERE selected_turn_id IS NOT NULL",
 )
 _EXPECTED_COLUMNS: dict[str, tuple[_ColumnIdentity, ...]] = {
     "content_state": (
@@ -96,6 +99,13 @@ _EXPECTED_COLUMNS: dict[str, tuple[_ColumnIdentity, ...]] = {
 _EXPECTED_INDEXES: dict[str, tuple[_IndexIdentity, ...]] = {
     "content_state": (),
     "items": (
+        (
+            "items_selected_turn_idx",
+            1,
+            "c",
+            1,
+            ("selected_session_id", "selected_turn_id"),
+        ),
         ("items_source_ack_idx", 0, "c", 0, ("source_id", "status", "snapshot_seq")),
         ("items_wake_idx", 0, "c", 0, ("status", "not_before", "snapshot_seq")),
         ("sqlite_autoindex_items_1", 1, "u", 0, ("snapshot_seq",)),
@@ -362,6 +372,16 @@ class ContentStore:
                 "items": items,
             }
 
+    def selection(
+        self, accepted_turn: Mapping[str, object]
+    ) -> dict[str, object] | None:
+        """Recover Content's durable selection from one accepted Turn receipt."""
+
+        accepted = _normalize_accepted_turn(accepted_turn)
+        with self._transaction() as connection:
+            row = self._selection_row(connection, accepted)
+            return None if row is None else self._selection_receipt(row)
+
     def select(
         self,
         item_ref: Mapping[str, object],
@@ -376,8 +396,20 @@ class ContentStore:
             raise ValueError("snapshot_seq 必须是非负整数")
         accepted = _normalize_accepted_turn(accepted_turn)
         instant = _aware_utc(now)
-        token = f"content-selection:{secrets.token_hex(16)}"
         with self._transaction() as connection:
+            existing = self._selection_row(connection, accepted)
+            if existing is not None:
+                state = self._state(connection)
+                return {
+                    "selected": False,
+                    "reason": "turn_already_selected",
+                    "selection_token": None,
+                    "accepted_turn": None,
+                    "state_version": int(state["state_version"]),
+                    "wake_needed": bool(state["wake_needed"]),
+                    "earliest_not_before": state["earliest_not_before"],
+                }
+            token = f"content-selection:{secrets.token_hex(16)}"
             cursor = connection.execute(
                 """
                 UPDATE items
@@ -418,6 +450,42 @@ class ContentStore:
                 "wake_needed": bool(state["wake_needed"]),
                 "earliest_not_before": state["earliest_not_before"],
             }
+
+    @staticmethod
+    def _selection_row(
+        connection: sqlite3.Connection, accepted_turn: Mapping[str, str]
+    ) -> sqlite3.Row | None:
+        return connection.execute(
+            """
+            SELECT source_id, item_id, revision, payload_json, snapshot_seq,
+                   status, not_before, requires_ack, item_state_version,
+                   selection_token, selected_session_id, selected_turn_id
+            FROM items
+            WHERE selected_session_id = ? AND selected_turn_id = ?
+            """,
+            (accepted_turn["session_id"], accepted_turn["turn_id"]),
+        ).fetchone()
+
+    @staticmethod
+    def _selection_receipt(row: sqlite3.Row) -> dict[str, object]:
+        return {
+            "selection_token": row["selection_token"],
+            "ref": {
+                "source_id": row["source_id"],
+                "item_id": row["item_id"],
+                "revision": row["revision"],
+                "state_version": int(row["item_state_version"]),
+            },
+            "payload": json.loads(row["payload_json"]),
+            "snapshot_seq": int(row["snapshot_seq"]),
+            "status": row["status"],
+            "not_before": row["not_before"],
+            "requires_ack": bool(row["requires_ack"]),
+            "accepted_turn": {
+                "session_id": row["selected_session_id"],
+                "turn_id": row["selected_turn_id"],
+            },
+        }
 
     def transition(
         self,

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Generator, TypedDict, cast
+from typing import Generator, Literal, TypedDict, cast
 
 _SCHEMA_VERSION = 1
 _IMMEDIATE_NOT_BEFORE = "1970-01-01T00:00:00+00:00"
@@ -175,13 +175,19 @@ class _NormalizedItem(TypedDict):
 class ContentStore:
     """Persist Content revisions and expose source- and Wake-scoped transitions."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        data_access: Literal["read_write", "read_only"] = "read_write",
+    ) -> None:
         self.path = path
+        self.data_access = data_access
 
     def initialize(self) -> None:
         """Create or validate the exact schema and SQLite file integrity."""
 
-        with self._transaction() as connection:
+        with self._transaction(write=self.data_access == "read_write") as connection:
             self._validate_schema(connection)
             result = connection.execute("PRAGMA integrity_check").fetchone()
             if result is None or result[0] != "ok":
@@ -203,7 +209,7 @@ class ContentStore:
         fingerprint = _batch_fingerprint(normalized)
 
         # 2. Reuse an exact durable receipt, or append each previously unseen revision.
-        with self._transaction() as connection:
+        with self._transaction(write=True) as connection:
             previous = self._submission_receipt(connection, source, batch, fingerprint)
             if previous is not None:
                 return previous
@@ -335,7 +341,7 @@ class ContentStore:
         """Return one immutable high-watermark view for a Wake proposal."""
 
         instant = _aware_utc(now)
-        with self._transaction() as connection:
+        with self._transaction(write=False) as connection:
             state = self._state(connection)
             high_watermark = int(state["next_seq"])
             rows = connection.execute(
@@ -378,7 +384,7 @@ class ContentStore:
         """Recover Content's durable selection from one accepted Turn receipt."""
 
         accepted = _normalize_accepted_turn(accepted_turn)
-        with self._transaction() as connection:
+        with self._transaction(write=False) as connection:
             row = self._selection_row(connection, accepted)
             return None if row is None else self._selection_receipt(row)
 
@@ -396,7 +402,7 @@ class ContentStore:
             raise ValueError("snapshot_seq 必须是非负整数")
         accepted = _normalize_accepted_turn(accepted_turn)
         instant = _aware_utc(now)
-        with self._transaction() as connection:
+        with self._transaction(write=True) as connection:
             existing = self._selection_row(connection, accepted)
             if existing is not None:
                 state = self._state(connection)
@@ -521,7 +527,7 @@ class ContentStore:
             else None
         )
 
-        with self._transaction() as connection:
+        with self._transaction(write=True) as connection:
             row = connection.execute(
                 "SELECT status, requires_ack FROM items WHERE selection_token = ?",
                 (token,),
@@ -573,7 +579,7 @@ class ContentStore:
         source = _identity("source_id", source_id)
         if type(limit) is not int or limit <= 0:
             raise ValueError("limit 必须是正整数")
-        with self._transaction() as connection:
+        with self._transaction(write=False) as connection:
             rows = connection.execute(
                 """
                 SELECT source_id, item_id, revision, settlement_ref, payload_json
@@ -602,7 +608,7 @@ class ContentStore:
 
         source = _identity("source_id", source_id)
         settlement = _identity("settlement_ref", settlement_ref)
-        with self._transaction() as connection:
+        with self._transaction(write=True) as connection:
             row = connection.execute(
                 """
                 SELECT status FROM items
@@ -632,26 +638,42 @@ class ContentStore:
     def state_counts(self) -> dict[str, int]:
         """Expose deterministic state counts for tests and runtime inspection."""
 
-        with self._transaction() as connection:
+        with self._transaction(write=False) as connection:
             rows = connection.execute(
                 "SELECT status, COUNT(*) AS count FROM items GROUP BY status"
             ).fetchall()
             return {str(row["status"]): int(row["count"]) for row in rows}
 
     @contextmanager
-    def _transaction(self) -> Generator[sqlite3.Connection]:
-        """Open one serialized SQLite transaction and close it at the boundary."""
+    def _transaction(self, *, write: bool) -> Generator[sqlite3.Connection]:
+        """Open one mode-aware SQLite transaction and close it at the boundary."""
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        connection = sqlite3.connect(self.path)
+        # 1. Reject every candidate write at the store's single transaction boundary.
+        if write and self.data_access == "read_only":
+            raise PermissionError("Content read-only candidate cannot write shared data")
+
+        # 2. Preserve the formal store's serialized transaction and lazy schema setup.
+        if self.data_access == "read_write":
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(self.path)
+        else:
+            database_uri = self.path.resolve(strict=False).as_uri() + "?mode=ro"
+            connection = sqlite3.connect(database_uri, uri=True)
         connection.row_factory = sqlite3.Row
         try:
-            _ = connection.execute("PRAGMA journal_mode = WAL")
-            _ = connection.execute("PRAGMA foreign_keys = ON")
-            _ = connection.execute("BEGIN IMMEDIATE")
-            self._ensure_schema(connection)
+            if self.data_access == "read_write":
+                _ = connection.execute("PRAGMA journal_mode = WAL")
+                _ = connection.execute("PRAGMA foreign_keys = ON")
+                _ = connection.execute("BEGIN IMMEDIATE")
+                self._ensure_schema(connection)
+            else:
+                _ = connection.execute("PRAGMA query_only = ON")
+                _ = connection.execute("BEGIN")
             yield connection
-            connection.commit()
+            if self.data_access == "read_write":
+                connection.commit()
+            else:
+                connection.rollback()
         except BaseException:
             connection.rollback()
             raise
@@ -679,7 +701,12 @@ class ContentStore:
     def _validate_schema(connection: sqlite3.Connection) -> None:
         """Reject every version-one database that is not this exact schema."""
 
-        # 1. Match the complete owned table set and each constraint-bearing DDL.
+        # 1. Exact identity includes the schema version, not only matching tables.
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version != _SCHEMA_VERSION:
+            raise RuntimeError(f"不支持的 Content schema version: {version}")
+
+        # 2. Match the complete owned table set and each constraint-bearing DDL.
         tables = {
             str(row["name"]): str(row["sql"])
             for row in connection.execute(
@@ -696,7 +723,7 @@ class ContentStore:
             if _normalize_sql(tables[table]) != _normalize_sql(expected_sql):
                 raise RuntimeError(f"Content schema mismatch: {table} table SQL")
 
-        # 2. Match storage attributes and every explicit or constraint-owned index.
+        # 3. Match storage attributes and every explicit or constraint-owned index.
         for table, expected_columns in _EXPECTED_COLUMNS.items():
             actual_columns = tuple(
                 (
@@ -715,7 +742,7 @@ class ContentStore:
             if actual_indexes != _EXPECTED_INDEXES[table]:
                 raise RuntimeError(f"Content schema mismatch: {table} indexes")
 
-        # 3. The state table owns one singleton row, never zero or a second row.
+        # 4. The state table owns one singleton row, never zero or a second row.
         state_rows = tuple(
             int(row["singleton"])
             for row in connection.execute("SELECT singleton FROM content_state")

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -388,6 +388,26 @@ class ContentStore:
             row = self._selection_row(connection, accepted)
             return None if row is None else self._selection_receipt(row)
 
+    def selected(self, limit: int = 100) -> tuple[dict[str, object], ...]:
+        """Return selected rows in stable inbox order for external recovery."""
+
+        if type(limit) is not int or limit <= 0:
+            raise ValueError("limit 必须是正整数")
+        with self._transaction(write=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT source_id, item_id, revision, payload_json, snapshot_seq,
+                       status, not_before, requires_ack, item_state_version,
+                       selection_token, selected_session_id, selected_turn_id
+                FROM items
+                WHERE status = 'selected'
+                ORDER BY snapshot_seq
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+            return tuple(self._selection_receipt(row) for row in rows)
+
     def select(
         self,
         item_ref: Mapping[str, object],

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Generator, TypedDict, cast
+
+_SCHEMA_VERSION = 1
+_IMMEDIATE_NOT_BEFORE = "1970-01-01T00:00:00+00:00"
+_ColumnIdentity = tuple[int, str, str, int, str | None, int]
+_IndexIdentity = tuple[str, int, str, int, tuple[str, ...]]
+
+_TABLE_SQL = {
+    "content_state": """
+        CREATE TABLE content_state(
+            singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+            next_seq INTEGER NOT NULL,
+            state_version INTEGER NOT NULL,
+            wake_needed INTEGER NOT NULL CHECK(wake_needed IN (0, 1)),
+            earliest_not_before TEXT
+        )
+    """,
+    "items": """
+        CREATE TABLE items(
+            source_id TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            revision TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            snapshot_seq INTEGER NOT NULL UNIQUE,
+            status TEXT NOT NULL,
+            not_before TEXT NOT NULL,
+            requires_ack INTEGER NOT NULL CHECK(requires_ack IN (0, 1)),
+            item_state_version INTEGER NOT NULL DEFAULT 1,
+            selection_token TEXT UNIQUE,
+            selected_session_id TEXT,
+            selected_turn_id TEXT,
+            settlement_ref TEXT UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY(source_id, item_id, revision)
+        )
+    """,
+    "submissions": """
+        CREATE TABLE submissions(
+            source_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            receipt_json TEXT NOT NULL,
+            submitted_at TEXT NOT NULL,
+            PRIMARY KEY(source_id, batch_id)
+        )
+    """,
+}
+_INDEX_SQL = (
+    "CREATE INDEX items_wake_idx ON items(status, not_before, snapshot_seq)",
+    "CREATE INDEX items_source_ack_idx ON items(source_id, status, snapshot_seq)",
+)
+_EXPECTED_COLUMNS: dict[str, tuple[_ColumnIdentity, ...]] = {
+    "content_state": (
+        (0, "singleton", "INTEGER", 0, None, 1),
+        (1, "next_seq", "INTEGER", 1, None, 0),
+        (2, "state_version", "INTEGER", 1, None, 0),
+        (3, "wake_needed", "INTEGER", 1, None, 0),
+        (4, "earliest_not_before", "TEXT", 0, None, 0),
+    ),
+    "items": (
+        (0, "source_id", "TEXT", 1, None, 1),
+        (1, "item_id", "TEXT", 1, None, 2),
+        (2, "revision", "TEXT", 1, None, 3),
+        (3, "payload_json", "TEXT", 1, None, 0),
+        (4, "snapshot_seq", "INTEGER", 1, None, 0),
+        (5, "status", "TEXT", 1, None, 0),
+        (6, "not_before", "TEXT", 1, None, 0),
+        (7, "requires_ack", "INTEGER", 1, None, 0),
+        (8, "item_state_version", "INTEGER", 1, "1", 0),
+        (9, "selection_token", "TEXT", 0, None, 0),
+        (10, "selected_session_id", "TEXT", 0, None, 0),
+        (11, "selected_turn_id", "TEXT", 0, None, 0),
+        (12, "settlement_ref", "TEXT", 0, None, 0),
+        (13, "created_at", "TEXT", 1, None, 0),
+        (14, "updated_at", "TEXT", 1, None, 0),
+    ),
+    "submissions": (
+        (0, "source_id", "TEXT", 1, None, 1),
+        (1, "batch_id", "TEXT", 1, None, 2),
+        (2, "fingerprint", "TEXT", 1, None, 0),
+        (3, "receipt_json", "TEXT", 1, None, 0),
+        (4, "submitted_at", "TEXT", 1, None, 0),
+    ),
+}
+_EXPECTED_INDEXES: dict[str, tuple[_IndexIdentity, ...]] = {
+    "content_state": (),
+    "items": (
+        ("items_source_ack_idx", 0, "c", 0, ("source_id", "status", "snapshot_seq")),
+        ("items_wake_idx", 0, "c", 0, ("status", "not_before", "snapshot_seq")),
+        ("sqlite_autoindex_items_1", 1, "u", 0, ("snapshot_seq",)),
+        ("sqlite_autoindex_items_2", 1, "u", 0, ("selection_token",)),
+        ("sqlite_autoindex_items_3", 1, "u", 0, ("settlement_ref",)),
+        (
+            "sqlite_autoindex_items_4",
+            1,
+            "pk",
+            0,
+            ("source_id", "item_id", "revision"),
+        ),
+    ),
+    "submissions": (
+        (
+            "sqlite_autoindex_submissions_1",
+            1,
+            "pk",
+            0,
+            ("source_id", "batch_id"),
+        ),
+    ),
+}
+
+
+def _normalize_sql(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _schema_indexes(
+    connection: sqlite3.Connection, table: str
+) -> tuple[_IndexIdentity, ...]:
+    indexes: list[_IndexIdentity] = []
+    for row in connection.execute(f"PRAGMA index_list({table})"):
+        index_name = str(row["name"])
+        columns = tuple(
+            str(column["name"])
+            for column in connection.execute(
+                "SELECT name FROM pragma_index_info(?) ORDER BY seqno",
+                (index_name,),
+            )
+        )
+        indexes.append(
+            (
+                index_name,
+                int(row["unique"]),
+                str(row["origin"]),
+                int(row["partial"]),
+                columns,
+            )
+        )
+    return tuple(sorted(indexes))
+
+
+class ContentIdentityConflict(RuntimeError):
+    """Report reuse of one stable identity with different canonical content."""
+
+
+class _NormalizedItem(TypedDict):
+    item_id: str
+    revision: str
+    payload_json: str
+    not_before: str
+    requires_ack: bool
+
+
+class ContentStore:
+    """Persist Content revisions and expose source- and Wake-scoped transitions."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def initialize(self) -> None:
+        """Create or validate the exact schema and SQLite file integrity."""
+
+        with self._transaction() as connection:
+            self._validate_schema(connection)
+            result = connection.execute("PRAGMA integrity_check").fetchone()
+            if result is None or result[0] != "ok":
+                detail = "missing result" if result is None else str(result[0])
+                raise RuntimeError(f"Content SQLite integrity check failed: {detail}")
+
+    def submit(
+        self,
+        source_id: str,
+        batch_id: str,
+        items: Sequence[Mapping[str, object]],
+    ) -> dict[str, object]:
+        """Commit one idempotent source batch before its cursor may advance."""
+
+        # 1. Freeze and validate the external source batch before opening a transaction.
+        source = _identity("source_id", source_id)
+        batch = _identity("batch_id", batch_id)
+        normalized = tuple(_normalize_item(item) for item in items)
+        fingerprint = _batch_fingerprint(normalized)
+
+        # 2. Reuse an exact durable receipt, or append each previously unseen revision.
+        with self._transaction() as connection:
+            previous = self._submission_receipt(connection, source, batch, fingerprint)
+            if previous is not None:
+                return previous
+            now = _utc_now()
+            inserted, duplicates = self._append_items(
+                connection, source, normalized, now
+            )
+            self._recompute_wake(connection)
+            current = self._state(connection)
+            receipt: dict[str, object] = {
+                "receipt_id": f"content-submit:{source}:{batch}",
+                "source_id": source,
+                "batch_id": batch,
+                "inserted": inserted,
+                "duplicates": duplicates,
+                "high_watermark": int(current["next_seq"]),
+                "state_version": int(current["state_version"]),
+                "wake_needed": bool(current["wake_needed"]),
+            }
+            self._record_submission(
+                connection, source, batch, fingerprint, receipt, now
+            )
+            return receipt
+
+    @staticmethod
+    def _submission_receipt(
+        connection: sqlite3.Connection,
+        source: str,
+        batch: str,
+        fingerprint: str,
+    ) -> dict[str, object] | None:
+        row = connection.execute(
+            """
+            SELECT receipt_json, fingerprint FROM submissions
+            WHERE source_id = ? AND batch_id = ?
+            """,
+            (source, batch),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["fingerprint"] != fingerprint:
+            raise ContentIdentityConflict(
+                f"Content batch identity conflict: {source}/{batch}"
+            )
+        return cast(dict[str, object], json.loads(row["receipt_json"]))
+
+    def _append_items(
+        self,
+        connection: sqlite3.Connection,
+        source: str,
+        items: Sequence[_NormalizedItem],
+        now: str,
+    ) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+        """Append unseen revisions and return inserted and duplicate refs."""
+
+        next_seq = int(self._state(connection)["next_seq"])
+        inserted: list[dict[str, str]] = []
+        duplicates: list[dict[str, str]] = []
+        for item in items:
+            existing = connection.execute(
+                """
+                SELECT payload_json, not_before, requires_ack FROM items
+                WHERE source_id = ? AND item_id = ? AND revision = ?
+                """,
+                (source, item["item_id"], item["revision"]),
+            ).fetchone()
+            item_ref = _item_ref(source, item)
+            if existing is not None:
+                _assert_same_revision(source, item, existing)
+                duplicates.append(item_ref)
+                continue
+            next_seq += 1
+            _ = connection.execute(
+                """
+                INSERT INTO items(
+                    source_id, item_id, revision, payload_json, snapshot_seq,
+                    status, not_before, requires_ack, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
+                """,
+                (
+                    source,
+                    item["item_id"],
+                    item["revision"],
+                    item["payload_json"],
+                    next_seq,
+                    item["not_before"],
+                    int(item["requires_ack"]),
+                    now,
+                    now,
+                ),
+            )
+            inserted.append(item_ref)
+        if inserted:
+            _ = connection.execute(
+                """
+                UPDATE content_state
+                SET next_seq = ?, state_version = state_version + 1
+                WHERE singleton = 1
+                """,
+                (next_seq,),
+            )
+        return inserted, duplicates
+
+    @staticmethod
+    def _record_submission(
+        connection: sqlite3.Connection,
+        source: str,
+        batch: str,
+        fingerprint: str,
+        receipt: Mapping[str, object],
+        now: str,
+    ) -> None:
+        _ = connection.execute(
+            """
+            INSERT INTO submissions(
+                source_id, batch_id, fingerprint, receipt_json, submitted_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                source,
+                batch,
+                fingerprint,
+                json.dumps(receipt, sort_keys=True, separators=(",", ":")),
+                now,
+            ),
+        )
+
+    def snapshot(self, now: datetime) -> dict[str, object]:
+        """Return one immutable high-watermark view for a Wake proposal."""
+
+        instant = _aware_utc(now)
+        with self._transaction() as connection:
+            state = self._state(connection)
+            high_watermark = int(state["next_seq"])
+            rows = connection.execute(
+                """
+                SELECT source_id, item_id, revision, payload_json, snapshot_seq,
+                       status, not_before, item_state_version
+                FROM items
+                WHERE snapshot_seq <= ? AND status IN ('pending', 'deferred')
+                ORDER BY snapshot_seq
+                """,
+                (high_watermark,),
+            ).fetchall()
+            items = tuple(
+                {
+                    "ref": {
+                        "source_id": row["source_id"],
+                        "item_id": row["item_id"],
+                        "revision": row["revision"],
+                        "state_version": int(row["item_state_version"]),
+                    },
+                    "payload": json.loads(row["payload_json"]),
+                    "snapshot_seq": int(row["snapshot_seq"]),
+                    "status": row["status"],
+                    "not_before": row["not_before"],
+                    "due": row["not_before"] <= instant,
+                }
+                for row in rows
+            )
+            return {
+                "snapshot_seq": high_watermark,
+                "state_version": int(state["state_version"]),
+                "wake_needed": bool(state["wake_needed"]),
+                "earliest_not_before": state["earliest_not_before"],
+                "items": items,
+            }
+
+    def select(
+        self,
+        item_ref: Mapping[str, object],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> dict[str, object]:
+        """CAS one frozen eligible revision into a Turn-bound selection."""
+
+        ref = _normalize_ref(item_ref)
+        if type(snapshot_seq) is not int or snapshot_seq < 0:
+            raise ValueError("snapshot_seq 必须是非负整数")
+        accepted = _normalize_accepted_turn(accepted_turn)
+        instant = _aware_utc(now)
+        token = f"content-selection:{secrets.token_hex(16)}"
+        with self._transaction() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE items
+                SET status = 'selected', selection_token = ?,
+                    selected_session_id = ?, selected_turn_id = ?,
+                    item_state_version = item_state_version + 1, updated_at = ?
+                WHERE source_id = ? AND item_id = ? AND revision = ?
+                  AND snapshot_seq <= ?
+                  AND item_state_version = ?
+                  AND status IN ('pending', 'deferred')
+                  AND not_before <= ?
+                """,
+                (
+                    token,
+                    accepted["session_id"],
+                    accepted["turn_id"],
+                    _utc_now(),
+                    ref["source_id"],
+                    ref["item_id"],
+                    ref["revision"],
+                    snapshot_seq,
+                    ref["state_version"],
+                    instant,
+                ),
+            )
+            selected = cursor.rowcount == 1
+            if selected:
+                _ = connection.execute(
+                    "UPDATE content_state SET state_version = state_version + 1 WHERE singleton = 1"
+                )
+            self._recompute_wake(connection)
+            state = self._state(connection)
+            return {
+                "selected": selected,
+                "selection_token": token if selected else None,
+                "accepted_turn": accepted if selected else None,
+                "state_version": int(state["state_version"]),
+                "wake_needed": bool(state["wake_needed"]),
+                "earliest_not_before": state["earliest_not_before"],
+            }
+
+    def transition(
+        self,
+        selection_token: str,
+        action: str,
+        *,
+        not_before: datetime | None = None,
+        settlement_ref: str | None = None,
+    ) -> dict[str, object]:
+        """Commit one explicit domain transition without inferring Turn state."""
+
+        token = _identity("selection_token", selection_token)
+        if action not in {
+            "ready_for_delivery",
+            "defer",
+            "await_change",
+            "invalidated",
+            "abandoned",
+            "expired",
+            "delivered",
+        }:
+            raise ValueError(f"未知 Content transition: {action}")
+        if action == "defer" and not_before is None:
+            raise ValueError("defer 必须提供 not_before")
+        if action == "delivered" and settlement_ref is None:
+            raise ValueError("delivered 必须提供 settlement_ref")
+        if action != "delivered" and settlement_ref is not None:
+            raise ValueError("只有 delivered transition 可以提供 settlement_ref")
+        deadline = _aware_utc(not_before) if not_before is not None else None
+        settlement = (
+            _identity("settlement_ref", settlement_ref)
+            if settlement_ref is not None
+            else None
+        )
+
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT status, requires_ack FROM items WHERE selection_token = ?",
+                (token,),
+            ).fetchone()
+            if row is None:
+                return {"changed": False, "reason": "selection_missing"}
+            allowed_statuses = (
+                {"ready_for_delivery"}
+                if action == "delivered"
+                else (
+                    {"selected", "ready_for_delivery"}
+                    if action == "abandoned"
+                    else {"selected"}
+                )
+            )
+            if row["status"] not in allowed_statuses:
+                return {"changed": False, "reason": f"status:{row['status']}"}
+            status = "deferred" if action == "defer" else action
+            if action == "delivered" and not bool(row["requires_ack"]):
+                status = "settled"
+            _ = connection.execute(
+                """
+                UPDATE items
+                SET status = ?, not_before = COALESCE(?, not_before),
+                    settlement_ref = COALESCE(?, settlement_ref),
+                    item_state_version = item_state_version + 1, updated_at = ?
+                WHERE selection_token = ?
+                """,
+                (status, deadline, settlement, _utc_now(), token),
+            )
+            _ = connection.execute(
+                "UPDATE content_state SET state_version = state_version + 1 WHERE singleton = 1"
+            )
+            self._recompute_wake(connection)
+            state = self._state(connection)
+            return {
+                "changed": True,
+                "status": status,
+                "state_version": int(state["state_version"]),
+                "wake_needed": bool(state["wake_needed"]),
+                "earliest_not_before": state["earliest_not_before"],
+            }
+
+    def unsettled(
+        self, source_id: str, limit: int = 100
+    ) -> tuple[dict[str, object], ...]:
+        """Return only delivered rows owned by one bound source."""
+
+        source = _identity("source_id", source_id)
+        if type(limit) is not int or limit <= 0:
+            raise ValueError("limit 必须是正整数")
+        with self._transaction() as connection:
+            rows = connection.execute(
+                """
+                SELECT source_id, item_id, revision, settlement_ref, payload_json
+                FROM items
+                WHERE source_id = ? AND status = 'delivered' AND requires_ack = 1
+                ORDER BY snapshot_seq
+                LIMIT ?
+                """,
+                (source, limit),
+            ).fetchall()
+            return tuple(
+                {
+                    "ref": {
+                        "source_id": row["source_id"],
+                        "item_id": row["item_id"],
+                        "revision": row["revision"],
+                    },
+                    "settlement_ref": row["settlement_ref"],
+                    "payload": json.loads(row["payload_json"]),
+                }
+                for row in rows
+            )
+
+    def ack(self, source_id: str, settlement_ref: str) -> dict[str, object]:
+        """Settle one delivered row only through its source-bound view."""
+
+        source = _identity("source_id", source_id)
+        settlement = _identity("settlement_ref", settlement_ref)
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT status FROM items
+                WHERE source_id = ? AND settlement_ref = ?
+                """,
+                (source, settlement),
+            ).fetchone()
+            if row is None:
+                return {"settled": False, "reason": "settlement_missing"}
+            if row["status"] == "settled":
+                return {"settled": True, "duplicate": True}
+            if row["status"] != "delivered":
+                return {"settled": False, "reason": f"status:{row['status']}"}
+            _ = connection.execute(
+                """
+                UPDATE items SET status = 'settled',
+                    item_state_version = item_state_version + 1, updated_at = ?
+                WHERE source_id = ? AND settlement_ref = ? AND status = 'delivered'
+                """,
+                (_utc_now(), source, settlement),
+            )
+            _ = connection.execute(
+                "UPDATE content_state SET state_version = state_version + 1 WHERE singleton = 1"
+            )
+            return {"settled": True, "duplicate": False}
+
+    def state_counts(self) -> dict[str, int]:
+        """Expose deterministic state counts for tests and runtime inspection."""
+
+        with self._transaction() as connection:
+            rows = connection.execute(
+                "SELECT status, COUNT(*) AS count FROM items GROUP BY status"
+            ).fetchall()
+            return {str(row["status"]): int(row["count"]) for row in rows}
+
+    @contextmanager
+    def _transaction(self) -> Generator[sqlite3.Connection]:
+        """Open one serialized SQLite transaction and close it at the boundary."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        try:
+            _ = connection.execute("PRAGMA journal_mode = WAL")
+            _ = connection.execute("PRAGMA foreign_keys = ON")
+            _ = connection.execute("BEGIN IMMEDIATE")
+            self._ensure_schema(connection)
+            yield connection
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _ensure_schema(connection: sqlite3.Connection) -> None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version not in (0, _SCHEMA_VERSION):
+            raise RuntimeError(f"不支持的 Content schema version: {version}")
+        if version == _SCHEMA_VERSION:
+            return
+        statements = (
+            _TABLE_SQL["content_state"],
+            "INSERT INTO content_state VALUES(1, 0, 0, 0, NULL)",
+            _TABLE_SQL["items"],
+            *_INDEX_SQL,
+            _TABLE_SQL["submissions"],
+            f"PRAGMA user_version = {_SCHEMA_VERSION}",
+        )
+        _ = connection.executescript(";\n".join(statements) + ";")
+
+    @staticmethod
+    def _validate_schema(connection: sqlite3.Connection) -> None:
+        """Reject every version-one database that is not this exact schema."""
+
+        # 1. Match the complete owned table set and each constraint-bearing DDL.
+        tables = {
+            str(row["name"]): str(row["sql"])
+            for row in connection.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        if set(tables) != set(_TABLE_SQL):
+            raise RuntimeError(
+                f"Content schema mismatch: tables expected={sorted(_TABLE_SQL)} "
+                f"actual={sorted(tables)}"
+            )
+        for table, expected_sql in _TABLE_SQL.items():
+            if _normalize_sql(tables[table]) != _normalize_sql(expected_sql):
+                raise RuntimeError(f"Content schema mismatch: {table} table SQL")
+
+        # 2. Match storage attributes and every explicit or constraint-owned index.
+        for table, expected_columns in _EXPECTED_COLUMNS.items():
+            actual_columns = tuple(
+                (
+                    int(row["cid"]),
+                    str(row["name"]),
+                    str(row["type"]),
+                    int(row["notnull"]),
+                    row["dflt_value"],
+                    int(row["pk"]),
+                )
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            )
+            if actual_columns != expected_columns:
+                raise RuntimeError(f"Content schema mismatch: {table} columns")
+            actual_indexes = _schema_indexes(connection, table)
+            if actual_indexes != _EXPECTED_INDEXES[table]:
+                raise RuntimeError(f"Content schema mismatch: {table} indexes")
+
+        # 3. The state table owns one singleton row, never zero or a second row.
+        state_rows = tuple(
+            int(row["singleton"])
+            for row in connection.execute("SELECT singleton FROM content_state")
+        )
+        if state_rows != (1,):
+            raise RuntimeError("Content schema mismatch: content_state singleton row")
+
+    @staticmethod
+    def _state(connection: sqlite3.Connection) -> sqlite3.Row:
+        row = connection.execute(
+            "SELECT * FROM content_state WHERE singleton = 1"
+        ).fetchone()
+        assert row is not None
+        return row
+
+    @staticmethod
+    def _recompute_wake(connection: sqlite3.Connection) -> None:
+        row = connection.execute("""
+            SELECT MIN(not_before) AS earliest
+            FROM items WHERE status IN ('pending', 'deferred')
+            """).fetchone()
+        earliest = row["earliest"] if row is not None else None
+        _ = connection.execute(
+            """
+            UPDATE content_state
+            SET wake_needed = ?, earliest_not_before = ?
+            WHERE singleton = 1
+            """,
+            (int(earliest is not None), earliest),
+        )
+
+
+def _normalize_item(item: Mapping[str, object]) -> _NormalizedItem:
+    if not isinstance(item, Mapping):
+        raise ValueError("Content item 必须是 Mapping")
+    item_id = _identity("item_id", item.get("item_id"))
+    revision = _identity("revision", item.get("revision"))
+    payload = item.get("payload")
+    if not isinstance(payload, Mapping):
+        raise ValueError("Content payload 必须是 Mapping")
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    raw_not_before = item.get("not_before")
+    not_before = (
+        _IMMEDIATE_NOT_BEFORE
+        if raw_not_before is None
+        else _aware_utc(_parse_datetime(raw_not_before))
+    )
+    requires_ack = item.get("requires_ack", True)
+    if type(requires_ack) is not bool:
+        raise ValueError("requires_ack 必须是 bool")
+    return {
+        "item_id": item_id,
+        "revision": revision,
+        "payload_json": payload_json,
+        "not_before": not_before,
+        "requires_ack": requires_ack,
+    }
+
+
+def _normalize_ref(item_ref: Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(item_ref, Mapping):
+        raise ValueError("Content item_ref 必须是 Mapping")
+    state_version = item_ref.get("state_version")
+    if type(state_version) is not int or state_version <= 0:
+        raise ValueError("Content item_ref state_version 必须是正整数")
+    return {
+        "source_id": _identity("source_id", item_ref.get("source_id")),
+        "item_id": _identity("item_id", item_ref.get("item_id")),
+        "revision": _identity("revision", item_ref.get("revision")),
+        "state_version": state_version,
+    }
+
+
+def _normalize_accepted_turn(value: Mapping[str, object]) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise ValueError("accepted_turn 必须是 Mapping")
+    return {
+        "session_id": _identity("accepted_turn.session_id", value.get("session_id")),
+        "turn_id": _identity("accepted_turn.turn_id", value.get("turn_id")),
+    }
+
+
+def _item_ref(source_id: str, item: _NormalizedItem) -> dict[str, str]:
+    return {
+        "source_id": source_id,
+        "item_id": item["item_id"],
+        "revision": item["revision"],
+    }
+
+
+def _identity(field: str, value: object) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(f"{field} 必须是非空且无首尾空白的字符串")
+    return value
+
+
+def _parse_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    raise ValueError("not_before 必须是 datetime 或 ISO 字符串")
+
+
+def _aware_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("Content 时间必须带时区")
+    return value.astimezone(UTC).isoformat()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _batch_fingerprint(items: Sequence[Mapping[str, object]]) -> str:
+    payload = json.dumps(items, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _assert_same_revision(
+    source_id: str,
+    item: _NormalizedItem,
+    existing: sqlite3.Row,
+) -> None:
+    same = (
+        existing["payload_json"] == item["payload_json"]
+        and existing["not_before"] == item["not_before"]
+        and bool(existing["requires_ack"]) is item["requires_ack"]
+    )
+    if not same:
+        raise ContentIdentityConflict(
+            "Content revision identity conflict: "
+            f"{source_id}/{item['item_id']}/{item['revision']}"
+        )

--- a/tests/fixtures/content_clock_source/__init__.py
+++ b/tests/fixtures/content_clock_source/__init__.py
@@ -1,0 +1,1 @@
+"""Clock/feed boundary fixture for the Content plugin."""

--- a/tests/fixtures/content_clock_source/plugin.py
+++ b/tests/fixtures/content_clock_source/plugin.py
@@ -15,6 +15,7 @@ from agent.plugin_composition import (
     RUNTIME_STOPPING,
     TIMERS,
     Context,
+    EmitEventKey,
     PluginTimers,
     ServiceKey,
 )
@@ -44,8 +45,32 @@ class ContentSourceServices(Protocol):
     def bind(self, source_id: str) -> BoundContentSource: ...
 
 
+class ContentWakeServices(Protocol):
+    def snapshot(self, now: datetime) -> Mapping[str, object]: ...
+
+
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
-inject = (TIMERS, CONTENT_SOURCE)
+CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+CONTENT_CHANGED = EmitEventKey[None]("content.changed")
+
+
+class ContentHintProbe:
+    """Record lossy Content hints and the state visible inside each listener."""
+
+    def __init__(self, wake: ContentWakeServices) -> None:
+        self._wake = wake
+        self.snapshots: list[Mapping[str, object]] = []
+
+    @property
+    def count(self) -> int:
+        return len(self.snapshots)
+
+    def changed(self, _payload: None) -> None:
+        self.snapshots.append(self._wake.snapshot(datetime.now(UTC)))
+
+
+CONTENT_HINT_PROBE = ServiceKey[ContentHintProbe]("fixture.content-hint-probe.v1")
+inject = (TIMERS, CONTENT_SOURCE, CONTENT_WAKE)
 
 
 class FixtureSourceStore:
@@ -245,6 +270,9 @@ async def apply(ctx: Context, config: object) -> None:
     """Bind the fake source to formal runtime lifecycle only."""
 
     _ = config
+    hint_probe = ContentHintProbe(ctx.require(CONTENT_WAKE))
+    _ = await ctx.provide(CONTENT_HINT_PROBE, hint_probe)
+    _ = await ctx.on(CONTENT_CHANGED, hint_probe.changed)
     runtime = SourceRuntime(
         FixtureSourceStore(ctx.data_root / "source.sqlite3"),
         ctx.require(TIMERS),

--- a/tests/fixtures/content_clock_source/plugin.py
+++ b/tests/fixtures/content_clock_source/plugin.py
@@ -15,7 +15,6 @@ from agent.plugin_composition import (
     RUNTIME_STOPPING,
     TIMERS,
     Context,
-    EmitEventKey,
     PluginTimers,
     ServiceKey,
 )
@@ -45,32 +44,8 @@ class ContentSourceServices(Protocol):
     def bind(self, source_id: str) -> BoundContentSource: ...
 
 
-class ContentWakeServices(Protocol):
-    def snapshot(self, now: datetime) -> Mapping[str, object]: ...
-
-
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
-CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
-CONTENT_CHANGED = EmitEventKey[None]("content.changed")
-
-
-class ContentHintProbe:
-    """Record lossy Content hints and the state visible inside each listener."""
-
-    def __init__(self, wake: ContentWakeServices) -> None:
-        self._wake = wake
-        self.snapshots: list[Mapping[str, object]] = []
-
-    @property
-    def count(self) -> int:
-        return len(self.snapshots)
-
-    def changed(self, _payload: None) -> None:
-        self.snapshots.append(self._wake.snapshot(datetime.now(UTC)))
-
-
-CONTENT_HINT_PROBE = ServiceKey[ContentHintProbe]("fixture.content-hint-probe.v1")
-inject = (TIMERS, CONTENT_SOURCE, CONTENT_WAKE)
+inject = (TIMERS, CONTENT_SOURCE)
 
 
 class FixtureSourceStore:
@@ -270,9 +245,6 @@ async def apply(ctx: Context, config: object) -> None:
     """Bind the fake source to formal runtime lifecycle only."""
 
     _ = config
-    hint_probe = ContentHintProbe(ctx.require(CONTENT_WAKE))
-    _ = await ctx.provide(CONTENT_HINT_PROBE, hint_probe)
-    _ = await ctx.on(CONTENT_CHANGED, hint_probe.changed)
     runtime = SourceRuntime(
         FixtureSourceStore(ctx.data_root / "source.sqlite3"),
         ctx.require(TIMERS),

--- a/tests/fixtures/content_clock_source/plugin.py
+++ b/tests/fixtures/content_clock_source/plugin.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Generator, Protocol
+
+from agent.control.timer import TimerHandle, TimerStatus
+from agent.plugin_composition import (
+    RUNTIME_STARTED,
+    RUNTIME_STOPPING,
+    TIMERS,
+    Context,
+    PluginTimers,
+    ServiceKey,
+)
+
+api_version = 3
+name = "content_clock_source"
+version = "3.0.0"
+desc = "Deterministic clock and feed boundary for Content composition tests"
+author = "Akashic Core"
+skill_roots = ()
+drift_skill_roots = ()
+workspace_roots = ()
+workspace_files = ()
+
+
+class BoundContentSource(Protocol):
+    def submit(
+        self, batch_id: str, items: Sequence[Mapping[str, object]]
+    ) -> Mapping[str, object]: ...
+
+    def unsettled(self, limit: int = 100) -> tuple[Mapping[str, object], ...]: ...
+
+    def ack(self, settlement_ref: str) -> Mapping[str, object]: ...
+
+
+class ContentSourceServices(Protocol):
+    def bind(self, source_id: str) -> BoundContentSource: ...
+
+
+CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
+inject = (TIMERS, CONTENT_SOURCE)
+
+
+class FixtureSourceStore:
+    """Persist the fake external feed and the source-owned cursor/deadline."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def seed(self, payloads: Sequence[Mapping[str, object]], now: datetime) -> None:
+        with self._transaction() as connection:
+            for payload in payloads:
+                connection.execute(
+                    "INSERT INTO feed(payload_json, observed_at) VALUES (?, ?)",
+                    (
+                        json.dumps(payload, sort_keys=True, separators=(",", ":")),
+                        _aware_utc(now),
+                    ),
+                )
+            connection.execute(
+                "UPDATE source_state SET next_due = ? WHERE singleton = 1",
+                (_aware_utc(now),),
+            )
+
+    def poll(self) -> tuple[int, tuple[dict[str, object], ...]]:
+        with self._transaction() as connection:
+            cursor = int(
+                connection.execute(
+                    "SELECT cursor FROM source_state WHERE singleton = 1"
+                ).fetchone()[0]
+            )
+            rows = connection.execute(
+                """
+                SELECT seq, payload_json, observed_at
+                FROM feed WHERE seq > ? ORDER BY seq
+                """,
+                (cursor,),
+            ).fetchall()
+            return cursor, tuple(
+                {
+                    "item_id": f"event-{int(row['seq'])}",
+                    "revision": "1",
+                    "payload": json.loads(row["payload_json"]),
+                    "not_before": row["observed_at"],
+                    "requires_ack": True,
+                }
+                for row in rows
+            )
+
+    def commit_poll(self, cursor: int, count: int, next_due: datetime) -> None:
+        with self._transaction() as connection:
+            changed = connection.execute(
+                """
+                UPDATE source_state
+                SET cursor = ?, next_due = ?, poll_count = poll_count + 1
+                WHERE singleton = 1 AND cursor = ?
+                """,
+                (cursor + count, _aware_utc(next_due), cursor),
+            )
+            if changed.rowcount != 1:
+                raise RuntimeError("fixture source cursor CAS failed")
+
+    def state(self, now: datetime) -> dict[str, object]:
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT cursor, next_due, poll_count FROM source_state WHERE singleton = 1"
+            ).fetchone()
+            next_due = row["next_due"] or _aware_utc(now)
+            return {
+                "cursor": int(row["cursor"]),
+                "next_due": datetime.fromisoformat(next_due),
+                "poll_count": int(row["poll_count"]),
+            }
+
+    @contextmanager
+    def _transaction(self) -> Generator[sqlite3.Connection]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.executescript("""
+                CREATE TABLE IF NOT EXISTS feed(
+                    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload_json TEXT NOT NULL,
+                    observed_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS source_state(
+                    singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                    cursor INTEGER NOT NULL,
+                    next_due TEXT,
+                    poll_count INTEGER NOT NULL
+                );
+                INSERT OR IGNORE INTO source_state VALUES(1, 0, NULL, 0);
+                """)
+            yield connection
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+class SourceRuntime:
+    """Compose one-shot Timer waits with a submit-before-cursor source protocol."""
+
+    def __init__(
+        self,
+        store: FixtureSourceStore,
+        timers: PluginTimers,
+        content: BoundContentSource,
+        *,
+        now: Callable[[], datetime] | None = None,
+        after_submit: Callable[[], None] | None = None,
+    ) -> None:
+        self.store = store
+        self._timers = timers
+        self._content = content
+        self._now = now or (lambda: datetime.now(UTC))
+        self._after_submit = after_submit
+        self._handle: TimerHandle | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    async def start(self) -> None:
+        """Recover the source-owned deadline and arm exactly one wait."""
+
+        if self._closed:
+            raise RuntimeError("content fixture source 已关闭")
+        if self._handle is not None:
+            return
+        state = self.store.state(self._aware_now())
+        self._arm(state["next_due"])
+
+    async def close(self) -> None:
+        """Cancel the owned wait/task without changing cursor or feed."""
+
+        self._closed = True
+        handle = self._handle
+        task = self._task
+        self._handle = None
+        self._task = None
+        if handle is not None:
+            _ = await handle.cancel()
+        if task is not None and task is not asyncio.current_task():
+            _ = await asyncio.gather(task, return_exceptions=True)
+        if handle is not None:
+            await handle.cleanup()
+
+    def _arm(self, deadline: object) -> None:
+        if self._closed or self._handle is not None:
+            return
+        if not isinstance(deadline, datetime):
+            raise RuntimeError("fixture source next_due 不是 datetime")
+        handle = self._timers.schedule(deadline)
+        self._handle = handle
+        self._task = asyncio.create_task(
+            self._wait_poll_rearm(handle), name="content-clock-source:poll"
+        )
+
+    async def _wait_poll_rearm(self, handle: TimerHandle) -> None:
+        """Poll, commit Content, advance the cursor, then re-arm."""
+
+        try:
+            receipt = await handle.result()
+            if receipt.status is TimerStatus.CANCELLED or self._closed:
+                return
+
+            # 1. Read the fake external feed without changing its cursor.
+            cursor, items = self.store.poll()
+            batch_id = f"poll:{cursor}:{cursor + len(items)}"
+
+            # 2. Commit Content before any source-owned progress becomes visible.
+            _ = self._content.submit(batch_id, items)
+            if self._after_submit is not None:
+                self._after_submit()
+
+            # 3. Advance the source cursor/deadline only after the submit receipt.
+            next_due = self._aware_now() + timedelta(minutes=5)
+            self.store.commit_poll(cursor, len(items), next_due)
+        finally:
+            self._handle = None
+            self._task = None
+            await handle.cleanup()
+        if not self._closed:
+            state = self.store.state(self._aware_now())
+            self._arm(state["next_due"])
+
+    def _aware_now(self) -> datetime:
+        value = self._now()
+        if value.tzinfo is None:
+            raise ValueError("fixture source clock 必须带时区")
+        return value.astimezone(UTC)
+
+
+async def apply(ctx: Context, config: object) -> None:
+    """Bind the fake source to formal runtime lifecycle only."""
+
+    _ = config
+    runtime = SourceRuntime(
+        FixtureSourceStore(ctx.data_root / "source.sqlite3"),
+        ctx.require(TIMERS),
+        ctx.require(CONTENT_SOURCE).bind("clock-feed"),
+    )
+
+    def setup() -> object:
+        return runtime.close
+
+    _ = await ctx.effect(setup, label="content-clock-source-runtime")
+
+    async def start(_event: object) -> None:
+        await runtime.start()
+
+    async def stop(_event: object) -> None:
+        await runtime.close()
+
+    _ = await ctx.on(RUNTIME_STARTED, start)
+    _ = await ctx.on(RUNTIME_STOPPING, stop)
+
+
+def _aware_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("fixture source 时间必须带时区")
+    return value.astimezone(UTC).isoformat()

--- a/tests/fixtures/content_hint_probe/__init__.py
+++ b/tests/fixtures/content_hint_probe/__init__.py
@@ -1,0 +1,1 @@
+"""Independent observer fixture for Content's lossy changed hint."""

--- a/tests/fixtures/content_hint_probe/plugin.py
+++ b/tests/fixtures/content_hint_probe/plugin.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Protocol
+
+from agent.plugin_composition import Context, EmitEventKey, ServiceKey
+
+api_version = 3
+name = "content_hint_probe"
+version = "3.0.0"
+desc = "Independent observer for Content's lossy changed hint"
+author = "Akashic Core"
+skill_roots = ()
+drift_skill_roots = ()
+workspace_roots = ()
+workspace_files = ()
+
+
+class ContentWakeServices(Protocol):
+    def snapshot(self, now: datetime) -> Mapping[str, object]: ...
+
+
+CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+CONTENT_CHANGED = EmitEventKey[None]("content.changed")
+
+
+class ContentHintProbe:
+    """Record each hint and the Content snapshot visible inside its listener."""
+
+    def __init__(self, wake: ContentWakeServices) -> None:
+        self._wake = wake
+        self.snapshots: list[Mapping[str, object]] = []
+
+    @property
+    def count(self) -> int:
+        return len(self.snapshots)
+
+    def changed(self, _payload: None) -> None:
+        self.snapshots.append(self._wake.snapshot(datetime.now(UTC)))
+
+
+CONTENT_HINT_PROBE = ServiceKey[ContentHintProbe]("fixture.content-hint-probe.v1")
+inject = (CONTENT_WAKE,)
+
+
+async def apply(ctx: Context, config: object) -> None:
+    """Publish an in-memory hint observer without source or Timer capabilities."""
+
+    _ = config
+    probe = ContentHintProbe(ctx.require(CONTENT_WAKE))
+    _ = await ctx.provide(CONTENT_HINT_PROBE, probe)
+    _ = await ctx.on(CONTENT_CHANGED, probe.changed)

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -426,6 +426,47 @@ def test_source_id_has_one_bound_owner_per_root(tmp_path) -> None:
     assert first.unsettled() == ()
 
 
+def test_read_only_store_reads_formal_state_and_rejects_every_write(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    path = tmp_path / "content.sqlite3"
+    formal = ContentStore(path)
+    _ = formal.submit("feed", "poll:1", [_item("one", not_before=now)])
+    snapshot = formal.snapshot(now)
+    token = _select(formal, now)
+    candidate = ContentStore(path, data_access="read_only")
+
+    candidate.initialize()
+    assert candidate.snapshot(now)["snapshot_seq"] == snapshot["snapshot_seq"]
+    assert candidate.selection(
+        {"session_id": "wake:fixture", "turn_id": "turn:one"}
+    )["selection_token"] == token
+    assert candidate.unsettled("feed") == ()
+    assert candidate.state_counts() == {"selected": 1}
+
+    with pytest.raises(PermissionError, match="read-only candidate"):
+        candidate.submit("feed", "poll:2", [_item("two", not_before=now)])
+    with pytest.raises(PermissionError, match="read-only candidate"):
+        candidate.select(
+            snapshot["items"][0]["ref"],
+            snapshot["snapshot_seq"],
+            {"session_id": "wake:candidate", "turn_id": "turn:write"},
+            now,
+        )
+    with pytest.raises(PermissionError, match="read-only candidate"):
+        candidate.transition(token, "ready_for_delivery")
+    with pytest.raises(PermissionError, match="read-only candidate"):
+        candidate.ack("feed", "delivery:missing")
+
+
+def test_read_only_initialize_does_not_create_database_or_parent(tmp_path) -> None:
+    path = tmp_path / "missing" / "content.sqlite3"
+
+    with pytest.raises(sqlite3.OperationalError, match="open database"):
+        ContentStore(path, data_access="read_only").initialize()
+
+    assert not path.parent.exists()
+
+
 def test_initialize_rejects_unknown_or_malformed_schema(tmp_path) -> None:
     unknown = tmp_path / "unknown.sqlite3"
     connection = sqlite3.connect(unknown)

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -141,6 +141,120 @@ def test_cas_selection_allows_only_one_turn_for_one_revision(tmp_path) -> None:
     assert store.state_counts() == {"selected": 1}
 
 
+def test_selection_recovers_after_wake_loses_token(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    path = tmp_path / "content.sqlite3"
+    store = ContentStore(path)
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    snapshot = store.snapshot(now)
+    accepted = {"session_id": "wake:recovery", "turn_id": "turn:accepted"}
+    selected = store.select(
+        snapshot["items"][0]["ref"], snapshot["snapshot_seq"], accepted, now
+    )
+
+    restarted = ContentStore(path)
+    restarted.initialize()
+    recovered = restarted.selection(accepted)
+
+    assert recovered is not None
+    assert recovered["selection_token"] == selected["selection_token"]
+    assert recovered["ref"]["item_id"] == "one"
+    assert recovered["payload"] == {"value": "one"}
+    assert recovered["status"] == "selected"
+    assert recovered["accepted_turn"] == accepted
+    assert "settlement_ref" not in recovered
+
+
+def test_one_accepted_turn_cannot_select_two_items_concurrently(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:1",
+        [_item("one", not_before=now), _item("two", not_before=now)],
+    )
+    snapshot = store.snapshot(now)
+    accepted = {"session_id": "wake:one", "turn_id": "turn:shared"}
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(
+            executor.map(
+                lambda item: store.select(
+                    item["ref"], snapshot["snapshot_seq"], accepted, now
+                ),
+                snapshot["items"],
+            )
+        )
+
+    assert sum(result["selected"] is True for result in results) == 1
+    rejected = next(result for result in results if result["selected"] is False)
+    assert rejected["reason"] == "turn_already_selected"
+    assert store.selection(accepted) is not None
+    assert store.state_counts() == {"pending": 1, "selected": 1}
+
+
+def test_selection_is_missing_or_isolated_by_full_turn_receipt(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:1",
+        [_item("one", not_before=now), _item("two", not_before=now)],
+    )
+    snapshot = store.snapshot(now)
+    first = {"session_id": "wake:a", "turn_id": "turn:same"}
+    second = {"session_id": "wake:b", "turn_id": "turn:same"}
+
+    assert store.selection(first) is None
+    assert (
+        store.select(snapshot["items"][0]["ref"], snapshot["snapshot_seq"], first, now)[
+            "selected"
+        ]
+        is True
+    )
+    assert (
+        store.select(
+            snapshot["items"][1]["ref"], snapshot["snapshot_seq"], second, now
+        )["selected"]
+        is True
+    )
+
+    assert store.selection(first)["ref"]["item_id"] == "one"
+    assert store.selection(second)["ref"]["item_id"] == "two"
+    assert (
+        store.selection({"session_id": "wake:missing", "turn_id": "turn:same"}) is None
+    )
+
+
+def test_deferred_selection_keeps_turn_owner_and_recovery_token(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:1",
+        [_item("one", not_before=now), _item("two", not_before=now)],
+    )
+    snapshot = store.snapshot(now)
+    accepted = {"session_id": "wake:defer", "turn_id": "turn:complete"}
+    selected = store.select(
+        snapshot["items"][0]["ref"], snapshot["snapshot_seq"], accepted, now
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+    _ = store.transition(token, "defer", not_before=now)
+    fresh = store.snapshot(now)
+    other = next(item for item in fresh["items"] if item["ref"]["item_id"] == "two")
+
+    repeated = store.select(other["ref"], fresh["snapshot_seq"], accepted, now)
+    recovered = store.selection(accepted)
+
+    assert repeated["selected"] is False
+    assert repeated["reason"] == "turn_already_selected"
+    assert recovered is not None
+    assert recovered["selection_token"] == token
+    assert recovered["status"] == "deferred"
+
+
 def test_item_state_version_rejects_stale_snapshot_after_defer(tmp_path) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
     store = ContentStore(tmp_path / "content.sqlite3")

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import inspect
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from plugins.content import plugin as content_plugin
+from plugins.content.store import ContentIdentityConflict, ContentStore
+
+
+def _item(
+    item_id: str,
+    *,
+    revision: str = "1",
+    value: str | None = None,
+    not_before: datetime | None = None,
+    requires_ack: bool = True,
+) -> dict[str, object]:
+    return {
+        "item_id": item_id,
+        "revision": revision,
+        "payload": {"value": value or item_id},
+        "not_before": not_before,
+        "requires_ack": requires_ack,
+    }
+
+
+def _select(store: ContentStore, now: datetime, item_id: str = "one") -> str:
+    snapshot = store.snapshot(now)
+    candidate = next(
+        item for item in snapshot["items"] if item["ref"]["item_id"] == item_id
+    )
+    result = store.select(
+        candidate["ref"],
+        snapshot["snapshot_seq"],
+        {"session_id": "wake:fixture", "turn_id": f"turn:{item_id}"},
+        now,
+    )
+    assert result["selected"] is True
+    token = result["selection_token"]
+    assert isinstance(token, str)
+    return token
+
+
+def test_submit_reuses_batch_receipt_and_revision_without_duplicate_item(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    items = [_item("one", not_before=now)]
+
+    first = store.submit("fitbit", "poll:1", items)
+    repeated = store.submit("fitbit", "poll:1", items)
+    another_batch = store.submit("fitbit", "poll:2", items)
+
+    assert first == repeated
+    assert first["inserted"] == [
+        {"source_id": "fitbit", "item_id": "one", "revision": "1"}
+    ]
+    assert another_batch["inserted"] == []
+    assert another_batch["duplicates"] == first["inserted"]
+    assert another_batch["high_watermark"] == 1
+    assert store.state_counts() == {"pending": 1}
+
+
+def test_missing_not_before_stays_idempotent_across_later_poll(tmp_path) -> None:
+    store = ContentStore(tmp_path / "content.sqlite3")
+    item = _item("one")
+
+    _ = store.submit("feed", "poll:1", [item])
+    repeated = store.submit("feed", "poll:1", [item])
+    later_poll = store.submit("feed", "poll:2", [item])
+
+    assert repeated["receipt_id"] == "content-submit:feed:poll:1"
+    assert later_poll["duplicates"] == [
+        {"source_id": "feed", "item_id": "one", "revision": "1"}
+    ]
+
+
+def test_stable_batch_and_revision_identity_reject_different_content(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", value="a", not_before=now)])
+
+    with pytest.raises(ContentIdentityConflict, match="batch identity"):
+        store.submit("feed", "poll:1", [_item("one", value="b", not_before=now)])
+    with pytest.raises(ContentIdentityConflict, match="revision identity"):
+        store.submit("feed", "poll:2", [_item("one", value="b", not_before=now)])
+    with pytest.raises(ContentIdentityConflict, match="revision identity"):
+        store.submit(
+            "feed",
+            "poll:3",
+            [_item("one", value="a", not_before=now + timedelta(seconds=1))],
+        )
+
+
+def test_frozen_high_watermark_selection_keeps_new_item_for_next_wake(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    frozen = store.snapshot(now)
+
+    _ = store.submit("feed", "poll:2", [_item("two", not_before=now)])
+    selected = store.select(
+        frozen["items"][0]["ref"],
+        frozen["snapshot_seq"],
+        {"session_id": "wake:fixture", "turn_id": "turn:one"},
+        now,
+    )
+
+    assert selected["selected"] is True
+    assert selected["wake_needed"] is True
+    assert [item["ref"]["item_id"] for item in store.snapshot(now)["items"]] == ["two"]
+    assert store.state_counts() == {"pending": 1, "selected": 1}
+
+
+def test_cas_selection_allows_only_one_turn_for_one_revision(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    snapshot = store.snapshot(now)
+    ref = snapshot["items"][0]["ref"]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(
+            executor.map(
+                lambda turn: store.select(
+                    ref,
+                    snapshot["snapshot_seq"],
+                    {"session_id": "wake:fixture", "turn_id": turn},
+                    now,
+                ),
+                ("turn:a", "turn:b"),
+            )
+        )
+
+    assert sum(result["selected"] is True for result in results) == 1
+    assert store.state_counts() == {"selected": 1}
+
+
+def test_item_state_version_rejects_stale_snapshot_after_defer(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    stale = store.snapshot(now)
+    token = _select(store, now)
+    _ = store.transition(token, "defer", not_before=now)
+
+    rejected = store.select(
+        stale["items"][0]["ref"],
+        stale["snapshot_seq"],
+        {"session_id": "wake:fixture", "turn_id": "turn:stale"},
+        now,
+    )
+    fresh = store.snapshot(now)
+    accepted = store.select(
+        fresh["items"][0]["ref"],
+        fresh["snapshot_seq"],
+        {"session_id": "wake:fixture", "turn_id": "turn:fresh"},
+        now,
+    )
+
+    assert rejected["selected"] is False
+    assert accepted["selected"] is True
+    assert accepted["accepted_turn"] == {
+        "session_id": "wake:fixture",
+        "turn_id": "turn:fresh",
+    }
+    connection = sqlite3.connect(store.path)
+    selected_owner = connection.execute("""
+        SELECT selected_session_id, selected_turn_id FROM items
+        WHERE source_id = 'feed' AND item_id = 'one' AND revision = '1'
+        """).fetchone()
+    connection.close()
+    assert selected_owner == ("wake:fixture", "turn:fresh")
+
+
+def test_decline_transitions_recompute_wake_without_timer_state(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    token = _select(store, now)
+    later = now + timedelta(hours=1)
+
+    deferred = store.transition(token, "defer", not_before=later)
+    before_due = store.snapshot(now)
+    at_due = store.snapshot(later)
+
+    assert deferred["status"] == "deferred"
+    assert before_due["wake_needed"] is True
+    assert before_due["items"][0]["due"] is False
+    assert at_due["items"][0]["due"] is True
+
+
+def test_source_bound_unsettled_and_ack_cannot_cross_source(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("fitbit", "poll:1", [_item("sleep", not_before=now)])
+    token = _select(store, now, "sleep")
+    assert store.transition(token, "ready_for_delivery")["changed"] is True
+    assert (
+        store.transition(token, "delivered", settlement_ref="delivery:settle:1")[
+            "status"
+        ]
+        == "delivered"
+    )
+
+    assert store.unsettled("feed") == ()
+    assert store.ack("feed", "delivery:settle:1") == {
+        "settled": False,
+        "reason": "settlement_missing",
+    }
+    assert [row["settlement_ref"] for row in store.unsettled("fitbit")] == [
+        "delivery:settle:1"
+    ]
+    assert store.ack("fitbit", "delivery:settle:1") == {
+        "settled": True,
+        "duplicate": False,
+    }
+    assert store.ack("fitbit", "delivery:settle:1") == {
+        "settled": True,
+        "duplicate": True,
+    }
+    assert store.state_counts() == {"settled": 1}
+
+
+def test_context_without_provider_ack_settles_at_delivery(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "steam",
+        "poll:1",
+        [_item("context", not_before=now, requires_ack=False)],
+    )
+    token = _select(store, now, "context")
+    _ = store.transition(token, "ready_for_delivery")
+
+    delivered = store.transition(
+        token, "delivered", settlement_ref="delivery:context:1"
+    )
+
+    assert delivered["status"] == "settled"
+    assert store.unsettled("steam") == ()
+    assert store.state_counts() == {"settled": 1}
+
+
+def test_wake_capability_cannot_commit_delivery_but_can_abandon_ready_item(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    token = _select(store, now)
+    wake = content_plugin._WakeServices(store)
+    assert wake.transition(token, "ready_for_delivery")["changed"] is True
+
+    with pytest.raises(ValueError, match="不拥有 transition: delivered"):
+        wake.transition(token, "delivered")
+    assert "settlement_ref" not in inspect.signature(wake.transition).parameters
+    assert wake.transition(token, "abandoned")["status"] == "abandoned"
+
+
+@pytest.mark.parametrize(
+    "action",
+    (
+        "ready_for_delivery",
+        "defer",
+        "await_change",
+        "invalidated",
+        "abandoned",
+        "expired",
+    ),
+)
+def test_non_delivery_transition_cannot_write_settlement_ref(
+    tmp_path, action: str
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("feed", "poll:1", [_item("one", not_before=now)])
+    token = _select(store, now)
+    not_before = now + timedelta(hours=1) if action == "defer" else None
+
+    with pytest.raises(ValueError, match="只有 delivered"):
+        store.transition(
+            token,
+            action,
+            not_before=not_before,
+            settlement_ref="delivery:forbidden",
+        )
+
+    connection = sqlite3.connect(store.path)
+    persisted = connection.execute(
+        "SELECT status, settlement_ref FROM items WHERE selection_token = ?",
+        (token,),
+    ).fetchone()
+    connection.close()
+    assert persisted == ("selected", None)
+
+
+def test_source_id_has_one_bound_owner_per_root(tmp_path) -> None:
+    services = content_plugin._SourceServices(
+        ContentStore(tmp_path / "content.sqlite3")
+    )
+    first = services.bind("fitbit")
+
+    with pytest.raises(RuntimeError, match="已有 owner"):
+        services.bind("fitbit")
+
+    assert first.unsettled() == ()
+
+
+def test_initialize_rejects_unknown_or_malformed_schema(tmp_path) -> None:
+    unknown = tmp_path / "unknown.sqlite3"
+    connection = sqlite3.connect(unknown)
+    connection.execute("PRAGMA user_version = 99")
+    connection.close()
+    with pytest.raises(RuntimeError, match="schema version: 99"):
+        ContentStore(unknown).initialize()
+
+    malformed = tmp_path / "malformed.sqlite3"
+    connection = sqlite3.connect(malformed)
+    connection.execute("CREATE TABLE items(wrong TEXT)")
+    connection.execute("PRAGMA user_version = 1")
+    connection.close()
+    with pytest.raises(RuntimeError, match="schema mismatch"):
+        ContentStore(malformed).initialize()
+
+
+def test_initialize_rejects_constraint_free_schema_with_same_columns(tmp_path) -> None:
+    path = tmp_path / "lookalike.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        CREATE TABLE content_state(
+            singleton INTEGER,
+            next_seq INTEGER NOT NULL,
+            state_version INTEGER NOT NULL,
+            wake_needed INTEGER NOT NULL,
+            earliest_not_before TEXT
+        );
+        INSERT INTO content_state VALUES(1, 0, 0, 0, NULL);
+        CREATE TABLE items(
+            source_id TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            revision TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            snapshot_seq INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            not_before TEXT NOT NULL,
+            requires_ack INTEGER NOT NULL,
+            item_state_version INTEGER NOT NULL,
+            selection_token TEXT,
+            selected_session_id TEXT,
+            selected_turn_id TEXT,
+            settlement_ref TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE submissions(
+            source_id TEXT NOT NULL,
+            batch_id TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            receipt_json TEXT NOT NULL,
+            submitted_at TEXT NOT NULL
+        );
+        PRAGMA user_version = 1;
+        """)
+    connection.close()
+
+    with pytest.raises(RuntimeError, match="schema mismatch"):
+        ContentStore(path).initialize()
+
+
+def test_initialize_rejects_missing_index_and_singleton_row(tmp_path) -> None:
+    missing_index = ContentStore(tmp_path / "missing-index.sqlite3")
+    missing_index.initialize()
+    connection = sqlite3.connect(missing_index.path)
+    connection.execute("DROP INDEX items_wake_idx")
+    connection.commit()
+    connection.close()
+    with pytest.raises(RuntimeError, match="items indexes"):
+        missing_index.initialize()
+
+    missing_state = ContentStore(tmp_path / "missing-state.sqlite3")
+    missing_state.initialize()
+    connection = sqlite3.connect(missing_state.path)
+    connection.execute("DELETE FROM content_state")
+    connection.commit()
+    connection.close()
+    with pytest.raises(RuntimeError, match="content_state singleton row"):
+        missing_state.initialize()
+
+
+def test_initialize_rejects_physically_corrupt_sqlite(tmp_path) -> None:
+    path = tmp_path / "corrupt.sqlite3"
+    path.write_bytes(b"not a sqlite database")
+
+    with pytest.raises(sqlite3.DatabaseError, match="database|encrypted"):
+        ContentStore(path).initialize()

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -465,7 +465,8 @@ def test_non_delivery_transition_cannot_write_settlement_ref(
 
 def test_source_id_has_one_bound_owner_per_root(tmp_path) -> None:
     services = content_plugin._SourceServices(
-        ContentStore(tmp_path / "content.sqlite3")
+        ContentStore(tmp_path / "content.sqlite3"),
+        lambda: None,
     )
     first = services.bind("fitbit")
 

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -165,6 +165,55 @@ def test_selection_recovers_after_wake_loses_token(tmp_path) -> None:
     assert "settlement_ref" not in recovered
 
 
+def test_selected_recovers_same_tokens_in_snapshot_order_with_limit(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    path = tmp_path / "content.sqlite3"
+    store = ContentStore(path)
+    _ = store.submit(
+        "feed",
+        "poll:1",
+        (
+            _item("one", not_before=now),
+            _item("two", not_before=now),
+            _item("three", not_before=now),
+        ),
+    )
+    tokens = tuple(
+        _select(store, now, item_id) for item_id in ("one", "two", "three")
+    )
+
+    restarted = ContentStore(path)
+    recovered = restarted.selected(limit=2)
+
+    assert tuple(row["selection_token"] for row in recovered) == tokens[:2]
+    assert tuple(row["ref"]["item_id"] for row in recovered) == ("one", "two")
+    assert tuple(row["accepted_turn"] for row in recovered) == (
+        {"session_id": "wake:fixture", "turn_id": "turn:one"},
+        {"session_id": "wake:fixture", "turn_id": "turn:two"},
+    )
+    assert restarted.selected(limit=1) == recovered[:1]
+
+
+def test_selected_excludes_ready_for_delivery_and_rejects_invalid_limit(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:1",
+        (_item("one", not_before=now), _item("two", not_before=now)),
+    )
+    first = _select(store, now, "one")
+    second = _select(store, now, "two")
+    _ = store.transition(first, "ready_for_delivery")
+
+    assert tuple(row["selection_token"] for row in store.selected()) == (second,)
+    for limit in (0, -1, True, 1.5):
+        with pytest.raises(ValueError, match="limit 必须是正整数"):
+            store.selected(limit)  # pyright: ignore[reportArgumentType]
+
+
 def test_one_accepted_turn_cannot_select_two_items_concurrently(tmp_path) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
     store = ContentStore(tmp_path / "content.sqlite3")

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -24,10 +24,10 @@ from plugins.content.plugin import ContentSourceServices, ContentWakeServices
 from plugins.content.store import ContentStore
 from tests.fixtures.content_clock_source.plugin import (
     BoundContentSource,
-    CONTENT_HINT_PROBE,
     FixtureSourceStore,
     SourceRuntime,
 )
+from tests.fixtures.content_hint_probe.plugin import CONTENT_HINT_PROBE
 
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
 CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
@@ -83,16 +83,21 @@ async def _eventually(predicate) -> None:
     raise AssertionError("condition did not settle")
 
 
-def _copy_plugins(tmp_path: Path) -> tuple[Path, Path]:
+def _copy_plugins(tmp_path: Path) -> tuple[Path, Path, Path]:
     root = Path(__file__).resolve().parents[1]
     content = tmp_path / "plugins" / "content"
     source = tmp_path / "plugins" / "content_clock_source"
+    probe = tmp_path / "plugins" / "content_hint_probe"
     shutil.copytree(root / "plugins" / "content", content)
     shutil.copytree(
         root / "tests" / "fixtures" / "content_clock_source",
         source,
     )
-    return content, source
+    shutil.copytree(
+        root / "tests" / "fixtures" / "content_hint_probe",
+        probe,
+    )
+    return content, source, probe
 
 
 def _sqlite_hashes(path: Path) -> dict[str, str]:
@@ -110,14 +115,14 @@ async def test_real_v3_loader_timer_and_stores_submit_before_cursor(
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
     timer = _Timer(now)
     monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", lambda: timer)
-    content_dir, source_dir = _copy_plugins(tmp_path)
+    content_dir, source_dir, probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     source_store = FixtureSourceStore(
         workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
     )
     source_store.seed(({"kind": "sleep", "score": 92},), now)
     manager = PluginManager(
-        plugin_dirs=[content_dir, source_dir],
+        plugin_dirs=[content_dir, source_dir, probe_dir],
         event_bus=EventBus(),
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
@@ -216,7 +221,7 @@ async def test_content_submit_without_changed_listener_still_succeeds(
     tmp_path: Path,
 ) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
-    content_dir, _source_dir = _copy_plugins(tmp_path)
+    content_dir, _source_dir, _probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     manager = PluginManager(
         plugin_dirs=[content_dir],
@@ -265,14 +270,14 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         return timer
 
     monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", timer_factory)
-    content_dir, source_dir = _copy_plugins(tmp_path)
+    content_dir, source_dir, probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     source_store = FixtureSourceStore(
         workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
     )
     source_store.seed(({"kind": "calendar"},), now + timedelta(hours=1))
     manager = PluginManager(
-        plugin_dirs=[content_dir, source_dir],
+        plugin_dirs=[content_dir, source_dir, probe_dir],
         event_bus=EventBus(),
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
@@ -412,14 +417,14 @@ async def test_promotion_drains_old_wait_and_only_new_root_recovers(
         return timer
 
     monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", timer_factory)
-    content_dir, source_dir = _copy_plugins(tmp_path)
+    content_dir, source_dir, probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     source_store = FixtureSourceStore(
         workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
     )
     source_store.seed(({"kind": "future"},), now + timedelta(hours=1))
     manager = PluginManager(
-        plugin_dirs=[content_dir, source_dir],
+        plugin_dirs=[content_dir, source_dir, probe_dir],
         event_bus=EventBus(),
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
@@ -455,10 +460,10 @@ async def test_shared_candidate_stays_readable_during_concurrent_submit(
     tmp_path: Path,
 ) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
-    content_dir, source_dir = _copy_plugins(tmp_path)
+    content_dir, source_dir, probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     manager = PluginManager(
-        plugin_dirs=[content_dir, source_dir],
+        plugin_dirs=[content_dir, source_dir, probe_dir],
         event_bus=EventBus(),
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
@@ -539,10 +544,10 @@ async def test_shared_candidate_stays_readable_during_concurrent_submit(
 async def test_candidate_readiness_rejects_unknown_content_schema(
     tmp_path: Path,
 ) -> None:
-    content_dir, source_dir = _copy_plugins(tmp_path)
+    content_dir, source_dir, probe_dir = _copy_plugins(tmp_path)
     workspace = tmp_path / "workspace"
     manager = PluginManager(
-        plugin_dirs=[content_dir, source_dir],
+        plugin_dirs=[content_dir, source_dir, probe_dir],
         event_bus=EventBus(),
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
@@ -571,9 +576,20 @@ def test_fixture_declares_its_own_structural_content_protocol() -> None:
     source = (
         root / "tests" / "fixtures" / "content_clock_source" / "plugin.py"
     ).read_text(encoding="utf-8")
+    probe = (
+        root / "tests" / "fixtures" / "content_hint_probe" / "plugin.py"
+    ).read_text(encoding="utf-8")
 
     assert "from plugins.content" not in source
     assert 'ServiceKey[ContentSourceServices]("content.source.v1")' in source
+    assert "CONTENT_WAKE" not in source
+    assert "CONTENT_CHANGED" not in source
     assert "SCOPED_TURNS" not in source
     assert "DELIVERIES" not in source
     assert "MCP_SERVERS" not in source
+    assert "from plugins.content" not in probe
+    assert 'ServiceKey[ContentWakeServices]("content.wake.v1")' in probe
+    assert 'EmitEventKey[None]("content.changed")' in probe
+    assert "CONTENT_SOURCE" not in probe
+    assert "TIMERS" not in probe
+    assert "SCOPED_TURNS" not in probe

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -284,6 +284,7 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         assert recovered is not None
         assert recovered["selection_token"] == selected["selection_token"]
         assert "settlement_ref" not in recovered
+        assert candidate_wake.selected() == (recovered,)
         assert candidate_wake.snapshot(now)["items"] == ()
         with pytest.raises(PermissionError, match="read-only candidate"):
             candidate_source.submit(

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -468,15 +468,11 @@ async def test_shared_candidate_stays_readable_during_concurrent_submit(
         workspace=workspace,
         installed_cache_root=tmp_path / "cache",
     )
-    await manager.load_all()
-    snapshot = manager.current_snapshot
-    assert snapshot is not None and snapshot.composition_root is not None
-    source = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
-        "clone-stress"
-    )
     started = threading.Event()
     stop = threading.Event()
     written = 0
+    candidate = None
+    writer: asyncio.Task[None] | None = None
 
     def submit_until_stopped() -> None:
         nonlocal written
@@ -497,47 +493,58 @@ async def test_shared_candidate_stays_readable_during_concurrent_submit(
             started.set()
             time.sleep(0.0005)
 
-    writer = asyncio.create_task(asyncio.to_thread(submit_until_stopped))
-    candidate = None
     try:
-        await asyncio.to_thread(started.wait)
-        with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
-            handle.write("\n# concurrent clone fixture revision\n")
-        candidate = await manager.prepare_candidate("content_clock_source")
-        assert candidate is not None and candidate.runtime_snapshot is not None
-        candidate_root = candidate.runtime_snapshot.composition_root
-        assert candidate_root is not None
-        candidate_runtime = candidate_root.plugin_runtime("content")
-        formal_path = (
-            workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        await manager.load_all()
+        snapshot = manager.current_snapshot
+        assert snapshot is not None and snapshot.composition_root is not None
+        source = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
+            "clone-stress"
         )
-        assert candidate_runtime.data_access == "read_only"
-        assert candidate_runtime.data_dir / "content.sqlite3" == formal_path
-        candidate_wake = candidate_root.context.require(CONTENT_WAKE)
-        candidate_snapshot = candidate_wake.snapshot(now)
-        assert 1 <= len(candidate_snapshot["items"]) <= written
-        assert candidate_wake.selection(
-            {"session_id": "wake:candidate", "turn_id": "turn:missing"}
-        ) is None
-        candidate_source = candidate_root.context.require(CONTENT_SOURCE).bind(
-            "concurrent-candidate-probe"
-        )
-        with pytest.raises(PermissionError, match="read-only candidate"):
-            candidate_source.submit("poll:forbidden", ())
-    finally:
-        stop.set()
-        await writer
+        writer = asyncio.create_task(asyncio.to_thread(submit_until_stopped))
+        try:
+            await asyncio.to_thread(started.wait)
+            with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
+                handle.write("\n# concurrent clone fixture revision\n")
+            candidate = await manager.prepare_candidate("content_clock_source")
+            assert candidate is not None and candidate.runtime_snapshot is not None
+            candidate_root = candidate.runtime_snapshot.composition_root
+            assert candidate_root is not None
+            candidate_runtime = candidate_root.plugin_runtime("content")
+            formal_path = (
+                workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+            )
+            assert candidate_runtime.data_access == "read_only"
+            assert candidate_runtime.data_dir / "content.sqlite3" == formal_path
+            candidate_wake = candidate_root.context.require(CONTENT_WAKE)
+            candidate_snapshot = candidate_wake.snapshot(now)
+            candidate_count = len(candidate_snapshot["items"])
+            assert candidate_count >= 1
+            assert candidate_wake.selection(
+                {"session_id": "wake:candidate", "turn_id": "turn:missing"}
+            ) is None
+            candidate_source = candidate_root.context.require(CONTENT_SOURCE).bind(
+                "concurrent-candidate-probe"
+            )
+            with pytest.raises(PermissionError, match="read-only candidate"):
+                candidate_source.submit("poll:forbidden", ())
+        finally:
+            stop.set()
+            await writer
 
-    try:
+        assert candidate_count <= written
         formal_store = ContentStore(
             workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
         )
-
         assert sum(formal_store.state_counts().values()) == written
     finally:
-        if candidate is not None:
-            await manager.discard_prepared("content_clock_source")
-        await manager.terminate_all()
+        stop.set()
+        if writer is not None and not writer.done():
+            await writer
+        try:
+            if candidate is not None:
+                await manager.discard_prepared("content_clock_source")
+        finally:
+            await manager.terminate_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -6,6 +6,7 @@ import shutil
 import sqlite3
 import threading
 import time
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
@@ -18,10 +19,12 @@ from agent.plugin_composition import ServiceKey
 from agent.plugin_composition.timers import PluginTimers
 from agent.plugins.manager import PluginManager
 from bus.event_bus import EventBus
+from plugins.content import plugin as content_plugin
 from plugins.content.plugin import ContentSourceServices, ContentWakeServices
 from plugins.content.store import ContentStore
 from tests.fixtures.content_clock_source.plugin import (
     BoundContentSource,
+    CONTENT_HINT_PROBE,
     FixtureSourceStore,
     SourceRuntime,
 )
@@ -143,7 +146,7 @@ async def test_real_v3_loader_timer_and_stores_submit_before_cursor(
 
 
 @pytest.mark.asyncio
-async def test_submit_crash_before_cursor_repolls_without_duplicate_content(
+async def test_hint_listener_failure_repolls_before_cursor_without_duplicate_content(
     tmp_path: Path,
 ) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
@@ -151,37 +154,50 @@ async def test_submit_crash_before_cursor_repolls_without_duplicate_content(
     source_store.seed(({"kind": "feed"},), now)
     content_store = ContentStore(tmp_path / "content.sqlite3")
 
-    class Bound:
+    visible_snapshots: list[dict[str, object]] = []
+
+    def changed() -> None:
+        visible_snapshots.append(content_store.snapshot(now))
+        if len(visible_snapshots) == 1:
+            raise RuntimeError("hint listener failed")
+
+    bound = content_plugin._SourceServices(content_store, changed).bind("clock-feed")
+    successful_receipts: list[Mapping[str, object]] = []
+
+    class RecordingBound:
         def submit(self, batch_id, items):
-            return content_store.submit("clock-feed", batch_id, items)
+            receipt = bound.submit(batch_id, items)
+            successful_receipts.append(receipt)
+            return receipt
 
     first_timer = _Timer(now)
-
-    def crash() -> None:
-        raise RuntimeError("crash after submit")
 
     first = SourceRuntime(
         source_store,
         PluginTimers(first_timer),
-        cast(BoundContentSource, Bound()),
+        cast(BoundContentSource, RecordingBound()),
         now=lambda: now,
-        after_submit=crash,
     )
     await first.start()
     task = first._task
     assert task is not None
     first_timer.handles[0].fire()
-    with pytest.raises(RuntimeError, match="crash after submit"):
+    with pytest.raises(RuntimeError, match="hint listener failed"):
         await task
 
     assert source_store.state(now)["cursor"] == 0
     assert content_store.state_counts() == {"pending": 1}
+    cursor, items = source_store.poll()
+    persisted_receipt = content_store.submit("clock-feed", "poll:0:1", items)
+    assert cursor == 0
+    assert len(visible_snapshots) == 1
+    assert visible_snapshots[0]["items"][0]["ref"]["item_id"] == "event-1"
 
     second_timer = _Timer(now)
     second = SourceRuntime(
         source_store,
         PluginTimers(second_timer),
-        cast(BoundContentSource, Bound()),
+        cast(BoundContentSource, RecordingBound()),
         now=lambda: now,
     )
     await second.start()
@@ -190,7 +206,49 @@ async def test_submit_crash_before_cursor_repolls_without_duplicate_content(
 
     assert content_store.state_counts() == {"pending": 1}
     assert source_store.state(now)["poll_count"] == 1
+    assert len(visible_snapshots) == 2
+    assert successful_receipts == [persisted_receipt]
     await second.close()
+
+
+@pytest.mark.asyncio
+async def test_content_submit_without_changed_listener_still_succeeds(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    content_dir, _source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    manager = PluginManager(
+        plugin_dirs=[content_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    try:
+        snapshot = manager.current_snapshot
+        assert snapshot is not None and snapshot.composition_root is not None
+        source = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
+            "no-listener"
+        )
+
+        receipt = source.submit(
+            "poll:1",
+            (
+                {
+                    "item_id": "one",
+                    "revision": "1",
+                    "payload": {"kind": "no-listener"},
+                    "not_before": now,
+                },
+            ),
+        )
+
+        assert receipt["inserted"] == [
+            {"source_id": "no-listener", "item_id": "one", "revision": "1"}
+        ]
+    finally:
+        await manager.terminate_all()
 
 
 @pytest.mark.asyncio
@@ -230,6 +288,8 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         snapshot = manager.current_snapshot
         assert snapshot is not None and snapshot.composition_root is not None
         wake = snapshot.composition_root.context.require(CONTENT_WAKE)
+        hint_probe = snapshot.composition_root.context.require(CONTENT_HINT_PROBE)
+        assert hint_probe.count == 0
         content = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
             "candidate-probe"
         )
@@ -245,6 +305,25 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
             ),
         )
         assert receipt["high_watermark"] == 1
+        repeated = content.submit(
+            "poll:1",
+            (
+                {
+                    "item_id": "candidate-row",
+                    "revision": "1",
+                    "payload": {"kind": "candidate"},
+                    "not_before": now,
+                },
+            ),
+        )
+        assert repeated == receipt
+        assert hint_probe.count == 2
+        visible_counts: list[int] = []
+        for view in hint_probe.snapshots:
+            items = view["items"]
+            assert isinstance(items, tuple)
+            visible_counts.append(len(items))
+        assert visible_counts == [1, 1]
         frozen = wake.snapshot(now)
         accepted = {
             "session_id": "wake:candidate",
@@ -280,6 +359,8 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         candidate_source = candidate_root.context.require(CONTENT_SOURCE).bind(
             "candidate-write-probe"
         )
+        candidate_hint_probe = candidate_root.context.require(CONTENT_HINT_PROBE)
+        assert candidate_hint_probe.count == 0
         recovered = candidate_wake.selection(accepted)
         assert recovered is not None
         assert recovered["selection_token"] == selected["selection_token"]
@@ -298,6 +379,7 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
                     },
                 ),
             )
+        assert candidate_hint_probe.count == 0
         assert sum(len(timer.handles) for timer in timers) == 1
         assert source_store.state(now) == before
         assert _sqlite_hashes(content_path) == formal_hashes

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import shutil
+import sqlite3
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import agent.plugins.manager as plugin_manager_module
+from agent.control.timer import TimerReceipt, TimerStatus
+from agent.plugin_composition import ServiceKey
+from agent.plugin_composition.timers import PluginTimers
+from agent.plugins.manager import PluginManager
+from bus.event_bus import EventBus
+from plugins.content.plugin import ContentSourceServices, ContentWakeServices
+from plugins.content.store import ContentStore
+from tests.fixtures.content_clock_source.plugin import (
+    BoundContentSource,
+    FixtureSourceStore,
+    SourceRuntime,
+)
+
+CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
+CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+
+
+class _TimerHandle:
+    def __init__(self, timer_id: str, deadline: datetime, now: datetime) -> None:
+        self._id = timer_id
+        self.deadline = deadline
+        self.now = now
+        self.future: asyncio.Future[TimerReceipt] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    async def result(self) -> TimerReceipt:
+        return await asyncio.shield(self.future)
+
+    async def cancel(self) -> TimerReceipt:
+        if not self.future.done():
+            self.future.set_result(self._receipt(TimerStatus.CANCELLED))
+        return await self.future
+
+    async def cleanup(self) -> None:
+        _ = await self.cancel()
+
+    def fire(self) -> None:
+        self.future.set_result(self._receipt(TimerStatus.FIRED))
+
+    def _receipt(self, status: TimerStatus) -> TimerReceipt:
+        return TimerReceipt(self.id, self.deadline, self.now, status)
+
+
+class _Timer:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.handles: list[_TimerHandle] = []
+
+    def schedule(self, deadline: datetime) -> _TimerHandle:
+        handle = _TimerHandle(f"timer:{len(self.handles)}", deadline, self.now)
+        self.handles.append(handle)
+        return handle
+
+
+async def _eventually(predicate) -> None:
+    for _ in range(200):
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition did not settle")
+
+
+def _copy_plugins(tmp_path: Path) -> tuple[Path, Path]:
+    root = Path(__file__).resolve().parents[1]
+    content = tmp_path / "plugins" / "content"
+    source = tmp_path / "plugins" / "content_clock_source"
+    shutil.copytree(root / "plugins" / "content", content)
+    shutil.copytree(
+        root / "tests" / "fixtures" / "content_clock_source",
+        source,
+    )
+    return content, source
+
+
+def _sqlite_hashes(path: Path) -> dict[str, str]:
+    return {
+        candidate.name: hashlib.sha256(candidate.read_bytes()).hexdigest()
+        for candidate in sorted(path.parent.glob(path.name + "*"))
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_v3_loader_timer_and_stores_submit_before_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    timer = _Timer(now)
+    monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", lambda: timer)
+    content_dir, source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    source_store = FixtureSourceStore(
+        workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
+    )
+    source_store.seed(({"kind": "sleep", "score": 92},), now)
+    manager = PluginManager(
+        plugin_dirs=[content_dir, source_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    lifecycle = asyncio.create_task(manager.run_runtime_services())
+    try:
+        await _eventually(lambda: len(timer.handles) == 1)
+        timer.handles[0].fire()
+        await _eventually(lambda: source_store.state(now)["cursor"] == 1)
+
+        content_store = ContentStore(
+            workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        )
+        assert content_store.state_counts() == {"pending": 1}
+        assert source_store.state(now)["poll_count"] == 1
+        assert len(timer.handles) == 2
+        snapshot = manager.current_snapshot
+        assert snapshot is not None and snapshot.composition_root is not None
+        wake = snapshot.composition_root.context.require(CONTENT_WAKE)
+        assert wake.snapshot(now)["wake_needed"] is True
+    finally:
+        lifecycle.cancel()
+        _ = await asyncio.gather(lifecycle, return_exceptions=True)
+        await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_submit_crash_before_cursor_repolls_without_duplicate_content(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    source_store = FixtureSourceStore(tmp_path / "source.sqlite3")
+    source_store.seed(({"kind": "feed"},), now)
+    content_store = ContentStore(tmp_path / "content.sqlite3")
+
+    class Bound:
+        def submit(self, batch_id, items):
+            return content_store.submit("clock-feed", batch_id, items)
+
+    first_timer = _Timer(now)
+
+    def crash() -> None:
+        raise RuntimeError("crash after submit")
+
+    first = SourceRuntime(
+        source_store,
+        PluginTimers(first_timer),
+        cast(BoundContentSource, Bound()),
+        now=lambda: now,
+        after_submit=crash,
+    )
+    await first.start()
+    task = first._task
+    assert task is not None
+    first_timer.handles[0].fire()
+    with pytest.raises(RuntimeError, match="crash after submit"):
+        await task
+
+    assert source_store.state(now)["cursor"] == 0
+    assert content_store.state_counts() == {"pending": 1}
+
+    second_timer = _Timer(now)
+    second = SourceRuntime(
+        source_store,
+        PluginTimers(second_timer),
+        cast(BoundContentSource, Bound()),
+        now=lambda: now,
+    )
+    await second.start()
+    second_timer.handles[0].fire()
+    await _eventually(lambda: source_store.state(now)["cursor"] == 1)
+
+    assert content_store.state_counts() == {"pending": 1}
+    assert source_store.state(now)["poll_count"] == 1
+    await second.close()
+
+
+@pytest.mark.asyncio
+async def test_candidate_root_has_no_timer_poll_or_formal_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    timers: list[_Timer] = []
+
+    def timer_factory() -> _Timer:
+        timer = _Timer(now)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", timer_factory)
+    content_dir, source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    source_store = FixtureSourceStore(
+        workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
+    )
+    source_store.seed(({"kind": "calendar"},), now + timedelta(hours=1))
+    manager = PluginManager(
+        plugin_dirs=[content_dir, source_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    lifecycle = asyncio.create_task(manager.run_runtime_services())
+    try:
+        await _eventually(lambda: sum(len(timer.handles) for timer in timers) == 1)
+        before = source_store.state(now)
+        content_path = workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        assert content_path.is_file()
+        snapshot = manager.current_snapshot
+        assert snapshot is not None and snapshot.composition_root is not None
+        content = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
+            "candidate-probe"
+        )
+        receipt = content.submit(
+            "poll:1",
+            (
+                {
+                    "item_id": "candidate-row",
+                    "revision": "1",
+                    "payload": {"kind": "candidate"},
+                    "not_before": now,
+                },
+            ),
+        )
+        assert receipt["high_watermark"] == 1
+        formal_hashes = _sqlite_hashes(content_path)
+
+        with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n# candidate fixture revision\n")
+        candidate = await manager.prepare_candidate("content_clock_source")
+
+        assert candidate is not None
+        assert candidate.runtime_snapshot is not None
+        candidate_content = candidate.runtime_snapshot.generations["content"]
+        candidate_path = candidate_content.data_dir / "content.sqlite3"
+        candidate_store = ContentStore(candidate_path)
+        candidate_store.initialize()
+        assert candidate_store.state_counts() == {"pending": 1}
+        assert sum(len(timer.handles) for timer in timers) == 1
+        assert source_store.state(now) == before
+        assert _sqlite_hashes(content_path) == formal_hashes
+        await manager.discard_prepared("content_clock_source")
+    finally:
+        lifecycle.cancel()
+        _ = await asyncio.gather(lifecycle, return_exceptions=True)
+        await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_promotion_drains_old_wait_and_only_new_root_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    timers: list[_Timer] = []
+
+    def timer_factory() -> _Timer:
+        timer = _Timer(now)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", timer_factory)
+    content_dir, source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    source_store = FixtureSourceStore(
+        workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
+    )
+    source_store.seed(({"kind": "future"},), now + timedelta(hours=1))
+    manager = PluginManager(
+        plugin_dirs=[content_dir, source_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    lifecycle = asyncio.create_task(manager.run_runtime_services())
+    try:
+        await _eventually(lambda: sum(len(timer.handles) for timer in timers) == 1)
+        old_handle = next(timer.handles[0] for timer in timers if timer.handles)
+
+        with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n# promoted fixture revision\n")
+        assert await manager.prepare_candidate("content_clock_source") is not None
+        result = await manager.publish_prepared("content_clock_source")
+
+        assert result["publication_state"] == "committed"
+        await _eventually(
+            lambda: sum(
+                not handle.future.done() for timer in timers for handle in timer.handles
+            )
+            == 1
+        )
+        assert old_handle.future.result().status is TimerStatus.CANCELLED
+        assert source_store.state(now)["poll_count"] == 0
+    finally:
+        lifecycle.cancel()
+        _ = await asyncio.gather(lifecycle, return_exceptions=True)
+        await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_clone_stays_readable_during_concurrent_submit(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    content_dir, source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    manager = PluginManager(
+        plugin_dirs=[content_dir, source_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    snapshot = manager.current_snapshot
+    assert snapshot is not None and snapshot.composition_root is not None
+    source = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
+        "clone-stress"
+    )
+    started = threading.Event()
+    stop = threading.Event()
+    written = 0
+
+    def submit_until_stopped() -> None:
+        nonlocal written
+        while not stop.is_set() and written < 2_000:
+            sequence = written + 1
+            _ = source.submit(
+                f"poll:{sequence}",
+                (
+                    {
+                        "item_id": f"item-{sequence}",
+                        "revision": "1",
+                        "payload": {"sequence": sequence},
+                        "not_before": now,
+                    },
+                ),
+            )
+            written = sequence
+            started.set()
+            time.sleep(0.0005)
+
+    writer = asyncio.create_task(asyncio.to_thread(submit_until_stopped))
+    candidate = None
+    try:
+        await asyncio.to_thread(started.wait)
+        with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n# concurrent clone fixture revision\n")
+        candidate = await manager.prepare_candidate("content_clock_source")
+        assert candidate is not None and candidate.runtime_snapshot is not None
+    finally:
+        stop.set()
+        await writer
+
+    try:
+        candidate_path = (
+            candidate.runtime_snapshot.generations["content"].data_dir
+            / "content.sqlite3"
+        )
+        candidate_store = ContentStore(candidate_path)
+        candidate_store.initialize()
+        candidate_count = sum(candidate_store.state_counts().values())
+        formal_store = ContentStore(
+            workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        )
+
+        assert 1 <= candidate_count <= written
+        assert sum(formal_store.state_counts().values()) == written
+    finally:
+        if candidate is not None:
+            await manager.discard_prepared("content_clock_source")
+        await manager.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_candidate_readiness_rejects_unknown_content_schema(
+    tmp_path: Path,
+) -> None:
+    content_dir, source_dir = _copy_plugins(tmp_path)
+    workspace = tmp_path / "workspace"
+    manager = PluginManager(
+        plugin_dirs=[content_dir, source_dir],
+        event_bus=EventBus(),
+        workspace=workspace,
+        installed_cache_root=tmp_path / "cache",
+    )
+    await manager.load_all()
+    content_path = workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+    connection = sqlite3.connect(content_path)
+    connection.execute("PRAGMA user_version = 99")
+    connection.close()
+    try:
+        with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n# invalid clone fixture revision\n")
+
+        assert await manager.prepare_candidate("content_clock_source") is None
+        assert manager.current_snapshot is not None
+    finally:
+        connection = sqlite3.connect(content_path)
+        connection.execute("PRAGMA user_version = 1")
+        connection.close()
+        await manager.terminate_all()
+
+
+def test_fixture_declares_its_own_structural_content_protocol() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (
+        root / "tests" / "fixtures" / "content_clock_source" / "plugin.py"
+    ).read_text(encoding="utf-8")
+
+    assert "from plugins.content" not in source
+    assert 'ServiceKey[ContentSourceServices]("content.source.v1")' in source
+    assert "SCOPED_TURNS" not in source
+    assert "DELIVERIES" not in source
+    assert "MCP_SERVERS" not in source

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -228,6 +228,7 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         assert content_path.is_file()
         snapshot = manager.current_snapshot
         assert snapshot is not None and snapshot.composition_root is not None
+        wake = snapshot.composition_root.context.require(CONTENT_WAKE)
         content = snapshot.composition_root.context.require(CONTENT_SOURCE).bind(
             "candidate-probe"
         )
@@ -243,6 +244,15 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
             ),
         )
         assert receipt["high_watermark"] == 1
+        frozen = wake.snapshot(now)
+        accepted = {
+            "session_id": "wake:candidate",
+            "turn_id": "turn:accepted",
+        }
+        selected = wake.select(
+            frozen["items"][0]["ref"], frozen["snapshot_seq"], accepted, now
+        )
+        assert selected["selected"] is True
         formal_hashes = _sqlite_hashes(content_path)
 
         with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
@@ -255,7 +265,11 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         candidate_path = candidate_content.data_dir / "content.sqlite3"
         candidate_store = ContentStore(candidate_path)
         candidate_store.initialize()
-        assert candidate_store.state_counts() == {"pending": 1}
+        recovered = candidate_store.selection(accepted)
+        assert recovered is not None
+        assert recovered["selection_token"] == selected["selection_token"]
+        assert "settlement_ref" not in recovered
+        assert candidate_store.state_counts() == {"selected": 1}
         assert sum(len(timer.handles) for timer in timers) == 1
         assert source_store.state(now) == before
         assert _sqlite_hashes(content_path) == formal_hashes

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -96,7 +96,6 @@ def _sqlite_hashes(path: Path) -> dict[str, str]:
     return {
         candidate.name: hashlib.sha256(candidate.read_bytes()).hexdigest()
         for candidate in sorted(path.parent.glob(path.name + "*"))
-        if not candidate.name.endswith("-shm")
     }
 
 
@@ -261,7 +260,6 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         formal_mtimes = {
             path.name: path.stat().st_mtime_ns
             for path in content_path.parent.glob(content_path.name + "*")
-            if not path.name.endswith("-shm")
         }
 
         with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
@@ -305,7 +303,6 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
         assert {
             path.name: path.stat().st_mtime_ns
             for path in content_path.parent.glob(content_path.name + "*")
-            if not path.name.endswith("-shm")
         } == formal_mtimes
         await manager.discard_prepared("content_clock_source")
         assert content_path.is_file()

--- a/tests/test_content_v3_composition.py
+++ b/tests/test_content_v3_composition.py
@@ -96,6 +96,7 @@ def _sqlite_hashes(path: Path) -> dict[str, str]:
     return {
         candidate.name: hashlib.sha256(candidate.read_bytes()).hexdigest()
         for candidate in sorted(path.parent.glob(path.name + "*"))
+        if not candidate.name.endswith("-shm")
     }
 
 
@@ -221,6 +222,7 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
     )
     await manager.load_all()
     lifecycle = asyncio.create_task(manager.run_runtime_services())
+    formal_reader: sqlite3.Connection | None = None
     try:
         await _eventually(lambda: sum(len(timer.handles) for timer in timers) == 1)
         before = source_store.state(now)
@@ -253,28 +255,64 @@ async def test_candidate_root_has_no_timer_poll_or_formal_write(
             frozen["items"][0]["ref"], frozen["snapshot_seq"], accepted, now
         )
         assert selected["selected"] is True
+        formal_reader = sqlite3.connect(content_path)
+        assert formal_reader.execute("SELECT COUNT(*) FROM items").fetchone() == (1,)
         formal_hashes = _sqlite_hashes(content_path)
+        formal_mtimes = {
+            path.name: path.stat().st_mtime_ns
+            for path in content_path.parent.glob(content_path.name + "*")
+            if not path.name.endswith("-shm")
+        }
 
         with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:
             handle.write("\n# candidate fixture revision\n")
         candidate = await manager.prepare_candidate("content_clock_source")
 
-        assert candidate is not None
-        assert candidate.runtime_snapshot is not None
+        assert candidate is not None and candidate.runtime_snapshot is not None
         candidate_content = candidate.runtime_snapshot.generations["content"]
         candidate_path = candidate_content.data_dir / "content.sqlite3"
-        candidate_store = ContentStore(candidate_path)
-        candidate_store.initialize()
-        recovered = candidate_store.selection(accepted)
+        candidate_root = candidate.runtime_snapshot.composition_root
+        assert candidate_root is not None
+        candidate_runtime = candidate_root.plugin_runtime("content")
+        assert candidate_content.static_manifest is not None
+        assert candidate_content.static_manifest.candidate_data_mode == "shared_read"
+        assert candidate_runtime.data_access == "read_only"
+        assert candidate_path == content_path
+        candidate_wake = candidate_root.context.require(CONTENT_WAKE)
+        candidate_source = candidate_root.context.require(CONTENT_SOURCE).bind(
+            "candidate-write-probe"
+        )
+        recovered = candidate_wake.selection(accepted)
         assert recovered is not None
         assert recovered["selection_token"] == selected["selection_token"]
         assert "settlement_ref" not in recovered
-        assert candidate_store.state_counts() == {"selected": 1}
+        assert candidate_wake.snapshot(now)["items"] == ()
+        with pytest.raises(PermissionError, match="read-only candidate"):
+            candidate_source.submit(
+                "poll:1",
+                (
+                    {
+                        "item_id": "forbidden",
+                        "revision": "1",
+                        "payload": {"kind": "candidate-write"},
+                        "not_before": now,
+                    },
+                ),
+            )
         assert sum(len(timer.handles) for timer in timers) == 1
         assert source_store.state(now) == before
         assert _sqlite_hashes(content_path) == formal_hashes
+        assert {
+            path.name: path.stat().st_mtime_ns
+            for path in content_path.parent.glob(content_path.name + "*")
+            if not path.name.endswith("-shm")
+        } == formal_mtimes
         await manager.discard_prepared("content_clock_source")
+        assert content_path.is_file()
+        assert ContentStore(content_path).selection(accepted) == recovered
     finally:
+        if formal_reader is not None:
+            formal_reader.close()
         lifecycle.cancel()
         _ = await asyncio.gather(lifecycle, return_exceptions=True)
         await manager.terminate_all()
@@ -333,7 +371,7 @@ async def test_promotion_drains_old_wait_and_only_new_root_recovers(
 
 
 @pytest.mark.asyncio
-async def test_candidate_clone_stays_readable_during_concurrent_submit(
+async def test_shared_candidate_stays_readable_during_concurrent_submit(
     tmp_path: Path,
 ) -> None:
     now = datetime(2026, 8, 23, 5, tzinfo=UTC)
@@ -382,23 +420,34 @@ async def test_candidate_clone_stays_readable_during_concurrent_submit(
             handle.write("\n# concurrent clone fixture revision\n")
         candidate = await manager.prepare_candidate("content_clock_source")
         assert candidate is not None and candidate.runtime_snapshot is not None
+        candidate_root = candidate.runtime_snapshot.composition_root
+        assert candidate_root is not None
+        candidate_runtime = candidate_root.plugin_runtime("content")
+        formal_path = (
+            workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        )
+        assert candidate_runtime.data_access == "read_only"
+        assert candidate_runtime.data_dir / "content.sqlite3" == formal_path
+        candidate_wake = candidate_root.context.require(CONTENT_WAKE)
+        candidate_snapshot = candidate_wake.snapshot(now)
+        assert 1 <= len(candidate_snapshot["items"]) <= written
+        assert candidate_wake.selection(
+            {"session_id": "wake:candidate", "turn_id": "turn:missing"}
+        ) is None
+        candidate_source = candidate_root.context.require(CONTENT_SOURCE).bind(
+            "concurrent-candidate-probe"
+        )
+        with pytest.raises(PermissionError, match="read-only candidate"):
+            candidate_source.submit("poll:forbidden", ())
     finally:
         stop.set()
         await writer
 
     try:
-        candidate_path = (
-            candidate.runtime_snapshot.generations["content"].data_dir
-            / "content.sqlite3"
-        )
-        candidate_store = ContentStore(candidate_path)
-        candidate_store.initialize()
-        candidate_count = sum(candidate_store.state_counts().values())
         formal_store = ContentStore(
             workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
         )
 
-        assert 1 <= candidate_count <= written
         assert sum(formal_store.state_counts().values()) == written
     finally:
         if candidate is not None:
@@ -422,6 +471,7 @@ async def test_candidate_readiness_rejects_unknown_content_schema(
     content_path = workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
     connection = sqlite3.connect(content_path)
     connection.execute("PRAGMA user_version = 99")
+    connection.commit()
     connection.close()
     try:
         with (source_dir / "plugin.py").open("a", encoding="utf-8") as handle:

--- a/tests/test_plugin_packages.py
+++ b/tests/test_plugin_packages.py
@@ -59,6 +59,7 @@ def test_manager_discover_reads_each_package_file_once(
     ]
     assert [(mod["name"], mod["package_id"], mod["source_type"]) for mod in mods] == [
         ("akasha", "", "builtin"),
+        ("content", "", "builtin"),
         ("default_memory", "", "builtin"),
         ("scheduler", "", "builtin"),
         ("subagent", "", "builtin"),


### PR DESCRIPTION
## 问题与结果

- 解决的问题：主动来源缺少一个不拥有时钟、模型和投递的持久 Content 邮箱；大数据库候选校验也不能继续整库复制。
- 用户可见结果：普通 v3 来源按 `poll → Content.submit → cursor/next_due → re-arm` 组合已有 Timer；提交后发出可丢失空 hint；Wake 获得冻结 snapshot、accepted-Turn-bound CAS selection 与 selected 只读恢复视图；Content 候选直接只读同一正式库。
- 本 PR 不处理：Wake/Drift admission、通用 delivery settlement、真实来源插件迁移、旧 proactive island 删除与生产激活。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：普通 v3 source 与后续 Wake/Delivery 插件
- `runtime_patch`：`none`
- `runtime_patch_reason`：复用父层提供的 Service、Timer、candidate `shared_read` 与 Root writer handoff。
- `authoritative_state_owner`：Content 拥有 inbox/selection；每个 source 拥有 upstream cursor 与 ACK；delivery settlement 不归 Wake。
- `client_only_alternative`：不适用。
- `concept_gate`：`required`
- `concept_gate_reason`：新增跨插件持久 capability 与状态 owner。
- 关联不变量：Content 无 Timer/Turn/MCP/delivery loop；source identity 幂等；hint 只在 submit commit 后发出且不承载事实；selection 绑定 accepted Turn；selected 枚举不复制 Turn 状态；无 DELETE；candidate 只读 formal state。
- `protected_state`：Session messages、正式 plugin-data、来源 cursor、旧 proactive 状态。
- 允许的副作用：formal Content Root 追加/转换自己的 SQLite 状态；fixture source 推进自己的 cursor/deadline。
- 禁止的副作用：candidate 写 formal state、Wake 写 settlement ref、Content 自行 poll/启动 Turn/投递、自动删除旧状态。

## 改动范围

- 主要文件：`plugins/content/**`、`tests/fixtures/content_clock_source/**`、Content store/组合测试。
- 配置或迁移影响：builtin 静态 manifest 声明 `candidate_data_mode="shared_read"`；首次 formal 安装建立 `plugin-data/content-*/content.sqlite3`。
- 已知 schema lineage 与最终 schema identity：新建 `user_version=1`；精确核对 owned tables、列、PK/UNIQUE/CHECK/default、全部索引与 singleton；同版本异构 schema fail-loud。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `5baa7bb78ea7522c47772b9e11c3021741ae870a`；head `96c2f69c92928e652b5f36b5593df39f7a86dffe`；provider 不适用；fixtures `content_clock_source` 与独立 `content_hint_probe`。
- 回滚方式：revert 本 PR；备份 `/mnt/data/coding/backups/akasic-agent-content-selected-read-20260823/pre-selected-read-14c15aee.bundle`。

## 验证

- [x] 相关 targeted tests 已通过：Content/manifest/composition loader 共 `159 passed`。
- [x] Python 类型检查已通过：Pyright `0 errors / 0 warnings`；`git diff --check` clean。
- [x] `python docker/debug/gate.py run --base 5baa7bb78ea7522c47772b9e11c3021741ae870a` 已通过：24 个公开场景。
- `sourceDigest`：`5cf3f48feed0849741923c96fd105cca6dbd7c4b856ecbc790f71d376d56efee`
- `planDigest`：`4463b99abcefbfb27f931f11517e8e01cce2b473f1b45a6e9b95b45e1ab16c70`
- 真实设备证据：不适用；使用真实 v3 loader/Root/Timer/SQLite 的隔离组合 fixture。
- 未运行项与原因：真实 provider、真实来源与生产 workspace 留给后续 PR-F/PR-G。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：Terra / `gpt-5.6-terra` / `xhigh`
- 审查 head：`96c2f69c92928e652b5f36b5593df39f7a86dffe`
- 新增概念及其唯一 owner；没有时写 `none`：Content inbox/selection 由 Content plugin 独占；source cursor/Timer/ACK 仍由 source 独占；`candidate_data_mode` 来自父层通用 manifest。
- 无关设计轴的变化传播；没有时写 `none`：Core、Turn、Session、delivery、旧 proactive 均无变化。
- 最短正常/失败/热更新链路：poll→submit commit→lossy hint→cursor persist→re-arm；hint listener 失败时 Content 已提交而 cursor 不进，重 poll 复用 receipt；select 后崩溃由 `selected()` 找回 accepted receipt；candidate 共享只读，publish 由父层串行交接 writer。
- legacy/source-specific 残留扫描：Content 生产代码没有 source ID、Timer、Turn、MCP、proactive 或 delivery loop。
- must-fix 及处置证据：Wake settlement_ref 越界已移除；schema exact identity；selection 唯一绑定 accepted Turn；共享候选只读；selected-only restart view；hint 使用空 marker 且独立 probe 不扩大 source 权限；并发 oracle 在 writer settle 后比较并无条件 cleanup；Terra exact HEAD 最终无 must-fix。
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认。
- [x] 跨仓库或客户端改动不适用；真实 adapter 留给独立 canonical repo PR。
- [x] 当前为中间 stacked PR，无对应已完成 NOW 项。
