### PR TITLE
在创建线程关闭 Mobile 网关资源

### DIFF
--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -160,7 +160,8 @@ def _wait_server_task(
 def _close_mobile_gateway(runtime: Any | None) -> Callable[[], Awaitable[None]]:
     async def close() -> None:
         if runtime is not None:
-            await asyncio.to_thread(runtime.close)
+            # Gateway 的 task 与 SQLite publication 都由当前 loop 线程创建。
+            runtime.close()
 
     return close
 

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import sqlite3
 import subprocess
 import sys
 import types
@@ -26,6 +27,7 @@ from agent.config import (
 from agent.persona import reset_veda
 from bus.event_bus import EventBus
 from core.net.http import SharedHttpResources
+from infra.mobile_webui.store import MobileWebUiStore
 
 
 class _FakeDashboardServer:
@@ -842,6 +844,17 @@ async def test_app_runtime_start_preserves_startup_error_when_rollback_fails(
 
     assert caught.value is startup_error
     assert caught.value.__cause__ is rollback_error
+
+
+@pytest.mark.asyncio
+async def test_mobile_gateway_close_keeps_publication_owner_thread(tmp_path: Path):
+    store = MobileWebUiStore(tmp_path / "mobile-webui", server_id="shutdown-test")
+    try:
+        await bootstrap_app._close_mobile_gateway(store)()
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            store.get_release()
+    finally:
+        store.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
启用 Mobile 后，启动回退或正常关闭会把 Gateway.close 放到工作线程，触发 publication SQLite 的线程归属错误；已有后台 task 也属于原事件循环。本次让关闭留在创建它们的 loop 线程，不改 Message、协议或数据库 schema。

验证：真实 MobileWebUiStore 回归在修改前复现同一 SQLite ProgrammingError；修改后 runtime smoke、restart 和 native sender 共 96 项测试通过。Pyright 0 errors，4 项未改动位置的 warnings。按用户本次要求未运行完整 provider pytest、Docker Gate 或等待 CI。

Change intent：change_type=fix；semantic_delta=none；capability_owner=core；consumer_scope=Mobile gateway shutdown/startup rollback；runtime_patch=required（资源由 Core loop 创建，客户端无法改变其关闭线程）；authoritative_state_owner=MobileWebUiStore；client_only_alternative=none。保留既有生命周期和持久化边界，仅修复错误的线程切换，不引入新概念或外部发送。保护 sessions.db 消息、publication 数据及连接凭据；允许关闭既有连接和任务。

范围仅 bootstrap/app.py 与既有 runtime smoke 测试。局部修复，概念 Gate 不适用；无长期语义变化或新增 NOW 待办。独立 worktree，base 477ef117；恢复点 core-before-close-fix.tar，代码可 revert。正式切换的完整状态恢复点为 pre-message-20260908-0755，回滚旧 Message schema 必须恢复整套状态。