### PR TITLE
fix(wake): require explicit content decisions

### DIFF
--- a/agent/control/scoped_turn.py
+++ b/agent/control/scoped_turn.py
@@ -6,7 +6,13 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Protocol, cast
 
-from agent.control.models import TurnRecord, TurnRequest, TurnResult, TurnStatus
+from agent.control.models import (
+    TurnItem,
+    TurnRecord,
+    TurnRequest,
+    TurnResult,
+    TurnStatus,
+)
 from agent.control.turn_scope import TurnExecutionScope
 
 
@@ -53,6 +59,7 @@ class DurableTurnView:
     error_type: str | None
     error_message: str | None
     error_retryable: bool | None
+    items: tuple[TurnItem, ...] = ()
 
     @classmethod
     def from_record(cls, record: TurnRecord) -> DurableTurnView:
@@ -65,6 +72,7 @@ class DurableTurnView:
             error_type=error.type if error is not None else None,
             error_message=error.message if error is not None else None,
             error_retryable=error.retryable if error is not None else None,
+            items=tuple(record.items),
         )
 
 

--- a/agent/control/turn_scope.py
+++ b/agent/control/turn_scope.py
@@ -54,10 +54,17 @@ class TurnExecutionScope:
     memory_write: bool = True
     stateless: bool = False
     tool_source: ToolSource = "passive"
+    preloaded_tools: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if any(not hint.strip() for hint in self.prompt_hints):
             raise ValueError("Turn scope prompt hint 不能为空")
+        if any(not name or name.strip() != name for name in self.preloaded_tools):
+            raise ValueError("Turn scope preload Tool 名称必须非空且无首尾空白")
+        if len(self.preloaded_tools) != len(set(self.preloaded_tools)):
+            raise ValueError("Turn scope preload Tool 名称不得重复")
+        if any(not self.tool_grant.allows(name) for name in self.preloaded_tools):
+            raise ValueError("Turn scope preload Tool 必须已由 Tool grant 授权")
         overrides = dict(self.tool_overrides)
         if any(not name or tool.name != name for name, tool in overrides.items()):
             raise ValueError("Turn scope tool override 名称必须与 Tool 一致")

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1241,9 +1241,22 @@ class DefaultReasoner(Reasoner):
         disabled_tools = _disabled_tools_from_msg(msg)
         turn_scope = get_current_turn_scope()
         if turn_scope is not None:
+            registered_tools = set(self._tools.get_registered_names())
+            missing_preloads = set(turn_scope.preloaded_tools) - registered_tools
+            if missing_preloads:
+                raise RuntimeError(
+                    "Turn scope preload Tool 未注册: "
+                    + ", ".join(sorted(missing_preloads))
+                )
+            if preloaded is None:
+                preloaded = set()
+            for name in turn_scope.preloaded_tools:
+                if name not in preloaded:
+                    preloaded.add(name)
+                    preloaded_order.append(name)
             disabled_tools |= {
                 name
-                for name in self._tools.get_registered_names()
+                for name in registered_tools
                 if not turn_scope.tool_grant.allows(name)
             }
         rollout_fact = str(

--- a/docker/debug/wake_v3_provider_e2e.py
+++ b/docker/debug/wake_v3_provider_e2e.py
@@ -25,6 +25,7 @@ from agent.config_models import Config
 from agent.control.models import TurnRequest, TurnStatus
 from agent.control.runtime import ConversationRuntime
 from agent.control.timer import TimerReceipt, TimerStatus
+from agent.model_runtime.types import ToolCall
 from agent.looping.core import AgentLoop
 from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, LLMConfig
 from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
@@ -174,15 +175,27 @@ class CountingProvider:
 
 
 class ScriptedProvider:
-    """Return one deterministic model response without opening a network boundary."""
+    """Return one typed Wake decision, then the ordinary loop summary."""
 
     context_window = 64_000
 
     def __init__(self, response: str = "E2E wake response") -> None:
         self.response = response
 
-    async def chat(self, **_kwargs: object) -> LLMResponse:
-        return LLMResponse(content=self.response, tool_calls=[])
+    async def chat(self, **kwargs: object) -> LLMResponse:
+        tools = kwargs.get("tools")
+        if isinstance(tools, list) and tools:
+            return LLMResponse(
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="call:wake-share",
+                        name="share_content",
+                        arguments={"message": self.response},
+                    )
+                ],
+            )
+        return LLMResponse(content="Wake decision recorded.", tool_calls=[])
 
     def estimate_context_tokens(
         self, messages: list[dict[str, object]], tools: list[dict[str, object]]
@@ -233,8 +246,8 @@ class ProviderMilestones(logging.Handler):
         )
         return nonstream_starts + self.nonstream_retries
 
-    def logical_identity(self) -> tuple[str, str]:
-        """Return the single provider call and control Turn identities."""
+    def logical_identity(self, expected_calls: int = 1) -> tuple[tuple[str, ...], str]:
+        """Return exact provider call identities bound to one control Turn."""
 
         # 1. Every logical/transport/HTTP start must retain one provider call id.
         starts = [
@@ -252,11 +265,11 @@ class ProviderMilestones(logging.Handler):
             for event in starts
         }
         turn_ids = {str(event.get("turn_id") or "") for event in starts}
-        if len(call_ids) != 1 or "" in call_ids:
+        if len(call_ids) != expected_calls or "" in call_ids:
             raise GateFailure("PROVIDER_CALL_IDENTITY_MISMATCH")
         if len(turn_ids) != 1 or "" in turn_ids:
             raise GateFailure("PROVIDER_CONTROL_IDENTITY_MISMATCH")
-        return next(iter(call_ids)), next(iter(turn_ids))
+        return tuple(sorted(call_ids)), next(iter(turn_ids))
 
     def safe_evidence(self) -> dict[str, object]:
         """Summarize provider identities as counts and optional single digests."""
@@ -1186,11 +1199,11 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
                     llm_config=selected_llm,
                 )
                 stage = "selected_oracles"
-                if selected["logical_provider_requests"] != 1:
+                if selected["logical_provider_requests"] != 2:
                     raise GateFailure("SELECTED_LOGICAL_REQUEST_COUNT_MISMATCH")
                 if milestones.http_attempts() < 1:
                     raise GateFailure("SELECTED_HTTP_ATTEMPT_MISSING")
-                provider_call_id, provider_turn_id = milestones.logical_identity()
+                provider_call_ids, provider_turn_id = milestones.logical_identity(2)
                 if _digest_text(provider_turn_id) != selected["control_id_digest"]:
                     raise GateFailure("SELECTED_PROVIDER_CONTROL_IDENTITY_MISMATCH")
                 report.update(
@@ -1199,7 +1212,9 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
                         "deterministic_recovery": deterministic,
                         "deterministic_quiet": quiet,
                         "http_attempts": milestones.http_attempts(),
-                        "provider_call_id_digest": _digest_text(provider_call_id),
+                        "provider_call_id_digest": _digest_text(
+                            "\x00".join(provider_call_ids)
+                        ),
                         "process_isolation": isolation,
                     }
                 )

--- a/docs/decisions/0040-wake-duty-gate-lives-in-scoped-react.md
+++ b/docs/decisions/0040-wake-duty-gate-lives-in-scoped-react.md
@@ -32,12 +32,14 @@ durable due admission check
         ▼
    turn.context_prepared
         │
-        ├─ Content duty proposal ─▶ shared react
+        ├─ Content duty proposal ─▶ shared react ─▶ share_content / skip_content
         ├─ Content decline → Drift duty proposal ─▶ shared react
         └─ both decline ─▶ domain transition + existing abort
 ```
 
 外层 admission check 只回答“有没有到期事实”，不读取内容价值、不选择 Content/Drift、不构造 Prompt。内层 duty gate 是 Wake scoped Turn 的 lifecycle：固定先 Content、后 Drift；Gate 本身只读冻结 snapshot，领域 owner 负责 CAS selection 或 decline transition。
+
+Content proposal 进入 reasoner 后，普通 assistant 正文只属于 Turn 执行诊断，不拥有用户发送语义。Wake 用本轮 scope 精确预加载两个插件 Tool：`share_content(message)` 与 `skip_content(reason)`；只有 durable Turn items 中恰好一个成功调用才是 Content 的权威终态决策。`share_content.message` 是唯一可进入通用 delivery 的正文，`skip_content` 直接把 Content 逻辑失效为 abandoned；缺失或冲突的决策 defer 且零发送。Core 只提供来源无关的 scoped Tool 可见性和 durable Turn items，不识别 Wake 名称，也不解析模型自然语言。
 
 普通 lifecycle listener `return` 仍只结束 listener。两者都 decline 时必须使用现有 before-turn abort 合同，并先由 fixture 证明 quiet terminal、Session Message、after hook、memory 和 outbound 的真实行为。若现有 abort 不能满足 Wake 语义，停止实现并另立 Turn 合同；不得添加 Core `Skip`、插件名字分支或特殊返回字符串。
 
@@ -49,6 +51,7 @@ Wake listener 使用 scoped Turn 已有的 `channel="wake"` 分流。`channel` �
 - due admission 与 duty selection 分别拥有不同事实，不因都叫“gate”而合并。
 - Content/Drift 顺序由 Wake 私有 listener 明确调用，不依赖全局 listener 注册碰巧排序。
 - quiet path 使用已有 lifecycle 语义，不把插件私有 skip 升格成 Core 控制对象。
+- Content 的发送判断由 Wake 私有 typed Tool 拥有；通用 delivery 不猜 `final_response` 的含义。
 
 ## 影响
 
@@ -56,6 +59,7 @@ Wake listener 使用 scoped Turn 已有的 `channel="wake"` 分流。`channel` �
 - 第一阶段先实现真实 fixture，不迁移正式 Wake，不修改旧 proactive/Wake/Drift 数据。
 - characterization 已确认 quiet abort 不写 Session messages、不发送 outbound，也不运行 after hooks；Control runtime 仍保留 completed Turn、输入 item 和空 assistant item。实现 fixture 必须同时锁定这两类事实。
 - `tool_source` 不会因本决策自动改名或扩大职责。
+- `TurnExecutionScope.preloaded_tools` 只把已经注册且已被 `ToolGrant` 授权的 Tool 加入本轮可见集合；它不改变全局 Tool 定义、其他 Turn 或插件生命周期。
 
 ## 验收
 
@@ -66,6 +70,8 @@ Wake listener 使用 scoped Turn 已有的 `channel="wake"` 分流。`channel` �
 - [ ] quiet terminal 不产生空 outbound，不把临时 Wake input 错写成用户 Message。
 - [ ] passive、Scheduler 和 Subagent Turn 不运行 Wake duty 逻辑。
 - [ ] Core 没有 Content、Wake、Drift 名称分支或通用 `Skip`。
+- [ ] Content completed Turn 必须恰有一个成功的 `share_content` 或 `skip_content`；普通 `final_response` 永不直接投递。
+- [ ] `skip_content`、缺失决策和冲突决策均产生零 channel delivery、零用户 Session projection；重启恢复仍读取相同 durable Turn items。
 
 ## 关联设计
 

--- a/docs/design/content-wake-existing-atoms-first-stage.md
+++ b/docs/design/content-wake-existing-atoms-first-stage.md
@@ -60,7 +60,7 @@
 | `RUNTIME_STARTED / RUNTIME_STOPPING` | formal Root 开始接纳工作和停止排空的顺序 | 恢复持久 deadline、arm Timer、取消并等待本 Root task | candidate Root 不能启动真实 timer 或外部工作 |
 | `TIMERS` | 一个带时区 deadline 的 one-shot wait、cancel、receipt 和 cleanup | 等一次；到点后由插件决定下一步并重新 arm | 不知道 recurrence、job、source、retry、Content 或 Wake |
 | `SCOPED_TURNS` | exact snapshot lease、Turn admission、活进程 handle terminal、interrupt 和 cleanup | 递交普通 Message，配置临时 Prompt/Tool/Memory scope，复用同一 `react` | 当前不能在重启后按 accepted receipt 读取 durable Turn terminal，也不能显式要求 fresh logical interaction |
-| `TurnExecutionScope` | 本次 Turn 的临时执行边界 | 限定 tool grant、memory read/write、stateless、来源 | 临时 scope 不得反向改写 Session 保留语义 |
+| `TurnExecutionScope` | 本次 Turn 的临时执行边界 | 限定 tool grant、精确预加载已授权 Tool、memory read/write、stateless、来源 | 临时 scope 不得改变全局 Tool 定义或反向改写 Session 保留语义 |
 | `DELIVERIES` | 当前 Root 的完整逻辑消息发送边界和 provider receipt | 向正式 channel 发送一条完整消息并取得 delivered receipt | 当前没有 caller-supplied stable logical id 或跨崩溃 settlement ledger |
 | `CONTINUATIONS` | 向既有 parent flow 投递普通 continuation Message | Subagent 完成后通知父流程 | 不是 durable mailbox，也不等于长期记忆 |
 | `TOOL_CATALOG` | exact Root 的 Tool definition 与 bound handler | 普通插件登记 Tool；handler 捕获本 Root 私有 runtime | Core 不按插件名字寻找 handler |
@@ -181,16 +181,26 @@ submit
   ▼
 pending ──CAS select(item, revision, turn_id)──▶ selected
   │                                                │
-  ├─ defer(not_before)                             ├─ Turn completed ─────▶ ready_for_delivery
+  ├─ defer(not_before)                             ├─ completed + share ──▶ ready_for_delivery
+  │                                                ├─ completed + skip ───▶ abandoned
+  │                                                ├─ missing/conflict ───▶ deferred
   ├─ await_change                                  ├─ known retryable ────▶ deferred / pending
   └─ invalidated                                   └─ known nonretryable ─▶ invalidated / abandoned
 
 ready_for_delivery ──generic delivery settled──▶ delivered ──source ACK──▶ settled
 ```
 
+其中 Content 的 completed 分支必须进一步满足 typed decision：
+
+```text
+completed + share_content(message) ──▶ ready_for_delivery(message)
+completed + skip_content(reason)   ──▶ abandoned
+completed + missing/conflict       ──▶ deferred（零发送）
+```
+
 - `ContentGate` 只读冻结 snapshot，返回 proposal 或 decline；它不改数据库。
 - proposal 后由 Content owner 用 `item_ref + snapshot_seq/revision + accepted Turn receipt` 做 CAS selection。CAS 冲突时本 Turn quiet abort，不进入 reasoner。
-- `selected` 不是“已经消费”。它保存 selection token 与 accepted Turn receipt；Turn completed 只推进 `ready_for_delivery`，只有 durable delivery settlement 才能推进 delivered。模型失败、Tool 失败、取消或明确 rejected 均由 Wake 根据 terminal receipt 向 Content 提交 retry/defer/invalidated；结果 unknown 时保持 selected 或对应 delivery uncertain 并进入可观察恢复，不得猜测超时后再选一次。
+- `selected` 不是“已经消费”。它保存 selection token 与 accepted Turn receipt；Turn completed 本身不拥有发送语义。只有 durable Turn items 中恰好一个成功的 `share_content(message)` 才推进 `ready_for_delivery`，`skip_content(reason)` 推进 abandoned，缺失或冲突决策 defer。普通 `final_response` 只是内部诊断，不能进入 delivery。只有 durable delivery settlement 才能推进 delivered。模型失败、Tool 失败、取消或明确 rejected 均由 Wake 根据 terminal receipt 向 Content 提交 retry/defer/invalidated；结果 unknown 时保持 selected 或对应 delivery uncertain 并进入可观察恢复，不得猜测超时后再选一次。
 - 进程崩溃后的 selection 只按 durable Turn terminal 与 delivery settlement forward-complete。S1 必须先固定现有 Control recovery 的真实查询入口；若没有插件可用的窄查询能力，先用失败 fixture 证明，再评审来源无关的 Turn terminal read port。不得在 Content 中复制 Turn ledger。
 - decline 不是一句日志。Content owner 必须提交 `defer(not_before)`、`await_change` 或 `invalidated`，再重算 `wake_needed` 与 `earliest_not_before`。
 - `wake_needed` 是由 eligible 条目推导并持久化的领域事实，不是 Timer 状态。并发 submit 与重算必须以事务/CAS 防止丢更新。
@@ -221,7 +231,9 @@ Wake 的工作是：
 5. 仍有 due fact 时，创建一个带 Wake `TurnExecutionScope` 的 scoped Turn；
 6. 在 `turn.context_prepared` 的一个 Wake listener 内，固定先读纯 `ContentGate`，未命中再读纯 `DriftGate`；
 7. proposal 经领域 owner CAS 成功后才让共享 reasoner/tools 继续；两者都 decline 时由 Wake 记录领域 transition，并使用现有 before-turn abort 路径安静结束；
-8. fixture 必须先证明 abort 不产生空 outbound、不写错误 Session Message、不触发不适用的 memory/after hooks。若做不到，停止并回到 Turn 合同，不新增 Core `Skip`。
+8. Content proposal 的 Wake scope 精确预加载 `share_content` 与 `skip_content`；结算只读取 durable Tool call，绝不把普通模型正文当成用户消息；
+9. fixture 必须证明 `skip_content` 即使伴随“过滤、不推”正文也产生零 outbound/零用户 Session projection，`share_content` 只发送其 `message` 参数，重启恢复仍读取同一 durable decision；
+10. fixture 必须先证明 abort 不产生空 outbound、不写错误 Session Message、不触发不适用的 memory/after hooks。若做不到，停止并回到 Turn 合同，不新增 Core `Skip`。
 
 ```text
 Wake Timer fired
@@ -250,7 +262,7 @@ turn.context_prepared
 
 另一个已证明的缺口与 origin 无关：`BeforeTurnCtx` 看不到当前 durable `turn_id`，而 Content/Drift selection 必须绑定 Core 已经接受的 Turn；活进程 handle 丢失后，`SCOPED_TURNS` 也不能按 receipt 读取 SessionDB 中已经收敛的 terminal。最小 Core 修补仍属于同一个 Turn 聚合：lifecycle 投影当前 `turn_id`，并让 `SCOPED_TURNS.read(accepted_receipt)` 返回 immutable durable Turn view。插件不得获得 SessionStore 或完整 ControlService。
 
-Control 启动时会在插件启动前把遗留 queued/in-progress Turn 收敛为 cancelled/interrupted。owner 启动扫描据此 forward-complete selected：active 不重选；completed 进入 delivery；cancelled/interrupted/明确 retryable failure 原子 defer；明确 non-retryable failure 进入 invalidated/abandoned；receipt 指向缺失 Turn 时保持 orphaned 并发出 Incident。任何分支都不以经过多少秒猜测 terminal。
+Control 启动时会在插件启动前把遗留 queued/in-progress Turn 收敛为 cancelled/interrupted。owner 启动扫描据此 forward-complete selected：active 不重选；completed 重新读取 durable Turn items，`share_content` 才进入 delivery，`skip_content` 进入 abandoned，缺失/冲突决策 defer；cancelled/interrupted/明确 retryable failure 原子 defer；明确 non-retryable failure进入 invalidated/abandoned；receipt 指向缺失 Turn 时保持 orphaned 并发出 Incident。任何分支都不以经过多少秒猜测 terminal，也不重新解释 `final_response`。
 
 固定 Wake session 还暴露了 fresh interaction 缺口：失败或中断后的下一次 Control start 当前会自动续接旧 logical interaction。如果下一次已经选择另一个 Content/Drift proposal，这会错误继承旧 attempt replay。因此同一 Core 修补必须让 scoped programmatic start 直接表达独立 Turn 边界，不能靠随机换 session 绕过并发 owner。
 

--- a/plugins/wake/plugin.py
+++ b/plugins/wake/plugin.py
@@ -5,14 +5,16 @@ import hashlib
 import json
 import logging
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from agent.control.models import TurnStatus
+from agent.control.models import TurnItem, TurnItemKind, TurnStatus
 from agent.control.scoped_turn import DurableTurnView, TurnAcceptedReceipt
 from agent.control.timer import TimerHandle, TimerStatus
+from agent.tools.base import ToolExecutionContext
 from agent.lifecycle.composition import CONTEXT_PREPARED_EVENT
 from agent.lifecycle.types import BeforeTurnCtx
 from agent.plugin_composition import (
@@ -20,6 +22,7 @@ from agent.plugin_composition import (
     RUNTIME_STOPPING,
     SCOPED_TURNS,
     TIMERS,
+    TOOL_CATALOG,
     DURABLE_DELIVERIES,
     Context,
     DurableDeliveryRequest,
@@ -28,6 +31,7 @@ from agent.plugin_composition import (
     PluginScopedTurns,
     PluginDurableDeliveries,
     PluginTimers,
+    PluginToolDefinition,
     ServiceKey,
     TurnExecutionScope,
     ToolGrant,
@@ -128,7 +132,18 @@ inject = (
     CONTENT_WAKE,
     CONTENT_DELIVERY,
     DRIFT_WAKE,
+    TOOL_CATALOG,
 )
+
+_SHARE_CONTENT = "share_content"
+_SKIP_CONTENT = "skip_content"
+_DECISION_TOOLS = frozenset({_SHARE_CONTENT, _SKIP_CONTENT})
+
+
+@dataclass(frozen=True, slots=True)
+class _ContentDecision:
+    action: Literal["share", "skip"]
+    message: str | None = None
 
 
 class WakeRuntime:
@@ -232,7 +247,11 @@ class WakeRuntime:
             if drift_proposal.decision == "select":
                 ctx.extra_hints.append(_hint("drift", drift_proposal))
                 return
-            action = "defer" if _proposal_next_due(drift_proposals, drift_proposal) else "await_change"
+            action = (
+                "defer"
+                if _proposal_next_due(drift_proposals, drift_proposal)
+                else "await_change"
+            )
             self._drift.transition(token, action)
         self._quiet(ctx)
 
@@ -281,6 +300,7 @@ class WakeRuntime:
             session,
             "Check durable Wake duties.",
             scope=TurnExecutionScope(
+                preloaded_tools=(_SHARE_CONTENT, _SKIP_CONTENT),
                 tool_source="wake",
                 tool_grant=ToolGrant.except_names(("message_push",)),
                 stateless=True,
@@ -339,7 +359,21 @@ class WakeRuntime:
         view: DurableTurnView,
     ) -> None:
         token = _string(receipt.get("selection_token"), "selection_token")
-        if view.status is TurnStatus.COMPLETED:
+        if view.status is TurnStatus.COMPLETED and owner == "content":
+            decision = _content_decision(view)
+            if decision is None:
+                logger.error(
+                    "Wake completed Content Turn without one valid decision "
+                    "accepted=%s/%s",
+                    view.session_id,
+                    view.turn_id,
+                )
+                action = "defer"
+            else:
+                action = (
+                    "ready_for_delivery" if decision.action == "share" else "abandoned"
+                )
+        elif view.status is TurnStatus.COMPLETED:
             action = "ready_for_delivery"
         elif view.status is TurnStatus.FAILED and view.error_retryable is False:
             action = "invalidated"
@@ -352,7 +386,9 @@ class WakeRuntime:
         else:
             raise RuntimeError(f"Wake 无法 settle 非终态 Turn: {view.status.value}")
         if owner == "content":
-            deadline = self._aware_now() + timedelta(minutes=5) if action == "defer" else None
+            deadline = (
+                self._aware_now() + timedelta(minutes=5) if action == "defer" else None
+            )
             transition = self._content.transition(token, action, not_before=deadline)
         else:
             if action == "defer" and receipt.get("next_due") is None:
@@ -382,9 +418,7 @@ class WakeRuntime:
         for pending in content_delivery.pending(100):
             await self._deliver_pending(pending, deliveries, target)
 
-    async def _resume_deliveries(
-        self, deliveries: PluginDurableDeliveries
-    ) -> None:
+    async def _resume_deliveries(self, deliveries: PluginDurableDeliveries) -> None:
         """Advance existing Core rows without consulting Content payload state."""
 
         for delivery in deliveries.recoverable():
@@ -413,8 +447,9 @@ class WakeRuntime:
                     "Content ready selection 不属于 completed Turn: "
                     f"{accepted!r}/{turn.status.value}"
                 )
-            if not turn.final_response:
-                raise RuntimeError("Content ready Turn 缺少可投递 final_response")
+            decision = _content_decision(turn)
+            if decision is None or decision.action != "share" or not decision.message:
+                raise RuntimeError("Content ready Turn 缺少 share_content 决策")
             current = await deliveries.submit(
                 DurableDeliveryRequest(
                     logical_delivery_id=_logical_delivery_id(accepted),
@@ -423,7 +458,7 @@ class WakeRuntime:
                     channel=target.channel,
                     recipient=target.recipient,
                     projection_session_id=target.session_id,
-                    body=turn.final_response,
+                    body=decision.message,
                     metadata={"proactive": True},
                 )
             )
@@ -469,28 +504,32 @@ class WakeRuntime:
             delivery.logical_delivery_id,
         )
         if settled.get("settled") is not True:
-            raise RuntimeError(
-                f"Content delivery settlement 未提交: {dict(settled)!r}"
-            )
+            raise RuntimeError(f"Content delivery settlement 未提交: {dict(settled)!r}")
         receipt = _string(settled.get("receipt"), "Content delivery receipt")
-        _ = deliveries.confirm_settled(
-            delivery.logical_delivery_id, receipt
-        )
+        _ = deliveries.confirm_settled(delivery.logical_delivery_id, receipt)
 
     def _earliest_deadline(self) -> datetime | None:
         now = self._aware_now()
         content = self._content.snapshot(now).get("earliest_not_before")
         drift = self._drift.snapshot(now).get("next_due")
-        deadlines = [_datetime(value) for value in (content, drift) if value is not None]
+        deadlines = [
+            _datetime(value) for value in (content, drift) if value is not None
+        ]
         return min(deadlines) if deadlines else None
 
     def _has_due(self) -> bool:
         now = self._aware_now()
         content = self._content.snapshot(now)
-        if any(item.get("due") is True for item in _sequence(content.get("items"), "Content items")):
+        if any(
+            item.get("due") is True
+            for item in _sequence(content.get("items"), "Content items")
+        ):
             return True
         drift = self._drift.snapshot(now)
-        return any(item.get("due") is True for item in _sequence(drift.get("proposals"), "Drift proposals"))
+        return any(
+            item.get("due") is True
+            for item in _sequence(drift.get("proposals"), "Drift proposals")
+        )
 
     def _aware_now(self, value: datetime | None = None) -> datetime:
         instant = value or self._now()
@@ -526,6 +565,33 @@ async def apply(ctx: Context, config: object) -> None:
     )
     archived_rules = ArchivedRules(ctx.data_root)
 
+    async def share_handler(
+        context: ToolExecutionContext, arguments: Mapping[str, object]
+    ) -> str:
+        _validate_decision_context(context)
+        _validate_decision_argument(arguments, "message")
+        return json.dumps(
+            {"recorded": True, "turn_id": context.turn_id},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    async def skip_handler(
+        context: ToolExecutionContext, arguments: Mapping[str, object]
+    ) -> str:
+        _validate_decision_context(context)
+        _validate_decision_argument(arguments, "reason")
+        return json.dumps(
+            {"recorded": True, "turn_id": context.turn_id},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    tools = ctx.require(TOOL_CATALOG)
+    share_definition, skip_definition = _decision_definitions()
+    await tools.register(ctx, share_definition, share_handler)
+    await tools.register(ctx, skip_definition, skip_handler)
+
     def setup() -> object:
         return runtime.close
 
@@ -538,11 +604,114 @@ async def apply(ctx: Context, config: object) -> None:
 
 
 def _hint(owner: str, proposal: DutyProposal) -> str:
-    return "Wake duty:\n" + json.dumps(
+    hint = "Wake duty:\n" + json.dumps(
         {"owner": owner, "payload": dict(proposal.payload)},
         sort_keys=True,
         separators=(",", ":"),
     )
+    return hint + ("\n\n" + _decision_prompt() if owner == "content" else "")
+
+
+def _decision_prompt() -> str:
+    return (
+        "【Wake Content 决策合同】本轮普通回答不会发送给用户。处理 Content duty 后必须且只能"
+        "提交一个结构化终态：值得主动告诉用户时调用 share_content，message 只写最终用户可见"
+        "正文；不值得发送时调用 skip_content，reason 只写内部理由。"
+    )
+
+
+def _decision_definitions() -> tuple[PluginToolDefinition, ...]:
+    return (
+        PluginToolDefinition(
+            name=_SHARE_CONTENT,
+            description=(
+                "确认当前 Wake Content 候选值得主动发送。message 是唯一用户可见正文；"
+                "不要在其中写筛选过程、分数或内部判断。"
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "完整、自然、可直接发送给用户的主动消息",
+                    }
+                },
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+            handler_export="share_content",
+            risk="read-write",
+            search_hint="Wake Content 分享 主动发送",
+        ),
+        PluginToolDefinition(
+            name=_SKIP_CONTENT,
+            description="确认当前 Wake Content 候选不值得发送，并保持用户侧安静。",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": "仅供内部审计的跳过理由",
+                    }
+                },
+                "required": ["reason"],
+                "additionalProperties": False,
+            },
+            handler_export="skip_content",
+            risk="read-write",
+            search_hint="Wake Content 跳过 静默 不发送",
+        ),
+    )
+
+
+def _validate_decision_context(context: ToolExecutionContext) -> None:
+    """Confine Wake decision tools to their exact scoped Turn boundary."""
+
+    if (
+        context.origin_channel != "wake"
+        or context.origin_session_key != "wake:default"
+        or not context.turn_id
+    ):
+        raise PermissionError("Wake decision tool 只允许 wake:default scoped Turn")
+
+
+def _validate_decision_argument(arguments: Mapping[str, object], field: str) -> None:
+    """Reject empty decision payloads at the plugin Tool boundary."""
+
+    value = arguments.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} 必须是非空字符串")
+
+
+def _content_decision(view: DurableTurnView) -> _ContentDecision | None:
+    """Read one exact successful decision from the durable Turn items."""
+
+    # 1. Collect only successful Wake-private terminal calls.
+    calls: list[tuple[str, Mapping[str, object]]] = []
+    for item in view.items:
+        if item.kind is not TurnItemKind.TOOL_CALL:
+            continue
+        name = item.data.get("name")
+        if name not in _DECISION_TOOLS or item.data.get("status") != "success":
+            continue
+        arguments = item.data.get("arguments")
+        if not isinstance(arguments, Mapping):
+            raise ValueError("Wake decision tool arguments 必须是 object")
+        calls.append((cast(str, name), cast(Mapping[str, object], arguments)))
+
+    # 2. Exactly one terminal call owns the delivery decision.
+    if len(calls) != 1:
+        return None
+    name, arguments = calls[0]
+    if name == _SKIP_CONTENT:
+        reason = arguments.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("skip_content reason 必须是非空字符串")
+        return _ContentDecision("skip")
+    message = arguments.get("message")
+    if not isinstance(message, str) or not message.strip():
+        raise ValueError("share_content message 必须是非空字符串")
+    return _ContentDecision("share", message)
 
 
 def _accepted_receipt(receipt: Mapping[str, object]) -> TurnAcceptedReceipt:
@@ -565,6 +734,11 @@ def _view_from_result(result: object) -> DurableTurnView:
     if not isinstance(status, TurnStatus):
         raise TypeError("Wake scoped Turn result 缺少 typed status")
     error = getattr(result, "error", None)
+    raw_items = getattr(result, "items", None)
+    if not isinstance(raw_items, list) or any(
+        not isinstance(item, TurnItem) for item in raw_items
+    ):
+        raise TypeError("Wake scoped Turn result 缺少 typed items")
     return DurableTurnView(
         session_id=_string(getattr(result, "thread_id", None), "thread_id"),
         turn_id=_string(getattr(result, "id", None), "turn_id"),
@@ -573,6 +747,7 @@ def _view_from_result(result: object) -> DurableTurnView:
         error_type=getattr(error, "type", None),
         error_message=getattr(error, "message", None),
         error_retryable=getattr(error, "retryable", None),
+        items=tuple(raw_items),
     )
 
 

--- a/tests/control/test_scoped_turn.py
+++ b/tests/control/test_scoped_turn.py
@@ -11,7 +11,7 @@ from agent.control.errors import ThreadBusyError, TurnNotFoundError
 from agent.control.models import TurnError, TurnRecord, TurnRequest, TurnStatus
 from agent.control.runtime import ConversationRuntime
 from agent.control.scoped_turn import ScopedTurnPort, TurnAcceptedReceipt
-from agent.control.turn_scope import TurnExecutionScope
+from agent.control.turn_scope import ToolGrant, TurnExecutionScope
 from agent.plugin_composition.scoped_turns import PluginScopedTurns
 from session.store import SessionStore
 
@@ -45,6 +45,18 @@ def _queued_turn(turn_id: str, session_id: str) -> TurnRecord:
         input=turn_id,
         created_at=datetime.now(UTC),
     )
+
+
+def test_turn_scope_preload_must_be_exact_unique_and_authorized() -> None:
+    with pytest.raises(ValueError, match="无首尾空白"):
+        TurnExecutionScope(preloaded_tools=(" share_content",))
+    with pytest.raises(ValueError, match="不得重复"):
+        TurnExecutionScope(preloaded_tools=("share_content", "share_content"))
+    with pytest.raises(ValueError, match="Tool grant 授权"):
+        TurnExecutionScope(
+            preloaded_tools=("share_content",),
+            tool_grant=ToolGrant.only(("skip_content",)),
+        )
 
 
 @pytest.mark.asyncio
@@ -246,12 +258,14 @@ def test_scoped_read_observes_restart_recovery_terminals(tmp_path: Path) -> None
 
     runtime = ConversationRuntime(reopened, execute)
     service = PluginScopedTurns(runtime, reopened.create_session)
-    assert service.read(
-        TurnAcceptedReceipt(session_id, "turn:queued-restart")
-    ).status is TurnStatus.CANCELLED
-    assert service.read(
-        TurnAcceptedReceipt(session_id, "turn:active-restart")
-    ).status is TurnStatus.INTERRUPTED
+    assert (
+        service.read(TurnAcceptedReceipt(session_id, "turn:queued-restart")).status
+        is TurnStatus.CANCELLED
+    )
+    assert (
+        service.read(TurnAcceptedReceipt(session_id, "turn:active-restart")).status
+        is TurnStatus.INTERRUPTED
+    )
     reopened.close()
 
 
@@ -279,9 +293,7 @@ async def test_scoped_fresh_turn_supersedes_failed_interaction_across_restart(
 
     runtime = ConversationRuntime(store, fail_fresh)
     owner = _Scope([0])
-    fresh = await ScopedTurnPort(runtime, owner).start(
-        TurnRequest(session_id, "new")
-    )
+    fresh = await ScopedTurnPort(runtime, owner).start(TurnRequest(session_id, "new"))
     assert (await fresh.result()).status is TurnStatus.FAILED
     fresh_record = runtime.read_turn(session_id, fresh.id)
     assert fresh_record.metadata["interactionId"] == fresh.id

--- a/tests/test_agent_core_p2_reasoner.py
+++ b/tests/test_agent_core_p2_reasoner.py
@@ -8,6 +8,12 @@ from typing import Any, cast
 import pytest
 
 from agent.config_models import ContextCompactionConfig
+from agent.control.turn_scope import (
+    ToolGrant,
+    TurnExecutionScope,
+    bind_turn_scope,
+    reset_turn_scope,
+)
 from agent.core.passive_turn import DefaultReasoner
 from agent.control.ports import TurnUserInput
 from agent.core.runtime_support import SessionLike, ToolDiscoveryState
@@ -38,6 +44,7 @@ from core.error_context import (
 from session.compaction_runtime import CompactionProjection
 from session.manager import Session
 from session.store import CompactionHead
+
 
 class _ProviderContextBudget:
     context_window = 1_000_000
@@ -1145,6 +1152,116 @@ def test_default_reasoner_run_turn_uses_context_render():
     result = asyncio.run(reasoner.run_turn(msg=msg, session=cast(Any, session)))
 
     assert result.reply == "done"
+
+
+@pytest.mark.asyncio
+async def test_turn_scope_preloads_only_authorized_deferred_tool() -> None:
+    provider = _Provider([LLMResponse(content="done", tool_calls=[])])
+    tools = ToolRegistry()
+    tools.register(ToolSearchTool(tools), always_on=True, risk="read-only")
+    tools.register(_DummyTool("scoped_decision"))
+    tools.register(_DummyTool("other_deferred"))
+    reasoner = _build_reasoner(
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=tools,
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=True,
+        context=cast(
+            Any,
+            SimpleNamespace(
+                render=lambda request, **_: SimpleNamespace(
+                    messages=[
+                        {"role": "system", "content": "test context"},
+                        *request.history,
+                        {"role": "user", "content": request.current_message},
+                    ],
+                )
+            ),
+        ),
+    )
+    session = SimpleNamespace(
+        key="programmatic:scoped",
+        created_at=datetime(2026, 8, 25, tzinfo=UTC),
+        messages=[],
+        get_history=lambda max_messages=500: [],
+        last_consolidated=0,
+    )
+    msg = SimpleNamespace(
+        content="decide",
+        media=[],
+        metadata={},
+        channel="programmatic",
+        chat_id="scoped",
+        timestamp=datetime(2026, 8, 25, tzinfo=UTC),
+    )
+    token = bind_turn_scope(
+        TurnExecutionScope(
+            preloaded_tools=("scoped_decision",),
+            tool_grant=ToolGrant.only(("scoped_decision",)),
+        )
+    )
+    try:
+        result = await reasoner.run_turn(msg=msg, session=cast(Any, session))
+    finally:
+        reset_turn_scope(token)
+
+    assert result.reply == "done"
+    first_tool_names = {
+        schema["function"]["name"] for schema in provider.calls[0]["tools"]
+    }
+    assert first_tool_names == {"scoped_decision"}
+
+
+@pytest.mark.asyncio
+async def test_turn_scope_missing_preload_fails_before_provider_call() -> None:
+    provider = _Provider([LLMResponse(content="must not run", tool_calls=[])])
+    reasoner = _build_reasoner(
+        llm=cast(
+            Any,
+            LLMServices(
+                provider=cast(Any, provider), light_provider=cast(Any, provider)
+            ),
+        ),
+        llm_config=LLMConfig(model="m", max_iterations=4, max_tokens=512),
+        tools=ToolRegistry(),
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=True,
+        context=cast(Any, SimpleNamespace(render=lambda *_args, **_kwargs: None)),
+    )
+    session = SimpleNamespace(
+        key="programmatic:missing",
+        created_at=datetime(2026, 8, 25, tzinfo=UTC),
+        messages=[],
+        get_history=lambda max_messages=500: [],
+        last_consolidated=0,
+    )
+    msg = SimpleNamespace(
+        content="decide",
+        media=[],
+        metadata={},
+        channel="programmatic",
+        chat_id="missing",
+        timestamp=datetime(2026, 8, 25, tzinfo=UTC),
+    )
+    token = bind_turn_scope(
+        TurnExecutionScope(
+            preloaded_tools=("missing_decision",),
+            tool_grant=ToolGrant.only(("missing_decision",)),
+        )
+    )
+    try:
+        with pytest.raises(RuntimeError, match="preload Tool 未注册: missing_decision"):
+            await reasoner.run_turn(msg=msg, session=cast(Any, session))
+    finally:
+        reset_turn_scope(token)
+
+    assert provider.calls == []
 
 
 def test_default_reasoner_run_turn_reports_llm_timeout():

--- a/tests/test_wake_durable_delivery.py
+++ b/tests/test_wake_durable_delivery.py
@@ -7,7 +7,7 @@ from typing import cast
 
 import pytest
 
-from agent.control.models import TurnStatus
+from agent.control.models import TurnItem, TurnItemKind, TurnStatus
 from agent.control.scoped_turn import DurableTurnView, TurnAcceptedReceipt
 from agent.plugin_composition import PluginScopedTurns, PluginTimers
 from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
@@ -46,6 +46,19 @@ class _Turns:
             None,
             None,
             None,
+            (
+                TurnItem(
+                    TurnItemKind.TOOL_CALL,
+                    "item:share",
+                    {
+                        "callId": "call:share",
+                        "name": "share_content",
+                        "status": "success",
+                        "arguments": {"message": self.response},
+                        "resultPreview": '{"recorded":true}',
+                    },
+                ),
+            ),
         )
 
 

--- a/tests/test_wake_v3.py
+++ b/tests/test_wake_v3.py
@@ -7,7 +7,7 @@ from typing import cast
 
 import pytest
 
-from agent.control.models import TurnError, TurnStatus
+from agent.control.models import TurnError, TurnItem, TurnItemKind, TurnStatus
 from agent.control.scoped_turn import DurableTurnView, TurnAcceptedReceipt
 from agent.control.timer import TimerReceipt, TimerStatus
 from agent.lifecycle.types import BeforeTurnCtx
@@ -17,6 +17,20 @@ from plugins.wake.plugin import (
     DriftWakeServices,
     WakeRuntime,
 )
+
+
+def _decision_item(name: str, arguments: dict[str, object]) -> TurnItem:
+    return TurnItem(
+        TurnItemKind.TOOL_CALL,
+        f"item:{name}",
+        {
+            "callId": f"call:{name}",
+            "name": name,
+            "status": "success",
+            "arguments": arguments,
+            "resultPreview": '{"recorded":true}',
+        },
+    )
 
 
 class _TimerHandle:
@@ -67,6 +81,7 @@ class _TurnHandle:
             status=status,
             final_response="hello" if status is TurnStatus.COMPLETED else None,
             error=None,
+            items=[_decision_item("share_content", {"message": "hello"})],
         )
 
     async def result(self):
@@ -392,6 +407,11 @@ def test_terminal_matrix(status, retryable, action) -> None:
         error.type if error else None,
         error.message if error else None,
         error.retryable if error else None,
+        (
+            (_decision_item("share_content", {"message": "hello"}),)
+            if status is TurnStatus.COMPLETED
+            else ()
+        ),
     )
 
     runtime._settle(
@@ -404,7 +424,20 @@ def test_terminal_matrix(status, retryable, action) -> None:
 
 
 @pytest.mark.asyncio
-async def test_startup_reconciles_terminal_selection_before_arming() -> None:
+@pytest.mark.parametrize(
+    ("decision", "arguments", "expected_action", "expected_timers"),
+    [
+        ("share_content", {"message": "done"}, "ready_for_delivery", 0),
+        ("skip_content", {"reason": "not relevant"}, "abandoned", 0),
+        (None, {}, "defer", 0),
+    ],
+)
+async def test_startup_reconciles_durable_typed_decision_before_arming(
+    decision: str | None,
+    arguments: dict[str, object],
+    expected_action: str,
+    expected_timers: int,
+) -> None:
     now = datetime(2026, 8, 23, 9, tzinfo=UTC)
     content = _Content(now)
     content.selected_rows = [
@@ -424,22 +457,64 @@ async def test_startup_reconciles_terminal_selection_before_arming() -> None:
         "wake:default",
         "turn:old",
         TurnStatus.COMPLETED,
-        "done",
+        "过滤，不推送（事故诱饵）",
         None,
         None,
         None,
+        (() if decision is None else (_decision_item(decision, arguments),)),
     )
 
     await runtime.start()
     await asyncio.sleep(0)
 
-    assert content.transitions[0][1] == "ready_for_delivery"
-    assert timers.handles == []
+    assert content.transitions[0][1] == expected_action
+    assert len(timers.handles) == expected_timers
     await runtime.close()
 
 
+@pytest.mark.parametrize(
+    ("items", "action"),
+    [
+        ((_decision_item("skip_content", {"reason": "not relevant"}),), "abandoned"),
+        ((), "defer"),
+        (
+            (
+                _decision_item("share_content", {"message": "share"}),
+                _decision_item("skip_content", {"reason": "conflict"}),
+            ),
+            "defer",
+        ),
+    ],
+)
+def test_completed_content_requires_one_structured_decision(
+    items: tuple[TurnItem, ...], action: str
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    content = _Content(now)
+    runtime, _timers, _turns = _runtime(now, content, _Drift(now))
+
+    runtime._settle(
+        "content",
+        {"selection_token": "content:selection"},
+        DurableTurnView(
+            "wake:default",
+            "turn:decision",
+            TurnStatus.COMPLETED,
+            "internal diagnostic text",
+            None,
+            None,
+            None,
+            items,
+        ),
+    )
+
+    assert content.transitions[0][1] == action
+
+
 @pytest.mark.asyncio
-async def test_startup_active_selection_fails_loud_without_timer_or_second_turn() -> None:
+async def test_startup_active_selection_fails_loud_without_timer_or_second_turn() -> (
+    None
+):
     now = datetime(2026, 8, 23, 9, tzinfo=UTC)
     content = _Content(now)
     content.selected_rows = [

--- a/tests/test_wake_v3_composition.py
+++ b/tests/test_wake_v3_composition.py
@@ -10,12 +10,15 @@ from typing import cast
 import pytest
 
 import agent.plugins.manager as plugin_manager_module
-from agent.control.models import TurnRequest, TurnStatus
+from agent.control.models import TurnItem, TurnItemKind, TurnRequest, TurnStatus
 from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
 from agent.control.scoped_turn import TurnAcceptedReceipt
 from agent.control.timer import TimerReceipt, TimerStatus
-from agent.lifecycle.composition import CONTEXT_PREPARED_EVENT, run_composition_lifecycle
+from agent.lifecycle.composition import (
+    CONTEXT_PREPARED_EVENT,
+    run_composition_lifecycle,
+)
 from agent.lifecycle.types import BeforeTurnCtx
 from agent.plugin_composition.channels import ChannelDeliveryReceipt, DeliveryStatus
 from agent.plugin_composition.durable_deliveries import (
@@ -24,8 +27,11 @@ from agent.plugin_composition.durable_deliveries import (
 )
 from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from agent.plugins.manager import PluginManager
+from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
+from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
 from plugins.content.plugin import CONTENT_SOURCE, CONTENT_WAKE
+from plugins.content.store import ContentStore
 from plugins.drift.plugin import DRIFT_PROPOSALS, DRIFT_WAKE
 from session.manager import SessionManager
 from session.store import SessionStore
@@ -48,7 +54,9 @@ class _TimerHandle:
     async def cancel(self) -> TimerReceipt:
         if not self.future.done():
             self.future.set_result(
-                TimerReceipt(self.id, self.deadline, datetime.now(UTC), TimerStatus.CANCELLED)
+                TimerReceipt(
+                    self.id, self.deadline, datetime.now(UTC), TimerStatus.CANCELLED
+                )
             )
         return await self.future
 
@@ -90,9 +98,42 @@ def _copy_plugins(tmp_path: Path) -> list[Path]:
 
 
 @pytest.mark.asyncio
-async def test_real_wake_plugin_delivers_projects_and_settles_once(
+@pytest.mark.parametrize(
+    (
+        "decision_name",
+        "decision_arguments",
+        "decision_status",
+        "expected_content_state",
+        "expected_body",
+    ),
+    [
+        (
+            "share_content",
+            {"message": "fixture share body"},
+            "success",
+            "settled",
+            "fixture share body",
+        ),
+        (
+            "skip_content",
+            {"reason": "fixture candidate is irrelevant"},
+            "success",
+            "abandoned",
+            None,
+        ),
+        (None, {}, None, "deferred", None),
+        ("share_content", {"message": "   "}, "error", "deferred", None),
+        ("skip_content", {"reason": "\t"}, "error", "deferred", None),
+    ],
+)
+async def test_real_wake_plugin_uses_typed_decision_not_model_response(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    decision_name: str | None,
+    decision_arguments: dict[str, object],
+    decision_status: str | None,
+    expected_content_state: str,
+    expected_body: str | None,
 ) -> None:
     timer = _Timer()
     monkeypatch.setattr(plugin_manager_module, "AsyncioOneShotTimer", lambda: timer)
@@ -106,8 +147,7 @@ async def test_real_wake_plugin_delivers_projects_and_settles_once(
 channel = "recording"
 recipient = "recipient:one"
 session_id = "recipient-session"
-""".strip()
-        + "\n",
+""".strip() + "\n",
         encoding="utf-8",
     )
     store = SessionStore(workspace / "sessions.db")
@@ -129,7 +169,27 @@ session_id = "recipient-session"
             turn_id=turn_id,
         )
         await run_composition_lifecycle(CONTEXT_PREPARED_EVENT, ctx)
-        return ControlExecutionResult(response="recorded Wake response")
+        items = (
+            []
+            if decision_name is None
+            else [
+                TurnItem(
+                    TurnItemKind.TOOL_CALL,
+                    f"item:{decision_name}",
+                    {
+                        "callId": f"call:{decision_name}",
+                        "name": decision_name,
+                        "status": decision_status,
+                        "arguments": decision_arguments,
+                        "resultPreview": '{"recorded":true}',
+                    },
+                )
+            ]
+        )
+        return ControlExecutionResult(
+            response="过滤，不推送（事故诱饵，绝不能发给用户）",
+            items=items,
+        )
 
     async def deliver(request, provider_started):
         provider_started(
@@ -153,6 +213,7 @@ session_id = "recipient-session"
         event_bus=EventBus(),
         workspace=workspace,
         session_manager=sessions,
+        tool_registry=ToolRegistry(),
         installed_cache_root=tmp_path / "cache",
     )
     manager.bind_conversation_runtime(
@@ -162,6 +223,26 @@ session_id = "recipient-session"
     )
     manager.bind_durable_delivery_sender(deliver)
     await manager.load_all()
+    if decision_status == "error":
+        registry = manager.current_snapshot.tool_registry
+        assert registry is not None and decision_name is not None
+        lease = manager.snapshot_store.lease()
+        snapshot_token = bind_runtime_snapshot(lease)
+        try:
+            registry.set_context(
+                origin_channel="wake",
+                origin_session_key="wake:default",
+                turn_id="turn:boundary",
+            )
+            with pytest.raises(ValueError, match="必须是非空字符串"):
+                await registry.execute(
+                    decision_name,
+                    decision_arguments,
+                    raise_errors=True,
+                )
+        finally:
+            reset_runtime_snapshot(snapshot_token)
+            await lease.release()
     root = manager.current_snapshot.composition_root
     assert root is not None
     source = root.context.require(CONTENT_SOURCE).bind("fitbit-e2e")
@@ -180,15 +261,15 @@ session_id = "recipient-session"
     ledger = DurableDeliveryStore(
         workspace / "runtime" / "deliveries" / "settlements.sqlite"
     )
+    content_store = ContentStore(
+        workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+    )
     lifecycle = asyncio.create_task(manager.run_runtime_services())
     try:
         await _eventually(lambda: len(timer.handles) == 1)
         timer.handles[0].fire()
-        await _eventually(lambda: provider_calls == ["recorded Wake response"])
         await _eventually(
-            lambda: bool(ledger.recoverable()) is False
-            and len(sessions.control_store.fetch_session_messages("recipient-session"))
-            == 1
+            lambda: content_store.state_counts() == {expected_content_state: 1}
         )
 
         turns = store.list_turns("wake:default")
@@ -196,10 +277,18 @@ session_id = "recipient-session"
         accepted = TurnAcceptedReceipt("wake:default", turns[0].id)
         delivery = PluginDurableDeliveries(ledger, None, None, recover_started=False)
         view = delivery.lookup(accepted)
-        assert view is not None and view.state == "settled"
         messages = sessions.control_store.fetch_session_messages("recipient-session")
-        assert messages[0]["content"] == "recorded Wake response"
-        assert messages[0]["control_turn_id"] == turns[0].id
+        if expected_body is None:
+            assert provider_calls == []
+            assert messages == []
+            assert view is None
+        else:
+            assert provider_calls == [expected_body]
+            assert len(messages) == 1
+            assert messages[0]["content"] == expected_body
+            assert messages[0]["control_turn_id"] == turns[0].id
+            assert view is not None and view.state == "settled"
+        assert all("事故诱饵" not in message["content"] for message in messages)
     finally:
         lifecycle.cancel()
         _ = await asyncio.gather(lifecycle, return_exceptions=True)

--- a/tests/test_wake_v3_provider_e2e.py
+++ b/tests/test_wake_v3_provider_e2e.py
@@ -53,6 +53,36 @@ async def _start_provider_fixture(
 
         # 2. Return one explicit provider layer outcome.
         if status == 200:
+            request_tools = requests[-1].get("tools")
+            decision_request = isinstance(request_tools, list) and bool(request_tools)
+            message: dict[str, object]
+            finish_reason: str
+            if decision_request:
+                message = {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "fixture reasoning",
+                    "tool_calls": [
+                        {
+                            "id": "call:fixture-share",
+                            "type": "function",
+                            "function": {
+                                "name": "share_content",
+                                "arguments": json.dumps(
+                                    {"message": "fixture provider response"}
+                                ),
+                            },
+                        }
+                    ],
+                }
+                finish_reason = "tool_calls"
+            else:
+                message = {
+                    "role": "assistant",
+                    "content": "Wake decision recorded.",
+                    "reasoning_content": "fixture summary reasoning",
+                }
+                finish_reason = "stop"
             payload: dict[str, object] = {
                 "id": "fixture-completion",
                 "object": "chat.completion",
@@ -61,12 +91,8 @@ async def _start_provider_fixture(
                 "choices": [
                     {
                         "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": "fixture provider response",
-                            "reasoning_content": "fixture reasoning",
-                        },
-                        "finish_reason": "stop",
+                        "message": message,
+                        "finish_reason": finish_reason,
                     }
                 ],
                 "usage": {
@@ -117,7 +143,7 @@ async def test_selected_chain_uses_one_react_delivery_projection_and_ack(
 ) -> None:
     result = await run_suite(tmp_path, provider=ScriptedProvider())
 
-    assert result["logical_provider_requests"] == 1
+    assert result["logical_provider_requests"] == 2
     assert result["delivery_count"] == 1
     assert result["session_projection_count"] == 1
     assert result["content_counts"] == {"settled": 1}
@@ -138,7 +164,7 @@ async def test_restart_and_ack_retry_never_repeat_provider_or_history(
         ack_failures=1,
     )
 
-    assert result["logical_provider_requests"] == 1
+    assert result["logical_provider_requests"] == 2
     assert result["restart_count"] == 1
     assert result["settlement_failure_count"] == 1
     assert result["delivery_count"] == 1
@@ -428,12 +454,16 @@ async def test_formal_provider_200_reaches_delivery_with_production_request_shap
         await server.wait_closed()
 
     assert payload["status"] == "passed"
-    assert len(requests) == 1
-    request = requests[0]
+    assert len(requests) == 2
+    request, summary_request = requests
     assert request["model"] == "deepseek-v4-flash"
     assert request["reasoning_effort"] == "max"
     assert request["thinking"] == {"type": "enabled"}
     assert "max_tokens" not in request
+    tools = cast(list[dict[str, object]], request["tools"])
+    tool_names = {cast(dict[str, object], tool["function"])["name"] for tool in tools}
+    assert {"share_content", "skip_content"}.issubset(tool_names)
+    assert "tools" not in summary_request
     messages = cast(list[dict[str, object]], request["messages"])
     first = messages[0]
     assert first.get("role") == "system"
@@ -442,10 +472,10 @@ async def test_formal_provider_200_reaches_delivery_with_production_request_shap
     assert _BUILDER_SYSTEM_MARKER not in first_system
     evidence = cast(dict[str, Any], payload["selected_evidence"])
     assert evidence["provider_terminal_counts"] == {
-        "call_done": 1,
+        "call_done": 2,
         "call_error": 0,
         "call_cancelled": 0,
-        "nonstream_done": 1,
+        "nonstream_done": 2,
         "nonstream_error": 0,
         "nonstream_cancelled": 0,
     }


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Wake 曾把 completed Turn 的普通 `final_response` 直接当成 Content 推送正文，导致模型明确写“过滤、不推”时仍发送到 mobile。
- 用户可见结果：只有 `share_content(message)` 会产生推送；`skip_content(reason)`、缺失/冲突/非法决策均保持用户侧安静。
- 本 PR 不处理：不删除事故期间已追加的 Session messages，不改变既有 delivery target 或迁移数据。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`
- `consumer_scope`：Core Turn scope/durable view；Wake/Content 插件；通用 durable delivery consumer
- `runtime_patch`：`required`
- `runtime_patch_reason`：Core 需以来源无关方式让一个 Turn 精确预加载已授权 Tool，并向插件投影 durable Turn items。
- `authoritative_state_owner`：Core owns Turn items；Wake owns Content share/skip interpretation；Content owns item state；Core/Channel owns delivery settlement。
- `client_only_alternative`：不适用；事故发生在服务端决策与发送边界。
- `concept_gate`：`required`
- `concept_gate_reason`：改变 Turn Tool visibility 与 Wake terminal control flow。
- 关联不变量：sessions.db/messages 正常路径只追加；普通 final_response 不拥有主动发送语义；Core 不出现 Wake/Content 来源特判。
- `protected_state`：正式 workspace、既有 Session messages、delivery target、Content/Turn ledgers。
- 允许的副作用：新 Wake Turn 可追加 typed Tool call item；Content 可进入 ready_for_delivery/abandoned/deferred；share 可创建通用 delivery。
- 禁止的副作用：skip/missing/conflict/blank 决策不得产生 channel delivery 或用户 Session projection；不得改写或删除既有消息。

## 改动范围

- 主要文件：`agent/control/turn_scope.py`、`agent/control/scoped_turn.py`、`agent/core/passive_turn.py`、`plugins/wake/plugin.py` 及事故 fixtures。
- 配置或迁移影响：无新配置、无 schema migration。
- 已知 schema lineage 与最终 schema identity：无 schema 变化。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `df2a1101b558787d5faf9c25d6eb6bde7796f7e9`；head `c96d9ce1`；Gate scenario plan `40e79bd28038692076a1b25bd4a755795530fba7ee1afe24e95eaed8ebf771a0`。
- 回滚方式：激活前保留 release/config/workspace 备份；运行时可将 activation pointer 回滚到 `df2a1101` 并恢复备份。

## 验证

- [x] 相关 targeted tests 已通过：扩大相关集 104 passed，唯一失败为新增 fixture 的错误 Timer 预期；修正后单独 3 passed，最新公开 Gate 再次全绿。
- [x] Python 类型检查已通过：pyright 0 errors（既有 warnings 保留）。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：`docker/debug/reports/change-gate/20260825-014740-68349a62`。
- `sourceDigest`：`683b2afb8a412b853e001bd3c29265e3a546dc945c49134b0077956abd509617`
- `planDigest`：`40e79bd28038692076a1b25bd4a755795530fba7ee1afe24e95eaed8ebf771a0`
- 真实设备证据：本 PR 合并前不触碰正式 mobile；合并 release 后在 hua-home 做 isolated share/skip/no-decision 验收。
- 未运行项与原因：尚未激活 hua-home，等待远端 CI 与 merge。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：独立 Codex reviewer / gpt-5.6-terra / xhigh
- 审查 head：`c96d9ce1` 后同一工作树追加 fixture must-fix；最终 diff 复审 PASS
- 新增概念及其唯一 owner；没有时写 `preloaded_tools` 由 TurnExecutionScope 拥有本 Turn 可见性；Content decision 由 Wake 私有 typed tools 拥有。
- 无关设计轴的变化传播；没有时写 `none`：Scheduler/Subagent/其他插件无需修改。
- 最短正常/失败/热更新链路：selected → scoped react → durable toolCall → Wake settle → Content state → generic delivery；missing/error/conflict → defer；重启读取同一 durable items。
- legacy/source-specific 残留扫描：Core diff 无 Wake/Content/Drift 名称；decision handler 只在插件边界验证 exact wake context。
- must-fix 及处置证据：补全 no-decision 全链零发送 fixture、blank argument boundary/error fixture、tool_search=true generic scoped preload oracle；均已通过。
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已由维护者确认：使用正交能力解决，不采用简单补丁。
- [x] 跨仓库或客户端改动不适用。
- [x] `NOW.md` 的 Content/Wake 正式激活仍包含上线观察，不在本 PR 提前删除。
