### PR TITLE
[codex] mirror Akashic sessions across Web and Mobile

### DIFF
--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -89,7 +89,8 @@ class MessagePushTool(Tool):
         metadata_object = cast(dict[object, object], raw_outbound_metadata)
         if not all(isinstance(key, str) for key in metadata_object):
             raise TypeError("message_push _outbound_metadata 必须是字符串键对象")
-        outbound_metadata = cast(dict[str, object], metadata_object)
+        outbound_metadata = dict(cast(dict[str, object], metadata_object))
+        outbound_metadata.setdefault("source", "message_push")
 
         if not message and not file and not image:
             return "错误：message、file、image 至少提供一个"
@@ -141,9 +142,6 @@ class MessagePushTool(Tool):
     ) -> ChannelDeliveryReceipt:
         """Dispatch through the required committed Channel catalog and fail loudly otherwise."""
 
-        metadata = dict(message.metadata)
-        metadata.setdefault("source", "message_push")
-        message = replace(message, metadata=metadata)
         if commit_role != "passive" and message.control_turn_id is None:
             message = replace(message, control_turn_id=f"turn:{uuid4().hex}")
         dispatcher = self._v3_dispatcher

--- a/agent/tools/message_push.py
+++ b/agent/tools/message_push.py
@@ -141,6 +141,9 @@ class MessagePushTool(Tool):
     ) -> ChannelDeliveryReceipt:
         """Dispatch through the required committed Channel catalog and fail loudly otherwise."""
 
+        metadata = dict(message.metadata)
+        metadata.setdefault("source", "message_push")
+        message = replace(message, metadata=metadata)
         if commit_role != "passive" and message.control_turn_id is None:
             message = replace(message, control_turn_id=f"turn:{uuid4().hex}")
         dispatcher = self._v3_dispatcher

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -297,6 +297,9 @@ export function useDesktopChatController() {
           getStatus: () => statusLiveRef.current,
           setStatus: setStatusLive,
           getActiveTurnId: () => activeTurnIdRef.current,
+          isSettledTurn: (turnId) => messagesRef.current.some(
+            (message) => message.id === turnId && message.role === "assistant" && message.streaming === false,
+          ),
           setActiveTurnId: (turnId) => { activeTurnIdRef.current = turnId; },
           loadSessions: loadSessionsSafely,
           loadMessages: loadMessagesSafely,

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -121,6 +121,7 @@ export function useDesktopChatController() {
   const statusRef = useRef<ChatStatus>("idle");
   const statusLiveRef = useRef<ChatStatus>("idle");
   const activeTurnIdRef = useRef<string | null>(null);
+  const settledTurnIdsRef = useRef(new Map<string, Set<string>>());
   const sessionsRequestRef = useRef<AbortController | null>(null);
   const messagesRequestRef = useRef<AbortController | null>(null);
   const olderMessagesRequestRef = useRef<AbortController | null>(null);
@@ -297,9 +298,14 @@ export function useDesktopChatController() {
           getStatus: () => statusLiveRef.current,
           setStatus: setStatusLive,
           getActiveTurnId: () => activeTurnIdRef.current,
-          isSettledTurn: (turnId) => messagesRef.current.some(
-            (message) => message.id === turnId && message.role === "assistant" && message.streaming === false,
-          ),
+          isSettledTurn: (turnId) => settledTurnIdsRef.current
+            .get(activeSessionRef.current)?.has(turnId) === true,
+          markSettledTurn: (turnId) => {
+            const sessionId = activeSessionRef.current;
+            const settled = settledTurnIdsRef.current.get(sessionId) ?? new Set<string>();
+            settled.add(turnId);
+            settledTurnIdsRef.current.set(sessionId, settled);
+          },
           setActiveTurnId: (turnId) => { activeTurnIdRef.current = turnId; },
           loadSessions: loadSessionsSafely,
           loadMessages: loadMessagesSafely,

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -392,7 +392,7 @@ export function useDesktopChatController() {
 
   const ensureSession = useCallback(async () => {
     if (activeSessionRef.current) return activeSessionRef.current;
-    const sessionId = `web:${createUuid().replaceAll("-", "")}`;
+    const sessionId = `akashic:${createUuid().replaceAll("-", "")}`;
     activeSessionRef.current = sessionId;
     setActiveSessionId(sessionId);
     return sessionId;
@@ -408,7 +408,7 @@ export function useDesktopChatController() {
     sendRequestRef.current?.abort();
     const controller = new AbortController();
     sendRequestRef.current = controller;
-    const optimisticId = createUuid();
+    const clientMessageId = createUuid();
     const reply = replyTarget;
     try {
       const sessionId = await ensureSession();
@@ -422,7 +422,7 @@ export function useDesktopChatController() {
       setMessages((current) => [
         ...current,
         {
-          id: optimisticId,
+          id: clientMessageId,
           role: "user",
           content: cleanText || media.map((item) => item.filename).join("\n"),
           attachments,
@@ -438,7 +438,7 @@ export function useDesktopChatController() {
       ]);
       const payload: Record<string, unknown> = {
         type: "message.send",
-        request_id: createUuid(),
+        request_id: clientMessageId,
         session_id: sessionId,
         text: cleanText,
         media: media.map((item) => item.artifact_id),
@@ -453,7 +453,7 @@ export function useDesktopChatController() {
       setModelSelectionDirty(false);
       setReplyTarget(null);
     } catch (error) {
-      setMessages((current) => current.filter((message) => message.id !== optimisticId));
+      setMessages((current) => current.filter((message) => message.id !== clientMessageId));
       if (isAbortError(error)) throw error;
       reportError(error, "error");
       throw error;

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -124,8 +124,11 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
   assert.deepEqual(loadedSessions, ["session"]);
 });
 
-test("foreign frames cannot mutate the active session and push terminal lands immediately", () => {
+test("foreign frames stay isolated and message push does not own the active turn", () => {
+  let status = "streaming";
+  let activeTurnId = "turn";
   let messages = [{ id: "turn", role: "assistant", content: "", blocks: [], streaming: true }];
+  const settledTurnIds = new Set();
   const context = {
     activeSessionId: () => "active",
     activateSession: () => {},
@@ -133,12 +136,12 @@ test("foreign frames cannot mutate the active session and push terminal lands im
     setMessages: (updater) => {
       messages = updater(messages);
     },
-    getStatus: () => "streaming",
-    setStatus: () => {},
-    getActiveTurnId: () => "turn",
-    isSettledTurn: () => false,
-    markSettledTurn: () => {},
-    setActiveTurnId: () => {},
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
+    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
+    setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
   };
@@ -147,12 +150,36 @@ test("foreign frames cannot mutate the active session and push terminal lands im
   applyChatFrame(parseChatFrame({
     type: "message.final",
     session_id: "active",
-    turn_id: "turn",
+    turn_id: "delivery:push",
     content: "push",
     metadata: { source: "message_push" },
   }), context);
-  assert.equal(messages[0].content, "push");
+  assert.equal(messages[0].content, "");
   assert.equal(messages[0].streaming, true);
+  assert.equal(messages[1].id, "delivery:push");
+  assert.equal(messages[1].content, "push");
+  assert.equal(messages[1].streaming, false);
+  assert.equal(status, "streaming");
+  assert.equal(activeTurnId, "turn");
+  assert.equal(settledTurnIds.size, 0);
+
+  applyChatFrame(parseChatFrame({
+    type: "turn.interrupted",
+    request_id: "stop",
+    session_id: "active",
+    status: "interrupted",
+    message: "已中断",
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "turn.started",
+    session_id: "active",
+    turn_id: "turn",
+    client_message_id: "client:continued",
+    content: "继续",
+  }), context);
+  assert.equal(status, "streaming");
+  assert.equal(activeTurnId, "turn");
+  assert.equal(messages.some((message) => message.id === "client:continued"), true);
 });
 
 test("output completed enters finalizing then terminal returns to idle", () => {
@@ -359,6 +386,7 @@ test("replayed turn started does not reopen a settled turn", () => {
     session_id: "akashic:session",
     turn_id: "turn:mobile",
     content: "回复",
+    terminal_status: "completed",
   }), context);
   messages = [
     { id: "akashic:session:1", role: "user", content: "手机发出的消息", blocks: [], canonical: true },

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -42,6 +42,7 @@ test("failed terminal exposes provider error and reconciles durable messages", (
     isSettledTurn: (turnId) => messages.some((message) => (
       message.id === turnId && message.role === "assistant" && message.streaming === false
     )),
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
@@ -83,6 +84,7 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: () => false,
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => { loadedSessions.push(activeSessionId); },
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
@@ -135,6 +137,7 @@ test("foreign frames cannot mutate the active session and push terminal lands im
     setStatus: () => {},
     getActiveTurnId: () => "turn",
     isSettledTurn: () => false,
+    markSettledTurn: () => {},
     setActiveTurnId: () => {},
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -164,6 +167,7 @@ test("output completed enters finalizing then terminal returns to idle", () => {
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: () => false,
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -194,6 +198,7 @@ test("late output completed after terminal is ignored and keeps idle", () => {
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: () => false,
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -223,6 +228,7 @@ test("stale output completed from previous turn does not pollute next turn", () 
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: () => false,
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -258,6 +264,7 @@ test("stale final closes its own row without terminating the next turn", () => {
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -294,6 +301,7 @@ test("turn started mirrors a message sent by another client exactly once", () =>
     setStatus: () => {},
     getActiveTurnId: () => activeTurnId,
     isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
+    markSettledTurn: () => {},
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -322,6 +330,7 @@ test("replayed turn started does not reopen a settled turn", () => {
   let status = "idle";
   let activeTurnId = null;
   let messages = [];
+  const settledTurnIds = new Set();
   const context = {
     activeSessionId: () => "akashic:session",
     activateSession: () => {},
@@ -330,7 +339,8 @@ test("replayed turn started does not reopen a settled turn", () => {
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
-    isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
+    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
+    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -350,13 +360,65 @@ test("replayed turn started does not reopen a settled turn", () => {
     turn_id: "turn:mobile",
     content: "回复",
   }), context);
+  messages = [
+    { id: "akashic:session:1", role: "user", content: "手机发出的消息", blocks: [], canonical: true },
+    { id: "akashic:session:2", role: "assistant", content: "回复", blocks: [], canonical: true },
+  ];
   applyChatFrame(started, context);
 
   assert.equal(status, "idle");
   assert.equal(activeTurnId, null);
   assert.equal(messages.length, 2);
   assert.equal(messages[1].content, "回复");
-  assert.equal(messages[1].streaming, false);
+  assert.equal(messages[1].canonical, true);
+});
+
+test("interrupted terminal does not settle a continued interaction", () => {
+  let status = "idle";
+  let activeTurnId = null;
+  let messages = [];
+  const settledTurnIds = new Set();
+  const context = {
+    activeSessionId: () => "akashic:session",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
+    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
+    setActiveTurnId: (next) => { activeTurnId = next; },
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  };
+
+  applyChatFrame(parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:session",
+    turn_id: "turn:continued",
+    client_message_id: "client:first",
+    content: "第一次输入",
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "message.final",
+    session_id: "akashic:session",
+    turn_id: "turn:continued",
+    content: "已中断",
+    terminal_status: "interrupted",
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:session",
+    turn_id: "turn:continued",
+    client_message_id: "client:continued",
+    content: "继续完成",
+  }), context);
+
+  assert.equal(settledTurnIds.has("turn:continued"), false);
+  assert.equal(status, "streaming");
+  assert.equal(activeTurnId, "turn:continued");
+  assert.equal(messages.some((message) => message.id === "client:continued"), true);
 });
 
 test("turn started reuses the Web optimistic message identity", () => {
@@ -376,6 +438,7 @@ test("turn started reuses the Web optimistic message identity", () => {
     setStatus: () => {},
     getActiveTurnId: () => null,
     isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
+    markSettledTurn: () => {},
     setActiveTurnId: () => {},
     loadSessions: async () => {},
     loadMessages: async () => {},

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -39,6 +39,9 @@ test("failed terminal exposes provider error and reconciles durable messages", (
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => messages.some((message) => (
+      message.id === turnId && message.role === "assistant" && message.streaming === false
+    )),
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
@@ -79,6 +82,7 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: () => false,
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => { loadedSessions.push(activeSessionId); },
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
@@ -130,6 +134,7 @@ test("foreign frames cannot mutate the active session and push terminal lands im
     getStatus: () => "streaming",
     setStatus: () => {},
     getActiveTurnId: () => "turn",
+    isSettledTurn: () => false,
     setActiveTurnId: () => {},
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -158,6 +163,7 @@ test("output completed enters finalizing then terminal returns to idle", () => {
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: () => false,
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -187,6 +193,7 @@ test("late output completed after terminal is ignored and keeps idle", () => {
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: () => false,
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -215,6 +222,7 @@ test("stale output completed from previous turn does not pollute next turn", () 
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: () => false,
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -249,6 +257,7 @@ test("stale final closes its own row without terminating the next turn", () => {
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -284,6 +293,7 @@ test("turn started mirrors a message sent by another client exactly once", () =>
     getStatus: () => "idle",
     setStatus: () => {},
     getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -308,6 +318,47 @@ test("turn started mirrors a message sent by another client exactly once", () =>
   );
 });
 
+test("replayed turn started does not reopen a settled turn", () => {
+  let status = "idle";
+  let activeTurnId = null;
+  let messages = [];
+  const context = {
+    activeSessionId: () => "akashic:session",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
+    setActiveTurnId: (next) => { activeTurnId = next; },
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  };
+  const started = parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:session",
+    turn_id: "turn:mobile",
+    client_message_id: "01JREMOTE",
+    content: "手机发出的消息",
+  });
+
+  applyChatFrame(started, context);
+  applyChatFrame(parseChatFrame({
+    type: "message.final",
+    session_id: "akashic:session",
+    turn_id: "turn:mobile",
+    content: "回复",
+  }), context);
+  applyChatFrame(started, context);
+
+  assert.equal(status, "idle");
+  assert.equal(activeTurnId, null);
+  assert.equal(messages.length, 2);
+  assert.equal(messages[1].content, "回复");
+  assert.equal(messages[1].streaming, false);
+});
+
 test("turn started reuses the Web optimistic message identity", () => {
   let messages = [{
     id: "client:web",
@@ -324,6 +375,7 @@ test("turn started reuses the Web optimistic message identity", () => {
     getStatus: () => "submitted",
     setStatus: () => {},
     getActiveTurnId: () => null,
+    isSettledTurn: (turnId) => messages.some((message) => message.id === turnId && message.streaming === false),
     setActiveTurnId: () => {},
     loadSessions: async () => {},
     loadMessages: async () => {},

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -44,7 +44,7 @@ test("failed terminal exposes provider error and reconciles durable messages", (
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
   applyChatFrame(parseChatFrame({
     type: "message.final",
     session_id: "session",
@@ -84,7 +84,7 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "react.thinking.delta", session_id: "session", turn_id: "turn", delta: "思考" }), context);
   applyChatFrame(parseChatFrame({ type: "react.tool.started", session_id: "session", turn_id: "turn", call_id: "call", tool_name: "shell", arguments: { cmd: "pwd" } }), context);
   applyChatFrame(parseChatFrame({ type: "react.tool.completed", session_id: "session", turn_id: "turn", call_id: "call", tool_name: "shell", status: "success", result_preview: "ok" }), context);
@@ -163,7 +163,7 @@ test("output completed enters finalizing then terminal returns to idle", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
   assert.equal(status, "streaming");
 
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn", delta: "答案" }), context);
@@ -192,7 +192,7 @@ test("late output completed after terminal is ignored and keeps idle", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
   assert.equal(status, "streaming");
 
   // /stop terminal 先到，composer 回 idle
@@ -221,13 +221,13 @@ test("stale output completed from previous turn does not pollute next turn", () 
   };
 
   // T1 开始 → 中断 → idle
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
   assert.equal(status, "streaming");
   applyChatFrame(parseChatFrame({ type: "turn.interrupted", request_id: "r", session_id: "session", status: "interrupted", message: "已中断" }), context);
   assert.equal(status, "idle");
 
   // T2 开始（新 turn）
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
   assert.equal(status, "streaming");
   assert.equal(activeTurnId, "turn-2");
 
@@ -254,10 +254,10 @@ test("stale final closes its own row without terminating the next turn", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn-1", delta: "T1 partial" }), context);
   applyChatFrame(parseChatFrame({ type: "turn.output.completed", session_id: "session", turn_id: "turn-1" }), context);
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn-2", delta: "T2 partial" }), context);
 
   applyChatFrame(parseChatFrame({ type: "message.final", session_id: "session", turn_id: "turn-1", content: "T1 final" }), context);
@@ -271,6 +271,74 @@ test("stale final closes its own row without terminating the next turn", () => {
       { id: "turn-2", content: "T2 partial", streaming: true },
     ],
   );
+});
+
+test("turn started mirrors a message sent by another client exactly once", () => {
+  let messages = [];
+  let activeTurnId = null;
+  const context = {
+    activeSessionId: () => "akashic:session",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => "idle",
+    setStatus: () => {},
+    getActiveTurnId: () => activeTurnId,
+    setActiveTurnId: (next) => { activeTurnId = next; },
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  };
+  const started = parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:session",
+    turn_id: "turn:mobile",
+    client_message_id: "01JREMOTE",
+    content: "手机发出的消息",
+  });
+
+  applyChatFrame(started, context);
+  applyChatFrame(started, context);
+
+  assert.deepEqual(
+    messages.map(({ id, role, content }) => ({ id, role, content })),
+    [
+      { id: "01JREMOTE", role: "user", content: "手机发出的消息" },
+      { id: "turn:mobile", role: "assistant", content: "" },
+    ],
+  );
+});
+
+test("turn started reuses the Web optimistic message identity", () => {
+  let messages = [{
+    id: "client:web",
+    role: "user",
+    content: "网页发出的消息",
+    blocks: [],
+    canonical: false,
+  }];
+  const context = {
+    activeSessionId: () => "akashic:session",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => "submitted",
+    setStatus: () => {},
+    getActiveTurnId: () => null,
+    setActiveTurnId: () => {},
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  };
+
+  applyChatFrame(parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:session",
+    turn_id: "turn:web",
+    client_message_id: "client:web",
+    content: "网页发出的消息",
+  }), context);
+
+  assert.equal(messages.filter((message) => message.role === "user").length, 1);
+  assert.equal(messages.filter((message) => message.role === "assistant").length, 1);
 });
 
 test("send transport serializes once, waits for open, and aborts before delivery", async () => {

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -182,6 +182,78 @@ test("foreign frames stay isolated and message push does not own the active turn
   assert.equal(messages.some((message) => message.id === "client:continued"), true);
 });
 
+test("stream events keep their turn identity across an inserted message push", () => {
+  let status = "streaming";
+  let activeTurnId = "turn:active";
+  let messages = [{ id: "turn:active", role: "assistant", content: "", blocks: [], streaming: true }];
+  const settledTurnIds = new Set();
+  const context = {
+    activeSessionId: () => "active",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => activeTurnId,
+    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
+    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
+    setActiveTurnId: (next) => { activeTurnId = next; },
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  };
+
+  applyChatFrame(parseChatFrame({
+    type: "react.tool.started",
+    session_id: "active",
+    turn_id: "turn:active",
+    call_id: "call:push",
+    tool_name: "message_push",
+    arguments: { message: "推送" },
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "message.final",
+    session_id: "active",
+    turn_id: "delivery:push",
+    content: "推送",
+    metadata: { source: "message_push" },
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "react.tool.completed",
+    session_id: "active",
+    turn_id: "turn:active",
+    call_id: "call:push",
+    tool_name: "message_push",
+    status: "success",
+    result_preview: "delivered",
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "answer.delta",
+    session_id: "active",
+    turn_id: "turn:active",
+    delta: "答案",
+  }), context);
+  applyChatFrame(parseChatFrame({
+    type: "message.final",
+    session_id: "active",
+    turn_id: "turn:active",
+    content: "最终答案",
+    terminal_status: "completed",
+  }), context);
+
+  const turn = messages.find((message) => message.id === "turn:active");
+  const push = messages.find((message) => message.id === "delivery:push");
+  assert.equal(turn.content, "最终答案");
+  assert.equal(turn.streaming, false);
+  assert.equal(turn.blocks[0].status, "output-available");
+  assert.equal(turn.blocks[0].output, "delivered");
+  assert.equal(push.content, "推送");
+  assert.equal(push.streaming, false);
+  assert.deepEqual(push.blocks, []);
+  assert.equal(status, "idle");
+  assert.equal(activeTurnId, null);
+  assert.equal(settledTurnIds.has("turn:active"), true);
+});
+
 test("output completed enters finalizing then terminal returns to idle", () => {
   let status = "idle";
   let activeTurnId = null;

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -1,5 +1,4 @@
 import type { ChatMessage, ToolBlock } from "./chat-message";
-import { createUuid } from "./browser-uuid.ts";
 import type { ChatStatus } from "./web-chat-status";
 import { blocksWithFinalThinking, mediaToAttachments, mergeAttachments } from "./web-chat-message-data.ts";
 import type { WebTurnTraceKind } from "./web-turn-trace";
@@ -233,7 +232,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type === "react.thinking.delta") {
     context.setStatus("streaming");
-    context.setMessages((messages) => updateLastAssistant(messages, (message) => {
+    context.setMessages((messages) => updateAssistantById(messages, frame.turn_id, (message) => {
       const blocks = [...message.blocks];
       const last = blocks.at(-1);
       if (last?.kind === "thinking") blocks[blocks.length - 1] = { ...last, content: last.content + frame.delta };
@@ -243,7 +242,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     return;
   }
   if (frame.type === "react.tool.started") {
-    context.setMessages((messages) => updateLastAssistant(messages, (message) => ({
+    context.setMessages((messages) => updateAssistantById(messages, frame.turn_id, (message) => ({
       ...message,
       blocks: [...message.blocks, {
         kind: "tool",
@@ -260,7 +259,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type === "react.tool.completed") {
     const succeeded = frame.status === "success";
-    context.setMessages((messages) => updateTool(messages, frame.call_id, {
+    context.setMessages((messages) => updateTool(messages, frame.turn_id, frame.call_id, {
       status: succeeded ? "output-available" : "output-error",
       output: frame.result_preview,
       errorText: succeeded ? undefined : frame.result_preview,
@@ -269,7 +268,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type === "answer.delta") {
     console.debug("[chat-transport] answer.delta", { turn_id: frame.turn_id });
-    context.setMessages((messages) => updateLastAssistant(messages, (message) => ({
+    context.setMessages((messages) => updateAssistantById(messages, frame.turn_id, (message) => ({
       ...message,
       content: message.content + frame.delta,
       streaming: true,
@@ -403,17 +402,6 @@ export function sendWhenOpen(
   });
 }
 
-function updateLastAssistant(messages: ChatMessage[], updater: (message: ChatMessage) => ChatMessage): ChatMessage[] {
-  const next = [...messages];
-  for (let index = next.length - 1; index >= 0; index -= 1) {
-    if (next[index].role === "assistant") {
-      next[index] = updater(next[index]);
-      return next;
-    }
-  }
-  return [...messages, updater({ id: createUuid(), role: "assistant", content: "", blocks: [] })];
-}
-
 function updateAssistantById(
   messages: ChatMessage[],
   messageId: string,
@@ -430,10 +418,11 @@ function updateAssistantById(
 
 function updateTool(
   messages: ChatMessage[],
+  messageId: string,
   callId: string,
   patch: Pick<ToolBlock, "status" | "output" | "errorText">,
 ): ChatMessage[] {
-  return updateLastAssistant(messages, (message) => ({
+  return updateAssistantById(messages, messageId, (message) => ({
     ...message,
     blocks: message.blocks.map((block) => block.kind === "tool" && block.callId === callId
       ? { ...block, ...patch }

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -290,25 +290,22 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type !== "message.final") return;
 
-  if (frame.terminal_status === undefined || frame.terminal_status === "completed") {
-    context.markSettledTurn(frame.turn_id);
-  }
-
   if (frame.metadata?.source === "message_push") {
     console.debug("[chat-transport] message_push final", {
       session_id: frame.session_id,
       turn_id: frame.turn_id,
     });
-    context.setMessages((messages) => updateLastAssistant(messages, (message) => ({
+    context.setMessages((messages) => updateAssistantById(messages, frame.turn_id, (message) => ({
       ...message,
       content: message.content || frame.content,
       attachments: mergeAttachments(message.attachments, mediaToAttachments(frame.media)),
       blocks: blocksWithFinalThinking(message.blocks, frame.thinking),
-      streaming: message.streaming,
+      streaming: false,
     })));
     void context.loadSessions();
     return;
   }
+  if (frame.terminal_status === "completed") context.markSettledTurn(frame.turn_id);
   const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
   const isRecoveredTerminal = context.getActiveTurnId() === null;
   const failed = frame.terminal_status === "failed";

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -39,6 +39,7 @@ export interface WebChatFrameContext {
   getStatus: () => ChatStatus;
   setStatus: (status: ChatStatus) => void;
   getActiveTurnId: () => string | null;
+  isSettledTurn: (turnId: string) => boolean;
   setActiveTurnId: (turnId: string | null) => void;
   loadSessions: () => Promise<void>;
   loadMessages: (sessionId: string) => Promise<void>;
@@ -197,6 +198,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type === "turn.started") {
     console.debug("[chat-transport] turn.started", { turn_id: frame.turn_id });
+    if (context.isSettledTurn(frame.turn_id)) return;
     context.setStatus("streaming");
     context.setActiveTurnId(frame.turn_id);
     context.setMessages((messages) => {

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -40,6 +40,7 @@ export interface WebChatFrameContext {
   setStatus: (status: ChatStatus) => void;
   getActiveTurnId: () => string | null;
   isSettledTurn: (turnId: string) => boolean;
+  markSettledTurn: (turnId: string) => void;
   setActiveTurnId: (turnId: string | null) => void;
   loadSessions: () => Promise<void>;
   loadMessages: (sessionId: string) => Promise<void>;
@@ -288,6 +289,10 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     return;
   }
   if (frame.type !== "message.final") return;
+
+  if (frame.terminal_status === undefined || frame.terminal_status === "completed") {
+    context.markSettledTurn(frame.turn_id);
+  }
 
   if (frame.metadata?.source === "message_push") {
     console.debug("[chat-transport] message_push final", {

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -6,7 +6,7 @@ import type { WebTurnTraceKind } from "./web-turn-trace";
 
 export type ChatFrame =
   | { type: "session.created"; request_id: string; session_id: string }
-  | { type: "turn.started"; session_id: string; turn_id: string; content: string }
+  | { type: "turn.started"; session_id: string; turn_id: string; client_message_id: string; content: string }
   | { type: "react.thinking.delta"; session_id: string; turn_id: string; delta: string }
   | { type: "react.tool.started"; session_id: string; turn_id: string; call_id: string; tool_name: string; arguments: unknown }
   | { type: "react.tool.completed"; session_id: string; turn_id: string; call_id: string; tool_name: string; status: string; result_preview: string }
@@ -61,7 +61,7 @@ export function parseChatFrame(value: unknown): ChatFrame {
       requireStrings(frame, ["request_id", "session_id"]);
       break;
     case "turn.started":
-      requireStrings(frame, ["session_id", "turn_id", "content"]);
+      requireStrings(frame, ["session_id", "turn_id", "client_message_id", "content"]);
       break;
     case "react.thinking.delta":
       requireStrings(frame, ["session_id", "turn_id", "delta"]);
@@ -199,14 +199,33 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     console.debug("[chat-transport] turn.started", { turn_id: frame.turn_id });
     context.setStatus("streaming");
     context.setActiveTurnId(frame.turn_id);
-    context.setMessages((messages) => [...messages, {
-      id: frame.turn_id,
-      role: "assistant",
-      content: "",
-      blocks: [],
-      streaming: true,
-      startedAt: Date.now(),
-    }]);
+    context.setMessages((messages) => {
+      const next = [...messages];
+      if (
+        frame.content !== ""
+        && !next.some((message) => message.id === frame.client_message_id)
+      ) {
+        next.push({
+          id: frame.client_message_id,
+          role: "user",
+          content: frame.content,
+          blocks: [],
+          createdAt: new Date().toISOString(),
+          canonical: false,
+        });
+      }
+      if (!next.some((message) => message.id === frame.turn_id)) {
+        next.push({
+          id: frame.turn_id,
+          role: "assistant",
+          content: "",
+          blocks: [],
+          streaming: true,
+          startedAt: Date.now(),
+        });
+      }
+      return next;
+    });
     return;
   }
   if (frame.type === "react.thinking.delta") {

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -985,6 +985,7 @@ class WebChatChannel:
             "type": "turn.started",
             "session_id": event.session_key,
             "turn_id": turn_id,
+            "client_message_id": event.client_message_id,
             "content": event.content,
         })
 

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -611,10 +611,18 @@ class WebChatChannel:
                 metadata.pop("_channel_commit_role", None)
                 if request.commit_role.value != "passive":
                     metadata.setdefault("source", "message_push")
+                message_push = metadata.get("source") == "message_push"
                 frame: dict[str, Any] = {
                     "type": "message.final",
                     "session_id": session_key,
-                    "turn_id": request.control_turn_id or self._current_turn_id(session_key),
+                    "turn_id": (
+                        request.control_turn_id
+                        or (
+                            f"delivery:{request.delivery_id}"
+                            if message_push
+                            else self._current_turn_id(session_key)
+                        )
+                    ),
                     "content": request.body,
                     "thinking": request.thinking or "",
                     "media": [self.artifact_descriptor(ref) for ref in request.attachments],

--- a/tests/mobile_realtime/test_isolated_e2e.py
+++ b/tests/mobile_realtime/test_isolated_e2e.py
@@ -42,7 +42,7 @@ from bootstrap.passive_worker import PassiveMessageWorker
 from bootstrap.tools import _dispatch_v3_durable_delivery
 from bus.event_bus import EventBus
 from bus.events import OutboundMessage, channel_message_from_outbound
-from bus.events_lifecycle import TurnStarted
+from bus.events_lifecycle import StreamDeltaReady, TurnOutputCompleted, TurnStarted
 from bus.queue import MessageBus
 from infra.channels.base import AttachmentStore
 from infra.channels.akashic_channel import AkashicChannel
@@ -123,11 +123,16 @@ class _PushTool:
 class _SharedSessionBus:
     """Persist public Web/Mobile ingress into one real SessionManager."""
 
-    def __init__(self, manager: SessionManager) -> None:
+    def __init__(self, manager: SessionManager, event_bus: EventBus) -> None:
         self._manager = manager
+        self._event_bus = event_bus
+        self._adapter: Any | None = None
         self._recovery = None
         self._count = 0
         self._changed = threading.Condition()
+
+    def bind_adapter(self, adapter: Any) -> None:
+        self._adapter = adapter
 
     def bind_mobile_channel_inbound_recoverer(self, callback: object) -> None:
         self._recovery = callback
@@ -159,6 +164,45 @@ class _SharedSessionBus:
             client_message_id=raw.message_id,
         )
         self._manager.save(session)
+        turn_id = f"turn:shared:{self._count + 1}"
+        await self._event_bus.fanout(TurnStarted(
+            session_key=session_id,
+            channel="akashic",
+            chat_id=raw.message.chat_id,
+            content=raw.message.content,
+            timestamp=datetime.now(timezone.utc),
+            turn_id=turn_id,
+            control_turn_id=turn_id,
+            client_message_id=raw.message_id,
+        ))
+        await self._event_bus.fanout(StreamDeltaReady(
+            session_key=session_id,
+            channel="akashic",
+            chat_id=raw.message.chat_id,
+            turn_id=turn_id,
+            thinking_delta="共享思考",
+            content_delta="共享回答",
+        ))
+        await self._event_bus.fanout(TurnOutputCompleted(
+            session_key=session_id,
+            channel="akashic",
+            chat_id=raw.message.chat_id,
+            turn_id=turn_id,
+            client_message_id=raw.message_id,
+        ))
+        if self._adapter is None:
+            raise RuntimeError("Shared Akashic fixture 尚未绑定 adapter")
+        receipt = await self._adapter.deliver(ProviderDeliveryRequest(
+            binding_token="shared-e2e-binding",
+            delivery_id=f"reply:{raw.message_id}",
+            recipient=raw.message.chat_id,
+            body="共享回答",
+            thinking="共享思考",
+            metadata={"client_message_id": raw.message_id},
+            commit_role=ChannelCommitRole.PASSIVE,
+            control_turn_id=turn_id,
+        ))
+        assert receipt.status.value == "delivered"
         with self._changed:
             self._count += 1
             self._changed.notify_all()
@@ -387,13 +431,14 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
     runtime, _ = asyncio.run(build_runtime())
     web = WebChatChannel()
     channel = AkashicChannel(web, runtime.channel)
-    bus = _SharedSessionBus(manager)
+    event_bus = EventBus()
+    bus = _SharedSessionBus(manager, event_bus)
     context = cast(
         Any,
         SimpleNamespace(
             bus=bus,
             session_manager=manager,
-            event_bus=EventBus(),
+            event_bus=event_bus,
             push_tool=_PushTool(),
             interrupt_controller=None,
             attachment_store=AttachmentStore(root / "attachments"),
@@ -407,6 +452,7 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
             binding_token="shared-e2e-binding",
         )
     )
+    bus.bind_adapter(adapter)
 
     device_key = ec.generate_private_key(ec.SECP256R1())
     device_id = uuid4().hex
@@ -451,6 +497,22 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                     }
                 )
                 bus.wait_for_count(1)
+                web_live = [web_socket.receive_json() for _ in range(5)]
+                mobile_live = [mobile_socket.receive_json() for _ in range(4)]
+                assert [frame["type"] for frame in web_live] == [
+                    "turn.started",
+                    "react.thinking.delta",
+                    "answer.delta",
+                    "turn.output.completed",
+                    "message.final",
+                ]
+                assert [frame["type"] for frame in mobile_live] == [
+                    "turn.started",
+                    "react.thinking.delta",
+                    "answer.delta",
+                    "message.final",
+                ]
+                assert web_live[0]["client_message_id"] == "web-message"
 
                 # 2. Mobile lists and reads the exact same durable Session.
                 mobile_socket.send_json(
@@ -493,8 +555,27 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                         },
                     )
                 )
-                assert mobile_socket.receive_json()["type"] == "message.send.ok"
+                mobile_reply_frames = [mobile_socket.receive_json() for _ in range(5)]
+                assert [frame["type"] for frame in mobile_reply_frames] == [
+                    "turn.started",
+                    "react.thinking.delta",
+                    "answer.delta",
+                    "message.final",
+                    "message.send.ok",
+                ]
                 bus.wait_for_count(2)
+                web_reply_frames = [web_socket.receive_json() for _ in range(5)]
+                assert [frame["type"] for frame in web_reply_frames] == [
+                    "turn.started",
+                    "react.thinking.delta",
+                    "answer.delta",
+                    "turn.output.completed",
+                    "message.final",
+                ]
+                assert web_reply_frames[0]["client_message_id"] == (
+                    "01J00000000000000000000022"
+                )
+                assert web_reply_frames[0]["content"] == "Mobile 写回同一个会话"
                 history = client.get(f"/api/chat/sessions/{session_id}/messages").json()
                 assert [item["content"] for item in history["items"]] == [
                     "Web 写入同一个会话",

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -27,6 +27,7 @@ from bus.events import (
     ChannelMessage,
     InboundMessage,
     OutboundMessage,
+    TurnTerminalStatus,
 )
 from bus.queue import ChatLane, MessageBus
 from core.common import timekit
@@ -193,6 +194,34 @@ async def test_message_push_passive_role_is_forwarded_to_committed_dispatcher() 
     assert messages[0].metadata == {"source": "message_push"}
     assert result["status"] == "unknown"
     assert result["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_passive_terminal_dispatch_does_not_become_message_push() -> None:
+    tool = MessagePushTool()
+    messages: list[ChannelMessage] = []
+
+    async def dispatch(
+        message: ChannelMessage,
+        _passive: bool,
+    ) -> ChannelDeliveryReceipt:
+        messages.append(message)
+        return ChannelDeliveryReceipt(
+            delivery_id="delivery-terminal",
+            status=ChannelDeliveryStatus.DELIVERED,
+        )
+
+    tool.bind_v3_channel_dispatcher(dispatch)
+    await tool.dispatch(ChannelMessage(
+        channel="akashic",
+        chat_id="session",
+        content="普通最终回复",
+        control_turn_id="turn:normal",
+        terminal_status=TurnTerminalStatus.COMPLETED,
+    ), commit_role="passive")
+
+    assert messages[0].metadata == {}
+    assert messages[0].terminal_status is TurnTerminalStatus.COMPLETED
 
 
 @pytest.mark.asyncio

--- a/tests/test_support_modules.py
+++ b/tests/test_support_modules.py
@@ -146,6 +146,7 @@ async def test_message_push_dispatches_exact_v3_receipt_and_media():
         ChannelAttachment(AttachmentKind.FILE, "/tmp/demo.txt", "demo.txt"),
         ChannelAttachment(AttachmentKind.IMAGE, "https://img"),
     )
+    assert seen[0][0].metadata == {"source": "message_push"}
 
 
 @pytest.mark.asyncio
@@ -164,12 +165,14 @@ async def test_message_push_missing_committed_dispatcher_fails_loud() -> None:
 async def test_message_push_passive_role_is_forwarded_to_committed_dispatcher() -> None:
     tool = MessagePushTool()
     passive_roles: list[bool] = []
+    messages: list[ChannelMessage] = []
 
     async def dispatch(
         _message: ChannelMessage,
         passive: bool,
     ) -> ChannelDeliveryReceipt:
         passive_roles.append(passive)
+        messages.append(_message)
         return ChannelDeliveryReceipt(
             delivery_id="delivery-passive",
             status=ChannelDeliveryStatus.UNKNOWN,
@@ -187,6 +190,7 @@ async def test_message_push_passive_role_is_forwarded_to_committed_dispatcher() 
     )
 
     assert passive_roles == [True]
+    assert messages[0].metadata == {"source": "message_push"}
     assert result["status"] == "unknown"
     assert result["retryable"] is False
 

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -15,6 +15,7 @@ from bootstrap.chat_api import create_chat_app
 from agent.plugin_composition.channels import (
     AttachmentKind as V3AttachmentKind,
     AttachmentRef,
+    ChannelCommitRole,
     ChannelRuntimePorts,
     ChannelFactoryContext,
     DeliveryStatus as V3DeliveryStatus,
@@ -990,6 +991,36 @@ async def test_web_v3_native_delivery_projects_opaque_artifacts_and_semantics() 
         "control_turn_id": "turn-1",
         "execution_attempt_id": "attempt-1",
         "duration_ms": 17,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_web_passive_message_push_uses_independent_projection_identity() -> None:
+    channel = WebChatChannel()
+    socket = _WebSocket()
+    channel._connections["akashic:abc"] = {cast(Any, socket)}
+    channel._active_turn_ids["akashic:abc"] = "turn:active"
+    adapter = channel.build_v3_adapter(_v3_context())
+    ready = await adapter.start()
+
+    receipt = await adapter.deliver(ProviderDeliveryRequest(
+        binding_token=ready.binding_token,
+        delivery_id="push-1",
+        recipient="abc",
+        body="独立推送",
+        metadata={"source": "message_push"},
+        commit_role=ChannelCommitRole.PASSIVE,
+    ))
+
+    assert receipt.status is V3DeliveryStatus.DELIVERED
+    assert socket.frames == [{
+        "type": "message.final",
+        "session_id": "akashic:abc",
+        "turn_id": "delivery:push-1",
+        "content": "独立推送",
+        "thinking": "",
+        "media": [],
+        "metadata": {"source": "message_push"},
     }]
 
 

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -1092,6 +1092,7 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
         "answer.delta",
         "turn.output.completed",
     ]
+    assert socket.frames[0]["client_message_id"] == "client-1"
     assert {frame["turn_id"] for frame in socket.frames} == {
         "turn:server-owner"
     }


### PR DESCRIPTION
## What changed

- mirror remote user messages into the open WebUI session using the existing Core `turn.started` lifecycle
- reuse one `client_message_id` for Web optimistic rows and Core admission dedupe
- route thinking, tool, answer, and terminal projections by exact turn identity
- keep completed replay identity outside replaceable history rows
- give real `message_push` and proactive deliveries an independent Web projection identity
- create new Web sessions with the shared `akashic:` prefix

## Why

Web and Mobile already share one Akashic Core session and lifecycle fan-out, but WebUI only rendered its own optimistic user row. Mobile-origin input therefore appeared only after a history refresh, and proactive output could collide with an active Web turn.

This keeps the Core model unchanged: both adapters consume the same lifecycle, while each UI projects it using stable identities.

## Validation

- `npm run typecheck`
- `npm run build:chat`
- `npm run test:desktop-navigation` — 52 passed
- `node --test frontend/chat/src/web-chat-transport.test.mjs` — 14 passed
- `.venv/bin/python -m pytest -q tests/test_support_modules.py tests/test_web_chat_channel.py tests/test_agent_core_p2_reasoner.py tests/mobile_realtime/test_isolated_e2e.py` — 102 passed
- Terra xhigh read-only review — APPROVE
