### PR TITLE
[codex] Make Wake decisions and source links explicit

### DIFF
--- a/agent/control/turn_scope.py
+++ b/agent/control/turn_scope.py
@@ -58,6 +58,7 @@ class TurnExecutionScope:
     session_history_read: bool = False
     tool_source: ToolSource = "passive"
     preloaded_tools: tuple[str, ...] = ()
+    terminal_tools: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if any(not hint.strip() for hint in self.prompt_hints):
@@ -75,6 +76,12 @@ class TurnExecutionScope:
             raise ValueError("Turn scope preload Tool 名称不得重复")
         if any(not self.tool_grant.allows(name) for name in self.preloaded_tools):
             raise ValueError("Turn scope preload Tool 必须已由 Tool grant 授权")
+        if any(not name or name.strip() != name for name in self.terminal_tools):
+            raise ValueError("Turn scope terminal Tool 名称必须非空且无首尾空白")
+        if len(self.terminal_tools) != len(set(self.terminal_tools)):
+            raise ValueError("Turn scope terminal Tool 名称不得重复")
+        if any(name not in self.preloaded_tools for name in self.terminal_tools):
+            raise ValueError("Turn scope terminal Tool 必须已 preload")
         overrides = dict(self.tool_overrides)
         if any(not name or tool.name != name for name, tool in overrides.items()):
             raise ValueError("Turn scope tool override 名称必须与 Tool 一致")

--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -1718,6 +1718,57 @@ class DefaultReasoner(Reasoner):
                         retry_response.finish_reason,
                     )
 
+            # 5a. Scoped Turn 要求结构化终态时，在同一 Turn 内纠正一次。
+            terminal_tools = turn_scope.terminal_tools if turn_scope is not None else ()
+            if terminal_tools and not response.tool_calls:
+                terminal_retry_assistant: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": response.content or "",
+                }
+                model_state = response.provider_fields.get("model_state")
+                if isinstance(model_state, dict):
+                    terminal_retry_assistant["model_state"] = model_state
+                messages.append(terminal_retry_assistant)
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "你刚才没有提交本 Turn 要求的结构化终态。"
+                            "不要继续解释；现在必须且只能调用以下一个工具："
+                            + "、".join(terminal_tools)
+                            + "。"
+                        ),
+                    }
+                )
+                terminal_retry = await self._call_provider(
+                    compaction_state,
+                    messages,
+                    tools=tool_schemas,
+                    max_tokens=self._llm_config.max_tokens,
+                    disable_thinking=True,
+                    on_content_delta=None,
+                    cache_namespace=tool_event_session_key,
+                )
+                response = terminal_retry.response
+                react_usages.extend(terminal_retry.compaction_usages)
+                retry_prepared = terminal_retry.prepared
+                if retry_prepared is None:
+                    raise RuntimeError(
+                        "session compaction gate 未返回 terminal retry prepared context"
+                    )
+                batch_start = retry_prepared.pending_start
+                react_usages.append(response.usage or ModelUsage())
+                react_finish_reasons.append(response.finish_reason)
+                if response.cache_prompt_tokens is not None:
+                    react_cache_seen = True
+                    react_cache_prompt_tokens += response.cache_prompt_tokens
+                    react_cache_hit_tokens += response.cache_hit_tokens or 0
+                logger.info(
+                    "[结构化终态重试] 第%d轮，tool_calls=%d",
+                    iteration + 1,
+                    len(response.tool_calls),
+                )
+
             # 6. 模型返回 tool_calls 时，进入工具执行分支。
             if response.tool_calls:
                 logger.info(

--- a/docker/debug/wake_decision_ab_fixture.py
+++ b/docker/debug/wake_decision_ab_fixture.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+if str(_SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SOURCE_ROOT))
+
+import agent.plugins.manager as plugin_manager_module
+import plugins.wake.plugin as wake_plugin_module
+from agent.model_runtime.types import ToolCall
+from agent.plugin_composition.durable_delivery_store import DurableDeliveryStore
+from agent.provider import LLMResponse
+from docker.debug.wake_v3_provider_e2e import (
+    ControlledTimer,
+    CountingProvider,
+    _build_stack,
+    _eventually,
+    _write_plugin_configs,
+)
+from plugins.content.store import ContentStore
+from tests.fixtures.content_clock_source.plugin import FixtureSourceStore
+
+_FIXTURE_PATH = (
+    _SOURCE_ROOT / "tests" / "fixtures" / "wake_decision_ab_v1.json"
+)
+_INVALID_MARKER = "INVALID_DECISION_MUST_NOT_LEAK_7F3A"
+
+
+class InvalidThenValidProvider:
+    """Return the production failure shape, then one valid repair decision."""
+
+    context_window = 1_000_000
+
+    def __init__(self) -> None:
+        self.decision_requests = 0
+
+    async def chat(self, **kwargs: object) -> LLMResponse:
+        tools = kwargs.get("tools")
+        if not isinstance(tools, list) or not tools:
+            return LLMResponse(content="Wake decision recorded.")
+        self.decision_requests += 1
+        if self.decision_requests == 1:
+            return LLMResponse(content=f"Useful items. {_INVALID_MARKER}")
+        prompt = json.dumps(kwargs.get("messages"), ensure_ascii=False)
+        candidate = re.search(r"candidate_[0-9a-f]{16}", prompt)
+        if candidate is None:
+            raise RuntimeError("Wake repair fixture prompt is missing candidate_id")
+        return LLMResponse(
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    "call:wake-repair-share",
+                    "share_content",
+                    {
+                        "message": "One memory item is worth sharing.",
+                        "items": [candidate.group(0)],
+                    },
+                )
+            ],
+        )
+
+    def estimate_context_tokens(
+        self, messages: list[dict[str, object]], tools: list[dict[str, object]]
+    ) -> int:
+        return max(1, len(json.dumps([messages, tools], ensure_ascii=False)) // 4)
+
+
+def load_fixture(path: Path = _FIXTURE_PATH) -> dict[str, object]:
+    """Load and validate the frozen Wake decision sample."""
+
+    raw = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise ValueError("Wake decision A/B fixture schema mismatch")
+    candidates = raw.get("candidates")
+    expected = raw.get("expected_share_ids")
+    if not isinstance(candidates, list) or len(candidates) != 10:
+        raise ValueError("Wake decision A/B fixture must contain ten candidates")
+    candidate_count = raw.get("candidate_count")
+    noise_template = raw.get("noise_template")
+    if (
+        not isinstance(candidate_count, int)
+        or candidate_count < len(candidates)
+        or not isinstance(noise_template, dict)
+    ):
+        raise ValueError("Wake decision A/B candidate expansion is invalid")
+    expanded = [*candidates]
+    for index in range(len(candidates) + 1, candidate_count + 1):
+        expanded.append(
+            {
+                "candidate_id": f"candidate_noise_{index:03d}",
+                "title": str(noise_template.get("title", "")).format(index=index),
+                "summary": str(noise_template.get("summary", "")).format(index=index),
+                "preprocess_score": noise_template.get("preprocess_score", 0.0),
+            }
+        )
+    raw["candidates"] = expanded
+    ids = [_candidate_id(candidate) for candidate in expanded]
+    if len(ids) != len(set(ids)):
+        raise ValueError("Wake decision A/B candidate ids must be unique")
+    if (
+        not isinstance(expected, list)
+        or not expected
+        or any(not isinstance(item, str) or item not in ids for item in expected)
+    ):
+        raise ValueError("Wake decision A/B expected ids are invalid")
+    return cast(dict[str, object], raw)
+
+
+def fixture_digest(fixture: Mapping[str, object]) -> str:
+    """Return the stable identity used to compare later A/B reports."""
+
+    payload = json.dumps(
+        fixture, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+async def run_runtime_fixture(root: Path) -> dict[str, object]:
+    """Measure the missing-decision fixture through the full Wake runtime."""
+
+    fixture = load_fixture()
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True)
+    receipt_db = workspace / "recording-receipts.sqlite3"
+    _write_plugin_configs(workspace, receipt_db)
+    source_store = FixtureSourceStore(
+        workspace / "plugin-data" / "content_clock_source-builtin" / "source.sqlite3"
+    )
+    candidates = cast(list[dict[str, object]], fixture["candidates"])
+    source_store.seed(
+        tuple(
+            {
+                "kind": "fixture",
+                "wake_action": "select",
+                "title": candidate["title"],
+                "summary": candidate["summary"],
+                "preprocess_score": candidate["preprocess_score"],
+            }
+            for candidate in candidates
+        ),
+        datetime.now(UTC),
+    )
+    scripted = InvalidThenValidProvider()
+    counted = CountingProvider(scripted)
+    timer = ControlledTimer()
+    original_timer = plugin_manager_module.AsyncioOneShotTimer
+    original_random = wake_plugin_module.random.random
+    plugin_manager_module.AsyncioOneShotTimer = lambda: timer
+    wake_plugin_module.random.random = lambda: 0.0
+    stack = _build_stack(workspace, root, timer, counted)
+    try:
+        await stack.start()
+        await _eventually(lambda: timer.pending_count() >= 1, "SOURCE_TIMER_NOT_ARMED")
+        timer.fire_earliest()
+        await _eventually(
+            lambda: source_store.state(datetime.now(UTC))["cursor"] == 100,
+            "SOURCE_CURSOR_NOT_COMMITTED",
+        )
+        await _eventually(lambda: timer.pending_count() >= 1, "WAKE_TIMER_NOT_ARMED")
+        timer.fire_earliest()
+        content = ContentStore(
+            workspace / "plugin-data" / "content-builtin" / "content.sqlite3"
+        )
+        ledger = DurableDeliveryStore(
+            workspace / "runtime" / "deliveries" / "settlements.sqlite"
+        )
+        ledger.initialize()
+        await _eventually(
+            lambda: content.state_counts()
+            in (
+                {"deferred": 1, "pending": 99},
+                {"delivered": 1, "pending": 99},
+                {"pending": 99, "settled": 1},
+            ),
+            "INVALID_DECISION_NOT_TERMINAL",
+        )
+        turns = stack.sessions.control_store.list_turns("wake-provider-e2e")
+        messages = stack.sessions.control_store.fetch_session_messages(
+            "wake-provider-e2e"
+        )
+        delivery_count = _delivery_count(ledger.path)
+        valid_decisions = int(delivery_count == 1)
+        return {
+            "schema_version": 1,
+            "fixture_id": fixture["fixture_id"],
+            "fixture_digest": fixture_digest(fixture),
+            "variant": "candidate" if valid_decisions else "baseline",
+            "provider": "scripted-invalid-then-valid",
+            "trials": 1,
+            "valid_decisions": valid_decisions,
+            "valid_decision_rate": float(valid_decisions),
+            "provider_decision_requests": scripted.decision_requests,
+            "control_turn_count": len(turns),
+            "content_counts": content.state_counts(),
+            "delivery_count": delivery_count,
+            "session_projection_count": len(messages),
+            "invalid_marker_user_leak": any(
+                _INVALID_MARKER in str(message) for message in messages
+            ),
+        }
+    finally:
+        plugin_manager_module.AsyncioOneShotTimer = original_timer
+        wake_plugin_module.random.random = original_random
+        await stack.close()
+
+
+def _candidate_id(value: object) -> str:
+    if not isinstance(value, Mapping):
+        raise ValueError("Wake decision candidate must be an object")
+    candidate_id = value.get("candidate_id")
+    if not isinstance(candidate_id, str) or not candidate_id:
+        raise ValueError("Wake decision candidate_id must be non-empty")
+    return candidate_id
+
+
+def _delivery_count(path: Path) -> int:
+    connection = sqlite3.connect(path)
+    try:
+        return int(connection.execute("SELECT COUNT(*) FROM deliveries").fetchone()[0])
+    finally:
+        connection.close()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the frozen Wake decision baseline")
+    _ = parser.add_argument("--report", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    report_path = Path(args.report)
+    try:
+        with TemporaryDirectory(prefix="akashic-wake-decision-runtime-") as root:
+            report = asyncio.run(run_runtime_fixture(Path(root)))
+        report["status"] = "passed"
+        exit_code = 0
+    except BaseException as error:
+        report = {
+            "status": "failed",
+            "variant": "baseline",
+            "failure_code": str(error),
+        }
+        exit_code = 1
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"status": report["status"], "report": str(report_path)}))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/wake/plugin.py
+++ b/plugins/wake/plugin.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Literal, Protocol, cast
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -359,6 +360,7 @@ class WakeRuntime:
             "Check durable Wake duties.",
             scope=TurnExecutionScope(
                 preloaded_tools=(_SHARE_CONTENT, _SKIP_CONTENT),
+                terminal_tools=(_SHARE_CONTENT, _SKIP_CONTENT),
                 tool_source="wake",
                 tool_grant=ToolGrant.only((_SHARE_CONTENT, _SKIP_CONTENT)),
                 storage=TurnStorage.IN_MEMORY,
@@ -570,6 +572,7 @@ class WakeRuntime:
             )
             if decision is None or decision.action != "share" or not decision.message:
                 raise RuntimeError("Wake ready Turn 缺少 share_content 决策")
+            metadata = _delivery_metadata(pending)
             current = await deliveries.submit(
                 DurableDeliveryRequest(
                     logical_delivery_id=_logical_delivery_id(accepted),
@@ -578,9 +581,9 @@ class WakeRuntime:
                     channel=target.channel,
                     recipient=target.recipient,
                     projection_session_id=target.session_id,
-                    body=decision.message,
+                    body=_message_with_source_links(decision.message, metadata),
                     metadata={
-                        **_delivery_metadata(pending),
+                        **metadata,
                         "proactive": True,
                         "effects": {
                             "post_commit": PostCommitEffect.SUPPRESS.value,
@@ -1025,6 +1028,42 @@ def _delivery_metadata(receipt: Mapping[str, object]) -> dict[str, object]:
     if not isinstance(raw, Mapping):
         raise TypeError("Wake delivery message_metadata 必须是 Mapping")
     return dict(cast(Mapping[str, object], raw))
+
+
+def _message_with_source_links(
+    message: str, metadata: Mapping[str, object]
+) -> str:
+    """Append selected source links so the user and later Turns retain provenance."""
+
+    raw_refs = metadata.get("source_refs")
+    if not isinstance(raw_refs, (list, tuple)):
+        return message
+    links: list[str] = []
+    seen: set[str] = set()
+    for raw_ref in cast(Sequence[object], raw_refs):
+        if not isinstance(raw_ref, Mapping):
+            continue
+        source_ref = cast(Mapping[str, object], raw_ref)
+        raw_url = source_ref.get("url")
+        if not isinstance(raw_url, str):
+            continue
+        url = raw_url.strip()
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            continue
+        if url in seen or url in message:
+            continue
+        seen.add(url)
+        raw_title = source_ref.get("title")
+        title = (
+            " ".join(raw_title.split())
+            if isinstance(raw_title, str) and raw_title.strip()
+            else f"来源 {len(links) + 1}"
+        )
+        links.append(f"- {title}：<{url}>")
+    if not links:
+        return message
+    return f"{message.rstrip()}\n\n来源：\n" + "\n".join(links)
 
 
 def _logical_delivery_id(accepted: TurnAcceptedReceipt) -> str:

--- a/tests/control/test_scoped_turn.py
+++ b/tests/control/test_scoped_turn.py
@@ -57,6 +57,12 @@ def test_turn_scope_preload_must_be_exact_unique_and_authorized() -> None:
             preloaded_tools=("share_content",),
             tool_grant=ToolGrant.only(("skip_content",)),
         )
+    with pytest.raises(ValueError, match="terminal Tool 必须已 preload"):
+        TurnExecutionScope(
+            preloaded_tools=("share_content",),
+            terminal_tools=("skip_content",),
+            tool_grant=ToolGrant.only(("share_content", "skip_content")),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/wake_decision_ab_v1.baseline.json
+++ b/tests/fixtures/wake_decision_ab_v1.baseline.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "fixture_id": "wake-decision-ab-v1",
+  "fixture_digest": "dd269172d553d51cc3a3af8e2e54067bc76c81fb90a1a4ea305d96002f84c8f8",
+  "source_commit": "8296b3da76d191c99284b34a3eb4e33fecda5272",
+  "variant": "baseline",
+  "provider": "scripted-invalid-then-valid",
+  "trials": 1,
+  "valid_decisions": 0,
+  "valid_decision_rate": 0.0,
+  "provider_decision_requests": 1,
+  "control_turn_count": 1,
+  "content_counts": {
+    "deferred": 1,
+    "pending": 99
+  },
+  "delivery_count": 0,
+  "session_projection_count": 0,
+  "invalid_marker_user_leak": false
+}

--- a/tests/fixtures/wake_decision_ab_v1.json
+++ b/tests/fixtures/wake_decision_ab_v1.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "fixture_id": "wake-decision-ab-v1",
+  "candidate_count": 100,
+  "candidates": [
+    {
+      "candidate_id": "candidate_memory_audit",
+      "title": "Auditing synthetic autobiographical memory against source records",
+      "summary": "A new agent-memory paper measures unsupported scene-level claims and provenance failures.",
+      "preprocess_score": 0.94
+    },
+    {
+      "candidate_id": "candidate_brain_graph",
+      "title": "Interpretable tensor networks for human brain graphs",
+      "summary": "A neuroscience paper connects graph analysis with interpretable brain-network structure.",
+      "preprocess_score": 0.89
+    },
+    {
+      "candidate_id": "candidate_memory_benchmark",
+      "title": "A benchmark for upstream dependency loss in agent memory",
+      "summary": "The benchmark tests when retrieval loses weakly aligned prerequisite context.",
+      "preprocess_score": 0.87
+    },
+    {
+      "candidate_id": "candidate_cloud_weekly",
+      "title": "Routine cloud platform weekly roundup",
+      "summary": "General product announcements and regional service availability.",
+      "preprocess_score": 0.08
+    },
+    {
+      "candidate_id": "candidate_console_patch",
+      "title": "Console game receives a 60 fps patch",
+      "summary": "A routine performance-mode update for a console release.",
+      "preprocess_score": 0.04
+    },
+    {
+      "candidate_id": "candidate_celebrity_birthday",
+      "title": "Game producer celebrates an industry anniversary",
+      "summary": "A short entertainment-industry birthday retrospective.",
+      "preprocess_score": 0.03
+    },
+    {
+      "candidate_id": "candidate_mmorpg_launch",
+      "title": "Legacy MMORPG announces another expansion",
+      "summary": "A conventional content update for an unrelated online game.",
+      "preprocess_score": 0.03
+    },
+    {
+      "candidate_id": "candidate_phone_discount",
+      "title": "Midrange phone receives a weekend discount",
+      "summary": "A temporary retail promotion without technical novelty.",
+      "preprocess_score": 0.02
+    },
+    {
+      "candidate_id": "candidate_streamer_clip",
+      "title": "Streamer reacts to a game trailer",
+      "summary": "A short reaction clip without original reporting.",
+      "preprocess_score": 0.01
+    },
+    {
+      "candidate_id": "candidate_weather_digest",
+      "title": "Routine national weather digest",
+      "summary": "A broad forecast with no location-specific alert.",
+      "preprocess_score": 0.01
+    }
+  ],
+  "expected_share_ids": [
+    "candidate_memory_audit",
+    "candidate_brain_graph",
+    "candidate_memory_benchmark"
+  ],
+  "noise_template": {
+    "title": "Routine unrelated feed item {index}",
+    "summary": "Low-value entertainment, retail, platform, or general-news item {index} without a connection to the user's established interests.",
+    "preprocess_score": 0.01
+  }
+}

--- a/tests/test_wake_decision_ab_fixture.py
+++ b/tests/test_wake_decision_ab_fixture.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from docker.debug.wake_decision_ab_fixture import (
+    InvalidThenValidProvider,
+    fixture_digest,
+    load_fixture,
+    run_runtime_fixture,
+)
+
+
+def test_frozen_fixture_has_stable_identity() -> None:
+    fixture = load_fixture()
+
+    assert fixture["fixture_id"] == "wake-decision-ab-v1"
+    assert len(fixture["candidates"]) == 100
+    assert fixture_digest(fixture) == (
+        "dd269172d553d51cc3a3af8e2e54067bc76c81fb90a1a4ea305d96002f84c8f8"
+    )
+
+
+def test_frozen_baseline_matches_fixture_identity() -> None:
+    fixture = load_fixture()
+    path = Path("tests/fixtures/wake_decision_ab_v1.baseline.json")
+    baseline = json.loads(path.read_text(encoding="utf-8"))
+
+    assert baseline["source_commit"] == (
+        "8296b3da76d191c99284b34a3eb4e33fecda5272"
+    )
+    assert baseline["fixture_digest"] == fixture_digest(fixture)
+    assert baseline["valid_decision_rate"] == 0.0
+    assert baseline["provider_decision_requests"] == 1
+    assert baseline["content_counts"] == {"deferred": 1, "pending": 99}
+
+
+def test_provider_freezes_invalid_then_valid_ab_sequence() -> None:
+    provider = InvalidThenValidProvider()
+    kwargs = {
+        "tools": [{"type": "function"}],
+        "messages": [
+            {"role": "user", "content": "candidate_1234567890abcdef"}
+        ],
+    }
+
+    first = asyncio.run(provider.chat(**kwargs))
+    second = asyncio.run(provider.chat(**kwargs))
+
+    assert first.tool_calls == []
+    assert "INVALID_DECISION_MUST_NOT_LEAK_7F3A" in str(first.content)
+    assert len(second.tool_calls) == 1
+    assert second.tool_calls[0].name == "share_content"
+    assert second.tool_calls[0].arguments["items"] == [
+        "candidate_1234567890abcdef"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_fixture_improves_frozen_baseline(tmp_path: Path) -> None:
+    baseline_path = Path("tests/fixtures/wake_decision_ab_v1.baseline.json")
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    candidate = await run_runtime_fixture(tmp_path)
+
+    assert candidate["fixture_digest"] == baseline["fixture_digest"]
+    assert candidate["valid_decision_rate"] > baseline["valid_decision_rate"]
+    assert candidate["provider_decision_requests"] == 2
+    assert candidate["control_turn_count"] == 1
+    assert candidate["delivery_count"] == 1
+    assert candidate["session_projection_count"] == 1
+    assert candidate["invalid_marker_user_leak"] is False

--- a/tests/test_wake_decision_ab_fixture.py
+++ b/tests/test_wake_decision_ab_fixture.py
@@ -16,9 +16,11 @@ from docker.debug.wake_decision_ab_fixture import (
 
 def test_frozen_fixture_has_stable_identity() -> None:
     fixture = load_fixture()
+    candidates = fixture["candidates"]
 
     assert fixture["fixture_id"] == "wake-decision-ab-v1"
-    assert len(fixture["candidates"]) == 100
+    assert isinstance(candidates, list)
+    assert len(candidates) == 100
     assert fixture_digest(fixture) == (
         "dd269172d553d51cc3a3af8e2e54067bc76c81fb90a1a4ea305d96002f84c8f8"
     )

--- a/tests/test_wake_v3.py
+++ b/tests/test_wake_v3.py
@@ -463,6 +463,7 @@ async def test_due_timer_starts_memoryless_wake_scoped_turn() -> None:
     assert scope.tool_grant.allows("tool_search") is False
     assert scope.tool_grant.allows("share_content") is True
     assert scope.tool_grant.allows("skip_content") is True
+    assert scope.terminal_tools == ("share_content", "skip_content")
     await runtime.close()
 
 

--- a/tests/test_wake_v3_composition.py
+++ b/tests/test_wake_v3_composition.py
@@ -34,7 +34,7 @@ from bus.event_bus import EventBus
 from plugins.content.plugin import CONTENT_SOURCE, CONTENT_WAKE
 from plugins.content.store import ContentStore
 from plugins.drift.plugin import DRIFT_PROPOSALS, DRIFT_WAKE
-from plugins.wake.plugin import _candidate_id
+from plugins.wake.plugin import _candidate_id, _message_with_source_links
 from session.manager import SessionManager
 from session.store import SessionStore
 
@@ -124,6 +124,24 @@ async def apply(ctx, config):
     return paths
 
 
+def test_wake_source_links_keep_order_and_do_not_duplicate_existing_url() -> None:
+    body = _message_with_source_links(
+        "First source is already cited: https://example.test/one",
+        {
+            "source_refs": [
+                {"title": "One", "url": "https://example.test/one"},
+                {"title": "Two\nsource", "url": "https://example.test/two"},
+                {"title": "Unsafe", "url": "javascript:alert(1)"},
+            ]
+        },
+    )
+
+    assert body == (
+        "First source is already cited: https://example.test/one\n\n"
+        "来源：\n- Two source：<https://example.test/two>"
+    )
+
+
 @pytest.mark.asyncio
 async def test_wake_fails_loud_without_semantic_interest_provider(
     tmp_path: Path,
@@ -178,7 +196,10 @@ async def test_wake_fails_loud_without_semantic_interest_provider(
             },
             "success",
             "settled",
-            "fixture share body",
+            (
+                "fixture share body\n\n来源：\n"
+                "- Fixture sleep source：<https://example.test/sleep/e2e>"
+            ),
         ),
         (
             "skip_content",
@@ -322,7 +343,12 @@ session_id = "recipient-session"
             {
                 "item_id": "sleep:e2e",
                 "revision": "1",
-                "payload": {"kind": "sleep", "preprocess_score": 0.9},
+                "payload": {
+                    "kind": "sleep",
+                    "preprocess_score": 0.9,
+                    "title": "Fixture sleep source",
+                    "url": "https://example.test/sleep/e2e",
+                },
                 "not_before": datetime.now(UTC),
                 "requires_ack": False,
             },
@@ -367,6 +393,8 @@ session_id = "recipient-session"
                 {
                     "display_index": 1,
                     "event_id": "fitbit-e2e:sleep:e2e:1",
+                    "title": "Fixture sleep source",
+                    "url": "https://example.test/sleep/e2e",
                 }
             ]
             assert messages[0]["state_summary_tag"] == "none"


### PR DESCRIPTION
## What changed

- retry one missing structured Wake decision inside the same Turn
- append selected HTTP(S) source links to proactive message bodies
- preserve source metadata for later lookup
- add a frozen one-shot A/B fixture for the missing-decision regression

## Why

Wake could defer a useful batch when the model returned prose instead of share_content or skip_content. Source URLs were retained only in message metadata, so users and later model Turns could not see them in conversation history.

## Validation

- 118 focused Wake and control tests passed
- frozen fixture improved valid decision rate from 0% to 100% with the same digest
- BasedPyright: 0 errors
- Change Gate: passed
- git diff --check: passed