### PR TITLE
Fix failed turn retry semantics

### DIFF
--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -73,6 +73,8 @@ _PRIOR_INPUT_COUNT = "priorInputCount"
 _INTERACTION_REJECTED = "interactionRejected"
 _FRESH_INTERACTION = "freshInteraction"
 _SUPERSEDES_INTERACTION_ID = "supersedesInteractionId"
+_RETRY_SOURCE_CLIENT_MESSAGE_ID = "retrySourceClientMessageId"
+_RETRY_CLIENT_MESSAGE_ID = "retryClientMessageId"
 
 
 def _validate_turn_request_metadata(request: TurnRequest) -> None:
@@ -82,6 +84,8 @@ def _validate_turn_request_metadata(request: TurnRequest) -> None:
         _INTERACTION_REJECTED,
         _FRESH_INTERACTION,
         _SUPERSEDES_INTERACTION_ID,
+        _RETRY_SOURCE_CLIENT_MESSAGE_ID,
+        _RETRY_CLIENT_MESSAGE_ID,
     )
     forged = next((field for field in reserved if field in request.metadata), None)
     if forged is not None:
@@ -337,6 +341,7 @@ class ConversationRuntime:
         live_media: tuple[str, ...] = (),
         execution_scope: TurnExecutionScope | None = None,
         fresh_interaction: bool = False,
+        retry_source_client_message_id: str | None = None,
     ) -> TurnHandle:
         """拒绝 active thread，并仅把本次进程可用的 media 交给 executor。"""
 
@@ -350,19 +355,43 @@ class ConversationRuntime:
                 raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
             turn_id = new_turn_id()
             recoverable_attempts = self._open_interaction_attempts(request.thread_id)
+            if fresh_interaction and retry_source_client_message_id is not None:
+                raise ValueError("fresh interaction 不能同时重试既有输入")
             previous_attempts = [] if fresh_interaction else recoverable_attempts
             prior_inputs = self._attempt_user_inputs(previous_attempts)
+            retrying = retry_source_client_message_id is not None
+            replay_attempts = previous_attempts
+            if retrying:
+                prior_inputs, replay_attempts, request = self._prepare_retry(
+                    request,
+                    previous_attempts,
+                    prior_inputs,
+                    retry_source_client_message_id,
+                )
             attempt_replay = replay_messages(
-                previous_attempts,
+                replay_attempts,
                 tool_group_from_item=ConversationRuntime._tool_group_from_item,
             )
-            prior_tool_chain = self._attempt_tool_chain(previous_attempts)
+            prior_tool_chain = self._attempt_tool_chain(replay_attempts)
             effective_request = _build_effective_turn_request(
                 request,
                 turn_id=turn_id,
                 previous_attempts=previous_attempts,
                 prior_inputs=prior_inputs,
             )
+            if retrying:
+                effective_request = TurnRequest(
+                    effective_request.thread_id,
+                    effective_request.input,
+                    {
+                        **effective_request.metadata,
+                        _PRIOR_INPUT_COUNT: len(prior_inputs) - 1,
+                        _RETRY_SOURCE_CLIENT_MESSAGE_ID: retry_source_client_message_id,
+                        _RETRY_CLIENT_MESSAGE_ID: self._request_client_message_id(
+                            request
+                        ),
+                    },
+                )
             if fresh_interaction:
                 metadata: dict[str, Any] = {
                     **effective_request.metadata,
@@ -386,11 +415,19 @@ class ConversationRuntime:
 
             # 2. 先持久化 queued handle；失败时只回滚本轮 admission token。
             try:
-                initial_input = self._build_turn_user_input(
-                    effective_request,
-                    ordinal=len(prior_inputs),
+                initial_input = (
+                    None
+                    if retrying
+                    else self._build_turn_user_input(
+                        effective_request,
+                        ordinal=len(prior_inputs),
+                    )
                 )
-                user_item = self._user_input_item(initial_input)
+                user_item = (
+                    None
+                    if initial_input is None
+                    else self._user_input_item(initial_input)
+                )
                 record = self._store.create_turn(
                     TurnRecord(
                         id=turn_id,
@@ -398,7 +435,7 @@ class ConversationRuntime:
                         status=TurnStatus.QUEUED,
                         input=effective_request.input,
                         metadata=dict(effective_request.metadata),
-                        items=[user_item],
+                        items=[] if user_item is None else [user_item],
                         usage=None,
                         error=None,
                         created_at=datetime.now(UTC),
@@ -410,7 +447,11 @@ class ConversationRuntime:
             self._commit_admission_token(admission_token, turn_id, request_bytes)
             self._active_by_thread[request.thread_id] = turn_id
             self._thread_idle[request.thread_id] = asyncio.Event()
-            self._consumed_inputs[turn_id] = [*prior_inputs, initial_input]
+            self._consumed_inputs[turn_id] = (
+                list(prior_inputs)
+                if initial_input is None
+                else [*prior_inputs, initial_input]
+            )
             source = _RuntimeInputLock(self, turn_id)
             self._turn_input_sources[turn_id] = source
             loop = asyncio.get_running_loop()
@@ -427,7 +468,8 @@ class ConversationRuntime:
                     "turn/queued", request.thread_id, turn_id, turn=record.to_dict()
                 )
             )
-            self._publish_user_item(request.thread_id, turn_id, user_item)
+            if user_item is not None:
+                self._publish_user_item(request.thread_id, turn_id, user_item)
             execution_request = (
                 TurnRequest(
                     effective_request.thread_id,
@@ -733,6 +775,74 @@ class ConversationRuntime:
                     )
                 )
         return inputs
+
+    @staticmethod
+    def _request_client_message_id(request: TurnRequest) -> str:
+        """Read the current transport identity from the validated inbound metadata."""
+
+        inbound = request.metadata.get("inboundMetadata", {})
+        if not isinstance(inbound, dict):
+            raise ValueError("control inboundMetadata 必须是对象")
+        value = inbound.get("client_message_id")
+        if not isinstance(value, str) or not value:
+            raise ValueError("retry turn 缺少当前 client_message_id")
+        return value
+
+    @staticmethod
+    def _prepare_retry(
+        request: TurnRequest,
+        attempts: list[TurnRecord],
+        prior_inputs: list[TurnUserInput],
+        source_client_message_id: str,
+    ) -> tuple[list[TurnUserInput], list[TurnRecord], TurnRequest]:
+        """Reuse the latest logical input while starting a new execution attempt."""
+
+        if not attempts or not prior_inputs:
+            raise ValueError("没有可重试的 logical turn")
+        latest = attempts[-1]
+        if (
+            latest.status is not TurnStatus.FAILED
+            or latest.error is None
+            or latest.error.retryable is not True
+        ):
+            raise ValueError("只有最新的可重试 failed attempt 可以重试")
+
+        source_index = next(
+            (
+                index
+                for index in range(len(attempts) - 1, -1, -1)
+                if any(
+                    item.kind is TurnItemKind.USER_MESSAGE
+                    for item in attempts[index].items
+                )
+            ),
+            None,
+        )
+        if source_index is None:
+            raise RuntimeError("failed interaction 缺少用户输入 owner")
+        logical_input_id = prior_inputs[-1].metadata.get("client_message_id")
+        if logical_input_id != source_client_message_id:
+            raise ValueError("retry source 不是当前 failed attempt 的用户输入")
+
+        inbound = request.metadata.get("inboundMetadata", {})
+        if not isinstance(inbound, dict) or not all(
+            isinstance(key, str) for key in inbound
+        ):
+            raise ValueError("control inboundMetadata 必须是字符串键对象")
+        current_client_message_id = inbound.get("client_message_id")
+        if (
+            not isinstance(current_client_message_id, str)
+            or not current_client_message_id
+        ):
+            raise ValueError("retry turn 缺少当前 client_message_id")
+
+        source = prior_inputs[-1]
+        effective_request = TurnRequest(
+            request.thread_id,
+            source.content,
+            dict(request.metadata),
+        )
+        return prior_inputs, attempts[:source_index], effective_request
 
     @staticmethod
     def _tool_group_from_item(item: TurnItem) -> dict[str, Any] | None:

--- a/agent/control/runtime.py
+++ b/agent/control/runtime.py
@@ -6,6 +6,7 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Callable, cast
 
@@ -75,6 +76,14 @@ _FRESH_INTERACTION = "freshInteraction"
 _SUPERSEDES_INTERACTION_ID = "supersedesInteractionId"
 _RETRY_SOURCE_CLIENT_MESSAGE_ID = "retrySourceClientMessageId"
 _RETRY_CLIENT_MESSAGE_ID = "retryClientMessageId"
+
+
+@dataclass(frozen=True)
+class _PreparedTurnRequest:
+    effective_request: TurnRequest
+    prior_inputs: list[TurnUserInput]
+    replay_attempts: list[TurnRecord]
+    retrying: bool
 
 
 def _validate_turn_request_metadata(request: TurnRequest) -> None:
@@ -341,6 +350,7 @@ class ConversationRuntime:
         live_media: tuple[str, ...] = (),
         execution_scope: TurnExecutionScope | None = None,
         fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
         retry_source_client_message_id: str | None = None,
     ) -> TurnHandle:
         """拒绝 active thread，并仅把本次进程可用的 media 交给 executor。"""
@@ -354,62 +364,23 @@ class ConversationRuntime:
             if request.thread_id in self._active_by_thread:
                 raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
             turn_id = new_turn_id()
-            recoverable_attempts = self._open_interaction_attempts(request.thread_id)
-            if fresh_interaction and retry_source_client_message_id is not None:
-                raise ValueError("fresh interaction 不能同时重试既有输入")
-            previous_attempts = [] if fresh_interaction else recoverable_attempts
-            prior_inputs = self._attempt_user_inputs(previous_attempts)
-            retrying = retry_source_client_message_id is not None
-            replay_attempts = previous_attempts
-            if retrying:
-                prior_inputs, replay_attempts, request = self._prepare_retry(
-                    request,
-                    previous_attempts,
-                    prior_inputs,
-                    retry_source_client_message_id,
-                )
+            prepared = self._prepare_turn_request(
+                request,
+                turn_id=turn_id,
+                fresh_interaction=fresh_interaction,
+                fresh_interaction_after_failure=fresh_interaction_after_failure,
+                retry_source_client_message_id=retry_source_client_message_id,
+                execution_scope=execution_scope,
+            )
+            effective_request = prepared.effective_request
+            prior_inputs = prepared.prior_inputs
+            replay_attempts = prepared.replay_attempts
+            retrying = prepared.retrying
             attempt_replay = replay_messages(
                 replay_attempts,
                 tool_group_from_item=ConversationRuntime._tool_group_from_item,
             )
             prior_tool_chain = self._attempt_tool_chain(replay_attempts)
-            effective_request = _build_effective_turn_request(
-                request,
-                turn_id=turn_id,
-                previous_attempts=previous_attempts,
-                prior_inputs=prior_inputs,
-            )
-            if retrying:
-                effective_request = TurnRequest(
-                    effective_request.thread_id,
-                    effective_request.input,
-                    {
-                        **effective_request.metadata,
-                        _PRIOR_INPUT_COUNT: len(prior_inputs) - 1,
-                        _RETRY_SOURCE_CLIENT_MESSAGE_ID: retry_source_client_message_id,
-                        _RETRY_CLIENT_MESSAGE_ID: self._request_client_message_id(
-                            request
-                        ),
-                    },
-                )
-            if fresh_interaction:
-                metadata: dict[str, Any] = {
-                    **effective_request.metadata,
-                    _FRESH_INTERACTION: True,
-                }
-                if recoverable_attempts:
-                    metadata[_SUPERSEDES_INTERACTION_ID] = self._interaction_id(
-                        recoverable_attempts[-1]
-                    )
-                effective_request = TurnRequest(
-                    effective_request.thread_id,
-                    effective_request.input,
-                    metadata,
-                )
-            effective_request = _persist_execution_scope(
-                effective_request,
-                execution_scope,
-            )
             request_bytes = _encoded_turn_bytes(effective_request)
             admission_token = self._reserve_admission(request_bytes)
 
@@ -542,7 +513,14 @@ class ConversationRuntime:
         finally:
             self._release_turn_ownership(thread_id, turn_id)
 
-    async def reject_never_fit_turn(self, request: TurnRequest) -> TurnHandle:
+    async def reject_never_fit_turn(
+        self,
+        request: TurnRequest,
+        *,
+        fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
+        retry_source_client_message_id: str | None = None,
+    ) -> TurnHandle:
         """把永久超过单请求容量的输入持久化为可观察 failed turn。"""
 
         # 1. 在准入 owner 内复核关闭、thread 与永久超限不变量。
@@ -554,14 +532,14 @@ class ConversationRuntime:
             if request.thread_id in self._active_by_thread:
                 raise ThreadBusyError(f"thread 已有 active turn: {request.thread_id}")
             turn_id = new_turn_id()
-            previous_attempts = self._open_interaction_attempts(request.thread_id)
-            prior_inputs = self._attempt_user_inputs(previous_attempts)
-            effective_request = _build_effective_turn_request(
+            prepared = self._prepare_turn_request(
                 request,
                 turn_id=turn_id,
-                previous_attempts=previous_attempts,
-                prior_inputs=prior_inputs,
+                fresh_interaction=fresh_interaction,
+                fresh_interaction_after_failure=fresh_interaction_after_failure,
+                retry_source_client_message_id=retry_source_client_message_id,
             )
+            effective_request = prepared.effective_request
             effective_request = TurnRequest(
                 effective_request.thread_id,
                 effective_request.input,
@@ -572,11 +550,17 @@ class ConversationRuntime:
                 raise RuntimeError("reject_never_fit_turn 仅接受永久超限请求")
 
             # 2. Runtime 持久化 queued → in_progress → failed；channel 不伪造终态。
-            initial_input = self._build_turn_user_input(
-                effective_request,
-                ordinal=len(prior_inputs),
+            initial_input = (
+                None
+                if prepared.retrying
+                else self._build_turn_user_input(
+                    effective_request,
+                    ordinal=len(prepared.prior_inputs),
+                )
             )
-            user_item = self._user_input_item(initial_input)
+            user_item = (
+                None if initial_input is None else self._user_input_item(initial_input)
+            )
             queued = self._store.create_turn(
                 TurnRecord(
                     id=turn_id,
@@ -584,7 +568,7 @@ class ConversationRuntime:
                     status=TurnStatus.QUEUED,
                     input=effective_request.input,
                     metadata=dict(effective_request.metadata),
-                    items=[user_item],
+                    items=[] if user_item is None else [user_item],
                     usage=None,
                     error=None,
                     created_at=datetime.now(UTC),
@@ -606,7 +590,8 @@ class ConversationRuntime:
                     turn=queued.to_dict(),
                 )
             )
-            self._publish_user_item(request.thread_id, turn_id, user_item)
+            if user_item is not None:
+                self._publish_user_item(request.thread_id, turn_id, user_item)
             started = self._store.transition_turn(
                 turn_id,
                 expected_status=TurnStatus.QUEUED,
@@ -666,7 +651,12 @@ class ConversationRuntime:
             )
         return TurnHandle(self, request.thread_id, turn_id)
 
-    def _open_interaction_attempts(self, thread_id: str) -> list[TurnRecord]:
+    def _open_interaction_attempts(
+        self,
+        thread_id: str,
+        *,
+        include_fresh: bool = False,
+    ) -> list[TurnRecord]:
         """从最新未完成 attempt 沿显式前驱恢复 logical interaction。"""
 
         # 1. completed 与永久拒绝都关闭当前 logical interaction；普通失败和
@@ -682,7 +672,7 @@ class ConversationRuntime:
             not isinstance(superseded, str) or not superseded
         ):
             raise ValueError("supersedesInteractionId 必须是非空字符串")
-        if fresh is True:
+        if fresh is True and not include_fresh:
             return []
         rejected = latest_page[0].metadata.get(_INTERACTION_REJECTED)
         if rejected is not None and not isinstance(rejected, bool):
@@ -1013,25 +1003,131 @@ class ConversationRuntime:
             and self._live_runtime_objects < self._max_live_runtime_objects
         )
 
-    def _effective_request_bytes(self, request: TurnRequest) -> int:
-        """计算 start_turn 会实际计费的 effective request 字节数。"""
+    def _prepare_turn_request(
+        self,
+        request: TurnRequest,
+        *,
+        turn_id: str,
+        fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
+        retry_source_client_message_id: str | None = None,
+        execution_scope: TurnExecutionScope | None = None,
+    ) -> _PreparedTurnRequest:
+        """Build the one effective request used by admission and execution."""
 
-        previous_attempts = self._open_interaction_attempts(request.thread_id)
+        recoverable_attempts = self._open_interaction_attempts(
+            request.thread_id,
+            include_fresh=(
+                retry_source_client_message_id is not None
+                or fresh_interaction_after_failure
+            ),
+        )
+        if (
+            fresh_interaction_after_failure
+            and recoverable_attempts
+            and recoverable_attempts[-1].status is TurnStatus.FAILED
+        ):
+            fresh_interaction = True
+        if fresh_interaction and retry_source_client_message_id is not None:
+            raise ValueError("fresh interaction 不能同时重试既有输入")
+        previous_attempts = [] if fresh_interaction else recoverable_attempts
         prior_inputs = self._attempt_user_inputs(previous_attempts)
+        retrying = retry_source_client_message_id is not None
+        replay_attempts = previous_attempts
+        effective_source = request
+        if retrying:
+            prior_inputs, replay_attempts, effective_source = self._prepare_retry(
+                request,
+                previous_attempts,
+                prior_inputs,
+                retry_source_client_message_id,
+            )
         effective_request = _build_effective_turn_request(
-            request,
-            turn_id=new_turn_id(),
+            effective_source,
+            turn_id=turn_id,
             previous_attempts=previous_attempts,
             prior_inputs=prior_inputs,
         )
-        return _encoded_turn_bytes(effective_request)
+        if retrying:
+            effective_request = TurnRequest(
+                effective_request.thread_id,
+                effective_request.input,
+                {
+                    **effective_request.metadata,
+                    _PRIOR_INPUT_COUNT: len(prior_inputs) - 1,
+                    _RETRY_SOURCE_CLIENT_MESSAGE_ID: retry_source_client_message_id,
+                    _RETRY_CLIENT_MESSAGE_ID: self._request_client_message_id(request),
+                },
+            )
+        if fresh_interaction:
+            metadata: dict[str, Any] = {
+                **effective_request.metadata,
+                _FRESH_INTERACTION: True,
+            }
+            if recoverable_attempts:
+                metadata[_SUPERSEDES_INTERACTION_ID] = self._interaction_id(
+                    recoverable_attempts[-1]
+                )
+            effective_request = TurnRequest(
+                effective_request.thread_id,
+                effective_request.input,
+                metadata,
+            )
+        effective_request = _persist_execution_scope(effective_request, execution_scope)
+        return _PreparedTurnRequest(
+            effective_request=effective_request,
+            prior_inputs=prior_inputs,
+            replay_attempts=replay_attempts,
+            retrying=retrying,
+        )
 
-    def admission_request_never_fits(self, request: TurnRequest) -> bool:
+    def _effective_request_bytes(
+        self,
+        request: TurnRequest,
+        *,
+        fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
+        retry_source_client_message_id: str | None = None,
+    ) -> int:
+        """计算 start_turn 会实际计费的 effective request 字节数。"""
+
+        prepared = self._prepare_turn_request(
+            request,
+            turn_id=new_turn_id(),
+            fresh_interaction=fresh_interaction,
+            fresh_interaction_after_failure=fresh_interaction_after_failure,
+            retry_source_client_message_id=retry_source_client_message_id,
+        )
+        return _encoded_turn_bytes(prepared.effective_request)
+
+    def admission_request_never_fits(
+        self,
+        request: TurnRequest,
+        *,
+        fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
+        retry_source_client_message_id: str | None = None,
+    ) -> bool:
         """单个请求永久超过最大字节容量时返回 True，等待容量无意义。"""
 
-        return self._effective_request_bytes(request) > self._max_active_bytes
+        return (
+            self._effective_request_bytes(
+                request,
+                fresh_interaction=fresh_interaction,
+                fresh_interaction_after_failure=fresh_interaction_after_failure,
+                retry_source_client_message_id=retry_source_client_message_id,
+            )
+            > self._max_active_bytes
+        )
 
-    async def wait_capacity_available(self, request: TurnRequest) -> None:
+    async def wait_capacity_available(
+        self,
+        request: TurnRequest,
+        *,
+        fresh_interaction: bool = False,
+        fresh_interaction_after_failure: bool = False,
+        retry_source_client_message_id: str | None = None,
+    ) -> None:
         """等待控制面全局容量或关闭状态变化，由调用方重新尝试 start_turn。
 
         阶段1：先按单请求永久超出容量边界直接返回，避免无意义的无限等待；
@@ -1040,7 +1136,12 @@ class ConversationRuntime:
         阶段3：关闭或排空也会唤醒，随后 start_turn 暴露 RuntimeClosedError。
         """
 
-        request_bytes = self._effective_request_bytes(request)
+        request_bytes = self._effective_request_bytes(
+            request,
+            fresh_interaction=fresh_interaction,
+            fresh_interaction_after_failure=fresh_interaction_after_failure,
+            retry_source_client_message_id=retry_source_client_message_id,
+        )
         while not self._closed and self._accepting_turns:
             self._admission_capacity_event.clear()
             if request_bytes > self._max_active_bytes or self._admission_can_fit(

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -323,6 +323,11 @@ class PassiveMessageWorker:
                     "channelBindingToken": envelope.binding_token,
                 },
             )
+            retry_source = message.metadata.get("retry_of_client_message_id")
+            if retry_source is not None and (
+                not isinstance(retry_source, str) or not retry_source
+            ):
+                raise ValueError("retry_of_client_message_id 必须是非空字符串")
 
             # 2. Capacity waits retain the exact old binding; they never reacquire current.
             while True:
@@ -336,6 +341,10 @@ class PassiveMessageWorker:
                         channel_binding_lease=cast(Any, envelope.lease),
                         live_media=tuple(
                             lease.model_path for lease in attachment_leases
+                        ),
+                        retry_source_client_message_id=cast(
+                            str | None,
+                            retry_source,
                         ),
                     )
                     break
@@ -594,12 +603,21 @@ class PassiveMessageWorker:
                     "inboundMetadata": dict(item.metadata),
                 },
             )
+            retry_source = item.metadata.get("retry_of_client_message_id")
+            if retry_source is not None and (
+                not isinstance(retry_source, str) or not retry_source
+            ):
+                raise ValueError("retry_of_client_message_id 必须是非空字符串")
             while True:
                 try:
                     handle = await self._runtime.start_turn(
                         request,
                         live_media=tuple(
                             lease.model_path for lease in attachment_leases
+                        ),
+                        retry_source_client_message_id=cast(
+                            str | None,
+                            retry_source,
                         ),
                     )
                     break
@@ -857,6 +875,14 @@ class PassiveMessageWorker:
         阶段3：唯一非空值返回，缺失返回空串由调用方按 channel 语义处理。
         """
 
+        retry_client_message_id = result.metadata.get("retryClientMessageId")
+        if retry_client_message_id is not None:
+            if (
+                not isinstance(retry_client_message_id, str)
+                or not retry_client_message_id
+            ):
+                raise ValueError("retryClientMessageId 必须是非空字符串")
+            return retry_client_message_id
         values: set[str] = set()
         for entry in result.items:
             if entry.kind is not TurnItemKind.USER_MESSAGE:
@@ -978,6 +1004,8 @@ class PassiveMessageWorker:
             if result.error is not None
             else "处理消息时出错，请稍后再试。"
         )
+        if result.error is not None:
+            metadata["retryable"] = result.error.retryable
         return OutboundMessage(
             channel=item.channel,
             chat_id=item.chat_id,

--- a/bootstrap/passive_worker.py
+++ b/bootstrap/passive_worker.py
@@ -75,6 +75,7 @@ async def _complete_critical(awaitable: Awaitable[T]) -> T:
         raise asyncio.CancelledError
     return result
 
+
 _TERMINAL_LANE_RETRY_DELAY = 1.0
 
 
@@ -221,7 +222,10 @@ class PassiveMessageWorker:
                     await asyncio.sleep(_TERMINAL_LANE_RETRY_DELAY)
                 except Exception:
                     logger.exception("passive lane message failed thread=%s", key)
-                    if isinstance(item, InboundEnvelope) and item.owner is not InboundOwner.CLOSED:
+                    if (
+                        isinstance(item, InboundEnvelope)
+                        and item.owner is not InboundOwner.CLOSED
+                    ):
                         if _has_mobile_handoff(item):
                             if not self._bus.mobile_inbound_cleanup_pending(item):
                                 await self._bus.retain_mobile_channel_inbound(
@@ -259,9 +263,7 @@ class PassiveMessageWorker:
         try:
             message = envelope.message
             if _has_mobile_handoff(envelope):
-                session_admission_id = self._bus.mobile_session_admission_id(
-                    envelope
-                )
+                session_admission_id = self._bus.mobile_session_admission_id(envelope)
                 store = self._legacy_loop.session_manager.control_store
                 matched = store.find_turn_by_client_message_id(
                     envelope.session_key,
@@ -292,9 +294,7 @@ class PassiveMessageWorker:
                         envelope.session_key
                     )
                 )
-            attachment_leases = await self._acquire_attachment_refs(
-                message.attachments
-            )
+            attachment_leases = await self._acquire_attachment_refs(message.attachments)
             request = TurnRequest(
                 envelope.session_key,
                 message.content,
@@ -328,6 +328,7 @@ class PassiveMessageWorker:
                 not isinstance(retry_source, str) or not retry_source
             ):
                 raise ValueError("retry_of_client_message_id 必须是非空字符串")
+            fresh_after_failure = _has_mobile_handoff(envelope) and retry_source is None
 
             # 2. Capacity waits retain the exact old binding; they never reacquire current.
             while True:
@@ -346,15 +347,30 @@ class PassiveMessageWorker:
                             str | None,
                             retry_source,
                         ),
+                        fresh_interaction_after_failure=fresh_after_failure,
                     )
                     break
                 except ThreadBusyError:
                     await self._runtime.wait_thread_available(envelope.session_key)
                 except ControlAdmissionError:
-                    if self._runtime.admission_request_never_fits(request):
-                        handle = await self._runtime.reject_never_fit_turn(request)
+                    if self._runtime.admission_request_never_fits(
+                        request,
+                        fresh_interaction_after_failure=fresh_after_failure,
+                        retry_source_client_message_id=cast(str | None, retry_source),
+                    ):
+                        handle = await self._runtime.reject_never_fit_turn(
+                            request,
+                            fresh_interaction_after_failure=fresh_after_failure,
+                            retry_source_client_message_id=cast(
+                                str | None, retry_source
+                            ),
+                        )
                         break
-                    await self._runtime.wait_capacity_available(request)
+                    await self._runtime.wait_capacity_available(
+                        request,
+                        fresh_interaction_after_failure=fresh_after_failure,
+                        retry_source_client_message_id=cast(str | None, retry_source),
+                    )
                 except RuntimeClosedError:
                     await self._runtime.wait_until_accepting_turns()
 
@@ -556,9 +572,7 @@ class PassiveMessageWorker:
                 return_exceptions=True,
             )
             failures.extend(
-                result
-                for result in results
-                if isinstance(result, Exception)
+                result for result in results if isinstance(result, Exception)
             )
         if failures:
             raise ExceptionGroup("v3 Channel turn cleanup 失败", failures)
@@ -587,9 +601,7 @@ class PassiveMessageWorker:
         transferred = False
         attachment_leases: tuple[_ModelAttachmentLease, ...] = ()
         try:
-            attachment_leases = await self._acquire_mobile_attachment_ids(
-                item.metadata
-            )
+            attachment_leases = await self._acquire_mobile_attachment_ids(item.metadata)
             # 阶段3：渠道信息只作为 executor 所需的受控 metadata，不改变 thread identity。
             request = TurnRequest(
                 item.session_key,
@@ -608,6 +620,7 @@ class PassiveMessageWorker:
                 not isinstance(retry_source, str) or not retry_source
             ):
                 raise ValueError("retry_of_client_message_id 必须是非空字符串")
+            fresh_after_failure = _has_mobile_handoff(item) and retry_source is None
             while True:
                 try:
                     handle = await self._runtime.start_turn(
@@ -619,17 +632,32 @@ class PassiveMessageWorker:
                             str | None,
                             retry_source,
                         ),
+                        fresh_interaction_after_failure=fresh_after_failure,
                     )
                     break
                 except ThreadBusyError:
                     await self._runtime.wait_thread_available(item.session_key)
                     continue
                 except ControlAdmissionError:
-                    if self._runtime.admission_request_never_fits(request):
-                        handle = await self._runtime.reject_never_fit_turn(request)
+                    if self._runtime.admission_request_never_fits(
+                        request,
+                        fresh_interaction_after_failure=fresh_after_failure,
+                        retry_source_client_message_id=cast(str | None, retry_source),
+                    ):
+                        handle = await self._runtime.reject_never_fit_turn(
+                            request,
+                            fresh_interaction_after_failure=fresh_after_failure,
+                            retry_source_client_message_id=cast(
+                                str | None, retry_source
+                            ),
+                        )
                         break
                     self._release_admission_once(item)
-                    await self._runtime.wait_capacity_available(request)
+                    await self._runtime.wait_capacity_available(
+                        request,
+                        fresh_interaction_after_failure=fresh_after_failure,
+                        retry_source_client_message_id=cast(str | None, retry_source),
+                    )
                     if _has_mobile_handoff(item) and item.session_admission_id is None:
                         _, item.session_admission_id = (
                             self._legacy_loop.session_manager.admit_existing(

--- a/docs/design/codex-style-same-turn-input-requirements.md
+++ b/docs/design/codex-style-same-turn-input-requirements.md
@@ -28,7 +28,7 @@
 
 ### STI-004 最终 A 才结束 Logical Interaction
 
-interrupted、cancelled 或 failed attempt 都不关闭 logical interaction。只有一次 attempt 成功提交 terminal assistant 时，该回复才成为 `A_final`，interaction completed；此后的普通 U 才创建新的 interaction。
+interrupted 或 cancelled attempt 不关闭 logical interaction。failed attempt 保留给显式重试；Mobile 普通 U 不复用它，而是创建带 `supersedesInteractionId` 的新 interaction。只有一次 attempt 成功提交 terminal assistant 时，该回复才成为 `A_final`，interaction completed；此后的普通 U 创建新的 interaction。
 
 ### STI-005 控制面只提供精确中断
 

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -449,6 +449,8 @@ orphan recovery 可以清除 prepare。
 
 一个 logical interaction 可以拥有多个 execution attempt 和多个有序 user input。每个 attempt 的输入、工具 started/completed 和中止终态先写入 `turns`；下一 attempt 从这些事实构造 prompt replay，不恢复隐藏思维，也不重放未闭合工具。只有最终 assistant 成功提交时 interaction 才 completed。completed transcript 在一个事务中按 ordinal 追加全部 user message 和唯一 terminal assistant，并携带共同 interaction identity；不得为中止 attempt 生成 Akasha 学习样本或用角色邻接推断归属。
 
+客户端对最新 retryable failed attempt 执行显式重试时，必须复用该 interaction 的最后一个 user input，只新建 execution attempt，不追加第二条 user message。重试请求用稳定的原 user message identity 指明来源，并用新的命令 identity 保证本次传输幂等；普通发送即使正文相同也始终是新 user input，不得按正文猜测重试关系。failed、cancelled 与 interrupted 终态必须原样投影，不能合并成同一个展示状态。
+
 ## 8. 记忆系统
 
 ### MEM-001 档案重写同时验证结构和事实保全

--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -445,6 +445,8 @@ orphan recovery 可以清除 prepare。
 
 同一 session 没有 active execution attempt 时，普通 user input 创建 attempt；最新 logical interaction 尚未产生 terminal assistant 时，新 attempt 必须沿用同一 interaction identity，并看到此前全部有序 user input 和已经闭合的工具调用/结果。active attempt 期间普通 `turn/start` 明确返回 busy，Mobile 普通发送不可用；channel 消息先通过 `/stop` 或等价中止结束 attempt，再由下一条普通输入续接。控制协议不提供 steer/follow-up 输入模式。
 
+Mobile 对 failed 终态使用更窄的入口：携带 `retry_of_client_message_id` 的显式重试才沿用原 interaction；不携带该字段的普通发送必须创建新的 interaction，并以 `supersedesInteractionId` 记录它替代的未完成 interaction。interrupted 后的普通输入仍按上一段续接。容量等待、永久拒绝与真正启动必须使用同一份有效请求及同一组 retry/fresh 参数，不能在拒绝路径补写第二条 user message。
+
 ### SES-008 Completed Interaction 显式拥有全部输入和唯一最终回复
 
 一个 logical interaction 可以拥有多个 execution attempt 和多个有序 user input。每个 attempt 的输入、工具 started/completed 和中止终态先写入 `turns`；下一 attempt 从这些事实构造 prompt replay，不恢复隐藏思维，也不重放未闭合工具。只有最终 assistant 成功提交时 interaction 才 completed。completed transcript 在一个事务中按 ordinal 追加全部 user message 和唯一 terminal assistant，并携带共同 interaction identity；不得为中止 attempt 生成 Akasha 学习样本或用角色邻接推断归属。

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -190,6 +190,7 @@ interface MobileMessage {
   blocks: MobileProcessBlock[];
   streaming: boolean;
   interrupted: boolean;
+  terminalStatus?: "failed" | "cancelled" | "interrupted";
   durationSeconds?: number;
   attachments: MobileAttachment[];
   controlTurnId?: string;
@@ -563,6 +564,18 @@ function parseMessage(value: unknown, index: number): MobileMessage {
   if (deliveryAction !== undefined && deliveryAction !== "retry" && deliveryAction !== "verify") {
     throw new Error(`messages[${index}].deliveryAction 不受支持`);
   }
+  const terminalStatus = optionalString(
+    raw.terminalStatus,
+    `messages[${index}].terminalStatus`,
+  );
+  if (
+    terminalStatus !== undefined
+    && terminalStatus !== "failed"
+    && terminalStatus !== "cancelled"
+    && terminalStatus !== "interrupted"
+  ) {
+    throw new Error(`messages[${index}].terminalStatus 不受支持`);
+  }
   return {
     id: requireString(raw.id, `messages[${index}].id`),
     sessionId: requireString(raw.sessionId, `messages[${index}].sessionId`),
@@ -577,6 +590,7 @@ function parseMessage(value: unknown, index: number): MobileMessage {
     blocks: optionalArray(raw.blocks, `messages[${index}].blocks`, parseProcessBlock),
     streaming: raw.streaming === undefined ? false : requireBoolean(raw.streaming, `messages[${index}].streaming`),
     interrupted: raw.interrupted === undefined ? false : requireBoolean(raw.interrupted, `messages[${index}].interrupted`),
+    terminalStatus,
     durationSeconds: raw.durationSeconds === undefined ? undefined : requireNumber(raw.durationSeconds, `messages[${index}].durationSeconds`),
     attachments: optionalArray(raw.attachments, `messages[${index}].attachments`, parseAttachment),
     controlTurnId: optionalString(raw.controlTurnId, `messages[${index}].controlTurnId`),
@@ -2427,6 +2441,7 @@ const MobileMessageRow = React.memo(function MobileMessageRow({
             deliveryLabel={source.deliveryLabel}
             deliveryAction={source.deliveryAction}
             interrupted={source.interrupted}
+            terminalStatus={source.terminalStatus}
             hasContent={Boolean(source.content)}
             copied={copied}
             canReply={canReply}
@@ -3962,6 +3977,7 @@ const MessageMeta = React.memo(function MessageMeta({
   deliveryLabel,
   deliveryAction,
   interrupted,
+  terminalStatus,
   hasContent,
   copied,
   canReply,
@@ -3975,6 +3991,7 @@ const MessageMeta = React.memo(function MessageMeta({
   deliveryLabel?: string;
   deliveryAction?: MobileMessage["deliveryAction"];
   interrupted: boolean;
+  terminalStatus?: MobileMessage["terminalStatus"];
   hasContent: boolean;
   copied: boolean;
   canReply: boolean;
@@ -3989,6 +4006,13 @@ const MessageMeta = React.memo(function MessageMeta({
   const deliveryActionAria = deliveryAction === "retry"
     ? "发送失败，重试消息"
     : "结果待确认，核对消息状态";
+  const terminalLabel = terminalStatus === "failed"
+    ? "本轮生成失败，请重试"
+    : terminalStatus === "cancelled"
+      ? "本轮已取消"
+      : terminalStatus === "interrupted" || interrupted
+        ? "本轮已中止"
+        : undefined;
   return (
     <div className={`mobile-message-meta ${role}`}>
       <div className="mobile-message-meta__text">
@@ -4011,7 +4035,7 @@ const MessageMeta = React.memo(function MessageMeta({
             <span>{deliveryActionLabel}</span>
           </button>
         ) : null}
-        {interrupted ? <span className="interrupted-label">本轮已中止</span> : null}
+        {terminalLabel ? <span className="interrupted-label">{terminalLabel}</span> : null}
       </div>
       <SharedMessageActions
         canReply={canReply}

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -2096,6 +2096,11 @@ class MobileRealtimeChannel:
             except (AttachmentRequestError, AttachmentStateError) as error:
                 raise MobileCommandError("attachment_not_ready", str(error)) from error
             reply = self._resolve_reply(session_id, frame.payload.reply_to)
+            if frame.payload.retry_of_client_message_id is not None:
+                self._validate_retry_source(
+                    session_id,
+                    frame.payload.retry_of_client_message_id,
+                )
             inbound_content = frame.payload.text
             metadata: dict[str, object] = {
                 "client_request_id": frame.id,
@@ -2107,6 +2112,10 @@ class MobileRealtimeChannel:
                 "mobile_v3_handoff": True,
                 "mobile_handoff_id": uuid4().hex,
             }
+            if frame.payload.retry_of_client_message_id is not None:
+                metadata["retry_of_client_message_id"] = (
+                    frame.payload.retry_of_client_message_id
+                )
             if frame.payload.model_runtime_id is not None:
                 metadata["model_runtime_id"] = frame.payload.model_runtime_id
                 metadata["model_reasoning_effort"] = (
@@ -2204,6 +2213,24 @@ class MobileRealtimeChannel:
             raise
         finally:
             self._v3_inbound_runtime.release_capture(callback_task)
+
+    def _validate_retry_source(self, session_id: str, client_message_id: str) -> None:
+        """Accept an explicit retry only for the latest retryable failed interaction."""
+
+        store = self._require_ctx().session_manager.control_store
+        source = store.find_turn_by_client_message_id(session_id, client_message_id)
+        latest_page = store.list_turns(session_id, limit=1)
+        latest = latest_page[0] if latest_page else None
+        if source is None or latest is None:
+            raise MobileCommandError("turn_not_retryable", "找不到可重试的失败消息")
+        interaction_id = latest.metadata.get("interactionId", latest.id)
+        if (
+            latest.status is not TurnStatus.FAILED
+            or latest.error is None
+            or latest.error.retryable is not True
+            or interaction_id != source.id
+        ):
+            raise MobileCommandError("turn_not_retryable", "这条消息现在不能重试")
 
     def _prepare_message_attachment_refs(
         self,
@@ -2891,6 +2918,11 @@ class MobileRealtimeChannel:
             }
             if client_message_id is not None:
                 payload["client_message_id"] = client_message_id
+            retryable = source_metadata.get("retryable")
+            if message.terminal_status is TurnTerminalStatus.FAILED:
+                if not isinstance(retryable, bool):
+                    raise RuntimeError("mobile failed terminal 缺少 retryable")
+                payload["retryable"] = retryable
             started_at = self._turn_started_at.get(key)
             published = await self._publish_terminal(
                 session_id=session_id,

--- a/infra/mobile_realtime/protocol.py
+++ b/infra/mobile_realtime/protocol.py
@@ -188,6 +188,7 @@ class MessageReplyReference(ProtocolModel):
 
 class MessageSendPayload(ProtocolModel):
     client_message_id: FrameId
+    retry_of_client_message_id: FrameId | None = None
     session_id: NonEmptyId
     text: str = Field(max_length=65_536)
     media_refs: list[NonEmptyId] = Field(max_length=10)
@@ -216,6 +217,13 @@ class MessageSendPayload(ProtocolModel):
     @model_validator(mode="after")
     def validate_client_message_id(self) -> MessageSendPayload:
         _validate_frame_id(self.client_message_id, "client_message_id")
+        if self.retry_of_client_message_id is not None:
+            _validate_frame_id(
+                self.retry_of_client_message_id,
+                "retry_of_client_message_id",
+            )
+            if self.retry_of_client_message_id == self.client_message_id:
+                raise ValueError("retry_of_client_message_id 必须指向既有消息")
         if len(set(self.media_refs)) != len(self.media_refs):
             raise ValueError("media_refs 不能重复")
         if self.model_runtime_id is not None:

--- a/schema/mobile-realtime-v1.json
+++ b/schema/mobile-realtime-v1.json
@@ -1087,6 +1087,21 @@
             ],
             "default": null
           },
+          "retry_of_client_message_id": {
+            "anyOf": [
+              {
+                "maxLength": 36,
+                "minLength": 26,
+                "pattern": "^(?:[0-9A-HJKMNP-TV-Z]{26}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Retry Of Client Message Id"
+          },
           "session_id": {
             "maxLength": 512,
             "minLength": 1,

--- a/session/store.py
+++ b/session/store.py
@@ -5055,7 +5055,7 @@ class SessionStore:
         session_key: str,
         client_message_id: str,
     ) -> TurnRecord | None:
-        """按 turns.items_json 的 userMessage client_message_id 返回唯一 turn。
+        """按 userMessage 或 retry attempt client_message_id 返回唯一 turn。
 
         阶段1：0 条匹配返回 None，调用方按未建立 turn 正常准入；
         阶段2：唯一匹配返回该权威 TurnRecord；
@@ -5079,10 +5079,22 @@ class SessionStore:
                               '$.data.metadata.client_message_id'
                             ) = ?
                   )
+                  OR (
+                    turn_record.session_key = ?
+                    AND json_extract(
+                          turn_record.input_json,
+                          '$.metadata.retryClientMessageId'
+                        ) = ?
+                  )
                 ORDER BY turn_record.created_at DESC, turn_record.id DESC
                 LIMIT 2
                 """,
-                (session_key, client_message_id),
+                (
+                    session_key,
+                    client_message_id,
+                    session_key,
+                    client_message_id,
+                ),
             ).fetchall()
         if len(rows) > 1:
             raise RuntimeError(

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -1197,6 +1197,122 @@ async def test_explicit_retry_reuses_user_message_and_starts_new_attempt(
 
 
 @pytest.mark.asyncio
+async def test_ordinary_mobile_send_after_failure_starts_new_interaction(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "akashic:ordinary-after-failure"
+    manager.save(manager.get_or_create(session_key))
+
+    async def execute(request: TurnRequest) -> str:
+        if request.input == "u1":
+            raise ControlExecutionError("provider_offline", "offline", retryable=True)
+        return f"echo:{request.input}"
+
+    runtime = ConversationRuntime(manager.control_store, execute)
+    bus, worker = _real_worker(manager, runtime)
+
+    async def on_outbound(_message: OutboundMessage) -> None:
+        return None
+
+    _bind_channel_delivery(worker, on_outbound)
+    await bus.publish_inbound(_mobile_item("ordinary-after-failure", "u1", "client:u1"))
+    await worker._run_message(await _consume_message(bus))
+    await bus.publish_inbound(_mobile_item("ordinary-after-failure", "u2", "client:u2"))
+    await worker._run_message(await _consume_message(bus))
+
+    turns = list(reversed(manager.control_store.list_turns(session_key)))
+    assert [turn.status for turn in turns] == [TurnStatus.FAILED, TurnStatus.COMPLETED]
+    assert turns[0].metadata["interactionId"] == turns[0].id
+    assert turns[1].metadata["interactionId"] == turns[1].id
+    assert turns[1].metadata["supersedesInteractionId"] == turns[0].id
+    assert turns[1].metadata["priorInputCount"] == 0
+    assert "continuedFromTurnId" not in turns[1].metadata
+    assert [
+        item.data["content"]
+        for turn in turns
+        for item in turn.items
+        if item.kind is TurnItemKind.USER_MESSAGE
+    ] == ["u1", "u2"]
+    await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_never_fit_retry_keeps_single_user_message(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "akashic:retry-never-fit"
+    manager.save(manager.get_or_create(session_key))
+
+    async def execute(_request: TurnRequest) -> str:
+        raise ControlExecutionError("provider_offline", "offline", retryable=True)
+
+    runtime = ConversationRuntime(manager.control_store, execute, max_active_bytes=4096)
+    bus, worker = _real_worker(manager, runtime)
+    delivered: list[OutboundMessage] = []
+
+    async def on_outbound(message: OutboundMessage) -> None:
+        delivered.append(message)
+
+    _bind_channel_delivery(worker, on_outbound)
+    source_id = "client:retry-never-fit-source"
+    await bus.publish_inbound(_mobile_item("retry-never-fit", "u1", source_id))
+    await worker._run_message(await _consume_message(bus))
+
+    retry_id = "client:retry-never-fit-attempt"
+    retry_request = TurnRequest(
+        session_key,
+        "ignored retry body",
+        {
+            "channel": "akashic",
+            "chatId": "retry-never-fit",
+            "sender": "device:1",
+            "media": [],
+            "inboundMetadata": {
+                "client_message_id": retry_id,
+                "retry_of_client_message_id": source_id,
+            },
+        },
+    )
+    retry_bytes = runtime._effective_request_bytes(
+        retry_request,
+        retry_source_client_message_id=source_id,
+    )
+    runtime._max_active_bytes = retry_bytes - 1
+    await bus.publish_inbound(
+        _mobile_item(
+            "retry-never-fit",
+            "ignored retry body",
+            retry_id,
+            retry_of_client_message_id=source_id,
+        )
+    )
+    await worker._run_message(await _consume_message(bus))
+
+    turns = list(reversed(manager.control_store.list_turns(session_key)))
+    assert [turn.status for turn in turns] == [TurnStatus.FAILED, TurnStatus.FAILED]
+    assert turns[1].metadata["interactionId"] == turns[0].id
+    assert turns[1].metadata["retryClientMessageId"] == retry_id
+    assert turns[1].metadata["interactionRejected"] is True
+    assert turns[1].error is not None
+    assert turns[1].error.type == "resource-exhausted"
+    assert (
+        sum(
+            item.kind is TurnItemKind.USER_MESSAGE
+            for turn in turns
+            for item in turn.items
+        )
+        == 1
+    )
+    assert delivered[-1].metadata["client_message_id"] == retry_id
+    assert delivered[-1].metadata["retryable"] is False
+    await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
 async def test_handoff_retained_without_subscriber(tmp_path: Path) -> None:
     manager = SessionManager(tmp_path / "workspace")
     session_key = "akashic:nosub"

--- a/tests/control/test_channel_adapter.py
+++ b/tests/control/test_channel_adapter.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, cast
 import pytest
 
 from agent.control.errors import ControlExecutionError
-from agent.control.models import TurnRequest, TurnStatus
+from agent.control.models import TurnItemKind, TurnRequest, TurnStatus
 from agent.control.ports import ControlExecutionResult
 from agent.control.runtime import ConversationRuntime
 from agent.plugin_composition.channels import (
@@ -157,6 +157,8 @@ def _mobile_item(
     chat_id: str,
     content: str,
     client_message_id: str,
+    *,
+    retry_of_client_message_id: str | None = None,
 ) -> InboundMessage:
     handoff_id = f"handoff:{client_message_id}"
     return InboundMessage(
@@ -164,7 +166,14 @@ def _mobile_item(
         "device:1",
         chat_id,
         content,
-        metadata={"client_message_id": client_message_id},
+        metadata={
+            "client_message_id": client_message_id,
+            **(
+                {"retry_of_client_message_id": retry_of_client_message_id}
+                if retry_of_client_message_id is not None
+                else {}
+            ),
+        },
         handoff_id=handoff_id,
     )
 
@@ -1127,6 +1136,62 @@ async def test_provider_failure_body_reaches_channel_terminal(tmp_path: Path) ->
     assert len(delivered) == 1
     assert delivered[0].content == provider_error
     assert delivered[0].terminal_status is TurnTerminalStatus.FAILED
+    assert delivered[0].metadata["retryable"] is True
+    await runtime.shutdown()
+    manager.close()
+
+
+@pytest.mark.asyncio
+async def test_explicit_retry_reuses_user_message_and_starts_new_attempt(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path / "workspace")
+    session_key = "akashic:retry"
+    manager.save(manager.get_or_create(session_key))
+    calls = 0
+
+    async def execute(request: TurnRequest) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ControlExecutionError("provider_offline", "offline", retryable=True)
+        return f"echo:{request.input}"
+
+    runtime = ConversationRuntime(manager.control_store, execute)
+    bus, worker = _real_worker(manager, runtime)
+    delivered: list[OutboundMessage] = []
+
+    async def on_outbound(message: OutboundMessage) -> None:
+        delivered.append(message)
+
+    _bind_channel_delivery(worker, on_outbound)
+    original_id = "client:retry-original"
+    await bus.publish_inbound(_mobile_item("retry", "u1", original_id))
+    await worker._run_message(await _consume_message(bus))
+    retry_id = "client:retry-attempt-2"
+    await bus.publish_inbound(
+        _mobile_item(
+            "retry",
+            "client text is ignored",
+            retry_id,
+            retry_of_client_message_id=original_id,
+        )
+    )
+    await worker._run_message(await _consume_message(bus))
+
+    turns = list(reversed(manager.control_store.list_turns(session_key)))
+    assert [turn.status for turn in turns] == [TurnStatus.FAILED, TurnStatus.COMPLETED]
+    assert turns[1].metadata["interactionId"] == turns[0].id
+    assert (
+        sum(
+            item.kind is TurnItemKind.USER_MESSAGE
+            for turn in turns
+            for item in turn.items
+        )
+        == 1
+    ), [[item.kind.value for item in turn.items] for turn in turns]
+    assert delivered[-1].content == "echo:u1"
+    assert delivered[-1].metadata["client_message_id"] == retry_id
     await runtime.shutdown()
     manager.close()
 
@@ -1145,7 +1210,9 @@ async def test_handoff_retained_without_subscriber(tmp_path: Path) -> None:
     inbound = _mobile_item("nosub", "hello", "client:n")
     await bus.publish_inbound(inbound)
     consumed = await _consume_message(bus)
-    with pytest.raises(RuntimeError, match="Passive terminal exact Channel dispatcher 未绑定"):
+    with pytest.raises(
+        RuntimeError, match="Passive terminal exact Channel dispatcher 未绑定"
+    ):
         await worker._run_message(consumed)
 
     # 1. 无 subscriber 不算 delivered：row 与 owner 保留。
@@ -1360,7 +1427,9 @@ async def test_restart_redelivery_failed_carries_verified_client_message_id(
     inbound1 = _mobile_item("rdfail", "hello", "client:rdfail")
     await bus1.publish_inbound(inbound1)
     consumed1 = await _consume_message(bus1)
-    with pytest.raises(RuntimeError, match="Passive terminal exact Channel dispatcher 未绑定"):
+    with pytest.raises(
+        RuntimeError, match="Passive terminal exact Channel dispatcher 未绑定"
+    ):
         await worker1._run_message(consumed1)
     assert len(manager1.control_store.list_inbound_handoffs()) == 1
     await bus1.aclose()

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -334,7 +334,7 @@ async def test_retry_reuses_latest_input_without_appending_user_message(
 
     async def execute(request: TurnRequest) -> str:
         nonlocal captured, captured_inputs
-        if request.metadata["attemptOrdinal"] == 0:
+        if request.metadata["attemptOrdinal"] < 2:
             raise ControlExecutionError(
                 "provider_connection_error", "offline", retryable=True
             )
@@ -361,7 +361,17 @@ async def test_retry_reuses_latest_input_without_appending_user_message(
         ),
         retry_source_client_message_id="client:one",
     )
-    result = await second.result()
+    assert (await second.result()).status is TurnStatus.FAILED
+
+    third = await runtime.start_turn(
+        TurnRequest(
+            "mobile:retry",
+            "client text is still ignored",
+            {"inboundMetadata": {"client_message_id": "client:three"}},
+        ),
+        retry_source_client_message_id="client:one",
+    )
+    result = await third.result()
 
     assert captured is not None
     assert [(item.ordinal, item.content) for item in captured_inputs] == [(0, "u1")]
@@ -371,12 +381,19 @@ async def test_retry_reuses_latest_input_without_appending_user_message(
     assert captured.metadata["_controlAttemptReplay"] == []
     assert result.status is TurnStatus.COMPLETED
     assert result.interaction_id == first.id
-    retry_record = store.read_turn(second.id)
+    retry_record = store.read_turn(third.id)
     assert retry_record is not None
     assert retry_record.items[-1].kind is TurnItemKind.ASSISTANT_MESSAGE
     assert all(
         item.kind is not TurnItemKind.USER_MESSAGE for item in retry_record.items
     )
+    attempts = store.list_turns("mobile:retry")
+    assert len(attempts) == 3
+    assert sum(
+        item.kind is TurnItemKind.USER_MESSAGE
+        for attempt in attempts
+        for item in attempt.items
+    ) == 1
     await runtime.shutdown()
     store.close()
 

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -24,7 +24,7 @@ from agent.control.models import (
     TurnStatus,
     TurnUsage,
 )
-from agent.control.ports import ControlExecutionResult
+from agent.control.ports import ControlExecutionResult, TurnUserInput
 from agent.control.runtime import ConversationRuntime
 from agent.control.turn_scope import TurnExecutionScope
 from agent.turn_effects import PostCommitEffect

--- a/tests/control/test_conversation_runtime.py
+++ b/tests/control/test_conversation_runtime.py
@@ -9,7 +9,11 @@ from typing import Any, cast
 
 import pytest
 
-from agent.control.errors import ThreadBusyError, TurnAdmissionUncertainError
+from agent.control.errors import (
+    ControlExecutionError,
+    ThreadBusyError,
+    TurnAdmissionUncertainError,
+)
 from agent.control.events import TurnEvent
 from agent.control.models import (
     TurnItem,
@@ -133,9 +137,7 @@ async def test_runtime_keeps_live_attachment_paths_out_of_durable_turn(
     assert record is not None
     assert seen_media == ["/proc/self/fd/999"]
     assert record.metadata["media"] == []
-    assert record.metadata["inboundMetadata"] == {
-        "attachment_ids": ["artifact-1"]
-    }
+    assert record.metadata["inboundMetadata"] == {"attachment_ids": ["artifact-1"]}
     assert record.items[0].data["media"] == []
     assert "/proc/" not in json.dumps(record.to_dict(), ensure_ascii=False)
     await runtime.shutdown()
@@ -202,7 +204,7 @@ async def test_runtime_startup_interrupts_crash_stale_in_progress_turn(
                         "arguments": {},
                         "status": "in_progress",
                     },
-                )
+                ),
             ],
             usage=None,
             error=None,
@@ -225,9 +227,7 @@ async def test_runtime_startup_interrupts_crash_stale_in_progress_turn(
     assert recovered is not None
     assert recovered.status is TurnStatus.INTERRUPTED
     assert recovered.items[1].data["status"] == "interrupted"
-    continued = await runtime.start_turn(
-        TurnRequest("programmatic:restart", "u2")
-    )
+    continued = await runtime.start_turn(TurnRequest("programmatic:restart", "u2"))
     assert (await continued.result()).status is TurnStatus.COMPLETED
     await runtime.shutdown()
     store.close()
@@ -320,6 +320,63 @@ async def test_runtime_replays_two_interrupted_attempts_into_one_interaction(
         TurnStatus.COMPLETED,
     ]
     assert {attempt.metadata["interactionId"] for attempt in attempts} == {first.id}
+    await runtime.shutdown()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_retry_reuses_latest_input_without_appending_user_message(
+    tmp_path: Path,
+) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    captured: TurnRequest | None = None
+    captured_inputs: tuple[TurnUserInput, ...] = ()
+
+    async def execute(request: TurnRequest) -> str:
+        nonlocal captured, captured_inputs
+        if request.metadata["attemptOrdinal"] == 0:
+            raise ControlExecutionError(
+                "provider_connection_error", "offline", retryable=True
+            )
+        captured = request
+        source = request.metadata["_controlTurnInputSource"]
+        captured_inputs = source.used_inputs()
+        return "answer"
+
+    runtime = ConversationRuntime(store, execute)
+    first = await runtime.start_turn(
+        TurnRequest(
+            "mobile:retry",
+            "u1",
+            {"inboundMetadata": {"client_message_id": "client:one"}},
+        )
+    )
+    assert (await first.result()).status is TurnStatus.FAILED
+
+    second = await runtime.start_turn(
+        TurnRequest(
+            "mobile:retry",
+            "client text is ignored",
+            {"inboundMetadata": {"client_message_id": "client:two"}},
+        ),
+        retry_source_client_message_id="client:one",
+    )
+    result = await second.result()
+
+    assert captured is not None
+    assert [(item.ordinal, item.content) for item in captured_inputs] == [(0, "u1")]
+    assert captured_inputs[0].metadata["client_message_id"] == "client:one"
+    assert captured.input == "u1"
+    assert captured.metadata["priorInputCount"] == 0
+    assert captured.metadata["_controlAttemptReplay"] == []
+    assert result.status is TurnStatus.COMPLETED
+    assert result.interaction_id == first.id
+    retry_record = store.read_turn(second.id)
+    assert retry_record is not None
+    assert retry_record.items[-1].kind is TurnItemKind.ASSISTANT_MESSAGE
+    assert all(
+        item.kind is not TurnItemKind.USER_MESSAGE for item in retry_record.items
+    )
     await runtime.shutdown()
     store.close()
 
@@ -686,7 +743,9 @@ async def test_late_executor_exception_reuses_existing_terminal_turn(
         raise RuntimeError("late executor event")
 
     runtime = ConversationRuntime(store, execute)
-    handle = await runtime.start_turn(TurnRequest("programmatic:terminal-race", "hello"))
+    handle = await runtime.start_turn(
+        TurnRequest("programmatic:terminal-race", "hello")
+    )
 
     result = await handle.result()
 

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -17,7 +17,9 @@ import infra.mobile_realtime.channel as channel_module
 import infra.mobile_realtime.gateway as gateway_module
 
 from agent.config_models import MobileRealtimeConfig
-from agent.control.models import TurnRecord, TurnStatus
+from agent.control.errors import ControlExecutionError
+from agent.control.models import TurnRecord, TurnRequest, TurnStatus
+from agent.control.runtime import ConversationRuntime
 from agent.plugin_composition import (
     CapabilitySources,
     ConnectionDescriptor,
@@ -450,6 +452,66 @@ async def test_mobile_message_send_uses_exact_v3_ingress_without_legacy_bus(
     assert raw.message.channel == "akashic"
     assert raw.message.metadata["session_key_override"] == session_id
     assert raw.message.metadata["mobile_v3_handoff"] is True
+    manager.close()
+    storage.close()
+
+
+@pytest.mark.asyncio
+async def test_mobile_message_send_accepts_only_explicit_latest_failed_retry(
+    tmp_path: Path,
+) -> None:
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    runtime = _Runtime(storage)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
+    bus = _Bus()
+    manager = SessionManager(tmp_path / "workspace")
+    session_id = f"akashic:{uuid4()}"
+    manager.save(manager.get_or_create(session_id))
+    await channel.start(
+        cast(
+            Any,
+            SimpleNamespace(
+                bus=bus,
+                session_manager=manager,
+                event_bus=_EventBus(),
+                push_tool=_PushTool(),
+                interrupt_controller=None,
+                attachment_store=AttachmentStore(tmp_path / "uploads"),
+            ),
+        )
+    )
+    source_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+    async def fail(_request: TurnRequest) -> str:
+        raise ControlExecutionError("provider_offline", "offline", retryable=True)
+
+    control_runtime = ConversationRuntime(manager.control_store, fail)
+    failed = await control_runtime.start_turn(
+        TurnRequest(
+            session_id,
+            "u1",
+            {"inboundMetadata": {"client_message_id": source_id}},
+        )
+    )
+    assert (await failed.result()).status is TurnStatus.FAILED
+
+    retry_id = "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+    reply = await channel.handle_command(
+        device_id=device_id,
+        frame=_message_frame(
+            frame_id=retry_id,
+            session_id=session_id,
+            retry_of_client_message_id=source_id,
+        ),
+    )
+
+    assert reply.type == "message.send.ok"
+    raw = cast(RawInbound, bus.inbound[-1])
+    assert raw.message.metadata["retry_of_client_message_id"] == source_id
+    await control_runtime.shutdown()
+    await channel.stop()
     manager.close()
     storage.close()
 
@@ -1182,7 +1244,7 @@ async def test_model_catalog_returns_bound_registry_and_session_selection(
             "sourceName": "OpenAI",
             "reasoningEffort": "medium",
             "supportedReasoningEfforts": ["low", "medium", "high"],
-                "roles": ["agent", "default"],
+            "roles": ["agent", "default"],
             "contextWindow": 128_000,
             "inputModalities": ["text", "image"],
         }
@@ -1546,6 +1608,7 @@ def _message_frame(
     model_runtime_id: str | None = None,
     model_reasoning_effort: str | None = None,
     media_refs: list[str] | None = None,
+    retry_of_client_message_id: str | None = None,
 ) -> MessageSendCommand:
     frame = parse_frame(
         json.dumps(
@@ -1563,6 +1626,11 @@ def _message_frame(
                     "media_refs": media_refs or [],
                     "client_created_at": datetime.now(timezone.utc).isoformat(),
                     **({"reply_to": reply_to} if reply_to is not None else {}),
+                    **(
+                        {"retry_of_client_message_id": (retry_of_client_message_id)}
+                        if retry_of_client_message_id is not None
+                        else {}
+                    ),
                     **(
                         {"model_runtime_id": model_runtime_id}
                         if model_runtime_id is not None
@@ -2829,7 +2897,10 @@ async def test_failed_terminal_accepts_client_message_id_without_user_message_id
                 channel="akashic",
                 chat_id=session_id.removeprefix("akashic:"),
                 content="处理消息时出错，请稍后再试。",
-                metadata={"client_message_id": "cmid-fail"},
+                metadata={
+                    "client_message_id": "cmid-fail",
+                    "retryable": False,
+                },
                 control_turn_id=turn_id,
                 execution_attempt_id=turn_id,
                 terminal_status=TurnTerminalStatus.FAILED,
@@ -2843,9 +2914,10 @@ async def test_failed_terminal_accepts_client_message_id_without_user_message_id
     assert payload == {
         "status": "failed",
         "message": "处理消息时出错，请稍后再试。",
-        "control_turn_id": turn_id,
-        "client_message_id": "cmid-fail",
-    }
+            "control_turn_id": turn_id,
+            "client_message_id": "cmid-fail",
+            "retryable": False,
+        }
     final_records = [
         record
         for record in caplog.records

--- a/tests/mobile_realtime/test_mobile_realtime_protocol.py
+++ b/tests/mobile_realtime/test_mobile_realtime_protocol.py
@@ -118,6 +118,22 @@ def test_message_send_validates_reply_identity() -> None:
         parse_frame(json.dumps(invalid))
 
 
+def test_message_send_validates_explicit_retry_identity() -> None:
+    frame = _golden_frame(0)
+    frame["payload"]["retry_of_client_message_id"] = "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+
+    parsed = parse_frame(json.dumps(frame))
+
+    assert isinstance(parsed, MessageSendCommand)
+    assert parsed.payload.retry_of_client_message_id == "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+
+    frame["payload"]["retry_of_client_message_id"] = frame["payload"][
+        "client_message_id"
+    ]
+    with pytest.raises(ValidationError, match="必须指向既有消息"):
+        parse_frame(json.dumps(frame))
+
+
 def test_message_send_accepts_real_client_creation_time() -> None:
     frame = _golden_frame(0)
     frame["payload"]["client_created_at"] = "2026-07-16T12:34:56+08:00"

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -308,6 +308,19 @@ def test_find_turn_by_client_message_id_unique_none_and_duplicate_fail_loud(
     store.close()
 
 
+def test_find_turn_by_client_message_id_recovers_retry_attempt(tmp_path) -> None:
+    store = SessionStore(tmp_path / "sessions.db")
+    retry = _queued("turn:retry", "mobile:one")
+    retry.metadata["retryClientMessageId"] = "client:retry"
+    store.create_turn(retry)
+
+    matched = store.find_turn_by_client_message_id("mobile:one", "client:retry")
+
+    assert matched is not None
+    assert matched.id == "turn:retry"
+    store.close()
+
+
 def test_recover_in_progress_turns_converges_queued_and_in_progress(tmp_path) -> None:
     store = SessionStore(tmp_path / "sessions.db")
     store.create_turn(_turn_with_client_message("turn:q", "mobile:q", "client:q"))


### PR DESCRIPTION
## 问题与结果

- 解决的问题：Mobile 把 failed、cancelled 和 interrupted 都显示成“本轮已中止”，用户重发失败输入会追加第二条 User Message。
- 用户可见结果：失败、取消和中止分别显示；只有 retryable failed 提供显式重试；连续重试仍只有一条 User Message，同一逻辑 Turn 内增加 Attempt。
- 本 PR 不处理：自动重试、按正文猜测重试、普通重复发送去重、正式部署。

## Change intent

- change_type：fix
- semantic_delta：compatible
- capability_owner：mixed
- consumer_scope：Core Mobile protocol、PassiveWorker、共享 Mobile WebUI、Android 配套 PR
- runtime_patch：required
- runtime_patch_reason：复用 User Message 并新建 Attempt 属于 Core Turn/Attempt 语义，客户端不能自行伪造。
- authoritative_state_owner：SessionStore turns 与 ConversationRuntime
- client_only_alternative：只能修正文案，无法阻止重复 User Message 或安全恢复 handoff。
- concept_gate：required
- concept_gate_reason：改变失败重试的 Turn/Attempt 归属；提交后由 Terra xhigh 只读复审。
- 关联不变量：SessionDB messages 只追加；显式重试不追加 userMessage item；普通发送仍是新输入。
- protected_state：既有 SessionDB messages、workspace、插件状态与正式服务。
- 允许的副作用：增加可选 message.send 字段、Turn metadata 和终态 retryable 投影。
- 禁止的副作用：正文匹配、历史删除/改写、自动重试、部署。

## 改动范围

- 主要文件：agent/control/runtime.py、bootstrap/passive_worker.py、infra/mobile_realtime、frontend/chat/src/mobile-native.tsx、session/store.py。
- 配置或迁移影响：无数据库迁移；协议仅兼容新增 retry_of_client_message_id 与 failed.retryable。
- 已知 schema lineage 与最终 schema identity：schema/mobile-realtime-v1.json SHA-256 ce82ff7a534531ca5e4b1dcdf809efd2561a1751fb28f4627fc4a742833ea7d7。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：Core 3ee32b2a7e796b065bb368fbe632ae38bfae14ea；Android 配套 PR 固定该 revision/tree/schema。
- 回滚方式：revert 本 PR；无持久 schema 或消息迁移需要回滚。

## 验证

- [x] 相关 targeted tests 已通过：control + mobile_realtime 405 passed。
- [x] 前端 typecheck 通过；目标文件 eslint 无 error；mobile Web build 与 clean-commit package 通过。
- [ ] python docker/debug/gate.py run --base origin/main 未运行；本轮使用真实 Channel/PassiveWorker targeted tests 与移动端 runtime contract 校验。
- sourceDigest：ce82ff7a534531ca5e4b1dcdf809efd2561a1751fb28f4627fc4a742833ea7d7
- planDigest：not_applicable
- 真实设备证据：未运行；本 PR 未部署。
- 未运行项与原因：全仓 eslint 被既存 frontend/chat/src/kaomoji-markdown.ts 的 3 个错误阻断；隔离设备 Gate 留给 Android PR。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：yes
- 独立 reviewer / model / reasoning：Terra / xhigh，PR 创建后执行
- 审查 head：3ee32b2a7e796b065bb368fbe632ae38bfae14ea
- 新增概念及其唯一 owner：不新增领域概念；retry_of_client_message_id 是协议中的显式来源 identity。
- 无关设计轴的变化传播：none
- 最短正常/失败/热更新链路：message.send → Attempt → failed(retryable) → 显式 retry → 新 Attempt → final；无热更新变化。
- legacy/source-specific 残留扫描：普通 send、stop、recovery 与旧客户端省略新字段均保留。
- must-fix 及处置证据：首轮 Terra 指出的 Mobile failed 后普通发送错误续入旧 interaction、以及 retry capacity precheck/reject 丢失 retry 语义均已修复；新增 U1 failed → 普通 U2、near-capacity retry 和 scoped fresh 回归。
- 最终结论：Terra xhigh 第二轮终审 PASS（P0=0、P1=0）；保留 1 个 Android file-backed fixture 的 P2 覆盖建议，不是已证实行为缺陷。

## 工作手册

- [x] 已核对 projectneed.md、相关设计和 NOW.md。
- [x] 长期语义由用户明确确认：失败重试属于同一 Turn 的新 Attempt，不新增 User Message。
- [x] 跨仓库能力由 Core 拥有；Android 只持有 Room/outbox 与原生投影。
- [x] 当前 NOW.md 没有对应完成项。
