### PR TITLE
[codex] 收敛 Computer 单一工具入口与网页使用指引

### DIFF
--- a/docs/design/computer-driver-source-migration.md
+++ b/docs/design/computer-driver-source-migration.md
@@ -165,3 +165,36 @@ reward 为 0，与原版 Browser + Desktop 相同。最终冻结镜像复验记�
 构建命令：`docker build -f docker/computer/Dockerfile -t akashic-computer:driver-source-20260905 .`。
 现有镜像工作流仍可发布这个 Dockerfile。后续更新镜像时核验 registry digest，再同步两处 pin 并走正式插件安装/candidate 链；
 不手改 cache。恢复使用开工备份与旧镜像 digest，profile 不迁移也不清空。
+
+## 7. 单一工具入口与网页工具选择
+
+模型只使用普通插件工具 `computer`。删除四个旧 MCP 工具的声明、schema 和动作适配；
+旧工具名再次调用会显式失败，历史消息和调用记录保持原样。无需迁移 profile 或更换容器镜像。
+
+参考 `codex-desktop-rev/computer-use-plugin/unified-computer-use/resources/` 的
+`server-instructions.md`、`js-tool-description.md`、`browser-description.md` 和
+`computer-description.md`：参考项目将 CU 定义为通过持久 JS 读取或操作界面，
+优先使用已有专用 skill、connector、API 或 CLI，并在首次调用返回后按需读取 API 文档。
+该本地参考快照没有明确的 web_search/web_fetch 分流条款；以下规则是维护者确认的 Akashic 适配，
+不冒充参考项目原文：
+
+- 普通信息查询优先 `web_search` / `web_fetch`。
+- 交互、登录态、已有标签、视觉检查或桌面控制使用 `computer`；检索抓取失败或内容不足时也使用它。
+- 已明确需要界面操作时直接使用，不强制先失败一次。用户明确指定浏览器时遵从。
+- 根据实际页面状态确认结果，不把部分内容称为完整结果，不为某个网站增加专用规则。
+
+```text
+信息查询 ──→ web_search / web_fetch
+                   │ 内容不足或失败
+                   ▼
+界面操作 ──→ computer skill → computer → Browser / Desktop
+```
+
+MCP 子进程仍承接现有 WorkloadEnv 注入、v2/source/ready 检查和控制连接取消回执；
+`tools/list` 返回空列表，它不再向模型发布工具。普通插件 Context 当前没有 Workload endpoint
+读取接口，删除该进程需要另改 Core 生命周期；本次不引入这样的扩展。
+容器 HTTP 路由仍被既有 Cua benchmark adapter 和驱动集成检查使用，不以删除 Agent 工具为由
+破坏这些消费者。Dashboard 的 activity/display 和人工接管保持不变。
+
+验收复用真实 Root 与容器夹具：普通工具目录唯一入口、MCP 空目录与旧调用拒绝、
+截图直传/文字模型提示、取消释放和 Turn 标签收尾。真实模型任务另检查无需提示工具名称的发现路径。

--- a/docs/design/computer-plugin-workload-task-contract.md
+++ b/docs/design/computer-plugin-workload-task-contract.md
@@ -414,8 +414,8 @@ WorkloadData 也不能挂正式目录；Computer candidate 只使用隔离复制
 - Gateway：`/health`、`/activity`、`/screenshot`、`/input` 和结构化 Browser route；
 - 同一 Xvnc 桌面、轻量窗口管理器、Chromium/profile 与 RFB WebSocket bridge 的启动和监督；
 - OpenCLI daemon/extension 配对和登录自动刷新；
-- 直接通过 CDP 实现的 `browser_observe`、`browser_action`，以及视觉
-  `computer_observe`、`computer_action` MCP Tool；
+- 唯一的普通插件工具 `computer`，组合 Browser 与 Desktop 驱动；
+- MCP 子进程只承接 WorkloadEnv、启动检查和驱动控制连接，不发布模型工具；
 - `opencli` Skill；Skill 只教 Agent 通过普通 `shell` 调用 CLI，不把 CLI 参数包装成 Browser Tool；
 - `conversation.tools.v1` 中的 Computer 标签；标签使用标准 noVNC RFB client，不自行模拟鼠标或键盘；
 - 人工输入经 generation-bound dashboard WebSocket 到 RFB；Agent 视觉输入经 Gateway 到同一个 Xvnc display；
@@ -435,26 +435,22 @@ OpenCLI daemon、extension 和 connectivity 可用。登录态是各站自己的
 
 ## 9. Agent 能力
 
-Browser Use 分成只读 `browser_observe` 和写入 `browser_action`。前者首版提供 `snapshot`、`get_content`、
-`get_url`、`get_title`、`screenshot` 和 `tab_list`；每次 snapshot 返回不透明 `snapshot_id`，ref 只在该快照、
-标签页和文档内有效，导航或 DOM 节点失效后必须明确报 stale。后者提供 `navigate`、基于 snapshot ref 的 `click`、
-`fill`、`type`、`press`、`scroll`、`wait`、前进后退、刷新和标签页操作。Browser Tool 直接使用 CDP，
-点击和文字输入使用 CDP 原生 Input 事件；不得转发 OpenCLI argv，也不得让模型猜 CLI 语法。
+Agent 使用 `computer` 执行持久 JavaScript，通过 `browser` 读取页面结构和操作元素，通过
+`sky` 完成桌面输入和截图。调用身份、取消、标签归属和 Turn 收尾见
+[驱动源码迁移](computer-driver-source-migration.md)。原四个 MCP 工具已移除。
 截图结果原子写入 Computer plugin-data 下的有界文件集合并返回绝对路径，统一提示用 `read_file`
 读取。`read_file` 按当前 Agent 的真实模型能力提供图片内容；不支持图片时才提示使用
 `read_image_vision`。截图工具不把 base64 当作文本返回；每次写入仍只保留最近 32 张截图。
 
-视觉 Computer Use 首版只有：`observe`、`move`、`click`、`double_click`、`drag`、`scroll`、`type`、`key`
-和 `wait`。Gateway 只接受这组固定动作和有界参数。Agent 通过 MCP 调用；用户通过完整 RFB client 直接使用
-全部鼠标按钮、移动、拖动、滚轮、普通键、组合键、连续输入和剪贴板。两条路径不建立第二套桌面、浏览器或 profile。
-
-`move`、`click` 和 `double_click` 使用 1280×800 画面中的 `x`、`y`；`drag` 额外使用同一边界内的
-`to_x`、`to_y`。
+用户通过完整 RFB client 使用桌面；Agent 通过同一个容器内的驱动操作。两条路径复用同一桌面、
+浏览器和 profile。原 HTTP 路由仍供已有 benchmark 与驱动检查使用，不作为模型工具发布。
 
 能力选择顺序：
 
 ```text
-OpenCLI Skill + shell → Browser Use → visual Computer Use → 用户完成登录
+普通信息 → web_search / web_fetch
+专用站点能力 → OpenCLI skill + shell
+界面交互、登录态、视觉检查或抓取不足 → computer skill + computer
 ```
 
 ## 10. 数据与迁移

--- a/plugins/computer/akashic.plugin.toml
+++ b/plugins/computer/akashic.plugin.toml
@@ -51,8 +51,6 @@ pids = 0
 [[mcp]]
 name = "computer"
 command = ["mcp_server.py"]
-required_tools = ["browser_observe", "browser_action", "computer_observe", "computer_action"]
-candidate_read_only_tools = ["browser_observe", "computer_observe"]
 
 [[mcp.workload_env]]
 env = "COMPUTER_URL"

--- a/plugins/computer/mcp_server.py
+++ b/plugins/computer/mcp_server.py
@@ -12,8 +12,6 @@ import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 import httpx
 from control import endpoint_name
@@ -26,156 +24,6 @@ _SCREENSHOT_EXTENSIONS = {
     "image/webp": ".webp",
 }
 _MAX_SCREENSHOT_FILES = 32
-
-TOOLS = (
-    {
-        "name": "browser_observe",
-        "description": (
-            "Inspect the persistent Chromium browser without changing page state. "
-            "Use snapshot before actions so later calls can target stable element refs. "
-            "Screenshots are saved as local files; use read_file with the returned path."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "observe": {
-                    "type": "string",
-                    "enum": [
-                        "snapshot",
-                        "get_content",
-                        "get_url",
-                        "get_title",
-                        "screenshot",
-                        "tab_list",
-                    ],
-                },
-                "target_id": {"type": "string", "maxLength": 128},
-            },
-            "required": ["observe"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "browser_action",
-        "description": (
-            "Operate the persistent Chromium browser through CDP. Prefer a ref from "
-            "browser_observe snapshot over coordinates or guessed selectors."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": [
-                        "navigate",
-                        "click",
-                        "fill",
-                        "type",
-                        "press",
-                        "scroll",
-                        "wait",
-                        "go_back",
-                        "go_forward",
-                        "reload",
-                        "tab_new",
-                        "tab_select",
-                        "tab_close",
-                    ],
-                },
-                "url": {"type": "string", "maxLength": 8192},
-                "ref": {"type": "string", "pattern": "^e[1-9][0-9]{0,3}$"},
-                "snapshot_id": {"type": "string", "maxLength": 64},
-                "text": {"type": "string", "maxLength": 16384},
-                "key": {"type": "string", "maxLength": 80},
-                "direction": {
-                    "type": "string",
-                    "enum": ["up", "down", "left", "right"],
-                },
-                "amount": {"type": "integer", "minimum": 1, "maximum": 5000},
-                "timeout": {"type": "integer", "minimum": 0, "maximum": 30000},
-                "target_id": {"type": "string", "maxLength": 128},
-            },
-            "required": ["action"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "computer_observe",
-        "description": (
-            "Read the current desktop screenshot or Computer activity state. Screenshots "
-            "are saved as local files; use read_file with the returned path."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "observe": {"type": "string", "enum": ["screenshot", "activity"]}
-            },
-            "required": ["observe"],
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "computer_action",
-        "description": (
-            "Control the persistent desktop. Use browser first for web pages; use this "
-            "for login screens, native dialogs, or visual-coordinate fallback."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": [
-                        "click",
-                        "double_click",
-                        "move",
-                        "drag",
-                        "type",
-                        "key",
-                        "scroll",
-                        "wait",
-                    ],
-                },
-                "mouse_button": {"type": "string", "enum": ["left", "middle", "right"]},
-                "x": {"type": "integer", "minimum": 0, "maximum": 1279},
-                "y": {"type": "integer", "minimum": 0, "maximum": 799},
-                "to_x": {"type": "integer", "minimum": 0, "maximum": 1279},
-                "to_y": {"type": "integer", "minimum": 0, "maximum": 799},
-                "text": {"type": "string", "maxLength": 16384},
-                "key": {"type": "string", "maxLength": 80},
-                "amount": {"type": "integer", "minimum": -100, "maximum": 100},
-                "ms": {"type": "integer", "minimum": 0, "maximum": 30000},
-            },
-            "required": ["action"],
-            "additionalProperties": False,
-        },
-    },
-)
-
-
-def request(path: str, payload: dict[str, Any] | None = None) -> tuple[bytes, str]:
-    """Call the Workload gateway and return its bounded response."""
-
-    if not BASE_URL:
-        raise RuntimeError("COMPUTER_URL is missing")
-    data = None if payload is None else json.dumps(payload).encode("utf-8")
-    req = Request(
-        BASE_URL + path,
-        data=data,
-        method="GET" if payload is None else "POST",
-        headers={"content-type": "application/json"},
-    )
-    try:
-        with urlopen(req, timeout=125) as response:
-            body = response.read(8 * 1024 * 1024 + 1)
-            if len(body) > 8 * 1024 * 1024:
-                raise RuntimeError("Computer response is too large")
-            return body, response.headers.get_content_type()
-    except HTTPError as error:
-        detail = error.read(16 * 1024).decode("utf-8", "replace")
-        raise RuntimeError(f"Computer returned HTTP {error.code}: {detail}") from error
-    except URLError as error:
-        raise RuntimeError(f"Computer is unavailable: {error.reason}") from error
 
 
 def save_screenshot(raw: bytes, media_type: str) -> str:
@@ -253,47 +101,6 @@ def screenshot_result(raw: bytes, media_type: str) -> dict[str, object]:
     return {"content": [{"type": "text", "text": json.dumps(value)}]}
 
 
-def call_tool(name: str, arguments: object) -> dict[str, object]:
-    """Execute one known tool and build MCP content blocks."""
-
-    if not isinstance(arguments, dict):
-        raise TypeError("tool arguments must be an object")
-    if name == "browser_observe":
-        raw, _ = request("/browser/observe", arguments)
-        value = json.loads(raw)
-        if arguments.get("observe") == "screenshot":
-            media_type = value.get("mimeType")
-            data = value.get("data")
-            if not isinstance(media_type, str) or not isinstance(data, str):
-                raise RuntimeError("Computer returned an invalid browser screenshot")
-            try:
-                raw = base64.b64decode(data, validate=True)
-            except ValueError as error:
-                raise RuntimeError(
-                    "Computer returned invalid screenshot data"
-                ) from error
-            return screenshot_result(raw, media_type)
-        return {
-            "content": [{"type": "text", "text": json.dumps(value, ensure_ascii=False)}]
-        }
-    if name == "browser_action":
-        raw, _ = request("/browser/action", arguments)
-        return {"content": [{"type": "text", "text": raw.decode("utf-8")}]}
-    if name == "computer_observe":
-        observe = arguments.get("observe")
-        if observe == "activity":
-            raw, _ = request("/activity")
-            return {"content": [{"type": "text", "text": raw.decode("utf-8")}]}
-        if observe == "screenshot":
-            raw, media_type = request("/screenshot")
-            return screenshot_result(raw, media_type)
-        raise ValueError("observe must be screenshot or activity")
-    if name == "computer_action":
-        raw, _ = request("/input", arguments)
-        return {"content": [{"type": "text", "text": raw.decode("utf-8")}]}
-    raise ValueError(f"unknown tool: {name}")
-
-
 def reply(message: dict[str, Any]) -> dict[str, object] | None:
     """Handle one MCP JSON-RPC message."""
 
@@ -314,16 +121,7 @@ def reply(message: dict[str, Any]) -> dict[str, object] | None:
             },
         }
     if method == "tools/list":
-        return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": list(TOOLS)}}
-    if method == "tools/call":
-        params = message.get("params")
-        if not isinstance(params, dict) or not isinstance(params.get("name"), str):
-            raise ValueError("tools/call params are invalid")
-        return {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": call_tool(params["name"], params.get("arguments", {})),
-        }
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": []}}
     return {
         "jsonrpc": "2.0",
         "id": request_id,
@@ -436,7 +234,7 @@ async def control_connection(
 
 
 async def serve() -> None:
-    """MCP 和本代控制连接共用一个事件循环，旧工具保持原协议。"""
+    """通过现有 MCP 生命周期管理驱动连接，不向模型发布 MCP 工具。"""
     async with httpx.AsyncClient(base_url=BASE_URL, timeout=15) as client:
         status = await client.get("/driver/status")
         status.raise_for_status()

--- a/plugins/computer/plugin.py
+++ b/plugins/computer/plugin.py
@@ -51,7 +51,7 @@ _IMAGE = (
 
 
 async def apply(ctx: Context, config: object) -> None:
-    """Register the Computer workload and its narrow MCP adapter."""
+    """注册唯一的 Computer 工具、容器和驱动连接。"""
 
     _ = config
     control_name = endpoint_name(ctx.data_root)
@@ -110,7 +110,12 @@ async def apply(ctx: Context, config: object) -> None:
         PluginToolDefinition(
             name="computer",
             description=(
-                "Run JavaScript against the persistent container browser and Linux desktop. "
+                "Read or operate browser and desktop UI in the persistent container. "
+                "Prefer web_search/web_fetch for information available without UI interaction; "
+                "use this for interactive or login-dependent pages, visual inspection, or when "
+                "search/fetch fails or cannot provide the needed content. "
+                "Prefer suitable dedicated skills, connectors, APIs or CLIs when available. "
+                "Run JavaScript with the initialized browser and desktop APIs. "
                 "Use browser.tabs, tab.ax, tab.playwright, tab.dom_cua or sky. "
                 "Bindings persist within this Session. Call nodeRepl.write(value) or "
                 "nodeRepl.emitImage(bytes) for output. Read the computer skill first."
@@ -183,13 +188,6 @@ async def apply(ctx: Context, config: object) -> None:
         McpServerDefinition(
             name="computer",
             command=("mcp_server.py",),
-            required_tools=(
-                "browser_observe",
-                "browser_action",
-                "computer_observe",
-                "computer_action",
-            ),
-            candidate_read_only_tools=("browser_observe", "computer_observe"),
             workload_env=(WorkloadEnv("COMPUTER_URL", "computer", "gateway"),),
         ),
     )

--- a/plugins/computer/skills/computer/SKILL.md
+++ b/plugins/computer/skills/computer/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: computer
-description: Use the container browser and Linux desktop with persistent JavaScript bindings, accessible elements, locators, and screenshots.
+description: Read or operate browser and desktop UI when a task needs interaction, login state, visual inspection, or content that web search/fetch cannot obtain.
 ---
 
 # Computer
+
+Prefer `web_search` / `web_fetch` for information that can be retrieved without operating UI.
+Use `computer` when the task needs browser interaction, an existing login or tab, desktop controls,
+visual inspection, or when search/fetch fails or returns insufficient content. If UI interaction is
+clearly required, start here without a redundant search/fetch attempt. Prefer a suitable dedicated
+skill, connector, API, or CLI when available. Respect an explicit user request to use the browser.
 
 Use the `computer` tool for browser and desktop work. It runs JavaScript inside the existing Computer
 container, using its logged-in Chromium profile. `browser`, `agent`, `sky`, and `nodeRepl` are ready.
@@ -24,7 +30,8 @@ listed before use. macOS application AX and optional desktop audio are unavailab
    Derive indices from the latest AX state; derive selectors from observed page structure.
 2. Use `fill()` for typed controls such as dates and range sliders, and `selectOption()` for native
    selects. Do not type an ISO date into Chromium's segmented date editor.
-3. Batch related actions and their resulting observation in one call. The driver waits after input;
+3. Verify the resulting UI state before claiming success; partial content does not prove completeness.
+   Batch related actions and their resulting observation in one call. The driver waits after input;
    use page state or locator waits when loading is asynchronous.
 4. Use `sky` for native dialogs, browser chrome, and coordinate actions. Coordinates refer to the
    container's 1280 × 800 desktop. It supports click, move, drag, scroll, press_key, type_text and screenshot.
@@ -53,5 +60,4 @@ reports that the current model cannot accept images.
 `sky.get_screenshot()` returns bytes and a data URL, without a separate temporary filepath. AX state is
 currently full text; its formatting and compression are not claimed identical to the original WASM.
 
-The four legacy `browser_observe/action` and `computer_observe/action` tools remain compatibility entrypoints.
-Prefer `computer` for new work. OpenCLI remains a separate ordinary shell command and uses the same browser.
+OpenCLI remains a separate ordinary shell command and uses the same browser.

--- a/plugins/computer/skills/opencli/SKILL.md
+++ b/plugins/computer/skills/opencli/SKILL.md
@@ -5,7 +5,7 @@ description: Use OpenCLI from the ordinary shell for site adapters, structured w
 
 # OpenCLI
 
-OpenCLI is a command-line program, not the Browser Use tool. Run it with the ordinary `shell` tool; the Computer plugin connects OpenCLI's standard local port to its persistent browser. Use `browser_observe` and `browser_action` when the task needs direct page interaction.
+OpenCLI is a command-line program, not the Browser Use tool. Run it with the ordinary `shell` tool; the Computer plugin connects OpenCLI's standard local port to its persistent browser. For direct page or desktop interaction, load the computer skill and use `computer`.
 
 ## Rules
 
@@ -41,6 +41,5 @@ The Computer plugin refreshes known login sessions every 12 hours and retries a 
 
 ```text
 Site adapter or structured data → OpenCLI through shell
-Direct page navigation or element interaction → browser_observe / browser_action
-Login dialog or whole-desktop fallback → computer_observe / computer_action
+Page or desktop interaction → computer skill + computer
 ```

--- a/tests/test_computer_driver_plugin.py
+++ b/tests/test_computer_driver_plugin.py
@@ -56,6 +56,8 @@ async def test_computer_plugin_mounts_with_static_manifest(tmp_path: Path) -> No
         registry = _freeze_plugin_mcp_servers(mcp, root.instance_token)
         binding = next(iter(registry.values()))
         assert dict(binding.definition.env) == {}
+        assert binding.definition.required_tools == ()
+        assert binding.definition.candidate_read_only_tools == ()
         assert len(registry) == 1
         catalog = _freeze_plugin_tools(
             tools, root.instance_token, {"computer": "computer-test"}
@@ -226,19 +228,18 @@ async def test_computer_control_against_container(tmp_path: Path) -> None:
                     assert len(messages) == 1
                     assert isinstance(messages[0]["content"], str)
 
-        # 1. 新 JS 驱动和两条旧 MCP 截图入口使用相同的读图合同。
+        # 1. 唯一 JS 入口保留读图合同；实际 MCP discovery 不再发布旧工具。
         await check_screenshot_read(output)
-        for request_id, name in enumerate(["computer_observe", "browser_observe"], 2):
-            child.stdin.write(
-                json.dumps({
-                    "jsonrpc": "2.0", "id": request_id, "method": "tools/call",
-                    "params": {"name": name, "arguments": {"observe": "screenshot"}},
-                }).encode() + b"\n"
-            )
-            await child.stdin.drain()
-            reply = json.loads(await asyncio.wait_for(child.stdout.readline(), 20))
-            assert reply["id"] == request_id
-            await check_screenshot_read(reply["result"])
+        child.stdin.write(b'{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n')
+        await child.stdin.drain()
+        reply = json.loads(await child.stdout.readline())
+        assert reply["result"]["tools"] == []
+        child.stdin.write(
+            b'{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"browser_action","arguments":{"action":"navigate","url":"about:blank"}}}\n'
+        )
+        await child.stdin.drain()
+        reply = json.loads(await child.stdout.readline())
+        assert reply["error"]["code"] == -32601
 
         # 2. 保留既有取消及 Turn 收尾验证。
         reader, writer = await asyncio.open_unix_connection(


### PR DESCRIPTION
## 问题与结果

模型仍能精确加载旧 Computer MCP 工具，绕过新的组合 Browser/Desktop API。删除四个旧工具的 schema、调用分支和独占 HTTP adapter，普通插件工具 `computer` 成为唯一模型入口。

工具与 skill 说明：普通信息查询优先 web_search/web_fetch；需要交互、登录态、已有页面、视觉检查，或检索抓取失败/不足时使用 computer。明确需要交互时直接使用，无网站专用规则。参考本地 codex-desktop-rev 的 unified-computer-use/resources：CU 用于读写 UI、优先专用能力；web_search/web_fetch 分流是本项目用户确认的适配，并非原文。

## Change intent

- change_type: refactor; semantic_delta: breaking（移除四个旧工具）。
- capability_owner: plugin; consumer_scope: Agent Computer tools。
- runtime_patch: none; runtime_patch_reason: 复用现有 Workload/MCP 生命周期。
- authoritative_state_owner: 既有 workspace、Chromium/profile 与插件数据 owner 不变。
- client_only_alternative: 不适用，服务端工具目录改变。
- concept_gate: required，独立 Terra xhigh 评审 PASS。
- protected_state: 消息、历史调用、登录态、容器镜像、Dashboard、其他插件。
- 允许副作用: 插件源码、相关测试/文档与隔离验证。
- 禁止副作用: 数据迁移、profile 清理、Core 特判。

## 范围与恢复

MCP 子进程仍负责 WorkloadEnv、启动检查及新工具控制 socket 的取消/drain；tools/list 为空，tools/call 显式拒绝。当前普通 Context 无 Workload endpoint 读取接口，因此保留真实使用的连接层，未为删除进程扩大 Core。

容器 HTTP 接口仍有 Cua benchmark 与集成测试消费者，本 PR 不改变镜像。删除旧模型工具不删除这些底层接口。恢复点：base 33bdaacc；本地 before.tar 已归档全部修改前文件。部署可通过 exact release installer 回到上一代。

## 验证

- Ruff、git diff --check 通过。
- 真实容器插件集成 2/2：Root/static manifest、MCP 空目录和旧调用拒绝、截图多模态直传/文字模型提示、取消及 Turn 标签收尾。
- Node 驱动 4/4：AX、Browser/ownership、native fail-closed、touch release。
- 固定镜像 9bd4f6e2，43 个源码文件一致；测试容器已清理。
- 最终 HEAD change-impact Gate 26/26 通过（20260905-165138-283a38e2），清理完成。
- sourceDigest: 82662cf6d3b7d5f860512390b7ff626749c2cb0cf0c877f38c2d0032a3fd21d4
- planDigest: c124345642de07bf951ecf07906ba7e408452e7999c2deebfb5c7e9327355338
- GitHub CI run 33956400661：check-and-test、change-impact-gate 均通过。
- hua-home 已部署合并提交 b54695231cb7524eda8bd20862ab50ea230d1d7c；installer doctor healthy。
- 真实模型无工具名提示，自行 load_skill(computer) → tool_search → computer；填表/提交、AX、截图确认、关闭自建标签成功。旧工具调用0次。
- 此次默认文字模型 deepseek-v4-flash，read_file 正确提示后使用 read_image_vision；一次 browser.tabs.create 猜错后读取文档并改用 tabs.new 恢复，非零失误运行。
- 停机恢复点 pre-computer-single-tool-20260905-1650：113822文件/71符号链接已归档、解包和hash校验；原14619条消息无丢失或改写，未过期持久Cookie缺失0。原Computer镜像与profile挂载保持。
- LAN HTTP200、公网WSS server.challenge、OpenCLI连接、基础服务和容器健康检查通过。

## 正交性与概念完整性

独立 reviewer: /root/computer_review / gpt-5.6-terra / xhigh；最终审查 head 6a24dd6e698613242790bf63a60d73e2dd8b8c82，概念 Gate PASS，P0/P1/P2 均为 0。首次发现 OpenCLI skill 仍指向旧工具（P1），已在 6a24dd6e 更新该 skill 与现行 Workload 合同，reviewer 复核通过。
新增概念 none；唯一入口沿现有调用身份、控制连接、driver 取消和收尾链执行。
工作手册/NOW 已核对，更新既有驱动迁移文档；无新增持久化语义或 NOW 完成项。