### PR TITLE
fix: 修复模型配置保存反馈并补齐连接编辑

### DIFF
--- a/plugins/models/web_module.css
+++ b/plugins/models/web_module.css
@@ -441,3 +441,8 @@ dialog.settings-scrim::backdrop { background: transparent; }
   .settings-connection-card { transition-duration: 0.01ms; }
   .is-spinning { animation-duration: 1.8s; }
 }
+
+.settings-saved-models { padding: 1rem 1.25rem; border-block-start: 1px solid var(--md-sys-color-outline-variant); }
+.settings-saved-models summary { cursor: pointer; }
+.settings-saved-models ul { padding-inline-start: 1.25rem; max-height: 16rem; overflow: auto; overflow-wrap: anywhere; }
+.settings-role-grid [role="status"] { white-space: normal; overflow-wrap: anywhere; }

--- a/plugins/models/web_module.js
+++ b/plugins/models/web_module.js
@@ -15,7 +15,9 @@ export async function readJsonResponse(response) {
     const code = body && typeof body.code === "string" ? body.code : null;
     const message = code === "forbidden_contract"
       ? "服务已更新，请刷新页面后重试。"
-      : body && typeof body.detail === "string" ? body.detail : `请求失败：${response.status}`;
+      : body && typeof body.detail === "string" ? body.detail
+      : Array.isArray(body?.detail) ? "填写的信息格式不正确，请检查必填字段和地址后重新保存。"
+      : `保存未完成（${response.status}），请稍后重试；持续失败时刷新页面重新加载配置。`;
     const error = new Error(message);
     error.status = response.status;
     error.code = code;
@@ -105,7 +107,11 @@ export function activate(ctx) {
           headers: {"Content-Type": "application/json"},
           body: JSON.stringify(payload),
         });
-        await load();
+        try {
+          await load();
+        } catch (error) {
+          showError(new Error(`设置已保存，但刷新失败。请刷新页面查看最新配置。${error instanceof Error ? error.message : String(error)}`));
+        }
         return receipt;
       };
       const report = (work) => work.catch(showError);
@@ -132,8 +138,7 @@ export function activate(ctx) {
 
       function renderCatalog() {
         const chatModels = catalog.models.filter((model) => model.kind === "chat");
-        const chatConnectionIds = new Set(chatModels.map((model) => model.connectionId));
-        const chatConnections = catalog.connections.filter((connection) => chatConnectionIds.has(connection.id));
+        const chatConnections = catalog.connections;
         const hasConnections = chatConnections.length > 0;
         shell.classList.toggle("settings-shell--first-run", !hasConnections);
         title.textContent = hasConnections ? "模型连接" : "连接你的第一个模型";
@@ -158,7 +163,7 @@ export function activate(ctx) {
         const filtered = allConnections.filter((connection) => {
           if (!normalizedQuery) return true;
           const modelNames = catalog.models
-            .filter((model) => model.connectionId === connection.id && model.kind === "chat")
+            .filter((model) => model.connectionId === connection.id)
             .map((model) => model.model)
             .join(" ");
           return `${connection.name} ${connection.driverId} ${modelNames}`.toLocaleLowerCase().includes(normalizedQuery);
@@ -166,7 +171,7 @@ export function activate(ctx) {
         connectionCount.textContent = `${filtered.length} 个`;
         connections.replaceChildren();
         for (const connection of filtered) {
-          const models = catalog.models.filter((model) => model.connectionId === connection.id && model.kind === "chat");
+          const models = catalog.models.filter((model) => model.connectionId === connection.id);
           const entry = providerEntries.find((candidate) => candidate.id === connection.driverId);
           const item = document.createElement(entry ? "button" : "article");
           if (entry) item.type = "button";
@@ -232,13 +237,35 @@ export function activate(ctx) {
         title.textContent = label;
         description.textContent = detail;
         copy.append(title, description);
-        select.append(new Option("尚未配置", ""));
+        const unconfigured = new Option("尚未配置", "");
+        unconfigured.disabled = true;
+        select.append(unconfigured);
         for (const model of models) {
           const connection = catalog.connections.find((item) => item.id === model.connectionId);
           select.append(new Option(`${model.model}：${connection?.name ?? model.connectionId}`, model.id));
         }
         select.value = value;
-        select.addEventListener("change", () => report(change(select.value)));
+        const feedback = document.createElement("small");
+        feedback.setAttribute("role", "status");
+        feedback.setAttribute("aria-live", "polite");
+        select.addEventListener("change", async () => {
+          const selected = select.value;
+          const controls = [...bindings.querySelectorAll("select")];
+          controls.forEach((control) => { control.disabled = true; });
+          feedback.textContent = "正在保存…";
+          try {
+            await change(selected);
+            value = selected;
+            feedback.textContent = "已保存";
+            showNotice(`${label}已保存，下次使用系统绑定时生效；会话固定模型不受影响。`);
+          } catch (error) {
+            select.value = value;
+            feedback.textContent = `未保存，已恢复原选择。${error instanceof Error ? error.message : String(error)} 请重新选择后重试。`;
+          } finally {
+            controls.forEach((control) => { control.disabled = false; });
+          }
+        });
+        copy.append(feedback);
         row.append(copy, select);
         return row;
       }
@@ -368,6 +395,21 @@ export function activate(ctx) {
           scrim.remove();
           showError(error);
           return;
+        }
+        if (connection) {
+          const list = document.createElement("details");
+          list.className = "settings-saved-models";
+          const savedModels = catalog.models.filter((model) => model.connectionId === connectionId);
+          const summary = document.createElement("summary");
+          summary.textContent = `查看已保存模型（${savedModels.length}）`;
+          const items = document.createElement("ul");
+          for (const model of savedModels) {
+            const item = document.createElement("li");
+            item.textContent = `${model.model}${model.kind === "embedding" ? " · 向量模型" : ""}`;
+            items.append(item);
+          }
+          list.append(summary, items);
+          dialogHost.querySelector(".settings-dialog-body").append(list);
         }
         const close = () => disposeDialog();
         scrim.addEventListener("close", close, {once: true});

--- a/plugins/openai_compatible/web_module.js
+++ b/plugins/openai_compatible/web_module.js
@@ -48,11 +48,11 @@ export function activate(ctx) {
         <form class="settings-dialog-form"><div class="settings-dialog-body"><div class="settings-form-grid">
           <label class="is-wide"><span>连接名称</span><input name="name" aria-label="连接名称" required autocomplete="organization" placeholder="${isDeepSeek ? "例如：DeepSeek 官方" : "例如：公司网关"}"></label>
           <label class="is-wide"><span>Base URL${existing ? "（留空则保持不变）" : ""}</span><input name="endpoint" aria-label="Base URL" ${existing ? "" : "required"} type="url" placeholder="https://api.example.com/v1"></label>
-          <label class="settings-secret is-wide"><span>API Key</span><input name="apiKey" aria-label="API Key" type="password" ${existing ? "" : "required"} autocomplete="off" placeholder="sk-…"><button type="button" data-show-key aria-label="显示 API Key">${EYE_ICON}</button></label>
+          <label class="settings-secret is-wide"><span>API Key</span><input name="apiKey" aria-label="API Key" type="password" ${existing ? "" : "required"} autocomplete="off" placeholder="${existing ? "留空保留现有密钥" : "sk-…"}"><button type="button" data-show-key aria-label="显示 API Key">${EYE_ICON}</button></label>
         </div>
         ${existing ? "" : `<details class="settings-advanced"><summary>高级设置</summary><p>Provider ID 仅用于补充模型能力；通常无需修改。</p><div class="settings-form-grid"><label class="is-wide"><span>Provider ID</span><input name="provider" aria-label="Provider ID" required placeholder="例如：openai"></label></div></details>`}
         <p class="settings-credential-note">${SHIELD_ICON}<span>API Key 保存后不会显示在页面中</span></p>
-        <section class="settings-model-discovery"><header><div><h3>模型</h3><p>${existing ? "可随时重新检测目录与已知能力。" : "从服务目录选择一个默认模型，不必手填名称。"}</p></div></header>
+        <section class="settings-model-discovery"><header><div><h3>模型</h3><p>${existing ? "检测使用已保存的地址和密钥；修改后请先保存连接。" : "从服务目录选择一个默认模型，不必手填名称。"}</p></div></header>
           ${existing ? `<p class="settings-discovery-summary">当前已保存 ${props.state.models.length} 个模型。</p>` : `<div class="settings-discovery-empty" data-discovery-empty>
             <button type="button" class="settings-primary-button" data-discover>检测可用模型</button>
             <button type="button" class="settings-text-button" data-manual>无法检测？手动填写模型名</button>
@@ -61,7 +61,7 @@ export function activate(ctx) {
           <div class="settings-discovery-manual" data-discovery-manual hidden><label><span>模型名称</span><input name="manualModel" aria-label="模型名称" placeholder="${isDeepSeek ? "例如：deepseek-chat" : "例如：your-model-name"}"></label><p>手动添加时图片等能力保持待识别，保存后仍可重新检测。</p><label class="settings-manual-confirm"><input type="checkbox" name="manualConfirm"><span>我知道模型目录未经验证，仍要保存这个连接。</span></label></div>
           <p class="settings-discovery-status" data-status role="status" aria-live="polite" hidden></p>`}
         </section><p class="settings-inline-error" data-error role="alert" hidden></p></div>
-        <footer class="settings-dialog-footer" data-footer ${existing ? "" : "hidden"}><span class="settings-dialog-footer-note" data-footer-note>${SHIELD_ICON}连接信息会在保存前验证</span><div class="settings-dialog-actions"><button type="button" class="settings-secondary-button" data-rescan>${existing ? "重新检测模型" : "重新检测"}</button><button type="submit" class="settings-primary-button">保存连接</button></div></footer></form>`;
+        <footer class="settings-dialog-footer" data-footer ${existing ? "" : "hidden"}><span class="settings-dialog-footer-note" data-footer-note>${SHIELD_ICON}连接信息会在保存前验证</span><div class="settings-dialog-actions"><button type="button" class="settings-secondary-button" data-rescan>${existing ? "检测已保存连接" : "重新检测"}</button><button type="submit" class="settings-primary-button">保存连接</button></div></footer></form>`;
       const form = host.querySelector("form");
       form.elements.name.value = existing?.name ?? defaults.name ?? "";
       form.elements.endpoint.value = defaults.endpoint ?? "";

--- a/plugins/opencode_go/web_module.js
+++ b/plugins/opencode_go/web_module.js
@@ -21,11 +21,11 @@ export function activate(ctx) {
         <form class="settings-dialog-form"><div class="settings-dialog-body"><div class="settings-form-grid">
           <label class="is-wide"><span>连接名称</span><input name="name" aria-label="连接名称" required autocomplete="organization"></label>
           <label class="is-wide"><span>Base URL</span><input name="endpoint" aria-label="Base URL" ${existing ? "" : "required"} type="url" placeholder="${existing ? "留空则保持原地址" : "https://api.example.com/v1"}"></label>
-          <label class="settings-secret is-wide"><span>API Key（可留空使用本机登录）</span><input name="apiKey" aria-label="API Key" type="password" autocomplete="off" placeholder="sk-…"><button type="button" data-show-key aria-label="显示 API Key">${EYE_ICON}</button></label>
+          <label class="settings-secret is-wide"><span>API Key（${existing ? "留空保留现有密钥" : "可留空使用本机登录"}）</span><input name="apiKey" aria-label="API Key" type="password" autocomplete="off" placeholder="sk-…"><button type="button" data-show-key aria-label="显示 API Key">${EYE_ICON}</button></label>
         </div>
         <section class="settings-model-discovery settings-model-discovery--automatic"><header><div><h3>模型与能力自动同步</h3><p>保存后读取账号当前可用的模型，并识别图片等已知能力；断网时仍可连接。</p></div></header></section>
         <p class="settings-inline-error" data-error role="alert" hidden></p></div>
-        <footer class="settings-dialog-footer"><span class="settings-dialog-footer-note">${SHIELD_ICON}凭据保存后不会显示在页面中</span><span class="settings-dialog-actions">${existing ? '<button type="button" class="settings-secondary-button" data-resync>重新同步模型与能力</button>' : ""}<button type="submit" class="settings-primary-button">${existing ? "保存连接并同步" : "保存并同步模型与能力"}</button></span></footer></form>`;
+        <footer class="settings-dialog-footer"><span class="settings-dialog-footer-note">${SHIELD_ICON}凭据保存后不会显示在页面中</span><span class="settings-dialog-actions">${existing ? '<button type="button" class="settings-secondary-button" data-resync>检测已保存连接</button>' : ""}<button type="submit" class="settings-primary-button">${existing ? "保存连接并同步" : "保存并同步模型与能力"}</button></span></footer></form>`;
       const form = host.querySelector("form");
       form.elements.name.value = existing?.name ?? "OpenCode Go";
       form.elements.endpoint.value = existing ? "" : "https://opencode.ai/zen/go/v1";
@@ -59,8 +59,14 @@ export function activate(ctx) {
             endpoint: endpoint || null,
             credential: apiKey ? {driver: "api_key", access_token: apiKey} : null,
             driverConfig: null,
-          }).then(() => props.actions.sync())
-            .then(() => props.changed("OpenCode Go 连接已更新")));
+          }).then(async () => {
+            try {
+              await props.actions.sync();
+            } catch (error) {
+              throw new Error(`连接已保存，但模型同步失败。${error instanceof Error ? error.message : String(error)} 请点击“检测已保存连接”重试。`);
+            }
+            props.changed("OpenCode Go 连接已更新");
+          }));
           return;
         }
         submit(form, props.actions.startAuth(input)


### PR DESCRIPTION
模型设置保存失败时，下拉框原先仍显示未保存的新值；重新检测也容易被误认为使用正在编辑的密钥。现在绑定保存期间禁用并行选择，失败恢复原值并就地说明，成功说明生效范围；设置已提交但刷新或同步失败时单独反馈。

连接列表包含纯向量和未配置模型的连接，各 Provider 编辑窗口可展开完整已保存模型列表。API Key 明确提示留空保留旧值，检测按钮说明使用已保存连接；结构化校验失败提供修正提示，禁止选择后端不支持的“尚未配置”空绑定。

验证：
- TypeScript typecheck、Web 插件构建、git diff --check 通过。
- 隔离挂载实际模块：验证名称/地址/凭据提交、五类绑定成功、409 失败恢复、422 提示及检测使用已保存值。
- 浏览器验证向量连接编辑和完整模型列表展开。320px 窄屏复核展开列表：弹窗 clientWidth=scrollWidth=305px（含页面滚动条），没有横向溢出。
- 本地未重复全量 Gate；远端 CI 负责完整检查。

范围仅四个插件前端源码文件，无协议、凭据持久化或正式绑定变更。恢复点：提交前源码 tar 位于本地 artifacts/model-settings-ux-20260906/before.tar，可通过 revert 回退。
