### PR TITLE
[codex] Stream shared Akashic sessions across Web and Mobile

### DIFF
--- a/agent/core/passive_turn.py
+++ b/agent/core/passive_turn.py
@@ -67,6 +67,7 @@ from bus.events import (
     InboundMessage,
     OutboundMessage,
     TurnDisposition,
+    TurnTerminalStatus,
 )
 from bus.events_lifecycle import (
     ToolCallCompleted,
@@ -654,6 +655,7 @@ class PassiveTurnPipeline:
                         channel=msg.channel,
                         chat_id=msg.chat_id,
                         content="处理消息时出错，请稍后再试。",
+                        terminal_status=TurnTerminalStatus.FAILED,
                     ),
                 )
 
@@ -775,6 +777,12 @@ class PassiveTurnPipeline:
                     control_turn_id=(
                         outbound.control_turn_id or running_turn_id.get() or None
                     ),
+                    execution_attempt_id=(
+                        outbound.execution_attempt_id
+                        or running_turn_id.get()
+                        or None
+                    ),
+                    terminal_status=outbound.terminal_status,
                 )
             )
         return outbound

--- a/agent/lifecycle/phases/after_reasoning.py
+++ b/agent/lifecycle/phases/after_reasoning.py
@@ -535,6 +535,11 @@ class _BuildOutboundMessageModule:
                 session_message_id = raw_message_id
             elif durable_mobile:
                 raise RuntimeError("本轮 assistant 消息缺少稳定 ID")
+        execution_attempt_id = running_turn_id.get()
+        control_turn_id = str(
+            frame.input.state.msg.metadata.get("control_turn_id")
+            or execution_attempt_id
+        )
         frame.slots[_OUTBOUND_SLOT] = OutboundMessage(
             channel=ctx.channel,
             chat_id=ctx.chat_id,
@@ -543,7 +548,8 @@ class _BuildOutboundMessageModule:
             attachment_refs=attachment_refs,
             metadata=metadata,
             session_message_id=session_message_id,
-            control_turn_id=running_turn_id.get(),
+            control_turn_id=control_turn_id,
+            execution_attempt_id=execution_attempt_id,
         )
         return frame
 

--- a/agent/lifecycle/phases/after_turn.py
+++ b/agent/lifecycle/phases/after_turn.py
@@ -374,6 +374,8 @@ class _DispatchOutboundModule:
                     attachment_refs=outbound.attachment_refs,
                     session_message_id=outbound.session_message_id,
                     control_turn_id=outbound.control_turn_id,
+                    execution_attempt_id=outbound.execution_attempt_id,
+                    terminal_status=outbound.terminal_status,
                 )
             )
         return frame

--- a/agent/looping/core.py
+++ b/agent/looping/core.py
@@ -48,6 +48,7 @@ from bus.events import (
     InboundItem,
     InboundMessage,
     OutboundMessage,
+    TurnTerminalStatus,
 )
 from bus.events_lifecycle import (
     StreamDeltaReady,
@@ -515,7 +516,14 @@ class AgentLoop:
                         channel=item.channel,
                         chat_id=item.chat_id,
                         content=f"出错：{e}",
-                        control_turn_id=execution_turn_id,
+                        control_turn_id=(
+                            str(item.metadata.get("control_turn_id"))
+                            if isinstance(item, InboundMessage)
+                            and item.metadata.get("control_turn_id")
+                            else execution_turn_id
+                        ),
+                        execution_attempt_id=execution_turn_id,
+                        terminal_status=TurnTerminalStatus.FAILED,
                     )
                 )
         finally:
@@ -693,6 +701,11 @@ class AgentLoop:
             control_turn_id = str(
                 msg.metadata.get("control_turn_id") or control_turn_id
             )
+        display_content = (
+            msg.metadata.get("display_content")
+            if isinstance(msg, InboundMessage)
+            else None
+        )
 
         # 1. 对外发布被动 turn 开始事件，具体副作用由 observer 决定。
         #    身份使用入站边界已解析的同一个 client_message_id，禁止再次解析。
@@ -701,7 +714,11 @@ class AgentLoop:
                 session_key=key,
                 channel=msg.channel,
                 chat_id=msg.chat_id,
-                content=_item_content(msg),
+                content=(
+                    display_content
+                    if isinstance(display_content, str)
+                    else _item_content(msg)
+                ),
                 timestamp=msg.timestamp,
                 turn_id=running_turn_id.get(),
                 control_turn_id=control_turn_id,

--- a/agent/turns/outbound.py
+++ b/agent/turns/outbound.py
@@ -13,6 +13,7 @@ from bus.events import (
     AttachmentKind,
     ChannelAttachment,
     ChannelMessage,
+    TurnTerminalStatus,
 )
 
 
@@ -28,6 +29,8 @@ class OutboundDispatch:
     attachment_refs: tuple[AttachmentRef, ...] = ()
     session_message_id: str | None = None
     control_turn_id: str | None = None
+    execution_attempt_id: str | None = None
+    terminal_status: TurnTerminalStatus | None = None
 
 
 class OutboundPort(Protocol):
@@ -68,6 +71,8 @@ class PushToolOutboundPort:
                 reply_to=outbound.reply_to,
                 session_message_id=outbound.session_message_id,
                 control_turn_id=outbound.control_turn_id,
+                execution_attempt_id=outbound.execution_attempt_id,
+                terminal_status=outbound.terminal_status,
             ),
             commit_role=self._commit_role,
         )

--- a/frontend/chat/src/browser-uuid.test.mjs
+++ b/frontend/chat/src/browser-uuid.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createUuid } from "./browser-uuid.ts";
+import { createUuid, createUuidV7 } from "./browser-uuid.ts";
 
 test("uses the native UUID implementation when the browser exposes it", () => {
   const value = createUuid({
@@ -20,4 +20,16 @@ test("creates an RFC 4122 UUID with getRandomValues on plain HTTP", () => {
   });
   assert.equal(value, "abababab-abab-4bab-abab-abababababab");
   assert.match(value, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
+});
+
+test("creates a cross-client UUIDv7 from browser time and randomness", () => {
+  const value = createUuidV7({
+    getRandomValues: (bytes) => {
+      bytes.fill(0xab);
+      return bytes;
+    },
+  }, 1_700_000_000_000);
+
+  assert.equal(value, "018bcfe5-6800-7bab-abab-abababababab");
+  assert.match(value, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
 });

--- a/frontend/chat/src/browser-uuid.ts
+++ b/frontend/chat/src/browser-uuid.ts
@@ -9,3 +9,20 @@ export function createUuid(source: BrowserCrypto = globalThis.crypto): string {
   const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0"));
   return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
 }
+
+/** Create a UUIDv7 whose identity is valid on every Akashic client. */
+export function createUuidV7(
+  source: BrowserCrypto = globalThis.crypto,
+  now = Date.now(),
+): string {
+  const bytes = source.getRandomValues(new Uint8Array(16));
+  let timestamp = Math.floor(now);
+  for (let index = 5; index >= 0; index -= 1) {
+    bytes[index] = timestamp % 256;
+    timestamp = Math.floor(timestamp / 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}

--- a/frontend/chat/src/desktop-navigation.test.mjs
+++ b/frontend/chat/src/desktop-navigation.test.mjs
@@ -28,6 +28,13 @@ test("session activation is idempotent and aborts stale model requests", () => {
   assert.match(controller, /activeSessionRef\.current === sessionId\) return/);
   assert.match(controller, /modelsRequestRef\.current\?\.abort\(\)/);
   assert.match(controller, /fetchChatJson<unknown>\(`\/api\/chat\/models\$\{query\}`, \{ signal: controller\.signal \}\)/);
+  assert.match(controller, /activeSessionRef\.current = sessionId;\s+attachSession\(socketRef\.current, sessionId\);/u);
+});
+
+test("history cannot overwrite a newer live projection", () => {
+  assert.match(controller, /const projectionRevision = liveProjectionRevisionRef\.current;/u);
+  assert.match(controller, /liveProjectionRevisionRef\.current !== projectionRevision/u);
+  assert.match(controller, /frame\.session_id === activeSessionRef\.current[\s\S]*liveProjectionRevisionRef\.current \+= 1/u);
 });
 
 test("shared navigation reports semantic session identities to both adapters", () => {

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
-import { createUuid } from "./browser-uuid.ts";
+import { createUuid, createUuidV7 } from "./browser-uuid.ts";
 import type { ChatMessage } from "./chat-message";
 import { desktopComposerReplyPreview, type ComposerFile } from "./desktop-composer";
 import { loadWebPluginCatalog } from "./mobile-plugin-runtime";
@@ -58,6 +58,15 @@ function observeTurnMetrics(tracker: ClientTurnMetricsTracker, frame: ChatFrame)
   if (frame.type === "turn.interrupted" || frame.type === "error") {
     tracker.onInterrupted();
   }
+}
+
+function attachSession(socket: WebSocket | null, sessionId: string): void {
+  if (!sessionId || socket?.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify({
+    type: "session.attach",
+    request_id: createUuid(),
+    session_id: sessionId,
+  }));
 }
 
 export function useDesktopChatController() {
@@ -121,7 +130,7 @@ export function useDesktopChatController() {
   const statusRef = useRef<ChatStatus>("idle");
   const statusLiveRef = useRef<ChatStatus>("idle");
   const activeTurnIdRef = useRef<string | null>(null);
-  const settledTurnIdsRef = useRef(new Map<string, Set<string>>());
+  const liveProjectionRevisionRef = useRef(0);
   const sessionsRequestRef = useRef<AbortController | null>(null);
   const messagesRequestRef = useRef<AbortController | null>(null);
   const olderMessagesRequestRef = useRef<AbortController | null>(null);
@@ -163,12 +172,16 @@ export function useDesktopChatController() {
     const controller = new AbortController();
     messagesRequestRef.current = controller;
     const endpoint = `/api/chat/sessions/${encodeURIComponent(sessionId)}/messages`;
+    const projectionRevision = liveProjectionRevisionRef.current;
     try {
       const page = chatHistoryPage(
         await fetchChatJson<unknown>(`${endpoint}?page_size=50`, { signal: controller.signal }),
         endpoint,
       );
-      if (activeSessionRef.current !== sessionId) return;
+      if (
+        activeSessionRef.current !== sessionId
+        || liveProjectionRevisionRef.current !== projectionRevision
+      ) return;
       streamStore.clear();
       setMessages(page.items.filter(isVisibleChatRow).map(rowToMessage));
       setHistoryBeforeSeq(page.beforeSeq);
@@ -282,6 +295,9 @@ export function useDesktopChatController() {
       console.debug("[chat-ui] ws message", typeof event.data);
       try {
         const frame = parseChatFrame(JSON.parse(String(event.data)));
+        if ("session_id" in frame && frame.session_id === activeSessionRef.current) {
+          liveProjectionRevisionRef.current += 1;
+        }
         const traceKind = traceKindForChatFrame(frame);
         if (traceKind !== undefined && "session_id" in frame && "turn_id" in frame) {
           webTurnTrace.observeFrame(frame.session_id, frame.turn_id, traceKind);
@@ -298,14 +314,6 @@ export function useDesktopChatController() {
           getStatus: () => statusLiveRef.current,
           setStatus: setStatusLive,
           getActiveTurnId: () => activeTurnIdRef.current,
-          isSettledTurn: (turnId) => settledTurnIdsRef.current
-            .get(activeSessionRef.current)?.has(turnId) === true,
-          markSettledTurn: (turnId) => {
-            const sessionId = activeSessionRef.current;
-            const settled = settledTurnIdsRef.current.get(sessionId) ?? new Set<string>();
-            settled.add(turnId);
-            settledTurnIdsRef.current.set(sessionId, settled);
-          },
           setActiveTurnId: (turnId) => { activeTurnIdRef.current = turnId; },
           loadSessions: loadSessionsSafely,
           loadMessages: loadMessagesSafely,
@@ -317,15 +325,9 @@ export function useDesktopChatController() {
     socket.onopen = () => {
       console.info("[chat-ui] ws connected", socket.url);
       reconnectAttemptRef.current = 0;
-      const attachSessionId = activeSessionRef.current;
-      if (attachSessionId) {
-        console.debug("[chat-ui] ws attach", { sessionId: attachSessionId });
-        socket.send(JSON.stringify({
-          type: "session.attach",
-          request_id: createUuid(),
-          session_id: attachSessionId,
-        }));
-      }
+      const sessionId = activeSessionRef.current;
+      attachSession(socket, sessionId);
+      if (sessionId) loadMessagesSafely(sessionId);
     };
     socket.onerror = () => {
       if (socketRef.current === socket) socket.close();
@@ -403,6 +405,7 @@ export function useDesktopChatController() {
     if (activeSessionRef.current) return activeSessionRef.current;
     const sessionId = `akashic:${createUuid().replaceAll("-", "")}`;
     activeSessionRef.current = sessionId;
+    attachSession(socketRef.current, sessionId);
     setActiveSessionId(sessionId);
     return sessionId;
   }, []);
@@ -417,7 +420,7 @@ export function useDesktopChatController() {
     sendRequestRef.current?.abort();
     const controller = new AbortController();
     sendRequestRef.current = controller;
-    const clientMessageId = createUuid();
+    const clientMessageId = createUuidV7();
     const reply = replyTarget;
     try {
       const sessionId = await ensureSession();
@@ -532,6 +535,7 @@ export function useDesktopChatController() {
     setSurface("chat");
     window.history.replaceState(null, "", window.location.pathname);
     activeSessionRef.current = sessionId;
+    attachSession(socketRef.current, sessionId);
     olderMessagesRequestRef.current?.abort();
     setActiveSessionId(sessionId);
     setPendingSessionId(sessionId);

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -25,6 +25,33 @@ test("WebSocket boundary validates every frame family and observable trace lane"
   assert.throws(() => parseChatFrame({ type: "future.frame" }), /未知消息类型/u);
 });
 
+test("session frames are ignored while no Session is active", () => {
+  let messages = [];
+  let status = "idle";
+  applyChatFrame(parseChatFrame({
+    type: "turn.started",
+    session_id: "akashic:old",
+    turn_id: "turn:old",
+    control_turn_id: "turn:old",
+    client_message_id: "01945f4c-2000-7000-8000-000000000001",
+    content: "旧会话消息",
+  }), {
+    activeSessionId: () => "",
+    activateSession: () => {},
+    setError: () => {},
+    setMessages: (updater) => { messages = updater(messages); },
+    getStatus: () => status,
+    setStatus: (next) => { status = next; },
+    getActiveTurnId: () => null,
+    setActiveTurnId: () => {},
+    loadSessions: async () => {},
+    loadMessages: async () => {},
+  });
+
+  assert.deepEqual(messages, []);
+  assert.equal(status, "idle");
+});
+
 test("failed terminal exposes provider error and reconciles durable messages", () => {
   let messages = [];
   let status = "idle";
@@ -48,7 +75,7 @@ test("failed terminal exposes provider error and reconciles durable messages", (
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", control_turn_id: "turn", client_message_id: "client", content: "" }), context);
   applyChatFrame(parseChatFrame({
     type: "message.final",
     session_id: "session",
@@ -90,7 +117,7 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
     loadMessages: async (sessionId) => { loadedMessages.push(sessionId); },
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", control_turn_id: "turn", client_message_id: "client", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "react.thinking.delta", session_id: "session", turn_id: "turn", delta: "思考" }), context);
   applyChatFrame(parseChatFrame({ type: "react.tool.started", session_id: "session", turn_id: "turn", call_id: "call", tool_name: "shell", arguments: { cmd: "pwd" } }), context);
   applyChatFrame(parseChatFrame({ type: "react.tool.completed", session_id: "session", turn_id: "turn", call_id: "call", tool_name: "shell", status: "success", result_preview: "ok" }), context);
@@ -128,7 +155,6 @@ test("foreign frames stay isolated and message push does not own the active turn
   let status = "streaming";
   let activeTurnId = "turn";
   let messages = [{ id: "turn", role: "assistant", content: "", blocks: [], streaming: true }];
-  const settledTurnIds = new Set();
   const context = {
     activeSessionId: () => "active",
     activateSession: () => {},
@@ -139,8 +165,6 @@ test("foreign frames stay isolated and message push does not own the active turn
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
-    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
-    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -160,7 +184,6 @@ test("foreign frames stay isolated and message push does not own the active turn
   assert.equal(messages.length, 1);
   assert.equal(status, "streaming");
   assert.equal(activeTurnId, "turn");
-  assert.equal(settledTurnIds.size, 0);
 
   applyChatFrame(parseChatFrame({
     type: "turn.interrupted",
@@ -173,6 +196,7 @@ test("foreign frames stay isolated and message push does not own the active turn
     type: "turn.started",
     session_id: "active",
     turn_id: "turn",
+    control_turn_id: "turn",
     client_message_id: "client:continued",
     content: "继续",
   }), context);
@@ -185,7 +209,6 @@ test("stream events keep their turn identity across an inserted message push", (
   let status = "streaming";
   let activeTurnId = "turn:active";
   let messages = [{ id: "turn:active", role: "assistant", content: "", blocks: [], streaming: true }];
-  const settledTurnIds = new Set();
   const context = {
     activeSessionId: () => "active",
     activateSession: () => {},
@@ -194,8 +217,6 @@ test("stream events keep their turn identity across an inserted message push", (
     getStatus: () => status,
     setStatus: (next) => { status = next; },
     getActiveTurnId: () => activeTurnId,
-    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
-    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
     setActiveTurnId: (next) => { activeTurnId = next; },
     loadSessions: async () => {},
     loadMessages: async () => {},
@@ -249,7 +270,6 @@ test("stream events keep their turn identity across an inserted message push", (
   assert.equal(push, undefined);
   assert.equal(status, "idle");
   assert.equal(activeTurnId, null);
-  assert.equal(settledTurnIds.has("turn:active"), true);
 });
 
 test("output completed enters finalizing then terminal returns to idle", () => {
@@ -270,7 +290,7 @@ test("output completed enters finalizing then terminal returns to idle", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", control_turn_id: "turn", client_message_id: "client", content: "" }), context);
   assert.equal(status, "streaming");
 
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn", delta: "答案" }), context);
@@ -301,7 +321,7 @@ test("late output completed after terminal is ignored and keeps idle", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", client_message_id: "client", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn", control_turn_id: "turn", client_message_id: "client", content: "" }), context);
   assert.equal(status, "streaming");
 
   // /stop terminal 先到，composer 回 idle
@@ -332,13 +352,13 @@ test("stale output completed from previous turn does not pollute next turn", () 
   };
 
   // T1 开始 → 中断 → idle
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", control_turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
   assert.equal(status, "streaming");
   applyChatFrame(parseChatFrame({ type: "turn.interrupted", request_id: "r", session_id: "session", status: "interrupted", message: "已中断" }), context);
   assert.equal(status, "idle");
 
   // T2 开始（新 turn）
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", control_turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
   assert.equal(status, "streaming");
   assert.equal(activeTurnId, "turn-2");
 
@@ -367,10 +387,10 @@ test("stale final closes its own row without terminating the next turn", () => {
     loadMessages: async () => {},
   };
 
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-1", control_turn_id: "turn-1", client_message_id: "client-1", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn-1", delta: "T1 partial" }), context);
   applyChatFrame(parseChatFrame({ type: "turn.output.completed", session_id: "session", turn_id: "turn-1" }), context);
-  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
+  applyChatFrame(parseChatFrame({ type: "turn.started", session_id: "session", turn_id: "turn-2", control_turn_id: "turn-2", client_message_id: "client-2", content: "" }), context);
   applyChatFrame(parseChatFrame({ type: "answer.delta", session_id: "session", turn_id: "turn-2", delta: "T2 partial" }), context);
 
   applyChatFrame(parseChatFrame({ type: "message.final", session_id: "session", turn_id: "turn-1", content: "T1 final" }), context);
@@ -407,6 +427,7 @@ test("turn started mirrors a message sent by another client exactly once", () =>
     type: "turn.started",
     session_id: "akashic:session",
     turn_id: "turn:mobile",
+    control_turn_id: "turn:mobile",
     client_message_id: "01JREMOTE",
     content: "手机发出的消息",
   });
@@ -421,102 +442,6 @@ test("turn started mirrors a message sent by another client exactly once", () =>
       { id: "turn:mobile", role: "assistant", content: "" },
     ],
   );
-});
-
-test("replayed turn started does not reopen a settled turn", () => {
-  let status = "idle";
-  let activeTurnId = null;
-  let messages = [];
-  const settledTurnIds = new Set();
-  const context = {
-    activeSessionId: () => "akashic:session",
-    activateSession: () => {},
-    setError: () => {},
-    setMessages: (updater) => { messages = updater(messages); },
-    getStatus: () => status,
-    setStatus: (next) => { status = next; },
-    getActiveTurnId: () => activeTurnId,
-    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
-    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
-    setActiveTurnId: (next) => { activeTurnId = next; },
-    loadSessions: async () => {},
-    loadMessages: async () => {},
-  };
-  const started = parseChatFrame({
-    type: "turn.started",
-    session_id: "akashic:session",
-    turn_id: "turn:mobile",
-    client_message_id: "01JREMOTE",
-    content: "手机发出的消息",
-  });
-
-  applyChatFrame(started, context);
-  applyChatFrame(parseChatFrame({
-    type: "message.final",
-    session_id: "akashic:session",
-    turn_id: "turn:mobile",
-    content: "回复",
-    terminal_status: "completed",
-  }), context);
-  messages = [
-    { id: "akashic:session:1", role: "user", content: "手机发出的消息", blocks: [], canonical: true },
-    { id: "akashic:session:2", role: "assistant", content: "回复", blocks: [], canonical: true },
-  ];
-  applyChatFrame(started, context);
-
-  assert.equal(status, "idle");
-  assert.equal(activeTurnId, null);
-  assert.equal(messages.length, 2);
-  assert.equal(messages[1].content, "回复");
-  assert.equal(messages[1].canonical, true);
-});
-
-test("interrupted terminal does not settle a continued interaction", () => {
-  let status = "idle";
-  let activeTurnId = null;
-  let messages = [];
-  const settledTurnIds = new Set();
-  const context = {
-    activeSessionId: () => "akashic:session",
-    activateSession: () => {},
-    setError: () => {},
-    setMessages: (updater) => { messages = updater(messages); },
-    getStatus: () => status,
-    setStatus: (next) => { status = next; },
-    getActiveTurnId: () => activeTurnId,
-    isSettledTurn: (turnId) => settledTurnIds.has(turnId),
-    markSettledTurn: (turnId) => { settledTurnIds.add(turnId); },
-    setActiveTurnId: (next) => { activeTurnId = next; },
-    loadSessions: async () => {},
-    loadMessages: async () => {},
-  };
-
-  applyChatFrame(parseChatFrame({
-    type: "turn.started",
-    session_id: "akashic:session",
-    turn_id: "turn:continued",
-    client_message_id: "client:first",
-    content: "第一次输入",
-  }), context);
-  applyChatFrame(parseChatFrame({
-    type: "message.final",
-    session_id: "akashic:session",
-    turn_id: "turn:continued",
-    content: "已中断",
-    terminal_status: "interrupted",
-  }), context);
-  applyChatFrame(parseChatFrame({
-    type: "turn.started",
-    session_id: "akashic:session",
-    turn_id: "turn:continued",
-    client_message_id: "client:continued",
-    content: "继续完成",
-  }), context);
-
-  assert.equal(settledTurnIds.has("turn:continued"), false);
-  assert.equal(status, "streaming");
-  assert.equal(activeTurnId, "turn:continued");
-  assert.equal(messages.some((message) => message.id === "client:continued"), true);
 });
 
 test("turn started reuses the Web optimistic message identity", () => {
@@ -546,6 +471,7 @@ test("turn started reuses the Web optimistic message identity", () => {
     type: "turn.started",
     session_id: "akashic:session",
     turn_id: "turn:web",
+    control_turn_id: "turn:web",
     client_message_id: "client:web",
     content: "网页发出的消息",
   }), context);

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -5,7 +5,7 @@ import type { WebTurnTraceKind } from "./web-turn-trace";
 
 export type ChatFrame =
   | { type: "session.created"; request_id: string; session_id: string }
-  | { type: "turn.started"; session_id: string; turn_id: string; client_message_id: string; content: string }
+  | { type: "turn.started"; session_id: string; turn_id: string; control_turn_id: string; client_message_id: string; content: string }
   | { type: "react.thinking.delta"; session_id: string; turn_id: string; delta: string }
   | { type: "react.tool.started"; session_id: string; turn_id: string; call_id: string; tool_name: string; arguments: unknown }
   | { type: "react.tool.completed"; session_id: string; turn_id: string; call_id: string; tool_name: string; status: string; result_preview: string }
@@ -38,8 +38,6 @@ export interface WebChatFrameContext {
   getStatus: () => ChatStatus;
   setStatus: (status: ChatStatus) => void;
   getActiveTurnId: () => string | null;
-  isSettledTurn: (turnId: string) => boolean;
-  markSettledTurn: (turnId: string) => void;
   setActiveTurnId: (turnId: string | null) => void;
   loadSessions: () => Promise<void>;
   loadMessages: (sessionId: string) => Promise<void>;
@@ -62,7 +60,7 @@ export function parseChatFrame(value: unknown): ChatFrame {
       requireStrings(frame, ["request_id", "session_id"]);
       break;
     case "turn.started":
-      requireStrings(frame, ["session_id", "turn_id", "client_message_id", "content"]);
+      requireStrings(frame, ["session_id", "turn_id", "control_turn_id", "client_message_id", "content"]);
       break;
     case "react.thinking.delta":
       requireStrings(frame, ["session_id", "turn_id", "delta"]);
@@ -103,6 +101,12 @@ export function parseChatFrame(value: unknown): ChatFrame {
         && !["completed", "failed", "interrupted", "cancelled"].includes(frame.terminal_status as string)
       ) {
         throw new Error("message.final.terminal_status 格式无效");
+      }
+      if (frame.execution_attempt_id !== undefined || frame.control_turn_id !== undefined) {
+        requireStrings(frame, ["execution_attempt_id", "control_turn_id"]);
+        if (frame.turn_id !== frame.execution_attempt_id) {
+          throw new Error("message.final.turn_id 必须等于 execution_attempt_id");
+        }
       }
       break;
     case "turn.output.completed":
@@ -177,7 +181,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     return;
   }
   if (!("session_id" in frame)) return;
-  if (context.activeSessionId() && frame.session_id !== context.activeSessionId()) {
+  if (frame.session_id !== context.activeSessionId()) {
     console.debug("[chat-transport] skip frame for inactive session", {
       type: frame.type,
       frameSessionId: frame.session_id,
@@ -198,7 +202,6 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
   }
   if (frame.type === "turn.started") {
     console.debug("[chat-transport] turn.started", { turn_id: frame.turn_id });
-    if (context.isSettledTurn(frame.turn_id)) return;
     context.setStatus("streaming");
     context.setActiveTurnId(frame.turn_id);
     context.setMessages((messages) => {
@@ -301,7 +304,6 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     void context.loadSessions();
     return;
   }
-  if (frame.terminal_status === "completed") context.markSettledTurn(frame.turn_id);
   const isActiveTerminal = frame.turn_id === context.getActiveTurnId();
   const isRecoveredTerminal = context.getActiveTurnId() === null;
   const failed = frame.terminal_status === "failed";

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -16,6 +16,7 @@ from agent.plugin_composition.channels import (
     AttachmentRef,
     ChannelInboundMessage,
     ChannelAttachmentReadPort,
+    ChannelCommitRole,
     ChannelFactoryContext,
     ChannelRuntimePorts,
     ChannelReady,
@@ -202,7 +203,6 @@ class WebChatChannel:
         self._attachments: AttachmentStore | None = None
         self._artifact_store: ChannelAttachmentArtifactStore | None = None
         self._connections: dict[str, set[WebSocket]] = {}
-        self._active_turn_ids: dict[str, str] = {}
         self._pending_terminal: dict[str, dict[str, Any]] = {}
         self._media_paths: set[str] = set()
         self._connection_lock = asyncio.Lock()
@@ -303,19 +303,16 @@ class WebChatChannel:
         socket_id = self._socket_id(websocket)
         logger.info("[web_chat] websocket opened id=%s", socket_id)
         await websocket.accept()
-        session_keys: set[str] = set()
         try:
             while True:
                 payload = await websocket.receive_json()
                 if not isinstance(payload, dict):
                     await self._send_error(websocket, "", "消息格式必须是 JSON object")
                     continue
-                session_key = await self._handle_client_frame(
+                await self._handle_client_frame(
                     websocket,
                     cast(dict[str, Any], payload),
                 )
-                if session_key:
-                    session_keys.add(session_key)
         except WebSocketDisconnect as error:
             logger.info(
                 "[web_chat] websocket disconnect id=%s code=%s reason=%s",
@@ -324,7 +321,7 @@ class WebChatChannel:
                 error.reason,
             )
         finally:
-            await self._remove_connection(websocket, session_keys)
+            await self._remove_connection(websocket)
             logger.info("[web_chat] websocket closed id=%s", socket_id)
 
     def save_upload(self, data: bytes, filename: str) -> dict[str, Any]:
@@ -546,15 +543,22 @@ class WebChatChannel:
         passive = metadata.pop("_channel_commit_role", None) == "passive"
         if not passive:
             metadata.setdefault("source", "message_push")
+        if passive and (
+            not message.execution_attempt_id or not message.control_turn_id
+        ):
+            raise RuntimeError("Web passive final 缺少 Turn/Attempt 身份")
         frame: dict[str, Any] = {
             "type": "message.final",
             "session_id": session_key,
-            "turn_id": message.control_turn_id or self._current_turn_id(session_key),
+            "turn_id": message.execution_attempt_id or "",
             "content": message.content,
             "thinking": message.thinking or "",
             "media": media,
             "metadata": metadata,
         }
+        if passive:
+            frame["control_turn_id"] = message.control_turn_id
+            frame["execution_attempt_id"] = message.execution_attempt_id
         duration = metadata.get("turn_duration_ms")
         if isinstance(duration, (int, float)) and not isinstance(duration, bool):
             frame["duration_ms"] = duration
@@ -611,17 +615,22 @@ class WebChatChannel:
                 metadata.pop("_channel_commit_role", None)
                 if request.commit_role.value != "passive":
                     metadata.setdefault("source", "message_push")
-                message_push = metadata.get("source") == "message_push"
+                independent_delivery = (
+                    request.commit_role is not ChannelCommitRole.PASSIVE
+                    or metadata.get("source") == "message_push"
+                )
+                if not independent_delivery and (
+                    request.execution_attempt_id is None
+                    or request.control_turn_id is None
+                ):
+                    raise RuntimeError("Web passive final 缺少 Turn/Attempt 身份")
                 frame: dict[str, Any] = {
                     "type": "message.final",
                     "session_id": session_key,
                     "turn_id": (
-                        request.control_turn_id
-                        or (
-                            f"delivery:{request.delivery_id}"
-                            if message_push
-                            else self._current_turn_id(session_key)
-                        )
+                        f"delivery:{request.delivery_id}"
+                        if independent_delivery
+                        else request.execution_attempt_id
                     ),
                     "content": request.body,
                     "thinking": request.thinking or "",
@@ -632,9 +641,9 @@ class WebChatChannel:
                     frame["reply_to"] = request.reply_to
                 if request.session_message_id is not None:
                     frame["session_message_id"] = request.session_message_id
-                if request.control_turn_id is not None:
+                if not independent_delivery and request.control_turn_id is not None:
                     frame["control_turn_id"] = request.control_turn_id
-                if request.execution_attempt_id is not None:
+                if not independent_delivery and request.execution_attempt_id is not None:
                     frame["execution_attempt_id"] = request.execution_attempt_id
                 if request.terminal_status is not None:
                     frame["terminal_status"] = request.terminal_status.value
@@ -985,14 +994,14 @@ class WebChatChannel:
     async def _on_turn_started(self, event: TurnStarted) -> None:
         if event.channel != self.name:
             return
-        turn_id = event.control_turn_id or event.turn_id
-        if not turn_id:
+        if not event.turn_id:
             raise RuntimeError("Web TurnStarted 缺少 Server 权威 turn_id")
-        self._active_turn_ids[event.session_key] = turn_id
+        turn_id = event.turn_id
         await self._broadcast(event.session_key, {
             "type": "turn.started",
             "session_id": event.session_key,
             "turn_id": turn_id,
+            "control_turn_id": event.control_turn_id or turn_id,
             "client_message_id": event.client_message_id,
             "content": event.content,
         })
@@ -1000,18 +1009,19 @@ class WebChatChannel:
     async def _on_stream_delta(self, event: StreamDeltaReady) -> None:
         if event.channel != self.name:
             return
+        turn_id = self._event_turn_id(event.turn_id)
         if event.thinking_delta:
             await self._broadcast(event.session_key, {
                 "type": "react.thinking.delta",
                 "session_id": event.session_key,
-                "turn_id": self._current_turn_id(event.session_key),
+                "turn_id": turn_id,
                 "delta": event.thinking_delta,
             })
         if event.content_delta:
             await self._broadcast(event.session_key, {
                 "type": "answer.delta",
                 "session_id": event.session_key,
-                "turn_id": self._current_turn_id(event.session_key),
+                "turn_id": turn_id,
                 "delta": event.content_delta,
             })
 
@@ -1021,7 +1031,7 @@ class WebChatChannel:
         await self._broadcast(event.session_key, {
             "type": "react.tool.started",
             "session_id": event.session_key,
-            "turn_id": self._current_turn_id(event.session_key),
+            "turn_id": self._event_turn_id(event.turn_id),
             "call_id": event.call_id,
             "tool_name": event.tool_name,
             "arguments": event.arguments,
@@ -1033,7 +1043,7 @@ class WebChatChannel:
         await self._broadcast(event.session_key, {
             "type": "react.tool.completed",
             "session_id": event.session_key,
-            "turn_id": self._current_turn_id(event.session_key),
+            "turn_id": self._event_turn_id(event.turn_id),
             "call_id": event.call_id,
             "tool_name": event.tool_name,
             "status": event.status,
@@ -1043,17 +1053,26 @@ class WebChatChannel:
     async def _on_output_completed(self, event: TurnOutputCompleted) -> None:
         if event.channel != self.name:
             return
+        turn_id = self._event_turn_id(event.turn_id)
         await self._broadcast(event.session_key, {
             "type": "turn.output.completed",
             "session_id": event.session_key,
-            "turn_id": self._current_turn_id(event.session_key),
+            "turn_id": turn_id,
             "client_message_id": event.client_message_id,
         })
 
     async def _add_connection(self, session_key: str, websocket: WebSocket) -> bool:
+        """把一个 Web socket 投影到唯一的当前 Session。"""
+
         async with self._connection_lock:
+            added = websocket not in self._connections.get(session_key, set())
+            for bound_session_key, bound_sockets in tuple(self._connections.items()):
+                if bound_session_key == session_key:
+                    continue
+                bound_sockets.discard(websocket)
+                if not bound_sockets:
+                    _ = self._connections.pop(bound_session_key, None)
             sockets = self._connections.setdefault(session_key, set())
-            added = websocket not in sockets
             sockets.add(websocket)
         await self._refill_terminal(session_key, websocket)
         return added
@@ -1093,10 +1112,9 @@ class WebChatChannel:
     async def _remove_connection(
         self,
         websocket: WebSocket,
-        session_keys: set[str],
     ) -> None:
         async with self._connection_lock:
-            for session_key in session_keys:
+            for session_key in tuple(self._connections):
                 sockets = self._connections.get(session_key)
                 if sockets is None:
                     continue
@@ -1172,8 +1190,11 @@ class WebChatChannel:
     def _turn_id(self, session_key: str, seed: float) -> str:
         return f"{session_key}:{seed:.6f}"
 
-    def _current_turn_id(self, session_key: str) -> str:
-        return self._active_turn_ids.get(session_key, session_key)
+    @staticmethod
+    def _event_turn_id(attempt_turn_id: str) -> str:
+        if not attempt_turn_id:
+            raise RuntimeError("Web lifecycle event 缺少 turn_id")
+        return attempt_turn_id
 
     def _require_ctx(self) -> ChannelContext:
         if self._ctx is None:

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -2402,7 +2402,7 @@ class MobileRealtimeChannel:
         self._raise_delta_failure()
         if event.channel != self.name:
             return
-        turn_id = event.turn_id or event.session_key
+        turn_id = self._event_turn_id(event.turn_id)
         self._active_turn_ids[event.session_key] = turn_id
         process_key = (event.session_key, turn_id)
         if process_key in self._process_turns:
@@ -2450,7 +2450,7 @@ class MobileRealtimeChannel:
         if event.channel != self.name:
             return
         session_id = event.session_key
-        turn_id = event.turn_id or self._current_turn_id(session_id)
+        turn_id = self._event_turn_id(event.turn_id)
         # 0. 终态已收口（墓碑在而锁已清理）的迟到事件先读 closed 直接丢弃，
         #    绝不等待锁、绝不重建 batch/timer/lock，也绝不让它滑向崩溃路径。
         if (session_id, turn_id) in self._turn_terminals:
@@ -2621,7 +2621,7 @@ class MobileRealtimeChannel:
         if event.channel != self.name:
             return
         session_id = event.session_key
-        turn_id = event.turn_id or self._current_turn_id(session_id)
+        turn_id = self._event_turn_id(event.turn_id)
         # 0. 终态已收口的迟到事件先读 closed 直接丢弃，不触碰任何 per-turn 结构。
         if (session_id, turn_id) in self._turn_terminals:
             self._log_late_event_dropped(session_id, turn_id, "react.tool.started")
@@ -2660,7 +2660,7 @@ class MobileRealtimeChannel:
         if event.channel != self.name:
             return
         session_id = event.session_key
-        turn_id = event.turn_id or self._current_turn_id(session_id)
+        turn_id = self._event_turn_id(event.turn_id)
         if (session_id, turn_id) in self._turn_terminals:
             self._log_late_event_dropped(session_id, turn_id, "react.tool.completed")
             return
@@ -2702,7 +2702,7 @@ class MobileRealtimeChannel:
         if event.channel != self.name:
             return
         session_id = event.session_key
-        turn_id = event.turn_id or self._current_turn_id(session_id)
+        turn_id = self._event_turn_id(event.turn_id)
         # 终态已收口则丢弃迟到信号，绝不重建 per-turn 结构。
         if (session_id, turn_id) in self._turn_terminals:
             self._log_late_event_dropped(session_id, turn_id, "turn.output.completed")
@@ -2843,11 +2843,11 @@ class MobileRealtimeChannel:
             not isinstance(raw_attempt_id, str) or not raw_attempt_id
         ):
             raise RuntimeError("mobile final execution attempt id 无效")
-        turn_id = (
-            cast(str | None, raw_attempt_id)
-            or message.control_turn_id
-            or self._current_turn_id(session_id)
-        )
+        if raw_attempt_id is None:
+            raise RuntimeError("mobile passive final 缺少 execution_attempt_id")
+        if not message.control_turn_id:
+            raise RuntimeError("mobile passive final 缺少 control_turn_id")
+        turn_id = raw_attempt_id
         key = (session_id, turn_id)
         message_id = message.session_message_id
         media = [attachment.source for attachment in message.attachments]
@@ -2862,13 +2862,15 @@ class MobileRealtimeChannel:
         if message.terminal_status in (
             TurnTerminalStatus.INTERRUPTED,
             TurnTerminalStatus.CANCELLED,
+            TurnTerminalStatus.FAILED,
         ):
-            # 1. 中断/取消使用权威 typed terminal；与 /stop 已发布终态共用墓碑幂等。
+            # 1. 无持久 assistant 消息的非完成终态共用 typed terminal；
+            #    与 /stop 已发布终态共用墓碑幂等。
             if message.control_turn_id is None:
                 raise RuntimeError("mobile interrupted terminal 缺少权威 turn_id")
             payload: dict[str, object] = {
                 "status": message.terminal_status.value,
-                "message": message.content or "本轮已中断。",
+                "message": message.content or "本轮未完成。",
                 "control_turn_id": message.control_turn_id,
             }
             if client_message_id is not None:
@@ -3528,6 +3530,12 @@ class MobileRealtimeChannel:
 
     def _current_turn_id(self, session_id: str) -> str:
         return self._active_turn_ids.get(session_id, session_id)
+
+    @staticmethod
+    def _event_turn_id(turn_id: str) -> str:
+        if not turn_id:
+            raise RuntimeError("mobile lifecycle event 缺少 turn_id")
+        return turn_id
 
     def _interrupt_payload(
         self,

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -385,6 +385,11 @@ def _provider_delivery(channel: MobileRealtimeChannel):
     async def deliver(message: OutboundMessage | ChannelMessage):
         if isinstance(message, ChannelMessage):
             return await channel._deliver_message(message)
+        if message.execution_attempt_id is None:
+            message = replace(
+                message,
+                execution_attempt_id=message.control_turn_id,
+            )
         channel_message = channel_message_from_outbound(message)
         metadata = dict(channel_message.metadata)
         metadata["_channel_commit_role"] = "passive"
@@ -868,6 +873,7 @@ async def test_native_v3_mobile_passive_rejects_terminal_after_device_race(
             body="passive no recipient",
             commit_role=ChannelCommitRole.PASSIVE,
             control_turn_id="turn:passive-race",
+            execution_attempt_id="turn:passive-race",
         )
     )
     assert receipt.status is V3DeliveryStatus.REJECTED
@@ -940,6 +946,7 @@ async def test_native_v3_mobile_passive_preserves_pending_delta_for_retry(
         body="done",
         commit_role=ChannelCommitRole.PASSIVE,
         control_turn_id=turn_id,
+        execution_attempt_id=turn_id,
     )
     rejected = await adapter.deliver(request)
     assert rejected.status is V3DeliveryStatus.REJECTED
@@ -2751,12 +2758,11 @@ async def test_final_event_maps_optimistic_user_to_persisted_identity(
 
 
 @pytest.mark.asyncio
-async def test_final_payload_accepts_client_message_id_without_user_message_id(
+async def test_failed_terminal_accepts_client_message_id_without_user_message_id(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """client_message_id 可单独存在（failed 终态）；state 缺失时 tl:final.published
-    用已验证 outbound client_message_id 贯通，不用 current turn 猜。"""
+    """failed 终态不伪造 canonical assistant 消息。"""
 
     storage = MobileRealtimeStorage(tmp_path / "mobile.db")
     runtime = _Runtime(storage)
@@ -2771,15 +2777,21 @@ async def test_final_payload_accepts_client_message_id_without_user_message_id(
                 content="处理消息时出错，请稍后再试。",
                 metadata={"client_message_id": "cmid-fail"},
                 control_turn_id=turn_id,
+                execution_attempt_id=turn_id,
+                terminal_status=TurnTerminalStatus.FAILED,
             )
         )
 
     final = runtime.events[-1]
-    assert final["event_type"] == "message.final"
+    assert final["event_type"] == "turn.interrupted"
     assert final["turn_id"] == turn_id
     payload = cast(dict[str, object], final["payload"])
-    assert payload["client_message_id"] == "cmid-fail"
-    assert "user_message_id" not in payload
+    assert payload == {
+        "status": "failed",
+        "message": "处理消息时出错，请稍后再试。",
+        "control_turn_id": turn_id,
+        "client_message_id": "cmid-fail",
+    }
     final_records = [
         record
         for record in caplog.records
@@ -2860,6 +2872,8 @@ async def test_control_reply_never_reuses_previous_message_id(tmp_path: Path) ->
             channel="akashic",
             chat_id=session_id.removeprefix("akashic:"),
             content="相同的固定回复",
+            control_turn_id="turn:control-reply",
+            execution_attempt_id="turn:control-reply",
         )
     )
 

--- a/tests/mobile_realtime/test_gateway.py
+++ b/tests/mobile_realtime/test_gateway.py
@@ -1291,13 +1291,14 @@ def test_authenticated_message_send_reaches_agent_event_path_once(
             )
             receipt = await runtime.channel._deliver_message(
                 channel_message_from_outbound(
-                    OutboundMessage(
-                        channel="akashic",
-                        chat_id=inbound.chat_id,
-                        content="完成",
-                        thinking="先检查",
-                        control_turn_id=turn_id,
-                        metadata={"_channel_commit_role": "passive"},
+                        OutboundMessage(
+                            channel="akashic",
+                            chat_id=inbound.chat_id,
+                            content="完成",
+                            thinking="先检查",
+                            control_turn_id=turn_id,
+                            execution_attempt_id=turn_id,
+                            metadata={"_channel_commit_role": "passive"},
                     )
                 )
             )
@@ -2107,9 +2108,10 @@ def test_outbound_attachment_download_replays_binary_before_reply(
                     channel="akashic",
                     chat_id=chat_id,
                     content="文件已生成",
-                    media=[str(source)],
-                    control_turn_id=turn_id,
-                    session_message_id=str(persisted.messages[-1]["id"]),
+                        media=[str(source)],
+                        control_turn_id=turn_id,
+                        execution_attempt_id=turn_id,
+                        session_message_id=str(persisted.messages[-1]["id"]),
                     metadata={"_channel_commit_role": "passive"},
                 )
             )

--- a/tests/mobile_realtime/test_isolated_e2e.py
+++ b/tests/mobile_realtime/test_isolated_e2e.py
@@ -208,6 +208,7 @@ class _SharedSessionBus:
                 metadata={"client_message_id": raw.message_id},
                 commit_role=ChannelCommitRole.PASSIVE,
                 control_turn_id=turn_id,
+                execution_attempt_id=turn_id,
             )
         )
         assert receipt.status.value == "delivered"
@@ -292,6 +293,8 @@ class _DeterministicAgentBus:
                 content=inbound.content,
                 timestamp=datetime.now(timezone.utc),
                 turn_id=turn_id,
+                control_turn_id=turn_id,
+                client_message_id=client_message_id,
             )
         )
         receipt = await runtime.channel._deliver_message(
@@ -302,6 +305,7 @@ class _DeterministicAgentBus:
                     content="隔离网关固定回复",
                     media=[str(self._reply_media)],
                     control_turn_id=turn_id,
+                    execution_attempt_id=turn_id,
                     session_message_id=assistant_message_id,
                     metadata={"_channel_commit_role": "passive"},
                 )
@@ -481,6 +485,7 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
         with TestClient(app) as client:
             with (
                 client.websocket_connect("/ws") as web_socket,
+                client.websocket_connect("/ws") as observing_web_socket,
                 client.websocket_connect("/mobile/ws") as mobile_socket,
             ):
                 epoch = _authenticate(mobile_socket, device_id, device_key)
@@ -498,7 +503,7 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                 web_socket.send_json(
                     {
                         "type": "message.send",
-                        "request_id": "web-message",
+                        "request_id": "01945f4c-2000-7000-8000-000000000001",
                         "session_id": session_id,
                         "text": "Web 写入同一个会话",
                         "media": [],
@@ -520,7 +525,9 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                     "answer.delta",
                     "message.final",
                 ]
-                assert web_live[0]["client_message_id"] == "web-message"
+                assert web_live[0]["client_message_id"] == (
+                    "01945f4c-2000-7000-8000-000000000001"
+                )
 
                 # 2. Mobile lists and reads the exact same durable Session.
                 mobile_socket.send_json(
@@ -548,6 +555,11 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                 ]
 
                 # 3. Mobile writes back; Web HTTP history sees both messages once.
+                observing_web_socket.send_json({
+                    "type": "session.attach",
+                    "request_id": "observer-attach",
+                    "session_id": session_id,
+                })
                 mobile_socket.send_json(
                     _command(
                         "01J00000000000000000000022",
@@ -573,6 +585,9 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                 ]
                 bus.wait_for_count(2)
                 web_reply_frames = [web_socket.receive_json() for _ in range(5)]
+                observer_reply_frames = [
+                    observing_web_socket.receive_json() for _ in range(5)
+                ]
                 assert [frame["type"] for frame in web_reply_frames] == [
                     "turn.started",
                     "react.thinking.delta",
@@ -584,6 +599,7 @@ def test_web_and_mobile_share_one_session_and_receive_one_delivery(
                     "01J00000000000000000000022"
                 )
                 assert web_reply_frames[0]["content"] == "Mobile 写回同一个会话"
+                assert observer_reply_frames == web_reply_frames
                 history = client.get(f"/api/chat/sessions/{session_id}/messages").json()
                 assert [item["content"] for item in history["items"]] == [
                     "Web 写入同一个会话",

--- a/tests/test_agent_loop_contracts.py
+++ b/tests/test_agent_loop_contracts.py
@@ -19,7 +19,12 @@ from agent.looping.ports import LLMConfig
 from agent.looping.session_lane import SessionLaneRegistry
 from agent.plugins.snapshot import bind_runtime_snapshot, reset_runtime_snapshot
 from bus.event_bus import EventBus
-from bus.events import InboundItem, InboundMessage, OutboundMessage
+from bus.events import (
+    InboundItem,
+    InboundMessage,
+    OutboundMessage,
+    TurnTerminalStatus,
+)
 from bus.events_lifecycle import TurnStarted
 from bus.queue import MessageBus
 from core.error_context import (
@@ -301,6 +306,7 @@ async def test_error_final_carries_authoritative_execution_turn_id() -> None:
         sender="user",
         chat_id="chat-a",
         content="hello",
+        metadata={"display_content": "继续说明"},
     )
     bus = SimpleNamespace(
         complete_inbound=AsyncMock(),
@@ -328,6 +334,7 @@ async def test_error_final_carries_authoritative_execution_turn_id() -> None:
     assert outbound.control_turn_id == observed_child_turn_ids[0]
     assert outbound.control_turn_id.startswith("turn:")
     assert started_events[0].turn_id == observed_child_turn_ids[0]
+    assert started_events[0].content == "继续说明"
     bus.complete_inbound.assert_awaited_once_with(item)
     assert loop._active_tasks == {}
     assert loop._active_turn_states == {}
@@ -366,7 +373,9 @@ async def test_error_final_preserves_preprovided_execution_turn_id() -> None:
     await loop._run_inbound_turn(item)
 
     (outbound,) = loop._outbound_port.dispatch.call_args.args
-    assert outbound.control_turn_id == "turn:pre"
+    assert outbound.control_turn_id == "interaction:1"
+    assert outbound.execution_attempt_id == "turn:pre"
+    assert outbound.terminal_status is TurnTerminalStatus.FAILED
     assert started_events[0].turn_id == "turn:pre"
     bus.complete_inbound.assert_awaited_once_with(item)
     assert loop._active_tasks == {}

--- a/tests/test_lifecycle_phases.py
+++ b/tests/test_lifecycle_phases.py
@@ -38,6 +38,7 @@ from bus.event_bus import EventBus
 from bus.events import (
     InboundMessage,
     OutboundMessage,
+    TurnTerminalStatus,
 )
 from bus.events_lifecycle import TurnCommitted
 from core.error_context import current_client_message_id, current_session_key
@@ -2196,8 +2197,9 @@ async def test_after_reasoning_append_records_success_milestones(
     persisted_user = appended[0][1][0]
     assert persisted_user["client_message_id"] == client_message_id
     assert persisted_user["control_turn_id"] == turn_id
-    # 正常 final 的 OutboundMessage 直接携带 running turn id，不再依赖 channel fallback。
+    # 正常 final 显式携带 logical Turn 与 execution Attempt，不依赖 channel fallback。
     assert result.outbound.control_turn_id == turn_id
+    assert result.outbound.execution_attempt_id == turn_id
     records = _milestone_records(
         caplog, "after_reasoning.append.start", "after_reasoning.append.done"
     )
@@ -2425,6 +2427,7 @@ async def _run_after_turn(
                 media=list(media or []),
                 session_message_id=session_message_id,
                 control_turn_id=str(msg.metadata.get("control_turn_id") or ""),
+                execution_attempt_id=running_turn_id.get() or None,
             ),
             ctx=AfterReasoningCtx(
                 session_key=session.key,
@@ -2683,6 +2686,7 @@ async def test_after_turn_dispatch_forwards_typed_identity_to_channel_port() -> 
     assert len(dispatched) == 1
     outbound_message = dispatched[0]
     assert outbound_message.control_turn_id == turn_id
+    assert outbound_message.execution_attempt_id == turn_id
     assert outbound_message.reply_to == "message-1"
     assert outbound_message.session_message_id == "telegram:123:2"
     assert outbound_message.media == ["/tmp/image.png"]
@@ -2759,6 +2763,8 @@ async def test_control_outbound_forwards_current_turn_id_under_turn_context() ->
     dispatched = dispatch_port.dispatch.await_args.args[0]
     assert isinstance(dispatched, OutboundDispatch)
     assert dispatched.control_turn_id == turn_id
+    assert dispatched.execution_attempt_id == turn_id
+    assert dispatched.terminal_status is TurnTerminalStatus.FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -70,6 +70,31 @@ class _FailingWebSocket(_WebSocket):
         raise OSError("socket closed")
 
 
+@pytest.mark.asyncio
+async def test_web_socket_projects_only_one_current_session() -> None:
+    channel = WebChatChannel()
+    switching_socket = _WebSocket()
+    other_socket = _WebSocket()
+
+    assert await channel._add_connection(
+        "akashic:first", cast(Any, switching_socket)
+    ) is True
+    assert await channel._add_connection(
+        "akashic:first", cast(Any, other_socket)
+    ) is True
+    assert await channel._add_connection(
+        "akashic:second", cast(Any, switching_socket)
+    ) is True
+
+    assert channel._connections == {
+        "akashic:first": {other_socket},
+        "akashic:second": {switching_socket},
+    }
+
+    await channel._remove_connection(cast(Any, switching_socket))
+    assert channel._connections == {"akashic:first": {other_socket}}
+
+
 class _ProviderClientFactory:
     async def create(self, credentials: Any) -> Any:
         _ = credentials
@@ -894,7 +919,6 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
     channel = WebChatChannel()
     socket = _WebSocket()
     channel._connections["akashic:abc"] = {cast(Any, socket)}
-    channel._active_turn_ids["akashic:abc"] = "turn-1"
     image = tmp_path / "result.png"
     image.write_bytes(b"image")
 
@@ -910,6 +934,8 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
                 "turn_duration_ms": 17,
                 "_channel_commit_role": "passive",
             },
+            control_turn_id="turn-1",
+            execution_attempt_id="attempt-1",
         )
     )
     assert receipt.succeeded
@@ -918,12 +944,14 @@ async def test_web_final_preserves_full_outbound_projection(tmp_path: Path) -> N
         {
             "type": "message.final",
             "session_id": "akashic:abc",
-            "turn_id": "turn-1",
+            "turn_id": "attempt-1",
             "content": "answer",
             "thinking": "reasoning",
             "media": [str(image)],
             "duration_ms": 17,
             "metadata": {"render": "card", "turn_duration_ms": 17},
+            "control_turn_id": "turn-1",
+            "execution_attempt_id": "attempt-1",
         }
     ]
     assert channel.has_media(image)
@@ -961,6 +989,7 @@ async def test_web_v3_native_delivery_projects_opaque_artifacts_and_semantics() 
             session_message_id="assistant-1",
             control_turn_id="turn-1",
             execution_attempt_id="attempt-1",
+            commit_role=ChannelCommitRole.PASSIVE,
         )
     )
 
@@ -969,7 +998,7 @@ async def test_web_v3_native_delivery_projects_opaque_artifacts_and_semantics() 
     assert socket.frames == [{
         "type": "message.final",
         "session_id": "akashic:abc",
-        "turn_id": "turn-1",
+        "turn_id": "attempt-1",
         "content": "answer",
         "thinking": "reasoning",
         "media": [{
@@ -984,7 +1013,6 @@ async def test_web_v3_native_delivery_projects_opaque_artifacts_and_semantics() 
         "metadata": {
             "turn_duration_ms": 17,
             "render": {"kind": "card", "citations": ["mem_1"]},
-            "source": "message_push",
         },
         "reply_to": "user-1",
         "session_message_id": "assistant-1",
@@ -999,7 +1027,6 @@ async def test_web_passive_message_push_uses_independent_projection_identity() -
     channel = WebChatChannel()
     socket = _WebSocket()
     channel._connections["akashic:abc"] = {cast(Any, socket)}
-    channel._active_turn_ids["akashic:abc"] = "turn:active"
     adapter = channel.build_v3_adapter(_v3_context())
     ready = await adapter.start()
 
@@ -1059,6 +1086,8 @@ async def test_web_v3_terminal_without_socket_refills_after_session_attach() -> 
                 "nested": {"ids": ["mem_1"]},
             }),
             control_turn_id="turn-1",
+            execution_attempt_id="attempt-1",
+            commit_role=ChannelCommitRole.PASSIVE,
         )
     )
     socket = _WebSocket()
@@ -1072,16 +1101,16 @@ async def test_web_v3_terminal_without_socket_refills_after_session_attach() -> 
     assert socket.frames == [{
         "type": "message.final",
         "session_id": "akashic:abc",
-        "turn_id": "turn-1",
+        "turn_id": "attempt-1",
         "content": "answer",
         "thinking": "",
         "media": [],
         "metadata": {
             "turn_duration_ms": None,
             "nested": {"ids": ["mem_1"]},
-            "source": "message_push",
         },
         "control_turn_id": "turn-1",
+        "execution_attempt_id": "attempt-1",
     }]
     assert "duration_ms" not in socket.frames[0]
     assert "akashic:abc" not in channel._pending_terminal
@@ -1124,9 +1153,8 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
         "turn.output.completed",
     ]
     assert socket.frames[0]["client_message_id"] == "client-1"
-    assert {frame["turn_id"] for frame in socket.frames} == {
-        "turn:server-owner"
-    }
+    assert {frame["turn_id"] for frame in socket.frames} == {"attempt-1"}
+    assert socket.frames[0]["control_turn_id"] == "turn:server-owner"
 
 
 @pytest.mark.asyncio

--- a/tests/turns/test_outbound.py
+++ b/tests/turns/test_outbound.py
@@ -10,12 +10,12 @@ from agent.plugin_composition.channels import (
 )
 from agent.turns.outbound import OutboundDispatch, PushToolOutboundPort
 from agent.tools.message_push import MessagePushTool
-from bus.events import ChannelMessage
+from bus.events import ChannelMessage, TurnTerminalStatus
 from bus.queue import ChatLane
 
 
 @pytest.mark.asyncio
-async def test_push_tool_outbound_port_forwards_control_turn_id_verbatim() -> None:
+async def test_push_tool_outbound_port_forwards_turn_identity_verbatim() -> None:
     delivered: list[ChannelMessage] = []
 
     class _PushTool:
@@ -43,13 +43,17 @@ async def test_push_tool_outbound_port_forwards_control_turn_id_verbatim() -> No
             metadata={"source": "passive"},
             media=["/tmp/image.png"],
             session_message_id="telegram:123:5",
-            control_turn_id="turn:authoritative",
+            control_turn_id="interaction:authoritative",
+            execution_attempt_id="turn:attempt",
+            terminal_status=TurnTerminalStatus.COMPLETED,
         )
     )
 
     assert len(delivered) == 1
     message = delivered[0]
-    assert message.control_turn_id == "turn:authoritative"
+    assert message.control_turn_id == "interaction:authoritative"
+    assert message.execution_attempt_id == "turn:attempt"
+    assert message.terminal_status is TurnTerminalStatus.COMPLETED
     assert message.reply_to == "message-1"
     assert message.session_message_id == "telegram:123:5"
     assert message.metadata == {"source": "passive"}


### PR DESCRIPTION
## 问题与结果

- 解决的问题：同一 `akashic:*` Session 的 Web/Mobile 客户端只看到自己发起的实时流，另一端需要刷新；切换 Session 与 HTTP history 也可能覆盖实时投影。
- 用户可见结果：任一端发起 Turn，已打开同一 Session 的 Web 与 Mobile 都立即投影 user、thinking、tool、answer 与 terminal；断线仍由历史恢复。
- 本 PR 不处理：客户端导航、草稿、已读状态同步；旧 APK 兼容。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`breaking`
- `capability_owner`：`core`
- `consumer_scope`：Web Chat、Android Mobile、Akashic Channel
- `runtime_patch`：`none`
- `runtime_patch_reason`：Core 本身是 provider runtime；Mobile PR 单独锁定本 head。
- `authoritative_state_owner`：SessionDB Message/Turn；客户端只保留可重建投影。
- `client_only_alternative`：不可行；客户端无法观察另一入口的实时 Turn。
- `concept_gate`：`required`
- `concept_gate_reason`：修改跨 adapter 投影、Turn/Attempt 身份和终态。
- 关联不变量：AKC-001～AKC-002、MOB-002、MOB-005、Decision 0034/0044。
- `protected_state`：既有 SessionDB messages、workspace、插件 generation、外部 Channel。
- 允许的副作用：当前 Session 的 Web/Mobile 实时事件与可重建本地行。
- 禁止的副作用：双写正文、猜测当前 Turn、客户端反写权威历史、兼容 fallback。

## 改动范围

- 主要文件：Web/Mobile channel adapters、typed outbound identity、Web reducer/controller、跨端 E2E。
- 配置或迁移影响：无 schema/持久化迁移；Web client message ID 改为 UUIDv7；passive final 必须显式携带 Attempt 与逻辑 Turn。
- 已知 schema lineage 与最终 schema identity：`schema/mobile-realtime-v1.json` 未变，sha256 `f8ad6c420a22c5daf8c6bc3db2ff670b0aaf7e1c90c74cffbc09a702647182a2`。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：provider `de571f83a38de0f5b760f21629a604430f24277b`，tree `0d7dacd2ab12161c7ecae75e3b881fd7709281f0`；Mobile runtime profile 在依赖 PR 锁定。
- 回滚方式：revert 本 PR；恢复分支 `backup/session-live-projection-core-20260827`。

## 验证

- [x] 相关 targeted tests 已通过：212 项；跨端隔离 E2E 覆盖 Web→Mobile、Mobile→两个 Web socket、历史幂等与主动投影。
- [x] 前端 typecheck/lint/build 已通过：53 tests；lint 0 error（57 个既有 warning）；生产 build 通过。
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：24/24 public scenarios passed。
- `sourceDigest`：`8d543801a6db6c816087c0860505c46074eba9c03f8067e25fdcb98883b2d561`
- `planDigest`：`b5bf7120ef93789affd0aee93f926fff10a34ae0ae4b91e78697e101cbfb2ea8`
- 真实设备证据：未运行；当前 `adb devices -l` 无设备。
- 未运行项与原因：Android 真机同屏与 lifecycle 验证由 Mobile PR/后续设备 Gate 补充。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：`concept_gate` / `gpt-5.6-terra` / `xhigh`
- 审查 head：`de571f83a38de0f5b760f21629a604430f24277b`（最终源代码与 Gate 内容一致；最后仅补旧 fixture 的显式 Attempt）
- 新增概念及其唯一 owner；没有时写 `none`：`none`。复用 Session、Message、Turn、Attempt 与 adapter。
- 无关设计轴的变化传播；没有时写 `none`：`none`。导航/草稿/已读仍各端本地。
- 最短正常/失败/热更新链路：TurnStarted/Delta/Final → 两个 adapter → 本地投影；FAILED → typed non-completed terminal；reconnect → Session history。
- legacy/source-specific 残留扫描：移除 Web settled-turn 集合和 channel 当前 Turn 猜测；测试覆盖外来 Session frame 隔离。
- must-fix 及处置证据：补 Session activate attach；补 Attempt 全链；FAILED 不伪造 canonical Message，Mobile 使用 typed terminal。最终复审 PASS。
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次修复落实既有 AKC/MOB 长期语义，没有新增竞争真源。
- [x] 跨仓库客户端改动按 MOB-001 由独立 Mobile PR 与固定 runtime lock 交付。
- [x] 当前 `NOW.md` 没有对应已完成条目。