### PR TITLE
fix: restore mobile optical alignment across chat chrome

### DIFF
--- a/frontend/chat/src/composer-action.css
+++ b/frontend/chat/src/composer-action.css
@@ -32,7 +32,8 @@
 }
 
 .composer-action-button[data-mode="send"] > svg {
-  transform: translateX(0.75px);
+  /* 相对自身宽度：20px→1px，桌面 compact 15px→0.75px。 */
+  transform: translateX(5%);
 }
 
 .composer-action-button[data-mode="stop"] {

--- a/frontend/chat/src/conversation-navigation.css
+++ b/frontend/chat/src/conversation-navigation.css
@@ -291,8 +291,9 @@
 
 .conversation-session__state {
   display: grid;
-  width: 22px;
+  /* 下限 22px 稳住 Check/dot；不设死 width，避免两位数/99+ 未读角标被压扁。 */
   min-width: 22px;
+  justify-self: end;
   place-items: center;
   color: var(--md-sys-color-primary);
 }

--- a/frontend/chat/src/conversation-navigation.css
+++ b/frontend/chat/src/conversation-navigation.css
@@ -39,7 +39,7 @@
   display: grid;
   width: 100%;
   min-height: 52px;
-  grid-template-columns: 24px minmax(0, 1fr) auto 20px;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
   border: 0;
@@ -66,7 +66,7 @@
 
 .conversation-destination.active .conversation-destination__icon,
 .conversation-destination.active small,
-.conversation-destination.active > svg {
+.conversation-destination.active .conversation-destination__trail > svg {
   color: inherit;
 }
 
@@ -87,10 +87,11 @@
 
 .conversation-destination.featured {
   min-height: 68px;
-  grid-template-columns: 26px minmax(0, 1fr) 20px;
+  grid-template-columns: 26px minmax(0, 1fr) auto;
   gap: 11px;
   border-radius: 22px;
-  padding: 10px 14px;
+  /* 尾侧略紧：补偿行尾 Chevron 视觉重心。 */
+  padding: 10px 12px 10px 14px;
   color: var(--ak-color-on-action-primary);
   background: var(--ak-color-action-primary);
   box-shadow: none;
@@ -99,8 +100,13 @@
 .conversation-destination.featured .conversation-destination__icon,
 .conversation-destination.featured small,
 .conversation-destination.featured .conversation-destination__badge,
-.conversation-destination.featured > svg {
+.conversation-destination.featured .conversation-destination__trail > svg {
   color: inherit;
+}
+
+.conversation-destination.featured .conversation-destination__icon {
+  width: 26px;
+  height: 26px;
 }
 
 .conversation-destination.featured small {
@@ -140,6 +146,20 @@
   color: var(--ak-color-text-secondary);
   font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
+}
+
+.conversation-destination__trail {
+  display: flex;
+  min-width: 20px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* 行尾 Chevron：光学右移（墨水偏左）。 */
+.conversation-destination__trail > svg {
+  flex: 0 0 auto;
+  translate: 0.75px 0;
 }
 
 .conversation-navigation__sessions {
@@ -271,7 +291,8 @@
 
 .conversation-session__state {
   display: grid;
-  min-width: 20px;
+  width: 22px;
+  min-width: 22px;
   place-items: center;
   color: var(--md-sys-color-primary);
 }

--- a/frontend/chat/src/conversation-navigation.tsx
+++ b/frontend/chat/src/conversation-navigation.tsx
@@ -152,8 +152,12 @@ function DestinationList({ destinations, featured = false }: { destinations: Con
               <strong>{destination.label}</strong>
               {destination.description ? <small>{destination.description}</small> : null}
             </span>
-            {destination.badge ? <span className="conversation-destination__badge">{destination.badge}</span> : null}
-            <ChevronRight size={18} aria-hidden="true" />
+            <span className="conversation-destination__trail">
+              {destination.badge ? (
+                <span className="conversation-destination__badge">{destination.badge}</span>
+              ) : null}
+              <ChevronRight size={18} aria-hidden="true" />
+            </span>
           </>
         );
         const className = `conversation-destination ${featured ? "featured" : ""} ${destination.active ? "active" : ""}`;

--- a/frontend/chat/src/message-view.css
+++ b/frontend/chat/src/message-view.css
@@ -877,6 +877,10 @@ button.tool-step-summary:active {
   transition: scale 150ms cubic-bezier(0.2, 0, 0, 1), background-color 150ms cubic-bezier(0.2, 0, 0, 1), color 150ms cubic-bezier(0.2, 0, 0, 1);
 }
 
+.shared-message-actions .lucide-reply {
+  translate: 0.5px -0.25px;
+}
+
 .composer-reply > button:hover,
 .composer-reply > button:active,
 .shared-message-actions button:hover,

--- a/frontend/chat/src/message-view.css
+++ b/frontend/chat/src/message-view.css
@@ -877,7 +877,8 @@ button.tool-step-summary:active {
   transition: scale 150ms cubic-bezier(0.2, 0, 0, 1), background-color 150ms cubic-bezier(0.2, 0, 0, 1), color 150ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-.shared-message-actions .lucide-reply {
+.shared-message-actions .lucide-reply,
+.composer-reply > .lucide-reply {
   translate: 0.5px -0.25px;
 }
 

--- a/frontend/chat/src/mobile-native.css
+++ b/frontend/chat/src/mobile-native.css
@@ -150,6 +150,8 @@ button {
   min-width: 0;
   flex: 1;
   padding-inline: 8px;
+  /* 与 plugin 顶栏标题一致：flex-end 下抬升光学中心对齐 44 图标钮。 */
+  padding-block-end: 11px;
   overflow: hidden;
   font-size: 1rem;
   font-weight: 650;
@@ -315,6 +317,8 @@ button {
 
 .mobile-plugin-directory__list > button > svg:last-child {
   color: var(--ak-color-text-secondary);
+  justify-self: center;
+  translate: 0.75px 0;
 }
 
 .mobile-plugin-directory__mark {
@@ -328,6 +332,7 @@ button {
   font-size: 0.6875rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  line-height: 1;
 }
 
 .mobile-plugin-directory__list span {
@@ -583,6 +588,8 @@ button {
 
 .runtime-item > svg {
   color: var(--ak-color-text-secondary);
+  justify-self: center;
+  translate: 0.75px 0;
 }
 
 .runtime-status {
@@ -798,7 +805,8 @@ button {
   align-items: center;
   gap: 6px;
   border-radius: var(--m-shape-full);
-  padding: 0 12px;
+  /* 左侧圆点侧略紧，避免等宽 padding 右侧显空。 */
+  padding: 0 12px 0 10px;
   color: var(--ak-color-status-trace-text);
   background: var(--ak-color-status-trace-container);
   font-size: 0.75rem;
@@ -1533,7 +1541,7 @@ button {
 }
 
 .mobile-composer-frame.has-reply {
-  border-radius: 18px;
+  border-radius: var(--composer-compact-radius);
 }
 
 .composer-queue {
@@ -1562,6 +1570,7 @@ button {
 }
 
 .composer-queue > button > svg:last-child {
+  translate: 0 0.5px;
   transition: transform 180ms cubic-bezier(0.2, 0, 0, 1);
 }
 
@@ -1636,12 +1645,13 @@ button {
 
 .mobile-composer textarea {
   display: grid;
-  min-height: 40px;
+  min-height: 44px;
   max-height: 148px;
   flex: 1;
   resize: none;
   border: 0;
-  padding: 8px 6px;
+  /* 单行光学中心对齐两侧 44 钮：(44 - 1.4×0.9375rem) / 2 ≈ 11px。 */
+  padding: 11px 6px;
   color: var(--ak-color-text-primary);
   background: transparent;
   font-size: 0.9375rem;
@@ -1673,6 +1683,15 @@ button {
   background: var(--ak-color-bg-surface-low);
   font-size: 0.6875rem;
   font-weight: 720;
+  line-height: 1;
+}
+
+/* Optical center for Latin caps inside the monogram (对齐桌面 model-capsule__mark)。 */
+.mms-mark > span {
+  display: grid;
+  place-items: center;
+  line-height: 1;
+  transform: translateY(0.02em);
 }
 
 .mms-mark img {
@@ -1730,7 +1749,13 @@ button {
   padding: 0.125rem 0.5rem 0.125rem 0.25rem;
   color: var(--ak-color-text-primary);
   background: var(--ak-color-bg-surface-high);
-  transition: background-color 130ms cubic-bezier(0.2, 0, 0, 1), scale 130ms cubic-bezier(0.2, 0, 0, 1);
+  transition: background-color 130ms cubic-bezier(0.2, 0, 0, 1), scale 130ms cubic-bezier(0.2, 0, 0, 1), inset 240ms cubic-bezier(0.2, 0, 0, 1), width 240ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* 展开态留同心缝，避免满宽 stadium 贴 18px 外壳。 */
+.mms-capsule.is-open .mms-capsule__trigger {
+  inset: auto 0.125rem 0.125rem;
+  width: calc(100% - 0.25rem);
 }
 
 .mms-capsule__trigger:active:not(:disabled) {
@@ -1753,6 +1778,8 @@ button {
 .mms-capsule__trigger > svg {
   flex: 0 0 auto;
   color: var(--ak-color-text-secondary);
+  /* translate 独立于 transform，展开 rotate 时仍保持光学下移。 */
+  translate: 0 0.5px;
   transition: transform 180ms cubic-bezier(0.2, 0, 0, 1);
 }
 
@@ -1858,6 +1885,8 @@ button {
 .mms-capsule__back > svg {
   color: var(--ak-color-action-primary);
   transform: rotate(180deg);
+  /* 旋转后等价左箭头：墨水偏「尖端」侧，略右移回光学中心。 */
+  translate: 0.5px 0;
 }
 
 .mms-capsule__model-view {
@@ -2267,8 +2296,11 @@ button {
 }
 
 .message-attachment-action {
+  display: inline-flex;
   min-width: 44px;
   min-height: 44px;
+  align-items: center;
+  justify-content: center;
   border: 0;
   border-radius: 22px;
   margin-right: 4px;
@@ -2454,7 +2486,8 @@ button {
 .mobile-drawer__close {
   position: absolute;
   inset-block-start: calc(8px + env(safe-area-inset-top));
-  inset-inline-start: 12px;
+  /* 与 paper 皮肤 topbar 起始 pad 对齐，开合时不横跳。 */
+  inset-inline-start: 10px;
   display: grid;
   width: 44px;
   height: 44px;
@@ -2495,13 +2528,19 @@ button {
 
 .mobile-topbar {
   min-height: calc(60px + env(safe-area-inset-top));
-  padding: env(safe-area-inset-top) 10px 5px;
+  /* 左少右多 ~2px：图标栏光学边距（覆盖上方对称简写）。 */
+  padding: env(safe-area-inset-top) 12px 5px 10px;
   border-block-end: 1px solid var(--chat-line);
   background: var(--chat-page);
 }
 
 .mobile-icon-button {
   border-radius: 8px;
+}
+
+/* Composer 行端钮与 Send 正圆同族，不被纸面 8px 方角覆盖。 */
+.mobile-composer .mobile-icon-button {
+  border-radius: 50%;
 }
 
 .mobile-conversation {
@@ -2534,8 +2573,9 @@ button {
   box-shadow: none;
 }
 
+/* 回复态保持 stadium，避免 18px 外壳与圆角端钮冲突。 */
 .mobile-composer-frame.has-reply {
-  border-radius: 18px;
+  border-radius: var(--composer-compact-radius);
 }
 
 .mobile-composer-frame:focus-within {
@@ -2570,6 +2610,58 @@ button {
   font-size: 0.6875rem;
   font-variant-numeric: tabular-nums;
 }
+
+/* —— 非对称 Lucide：光学对齐（几何 place-items:center 之上的字形微移）—— */
+.mobile-icon-button .lucide-arrow-left,
+.image-viewer-toolbar .lucide-arrow-left {
+  translate: 1px 0;
+}
+
+.mobile-icon-button .lucide-reply {
+  translate: 0.75px -0.25px;
+}
+
+.mobile-icon-button .lucide-share-2,
+.image-viewer-toolbar .lucide-share-2,
+.message-attachment-action .lucide-share-2 {
+  translate: 0.5px 0;
+}
+
+.mobile-icon-button .lucide-search,
+.mobile-search-field > .lucide-search {
+  translate: 0.5px -0.5px;
+}
+
+.mobile-icon-button .lucide-paperclip {
+  translate: 0 -0.5px;
+}
+
+.mobile-icon-button .lucide-menu {
+  translate: 0 0.5px;
+}
+
+.mobile-icon-button .lucide-chevron-down,
+.command-sheet__header .lucide-chevron-down {
+  translate: 0 0.75px;
+}
+
+.mobile-scroll-button > .lucide-chevron-down {
+  translate: 0 1px;
+}
+
+.mobile-search-navigator .lucide-chevron-up {
+  translate: 0 -0.75px;
+}
+
+.mobile-search-navigator .lucide-chevron-down {
+  translate: 0 0.75px;
+}
+
+.mms-capsule__effort-entry > .lucide-chevron-right,
+.mms-capsule__option > .lucide-chevron-right {
+  translate: 0.75px 0;
+}
+
 @keyframes connection-spin {
   to { transform: rotate(360deg); }
 }

--- a/frontend/chat/src/runtime-dashboard.css
+++ b/frontend/chat/src/runtime-dashboard.css
@@ -71,6 +71,14 @@
   transition: background-color var(--ak-sys-duration-short) var(--ak-sys-motion-standard), scale var(--ak-sys-duration-short) var(--ak-sys-motion-standard);
 }
 
+.runtime-detail__back:has(> svg) {
+  padding-inline: 12px 14px;
+}
+
+.runtime-detail__back > .lucide-arrow-left {
+  translate: 1px 0;
+}
+
 .runtime-dashboard__sync button:hover,
 .runtime-detail__copy:hover,
 .runtime-detail__back:hover {

--- a/frontend/chat/src/settings.css
+++ b/frontend/chat/src/settings.css
@@ -71,6 +71,10 @@
   transition-duration: var(--ak-sys-duration-short);
   transition-timing-function: var(--ak-sys-motion-standard);
 }
+.settings-primary-button:has(> svg),
+.settings-quiet-button:has(> svg) {
+  padding-inline: calc(1.125rem - 2px) 1.125rem;
+}
 .settings-primary-button { color: var(--md-sys-color-on-primary); background: var(--md-sys-color-primary); }
 .settings-primary-button:hover { background: color-mix(in srgb, var(--md-sys-color-primary) 92%, var(--md-sys-color-on-primary) 8%); }
 .settings-quiet-button { color: var(--md-sys-color-on-surface); background: var(--md-sys-color-surface-container-high); }
@@ -140,6 +144,16 @@
 .settings-connection-card:hover {
   background: color-mix(in srgb, var(--md-sys-color-on-surface) 8%, transparent);
 }
+
+.settings-connection-card > .lucide-chevron-right,
+.settings-template-action.lucide-chevron-right {
+  translate: 0.75px 0;
+}
+
+.settings-search > .lucide-search {
+  translate: 0.5px -0.5px;
+}
+
 .settings-connection-mark {
   display: grid;
   width: 2.5rem;

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -1353,6 +1353,10 @@ form.composer:focus-within [data-slot="input-group"] {
   border-radius: 50%;
 }
 
+.mobile-pairing-result-icon .lucide-check {
+  translate: 1px 0.5px;
+}
+
 .mobile-pairing-spinner {
   animation: mobile-pairing-spin 900ms linear infinite;
 }
@@ -1542,6 +1546,11 @@ form.composer:focus-within [data-slot="input-group"] {
   transition-property: scale, color, background-color, opacity;
   transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.mobile-pairing-button:has(> svg) {
+  /* icon+text：图标侧略紧。 */
+  padding-inline: 18px 20px;
 }
 
 .mobile-pairing-button:active {
@@ -1927,6 +1936,8 @@ form.composer:focus-within [data-slot="input-group"] {
   flex: 0 0 auto;
   margin-inline-start: auto;
   color: var(--md-sys-color-on-surface-variant);
+  /* 非 compact 路径也保持光学下移；与 transform:rotate 分离。 */
+  translate: 0 0.5px;
   transition: transform 180ms var(--ak-sys-motion-standard);
 }
 
@@ -2036,6 +2047,10 @@ form.composer:focus-within [data-slot="input-group"] {
   color: inherit;
   background: transparent;
   cursor: pointer;
+}
+.model-capsule__back > svg {
+  /* ChevronLeft：墨水偏尖端侧，略右移回光学中心。 */
+  translate: 0.5px 0;
 }
 .model-capsule__back > span { display: grid; gap: 0.08rem; text-align: start; }
 .model-capsule__back:hover { background: color-mix(in srgb, var(--md-sys-color-on-surface) 8%, transparent); }
@@ -2256,7 +2271,10 @@ form.composer:focus-within [data-slot="input-group"] {
 }
 .model-capsule__effort-entry:active { scale: 0.96; }
 .model-capsule__effort-entry > svg:first-child { color: var(--md-sys-color-on-surface-variant); }
-.model-capsule__effort-entry > svg:last-child { color: var(--md-sys-color-on-surface-variant); }
+.model-capsule__effort-entry > svg:last-child {
+  color: var(--md-sys-color-on-surface-variant);
+  translate: 0.75px 0;
+}
 .model-capsule__effort-entry > span { display: grid; min-width: 0; gap: 0.1rem; text-align: start; }
 .model-capsule__effort-entry small {
   color: var(--md-sys-color-on-surface-variant);
@@ -2337,4 +2355,22 @@ form.composer:focus-within [data-slot="input-group"] {
   .model-capsule__back,
   .model-capsule__effort-entry,
   .model-capsule__effort-option { transition-duration: 0.01ms; }
+}
+
+/* —— 桌面 WebUI：非对称 Lucide 光学对齐 —— */
+.chat-sidebar__search > .lucide-search,
+.model-capsule__search > .lucide-search {
+  translate: 0.5px -0.5px;
+}
+
+.desktop-mobile-navigation-trigger .lucide-menu {
+  translate: 0 0.5px;
+}
+
+.desktop-scroll-return .lucide-arrow-down {
+  translate: 0 1px;
+}
+
+.model-capsule__option > .lucide-chevron-right {
+  translate: 0.75px 0;
 }


### PR DESCRIPTION
## Summary
- Fix drawer destination trail layout so Chevron stays flush when `badge` is absent (including `pluginCount === 0`).
- Add Lucide glyph optical nudges for mobile chrome and capsule/composer desktop-parity tweaks.
- Extend optical alignment to desktop WebUI: sidebar/capsule Search, Menu trigger, scroll ArrowDown, model-capsule chevrons/back, pairing Check + button padding, settings cards, runtime back, composer-reply Reply.

## Test plan
- [x] `npm run test:mobile-web-state` / `test:desktop-navigation` / `build:mobile-web` / `build:chat`
- [ ] Visual check mobile + desktop surfaces

## Rollback
Revert commits on this branch; CSS/TSX only.