### PR TITLE
修复召回投影发布交接

### DIFF
--- a/frontend/chat/src/chat-message.ts
+++ b/frontend/chat/src/chat-message.ts
@@ -37,6 +37,7 @@ export interface ChatMessage {
   durationMs?: number;
   createdAt?: string;
   canonical?: boolean;
+  controlTurnId?: string;
   reply?: {
     messageId: string;
     role: ChatRole;

--- a/frontend/chat/src/desktop-conversation.test.mjs
+++ b/frontend/chat/src/desktop-conversation.test.mjs
@@ -21,7 +21,7 @@ test("desktop history isolates stable rows but never the active stream", () => {
 test("desktop plugin cards keep the control turn through terminal publication", () => {
   assert.match(
     conversation,
-    /message\.controlTurnId \?\? \(message\.streaming \? message\.id : undefined\)/,
+    /const pluginTurnId = message\.controlTurnId;/,
   );
   assert.equal((conversation.match(/turnId=\{pluginTurnId\}/g) ?? []).length, 3);
 });

--- a/frontend/chat/src/desktop-conversation.test.mjs
+++ b/frontend/chat/src/desktop-conversation.test.mjs
@@ -18,6 +18,14 @@ test("desktop history isolates stable rows but never the active stream", () => {
   assert.match(desktopApp, /scrollElement\.scrollTop \+= restoredAnchor\.getBoundingClientRect\(\)\.top - anchorTop/);
 });
 
+test("desktop plugin cards keep the control turn through terminal publication", () => {
+  assert.match(
+    conversation,
+    /message\.controlTurnId \?\? \(message\.streaming \? message\.id : undefined\)/,
+  );
+  assert.equal((conversation.match(/turnId=\{pluginTurnId\}/g) ?? []).length, 3);
+});
+
 test("desktop auto-scroll subscribes only to the tail message and preserves user escape", () => {
   assert.match(desktopApp, /<DesktopAutoScroll messages=\{messages\}/);
   assert.match(desktopAutoScroll, /streamStore\.subscribe\(baselineLastMessageId, listener\)/);

--- a/frontend/chat/src/desktop-conversation.tsx
+++ b/frontend/chat/src/desktop-conversation.tsx
@@ -144,7 +144,7 @@ const DesktopMessageRow = React.memo(function DesktopMessageRow({
   }, [enhancementSuspended, nearViewport]);
 
   const renderFullMessage = nearViewport || message.streaming === true;
-  const pluginTurnId = message.controlTurnId ?? (message.streaming ? message.id : undefined);
+  const pluginTurnId = message.controlTurnId;
   return (
     <>
       {followsSameRole ? <RoleDivider role={message.role} /> : null}

--- a/frontend/chat/src/desktop-conversation.tsx
+++ b/frontend/chat/src/desktop-conversation.tsx
@@ -144,6 +144,7 @@ const DesktopMessageRow = React.memo(function DesktopMessageRow({
   }, [enhancementSuspended, nearViewport]);
 
   const renderFullMessage = nearViewport || message.streaming === true;
+  const pluginTurnId = message.controlTurnId ?? (message.streaming ? message.id : undefined);
   return (
     <>
       {followsSameRole ? <RoleDivider role={message.role} /> : null}
@@ -182,7 +183,7 @@ const DesktopMessageRow = React.memo(function DesktopMessageRow({
                   name="turn.before_reasoning"
                   sessionId={activeSessionId}
                   messageId={message.streaming ? `assistant:${message.id}` : message.id}
-                  turnId={message.streaming ? message.id : undefined}
+                  turnId={pluginTurnId}
                 />
               ) : undefined}
               beforeProcessBlock={(block) => message.role === "assistant" && block.kind === "tool" ? (
@@ -190,7 +191,7 @@ const DesktopMessageRow = React.memo(function DesktopMessageRow({
                   name="turn.before_tool"
                   sessionId={activeSessionId}
                   messageId={message.streaming ? `assistant:${message.id}` : message.id}
-                  turnId={message.streaming ? message.id : undefined}
+                  turnId={pluginTurnId}
                   block={block}
                 />
               ) : null}
@@ -199,7 +200,7 @@ const DesktopMessageRow = React.memo(function DesktopMessageRow({
                   name="turn.after_answer"
                   sessionId={activeSessionId}
                   messageId={message.streaming ? `assistant:${message.id}` : message.id}
-                  turnId={message.streaming ? message.id : undefined}
+                  turnId={pluginTurnId}
                 />
               ) : undefined}
               onCopyToolDetail={(text) => {

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -4773,7 +4773,7 @@ function isPluginTurnMessage(message: ChatMessage): boolean {
 }
 
 function pluginTurnId(message: ChatMessage): string | undefined {
-  return message.controlTurnId ?? parseMobileTurnId(message.id);
+  return message.controlTurnId;
 }
 
 function toAgentBlock(block: MobileProcessBlock): AgentBlock {

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -192,6 +192,7 @@ interface MobileMessage {
   interrupted: boolean;
   durationSeconds?: number;
   attachments: MobileAttachment[];
+  controlTurnId?: string;
 }
 
 interface MobileReply {
@@ -578,6 +579,7 @@ function parseMessage(value: unknown, index: number): MobileMessage {
     interrupted: raw.interrupted === undefined ? false : requireBoolean(raw.interrupted, `messages[${index}].interrupted`),
     durationSeconds: raw.durationSeconds === undefined ? undefined : requireNumber(raw.durationSeconds, `messages[${index}].durationSeconds`),
     attachments: optionalArray(raw.attachments, `messages[${index}].attachments`, parseAttachment),
+    controlTurnId: optionalString(raw.controlTurnId, `messages[${index}].controlTurnId`),
   };
 }
 
@@ -4734,6 +4736,7 @@ function toChatMessage(message: MobileMessage): ChatMessage {
     streaming: message.streaming,
     interrupted: message.interrupted,
     durationMs: message.durationSeconds !== undefined ? message.durationSeconds * 1000 : undefined,
+    controlTurnId: message.controlTurnId,
   };
 }
 
@@ -4770,8 +4773,7 @@ function isPluginTurnMessage(message: ChatMessage): boolean {
 }
 
 function pluginTurnId(message: ChatMessage): string | undefined {
-  if (!message.streaming || !message.id.startsWith("assistant:")) return undefined;
-  return message.id.slice("assistant:".length);
+  return message.controlTurnId ?? parseMobileTurnId(message.id);
 }
 
 function toAgentBlock(block: MobileProcessBlock): AgentBlock {

--- a/frontend/chat/src/mobile-plugin-layout.test.mjs
+++ b/frontend/chat/src/mobile-plugin-layout.test.mjs
@@ -79,6 +79,13 @@ const runtimeDashboardStyles = await readFile(
   "utf8",
 );
 
+test("pending plugin projections never enter the immutable result cache", () => {
+  assert.match(
+    pluginRuntimeSource,
+    /request\.cacheKey[\s\S]*?result\.pending !== true[\s\S]*?immutableResults\.set/,
+  );
+});
+
 test("process plugin slots align with thinking and tool content", () => {
   assert.match(
     sharedStyles,

--- a/frontend/chat/src/mobile-plugin-runtime.tsx
+++ b/frontend/chat/src/mobile-plugin-runtime.tsx
@@ -360,7 +360,11 @@ export function receiveMobilePluginResult(response: MobilePluginResult) {
   try {
     const resultJson = response.resultJson ?? "{}";
     const result = JSON.parse(resultJson) as Record<string, unknown>;
-    if (request.cacheKey && Object.values(result).some((value) => value !== null)) {
+    if (
+      request.cacheKey
+      && result.pending !== true
+      && Object.values(result).some((value) => value !== null)
+    ) {
       immutableResults.set(request.cacheKey, resultJson);
     }
     request.resolve(result);

--- a/frontend/chat/src/mobile-turn-trace.test.mjs
+++ b/frontend/chat/src/mobile-turn-trace.test.mjs
@@ -35,8 +35,9 @@ test("plugin cards keep the Core turn identity after streaming ends", () => {
   assert.match(mobileSource, /controlTurnId:\s*message\.controlTurnId/);
   assert.match(
     mobileSource,
-    /return message\.controlTurnId \?\? parseMobileTurnId\(message\.id\)/,
+    /return message\.controlTurnId;/,
   );
+  assert.doesNotMatch(mobileSource, /controlTurnId \?\? parseMobileTurnId/);
 });
 
 test("full identity is session + turn + client_message_id", () => {

--- a/frontend/chat/src/mobile-turn-trace.test.mjs
+++ b/frontend/chat/src/mobile-turn-trace.test.mjs
@@ -30,6 +30,15 @@ test("turn id parses only from the non-empty assistant:<turn> messageId contract
   assert.equal(parseMobileTurnId(""), undefined);
 });
 
+test("plugin cards keep the Core turn identity after streaming ends", () => {
+  assert.match(mobileSource, /controlTurnId:\s*optionalString\(raw\.controlTurnId/);
+  assert.match(mobileSource, /controlTurnId:\s*message\.controlTurnId/);
+  assert.match(
+    mobileSource,
+    /return message\.controlTurnId \?\? parseMobileTurnId\(message\.id\)/,
+  );
+});
+
 test("full identity is session + turn + client_message_id", () => {
   const registry = new MobileTurnTraceRegistry(() => {});
   const identity = registry.registerTurnIdentity("session-1", "turn-1", "client-1");

--- a/frontend/chat/src/web-chat-data.test.mjs
+++ b/frontend/chat/src/web-chat-data.test.mjs
@@ -101,6 +101,7 @@ test("history projection owns reply, tools, media, filtering, and navigation lab
     }],
     reasoning_content: "思考",
     turn_duration_ms: "42",
+    extra: { control_turn_id: "turn:history" },
     reply_to_message_id: "7",
     reply_role: "user",
     reply_preview: "问题",
@@ -109,12 +110,17 @@ test("history projection owns reply, tools, media, filtering, and navigation lab
   const message = rowToMessage(row);
   assert.equal(message.id, "9");
   assert.equal(message.durationMs, 42);
+  assert.equal(message.controlTurnId, "turn:history");
   assert.equal(message.attachments?.[0].mediaType, "image/png");
   assert.deepEqual(message.blocks.map((block) => block.kind), ["tool", "thinking"]);
   assert.equal(message.reply?.messageId, "7");
   assert.equal(isVisibleChatRow({ id: 1, role: "user", content: "[后台任务完成]内部", }), false);
   assert.equal(sessionLabel({ key: "one", first_message_content: "a".repeat(29) }), `${"a".repeat(28)}...`);
   assert.equal(formatNavigationTime("invalid"), undefined);
+  assert.throws(
+    () => messageRows({ items: [{ id: 1, role: "assistant", content: "bad", extra: { control_turn_id: 7 } }] }, "/messages"),
+    /无效 message 行/u,
+  );
 });
 
 test("HTTP and upload failures stay explicit at the transport boundary", async () => {

--- a/frontend/chat/src/web-chat-data.ts
+++ b/frontend/chat/src/web-chat-data.ts
@@ -108,6 +108,9 @@ export function messageRows(payload: unknown, endpoint: string): MessageRow[] {
     (typeof item.id !== "string" && (typeof item.id !== "number" || !Number.isFinite(item.id)))
     || (item.role !== "user" && item.role !== "assistant")
     || typeof item.content !== "string"
+    || (item.extra !== undefined && (recordValue(item.extra) === null
+      || (recordValue(item.extra)?.control_turn_id !== undefined
+        && typeof recordValue(item.extra)?.control_turn_id !== "string")))
     || (item.reply_to_message_id !== undefined && typeof item.reply_to_message_id !== "string")
     || (item.reply_role !== undefined && item.reply_role !== "user" && item.reply_role !== "assistant")
     || (item.reply_preview !== undefined && typeof item.reply_preview !== "string")

--- a/frontend/chat/src/web-chat-message-data.ts
+++ b/frontend/chat/src/web-chat-message-data.ts
@@ -11,6 +11,9 @@ export function rowToMessage(row: MessageRow): ChatMessage {
     durationMs: numberValue(row.turn_duration_ms),
     createdAt: row.timestamp,
     canonical: true,
+    controlTurnId: typeof row.extra?.control_turn_id === "string"
+      ? row.extra.control_turn_id
+      : undefined,
     reply: row.reply_to_message_id && row.reply_role && row.reply_preview !== undefined
       ? {
         messageId: row.reply_to_message_id,

--- a/frontend/chat/src/web-chat-transport.test.mjs
+++ b/frontend/chat/src/web-chat-transport.test.mjs
@@ -89,6 +89,7 @@ test("failed terminal exposes provider error and reconciles durable messages", (
   assert.equal(error, "Error code: 429 - weekly usage limit reached");
   assert.equal(messages[0].content, "Error code: 429 - weekly usage limit reached");
   assert.equal(messages[0].streaming, false);
+  assert.equal(messages[0].controlTurnId, "turn");
   assert.deepEqual(loadedMessages, ["session"]);
 });
 
@@ -144,6 +145,7 @@ test("frame controller preserves thinking, tool, answer, and terminal lifecycle"
   assert.equal(messages.length, 1);
   assert.equal(messages[0].content, "答案");
   assert.equal(messages[0].streaming, false);
+  assert.equal(messages[0].controlTurnId, "turn");
   assert.deepEqual(messages[0].blocks.map((block) => block.kind), ["thinking", "tool"]);
   assert.equal(messages[0].blocks[1].status, "output-available");
   assert.equal(messages[0].attachments[0].mediaType, "image/png");

--- a/frontend/chat/src/web-chat-transport.ts
+++ b/frontend/chat/src/web-chat-transport.ts
@@ -227,6 +227,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
           blocks: [],
           streaming: true,
           startedAt: Date.now(),
+          controlTurnId: frame.control_turn_id,
         });
       }
       return next;
@@ -324,6 +325,7 @@ export function applyChatFrame(frame: ChatFrame, context: WebChatFrameContext): 
     blocks: blocksWithFinalThinking(message.blocks, frame.thinking),
     durationMs: frame.duration_ms ?? (message.startedAt ? Date.now() - message.startedAt : message.durationMs),
     streaming: false,
+    controlTurnId: frame.control_turn_id ?? message.controlTurnId,
   })));
   void context.loadMessages(frame.session_id);
   void context.loadSessions();

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -426,7 +426,7 @@ class AkashaMemoryEngine:
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
-        self._pending_failures: dict[str, tuple[str, str]] = {}
+        self._publication_failure: str | None = None
         self._source_generation = 0
         self._source_invalidated_error: RuntimeError | None = None
         self._staged_feedback: dict[
@@ -662,7 +662,6 @@ class AkashaMemoryEngine:
                         turn_id,
                         lanes,
                     )
-                    _ = self._pending_failures.pop(session_key, None)
                     self._pending_changed.notify_all()
         finally:
             self._commit_gate.release()
@@ -714,10 +713,10 @@ class AkashaMemoryEngine:
                         query_id=pending.ticket.turn_id,
                         records=pending.records,
                     )
-                failure = self._pending_failures.get(session_key)
-                if failure is not None and failure[0] == turn_id:
+                if self._publication_failure is not None:
                     raise RuntimeError(
-                        f"Akasha recall publication failed: {failure[1]}"
+                        "Akasha recall publication failed: "
+                        f"{self._publication_failure}"
                     )
                 remaining = deadline - monotonic()
                 if remaining <= 0.0:
@@ -1446,7 +1445,6 @@ class AkashaMemoryEngine:
             if self._pending:
                 self._pending.clear()
                 self._pending_changed.notify_all()
-            self._pending_failures.clear()
 
         # 3. 以 canonical source 全量替换 turn 派生状态。
         try:
@@ -1497,13 +1495,9 @@ class AkashaMemoryEngine:
             await asyncio.to_thread(self._publish_staged, staged)
         except BaseException as error:
             with self._pending_changed:
-                if pending is not None and self._pending.get(session_key) is pending:
-                    _ = self._pending.pop(session_key)
-                    self._pending_failures[session_key] = (
-                        pending.turn_id,
-                        str(error),
-                    )
-                    self._pending_changed.notify_all()
+                self._publication_failure = str(error) or type(error).__name__
+                self._pending.clear()
+                self._pending_changed.notify_all()
             raise
         else:
             with self._pending_changed:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1353,7 +1353,6 @@ class AkashaMemoryEngine:
                     )
                     selected_ticket = None
                     if self._pending.get(event.session_key) is pending:
-                        _ = self._pending.pop(event.session_key, None)
                         selected_ticket = None if pending is None else pending.ticket
                     staged = self._runtime.stage_from_source(
                         user_message_id=user_id,
@@ -1376,7 +1375,11 @@ class AkashaMemoryEngine:
                 **identity,
             )
             self._publish_task = asyncio.create_task(
-                asyncio.to_thread(self._publish_staged, staged),
+                self._publish_staged_and_release_pending(
+                    staged,
+                    event.session_key,
+                    pending,
+                ),
                 name="akasha-publish-staged",
             )
             _milestone("akasha.publish_scheduled", **identity)
@@ -1473,6 +1476,20 @@ class AkashaMemoryEngine:
 
         with self._lock:
             self._runtime.publish_staged(staged)
+
+    async def _publish_staged_and_release_pending(
+        self,
+        staged: StagedOnlineCommit,
+        session_key: str,
+        pending: PendingRetrieval | None,
+    ) -> None:
+        """Release the frozen recall only after every projection is visible."""
+
+        await asyncio.to_thread(self._publish_staged, staged)
+        with self._pending_changed:
+            if pending is not None and self._pending.get(session_key) is pending:
+                _ = self._pending.pop(session_key)
+                self._pending_changed.notify_all()
 
     def _require_valid_source(self) -> None:
         if self._source_invalidated_error is not None:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -426,6 +426,7 @@ class AkashaMemoryEngine:
         self._commit_gate = asyncio.Lock()
         self._publish_task: asyncio.Task[None] | None = None
         self._pending: dict[str, PendingRetrieval] = {}
+        self._pending_failures: dict[str, tuple[str, str]] = {}
         self._source_generation = 0
         self._source_invalidated_error: RuntimeError | None = None
         self._staged_feedback: dict[
@@ -661,6 +662,7 @@ class AkashaMemoryEngine:
                         turn_id,
                         lanes,
                     )
+                    _ = self._pending_failures.pop(session_key, None)
                     self._pending_changed.notify_all()
         finally:
             self._commit_gate.release()
@@ -711,6 +713,11 @@ class AkashaMemoryEngine:
                     return ActiveRecallSnapshot(
                         query_id=pending.ticket.turn_id,
                         records=pending.records,
+                    )
+                failure = self._pending_failures.get(session_key)
+                if failure is not None and failure[0] == turn_id:
+                    raise RuntimeError(
+                        f"Akasha recall publication failed: {failure[1]}"
                     )
                 remaining = deadline - monotonic()
                 if remaining <= 0.0:
@@ -1439,6 +1446,7 @@ class AkashaMemoryEngine:
             if self._pending:
                 self._pending.clear()
                 self._pending_changed.notify_all()
+            self._pending_failures.clear()
 
         # 3. 以 canonical source 全量替换 turn 派生状态。
         try:
@@ -1485,11 +1493,23 @@ class AkashaMemoryEngine:
     ) -> None:
         """Release the frozen recall only after every projection is visible."""
 
-        await asyncio.to_thread(self._publish_staged, staged)
-        with self._pending_changed:
-            if pending is not None and self._pending.get(session_key) is pending:
-                _ = self._pending.pop(session_key)
-                self._pending_changed.notify_all()
+        try:
+            await asyncio.to_thread(self._publish_staged, staged)
+        except BaseException as error:
+            with self._pending_changed:
+                if pending is not None and self._pending.get(session_key) is pending:
+                    _ = self._pending.pop(session_key)
+                    self._pending_failures[session_key] = (
+                        pending.turn_id,
+                        str(error),
+                    )
+                    self._pending_changed.notify_all()
+            raise
+        else:
+            with self._pending_changed:
+                if pending is not None and self._pending.get(session_key) is pending:
+                    _ = self._pending.pop(session_key)
+                    self._pending_changed.notify_all()
 
     def _require_valid_source(self) -> None:
         if self._source_invalidated_error is not None:

--- a/plugins/akasha/engine.py
+++ b/plugins/akasha/engine.py
@@ -1177,7 +1177,8 @@ class AkashaMemoryEngine:
                     skipped = True
             finally:
                 self._source_event_gate.release()
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as error:
+            self._fail_publication(error)
             _milestone(
                 "akasha.turn_commit.cancelled",
                 duration_ms=(perf_counter() - total_started) * 1000,
@@ -1185,7 +1186,8 @@ class AkashaMemoryEngine:
                 **identity,
             )
             raise
-        except Exception:
+        except Exception as error:
+            self._fail_publication(error)
             _milestone(
                 "akasha.turn_commit.error",
                 duration_ms=(perf_counter() - total_started) * 1000,
@@ -1494,16 +1496,22 @@ class AkashaMemoryEngine:
         try:
             await asyncio.to_thread(self._publish_staged, staged)
         except BaseException as error:
-            with self._pending_changed:
-                self._publication_failure = str(error) or type(error).__name__
-                self._pending.clear()
-                self._pending_changed.notify_all()
+            self._fail_publication(error)
             raise
         else:
             with self._pending_changed:
                 if pending is not None and self._pending.get(session_key) is pending:
                     _ = self._pending.pop(session_key)
                     self._pending_changed.notify_all()
+
+    def _fail_publication(self, error: BaseException) -> None:
+        """Fail the global projection fence and retire every active handoff."""
+
+        with self._pending_changed:
+            if self._publication_failure is None:
+                self._publication_failure = str(error) or type(error).__name__
+            self._pending.clear()
+            self._pending_changed.notify_all()
 
     def _require_valid_source(self) -> None:
         if self._source_invalidated_error is not None:

--- a/plugins/akasha/inspector.py
+++ b/plugins/akasha/inspector.py
@@ -427,6 +427,12 @@ class AkashaInspectorReader:
                     AS activation_capture_available,
                 recall.query_turn_node_id IS NOT NULL
                     AS recall_capture_available,
+                EXISTS (
+                    SELECT 1
+                    FROM sparse.turn_dense AS query_dense
+                    WHERE query_dense.turn_id = turn.turn_id
+                      AND query_dense.field = 'user'
+                ) AS projection_ready,
                 COALESCE(
                     activation.completion_support,
                     (
@@ -485,6 +491,7 @@ class AkashaInspectorReader:
             item["activation_capture_available"]
         )
         item["recall_capture_available"] = bool(item["recall_capture_available"])
+        item["projection_ready"] = bool(item["projection_ready"])
         return item
 
     @staticmethod

--- a/plugins/akasha/mobile_ui.js
+++ b/plugins/akasha/mobile_ui.js
@@ -139,24 +139,25 @@ function mountRecall(host, context) {
         { cache: activeMessage ? "none" : "immutable", transport: "https" },
       );
       if (!active) return;
-      if (result.pending === true) {
-        host.innerHTML = '<p class="akasha-mobile-loading">记忆生成中…</p>';
-        await waitToRetry();
-        continue;
-      }
       const left = Array.isArray(result.left) ? result.left : [];
       const right = Array.isArray(result.right) ? result.right : [];
       const toolLeft = Array.isArray(result.tool_left) ? result.tool_left : [];
       const toolRight = Array.isArray(result.tool_right) ? result.tool_right : [];
       const recallCaptured = result.recall_capture_available !== false;
-      host.innerHTML = `
-        <div class="akasha-mobile-recall-group">
-          ${recallSection("左脑 · 精确回忆", left, "precise")}
-          ${recallSection("右脑 · 模式补全", right, "completion", recallCaptured)}
-          ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft, "precise") : ""}
-          ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight, "completion") : ""}
-        </div>
-      `;
+      if (result.pending !== true || result.recall_capture_available === true) {
+        host.innerHTML = `
+          <div class="akasha-mobile-recall-group">
+            ${recallSection("左脑 · 精确回忆", left, "precise")}
+            ${recallSection("右脑 · 模式补全", right, "completion", recallCaptured)}
+            ${toolLeft.length ? recallSection("工具回忆 · 精确回忆", toolLeft, "precise") : ""}
+            ${toolRight.length ? recallSection("工具回忆 · 模式补全", toolRight, "completion") : ""}
+          </div>
+        `;
+      }
+      if (result.pending === true) {
+        await waitToRetry();
+        continue;
+      }
       return;
     }
   };

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -322,7 +322,7 @@ class _AkashaMobileQuery:
             pending = self._runtime.wait_active_recall(session_id, turn_id)
             if pending is None:
                 return _empty_mobile_recall(pending=True)
-            return _active_mobile_recall(pending)
+            return _active_mobile_recall(pending, publishing=False)
 
         # 3. Persisted messages read only Akasha's deterministic sidecars.
         item = (
@@ -337,7 +337,7 @@ class _AkashaMobileQuery:
             return (
                 _empty_mobile_recall(pending=True)
                 if pending is None
-                else _active_mobile_recall(pending)
+                else _active_mobile_recall(pending, publishing=True)
             )
         if not cast(bool, item["projection_ready"]):
             if turn_id is None:
@@ -346,7 +346,7 @@ class _AkashaMobileQuery:
             return (
                 _empty_mobile_recall(pending=True)
                 if pending is None
-                else _active_mobile_recall(pending)
+                else _active_mobile_recall(pending, publishing=True)
             )
         return {
             "schema": _MOBILE_RECALL_SCHEMA,
@@ -730,12 +730,17 @@ def _empty_mobile_recall(*, pending: bool = False) -> dict[str, object]:
     }
 
 
-def _active_mobile_recall(pending: ActiveRecallView) -> dict[str, object]:
+def _active_mobile_recall(
+    pending: ActiveRecallView,
+    *,
+    publishing: bool,
+) -> dict[str, object]:
     """Project the frozen active lanes through the stable card schema."""
 
     return {
         "schema": _MOBILE_RECALL_SCHEMA,
         "query_id": pending.query_id,
+        "pending": publishing,
         "recall_capture_available": True,
         "left": _mobile_recall_records(pending.dense),
         "right": _mobile_recall_records(pending.completion),

--- a/plugins/akasha/plugin.py
+++ b/plugins/akasha/plugin.py
@@ -322,15 +322,7 @@ class _AkashaMobileQuery:
             pending = self._runtime.wait_active_recall(session_id, turn_id)
             if pending is None:
                 return _empty_mobile_recall(pending=True)
-            return {
-                "schema": _MOBILE_RECALL_SCHEMA,
-                "query_id": pending.query_id,
-                "recall_capture_available": True,
-                "left": _mobile_recall_records(pending.dense),
-                "right": _mobile_recall_records(pending.completion),
-                "tool_left": [],
-                "tool_right": [],
-            }
+            return _active_mobile_recall(pending)
 
         # 3. Persisted messages read only Akasha's deterministic sidecars.
         item = (
@@ -339,7 +331,23 @@ class _AkashaMobileQuery:
             else self._inspector().latest_for_session(session_id)
         )
         if item is None:
-            return _empty_mobile_recall()
+            if turn_id is None:
+                return _empty_mobile_recall()
+            pending = self._runtime.wait_active_recall(session_id, turn_id)
+            return (
+                _empty_mobile_recall(pending=True)
+                if pending is None
+                else _active_mobile_recall(pending)
+            )
+        if not cast(bool, item["projection_ready"]):
+            if turn_id is None:
+                return _empty_mobile_recall(pending=True)
+            pending = self._runtime.wait_active_recall(session_id, turn_id)
+            return (
+                _empty_mobile_recall(pending=True)
+                if pending is None
+                else _active_mobile_recall(pending)
+            )
         return {
             "schema": _MOBILE_RECALL_SCHEMA,
             "query_id": item["query_id"],
@@ -717,6 +725,20 @@ def _empty_mobile_recall(*, pending: bool = False) -> dict[str, object]:
         "recall_capture_available": False,
         "left": [],
         "right": [],
+        "tool_left": [],
+        "tool_right": [],
+    }
+
+
+def _active_mobile_recall(pending: ActiveRecallView) -> dict[str, object]:
+    """Project the frozen active lanes through the stable card schema."""
+
+    return {
+        "schema": _MOBILE_RECALL_SCHEMA,
+        "query_id": pending.query_id,
+        "recall_capture_available": True,
+        "left": _mobile_recall_records(pending.dense),
+        "right": _mobile_recall_records(pending.completion),
         "tool_left": [],
         "tool_right": [],
     }

--- a/tests/test_akasha_mobile_ui.mjs
+++ b/tests/test_akasha_mobile_ui.mjs
@@ -29,10 +29,11 @@ test("Akasha contributes current-turn recall and a mobile Inspector", () => {
   assert.match(source, /context\.query\("inspector\.detail"/);
 });
 
-test("active recall does not cache a temporary empty projection", () => {
+test("active recall stays visible while an unpublished projection retries", () => {
   assert.match(source, /activeMessage \? "none" : "immutable"/);
+  assert.match(source, /result\.pending !== true \|\| result\.recall_capture_available === true/);
   assert.match(source, /if \(result\.pending === true\)[\s\S]*?continue;/);
-  assert.match(source, /记忆生成中…/);
+  assert.doesNotMatch(source, /result\.pending === true[\s\S]{0,120}记忆生成中/);
 });
 
 test("recall entries survive the Akasha user field migration", () => {

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -1066,7 +1066,17 @@ async def test_online_turn_recall_and_replay_share_one_state(
         ]
     )
 
-    # 4. Commit the second turn and compare online learned state with replay.
+    # 4. Keep the exact prompt lanes readable until both sidecars are published.
+    publish_entered = threading.Event()
+    release_publish = threading.Event()
+    publish_staged = engine._publish_staged  # noqa: SLF001
+
+    def blocked_publish(staged: object) -> None:
+        publish_entered.set()
+        assert release_publish.wait(1.0)
+        publish_staged(cast(Any, staged))
+
+    monkeypatch.setattr(engine, "_publish_staged", blocked_publish)
     _append_turn(
         tmp_path / "sessions.db",
         sequence=2,
@@ -1083,7 +1093,21 @@ async def test_online_turn_recall_and_replay_share_one_state(
             started=next_time,
         )
     )
+    assert await asyncio.to_thread(publish_entered.wait, 1.0)
+    assert engine._pending["test:one"] is pending  # noqa: SLF001
+    during_publish = mobile_query(
+        "recall.current",
+        {"message_id": "message:3"},
+        session_id="test:one",
+        turn_id=active_turn_id,
+    )
+    assert during_publish["left"] == active_mobile["left"]
+    assert during_publish["right"] == active_mobile["right"]
+    release_publish.set()
     await engine._wait_for_publication()  # noqa: SLF001
+    assert "test:one" not in engine._pending  # noqa: SLF001
+
+    # 5. Compare the fully published online learned state with replay.
     replay = tmp_path / "memory" / "replay.db"
     rebuild_memory(
         tmp_path / "memory" / "akasha-v2-index.db",
@@ -1099,7 +1123,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
             "SELECT COUNT(*) FROM activation_runs"
         ).fetchone() == (0,)
 
-    # 5. Inspector reconstructs the exact prior-only lanes without writes.
+    # 6. Inspector reconstructs the exact prior-only lanes without writes.
     _write_inspector_config(tmp_path)
     before_memory = logical_state_sha256(tmp_path / "memory" / "akasha.db")
     reader = AkashaInspectorReader(
@@ -1117,6 +1141,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert detail["query_text"] == "alpha follow"
     assert detail["assistant_text"] == "second answer"
     assert detail["recall_capture_available"] is True
+    assert detail["projection_ready"] is True
     assert detail["left_count"] == 1
     assert detail["tool_left_count"] == 1
     assert detail["tool_right_count"] == 1
@@ -1127,7 +1152,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
     assert detail["activation_capture_available"] is False
     assert before_memory == logical_state_sha256(tmp_path / "memory" / "akasha.db")
 
-    # 6. The desktop API exposes the same state through read-only routes.
+    # 7. The desktop API exposes the same state through read-only routes.
     app = FastAPI()
     register_dashboard(
         app,
@@ -1152,7 +1177,7 @@ async def test_online_turn_recall_and_replay_share_one_state(
         assert api_detail.status_code == 200
         assert api_detail.json()["left_count"] == 1
 
-    # 7. Mobile projections resolve the same committed assistant message.
+    # 8. Mobile projections resolve the same committed assistant message.
     mobile = mobile_query(
         "recall.current",
         {"message_id": "message:3"},

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -782,6 +782,59 @@ def test_active_mobile_recall_marks_temporary_absence_as_pending() -> None:
     assert _empty_mobile_recall(pending=True)["pending"] is True
 
 
+@pytest.mark.asyncio
+async def test_failed_publication_retires_active_recall_and_fails_loud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not present a failed sidecar publication as a valid active handoff."""
+
+    _create_sessions(tmp_path / "sessions.db")
+    engine = _engine(tmp_path)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    turn_id = "turn:publish-failure"
+    await engine.query(
+        MemoryQuery(
+            text="alpha",
+            intent="context",
+            scope=MemoryScope(
+                session_key="test:one",
+                channel="test",
+                chat_id="one",
+            ),
+            context={"history": [], "turn_id": turn_id},
+            timestamp=started,
+        )
+    )
+    _append_turn(
+        tmp_path / "sessions.db",
+        sequence=0,
+        user="alpha",
+        assistant="answer",
+        started=started,
+    )
+
+    def fail_publish(_staged: object) -> None:
+        raise RuntimeError("publish boom")
+
+    monkeypatch.setattr(engine, "_publish_staged", fail_publish)
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=0,
+            user="alpha",
+            assistant="answer",
+            started=started,
+        )
+    )
+    with pytest.raises(RuntimeError, match="publish boom"):
+        await engine._wait_for_publication()  # noqa: SLF001
+    assert "test:one" not in engine._pending  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="recall publication failed: publish boom"):
+        engine.wait_for_active_recall("test:one", turn_id, timeout=0)
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
+
+
 def test_suffix_loader_and_appendable_features_match_full_replay(
     tmp_path: Path,
 ) -> None:
@@ -1103,9 +1156,19 @@ async def test_online_turn_recall_and_replay_share_one_state(
     )
     assert during_publish["left"] == active_mobile["left"]
     assert during_publish["right"] == active_mobile["right"]
+    assert during_publish["pending"] is True
     release_publish.set()
     await engine._wait_for_publication()  # noqa: SLF001
     assert "test:one" not in engine._pending  # noqa: SLF001
+    published_mobile = mobile_query(
+        "recall.current",
+        {"message_id": "message:3"},
+        session_id="test:one",
+        turn_id=active_turn_id,
+    )
+    assert published_mobile.get("pending") is not True
+    assert len(cast(list[object], published_mobile["tool_left"])) == 1
+    assert len(cast(list[object], published_mobile["tool_right"])) == 1
 
     # 5. Compare the fully published online learned state with replay.
     replay = tmp_path / "memory" / "replay.db"

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -806,6 +806,21 @@ async def test_failed_publication_retires_active_recall_and_fails_loud(
             timestamp=started,
         )
     )
+    other_turn_id = "turn:other-session"
+    await engine.query(
+        MemoryQuery(
+            text="beta",
+            intent="context",
+            scope=MemoryScope(
+                session_key="test:two",
+                channel="test",
+                chat_id="two",
+            ),
+            context={"history": [], "turn_id": other_turn_id},
+            timestamp=started,
+        )
+    )
+    assert set(engine._pending) == {"test:one", "test:two"}  # noqa: SLF001
     _append_turn(
         tmp_path / "sessions.db",
         sequence=0,
@@ -831,6 +846,74 @@ async def test_failed_publication_retires_active_recall_and_fails_loud(
     assert "test:one" not in engine._pending  # noqa: SLF001
     with pytest.raises(RuntimeError, match="recall publication failed: publish boom"):
         engine.wait_for_active_recall("test:one", turn_id, timeout=0)
+    with pytest.raises(RuntimeError, match="recall publication failed: publish boom"):
+        engine.wait_for_active_recall("test:two", other_turn_id, timeout=0)
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_cancelled_publication_clears_every_active_recall(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Treat cancellation of the global publication fence as a global failure."""
+
+    _create_sessions(tmp_path / "sessions.db")
+    engine = _engine(tmp_path)
+    started_at = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    turn_id = "turn:cancelled-publication"
+    await engine.query(
+        MemoryQuery(
+            text="alpha",
+            intent="context",
+            scope=MemoryScope(
+                session_key="test:one",
+                channel="test",
+                chat_id="one",
+            ),
+            context={"history": [], "turn_id": turn_id},
+            timestamp=started_at,
+        )
+    )
+    _append_turn(
+        tmp_path / "sessions.db",
+        sequence=0,
+        user="alpha",
+        assistant="answer",
+        started=started_at,
+    )
+    publish_started = threading.Event()
+    release_publish = threading.Event()
+    publish_finished = threading.Event()
+
+    def blocked_publish(_staged: object) -> None:
+        publish_started.set()
+        try:
+            assert release_publish.wait(1.0)
+        finally:
+            publish_finished.set()
+
+    monkeypatch.setattr(engine, "_publish_staged", blocked_publish)
+    await engine._on_turn_committed(  # noqa: SLF001
+        _event(
+            sequence=0,
+            user="alpha",
+            assistant="answer",
+            started=started_at,
+        )
+    )
+    assert await asyncio.to_thread(publish_started.wait, 1.0)
+    publish_task = engine._publish_task  # noqa: SLF001
+    assert publish_task is not None
+    publish_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await engine._wait_for_publication()  # noqa: SLF001
+    assert engine._pending == {}  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="recall publication failed: CancelledError"):
+        engine.wait_for_active_recall("test:one", turn_id, timeout=0)
+    release_publish.set()
+    assert await asyncio.to_thread(publish_finished.wait, 1.0)
     engine._runtime.close()  # noqa: SLF001
     engine._embedding_store.close()  # noqa: SLF001
 

--- a/tests/test_akasha_plugin.py
+++ b/tests/test_akasha_plugin.py
@@ -853,6 +853,87 @@ async def test_failed_publication_retires_active_recall_and_fails_loud(
 
 
 @pytest.mark.asyncio
+async def test_failed_staging_retires_every_active_recall_and_rpc_fails_loud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retire every handoff when durable staging fails before publication."""
+
+    _create_sessions(tmp_path / "sessions.db")
+    engine = _engine(tmp_path)
+    started = datetime(2026, 7, 6, 8, tzinfo=timezone.utc)
+    turn_id = "turn:stage-failure"
+    other_turn_id = "turn:other-session"
+    for session_key, chat_id, text, active_turn_id in (
+        ("test:one", "one", "alpha", turn_id),
+        ("test:two", "two", "beta", other_turn_id),
+    ):
+        await engine.query(
+            MemoryQuery(
+                text=text,
+                intent="context",
+                scope=MemoryScope(
+                    session_key=session_key,
+                    channel="test",
+                    chat_id=chat_id,
+                ),
+                context={"history": [], "turn_id": active_turn_id},
+                timestamp=started,
+            )
+        )
+    _append_turn(
+        tmp_path / "sessions.db",
+        sequence=0,
+        user="alpha",
+        assistant="answer",
+        started=started,
+    )
+
+    def fail_stage(**_kwargs: object) -> None:
+        raise RuntimeError("stage exploded")
+
+    monkeypatch.setattr(engine._runtime, "stage_from_source", fail_stage)  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="stage exploded"):
+        await engine._on_turn_committed(  # noqa: SLF001
+            _event(
+                sequence=0,
+                user="alpha",
+                assistant="answer",
+                started=started,
+            )
+        )
+
+    assert engine._pending == {}  # noqa: SLF001
+    for session_key, active_turn_id in (
+        ("test:one", turn_id),
+        ("test:two", other_turn_id),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="recall publication failed: stage exploded",
+        ):
+            engine.wait_for_active_recall(session_key, active_turn_id, timeout=0)
+
+    mobile_query = _AkashaMobileQuery(
+        _runtime_handle(engine),
+        memory_root=tmp_path / "memory",
+        data_root=builtin_plugin_data_dir("akasha", tmp_path),
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="recall publication failed: stage exploded",
+    ):
+        mobile_query(
+            "recall.current",
+            {"message_id": "message:1"},
+            session_id="test:one",
+            turn_id=turn_id,
+        )
+    engine._runtime.close()  # noqa: SLF001
+    engine._embedding_store.close()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_cancelled_publication_clears_every_active_recall(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 问题

Akasha 在 memory sidecar 已发布、sparse sidecar 尚未发布的短窗口内，会把部分状态重建成左脑 0 / 右脑 13；终态消息又会丢失 control turn 身份，客户端因此缓存不完整结果。

## 修改

- 冻结的 active recall 只在完整投影发布成功后释放
- Inspector 明确区分投影尚未就绪与合法空召回
- Web 与 Mobile Web 延续 Core 原有的 control turn 身份，不新增状态 owner
- 发布窗口内继续展示查询时已经冻结的实际 prompt lanes

## 验证

- `pytest -q tests/test_akasha_plugin.py`：58 passed
- `npm run test:desktop-navigation`：57 passed
- `npm run test:mobile-web-state`：138 passed
- `npm run build:chat`：通过
- `npm run build:mobile-web`：通过
- `npm run typecheck`：通过
- `npm run lint`：本次文件无新增错误；全仓仍有 `frontend/chat/src/kaomoji-markdown.ts` 的 3 个既有错误
