### PR TITLE
[codex] fix embeddings provider batch limits

### DIFF
--- a/plugins/openai_compatible/driver.py
+++ b/plugins/openai_compatible/driver.py
@@ -82,6 +82,7 @@ class _ConnectionConfig:
 @dataclass(frozen=True, slots=True)
 class _ModelConfig:
     max_tool_schemas: int | None
+    embedding_batch_size: int
 
 
 class _BoundChat:
@@ -159,18 +160,21 @@ class _BoundEmbedding:
 
         if not texts or any(not isinstance(text, str) for text in texts):
             raise ValueError("embedding texts must be a non-empty string sequence")
-        body: dict[str, Any] = {
-            "model": self._descriptor.model,
-            "input": list(texts),
-        }
-        payload = await _request_json(
-            self._connection,
-            self._credential,
-            "POST",
-            "/embeddings",
-            body=body,
-        )
-        return _parse_embedding_response(payload, expected_count=len(texts))
+        vectors: list[tuple[float, ...]] = []
+        usages: list[ModelUsage | None] = []
+        for start in range(0, len(texts), self._config.embedding_batch_size):
+            batch = texts[start : start + self._config.embedding_batch_size]
+            payload = await _request_json(
+                self._connection,
+                self._credential,
+                "POST",
+                "/embeddings",
+                body={"model": self._descriptor.model, "input": list(batch)},
+            )
+            result = _parse_embedding_response(payload, expected_count=len(batch))
+            vectors.extend(result.vectors)
+            usages.append(result.usage)
+        return EmbeddingResult(vectors=tuple(vectors), usage=_merge_usage(usages))
 
 
 def definition() -> ModelDriverDefinition:
@@ -349,6 +353,7 @@ def _connection_config(descriptor: DriverConnectionDescriptor) -> _ConnectionCon
 def _model_config(config: Mapping[str, Any]) -> _ModelConfig:
     allowed = {
         "format_version",
+        "embedding_batch_size",
         "max_tool_schemas",
         "use_responses_lite",
         "reasoning_summary",
@@ -370,7 +375,17 @@ def _model_config(config: Mapping[str, Any]) -> _ModelConfig:
         raise ValueError("use_responses_lite belongs to a different driver")
     if config.get("reasoning_summary", "none") not in {"", "none"}:
         raise ValueError("reasoning_summary belongs to a different driver")
-    return _ModelConfig(max_tool_schemas=max_tool_schemas)
+    embedding_batch_size = config.get("embedding_batch_size", 10)
+    if (
+        not isinstance(embedding_batch_size, int)
+        or isinstance(embedding_batch_size, bool)
+        or embedding_batch_size <= 0
+    ):
+        raise ValueError("embedding_batch_size must be a positive integer")
+    return _ModelConfig(
+        max_tool_schemas=max_tool_schemas,
+        embedding_batch_size=embedding_batch_size,
+    )
 
 
 def _chat_body(
@@ -940,6 +955,43 @@ def _usage(raw: Mapping[str, Any]) -> ModelUsage:
         cached_input_tokens=cached,
         output_tokens=output_tokens,
         reasoning_output_tokens=reasoning,
+        covered_request_count=covered,
+        coverage=coverage,
+    )
+
+
+def _merge_usage(items: Sequence[ModelUsage | None]) -> ModelUsage | None:
+    """Merge per-request usage while preserving unknown token counts."""
+
+    if not any(item is not None for item in items):
+        return None
+    normalized = tuple(item or ModelUsage() for item in items)
+
+    def total(field: str) -> int | None:
+        known = [
+            value
+            for item in normalized
+            if (value := getattr(item, field)) is not None
+        ]
+        return sum(known) if known else None
+
+    request_count = sum(item.request_count for item in normalized)
+    covered = sum(item.covered_request_count for item in normalized)
+    coverage = (
+        UsageCoverage.UNAVAILABLE
+        if all(item.coverage is UsageCoverage.UNAVAILABLE for item in normalized)
+        else UsageCoverage.EXACT
+        if covered == request_count
+        and all(item.coverage is UsageCoverage.EXACT for item in normalized)
+        else UsageCoverage.PARTIAL
+    )
+    return ModelUsage(
+        input_tokens=total("input_tokens"),
+        cache_write_input_tokens=total("cache_write_input_tokens"),
+        cached_input_tokens=total("cached_input_tokens"),
+        output_tokens=total("output_tokens"),
+        reasoning_output_tokens=total("reasoning_output_tokens"),
+        request_count=request_count,
         covered_request_count=covered,
         coverage=coverage,
     )

--- a/tests/test_openai_compatible_model_plugin.py
+++ b/tests/test_openai_compatible_model_plugin.py
@@ -136,7 +136,12 @@ class _Handler(BaseHTTPRequestHandler):
             vectors = (
                 ([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
                 if len(inputs) == 2
-                else tuple([1.0, 0.0, 0.0] for _ in inputs)
+                else tuple(
+                    [float(value.removeprefix("item-")), 0.0, 0.0]
+                    if isinstance(value, str) and value.startswith("item-")
+                    else [1.0, 0.0, 0.0]
+                    for value in inputs
+                )
             )
             self._json(
                 200,
@@ -532,6 +537,32 @@ async def test_driver_discovers_chats_and_runs_nonstream_stream_and_embedding() 
         )
         assert sent["reasoning_effort"] == "high"
         assert sent["messages"][0] == {"role": "system", "content": "system"}
+
+
+@pytest.mark.asyncio
+async def test_embedding_uses_default_batch_limit_and_preserves_order() -> None:
+    with _provider() as (server, endpoint):
+        opened = await definition().open(_connection(endpoint), _Credential())
+        with pytest.raises(ValueError, match="embedding_batch_size"):
+            opened.bind_embedding(
+                _embedding_descriptor(),
+                {"embedding_batch_size": 0},
+            )
+        embedding = opened.bind_embedding(_embedding_descriptor(), {})
+
+        result = await embedding.embed(tuple(f"item-{index}" for index in range(23)))
+
+        requests = [
+            request["body"]["input"]
+            for request in server.requests
+            if request["path"] == "/v1/embeddings"
+        ]
+        assert [len(batch) for batch in requests] == [10, 10, 3]
+        assert result.vectors == tuple((float(index), 0.0, 0.0) for index in range(23))
+        assert result.usage is not None
+        assert result.usage.input_tokens == 12
+        assert result.usage.request_count == 3
+        assert result.usage.coverage is UsageCoverage.PARTIAL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- split OpenAI-compatible embedding calls by a per-model `embedding_batch_size`
- default the limit to 10 so existing models recover without a registry rewrite
- preserve input order and aggregate usage across provider requests

## Why

Wake passes every unscored due item to the embedding model. The current provider rejects batches larger than 10, so one 55-item feed refresh caused every Wake maintenance attempt to fail before scoring.

## Impact

Callers keep the same one-call embedding API. Models with a different provider limit can override `embedding_batch_size`; existing model configs use the safe default.

## Validation

- `python -m pytest -q tests/test_openai_compatible_model_plugin.py` — 7 passed
- `pyright plugins/openai_compatible/driver.py tests/test_openai_compatible_model_plugin.py` — 0 errors
- change-impact Gate — passed, report `docker/debug/reports/change-gate/20260902-131515-11811d72`

## Rollback

Revert commit `890eee82`. No schema or persisted workspace data changes are included.
