### PR TITLE
fix(wake): restore pre-refactor proactive behavior

### DIFF
--- a/agent/control/turn_scope.py
+++ b/agent/control/turn_scope.py
@@ -53,6 +53,7 @@ class TurnExecutionScope:
     memory_read: bool = True
     memory_write: bool = True
     stateless: bool = False
+    session_history_read: bool = False
     tool_source: ToolSource = "passive"
     preloaded_tools: tuple[str, ...] = ()
 

--- a/agent/plugin_composition/__init__.py
+++ b/agent/plugin_composition/__init__.py
@@ -61,6 +61,10 @@ from agent.plugin_composition.session_read import (
     SessionReadService,
     SessionReadSnapshot,
 )
+from agent.plugin_composition.semantic_interest import (
+    CONVERSATION_SEMANTIC_INTEREST,
+    ConversationSemanticInterest,
+)
 from agent.plugin_composition.scoped_turns import PluginScopedTurns, SCOPED_TURNS
 from agent.plugin_composition.continuations import (
     CONTINUATIONS,
@@ -174,6 +178,8 @@ from agent.plugin_composition.ui_slots import (
 )
 
 __all__ = [
+    "CONVERSATION_SEMANTIC_INTEREST",
+    "ConversationSemanticInterest",
     "CompositionError",
     "CompositionReceipt",
     "CompositionRoot",

--- a/agent/plugin_composition/semantic_interest.py
+++ b/agent/plugin_composition/semantic_interest.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+from collections.abc import Awaitable, Sequence
+from contextlib import closing
+from pathlib import Path
+from typing import Protocol, cast
+
+from agent.plugin_composition.model import ServiceKey
+from session.embedding_store import MessageEmbeddingStore
+
+_SEMANTIC_CALIBRATION_POWER = 4
+
+
+class _EmbeddingApi(Protocol):
+    model_id: str
+
+    def embed_batch(self, texts: list[str]) -> Awaitable[list[list[float]]]: ...
+
+
+class ConversationSemanticInterest:
+    """Score candidate text against completed non-proactive conversation turns."""
+
+    def __init__(
+        self,
+        db_path: Path | None,
+        embedding_api: _EmbeddingApi | None,
+    ) -> None:
+        self._db_path = db_path
+        self._embedding_api = embedding_api
+
+    @classmethod
+    def candidate_validation(cls) -> ConversationSemanticInterest:
+        """Keep candidate topology while refusing formal conversation reads."""
+
+        return cls(None, None)
+
+    async def score(self, texts: Sequence[str], *, cutoff: str) -> tuple[float, ...]:
+        """Return the legacy calibrated maximum similarity for every candidate."""
+
+        # 1. Candidate validation must never observe formal Session state.
+        if self._db_path is None:
+            raise RuntimeError("candidate 验证期禁止访问正式 conversation semantics")
+        if any(not isinstance(text, str) for text in texts):
+            raise TypeError("semantic interest candidate text 必须是字符串")
+
+        # 2. A configured runtime without embeddings has no semantic evidence.
+        api = self._embedding_api
+        model = str(getattr(api, "model_id", "") or "")
+        if api is None or not model or not self._db_path.exists():
+            return tuple(0.0 for _ in texts)
+
+        # 3. Embed candidates, then compare only with completed passive turns.
+        indexed = [(index, text) for index, text in enumerate(texts) if text.strip()]
+        if not indexed:
+            return tuple(0.0 for _ in texts)
+        vectors = await api.embed_batch([text for _, text in indexed])
+        if len(vectors) != len(indexed):
+            raise RuntimeError("embedding provider 返回数量与候选不一致")
+        prototypes = _load_turn_prototypes(self._db_path, model=model, cutoff=cutoff)
+        scores = [0.0 for _ in texts]
+        for (index, _), vector in zip(indexed, vectors, strict=True):
+            scores[index] = min(
+                0.999,
+                max(
+                    0.0,
+                    max((_cosine(vector, item) for item in prototypes), default=0.0),
+                )
+                ** _SEMANTIC_CALIBRATION_POWER,
+            )
+        return tuple(scores)
+
+
+def _load_turn_prototypes(
+    db_path: Path, *, model: str, cutoff: str
+) -> tuple[list[float], ...]:
+    """Rebuild the last 256 passive user-assistant turn prototypes."""
+
+    store = MessageEmbeddingStore(db_path)
+    try:
+        visible = dict(store.list_until(model=model, cutoff=cutoff))
+    finally:
+        store.close()
+    if not visible:
+        return ()
+    with closing(sqlite3.connect(str(db_path))) as db:
+        rows = db.execute(
+            """
+            SELECT id, session_key, seq, role, extra, julianday(ts)
+            FROM messages
+            WHERE julianday(ts) <= julianday(?)
+            ORDER BY session_key, seq
+            """,
+            (cutoff,),
+        ).fetchall()
+    timestamped: list[tuple[float, str, int, list[float]]] = []
+    pending_user: list[float] | None = None
+    pending_session = ""
+    for message_id, session_key, seq, role, extra_json, ts_julian in rows:
+        vector = visible.get(str(message_id))
+        if role == "user":
+            pending_user = vector
+            pending_session = str(session_key)
+            continue
+        if (
+            role == "assistant"
+            and vector is not None
+            and pending_user is not None
+            and pending_session == str(session_key)
+            and not _is_proactive_message(extra_json)
+        ):
+            timestamped.append(
+                (
+                    float(ts_julian),
+                    str(session_key),
+                    int(seq),
+                    _normalize_weighted(pending_user, vector),
+                )
+            )
+            pending_user = None
+    timestamped.sort(key=lambda item: (item[0], item[1], item[2]))
+    return tuple(item[3] for item in timestamped[-256:])
+
+
+def _normalize_weighted(user: list[float], assistant: list[float]) -> list[float]:
+    if len(user) != len(assistant) or not user:
+        return []
+    combined = [
+        0.9 * left + 0.1 * right for left, right in zip(user, assistant, strict=True)
+    ]
+    norm = math.sqrt(sum(value * value for value in combined))
+    return [value / norm for value in combined] if norm > 0 else []
+
+
+def _cosine(left: list[float], right: list[float]) -> float:
+    if len(left) != len(right) or not left:
+        return 0.0
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    if left_norm <= 0 or right_norm <= 0:
+        return 0.0
+    return sum(a * b for a, b in zip(left, right, strict=True)) / (
+        left_norm * right_norm
+    )
+
+
+def _is_proactive_message(extra_json: object) -> bool:
+    try:
+        extra = json.loads(str(extra_json or "{}"))
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(extra, dict):
+        return False
+    return bool(cast(dict[str, object], extra).get("proactive"))
+
+
+CONVERSATION_SEMANTIC_INTEREST = ServiceKey[ConversationSemanticInterest](
+    "core.conversation.semantic_interest"
+)
+
+__all__ = ["CONVERSATION_SEMANTIC_INTEREST", "ConversationSemanticInterest"]

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -23,6 +23,7 @@ from pydantic import AliasChoices, AliasPath, BaseModel, ValidationError
 from agent.plugin_composition import (
     CHANNELS,
     COMMANDS,
+    CONVERSATION_SEMANTIC_INTEREST,
     CompositionError,
     MANAGED_PROCESSES,
     MCP_SERVERS,
@@ -39,6 +40,7 @@ from agent.plugin_composition import (
     TOOL_CATALOG,
     UI_SLOTS,
     CompositionRoot,
+    ConversationSemanticInterest,
     CredentialRef,
     FiberState,
     MemoryRuntimeInfo,
@@ -5225,6 +5227,23 @@ class PluginManager:
                 )
                 _ = await root.context.provide(SESSION_READ, session_read)
             if any(
+                CONVERSATION_SEMANTIC_INTEREST
+                in cast(ComposablePlugin, item.instance).inject
+                for item in ordered
+            ):
+                semantic_interest = (
+                    ConversationSemanticInterest(
+                        self._workspace / "sessions.db",
+                        cast(Any, getattr(self._memory_engine, "embedding_api", None)),
+                    )
+                    if candidate_owner is None
+                    else ConversationSemanticInterest.candidate_validation()
+                )
+                _ = await root.context.provide(
+                    CONVERSATION_SEMANTIC_INTEREST,
+                    semantic_interest,
+                )
+            if any(
                 SCOPED_TURNS in cast(ComposablePlugin, item.instance).inject
                 for item in ordered
             ):
@@ -5393,6 +5412,7 @@ class PluginManager:
                     content=request.body,
                     delivery_id=request.logical_delivery_id,
                     control_turn_id=request.accepted_turn.turn_id,
+                    metadata=request.metadata,
                 )
 
             projector = project

--- a/bootstrap/control_execution.py
+++ b/bootstrap/control_execution.py
@@ -116,9 +116,10 @@ async def execute_control_turn(
                         {
                             "omit_user_turn": True,
                             "omit_assistant_turn": True,
-                            "skip_session_history": True,
                         }
                     )
+                    if not turn_scope.session_history_read:
+                        inbound_metadata["skip_session_history"] = True
                 if not turn_scope.memory_read:
                     inbound_metadata["skip_memory_retrieval"] = True
                 if not turn_scope.memory_write:

--- a/docker/debug/wake_v3_provider_e2e.py
+++ b/docker/debug/wake_v3_provider_e2e.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import sys
 from collections.abc import Callable
@@ -20,6 +21,7 @@ if str(_SOURCE_ROOT) not in sys.path:
     sys.path.insert(0, str(_SOURCE_ROOT))
 
 import agent.plugins.manager as plugin_manager_module
+import plugins.wake.plugin as wake_plugin_module
 from agent.config import load_config
 from agent.config_models import Config
 from agent.control.models import TurnRequest, TurnStatus
@@ -185,13 +187,20 @@ class ScriptedProvider:
     async def chat(self, **kwargs: object) -> LLMResponse:
         tools = kwargs.get("tools")
         if isinstance(tools, list) and tools:
+            prompt = json.dumps(kwargs.get("messages"), ensure_ascii=False)
+            candidate = re.search(r"candidate_[0-9a-f]{16}", prompt)
+            if candidate is None:
+                raise RuntimeError("Wake E2E prompt 缺少 candidate_id")
             return LLMResponse(
                 content=None,
                 tool_calls=[
                     ToolCall(
                         id="call:wake-share",
                         name="share_content",
-                        arguments={"message": self.response},
+                        arguments={
+                            "message": self.response,
+                            "items": [candidate.group(0)],
+                        },
                     )
                 ],
             )
@@ -376,13 +385,22 @@ async def run_suite(
         workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
     )
     source_store.seed(
-        ({"kind": "fixture", "wake_action": "select"},), datetime.now(UTC)
+        (
+            {
+                "kind": "fixture",
+                "wake_action": "select",
+                "preprocess_score": 0.9,
+            },
+        ),
+        datetime.now(UTC),
     )
     source_store.fail_next_acks(ack_failures)
     counted = request_counter or CountingProvider(provider)
     timer = ControlledTimer()
     original_timer = plugin_manager_module.AsyncioOneShotTimer
     plugin_manager_module.AsyncioOneShotTimer = lambda: timer
+    original_random = wake_plugin_module.random.random
+    wake_plugin_module.random.random = lambda: 0.0
     original_settle = ContentStore.settle_delivery
     settlement_failures = 0
 
@@ -472,7 +490,7 @@ async def run_suite(
         session_rows = active.sessions.control_store.fetch_session_messages(
             "wake-provider-e2e"
         )
-        turns = active.sessions.control_store.list_turns("wake:default")
+        turns = active.sessions.control_store.list_turns("wake-provider-e2e")
         if len(channel_rows) != 1 or len(session_rows) != 1 or len(turns) != 1:
             raise GateFailure("DURABLE_ORACLE_MULTIPLICITY_MISMATCH")
         turn = turns[0]
@@ -516,6 +534,7 @@ async def run_suite(
     finally:
         ContentStore.settle_delivery = original_settle
         plugin_manager_module.AsyncioOneShotTimer = original_timer
+        wake_plugin_module.random.random = original_random
         if first is not None:
             await first.close()
         if restarted is not None:
@@ -737,12 +756,21 @@ async def run_quiet_suite(root: Path) -> dict[str, object]:
         workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
     )
     source_store.seed(
-        ({"kind": "fixture", "wake_action": "decline"},), datetime.now(UTC)
+        (
+            {
+                "kind": "fixture",
+                "wake_action": "decline",
+                "preprocess_score": 0.9,
+            },
+        ),
+        datetime.now(UTC),
     )
     counted = CountingProvider(ScriptedProvider("unexpected"))
     timer = ControlledTimer()
     original_timer = plugin_manager_module.AsyncioOneShotTimer
     plugin_manager_module.AsyncioOneShotTimer = lambda: timer
+    original_random = wake_plugin_module.random.random
+    wake_plugin_module.random.random = lambda: 0.0
     stack: RuntimeStack | None = None
     try:
         stack = _build_stack(workspace, root, timer, counted)
@@ -760,7 +788,7 @@ async def run_quiet_suite(root: Path) -> dict[str, object]:
         )
         timer.fire_earliest()
         await _eventually(
-            lambda: bool(stack.sessions.control_store.list_turns("wake:default")),
+            lambda: bool(stack.sessions.control_store.list_turns("wake-provider-e2e")),
             "QUIET_CONTROL_TURN_MISSING",
         )
 
@@ -773,7 +801,7 @@ async def run_quiet_suite(root: Path) -> dict[str, object]:
             lambda: _source_count(source_store, "poll_count") >= 2,
             "QUIET_EMPTY_POLL_NOT_COMMITTED",
         )
-        turns = stack.sessions.control_store.list_turns("wake:default")
+        turns = stack.sessions.control_store.list_turns("wake-provider-e2e")
         content_db = workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
         messages = stack.sessions.control_store.fetch_session_messages(
             "wake-provider-e2e"
@@ -801,6 +829,7 @@ async def run_quiet_suite(root: Path) -> dict[str, object]:
         }
     finally:
         plugin_manager_module.AsyncioOneShotTimer = original_timer
+        wake_plugin_module.random.random = original_random
         if stack is not None:
             await stack.close()
 
@@ -902,7 +931,7 @@ def _selected_failure_evidence(
         "SELECT id, status, json_extract(error_json, '$.type'), "
         "json_extract(error_json, '$.retryable'), final_response IS NOT NULL "
         "FROM turns WHERE session_key = ?",
-        ("wake:default",),
+        ("wake-provider-e2e",),
     )
     content_rows = _read_failure_rows(
         workspace / "plugin-data/content-builtin/content.sqlite3",

--- a/docs/decisions/0040-wake-duty-gate-lives-in-scoped-react.md
+++ b/docs/decisions/0040-wake-duty-gate-lives-in-scoped-react.md
@@ -39,7 +39,11 @@ durable due admission check
 
 外层 admission check 只回答“有没有到期事实”，不读取内容价值、不选择 Content/Drift、不构造 Prompt。内层 duty gate 是 Wake scoped Turn 的 lifecycle：固定先 Content、后 Drift；Gate 本身只读冻结 snapshot，领域 owner 负责 CAS selection 或 decline transition。
 
-Content proposal 进入 reasoner 后，普通 assistant 正文只属于 Turn 执行诊断，不拥有用户发送语义。Wake 用本轮 scope 精确预加载两个插件 Tool：`share_content(message)` 与 `skip_content(reason)`；只有 durable Turn items 中恰好一个成功调用才是 Content 的权威终态决策。`share_content.message` 是唯一可进入通用 delivery 的正文，`skip_content` 直接把 Content 逻辑失效为 abandoned；缺失或冲突的决策 defer 且零发送。Core 只提供来源无关的 scoped Tool 可见性和 durable Turn items，不识别 Wake 名称，也不解析模型自然语言。
+Content proposal 进入 reasoner 后，普通 assistant 正文只属于 Turn 执行诊断，不拥有用户发送语义。Wake 用本轮 scope 精确预加载两个插件 Tool：`share_content(message, items)` 与 `skip_content(reason)`；只有 durable Turn items 中恰好一个成功调用才是 Content 的权威终态决策。为保持大重构前的用户体验，Content 一次冻结最多 100 个候选，`share_content.items` 必须引用其中 1～5 个，整批只产生一条 `share_content.message`、一次通用 delivery 和一次 Session 投影。未引用候选继续 pending；`skip_content` 释放整批并保持 pending，不 ACK、不投影。缺失、冲突或越界引用 defer 且零发送。Core 只提供来源无关的 scoped Tool 可见性和 durable Turn items，不识别 Wake 名称，也不解析模型自然语言。
+
+重构前的兴趣语义同样属于兼容合同。Core 提供只读、来源无关的 `ConversationSemanticInterest` 窄服务：它用当前 embedding runtime 对候选标题/正文编码，并只从最近 256 个完整的非 proactive 用户—助手 Turn 构造 prototype；20 条仅主动投影不能成为 prototype。Wake 把合成后的兴趣同时用于 hazard admission 与同一冻结候选页的排序，不能“因语义醒来、却仍按未增强 preprocess 顺序选择”。没有 embedding runtime 或候选正文为空时语义分为零，保留 preprocess 路径。candidate Root 只能验证拓扑，禁止读取正式 Session。
+
+配置了 delivery target 时，Wake scoped Turn 归入目标 conversation Session，并以 `stateless + session_history_read + memory_read + memory_write=false` 执行：目标会话历史和记忆只作为本轮读入，临时 Wake 输入、内部 reasoning 与普通 `final_response` 不追加为用户消息，也不进入 Akasha；只有 provider 已送达并完成 durable projection 的主动 assistant Message 追加到目标 Session。没有 delivery target 的隔离 fixture 保持 `wake:default` 且不读取会话历史或记忆。
 
 普通 lifecycle listener `return` 仍只结束 listener。两者都 decline 时必须使用现有 before-turn abort 合同，并先由 fixture 证明 quiet terminal、Session Message、after hook、memory 和 outbound 的真实行为。若现有 abort 不能满足 Wake 语义，停止实现并另立 Turn 合同；不得添加 Core `Skip`、插件名字分支或特殊返回字符串。
 
@@ -52,6 +56,9 @@ Wake listener 使用 scoped Turn 已有的 `channel="wake"` 分流。`channel` �
 - Content/Drift 顺序由 Wake 私有 listener 明确调用，不依赖全局 listener 注册碰巧排序。
 - quiet path 使用已有 lifecycle 语义，不把插件私有 skip 升格成 Core 控制对象。
 - Content 的发送判断由 Wake 私有 typed Tool 拥有；通用 delivery 不猜 `final_response` 的含义。
+- Content 批次、候选成员、引用集合和 settlement 由 Content 自己的 SQLite ledger 唯一拥有；Wake 只组合 snapshot、typed decision 和通用 delivery。
+- Wake scoped Turn 的 `ToolGrant` 只允许上述两个 decision Tool；`message_push`、`tool_search` 和其他全局 Tool 均不可见、不可执行。
+- Content admission 用稳定 source/item/revision identity 记录已抽签条目；future `not_before` 条目在真正到期前不得被较大的 snapshot watermark 标成已见。
 
 ## 影响
 
@@ -72,6 +79,8 @@ Wake listener 使用 scoped Turn 已有的 `channel="wake"` 分流。`channel` �
 - [ ] Core 没有 Content、Wake、Drift 名称分支或通用 `Skip`。
 - [ ] Content completed Turn 必须恰有一个成功的 `share_content` 或 `skip_content`；普通 `final_response` 永不直接投递。
 - [ ] `skip_content`、缺失决策和冲突决策均产生零 channel delivery、零用户 Session projection；重启恢复仍读取相同 durable Turn items。
+- [ ] 20 个候选只创建一个 Wake Turn；share 最多消费 5 个并只投影一条消息，skip 后 20 个仍 pending 且零 ACK。
+- [ ] 配置目标会话时，Wake 读取该 Session 历史和记忆但不写临时 input/reasoning；20 条未回复 proactive 后的 `u → a` 仍只形成一个 Akasha interaction。
 
 ## 关联设计
 

--- a/docs/design/content-wake-existing-atoms-first-stage.md
+++ b/docs/design/content-wake-existing-atoms-first-stage.md
@@ -179,10 +179,10 @@ CONTENT_TRANSITION   Wake/delivery settlement → select/defer/delivered
 submit
   │
   ▼
-pending ──CAS select(item, revision, turn_id)──▶ selected
+pending ──CAS select_batch(≤100 items, turn_id)──▶ selected batch
   │                                                │
-  ├─ defer(not_before)                             ├─ completed + share ──▶ ready_for_delivery
-  │                                                ├─ completed + skip ───▶ abandoned
+  ├─ defer(not_before)                             ├─ completed + share(1..5) ─▶ ready_for_delivery
+  │                                                ├─ completed + skip ───▶ release all to pending
   │                                                ├─ missing/conflict ───▶ deferred
   ├─ await_change                                  ├─ known retryable ────▶ deferred / pending
   └─ invalidated                                   └─ known nonretryable ─▶ invalidated / abandoned
@@ -193,14 +193,17 @@ ready_for_delivery ──generic delivery settled──▶ delivered ──sourc
 其中 Content 的 completed 分支必须进一步满足 typed decision：
 
 ```text
-completed + share_content(message) ──▶ ready_for_delivery(message)
-completed + skip_content(reason)   ──▶ abandoned
+completed + share_content(message, items[1..5]) ──▶ one delivery; cited items only
+completed + skip_content(reason)                 ──▶ release batch to pending
 completed + missing/conflict       ──▶ deferred（零发送）
 ```
 
 - `ContentGate` 只读冻结 snapshot，返回 proposal 或 decline；它不改数据库。
-- proposal 后由 Content owner 用 `item_ref + snapshot_seq/revision + accepted Turn receipt` 做 CAS selection。CAS 冲突时本 Turn quiet abort，不进入 reasoner。
-- `selected` 不是“已经消费”。它保存 selection token 与 accepted Turn receipt；Turn completed 本身不拥有发送语义。只有 durable Turn items 中恰好一个成功的 `share_content(message)` 才推进 `ready_for_delivery`，`skip_content(reason)` 推进 abandoned，缺失或冲突决策 defer。普通 `final_response` 只是内部诊断，不能进入 delivery。只有 durable delivery settlement 才能推进 delivered。模型失败、Tool 失败、取消或明确 rejected 均由 Wake 根据 terminal receipt 向 Content 提交 retry/defer/invalidated；结果 unknown 时保持 selected 或对应 delivery uncertain 并进入可观察恢复，不得猜测超时后再选一次。
+- proposal 后由 Content owner 用冻结页的 `item_ref + snapshot_seq/revision + accepted Turn receipt` 做一次批次 CAS selection，最多包含 100 个候选。CAS 冲突时本 Turn quiet abort，不进入 reasoner。
+- `selected batch` 不是“已经消费”。Content selection ledger 保存 selection token、accepted Turn receipt、冻结成员与顺序。只有 durable Turn items 中恰好一个成功的 `share_content(message, items)` 才推进 `ready_for_delivery`；`items` 必须是冻结页内 1～5 个不重复 candidate id，整批只对应一条 logical delivery。投影成功后只有被引用成员进入 delivered/settled，未引用成员保持 pending。`skip_content(reason)` 释放整批到 pending，不 ACK、不发送。缺失、冲突或越界引用 defer。普通 `final_response` 只是内部诊断，不能进入 delivery。模型失败、Tool 失败、取消或明确 rejected 均由 Wake 根据 terminal receipt 向 Content 提交 retry/defer/invalidated；结果 unknown 时保持 selected 或对应 delivery uncertain 并进入可观察恢复，不得猜测超时后再选一次。
+- `selected` 阶段冻结整页，避免同一候选同时进入另一 Turn；进入 `ready_for_delivery` 后只继续锁定实际引用的 1～5 个成员。provider `uncertain` 时这些引用成员不能重选或二次发送，未引用成员仍可在下一轮选择。
+- Wake admission 的已见事实按稳定 source/item/revision identity 持久化。一次抽签只标记当时已经 due 的新条目，不能用全局 snapshot watermark 顺带吞掉 future `not_before` 条目。
+- 兼容重构前行为时，Core 的只读 conversation semantic service 从最近 256 个完整非 proactive Turn 生成 prototype。Wake 对 due 候选合成 `1-(1-preprocess)*(1-semantic)`，同一份增强后的冻结页同时进入 hazard 与候选排序；主动投影不作为 prototype，空正文或无 embedding runtime 的语义分为零。
 - 进程崩溃后的 selection 只按 durable Turn terminal 与 delivery settlement forward-complete。S1 必须先固定现有 Control recovery 的真实查询入口；若没有插件可用的窄查询能力，先用失败 fixture 证明，再评审来源无关的 Turn terminal read port。不得在 Content 中复制 Turn ledger。
 - decline 不是一句日志。Content owner 必须提交 `defer(not_before)`、`await_change` 或 `invalidated`，再重算 `wake_needed` 与 `earliest_not_before`。
 - `wake_needed` 是由 eligible 条目推导并持久化的领域事实，不是 Timer 状态。并发 submit 与重算必须以事务/CAS 防止丢更新。
@@ -213,6 +216,8 @@ Content snapshot 使用冻结 high-watermark。snapshot 建立后到达的新 it
 | 对象 | 正常增加 | 允许原位更新/逻辑失效 | 物理减少 | owner 与恢复证据 |
 |---|---|---|---|---|
 | inbox item/revision | `submit` INSERT 新 item/revision | pending、selected、ready-for-delivery、deferred、await-change、delivered、settled；invalidated/abandoned/expired 是逻辑失效 | 第一阶段无自动减少协议 | Content；完整 row、revision、snapshot_seq、accepted Turn receipt、事务 receipt |
+| Content selection batch | selection 时 INSERT batch/member ledger | selected、released、ready-for-delivery、delivered/settled | 无自动物理减少协议 | Content；selection token、accepted Turn、冻结成员、引用集合、settlement receipt |
+| Wake admission seen set | due 新条目完成一次 hazard 抽签后 INSERT stable identity | v1 watermark 只作旧状态兼容；新条目逐 identity 追加 | 无自动物理减少协议 | Wake；schema migration、SQLite integrity、future-due fixture |
 | wake state | submit/transition 更新 `wake_needed`、earliest deadline | 只由 Content 根据 eligible rows 重算 | 不适用；是单例状态 | Content；重启扫描与 invariant query |
 | source cursor/next_due | 成功 submit 后推进 | backoff/retry-after/last result 更新 | 第一阶段不自动减少 | source plugin；source 私有状态与 poll receipt |
 | source ACK record | Content delivered 后 source 查询并建立 pending | provider_acked、content_settled、uncertain | 第一阶段不自动减少 | source plugin；provider receipt 与 Content ack receipt |
@@ -260,9 +265,11 @@ turn.context_prepared
 
 当前 `TurnExecutionScope.tool_source` 只进入 Tool 调用归因，不会投影到 `BeforeTurnCtx`。但 `SCOPED_TURNS.start(channel=...)` 已把 channel 投影到 lifecycle context；Scheduler 也用自己的 channel 启动 scoped Turn。因此 Wake 使用 `channel="wake"` 分流 listener，`tool_source` 继续只负责工具归因，本阶段不新增 Core origin 字段。只有未来出现“同一 channel 内还必须区分 exact execution source”的真实案例，才重新评估来源无关的不可变 Turn origin。
 
+配置 delivery target 后，Wake Turn 使用目标 conversation Session，而不是另建 `wake:*` 用户历史。其 scope 固定为 `stateless + session_history_read + memory_read + memory_write=false`：react 能读目标会话最近历史和 Core 记忆，但临时 Wake input、reasoning 与普通 `final_response` 不进入 Session messages 或 Akasha。只有 durable provider delivery 完成后的 proactive assistant projection 才追加到目标 Session；因此连续 20 条未回复 proactive 会保留为 20 个独立主动 Message，随后 `u → a` 仍只形成一个普通 Akasha interaction，不把前面的主动消息并入该 interaction。
+
 另一个已证明的缺口与 origin 无关：`BeforeTurnCtx` 看不到当前 durable `turn_id`，而 Content/Drift selection 必须绑定 Core 已经接受的 Turn；活进程 handle 丢失后，`SCOPED_TURNS` 也不能按 receipt 读取 SessionDB 中已经收敛的 terminal。最小 Core 修补仍属于同一个 Turn 聚合：lifecycle 投影当前 `turn_id`，并让 `SCOPED_TURNS.read(accepted_receipt)` 返回 immutable durable Turn view。插件不得获得 SessionStore 或完整 ControlService。
 
-Control 启动时会在插件启动前把遗留 queued/in-progress Turn 收敛为 cancelled/interrupted。owner 启动扫描据此 forward-complete selected：active 不重选；completed 重新读取 durable Turn items，`share_content` 才进入 delivery，`skip_content` 进入 abandoned，缺失/冲突决策 defer；cancelled/interrupted/明确 retryable failure 原子 defer；明确 non-retryable failure进入 invalidated/abandoned；receipt 指向缺失 Turn 时保持 orphaned 并发出 Incident。任何分支都不以经过多少秒猜测 terminal，也不重新解释 `final_response`。
+Control 启动时会在插件启动前把遗留 queued/in-progress Turn 收敛为 cancelled/interrupted。owner 启动扫描据此 forward-complete selected：active 不重选；completed 重新读取 durable Turn items，合法 `share_content` 才进入 delivery，`skip_content` 释放整批到 pending，缺失/冲突决策 defer；cancelled/interrupted/明确 retryable failure 原子 defer；明确 non-retryable failure进入 invalidated/abandoned；receipt 指向缺失 Turn 时保持 orphaned 并发出 Incident。任何分支都不以经过多少秒猜测 terminal，也不重新解释 `final_response`。
 
 固定 Wake session 还暴露了 fresh interaction 缺口：失败或中断后的下一次 Control start 当前会自动续接旧 logical interaction。如果下一次已经选择另一个 Content/Drift proposal，这会错误继承旧 attempt replay。因此同一 Core 修补必须让 scoped programmatic start 直接表达独立 Turn 边界，不能靠随机换 session 绕过并发 owner。
 

--- a/docs/design/content-wake-proactive-migration-task-contract.md
+++ b/docs/design/content-wake-proactive-migration-task-contract.md
@@ -28,6 +28,35 @@ Source plugin ◀──────── Content unsettled + ACK ────�
 
 Core 不认识 Fitbit、Feed、Calendar、Steam、GitHub Watch、Content、Wake 或 Drift。每个来源只拥有自己的外部协议、cursor、Timer 和 ACK；Content 只拥有邮箱；Wake 只拥有 admission 与 Content→Drift 串行 duty 选择；React、Turn、Session 与 delivery 保持通用。
 
+### 2026-08-25 · 大重构前行为等价修订
+
+首次正式候选暴露出一个测试盲区：普通 `final_response` 被误当成主动正文，导致“过滤、不推送”的内部判断进入目标 Session。修复不能只拦一类字符串，激活前必须同时保持大重构前的用户体验和记录语义：
+
+```text
+new Content revisions
+        │
+        ▼
+legacy hazard admission ── reject ──▶ zero Turn / zero delivery
+        │ accept
+        ▼
+freeze ≤100 candidates in Content-owned selection ledger
+        │
+        ▼
+target Session scoped react ── share(1..5) ──▶ one durable delivery
+        │                          │
+        └─ skip ──▶ release all    └─▶ one proactive Session projection + cited ACK
+```
+
+- Wake 只能从 durable `share_content(message, items)` 取得用户正文；普通 `final_response` 永不投递。
+- Content 的 hazard 只在新条目到达时推进；一次接受只创建一个批次 Turn，最多看 100 个候选并聚合 1～5 个，不能按单条快速排空。
+- 新条目按稳定 identity 逐项记为已抽签；同一 snapshot 中尚未到期的条目继续保留未来 deadline，不能被 watermark 顺带吃掉。
+- 候选语义兴趣必须同时影响 admission 与冻结页排序；prototype 只来自最近 256 个完整非 proactive Turn，主动推送不参与。
+- v1 已经 `ready_for_delivery` 的单条 selection 迁移时标记为 `legacy_single`，只允许其既有 `share_content(message)` Turn 完成一次 provider/Session/settlement 链；新 Turn 仍严格要求 1～5 个 candidate id。
+- skip、低分未准入和未引用候选都保持用户侧静默；skip 不 ACK，候选仍 pending。
+- Drift 使用同一 typed share/skip 和 durable delivery 链；旧 schema 中已丢失正文且无法证明 provider effect 的 `ready_for_delivery` orphan 只逻辑 invalidated，禁止猜测重发。
+- 配置 target 后 Wake 读取目标 Session 历史与记忆，但 `memory_write=false`，临时 input/reasoning 不写 messages；仅 provider delivered 的 proactive assistant 追加到目标 Session，并携带 `message_push`、evidence 与 source refs 投影。
+- fixture 必须覆盖 20 条未回复 proactive 后的 `u → a`：Session 保留全部 22 条消息，Akasha 只把 `u → a` 形成一个普通 interaction，20 条 proactive 不被并入。
+
 ## 2. Change intent
 
 ```yaml

--- a/plugins/content/plugin.py
+++ b/plugins/content/plugin.py
@@ -28,9 +28,7 @@ class BoundContentSource(Protocol):
         """Read a checkpointed receipt during offline handoff verification."""
         ...
 
-    def read_revision(
-        self, item_id: str, revision: str
-    ) -> Mapping[str, object] | None:
+    def read_revision(self, item_id: str, revision: str) -> Mapping[str, object] | None:
         """Read a checkpointed revision during offline handoff verification."""
         ...
 
@@ -60,12 +58,21 @@ class ContentWakeServices(Protocol):
         now: datetime,
     ) -> Mapping[str, object]: ...
 
+    def select_batch(
+        self,
+        item_refs: Sequence[Mapping[str, object]],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> Mapping[str, object]: ...
+
     def transition(
         self,
         selection_token: str,
         action: str,
         *,
         not_before: datetime | None = None,
+        selected_refs: Sequence[Mapping[str, object]] | None = None,
     ) -> Mapping[str, object]: ...
 
 
@@ -79,6 +86,7 @@ class ContentDeliveryServices(Protocol):
     def settle(
         self, selection_token: str, settlement_ref: str
     ) -> Mapping[str, object]: ...
+
 
 CONTENT_SOURCE = ServiceKey[ContentSourceServices]("content.source.v1")
 CONTENT_WAKE = ServiceKey[ContentWakeServices]("content.wake.v1")
@@ -157,15 +165,26 @@ class _WakeServices:
     ) -> Mapping[str, object]:
         return self._store.select(item_ref, snapshot_seq, accepted_turn, now)
 
+    def select_batch(
+        self,
+        item_refs: Sequence[Mapping[str, object]],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> Mapping[str, object]:
+        return self._store.select_batch(item_refs, snapshot_seq, accepted_turn, now)
+
     def transition(
         self,
         selection_token: str,
         action: str,
         *,
         not_before: datetime | None = None,
+        selected_refs: Sequence[Mapping[str, object]] | None = None,
     ) -> Mapping[str, object]:
         allowed = {
             "ready_for_delivery",
+            "release",
             "defer",
             "await_change",
             "invalidated",
@@ -178,6 +197,7 @@ class _WakeServices:
             selection_token,
             action,
             not_before=not_before,
+            selected_refs=selected_refs,
         )
 
 
@@ -193,9 +213,7 @@ class _DeliveryServices:
     ) -> Mapping[str, object] | None:
         return self._store.delivery(accepted_turn)
 
-    def settle(
-        self, selection_token: str, settlement_ref: str
-    ) -> Mapping[str, object]:
+    def settle(self, selection_token: str, settlement_ref: str) -> Mapping[str, object]:
         return self._store.settle_delivery(selection_token, settlement_ref)
 
 

--- a/plugins/content/store.py
+++ b/plugins/content/store.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Generator, Literal, NotRequired, TypedDict, cast
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _IMMEDIATE_NOT_BEFORE = "1970-01-01T00:00:00+00:00"
 _ColumnIdentity = tuple[int, str, str, int, str | None, int]
 _IndexIdentity = tuple[str, int, str, int, tuple[str, ...]]
@@ -55,6 +55,37 @@ _TABLE_SQL = {
             PRIMARY KEY(source_id, batch_id)
         )
     """,
+    "content_selections": """
+        CREATE TABLE content_selections(
+            selection_token TEXT PRIMARY KEY,
+            accepted_session_id TEXT NOT NULL,
+            accepted_turn_id TEXT NOT NULL,
+            snapshot_seq INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            driver_source_id TEXT NOT NULL,
+            driver_item_id TEXT NOT NULL,
+            driver_revision TEXT NOT NULL,
+            decision_format TEXT NOT NULL,
+            settlement_ref TEXT UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(accepted_session_id, accepted_turn_id)
+        )
+    """,
+    "content_selection_members": """
+        CREATE TABLE content_selection_members(
+            selection_token TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            source_id TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            revision TEXT NOT NULL,
+            selected_for_delivery INTEGER NOT NULL DEFAULT 0
+                CHECK(selected_for_delivery IN (0, 1)),
+            settlement_ref TEXT UNIQUE,
+            PRIMARY KEY(selection_token, source_id, item_id, revision),
+            FOREIGN KEY(selection_token) REFERENCES content_selections(selection_token)
+        )
+    """,
 }
 _INDEX_SQL = (
     "CREATE INDEX items_wake_idx ON items(status, not_before, snapshot_seq)",
@@ -62,6 +93,10 @@ _INDEX_SQL = (
     "CREATE UNIQUE INDEX items_selected_turn_idx "
     "ON items(selected_session_id, selected_turn_id) "
     "WHERE selected_turn_id IS NOT NULL",
+    "CREATE INDEX content_selection_status_idx "
+    "ON content_selections(status, snapshot_seq)",
+    "CREATE INDEX content_selection_members_order_idx "
+    "ON content_selection_members(selection_token, position)",
 )
 _EXPECTED_COLUMNS: dict[str, tuple[_ColumnIdentity, ...]] = {
     "content_state": (
@@ -95,6 +130,29 @@ _EXPECTED_COLUMNS: dict[str, tuple[_ColumnIdentity, ...]] = {
         (3, "receipt_json", "TEXT", 1, None, 0),
         (4, "submitted_at", "TEXT", 1, None, 0),
     ),
+    "content_selections": (
+        (0, "selection_token", "TEXT", 0, None, 1),
+        (1, "accepted_session_id", "TEXT", 1, None, 0),
+        (2, "accepted_turn_id", "TEXT", 1, None, 0),
+        (3, "snapshot_seq", "INTEGER", 1, None, 0),
+        (4, "status", "TEXT", 1, None, 0),
+        (5, "driver_source_id", "TEXT", 1, None, 0),
+        (6, "driver_item_id", "TEXT", 1, None, 0),
+        (7, "driver_revision", "TEXT", 1, None, 0),
+        (8, "decision_format", "TEXT", 1, None, 0),
+        (9, "settlement_ref", "TEXT", 0, None, 0),
+        (10, "created_at", "TEXT", 1, None, 0),
+        (11, "updated_at", "TEXT", 1, None, 0),
+    ),
+    "content_selection_members": (
+        (0, "selection_token", "TEXT", 1, None, 1),
+        (1, "position", "INTEGER", 1, None, 0),
+        (2, "source_id", "TEXT", 1, None, 2),
+        (3, "item_id", "TEXT", 1, None, 3),
+        (4, "revision", "TEXT", 1, None, 4),
+        (5, "selected_for_delivery", "INTEGER", 1, "0", 0),
+        (6, "settlement_ref", "TEXT", 0, None, 0),
+    ),
 }
 _EXPECTED_INDEXES: dict[str, tuple[_IndexIdentity, ...]] = {
     "content_state": (),
@@ -126,6 +184,59 @@ _EXPECTED_INDEXES: dict[str, tuple[_IndexIdentity, ...]] = {
             "pk",
             0,
             ("source_id", "batch_id"),
+        ),
+    ),
+    "content_selections": (
+        (
+            "content_selection_status_idx",
+            0,
+            "c",
+            0,
+            ("status", "snapshot_seq"),
+        ),
+        (
+            "sqlite_autoindex_content_selections_1",
+            1,
+            "pk",
+            0,
+            ("selection_token",),
+        ),
+        (
+            "sqlite_autoindex_content_selections_2",
+            1,
+            "u",
+            0,
+            ("settlement_ref",),
+        ),
+        (
+            "sqlite_autoindex_content_selections_3",
+            1,
+            "u",
+            0,
+            ("accepted_session_id", "accepted_turn_id"),
+        ),
+    ),
+    "content_selection_members": (
+        (
+            "content_selection_members_order_idx",
+            0,
+            "c",
+            0,
+            ("selection_token", "position"),
+        ),
+        (
+            "sqlite_autoindex_content_selection_members_1",
+            1,
+            "u",
+            0,
+            ("settlement_ref",),
+        ),
+        (
+            "sqlite_autoindex_content_selection_members_2",
+            1,
+            "pk",
+            0,
+            ("selection_token", "source_id", "item_id", "revision"),
         ),
     ),
 }
@@ -208,6 +319,8 @@ class ContentSelectionReceipt(TypedDict):
     requires_ack: bool
     selection_token: str
     accepted_turn: AcceptedTurn
+    items: tuple[ContentSnapshotItem, ...]
+    decision_format: str
 
 
 class ContentSnapshot(TypedDict):
@@ -475,6 +588,21 @@ class ContentStore:
                        status, not_before, item_state_version
                 FROM items
                 WHERE snapshot_seq <= ? AND status IN ('pending', 'deferred')
+                  AND NOT EXISTS (
+                    SELECT 1 FROM content_selection_members AS member
+                    JOIN content_selections AS selection
+                      ON selection.selection_token = member.selection_token
+                    WHERE member.source_id = items.source_id
+                      AND member.item_id = items.item_id
+                      AND member.revision = items.revision
+                      AND (
+                        selection.status = 'selected'
+                        OR (
+                          selection.status = 'ready_for_delivery'
+                          AND member.selected_for_delivery = 1
+                        )
+                      )
+                  )
                 ORDER BY snapshot_seq
                 """,
                 (high_watermark,),
@@ -506,32 +634,35 @@ class ContentStore:
     def selection(
         self, accepted_turn: Mapping[str, object]
     ) -> ContentSelectionReceipt | None:
-        """Recover Content's durable selection from one accepted Turn receipt."""
+        """Recover one durable Content batch from its accepted Turn receipt."""
 
         accepted = _normalize_accepted_turn(accepted_turn)
         with self._transaction(write=False) as connection:
-            row = self._selection_row(connection, accepted)
-            return None if row is None else self._selection_receipt(row)
+            row = connection.execute(
+                """
+                SELECT * FROM content_selections
+                WHERE accepted_session_id = ? AND accepted_turn_id = ?
+                """,
+                (accepted["session_id"], accepted["turn_id"]),
+            ).fetchone()
+            return None if row is None else self._selection_receipt(connection, row)
 
     def selected(self, limit: int = 100) -> tuple[ContentSelectionReceipt, ...]:
-        """Return selected rows in stable inbox order for external recovery."""
+        """Return selected batches in stable inbox order for external recovery."""
 
         if type(limit) is not int or limit <= 0:
             raise ValueError("limit 必须是正整数")
         with self._transaction(write=False) as connection:
             rows = connection.execute(
                 """
-                SELECT source_id, item_id, revision, payload_json, snapshot_seq,
-                       status, not_before, requires_ack, item_state_version,
-                       selection_token, selected_session_id, selected_turn_id
-                FROM items
+                SELECT * FROM content_selections
                 WHERE status = 'selected'
                 ORDER BY snapshot_seq
                 LIMIT ?
                 """,
                 (limit,),
             ).fetchall()
-            return tuple(self._selection_receipt(row) for row in rows)
+            return tuple(self._selection_receipt(connection, row) for row in rows)
 
     def select(
         self,
@@ -540,15 +671,39 @@ class ContentStore:
         accepted_turn: Mapping[str, object],
         now: datetime,
     ) -> ContentSelectResult:
-        """CAS one frozen eligible revision into a Turn-bound selection."""
+        """CAS one frozen eligible revision into a one-item batch."""
 
-        ref = _normalize_ref(item_ref)
+        return self.select_batch((item_ref,), snapshot_seq, accepted_turn, now)
+
+    def select_batch(
+        self,
+        item_refs: Sequence[Mapping[str, object]],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> ContentSelectResult:
+        """CAS one frozen candidate page into a Turn-bound durable batch."""
+
+        refs = tuple(_normalize_ref(item_ref) for item_ref in item_refs)
+        if not refs or len(refs) > 100:
+            raise ValueError("Content batch selection 必须包含 1..100 个候选")
+        identities = {
+            (ref["source_id"], ref["item_id"], ref["revision"]) for ref in refs
+        }
+        if len(identities) != len(refs):
+            raise ValueError("Content batch selection 不允许重复候选")
         if type(snapshot_seq) is not int or snapshot_seq < 0:
             raise ValueError("snapshot_seq 必须是非负整数")
         accepted = _normalize_accepted_turn(accepted_turn)
         instant = _aware_utc(now)
         with self._transaction(write=True) as connection:
-            existing = self._selection_row(connection, accepted)
+            existing = connection.execute(
+                """
+                SELECT selection_token FROM content_selections
+                WHERE accepted_session_id = ? AND accepted_turn_id = ?
+                """,
+                (accepted["session_id"], accepted["turn_id"]),
+            ).fetchone()
             if existing is not None:
                 state = self._state(connection)
                 return {
@@ -561,6 +716,52 @@ class ContentStore:
                     "earliest_not_before": state["earliest_not_before"],
                 }
             token = f"content-selection:{secrets.token_hex(16)}"
+            candidates: list[sqlite3.Row] = []
+            for ref in refs:
+                row = connection.execute(
+                    """
+                    SELECT * FROM items
+                    WHERE source_id = ? AND item_id = ? AND revision = ?
+                      AND snapshot_seq <= ? AND item_state_version = ?
+                      AND status IN ('pending', 'deferred') AND not_before <= ?
+                      AND NOT EXISTS (
+                        SELECT 1 FROM content_selection_members AS member
+                        JOIN content_selections AS selection
+                          ON selection.selection_token = member.selection_token
+                        WHERE member.source_id = items.source_id
+                          AND member.item_id = items.item_id
+                          AND member.revision = items.revision
+                          AND (
+                            selection.status = 'selected'
+                            OR (
+                              selection.status = 'ready_for_delivery'
+                              AND member.selected_for_delivery = 1
+                            )
+                          )
+                      )
+                    """,
+                    (
+                        ref["source_id"],
+                        ref["item_id"],
+                        ref["revision"],
+                        snapshot_seq,
+                        ref["state_version"],
+                        instant,
+                    ),
+                ).fetchone()
+                if row is None:
+                    state = self._state(connection)
+                    return {
+                        "selected": False,
+                        "reason": "batch_candidate_changed",
+                        "selection_token": None,
+                        "accepted_turn": None,
+                        "state_version": int(state["state_version"]),
+                        "wake_needed": bool(state["wake_needed"]),
+                        "earliest_not_before": state["earliest_not_before"],
+                    }
+                candidates.append(row)
+            driver = candidates[0]
             cursor = connection.execute(
                 """
                 UPDATE items
@@ -578,16 +779,52 @@ class ContentStore:
                     accepted["session_id"],
                     accepted["turn_id"],
                     _utc_now(),
-                    ref["source_id"],
-                    ref["item_id"],
-                    ref["revision"],
+                    driver["source_id"],
+                    driver["item_id"],
+                    driver["revision"],
                     snapshot_seq,
-                    ref["state_version"],
+                    driver["item_state_version"],
                     instant,
                 ),
             )
             selected = cursor.rowcount == 1
             if selected:
+                created = _utc_now()
+                _ = connection.execute(
+                    """
+                    INSERT INTO content_selections(
+                        selection_token, accepted_session_id, accepted_turn_id,
+                        snapshot_seq, status, driver_source_id, driver_item_id,
+                        driver_revision, decision_format, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, 'selected', ?, ?, ?, 'items_v1', ?, ?)
+                    """,
+                    (
+                        token,
+                        accepted["session_id"],
+                        accepted["turn_id"],
+                        snapshot_seq,
+                        driver["source_id"],
+                        driver["item_id"],
+                        driver["revision"],
+                        created,
+                        created,
+                    ),
+                )
+                for position, row in enumerate(candidates, start=1):
+                    _ = connection.execute(
+                        """
+                        INSERT INTO content_selection_members(
+                            selection_token, position, source_id, item_id, revision
+                        ) VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (
+                            token,
+                            position,
+                            row["source_id"],
+                            row["item_id"],
+                            row["revision"],
+                        ),
+                    )
                 _ = connection.execute(
                     "UPDATE content_state SET state_version = state_version + 1 WHERE singleton = 1"
                 )
@@ -603,39 +840,50 @@ class ContentStore:
             }
 
     @staticmethod
-    def _selection_row(
-        connection: sqlite3.Connection, accepted_turn: AcceptedTurn
-    ) -> sqlite3.Row | None:
-        return connection.execute(
+    def _selection_receipt(
+        connection: sqlite3.Connection, row: sqlite3.Row
+    ) -> ContentSelectionReceipt:
+        members = connection.execute(
             """
-            SELECT source_id, item_id, revision, payload_json, snapshot_seq,
-                   status, not_before, requires_ack, item_state_version,
-                   selection_token, selected_session_id, selected_turn_id
-            FROM items
-            WHERE selected_session_id = ? AND selected_turn_id = ?
+            SELECT i.* FROM content_selection_members AS m
+            JOIN items AS i USING(source_id, item_id, revision)
+            WHERE m.selection_token = ? ORDER BY m.position
             """,
-            (accepted_turn["session_id"], accepted_turn["turn_id"]),
-        ).fetchone()
-
-    @staticmethod
-    def _selection_receipt(row: sqlite3.Row) -> ContentSelectionReceipt:
+            (row["selection_token"],),
+        ).fetchall()
+        if not members:
+            raise RuntimeError("Content selection batch 缺少 members")
+        driver = next(
+            (
+                member
+                for member in members
+                if member["source_id"] == row["driver_source_id"]
+                and member["item_id"] == row["driver_item_id"]
+                and member["revision"] == row["driver_revision"]
+            ),
+            None,
+        )
+        if driver is None:
+            raise RuntimeError("Content selection batch 缺少 driver")
         return {
             "selection_token": row["selection_token"],
             "ref": {
-                "source_id": row["source_id"],
-                "item_id": row["item_id"],
-                "revision": row["revision"],
-                "state_version": int(row["item_state_version"]),
+                "source_id": driver["source_id"],
+                "item_id": driver["item_id"],
+                "revision": driver["revision"],
+                "state_version": int(driver["item_state_version"]),
             },
-            "payload": json.loads(row["payload_json"]),
+            "payload": json.loads(driver["payload_json"]),
             "snapshot_seq": int(row["snapshot_seq"]),
             "status": row["status"],
-            "not_before": row["not_before"],
-            "requires_ack": bool(row["requires_ack"]),
+            "not_before": driver["not_before"],
+            "requires_ack": bool(driver["requires_ack"]),
             "accepted_turn": {
-                "session_id": row["selected_session_id"],
-                "turn_id": row["selected_turn_id"],
+                "session_id": row["accepted_session_id"],
+                "turn_id": row["accepted_turn_id"],
             },
+            "items": tuple(_snapshot_item(member) for member in members),
+            "decision_format": row["decision_format"],
         }
 
     def transition(
@@ -645,12 +893,14 @@ class ContentStore:
         *,
         not_before: datetime | None = None,
         settlement_ref: str | None = None,
+        selected_refs: Sequence[Mapping[str, object]] | None = None,
     ) -> ContentTransitionResult:
         """Commit one explicit domain transition without inferring Turn state."""
 
         token = _identity("selection_token", selection_token)
         if action not in {
             "ready_for_delivery",
+            "release",
             "defer",
             "await_change",
             "invalidated",
@@ -665,16 +915,24 @@ class ContentStore:
             raise ValueError("delivered 必须提供 settlement_ref")
         if action != "delivered" and settlement_ref is not None:
             raise ValueError("只有 delivered transition 可以提供 settlement_ref")
+        if action != "ready_for_delivery" and selected_refs is not None:
+            raise ValueError("只有 ready_for_delivery 可以提供 selected_refs")
         deadline = _aware_utc(not_before) if not_before is not None else None
         settlement = (
             _identity("settlement_ref", settlement_ref)
             if settlement_ref is not None
             else None
         )
+        if action == "delivered":
+            assert settlement is not None
+            return cast(
+                ContentTransitionResult,
+                self.settle_delivery(token, settlement),
+            )
 
         with self._transaction(write=True) as connection:
             row = connection.execute(
-                "SELECT status, requires_ack FROM items WHERE selection_token = ?",
+                "SELECT * FROM content_selections WHERE selection_token = ?",
                 (token,),
             ).fetchone()
             if row is None:
@@ -691,17 +949,56 @@ class ContentStore:
             if row["status"] not in allowed_statuses:
                 return {"changed": False, "reason": f"status:{row['status']}"}
             status = "deferred" if action == "defer" else action
-            if action == "delivered" and not bool(row["requires_ack"]):
-                status = "settled"
+            result_status = status
+            updated = _utc_now()
+            if action == "ready_for_delivery":
+                chosen = self._select_delivery_members(
+                    connection,
+                    token,
+                    selected_refs,
+                    driver=(
+                        row["driver_source_id"],
+                        row["driver_item_id"],
+                        row["driver_revision"],
+                    ),
+                )
+                driver_chosen = (
+                    row["driver_source_id"],
+                    row["driver_item_id"],
+                    row["driver_revision"],
+                ) in chosen
+                if driver_chosen:
+                    _ = connection.execute(
+                        """
+                        UPDATE items SET status = 'ready_for_delivery',
+                            item_state_version = item_state_version + 1, updated_at = ?
+                        WHERE selection_token = ? AND status = 'selected'
+                        """,
+                        (updated, token),
+                    )
+                else:
+                    self._release_driver(connection, token, updated)
+            elif action == "release":
+                status = "released"
+                result_status = "pending"
+                self._release_driver(connection, token, updated)
+            else:
+                _ = connection.execute(
+                    """
+                    UPDATE items SET status = ?, not_before = COALESCE(?, not_before),
+                        settlement_ref = COALESCE(?, settlement_ref),
+                        item_state_version = item_state_version + 1, updated_at = ?
+                    WHERE selection_token = ?
+                    """,
+                    (status, deadline, settlement, updated, token),
+                )
             _ = connection.execute(
                 """
-                UPDATE items
-                SET status = ?, not_before = COALESCE(?, not_before),
-                    settlement_ref = COALESCE(?, settlement_ref),
-                    item_state_version = item_state_version + 1, updated_at = ?
-                WHERE selection_token = ?
+                UPDATE content_selections
+                SET status = ?, settlement_ref = COALESCE(?, settlement_ref),
+                    updated_at = ? WHERE selection_token = ?
                 """,
-                (status, deadline, settlement, _utc_now(), token),
+                (status, settlement, updated, token),
             )
             _ = connection.execute(
                 "UPDATE content_state SET state_version = state_version + 1 WHERE singleton = 1"
@@ -710,11 +1007,72 @@ class ContentStore:
             state = self._state(connection)
             return {
                 "changed": True,
-                "status": status,
+                "status": result_status,
                 "state_version": int(state["state_version"]),
                 "wake_needed": bool(state["wake_needed"]),
                 "earliest_not_before": state["earliest_not_before"],
             }
+
+    @staticmethod
+    def _select_delivery_members(
+        connection: sqlite3.Connection,
+        token: str,
+        selected_refs: Sequence[Mapping[str, object]] | None,
+        *,
+        driver: tuple[str, str, str],
+    ) -> set[tuple[str, str, str]]:
+        """Validate and persist the one-to-five members represented by one message."""
+
+        raw_refs = (
+            ({"source_id": driver[0], "item_id": driver[1], "revision": driver[2]},)
+            if selected_refs is None
+            else selected_refs
+        )
+        chosen = {
+            (
+                _identity("source_id", ref.get("source_id")),
+                _identity("item_id", ref.get("item_id")),
+                _identity("revision", ref.get("revision")),
+            )
+            for ref in raw_refs
+        }
+        if not chosen or len(chosen) > 5 or len(chosen) != len(raw_refs):
+            raise ValueError("Content share 必须引用 1..5 个不重复候选")
+        available = {
+            (str(row["source_id"]), str(row["item_id"]), str(row["revision"]))
+            for row in connection.execute(
+                """
+                SELECT source_id, item_id, revision
+                FROM content_selection_members WHERE selection_token = ?
+                """,
+                (token,),
+            )
+        }
+        if not chosen <= available:
+            raise ValueError("Content share 引用了批次外候选")
+        for source_id, item_id, revision in chosen:
+            _ = connection.execute(
+                """
+                UPDATE content_selection_members SET selected_for_delivery = 1
+                WHERE selection_token = ? AND source_id = ? AND item_id = ? AND revision = ?
+                """,
+                (token, source_id, item_id, revision),
+            )
+        return chosen
+
+    @staticmethod
+    def _release_driver(
+        connection: sqlite3.Connection, token: str, updated_at: str
+    ) -> None:
+        _ = connection.execute(
+            """
+            UPDATE items SET status = 'pending', selection_token = NULL,
+                selected_session_id = NULL, selected_turn_id = NULL,
+                item_state_version = item_state_version + 1, updated_at = ?
+            WHERE selection_token = ? AND status IN ('selected', 'ready_for_delivery')
+            """,
+            (updated_at, token),
+        )
 
     def unsettled(
         self, source_id: str, limit: int = 100
@@ -756,45 +1114,44 @@ class ContentStore:
         with self._transaction(write=False) as connection:
             rows = connection.execute(
                 """
-                SELECT selection_token, selected_session_id, selected_turn_id,
-                       snapshot_seq
-                FROM items
+                SELECT * FROM content_selections
                 WHERE status = 'ready_for_delivery'
                 ORDER BY snapshot_seq
                 LIMIT ?
                 """,
                 (limit,),
             ).fetchall()
-            return tuple(
-                {
-                    "selection_token": _identity(
-                        "selection_token", row["selection_token"]
-                    ),
-                    "accepted_turn": {
-                        "session_id": _identity(
-                            "selected_session_id", row["selected_session_id"]
+            pending: list[dict[str, object]] = []
+            for row in rows:
+                members = self._delivery_member_rows(connection, row["selection_token"])
+                pending.append(
+                    {
+                        "selection_token": _identity(
+                            "selection_token", row["selection_token"]
                         ),
-                        "turn_id": _identity(
-                            "selected_turn_id", row["selected_turn_id"]
-                        ),
-                    },
-                }
-                for row in rows
-            )
+                        "accepted_turn": {
+                            "session_id": _identity(
+                                "accepted_session_id", row["accepted_session_id"]
+                            ),
+                            "turn_id": _identity(
+                                "accepted_turn_id", row["accepted_turn_id"]
+                            ),
+                        },
+                        "message_metadata": _message_metadata_many(members),
+                        "decision_format": row["decision_format"],
+                    }
+                )
+            return tuple(pending)
 
-    def delivery(
-        self, accepted_turn: Mapping[str, object]
-    ) -> dict[str, object] | None:
+    def delivery(self, accepted_turn: Mapping[str, object]) -> dict[str, object] | None:
         """Read a body-free delivery receipt by its accepted Turn identity."""
 
         accepted = _normalize_accepted_turn(accepted_turn)
         with self._transaction(write=False) as connection:
             row = connection.execute(
                 """
-                SELECT selection_token, selected_session_id, selected_turn_id,
-                       status, settlement_ref
-                FROM items
-                WHERE selected_session_id = ? AND selected_turn_id = ?
+                SELECT * FROM content_selections
+                WHERE accepted_session_id = ? AND accepted_turn_id = ?
                 """,
                 (accepted["session_id"], accepted["turn_id"]),
             ).fetchone()
@@ -807,6 +1164,14 @@ class ContentStore:
                 "settlement_ref": row["settlement_ref"],
             }
             if row["status"] in {"delivered", "settled"}:
+                member_statuses = {
+                    str(member["status"])
+                    for member in self._delivery_member_rows(
+                        connection, row["selection_token"]
+                    )
+                }
+                if member_statuses == {"settled"}:
+                    result["status"] = "settled"
                 settlement = _identity("settlement_ref", row["settlement_ref"])
                 result["receipt"] = _delivery_receipt(
                     str(row["selection_token"]), settlement
@@ -826,10 +1191,7 @@ class ContentStore:
 
         with self._transaction(write=True) as connection:
             row = connection.execute(
-                """
-                SELECT status, requires_ack, settlement_ref
-                FROM items WHERE selection_token = ?
-                """,
+                "SELECT * FROM content_selections WHERE selection_token = ?",
                 (token,),
             ).fetchone()
             if row is None:
@@ -845,22 +1207,72 @@ class ContentStore:
                 }
             if row["status"] != "ready_for_delivery":
                 return {"settled": False, "reason": f"status:{row['status']}"}
-            status = "delivered" if bool(row["requires_ack"]) else "settled"
+            members = self._delivery_member_rows(connection, token)
+            if not members:
+                raise RuntimeError("Content ready batch 缺少 delivery members")
+            updated = _utc_now()
+            statuses: set[str] = set()
+            for member in members:
+                member_settlement = (
+                    settlement
+                    if len(members) == 1
+                    else _member_settlement(settlement, member)
+                )
+                status = "delivered" if bool(member["requires_ack"]) else "settled"
+                statuses.add(status)
+                cursor = connection.execute(
+                    """
+                    UPDATE items SET status = ?, settlement_ref = ?,
+                        item_state_version = item_state_version + 1, updated_at = ?
+                    WHERE source_id = ? AND item_id = ? AND revision = ?
+                      AND status IN ('pending', 'deferred', 'selected', 'ready_for_delivery')
+                    """,
+                    (
+                        status,
+                        member_settlement,
+                        updated,
+                        member["source_id"],
+                        member["item_id"],
+                        member["revision"],
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError(
+                        "Content delivery member state changed before settlement"
+                    )
+                _ = connection.execute(
+                    """
+                    UPDATE content_selection_members SET settlement_ref = ?
+                    WHERE selection_token = ? AND source_id = ? AND item_id = ? AND revision = ?
+                    """,
+                    (
+                        member_settlement,
+                        token,
+                        member["source_id"],
+                        member["item_id"],
+                        member["revision"],
+                    ),
+                )
+            driver_selected = any(
+                member["source_id"] == row["driver_source_id"]
+                and member["item_id"] == row["driver_item_id"]
+                and member["revision"] == row["driver_revision"]
+                for member in members
+            )
+            if not driver_selected:
+                self._release_driver(connection, token, updated)
+            status = "delivered" if "delivered" in statuses else "settled"
             _ = connection.execute(
                 """
-                UPDATE items
-                SET status = ?, settlement_ref = ?,
-                    item_state_version = item_state_version + 1, updated_at = ?
+                UPDATE content_selections SET status = ?, settlement_ref = ?, updated_at = ?
                 WHERE selection_token = ? AND status = 'ready_for_delivery'
                 """,
-                (status, settlement, _utc_now(), token),
+                (status, settlement, updated, token),
             )
-            _ = connection.execute(
-                """
+            _ = connection.execute("""
                 UPDATE content_state
                 SET state_version = state_version + 1 WHERE singleton = 1
-                """
-            )
+                """)
             self._recompute_wake(connection)
             return {
                 "settled": True,
@@ -868,6 +1280,21 @@ class ContentStore:
                 "status": status,
                 "receipt": receipt,
             }
+
+    @staticmethod
+    def _delivery_member_rows(
+        connection: sqlite3.Connection, selection_token: str
+    ) -> tuple[sqlite3.Row, ...]:
+        rows = connection.execute(
+            """
+            SELECT i.* FROM content_selection_members AS m
+            JOIN items AS i USING(source_id, item_id, revision)
+            WHERE m.selection_token = ? AND m.selected_for_delivery = 1
+            ORDER BY m.position
+            """,
+            (selection_token,),
+        ).fetchall()
+        return tuple(rows)
 
     def ack(self, source_id: str, settlement_ref: str) -> dict[str, object]:
         """Settle one delivered row only through its source-bound view."""
@@ -916,7 +1343,9 @@ class ContentStore:
 
         # 1. Reject every candidate write at the store's single transaction boundary.
         if write and self.data_access == "read_only":
-            raise PermissionError("Content read-only candidate cannot write shared data")
+            raise PermissionError(
+                "Content read-only candidate cannot write shared data"
+            )
 
         # 2. Preserve the formal store's serialized transaction and lazy schema setup.
         if self.data_access == "read_write":
@@ -958,9 +1387,7 @@ class ContentStore:
             )
 
         # 2. Immutable mode proves the verification read itself creates no WAL/SHM.
-        database_uri = (
-            self.path.resolve(strict=False).as_uri() + "?mode=ro&immutable=1"
-        )
+        database_uri = self.path.resolve(strict=False).as_uri() + "?mode=ro&immutable=1"
         connection = sqlite3.connect(database_uri, uri=True)
         connection.row_factory = sqlite3.Row
         try:
@@ -977,19 +1404,119 @@ class ContentStore:
     @staticmethod
     def _ensure_schema(connection: sqlite3.Connection) -> None:
         version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-        if version not in (0, _SCHEMA_VERSION):
+        if version not in (0, 1, _SCHEMA_VERSION):
             raise RuntimeError(f"不支持的 Content schema version: {version}")
         if version == _SCHEMA_VERSION:
+            return
+        if version == 1:
+            ContentStore._migrate_v1(connection)
             return
         statements = (
             _TABLE_SQL["content_state"],
             "INSERT INTO content_state VALUES(1, 0, 0, 0, NULL)",
             _TABLE_SQL["items"],
-            *_INDEX_SQL,
             _TABLE_SQL["submissions"],
+            _TABLE_SQL["content_selections"],
+            _TABLE_SQL["content_selection_members"],
+            *_INDEX_SQL,
             f"PRAGMA user_version = {_SCHEMA_VERSION}",
         )
         _ = connection.executescript(";\n".join(statements) + ";")
+
+    @staticmethod
+    def _migrate_v1(connection: sqlite3.Connection) -> None:
+        """Add durable batch selections after proving the exact v1 owner schema."""
+
+        # 1. Refuse to reinterpret an unknown database as Content v1.
+        tables = {
+            str(row["name"]): str(row["sql"])
+            for row in connection.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        legacy_tables = {
+            key: _TABLE_SQL[key] for key in ("content_state", "items", "submissions")
+        }
+        if set(tables) != set(legacy_tables):
+            raise RuntimeError("Content v1 schema mismatch: owned tables")
+        for table, expected in legacy_tables.items():
+            if _normalize_sql(tables[table]) != _normalize_sql(expected):
+                raise RuntimeError(f"Content v1 schema mismatch: {table} table SQL")
+        legacy_indexes = {
+            "content_state": _EXPECTED_INDEXES["content_state"],
+            "items": _EXPECTED_INDEXES["items"],
+            "submissions": _EXPECTED_INDEXES["submissions"],
+        }
+        for table, expected in legacy_indexes.items():
+            if _schema_indexes(connection, table) != expected:
+                raise RuntimeError(f"Content v1 schema mismatch: {table} indexes")
+
+        # 2. Add one selection ledger and preserve every extant single-item selection.
+        _ = connection.executescript(
+            ";\n".join(
+                (
+                    _TABLE_SQL["content_selections"],
+                    _TABLE_SQL["content_selection_members"],
+                    _INDEX_SQL[3],
+                    _INDEX_SQL[4],
+                )
+            )
+            + ";"
+        )
+        rows = connection.execute("""
+            SELECT source_id, item_id, revision, snapshot_seq, status,
+                   selection_token, selected_session_id, selected_turn_id,
+                   settlement_ref, updated_at
+            FROM items WHERE selection_token IS NOT NULL
+            ORDER BY snapshot_seq
+            """).fetchall()
+        for row in rows:
+            token = _identity("selection_token", row["selection_token"])
+            session_id = _identity("selected_session_id", row["selected_session_id"])
+            turn_id = _identity("selected_turn_id", row["selected_turn_id"])
+            _ = connection.execute(
+                """
+                INSERT INTO content_selections(
+                    selection_token, accepted_session_id, accepted_turn_id,
+                    snapshot_seq, status, driver_source_id, driver_item_id,
+                    driver_revision, decision_format, settlement_ref,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'legacy_single', ?, ?, ?)
+                """,
+                (
+                    token,
+                    session_id,
+                    turn_id,
+                    int(row["snapshot_seq"]),
+                    row["status"],
+                    row["source_id"],
+                    row["item_id"],
+                    row["revision"],
+                    row["settlement_ref"],
+                    row["updated_at"],
+                    row["updated_at"],
+                ),
+            )
+            _ = connection.execute(
+                """
+                INSERT INTO content_selection_members(
+                    selection_token, position, source_id, item_id, revision,
+                    selected_for_delivery, settlement_ref
+                ) VALUES (?, 1, ?, ?, ?, ?, ?)
+                """,
+                (
+                    token,
+                    row["source_id"],
+                    row["item_id"],
+                    row["revision"],
+                    int(
+                        row["status"] in {"ready_for_delivery", "delivered", "settled"}
+                    ),
+                    row["settlement_ref"],
+                ),
+            )
+        connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
     @staticmethod
     def _validate_schema(connection: sqlite3.Connection) -> None:
@@ -1117,6 +1644,68 @@ def _normalize_accepted_turn(value: Mapping[str, object]) -> AcceptedTurn:
         "session_id": _identity("accepted_turn.session_id", value.get("session_id")),
         "turn_id": _identity("accepted_turn.turn_id", value.get("turn_id")),
     }
+
+
+def _message_metadata(row: sqlite3.Row) -> dict[str, object]:
+    """Project stable source evidence without exposing the candidate body."""
+
+    return _message_metadata_many((row,))
+
+
+def _message_metadata_many(rows: Sequence[sqlite3.Row]) -> dict[str, object]:
+    """Project one ordered evidence list for an aggregated proactive message."""
+
+    evidence: list[str] = []
+    source_refs: list[dict[str, object]] = []
+    for display_index, row in enumerate(rows, start=1):
+        payload = json.loads(row["payload_json"])
+        if not isinstance(payload, dict):
+            raise ValueError("Content payload_json 必须解码为 object")
+        event_id = f"{row['source_id']}:{row['item_id']}:{row['revision']}"
+        evidence.append(event_id)
+        source_refs.append(
+            {
+                "display_index": display_index,
+                "event_id": event_id,
+                **{
+                    field: payload[field]
+                    for field in ("source_name", "title", "url")
+                    if isinstance(payload.get(field), str) and payload[field].strip()
+                },
+            }
+        )
+    return {
+        "tools_used": ["message_push"],
+        "evidence_item_ids": evidence,
+        "source_refs": source_refs,
+        "state_summary_tag": "none",
+    }
+
+
+def _snapshot_item(row: sqlite3.Row) -> ContentSnapshotItem:
+    payload = json.loads(row["payload_json"])
+    if not isinstance(payload, dict):
+        raise ValueError("Content payload_json 必须解码为 object")
+    return {
+        "ref": {
+            "source_id": row["source_id"],
+            "item_id": row["item_id"],
+            "revision": row["revision"],
+            "state_version": int(row["item_state_version"]),
+        },
+        "payload": payload,
+        "snapshot_seq": int(row["snapshot_seq"]),
+        "status": row["status"],
+        "not_before": row["not_before"],
+        "due": True,
+    }
+
+
+def _member_settlement(settlement_ref: str, row: sqlite3.Row) -> str:
+    identity = f"{row['source_id']}\x00{row['item_id']}\x00{row['revision']}".encode(
+        "utf-8"
+    )
+    return settlement_ref + ":" + hashlib.sha256(identity).hexdigest()[:16]
 
 
 def _item_ref(source_id: str, item: _NormalizedItem) -> SubmissionRef:

--- a/plugins/drift/plugin.py
+++ b/plugins/drift/plugin.py
@@ -56,6 +56,21 @@ class DriftProposalServices(Protocol):
 DRIFT_PROPOSALS = ServiceKey[DriftProposalServices]("drift.proposals.v1")
 
 
+class DriftDeliveryServices(Protocol):
+    def pending(self, limit: int = 100) -> tuple[Mapping[str, object], ...]: ...
+
+    def lookup(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None: ...
+
+    def settle(
+        self, selection_token: str, settlement_ref: str
+    ) -> Mapping[str, object]: ...
+
+
+DRIFT_DELIVERY = ServiceKey[DriftDeliveryServices]("drift.delivery.v1")
+
+
 class _WakeServices:
     def __init__(self, store: DriftStore) -> None:
         self._store = store
@@ -105,6 +120,22 @@ class _ProposalServices:
         )
 
 
+class _DeliveryServices:
+    def __init__(self, store: DriftStore) -> None:
+        self._store = store
+
+    def pending(self, limit: int = 100) -> tuple[Mapping[str, object], ...]:
+        return self._store.pending_delivery(limit)
+
+    def lookup(
+        self, accepted_turn: Mapping[str, object]
+    ) -> Mapping[str, object] | None:
+        return self._store.delivery(accepted_turn)
+
+    def settle(self, selection_token: str, settlement_ref: str) -> Mapping[str, object]:
+        return self._store.settle_delivery(selection_token, settlement_ref)
+
+
 async def apply(ctx: Context, config: object) -> None:
     """Publish the narrow Drift view over one generation-scoped store."""
 
@@ -116,3 +147,4 @@ async def apply(ctx: Context, config: object) -> None:
     store.initialize()
     _ = await ctx.provide(DRIFT_PROPOSALS, _ProposalServices(store))
     _ = await ctx.provide(DRIFT_WAKE, _WakeServices(store))
+    _ = await ctx.provide(DRIFT_DELIVERY, _DeliveryServices(store))

--- a/plugins/drift/store.py
+++ b/plugins/drift/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import secrets
 import sqlite3
@@ -9,8 +10,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Generator, Literal, NotRequired, TypedDict
 
-_SCHEMA_VERSION = 1
-_TABLE_SQL = """
+_SCHEMA_VERSION = 2
+_TABLE_SQL_V1 = """
     CREATE TABLE proposals(
         proposal_id TEXT NOT NULL,
         revision TEXT NOT NULL,
@@ -27,6 +28,24 @@ _TABLE_SQL = """
         PRIMARY KEY(proposal_id, revision)
     )
 """
+_TABLE_SQL = """
+    CREATE TABLE proposals(
+        proposal_id TEXT NOT NULL,
+        revision TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        due_at TEXT NOT NULL,
+        next_due TEXT,
+        state_version INTEGER NOT NULL,
+        selection_token TEXT UNIQUE,
+        selected_session_id TEXT,
+        selected_turn_id TEXT,
+        settlement_ref TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(proposal_id, revision)
+    )
+"""
 _INDEX_SQL = (
     """
     CREATE UNIQUE INDEX proposals_selected_turn_idx
@@ -34,6 +53,8 @@ _INDEX_SQL = (
     WHERE selected_turn_id IS NOT NULL
     """,
     "CREATE INDEX proposals_due_idx ON proposals(status, due_at)",
+    "CREATE UNIQUE INDEX proposals_settlement_ref_idx "
+    "ON proposals(settlement_ref) WHERE settlement_ref IS NOT NULL",
 )
 
 
@@ -160,8 +181,8 @@ class DriftStore:
                 INSERT INTO proposals(
                     proposal_id, revision, payload_json, status, due_at, next_due,
                     state_version, selection_token, selected_session_id,
-                    selected_turn_id, created_at, updated_at
-                ) VALUES (?, ?, ?, 'pending', ?, ?, 1, NULL, NULL, NULL, ?, ?)
+                    selected_turn_id, settlement_ref, created_at, updated_at
+                ) VALUES (?, ?, ?, 'pending', ?, ?, 1, NULL, NULL, NULL, NULL, ?, ?)
                 """,
                 (proposal, proposal_revision, payload_json, due, retry, now, now),
             )
@@ -179,15 +200,13 @@ class DriftStore:
 
         instant = _aware_utc(now)
         with self._transaction(write=False) as connection:
-            rows = connection.execute(
-                """
+            rows = connection.execute("""
                 SELECT proposal_id, revision, payload_json, due_at, next_due,
                        state_version
                 FROM proposals
                 WHERE status IN ('pending', 'deferred')
                 ORDER BY due_at, proposal_id, revision
-                """
-            ).fetchall()
+                """).fetchall()
             proposals: tuple[DriftProposal, ...] = tuple(
                 {
                     "ref": {
@@ -323,18 +342,139 @@ class DriftStore:
                 raise RuntimeError("Drift defer 缺少 proposal owner 提供的 next_due")
             status = "deferred" if action == "defer" else action
             due_at = row["next_due"] if action == "defer" else None
+            if action == "ready_for_delivery":
+                connection.execute(
+                    """
+                    UPDATE proposals
+                    SET status = 'ready_for_delivery',
+                        state_version = state_version + 1, updated_at = ?
+                    WHERE selection_token = ? AND status = 'selected'
+                    """,
+                    (datetime.now(UTC).isoformat(), selection),
+                )
+            else:
+                connection.execute(
+                    """
+                    UPDATE proposals
+                    SET status = ?, due_at = COALESCE(?, due_at),
+                        selection_token = NULL, selected_session_id = NULL,
+                        selected_turn_id = NULL, state_version = state_version + 1,
+                        updated_at = ?
+                    WHERE selection_token = ? AND status = 'selected'
+                    """,
+                    (status, due_at, datetime.now(UTC).isoformat(), selection),
+                )
+            return {"changed": True, "status": status, "next_due": due_at}
+
+    def pending_delivery(self, limit: int = 100) -> tuple[dict[str, object], ...]:
+        """Return ready Drift selections without exposing proposal payloads."""
+
+        if type(limit) is not int or limit <= 0:
+            raise ValueError("limit 必须是正整数")
+        with self._transaction(write=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT selection_token, selected_session_id, selected_turn_id
+                FROM proposals
+                WHERE status = 'ready_for_delivery'
+                ORDER BY due_at, proposal_id, revision
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+            return tuple(
+                {
+                    "selection_token": _identity(
+                        "selection_token", row["selection_token"]
+                    ),
+                    "accepted_turn": {
+                        "session_id": _identity(
+                            "selected_session_id", row["selected_session_id"]
+                        ),
+                        "turn_id": _identity(
+                            "selected_turn_id", row["selected_turn_id"]
+                        ),
+                    },
+                    "message_metadata": {
+                        "tools_used": ["message_push"],
+                        "evidence_item_ids": [],
+                        "source_refs": [],
+                        "state_summary_tag": "none",
+                    },
+                }
+                for row in rows
+            )
+
+    def delivery(self, accepted_turn: Mapping[str, object]) -> dict[str, object] | None:
+        """Read one Drift delivery state by its accepted Turn identity."""
+
+        accepted = _accepted_turn(accepted_turn)
+        with self._transaction(write=False) as connection:
+            row = connection.execute(
+                """
+                SELECT selection_token, selected_session_id, selected_turn_id,
+                       status, settlement_ref
+                FROM proposals
+                WHERE selected_session_id = ? AND selected_turn_id = ?
+                """,
+                (accepted["session_id"], accepted["turn_id"]),
+            ).fetchone()
+            if row is None:
+                return None
+            result: dict[str, object] = {
+                "selection_token": row["selection_token"],
+                "accepted_turn": dict(accepted),
+                "status": row["status"],
+                "settlement_ref": row["settlement_ref"],
+            }
+            if row["status"] == "settled":
+                settlement = _identity("settlement_ref", row["settlement_ref"])
+                result["receipt"] = _delivery_receipt(
+                    str(row["selection_token"]), settlement
+                )
+            return result
+
+    def settle_delivery(
+        self, selection_token: str, settlement_ref: str
+    ) -> dict[str, object]:
+        """Idempotently settle one projected Drift message."""
+
+        token = _identity("selection_token", selection_token)
+        settlement = _identity("settlement_ref", settlement_ref)
+        receipt = _delivery_receipt(token, settlement)
+        with self._transaction(write=True) as connection:
+            row = connection.execute(
+                "SELECT status, settlement_ref FROM proposals WHERE selection_token = ?",
+                (token,),
+            ).fetchone()
+            if row is None:
+                return {"settled": False, "reason": "selection_missing"}
+            if row["status"] == "settled":
+                if row["settlement_ref"] != settlement:
+                    raise RuntimeError("Drift delivery settlement identity conflict")
+                return {
+                    "settled": True,
+                    "duplicate": True,
+                    "status": "settled",
+                    "receipt": receipt,
+                }
+            if row["status"] != "ready_for_delivery":
+                return {"settled": False, "reason": f"status:{row['status']}"}
             connection.execute(
                 """
                 UPDATE proposals
-                SET status = ?, due_at = COALESCE(?, due_at),
-                    selection_token = NULL, selected_session_id = NULL,
-                    selected_turn_id = NULL, state_version = state_version + 1,
-                    updated_at = ?
-                WHERE selection_token = ?
+                SET status = 'settled', settlement_ref = ?,
+                    state_version = state_version + 1, updated_at = ?
+                WHERE selection_token = ? AND status = 'ready_for_delivery'
                 """,
-                (status, due_at, datetime.now(UTC).isoformat(), selection),
+                (settlement, datetime.now(UTC).isoformat(), token),
             )
-            return {"changed": True, "status": status, "next_due": due_at}
+            return {
+                "settled": True,
+                "duplicate": False,
+                "status": "settled",
+                "receipt": receipt,
+            }
 
     @contextmanager
     def _transaction(self, *, write: bool) -> Generator[sqlite3.Connection]:
@@ -372,13 +512,70 @@ class DriftStore:
     @staticmethod
     def _ensure_schema(connection: sqlite3.Connection) -> None:
         version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-        if version not in (0, _SCHEMA_VERSION):
+        if version not in (0, 1, _SCHEMA_VERSION):
             raise RuntimeError(f"不支持的 Drift schema version: {version}")
         if version == _SCHEMA_VERSION:
             return
-        connection.execute(_TABLE_SQL)
-        for statement in _INDEX_SQL:
-            connection.execute(statement)
+        if version == 0:
+            connection.execute(_TABLE_SQL)
+            for statement in _INDEX_SQL:
+                connection.execute(statement)
+        else:
+            # v1 cleared delivery identity too early. Invalidate only those exact
+            # orphaned rows because their user-visible body cannot be recovered.
+            table_sql = connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'proposals'"
+            ).fetchone()
+            if table_sql is None or _normalize_sql(str(table_sql[0])) != _normalize_sql(
+                _TABLE_SQL_V1
+            ):
+                raise RuntimeError("Drift v1 constraint-bearing table SQL 不匹配")
+            connection.execute("DROP INDEX proposals_selected_turn_idx")
+            connection.execute("DROP INDEX proposals_due_idx")
+            connection.execute("ALTER TABLE proposals RENAME TO proposals_v1")
+            connection.execute(_TABLE_SQL)
+            connection.execute(
+                """
+                INSERT INTO proposals(
+                    proposal_id, revision, payload_json, status, due_at, next_due,
+                    state_version, selection_token, selected_session_id,
+                    selected_turn_id, settlement_ref, created_at, updated_at
+                )
+                SELECT proposal_id, revision, payload_json,
+                    CASE
+                        WHEN status = 'ready_for_delivery'
+                         AND selection_token IS NULL
+                         AND selected_session_id IS NULL
+                         AND selected_turn_id IS NULL
+                        THEN 'invalidated'
+                        ELSE status
+                    END,
+                    due_at, next_due,
+                    CASE
+                        WHEN status = 'ready_for_delivery'
+                         AND selection_token IS NULL
+                         AND selected_session_id IS NULL
+                         AND selected_turn_id IS NULL
+                        THEN state_version + 1
+                        ELSE state_version
+                    END,
+                    selection_token, selected_session_id, selected_turn_id, NULL,
+                    created_at,
+                    CASE
+                        WHEN status = 'ready_for_delivery'
+                         AND selection_token IS NULL
+                         AND selected_session_id IS NULL
+                         AND selected_turn_id IS NULL
+                        THEN ?
+                        ELSE updated_at
+                    END
+                FROM proposals_v1
+                """,
+                (datetime.now(UTC).isoformat(),),
+            )
+            connection.execute("DROP TABLE proposals_v1")
+            for statement in _INDEX_SQL:
+                connection.execute(statement)
         connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
 
@@ -393,6 +590,7 @@ _EXPECTED_COLUMNS = (
     ("selection_token", "TEXT", 0, 0),
     ("selected_session_id", "TEXT", 0, 0),
     ("selected_turn_id", "TEXT", 0, 0),
+    ("settlement_ref", "TEXT", 0, 0),
     ("created_at", "TEXT", 1, 0),
     ("updated_at", "TEXT", 1, 0),
 )
@@ -405,6 +603,13 @@ _EXPECTED_INDEXES = (
         1,
         ("selected_session_id", "selected_turn_id"),
     ),
+    (
+        "proposals_settlement_ref_idx",
+        1,
+        "c",
+        1,
+        ("settlement_ref",),
+    ),
     ("sqlite_autoindex_proposals_1", 1, "u", 0, ("selection_token",)),
     (
         "sqlite_autoindex_proposals_2",
@@ -414,6 +619,11 @@ _EXPECTED_INDEXES = (
         ("proposal_id", "revision"),
     ),
 )
+
+
+def _delivery_receipt(selection_token: str, settlement_ref: str) -> str:
+    payload = f"{selection_token}\x00{settlement_ref}".encode()
+    return "drift:" + hashlib.sha256(payload).hexdigest()
 
 
 def _normalize_sql(sql: str) -> str:

--- a/plugins/wake/hazard.py
+++ b/plugins/wake/hazard.py
@@ -35,7 +35,7 @@ def advance_hazard(
     if not events or not new_item_ids:
         return HazardResult(False, 0.0, 0.0, random_draw, 0.0, 0.0, 0.0, 0.0, "")
     ranked = rank_events(events, now=now)
-    contributions: list[tuple[str, float]] = []
+    contributions: list[tuple[str, str, float]] = []
     preference_pressure = 0.0
     new_mass = 0.0
     for event in ranked:
@@ -49,14 +49,15 @@ def advance_hazard(
             semantic_interest * probability * freshness * confidence,
         )
         item_id = str(event.get("id") or "")
+        admission_identity = str(event.get("_wake_admission_identity") or item_id)
         contribution = max(
             0.0, float(event["_wake_rank_score"]) - WAKE_ADMISSION_FLOOR
         )
-        contributions.append((item_id, contribution))
-        if item_id in new_item_ids:
+        contributions.append((item_id, admission_identity, contribution))
+        if admission_identity in new_item_ids:
             new_mass += contribution
     evidence = max(
-        sum(value for _, value in contributions),
+        sum(value for _, _, value in contributions),
         max(0.0, float(pool_mass or 0.0)),
     )
     refractory = (
@@ -79,7 +80,7 @@ def advance_hazard(
         refractory,
         probability,
         preference_pressure,
-        max(contributions, key=lambda pair: pair[1])[0],
+        max(contributions, key=lambda contribution: contribution[2])[0],
     )
 
 

--- a/plugins/wake/plugin.py
+++ b/plugins/wake/plugin.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import random
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -35,10 +36,14 @@ from agent.plugin_composition import (
     ServiceKey,
     TurnExecutionScope,
     ToolGrant,
+    CONVERSATION_SEMANTIC_INTEREST,
+    ConversationSemanticInterest,
 )
 from plugins.content.plugin import CONTENT_DELIVERY, ContentDeliveryServices
+from plugins.drift.plugin import DRIFT_DELIVERY, DriftDeliveryServices
 from plugins.wake.legacy_rules import ArchivedRules
 from plugins.wake.selection import DutyProposal, propose_content, propose_drift
+from plugins.wake.state import WakeState
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +99,21 @@ class ContentWakeServices(Protocol):
         now: datetime,
     ) -> Mapping[str, object]: ...
 
+    def select_batch(
+        self,
+        item_refs: Sequence[Mapping[str, object]],
+        snapshot_seq: int,
+        accepted_turn: Mapping[str, object],
+        now: datetime,
+    ) -> Mapping[str, object]: ...
+
     def transition(
         self,
         selection_token: str,
         action: str,
         *,
         not_before: datetime | None = None,
+        selected_refs: Sequence[Mapping[str, object]] | None = None,
     ) -> Mapping[str, object]: ...
 
 
@@ -132,7 +146,9 @@ inject = (
     CONTENT_WAKE,
     CONTENT_DELIVERY,
     DRIFT_WAKE,
+    DRIFT_DELIVERY,
     TOOL_CATALOG,
+    CONVERSATION_SEMANTIC_INTEREST,
 )
 
 _SHARE_CONTENT = "share_content"
@@ -141,9 +157,10 @@ _DECISION_TOOLS = frozenset({_SHARE_CONTENT, _SKIP_CONTENT})
 
 
 @dataclass(frozen=True, slots=True)
-class _ContentDecision:
+class _WakeDecision:
     action: Literal["share", "skip"]
     message: str | None = None
+    item_ids: tuple[str, ...] = ()
 
 
 class WakeRuntime:
@@ -158,17 +175,29 @@ class WakeRuntime:
         *,
         deliveries: PluginDurableDeliveries | None = None,
         content_delivery: ContentDeliveryServices | None = None,
+        drift_delivery: DriftDeliveryServices | None = None,
         target: DeliveryTarget | None = None,
+        state: WakeState | None = None,
+        random_draw: Callable[[], float] | None = None,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
+        semantic_interest: ConversationSemanticInterest | None = None,
     ) -> None:
         self._timers = timers
         self._turns = turns
         self._deliveries = deliveries
         self._content = content
         self._content_delivery = content_delivery
+        self._drift_delivery = drift_delivery
         self._drift = drift
         self._target = target
+        self._state = state
+        self._random_draw = random_draw or random.random
+        self._active_owner: Literal["content", "drift"] | None = None
+        self._admitted_content: tuple[int, tuple[Mapping[str, object], ...]] | None = (
+            None
+        )
         self._now = now
+        self._semantic_interest = semantic_interest
         self._dirty = asyncio.Event()
         self._runner: asyncio.Task[None] | None = None
         self._handle: TimerHandle | None = None
@@ -214,14 +243,35 @@ class WakeRuntime:
         accepted = self._accepted(ctx)
         now = self._aware_now(ctx.timestamp)
 
-        # 1. Content always owns the first proposal and CAS opportunity.
-        content_snapshot = self._content.snapshot(now)
-        content_items = _sequence(content_snapshot.get("items"), "Content items")
-        content_proposal = propose_content(content_items, now=now)
+        # 1. Content owns the first proposal only after its admission gate wins.
+        if self._active_owner != "drift":
+            admitted = (
+                self._admitted_content if self._active_owner == "content" else None
+            )
+            if admitted is None:
+                content_snapshot = self._content.snapshot(now)
+                content_items = _sequence(
+                    content_snapshot.get("items"), "Content items"
+                )
+                content_snapshot_seq = _integer(
+                    content_snapshot.get("snapshot_seq"), "snapshot_seq"
+                )
+            else:
+                content_snapshot_seq, content_items = admitted
+                content_snapshot = {}
+            content_proposal = propose_content(content_items, now=now)
+        else:
+            content_snapshot = {}
+            content_proposal = None
         if content_proposal is not None:
-            selected = self._content.select(
-                content_proposal.ref,
-                _integer(content_snapshot.get("snapshot_seq"), "snapshot_seq"),
+            candidates = content_proposal.candidates or ({"ref": content_proposal.ref},)
+            refs = tuple(
+                _mapping(candidate.get("ref"), "Content candidate ref")
+                for candidate in candidates
+            )
+            selected = self._content.select_batch(
+                refs,
+                content_snapshot_seq,
                 accepted,
                 now,
             )
@@ -285,30 +335,38 @@ class WakeRuntime:
             self._handle = None
             if receipt.status is TimerStatus.CANCELLED or self._closed:
                 continue
-            if not self._has_due():
+            owner = await self._admit_owner()
+            if owner is None:
                 continue
-            await self._start_turn()
+            await self._start_turn(owner)
 
-    async def _start_turn(self) -> None:
-        """Admit one memoryless Wake Turn and settle its selected duty."""
+    async def _start_turn(
+        self, owner: Literal["content", "drift"] | None = None
+    ) -> None:
+        """Admit one quiet Wake Turn against the target conversation history."""
 
+        target_session = (
+            self._target.session_id if self._target is not None else "wake:default"
+        )
         session = await self._turns.ensure_session(
-            "wake:default",
+            target_session,
             metadata={"programmatic": True, "wake": True},
         )
+        self._active_owner = owner
         handle = await self._turns.start(
             session,
             "Check durable Wake duties.",
             scope=TurnExecutionScope(
                 preloaded_tools=(_SHARE_CONTENT, _SKIP_CONTENT),
                 tool_source="wake",
-                tool_grant=ToolGrant.except_names(("message_push",)),
+                tool_grant=ToolGrant.only((_SHARE_CONTENT, _SKIP_CONTENT)),
                 stateless=True,
-                memory_read=False,
+                session_history_read=self._target is not None,
+                memory_read=self._target is not None,
                 memory_write=False,
             ),
             channel="wake",
-            chat_id="wake:default",
+            chat_id=target_session,
             sender="wake",
         )
         try:
@@ -316,6 +374,8 @@ class WakeRuntime:
             await self._settle_accepted(handle.accepted, _view_from_result(result))
             await self._reconcile_deliveries()
         finally:
+            self._active_owner = None
+            self._admitted_content = None
             await handle.cleanup()
 
     async def _reconcile_selected(self) -> None:
@@ -359,22 +419,42 @@ class WakeRuntime:
         view: DurableTurnView,
     ) -> None:
         token = _string(receipt.get("selection_token"), "selection_token")
-        if view.status is TurnStatus.COMPLETED and owner == "content":
-            decision = _content_decision(view)
-            if decision is None:
+        if view.status is TurnStatus.COMPLETED:
+            legacy_single = receipt.get("decision_format") == "legacy_single"
+            try:
+                decision = _content_decision(view, allow_legacy_items=legacy_single)
+            except ValueError as exc:
                 logger.error(
-                    "Wake completed Content Turn without one valid decision "
-                    "accepted=%s/%s",
+                    "Wake completed Turn has invalid decision accepted=%s/%s error=%s",
+                    view.session_id,
+                    view.turn_id,
+                    exc,
+                )
+                decision = None
+            if (
+                owner == "content"
+                and decision is not None
+                and decision.action == "share"
+                and not decision.item_ids
+                and not legacy_single
+            ):
+                logger.error(
+                    "Wake Content share decision has no candidate ids accepted=%s/%s",
                     view.session_id,
                     view.turn_id,
                 )
-                action = "defer"
+                decision = None
+            if decision is None:
+                logger.error(
+                    "Wake completed Turn without one valid decision " "accepted=%s/%s",
+                    view.session_id,
+                    view.turn_id,
+                )
+                action = "defer" if owner == "content" else "await_change"
             else:
                 action = (
-                    "ready_for_delivery" if decision.action == "share" else "abandoned"
+                    "ready_for_delivery" if decision.action == "share" else "release"
                 )
-        elif view.status is TurnStatus.COMPLETED:
-            action = "ready_for_delivery"
         elif view.status is TurnStatus.FAILED and view.error_retryable is False:
             action = "invalidated"
         elif view.status in {
@@ -386,11 +466,35 @@ class WakeRuntime:
         else:
             raise RuntimeError(f"Wake 无法 settle 非终态 Turn: {view.status.value}")
         if owner == "content":
+            selected_refs = None
+            if action == "ready_for_delivery" and decision is not None:
+                try:
+                    selected_refs = _selected_content_refs(
+                        receipt,
+                        decision.item_ids,
+                        allow_legacy_single=legacy_single,
+                    )
+                except ValueError as exc:
+                    logger.error(
+                        "Wake Content share decision references invalid candidates "
+                        "accepted=%s/%s error=%s",
+                        view.session_id,
+                        view.turn_id,
+                        exc,
+                    )
+                    action = "defer"
             deadline = (
                 self._aware_now() + timedelta(minutes=5) if action == "defer" else None
             )
-            transition = self._content.transition(token, action, not_before=deadline)
+            transition = self._content.transition(
+                token,
+                action,
+                not_before=deadline,
+                selected_refs=selected_refs,
+            )
         else:
+            if action in {"abandoned", "release"}:
+                action = "await_change"
             if action == "defer" and receipt.get("next_due") is None:
                 action = "await_change"
             transition = self._drift.transition(token, action)
@@ -401,42 +505,52 @@ class WakeRuntime:
             )
 
     async def _reconcile_deliveries(self) -> None:
-        """Forward-complete delivery, projection, and Content settlement windows."""
+        """Forward-complete delivery, projection, and domain settlement windows."""
 
         target = self._target
         if target is None:
             return
         deliveries = self._deliveries
-        content_delivery = self._content_delivery
-        if deliveries is None or content_delivery is None:
-            raise RuntimeError("Wake delivery target 缺少 durable/Content capability")
+        if deliveries is None:
+            raise RuntimeError("Wake delivery target 缺少 durable capability")
 
-        # 1. Resume every Core row owned by Content before creating missing rows.
+        # 1. Resume every Core row before creating missing domain rows.
         await self._resume_deliveries(deliveries)
 
-        # 2. Create a stable logical delivery for each ready Content selection.
-        for pending in content_delivery.pending(100):
-            await self._deliver_pending(pending, deliveries, target)
+        # 2. Create one stable logical delivery for each ready domain selection.
+        for target_service, domain in self._delivery_domains():
+            for pending in domain.pending(100):
+                await self._deliver_pending(
+                    pending,
+                    deliveries,
+                    target,
+                    target_service=target_service,
+                    domain=domain,
+                )
 
     async def _resume_deliveries(self, deliveries: PluginDurableDeliveries) -> None:
-        """Advance existing Core rows without consulting Content payload state."""
+        """Advance existing Core rows without consulting domain payload state."""
 
         for delivery in deliveries.recoverable():
-            if delivery.target_service != CONTENT_DELIVERY.name:
+            domain = self._delivery_domain(delivery.target_service)
+            if domain is None:
                 continue
             current = delivery
             if current.state in {"prepared", "delivered"}:
                 current = await deliveries.resume(current.accepted_turn)
             if current.state == "projected":
-                self._settle_projected(current)
+                self._settle_projected(current, domain)
 
     async def _deliver_pending(
         self,
         pending: Mapping[str, object],
         deliveries: PluginDurableDeliveries,
         target: DeliveryTarget,
+        *,
+        target_service: str,
+        domain: ContentDeliveryServices | DriftDeliveryServices,
     ) -> None:
-        """Create or forward-complete one ready Content delivery."""
+        """Create or forward-complete one ready domain delivery."""
 
         accepted = _accepted_receipt(pending)
         current = deliveries.lookup(accepted)
@@ -444,22 +558,28 @@ class WakeRuntime:
             turn = self._turns.read(accepted)
             if turn.status is not TurnStatus.COMPLETED:
                 raise RuntimeError(
-                    "Content ready selection 不属于 completed Turn: "
+                    "Wake ready selection 不属于 completed Turn: "
                     f"{accepted!r}/{turn.status.value}"
                 )
-            decision = _content_decision(turn)
+            decision = _content_decision(
+                turn,
+                allow_legacy_items=pending.get("decision_format") == "legacy_single",
+            )
             if decision is None or decision.action != "share" or not decision.message:
-                raise RuntimeError("Content ready Turn 缺少 share_content 决策")
+                raise RuntimeError("Wake ready Turn 缺少 share_content 决策")
             current = await deliveries.submit(
                 DurableDeliveryRequest(
                     logical_delivery_id=_logical_delivery_id(accepted),
                     accepted_turn=accepted,
-                    target_service=CONTENT_DELIVERY.name,
+                    target_service=target_service,
                     channel=target.channel,
                     recipient=target.recipient,
                     projection_session_id=target.session_id,
                     body=decision.message,
-                    metadata={"proactive": True},
+                    metadata={
+                        **_delivery_metadata(pending),
+                        "proactive": True,
+                    },
                 )
             )
         elif current.state in {"prepared", "delivered"}:
@@ -475,19 +595,19 @@ class WakeRuntime:
                 current.provider_receipt,
             )
         if current.state == "projected":
-            self._settle_projected(current)
+            self._settle_projected(current, domain)
 
     def _settle_projected(
         self,
         delivery: DurableDeliveryView,
+        domain: ContentDeliveryServices | DriftDeliveryServices,
     ) -> None:
-        """Commit Content first, then close the Core settlement receipt."""
+        """Commit domain state first, then close the Core settlement receipt."""
 
-        content_delivery = self._content_delivery
         deliveries = self._deliveries
-        if content_delivery is None or deliveries is None:
+        if deliveries is None:
             raise RuntimeError("Wake delivery settlement capability 缺失")
-        selected = content_delivery.lookup(
+        selected = domain.lookup(
             {
                 "session_id": delivery.accepted_turn.session_id,
                 "turn_id": delivery.accepted_turn.turn_id,
@@ -495,41 +615,114 @@ class WakeRuntime:
         )
         if selected is None:
             raise RuntimeError(
-                "durable Content delivery 缺少 accepted Turn selection: "
+                "durable Wake delivery 缺少 accepted Turn selection: "
                 f"{delivery.accepted_turn!r}"
             )
         token = _string(selected.get("selection_token"), "selection_token")
-        settled = content_delivery.settle(
+        settled = domain.settle(
             token,
             delivery.logical_delivery_id,
         )
         if settled.get("settled") is not True:
-            raise RuntimeError(f"Content delivery settlement 未提交: {dict(settled)!r}")
-        receipt = _string(settled.get("receipt"), "Content delivery receipt")
+            raise RuntimeError(f"Wake delivery settlement 未提交: {dict(settled)!r}")
+        receipt = _string(settled.get("receipt"), "Wake delivery receipt")
         _ = deliveries.confirm_settled(delivery.logical_delivery_id, receipt)
+
+    def _delivery_domains(
+        self,
+    ) -> tuple[tuple[str, ContentDeliveryServices | DriftDeliveryServices], ...]:
+        content = self._content_delivery
+        drift = self._drift_delivery
+        if content is None or drift is None:
+            raise RuntimeError("Wake delivery target 缺少 Content/Drift capability")
+        return (
+            (CONTENT_DELIVERY.name, content),
+            (DRIFT_DELIVERY.name, drift),
+        )
+
+    def _delivery_domain(
+        self, target_service: str
+    ) -> ContentDeliveryServices | DriftDeliveryServices | None:
+        return dict(self._delivery_domains()).get(target_service)
 
     def _earliest_deadline(self) -> datetime | None:
         now = self._aware_now()
-        content = self._content.snapshot(now).get("earliest_not_before")
+        content_snapshot = self._content.snapshot(now)
+        content_items = _sequence(content_snapshot.get("items"), "Content items")
+        content_deadlines = [
+            _datetime(item.get("not_before"))
+            for item in content_items
+            if item.get("status") == "deferred"
+        ]
+        if self._state is None:
+            raw_content = content_snapshot.get("earliest_not_before")
+            if raw_content is not None:
+                content_deadlines.append(_datetime(raw_content))
+        else:
+            unseen = self._state.unseen_deadline(content_items)
+            if unseen is not None:
+                content_deadlines.append(unseen)
         drift = self._drift.snapshot(now).get("next_due")
         deadlines = [
-            _datetime(value) for value in (content, drift) if value is not None
+            *content_deadlines,
+            *([_datetime(drift)] if drift is not None else []),
         ]
         return min(deadlines) if deadlines else None
 
-    def _has_due(self) -> bool:
+    async def _admit_owner(self) -> Literal["content", "drift"] | None:
+        """Choose one due owner after applying legacy Content admission."""
+
         now = self._aware_now()
         content = self._content.snapshot(now)
+        items = _sequence(content.get("items"), "Content items")
+        if any(
+            item.get("status") == "deferred" and item.get("due") is True
+            for item in items
+        ):
+            return "content"
+        if self._state is None and any(item.get("due") is True for item in items):
+            return "content"
+        if self._state is not None and self._state.has_unseen_due(items, now):
+            items = await self._apply_semantic_interest(items, now)
+            result = self._state.evaluate(
+                items,
+                snapshot_seq=_integer(content.get("snapshot_seq"), "snapshot_seq"),
+                now=now,
+                random_draw=self._random_draw(),
+            )
+            if result.should_wake:
+                self._admitted_content = (
+                    _integer(content.get("snapshot_seq"), "snapshot_seq"),
+                    tuple(items),
+                )
+                return "content"
+        drift = self._drift.snapshot(now)
         if any(
             item.get("due") is True
-            for item in _sequence(content.get("items"), "Content items")
-        ):
-            return True
-        drift = self._drift.snapshot(now)
-        return any(
-            item.get("due") is True
             for item in _sequence(drift.get("proposals"), "Drift proposals")
-        )
+        ):
+            return "drift"
+        return None
+
+    async def _apply_semantic_interest(
+        self, items: Sequence[Mapping[str, object]], now: datetime
+    ) -> tuple[Mapping[str, object], ...]:
+        """Attach legacy semantic interest without exposing Session storage."""
+
+        service = self._semantic_interest
+        if service is None:
+            return tuple(items)
+        due = [item for item in items if item.get("due") is True]
+        texts = [_content_text(item) for item in due]
+        scores = await service.score(texts, cutoff=now.isoformat())
+        enriched: dict[int, Mapping[str, object]] = {}
+        for item, score in zip(due, scores, strict=True):
+            payload = dict(_mapping(item.get("payload"), "Content item payload"))
+            base = _preprocess_interest(payload)
+            payload["_wake_semantic_interest"] = score
+            payload["_wake_interest_score"] = 1 - (1 - base) * (1 - score)
+            enriched[id(item)] = {**dict(item), "payload": payload}
+        return tuple(enriched.get(id(item), item) for item in items)
 
     def _aware_now(self, value: datetime | None = None) -> datetime:
         instant = value or self._now()
@@ -561,14 +754,24 @@ async def apply(ctx: Context, config: object) -> None:
         ctx.require(DRIFT_WAKE),
         deliveries=ctx.require(DURABLE_DELIVERIES),
         content_delivery=ctx.require(CONTENT_DELIVERY),
+        drift_delivery=ctx.require(DRIFT_DELIVERY),
         target=config.delivery,
+        state=WakeState(ctx.data_root / "wake.sqlite3"),
+        semantic_interest=ctx.require(CONVERSATION_SEMANTIC_INTEREST),
     )
     archived_rules = ArchivedRules(ctx.data_root)
 
     async def share_handler(
         context: ToolExecutionContext, arguments: Mapping[str, object]
     ) -> str:
-        _validate_decision_context(context)
+        _validate_decision_context(
+            context,
+            (
+                config.delivery.session_id
+                if config.delivery is not None
+                else "wake:default"
+            ),
+        )
         _validate_decision_argument(arguments, "message")
         return json.dumps(
             {"recorded": True, "turn_id": context.turn_id},
@@ -579,7 +782,14 @@ async def apply(ctx: Context, config: object) -> None:
     async def skip_handler(
         context: ToolExecutionContext, arguments: Mapping[str, object]
     ) -> str:
-        _validate_decision_context(context)
+        _validate_decision_context(
+            context,
+            (
+                config.delivery.session_id
+                if config.delivery is not None
+                else "wake:default"
+            ),
+        )
         _validate_decision_argument(arguments, "reason")
         return json.dumps(
             {"recorded": True, "turn_id": context.turn_id},
@@ -604,17 +814,32 @@ async def apply(ctx: Context, config: object) -> None:
 
 
 def _hint(owner: str, proposal: DutyProposal) -> str:
+    payload: Mapping[str, object] = proposal.payload
+    if owner == "content" and proposal.candidates:
+        candidates: list[dict[str, object]] = []
+        for candidate in proposal.candidates:
+            ref = _mapping(candidate.get("ref"), "Content candidate ref")
+            candidate_payload = _mapping(
+                candidate.get("payload"), "Content candidate payload"
+            )
+            candidates.append(
+                {
+                    "candidate_id": _candidate_id(ref),
+                    **dict(candidate_payload),
+                }
+            )
+        payload = {"candidates": candidates}
     hint = "Wake duty:\n" + json.dumps(
-        {"owner": owner, "payload": dict(proposal.payload)},
+        {"owner": owner, "payload": dict(payload)},
         sort_keys=True,
         separators=(",", ":"),
     )
-    return hint + ("\n\n" + _decision_prompt() if owner == "content" else "")
+    return hint + "\n\n" + _decision_prompt()
 
 
 def _decision_prompt() -> str:
     return (
-        "【Wake Content 决策合同】本轮普通回答不会发送给用户。处理 Content duty 后必须且只能"
+        "【Wake 决策合同】本轮普通回答不会发送给用户。处理 duty 后必须且只能"
         "提交一个结构化终态：值得主动告诉用户时调用 share_content，message 只写最终用户可见"
         "正文；不值得发送时调用 skip_content，reason 只写内部理由。"
     )
@@ -634,9 +859,20 @@ def _decision_definitions() -> tuple[PluginToolDefinition, ...]:
                     "message": {
                         "type": "string",
                         "description": "完整、自然、可直接发送给用户的主动消息",
-                    }
+                    },
+                    "items": {
+                        "type": "array",
+                        "minItems": 0,
+                        "maxItems": 5,
+                        "uniqueItems": True,
+                        "items": {"type": "string"},
+                        "description": (
+                            "Content duty 必填：本条消息实际采用的 1..5 个 candidate_id；"
+                            "Drift duty 不填写。"
+                        ),
+                    },
                 },
-                "required": ["message"],
+                "required": ["message", "items"],
                 "additionalProperties": False,
             },
             handler_export="share_content",
@@ -664,15 +900,17 @@ def _decision_definitions() -> tuple[PluginToolDefinition, ...]:
     )
 
 
-def _validate_decision_context(context: ToolExecutionContext) -> None:
+def _validate_decision_context(
+    context: ToolExecutionContext, expected_session_id: str
+) -> None:
     """Confine Wake decision tools to their exact scoped Turn boundary."""
 
     if (
         context.origin_channel != "wake"
-        or context.origin_session_key != "wake:default"
+        or context.origin_session_key != expected_session_id
         or not context.turn_id
     ):
-        raise PermissionError("Wake decision tool 只允许 wake:default scoped Turn")
+        raise PermissionError("Wake decision tool 只允许 configured Wake scoped Turn")
 
 
 def _validate_decision_argument(arguments: Mapping[str, object], field: str) -> None:
@@ -683,7 +921,9 @@ def _validate_decision_argument(arguments: Mapping[str, object], field: str) -> 
         raise ValueError(f"{field} 必须是非空字符串")
 
 
-def _content_decision(view: DurableTurnView) -> _ContentDecision | None:
+def _content_decision(
+    view: DurableTurnView, *, allow_legacy_items: bool = False
+) -> _WakeDecision | None:
     """Read one exact successful decision from the durable Turn items."""
 
     # 1. Collect only successful Wake-private terminal calls.
@@ -707,11 +947,21 @@ def _content_decision(view: DurableTurnView) -> _ContentDecision | None:
         reason = arguments.get("reason")
         if not isinstance(reason, str) or not reason.strip():
             raise ValueError("skip_content reason 必须是非空字符串")
-        return _ContentDecision("skip")
+        return _WakeDecision("skip")
     message = arguments.get("message")
     if not isinstance(message, str) or not message.strip():
         raise ValueError("share_content message 必须是非空字符串")
-    return _ContentDecision("share", message)
+    raw_item_ids = arguments.get("items")
+    if raw_item_ids is None and allow_legacy_items:
+        return _WakeDecision("share", message)
+    if not isinstance(raw_item_ids, (tuple, list)) or any(
+        not isinstance(item_id, str) or not item_id for item_id in raw_item_ids
+    ):
+        raise ValueError("share_content items 必须是字符串数组")
+    item_ids = tuple(cast(Sequence[str], raw_item_ids))
+    if len(item_ids) > 5 or len(item_ids) != len(set(item_ids)):
+        raise ValueError("share_content items 必须是不重复的 0..5 个候选")
+    return _WakeDecision("share", message, item_ids)
 
 
 def _accepted_receipt(receipt: Mapping[str, object]) -> TurnAcceptedReceipt:
@@ -722,6 +972,53 @@ def _accepted_receipt(receipt: Mapping[str, object]) -> TurnAcceptedReceipt:
         _string(accepted.get("session_id"), "session_id"),
         _string(accepted.get("turn_id"), "turn_id"),
     )
+
+
+def _selected_content_refs(
+    receipt: Mapping[str, object],
+    item_ids: Sequence[str],
+    *,
+    allow_legacy_single: bool = False,
+) -> tuple[Mapping[str, object], ...]:
+    """Resolve the model's candidate ids only against the frozen Content batch."""
+
+    raw_items = receipt.get("items")
+    items = _sequence(raw_items, "Content selection items")
+    if not item_ids and allow_legacy_single:
+        if len(items) != 1:
+            raise RuntimeError("legacy Content selection 必须恰好包含一个 member")
+        return (_mapping(items[0].get("ref"), "Content selection ref"),)
+    if not item_ids:
+        raise ValueError("Content share_content 必须引用至少一个 candidate_id")
+    candidates: dict[str, Mapping[str, object]] = {}
+    for item in items:
+        ref = _mapping(item.get("ref"), "Content selection ref")
+        candidates[_candidate_id(ref)] = ref
+    unknown = set(item_ids) - set(candidates)
+    if unknown:
+        raise ValueError(
+            f"Content share_content 引用了批次外 candidate_id: {sorted(unknown)}"
+        )
+    return tuple(candidates[item_id] for item_id in item_ids)
+
+
+def _candidate_id(ref: Mapping[str, object]) -> str:
+    fields = (
+        _string(ref.get("source_id"), "source_id"),
+        _string(ref.get("item_id"), "item_id"),
+        _string(ref.get("revision"), "revision"),
+    )
+    payload = "\x00".join(fields).encode("utf-8")
+    return "candidate_" + hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _delivery_metadata(receipt: Mapping[str, object]) -> dict[str, object]:
+    raw = receipt.get("message_metadata")
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise TypeError("Wake delivery message_metadata 必须是 Mapping")
+    return dict(cast(Mapping[str, object], raw))
 
 
 def _logical_delivery_id(accepted: TurnAcceptedReceipt) -> str:
@@ -768,6 +1065,12 @@ def _sequence(value: object, field: str) -> Sequence[Mapping[str, object]]:
     return cast(Sequence[Mapping[str, object]], value)
 
 
+def _mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} 必须是 Mapping")
+    return cast(Mapping[str, object], value)
+
+
 def _integer(value: object, field: str) -> int:
     if type(value) is not int:
         raise ValueError(f"{field} 必须是整数")
@@ -790,3 +1093,31 @@ def _datetime(value: object) -> datetime:
     if result.tzinfo is None:
         raise ValueError("Wake deadline 必须带时区")
     return result.astimezone(UTC)
+
+
+def _content_text(item: Mapping[str, object]) -> str:
+    payload = _mapping(item.get("payload"), "Content item payload")
+    text = "\n".join(
+        part
+        for part in (
+            str(payload.get("title") or "").strip(),
+            str(payload.get("content") or payload.get("body") or "").strip(),
+        )
+        if part
+    )
+    return text
+
+
+def _preprocess_interest(payload: Mapping[str, object]) -> float:
+    features = payload.get("preprocess_features")
+    raw = (
+        features.get("interest")
+        if isinstance(features, Mapping)
+        else payload.get("preprocess_score")
+    )
+    if not isinstance(raw, (int, float, str)):
+        return 0.0
+    try:
+        return min(0.999, max(0.0, float(raw or 0.0)))
+    except (TypeError, ValueError):
+        return 0.0

--- a/plugins/wake/selection.py
+++ b/plugins/wake/selection.py
@@ -7,7 +7,6 @@ from typing import Literal, cast
 
 from plugins.wake.hazard import rank_events
 
-
 SelectionDecision = Literal["select", "decline"]
 
 
@@ -18,6 +17,7 @@ class DutyProposal:
     ref: Mapping[str, object]
     payload: Mapping[str, object]
     decision: SelectionDecision
+    candidates: tuple[Mapping[str, object], ...] = ()
 
 
 def propose_content(
@@ -32,7 +32,10 @@ def propose_content(
         [_content_event(item) for item in due],
         now=now,
     )
-    selected = ranked[0]["_wake_item"]
+    page = tuple(event["_wake_item"] for event in ranked[:100])
+    if any(not isinstance(item, Mapping) for item in page):
+        raise TypeError("Wake ranked Content page 必须是 Mapping sequence")
+    selected = page[0]
     if not isinstance(selected, Mapping):
         raise TypeError("Wake ranked Content item 必须是 Mapping")
     selected_map = cast(Mapping[str, object], selected)
@@ -45,6 +48,7 @@ def propose_content(
         ref=cast(Mapping[str, object], ref),
         payload=cast(Mapping[str, object], payload),
         decision=decision,
+        candidates=cast(tuple[Mapping[str, object], ...], page),
     )
 
 

--- a/plugins/wake/state.py
+++ b/plugins/wake/state.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping, Sequence
+from contextlib import closing
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+from plugins.wake.hazard import HazardResult, advance_hazard
+
+_SCHEMA_VERSION = 2
+_ADMISSION_TABLE_SQL = """
+    CREATE TABLE admission_state(
+        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+        content_high_watermark INTEGER NOT NULL,
+        last_content_attempt_at TEXT
+    )
+"""
+_SEEN_TABLE_SQL = "CREATE TABLE seen_content(item_identity TEXT PRIMARY KEY)"
+
+
+class WakeState:
+    """Persist Content admission history independently from Content inbox state."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def initialize(self) -> None:
+        """Create and validate the singleton admission ledger."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(self.path)) as connection, connection:
+            connection.execute("PRAGMA journal_mode = WAL")
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            if version == 0:
+                connection.execute(_ADMISSION_TABLE_SQL)
+                connection.execute("INSERT INTO admission_state VALUES(1, 0, NULL)")
+                connection.execute(_SEEN_TABLE_SQL)
+                connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+            elif version == 1:
+                self._validate_tables(connection, {"admission_state"})
+                connection.execute(_SEEN_TABLE_SQL)
+                connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+            elif version != _SCHEMA_VERSION:
+                raise RuntimeError(f"不支持的 Wake state schema version: {version}")
+            self._validate_tables(connection, {"admission_state", "seen_content"})
+            if connection.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+                raise RuntimeError("Wake state SQLite integrity check failed")
+
+    @staticmethod
+    def _validate_tables(
+        connection: sqlite3.Connection, expected_names: set[str]
+    ) -> None:
+        """Reject same-version databases that do not match Wake-owned DDL."""
+
+        rows = connection.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+        tables = {str(name): str(sql) for name, sql in rows}
+        if set(tables) != expected_names:
+            raise RuntimeError("Wake state schema mismatch: owned tables")
+        expected_sql = {"admission_state": _ADMISSION_TABLE_SQL}
+        if "seen_content" in expected_names:
+            expected_sql["seen_content"] = _SEEN_TABLE_SQL
+        for name, sql in expected_sql.items():
+            if _normalize_sql(tables[name]) != _normalize_sql(sql):
+                raise RuntimeError(f"Wake state schema mismatch: {name} table SQL")
+        rows = connection.execute(
+            "SELECT singleton FROM admission_state ORDER BY singleton"
+        ).fetchall()
+        if rows != [(1,)]:
+            raise RuntimeError("Wake state schema mismatch: admission singleton")
+
+    def unseen_deadline(self, items: Sequence[Mapping[str, object]]) -> datetime | None:
+        """Return the earliest due time owned by unseen pending Content."""
+
+        high_watermark, _ = self._read()
+        seen = self._seen()
+        deadlines = [
+            _datetime(item.get("not_before"))
+            for item in items
+            if item.get("status") == "pending"
+            and not _is_seen(item, high_watermark=high_watermark, seen=seen)
+        ]
+        return min(deadlines) if deadlines else None
+
+    def has_unseen_due(
+        self, items: Sequence[Mapping[str, object]], now: datetime
+    ) -> bool:
+        deadline = self.unseen_deadline(items)
+        return deadline is not None and deadline <= _aware(now)
+
+    def evaluate(
+        self,
+        items: Sequence[Mapping[str, object]],
+        *,
+        snapshot_seq: int,
+        now: datetime,
+        random_draw: float,
+    ) -> HazardResult:
+        """Advance the legacy admission draw once for each frozen Content watermark."""
+
+        if type(snapshot_seq) is not int or snapshot_seq < 0:
+            raise ValueError("snapshot_seq 必须是非负整数")
+        instant = _aware(now)
+        high_watermark, last_attempt = self._read()
+        seen = self._seen()
+        unseen = [
+            item
+            for item in items
+            if item.get("status") == "pending"
+            and item.get("due") is True
+            and not _is_seen(item, high_watermark=high_watermark, seen=seen)
+        ]
+        events = [_event(item) for item in items if item.get("due") is True]
+        result = advance_hazard(
+            events,
+            now=instant,
+            new_item_ids={_item_id(item) for item in unseen},
+            random_draw=random_draw,
+            last_wake_at=last_attempt,
+        )
+        with closing(sqlite3.connect(self.path)) as connection, connection:
+            connection.execute("BEGIN IMMEDIATE")
+            current = connection.execute(
+                "SELECT content_high_watermark FROM admission_state WHERE singleton = 1"
+            ).fetchone()
+            if current is None or int(current[0]) != high_watermark:
+                raise RuntimeError(
+                    "Wake Content admission watermark changed concurrently"
+                )
+            connection.execute(
+                """
+                UPDATE admission_state
+                SET last_content_attempt_at = CASE WHEN ? THEN ? ELSE last_content_attempt_at END
+                WHERE singleton = 1
+                """,
+                (
+                    int(result.should_wake),
+                    instant.isoformat(),
+                ),
+            )
+            connection.executemany(
+                "INSERT OR IGNORE INTO seen_content(item_identity) VALUES (?)",
+                ((_item_identity(item),) for item in unseen),
+            )
+        return result
+
+    def _read(self) -> tuple[int, datetime | None]:
+        self.initialize()
+        with closing(sqlite3.connect(self.path)) as connection:
+            row = connection.execute(
+                "SELECT content_high_watermark, last_content_attempt_at "
+                "FROM admission_state WHERE singleton = 1"
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("Wake admission_state singleton 缺失")
+        return int(row[0]), None if row[1] is None else _datetime(row[1])
+
+    def _seen(self) -> frozenset[str]:
+        self.initialize()
+        with closing(sqlite3.connect(self.path)) as connection:
+            rows = connection.execute(
+                "SELECT item_identity FROM seen_content"
+            ).fetchall()
+        return frozenset(str(row[0]) for row in rows)
+
+
+def _event(item: Mapping[str, object]) -> dict[str, object]:
+    payload = item.get("payload")
+    ref = item.get("ref")
+    if not isinstance(payload, Mapping) or not isinstance(ref, Mapping):
+        raise ValueError("Wake Content item 缺少 payload/ref")
+    event = dict(cast(Mapping[str, object], payload))
+    event["id"] = _item_id(item)
+    event["source_id"] = ref.get("source_id", "")
+    if "_wake_interest_score" not in event:
+        event["_wake_interest_score"] = payload.get("preprocess_score", 1.0)
+    return event
+
+
+def _item_id(item: Mapping[str, object]) -> str:
+    ref = item.get("ref")
+    if not isinstance(ref, Mapping):
+        raise ValueError("Wake Content item 缺少 ref")
+    value = ref.get("item_id")
+    if not isinstance(value, str) or not value:
+        raise ValueError("Wake Content item_id 必须非空")
+    return value
+
+
+def _item_identity(item: Mapping[str, object]) -> str:
+    ref = item.get("ref")
+    if not isinstance(ref, Mapping):
+        raise ValueError("Wake Content item 缺少 ref")
+    fields = tuple(ref.get(field) for field in ("source_id", "item_id", "revision"))
+    if any(not isinstance(value, str) or not value for value in fields):
+        raise ValueError("Wake Content ref identity 必须是非空字符串")
+    return "\x00".join(cast(tuple[str, str, str], fields))
+
+
+def _is_seen(
+    item: Mapping[str, object], *, high_watermark: int, seen: frozenset[str]
+) -> bool:
+    return (
+        _integer(item.get("snapshot_seq"), "snapshot_seq") <= high_watermark
+        or _item_identity(item) in seen
+    )
+
+
+def _integer(value: object, field: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{field} 必须是非负整数")
+    return value
+
+
+def _datetime(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("Wake deadline 必须是 ISO 字符串")
+    return _aware(datetime.fromisoformat(value))
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("Wake state 时间必须带时区")
+    return value.astimezone(UTC)
+
+
+def _normalize_sql(value: str) -> str:
+    return " ".join(value.replace('"', "").split()).lower()
+
+
+__all__ = ["WakeState"]

--- a/plugins/wake/state.py
+++ b/plugins/wake/state.py
@@ -118,7 +118,7 @@ class WakeState:
         result = advance_hazard(
             events,
             now=instant,
-            new_item_ids={_item_id(item) for item in unseen},
+            new_item_ids={_item_identity(item) for item in unseen},
             random_draw=random_draw,
             last_wake_at=last_attempt,
         )
@@ -176,6 +176,7 @@ def _event(item: Mapping[str, object]) -> dict[str, object]:
     event = dict(cast(Mapping[str, object], payload))
     event["id"] = _item_id(item)
     event["source_id"] = ref.get("source_id", "")
+    event["_wake_admission_identity"] = _item_identity(item)
     if "_wake_interest_score" not in event:
         event["_wake_interest_score"] = payload.get("preprocess_score", 1.0)
     return event

--- a/session/manager.py
+++ b/session/manager.py
@@ -373,7 +373,11 @@ class Session:
     def history_units(self, *, after_seq: int = -1) -> tuple[CommittedContextUnit, ...]:
         """Render complete canonical history units with immutable DB provenance."""
 
-        if not isinstance(after_seq, int) or isinstance(after_seq, bool) or after_seq < -1:
+        if (
+            not isinstance(after_seq, int)
+            or isinstance(after_seq, bool)
+            or after_seq < -1
+        ):
             raise ValueError("history unit after_seq 必须是大于等于 -1 的整数")
         units: list[CommittedContextUnit] = []
         for unit_index, (start, end) in enumerate(
@@ -386,7 +390,11 @@ class Session:
             for row in source_rows:
                 raw_id = row.get("id")
                 raw_seq = row.get("seq")
-                if not isinstance(raw_id, str) or not raw_id or not isinstance(raw_seq, int):
+                if (
+                    not isinstance(raw_id, str)
+                    or not raw_id
+                    or not isinstance(raw_seq, int)
+                ):
                     source_ids = [f"active:unpersisted:{unit_index}"]
                     source_seqs = []
                     break
@@ -398,9 +406,7 @@ class Session:
                 raw_seq = row.get("seq")
                 row_ref = (
                     (str(raw_id), int(raw_seq))
-                    if isinstance(raw_id, str)
-                    and raw_id
-                    and isinstance(raw_seq, int)
+                    if isinstance(raw_id, str) and raw_id and isinstance(raw_seq, int)
                     else (source_ids[0], 0)
                 )
                 rendered_with_refs.extend(
@@ -488,10 +494,9 @@ class SessionManager:
     def _cache_matches_meta(session: Session, meta: dict[str, Any]) -> bool:
         """比较缓存会话与 Store 持有的元数据修订字段。"""
 
-        return (
-            session.updated_at.isoformat() == str(meta["updated_at"])
-            and session.last_consolidated == int(meta["last_consolidated"])
-        )
+        return session.updated_at.isoformat() == str(
+            meta["updated_at"]
+        ) and session.last_consolidated == int(meta["last_consolidated"])
 
     def admit_existing(self, key: str) -> tuple[Session, str]:
         """为仍存在的会话建立跨连接处理租约并返回会话。"""
@@ -650,19 +655,36 @@ class SessionManager:
         content: str,
         delivery_id: str,
         control_turn_id: str,
+        metadata: Mapping[str, object] | None = None,
     ) -> str:
         """Append one proactive assistant projection exactly once per delivery id."""
 
         delivery_id = validate_message_delivery_id(delivery_id)
+        message_metadata = dict(metadata or {})
+        reserved = {
+            "id",
+            "role",
+            "content",
+            "timestamp",
+            "delivery_id",
+            "control_turn_id",
+        }
+        if conflict := reserved.intersection(message_metadata):
+            raise ValueError(
+                "durable delivery metadata 不得覆盖 Session 字段: "
+                + ", ".join(sorted(conflict))
+            )
         async with self._lock(session_key):
             # 1. A committed Session message is the crash-recovery receipt.
-            existing = self._store.get_message_by_delivery_id(
-                session_key, delivery_id
-            )
+            existing = self._store.get_message_by_delivery_id(session_key, delivery_id)
             if existing is not None:
                 if (
                     existing["content"] != content
                     or existing.get("control_turn_id") != control_turn_id
+                    or any(
+                        existing.get(key) != value
+                        for key, value in message_metadata.items()
+                    )
                 ):
                     raise RuntimeError(
                         f"durable delivery Session projection conflict: {delivery_id}"
@@ -672,6 +694,7 @@ class SessionManager:
             # 2. Persist and publish the new append-only projection under one lock.
             session = self.get_or_create(session_key)
             message: dict[str, object] = {
+                **message_metadata,
                 "role": "assistant",
                 "content": content,
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -753,7 +776,11 @@ class SessionManager:
         async with self._lock(session_key):
             # 1. Build a transient Session without creating a durable row.
             stored = self._store.get_session_meta(session_key)
-            session = Session(session_key) if stored is None else self.get_existing(session_key)
+            session = (
+                Session(session_key)
+                if stored is None
+                else self.get_existing(session_key)
+            )
             updated_at = datetime.now(UTC)
             metadata = dict(session.metadata)
             metadata[metadata_key] = identity

--- a/tests/control/test_control_execution.py
+++ b/tests/control/test_control_execution.py
@@ -85,7 +85,10 @@ async def test_control_turn_persists_outbound_attachment_identity() -> None:
 
 
 @pytest.mark.asyncio
-async def test_control_turn_translates_memoryless_stateless_scope() -> None:
+@pytest.mark.parametrize("session_history_read", (False, True))
+async def test_control_turn_translates_memoryless_stateless_scope(
+    session_history_read: bool,
+) -> None:
     bus = EventBus()
     observed: dict[str, object] = {}
 
@@ -123,6 +126,7 @@ async def test_control_turn_translates_memoryless_stateless_scope() -> None:
     token = bind_turn_scope(
         TurnExecutionScope(
             stateless=True,
+            session_history_read=session_history_read,
             memory_read=False,
             memory_write=False,
             tool_source="fixture-plugin",
@@ -134,14 +138,16 @@ async def test_control_turn_translates_memoryless_stateless_scope() -> None:
         reset_turn_scope(token)
 
     assert result.response == "done"
-    assert observed == {
+    expected = {
         "omit_user_turn": True,
         "omit_assistant_turn": True,
-        "skip_session_history": True,
         "skip_memory_retrieval": True,
         "skip_post_memory": True,
         "disable_memory_writes": True,
     }
+    if not session_history_read:
+        expected["skip_session_history"] = True
+    assert observed == expected
     await bus.aclose()
 
 
@@ -163,9 +169,7 @@ async def test_committed_control_turn_survives_shell_cleanup_error(
     loop._interrupt_states = {}
     loop._session_lanes = SessionLaneRegistry()
     loop._runtime_snapshot_store = None
-    loop._passive_pipeline = SimpleNamespace(
-        run_command=AsyncMock(return_value=None)
-    )
+    loop._passive_pipeline = SimpleNamespace(run_command=AsyncMock(return_value=None))
     loop._llm_services = SimpleNamespace(provider=object())
     loop._resume_interrupted_message = AsyncMock(
         side_effect=lambda message, _key: (message, False)
@@ -235,7 +239,9 @@ async def test_committed_control_turn_survives_shell_cleanup_error(
 
 
 @pytest.mark.asyncio
-async def test_tool_started_is_published_before_core_execution_finishes(tmp_path: Path) -> None:
+async def test_tool_started_is_published_before_core_execution_finishes(
+    tmp_path: Path,
+) -> None:
     bus = EventBus()
     release = asyncio.Event()
 
@@ -333,7 +339,9 @@ async def test_tool_started_is_published_before_core_execution_finishes(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_short_circuited_turn_completes_without_turn_committed(tmp_path: Path) -> None:
+async def test_short_circuited_turn_completes_without_turn_committed(
+    tmp_path: Path,
+) -> None:
     bus = EventBus()
 
     class _Loop:

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -2132,8 +2132,10 @@ def test_embedding_preflight_excludes_legacy_interrupted_turn(
     assert audit.issues == ()
 
 
-def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
-    """忽略前置 proactive，只为显式 interaction 构建一个 Akasha 样本。"""
+def test_sparse_builder_ignores_twenty_proactive_messages_before_user_turn(
+    tmp_path: Path,
+) -> None:
+    """忽略二十条无人回复的 proactive，只学习随后的完整 interaction。"""
 
     # 1. 构造 proactive 先提交、completed interaction 后提交的 canonical 顺序。
     sessions = tmp_path / "sessions.db"
@@ -2143,28 +2145,28 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
     rows = [
         (
             "u1",
-            1,
+            20,
             "user",
             "alpha",
             {"control_turn_id": "t1", "turn_input_ordinal": 0},
         ),
         (
             "u2",
-            2,
+            21,
             "user",
             "beta",
             {"control_turn_id": "t1", "turn_input_ordinal": 1},
         ),
         (
             "u3",
-            3,
+            22,
             "user",
             "gamma",
             {"control_turn_id": "t1", "turn_input_ordinal": 2},
         ),
         (
             "a1",
-            4,
+            23,
             "assistant",
             "final",
             {
@@ -2185,23 +2187,24 @@ def test_sparse_builder_groups_explicit_multi_user_turn(tmp_path: Path) -> None:
             "INSERT INTO sessions VALUES ('test:one', ?, ?, 0, NULL)",
             (started.isoformat(), started.isoformat()),
         )
-        connection.execute(
-            "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, ?, ?)",
-            (
-                "p1",
-                0,
-                "assistant",
-                "proactive",
-                json.dumps(
-                    {
-                        "proactive": True,
-                        "delivery_id": "delivery-1",
-                        "control_turn_id": "proactive-turn",
-                    }
+        for sequence in range(20):
+            connection.execute(
+                "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, ?, ?)",
+                (
+                    f"p{sequence}",
+                    sequence,
+                    "assistant",
+                    f"proactive {sequence}",
+                    json.dumps(
+                        {
+                            "proactive": True,
+                            "delivery_id": f"delivery-{sequence}",
+                            "control_turn_id": f"proactive-turn-{sequence}",
+                        }
+                    ),
+                    (started + timedelta(seconds=sequence)).isoformat(),
                 ),
-                started.isoformat(),
-            ),
-        )
+            )
         for message_id, seq, role, content, extra in rows:
             connection.execute(
                 "INSERT INTO messages VALUES (?, 'test:one', ?, ?, ?, NULL, ?, ?)",
@@ -3273,8 +3276,7 @@ def test_online_runtime_rebuilds_pair_after_crash_between_sidecar_replaces(
             "SELECT value FROM metadata WHERE key = 'source_index_sha256'"
         ).fetchone()
         stale_memory_state_sha = connection.execute(
-            "SELECT value FROM metadata "
-            "WHERE key = 'source_index_state_sha256'"
+            "SELECT value FROM metadata " "WHERE key = 'source_index_state_sha256'"
         ).fetchone()
     assert stale_memory_sha != (mixed_index_sha,)
     assert stale_memory_state_sha != (mixed_index_state_sha,)
@@ -3295,13 +3297,10 @@ def test_online_runtime_rebuilds_pair_after_crash_between_sidecar_replaces(
             "SELECT value FROM metadata WHERE key = 'source_index_sha256'"
         ).fetchone()
         recovered_memory_state_sha = connection.execute(
-            "SELECT value FROM metadata "
-            "WHERE key = 'source_index_state_sha256'"
+            "SELECT value FROM metadata " "WHERE key = 'source_index_state_sha256'"
         ).fetchone()
     assert recovered_memory_sha == (final_index_sha,)
-    assert recovered_memory_state_sha == (
-        sparse_index_state_sha256(index_path),
-    )
+    assert recovered_memory_state_sha == (sparse_index_state_sha256(index_path),)
 
 
 def test_online_runtime_reopens_unchanged_sidecars_without_rebuilding(
@@ -3388,9 +3387,7 @@ def test_online_runtime_ignores_excluded_turn_diagnostics_on_restart(
     )
     first.close()
     with closing(sqlite3.connect(memory_path)) as connection, connection:
-        connection.execute(
-            "DELETE FROM metadata WHERE key='source_index_state_sha256'"
-        )
+        connection.execute("DELETE FROM metadata WHERE key='source_index_state_sha256'")
     _append_turn(
         sessions_path,
         sequence=0,

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -179,9 +179,7 @@ def test_selected_recovers_same_tokens_in_snapshot_order_with_limit(tmp_path) ->
             _item("three", not_before=now),
         ),
     )
-    tokens = tuple(
-        _select(store, now, item_id) for item_id in ("one", "two", "three")
-    )
+    tokens = tuple(_select(store, now, item_id) for item_id in ("one", "two", "three"))
 
     restarted = ContentStore(path)
     recovered = restarted.selected(limit=2)
@@ -433,7 +431,17 @@ def test_delivery_capability_is_body_free_and_replays_stable_receipt(
     delivery = content_plugin._DeliveryServices(store)
 
     assert delivery.pending() == (
-        {"selection_token": token, "accepted_turn": accepted},
+        {
+            "selection_token": token,
+            "accepted_turn": accepted,
+            "message_metadata": {
+                "tools_used": ["message_push"],
+                "evidence_item_ids": ["fitbit:delivery:1"],
+                "source_refs": [{"display_index": 1, "event_id": "fitbit:delivery:1"}],
+                "state_summary_tag": "none",
+            },
+            "decision_format": "items_v1",
+        },
     )
     first = delivery.settle(token, "wake:logical-delivery")
     recovered = delivery.lookup(accepted)
@@ -464,6 +472,101 @@ def test_delivery_capability_is_body_free_and_replays_stable_receipt(
         assert after_ack is not None
         assert after_ack["status"] == "settled"
         assert after_ack["receipt"] == first["receipt"]
+
+
+def test_skip_release_keeps_candidate_pending_without_source_ack(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:skip",
+        [_item("skip", not_before=now, requires_ack=True)],
+    )
+    token = _select(store, now, "skip")
+
+    result = store.transition(token, "release")
+
+    assert result["changed"] is True and result["status"] == "pending"
+    assert store.state_counts() == {"pending": 1}
+    assert store.unsettled("feed") == ()
+
+
+def test_batch_share_projects_one_message_and_consumes_only_cited_members(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:batch",
+        [
+            {
+                **_item(f"item:{index}", not_before=now, requires_ack=True),
+                "payload": {
+                    "title": f"Title {index}",
+                    "url": f"https://example.test/{index}",
+                },
+            }
+            for index in range(6)
+        ],
+    )
+    snapshot = store.snapshot(now)
+    accepted = {"session_id": "mobile:one", "turn_id": "turn:batch"}
+    selected = store.select_batch(
+        tuple(item["ref"] for item in snapshot["items"]),
+        snapshot["snapshot_seq"],
+        accepted,
+        now,
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+    cited = (snapshot["items"][1]["ref"], snapshot["items"][4]["ref"])
+
+    ready = store.transition(token, "ready_for_delivery", selected_refs=cited)
+    pending = store.pending_delivery()
+    settled = store.settle_delivery(token, "wake:batch")
+
+    assert ready["status"] == "ready_for_delivery"
+    assert len(pending) == 1
+    assert pending[0]["accepted_turn"] == accepted
+    assert pending[0]["message_metadata"]["evidence_item_ids"] == [
+        "feed:item:1:1",
+        "feed:item:4:1",
+    ]
+    assert settled["settled"] is True
+    assert store.state_counts() == {"delivered": 2, "pending": 4}
+    acknowledgements = store.unsettled("feed")
+    assert len(acknowledgements) == 2
+    assert {row["ref"]["item_id"] for row in acknowledgements} == {
+        "item:1",
+        "item:4",
+    }
+
+
+def test_batch_skip_releases_entire_candidate_page_without_ack(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    store = ContentStore(tmp_path / "content.sqlite3")
+    _ = store.submit(
+        "feed",
+        "poll:batch-skip",
+        [_item(f"item:{index}", not_before=now) for index in range(20)],
+    )
+    snapshot = store.snapshot(now)
+    selected = store.select_batch(
+        tuple(item["ref"] for item in snapshot["items"]),
+        snapshot["snapshot_seq"],
+        {"session_id": "mobile:one", "turn_id": "turn:skip"},
+        now,
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+
+    result = store.transition(token, "release")
+
+    assert result["status"] == "pending"
+    assert store.state_counts() == {"pending": 20}
+    assert len(store.snapshot(now)["items"]) == 20
+    assert store.unsettled("feed") == ()
 
 
 def test_delivery_capability_rejects_conflicting_settlement_identity(tmp_path) -> None:
@@ -610,9 +713,12 @@ def test_read_only_store_reads_formal_state_and_rejects_every_write(tmp_path) ->
 
     candidate.initialize()
     assert candidate.snapshot(now)["snapshot_seq"] == snapshot["snapshot_seq"]
-    assert candidate.selection(
-        {"session_id": "wake:fixture", "turn_id": "turn:one"}
-    )["selection_token"] == token
+    assert (
+        candidate.selection({"session_id": "wake:fixture", "turn_id": "turn:one"})[
+            "selection_token"
+        ]
+        == token
+    )
     assert candidate.unsettled("feed") == ()
     assert candidate.state_counts() == {"selected": 1}
 
@@ -655,6 +761,39 @@ def test_initialize_rejects_unknown_or_malformed_schema(tmp_path) -> None:
     connection.close()
     with pytest.raises(RuntimeError, match="schema mismatch"):
         ContentStore(malformed).initialize()
+
+
+def test_v1_single_item_selection_migrates_to_exact_batch_ledger(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 5, tzinfo=UTC)
+    path = tmp_path / "content-v1.sqlite3"
+    store = ContentStore(path)
+    _ = store.submit("feed", "poll:v1", [_item("one", not_before=now)])
+    token = _select(store, now)
+    _ = store.transition(token, "ready_for_delivery")
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        DROP INDEX content_selection_members_order_idx;
+        DROP INDEX content_selection_status_idx;
+        DROP TABLE content_selection_members;
+        DROP TABLE content_selections;
+        PRAGMA user_version = 1;
+        """)
+    connection.close()
+
+    migrated = ContentStore(path)
+    migrated.initialize()
+    recovered = migrated.selection(
+        {"session_id": "wake:fixture", "turn_id": "turn:one"}
+    )
+
+    assert recovered is not None
+    assert recovered["status"] == "ready_for_delivery"
+    assert len(recovered["items"]) == 1
+    assert migrated.pending_delivery()[0]["selection_token"] == token
+    connection = sqlite3.connect(path)
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    connection.close()
 
 
 def test_initialize_rejects_constraint_free_schema_with_same_columns(tmp_path) -> None:

--- a/tests/test_content_store.py
+++ b/tests/test_content_store.py
@@ -486,7 +486,7 @@ def test_skip_release_keeps_candidate_pending_without_source_ack(tmp_path) -> No
 
     result = store.transition(token, "release")
 
-    assert result["changed"] is True and result["status"] == "pending"
+    assert result["changed"] is True and result.get("status") == "pending"
     assert store.state_counts() == {"pending": 1}
     assert store.unsettled("feed") == ()
 
@@ -526,10 +526,12 @@ def test_batch_share_projects_one_message_and_consumes_only_cited_members(
     pending = store.pending_delivery()
     settled = store.settle_delivery(token, "wake:batch")
 
-    assert ready["status"] == "ready_for_delivery"
+    assert ready.get("status") == "ready_for_delivery"
     assert len(pending) == 1
     assert pending[0]["accepted_turn"] == accepted
-    assert pending[0]["message_metadata"]["evidence_item_ids"] == [
+    metadata = pending[0]["message_metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["evidence_item_ids"] == [
         "feed:item:1:1",
         "feed:item:4:1",
     ]
@@ -537,10 +539,14 @@ def test_batch_share_projects_one_message_and_consumes_only_cited_members(
     assert store.state_counts() == {"delivered": 2, "pending": 4}
     acknowledgements = store.unsettled("feed")
     assert len(acknowledgements) == 2
-    assert {row["ref"]["item_id"] for row in acknowledgements} == {
-        "item:1",
-        "item:4",
-    }
+    item_ids: set[str] = set()
+    for row in acknowledgements:
+        ref = row["ref"]
+        assert isinstance(ref, dict)
+        item_id = ref["item_id"]
+        assert isinstance(item_id, str)
+        item_ids.add(item_id)
+    assert item_ids == {"item:1", "item:4"}
 
 
 def test_batch_skip_releases_entire_candidate_page_without_ack(tmp_path) -> None:
@@ -563,7 +569,7 @@ def test_batch_skip_releases_entire_candidate_page_without_ack(tmp_path) -> None
 
     result = store.transition(token, "release")
 
-    assert result["status"] == "pending"
+    assert result.get("status") == "pending"
     assert store.state_counts() == {"pending": 20}
     assert len(store.snapshot(now)["items"]) == 20
     assert store.unsettled("feed") == ()

--- a/tests/test_conversation_semantic_interest.py
+++ b/tests/test_conversation_semantic_interest.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent.plugin_composition.semantic_interest import ConversationSemanticInterest
+from session.embedding_store import MessageEmbeddingStore
+
+
+class _EmbeddingApi:
+    model_id = "fixture-embedding"
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        vectors = {
+            "looks proactive": [1.0, 0.0],
+            "looks passive": [0.0, 1.0],
+        }
+        return [vectors[text] for text in texts]
+
+
+@pytest.mark.asyncio
+async def test_scores_against_passive_turns_and_ignores_twenty_proactive_rows(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    now = datetime(2026, 8, 25, 1, tzinfo=UTC)
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("""
+            CREATE TABLE messages(
+                id TEXT PRIMARY KEY, session_key TEXT, seq INTEGER, role TEXT,
+                content TEXT, extra TEXT, ts TEXT
+            )
+            """)
+        rows = [
+            ("u-pro", "mobile", 1, "user", "proactive seed", "{}", now.isoformat()),
+            *[
+                (
+                    f"p{index}",
+                    "mobile",
+                    index + 2,
+                    "assistant",
+                    f"push {index}",
+                    '{"proactive":true}',
+                    (now + timedelta(seconds=index + 1)).isoformat(),
+                )
+                for index in range(20)
+            ],
+            (
+                "u-passive",
+                "mobile",
+                22,
+                "user",
+                "passive user",
+                "{}",
+                (now + timedelta(seconds=30)).isoformat(),
+            ),
+            (
+                "a-passive",
+                "mobile",
+                23,
+                "assistant",
+                "passive assistant",
+                "{}",
+                (now + timedelta(seconds=31)).isoformat(),
+            ),
+        ]
+        connection.executemany("INSERT INTO messages VALUES(?, ?, ?, ?, ?, ?, ?)", rows)
+    embeddings = MessageEmbeddingStore(db_path)
+    embeddings.upsert(
+        message_id="u-pro",
+        content="proactive seed",
+        model=_EmbeddingApi.model_id,
+        embedding=[1.0, 0.0],
+    )
+    for index in range(20):
+        embeddings.upsert(
+            message_id=f"p{index}",
+            content=f"push {index}",
+            model=_EmbeddingApi.model_id,
+            embedding=[1.0, 0.0],
+        )
+    embeddings.upsert(
+        message_id="u-passive",
+        content="passive user",
+        model=_EmbeddingApi.model_id,
+        embedding=[0.0, 1.0],
+    )
+    embeddings.upsert(
+        message_id="a-passive",
+        content="passive assistant",
+        model=_EmbeddingApi.model_id,
+        embedding=[0.0, 1.0],
+    )
+    embeddings.close()
+
+    service = ConversationSemanticInterest(db_path, _EmbeddingApi())
+    scores = await service.score(
+        ("looks proactive", "looks passive"),
+        cutoff=(now + timedelta(minutes=1)).isoformat(),
+    )
+
+    assert scores[0] == 0.0
+    assert scores[1] == pytest.approx(0.999)
+
+
+@pytest.mark.asyncio
+async def test_candidate_validation_cannot_read_formal_semantics() -> None:
+    service = ConversationSemanticInterest.candidate_validation()
+
+    with pytest.raises(RuntimeError, match="candidate 验证期禁止"):
+        await service.score(("candidate",), cutoff=datetime.now(UTC).isoformat())

--- a/tests/test_drift_store.py
+++ b/tests/test_drift_store.py
@@ -100,6 +100,90 @@ def test_drift_same_turn_second_proposal_is_explicit_cas_loser(tmp_path) -> None
     }
 
 
+def test_drift_ready_delivery_preserves_turn_and_settles_once(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 8, tzinfo=UTC)
+    store = DriftStore(tmp_path / "drift.sqlite3")
+    store.initialize()
+    store.propose("reflection", "1", {}, now)
+    proposal = store.snapshot(now)["proposals"][0]
+    accepted = {"session_id": "wake:default", "turn_id": "turn:share"}
+    selected = store.select(proposal["ref"], accepted, now)
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+
+    assert store.transition(token, "ready_for_delivery") == {
+        "changed": True,
+        "status": "ready_for_delivery",
+        "next_due": None,
+    }
+    assert store.pending_delivery() == (
+        {
+            "selection_token": token,
+            "accepted_turn": accepted,
+            "message_metadata": {
+                "tools_used": ["message_push"],
+                "evidence_item_ids": [],
+                "source_refs": [],
+                "state_summary_tag": "none",
+            },
+        },
+    )
+    first = store.settle_delivery(token, "wake:delivery")
+    second = store.settle_delivery(token, "wake:delivery")
+
+    assert first["settled"] is True and first["duplicate"] is False
+    assert second["settled"] is True and second["duplicate"] is True
+    assert first["receipt"] == second["receipt"]
+    assert store.delivery(accepted)["status"] == "settled"
+
+
+def test_drift_v1_orphaned_ready_row_is_invalidated_without_guessing_body(
+    tmp_path,
+) -> None:
+    path = tmp_path / "drift.sqlite3"
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        CREATE TABLE proposals(
+            proposal_id TEXT NOT NULL,
+            revision TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            due_at TEXT NOT NULL,
+            next_due TEXT,
+            state_version INTEGER NOT NULL,
+            selection_token TEXT UNIQUE,
+            selected_session_id TEXT,
+            selected_turn_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY(proposal_id, revision)
+        );
+        CREATE UNIQUE INDEX proposals_selected_turn_idx
+        ON proposals(selected_session_id, selected_turn_id)
+        WHERE selected_turn_id IS NOT NULL;
+        CREATE INDEX proposals_due_idx ON proposals(status, due_at);
+        INSERT INTO proposals VALUES(
+            'reflection', '1', '{}', 'ready_for_delivery',
+            '2026-08-23T08:00:00+00:00', NULL, 2,
+            NULL, NULL, NULL,
+            '2026-08-23T08:00:00+00:00', '2026-08-23T08:01:00+00:00'
+        );
+        PRAGMA user_version = 1;
+        """)
+    connection.close()
+
+    store = DriftStore(path)
+    store.initialize()
+
+    assert store.snapshot(datetime(2026, 8, 23, 9, tzinfo=UTC))["proposals"] == ()
+    connection = sqlite3.connect(path)
+    status, state_version = connection.execute(
+        "SELECT status, state_version FROM proposals"
+    ).fetchone()
+    connection.close()
+    assert (status, state_version) == ("invalidated", 3)
+
+
 @pytest.mark.parametrize("mutation", ["missing_index", "extra_table"])
 def test_drift_rejects_same_version_schema_topology_drift(tmp_path, mutation) -> None:
     path = tmp_path / "drift.sqlite3"
@@ -120,8 +204,7 @@ def test_drift_rejects_same_version_schema_topology_drift(tmp_path, mutation) ->
 def test_drift_rejects_constraint_free_same_version_table(tmp_path) -> None:
     path = tmp_path / "drift.sqlite3"
     connection = sqlite3.connect(path)
-    connection.executescript(
-        """
+    connection.executescript("""
         CREATE TABLE proposals(
             proposal_id TEXT NOT NULL,
             revision TEXT NOT NULL,
@@ -141,8 +224,7 @@ def test_drift_rejects_constraint_free_same_version_table(tmp_path) -> None:
         WHERE selected_turn_id IS NOT NULL;
         CREATE INDEX proposals_due_idx ON proposals(status, due_at);
         PRAGMA user_version = 1;
-        """
-    )
+        """)
     connection.close()
 
     with pytest.raises(RuntimeError, match="constraint-bearing table SQL"):

--- a/tests/test_logic_modules.py
+++ b/tests/test_logic_modules.py
@@ -656,6 +656,41 @@ def test_session_get_history_allows_proactive_assistant_boundary():
     ]
 
 
+def test_session_get_history_keeps_twenty_proactive_messages_before_reply():
+    session = Session("mobile:fixture")
+    for index in range(20):
+        session.add_message(
+            "assistant",
+            f"主动消息 {index}",
+            proactive=True,
+            delivery_id=f"delivery-{index}",
+            control_turn_id=f"wake-turn-{index}",
+        )
+    session.add_message(
+        "user",
+        "u",
+        control_turn_id="passive-turn",
+        turn_input_ordinal=0,
+    )
+    session.add_message(
+        "assistant",
+        "a",
+        control_turn_id="passive-turn",
+        turn_terminal=True,
+        turn_input_count=1,
+    )
+
+    history = session.get_history()
+
+    assert [message["content"] for message in history[:20]] == [
+        f"[主动推送] 主动消息 {index}" for index in range(20)
+    ]
+    assert history[-2:] == [
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a"},
+    ]
+
+
 def test_session_get_history_never_splits_explicit_multi_input_turn():
     session = Session("cli:multi-input")
     session.add_message("user", "old")

--- a/tests/test_wake_durable_delivery.py
+++ b/tests/test_wake_durable_delivery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
+from contextlib import closing
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -19,9 +21,15 @@ from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
 from plugins.content.plugin import (
     ContentDeliveryServices,
     _DeliveryServices,
-    _WakeServices,
+    _WakeServices as _ContentWakeServices,
 )
 from plugins.content.store import ContentStore
+from plugins.drift.plugin import (
+    DriftDeliveryServices,
+    _DeliveryServices as _DriftDeliveryServices,
+    _WakeServices as _DriftWakeServices,
+)
+from plugins.drift.store import DriftStore
 from plugins.wake.plugin import DeliveryTarget, DriftWakeServices, WakeRuntime
 from session.manager import SessionManager
 
@@ -32,9 +40,12 @@ class _NoTimers:
 
 
 class _Turns:
-    def __init__(self, accepted: TurnAcceptedReceipt, response: str) -> None:
+    def __init__(
+        self, accepted: TurnAcceptedReceipt, response: str, *, legacy: bool = False
+    ) -> None:
         self.accepted = accepted
         self.response = response
+        self.legacy = legacy
 
     def read(self, accepted: TurnAcceptedReceipt) -> DurableTurnView:
         assert accepted == self.accepted
@@ -54,7 +65,11 @@ class _Turns:
                         "callId": "call:share",
                         "name": "share_content",
                         "status": "success",
-                        "arguments": {"message": self.response},
+                        "arguments": (
+                            {"message": self.response}
+                            if self.legacy
+                            else {"message": self.response, "items": []}
+                        ),
                         "resultPreview": '{"recorded":true}',
                     },
                 ),
@@ -110,20 +125,107 @@ def _runtime(
     deliveries: PluginDurableDeliveries,
     *,
     response: str = "Wake says hello",
+    legacy: bool = False,
 ) -> WakeRuntime:
     return WakeRuntime(
         cast(PluginTimers, _NoTimers()),
-        cast(PluginScopedTurns, _Turns(accepted, response)),
-        _WakeServices(content),
+        cast(PluginScopedTurns, _Turns(accepted, response, legacy=legacy)),
+        _ContentWakeServices(content),
         cast(DriftWakeServices, _NoDrift()),
         deliveries=deliveries,
         content_delivery=cast(ContentDeliveryServices, _DeliveryServices(content)),
+        drift_delivery=cast(
+            DriftDeliveryServices,
+            _DriftDeliveryServices(DriftStore(content.path.with_name("drift.sqlite3"))),
+        ),
         target=DeliveryTarget(
             channel="recording",
             recipient="recipient:one",
             session_id="recipient-session",
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_drift_share_uses_same_provider_session_and_settlement_chain(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    accepted = TurnAcceptedReceipt("wake:default", "turn:drift-delivery")
+    content = ContentStore(tmp_path / "content.sqlite3")
+    content.initialize()
+    drift = DriftStore(tmp_path / "drift.sqlite3")
+    drift.initialize()
+    drift.propose("reflection", "1", {"kind": "drift"}, now)
+    proposal = drift.snapshot(now)["proposals"][0]
+    selected = drift.select(
+        proposal["ref"],
+        {"session_id": accepted.session_id, "turn_id": accepted.turn_id},
+        now,
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+    assert drift.transition(token, "ready_for_delivery")["changed"] is True
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    sessions = SessionManager(tmp_path / "workspace")
+    provider_calls: list[str] = []
+
+    async def sender(request, provider_started):
+        provider_started(
+            DurableBindingAttempt(
+                request.logical_delivery_id,
+                "snapshot:recording",
+                "generation:recording",
+                "binding:recording",
+            )
+        )
+        provider_calls.append(request.body)
+        return ChannelDeliveryReceipt(
+            request.logical_delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:recording",),
+        )
+
+    async def project(request) -> str:
+        return await sessions.append_durable_delivery(
+            session_key=request.projection_session_id,
+            content=request.body,
+            delivery_id=request.logical_delivery_id,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+
+    deliveries = PluginDurableDeliveries(ledger, sender, project)
+    runtime = WakeRuntime(
+        cast(PluginTimers, _NoTimers()),
+        cast(PluginScopedTurns, _Turns(accepted, "drift thought")),
+        _ContentWakeServices(content),
+        _DriftWakeServices(drift),
+        deliveries=deliveries,
+        content_delivery=cast(ContentDeliveryServices, _DeliveryServices(content)),
+        drift_delivery=cast(
+            DriftDeliveryServices,
+            _DriftDeliveryServices(drift),
+        ),
+        target=DeliveryTarget(
+            channel="recording",
+            recipient="recipient:one",
+            session_id="recipient-session",
+        ),
+    )
+
+    await runtime.start()
+    await runtime.close()
+
+    assert provider_calls == ["drift thought"]
+    messages = sessions.control_store.fetch_session_messages("recipient-session")
+    assert [message["content"] for message in messages] == ["drift thought"]
+    assert (
+        drift.delivery(
+            {"session_id": accepted.session_id, "turn_id": accepted.turn_id}
+        )["status"]
+        == "settled"
+    )
+    sessions.close()
 
 
 @pytest.mark.asyncio
@@ -178,6 +280,67 @@ async def test_wake_composes_provider_session_content_and_core_settlement(
     assert messages[0]["content"] == "Wake says hello"
     assert messages[0]["control_turn_id"] == accepted.turn_id
     assert content.state_counts() == {"settled": 1}
+    sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_v1_ready_turn_with_message_only_decision_recovers_once(
+    tmp_path: Path,
+) -> None:
+    content, accepted, _token = _ready_content(tmp_path / "content.sqlite3")
+    with closing(sqlite3.connect(content.path)) as connection, connection:
+        connection.executescript("""
+            DROP INDEX content_selection_members_order_idx;
+            DROP INDEX content_selection_status_idx;
+            DROP TABLE content_selection_members;
+            DROP TABLE content_selections;
+            PRAGMA user_version = 1;
+            """)
+    content.initialize()
+    recovered = content.selection(
+        {"session_id": accepted.session_id, "turn_id": accepted.turn_id}
+    )
+    assert recovered is not None and recovered["decision_format"] == "legacy_single"
+
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    sessions = SessionManager(tmp_path / "workspace")
+    provider_calls: list[str] = []
+
+    async def sender(request, provider_started):
+        provider_started(
+            DurableBindingAttempt(
+                request.logical_delivery_id,
+                "snapshot:recording",
+                "generation:recording",
+                "binding:recording",
+            )
+        )
+        provider_calls.append(request.body)
+        return ChannelDeliveryReceipt(
+            request.logical_delivery_id,
+            DeliveryStatus.DELIVERED,
+            ("provider:recording",),
+        )
+
+    async def project(request) -> str:
+        return await sessions.append_durable_delivery(
+            session_key=request.projection_session_id,
+            content=request.body,
+            delivery_id=request.logical_delivery_id,
+            control_turn_id=request.accepted_turn.turn_id,
+        )
+
+    deliveries = PluginDurableDeliveries(ledger, sender, project)
+    runtime = _runtime(accepted, content, deliveries, legacy=True)
+    await runtime.start()
+    await runtime.close()
+
+    assert provider_calls == ["Wake says hello"]
+    assert content.state_counts() == {"settled": 1}
+    messages = sessions.control_store.fetch_session_messages("recipient-session")
+    assert [message["content"] for message in messages] == ["Wake says hello"]
+    current = deliveries.lookup(accepted)
+    assert current is not None and current.state == "settled"
     sessions.close()
 
 
@@ -268,6 +431,97 @@ async def test_terminal_provider_result_is_observable_and_never_resent(
     assert content.state_counts() == {"ready_for_delivery": 1}
     current = deliveries.lookup(accepted)
     assert current is not None and current.state == terminal
+
+
+@pytest.mark.asyncio
+async def test_uncertain_batch_locks_only_cited_member_from_next_selection(
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    content = ContentStore(tmp_path / "content.sqlite3")
+    _ = content.submit(
+        "feed",
+        "poll:first",
+        (
+            {
+                "item_id": "uncited",
+                "revision": "1",
+                "payload": {"title": "uncited"},
+                "not_before": now,
+                "requires_ack": False,
+            },
+            {
+                "item_id": "cited",
+                "revision": "1",
+                "payload": {"title": "cited"},
+                "not_before": now,
+                "requires_ack": False,
+            },
+        ),
+    )
+    snapshot = content.snapshot(now)
+    accepted = TurnAcceptedReceipt("wake:default", "turn:uncertain")
+    selected = content.select_batch(
+        tuple(item["ref"] for item in snapshot["items"]),
+        snapshot["snapshot_seq"],
+        {"session_id": accepted.session_id, "turn_id": accepted.turn_id},
+        now,
+    )
+    token = selected["selection_token"]
+    assert isinstance(token, str)
+    cited = snapshot["items"][1]["ref"]
+    _ = content.transition(token, "ready_for_delivery", selected_refs=(cited,))
+    ledger = DurableDeliveryStore(tmp_path / "settlements.sqlite")
+    ledger.initialize()
+    _prepare_delivery(ledger, accepted, "wake:uncertain-batch")
+    _ = ledger.mark_provider_started(
+        "wake:uncertain-batch",
+        attempt_id="wake:uncertain-batch",
+        snapshot_id="snapshot:one",
+        generation_id="generation:one",
+        binding_token="binding:one",
+    )
+    _ = ledger.mark_provider_result(
+        "wake:uncertain-batch",
+        state="uncertain",
+        receipt={"status": "uncertain"},
+    )
+
+    async def no_sender(_request, _provider_started):
+        raise AssertionError("uncertain delivery must not resend")
+
+    async def no_projector(_request):
+        raise AssertionError("uncertain delivery must not project")
+
+    deliveries = PluginDurableDeliveries(ledger, no_sender, no_projector)
+    runtime = _runtime(accepted, content, deliveries)
+    await runtime.start()
+    await runtime.close()
+    _ = content.submit(
+        "feed",
+        "poll:second",
+        (
+            {
+                "item_id": "new",
+                "revision": "1",
+                "payload": {"title": "new"},
+                "not_before": now,
+                "requires_ack": False,
+            },
+        ),
+    )
+    available = content.snapshot(now)
+    available_ids = {str(item["ref"]["item_id"]) for item in available["items"]}
+
+    assert available_ids == {"uncited", "new"}
+    next_selected = content.select_batch(
+        tuple(item["ref"] for item in available["items"]),
+        available["snapshot_seq"],
+        {"session_id": "wake:default", "turn_id": "turn:next"},
+        now,
+    )
+    assert next_selected["selected"] is True
+    assert deliveries.lookup(accepted).state == "uncertain"
 
 
 def _prepare_delivery(

--- a/tests/test_wake_state.py
+++ b/tests/test_wake_state.py
@@ -1,0 +1,104 @@
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from plugins.wake.state import WakeState
+
+
+def _item(sequence: int, score: float) -> dict[str, object]:
+    now = "2026-08-23T09:00:00+00:00"
+    return {
+        "ref": {
+            "source_id": "feed",
+            "item_id": f"item:{sequence}",
+            "revision": "1",
+            "state_version": 1,
+        },
+        "payload": {
+            "preprocess_score": score,
+            "published_at": now,
+        },
+        "snapshot_seq": sequence,
+        "status": "pending",
+        "not_before": now,
+        "due": True,
+    }
+
+
+def test_low_value_batch_advances_watermark_without_starting_turn(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    state = WakeState(tmp_path / "wake.sqlite3")
+    items = [_item(index, 0.001) for index in range(1, 21)]
+
+    result = state.evaluate(items, snapshot_seq=20, now=now, random_draw=0.0)
+
+    assert result.should_wake is False
+    assert state.has_unseen_due(items, now) is False
+    assert state.unseen_deadline(items) is None
+
+
+def test_successful_admission_applies_refractory_to_immediate_new_item(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    state = WakeState(tmp_path / "wake.sqlite3")
+    first = [_item(1, 0.9)]
+    assert state.evaluate(first, snapshot_seq=1, now=now, random_draw=0.0).should_wake
+
+    second = [*first, _item(2, 0.9)]
+    result = state.evaluate(second, snapshot_seq=2, now=now, random_draw=0.0)
+
+    assert result.should_wake is False
+    assert state.has_unseen_due(second, now) is False
+
+
+def test_future_item_remains_unseen_after_current_batch_is_evaluated(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    tomorrow = now + timedelta(days=1)
+    state = WakeState(tmp_path / "wake.sqlite3")
+    current = _item(1, 0.001)
+    future = _item(2, 0.9)
+    future["not_before"] = tomorrow.isoformat()
+    future["due"] = False
+
+    first = state.evaluate((current, future), snapshot_seq=2, now=now, random_draw=0.0)
+
+    assert first.should_wake is False
+    assert state.unseen_deadline((current, future)) == tomorrow
+    future["due"] = True
+    second = state.evaluate(
+        (current, future), snapshot_seq=2, now=tomorrow, random_draw=0.0
+    )
+    assert second.should_wake is True
+    assert second.driver_item_id == "item:2"
+
+
+def test_v1_watermark_migrates_without_reclassifying_legacy_rows(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    path = tmp_path / "wake.sqlite3"
+    state = WakeState(path)
+    state.initialize()
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("DROP TABLE seen_content")
+        connection.execute("UPDATE admission_state SET content_high_watermark = 3")
+        connection.execute("PRAGMA user_version = 1")
+
+    migrated = WakeState(path)
+    migrated.initialize()
+
+    assert migrated.has_unseen_due((_item(3, 0.9),), now) is False
+    assert migrated.has_unseen_due((_item(4, 0.9),), now) is True
+
+
+def test_same_version_schema_mutation_fails_loud(tmp_path) -> None:
+    path = tmp_path / "wake.sqlite3"
+    state = WakeState(path)
+    state.initialize()
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("ALTER TABLE seen_content RENAME TO old_seen_content")
+        connection.execute("CREATE TABLE seen_content(item_identity TEXT)")
+
+    with pytest.raises(RuntimeError, match="schema mismatch"):
+        WakeState(path).initialize()

--- a/tests/test_wake_state.py
+++ b/tests/test_wake_state.py
@@ -85,13 +85,17 @@ def test_new_mass_uses_full_content_identity(
     now = datetime(2026, 8, 23, 9, tzinfo=UTC)
     state = WakeState(tmp_path / "wake.sqlite3")
     old_high = _item(1, 0.9)
-    old_high["ref"]["item_id"] = "shared-id"
+    old_ref = old_high["ref"]
+    assert isinstance(old_ref, dict)
+    old_ref["item_id"] = "shared-id"
     assert state.evaluate(
         (old_high,), snapshot_seq=1, now=now, random_draw=0.0
     ).should_wake
 
     new_low = _item(2, 0.001)
-    new_low["ref"].update(
+    new_ref = new_low["ref"]
+    assert isinstance(new_ref, dict)
+    new_ref.update(
         {"source_id": source_id, "item_id": "shared-id", "revision": revision}
     )
     result = state.evaluate(

--- a/tests/test_wake_state.py
+++ b/tests/test_wake_state.py
@@ -75,6 +75,36 @@ def test_future_item_remains_unseen_after_current_batch_is_evaluated(tmp_path) -
     assert second.driver_item_id == "item:2"
 
 
+@pytest.mark.parametrize(
+    ("source_id", "revision"),
+    (("other-feed", "1"), ("feed", "2")),
+)
+def test_new_mass_uses_full_content_identity(
+    tmp_path, source_id: str, revision: str
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    state = WakeState(tmp_path / "wake.sqlite3")
+    old_high = _item(1, 0.9)
+    old_high["ref"]["item_id"] = "shared-id"
+    assert state.evaluate(
+        (old_high,), snapshot_seq=1, now=now, random_draw=0.0
+    ).should_wake
+
+    new_low = _item(2, 0.001)
+    new_low["ref"].update(
+        {"source_id": source_id, "item_id": "shared-id", "revision": revision}
+    )
+    result = state.evaluate(
+        (old_high, new_low),
+        snapshot_seq=2,
+        now=now + timedelta(hours=12),
+        random_draw=0.0,
+    )
+
+    assert result.should_wake is False
+    assert state.has_unseen_due((old_high, new_low), now) is False
+
+
 def test_v1_watermark_migrates_without_reclassifying_legacy_rows(tmp_path) -> None:
     now = datetime(2026, 8, 23, 9, tzinfo=UTC)
     path = tmp_path / "wake.sqlite3"

--- a/tests/test_wake_v3.py
+++ b/tests/test_wake_v3.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -14,9 +15,27 @@ from agent.lifecycle.types import BeforeTurnCtx
 from agent.plugin_composition import PluginScopedTurns, PluginTimers
 from plugins.wake.plugin import (
     ContentWakeServices,
+    DeliveryTarget,
     DriftWakeServices,
     WakeRuntime,
+    _candidate_id,
 )
+from plugins.wake.state import WakeState
+
+_CONTENT_REF = {
+    "source_id": "fixture",
+    "item_id": "item:1",
+    "revision": "1",
+    "state_version": 1,
+}
+_CONTENT_CANDIDATE = _candidate_id(_CONTENT_REF)
+
+
+def _content_receipt() -> dict[str, object]:
+    return {
+        "selection_token": "content:selection",
+        "items": ({"ref": dict(_CONTENT_REF), "payload": {}},),
+    }
 
 
 def _decision_item(name: str, arguments: dict[str, object]) -> TurnItem:
@@ -81,7 +100,12 @@ class _TurnHandle:
             status=status,
             final_response="hello" if status is TurnStatus.COMPLETED else None,
             error=None,
-            items=[_decision_item("share_content", {"message": "hello"})],
+            items=[
+                _decision_item(
+                    "share_content",
+                    {"message": "hello", "items": [_CONTENT_CANDIDATE]},
+                )
+            ],
         )
 
     async def result(self):
@@ -126,13 +150,11 @@ class _Content:
         if self.payload is not None:
             items = (
                 {
-                    "ref": {
-                        "source_id": "fixture",
-                        "item_id": "item:1",
-                        "revision": "1",
-                        "state_version": 1,
-                    },
+                    "ref": dict(_CONTENT_REF),
                     "payload": self.payload,
+                    "snapshot_seq": 1,
+                    "status": "pending",
+                    "not_before": self.now.isoformat(),
                     "due": now >= self.now,
                 },
             )
@@ -143,6 +165,9 @@ class _Content:
         }
 
     def select(self, item_ref, snapshot_seq, accepted_turn, now):
+        return self.select_batch((item_ref,), snapshot_seq, accepted_turn, now)
+
+    def select_batch(self, item_refs, snapshot_seq, accepted_turn, now):
         self.selects += 1
         if not self.cas_wins:
             return {"selected": False, "selection_token": None}
@@ -151,6 +176,10 @@ class _Content:
             "status": "selected",
             "accepted_turn": dict(accepted_turn),
             "payload": self.payload or {},
+            "items": tuple(
+                {"ref": dict(item_ref), "payload": self.payload or {}}
+                for item_ref in item_refs
+            ),
         }
         self.selected_rows = [row]
         return {"selected": True, "selection_token": "content:selection"}
@@ -168,12 +197,41 @@ class _Content:
     def selected(self, limit: int = 100):
         return tuple(self.selected_rows[:limit])
 
-    def transition(self, token, action, *, not_before=None):
+    def transition(self, token, action, *, not_before=None, selected_refs=None):
         self.transitions.append((token, action, not_before))
         self.selected_rows = [
             row for row in self.selected_rows if row["selection_token"] != token
         ]
         return {"changed": True, "status": action}
+
+
+class _BatchContent(_Content):
+    def snapshot(self, now: datetime):
+        self.snapshots += 1
+        items = tuple(
+            {
+                "ref": {
+                    "source_id": "fixture",
+                    "item_id": f"item:{index}",
+                    "revision": "1",
+                    "state_version": 1,
+                },
+                "payload": {
+                    "title": f"Title {index}",
+                    "preprocess_score": 1 - index / 100,
+                },
+                "snapshot_seq": index + 1,
+                "status": "pending",
+                "not_before": self.now.isoformat(),
+                "due": now >= self.now,
+            }
+            for index in range(20)
+        )
+        return {
+            "snapshot_seq": 20,
+            "earliest_not_before": self.now.isoformat(),
+            "items": items,
+        }
 
 
 class _Drift:
@@ -285,6 +343,26 @@ async def test_content_wins_without_reading_or_writing_drift() -> None:
 
 
 @pytest.mark.asyncio
+async def test_one_content_turn_receives_one_frozen_twenty_candidate_page() -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    content = _BatchContent(now, {"kind": "fixture"})
+    runtime, _timers, _turns = _runtime(now, content, _Drift(now))
+    ctx = _ctx(now)
+
+    await runtime.prepare(ctx)
+
+    assert content.selects == 1
+    assert len(content.selected_rows[0]["items"]) == 20
+    duty = json.loads(ctx.extra_hints[0].split("\n", 2)[1])
+    assert duty["owner"] == "content"
+    assert len(duty["payload"]["candidates"]) == 20
+    assert all(
+        candidate["candidate_id"].startswith("candidate_")
+        for candidate in duty["payload"]["candidates"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_content_declines_then_drift_wins() -> None:
     now = datetime(2026, 8, 23, 9, tzinfo=UTC)
     content = _Content(now, {"wake_action": "decline"})
@@ -380,7 +458,130 @@ async def test_due_timer_starts_memoryless_wake_scoped_turn() -> None:
     assert scope.stateless is True
     assert scope.memory_read is scope.memory_write is False
     assert scope.tool_grant.allows("message_push") is False
+    assert scope.tool_grant.allows("tool_search") is False
+    assert scope.tool_grant.allows("share_content") is True
+    assert scope.tool_grant.allows("skip_content") is True
     await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_low_value_content_batch_does_not_admit_scoped_turn(tmp_path) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    content = _Content(now, {"preprocess_score": 0.001})
+    turns = _Turns()
+    runtime = WakeRuntime(
+        cast(PluginTimers, _Timers()),
+        cast(PluginScopedTurns, turns),
+        cast(ContentWakeServices, content),
+        cast(DriftWakeServices, _Drift(now)),
+        state=WakeState(tmp_path / "wake.sqlite3"),
+        random_draw=lambda: 0.0,
+        now=lambda: now,
+    )
+
+    assert await runtime._admit_owner() is None
+
+
+@pytest.mark.asyncio
+async def test_passive_semantic_interest_can_admit_low_preprocess_content(
+    tmp_path,
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+
+    class RankedContent(_Content):
+        def snapshot(self, _now):
+            items = tuple(
+                {
+                    "ref": {
+                        "source_id": "fixture",
+                        "item_id": item_id,
+                        "revision": "1",
+                        "state_version": 1,
+                    },
+                    "payload": payload,
+                    "snapshot_seq": index,
+                    "status": "pending",
+                    "not_before": now.isoformat(),
+                    "due": True,
+                }
+                for index, (item_id, payload) in enumerate(
+                    (
+                        (
+                            "generic",
+                            {
+                                "title": "generic headline",
+                                "preprocess_score": 0.2,
+                                "published_at": now.isoformat(),
+                            },
+                        ),
+                        (
+                            "matched",
+                            {
+                                "title": "matched memory topic",
+                                "preprocess_score": 0.001,
+                                "published_at": now.isoformat(),
+                            },
+                        ),
+                    ),
+                    start=1,
+                )
+            )
+            return {"snapshot_seq": 2, "items": items}
+
+    content = RankedContent(now)
+
+    class SemanticInterest:
+        async def score(self, texts, *, cutoff):
+            assert texts == ["generic headline", "matched memory topic"]
+            assert cutoff == now.isoformat()
+            return (0.0, 0.999)
+
+    runtime = WakeRuntime(
+        cast(PluginTimers, _Timers()),
+        cast(PluginScopedTurns, _Turns()),
+        cast(ContentWakeServices, content),
+        cast(DriftWakeServices, _Drift(now)),
+        state=WakeState(tmp_path / "wake.sqlite3"),
+        random_draw=lambda: 0.1,
+        now=lambda: now,
+        semantic_interest=cast(Any, SemanticInterest()),
+    )
+
+    assert await runtime._admit_owner() == "content"
+    runtime._active_owner = "content"
+    ctx = _ctx(now)
+    await runtime.prepare(ctx)
+    duty = json.loads(ctx.extra_hints[0].split("\n", 2)[1])
+    assert duty["payload"]["candidates"][0]["title"] == "matched memory topic"
+
+
+@pytest.mark.asyncio
+async def test_targeted_wake_turn_reads_mobile_history_without_writing_memory() -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    turns = _Turns()
+    runtime = WakeRuntime(
+        cast(PluginTimers, _Timers()),
+        cast(PluginScopedTurns, turns),
+        cast(ContentWakeServices, _Content(now)),
+        cast(DriftWakeServices, _Drift(now)),
+        target=DeliveryTarget(
+            channel="mobile",
+            recipient="device:one",
+            session_id="mobile:conversation",
+        ),
+        now=lambda: now,
+    )
+
+    with pytest.raises(RuntimeError, match="缺少 durable capability"):
+        await runtime._start_turn()
+
+    start = turns.starts[0]
+    scope = start["scope"]
+    assert start["session_id"] == "mobile:conversation"
+    assert scope.stateless is True
+    assert scope.session_history_read is True
+    assert scope.memory_read is True
+    assert scope.memory_write is False
 
 
 @pytest.mark.parametrize(
@@ -408,7 +609,12 @@ def test_terminal_matrix(status, retryable, action) -> None:
         error.message if error else None,
         error.retryable if error else None,
         (
-            (_decision_item("share_content", {"message": "hello"}),)
+            (
+                _decision_item(
+                    "share_content",
+                    {"message": "hello", "items": [_CONTENT_CANDIDATE]},
+                ),
+            )
             if status is TurnStatus.COMPLETED
             else ()
         ),
@@ -416,7 +622,7 @@ def test_terminal_matrix(status, retryable, action) -> None:
 
     runtime._settle(
         "content",
-        {"selection_token": "content:selection"},
+        _content_receipt(),
         view,
     )
 
@@ -427,8 +633,13 @@ def test_terminal_matrix(status, retryable, action) -> None:
 @pytest.mark.parametrize(
     ("decision", "arguments", "expected_action", "expected_timers"),
     [
-        ("share_content", {"message": "done"}, "ready_for_delivery", 0),
-        ("skip_content", {"reason": "not relevant"}, "abandoned", 0),
+        (
+            "share_content",
+            {"message": "done", "items": [_CONTENT_CANDIDATE]},
+            "ready_for_delivery",
+            0,
+        ),
+        ("skip_content", {"reason": "not relevant"}, "release", 0),
         (None, {}, "defer", 0),
     ],
 )
@@ -448,6 +659,7 @@ async def test_startup_reconciles_durable_typed_decision_before_arming(
                 "session_id": "wake:default",
                 "turn_id": "turn:old",
             },
+            "items": ({"ref": dict(_CONTENT_REF), "payload": {}},),
         }
     ]
     drift = _Drift(now)
@@ -475,12 +687,37 @@ async def test_startup_reconciles_durable_typed_decision_before_arming(
 @pytest.mark.parametrize(
     ("items", "action"),
     [
-        ((_decision_item("skip_content", {"reason": "not relevant"}),), "abandoned"),
+        ((_decision_item("skip_content", {"reason": "not relevant"}),), "release"),
         ((), "defer"),
         (
             (
                 _decision_item("share_content", {"message": "share"}),
                 _decision_item("skip_content", {"reason": "conflict"}),
+            ),
+            "defer",
+        ),
+        (
+            (_decision_item("share_content", {"message": "share", "items": []}),),
+            "defer",
+        ),
+        (
+            (
+                _decision_item(
+                    "share_content",
+                    {"message": "share", "items": ["candidate_unknown"]},
+                ),
+            ),
+            "defer",
+        ),
+        (
+            (
+                _decision_item(
+                    "share_content",
+                    {
+                        "message": "share",
+                        "items": [_CONTENT_CANDIDATE, _CONTENT_CANDIDATE],
+                    },
+                ),
             ),
             "defer",
         ),
@@ -495,7 +732,7 @@ def test_completed_content_requires_one_structured_decision(
 
     runtime._settle(
         "content",
-        {"selection_token": "content:selection"},
+        _content_receipt(),
         DurableTurnView(
             "wake:default",
             "turn:decision",
@@ -509,6 +746,46 @@ def test_completed_content_requires_one_structured_decision(
     )
 
     assert content.transitions[0][1] == action
+
+
+@pytest.mark.parametrize(
+    ("items", "action"),
+    [
+        (
+            (
+                _decision_item(
+                    "share_content", {"message": "drift thought", "items": []}
+                ),
+            ),
+            "ready_for_delivery",
+        ),
+        ((_decision_item("skip_content", {"reason": "stay quiet"}),), "await_change"),
+        ((), "await_change"),
+    ],
+)
+def test_completed_drift_uses_same_typed_delivery_decision(
+    items: tuple[TurnItem, ...], action: str
+) -> None:
+    now = datetime(2026, 8, 23, 9, tzinfo=UTC)
+    drift = _Drift(now)
+    runtime, _timers, _turns = _runtime(now, _Content(now), drift)
+
+    runtime._settle(
+        "drift",
+        {"selection_token": "drift:selection", "next_due": None},
+        DurableTurnView(
+            "wake:default",
+            "turn:drift",
+            TurnStatus.COMPLETED,
+            "过滤，不推送（事故诱饵）",
+            None,
+            None,
+            None,
+            items,
+        ),
+    )
+
+    assert drift.transitions[0][1] == action
 
 
 @pytest.mark.asyncio
@@ -601,7 +878,7 @@ def test_startup_transition_rejection_fails_loud_instead_of_looping() -> None:
         None,
     )
 
-    def rejected(token, action, *, not_before=None):
+    def rejected(token, action, *, not_before=None, selected_refs=None):
         return {"changed": False, "reason": "status:ready_for_delivery"}
 
     content.transition = rejected

--- a/tests/test_wake_v3.py
+++ b/tests/test_wake_v3.py
@@ -352,7 +352,9 @@ async def test_one_content_turn_receives_one_frozen_twenty_candidate_page() -> N
     await runtime.prepare(ctx)
 
     assert content.selects == 1
-    assert len(content.selected_rows[0]["items"]) == 20
+    selected_items = content.selected_rows[0]["items"]
+    assert isinstance(selected_items, tuple)
+    assert len(selected_items) == 20
     duty = json.loads(ctx.extra_hints[0].split("\n", 2)[1])
     assert duty["owner"] == "content"
     assert len(duty["payload"]["candidates"]) == 20

--- a/tests/test_wake_v3_composition.py
+++ b/tests/test_wake_v3_composition.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 import shutil
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -33,8 +34,14 @@ from bus.event_bus import EventBus
 from plugins.content.plugin import CONTENT_SOURCE, CONTENT_WAKE
 from plugins.content.store import ContentStore
 from plugins.drift.plugin import DRIFT_PROPOSALS, DRIFT_WAKE
+from plugins.wake.plugin import _candidate_id
 from session.manager import SessionManager
 from session.store import SessionStore
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_wake_admission(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(random, "random", lambda: 0.0)
 
 
 class _TimerHandle:
@@ -109,7 +116,18 @@ def _copy_plugins(tmp_path: Path) -> list[Path]:
     [
         (
             "share_content",
-            {"message": "fixture share body"},
+            {
+                "message": "fixture share body",
+                "items": [
+                    _candidate_id(
+                        {
+                            "source_id": "fitbit-e2e",
+                            "item_id": "sleep:e2e",
+                            "revision": "1",
+                        }
+                    )
+                ],
+            },
             "success",
             "settled",
             "fixture share body",
@@ -118,11 +136,17 @@ def _copy_plugins(tmp_path: Path) -> list[Path]:
             "skip_content",
             {"reason": "fixture candidate is irrelevant"},
             "success",
-            "abandoned",
+            "pending",
             None,
         ),
         (None, {}, None, "deferred", None),
-        ("share_content", {"message": "   "}, "error", "deferred", None),
+        (
+            "share_content",
+            {"message": "   ", "items": []},
+            "error",
+            "deferred",
+            None,
+        ),
         ("skip_content", {"reason": "\t"}, "error", "deferred", None),
     ],
 )
@@ -231,7 +255,7 @@ session_id = "recipient-session"
         try:
             registry.set_context(
                 origin_channel="wake",
-                origin_session_key="wake:default",
+                origin_session_key="recipient-session",
                 turn_id="turn:boundary",
             )
             with pytest.raises(ValueError, match="必须是非空字符串"):
@@ -252,7 +276,7 @@ session_id = "recipient-session"
             {
                 "item_id": "sleep:e2e",
                 "revision": "1",
-                "payload": {"kind": "sleep"},
+                "payload": {"kind": "sleep", "preprocess_score": 0.9},
                 "not_before": datetime.now(UTC),
                 "requires_ack": False,
             },
@@ -269,12 +293,16 @@ session_id = "recipient-session"
         await _eventually(lambda: len(timer.handles) == 1)
         timer.handles[0].fire()
         await _eventually(
+            lambda: bool(store.list_turns("recipient-session"))
+            and store.list_turns("recipient-session")[0].status is TurnStatus.COMPLETED
+        )
+        await _eventually(
             lambda: content_store.state_counts() == {expected_content_state: 1}
         )
 
-        turns = store.list_turns("wake:default")
+        turns = store.list_turns("recipient-session")
         assert len(turns) == 1
-        accepted = TurnAcceptedReceipt("wake:default", turns[0].id)
+        accepted = TurnAcceptedReceipt("recipient-session", turns[0].id)
         delivery = PluginDurableDeliveries(ledger, None, None, recover_started=False)
         view = delivery.lookup(accepted)
         messages = sessions.control_store.fetch_session_messages("recipient-session")
@@ -287,6 +315,15 @@ session_id = "recipient-session"
             assert len(messages) == 1
             assert messages[0]["content"] == expected_body
             assert messages[0]["control_turn_id"] == turns[0].id
+            assert messages[0]["tools_used"] == ["message_push"]
+            assert messages[0]["evidence_item_ids"] == ["fitbit-e2e:sleep:e2e:1"]
+            assert messages[0]["source_refs"] == [
+                {
+                    "display_index": 1,
+                    "event_id": "fitbit-e2e:sleep:e2e:1",
+                }
+            ]
+            assert messages[0]["state_summary_tag"] == "none"
             assert view is not None and view.state == "settled"
         assert all("事故诱饵" not in message["content"] for message in messages)
     finally:

--- a/tests/test_wake_v3_provider_e2e.py
+++ b/tests/test_wake_v3_provider_e2e.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import hashlib
 import json
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any, cast
@@ -58,6 +59,10 @@ async def _start_provider_fixture(
             message: dict[str, object]
             finish_reason: str
             if decision_request:
+                prompt = json.dumps(requests[-1].get("messages"), ensure_ascii=False)
+                candidate = re.search(r"candidate_[0-9a-f]{16}", prompt)
+                if candidate is None:
+                    raise AssertionError("provider fixture prompt missing candidate_id")
                 message = {
                     "role": "assistant",
                     "content": None,
@@ -69,7 +74,10 @@ async def _start_provider_fixture(
                             "function": {
                                 "name": "share_content",
                                 "arguments": json.dumps(
-                                    {"message": "fixture provider response"}
+                                    {
+                                        "message": "fixture provider response",
+                                        "items": [candidate.group(0)],
+                                    }
                                 ),
                             },
                         }


### PR DESCRIPTION
## 问题与结果

- 解决的问题：大重构后 Wake 把普通 final_response 当成主动正文，并丢失旧版 hazard、批次、Drift、个性化和恢复语义。
- 用户可见结果：只有 typed share decision 会推送；skip、低分和无效决策保持静默；Content 最多 100 选 1～5 聚合，Drift 复用同一 durable delivery；投影只追加到配置的 mobile Session。
- 本 PR 不处理：删除事故期间已追加的 22 条消息；它们继续遵守 Session append-only。

## Change intent

- change_type：fix + migration
- semantic_delta：compatible
- capability_owner：mixed
- consumer_scope：Wake、Content、Drift、Session、Akasha、mobile proactive delivery
- runtime_patch：required；恢复 8c67dccb 用户体验和记录等价性
- authoritative_state_owner：Content/Drift plugin SQLite；Core durable Turn/delivery；Session messages
- concept_gate：required；改变 lifecycle、持久 schema、delivery 恢复和公共 composition service
- 关联不变量：普通 final_response 不发送；Session messages 只追加；provider delivered 后才投影；skip 零发送零 ACK
- protected_state：sessions.db/messages、正式 plugin-data、provider 外部效果
- 允许的副作用：typed share 的一次 provider delivery、一次 proactive Session projection、被引用 Content ACK
- 禁止的副作用：skip/no-decision 推送、重复发送、删除历史消息、candidate 读取正式 Session

## 改动与迁移

- Content v1→v2 batch ledger；Drift v1→v2 settlement ledger；Wake v1→v2 per-identity seen ledger。
- 三条 v1 均 exact DDL 校验后迁移；same-version 异构 fail-loud；正式 DB 副本 v2 integrity/quick check 均 ok。
- baseline：8c67dccb；head：713bd4ad6ecdbbef92961347c60243cec43420f5；tree：8a944fcab71a44bfa2eb1b3383e74aa70edc19da。
- 回滚：停止 Core，使用 hua-home release previous generation；正式写入前另建完整恢复点。Session 外部效果不伪装回滚。

## 验证

- 相关回归：211 passed；另有一次 H5 fixture setup 因复用临时 venv 缺 pip 失败，不是行为断言失败。
- focused pyright：0 errors（既有 warnings 保留）。
- 公共 Change Gate：PASSED，report `docker/debug/reports/change-gate/20260825-033825-17cc19fd`。
- sourceDigest：f762fda7a81caff33e79b12d772a31f608c8ade6df027f3daa86d14f962c76db。
- planDigest：9f3a7e73606b0f865ff5ae29929fdd8d425166011d080e548360d3942bd5c8d4。
- 正式 hua-home 激活和观察：合并后执行。

## 正交性与概念完整性

- 独立 reviewer / model / reasoning：Codex / gpt-5.6-terra / xhigh。
- 审查 head：713bd4ad6ecdbbef92961347c60243cec43420f5；patch SHA-256：27719f89df67cec3c35f9d269d8301f0b90f7bc03ed8096ebeb2a55323710b12。
- 结论：PASS；must-fix 0。
- 审查中发现并修复：跨 source/revision 的相同 item_id 会误计旧高分 new mass；现在 admission 使用完整 source_id/item_id/revision，driver_item_id 保持旧语义，并有两类碰撞 fixture。
- Core 不识别 Wake/Content/Drift 名称；目标 Session 仅 history/memory read，只有 durable provider delivery 成功后 append projection。
- 最短链路：new due → hazard → scoped react → typed share/skip → generic durable delivery → Session projection → domain settlement；失败只 forward-complete/defer/uncertain。

## 工作手册

- [x] 已核对 projectneed.md、相关决策和 NOW.md。
- [x] 已完成公开 Gate 与独立概念 Gate。
- [ ] NOW.md 在正式激活和观察完成后对账。