### PR TITLE
feat(core): add durable delivery settlement

### DIFF
--- a/agent/plugin_composition/__init__.py
+++ b/agent/plugin_composition/__init__.py
@@ -67,6 +67,13 @@ from agent.plugin_composition.continuations import (
     PluginContinuations,
 )
 from agent.plugin_composition.deliveries import DELIVERIES, PluginDeliveries
+from agent.plugin_composition.durable_deliveries import (
+    DURABLE_DELIVERIES,
+    DurableBindingAttempt,
+    DurableDeliveryRequest,
+    DurableDeliveryView,
+    PluginDurableDeliveries,
+)
 from agent.plugin_composition.timers import TIMERS, PluginTimers
 from agent.plugin_composition.runtime_lifecycle import (
     RUNTIME_STARTED,
@@ -313,6 +320,11 @@ __all__ = [
     "PluginContinuations",
     "DELIVERIES",
     "PluginDeliveries",
+    "DURABLE_DELIVERIES",
+    "DurableBindingAttempt",
+    "DurableDeliveryRequest",
+    "DurableDeliveryView",
+    "PluginDurableDeliveries",
     "TIMERS",
     "PluginTimers",
     "RUNTIME_STARTED",

--- a/agent/plugin_composition/durable_deliveries.py
+++ b/agent/plugin_composition/durable_deliveries.py
@@ -10,6 +10,7 @@ from agent.control.scoped_turn import TurnAcceptedReceipt
 from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
 from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from agent.plugin_composition.model import ServiceKey
+from session.store import validate_message_delivery_id
 
 
 def _empty_metadata() -> dict[str, object]:
@@ -30,8 +31,8 @@ class DurableDeliveryRequest:
     metadata: Mapping[str, object] = field(default_factory=_empty_metadata)
 
     def __post_init__(self) -> None:
+        _ = validate_message_delivery_id(self.logical_delivery_id)
         for name in (
-            "logical_delivery_id",
             "target_service",
             "channel",
             "recipient",
@@ -124,6 +125,13 @@ class PluginDurableDeliveries:
 
     async def submit(self, request: DurableDeliveryRequest) -> DurableDeliveryView:
         """Prepare once, then advance provider and Session effects in order."""
+
+        return await _complete_critical(self._submit_owned(request))
+
+    async def _submit_owned(
+        self, request: DurableDeliveryRequest
+    ) -> DurableDeliveryView:
+        """Complete provider receipt and projection inside one Core-owned task."""
 
         store, sender, projector = self._require_formal()
         async with self._lock:
@@ -344,3 +352,21 @@ def _state(value: object) -> Literal[
 
 
 DURABLE_DELIVERIES = ServiceKey[PluginDurableDeliveries]("core.durable_deliveries")
+
+
+async def _complete_critical(
+    awaitable: Awaitable[DurableDeliveryView],
+) -> DurableDeliveryView:
+    """Finish durable forward progress before restoring caller cancellation."""
+
+    task = asyncio.ensure_future(awaitable)
+    cancelled = False
+    while not task.done():
+        try:
+            _ = await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    result = task.result()
+    if cancelled:
+        raise asyncio.CancelledError
+    return result

--- a/agent/plugin_composition/durable_deliveries.py
+++ b/agent/plugin_composition/durable_deliveries.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Literal, cast
+
+from agent.control.scoped_turn import TurnAcceptedReceipt
+from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from agent.plugin_composition.model import ServiceKey
+
+
+def _empty_metadata() -> dict[str, object]:
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class DurableDeliveryRequest:
+    """Describe one immutable source-neutral delivery and Session projection."""
+
+    logical_delivery_id: str
+    accepted_turn: TurnAcceptedReceipt
+    target_service: str
+    channel: str
+    recipient: str
+    projection_session_id: str
+    body: str
+    metadata: Mapping[str, object] = field(default_factory=_empty_metadata)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "logical_delivery_id",
+            "target_service",
+            "channel",
+            "recipient",
+            "projection_session_id",
+        ):
+            value = getattr(self, name)
+            if not value or value.strip() != value:
+                raise ValueError(f"{name} 必须非空且无首尾空白")
+        if not isinstance(self.body, str) or not self.body:
+            raise ValueError("body 必须是非空字符串")
+        if not isinstance(self.accepted_turn, TurnAcceptedReceipt):
+            raise TypeError("accepted_turn 必须是 TurnAcceptedReceipt")
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+@dataclass(frozen=True, slots=True)
+class DurableBindingAttempt:
+    """Freeze the exact Channel binding that is about to perform provider I/O."""
+
+    attempt_id: str
+    snapshot_id: str
+    generation_id: str
+    binding_token: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableDeliveryView:
+    """Expose one immutable envelope with its current forward-only state."""
+
+    logical_delivery_id: str
+    accepted_turn: TurnAcceptedReceipt
+    target_service: str
+    channel: str
+    recipient: str
+    projection_session_id: str
+    body: str
+    metadata: Mapping[str, object]
+    state: Literal[
+        "prepared",
+        "provider_started",
+        "delivered",
+        "projected",
+        "settled",
+        "rejected",
+        "uncertain",
+    ]
+    attempt_id: str | None
+    snapshot_id: str | None
+    generation_id: str | None
+    binding_token: str | None
+    provider_receipt: Mapping[str, object] | None
+    projection_message_id: str | None
+    domain_receipt: str | None
+
+
+ProviderStarted = Callable[[DurableBindingAttempt], None]
+DurableSender = Callable[
+    [DurableDeliveryRequest, ProviderStarted], Awaitable[ChannelDeliveryReceipt]
+]
+DurableProjector = Callable[[DurableDeliveryRequest], Awaitable[str]]
+
+
+class PluginDurableDeliveries:
+    """Own provider receipt, Session projection, and durable settlement ordering."""
+
+    def __init__(
+        self,
+        store: DurableDeliveryStore | None,
+        sender: DurableSender | None,
+        projector: DurableProjector | None,
+        *,
+        recover_started: bool = True,
+    ) -> None:
+        self._store = store
+        self._sender = sender
+        self._projector = projector
+        self._lock = asyncio.Lock()
+        if store is not None:
+            store.initialize()
+            if recover_started:
+                _ = store.recover_interrupted_provider_calls()
+
+    @classmethod
+    def candidate_validation(cls) -> PluginDurableDeliveries:
+        return cls(None, None, None, recover_started=False)
+
+    @property
+    def formal(self) -> bool:
+        return self._store is not None
+
+    async def submit(self, request: DurableDeliveryRequest) -> DurableDeliveryView:
+        """Prepare once, then advance provider and Session effects in order."""
+
+        store, sender, projector = self._require_formal()
+        async with self._lock:
+            row = store.prepare(_envelope(request))
+            state = str(row["state"])
+            if state == "prepared":
+                row = await self._send(store, sender, request)
+                state = str(row["state"])
+            if state == "delivered":
+                message_id = await projector(request)
+                row = store.mark_projected(request.logical_delivery_id, message_id)
+            return _view(row)
+
+    def lookup(self, accepted_turn: TurnAcceptedReceipt) -> DurableDeliveryView | None:
+        """Read the unique logical delivery associated with an accepted Turn."""
+
+        store = self._require_store()
+        row = store.lookup(accepted_turn.session_id, accepted_turn.turn_id)
+        return None if row is None else _view(row)
+
+    def recoverable(self) -> tuple[DurableDeliveryView, ...]:
+        """Read forward-completable prepared, delivered, and projected rows."""
+
+        store = self._require_store()
+        return tuple(_view(row) for row in store.recoverable())
+
+    async def resume(self, accepted_turn: TurnAcceptedReceipt) -> DurableDeliveryView:
+        """Advance one existing prepared or delivered row without changing identity."""
+
+        current = self.lookup(accepted_turn)
+        if current is None:
+            raise KeyError(
+                f"durable delivery missing: {accepted_turn.session_id}/{accepted_turn.turn_id}"
+            )
+        return await self.submit(_request(current))
+
+    def confirm_settled(
+        self, settlement_ref: str, domain_receipt: str
+    ) -> DurableDeliveryView:
+        """Persist one opaque domain receipt after projection."""
+
+        store = self._require_store()
+        return _view(store.confirm_settled(settlement_ref, domain_receipt))
+
+    def _require_store(self) -> DurableDeliveryStore:
+        if self._store is None:
+            raise RuntimeError("candidate 验证期禁止 durable delivery")
+        return self._store
+
+    async def _send(
+        self,
+        store: DurableDeliveryStore,
+        sender: DurableSender,
+        request: DurableDeliveryRequest,
+    ) -> dict[str, object]:
+        """Persist provider_started through the sender callback before external I/O."""
+
+        started = False
+
+        def mark_started(attempt: DurableBindingAttempt) -> None:
+            nonlocal started
+            _ = store.mark_provider_started(
+                request.logical_delivery_id,
+                attempt_id=attempt.attempt_id,
+                snapshot_id=attempt.snapshot_id,
+                generation_id=attempt.generation_id,
+                binding_token=attempt.binding_token,
+            )
+            started = True
+
+        try:
+            receipt = await sender(request, mark_started)
+        except BaseException:
+            if started:
+                _ = store.mark_provider_result(
+                    request.logical_delivery_id,
+                    state="uncertain",
+                    receipt={"status": "unknown", "error": "provider call interrupted"},
+                )
+            raise
+        if not started:
+            raise RuntimeError("durable sender 未在 provider I/O 前提交 binding attempt")
+        state = {
+            DeliveryStatus.DELIVERED: "delivered",
+            DeliveryStatus.REJECTED: "rejected",
+            DeliveryStatus.UNKNOWN: "uncertain",
+        }[receipt.status]
+        return store.mark_provider_result(
+            request.logical_delivery_id,
+            state=state,
+            receipt={
+                "delivery_id": receipt.delivery_id,
+                "status": receipt.status.value,
+                "provider_ids": list(receipt.provider_ids),
+                "error": receipt.error,
+            },
+        )
+
+    def _require_formal(
+        self,
+    ) -> tuple[DurableDeliveryStore, DurableSender, DurableProjector]:
+        if self._store is None or self._sender is None or self._projector is None:
+            raise RuntimeError("durable delivery provider/Session boundary 尚未绑定")
+        return self._store, self._sender, self._projector
+
+
+def _envelope(request: DurableDeliveryRequest) -> dict[str, object]:
+    return {
+        "logical_delivery_id": request.logical_delivery_id,
+        "accepted_session_id": request.accepted_turn.session_id,
+        "accepted_turn_id": request.accepted_turn.turn_id,
+        "target_service": request.target_service,
+        "channel": request.channel,
+        "recipient": request.recipient,
+        "projection_session_id": request.projection_session_id,
+        "body": request.body,
+        "metadata": dict(request.metadata),
+    }
+
+
+def _view(row: Mapping[str, object]) -> DurableDeliveryView:
+    metadata = _mapping(row["metadata"], "metadata")
+    provider_raw = row["provider_receipt"]
+    provider_receipt = (
+        None
+        if provider_raw is None
+        else MappingProxyType(dict(_mapping(provider_raw, "provider_receipt")))
+    )
+    return DurableDeliveryView(
+        logical_delivery_id=_text(row["logical_delivery_id"], "logical_delivery_id"),
+        accepted_turn=TurnAcceptedReceipt(
+            _text(row["accepted_session_id"], "accepted_session_id"),
+            _text(row["accepted_turn_id"], "accepted_turn_id"),
+        ),
+        target_service=_text(row["target_service"], "target_service"),
+        channel=_text(row["channel"], "channel"),
+        recipient=_text(row["recipient"], "recipient"),
+        projection_session_id=_text(
+            row["projection_session_id"], "projection_session_id"
+        ),
+        body=_text(row["body"], "body"),
+        metadata=MappingProxyType(dict(metadata)),
+        state=_state(row["state"]),
+        attempt_id=_optional_text(row["attempt_id"], "attempt_id"),
+        snapshot_id=_optional_text(row["snapshot_id"], "snapshot_id"),
+        generation_id=_optional_text(row["generation_id"], "generation_id"),
+        binding_token=_optional_text(row["binding_token"], "binding_token"),
+        provider_receipt=provider_receipt,
+        projection_message_id=_optional_text(
+            row["projection_message_id"], "projection_message_id"
+        ),
+        domain_receipt=_optional_text(row["domain_receipt"], "domain_receipt"),
+    )
+
+
+def _request(view: DurableDeliveryView) -> DurableDeliveryRequest:
+    return DurableDeliveryRequest(
+        logical_delivery_id=view.logical_delivery_id,
+        accepted_turn=view.accepted_turn,
+        target_service=view.target_service,
+        channel=view.channel,
+        recipient=view.recipient,
+        projection_session_id=view.projection_session_id,
+        body=view.body,
+        metadata=view.metadata,
+    )
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"durable delivery row {field} invalid")
+    return value
+
+
+def _optional_text(value: object, field: str) -> str | None:
+    return None if value is None else _text(value, field)
+
+
+def _mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or any(
+        not isinstance(key, str) for key in value
+    ):
+        raise RuntimeError(f"durable delivery row {field} invalid")
+    return cast(Mapping[str, object], value)
+
+
+def _state(value: object) -> Literal[
+    "prepared",
+    "provider_started",
+    "delivered",
+    "projected",
+    "settled",
+    "rejected",
+    "uncertain",
+]:
+    if value not in {
+        "prepared",
+        "provider_started",
+        "delivered",
+        "projected",
+        "settled",
+        "rejected",
+        "uncertain",
+    }:
+        raise RuntimeError(f"durable delivery row state invalid: {value!r}")
+    return cast(
+        Literal[
+            "prepared",
+            "provider_started",
+            "delivered",
+            "projected",
+            "settled",
+            "rejected",
+            "uncertain",
+        ],
+        value,
+    )
+
+
+DURABLE_DELIVERIES = ServiceKey[PluginDurableDeliveries]("core.durable_deliveries")

--- a/agent/plugin_composition/durable_delivery_store.py
+++ b/agent/plugin_composition/durable_delivery_store.py
@@ -258,15 +258,16 @@ class DurableDeliveryStore:
             ).fetchall()
             return tuple(self._view(row) for row in rows)
 
-    def prepared_targets(self) -> frozenset[str]:
-        """Read only target identities that may still begin provider I/O."""
+    def forward_targets(self) -> frozenset[str]:
+        """Read target identities still needed for provider or settlement progress."""
 
         if not self.path.exists():
             return frozenset()
         self.initialize()
         with self._transaction(write=False) as connection:
             rows = connection.execute(
-                "SELECT DISTINCT target_service FROM deliveries WHERE state = 'prepared'"
+                "SELECT DISTINCT target_service FROM deliveries "
+                "WHERE state IN ('prepared', 'delivered', 'projected')"
             ).fetchall()
             return frozenset(str(row[0]) for row in rows)
 
@@ -341,6 +342,7 @@ class DurableDeliveryStore:
                 connection.execute("PRAGMA query_only = ON")
                 connection.execute("BEGIN")
             else:
+                self._validate_schema_admission(connection)
                 connection.execute("PRAGMA journal_mode = WAL")
                 connection.execute("BEGIN IMMEDIATE")
                 self._ensure_schema(connection)
@@ -362,10 +364,33 @@ class DurableDeliveryStore:
             raise RuntimeError(f"unsupported durable delivery schema: {version}")
         if version == _SCHEMA_VERSION:
             return
-        connection.executescript(
-            ";\n".join((_TABLE_SQL, _INDEX_SQL, f"PRAGMA user_version = {_SCHEMA_VERSION}"))
-            + ";"
+        DurableDeliveryStore._validate_schema_admission(connection)
+        _ = connection.execute(_TABLE_SQL)
+        _ = connection.execute(_INDEX_SQL)
+        _ = connection.execute(
+            f"PRAGMA user_version = {_SCHEMA_VERSION}"
         )
+
+    @staticmethod
+    def _validate_schema_admission(connection: sqlite3.Connection) -> None:
+        """Reject unsupported or unowned schemas before journal/schema mutation."""
+
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version == _SCHEMA_VERSION:
+            return
+        if version != 0:
+            raise RuntimeError(f"unsupported durable delivery schema: {version}")
+        objects = connection.execute(
+            "SELECT type, name FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+        if objects:
+            identities = ", ".join(
+                f"{row['type']}:{row['name']}" for row in objects
+            )
+            raise RuntimeError(
+                "durable delivery version 0 schema must be empty: " + identities
+            )
 
     @staticmethod
     def _validate_schema(connection: sqlite3.Connection) -> None:

--- a/agent/plugin_composition/durable_delivery_store.py
+++ b/agent/plugin_composition/durable_delivery_store.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Generator, Mapping, cast
+
+_SCHEMA_VERSION = 1
+_TABLE_SQL = """
+CREATE TABLE deliveries(
+    logical_delivery_id TEXT PRIMARY KEY,
+    accepted_session_id TEXT NOT NULL,
+    accepted_turn_id TEXT NOT NULL,
+    target_service TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    recipient TEXT NOT NULL,
+    projection_session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    metadata_json TEXT NOT NULL,
+    state TEXT NOT NULL CHECK(state IN (
+        'prepared', 'provider_started', 'delivered', 'projected', 'settled',
+        'rejected', 'uncertain'
+    )),
+    attempt_id TEXT,
+    snapshot_id TEXT,
+    generation_id TEXT,
+    binding_token TEXT,
+    provider_receipt_json TEXT,
+    projection_message_id TEXT,
+    domain_receipt TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(accepted_session_id, accepted_turn_id)
+)
+""".strip()
+_INDEX_SQL = """
+CREATE INDEX idx_deliveries_recoverable
+ON deliveries(state, created_at, logical_delivery_id)
+""".strip()
+
+
+def _normalize_sql(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+class DurableDeliveryStore:
+    """Persist immutable delivery envelopes and forward-only settlement state."""
+
+    def __init__(self, path: Path, *, read_only: bool = False) -> None:
+        self.path = path
+        self.read_only = read_only
+
+    def initialize(self) -> None:
+        """Create or validate the exact ledger schema."""
+
+        with self._transaction(write=not self.read_only) as connection:
+            self._validate_schema(connection)
+            result = connection.execute("PRAGMA integrity_check").fetchone()
+            if result is None or result[0] != "ok":
+                detail = "missing result" if result is None else str(result[0])
+                raise RuntimeError(
+                    f"Durable delivery SQLite integrity check failed: {detail}"
+                )
+
+    def recover_interrupted_provider_calls(self) -> int:
+        """Freeze every crash-interrupted provider call as uncertain."""
+
+        now = _utc_now()
+        with self._transaction(write=True) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE deliveries SET state = 'uncertain', updated_at = ?
+                WHERE state = 'provider_started'
+                """,
+                (now,),
+            )
+            return cursor.rowcount
+
+    def prepare(self, envelope: Mapping[str, object]) -> dict[str, object]:
+        """Insert one immutable envelope or return its exact prior row."""
+
+        normalized = _normalize_envelope(envelope)
+        now = _utc_now()
+        with self._transaction(write=True) as connection:
+            existing = self._lookup_identity(connection, normalized)
+            if existing is not None:
+                self._assert_same_envelope(existing, normalized)
+                return self._view(existing)
+            connection.execute(
+                """
+                INSERT INTO deliveries(
+                    logical_delivery_id, accepted_session_id, accepted_turn_id,
+                    target_service, channel, recipient, projection_session_id, body,
+                    metadata_json, state, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared', ?, ?)
+                """,
+                (
+                    normalized["logical_delivery_id"],
+                    normalized["accepted_session_id"],
+                    normalized["accepted_turn_id"],
+                    normalized["target_service"],
+                    normalized["channel"],
+                    normalized["recipient"],
+                    normalized["projection_session_id"],
+                    normalized["body"],
+                    normalized["metadata_json"],
+                    now,
+                    now,
+                ),
+            )
+            return self._required(connection, normalized["logical_delivery_id"])
+
+    def mark_provider_started(
+        self,
+        logical_delivery_id: str,
+        *,
+        attempt_id: str,
+        snapshot_id: str,
+        generation_id: str,
+        binding_token: str,
+    ) -> dict[str, object]:
+        """Commit the exact binding attempt before provider I/O may begin."""
+
+        fields = tuple(
+            _identity(name, value)
+            for name, value in (
+                ("logical_delivery_id", logical_delivery_id),
+                ("attempt_id", attempt_id),
+                ("snapshot_id", snapshot_id),
+                ("generation_id", generation_id),
+                ("binding_token", binding_token),
+            )
+        )
+        with self._transaction(write=True) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE deliveries
+                SET state = 'provider_started', attempt_id = ?, snapshot_id = ?,
+                    generation_id = ?, binding_token = ?, updated_at = ?
+                WHERE logical_delivery_id = ? AND state = 'prepared'
+                """,
+                (*fields[1:], _utc_now(), fields[0]),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"delivery provider_started transition invalid: {logical_delivery_id}"
+                )
+            return self._required(connection, fields[0])
+
+    def mark_provider_result(
+        self,
+        logical_delivery_id: str,
+        *,
+        state: str,
+        receipt: Mapping[str, object],
+    ) -> dict[str, object]:
+        """Commit delivered, rejected, or uncertain provider outcome."""
+
+        if state not in {"delivered", "rejected", "uncertain"}:
+            raise ValueError(f"provider result state invalid: {state}")
+        logical_id = _identity("logical_delivery_id", logical_delivery_id)
+        receipt_json = json.dumps(
+            dict(receipt), sort_keys=True, separators=(",", ":")
+        )
+        with self._transaction(write=True) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE deliveries
+                SET state = ?, provider_receipt_json = ?, updated_at = ?
+                WHERE logical_delivery_id = ? AND state = 'provider_started'
+                """,
+                (state, receipt_json, _utc_now(), logical_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"delivery provider result transition invalid: {logical_id}"
+                )
+            return self._required(connection, logical_id)
+
+    def mark_projected(
+        self, logical_delivery_id: str, message_id: str
+    ) -> dict[str, object]:
+        """Bind one delivered envelope to its canonical Session message."""
+
+        logical_id = _identity("logical_delivery_id", logical_delivery_id)
+        projected = _identity("message_id", message_id)
+        with self._transaction(write=True) as connection:
+            cursor = connection.execute(
+                """
+                UPDATE deliveries
+                SET state = 'projected', projection_message_id = ?, updated_at = ?
+                WHERE logical_delivery_id = ? AND state = 'delivered'
+                """,
+                (projected, _utc_now(), logical_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"delivery projected transition invalid: {logical_id}"
+                )
+            return self._required(connection, logical_id)
+
+    def confirm_settled(
+        self, settlement_ref: str, domain_receipt: str
+    ) -> dict[str, object]:
+        """Commit the opaque domain receipt after Session projection."""
+
+        logical_id = _identity("settlement_ref", settlement_ref)
+        opaque = _identity("domain_receipt", domain_receipt)
+        with self._transaction(write=True) as connection:
+            row = self._required(connection, logical_id)
+            if row["state"] == "settled":
+                if row["domain_receipt"] != opaque:
+                    raise RuntimeError(
+                        f"delivery settlement receipt conflict: {logical_id}"
+                    )
+                return row
+            cursor = connection.execute(
+                """
+                UPDATE deliveries
+                SET state = 'settled', domain_receipt = ?, updated_at = ?
+                WHERE logical_delivery_id = ? AND state = 'projected'
+                """,
+                (opaque, _utc_now(), logical_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"delivery settled transition invalid: {logical_id}"
+                )
+            return self._required(connection, logical_id)
+
+    def lookup(self, accepted_session_id: str, accepted_turn_id: str) -> dict[str, object] | None:
+        """Read the unique delivery associated with one accepted Turn."""
+
+        accepted_session = _identity("accepted_session_id", accepted_session_id)
+        accepted_turn = _identity("accepted_turn_id", accepted_turn_id)
+        with self._transaction(write=False) as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM deliveries
+                WHERE accepted_session_id = ? AND accepted_turn_id = ?
+                """,
+                (accepted_session, accepted_turn),
+            ).fetchone()
+            return None if row is None else self._view(row)
+
+    def recoverable(self) -> tuple[dict[str, object], ...]:
+        """Read all forward-completable rows in stable creation order."""
+
+        with self._transaction(write=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM deliveries
+                WHERE state IN ('prepared', 'delivered', 'projected')
+                ORDER BY created_at, logical_delivery_id
+                """
+            ).fetchall()
+            return tuple(self._view(row) for row in rows)
+
+    def prepared_targets(self) -> frozenset[str]:
+        """Read only target identities that may still begin provider I/O."""
+
+        if not self.path.exists():
+            return frozenset()
+        self.initialize()
+        with self._transaction(write=False) as connection:
+            rows = connection.execute(
+                "SELECT DISTINCT target_service FROM deliveries WHERE state = 'prepared'"
+            ).fetchall()
+            return frozenset(str(row[0]) for row in rows)
+
+    def _required(self, connection: sqlite3.Connection, logical_id: str) -> dict[str, object]:
+        row = connection.execute(
+            "SELECT * FROM deliveries WHERE logical_delivery_id = ?", (logical_id,)
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(f"durable delivery missing: {logical_id}")
+        return self._view(row)
+
+    @staticmethod
+    def _lookup_identity(
+        connection: sqlite3.Connection, envelope: Mapping[str, str]
+    ) -> sqlite3.Row | None:
+        rows = connection.execute(
+            """
+            SELECT * FROM deliveries
+            WHERE logical_delivery_id = ? OR (
+                accepted_session_id = ? AND accepted_turn_id = ?
+            )
+            """,
+            (
+                envelope["logical_delivery_id"],
+                envelope["accepted_session_id"],
+                envelope["accepted_turn_id"],
+            ),
+        ).fetchall()
+        if len(rows) > 1:
+            raise RuntimeError("logical delivery 与 accepted Turn identity 分裂")
+        return None if not rows else rows[0]
+
+    @staticmethod
+    def _assert_same_envelope(row: sqlite3.Row, envelope: Mapping[str, str]) -> None:
+        for field in (
+            "logical_delivery_id",
+            "accepted_session_id",
+            "accepted_turn_id",
+            "target_service",
+            "channel",
+            "recipient",
+            "projection_session_id",
+            "body",
+            "metadata_json",
+        ):
+            if row[field] != envelope[field]:
+                raise RuntimeError(
+                    f"durable delivery immutable envelope conflict: {field}"
+                )
+
+    @staticmethod
+    def _view(row: sqlite3.Row) -> dict[str, object]:
+        view = {key: row[key] for key in row.keys()}
+        view["metadata"] = json.loads(cast(str, view.pop("metadata_json")))
+        receipt = view.pop("provider_receipt_json")
+        view["provider_receipt"] = None if receipt is None else json.loads(receipt)
+        return view
+
+    @contextmanager
+    def _transaction(self, *, write: bool) -> Generator[sqlite3.Connection]:
+        if write and self.read_only:
+            raise PermissionError("durable delivery candidate store is read-only")
+        if self.read_only:
+            uri = self.path.resolve(strict=False).as_uri() + "?mode=ro"
+            connection = sqlite3.connect(uri, uri=True)
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        try:
+            if self.read_only:
+                connection.execute("PRAGMA query_only = ON")
+                connection.execute("BEGIN")
+            else:
+                connection.execute("PRAGMA journal_mode = WAL")
+                connection.execute("BEGIN IMMEDIATE")
+                self._ensure_schema(connection)
+            yield connection
+            if self.read_only:
+                connection.rollback()
+            else:
+                connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _ensure_schema(connection: sqlite3.Connection) -> None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version not in (0, _SCHEMA_VERSION):
+            raise RuntimeError(f"unsupported durable delivery schema: {version}")
+        if version == _SCHEMA_VERSION:
+            return
+        connection.executescript(
+            ";\n".join((_TABLE_SQL, _INDEX_SQL, f"PRAGMA user_version = {_SCHEMA_VERSION}"))
+            + ";"
+        )
+
+    @staticmethod
+    def _validate_schema(connection: sqlite3.Connection) -> None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version != _SCHEMA_VERSION:
+            raise RuntimeError(f"unsupported durable delivery schema: {version}")
+        tables = {
+            str(row["name"]): str(row["sql"])
+            for row in connection.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        if tables.keys() != {"deliveries"} or _normalize_sql(tables["deliveries"]) != _normalize_sql(_TABLE_SQL):
+            raise RuntimeError("durable delivery schema table identity mismatch")
+        indexes = {
+            str(row["name"]): str(row["sql"])
+            for row in connection.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type = 'index' AND sql IS NOT NULL"
+            )
+        }
+        if indexes != {"idx_deliveries_recoverable": _INDEX_SQL}:
+            raise RuntimeError("durable delivery schema index identity mismatch")
+
+
+def _normalize_envelope(envelope: Mapping[str, object]) -> dict[str, str]:
+    metadata = envelope.get("metadata")
+    if not isinstance(metadata, Mapping) or any(
+        not isinstance(key, str) for key in metadata
+    ):
+        raise ValueError("delivery metadata must be a string-key mapping")
+    normalized = {
+        field: _identity(field, envelope.get(field))
+        for field in (
+            "logical_delivery_id",
+            "accepted_session_id",
+            "accepted_turn_id",
+            "target_service",
+            "channel",
+            "recipient",
+            "projection_session_id",
+        )
+    }
+    body = envelope.get("body")
+    if not isinstance(body, str) or not body:
+        raise ValueError("body must be a non-empty string")
+    typed_metadata = cast(Mapping[str, object], metadata)
+    return normalized | {
+        "body": body,
+        "metadata_json": json.dumps(
+            dict(typed_metadata), sort_keys=True, separators=(",", ":")
+        )
+    }
+
+
+def _identity(field: str, value: object) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(f"{field} must be non-empty without surrounding whitespace")
+    return value
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -5488,24 +5488,24 @@ class PluginManager:
     def _preflight_durable_delivery_targets(
         self, snapshot: RuntimeSnapshot
     ) -> None:
-        """Fence prepared rows whose settlement service vanished from candidate."""
+        """Fence forward-completable rows whose target vanished from candidate."""
 
         store = DurableDeliveryStore(
             self._workspace / "runtime" / "deliveries" / "settlements.sqlite",
             read_only=True,
         )
-        prepared = store.prepared_targets()
-        if not prepared:
+        forward_targets = store.forward_targets()
+        if not forward_targets:
             return
         topology = snapshot.composition_topology
         if topology is None:
             raise RuntimeError(
                 "durable delivery candidate 缺少 composition topology"
             )
-        missing = tuple(sorted(prepared.difference(topology.services)))
+        missing = tuple(sorted(forward_targets.difference(topology.services)))
         if missing:
             raise RuntimeError(
-                "durable delivery prepared target service 不可解析: "
+                "durable delivery forward target service 不可解析: "
                 + ", ".join(missing)
             )
 

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -34,6 +34,7 @@ from agent.plugin_composition import (
     SCOPED_TURNS,
     CONTINUATIONS,
     DELIVERIES,
+    DURABLE_DELIVERIES,
     TIMERS,
     BACKGROUND_JOBS,
     TOOL_CATALOG,
@@ -57,6 +58,7 @@ from agent.plugin_composition import (
     PluginScopedTurns,
     PluginContinuations,
     PluginDeliveries,
+    PluginDurableDeliveries,
     PluginTimers,
     ServiceView,
     RUNTIME_STARTED,
@@ -80,6 +82,12 @@ from agent.plugin_composition.model import (
     resolve_declared_workspace_root,
 )
 from agent.control.timer import AsyncioOneShotTimer
+from agent.plugin_composition.durable_deliveries import (
+    DurableProjector,
+    DurableDeliveryRequest,
+    DurableSender,
+)
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from bus.events import ChannelMessage
 from agent.plugin_composition.channels import ChannelDeliveryReceipt
 from agent.plugins.composable import ComposablePlugin
@@ -378,6 +386,8 @@ class PluginManager:
         self._delivery_sender: (
             Callable[[ChannelMessage], Awaitable[ChannelDeliveryReceipt]] | None
         ) = None
+        self._durable_delivery_sender: DurableSender | None = None
+        self._durable_delivery_recovered = False
 
     @property
     def loaded_count(self) -> int:
@@ -417,6 +427,13 @@ class PluginManager:
         if self._delivery_sender is not None:
             raise RuntimeError("PluginManager delivery sender 已绑定")
         self._delivery_sender = sender
+
+    def bind_durable_delivery_sender(self, sender: DurableSender) -> None:
+        """Bind the two-stage provider boundary before loading durable consumers."""
+
+        if self._durable_delivery_sender is not None:
+            raise RuntimeError("PluginManager durable delivery sender 已绑定")
+        self._durable_delivery_sender = sender
 
     async def run_runtime_services(self) -> None:
         """Follow stable Roots without retaining Turn admission across reloads."""
@@ -5129,6 +5146,8 @@ class PluginManager:
                 require_composition_ready=True,
             )
             _validate_static_manifest_runtime(snapshot, generations)
+            if candidate_owner is not None:
+                self._preflight_durable_delivery_targets(snapshot)
             snapshot.tool_registry = self._compile_snapshot_tools(
                 generations,
                 snapshot.plugin_tool_catalog,
@@ -5326,6 +5345,18 @@ class PluginManager:
                     else PluginDeliveries.candidate_validation()
                 )
                 _ = await root.context.provide(DELIVERIES, deliveries)
+            if any(
+                DURABLE_DELIVERIES in cast(ComposablePlugin, item.instance).inject
+                for item in ordered
+            ):
+                durable_deliveries = (
+                    self._formal_durable_deliveries()
+                    if candidate_owner is None
+                    else PluginDurableDeliveries.candidate_validation()
+                )
+                _ = await root.context.provide(
+                    DURABLE_DELIVERIES, durable_deliveries
+                )
             if self._interaction_undo is not None and any(
                 INTERACTION_UNDO in cast(ComposablePlugin, item.instance).inject
                 for item in ordered
@@ -5422,6 +5453,62 @@ class PluginManager:
             self._composition_memory_runtime,
         )
 
+    def _formal_durable_deliveries(self) -> PluginDurableDeliveries:
+        """Build one Root-local port over the process-owned delivery ledger."""
+
+        sender = self._durable_delivery_sender
+        session_manager = self._session_manager
+        projector: DurableProjector | None = None
+        if session_manager is not None:
+
+            async def project(request: DurableDeliveryRequest) -> str:
+                return await session_manager.append_durable_delivery(
+                    session_key=request.projection_session_id,
+                    content=request.body,
+                    delivery_id=request.logical_delivery_id,
+                    control_turn_id=request.accepted_turn.turn_id,
+                )
+
+            projector = project
+
+        service = PluginDurableDeliveries(
+            DurableDeliveryStore(
+                self._workspace
+                / "runtime"
+                / "deliveries"
+                / "settlements.sqlite"
+            ),
+            sender,
+            projector,
+            recover_started=not self._durable_delivery_recovered,
+        )
+        self._durable_delivery_recovered = True
+        return service
+
+    def _preflight_durable_delivery_targets(
+        self, snapshot: RuntimeSnapshot
+    ) -> None:
+        """Fence prepared rows whose settlement service vanished from candidate."""
+
+        store = DurableDeliveryStore(
+            self._workspace / "runtime" / "deliveries" / "settlements.sqlite",
+            read_only=True,
+        )
+        prepared = store.prepared_targets()
+        if not prepared:
+            return
+        topology = snapshot.composition_topology
+        if topology is None:
+            raise RuntimeError(
+                "durable delivery candidate 缺少 composition topology"
+            )
+        missing = tuple(sorted(prepared.difference(topology.services)))
+        if missing:
+            raise RuntimeError(
+                "durable delivery prepared target service 不可解析: "
+                + ", ".join(missing)
+            )
+
     def _composition_service_view(self) -> ServiceView:
         """冻结静态 v3 声明可读取的 Core service 输入。"""
 
@@ -5450,6 +5537,7 @@ class PluginManager:
             if self._delivery_sender is not None
             else PluginDeliveries.candidate_validation()
         )
+        values[DURABLE_DELIVERIES] = PluginDurableDeliveries.candidate_validation()
         return ServiceView.freeze(values)
 
     @staticmethod

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -24,6 +24,11 @@ from agent.plugin_composition.channels import (
     JsonValue,
     OutboundEnvelope,
 )
+from agent.plugin_composition.durable_deliveries import (
+    DurableBindingAttempt,
+    DurableDeliveryRequest,
+    ProviderStarted,
+)
 from agent.plugins.manifest import plugins_root
 from agent.plugins.snapshot import lease_current_runtime_snapshot
 from agent.context import ContextBuilder
@@ -166,6 +171,87 @@ async def _dispatch_v3_channel_push(
             ),
             binding,
             passive=passive,
+        )
+    finally:
+        await binding.aclose()
+
+
+async def _dispatch_v3_durable_delivery(
+    plugin_manager: PluginManager,
+    bus: MessageBus,
+    request: DurableDeliveryRequest,
+    provider_started: ProviderStarted,
+) -> ChannelDeliveryReceipt:
+    """Persist one exact binding attempt before its direct provider dispatch."""
+
+    # 1. Resolve and retain the same committed Channel boundary as ordinary sends.
+    source = lease_current_runtime_snapshot()
+    if source is None:
+        source = await plugin_manager.snapshot_store.acquire()
+    binding = None
+    try:
+        catalog = source.snapshot.channel_catalog
+        registry = (
+            catalog.registry
+            if catalog is not None
+            else source.snapshot.channel_registry
+        )
+        descriptor = (
+            None
+            if registry is None
+            else next(
+                (
+                    item
+                    for item in registry.descriptors
+                    if item.name == request.channel
+                ),
+                None,
+            )
+        )
+        if descriptor is None:
+            raise RuntimeError(
+                f"committed Channel catalog 缺少目标渠道: {request.channel!r}"
+            )
+        binding = plugin_manager.channel_generation_host.acquire_binding(
+            source, request.channel
+        )
+    finally:
+        try:
+            await source.release()
+        except BaseException:
+            if binding is not None:
+                await binding.aclose()
+            raise
+
+    # 2. Freeze the exact binding; MessageBus commits provider_started at its adapter edge.
+    if binding is None:
+        raise RuntimeError("durable delivery exact Channel binding 未建立")
+    try:
+        attempt = DurableBindingAttempt(
+            attempt_id=request.logical_delivery_id,
+            snapshot_id=binding.snapshot_id,
+            generation_id=binding.generation_id,
+            binding_token=binding.binding_token,
+        )
+        envelope = OutboundEnvelope(
+            logical_delivery_id=request.logical_delivery_id,
+            delivery_id=request.logical_delivery_id,
+            attempt_sequence=1,
+            snapshot_id=binding.snapshot_id,
+            generation_id=binding.generation_id,
+            binding_token=binding.binding_token,
+            channel=request.channel,
+            recipient=request.recipient,
+            body=request.body,
+            metadata=cast(Mapping[str, JsonValue], request.metadata),
+            commit_role=ChannelCommitRole.DIRECT,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+        return await bus.publish_channel_outbound_awaited(
+            envelope,
+            binding,
+            passive=False,
+            before_provider=lambda: provider_started(attempt),
         )
     finally:
         await binding.aclose()
@@ -690,6 +776,14 @@ def build_core_runtime(
     )
     plugin_manager.bind_continuation_publisher(bus.publish_inbound)
     plugin_manager.bind_delivery_sender(push_tool.dispatch)
+    plugin_manager.bind_durable_delivery_sender(
+        lambda request, provider_started: _dispatch_v3_durable_delivery(
+            plugin_manager,
+            bus,
+            request,
+            provider_started,
+        )
+    )
     from agent.plugins.generation_activity_host import ActivityHost
     from agent.plugins.generation_job_host import BackgroundJobActivityAdapter
     from agent.plugins.generation_proactive_host import ProactiveActivityAdapter

--- a/bus/queue.py
+++ b/bus/queue.py
@@ -259,6 +259,7 @@ class _AwaitedChannelOutbound:
     binding: _ChannelBindingOwner
     receipt: "asyncio.Future[ChannelDeliveryReceipt]"
     passive: bool
+    before_provider: Callable[[], None] | None = None
     provider_started: bool = False
 
 
@@ -1390,6 +1391,7 @@ class MessageBus:
         binding: _ChannelBindingOwner,
         *,
         passive: bool = True,
+        before_provider: Callable[[], None] | None = None,
     ) -> ChannelDeliveryReceipt:
         """Queue one exact v3 delivery and wait for its non-retryable receipt."""
 
@@ -1420,7 +1422,9 @@ class MessageBus:
                 )
         try:
             self._outbound.put_nowait(
-                _AwaitedChannelOutbound(envelope, binding, future, passive)
+                _AwaitedChannelOutbound(
+                    envelope, binding, future, passive, before_provider
+                )
             )
         except BaseException:
             if passive:
@@ -1516,6 +1520,22 @@ class MessageBus:
             )
         if dispatcher is None:
             raise RuntimeError("v3 Channel outbound dispatcher 未绑定")
+        if item.before_provider is not None:
+            try:
+                item.before_provider()
+            except BaseException as error:
+                logger.error(
+                    "v3 channel pre-provider commit rejected channel=%s "
+                    "delivery_id=%s error=%s",
+                    item.envelope.channel,
+                    item.envelope.delivery_id,
+                    error,
+                )
+                return _channel_delivery_receipt(
+                    item.envelope,
+                    ChannelDeliveryStatus.REJECTED,
+                    str(error) or type(error).__name__,
+                )
         item.provider_started = True
         try:
             receipt = await dispatcher(item.envelope, item.binding)

--- a/docs/design/content-wake-proactive-migration-task-contract.md
+++ b/docs/design/content-wake-proactive-migration-task-contract.md
@@ -146,14 +146,14 @@ rollback: close the affected stacked PR and return to its parent commit; formal 
 
 目标：只修通用 delivery 的跨崩溃窗口，不在 Core 引入任何 proactive/source 名词。
 
-- [ ] 固定 stable logical delivery id 与 prepared→delivered→projected→settled 状态。
-- [ ] provider receipt durable 后，重启只补 Session projection/领域通知，不再次 send。
-- [ ] provider 结果未知且不可幂等时进入可观察 `uncertain`，不伪装成功或盲目重发。
-- [ ] 通用 settlement 先持久化 stable owner identity + settlement_ref；Content 以该 ref 幂等提交 delivered/unsettled 并 forward-complete，不宣称跨库原子。
-- [ ] pending settlement 不捕获退役 Root closure；candidate promotion 用只读 resolver 证明当前 compatible owner 能解析 stable owner/ref，否则不发布候选。
-- [ ] ACK 首次失败只重试 ACK；provider_acked 后本地崩溃只重试 Content ack。
+- [x] 固定 stable logical delivery id 与 prepared→provider_started→delivered→projected→settled 状态，并以 rejected/uncertain 收束不可前进结果。
+- [x] provider receipt durable 后，重启只补 Session projection/领域通知，不再次 send；caller cancellation 也先完成 Core-owned forward step 再恢复取消。
+- [x] provider 结果未知且不可幂等时进入可观察 `uncertain`，不伪装成功或盲目重发。
+- [x] 通用 settlement 持久化 stable target service 与 logical/settlement ref；Content 以该 ref 幂等提交 delivered/settled 并 forward-complete，不宣称跨库原子。
+- [x] pending settlement 不捕获退役 Root closure；candidate promotion 只读证明 `prepared/delivered/projected` 的 target service 仍能由 candidate topology 解析，否则不发布候选。
+- [x] ACK 首次失败只重试 source ACK；Content settle 后本地崩溃只重放稳定 receipt 并补 Core confirm。
 - [ ] 不修改 PR-D crash probe/oracle，让同一命令由非零变为零并进入 required Gate。
-- [ ] 验证 Session messages 仍只追加，普通 passive delivery 行为不变。
+- [x] 验证 Session messages 仍只追加，普通 passive delivery 与 `message_push` 既有入口不变。
 - [ ] Terra xhigh、targeted tests、pyright、相邻 Gate 通过。
 - [ ] 提交、推送并创建 PR-E，base 指向 PR-D head。
 

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -102,6 +102,7 @@ workspace 仍不是完整运行环境的全部。模型 Provider credential 已�
 | `plugin-data/` | 已激活插件在自己的 opaque 目录增加数据 | 由插件 schema 和 owner 决定 | 普通卸载只删除代码和能力投影，保留数据；永久删除必须使用名称不同的用户操作、影响预览、备份和再次确认 |
 | `runtime/plugin-reloads.sqlite3` | 每次热重载增加 transaction 与阶段事件；首次启动 candidate/formal runtime 前固定 old/new snapshot、old/new generation、base/candidate artifact pointer 与 `runtime_owner_boot_id`；已有 candidate 时 stable watchdog 加入同一 transaction，不另建 owner | 同一 transaction 按状态机更新 phase、failure resource、recovery target/action、单调 attempt 和 retry receipt；failure 只允许 `cleanup_failed → degraded` 单调强化且 target 不可覆盖，终态只能由 exact Host retry 成功后收束；同 boot 不做进程清理，新 supervised boot 只按已记录 old boot ID 恢复 | 当前没有自动 retention；恢复和事故审计仍依赖的记录不得自动删除，artifact/Host tombstone 只在对应 retry receipt 成功后减少 |
 | `runtime/plugin-jobs/outcomes.sqlite` | generation-scoped plugin job 首次 admission INSERT semantic job/event/interval identity、exact snapshot/plugin/model generation、artifact/source/handler/lifecycle identity 与 queued 状态 | 同一 invocation 只按 queued→running→terminal/retry_pending 状态机更新 attempt、phase（handler/provider/documents）、error 与 result digest；跨 generation redelivery 复用同一 semantic key，不新建第二次 effect；documents phase 只由 ActivityHost forward recovery | 当前没有自动 retention；这是 event dedupe、取消与 crash recovery 证据，普通插件卸载、重载或日志清理不得删除。workspace 备份应以 SQLite online backup + integrity_check 保存；只有后续名称明确的 retention/插件数据管理操作可减少 |
+| `runtime/deliveries/settlements.sqlite` | Core 为每个 accepted Turn INSERT 一条 immutable delivery envelope 与 stable logical id | 只按 `prepared → provider_started → delivered → projected → settled` 前向更新 exact binding、provider receipt、Session message 与 opaque domain receipt；provider 调用中断进入 `uncertain`，明确拒绝进入 `rejected`；候选只读检查 `prepared/delivered/projected` 的 target service 仍可解析 | 当前没有 DELETE 或自动 retention；Core ledger 是 provider effect、Session projection 与领域 settle 的恢复证据。备份应覆盖数据库、WAL/SHM 并使用 SQLite online backup + `integrity_check`；只有后续名称明确的 delivery retention 操作可以减少 |
 | `runtime/proactive-documents/intents/<invocation-id>/` | `ProactiveDocuments.prepare_pair()` 在 DB effect 前创建，保存两份 old state（bytes 或 absent marker）、完整 new bytes、expected digest、idempotency key 与 fsync receipt | 无 DB receipt 时只允许 abort 并保持正文原状态；有 DB receipt 时只允许 ordered replace/forward recovery；partial replace 依据 old bytes 恢复两份原始状态 | commit/abort terminal receipt、目标 digest 与目录 fsync 均完成后才能删除该 intent；启动恢复不得按年龄猜测 orphan。workspace 备份必须与 outcomes.sqlite、两份 Markdown 一起覆盖该目录 |
 | `runtime/plugin-rollout-fact.json` | turn 后 install/uninstall 产生一条待反馈事实 | 新结果原子替换尚未消费的旧事实 | 下一次非 programmatic 用户 turn 注入后删除；它是可重建反馈，不是会话或长期记忆 |
 | `runtime/plugin-skill-links.json` | legacy adoption 或首次插件 Skill/Drift skill 投影时创建 ownership registry；每次链接切换先原子写入含 old/new 的 pending journal | 目录项切换后原子提交 `links` 并清除对应 pending；进程重启只在实际链接仍等于 old 或 new 时收敛，用户文件、未登记软链接和第三种状态 fail-loud | 只有插件 disable/uninstall 或 generation 切换的 linker owner 可以删除已登记且 target 匹配的投影链接并移除对应 ownership；不得删除用户文件、普通目录、未登记链接或外部 canonical source。registry 是重建与恢复证据，当前没有整文件自动删除协议 |
@@ -262,6 +263,7 @@ workspace 之外还有两组明确的全局状态：
 ├── runtime/
 │   ├── plugin-reloads.sqlite3         插件热重载事务与恢复阶段
 │   ├── plugin-jobs/outcomes.sqlite    插件 background job 幂等与恢复状态
+│   ├── deliveries/settlements.sqlite  通用 delivery、provider、Session projection 与领域 settle
 │   ├── proactive-documents/
 │   │   └── intents/<invocation-id>/   paired Markdown old/new bytes 与恢复回执
 │   ├── plugin-rollout-fact.json       下一用户 turn 消费的一条派生结果
@@ -400,6 +402,15 @@ Akasha V2 保存 turn 指针、稀疏特征、engram hub、有向关系、activa
 - `proactive_quota.json` 由 `QuotaStore` 保存每日窗口、已用次数和最后动作时间。损坏不会静默重置。
 
 **F-011：** 两者都会决定重启后的外部行为。它们是体积很小但不能随意丢弃的操作状态。
+
+### 9.5 v3 Content 与通用 delivery
+
+- `plugin-data/content-builtin/content.sqlite3` 由 Content 插件拥有。source submit 追加 revision 与 batch receipt；Wake 只把 selected item 前向变成 `ready_for_delivery`；`CONTENT_DELIVERY` 只暴露无正文 pending/lookup，并以一个 stable settlement ref 幂等提交 `delivered` 或 `settled`。
+- `runtime/deliveries/settlements.sqlite` 由 Core 拥有。Core 不读取 Content DB，也不持有 Content closure；它只保存通用 envelope、exact channel attempt/receipt、Session projection message id 和 opaque Content receipt。
+- Wake 是普通组合 owner：先让 Core 到 `projected`，再让 Content settle，最后把 Content 的稳定 receipt 交回 Core confirm。两库之间不宣称原子事务；任一崩溃窗口都只向前补尚未完成的一步。
+- `rejected` 与 `uncertain` 是可观察终态，不自动重发、不投影 Session、不消费 Content。source-bound ACK 失败只保留 Content `delivered`，由该 source 的 `unsettled/ack` 窄口重试，不重做 Turn 或 provider delivery。
+
+**F-012：** provider effect、Session message 和 Content settle 各有唯一 owner。候选 generation 不能移除仍被 `prepared/delivered/projected` ledger row 引用的 target service；`settled/rejected/uncertain` 不形成该发布 fence。
 
 ## 10. 插件数据与 Skill/MCP 能力发布
 

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -59,8 +59,20 @@ class ContentWakeServices(Protocol):
     ) -> Mapping[str, object]: ...
 
 
+class ContentDeliveryServices(Protocol):
+    def pending(self, limit: int = 100) -> tuple[Mapping[str, object], ...]: ...
+
+    def lookup(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None: ...
+
+    def settle(
+        self, selection_token: str, settlement_ref: str
+    ) -> Mapping[str, object]: ...
+
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
 CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
+CONTENT_DELIVERY = ServiceKey[ContentDeliveryServices]("content.delivery.v1")
 CONTENT_CHANGED = EmitEventKey[None]("content.changed")
 
 
@@ -153,8 +165,26 @@ class _WakeServices:
         )
 
 
+class _DeliveryServices:
+    def __init__(self, store: ContentStore) -> None:
+        self._store = store
+
+    def pending(self, limit: int = 100) -> tuple[Mapping[str, object], ...]:
+        return self._store.pending_delivery(limit)
+
+    def lookup(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None:
+        return self._store.delivery(accepted_turn)
+
+    def settle(
+        self, selection_token: str, settlement_ref: str
+    ) -> Mapping[str, object]:
+        return self._store.settle_delivery(selection_token, settlement_ref)
+
+
 async def apply(ctx: Context, config: object) -> None:
-    """Publish two narrow views over one generation-scoped Content store."""
+    """Publish three narrow views over one generation-scoped Content store."""
 
     _ = config
     store = ContentStore(
@@ -167,3 +197,4 @@ async def apply(ctx: Context, config: object) -> None:
         _SourceServices(store, lambda: ctx.emit(CONTENT_CHANGED, None)),
     )
     _ = await ctx.provide(CONTENT_WAKE, _WakeServices(store))
+    _ = await ctx.provide(CONTENT_DELIVERY, _DeliveryServices(store))

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -623,6 +623,127 @@ class ContentStore:
                 for row in rows
             )
 
+    def pending_delivery(self, limit: int = 100) -> tuple[dict[str, object], ...]:
+        """Return body-free ready selections for the delivery composition owner."""
+
+        if type(limit) is not int or limit <= 0:
+            raise ValueError("limit 必须是正整数")
+        with self._transaction(write=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT selection_token, selected_session_id, selected_turn_id,
+                       snapshot_seq
+                FROM items
+                WHERE status = 'ready_for_delivery'
+                ORDER BY snapshot_seq
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+            return tuple(
+                {
+                    "selection_token": _identity(
+                        "selection_token", row["selection_token"]
+                    ),
+                    "accepted_turn": {
+                        "session_id": _identity(
+                            "selected_session_id", row["selected_session_id"]
+                        ),
+                        "turn_id": _identity(
+                            "selected_turn_id", row["selected_turn_id"]
+                        ),
+                    },
+                }
+                for row in rows
+            )
+
+    def delivery(
+        self, accepted_turn: Mapping[str, object]
+    ) -> dict[str, object] | None:
+        """Read a body-free delivery receipt by its accepted Turn identity."""
+
+        accepted = _normalize_accepted_turn(accepted_turn)
+        with self._transaction(write=False) as connection:
+            row = connection.execute(
+                """
+                SELECT selection_token, selected_session_id, selected_turn_id,
+                       status, settlement_ref
+                FROM items
+                WHERE selected_session_id = ? AND selected_turn_id = ?
+                """,
+                (accepted["session_id"], accepted["turn_id"]),
+            ).fetchone()
+            if row is None:
+                return None
+            result: dict[str, object] = {
+                "selection_token": row["selection_token"],
+                "accepted_turn": dict(accepted),
+                "status": row["status"],
+                "settlement_ref": row["settlement_ref"],
+            }
+            if row["status"] in {"delivered", "settled"}:
+                settlement = _identity("settlement_ref", row["settlement_ref"])
+                result["receipt"] = _delivery_receipt(
+                    str(row["selection_token"]), settlement
+                )
+            return result
+
+    def settle_delivery(
+        self,
+        selection_token: str,
+        settlement_ref: str,
+    ) -> dict[str, object]:
+        """Idempotently bind one projected logical delivery to its Content selection."""
+
+        token = _identity("selection_token", selection_token)
+        settlement = _identity("settlement_ref", settlement_ref)
+        receipt = _delivery_receipt(token, settlement)
+
+        with self._transaction(write=True) as connection:
+            row = connection.execute(
+                """
+                SELECT status, requires_ack, settlement_ref
+                FROM items WHERE selection_token = ?
+                """,
+                (token,),
+            ).fetchone()
+            if row is None:
+                return {"settled": False, "reason": "selection_missing"}
+            if row["status"] in {"delivered", "settled"}:
+                if row["settlement_ref"] != settlement:
+                    raise RuntimeError("Content delivery settlement identity conflict")
+                return {
+                    "settled": True,
+                    "duplicate": True,
+                    "status": row["status"],
+                    "receipt": receipt,
+                }
+            if row["status"] != "ready_for_delivery":
+                return {"settled": False, "reason": f"status:{row['status']}"}
+            status = "delivered" if bool(row["requires_ack"]) else "settled"
+            _ = connection.execute(
+                """
+                UPDATE items
+                SET status = ?, settlement_ref = ?,
+                    item_state_version = item_state_version + 1, updated_at = ?
+                WHERE selection_token = ? AND status = 'ready_for_delivery'
+                """,
+                (status, settlement, _utc_now(), token),
+            )
+            _ = connection.execute(
+                """
+                UPDATE content_state
+                SET state_version = state_version + 1 WHERE singleton = 1
+                """
+            )
+            self._recompute_wake(connection)
+            return {
+                "settled": True,
+                "duplicate": False,
+                "status": status,
+                "receipt": receipt,
+            }
+
     def ack(self, source_id: str, settlement_ref: str) -> dict[str, object]:
         """Settle one delivered row only through its source-bound view."""
 
@@ -880,6 +1001,11 @@ def _utc_now() -> str:
 def _batch_fingerprint(items: Sequence[Mapping[str, object]]) -> str:
     payload = json.dumps(items, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _delivery_receipt(selection_token: str, settlement_ref: str) -> str:
+    payload = f"{selection_token}\x00{settlement_ref}".encode("utf-8")
+    return "content-delivery:" + hashlib.sha256(payload).hexdigest()
 
 
 def _assert_same_revision(

--- a/plugins/wake/plugin.py
+++ b/plugins/wake/plugin.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
+import logging
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from agent.control.models import TurnStatus
 from agent.control.scoped_turn import DurableTurnView, TurnAcceptedReceipt
@@ -16,14 +20,22 @@ from agent.plugin_composition import (
     RUNTIME_STOPPING,
     SCOPED_TURNS,
     TIMERS,
+    DURABLE_DELIVERIES,
     Context,
+    DurableDeliveryRequest,
+    DurableDeliveryView,
     EmitEventKey,
     PluginScopedTurns,
+    PluginDurableDeliveries,
     PluginTimers,
     ServiceKey,
     TurnExecutionScope,
+    ToolGrant,
 )
+from plugins.content.plugin import CONTENT_DELIVERY, ContentDeliveryServices
 from plugins.wake.selection import DutyProposal, propose_content, propose_drift
+
+logger = logging.getLogger(__name__)
 
 api_version = 3
 name = "wake"
@@ -34,6 +46,30 @@ skill_roots = ()
 drift_skill_roots = ()
 workspace_roots = ()
 workspace_files = ()
+
+
+class DeliveryTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    channel: str
+    recipient: str
+    session_id: str
+
+    @field_validator("channel", "recipient", "session_id")
+    @classmethod
+    def validate_identity(cls, value: str) -> str:
+        if not value or value.strip() != value:
+            raise ValueError("Wake delivery target 必须非空且无首尾空白")
+        return value
+
+
+class Config(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    delivery: DeliveryTarget | None = None
+
+
+ConfigModel = Config
 
 
 class ContentWakeServices(Protocol):
@@ -84,7 +120,14 @@ class DriftWakeServices(Protocol):
 CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
 DRIFT_WAKE = ServiceKey[DriftWakeServices]("drift.wake.v1")
 CONTENT_CHANGED = EmitEventKey[None]("content.changed")
-inject = (TIMERS, SCOPED_TURNS, CONTENT_WAKE, DRIFT_WAKE)
+inject = (
+    TIMERS,
+    SCOPED_TURNS,
+    DURABLE_DELIVERIES,
+    CONTENT_WAKE,
+    CONTENT_DELIVERY,
+    DRIFT_WAKE,
+)
 
 
 class WakeRuntime:
@@ -97,12 +140,18 @@ class WakeRuntime:
         content: ContentWakeServices,
         drift: DriftWakeServices,
         *,
+        deliveries: PluginDurableDeliveries | None = None,
+        content_delivery: ContentDeliveryServices | None = None,
+        target: DeliveryTarget | None = None,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
     ) -> None:
         self._timers = timers
         self._turns = turns
+        self._deliveries = deliveries
         self._content = content
+        self._content_delivery = content_delivery
         self._drift = drift
+        self._target = target
         self._now = now
         self._dirty = asyncio.Event()
         self._runner: asyncio.Task[None] | None = None
@@ -117,6 +166,7 @@ class WakeRuntime:
         if self._runner is not None:
             return
         await self._reconcile_selected()
+        await self._reconcile_deliveries()
         self._runner = asyncio.create_task(self._run(), name="wake:due-loop")
 
     async def close(self) -> None:
@@ -231,6 +281,7 @@ class WakeRuntime:
             "Check durable Wake duties.",
             scope=TurnExecutionScope(
                 tool_source="wake",
+                tool_grant=ToolGrant.except_names(("message_push",)),
                 stateless=True,
                 memory_read=False,
                 memory_write=False,
@@ -242,6 +293,7 @@ class WakeRuntime:
         try:
             result = await handle.result()
             await self._settle_accepted(handle.accepted, _view_from_result(result))
+            await self._reconcile_deliveries()
         finally:
             await handle.cleanup()
 
@@ -311,6 +363,119 @@ class WakeRuntime:
                 f"token={token}, result={dict(transition)!r}"
             )
 
+    async def _reconcile_deliveries(self) -> None:
+        """Forward-complete delivery, projection, and Content settlement windows."""
+
+        target = self._target
+        if target is None:
+            return
+        deliveries = self._deliveries
+        content_delivery = self._content_delivery
+        if deliveries is None or content_delivery is None:
+            raise RuntimeError("Wake delivery target 缺少 durable/Content capability")
+
+        # 1. Resume every Core row owned by Content before creating missing rows.
+        await self._resume_deliveries(deliveries)
+
+        # 2. Create a stable logical delivery for each ready Content selection.
+        for pending in content_delivery.pending(100):
+            await self._deliver_pending(pending, deliveries, target)
+
+    async def _resume_deliveries(
+        self, deliveries: PluginDurableDeliveries
+    ) -> None:
+        """Advance existing Core rows without consulting Content payload state."""
+
+        for delivery in deliveries.recoverable():
+            if delivery.target_service != CONTENT_DELIVERY.name:
+                continue
+            current = delivery
+            if current.state in {"prepared", "delivered"}:
+                current = await deliveries.resume(current.accepted_turn)
+            if current.state == "projected":
+                self._settle_projected(current)
+
+    async def _deliver_pending(
+        self,
+        pending: Mapping[str, object],
+        deliveries: PluginDurableDeliveries,
+        target: DeliveryTarget,
+    ) -> None:
+        """Create or forward-complete one ready Content delivery."""
+
+        accepted = _accepted_receipt(pending)
+        current = deliveries.lookup(accepted)
+        if current is None:
+            turn = self._turns.read(accepted)
+            if turn.status is not TurnStatus.COMPLETED:
+                raise RuntimeError(
+                    "Content ready selection 不属于 completed Turn: "
+                    f"{accepted!r}/{turn.status.value}"
+                )
+            if not turn.final_response:
+                raise RuntimeError("Content ready Turn 缺少可投递 final_response")
+            current = await deliveries.submit(
+                DurableDeliveryRequest(
+                    logical_delivery_id=_logical_delivery_id(accepted),
+                    accepted_turn=accepted,
+                    target_service=CONTENT_DELIVERY.name,
+                    channel=target.channel,
+                    recipient=target.recipient,
+                    projection_session_id=target.session_id,
+                    body=turn.final_response,
+                    metadata={"proactive": True},
+                )
+            )
+        elif current.state in {"prepared", "delivered"}:
+            current = await deliveries.resume(accepted)
+        elif current.state in {"rejected", "uncertain"}:
+            logger.warning(
+                "Wake durable delivery terminal without resend "
+                "accepted=%s/%s delivery_id=%s state=%s receipt=%r",
+                accepted.session_id,
+                accepted.turn_id,
+                current.logical_delivery_id,
+                current.state,
+                current.provider_receipt,
+            )
+        if current.state == "projected":
+            self._settle_projected(current)
+
+    def _settle_projected(
+        self,
+        delivery: DurableDeliveryView,
+    ) -> None:
+        """Commit Content first, then close the Core settlement receipt."""
+
+        content_delivery = self._content_delivery
+        deliveries = self._deliveries
+        if content_delivery is None or deliveries is None:
+            raise RuntimeError("Wake delivery settlement capability 缺失")
+        selected = content_delivery.lookup(
+            {
+                "session_id": delivery.accepted_turn.session_id,
+                "turn_id": delivery.accepted_turn.turn_id,
+            }
+        )
+        if selected is None:
+            raise RuntimeError(
+                "durable Content delivery 缺少 accepted Turn selection: "
+                f"{delivery.accepted_turn!r}"
+            )
+        token = _string(selected.get("selection_token"), "selection_token")
+        settled = content_delivery.settle(
+            token,
+            delivery.logical_delivery_id,
+        )
+        if settled.get("settled") is not True:
+            raise RuntimeError(
+                f"Content delivery settlement 未提交: {dict(settled)!r}"
+            )
+        receipt = _string(settled.get("receipt"), "Content delivery receipt")
+        _ = deliveries.confirm_settled(
+            delivery.logical_delivery_id, receipt
+        )
+
     def _earliest_deadline(self) -> datetime | None:
         now = self._aware_now()
         content = self._content.snapshot(now).get("earliest_not_before")
@@ -347,12 +512,16 @@ class WakeRuntime:
 async def apply(ctx: Context, config: object) -> None:
     """Compose Wake from Timer, scoped Turn, Content, Drift, and lifecycle."""
 
-    _ = config
+    if not isinstance(config, Config):
+        raise TypeError("Wake config 必须通过 ConfigModel 校验")
     runtime = WakeRuntime(
         ctx.require(TIMERS),
         ctx.require(SCOPED_TURNS),
         ctx.require(CONTENT_WAKE),
         ctx.require(DRIFT_WAKE),
+        deliveries=ctx.require(DURABLE_DELIVERIES),
+        content_delivery=ctx.require(CONTENT_DELIVERY),
+        target=config.delivery,
     )
 
     def setup() -> object:
@@ -381,6 +550,11 @@ def _accepted_receipt(receipt: Mapping[str, object]) -> TurnAcceptedReceipt:
         _string(accepted.get("session_id"), "session_id"),
         _string(accepted.get("turn_id"), "turn_id"),
     )
+
+
+def _logical_delivery_id(accepted: TurnAcceptedReceipt) -> str:
+    payload = f"{accepted.session_id}\x00{accepted.turn_id}".encode("utf-8")
+    return "wake:" + hashlib.sha256(payload).hexdigest()
 
 
 def _view_from_result(result: object) -> DurableTurnView:

--- a/session/manager.py
+++ b/session/manager.py
@@ -642,6 +642,51 @@ class SessionManager:
                 session.metadata = dict(metadata)
             self._cache[session.key] = session
 
+    async def append_durable_delivery(
+        self,
+        *,
+        session_key: str,
+        content: str,
+        delivery_id: str,
+        control_turn_id: str,
+    ) -> str:
+        """Append one proactive assistant projection exactly once per delivery id."""
+
+        async with self._lock(session_key):
+            # 1. A committed Session message is the crash-recovery receipt.
+            existing = self._store.get_message_by_delivery_id(
+                session_key, delivery_id
+            )
+            if existing is not None:
+                if (
+                    existing["content"] != content
+                    or existing.get("control_turn_id") != control_turn_id
+                ):
+                    raise RuntimeError(
+                        f"durable delivery Session projection conflict: {delivery_id}"
+                    )
+                return str(existing["id"])
+
+            # 2. Persist and publish the new append-only projection under one lock.
+            session = self.get_or_create(session_key)
+            message: dict[str, object] = {
+                "role": "assistant",
+                "content": content,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "proactive": True,
+                "delivery_id": delivery_id,
+                "control_turn_id": control_turn_id,
+            }
+            updated_at = datetime.now(UTC)
+            _ = self._persist_session(
+                session,
+                [message],
+                updated_at=updated_at,
+            )
+            session.messages.append(message)
+            self._cache[session.key] = session
+            return str(message["id"])
+
     def invalidate(self, key: str) -> None:
         _ = self._cache.pop(key, None)
 

--- a/session/manager.py
+++ b/session/manager.py
@@ -20,6 +20,7 @@ from session.store import (
     ChannelIdentityWriteReceipt,
     SessionDeleteAudit,
     SessionStore,
+    validate_message_delivery_id,
 )
 
 _TOOL_RESULT_CHAR_BUDGET = 10000
@@ -652,6 +653,7 @@ class SessionManager:
     ) -> str:
         """Append one proactive assistant projection exactly once per delivery id."""
 
+        delivery_id = validate_message_delivery_id(delivery_id)
         async with self._lock(session_key):
             # 1. A committed Session message is the crash-recovery receipt.
             existing = self._store.get_message_by_delivery_id(

--- a/session/store.py
+++ b/session/store.py
@@ -33,6 +33,14 @@ _ATTACHMENT_MEDIA_TYPE_RE = re.compile(
 )
 
 
+def validate_message_delivery_id(value: object) -> str:
+    """Validate the shared delivery identity stored in Session message extras."""
+
+    if not isinstance(value, str) or not value or len(value) > 128:
+        raise ValueError("delivery_id 必须是 1..128 字符串")
+    return value
+
+
 class InteractionDeleteRequiredError(ValueError):
     """要求调用方按完整 interaction 执行原子撤销。"""
 
@@ -332,11 +340,13 @@ def _decode_message_extra(
     proactive = extra_dict.get("proactive")
     if "proactive" in extra_dict and not isinstance(proactive, bool):
         raise ValueError(f"message proactive 必须是布尔值: {message_id}")
-    delivery_id = extra_dict.get("delivery_id")
-    if "delivery_id" in extra_dict and (
-        not isinstance(delivery_id, str) or not delivery_id or len(delivery_id) > 128
-    ):
-        raise ValueError(f"message delivery_id 必须是 1..128 字符串: {message_id}")
+    if "delivery_id" in extra_dict:
+        try:
+            _ = validate_message_delivery_id(extra_dict["delivery_id"])
+        except ValueError as error:
+            raise ValueError(
+                f"message delivery_id 必须是 1..128 字符串: {message_id}"
+            ) from error
     for field in ("state_summary_tag", "reasoning_content"):
         value = extra_dict.get(field)
         if field in extra_dict and not isinstance(value, str):

--- a/tests/fixtures/durable_delivery_crash/runner.py
+++ b/tests/fixtures/durable_delivery_crash/runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+from agent.plugin_composition.channels import (
+    ChannelDeliveryReceipt,
+    DeliveryStatus,
+    OutboundEnvelope,
+)
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from bus.queue import MessageBus
+
+
+class _Binding:
+    snapshot_id = "snapshot:fixture"
+    generation_id = "generation:fixture"
+    binding_token = "binding:fixture"
+    channel_name = "recording"
+    active = True
+
+
+async def main(root: Path) -> None:
+    """Crash at the real MessageBus provider edge after the durable commit."""
+
+    # 1. Prepare the immutable Core delivery before it enters the bus.
+    logical_id = "delivery:crash"
+    store = DurableDeliveryStore(root / "settlements.sqlite")
+    store.initialize()
+    _ = store.prepare(
+        {
+            "logical_delivery_id": logical_id,
+            "accepted_session_id": "session:crash",
+            "accepted_turn_id": "turn:crash",
+            "target_service": "content.delivery.v1",
+            "channel": "recording",
+            "recipient": "recipient:crash",
+            "projection_session_id": "projection:crash",
+            "body": "crash payload",
+            "metadata": {},
+        }
+    )
+    envelope = OutboundEnvelope(
+        logical_delivery_id=logical_id,
+        delivery_id=logical_id,
+        attempt_sequence=1,
+        snapshot_id=_Binding.snapshot_id,
+        generation_id=_Binding.generation_id,
+        binding_token=_Binding.binding_token,
+        channel=_Binding.channel_name,
+        recipient="recipient:crash",
+        body="crash payload",
+        metadata={},
+    )
+
+    # 2. Prove SIGKILL lands after the durable callback and before provider effect.
+    async def provider(
+        _envelope: OutboundEnvelope, _binding: object
+    ) -> ChannelDeliveryReceipt:
+        with (root / "provider-calls").open("a", encoding="utf-8") as handle:
+            _ = handle.write(logical_id + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        return ChannelDeliveryReceipt(logical_id, DeliveryStatus.DELIVERED)
+
+    def before_provider() -> None:
+        _ = store.mark_provider_started(
+            logical_id,
+            attempt_id=logical_id,
+            snapshot_id=_Binding.snapshot_id,
+            generation_id=_Binding.generation_id,
+            binding_token=_Binding.binding_token,
+        )
+        with (root / "provider-edge").open("w", encoding="utf-8") as handle:
+            _ = handle.write("provider_started\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    bus = MessageBus()
+    bus.bind_channel_outbound_dispatcher(provider)
+    dispatch = asyncio.create_task(bus.dispatch_outbound())
+    await bus.publish_channel_outbound_awaited(
+        envelope,
+        _Binding(),
+        passive=False,
+        before_provider=before_provider,
+    )
+    await dispatch
+
+
+if __name__ == "__main__":
+    asyncio.run(main(Path(sys.argv[1])))

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -410,6 +410,73 @@ def test_context_without_provider_ack_settles_at_delivery(tmp_path) -> None:
     assert store.state_counts() == {"settled": 1}
 
 
+@pytest.mark.parametrize(
+    ("requires_ack", "expected_status"),
+    ((True, "delivered"), (False, "settled")),
+)
+def test_delivery_capability_is_body_free_and_replays_stable_receipt(
+    tmp_path,
+    requires_ack: bool,
+    expected_status: str,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "fitbit",
+        "poll:delivery",
+        [_item("delivery", not_before=now, requires_ack=requires_ack)],
+    )
+    token = _select(store, now, "delivery")
+    _ = store.transition(token, "ready_for_delivery")
+    accepted = {"session_id": "wake:fixture", "turn_id": "turn:delivery"}
+    delivery = content_plugin._DeliveryServices(store)
+
+    assert delivery.pending() == (
+        {"selection_token": token, "accepted_turn": accepted},
+    )
+    first = delivery.settle(token, "wake:logical-delivery")
+    recovered = delivery.lookup(accepted)
+    duplicate = delivery.settle(token, "wake:logical-delivery")
+
+    assert first["status"] == expected_status
+    assert first["receipt"] == duplicate["receipt"]
+    assert recovered == {
+        "selection_token": token,
+        "accepted_turn": accepted,
+        "status": expected_status,
+        "settlement_ref": "wake:logical-delivery",
+        "receipt": first["receipt"],
+    }
+    assert delivery.pending() == ()
+    assert set(recovered) == {
+        "selection_token",
+        "accepted_turn",
+        "status",
+        "settlement_ref",
+        "receipt",
+    }
+
+    if requires_ack:
+        assert store.ack("fitbit", "wake:logical-delivery")["settled"] is True
+        after_ack = delivery.lookup(accepted)
+        assert after_ack is not None
+        assert after_ack["status"] == "settled"
+        assert after_ack["receipt"] == first["receipt"]
+
+
+def test_delivery_capability_rejects_conflicting_settlement_identity(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit("fitbit", "poll:1", [_item("one", not_before=now)])
+    token = _select(store, now)
+    _ = store.transition(token, "ready_for_delivery")
+    delivery = content_plugin._DeliveryServices(store)
+    _ = delivery.settle(token, "wake:one")
+
+    with pytest.raises(RuntimeError, match="settlement identity conflict"):
+        delivery.settle(token, "wake:two")
+
+
 def test_wake_capability_cannot_commit_delivery_but_can_abandon_ready_item(
     tmp_path,
 ) -> None:

--- a/tests/test_durable_deliveries.py
+++ b/tests/test_durable_deliveries.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from agent.control.scoped_turn import TurnAcceptedReceipt
+from agent.plugin_composition import TopologyView
 from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
 from agent.plugin_composition.durable_deliveries import (
     DurableBindingAttempt,
@@ -17,6 +18,9 @@ from agent.plugin_composition.durable_deliveries import (
     PluginDurableDeliveries,
 )
 from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from agent.plugins.manager import PluginManager
+from agent.plugins.snapshot import RuntimeSnapshot
+from bus.event_bus import EventBus
 from session.manager import SessionManager
 
 
@@ -253,3 +257,68 @@ def test_delivery_body_preserves_surrounding_newlines(tmp_path: Path) -> None:
         projection_session_id="projection:body",
         body=body,
     ).body == body
+
+
+def test_candidate_fence_reads_only_prepared_target_service_identity(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    manager = PluginManager([], event_bus=EventBus(), workspace=workspace)
+    store = DurableDeliveryStore(
+        workspace / "runtime" / "deliveries" / "settlements.sqlite"
+    )
+    store.initialize()
+    request = _request()
+    _ = store.prepare(
+        {
+            "logical_delivery_id": request.logical_delivery_id,
+            "accepted_session_id": request.accepted_turn.session_id,
+            "accepted_turn_id": request.accepted_turn.turn_id,
+            "target_service": request.target_service,
+            "channel": request.channel,
+            "recipient": request.recipient,
+            "projection_session_id": request.projection_session_id,
+            "body": request.body,
+            "metadata": dict(request.metadata),
+        }
+    )
+
+    def candidate(services: tuple[str, ...]) -> RuntimeSnapshot:
+        return RuntimeSnapshot(
+            "candidate",
+            {},
+            None,
+            composition_topology=TopologyView(
+                generation_id="root:candidate",
+                identity="topology:candidate",
+                composition_revision=1,
+                fibers=(),
+                services=services,
+                effects=(),
+                listeners=(),
+            ),
+        )
+
+    manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
+        candidate(("content.delivery.v1",))
+    )
+    with pytest.raises(RuntimeError, match="target service 不可解析"):
+        manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
+            candidate(())
+        )
+
+    _ = store.mark_provider_started(
+        request.logical_delivery_id,
+        attempt_id="attempt:changed-binding",
+        snapshot_id="snapshot:changed",
+        generation_id="generation:changed",
+        binding_token="binding:changed",
+    )
+    _ = store.mark_provider_result(
+        request.logical_delivery_id,
+        state="rejected",
+        receipt={"status": "rejected"},
+    )
+    manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
+        candidate(())
+    )

--- a/tests/test_durable_deliveries.py
+++ b/tests/test_durable_deliveries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import sqlite3
 import subprocess
@@ -11,7 +12,11 @@ import pytest
 
 from agent.control.scoped_turn import TurnAcceptedReceipt
 from agent.plugin_composition import TopologyView
-from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
+from agent.plugin_composition.channels import (
+    ChannelDeliveryReceipt,
+    DeliveryStatus,
+    OutboundEnvelope,
+)
 from agent.plugin_composition.durable_deliveries import (
     DurableBindingAttempt,
     DurableDeliveryRequest,
@@ -21,6 +26,7 @@ from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from agent.plugins.manager import PluginManager
 from agent.plugins.snapshot import RuntimeSnapshot
 from bus.event_bus import EventBus
+from bus.queue import MessageBus
 from session.manager import SessionManager
 
 
@@ -35,6 +41,14 @@ def _request(logical_id: str = "delivery:one") -> DurableDeliveryRequest:
         body="hello from Wake",
         metadata={"proactive": True},
     )
+
+
+class _RecordingBinding:
+    snapshot_id = "snapshot:recording"
+    generation_id = "generation:recording"
+    binding_token = "binding:recording"
+    channel_name = "recording"
+    active = True
 
 
 @pytest.mark.asyncio
@@ -141,6 +155,82 @@ async def test_delivered_restart_only_projects_without_provider_resend(
     assert projections == 1
 
 
+@pytest.mark.asyncio
+async def test_caller_cancellation_waits_for_receipt_and_projection(
+    tmp_path: Path,
+) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    sessions = SessionManager(tmp_path / "workspace")
+    bus = MessageBus()
+    provider_entered = asyncio.Event()
+    provider_release = asyncio.Event()
+
+    async def provider(
+        envelope: OutboundEnvelope, _binding: object
+    ) -> ChannelDeliveryReceipt:
+        provider_entered.set()
+        await provider_release.wait()
+        return ChannelDeliveryReceipt(
+            envelope.delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:after-cancel",),
+        )
+
+    async def sender(request, provider_started):
+        binding = _RecordingBinding()
+        envelope = OutboundEnvelope(
+            logical_delivery_id=request.logical_delivery_id,
+            delivery_id=request.logical_delivery_id,
+            attempt_sequence=1,
+            snapshot_id=binding.snapshot_id,
+            generation_id=binding.generation_id,
+            binding_token=binding.binding_token,
+            channel=binding.channel_name,
+            recipient=request.recipient,
+            body=request.body,
+            metadata={},
+        )
+        attempt = DurableBindingAttempt(
+            request.logical_delivery_id,
+            binding.snapshot_id,
+            binding.generation_id,
+            binding.binding_token,
+        )
+        return await bus.publish_channel_outbound_awaited(
+            envelope,
+            binding,
+            passive=False,
+            before_provider=lambda: provider_started(attempt),
+        )
+
+    async def project(request) -> str:
+        return await sessions.append_durable_delivery(
+            session_key=request.projection_session_id,
+            content=request.body,
+            delivery_id=request.logical_delivery_id,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+
+    bus.bind_channel_outbound_dispatcher(provider)
+    dispatch = asyncio.create_task(bus.dispatch_outbound())
+    service = PluginDurableDeliveries(store, sender, project)
+    caller = asyncio.create_task(service.submit(_request()))
+    await provider_entered.wait()
+    caller.cancel()
+    provider_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    current = service.lookup(TurnAcceptedReceipt("wake:default", "turn:one"))
+    assert current is not None and current.state == "projected"
+    assert current.provider_receipt is not None
+    assert current.provider_receipt["status"] == "delivered"
+    assert len(sessions.control_store.fetch_session_messages("recipient-session")) == 1
+    bus.stop()
+    await dispatch
+    sessions.close()
+
+
 def test_provider_started_sigkill_recovers_uncertain_without_resend(
     tmp_path: Path,
 ) -> None:
@@ -184,6 +274,37 @@ def test_exact_schema_rejects_same_version_missing_index_and_extra_table(
         connection.commit()
     with pytest.raises(RuntimeError, match="table identity"):
         store.initialize()
+
+
+def test_version_zero_unknown_schema_failure_leaves_database_unchanged(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "settlements.sqlite"
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute("CREATE TABLE legacy_delivery(value TEXT)")
+        connection.commit()
+
+    def schema() -> tuple[int, str, tuple[tuple[str, str], ...]]:
+        with closing(sqlite3.connect(path)) as connection:
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            journal_mode = str(connection.execute("PRAGMA journal_mode").fetchone()[0])
+            objects = tuple(
+                (str(row[0]), str(row[1]))
+                for row in connection.execute(
+                    "SELECT type, name FROM sqlite_master "
+                    "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+                )
+            )
+            return version, journal_mode, objects
+
+    before = schema()
+    with pytest.raises(RuntimeError, match="version 0 schema must be empty"):
+        DurableDeliveryStore(path).initialize()
+    assert schema() == before == (
+        0,
+        "delete",
+        (("table", "legacy_delivery"),),
+    )
 
 
 def test_terminal_transitions_reject_backward_or_conflicting_receipts(
@@ -316,9 +437,92 @@ def test_candidate_fence_reads_only_prepared_target_service_identity(
     )
     _ = store.mark_provider_result(
         request.logical_delivery_id,
-        state="rejected",
-        receipt={"status": "rejected"},
+        state="delivered",
+        receipt={"status": "delivered"},
     )
+    _ = store.mark_projected(request.logical_delivery_id, "message:one")
+    with pytest.raises(RuntimeError, match="target service 不可解析"):
+        manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
+            candidate(())
+        )
+    _ = store.confirm_settled(request.logical_delivery_id, "content:receipt")
     manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
         candidate(())
     )
+
+
+@pytest.mark.parametrize("terminal", ("rejected", "uncertain"))
+def test_candidate_fence_ignores_nonrecoverable_terminal_rows(
+    tmp_path: Path,
+    terminal: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    manager = PluginManager([], event_bus=EventBus(), workspace=workspace)
+    store = DurableDeliveryStore(
+        workspace / "runtime" / "deliveries" / "settlements.sqlite"
+    )
+    store.initialize()
+    request = _request(f"delivery:{terminal}")
+    envelope = {
+        "logical_delivery_id": request.logical_delivery_id,
+        "accepted_session_id": request.accepted_turn.session_id,
+        "accepted_turn_id": request.accepted_turn.turn_id,
+        "target_service": request.target_service,
+        "channel": request.channel,
+        "recipient": request.recipient,
+        "projection_session_id": request.projection_session_id,
+        "body": request.body,
+        "metadata": {},
+    }
+    _ = store.prepare(envelope)
+    _ = store.mark_provider_started(
+        request.logical_delivery_id,
+        attempt_id=request.logical_delivery_id,
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = store.mark_provider_result(
+        request.logical_delivery_id,
+        state=terminal,
+        receipt={"status": terminal},
+    )
+    snapshot = RuntimeSnapshot(
+        "candidate",
+        {},
+        None,
+        composition_topology=TopologyView(
+            "root:candidate", "topology:candidate", 1, (), (), (), ()
+        ),
+    )
+    manager._preflight_durable_delivery_targets(  # pyright: ignore[reportPrivateUsage]
+        snapshot
+    )
+
+
+def test_oversized_logical_id_is_rejected_before_any_write_or_provider(
+    tmp_path: Path,
+) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    store.initialize()
+    provider_calls = 0
+
+    async def sender(_request, _provider_started):
+        nonlocal provider_calls
+        provider_calls += 1
+        raise AssertionError("invalid delivery id must not reach provider")
+
+    _ = PluginDurableDeliveries(store, sender, None)
+    with pytest.raises(ValueError, match=r"1\.\.128"):
+        DurableDeliveryRequest(
+            logical_delivery_id="d" * 129,
+            accepted_turn=TurnAcceptedReceipt("session:long", "turn:long"),
+            target_service="content.delivery.v1",
+            channel="recording",
+            recipient="recipient:long",
+            projection_session_id="projection:long",
+            body="payload",
+        )
+
+    assert provider_calls == 0
+    assert store.recoverable() == ()

--- a/tests/test_durable_deliveries.py
+++ b/tests/test_durable_deliveries.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from agent.control.scoped_turn import TurnAcceptedReceipt
+from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
+from agent.plugin_composition.durable_deliveries import (
+    DurableBindingAttempt,
+    DurableDeliveryRequest,
+    PluginDurableDeliveries,
+)
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from session.manager import SessionManager
+
+
+def _request(logical_id: str = "delivery:one") -> DurableDeliveryRequest:
+    return DurableDeliveryRequest(
+        logical_delivery_id=logical_id,
+        accepted_turn=TurnAcceptedReceipt("wake:default", "turn:one"),
+        target_service="content.delivery.v1",
+        channel="recording",
+        recipient="recipient:one",
+        projection_session_id="recipient-session",
+        body="hello from Wake",
+        metadata={"proactive": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_receipt_precedes_one_append_only_session_projection(
+    tmp_path: Path,
+) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    sessions = SessionManager(tmp_path / "workspace")
+    provider_states: list[str] = []
+
+    async def sender(request, provider_started):
+        provider_started(
+            DurableBindingAttempt(
+                request.logical_delivery_id,
+                "snapshot:one",
+                "generation:one",
+                "binding:one",
+            )
+        )
+        row = store.lookup("wake:default", "turn:one")
+        assert row is not None
+        provider_states.append(str(row["state"]))
+        return ChannelDeliveryReceipt(
+            request.logical_delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:one",),
+        )
+
+    async def project(request) -> str:
+        row = store.lookup("wake:default", "turn:one")
+        assert row is not None and row["state"] == "delivered"
+        return await sessions.append_durable_delivery(
+            session_key=request.projection_session_id,
+            content=request.body,
+            delivery_id=request.logical_delivery_id,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+
+    service = PluginDurableDeliveries(store, sender, project)
+    projected = await service.submit(_request())
+    duplicate = await service.submit(_request())
+
+    assert provider_states == ["provider_started"]
+    assert projected.state == duplicate.state == "projected"
+    messages = sessions.control_store.fetch_session_messages("recipient-session")
+    assert len(messages) == 1
+    assert messages[0]["content"] == "hello from Wake"
+    assert messages[0]["delivery_id"] == "delivery:one"
+    assert store.confirm_settled("delivery:one", "domain:one")["state"] == "settled"
+    assert store.confirm_settled("delivery:one", "domain:one")["state"] == "settled"
+    sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_delivered_restart_only_projects_without_provider_resend(
+    tmp_path: Path,
+) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    store.initialize()
+    request = _request()
+    _ = store.prepare(
+        {
+            "logical_delivery_id": request.logical_delivery_id,
+            "accepted_session_id": request.accepted_turn.session_id,
+            "accepted_turn_id": request.accepted_turn.turn_id,
+            "target_service": request.target_service,
+            "channel": request.channel,
+            "recipient": request.recipient,
+            "projection_session_id": request.projection_session_id,
+            "body": request.body,
+            "metadata": dict(request.metadata),
+        }
+    )
+    _ = store.mark_provider_started(
+        request.logical_delivery_id,
+        attempt_id=request.logical_delivery_id,
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = store.mark_provider_result(
+        request.logical_delivery_id,
+        state="delivered",
+        receipt={"delivery_id": request.logical_delivery_id, "status": "delivered"},
+    )
+    provider_calls = 0
+    projections = 0
+
+    async def sender(_request, _provider_started):
+        nonlocal provider_calls
+        provider_calls += 1
+        raise AssertionError("delivered recovery must not call provider")
+
+    async def projector(_request) -> str:
+        nonlocal projections
+        projections += 1
+        return "recipient-session:1"
+
+    service = PluginDurableDeliveries(store, sender, projector)
+    result = await service.resume(request.accepted_turn)
+
+    assert result.state == "projected"
+    assert provider_calls == 0
+    assert projections == 1
+
+
+def test_provider_started_sigkill_recovers_uncertain_without_resend(
+    tmp_path: Path,
+) -> None:
+    runner = Path(__file__).parent / "fixtures" / "durable_delivery_crash" / "runner.py"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    completed = subprocess.run(
+        [sys.executable, str(runner), str(tmp_path)],
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == -9
+    assert (tmp_path / "provider-edge").read_text(encoding="utf-8").splitlines() == [
+        "provider_started"
+    ]
+    assert not (tmp_path / "provider-calls").exists()
+
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    service = PluginDurableDeliveries(store, None, None)
+    recovered = service.lookup(TurnAcceptedReceipt("session:crash", "turn:crash"))
+    assert recovered is not None and recovered.state == "uncertain"
+    assert service.recoverable() == ()
+
+
+def test_exact_schema_rejects_same_version_missing_index_and_extra_table(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "settlements.sqlite"
+    store = DurableDeliveryStore(path)
+    store.initialize()
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute("DROP INDEX idx_deliveries_recoverable")
+        connection.commit()
+    with pytest.raises(RuntimeError, match="index identity"):
+        store.initialize()
+
+    path.unlink()
+    store.initialize()
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute("CREATE TABLE extra_state(value TEXT)")
+        connection.commit()
+    with pytest.raises(RuntimeError, match="table identity"):
+        store.initialize()
+
+
+def test_terminal_transitions_reject_backward_or_conflicting_receipts(
+    tmp_path: Path,
+) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    store.initialize()
+    request = _request()
+    envelope = {
+        "logical_delivery_id": request.logical_delivery_id,
+        "accepted_session_id": request.accepted_turn.session_id,
+        "accepted_turn_id": request.accepted_turn.turn_id,
+        "target_service": request.target_service,
+        "channel": request.channel,
+        "recipient": request.recipient,
+        "projection_session_id": request.projection_session_id,
+        "body": request.body,
+        "metadata": dict(request.metadata),
+    }
+    _ = store.prepare(envelope)
+    _ = store.mark_provider_started(
+        request.logical_delivery_id,
+        attempt_id=request.logical_delivery_id,
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = store.mark_provider_result(
+        request.logical_delivery_id,
+        state="rejected",
+        receipt={"status": "rejected"},
+    )
+    with pytest.raises(RuntimeError, match="provider result transition"):
+        store.mark_provider_result(
+            request.logical_delivery_id,
+            state="delivered",
+            receipt={"status": "delivered"},
+        )
+    with pytest.raises(RuntimeError, match="projected transition"):
+        store.mark_projected(request.logical_delivery_id, "message:one")
+
+    with pytest.raises(RuntimeError, match="immutable envelope conflict"):
+        store.prepare({**envelope, "body": "different"})
+
+
+def test_delivery_body_preserves_surrounding_newlines(tmp_path: Path) -> None:
+    store = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    store.initialize()
+    request = _request()
+    body = "\n  model response  \n"
+    row = store.prepare(
+        {
+            "logical_delivery_id": request.logical_delivery_id,
+            "accepted_session_id": request.accepted_turn.session_id,
+            "accepted_turn_id": request.accepted_turn.turn_id,
+            "target_service": request.target_service,
+            "channel": request.channel,
+            "recipient": request.recipient,
+            "projection_session_id": request.projection_session_id,
+            "body": body,
+            "metadata": {},
+        }
+    )
+    assert row["body"] == body
+    assert DurableDeliveryRequest(
+        logical_delivery_id="delivery:body",
+        accepted_turn=TurnAcceptedReceipt("session:body", "turn:body"),
+        target_service="content.delivery.v1",
+        channel="recording",
+        recipient="recipient:body",
+        projection_session_id="projection:body",
+        body=body,
+    ).body == body

--- a/tests/test_message_bus_admission.py
+++ b/tests/test_message_bus_admission.py
@@ -381,6 +381,39 @@ async def test_v3_channel_outbound_returns_exact_provider_receipt_once() -> None
 
 
 @pytest.mark.asyncio
+async def test_v3_channel_pre_provider_commit_fences_adapter_effect() -> None:
+    bus = MessageBus()
+    envelope, binding = _v3_outbound()
+    provider_calls = 0
+
+    async def deliver(
+        _received: OutboundEnvelope,
+        _owner: Any,
+    ) -> ChannelDeliveryReceipt:
+        nonlocal provider_calls
+        provider_calls += 1
+        raise AssertionError("failed pre-provider commit must fence adapter effect")
+
+    def reject_commit() -> None:
+        raise RuntimeError("ledger commit failed")
+
+    bus.bind_channel_outbound_dispatcher(deliver)
+    dispatch = asyncio.create_task(bus.dispatch_outbound())
+    receipt = await bus.publish_channel_outbound_awaited(
+        envelope,
+        binding,
+        passive=False,
+        before_provider=reject_commit,
+    )
+
+    assert receipt.status is DeliveryStatus.REJECTED
+    assert receipt.error == "ledger commit failed"
+    assert provider_calls == 0
+    bus.stop()
+    await dispatch
+
+
+@pytest.mark.asyncio
 async def test_v3_direct_channel_outbound_waits_for_passive_turn() -> None:
     bus = MessageBus()
     envelope, binding = _v3_outbound()

--- a/tests/test_wake_durable_delivery.py
+++ b/tests/test_wake_durable_delivery.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from agent.control.models import TurnStatus
+from agent.control.scoped_turn import DurableTurnView, TurnAcceptedReceipt
+from agent.plugin_composition import PluginScopedTurns, PluginTimers
+from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
+from agent.plugin_composition.durable_deliveries import (
+    DurableBindingAttempt,
+    PluginDurableDeliveries,
+)
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from plugins.content.plugin import (
+    ContentDeliveryServices,
+    _DeliveryServices,
+    _WakeServices,
+)
+from plugins.content.store import ContentStore
+from plugins.wake.plugin import DeliveryTarget, DriftWakeServices, WakeRuntime
+from session.manager import SessionManager
+
+
+class _NoTimers:
+    def schedule(self, _deadline):
+        raise AssertionError("ready delivery reconciliation must not schedule a timer")
+
+
+class _Turns:
+    def __init__(self, accepted: TurnAcceptedReceipt, response: str) -> None:
+        self.accepted = accepted
+        self.response = response
+
+    def read(self, accepted: TurnAcceptedReceipt) -> DurableTurnView:
+        assert accepted == self.accepted
+        return DurableTurnView(
+            accepted.session_id,
+            accepted.turn_id,
+            TurnStatus.COMPLETED,
+            self.response,
+            None,
+            None,
+            None,
+        )
+
+
+class _NoDrift:
+    def snapshot(self, _now):
+        return {"next_due": None, "proposals": ()}
+
+    def selected(self, _limit: int = 100):
+        return ()
+
+
+def _ready_content(
+    path: Path,
+    *,
+    requires_ack: bool = False,
+) -> tuple[ContentStore, TurnAcceptedReceipt, str]:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    accepted = TurnAcceptedReceipt("wake:default", "turn:delivery")
+    store = ContentStore(path)
+    _ = store.submit(
+        "fitbit",
+        "poll:delivery",
+        (
+            {
+                "item_id": "sleep:delivery",
+                "revision": "1",
+                "payload": {"kind": "sleep"},
+                "not_before": now,
+                "requires_ack": requires_ack,
+            },
+        ),
+    )
+    snapshot = store.snapshot(now)
+    selected = store.select(
+        snapshot["items"][0]["ref"],
+        snapshot["snapshot_seq"],
+        {"session_id": accepted.session_id, "turn_id": accepted.turn_id},
+        now,
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+    assert store.transition(token, "ready_for_delivery")["changed"] is True
+    return store, accepted, token
+
+
+def _runtime(
+    accepted: TurnAcceptedReceipt,
+    content: ContentStore,
+    deliveries: PluginDurableDeliveries,
+    *,
+    response: str = "Wake says hello",
+) -> WakeRuntime:
+    return WakeRuntime(
+        cast(PluginTimers, _NoTimers()),
+        cast(PluginScopedTurns, _Turns(accepted, response)),
+        _WakeServices(content),
+        cast(DriftWakeServices, _NoDrift()),
+        deliveries=deliveries,
+        content_delivery=cast(ContentDeliveryServices, _DeliveryServices(content)),
+        target=DeliveryTarget(
+            channel="recording",
+            recipient="recipient:one",
+            session_id="recipient-session",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_wake_composes_provider_session_content_and_core_settlement(
+    tmp_path: Path,
+) -> None:
+    content, accepted, _token = _ready_content(tmp_path / "content.sqlite3")
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    sessions = SessionManager(tmp_path / "workspace")
+    provider_calls: list[str] = []
+
+    async def sender(request, provider_started):
+        provider_started(
+            DurableBindingAttempt(
+                request.logical_delivery_id,
+                "snapshot:recording",
+                "generation:recording",
+                "binding:recording",
+            )
+        )
+        provider_calls.append(request.body)
+        return ChannelDeliveryReceipt(
+            request.logical_delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:recording",),
+        )
+
+    async def project(request) -> str:
+        return await sessions.append_durable_delivery(
+            session_key=request.projection_session_id,
+            content=request.body,
+            delivery_id=request.logical_delivery_id,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+
+    deliveries = PluginDurableDeliveries(ledger, sender, project)
+    runtime = _runtime(accepted, content, deliveries)
+    await runtime.start()
+    await runtime.close()
+
+    delivery = deliveries.lookup(accepted)
+    assert delivery is not None and delivery.state == "settled"
+    assert delivery.provider_receipt == {
+        "delivery_id": delivery.logical_delivery_id,
+        "error": None,
+        "provider_ids": ["provider:recording"],
+        "status": "delivered",
+    }
+    assert provider_calls == ["Wake says hello"]
+    messages = sessions.control_store.fetch_session_messages("recipient-session")
+    assert len(messages) == 1
+    assert messages[0]["content"] == "Wake says hello"
+    assert messages[0]["control_turn_id"] == accepted.turn_id
+    assert content.state_counts() == {"settled": 1}
+    sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_restart_after_content_settle_replays_receipt_into_core(
+    tmp_path: Path,
+) -> None:
+    content, accepted, token = _ready_content(tmp_path / "content.sqlite3")
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    ledger.initialize()
+    logical_id = "wake:projected-crash"
+    _prepare_delivery(ledger, accepted, logical_id)
+    _ = ledger.mark_provider_started(
+        logical_id,
+        attempt_id=logical_id,
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = ledger.mark_provider_result(
+        logical_id,
+        state="delivered",
+        receipt={"status": "delivered"},
+    )
+    _ = ledger.mark_projected(logical_id, "message:one")
+    first = _DeliveryServices(content).settle(token, logical_id)
+
+    async def no_sender(_request, _provider_started):
+        raise AssertionError("projected recovery must not resend")
+
+    async def no_projector(_request):
+        raise AssertionError("projected recovery must not append Session again")
+
+    deliveries = PluginDurableDeliveries(ledger, no_sender, no_projector)
+    runtime = _runtime(accepted, content, deliveries)
+    await runtime.start()
+    await runtime.close()
+
+    settled = deliveries.lookup(accepted)
+    assert settled is not None and settled.state == "settled"
+    assert settled.domain_receipt == first["receipt"]
+    assert content.state_counts() == {"settled": 1}
+
+
+@pytest.mark.parametrize("terminal", ("rejected", "uncertain"))
+@pytest.mark.asyncio
+async def test_terminal_provider_result_is_observable_and_never_resent(
+    tmp_path: Path,
+    terminal: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    content, accepted, _token = _ready_content(tmp_path / "content.sqlite3")
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    ledger.initialize()
+    logical_id = f"wake:{terminal}"
+    _prepare_delivery(ledger, accepted, logical_id)
+    _ = ledger.mark_provider_started(
+        logical_id,
+        attempt_id=logical_id,
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = ledger.mark_provider_result(
+        logical_id,
+        state=terminal,
+        receipt={"status": terminal, "error": "recording terminal"},
+    )
+    provider_calls = 0
+
+    async def no_sender(_request, _provider_started):
+        nonlocal provider_calls
+        provider_calls += 1
+        raise AssertionError("terminal delivery must not resend")
+
+    async def no_projector(_request):
+        raise AssertionError("terminal delivery must not project")
+
+    deliveries = PluginDurableDeliveries(ledger, no_sender, no_projector)
+    runtime = _runtime(accepted, content, deliveries)
+    with caplog.at_level(logging.WARNING, logger="plugins.wake.plugin"):
+        await runtime.start()
+        await runtime.close()
+
+    assert provider_calls == 0
+    assert f"state={terminal}" in caplog.text
+    assert "terminal without resend" in caplog.text
+    assert content.state_counts() == {"ready_for_delivery": 1}
+    current = deliveries.lookup(accepted)
+    assert current is not None and current.state == terminal
+
+
+def _prepare_delivery(
+    ledger: DurableDeliveryStore,
+    accepted: TurnAcceptedReceipt,
+    logical_id: str,
+) -> None:
+    _ = ledger.prepare(
+        {
+            "logical_delivery_id": logical_id,
+            "accepted_session_id": accepted.session_id,
+            "accepted_turn_id": accepted.turn_id,
+            "target_service": "content.delivery.v1",
+            "channel": "recording",
+            "recipient": "recipient:one",
+            "projection_session_id": "recipient-session",
+            "body": "Wake says hello",
+            "metadata": {"proactive": True},
+        }
+    )

--- a/tests/test_wake_v3.py
+++ b/tests/test_wake_v3.py
@@ -364,6 +364,7 @@ async def test_due_timer_starts_memoryless_wake_scoped_turn() -> None:
     scope = start["scope"]
     assert scope.stateless is True
     assert scope.memory_read is scope.memory_write is False
+    assert scope.tool_grant.allows("message_push") is False
     await runtime.close()
 
 

--- a/tests/test_wake_v3_composition.py
+++ b/tests/test_wake_v3_composition.py
@@ -11,13 +11,21 @@ import agent.plugins.manager as plugin_manager_module
 from agent.control.models import TurnRequest, TurnStatus
 from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
+from agent.control.scoped_turn import TurnAcceptedReceipt
 from agent.control.timer import TimerReceipt, TimerStatus
 from agent.lifecycle.composition import CONTEXT_PREPARED_EVENT, run_composition_lifecycle
 from agent.lifecycle.types import BeforeTurnCtx
+from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
+from agent.plugin_composition.durable_deliveries import (
+    DurableBindingAttempt,
+    PluginDurableDeliveries,
+)
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from agent.plugins.manager import PluginManager
 from bus.event_bus import EventBus
 from plugins.content.plugin import CONTENT_SOURCE, CONTENT_WAKE
 from plugins.drift.plugin import DRIFT_PROPOSALS, DRIFT_WAKE
+from session.manager import SessionManager
 from session.store import SessionStore
 
 
@@ -77,6 +85,126 @@ def _copy_plugins(tmp_path: Path) -> list[Path]:
         shutil.copytree(root / "plugins" / name, target)
         paths.append(target)
     return paths
+
+
+@pytest.mark.asyncio
+async def test_real_wake_plugin_delivers_projects_and_settles_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timer = _Timer()
+    monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", lambda: timer)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    wake_data = workspace / "plugin-data" / "wake-builtin"
+    wake_data.mkdir(parents=True)
+    (wake_data / "config.local.toml").write_text(
+        """
+[delivery]
+channel = "recording"
+recipient = "recipient:one"
+session_id = "recipient-session"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    store = SessionStore(workspace / "sessions.db")
+    sessions = SessionManager(workspace)
+    provider_calls: list[str] = []
+
+    async def execute(request: TurnRequest) -> ControlExecutionResult:
+        turn_id = request.metadata["turnId"]
+        assert isinstance(turn_id, str)
+        ctx = BeforeTurnCtx(
+            session_key=request.thread_id,
+            channel=str(request.metadata["channel"]),
+            chat_id=str(request.metadata["chatId"]),
+            content=request.input,
+            timestamp=datetime.now(UTC),
+            retrieved_memory_block="",
+            retrieval_trace_raw=None,
+            history_messages=(),
+            turn_id=turn_id,
+        )
+        await run_composition_lifecycle(CONTEXT_PREPARED_EVENT, ctx)
+        return ControlExecutionResult(response="recorded Wake response")
+
+    async def deliver(request, provider_started):
+        provider_started(
+            DurableBindingAttempt(
+                request.logical_delivery_id,
+                "snapshot:recording",
+                "generation:recording",
+                "binding:recording",
+            )
+        )
+        provider_calls.append(request.body)
+        return ChannelDeliveryReceipt(
+            request.logical_delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:recording",),
+        )
+
+    conversation = ConversationRuntime(store, execute)
+    manager = PluginManager(
+        plugin_dirs=_copy_plugins(tmp_path),
+        event_bus=EventBus(),
+        workspace=workspace,
+        session_manager=sessions,
+        installed_cache_root=tmp_path / "cache",
+    )
+    manager.bind_conversation_runtime(
+        conversation,
+        programmatic_session_creator=store.create_session,
+        programmatic_session_reader=store.get_session_meta,
+    )
+    manager.bind_durable_delivery_sender(deliver)
+    await manager.load_all()
+    root = manager.current_snapshot.composition_root
+    assert root is not None
+    source = root.context.require(CONTENT_SOURCE).bind("fitbit-e2e")
+    _ = source.submit(
+        "poll:e2e",
+        (
+            {
+                "item_id": "sleep:e2e",
+                "revision": "1",
+                "payload": {"kind": "sleep"},
+                "not_before": datetime.now(UTC),
+                "requires_ack": False,
+            },
+        ),
+    )
+    ledger = DurableDeliveryStore(
+        workspace / "runtime" / "deliveries" / "settlements.sqlite"
+    )
+    lifecycle = asyncio.create_task(manager.run_runtime_services())
+    try:
+        await _eventually(lambda: len(timer.handles) == 1)
+        timer.handles[0].fire()
+        await _eventually(lambda: provider_calls == ["recorded Wake response"])
+        await _eventually(
+            lambda: bool(ledger.recoverable()) is False
+            and len(sessions.control_store.fetch_session_messages("recipient-session"))
+            == 1
+        )
+
+        turns = store.list_turns("wake:default")
+        assert len(turns) == 1
+        accepted = TurnAcceptedReceipt("wake:default", turns[0].id)
+        delivery = PluginDurableDeliveries(ledger, None, None, recover_started=False)
+        view = delivery.lookup(accepted)
+        assert view is not None and view.state == "settled"
+        messages = sessions.control_store.fetch_session_messages("recipient-session")
+        assert messages[0]["content"] == "recorded Wake response"
+        assert messages[0]["control_turn_id"] == turns[0].id
+    finally:
+        lifecycle.cancel()
+        _ = await asyncio.gather(lifecycle, return_exceptions=True)
+        await manager.terminate_all()
+        await conversation.shutdown()
+        sessions.close()
+        store.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Wake 的成功 Content Turn 以前只停在 `ready_for_delivery`，缺少 provider、Session 与 Content 之间可恢复的投递结算。
- 用户可见结果：同一 Wake 结果只调用 provider 一次、只向 Session 追加一条 proactive assistant message，并在 Content 与 Core 两个 owner 中逐步结算；崩溃后从持久事实向前补完。
- 本 PR 不处理：Content source 上游 ACK adapter、真实外部插件迁移、旧 proactive island 删除、生产启用。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Core durable delivery 原语、Content delivery 窄口、Wake 组合；现有 DELIVERIES/passive/scheduler/message_push 不变
- `runtime_patch`：`none`
- `runtime_patch_reason`：本层使用既有 Channel exact binding、MessageBus receipt 与 Session append
- `authoritative_state_owner`：Core ledger 拥有 provider/Session forward state；Content 拥有 selection settlement；SessionStore 拥有消息
- `client_only_alternative`：不适用
- `concept_gate`：`required`
- `concept_gate_reason`：新增持久 owner、外部调用提交时机、跨库崩溃恢复与 candidate fence
- 关联不变量：provider_started 先持久化后 I/O；已知 receipt 不降为 uncertain；Session append 幂等；Core 不 import/call Content；candidate 不切断 forward target
- `protected_state`：既有 DELIVERIES、passive、Scheduler、Subagent、message_push、Session 只追加、Content source ACK、candidate 正式数据
- 允许的副作用：ledger INSERT/前向 UPDATE、一次 provider I/O、一条 Session INSERT、Content ready→delivered/settled
- 禁止的副作用：ledger DELETE、重复 provider/Session、candidate 外部调用/正式写、Core 持有 Content closure、rejected/uncertain 自动重发

## 改动范围

- 主要文件：`agent/plugin_composition/durable_deliveries.py`、`durable_delivery_store.py`、`bus/queue.py`、`agent/plugins/manager.py`、`session/**`、`plugins/content/**`、`plugins/wake/**`
- 配置或迁移影响：Wake 新增普通 delivery target 配置；正式 workspace 未迁移/启用
- 已知 schema lineage 与最终 schema identity：新增 durable delivery schema v1，exact table/constraint/index identity；v0 仅空库可初始化，未知对象 fail-loud 且零变更
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `c55a1eac942d489b8f41e81f6b1218d98ec1c6f1`；head `9da3a988a2bf62b0f550bd4f6bb98c4eeb1f56f5`
- 回滚方式：回退本 PR；备份 bundle `/mnt/data/coding/backups/akasic-agent-durable-delivery-20260823/pre-implementation-c55a1eac.bundle`

## 验证

- [x] 相关 targeted tests 已通过：`150 passed`（主任务独立复跑）
- [x] 定向 Pyright：`0 errors, 265 warnings`；warnings 来自纳入的既有大型模块
- [x] `python docker/debug/gate.py run --base c55a1eac942d489b8f41e81f6b1218d98ec1c6f1` 已运行并通过
- `sourceDigest`：`f373ba7dc5539c2cdcd54330c6129228cd7b741cfe7f4b860d2215612d15dece`
- `planDigest`：`6c3138ed7633f7773ff5e81bd07bdd709db8ab4d143ae6d7d09db832d48874b9`
- 真实设备证据：不适用；本层不改客户端协议
- 未运行项与原因：真实 provider/runtime E2E 留给独立 PR-G；本 PR 使用真实 MessageBus、recording Channel、SQLite、SessionStore 与 subprocess SIGKILL fixture

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：Terra / `gpt-5.6-terra` / `xhigh`；另有独立 Core commit correctness review
- 审查 head：`9da3a988a2bf62b0f550bd4f6bb98c4eeb1f56f5`
- 新增概念及其唯一 owner：Durable ledger 仅拥有 immutable envelope、provider receipt、Session projection、opaque settlement receipt；Content 仍独占领域结算
- 无关设计轴的变化传播：既有 DELIVERIES/passive/scheduler/subagent/message_push 默认路径零语义变化
- 最短正常/失败/热更新链路：prepared→provider_started→delivered→projected→Content settle→Core settled；crash provider_started→uncertain；rejected/uncertain 仅诊断；candidate fence forward target
- legacy/source-specific 残留扫描：Core 不引用 Content 类型/服务；Wake 只通过两个普通 ServiceKey 组合
- must-fix 及处置证据：取消丢 receipt、超长 ID 污染 Session、projected target 被候选切断、v0 半初始化均已修并有复现 fixture
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 当前无本层对应已完成事项。
