### PR TITLE
fix: bound compaction summary requests

### DIFF
--- a/agent/model_runtime/context_compaction.py
+++ b/agent/model_runtime/context_compaction.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping, Sequence, cas
 
 from agent.model_runtime.execution_history import active_shell_execution_origins
 from agent.model_runtime.types import ModelUsage, UsageCoverage
+from agent.provider import ContextLengthError
 
 logger = logging.getLogger(__name__)
 from agent.model_runtime.usage import aggregate_usage
@@ -812,14 +813,24 @@ class ContextCompactor:
                 include_temporary=include_temporary,
                 previous_summary=summary,
             )
-            summary_input = self._summary_input(
-                chunk,
-                include_temporary=include_temporary,
-                previous_summary=summary,
-            )
-            summary, usage = await self._request_summary(
-                provider, model=model, summary_input=summary_input
-            )
+            # Provider tokenizers may count more than the local estimator. Keep
+            # complete units and shrink only the rejected request.
+            while True:
+                summary_input = self._summary_input(
+                    chunk,
+                    include_temporary=include_temporary,
+                    previous_summary=summary,
+                )
+                try:
+                    summary, usage = await self._request_summary(
+                        provider, model=model, summary_input=summary_input
+                    )
+                except ContextLengthError:
+                    if len(chunk) == 1:
+                        raise
+                    chunk = chunk[: max(1, len(chunk) // 2)]
+                    continue
+                break
             if usage is not None:
                 usages.append(usage)
             logger.info(
@@ -869,11 +880,12 @@ class ContextCompactor:
         include_temporary: bool,
         previous_summary: str,
     ) -> list[CommittedContextUnit]:
-        """Find the largest fitting prefix without quadratic tokenization."""
+        """Find the largest prefix whose final summary request stays below soft limit."""
 
         low = 1
         high = len(remaining)
         size = 0
+        soft_limit = math.floor(int(provider.context_window) * SOFT_LIMIT_RATIO)
         while low <= high:
             middle = (low + high) // 2
             summary_input = self._summary_input(
@@ -886,11 +898,26 @@ class ContextCompactor:
             except ContextCompactionError:
                 high = middle - 1
             else:
-                size = middle
-                low = middle + 1
+                estimated_input = provider.estimate_context_tokens(summary_input, [])
+                if estimated_input >= soft_limit:
+                    high = middle - 1
+                else:
+                    size = middle
+                    low = middle + 1
         if size:
             return list(remaining[:size])
         unit = remaining[0]
+        single_input = self._summary_input(
+            (unit,),
+            include_temporary=include_temporary,
+            previous_summary=previous_summary,
+        )
+        try:
+            _ = _summary_output_limit(provider, single_input)
+        except ContextCompactionError:
+            pass
+        else:
+            return [unit]
         raise ContextCompactionError(
             "context_compaction_unit_exceeds_summary_window "
             f"source_from_seq={unit.source_from_seq} "

--- a/tests/test_context_compaction_contract.py
+++ b/tests/test_context_compaction_contract.py
@@ -14,7 +14,7 @@ from agent.model_runtime.context_compaction import (
     _summary_output_limit,
 )
 from agent.model_runtime.types import LLMResponse, ModelUsage
-from agent.provider import LLMProvider
+from agent.provider import ContextLengthError, LLMProvider
 from agent.tool_runtime import append_tool_result
 
 
@@ -683,9 +683,85 @@ def test_summary_reduces_oversized_history_in_bounded_unit_chunks() -> None:
     )
 
     assert result.compacted
-    assert len(provider.calls) == 2
+    assert len(provider.calls) == 3
     assert "[Previous compaction summary]" in _call_message_content(provider.calls[1])
     assert all(_call_int(call, "max_tokens") > 0 for call in provider.calls)
+
+
+def test_summary_shrinks_complete_unit_chunk_after_provider_overflow() -> None:
+    class _UnderestimatingProvider(_Provider):
+        def __init__(self) -> None:
+            super().__init__(context_window=100)
+            self.attempt_sizes: list[int] = []
+
+        def estimate_context_tokens(self, messages, tools):
+            content = str(messages[0].get("content", "")) if messages else ""
+            units = sum(content.count(f'"content":"u{seq}"') for seq in range(1, 7))
+            return 1 + units * 10
+
+        async def chat(self, **kwargs):
+            content = _call_message_content(kwargs)
+            units = sum(content.count(f'"content":"u{seq}"') for seq in range(1, 7))
+            self.attempt_sizes.append(units)
+            if units > 2:
+                raise ContextLengthError("provider counted more tokens")
+            return await super().chat(**kwargs)
+
+    provider = _UnderestimatingProvider()
+    segments = ContextPayloadSegments(
+        prefix=(),
+        committed_units=tuple(_unit(seq, 10) for seq in range(1, 7)),
+        current_anchor=(),
+    )
+    compactor = ContextCompactor(
+        provider=provider,
+        model="m",
+        scope_id="provider-overflow",
+        payload_segments=segments,
+        max_output_tokens=1,
+        next_generation=1,
+        keep_recent_tokens=1,
+    )
+
+    result = _run(
+        compactor.prepare(segments.flatten(), pending_start=6, tools=[], force=True)
+    )
+
+    assert result.compacted
+    assert provider.attempt_sizes[:2] == [5, 2]
+    assert provider.attempt_sizes[2:] == [3, 1, 2]
+
+
+def test_summary_does_not_split_single_unit_after_provider_overflow() -> None:
+    class _SingleUnitOverflowProvider(_Provider):
+        def __init__(self) -> None:
+            super().__init__(context_window=100)
+            self.attempts = 0
+
+        async def chat(self, **kwargs):
+            self.attempts += 1
+            raise ContextLengthError("one complete unit exceeds provider window")
+
+    provider = _SingleUnitOverflowProvider()
+    segments = ContextPayloadSegments(
+        prefix=(),
+        committed_units=(_unit(1, 10), _unit(2, 10)),
+        current_anchor=(),
+    )
+    compactor = ContextCompactor(
+        provider=provider,
+        model="m",
+        scope_id="single-unit-overflow",
+        payload_segments=segments,
+        max_output_tokens=1,
+        next_generation=1,
+        keep_recent_tokens=1,
+    )
+
+    with pytest.raises(ContextCompactionError, match="ContextLengthError"):
+        _run(compactor.prepare(segments.flatten(), pending_start=2, tools=[], force=True))
+
+    assert provider.attempts == 1
 
 
 def test_request_output_limit_moves_hard_edge_for_each_payload() -> None:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：首次重建 compaction 时，原始消息估算与最终摘要 payload、provider tokenizer 计数不一致，摘要请求可能越过真实窗口。
- 用户可见结果：最终序列化摘要请求按既有 74% 安全水位选择完整 logical units；provider 仍报 ContextLengthError 时按完整 unit 缩块重试。
- 本 PR 不处理：Session 身份迁移、旧 compaction 复活、原始消息或持久化 schema。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`core`
- `consumer_scope`：所有使用 ContextCompactor 的 session 与内存态调用
- `runtime_patch`：`required`
- `runtime_patch_reason`：线上 Akashic Session 首次摘要重建被 provider 拒绝
- `authoritative_state_owner`：SessionDB；本 PR 不修改其所有权或数据
- `client_only_alternative`：不适用
- `concept_gate`：`required`
- `concept_gate_reason`：改变 compaction summary 容量与重试控制流
- 关联不变量：CTX-007、决策 0030
- `protected_state`：messages、turns、session_compactions、last_consolidated
- 允许的副作用：摘要 provider 超窗后发送更小的完整-unit摘要请求
- 禁止的副作用：拆分 logical unit、删除或改写消息、提交失败 checkpoint

## 改动范围

- 主要文件：`agent/model_runtime/context_compaction.py`、直接合同测试
- 配置或迁移影响：无
- 已知 schema lineage 与最终 schema identity：不变
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `f1938243`，head `baf17844`
- 回滚方式：回滚本提交并部署前一 exact release；正式 workspace 使用部署前备份

## 验证

- [x] 相关 targeted tests 已通过：97 passed
- [x] Python 类型检查或前端 typecheck/lint：不适用；仅 Python 局部改动，import/runtime 由相关测试覆盖
- [ ] `python docker/debug/gate.py run --base origin/main`：按维护者明确要求跳过
- `sourceDigest`：不适用
- `planDigest`：不适用
- 真实设备证据：不适用，Core-only
- 未运行项与原因：远端 CI 与语义 Gate 均按用户明确授权跳过；保留 targeted tests 与独立概念评审

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`no`，但进行了独立概念评审
- 独立 reviewer / model / reasoning：Terra / gpt-5.6-terra / xhigh
- 审查 head：实现 diff `baf17844`；随后只补 reviewer 建议的单-unit测试
- 新增概念及其唯一 owner；没有时写 `none`
- 无关设计轴的变化传播：`none`
- 最短正常/失败链路：最终 summary payload 低于 soft limit直接发送；provider超窗则完整unit减半；单unit仍超窗则fail-loud并进入既有fallback
- legacy/source-specific 残留扫描：无 Session/channel/mobile 特判
- must-fix 及处置证据：无 must-fix；P2 单unit终止测试已补，97 passed
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 跨仓库或客户端改动不适用。
- [x] 当前没有对应 NOW 事项。