### PR TITLE
[codex] 修复摘要输出截断与不必要的第二次压缩

### DIFF
--- a/docs/design/session-context-compaction-ledger.md
+++ b/docs/design/session-context-compaction-ledger.md
@@ -167,11 +167,19 @@ Critical Context
 保留工具结果、路径、错误、外部 effect、execution ID、关键数值和验证证据；不得补写未
 出现的事实。
 
+旧历史摘要完成后，若当前任务还没有临时摘要，先保留当前任务全部原文并重新计算完整
+messages/tools 的长度。已同时低于软水位和硬边界时，不再生成当前任务摘要；仍超限才
+压缩已闭合的工具批次。已有临时摘要在旧历史摘要更新后仍沿原路径刷新，避免遗漏新的
+历史摘要。当前任务原文不会进入持久 checkpoint 的 source plan。
+
 当前 session 选中的模型先执行 summary；失败后使用同一个冻结 execution generation 的
 configured default 模型。两者都失败、正文为空/格式错误或 summary input 不能落入其硬
 边界时，业务调用明确阻断。summary provider request 使用 `tools=[]`、
 `disable_thinking=True`，不递归进入 business-call Gate；它仍使用自身的硬输入边界并把
 实际 runtime/model/usage 写进 checkpoint/receipt。
+摘要请求使用 `max_output_tokens=0`，由 provider 默认策略决定输出长度，不再设置 8192
+或从模型能力复制输出上限；主模型、fallback 和分块摘要使用同一规则。摘要输入容量
+校验、完整单元分块以及超窗后的错误语义保持不变。
 
 ## 6. Markdown exact source plan
 

--- a/plugins/compaction/engine.py
+++ b/plugins/compaction/engine.py
@@ -39,7 +39,6 @@ SUMMARY_HEADINGS = (
     "## Next Steps",
     "## Critical Context",
 )
-SUMMARY_MAX_TOKENS = 8192
 KEEP_RECENT_TOKENS = 20_000
 SOFT_LIMIT_RATIO = 0.74
 _SUMMARY_PROMPT = """更新当前长任务的上下文压缩摘要。
@@ -503,6 +502,25 @@ class ContextCompactor:
                 ),
             ]
             self._persistent_summary = summary
+
+        # 3. 先放回当前任务原文；旧临时摘要仍需沿既有路径刷新。
+        if selected_committed and selected_active and not previous_temp:
+            restored_active = [*selected_active, *retained_active]
+            restored = _flatten_projection(
+                prefix=current_prefix,
+                committed=retained_committed,
+                current_anchor=current_anchor,
+                temporary_summary=temporary_summary,
+                active=restored_active,
+                pending=pending,
+            )
+            restored_tokens = self._provider.estimate_context_tokens(restored, tools)
+            if restored_tokens < min(soft_limit, hard_limit):
+                selected_active = []
+                retained_active = restored_active
+                selected_all = selected_committed
+                retained_all = [*retained_committed, *retained_active]
+
         rebuilt = _flatten_projection(
             prefix=current_prefix,
             committed=retained_committed,
@@ -513,7 +531,7 @@ class ContextCompactor:
         )
         after = self._provider.estimate_context_tokens(rebuilt, tools)
 
-        # 3. If the committed checkpoint is not enough, compact only closed active batches.
+        # 4. 原文仍超限或已有临时摘要时，摘要已闭合的当前任务批次。
         temporary_checkpoint: ContextCompaction | None = None
         refresh_temporary = bool(selected_active) or (
             bool(previous_temp) and bool(selected_committed)
@@ -586,7 +604,7 @@ class ContextCompactor:
                 f"estimated={after} soft_limit={soft_limit} hard_limit={hard_limit}"
             )
 
-        # 4. Commit only the source-backed row; the active projection remains ephemeral.
+        # 5. Commit only the source-backed row; the active projection remains ephemeral.
         if committed_checkpoint is not None:
             committed_checkpoint = _replace_checkpoint_after_projection(
                 committed_checkpoint,
@@ -836,20 +854,20 @@ class ContextCompactor:
     ) -> tuple[str, ModelUsage | None]:
         """Send one bounded summary request and validate its result."""
 
-        max_tokens = _summary_output_limit(provider, summary_input)
+        _check_summary_input(provider, summary_input)
         if self._chat_call is not None:
             response = await self._chat_call(
                 provider=provider,
                 messages=summary_input,
                 tools=[],
-                max_tokens=max_tokens,
+                max_tokens=0,
                 disable_thinking=True,
             )
         else:
             response = await provider.complete(
                 ModelRequest(
                     messages=summary_input,
-                    max_output_tokens=max_tokens,
+                    max_output_tokens=0,
                     disable_reasoning=True,
                 )
             )
@@ -880,7 +898,7 @@ class ContextCompactor:
                 previous_summary=previous_summary,
             )
             try:
-                _ = _summary_output_limit(provider, summary_input)
+                _check_summary_input(provider, summary_input)
             except ContextCompactionError:
                 high = middle - 1
             else:
@@ -899,7 +917,7 @@ class ContextCompactor:
             previous_summary=previous_summary,
         )
         try:
-            _ = _summary_output_limit(provider, single_input)
+            _check_summary_input(provider, single_input)
         except ContextCompactionError:
             pass
         else:
@@ -1012,10 +1030,12 @@ def _validate_keep_recent_tokens(value: int) -> int:
     return value
 
 
-def _summary_output_limit(
+def _check_summary_input(
     provider: BoundChatModel,
     summary_input: list[dict[str, Any]],
-) -> int:
+) -> None:
+    """校验摘要输入容量，输出长度由 provider 默认策略决定。"""
+
     estimated_input = provider.estimate_context_tokens(summary_input, [])
     context_window = _context_window(provider)
     if estimated_input > context_window:
@@ -1023,11 +1043,6 @@ def _summary_output_limit(
             "context_compaction_summary_input_exceeds_window "
             f"estimated={estimated_input} window={context_window}"
         )
-    configured_max_output = _provider_max_output_tokens(provider)
-    limits = [SUMMARY_MAX_TOKENS]
-    if configured_max_output > 0:
-        limits.append(configured_max_output)
-    return max(1, min(limits))
 
 
 def _copy_segments(segments: ContextPayloadSegments) -> ContextPayloadSegments:
@@ -1405,10 +1420,6 @@ def _aggregate_usage(items: Sequence[ModelUsage]) -> ModelUsage:
 
 def _provider_runtime_id(provider: BoundChatModel) -> str:
     return provider.descriptor.model_id
-
-
-def _provider_max_output_tokens(provider: BoundChatModel) -> int:
-    return provider.descriptor.capabilities.max_output_tokens or 0
 
 
 def _context_window(provider: BoundChatModel) -> int:

--- a/tests/test_context_compaction_contract.py
+++ b/tests/test_context_compaction_contract.py
@@ -12,7 +12,6 @@ from plugins.compaction.engine import (
     ContextCompactionError,
     ContextCompactor,
     ContextPayloadSegments,
-    _summary_output_limit,
 )
 from agent.plugin_composition import (
     BoundModelDescriptor,
@@ -233,8 +232,8 @@ class _UsageProvider(_Provider):
 
 def test_committed_and_temporary_summary_usage_are_aggregated() -> None:
     active_batch = (
-        {"role": "assistant", "tool_calls": [{"id": "c1"}], "tokens": 15},
-        {"role": "tool", "tool_call_id": "c1", "content": "r", "tokens": 15},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}], "tokens": 20},
+        {"role": "tool", "tool_call_id": "c1", "content": "r", "tokens": 20},
     )
     segments = ContextPayloadSegments(
         prefix=(),
@@ -271,6 +270,54 @@ def test_committed_and_temporary_summary_usage_are_aggregated() -> None:
     assert result.checkpoint.summary_usage is not None
     assert result.checkpoint.summary_usage.input_tokens == 10
     assert result.checkpoint.summary_usage.output_tokens == 1
+
+
+@pytest.mark.parametrize("tool_count, expected_calls", [(0, 1), (12, 2)])
+def test_history_summary_keeps_active_originals_when_full_request_fits(
+    tool_count: int, expected_calls: int,
+) -> None:
+    """旧历史摘要后按完整请求复查，只有仍超限才摘要当前工具批次。"""
+
+    batches = tuple(
+        (
+            {"role": "assistant", "content": "", "tool_calls": [{"id": call_id}], "tokens": 15},
+            {"role": "tool", "tool_call_id": call_id, "content": call_id, "tokens": 15},
+        )
+        for call_id in ("sent", "reply")
+    )
+    segments = ContextPayloadSegments(
+        prefix=({"role": "system", "content": "rules", "tokens": 1},),
+        committed_units=(_unit(1, 30), _unit(2, 30)),
+        current_anchor=({"role": "user", "content": "continue", "tokens": 1},),
+        active_batches=batches,
+        pending=({"role": "assistant", "content": "pending", "tokens": 1},),
+    )
+    provider = _UsageProvider()
+    compactor = ContextCompactor(
+        provider=provider, scope_id="restore-active", payload_segments=segments,
+        max_output_tokens=10, next_generation=1, keep_recent_tokens=20,
+    )
+    messages = segments.flatten()
+    original = segments.flatten()
+    tools = [{"type": "function", "function": {"name": f"tool_{i}"}} for i in range(tool_count)]
+
+    result = _run(compactor.prepare(messages, pending_start=8, tools=tools))
+
+    assert len(provider.calls) == expected_calls
+    assert result.checkpoint.source_message_ids == ("m1", "m2")
+    assert result.summary_usage.request_count == expected_calls
+    assert result.estimated_tokens == provider.estimate_context_tokens(messages, tools)
+    assert result.estimated_tokens < 74
+    assert segments.flatten() == original
+    if expected_calls == 1:
+        assert messages[2:] == [*segments.current_anchor, *batches[0], *batches[1], *segments.pending]
+        assert result.pending_start == len(messages) - 1
+        assert compactor._segments.active_batches == batches
+        assert not compactor._segments.temporary_summary
+        assert "sent" not in _call_message_content(provider.calls[0])
+    else:
+        assert "sent" in _call_message_content(provider.calls[1])
+        assert compactor._segments.active_batches == (batches[1],)
 
 
 def test_single_interaction_remains_atomic_after_closed_tool_batches() -> None:
@@ -508,7 +555,8 @@ def test_summary_uses_current_once_then_distinct_fallback_once_with_own_budget()
     assert len(fallback.calls) == 1
     assert current.calls[0]["model"] == "selected-model"
     assert fallback.calls[0]["model"] == "default-model"
-    assert _call_int(fallback.calls[0], "max_tokens") == 8_192
+    assert _call_int(current.calls[0], "max_tokens") == 0
+    assert _call_int(fallback.calls[0], "max_tokens") == 0
     assert result.checkpoint is not None
     assert result.checkpoint.model_runtime_id == "main"
     assert result.checkpoint.model == "default-model"
@@ -671,20 +719,29 @@ def test_logical_interaction_inputs_only_enter_temporary_summary() -> None:
     assert all(value not in committed_prompt for value in ("U1", "U2", "U3"))
 
 
-def test_summary_output_limit_keeps_input_and_output_limits_independent() -> None:
-    summary_input = [{"role": "user", "content": "summary", "tokens": 2}]
-    assert (
-        _summary_output_limit(_Provider(context_window=8_193), summary_input) == 8_192
-    )
-    assert (
-        _summary_output_limit(_Provider(context_window=8_192), summary_input) == 8_192
-    )
-    with pytest.raises(ContextCompactionError, match="summary_input_exceeds_window"):
-        _summary_output_limit(_Provider(context_window=1), summary_input)
+@pytest.mark.parametrize("through_callback", [False, True])
+@pytest.mark.parametrize("model_output_limit", [None, 123])
+def test_summary_request_leaves_output_limit_to_provider(
+    through_callback: bool, model_output_limit: int | None,
+) -> None:
+    """两条摘要调用入口都不把模型能力或历史常量变成输出截断参数。"""
 
-    capped = _Provider(context_window=8_193)
-    capped.max_output_tokens = 123
-    assert _summary_output_limit(capped, summary_input) == 123
+    provider = _Provider()
+    provider.max_output_tokens = model_output_limit
+    segments = ContextPayloadSegments(
+        prefix=(), committed_units=(_unit(1, 30), _unit(2, 30)), current_anchor=(),
+    )
+    compactor = ContextCompactor(
+        provider=provider, scope_id="summary-output", payload_segments=segments,
+        max_output_tokens=100, next_generation=1, keep_recent_tokens=20,
+        chat_call=provider.chat if through_callback else None,
+    )
+
+    result = _run(compactor.prepare(segments.flatten(), pending_start=2, tools=[], force=True))
+
+    assert result.compacted
+    assert len(provider.calls) == 1
+    assert _call_int(provider.calls[0], "max_tokens") == 0
 
 
 def test_summary_reduces_oversized_history_in_bounded_unit_chunks() -> None:
@@ -730,7 +787,7 @@ def test_summary_reduces_oversized_history_in_bounded_unit_chunks() -> None:
     assert result.compacted
     assert len(provider.calls) == 3
     assert "[Previous compaction summary]" in _call_message_content(provider.calls[1])
-    assert all(_call_int(call, "max_tokens") > 0 for call in provider.calls)
+    assert all(_call_int(call, "max_tokens") == 0 for call in provider.calls)
 
 
 def test_summary_shrinks_complete_unit_chunk_after_provider_overflow() -> None:
@@ -953,7 +1010,7 @@ def test_same_turn_temporary_summary_replaces_previous_projection() -> None:
         current_anchor=(),
         active_batches=(active, active),
     )
-    provider = _SentinelProvider()
+    provider = _SentinelProvider(context_window=10)
     compactor = ContextCompactor(
         provider=provider,
         scope_id="same-turn",


### PR DESCRIPTION
## 问题与结果

旧历史和当前任务批次同时被选中时，现有代码在旧历史摘要完成后仍按初始选区生成第二次摘要。现在先放回当前任务原文，重新计算包含工具目录的完整请求；已低于软、硬边界就保留原文，否则继续摘要已闭合批次。已有临时摘要仍沿原路径刷新。

摘要请求不再使用 8192 或模型能力值作为输出上限，统一传入公共模型协议的 `max_output_tokens=0`，由 provider 默认策略决定输出。主模型、fallback、分块摘要和 callback 入口一致；输入容量校验与超窗错误继续有效。

只处理这两个修复。74% 阈值、20k 原文保留目标、推理设置和工具目录不变；工具重排序另见 #551。

## Change intent

- `change_type`: fix；`semantic_delta`: compatible。
- `capability_owner`: plugin；`consumer_scope`: 使用 compaction 插件的请求。
- `runtime_patch`: none；`runtime_patch_reason`: 修复全部位于插件现有引擎，不修改 Core 接口。
- `authoritative_state_owner`: SessionStore 持有 messages/ledger，compaction 插件持有请求投影与摘要策略。
- `client_only_alternative`: 不适用，客户端不拥有摘要调用。
- `concept_gate`: not_applicable；`concept_gate_reason`: 两个局部分支/参数修复，无 owner、生命周期或公共扩展接口重构。
- 关联不变量与 `protected_state`: CTX-001/003/007、SES-005；消息正文、source plan、ledger generation、receipt 与当前用户/未闭合工具记录。
- 允许副作用：减少无需执行的摘要调用、按原协议提交 checkpoint、发布本修复 PR。
- 禁止副作用：改写/删除历史、变更模型目录、迁移正式 workspace、合并或部署。

## 改动范围

- `plugins/compaction/engine.py`：完整请求复查、摘要输出参数与输入校验。
- `tests/test_context_compaction_contract.py`：复用现有 provider/历史夹具验证两条摘要入口、fallback、分块、当前原文及工具预算；原双摘要测试调整为确实仍超限的输入。
- `docs/design/session-context-compaction-ledger.md`：补充两项可观察行为。
- 配置、schema、迁移、跨仓库协议：无变化；不增加依赖或新模型策略。
- 基线 `b54695231cb7524eda8bd20862ab50ea230d1d7c`；候选 `6ad71156`。
- 回滚：revert 本提交；修改前原文件已保存于本机独立备份目录 `compaction-summary-fix-20260905`。

## 验证

- [x] `pytest tests/test_context_compaction_contract.py tests/test_session_compaction_runtime.py tests/semantic/test_context_history_contract.py -q`：62 passed。
- [x] `pyright plugins/compaction/engine.py tests/test_context_compaction_contract.py --level error`：0 errors。
- [x] `git diff --check`。
- [x] `python docker/debug/gate.py run --base origin/main`：26/26 场景 passed，清理通过，当前源码摘要复核一致。
- Gate：`docker/debug/reports/change-gate/20260905-215008-04fcf9ad/`。
- `sourceDigest`: `cefd37c4fcbd4fc606ea0abfbe299feebb7495248df067d0ff3e5cff6ac87284`。
- `planDigest`: `791954891e6f082ebe7b3b18a75807bde0f61d63286ed7ef6b96841a2f28763b`。
- 真实设备不适用。既有真实模型实验支持两项修复；本提交没有新增付费模型调用，上游周额度已耗尽。这里不将旧实验当作本提交的完整线上验收。

## 正交性与概念完整性

- 架构性 PR 或大改动：no；独立概念 reviewer：不适用。
- 新概念及无关设计轴变化：none。
- 正常链路：旧历史摘要 → 恢复当前原文并计完整请求 → 必要时临时摘要 → 原 checkpoint 提交；原失败、取消和恢复 owner 不变。
- 累计 diff 自查：仅上述三个文件，没有研究脚本、私有历史或 benchmark 数据；没有新增 legacy/source-specific 分支。
- must-fix：无未处理项；局部自查结论 pass。

## 工作手册

- [x] 已核对 projectneed、0030/0052、持久化状态地图和 NOW。
- [x] 保留已确认的模型窗口比例和原文保留策略。
- [x] 无跨仓库/客户端变更；NOW 没有对应待关闭事项。
