### PR TITLE
fix(migrations): preserve proactive delivery target

### DIFF
--- a/migrations/yoyo/20260825_01_migrate_proactive_delivery_target.py
+++ b/migrations/yoyo/20260825_01_migrate_proactive_delivery_target.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tomllib
+from pathlib import Path
+from uuid import uuid4
+
+import tomlkit
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+
+__depends__ = {"20260823_01_retire_legacy_toolset_wiring"}
+__transactional__ = False
+
+_MIGRATION_NAME = "migrate-proactive-delivery-target"
+
+
+class _FileSnapshot:
+    """Capture one file's bytes, permissions, and symbolic-link identity."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        content: bytes | None,
+        kind: str,
+        mode: int,
+        resolved_target: Path,
+        symlink_target: str | None,
+    ) -> None:
+        self.path = path
+        self.content = content
+        self.kind = kind
+        self.mode = mode
+        self.resolved_target = resolved_target
+        self.symlink_target = symlink_target
+
+
+class _MigrationPlan:
+    """Describe the two file publications required by one legacy config."""
+
+    def __init__(self, *, config: bytes, wake: bytes | None) -> None:
+        self.config = config
+        self.wake = wake
+
+
+def _snapshot_file(path: Path, *, absent_mode: int = 0o600) -> _FileSnapshot:
+    """Read a regular file while preserving an existing symbolic-link boundary."""
+
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return _FileSnapshot(
+            path=path,
+            content=None,
+            kind="absent",
+            mode=absent_mode,
+            resolved_target=path,
+            symlink_target=None,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"无法读取迁移源元数据: {path}") from exc
+
+    if stat.S_ISLNK(metadata.st_mode):
+        target = os.readlink(path)
+        resolved = path.resolve(strict=False)
+        if not path.is_file() or not resolved.is_file():
+            raise RuntimeError(f"迁移源软链接不是可读文件: {path}")
+        return _FileSnapshot(
+            path=path,
+            content=path.read_bytes(),
+            kind="symlink",
+            mode=stat.S_IMODE(resolved.stat().st_mode),
+            resolved_target=resolved,
+            symlink_target=target,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"迁移源必须是普通文件或软链接: {path}")
+    return _FileSnapshot(
+        path=path,
+        content=path.read_bytes(),
+        kind="file",
+        mode=stat.S_IMODE(metadata.st_mode),
+        resolved_target=path,
+        symlink_target=None,
+    )
+
+
+def _sha256(payload: bytes) -> str:
+    """Return the digest used to verify a recoverable source snapshot."""
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory entries after an atomic replacement or removal."""
+
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_atomic(path: Path, payload: bytes, mode: int) -> None:
+    """Publish one fsynced regular file through a same-directory replacement."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    candidate = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        candidate.write_bytes(payload)
+        candidate.chmod(mode)
+        with candidate.open("rb") as stream:
+            os.fsync(stream.fileno())
+        candidate.replace(path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        candidate.unlink(missing_ok=True)
+        raise
+
+
+def _validated_text(value: object, *, field: str) -> str:
+    """Validate one legacy target identity at the configuration boundary."""
+
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(f"{field} 必须是非空且无首尾空白的字符串")
+    return value
+
+
+def _legacy_delivery(proactive: object) -> dict[str, str] | None:
+    """Map one enabled legacy target to Wake's delivery schema."""
+
+    if not isinstance(proactive, dict):
+        raise ValueError("proactive 必须是 table")
+    enabled = proactive.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError("proactive.enabled 必须是布尔值")
+    if not enabled:
+        return None
+    target = proactive.get("target")
+    if not isinstance(target, dict):
+        raise ValueError("已启用 proactive 时必须配置 proactive.target")
+    channel = _validated_text(target.get("channel"), field="proactive.target.channel")
+    recipient = _validated_text(target.get("chat_id"), field="proactive.target.chat_id")
+    return {
+        "channel": channel,
+        "recipient": recipient,
+        "session_id": f"{channel}:{recipient}",
+    }
+
+
+def _render_plan(config_raw: bytes, wake_raw: bytes | None) -> _MigrationPlan | None:
+    """Remove retired proactive config and preserve its enabled delivery target."""
+
+    # 1. Parse both trust-boundary files before producing any mutation.
+    config_text = config_raw.decode("utf-8")
+    config_data = tomllib.loads(config_text)
+    if "proactive" not in config_data:
+        return None
+    delivery = _legacy_delivery(config_data["proactive"])
+    config_document = tomlkit.parse(config_text)
+    del config_document["proactive"]
+    rendered_config = tomlkit.dumps(config_document).encode("utf-8")
+    if "proactive" in tomllib.loads(rendered_config.decode("utf-8")):
+        raise RuntimeError("迁移后主配置仍含 proactive")
+
+    # 2. Add only the missing Wake delivery, preserving matching plugin config.
+    if wake_raw is None:
+        wake_document = tomlkit.document()
+    else:
+        wake_text = wake_raw.decode("utf-8")
+        tomllib.loads(wake_text)
+        wake_document = tomlkit.parse(wake_text)
+    existing = wake_document.get("delivery")
+    if delivery is None:
+        rendered_wake = wake_raw
+    elif existing is None:
+        wake_document["delivery"] = delivery
+        rendered_wake = tomlkit.dumps(wake_document).encode("utf-8")
+    elif dict(existing) == delivery:
+        rendered_wake = wake_raw
+    else:
+        raise RuntimeError("Wake delivery 已存在且与 proactive.target 冲突")
+
+    if rendered_wake is not None:
+        parsed_wake = tomllib.loads(rendered_wake.decode("utf-8"))
+        if delivery is not None and parsed_wake.get("delivery") != delivery:
+            raise RuntimeError("迁移后 Wake delivery 与旧 proactive.target 不一致")
+    return _MigrationPlan(config=rendered_config, wake=rendered_wake)
+
+
+def _write_backup(
+    snapshots: tuple[_FileSnapshot, ...], root: Path
+) -> dict[Path, Path | None]:
+    """Store verified 0600 source copies and an integrity manifest."""
+
+    root.mkdir(parents=True, mode=0o700, exist_ok=False)
+    os.chmod(root, 0o700)
+    backups: dict[Path, Path | None] = {}
+    sources: dict[str, object] = {}
+    for index, snapshot in enumerate(snapshots):
+        backup: Path | None = None
+        digest: str | None = None
+        if snapshot.content is not None:
+            backup = root / f"source-{index}.before"
+            _write_atomic(backup, snapshot.content, 0o600)
+            digest = _sha256(snapshot.content)
+            if _sha256(backup.read_bytes()) != digest:
+                raise RuntimeError(f"迁移备份校验失败: {snapshot.path}")
+        backups[snapshot.path] = backup
+        sources[str(snapshot.path)] = {
+            "kind": snapshot.kind,
+            "resolved_target": str(snapshot.resolved_target),
+            "symlink_target": snapshot.symlink_target,
+            "mode": snapshot.mode,
+            "backup": None if backup is None else backup.name,
+            "sha256": digest,
+        }
+    manifest = {
+        "schema_version": 1,
+        "migration": _MIGRATION_NAME,
+        "sources": sources,
+    }
+    payload = (
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    _write_atomic(root / "manifest.json", payload, 0o600)
+    if json.loads((root / "manifest.json").read_text(encoding="utf-8")) != manifest:
+        raise RuntimeError(f"迁移备份 manifest 校验失败: {root}")
+    return backups
+
+
+def _publish(snapshot: _FileSnapshot, payload: bytes | None) -> None:
+    """Publish or remove one file while preserving its original link boundary."""
+
+    if payload is None:
+        if snapshot.kind != "absent":
+            snapshot.path.unlink()
+            _fsync_directory(snapshot.path.parent)
+        return
+    target = snapshot.resolved_target if snapshot.kind == "symlink" else snapshot.path
+    _write_atomic(target, payload, snapshot.mode)
+    if snapshot.kind == "symlink" and (
+        not snapshot.path.is_symlink()
+        or os.readlink(snapshot.path) != snapshot.symlink_target
+    ):
+        raise RuntimeError(f"迁移发布改变了软链接身份: {snapshot.path}")
+    if snapshot.path.read_bytes() != payload:
+        raise RuntimeError(f"迁移发布校验失败: {snapshot.path}")
+
+
+def _restore(snapshot: _FileSnapshot, backup: Path | None) -> None:
+    """Restore one file to its exact pre-migration presence and bytes."""
+
+    if snapshot.content is None:
+        if snapshot.path.exists() or snapshot.path.is_symlink():
+            snapshot.path.unlink()
+            _fsync_directory(snapshot.path.parent)
+        return
+    if backup is None:
+        raise RuntimeError(f"迁移恢复缺少备份: {snapshot.path}")
+    payload = backup.read_bytes()
+    if _sha256(payload) != _sha256(snapshot.content):
+        raise RuntimeError(f"迁移恢复备份摘要不匹配: {snapshot.path}")
+    target = snapshot.resolved_target if snapshot.kind == "symlink" else snapshot.path
+    _write_atomic(target, payload, snapshot.mode)
+    if snapshot.kind == "symlink" and (
+        not snapshot.path.is_symlink()
+        or os.readlink(snapshot.path) != snapshot.symlink_target
+    ):
+        raise RuntimeError(f"迁移恢复改变了软链接身份: {snapshot.path}")
+    if snapshot.path.read_bytes() != snapshot.content:
+        raise RuntimeError(f"迁移恢复校验失败: {snapshot.path}")
+
+
+def migrate_proactive_delivery_target(_connection: object) -> None:
+    """Move the enabled legacy proactive target into Wake plugin configuration."""
+
+    _ = _connection
+    current = current_migration_context()
+    config = _snapshot_file(current.config_path)
+    if config.content is None:
+        return
+    wake_path = current.workspace / "plugin-data" / "wake-builtin" / "config.local.toml"
+    wake = _snapshot_file(wake_path)
+    plan = _render_plan(config.content, wake.content)
+    if plan is None:
+        return
+
+    # 1. Persist both source states before publishing either destination.
+    backup_root = current.workspace / "backups" / _MIGRATION_NAME / uuid4().hex
+    backups = _write_backup((config, wake), backup_root)
+
+    # 2. Publish Wake first, then retire legacy config; restore both on failure.
+    try:
+        if plan.wake != wake.content:
+            _publish(wake, plan.wake)
+        _publish(config, plan.config)
+    except BaseException as migration_error:
+        restore_errors: list[BaseException] = []
+        for snapshot in (wake, config):
+            try:
+                _restore(snapshot, backups[snapshot.path])
+            except BaseException as exc:
+                restore_errors.append(exc)
+        if restore_errors:
+            raise RuntimeError(
+                f"proactive target migration failed and restore failed: {migration_error}"
+            ) from restore_errors[0]
+        raise
+
+
+steps = [step(migrate_proactive_delivery_target)]

--- a/tests/test_main_lightweight_commands.py
+++ b/tests/test_main_lightweight_commands.py
@@ -82,6 +82,7 @@ def test_init_records_yoyo_origin_in_workspace_ledger(tmp_path: Path) -> None:
         ("20260808_06_retire_legacy_context_state",),
         ("20260817_01_akasha_sparse_index_v10",),
         ("20260823_01_retire_legacy_toolset_wiring",),
+        ("20260825_01_migrate_proactive_delivery_target",),
     ]
     assert not config_path.with_name("config.toml.migration-cursor").exists()
 

--- a/tests/test_migrate_proactive_delivery_target_migration.py
+++ b/tests/test_migrate_proactive_delivery_target_migration.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+import yoyo
+
+from agent.migrations.context import bind_migration_context
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+_MIGRATION_PATH = (
+    _PROJECT_ROOT
+    / "migrations"
+    / "yoyo"
+    / "20260825_01_migrate_proactive_delivery_target.py"
+)
+
+
+def _load_migration():
+    """Load the migration callback without wrapping it in Yoyo."""
+
+    spec = importlib.util.spec_from_file_location(
+        "migrate_proactive_delivery_target_under_test",
+        _MIGRATION_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"无法加载迁移: {_MIGRATION_PATH}")
+    original_step = yoyo.step
+    yoyo.step = lambda callback: callback  # type: ignore[assignment]
+    try:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        yoyo.step = original_step
+    return module
+
+
+def _run(module, config: Path, workspace: Path) -> None:
+    with bind_migration_context(config_path=config, workspace=workspace):
+        module.migrate_proactive_delivery_target(None)
+
+
+def _legacy_config(*, enabled: bool = True) -> bytes:
+    return (
+        '[runtime]\nworkspace = "/state/workspace"\n\n'
+        "[proactive]\n"
+        f"enabled = {str(enabled).lower()}\n"
+        'profile = "daily"\n\n'
+        "[proactive.target]\n"
+        'channel = "mobile"\n'
+        'chat_id = "conversation-id"\n\n'
+        "[proactive.agent]\n"
+        "max_steps = 35\n\n"
+        "[agent]\n"
+        'system_prompt = "preserve"\n'
+    ).encode("utf-8")
+
+
+def _wake_path(workspace: Path) -> Path:
+    return workspace / "plugin-data/wake-builtin/config.local.toml"
+
+
+def _latest_backup(workspace: Path) -> Path:
+    roots = sorted((workspace / "backups/migrate-proactive-delivery-target").iterdir())
+    assert len(roots) == 1
+    return roots[0]
+
+
+def test_enabled_mobile_target_moves_to_wake_and_preserves_root_config(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    original = _legacy_config()
+    config.write_bytes(original)
+
+    _run(module, config, workspace)
+
+    migrated = tomllib.loads(config.read_text(encoding="utf-8"))
+    assert "proactive" not in migrated
+    assert migrated["runtime"]["workspace"] == "/state/workspace"
+    assert migrated["agent"]["system_prompt"] == "preserve"
+    assert tomllib.loads(_wake_path(workspace).read_text(encoding="utf-8")) == {
+        "delivery": {
+            "channel": "mobile",
+            "recipient": "conversation-id",
+            "session_id": "mobile:conversation-id",
+        }
+    }
+    backup = _latest_backup(workspace)
+    manifest = json.loads((backup / "manifest.json").read_text(encoding="utf-8"))
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o700
+    assert stat.S_IMODE((backup / "manifest.json").stat().st_mode) == 0o600
+    config_source = manifest["sources"][str(config)]
+    assert (backup / config_source["backup"]).read_bytes() == original
+    wake_source = manifest["sources"][str(_wake_path(workspace))]
+    assert wake_source["kind"] == "absent"
+    assert wake_source["backup"] is None
+
+
+def test_disabled_legacy_proactive_is_removed_without_enabling_wake(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_bytes(_legacy_config(enabled=False))
+
+    _run(module, config, workspace)
+
+    assert "proactive" not in tomllib.loads(config.read_text(encoding="utf-8"))
+    assert not _wake_path(workspace).exists()
+
+
+def test_matching_wake_target_is_preserved_and_direct_retry_is_noop(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    config.write_bytes(_legacy_config())
+    wake = _wake_path(workspace)
+    wake.parent.mkdir(parents=True)
+    original_wake = (
+        "# operator target\n"
+        "[delivery]\n"
+        'channel = "mobile"\n'
+        'recipient = "conversation-id"\n'
+        'session_id = "mobile:conversation-id"\n'
+    ).encode("utf-8")
+    wake.write_bytes(original_wake)
+
+    _run(module, config, workspace)
+    _run(module, config, workspace)
+
+    assert wake.read_bytes() == original_wake
+    roots = sorted((workspace / "backups/migrate-proactive-delivery-target").iterdir())
+    assert len(roots) == 1
+
+
+def test_conflicting_wake_target_fails_before_any_write(tmp_path: Path) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    original_config = _legacy_config()
+    config.write_bytes(original_config)
+    wake = _wake_path(workspace)
+    wake.parent.mkdir(parents=True)
+    original_wake = (
+        "[delivery]\n"
+        'channel = "telegram"\n'
+        'recipient = "other"\n'
+        'session_id = "telegram:other"\n'
+    ).encode("utf-8")
+    wake.write_bytes(original_wake)
+
+    with pytest.raises(RuntimeError, match="冲突"):
+        _run(module, config, workspace)
+
+    assert config.read_bytes() == original_config
+    assert wake.read_bytes() == original_wake
+    assert not (workspace / "backups").exists()
+
+
+def test_enabled_target_requires_complete_identity_before_any_write(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = tmp_path / "config.toml"
+    original = b"[proactive]\nenabled = true\n"
+    config.write_bytes(original)
+
+    with pytest.raises(ValueError, match="proactive.target"):
+        _run(module, config, workspace)
+
+    assert config.read_bytes() == original
+    assert not (workspace / "backups").exists()
+
+
+def test_failed_second_publication_restores_both_files_and_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_target = tmp_path / "config-target.toml"
+    original_config = _legacy_config()
+    config_target.write_bytes(original_config)
+    config = tmp_path / "config.toml"
+    config.symlink_to(config_target)
+    original_link = os.readlink(config)
+    wake = _wake_path(workspace)
+
+    real_publish = module._publish
+
+    def fail_config_publish(snapshot, payload):
+        if snapshot.path == config:
+            raise RuntimeError("forced config publication failure")
+        real_publish(snapshot, payload)
+
+    monkeypatch.setattr(module, "_publish", fail_config_publish)
+    with pytest.raises(RuntimeError, match="forced config publication failure"):
+        _run(module, config, workspace)
+
+    assert config.is_symlink() and os.readlink(config) == original_link
+    assert config_target.read_bytes() == original_config
+    assert not wake.exists()

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -33,6 +33,7 @@ _MODEL_CAPABILITIES_ID = "20260808_01_restore_migrated_reasoning_efforts"
 _OPENCODE_VARIANTS_ID = "20260808_02_correct_opencode_go_variants"
 _AKASHA_V10_ID = "20260817_01_akasha_sparse_index_v10"
 _TOOLSET_WIRING_ID = "20260823_01_retire_legacy_toolset_wiring"
+_PROACTIVE_DELIVERY_TARGET_ID = "20260825_01_migrate_proactive_delivery_target"
 _CURRENT_IDS = (
     _ORIGIN_ID,
     _AKASHA_V9_ID,
@@ -49,6 +50,7 @@ _CURRENT_IDS = (
     _RETIRE_ID,
     _AKASHA_V10_ID,
     _TOOLSET_WIRING_ID,
+    _PROACTIVE_DELIVERY_TARGET_ID,
 )
 _CURRENT_LEDGER_IDS = tuple(sorted(_CURRENT_IDS))
 
@@ -327,13 +329,16 @@ def test_toolset_wiring_migration_retires_only_the_exact_legacy_default(
     )
     config.chmod(0o640)
 
-    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
-    assert _runner(root, repo_root=legacy_repo).run().migrations == _CURRENT_IDS[:-1]
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-2])
+    assert _runner(root, repo_root=legacy_repo).run().migrations == _CURRENT_IDS[:-2]
     before = config.read_bytes()
 
     outcome = _runner(root).run()
 
-    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    assert outcome.migrations == (
+        _TOOLSET_WIRING_ID,
+        _PROACTIVE_DELIVERY_TARGET_ID,
+    )
     migrated = tomllib.loads(config.read_text(encoding="utf-8"))
     assert migrated["agent"]["wiring"]["toolsets"] == ["meta_common"]
     assert migrated["custom"] == {"value": "protected"}
@@ -369,13 +374,16 @@ def test_toolset_wiring_migration_leaves_nonlegacy_values_untouched(
         encoding="utf-8",
     )
 
-    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-2])
     _ = _runner(root, repo_root=legacy_repo).run()
     before = config.read_bytes()
 
     outcome = _runner(root).run()
 
-    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    assert outcome.migrations == (
+        _TOOLSET_WIRING_ID,
+        _PROACTIVE_DELIVERY_TARGET_ID,
+    )
     assert config.read_bytes() == before
     assert not (root / "workspace/backups/retire-legacy-toolset-wiring").exists()
 
@@ -393,12 +401,15 @@ def test_toolset_wiring_migration_preserves_config_symlink_identity(
     config = root / "config.toml"
     config.symlink_to(source.name)
 
-    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-1])
+    legacy_repo = _catalog(tmp_path / "legacy-repo", _CURRENT_IDS[:-2])
     _ = _runner(root, repo_root=legacy_repo).run()
 
     outcome = _runner(root).run()
 
-    assert outcome.migrations == (_TOOLSET_WIRING_ID,)
+    assert outcome.migrations == (
+        _TOOLSET_WIRING_ID,
+        _PROACTIVE_DELIVERY_TARGET_ID,
+    )
     assert config.is_symlink()
     assert os.readlink(config) == source.name
     assert tomllib.loads(source.read_text(encoding="utf-8"))["agent"]["wiring"][
@@ -771,6 +782,7 @@ api_key = "secret"
         _RETIRE_ID,
         _AKASHA_V10_ID,
         _TOOLSET_WIRING_ID,
+        _PROACTIVE_DELIVERY_TARGET_ID,
     )
     assert (
         CredentialStore.for_workspace(root / "workspace").api_key("model_deepseek_main")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：旧 proactive runtime 退出时，线上投递目标没有迁入 Wake 插件配置，导致 Content 只生成待投递内容而不向 mobile 发送。
- 用户可见结果：启用的旧 target 会一次性迁为 Wake delivery，继续投到同一个 channel、recipient 和 session。
- 本 PR 不处理：不删除 Content pending，不修改 SessionDB 消息，不改变 Wake 循环或 durable delivery 状态机。

## Change intent

- `change_type`：`migration`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：旧 proactive 配置、Wake 插件配置
- `runtime_patch`：`required`
- `runtime_patch_reason`：启动迁移必须在新配置解析前保存旧投递身份。
- `authoritative_state_owner`：Yoyo 账本拥有一次性迁移；Wake 插件配置拥有当前投递目标。
- `client_only_alternative`：不适用
- `concept_gate`：`not_applicable`
- `concept_gate_reason`：没有新增领域概念、owner、公共接口或运行控制流。
- 关联不变量：MIG-001、OUT-001、OUT-003、PRO-002、BAK-001
- `protected_state`：Session 消息、Content 状态、现有插件配置、主配置其他字段
- 允许的副作用：备份旧主配置与 Wake 配置；原子写入 Wake target；移除退役 proactive table
- 禁止的副作用：冲突目标覆盖、消息删除、pending 丢弃、静默降级

## 改动范围

- 主要文件：`migrations/yoyo/20260825_01_migrate_proactive_delivery_target.py` 及定向测试
- 配置或迁移影响：enabled target 映射为 delivery.channel、recipient、session_id；disabled 配置只退出旧 table。
- 已知 schema lineage 与最终 schema identity：Yoyo ledger 新增迁移 ID；无 SQLite schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：Core head `7d79e0116a05a9f4f5f398d839976c6b3be40bbf`。
- 回滚方式：使用 migration manifest 中的逐文件 verified backup，或恢复 bundle `/mnt/data/coding/backups/akasic-agent-wake-target-yoyo-20260825/origin-main-a8603ade.bundle`。

## 验证

- [x] 相关 targeted tests 已通过：30 passed。
- [x] Pyright：0 errors；Black check 与 compileall 通过。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行并通过。
- `sourceDigest`：`ee5fbcf72f31b6184e548d92afec18a697981b69c894d550600049c0ac831d9e`
- `planDigest`：`ebba391ba495cc6d002abf79d3f337bceaf243dffd64446b220a448341c16a04`
- 真实设备证据：不适用；正式 hua-home 激活在合并发布后单独验收。
- 未运行项与原因：全量 pytest 不适用，公开 Gate 已选择并通过全部受影响合同。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`no`
- 独立 reviewer / model / reasoning：不适用
- 审查 head：`7d79e0116a05a9f4f5f398d839976c6b3be40bbf`
- 新增概念及其唯一 owner；没有时写 `none`：none
- 无关设计轴的变化传播；没有时写 `none`：none
- 最短正常/失败/热更新链路：Yoyo 读旧 target → verified backup → 写 Wake config → 删旧 table；冲突或写失败则失败并恢复，不启动 runtime。
- legacy/source-specific 残留扫描：迁移后主配置不含 proactive；Wake target 使用通用 channel/recipient/session_id。
- must-fix 及处置证据：none
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前对应 NOW 事项仍包含其他正式激活收尾，不在本 PR 整段删除。
