### PR TITLE
[codex] fix formal plugin root ownership handoff

### DIFF
--- a/agent/plugins/generation.py
+++ b/agent/plugins/generation.py
@@ -79,6 +79,8 @@ class PluginGeneration:
     static_runtime_commands: tuple[tuple[str, tuple[str, ...]], ...] = ()
     composition_runtime_cleanup_registered: bool = False
     replaced_composition_runtime_generation: PluginGeneration | None = None
+    formal_root_stopped: bool = False
+    formal_root_released: bool = False
     entrypoint: str = "plugin.py"
     skill_catalog: PreparedSkillCatalog | None = None
     runtime_snapshot: RuntimeSnapshot | None = None

--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1424,12 +1424,23 @@ class PluginManager:
         if action.recovery_target == "base":
             accepted = {(base, base)}
             if candidate_pointer is not None:
-                accepted.add((base, ArtifactPointer(candidate_pointer)))
+                candidate = ArtifactPointer(candidate_pointer)
+                accepted.update(
+                    {
+                        (base, candidate),
+                        (candidate, candidate),
+                    }
+                )
             if pair not in accepted:
                 raise RuntimeError(
                     f"runtime recovery base pointer 漂移: {plugin_base}: {pair}"
                 )
-            _ = write_pointers(plugin_base, stable=base, latest=base)
+            latest = (
+                ArtifactPointer(candidate_pointer)
+                if candidate_pointer is not None
+                else base
+            )
+            _ = write_pointers(plugin_base, stable=base, latest=latest)
             return
         if candidate_pointer is None:
             raise RuntimeError("runtime recovery candidate target 缺少 exact pointer")
@@ -2760,11 +2771,17 @@ class PluginManager:
             v3_channel_catalog_changed = self._channel_catalog_identity(
                 stable_snapshot
             ) != self._channel_catalog_identity(ready.snapshot)
+            formal_root_handoff = (
+                generation.production_contributions is not None
+                and stable_snapshot is not None
+                and stable_snapshot.composition_root is not None
+            )
             publication_gated = (
                 exclusive_endpoint_changed
                 or command_catalog_changed
                 or v3_channel_catalog_changed
                 or shared_handoff
+                or formal_root_handoff
             )
             from agent.plugins.snapshot import get_current_runtime_lease
 
@@ -2791,7 +2808,7 @@ class PluginManager:
                 else None
             )
             runtime_restore_started = False
-            shared_stable_stopped = False
+            stable_root_stopped = False
             provisional_transaction: SnapshotTransaction | None = None
             provisional_cancelled = False
             if publication_gated:
@@ -2809,21 +2826,10 @@ class PluginManager:
                         exclusive_endpoint_changed
                         or v3_channel_catalog_changed
                         or shared_handoff
+                        or formal_root_handoff
                     ):
                         await self._snapshot_store.wait_for_no_leases(quiesced_snapshot)
-                    if shared_handoff:
-                        assert quiesced_snapshot is not None
-                        try:
-                            await self._stop_shared_read_stable_runtime(
-                                generation,
-                                quiesced_snapshot,
-                            )
-                        finally:
-                            shared_stable_stopped = (
-                                generation.replaced_composition_runtime_generation
-                                is not None
-                            )
-                    else:
+                    if not shared_handoff:
                         await self._snapshot_store.wait_for_no_leases(ready.snapshot)
                         self._snapshot_store.seal_candidate_validation(ready.snapshot)
                     (
@@ -2833,15 +2839,21 @@ class PluginManager:
                         self._snapshot_store.promote_latest_provisional()
                     )
                     runtime_restore_started = True
-                    await self._restore_ready_runtime(ready)
+                    try:
+                        await self._restore_ready_runtime(
+                            ready,
+                            stable_snapshot=quiesced_snapshot,
+                        )
+                    finally:
+                        stable_root_stopped = generation.formal_root_stopped
                     generation = ready.candidate
                     new_commands = self._snapshot_bot_commands(ready.snapshot)
                 except BaseException:
                     gated_runtime_error: BaseException | None = None
-                    if shared_stable_stopped:
+                    if stable_root_stopped:
                         assert quiesced_snapshot is not None
                         try:
-                            await self._recover_shared_read_stable_runtime(
+                            await self._recover_stable_root(
                                 generation,
                                 quiesced_snapshot,
                             )
@@ -2875,7 +2887,7 @@ class PluginManager:
                         await self._endpoint_resumer()
                     if runtime_restore_started and self._ready_candidate is ready:
                         if gated_runtime_error is None:
-                            _ = await self._drop_ready(plugin_id)
+                            await self._clear_ready_after_failed_promotion(ready)
                     else:
                         await self._snapshot_store.resume(candidate_snapshot)
                     if gated_runtime_error is not None:
@@ -2886,6 +2898,7 @@ class PluginManager:
                                 "candidate_validation_stopped",
                                 "old_runtime_restore_uncertain",
                             ),
+                            recovery_target="base",
                         )
                         raise RuntimeError(
                             "candidate formalization 失败后旧 v3 runtime 恢复失败"
@@ -2896,7 +2909,10 @@ class PluginManager:
                     await self._snapshot_store.wait_for_no_leases(ready.snapshot)
                     self._snapshot_store.seal_candidate_validation(ready.snapshot)
                     runtime_restore_started = True
-                    await self._restore_ready_runtime(ready)
+                    await self._restore_ready_runtime(
+                        ready,
+                        stable_snapshot=None,
+                    )
                     generation = ready.candidate
                 except BaseException:
                     formalization_runtime_error: BaseException | None = None
@@ -2909,7 +2925,7 @@ class PluginManager:
                             formalization_runtime_error = error
                     if runtime_restore_started and self._ready_candidate is ready:
                         if formalization_runtime_error is None:
-                            _ = await self._drop_ready(plugin_id)
+                            await self._clear_ready_after_failed_promotion(ready)
                     else:
                         await self._snapshot_store.resume(candidate_snapshot)
                     if formalization_runtime_error is not None:
@@ -2974,7 +2990,7 @@ class PluginManager:
                         promote_latest=True,
                         force_provisional=exclusive_endpoint_changed,
                         provisional_started=provisional_transaction is not None,
-                        reopen_previous_on_failure=not shared_handoff,
+                        reopen_previous_on_failure=not formal_root_handoff,
                         before_open=before_open,
                         after_open=after_open,
                     )
@@ -2982,6 +2998,7 @@ class PluginManager:
                 cancelled = provisional_cancelled or final_cancelled
             except BaseException as publication_error:
                 skill_error: BaseException | None = None
+                pointer_error: BaseException | None = None
                 runtime_error: BaseException | None = None
                 participant_restore_error = (
                     publication_error
@@ -2991,15 +3008,21 @@ class PluginManager:
                     )
                     else None
                 )
+                artifact_base = _installed_artifact_base(generation)
+                if artifact_base is not None:
+                    try:
+                        _preserve_ready_pointer(ready, artifact_base)
+                    except BaseException as error:
+                        pointer_error = error
                 if skill_links_switched:
                     try:
                         skill_linker.sync(stable_skill_plugins)
                     except BaseException as error:
                         skill_error = error
-                if shared_stable_stopped:
+                if stable_root_stopped:
                     assert quiesced_snapshot is not None
                     try:
-                        await self._recover_shared_read_stable_runtime(
+                        await self._recover_stable_root(
                             generation,
                             quiesced_snapshot,
                         )
@@ -3021,22 +3044,27 @@ class PluginManager:
                 if (
                     runtime_error is None
                     and skill_error is None
+                    and pointer_error is None
                     and participant_restore_error is None
                 ):
                     await self._snapshot_store.resume(quiesced_snapshot)
                 if (
                     runtime_error is None
                     and skill_error is None
+                    and pointer_error is None
                     and participant_restore_error is None
                     and self._endpoint_resumer is not None
                     and exclusive_endpoint_changed
                 ):
                     await self._endpoint_resumer()
                 recovery_error = (
-                    runtime_error or participant_restore_error or skill_error
+                    runtime_error
+                    or participant_restore_error
+                    or skill_error
+                    or pointer_error
                 )
                 if self._ready_candidate is ready and recovery_error is None:
-                    _ = await self._drop_ready(plugin_id)
+                    await self._clear_ready_after_failed_promotion(ready)
                 if recovery_error is not None:
                     recovery_resources: list[str] = []
                     recovery_effects: list[str] = []
@@ -3062,11 +3090,15 @@ class PluginManager:
                     if skill_error is not None:
                         recovery_resources.append("plugin-skill-projection")
                         recovery_effects.append("stable_skill_restore_uncertain")
+                    if pointer_error is not None:
+                        recovery_resources.append("plugin-artifact-pointer")
+                        recovery_effects.append("stable_pointer_restore_uncertain")
                     self._record_composition_runtime_failure(
                         generation,
                         recovery_error,
                         resource=",".join(recovery_resources),
                         formal_effects=tuple(recovery_effects),
+                        recovery_target="base",
                     )
                     raise RuntimeError(
                         "插件 promote 失败后存在未完成的 formal recovery: "
@@ -3075,6 +3107,8 @@ class PluginManager:
                 raise
             self._ready_candidate = None
             generation.replaced_composition_runtime_generation = None
+            generation.formal_root_stopped = False
+            generation.formal_root_released = False
             self._track_reload_drain(generation, transaction.previous)
             if self._endpoint_resumer is not None and exclusive_endpoint_changed:
                 await self._endpoint_resumer()
@@ -3221,11 +3255,7 @@ class PluginManager:
                     or ready.candidate.replaced_composition_runtime_generation is None
                 )
             ):
-                await self._start_composition_generation_runtime(
-                    stable,
-                    current,
-                    mode="formal",
-                )
+                await self._rebuild_stable_root(stable, current)
                 receipts.append("stable-composition-runtime-restored")
 
             # 3. Restore non-runtime formal effects only while their candidate owner exists.
@@ -3234,7 +3264,9 @@ class PluginManager:
                 and ready is not None
                 and ready.candidate.replaced_composition_runtime_generation is not None
             ):
-                await self._restore_replaced_composition_runtime(ready.candidate)
+                if current is None:
+                    raise RuntimeError("runtime recovery 缺少 stable snapshot")
+                await self._recover_stable_root(ready.candidate, current)
                 receipts.append("stable-composition-runtime-restored")
             if "plugin-skill-projection" in resource:
                 if ready is None:
@@ -3352,8 +3384,10 @@ class PluginManager:
     async def _restore_ready_runtime(
         self,
         ready: _ReadyPluginCandidate,
+        *,
+        stable_snapshot: RuntimeSnapshot | None,
     ) -> None:
-        """Replace isolated validation resources before formal endpoint commit."""
+        """Replace validation and stable Roots without overlapping formal owners."""
 
         generation = ready.candidate
         production = generation.production_contributions
@@ -3385,6 +3419,7 @@ class PluginManager:
         # 2. Restore the formal data projection, then refresh the exact Root payload.
         generation.contributions = production
         generation.data_dir = production_data_dir
+        await self._stop_stable_root(generation, stable_snapshot)
         replacement = await self._compile_generation_snapshot(
             generation,
         )
@@ -3399,30 +3434,14 @@ class PluginManager:
             await self._dispose_unreferenced_composition_root(replacement)
             raise
         try:
-            await self._stop_replaced_composition_runtime(generation)
-            await self._start_composition_generation_runtime(
-                generation,
+            await self._start_snapshot_composition_runtimes(
                 replacement,
-                mode="formal",
+                candidate=generation,
                 expected_mcp_catalog_digests=expected_mcp_catalog_digests,
             )
-            if _requires_shared_candidate_handoff(
-                generation.replaced_composition_runtime_generation,
-                generation,
-            ):
-                await self._start_runtime_snapshot(replacement)
+            await self._start_runtime_snapshot(replacement)
         except BaseException:
-            try:
-                await self._stop_composition_generation_runtime(generation)
-                if not _requires_shared_candidate_handoff(
-                    generation.replaced_composition_runtime_generation,
-                    generation,
-                ):
-                    await self._restore_replaced_composition_runtime(generation)
-            except BaseException as restore_error:
-                raise RuntimeError(
-                    "candidate formal runtime 失败后旧 stable runtime 恢复失败"
-                ) from restore_error
+            await self._stop_snapshot_composition_runtimes(replacement)
             await self._dispose_unreferenced_composition_root(replacement)
             raise
         _replace_snapshot_payload(ready.snapshot, replacement)
@@ -3484,6 +3503,22 @@ class PluginManager:
         if cancelled:
             raise asyncio.CancelledError
         return result
+
+    async def _clear_ready_after_failed_promotion(
+        self,
+        ready: _ReadyPluginCandidate,
+    ) -> None:
+        """Release invalid validation state while retaining durable latest."""
+
+        artifact_base = _installed_artifact_base(ready.candidate)
+        if artifact_base is not None:
+            _preserve_ready_pointer(ready, artifact_base)
+        _, cancelled = await _complete_critical(
+            self._snapshot_store.discard_latest(ready.snapshot)
+        )
+        self._ready_candidate = None
+        if cancelled:
+            raise asyncio.CancelledError
 
     def candidate_status(self, plugin_id: str | None = None) -> dict[str, object]:
         ready = self._ready_candidate
@@ -3708,11 +3743,18 @@ class PluginManager:
         v3_channel_catalog_changed = self._channel_catalog_identity(
             current
         ) != self._channel_catalog_identity(snapshot)
+        formal_root_handoff = (
+            not stage_latest
+            and current is not None
+            and current.composition_root is not None
+            and snapshot.composition_root is not current.composition_root
+        )
         publication_gated = not stage_latest and (
             exclusive_endpoint_changed
             or command_catalog_changed
             or v3_channel_catalog_changed
             or shared_handoff
+            or formal_root_handoff
         )
         if self._dashboard_preparer is not None:
             try:
@@ -3764,7 +3806,9 @@ class PluginManager:
                 if exclusive_endpoint_changed and self._endpoint_quiescer is not None:
                     await self._endpoint_quiescer()
                 if quiesced_snapshot is not None and (
-                    exclusive_endpoint_changed or v3_channel_catalog_changed
+                    exclusive_endpoint_changed
+                    or v3_channel_catalog_changed
+                    or formal_root_handoff
                 ):
                     await self._snapshot_store.wait_for_no_leases(quiesced_snapshot)
             except BaseException as error:
@@ -3805,7 +3849,7 @@ class PluginManager:
 
         provisional_started = False
         provisional_cancelled = False
-        shared_stable_stopped = False
+        stable_root_stopped = False
         if not stage_latest:
             try:
                 self._snapshot_store.seal_pending_validation(snapshot)
@@ -3818,37 +3862,31 @@ class PluginManager:
                         await self._endpoint_quiescer()
                     assert quiesced_snapshot is not None
                     await self._snapshot_store.wait_for_no_leases(quiesced_snapshot)
-                    try:
-                        await self._stop_shared_read_stable_runtime(
-                            generation,
-                            quiesced_snapshot,
-                        )
-                    finally:
-                        shared_stable_stopped = (
-                            generation.replaced_composition_runtime_generation
-                            is not None
-                        )
                 if publication_gated:
                     _, provisional_cancelled = await _complete_critical(
                         self._snapshot_store.commit_provisional(transaction)
                     )
                     provisional_started = True
-                _ = await self._restore_direct_candidate_runtime(
-                    generation,
-                    validation_snapshot=snapshot,
-                )
+                try:
+                    _ = await self._restore_direct_candidate_runtime(
+                        generation,
+                        validation_snapshot=snapshot,
+                        stable_snapshot=quiesced_snapshot,
+                    )
+                finally:
+                    stable_root_stopped = generation.formal_root_stopped
             except (asyncio.CancelledError, Exception) as error:
                 error_text = str(error) or type(error).__name__
-                shared_recovery_error: BaseException | None = None
-                if shared_stable_stopped:
+                stable_recovery_error: BaseException | None = None
+                if stable_root_stopped:
                     assert quiesced_snapshot is not None
                     try:
-                        await self._recover_shared_read_stable_runtime(
+                        await self._recover_stable_root(
                             generation,
                             quiesced_snapshot,
                         )
                     except BaseException as recovery_error:
-                        shared_recovery_error = recovery_error
+                        stable_recovery_error = recovery_error
                 self._record_failed_gate(
                     plugin_id=plugin_id,
                     revision=generation.source_revision,
@@ -3867,13 +3905,14 @@ class PluginManager:
                 ):
                     self._record_composition_runtime_failure(
                         generation,
-                        shared_recovery_error or error,
+                        stable_recovery_error or error,
                         formal_effects=(
                             "candidate_pointer_restored",
                             "old_runtime_restore_uncertain",
                         ),
+                        recovery_target="base",
                     )
-                runtime_restore_uncertain = shared_recovery_error is not None or (
+                runtime_restore_uncertain = stable_recovery_error is not None or (
                     previous_runtime is not None
                     and self._composition_generation_host.get(
                         previous_runtime.generation_id
@@ -3941,7 +3980,7 @@ class PluginManager:
                         promote_latest=False,
                         force_provisional=exclusive_endpoint_changed,
                         provisional_started=provisional_started,
-                        reopen_previous_on_failure=not shared_handoff,
+                        reopen_previous_on_failure=not formal_root_handoff,
                         before_open=open_candidate,
                         after_open=(
                             None
@@ -3974,13 +4013,13 @@ class PluginManager:
                     commit_error,
                     _PublicationParticipantRestoreError,
                 )
-                and not shared_stable_stopped,
+                and not stable_root_stopped,
             )
             runtime_restore_error: BaseException | None = None
             try:
-                if shared_stable_stopped:
+                if stable_root_stopped:
                     assert quiesced_snapshot is not None
-                    await self._recover_shared_read_stable_runtime(
+                    await self._recover_stable_root(
                         generation,
                         quiesced_snapshot,
                     )
@@ -3988,7 +4027,14 @@ class PluginManager:
                     await self._restore_replaced_composition_runtime(generation)
             except BaseException as error:
                 runtime_restore_error = error
-            if runtime_restore_error is None and shared_stable_stopped:
+            if (
+                runtime_restore_error is None
+                and stable_root_stopped
+                and not isinstance(
+                    commit_error,
+                    _PublicationParticipantRestoreError,
+                )
+            ):
                 await self._snapshot_store.resume(quiesced_snapshot)
             participant_restore_error = isinstance(
                 commit_error,
@@ -4002,6 +4048,7 @@ class PluginManager:
                         "candidate_pointer_restored",
                         "old_runtime_restore_uncertain",
                     ),
+                    recovery_target="base",
                 )
             elif participant_restore_error:
                 participant_resource = (
@@ -4022,6 +4069,7 @@ class PluginManager:
                     cast(BaseException, commit_error),
                     resource=participant_resource,
                     formal_effects=participant_effects,
+                    recovery_target="base",
                 )
             else:
                 self._abort_reload(
@@ -4083,6 +4131,8 @@ class PluginManager:
         generation.state = "active"
         self._active_generations[plugin_id] = generation
         generation.replaced_composition_runtime_generation = None
+        generation.formal_root_stopped = False
+        generation.formal_root_released = False
         if active is not None:
             active.state = "retired"
         resume_cancelled = False
@@ -4109,8 +4159,9 @@ class PluginManager:
         generation: PluginGeneration,
         *,
         validation_snapshot: RuntimeSnapshot,
+        stable_snapshot: RuntimeSnapshot | None,
     ) -> RuntimeSnapshot:
-        """直接发布前用正式 runtime 重建并关闭 candidate Root。"""
+        """Close validation and stable Roots before rebuilding the formal Root."""
 
         candidate_runtime = self._composition_generation_host.get(
             generation.generation_id
@@ -4133,6 +4184,7 @@ class PluginManager:
         ensure_workspace_plugin_data_dir(generation.data_dir, self._workspace)
         production_snapshot: RuntimeSnapshot | None = None
         try:
+            await self._stop_stable_root(generation, stable_snapshot)
             production_snapshot = await self._compile_generation_snapshot(
                 generation,
             )
@@ -4146,30 +4198,15 @@ class PluginManager:
             except RuntimeError:
                 await self._dispose_unreferenced_composition_root(production_snapshot)
                 raise
-            await self._stop_replaced_composition_runtime(generation)
-            await self._start_composition_generation_runtime(
-                generation,
+            await self._start_snapshot_composition_runtimes(
                 production_snapshot,
-                mode="formal",
+                candidate=generation,
                 expected_mcp_catalog_digests=expected_mcp_catalog_digests,
             )
-            if _requires_shared_candidate_handoff(
-                generation.replaced_composition_runtime_generation,
-                generation,
-            ):
-                await self._start_runtime_snapshot(production_snapshot)
+            await self._start_runtime_snapshot(production_snapshot)
         except BaseException:
-            try:
-                await self._stop_composition_generation_runtime(generation)
-                if not _requires_shared_candidate_handoff(
-                    generation.replaced_composition_runtime_generation,
-                    generation,
-                ):
-                    await self._restore_replaced_composition_runtime(generation)
-            except BaseException as restore_error:
-                raise RuntimeError(
-                    "production runtime 失败后旧 stable runtime 恢复失败"
-                ) from restore_error
+            if production_snapshot is not None:
+                await self._stop_snapshot_composition_runtimes(production_snapshot)
             if production_snapshot is not None:
                 await self._dispose_unreferenced_composition_root(production_snapshot)
             if created_data_dir:
@@ -5739,6 +5776,43 @@ class PluginManager:
         self._refresh_composition_runtime_tools(snapshot)
         return runtime
 
+    async def _start_snapshot_composition_runtimes(
+        self,
+        snapshot: RuntimeSnapshot,
+        *,
+        candidate: PluginGeneration | None = None,
+        expected_mcp_catalog_digests: Mapping[str, str] | None = None,
+    ) -> None:
+        """Start every managed runtime owned by one formal Root."""
+
+        started: list[PluginGeneration] = []
+        try:
+            for item in snapshot.generations.values():
+                await self._start_composition_generation_runtime(
+                    item,
+                    snapshot,
+                    mode="formal",
+                    expected_mcp_catalog_digests=(
+                        expected_mcp_catalog_digests
+                        if item is candidate
+                        else None
+                    ),
+                )
+                started.append(item)
+        except BaseException:
+            for item in reversed(started):
+                await self._stop_composition_generation_runtime(item)
+            raise
+
+    async def _stop_snapshot_composition_runtimes(
+        self,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
+        """Stop every managed runtime before its formal Root is disposed."""
+
+        for item in reversed(tuple(snapshot.generations.values())):
+            await self._stop_composition_generation_runtime(item)
+
     async def _stop_composition_generation_runtime(
         self,
         generation: PluginGeneration,
@@ -5766,64 +5840,108 @@ class PluginManager:
         await self._stop_composition_generation_runtime(previous)
         generation.replaced_composition_runtime_generation = previous
 
-    async def _stop_shared_read_stable_runtime(
+    async def _stop_stable_root(
         self,
         generation: PluginGeneration,
-        stable_snapshot: RuntimeSnapshot,
+        stable_snapshot: RuntimeSnapshot | None,
     ) -> None:
-        """Settle the old shared-data Root and retain its generation for recovery."""
+        """Stop and dispose the old formal Root before mounting its replacement."""
+
+        if stable_snapshot is None or stable_snapshot.composition_root is None:
+            return
+        previous = self._active_generations.get(generation.plugin_id)
+        recovery_anchor = previous or next(
+            iter(stable_snapshot.generations.values()),
+            None,
+        )
+        generation.replaced_composition_runtime_generation = recovery_anchor
+        generation.formal_root_stopped = True
+        generation.formal_root_released = False
 
         # 1. Lifecycle handlers close and join plugin-owned writers.
         await self._stop_runtime_snapshot(stable_snapshot)
 
-        # 2. Exact managed runtimes stop before a fresh formal Root can start.
-        previous = self._active_generations.get(generation.plugin_id)
-        if previous is None:
-            raise RuntimeError("shared-read handoff 缺少 stable generation")
-        generation.replaced_composition_runtime_generation = previous
-        await self._stop_composition_generation_runtime(previous)
+        # 2. Exact managed runtimes and Root effects release every formal owner.
+        await self._stop_snapshot_composition_runtimes(stable_snapshot)
+        await stable_snapshot.composition_root.dispose()
+        generation.formal_root_released = True
 
-    async def _recover_shared_read_stable_runtime(
+    async def _recover_stable_root(
         self,
         generation: PluginGeneration,
         stable_snapshot: RuntimeSnapshot,
     ) -> None:
-        """Rebuild a stopped stable generation on a fresh read-write Root."""
+        """Rebuild a stopped stable generation on a fresh formal Root."""
 
         previous = generation.replaced_composition_runtime_generation
-        if previous is None:
-            raise RuntimeError("shared-read recovery 缺少 stopped stable generation")
-        old_root = stable_snapshot.composition_root
-        replacement: RuntimeSnapshot | None = None
+        if not generation.formal_root_stopped:
+            raise RuntimeError("formal Root recovery 缺少 stopped stable Root")
 
         # 1. Remove any unpublished new owner before rebuilding stable.
         candidate_snapshot = generation.runtime_snapshot
         if candidate_snapshot is not None:
             await self._stop_runtime_snapshot(candidate_snapshot)
-        await self._stop_composition_generation_runtime(generation)
+            await self._stop_snapshot_composition_runtimes(candidate_snapshot)
+        else:
+            await self._stop_composition_generation_runtime(generation)
+        if not generation.formal_root_released:
+            await self._stop_runtime_snapshot(stable_snapshot)
+            await self._stop_snapshot_composition_runtimes(stable_snapshot)
+            old_root = stable_snapshot.composition_root
+            if old_root is not None:
+                await old_root.dispose()
+            generation.formal_root_released = True
+        await self._rebuild_stable_root(previous, stable_snapshot)
+        generation.replaced_composition_runtime_generation = None
+        generation.formal_root_stopped = False
+        generation.formal_root_released = False
+
+    async def _rebuild_stable_root(
+        self,
+        stable: PluginGeneration | None,
+        stable_snapshot: RuntimeSnapshot,
+    ) -> None:
+        """Replace a terminal stable Root with a fresh formal owner."""
+
+        old_root = stable_snapshot.composition_root
+        replacement: RuntimeSnapshot | None = None
         if old_root is not None:
             await old_root.dispose()
         try:
-            # 2. Recompile formal generations without reusing the terminal old Root.
-            replacement = await self._compile_generation_snapshot(
-                previous,
-                force_fresh_composition=True,
-            )
-            await self._start_composition_generation_runtime(
-                previous,
+            # 1. Recompile formal generations without reusing the terminal old Root.
+            if stable is None:
+                composition_root, _ = await self._resolve_composition_root(
+                    {},
+                    force_fresh=True,
+                )
+                replacement = self._snapshot_compiler.compile(
+                    {},
+                    composition_root=composition_root,
+                    core_channel_definitions=self._core_channel_definitions,
+                    require_composition_ready=True,
+                )
+                replacement.tool_registry = self._compile_snapshot_tools(
+                    {},
+                    replacement.plugin_tool_catalog,
+                )
+            else:
+                replacement = await self._compile_generation_snapshot(
+                    stable,
+                    force_fresh_composition=True,
+                )
+            await self._start_snapshot_composition_runtimes(
                 replacement,
-                mode="formal",
             )
             await self._start_runtime_snapshot(replacement)
         except BaseException:
-            await self._stop_composition_generation_runtime(previous)
+            if replacement is not None:
+                await self._stop_snapshot_composition_runtimes(replacement)
             if replacement is not None:
                 await self._dispose_unreferenced_composition_root(replacement)
             raise
 
-        # 3. Replace the closed stable payload only after fresh STARTED succeeds.
+        # 2. Replace the closed stable payload only after fresh STARTED succeeds.
         _replace_snapshot_payload(stable_snapshot, replacement)
-        generation.replaced_composition_runtime_generation = None
 
     async def _restore_replaced_composition_runtime(
         self,
@@ -5863,6 +5981,7 @@ class PluginManager:
         *,
         resource: str = "composition-runtime",
         formal_effects: tuple[str, ...],
+        recovery_target: RecoveryTarget | None = None,
     ) -> None:
         """Persist one executable runtime failure without releasing its owner."""
 
@@ -5894,9 +6013,13 @@ class PluginManager:
             resource=failure_resource,
             formal_effects=formal_effects,
             recovery_action=action,
-            recovery_target=self._composition_recovery_target(
-                generation,
-                tx_id=tx_id,
+            recovery_target=(
+                recovery_target
+                if recovery_target is not None
+                else self._composition_recovery_target(
+                    generation,
+                    tx_id=tx_id,
+                )
             ),
         )
         ready = self._ready_candidate
@@ -6858,6 +6981,23 @@ def _restore_ready_pointer(
     }:
         raise RuntimeError(f"插件 artifact pointer 已被其他发布改变: {plugin_base}")
     _ = write_pointers(plugin_base, stable=previous, latest=previous)
+
+
+def _preserve_ready_pointer(
+    ready: _ReadyPluginCandidate,
+    plugin_base: Path,
+) -> None:
+    """Restore stable while retaining the validated candidate as latest."""
+
+    previous, candidate = _ready_artifact_pointers(ready, plugin_base)
+    pointers = read_pointers(plugin_base)
+    if pointers is None or (pointers.stable, pointers.latest) not in {
+        (previous, candidate),
+        (candidate, candidate),
+        (previous, previous),
+    }:
+        raise RuntimeError(f"插件 artifact pointer 已被其他发布改变: {plugin_base}")
+    _ = write_pointers(plugin_base, stable=previous, latest=candidate)
 
 
 def _ready_artifact_pointers(

--- a/docs/decisions/0046-plugin-candidate-validation-is-incremental.md
+++ b/docs/decisions/0046-plugin-candidate-validation-is-incremental.md
@@ -26,13 +26,16 @@ candidate plugin ─ incremental Root
 
 RuntimeSnapshot 把 stable 中未替换 owner 的不可变 catalog contribution 与增量 Root 的 contribution 合并。重复 Service、catalog 名称冲突、required dependency 缺失、manifest/credential 不一致仍在 latest 发布前 fail-loud。snapshot identity 只由最终逻辑拓扑、generation 与最终 catalog 内容计算，不由它物理来自一棵或两棵 Root 决定。
 
-验证期不派发 `runtime.started`/`runtime.stopping`：这两个事件代表正式 effect 准入，scheduler timer 等能力也只存在于 formal Root。候选只验证 lifecycle listener 的注册合同与拓扑；正式 Root 才在旧 owner 停止后启动。显式 promotion 仍由原 publication owner 排空 lease、销毁验证 Root、用正式路径构造并原子提交 production Root；本决定不改变 stable/latest、父 Turn 授权或恢复日志。
+验证期不派发 `runtime.started`/`runtime.stopping`：这两个事件代表正式 effect 准入，scheduler timer 等能力也只存在于 formal Root。候选只验证 lifecycle listener 的注册合同与拓扑；正式 Root 才在旧 owner 停止后启动。
+
+显式 promotion 是同一份正式数据的 owner 交接，不是数据复制，也不是让 stable 与 latest 同时挂载正式数据：publication owner 先停止旧 snapshot 接收新 lease，排空已有 lease，销毁验证 Root，再停止并销毁旧 formal Root，使它释放全部 reader、writer 和 Effect；随后新 formal Root 打开相同的 production 路径。新 Root 完整启动后才提交 stable pointer 和 snapshot。失败时 latest pointer 保留候选事实，stable pointer 不动，并用 stable generation 在相同路径重建旧 formal Root。本决定不改变父 Turn 授权或恢复日志。
 
 ## 理由
 
 - `Service provider → inject consumer` 是运行时已经拥有的依赖事实，不新增静态 `provides` 清单或第二套图。
 - 复制范围由依赖关系决定，不由插件名称、数据大小或 Akasha 特判决定。
 - `Root/Fiber/Effect` 继续拥有生命周期；overlay 只拥有一次不可变 snapshot 选择，不取得插件状态所有权。
+- `stable` 指向当前正式 owner，`latest` 指向已验证候选；双指针表达发布状态，不表示两套正式 owner 可以并存。
 - 无关 stateful 插件既不重挂载也不复制；候选真正依赖的 provider 才在隔离区重建。
 
 ## 失败与数据边界

--- a/tests/semantic/test_recursive_plugin_self_validation_trajectory.py
+++ b/tests/semantic/test_recursive_plugin_self_validation_trajectory.py
@@ -399,10 +399,16 @@ async def _run_trajectory(
                     ready_observation["candidate_tool_result"] = {"raw": preview}
         assert_recursive_candidate_ready(ready_observation)
 
-        # 5. 晋升只验证提交 finality；父 lease 在 pointer 切换后仍保持 stable。
-        promoted = await app._promote_plugin("candidate_only@lab")
+        # 5. 晋升先封住 stable admission，再等待父 lease 归还。
+        promotion = asyncio.create_task(
+            app._promote_plugin("candidate_only@lab")
+        )
+        while stable.accepting_leases:
+            await asyncio.sleep(0)
+        assert not promotion.done()
         parent_release.set()
         parent_result = await parent_handle.result()
+        promoted = await promotion
         await manager.snapshot_store.retry_drains()
         await bus.chat_lane.mark_passive_done("proof", "parent")
         parent_lane_pending = False

--- a/tests/test_plugin_composition_loader.py
+++ b/tests/test_plugin_composition_loader.py
@@ -2817,7 +2817,7 @@ async def test_cancelled_stable_batch_finishes_all_cleanup(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_v3_reload_waits_for_snapshot_lease_before_root_handoff(
+async def test_v3_reload_keeps_old_root_until_snapshot_lease_drains(
     tmp_path: Path,
 ) -> None:
     plugin_dir = _write_plugin(

--- a/tests/test_plugin_composition_loader.py
+++ b/tests/test_plugin_composition_loader.py
@@ -513,7 +513,14 @@ async def test_unrelated_candidate_does_not_mount_or_copy_stateful_plugin(
         "    ctx.data_root.mkdir(parents=True, exist_ok=True)\n"
         "    marker = ctx.data_root / 'mount-count'\n"
         "    count = int(marker.read_text()) if marker.exists() else 0\n"
-        "    marker.write_text(str(count + 1))\n",
+        "    marker.write_text(str(count + 1))\n"
+        "    writer = ctx.data_root / 'exclusive-writer'\n"
+        "    if writer.exists():\n"
+        "        raise RuntimeError('stateful writer already mounted')\n"
+        "    writer.write_text(ctx.runtime.generation_id)\n"
+        "    def cleanup():\n"
+        "        writer.unlink()\n"
+        "    await ctx.effect(lambda: cleanup, label='exclusive-writer')\n",
     )
     candidate_dir = _write_plugin(
         tmp_path / "plugins",
@@ -533,7 +540,9 @@ async def test_unrelated_candidate_does_not_mount_or_copy_stateful_plugin(
     stateful = manager.generation("stateful")
     assert stateful is not None
     marker = stateful.data_dir / "mount-count"
+    writer = stateful.data_dir / "exclusive-writer"
     assert marker.read_text() == "1"
+    assert writer.is_file()
 
     with (candidate_dir / "plugin.py").open("a", encoding="utf-8") as handle:
         handle.write("\n# candidate revision\n")
@@ -544,6 +553,7 @@ async def test_unrelated_candidate_does_not_mount_or_copy_stateful_plugin(
     assert root is not None
     assert [fiber.name for fiber in root.root_fiber.children] == ["candidate_only"]
     assert marker.read_text() == "1"
+    assert writer.is_file()
     validation_root = candidate.validation_workspace
     assert validation_root is not None
     assert not (validation_root / "memory").exists()
@@ -554,6 +564,7 @@ async def test_unrelated_candidate_does_not_mount_or_copy_stateful_plugin(
 
     assert result["publication_state"] == "committed"
     assert marker.read_text() == "2"
+    assert writer.is_file()
     assert not attempt_root.exists()
     await manager.terminate_all()
 
@@ -2806,7 +2817,7 @@ async def test_cancelled_stable_batch_finishes_all_cleanup(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_v3_reload_keeps_old_root_until_snapshot_lease_drains(
+async def test_v3_reload_waits_for_snapshot_lease_before_root_handoff(
     tmp_path: Path,
 ) -> None:
     plugin_dir = _write_plugin(
@@ -2846,7 +2857,13 @@ async def test_v3_reload_keeps_old_root_until_snapshot_lease_drains(
     candidate = await manager.prepare_candidate("reloadable")
     assert candidate is not None
 
-    result = await manager.publish_prepared("reloadable")
+    publication = asyncio.create_task(manager.publish_prepared("reloadable"))
+    while old_snapshot.accepting_leases:
+        await asyncio.sleep(0)
+    assert not publication.done()
+    assert old_generation.instance.module.disposed is False
+    await lease.release()
+    result = await publication
 
     assert result["publication_state"] == "committed"
     assert manager.current_snapshot is not old_snapshot
@@ -2856,9 +2873,6 @@ async def test_v3_reload_keeps_old_root_until_snapshot_lease_drains(
     assert active_runtime is not None
     assert active_runtime.workspace == tmp_path / "workspace"
     assert candidate.validation_workspace is None
-    assert old_generation.instance.module.disposed is False
-    await lease.release()
-    await manager._snapshot_store.retry_drains()
     assert old_generation.instance.module.disposed is True
 
     await manager.terminate_all()
@@ -3121,9 +3135,14 @@ async def test_installed_v3_candidate_rebuilds_runtime_then_promotes(
         "disposed = []\n"
         "async def apply(ctx, config):\n"
         "    workspace = str(ctx.runtime.workspace)\n"
+        "    writer = ctx.runtime.workspace / '.installed-v3-writer'\n"
+        "    if writer.exists():\n"
+        "        raise RuntimeError('installed writer already mounted')\n"
+        "    writer.write_text(ctx.runtime.generation_id, encoding='utf-8')\n"
         "    applied.append((workspace, config.marker))\n"
         "    def cleanup():\n"
         "        disposed.append(workspace)\n"
+        "        writer.unlink()\n"
         "    await ctx.effect(lambda: cleanup, label='runtime')\n"
     )
     (stable_root / "plugin.py").write_text(source, encoding="utf-8")
@@ -3211,7 +3230,26 @@ async def test_installed_v3_candidate_rebuilds_runtime_then_promotes(
         if module_name.startswith(f"{candidate.module_path}__candidate_")
     }
     assert clone_modules
-    promoted = await manager.switch_ready("installed_v3@lab")
+    original_start_runtime = manager._start_runtime_snapshot
+    formal_started_before_pointer = False
+
+    async def observe_formal_start(snapshot) -> None:
+        nonlocal formal_started_before_pointer
+        if snapshot is not stable_snapshot:
+            assert read_pointer(plugin_base, "stable") == stable_pointer
+            assert read_pointer(plugin_base, "latest") == latest_pointer
+            formal_started_before_pointer = True
+        await original_start_runtime(snapshot)
+
+    manager._start_runtime_snapshot = observe_formal_start  # type: ignore[method-assign]
+    promotion = asyncio.create_task(manager.switch_ready("installed_v3@lab"))
+    while stable_snapshot.accepting_leases:
+        await asyncio.sleep(0)
+    assert not promotion.done()
+    assert stable.instance.module.disposed == []
+    await stable_lease.release()
+    promoted = await promotion
+    assert formal_started_before_pointer
 
     assert promoted["publication_state"] == "promoted"
     promoted_snapshot = manager.current_snapshot
@@ -3243,10 +3281,8 @@ async def test_installed_v3_candidate_rebuilds_runtime_then_promotes(
     )
     assert clone_modules.isdisjoint(sys.modules)
     assert not validation_root.exists()
-    assert stable.instance.module.disposed == []
-    await stable_lease.release()
-    await manager.snapshot_store.retry_drains()
     assert stable.instance.module.disposed == [str(tmp_path / "workspace")]
+    assert (tmp_path / "workspace" / ".installed-v3-writer").exists()
 
     await manager.terminate_all()
 
@@ -3761,17 +3797,53 @@ async def test_installed_v3_shared_handoff_success_and_owner_failure(
     original_activate = manager._activate_published_generation
 
     if owner_commit_fails:
+        original_recover = manager._recover_stable_root
+        original_write_pointers = plugin_manager_module.write_pointers
+        recovery_failed = False
+        pointer_restore_failed = False
 
         def fail_owner_commit(*_args: object) -> None:
             raise RuntimeError("candidate owner commit failed")
+
+        async def fail_recovery_once(*args: object, **kwargs: object) -> None:
+            nonlocal recovery_failed
+            if not recovery_failed:
+                recovery_failed = True
+                raise RuntimeError("stable Root rebuild failed")
+            await original_recover(*args, **kwargs)  # type: ignore[arg-type]
+
+        def fail_pointer_restore_once(*args: object, **kwargs: object):
+            nonlocal pointer_restore_failed
+            if (
+                not pointer_restore_failed
+                and kwargs.get("stable") == stable_pointer
+                and kwargs.get("latest") == latest_pointer
+            ):
+                pointer_restore_failed = True
+                raise RuntimeError("stable pointer restore failed")
+            return original_write_pointers(*args, **kwargs)  # type: ignore[arg-type]
 
         monkeypatch.setattr(
             manager,
             "_activate_published_generation",
             fail_owner_commit,
         )
-        with pytest.raises(RuntimeError, match="candidate owner commit failed"):
+        monkeypatch.setattr(manager, "_recover_stable_root", fail_recovery_once)
+        monkeypatch.setattr(
+            plugin_manager_module,
+            "write_pointers",
+            fail_pointer_restore_once,
+        )
+        with pytest.raises(RuntimeError, match="formal recovery"):
             await manager.switch_ready("installed_v3@lab")
+        record = manager.reload_journal.get(candidate.reload_tx_id)
+        assert record.phase == "degraded"
+        assert record.recovery_target == "base"
+        assert read_pointer(plugin_base, "stable") == latest_pointer
+        assert read_pointer(plugin_base, "latest") == latest_pointer
+        monkeypatch.setattr(manager, "_recover_stable_root", original_recover)
+        recovered = await manager.retry_runtime_recovery("installed_v3@lab")
+        assert recovered["publication_state"] == "recovered"
     else:
         result = await manager.switch_ready("installed_v3@lab")
         assert result["publication_state"] == "promoted"
@@ -3807,7 +3879,7 @@ async def test_installed_v3_shared_handoff_success_and_owner_failure(
     assert candidate.instance.module.disposed is True
     assert candidate.scope.closed is True
     assert read_pointer(plugin_base, "stable") == stable_pointer
-    assert read_pointer(plugin_base, "latest") == stable_pointer
+    assert read_pointer(plugin_base, "latest") == latest_pointer
     assert stable.instance.module.disposed is False
     assert stable.instance.module.started_roots == [
         id(old_root.instance_token),

--- a/tests/test_plugin_composition_mcp_slots.py
+++ b/tests/test_plugin_composition_mcp_slots.py
@@ -659,9 +659,13 @@ async def test_unrelated_mcp_reload_keeps_builtin_runtimes_root_local(
             await original_stop(snapshot)
 
         monkeypatch.setattr(manager, "_stop_runtime_snapshot", gated_stop)
-        result = await manager.publish_prepared("calendar")
-        assert result["publication_state"] == "committed"
+        publication = asyncio.create_task(manager.publish_prepared("calendar"))
         await asyncio.wait_for(stop_entered.wait(), timeout=5)
+        assert not publication.done()
+        assert manager.current_snapshot is old_snapshot
+        release_stop.set()
+        result = await publication
+        assert result["publication_state"] == "committed"
         new_snapshot = manager.current_snapshot
         assert new_snapshot is not None and new_snapshot is not old_snapshot
         assert old_snapshot.lease_count == 0
@@ -681,11 +685,10 @@ async def test_unrelated_mcp_reload_keeps_builtin_runtimes_root_local(
             assert old_binding.handler is not None
             assert new_binding.handler is not None
             assert old_binding.handler is not new_binding.handler
-            assert old_binding.is_live()
+            assert not old_binding.is_live()
             assert new_binding.is_live()
 
-        # 3. Drain the old Root; only the new Root may admit later child Turns.
-        release_stop.set()
+        # 3. The old Root is closed before commit; only the new Root admits work.
         for _ in range(500):
             if not old_snapshot.plugin_tool_catalog["spawn"].is_live():
                 break
@@ -755,6 +758,50 @@ async def test_core_channel_rebind_preserves_live_mcp_tools(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_first_plugin_failure_rebuilds_core_only_formal_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(
+        tmp_path,
+        tool_registry=ToolRegistry(follow_runtime_snapshot=False),
+    )
+    await manager.bind_core_channel_definitions((_core_channel_definition(),))
+    stable_snapshot = manager.current_snapshot
+    assert stable_snapshot is not None and stable_snapshot.generations == {}
+    old_root = stable_snapshot.composition_root
+    assert old_root is not None
+
+    _ = _write_static_manager_plugin(tmp_path, "1")
+    candidate = await manager.prepare_candidate("calendar")
+    assert candidate is not None
+    original_start = manager._composition_generation_host.start  # pyright: ignore[reportPrivateUsage]
+    formal_failed = False
+
+    async def fail_formal_once(*args, **kwargs):
+        nonlocal formal_failed
+        if kwargs.get("mode") == "formal" and not formal_failed:
+            formal_failed = True
+            raise RuntimeError("first plugin formal start failed")
+        return await original_start(*args, **kwargs)
+
+    monkeypatch.setattr(
+        manager._composition_generation_host,  # pyright: ignore[reportPrivateUsage]
+        "start",
+        fail_formal_once,
+    )
+    with pytest.raises(RuntimeError, match="first plugin formal start failed"):
+        await manager.publish_prepared("calendar")
+
+    replacement = manager.current_snapshot
+    assert replacement is stable_snapshot
+    assert replacement.generations == {}
+    assert replacement.composition_root is not None
+    assert replacement.composition_root is not old_root
+    await manager.terminate_all()
+
+
+@pytest.mark.asyncio
 async def test_builtin_direct_formal_failure_recovers_stable_runtime_explicitly(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -775,7 +822,7 @@ async def test_builtin_direct_formal_failure_recovers_stable_runtime_explicitly(
         candidate = await manager.prepare_candidate("calendar")
         assert candidate is not None and candidate.reload_tx_id is not None
         original_start = manager._composition_generation_host.start  # pyright: ignore[reportPrivateUsage]
-        original_restore = manager._restore_replaced_composition_runtime  # pyright: ignore[reportPrivateUsage]
+        original_restore = manager._recover_stable_root  # pyright: ignore[reportPrivateUsage]
         formal_failed = False
         restore_failures = 0
 
@@ -791,9 +838,9 @@ async def test_builtin_direct_formal_failure_recovers_stable_runtime_explicitly(
                 raise RuntimeError("builtin candidate formal start failed")
             return await original_start(*args, **kwargs)
 
-        async def fail_stable_restore_twice(*args, **kwargs):
+        async def fail_stable_restore_once(*args, **kwargs):
             nonlocal restore_failures
-            if restore_failures < 2:
+            if restore_failures < 1:
                 restore_failures += 1
                 raise RuntimeError("builtin stable restore failed")
             return await original_restore(*args, **kwargs)
@@ -805,11 +852,11 @@ async def test_builtin_direct_formal_failure_recovers_stable_runtime_explicitly(
         )
         monkeypatch.setattr(
             manager,
-            "_restore_replaced_composition_runtime",
-            fail_stable_restore_twice,
+            "_recover_stable_root",
+            fail_stable_restore_once,
         )
 
-        with pytest.raises(RuntimeError, match="旧 stable runtime 恢复失败"):
+        with pytest.raises(RuntimeError, match="builtin candidate formal start failed"):
             await manager.publish_prepared("calendar")
 
         record = manager._reload_journal.get(  # pyright: ignore[reportPrivateUsage]
@@ -831,6 +878,55 @@ async def test_builtin_direct_formal_failure_recovers_stable_runtime_explicitly(
         assert manager._reload_journal.get(  # pyright: ignore[reportPrivateUsage]
             candidate.reload_tx_id
         ).phase == "recovered"
+    finally:
+        await manager.terminate_all()
+    assert not _port_live(18000)
+
+
+@pytest.mark.asyncio
+async def test_formal_handoff_retries_old_root_stop_before_rebuild(
+    tmp_path: Path,
+) -> None:
+    plugin_dir = _write_static_manager_plugin(tmp_path, "1")
+    entry = plugin_dir / "entry.py"
+    source = entry.read_text(encoding="utf-8")
+    source = source.replace(
+        "async def apply(ctx, config):\n",
+        "stop_attempts = 0\n"
+        "async def stop_once(_event):\n"
+        "    global stop_attempts\n"
+        "    stop_attempts += 1\n"
+        "    if stop_attempts == 1:\n"
+        "        raise RuntimeError('stable stop failed once')\n"
+        "async def apply(ctx, config):\n",
+    )
+    entry.write_text(
+        source
+        + "    from agent.plugin_composition import RUNTIME_STOPPING\n"
+        + "    await ctx.on(RUNTIME_STOPPING, stop_once)\n",
+        encoding="utf-8",
+    )
+    manager = _manager(
+        tmp_path,
+        tool_registry=ToolRegistry(follow_runtime_snapshot=False),
+    )
+    try:
+        await manager.load_all()
+        stable = manager.generation("calendar")
+        stable_snapshot = manager.current_snapshot
+        assert stable is not None and stable_snapshot is not None
+        await manager._start_runtime_snapshot(stable_snapshot)  # pyright: ignore[reportPrivateUsage]
+        assert _port_live(18000)
+
+        _upgrade_static_manager_plugin(plugin_dir, "2")
+        candidate = await manager.prepare_candidate("calendar")
+        assert candidate is not None
+        with pytest.raises(RuntimeError, match="stable stop failed once"):
+            await manager.publish_prepared("calendar")
+
+        assert manager.current_snapshot is stable_snapshot
+        assert stable.instance.module.stop_attempts == 2
+        assert _port_live(18000)
     finally:
         await manager.terminate_all()
     assert not _port_live(18000)
@@ -906,7 +1002,7 @@ async def test_installed_runtime_candidate_isolated_and_commit_failure_restores_
         assert _port_live(18000)
 
         original_host_start = manager._composition_generation_host.start  # pyright: ignore[reportPrivateUsage]
-        original_restore = manager._restore_replaced_composition_runtime  # pyright: ignore[reportPrivateUsage]
+        original_restore = manager._recover_stable_root  # pyright: ignore[reportPrivateUsage]
         formal_failed = False
         restore_failures = 0
 
@@ -924,7 +1020,7 @@ async def test_installed_runtime_candidate_isolated_and_commit_failure_restores_
 
         async def fail_stable_restore_once(*args, **kwargs):
             nonlocal restore_failures
-            if restore_failures < 2:
+            if restore_failures < 1:
                 restore_failures += 1
                 raise RuntimeError("stable runtime restore failed")
             return await original_restore(*args, **kwargs)
@@ -936,7 +1032,7 @@ async def test_installed_runtime_candidate_isolated_and_commit_failure_restores_
         )
         monkeypatch.setattr(
             manager,
-            "_restore_replaced_composition_runtime",
+            "_recover_stable_root",
             fail_stable_restore_once,
         )
         with pytest.raises(RuntimeError, match="candidate formalization 失败"):
@@ -1293,7 +1389,7 @@ async def test_watchdog_failure_revokes_ready_candidate_and_restores_base(
         pointers = read_pointers(plugin_base)
         assert pointers is not None
         assert pointers.stable == stable_pointer
-        assert pointers.latest == stable_pointer
+        assert pointers.latest == latest_pointer
         assert manager._reload_journal.get(action.tx_id).phase == "recovered"  # pyright: ignore[reportPrivateUsage]
     finally:
         await manager.terminate_all()
@@ -1787,7 +1883,7 @@ async def test_supervised_boot_reconciles_degraded_runtime_to_exact_base(
         )
         monkeypatch.setattr(
             old_manager,
-            "_restore_replaced_composition_runtime",
+            "_recover_stable_root",
             fail_restore,
         )
         with pytest.raises(RuntimeError, match="candidate formalization 失败"):
@@ -1818,7 +1914,7 @@ async def test_supervised_boot_reconciles_degraded_runtime_to_exact_base(
         pointers = read_pointers(plugin_base)
         assert pointers is not None
         assert pointers.stable == stable_pointer
-        assert pointers.latest == stable_pointer
+        assert pointers.latest == latest_pointer
         assert await asyncio.wait_for(orphan.wait(), timeout=2) != 0
         stable = new_manager.generation("calendar@lab")
         snapshot = new_manager.current_snapshot

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -1205,14 +1205,19 @@ async def test_dashboard_routes_follow_snapshot_generation(
     }
     write_dashboard("release-b")
     assert await manager.prepare_candidate("snapshot_dashboard") is not None
-    await manager.publish_prepared("snapshot_dashboard")
+    publication = asyncio.create_task(
+        manager.publish_prepared("snapshot_dashboard")
+    )
+    while old_snapshot.accepting_leases:
+        await asyncio.sleep(0)
+    assert not publication.done()
+    await old_lease.release()
+    await publication
     assert client.get("/api/dashboard/snapshot-version").json() == {
         "version": "release-b"
     }
     old_binding = old_snapshot.dashboard_bindings[0]
     assert TestClient(old_binding.app).get("/api/dashboard/snapshot-version").json() == {"version": "release-a"}  # type: ignore[attr-defined]
-    assert not (old_generation.data_dir / "dashboard-release-a-closed").exists()
-    await old_lease.release()
     await manager.snapshot_store.retry_drains()
     assert (old_generation.data_dir / "dashboard-release-a-closed").exists()
     assert old_generation.scope.closed
@@ -1313,12 +1318,17 @@ async def test_skill_body_stays_on_snapshot_generation(tmp_path: Path) -> None:
     message = cast(Any, SimpleNamespace(session_key="cli:snapshot-skill"))
     old_turn = asyncio.create_task(loop._process_with_runtime_admission(message))
     await entered.wait()
-    await manager.publish_prepared("snapshot_skill")
-    (plugin_dir / "skills-a" / "snapshot-skill" / "SKILL.md").write_text(
-        "---\ndescription: mutated\n---\nmutated\n", encoding="utf-8"
+    old_snapshot = manager.current_snapshot
+    assert old_snapshot is not None
+    publication = asyncio.create_task(
+        manager.publish_prepared("snapshot_skill")
     )
+    while old_snapshot.accepting_leases:
+        await asyncio.sleep(0)
+    assert not publication.done()
     release.set()
     assert await old_turn == "done"
+    await publication
     await loop._process_with_runtime_admission(message)
     assert seen[:2] == ["body a", "body a"]
     assert seen[2:] == ["body b", "body b"]

--- a/tests/test_scheduler_v3_shadow.py
+++ b/tests/test_scheduler_v3_shadow.py
@@ -632,8 +632,8 @@ async def test_scheduler_runtime_lifecycle_follows_hot_reloaded_stable_root(
     finally:
         lifecycle.cancel()
         _ = await asyncio.gather(lifecycle, return_exceptions=True)
-        await _eventually(lambda: active_waits() == 0)
         await manager.terminate_all()
+        await _eventually(lambda: active_waits() == 0)
         await conversation.shutdown()
         store.close()
 
@@ -708,21 +708,21 @@ async def test_scheduler_hot_reload_hands_unaccepted_job_to_new_root(
         with (plugin_dir / "plugin.py").open("a", encoding="utf-8") as handle:
             handle.write("\n# handoff fixture revision\n")
         assert await manager.prepare_candidate("scheduler") is not None
-        result = await manager.publish_prepared("scheduler")
-        assert result["publication_state"] == "committed"
+        publication = asyncio.create_task(manager.publish_prepared("scheduler"))
         await asyncio.wait_for(stop_entered.wait(), timeout=5)
+        assert not publication.done()
 
-        # 2. Fire the retired Root while stopping is gated; it must not settle state.
-        old_timer.handles[0].fire()
-        await _settled()
+        # 2. While release is gated, durable work still belongs to the old Root.
         retained = JobStore(workspace / "schedules.json").load()[0]
         assert retained.enabled is True
         assert retained.run_count == 0
         assert executions == []
         assert delivered == []
 
-        # 3. Let the old Root settle; the new Root re-arms and completes once.
+        # 3. Release the old Root; cancellation preserves work for the new Root.
         release_stop.set()
+        result = await publication
+        assert result["publication_state"] == "committed"
         await _eventually(lambda: sum(bool(timer.handles) for timer in timers) == 2)
         new_timer = next(
             timer for timer in timers if timer is not old_timer and timer.handles


### PR DESCRIPTION
## What changed

- treat plugin promotion as an exclusive ownership handoff over the same production data
- drain snapshot leases, stop lifecycle and every Root-owned managed runtime, then dispose the old formal Root before starting the replacement
- rebuild stable on a fresh Root after immediate or durable recovery failures
- preserve `stable=old` and `latest=candidate` across failed promotion and pointer recovery
- cover exclusive writers, readers, MCP/process owners, lifecycle failures, pointer failures, and core-only Roots

## Root cause

Formal promotion rebuilt a complete production Root while the previous Root still owned stateful resources such as the Akasha writer. Candidate validation was isolated correctly, but the formal handoff boundary did not release the old Root before mounting the new one.

## Validation

- `370 passed` across `tests/test_plugin_composition_*.py tests/test_plugin_manager.py`
- `git diff --check`
- independent Terra xhigh architecture review: no blocking findings