### PR TITLE
fix(release): wait for created core containers

### DIFF
--- a/scripts/restart_host_runtime_release.py
+++ b/scripts/restart_host_runtime_release.py
@@ -39,6 +39,7 @@ def wait_for_core_health(container_name: str, timeout_sec: float) -> None:
                 "inspect",
                 container_name,
                 "--format",
+                "{{.State.Status}}|"
                 "{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}",
             ],
             check=False,
@@ -46,7 +47,18 @@ def wait_for_core_health(container_name: str, timeout_sec: float) -> None:
             text=True,
         )
         if result.returncode == 0:
-            status = result.stdout.strip()
+            try:
+                container_status, health_status = result.stdout.strip().split("|", 1)
+            except ValueError as error:
+                raise RuntimeError(
+                    f"Docker inspect 返回非法状态: {result.stdout.strip()!r}"
+                ) from error
+            status = (
+                "starting"
+                if health_status == "missing"
+                and container_status in {"created", "restarting"}
+                else health_status
+            )
         elif "No such object" in result.stderr or "No such container" in result.stderr:
             status = "starting"
         else:

--- a/tests/test_host_runtime_lifecycle.py
+++ b/tests/test_host_runtime_lifecycle.py
@@ -64,7 +64,7 @@ def test_release_restart_does_not_control_external_services(monkeypatch) -> None
         arguments: list[str], **_kwargs: object
     ) -> subprocess.CompletedProcess[str]:
         calls.append(arguments)
-        output = "healthy\n" if arguments[0] == "docker" else ""
+        output = "running|healthy\n" if arguments[0] == "docker" else ""
         return subprocess.CompletedProcess(arguments, 0, output, "")
 
     monkeypatch.setattr("subprocess.run", run)
@@ -91,7 +91,7 @@ def test_release_restart_rejects_unhealthy_core(monkeypatch) -> None:
     monkeypatch.setattr(
         "subprocess.run",
         lambda arguments, **_kwargs: subprocess.CompletedProcess(
-            arguments, 0, "unhealthy\n", ""
+            arguments, 0, "running|unhealthy\n", ""
         ),
     )
     with pytest.raises(RuntimeError, match="healthcheck 未通过"):
@@ -106,11 +106,29 @@ def test_release_restart_waits_for_container_creation(monkeypatch) -> None:
             subprocess.CompletedProcess(
                 [], 1, "", "Error: No such object: akashic-core"
             ),
-            subprocess.CompletedProcess([], 0, "healthy\n", ""),
+            subprocess.CompletedProcess([], 0, "running|healthy\n", ""),
         )
     )
     monkeypatch.setattr("subprocess.run", lambda *_args, **_kwargs: next(results))
     monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    wait_for_core_health("akashic-core", 10)
+
+
+def test_release_restart_waits_while_container_depends_on_controller(
+    monkeypatch,
+) -> None:
+    from scripts.restart_host_runtime_release import wait_for_core_health
+
+    results = iter(
+        (
+            subprocess.CompletedProcess([], 0, "created|missing\n", ""),
+            subprocess.CompletedProcess([], 0, "running|starting\n", ""),
+            subprocess.CompletedProcess([], 0, "running|healthy\n", ""),
+        )
+    )
+    monkeypatch.setattr("subprocess.run", lambda *_args, **_kwargs: next(results))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
     wait_for_core_health("akashic-core", 10)
 
 


### PR DESCRIPTION
## What changed

- inspect both Docker container state and health state during release activation
- keep waiting while the Core container is `created` or `restarting` and has not received a health state yet
- continue to fail immediately when a running container is unhealthy or has no healthcheck

## Why

The Computer release adds a healthy Workload Controller dependency. Docker Compose creates the Core container before that dependency becomes healthy, so the container temporarily reports `created` without `.State.Health`. The release probe treated this valid startup phase as a broken healthcheck and rolled the candidate back before Docker could start it.

## Validation

- `python -m pytest tests/test_akashic_release_installer.py tests/test_build_host_runtime_release.py tests/test_host_runtime_cli.py tests/test_host_runtime_healthcheck.py tests/test_host_runtime_lifecycle.py tests/test_release_source_identity.py tests/test_verify_host_runtime_deployment.py -q` — 54 passed
- `python -m black --check scripts/restart_host_runtime_release.py tests/test_host_runtime_lifecycle.py`
- `python docker/debug/gate.py run --base origin/main` — passed, report `20260901-023806-14faf777`

## Recovery

Revert this commit to restore the previous immediate rejection of any container without `.State.Health`.
